### PR TITLE
fix: SIM hooks-order + test-learner popup-blocker

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseLearnersTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseLearnersTab.tsx
@@ -185,6 +185,12 @@ export function CourseLearnersTab({ courseId, initialJoinToken, studentProgress 
 
   const handleCreateTestLearner = useCallback(async () => {
     if (creatingTestLearner) return;
+    // Open the tab SYNCHRONOUSLY in the click handler so popup blockers accept
+    // it as user-initiated — `await fetch` later breaks that gesture context.
+    // `noopener` is dropped because Chromium returns null from window.open when
+    // it's set, and we need the handle to redirect once the fetch resolves.
+    // Admin-only tooling — opener access is acceptable here.
+    const newTab = window.open('about:blank', '_blank');
     setCreatingTestLearner(true);
     setTestLearnerError(null);
     try {
@@ -193,13 +199,20 @@ export function CourseLearnersTab({ courseId, initialJoinToken, studentProgress 
       });
       const data = await res.json();
       if (data.ok) {
-        // Open in a new tab so the educator can keep the course config tab
-        // open and watch the sim run side-by-side.
-        window.open(`/x/callers/${data.callerId}?section=ai-call`, '_blank', 'noopener');
+        const url = `/x/callers/${data.callerId}?section=ai-call`;
+        if (newTab && !newTab.closed) {
+          newTab.location.href = url;
+        } else {
+          // Popup blocker swallowed the open() despite the gesture context, or
+          // the user closed it. Fall back to in-place navigation.
+          window.location.href = url;
+        }
       } else {
+        if (newTab && !newTab.closed) newTab.close();
         setTestLearnerError(data.error || 'Failed to create test learner');
       }
     } catch {
+      if (newTab && !newTab.closed) newTab.close();
       setTestLearnerError('Network error');
     } finally {
       setCreatingTestLearner(false);

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -126,6 +126,18 @@ export default function SimConversationPage() {
     // Journey onCallEnd is now called directly inside SimChat
   }, [router, isStudent]);
 
+  // #242 Slice 2: must live ABOVE the early returns or React's hook order
+  // changes between renders (Rules of Hooks violation).
+  const handlePickModule = useCallback(() => {
+    if (!playbookId) return;
+    const sp = new URLSearchParams();
+    // Strip requestedModuleId so the banner doesn't keep firing on re-pick.
+    const carryParams = new URLSearchParams(searchParams.toString());
+    carryParams.delete('requestedModuleId');
+    sp.set('returnTo', `/x/sim/${callerId}${carryParams.toString() ? `?${carryParams.toString()}` : ''}`);
+    router.push(`/x/student/${playbookId}/modules?${sp.toString()}`);
+  }, [callerId, playbookId, router, searchParams]);
+
   if (error) {
     return (
       <>
@@ -148,16 +160,6 @@ export default function SimConversationPage() {
       </>
     );
   }
-
-  const handlePickModule = useCallback(() => {
-    if (!playbookId) return;
-    const sp = new URLSearchParams();
-    // Strip requestedModuleId so the banner doesn't keep firing on re-pick.
-    const carryParams = new URLSearchParams(searchParams.toString());
-    carryParams.delete('requestedModuleId');
-    sp.set('returnTo', `/x/sim/${callerId}${carryParams.toString() ? `?${carryParams.toString()}` : ''}`);
-    router.push(`/x/student/${playbookId}/modules?${sp.toString()}`);
-  }, [callerId, playbookId, router, searchParams]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

Two SIM-page bugs that surfaced during live testing on hf-dev.

**1. Rules of Hooks violation in `/x/sim/[callerId]` (regressed in #248)**

`handlePickModule = useCallback(...)` sat BELOW the early returns (`if (error)` / `if (!caller)`), so the hook count varied between renders. React 19 / Next 16 catches this loudly. Moved the useCallback above the early returns. No behaviour change.

**2. "New test learner" button never opened a new tab (#211 regression)**

`window.open()` was called AFTER `await fetch(...)` — popup blockers reject this because the call is no longer in the user-gesture context. Plus `noopener` made `window.open` return `null` in Chromium, blocking the redirect-after-fetch approach. Now opens the tab synchronously with `about:blank` in the click handler, drops `noopener` (admin tooling), redirects the pre-opened tab once the fetch resolves. Falls back to in-place navigation if the browser still swallowed it.

## Test plan

- [x] 29/29 picker tests still green
- [ ] `/vm-cp` deploy. Then on VM:
  1. Open `/x/sim/<callerId>` — no React error in console (hooks fix)
  2. Course Learners tab → click "New test learner" — new tab opens, redirects after the fetch resolves

## Deploy

`/vm-cp` — no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)