### PR TITLE
feat: real picker→pipeline wiring for SIM (#242 Slice 2, SIM-only)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/calls/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/calls/route.ts
@@ -88,7 +88,7 @@ export async function POST(
 
     const { callerId } = await params;
     const body = await request.json();
-    const { source = "ai-simulation", callSequence, transcript = "", usedPromptId, playbookId } = body;
+    const { source = "ai-simulation", callSequence, transcript = "", usedPromptId, playbookId, requestedModuleId } = body;
 
     // Verify caller exists
     const caller = await prisma.caller.findUnique({
@@ -146,6 +146,11 @@ export async function POST(
         externalId: source === "playground-upload" ? `upload-${Date.now()}` : `ai-sim-${Date.now()}`,
         playbookId: resolvedPlaybookId,
         ...(usedPromptId ? { usedPromptId } : {}),
+        // #242 Slice 2: learner's pre-call module pick from the picker.
+        // Read by the pipeline's loadCurrentModuleContext to override the
+        // scheduler-selected module so mastery is emitted against the
+        // learner's choice.
+        ...(requestedModuleId ? { requestedModuleId } : {}),
       },
     });
 

--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -63,7 +63,23 @@ import type { SpecConfig } from "@/lib/types/json-fields";
  */
 async function loadCurrentModuleContext(
   callerId: string,
-  log: PipelineLogger
+  log: PipelineLogger,
+  opts?: {
+    /**
+     * #242 Slice 2: explicit module pick from the picker, persisted on
+     * Call.requestedModuleId. When provided AND found in
+     * Playbook.config.modules, we build a moduleContext from it directly
+     * rather than running the scheduler — guarantees mastery is emitted
+     * against the learner's choice.
+     */
+    requestedModuleId?: string | null;
+    /**
+     * Fallback playbookId from the call record itself, used when the caller
+     * has no CallerPlaybook enrollment (common for SIM testers). Must NOT
+     * shadow a real enrollment.
+     */
+    callPlaybookId?: string | null;
+  }
 ): Promise<{
   specSlug: string;
   moduleId: string;
@@ -72,11 +88,64 @@ async function loadCurrentModuleContext(
   masteryThreshold: number;
   allModuleIds: string[];
 } | null> {
-  // Resolve the caller's actual enrolment (CallerPlaybook) instead of picking
-  // a random playbook in the domain. Prior findFirst-by-domain was silently
-  // binding to the wrong course in any multi-course domain.
-  const resolvedPlaybookId = await resolvePlaybookId(callerId);
+  // Resolve the caller's actual enrolment (CallerPlaybook) first.
+  // Fall back to the call's own playbookId for SIM testers without
+  // an explicit CallerPlaybook row.
+  let resolvedPlaybookId = await resolvePlaybookId(callerId);
+  if (!resolvedPlaybookId && opts?.callPlaybookId) {
+    log.info("No enrollment; using call.playbookId as fallback", {
+      callPlaybookId: opts.callPlaybookId,
+    });
+    resolvedPlaybookId = opts.callPlaybookId;
+  }
   if (!resolvedPlaybookId) return null;
+
+  // ── #242 Slice 2: requestedModuleId override ──
+  // When the learner picked a module via the picker, build the moduleContext
+  // directly from Playbook.config.modules (the authored shape). The override
+  // bypasses the scheduler so mastery fires against the learner's choice
+  // even if scheduler logic would have selected a different module.
+  if (opts?.requestedModuleId) {
+    const pb = await prisma.playbook.findUnique({
+      where: { id: resolvedPlaybookId },
+      select: {
+        name: true,
+        config: true,
+        curricula: {
+          orderBy: { createdAt: "asc" },
+          take: 1,
+          select: { slug: true },
+        },
+      },
+    });
+    const cfg = (pb?.config ?? {}) as Record<string, any>;
+    const authored = Array.isArray(cfg.modules) ? cfg.modules : [];
+    const match = authored.find((m: any) => m?.id === opts.requestedModuleId);
+    if (match) {
+      const specSlug =
+        pb?.curricula[0]?.slug ??
+        `playbook-${resolvedPlaybookId.slice(0, 8)}-modules`;
+      log.info("Module context override from picker", {
+        requestedModuleId: opts.requestedModuleId,
+        specSlug,
+        loCount: (match.outcomesPrimary || []).length,
+      });
+      return {
+        specSlug,
+        moduleId: match.id,
+        moduleName: match.label || match.id,
+        learningOutcomes: Array.isArray(match.outcomesPrimary)
+          ? match.outcomesPrimary
+          : [],
+        masteryThreshold: 0.7,
+        allModuleIds: authored.map((m: any) => m?.id).filter(Boolean),
+      };
+    }
+    log.warn("requestedModuleId not found in Playbook.config.modules — falling back to scheduler", {
+      requestedModuleId: opts.requestedModuleId,
+      playbookId: resolvedPlaybookId,
+    });
+  }
 
   // Path 1: CONTENT spec via the caller's enrolled playbook
   const playbook = await prisma.playbook.findUnique({
@@ -263,7 +332,12 @@ Return compact JSON:
  * Run batched caller analysis (MEASURE + LEARN)
  */
 async function runBatchedCallerAnalysis(
-  call: { id: string; transcript: string | null },
+  call: {
+    id: string;
+    transcript: string | null;
+    playbookId?: string | null;
+    requestedModuleId?: string | null;
+  },
   callerId: string,
   engine: AIEngine,
   log: PipelineLogger,
@@ -405,7 +479,10 @@ async function runBatchedCallerAnalysis(
   if (assessmentSpec) {
     const assessConfig = assessmentSpec.config as Record<string, any>;
     try {
-      moduleContext = await loadCurrentModuleContext(callerId, log);
+      moduleContext = await loadCurrentModuleContext(callerId, log, {
+        requestedModuleId: call.requestedModuleId ?? null,
+        callPlaybookId: call.playbookId ?? null,
+      });
       if (moduleContext) {
         // Use mastery threshold from spec config (overrides default)
         moduleContext.masteryThreshold = assessConfig.masteryThreshold ?? moduleContext.masteryThreshold;
@@ -1940,7 +2017,7 @@ async function updateTpMasteryAfterCall(
 interface PipelineContext {
   callId: string;
   callerId: string;
-  call: { id: string; transcript: string | null; playbookId: string | null };
+  call: { id: string; transcript: string | null; playbookId: string | null; requestedModuleId: string | null };
   engine: AIEngine;
   guardrails: GuardrailsConfig;
   pipelineStages: PipelineStage[];
@@ -2498,7 +2575,7 @@ export async function POST(
     // Load call
     const call = await prisma.call.findUnique({
       where: { id: callId },
-      select: { id: true, transcript: true, playbookId: true },
+      select: { id: true, transcript: true, playbookId: true, requestedModuleId: true },
     });
 
     if (!call) {

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -162,7 +162,7 @@ export default function SimConversationPage() {
   return (
     <>
       {requestedModuleId && (
-        <ModulePickerPlaceholderBanner moduleId={requestedModuleId} />
+        <ModulePickerSelectionBanner moduleId={requestedModuleId} />
       )}
       <SimChat
         callerId={callerId}
@@ -179,6 +179,7 @@ export default function SimConversationPage() {
         onBack={isDesktop ? undefined : () => router.push('/x/sim')}
         onCallEnd={isStudent ? handleStudentCallEnd : undefined}
         onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
+        requestedModuleId={requestedModuleId}
         journey={journey}
       />
     </>
@@ -186,12 +187,12 @@ export default function SimConversationPage() {
 }
 
 /**
- * Placeholder banner — Slice 2 of #242. Renders when the SIM is hit with
- * `?requestedModuleId=<id>` (from the picker → SIM round-trip). The real
- * VAPI dial wiring happens once the call-init path is identified by recon
- * (see TODO in launchSelected at /x/student/[courseId]/modules/page.tsx).
+ * Selection banner — confirms which module the learner picked. The id is
+ * forwarded to POST /api/callers/[id]/calls and persisted as
+ * Call.requestedModuleId so the pipeline overrides the scheduler-selected
+ * module when computing mastery (#242 Slice 2).
  */
-function ModulePickerPlaceholderBanner({ moduleId }: { moduleId: string }) {
+function ModulePickerSelectionBanner({ moduleId }: { moduleId: string }) {
   return (
     <div
       role="status"
@@ -207,9 +208,9 @@ function ModulePickerPlaceholderBanner({ moduleId }: { moduleId: string }) {
         gap: 8,
       }}
     >
-      <strong>Placeholder:</strong>
+      <strong>Module selected:</strong>
       <span>
-        VAPI call would now start with module{' '}
+        Next session will focus on{' '}
         <code
           style={{
             padding: '2px 6px',
@@ -220,7 +221,7 @@ function ModulePickerPlaceholderBanner({ moduleId }: { moduleId: string }) {
         >
           {moduleId}
         </code>
-        {' '}— wiring pending recon (#242 Slice 2).
+        . Mastery will be tracked against this module after the call.
       </span>
     </div>
   );

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -51,6 +51,12 @@ export interface SimChatProps {
   onBack?: () => void;
   /** When set, renders a "Pick module" header button (Issue #242 SIM-first mount) */
   onPickModule?: () => void;
+  /**
+   * #242 Slice 2: learner's pre-call module pick from the picker. When set,
+   * forwarded to POST /api/callers/[id]/calls so the pipeline's module
+   * context loader overrides the scheduler-selected module.
+   */
+  requestedModuleId?: string;
   /** Journey chat integration — items rendered before call history */
   journey?: UseJourneyChatResult;
 }
@@ -123,6 +129,7 @@ export function SimChat({
   onNewCall,
   onBack,
   onPickModule,
+  requestedModuleId,
   journey,
 }: SimChatProps) {
   const router = useRouter();
@@ -388,7 +395,12 @@ export function SimChat({
       const callRes = await fetch(`/api/callers/${callerId}/calls`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ source: 'sim', usedPromptId, ...(playbookId ? { playbookId } : {}) }),
+        body: JSON.stringify({
+          source: 'sim',
+          usedPromptId,
+          ...(playbookId ? { playbookId } : {}),
+          ...(requestedModuleId ? { requestedModuleId } : {}),
+        }),
       });
       const callData = await callRes.json();
       if (callData.ok) {

--- a/apps/admin/prisma/migrations/20260506_add_call_requested_module_id/migration.sql
+++ b/apps/admin/prisma/migrations/20260506_add_call_requested_module_id/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: Call gains requestedModuleId so the picker's pre-call pick
+-- can override the scheduler-selected module when computing mastery.
+-- See #242 Slice 2.
+
+ALTER TABLE "Call" ADD COLUMN "requestedModuleId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Call_requestedModuleId_idx" ON "Call"("requestedModuleId");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -1295,6 +1295,14 @@ model Call {
   curriculumModuleId String?
   curriculumModule   CurriculumModule? @relation(fields: [curriculumModuleId], references: [id], onDelete: SetNull)
 
+  // Learner's pre-call module pick from the picker (#242 Slice 2). Stored as a
+  // hint for the prompt composer to override the scheduler-selected module
+  // when set. Distinct from curriculumModuleId, which is set by the pipeline
+  // post-call to record what the call actually covered.
+  // Slug only — no FK because the picker may target authored modules whose
+  // sync into CurriculumModule is on a separate write path (#245).
+  requestedModuleId String?
+
   // Call sequencing for delta calculations
   // Links to the previous call for this caller (for computing ADAPT parameters)
   previousCallId String?
@@ -1344,6 +1352,7 @@ model Call {
   @@index([usedPromptId])
   @@index([playbookId])
   @@index([curriculumModuleId])
+  @@index([requestedModuleId])
 }
 
 model CallMessage {


### PR DESCRIPTION
## Summary

Replaces the Slice 2 placeholder banner with real end-to-end wiring **for SIM only** (VAPI/phone deferred per user). Closes the dead end identified in today's mastery-emission audit: previously the picker pick reached the SIM URL but never influenced what got assessed, so `CallerModuleProgress` rows were never written for authored modules and the picker could never show "Done".

The flow now works end-to-end in SIM:

```
picker → URL → SimChat → POST /api/callers/[id]/calls
      → Call.requestedModuleId          (NEW)
      → pipeline → loadCurrentModuleContext({requestedModuleId})
      → assessment → moduleMastery[<slug>]
      → CallerModuleProgress upsert
      → picker shows In progress / Done
```

## Changes

| File | Change |
|---|---|
| `prisma/schema.prisma` + migration | New `Call.requestedModuleId String?` + index |
| `app/api/callers/[id]/calls/route.ts` | Accept `requestedModuleId` in POST body, persist on Call |
| `components/sim/SimChat.tsx` | New optional prop, include in POST body |
| `app/x/sim/[callerId]/page.tsx` | Pass URL `?requestedModuleId=` through to SimChat. Banner copy honest: "Module selected: <id>. Mastery will be tracked against this module after the call." |
| `app/api/calls/[callId]/pipeline/route.ts` | `loadCurrentModuleContext` gains optional `{ requestedModuleId, callPlaybookId }`. Override path reads `Playbook.config.modules` directly so the learner's pick wins over scheduler. Enrollment fallback to `call.playbookId` for SIM testers without `CallerPlaybook` rows |

The override path **bypasses the scheduler** when `requestedModuleId` is set and found in `Playbook.config.modules`. The AuthoredModule's `outcomesPrimary` becomes the assessment's learning outcomes; `label` becomes module name; sibling ids become `allModuleIds`. Mastery threshold defaults to 0.7 (same as elsewhere).

## Out of scope

- VAPI / phone-call mastery emission — separate flow, deferred
- Journey-position routing for real learners (Slice 4)
- Tutor system prompt module-override consumer beyond `loadCurrentModuleContext`

## Test plan

- [x] 3503/3503 unit tests pass after `pnpm prisma generate`. 241/241 test files green.
- [ ] `/vm-cpp` deploy (migration required), then on VM:
  1. Re-import IELTS Course Reference → confirm CurriculumModule rows for baseline/part1/part2/part3/mock (already wired by #245)
  2. Open SIM as a learner enrolled in IELTS → click "Pick module" → choose `baseline`
  3. After redirect, banner reads "Module selected: baseline. Mastery will be tracked..."
  4. Run a SIM session, end the call
  5. After pipeline completes, verify `CallerModuleProgress` row exists with `moduleId=<baseline>` and a non-zero mastery
  6. Return to picker → `baseline` appears in "In progress" or "Completed" section

## Deploy

`/vm-cpp` — schema migration required (adds `Call.requestedModuleId` column + index).

Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)