### PR TITLE
fix: hide 'Regenerate curriculum' CTA for authored-modules courses

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
@@ -192,8 +192,13 @@ export function CourseCurriculumTab({
   // #208: Curriculum exists but has zero modules — surface a recovery CTA
   // before the rest of the scorecard renders, so educators don't see a
   // health card with no actionable next step.
+  // Authored-modules courses are excluded: their structure is educator-
+  // authored and "Regenerate curriculum" would clobber it. The
+  // AuthoredModules panel (above) is the right surface for them.
   const hasZeroModules =
-    !!curriculumId && (scorecard?.structure?.activeModules ?? 0) === 0;
+    !!curriculumId
+    && (scorecard?.structure?.activeModules ?? 0) === 0
+    && modulesAuthored !== true;
 
   return (
     <div className="hf-stack-md">

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.291",
+  "version": "0.7.292",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Foot-gun fix. Authored courses no longer see the recovery CTA that would clobber their config.