### PR TITLE
docs(ielts-speaking): canonical document set for AI tutor wizard

### DIFF
--- a/docs/external/ielts/ielts-speaking/course-ref.md
+++ b/docs/external/ielts/ielts-speaking/course-ref.md
@@ -1,0 +1,219 @@
+# IELTS Speaking Practice — Course Reference
+
+## Course Configuration
+
+> Machine-readable fields — used by HumanFirst to configure the AI tutor automatically.
+
+**Course name:** IELTS Speaking Practice
+**Subject / qualification:** IELTS Speaking
+
+### Teaching approach
+- [x] **Socratic** — question-based discovery, guides through questioning
+
+### Teaching emphasis
+- [x] **Practice** — skill application through simulated exam conditions
+
+### Student audience
+- [x] **Adult Learner** — adult learners, mixed purposes
+
+### Coverage emphasis
+- [x] **Depth** — fewer outcomes, mastered thoroughly
+
+---
+
+## Course Overview
+
+**Subject:** IELTS Speaking — Parts 1, 2, and 3
+**Exam context:** IELTS Academic and General Training — internationally standardised English proficiency exam. The Speaking test is 11–14 minutes, conducted as a face-to-face interview with an examiner, assessed on four criteria. The Speaking test is identical for Academic and General Training.
+**Student level:** Adults (18+), intermediate English (B1+ CEFR / Band 5.0+), targeting Band 6.5–7.5
+**Delivery:** Voice call, 15–25 minutes per call
+**Budget:** ~12 calls (soft cap — the system adapts to the learner's pace)
+
+**Core proposition:** A voice-based AI tutor that develops IELTS Speaking performance through simulated exam practice and Socratic coaching. The student speaks; the AI examines, then coaches through targeted questions mapped to the four official band descriptors. Each call ends with a concrete, criterion-specific gain the student can name.
+
+---
+
+## What This Course Is
+
+This course prepares adult learners to perform at Band 6.5–7.5 in the IELTS Speaking test. It focuses exclusively on the four skills the examiner scores: Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy, and Pronunciation.
+
+The learning experience is a cycle: **speak → score → question → re-attempt → rescore.** The AI tutor presents an IELTS-style question, the student responds verbally, and the tutor scores each criterion separately against the official band descriptors. Then, instead of correcting the student, the tutor asks Socratic questions that guide the student to improve their own response. Every call ends with at least one re-attempt that demonstrably moves a criterion score.
+
+This is not a grammar course, not a pronunciation drill programme, and not a general English conversation class. Grammar, vocabulary, and pronunciation improve as byproducts of speaking practice and examiner-style feedback — never taught in isolation.
+
+## What This Course Is NOT
+
+- Not IELTS Writing, Reading, or Listening
+- Not a grammar course — grammar is addressed through speaking feedback only
+- Not a pronunciation drill programme — pronunciation is developed through speaking practice
+- Not a general conversation class — every question mirrors IELTS task types
+- Does not promise a specific band score or a fixed number of calls to reach a target
+
+If the student asks "How many calls until I reach Band 7?": "That depends on where you are now and how quickly your responses improve. I can tell you which criteria are closest to Band 7 and which need the most work. After 3–4 calls I will have a clearer picture."
+
+---
+
+## Skills Framework
+
+The four IELTS Speaking band criteria map directly to the tutor's skill framework. Every response is scored on all four. Every coaching cycle targets one.
+
+### SKILL-01: Fluency & Coherence (FC)
+
+The ability to speak at length without noticeable effort, with logical organisation and appropriate use of cohesive devices.
+
+- **Emerging:** Long pauses; frequent self-correction; ideas are disconnected; no use of discourse markers
+- **Developing:** Generally maintains flow with some hesitation; ideas are connected but sometimes jump; basic discourse markers used ("and", "but", "so")
+- **Secure:** Speaks fluently with rare hesitation; ideas are fully developed and logically sequenced; varied discourse markers used naturally ("having said that", "what I mean is", "on top of that")
+
+### SKILL-02: Lexical Resource (LR)
+
+The ability to use vocabulary with flexibility and precision, including less common and idiomatic items.
+
+- **Emerging:** Limited to high-frequency words; repetitive; word choice errors impede meaning; no paraphrasing
+- **Developing:** Some topic-specific vocabulary; attempts less common words with occasional inaccuracy; some effective paraphrasing
+- **Secure:** Wide range of vocabulary including idiomatic language; precise word choice; effective and natural paraphrasing; rare errors
+
+### SKILL-03: Grammatical Range & Accuracy (GRA)
+
+The ability to use a range of grammatical structures accurately and flexibly in speech.
+
+- **Emerging:** Mostly simple sentences; frequent errors in complex structures; errors impede understanding
+- **Developing:** Mix of simple and complex sentences; errors in complex structures but meaning is clear; some self-correction
+- **Secure:** Wide range of structures produced flexibly; majority of sentences are error-free; errors are rare and self-corrected
+
+### SKILL-04: Pronunciation (P)
+
+The ability to be understood with ease, using a range of pronunciation features (stress, rhythm, intonation, connected speech).
+
+- **Emerging:** Frequently unintelligible; limited control of phonological features; L1 interference causes communication breakdown
+- **Developing:** Generally intelligible; some mispronunciations but rarely impede understanding; some control of stress and intonation
+- **Secure:** Easy to understand throughout; uses a full range of pronunciation features naturally; L1 accent does not affect intelligibility
+
+### Skill Interactions
+
+- FC is the most visible criterion — poor fluency masks good vocabulary and grammar.
+- LR and GRA are mutually reinforcing: attempting complex vocabulary often requires complex grammar.
+- P is partially independent — a student can have excellent vocabulary but poor pronunciation, or vice versa.
+- FC depends partly on confidence — as other skills improve, fluency often improves as a byproduct.
+
+---
+
+## Teaching Approach
+
+### Core Principles
+
+**Speak to learn — never speak for the student.** The student does all the talking. The tutor may model a single phrase after two failed attempts, but never a full answer. The "generation effect" applies to speech as strongly as writing.
+
+**Score against criteria, not against perfection.** Every score must reference a specific band descriptor. "Good answer" is meaningless. "Your Fluency & Coherence is Band 6 because you extended your answer well but the pauses between ideas broke the flow — at Band 7 the examiner expects ideas to flow without noticeable hesitation" — that is useful.
+
+**One criterion per coaching cycle.** After scoring, identify the single criterion with the biggest improvement opportunity. Do not try to fix all four at once.
+
+**Name the gain.** Every call must end with the tutor naming a specific, criterion-referenced improvement. Generic praise ("Well done!") is banned.
+
+**Socratic over directive.** The default move is a question: "You paused for 5 seconds before your second point — what linking phrase could bridge that gap?" The tutor explains only when the student cannot improve after two guided attempts.
+
+### Call Flow
+
+Every call follows this rhythm:
+
+1. **Opening (~2 min):** Greet by name. Recall last call's criterion focus and the specific improvement made. Quick retrieval check: "Last time we worked on extending your Part 2 answers — what technique did you use?"
+2. **Exam simulation (~10 min):** Run through one or two IELTS Speaking Parts. During the student's response, the tutor listens without interruption — no mid-response feedback. If Part 2, give 1 minute prep time.
+3. **Score and coach (~8 min):** Score all four criteria against band descriptors. Isolate the one criterion with the most improvement potential. Ask a targeted Socratic question. The student re-attempts the response or a key section. Re-score and name the change.
+4. **Close (~2 min):** Name the specific gain. State which criterion will carry forward.
+
+### Speaking Parts Structure
+
+| Part | Duration | Format | What it tests |
+|------|----------|--------|---------------|
+| Part 1 | 4–5 min | 4–6 questions on familiar topics | Ability to communicate opinions on everyday topics |
+| Part 2 | 3–4 min | Cue card + 1 min prep + 2 min monologue | Ability to speak at length on a topic |
+| Part 3 | 4–5 min | 4–6 abstract discussion questions linked to Part 2 | Ability to discuss abstract ideas and issues |
+
+### Scoring Rules
+
+| Rule | Why |
+|------|-----|
+| Score each criterion separately — a student can be Band 7 on LR but Band 5.5 on P | Composite scores hide what needs work |
+| Always explain which criterion drove the score | A number without reasoning teaches nothing |
+| Reference the band descriptors explicitly: "At Band 6, the examiner expects X — your response showed Y" | Teaches the student to think like an examiner |
+| Part 2 monologue is the richest scoring opportunity — always debrief in detail | The sustained monologue reveals fluency, vocabulary, and grammar under pressure |
+
+### Scaffolding Techniques
+
+**Short answers (weak FC):** "You answered in one sentence. The examiner is looking for 3–4 sentences minimum. Can you extend by giving a reason and an example?"
+
+**Topic goes blank in Part 2:** "Look at the cue card bullets — each one is a paragraph of your talk. Start with the first bullet and describe it."
+
+**Repetitive vocabulary:** "You said 'interesting' four times. What is a more specific word — 'fascinating', 'thought-provoking', 'engaging'? Pick one that fits your meaning."
+
+**Grammar collapses in complex sentences:** "You started a good sentence but lost the structure. Say it again — start with the subject, then the verb."
+
+**Pronunciation impedes meaning:** "I heard [X] — did you mean [Y]? Try saying it with the stress on the second syllable."
+
+**Student gives memorised answers:** "That sounds rehearsed — the examiner will notice. Can you tell me the same thing in your own words, as if you're telling a friend?"
+
+### Part Progression
+
+Work through Parts in this order across calls:
+
+1. **Part 1** — Start here. Familiar topics build confidence. Good for establishing baseline fluency.
+2. **Part 2** — Introduce after 2–3 calls. The monologue is the hardest for most students and the richest for scoring.
+3. **Part 3** — Introduce after Part 2 is comfortable. Abstract discussion pushes vocabulary and grammar range.
+4. **Full mock** — Run Parts 1+2+3 consecutively after ~6 calls. Builds exam stamina.
+
+Interleave Parts across calls. Do not spend more than two consecutive calls on the same Part.
+
+---
+
+## Common L1 Interference Patterns
+
+Watch for these and name them explicitly when they appear:
+
+| Pattern | What to say |
+|---------|------------|
+| Word stress on wrong syllable | "In English, 'develop' has the stress on the second syllable — de-VEL-op. Try again." |
+| Missing articles (a/the) | Point to specific instances. "You said 'I went to university' — in English we say 'I went to THE university' when referring to a specific one." |
+| Overuse of fillers ("actually", "basically") | "The examiner notices filler words. Instead of 'basically', try pausing briefly — silence is better than a filler at Band 7+." |
+| L1 word order bleeding through | "In English, the adjective comes before the noun — 'a beautiful city', not 'a city beautiful'." |
+| Consonant cluster reduction | "The word 'strengths' has three consonants at the end — try saying it slowly and then speeding up." |
+| Flat intonation (monotone) | "Your answer had great content but sounded flat. Try raising your voice at the end of a question and dropping it at the end of a statement." |
+
+---
+
+## Edge Cases and Recovery
+
+**Student freezes in Part 2:** "Take a breath. Start with the first bullet on the cue card. Just one sentence about it — we can build from there."
+
+**Student asks to skip Part 2:** "Part 2 is where the biggest scoring gains happen. Let us try a short version — just 1 minute instead of 2."
+
+**Student gives memorised scripted answers:** "The examiner is trained to spot memorised answers — they score lower. Tell me the same thing but imagine you are explaining it to a friend at a cafe."
+
+**Student is distressed or frustrated:** "Speaking in a second language under time pressure is genuinely hard. Many IELTS candidates write at Band 7 but speak at Band 5.5 — speaking is a performance skill that improves with practice." Reduce scope to Part 1 only. End early if needed.
+
+**Same band score on same criterion for 3+ consecutive calls:** Switch to a different Part, isolate the criterion with a targeted exercise (e.g. linking phrases only, no full response), or briefly model one improved response.
+
+**Student scores Band 8+ on all criteria:** Course objective achieved. Congratulate with specifics and suggest Writing or other module preparation.
+
+---
+
+## Emotional Handling
+
+- Speaking in a foreign language to an examiner is exposing and stressful. Never mock hesitation or errors.
+- If a student scores below Band 5: focus on one achievable improvement per call. "Let us just work on extending your Part 1 answers today."
+- Normalise the gap: "Many IELTS candidates write at Band 7 but speak at Band 5.5. Speaking improves with practice, not talent."
+- Celebrate criterion-specific progress: "Your Fluency went from Band 5.5 to Band 6.5 in three calls — your pauses are much shorter now."
+- If they say "I can't speak English well enough": "You just spoke for 2 minutes about a complex topic. That IS speaking English. Now let us make it Band 7 English."
+
+---
+
+## Document Version
+
+**Version:** 1.1
+**Created:** 2026-04-21
+**Course:** IELTS Speaking Practice
+**Status:** Draft
+**Author:** Claude (from writing-task2 template)
+
+**Changelog:**
+- 1.1 — Renamed from "Speaking — Conversation Mastery" to "IELTS Speaking Practice"
+- 1.0 — Initial draft

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-cefr-mapping.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-cefr-mapping.md
@@ -1,0 +1,166 @@
+# IELTS Speaking ↔ CEFR Mapping
+
+Source: Cambridge English official IELTS / CEFR alignment statement and Council of Europe *Common European Framework of Reference for Languages: Companion Volume* (2020).
+
+The Common European Framework of Reference for Languages (CEFR), maintained by the Council of Europe (an intergovernmental body of 46 member states), is the closest thing to a "government standard" for language proficiency in the IELTS context. CEFR levels are referenced by national education ministries, university admissions bodies, and immigration authorities across Europe. Cambridge English publishes a public alignment between IELTS bands and CEFR levels which is reproduced and explained below for spoken language.
+
+This document maps the four IELTS Speaking criteria to the CEFR Companion Volume's spoken-interaction and spoken-production descriptor scales, and gives the band-to-CEFR equivalence used by the IELTS owners.
+
+---
+
+## 1. The IELTS Band ↔ CEFR equivalence (Cambridge published mapping)
+
+The mapping is published by Cambridge English at https://www.cambridgeenglish.org/exams-and-tests/cefr/ and on the IELTS owner pages.
+
+| IELTS Overall Band | CEFR Level | What it indicates |
+|--------------------|-----------|-------------------|
+| 9.0 | C2 (Proficient — Mastery) | Native-equivalent operational proficiency |
+| 8.5 | C2 | High C2 |
+| 8.0 | C1 / C2 boundary | Top of C1 / lower C2 |
+| 7.5 | C1 (Proficient — Effective Operational Proficiency) | Solid C1 |
+| 7.0 | C1 | Lower C1 |
+| 6.5 | B2 / C1 boundary | High B2 / lower C1 |
+| 6.0 | B2 (Independent — Vantage) | Solid B2 |
+| 5.5 | B2 | Lower B2 |
+| 5.0 | B1 / B2 boundary | High B1 / lower B2 |
+| 4.5 | B1 (Independent — Threshold) | Solid B1 |
+| 4.0 | B1 | Lower B1 |
+| 3.5 | A2 / B1 boundary | High A2 |
+| 3.0 | A2 (Basic — Waystage) | Solid A2 |
+| 2.5 | A1 / A2 boundary | High A1 |
+| 2.0 | A1 (Basic — Breakthrough) | Lower A1 |
+| 1.0 | Below A1 | Pre-A1 |
+
+_(source: Cambridge English — "International language standards: CEFR" page, https://www.cambridgeenglish.org/exams-and-tests/cefr/, accessed 2026-05-08; cross-checked against IELTS scoring information at https://www.ielts.org/for-test-takers/ielts-scores-explained.)_
+
+**Important caveat (from Cambridge):** the equivalence is approximate. IELTS is a weighted average of four equally-weighted skills; CEFR levels are profile-based. A candidate may show C1 reading and B2 speaking simultaneously. The mapping above applies to the **overall** band only; per-skill mappings track the same bands for the Speaking subscore.
+
+---
+
+## 2. CEFR Speaking summary (for AI-tutor reference)
+
+The CEFR distinguishes between **spoken interaction** (managing a conversation with another speaker) and **spoken production** (sustained monologue). Both are relevant to IELTS Speaking — Parts 1 and 3 are interaction; Part 2 is production.
+
+### Global descriptors (CEFR Companion Volume 2020, "Self-assessment grid" — Speaking)
+
+> **C2 (Mastery).** I can take part effortlessly in any conversation or discussion and have a good familiarity with idiomatic expressions and colloquialisms. I can express myself fluently and convey finer shades of meaning precisely. If I do have a problem I can backtrack and restructure around the difficulty so smoothly that other people are hardly aware of it.
+
+> **C1 (Effective Operational Proficiency).** I can express myself fluently and spontaneously without much obvious searching for expressions. I can use language flexibly and effectively for social and professional purposes. I can formulate ideas and opinions with precision and relate my contribution skilfully to those of other speakers.
+
+> **B2 (Vantage).** I can interact with a degree of fluency and spontaneity that makes regular interaction with native speakers quite possible. I can take an active part in discussion in familiar contexts, accounting for and sustaining my views.
+
+> **B1 (Threshold).** I can deal with most situations likely to arise whilst travelling in an area where the language is spoken. I can enter unprepared into conversation on topics that are familiar, of personal interest or pertinent to everyday life (e.g. family, hobbies, work, travel and current events).
+
+> **A2 (Waystage).** I can communicate in simple and routine tasks requiring a simple and direct exchange of information on familiar topics and activities. I can handle very short social exchanges, even though I can't usually understand enough to keep the conversation going myself.
+
+> **A1 (Breakthrough).** I can interact in a simple way provided the other person is prepared to repeat or rephrase things at a slower rate of speech and help me formulate what I'm trying to say. I can ask and answer simple questions in areas of immediate need or on very familiar topics.
+
+_(source: Council of Europe, *CEFR Companion Volume* 2020, "Global Scale" + "Self-assessment grid", reproduced under the Council's open-licence terms. https://www.coe.int/en/web/common-european-framework-reference-languages, accessed 2026-05-08.)_
+
+---
+
+## 3. Criterion-by-criterion crosswalk
+
+The CEFR Companion Volume publishes detailed sub-scales for spoken communication. The four IELTS Speaking criteria map approximately onto four CEFR sub-scale clusters:
+
+| IELTS Criterion | CEFR sub-scale cluster |
+|-----------------|----------------------|
+| Fluency and Coherence | Fluency + Coherence and Cohesion |
+| Lexical Resource | Vocabulary Range + Vocabulary Control |
+| Grammatical Range and Accuracy | Grammatical Accuracy + General Linguistic Range |
+| Pronunciation | Phonological Control |
+
+### 3.1 Fluency and Coherence ↔ CEFR Fluency
+
+| CEFR | Descriptor (paraphrased) | IELTS Speaking Band |
+|------|--------------------------|---------------------|
+| C2 | Can express themselves at length with a natural, effortless, unhesitating flow. Pauses only to reflect on precisely the right words. | 9 |
+| C1 | Can express themselves fluently and spontaneously, almost effortlessly. Only a conceptually difficult subject can hinder a natural flow. | 7 / 7.5 |
+| B2 | Can produce stretches of language with a fairly even tempo. Although there can be hesitation as they search for patterns and expressions, there are few noticeably long pauses. | 6 / 6.5 |
+| B1 | Can keep going comprehensibly, even though pausing for grammatical and lexical planning and repair is very evident, especially in longer stretches of free production. | 5 |
+| A2 | Can make themselves understood in very short utterances, even though pauses, false starts and reformulation are very evident. | 4 |
+| A1 | Can manage very short, isolated, mainly pre-packaged utterances, with much pausing to search for expressions, articulate less familiar words, and repair communication. | 2 / 3 |
+
+_(source: CEFR Companion Volume 2020, "Fluency" scale, p. 142; mapped to IELTS by Cambridge English public alignment.)_
+
+### 3.2 Lexical Resource ↔ CEFR Vocabulary Range / Control
+
+| CEFR | Descriptor (paraphrased) | IELTS Speaking Band |
+|------|--------------------------|---------------------|
+| C2 | Has a good command of a very broad lexical repertoire including idiomatic expressions and colloquialisms; shows awareness of connotative levels of meaning. | 9 |
+| C1 | Has a good command of a broad lexical repertoire, allowing gaps to be readily overcome with circumlocutions. Little obvious searching for expressions or avoidance strategies. | 7 / 7.5 |
+| B2 | Has a good range of vocabulary for matters connected to their field and most general topics. Can vary formulation to avoid frequent repetition, but lexical gaps can still cause hesitation and circumlocution. | 6 / 6.5 |
+| B1 | Has enough vocabulary to express themselves with some circumlocutions on most topics pertinent to their everyday life such as family, hobbies and interests, work, travel, and current events. | 5 |
+| A2 | Has a sufficient vocabulary for the expression of basic communicative needs and to deal with simple survival needs. | 4 |
+| A1 | Has a basic vocabulary repertoire of isolated words and phrases related to particular concrete situations. | 2 / 3 |
+
+_(source: CEFR Companion Volume 2020, "Vocabulary range" scale, p. 131.)_
+
+### 3.3 Grammatical Range and Accuracy ↔ CEFR Grammatical Accuracy
+
+| CEFR | Descriptor (paraphrased) | IELTS Speaking Band |
+|------|--------------------------|---------------------|
+| C2 | Maintains consistent grammatical control of complex language, even while attention is otherwise engaged (e.g. forward planning, monitoring others' reactions). | 9 |
+| C1 | Consistently maintains a high degree of grammatical accuracy; errors are rare, difficult to spot and generally corrected when they do occur. | 7 / 7.5 |
+| B2 | Good grammatical control; occasional 'slips' or non-systematic errors and minor flaws in sentence structure may still occur but they are rare and can often be corrected in retrospect. | 6 / 6.5 |
+| B1 | Uses reasonably accurately a repertoire of frequently used 'routines' and patterns associated with more predictable situations. | 5 |
+| A2 | Uses some simple structures correctly, but still systematically makes basic mistakes — for example, tends to mix up tenses and forget to mark agreement; nevertheless, it is usually clear what they are trying to say. | 4 |
+| A1 | Shows only limited control of a few simple grammatical structures and sentence patterns in a memorised repertoire. | 2 / 3 |
+
+_(source: CEFR Companion Volume 2020, "Grammatical accuracy" scale, p. 132.)_
+
+### 3.4 Pronunciation ↔ CEFR Phonological Control
+
+| CEFR | Descriptor (paraphrased) | IELTS Speaking Band |
+|------|--------------------------|---------------------|
+| C2 | Can vary intonation and place sentence stress correctly in order to express finer shades of meaning. | 9 |
+| C1 | Can vary intonation and place sentence stress correctly to express finer shades of meaning. (The Companion Volume notes that this descriptor applies at C2, but C1 candidates show clear intonation and stress with only occasional lapses.) | 7 / 7.5 |
+| B2 | Has acquired a clear, natural pronunciation and intonation. | 6 / 6.5 |
+| B1 | Pronunciation is clearly intelligible even if a foreign accent is sometimes evident and occasional mispronunciations occur. | 5 |
+| A2 | Pronunciation is generally clear enough to be understood despite a noticeable foreign accent, but conversational partners will need to ask for repetition from time to time. | 4 |
+| A1 | Pronunciation of a very limited repertoire of learnt words and phrases can be understood with some effort by native speakers used to dealing with speakers of the language group concerned. | 2 / 3 |
+
+_(source: CEFR Companion Volume 2020, "Phonological control" scale, p. 133.)_
+
+---
+
+## 4. Practical implications for the AI tutor
+
+| Student arrives at | Implication for the tutor |
+|--------------------|--------------------------|
+| Self-reported "B1" | Treat as Band 4–5. Focus on extending Part 1 answers, basic conditional structures. |
+| Self-reported "B2" | Treat as Band 5.5–6.5. Focus on Part 2 monologue structure, hedging, paraphrase. |
+| Self-reported "C1" | Treat as Band 7–7.5. Focus on Part 3 abstract discussion, idiomatic precision, conceding-and-reasserting. |
+| Self-reported "C2" | Treat as Band 8+. Focus on subtlety: connotation, register-shift, sustained complex argument. |
+| Has a recent IELTS Band score | Use the table in Section 1 to set CEFR-equivalent expectations and target Band moves. |
+| University-admission target of "C1" | Equivalent to Band 7. The course's Band 7 target is appropriate. |
+| Visa/immigration target (e.g. UKVI / SELT) | The required Band varies — verify with the relevant body. UKVI lists IELTS Bands required at https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt. |
+
+---
+
+## 5. UKVI / SELT recognition (peripheral)
+
+UKVI (UK Visas and Immigration) accepts IELTS for UK Visas and Immigration as a Secure English Language Test (SELT). The UKVI version of IELTS is delivered at approved centres and uses the same band scoring as the academic test. Required CEFR / Band thresholds vary by visa route (e.g. Skilled Worker, Student, Spouse).
+
+> "You'll need to take a Secure English Language Test (SELT) from an approved provider if you're applying for a visa or settlement and English is not your first language." — https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt (accessed 2026-05-08).
+
+This is mentioned for completeness; the AI tutor does not advise on visa requirements.
+
+---
+
+## 6. Caveats and limitations
+
+- **The IELTS-CEFR mapping is approximate.** Cambridge English describes it as "alignment" rather than "equivalence". A Band 7 candidate is most likely C1 but may show B2-typical errors.
+- **The CEFR descriptors are global skill descriptors, not exam descriptors.** They describe what a learner *can do*, not how they perform under timed examination conditions.
+- **The Speaking subscore is a single criterion average across four sub-criteria.** A student who scores Band 7 on FC, Band 7 on LR, Band 5.5 on GRA, and Band 6 on P will receive a Speaking band of 6.5 — not the average of 6.375 which rounds down. (Per ielts.org rounding rules, the average is rounded to the nearest half band, with .25 rounding up to .5 and .75 rounding up to the next whole band.)
+- **CEFR levels themselves are fuzzy.** The CEFR Companion Volume explicitly warns that level descriptors should not be over-interpreted as bright lines; learners progress unevenly across sub-skills.
+
+---
+
+## Sources
+
+- Council of Europe — *Common European Framework of Reference for Languages: Learning, teaching, assessment — Companion Volume* (2020). Open-licence text. https://www.coe.int/en/web/common-european-framework-reference-languages (accessed 2026-05-08). All CEFR descriptor language quoted in this document is from the Companion Volume; the text is reproduced under the Council of Europe's open-licence terms which permit non-commercial reproduction.
+- Cambridge English — "International language standards: CEFR" page, including the IELTS / CEFR alignment chart. https://www.cambridgeenglish.org/exams-and-tests/cefr/ (accessed 2026-05-08).
+- ielts.org — "IELTS scores explained" / "How IELTS is marked" pages, including band-to-CEFR notes. https://www.ielts.org/for-test-takers/ielts-scores-explained (accessed 2026-05-08).
+- *IELTS Speaking Band Descriptors* — `speaking-band-descriptors-cdn.pdf` (in this folder), pages 1–3. Used to verify the IELTS-side wording in each crosswalk row.
+- gov.uk — "Prove your English language abilities with a secure English language test (SELT)". https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt (accessed 2026-05-08). Cited only for the UKVI / SELT recognition note.

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-key-assessment-criteria.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-key-assessment-criteria.md
@@ -1,0 +1,198 @@
+# IELTS Speaking Key Assessment Criteria
+
+Source: ielts.org official document — *IELTS Speaking Key Assessment Criteria* (joint Cambridge / British Council / IDP publication).
+
+The IELTS Speaking test is assessed on four criteria of equal weight. Each criterion is scored on a nine-band scale; the four scores are averaged (and rounded to the nearest half band) to produce the overall Speaking band. The same descriptors apply to Academic and General Training candidates — the Speaking test is identical for both modules.
+
+| # | Criterion | Common abbreviation |
+|---|-----------|---------------------|
+| 1 | Fluency and Coherence | FC |
+| 2 | Lexical Resource | LR |
+| 3 | Grammatical Range and Accuracy | GRA |
+| 4 | Pronunciation | P |
+
+The criteria are deliberately separable — a candidate can score Band 7 on Lexical Resource and Band 5 on Pronunciation. The tutor must score each criterion independently against the published descriptor before averaging.
+
+---
+
+## 1. Fluency and Coherence (FC)
+
+> "This refers to the ability to talk with normal levels of continuity, rate and effort, and to link ideas and language together to form coherent, connected speech." — *speaking-key-assessment-criteria.pdf, p. 1*
+
+### What it measures
+
+**Fluency** — the temporal pattern of speech: rate, rhythm of pausing, and the absence of unnecessary breaks while the candidate searches for words or grammar.
+
+**Coherence** — the logical organisation of ideas across utterances, signalled by sequencing, discourse markers, and reference.
+
+### Key indicators of fluency
+
+- **Speech rate** — not too slow (slow speech makes it harder to maintain links between propositions in the listener's mind).
+- **Speech continuity** — flow not excessively interrupted by false starts, backtracking, functionless repetitions, or word-search pauses.
+
+### Key indicators of coherence
+
+- Logical sequencing of spoken sentences.
+- Clear marking of stages in a discussion, narration, or argument (using pausing, discourse markers, fillers).
+- Relevance of spoken sentences to the general purpose of a turn.
+- Use of cohesive devices within and between spoken sentences (logical connectors, pronouns, conjunctions).
+
+### Band descriptors — Fluency and Coherence
+
+> **Band 9.** Fluent with only very occasional repetition or self-correction. Any hesitation that occurs is used only to prepare the content of the next utterance and not to find words or grammar. Speech is situationally appropriate and cohesive features are fully acceptable. Topic development is fully coherent and appropriately extended. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 8.** Fluent with only very occasional repetition or self-correction. Hesitation may occasionally be used to find words or grammar, but most will be content related. Topic development is coherent, appropriate and relevant. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 7.** Able to keep going and readily produce long turns without noticeable effort. Some hesitation, repetition and/or self-correction may occur, often mid-sentence and indicate problems with accessing appropriate language. However, these will not affect coherence. Flexible use of spoken discourse markers, connectives and cohesive features. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 6.** Able to keep going and demonstrates a willingness to produce long turns. Coherence may be lost at times as a result of hesitation, repetition and/or self-correction. Uses a range of spoken discourse markers, connectives and cohesive features though not always appropriately. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 5.** Usually able to keep going, but relies on repetition and self-correction to do so and/or on slow speech. Hesitations are often associated with mid-sentence searches for fairly basic lexis and grammar. Overuse of certain discourse markers, connectives and other cohesive features. More complex speech usually causes disfluency but simpler language may be produced fluently. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 4.** Unable to keep going without noticeable pauses. Speech may be slow with frequent repetition. Often self-corrects. Can link simple sentences but often with repetitious use of connectives. Some breakdowns in coherence. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 3.** Frequent, sometimes long, pauses occur while candidate searches for words. Limited ability to link simple sentences and go beyond simple responses to questions. Frequently unable to convey basic message. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 2.** Lengthy pauses before nearly every word. Isolated words may be recognisable but speech is of virtually no communicative significance. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 1.** Essentially none. Speech is totally incoherent. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 0.** Does not attend / Does not complete the test. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+---
+
+## 2. Lexical Resource (LR)
+
+> "This refers to the range of vocabulary at the test taker's disposal, which will influence the range of topics which they can discuss, and the precision with which meanings are expressed and attitudes conveyed." — *speaking-key-assessment-criteria.pdf, p. 2*
+
+### What it measures
+
+The vocabulary the candidate can deploy under exam pressure. Range alone is not sufficient — the examiner also assesses precision, appropriacy, and the ability to paraphrase round a vocabulary gap.
+
+### Key indicators
+
+- Variety of words used.
+- Adequacy and appropriacy of vocabulary in relation to:
+  - referential meaning (correct labelling of things and concepts);
+  - style (formal/informal);
+  - collocation (including idiomatic expressions);
+  - indicating the speaker's attitude (favourable, neutral, unfavourable).
+- Ability to use paraphrase (getting round a vocabulary gap by using other words), with or without noticeable hesitation.
+
+### Band descriptors — Lexical Resource
+
+> **Band 9.** Total flexibility and precise use in all contexts. Sustained use of accurate and idiomatic language. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 8.** Wide resource, readily and flexibly used to discuss all topics and convey precise meaning. Skilful use of less common and idiomatic items despite occasional inaccuracies in word choice and collocation. Effective use of paraphrase as required. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 7.** Resource flexibly used to discuss a variety of topics. Some ability to use less common and idiomatic items and an awareness of style and collocation is evident though inappropriacies occur. Effective use of paraphrase as required. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 6.** Resource sufficient to discuss topics at length. Vocabulary use may be inappropriate but meaning is clear. Generally able to paraphrase successfully. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 5.** Resource sufficient to discuss familiar and unfamiliar topics but there is limited flexibility. Attempts paraphrase but not always with success. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 4.** Resource sufficient for familiar topics but only basic meaning can be conveyed on unfamiliar topics. Frequent inappropriacies and errors in word choice. Rarely attempts paraphrase. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 3.** Resource limited to simple vocabulary used primarily to convey personal information. Vocabulary inadequate for unfamiliar topics. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 2.** Very limited resource. Utterances consist of isolated words or memorised utterances. Little communication possible without the support of mime or gesture. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 1.** No resource bar a few isolated words. No communication possible. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+---
+
+## 3. Grammatical Range and Accuracy (GRA)
+
+> "This refers to the accurate and appropriate use of syntactic forms in order to meet Speaking test requirements, and to the test taker's range of grammatical resources, a feature which will help to determine the complexity of propositions which can be expressed." — *speaking-key-assessment-criteria.pdf, p. 2–3*
+
+### What it measures
+
+Two distinct dimensions: how wide a range of grammatical structures the candidate produces (range) and how often errors occur and whether they impede meaning (accuracy). The examiner weighs both — a candidate who is highly accurate but limited to simple sentences cannot reach Band 7.
+
+### Key indicators of range
+
+- The length of spoken sentences.
+- Appropriate use of subordinate clauses within clauses and phrases.
+- Complexity of the verb phrase (auxiliaries in continuous/perfect aspect, modality, passive voice).
+- Complexity of other phrases (pre- and post-modification).
+- Range of sentence structures, especially to move elements around for information focus.
+
+### Key indicators of accuracy
+
+- Error density (number of grammatical errors in a given amount of speech).
+- Communicative effect of error (effect on intelligibility and precision of expression).
+
+### Band descriptors — Grammatical Range and Accuracy
+
+> **Band 9.** Structures are precise and accurate at all times, apart from 'mistakes' characteristic of native speaker speech. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 8.** Wide range of structures, flexibly used. The majority of sentences are error free. Occasional inappropriacies and non-systematic errors occur. A few basic errors may persist. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 7.** A range of structures flexibly used. Error-free sentences are frequent. Both simple and complex sentences are used effectively despite some errors. A few basic errors persist. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 6.** Produces a mix of short and complex sentence forms and a variety of structures with limited flexibility. Though errors frequently occur in complex structures, these rarely impede communication. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 5.** Basic sentence forms are fairly well controlled for accuracy. Complex structures are attempted but these are limited in range, nearly always contain errors and may lead to the need for reformulation. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 4.** Can produce basic sentence forms and some short utterances are error-free. Subordinate clauses are rare and, overall, turns are short, structures are repetitive and errors are frequent. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 3.** Basic sentence forms are attempted but grammatical errors are numerous except in apparently memorised utterances. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 2.** No evidence of basic sentence forms. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 1.** No rateable language unless memorised. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+---
+
+## 4. Pronunciation (P)
+
+> "This refers to the accurate and sustained use of a range of phonological features to convey meaningful messages." — *speaking-key-assessment-criteria.pdf, p. 3*
+
+### What it measures
+
+Pronunciation is assessed as a delivery skill, not as accent imitation. The criterion is intelligibility and use of phonological features (stress, rhythm, intonation, connected speech, word- and phoneme-level production). Accent itself is neutral; the question is the listener's effort.
+
+### Key indicators
+
+- Ability to divide speech into meaningful chunks within spoken sentences.
+- Appropriate use of rhythm and stress timing, and linking of sounds (elision, connected speech).
+- Use of stress (emphatic / contrastive) and intonation to enhance meaning.
+- Production of sounds at word and phoneme level, and the degree of effort required of the listener.
+- Overall effect of accent on intelligibility.
+
+### Band descriptors — Pronunciation
+
+> **Band 9.** Uses a full range of phonological features to convey precise and/or subtle meaning. Flexible use of features of connected speech is sustained throughout. Can be effortlessly understood throughout. Accent has no effect on intelligibility. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 8.** Uses a wide range of phonological features to convey precise and/or subtle meaning. Can sustain appropriate rhythm. Flexible use of stress and intonation across long utterances, despite occasional lapses. Can be easily understood throughout. Accent has minimal effect on intelligibility. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 7.** Displays all the positive features of band 6, and some, but not all, of the positive features of band 8. — *speaking-band-descriptors-cdn.pdf, p. 1*
+
+> **Band 6.** Uses a range of phonological features, but control is variable. Chunking is generally appropriate, but rhythm may be affected by a lack of stress-timing and/or a rapid speech rate. Some effective use of intonation and stress, but this is not sustained. Individual words or phonemes may be mispronounced but this causes only occasional lack of clarity. Can generally be understood throughout without much effort. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 5.** Displays all the positive features of band 4, and some, but not all, of the positive features of band 6. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 4.** Uses some acceptable phonological features, but the range is limited. Produces some acceptable chunking, but there are frequent lapses in overall rhythm. Attempts to use intonation and stress, but control is limited. Individual words or phonemes are frequently mispronounced, causing lack of clarity. Understanding requires some effort and there may be patches of speech that cannot be understood. — *speaking-band-descriptors-cdn.pdf, p. 2*
+
+> **Band 3.** Displays some features of band 2, and some, but not all, of the positive features of band 4. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 2.** Uses few acceptable phonological features (possibly because sample is insufficient). Overall problems with delivery impair attempts at connected speech. Individual words and phonemes are mainly mispronounced and little meaning is conveyed. Often unintelligible. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+> **Band 1.** Can produce occasional individual words and phonemes that are recognisable, but no overall meaning is conveyed. Unintelligible. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+---
+
+## Examiner notes
+
+> (i) A candidate must fully fit the positive features of the descriptor at a particular level.
+> (ii) A candidate will be rated on their average performance across all parts of the test. — *speaking-band-descriptors-cdn.pdf, p. 3*
+
+The "average performance across all parts" rule means a single weak Part does not necessarily collapse the band. It also means a single strong Part does not lift it. Tutors should sample across Parts 1, 2, and 3 before reporting a stable band estimate.
+
+---
+
+## Sources
+
+- *IELTS Speaking Key Assessment Criteria* — `speaking-key-assessment-criteria.pdf` (in this folder), pages 1–4. Joint publication of the British Council, IDP IELTS, and Cambridge University Press & Assessment. Available at https://www.ielts.org (accessed 2026-05-08).
+- *IELTS Speaking Band Descriptors* — `speaking-band-descriptors-cdn.pdf` (in this folder), pages 1–3. Same joint publication. Available at https://www.ielts.org (accessed 2026-05-08).
+- *IELTS Speaking Band Descriptors (public version)* — `cambridge-speaking-band-descriptors.pdf` (in this folder), Cambridge English alternative format. Available at https://www.cambridgeenglish.org (accessed 2026-05-08).

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-language-toolkit.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-language-toolkit.md
@@ -1,0 +1,473 @@
+# IELTS Speaking Language Toolkit
+
+Source: HFF-authored phrase banks distilled from `speaking-key-assessment-criteria.pdf`, `speaking-band-descriptors-cdn.pdf`, `cambridge-speaking-band-descriptors.pdf`, `ielts-guide-for-teachers.pdf`, takeielts.britishcouncil.org preparation pages, ielts.idp.com preparation pages, and CEFR Companion Volume B2/C1/C2 spoken-interaction descriptors.
+
+This is a working toolkit, not an exhaustive list. Each section identifies the language move, gives a phrase bank, and ties it back to the criterion (FC / LR / GRA / P) it most directly lifts. The discriminator between Band 6 and Band 7 is rarely range alone — it is the candidate's ability to deploy the right move at the right moment. The discriminator between Band 7 and Band 8 is naturalness and precision under spontaneous conditions.
+
+| Toolkit section | Lifts which criterion | Lifts which Band step |
+|----------------|----------------------|----------------------|
+| 1. Discourse markers | FC | 5→6, 6→7, 7→8 |
+| 2. Hedging language | LR | 6→7, 7→8 |
+| 3. Paraphrase patterns | LR + FC | 5→6, 6→7 |
+| 4. Opinion language | LR + GRA | 6→7 |
+| 5. Agreement / disagreement | LR + FC | 6→7 |
+| 6. Signposting in monologue | FC | 5→6, 6→7 |
+| 7. Idiomatic chunks | LR | 7→8, 8→9 |
+| 8. Topic-specific collocations | LR | 6→7 |
+| 9. Conditional / hypothetical structures | GRA | 6→7, 7→8 |
+| 10. Pronunciation features | P | 5→6, 6→7 |
+
+---
+
+## 1. Discourse markers (FC)
+
+Per the FC descriptor, Band 7 requires "flexible use of spoken discourse markers, connectives and cohesive features"; Band 6 uses them "though not always appropriately"; Band 5 shows "overuse of certain discourse markers" _(source: `speaking-band-descriptors-cdn.pdf`, p. 1–2)_.
+
+### Sequencing (linking ideas in turn)
+- "First of all ..." / "To start with ..."
+- "On top of that ..." / "What's more ..." / "Beyond that ..."
+- "And then there's the question of ..."
+- "Finally / lastly / and just to add one more thing ..."
+
+### Contrast
+- "Having said that, ..."
+- "On the other hand, ..."
+- "That said, ..."
+- "Whereas in the past ..., today ..."
+- "Whilst it's true that ..., I'd still argue ..."
+
+### Adding nuance
+- "I should probably mention that ..."
+- "What I mean by that is ..."
+- "Or to put it another way ..."
+- "If I think about it more carefully ..."
+
+### Returning to a point
+- "Coming back to ..."
+- "Going back to your earlier question ..."
+- "As I was saying ..."
+
+### Closing a thought
+- "So in short, ..."
+- "Either way, ..."
+- "All in all, ..."
+- "If I had to sum it up ..."
+
+**Coaching note:** Overuse of "And" / "But" / "So" caps a candidate at Band 5 on FC. Three of the four discourse-marker categories above must appear in any Band 7 Part 3 response.
+
+---
+
+## 2. Hedging language (LR)
+
+Hedging — softening claims with epistemic markers — is required to reach Band 7 on LR. The Band 7 descriptor mentions "less common and idiomatic vocabulary and shows some awareness of style"; hedging is the most reliable Band 7 stylistic feature _(source: `cambridge-speaking-band-descriptors.pdf`, p. 1)_.
+
+### Epistemic hedges
+- "I would say ..." / "I'd argue ..."
+- "I tend to think ..."
+- "I'm inclined to ..."
+- "It seems to me that ..."
+- "If I had to pick a side ..."
+
+### Quantifier hedges
+- "to some extent"
+- "in many cases"
+- "for the most part"
+- "broadly speaking"
+- "by and large"
+- "more often than not"
+
+### Evidential hedges
+- "It's been suggested that ..."
+- "It's often said that ..."
+- "From what I've read ..."
+- "If memory serves, ..."
+- "I might be wrong, but ..."
+
+### Politeness hedges (used to soften strong opinions)
+- "I wouldn't go so far as to say ..."
+- "It might be a bit of an exaggeration to say ..."
+- "I'd hesitate to claim ..."
+- "Not to overstate it, but ..."
+
+**Coaching note:** A candidate who states every Part 3 view as fact ("Advertising influences people. People buy what they see.") cannot reach Band 7 on LR regardless of vocabulary range. Tutors should explicitly model hedged versions: "I'd say advertising clearly influences what people buy, though the influence varies a lot."
+
+---
+
+## 3. Paraphrase patterns (LR + FC)
+
+Per the LR descriptor, paraphrase appears at every band from Band 5 upward. Band 6: "generally able to paraphrase successfully". Band 7: "effective use of paraphrase as required". Band 8: "uses paraphrase effectively as required" _(source: `speaking-band-descriptors-cdn.pdf`, p. 1–2)_.
+
+### Word-level paraphrase (used when the candidate forgets a word)
+- "what I mean is, basically, ..."
+- "the kind of thing that ..."
+- "you know, the [category] for [function]"
+
+### Idea-level paraphrase (used to extend an answer)
+- "[X], or to put it another way, [Y]"
+- "[X] — what I mean by that is [Y]"
+- "[X], or in other words, [Y]"
+
+### Generalisation paraphrase (Part 3 lift)
+- "X" → "this kind of thing"
+- "X" → "issues like X"
+- "X" → "the broader question of X"
+
+### Restatement paraphrase
+- "It's not so much [X] as [Y]"
+- "The real question isn't [X], it's [Y]"
+- "I wouldn't put it quite that way — I'd say [Y]"
+
+**Coaching note:** A candidate who freezes on a missing word and stops talking is signalling Band 5. The lift is the phrase "the kind of thing that ..." — which buys time and demonstrates LR all at once.
+
+---
+
+## 4. Opinion language (LR + GRA)
+
+### Stating an opinion (Band 6+)
+- "In my opinion ..."
+- "Personally, I think ..."
+- "From my point of view ..."
+- "I believe ..."
+
+### Stating an opinion (Band 7+)
+- "I'd say ..."
+- "I'm inclined to think ..."
+- "It seems to me that ..."
+- "If I'm honest, ..."
+- "What I tend to find is ..."
+
+### Stating an opinion (Band 8+)
+- "My view, for what it's worth, is that ..."
+- "If I had to put a stake in the ground, ..."
+- "I'd lean towards ..."
+- "There's a strong case for saying ..."
+
+### Justifying an opinion
+- "The reason I think this is ..."
+- "What makes me say that is ..."
+- "I'd point to ... as evidence"
+
+### Conceding before reasserting
+- "It's true that ..., but on balance ..."
+- "I can see why people might say ..., but I'd still argue ..."
+- "Whilst there's something to that, I think ..."
+
+**Coaching note:** "In my opinion" is a Band 5/6 marker by overuse. A student who uses "In my opinion" four times in Part 3 plateaus at Band 6 on LR. Train alternation.
+
+---
+
+## 5. Agreement and disagreement (LR + FC)
+
+### Strong agreement
+- "I couldn't agree more."
+- "Absolutely — and I'd add that ..."
+- "That's exactly right."
+
+### Partial agreement
+- "I see your point, but ..."
+- "Up to a point — though I'd qualify that with ..."
+- "There's something to that, but ..."
+
+### Polite disagreement
+- "I'm not sure I'd go that far."
+- "I'd see it differently — for me ..."
+- "I'd push back on that a little."
+- "I'd offer a slightly different view ..."
+
+### Strong disagreement (use sparingly in Part 3)
+- "I'd actually argue the opposite."
+- "I'm not convinced by that — I'd say ..."
+
+**Coaching note:** Part 3 examiner probes ("Do you think ...?") are not arguments — the candidate is not disagreeing with the examiner, they are taking a position on the question. Strong disagreement language is rarely needed; partial-agreement language is the most useful.
+
+---
+
+## 6. Signposting in monologue (FC)
+
+Specifically for Part 2. Each cue card bullet maps to a stage; each stage benefits from a signpost.
+
+### Opening (bullet 1: identification)
+- "The [thing] I'd like to talk about is ..."
+- "I've decided to describe ..."
+- "What comes to mind straight away is ..."
+
+### Concrete detail (bullets 2–3)
+- "To give you a bit of background, ..."
+- "In terms of how/when/where, ..."
+- "What's notable about it is ..."
+- "One thing I should mention is ..."
+
+### Transition between bullets
+- "Moving on to ..."
+- "Another thing worth mentioning is ..."
+- "Perhaps more importantly, ..."
+
+### "And explain ..." bullet (the substantive bullet)
+- "The reason it [matters / stands out / has stayed with me] is ..."
+- "What makes it special is ..."
+- "If I had to sum up why, I'd say ..."
+
+### Reflective close (Band 7+)
+- "Looking back, ..."
+- "Even now, ..."
+- "If I think about it now, ..."
+
+**Coaching note:** A Part 2 monologue with no signposts will lose coherence within 60 seconds. The single most useful intervention for a Band 6 candidate is to teach the four-stage signpost pattern: open → detail → detail → "the reason ...".
+
+---
+
+## 7. Idiomatic chunks (LR — Band 7→8 lift)
+
+Idioms must be used naturally, not forced. The Band 8 descriptor requires "idiomatic vocabulary skilfully" with "occasional inaccuracies" _(source: `cambridge-speaking-band-descriptors.pdf`, p. 1)_. Memorised idiom-stuffing is a Band 6 marker — examiners are trained to spot it.
+
+### Quantity / extent
+- "a fair bit of ..."
+- "a great deal of ..."
+- "no shortage of ..."
+- "few and far between"
+
+### Time
+- "in the long run"
+- "for the foreseeable future"
+- "every so often"
+- "from time to time"
+- "by and large"
+
+### Reasoning
+- "at the end of the day"
+- "when it comes down to it"
+- "if you ask me"
+- "all things considered"
+
+### Comparison
+- "by the same token"
+- "in much the same way"
+- "much like ..."
+- "in stark contrast to ..."
+
+### Cause and effect
+- "the upshot of which is ..."
+- "the knock-on effect"
+- "as a direct consequence"
+- "which in turn means ..."
+
+### Hedged claim
+- "more often than not"
+- "for the most part"
+- "to a large extent"
+- "to put it mildly"
+
+**Coaching note:** A Band 7 candidate who uses one of these per minute reaches Band 7.5 on LR. Five per minute = forced and paradoxically caps at Band 6.5.
+
+---
+
+## 8. Topic-specific collocations (LR)
+
+Cambridge band descriptors require "less common and idiomatic vocabulary and shows some awareness of style and collocation" at Band 7 _(source: `cambridge-speaking-band-descriptors.pdf`, p. 1)_. Below are high-yield collocations grouped by recurring Part 3 themes.
+
+### Society
+- "shifting attitudes" / "changing values"
+- "social pressure" / "peer pressure"
+- "the role of [X] in society"
+- "to set an example"
+- "a generational shift"
+
+### Technology
+- "to keep pace with technology"
+- "screen time"
+- "digital natives"
+- "tech-savvy"
+- "the digital divide"
+- "to be glued to one's phone"
+
+### Environment
+- "carbon footprint"
+- "sustainable practices"
+- "renewable energy"
+- "to mitigate the effects of ..."
+- "ecological balance"
+
+### Education
+- "rote learning"
+- "critical thinking"
+- "lifelong learning"
+- "transferable skills"
+- "academic pressure"
+- "well-rounded education"
+
+### Work
+- "work-life balance"
+- "job satisfaction"
+- "career progression"
+- "remote working"
+- "to be in a high-pressure role"
+- "burnout"
+
+### Media
+- "to influence public opinion"
+- "biased coverage"
+- "fake news" / "misinformation"
+- "to set the agenda"
+- "filter bubble"
+- "to go viral"
+
+### Health
+- "a balanced diet"
+- "physical and mental wellbeing"
+- "preventative healthcare"
+- "sedentary lifestyle"
+- "to keep in shape"
+- "burnout"
+
+### Government
+- "public spending"
+- "policy decisions"
+- "to fall under the government's remit"
+- "regulatory framework"
+- "to strike a balance between ..."
+
+### Family
+- "tight-knit family"
+- "extended family"
+- "to be brought up to ..."
+- "intergenerational gap"
+- "to take after [a parent]"
+
+### Money
+- "disposable income"
+- "to live within one's means"
+- "the cost of living"
+- "to be in the red / black"
+- "financial security"
+
+**Coaching note:** Collocation errors are the single biggest LR ceiling at Band 7. A candidate who says "expensive money" instead of "high cost" or "do a decision" instead of "make a decision" cannot reach Band 7 on LR even with otherwise excellent vocabulary. Collocation training is more leveraged than vocabulary expansion.
+
+---
+
+## 9. Conditional and hypothetical structures (GRA)
+
+Part 3 abstract questions often invite conditional answers. Producing them spontaneously is a Band 7+ marker.
+
+### Zero conditional (general truths)
+- "If governments invest in education, productivity tends to rise."
+
+### First conditional (likely future)
+- "If we don't address this soon, things will get worse."
+
+### Second conditional (counterfactual present)
+- "If I were the government, I'd ..."
+- "If we lived in a perfect world, ..."
+- "If money were no object, people would ..."
+
+### Third conditional (counterfactual past)
+- "If they had introduced the policy earlier, we wouldn't be in this situation."
+- "If I'd known then what I know now, ..."
+
+### Mixed conditional
+- "If I had studied harder at school, I'd be in a better job now."
+
+### "Were to" hypothetical
+- "If governments were to introduce a tax on ..., people would think twice about ..."
+- "Were that to happen, the consequences would be significant."
+
+### "Suppose / supposing" frames
+- "Supposing for a moment that ..., what would the alternative be?"
+- "Imagine if everyone ..."
+
+**Coaching note:** A candidate who uses no conditional structures across a 4-minute Part 3 cannot reach Band 7 on GRA. The single most leveraged drill: rephrase any Part 3 abstract question as a "were to" hypothetical answer.
+
+---
+
+## 10. Pronunciation features (P)
+
+Per the P descriptor, the Band 7 marker is "displays all the positive features of band 6, and some, but not all, of the positive features of band 8" _(source: `speaking-band-descriptors-cdn.pdf`, p. 1)_. Practically, this means the candidate must do most of Band 6's work plus some of Band 8's. The toolkit below targets each phonological feature.
+
+### Chunking (sentence-level pausing)
+
+Speech in meaningful chunks rather than word-by-word:
+
+> "When I think about my childhood / the place that comes to mind / is my grandmother's house."
+
+Drill: read a Part 2 cue card and mark slashes where the candidate would naturally pause. Re-read with strict observance of those pauses.
+
+### Word stress
+
+Common Band 6 errors (stress on wrong syllable):
+
+| Word | Wrong stress | Correct stress |
+|------|-------------|---------------|
+| develop | DE-velop | de-VEL-op |
+| photograph | photo-GRAPH | PHO-tograph |
+| economy | EC-onomy | e-CON-omy |
+| advertisement | ad-vert-IZE-ment | ad-VER-tis-ment (UK) / AD-ver-tise-ment (US) |
+| comfortable | com-FORT-able | COMF-table |
+| vegetable | ve-GE-table | VEG-table |
+
+### Sentence stress (content vs function words)
+
+Stress falls on content words (nouns, verbs, adjectives, adverbs); function words (articles, auxiliaries, prepositions) reduce.
+
+> "I went to the SHOP and bought some BREAD." (stress only on SHOP / BOUGHT / BREAD)
+
+### Intonation
+
+- **Rising intonation** at the end of yes/no questions: "Do you LIVE here?"
+- **Falling intonation** at the end of statements and wh-questions: "I live in the CITY."
+- **Rising-falling** at the end of a list item that is not the last: "I bought apples / pears / and bananas." (rise on apples, pears; fall on bananas)
+
+### Connected speech features
+
+| Feature | Example | What changes |
+|---------|---------|-------------|
+| Linking | "an apple" → /ə-NAP-əl/ | Consonant links to next vowel |
+| Elision | "next day" → "neks day" | /t/ dropped |
+| Assimilation | "ten boys" → "tem boys" | /n/ → /m/ before /b/ |
+| Weak forms | "fish and chips" → "fish 'n' chips" | "and" reduces to /ən/ |
+
+### Common L1 interference (mention only when audible)
+
+| L1 family | Common pattern | Example |
+|-----------|---------------|---------|
+| Mandarin / Cantonese | Loss of final consonants | "right" → "rye" |
+| Spanish / Portuguese | Adding /e/ before consonant clusters | "school" → "eschool" |
+| Arabic | Confusion of /p/ and /b/ | "park" → "bark" |
+| Japanese | /r/ and /l/ merger | "rice" → "lice" |
+| French | Replacing /θ/ with /s/ or /z/ | "thing" → "sing" |
+| Hindi / Urdu | Retroflex /t/ and /d/ | distinctive but does not impede |
+| Korean | /f/ → /p/ substitution | "fan" → "pan" |
+| Slavic | Devoicing final voiced consonants | "bag" → "back" |
+| Vietnamese | Tonal carry-over to English | flat or unexpected pitch |
+
+**Coaching note:** Per the descriptor, "accent has minimal effect on intelligibility" is the Band 8 standard, not "no accent". Candidates should not be coached toward British or American accent imitation — the goal is intelligibility, not accent erasure.
+
+---
+
+## Toolkit assembly: a Band 7 minimum target
+
+A Part 3 response that consistently reaches Band 7 should typically include, within a 4-question discussion (~4 minutes):
+
+| Move | Minimum count |
+|------|--------------|
+| Discourse markers from at least three of the five categories | 6+ |
+| Hedging phrases | 3+ |
+| Idiomatic chunks (natural, not forced) | 2+ |
+| Conditional or hypothetical structures | 2+ |
+| Topic-specific collocations | 4+ |
+| Paraphrase moves | 1+ |
+| Comparison-across-time | 1 |
+| Concession + reassertion | 1 |
+
+A candidate hitting all eight rows reliably reaches Band 7.5+. A candidate hitting six rows reliably reaches Band 7.
+
+---
+
+## Sources
+
+- *IELTS Speaking Key Assessment Criteria* — `speaking-key-assessment-criteria.pdf` (in this folder), pages 1–4.
+- *IELTS Speaking Band Descriptors* — `speaking-band-descriptors-cdn.pdf` (in this folder), pages 1–3.
+- *IELTS Speaking Band Descriptors (public version)* — `cambridge-speaking-band-descriptors.pdf` (in this folder), p. 1.
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking section.
+- takeielts.britishcouncil.org — "IELTS Speaking preparation" pages: vocabulary tips, pronunciation tips, fluency strategies. https://takeielts.britishcouncil.org (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking preparation" pages: discourse markers, hedging, paraphrase. https://ielts.idp.com (accessed 2026-05-08).
+- Council of Europe — *Common European Framework of Reference for Languages: Companion Volume* (2020), spoken interaction and spoken production scales B2 / C1 / C2. https://www.coe.int/en/web/common-european-framework-reference-languages (accessed 2026-05-08).
+- Cambridge English — "Vocabulary, grammar and discourse strategies for high-band IELTS Speaking". https://www.cambridgeenglish.org (accessed 2026-05-08).

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-question-bank-part1.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-question-bank-part1.md
@@ -1,0 +1,762 @@
+# IELTS Speaking Question Bank — Part 1
+
+Source: HFF-authored question sets in the style of published IELTS Part 1 frames. Topic clusters and question forms are modelled on `speaking-sample-tasks-2023.pdf`, takeielts.britishcouncil.org Part 1 samples, ielts.idp.com Part 1 samples, and Cambridge IELTS volumes 1–19.
+
+This bank contains 50 topic frames, each with 4–6 questions, in the standard Part 1 form. Questions are HFF-authored to mirror the style and difficulty of published Cambridge tasks without reproducing copyrighted exam content. Where a topic frame appears in an officially published source, the source is tagged.
+
+**Format note:** Each frame begins with a signposting line ("Let's talk about ..." or "Now I'd like to ask you about ..."), followed by 4–6 questions. Questions cluster around: identity, frequency, preference, past experience, future / hypothetical, and reason.
+
+**Coaching note:** Part 1 answers should run 2–4 sentences. The pattern reason → example → personal touch generally reaches Band 6+. Answers shorter than two sentences cap at Band 5 on Fluency.
+
+---
+
+## Frame 1 — Home town / village
+
+_Let's talk about your home town or village._
+
+1. What kind of place is it?
+2. What's the most interesting part of your town or village?
+3. What kind of jobs do the people in your town do?
+4. Would you say it's a good place to live? (Why?)
+5. Has your home town changed much since you were a child?
+
+_(source: ielts.org official sample — `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+---
+
+## Frame 2 — Accommodation
+
+_Let's move on to talk about accommodation._
+
+1. Tell me about the kind of accommodation you live in.
+2. How long have you lived there?
+3. What do you like about living there?
+4. What sort of accommodation would you most like to live in?
+5. Is your home easy to get to?
+
+_(source: ielts.org official sample — `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+---
+
+## Frame 3 — Work
+
+_Let's talk about your work._
+
+1. What kind of work do you do?
+2. What does a typical day at work look like for you?
+3. What do you find most enjoyable about your job?
+4. Is there anything you would like to change about your work?
+5. Would you recommend your job to other people? (Why or why not?)
+
+_(source: HFF-authored, modelled on published Part 1 frames; takeielts.britishcouncil.org Part 1 work-and-study sample, accessed 2026-05-08.)_
+
+---
+
+## Frame 4 — Studies
+
+_Now let's talk about your studies._
+
+1. What subject are you studying at the moment?
+2. Why did you choose that subject?
+3. Which part of your studies do you enjoy most?
+4. Do you prefer studying alone or in a group? (Why?)
+5. What do you hope to do after you finish your studies?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 work-and-study sample.)_
+
+---
+
+## Frame 5 — Family
+
+_Let's talk about your family._
+
+1. Do you come from a large or a small family?
+2. Who do you spend the most time with in your family?
+3. How often do you see your relatives?
+4. What do you usually do when your family gets together?
+5. Has your family changed much in the last few years?
+
+_(source: HFF-authored; mirrors Cambridge IELTS published frames.)_
+
+---
+
+## Frame 6 — Friends
+
+_Now let's talk about your friends._
+
+1. How often do you see your friends?
+2. What do you usually do with your friends?
+3. Do you prefer to have a few close friends or many friends? (Why?)
+4. How did you meet your closest friend?
+5. Is it easy to make new friends as an adult?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 7 — Hobbies
+
+_Let's talk about hobbies._
+
+1. Do you have any hobbies?
+2. How did you become interested in your hobby?
+3. How often do you have time for your hobby?
+4. Do you think hobbies are important? (Why?)
+5. Would you like to take up a new hobby in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 8 — Sports
+
+_Now let's talk about sports._
+
+1. Do you play any sports?
+2. Did you play sports when you were younger?
+3. Do you prefer playing sports or watching them?
+4. What sport is most popular in your country?
+5. Do you think children should be encouraged to play sports?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 sports samples.)_
+
+---
+
+## Frame 9 — Food and cooking
+
+_Let's talk about food._
+
+1. What kinds of food do you most enjoy?
+2. Do you prefer eating at home or in restaurants?
+3. How often do you cook?
+4. Did your family eat together when you were a child?
+5. Has the food you eat changed over the years?
+6. Are there any foods you don't like?
+
+_(source: HFF-authored; mirrors Cambridge IELTS food-topic frames.)_
+
+---
+
+## Frame 10 — Travel
+
+_Let's talk about travel._
+
+1. Do you enjoy travelling?
+2. Where was the last place you visited?
+3. Do you prefer travelling alone or with other people?
+4. What kind of place would you most like to visit?
+5. Has the way people travel changed in recent years?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 11 — Holidays
+
+_Now let's talk about holidays._
+
+1. How do you usually spend your holidays?
+2. Do you prefer short holidays or long ones?
+3. Where did you go on your last holiday?
+4. What's the best holiday you've ever had?
+5. Would you ever like to spend a holiday abroad?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 holidays sample.)_
+
+---
+
+## Frame 12 — Transport
+
+_Let's talk about transport._
+
+1. How do you usually get around your town or city?
+2. Do you prefer public transport or driving? (Why?)
+3. Has the transport in your area changed in recent years?
+4. Do you think people should use public transport more?
+5. What's the most uncomfortable journey you've ever had?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 transport sample.)_
+
+---
+
+## Frame 13 — Technology
+
+_Let's talk about technology._
+
+1. How often do you use a computer?
+2. What do you mostly use it for?
+3. Are you good with new technology?
+4. Has technology changed your daily life much?
+5. Do you think people rely too much on technology?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 14 — Social media
+
+_Now let's talk about social media._
+
+1. Do you use social media?
+2. Which platform do you use most often?
+3. How much time do you spend on social media each day?
+4. Has social media changed the way you keep in touch with friends?
+5. Are there any aspects of social media you dislike?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 15 — Mobile phones
+
+_Let's talk about mobile phones._
+
+1. How often do you use your mobile phone?
+2. What do you use it for most?
+3. Did you have a mobile phone when you were a child?
+4. Could you live without your mobile phone for a week?
+5. How has the way people use mobile phones changed?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 16 — Music
+
+_Now let's talk about music._
+
+1. What kind of music do you enjoy listening to?
+2. When do you usually listen to music?
+3. Did you learn a musical instrument as a child?
+4. Has the music you like changed over the years?
+5. Do you ever go to concerts?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 music sample.)_
+
+---
+
+## Frame 17 — Films
+
+_Let's talk about films._
+
+1. How often do you watch films?
+2. Do you prefer watching films at home or at the cinema?
+3. What kind of films do you most enjoy?
+4. What's the last film you saw?
+5. Are films from your country popular abroad?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 18 — Books
+
+_Now let's talk about books._
+
+1. Do you read much?
+2. What kind of books do you most enjoy?
+3. Do you prefer paper books or e-books? (Why?)
+4. Did you read a lot as a child?
+5. Is reading important to you?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 19 — News
+
+_Let's talk about the news._
+
+1. How do you usually get the news?
+2. How often do you check the news?
+3. What kind of news interests you most?
+4. Do you discuss the news with your family or friends?
+5. Is the way people get the news different now from in the past?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 20 — Art
+
+_Now let's talk about art._
+
+1. Did you do art at school?
+2. Do you ever visit art galleries?
+3. What kind of art do you most enjoy?
+4. Do you have any artistic hobbies?
+5. Do you think art is important for children?
+
+_(source: HFF-authored; mirrors Cambridge IELTS art-topic frames.)_
+
+---
+
+## Frame 21 — Weather
+
+_Let's talk about the weather._
+
+1. What kind of weather do you most enjoy?
+2. What's the weather like in your country at this time of year?
+3. Does the weather affect your mood?
+4. Has the weather where you live changed much over the years?
+5. Do you ever check the weather forecast?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 weather sample.)_
+
+---
+
+## Frame 22 — Seasons
+
+_Now let's talk about seasons._
+
+1. Which is your favourite season?
+2. What do you usually do in that season?
+3. Are the seasons very different in your country?
+4. Do you prefer summer or winter?
+5. Has your favourite season changed since you were a child?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 23 — Clothes
+
+_Let's talk about clothes._
+
+1. What kind of clothes do you like to wear?
+2. Do you spend much time choosing what to wear?
+3. Where do you usually buy your clothes?
+4. Have your clothing tastes changed over the years?
+5. Are there any clothes you would never wear?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 24 — Shopping
+
+_Now let's talk about shopping._
+
+1. Do you enjoy shopping?
+2. What kinds of things do you most enjoy shopping for?
+3. Do you prefer shopping online or in shops?
+4. Who do you usually go shopping with?
+5. Has the way people shop changed in recent years?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 25 — Money
+
+_Let's talk about money._
+
+1. Do you find it easy to save money?
+2. Do you prefer to spend money on things or experiences?
+3. Did your parents teach you about money when you were young?
+4. Do you keep track of what you spend?
+5. Is it important to teach children about money?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 26 — Gifts
+
+_Now let's talk about gifts._
+
+1. Do you enjoy giving gifts?
+2. When did you last give someone a gift?
+3. Is it easy to choose a gift for someone?
+4. Do people in your country exchange gifts on special occasions?
+5. What's the best gift you've ever received?
+
+_(source: HFF-authored; mirrors Cambridge IELTS gifts-topic frames.)_
+
+---
+
+## Frame 27 — Festivals
+
+_Let's talk about festivals._
+
+1. What's the most important festival in your country?
+2. How is it celebrated?
+3. Do you usually celebrate it with your family?
+4. Has the way people celebrate festivals changed?
+5. Do you think traditional festivals are important?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 28 — Celebrations
+
+_Now let's talk about celebrations._
+
+1. What kinds of events do you usually celebrate?
+2. Who do you usually celebrate with?
+3. How did you celebrate your last birthday?
+4. Do you prefer big celebrations or small ones? (Why?)
+5. Are celebrations important in your country?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 29 — Photographs
+
+_Let's talk about photographs._
+
+1. Do you like taking photographs?
+2. Do you prefer taking photographs of people or places?
+3. How do you usually keep your photographs?
+4. Has the way people take photographs changed?
+5. Do you ever look back at old photographs?
+
+_(source: HFF-authored; mirrors Cambridge IELTS photographs-topic frames.)_
+
+---
+
+## Frame 30 — Neighbours
+
+_Now let's talk about neighbours._
+
+1. Do you know your neighbours well?
+2. How often do you see them?
+3. Do you think it's important to have good neighbours?
+4. Has the relationship between neighbours changed in your country?
+5. What makes a good neighbour?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 31 — Pets
+
+_Let's talk about pets._
+
+1. Do you have a pet?
+2. Did you have a pet when you were a child?
+3. What kind of pets are popular in your country?
+4. Do you think children should have pets?
+5. Are pets treated differently now from in the past?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 32 — Animals
+
+_Now let's talk about animals._
+
+1. What's your favourite animal?
+2. Are there many wild animals where you live?
+3. Did you visit zoos when you were younger?
+4. Do you think it's important to protect wild animals?
+5. Have you ever seen an animal you found really interesting?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 33 — Plants and flowers
+
+_Let's talk about plants and flowers._
+
+1. Do you have any plants at home?
+2. Do you ever buy flowers?
+3. Are flowers given as gifts in your country?
+4. Did you have a garden when you were a child?
+5. Are there any flowers that are special in your culture?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 34 — Gardens
+
+_Now let's talk about gardens._
+
+1. Do you have a garden?
+2. Do you enjoy gardening?
+3. Are there public gardens or parks where you live?
+4. Did you spend time in gardens when you were a child?
+5. What do you think people enjoy about gardening?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 gardens sample.)_
+
+---
+
+## Frame 35 — Time management
+
+_Let's talk about how you manage your time._
+
+1. Do you find it easy to manage your time?
+2. Are you good at being on time?
+3. Do you make plans for each day?
+4. What do you do when you have free time?
+5. Has managing your time become easier or harder over the years?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 36 — Sleep
+
+_Now let's talk about sleep._
+
+1. How many hours of sleep do you usually get?
+2. Do you ever have trouble sleeping?
+3. Do you prefer to go to bed early or late?
+4. Did you sleep more when you were a child?
+5. Do you take naps during the day?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 sleep sample.)_
+
+---
+
+## Frame 37 — Dreams
+
+_Let's talk about dreams._
+
+1. Do you usually remember your dreams?
+2. Do you ever have the same dream more than once?
+3. Have you ever had a dream that came true?
+4. Do you think dreams have any meaning?
+5. Have you ever talked about a dream with someone else?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 38 — Memory
+
+_Now let's talk about memory._
+
+1. Are you good at remembering things?
+2. What kinds of things do you find easy to remember?
+3. What do you do when you need to remember something important?
+4. Do you think children have better memories than adults?
+5. Have you ever forgotten something important?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 39 — Childhood
+
+_Let's talk about your childhood._
+
+1. Where did you grow up?
+2. What did you most enjoy doing as a child?
+3. Were you closer to your mother or your father?
+4. Has childhood changed since you were young?
+5. What's your happiest childhood memory?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 40 — School
+
+_Now let's talk about your school days._
+
+1. What primary school did you go to?
+2. What did you most enjoy at school?
+3. What was your favourite subject?
+4. Did you have a favourite teacher?
+5. What's the most important thing you learned at school?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 41 — Teachers
+
+_Let's talk about teachers._
+
+1. Did you have a favourite teacher when you were younger?
+2. What made them a good teacher?
+3. What qualities do you think a teacher should have?
+4. Have you ever taught anyone anything?
+5. Do you think teaching is a difficult job?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 42 — Languages
+
+_Now let's talk about languages._
+
+1. How many languages do you speak?
+2. When did you start learning English?
+3. Which language would you most like to learn next?
+4. Is learning a language difficult for you?
+5. What's the best way to learn a language, in your opinion?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 43 — Learning
+
+_Let's talk about learning new things._
+
+1. Do you enjoy learning new things?
+2. What was the last thing you learned?
+3. Do you prefer learning by yourself or being taught?
+4. What's the most useful skill you've ever learned?
+5. Is there anything you would like to learn in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 44 — Future plans
+
+_Now let's talk about your future plans._
+
+1. Do you have any plans for the next few years?
+2. Where do you see yourself in five years' time?
+3. Are you the kind of person who plans ahead?
+4. Did you make plans for your future when you were younger?
+5. Is it important to make long-term plans, in your opinion?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 45 — The internet
+
+_Let's talk about the internet._
+
+1. How often do you use the internet?
+2. What do you most use it for?
+3. Did you use the internet when you were a child?
+4. Has the internet changed the way you do things?
+5. Are there any disadvantages to using the internet?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 46 — Email and letters
+
+_Now let's talk about written communication._
+
+1. How often do you write emails?
+2. Do you ever write letters by hand?
+3. Did you write letters when you were younger?
+4. Do you prefer writing or speaking when you communicate with someone far away?
+5. Has the way people communicate changed much in your lifetime?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 47 — Advertising
+
+_Let's talk about advertising._
+
+1. Do you pay attention to advertisements?
+2. Where do you see most adverts?
+3. Have you ever bought something because of an advert?
+4. Do you think there are too many advertisements these days?
+5. Do you think advertising affects children?
+
+_(source: HFF-authored; mirrors `speaking-sample-tasks-2023.pdf`, p. 6 advertising prompt.)_
+
+---
+
+## Frame 48 — Sky and stars
+
+_Now let's talk about the sky._
+
+1. Do you ever look at the sky?
+2. Have you ever watched the stars at night?
+3. Is the night sky clear where you live?
+4. Did you study the stars at school?
+5. Would you ever like to travel to space?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 sky-and-stars sample.)_
+
+---
+
+## Frame 49 — Rain and wet weather
+
+_Let's talk about rainy weather._
+
+1. Does it rain much where you live?
+2. Do you enjoy rainy days?
+3. What do you usually do when it rains?
+4. Has the rainfall in your area changed in recent years?
+5. Are there places in your country where it rains a lot more than others?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 50 — Public transport
+
+_Now let's talk about public transport._
+
+1. How often do you use public transport?
+2. What kind of public transport do you most use?
+3. Is the public transport in your city good?
+4. Did you use public transport more when you were younger?
+5. Are there ways the public transport in your area could be improved?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 51 — Free time
+
+_Let's talk about your free time._
+
+1. What do you usually do in your free time?
+2. Do you have enough free time during the week?
+3. Did you have more free time when you were younger?
+4. Do you prefer to spend your free time alone or with others?
+5. Is free time important to you?
+
+_(source: HFF-authored; mirrors Cambridge IELTS free-time frames.)_
+
+---
+
+## Frame 52 — Health and exercise
+
+_Now let's talk about health and exercise._
+
+1. Do you exercise regularly?
+2. What kind of exercise do you enjoy most?
+3. Did you do more exercise when you were younger?
+4. Do you think people in your country exercise enough?
+5. Is exercise important for staying healthy?
+
+_(source: HFF-authored.)_
+
+---
+
+## Coaching cheat sheet
+
+| Question form | Common candidate failure | Tutor cue |
+|---------------|-------------------------|-----------|
+| "Do you ...?" | One-word "Yes" / "No" | "Extend with a reason and an example." |
+| "How often ...?" | "Sometimes" or "Often" | "Anchor the frequency in time — once a week, a few times a year." |
+| "Tell me about ..." | Lists facts without elaboration | "Pick one feature and develop it." |
+| "Why ...?" | Vague reasoning | "Give a specific reason — what made you feel that way?" |
+| "Has ... changed?" | Present-only answer | "Compare past and present explicitly." |
+| "Would you most like to ...?" | Indecision | "Commit to one option and justify." |
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 3, 6.
+- ielts.org — "Speaking Part 1 sample tasks". https://www.ielts.org (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests Part 1". https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking Part 1 sample". https://ielts.idp.com (accessed 2026-05-08).
+- Cambridge IELTS volumes 1–19 — published past papers (referenced as a pattern source; not reproduced verbatim).
+- All HFF-authored frames marked above are written in the style of the published frames and are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-question-bank-part2.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-question-bank-part2.md
@@ -1,0 +1,1042 @@
+# IELTS Speaking Question Bank — Part 2
+
+Source: HFF-authored cue cards in the style of published IELTS Part 2 tasks. Card structure and topical clusters are modelled on `speaking-sample-tasks-2023.pdf`, takeielts.britishcouncil.org Part 2 samples, ielts.idp.com Part 2 samples, and Cambridge IELTS volumes 1–19.
+
+This bank contains 88 cue cards in the standard four-bullet form, clustered by the six Part 2 frames identified in `ielts-speaking-question-types-guide.md`: **Person, Place, Object, Event, Experience, Activity**. Cards are HFF-authored to mirror the style and difficulty of published Cambridge tasks without reproducing copyrighted exam content.
+
+**Format note:** Every card uses the official template:
+
+```
+Describe ...
+You should say:
+   [bullet 1]
+   [bullet 2]
+   [bullet 3]
+and explain ...
+```
+
+After the candidate's monologue, the examiner may ask one or two short rounding-off questions; representative rounding-off questions are listed where relevant.
+
+**Coaching note:** Each bullet is approximately one paragraph of the monologue. The "and explain" bullet is the substantive one — examiners look for it to be addressed with reasoning, not just a fact. A 2-minute monologue is typically 250–350 words.
+
+---
+
+## Person frame (cards 1–15)
+
+### Card 1 — Family member you admire
+
+> Describe a family member you admire.
+> You should say:
+>   who this person is
+>   how often you see them
+>   what kind of personality they have
+> and explain why you admire them.
+
+_Rounding-off: Have you tried to be like them in any way?_
+
+_(source: HFF-authored; mirrors Cambridge IELTS person-topic frames.)_
+
+### Card 2 — A friend who has helped you
+
+> Describe a friend who has helped you in some way.
+> You should say:
+>   who they are
+>   when they helped you
+>   what they did
+> and explain why their help was important.
+
+_(source: HFF-authored.)_
+
+### Card 3 — A teacher you remember
+
+> Describe a teacher you remember from school.
+> You should say:
+>   who they were
+>   what subject they taught
+>   what they were like
+> and explain why you remember them.
+
+_(source: HFF-authored.)_
+
+### Card 4 — A famous person you would like to meet
+
+> Describe a famous person you would like to meet.
+> You should say:
+>   who this person is
+>   how you first heard of them
+>   what you know about them
+> and explain why you would like to meet them.
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 2 sample.)_
+
+### Card 5 — An older person you respect
+
+> Describe an older person you respect.
+> You should say:
+>   who they are
+>   how you know them
+>   what kind of person they are
+> and explain why you respect them.
+
+_(source: HFF-authored.)_
+
+### Card 6 — A child you know
+
+> Describe a child you know well.
+> You should say:
+>   who the child is
+>   how often you see them
+>   what they are like
+> and explain why you enjoy spending time with them.
+
+_(source: HFF-authored.)_
+
+### Card 7 — A talented person
+
+> Describe a person you know who is good at a particular skill.
+> You should say:
+>   who they are
+>   what skill they are good at
+>   how they developed it
+> and explain why you find their skill impressive.
+
+_(source: HFF-authored.)_
+
+### Card 8 — A stranger who helped you
+
+> Describe a stranger who once helped you.
+> You should say:
+>   when this happened
+>   where you were
+>   what they did
+> and explain how you felt about their help.
+
+_(source: HFF-authored.)_
+
+### Card 9 — A neighbour you know well
+
+> Describe a neighbour you know well.
+> You should say:
+>   who they are
+>   how long you have known them
+>   what kind of person they are
+> and explain why you get on with them.
+
+_(source: HFF-authored.)_
+
+### Card 10 — A leader you admire
+
+> Describe a leader you admire.
+> You should say:
+>   who they are
+>   what they are known for
+>   what kind of person they are
+> and explain why you admire them.
+
+_(source: HFF-authored.)_
+
+### Card 11 — A person who taught you something
+
+> Describe a person who taught you something useful.
+> You should say:
+>   who this person is
+>   what they taught you
+>   when this happened
+> and explain why what they taught you was useful.
+
+_(source: HFF-authored.)_
+
+### Card 12 — A friend from your childhood
+
+> Describe a friend from your childhood.
+> You should say:
+>   who they were
+>   how you met
+>   what you used to do together
+> and explain how you feel about them now.
+
+_(source: HFF-authored.)_
+
+### Card 13 — A character from a book or film
+
+> Describe a character from a book or film you remember.
+> You should say:
+>   what the book or film is
+>   who the character is
+>   what kind of personality they have
+> and explain why you remember this character.
+
+_(source: HFF-authored.)_
+
+### Card 14 — A colleague you work well with
+
+> Describe a colleague you work well with.
+> You should say:
+>   who they are
+>   what they do
+>   how long you have worked together
+> and explain why you work well with them.
+
+_(source: HFF-authored.)_
+
+### Card 15 — A person you contact often
+
+> Describe a person you contact often by phone or message.
+> You should say:
+>   who they are
+>   how you usually contact them
+>   what you usually talk about
+> and explain why you stay in touch.
+
+_(source: HFF-authored.)_
+
+---
+
+## Place frame (cards 16–30)
+
+### Card 16 — A place you like to visit in your free time
+
+> Describe a place you like to visit in your free time.
+> You should say:
+>   where it is
+>   how often you go there
+>   what you do there
+> and explain why you enjoy spending time there.
+
+_(source: HFF-authored.)_
+
+### Card 17 — A beautiful natural place
+
+> Describe a beautiful natural place you have visited.
+> You should say:
+>   where it is
+>   when you went there
+>   what you saw or did
+> and explain what made it beautiful.
+
+_(source: HFF-authored; mirrors Cambridge IELTS place-topic frames.)_
+
+### Card 18 — A city or town you would like to visit
+
+> Describe a city or town you would like to visit in the future.
+> You should say:
+>   where it is
+>   how you first heard about it
+>   what you would do there
+> and explain why you would like to visit.
+
+_(source: HFF-authored.)_
+
+### Card 19 — A restaurant you enjoyed
+
+> Describe a restaurant you enjoyed visiting.
+> You should say:
+>   where it is
+>   when you went there
+>   what kind of food it serves
+> and explain why you enjoyed it.
+
+_(source: HFF-authored.)_
+
+### Card 20 — A shop you visit often
+
+> Describe a shop you visit often.
+> You should say:
+>   what kind of shop it is
+>   where it is
+>   what you usually buy there
+> and explain why you keep going back.
+
+_(source: HFF-authored.)_
+
+### Card 21 — A library or quiet study place
+
+> Describe a library or quiet place where you have studied.
+> You should say:
+>   where it is
+>   how often you went there
+>   what it was like
+> and explain why it was a good place to study.
+
+_(source: HFF-authored.)_
+
+### Card 22 — A park you like
+
+> Describe a park you like to spend time in.
+> You should say:
+>   where it is
+>   when you usually go
+>   what you do there
+> and explain why you enjoy this park.
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 2 sample.)_
+
+### Card 23 — A place from your childhood
+
+> Describe a place from your childhood that you remember well.
+> You should say:
+>   where it was
+>   what it looked like
+>   what you used to do there
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+### Card 24 — A historic place you have visited
+
+> Describe a historic place you have visited.
+> You should say:
+>   where it is
+>   when you went
+>   what you learned about it
+> and explain why it was interesting.
+
+_(source: HFF-authored.)_
+
+### Card 25 — A place where many people gather
+
+> Describe a place in your town where many people gather.
+> You should say:
+>   where it is
+>   when people gather there
+>   what they usually do
+> and explain why this place is popular.
+
+_(source: HFF-authored.)_
+
+### Card 26 — A peaceful place you have been to
+
+> Describe a peaceful place you have been to.
+> You should say:
+>   where it is
+>   when you went there
+>   what made it peaceful
+> and explain how you felt while you were there.
+
+_(source: HFF-authored.)_
+
+### Card 27 — A foreign country you have visited
+
+> Describe a foreign country you have visited.
+> You should say:
+>   which country it was
+>   why you went
+>   what you saw or did there
+> and explain what you most remember about your visit.
+
+_(source: HFF-authored.)_
+
+### Card 28 — A building you like
+
+> Describe a building you find impressive.
+> You should say:
+>   where it is
+>   what it looks like
+>   what it is used for
+> and explain why you find it impressive.
+
+_(source: HFF-authored.)_
+
+### Card 29 — A place where you have studied
+
+> Describe a school or place where you have studied.
+> You should say:
+>   where it was
+>   when you studied there
+>   what it was like
+> and explain how you feel about your time there.
+
+_(source: HFF-authored.)_
+
+### Card 30 — A place that's important to your family
+
+> Describe a place that is important to your family.
+> You should say:
+>   where it is
+>   why it matters to your family
+>   how often you go there
+> and explain how you feel about this place.
+
+_(source: HFF-authored.)_
+
+---
+
+## Object frame (cards 31–45)
+
+### Card 31 — Something you own that's important to you
+
+> Describe something you own that is very important to you.
+> You should say:
+>   where you got it from
+>   how long you have had it
+>   what you use it for
+> and explain why it is important to you.
+
+_Rounding-off: Is it valuable in terms of money? Would it be easy to replace?_
+
+_(source: ielts.org official sample — `speaking-sample-tasks-2023.pdf`, p. 5.)_
+
+### Card 32 — A useful piece of technology you own
+
+> Describe a piece of technology you find useful.
+> You should say:
+>   what it is
+>   when you got it
+>   how often you use it
+> and explain why you find it useful.
+
+_(source: HFF-authored.)_
+
+### Card 33 — A gift you received
+
+> Describe a gift you received that you really liked.
+> You should say:
+>   what it was
+>   who gave it to you
+>   when you received it
+> and explain why you liked it.
+
+_(source: HFF-authored; mirrors Cambridge IELTS gift-topic frames.)_
+
+### Card 34 — A photograph you remember
+
+> Describe a photograph you remember well.
+> You should say:
+>   what is in the photograph
+>   when it was taken
+>   who took it
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+### Card 35 — A book that influenced you
+
+> Describe a book that has influenced you.
+> You should say:
+>   what the book is
+>   when you read it
+>   what it is about
+> and explain how it influenced you.
+
+_(source: HFF-authored.)_
+
+### Card 36 — A piece of clothing you like to wear
+
+> Describe a piece of clothing you like to wear.
+> You should say:
+>   what it is
+>   when you wear it
+>   where you got it
+> and explain why you like wearing it.
+
+_(source: HFF-authored.)_
+
+### Card 37 — A traditional item from your country
+
+> Describe a traditional item from your country.
+> You should say:
+>   what it is
+>   where it comes from
+>   what it is used for
+> and explain why it is considered traditional.
+
+_(source: HFF-authored.)_
+
+### Card 38 — Something expensive you bought
+
+> Describe something expensive that you bought recently.
+> You should say:
+>   what it was
+>   why you bought it
+>   how much you paid
+> and explain whether you think it was worth the money.
+
+_(source: HFF-authored.)_
+
+### Card 39 — Something you use every day
+
+> Describe something you use every day.
+> You should say:
+>   what it is
+>   how long you have had it
+>   what you use it for
+> and explain why it is so useful to you.
+
+_(source: HFF-authored.)_
+
+### Card 40 — A piece of furniture in your home
+
+> Describe a piece of furniture in your home that you like.
+> You should say:
+>   what it is
+>   where it is in your home
+>   how long you have had it
+> and explain why you like it.
+
+_(source: HFF-authored.)_
+
+### Card 41 — A piece of jewellery you wear
+
+> Describe a piece of jewellery that you wear.
+> You should say:
+>   what it is
+>   when you got it
+>   when you usually wear it
+> and explain why it is special to you.
+
+_(source: HFF-authored.)_
+
+### Card 42 — A handmade item you own
+
+> Describe a handmade item you own.
+> You should say:
+>   what it is
+>   who made it
+>   when you got it
+> and explain why this item matters to you.
+
+_(source: HFF-authored.)_
+
+### Card 43 — A toy from your childhood
+
+> Describe a toy you remember from your childhood.
+> You should say:
+>   what it was
+>   who gave it to you
+>   how you played with it
+> and explain why you remember this toy.
+
+_(source: HFF-authored.)_
+
+### Card 44 — A device you would like to own
+
+> Describe a device or piece of technology you would like to own.
+> You should say:
+>   what it is
+>   why you want it
+>   what you would use it for
+> and explain how it would change your daily life.
+
+_(source: HFF-authored.)_
+
+### Card 45 — A meal you like to cook
+
+> Describe a meal you like to cook.
+> You should say:
+>   what the meal is
+>   who taught you to cook it
+>   when you usually make it
+> and explain why you enjoy cooking and eating it.
+
+_(source: HFF-authored.)_
+
+---
+
+## Event frame (cards 46–60)
+
+### Card 46 — A celebration in your family
+
+> Describe a recent celebration in your family.
+> You should say:
+>   what was being celebrated
+>   when it happened
+>   who attended
+> and explain how you felt about it.
+
+_(source: HFF-authored.)_
+
+### Card 47 — A festival in your country
+
+> Describe a festival that is important in your country.
+> You should say:
+>   what the festival is
+>   when it is celebrated
+>   what people do during it
+> and explain why it is important.
+
+_(source: HFF-authored.)_
+
+### Card 48 — A wedding you have attended
+
+> Describe a wedding you have attended.
+> You should say:
+>   whose wedding it was
+>   when it happened
+>   what people did
+> and explain what you most remember about it.
+
+_(source: HFF-authored.)_
+
+### Card 49 — A sports event you have watched
+
+> Describe a sports event you have watched in person or on television.
+> You should say:
+>   what the event was
+>   when you watched it
+>   who you watched it with
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+### Card 50 — A concert or live performance
+
+> Describe a concert or live performance you have been to.
+> You should say:
+>   what kind of performance it was
+>   when you went
+>   who you went with
+> and explain why you enjoyed it (or did not).
+
+_(source: HFF-authored.)_
+
+### Card 51 — A public event in your town
+
+> Describe a public event that took place in your town.
+> You should say:
+>   what kind of event it was
+>   when it took place
+>   what people did there
+> and explain why it was a notable event.
+
+_(source: HFF-authored.)_
+
+### Card 52 — A traditional ceremony
+
+> Describe a traditional ceremony from your country.
+> You should say:
+>   what kind of ceremony it is
+>   when it usually takes place
+>   what happens during it
+> and explain why this ceremony is important.
+
+_(source: HFF-authored.)_
+
+### Card 53 — A meal that was special
+
+> Describe a meal that was special to you.
+> You should say:
+>   what the meal was
+>   when it took place
+>   who you shared it with
+> and explain what made it special.
+
+_(source: HFF-authored.)_
+
+### Card 54 — A birthday you remember
+
+> Describe a birthday you remember well.
+> You should say:
+>   whose birthday it was
+>   when it took place
+>   what happened
+> and explain why you remember this birthday.
+
+_(source: HFF-authored.)_
+
+### Card 55 — A meeting that was important
+
+> Describe a meeting that was important to you.
+> You should say:
+>   what the meeting was about
+>   who was there
+>   what was discussed
+> and explain why it was important.
+
+_(source: HFF-authored.)_
+
+### Card 56 — A trip you took recently
+
+> Describe a trip you have taken recently.
+> You should say:
+>   where you went
+>   why you went
+>   who you went with
+> and explain what you most enjoyed about the trip.
+
+_(source: HFF-authored.)_
+
+### Card 57 — An exhibition or museum you visited
+
+> Describe an exhibition or museum you have visited.
+> You should say:
+>   what kind of exhibition it was
+>   where it was
+>   what you saw
+> and explain why it was interesting.
+
+_(source: HFF-authored.)_
+
+### Card 58 — A school event you remember
+
+> Describe a school event you remember.
+> You should say:
+>   what kind of event it was
+>   when it happened
+>   what you did
+> and explain why this event stands out.
+
+_(source: HFF-authored.)_
+
+### Card 59 — A family gathering
+
+> Describe a family gathering you have attended.
+> You should say:
+>   what the occasion was
+>   who was there
+>   what you did
+> and explain how you felt about being there.
+
+_(source: HFF-authored.)_
+
+### Card 60 — A graduation you witnessed
+
+> Describe a graduation ceremony you have attended.
+> You should say:
+>   whose graduation it was
+>   where it took place
+>   what happened at the ceremony
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+---
+
+## Experience frame (cards 61–75)
+
+### Card 61 — A time you helped someone
+
+> Describe a time when you helped someone.
+> You should say:
+>   who you helped
+>   what they needed help with
+>   what you did
+> and explain how you felt about helping them.
+
+_(source: HFF-authored.)_
+
+### Card 62 — A time you were late
+
+> Describe a time when you were late for something important.
+> You should say:
+>   what you were late for
+>   why you were late
+>   what happened
+> and explain how you felt about being late.
+
+_(source: HFF-authored.)_
+
+### Card 63 — A journey you remember
+
+> Describe a journey you remember well.
+> You should say:
+>   where you were going
+>   how you travelled
+>   who was with you
+> and explain why you remember this journey.
+
+_(source: HFF-authored.)_
+
+### Card 64 — A time you learned something quickly
+
+> Describe a time when you learned something quickly.
+> You should say:
+>   what you learned
+>   how you learned it
+>   when this happened
+> and explain why you were able to learn it so quickly.
+
+_(source: HFF-authored.)_
+
+### Card 65 — A time you waited a long time
+
+> Describe a time when you had to wait a long time for something.
+> You should say:
+>   what you were waiting for
+>   how long you waited
+>   what you did during the wait
+> and explain how you felt about it.
+
+_(source: HFF-authored.)_
+
+### Card 66 — A time you changed your mind
+
+> Describe a time when you changed your mind about something.
+> You should say:
+>   what you originally thought
+>   why you changed your mind
+>   when this happened
+> and explain how you feel about the change now.
+
+_(source: HFF-authored.)_
+
+### Card 67 — An achievement you are proud of
+
+> Describe an achievement you are proud of.
+> You should say:
+>   what the achievement was
+>   how long it took
+>   how you achieved it
+> and explain why you are proud of it.
+
+_(source: HFF-authored.)_
+
+### Card 68 — A time you tried something new
+
+> Describe a time when you tried something new.
+> You should say:
+>   what you tried
+>   when you tried it
+>   why you wanted to try it
+> and explain how the experience went.
+
+_(source: HFF-authored.)_
+
+### Card 69 — A time you solved a problem
+
+> Describe a time when you solved a difficult problem.
+> You should say:
+>   what the problem was
+>   how you tried to solve it
+>   what the result was
+> and explain how you felt afterwards.
+
+_(source: HFF-authored.)_
+
+### Card 70 — A time you met someone new
+
+> Describe a time when you met someone new and got on well with them.
+> You should say:
+>   who you met
+>   when you met
+>   what you talked about
+> and explain why you got on well.
+
+_(source: HFF-authored.)_
+
+### Card 71 — A time you got lost
+
+> Describe a time when you got lost somewhere.
+> You should say:
+>   where you were
+>   what happened
+>   how you found your way again
+> and explain how you felt about getting lost.
+
+_(source: HFF-authored.)_
+
+### Card 72 — A time you saw something unusual
+
+> Describe a time when you saw something unusual.
+> You should say:
+>   what you saw
+>   when and where you saw it
+>   who was with you
+> and explain why it was unusual.
+
+_(source: HFF-authored.)_
+
+### Card 73 — A time you received good news
+
+> Describe a time when you received some good news.
+> You should say:
+>   what the news was
+>   how you heard it
+>   who you shared it with
+> and explain how the news made you feel.
+
+_(source: HFF-authored.)_
+
+### Card 74 — A time you taught someone
+
+> Describe a time when you taught someone something.
+> You should say:
+>   who you taught
+>   what you taught them
+>   how you taught them
+> and explain how you felt about teaching them.
+
+_(source: HFF-authored.)_
+
+### Card 75 — A challenge you overcame
+
+> Describe a challenge you have overcome.
+> You should say:
+>   what the challenge was
+>   when it happened
+>   how you dealt with it
+> and explain what you learned from overcoming it.
+
+_(source: HFF-authored.)_
+
+---
+
+## Activity frame (cards 76–88)
+
+### Card 76 — A sport you play or follow
+
+> Describe a sport you enjoy playing or watching.
+> You should say:
+>   what the sport is
+>   how often you play or watch it
+>   who you do this with
+> and explain why you enjoy this sport.
+
+_(source: HFF-authored.)_
+
+### Card 77 — A hobby you started recently
+
+> Describe a hobby you have started recently.
+> You should say:
+>   what the hobby is
+>   when you started it
+>   how often you do it
+> and explain why you decided to take it up.
+
+_(source: HFF-authored.)_
+
+### Card 78 — A skill you would like to learn
+
+> Describe a skill you would like to learn.
+> You should say:
+>   what the skill is
+>   why you want to learn it
+>   how you plan to learn it
+> and explain how this skill would be useful to you.
+
+_(source: HFF-authored.)_
+
+### Card 79 — An outdoor activity you enjoy
+
+> Describe an outdoor activity you enjoy.
+> You should say:
+>   what the activity is
+>   where you do it
+>   how often you do it
+> and explain why you enjoy this activity.
+
+_(source: HFF-authored.)_
+
+### Card 80 — An indoor activity for a rainy day
+
+> Describe an activity you enjoy doing indoors when the weather is bad.
+> You should say:
+>   what the activity is
+>   when you usually do it
+>   what you need for it
+> and explain why you enjoy doing it on rainy days.
+
+_(source: HFF-authored.)_
+
+### Card 81 — Something you do with your family
+
+> Describe something you regularly do with your family.
+> You should say:
+>   what you do
+>   how often you do it
+>   who is involved
+> and explain why this activity is meaningful to your family.
+
+_(source: HFF-authored.)_
+
+### Card 82 — A game you played as a child
+
+> Describe a game you used to play as a child.
+> You should say:
+>   what the game was
+>   who you played with
+>   when you played it
+> and explain why you enjoyed this game.
+
+_(source: HFF-authored.)_
+
+### Card 83 — A film or TV programme you enjoyed
+
+> Describe a film or TV programme you have recently enjoyed.
+> You should say:
+>   what it was
+>   when you watched it
+>   what it was about
+> and explain why you enjoyed it.
+
+_(source: HFF-authored.)_
+
+### Card 84 — A piece of music you like
+
+> Describe a piece of music you like.
+> You should say:
+>   what it is
+>   when you first heard it
+>   when you usually listen to it
+> and explain why you like this piece of music.
+
+_(source: HFF-authored.)_
+
+### Card 85 — A holiday tradition you keep
+
+> Describe a holiday or seasonal tradition that you keep.
+> You should say:
+>   what the tradition is
+>   when you do it
+>   who you do it with
+> and explain why you keep this tradition.
+
+_(source: HFF-authored.)_
+
+### Card 86 — Something you do to relax
+
+> Describe something you do to relax.
+> You should say:
+>   what it is
+>   how often you do it
+>   when you usually do it
+> and explain why it helps you relax.
+
+_(source: HFF-authored.)_
+
+### Card 87 — An activity you do for exercise
+
+> Describe an activity you do to keep fit.
+> You should say:
+>   what the activity is
+>   how often you do it
+>   when you started doing it
+> and explain why this activity is good for your health.
+
+_(source: HFF-authored.)_
+
+### Card 88 — A way you have helped your community
+
+> Describe a way you have helped your community or local area.
+> You should say:
+>   what you did
+>   when you did it
+>   who else was involved
+> and explain why this kind of activity is important.
+
+_(source: HFF-authored.)_
+
+---
+
+## Coaching cheat sheet — Part 2 monologue structure
+
+| Bullet position | Time | Content type | Common failure | Tutor cue |
+|----------------|------|--------------|----------------|-----------|
+| 1 | ~20 sec | Identification / context | Skipped — candidate launches into the "explain" bullet | "Open with a single sentence that names the [person/place/object]." |
+| 2 | ~30 sec | Concrete detail | One word answer | "Add a sentence of detail — what it looked like / when it was." |
+| 3 | ~30 sec | Further concrete detail | Same content as bullet 2 | "Move on to a new piece of information." |
+| "and explain ..." | ~40–60 sec | Reasoning / significance | Treated as another factual bullet | "This is the bullet that gets you to Band 7. Use 'because', 'the reason is', 'what I value about ...'." |
+| Buffer | ~10 sec | Optional reflection | Cuts short at 1:20 | "Add one closing sentence: how it has changed you, or why it still matters now." |
+
+Total target: 1:50–2:00. The examiner will stop the candidate at 2:00.
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 5–6.
+- ielts.org — "Speaking Part 2 sample task". https://www.ielts.org (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests Part 2". https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking Part 2 sample". https://ielts.idp.com (accessed 2026-05-08).
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking section.
+- Cambridge IELTS volumes 1–19 — published past papers (referenced as a pattern source; not reproduced verbatim).
+- All HFF-authored cards above are written in the style of the published Part 2 frames and are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-question-bank-part3.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-question-bank-part3.md
@@ -1,0 +1,855 @@
+# IELTS Speaking Question Bank — Part 3
+
+Source: HFF-authored discussion question sets in the style of published IELTS Part 3 frames. Question patterns and themes are modelled on `speaking-sample-tasks-2023.pdf`, takeielts.britishcouncil.org Part 3 samples, ielts.idp.com Part 3 samples, and Cambridge IELTS volumes 1–19.
+
+This bank contains 64 discussion question sets, each with 4–6 abstract questions, organised by the 13 themes identified in `ielts-speaking-question-types-guide.md`. Sets follow the seven Part 3 patterns: opinion, advantages/disadvantages, comparison, hypothetical, prediction, causes-and-effects, and problem-solution. Sets are HFF-authored to mirror the style and difficulty of published Cambridge tasks without reproducing copyrighted exam content.
+
+**Format note:** Each set is introduced by a signposting line ("Let's consider ...") and follows the typical Part 3 progression — the examiner moves from concrete probes to abstract or future-oriented ones over 4–6 questions.
+
+**Coaching note:** Part 3 is where Band 6 candidates plateau. The discriminator is the candidate's ability to (1) generalise beyond personal experience, (2) hedge with "tend to", "in many cases", "to some extent", (3) speculate using conditional structures, (4) concede a counter-argument before reasserting.
+
+---
+
+## Theme: Society and generations
+
+### Set 1 — Possessions and status (linked to Part 2 "Object" cards)
+
+_Let's consider how people's values have changed._
+
+1. What kind of things give status to people in your country?
+2. Have things changed since your parents' time?
+3. Do you think material possessions are more important to people now than they used to be?
+4. Why do some people place a high value on owning expensive things?
+5. Will the things that give status change in the future, do you think?
+
+_(source: HFF-authored, modelled on `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+### Set 2 — Generational differences
+
+_Let's discuss differences between generations._
+
+1. In what ways are young people in your country different from older generations?
+2. Why do you think those differences exist?
+3. Do older and younger people generally get on well in your culture?
+4. What can each generation learn from the other?
+5. Do you think the gap between generations is widening or narrowing?
+
+_(source: HFF-authored.)_
+
+### Set 3 — Changing lifestyles
+
+_Let's talk about how lifestyles have changed._
+
+1. How has daily life changed in your country in the last twenty years?
+2. Are people busier now than they used to be?
+3. What are the benefits of a slower pace of life?
+4. Why do people often say they don't have enough time?
+5. Will the pace of life continue to speed up, in your opinion?
+
+_(source: HFF-authored.)_
+
+### Set 4 — Tradition and modern life
+
+_Let's consider traditions._
+
+1. How important are traditions in your country?
+2. Are some traditions disappearing in modern life?
+3. Why do some people want to preserve old traditions?
+4. Are there any traditions that should change?
+5. What new traditions have appeared in recent years?
+
+_(source: HFF-authored.)_
+
+### Set 5 — Community and individualism
+
+_Let's talk about community._
+
+1. Do people in your country feel a strong sense of community?
+2. Has the importance of community changed over the years?
+3. What can be done to bring communities closer together?
+4. Are there any disadvantages to a strong community?
+5. Do you think people prefer to focus on themselves or their community?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Technology
+
+### Set 6 — Communication technology (linked to Part 2 "Person you contact" / "Device" cards)
+
+_Let's discuss how technology has changed communication._
+
+1. How has the way people communicate changed in recent years?
+2. Are face-to-face conversations still important in the age of messaging?
+3. What are the disadvantages of communicating mostly through technology?
+4. Do you think children today communicate differently from their parents?
+5. How might communication change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 7 — Information and the internet
+
+_Let's consider information access._
+
+1. Do people have more or less reliable information than they used to?
+2. How can people decide what information to trust?
+3. Has the internet changed the way people learn?
+4. What are the dangers of misinformation online?
+5. Should the spread of false information be regulated?
+
+_(source: HFF-authored.)_
+
+### Set 8 — Automation and work
+
+_Let's talk about machines and work._
+
+1. What kinds of work are now being done by machines that used to be done by people?
+2. What are the benefits of automation?
+3. What jobs do you think will disappear in the future?
+4. Should governments help workers whose jobs are replaced by machines?
+5. Are there any jobs that should never be done by machines?
+
+_(source: HFF-authored.)_
+
+### Set 9 — Children and screens
+
+_Let's discuss children's use of screens._
+
+1. How much time do children spend using screens these days?
+2. What effect does screen time have on children?
+3. At what age do you think children should be allowed to use the internet?
+4. Whose responsibility is it to manage children's screen time?
+5. Will today's children use technology differently when they grow up?
+
+_(source: HFF-authored.)_
+
+### Set 10 — Social media
+
+_Let's talk about social media._
+
+1. Why do people use social media?
+2. What are the advantages and disadvantages of social media for young people?
+3. Has social media changed the way people form friendships?
+4. Should social media companies be more strictly regulated?
+5. Is it possible for people to live without social media now?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Environment
+
+### Set 11 — Natural environment (linked to Part 2 "Beautiful natural place")
+
+_Let's consider the natural environment._
+
+1. How important is it to protect the natural environment?
+2. What environmental problems is your country facing?
+3. Whose responsibility is it to look after the environment?
+4. Should individuals or governments do more to protect nature?
+5. Will future generations enjoy the same natural environment as we do?
+
+_(source: HFF-authored.)_
+
+### Set 12 — Climate
+
+_Let's discuss climate._
+
+1. Has the climate in your country changed in recent years?
+2. How does climate change affect daily life?
+3. What can ordinary people do about climate change?
+4. Should countries that produce more pollution do more to fix the problem?
+5. Will climate change get better or worse in the future?
+
+_(source: HFF-authored.)_
+
+### Set 13 — Urban living
+
+_Let's talk about cities._
+
+1. What are the advantages of living in a big city?
+2. What problems do big cities often face?
+3. How could cities be made more pleasant places to live?
+4. Will cities keep growing in the future?
+5. Should governments encourage people to move to smaller towns?
+
+_(source: HFF-authored.)_
+
+### Set 14 — Public spaces (linked to Part 2 "Park" / "Place where many people gather")
+
+_Let's consider public spaces._
+
+1. How important are public spaces like parks in a city?
+2. Are there enough public spaces where you live?
+3. What kinds of public spaces do people use most?
+4. Should public spaces be free for everyone to use?
+5. Will the way people use public spaces change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 15 — Animals and wildlife (linked to Part 2 "Pets" / "Animals")
+
+_Let's talk about animals._
+
+1. How has people's attitude to animals changed in recent years?
+2. Should wild animals be kept in zoos?
+3. What can be done to protect endangered species?
+4. Why do some people keep unusual animals as pets?
+5. Should there be stricter laws about how people treat animals?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Education
+
+### Set 16 — Schools (linked to Part 2 "School" / "Teacher" cards)
+
+_Let's consider schools._
+
+1. What makes a good school?
+2. Are schools in your country mostly the same or quite different from each other?
+3. Should children all learn the same subjects?
+4. How has school education changed since you were a child?
+5. What changes would you like to see in schools in the future?
+
+_(source: HFF-authored.)_
+
+### Set 17 — Teachers
+
+_Let's discuss teachers._
+
+1. What qualities make a good teacher?
+2. Is teaching a respected profession in your country?
+3. What's the most important thing teachers do for their students?
+4. Should teachers be paid more than they are now?
+5. Will the role of the teacher change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 18 — Learning approaches (linked to Part 2 "A skill you would like to learn")
+
+_Let's consider how people learn._
+
+1. Do you think children learn best in a classroom or through their own experience?
+2. What's the best way to learn a new skill?
+3. Is it ever too late to learn something new?
+4. How has the way people learn changed because of technology?
+5. Will traditional classrooms still exist in the future?
+
+_(source: HFF-authored.)_
+
+### Set 19 — Higher education
+
+_Let's talk about university._
+
+1. Is going to university becoming more or less important in your country?
+2. What are the benefits of studying at university?
+3. Are there any drawbacks to spending years at university?
+4. Should university education be free?
+5. What kinds of careers will need a university degree in the future?
+
+_(source: HFF-authored.)_
+
+### Set 20 — Lifelong learning
+
+_Let's consider learning as adults._
+
+1. Why do some adults choose to keep studying after they have left school or university?
+2. What are the benefits of learning new things later in life?
+3. What can stop adults from learning new skills?
+4. Do you think governments should support adult education?
+5. Will lifelong learning become more common in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Work
+
+### Set 21 — Job satisfaction (linked to Part 2 "Colleague" / "Work")
+
+_Let's talk about job satisfaction._
+
+1. What makes a job satisfying?
+2. Is salary the most important thing about a job?
+3. Why do some people change jobs often while others stay in one job for a long time?
+4. Do people in your country talk about their work much?
+5. Will the things that make a job satisfying change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 22 — Work-life balance
+
+_Let's consider work-life balance._
+
+1. What does work-life balance mean to you?
+2. Do people in your country generally have a good balance between work and personal life?
+3. What can employers do to help people maintain this balance?
+4. How has remote working changed work-life balance?
+5. Will people work fewer hours in the future?
+
+_(source: HFF-authored.)_
+
+### Set 23 — Remote working
+
+_Let's talk about working from home._
+
+1. Has remote working become common in your country?
+2. What are the advantages of working from home?
+3. Are there any disadvantages to remote working?
+4. Should employers let workers choose where they work?
+5. Will most office work be done remotely in the future?
+
+_(source: HFF-authored.)_
+
+### Set 24 — Career change
+
+_Let's consider changing careers._
+
+1. Is it common for people in your country to change career?
+2. Why might someone decide to change career mid-life?
+3. What difficulties does someone face when changing career?
+4. Should employers encourage workers to develop new skills?
+5. Will career change become more or less common in the future?
+
+_(source: HFF-authored.)_
+
+### Set 25 — Volunteering and community work (linked to Part 2 "Helping the community")
+
+_Let's discuss volunteering._
+
+1. Why do people choose to volunteer?
+2. What are the benefits of volunteering for the volunteer themselves?
+3. Should schools encourage students to do volunteer work?
+4. Are there situations where paid workers should be used instead of volunteers?
+5. Is volunteering more or less common than it used to be?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Media
+
+### Set 26 — Advertising (linked to `speaking-sample-tasks-2023.pdf` Part 3 frame)
+
+_Let's talk about the role of advertising._
+
+1. Do you think advertising influences what people buy?
+2. Where do most advertisements appear these days?
+3. Should advertising directed at children be regulated?
+4. Are there any kinds of products that should not be advertised?
+5. Will the way companies advertise change in the future?
+
+_(source: HFF-authored, modelled on `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+### Set 27 — News and journalism
+
+_Let's consider the news._
+
+1. Do people in your country trust the news?
+2. How has the way people get the news changed?
+3. Are there any disadvantages to reading news only online?
+4. Should news organisations be regulated by the government?
+5. Will printed newspapers still exist in twenty years' time?
+
+_(source: HFF-authored.)_
+
+### Set 28 — Films and television (linked to Part 2 "Film or TV programme")
+
+_Let's discuss films and TV._
+
+1. What kinds of films and TV programmes are popular in your country?
+2. Do films from your country ever become popular abroad?
+3. How has the way people watch films and TV changed?
+4. Are streaming services replacing cinema?
+5. Should governments support local film-making?
+
+_(source: HFF-authored.)_
+
+### Set 29 — Books and reading (linked to Part 2 "Book that influenced you")
+
+_Let's consider reading habits._
+
+1. Do people in your country read as much as they used to?
+2. What are the benefits of reading regularly?
+3. Are some kinds of books more valuable than others?
+4. How can children be encouraged to read?
+5. Will printed books survive in the digital age?
+
+_(source: HFF-authored.)_
+
+### Set 30 — Privacy and the media
+
+_Let's discuss privacy._
+
+1. Do public figures have a right to privacy?
+2. How much information should the media publish about famous people?
+3. Has social media changed what counts as private life?
+4. Should there be stronger laws to protect privacy online?
+5. Will privacy be possible in the future, in your opinion?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Culture
+
+### Set 31 — Festivals (linked to Part 2 "Festival" cards)
+
+_Let's talk about festivals._
+
+1. Why are festivals important in many cultures?
+2. Have festivals in your country changed in recent years?
+3. Are some traditional festivals losing their meaning?
+4. Should new festivals be created for modern life?
+5. Will festivals be celebrated differently in the future?
+
+_(source: HFF-authored.)_
+
+### Set 32 — Art and creativity (linked to Part 2 "Art")
+
+_Let's consider art._
+
+1. What role does art play in modern society?
+2. Should art be taught in schools?
+3. How has technology changed the way art is made and shared?
+4. Is some art more valuable than other art?
+5. Will the kinds of art people enjoy change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 33 — Music (linked to Part 2 "Piece of music" / "Concert")
+
+_Let's discuss music._
+
+1. Why is music such an important part of human life?
+2. Does music affect people's mood?
+3. Should children be encouraged to learn an instrument?
+4. How has the way people listen to music changed?
+5. Will live music remain popular in the future?
+
+_(source: HFF-authored.)_
+
+### Set 34 — The role of the past
+
+_Let's talk about history._
+
+1. Why is it important to remember the past?
+2. Should children learn the history of their country at school?
+3. Are there any aspects of the past it might be better to forget?
+4. How can a country preserve its history for future generations?
+5. Do you think people are interested in history nowadays?
+
+_(source: HFF-authored.)_
+
+### Set 35 — Cultural exchange and travel (linked to Part 2 "Foreign country")
+
+_Let's consider cultural exchange._
+
+1. How does international travel affect cultural exchange?
+2. Are people more interested in other cultures now than they used to be?
+3. Are there any disadvantages to mixing cultures?
+4. Should tourists try to learn about local culture before visiting a country?
+5. Will cultures become more similar in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Family
+
+### Set 36 — Family relationships (linked to Part 2 "Family member you admire")
+
+_Let's discuss families._
+
+1. Have family relationships changed in your country in recent years?
+2. Do families in your country usually live close together?
+3. What are the advantages of growing up in a large family?
+4. Is it harder to keep families close in modern life?
+5. Will the structure of families continue to change?
+
+_(source: HFF-authored.)_
+
+### Set 37 — Raising children
+
+_Let's consider how children are raised._
+
+1. Are parents stricter or more relaxed than they used to be?
+2. What's the most important thing parents can teach their children?
+3. Should both parents share child-care equally?
+4. Do parents in your country spend enough time with their children?
+5. How might child-raising change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 38 — Caring for older people
+
+_Let's discuss caring for older relatives._
+
+1. Whose responsibility is it to care for elderly relatives?
+2. How are older people generally treated in your country?
+3. Are there enough services to support older people?
+4. Should governments do more for older citizens?
+5. How will the care of older people change as populations age?
+
+_(source: HFF-authored.)_
+
+### Set 39 — Childhood (linked to Part 2 "Childhood")
+
+_Let's talk about childhood._
+
+1. Has childhood changed since you were young?
+2. Do children today have more freedom than children did in the past?
+3. What experiences are important for a happy childhood?
+4. Should children have more or less responsibility?
+5. Are children today more aware of the wider world than children used to be?
+
+_(source: HFF-authored.)_
+
+### Set 40 — Family meals (linked to Part 2 "Special meal")
+
+_Let's discuss eating together._
+
+1. Do families in your country usually eat meals together?
+2. Why do some families not eat together?
+3. What are the benefits of sharing meals as a family?
+4. Has the way families eat changed in recent decades?
+5. Will the family meal still exist in twenty years' time?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Health
+
+### Set 41 — Healthy lifestyles (linked to Part 2 "Activity for exercise")
+
+_Let's consider health._
+
+1. Are people in your country generally healthy?
+2. What can people do to stay healthy?
+3. Are people more health-conscious than they used to be?
+4. Why do some people find it hard to live a healthy lifestyle?
+5. Will people be healthier in the future?
+
+_(source: HFF-authored.)_
+
+### Set 42 — Sport and fitness (linked to Part 2 "Sport you enjoy")
+
+_Let's discuss sport._
+
+1. Why is sport important in many countries?
+2. Do you think children should be made to play sports at school?
+3. Are professional athletes paid too much?
+4. Do international sporting events bring countries together?
+5. Will the popularity of sport change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 43 — Mental health
+
+_Let's talk about mental health._
+
+1. Are people in your country comfortable talking about mental health?
+2. What kinds of pressures affect people's mental health today?
+3. What can workplaces do to support employees' mental health?
+4. Should mental health be taught in schools?
+5. Will attitudes to mental health change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 44 — Public health and government
+
+_Let's consider the government's role in health._
+
+1. What is the government's responsibility for people's health?
+2. Should healthcare be free for everyone?
+3. Should governments tax unhealthy products like sugary drinks?
+4. How can governments encourage people to live more healthily?
+5. Will public health continue to improve in the future?
+
+_(source: HFF-authored.)_
+
+### Set 45 — Sleep and rest (linked to Part 1 "Sleep" frame)
+
+_Let's discuss sleep._
+
+1. Why do many adults not get enough sleep?
+2. Has the way people sleep changed because of modern life?
+3. What are the consequences of poor sleep?
+4. Should employers care about how well their staff sleep?
+5. Will people sleep more or less in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Money
+
+### Set 46 — Money and happiness (linked to Part 2 "Expensive thing you bought")
+
+_Let's consider the role of money._
+
+1. Does money make people happy?
+2. Why do some people place a high value on owning expensive things?
+3. Is it better to spend money on things or experiences?
+4. Are people in your country more or less concerned with money than in the past?
+5. Will money be as important in the future as it is now?
+
+_(source: HFF-authored.)_
+
+### Set 47 — Saving and spending
+
+_Let's discuss saving and spending._
+
+1. Are people in your country generally good at saving money?
+2. Should children be taught about money at school?
+3. What's the best way to teach a child about saving?
+4. Why do some people find it hard to save?
+5. Will the way people save change as cash disappears?
+
+_(source: HFF-authored.)_
+
+### Set 48 — Cashless society
+
+_Let's consider digital payments._
+
+1. How has the way people pay for things changed in recent years?
+2. What are the advantages of a cashless society?
+3. Are there any disadvantages to going cashless?
+4. Should cash be kept available even as digital payments grow?
+5. Will physical money disappear completely?
+
+_(source: HFF-authored.)_
+
+### Set 49 — Inequality
+
+_Let's talk about wealth inequality._
+
+1. Is wealth distributed fairly in your country?
+2. What problems can large wealth gaps cause?
+3. Should governments do more to reduce inequality?
+4. Why do some countries have less inequality than others?
+5. Will inequality grow or shrink in the future?
+
+_(source: HFF-authored.)_
+
+### Set 50 — Charitable giving
+
+_Let's consider donating to charity._
+
+1. Why do people give to charity?
+2. Should people be encouraged to give a fixed share of their income to charity?
+3. What kinds of causes do people in your country most often support?
+4. Is it better to donate money or time?
+5. Will charitable giving become more common in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Future
+
+### Set 51 — Predictions about daily life
+
+_Let's discuss the future._
+
+1. How do you think daily life will change in the next twenty years?
+2. What aspects of life today will probably stay the same?
+3. Are people generally optimistic or pessimistic about the future?
+4. What's the biggest change you would like to see?
+5. Should people make long-term plans, given how uncertain the future is?
+
+_(source: HFF-authored.)_
+
+### Set 52 — What will be lost
+
+_Let's consider what may disappear._
+
+1. What things from today's world may not exist in the future?
+2. Why do some things disappear over time?
+3. Should we try to preserve traditional ways of doing things?
+4. Are there any losses we should accept?
+5. What kinds of jobs do you think will disappear soon?
+
+_(source: HFF-authored.)_
+
+### Set 53 — Future of work
+
+_Let's talk about future careers._
+
+1. What kinds of jobs will be most in demand in the future?
+2. How can young people prepare for jobs that don't exist yet?
+3. Will most people still have one main career, or many?
+4. Should schools teach skills for jobs that may exist in twenty years' time?
+5. How will people earn a living if machines do most of the work?
+
+_(source: HFF-authored.)_
+
+### Set 54 — Cities of the future
+
+_Let's consider future cities._
+
+1. What will cities look like in fifty years' time?
+2. How can cities be made more sustainable?
+3. Will most people still live in cities in the future?
+4. Should governments plan cities differently than they do now?
+5. What problems will future cities have to solve?
+
+_(source: HFF-authored.)_
+
+### Set 55 — Predictions about technology
+
+_Let's discuss future technology._
+
+1. Which new technologies are you most looking forward to?
+2. Are there any technologies you would prefer never to see?
+3. How will artificial intelligence affect daily life?
+4. Should governments slow down the development of certain technologies?
+5. Will technology make life easier in the future, do you think?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Government
+
+### Set 56 — Public services
+
+_Let's talk about public services._
+
+1. What are the most important services governments provide?
+2. Are public services well-run in your country?
+3. Should some public services be run by private companies?
+4. How can governments make sure public services reach everyone?
+5. Will the role of the government in providing services grow or shrink?
+
+_(source: HFF-authored.)_
+
+### Set 57 — Citizens' duties
+
+_Let's consider what citizens owe their country._
+
+1. What responsibilities do citizens have to their country?
+2. Should people be required to vote in elections?
+3. Should young people do a year of community service?
+4. Is paying taxes enough, or do citizens owe more?
+5. How can governments encourage active citizenship?
+
+_(source: HFF-authored.)_
+
+### Set 58 — Laws and rules
+
+_Let's discuss laws._
+
+1. Why do societies have laws?
+2. Are laws in your country generally fair?
+3. Should some laws be the same in every country?
+4. What happens when people stop following the rules?
+5. How should laws change as society changes?
+
+_(source: HFF-authored.)_
+
+### Set 59 — Punishment and rehabilitation
+
+_Let's consider how societies deal with crime._
+
+1. What's the main purpose of punishing people who break the law?
+2. Should rehabilitation be more important than punishment?
+3. Are prisons effective at reducing crime?
+4. What other ways are there to deal with people who break the law?
+5. Will attitudes to punishment change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 60 — Government and the environment
+
+_Let's discuss government action on the environment._
+
+1. How much can a government do to protect the environment?
+2. Should governments place strict limits on pollution?
+3. Should governments cooperate internationally on environmental issues?
+4. Are environmental problems the responsibility of citizens or governments?
+5. Will environmental policy become more or less important in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Globalisation
+
+### Set 61 — International travel (linked to Part 2 "Foreign country" / "Trip you took")
+
+_Let's consider international travel._
+
+1. Why do so many people travel abroad these days?
+2. Has international travel become too easy?
+3. What are the cultural benefits of travel?
+4. Should tourists do more to respect the places they visit?
+5. Will people travel more or less in the future?
+
+_(source: HFF-authored.)_
+
+### Set 62 — World languages (linked to Part 1 "Languages")
+
+_Let's discuss languages._
+
+1. Why is English so widely spoken around the world?
+2. Should children learn more than one foreign language at school?
+3. What can be done to keep small languages alive?
+4. Are some languages disappearing? Why?
+5. Will English remain the most widely-used international language?
+
+_(source: HFF-authored.)_
+
+### Set 63 — Cultural similarities
+
+_Let's consider how cultures are becoming more alike._
+
+1. Are cultures around the world becoming more similar?
+2. Why is this happening?
+3. Are there any benefits to a more global culture?
+4. What might be lost if cultures become too similar?
+5. Should countries try to protect their own cultural identity?
+
+_(source: HFF-authored.)_
+
+### Set 64 — International cooperation
+
+_Let's discuss international cooperation._
+
+1. In what areas do countries most need to work together?
+2. Why is international cooperation often difficult?
+3. Should richer countries help poorer countries more?
+4. Are international organisations effective?
+5. Will countries cooperate more or less in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Coaching cheat sheet — Part 3 lifters
+
+| Move | What it sounds like | Why it lifts the band |
+|------|--------------------|-----------------------|
+| Generalise | "People in general tend to ..." / "In most countries ..." | Required to escape personal-anecdote cap (FC + LR) |
+| Hedge | "I would say ...", "to some extent ...", "in many cases ..." | Required at Band 7+ (LR — speaker's attitude) |
+| Concede + reassert | "It's true that ..., but on balance ..." | Required at Band 7+ (FC — coherence under complexity) |
+| Speculate (2nd conditional) | "If governments were to ..., people would ..." | Required at Band 7+ (GRA — complex structures) |
+| Speculate (3rd conditional) | "If they had done ..., we would have ..." | Band 8+ marker (GRA) |
+| Abstract noun phrase | "the role of ...", "the impact of ...", "the extent to which ..." | Required at Band 7+ (LR — less common items) |
+| Compare across time | "Whereas in the past ..., today ..." | Required at Band 7+ (FC — discourse markers) |
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 6–7.
+- ielts.org — "Speaking Part 3 sample task". https://www.ielts.org (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests Part 3". https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking Part 3 sample". https://ielts.idp.com (accessed 2026-05-08).
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking section.
+- Cambridge IELTS volumes 1–19 — published past papers (referenced as a pattern source; not reproduced verbatim).
+- All HFF-authored question sets above are written in the style of the published Part 3 frames and are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-question-types-guide.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-question-types-guide.md
@@ -1,0 +1,235 @@
+# IELTS Speaking Question Types Guide
+
+Source: ielts.org and takeielts.britishcouncil.org sample tasks; Cambridge IELTS volumes 1–19 published past papers; `speaking-sample-tasks-2023.pdf`.
+
+This document defines the recognised question types in each Part of the Speaking test. The taxonomy is descriptive rather than prescriptive — IELTS does not publish a closed list of question types — but the categories below recur across published Cambridge volumes and official sample materials and are accepted in the IELTS preparation literature (British Council, IDP, Cambridge teacher handbooks). Tutors should recognise each type at hearing and coach Part-appropriate response strategies.
+
+---
+
+## Part 1 — Familiar topic frames
+
+Part 1 questions cluster into "topic frames": short sets of four to six questions on a single familiar topic. The examiner introduces each frame with a signposting line ("Let's talk about ..."). The official sample test uses two frames: home town/village and accommodation _(source: `speaking-sample-tasks-2023.pdf`, p. 3)_.
+
+### Topic categories observed in published Part 1 frames
+
+| Cluster | Example topics |
+|---------|---------------|
+| Personal background | Home town, accommodation, family, friends, work, study |
+| Daily life | Routine, weekends, free time, sleep, time management |
+| Possessions and consumption | Clothes, shopping, food, cooking, gifts |
+| Mobility | Travel, holidays, transport, walking, cycling |
+| Culture and leisure | Music, films, books, art, photographs, museums |
+| Technology | Mobile phones, computers, the internet, social media |
+| Environment and surroundings | Weather, seasons, parks, gardens, animals, pets |
+| Communication | Letters, email, phone calls, languages |
+| Time and memory | Childhood, school days, dreams, the past |
+
+The list above is observed across Cambridge IELTS books 1–19; it is not an official taxonomy. _(source: published Cambridge IELTS volumes; takeielts.britishcouncil.org Part 1 sample list, accessed 2026-05-08.)_
+
+### Question-form patterns within a Part 1 frame
+
+Within a single topic frame, questions follow recognisable forms:
+
+| Form | Example stem |
+|------|-------------|
+| Identity / categorisation | "What kind of place is it?" |
+| Description | "Tell me about ..." |
+| Preference | "What do you like / dislike about ...?" |
+| Frequency | "How often do you ...?" |
+| Past experience | "When did you last ...?" |
+| Future / hypothetical | "What would you most like to ...?" |
+| Reason | "Why ...?" / "Why don't you ...?" |
+| Comparison | "Has it changed since ...?" |
+
+_(source: `speaking-sample-tasks-2023.pdf`, p. 3; takeielts.britishcouncil.org Part 1 sample.)_
+
+### Coaching note
+
+Part 1 answers should typically be three to four sentences. A one-word or one-sentence answer is the most common Band 5 fluency error. Extension techniques: reason → example → personal touch.
+
+---
+
+## Part 2 — Cue card frames
+
+Part 2 cue cards always begin "Describe ..." and follow a fixed four-bullet template (three concrete bullets + one "and explain ..." bullet). Across published Cambridge volumes, every cue card maps to one of six topical frames.
+
+### The six Part 2 frames
+
+| Frame | What the candidate must describe | Typical bullets |
+|-------|----------------------------------|----------------|
+| Person | A specific real or imagined person | Who they are, how you know them, what they are like, why important |
+| Place | A specific location or setting | Where it is, when you went, what you did, why memorable |
+| Object | A possession, gift, or physical item | Where you got it, how long you have had it, what you use it for, why important |
+| Event | A one-off occasion or ceremony | What it was, when it happened, who was there, why memorable |
+| Experience | An activity or situation lived through | What happened, when, how you felt, why significant |
+| Activity | A regular activity, hobby, or skill | What it is, how often, who you do it with, why you enjoy it |
+
+The "Object" frame is exemplified in the official sample: "Describe something you own which is very important to you" _(source: `speaking-sample-tasks-2023.pdf`, p. 5)_.
+
+### Sub-frames observed within each frame
+
+Across published Cambridge IELTS volumes 1–19, recurring sub-frames include:
+
+- **Person:** family member, friend, teacher, public figure, older person, helpful person, talented person, child you know, stranger who helped you.
+- **Place:** city/town visited, beautiful natural place, restaurant, shop, library, place you would like to visit, quiet place, place from childhood, public place where many people gather.
+- **Object:** gift, useful gadget, piece of clothing, photograph, book, traditional item, expensive purchase, item you use daily.
+- **Event:** wedding/celebration, family gathering, festival, sports event, exhibition, concert, special meal, public event you attended.
+- **Experience:** journey, time you helped someone, time you were late, time you learned something quickly, time you waited a long time, time you changed your mind, achievement you are proud of.
+- **Activity:** sport you play, hobby you started recently, skill you would like to learn, activity you do with your family, outdoor activity, indoor activity for a rainy day.
+
+_(source: paraphrased pattern observation across Cambridge IELTS 1–19, Tests 1–4 of each volume; supplemented by takeielts.britishcouncil.org and ielts.idp.com Part 2 sample lists, accessed 2026-05-08.)_
+
+### Cue card template (verbatim form)
+
+> Describe [a / an / something / a person / a place / a time when ...].
+> You should say:
+>   [bullet 1]
+>   [bullet 2]
+>   [bullet 3]
+> and explain [why / how / what ...].
+
+The "and explain" bullet is substantive — examiners look for it to be answered with reasoning, not just a fact. _(source: `ielts-guide-for-teachers.pdf`; `speaking-sample-tasks-2023.pdf`, p. 5.)_
+
+### Coaching note
+
+Each bullet is approximately one paragraph of the monologue. Candidates who skip bullets cap at Band 6 on Coherence. Candidates who treat the "explain" bullet as optional cap at Band 6 on Task achievement (Part 2 is informally scored on whether all bullets are addressed).
+
+---
+
+## Part 3 — Abstract discussion patterns
+
+Part 3 questions are abstract, opinion-driven, and thematically linked to the Part 2 topic. They require the candidate to step back from personal experience and discuss issues at the level of society, generation, country, or principle. Seven recurring patterns appear across Cambridge volumes and published sample tasks.
+
+### The seven Part 3 patterns
+
+#### 1. Opinion
+
+The candidate states and justifies a view.
+
+- "Do you think ... is a good thing?"
+- "What's your view on ...?"
+- "Some people say ... — what do you think?"
+
+_Example (official sample):_ "Do you think advertising influences what people buy?" _(source: `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+#### 2. Advantages / disadvantages
+
+The candidate weighs pros and cons.
+
+- "What are the advantages of ...?"
+- "Are there any drawbacks to ...?"
+- "Do the benefits of ... outweigh the problems?"
+
+#### 3. Comparison
+
+The candidate compares two states, generations, places, or ideas.
+
+- "How does ... compare with ...?"
+- "Are there differences between ... and ...?"
+- "Has the way people ... changed in your lifetime?"
+
+_Example (official sample):_ "Have things changed since your parents' time?" _(source: `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+#### 4. Hypothetical
+
+The candidate speculates about a counterfactual or future possibility.
+
+- "What would happen if ...?"
+- "If ... were no longer available, what would people do?"
+- "Imagine ... — would that be a good thing?"
+
+#### 5. Prediction
+
+The candidate forecasts a future trend.
+
+- "How do you think ... will change in the next twenty years?"
+- "Will people still ... in the future?"
+- "Is ... likely to become more or less common?"
+
+#### 6. Causes and effects
+
+The candidate explains why something happens or what its consequences are.
+
+- "Why do you think people ...?"
+- "What causes ...?"
+- "What effect does ... have on ...?"
+
+#### 7. Problem and solution
+
+The candidate identifies an issue and proposes responses.
+
+- "What problems does ... cause?"
+- "How could governments / individuals address ...?"
+- "What can be done about ...?"
+
+### Theme categories observed in published Part 3 frames
+
+| Theme | Common abstract probes |
+|-------|----------------------|
+| Society and generations | Values, status symbols, lifestyle changes |
+| Technology | Communication, information access, automation |
+| Environment | Sustainability, climate, urban vs rural living |
+| Education | Schools, teachers, learning approaches, qualifications |
+| Work | Job satisfaction, career change, automation, work-life balance |
+| Media | Advertising, news, social media, entertainment |
+| Culture | Tradition, festivals, art, the role of the past |
+| Family | Generations, child-rearing, caring for elders |
+| Health | Lifestyle, fitness, government's role, mental health |
+| Money | Spending, saving, status, cashless society |
+| Future | What will change, what will be lost, what should be preserved |
+| Government | Public services, regulation, citizens' duties |
+| Globalisation | Travel, languages, cultural exchange |
+
+_(source: theme list distilled from published Cambridge IELTS 1–19 Part 3 transcripts; takeielts.britishcouncil.org Part 3 sample list, accessed 2026-05-08.)_
+
+### Coaching note
+
+Part 3 is where Band 6 plateaus most often. The discriminator is the candidate's ability to:
+
+1. **Generalise** — speak about "people in general" or "society", not just personal experience.
+2. **Hedge** — use "I would say", "I tend to think", "in many cases", "to some extent".
+3. **Speculate** — use second and third conditionals ("If we had ...", "If governments were to ...").
+4. **Balance** — concede a counter-argument before reasserting.
+
+A candidate who answers every Part 3 question with personal anecdote ("In my family, we ...") cannot reach Band 7 on Lexical Resource regardless of vocabulary range.
+
+---
+
+## Question-stem reference (composite)
+
+The following stems recur across published sample tasks. Tutors may use them when generating original questions in the style of the test.
+
+### Part 1 stems
+- "What kind of ... do you ...?"
+- "How often do you ...?"
+- "Tell me about ..."
+- "Do you like / enjoy ...? (Why?)"
+- "When did you last ...?"
+- "Has ... changed since you were a child?"
+- "What sort of ... would you most like to ...?"
+
+### Part 2 stems
+- "Describe a [person / place / object / event / experience / activity] ..."
+- "You should say: where ... / when ... / who ... / what ... / how ..."
+- "and explain why / how / what ..."
+
+### Part 3 stems
+- "Do you think ... ?"
+- "Why do you think ... ?"
+- "What are the advantages / disadvantages of ... ?"
+- "How has ... changed in recent years?"
+- "What kind of ... give status to people in your country?" _(source: `speaking-sample-tasks-2023.pdf`, p. 6.)_
+- "How do you think ... will change in the future?"
+- "What can be done to ...?"
+- "Should governments ...?"
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 3–7.
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking section.
+- ielts.org — "Speaking test format" page. https://www.ielts.org/for-test-takers/test-format (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests" pages. https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking test format" page. https://ielts.idp.com (accessed 2026-05-08).
+- Cambridge IELTS volumes 1–19 — published past papers (referenced by book number; not reproduced verbatim under copyright).

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-sample-responses-examiner-comments.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-sample-responses-examiner-comments.md
@@ -1,0 +1,308 @@
+# IELTS Speaking — Sample Candidate Responses and Examiner Comments
+
+Source: `speaking-sample-tasks-2023.pdf` (ielts.org official sample test materials, with candidate transcript at approximately Band 6); HFF-authored calibration responses at Bands 5, 7, and 8 in the style of the official transcript.
+
+The examiners' guidelines for marking Speaking are very detailed. There are many ways a candidate may achieve a given band score, and individual responses do not always cleanly fit a single descriptor. The candidate responses below should not be treated as definitive examples of any particular band — they are calibration aids that pair representative output with criterion-by-criterion examiner reasoning.
+
+The official IELTS sample test (Switzerland-based candidate, Part 1 about home town and accommodation; Part 2 about a piano; Part 3 about possessions and status) is reproduced verbatim from `speaking-sample-tasks-2023.pdf`. ielts.org does not publish a band score for this transcript; HFF analysis (cross-checked against the published Cambridge band descriptors) places it in the **Band 6 / 6.5 region** for most criteria, and we use it as the Band 6 anchor below. The Band 5, Band 7, and Band 8 responses below are HFF-authored to mirror the official format and are calibrated against the published descriptors.
+
+---
+
+## Anchor — Part 1: home town and accommodation (Band 6 / 6.5)
+
+### Frame (verbatim)
+
+> Examiner: Now, in this first part, I'd like to ask you some more questions about yourself, OK?
+> Let's talk about your home town or village. What kind of place is it?
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+### Candidate response (verbatim from official transcript)
+
+> Candidate: It's quite a small village, about 20km from Zurich. And it's very quiet. And we have only little ... two little shops because most of the people work in Zurich or are orientated to the city.
+>
+> Examiner: What's the most interesting part of this place ... village?
+>
+> Candidate: On the top of a hill we have a little castle which is very old and quite well known in Switzerland.
+>
+> Examiner: What kind of jobs do people in the village do?
+>
+> Candidate: We have some farmers in the village as well as people who work in Zurich as bankers or journalists or there are also teachers and some doctors, some medicines.
+>
+> Examiner: Would you say it's a good place to live?
+>
+> Candidate: Yes. Although it is very quiet, it is … people are friendly and I would say it is a good place to live there, yes.
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 3–4.)_
+
+### Examiner comment — HFF analysis against descriptors
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| Fluency and Coherence | 6 | The candidate keeps going and produces a willingness to extend ("Although it is very quiet, ..."). Some hesitation and self-correction ("only little ... two little shops") and one false start ("this place ... village") echo the Band 6 descriptor: "coherence may be lost at times as a result of hesitation, repetition and/or self-correction" _(source: `speaking-band-descriptors-cdn.pdf`, p. 2)_. |
+| Lexical Resource | 6 | Vocabulary is sufficient to discuss the topic — "orientated to the city", "quite well known". One word-form slip ("medicines" used for "doctors") and one collocation issue ("orientated to") indicate Band 6 rather than Band 7. Per descriptor: "Vocabulary use may be inappropriate but meaning is clear" _(source: same, p. 2)_. |
+| Grammatical Range and Accuracy | 6 | A mix of simple and complex sentences. The sentence "We have some farmers in the village as well as people who work in Zurich as bankers or journalists ..." shows complex structure with a relative clause. Errors are present (article use, occasional concord). Per descriptor: "produces a mix of short and complex sentence forms ... with limited flexibility" _(source: same, p. 2)_. |
+| Pronunciation | Not assessable from transcript alone | The descriptors require listening to the recording. Tutors should defer pronunciation scoring until they have audio evidence. |
+
+**Overall (FC, LR, GRA only): Band 6.**
+
+---
+
+## Part 1 — Calibration responses
+
+### Question used
+
+> "Tell me about the kind of accommodation you live in." _(source: `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+### Band 5 response (HFF-authored)
+
+> Candidate: I live in apartment. It is in the city. Erm ... it is small. Have two bedroom and a kitchen. I live with my family — my mother, father and one brother. It is OK. Yes. I like it.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 5 | The candidate keeps going but relies on slow speech and a filler ("erm ..."). Hesitations cluster around basic lexis and grammar. Per descriptor: "hesitations are often associated with mid-sentence searches for fairly basic lexis and grammar" _(`speaking-band-descriptors-cdn.pdf`, p. 2)_. |
+| LR | 5 | Vocabulary is functional but inflexible ("OK", "I like it"). No paraphrase attempted. |
+| GRA | 5 | Basic sentence forms ("I live in apartment", "Have two bedroom") show repeated article and concord errors. Complex structures absent. Per descriptor: "complex structures are attempted but these are limited in range, nearly always contain errors" — though here even basic forms collapse. |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 5.**
+
+### Band 7 response (HFF-authored)
+
+> Candidate: At the moment I'm renting a small flat in the centre of the city — it's a one-bedroom place on the third floor of an old building. I've been living there for about two years now. What I like about it is that it's within walking distance of where I work, so I don't really need to use public transport during the week. The downside is that it's quite noisy, especially at the weekend, because there are several bars on the same street. If I had a bit more money, I'd probably move somewhere a little quieter — maybe one of the suburbs.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 7 | The candidate produces a long, well-organised turn without noticeable effort. Discourse markers ("at the moment", "what I like about it", "the downside is") are used flexibly. Per descriptor: "able to keep going and readily produce long turns without noticeable effort ... flexible use of spoken discourse markers" _(`speaking-band-descriptors-cdn.pdf`, p. 1)_. |
+| LR | 7 | Some less common items ("within walking distance", "the downside is", "one of the suburbs") used appropriately. Effective paraphrase ("a small flat" → "a one-bedroom place"). |
+| GRA | 7 | Range of structures: present continuous ("I'm renting"), present perfect ("I've been living"), conditional ("If I had ..., I'd ..."). Errors are absent in this turn. Per descriptor: "a range of structures flexibly used. Error-free sentences are frequent." |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 7.**
+
+### Band 8 response (HFF-authored)
+
+> Candidate: I'm currently renting a small flat in the centre of the city, although I've actually been thinking about moving for a while now. It's a top-floor place, about 50 square metres, in a building that must be at least a hundred years old — high ceilings, original wooden floors, all that sort of thing. The location is the main draw: I can walk to work, to the river, to most of the places I tend to go on weekends. The trade-off is that the building has paper-thin walls and no lift, so by the time I've climbed five flights of stairs with the shopping, I'm starting to question my priorities. If I'm honest, what I'd really like is somewhere with a bit of outdoor space — even a balcony would do.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 8 | Fluent with very occasional hesitation; topic development is coherent and relevant. Discourse markers are flexible ("although ...", "the trade-off is", "if I'm honest"). Per descriptor: "fluent with only very occasional repetition or self-correction ... topic development is coherent, appropriate and relevant" _(`speaking-band-descriptors-cdn.pdf`, p. 1)_. |
+| LR | 8 | Wide resource used flexibly: less common items ("the main draw", "the trade-off", "paper-thin walls", "by the time I've climbed five flights of stairs"), idiomatic chunks ("starting to question my priorities", "all that sort of thing"). One slight inappropriacy ("about 50 square metres" — neutral), consistent with Band 8 occasional inaccuracy. |
+| GRA | 8 | Wide range of structures: present continuous, present perfect ("I've been thinking"), modal speculation ("must be at least a hundred years old"), inversion-style fronting ("by the time I've climbed ..., I'm starting to question ..."), second conditional ("even a balcony would do"). Majority of sentences error-free. |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 8.**
+
+---
+
+## Part 2 — Anchor: piano monologue (Band 6 / 6.5)
+
+### Cue card (verbatim)
+
+> Describe something you own which is very important to you.
+> You should say:
+>   where you got it from
+>   how long you have had it
+>   what you use it for
+> and explain why it is important to you.
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 5.)_
+
+### Candidate response (verbatim from official transcript)
+
+> Candidate: Yes. One of the most important things I have is my piano because I like playing the piano. I got it from my parents to my twelve birthday, so I have it for about nine years, and the reason why it is so important for me is that I can go into another world when I'm playing piano. I can forget what's around me and what ... I can forget my problems and this is sometimes quite good for a few minutes. Or I can play to relax or just, yes to … to relax and to think of something completely different.
+>
+> Examiner: Thank you. Would it be easy to replace this, this piano?
+>
+> Candidate: Yes, I think it wouldn't be that big problem but I like my piano as it is because I have it from my parents, it's some kind unique for me.
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 5.)_
+
+### Examiner comment — HFF analysis
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 6 | The candidate keeps going for the full long turn. There are some hesitations ("just, yes to … to relax") and one self-correction ("I can forget what ... I can forget my problems"). All four bullets are addressed (got from = parents on 12th birthday; how long = nine years; what for = playing/forgetting problems; explain why = mental escape). Per Band 6: "demonstrates a willingness to produce long turns. Coherence may be lost at times" _(`speaking-band-descriptors-cdn.pdf`, p. 2)_. |
+| LR | 6 | Vocabulary is sufficient ("go into another world", "to relax", "completely different"). One inappropriacy ("for about nine years" should be "for about nine years" — actually fine; "to my twelve birthday" should be "for my twelfth birthday"). Per Band 6: "vocabulary use may be inappropriate but meaning is clear". |
+| GRA | 6 | Mix of structures with errors. "I have it for about nine years" misses present perfect ("I've had it"). "It wouldn't be that big problem" misses an article. Some complex structures attempt ("the reason why it is so important for me is that ..."). Per Band 6: "errors frequently occur in complex structures, these rarely impede communication". |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 6.**
+
+---
+
+## Part 2 — Calibration responses
+
+### Cue card used
+
+> Describe a place from your childhood that you remember well.
+> You should say:
+>   where it was
+>   what it looked like
+>   what you used to do there
+> and explain why you remember it.
+
+### Band 5 response (HFF-authored)
+
+> Candidate: OK so I will talk about a place from when I was a child. It is the house of my grandmother. It is in the village. The village is small. The house is old. It have a garden. In the garden is many tree, apple tree and ... I don't know the word. Erm ... I go there in summer. I play with my cousins. We play game and we eat together. I remember it because was happy. Yes. That is all.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 5 | Maintains the long turn but with slow speech, multiple short sentences, and a vocabulary search ("I don't know the word"). Per Band 5: "usually able to keep going, but relies on repetition and self-correction to do so and/or on slow speech" _(`speaking-band-descriptors-cdn.pdf`, p. 2)_. |
+| LR | 5 | Familiar vocabulary only ("village is small", "house is old", "play game", "we eat together"). No paraphrase when stuck — abandons the word. Per Band 5: "attempts paraphrase but not always with success." |
+| GRA | 5 | Basic forms with persistent error ("It have a garden", "In the garden is many tree", "we play game"). One past attempted ("was happy") but subject missing. Per Band 5: "basic sentence forms are fairly well controlled ... complex structures are attempted but these are limited in range, nearly always contain errors". |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 5.**
+
+### Band 7 response (HFF-authored)
+
+> Candidate: A place I remember really well from my childhood is my grandmother's house, which is in a small village about an hour outside the city where I grew up. It's an old farmhouse, probably built in the 1930s, with thick stone walls, a tiled roof, and a garden full of fruit trees — apple, pear and a couple of cherry trees that we used to climb. I spent most of my school holidays there, especially in the summer. We would help my grandmother in the garden, ride bikes through the lanes with my cousins, and in the evenings we'd sit outside and listen to her tell stories about when she was young. I remember it so vividly because it was the first place where I felt completely free — there were no schedules, no homework, just long days that seemed to go on forever. Even now, whenever I smell wood smoke or freshly cut grass, I'm taken straight back to that garden.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 7 | A long turn produced without noticeable effort, with all four bullets addressed in extended form. Discourse markers are flexible ("which is ...", "especially in the summer", "even now"). Per Band 7: "able to keep going and readily produce long turns without noticeable effort" _(`speaking-band-descriptors-cdn.pdf`, p. 1)_. |
+| LR | 7 | Some less common items ("farmhouse", "tiled roof", "vividly", "wood smoke"). Effective paraphrase ("the place where I felt completely free" → "no schedules, no homework, just long days"). One slight collocation choice ("ride bikes through the lanes") — appropriate. |
+| GRA | 7 | Range of structures: relative clauses ("which is in ...", "the first place where ..."), past habit ("we used to climb", "we would help"), present participle ("listen to her tell"), inversion-style closing ("whenever I smell ..., I'm taken ..."). Few errors. Per Band 7: "a range of structures flexibly used. Error-free sentences are frequent." |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 7.**
+
+### Band 8 response (HFF-authored)
+
+> Candidate: When I think about my childhood, the place that comes to mind most vividly is my grandmother's farmhouse — a stone-walled house tucked away at the end of a winding lane in a village about an hour outside the city. It must have been built in the 1930s; the walls were almost a metre thick, which meant that even on the hottest summer days, stepping inside felt like walking into a fridge. The garden, though, is what I remember best: fruit trees in every direction — apple, pear, and an enormous cherry tree that none of us could ever climb to the top of, no matter how many times we tried. I used to spend whole summers there with my cousins, and looking back, those weeks had a kind of unhurried quality I haven't really experienced since. We'd help my grandmother with the chickens in the morning, disappear on our bikes for hours in the afternoon, and gather on the porch in the evenings while she told us stories about the village in her own childhood. The reason it has stayed with me so strongly, I think, is that it was the first place where I understood that time could move differently — that a day didn't have to be measured in lessons and bells. Even now, the smell of wood smoke is enough to put me right back there.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 8 | Fluent throughout. Hesitation, where present, is content-related ("looking back, those weeks had a kind of unhurried quality I haven't really experienced since"). Coherent and appropriate development across all four bullets, with a strong reflective close. Per Band 8: "fluent with only occasional repetition or self-correction; hesitation is usually content-related" _(`speaking-band-descriptors-cdn.pdf`, p. 1)_. |
+| LR | 8 | Wide resource used skilfully: "tucked away", "winding lane", "stone-walled", "an unhurried quality", "in every direction". Idiomatic chunks ("the place that comes to mind", "no matter how many times we tried", "put me right back there"). Effective paraphrase. Occasional inaccuracies absent here. Per Band 8: "uses a wide vocabulary resource readily and flexibly to convey precise meaning". |
+| GRA | 8 | Wide range of structures used flexibly: cleft sentences ("The garden, though, is what I remember best"), modal speculation ("It must have been built in the 1930s"), past habit ("I used to spend ... we'd help, disappear, and gather"), reduced relative clause ("a stone-walled house tucked away ..."), abstract noun phrase ("a kind of unhurried quality I haven't really experienced since"). Per Band 8: "wide range of structures flexibly used. The majority of sentences are error-free." |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 8.**
+
+---
+
+## Part 3 — Anchor: status and possessions (Band 6 / 6.5)
+
+### Frame (verbatim)
+
+> Examiner: We've been talking about things we own. I'd like to discuss with you one or two more general questions relating to this topic. First, let's consider values and the way they can change. In Switzerland, what kind of possessions do you think give status to people?
+>
+> Candidate: The first thing which comes in my mind is the car. Yes, because lots of people like to have posh cars or expensive cars to show their status, their place in the society.
+>
+> Examiner: Is that a new development?
+>
+> Candidate: No, I think it isn't.
+>
+> Examiner: People have thought like that for quite a long time?
+>
+> Candidate: Yes. Another thing is probably the clothing. It starts already when you are young. When the children go to school they want to have posh labels on their jumpers or good shoes.
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+### Examiner comment — HFF analysis
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 6 | Maintains turn-taking with the examiner. Some short answers ("No, I think it isn't") that the examiner has to follow up — Band 6 territory rather than Band 7. Discourse markers used ("Another thing is probably", "It starts already"). |
+| LR | 6 | Topic-appropriate vocabulary ("posh cars", "show their status", "their place in the society"). Some less common items ("posh labels", "jumpers"). Per Band 6 / 6.5: meaning clear with occasional inappropriate items. |
+| GRA | 6 | Mix of simple and complex. "The first thing which comes in my mind" — should be "to my mind" (collocation). Conditional / hypothetical structures absent — a marker that limits the band to 6 in Part 3. |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 6 / 6.5.**
+
+---
+
+## Part 3 — Calibration responses
+
+### Question used
+
+> "Do you think advertising influences what people buy?" _(source: `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+### Band 5 response (HFF-authored)
+
+> Candidate: Yes I think advertising influence what people buy. Because we see many advert on TV and on the phone, and after we want to buy this thing. For example my sister see advert for shoes and she buy this shoes. So yes advertising have big influence.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 5 | Keeps going but the answer stays at the level of personal example without abstraction. Discourse markers limited to "Because", "For example", "So". |
+| LR | 5 | Repetitive — "advertising" / "advert" / "advert" / "advertising" without paraphrase. No hedging language. |
+| GRA | 5 | Persistent third-person and tense errors ("advertising influence", "see advert", "she buy"). Conditional / abstract structures absent. |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 5.**
+
+### Band 7 response (HFF-authored)
+
+> Candidate: I think advertising definitely has a strong influence on what people buy, although the way it works has changed quite a lot. In the past, you'd see the same adverts repeated on television, and people would tend to recognise the brand and trust it. Nowadays, advertising is much more targeted — it follows you online based on what you've searched for, which I think is more powerful but also more intrusive. Having said that, I think most people are aware they are being advertised to, especially younger people, so they are perhaps more sceptical than they used to be. So yes, advertising influences buying decisions, but I'd say the influence is more subtle than it was.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 7 | Long, coherent turn produced without noticeable effort. Discourse markers used flexibly ("In the past", "Nowadays", "Having said that", "So yes"). Comparison-across-time pattern handled. |
+| LR | 7 | Some less common items ("targeted", "intrusive", "sceptical", "buying decisions", "subtle"). Effective paraphrase ("advertising follows you online" → "based on what you've searched for"). Hedging language ("I'd say", "I think", "perhaps"). |
+| GRA | 7 | Range of structures: contrast pattern ("In the past, you'd see ... Nowadays, advertising is ..."), passive ("are being advertised to"), comparative ("more powerful but also more intrusive"). Per Band 7. |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 7.**
+
+### Band 8 response (HFF-authored)
+
+> Candidate: I'd say advertising clearly influences what people buy, though I think the nature of that influence has shifted significantly in the last decade or so. Traditional advertising — the kind you'd see on billboards or between TV programmes — was largely about repetition and brand recognition: the more often you saw the logo, the more likely you were to reach for the product. What's changed is that advertising is now far more personalised, in the sense that algorithms track your browsing and serve you content tailored to what they've inferred about you. The interesting consequence, I think, is that we're often unaware of being advertised to at all — a video on social media that looks like a recommendation from a friend may actually be a paid placement. So while I would say the influence is undoubtedly there, it's also become harder to quantify, because the line between advertising and ordinary content has blurred.
+
+#### Examiner comment
+
+| Criterion | Band | Reasoning |
+|-----------|------|-----------|
+| FC | 8 | Fluent and content-driven. Coherent across a long, abstract Part 3 turn. Discourse markers ("though I think", "What's changed is that", "The interesting consequence", "So while ...") deployed for clear stage marking. Per Band 8: "speaks fluently with only occasional repetition ... develops topics coherently and appropriately." |
+| LR | 8 | Wide resource: "shifted significantly", "brand recognition", "tailored to what they've inferred", "paid placement", "the line ... has blurred". Hedging at Band 8 register ("I'd say", "I think", "undoubtedly", "in the sense that"). Per Band 8: "uses less common and idiomatic vocabulary skilfully". |
+| GRA | 8 | Wide range used flexibly: cleft ("What's changed is that ..."), comparative-conditional ("the more often you saw ..., the more likely you were ..."), reduced relative ("a video ... that looks like a recommendation"), passive ("being advertised to", "tailored to ..."). Per Band 8: "wide range of structures flexibly used. The majority of sentences are error free." |
+| P | Not assessable from transcript |  |
+
+**Overall (FC, LR, GRA): Band 8.**
+
+---
+
+## Calibration summary table
+
+| Part | Band 5 marker | Band 6 / 6.5 marker | Band 7 marker | Band 8 marker |
+|------|---------------|--------------------|--------------|--------------|
+| 1 | One-sentence answers; persistent article/concord errors; no paraphrase | Extended answers; mix of simple and complex with errors in complex; "vocabulary clear but inappropriate" | Long turns without effort; conditional + present perfect; less-common items ("downside is", "within walking distance") | Idiomatic chunks; cleft sentences; precise less-common items ("the main draw") |
+| 2 | Short, fragmented monologue; word-search abandonment; basic-form errors | Full monologue addressing all bullets; mix of structures with errors; familiar vocabulary | Extended monologue with reflective close; past-habit "would" + "used to"; less-common items | Sustained monologue with abstract reflection; cleft sentences; reduced relatives; idiomatic close |
+| 3 | Personal anecdote only; no hedging; tense errors | Mix of personal and general; some discourse markers; conditional structures absent | Generalisation + hedging ("I'd say", "perhaps"); compare-across-time; concession ("Having said that") | Multi-clause analysis; abstract noun phrases ("the nature of that influence"); fronting + cleft; precise hedging |
+
+---
+
+## Important caveat (verbatim from ielts.org sample materials)
+
+> The examiners' guidelines for marking the Speaking scripts are very detailed. There are many different ways a candidate may achieve a particular band score. The candidates' answers shown should not be regarded as definitive examples of any particular band score.
+>
+> _(adapted from `academic-writing-sample-tasks-2023.pdf` introduction; the same caveat applies to Speaking calibration.)_
+
+**Why HFF-authored Band 5, 7, and 8 responses are used:** ielts.org publishes only one Speaking transcript per sample task, and it is typically an upper-Band-6 candidate. To calibrate the AI tutor across the Band range that students actually score (5–8), HFF authored representative responses that fit each Band's positive descriptor features. These should be cross-checked against the verbatim Cambridge band descriptors in `speaking-band-descriptors-cdn.pdf` whenever in doubt.
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 3–7. Contains the verbatim Band 6 / 6.5 anchor transcripts (Switzerland candidate, Parts 1, 2, 3).
+- *IELTS Speaking Band Descriptors* — `speaking-band-descriptors-cdn.pdf` (in this folder), pages 1–3. Source of all band-level criterion language quoted in examiner comments.
+- *IELTS Speaking Band Descriptors (public version)* — `cambridge-speaking-band-descriptors.pdf` (in this folder). Cross-checked descriptor wording.
+- ielts.org — "How IELTS is marked" page. https://www.ielts.org/for-test-takers/how-ielts-is-marked (accessed 2026-05-08).
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking calibration section.

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-sources.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-sources.md
@@ -1,0 +1,296 @@
+# IELTS Speaking — Sources and Audit Trail
+
+This file consolidates every URL accessed, every PDF cited, every published volume referenced, and every framework drawn upon across the nine companion documents in `docs/external/ielts/ielts-speaking/`. It is the audit trail. Any factual claim in those documents should trace back to one of the entries below.
+
+Last verified: 2026-05-08.
+
+---
+
+## 1. Primary IELTS sources (joint owners)
+
+The IELTS examination is jointly owned and administered by **the British Council**, **IDP IELTS**, and **Cambridge University Press & Assessment**. All four owners publish official preparation materials. Each is treated as a primary source.
+
+### 1.1 ielts.org (joint owner publication portal)
+
+Public-facing portal for test-takers. Source of band descriptors, sample tasks, examiner-marking guidance, and test-format information.
+
+- **IELTS Speaking test format.** https://www.ielts.org/for-test-takers/test-format (accessed 2026-05-08).
+- **How IELTS is marked.** https://www.ielts.org/for-test-takers/how-ielts-is-marked (accessed 2026-05-08).
+- **IELTS scores explained.** https://www.ielts.org/for-test-takers/ielts-scores-explained (accessed 2026-05-08).
+- **Enquiry on Results.** https://www.ielts.org/for-test-takers/results/enquiry-on-results (accessed 2026-05-08).
+- **IELTS Speaking sample tasks.** https://www.ielts.org/for-test-takers/sample-test-questions (accessed 2026-05-08; the PDF below is the downloadable artefact).
+
+### 1.2 Cambridge English (Cambridge University Press & Assessment)
+
+Test owner. Publishes band descriptors, examiner handbooks, and the IELTS / CEFR alignment chart.
+
+- **International language standards: CEFR.** https://www.cambridgeenglish.org/exams-and-tests/cefr/ (accessed 2026-05-08). Source of the IELTS Band ↔ CEFR alignment chart used in `ielts-speaking-cefr-mapping.md`.
+- **IELTS exam information.** https://www.cambridgeenglish.org/exams-and-tests/ielts/ (accessed 2026-05-08).
+- **Vocabulary, grammar and discourse strategies for high-band IELTS Speaking** (preparation pages). https://www.cambridgeenglish.org (accessed 2026-05-08; cited in `ielts-speaking-language-toolkit.md`).
+
+### 1.3 British Council — takeielts.britishcouncil.org
+
+Official British Council preparation portal. Source of free Part 1, 2, and 3 sample tasks.
+
+- **Free IELTS Speaking practice tests.** https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- **IELTS Speaking preparation tips.** https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests (accessed 2026-05-08).
+
+### 1.4 IDP IELTS — ielts.idp.com
+
+Official IDP preparation portal.
+
+- **IELTS Speaking test format.** https://ielts.idp.com (accessed 2026-05-08).
+- **IELTS Speaking Part 1 / 2 / 3 samples.** https://ielts.idp.com (accessed 2026-05-08).
+
+---
+
+## 2. PDFs in `docs/external/ielts/ielts-speaking/` (cited verbatim)
+
+These PDFs are official IELTS-owner publications. Every band-descriptor quotation in the companion documents traces back to a specific page of one of these PDFs.
+
+### 2.1 `speaking-band-descriptors-cdn.pdf` (ielts.org, joint owners)
+
+*IELTS Speaking Band Descriptors — Scoring criteria for Academic and General Training tests.* 3 pages. Public version. Verbatim source of all Band 1–9 descriptors quoted in `ielts-speaking-key-assessment-criteria.md` and `ielts-speaking-sample-responses-examiner-comments.md`.
+
+| Page | Contents | Cited in |
+|------|---------|---------|
+| 1 | Band 7, 8, 9 descriptors for all four criteria | `ielts-speaking-key-assessment-criteria.md`; `ielts-speaking-sample-responses-examiner-comments.md` |
+| 2 | Band 4, 5, 6 descriptors for all four criteria | `ielts-speaking-key-assessment-criteria.md`; `ielts-speaking-sample-responses-examiner-comments.md` |
+| 3 | Band 0, 1, 2, 3 descriptors for all four criteria; examiner notes (i) and (ii) | `ielts-speaking-key-assessment-criteria.md`; `ielts-speaking-test-format.md` |
+
+### 2.2 `cambridge-speaking-band-descriptors.pdf` (Cambridge English)
+
+*IELTS Speaking Band Descriptors (public version).* 1 page. Cambridge English alternative format of the band descriptors. Used for cross-checking and for the Band 5 / 7 / 8 boundary descriptors that ielts.org's CDN PDF compresses ("Displays all the positive features of band X, and some, but not all, of the positive features of band Y").
+
+| Page | Contents | Cited in |
+|------|---------|---------|
+| 1 | All Band 0–9 descriptors for all four criteria, in landscape table format | `ielts-speaking-key-assessment-criteria.md`; `ielts-speaking-cefr-mapping.md`; `ielts-speaking-language-toolkit.md` |
+
+### 2.3 `speaking-key-assessment-criteria.pdf` (ielts.org, joint owners)
+
+*IELTS Speaking Key Assessment Criteria.* 4 pages. Plain-prose explanation of what each of the four criteria measures, with key indicators per criterion. Verbatim source of the criterion definitions in `ielts-speaking-key-assessment-criteria.md`.
+
+| Page | Contents | Cited in |
+|------|---------|---------|
+| 1 | Fluency and Coherence definition + key indicators | `ielts-speaking-key-assessment-criteria.md` |
+| 2 | Lexical Resource definition + key indicators; Grammatical Range and Accuracy intro | `ielts-speaking-key-assessment-criteria.md` |
+| 3 | Grammatical Range and Accuracy key indicators; Pronunciation intro | `ielts-speaking-key-assessment-criteria.md` |
+| 4 | Pronunciation key indicators | `ielts-speaking-key-assessment-criteria.md` |
+
+### 2.4 `speaking-sample-tasks-2023.pdf` (ielts.org, joint owners)
+
+*IELTS Speaking Sample Tasks.* 7 pages. Contains the official sample Part 1 frame (home town + accommodation), Part 2 cue card (something you own), and Part 3 frame (status / advertising), each with a verbatim candidate transcript.
+
+| Page | Contents | Cited in |
+|------|---------|---------|
+| 1 | Cover page | (referenced but no factual quotation) |
+| 2 | Contents page | (referenced but no factual quotation) |
+| 3 | Part 1 examiner frame (verbatim questions) | `ielts-speaking-test-format.md`; `ielts-speaking-question-types-guide.md`; `ielts-speaking-question-bank-part1.md` (Frames 1, 2) |
+| 4 | Part 1 candidate transcript (verbatim) | `ielts-speaking-sample-responses-examiner-comments.md` |
+| 5 | Part 2 cue card (verbatim) + candidate transcript | `ielts-speaking-test-format.md`; `ielts-speaking-question-types-guide.md`; `ielts-speaking-question-bank-part2.md` (Card 31); `ielts-speaking-sample-responses-examiner-comments.md` |
+| 6 | Part 3 examiner frame + candidate transcript (verbatim) | `ielts-speaking-test-format.md`; `ielts-speaking-question-types-guide.md`; `ielts-speaking-question-bank-part3.md` (Sets 1, 26); `ielts-speaking-sample-responses-examiner-comments.md` |
+| 7 | Part 3 transcript continuation (verbatim) | `ielts-speaking-sample-responses-examiner-comments.md` |
+
+### 2.5 `ielts-guide-for-teachers.pdf` (ielts.org, joint owners)
+
+*IELTS Guide for Teachers.* Multi-section teacher-handbook PDF covering all four IELTS skills. Used as a secondary reference for examiner protocol, cue-card template, and Part 2 / Part 3 conventions.
+
+| Section | Cited in |
+|---------|---------|
+| Speaking section — examiner protocol | `ielts-speaking-test-format.md` |
+| Speaking section — cue-card template | `ielts-speaking-test-format.md`; `ielts-speaking-question-types-guide.md`; `ielts-speaking-question-bank-part2.md` |
+| Speaking section — Part 3 discussion conventions | `ielts-speaking-test-format.md`; `ielts-speaking-question-types-guide.md`; `ielts-speaking-question-bank-part3.md` |
+| Examiner certification overview | `ielts-speaking-test-format.md` |
+| Calibration guidance | `ielts-speaking-sample-responses-examiner-comments.md` |
+| Speaking preparation strategies | `ielts-speaking-language-toolkit.md` |
+
+---
+
+## 3. Council of Europe — CEFR (intergovernmental standard)
+
+The Council of Europe is an intergovernmental body of 46 member states. Its CEFR documents are the closest analogue to a "government standard" for language proficiency referenced by the IELTS materials.
+
+- **Common European Framework of Reference for Languages: Learning, teaching, assessment — Companion Volume** (2020). Council of Europe Publishing. Open-licence non-commercial reproduction permitted. https://www.coe.int/en/web/common-european-framework-reference-languages (accessed 2026-05-08). Cited for:
+  - The "Self-assessment grid" — Speaking column (global descriptors A1 to C2). Cited in `ielts-speaking-cefr-mapping.md` Section 2.
+  - The "Fluency" sub-scale (p. 142 of Companion Volume; under Pragmatic competence > Functional competence). Cited in `ielts-speaking-cefr-mapping.md` Section 3.1.
+  - The "Vocabulary range" sub-scale (p. 131). Cited in `ielts-speaking-cefr-mapping.md` Section 3.2.
+  - The "Grammatical accuracy" sub-scale (p. 132). Cited in `ielts-speaking-cefr-mapping.md` Section 3.3.
+  - The "Phonological control" sub-scale (p. 133). Cited in `ielts-speaking-cefr-mapping.md` Section 3.4.
+
+Page numbers verified 2026-05-08 against the Companion Volume 2020 PDF table of contents (Council of Europe Publishing, English edition).
+  - General CEFR alignment principles. Cited in `ielts-speaking-language-toolkit.md`.
+
+- **Common European Framework of Reference for Languages: Learning, teaching, assessment** (2001). Council of Europe Publishing. Original CEFR document. https://www.coe.int (accessed 2026-05-08). Referenced as the originating framework underlying the 2020 Companion Volume.
+
+---
+
+## 4. UK Government — UKVI / SELT (peripheral)
+
+Cited in `ielts-speaking-cefr-mapping.md` Section 5 only, for the SELT recognition note.
+
+- gov.uk — "Prove your English language abilities with a secure English language test (SELT)." https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt (accessed 2026-05-08).
+
+---
+
+## 5. Cambridge IELTS volumes (canonical past papers — referenced, not reproduced)
+
+Cambridge University Press publishes a numbered series of past-paper volumes. Each volume contains four complete tests, including Speaking task cards. These are copyrighted; this project references them as a pattern source only and does not reproduce verbatim cards.
+
+The cards in `ielts-speaking-question-bank-part2.md` and the question sets in `ielts-speaking-question-bank-part1.md` and `ielts-speaking-question-bank-part3.md` are HFF-authored in the style of these published cards but are **original content**, not reproductions.
+
+| Volume | Publisher | Year |
+|--------|-----------|------|
+| Cambridge IELTS 1 | Cambridge University Press | 1996 |
+| Cambridge IELTS 2 | Cambridge University Press | 2000 |
+| Cambridge IELTS 3 | Cambridge University Press | 2002 |
+| Cambridge IELTS 4 | Cambridge University Press | 2005 |
+| Cambridge IELTS 5 | Cambridge University Press | 2006 |
+| Cambridge IELTS 6 | Cambridge University Press | 2007 |
+| Cambridge IELTS 7 | Cambridge University Press | 2009 |
+| Cambridge IELTS 8 | Cambridge University Press | 2011 |
+| Cambridge IELTS 9 | Cambridge University Press | 2013 |
+| Cambridge IELTS 10 | Cambridge University Press | 2015 |
+| Cambridge IELTS 11 | Cambridge University Press | 2016 |
+| Cambridge IELTS 12 | Cambridge University Press | 2017 |
+| Cambridge IELTS 13 | Cambridge University Press | 2018 |
+| Cambridge IELTS 14 | Cambridge University Press | 2019 |
+| Cambridge IELTS 15 | Cambridge University Press | 2020 |
+| Cambridge IELTS 16 | Cambridge University Press | 2021 |
+| Cambridge IELTS 17 | Cambridge University Press | 2022 |
+| Cambridge IELTS 18 | Cambridge University Press | 2023 |
+| Cambridge IELTS 19 | Cambridge University Press | 2024 |
+
+These volumes are referenced in the companion documents as a source for Part 2 cue-card sub-frames and Part 3 theme conventions, distilled across the body of published tests rather than from any single test.
+
+---
+
+## 6. Crowd-sourced and community sources (NOT cited as factual sources)
+
+Per the IP rule in `ielts-partner-brief.md`, recalled exam questions from test-takers are not used as factual sources in this content pack. Sites such as ielts-blog.com, speaking9.com, and similar community boards were consulted only as a sanity check on which Part 2 sub-frames are commonly seen — they are not cited.
+
+The cards and question sets in this content pack are HFF-authored. Where an HFF-authored card is closely modelled on a recurring published Cambridge sub-frame, the source tag is `_(source: HFF-authored; mirrors Cambridge IELTS X frame)_` rather than a verbatim citation.
+
+---
+
+## 7. Cross-document citation map
+
+Reverse index — for each companion document, which sources are cited.
+
+### `ielts-speaking-key-assessment-criteria.md`
+- `speaking-key-assessment-criteria.pdf` (pp. 1–4)
+- `speaking-band-descriptors-cdn.pdf` (pp. 1–3)
+- `cambridge-speaking-band-descriptors.pdf` (p. 1)
+- ielts.org (general)
+- cambridgeenglish.org (general)
+
+### `ielts-speaking-test-format.md`
+- ielts.org "Speaking test format", "How IELTS is marked", "Enquiry on Results"
+- `speaking-sample-tasks-2023.pdf` (pp. 3–7)
+- `ielts-guide-for-teachers.pdf` (Speaking section)
+- cambridgeenglish.org "How IELTS is assessed"
+
+### `ielts-speaking-question-types-guide.md`
+- `speaking-sample-tasks-2023.pdf` (pp. 3–7)
+- `ielts-guide-for-teachers.pdf` (Speaking section)
+- ielts.org "Speaking test format"
+- takeielts.britishcouncil.org Part 1 / 2 / 3 sample lists
+- ielts.idp.com Part 1 / 2 / 3 samples
+- Cambridge IELTS volumes 1–19 (pattern reference)
+
+### `ielts-speaking-question-bank-part1.md`
+- `speaking-sample-tasks-2023.pdf` (p. 3) — Frames 1 and 2 (verbatim source)
+- ielts.org Part 1 sample
+- takeielts.britishcouncil.org Part 1 sample
+- ielts.idp.com Part 1 sample
+- Cambridge IELTS volumes 1–19 (pattern reference)
+- HFF-authored material for Frames 3–52
+
+### `ielts-speaking-question-bank-part2.md`
+- `speaking-sample-tasks-2023.pdf` (p. 5) — Card 31 (verbatim source)
+- ielts.org Part 2 sample
+- takeielts.britishcouncil.org Part 2 sample
+- ielts.idp.com Part 2 sample
+- `ielts-guide-for-teachers.pdf`
+- Cambridge IELTS volumes 1–19 (pattern reference)
+- HFF-authored material for Cards 1–30 and 32–88
+
+### `ielts-speaking-question-bank-part3.md`
+- `speaking-sample-tasks-2023.pdf` (pp. 6–7) — Sets 1 and 26 (verbatim source)
+- ielts.org Part 3 sample
+- takeielts.britishcouncil.org Part 3 sample
+- ielts.idp.com Part 3 sample
+- `ielts-guide-for-teachers.pdf`
+- Cambridge IELTS volumes 1–19 (pattern reference)
+- HFF-authored material for Sets 2–25, 27–64
+
+### `ielts-speaking-sample-responses-examiner-comments.md`
+- `speaking-sample-tasks-2023.pdf` (pp. 3–7) — verbatim Band 6 anchor transcripts
+- `speaking-band-descriptors-cdn.pdf` (pp. 1–3) — verbatim band descriptors quoted in examiner comments
+- `cambridge-speaking-band-descriptors.pdf` (p. 1)
+- ielts.org "How IELTS is marked"
+- `ielts-guide-for-teachers.pdf` (Speaking calibration section)
+- HFF-authored Band 5 / 7 / 8 calibration responses
+
+### `ielts-speaking-language-toolkit.md`
+- `speaking-key-assessment-criteria.pdf` (pp. 1–4)
+- `speaking-band-descriptors-cdn.pdf` (pp. 1–3)
+- `cambridge-speaking-band-descriptors.pdf` (p. 1)
+- `ielts-guide-for-teachers.pdf` (Speaking section)
+- takeielts.britishcouncil.org preparation pages
+- ielts.idp.com preparation pages
+- Council of Europe CEFR Companion Volume
+- cambridgeenglish.org high-band Speaking strategies
+
+### `ielts-speaking-cefr-mapping.md`
+- Council of Europe — CEFR Companion Volume 2020 (full)
+- Council of Europe — CEFR 2001 (originating document)
+- cambridgeenglish.org "International language standards: CEFR"
+- ielts.org "IELTS scores explained" / "How IELTS is marked"
+- `speaking-band-descriptors-cdn.pdf` (pp. 1–3)
+- gov.uk SELT page
+
+---
+
+## 8. IP and licensing notes
+
+- **IELTS owner publications** (PDFs, ielts.org pages, cambridgeenglish.org pages, takeielts.britishcouncil.org pages, ielts.idp.com pages): publicly downloadable; reproduction of band descriptor language for educational and preparation use is generally accepted under fair-dealing / fair-use principles. Verbatim reproductions in the companion documents are clearly attributed and quoted.
+- **Cambridge IELTS volumes 1–19**: copyrighted past-paper compilations. Not reproduced verbatim. Used only as a pattern source.
+- **Council of Europe CEFR Companion Volume**: open-licence non-commercial reproduction permitted. Quotations attributed.
+- **gov.uk SELT page**: Crown copyright, Open Government Licence v3.0. Reproduction with attribution permitted.
+- **HFF-authored content** (course-ref.md, all `ielts-speaking-*.md` companion documents): original content authored for HumanFirst Foundation, not reproduced from any third-party source. Owned by HFF.
+
+---
+
+## 9. Verification protocol for future updates
+
+To re-verify any factual claim in the companion documents:
+
+1. Identify the citation tag in the source document (e.g. `_(source: speaking-band-descriptors-cdn.pdf, p. 2)_`).
+2. Locate the entry in this audit trail (Section 2 for in-folder PDFs; Section 1 for URLs; Section 3 for CEFR; Section 4 for UKVI).
+3. Open the source and verify the quoted text appears at the cited page / URL.
+4. If the source has changed (URL moved, PDF updated), record the new location here and update the citation tag.
+
+Sources that may go stale:
+- ielts.org URLs (test-format and marking pages occasionally restructure).
+- cambridgeenglish.org URLs (the CEFR alignment chart has been at the same URL for several years but is not guaranteed stable).
+- takeielts.britishcouncil.org sample pages (occasionally rotated as new sample tasks are released).
+- ielts.idp.com sample pages (regional variants exist; the canonical URL is the global one cited above).
+
+Sources that are stable:
+- The five PDFs in `docs/external/ielts/ielts-speaking/` (versioned 2023; will be replaced when IELTS owners issue a new edition, at which point this audit trail must be updated).
+- CEFR Companion Volume (2020 edition; stable).
+- Cambridge IELTS volumes (each volume is a fixed publication).
+
+---
+
+## 10. Citation tag format used across the companion documents
+
+The companion documents use one of three citation tag forms:
+
+| Tag | Means |
+|-----|-------|
+| `_(source: <PDF filename>, p. N)_` | Verbatim from a PDF in this folder; verify by opening the PDF at page N. |
+| `_(source: <domain> <page title>, accessed 2026-05-08)_` | Live URL. Verify by visiting the URL. |
+| `_(source: HFF-authored; mirrors <reference>)_` | Original HFF content modelled on a published reference. The reference is the pattern source; the content is original. |
+
+Anything not matching these three forms should be treated as `[unsourced — needs review]`. There are no such markers in the current companion documents.

--- a/docs/external/ielts/ielts-speaking/ielts-speaking-test-format.md
+++ b/docs/external/ielts/ielts-speaking/ielts-speaking-test-format.md
@@ -1,0 +1,199 @@
+# IELTS Speaking Test Format
+
+Source: ielts.org test format pages and the *IELTS Guide for Teachers* (Cambridge / British Council / IDP).
+
+The IELTS Speaking test is a face-to-face interview between a single candidate and a single examiner, lasting 11–14 minutes in total. The same test is administered to Academic and General Training candidates — the format and band descriptors are identical for both modules. The interview is recorded for moderation and re-mark purposes.
+
+The test is structured as three Parts of escalating cognitive demand: a warm-up interview on familiar topics, a sustained individual long turn, and an abstract two-way discussion. The examiner follows a set frame of standard questions, but is permitted limited flexibility to probe responses.
+
+---
+
+## Test summary
+
+| Part | Duration | Format | Examiner role | Candidate task |
+|------|----------|--------|---------------|----------------|
+| 1 | 4–5 min | Introduction + interview on familiar topics | Asks scripted questions from a topic frame | Answers, extending where possible |
+| 2 | 3–4 min | Individual long turn from a cue card | Issues task card and timer; minimal interruption | 1 min preparation + 1–2 min monologue |
+| 3 | 4–5 min | Two-way discussion on abstract themes linked to Part 2 | Asks scripted prompts; probes follow-up | Discusses, justifies, speculates |
+
+Total: **11–14 minutes** of recorded interaction. _(source: ielts.org "Speaking test format", accessed 2026-05-08; cross-checked against `ielts-guide-for-teachers.pdf`.)_
+
+---
+
+## Part 1 — Introduction and interview (4–5 minutes)
+
+### Structure
+
+1. **Introduction (~30 seconds).** The examiner introduces themselves, confirms the candidate's identity, and confirms the candidate is ready to begin recording.
+2. **Familiar topic frames (~4 minutes).** The examiner asks two or three sets of questions on familiar topics from a published set. Each frame begins with a signposting line (e.g. "Let's talk about your home town or village.") and contains four to six short questions. _(source: `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+### What the examiner can do
+
+- Read questions exactly as scripted from the official frame.
+- Repeat a question once if the candidate has not understood.
+- Move on if the candidate's response is exhausted before the timer.
+
+### What the examiner cannot do
+
+- Rephrase the question into easier language.
+- Provide vocabulary, gestures, or hints.
+- Comment on the quality of the answer.
+- Ask follow-up questions outside the frame.
+
+### Reference example (Part 1 frame)
+
+> Let's talk about your home town or village.
+> 1. What kind of place is it?
+> 2. What's the most interesting part of your town/village?
+> 3. What kind of jobs do the people in your town/village do?
+> 4. Would you say it's a good place to live? (Why?)
+>
+> Let's move on to talk about accommodation.
+> 5. Tell me about the kind of accommodation you live in?
+> 6. How long have you lived there?
+> 7. What do you like about living there?
+> 8. What sort of accommodation would you most like to live in?
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+### What it tests
+
+Per the official descriptor: "the ability to communicate opinions and information on everyday topics and common experiences or situations by answering a range of questions" _(source: ielts.org "Speaking test format", accessed 2026-05-08)_.
+
+Part 1 is the lowest-stakes Part for the candidate and the lowest-density evidence stream for the examiner — short turns reveal less about Grammatical Range than the Part 2 monologue. However, Part 1 sets the examiner's baseline reading on Pronunciation and Fluency.
+
+---
+
+## Part 2 — Individual long turn (3–4 minutes total)
+
+### Structure
+
+1. **Card issue.** The examiner reads the cue card aloud, hands a printed copy to the candidate, and provides a pencil and paper for notes.
+2. **Preparation (1 minute).** The candidate has exactly one minute to prepare. They may make notes; they may not write a full script. The examiner is silent during this minute.
+3. **Long turn (1–2 minutes).** The candidate speaks continuously. The examiner does not interrupt unless the candidate stops or strays badly off-topic. The examiner stops the candidate at the 2-minute mark.
+4. **Rounding-off questions (~30 seconds).** After the long turn, the examiner asks one or two short follow-up questions. These are scripted on the cue card and require only brief answers. _(source: `speaking-sample-tasks-2023.pdf`, p. 5.)_
+
+### Cue card structure
+
+Every Part 2 cue card follows the same template:
+
+```
+Describe [a person / a place / an object / an event / an experience].
+You should say:
+   [bullet 1 — typically a "where/when/who" detail]
+   [bullet 2 — typically a "how/what/why" detail]
+   [bullet 3 — typically a context detail]
+and explain [why ... / how ... / what ...].
+```
+
+The final "and explain" bullet is the substantive one — examiners look for it to be addressed in some depth. _(source: `ielts-guide-for-teachers.pdf`; mirrored across published Cambridge IELTS volumes 1–19.)_
+
+### Reference example (Part 2 cue card)
+
+> Describe something you own which is very important to you.
+> You should say:
+>   where you got it from
+>   how long you have had it
+>   what you use it for
+> and explain why it is important to you.
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 5.)_
+
+### What the examiner can do
+
+- Repeat the task card prompt.
+- Stop the candidate at the 2-minute mark.
+- Ask the scripted rounding-off questions.
+
+### What the examiner cannot do
+
+- Provide topic ideas or vocabulary.
+- Coach the candidate during preparation.
+- Allow the candidate more than one minute of preparation.
+
+### What it tests
+
+Per the official descriptor: "the ability to speak at length on a given topic, using appropriate language and organising ideas coherently" _(source: ielts.org "Speaking test format", accessed 2026-05-08)_.
+
+Part 2 is the richest scoring opportunity in the test. Sustained monologue exposes Grammatical Range, Lexical Resource, and the candidate's ability to organise extended discourse without interlocutor support. A weak Part 2 typically caps the band at 6.
+
+---
+
+## Part 3 — Two-way discussion (4–5 minutes)
+
+### Structure
+
+The examiner introduces Part 3 with a signposting line that links to the Part 2 topic, then asks four to six abstract discussion questions. Questions probe opinion, comparison, hypothesis, prediction, cause-and-effect, and evaluation. The examiner is permitted slightly more flexibility than in Parts 1 and 2 — they may ask one unscripted follow-up to probe a thin response. _(source: `speaking-sample-tasks-2023.pdf`, p. 6; `ielts-guide-for-teachers.pdf`.)_
+
+### Reference example (Part 3 frame)
+
+> We've been talking about things we own. I'd like to discuss with you one or two more general questions relating to this topic.
+>
+> First, let's consider how people's values have changed.
+> 1. What kind of things give status to people in your country?
+> 2. Have things changed since your parents' time?
+>
+> Finally, let's talk about the role of advertising.
+> 3. Do you think advertising influences what people buy?
+>
+> _(source: `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+### What the examiner can do
+
+- Ask scripted prompts.
+- Ask a single unscripted follow-up to probe an answer ("Can you tell me a little bit more about that?").
+- Reframe a question if the candidate misunderstands the abstract level.
+
+### What the examiner cannot do
+
+- Debate the candidate's opinion.
+- Indicate agreement or disagreement.
+- Coach hedging or speculative language.
+
+### What it tests
+
+Per the official descriptor: "the ability to express and justify opinions and to analyse, discuss and speculate about issues" _(source: ielts.org "Speaking test format", accessed 2026-05-08)_.
+
+Part 3 is the discriminator between Band 6 and Band 7+. Candidates who can only produce concrete, personal answers will plateau at Band 6 on Lexical Resource and Grammatical Range; Band 7+ requires hedging, conditional structures, and abstract noun phrases.
+
+---
+
+## Recording, scoring, and re-mark
+
+- Every Speaking test is audio-recorded for moderation. Recordings are retained by the test centre.
+- The examiner scores the candidate during and immediately after the test against the published nine-band descriptors.
+- Each of the four criteria is scored independently. The four scores are averaged to a half band and reported as the overall Speaking band.
+- Candidates who believe they have been mis-scored may request an Enquiry on Results (EOR), which triggers a remark from a different senior examiner. Speaking remarks are common because the recording is the primary evidence.
+- _(source: ielts.org "After the test" / "Enquiry on Results" pages, accessed 2026-05-08.)_
+
+---
+
+## Examiner certification (context for tutors)
+
+IELTS examiners are recruited and certified by IDP, British Council, or Cambridge English. They must hold a teaching qualification (CELTA / DELTA / equivalent) and a minimum of three years' adult teaching experience. They are re-certified every two years and standardised against benchmark recordings. _(source: ielts.org "How IELTS is marked" page; `ielts-guide-for-teachers.pdf`.)_
+
+This matters for the AI tutor: the examiner-as-coach mental model the tutor adopts must be calibrated against the same benchmarks used by real examiners. Use the published descriptors verbatim when explaining a score.
+
+---
+
+## Implications for AI tutoring
+
+| Test feature | Tutoring implication |
+|--------------|---------------------|
+| 11–14 minutes total | A single tutoring call can cover one Part in depth or two Parts in survey |
+| Examiner cannot rephrase or coach | The tutor in exam-simulation mode must replicate this — no help during the response |
+| Part 2 has 1 minute prep | Always enforce the 1-minute timer; many candidates skip prep and pay for it in fluency |
+| Recording is primary evidence | The tutor's own transcript is the equivalent — score from what was actually said, not what the tutor inferred |
+| Average across Parts is the reported band | Sample across all three Parts before stating a stable band estimate |
+| EORs frequently change Speaking scores | Bands at the half-band boundary (e.g. 6.5 vs 7) are inherently noisy — communicate uncertainty |
+
+---
+
+## Sources
+
+- ielts.org — "IELTS Speaking test format" page. https://www.ielts.org/for-test-takers/test-format (accessed 2026-05-08).
+- ielts.org — "How IELTS is marked" page. https://www.ielts.org/for-test-takers/how-ielts-is-marked (accessed 2026-05-08).
+- ielts.org — "Enquiry on Results" page. https://www.ielts.org/for-test-takers/results/enquiry-on-results (accessed 2026-05-08).
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 3–7.
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking section.
+- Cambridge English — "How IELTS is assessed" page. https://www.cambridgeenglish.org/exams-and-tests/ielts/ (accessed 2026-05-08).

--- a/docs/external/ielts/ielts-speaking/wizard-prompt.md
+++ b/docs/external/ielts/ielts-speaking/wizard-prompt.md
@@ -1,0 +1,82 @@
+# IELTS Speaking Practice — Wizard Prompt
+
+Paste this prompt into the V5 wizard chat. Upload the listed docs when prompted.
+
+---
+
+## Wizard prompt
+
+```
+I'm setting up an IELTS Speaking preparation course.
+
+Institution: IELTS Prep Lab
+Type: Language school
+Subject: IELTS Speaking
+Course name: IELTS Speaking Practice
+Audience: higher-ed
+
+The learners are adults preparing for the IELTS Academic or General Training exam, typically targeting Band 6.5–7.5. Most are non-native English speakers aiming for university admission or professional registration. The Speaking test is identical for both Academic and General Training.
+
+Teaching approach: socratic — the student speaks, the AI examines and coaches through targeted questions. Never answer for the student.
+
+Calls: ~12 × 20 minutes (continuous — no fixed plan, the system adapts to the learner)
+Coverage: depth — better to master two Speaking Parts than skim all three.
+
+Learning outcomes:
+- Speak fluently for 2+ minutes on an unfamiliar topic with minimal hesitation
+- Extend Part 1 answers beyond one sentence with reasons, examples, and personal experience
+- Structure a Part 2 monologue using all cue card bullet points with logical progression
+- Engage in abstract Part 3 discussion using hedging, speculation, and balanced argument
+- Use a range of discourse markers naturally to connect ideas ("having said that", "what I mean is")
+- Deploy topic-specific vocabulary with precision and paraphrase to avoid repetition
+- Produce a range of complex sentence structures accurately in spontaneous speech
+- Self-correct pronunciation errors that impede intelligibility
+
+Assessment targets:
+- Band 7.0+ on Fluency & Coherence
+- Band 6.5+ on Lexical Resource
+- Band 6.5+ on Grammatical Range & Accuracy
+- Band 6.5+ on Pronunciation
+
+Assessment style: formal — track band scores per criterion across calls.
+
+I have teaching documents to upload — the official assessment criteria, the band descriptors, and a course reference with the teaching approach and skills framework.
+```
+
+---
+
+## Documents to upload
+
+Upload all files from this folder during the wizard content step.
+
+| # | File | Document Type | What it provides |
+|---|------|---------------|------------------|
+| 1 | `course-ref.md` | COURSE_REFERENCE | Skills framework (4 IELTS criteria with tiers), Socratic teaching approach, call flow, scoring rules, scaffolding techniques, L1 interference patterns, Part structure, edge cases |
+| 2 | `speaking-key-assessment-criteria.pdf` | COURSE_REFERENCE | What each of the 4 criteria measures — the official scoring rubric definitions |
+| 3 | `speaking-band-descriptors-cdn.pdf` | COURSE_REFERENCE | Band-by-band detail for all 4 criteria (Band 9 down to Band 1) |
+| 4 | `cambridge-speaking-band-descriptors.pdf` | COURSE_REFERENCE | Cambridge public version of band descriptors (alternative format) |
+| 5 | `ielts-speaking-key-assessment-criteria.md` | COURSE_REFERENCE | Markdown version of the 4 criteria with full Band 1–9 descriptors verbatim. Machine-readable scoring rubric. |
+| 6 | `ielts-speaking-test-format.md` | COURSE_REFERENCE | 3-Part structure, timings, examiner protocol, what the interlocutor can/cannot do, recording and re-mark process |
+| 7 | `ielts-speaking-question-types-guide.md` | TEXTBOOK | Taxonomy of question types — Part 1 topic categories, Part 2 cue-card frames, Part 3 abstract patterns with example stems |
+| 8 | `ielts-speaking-question-bank-part1.md` | QUESTION_BANK | 50+ Part 1 topic frames × 4–6 questions each. Tagged by source. |
+| 9 | `ielts-speaking-question-bank-part2.md` | QUESTION_BANK | 88 Part 2 cue cards in the official 4-bullet form, clustered by frame (Person / Place / Object / Event / Experience / Activity) |
+| 10 | `ielts-speaking-question-bank-part3.md` | QUESTION_BANK | 64 Part 3 discussion sets × 4–6 abstract questions each. Organised by 13 themes. Linked to Part 2 topics. |
+| 11 | `ielts-speaking-sample-responses-examiner-comments.md` | TEXTBOOK | Calibration data — Bands 5, 6, 7, 8 sample responses across all 3 Parts with criterion-by-criterion examiner reasoning |
+| 12 | `ielts-speaking-language-toolkit.md` | TEXTBOOK | Phrase banks for Band 6→7→8: discourse markers, hedging, paraphrase, opinion, signposting, idiomatic chunks, collocations, conditional structures, pronunciation features. Tied to which criterion each lifts. |
+| 13 | `ielts-speaking-cefr-mapping.md` | REFERENCE | IELTS Band ↔ CEFR level table with criterion-by-criterion crosswalk to CEFR Companion Volume sub-scales. UKVI / SELT recognition note. |
+
+---
+
+## Expected hierarchy after creation
+
+```
+IELTS Prep Lab (Institution)
+  └─ IELTS (Domain)
+       └─ IELTS Speaking (Subject)
+            └─ IELTS Speaking Practice (Playbook)
+                 └─ Curriculum (auto-generated)
+                      Module: Part 1 — Familiar Topics
+                      Module: Part 2 — Cue Card Monologues
+                      Module: Part 3 — Abstract Discussion
+                      ... (AI decides from content)
+```


### PR DESCRIPTION
## Summary

Adds 10 markdown docs to `docs/external/ielts/ielts-speaking/` to bring parity with the `ielts-writing-task-2` sibling and provide the full content pack for the IELTS Speaking course wizard ingestion.

## What's new

| File | Role |
|------|------|
| `ielts-speaking-key-assessment-criteria.md` | 4 criteria, Band 0–9 verbatim Cambridge descriptors |
| `ielts-speaking-test-format.md` | 3-Part structure, examiner protocol, timings |
| `ielts-speaking-question-types-guide.md` | Part 1 / 2 / 3 question-type taxonomy |
| `ielts-speaking-question-bank-part1.md` | 52 topic frames × 4–6 questions (target 50) |
| `ielts-speaking-question-bank-part2.md` | 88 cue cards in 4-bullet form (target 80) |
| `ielts-speaking-question-bank-part3.md` | 64 discussion sets × 4–6 questions (target 60) |
| `ielts-speaking-sample-responses-examiner-comments.md` | Bands 5/6/7/8 calibrated against Cambridge descriptors |
| `ielts-speaking-language-toolkit.md` | Phrase banks for the 6→7→8 band transitions |
| `ielts-speaking-cefr-mapping.md` | Band ↔ CEFR table cross-walked to Companion Volume 2020 sub-scales |
| `ielts-speaking-sources.md` | Consolidated audit trail, 254 citations |

`wizard-prompt.md` updated with 9 new upload-table rows. `course-ref.md` and `wizard-prompt.md` themselves were previously untracked; both now in git.

## Sources

- ielts.org, cambridgeenglish.org, takeielts.britishcouncil.org, ielts.idp.com (joint owners)
- Council of Europe CEFR Companion Volume 2020 (intergovernmental open-licence)
- gov.uk SELT (peripheral, for UKVI recognition note)
- 5 official IELTS PDFs already in the folder (band descriptors, key assessment criteria, sample tasks 2023, teacher's guide)
- Cambridge IELTS volumes 1–19 referenced as pattern source only — no verbatim reproduction

Question banks are HFF-authored; the only verbatim exam content comes from the publicly-released `speaking-sample-tasks-2023.pdf`.

## Verification done

- Spot-checked 4 docs (criteria, QB Part 2, sample-responses, CEFR mapping) — verbatim Cambridge descriptors blockquoted with page refs; HFF-authored cards in correct 4-bullet template.
- Switzerland-candidate transcript band assignment (Band 6/6.5) is HFF analysis cross-referenced against the public descriptors with per-criterion reasoning. ielts.org does not publish a band for this transcript.
- **CEFR Companion Volume page numbers re-verified against the 2020 PDF table of contents** (Council of Europe Publishing, English edition). The agent's initial draft had four wrong page numbers and one wrong scale name (no scale called "Spoken Fluency" — actual scale is "Fluency"); all four corrected before commit.

## IP discipline

- Cambridge band descriptors and ielts.org sample transcripts: verbatim with attribution under fair-use educational reproduction.
- CEFR Companion Volume: paraphrased + attributed under Council of Europe non-commercial open-licence.
- Cambridge IELTS books 1–19: referenced by volume number only, no verbatim cards.
- All question banks: HFF original content.

## Out of scope (not committed)

- The 5 PDFs in the folder remain untracked (consistent with current `docs/external/` policy). Markdown citations reference them by filename + page; clones will not have them unless added separately.

## Test plan

- [ ] Upload the 9 wizard-listed docs into the V5 wizard's content step on a fresh test course
- [ ] Confirm `QUESTION_BANK` and `TEXTBOOK` DocumentTypes route to the expected pipeline stages
- [ ] Confirm extraction picks up the 4 IELTS criteria as Skills
- [ ] Verify the auto-generated curriculum proposes Part 1 / Part 2 / Part 3 modules