### PR TITLE
feat: unify welcome-phase toggles across wizard + Course Design tab

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Wand2, ArrowRight, Check, MessageSquare, Target, Brain, ClipboardCheck, Sparkles, ThumbsUp } from 'lucide-react';
-import type { WelcomeConfig, NpsConfig } from '@/lib/types/json-fields';
-import { DEFAULT_WELCOME_CONFIG, DEFAULT_NPS_CONFIG } from '@/lib/types/json-fields';
+import { Wand2, ArrowRight, Check, Brain, Sparkles, ThumbsUp } from 'lucide-react';
+import type { IntakeConfig, NpsConfig } from '@/lib/types/json-fields';
+import { DEFAULT_INTAKE_CONFIG, DEFAULT_NPS_CONFIG } from '@/lib/types/json-fields';
+import { IntakeToggleGroup, type IntakeValues } from '@/components/wizards/IntakeToggleGroup';
 import { CourseSetupTracker } from '@/components/shared/CourseSetupTracker';
 import { CourseSummaryCard } from './CourseSummaryCard';
 import { archetypeLabel } from '@/lib/course/group-specs';
@@ -77,21 +78,31 @@ const FLOW_STATES: FlowStateConfig[] = [
   { key: 'COMPLETE', label: 'Complete', icon: <Check size={16} />, description: 'Course finished' },
 ];
 
-// ── Welcome Phase Toggles ──────────────────────────────
+// ── Intake ↔ IntakeValues mapping ───────────────────────
+//
+// `IntakeConfig` is the canonical persistence shape under
+// `Playbook.config.sessionFlow.intake`. `IntakeValues` is the flat shape used
+// by the shared `<IntakeToggleGroup>` (single source of truth across wizard
+// and Design tab). Convert at the UI boundary.
 
