### PR TITLE
fix: pass callerId when admin opens picker from CallerDetailPage (#270)

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -420,6 +420,11 @@ export default function CallerDetailPage() {
   const handlePickModule = useCallback(() => {
     if (selectedPlaybookId === "all" || !selectedPlaybookId) return;
     const sp = new URLSearchParams();
+    // #270: pass callerId so the picker (admin context) can include it on
+    // GET /api/student/module-progress — without it the route returns 400
+    // because requireStudentOrAdmin demands explicit caller selection for
+    // non-STUDENT users.
+    sp.set("callerId", callerId);
     // Strip requestedModuleId from the carry-over so the banner doesn't
     // double-fire when the learner returns from the picker.
     const carryParams = new URLSearchParams(searchParams.toString());

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.278",
+  "version": "0.7.279",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
One-line fix — `handlePickModule` in CallerDetailPage now passes `callerId` in the URL when navigating to `/x/student/[playbookId]/modules`. Picker's admin context can then thread it through to `GET /api/student/module-progress` which requires `?callerId=` for non-STUDENT users.

## Test plan
- [x] tsc clean for changed line (2 pre-existing errors in same file unrelated)
- [x] 3522/3522 vitest pass
- [ ] Manual: admin clicks "Pick module" from CallerDetailPage → picker loads progress without 400 in dev log

Closes #270