### PR TITLE
fix: tutor discovery_guidance skips name probe when caller name on file (#268 follow-up)

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/quickstart.ts
+++ b/apps/admin/lib/prompt/composition/transforms/quickstart.ts
@@ -601,9 +601,15 @@ registerTransform("computeQuickStart", (
       }
 
       // COLD_START — discovery is on. Append granular skips for partial opt-outs.
-      const parts: string[] = [
-        "This is a new learner with no prior data. Start with a warm welcome, then discover their name, goals, and prior experience before teaching.",
-      ];
+      // #268 follow-up: when caller.name is already on file (joined via magic
+      // link, prior session, or admin-created), drop the "discover their name"
+      // instruction and direct the tutor to use it. The welcome-message strip
+      // alone wasn't enough — this guidance was re-prompting the AI to ask.
+      const knownName = caller?.name;
+      const opener = knownName
+        ? `This is a new learner — their name is already on file as ${knownName}. Greet them by name. Do NOT ask for their name. Discover their goals and prior experience before teaching.`
+        : "This is a new learner with no prior data. Start with a warm welcome, then discover their name, goals, and prior experience before teaching.";
+      const parts: string[] = [opener];
       if (!askGoals) parts.push("Do NOT ask about their learning goals — the educator has captured these elsewhere.");
       if (!askAboutYou) parts.push("Do NOT ask about their motivation or confidence.");
       if (!askKnowledge) parts.push("Do NOT probe their prior knowledge level.");

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.279",
+  "version": "0.7.280",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/composition/quickstart.test.ts
+++ b/apps/admin/tests/lib/composition/quickstart.test.ts
@@ -650,13 +650,37 @@ describe("computeQuickStart transform", () => {
     expect(result.discovery_guidance).toBeNull();
   });
 
-  it("returns COLD_START guidance when no pre-survey attributes exist", () => {
+  it("returns COLD_START guidance when no pre-survey attributes AND no caller.name", () => {
     const ctx = makeContext({
       sharedState: { ...makeContext().sharedState, isFirstCall: true },
+      loadedData: {
+        ...makeContext().loadedData,
+        caller: { id: "c1", name: null, email: null, phone: null, externalId: null, domain: null },
+      },
     });
     const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
     expect(result.discovery_guidance).toContain("new learner");
     expect(result.discovery_guidance).toContain("discover their name");
+  });
+
+  // ── #268 follow-up: COLD_START with caller.name on file ──
+
+  it("COLD_START: when caller.name is on file, instructs greet-by-name and skips name discovery", () => {
+    const ctx = makeContext({
+      sharedState: { ...makeContext().sharedState, isFirstCall: true },
+      loadedData: {
+        ...makeContext().loadedData,
+        caller: { id: "c1", name: "Wyatt Diallo", email: null, phone: null, externalId: null, domain: null },
+        // No PRE-survey or personality data → still COLD_START
+        callerAttributes: [],
+      },
+    });
+    const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
+    expect(result.discovery_guidance).toContain("Wyatt Diallo");
+    expect(result.discovery_guidance).toContain("Do NOT ask for their name");
+    expect(result.discovery_guidance).not.toContain("discover their name");
+    // Still discovers goals + experience (not yet known)
+    expect(result.discovery_guidance).toContain("goals");
   });
 
   it("returns PRE_LOADED guidance when caller has pre-survey goal", () => {
@@ -746,6 +770,8 @@ describe("computeQuickStart transform", () => {
       sharedState: { ...makeContext().sharedState, isFirstCall: true },
       loadedData: {
         ...makeContext().loadedData,
+        // Anonymous learner so the COLD_START "discover their name" branch fires.
+        caller: { id: "c1", name: null, email: null, phone: null, externalId: null, domain: null },
         playbooks: [{
           id: "pb-1",
           name: "Course",
@@ -802,6 +828,8 @@ describe("computeQuickStart transform", () => {
       sharedState: { ...makeContext().sharedState, isFirstCall: true },
       loadedData: {
         ...makeContext().loadedData,
+        // Anonymous learner so the COLD_START "discover their name" branch fires.
+        caller: { id: "c1", name: null, email: null, phone: null, externalId: null, domain: null },
         playbooks: [{
           id: "pb-1",
           name: "Legacy",


### PR DESCRIPTION
Follow-up to #269. The welcome-message strip alone wasn't enough — _quickStart.discovery_guidance was telling the tutor to 'discover their name' on every COLD_START first call, so the AI re-introduced the question.

Now COLD_START checks caller.name: when set, instructs greet-by-name and NO name probe. When null/empty (anonymous VAPI caller, unjoined session), original 'discover their name' applies.

3522/3522 pass. Closes #268 (the strip + discovery-guidance gap together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)