-interface WelcomePhase {
-  key: keyof WelcomeConfig;
-  label: string;
-  description: string;
-  icon: React.ReactNode;
+function intakeToValues(i: IntakeConfig): IntakeValues {
+  return {
+    goals: i.goals.enabled,
+    aboutYou: i.aboutYou.enabled,
+    knowledgeCheck: i.knowledgeCheck.enabled,
+    knowledgeCheckMode: i.knowledgeCheck.deliveryMode ?? 'mcq',
+    aiIntroCall: i.aiIntroCall.enabled,
+  };
 }
 
-const WELCOME_PHASES: WelcomePhase[] = [
-  { key: 'goals', label: 'Goals', description: 'Students set their learning goals', icon: <Target size={14} /> },
-  { key: 'aboutYou', label: 'About You', description: 'Confidence + motivation check', icon: <MessageSquare size={14} /> },
-  { key: 'knowledgeCheck', label: 'Knowledge Check', description: 'Baseline MCQs from curriculum. Also gates the open-ended "what do you already know?" probe in the first call.', icon: <ClipboardCheck size={14} /> },
-  { key: 'aiIntroCall', label: 'AI Introduction', description: 'Warm-up voice/chat call', icon: <Sparkles size={14} /> },
-];
+function valuesToIntake(v: IntakeValues): IntakeConfig {
+  return {
+    goals: { enabled: v.goals },
+    aboutYou: { enabled: v.aboutYou },
+    knowledgeCheck: { enabled: v.knowledgeCheck, deliveryMode: v.knowledgeCheckMode },
+    aiIntroCall: { enabled: v.aiIntroCall },
+  };
+}
 
 // ── Main Component ─────────────────────────────────────
 
@@ -101,49 +112,84 @@ export function CourseDesignTab({
   onSimCall, instructionTotal, categoryCounts, contentMethods, onNavigate,
   onReadinessChange,
 }: CourseDesignTabProps): React.ReactElement {
-  const [welcome, setWelcome] = useState<WelcomeConfig>(DEFAULT_WELCOME_CONFIG);
+  const [intake, setIntake] = useState<IntakeConfig>(DEFAULT_INTAKE_CONFIG);
   const [nps, setNps] = useState<NpsConfig>(DEFAULT_NPS_CONFIG);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [activeState, setActiveState] = useState<FlowState>('WELCOME');
 
-  // Load config from playbook
+  // Load config from playbook — prefer canonical sessionFlow.intake, fall back
+  // to legacy `welcome` shape (matches resolveSessionFlow precedence).
   useEffect(() => {
-    if (playbookConfig?.welcome) {
-      setWelcome({ ...DEFAULT_WELCOME_CONFIG, ...(playbookConfig.welcome as Partial<WelcomeConfig>) });
+    if (!playbookConfig) return;
+    const sf = (playbookConfig.sessionFlow as { intake?: Partial<IntakeConfig> } | undefined);
+    if (sf?.intake) {
+      setIntake({ ...DEFAULT_INTAKE_CONFIG, ...sf.intake } as IntakeConfig);
+    } else if (playbookConfig.welcome) {
+      const w = playbookConfig.welcome as {
+        goals?: { enabled?: boolean };
+        aboutYou?: { enabled?: boolean };
+        knowledgeCheck?: { enabled?: boolean };
+        aiIntroCall?: { enabled?: boolean };
+      };
+      setIntake({
+        goals: { enabled: w.goals?.enabled ?? DEFAULT_INTAKE_CONFIG.goals.enabled },
+        aboutYou: { enabled: w.aboutYou?.enabled ?? DEFAULT_INTAKE_CONFIG.aboutYou.enabled },
+        knowledgeCheck: {
+          enabled: w.knowledgeCheck?.enabled ?? DEFAULT_INTAKE_CONFIG.knowledgeCheck.enabled,
+          deliveryMode: DEFAULT_INTAKE_CONFIG.knowledgeCheck.deliveryMode,
+        },
+        aiIntroCall: { enabled: w.aiIntroCall?.enabled ?? DEFAULT_INTAKE_CONFIG.aiIntroCall.enabled },
+      });
     }
-    if (playbookConfig?.nps) {
+    if (playbookConfig.nps) {
       setNps({ ...DEFAULT_NPS_CONFIG, ...(playbookConfig.nps as Partial<NpsConfig>) });
     }
   }, [playbookConfig]);
 
-  const saveConfig = useCallback(async (newWelcome: WelcomeConfig, newNps: NpsConfig) => {
+  // Persist via the session-flow route. That route writes both
+  // `sessionFlow.intake` (canonical) and mirrors to legacy `welcome` for the
+  // dual-read window — same pattern the wizard uses. Single write path means
+  // every reader (resolveSessionFlow, isPreSurveyEnabled, pedagogy.ts) sees
+  // the same shape regardless of where the educator made the change.
+  const saveConfig = useCallback(async (newIntake: IntakeConfig, newNps: NpsConfig) => {
     setSaving(true);
     setSaved(false);
+    setSaveError(null);
     try {
-      await fetch(`/api/courses/${courseId}/design`, {
+      const res = await fetch(`/api/courses/${courseId}/session-flow`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ welcome: newWelcome, nps: newNps }),
+        body: JSON.stringify({ sessionFlow: { intake: newIntake }, nps: newNps }),
       });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error || `Save failed (${res.status})`);
+      }
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setSaveError((err as Error).message);
     } finally {
       setSaving(false);
     }
   }, [courseId]);
 
-  const toggleWelcomePhase = useCallback((key: keyof WelcomeConfig) => {
-    const updated = { ...welcome, [key]: { enabled: !welcome[key].enabled } };
-    setWelcome(updated);
+  const handleIntakeChange = useCallback((next: IntakeValues) => {
+    const updated = valuesToIntake(next);
+    // Skip the redundant initial onChange that fires from IntakeToggleGroup's
+    // mount effect — only persist when values actually differ.
+    if (JSON.stringify(updated) === JSON.stringify(intake)) return;
+    setIntake(updated);
     saveConfig(updated, nps);
-  }, [welcome, nps, saveConfig]);
+  }, [intake, nps, saveConfig]);
 
   const toggleNps = useCallback(() => {
     const updated = { ...nps, enabled: !nps.enabled };
     setNps(updated);
-    saveConfig(welcome, updated);
-  }, [welcome, nps, saveConfig]);
+    saveConfig(intake, updated);
+  }, [intake, nps, saveConfig]);
 
   // Duration from playbook config (sessionCount is now just a budget, not pacing)
   const durationMins = (playbookConfig?.durationMins as number) || null;
@@ -200,6 +246,11 @@ export function CourseDesignTab({
           <span className="hf-section-title" style={{ margin: 0 }}>Student Experience Flow</span>
           {saving && <span className="hf-text-xs hf-text-muted">Saving...</span>}
           {saved && <span className="hf-text-xs" style={{ color: 'var(--status-success-text)' }}>Saved</span>}
+          {saveError && (
+            <span className="hf-text-xs" style={{ color: 'var(--status-error-text)' }}>
+              Save failed — {saveError}
+            </span>
+          )}
         </div>
 
         {/* Tab strip */}
@@ -233,25 +284,11 @@ export function CourseDesignTab({
             <p className="hf-text-xs hf-text-muted hf-mb-md">
               Configure what students see before their first learning session. Toggle phases on or off.
             </p>
-            <div className="cdt-phase-list">
-              {WELCOME_PHASES.map((phase) => (
-                <label key={phase.key} className="cdt-phase-row">
-                  <div className="cdt-phase-toggle">
-                    <input
-                      type="checkbox"
-                      checked={welcome[phase.key].enabled}
-                      onChange={() => toggleWelcomePhase(phase.key)}
-                      className="hf-checkbox"
-                    />
-                  </div>
-                  <div className="cdt-phase-icon">{phase.icon}</div>
-                  <div className="cdt-phase-info">
-                    <span className="cdt-phase-name">{phase.label}</span>
-                    <span className="cdt-phase-desc">{phase.description}</span>
-                  </div>
-                </label>
-              ))}
-            </div>
+            <IntakeToggleGroup
+              initial={intakeToValues(intake)}
+              onChange={handleIntakeChange}
+              showHeader={false}
+            />
 
             {/* Welcome message preview */}
             {typeof playbookConfig?.welcomeMessage === 'string' && playbookConfig.welcomeMessage && (

--- a/apps/admin/components/wizards/IntakeToggleGroup.tsx
+++ b/apps/admin/components/wizards/IntakeToggleGroup.tsx
@@ -42,6 +42,9 @@ export interface IntakeToggleGroupProps {
   initial: IntakeValues;
   /** Called every time any toggle changes — caller persists via setData */
   onChange: (next: IntakeValues) => void;
+  /** When false, suppress the section header + help paragraph. Used by the
+   * Course Design tab where the parent panel already provides framing. */
+  showHeader?: boolean;
 }
 
 const DEFAULTS: IntakeValues = {
@@ -52,7 +55,7 @@ const DEFAULTS: IntakeValues = {
   aiIntroCall: false,
 };
 
-export function IntakeToggleGroup({ initial, onChange }: IntakeToggleGroupProps) {
+export function IntakeToggleGroup({ initial, onChange, showHeader = true }: IntakeToggleGroupProps) {
   const [values, setValues] = useState<IntakeValues>({ ...DEFAULTS, ...initial });
 
   // Push to caller whenever values change.
@@ -66,14 +69,18 @@ export function IntakeToggleGroup({ initial, onChange }: IntakeToggleGroupProps)
 
   return (
     <section className="itg">
-      <FieldHint
-        label="First-call intake"
-        hint={WIZARD_HINTS["course.firstCallIntake"]}
-        labelClass="hf-section-title"
-      />
-      <p className="itg-help">
-        What should the AI ask the learner on Call 1? Each toggle is independent.
-      </p>
+      {showHeader && (
+        <>
+          <FieldHint
+            label="First-call intake"
+            hint={WIZARD_HINTS["course.firstCallIntake"]}
+            labelClass="hf-section-title"
+          />
+          <p className="itg-help">
+            What should the AI ask the learner on Call 1? Each toggle is independent.
+          </p>
+        </>
+      )}
 
       <ul className="itg-list">
         <ToggleItem

--- a/apps/admin/lib/learner/survey-config.ts
+++ b/apps/admin/lib/learner/survey-config.ts
@@ -7,21 +7,23 @@ import { ContractRegistry } from "@/lib/contracts/registry";
 // ---------------------------------------------------------------------------
 
 /**
- * True iff at least one Welcome-flow phase is enabled.
+ * True iff at least one Welcome-flow / Intake phase is enabled.
  *
- * Source of truth: `playbook.config.welcome.*` (written by the Course Design tab).
- * Replaces the legacy `playbook.config.surveys.pre.enabled` field — that field is
- * no longer written, and any stale value left on existing playbooks is ignored.
+ * Read precedence (matches resolveSessionFlow().intake):
+ *   1. `playbook.config.sessionFlow.intake.*` — canonical shape (#221)
+ *   2. `playbook.config.welcome.*`             — legacy mirror (Course Design tab + wizard)
+ *   3. DEFAULT_INTAKE_CONFIG                   — empty playbook config
  *
- * Defaults match DEFAULT_WELCOME_CONFIG in `lib/types/json-fields.ts`:
- *   - goals: true
- *   - aboutYou: true
- *   - knowledgeCheck: false
- *
- * `welcome.aiIntroCall` is intentionally excluded — it gates a separate intro
- * call, not the in-call discovery / pre-survey scaffolding.
+ * `aiIntroCall` is intentionally excluded — it gates a separate intro call,
+ * not the in-call discovery / pre-survey scaffolding.
  */
 export function isPreSurveyEnabled(pbConfig: PlaybookConfig | null | undefined): boolean {
+  const intake = pbConfig?.sessionFlow?.intake;
+  if (intake) {
+    return intake.goals.enabled
+        || intake.aboutYou.enabled
+        || intake.knowledgeCheck.enabled;
+  }
   const w = pbConfig?.welcome;
   return (w?.goals?.enabled ?? true)
       || (w?.aboutYou?.enabled ?? true)

--- a/apps/admin/tests/lib/learner/survey-config-intake.test.ts
+++ b/apps/admin/tests/lib/learner/survey-config-intake.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { isPreSurveyEnabled } from "@/lib/learner/survey-config";
+import { resolveSessionFlow } from "@/lib/session-flow/resolver";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #301 — unify welcome-phase reads.
+//
+// Two writers persist the same four flags:
+//   - wizard / session-flow editor  → writes BOTH `sessionFlow.intake` AND
+//                                     legacy `welcome` (mirrored)
+//   - course design tab             → writes `sessionFlow.intake` via the
+//                                     session-flow PUT route, which mirrors
+//                                     to legacy `welcome`
+//
+// Every reader (resolveSessionFlow, isPreSurveyEnabled) must see the same
+// IntakeConfig shape regardless of which writer ran. These tests pin that
+// invariant so future drift is caught.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const WIZARD_WRITTEN: PlaybookConfig = {
+  welcome: {
+    goals: { enabled: true },
+    aboutYou: { enabled: false },
+    knowledgeCheck: { enabled: true },
+    aiIntroCall: { enabled: false },
+  },
+  sessionFlow: {
+    intake: {
+      goals: { enabled: true },
+      aboutYou: { enabled: false },
+      knowledgeCheck: { enabled: true, deliveryMode: "socratic" },
+      aiIntroCall: { enabled: false },
+    },
+  },
+};
+
+const DESIGN_TAB_WRITTEN: PlaybookConfig = {
+  welcome: {
+    goals: { enabled: true },
+    aboutYou: { enabled: false },
+    knowledgeCheck: { enabled: true },
+    aiIntroCall: { enabled: false },
+  },
+  sessionFlow: {
+    intake: {
+      goals: { enabled: true },
+      aboutYou: { enabled: false },
+      knowledgeCheck: { enabled: true, deliveryMode: "mcq" },
+      aiIntroCall: { enabled: false },
+    },
+  },
+};
+
+const LEGACY_ONLY: PlaybookConfig = {
+  welcome: {
+    goals: { enabled: true },
+    aboutYou: { enabled: false },
+    knowledgeCheck: { enabled: true },
+    aiIntroCall: { enabled: false },
+  },
+};
+
+describe("welcome-phase read unification (#301)", () => {
+  describe("resolveSessionFlow().intake", () => {
+    it("prefers sessionFlow.intake over legacy welcome (wizard write)", () => {
+      const r = resolveSessionFlow({ playbook: { config: WIZARD_WRITTEN } });
+      expect(r.source.intake).toBe("new-shape");
+      expect(r.intake.knowledgeCheck.deliveryMode).toBe("socratic");
+    });
+
+    it("returns canonical shape for design-tab write (mcq mode)", () => {
+      const r = resolveSessionFlow({ playbook: { config: DESIGN_TAB_WRITTEN } });
+      expect(r.source.intake).toBe("new-shape");
+      expect(r.intake.knowledgeCheck.deliveryMode).toBe("mcq");
+    });
+
+    it("falls back to legacy welcome when sessionFlow.intake absent", () => {
+      const r = resolveSessionFlow({ playbook: { config: LEGACY_ONLY } });
+      expect(r.source.intake).toBe("legacy-welcome");
+      expect(r.intake.knowledgeCheck.enabled).toBe(true);
+    });
+  });
+
+  describe("isPreSurveyEnabled", () => {
+    it("reads sessionFlow.intake when present (wizard write)", () => {
+      expect(isPreSurveyEnabled(WIZARD_WRITTEN)).toBe(true);
+    });
+
+    it("reads sessionFlow.intake when present (design-tab write)", () => {
+      expect(isPreSurveyEnabled(DESIGN_TAB_WRITTEN)).toBe(true);
+    });
+
+    it("falls back to legacy welcome when sessionFlow.intake absent", () => {
+      expect(isPreSurveyEnabled(LEGACY_ONLY)).toBe(true);
+    });
+
+    it("respects an explicit all-off intake even if legacy welcome is missing", () => {
+      const allOff: PlaybookConfig = {
+        sessionFlow: {
+          intake: {
+            goals: { enabled: false },
+            aboutYou: { enabled: false },
+            knowledgeCheck: { enabled: false, deliveryMode: "mcq" },
+            aiIntroCall: { enabled: false },
+          },
+        },
+      };
+      expect(isPreSurveyEnabled(allOff)).toBe(false);
+    });
+
+    it("respects intake.* over a stale legacy welcome that disagrees", () => {
+      // Simulates the divergence the unification fixes: educator turns kc off
+      // via the new shape, but legacy welcome still has it on. Reader must
+      // honour the canonical shape.
+      const divergent: PlaybookConfig = {
+        welcome: {
+          goals: { enabled: false },
+          aboutYou: { enabled: false },
+          knowledgeCheck: { enabled: true },
+          aiIntroCall: { enabled: false },
+        },
+        sessionFlow: {
+          intake: {
+            goals: { enabled: false },
+            aboutYou: { enabled: false },
+            knowledgeCheck: { enabled: false, deliveryMode: "mcq" },
+            aiIntroCall: { enabled: false },
+          },
+        },
+      };
+      expect(isPreSurveyEnabled(divergent)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #301

## Summary

The same four flags (Goals / About You / Knowledge Check / AI Intro) were surfaced in two divergent UIs with separate persistence paths:

- **Wizard + Session Flow editor** → `IntakeToggleGroup`, writes both `sessionFlow.intake` (canonical) and legacy `welcome` (mirror)
- **Course Design tab** → bespoke checkboxes, wrote only legacy `welcome`, silently dropped `knowledgeCheckMode`

Now: one component, one write path, one reader.

## Changes

- `CourseDesignTab.tsx` — replaced inline checkboxes with `<IntakeToggleGroup>`. State swapped `WelcomeConfig` → `IntakeConfig` (carries `deliveryMode`). Save re-pointed from `/api/courses/[id]/design` → `/api/courses/[id]/session-flow`, which mirrors `intake → welcome` for the dual-read window. Added `saveError` UI.
- `IntakeToggleGroup.tsx` — added optional `showHeader` prop so the Design tab can embed without double-titling. Wizard usage unchanged.
- `survey-config.ts` — `isPreSurveyEnabled` now reads `sessionFlow.intake` first, falls back to legacy `welcome`. Same precedence as `resolveSessionFlow().intake`. Closes the divergence risk where a stale legacy mirror could disagree with canonical intake.

## Test plan

- [x] `tests/lib/learner/survey-config-intake.test.ts` — 8 new unit tests pinning the unified-read invariant (wizard write, design-tab write, legacy-only, divergent, all-off)
- [x] `tests/lib/session-flow/*` — 110 related tests still green
- [x] `tsc --noEmit` clean for changed files
- [ ] Manual: toggle a phase in Design tab, confirm wizard reflects it, AI honours it on first call

🤖 Generated with [Claude Code](https://claude.com/claude-code)