### PR TITLE
feat: parse + display OUT-NN outcome statements (Closes #258)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -82,6 +82,8 @@ export async function GET(
     moduleDefaults: cfg.moduleDefaults ?? {},
     moduleSource: cfg.moduleSource ?? null,
     moduleSourceRef: cfg.moduleSourceRef ?? null,
+    // #258: outcome statements parsed from `**OUT-NN: <statement>.**` headings.
+    outcomes: cfg.outcomes ?? {},
     validationWarnings: warnings,
     hasErrors: warnings.some((w) => w.severity === "error"),
     // Surfaced so the learner-preview component can pick the right layout
@@ -178,6 +180,7 @@ export async function POST(
     modulesAuthored: detected.modulesAuthored,
     modules: detected.modules,
     moduleDefaults: detected.moduleDefaults,
+    outcomes: detected.outcomes,
     validationWarnings: detected.validationWarnings,
     detectedFrom: detected.detectedFrom,
     hasErrors: hasBlockingErrors(detected),

--- a/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
@@ -69,6 +69,7 @@ const EMPTY_STATE: AuthoredModulesState = {
   moduleDefaults: {},
   moduleSource: null,
   moduleSourceRef: null,
+  outcomes: {},
   validationWarnings: [],
   hasErrors: false,
   lessonPlanMode: null,
@@ -99,6 +100,7 @@ export function AuthoredModulesPanel({
         moduleDefaults: data.moduleDefaults,
         moduleSource: data.moduleSource,
         moduleSourceRef: data.moduleSourceRef,
+        outcomes: data.outcomes ?? {},
         validationWarnings: data.validationWarnings,
         hasErrors: data.hasErrors,
         lessonPlanMode: data.lessonPlanMode,
@@ -162,7 +164,7 @@ export function AuthoredModulesPanel({
 
       {state.modules.length > 0 && (
         <>
-          <CatalogueTable modules={state.modules} />
+          <CatalogueTable modules={state.modules} outcomes={state.outcomes} />
           <StatusStrip
             warnings={state.validationWarnings}
             hasErrors={state.hasErrors}
@@ -234,7 +236,13 @@ function EmptyState({
 
 // ── Catalogue table (expandable rows) ──────────────────────────────
 
-function CatalogueTable({ modules }: { modules: AuthoredModule[] }) {
+function CatalogueTable({
+  modules,
+  outcomes,
+}: {
+  modules: AuthoredModule[];
+  outcomes: Record<string, string>;
+}) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const toggle = (id: string) =>
     setExpandedId((prev) => (prev === id ? null : id));
@@ -261,6 +269,7 @@ function CatalogueTable({ modules }: { modules: AuthoredModule[] }) {
               <CatalogueRow
                 key={m.id}
                 module={m}
+                outcomes={outcomes}
                 isExpanded={isExpanded}
                 onToggle={() => toggle(m.id)}
               />
@@ -274,10 +283,12 @@ function CatalogueTable({ modules }: { modules: AuthoredModule[] }) {
 
 function CatalogueRow({
   module: m,
+  outcomes,
   isExpanded,
   onToggle,
 }: {
   module: AuthoredModule;
+  outcomes: Record<string, string>;
   isExpanded: boolean;
   onToggle: () => void;
 }) {
@@ -324,7 +335,7 @@ function CatalogueRow({
       {isExpanded && (
         <tr className="authored-modules-table__detail-row">
           <td colSpan={8} className="authored-modules-table__detail-cell">
-            <ModuleDetail module={m} />
+            <ModuleDetail module={m} outcomes={outcomes} />
           </td>
         </tr>
       )}
@@ -361,7 +372,13 @@ function FrequencyPill({ frequency }: { frequency: AuthoredModule["frequency"] }
   );
 }
 
-function ModuleDetail({ module: m }: { module: AuthoredModule }) {
+function ModuleDetail({
+  module: m,
+  outcomes,
+}: {
+  module: AuthoredModule;
+  outcomes: Record<string, string>;
+}) {
   return (
     <div className="authored-modules-detail">
       {/* Top metadata strip */}
@@ -391,11 +408,19 @@ function ModuleDetail({ module: m }: { module: AuthoredModule }) {
             <p className="hf-text-sm hf-text-muted">None declared.</p>
           ) : (
             <ul className="authored-modules-detail__list">
-              {m.outcomesPrimary.map((id) => (
-                <li key={id} className="authored-modules-detail__list-item">
-                  <code className="authored-modules-detail__outcome-id">{id}</code>
-                </li>
-              ))}
+              {m.outcomesPrimary.map((id) => {
+                const statement = outcomes[id];
+                return (
+                  <li key={id} className="authored-modules-detail__list-item">
+                    <code className="authored-modules-detail__outcome-id">{id}</code>
+                    {statement && (
+                      <span className="authored-modules-detail__outcome-text">
+                        {statement}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
             </ul>
           )}
         </section>

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -133,6 +133,13 @@
   border-radius: 4px;
   padding: 2px 6px;
   color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.authored-modules-detail__outcome-text {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.4;
 }
 
 .authored-modules-detail__chips {

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -340,6 +340,13 @@ export interface PlaybookConfig {
    * defaults. See per-field-defaults-with-warnings policy in spec #236.
    */
   moduleDefaults?: Partial<ModuleDefaults>;
+  /**
+   * Outcome statements parsed from `**OUT-NN: <statement>.**` bold headings
+   * in the Course Reference. Keyed by outcome ID. Used to render the
+   * AuthoredModulesPanel detail view with full text instead of bare IDs.
+   * Issue #258.
+   */
+  outcomes?: Record<string, string>;
   pickerLayout?: PickerLayout;
   validationWarnings?: ValidationWarning[];
   [key: string]: any;

--- a/apps/admin/lib/wizard/__tests__/extract-outcome-statements.test.ts
+++ b/apps/admin/lib/wizard/__tests__/extract-outcome-statements.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for extractOutcomeStatements (#258).
+ *
+ * Parses `**OUT-NN: <statement>.**` bold headings out of a Course Reference
+ * markdown body into a Record<id, statement> map. Tolerates variant
+ * whitespace, optional trailing periods, and outcome ID widths.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractOutcomeStatements } from "@/lib/wizard/detect-authored-modules";
+
+describe("extractOutcomeStatements", () => {
+  it("returns empty object when no OUT-NN headings exist", () => {
+    const md = `# Some doc\n\nNo outcome headings here.\n\nOUT-01 in prose isn't a heading.\n`;
+    expect(extractOutcomeStatements(md)).toEqual({});
+  });
+
+  it("extracts a single statement on its own line", () => {
+    const md = `before\n**OUT-01: Extends every answer to the minimum length expected for Part 1.**\nafter`;
+    expect(extractOutcomeStatements(md)).toEqual({
+      "OUT-01": "Extends every answer to the minimum length expected for Part 1",
+    });
+  });
+
+  it("extracts multiple statements", () => {
+    const md = [
+      "**OUT-01: Extends every answer to the minimum length expected for Part 1.**",
+      "",
+      "Body prose.",
+      "",
+      "**OUT-02: Selects the framework opening matched to the question type.**",
+      "**OUT-24: Improves pronunciation on 2–3 targeted problem sounds.**",
+    ].join("\n");
+
+    const out = extractOutcomeStatements(md);
+    expect(Object.keys(out)).toEqual(["OUT-01", "OUT-02", "OUT-24"]);
+    expect(out["OUT-02"]).toBe("Selects the framework opening matched to the question type");
+    expect(out["OUT-24"]).toBe("Improves pronunciation on 2–3 targeted problem sounds");
+  });
+
+  it("strips a trailing period from the statement", () => {
+    const md = `**OUT-05: Produces natural 2–3 sentence Part 1 answers.**`;
+    expect(extractOutcomeStatements(md)["OUT-05"]).toBe(
+      "Produces natural 2–3 sentence Part 1 answers",
+    );
+  });
+
+  it("preserves a statement with no trailing period", () => {
+    const md = `**OUT-09: Open-ended outcome with no period**`;
+    expect(extractOutcomeStatements(md)["OUT-09"]).toBe(
+      "Open-ended outcome with no period",
+    );
+  });
+
+  it("ignores OUT-NN references inline in prose (not bold-on-its-own-line)", () => {
+    const md = `*Outcomes served:* OUT-01, OUT-02, OUT-05.\n\nInline mention of **OUT-01** is also ignored unless followed by ': statement'.`;
+    expect(extractOutcomeStatements(md)).toEqual({});
+  });
+
+  it("tolerates extra surrounding whitespace", () => {
+    const md = `   **OUT-07:    Demonstrates confidence on the four most common Part 1 topic clusters.**   \n`;
+    expect(extractOutcomeStatements(md)["OUT-07"]).toBe(
+      "Demonstrates confidence on the four most common Part 1 topic clusters",
+    );
+  });
+
+  it("later occurrence wins on duplicate IDs", () => {
+    const md = [
+      "**OUT-01: First definition.**",
+      "**OUT-01: Refined definition that supersedes the first.**",
+    ].join("\n");
+    expect(extractOutcomeStatements(md)["OUT-01"]).toBe(
+      "Refined definition that supersedes the first",
+    );
+  });
+});

--- a/apps/admin/lib/wizard/detect-authored-modules.ts
+++ b/apps/admin/lib/wizard/detect-authored-modules.ts
@@ -45,10 +45,34 @@ export interface DetectedAuthoredModules {
   modules: AuthoredModule[];
   /** Defaults block parsed from the document; empty object when none present. */
   moduleDefaults: Partial<ModuleDefaults>;
+  /**
+   * Outcome statements parsed from `**OUT-NN: <statement>.**` bold headings.
+   * Keyed by outcome ID. Empty object when no such headings present.
+   * #258.
+   */
+  outcomes: Record<string, string>;
   /** Warnings + errors raised during parsing. Drives the publish gate. */
   validationWarnings: ValidationWarning[];
   /** Raw text snippets that triggered each detection — surfaced for debug. */
   detectedFrom: string[];
+}
+
+// ── Outcome statement extraction (#258) ──────────────────────────────
+// Matches a line like `**OUT-01: Extends every answer to ... .**`. Tolerates
+// trailing whitespace, optional trailing period, and outcome ID widths.
+const OUTCOME_STATEMENT_LINE = /^\s*\*\*\s*(OUT-\d+)\s*:\s*([^*]+?)\s*\*\*\s*$/;
+
+export function extractOutcomeStatements(bodyText: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of bodyText.split(/\r?\n/)) {
+    const m = line.match(OUTCOME_STATEMENT_LINE);
+    if (!m) continue;
+    const [, id, statement] = m;
+    // Strip a single trailing period to keep the value tidy when re-rendered.
+    const cleaned = statement.replace(/\.$/, "").trim();
+    if (cleaned) out[id] = cleaned;
+  }
+  return out;
 }
 
 // ── Module ID validation ──────────────────────────────────────────────
@@ -465,9 +489,14 @@ export function detectAuthoredModules(bodyText: string): DetectedAuthoredModules
     modulesAuthored: null,
     modules: [],
     moduleDefaults: {},
+    outcomes: {},
     validationWarnings: [],
     detectedFrom: [],
   };
+
+  // ── 0. Outcome statements (#258) — runs unconditionally so we never lose
+  // the data even when the modules-authored signal is missing or partial.
+  result.outcomes = extractOutcomeStatements(bodyText);
 
   // ── 1. Header declaration
   const headerMatch = bodyText.match(MODULES_AUTHORED_HEADER);

--- a/apps/admin/lib/wizard/persist-authored-modules.ts
+++ b/apps/admin/lib/wizard/persist-authored-modules.ts
@@ -69,12 +69,21 @@ export function applyAuthoredModules(
   }
 
   // Authored = true. Merge in.
+  // #258: outcome statements are merged from the parse so they survive a
+  // re-import that drops a previously-declared OUT-NN heading. If the parse
+  // produced no outcomes, the existing map is preserved unchanged — keeps
+  // backward-compat for courses imported before #258 landed.
+  const mergedOutcomes = Object.keys(parsed.outcomes ?? {}).length > 0
+    ? { ...(existing.outcomes ?? {}), ...parsed.outcomes }
+    : existing.outcomes;
+
   const next: PlaybookConfig = {
     ...existing,
     modulesAuthored: true,
     moduleSource: "authored",
     modules: parsed.modules,
     moduleDefaults: { ...(existing.moduleDefaults ?? {}), ...parsed.moduleDefaults },
+    ...(mergedOutcomes ? { outcomes: mergedOutcomes } : {}),
     validationWarnings: parsed.validationWarnings,
     ...(options.sourceRef ? { moduleSourceRef: options.sourceRef } : {}),
   };


### PR DESCRIPTION
## Summary

The expanded Authored Modules detail (PR #257) showed bare outcome IDs without statements. This PR captures the **bold OUT-NN headings** from the Course Reference and surfaces them next to each ID in the expanded row.

```
Before:    OUT-01    OUT-02    OUT-05    …
After:     OUT-01  Extends every answer to the minimum length expected for Part 1
           OUT-02  Selects the framework opening matched to the question type
           OUT-05  Produces natural 2–3 sentence Part 1 answers
```

## Changes

- `extractOutcomeStatements()` regex parses `**OUT-NN: <statement>.**` lines
- `detectAuthoredModules` runs it unconditionally and exposes `outcomes`
- `PlaybookConfig.outcomes?: Record<string, string>` (JSON shape — no migration)
- `applyAuthoredModules` merges parsed outcomes with existing (preserves carry-over)
- GET `/api/courses/[id]/import-modules` returns `outcomes`
- AuthoredModulesPanel detail row renders ID + statement; falls back to ID-only when no statement parsed

## Test plan

- [x] 58/58 across parser + persist + panel + import-modules + new outcome-statements suites. 8 new unit tests.
- [ ] `/vm-cp` deploy. Re-import the IELTS v2.2 Course Reference. Expand `part1` row. Each outcome (`OUT-01`…`OUT-24`) should render with its full statement.

## Deploy

`/vm-cp` — JSON shape only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)