### PR TITLE
fix: STRUCTURED_LO_REF_PATTERN accepts OUT-NN authored refs

### DIFF
--- a/apps/admin/lib/content-trust/validate-lo-linkage.ts
+++ b/apps/admin/lib/content-trust/validate-lo-linkage.ts
@@ -23,13 +23,15 @@
  */
 
 /**
- * Matches structured LO refs: LO1, LO-1, LO12, AC2.3, R04-LO2-AC2.3, etc.
- * Case-insensitive. Hyphen between LO and the number is optional — both "LO1"
- * and "LO-1" are accepted because the legacy `parseLORef` synthesiser wrote
- * the hyphenated form into the DB. Rejects free-text values like
- * "Character analysis".
+ * Matches structured LO refs across both naming schemes:
+ *   - Legacy: `LO1`, `LO-1`, `LO12`, `AC2.3`, `R04-LO2-AC2.3` (auto-extractor era)
+ *   - Authored (#258): `OUT-01`, `OUT-1`, `OUT12` (parsed from `**OUT-NN: ...**`
+ *     headings in course-reference markdown; carried into `Playbook.config.modules`
+ *     `outcomesPrimary` and synced into LearningObjective rows by #292)
+ * Case-insensitive. Hyphen between prefix and the number is optional. Rejects
+ * free-text values like "Character analysis".
  */
-export const STRUCTURED_LO_REF_PATTERN = /^(LO-?\d+|AC[\d.]+|R\d+-LO-?\d+(?:-AC[\d.]+)?)$/i;
+export const STRUCTURED_LO_REF_PATTERN = /^(LO-?\d+|OUT-?\d+|AC[\d.]+|R\d+-LO-?\d+(?:-AC[\d.]+)?)$/i;
 
 /**
  * Normalise a raw LO ref string to its canonical form, or return null if it

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.289",
+  "version": "0.7.290",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/content-trust/validate-lo-linkage.test.ts
+++ b/apps/admin/tests/lib/content-trust/validate-lo-linkage.test.ts
@@ -36,6 +36,15 @@ describe("validate-lo-linkage", () => {
       expect(STRUCTURED_LO_REF_PATTERN.test("LO")).toBe(false);
       expect(STRUCTURED_LO_REF_PATTERN.test("1")).toBe(false);
     });
+
+    // ── #292/#293: authored OUT-NN refs (course-reference markdown #258) ──
+
+    it("matches OUT-01, OUT-12, OUT123 (authored scheme)", () => {
+      expect(STRUCTURED_LO_REF_PATTERN.test("OUT-01")).toBe(true);
+      expect(STRUCTURED_LO_REF_PATTERN.test("OUT-1")).toBe(true);
+      expect(STRUCTURED_LO_REF_PATTERN.test("OUT12")).toBe(true);
+      expect(STRUCTURED_LO_REF_PATTERN.test("out-27")).toBe(true);
+    });
   });
 
   describe("sanitiseLORef", () => {
@@ -61,6 +70,12 @@ describe("validate-lo-linkage", () => {
       expect(sanitiseLORef(undefined)).toBe(null);
       expect(sanitiseLORef("")).toBe(null);
       expect(sanitiseLORef("   ")).toBe(null);
+    });
+
+    it("preserves OUT-NN authored refs through sanitisation", () => {
+      expect(sanitiseLORef("OUT-01")).toBe("OUT-01");
+      expect(sanitiseLORef("out-27")).toBe("OUT-27");
+      expect(sanitiseLORef("  OUT-12  ")).toBe("OUT-12");
     });
   });
 


### PR DESCRIPTION
Final missing piece for the authored-outcomes flow. Without this, every OUT-NN ref the AI wrote got stripped to null by sanitiseLORef. 3546/3546 pass.