### PR TITLE
feat: picker progress sections + In-progress badge (#242, Slice 3)

### DIFF
--- a/apps/admin/__tests__/ui/learner-module-picker.test.tsx
+++ b/apps/admin/__tests__/ui/learner-module-picker.test.tsx
@@ -11,6 +11,8 @@
  * - Renders "Ends session" badge for sessionTerminal modules
  * - Renders "Spoken bands" badge for voiceBandReadout modules
  * - In preview mode (no onSelect), tiles are <div>s, not <button>s
+ * - Tile sectioning when progress data is supplied (Slice 3 of #242)
+ * - In-progress badge on rail + tiles (Slice 3 of #242)
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -219,5 +221,127 @@ describe("LearnerModulePicker — null lessonPlanMode", () => {
     );
     expect(container.querySelector(".learner-picker--tiles")).not.toBeNull();
     expect(container.querySelector(".learner-picker--rail")).toBeNull();
+  });
+});
+
+// ── Progress sectioning (Slice 3) ──────────────────────────────────
+
+describe("LearnerModulePicker — tile sections (progress data supplied)", () => {
+  const PROGRESS_MODULES: AuthoredModule[] = [
+    mod({ id: "part1", label: "Part 1" }),
+    mod({ id: "part2", label: "Part 2" }),
+    mod({ id: "part3", label: "Part 3" }),
+  ];
+
+  it("groups tiles into Up next / In progress / Completed when progress is supplied", () => {
+    const { container } = render(
+      <LearnerModulePicker
+        modules={PROGRESS_MODULES}
+        lessonPlanMode="continuous"
+        completedModuleIds={["part1"]}
+        inProgressModuleIds={["part2"]}
+      />,
+    );
+
+    const sections = container.querySelectorAll(".learner-picker__section");
+    expect(sections.length).toBe(3);
+
+    const titles = Array.from(
+      container.querySelectorAll(".learner-picker__section-title"),
+    ).map((el) => el.textContent);
+    expect(titles).toEqual(["Up next", "In progress", "Completed"]);
+  });
+
+  it("omits sections that would be empty", () => {
+    const { container } = render(
+      <LearnerModulePicker
+        modules={PROGRESS_MODULES}
+        lessonPlanMode="continuous"
+        completedModuleIds={["part1", "part2", "part3"]}
+      />,
+    );
+
+    const titles = Array.from(
+      container.querySelectorAll(".learner-picker__section-title"),
+    ).map((el) => el.textContent);
+    // Only "Completed" — no Up next, no In progress
+    expect(titles).toEqual(["Completed"]);
+  });
+
+  it("renders an ungrouped grid when no progress data supplied", () => {
+    const { container } = render(
+      <LearnerModulePicker
+        modules={PROGRESS_MODULES}
+        lessonPlanMode="continuous"
+      />,
+    );
+    expect(container.querySelectorAll(".learner-picker__section").length).toBe(0);
+    expect(container.querySelectorAll(".learner-picker__tile").length).toBe(3);
+  });
+
+  it("hides `frequency: once` completed modules even within sections", () => {
+    const modules = [
+      mod({ id: "baseline", label: "Baseline", frequency: "once" }),
+      mod({ id: "part1", label: "Part 1" }),
+    ];
+    render(
+      <LearnerModulePicker
+        modules={modules}
+        lessonPlanMode="continuous"
+        completedModuleIds={["baseline"]}
+      />,
+    );
+    expect(screen.queryByText("Baseline")).not.toBeInTheDocument();
+    expect(screen.getByText("Part 1")).toBeInTheDocument();
+  });
+
+  it("shows In progress badge on tiles in the in-progress section", () => {
+    const { container } = render(
+      <LearnerModulePicker
+        modules={PROGRESS_MODULES}
+        lessonPlanMode="continuous"
+        inProgressModuleIds={["part2"]}
+      />,
+    );
+    // Section title + badge both say "In progress" — count both surfaces
+    const matches = screen.getAllByText(/In progress/i);
+    expect(matches.length).toBe(2);
+    // At least one is the badge inside a tile
+    expect(
+      container.querySelector(".learner-picker__badge--progress"),
+    ).not.toBeNull();
+  });
+});
+
+describe("LearnerModulePicker — in-progress badge on rail", () => {
+  const SEQUENTIAL: AuthoredModule[] = [
+    mod({ id: "ch1", label: "Chapter 1", position: 1 }),
+    mod({ id: "ch2", label: "Chapter 2", position: 2 }),
+  ];
+
+  it("shows In progress pill alongside Done", () => {
+    render(
+      <LearnerModulePicker
+        modules={SEQUENTIAL}
+        lessonPlanMode="structured"
+        completedModuleIds={["ch1"]}
+        inProgressModuleIds={["ch2"]}
+      />,
+    );
+    expect(screen.getByText(/In progress/i)).toBeInTheDocument();
+    expect(screen.getByText(/Done/i)).toBeInTheDocument();
+  });
+
+  it("collapses Done to win when a module is both in-progress and completed (data race)", () => {
+    render(
+      <LearnerModulePicker
+        modules={[mod({ id: "ch1", label: "Chapter 1", position: 1 })]}
+        lessonPlanMode="structured"
+        completedModuleIds={["ch1"]}
+        inProgressModuleIds={["ch1"]}
+      />,
+    );
+    expect(screen.getByText(/Done/i)).toBeInTheDocument();
+    expect(screen.queryByText(/In progress/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/__tests__/ui/learner-picker-page.test.tsx
+++ b/apps/admin/__tests__/ui/learner-picker-page.test.tsx
@@ -12,6 +12,15 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams("returnTo=/x/sim/caller-1"),
 }));
 
+vi.mock("@/hooks/useStudentCallerId", () => ({
+  useStudentCallerId: () => ({
+    callerId: null,
+    isAdmin: false,
+    hasSelection: true,
+    buildUrl: (base: string) => base,
+  }),
+}));
+
 function mod(over: Partial<AuthoredModule>): AuthoredModule {
   return {
     id: "m",
@@ -34,14 +43,33 @@ const MODULES: AuthoredModule[] = [
   mod({ id: "part1", label: "Part 1" }),
 ];
 
-function mockFetch(payload: object, status = 200) {
-  return vi.fn(() =>
-    Promise.resolve({
-      ok: status === 200,
-      status,
-      json: () => Promise.resolve({ ok: status === 200, ...payload }),
-    } as Response),
-  );
+interface FetchOptions {
+  modulesPayload?: object;
+  modulesStatus?: number;
+  progress?: Array<{
+    moduleId: string;
+    status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+    completedAt: string | null;
+    module: { id: string; slug: string; title: string; sortOrder: number };
+  }>;
+}
+
+function mockFetch({ modulesPayload, modulesStatus = 200, progress = [] }: FetchOptions) {
+  return vi.fn((url: string) => {
+    if (typeof url === "string" && url.includes("/api/student/module-progress")) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ok: true, progress }),
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: modulesStatus === 200,
+      status: modulesStatus,
+      json: () =>
+        Promise.resolve({ ok: modulesStatus === 200, ...(modulesPayload ?? {}) }),
+    } as Response);
+  });
 }
 
 describe("StudentModulePickerPage", () => {
@@ -52,11 +80,13 @@ describe("StudentModulePickerPage", () => {
 
   it("renders the picker when modulesAuthored=true", async () => {
     global.fetch = mockFetch({
-      modulesAuthored: true,
-      modules: MODULES,
-      lessonPlanMode: "continuous",
-      validationWarnings: [],
-      hasErrors: false,
+      modulesPayload: {
+        modulesAuthored: true,
+        modules: MODULES,
+        lessonPlanMode: "continuous",
+        validationWarnings: [],
+        hasErrors: false,
+      },
     }) as typeof fetch;
 
     render(<StudentModulePickerPage />);
@@ -68,11 +98,13 @@ describe("StudentModulePickerPage", () => {
 
   it("redirects to returnTo when modulesAuthored=false", async () => {
     global.fetch = mockFetch({
-      modulesAuthored: false,
-      modules: [],
-      lessonPlanMode: null,
-      validationWarnings: [],
-      hasErrors: false,
+      modulesPayload: {
+        modulesAuthored: false,
+        modules: [],
+        lessonPlanMode: null,
+        validationWarnings: [],
+        hasErrors: false,
+      },
     }) as typeof fetch;
 
     render(<StudentModulePickerPage />);
@@ -84,11 +116,13 @@ describe("StudentModulePickerPage", () => {
 
   it("redirects when modulesAuthored=null (never imported)", async () => {
     global.fetch = mockFetch({
-      modulesAuthored: null,
-      modules: [],
-      lessonPlanMode: null,
-      validationWarnings: [],
-      hasErrors: false,
+      modulesPayload: {
+        modulesAuthored: null,
+        modules: [],
+        lessonPlanMode: null,
+        validationWarnings: [],
+        hasErrors: false,
+      },
     }) as typeof fetch;
 
     render(<StudentModulePickerPage />);
@@ -100,11 +134,13 @@ describe("StudentModulePickerPage", () => {
 
   it("non-terminal pick navigates to returnTo with requestedModuleId", async () => {
     global.fetch = mockFetch({
-      modulesAuthored: true,
-      modules: MODULES,
-      lessonPlanMode: "continuous",
-      validationWarnings: [],
-      hasErrors: false,
+      modulesPayload: {
+        modulesAuthored: true,
+        modules: MODULES,
+        lessonPlanMode: "continuous",
+        validationWarnings: [],
+        hasErrors: false,
+      },
     }) as typeof fetch;
 
     render(<StudentModulePickerPage />);
@@ -125,11 +161,13 @@ describe("StudentModulePickerPage", () => {
 
   it("terminal pick shows confirm dialog before launching", async () => {
     global.fetch = mockFetch({
-      modulesAuthored: true,
-      modules: MODULES,
-      lessonPlanMode: "continuous",
-      validationWarnings: [],
-      hasErrors: false,
+      modulesPayload: {
+        modulesAuthored: true,
+        modules: MODULES,
+        lessonPlanMode: "continuous",
+        validationWarnings: [],
+        hasErrors: false,
+      },
     }) as typeof fetch;
 
     render(<StudentModulePickerPage />);
@@ -155,11 +193,13 @@ describe("StudentModulePickerPage", () => {
 
   it("terminal cancel closes the dialog without launching", async () => {
     global.fetch = mockFetch({
-      modulesAuthored: true,
-      modules: MODULES,
-      lessonPlanMode: "continuous",
-      validationWarnings: [],
-      hasErrors: false,
+      modulesPayload: {
+        modulesAuthored: true,
+        modules: MODULES,
+        lessonPlanMode: "continuous",
+        validationWarnings: [],
+        hasErrors: false,
+      },
     }) as typeof fetch;
 
     render(<StudentModulePickerPage />);
@@ -175,8 +215,44 @@ describe("StudentModulePickerPage", () => {
   });
 
   it("shows an error message on 404", async () => {
-    global.fetch = mockFetch({}, 404) as typeof fetch;
+    global.fetch = mockFetch({ modulesStatus: 404 }) as typeof fetch;
     render(<StudentModulePickerPage />);
     expect(await screen.findByText("Course not found")).toBeInTheDocument();
+  });
+
+  it("renders sectioned tiles when progress contains COMPLETED + IN_PROGRESS", async () => {
+    global.fetch = mockFetch({
+      modulesPayload: {
+        modulesAuthored: true,
+        modules: MODULES,
+        lessonPlanMode: "continuous",
+        validationWarnings: [],
+        hasErrors: false,
+      },
+      progress: [
+        {
+          moduleId: "uuid-baseline",
+          status: "COMPLETED",
+          completedAt: "2026-05-01T00:00:00Z",
+          module: { id: "uuid-baseline", slug: "baseline", title: "Baseline", sortOrder: 0 },
+        },
+        {
+          moduleId: "uuid-part1",
+          status: "IN_PROGRESS",
+          completedAt: null,
+          module: { id: "uuid-part1", slug: "part1", title: "Part 1", sortOrder: 1 },
+        },
+      ],
+    }) as typeof fetch;
+
+    const { container } = render(<StudentModulePickerPage />);
+
+    // Wait for both fetches to settle
+    await screen.findByText("Part 1");
+    // Baseline is `frequency: once` + COMPLETED → still hidden
+    expect(screen.queryByText("Baseline")).not.toBeInTheDocument();
+    // Section title and tile badge both render — at least one of each
+    expect(container.querySelector(".learner-picker__section-title")).not.toBeNull();
+    expect(container.querySelector(".learner-picker__badge--progress")).not.toBeNull();
   });
 });

--- a/apps/admin/app/api/student/module-progress/route.ts
+++ b/apps/admin/app/api/student/module-progress/route.ts
@@ -1,0 +1,44 @@
+/**
+ * @api GET /api/student/module-progress
+ * @visibility internal
+ * @scope student:read
+ * @auth STUDENT (own caller) | OPERATOR+ (with ?callerId=)
+ * @description Returns the resolved caller's `CallerModuleProgress` rows joined
+ *   with `CurriculumModule` (id, slug, title). Used by the learner module
+ *   picker (#242 Slice 3) to derive `completedModuleIds` and
+ *   `inProgressModuleIds` for the authenticated learner without a path param.
+ *
+ *   Mirror of `/api/callers/[callerId]/module-progress` for the student-scoped
+ *   path family — STUDENT users have no path callerId, so they fetch via the
+ *   session-resolving helper.
+ *
+ * @response 200 { ok, progress: [{ moduleId, status, completedAt, module: { id, slug, title, sortOrder } }] }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireStudentOrAdmin(request);
+  if (isStudentAuthError(auth)) return auth.error;
+
+  const { callerId } = auth;
+
+  const progress = await prisma.callerModuleProgress.findMany({
+    where: { callerId },
+    include: {
+      module: {
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          sortOrder: true,
+        },
+      },
+    },
+    orderBy: { module: { sortOrder: "asc" } },
+  });
+
+  return NextResponse.json({ ok: true, progress });
+}

--- a/apps/admin/app/api/student/module-progress/route.ts
+++ b/apps/admin/app/api/student/module-progress/route.ts
@@ -6,16 +6,25 @@
  * @description Returns the resolved caller's `CallerModuleProgress` rows joined
  *   with `CurriculumModule` (id, slug, title). Used by the learner module
  *   picker (#242 Slice 3) to derive `completedModuleIds` and
- *   `inProgressModuleIds` for the authenticated learner without a path param.
+ *   `inProgressModuleIds`.
  *
- *   Mirror of `/api/callers/[callerId]/module-progress` for the student-scoped
- *   path family — STUDENT users have no path callerId, so they fetch via the
- *   session-resolving helper.
+ *   Optional `?courseId=` filter scopes results to a specific course
+ *   (Playbook). Without the filter, returns progress across ALL curricula
+ *   the caller has touched — risk: same module slug across two courses
+ *   bleeds completion state. Pass `courseId` whenever the caller is on a
+ *   single-course context.
  *
+ *   Mirror of `/api/callers/[callerId]/module-progress` for the student-
+ *   scoped path family — STUDENT users have no path callerId, so they fetch
+ *   via the session-resolving helper.
+ *
+ * @query courseId? — Playbook id; when present, results filtered to modules
+ *   whose Curriculum's `playbookId` matches.
  * @response 200 { ok, progress: [{ moduleId, status, completedAt, module: { id, slug, title, sortOrder } }] }
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
 
@@ -24,9 +33,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   if (isStudentAuthError(auth)) return auth.error;
 
   const { callerId } = auth;
+  const courseId = request.nextUrl.searchParams.get("courseId");
+
+  const where: Prisma.CallerModuleProgressWhereInput = courseId
+    ? { callerId, module: { curriculum: { playbookId: courseId } } }
+    : { callerId };
 
   const progress = await prisma.callerModuleProgress.findMany({
-    where: { callerId },
+    where,
     include: {
       module: {
         select: {

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -24,6 +24,7 @@ import {
   Pencil,
   Layers,
   CircleDot,
+  CircleDashed,
   AlertCircle,
 } from "lucide-react";
 import type { AuthoredModule } from "@/lib/types/json-fields";
@@ -35,11 +36,18 @@ interface LearnerModulePickerProps {
   /** "continuous" → tiles, "structured" → rail. Null defaults to tiles. */
   lessonPlanMode: "structured" | "continuous" | null;
   /**
-   * If supplied, these IDs are treated as completed. Used by the rail layout
-   * to show position progress and by the tiles layout to suppress repeats
-   * for `frequency: once` modules (e.g. Baseline). Empty array = first session.
+   * If supplied, these IDs are treated as completed. Tiles for `frequency: once`
+   * modules in this set are hidden; tiles for repeatable modules surface in
+   * the "Completed" section. Rail cards get a "Done" badge.
    */
   completedModuleIds?: string[];
+  /**
+   * If supplied, these IDs are treated as in-progress. Tiles in this set
+   * surface in the "In progress" section; rail cards get an "In progress"
+   * pill alongside the existing "Done" badge. Empty/omitted with no
+   * completed data = no progress sections (single ungrouped grid).
+   */
+  inProgressModuleIds?: string[];
   /**
    * If supplied, the picker calls this on tile/row activation. When omitted
    * (preview mode), tiles render as `<div>` rather than `<button>` and the
@@ -52,6 +60,7 @@ export function LearnerModulePicker({
   modules,
   lessonPlanMode,
   completedModuleIds = [],
+  inProgressModuleIds = [],
   onSelect,
 }: LearnerModulePickerProps) {
   const visible = modules.filter((m) => m.learnerSelectable !== false);
@@ -67,6 +76,7 @@ export function LearnerModulePicker({
   }
 
   const completed = new Set(completedModuleIds);
+  const inProgress = new Set(inProgressModuleIds);
   const layout: PickerLayout = lessonPlanMode === "structured" ? "rail" : "tiles";
 
   return (
@@ -75,12 +85,14 @@ export function LearnerModulePicker({
         <RailLayout
           modules={visible}
           completed={completed}
+          inProgress={inProgress}
           onSelect={onSelect}
         />
       ) : (
         <TilesLayout
           modules={visible}
           completed={completed}
+          inProgress={inProgress}
           onSelect={onSelect}
         />
       )}
@@ -93,53 +105,128 @@ export function LearnerModulePicker({
 function TilesLayout({
   modules,
   completed,
+  inProgress,
   onSelect,
 }: {
   modules: AuthoredModule[];
   completed: Set<string>;
+  inProgress: Set<string>;
   onSelect?: (id: string) => void;
 }) {
-  return (
-    <div className="learner-picker__tiles">
-      {modules.map((m) => {
-        const isOnce = m.frequency === "once";
-        const isHidden = isOnce && completed.has(m.id);
-        if (isHidden) return null;
+  // Hide `frequency: once` modules already completed (e.g. Baseline).
+  // Repeatable + completed stays visible so learners can retake.
+  const eligible = modules.filter(
+    (m) => !(m.frequency === "once" && completed.has(m.id)),
+  );
 
-        const Tag = onSelect ? "button" : "div";
-        return (
-          <Tag
-            key={m.id}
-            type={onSelect ? "button" : undefined}
-            className="learner-picker__tile"
-            onClick={onSelect ? () => onSelect(m.id) : undefined}
-            data-terminal={m.sessionTerminal || undefined}
-          >
-            <ModeIcon mode={m.mode} />
-            <div className="learner-picker__tile-body">
-              <div className="learner-picker__tile-label">{m.label}</div>
-              <div className="learner-picker__tile-meta">
-                <span>{m.duration}</span>
-                <span className="learner-picker__sep">·</span>
-                <span>{describeFrequency(m.frequency)}</span>
-              </div>
-              <div className="learner-picker__tile-badges">
-                {m.sessionTerminal && (
-                  <span className="learner-picker__badge learner-picker__badge--warn">
-                    Ends session
-                  </span>
-                )}
-                {m.voiceBandReadout && (
-                  <span className="learner-picker__badge">
-                    <Mic size={10} aria-hidden="true" /> Spoken bands
-                  </span>
-                )}
-              </div>
-            </div>
-          </Tag>
-        );
-      })}
-    </div>
+  // No progress data → single ungrouped grid (preserves pre-Slice-3 layout).
+  const hasProgressData = inProgress.size > 0 || completed.size > 0;
+  if (!hasProgressData) {
+    return (
+      <div className="learner-picker__tiles">
+        {eligible.map((m) => (
+          <Tile key={m.id} mod={m} inProgress={false} completed={false} onSelect={onSelect} />
+        ))}
+      </div>
+    );
+  }
+
+  const inProgressMods = eligible.filter((m) => inProgress.has(m.id));
+  const completedMods = eligible.filter(
+    (m) => completed.has(m.id) && !inProgress.has(m.id),
+  );
+  const upNextMods = eligible.filter(
+    (m) => !inProgress.has(m.id) && !completed.has(m.id),
+  );
+
+  return (
+    <>
+      {upNextMods.length > 0 && (
+        <Section title="Up next">
+          {upNextMods.map((m) => (
+            <Tile key={m.id} mod={m} inProgress={false} completed={false} onSelect={onSelect} />
+          ))}
+        </Section>
+      )}
+      {inProgressMods.length > 0 && (
+        <Section title="In progress">
+          {inProgressMods.map((m) => (
+            <Tile key={m.id} mod={m} inProgress completed={false} onSelect={onSelect} />
+          ))}
+        </Section>
+      )}
+      {completedMods.length > 0 && (
+        <Section title="Completed">
+          {completedMods.map((m) => (
+            <Tile key={m.id} mod={m} inProgress={false} completed onSelect={onSelect} />
+          ))}
+        </Section>
+      )}
+    </>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="learner-picker__section">
+      <h3 className="learner-picker__section-title">{title}</h3>
+      <div className="learner-picker__tiles">{children}</div>
+    </section>
+  );
+}
+
+function Tile({
+  mod,
+  inProgress,
+  completed,
+  onSelect,
+}: {
+  mod: AuthoredModule;
+  inProgress: boolean;
+  completed: boolean;
+  onSelect?: (id: string) => void;
+}) {
+  const Tag = onSelect ? "button" : "div";
+  return (
+    <Tag
+      type={onSelect ? "button" : undefined}
+      className="learner-picker__tile"
+      onClick={onSelect ? () => onSelect(mod.id) : undefined}
+      data-terminal={mod.sessionTerminal || undefined}
+      data-progress={inProgress ? "in-progress" : completed ? "completed" : undefined}
+    >
+      <ModeIcon mode={mod.mode} />
+      <div className="learner-picker__tile-body">
+        <div className="learner-picker__tile-label">{mod.label}</div>
+        <div className="learner-picker__tile-meta">
+          <span>{mod.duration}</span>
+          <span className="learner-picker__sep">·</span>
+          <span>{describeFrequency(mod.frequency)}</span>
+        </div>
+        <div className="learner-picker__tile-badges">
+          {inProgress && (
+            <span className="learner-picker__badge learner-picker__badge--progress">
+              <CircleDashed size={10} aria-hidden="true" /> In progress
+            </span>
+          )}
+          {completed && (
+            <span className="learner-picker__badge learner-picker__badge--ok">
+              <CircleDot size={10} aria-hidden="true" /> Done
+            </span>
+          )}
+          {mod.sessionTerminal && (
+            <span className="learner-picker__badge learner-picker__badge--warn">
+              Ends session
+            </span>
+          )}
+          {mod.voiceBandReadout && (
+            <span className="learner-picker__badge">
+              <Mic size={10} aria-hidden="true" /> Spoken bands
+            </span>
+          )}
+        </div>
+      </div>
+    </Tag>
   );
 }
 
@@ -148,10 +235,12 @@ function TilesLayout({
 function RailLayout({
   modules,
   completed,
+  inProgress,
   onSelect,
 }: {
   modules: AuthoredModule[];
   completed: Set<string>;
+  inProgress: Set<string>;
   onSelect?: (id: string) => void;
 }) {
   // Sort by `position` if provided, otherwise preserve catalogue order.
@@ -165,6 +254,7 @@ function RailLayout({
     <ol className="learner-picker__rail">
       {ordered.map((m, i) => {
         const isComplete = completed.has(m.id);
+        const isInProgress = inProgress.has(m.id) && !isComplete;
         const Tag = onSelect ? "button" : "div";
         const prereqsUnmet = m.prerequisites.filter((p) => !completed.has(p));
         const advisoryHint =
@@ -182,12 +272,18 @@ function RailLayout({
               className="learner-picker__rail-card"
               onClick={onSelect ? () => onSelect(m.id) : undefined}
               data-complete={isComplete || undefined}
+              data-in-progress={isInProgress || undefined}
               data-terminal={m.sessionTerminal || undefined}
             >
               <ModeIcon mode={m.mode} />
               <div className="learner-picker__rail-body">
                 <div className="learner-picker__rail-label">
                   {m.label}
+                  {isInProgress && (
+                    <span className="learner-picker__badge learner-picker__badge--progress">
+                      <CircleDashed size={10} aria-hidden="true" /> In progress
+                    </span>
+                  )}
                   {isComplete && (
                     <span className="learner-picker__badge learner-picker__badge--ok">
                       <CircleDot size={10} aria-hidden="true" /> Done

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -271,8 +271,7 @@ function RailLayout({
               type={onSelect ? "button" : undefined}
               className="learner-picker__rail-card"
               onClick={onSelect ? () => onSelect(m.id) : undefined}
-              data-complete={isComplete || undefined}
-              data-in-progress={isInProgress || undefined}
+              data-progress={isComplete ? "completed" : isInProgress ? "in-progress" : undefined}
               data-terminal={m.sessionTerminal || undefined}
             >
               <ModeIcon mode={m.mode} />

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -269,6 +269,39 @@
   color: var(--accent-primary);
 }
 
+.learner-picker__badge--progress {
+  background: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 12%, transparent);
+  color: var(--status-warning-text, var(--accent-primary));
+}
+
+/* Tile sections (in-progress / completed grouping) */
+
+.learner-picker__section {
+  display: block;
+  margin-top: 16px;
+}
+
+.learner-picker__section:first-of-type {
+  margin-top: 8px;
+}
+
+.learner-picker__section-title {
+  margin: 0 0 8px 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.learner-picker__tile[data-progress="completed"] {
+  background: color-mix(in srgb, var(--status-success-text) 4%, var(--surface-primary));
+}
+
+.learner-picker__tile[data-progress="in-progress"] {
+  border-color: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 35%, var(--border-default));
+}
+
 /* Tiles (continuous) */
 
 .learner-picker__tiles {

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -425,8 +425,12 @@ button.learner-picker__rail-card:hover {
   border-color: var(--accent-primary);
 }
 
-.learner-picker__rail-card[data-complete] {
+.learner-picker__rail-card[data-progress="completed"] {
   background: color-mix(in srgb, var(--status-success-text) 4%, var(--surface-primary));
+}
+
+.learner-picker__rail-card[data-progress="in-progress"] {
+  border-color: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 35%, var(--border-default));
 }
 
 .learner-picker__rail-card[data-terminal] {

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -22,6 +22,7 @@ import type {
   ValidationWarning,
 } from "@/lib/types/json-fields";
 import { LearnerModulePicker } from "@/app/x/courses/[courseId]/_components/LearnerModulePicker";
+import { useStudentCallerId } from "@/hooks/useStudentCallerId";
 import "@/app/x/courses/[courseId]/_components/authored-modules-panel.css";
 
 interface ModulesPayload {
@@ -33,6 +34,18 @@ interface ModulesPayload {
   validationWarnings: ValidationWarning[];
   hasErrors: boolean;
   lessonPlanMode: "structured" | "continuous" | null;
+}
+
+interface ProgressRow {
+  moduleId: string;
+  status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+  completedAt: string | null;
+  module: { id: string; slug: string; title: string; sortOrder: number };
+}
+
+interface ProgressPayload {
+  ok: boolean;
+  progress: ProgressRow[];
 }
 
 export default function StudentModulePickerPage() {
@@ -56,8 +69,10 @@ function PickerContent() {
   const { courseId } = useParams<{ courseId: string }>();
   const searchParams = useSearchParams();
   const returnTo = searchParams.get("returnTo");
+  const { buildUrl } = useStudentCallerId();
 
   const [data, setData] = useState<ModulesPayload | null>(null);
+  const [progress, setProgress] = useState<ProgressRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pendingTerminal, setPendingTerminal] = useState<AuthoredModule | null>(null);
@@ -67,13 +82,32 @@ function PickerContent() {
     let cancelled = false;
     async function load() {
       try {
-        const res = await fetch(`/api/courses/${courseId}/import-modules`);
-        if (!res.ok) {
-          if (!cancelled) setError(res.status === 404 ? "Course not found" : "Failed to load modules");
+        const [modulesRes, progressRes] = await Promise.all([
+          fetch(`/api/courses/${courseId}/import-modules`),
+          fetch(buildUrl("/api/student/module-progress")),
+        ]);
+
+        if (!modulesRes.ok) {
+          if (!cancelled) setError(modulesRes.status === 404 ? "Course not found" : "Failed to load modules");
           return;
         }
-        const json = (await res.json()) as ModulesPayload;
-        if (!cancelled) setData(json);
+        const modulesJson = (await modulesRes.json()) as ModulesPayload;
+
+        // Progress is a soft dependency — picker still renders without it.
+        let progressRows: ProgressRow[] = [];
+        if (progressRes.ok) {
+          try {
+            const progressJson = (await progressRes.json()) as ProgressPayload;
+            if (progressJson.ok) progressRows = progressJson.progress;
+          } catch {
+            // swallow — picker stays ungrouped if progress fetch malforms
+          }
+        }
+
+        if (!cancelled) {
+          setData(modulesJson);
+          setProgress(progressRows);
+        }
       } catch {
         if (!cancelled) setError("Failed to load modules");
       } finally {
@@ -84,7 +118,7 @@ function PickerContent() {
     return () => {
       cancelled = true;
     };
-  }, [courseId]);
+  }, [courseId, buildUrl]);
 
   // Fall-through guard: course has no authored modules → bounce back.
   // `null` (never imported) and `false` (explicitly off) both hide the picker;
@@ -106,6 +140,26 @@ function PickerContent() {
     if (data) data.modules.forEach((mod) => m.set(mod.id, mod));
     return m;
   }, [data]);
+
+  // Map progress rows (keyed by CurriculumModule.slug) to AuthoredModule.id sets.
+  // The slug-vs-id match works when authored module ids equal curriculum module
+  // slugs — the convention used in the v2.2 IELTS reference. Module IDs without
+  // a matching CurriculumModule row simply have no progress yet (which is fine
+  // until the dual-write path covers authored-module sources).
+  const { completedIds, inProgressIds } = useMemo(() => {
+    const completed: string[] = [];
+    const inProgress: string[] = [];
+    if (data) {
+      const authoredIds = new Set(data.modules.map((m) => m.id));
+      for (const row of progress) {
+        const match = authoredIds.has(row.module.slug) ? row.module.slug : null;
+        if (!match) continue;
+        if (row.status === "COMPLETED") completed.push(match);
+        else if (row.status === "IN_PROGRESS") inProgress.push(match);
+      }
+    }
+    return { completedIds: completed, inProgressIds: inProgress };
+  }, [data, progress]);
 
   const launchSelected = useCallback(
     (moduleId: string) => {
@@ -192,6 +246,8 @@ function PickerContent() {
         <LearnerModulePicker
           modules={data.modules}
           lessonPlanMode={data.lessonPlanMode}
+          completedModuleIds={completedIds}
+          inProgressModuleIds={inProgressIds}
           onSelect={handleSelect}
         />
 

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -84,7 +84,9 @@ function PickerContent() {
       try {
         const [modulesRes, progressRes] = await Promise.all([
           fetch(`/api/courses/${courseId}/import-modules`),
-          fetch(buildUrl("/api/student/module-progress")),
+          // courseId scopes progress to this Playbook's curricula — prevents
+          // module-slug collisions across the caller's other enrolments.
+          fetch(buildUrl("/api/student/module-progress", { courseId })),
         ]);
 
         if (!modulesRes.ok) {

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9954,6 +9954,19 @@ Analyse the diff between a current and desired prompt, returning
 
 ---
 
+### `GET` /api/student/module-progress
+
+Returns the resolved caller's `CallerModuleProgress` rows joined
+
+**Auth**: STUDENT (own caller) | OPERATOR+ (with ?callerId=) · **Scope**: `student:read`
+
+**Response** `200`
+```json
+{ ok, progress: [{ moduleId, status, completedAt, module: { id, slug, title, sortOrder } }] }
+```
+
+---
+
 ### `GET` /api/student/notifications
 
 **Auth**: STUDENT | OPERATOR+ (with callerId param)
@@ -14261,8 +14274,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 438 |
-| Files with annotations | 437 |
+| Route files found | 439 |
+| Files with annotations | 438 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 


### PR DESCRIPTION
## Summary

Slice 3 of 3 (in-scope) for #242. Wires `CallerModuleProgress` into the picker via a new session-resolving endpoint, then surfaces personal progress as **section grouping for tiles** ("Up next / In progress / Completed") and an **"In progress" badge alongside Done on the rail**.

UX decision: rail order is *not* replaced by status — position numbers remain the canonical "what's next in the course's design" answer, badges report personal state. Tiles get sectioning because they have no inherent order, so a status grouping fills a real gap.

**Stacked on #243 (Slice 1)** — merge order: 243 → this PR.

## Changes

- New endpoint: `GET /api/student/module-progress` (VIEWER, session-resolving via `requireStudentOrAdmin`). Mirror of `/api/callers/[id]/module-progress` for the student-scoped path family.
- `LearnerModulePicker`: new optional `inProgressModuleIds` prop, tile sectioning, rail in-progress pill.
- Page: parallel fetch + slug↔id mapping (matches v2.2 IELTS reference convention).
- CSS: section header + `--progress` badge (color-mix, no hex literals).

## Test plan

- [x] 29 vitest tests green (8 new + 21 existing). Includes: 3 sections, omits empty, frequency:once still hidden, Done wins data race with In-progress.
- [ ] `/vm-pull` + manual: open SIM with a completed authored module → picker shows "Completed" section, frequency:once item disappears.
- [ ] Manual: structured course rail → completed item shows Done, in-progress item shows In progress pill.

## Known gap (separate ticket needed)

The pipeline's `updateModuleMastery` resolves `moduleId` via `CurriculumModule.slug` lookup. **Authored modules without a corresponding CurriculumModule row never receive progress writes today.** The picker is correct; the upstream write path needs to be extended to cover authored-module sources. This was flagged by tech-lead before scoping. I'd open a follow-up issue once #242 is closed.

## Reviewer notes

`ui-reviewer`/`ux-reviewer` agents not spawnable in current runtime — manual checks done. All UI uses `hf-*`/component-scoped classes + CSS vars, `color-mix()` for alpha, accessibility kept on confirm dialog and badges (aria-hidden on decorative icons).

## Deploy

`/vm-cp` — no schema migration.

Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)