### PR TITLE
feat: module-locked MCQ pool for pre-test (Closes #302)

### DIFF
--- a/apps/admin/app/api/student/assessment-questions/route.ts
+++ b/apps/admin/app/api/student/assessment-questions/route.ts
@@ -5,7 +5,12 @@
  * @auth session (STUDENT | OPERATOR+)
  * @tags student, assessment
  * @description Returns pre-test or post-test questions for the authenticated student.
- *   Pre-test sources MCQ questions from the enrolled curriculum's content.
+ *   Pre-test sources MCQ questions from the enrolled curriculum's content. When
+ *   the learner has picked a specific authored module via the picker (#302), the
+ *   pre-test pool is restricted to MCQs whose `learningOutcomeRef` is in that
+ *   module's `outcomesPrimary`. The lock is read from `Call.requestedModuleId`
+ *   on the caller's most recent call. Falls back to the full course pool with a
+ *   warning when no MCQ matches the lock.
  *   Post-test mirrors the exact pre-test questions (knowledge courses) or queries
  *   POST_TEST-tagged comprehension MCQs directly (comprehension courses).
  * @query type — "pre_test" | "post_test"
@@ -19,6 +24,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
 import { buildPreTest, buildPreTestForPlaybook, buildPostTest, buildComprehensionPostTest } from "@/lib/assessment/pre-test-builder";
+import type { AuthoredModule } from "@/lib/types/json-fields";
 
 const VALID_TYPES = new Set(["pre_test", "post_test"]);
 
@@ -78,6 +84,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       playbookId: true,
       playbook: {
         select: {
+          config: true,
           curricula: {
             where: { deliveryConfig: { not: null } },
             select: { id: true },
@@ -90,9 +97,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   const curriculumId = enrollment?.playbook?.curricula?.[0]?.id;
 
+  // #302: When the learner picked a module via the picker, restrict the pre-test
+  // pool to that module's outcomesPrimary. The picker writes requestedModuleId
+  // onto the Call row at session-init, so the most recent call is the lock.
+  const lockedOutcomeRefs = await resolveLockedOutcomeRefs(
+    callerId,
+    enrollment?.playbook?.config,
+  );
+
   // Try curriculum-scoped first, then fall back to playbook-wide search
   if (curriculumId) {
-    const result = await buildPreTest(curriculumId);
+    const result = await buildPreTest(curriculumId, { lockedOutcomeRefs });
     if (!result.skipped) {
       return NextResponse.json({ ok: true, ...result });
     }
@@ -100,11 +115,41 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   // Playbook-wide fallback — searches all subjects' content sources
   if (enrollment?.playbookId) {
-    const result = await buildPreTestForPlaybook(enrollment.playbookId);
+    const result = await buildPreTestForPlaybook(enrollment.playbookId, { lockedOutcomeRefs });
     return NextResponse.json({ ok: true, ...result });
   }
 
   return NextResponse.json(
     { ok: true, questions: [], questionIds: [], skipped: true, skipReason: "no_curriculum" },
   );
+}
+
+/**
+ * Resolve the locked module's outcomesPrimary for the most recent call by the
+ * caller, if any. Returns undefined when no module is locked or the id is stale.
+ */
+async function resolveLockedOutcomeRefs(
+  callerId: string,
+  playbookConfig: unknown,
+): Promise<string[] | undefined> {
+  const recentCall = await prisma.call.findFirst({
+    where: { callerId, requestedModuleId: { not: null } },
+    orderBy: { createdAt: "desc" },
+    select: { requestedModuleId: true },
+  });
+  const lockedId = recentCall?.requestedModuleId;
+  if (!lockedId) return undefined;
+
+  const cfg = playbookConfig as { modules?: AuthoredModule[] } | null | undefined;
+  const modules = Array.isArray(cfg?.modules) ? cfg!.modules : [];
+  const match = modules.find((m) => m?.id === lockedId);
+  const refs = Array.isArray(match?.outcomesPrimary) ? (match!.outcomesPrimary as string[]) : [];
+
+  if (!match) {
+    console.warn(
+      `[assessment-questions] requestedModuleId="${lockedId}" not found in Playbook.config.modules — pre-test will use full pool.`,
+    );
+    return undefined;
+  }
+  return refs.length > 0 ? refs : undefined;
 }

--- a/apps/admin/lib/assessment/pre-test-builder.ts
+++ b/apps/admin/lib/assessment/pre-test-builder.ts
@@ -361,23 +361,42 @@ export interface PreTestResult {
   sourceId?: string;
 }
 
+export interface BuildPreTestOptions {
+  /**
+   * When the learner has picked a specific authored module (#302), restrict the
+   * pre-test pool to MCQs whose `learningOutcomeRef` is in this set. If the
+   * resulting pool is empty, the builder falls back to the full course pool with
+   * a server-side warning so the pre-test is never silently skipped.
+   */
+  lockedOutcomeRefs?: string[];
+}
+
 /**
  * Build a pre-test question set for a given curriculum.
  * Returns questions as SurveyStepConfig[] ready for ChatSurvey rendering.
  */
-export async function buildPreTest(curriculumId: string): Promise<PreTestResult> {
-  return buildFromSourceIds(await getSourceIdsForCurriculum(curriculumId));
+export async function buildPreTest(
+  curriculumId: string,
+  opts?: BuildPreTestOptions,
+): Promise<PreTestResult> {
+  return buildFromSourceIds(await getSourceIdsForCurriculum(curriculumId), opts);
 }
 
 /**
  * Build a pre-test by searching all subjects linked to a playbook (course).
  * Broader search — finds questions across all content sources in the course.
  */
-export async function buildPreTestForPlaybook(playbookId: string): Promise<PreTestResult> {
-  return buildFromSourceIds(await getSourceIdsForPlaybook(playbookId));
+export async function buildPreTestForPlaybook(
+  playbookId: string,
+  opts?: BuildPreTestOptions,
+): Promise<PreTestResult> {
+  return buildFromSourceIds(await getSourceIdsForPlaybook(playbookId), opts);
 }
 
-async function buildFromSourceIds(sourceIds: string[]): Promise<PreTestResult> {
+async function buildFromSourceIds(
+  sourceIds: string[],
+  opts?: BuildPreTestOptions,
+): Promise<PreTestResult> {
   if (sourceIds.length === 0) {
     return { questions: [], questionIds: [], skipped: true, skipReason: "no_content_source" };
   }
@@ -388,16 +407,40 @@ async function buildFromSourceIds(sourceIds: string[]): Promise<PreTestResult> {
     return { questions: [], questionIds: [], skipped: true, skipReason: "no_questions", sourceId: sourceIds[0] };
   }
 
+  // #302: When a learner has locked a module, restrict the primary pool to
+  // questions tagged with that module's outcomesPrimary. Empty match falls back
+  // to the full pool (logged) so the pre-test is never silently skipped.
+  const lockedRefs = opts?.lockedOutcomeRefs;
+  let pool = allQuestions;
+  if (lockedRefs && lockedRefs.length > 0) {
+    const refSet = new Set(lockedRefs);
+    const lockedPool = allQuestions.filter(
+      (q) => q.learningOutcomeRef && refSet.has(q.learningOutcomeRef),
+    );
+    if (lockedPool.length > 0) {
+      pool = lockedPool;
+    } else {
+      console.warn(
+        `[pre-test] Locked module pool empty for refs [${lockedRefs.join(", ")}] — falling back to full course pool (${allQuestions.length} MCQs)`,
+      );
+    }
+  }
+
   const strategy = assessmentCfg.selectionStrategy;
 
   const primary =
     strategy === "bloom_spread"
-      ? selectByBloomSpread(allQuestions, assessmentCfg.questionCount)
+      ? selectByBloomSpread(pool, assessmentCfg.questionCount)
       : strategy === "one_per_module"
-        ? selectOnePerModule(allQuestions, assessmentCfg.questionCount)
-        : selectRandom(allQuestions, assessmentCfg.questionCount);
+        ? selectOnePerModule(pool, assessmentCfg.questionCount)
+        : selectRandom(pool, assessmentCfg.questionCount);
 
-  const selected = fillUp(primary, allQuestions, assessmentCfg.questionCount);
+  // fillUp first from the locked pool, then from the full pool so a thin lock
+  // still delivers questionCount questions overall.
+  const filledFromLocked = fillUp(primary, pool, assessmentCfg.questionCount);
+  const selected = pool === allQuestions
+    ? filledFromLocked
+    : fillUp(filledFromLocked, allQuestions, assessmentCfg.questionCount);
 
   // Convert to SurveyStepConfig
   const steps = selected.map(toSurveyStep).filter((s): s is SurveyStepConfig => s !== null);

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.294",
+  "version": "0.7.295",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/assessment/pre-test-builder.test.ts
+++ b/apps/admin/tests/lib/assessment/pre-test-builder.test.ts
@@ -1,0 +1,187 @@
+/**
+ * #302: Module-locked MCQ selection — when a learner has picked a module via
+ * the picker, the pre-test pool must restrict to that module's outcomesPrimary.
+ *
+ * Covers the four cases in the story:
+ *   - locked pool fully satisfies questionCount
+ *   - locked pool is thin (fill-up from full pool)
+ *   - locked pool is empty (full fallback + warning)
+ *   - no lock provided (no regression)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    contentQuestion: {
+      findMany: vi.fn(),
+    },
+    curriculum: {
+      findUnique: vi.fn(),
+    },
+    subjectSource: {
+      findMany: vi.fn(),
+    },
+    callerAttribute: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/contracts/registry", () => ({
+  ContractRegistry: {
+    getContract: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/knowledge/domain-sources", () => ({
+  getSourceIdsForPlaybook: vi.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { ContractRegistry } from "@/lib/contracts/registry";
+import * as domainSources from "@/lib/knowledge/domain-sources";
+import { buildPreTestForPlaybook } from "@/lib/assessment/pre-test-builder";
+
+interface MockMcq {
+  id: string;
+  ref: string | null;
+  text?: string;
+}
+
+function mcq({ id, ref, text }: MockMcq) {
+  return {
+    id,
+    questionText: text ?? `Q ${id}`,
+    questionType: "MCQ",
+    options: [
+      { label: "A", text: "alpha", isCorrect: true },
+      { label: "B", text: "beta" },
+      { label: "C", text: "gamma" },
+      { label: "D", text: "delta" },
+    ],
+    correctAnswer: "A",
+    answerExplanation: null,
+    chapter: ref ?? null,
+    section: null,
+    learningOutcomeRef: ref,
+    difficulty: 2,
+    bloomLevel: "REMEMBER",
+    skillRef: null,
+  };
+}
+
+describe("buildPreTestForPlaybook — module-locked selection (#302)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Assessment config: random strategy, 5-question pre-test
+    vi.mocked(ContractRegistry.getContract).mockResolvedValue({
+      config: {
+        phases: {
+          pre_test: { questionCount: 5, selectionStrategy: "random", questionTypes: ["MCQ"] },
+        },
+      },
+    } as Awaited<ReturnType<typeof ContractRegistry.getContract>>);
+    vi.mocked(domainSources.getSourceIdsForPlaybook).mockResolvedValue(["src-1"]);
+  });
+
+  it("locked pool fully satisfies count → all questions are part1 outcomes", async () => {
+    const part1Refs = ["OUT-01", "OUT-02", "OUT-05", "OUT-06", "OUT-07", "OUT-24"];
+    const allMcqs = [
+      ...part1Refs.flatMap((r) =>
+        [0, 1].map((j) => mcq({ id: `p1-${r}-${j}`, ref: r })),
+      ), // 12 part1 questions
+      ...["OUT-08", "OUT-10", "OUT-11", "OUT-25"].map((r) => mcq({ id: `other-${r}`, ref: r })),
+    ];
+    vi.mocked(prisma.contentQuestion.findMany).mockResolvedValue(allMcqs);
+
+    const res = await buildPreTestForPlaybook("pb-1", { lockedOutcomeRefs: part1Refs });
+
+    expect(res.skipped).toBe(false);
+    expect(res.questions).toHaveLength(5);
+    for (const q of res.questions) {
+      expect(part1Refs).toContain(allMcqs.find((m) => m.id === q.id)!.learningOutcomeRef);
+    }
+  });
+
+  it("locked pool is thin (3 of 5) → filled from full pool, locked 3 still appear first", async () => {
+    const part1Refs = ["OUT-01", "OUT-06"];
+    const lockedQs = [
+      mcq({ id: "p1-a", ref: "OUT-01" }),
+      mcq({ id: "p1-b", ref: "OUT-01" }),
+      mcq({ id: "p1-c", ref: "OUT-06" }),
+    ];
+    const otherQs = [
+      mcq({ id: "p2-a", ref: "OUT-08" }),
+      mcq({ id: "p2-b", ref: "OUT-10" }),
+      mcq({ id: "p3-a", ref: "OUT-15" }),
+      mcq({ id: "p3-b", ref: "OUT-19" }),
+    ];
+    vi.mocked(prisma.contentQuestion.findMany).mockResolvedValue([...lockedQs, ...otherQs]);
+
+    const res = await buildPreTestForPlaybook("pb-1", { lockedOutcomeRefs: part1Refs });
+
+    expect(res.skipped).toBe(false);
+    expect(res.questions).toHaveLength(5);
+    const lockedIds = new Set(lockedQs.map((q) => q.id));
+    const includedLocked = res.questions.filter((q) => lockedIds.has(q.id));
+    expect(includedLocked).toHaveLength(3); // all 3 locked appear
+    // The first 3 should be the locked set (selectRandom on locked pool first, then fillUp)
+    expect(res.questions.slice(0, 3).every((q) => lockedIds.has(q.id))).toBe(true);
+  });
+
+  it("locked pool is empty → full fallback with warning", async () => {
+    const allMcqs = [
+      mcq({ id: "p2-a", ref: "OUT-08" }),
+      mcq({ id: "p2-b", ref: "OUT-10" }),
+      mcq({ id: "p3-a", ref: "OUT-15" }),
+      mcq({ id: "p3-b", ref: "OUT-19" }),
+      mcq({ id: "mock-a", ref: "OUT-25" }),
+    ];
+    vi.mocked(prisma.contentQuestion.findMany).mockResolvedValue(allMcqs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await buildPreTestForPlaybook("pb-1", { lockedOutcomeRefs: ["OUT-99"] });
+
+    expect(res.skipped).toBe(false);
+    expect(res.questions).toHaveLength(5);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Locked module pool empty"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("no lock provided → no regression, full pool used", async () => {
+    const allMcqs = [
+      mcq({ id: "p1-a", ref: "OUT-01" }),
+      mcq({ id: "p2-a", ref: "OUT-08" }),
+      mcq({ id: "p3-a", ref: "OUT-15" }),
+      mcq({ id: "mock-a", ref: "OUT-25" }),
+      mcq({ id: "p1-b", ref: "OUT-06" }),
+    ];
+    vi.mocked(prisma.contentQuestion.findMany).mockResolvedValue(allMcqs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await buildPreTestForPlaybook("pb-1");
+
+    expect(res.skipped).toBe(false);
+    expect(res.questions).toHaveLength(5);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("ignores empty lockedOutcomeRefs array → behaves like no lock", async () => {
+    const allMcqs = [
+      mcq({ id: "p1-a", ref: "OUT-01" }),
+      mcq({ id: "p2-a", ref: "OUT-08" }),
+    ];
+    vi.mocked(prisma.contentQuestion.findMany).mockResolvedValue(allMcqs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await buildPreTestForPlaybook("pb-1", { lockedOutcomeRefs: [] });
+
+    expect(res.skipped).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

When a learner picks an authored module via the picker, the pre-test now restricts the MCQ pool to that module's `outcomesPrimary`. Previously a Part 1 learner on IELTS Speaking v2 could see ~77% Part 2/3/Mock questions because the assessment selector was module-blind while the prompt composition pipeline (`teaching_content`) already filtered correctly.

Lock source is `Call.requestedModuleId` on the caller's most recent call (set at session-init by the picker → SIM flow). Falls back to the full course pool with a server-side warning when no MCQ matches, so the pre-test is never silently skipped.

## Changes

- `lib/assessment/pre-test-builder.ts` — adds `BuildPreTestOptions.lockedOutcomeRefs`, post-fetch filter, two-tier `fillUp` so a thin lock still delivers `questionCount`
- `app/api/student/assessment-questions/route.ts` — resolves lock from latest call, looks up `outcomesPrimary` in `Playbook.config.modules`, passes through to builder. JSDoc updated.
- `tests/lib/assessment/pre-test-builder.test.ts` — first test file for this module. 5 cases covering: full-satisfy, thin pool fill-up, empty pool fallback (warns), no lock (no regression), empty array

## IELTS v2 backfill

None needed — verified all 13 existing MCQs have `learningOutcomeRef` populated, distribution part1: 3, part2: 4, part3: 4, mock: 2. Filter works on existing data immediately.

## Test plan

- [x] `npx vitest run tests/lib/assessment/` — 37/37 pass
- [x] No new TS errors (only pre-existing inference quirks in same file)
- [x] No new lint errors
- [ ] Smoke on hf-dev: Freya scenario — Part 1 learner sees only Part 1 MCQs

## Out of scope

- Generating more Part 1 MCQs (content gap, separate story)
- Post-test lock (mirrors pre-test IDs, inherits automatically)
- `retrieval-question-selector.ts` (already handles LO scope via composition pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)