### PR TITLE
fix: hide regen view in Curriculum tab when authored modules are in use

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
@@ -63,6 +63,11 @@ export function CourseCurriculumTab({
   const [regenerating, setRegenerating] = useState(false);
   const [regenResult, setRegenResult] = useState<RegenerateResponse | null>(null);
 
+  // #253-follow-up: when authored modules are the source of truth, the
+  // derived/regen catalogue is noise — hide it. AuthoredModulesPanel signals
+  // its loaded state so we know which view to render.
+  const [modulesAuthored, setModulesAuthored] = useState<boolean | null>(null);
+
   // Authoritative curriculum id comes from the scorecard response. Until that
   // loads, fall back to the hint passed in by the course page.
   const curriculumId = scorecard?.curriculumId ?? curriculumIdProp ?? null;
@@ -197,6 +202,7 @@ export function CourseCurriculumTab({
       <AuthoredModulesPanel
         courseId={playbookId ?? courseId}
         isOperator={isOperator}
+        onModulesAuthoredChange={setModulesAuthored}
       />
 
       {hasZeroModules && (
@@ -220,7 +226,8 @@ export function CourseCurriculumTab({
         </div>
       )}
 
-      {scorecard && (
+      {/* Derived/regen view — hidden when authored modules are the source */}
+      {scorecard && modulesAuthored !== true && (
         <CurriculumHealthTabs
           scorecard={scorecard}
           courseId={courseId}

--- a/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
@@ -45,6 +45,14 @@ interface AuthoredModulesState {
 interface AuthoredModulesPanelProps {
   courseId: string;
   isOperator: boolean;
+  /**
+   * Fires whenever the panel learns the value of `modulesAuthored` from the
+   * server (after fetch / re-import). Used by the parent CurriculumTab to
+   * hide the derived/regen view when authored modules are in play. `null` =
+   * never imported, `false` = explicitly opted out, `true` = authored modules
+   * are the source of truth for this course.
+   */
+  onModulesAuthoredChange?: (value: boolean | null) => void;
 }
 
 const EMPTY_STATE: AuthoredModulesState = {
@@ -61,6 +69,7 @@ const EMPTY_STATE: AuthoredModulesState = {
 export function AuthoredModulesPanel({
   courseId,
   isOperator,
+  onModulesAuthoredChange,
 }: AuthoredModulesPanelProps) {
   const [state, setState] = useState<AuthoredModulesState>(EMPTY_STATE);
   const [loading, setLoading] = useState(true);
@@ -86,12 +95,13 @@ export function AuthoredModulesPanel({
         hasErrors: data.hasErrors,
         lessonPlanMode: data.lessonPlanMode,
       });
+      onModulesAuthoredChange?.(data.modulesAuthored);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setLoading(false);
     }
-  }, [courseId]);
+  }, [courseId, onModulesAuthoredChange]);
 
   useEffect(() => {
     load();


### PR DESCRIPTION
## Summary

When a course has author-declared modules (`modulesAuthored: true`), hide the derived `CurriculumHealthTabs` view so educators see only their own catalogue. Previously both rendered side-by-side, with the derived view's auto-generated MOD-1/MOD-2 entries and LLM-extracted meta-LOs contradicting the authored outcomes.

## Changes

- `AuthoredModulesPanel`: new optional `onModulesAuthoredChange` callback fires after the `import-modules` fetch resolves.
- `CourseCurriculumTab`: tracks `modulesAuthored` from the panel; hides `CurriculumHealthTabs` when it's `true`. `null` (never imported) and `false` (opted out) preserve the existing dual view.

## Test plan

- [x] 5/5 AuthoredModulesPanel tests still green
- [ ] `/vm-cp` deploy. Then on the IELTS Speaking course (modulesAuthored=true): only the Authored Modules panel should render. On a legacy course without authored modules: the regen view still appears as before.

## Deploy

`/vm-cp` — no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)