### PR TITLE
feat: LearnerModulePicker + setup-status authored-modules gate (Closes #236, PR4/4)

### DIFF
--- a/apps/admin/__tests__/ui/authored-modules-panel.test.tsx
+++ b/apps/admin/__tests__/ui/authored-modules-panel.test.tsx
@@ -110,18 +110,23 @@ describe("AuthoredModulesPanel — populated catalogue", () => {
     });
 
     render(<AuthoredModulesPanel courseId="c1" isOperator={true} />);
+    // ID code cell appears only in the catalogue table, so single match
     await waitFor(() => {
       expect(screen.getByText("baseline")).toBeInTheDocument();
     });
-    expect(screen.getByText("Baseline Assessment")).toBeInTheDocument();
     expect(screen.getByText("part1")).toBeInTheDocument();
-    expect(screen.getByText("Part 1: Familiar Topics")).toBeInTheDocument();
+    // Labels appear in BOTH the catalogue table and the picker preview now
+    // (PR4 mounted the picker as a preview); use getAllByText for them.
+    expect(screen.getAllByText("Baseline Assessment").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Part 1: Familiar Topics").length).toBeGreaterThanOrEqual(1);
     // Status strip
     expect(screen.getByText(/Production publish ready/i)).toBeInTheDocument();
     // Source ref
     expect(screen.getByText(/doc doc-9/i)).toBeInTheDocument();
     // "Re-import" wording when modules already exist
     expect(screen.getByRole("button", { name: /Re-import/i })).toBeInTheDocument();
+    // PR4: picker preview header is present
+    expect(screen.getByText(/Learner Picker Preview/i)).toBeInTheDocument();
   });
 });
 

