### PR TITLE
feat: expandable Authored Modules rows with full per-module detail

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
@@ -20,6 +20,14 @@ import {
   CheckCircle2,
   Upload,
   Eye,
+  ChevronDown,
+  ChevronRight,
+  GraduationCap,
+  Pencil,
+  Mic,
+  AlertOctagon,
+  Target,
+  Link as LinkIcon,
 } from "lucide-react";
 import type {
   AuthoredModule,
@@ -224,14 +232,19 @@ function EmptyState({
   );
 }
 
-// ── Catalogue table ────────────────────────────────────────────────
+// ── Catalogue table (expandable rows) ──────────────────────────────
 
 function CatalogueTable({ modules }: { modules: AuthoredModule[] }) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const toggle = (id: string) =>
+    setExpandedId((prev) => (prev === id ? null : id));
+
   return (
     <div className="authored-modules-table-wrap">
       <table className="authored-modules-table">
         <thead>
           <tr>
+            <th aria-label="Expand" />
             <th>ID</th>
             <th>Label</th>
             <th>Mode</th>
@@ -242,25 +255,200 @@ function CatalogueTable({ modules }: { modules: AuthoredModule[] }) {
           </tr>
         </thead>
         <tbody>
-          {modules.map((m) => (
-            <tr key={m.id}>
-              <td>
-                <code>{m.id}</code>
-              </td>
-              <td>{m.label}</td>
-              <td>{m.mode}</td>
-              <td>{m.duration}</td>
-              <td>{m.frequency}</td>
-              <td className="authored-modules-table__center">
-                {m.sessionTerminal ? "●" : "—"}
-              </td>
-              <td className="authored-modules-table__center">
-                {m.learnerSelectable ? "●" : "—"}
-              </td>
-            </tr>
-          ))}
+          {modules.map((m) => {
+            const isExpanded = expandedId === m.id;
+            return (
+              <CatalogueRow
+                key={m.id}
+                module={m}
+                isExpanded={isExpanded}
+                onToggle={() => toggle(m.id)}
+              />
+            );
+          })}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+function CatalogueRow({
+  module: m,
+  isExpanded,
+  onToggle,
+}: {
+  module: AuthoredModule;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <>
+      <tr
+        className="authored-modules-table__row authored-modules-table__row--clickable"
+        onClick={onToggle}
+        aria-expanded={isExpanded}
+      >
+        <td className="authored-modules-table__center">
+          {isExpanded ? (
+            <ChevronDown size={14} className="hf-text-muted" aria-hidden="true" />
+          ) : (
+            <ChevronRight size={14} className="hf-text-muted" aria-hidden="true" />
+          )}
+        </td>
+        <td>
+          <code>{m.id}</code>
+        </td>
+        <td>{m.label}</td>
+        <td>
+          <ModePill mode={m.mode} />
+        </td>
+        <td>{m.duration}</td>
+        <td>
+          <FrequencyPill frequency={m.frequency} />
+        </td>
+        <td className="authored-modules-table__center">
+          {m.sessionTerminal ? (
+            <span className="hf-badge hf-badge-xs hf-badge-warning">Ends session</span>
+          ) : (
+            <span className="hf-text-muted">—</span>
+          )}
+        </td>
+        <td className="authored-modules-table__center">
+          {m.learnerSelectable ? (
+            <span className="hf-badge hf-badge-xs hf-badge-success">Visible</span>
+          ) : (
+            <span className="hf-badge hf-badge-xs hf-badge-muted">Hidden</span>
+          )}
+        </td>
+      </tr>
+      {isExpanded && (
+        <tr className="authored-modules-table__detail-row">
+          <td colSpan={8} className="authored-modules-table__detail-cell">
+            <ModuleDetail module={m} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function ModePill({ mode }: { mode: AuthoredModule["mode"] }) {
+  const Icon =
+    mode === "examiner" ? GraduationCap : mode === "mixed" ? Layers : Pencil;
+  const tone =
+    mode === "examiner"
+      ? "hf-badge-info"
+      : mode === "mixed"
+        ? "hf-badge-accent"
+        : "hf-badge-muted";
+  return (
+    <span className={`hf-badge hf-badge-xs ${tone}`}>
+      <Icon size={10} aria-hidden="true" />
+      {mode}
+    </span>
+  );
+}
+
+function FrequencyPill({ frequency }: { frequency: AuthoredModule["frequency"] }) {
+  const tone =
+    frequency === "once"
+      ? "hf-badge-warning"
+      : frequency === "cooldown"
+        ? "hf-badge-info"
+        : "hf-badge-muted";
+  return (
+    <span className={`hf-badge hf-badge-xs ${tone}`}>{frequency}</span>
+  );
+}
+
+function ModuleDetail({ module: m }: { module: AuthoredModule }) {
+  return (
+    <div className="authored-modules-detail">
+      {/* Top metadata strip */}
+      <div className="authored-modules-detail__strip">
+        {m.position != null && (
+          <span className="hf-badge hf-badge-sm hf-badge-muted">
+            Position {m.position}
+          </span>
+        )}
+        <span className="hf-badge hf-badge-sm hf-badge-muted">
+          <Target size={11} aria-hidden="true" /> Scoring: {m.scoringFired}
+        </span>
+        {m.voiceBandReadout && (
+          <span className="hf-badge hf-badge-sm hf-badge-info">
+            <Mic size={11} aria-hidden="true" /> Spoken bands
+          </span>
+        )}
+      </div>
+
+      <div className="authored-modules-detail__grid">
+        {/* Outcomes (primary) */}
+        <section className="authored-modules-detail__section">
+          <h4 className="authored-modules-detail__section-title">
+            Primary outcomes
+          </h4>
+          {m.outcomesPrimary.length === 0 ? (
+            <p className="hf-text-sm hf-text-muted">None declared.</p>
+          ) : (
+            <ul className="authored-modules-detail__list">
+              {m.outcomesPrimary.map((id) => (
+                <li key={id} className="authored-modules-detail__list-item">
+                  <code className="authored-modules-detail__outcome-id">{id}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Prerequisites */}
+        <section className="authored-modules-detail__section">
+          <h4 className="authored-modules-detail__section-title">
+            Prerequisites
+          </h4>
+          {m.prerequisites.length === 0 ? (
+            <p className="hf-text-sm hf-text-muted">None — open from session 1.</p>
+          ) : (
+            <div className="authored-modules-detail__chips">
+              {m.prerequisites.map((id) => (
+                <span
+                  key={id}
+                  className="hf-badge hf-badge-sm hf-badge-muted"
+                  title="Advisory only — picker shows 'Recommended after' but does not gate"
+                >
+                  {id}
+                </span>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Content source */}
+        {m.contentSourceRef && (
+          <section className="authored-modules-detail__section">
+            <h4 className="authored-modules-detail__section-title">
+              Content source
+            </h4>
+            <p className="hf-text-sm">
+              <LinkIcon size={11} aria-hidden="true" className="hf-text-muted" />{" "}
+              {m.contentSourceRef}
+            </p>
+          </section>
+        )}
+      </div>
+
+      {/* Behaviour notes — derived from flags */}
+      {(m.sessionTerminal || m.frequency === "once") && (
+        <div className="authored-modules-detail__note">
+          <AlertOctagon size={12} aria-hidden="true" className="hf-text-muted" />
+          <span className="hf-text-xs hf-text-muted">
+            {m.sessionTerminal && m.frequency === "once"
+              ? "Single-session module that ends the call when started. Disappears from the picker after completion."
+              : m.sessionTerminal
+                ? "Starting this module ends the current session — picker will show a confirm dialog."
+                : "Single-session module — disappears from the picker after completion."}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -50,6 +50,106 @@
   text-align: center;
 }
 
+/* ── Expandable rows ────────────────────────────────────── */
+
+.authored-modules-table__row--clickable {
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.authored-modules-table__row--clickable:hover {
+  background: color-mix(in srgb, var(--accent-primary) 4%, transparent);
+}
+
+.authored-modules-table__row--clickable[aria-expanded="true"] {
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+}
+
+.authored-modules-table__detail-row {
+  background: var(--surface-secondary);
+}
+
+.authored-modules-table__detail-cell {
+  padding: 0;
+}
+
+.authored-modules-detail {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border-top: 1px solid var(--border-default);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.authored-modules-detail__strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.authored-modules-detail__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.authored-modules-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.authored-modules-detail__section-title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.authored-modules-detail__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.authored-modules-detail__list-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.authored-modules-detail__outcome-id {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  padding: 2px 6px;
+  color: var(--accent-primary);
+}
+
+.authored-modules-detail__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.authored-modules-detail__note {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 8%, transparent);
+}
+
 .authored-modules-table code {
   font-size: 12px;
   background: var(--surface-secondary);


### PR DESCRIPTION
## Summary

Each module row in the Authored Modules catalogue is now expandable. Click → reveals the full `AuthoredModule` data: outcomes, prerequisites, content source, scoring, voice readout, position. Replaces the previous flat 7-column view.

After #256 hid the derived/regen view, this was the only surface for module detail and it was hiding most of the data. This PR exposes everything per HF design system rules.

## What expands

| Section | What you see |
|---|---|
| Top metadata strip | Position badge (when set), Scoring-fired badge with target icon, Spoken-bands badge if voice readout |
| Primary outcomes | Monospace outcome IDs styled as accent-colour code chips |
| Prerequisites | Muted pills with advisory tooltip — "Recommended after — picker does not gate" |
| Content source | Link icon + the free-form ref from the markdown |
| Behaviour note | Yellow-tinted callout when `sessionTerminal` or `frequency: once`, explaining how the picker treats it |

## Inline pills replace the old `●/—` columns

- **Mode**: GraduationCap / Layers / Pencil icon + info/accent/muted tone
- **Frequency**: warning (once) / info (cooldown) / muted (repeatable)
- **Terminal**: "Ends session" warning pill or em-dash
- **Picker visibility**: "Visible" success pill / "Hidden" muted pill

## UI design system compliance

- All `hf-*` classes (badge sizes + tones)
- `color-mix()` for hover/expanded row backgrounds + behaviour callout. No hex literals.
- `aria-expanded` on toggle row

## Test plan

- [x] 34/34 tests pass (panel + picker + picker page suites)
- [ ] `/vm-cp` deploy. Then on the IELTS course's Curriculum tab: click a module row (e.g. `baseline`) → confirm expansion shows the 5 declared outcomes (`OUT-01`, …), session-terminal callout, frequency=once badge.

## Deploy

`/vm-cp` — no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)