### PR TITLE
feat: real-learner journey-position routes to picker (#242 Slice 4)

### DIFF
--- a/apps/admin/app/api/student/journey-position/route.ts
+++ b/apps/admin/app/api/student/journey-position/route.ts
@@ -202,11 +202,23 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }
 
       // State 4: COMPLETE or LEARNING
+      // #242 Slice 4: when the course has author-declared modules, route the
+      // learner to the picker before each session instead of straight to /x/sim.
+      // returnTo includes the caller's specific conversation so the learner
+      // lands back in their SIM session with ?requestedModuleId=… preserved.
+      const learningRedirect = pbConfig.modulesAuthored === true
+        ? {
+            type: "module_picker",
+            session: 1,
+            redirect: `/x/student/${enrollment.playbook.id}/modules?returnTo=${encodeURIComponent(`/x/sim/${callerId}`)}`,
+          }
+        : { type: "continuous", session: 1, redirect: "/x/sim" };
+
       return NextResponse.json({
         ok: true,
         nextStop: pct >= 100
           ? { type: "complete", session: 1, redirect: "/x/student/progress" }
-          : { type: "continuous", session: 1, redirect: "/x/sim" },
+          : learningRedirect,
         journey: journeyData,
       });
     }
@@ -270,10 +282,21 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
 
     // ── Default: onboarding gate then teaching ──
+    // #242 Slice 4: structured-mode courses with author-declared modules also
+    // route through the picker before each session. Onboarding still gates
+    // upstream — learners only reach the picker once onboarding is done.
+    const teachingRedirect = pbConfig.modulesAuthored === true
+      ? {
+          type: "module_picker" as const,
+          session: 1,
+          redirect: `/x/student/${enrollment.playbook.id}/modules?returnTo=${encodeURIComponent(`/x/sim/${callerId}`)}`,
+        }
+      : { type: "teaching" as const, session: 1, redirect: "/x/sim" };
+
     return NextResponse.json({
       ok: true,
       nextStop: onboardingComplete
-        ? { type: "teaching", session: 1, redirect: "/x/sim" }
+        ? teachingRedirect
         : { type: "onboarding", session: 1, redirect: "/x/sim" },
       journey: { totalStops: 0, completedStops: onboardingComplete ? 1 : 0, currentPosition: 0 },
     });

--- a/apps/admin/hooks/useJourneyChat.ts
+++ b/apps/admin/hooks/useJourneyChat.ts
@@ -9,6 +9,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import type { SurveyStep } from '@/components/student/ChatSurvey';
 import type { SurveyStepConfig } from '@/lib/types/json-fields';
 import { SURVEY_SCOPES, POST_SURVEY_KEYS } from '@/lib/learner/survey-keys';
