### PR TITLE
fix: align LEARN-ASSESS-001 scoringAnchors with schema (#280)

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/LEARN-ASSESS-001-curriculum-mastery.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/LEARN-ASSESS-001-curriculum-mastery.spec.json
@@ -185,20 +185,20 @@
       ],
       "scoringAnchors": [
         {
-          "scenario": "Caller correctly defines 'danger zone' temperature range and explains why bacteria multiply rapidly in that range",
-          "expectedScore": 0.85,
+          "example": "Caller correctly defines 'danger zone' temperature range and explains why bacteria multiply rapidly in that range",
+          "score": 0.85,
           "isGold": true,
           "rationale": "Demonstrates both recall (specific temperatures) and understanding (why it matters)"
         },
         {
-          "scenario": "Caller says 'I think it's something about keeping food hot' but cannot give specific temperatures",
-          "expectedScore": 0.3,
+          "example": "Caller says 'I think it's something about keeping food hot' but cannot give specific temperatures",
+          "score": 0.3,
           "isGold": true,
           "rationale": "Vague awareness but no specific recall — partial understanding at best"
         },
         {
-          "scenario": "Caller correctly answers a scenario: 'I would check the delivery temperature and reject if above 8°C'",
-          "expectedScore": 0.9,
+          "example": "Caller correctly answers a scenario: 'I would check the delivery temperature and reject if above 8°C'",
+          "score": 0.9,
           "isGold": true,
           "rationale": "Demonstrates practical application with specific threshold knowledge"
         }


### PR DESCRIPTION
## Summary

- The Uplift dashboard (`/x/callers/:callerId?section=ai-call`) showed `0% mastery, 0/0 modules` for every learner system-wide.
- Root cause: `LEARN-ASSESS-001` was missing from the DB — its `scoringAnchors` used `expectedScore` + `scenario` instead of the canonical `score` + `example`, so `compileSpecToTemplate` crashed during seed (`anchor.example.substring(...)`) and the row never landed.
- Without it, the pipeline gate at `apps/admin/app/api/calls/[callId]/pipeline/route.ts:474` (`learnSpecs.find(s => config.assessmentMode === "curriculum_mastery")`) returned undefined → `moduleContext` never built → AI never asked for `learning` → `learningAssessment` always null → `CallerModuleProgress` writes silently dropped.

## Verification (DEV)

After this change, re-running `seedFromSpecs({ specIds: ['LEARN-ASSESS-001'] })` on DEV:
- `spec-learn-assess-001` row created (active, scope=SYSTEM, outputType=LEARN, `config.assessmentMode='curriculum_mastery'`, masteryThreshold=0.7).
- 1 spec, 3 triggers, 3 actions created. No params/anchors (correctly skipped for LEARN specs).
- Active specs in DEV with `assessmentMode='curriculum_mastery'`: **1** (was 0).

## Test plan

- [ ] Run a fresh sim call against caller Luca Ziegler (`37255332-…`) with `requestedModuleId='part1'` and confirm a `CallerModuleProgress` row is written.
- [ ] Confirm the Uplift dashboard for that caller now shows non-zero mastery + the chosen module marked IN_PROGRESS.
- [ ] On TEST/PROD: same seed must run on next deploy (BA + TL flagged this as desired but worth explicit sign-off).

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)