### PR TITLE
feat: Authored Modules panel inside Curriculum tab (#236, PR3/4)

### DIFF
--- a/apps/admin/__tests__/ui/authored-modules-panel.test.tsx
+++ b/apps/admin/__tests__/ui/authored-modules-panel.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Tests for AuthoredModulesPanel — Module Catalogue read-only view.
+ *
+ * Covers:
+ * - Loading spinner before fetch resolves
+ * - Empty state when no authored modules persisted
+ * - Catalogue table renders rows with correct fields
+ * - "Modules authored: No" copy when explicitly opted out
+ * - Validation list renders warnings + errors
+ * - Re-import button is hidden when isOperator=false
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AuthoredModulesPanel } from "@/app/x/courses/[courseId]/_components/AuthoredModulesPanel";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function mockFetch(body: object, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: status === 200,
+    status,
+    json: async () => ({ ok: true, ...body }),
+  }) as typeof fetch;
+}
+
+const SAMPLE_MODULES = [
+  {
+    id: "baseline",
+    label: "Baseline Assessment",
+    learnerSelectable: true,
+    mode: "examiner",
+    duration: "20 min fixed",
+    scoringFired: "All four (FC, LR, GRA, Pron)",
+    voiceBandReadout: false,
+    sessionTerminal: true,
+    frequency: "once",
+    outcomesPrimary: [],
+    prerequisites: [],
+  },
+  {
+    id: "part1",
+    label: "Part 1: Familiar Topics",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "Student-led",
+    scoringFired: "LR + GRA only",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: ["OUT-01", "OUT-02"],
+    prerequisites: [],
+  },
+];
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("AuthoredModulesPanel — empty state", () => {
+  it("renders the empty-state CTA when no modules exist", async () => {
+    mockFetch({
+      modulesAuthored: null,
+      modules: [],
+      moduleDefaults: {},
+      moduleSource: null,
+      moduleSourceRef: null,
+      validationWarnings: [],
+      hasErrors: false,
+    });
+
+    render(<AuthoredModulesPanel courseId="c1" isOperator={true} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No authored modules for this course/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Import from Course Reference/i })).toBeInTheDocument();
+  });
+
+  it("hides the import button when isOperator=false", async () => {
+    mockFetch({
+      modulesAuthored: null,
+      modules: [],
+      moduleDefaults: {},
+      moduleSource: null,
+      moduleSourceRef: null,
+      validationWarnings: [],
+      hasErrors: false,
+    });
+
+    render(<AuthoredModulesPanel courseId="c1" isOperator={false} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No authored modules for this course/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /Import/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("AuthoredModulesPanel — populated catalogue", () => {
+  it("renders table rows for each module with stable IDs", async () => {
+    mockFetch({
+      modulesAuthored: true,
+      modules: SAMPLE_MODULES,
+      moduleDefaults: { mode: "tutor" },
+      moduleSource: "authored",
+      moduleSourceRef: { docId: "doc-9", version: "2.2" },
+      validationWarnings: [],
+      hasErrors: false,
+    });
+
+    render(<AuthoredModulesPanel courseId="c1" isOperator={true} />);
+    await waitFor(() => {
+      expect(screen.getByText("baseline")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Baseline Assessment")).toBeInTheDocument();
+    expect(screen.getByText("part1")).toBeInTheDocument();
+    expect(screen.getByText("Part 1: Familiar Topics")).toBeInTheDocument();
+    // Status strip
+    expect(screen.getByText(/Production publish ready/i)).toBeInTheDocument();
+    // Source ref
+    expect(screen.getByText(/doc doc-9/i)).toBeInTheDocument();
+    // "Re-import" wording when modules already exist
+    expect(screen.getByRole("button", { name: /Re-import/i })).toBeInTheDocument();
+  });
+});
+
+describe("AuthoredModulesPanel — explicit No", () => {
+  it("renders the opt-out copy when modulesAuthored=false and no modules", async () => {
+    mockFetch({
+      modulesAuthored: false,
+      modules: [],
+      moduleDefaults: {},
+      moduleSource: "derived",
+      moduleSourceRef: null,
+      validationWarnings: [],
+      hasErrors: false,
+    });
+
+    render(<AuthoredModulesPanel courseId="c1" isOperator={true} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Course Reference declared/i),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AuthoredModulesPanel — validation warnings", () => {
+  it("renders the warning list and shows publish-blocked status when errors present", async () => {
+    mockFetch({
+      modulesAuthored: true,
+      modules: SAMPLE_MODULES,
+      moduleDefaults: {},
+      moduleSource: "authored",
+      moduleSourceRef: null,
+      validationWarnings: [
+        {
+          code: "MODULE_FIELD_DEFAULTED",
+          message: "Module 'part1' defaulted scoring",
+          path: "modules.part1.scoringFired",
+          severity: "warning",
+        },
+        {
+          code: "MODULE_ID_INVALID",
+          message: "Bad module ID",
+          path: "modules.bad.id",
+          severity: "error",
+        },
+      ],
+      hasErrors: true,
+    });
+
+    render(<AuthoredModulesPanel courseId="c1" isOperator={true} />);
+    await waitFor(() => {
+      expect(screen.getByText("MODULE_ID_INVALID")).toBeInTheDocument();
+    });
+    expect(screen.getByText("MODULE_FIELD_DEFAULTED")).toBeInTheDocument();
+    expect(screen.getByText(/Production publish blocked/i)).toBeInTheDocument();
+  });
+});

--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -42,6 +42,51 @@ const BodySchema = z.object({
 type Body = z.infer<typeof BodySchema>;
 
 /**
+ * @api GET /api/courses/[courseId]/import-modules
+ * @visibility internal
+ * @scope course:read
+ * @auth session (VIEWER+)
+ * @description Read the current authored-modules state from PlaybookConfig.
+ *   Used by the Authored Modules panel in the Curriculum tab to render the
+ *   catalogue without re-parsing the source document. Returns nulls/empties
+ *   when no authored modules exist yet (derived path is in use).
+ * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors }
+ * @response 404 { ok: false, error: "Course not found" }
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAuth("VIEWER");
+  if (isAuthError(auth)) return auth.error;
+
+  const { courseId } = await params;
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    select: { id: true, config: true },
+  });
+  if (!playbook) {
+    return NextResponse.json(
+      { ok: false, error: "Course not found" },
+      { status: 404 },
+    );
+  }
+
+  const cfg = (playbook.config ?? {}) as PlaybookConfig;
+  const warnings = cfg.validationWarnings ?? [];
+  return NextResponse.json({
+    ok: true,
+    modulesAuthored: cfg.modulesAuthored ?? null,
+    modules: cfg.modules ?? [],
+    moduleDefaults: cfg.moduleDefaults ?? {},
+    moduleSource: cfg.moduleSource ?? null,
+    moduleSourceRef: cfg.moduleSourceRef ?? null,
+    validationWarnings: warnings,
+    hasErrors: warnings.some((w) => w.severity === "error"),
+  });
+}
+
+/**
  * @api POST /api/courses/[courseId]/import-modules
  * @visibility internal
  * @scope course:write

--- a/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
@@ -20,6 +20,7 @@ import { AlertTriangle, CheckCircle2 } from "lucide-react";
 import Link from "next/link";
 import type { CourseLinkageScorecard } from "@/lib/content-trust/validate-lo-linkage";
 import { CurriculumHealthTabs, type RegenerateActions } from "./CurriculumHealthTabs";
+import { AuthoredModulesPanel } from "./_components/AuthoredModulesPanel";
 import "./course-curriculum-tab.css";
 
 interface CourseCurriculumTabProps {
@@ -165,11 +166,20 @@ export function CourseCurriculumTab({
   }
 
   if (!curriculumId) {
+    // Authored modules live on Playbook.config and don't depend on a
+    // generated curriculum, so we still surface the panel here. The
+    // "no curriculum" empty state lives below the panel.
     return (
-      <div className="hf-empty">
-        <p className="hf-text-sm hf-text-muted">
-          No curriculum yet. Upload content on the Content tab to generate one.
-        </p>
+      <div className="hf-stack-md">
+        <AuthoredModulesPanel
+          courseId={playbookId ?? courseId}
+          isOperator={isOperator}
+        />
+        <div className="hf-empty">
+          <p className="hf-text-sm hf-text-muted">
+            No curriculum yet. Upload content on the Content tab to generate one.
+          </p>
+        </div>
       </div>
     );
   }
@@ -183,6 +193,11 @@ export function CourseCurriculumTab({
   return (
     <div className="hf-stack-md">
       {error && <div className="hf-banner hf-banner-error">{error}</div>}
+
+      <AuthoredModulesPanel
+        courseId={playbookId ?? courseId}
+        isOperator={isOperator}
+      />
 
       {hasZeroModules && (
         <div className="hf-banner hf-banner-warning">

--- a/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+/**
+ * AuthoredModulesPanel — Module Catalogue read-only view + re-import action.
+ *
+ * Renders inside the Curriculum tab. Lives alongside the derived-curriculum
+ * scorecard but is visually distinct because it covers a different concept:
+ * author-declared modules from a Course Reference document, persisted on
+ * `Playbook.config.modules`. The derived `CurriculumModule` data continues
+ * to render below via `CurriculumHealthTabs`.
+ *
+ * PR3 of 4 for #236. Read-only + re-import only — per-row inline editing
+ * is deferred to PR3.5 (or absorbed into the wizard step PR).
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { Layers, AlertTriangle, CheckCircle2, Upload } from "lucide-react";
+import type {
+  AuthoredModule,
+  ModuleDefaults,
+  ModuleSource,
+  ValidationWarning,
+} from "@/lib/types/json-fields";
+import { ImportModulesDialog } from "./ImportModulesDialog";
+import "./authored-modules-panel.css";
+
+interface AuthoredModulesState {
+  modulesAuthored: boolean | null;
+  modules: AuthoredModule[];
+  moduleDefaults: Partial<ModuleDefaults>;
+  moduleSource: ModuleSource | null;
+  moduleSourceRef: { docId: string; version: string } | null;
+  validationWarnings: ValidationWarning[];
+  hasErrors: boolean;
+}
+
+interface AuthoredModulesPanelProps {
+  courseId: string;
+  isOperator: boolean;
+}
+
+const EMPTY_STATE: AuthoredModulesState = {
+  modulesAuthored: null,
+  modules: [],
+  moduleDefaults: {},
+  moduleSource: null,
+  moduleSourceRef: null,
+  validationWarnings: [],
+  hasErrors: false,
+};
+
+export function AuthoredModulesPanel({
+  courseId,
+  isOperator,
+}: AuthoredModulesPanelProps) {
+  const [state, setState] = useState<AuthoredModulesState>(EMPTY_STATE);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/courses/${courseId}/import-modules`);
+      if (!res.ok) {
+        throw new Error(`Failed to load authored modules (status ${res.status})`);
+      }
+      const data = (await res.json()) as { ok: boolean } & AuthoredModulesState;
+      setState({
+        modulesAuthored: data.modulesAuthored,
+        modules: data.modules,
+        moduleDefaults: data.moduleDefaults,
+        moduleSource: data.moduleSource,
+        moduleSourceRef: data.moduleSourceRef,
+        validationWarnings: data.validationWarnings,
+        hasErrors: data.hasErrors,
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [courseId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleImported = useCallback(() => {
+    setDialogOpen(false);
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="hf-card hf-mb-lg">
+        <div className="hf-spinner" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="hf-card hf-mb-lg authored-modules-panel">
+      <div className="hf-flex hf-items-center hf-gap-sm hf-mb-md">
+        <Layers size={16} className="hf-text-muted" />
+        <span className="hf-section-title authored-modules-panel__title">
+          Authored Modules
+        </span>
+        <span className="hf-text-xs hf-text-muted">
+          {state.moduleSource === "authored"
+            ? "From Course Reference"
+            : state.moduleSource === "derived"
+              ? "Author opted out — using derived"
+              : "Not yet imported"}
+        </span>
+        {isOperator && state.modules.length > 0 && (
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary authored-modules-panel__action"
+            onClick={() => setDialogOpen(true)}
+          >
+            <Upload size={14} />
+            Re-import
+          </button>
+        )}
+      </div>
+
+      {error && <div className="hf-banner hf-banner-error hf-mb-md">{error}</div>}
+
+      {state.modulesAuthored === null && state.modules.length === 0 && (
+        <EmptyState onImport={() => setDialogOpen(true)} canImport={isOperator} />
+      )}
+
+      {state.modules.length > 0 && (
+        <>
+          <CatalogueTable modules={state.modules} />
+          <StatusStrip
+            warnings={state.validationWarnings}
+            hasErrors={state.hasErrors}
+          />
+          {Object.keys(state.moduleDefaults).length > 0 && (
+            <ModuleDefaultsRow defaults={state.moduleDefaults} />
+          )}
+          {state.validationWarnings.length > 0 && (
+            <ValidationList warnings={state.validationWarnings} />
+          )}
+          {state.moduleSourceRef && (
+            <p className="hf-text-xs hf-text-muted hf-mt-sm">
+              Source: doc {state.moduleSourceRef.docId} (v{state.moduleSourceRef.version})
+            </p>
+          )}
+        </>
+      )}
+
+      {state.modulesAuthored === false && state.modules.length === 0 && (
+        <p className="hf-text-sm hf-text-muted">
+          The Course Reference declared <code>Modules authored: No</code>. The
+          system will derive modules from the Outcome Graph at runtime.
+        </p>
+      )}
+
+      {dialogOpen && isOperator && (
+        <ImportModulesDialog
+          courseId={courseId}
+          onClose={() => setDialogOpen(false)}
+          onImported={handleImported}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Empty state ────────────────────────────────────────────────────
+
+function EmptyState({
+  onImport,
+  canImport,
+}: {
+  onImport: () => void;
+  canImport: boolean;
+}) {
+  return (
+    <div className="hf-empty">
+      <p className="hf-text-sm hf-text-muted">
+        No authored modules for this course. Paste your Course Reference
+        markdown to import the Module Catalogue. Without authored modules,
+        the system will derive modules from your Outcome Graph at runtime.
+      </p>
+      {canImport && (
+        <button
+          type="button"
+          className="hf-btn hf-btn-primary hf-mt-md"
+          onClick={onImport}
+        >
+          Import from Course Reference
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Catalogue table ────────────────────────────────────────────────
+
+function CatalogueTable({ modules }: { modules: AuthoredModule[] }) {
+  return (
+    <div className="authored-modules-table-wrap">
+      <table className="authored-modules-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Label</th>
+            <th>Mode</th>
+            <th>Duration</th>
+            <th>Frequency</th>
+            <th>Terminal</th>
+            <th>Picker</th>
+          </tr>
+        </thead>
+        <tbody>
+          {modules.map((m) => (
+            <tr key={m.id}>
+              <td>
+                <code>{m.id}</code>
+              </td>
+              <td>{m.label}</td>
+              <td>{m.mode}</td>
+              <td>{m.duration}</td>
+              <td>{m.frequency}</td>
+              <td className="authored-modules-table__center">
+                {m.sessionTerminal ? "●" : "—"}
+              </td>
+              <td className="authored-modules-table__center">
+                {m.learnerSelectable ? "●" : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Status strip ───────────────────────────────────────────────────
+
+function StatusStrip({
+  warnings,
+  hasErrors,
+}: {
+  warnings: ValidationWarning[];
+  hasErrors: boolean;
+}) {
+  const errorCount = warnings.filter((w) => w.severity === "error").length;
+  const warnCount = warnings.filter((w) => w.severity === "warning").length;
+  const ready = !hasErrors && warnCount === 0;
+
+  return (
+    <div className="authored-modules-status">
+      {ready ? (
+        <CheckCircle2
+          size={14}
+          className="authored-modules-status__icon authored-modules-status__icon--ok"
+          aria-hidden="true"
+        />
+      ) : (
+        <AlertTriangle
+          size={14}
+          className="authored-modules-status__icon authored-modules-status__icon--warn"
+          aria-hidden="true"
+        />
+      )}
+      <span className="hf-text-xs">
+        {errorCount} error{errorCount === 1 ? "" : "s"} · {warnCount} warning
+        {warnCount === 1 ? "" : "s"}
+        {ready && " · Production publish ready"}
+        {!ready && hasErrors && " · Production publish blocked"}
+      </span>
+    </div>
+  );
+}
+
+// ── Module Defaults row ────────────────────────────────────────────
+
+function ModuleDefaultsRow({ defaults }: { defaults: Partial<ModuleDefaults> }) {
+  const entries = Object.entries(defaults).filter(([, v]) => v != null);
+  if (entries.length === 0) return null;
+  return (
+    <div className="authored-modules-defaults">
+      <span className="hf-text-xs hf-text-muted authored-modules-defaults__label">
+        Defaults
+      </span>
+      <span className="hf-text-xs">
+        {entries.map(([k, v], i) => (
+          <span key={k}>
+            {i > 0 && <span className="authored-modules-defaults__sep"> · </span>}
+            <span className="authored-modules-defaults__key">{k}</span>{" "}
+            <span className="authored-modules-defaults__val">{String(v)}</span>
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}
+
+// ── Validation list ────────────────────────────────────────────────
+
+function ValidationList({ warnings }: { warnings: ValidationWarning[] }) {
+  return (
+    <ul className="authored-modules-warnings">
+      {warnings.map((w, i) => (
+        <li
+          key={`${w.code}-${w.path ?? "_"}-${i}`}
+          className={
+            w.severity === "error"
+              ? "authored-modules-warnings__item authored-modules-warnings__item--error"
+              : "authored-modules-warnings__item authored-modules-warnings__item--warn"
+          }
+        >
+          <span className="authored-modules-warnings__code">{w.code}</span>
+          <span className="authored-modules-warnings__msg">{w.message}</span>
+          {w.path && (
+            <code className="authored-modules-warnings__path">{w.path}</code>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/admin/app/x/courses/[courseId]/_components/ImportModulesDialog.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/ImportModulesDialog.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+/**
+ * ImportModulesDialog — paste markdown / drop a file, parse & import.
+ *
+ * Calls POST /api/courses/[courseId]/import-modules. Refreshes the parent
+ * panel via `onImported` on success. Per-field-defaults-with-warnings:
+ * even if the response includes warnings, the import succeeds — the panel
+ * surfaces them in the validation list so the author can act.
+ */
+
+import { useState, useCallback, useRef } from "react";
+import { X } from "lucide-react";
+import "./authored-modules-panel.css";
+
+interface ImportModulesDialogProps {
+  courseId: string;
+  onClose: () => void;
+  onImported: () => void;
+}
+
+export function ImportModulesDialog({
+  courseId,
+  onClose,
+  onImported,
+}: ImportModulesDialogProps) {
+  const [markdown, setMarkdown] = useState("");
+  const [docId, setDocId] = useState("");
+  const [version, setVersion] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const text = await file.text();
+      setMarkdown(text);
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!markdown.trim()) {
+      setError("Paste markdown or upload a .md file before importing.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const body: { markdown: string; sourceRef?: { docId: string; version: string } } = {
+        markdown,
+      };
+      if (docId.trim() && version.trim()) {
+        body.sourceRef = { docId: docId.trim(), version: version.trim() };
+      }
+      const res = await fetch(`/api/courses/${courseId}/import-modules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const errBody = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(errBody.error ?? `Import failed (status ${res.status})`);
+      }
+      onImported();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [markdown, docId, version, courseId, onImported]);
+
+  return (
+    <div
+      className="authored-modules-dialog__backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="import-modules-title"
+    >
+      <div className="authored-modules-dialog hf-card">
+        <div className="hf-flex hf-items-center hf-gap-sm hf-mb-md">
+          <h2 id="import-modules-title" className="hf-section-title authored-modules-dialog__title">
+            Import Modules from Course Reference
+          </h2>
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary authored-modules-dialog__close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <p className="hf-text-xs hf-text-muted hf-mb-md">
+          Paste Course Reference markdown that contains a{" "}
+          <code>**Modules authored:** Yes</code> declaration and a{" "}
+          <code>## Modules</code> section. Re-importing replaces the current
+          Module Catalogue. Module IDs are preserved across re-imports if the
+          new doc uses the same IDs.
+        </p>
+
+        <label htmlFor="import-modules-textarea" className="hf-label">
+          Markdown
+        </label>
+        <textarea
+          id="import-modules-textarea"
+          className="hf-input authored-modules-dialog__textarea"
+          rows={14}
+          value={markdown}
+          onChange={(e) => setMarkdown(e.target.value)}
+          placeholder="# Course Reference — ..."
+        />
+
+        <div className="hf-flex hf-items-center hf-gap-sm hf-mt-sm">
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".md,text/markdown,text/plain"
+            className="authored-modules-dialog__file-hidden"
+            onChange={handleFileChange}
+          />
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary"
+            onClick={() => fileRef.current?.click()}
+          >
+            Choose .md file
+          </button>
+          <span className="hf-text-xs hf-text-muted">
+            File contents replace the textarea.
+          </span>
+        </div>
+
+        <div className="authored-modules-dialog__sourceref">
+          <span className="hf-label">Source ref (optional)</span>
+          <div className="hf-flex hf-items-center hf-gap-sm">
+            <input
+              type="text"
+              className="hf-input"
+              placeholder="Doc ID"
+              value={docId}
+              onChange={(e) => setDocId(e.target.value)}
+            />
+            <input
+              type="text"
+              className="hf-input"
+              placeholder="Version"
+              value={version}
+              onChange={(e) => setVersion(e.target.value)}
+            />
+          </div>
+          <span className="hf-text-xs hf-text-muted">
+            Recorded on the course for audit. Leave both blank to skip.
+          </span>
+        </div>
+
+        {error && (
+          <div className="hf-banner hf-banner-error hf-mt-md">{error}</div>
+        )}
+
+        <div className="hf-flex hf-items-center hf-gap-sm hf-mt-md authored-modules-dialog__actions">
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="hf-btn hf-btn-primary"
+            onClick={handleSubmit}
+            disabled={submitting}
+          >
+            {submitting ? "Importing…" : "Parse & Import"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -1,0 +1,201 @@
+/* ═══════════════════════════════════════════════════════
+   Authored Modules panel — Module Catalogue read-only view
+   + import dialog. Issue #236 PR3.
+   ═══════════════════════════════════════════════════════ */
+
+.authored-modules-panel__title {
+  margin: 0;
+  flex: 1;
+}
+
+.authored-modules-panel__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ── Catalogue table ────────────────────────────────────── */
+
+.authored-modules-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+.authored-modules-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.authored-modules-table th,
+.authored-modules-table td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.authored-modules-table thead th {
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--surface-secondary);
+}
+
+.authored-modules-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.authored-modules-table__center {
+  text-align: center;
+}
+
+.authored-modules-table code {
+  font-size: 12px;
+  background: var(--surface-secondary);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+/* ── Status strip ───────────────────────────────────────── */
+
+.authored-modules-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.authored-modules-status__icon--ok {
+  color: var(--status-success-text);
+}
+
+.authored-modules-status__icon--warn {
+  color: var(--status-error-text);
+}
+
+/* ── Defaults row ───────────────────────────────────────── */
+
+.authored-modules-defaults {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-default);
+  margin-top: 8px;
+}
+
+.authored-modules-defaults__label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.authored-modules-defaults__sep {
+  color: var(--text-muted);
+}
+
+.authored-modules-defaults__key {
+  color: var(--text-muted);
+}
+
+.authored-modules-defaults__val {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+/* ── Validation list ────────────────────────────────────── */
+
+.authored-modules-warnings {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.authored-modules-warnings__item {
+  display: grid;
+  grid-template-columns: minmax(160px, auto) 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.authored-modules-warnings__item--warn {
+  background: color-mix(in srgb, var(--status-error-text) 8%, transparent);
+}
+
+.authored-modules-warnings__item--error {
+  background: color-mix(in srgb, var(--status-error-text) 16%, transparent);
+}
+
+.authored-modules-warnings__code {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.authored-modules-warnings__msg {
+  color: var(--text-primary);
+}
+
+.authored-modules-warnings__path {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* ── Import dialog ──────────────────────────────────────── */
+
+.authored-modules-dialog__backdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--text-primary) 50%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.authored-modules-dialog {
+  width: min(720px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+}
+
+.authored-modules-dialog__title {
+  margin: 0;
+  flex: 1;
+}
+
+.authored-modules-dialog__close {
+  flex-shrink: 0;
+  padding: 4px 8px;
+}
+
+.authored-modules-dialog__textarea {
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 12px;
+}
+
+.authored-modules-dialog__file-hidden {
+  display: none;
+}
+
+.authored-modules-dialog__sourceref {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.authored-modules-dialog__actions {
+  justify-content: flex-end;
+}

--- a/apps/admin/tests/api/import-modules.test.ts
+++ b/apps/admin/tests/api/import-modules.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/permissions", () => ({
 }));
 
 // Import AFTER mocks
-import { POST } from "@/app/api/courses/[courseId]/import-modules/route";
+import { GET, POST } from "@/app/api/courses/[courseId]/import-modules/route";
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -241,5 +241,77 @@ describe("POST /api/courses/[courseId]/import-modules — persistence", () => {
     expect(idError).toBeDefined();
     // Still persisted — caller decides whether to surface as blocker
     expect(body.persisted).toBe(true);
+  });
+});
+
+// ── GET handler ─────────────────────────────────────────────────
+
+function makeGetReq(): NextRequest {
+  return new NextRequest("http://localhost:3000/api/courses/c1/import-modules");
+}
+
+describe("GET /api/courses/[courseId]/import-modules", () => {
+  it("returns the auth error when requireAuth fails", async () => {
+    const errorResponse = NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    mockRequireAuth.mockResolvedValue({ error: errorResponse });
+    mockIsAuthError.mockReturnValue(true);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(401);
+    expect(mockPrisma.playbook.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the playbook does not exist", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Course not found");
+  });
+
+  it("returns empty state when no authored modules persisted yet", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "playbook-1",
+      config: { lessonPlanMode: "continuous" },
+    });
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.modulesAuthored).toBeNull();
+    expect(body.modules).toEqual([]);
+    expect(body.moduleDefaults).toEqual({});
+    expect(body.moduleSource).toBeNull();
+    expect(body.moduleSourceRef).toBeNull();
+    expect(body.hasErrors).toBe(false);
+  });
+
+  it("returns persisted modules + warnings + hasErrors", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "playbook-1",
+      config: {
+        modulesAuthored: true,
+        moduleSource: "authored",
+        moduleSourceRef: { docId: "doc-9", version: "2.2" },
+        modules: [
+          { id: "m1", label: "Module One", learnerSelectable: true, mode: "tutor",
+            duration: "Student-led", scoringFired: "LR + GRA only", voiceBandReadout: false,
+            sessionTerminal: false, frequency: "repeatable", outcomesPrimary: [],
+            prerequisites: [] },
+        ],
+        moduleDefaults: { mode: "tutor" },
+        validationWarnings: [
+          { code: "MODULE_FIELD_DEFAULTED", message: "x", severity: "warning" },
+          { code: "MODULE_ID_INVALID", message: "y", severity: "error" },
+        ],
+      },
+    });
+    const res = await GET(makeGetReq(), { params });
+    const body = await res.json();
+    expect(body.modulesAuthored).toBe(true);
+    expect(body.modules).toHaveLength(1);
+    expect(body.moduleSource).toBe("authored");
+    expect(body.moduleSourceRef).toEqual({ docId: "doc-9", version: "2.2" });
+    expect(body.validationWarnings).toHaveLength(2);
+    expect(body.hasErrors).toBe(true);
   });
 });

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9518,6 +9518,24 @@ List all classrooms (cohort groups) assigned to a course (playbook).
 
 ---
 
+### `GET` /api/courses/[courseId]/import-modules
+
+Read the current authored-modules state from PlaybookConfig.
+
+**Auth**: session (VIEWER+) · **Scope**: `course:read`
+
+**Response** `200`
+```json
+{ ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+---
+
 ### `POST` /api/courses/[courseId]/import-modules
 
 Parse a Course Reference markdown body for an author-declared


### PR DESCRIPTION
## Summary

Adds a read-only Module Catalogue view + re-import action inside the existing Curriculum tab on the Course page. Authored modules live on `Playbook.config` and render visually distinct from the derived `CurriculumModule` data below.

| Phase | Behaviour |
|---|---|
| **Setup** (first time) | Empty-state CTA → opens import dialog (paste markdown / upload .md) → `POST /api/courses/[id]/import-modules` |
| **Maintenance** (re-author) | "Re-import" button replaces the catalogue; validation list shows warnings + errors with severity-coloured rows |
| **Runtime** (learner) | Preview only — actual learner-facing picker is PR4 |

Per-row inline editing deferred to a later PR — this slice is the minimum viable end-to-end authoring loop.

## New API

`GET /api/courses/[courseId]/import-modules` — returns the current authored-modules state from `PlaybookConfig`. Used by the panel to render without re-parsing source. `VIEWER+` auth.

## Files

| Path | Change |
|---|---|
| `app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx` | New — main panel |
| `app/x/courses/[courseId]/_components/ImportModulesDialog.tsx` | New — paste/upload + POST |
| `app/x/courses/[courseId]/_components/authored-modules-panel.css` | New — scoped styles, all CSS vars |
| `__tests__/ui/authored-modules-panel.test.tsx` | New — 5 RTL tests |
| `app/api/courses/[courseId]/import-modules/route.ts` | Edit — added GET handler |
| `app/x/courses/[courseId]/CourseCurriculumTab.tsx` | Edit — mounts panel above existing tabs (and on no-curriculum-yet path) |
| `tests/api/import-modules.test.ts` | Edit — 4 new GET tests |

## UI design system compliance (per `.claude/rules/ui-design-system.md`)

- All `hf-*` classes (`hf-card`, `hf-section-title`, `hf-banner`, `hf-empty`, `hf-btn`, `hf-text-*`)
- New CSS uses CSS variables exclusively (`--text-muted`, `--border-default`, `--status-error-text`, `--surface-*`)
- No inline `style={{}}` for static properties
- `color-mix()` for alpha (no hex opacity)
- Empty state present; error states present; microcopy is educator-facing

**Note on review agents:** `ui-reviewer` and `ux-reviewer` agents are project-defined but not spawnable as `subagent_type` in this runtime. Flagging for a manual pass before merge.

## Test plan

- [x] 5 component tests (RTL): empty state, populated catalogue, opt-out copy, validation list with errors, hidden import button when not operator
- [x] 4 new GET route tests: auth error, 404 on missing playbook, empty state, persisted modules with warnings
- [x] All 13 import-modules route tests still pass (POST + GET)
- [x] Full project unit test impact: 115/115 in scope (parser + helper + route + component + sibling tests)
- [x] tsc clean (560 — same as parent baseline)
- [x] Lint baseline preserved (1 pre-existing error in `CourseCurriculumTab.tsx` unchanged, line shifted by panel insertion)
- [x] API docs auto-regenerated by pre-commit hook

## AI-to-DB guard

Per `.claude/rules/ai-to-db-guard.md`: this PR adds no AI-driven write paths. The panel reads via `requireAuth("VIEWER")` GET; the import dialog calls the existing PR2 POST which is deterministic-parser-only. No guard needed.

## Deploy

Ready for `/vm-cp` (no migration, no schema change).

Refs #236