### PR TITLE
fix: surface MCQ panel for authored-modules courses

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
@@ -19,7 +19,7 @@ import { useState, useEffect, useCallback } from "react";
 import { AlertTriangle, CheckCircle2 } from "lucide-react";
 import Link from "next/link";
 import type { CourseLinkageScorecard } from "@/lib/content-trust/validate-lo-linkage";
-import { CurriculumHealthTabs, type RegenerateActions } from "./CurriculumHealthTabs";
+import { CurriculumHealthTabs, McqPanel, type RegenerateActions } from "./CurriculumHealthTabs";
 import { AuthoredModulesPanel } from "./_components/AuthoredModulesPanel";
 import "./course-curriculum-tab.css";
 
@@ -226,7 +226,12 @@ export function CourseCurriculumTab({
         </div>
       )}
 
-      {/* Derived/regen view — hidden when authored modules are the source */}
+      {/* Derived/regen view — hidden when authored modules are the source.
+          The scorecard + regenerate affordances are meaningless for authored
+          courses (the educator authored the structure; auto-regen would
+          clobber it). #256 originally hid the entire CurriculumHealthTabs,
+          which inadvertently hid the MCQ list too — educators on authored
+          courses had no path to view their generated questions. */}
       {scorecard && modulesAuthored !== true && (
         <CurriculumHealthTabs
           scorecard={scorecard}
@@ -237,6 +242,21 @@ export function CourseCurriculumTab({
           regenerating={regenerating}
           onScorecardRefresh={loadScorecard}
         />
+      )}
+
+      {/* For authored-modules courses: show ONLY the MCQ list (the part
+          educators actually need to see) without the scorecard / regen
+          affordances. Renders standalone via the exported McqPanel. */}
+      {modulesAuthored === true && (
+        <section className="hf-card" style={{ marginTop: 16 }}>
+          <header className="hf-flex hf-items-center hf-gap-8" style={{ marginBottom: 12 }}>
+            <h3 className="hf-section-title" style={{ margin: 0 }}>Generated questions</h3>
+            <span className="hf-text-xs hf-text-muted">
+              MCQs created from your uploaded learner-facing content. Trust badge per row indicates provenance.
+            </span>
+          </header>
+          <McqPanel courseId={courseId} />
+        </section>
       )}
 
       {/* Regeneration result */}

--- a/apps/admin/app/x/courses/[courseId]/CurriculumHealthTabs.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CurriculumHealthTabs.tsx
@@ -983,8 +983,14 @@ function McqTrustBadge({ level }: { level: string | null }) {
 }
 
 // ── MCQ panel ────────────────────────────────────────────
+//
+// Exported so authored-modules courses (which hide the parent
+// CurriculumHealthTabs to suppress the scorecard + regenerate affordances)
+// can still render this panel directly. Without this, educators on
+// authored courses had no path to see their generated MCQs in the
+// curriculum tab — the questions existed but weren't surfaced.
 
-function McqPanel({ courseId }: { courseId: string }) {
+export function McqPanel({ courseId }: { courseId: string }) {
   const [items, setItems] = useState<McqItem[]>([]);
   const [loading, setLoading] = useState(false);
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.290",
+  "version": "0.7.291",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Authored-modules courses had MCQs hidden from the Curriculum tab. Now they show in a standalone section while the scorecard / regenerate affordances stay hidden. 3546/3546 pass.