### PR TITLE
fix(#348): retag-orphans/retag-mcqs default timeout + cascade

### DIFF
--- a/apps/admin/lib/ai/call-points.ts
+++ b/apps/admin/lib/ai/call-points.ts
@@ -242,6 +242,20 @@ export const CALL_POINTS: CallPointDef[] = [
     defaults: { provider: "claude", model: config.ai.claude.model, temperature: 0.2, maxTokens: 8000, timeoutMs: 120_000 },
   },
   {
+    id: "content-trust.retag-orphans",
+    label: "Content Trust - Retag Orphan Assertions",
+    description: "Re-links orphaned ContentAssertions to LearningOutcomes via AI mapping (reconcile-child-parent generic util)",
+    category: "content-processing",
+    defaults: { provider: "claude", model: config.ai.claude.lightModel, temperature: 0.1, maxTokens: 4000, timeoutMs: 90_000 },
+  },
+  {
+    id: "content-trust.retag-mcqs",
+    label: "Content Trust - Retag MCQ Questions",
+    description: "Re-links orphan MCQ Questions to LearningOutcomes via AI mapping (reconcile-child-parent generic util)",
+    category: "content-processing",
+    defaults: { provider: "claude", model: config.ai.claude.lightModel, temperature: 0.1, maxTokens: 4000, timeoutMs: 90_000 },
+  },
+  {
     id: "content-sources.suggest",
     label: "Materials - Suggest",
     description: "Suggests content source metadata from document text",

--- a/apps/admin/lib/content-trust/reconcile-child-parent.ts
+++ b/apps/admin/lib/content-trust/reconcile-child-parent.ts
@@ -173,13 +173,15 @@ Return the JSON mapping now.`;
             { role: "system", content: systemPrompt },
             { role: "user", content: userPrompt },
           ],
-          maxTokens: 4000,
-          temperature: 0,
         },
         { sourceOp: opts.aiCallPoint },
       );
     } catch (err) {
-      console.error(`[${opts.aiCallPoint}] batch ${i / batchSize} failed:`, err);
+      const droppedIds = batch.map(opts.getChildId);
+      console.error(
+        `[${opts.aiCallPoint}] batch ${i / batchSize} failed — ${batch.length} item(s) left unmatched:`,
+        { droppedIds, err },
+      );
       result.unmatched += batch.length;
       continue;
     }

--- a/apps/admin/tests/lib/content-trust/reconcile-child-parent.test.ts
+++ b/apps/admin/tests/lib/content-trust/reconcile-child-parent.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for reconcile-child-parent.ts — generic child→parent AI retag utility.
+ *
+ * Covers issue #348:
+ * - Error handler logs dropped child IDs (no silent unmatched count)
+ * - Call site does not pass explicit maxTokens / temperature (cascade owns it)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConfiguredMeteredAICompletion: vi.fn(),
+}));
+
+vi.mock("@/lib/metering/instrumented-ai", () => ({
+  getConfiguredMeteredAICompletion: mocks.getConfiguredMeteredAICompletion,
+}));
+
+import { reconcileChildToParent } from "@/lib/content-trust/reconcile-child-parent";
+
+interface Child {
+  id: string;
+  text: string;
+}
+
+interface Parent {
+  ref: string;
+  description: string;
+  id: string;
+}
+
+function makeOpts(overrides: Partial<Parameters<typeof reconcileChildToParent>[0]> = {}) {
+  return {
+    children: [
+      { id: "c1", text: "child one" },
+      { id: "c2", text: "child two" },
+    ] as Child[],
+    parents: [{ ref: "P1", description: "parent one", id: "p1" }] as Parent[],
+    getChildId: (c: Child) => c.id,
+    getChildText: (c: Child) => c.text,
+    getParentRef: (p: Parent) => p.ref,
+    getParentDescription: (p: Parent) => p.description,
+    getParentId: (p: Parent) => p.id,
+    writeFk: vi.fn().mockResolvedValue(undefined),
+    aiCallPoint: "test.retag",
+    childLabel: "items",
+    parentLabel: "buckets",
+    ...overrides,
+  };
+}
+
+describe("reconcileChildToParent — issue #348 hardening", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not pass explicit maxTokens or temperature (cascade owns numeric params)", async () => {
+    mocks.getConfiguredMeteredAICompletion.mockResolvedValue({
+      content: JSON.stringify({ c1: "P1", c2: null }),
+    });
+
+    await reconcileChildToParent(makeOpts() as any);
+
+    const callArgs = mocks.getConfiguredMeteredAICompletion.mock.calls[0][0];
+    expect(callArgs).not.toHaveProperty("maxTokens");
+    expect(callArgs).not.toHaveProperty("temperature");
+    expect(callArgs.callPoint).toBe("test.retag");
+  });
+
+  it("logs dropped child IDs when the AI call fails (not just a count)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.getConfiguredMeteredAICompletion.mockRejectedValue(new Error("Request was aborted."));
+
+    const result = await reconcileChildToParent(makeOpts() as any);
+
+    expect(result.unmatched).toBe(2);
+    expect(result.matched).toBe(0);
+
+    // The error log must include the actual dropped child IDs so operators
+    // can re-run / investigate specific items.
+    const logCalls = errSpy.mock.calls.flat();
+    const logString = JSON.stringify(logCalls);
+    expect(logString).toContain("c1");
+    expect(logString).toContain("c2");
+
+    errSpy.mockRestore();
+  });
+
+  it("still works on the happy path — matches child to parent and writes FK", async () => {
+    const writeFk = vi.fn().mockResolvedValue(undefined);
+    mocks.getConfiguredMeteredAICompletion.mockResolvedValue({
+      content: JSON.stringify({ c1: "P1", c2: null }),
+    });
+
+    const result = await reconcileChildToParent(makeOpts({ writeFk }) as any);
+
+    expect(result.matched).toBe(1);
+    expect(result.unmatched).toBe(1);
+    expect(writeFk).toHaveBeenCalledWith("c1", "p1", expect.any(Number));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #348.

`content-trust.retag-orphans` and `content-trust.retag-mcqs` were aborting mid-batch with TIMEOUT, swallowing whole batches into the unmatched count with no record of which child IDs were dropped. Three root causes:

1. `reconcile-child-parent.ts` pinned `maxTokens=4000` and `temperature=0` explicitly, short-circuiting the AIConfig cascade
2. Neither callPoint was registered in `call-points.ts`, so `timeoutMs` fell to the hardcoded 30s — too tight for 80-item batches, all retries doomed
3. Catch handler incremented `result.unmatched += batch.length` without logging which child IDs were dropped

Changes:
- Register both callPoints in `call-points.ts` with sensible defaults (claude lightModel, temperature 0.1, maxTokens 4000, timeoutMs 90_000)
- Remove explicit `maxTokens` / `temperature` from the call site (cascade owns numeric params per CLAUDE.md rule)
- Log dropped child IDs alongside count + error on AI failure

## Test plan

- [x] New tests/lib/content-trust/reconcile-child-parent.test.ts: asserts no maxTokens/temperature in call args, error handler logs dropped IDs, happy path matching still works
- [x] All 341 content-trust tests pass
- [x] Full unit suite green except pre-existing module-groups failures (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)