### PR TITLE
feat: LearnerModulePicker SIM mount (#242, Slice 1)

### DIFF
--- a/apps/admin/__tests__/ui/learner-picker-page.test.tsx
+++ b/apps/admin/__tests__/ui/learner-picker-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import StudentModulePickerPage from "@/app/x/student/[courseId]/modules/page";
 import type { AuthoredModule } from "@/lib/types/json-fields";
@@ -50,10 +50,6 @@ describe("StudentModulePickerPage", () => {
     pushMock.mockReset();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it("renders the picker when modulesAuthored=true", async () => {
     global.fetch = mockFetch({
       modulesAuthored: true,
@@ -103,7 +99,6 @@ describe("StudentModulePickerPage", () => {
   });
 
   it("non-terminal pick navigates to returnTo with requestedModuleId", async () => {
-    vi.useFakeTimers();
     global.fetch = mockFetch({
       modulesAuthored: true,
       modules: MODULES,
@@ -117,15 +112,18 @@ describe("StudentModulePickerPage", () => {
     fireEvent.click(tile);
 
     expect(screen.getByText("Starting session…")).toBeInTheDocument();
-    vi.runAllTimers();
 
-    expect(pushMock).toHaveBeenCalledWith(
-      "/x/sim/caller-1?requestedModuleId=part1",
+    await waitFor(
+      () => {
+        expect(pushMock).toHaveBeenCalledWith(
+          "/x/sim/caller-1?requestedModuleId=part1",
+        );
+      },
+      { timeout: 1500 },
     );
   });
 
   it("terminal pick shows confirm dialog before launching", async () => {
-    vi.useFakeTimers();
     global.fetch = mockFetch({
       modulesAuthored: true,
       modules: MODULES,
@@ -144,10 +142,14 @@ describe("StudentModulePickerPage", () => {
     expect(pushMock).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByLabelText(/Start Baseline/));
-    vi.runAllTimers();
 
-    expect(pushMock).toHaveBeenCalledWith(
-      "/x/sim/caller-1?requestedModuleId=baseline",
+    await waitFor(
+      () => {
+        expect(pushMock).toHaveBeenCalledWith(
+          "/x/sim/caller-1?requestedModuleId=baseline",
+        );
+      },
+      { timeout: 1500 },
     );
   });
 

--- a/apps/admin/__tests__/ui/learner-picker-page.test.tsx
+++ b/apps/admin/__tests__/ui/learner-picker-page.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import StudentModulePickerPage from "@/app/x/student/[courseId]/modules/page";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  useParams: () => ({ courseId: "course-1" }),
+  useSearchParams: () => new URLSearchParams("returnTo=/x/sim/caller-1"),
+}));
+
+function mod(over: Partial<AuthoredModule>): AuthoredModule {
+  return {
+    id: "m",
+    label: "Module",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "Student-led",
+    scoringFired: "All four",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: [],
+    ...over,
+  };
+}
+
+const MODULES: AuthoredModule[] = [
+  mod({ id: "baseline", label: "Baseline", sessionTerminal: true, frequency: "once" }),
+  mod({ id: "part1", label: "Part 1" }),
+];
+
+function mockFetch(payload: object, status = 200) {
+  return vi.fn(() =>
+    Promise.resolve({
+      ok: status === 200,
+      status,
+      json: () => Promise.resolve({ ok: status === 200, ...payload }),
+    } as Response),
+  );
+}
+
+describe("StudentModulePickerPage", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+    pushMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the picker when modulesAuthored=true", async () => {
+    global.fetch = mockFetch({
+      modulesAuthored: true,
+      modules: MODULES,
+      lessonPlanMode: "continuous",
+      validationWarnings: [],
+      hasErrors: false,
+    }) as typeof fetch;
+
+    render(<StudentModulePickerPage />);
+
+    expect(await screen.findByText("Baseline")).toBeInTheDocument();
+    expect(screen.getByText("Part 1")).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to returnTo when modulesAuthored=false", async () => {
+    global.fetch = mockFetch({
+      modulesAuthored: false,
+      modules: [],
+      lessonPlanMode: null,
+      validationWarnings: [],
+      hasErrors: false,
+    }) as typeof fetch;
+
+    render(<StudentModulePickerPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/x/sim/caller-1");
+    });
+  });
+
+  it("redirects when modulesAuthored=null (never imported)", async () => {
+    global.fetch = mockFetch({
+      modulesAuthored: null,
+      modules: [],
+      lessonPlanMode: null,
+      validationWarnings: [],
+      hasErrors: false,
+    }) as typeof fetch;
+
+    render(<StudentModulePickerPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/x/sim/caller-1");
+    });
+  });
+
+  it("non-terminal pick navigates to returnTo with requestedModuleId", async () => {
+    vi.useFakeTimers();
+    global.fetch = mockFetch({
+      modulesAuthored: true,
+      modules: MODULES,
+      lessonPlanMode: "continuous",
+      validationWarnings: [],
+      hasErrors: false,
+    }) as typeof fetch;
+
+    render(<StudentModulePickerPage />);
+    const tile = await screen.findByText("Part 1");
+    fireEvent.click(tile);
+
+    expect(screen.getByText("Starting session…")).toBeInTheDocument();
+    vi.runAllTimers();
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/x/sim/caller-1?requestedModuleId=part1",
+    );
+  });
+
+  it("terminal pick shows confirm dialog before launching", async () => {
+    vi.useFakeTimers();
+    global.fetch = mockFetch({
+      modulesAuthored: true,
+      modules: MODULES,
+      lessonPlanMode: "continuous",
+      validationWarnings: [],
+      hasErrors: false,
+    }) as typeof fetch;
+
+    render(<StudentModulePickerPage />);
+    const baselineTile = await screen.findByText("Baseline");
+    fireEvent.click(baselineTile);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/ends the session/i)).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText(/Start Baseline/));
+    vi.runAllTimers();
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/x/sim/caller-1?requestedModuleId=baseline",
+    );
+  });
+
+  it("terminal cancel closes the dialog without launching", async () => {
+    global.fetch = mockFetch({
+      modulesAuthored: true,
+      modules: MODULES,
+      lessonPlanMode: "continuous",
+      validationWarnings: [],
+      hasErrors: false,
+    }) as typeof fetch;
+
+    render(<StudentModulePickerPage />);
+    fireEvent.click(await screen.findByText("Baseline"));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Cancel/));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an error message on 404", async () => {
+    global.fetch = mockFetch({}, 404) as typeof fetch;
+    render(<StudentModulePickerPage />);
+    expect(await screen.findByText("Course not found")).toBeInTheDocument();
+  });
+});

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -51,6 +51,7 @@ export default function SimConversationPage() {
   const [caller, setCaller] = useState<CallerInfo | null>(null);
   const [playbookName, setPlaybookName] = useState<string | undefined>(undefined);
   const [subjectDiscipline, setSubjectDiscipline] = useState<string | undefined>(undefined);
+  const [modulesAuthored, setModulesAuthored] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
   // Journey chat — unified WhatsApp-style survey/onboarding/teaching flow
@@ -96,8 +97,11 @@ export default function SimConversationPage() {
               .then(pbData => {
                 if (!cancelled && pbData.ok) {
                   setPlaybookName(pbData.playbook?.name);
-                  const disc = (pbData.playbook?.config as any)?.subjectDiscipline;
-                  if (disc) setSubjectDiscipline(disc);
+                  const cfg = (pbData.playbook?.config as any) || {};
+                  if (cfg.subjectDiscipline) setSubjectDiscipline(cfg.subjectDiscipline);
+                  // Issue #242: gate the "Pick module" header button on authored modules.
+                  // Treat both `null` (never imported) and `false` (opted out) as off.
+                  setModulesAuthored(cfg.modulesAuthored === true);
                 }
               })
               .catch(() => {});
@@ -142,6 +146,13 @@ export default function SimConversationPage() {
     );
   }
 
+  const handlePickModule = useCallback(() => {
+    if (!playbookId) return;
+    const sp = new URLSearchParams();
+    sp.set('returnTo', `/x/sim/${callerId}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`);
+    router.push(`/x/student/${playbookId}/modules?${sp.toString()}`);
+  }, [callerId, playbookId, router, searchParams]);
+
   return (
     <SimChat
       callerId={callerId}
@@ -157,6 +168,7 @@ export default function SimConversationPage() {
       forceFirstCall={forceFirstCall || undefined}
       onBack={isDesktop ? undefined : () => router.push('/x/sim')}
       onCallEnd={isStudent ? handleStudentCallEnd : undefined}
+      onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
       journey={journey}
     />
   );

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+/**
+ * /x/student/[courseId]/modules — learner-facing Module Picker (Slice 1).
+ *
+ * SIM-first mount per #242. Renders LearnerModulePicker live (with onSelect)
+ * and lets a learner pick a module to drive the next session. Slice 2 will
+ * thread the selected moduleId through the call-launch flow; Slice 1 only
+ * confirms the pick and surfaces a "Starting session..." toast.
+ *
+ * Falls back silently when modulesAuthored !== true so legacy courses are
+ * unaffected (decision #3, AC: courses without authored modules are hidden).
+ */
+
+import { useEffect, useState, useCallback, useMemo, Suspense } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { GraduationCap, ArrowLeft } from "lucide-react";
+import type {
+  AuthoredModule,
+  ModuleDefaults,
+  ModuleSource,
+  ValidationWarning,
+} from "@/lib/types/json-fields";
+import { LearnerModulePicker } from "@/app/x/courses/[courseId]/_components/LearnerModulePicker";
+import "@/app/x/courses/[courseId]/_components/authored-modules-panel.css";
+
+interface ModulesPayload {
+  ok: boolean;
+  modulesAuthored: boolean | null;
+  modules: AuthoredModule[];
+  moduleDefaults: Partial<ModuleDefaults>;
+  moduleSource: ModuleSource | null;
+  validationWarnings: ValidationWarning[];
+  hasErrors: boolean;
+  lessonPlanMode: "structured" | "continuous" | null;
+}
+
+export default function StudentModulePickerPage() {
+  return (
+    <Suspense fallback={<PickerLoading />}>
+      <PickerContent />
+    </Suspense>
+  );
+}
+
+function PickerLoading() {
+  return (
+    <div className="hf-flex hf-items-center hf-justify-center" style={{ minHeight: 200, padding: 24 }}>
+      <div className="hf-spinner" style={{ width: 28, height: 28 }} />
+    </div>
+  );
+}
+
+function PickerContent() {
+  const router = useRouter();
+  const { courseId } = useParams<{ courseId: string }>();
+  const searchParams = useSearchParams();
+  const returnTo = searchParams.get("returnTo");
+
+  const [data, setData] = useState<ModulesPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingTerminal, setPendingTerminal] = useState<AuthoredModule | null>(null);
+  const [launching, setLaunching] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(`/api/courses/${courseId}/import-modules`);
+        if (!res.ok) {
+          if (!cancelled) setError(res.status === 404 ? "Course not found" : "Failed to load modules");
+          return;
+        }
+        const json = (await res.json()) as ModulesPayload;
+        if (!cancelled) setData(json);
+      } catch {
+        if (!cancelled) setError("Failed to load modules");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  // Fall-through guard: course has no authored modules → bounce back.
+  // `null` (never imported) and `false` (explicitly off) both hide the picker;
+  // we distinguish them only in the console log so prod telemetry can tell them apart.
+  useEffect(() => {
+    if (loading || error || !data) return;
+    if (data.modulesAuthored !== true) {
+      console.info(
+        "[picker] modulesAuthored=%s for course %s — silently bouncing",
+        data.modulesAuthored,
+        courseId,
+      );
+      router.replace(returnTo ?? "/x/sim");
+    }
+  }, [loading, error, data, returnTo, router, courseId]);
+
+  const moduleById = useMemo(() => {
+    const m = new Map<string, AuthoredModule>();
+    if (data) data.modules.forEach((mod) => m.set(mod.id, mod));
+    return m;
+  }, [data]);
+
+  const launchSelected = useCallback(
+    (moduleId: string) => {
+      // Slice 1 stub: log + toast. Slice 2 wires this into the call-launch flow.
+      console.info("[picker] selected moduleId=%s for course=%s", moduleId, courseId);
+      setLaunching(true);
+      setTimeout(() => {
+        setLaunching(false);
+        if (returnTo) {
+          const sep = returnTo.includes("?") ? "&" : "?";
+          router.push(`${returnTo}${sep}requestedModuleId=${encodeURIComponent(moduleId)}`);
+        } else {
+          router.push(`/x/sim?requestedModuleId=${encodeURIComponent(moduleId)}`);
+        }
+      }, 600);
+    },
+    [courseId, returnTo, router],
+  );
+
+  const handleSelect = useCallback(
+    (moduleId: string) => {
+      const mod = moduleById.get(moduleId);
+      if (!mod) return;
+      if (mod.sessionTerminal) {
+        setPendingTerminal(mod);
+        return;
+      }
+      launchSelected(moduleId);
+    },
+    [moduleById, launchSelected],
+  );
+
+  const handleTerminalConfirm = useCallback(() => {
+    if (!pendingTerminal) return;
+    const id = pendingTerminal.id;
+    setPendingTerminal(null);
+    launchSelected(id);
+  }, [pendingTerminal, launchSelected]);
+
+  const handleTerminalCancel = useCallback(() => {
+    setPendingTerminal(null);
+  }, []);
+
+  if (loading) return <PickerLoading />;
+
+  if (error) {
+    return (
+      <div className="hf-card" style={{ margin: 24, padding: 24 }}>
+        <p className="hf-text-muted">{error}</p>
+      </div>
+    );
+  }
+
+  // While the redirect effect runs, render nothing
+  if (!data || data.modulesAuthored !== true) return null;
+
+  return (
+    <div className="learner-picker-page">
+      <header
+        className="hf-flex hf-items-center hf-gap-sm"
+        style={{ padding: "16px 24px", borderBottom: "1px solid var(--border-default)" }}
+      >
+        {returnTo && (
+          <button
+            type="button"
+            className="hf-btn hf-btn-tertiary"
+            onClick={() => router.push(returnTo)}
+            aria-label="Back to session"
+          >
+            <ArrowLeft size={16} aria-hidden="true" />
+          </button>
+        )}
+        <GraduationCap size={18} className="hf-text-muted" aria-hidden="true" />
+        <h1 className="hf-section-title" style={{ margin: 0 }}>
+          Pick your module
+        </h1>
+      </header>
+
+      <div style={{ padding: 24, maxWidth: 960, margin: "0 auto" }}>
+        <p className="hf-text-sm hf-text-muted" style={{ marginBottom: 16 }}>
+          Choose what you want to practise. Recommendations are advisory — pick whatever helps you most.
+        </p>
+
+        <LearnerModulePicker
+          modules={data.modules}
+          lessonPlanMode={data.lessonPlanMode}
+          onSelect={handleSelect}
+        />
+
+        {launching && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="hf-banner"
+            style={{ marginTop: 16 }}
+          >
+            Starting session…
+          </div>
+        )}
+      </div>
+
+      {pendingTerminal && (
+        <ConfirmTerminalDialog
+          module={pendingTerminal}
+          onConfirm={handleTerminalConfirm}
+          onCancel={handleTerminalCancel}
+        />
+      )}
+    </div>
+  );
+}
+
+function ConfirmTerminalDialog({
+  module: mod,
+  onConfirm,
+  onCancel,
+}: {
+  module: AuthoredModule;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="picker-terminal-title"
+      className="learner-picker-page__dialog-backdrop"
+      onClick={onCancel}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "color-mix(in srgb, var(--text-primary) 40%, transparent)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 100,
+      }}
+    >
+      <div
+        className="hf-card"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: 420, width: "90%", padding: 24 }}
+      >
+        <h2 id="picker-terminal-title" className="hf-section-title" style={{ marginTop: 0 }}>
+          This module ends the session
+        </h2>
+        <p className="hf-text-sm hf-text-muted" style={{ marginBottom: 16 }}>
+          <strong>{mod.label}</strong> ({mod.duration}) is a single-segment session — once you start it, the
+          tutor will not move on to other modules in the same call.
+        </p>
+        <div className="hf-flex hf-gap-sm hf-justify-end">
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary"
+            onClick={onCancel}
+            aria-label="Cancel — return to picker"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="hf-btn hf-btn-primary"
+            onClick={onConfirm}
+            aria-label={`Start ${mod.label} — this ends the session`}
+          >
+            Start anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -49,6 +49,8 @@ export interface SimChatProps {
   onCallEnd?: () => void;
   onNewCall?: () => void;
   onBack?: () => void;
+  /** When set, renders a "Pick module" header button (Issue #242 SIM-first mount) */
+  onPickModule?: () => void;
   /** Journey chat integration — items rendered before call history */
   journey?: UseJourneyChatResult;
 }
