### PR TITLE
fix: wizard Phase 4c welcome-flow UX (#255)

### DIFF
--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -1353,14 +1353,23 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
           <div className="cv4-messages-spacer" />
           {(() => {
             const lastAssistantId = [...messages].reverse().find(m => m.role === "assistant")?.id;
-            // If the welcome-flow checklist is currently unresolved, suppress
-            // fallback chips on the last assistant message — the checklist
-            // owns the decision surface.
-            const welcomeChecklistActive = messages.some(
+            // Suppress fallback chips when Phase 4c is effectively unresolved.
+            // Two cases: (a) checklist visible and unresolved on screen, or
+            // (b) checklist has been shown at any point in history but the four
+            // welcome keys are still not all recorded — a stale chip like
+            // "create the course" emitted on a later turn would otherwise route
+            // through "Skip = recommended bundle" and silently flip flags on.
+            const welcomeChecklistEverShown = messages.some(
               (m) => m.systemType === "options"
-                && !m.resolved
                 && (m.optionsPanel as { dataKey?: string } | undefined)?.dataKey === "_welcomePhases",
             );
+            const welcomeKeysAllSet =
+              getData("welcomeGoals") !== undefined
+              && getData("welcomeAboutYou") !== undefined
+              && getData("welcomeKnowledgeCheck") !== undefined
+              && getData("welcomeAiIntro") !== undefined;
+            const welcomeChecklistActive =
+              welcomeChecklistEverShown && !welcomeKeysAllSet;
             return messages.map((msg) => {
             // Options card — skip if resolved (user already made a selection)
             if (msg.systemType === "options" && !msg.resolved && msg.optionsPanel) {

--- a/apps/admin/app/x/wizard/components/OptionsCard.tsx
+++ b/apps/admin/app/x/wizard/components/OptionsCard.tsx
@@ -66,14 +66,24 @@ export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse }: Option
     [onSelect],
   );
 
+  // _welcomePhases is the only checklist where "zero ticked" carries meaning
+  // (= "all four welcome flags off"). Skip on _welcomePhases means "use defaults"
+  // per the system prompt, so the only path to all-off is Confirm-at-zero → "None".
+  const isWelcomePhases = panel.dataKey === "_welcomePhases";
+
   const handleChecklistConfirm = useCallback(() => {
-    if (selected.size === 0) return;
+    if (selected.size === 0) {
+      if (isWelcomePhases) {
+        onSelect([], "None");
+      }
+      return;
+    }
     const values = Array.from(selected);
     const labels = values
       .map((v) => options.find((o) => o.value === v)?.label ?? v)
       .join(", ");
     onSelect(values, labels);
-  }, [selected, options, onSelect]);
+  }, [selected, options, onSelect, isWelcomePhases]);
 
   const toggleSelected = useCallback((value: string) => {
     setSelected((prev) => {
@@ -247,10 +257,12 @@ export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse }: Option
               <button
                 type="button"
                 className="cv4-options-confirm-btn"
-                disabled={selected.size === 0}
+                disabled={selected.size === 0 && !isWelcomePhases}
                 onClick={handleChecklistConfirm}
               >
-                Confirm{selected.size > 0 ? ` (${selected.size})` : ""}
+                {selected.size === 0 && isWelcomePhases
+                  ? "None of these"
+                  : `Confirm${selected.size > 0 ? ` (${selected.size})` : ""}`}
               </button>
             )}
             <button

--- a/apps/admin/evals/wizard/v4-welcome-flow.yaml
+++ b/apps/admin/evals/wizard/v4-welcome-flow.yaml
@@ -262,6 +262,33 @@ tests:
       - type: llm-rubric
         value: "Response text mentions that the AI's first-call discovery questions are also skipped (because welcome.aboutYou is off, which gates them). The educator should not be surprised by call-1 behaviour."
 
+  # ── Test 4b — V4 "None" payload (zero-tick Confirm) → all four off ──
+
+  - description: "Test 4b — V4 userMessage 'None' (educator clicked 'None of these' on _welcomePhases checklist) → all four welcome keys = false"
+    vars:
+      conversationContext: |
+        Last turn YOU (the AI) proposed the four welcome flow phases with the recommended bundle:
+        Goals on, About You on, Knowledge Check off, AI Introduction Call off. You called
+        show_options checklist with dataKey "_welcomePhases". The educator clicked "None of these"
+        on the checklist (zero ticks confirmed) — the wizard converts this to the literal user
+        message "None".
+      userMessage: "None"
+    assert:
+      - type: javascript
+        value: |
+          const _out = typeof output === 'string' ? output : JSON.stringify(output);
+          const _tc = output.tool_calls || _out.split('\n').flatMap(l => { try { const b = JSON.parse(l.trim()); return b.type === 'tool_use' ? [{name: b.name, args: b.input || {}}] : []; } catch(e) { return []; } });
+          const update = _tc.find(t => t.name === 'update_setup');
+          if (!update) return { pass: false, score: 0, reason: 'No update_setup after None — welcome keys not saved' };
+          const fields = update.args?.fields || update.args || {};
+          if (fields.welcomeGoals !== false) return { pass: false, score: 0, reason: `welcomeGoals must be false ('None' = all-off), got ${JSON.stringify(fields.welcomeGoals)}` };
+          if (fields.welcomeAboutYou !== false) return { pass: false, score: 0, reason: `welcomeAboutYou must be false` };
+          if (fields.welcomeKnowledgeCheck !== false) return { pass: false, score: 0, reason: `welcomeKnowledgeCheck must be false` };
+          if (fields.welcomeAiIntro !== false) return { pass: false, score: 0, reason: `welcomeAiIntro must be false` };
+          return true;
+      - type: llm-rubric
+        value: "Response text mentions that the AI's first-call discovery questions are also skipped (because welcome.aboutYou is off)."
+
   # ── Test 5 — Phase 5 summary line format (after welcome flow captured) ──
 
   - description: "Test 5 — V4 When asked for the summary, AI uses human bundle format for Welcome flow line"

--- a/apps/admin/evals/wizard/v5-welcome-flow.yaml
+++ b/apps/admin/evals/wizard/v5-welcome-flow.yaml
@@ -277,6 +277,58 @@ tests:
       - type: llm-rubric
         value: "Response text mentions that the AI's first-call discovery questions are also skipped (because welcome.aboutYou is off, which gates them). The educator should not be surprised by call-1 behaviour."
 
+  # ── Test 4b — "None" payload (zero-tick Confirm) → all four off ──
+
+  - description: "Test 4b — userMessage 'None' (educator clicked 'None of these' button on _welcomePhases checklist) → all four welcome keys = false"
+    vars:
+      conversationContext: |
+        Last turn YOU (the AI) proposed the four welcome flow phases with the recommended bundle:
+        Goals on, About You on, Knowledge Check off, AI Introduction Call off. You called
+        show_options checklist with dataKey "_welcomePhases". The educator clicked "None of these"
+        on the checklist (zero ticks confirmed) — the wizard converts this to the literal user
+        message "None".
+      userMessage: "None"
+    assert:
+      - type: javascript
+        value: |
+          const _out = typeof output === 'string' ? output : JSON.stringify(output);
+          const _tc = output.tool_calls || _out.split('\n').flatMap(l => { try { const b = JSON.parse(l.trim()); return b.type === 'tool_use' ? [{name: b.name, args: b.input || {}}] : []; } catch(e) { return []; } });
+          const update = _tc.find(t => t.name === 'update_setup');
+          if (!update) return { pass: false, score: 0, reason: 'No update_setup after None — welcome keys not saved' };
+          const fields = update.args?.fields || update.args || {};
+          if (fields.welcomeGoals !== false) return { pass: false, score: 0, reason: `welcomeGoals must be false ('None' = all-off), got ${JSON.stringify(fields.welcomeGoals)}` };
+          if (fields.welcomeAboutYou !== false) return { pass: false, score: 0, reason: `welcomeAboutYou must be false` };
+          if (fields.welcomeKnowledgeCheck !== false) return { pass: false, score: 0, reason: `welcomeKnowledgeCheck must be false` };
+          if (fields.welcomeAiIntro !== false) return { pass: false, score: 0, reason: `welcomeAiIntro must be false` };
+          return true;
+      - type: llm-rubric
+        value: "Response text mentions that the AI's first-call discovery questions are also skipped (because welcome.aboutYou is off). The educator should not be surprised by call-1 behaviour."
+
+  # ── Test 4c — Amendment path: "None" still maps to all-off post-creation ──
+
+  - description: "Test 4c — Amendment path: educator changes welcome flow to None, all four keys = false"
+    vars:
+      conversationContext: |
+        The course already exists (POST-SCAFFOLD amendment tier). The educator just clicked "Welcome flow"
+        on the progress panel and chose "Change something". YOU (the AI) re-proposed the four phases
+        via show_options checklist with dataKey "_welcomePhases" and recommended bundle Goals on,
+        About You on, Knowledge Check off, AI Introduction Call off. The educator clicked
+        "None of these" — the wizard sends "None".
+      userMessage: "None"
+    assert:
+      - type: javascript
+        value: |
+          const _out = typeof output === 'string' ? output : JSON.stringify(output);
+          const _tc = output.tool_calls || _out.split('\n').flatMap(l => { try { const b = JSON.parse(l.trim()); return b.type === 'tool_use' ? [{name: b.name, args: b.input || {}}] : []; } catch(e) { return []; } });
+          const update = _tc.find(t => t.name === 'update_setup');
+          if (!update) return { pass: false, score: 0, reason: 'No update_setup after None (amendment)' };
+          const fields = update.args?.fields || update.args || {};
+          if (fields.welcomeGoals !== false) return { pass: false, score: 0, reason: `welcomeGoals must be false on amendment None path, got ${JSON.stringify(fields.welcomeGoals)}` };
+          if (fields.welcomeAboutYou !== false) return { pass: false, score: 0, reason: `welcomeAboutYou must be false` };
+          if (fields.welcomeKnowledgeCheck !== false) return { pass: false, score: 0, reason: `welcomeKnowledgeCheck must be false` };
+          if (fields.welcomeAiIntro !== false) return { pass: false, score: 0, reason: `welcomeAiIntro must be false` };
+          return true;
+
   # ── Test 5 — Phase 5 summary line format (after welcome flow captured) ──
 
   - description: "Test 5 — When asked for the summary, AI uses human bundle format for Welcome flow line"

--- a/apps/admin/lib/chat/conversational-system-prompt.ts
+++ b/apps/admin/lib/chat/conversational-system-prompt.ts
@@ -670,6 +670,8 @@ confuse the educator. This is the one wizard step where show_suggestions is supp
 
 - A comma-separated list of ticked labels (e.g. \`"Goals, About You"\`) — ticked = true,
   un-ticked = false. Map labels back to the four \`welcome*\` keys.
+- \`"None"\` — the educator clicked "None of these" on the checklist (zero ticks confirmed).
+  Set ALL FOUR \`welcome*\` keys to \`false\` and acknowledge that the welcome flow is fully off.
 - \`"Skip"\` or empty — use your recommended bundle as-is.
 - Free-text from "Something else" or natural-language override (e.g. "turn off knowledge check") —
   parse intent and apply over your recommended bundle.
@@ -677,8 +679,9 @@ confuse the educator. This is the one wizard step where show_suggestions is supp
 In **every** case, call update_setup with **all four** welcome keys as explicit booleans. All four.
 Explicit. Never ship to create_course with these unset.
 
-Then confirm the chosen bundle in 1-2 sentences. If all four are off, mention that the AI's
-first-call discovery questions are also skipped (because aboutYou=false gates them).
+Then confirm the chosen bundle in 1-2 sentences. If all four are off (including the \`"None"\` path),
+mention that the AI's first-call discovery questions are also skipped (because aboutYou=false
+gates them).
 
 After the welcome flow is captured, advance to Phase 5 playback. Do NOT call create_course before
 all four welcome keys are explicitly set in setupData.`;

--- a/apps/admin/lib/chat/v5-system-prompt.ts
+++ b/apps/admin/lib/chat/v5-system-prompt.ts
@@ -258,6 +258,8 @@ and recommend the educator just teach.
 
 - A comma-separated list of ticked labels (e.g. \`"Goals, About You"\`) — ticked = true,
   un-ticked = false. Map labels back to the four \`welcome*\` keys.
+- \`"None"\` — the educator clicked "None of these" on the checklist (zero ticks confirmed).
+  Set ALL FOUR \`welcome*\` keys to \`false\` and acknowledge that the welcome flow is fully off.
 - \`"Skip"\` or empty — use your recommended bundle as-is.
 - Free-text from "Something else" or natural-language override (e.g. "turn off knowledge check") —
   parse intent and apply over your recommended bundle.
@@ -266,8 +268,9 @@ In **every** case, call update_setup with **all four** welcome keys as explicit 
 \`update_setup({ fields: { welcomeGoals: bool, welcomeAboutYou: bool, welcomeKnowledgeCheck: bool, welcomeAiIntro: bool } })\`.
 All four. Explicit. Never ship to create_course with these unset.
 
-Then confirm the chosen bundle in 1-2 sentences. If all four are off, mention that the AI's
-first-call discovery questions are also skipped (because aboutYou=false gates them).
+Then confirm the chosen bundle in 1-2 sentences. If all four are off (including the \`"None"\` path),
+mention that the AI's first-call discovery questions are also skipped (because aboutYou=false
+gates them).
 
 After the welcome flow is captured, ask about feedback (\`npsEnabled\`) using this wording (or
 close to it — the key is the framing):

--- a/apps/admin/lib/wizard/__tests__/graph-evaluator.test.ts
+++ b/apps/admin/lib/wizard/__tests__/graph-evaluator.test.ts
@@ -416,6 +416,36 @@ describe("buildGraphFallback", () => {
     expect(fallback.length).toBeGreaterThan(10);
   });
 
+  it("returns full-sentence questions verbatim (no 'Choose your … below.' wrapping)", () => {
+    const board = boardWith({ institutionName: "PAW", interactionPattern: "socratic" });
+    const eval1 = evaluateGraph(board);
+    const toolCalls = [
+      {
+        name: "show_options",
+        input: { question: "What should students see before their first teaching session?" },
+      },
+    ];
+    const fallback = buildGraphFallback(eval1, board, toolCalls);
+    expect(fallback).toBe("What should students see before their first teaching session?");
+    expect(fallback).not.toContain("Choose your");
+  });
+
+  it("wraps short noun-phrase show_options labels with 'Choose your … below.'", () => {
+    const board = boardWith({ institutionName: "PAW" });
+    const eval1 = evaluateGraph(board);
+    const toolCalls = [{ name: "show_options", input: { question: "audience" } }];
+    const fallback = buildGraphFallback(eval1, board, toolCalls);
+    expect(fallback).toBe("Choose your **audience** below.");
+  });
+
+  it("falls back to 'Pick an option below.' when show_options has no question", () => {
+    const board = boardWith({ institutionName: "PAW" });
+    const eval1 = evaluateGraph(board);
+    const toolCalls = [{ name: "show_options", input: {} }];
+    const fallback = buildGraphFallback(eval1, board, toolCalls);
+    expect(fallback).toBe("Pick an option below.");
+  });
+
   it("offers launch when all fields collected", () => {
     const board = boardWith({
       institutionName: "PAW",

--- a/apps/admin/lib/wizard/graph-evaluator.ts
+++ b/apps/admin/lib/wizard/graph-evaluator.ts
@@ -448,9 +448,12 @@ export function buildGraphFallback(
   if (names.has("show_options")) {
     const optionCall = toolCalls.find((tc) => tc.name === "show_options");
     const question = optionCall?.input?.question as string | undefined;
-    return question
-      ? `Choose your **${question.toLowerCase()}** below.`
-      : "Pick an option below.";
+    if (!question) return "Pick an option below.";
+    // Full-sentence interrogatives (e.g. "What should students see…?") are returned
+    // verbatim — wrapping them in "Choose your … below." produces broken grammar.
+    // Short noun-phrase labels (e.g. "audience") still get the wrapping.
+    if (question.trim().endsWith("?")) return question;
+    return `Choose your **${question.toLowerCase()}** below.`;
   }
   if (names.has("show_suggestions")) {
     const suggCall = toolCalls.find((tc) => tc.name === "show_suggestions");

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.277",
+  "version": "0.7.278",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- D1: graph-evaluator fallback no longer wraps full-sentence questions in "Choose your **{q}** below." — interrogatives are returned verbatim
- D2: OptionsCard offers a discoverable "all four off" path on `_welcomePhases` — Confirm enabled at zero ticks, labelled "None of these", sends `"None"` to the AI; both V4 + V5 prompts gain a `"None"` parsing rule
- D3: `welcomeChecklistActive` guard extended to history+keys-unset, blocking stale "create the course" chips after the checklist resolves with welcome keys still unset

## Test plan
- [x] 3 new unit tests for D1 in `graph-evaluator.test.ts` (verbatim, wrapped, fallback) — pass
- [x] 3510/3510 vitest pass; tsc clean for changed files; no new lint warnings
- [x] V5 eval: Test 4b (`"None"` → all-off) + Test 4c (amendment path) added to `v5-welcome-flow.yaml`
- [x] V4 eval: Test 4b mirror added to `v4-welcome-flow.yaml`
- [x] End-to-end V5 wizard run on hf-dev: Phase 4b → 4c (clean checklist, no malformed chip) → recommended-bundle path → NPS → Phase 5 → create_course; no errors
- [ ] Explicit "None of these" zero-tick path: not yet exercised end-to-end, but unit + eval coverage in place

## Note
Branch is based on `3f6001a5`; main has moved to `0fe5d925` (#256/#257/#259 merged after this branch). Will need rebase before merge — files touched here don't overlap with those PRs (this PR: wizard chat + chip rendering + welcome prompt; those PRs: authored modules display + outcomes parsing).

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)