### PR TITLE
feat: picker→SIM placeholder banner (#242, Slice 2)

### DIFF
--- a/apps/admin/__tests__/ui/learner-picker-page.test.tsx
+++ b/apps/admin/__tests__/ui/learner-picker-page.test.tsx
@@ -147,7 +147,7 @@ describe("StudentModulePickerPage", () => {
     const tile = await screen.findByText("Part 1");
     fireEvent.click(tile);
 
-    expect(screen.getByText("Starting session…")).toBeInTheDocument();
+    expect(screen.getByText(/VAPI call would start/i)).toBeInTheDocument();
 
     await waitFor(
       () => {

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -34,6 +34,9 @@ export default function SimConversationPage() {
   const playbookId = searchParams.get('playbookId') || undefined;
   const communityName = searchParams.get('communityName') || undefined;
   const forceFirstCall = searchParams.get('forceFirstCall') === 'true';
+  // #242 Slice 2 placeholder: surface the moduleId chosen in the picker.
+  // No real VAPI dial wiring yet — the banner just confirms the round-trip.
+  const requestedModuleId = searchParams.get('requestedModuleId') || undefined;
 
   const targetOverrides = useMemo(() => {
     const raw = searchParams.get('tunerPills');
@@ -149,27 +152,76 @@ export default function SimConversationPage() {
   const handlePickModule = useCallback(() => {
     if (!playbookId) return;
     const sp = new URLSearchParams();
-    sp.set('returnTo', `/x/sim/${callerId}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`);
+    // Strip requestedModuleId so the banner doesn't keep firing on re-pick.
+    const carryParams = new URLSearchParams(searchParams.toString());
+    carryParams.delete('requestedModuleId');
+    sp.set('returnTo', `/x/sim/${callerId}${carryParams.toString() ? `?${carryParams.toString()}` : ''}`);
     router.push(`/x/student/${playbookId}/modules?${sp.toString()}`);
   }, [callerId, playbookId, router, searchParams]);
 
   return (
-    <SimChat
-      callerId={callerId}
-      callerName={caller.name}
-      domainName={caller.domain?.name}
-      playbookId={playbookId}
-      playbookName={communityName ?? playbookName}
-      subjectDiscipline={subjectDiscipline}
-      pastCalls={caller.pastCalls}
-      mode="standalone"
-      sessionGoal={sessionGoal}
-      targetOverrides={targetOverrides}
-      forceFirstCall={forceFirstCall || undefined}
-      onBack={isDesktop ? undefined : () => router.push('/x/sim')}
-      onCallEnd={isStudent ? handleStudentCallEnd : undefined}
-      onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
-      journey={journey}
-    />
+    <>
+      {requestedModuleId && (
+        <ModulePickerPlaceholderBanner moduleId={requestedModuleId} />
+      )}
+      <SimChat
+        callerId={callerId}
+        callerName={caller.name}
+        domainName={caller.domain?.name}
+        playbookId={playbookId}
+        playbookName={communityName ?? playbookName}
+        subjectDiscipline={subjectDiscipline}
+        pastCalls={caller.pastCalls}
+        mode="standalone"
+        sessionGoal={sessionGoal}
+        targetOverrides={targetOverrides}
+        forceFirstCall={forceFirstCall || undefined}
+        onBack={isDesktop ? undefined : () => router.push('/x/sim')}
+        onCallEnd={isStudent ? handleStudentCallEnd : undefined}
+        onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
+        journey={journey}
+      />
+    </>
+  );
+}
+
+/**
+ * Placeholder banner — Slice 2 of #242. Renders when the SIM is hit with
+ * `?requestedModuleId=<id>` (from the picker → SIM round-trip). The real
+ * VAPI dial wiring happens once the call-init path is identified by recon
+ * (see TODO in launchSelected at /x/student/[courseId]/modules/page.tsx).
+ */
+function ModulePickerPlaceholderBanner({ moduleId }: { moduleId: string }) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        padding: '10px 16px',
+        borderBottom: '1px solid var(--border-default)',
+        background: 'color-mix(in srgb, var(--accent-primary) 8%, var(--surface-primary))',
+        fontSize: 13,
+        color: 'var(--text-primary)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+      }}
+    >
+      <strong>Placeholder:</strong>
+      <span>
+        VAPI call would now start with module{' '}
+        <code
+          style={{
+            padding: '2px 6px',
+            borderRadius: 4,
+            background: 'var(--surface-secondary)',
+            fontSize: 12,
+          }}
+        >
+          {moduleId}
+        </code>
+        {' '}— wiring pending recon (#242 Slice 2).
+      </span>
+    </div>
   );
 }

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -165,8 +165,16 @@ function PickerContent() {
 
   const launchSelected = useCallback(
     (moduleId: string) => {
-      // Slice 1 stub: log + toast. Slice 2 wires this into the call-launch flow.
-      console.info("[picker] selected moduleId=%s for course=%s", moduleId, courseId);
+      // TODO(#242 Slice 2): wire this into the real VAPI call-init flow once
+      // the dial path is identified. `useJourneyChat` is NOT a call-creator
+      // (per tech-lead review). For now, the picker logs the pick and bounces
+      // back to the SIM with `?requestedModuleId=<id>`; the SIM renders a
+      // placeholder banner so devs can verify end-to-end module routing.
+      console.info(
+        "[picker] selected moduleId=%s for course=%s — placeholder, no VAPI dial yet",
+        moduleId,
+        courseId,
+      );
       setLaunching(true);
       setTimeout(() => {
         setLaunching(false);
@@ -260,7 +268,8 @@ function PickerContent() {
             className="hf-banner"
             style={{ marginTop: 16 }}
           >
-            Starting session…
+            <strong>Placeholder:</strong> VAPI call would start now —
+            returning to the simulator with the selected module.
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Slice 2 of #242, **placeholder edition**. Replaces #246 (closed when stacked base merged). Real VAPI call-init wiring is BLOCKED-pending-recon — `useJourneyChat` is not a call-creator, and there's no obvious `POST /api/sessions`. Rather than guess, this slice surfaces the picker → SIM round-trip visually so devs can verify end-to-end module routing.

## What it does

- Picker page's launching banner reads "Placeholder: VAPI call would start now — returning to the simulator…"
- SIM page reads `?requestedModuleId=<id>` from URL and renders a banner above SimChat: "Placeholder: VAPI call would now start with module `<id>` — wiring pending recon (#242 Slice 2)."
- Re-picking from the SIM strips the param so the banner doesn't double-fire.
- `launchSelected()` carries `TODO(#242 Slice 2)` so the next agent knows where to wire the real dial.

## Test plan

- [x] 29 vitest tests green
- [ ] `/vm-pull` + manual: open SIM → "Pick module" header button → pick a tile → returns to SIM with banner showing the module ID
- [ ] Pick again from the SIM → banner updates with the new module ID; previous selection is stripped from URL

## Recon needed before real wiring

The TODO at `app/x/student/[courseId]/modules/page.tsx:launchSelected` is the wire-in point. Recon needs to identify:
1. Where the SIM initiates a VAPI call (NOT in `useJourneyChat`)
2. What payload field carries session config to the tutor
3. Whether the tutor system prompt already accepts a module override (separate ticket if not)

## Deploy

`/vm-cp` — no schema, no env.

Refs #242. Replaces #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)