### PR TITLE
fix(#338 followup): log create_course exceptions server-side

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -1797,6 +1797,14 @@ export async function executeWizardTool(
           }),
         };
       } catch (err) {
+        // #338 followup — log the error server-side so failed create_course
+        // calls are debuggable. Previously the error went only into the chat
+        // tool response, invisible in server logs. Includes stack so we can
+        // see where the throw originated.
+        console.error(
+          "[wizard-tools] create_course FAILED:",
+          err instanceof Error ? `${err.message}\n${err.stack}` : String(err),
+        );
         return {
           ...base,
           content: JSON.stringify({ ok: false, error: String(err) }),


### PR DESCRIPTION
Phase 6 testing surfaced that `create_course` swallowed exceptions into the chat tool response only — the actual error never hit the server log. Wizard showed a success card; `/x/courses` was empty; no diagnostic.

This patches the catch block to `console.error` the message + stack so future failures are debuggable from `/tmp/hf-dev.log`. Behaviour unchanged.

Trivial — direct merge OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)