### PR TITLE
fix(pedagogy): strip prior-knowledge goals from discovery when KC off

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/pedagogy.ts
+++ b/apps/admin/lib/prompt/composition/transforms/pedagogy.ts
@@ -121,11 +121,30 @@ registerTransform("computeSessionPedagogy", (
         : allPhases;
       const removedCount = allPhases.length - filteredPhases.length;
 
-      plan.firstCallPhases = filteredPhases;
+      // Per-goal filtering: when Knowledge Check is OFF but discovery phase
+      // survives (Goals or About You still on), strip goals that reference
+      // probing prior knowledge. Resolves the contradiction between phase-
+      // listed goals (e.g. "Assess existing knowledge level") and the
+      // "Do NOT probe their prior knowledge level" directive that
+      // quickstart.ts injects into discovery_guidance.
+      const KNOWLEDGE_GOAL_RE = /\b(prior\s+knowledge|existing\s+knowledge|knowledge\s+level|assess.*knowledge|probe.*knowledge)\b/i;
+      let goalDropCount = 0;
+      const phasesAfterGoalFilter = !toggles.askKnowledge
+        ? filteredPhases.map((p: any) => {
+            if (!DISCOVERY_PHASE_RE.test(p?.phase ?? "")) return p;
+            const originalGoals = (p.goals ?? []) as string[];
+            const keptGoals = originalGoals.filter(g => !KNOWLEDGE_GOAL_RE.test(g));
+            if (keptGoals.length === originalGoals.length) return p;
+            goalDropCount += originalGoals.length - keptGoals.length;
+            return { ...p, goals: keptGoals };
+          })
+        : filteredPhases;
+
+      plan.firstCallPhases = phasesAfterGoalFilter;
       plan.successMetrics = fcFlow.successMetrics;
 
       // Convert phases to flow steps, including content references
-      plan.flow = filteredPhases.map((phase: any, i: number) => {
+      plan.flow = phasesAfterGoalFilter.map((phase: any, i: number) => {
         const label = `${i + 1}. ${phase.phase.charAt(0).toUpperCase() + phase.phase.slice(1)} (${phase.duration}) - ${phase.goals[0]}`;
         const contentRefs = phase.content as Array<{ mediaId: string; instruction?: string }> | undefined;
         if (contentRefs?.length) {
@@ -137,9 +156,12 @@ registerTransform("computeSessionPedagogy", (
         return label;
       });
 
-      console.log(`[pedagogy] Using ${source} first-call flow with ${filteredPhases.length} phases`);
+      console.log(`[pedagogy] Using ${source} first-call flow with ${phasesAfterGoalFilter.length} phases`);
       if (removedCount > 0) {
         console.log(`[pedagogy] Filtered ${removedCount} discovery phase(s) — personalisation mode = ${mode}`);
+      }
+      if (goalDropCount > 0) {
+        console.log(`[pedagogy] Dropped ${goalDropCount} prior-knowledge goal(s) from discovery phase — Knowledge Check off`);
       }
     } else {
       // Fallback to default first-call flow.

--- a/apps/admin/tests/lib/composition/pedagogy.test.ts
+++ b/apps/admin/tests/lib/composition/pedagogy.test.ts
@@ -384,6 +384,134 @@ describe("computeSessionPedagogy transform", () => {
       expect(result.flow.some((s: string) => s.toLowerCase().includes("discovery"))).toBe(false);
     });
 
+    // ── KC-off partial-skip (#225 followup) ───────────────────────────
+    it("strips prior-knowledge goals from discovery phase when only KC is off", () => {
+      const ctx = makeContext({
+        loadedData: {
+          ...makeContext().loadedData,
+          playbooks: [{
+            id: "pb-1",
+            name: "Course",
+            status: "PUBLISHED",
+            domain: null,
+            items: [],
+            config: {
+              welcome: {
+                goals: { enabled: true },
+                aboutYou: { enabled: true },
+                knowledgeCheck: { enabled: false }, // OFF — but discovery phase must stay (Goals/AboutYou still on)
+              },
+              onboardingFlowPhases: {
+                phases: [
+                  { phase: "welcome", duration: "2 min", goals: ["Greet"] },
+                  {
+                    phase: "discovery",
+                    duration: "5 min",
+                    goals: [
+                      "Learn about the caller's background",
+                      "Understand their goals and motivations",
+                      "Assess existing knowledge level",
+                    ],
+                  },
+                  { phase: "first-topic", duration: "5 min", goals: ["Teach"] },
+                ],
+              },
+            },
+          }],
+        },
+        sharedState: {
+          ...makeContext().sharedState,
+          isFirstCall: true,
+        },
+      });
+
+      const result = getTransform("computeSessionPedagogy")!(null, ctx, makeSectionDef());
+
+      // Discovery phase still present (goals + about-you still on)
+      const discovery = result.firstCallPhases!.find((p: { phase: string }) => p.phase === "discovery");
+      expect(discovery).toBeDefined();
+      // The "Assess existing knowledge level" goal is filtered out
+      expect(discovery!.goals).toEqual([
+        "Learn about the caller's background",
+        "Understand their goals and motivations",
+      ]);
+    });
+
+    it("keeps prior-knowledge goals when KC is on", () => {
+      const ctx = makeContext({
+        loadedData: {
+          ...makeContext().loadedData,
+          playbooks: [{
+            id: "pb-1",
+            name: "Course",
+            status: "PUBLISHED",
+            domain: null,
+            items: [],
+            config: {
+              welcome: {
+                goals: { enabled: true },
+                aboutYou: { enabled: true },
+                knowledgeCheck: { enabled: true },
+              },
+              onboardingFlowPhases: {
+                phases: [
+                  {
+                    phase: "discovery",
+                    duration: "5 min",
+                    goals: ["Find name", "Assess existing knowledge level"],
+                  },
+                ],
+              },
+            },
+          }],
+        },
+        sharedState: {
+          ...makeContext().sharedState,
+          isFirstCall: true,
+        },
+      });
+
+      const result = getTransform("computeSessionPedagogy")!(null, ctx, makeSectionDef());
+      const discovery = result.firstCallPhases!.find((p: { phase: string }) => p.phase === "discovery");
+      expect(discovery!.goals).toContain("Assess existing knowledge level");
+    });
+
+    it("does not touch goals on non-discovery phases", () => {
+      const ctx = makeContext({
+        loadedData: {
+          ...makeContext().loadedData,
+          playbooks: [{
+            id: "pb-1",
+            name: "Course",
+            status: "PUBLISHED",
+            domain: null,
+            items: [],
+            config: {
+              welcome: {
+                goals: { enabled: true },
+                aboutYou: { enabled: true },
+                knowledgeCheck: { enabled: false },
+              },
+              onboardingFlowPhases: {
+                phases: [
+                  // first-topic phase happens to mention knowledge — must be left alone.
+                  { phase: "first-topic", duration: "5 min", goals: ["Foundations of knowledge work"] },
+                ],
+              },
+            },
+          }],
+        },
+        sharedState: {
+          ...makeContext().sharedState,
+          isFirstCall: true,
+        },
+      });
+
+      const result = getTransform("computeSessionPedagogy")!(null, ctx, makeSectionDef());
+      const firstTopic = result.firstCallPhases!.find((p: { phase: string }) => p.phase === "first-topic");
+      expect(firstTopic!.goals).toEqual(["Foundations of knowledge work"]);
+    });
+
     it("keeps discovery phase when welcome phases are enabled (regression)", () => {
       const ctx = makeContext({
         loadedData: {


### PR DESCRIPTION
Resolves a contradiction in the first-call prompt when the educator turns Knowledge Check off but leaves Goals or About You on.

## The bug

- Discovery phase survived the existing OPT_OUT filter (because not all 3 welcome flags were off)
- It still listed "Assess existing knowledge level" as a goal
- But `quickstart.ts` told the AI "Do NOT probe their prior knowledge level"
- AI saw both — followed the directive, but the educator UI (phase editor) showed a goal as if it would still fire

## The fix

Per-goal filter right after the existing per-phase filter in `pedagogy.ts`:
- When `intake.knowledgeCheck` is OFF
- And discovery phase survives
- Filter out goals matching prior-knowledge regex

Non-discovery phases untouched. Discovery goals that don't reference probing untouched.

## Tests

- 3 new tests (strip when KC off, keep when KC on, leave non-discovery alone)
- 47/47 pedagogy tests pass
- 88/88 session-flow tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)