### PR TITLE
refactor: single resolveCurrentModule helper + outcome resolution + retrieval gate (#284 #288)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -34,6 +34,7 @@ import { deliverArtifacts } from "@/lib/artifacts/deliver-artifacts";
 import { extractActions } from "@/lib/actions/extract-actions";
 import { config as appConfig } from "@/lib/config";
 import { updateCurriculumProgress, getCurriculumProgress, completeModule, updateTpMasteryBatch } from "@/lib/curriculum/track-progress";
+import { resolveCurrentModule } from "@/lib/curriculum/resolve-current-module";
 // initializeLessonPlanSession removed — scheduler replaces session tracking
 import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
 import { ContractRegistry } from "@/lib/contracts/registry";
@@ -59,26 +60,20 @@ import type { SpecConfig } from "@/lib/types/json-fields";
  */
 /**
  * Load current module context for learning assessment.
- * Tries CONTENT spec path first, then falls back to Subject curriculum.
+ *
+ * Thin adapter over `resolveCurrentModule` (lib/curriculum/resolve-current-module.ts)
+ * — the EXTRACT pipeline only needs the prompt-facing subset (specSlug,
+ * moduleId, name, outcome text, threshold, allModuleIds). The shared helper
+ * also handles picker override, authored fallback, and the deprecated
+ * CONTENT-spec / notableInfo / SubjectDomain paths in one place.
  */
 async function loadCurrentModuleContext(
   callerId: string,
   log: PipelineLogger,
   opts?: {
-    /**
-     * #242 Slice 2: explicit module pick from the picker, persisted on
-     * Call.requestedModuleId. When provided AND found in
-     * Playbook.config.modules, we build a moduleContext from it directly
-     * rather than running the scheduler — guarantees mastery is emitted
-     * against the learner's choice.
-     */
     requestedModuleId?: string | null;
-    /**
-     * Fallback playbookId from the call record itself, used when the caller
-     * has no CallerPlaybook enrollment (common for SIM testers). Must NOT
-     * shadow a real enrollment.
-     */
     callPlaybookId?: string | null;
+    callerDomainId?: string | null;
   }
 ): Promise<{
   specSlug: string;
@@ -88,184 +83,21 @@ async function loadCurrentModuleContext(
   masteryThreshold: number;
   allModuleIds: string[];
 } | null> {
-  // Resolve the caller's actual enrolment (CallerPlaybook) first.
-  // Fall back to the call's own playbookId for SIM testers without
-  // an explicit CallerPlaybook row.
-  let resolvedPlaybookId = await resolvePlaybookId(callerId);
-  if (!resolvedPlaybookId && opts?.callPlaybookId) {
-    log.info("No enrollment; using call.playbookId as fallback", {
-      callPlaybookId: opts.callPlaybookId,
-    });
-    resolvedPlaybookId = opts.callPlaybookId;
-  }
-  if (!resolvedPlaybookId) return null;
-
-  // ── #242 Slice 2: requestedModuleId override ──
-  // When the learner picked a module via the picker, build the moduleContext
-  // directly from Playbook.config.modules (the authored shape). The override
-  // bypasses the scheduler so mastery fires against the learner's choice
-  // even if scheduler logic would have selected a different module.
-  if (opts?.requestedModuleId) {
-    const pb = await prisma.playbook.findUnique({
-      where: { id: resolvedPlaybookId },
-      select: {
-        name: true,
-        config: true,
-        curricula: {
-          orderBy: { createdAt: "asc" },
-          take: 1,
-          select: { slug: true },
-        },
-      },
-    });
-    const cfg = (pb?.config ?? {}) as Record<string, any>;
-    const authored = Array.isArray(cfg.modules) ? cfg.modules : [];
-    const match = authored.find((m: any) => m?.id === opts.requestedModuleId);
-    if (match) {
-      const specSlug =
-        pb?.curricula[0]?.slug ??
-        `playbook-${resolvedPlaybookId.slice(0, 8)}-modules`;
-      log.info("Module context override from picker", {
-        requestedModuleId: opts.requestedModuleId,
-        specSlug,
-        loCount: (match.outcomesPrimary || []).length,
-      });
-      return {
-        specSlug,
-        moduleId: match.id,
-        moduleName: match.label || match.id,
-        learningOutcomes: Array.isArray(match.outcomesPrimary)
-          ? match.outcomesPrimary
-          : [],
-        masteryThreshold: 0.7,
-        allModuleIds: authored.map((m: any) => m?.id).filter(Boolean),
-      };
-    }
-    log.warn("requestedModuleId not found in Playbook.config.modules — falling back to scheduler", {
-      requestedModuleId: opts.requestedModuleId,
-      playbookId: resolvedPlaybookId,
-    });
-  }
-
-  // Path 1: CONTENT spec via the caller's enrolled playbook
-  const playbook = await prisma.playbook.findUnique({
-    where: { id: resolvedPlaybookId },
-    select: {
-      items: {
-        where: {
-          itemType: "SPEC",
-          isEnabled: true,
-          spec: { specRole: "CONTENT", isActive: true },
-        },
-        select: {
-          spec: { select: { slug: true, config: true } },
-        },
-      },
-    },
+  const resolved = await resolveCurrentModule(callerId, {
+    requestedModuleId: opts?.requestedModuleId ?? null,
+    callPlaybookId: opts?.callPlaybookId ?? null,
+    callerDomainId: opts?.callerDomainId ?? null,
+    log,
   });
-
-  if (playbook?.items?.length) {
-    for (const item of playbook.items) {
-      const spec = item.spec;
-      if (!spec) continue;
-      const specConfig = spec.config as Record<string, any> | null;
-      if (!specConfig) continue;
-
-      const modules = specConfig.modules || specConfig.curriculum?.modules || [];
-      if (modules.length === 0) continue;
-
-      const progress = await getCurriculumProgress(callerId, spec.slug);
-      const currentModuleId = progress.currentModuleId || modules[0]?.id || modules[0]?.slug;
-      const currentModule = modules.find((m: any) => (m.id || m.slug) === currentModuleId) || modules[0];
-
-      if (currentModule) {
-        return {
-          specSlug: spec.slug,
-          moduleId: currentModule.id || currentModule.slug,
-          moduleName: currentModule.name || currentModule.title || currentModule.id,
-          learningOutcomes: currentModule.learningOutcomes || [],
-          masteryThreshold: specConfig.metadata?.curriculum?.masteryThreshold ?? 0.7,
-          allModuleIds: modules.map((m: any) => m.id || m.slug),
-        };
-      }
-    }
-  }
-
-  // Path 2: Playbook curriculum (direct link via playbookId)
-  if (resolvedPlaybookId) {
-    const pbCurriculum = await prisma.curriculum.findFirst({
-      where: { playbookId: resolvedPlaybookId },
-      orderBy: { updatedAt: "desc" },
-      select: { slug: true, notableInfo: true },
-    });
-    if (pbCurriculum?.notableInfo) {
-      const rawModules = (pbCurriculum.notableInfo as Record<string, any>)?.modules;
-      if (Array.isArray(rawModules) && rawModules.length > 0) {
-        const progress = await getCurriculumProgress(callerId, pbCurriculum.slug);
-        const currentModuleId = progress.currentModuleId || rawModules[0]?.id;
-        const currentModule = rawModules.find((m: any) => m.id === currentModuleId) || rawModules[0];
-        if (currentModule) {
-          return {
-            specSlug: pbCurriculum.slug,
-            moduleId: currentModule.id,
-            moduleName: currentModule.name || currentModule.title || currentModule.id,
-            learningOutcomes: currentModule.learningOutcomes || [],
-            masteryThreshold: 0.7,
-            allModuleIds: rawModules.map((m: any) => m.id),
-          };
-        }
-      }
-    }
-  }
-
-  // Path 3: Domain-wide Subject curriculum fallback (legacy)
-  const subjectDomains = await prisma.subjectDomain.findMany({
-    where: { domainId: caller.domainId },
-    include: {
-      subject: {
-        include: {
-          curricula: {
-            orderBy: { updatedAt: "desc" },
-            take: 1,
-            select: {
-              slug: true,
-              notableInfo: true,
-            },
-          },
-        },
-      },
-    },
-  });
-
-  for (const sd of subjectDomains) {
-    const curriculum = sd.subject.curricula[0];
-    if (!curriculum?.notableInfo) continue;
-
-    const rawModules = (curriculum.notableInfo as Record<string, any>)?.modules;
-    if (!Array.isArray(rawModules) || rawModules.length === 0) continue;
-
-    const progress = await getCurriculumProgress(callerId, curriculum.slug);
-    const currentModuleId = progress.currentModuleId || rawModules[0]?.id;
-    const currentModule = rawModules.find((m: any) => m.id === currentModuleId) || rawModules[0];
-
-    if (currentModule) {
-      log.info(`Module context from Subject curriculum`, {
-        specSlug: curriculum.slug,
-        moduleId: currentModule.id,
-        loCount: (currentModule.learningOutcomes || []).length,
-      });
-      return {
-        specSlug: curriculum.slug,
-        moduleId: currentModule.id,
-        moduleName: currentModule.title || currentModule.name || currentModule.id,
-        learningOutcomes: currentModule.learningOutcomes || [],
-        masteryThreshold: (await ContractRegistry.getThresholds('CURRICULUM_PROGRESS_V1'))?.masteryComplete ?? 0.7,
-        allModuleIds: rawModules.map((m: any) => m.id),
-      };
-    }
-  }
-
-  return null;
+  if (!resolved) return null;
+  return {
+    specSlug: resolved.specSlug,
+    moduleId: resolved.moduleId,
+    moduleName: resolved.moduleName,
+    learningOutcomes: resolved.learningOutcomes,
+    masteryThreshold: resolved.masteryThreshold,
+    allModuleIds: resolved.allModuleIds,
+  };
 }
 
 function buildBatchedCallerPrompt(

--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -80,6 +80,14 @@ async function loadCurrentModuleContext(
   moduleId: string;
   moduleName: string;
   learningOutcomes: string[];
+  /**
+   * Original outcome refs (e.g. ["OUT-01", "OUT-02"]) parallel to
+   * `learningOutcomes` (which carry resolved statement text). The prompt
+   * uses BOTH so the AI scores against refs the DB can find — without this
+   * `updateTpMasteryAfterCall` couldn't match LO rows and silently wrote
+   * to the wrong curriculum.
+   */
+  outcomeRefs: string[];
   masteryThreshold: number;
   allModuleIds: string[];
 } | null> {
@@ -95,6 +103,7 @@ async function loadCurrentModuleContext(
     moduleId: resolved.moduleId,
     moduleName: resolved.moduleName,
     learningOutcomes: resolved.learningOutcomes,
+    outcomeRefs: resolved.outcomeRefs,
     masteryThreshold: resolved.masteryThreshold,
     allModuleIds: resolved.allModuleIds,
   };
@@ -105,7 +114,12 @@ function buildBatchedCallerPrompt(
   measureParams: Array<{ parameterId: string; name: string; definition: string | null }>,
   learnActions: Array<{ category: string; keyPrefix: string; keyHint: string; description: string }>,
   transcriptLimit: number = 4000,
-  moduleContext?: { moduleId: string; moduleName: string; learningOutcomes: string[] } | null,
+  moduleContext?: {
+    moduleId: string;
+    moduleName: string;
+    learningOutcomes: string[];
+    outcomeRefs?: string[];
+  } | null,
   assessmentPromptInstructions?: string | null,
 ): string {
   const paramList = measureParams.map(p => `${p.parameterId}:${p.name}`).join("|");
@@ -117,11 +131,22 @@ function buildBatchedCallerPrompt(
   let learningSection = "";
   let learningJsonHint = "";
   if (moduleContext?.learningOutcomes?.length) {
-    const loList = moduleContext.learningOutcomes.map((lo, i) => `LO${i + 1}:${lo}`).join("|");
+    // Use the canonical outcome refs as keys when we have them (authored
+    // courses provide OUT-NN refs from Playbook.config.outcomes). Fall back
+    // to LO1, LO2, … for legacy/DB-curriculum modules where refs aren't
+    // surfaced. The DB lookup in updateTpMasteryAfterCall keys on these
+    // exact strings, so the format MUST round-trip.
+    const text = moduleContext.learningOutcomes;
+    const refs = moduleContext.outcomeRefs ?? [];
+    const useRefs = refs.length === text.length;
+    const loList = text
+      .map((stmt, i) => `${useRefs ? refs[i] : `LO${i + 1}`}:${stmt}`)
+      .join("|");
+    const exampleKey = useRefs ? refs[0] : "LO1";
     const instructions = assessmentPromptInstructions
-      || "Score caller's demonstrated understanding of each outcome 0-1 (0=no evidence, 0.5=partial, 1=full mastery).";
+      || `Score caller's demonstrated understanding of each outcome 0-1 (0=no evidence, 0.5=partial, 1=full mastery). Key your outcomes object with the exact ref before the colon (e.g. "${exampleKey}").`;
     learningSection = `\n\nLEARNING OUTCOMES TO ASSESS (module "${moduleContext.moduleName}"):\n${loList}\n${instructions}`;
-    learningJsonHint = `,"learning":{"moduleId":"${moduleContext.moduleId}","outcomes":{"LO1":0.6},"overallMastery":0.7}`;
+    learningJsonHint = `,"learning":{"moduleId":"${moduleContext.moduleId}","outcomes":{"${exampleKey}":0.6},"overallMastery":0.7}`;
   }
 
   return `Analyze transcript. Score caller 0-1 on params, extract ALL personal facts.
@@ -1741,41 +1766,64 @@ async function updateTpMasteryAfterCall(
   });
   if (!caller?.domainId) return false;
 
-  // Try playbook curriculum first (direct link)
-  const enrolledPbForAssess = await resolvePlaybookId(callerId);
-  if (enrolledPbForAssess) {
-    const pbCurr = await prisma.curriculum.findFirst({
-      where: { playbookId: enrolledPbForAssess },
-      orderBy: { updatedAt: "desc" },
-      select: { slug: true },
+  // #284 follow-up: anchor TP-mastery writes on the specSlug the resolver
+  // already chose. The previous shape re-derived the curriculum via
+  // `resolvePlaybookId` + `findFirst({ orderBy: updatedAt })`, which could
+  // land on a different curriculum than the module was assessed against.
+  // When ref-lookup then returned 0 LO rows (e.g. authored OUT-NN keys
+  // didn't exist on a stale curriculum) the SubjectDomain fallback below
+  // wrote TP mastery to a completely unrelated course on the same domain.
+  // Now: try the named curriculum directly. If it doesn't match any LO
+  // refs, log + return false instead of falling through.
+  const targetCurriculum = await prisma.curriculum.findFirst({
+    where: { slug: learningAssessment.specSlug },
+    select: { id: true, slug: true },
+  });
+  if (targetCurriculum) {
+    const threshold = learningAssessment.masteryThreshold || 0.7;
+    const assessedLoRefs = Object.keys(learningAssessment.outcomes);
+    const loRows = await prisma.learningObjective.findMany({
+      where: {
+        ref: { in: assessedLoRefs },
+        module: { curriculum: { id: targetCurriculum.id }, isActive: true },
+      },
+      select: { id: true, ref: true },
     });
-    if (pbCurr) {
-      const threshold = learningAssessment.masteryThreshold || 0.7;
-      const assessedLoRefs = Object.keys(learningAssessment.outcomes);
-      const loRows = await prisma.learningObjective.findMany({
-        where: {
-          ref: { in: assessedLoRefs },
-          module: { curriculum: { slug: pbCurr.slug }, isActive: true },
-        },
-        select: { id: true, ref: true },
-      });
-      if (loRows.length > 0) {
-        for (const lo of loRows) {
-          const score = learningAssessment.outcomes[lo.ref];
-          if (score !== undefined) {
-            await prisma.callerAttribute.upsert({
-              where: { callerId_key: { callerId, key: `curriculum:${pbCurr.slug}:lo:${lo.ref}` } },
-              update: { value: String(score), updatedAt: new Date() },
-              create: { callerId, key: `curriculum:${pbCurr.slug}:lo:${lo.ref}`, value: String(score) },
-            });
-          }
-        }
-        return true;
-      }
+    if (loRows.length === 0) {
+      log.warn(
+        `TP mastery skipped — assessed refs [${assessedLoRefs.join(",")}] don't match any LearningObjective on ${targetCurriculum.slug}. Refusing to fall through to SubjectDomain to avoid cross-course pollution.`,
+      );
+      return false;
     }
+
+    const assessedLoIds = loRows.map((lo) => lo.id);
+    const assessedTps = await prisma.contentAssertion.findMany({
+      where: { learningObjectiveId: { in: assessedLoIds } },
+      select: { id: true, learningObjectiveId: true },
+    });
+    const loIdToRef = new Map(loRows.map((lo) => [lo.id, lo.ref]));
+
+    const updates: Record<string, { mastery: number; status: "not_started" | "in_progress" | "mastered" }> = {};
+    for (const tp of assessedTps) {
+      const loRef = tp.learningObjectiveId ? loIdToRef.get(tp.learningObjectiveId) : null;
+      const loScore = loRef ? learningAssessment.outcomes[loRef] ?? 0 : 0;
+      updates[tp.id] = {
+        mastery: loScore,
+        status: loScore >= threshold ? "mastered" : loScore > 0 ? "in_progress" : "not_started",
+      };
+    }
+    if (Object.keys(updates).length > 0) {
+      await updateTpMasteryBatch(callerId, targetCurriculum.slug, updates);
+      log.info(`Updated ${Object.keys(updates).length} TP mastery scores on ${targetCurriculum.slug}`);
+      return true;
+    }
+    return false;
   }
 
-  // Fallback: domain-wide Subject curriculum (legacy)
+  // Last-resort fallback: no curriculum matches the helper's specSlug
+  // (legacy / data drift). Try domain-wide Subject curriculum lookup.
+  // This ONLY runs when the helper-provided specSlug isn't a real
+  // curriculum — keeping cross-course pollution out of the common path.
   const subjectDomains = await prisma.subjectDomain.findMany({
     where: { domainId: caller.domainId },
     include: {

--- a/apps/admin/lib/curriculum/resolve-current-module.ts
+++ b/apps/admin/lib/curriculum/resolve-current-module.ts
@@ -1,0 +1,473 @@
+/**
+ * resolve-current-module.ts
+ *
+ * Single resolver for "which module is this caller working on right now?".
+ * Used by both the EXTRACT pipeline (to score mastery against the right
+ * module after a call) and the COMPOSE side (to lock the prompt's
+ * `nextModule` to the same anchor).
+ *
+ * Consolidates five legacy paths that had drifted across two call sites:
+ *   1. Picker override        — `requestedModuleId` from the call
+ *   2. Authored fallback      — `Playbook.config.modules` + `CallerModuleProgress`
+ *   3. CONTENT-spec items     — playbook items with `specRole=CONTENT` (deprecated)
+ *   4. notableInfo.modules    — `Curriculum.notableInfo.modules` (deprecated)
+ *   5. Subject curriculum     — domain → subject → curriculum (deprecated)
+ *
+ * Outcome resolution:
+ *   `learningOutcomes` is always resolved to statement text (via
+ *   `Playbook.config.outcomes` for authored, or `LearningObjective.description`
+ *   for DB modules). Raw refs are preserved on `outcomeRefs` so consumers
+ *   that need FK lookups (`teaching-content.ts`) still work.
+ *
+ * Closes #284, #288. Replaces inline logic at:
+ *   - apps/admin/app/api/calls/[callId]/pipeline/route.ts:loadCurrentModuleContext
+ *   - apps/admin/lib/prompt/composition/transforms/modules.ts:lockedModule block
+ */
+
+import { prisma } from "@/lib/prisma";
+import { getCurriculumProgress } from "@/lib/curriculum/track-progress";
+import { ContractRegistry } from "@/lib/contracts/registry";
+import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
+
+export type ResolvedModuleSource =
+  | "picker"
+  | "authored-prev-call"
+  | "authored-first-incomplete"
+  | "authored-first"
+  | "content-spec"
+  | "playbook-curriculum"
+  | "subject-curriculum";
+
+export interface ResolvedModule {
+  /** Which path produced this resolution — useful for logs and tests. */
+  source: ResolvedModuleSource;
+  /** Stable key for `getCurriculumProgress` and curriculum-scoped attrs. */
+  specSlug: string;
+  /** Authored module `id` OR `CurriculumModule.slug`. */
+  moduleId: string;
+  moduleName: string;
+  /**
+   * Resolved statement text — what the AI should see. Refs that fail
+   * resolution fall back to the raw ref string with a warn log.
+   */
+  learningOutcomes: string[];
+  /** Raw outcome refs (e.g. "OUT-01") — needed by teaching-content FK lookup. */
+  outcomeRefs: string[];
+  masteryThreshold: number;
+  /** All sibling module ids in the same curriculum, in order. */
+  allModuleIds: string[];
+  /**
+   * True when this caller has any prior progress on this curriculum
+   * (`CallerModuleProgress.callCount > 0` OR a `lo_mastery` attr exists).
+   * Used by pedagogy.ts to gate retrieval/review instructions so first-time
+   * learners don't get hallucinated "review of baseline work" openers.
+   */
+  hasPriorMastery: boolean;
+  /** Optional fields some COMPOSE consumers expect. */
+  prerequisites?: string[];
+  content?: Record<string, unknown>;
+  description?: string | null;
+}
+
+export interface ResolveOpts {
+  /** Picker selection from the current Call.requestedModuleId. */
+  requestedModuleId?: string | null;
+  /** Fallback playbookId from the call record itself (for SIM testers without enrollment). */
+  callPlaybookId?: string | null;
+  /** Lightweight logger — accepts info/warn so the call sites can plug in their own. */
+  log?: { info: (msg: string, data?: unknown) => void; warn: (msg: string, data?: unknown) => void };
+  /**
+   * Optional preloaded caller domainId, used only by the legacy SubjectDomain
+   * path (5). When omitted that path is skipped.
+   */
+  callerDomainId?: string | null;
+}
+
+const NO_LOG = { info: () => {}, warn: () => {} };
+
+interface AuthoredModuleShape {
+  id?: string;
+  label?: string;
+  outcomesPrimary?: unknown;
+  prerequisites?: unknown;
+  content?: Record<string, unknown>;
+  position?: number;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function resolveOutcomeText(
+  refs: string[],
+  outcomes: Record<string, string>,
+  log: NonNullable<ResolveOpts["log"]>,
+  moduleId: string,
+): string[] {
+  const known = Object.keys(outcomes).length > 0;
+  if (!known) return refs;
+  const resolved: string[] = [];
+  const missing: string[] = [];
+  for (const ref of refs) {
+    const text = outcomes[ref];
+    if (text) resolved.push(text);
+    else {
+      missing.push(ref);
+      resolved.push(ref); // Fall back to ref so AI still sees something.
+    }
+  }
+  if (missing.length > 0) {
+    log.warn(
+      `Module ${moduleId}: ${missing.length} unknown outcome ref(s) — kept as bare refs`,
+      { missing },
+    );
+  }
+  return resolved;
+}
+
+async function computeHasPriorMastery(
+  callerId: string,
+  curriculumId: string | null,
+  specSlug: string,
+): Promise<boolean> {
+  if (curriculumId) {
+    const cmp = await prisma.callerModuleProgress.findFirst({
+      where: { callerId, callCount: { gt: 0 }, module: { curriculumId } },
+      select: { id: true },
+    });
+    if (cmp) return true;
+  }
+  // Fallback: any LO mastery attribute under this curriculum's spec key prefix.
+  try {
+    const progress = await getCurriculumProgress(callerId, specSlug);
+    return Object.keys(progress.modulesMastery).length > 0
+      || Object.keys(progress.loMastery).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveCurrentModule(
+  callerId: string,
+  opts: ResolveOpts = {},
+): Promise<ResolvedModule | null> {
+  const log = opts.log ?? NO_LOG;
+  let resolvedPlaybookId = await resolvePlaybookId(callerId);
+  if (!resolvedPlaybookId && opts.callPlaybookId) {
+    log.info("No enrollment; using call.playbookId as fallback", {
+      callPlaybookId: opts.callPlaybookId,
+    });
+    resolvedPlaybookId = opts.callPlaybookId;
+  }
+  if (!resolvedPlaybookId) return null;
+
+  const pb = await prisma.playbook.findUnique({
+    where: { id: resolvedPlaybookId },
+    select: {
+      name: true,
+      config: true,
+      curricula: {
+        orderBy: { createdAt: "asc" },
+        take: 1,
+        select: { id: true, slug: true },
+      },
+      items: {
+        where: {
+          itemType: "SPEC",
+          isEnabled: true,
+          spec: { specRole: "CONTENT", isActive: true },
+        },
+        select: {
+          spec: { select: { slug: true, config: true } },
+        },
+      },
+    },
+  });
+
+  const cfg = (pb?.config ?? {}) as Record<string, any>;
+  const authored: AuthoredModuleShape[] = Array.isArray(cfg.modules) ? cfg.modules : [];
+  const knownOutcomes: Record<string, string> =
+    cfg.outcomes && typeof cfg.outcomes === "object" && !Array.isArray(cfg.outcomes)
+      ? (cfg.outcomes as Record<string, string>)
+      : {};
+  const fallbackSpecSlug = `playbook-${resolvedPlaybookId.slice(0, 8)}-modules`;
+  const primaryCurriculum = pb?.curricula[0] ?? null;
+
+  function buildAuthored(
+    chosen: AuthoredModuleShape,
+    source: Extract<ResolvedModuleSource, `picker` | `authored-${string}`>,
+    hasPrior: boolean,
+  ): ResolvedModule {
+    const rawRefs: string[] = Array.isArray(chosen.outcomesPrimary)
+      ? (chosen.outcomesPrimary as string[]).filter((s): s is string => typeof s === "string")
+      : [];
+    const learningOutcomes = resolveOutcomeText(rawRefs, knownOutcomes, log, chosen.id ?? "(unknown)");
+    const specSlug = primaryCurriculum?.slug ?? fallbackSpecSlug;
+    log.info(`Module context resolved (${source})`, {
+      moduleId: chosen.id,
+      specSlug,
+      loCount: learningOutcomes.length,
+      droppedRefs: rawRefs.length - learningOutcomes.filter((t, i) => t !== rawRefs[i]).length,
+    });
+    return {
+      source,
+      specSlug,
+      moduleId: chosen.id ?? "(unknown)",
+      moduleName: chosen.label || chosen.id || "(unknown)",
+      learningOutcomes,
+      outcomeRefs: rawRefs,
+      masteryThreshold: 0.7,
+      allModuleIds: authored.map((m) => m.id).filter((id): id is string => typeof id === "string"),
+      hasPriorMastery: hasPrior,
+      prerequisites: Array.isArray(chosen.prerequisites)
+        ? (chosen.prerequisites as string[])
+        : undefined,
+      content: chosen.content,
+    };
+  }
+
+  // ── Path 1: picker override ─────────────────────────
+  if (opts.requestedModuleId) {
+    const match = authored.find((m) => m.id === opts.requestedModuleId);
+    if (match) {
+      const hasPrior = await computeHasPriorMastery(
+        callerId,
+        primaryCurriculum?.id ?? null,
+        primaryCurriculum?.slug ?? fallbackSpecSlug,
+      );
+      return buildAuthored(match, "picker", hasPrior);
+    }
+    log.warn("requestedModuleId not in Playbook.config.modules — falling through", {
+      requestedModuleId: opts.requestedModuleId,
+      playbookId: resolvedPlaybookId,
+    });
+  }
+
+  // ── Path 2: authored fallback (no picker) ───────────
+  if (cfg.modulesAuthored === true && authored.length > 0) {
+    const curriculumId = primaryCurriculum?.id ?? null;
+    let chosen: AuthoredModuleShape | null = null;
+    let source: Extract<ResolvedModuleSource, `authored-${string}`> = "authored-first-incomplete";
+
+    if (curriculumId) {
+      const prevCall = await prisma.call.findFirst({
+        where: { callerId, curriculumModuleId: { not: null } },
+        orderBy: { createdAt: "desc" },
+        select: { curriculumModuleId: true },
+      });
+      if (prevCall?.curriculumModuleId) {
+        const prevMod = await prisma.curriculumModule.findUnique({
+          where: { id: prevCall.curriculumModuleId },
+          select: { slug: true, curriculumId: true },
+        });
+        if (prevMod && prevMod.curriculumId === curriculumId) {
+          const candidate = authored.find((m) => m.id === prevMod.slug) ?? null;
+          if (candidate) {
+            const completed = await prisma.callerModuleProgress.findFirst({
+              where: {
+                callerId,
+                moduleId: prevCall.curriculumModuleId,
+                status: "COMPLETED",
+              },
+              select: { id: true },
+            });
+            if (!completed) {
+              chosen = candidate;
+              source = "authored-prev-call";
+            }
+          }
+        }
+      }
+
+      if (!chosen) {
+        const completedRows = await prisma.callerModuleProgress.findMany({
+          where: { callerId, status: "COMPLETED", module: { curriculumId } },
+          select: { module: { select: { slug: true } } },
+        });
+        const completedSlugs = new Set(completedRows.map((r) => r.module.slug));
+        const ordered = [...authored].sort(
+          (a, b) => (a.position ?? 0) - (b.position ?? 0),
+        );
+        chosen = ordered.find((m) => m.id && !completedSlugs.has(m.id)) ?? null;
+        source = "authored-first-incomplete";
+      }
+    }
+
+    if (!chosen) {
+      chosen = authored[0] ?? null;
+      source = "authored-first";
+    }
+
+    if (chosen?.id) {
+      const hasPrior = await computeHasPriorMastery(
+        callerId,
+        primaryCurriculum?.id ?? null,
+        primaryCurriculum?.slug ?? fallbackSpecSlug,
+      );
+      return buildAuthored(chosen, source, hasPrior);
+    }
+  }
+
+  // ── Legacy Path 3: CONTENT-role spec items ──────────
+  if (pb?.items?.length) {
+    for (const item of pb.items) {
+      const spec = item.spec;
+      if (!spec) continue;
+      const specCfg = spec.config as Record<string, any> | null;
+      if (!specCfg) continue;
+      const modules = specCfg.modules || specCfg.curriculum?.modules || [];
+      if (!Array.isArray(modules) || modules.length === 0) continue;
+
+      const progress = await getCurriculumProgress(callerId, spec.slug);
+      const currentModuleId = progress.currentModuleId || modules[0]?.id || modules[0]?.slug;
+      const currentModule = modules.find((m: any) => (m.id || m.slug) === currentModuleId) || modules[0];
+      if (!currentModule) continue;
+
+      const rawRefs: string[] = Array.isArray(currentModule.learningOutcomes)
+        ? (currentModule.learningOutcomes as string[])
+        : [];
+      log.warn("Resolved via legacy CONTENT-spec path — verify if this course still needs it", {
+        playbookId: resolvedPlaybookId,
+        playbookName: pb?.name,
+        specSlug: spec.slug,
+        moduleId: currentModule.id || currentModule.slug,
+      });
+
+      const hasPrior = await computeHasPriorMastery(
+        callerId,
+        primaryCurriculum?.id ?? null,
+        spec.slug,
+      );
+      return {
+        source: "content-spec",
+        specSlug: spec.slug,
+        moduleId: currentModule.id || currentModule.slug,
+        moduleName: currentModule.name || currentModule.title || currentModule.id,
+        learningOutcomes: rawRefs,
+        outcomeRefs: rawRefs,
+        masteryThreshold: specCfg.metadata?.curriculum?.masteryThreshold ?? 0.7,
+        allModuleIds: modules.map((m: any) => m.id || m.slug),
+        hasPriorMastery: hasPrior,
+        prerequisites: Array.isArray(currentModule.prerequisites)
+          ? currentModule.prerequisites
+          : undefined,
+        content: currentModule.content,
+        description: asString(currentModule.description),
+      };
+    }
+  }
+
+  // ── Legacy Path 4: Curriculum.notableInfo.modules ───
+  if (resolvedPlaybookId) {
+    const pbCurriculum = await prisma.curriculum.findFirst({
+      where: { playbookId: resolvedPlaybookId },
+      orderBy: { updatedAt: "desc" },
+      select: { id: true, slug: true, notableInfo: true },
+    });
+    if (pbCurriculum?.notableInfo) {
+      const rawModules = (pbCurriculum.notableInfo as Record<string, any>)?.modules;
+      if (Array.isArray(rawModules) && rawModules.length > 0) {
+        const progress = await getCurriculumProgress(callerId, pbCurriculum.slug);
+        const currentModuleId = progress.currentModuleId || rawModules[0]?.id;
+        const currentModule = rawModules.find((m: any) => m.id === currentModuleId) || rawModules[0];
+        if (currentModule) {
+          log.warn("Resolved via legacy notableInfo.modules path — verify if this course still needs it", {
+            playbookId: resolvedPlaybookId,
+            playbookName: pb?.name,
+            specSlug: pbCurriculum.slug,
+            moduleId: currentModule.id,
+          });
+          const rawRefs: string[] = Array.isArray(currentModule.learningOutcomes)
+            ? (currentModule.learningOutcomes as string[])
+            : [];
+          const hasPrior = await computeHasPriorMastery(
+            callerId,
+            pbCurriculum.id,
+            pbCurriculum.slug,
+          );
+          return {
+            source: "playbook-curriculum",
+            specSlug: pbCurriculum.slug,
+            moduleId: currentModule.id,
+            moduleName: currentModule.name || currentModule.title || currentModule.id,
+            learningOutcomes: rawRefs,
+            outcomeRefs: rawRefs,
+            masteryThreshold: 0.7,
+            allModuleIds: rawModules.map((m: any) => m.id),
+            hasPriorMastery: hasPrior,
+            prerequisites: Array.isArray(currentModule.prerequisites)
+              ? currentModule.prerequisites
+              : undefined,
+            content: currentModule.content,
+            description: asString(currentModule.description),
+          };
+        }
+      }
+    }
+  }
+
+  // ── Legacy Path 5: SubjectDomain ────────────────────
+  if (opts.callerDomainId) {
+    const subjectDomains = await prisma.subjectDomain.findMany({
+      where: { domainId: opts.callerDomainId },
+      include: {
+        subject: {
+          include: {
+            curricula: {
+              orderBy: { updatedAt: "desc" },
+              take: 1,
+              select: { id: true, slug: true, notableInfo: true },
+            },
+          },
+        },
+      },
+    });
+
+    for (const sd of subjectDomains) {
+      const curriculum = sd.subject.curricula[0];
+      if (!curriculum?.notableInfo) continue;
+      const rawModules = (curriculum.notableInfo as Record<string, any>)?.modules;
+      if (!Array.isArray(rawModules) || rawModules.length === 0) continue;
+
+      const progress = await getCurriculumProgress(callerId, curriculum.slug);
+      const currentModuleId = progress.currentModuleId || rawModules[0]?.id;
+      const currentModule = rawModules.find((m: any) => m.id === currentModuleId) || rawModules[0];
+      if (!currentModule) continue;
+
+      log.warn("Resolved via legacy SubjectDomain curriculum path — verify if this course still needs it", {
+        domainId: opts.callerDomainId,
+        specSlug: curriculum.slug,
+        moduleId: currentModule.id,
+      });
+
+      const rawRefs: string[] = Array.isArray(currentModule.learningOutcomes)
+        ? (currentModule.learningOutcomes as string[])
+        : [];
+      const masteryThreshold =
+        (await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1"))?.masteryComplete ?? 0.7;
+      const hasPrior = await computeHasPriorMastery(
+        callerId,
+        curriculum.id,
+        curriculum.slug,
+      );
+      return {
+        source: "subject-curriculum",
+        specSlug: curriculum.slug,
+        moduleId: currentModule.id,
+        moduleName: currentModule.title || currentModule.name || currentModule.id,
+        learningOutcomes: rawRefs,
+        outcomeRefs: rawRefs,
+        masteryThreshold,
+        allModuleIds: rawModules.map((m: any) => m.id),
+        hasPriorMastery: hasPrior,
+        prerequisites: Array.isArray(currentModule.prerequisites)
+          ? currentModule.prerequisites
+          : undefined,
+        content: currentModule.content,
+        description: asString(currentModule.description),
+      };
+    }
+  }
+
+  return null;
+}

--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -412,8 +412,22 @@ export async function computeSharedState(
       ))
     : Math.max(0, estimatedProgress - 1);
 
-  // Module to review = last completed (or first if no progress)
-  const moduleToReview = modules[lastCompletedIndex] || modules[0] || null;
+  // #288: any LO mastery attribute counts as prior progress, even if the
+  // caller has zero CallerModuleProgress rows yet (continuous mode writes
+  // attrs first, rows on completion).
+  const hasLoMasteryAttr = data.callerAttributes.some(
+    (a) => a.scope === "CURRICULUM" && a.key.includes(":lo_mastery:") && a.numberValue != null,
+  );
+
+  // #288: Module to review = last completed module — or null when the learner
+  // has no prior progress at all. The previous fallback to `modules[0]`
+  // produced "review of baseline work" hallucinations on first-call learners
+  // because pedagogy.ts rendered a retrieval block against a module the
+  // learner had never seen.
+  const moduleToReview =
+    completedModules.size > 0 || hasLoMasteryAttr
+      ? (modules[lastCompletedIndex] || modules[0] || null)
+      : null;
 
   // Next module = one after last completed
   const nextModuleIndex = lastCompletedIndex + 1;
@@ -435,44 +449,41 @@ export async function computeSharedState(
   // scheduler MUST be bypassed at compose time — otherwise selectNextExchange
   // overwrites `nextModule` with its frontier choice and downstream transforms
   // narrate the wrong module. Symmetric to the pipeline-side override at
-  // pipeline/route.ts:108 (mastery scoring for end-of-call).
+  // pipeline/route.ts:loadCurrentModuleContext (mastery scoring for end-of-call).
+  // #288: outcome refs are resolved to text inside resolveCurrentModule so the
+  // tutor opener doesn't see opaque "OUT-01" strings and hallucinate a quiz.
   let lockedModule: ModuleData | null = null;
+  let lockedOutcomeRefs: string[] = [];
   const requestedModuleId = (specConfig.requestedModuleId as string | undefined) || undefined;
-  if (requestedModuleId) {
-    // Match against Playbook.config.modules (the authored shape). The picker
-    // emits the AuthoredModule.id as ?requestedModuleId=… so we match on id.
-    // pbConfig is declared further down (line ~672) for the isFinalSession
-    // logic — read directly here to avoid temporal-dead-zone gymnastics.
-    const lockedPbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, unknown>;
-    const authored = (Array.isArray(lockedPbConfig.modules) ? lockedPbConfig.modules : []) as Array<{
-      id?: string;
-      label?: string;
-      outcomesPrimary?: unknown;
-      prerequisites?: unknown;
-      content?: Record<string, unknown>;
-    }>;
-    const match = authored.find((m) => m?.id === requestedModuleId);
-    if (match) {
+  if (requestedModuleId && data.caller?.id) {
+    const { resolveCurrentModule } = await import("@/lib/curriculum/resolve-current-module");
+    const resolved = await resolveCurrentModule(data.caller.id, {
+      requestedModuleId,
+      log: {
+        info: (msg, meta) => console.log(`[modules] ${msg}`, meta ?? ""),
+        warn: (msg, meta) => console.warn(`[modules] ${msg}`, meta ?? ""),
+      },
+    });
+    if (resolved && resolved.source === "picker") {
       lockedModule = {
-        id: match.id,
-        slug: match.id || "",
-        // AuthoredModule has `label` not `name`; map for downstream `ModuleData` consumers.
-        name: match.label || match.id || requestedModuleId,
-        description: null,
-        learningOutcomes: Array.isArray(match.outcomesPrimary) ? (match.outcomesPrimary as string[]) : undefined,
-        prerequisites: Array.isArray(match.prerequisites) ? (match.prerequisites as string[]) : undefined,
-        content: match.content,
+        id: resolved.moduleId,
+        slug: resolved.moduleId,
+        name: resolved.moduleName,
+        description: resolved.description ?? null,
+        learningOutcomes: resolved.learningOutcomes,
+        prerequisites: resolved.prerequisites,
+        content: resolved.content,
       };
+      lockedOutcomeRefs = resolved.outcomeRefs;
       // Force `nextModule` so quickstart's existing this_session / first_line
-      // logic narrates the locked choice (Slice B will add explicit branches).
+      // logic narrates the locked choice.
       nextModule = lockedModule;
       console.log(
-        `[modules] #274 Slice A: locked to module "${requestedModuleId}" (label="${lockedModule.name}") — scheduler BYPASSED.`,
+        `[modules] Locked to module "${requestedModuleId}" (label="${lockedModule.name}", ${resolved.learningOutcomes.length} outcomes resolved) — scheduler BYPASSED.`,
       );
     } else {
-      // Fallback to scheduler — same behaviour as pipeline route's miss path.
       console.warn(
-        `[modules] #274: requestedModuleId "${requestedModuleId}" not found in Playbook.config.modules — falling back to scheduler.`,
+        `[modules] requestedModuleId "${requestedModuleId}" did not resolve to picker source — falling back to scheduler.`,
       );
     }
   }
@@ -752,6 +763,12 @@ export async function computeSharedState(
     hasAttemptData,
     // #274 Slice A: locked module from picker (null when not picked or unmatched)
     lockedModule,
+    // #288: raw outcome refs accompanying the locked module's resolved-text
+    // outcomes — preserved for FK lookup in teaching-content.
+    lockedOutcomeRefs: lockedOutcomeRefs.length > 0 ? lockedOutcomeRefs : undefined,
+    // #288: gate for retrieval/review pedagogy — true when any prior progress
+    // exists (CallerModuleProgress with callCount > 0 OR :lo_mastery: attr).
+    hasPriorMastery: hasAttemptData || hasLoMasteryAttr,
   };
 }
 

--- a/apps/admin/lib/prompt/composition/transforms/pedagogy.ts
+++ b/apps/admin/lib/prompt/composition/transforms/pedagogy.ts
@@ -24,7 +24,7 @@ registerTransform("computeSessionPedagogy", (
   const {
     isFirstCall, isFirstCallInDomain,
     modules, moduleToReview, nextModule, reviewType, reviewReason,
-    schedulerDecision, callNumber,
+    schedulerDecision, callNumber, hasPriorMastery,
   } = context.sharedState;
   const domain = context.loadedData.caller?.domain;
   const onboardingSpec = context.loadedData.onboardingSpec;
@@ -287,17 +287,21 @@ registerTransform("computeSessionPedagogy", (
     console.log(`[pedagogy] Scheduler call ${callNumber}: ${mode}`);
   } else if (hasCurriculum) {
     // === GENERIC RETURNING CALLER MODE (with curriculum) ===
-    plan.flow = [
-      "1. Reconnect - reference last session specifically",
-      `2. Spaced retrieval (${reviewType}) - recall question on ${moduleToReview?.name || "previous concept"}`,
-      "3. Reinforce or correct based on their recall",
-      `4. Bridge - connect ${moduleToReview?.name || "old"} to ${nextModule?.name || "new material"}`,
-      `5. New material - introduce ${nextModule?.name || "next concept"}`,
-      "6. Integrate - question using both old and new",
-      "7. Close with summary and preview",
-    ];
-
-    if (moduleToReview) {
+    // #288: split this branch on `hasPriorMastery`. A returning caller with
+    // no prior progress (e.g. their first authored-course session, even if
+    // they made a discovery call before) must NOT be told to do spaced
+    // retrieval — there's nothing to retrieve. Without this gate the AI
+    // hallucinates "review of last session" / "baseline work".
+    if (hasPriorMastery && moduleToReview) {
+      plan.flow = [
+        "1. Reconnect - reference last session specifically",
+        `2. Spaced retrieval (${reviewType}) - recall question on ${moduleToReview.name}`,
+        "3. Reinforce or correct based on their recall",
+        `4. Bridge - connect ${moduleToReview.name} to ${nextModule?.name || "new material"}`,
+        `5. New material - introduce ${nextModule?.name || "next concept"}`,
+        "6. Integrate - question using both old and new",
+        "7. Close with summary and preview",
+      ];
       plan.reviewFirst = {
         module: moduleToReview.name,
         reason: reviewReason,
@@ -307,12 +311,24 @@ registerTransform("computeSessionPedagogy", (
             ? "Give a scenario requiring them to apply the concept"
             : "Walk through the concept again with a fresh example",
       };
+    } else {
+      // First session on this curriculum — no priors to review.
+      plan.sessionType = "FIRST_CURRICULUM_SESSION";
+      plan.flow = [
+        "1. Welcome and orient - acknowledge this is the start of focused work on this material",
+        `2. Set goal - what ${nextModule?.name || "this session"} covers and why it matters`,
+        "3. Introduce - lead with examples or a concrete situation, then surface the concept",
+        "4. Practice - learner attempts; tutor coaches and corrects",
+        "5. Wrap - summarise what was covered, preview next session",
+      ];
     }
 
     if (nextModule) {
       plan.newMaterial = {
         module: nextModule.name,
-        approach: `After confirming ${moduleToReview?.name || "previous"} understanding, introduce ${nextModule.description || "new concepts"}`,
+        approach: hasPriorMastery && moduleToReview
+          ? `After confirming ${moduleToReview.name} understanding, introduce ${nextModule.description || "new concepts"}`
+          : `Introduce ${nextModule.description || "new concepts"} — lead with examples before definitions.`,
       };
     }
   } else {

--- a/apps/admin/lib/prompt/composition/transforms/teaching-content.ts
+++ b/apps/admin/lib/prompt/composition/transforms/teaching-content.ts
@@ -496,11 +496,18 @@ registerTransform("renderTeachingContent", (
   } else if (currentModule?.learningOutcomes?.length && allAssertions.length > 0) {
     // Fallback: no scheduler working set (no modules, or scheduler failed).
     // Filter to current module LOs. #142: Prefer FK path, fall back to string-ref.
-    const moduleLOs = currentModule.learningOutcomes as string[];
+    // #288: When the picker locked an authored module, `learningOutcomes` now
+    // carries resolved STATEMENT TEXT (so the AI sees grounded outcomes), and
+    // the raw refs sit on `sharedState.lockedOutcomeRefs`. Prefer those for
+    // ref-based filtering — text won't match the LO\d+ regex.
+    const lockedRefs = context.sharedState?.lockedOutcomeRefs as string[] | undefined;
+    const refsForLookup = lockedRefs && lockedRefs.length > 0
+      ? lockedRefs
+      : (currentModule.learningOutcomes as string[]);
     const loRefToId = context.sharedState?.loRefToIdMap as Map<string, string> | undefined;
 
     if (loRefToId) {
-      const moduleLoIds = moduleLOs
+      const moduleLoIds = refsForLookup
         .map((lo) => {
           const match = lo.match(/^(LO\d+|AC[\d.]+)/i);
           const ref = match ? match[1] : lo;
@@ -521,7 +528,7 @@ registerTransform("renderTeachingContent", (
 
     // Fallback: string-ref matching
     if (assertions === allAssertions) {
-      const loIds = moduleLOs.map((lo) => {
+      const loIds = refsForLookup.map((lo) => {
         const match = lo.match(/^(LO\d+|AC[\d.]+)/i);
         return match ? match[1] : lo;
       });

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -287,6 +287,21 @@ export interface SharedComputedState {
    * the scheduler runs as today (silent fallback, warn log).
    */
   lockedModule?: ModuleData | null;
+  /**
+   * #288: Raw outcome refs from the locked authored module (e.g.
+   * `["OUT-01","OUT-02"]`). `lockedModule.learningOutcomes` carries resolved
+   * statement TEXT (so the AI sees grounded outcomes instead of opaque IDs);
+   * this companion field carries the original refs so consumers that need to
+   * resolve back to LO FKs (teaching-content.ts) keep working.
+   */
+  lockedOutcomeRefs?: string[];
+  /**
+   * #288: True when this learner has any prior progress on this curriculum —
+   * either a `CallerModuleProgress.callCount > 0` OR a `:lo_mastery:` attribute.
+   * Pedagogy uses this to gate retrieval/review instructions so first-time
+   * learners don't get hallucinated "review of baseline work" openers.
+   */
+  hasPriorMastery?: boolean;
   /** Call number (1-based) — this is the Nth call for this learner */
   callNumber: number;
   /** Synthetic lesson plan entry built from scheduler working set (for downstream transform compat) */


### PR DESCRIPTION
## Summary

Collapses five "which module is this caller on?" code paths that had drifted across two call sites into one helper. Side-effect: fixes the bad opener at its source and removes the spaced-retrieval hallucination on first sessions.

### Before — 5 paths × 2 call sites + 4 pedagogy branches

| Side | Layer | Branches |
|---|---|---|
| EXTRACT (`pipeline/route.ts:loadCurrentModuleContext`) | 5 | picker, authored fallback (#285), CONTENT-spec, notableInfo.modules, SubjectDomain |
| COMPOSE (`transforms/modules.ts`) | 3 | lockedModule, scheduler, generic |
| PEDAGOGY (`transforms/pedagogy.ts`) | 4 | first-call, in-domain, scheduler, generic |

### After — single helper + one boolean

- `apps/admin/lib/curriculum/resolve-current-module.ts` — one resolver used by both EXTRACT and COMPOSE.
- Internal priority: picker → authored fallback → CONTENT-spec (WARN) → notableInfo.modules (WARN) → SubjectDomain (WARN). Deprecated paths log so we can confirm they're dead before deletion.
- Returns `learningOutcomes` as resolved statement TEXT (via `Playbook.config.outcomes`) and original refs on `outcomeRefs` for FK lookup compatibility.
- Returns `hasPriorMastery` derived from `CallerModuleProgress.callCount > 0` OR `:lo_mastery:` attribute.
- COMPOSE-side `lockedModule` block delegates to helper → AI sees outcome text not opaque "OUT-01" → meta-quiz opener gone.
- `moduleToReview` no longer falls back to `modules[0]` for zero-progress callers → "review your baseline work" hallucination gone.
- Pedagogy generic-returning-caller branch splits on `hasPriorMastery` → first-curriculum-session flow introduces material instead of asking to recall non-existent priors.

### Diff shape

`pipeline/route.ts` → `loadCurrentModuleContext` shrinks from ~210 LOC of inline branches to a thin adapter. Net: +596 / -236 across 6 files (most of the +596 is the new helper file with all five paths consolidated).

### Supersedes

- **PR #285** — Path 0.5 logic lives inside the helper now. Close #285 without merging once this lands.

### TL must-fixes addressed

1. ✅ `ResolvedModule` carries `content` + `prerequisites`.
2. ✅ `outcomeRefs` (raw) on sharedState; `learningOutcomes` (text) into prompt sections; `teaching-content.ts` prefers refs for FK lookup.
3. ✅ `authored-*` sources do not suppress scheduler — only `picker` source produces lockedModule.
4. ✅ `hasPriorMastery = hasAttemptData || hasLoMasteryAttr`.
5. ⏭ Unit test file deferred to a follow-up alongside the legacy-path deletion once WARN logs prove Paths 3-5 are unused.

## Test plan

- [ ] Sim call as Freya (`?requestedModuleId=part1`) — opener should reference an actual Part 1 outcome (e.g. sustaining a familiar-topic answer), not "the four IELTS scoring criteria"
- [ ] Same caller, no `requestedModuleId` — Path 0.5 still picks `part1` (or first non-completed); mastery writes a `CallerModuleProgress` row
- [ ] Pre-existing course on the legacy CONTENT-spec or notableInfo.modules path — pipeline log shows the deprecation WARN once, but resolution succeeds
- [ ] Zero-progress caller — pedagogy plan has `sessionType: FIRST_CURRICULUM_SESSION`, no `reviewFirst` block
- [ ] Caller with prior mastery — pedagogy plan still has `reviewFirst` (no regression on continuous mode)

Closes #284
Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)