### PR TITLE
fix: source list union + hard reload + learner-content counter-signal

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseIntelligenceTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseIntelligenceTab.tsx
@@ -13,7 +13,6 @@
  */
 
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import {
   BookMarked, AlertTriangle, Zap, RefreshCw,
@@ -368,7 +367,6 @@ export function CourseIntelligenceTab({
   // Bind uploads to the course's primary subject — that's what the
   // backend expects (see /api/subjects/[subjectId]/upload). When the
   // course has no subjects yet, the affordance hides.
-  const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
   const [dragOver, setDragOver] = useState(false);
@@ -403,14 +401,16 @@ export function CourseIntelligenceTab({
         // appear with their classified type; user can hit the "Extract" icon
         // per row to run extraction (intentionally NOT auto-fired here so the
         // educator can correct misclassification first).
-        router.refresh();
+        // Hard reload — the parent's client-side useEffect doesn't re-run
+        // on router signals; need a fresh page load to refetch courseSources.
+        window.location.reload();
       } catch (e) {
         setOpError(e instanceof Error ? e.message : "Upload failed");
       } finally {
         setUploading(false);
       }
     },
-    [courseId, primarySubjectId, router],
+    [courseId, primarySubjectId],
   );
 
   const handleExtract = useCallback(
@@ -427,14 +427,16 @@ export function CourseIntelligenceTab({
         if (!res.ok || data.ok === false) {
           throw new Error(data.error || `Extract failed (${res.status})`);
         }
-        router.refresh();
+        // Hard reload — the parent's client-side useEffect doesn't re-run
+        // on router signals; need a fresh page load to refetch courseSources.
+        window.location.reload();
       } catch (e) {
         setOpError(e instanceof Error ? e.message : "Extract failed");
       } finally {
         setBusySourceId(null);
       }
     },
-    [router],
+    [],
   );
 
   const handleDelete = useCallback(
@@ -466,14 +468,16 @@ export function CourseIntelligenceTab({
           const data = await permRes.json().catch(() => ({}));
           throw new Error(data.error || `Permanent delete failed (${permRes.status})`);
         }
-        router.refresh();
+        // Hard reload — the parent's client-side useEffect doesn't re-run
+        // on router signals; need a fresh page load to refetch courseSources.
+        window.location.reload();
       } catch (e) {
         setOpError(e instanceof Error ? e.message : "Delete failed");
       } finally {
         setBusySourceId(null);
       }
     },
-    [router],
+    [],
   );
 
   // ── Lazy fetch assertions when switching to points ──
@@ -564,37 +568,48 @@ export function CourseIntelligenceTab({
   }, []);
 
   // ── Sources ──────────────────────────────────────────
+  // Show the UNION of two link paths so adding a new course-scoped source
+  // doesn't hide existing subject-scoped ones:
+  //   - PlaybookSource (direct course → source link, populated by today's
+  //     upload flow)
+  //   - SubjectSource (course → subject → source, populated by older
+  //     wizard flows)
+  // Pre-#288 this branched: if courseSources had ANY entries it ignored
+  // the subject sources entirely. Result: the first PlaybookSource added
+  // to a previously-subject-only course made all the subject sources
+  // disappear from view.
   const { courseGuideSources, otherSources, allSources } = useMemo(() => {
     const guides: SourceItem[] = [];
     const others: SourceItem[] = [];
+    const seen = new Set<string>();
 
-    if (courseSources && courseSources.length > 0) {
-      for (const src of courseSources) {
-        if (src.documentType === 'COURSE_REFERENCE') {
-          guides.push(src);
-        } else {
-          others.push(src);
-        }
+    const push = (item: SourceItem) => {
+      if (seen.has(item.id)) return;
+      seen.add(item.id);
+      if (item.documentType === 'COURSE_REFERENCE') {
+        guides.push(item);
+      } else {
+        others.push(item);
       }
-    } else {
-      const seen = new Set<string>();
-      for (const sub of subjects) {
-        for (const src of sub.sources || []) {
-          if (seen.has(src.id)) continue;
-          seen.add(src.id);
-          const item: SourceItem = {
-            ...src,
-            contentAssertionCount: 0,
-            instructionAssertionCount: 0,
-            sortOrder: 0,
-            tags: [],
-          };
-          if (src.documentType === 'COURSE_REFERENCE') {
-            guides.push(item);
-          } else {
-            others.push(item);
-          }
-        }
+    };
+
+    // PlaybookSource entries first — they carry the full SourceItem shape
+    // (assertion counts split content vs instruction). Take precedence on
+    // dedup so we don't downgrade their counts to 0.
+    if (courseSources) {
+      for (const src of courseSources) push(src);
+    }
+    // Subject sources fill in anything not directly linked to the playbook.
+    // Their shape is lighter (no contentAssertion split), so pad zeros.
+    for (const sub of subjects) {
+      for (const src of sub.sources || []) {
+        push({
+          ...src,
+          contentAssertionCount: 0,
+          instructionAssertionCount: 0,
+          sortOrder: 0,
+          tags: [],
+        });
       }
     }
     return { courseGuideSources: guides, otherSources: others, allSources: [...guides, ...others] };

--- a/apps/admin/lib/content-trust/classify-document.ts
+++ b/apps/admin/lib/content-trust/classify-document.ts
@@ -144,22 +144,63 @@ const RUBRIC_CONTENT_MARKERS: RegExp[] = [
 ];
 
 /**
+ * Counter-signals that this is LEARNER-FACING content even if it mentions
+ * the rubric. Sample answers with first-person prose, practice cue cards,
+ * vocabulary lists, and pronunciation drills all skew toward this.
+ *
+ * If the doc has substantial student-content shape, we suppress the rubric
+ * override even when rubric markers appear (e.g. a learner-facing prep doc
+ * that explains the rubric for context but is mostly practice material).
+ */
+const LEARNER_CONTENT_MARKERS: RegExp[] = [
+  // Sample answer markers — first-person prose with quote markers
+  /["'"]I\s+(?:like|love|enjoy|live|think|feel|grew|cycle|travel|usually|always|often)\b/i,
+  /["'"](?:Honestly|Actually|To be honest|For me|In my view)\b/i,
+  // Practice / drill / exercise framing
+  /\bpractice\s+(?:cue\s+card|session|drill|exercise|answer)\b/i,
+  /\b(?:cue\s+card|prompt|exercise|drill)\s*[:#-]/i,
+  /\bsample\s+(?:answer|response|sentence)\b/i,
+  /\b(?:try\s+this|read\s+aloud|repeat|practise)\b/i,
+  // Vocabulary list markers
+  /\b(?:collocations?|phrasal\s+verbs?|vocabulary\s+list|word\s+bank)\b/i,
+  /^\s*[-*•]\s+to\s+\w+/im, // bulleted infinitive verbs (vocab lists)
+  // Pronunciation drill markers
+  /\bminimal\s+pairs?\b/i,
+  /\bsentence\s+stress\b/i,
+  /\bschwa\b/i,
+];
+
+function countMarkerOccurrences(text: string, markers: RegExp[], stopAt: number): number {
+  let total = 0;
+  for (const marker of markers) {
+    const global = new RegExp(marker.source, marker.flags.includes("g") ? marker.flags : marker.flags + "g");
+    const hits = text.match(global);
+    if (hits) total += hits.length;
+    if (total >= stopAt) return total;
+  }
+  return total;
+}
+
+/**
  * Returns true when the text sample matches enough rubric markers to be
  * confidently classified as COURSE_REFERENCE rather than learner content.
  *
  * Counts each OCCURRENCE not just unique markers — a sample with two CEFR
  * descriptors (C1, B2) is rubric content even if all hits come from one regex.
+ *
+ * Counter-signal: if learner-content markers (sample answers, practice
+ * framing, vocab lists, pronunciation drills) outnumber rubric markers,
+ * the doc is learner-facing despite mentioning rubric concepts. Without
+ * this guard the IELTS Speaking practice doc (which references the rubric
+ * for context) gets misclassified as COURSE_REFERENCE and excluded from
+ * MCQ generation.
  */
 export function isRubricContent(textSample: string): boolean {
-  let matches = 0;
-  for (const marker of RUBRIC_CONTENT_MARKERS) {
-    // Use a global flag clone so we count each occurrence, not just one hit.
-    const global = new RegExp(marker.source, marker.flags.includes("g") ? marker.flags : marker.flags + "g");
-    const hits = textSample.match(global);
-    if (hits) matches += hits.length;
-    if (matches >= 2) return true;
-  }
-  return false;
+  const rubricHits = countMarkerOccurrences(textSample, RUBRIC_CONTENT_MARKERS, 6);
+  if (rubricHits < 2) return false;
+  const learnerHits = countMarkerOccurrences(textSample, LEARNER_CONTENT_MARKERS, rubricHits + 1);
+  // Tie or learner-leaning → not rubric.
+  return rubricHits > learnerHits;
 }
 
 // ------------------------------------------------------------------

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.286",
+  "version": "0.7.287",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/content-trust/classify-document.test.ts
+++ b/apps/admin/tests/lib/content-trust/classify-document.test.ts
@@ -208,4 +208,51 @@ describe("isRubricContent", () => {
     `;
     expect(isRubricContent(sample)).toBe(true);
   });
+
+  // ── Counter-signal: learner content that REFERENCES the rubric ──
+
+  it("rejects learner-facing practice content that references rubric concepts in passing", () => {
+    const sample = `
+      ## Sample answers
+
+      "I live in a small flat in the city centre. It's only a one-bedroom place,
+      but it suits me because I'm out a lot for work."
+
+      "Honestly, it depends on my mood. On weeknights I usually throw something
+      quick together — pasta, a stir-fry, that kind of thing."
+
+      ## Practice cue cards
+
+      Cue card A: Describe a teacher who influenced you. You should say who the
+      teacher was, what subject they taught, and explain how they shaped your
+      approach to learning.
+
+      ## Topic-area vocabulary
+      - to grow up in / to put down roots / to be born and bred in
+      - a bustling city / a sleepy town
+
+      ## Pronunciation drills
+      Minimal pairs and sentence stress practice for IELTS speaking.
+      Try this: read aloud and aim for natural connected speech.
+
+      Note: aim for Band 7 in your responses.
+    `;
+    expect(isRubricContent(sample)).toBe(false);
+  });
+
+  it("still detects rubric content even with one sample-answer-like quote present", () => {
+    const sample = `
+      IELTS Speaking Band Descriptors
+
+      Band 9: Speakers at this band speak fluently with rare hesitation.
+      Band 7: Lexical Resource — uses vocabulary with flexibility.
+      Band 5: Grammatical Range and Accuracy — uses a limited range.
+
+      The four assessment criteria are weighted equally. Pronunciation features
+      are assessed on band score consistency.
+
+      "I live in London" — does NOT count as Band 9 alone; coherence required.
+    `;
+    expect(isRubricContent(sample)).toBe(true);
+  });
 });


### PR DESCRIPTION
Three bugs from the upload flow:

1. Source list showed playbook-linked OR subject-linked, not both → first upload hid existing sources. Now: union deduped.
2. router.refresh didn't re-trigger client-side parent fetch. Switched to window.location.reload.
3. isRubricContent over-fired on learner docs that mention the rubric. Added counter-signal for sample-answer prose, practice framing, vocab lists, pronunciation drill markers.

3540/3540 pass. /vm-cp.