### PR TITLE
chore: clarify picker launchSelected TODO

### DIFF
--- a/a-sample-docs/ielts-speaking-mock-exam-strategy.md
+++ b/a-sample-docs/ielts-speaking-mock-exam-strategy.md
@@ -1,0 +1,286 @@
+# IELTS Speaking — Mock Exam Strategy
+
+A learner-facing companion to `ielts-speaking-practice-content.md`. This doc focuses on **how to run a full mock test, diagnose your own performance, and recover when something goes wrong mid-test**. Upload alongside (not instead of) any IELTS Band Descriptors / scoring rubric. The system classifies this as `TEXTBOOK` / `READING_PASSAGE` (NOT `COURSE_REFERENCE`), so the MCQ generator sources from it and produces actual exam-strategy items rather than rubric trivia.
+
+Coverage:
+- §1 Full mock-exam walkthroughs (at exam pace)
+- §2 Self-diagnosis vocabulary across the four criteria
+- §3 Recovery scripts — what to say when things go wrong
+- §4 Collocations + phrasal verbs for exam talk
+- §5 Pronunciation drills under time pressure
+
+This doc is **strictly learner-facing prose**. No band numbers. No rubric language. Everything here is something a learner can say, do, or notice on the day.
+
+---
+
+## §1 Full mock-exam walkthroughs (at exam pace)
+
+A real Speaking test runs **11–14 minutes** end-to-end with no breaks. You have to switch register three times — chatty in Part 1, monologic in Part 2, analytical in Part 3 — and you don't get a re-do. The sample run below is timed at exam pace (read it aloud and check the clock).
+
+### 1.1 Full mock — "the 12-minute run"
+
+> **Examiner (Part 1, 4 min):** "Good morning. Could you tell me your full name, please?"
+>
+> **You:** "Yes, my name's Anna Klimenko. Most people just call me Anna."
+>
+> **Examiner:** "And where are you from?"
+>
+> **You:** "Originally from Kyiv, in Ukraine, but I've been living in Manchester for the last three years now, so I'd say I've got one foot in each place."
+>
+> **Examiner:** "Let's talk about hometowns. Do you live in a place you'd describe as quiet or busy?"
+>
+> **You:** "Manchester is definitely on the busy side — there's always something going on, especially at weekends. I quite like that, actually. I grew up somewhere a bit sleepier, so the energy here suits me. The downside is the traffic, which can be a bit of a nightmare around rush hour."
+>
+> *(continues through 6–8 short Q/A pairs, ~15–25s each)*
+>
+> ---
+>
+> **Examiner (Part 2, 3–4 min):** "I'd like you to describe a skill you'd like to learn. You'll have one minute to prepare. You can make notes if you wish. Then I'd like you to talk for between one and two minutes."
+>
+> *(60s prep — jot 4 keywords on the cue card: WHAT / WHY / HOW / OUTCOME)*
+>
+> **You (long turn):** "A skill I've been wanting to learn for a while now is touch-typing properly. At the moment I'm what you'd call a hunt-and-peck typist — I look at the keyboard, I use about four fingers, and although I'm reasonably fast, I know I'm hitting a ceiling.
+>
+> The reason I want to learn it is partly practical and partly, I suppose, about not feeling left behind. I write a lot in my work, and I find that the moments when I'm typing are also the moments when I lose my train of thought, because part of my brain is busy looking for the right key. If I could type without looking, I think my writing would actually flow better.
+>
+> In terms of how I'd go about it, I'd probably use one of those structured online programmes — there are a few free ones — and commit to fifteen minutes a day for a couple of months. The hardest part, from what I've heard, is the early stage, where you have to deliberately slow down to relearn the muscle memory.
+>
+> If I did manage it, the outcome I'd hope for is just that the typing becomes invisible — that I stop noticing it. Right now it's a small but constant friction in my day, and I'd love to clear it out."
+>
+> ---
+>
+> **Examiner (Part 3, 4–5 min):** "We've been talking about learning a skill. Let's discuss this more broadly. Why do you think some adults find it harder to learn new skills than children do?"
+>
+> **You:** "I think there are a few reasons, and they probably stack on top of each other. The first is just time and competing demands — children have whole afternoons and weekends to immerse themselves in something, whereas adults are usually fitting practice in around work, family, all the rest of it.
+>
+> But there's also a psychological piece. Adults tend to be much more self-conscious about being beginners. We're used to being competent, and the feeling of being clumsy at something new is genuinely uncomfortable, so a lot of people quit before they get past the awkward stage.
+>
+> Having said that, I'd push back a bit on the idea that adults are inherently slower learners. In some ways we're better — we can structure our practice, set goals, monitor progress. The challenge isn't really cognitive, I'd say; it's emotional."
+>
+> *(continues through 4–6 abstract Q/A pairs, ~30–45s each)*
+>
+> ---
+>
+> **Examiner:** "Thank you. That is the end of the speaking test."
+
+That's roughly 12 minutes of continuous talk. The point of running it end-to-end is to feel the **fatigue gradient** — Part 3 always feels harder than Part 1 because you've been talking for ten minutes already.
+
+### 1.2 What to track during a mock
+
+After each full run, jot down (in 30 seconds or less):
+
+- One moment you **stalled** — what was the question, what stopped you?
+- One moment you **recovered well** — how did you do it?
+- One phrase you used that **felt awkward** — could you say it differently next time?
+- One topic where your vocab felt **thin** — go drill that area.
+
+Don't try to fix everything. Pick **one** thing per mock to work on between runs.
+
+---
+
+## §2 Self-diagnosis vocabulary across the four criteria
+
+These are words and phrases you can use **about your own speaking**, when reflecting after a mock. Knowing this language helps you spot your own patterns.
+
+### 2.1 Fluency + flow (how it sounds)
+
+- *I tailed off / I lost my thread / I trailed off mid-sentence*
+- *I rushed it / I sped through that / I gabbled the answer*
+- *I was groping for the word / I was searching for it / it wouldn't come*
+- *I filled the gap with "um" / I padded the start with "well…" / I bought myself time with "that's a good question"*
+- *I hit my stride about a minute in / I warmed up gradually / it took me a while to settle*
+
+### 2.2 Vocabulary range (what you reached for)
+
+- *I went for the safe word / I played it safe lexically / I stuck to the basics*
+- *I overused "good" / "nice" / "interesting" — I leaned on it three times*
+- *I tried a more ambitious word and it didn't quite fit / I overreached*
+- *I used a fixed phrase that landed well / I had a chunk ready to go*
+- *I needed a precise word and only had a vague one to hand*
+
+### 2.3 Grammar + structure (how the sentences held up)
+
+- *I tangled my tenses there / I switched tense mid-sentence*
+- *I started a sentence I couldn't finish / I painted myself into a corner*
+- *I leaned on the same structure too often / I kept saying "I think that…"*
+- *I tried a conditional and didn't pull it off cleanly*
+- *That answer was all simple sentences / I didn't subordinate enough*
+
+### 2.4 Pronunciation + delivery (how it carried)
+
+- *My voice trailed off at the end of sentences / my endings dropped*
+- *I sounded flat / monotone / under-energised*
+- *My stress fell on the wrong syllable in "advertisement"*
+- *My linking was clean / I joined words smoothly / it flowed*
+- *I was tripping over the consonant clusters in "strengths"*
+
+These are diagnostic phrases — keep them in your back pocket. After a mock, write three sentences using them: *"In Part 2 I tailed off at minute 1:30 and filled with um. My vocab was thin around technology — I leaned on 'useful' four times. My pronunciation held up except on 'particularly' which I rushed."*
+
+---
+
+## §3 Recovery scripts — what to say when things go wrong
+
+Things go wrong in every Speaking test. The skill isn't avoiding the bad moment — it's **moving through it without freezing**. These are pre-rehearsed lines you can deploy instantly.
+
+### 3.1 You don't understand the question
+
+- "Sorry, would you mind rephrasing that? I want to make sure I answer the right question."
+- "Could you say that again? I caught the first part but lost the second half."
+- "By [word X], do you mean [paraphrase]? I just want to check I'm with you."
+
+You can ask for clarification **once** in Part 1 and Part 3 without penalty. Don't bluff.
+
+### 3.2 You go blank mid-sentence
+
+- "Sorry — let me start that thought again."
+- "What I'm trying to say is —"
+- "Let me put that differently."
+- "Give me a second to think about that properly."
+
+Saying *something* is always better than silence. Even "let me think for a moment" buys you time without breaking flow.
+
+### 3.3 You can't think of the exact word
+
+- "I can't think of the precise word, but it's the kind of thing where —"
+- "There's a specific term for this; for now I'd just say [paraphrase]."
+- "Something along the lines of [near-synonym]."
+- "It's like [analogy] but more [adjective]."
+
+Examiners want to hear you **navigate around** missing vocab, not panic about it.
+
+### 3.4 You realise mid-answer that you've gone off-topic
+
+- "Actually, to come back to the question —"
+- "Sorry, I'm wandering — the main point is —"
+- "To bring it back to what you asked —"
+
+Self-correcting your own drift is a sign of control, not weakness.
+
+### 3.5 You stumble over a word in pronunciation
+
+- *Don't restart the whole sentence.* Just say the word again, cleanly, and continue.
+- "*— particu— particularly* in winter, the —"
+- A single quick re-attempt is invisible. Three restarts in a row sounds like panic.
+
+### 3.6 You feel the test slipping away (Part 2 specifically)
+
+- If you've talked for only 30 seconds and run out of ideas, switch to **why it matters to you**: "And the reason this stays with me is —"
+- If you're at 1:30 and the examiner is about to stop you, land cleanly: "— and that's really what I'd say about it."
+- Never trail off into mumbled half-sentences. End on a complete thought, even a short one.
+
+---
+
+## §4 Collocations + phrasal verbs for exam talk
+
+### 4.1 Talking about pace
+
+- *to keep up the pace / to lose momentum / to settle into a rhythm*
+- *to hit your stride / to find your feet / to warm up gradually*
+- *to tail off / to peter out / to run out of steam*
+
+### 4.2 Talking about preparation
+
+- *to prep up for / to swot up on / to brush up on*
+- *to be primed / to be match-fit / to be in good shape for*
+- *to wing it / to play it by ear / to muddle through*
+
+### 4.3 Talking about confidence + nerves
+
+- *to have butterflies / to have first-night nerves / to be on edge*
+- *to talk yourself up / to psych yourself up / to settle your nerves*
+- *to keep your head / to hold it together / to stay composed*
+
+### 4.4 Talking about recovery
+
+- *to bounce back / to pick up where you left off / to get back on track*
+- *to gather your thoughts / to compose yourself / to take stock*
+- *to draw a blank / to lose the thread / to grind to a halt*
+
+### 4.5 Talking about reflection
+
+- *on reflection / looking back / with hindsight*
+- *what I took from it / what stuck with me / what stayed with me*
+- *to put my finger on / to nail down / to pin down (the issue)*
+
+---
+
+## §5 Pronunciation drills under time pressure
+
+Pace matters. These drills train you to maintain articulation **even when you're rushing**.
+
+### 5.1 The 30-second elevator pitch
+
+Say each of these in **exactly 30 seconds** — no faster, no slower. Use a stopwatch.
+
+> *"A skill I've been meaning to pick up for years now is something quite ordinary — I'd like to learn to cook properly, by which I mean from scratch, without recipes, the way my grandmother used to. It's not glamorous, but it's the kind of skill I think pays you back every day, and I've been putting it off for too long."*
+
+> *"The book that's stayed with me most isn't a novel — it's a memoir I read about ten years ago, written by someone who walked the length of Britain in winter. What I took from it wasn't really about walking; it was about how much you notice when you slow down enough to actually look at the place you live in."*
+
+If you're finishing in 22 seconds, you're rushing. If you're at 38, you're meandering. **30 seconds, on the dot.**
+
+### 5.2 Tongue-twister drills (for stressed speech)
+
+Read each three times — slowly, then medium, then fast. The goal is **clean articulation under speed**.
+
+- *"She sells specific shells specifically on the seventh shore."*
+- *"Particularly, particularly — I particularly think it's a particular case."*
+- *"Strengths and lengths — she lengthens her strengths."*
+- *"The thirty-three thinkers thought thirty thoughts thoroughly."*
+- *"World-renowned, world-renowned, the world-renowned author roared."*
+
+Words like *particularly, strengths, world-renowned* are exam regulars. Drill them until they're automatic.
+
+### 5.3 Recovery breathing drill
+
+If you feel your voice tightening mid-test, this resets you in three seconds:
+
+1. Inhale through the nose for 2 seconds.
+2. Exhale slowly while saying *"and"* — drawing it out, *"aaaand"*.
+3. Continue the sentence on the same exhale: *"aaand the reason I think that is —"*
+
+Practise this so it becomes invisible. Examiners hear *"and"*; you've actually just bought yourself a full breath.
+
+### 5.4 Pacing markers — the four checkpoints in Part 2
+
+When you start your 1–2 minute Part 2 talk, internally mark four checkpoints:
+
+- **0:15** — finished setting up the topic
+- **0:45** — into the meat of the answer
+- **1:15** — adding nuance / a complication
+- **1:45** — landing on a clean conclusion
+
+Practise hitting these in your home runs. By the test, your internal clock will know where you are without you having to think about it.
+
+### 5.5 The "land it" sentence
+
+Always have a closing-style sentence rehearsed for Part 2, in case the examiner stops you abruptly:
+
+- *"— and that's really the heart of what I'd say about it."*
+- *"— so that's the moment that comes to mind."*
+- *"— and I think that captures most of what I'd want to say."*
+
+Never trail off. Always **land**.
+
+---
+
+## How this content gets used
+
+When uploaded:
+- Classification routes to `TEXTBOOK` / `READING_PASSAGE` (NOT `COURSE_REFERENCE` — that's reserved for the Band Descriptors).
+- Extraction pulls assertions about exam-pace strategy, self-diagnosis phrasing, recovery scripts, and pacing drills.
+- MCQ generator sources from these assertions → produces questions that test **exam-day skill**, not rubric trivia.
+- Cross-question dedup (#276 Slice 2) keeps duplicate-flavoured items out.
+- Each question is stamped `trustLevel: AI_ASSISTED` (#276 Slice 3); curriculum admin shows a small badge.
+
+To use this alongside the practice-content doc:
+1. Upload both documents to the same Subject.
+2. The practice-content doc covers vocabulary + sample answers + drills.
+3. This doc covers the **strategy** layer — pacing, self-diagnosis, recovery.
+4. Hit "Reset MCQs" on the curriculum tab (or `POST /api/playbooks/[playbookId]/reset-mcqs`).
+5. New MCQs draw from both sources; pre-test fires.
+
+### Outcomes covered
+
+- **OUT-25** — *Completes a full mock test at exam pace.* Covered in §1 (full walkthrough) and §5 (pacing markers, 30-second drill, land-it sentence).
+- **OUT-26** — *Self-diagnoses across the four criteria.* Covered in §2 (vocabulary for fluency, range, grammar, pronunciation) and §1.2 (what to track).
+- **OUT-27** — *Recovers from a "bad moment".* Covered in §3 (recovery scripts) and §5.3 (recovery breathing drill).

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -165,13 +165,18 @@ function PickerContent() {
 
   const launchSelected = useCallback(
     (moduleId: string) => {
-      // TODO(#242 Slice 2): wire this into the real VAPI call-init flow once
-      // the dial path is identified. `useJourneyChat` is NOT a call-creator
-      // (per tech-lead review). For now, the picker logs the pick and bounces
-      // back to the SIM with `?requestedModuleId=<id>`; the SIM renders a
-      // placeholder banner so devs can verify end-to-end module routing.
+      // Status (2026-05-08):
+      //   ✅ SIM path is wired end-to-end via #250 (compose-prompt + Call.requestedModuleId
+      //      pickup #274 + tutor lockedModule narrative #266) — when returnTo points at
+      //      /x/sim/[id] the picker rewrites the URL with ?requestedModuleId and SimChat
+      //      forwards it on call init.
+      //   ⏳ VAPI / real voice dial path: NOT YET wired. The picker still bounces back to
+      //      a SIM session for voice scenarios; voice FOH integration would consume the
+      //      same /api/student/module-status data and pass requestedModuleId to the dial.
+      //      Tracked under #242 Slice 3 (in-chat picker — voice). Do not remove this
+      //      comment until Slice 3 lands.
       console.info(
-        "[picker] selected moduleId=%s for course=%s — placeholder, no VAPI dial yet",
+        "[picker] selected moduleId=%s for course=%s — SIM path active, VAPI dial deferred to #242 Slice 3",
         moduleId,
         courseId,
       );

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.293",
+  "version": "0.7.294",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
TODO is still valid — VAPI not wired. Just clarifying which slice landed and which is deferred so hygiene sweeps don't re-flag it.