@@ -120,6 +122,7 @@ export function SimChat({
   onCallEnd,
   onNewCall,
   onBack,
+  onPickModule,
   journey,
 }: SimChatProps) {
   const router = useRouter();
@@ -776,6 +779,7 @@ export function SimChat({
           setShowMediaLibrary(false);
         }}
         progressPanelActive={showProgressPanel}
+        onPickModule={onPickModule}
         onAdminPanel={isOperator ? () => { setShowAdminPanel(prev => !prev); setShowProgressPanel(false); } : undefined}
         adminPanelActive={showAdminPanel}
       />

--- a/apps/admin/components/sim/WhatsAppHeader.tsx
+++ b/apps/admin/components/sim/WhatsAppHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, PhoneOff, FolderOpen, Mic, Settings, BarChart3 } from 'lucide-react';
+import { ArrowLeft, PhoneOff, FolderOpen, Mic, Settings, BarChart3, Layers } from 'lucide-react';
 
 interface WhatsAppHeaderProps {
   title: string;
@@ -12,6 +12,7 @@ interface WhatsAppHeaderProps {
   onVoiceToggle?: () => void;
   onAdminPanel?: () => void;
   onProgressPanel?: () => void;
+  onPickModule?: () => void;
   mediaLibraryActive?: boolean;
   voiceActive?: boolean;
   callActive?: boolean;
@@ -20,7 +21,7 @@ interface WhatsAppHeaderProps {
   avatarColor?: string;
 }
 
-export function WhatsAppHeader({ title, subtitle, onBack, onEndCall, onMediaLibrary, onAvatarClick, onVoiceToggle, onAdminPanel, onProgressPanel, mediaLibraryActive, voiceActive, callActive, adminPanelActive, progressPanelActive, avatarColor = 'var(--text-muted)' }: WhatsAppHeaderProps) {
+export function WhatsAppHeader({ title, subtitle, onBack, onEndCall, onMediaLibrary, onAvatarClick, onVoiceToggle, onAdminPanel, onProgressPanel, onPickModule, mediaLibraryActive, voiceActive, callActive, adminPanelActive, progressPanelActive, avatarColor = 'var(--text-muted)' }: WhatsAppHeaderProps) {
   const initials = title.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
 
   return (
@@ -75,6 +76,16 @@ export function WhatsAppHeader({ title, subtitle, onBack, onEndCall, onMediaLibr
           style={{ color: progressPanelActive ? 'var(--wa-green-primary)' : undefined }}
         >
           <BarChart3 size={20} />
+        </button>
+      )}
+      {onPickModule && (
+        <button
+          className="wa-back-btn"
+          onClick={onPickModule}
+          aria-label="Pick a module to practise"
+          title="Pick module"
+        >
+          <Layers size={20} />
         </button>
       )}
       {onAdminPanel && (


### PR DESCRIPTION
## Summary

Slice 1 of 3 for #242. Mounts the `LearnerModulePicker` component (shipped in #236 PR4) into a learner-facing page and adds a "Pick module" header button in the SIM chat that links to it.

- New page `/x/student/[courseId]/modules` with full picker behaviour
- New `onPickModule` callback on `WhatsAppHeader` + `SimChat` (additive, non-breaking)
- SIM page gates the button on `PlaybookConfig.modulesAuthored === true`
- Session-terminal modules (Baseline, Mock) show a confirm dialog before launch
- `modulesAuthored = null` vs `false` both bounce silently — distinguished in logs

Pick currently console-logs + navigates back to the SIM with `?requestedModuleId=<id>` appended. **Slice 2** will thread that ID through the call-launch flow. **Slice 3** wires `CallerModuleProgress` into `completedModuleIds`.

## Out of scope (per #242)

- Real call-launch wiring (Slice 2 — needs VAPI dial path recon)
- Completion tracking (Slice 3)
- Journey-position routing for real learners (deferred, Slice 4)

## Test plan

- [x] Vitest component tests added (`__tests__/ui/learner-picker-page.test.tsx`) — 7 scenarios incl. terminal confirm/cancel + null/false redirects
- [ ] Local test execution blocked by stale pnpm symlinks in `node_modules` — relying on CI Unit Tests gate
- [ ] `/vm-pull` + manual: open SIM, confirm "Pick module" button only appears for `modulesAuthored=true` courses, click → picker → click tile → returns to SIM with `?requestedModuleId=...` in URL
- [ ] `/vm-pull` + manual: same flow but pick a session-terminal module (e.g. Baseline) → confirm dialog appears → "Start anyway" navigates, "Cancel" closes

## Reviewer notes

`ui-reviewer`, `ux-reviewer`, `guard-checker`, `standards-checker` agents are not spawnable in the current Claude Code runtime — matching the precedent set by #237–#240, this PR documents that gap rather than gating on it. Manual review for `hf-*` class adherence + CSS-var-only styling has been done; no inline hex literals; `color-mix()` used for the dialog backdrop.

## Deploy

`/vm-cp` — no schema migration. New page, new prop, no env vars.

Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)