@@ -137,6 +138,12 @@ function buildPostSteps(configs: SurveyStepConfig[]): SurveyStep[] {
 // ---------------------------------------------------------------------------
 
 export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJourneyChatOptions): UseJourneyChatResult {
+  // #242 Slice 4: navigate to the picker when journey-position returns
+  // module_picker. Skipped when ?requestedModuleId=… is already in the URL
+  // (treated as "already picked, proceed to teaching") so we don't loop.
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [items, setItems] = useState<ChatItem[]>([]);
   const [state, setState] = useState<JourneyState>('loading');
   const [activeSurveyStep, setActiveSurveyStep] = useState<SurveyStep | null>(null);
@@ -479,7 +486,20 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
 
       const stopType = data.nextStop.type;
 
-      if (stopType === 'post_survey') {
+      if (stopType === 'module_picker') {
+        // #242 Slice 4: route real learners to the picker before each session.
+        // Skip when the URL already has requestedModuleId — that means the
+        // learner has just picked, came back via returnTo, and is ready to
+        // teach. Without this guard the picker → SIM round-trip loops.
+        const alreadyPicked = !!searchParams?.get('requestedModuleId');
+        if (alreadyPicked) {
+          setState('teaching');
+        } else if (data.nextStop.redirect) {
+          router.push(data.nextStop.redirect);
+        } else {
+          setState('teaching');
+        }
+      } else if (stopType === 'post_survey') {
         await loadPostSurvey();
       } else if (stopType === 'onboarding') {
         // Fetch WelcomeConfig to decide which pre-course phases to show

--- a/apps/admin/tests/api/journey-position-module-picker.test.ts
+++ b/apps/admin/tests/api/journey-position-module-picker.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for /api/student/journey-position — picker routing (#242 Slice 4).
+ *
+ * Mocks prisma so the route can be exercised without a real database.
+ * Two scenarios:
+ *   1. Course with `modulesAuthored: true` → nextStop.type === "module_picker"
+ *      and redirect points at /x/student/{playbookId}/modules with a returnTo
+ *      that includes the caller's specific SIM URL.
+ *   2. Course without modulesAuthored → legacy behaviour preserved
+ *      (type === "continuous" or "teaching", redirect === "/x/sim").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockPrisma, mockRequireStudentOrAdmin } = vi.hoisted(() => ({
+  mockPrisma: {
+    callerPlaybook: { findFirst: vi.fn() },
+    onboardingSession: { findFirst: vi.fn() },
+    callerAttribute: { findMany: vi.fn() },
+    call: { count: vi.fn() },
+  },
+  mockRequireStudentOrAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/student-access", () => ({
+  requireStudentOrAdmin: (...args: unknown[]) => mockRequireStudentOrAdmin(...args),
+  isStudentAuthError: (result: unknown): boolean =>
+    result != null && typeof result === "object" && "error" in (result as object),
+}));
+
+// getTpProgressSummary is called dynamically via import() inside the route.
+// Mock the module so the dynamic import returns our stub.
+vi.mock("@/lib/curriculum/track-progress", () => ({
+  getTpProgressSummary: vi.fn().mockResolvedValue({
+    totalTps: 4,
+    mastered: 1,
+    inProgress: 1,
+    notStarted: 2,
+  }),
+}));
+
+// Session-flow resolver: stub to return no fired stops so the test exercises
+// the LEARNING / TEACHING path. The picker intercept lives there.
+vi.mock("@/lib/session-flow/resolver", () => ({
+  resolveSessionFlow: vi.fn().mockReturnValue({ stops: [] }),
+}));
+vi.mock("@/lib/session-flow/journey-stop-runner", () => ({
+  evaluateStops: vi.fn().mockReturnValue({ fire: false }),
+}));
+
+// Feature-flag config — leave default (resolver-enabled) on; the stubs above
+// neutralise its effect so we test the LEARNING fallthrough.
+vi.mock("@/lib/config", () => ({
+  config: { features: { sessionFlowResolverEnabled: true } },
+}));
+
+// Import after mocks
+import { GET } from "@/app/api/student/journey-position/route";
+
+const CALLER_ID = "caller-1";
+const PLAYBOOK_ID = "playbook-1";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost:3000/api/student/journey-position");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireStudentOrAdmin.mockResolvedValue({
+    callerId: CALLER_ID,
+    cohortGroupId: "cg-1",
+    cohortGroupIds: ["cg-1"],
+    institutionId: null,
+    session: { user: { id: "u1", role: "STUDENT" } },
+  });
+  mockPrisma.callerAttribute.findMany.mockResolvedValue([]);
+  mockPrisma.call.count.mockResolvedValue(2); // > 0 → past onboarding
+  mockPrisma.onboardingSession.findFirst.mockResolvedValue({
+    isComplete: true,
+    wasSkipped: false,
+  });
+});
+
+describe("journey-position — #242 Slice 4 picker routing", () => {
+  it("continuous + modulesAuthored=true → routes to picker with caller-specific returnTo", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: {
+        id: PLAYBOOK_ID,
+        config: {
+          lessonPlanMode: "continuous",
+          modulesAuthored: true,
+        },
+        curricula: [
+          { id: "curr-1", slug: "ielts-v22", deliveryConfig: { mode: "continuous" } },
+        ],
+      },
+    });
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.nextStop.type).toBe("module_picker");
+    expect(body.nextStop.redirect).toBe(
+      `/x/student/${PLAYBOOK_ID}/modules?returnTo=${encodeURIComponent(`/x/sim/${CALLER_ID}`)}`,
+    );
+  });
+
+  it("continuous + no modulesAuthored → legacy continuous redirect preserved", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: {
+        id: PLAYBOOK_ID,
+        config: { lessonPlanMode: "continuous" },
+        curricula: [
+          { id: "curr-1", slug: "legacy-v1", deliveryConfig: { mode: "continuous" } },
+        ],
+      },
+    });
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(body.nextStop.type).toBe("continuous");
+    expect(body.nextStop.redirect).toBe("/x/sim");
+  });
+
+  it("continuous + modulesAuthored=false → legacy continuous redirect preserved", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: {
+        id: PLAYBOOK_ID,
+        config: { lessonPlanMode: "continuous", modulesAuthored: false },
+        curricula: [
+          { id: "curr-1", slug: "opted-out-v1", deliveryConfig: { mode: "continuous" } },
+        ],
+      },
+    });
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(body.nextStop.type).toBe("continuous");
+    expect(body.nextStop.redirect).toBe("/x/sim");
+  });
+
+  it("structured + modulesAuthored=true + onboarding done → routes to picker", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: {
+        id: PLAYBOOK_ID,
+        config: {
+          // No lessonPlanMode → structured/default branch
+          modulesAuthored: true,
+        },
+        curricula: [
+          { id: "curr-1", slug: "structured-v1", deliveryConfig: null },
+        ],
+      },
+    });
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(body.nextStop.type).toBe("module_picker");
+    expect(body.nextStop.redirect).toBe(
+      `/x/student/${PLAYBOOK_ID}/modules?returnTo=${encodeURIComponent(`/x/sim/${CALLER_ID}`)}`,
+    );
+  });
+
+  it("structured + modulesAuthored=true + onboarding NOT done → onboarding still gates picker", async () => {
+    mockPrisma.onboardingSession.findFirst.mockResolvedValue({
+      isComplete: false,
+      wasSkipped: false,
+    });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: {
+        id: PLAYBOOK_ID,
+        config: { modulesAuthored: true },
+        curricula: [
+          { id: "curr-1", slug: "structured-v1", deliveryConfig: null },
+        ],
+      },
+    });
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    // Picker is downstream of onboarding — onboarding fires first
+    expect(body.nextStop.type).toBe("onboarding");
+    expect(body.nextStop.redirect).toBe("/x/sim");
+  });
+
+  it("continuous + mastery 100% + modulesAuthored=true → COMPLETE wins over picker", async () => {
+    const trackProgress = await import("@/lib/curriculum/track-progress");
+    vi.mocked(trackProgress.getTpProgressSummary).mockResolvedValueOnce({
+      totalTps: 4,
+      mastered: 4,
+      inProgress: 0,
+      notStarted: 0,
+    });
+
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: {
+        id: PLAYBOOK_ID,
+        config: { lessonPlanMode: "continuous", modulesAuthored: true },
+        curricula: [
+          { id: "curr-1", slug: "ielts-v22", deliveryConfig: { mode: "continuous" } },
+        ],
+      },
+    });
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(body.nextStop.type).toBe("complete");
+    expect(body.nextStop.redirect).toBe("/x/student/progress");
+  });
+
+  it("no enrollment → returns complete (unchanged)", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.nextStop.type).toBe("complete");
+    expect(body.nextStop.redirect).toBe("/x/student/progress");
+  });
+});


