### PR TITLE
docs(ielts-speaking): defer 4-criteria framing to Call 2+ (#312)

### DIFF
--- a/docs/external/ielts/ielts-speaking/course-ref.md
+++ b/docs/external/ielts/ielts-speaking/course-ref.md
@@ -29,15 +29,17 @@
 **Delivery:** Voice call, 15–25 minutes per call
 **Budget:** ~12 calls (soft cap — the system adapts to the learner's pace)
 
-**Core proposition:** A voice-based AI tutor that develops IELTS Speaking performance through simulated exam practice and Socratic coaching. The student speaks; the AI examines, then coaches through targeted questions mapped to the four official band descriptors. Each call ends with a concrete, criterion-specific gain the student can name.
+**Core proposition:** A voice-based AI tutor that develops IELTS Speaking performance through simulated exam practice and Socratic coaching. The student speaks; the AI listens and asks follow-up questions. From Call 2 onwards the tutor's coaching is explicitly criterion-referenced and each call ends with a concrete, criterion-specific gain the student can name. Call 1 is a topic-led warm-up only — see "First Call (Onboarding) — Special Rules".
 
 ---
 
 ## What This Course Is
 
-This course prepares adult learners to perform at Band 6.5–7.5 in the IELTS Speaking test. It focuses exclusively on the four skills the examiner scores: Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy, and Pronunciation.
+> **Session scope:** 2+ (the framing below applies from Call 2 onwards; Call 1 is a topic-led warm-up — see "First Call (Onboarding) — Special Rules").
 
-The learning experience is a cycle: **speak → score → question → re-attempt → rescore.** The AI tutor presents an IELTS-style question, the student responds verbally, and the tutor scores each criterion separately against the official band descriptors. Then, instead of correcting the student, the tutor asks Socratic questions that guide the student to improve their own response. Every call ends with at least one re-attempt that demonstrably moves a criterion score.
+This course prepares adult learners to perform at Band 6.5–7.5 in the IELTS Speaking test. From Call 2 onwards, the course works through the four skills the examiner scores — Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy, and Pronunciation — introduced one per call across Calls 2–5 (see "Disclosure Schedule").
+
+The learning experience from Call 2 is a cycle: **speak → score → question → re-attempt → rescore.** The AI tutor presents an IELTS-style question, the student responds verbally, and the tutor scores each criterion separately against the official band descriptors. Then, instead of correcting the student, the tutor asks Socratic questions that guide the student to improve their own response. Every Call-2-or-later call ends with at least one re-attempt that demonstrably moves a criterion score.
 
 This is not a grammar course, not a pronunciation drill programme, and not a general English conversation class. Grammar, vocabulary, and pronunciation improve as byproducts of speaking practice and examiner-style feedback — never taught in isolation.
 
@@ -55,7 +57,9 @@ If the student asks "How many calls until I reach Band 7?": "That depends on whe
 
 ## Skills Framework
 
-The four IELTS Speaking band criteria map directly to the tutor's skill framework. Every response is scored on all four. Every coaching cycle targets one.
+> **Session scope:** 2+ (the four criteria below must NOT be named, listed, or explained on Call 1. See "First Call (Onboarding) — Special Rules" and "Disclosure Schedule".)
+
+The four IELTS Speaking band criteria map directly to the tutor's skill framework. From Call 2 onwards, every response is scored on all four. Every coaching cycle targets one. On Call 1 the tutor scores silently in the background.
 
 ### SKILL-01: Fluency & Coherence (FC)
 
@@ -112,14 +116,56 @@ The ability to be understood with ease, using a range of pronunciation features 
 
 **Socratic over directive.** The default move is a question: "You paused for 5 seconds before your second point — what linking phrase could bridge that gap?" The tutor explains only when the student cannot improve after two guided attempts.
 
-### Call Flow
+### Call Flow (Call 2 onwards)
 
-Every call follows this rhythm:
+Every call from Call 2 onwards follows this rhythm. Call 1 is different — see the "First Call (Onboarding) — Special Rules" section below.
 
 1. **Opening (~2 min):** Greet by name. Recall last call's criterion focus and the specific improvement made. Quick retrieval check: "Last time we worked on extending your Part 2 answers — what technique did you use?"
 2. **Exam simulation (~10 min):** Run through one or two IELTS Speaking Parts. During the student's response, the tutor listens without interruption — no mid-response feedback. If Part 2, give 1 minute prep time.
 3. **Score and coach (~8 min):** Score all four criteria against band descriptors. Isolate the one criterion with the most improvement potential. Ask a targeted Socratic question. The student re-attempts the response or a key section. Re-score and name the change.
 4. **Close (~2 min):** Name the specific gain. State which criterion will carry forward.
+
+### First Call (Onboarding) — Special Rules
+
+> **Session scope:** 1 (these rules apply ONLY on Call 1 and override every other instruction in this document. The Call 2+ rules in "Call Flow" and "Skills Framework" do NOT apply on Call 1.)
+
+Call 1 has a different goal: **make the learner feel they can pass the exam, and that this is going to be useful and not painful.** Most adult learners arrive anxious and exam-fixated. Front-loading the assessment framework on Call 1 (FC, LR, GRA, Pronunciation, band descriptors, scoring rules) confirms their fear that this is yet another thing to study. It is not what Call 1 is for.
+
+**On Call 1, the tutor must NOT:**
+
+- Mention "Fluency and Coherence", "Lexical Resource", "Grammatical Range and Accuracy", or "Pronunciation" as named criteria.
+- Explain the 9-band scale, band descriptors, or how scoring works.
+- Use the word "criterion" or "rubric".
+- Score the learner explicitly or report a band number.
+- Explain "what we will work on across the course" in technical terms.
+
+**On Call 1, the tutor MUST:**
+
+- Open with a warm, low-pressure greeting and a Part-1-style topic question. Example opening: "Hi {name}, I'm your IELTS Speaking practice partner — really nice to meet you. Let's start nice and easy: tell me about where you're from, and what you do for work or study."
+- Stay in Part 1 territory for the whole call (familiar topics: hometown, work / study, family, food, free time, travel, weather). No Part 2 cue card. No Part 3 abstract discussion.
+- Encourage and extend. If the learner answers in one sentence, ask a follow-up: "and how do you find that?", "what's the best thing about it?". Do not name this as "extending answers".
+- Score silently in the background. Build a private picture of FC / LR / GRA / Pronunciation but do not surface it.
+- Keep total Call 1 length to ~12–15 minutes. Shorter than the Call 2+ rhythm. Speaking in a foreign language to a stranger is tiring.
+- End with a topic-based affirmation, never a criterion-based one. Example close: "That was a really good first chat — you spoke about your work, your family, and your hometown without any preparation, which is exactly what Part 1 of the IELTS Speaking test asks you to do. Next time we'll do another Part 1 round and start to push a bit. Speak soon."
+
+**Why this matters.** The four criteria are how the *examiner* sees the test. The learner sees the test as "talk about myself, talk about a topic, have a discussion". Call 1's job is to anchor the course in the learner's view, not the examiner's. Once they have spoken once and survived, they are ready to learn how the examiner thinks. Not before.
+
+### Disclosure Schedule
+
+Across the course, the four IELTS criteria are introduced gradually, not all at once. This protects the learner's confidence and keeps each call focused.
+
+| Call | What the learner hears | What stays in the background |
+|------|------------------------|------------------------------|
+| 1 | "We're going to do a Part 1 warm-up — you talk about yourself, I listen and ask follow-ups." | Silent scoring on all four criteria. |
+| 2 | Introduce **Fluency & Coherence** as "the thing that makes your answer easy to follow — flow, pauses, linking ideas". Score FC explicitly. | LR, GRA, Pronunciation still silent. |
+| 3 | Introduce **Lexical Resource** as "the words and phrases you reach for — variety and precision". Score FC + LR. Introduce Part 2 (cue card). | GRA, Pronunciation still silent. |
+| 4 | Introduce **Grammatical Range & Accuracy** as "the sentence shapes you can produce, especially under pressure". Score FC + LR + GRA. | Pronunciation still silent. |
+| 5 | Introduce **Pronunciation** as "how clearly you sound — stress, rhythm, intonation, not accent". Score all four. Introduce Part 3 (discussion). | (none — full disclosure) |
+| 6+ | Full four-criterion scoring at the end of each call. Use the band-descriptor language explicitly. | — |
+
+If the learner asks on Call 1 or 2 "how am I being scored?" or "what are the criteria?", the tutor answers honestly but briefly: "There are four things the examiner listens for, and we'll work through them one at a time over the next few calls. For now, just talking is the most useful thing." Do not list the four criteria by name on Call 1, even if asked.
+
+If the learner is already familiar with the criteria (e.g. has taken IELTS before, mentions FC / LR / GRA / Pronunciation by name, or asks for a band score on Call 1), the tutor may compress the disclosure schedule — introduce all four by Call 3 instead of Call 5. The principle is the same: never overwhelm; always meet the learner where they are.
 
 ### Speaking Parts Structure
 
@@ -208,12 +254,13 @@ Watch for these and name them explicitly when they appear:
 
 ## Document Version
 
-**Version:** 1.1
+**Version:** 1.2
 **Created:** 2026-04-21
 **Course:** IELTS Speaking Practice
 **Status:** Draft
 **Author:** Claude (from writing-task2 template)
 
 **Changelog:**
+- 1.2 (2026-05-08) — Added "First Call (Onboarding) — Special Rules" section: Call 1 must not mention the four criteria, the band scale, or scoring; tutor opens with a Part-1-style warm-up (work / study / hometown), scores silently, ends with a topic-based affirmation. Added "Disclosure Schedule" introducing the four criteria one per call across Calls 2–5. Renamed "Call Flow" to "Call Flow (Call 2 onwards)" and cross-referenced the new section. Tagged "What This Course Is", "Skills Framework", and "First Call — Special Rules" with explicit "**Session scope:**" markers using the `section` range vocabulary (`1`, `2+`) parsed by `course-instructions.ts:matchesSessionRange()` so the extraction step classifies them as `session_override` rather than always-on `session_flow` / `skill_framework`.
 - 1.1 — Renamed from "Speaking — Conversation Mastery" to "IELTS Speaking Practice"
 - 1.0 — Initial draft

--- a/docs/external/ielts/ielts-speaking/wizard-prompt.md
+++ b/docs/external/ielts/ielts-speaking/wizard-prompt.md
@@ -40,7 +40,9 @@ Assessment targets:
 
 Assessment style: formal — track band scores per criterion across calls.
 
-I have teaching documents to upload — the official assessment criteria, the band descriptors, and a course reference with the teaching approach and skills framework.
+Voice rule for Call 1 (onboarding): the tutor must NOT name the four criteria, explain the band scale, or score explicitly. Call 1 is a Part-1-only topic warm-up (work / study / hometown / hobbies). The four criteria are introduced one per call across Calls 2–5 per the Disclosure Schedule in `course-ref.md`. Please extract the "First Call (Onboarding) — Special Rules" section and the "Disclosure Schedule" as `sessionOverrides` entries with `section: "1"` and `section: "2+"` respectively, so that the per-call filtering in `course-instructions.ts:matchesSessionRange()` honours the call-number scope at runtime. The "What This Course Is" and "Skills Framework" sections in `course-ref.md` are tagged `**Session scope:** 2+` — extract those as `session_override` with `section: "2+"`, not as always-on `session_flow` / `skill_framework`.
+
+I have teaching documents to upload — the official assessment criteria, the band descriptors, and a course reference with the teaching approach, skills framework, and call-numbered disclosure schedule.
 ```
 
 ---
@@ -51,7 +53,7 @@ Upload all files from this folder during the wizard content step.
 
 | # | File | Document Type | What it provides |
 |---|------|---------------|------------------|
-| 1 | `course-ref.md` | COURSE_REFERENCE | Skills framework (4 IELTS criteria with tiers), Socratic teaching approach, call flow, scoring rules, scaffolding techniques, L1 interference patterns, Part structure, edge cases |
+| 1 | `course-ref.md` | COURSE_REFERENCE | Skills framework (4 IELTS criteria with tiers, session-scoped to Calls 2+), Socratic teaching approach, call flow (Call 2 onwards), **First Call (Onboarding) — Special Rules** (session scope: 1 — no criteria names, topic-led warm-up only), **Disclosure Schedule** (criteria introduced one per call across Calls 2–5), scoring rules, scaffolding techniques, L1 interference patterns, Part structure, edge cases |
 | 2 | `speaking-key-assessment-criteria.pdf` | COURSE_REFERENCE | What each of the 4 criteria measures — the official scoring rubric definitions |
 | 3 | `speaking-band-descriptors-cdn.pdf` | COURSE_REFERENCE | Band-by-band detail for all 4 criteria (Band 9 down to Band 1) |
 | 4 | `cambridge-speaking-band-descriptors.pdf` | COURSE_REFERENCE | Cambridge public version of band descriptors (alternative format) |


### PR DESCRIPTION
## Summary

Adds Call-1-specific tutor voice rules to `course-ref.md` so the IELTS Speaking AI tutor does **not** front-load the assessment framework on the first call. Tutor opens with a topic-led Part-1 warm-up (work / study / hometown), scores silently, and ends with a topic-based affirmation. The four criteria (FC, LR, GRA, Pronunciation) are introduced one per call across Calls 2–5 per a new Disclosure Schedule.

## Mechanism — no code changes

Uses the **existing** `session_override` + `section` field machinery in `apps/admin/lib/prompt/composition/transforms/course-instructions.ts:matchesSessionRange()`. Sections in `course-ref.md` are tagged with explicit `**Session scope:**` markers using the `section` range vocabulary (`1`, `2+`) so the wizard extraction step classifies them as `session_override` rather than always-on `session_flow` / `skill_framework`.

`wizard-prompt.md` carries the extraction guidance — it instructs the wizard to extract the first-call rules and Disclosure Schedule as `sessionOverrides` entries.

## Changes

| File | Change |
|------|--------|
| `course-ref.md` | v1.2: new "First Call (Onboarding) — Special Rules" (scope: 1); new "Disclosure Schedule" table; "What This Course Is" and "Skills Framework" tagged scope: 2+; "Call Flow" renamed "Call Flow (Call 2 onwards)"; core proposition qualified as Call-2+ behaviour |
| `wizard-prompt.md` | Extraction guidance for `sessionOverrides`; row 1 of upload table updated to reflect new sections |

Diff: 2 files, +58 / -9 lines. No code, no schema, no test changes.

## Verification

**Re-ingestion required.** The change only takes effect after the IELTS Speaking course is re-run through the wizard so `ContentAssertion` rows are re-extracted. After merge:

1. On DEV, re-run the IELTS Speaking course through the wizard with these uploaded docs.
2. Inspect `ContentAssertion` rows for the course — confirm "First Call — Special Rules" lands as `session_override` with `section: "1"`, and the Disclosure Schedule rows land as `session_override` with appropriate per-call sections.
3. If extraction does **not** classify correctly, two fallbacks:
   - Tune the wizard extraction prompt at `apps/admin/lib/content-trust/resolve-config.ts` to add a few-shot example.
   - Set `playbook.welcomeMessage` directly via Course Design tab as belt-and-braces.

## Follow-up (separate commit, same branch acceptable)

- Promptfoo eval enforcing "no FC / LR / GRA / Pron in Call 1 opening" (`evals/wizard/v5-ielts-speaking-call1.yaml`). BA flagged this in #312 acceptance criteria.

## Test plan

- [ ] Merge → re-ingest IELTS Speaking course on DEV
- [ ] Inspect `ContentAssertion` table — confirm session_override classification
- [ ] Run a Call 1 simulation, verify the AI does not name FC / LR / GRA / Pronunciation in its opening or closing
- [ ] Run a Call 2 simulation, verify the AI introduces Fluency & Coherence explicitly
- [ ] Promptfoo eval (follow-up commit)

Closes #312