--- a/apps/admin/__tests__/ui/learner-module-picker.test.tsx
+++ b/apps/admin/__tests__/ui/learner-module-picker.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Tests for LearnerModulePicker — read-only learner-facing module picker.
+ *
+ * Covers:
+ * - Tiles layout when lessonPlanMode is "continuous"
+ * - Rail layout when lessonPlanMode is "structured"
+ * - Hides modules with learnerSelectable=false
+ * - Hides `frequency: once` modules already in completedModuleIds (tiles)
+ * - Sorts rail by `position`
+ * - Surfaces "Recommended after X" advisory hint when prerequisites unmet
+ * - Renders "Ends session" badge for sessionTerminal modules
+ * - Renders "Spoken bands" badge for voiceBandReadout modules
+ * - In preview mode (no onSelect), tiles are <div>s, not <button>s
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LearnerModulePicker } from "@/app/x/courses/[courseId]/_components/LearnerModulePicker";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+
+function mod(over: Partial<AuthoredModule>): AuthoredModule {
+  return {
+    id: "m",
+    label: "Module",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "Student-led",
+    scoringFired: "LR + GRA",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: [],
+    ...over,
+  };
+}
+
+const IELTS_MODULES: AuthoredModule[] = [
+  mod({
+    id: "baseline",
+    label: "Baseline Assessment",
+    mode: "examiner",
+    duration: "20 min fixed",
+    scoringFired: "All four",
+    sessionTerminal: true,
+    frequency: "once",
+  }),
+  mod({ id: "part1", label: "Part 1: Familiar Topics" }),
+  mod({ id: "part2", label: "Part 2: Cue Card Monologues", mode: "mixed" }),
+  mod({ id: "part3", label: "Part 3: Abstract Discussion" }),
+  mod({
+    id: "mock",
+    label: "Mock Exam",
+    mode: "examiner",
+    duration: "20 min fixed",
+    scoringFired: "All four",
+    sessionTerminal: true,
+    voiceBandReadout: true,
+  }),
+];
+
+// ── Tiles ──────────────────────────────────────────────────────────
+
+describe("LearnerModulePicker — tiles (continuous)", () => {
+  it("renders one tile per learner-selectable module", () => {
+    render(<LearnerModulePicker modules={IELTS_MODULES} lessonPlanMode="continuous" />);
+    expect(screen.getByText("Baseline Assessment")).toBeInTheDocument();
+    expect(screen.getByText("Part 1: Familiar Topics")).toBeInTheDocument();
+    expect(screen.getByText("Mock Exam")).toBeInTheDocument();
+  });
+
+  it("hides modules with learnerSelectable=false", () => {
+    const modules = [...IELTS_MODULES, mod({ id: "hidden", label: "Internal", learnerSelectable: false })];
+    render(<LearnerModulePicker modules={modules} lessonPlanMode="continuous" />);
+    expect(screen.queryByText("Internal")).not.toBeInTheDocument();
+  });
+
+  it("hides `frequency: once` modules that have been completed", () => {
+    render(
+      <LearnerModulePicker
+        modules={IELTS_MODULES}
+        lessonPlanMode="continuous"
+        completedModuleIds={["baseline"]}
+      />,
+    );
+    expect(screen.queryByText("Baseline Assessment")).not.toBeInTheDocument();
+    // Other modules still visible
+    expect(screen.getByText("Part 1: Familiar Topics")).toBeInTheDocument();
+  });
+
+  it("renders `Ends session` badge for sessionTerminal modules", () => {
+    render(<LearnerModulePicker modules={IELTS_MODULES} lessonPlanMode="continuous" />);
+    const badges = screen.getAllByText(/Ends session/i);
+    // baseline + mock both terminal
+    expect(badges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders `Spoken bands` badge only for voiceBandReadout modules", () => {
+    render(<LearnerModulePicker modules={IELTS_MODULES} lessonPlanMode="continuous" />);
+    expect(screen.getByText(/Spoken bands/i)).toBeInTheDocument();
+  });
+
+  it("renders tiles as <div>s when no onSelect handler is provided (preview mode)", () => {
+    const { container } = render(
+      <LearnerModulePicker modules={IELTS_MODULES} lessonPlanMode="continuous" />,
+    );
+    expect(container.querySelectorAll("button.learner-picker__tile")).toHaveLength(0);
+    expect(container.querySelectorAll("div.learner-picker__tile").length).toBeGreaterThan(0);
+  });
+
+  it("renders tiles as <button>s and fires onSelect when activated", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={IELTS_MODULES}
+        lessonPlanMode="continuous"
+        onSelect={onSelect}
+      />,
+    );
+    const buttons = container.querySelectorAll("button.learner-picker__tile");
+    expect(buttons.length).toBeGreaterThan(0);
+    (buttons[1] as HTMLButtonElement).click();
+    expect(onSelect).toHaveBeenCalledWith("part1");
+  });
+});
+
+// ── Rail ───────────────────────────────────────────────────────────
+
+describe("LearnerModulePicker — rail (structured)", () => {
+  const SEQUENTIAL: AuthoredModule[] = [
+    mod({ id: "ch1", label: "Chapter 1", position: 1 }),
+    mod({ id: "ch2", label: "Chapter 2", position: 2, prerequisites: ["ch1"] }),
+    mod({ id: "ch3", label: "Chapter 3", position: 3, prerequisites: ["ch2"] }),
+  ];
+
+  it("renders an ordered list", () => {
+    const { container } = render(
+      <LearnerModulePicker modules={SEQUENTIAL} lessonPlanMode="structured" />,
+    );
+    expect(container.querySelector("ol.learner-picker__rail")).not.toBeNull();
+  });
+
+  it("sorts items by position even if input order is shuffled", () => {
+    const shuffled = [SEQUENTIAL[2], SEQUENTIAL[0], SEQUENTIAL[1]];
+    const { container } = render(
+      <LearnerModulePicker modules={shuffled} lessonPlanMode="structured" />,
+    );
+    const labels = Array.from(
+      container.querySelectorAll(".learner-picker__rail-label"),
+    ).map((el) => el.textContent ?? "");
+    // Each label may include suffix badges; just check ordering by prefix
+    expect(labels[0].startsWith("Chapter 1")).toBe(true);
+    expect(labels[1].startsWith("Chapter 2")).toBe(true);
+    expect(labels[2].startsWith("Chapter 3")).toBe(true);
+  });
+
+  it("surfaces 'Recommended after X' advisory when prerequisites are unmet", () => {
+    render(
+      <LearnerModulePicker
+        modules={SEQUENTIAL}
+        lessonPlanMode="structured"
+        completedModuleIds={[]}
+      />,
+    );
+    expect(screen.getByText(/Recommended after ch1/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recommended after ch2/i)).toBeInTheDocument();
+  });
+
+  it("hides the advisory and shows 'Done' when prerequisites are met", () => {
+    render(
+      <LearnerModulePicker
+        modules={SEQUENTIAL}
+        lessonPlanMode="structured"
+        completedModuleIds={["ch1"]}
+      />,
+    );
+    // ch2 prereq satisfied
+    expect(screen.queryByText(/Recommended after ch1/i)).not.toBeInTheDocument();
+    // ch1 marked Done
+    expect(screen.getByText(/Done/i)).toBeInTheDocument();
+  });
+
+  it("does NOT gate the rail card — it is rendered as a clickable button when onSelect provided, regardless of prereqs", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={SEQUENTIAL}
+        lessonPlanMode="structured"
+        onSelect={onSelect}
+      />,
+    );
+    const buttons = container.querySelectorAll("button.learner-picker__rail-card");
+    expect(buttons.length).toBe(3);
+    // Activate the third (whose prereqs are unmet) — must still fire
+    (buttons[2] as HTMLButtonElement).click();
+    expect(onSelect).toHaveBeenCalledWith("ch3");
+  });
+});
+
+// ── Empty state ────────────────────────────────────────────────────
+
+describe("LearnerModulePicker — empty visible set", () => {
+  it("renders the empty hint when every module is learnerSelectable=false", () => {
+    const modules = [
+      mod({ id: "x", label: "X", learnerSelectable: false }),
+      mod({ id: "y", label: "Y", learnerSelectable: false }),
+    ];
+    render(<LearnerModulePicker modules={modules} lessonPlanMode="continuous" />);
+    expect(screen.getByText(/No learner-selectable modules/i)).toBeInTheDocument();
+  });
+});
+
+// ── Layout fallback ────────────────────────────────────────────────
+
+describe("LearnerModulePicker — null lessonPlanMode", () => {
+  it("falls back to tiles when lessonPlanMode is null", () => {
+    const { container } = render(
+      <LearnerModulePicker modules={IELTS_MODULES} lessonPlanMode={null} />,
+    );
+    expect(container.querySelector(".learner-picker--tiles")).not.toBeNull();
+    expect(container.querySelector(".learner-picker--rail")).toBeNull();
+  });
+});

