### PR TITLE
fix: surface identity memories (name, surname) in Key Memories

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/quickstart.ts
+++ b/apps/admin/lib/prompt/composition/transforms/quickstart.ts
@@ -373,9 +373,33 @@ registerTransform("computeQuickStart", (
       return `Progress: ${completed}/${total} modules mastered${currentModuleName ? ` | Current: ${currentModuleName}` : ""}`;
     })() : null,
 
-    key_memories: deduplicated.length > 0
-      ? deduplicated.slice(0, 3).map((m: any) => `${m.key}: ${m.value}`)
-      : null,
+    key_memories: (() => {
+      // Identity-critical keys must always surface so the tutor knows what
+      // to call the learner. Promote them ahead of the slice cap; fill the
+      // remaining slots with the most-recent / highest-ranked memories.
+      // (Bug: a learner stated their name in call 1 and the call-2 tutor
+      // asked again — name was in CallerMemory but never made it into the
+      // composed prompt's Key Memories line.)
+      if (deduplicated.length === 0) return null;
+      const IDENTITY_KEYS = new Set([
+        "name",
+        "first_name",
+        "firstName",
+        "surname",
+        "last_name",
+        "lastName",
+        "nickname",
+        "preferred_name",
+        "preferredName",
+      ]);
+      const identity = deduplicated.filter((m: any) => IDENTITY_KEYS.has(m.key));
+      const others = deduplicated.filter((m: any) => !IDENTITY_KEYS.has(m.key));
+      // Cap at 4 (was 3) so an identity hit doesn't push out a relevant
+      // non-identity fact.
+      return [...identity, ...others]
+        .slice(0, 4)
+        .map((m: any) => `${m.key}: ${m.value}`);
+    })(),
 
     voice_style: (() => {
       const warmth = mergedTargets.find((t: any) => t.parameterId === PARAMS.BEH_WARMTH);


### PR DESCRIPTION
## Summary

A learner stated their name in call 1; on call 2 the tutor asked again. CallerMemory had `name: Mo` but the composed prompt's `Key Memories` line didn't include it — `quickstart.ts` took the first 3 deduplicated memories regardless of identity-critical keys.

Now: identity keys always surface first; cap raised from 3 → 4 so an identity hit doesn't push out a relevant non-identity fact.

Identity keys promoted: `name`, `first_name`, `firstName`, `surname`, `last_name`, `lastName`, `nickname`, `preferred_name`, `preferredName`.

## Test plan

- [x] 305/305 composition tests still green
- [ ] `/vm-cp` deploy. End a SIM call where learner states their name. Wait for pipeline. Start a new call. Verify the tutor opens by acknowledging the learner's name (or at least doesn't ask for it again).

## Deploy

`/vm-cp` — no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)