### PR TITLE
feat: MCQ semantic dedup + ContentQuestion.trustLevel column (#276 Slices 2+3)

### DIFF
--- a/apps/admin/lib/assessment/validate-mcqs.ts
+++ b/apps/admin/lib/assessment/validate-mcqs.ts
@@ -123,8 +123,14 @@ function checkDistractorSimilarity(q: ExtractedQuestion, idx: number): McqIssue[
   return issues;
 }
 
-/** Word-level Jaccard similarity */
-function computeWordOverlap(a: string, b: string): number {
+/**
+ * Word-level Jaccard similarity.
+ * Exported so cross-question dedup (#276 Slice 2) can reuse it without
+ * duplicating the implementation. Used:
+ *  - inside this file for distractor-similarity checks (within a question)
+ *  - in save-questions.ts for cross-question dedup (across the source)
+ */
+export function computeWordOverlap(a: string, b: string): number {
   const wordsA = new Set(a.toLowerCase().split(/\s+/).filter(Boolean));
   const wordsB = new Set(b.toLowerCase().split(/\s+/).filter(Boolean));
   if (wordsA.size === 0 || wordsB.size === 0) return 0;

--- a/apps/admin/lib/content-trust/save-questions.ts
+++ b/apps/admin/lib/content-trust/save-questions.ts
@@ -8,15 +8,59 @@
 import { prisma } from "@/lib/prisma";
 import type { ExtractedQuestion } from "./extractors/base-extractor";
 import { sanitiseLORef } from "./validate-lo-linkage";
+import { computeWordOverlap } from "@/lib/assessment/validate-mcqs";
 
 export interface SaveQuestionsResult {
   created: number;
   duplicatesSkipped: number;
+  /** #276 Slice 2: questions dropped by the cross-question semantic dedup pass. */
+  semanticDuplicatesSkipped?: number;
+}
+
+/**
+ * #276 Slice 2: word-overlap threshold for cross-question dedup.
+ * Two questions whose stopword-stripped Jaccard similarity ≥ this value
+ * are treated as duplicates. Tuned to catch the kind of paraphrased
+ * duplicate seen in the IELTS Speaking course:
+ *   "How many assessment criteria are used to evaluate IELTS Speaking?"
+ *   "How many assessment criteria are used in IELTS Speaking evaluation?"
+ * Without stopword stripping these score ~0.6 (TL's suggested 0.85 misses
+ * them). With stopwords stripped + 0.65, the pair collapses while
+ * genuinely different questions about the same topic stay separate.
+ */
+const SEMANTIC_DUPLICATE_THRESHOLD = 0.65;
+
+/**
+ * Stopwords that inflate the union without adding signal — strip before
+ * computing similarity so paraphrased dupes (different connectives) score
+ * higher.
+ */
+const SIMILARITY_STOPWORDS = new Set([
+  "a", "an", "the",
+  "is", "are", "was", "were", "be", "been",
+  "to", "of", "in", "on", "at", "for", "with", "by", "from",
+  "and", "or", "but",
+  "do", "does", "did",
+  "this", "that", "these", "those",
+  "it", "its",
+  "?",
+]);
+
+function normalisedQuestionWords(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[?.!,;:]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w && !SIMILARITY_STOPWORDS.has(w))
+    .join(" ");
 }
 
 /**
  * Save extracted questions for a content source.
- * Deduplicates by contentHash (skips existing).
+ * Two-pass dedup:
+ *   1. contentHash exact match (catches re-runs of identical AI output)
+ *   2. cross-question Jaccard overlap (catches paraphrased duplicates that
+ *      have different hashes — see #276 where Q1 and Q2 were near-identical)
  */
 export async function saveQuestions(
   sourceId: string,
@@ -25,23 +69,50 @@ export async function saveQuestions(
 ): Promise<SaveQuestionsResult> {
   if (questions.length === 0) return { created: 0, duplicatesSkipped: 0 };
 
-  // Fetch existing hashes for this source (scoped by subjectSourceId when available)
+  // Fetch existing hashes + question text for this source (scoped by
+  // subjectSourceId when available). Question text feeds the semantic
+  // dedup pass below.
   const existing = await prisma.contentQuestion.findMany({
     where: { sourceId, ...(subjectSourceId ? { subjectSourceId } : {}) },
-    select: { contentHash: true },
+    select: { contentHash: true, questionText: true },
   });
   const existingHashes = new Set(existing.map((e) => e.contentHash).filter(Boolean));
+  const existingTexts: string[] = existing.map((e) => e.questionText).filter(Boolean) as string[];
 
   const seen = new Set<string>();
-  const toCreate = questions.filter((q) => {
+  // Pass 1: contentHash dedup
+  const hashUnique = questions.filter((q) => {
     if (existingHashes.has(q.contentHash) || seen.has(q.contentHash)) return false;
     seen.add(q.contentHash);
     return true;
   });
-  const duplicatesSkipped = questions.length - toCreate.length;
+
+  // Pass 2: cross-question semantic dedup — Jaccard overlap ≥ 0.85.
+  // Compares each new question against (a) already-persisted questions and
+  // (b) other new questions accepted earlier in this batch. Catches near-
+  // identical paraphrases that contentHash misses.
+  const acceptedTexts: string[] = [...existingTexts];
+  const toCreate: ExtractedQuestion[] = [];
+  let semanticDuplicatesSkipped = 0;
+  for (const q of hashUnique) {
+    const qNorm = normalisedQuestionWords(q.questionText);
+    const dupe = acceptedTexts.find(
+      (existingText) => computeWordOverlap(qNorm, normalisedQuestionWords(existingText)) >= SEMANTIC_DUPLICATE_THRESHOLD,
+    );
+    if (dupe) {
+      semanticDuplicatesSkipped++;
+      console.log(
+        `[save-questions] #276 Slice 2: dropped near-duplicate "${q.questionText.slice(0, 60)}..." (overlap with "${dupe.slice(0, 60)}...")`,
+      );
+      continue;
+    }
+    acceptedTexts.push(q.questionText);
+    toCreate.push(q);
+  }
+  const duplicatesSkipped = questions.length - hashUnique.length;
 
   if (toCreate.length === 0) {
-    return { created: 0, duplicatesSkipped };
+    return { created: 0, duplicatesSkipped, semanticDuplicatesSkipped };
   }
 
   await prisma.contentQuestion.createMany({
@@ -68,11 +139,14 @@ export async function saveQuestions(
       contentHash: q.contentHash,
       bloomLevel: q.bloomLevel || null,
       assessmentUse: q.assessmentUse || null,
+      // #276 Slice 3: stamp generator-output as AI_ASSISTED. Educator-
+      // imported question banks may set a higher tier downstream.
+      trustLevel: "AI_ASSISTED",
     })),
     skipDuplicates: true,
   });
 
-  return { created: toCreate.length, duplicatesSkipped };
+  return { created: toCreate.length, duplicatesSkipped, semanticDuplicatesSkipped };
 }
 
 /**

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.283",
+  "version": "0.7.284",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/prisma/migrations/20260507_add_content_question_trust_level/migration.sql
+++ b/apps/admin/prisma/migrations/20260507_add_content_question_trust_level/migration.sql
@@ -1,0 +1,10 @@
+-- #276 Slice 3: provenance signal for ContentQuestion rows.
+-- AI_ASSISTED is the default for generator-output MCQs; higher tiers
+-- (EXPERT_CURATED, ACCREDITED_MATERIAL, REGULATORY_STANDARD) for educator-
+-- imported question banks. Surfaces a trust badge in the curriculum admin
+-- UI; future pre-test queries can gate on this when an educator wants only
+-- verified items.
+--
+-- Additive nullable column with default — safe; existing rows stay null
+-- until reset/regenerate, at which point the generator stamps AI_ASSISTED.
+ALTER TABLE "ContentQuestion" ADD COLUMN "trustLevel" "ContentTrustLevel" DEFAULT 'AI_ASSISTED';

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -3445,10 +3445,10 @@ model Ticket {
   tags String[]
 
   // Feedback context (captured on submit)
-  pageContext        String?   // Auto-captured URL + breadcrumbs
-  screenshotUrl      String?   // GCS URL if screenshot attached
-  githubIssueUrl     String?   // Linked GitHub issue URL
-  githubIssueNumber  Int?      // Linked GitHub issue number
+  pageContext       String? // Auto-captured URL + breadcrumbs
+  screenshotUrl     String? // GCS URL if screenshot attached
+  githubIssueUrl    String? // Linked GitHub issue URL
+  githubIssueNumber Int? // Linked GitHub issue number
 
   // Timestamps
   createdAt  DateTime  @default(now())
@@ -3767,6 +3767,12 @@ model ContentQuestion {
   bloomLevel         BloomLevel?
   assessmentUse      AssessmentUse?
   embedding          Unsupported("vector(1536)")?
+  // #276 Slice 3: provenance signal for questions. AI_ASSISTED for
+  // generator-default MCQs; higher tiers (EXPERT_CURATED, ACCREDITED_MATERIAL,
+  // REGULATORY_STANDARD) for imported educator question banks. Drives a
+  // trust badge in the curriculum admin UI; future pre-test queries can
+  // gate on this.
+  trustLevel         ContentTrustLevel?           @default(AI_ASSISTED)
 
   // Type-specific metadata (tiered responses, tutor moves, text references for TUTOR_QUESTION)
   metadata Json?

--- a/apps/admin/tests/lib/content-trust/save-questions.test.ts
+++ b/apps/admin/tests/lib/content-trust/save-questions.test.ts
@@ -64,7 +64,7 @@ describe("saveQuestions", () => {
     mocks.createMany.mockResolvedValue({ count: 2 });
 
     const result = await saveQuestions("src-1", questions);
-    expect(result).toEqual({ created: 2, duplicatesSkipped: 0 });
+    expect(result).toEqual({ created: 2, duplicatesSkipped: 0, semanticDuplicatesSkipped: 0 });
     expect(mocks.createMany).toHaveBeenCalledOnce();
 
     const createData = mocks.createMany.mock.calls[0][0].data;
@@ -84,7 +84,7 @@ describe("saveQuestions", () => {
     mocks.createMany.mockResolvedValue({ count: 1 });
 
     const result = await saveQuestions("src-1", questions);
-    expect(result).toEqual({ created: 1, duplicatesSkipped: 1 });
+    expect(result).toEqual({ created: 1, duplicatesSkipped: 1, semanticDuplicatesSkipped: 0 });
 
     const createData = mocks.createMany.mock.calls[0][0].data;
     expect(createData).toHaveLength(1);
@@ -100,8 +100,73 @@ describe("saveQuestions", () => {
     ];
 
     const result = await saveQuestions("src-1", questions);
-    expect(result).toEqual({ created: 0, duplicatesSkipped: 2 });
+    expect(result).toEqual({ created: 0, duplicatesSkipped: 2, semanticDuplicatesSkipped: 0 });
     expect(mocks.createMany).not.toHaveBeenCalled();
+  });
+
+  // ── #276 Slice 2: cross-question semantic dedup ──
+
+  it("drops near-duplicate questions in the same batch (different hashes, ≥ 0.85 word overlap)", async () => {
+    const questions = [
+      makeQuestion({
+        contentHash: "h1",
+        questionText: "How many assessment criteria are used to evaluate IELTS Speaking performance",
+      }),
+      makeQuestion({
+        contentHash: "h2",
+        questionText: "How many assessment criteria are used in IELTS Speaking evaluation",
+      }),
+      makeQuestion({
+        contentHash: "h3",
+        questionText: "Why does speaking too slowly negatively impact fluency in IELTS Speaking",
+      }),
+    ];
+    mocks.createMany.mockResolvedValue({ count: 2 });
+
+    const result = await saveQuestions("src-1", questions);
+    // h1 + h3 keep, h2 dropped as semantic dupe of h1
+    expect(result.created).toBe(2);
+    expect(result.duplicatesSkipped).toBe(0);
+    expect(result.semanticDuplicatesSkipped).toBe(1);
+    const createData = mocks.createMany.mock.calls[0][0].data;
+    expect(createData.map((d: any) => d.contentHash)).toEqual(["h1", "h3"]);
+  });
+
+  it("drops a new question that's a semantic duplicate of one already persisted", async () => {
+    mocks.findMany.mockResolvedValue([
+      { contentHash: "old1", questionText: "How many assessment criteria are used to evaluate IELTS Speaking" },
+    ]);
+    const questions = [
+      makeQuestion({
+        contentHash: "h1",
+        questionText: "How many assessment criteria are used in IELTS Speaking evaluation",
+      }),
+    ];
+    const result = await saveQuestions("src-1", questions);
+    expect(result.created).toBe(0);
+    expect(result.semanticDuplicatesSkipped).toBe(1);
+    expect(mocks.createMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps two genuinely different questions about the same topic", async () => {
+    const questions = [
+      makeQuestion({ contentHash: "h1", questionText: "What does Band 9 indicate in IELTS Speaking" }),
+      makeQuestion({ contentHash: "h2", questionText: "Why is fluency assessed in IELTS Speaking" }),
+    ];
+    mocks.createMany.mockResolvedValue({ count: 2 });
+    const result = await saveQuestions("src-1", questions);
+    expect(result.created).toBe(2);
+    expect(result.semanticDuplicatesSkipped).toBe(0);
+  });
+
+  // ── #276 Slice 3: trustLevel stamping ──
+
+  it("stamps trustLevel: AI_ASSISTED on every persisted question", async () => {
+    const questions = [makeQuestion({ contentHash: "h1" })];
+    mocks.createMany.mockResolvedValue({ count: 1 });
+    await saveQuestions("src-1", questions);
+    const data = mocks.createMany.mock.calls[0][0].data[0];
+    expect(data.trustLevel).toBe("AI_ASSISTED");
   });
 
   it("maps optional fields correctly", async () => {


### PR DESCRIPTION
Slice 2: cross-question dedup pass with stopword normalisation + Jaccard 0.65. Catches the IELTS paraphrased dupes that contentHash hashing missed. Slice 3: trustLevel column with AI_ASSISTED default.

**Migration included** — needs /vm-cpp deploy.

3538/3538 vitest pass. Closes #276 Slices 2+3 (UI banner deferred).