### PR TITLE
feat: tutor opens with learner module-status narrative (#266 Slice 1)

### DIFF
--- a/apps/admin/evals/tutor/module-status-narrative.yaml
+++ b/apps/admin/evals/tutor/module-status-narrative.yaml
@@ -1,0 +1,125 @@
+description: "Tutor opening — module-status narrative for authored courses (#266)"
+
+# Run with: npx promptfoo eval -c evals/tutor/module-status-narrative.yaml --no-cache
+#
+# Tests the AI tutor's opening turn when the playbook has authored modules AND
+# per-learner attempt data exists. The composed system prompt should include:
+#   - _quickStart.curriculum_progress: multi-line module status block
+#   - _quickStart.first_line: soft instruction to open by referencing progress
+#
+# The tutor's first utterance should:
+#   - Reference the learner's module history in plain language (not enum names)
+#   - Use the right vocabulary ("done", "in progress", "not started")
+#   - NOT read the list verbatim
+#   - Transition naturally into the active module
+#
+# When modulesAuthored is NOT set, the legacy reconnect line is preserved
+# (regression check).
+
+prompts:
+  - id: tutor-module-status-prompt
+    label: "Tutor opening — module-status injection"
+    raw: |
+      You are an AI tutor running a 1-to-1 voice/text teaching session.
+
+      ## How you communicate
+      - Warm, brief, conversational. 1-2 sentences for the opening.
+      - NEVER read lists verbatim. NEVER expose internal field names.
+      - Use plain language: "done", "in progress", "not started".
+
+      ## _quickStart context (instant orientation)
+
+      {{quickStartContext}}
+
+      ## Opening instruction
+
+      {{firstLineInstruction}}
+
+      ---
+      The learner has just joined the session. Speak first — your opening line.
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 400
+
+defaultTest:
+  vars: {}
+
+tests:
+
+  # ── Test 1 — Authored + attempt data: tutor narrates progress ──
+
+  - description: "Test 1 — Authored course with attempt data: tutor opening references module progress"
+    vars:
+      quickStartContext: |
+        Module progress (3 authored modules):
+          - Baseline: 2 sessions, done
+          - Part 1: 1 session, in progress
+          - Part 2: not started
+      firstLineInstruction: |
+        Open by referencing the learner's module progress (see Module progress above) in plain language —
+        name what they've done and how many times, then transition naturally into IELTS Speaking.
+        Keep it warm and brief; do NOT read the list verbatim.
+      userMessage: ""
+    assert:
+      - type: llm-rubric
+        value: "The opening line references the learner's module history in plain language — at minimum mentions Baseline (with 'done' or 'twice' or '2 sessions') OR Part 1 (with 'in progress' or 'continue'). Does NOT read the bullet list verbatim. Transitions toward today's session naturally."
+      - type: not-icontains
+        value: "NOT_STARTED"
+      - type: not-icontains
+        value: "IN_PROGRESS"
+      - type: not-icontains
+        value: "COMPLETED"
+
+  # ── Test 2 — Authored, no attempts (first session): no progress narrative ──
+
+  - description: "Test 2 — Authored course, no attempts yet: tutor uses warm reconnect line, no module status reference"
+    vars:
+      quickStartContext: |
+        Module progress (3 authored modules):
+          - Baseline: not started
+          - Part 1: not started
+          - Part 2: not started
+      firstLineInstruction: |
+        Good to reconnect. Ready to pick up where we left off?
+      userMessage: ""
+    assert:
+      - type: llm-rubric
+        value: "The opening line is a warm greeting. Does NOT mention specific modules by name (Baseline, Part 1, Part 2) since there's no progress to reference. Does NOT claim the learner has done anything yet."
+
+  # ── Test 3 — Non-authored course: no module status block, legacy opening ──
+
+  - description: "Test 3 — Non-authored course: tutor opens with generic reconnect line"
+    vars:
+      quickStartContext: |
+        Progress: 2/5 modules mastered | Current: Module 3
+      firstLineInstruction: |
+        Good to reconnect. Ready to pick up where we left off with Biology?
+      userMessage: ""
+    assert:
+      - type: llm-rubric
+        value: "The opening line is a warm reconnect greeting referencing Biology. Does NOT claim specific authored module names (Baseline, Part 1, etc) since the context only shows aggregate progress."
+      - type: not-icontains
+        value: "Module progress"
+      - type: not-icontains
+        value: "Baseline"
+
+  # ── Test 4 — Soft language: tutor doesn't promise specific assertion details ──
+
+  - description: "Test 4 — Authored with attempt data: opening stays warm and brief, no list dump"
+    vars:
+      quickStartContext: |
+        Module progress (4 authored modules):
+          - Vocabulary: 3 sessions, done
+          - Listening: 2 sessions, in progress
+          - Speaking: 1 session, in progress
+          - Writing: not started
+      firstLineInstruction: |
+        Open by referencing the learner's module progress in plain language —
+        name what they've done and how many times, then transition naturally into IELTS prep.
+        Keep it warm and brief; do NOT read the list verbatim.
+      userMessage: ""
+    assert:
+      - type: llm-rubric
+        value: "The opening line is BRIEF (one or two sentences max). Does NOT enumerate all four modules in a list. Does reference at least one specific module by name with a count or status indicator."

--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -626,6 +626,46 @@ export async function computeSharedState(
   // Determine if this is the final teaching session
   const pbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, any>;
   const sessionCount = pbConfig.sessionCount as number | undefined;
+
+  // ── #266 Slice 1: per-learner module progress (authored courses only) ──
+  // Source of truth for "you've done Baseline twice" narratives. Reads
+  // CallerModuleProgress, which is incremented inside updateModuleMastery
+  // (track-progress.ts) at session end — so the count the tutor sees at the
+  // start of a session reflects completed sessions only. Indexed on
+  // [callerId, status] (schema.prisma) → cheap.
+  let moduleAttemptCounts: SharedComputedState["moduleAttemptCounts"] = undefined;
+  let hasAttemptData = false;
+  if (pbConfig.modulesAuthored === true && curriculumId && data.caller?.id) {
+    try {
+      const rows = await prisma.callerModuleProgress.findMany({
+        where: {
+          callerId: data.caller.id,
+          module: { curriculumId },
+        },
+        select: {
+          moduleId: true,
+          callCount: true,
+          status: true,
+          completedAt: true,
+        },
+      });
+      moduleAttemptCounts = {};
+      for (const row of rows) {
+        moduleAttemptCounts[row.moduleId] = {
+          callCount: row.callCount,
+          status: (row.status as "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED") ?? "NOT_STARTED",
+          completedAt: row.completedAt,
+        };
+        if (row.callCount > 0) hasAttemptData = true;
+      }
+      console.log(
+        `[modules] #266: loaded ${rows.length} CallerModuleProgress rows; hasAttemptData=${hasAttemptData}`,
+      );
+    } catch (err) {
+      console.warn("[modules] #266: callerModuleProgress query failed (non-blocking):", err);
+    }
+  }
+
   const callNumber = data.recentCalls.length + 1; // 1-based: this is the Nth call
   const isFinalByBudget = !!(sessionCount && sessionCount > 0 && callNumber >= sessionCount);
   const isFinalByScheduler = schedulerTotalLOs > 0 && schedulerTotalMastered >= schedulerTotalLOs;
@@ -659,6 +699,9 @@ export async function computeSharedState(
     // #155 + #164: scheduler decision + policy for downstream transforms
     schedulerDecision,
     schedulerPolicy,
+    // #266 Slice 1: per-learner module progress (authored courses only)
+    moduleAttemptCounts,
+    hasAttemptData,
   };
 }
 
@@ -707,6 +750,15 @@ registerTransform("computeModuleProgress", (
     return "not_started";
   };
 
+  // #266 Slice 1: per-learner attempt counts, when available
+  const moduleAttemptCounts = sharedState.moduleAttemptCounts;
+  const hasAttemptData = sharedState.hasAttemptData === true;
+  const STATUS_LABEL: Record<"NOT_STARTED" | "IN_PROGRESS" | "COMPLETED", string> = {
+    NOT_STARTED: "not started",
+    IN_PROGRESS: "in progress",
+    COMPLETED: "done",
+  };
+
   return {
     name: (sharedState as Record<string, any>).curriculumName || null,
     hasData: curriculumAttrs.length > 0 || modules.length > 0,
@@ -716,19 +768,39 @@ registerTransform("computeModuleProgress", (
     completedCount: completedModules.size,
     estimatedProgress,
     masteryThreshold,
-    modules: modules.map((m: ModuleData, idx: number) => ({
-      id: m.id,
-      slug: m.slug || m.id || '',
-      name: m.name,
-      description: m.description,
-      order: m.sortOrder ?? m.sequence,
-      prerequisites: m.prerequisites,
-      masteryThreshold: m.masteryThreshold ?? masteryThreshold,
-      isCompleted: completedModules.has(getModuleKey(m)),
-      status: getModuleStatus(m, idx),
-      // Include module content for LLM context
-      content: m.content,
-    })),
+    // #266 Slice 1: gates module-aware opening line in _quickStart.first_line
+    hasAttemptData,
+    modules: modules.map((m: ModuleData, idx: number) => {
+      const learnerProgress = m.id ? moduleAttemptCounts?.[m.id] : undefined;
+      const callCount = learnerProgress?.callCount ?? 0;
+      const learnerStatus = learnerProgress?.status;
+      // Prefer authored learner status when present; otherwise fall back to the
+      // attribute-derived status used by every existing course.
+      const renderedStatus: "completed" | "in_progress" | "not_started" =
+        learnerStatus === "COMPLETED" ? "completed"
+          : learnerStatus === "IN_PROGRESS" ? "in_progress"
+          : learnerStatus === "NOT_STARTED" ? "not_started"
+          : getModuleStatus(m, idx);
+      return {
+        id: m.id,
+        slug: m.slug || m.id || '',
+        name: m.name,
+        description: m.description,
+        order: m.sortOrder ?? m.sequence,
+        prerequisites: m.prerequisites,
+        masteryThreshold: m.masteryThreshold ?? masteryThreshold,
+        isCompleted: renderedStatus === "completed",
+        status: renderedStatus,
+        // #266 Slice 1: per-learner attempt count (0 when no progress row, or when modulesAuthored !== true)
+        callCount,
+        statusLabel: STATUS_LABEL[
+          learnerStatus
+            ?? (renderedStatus === "completed" ? "COMPLETED" : renderedStatus === "in_progress" ? "IN_PROGRESS" : "NOT_STARTED")
+        ],
+        // Include module content for LLM context
+        content: m.content,
+      };
+    }),
     nextModule: nextModule ? {
       id: nextModule.id,
       slug: nextModule.slug || nextModule.id,

--- a/apps/admin/lib/prompt/composition/transforms/quickstart.ts
+++ b/apps/admin/lib/prompt/composition/transforms/quickstart.ts
@@ -80,7 +80,7 @@ registerTransform("computeQuickStart", (
   context: AssembledContext,
 ) => {
   const { sharedState, loadedData, resolvedSpecs, sections } = context;
-  const { modules, isFirstCall, completedModules, moduleToReview, nextModule, thresholds, callNumber, schedulerDecision, schedulerPolicy } = sharedState;
+  const { modules, isFirstCall, completedModules, moduleToReview, nextModule, thresholds, callNumber, schedulerDecision, schedulerPolicy, moduleAttemptCounts, hasAttemptData } = sharedState;
   const caller = loadedData.caller;
   const learnerGoals = loadedData.goals;
   const identitySpec = resolvedSpecs.identitySpec;
@@ -361,6 +361,29 @@ registerTransform("computeQuickStart", (
       : null,
 
     curriculum_progress: modules.length > 0 ? (() => {
+      // #266 Slice 1: when the playbook has authored modules AND we have
+      // per-learner attempt data, render a multi-line block the tutor can
+      // narrate (e.g. "Baseline — 2 sessions, done"). Falls back to the
+      // single-line summary for non-authored or never-attempted courses.
+      const isAuthoredWithData =
+        pbConfig.modulesAuthored === true && !!moduleAttemptCounts;
+      if (isAuthoredWithData) {
+        const STATUS_LABEL: Record<"NOT_STARTED" | "IN_PROGRESS" | "COMPLETED", string> = {
+          NOT_STARTED: "not started",
+          IN_PROGRESS: "in progress",
+          COMPLETED: "done",
+        };
+        const lines = modules.map((m) => {
+          const id = m.id || m.slug || "";
+          const progress = id ? moduleAttemptCounts?.[id] : undefined;
+          const status = (progress?.status ?? "NOT_STARTED") as "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+          const count = progress?.callCount ?? 0;
+          const sessions =
+            count === 0 ? "not started" : `${count} ${count === 1 ? "session" : "sessions"}, ${STATUS_LABEL[status]}`;
+          return `  - ${m.name || m.slug || id}: ${sessions}`;
+        });
+        return [`Module progress (${modules.length} authored modules):`, ...lines].join("\n");
+      }
       const completed = completedModules.size;
       const total = modules.length;
       const currentModuleName = moduleToReview?.name || nextModule?.name;
@@ -447,6 +470,23 @@ registerTransform("computeQuickStart", (
         }
         return msg;
       };
+
+      // 0. #266 Slice 1: module-aware opening for authored courses with
+      // attempt history. Soft instruction (data section + intent), not a
+      // scripted line — TUT-001 persona drives wording.
+      if (
+        !isFirstCall &&
+        pbConfig.modulesAuthored === true &&
+        hasAttemptData === true &&
+        modules.length > 0
+      ) {
+        return [
+          "Open by referencing the learner's module progress (see Module progress above) in plain language —",
+          "name what they've done and how many times, then transition naturally into",
+          subjectRef ? `${subjectRef}. ` : "today's teaching. ",
+          "Keep it warm and brief; do NOT read the list verbatim.",
+        ].join(" ");
+      }
 
       // 1. Identity spec instruction (highest priority — persona spec)
       const identityOpening = (identitySpec?.config as SpecConfig)?.sessionStructure?.opening?.instruction;

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -260,6 +260,21 @@ export interface SharedComputedState {
   isFirstCallInDomain?: boolean;
   /** Whether this is the learner's final teaching session (by budget, scheduler mastery, or module completion) */
   isFinalSession: boolean;
+  /**
+   * Per-module learner progress, keyed by `CurriculumModule.id`. Populated only
+   * when the playbook has `modulesAuthored === true`. First place
+   * `CallerModuleProgress` reads land in the COMPOSE stage — the per-learner
+   * dimension entering a section that has been per-module-only until now.
+   * Used by the tutor opening narrative ("you've done Baseline twice") and
+   * future in-chat module selection (Slice 2 of #266).
+   */
+  moduleAttemptCounts?: Record<string, {
+    callCount: number;
+    status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+    completedAt: Date | null;
+  }>;
+  /** True when at least one module has callCount > 0. Gates the tutor's module-aware opening line. */
+  hasAttemptData?: boolean;
   /** Call number (1-based) — this is the Nth call for this learner */
   callNumber: number;
   /** Synthetic lesson plan entry built from scheduler working set (for downstream transform compat) */

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.277",
+  "version": "0.7.278",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/composition/modules.test.ts
+++ b/apps/admin/tests/lib/composition/modules.test.ts
@@ -360,6 +360,96 @@ describe("computeModuleProgress transform", () => {
     expect(transform).toBeDefined();
     expect(typeof transform).toBe("function");
   });
+
+  // ── #266 Slice 1: per-learner attempt counts ──
+
+  function makeContext(
+    modules: ModuleData[],
+    moduleAttemptCounts: SharedComputedState["moduleAttemptCounts"] = undefined,
+    hasAttemptData = false,
+  ): any {
+    const sharedState = {
+      channel: "text" as const,
+      modules,
+      isFirstCall: false,
+      daysSinceLastCall: 0,
+      completedModules: new Set<string>(),
+      estimatedProgress: 0,
+      lastCompletedIndex: 0,
+      moduleToReview: null,
+      nextModule: null,
+      reviewType: "quick_recall",
+      reviewReason: "",
+      thresholds: { high: 0.65, low: 0.35 },
+      curriculumName: "Test Curriculum",
+      isFinalSession: false,
+      callNumber: 2,
+      moduleAttemptCounts,
+      hasAttemptData,
+    };
+    return {
+      sharedState,
+      loadedData: makeLoadedData({ callCount: 1 }),
+      resolvedSpecs: makeResolvedSpecs(),
+      sections: {},
+      specConfig: {},
+    };
+  }
+
+  it("surfaces hasAttemptData top-level on transform output", () => {
+    const ctx = makeContext(
+      [{ id: "m-1", slug: "baseline", name: "Baseline" }],
+      { "m-1": { callCount: 2, status: "COMPLETED", completedAt: new Date() } },
+      true,
+    );
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.hasAttemptData).toBe(true);
+  });
+
+  it("hasAttemptData is false when no attempts have been recorded", () => {
+    const ctx = makeContext(
+      [{ id: "m-1", slug: "baseline", name: "Baseline" }],
+      undefined,
+      false,
+    );
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.hasAttemptData).toBe(false);
+  });
+
+  it("populates per-module callCount, status, statusLabel from moduleAttemptCounts", () => {
+    const modules: ModuleData[] = [
+      { id: "m-1", slug: "baseline", name: "Baseline" },
+      { id: "m-2", slug: "part-1", name: "Part 1" },
+      { id: "m-3", slug: "part-2", name: "Part 2" },
+    ];
+    const ctx = makeContext(
+      modules,
+      {
+        "m-1": { callCount: 2, status: "COMPLETED", completedAt: new Date() },
+        "m-2": { callCount: 1, status: "IN_PROGRESS", completedAt: null },
+        // m-3 deliberately missing — never attempted
+      },
+      true,
+    );
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.modules).toHaveLength(3);
+    expect(out.modules[0]).toMatchObject({ id: "m-1", callCount: 2, status: "completed", statusLabel: "done", isCompleted: true });
+    expect(out.modules[1]).toMatchObject({ id: "m-2", callCount: 1, status: "in_progress", statusLabel: "in progress", isCompleted: false });
+    expect(out.modules[2]).toMatchObject({ id: "m-3", callCount: 0, statusLabel: "not started", isCompleted: false });
+  });
+
+  it("falls back to attribute-derived status when moduleAttemptCounts is undefined", () => {
+    const modules: ModuleData[] = [{ id: "m-1", slug: "baseline", name: "Baseline" }];
+    const ctx = makeContext(modules, undefined, false);
+    // Override loadedData callCount=0 + lastCompletedIndex=-1 so the legacy
+    // attribute-based getModuleStatus path returns "not_started" (no progress signal).
+    ctx.loadedData = makeLoadedData({ callCount: 0 });
+    ctx.sharedState.lastCompletedIndex = -1;
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.modules[0].callCount).toBe(0);
+    expect(out.modules[0].status).toBe("not_started");
+    expect(out.modules[0].statusLabel).toBe("not started");
+  });
 });
 
 // resolveLessonPlanMode tests removed — function deleted.

--- a/apps/admin/tests/lib/composition/quickstart.test.ts
+++ b/apps/admin/tests/lib/composition/quickstart.test.ts
@@ -224,6 +224,109 @@ describe("computeQuickStart transform", () => {
     expect(result.first_line).toContain("reconnect");
   });
 
+  // ── #266 Slice 1: authored-module narrative + module-aware first_line ──
+
+  it("renders multi-line module-status block when modulesAuthored=true and attempt data exists", () => {
+    const ctx = makeContext({
+      loadedData: {
+        ...makeContext().loadedData,
+        playbooks: [{ id: "pb-1", name: "C", isActive: true, isLatest: true, config: { modulesAuthored: true } } as any],
+      },
+      sharedState: {
+        ...makeContext().sharedState,
+        modules: [
+          { id: "m-1", slug: "baseline", name: "Baseline" },
+          { id: "m-2", slug: "part-1", name: "Part 1" },
+          { id: "m-3", slug: "part-2", name: "Part 2" },
+        ],
+        moduleAttemptCounts: {
+          "m-1": { callCount: 2, status: "COMPLETED", completedAt: new Date() },
+          "m-2": { callCount: 1, status: "IN_PROGRESS", completedAt: null },
+        },
+        hasAttemptData: true,
+      },
+    });
+    const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
+    expect(result.curriculum_progress).toContain("Module progress");
+    expect(result.curriculum_progress).toContain("Baseline");
+    expect(result.curriculum_progress).toContain("2 sessions, done");
+    expect(result.curriculum_progress).toContain("Part 1");
+    expect(result.curriculum_progress).toContain("1 session, in progress");
+    expect(result.curriculum_progress).toContain("Part 2");
+    expect(result.curriculum_progress).toContain("not started");
+  });
+
+  it("falls back to single-line summary when modulesAuthored is not true (regression)", () => {
+    const ctx = makeContext({
+      // playbooks empty by default → modulesAuthored undefined
+      sharedState: {
+        ...makeContext().sharedState,
+        moduleAttemptCounts: {
+          "m1": { callCount: 5, status: "COMPLETED", completedAt: new Date() },
+        },
+        hasAttemptData: true,
+      },
+    });
+    const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
+    expect(result.curriculum_progress).not.toContain("Module progress");
+    expect(result.curriculum_progress).toMatch(/modules mastered|Starting curriculum/);
+  });
+
+  it("first_line emits module-aware opening instruction when modulesAuthored=true and hasAttemptData", () => {
+    const ctx = makeContext({
+      loadedData: {
+        ...makeContext().loadedData,
+        playbooks: [{ id: "pb-1", name: "C", isActive: true, isLatest: true, config: { modulesAuthored: true, subjectDiscipline: "Biology" } } as any],
+      },
+      sharedState: {
+        ...makeContext().sharedState,
+        isFirstCall: false,
+        modules: [{ id: "m-1", slug: "baseline", name: "Baseline" }],
+        moduleAttemptCounts: { "m-1": { callCount: 2, status: "COMPLETED", completedAt: new Date() } },
+        hasAttemptData: true,
+      },
+    });
+    const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
+    expect(result.first_line).toContain("module progress");
+    expect(result.first_line).toContain("Biology");
+    expect(result.first_line).not.toContain("reconnect"); // overrides the legacy reconnect line
+  });
+
+  it("first_line uses legacy reconnect line when modulesAuthored=true but hasAttemptData is false (first-ever attempt)", () => {
+    const ctx = makeContext({
+      loadedData: {
+        ...makeContext().loadedData,
+        playbooks: [{ id: "pb-1", name: "C", isActive: true, isLatest: true, config: { modulesAuthored: true } } as any],
+      },
+      sharedState: {
+        ...makeContext().sharedState,
+        isFirstCall: false,
+        moduleAttemptCounts: {},
+        hasAttemptData: false,
+      },
+    });
+    const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
+    expect(result.first_line).toContain("reconnect");
+    expect(result.first_line).not.toContain("module progress");
+  });
+
+  it("first_line uses legacy first-call line when isFirstCall (regression)", () => {
+    const ctx = makeContext({
+      loadedData: {
+        ...makeContext().loadedData,
+        playbooks: [{ id: "pb-1", name: "C", isActive: true, isLatest: true, config: { modulesAuthored: true } } as any],
+      },
+      sharedState: {
+        ...makeContext().sharedState,
+        isFirstCall: true,
+        hasAttemptData: false,
+      },
+    });
+    const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
+    expect(result.first_line).toContain("ease into this");
+    expect(result.first_line).not.toContain("module progress");
+  });
+
   it("returns first-call first_line for new caller", () => {
     const ctx = makeContext({
       sharedState: { ...makeContext().sharedState, isFirstCall: true },


### PR DESCRIPTION
## Summary

When a course has authored modules, the AI tutor now opens each session referencing the learner's per-module progress in plain language ("You've done Baseline twice — ready for Part 1?") instead of the cold "Good to reconnect" line. Foundation for in-chat module selection (Slice 2) and VAPI/voice (Slice 3).

## Changes

| Layer | Change |
|---|---|
| `lib/prompt/composition/types.ts` | New `moduleAttemptCounts` + `hasAttemptData` on `SharedComputedState` |
| `transforms/modules.ts` `computeSharedState` | Parallel `CallerModuleProgress.findMany` gated on `modulesAuthored && curriculumId`. **First per-learner data in COMPOSE stage** — until now this transform was per-module-only |
| `transforms/modules.ts` `computeModuleProgress` | Surfaces `callCount`, `statusLabel` per module; `hasAttemptData` top-level |
| `transforms/quickstart.ts` `_quickStart.curriculum_progress` | Multi-line block when authored+attempted; legacy single-line otherwise |
| `transforms/quickstart.ts` `_quickStart.first_line` | Soft instruction (data not scripted) when `modulesAuthored && !isFirstCall && hasAttemptData` |
| `evals/tutor/module-status-narrative.yaml` | 4 promptfoo tests (with-status, no-attempts, non-authored, soft-language) |

## Test plan
- [x] 9 new vitest cases (4 in modules.test, 5 in quickstart.test); 3522/3522 pass
- [x] tsc clean for changed files; 0 new lint warnings (reduced 2)
- [x] Regression: non-authored courses see no behaviour change (verified via test)
- [x] Regression: isFirstCall path still uses welcome-flow line (verified via test)
- [ ] hf-dev smoke: SIM session 2 of an authored course opens with progress narrative

## Out of scope (Slice 2 / 3)

- In-chat selection chips (`show_options` with module tiles)
- VAPI/voice FOH endpoint exposing same data shape
- Module catalogue editing UI

## Notes

- Branched off latest `main` (`15b77063`)
- No migration; no schema changes
- Index `@@index([callerId, status])` on `CallerModuleProgress` (existing) keeps the new query cheap

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)