### PR TITLE
feat(#338): projection provenance migration — Phase 2

### DIFF
--- a/apps/admin/prisma/migrations/20260511_338_projection_provenance/migration.sql
+++ b/apps/admin/prisma/migrations/20260511_338_projection_provenance/migration.sql
@@ -1,0 +1,39 @@
+-- Issue #338 Phase 2 — projection provenance FK on Goal, BehaviorTarget, CurriculumModule.
+--
+-- Adds nullable sourceContentId FK to three tables, enabling the idempotent
+-- COURSE_REFERENCE → DB projection contract documented in:
+--   docs/CONTENT-PIPELINE.md §4 Phase 2.5
+--   docs/ENTITIES.md §6 invariant I7
+--
+-- Scope: NEW courses created on/after 2026-05-12. Pre-existing rows have
+-- NULL sourceContentId and are NOT backfilled. The projection's idempotent
+-- applier (apply-projection.ts, Phase 4) diffs by
+--   (playbookId, sourceContentId, slug/name)
+-- so re-runs against the same source produce empty diffs.
+--
+-- onDelete: SET NULL — direct source-delete leaves projected rows with null
+-- provenance (treated as legacy). The applier owns the explicit deletion
+-- path on doc replace/edit so cascading from the FK isn't needed.
+--
+-- Additive only — no existing data is rewritten. Safe under concurrent writes.
+
+-- Goal
+ALTER TABLE "Goal" ADD COLUMN "sourceContentId" TEXT;
+ALTER TABLE "Goal" ADD CONSTRAINT "Goal_sourceContentId_fkey"
+  FOREIGN KEY ("sourceContentId") REFERENCES "ContentSource"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX "Goal_sourceContentId_idx" ON "Goal"("sourceContentId");
+
+-- BehaviorTarget
+ALTER TABLE "BehaviorTarget" ADD COLUMN "sourceContentId" TEXT;
+ALTER TABLE "BehaviorTarget" ADD CONSTRAINT "BehaviorTarget_sourceContentId_fkey"
+  FOREIGN KEY ("sourceContentId") REFERENCES "ContentSource"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX "BehaviorTarget_sourceContentId_idx" ON "BehaviorTarget"("sourceContentId");
+
+-- CurriculumModule
+ALTER TABLE "CurriculumModule" ADD COLUMN "sourceContentId" TEXT;
+ALTER TABLE "CurriculumModule" ADD CONSTRAINT "CurriculumModule_sourceContentId_fkey"
+  FOREIGN KEY ("sourceContentId") REFERENCES "ContentSource"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX "CurriculumModule_sourceContentId_idx" ON "CurriculumModule"("sourceContentId");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -547,6 +547,13 @@ model BehaviorTarget {
   observationCount Int       @default(0) // How many observations informed this
   lastLearnedAt    DateTime?
 
+  // Projection provenance (#338, NEW courses since 2026-05-12). When this row
+  // was written by applyProjection() from a COURSE_REFERENCE doc, points to the
+  // source. NULL for legacy rows and for non-projected (admin / seed) rows.
+  // See docs/CONTENT-PIPELINE.md §4 Phase 2.5 + docs/ENTITIES.md §6 I7.
+  sourceContentId String?
+  sourceContent   ContentSource? @relation("BehaviorTargetProjection", fields: [sourceContentId], references: [id], onDelete: SetNull)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -557,6 +564,7 @@ model BehaviorTarget {
   @@index([callerIdentityId], map: "BehaviorTarget_callerId_idx")
   @@index([effectiveFrom])
   @@index([effectiveUntil])
+  @@index([sourceContentId])
 }
 
 // =========================
@@ -1190,11 +1198,20 @@ model Goal {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // Projection provenance (#338, NEW courses since 2026-05-12). When this row
+  // was written by applyProjection() from a COURSE_REFERENCE doc, points to
+  // the source. NULL for caller-expressed goals, ADAPT-suggested goals, legacy
+  // playbook-template goals, and admin / seed rows.
+  // See docs/CONTENT-PIPELINE.md §4 Phase 2.5 + docs/ENTITIES.md §6 I7.
+  sourceContentId String?
+  sourceContent   ContentSource? @relation("GoalProjection", fields: [sourceContentId], references: [id], onDelete: SetNull)
+
   @@index([callerId, status])
   @@index([callerId, isAssessmentTarget, status])
   @@index([type])
   @@index([status])
   @@index([playbookId])
+  @@index([sourceContentId])
 }
 
 // CallerPlaybook — Explicit enrollment of a caller in a specific playbook.
@@ -2257,9 +2274,18 @@ model CurriculumModule {
   callerProgress     CallerModuleProgress[]
   calls              Call[]
 
+  // Projection provenance (#338, NEW courses since 2026-05-12). When this
+  // module row was written by applyProjection() from a COURSE_REFERENCE doc's
+  // Modules table, points to the source. NULL for legacy modules and for
+  // modules derived from CURRICULUM extraction.
+  // See docs/CONTENT-PIPELINE.md §4 Phase 2.5 + docs/ENTITIES.md §6 I7.
+  sourceContentId String?
+  sourceContent   ContentSource? @relation("CurriculumModuleProjection", fields: [sourceContentId], references: [id], onDelete: SetNull)
+
   @@unique([curriculumId, slug])
   @@index([curriculumId, sortOrder])
   @@index([isActive])
+  @@index([sourceContentId])
 }
 
 // A measurable learning outcome within a module (e.g., "LO1: Understand mitosis")
@@ -3697,6 +3723,16 @@ model ContentSource {
   subjects        SubjectSource[] // Subjects this source belongs to (legacy scoping)
   playbookSources PlaybookSource[] // Direct course → source link (replaces Subject chain)
   mediaAssets     MediaAsset[] // Media files from this content source
+
+  // Inverse relations for projection provenance (#338, NEW courses since 2026-05-12).
+  // Populated when this source is a COURSE_REFERENCE doc and applyProjection() has
+  // written derived rows. onDelete: SetNull on each FK so direct source-delete
+  // leaves projected rows with null provenance (treat as legacy). The applier
+  // owns the explicit deletion path on doc replace/edit.
+  // See docs/CONTENT-PIPELINE.md §4 Phase 2.5 + docs/ENTITIES.md §6 I7.
+  projectedGoals             Goal[]             @relation("GoalProjection")
+  projectedBehaviorTargets   BehaviorTarget[]   @relation("BehaviorTargetProjection")
+  projectedCurriculumModules CurriculumModule[] @relation("CurriculumModuleProjection")
 
   @@index([trustLevel])
   @@index([documentType])


### PR DESCRIPTION
## Summary

Phase 2 of epic #338. Stacks on top of Phase 1 (PR #339, docs). Adds nullable \`sourceContentId\` FK on \`Goal\`, \`BehaviorTarget\`, \`CurriculumModule\` so the upcoming projection applier (Phase 4) can diff idempotently by \`(playbookId, sourceContentId, slug/name)\`.

This is a pure schema change — no application code uses the column yet. The projection function (Phase 3) and applier (Phase 4) follow in subsequent PRs.

## Migration

\`apps/admin/prisma/migrations/20260511_338_projection_provenance/migration.sql\`:
- \`ALTER TABLE\` on three tables — ADD \`sourceContentId TEXT\` (nullable)
- \`ADD CONSTRAINT\` FK to \`ContentSource(id)\` with \`ON DELETE SET NULL\`
- \`CREATE INDEX\` on each column

Additive only — no existing data is touched.

## migration-checker verdict: ✅ SAFE TO MIGRATE

- No destructive ops
- No data migration needed
- Three active seed scripts (seed-demo-course, seed-english-modules, seed-educator-demo) all omit \`sourceContentId\` and remain compatible
- \`ALTER TABLE ADD COLUMN\` (nullable) + \`ADD CONSTRAINT\` + \`CREATE INDEX\` are safe under concurrent writes
- \`ON DELETE SET NULL\` is the correct choice — the applier owns the explicit delete-on-source-replace path; FK is just graceful degradation if a source is hard-deleted out-of-band

## Index trade-off (flagged for Phase 4)

Ships with single-column \`@@index([sourceContentId])\`. The applier will query by \`WHERE playbookId = ? AND sourceContentId = ?\` — a composite index \`@@index([playbookId, sourceContentId])\` would be more efficient. **Deferred to Phase 4** because:
- The applier isn't built yet (no real query patterns to benchmark against)
- A composite index can be added in a follow-up migration with no data migration

## Test plan

- [ ] Review schema diff — three models gain identical structure
- [ ] Review migration SQL — matches the schema (verified via \`prisma migrate diff\`)
- [ ] After merge, run \`/vm-cpp\` to apply on hf-dev
- [ ] Spot check on hf-dev: \`SELECT column_name FROM information_schema.columns WHERE table_name IN ('Goal', 'BehaviorTarget', 'CurriculumModule') AND column_name = 'sourceContentId';\` returns 3 rows
- [ ] Seed (\`npm run db:seed\`) runs clean

## Deploy

\`/vm-cpp\` (commit + push + migrate + pull + restart on hf-dev VM)

## Refs

Epic: #338. Phase 1: PR #339 (docs). Supersedes #337. Origin: IELTS Speaking pack #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)