### PR TITLE
feat: progression-mode wizard step + Course Panel pill (Closes #253)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/course-detail.css
+++ b/apps/admin/app/x/courses/[courseId]/course-detail.css
@@ -599,3 +599,41 @@
   0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--status-success-text) 20%, transparent); }
   50% { box-shadow: 0 0 8px 2px color-mix(in srgb, var(--status-success-text) 25%, transparent); }
 }
+
+/* ── Module progression mode pill (#253) ── */
+
+.cd-progression-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  border: 1px solid var(--border-default);
+}
+
+.cd-progression-pill--learner {
+  color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent-primary) 25%, transparent);
+}
+
+.cd-progression-pill--ai {
+  color: var(--text-muted);
+  background: var(--surface-secondary);
+}
+
+.cd-progression-pill--unset {
+  color: var(--status-warning-text, var(--accent-primary));
+  background: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 10%, transparent);
+  border-color: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 25%, transparent);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.cd-progression-pill--unset:hover {
+  background: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 18%, transparent);
+}

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -994,6 +994,10 @@ export default function CourseDetailPage() {
                 {setupReadiness.allComplete ? 'Ready' : `${setupReadiness.completedCount}/6`}
               </span>
             )}
+            <ProgressionModePill
+              modulesAuthored={(detail.config as Record<string, unknown> | null | undefined)?.modulesAuthored as boolean | null | undefined}
+              onClickWhenUnset={() => router.push(`/x/courses/${detail.id}?tab=curriculum`)}
+            />
           </div>
           <div className="hf-flex hf-gap-sm hf-items-center">
             <DomainPill label={detail.domain.name} href={`/x/domains?id=${detail.domain.id}`} size="compact" />
@@ -1650,5 +1654,52 @@ export default function CourseDetailPage() {
         />
       )}
     </div>
+  );
+}
+
+// ── Module progression mode badge (#253) ─────────────────────────────
+//
+// Surfaces the course's `modulesAuthored` choice next to the title so
+// educators can see at a glance whether learners will be presented with a
+// picker (true) or fall through to scheduler-led teaching (false). When
+// unset, renders a clickable warning pill that routes to the Curriculum tab
+// so the educator can resolve it via Re-import.
+function ProgressionModePill({
+  modulesAuthored,
+  onClickWhenUnset,
+}: {
+  modulesAuthored: boolean | null | undefined;
+  onClickWhenUnset: () => void;
+}) {
+  if (modulesAuthored === true) {
+    return (
+      <span
+        className="cd-progression-pill cd-progression-pill--learner"
+        title="Learners pick from a module menu before each session"
+      >
+        Learner picks
+      </span>
+    );
+  }
+  if (modulesAuthored === false) {
+    return (
+      <span
+        className="cd-progression-pill cd-progression-pill--ai"
+        title="AI scheduler decides which module to cover each call"
+      >
+        AI-led
+      </span>
+    );
+  }
+  // null / undefined — never set
+  return (
+    <button
+      type="button"
+      className="cd-progression-pill cd-progression-pill--unset"
+      onClick={onClickWhenUnset}
+      title="Click to choose how learners progress (AI-led or learner-picks)"
+    >
+      Mode not set
+    </button>
   );
 }

--- a/apps/admin/lib/chat/conversational-system-prompt.ts
+++ b/apps/admin/lib/chat/conversational-system-prompt.ts
@@ -466,7 +466,19 @@ reason in the Phase 2 full configuration proposal.
 - facilitation — Discussion facilitation, draws out ideas from the student
 - reflective — Encourages self-reflection and learning-from-experience
 - open — Flexible, adapts to whatever the student needs in the moment