--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -50,7 +50,7 @@ type Body = z.infer<typeof BodySchema>;
  *   Used by the Authored Modules panel in the Curriculum tab to render the
  *   catalogue without re-parsing the source document. Returns nulls/empties
  *   when no authored modules exist yet (derived path is in use).
- * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors }
+ * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors, lessonPlanMode }
  * @response 404 { ok: false, error: "Course not found" }
  */
 export async function GET(
@@ -83,6 +83,9 @@ export async function GET(
     moduleSourceRef: cfg.moduleSourceRef ?? null,
     validationWarnings: warnings,
     hasErrors: warnings.some((w) => w.severity === "error"),
+    // Surfaced so the learner-preview component can pick the right layout
+    // (tiles for continuous, rail for structured) without a second fetch.
+    lessonPlanMode: cfg.lessonPlanMode ?? null,
   });
 }
 

--- a/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
@@ -61,7 +61,23 @@ export async function GET(
 
     let lessonPlanBuilt = false;
     if (isContinuous) {
-      lessonPlanBuilt = true;
+      // Continuous courses normally have no fixed lesson plan — but if the
+      // author opted in to authored modules (Issue #236), the catalogue
+      // becomes the structure, and we require it to exist with no blocking
+      // errors before we mark "Lesson Plan Built". Authors who haven't
+      // imported their catalogue yet will see this stage stay open.
+      const modules = Array.isArray(pbConfig.modules) ? pbConfig.modules : [];
+      const warnings = Array.isArray(pbConfig.validationWarnings)
+        ? pbConfig.validationWarnings
+        : [];
+      const hasBlockingErrors = warnings.some(
+        (w: { severity?: string }) => w?.severity === "error",
+      );
+      if (pbConfig.modulesAuthored === true) {
+        lessonPlanBuilt = modules.length > 0 && !hasBlockingErrors;
+      } else {
+        lessonPlanBuilt = true;
+      }
     } else {
       // Structured courses: check for lesson plan entries in curriculum
       const subjectIds = await prisma.playbookSubject.findMany({

--- a/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
@@ -14,7 +14,13 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
-import { Layers, AlertTriangle, CheckCircle2, Upload } from "lucide-react";
+import {
+  Layers,
+  AlertTriangle,
+  CheckCircle2,
+  Upload,
+  Eye,
+} from "lucide-react";
 import type {
   AuthoredModule,
   ModuleDefaults,
@@ -22,6 +28,7 @@ import type {
   ValidationWarning,
 } from "@/lib/types/json-fields";
 import { ImportModulesDialog } from "./ImportModulesDialog";
+import { LearnerModulePicker } from "./LearnerModulePicker";
 import "./authored-modules-panel.css";
 
 interface AuthoredModulesState {
@@ -32,6 +39,7 @@ interface AuthoredModulesState {
   moduleSourceRef: { docId: string; version: string } | null;
   validationWarnings: ValidationWarning[];
   hasErrors: boolean;
+  lessonPlanMode: "structured" | "continuous" | null;
 }
 
 interface AuthoredModulesPanelProps {
@@ -47,6 +55,7 @@ const EMPTY_STATE: AuthoredModulesState = {
   moduleSourceRef: null,
   validationWarnings: [],
   hasErrors: false,
+  lessonPlanMode: null,
 };
 
 export function AuthoredModulesPanel({
@@ -75,6 +84,7 @@ export function AuthoredModulesPanel({
         moduleSourceRef: data.moduleSourceRef,
         validationWarnings: data.validationWarnings,
         hasErrors: data.hasErrors,
+        lessonPlanMode: data.lessonPlanMode,
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unknown error");
@@ -145,6 +155,10 @@ export function AuthoredModulesPanel({
           {state.validationWarnings.length > 0 && (
             <ValidationList warnings={state.validationWarnings} />
           )}
+          <LearnerPickerPreview
+            modules={state.modules}
+            lessonPlanMode={state.lessonPlanMode}
+          />
           {state.moduleSourceRef && (
             <p className="hf-text-xs hf-text-muted hf-mt-sm">
               Source: doc {state.moduleSourceRef.docId} (v{state.moduleSourceRef.version})
@@ -324,5 +338,36 @@ function ValidationList({ warnings }: { warnings: ValidationWarning[] }) {
         </li>
       ))}
     </ul>
+  );
+}
+
+// ── Learner picker preview ────────────────────────────────────────
+
+function LearnerPickerPreview({
+  modules,
+  lessonPlanMode,
+}: {
+  modules: AuthoredModule[];
+  lessonPlanMode: "structured" | "continuous" | null;
+}) {
+  return (
+    <div className="authored-modules-preview">
+      <div className="hf-flex hf-items-center hf-gap-sm authored-modules-preview__header">
+        <Eye size={14} className="hf-text-muted" />
+        <span className="hf-section-title authored-modules-preview__title">
+          Learner Picker Preview
+        </span>
+        <span className="hf-text-xs hf-text-muted">
+          {lessonPlanMode === "structured"
+            ? "Sequenced rail (structured course)"
+            : "Free-pick tiles (continuous course)"}
+        </span>
+      </div>
+      <p className="hf-text-xs hf-text-muted authored-modules-preview__caption">
+        This is what learners will see when the picker is wired into the
+        student portal. Read-only here.
+      </p>
+      <LearnerModulePicker modules={modules} lessonPlanMode={lessonPlanMode} />
+    </div>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+/**
+ * LearnerModulePicker — read-only render of the learner-facing module picker.
+ *
+ * Adapts layout based on `lessonPlanMode`:
+ *   - "continuous" (or unknown) → free tile grid
+ *   - "structured"             → sequenced rail
+ *
+ * Per the v2.2 IELTS spec ("tutor advises but never gates") and Issue #236:
+ *   - Prerequisites are surfaced as advisory hints, never as gates
+ *   - Session-terminal modules show an "Ends session" badge
+ *   - Voice band-readout shown only when true (Mock pattern)
+ *   - Learner-selectable=false modules are hidden from the picker
+ *
+ * Mounted today as a *preview* inside the Authored Modules admin panel
+ * (PR4 of #236) so educators can see what learners will see. Reused later
+ * when wired into the learner portal — same component, same data.
+ */
+
+import {
+  GraduationCap,
+  Mic,
+  Pencil,
+  Layers,
+  CircleDot,
+  AlertCircle,
+} from "lucide-react";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+
+export type PickerLayout = "tiles" | "rail";
+
+interface LearnerModulePickerProps {
+  modules: AuthoredModule[];
+  /** "continuous" → tiles, "structured" → rail. Null defaults to tiles. */
+  lessonPlanMode: "structured" | "continuous" | null;
+  /**
+   * If supplied, these IDs are treated as completed. Used by the rail layout
+   * to show position progress and by the tiles layout to suppress repeats
+   * for `frequency: once` modules (e.g. Baseline). Empty array = first session.
+   */
+  completedModuleIds?: string[];
+  /**
+   * If supplied, the picker calls this on tile/row activation. When omitted
+   * (preview mode), tiles render as `<div>` rather than `<button>` and the
+   * "Start" affordance is hidden.
+   */
+  onSelect?: (moduleId: string) => void;
+}
+
+export function LearnerModulePicker({
+  modules,
+  lessonPlanMode,
+  completedModuleIds = [],
+  onSelect,
+}: LearnerModulePickerProps) {
+  const visible = modules.filter((m) => m.learnerSelectable !== false);
+  if (visible.length === 0) {
+    return (
+      <div className="hf-empty learner-picker__empty">
+        <p className="hf-text-sm hf-text-muted">
+          No learner-selectable modules. Make at least one module
+          <code> learnerSelectable: true</code> to populate the picker.
+        </p>
+      </div>
+    );
+  }
+
+  const completed = new Set(completedModuleIds);
+  const layout: PickerLayout = lessonPlanMode === "structured" ? "rail" : "tiles";
+
+  return (
+    <div className={`learner-picker learner-picker--${layout}`}>
+      {layout === "rail" ? (
+        <RailLayout
+          modules={visible}
+          completed={completed}
+          onSelect={onSelect}
+        />
+      ) : (
+        <TilesLayout
+          modules={visible}
+          completed={completed}
+          onSelect={onSelect}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Tile layout (continuous) ───────────────────────────────────────
+
+function TilesLayout({
+  modules,
+  completed,
+  onSelect,
+}: {
+  modules: AuthoredModule[];
+  completed: Set<string>;
+  onSelect?: (id: string) => void;
+}) {
+  return (
+    <div className="learner-picker__tiles">
+      {modules.map((m) => {
+        const isOnce = m.frequency === "once";
+        const isHidden = isOnce && completed.has(m.id);
+        if (isHidden) return null;
+
+        const Tag = onSelect ? "button" : "div";
+        return (
+          <Tag
+            key={m.id}
+            type={onSelect ? "button" : undefined}
+            className="learner-picker__tile"
+            onClick={onSelect ? () => onSelect(m.id) : undefined}
+            data-terminal={m.sessionTerminal || undefined}
+          >
+            <ModeIcon mode={m.mode} />
+            <div className="learner-picker__tile-body">
+              <div className="learner-picker__tile-label">{m.label}</div>
+              <div className="learner-picker__tile-meta">
+                <span>{m.duration}</span>
+                <span className="learner-picker__sep">·</span>
+                <span>{describeFrequency(m.frequency)}</span>
+              </div>
+              <div className="learner-picker__tile-badges">
+                {m.sessionTerminal && (
+                  <span className="learner-picker__badge learner-picker__badge--warn">
+                    Ends session
+                  </span>
+                )}
+                {m.voiceBandReadout && (
+                  <span className="learner-picker__badge">
+                    <Mic size={10} aria-hidden="true" /> Spoken bands
+                  </span>
+                )}
+              </div>
+            </div>
+          </Tag>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Rail layout (structured) ───────────────────────────────────────
+
+function RailLayout({
+  modules,
+  completed,
+  onSelect,
+}: {
+  modules: AuthoredModule[];
+  completed: Set<string>;
+  onSelect?: (id: string) => void;
+}) {
+  // Sort by `position` if provided, otherwise preserve catalogue order.
+  const ordered = [...modules].sort((a, b) => {
+    const pa = a.position ?? Number.MAX_SAFE_INTEGER;
+    const pb = b.position ?? Number.MAX_SAFE_INTEGER;
+    return pa - pb;
+  });
+
+  return (
+    <ol className="learner-picker__rail">
+      {ordered.map((m, i) => {
+        const isComplete = completed.has(m.id);
+        const Tag = onSelect ? "button" : "div";
+        const prereqsUnmet = m.prerequisites.filter((p) => !completed.has(p));
+        const advisoryHint =
+          prereqsUnmet.length > 0
+            ? `Recommended after ${prereqsUnmet.join(", ")}`
+            : null;
+
+        return (
+          <li key={m.id} className="learner-picker__rail-item">
+            <div className="learner-picker__rail-marker">
+              <span className="learner-picker__rail-position">{i + 1}</span>
+            </div>
+            <Tag
+              type={onSelect ? "button" : undefined}
+              className="learner-picker__rail-card"
+              onClick={onSelect ? () => onSelect(m.id) : undefined}
+              data-complete={isComplete || undefined}
+              data-terminal={m.sessionTerminal || undefined}
+            >
+              <ModeIcon mode={m.mode} />
+              <div className="learner-picker__rail-body">
+                <div className="learner-picker__rail-label">
+                  {m.label}
+                  {isComplete && (
+                    <span className="learner-picker__badge learner-picker__badge--ok">
+                      <CircleDot size={10} aria-hidden="true" /> Done
+                    </span>
+                  )}
+                </div>
+                <div className="learner-picker__rail-meta">
+                  <span>{m.duration}</span>
+                  <span className="learner-picker__sep">·</span>
+                  <span>{describeFrequency(m.frequency)}</span>
+                </div>
+                <div className="learner-picker__rail-badges">
+                  {advisoryHint && (
+                    <span className="learner-picker__badge learner-picker__badge--info">
+                      <AlertCircle size={10} aria-hidden="true" /> {advisoryHint}
+                    </span>
+                  )}
+                  {m.sessionTerminal && (
+                    <span className="learner-picker__badge learner-picker__badge--warn">
+                      Ends session
+                    </span>
+                  )}
+                </div>
+              </div>
+            </Tag>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function ModeIcon({ mode }: { mode: AuthoredModule["mode"] }) {
+  if (mode === "examiner") return <GraduationCap size={18} aria-hidden="true" className="learner-picker__icon" />;
+  if (mode === "mixed") return <Layers size={18} aria-hidden="true" className="learner-picker__icon" />;
+  return <Pencil size={18} aria-hidden="true" className="learner-picker__icon" />;
+}
+
+function describeFrequency(freq: AuthoredModule["frequency"]): string {
+  if (freq === "once") return "Once";
+  if (freq === "cooldown") return "Cooldown";
+  return "Repeatable";
+}

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -199,3 +199,236 @@
 .authored-modules-dialog__actions {
   justify-content: flex-end;
 }
+
+/* ── Learner picker preview wrapper (admin) ─────────────── */
+
+.authored-modules-preview {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-default);
+}
+
+.authored-modules-preview__header {
+  margin-bottom: 4px;
+}
+
+.authored-modules-preview__title {
+  margin: 0;
+}
+
+.authored-modules-preview__caption {
+  margin: 0 0 8px 0;
+}
+
+/* ── Learner picker (reusable) ──────────────────────────── */
+
+.learner-picker {
+  margin-top: 12px;
+}
+
+.learner-picker__empty {
+  margin: 0;
+}
+
+.learner-picker__icon {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.learner-picker__sep {
+  color: var(--text-muted);
+}
+
+.learner-picker__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.learner-picker__badge--warn {
+  background: color-mix(in srgb, var(--status-error-text) 12%, transparent);
+  color: var(--status-error-text);
+}
+
+.learner-picker__badge--ok {
+  background: color-mix(in srgb, var(--status-success-text) 12%, transparent);
+  color: var(--status-success-text);
+}
+
+.learner-picker__badge--info {
+  background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+  color: var(--accent-primary);
+}
+
+/* Tiles (continuous) */
+
+.learner-picker__tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.learner-picker__tile {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  background: var(--surface-primary);
+  text-align: left;
+  cursor: default;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+button.learner-picker__tile {
+  cursor: pointer;
+}
+
+button.learner-picker__tile:hover {
+  border-color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 4%, var(--surface-primary));
+}
+
+.learner-picker__tile[data-terminal] {
+  border-style: dashed;
+}
+
+.learner-picker__tile-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.learner-picker__tile-label {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.learner-picker__tile-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.learner-picker__tile-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+/* Rail (structured) */
+
+.learner-picker__rail {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.learner-picker__rail-item {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.learner-picker__rail-marker {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12px;
+}
+
+.learner-picker__rail-position {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.learner-picker__rail-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  background: var(--surface-primary);
+  text-align: left;
+  cursor: default;
+  width: 100%;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+button.learner-picker__rail-card {
+  cursor: pointer;
+}
+
+button.learner-picker__rail-card:hover {
+  border-color: var(--accent-primary);
+}
+
+.learner-picker__rail-card[data-complete] {
+  background: color-mix(in srgb, var(--status-success-text) 4%, var(--surface-primary));
+}
+
+.learner-picker__rail-card[data-terminal] {
+  border-style: dashed;
+}
+
+.learner-picker__rail-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.learner-picker__rail-label {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.learner-picker__rail-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.learner-picker__rail-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}

--- a/apps/admin/tests/api/import-modules.test.ts
+++ b/apps/admin/tests/api/import-modules.test.ts
@@ -283,6 +283,8 @@ describe("GET /api/courses/[courseId]/import-modules", () => {
     expect(body.moduleSource).toBeNull();
     expect(body.moduleSourceRef).toBeNull();
     expect(body.hasErrors).toBe(false);
+    // PR4: lessonPlanMode surfaced for the learner-picker preview
+    expect(body.lessonPlanMode).toBe("continuous");
   });
 
   it("returns persisted modules + warnings + hasErrors", async () => {

--- a/apps/admin/tests/api/setup-status-authored-modules.test.ts
+++ b/apps/admin/tests/api/setup-status-authored-modules.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the authored-modules branch of GET /api/courses/[courseId]/setup-status
+ * (PR4 of #236).
+ *
+ * The change: continuous courses are no longer auto-marked as
+ * `lessonPlanBuilt = true` when `modulesAuthored === true`. They must have at
+ * least one parsed module AND no blocking errors. Authors who haven't
+ * imported their catalogue yet keep the stage open.
+ *
+ * The pre-existing branches (no modulesAuthored / structured course / no
+ * playbook) keep their behaviour. We test the new logic directly via the
+ * route handler with mocked prisma.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { mockPrisma, mockRequireAuth, mockIsAuthError } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: {
+      findUnique: vi.fn(),
+    },
+    playbookSubject: {
+      findMany: vi.fn(),
+    },
+    curriculum: {
+      findFirst: vi.fn(),
+    },
+    composedPrompt: {
+      findFirst: vi.fn(),
+    },
+  },
+  mockRequireAuth: vi.fn(),
+  mockIsAuthError: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+  isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+}));
+
+import { GET } from "@/app/api/courses/[courseId]/setup-status/route";
+
+const params = Promise.resolve({ courseId: "playbook-1" });
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost:3000/api/courses/playbook-1/setup-status");
+}
+
+const passingAuth = { session: { user: { id: "u1", role: "VIEWER" } } };
+
+beforeEach(() => {
+  mockRequireAuth.mockReset();
+  mockIsAuthError.mockReset();
+  mockPrisma.playbook.findUnique.mockReset();
+  mockPrisma.playbookSubject.findMany.mockReset();
+  mockPrisma.curriculum.findFirst.mockReset();
+  mockPrisma.composedPrompt.findFirst.mockReset();
+
+  mockRequireAuth.mockResolvedValue(passingAuth);
+  mockIsAuthError.mockReturnValue(false);
+
+  // Defaults that don't affect the lessonPlan branch — onboarding "configured"
+  // varies per test via the playbook.findUnique mock.
+  mockPrisma.composedPrompt.findFirst.mockResolvedValue(null);
+});
+
+function basePlaybook(configOverrides: Record<string, unknown> = {}) {
+  return {
+    id: "playbook-1",
+    config: { lessonPlanMode: "continuous", ...configOverrides },
+    domain: {
+      onboardingIdentitySpecId: "id-1",
+      onboardingFlowPhases: { phases: [] },
+    },
+    domainId: "domain-1",
+  };
+}
+
+describe("setup-status — authored-modules branch (continuous course)", () => {
+  it("keeps lessonPlanBuilt=true when modulesAuthored is unset (existing behaviour)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(basePlaybook());
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.lessonPlanBuilt).toBe(true);
+  });
+
+  it("keeps lessonPlanBuilt=true when modulesAuthored=false (author opted out)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(
+      basePlaybook({ modulesAuthored: false, moduleSource: "derived" }),
+    );
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.lessonPlanBuilt).toBe(true);
+  });
+
+  it("blocks lessonPlanBuilt when modulesAuthored=true but no modules imported yet", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(
+      basePlaybook({
+        modulesAuthored: true,
+        moduleSource: "authored",
+        modules: [],
+      }),
+    );
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.lessonPlanBuilt).toBe(false);
+  });
+
+  it("blocks lessonPlanBuilt when modules exist but include error-severity warnings", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(
+      basePlaybook({
+        modulesAuthored: true,
+        moduleSource: "authored",
+        modules: [{ id: "m1" }],
+        validationWarnings: [
+          { code: "MODULE_ID_INVALID", message: "x", severity: "error" },
+        ],
+      }),
+    );
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.lessonPlanBuilt).toBe(false);
+  });
+
+  it("allows lessonPlanBuilt when modules exist and only warning-severity entries are present", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(
+      basePlaybook({
+        modulesAuthored: true,
+        moduleSource: "authored",
+        modules: [{ id: "m1" }, { id: "m2" }],
+        validationWarnings: [
+          { code: "MODULE_FIELD_DEFAULTED", message: "x", severity: "warning" },
+        ],
+      }),
+    );
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.lessonPlanBuilt).toBe(true);
+  });
+
+  it("allows lessonPlanBuilt when modules exist and no warnings at all", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(
+      basePlaybook({
+        modulesAuthored: true,
+        moduleSource: "authored",
+        modules: [{ id: "m1" }],
+        validationWarnings: [],
+      }),
+    );
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.lessonPlanBuilt).toBe(true);
+  });
+});
+
+describe("setup-status — auth and 404 still behave (regression)", () => {
+  it("returns the auth error when requireAuth fails", async () => {
+    const errorResponse = NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    mockRequireAuth.mockResolvedValue(errorResponse);
+    mockIsAuthError.mockReturnValue(true);
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    expect(res.status).toBe(401);
+    expect(mockPrisma.playbook.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the playbook does not exist", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    expect(res.status).toBe(404);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9526,7 +9526,7 @@ Read the current authored-modules state from PlaybookConfig.
 
 **Response** `200`
 ```json
-{ ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors }
+{ ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors, lessonPlanMode }
 ```
 
 **Response** `404`


### PR DESCRIPTION
Closes #236.

Final PR of the four-PR plan. Adds the learner-facing module picker component and fixes the setup-status "Lesson Plan Built" derivation for authored modules.

## Summary

- `LearnerModulePicker` component — tiles for `lessonPlanMode = continuous`, sequenced rail for `structured`. Read-only when no `onSelect` is provided (preview mode).
- Mounted today as a **preview** inside the Authored Modules admin panel so educators see what learners will see; learner-portal wiring is a follow-up ticket per the agreed scope.
- `setup-status` route fix: continuous courses with `modulesAuthored = true` now require at least one parsed module + no blocking errors before `lessonPlanBuilt = true`.
- `import-modules` GET now surfaces `lessonPlanMode` so the preview can pick its layout without a second fetch.

## Picker behaviour

| Layout | When | Affordances |
|---|---|---|
| **Tiles** | `lessonPlanMode = continuous` (or null) | Free pick. Hides `frequency: once` modules already in `completedModuleIds`. Hides `learnerSelectable: false` modules. |
| **Rail** | `lessonPlanMode = structured` | Sorted by `position`. Shows numbered position marker. Surfaces "Recommended after X" advisory when prerequisites are unmet — **never gates**. Shows "Done" badge on completed modules. |

Both layouts surface "Ends session" badge for `sessionTerminal` modules and "Spoken bands" badge for `voiceBandReadout` modules. Mode icon (examiner/tutor/mixed) on every entry.

## Setup-status "Lesson Plan Built" — new logic

| State | Result | Reason |
|---|---|---|
| `modulesAuthored` unset, continuous | `true` | Existing behaviour preserved |
| `modulesAuthored = false`, continuous | `true` | Author opted out — derived path runs unchanged |
| `modulesAuthored = true`, modules empty | `false` | Author hasn't imported catalogue yet |
| `modulesAuthored = true`, errors present | `false` | Production publish would block anyway |
| `modulesAuthored = true`, modules ≥ 1, only warnings | `true` | Per per-field-defaults-with-warnings policy |
| Structured course with `lessonPlan` entries | unchanged | Existing behaviour preserved |

## Files

| Path | Change |
|---|---|
| `app/x/courses/[courseId]/_components/LearnerModulePicker.tsx` | New — picker (tiles + rail) |
| `app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx` | Edit — mounts preview |
| `app/x/courses/[courseId]/_components/authored-modules-panel.css` | Edit — picker styles |
| `app/api/courses/[courseId]/setup-status/route.ts` | Edit — authored-modules branch |
| `app/api/courses/[courseId]/import-modules/route.ts` | Edit — surfaces `lessonPlanMode` in GET |
| `__tests__/ui/learner-module-picker.test.tsx` | New — 13 RTL tests |
| `tests/api/setup-status-authored-modules.test.ts` | New — 8 route tests |
| `__tests__/ui/authored-modules-panel.test.tsx` | Edit — asserts preview mount |
| `tests/api/import-modules.test.ts` | Edit — asserts `lessonPlanMode` in GET response |

## Test plan

- [x] 13 picker tests: tiles render, rail render, sort by position, empty state, learnerSelectable filter, frequency:once hides on completed, advisory hint surfaces, advisory clears when prereq met, badges (terminal/spoken bands/done), button vs div mode, onSelect fires, null lessonPlanMode falls back to tiles
- [x] 8 setup-status tests: pre-existing behaviour preserved (3 cases), authored gate behaviour (3 cases), auth + 404 regression (2 cases)
- [x] All 252 sibling tests still pass
- [x] tsc: 561 errors (down from main's 568 — net 7 fewer; no new errors introduced)
- [x] Lint: 3 pre-existing errors in touched files (line-shifted by my edits, same code on main); zero new errors

## UI design system compliance

`hf-*` classes throughout, CSS variables exclusively (`--text-muted`, `--border-default`, `--accent-primary`, `--status-error-text`, `--status-success-text`, `--surface-*`), `color-mix()` for alpha. No inline styles for static properties. Empty state present, ARIA roles on interactive elements.

**Project agents not available in this runtime:** `ui-reviewer`, `ux-reviewer`, `guard-checker`, `standards-checker` — manual pass needed before merge.

## What this closes vs what remains

**Closes #236** — all 10 acceptance criteria from the issue are now in:

| Criterion | PR |
|---|---|
| Parser detects `Modules authored` declaration | PR1 (#237) |
| Module Catalogue table → `AuthoredModule[]` | PR1 |
| Modules persist on `PlaybookConfig` | PR2 (#238) |
| Wizard `modules-choice` step + smart-default | *deferred* — see follow-ups |
| Module Catalogue editor in admin | PR3 (#239) |
| Learner picker: tiles vs rail | PR4 (this) |
| Per-field-defaults-with-warnings validation | PR1 + PR2 |
| Prerequisites advisory only | PR4 |
| Derived path unchanged when not authored | PR1–PR4 |
| Setup-status route knows about authored modules | PR4 |

**Follow-up tickets** (deferred from #236 scope, agreed during the build):

| Ticket | Description |
|---|---|
| `feat: wizard modules-choice step` | The conversational v5 wizard step; deferred because it requires a `prompt-eval-enforcement` pass. Pivoted to import-API path in PR2 |
| `feat: learner-portal picker mount` | Wire `LearnerModulePicker` into the student journey-position router — needs session-flow architectural decision |
| `feat: session transition API` | `POST /api/sessions/[id]/transition` + orchestrator events |
| `feat: recommended-next service` | Pure function over learner progress + module catalogue |
| `feat: voice intent classifier for module switching` | VAPI tool + handler |
| `feat: scheduled module sessions` | Calendar UI + worker dial |
| `feat: per-row module editor` | Inline editing inside the Authored Modules panel |

## Deploy

Ready for `/vm-cp` (no migration, no schema change).

Refs #236