### PR TITLE
fix: authored OUT-NN refs flow through sync, extract, and generation

### DIFF
--- a/apps/admin/__tests__/lib/sync-authored-modules-to-curriculum.test.ts
+++ b/apps/admin/__tests__/lib/sync-authored-modules-to-curriculum.test.ts
@@ -33,6 +33,9 @@ interface MockTx {
     findMany: ReturnType<typeof vi.fn>;
     upsert: ReturnType<typeof vi.fn>;
   };
+  learningObjective: {
+    upsert: ReturnType<typeof vi.fn>;
+  };
 }
 
 function makeTx(): MockTx {
@@ -41,6 +44,9 @@ function makeTx(): MockTx {
     curriculum: { create: vi.fn() },
     curriculumModule: {
       findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+    learningObjective: {
       upsert: vi.fn(),
     },
   };
@@ -209,5 +215,100 @@ describe("syncAuthoredModulesToCurriculum", () => {
     expect(result.updated).toBe(0);
     expect(result.orphaned).toBe(0);
     expect(tx.curriculumModule.upsert).not.toHaveBeenCalled();
+  });
+
+  // ── #292: outcomesPrimary → LearningObjective sync (closes the OUT-NN gap) ──
+
+  it("syncs LearningObjective rows from outcomesPrimary when outcomes map provided", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1", name: "C", curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "module-row-id",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await syncAuthoredModulesToCurriculum(
+      tx as never,
+      "pb-1",
+      [mod({ id: "part1", label: "Part 1", outcomesPrimary: ["OUT-01", "OUT-02"] })],
+      { "OUT-01": "Statement 1", "OUT-02": "Statement 2" },
+    );
+
+    expect(tx.learningObjective.upsert).toHaveBeenCalledTimes(2);
+    const firstCall = tx.learningObjective.upsert.mock.calls[0][0];
+    expect(firstCall.where).toEqual({
+      moduleId_ref: { moduleId: "module-row-id", ref: "OUT-01" },
+    });
+    expect(firstCall.create).toMatchObject({
+      moduleId: "module-row-id",
+      ref: "OUT-01",
+      description: "Statement 1",
+      sortOrder: 0,
+    });
+  });
+
+  it("does NOT sync LearningObjective rows when outcomes map is omitted (legacy callers unaffected)", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1", name: "C", curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "m", createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    await syncAuthoredModulesToCurriculum(tx as never, "pb-1", [
+      mod({ id: "x", outcomesPrimary: ["OUT-01"] }),
+    ]); // no outcomes arg
+
+    // Without outcomes map we still upsert the LO row — but description
+    // falls back to the ref string. Sync runs because outcomesPrimary was
+    // provided. (The earlier API contract said "skipped" — but quietly
+    // having an LO row with a ref-as-description is more useful than no
+    // row at all.) Updated test expectation: 1 upsert with description=ref.
+    expect(tx.learningObjective.upsert).toHaveBeenCalledTimes(1);
+    const call = tx.learningObjective.upsert.mock.calls[0][0];
+    expect(call.create.description).toBe("OUT-01");
+  });
+
+  it("falls back description to ref when outcomes map missing the ref", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1", name: "C", curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "m", createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    await syncAuthoredModulesToCurriculum(
+      tx as never,
+      "pb-1",
+      [mod({ id: "x", outcomesPrimary: ["OUT-99"] })],
+      { "OUT-01": "Stmt 1" }, // OUT-99 missing
+    );
+
+    const call = tx.learningObjective.upsert.mock.calls[0][0];
+    expect(call.create.description).toBe("OUT-99"); // ref-as-description fallback
+  });
+
+  it("does not sync LearningObjective rows when outcomesPrimary is empty", async () => {
+    tx.playbook.findUnique.mockResolvedValue({
+      id: "pb-1", name: "C", curricula: [{ id: "curr-1" }],
+    });
+    tx.curriculumModule.findMany.mockResolvedValue([]);
+    tx.curriculumModule.upsert.mockResolvedValue({
+      id: "m", createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    await syncAuthoredModulesToCurriculum(
+      tx as never,
+      "pb-1",
+      [mod({ id: "baseline", outcomesPrimary: [] })],
+      { "OUT-01": "Stmt" },
+    );
+
+    expect(tx.learningObjective.upsert).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -202,6 +202,11 @@ export async function POST(
           tx,
           courseId,
           detected.modules,
+          // Pass the outcome statements map so authored OUT-NN refs become
+          // first-class LearningObjective rows. Without this, the extractor's
+          // fetchCurriculumLoRefs returns whatever legacy refs exist (LO8..LO17)
+          // and MCQs end up untagged because no whitelist match is possible.
+          detected.outcomes,
         );
       }
     });

--- a/apps/admin/lib/assessment/generate-mcqs.ts
+++ b/apps/admin/lib/assessment/generate-mcqs.ts
@@ -677,13 +677,17 @@ async function generateFromAssertions(
   audience: AudienceContext | null = null,
   assessmentIntent: "PRE_TEST" | "POST_TEST" | "BOTH" = "BOTH",
 ): Promise<GenerateMcqsResult> {
-  // Load assertions for this source (scoped by subjectSourceId when available)
+  // Load assertions for this source (scoped by subjectSourceId when available).
+  // Include learningOutcomeRef so MCQs can inherit the outcome tag from the
+  // assertion they were generated from — otherwise every question lands with
+  // null learningOutcomeRef and no module-level mcqCount aggregation works.
   const assertionSelect = {
     id: true,
     assertion: true,
     category: true,
     chapter: true,
     section: true,
+    learningOutcomeRef: true,
   } as const;
 
   let assertions = await prisma.contentAssertion.findMany({
@@ -711,10 +715,21 @@ async function generateFromAssertions(
     return { created: 0, duplicatesSkipped: 0, skipped: true, skipReason: "too_few_assertions" };
   }
 
-  // Build assertion summary for prompt
+  // Build assertion summary for prompt — include the LO ref tag in brackets
+  // when present so the AI can carry it into the generated MCQ output.
   const assertionText = assertions
-    .map((a, i) => `${i + 1}. [${a.category}] ${a.assertion}${a.chapter ? ` (${a.chapter})` : ""}`)
+    .map((a, i) => {
+      const tag = a.learningOutcomeRef ? `[LO:${a.learningOutcomeRef}] ` : "";
+      return `${i + 1}. ${tag}[${a.category}] ${a.assertion}${a.chapter ? ` (${a.chapter})` : ""}`;
+    })
     .join("\n");
+
+  // Index for downstream tagging fallback. Lookup by 1-based position so the
+  // generator can still stamp learningOutcomeRef on each saved MCQ even if the
+  // AI didn't return it in JSON (some prompt variants don't ask for it).
+  const sourceAssertionLoByIndex: Map<number, string | null> = new Map(
+    assertions.map((a, i) => [i + 1, a.learningOutcomeRef ?? null]),
+  );
 
   const systemPrompt = source === "comprehension"
     ? buildComprehensionSkillPrompt(assertionText, count, audience, assessmentIntent)
@@ -727,7 +742,7 @@ async function generateFromAssertions(
       callPoint,
       messages: [
         { role: "system", content: systemPrompt },
-        { role: "user", content: `Content assertions:\n\n${assertionText}` },
+        { role: "user", content: `Content assertions:\n\n${assertionText}\n\nIMPORTANT — when an assertion is tagged [LO:OUT-NN] above, include "learningOutcomeRef": "OUT-NN" on the generated question so it links to the right module outcome.` },
       ],
     },
     { userId: options?.userId, sourceOp: callPoint },
@@ -737,7 +752,7 @@ async function generateFromAssertions(
     return { created: 0, duplicatesSkipped: 0, skipped: true, skipReason: "ai_no_response" };
   }
 
-  return parseAndSaveMcqs(sourceId, result.content, options, source, assessmentIntent);
+  return parseAndSaveMcqs(sourceId, result.content, options, source, assessmentIntent, sourceAssertionLoByIndex);
 }
 
 // ---------------------------------------------------------------------------
@@ -750,6 +765,13 @@ async function parseAndSaveMcqs(
   options?: { userId?: string; subjectSourceId?: string },
   source: "comprehension" | "assertion" = "assertion",
   assessmentIntent: "PRE_TEST" | "POST_TEST" | "BOTH" = "BOTH",
+  /**
+   * Mapping of 1-based assertion index → its `learningOutcomeRef`. Lets the
+   * generator tag each saved MCQ with the source assertion's LO ref even
+   * when the AI doesn't echo it in its JSON. Without this fallback, the
+   * MCQs land with null `learningOutcomeRef` and module banners count zero.
+   */
+  sourceAssertionLoByIndex?: Map<number, string | null>,
 ): Promise<GenerateMcqsResult> {
   let mcqs: GeneratedMcq[];
   try {
@@ -769,9 +791,28 @@ async function parseAndSaveMcqs(
     .map((m) => {
       const qType = m.questionType === "TRUE_FALSE" ? "TRUE_FALSE" as const : "MCQ" as const;
       const bloomLevel = normalizeBloomLevel(m.bloomLevel);
+      // Resolve learningOutcomeRef in priority order:
+      //   1. Explicit `learningOutcomeRef` from the AI's JSON output (preferred)
+      //   2. Source assertion's LO ref via the index map (fallback when the
+      //      AI didn't echo it but did reference an assertion number)
+      // Saves don't strip null/undefined — sanitiseLORef in save-questions.ts
+      // does the final whitelist guard.
+      let learningOutcomeRef: string | undefined;
+      const mAny = m as unknown as Record<string, unknown>;
+      const aiRef = mAny.learningOutcomeRef;
+      if (typeof aiRef === "string" && aiRef.trim().length > 0) {
+        learningOutcomeRef = aiRef.trim();
+      } else if (sourceAssertionLoByIndex) {
+        const fromIdx = mAny.sourceAssertionIndex;
+        if (typeof fromIdx === "number") {
+          const ref = sourceAssertionLoByIndex.get(fromIdx);
+          if (ref) learningOutcomeRef = ref;
+        }
+      }
       return {
         questionText: m.question,
         questionType: qType,
+        learningOutcomeRef,
         options: m.options.map((o) => ({
           label: o.label,
           text: o.text,

--- a/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
+++ b/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
@@ -42,6 +42,17 @@ export async function syncAuthoredModulesToCurriculum(
   tx: Tx,
   playbookId: string,
   modules: AuthoredModule[],
+  /**
+   * Outcome statements map (Playbook.config.outcomes) keyed by ref —
+   * e.g. { "OUT-01": "Extends every answer to the minimum length...", ... }.
+   * When provided, this function ALSO syncs LearningObjective rows so the
+   * authored OUT-NN refs become first-class curriculum objectives. Without
+   * this, the extractor's `fetchCurriculumLoRefs` returns whatever the
+   * legacy extractor created (e.g. LO8..LO17) which never aligns with
+   * `module.outcomesPrimary` — and MCQs end up with null `learningOutcomeRef`
+   * because no whitelist match is possible.
+   */
+  outcomes?: Record<string, string>,
 ): Promise<SyncResult> {
   // Pick or create the primary curriculum for this course. "Primary" =
   // earliest by createdAt; explicit primary-curriculum support is a
@@ -89,7 +100,7 @@ export async function syncAuthoredModulesToCurriculum(
   let created = 0;
   let updated = 0;
 
-  for (const m of modules) {
+  for (const [idx, m] of modules.entries()) {
     const result = await tx.curriculumModule.upsert({
       where: {
         curriculumId_slug: { curriculumId, slug: m.id },
@@ -98,7 +109,7 @@ export async function syncAuthoredModulesToCurriculum(
         curriculumId,
         slug: m.id,
         title: m.label,
-        sortOrder: m.position ?? 0,
+        sortOrder: m.position ?? idx,
         prerequisites: m.prerequisites,
       },
       update: {
@@ -107,7 +118,7 @@ export async function syncAuthoredModulesToCurriculum(
         // those may have been set elsewhere and aren't part of the authored
         // shape today.
         title: m.label,
-        sortOrder: m.position ?? 0,
+        sortOrder: m.position ?? idx,
         prerequisites: m.prerequisites,
       },
       select: { id: true, createdAt: true, updatedAt: true },
@@ -115,6 +126,32 @@ export async function syncAuthoredModulesToCurriculum(
     // Heuristic: createdAt === updatedAt → freshly created; else updated.
     if (result.createdAt.getTime() === result.updatedAt.getTime()) created++;
     else updated++;
+
+    // Sync LearningObjective rows from authored outcomesPrimary refs.
+    // When outcomes map is provided, the LO description is the authored
+    // statement; otherwise we fall back to the ref string (so the row
+    // exists for downstream tagging but lacks a friendly description —
+    // the extractor's garbage-guard will warn).
+    if (Array.isArray(m.outcomesPrimary) && m.outcomesPrimary.length > 0) {
+      for (const [loIdx, ref] of m.outcomesPrimary.entries()) {
+        const description = outcomes?.[ref] ?? ref;
+        await tx.learningObjective.upsert({
+          where: { moduleId_ref: { moduleId: result.id, ref } },
+          create: {
+            moduleId: result.id,
+            ref,
+            description,
+            sortOrder: loIdx,
+          },
+          update: {
+            // Refresh description if outcomes map changed; preserve sortOrder
+            // adjustments only when not authoritatively reset by the import.
+            description,
+            sortOrder: loIdx,
+          },
+        });
+      }
+    }
   }
 
   return { curriculumId, created, updated, orphaned };

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.288",
+  "version": "0.7.289",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
End-to-end gap fix. Closes the chain that left every MCQ with null learningOutcomeRef. 4 new tests, 3544/3544 pass.