### PR TITLE
fix(course-pack/analyze): use jsonrepair to parse AI response

### DIFF
--- a/apps/admin/app/api/course-pack/analyze/route.ts
+++ b/apps/admin/app/api/course-pack/analyze/route.ts
@@ -9,6 +9,7 @@ import { getPromptSpec } from "@/lib/prompts/spec-prompts";
 import { interpolateTemplate } from "@/lib/prompts/interpolate";
 import { config } from "@/lib/config";
 import { logAI } from "@/lib/logger";
+import { jsonrepair } from "jsonrepair";
 
 /**
  * @api POST /api/course-pack/analyze
@@ -304,15 +305,16 @@ Analyze these files and group them by subject. Return JSON only.`;
       { sourceOp: "course-pack:analyze" },
     );
 
-    // Parse AI response
+    // Parse AI response — wrap with jsonrepair to handle truncated strings,
+    // trailing commas, single quotes, etc. Mirrors the established pattern in
+    // base-extractor.ts:475 and generate-mcqs.ts:945.
     const raw = typeof result === "string" ? result : result?.content || "";
     const responseText = raw.trim();
-    let jsonStr = responseText.startsWith("{")
+    const jsonStr = responseText.startsWith("{")
       ? responseText
       : responseText.replace(/^```json?\n?/, "").replace(/\n?```$/, "");
-    jsonStr = jsonStr.replace(/,\s*([}\]])/g, "$1");
 
-    const parsed = JSON.parse(jsonStr) as PackManifest;
+    const parsed = JSON.parse(jsonrepair(jsonStr)) as PackManifest;
 
     // Validate and sanitize the manifest
     const manifest: PackManifest = {


### PR DESCRIPTION
## Bug

Wizard step 0 (`/x/get-started-v5` → \"Tell me about your course\") fails with 500 on `/api/course-pack/analyze` when the AI returns truncated/malformed JSON. Course creation is blocked.

From hf-dev logs 2026-05-08 17:40 UTC:

\`\`\`
[course-pack/analyze] Error: SyntaxError: Unterminated string in JSON at position 3761 (line 97 column 24)
  at JSON.parse (<anonymous>)
  at POST (app/api/course-pack/analyze/route.ts:315:25)
POST /api/course-pack/analyze 500 in 23.3s
\`\`\`

Repro: upload 13 IELTS Speaking content-pack files (~5 MB total) through the V5 wizard. The AI's grouping response is truncated mid-string and `JSON.parse` throws.

## Fix

Replace the route's bespoke cleanup (\"strip markdown fences + remove trailing commas + JSON.parse\") with the **already-established jsonrepair pattern** used in three other places in the codebase:

- \`lib/content-trust/extractors/base-extractor.ts:475\`
- \`lib/assessment/generate-mcqs.ts:945\`
- \`lib/assessment/validate-mcqs.ts\`

\`jsonrepair\` (\`^3.13.2\`, already a dependency) handles truncated strings, trailing commas, single quotes, missing brackets, etc.

## Diff

1 file, +6/-4 lines (mostly comment).

\`\`\`diff
+import { jsonrepair } from \"jsonrepair\";
...
-    let jsonStr = responseText.startsWith(\"{\") ? ... : ...;
-    jsonStr = jsonStr.replace(/,\\s*([}\\]])/g, \"\$1\");
-    const parsed = JSON.parse(jsonStr) as PackManifest;
+    const jsonStr = responseText.startsWith(\"{\") ? ... : ...;
+    const parsed = JSON.parse(jsonrepair(jsonStr)) as PackManifest;
\`\`\`

## Test plan

- [ ] Re-run the V5 wizard step 0 with the same 13 IELTS Speaking files that triggered the 500
- [ ] Confirm 200 response with a valid \`PackManifest\`
- [ ] Confirm wizard advances to the next step
- [ ] (Follow-up) Add a unit test feeding the route a truncated AI response to lock the regression