-- conversational-guide — Warm, curious guide for enriching 1:1 conversations around topics — no teaching, no coaching`;
+- conversational-guide — Warm, curious guide for enriching 1:1 conversations around topics — no teaching, no coaching
+
+### Module progression (progressionMode) — REQUIRED, mandatory step
+**This is a mandatory choice. Always ask explicitly using show_options.** Do NOT infer silently.
+
+- ai-led — The AI scheduler picks what to cover each call based on the learner's progress. Learner just calls in; no menu. Right for adaptive courses where the AI should decide.
+- learner-picks — Learner sees a menu of modules before each session and chooses. REQUIRES a Module Catalogue table in the Course Reference markdown.
+
+**Decision rules:**
+- If courseRefDigest exists AND it contains a "Module Catalogue" table → PROPOSE 'learner-picks' with reason ("your Course Reference declares modules — students will see a picker").
+- If user described an adaptive/scheduler-led course → PROPOSE 'ai-led'.
+- If 'learner-picks' is chosen but courseRefDigest missing or has no Module Catalogue → DO NOT save. Tell the user: "Learner picks needs a Module Catalogue table in your Course Reference. Either upload a Course Reference with one, or pick AI-led." Wait for them to upload or change.
+- Persist to PlaybookConfig.modulesAuthored: true when 'learner-picks', false when 'ai-led'.`;
 
 const FALLBACK_RULES = `## ⚠️ Graph priorities — Phase 1b guard
 If the user has just described their course for the first time and you have not yet

--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -740,6 +740,17 @@ export async function executeWizardTool(
             const constraints = (input.constraints as string[]) || (setupData?.constraints as string[]);
             if (constraints) configUpdate.constraints = constraints;
 
+            // #253: progressionMode — wizard's mandatory choice between
+            // AI-led teaching (scheduler picks each call) and learner-picks
+            // (picker shows authored modules). Maps to PlaybookConfig.modulesAuthored.
+            const progressionMode =
+              (input.progressionMode as string) || (setupData?.progressionMode as string);
+            if (progressionMode === "learner-picks") {
+              configUpdate.modulesAuthored = true;
+            } else if (progressionMode === "ai-led") {
+              configUpdate.modulesAuthored = false;
+            }
+
             // #167 — Carry through pedagogy detected from an uploaded course
             // reference. These values override the system defaults:
             //   - lessonPlanMode: "continuous" means the scheduler decides
@@ -1962,6 +1973,16 @@ export async function executeWizardTool(
         if (input.lessonPlanModel) configUpdate.lessonPlanModel = input.lessonPlanModel;
         if (welcomeMessage) configUpdate.welcomeMessage = welcomeMessage;
         if (input.courseContext) configUpdate.courseContext = input.courseContext;
+
+        // #253: progressionMode → modulesAuthored mapping (also handled at
+        // create_course; mirror here for update_course_config paths).
+        const updateProgressionMode =
+          (input.progressionMode as string) || (setupData?.progressionMode as string);
+        if (updateProgressionMode === "learner-picks") {
+          configUpdate.modulesAuthored = true;
+        } else if (updateProgressionMode === "ai-led") {
+          configUpdate.modulesAuthored = false;
+        }
 
         await prisma.playbook.update({
           where: { id: playbookId },

--- a/apps/admin/lib/wizard/graph-nodes.ts
+++ b/apps/admin/lib/wizard/graph-nodes.ts
@@ -101,6 +101,29 @@ export const WIZARD_GRAPH_NODES: WizardGraphNode[] = [
     affinityTags: ["course"],
   },
   {
+    // #253: mandatory choice between AI-scheduler-led teaching and
+    // learner-picks-from-menu. Maps to PlaybookConfig.modulesAuthored
+    // (true = learner picks; false = AI scheduler decides each call).
+    // Required and EARLY in the graph so downstream nodes (modules, picker
+    // wiring, journey-position routing) can branch on it cleanly.
+    key: "progressionMode",
+    label: "Module progression",
+    group: "course",
+    inputType: "options",
+    required: true,
+    priority: 1,
+    dependsOn: ["courseName"],
+    resolvedBy: ["course-lookup"],
+    optionsKey: "progressionModes",
+    promptHint:
+      "How do learners progress through the course? Two options:\n" +
+      "- 'AI-led' (modulesAuthored=false): the scheduler picks what to cover each call. Learner just calls in.\n" +
+      "- 'Learner picks' (modulesAuthored=true): learner sees a module menu before each session and picks. REQUIRES a Module Catalogue table in the Course Reference markdown — surface a friendly error if 'Learner picks' is chosen but courseRefDigest is missing or has no Module Catalogue.\n" +
+      "PROPOSE based on evidence: if Course Reference has a Module Catalogue table, propose 'Learner picks'. If the user described the course as 'adaptive' or 'AI decides each call', propose 'AI-led'. State your reasoning. Save as 'ai-led' or 'learner-picks' (string), then mirror to PlaybookConfig.modulesAuthored when persisting.",
+    mutablePostScaffold: true,
+    affinityTags: ["course", "progression"],
+  },
+  {
     key: "interactionPattern",
     label: "Teaching approach",
     group: "course",

--- a/apps/admin/lib/wizard/graph-schema.ts
+++ b/apps/admin/lib/wizard/graph-schema.ts
@@ -67,7 +67,10 @@ export type OptionsKey =
   | "durations"
   | "planEmphases"
   | "lessonModels"
-  | "subjectsCatalog";
+  | "subjectsCatalog"
+  // #253: how learners progress — AI scheduler-led vs learner-picks-from-menu.
+  // Maps to PlaybookConfig.modulesAuthored (true = learner picks).
+  | "progressionModes";
 
 // ── Graph node definition ─────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #253. Wizard now mandates an explicit choice between **AI-led** (scheduler picks each call) and **Learner picks** (authored-modules picker) — instead of silently inferring from prose. A pill on the course header surfaces the choice at all times.

Earlier today a live test showed: uploading a Course Reference with a Module Catalogue, the wizard inferred "scheduler decides call-by-call" anyway. This PR closes that gap.

## Changes

| Area | Change |
|---|---|
| Wizard graph | New mandatory `progressionMode` node after `courseName` (priority 1, no `skipWhen`) |
| Options registry | New `progressionModes` key in `OptionsKey` union |
| AI prompt | New "Module progression" FALLBACK_VALUES section. AI proposes `learner-picks` when `courseRefDigest` has a Module Catalogue, `ai-led` for adaptive prose; surfaces a friendly error if `learner-picks` is chosen without a Catalogue |
| Persistence | `progressionMode` ↔ `PlaybookConfig.modulesAuthored` mapping in both `create_course` and `update_course_config` |
| Course Panel pill | "Learner picks" (accent) / "AI-led" (muted) / "Mode not set" (warning, clickable to Curriculum tab) |
| CSS | New `.cd-progression-pill` family follows existing `.cd-readiness-pip` pattern — color-mix tones, no hex |

## Test plan

- [x] 34/34 picker / panel tests still green
- [ ] `/vm-cp` deploy. Then:
  1. Existing IELTS v1 (modulesAuthored=true) → pill reads "Learner picks"
  2. v2 (just created without progressionMode) → pill reads "Mode not set"; click → routes to Curriculum tab
  3. Re-import on v2 → modulesAuthored: true → pill flips to "Learner picks"
  4. Start a NEW wizard session with no Course Ref → wizard explicitly asks the progression-mode question

## Out of scope

- Wizard auto-imports Module Catalogue at finish (separate ticket)
- Outcome-graph cross-link from the pill
- Hybrid mode

## Deploy

`/vm-cp` — no schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)