### PR DESCRIPTION
## Summary

Final in-scope slice of #242. Real learners (STUDENT role) now get auto-routed to the module picker before each session when their course has author-declared modules. The legacy `/x/sim` redirect is preserved for any course where `modulesAuthored !== true`.

Combined with #245 (CurriculumModule sync) and #250 (picker→pipeline wiring), this completes the SIM-only end-to-end loop for real learners:

```
educator imports modules → learner auto-routed to picker → picks →
session → pipeline emits mastery → picker adapts on next visit
```

## Changes

| Area | Change |
|---|---|
| **Route** `/api/student/journey-position` | Both LEARNING (continuous) and TEACHING (structured) branches check `playbook.config.modulesAuthored === true`. When true, emit `nextStop.type === "module_picker"` + redirect to `/x/student/[playbookId]/modules?returnTo=/x/sim/[callerId]`. Upstream gates (onboarding, surveys, mastery 100%) still fire first. |
| **`useJourneyChat`** | New `module_picker` case: navigates to `nextStop.redirect` via `router.push`. Loop guard skips redirect when the URL already has `?requestedModuleId=…` (treats as "already picked, proceed to teaching"). |
| **Tests** | 7 new unit tests cover: picker fires for continuous+authored, structured+authored; legacy preserved without flag or with flag=false; onboarding gates picker upstream; mastery 100% beats picker (COMPLETE wins); no-enrollment unchanged. |

## Test plan

- [x] 242/242 vitest test files pass (3510 unit tests). 7 new picker-routing tests.
- [ ] `/vm-cp` deploy. Then on VM as a STUDENT user enrolled in IELTS:
  1. Login → land on `/x/student` → entry router redirects to picker page (not `/x/sim`)
  2. Pick `baseline` → return to `/x/sim/<callerId>?requestedModuleId=baseline`
  3. Banner reads "Module selected: baseline"
  4. Have a session, end the call
  5. After pipeline runs, return to picker via `/x/student` → reflects progress
  6. As a STUDENT enrolled in a course WITHOUT authored modules → goes straight to `/x/sim`, no picker

## Known follow-ups (out of scope for this slice)

- VAPI/phone learners — separate flow, deferred per user
- Tutor system prompt explicit module-override consumer beyond what `loadCurrentModuleContext` provides
- Recommended-next as a real algorithm (currently prereq-only)

## Deploy

`/vm-cp` — no schema migration.

Closes the in-scope work for #242. The wider follow-ups (VAPI, prompt module-override) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)