### PR TITLE
fix: deep-logging default to false (prod-launch blocker)

### DIFF
--- a/apps/admin/lib/deep-logging.ts
+++ b/apps/admin/lib/deep-logging.ts
@@ -14,12 +14,16 @@ import { prisma } from "@/lib/prisma";
 const DEEP_LOGGING_KEY = "deep_logging_enabled";
 
 /**
- * Check if deep logging is enabled (default: true for market test).
+ * Check if deep logging is enabled (default: false — production-safe).
  * Uses 30s TTL cache from system-settings — near-zero overhead per AI call.
- * TODO(prod-launch): Reset default to false before production launch.
+ *
+ * The DB-backed SystemSetting toggle in the StatusBar lets ops flip this
+ * on for an environment when needed (market test, debugging). Default-off
+ * keeps prod logs clean and avoids storing full prompts/responses by
+ * accident on a fresh deploy.
  */
 export async function isDeepLoggingEnabled(): Promise<boolean> {
-  return getSystemSetting(DEEP_LOGGING_KEY, true);
+  return getSystemSetting(DEEP_LOGGING_KEY, false);
 }
 
 /**

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.292",
+  "version": "0.7.293",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Per the prod-launch TODO. Default-off; ops flips on per-env via StatusBar.