### PR TITLE
feat: wizard surfaces curriculum module-source signal (#262)

### DIFF
--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -349,7 +349,7 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
       "draftCallerName", "draftDemoCallerId", "draftDemoCallerName",
       "launched", "sourceId", "packSubjectIds", "uploadSourceIds", "extractionTotals", "categoryCounts", "contentSkipped",
       "lastUploadClassifications", "courseContext",
-      "coursePedagogy", "courseRefDigest", "courseRefEnabled", "_docConfigKeys",
+      "coursePedagogy", "courseRefDigest", "courseRefEnabled", "_docConfigKeys", "curriculumPath",
       "welcomeSkipped", "tuneSkipped",
       "communityMode", "draftCohortGroupId", "communityJoinToken", "communityHubUrl",
     ];
@@ -961,6 +961,22 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
             ? `${rawSourceText}\n---\n${joinedAssertions}`
             : joinedAssertions;
           const pedagogy = detectPedagogy(combinedText);
+
+          // #262 — wizard-time curriculum path signal (authored vs generated).
+          // Header-based only: textSample (1000 chars) reliably contains the
+          // "**Modules authored:** Yes|No|Partial" declaration but rarely the
+          // full Module Catalogue table. Soft language reflects this — we
+          // record the educator's *declaration*, not a guarantee the catalogue
+          // will parse. The full parse runs post-creation in import-modules.
+          try {
+            const { detectAuthoredModules } = await import("@/lib/wizard/detect-authored-modules");
+            const detected = detectAuthoredModules(combinedText);
+            const curriculumPath = detected.modulesAuthored === true ? "authored" : "generated";
+            setData("curriculumPath", curriculumPath);
+            console.log("[wizard] curriculumPath:", curriculumPath, "detectedFrom:", detected.detectedFrom);
+          } catch (err) {
+            console.warn("[wizard] detectAuthoredModules failed:", err);
+          }
           if (hasPedagogy(pedagogy)) {
             setData("coursePedagogy", pedagogy);
             console.log("[wizard] detected pedagogy from course ref:", pedagogy);

--- a/apps/admin/evals/wizard/v5-curriculum-path.yaml
+++ b/apps/admin/evals/wizard/v5-curriculum-path.yaml
@@ -1,0 +1,210 @@
+description: "Wizard V5 — curriculum path signal (authored vs generated, #262)"
+
+# Run with: npx promptfoo eval -c evals/wizard/v5-curriculum-path.yaml --no-cache
+#
+# Tests the wizard-time signal of whether the post-creation curriculum will use
+# the educator's authored module catalogue OR be AI-generated. The signal is
+# set in setupData.curriculumPath ("authored" | "generated") by
+# ConversationalWizard.tsx after detecting the "**Modules authored:**
+# Yes|No|Partial" header in the COURSE_REFERENCE doc's textSample.
+#
+# The system prompt's curriculumPathOverlay (v5-system-prompt.ts) injects
+# guidance for the deep-reflection turn AND the Phase 5 summary "Curriculum:"
+# line.
+#
+# Soft language requirement (TL review): the wizard reads only the header in
+# the first ~1000 chars; the catalogue table almost always falls beyond that.
+# So the AI must record the educator's *declaration*, not promise specific
+# module counts or names.
+
+prompts:
+  - id: v5-curriculum-path-prompt
+    label: "V5 — curriculum path overlay + Phase 5 summary"
+    raw: |
+      You are the HumanFirst Studio setup assistant.
+
+      ## How you communicate
+      - **Bold the opening concept of each sentence or bullet.**
+      - NEVER expose internal field names like `curriculumPath` or `setupData.*`.
+      - NEVER output XML tags in your text responses.
+
+      ## Course reference deep reflection
+
+      When you receive "Teaching guide analyzed", synthesize what you found in 5-8 sentences
+      with one topic per paragraph (bold lead). End with: "Does that capture how you want me
+      to teach?" then call show_suggestions with EXACTLY ["That's exactly right", "I'd change something"].
+
+      ## Summary and launch
+
+      When all required fields are collected:
+
+        "Here's what we've set up:
+        - **Organisation:** [name]
+        - **Subject:** [discipline]
+        - **Course:** [name]
+        - **Approach:** [description]
+        - **Sessions:** [count] × [duration] min
+        - **Coverage:** [emphasis]
+        - **Teaching materials:** [count]
+        - **Personality:** [preset]
+        - **Welcome:** [first ~20 words]
+        - **Welcome flow:** [human bundle]
+        - **Curriculum:** [If setupData.curriculumPath === "authored": "module catalogue declared in your teaching guide — I'll parse it during course creation". If "generated" or missing: "AI-generated from your outcomes and content".]
+        - **Feedback (NPS):** [on/off]
+
+        Ready to create your course?"
+
+      ## Curriculum path overlay (injected dynamically based on setupData.curriculumPath)
+
+      {{curriculumPathOverlay}}
+
+      ---
+      Setup state: {{setupState}}
+      Conversation so far: {{conversationContext}}
+      The educator says: {{userMessage}}
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 1500
+      tools:
+        - name: show_suggestions
+          description: "Show clickable quick-reply chips"
+          input_schema:
+            type: object
+            properties:
+              question: { type: string }
+              suggestions: { type: array, items: { type: string } }
+            required: [question, suggestions]
+        - name: update_setup
+          description: "Save collected setup fields"
+          input_schema:
+            type: object
+            properties:
+              fields:
+                type: object
+                additionalProperties: true
+            required: [fields]
+
+tests:
+
+  # ── Test 1 — Deep reflection, authored path mentions module catalogue ──
+
+  - description: "Test 1 — Deep reflection (curriculumPath=authored) mentions module catalogue declared, not AI generation"
+    vars:
+      curriculumPathOverlay: |
+        ### Curriculum path — authored
+
+        The educator's course reference declares an authored module catalogue
+        (`**Modules authored: Yes**` or `Partial`).
+        When you narrate the course-ref deep reflection, include a line such as:
+          "Your module catalogue is declared — I'll parse it during course creation
+          and use your modules as the learning sequence."
+        Do NOT promise specific module counts or names — the full table parses
+        post-creation.
+      setupState: "courseRefDigest: present, curriculumPath: authored, courseName: 'GCSE Biology', subjectDiscipline: 'Biology'"
+      conversationContext: |
+        The educator just uploaded a COURSE_REFERENCE doc that declares
+        "**Modules authored: Yes**" in its header. The wizard set
+        setupData.curriculumPath = "authored".
+      userMessage: "Teaching guide analyzed"
+    assert:
+      - type: llm-rubric
+        value: "Response prose mentions that the educator's module catalogue / authored modules are declared, will be parsed, or will be used during course creation. Does NOT say modules will be 'AI-generated' or 'I'll generate modules'. Does NOT promise specific module counts or names."
+      - type: not-icontains
+        value: "AI-generated"
+      - type: not-icontains
+        value: "I'll generate modules"
+
+  # ── Test 2 — Deep reflection, generated path mentions AI generation ──
+
+  - description: "Test 2 — Deep reflection (curriculumPath=generated) mentions AI generation, not authored"
+    vars:
+      curriculumPathOverlay: |
+        ### Curriculum path — generated
+
+        The educator's course reference does NOT declare an authored module
+        catalogue. When you narrate the course-ref deep reflection, include a
+        line such as:
+          "I didn't see a module catalogue, so I'll generate modules from your
+          learning outcomes and uploaded content after creation."
+      setupState: "courseRefDigest: present, curriculumPath: generated, courseName: 'IELTS Speaking', subjectDiscipline: 'ESL'"
+      conversationContext: |
+        The educator just uploaded a COURSE_REFERENCE doc that does NOT declare
+        a module catalogue. The wizard set setupData.curriculumPath = "generated".
+      userMessage: "Teaching guide analyzed"
+    assert:
+      - type: llm-rubric
+        value: "Response prose mentions modules will be generated from learning outcomes and uploaded content (or AI-generated). Does NOT claim authored modules will be used or that a module catalogue is declared."
+      - type: not-icontains
+        value: "module catalogue declared"
+
+  # ── Test 3 — Phase 5 summary, authored path includes Curriculum: declared line ──
+
+  - description: "Test 3 — Phase 5 summary with curriculumPath=authored has Curriculum: 'declared' line"
+    vars:
+      curriculumPathOverlay: |
+        ### Curriculum path — authored
+
+        In the Phase 5 summary, the **Curriculum:** line MUST read:
+          "module catalogue declared in your teaching guide — I'll parse it during course creation"
+      setupState: |
+        All required fields collected. setupData.curriculumPath = "authored".
+        Organisation: Highfield Academy. Subject: Financial Services.
+        Course: R04 Investment Principles. Approach: Structured. Sessions: 8 × 20 min.
+        Welcome flow: Goals + About You. NPS: on.
+      conversationContext: "The user has confirmed everything and asked for the summary."
+      userMessage: "Show me the summary now"
+    assert:
+      - type: icontains
+        value: "Curriculum:"
+      - type: llm-rubric
+        value: "The 'Curriculum:' line in the summary explicitly states the module catalogue is declared (in the teaching guide / course reference) and will be parsed during course creation. Does NOT say 'AI-generated'."
+      - type: not-icontains
+        value: "AI-generated from your outcomes"
+
+  # ── Test 4 — Phase 5 summary, generated path includes Curriculum: AI-generated line ──
+
+  - description: "Test 4 — Phase 5 summary with curriculumPath=generated has Curriculum: 'AI-generated' line"
+    vars:
+      curriculumPathOverlay: |
+        ### Curriculum path — generated
+
+        In the Phase 5 summary, the **Curriculum:** line MUST read:
+          "AI-generated from your outcomes and content"
+      setupState: |
+        All required fields collected. setupData.curriculumPath = "generated".
+        Organisation: Westfield. Subject: ESL. Course: IELTS Speaking. Approach: Practice.
+        Sessions: continuous. Welcome flow: Goals + About You + Knowledge Check.
+      conversationContext: "The user has confirmed everything and asked for the summary."
+      userMessage: "Show me the summary now"
+    assert:
+      - type: icontains
+        value: "Curriculum:"
+      - type: llm-rubric
+        value: "The 'Curriculum:' line in the summary states modules will be AI-generated from the educator's outcomes and content. Does NOT claim a module catalogue is declared, parsed, or coming from the teaching guide."
+      - type: not-icontains
+        value: "module catalogue declared"
+
+  # ── Test 5 — Soft language guard: authored path doesn't promise module counts ──
+
+  - description: "Test 5 — Authored path uses soft language; never promises specific module counts or names"
+    vars:
+      curriculumPathOverlay: |
+        ### Curriculum path — authored
+
+        The educator's course reference declares an authored module catalogue.
+        Do NOT promise specific module counts or names — the full table parses
+        post-creation. Use language like "I'll parse it during course creation"
+        or "module catalogue declared", NOT "I'll use your 8 modules" or
+        "I see modules called X, Y, Z".
+      setupState: "curriculumPath: authored, courseRefDigest: present"
+      conversationContext: |
+        The educator uploaded a COURSE_REFERENCE doc declaring authored modules.
+        The wizard read only the header (first 1000 chars). The catalogue table
+        is beyond the textSample limit — exact module count and names are NOT
+        available wizard-time.
+      userMessage: "Teaching guide analyzed"
+    assert:
+      - type: llm-rubric
+        value: "Response avoids stating specific module counts (e.g. 'your 8 modules', '12-module curriculum', 'modules 1 through N') or specific module names. Uses softer language acknowledging the declaration without promising parsed details."

--- a/apps/admin/lib/chat/v5-system-prompt.ts
+++ b/apps/admin/lib/chat/v5-system-prompt.ts
@@ -532,6 +532,7 @@ When all required fields are collected (Can launch: YES):
   - **Personality:** [preset + description]
   - **Welcome:** [first ~20 words, or 'default']
   - **Welcome flow:** [human bundle of enabled phases joined with " + ", with disabled phases in parentheses; e.g. "Goals + About You (Knowledge Check off, AI Intro off)". When all four are off, write "none — direct entry to teaching".]
+  - **Curriculum:** [If setupData.curriculumPath === "authored": "module catalogue declared in your teaching guide — I'll parse it during course creation". If "generated" or missing: "AI-generated from your outcomes and content".]
   - **Feedback (NPS):** [on/off]
 
   Ready to create your course?"
@@ -698,6 +699,40 @@ export async function buildV5SystemPrompt(
     pedagogyOverlay = lines.join("\n");
   }
 
+  // ── Curriculum path overlay (#262) ──────────────────────
+  // Wizard-time signal of whether the post-creation curriculum will use the
+  // educator's authored module catalogue or be AI-generated. Detected from
+  // the COURSE_REFERENCE doc's textSample header. Soft language — we record
+  // the *declaration*, not a guarantee the catalogue will parse cleanly.
+  let curriculumPathOverlay = "";
+  const curriculumPath = setupData.curriculumPath as "authored" | "generated" | undefined;
+  if (curriculumPath === "authored") {
+    curriculumPathOverlay = [
+      "",
+      "### Curriculum path — authored",
+      "",
+      "The educator's course reference declares an authored module catalogue (`**Modules authored: Yes**` or `Partial`).",
+      "When you narrate the course-ref deep reflection, include a line such as:",
+      `  "Your module catalogue is declared — I'll parse it during course creation and use your modules as the learning sequence."`,
+      "Do NOT promise specific module counts or names — the full table parses post-creation.",
+      "In the Phase 5 summary, the **Curriculum:** line MUST read:",
+      `  "module catalogue declared in your teaching guide — I'll parse it during course creation"`,
+      "",
+    ].join("\n");
+  } else if (curriculumPath === "generated") {
+    curriculumPathOverlay = [
+      "",
+      "### Curriculum path — generated",
+      "",
+      "The educator's course reference does NOT declare an authored module catalogue.",
+      "When you narrate the course-ref deep reflection, include a line such as:",
+      `  "I didn't see a module catalogue, so I'll generate modules from your learning outcomes and uploaded content after creation."`,
+      "In the Phase 5 summary, the **Curriculum:** line MUST read:",
+      `  "AI-generated from your outcomes and content"`,
+      "",
+    ].join("\n");
+  }
+
   const nonCommunityValues = !isCommunity
     ? `### Teaching emphasis (teachingMode)
 - recall, comprehension (default), practice, syllabus
@@ -841,6 +876,7 @@ See "Welcome flow proposal" below for the full pattern.
     playback,
     proposal,
     content,
+    curriculumPathOverlay,
     pedagogySection,
     values,
     rules,

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.277",
+  "version": "0.7.278",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- New `setupData.curriculumPath` signal in V5 wizard distinguishing **authored** module catalogue (parsed from course-reference doc) vs **AI-generated** modules (from outcomes + content)
- Surfaces in two places: (1) deep-reflection turn after course-ref upload; (2) new "Curriculum:" line in the Phase 5 Summary
- Detection is header-based (`**Modules authored:** Yes/Partial/No`) — reads only what reliably fits in `textSample` (~1000 chars). Soft language: prompt forbids promising specific module counts or names because the full Module Catalogue parse happens post-creation in `import-modules`

## Test plan
- [x] 3518/3518 vitest pass; tsc clean for changed files; no new lint issues
- [x] 5 promptfoo eval tests in `evals/wizard/v5-curriculum-path.yaml` (deep reflection × 2 paths, Phase 5 summary × 2 paths, soft-language guard)
- [ ] hf-dev smoke test: upload a course-ref doc that declares `**Modules authored: Yes**` → wizard reflection mentions module catalogue, Phase 5 summary has "Curriculum:" with declared phrasing
- [ ] hf-dev smoke test: upload a course-ref doc with no module declaration → reflection says AI-generation, Phase 5 line says "AI-generated"

## Notes
- Branched from latest `main` (`fcde7c13`) so this PR is independent of #264 (#255 fix)
- No migration; no schema changes
- V4 prompt path is dead code (`/api/chat/route.ts` only uses V5) per Tech Lead review on #262 — no V4 changes needed

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)