### PR TITLE
fix: caller row click deep-links to AI Call tab

### DIFF
--- a/apps/admin/components/callers/CallersPage.tsx
+++ b/apps/admin/components/callers/CallersPage.tsx
@@ -376,7 +376,7 @@ export function CallersPage({ routePrefix = "" }: CallersPageProps) {
     if (target.closest("button") || target.closest("a")) {
       return;
     }
-    router.push(`${routePrefix}/callers/${caller.id}`);
+    router.push(`${routePrefix}/callers/${caller.id}?tab=ai-call`);
   };
 
   const handleCreateCaller = async () => {

--- a/apps/admin/components/callers/roster/CallerRoster.tsx
+++ b/apps/admin/components/callers/roster/CallerRoster.tsx
@@ -97,7 +97,9 @@ export function CallerRoster({ routePrefix = "/x", institutionId }: CallerRoster
   };
 
   const handleNavigate = (callerId: string) => {
-    router.push(`${routePrefix}/callers/${callerId}`);
+    // Deep-link to the AI Call tab so educators land on the actionable
+    // chat/call surface, not the read-only overview.
+    router.push(`${routePrefix}/callers/${callerId}?tab=ai-call`);
   };
 
   const handleObserve = (callId: string) => {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.280",
+  "version": "0.7.281",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Row click navigates straight to ?tab=ai-call so educators land on the chat surface. Observe button (in-call) untouched — still routes to /educator/observe.