### PR TITLE
fix: sync authored modules into CurriculumModule on import (Closes #245)

### DIFF
--- a/apps/admin/__tests__/lib/sync-authored-modules-to-curriculum.test.ts
+++ b/apps/admin/__tests__/lib/sync-authored-modules-to-curriculum.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for syncAuthoredModulesToCurriculum (#245).
+ *
+ * Mocks the Tx parameter directly rather than the @/lib/prisma module —
+ * the helper takes a Tx so we can hand-roll one for unit testing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+import { syncAuthoredModulesToCurriculum } from "@/lib/wizard/sync-authored-modules-to-curriculum";
+
+function mod(over: Partial<AuthoredModule>): AuthoredModule {
+  return {
+    id: "m",
+    label: "Module",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "Student-led",
+    scoringFired: "All four",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: [],
+    ...over,
+  };
+}
+
+interface MockTx {
+  playbook: { findUnique: ReturnType<typeof vi.fn> };
+  curriculum: { create: ReturnType<typeof vi.fn> };
+  curriculumModule: {
+    findMany: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeTx(): MockTx {
+  return {
+    playbook: { findUnique: vi.fn() },
+    curriculum: { create: vi.fn() },
+    curriculumModule: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  };
+}
+
+describe("syncAuthoredModulesToCurriculum", () => {
+  let tx: MockTx;
+
+  beforeEach(() => {
+    tx = makeTx();
+  });
+
+  it("uses the playbook's existing primary curriculum when present", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "IELTS Speaking",
+      curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "m-1",
+      createdAt: new Date("2026-05-01"),
+      updatedAt: new Date("2026-05-01"),
+    });
+
+    const result = await syncAuthoredModulesToCurriculum(tx as never, "pb-1", [
+      mod({ id: "baseline", label: "Baseline" }),
+    ]);
+
+    expect(result.curriculumId).toBe("curr-1");
+    expect(tx.curriculum.create).not.toHaveBeenCalled();
+    expect(tx.curriculumModule.upsert).toHaveBeenCalledOnce();
+  });
+
+  it("creates a default curriculum when the playbook has none", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-2",
+      name: "Brand-new course",
+      curricula: [],
+    });
+    tx.curriculum.create.mockResolvedValue({ id: "curr-new" });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "m-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await syncAuthoredModulesToCurriculum(tx as never, "pb-2", [
+      mod({ id: "intro", label: "Intro" }),
+    ]);
+
+    expect(tx.curriculum.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          playbookId: "pb-2",
+          name: expect.stringContaining("Brand-new course"),
+        }),
+      }),
+    );
+    expect(result.curriculumId).toBe("curr-new");
+  });
+
+  it("forwards label, position, and prerequisites on upsert", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "Course",
+      curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "m",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await syncAuthoredModulesToCurriculum(tx as never, "pb-1", [
+      mod({ id: "ch2", label: "Chapter 2", position: 2, prerequisites: ["ch1"] }),
+    ]);
+
+    const call = tx.curriculumModule.upsert.mock.calls[0][0];
+    expect(call.where).toEqual({ curriculumId_slug: { curriculumId: "curr-1", slug: "ch2" } });
+    expect(call.create).toMatchObject({
+      curriculumId: "curr-1",
+      slug: "ch2",
+      title: "Chapter 2",
+      sortOrder: 2,
+      prerequisites: ["ch1"],
+    });
+    // Update path must NOT clobber masteryThreshold or other non-authored fields
+    expect(call.update).toEqual({
+      title: "Chapter 2",
+      sortOrder: 2,
+      prerequisites: ["ch1"],
+    });
+  });
+
+  it("counts created vs updated based on createdAt/updatedAt heuristic", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "C",
+      curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    const same = new Date("2026-05-01T00:00:00Z");
+    const diff = new Date("2026-05-02T00:00:00Z");
+    tx.curriculumModule.upsert
+      .mockResolvedValueOnce({ id: "a", createdAt: same, updatedAt: same })
+      .mockResolvedValueOnce({ id: "b", createdAt: same, updatedAt: diff });
+
+    const result = await syncAuthoredModulesToCurriculum(tx as never, "pb-1", [
+      mod({ id: "a" }),
+      mod({ id: "b" }),
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(result.updated).toBe(1);
+  });
+
+  it("counts orphans (in DB but not in import) without deleting them", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "C",
+      curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([
+      { slug: "kept" },
+      { slug: "stale-1" },
+      { slug: "stale-2" },
+    ]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "x",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await syncAuthoredModulesToCurriculum(tx as never, "pb-1", [
+      mod({ id: "kept" }),
+    ]);
+
+    expect(result.orphaned).toBe(2);
+    // Critically: never call delete or deleteMany
+    expect(Object.keys(tx.curriculumModule)).not.toContain("delete");
+    expect(Object.keys(tx.curriculumModule)).not.toContain("deleteMany");
+  });
+
+  it("throws if playbook not found", async () => {
+    tx.playbook.findUnique.mockResolvedValue(null);
+    await expect(
+      syncAuthoredModulesToCurriculum(tx as never, "nope", []),
+    ).rejects.toThrow(/Playbook nope not found/);
+  });
+
+  it("handles empty modules array as a no-op upsert (still resolves curriculum)", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "C",
+      curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+
+    const result = await syncAuthoredModulesToCurriculum(tx as never, "pb-1", []);
+
+    expect(result.curriculumId).toBe("curr-1");
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.orphaned).toBe(0);
+    expect(tx.curriculumModule.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -26,6 +26,7 @@ import {
   applyAuthoredModules,
   hasBlockingErrors,
 } from "@/lib/wizard/persist-authored-modules";
+import { syncAuthoredModulesToCurriculum } from "@/lib/wizard/sync-authored-modules-to-curriculum";
 
 // ── Body schema ──────────────────────────────────────────────────────
 
@@ -151,10 +152,24 @@ export async function POST(
     { sourceRef: body.sourceRef },
   );
 
+  // #245: when modules were persisted, also upsert CurriculumModule rows so
+  // the pipeline's slug-based `updateModuleMastery` can write progress for
+  // authored modules. Wrapped in a transaction so the playbook and module
+  // tables stay in sync if either write fails.
+  let syncResult: Awaited<ReturnType<typeof syncAuthoredModulesToCurriculum>> | null = null;
   if (changed) {
-    await prisma.playbook.update({
-      where: { id: courseId },
-      data: { config: nextConfig as object },
+    await prisma.$transaction(async (tx) => {
+      await tx.playbook.update({
+        where: { id: courseId },
+        data: { config: nextConfig as object },
+      });
+      if (detected.modulesAuthored === true && detected.modules.length > 0) {
+        syncResult = await syncAuthoredModulesToCurriculum(
+          tx,
+          courseId,
+          detected.modules,
+        );
+      }
     });
   }
 
@@ -167,5 +182,6 @@ export async function POST(
     detectedFrom: detected.detectedFrom,
     hasErrors: hasBlockingErrors(detected),
     persisted: changed,
+    curriculumSync: syncResult,
   });
 }

--- a/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
+++ b/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
@@ -1,0 +1,121 @@
+/**
+ * sync-authored-modules-to-curriculum.ts
+ *
+ * Closes the #245 gap: authored modules (PlaybookConfig.modules[]) had no
+ * corresponding CurriculumModule rows, so the pipeline's `updateModuleMastery`
+ * (lib/curriculum/track-progress.ts) silently dropped writes for them. The
+ * #242 picker rendered correctly but never showed in-progress / completed
+ * state in production.
+ *
+ * This helper upserts a CurriculumModule per authored module, keyed by
+ * (curriculumId, slug) where slug = AuthoredModule.id. It runs alongside
+ * `applyAuthoredModules` from the import-modules POST route.
+ *
+ * Idempotency / preservation contract:
+ *   - Re-importing the same markdown is a no-op (upsert; no duplicates).
+ *   - Renaming an authored module's label updates `title`, does NOT clobber
+ *     mastery / completedAt / callCount on existing CallerModuleProgress rows.
+ *   - Removing an authored module from the markdown leaves the
+ *     CurriculumModule row in place — orphaned history is preserved, not
+ *     destructively wiped.
+ *   - Position / prerequisites updates are forwarded.
+ *   - When the playbook has no curricula yet, a default one is created so
+ *     authored-only courses still get a teaching-unit container.
+ *
+ * Issue #245.
+ */
+
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+
+type Tx = PrismaClient | Prisma.TransactionClient;
+
+export interface SyncResult {
+  curriculumId: string;
+  created: number;
+  updated: number;
+  /** Modules in DB but no longer in the import — preserved, never deleted. */
+  orphaned: number;
+}
+
+export async function syncAuthoredModulesToCurriculum(
+  tx: Tx,
+  playbookId: string,
+  modules: AuthoredModule[],
+): Promise<SyncResult> {
+  // Pick or create the primary curriculum for this course. "Primary" =
+  // earliest by createdAt; explicit primary-curriculum support is a
+  // separate ticket per #245's out-of-scope list.
+  const playbook = await tx.playbook.findUnique({
+    where: { id: playbookId },
+    select: {
+      id: true,
+      name: true,
+      curricula: {
+        orderBy: { createdAt: "asc" },
+        take: 1,
+        select: { id: true },
+      },
+    },
+  });
+  if (!playbook) {
+    throw new Error(`Playbook ${playbookId} not found`);
+  }
+
+  let curriculumId = playbook.curricula[0]?.id ?? null;
+  if (!curriculumId) {
+    const created = await tx.curriculum.create({
+      data: {
+        name: `${playbook.name} — Modules`,
+        slug: `playbook-${playbookId.slice(0, 8)}-modules`,
+        playbookId,
+      },
+      select: { id: true },
+    });
+    curriculumId = created.id;
+  }
+
+  // Track existing module slugs so we can count orphans (modules in DB but
+  // not in the new import). Never delete — preserves CallerModuleProgress
+  // history.
+  const existing = await tx.curriculumModule.findMany({
+    where: { curriculumId },
+    select: { slug: true },
+  });
+  const existingSlugs = new Set(existing.map((m) => m.slug));
+  const incomingSlugs = new Set(modules.map((m) => m.id));
+  const orphaned = [...existingSlugs].filter((s) => !incomingSlugs.has(s)).length;
+
+  let created = 0;
+  let updated = 0;
+
+  for (const m of modules) {
+    const result = await tx.curriculumModule.upsert({
+      where: {
+        curriculumId_slug: { curriculumId, slug: m.id },
+      },
+      create: {
+        curriculumId,
+        slug: m.id,
+        title: m.label,
+        sortOrder: m.position ?? 0,
+        prerequisites: m.prerequisites,
+      },
+      update: {
+        // Only forward fields the author authoritatively set in the markdown.
+        // Do NOT update masteryThreshold, estimatedDurationMinutes, keyTerms —
+        // those may have been set elsewhere and aren't part of the authored
+        // shape today.
+        title: m.label,
+        sortOrder: m.position ?? 0,
+        prerequisites: m.prerequisites,
+      },
+      select: { id: true, createdAt: true, updatedAt: true },
+    });
+    // Heuristic: createdAt === updatedAt → freshly created; else updated.
+    if (result.createdAt.getTime() === result.updatedAt.getTime()) created++;
+    else updated++;
+  }
+
+  return { curriculumId, created, updated, orphaned };
+}

--- a/apps/admin/tests/api/import-modules.test.ts
+++ b/apps/admin/tests/api/import-modules.test.ts
@@ -17,15 +17,25 @@ import { NextRequest, NextResponse } from "next/server";
 // vi.mock() is hoisted above all imports and `const` declarations.
 // Use vi.hoisted() so the mock instances exist by the time vi.mock factories run.
 
-const { mockPrisma, mockRequireAuth, mockIsAuthError } = vi.hoisted(() => ({
+const { mockPrisma, mockRequireAuth, mockIsAuthError, mockSyncAuthored } = vi.hoisted(() => ({
   mockPrisma: {
     playbook: {
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    // #245: import-modules POST now wraps the playbook update + module sync
+    // in a transaction. The mock invokes the callback with a tx that proxies
+    // playbook.update so existing assertions still see the call.
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        playbook: { update: mockPrisma.playbook.update },
+      };
+      return fn(tx);
+    }),
   },
   mockRequireAuth: vi.fn(),
   mockIsAuthError: vi.fn(),
+  mockSyncAuthored: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -35,6 +45,12 @@ vi.mock("@/lib/prisma", () => ({
 vi.mock("@/lib/permissions", () => ({
   requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
   isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+}));
+
+// #245: sync helper mocked so route tests stay focused on routing/persistence.
+// The helper has its own dedicated unit test file.
+vi.mock("@/lib/wizard/sync-authored-modules-to-curriculum", () => ({
+  syncAuthoredModulesToCurriculum: (...args: unknown[]) => mockSyncAuthored(...args),
 }));
 
 // Import AFTER mocks
@@ -89,9 +105,16 @@ beforeEach(() => {
   mockIsAuthError.mockReset();
   mockPrisma.playbook.findUnique.mockReset();
   mockPrisma.playbook.update.mockReset();
+  mockSyncAuthored.mockReset();
 
   mockRequireAuth.mockResolvedValue(passingAuth);
   mockIsAuthError.mockReturnValue(false);
+  mockSyncAuthored.mockResolvedValue({
+    curriculumId: "curr-1",
+    created: 0,
+    updated: 0,
+    orphaned: 0,
+  });
 });
 
 // ── Auth ─────────────────────────────────────────────────────────
@@ -241,6 +264,50 @@ describe("POST /api/courses/[courseId]/import-modules — persistence", () => {
     expect(idError).toBeDefined();
     // Still persisted — caller decides whether to surface as blocker
     expect(body.persisted).toBe(true);
+    // No modules to sync (all rejected as invalid)
+    expect(mockSyncAuthored).not.toHaveBeenCalled();
+  });
+
+  // ── #245 sync ─────────────────────────────────────────────────────
+
+  it("calls syncAuthoredModulesToCurriculum when modules are persisted", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({ id: "playbook-1", config: {} });
+    mockPrisma.playbook.update.mockResolvedValue({});
+    mockSyncAuthored.mockResolvedValue({
+      curriculumId: "curr-1",
+      created: 2,
+      updated: 0,
+      orphaned: 0,
+    });
+
+    const res = await POST(makeReq({ markdown: SMALL_AUTHORED_DOC }), { params });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+
+    expect(mockSyncAuthored).toHaveBeenCalledOnce();
+    const call = mockSyncAuthored.mock.calls[0];
+    expect(call[1]).toBe("playbook-1");
+    expect(call[2]).toHaveLength(2);
+    expect(body.curriculumSync).toEqual({
+      curriculumId: "curr-1",
+      created: 2,
+      updated: 0,
+      orphaned: 0,
+    });
+  });
+
+  it("skips sync when markdown opts out of authored modules (modulesAuthored=false)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({ id: "playbook-1", config: {} });
+    mockPrisma.playbook.update.mockResolvedValue({});
+
+    const NO_DOC = `## Modules\n\n**Modules authored:** No\n`;
+    const res = await POST(makeReq({ markdown: NO_DOC }), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.modulesAuthored).toBe(false);
+    expect(body.persisted).toBe(true);
+    // Decision is recorded, but no modules to sync
+    expect(mockSyncAuthored).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #245 — the gap tech-lead caught during #242 Slice 3 recon.

The pipeline's `updateModuleMastery` resolves `moduleId` via `CurriculumModule.slug` lookup. Authored modules (`PlaybookConfig.modules[].id`) had no matching `CurriculumModule` rows, so progress writes silently no-op'd. The #242 picker UI is correct; this PR makes the data path real.

## Changes

- New `syncAuthoredModulesToCurriculum(tx, playbookId, modules)` helper. Upserts a `CurriculumModule` per authored module, keyed by `(curriculumId, slug)` where `slug = AuthoredModule.id`. Compound unique already exists at `schema.prisma:2238`, so **no migration needed**.
- Picks earliest-created `Curriculum` as primary; creates a default one named `"<Playbook> — Modules"` if none exists. Multi-curriculum routing remains out-of-scope per the issue.
- POST `/api/courses/[courseId]/import-modules` now wraps the config update + module sync in a transaction.
- Response gains optional `curriculumSync: { curriculumId, created, updated, orphaned }`.

## Idempotency / preservation

- Re-importing the same markdown is a no-op (upsert; no duplicates).
- Renaming a label updates `title` only — `masteryThreshold`, `estimatedDurationMinutes`, `keyTerms` are NOT clobbered.
- Removing a module from the markdown leaves the row in place. Orphan count returned; **never deleted** so `CallerModuleProgress` history is preserved.

## Test plan

- [x] 7 unit tests on the helper cover all the contract guarantees above.
- [x] 41/41 tests pass across `lib/sync`, `ui/learner-*`, `ui/authored-modules-panel`.
- [ ] `/vm-pull` + manual: re-import the IELTS Course Reference, confirm `CurriculumModule` rows exist with slugs `baseline`, `part1`, `part2`, `part3`, `mock`. Then run a real test call → confirm `CallerModuleProgress` is written.

## Deploy

`/vm-cp` — no migration. (The compound unique was already in the schema.)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)