### PR TITLE
fix(#352): link uploadSourceIds in create_course existing-path

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -844,6 +844,21 @@ export async function executeWizardTool(
               await applyBehaviorTargets(existingPlaybookId, behaviorTargets);
             }
 
+            // PlaybookSource link (#352) — mirror step 7c from the new-course
+            // branch. Without this, fresh ContentSources uploaded during a
+            // wizard run that lands on the existing-path (duplicate-name reuse
+            // or explicit draftPlaybookId) never get linked to the reused
+            // playbook, so the projection below has no COURSE_REFERENCE to
+            // derive Goals / BehaviorTargets / CurriculumModule from and the
+            // course shows up as "degenerate". `upsertPlaybookSource` is
+            // idempotent so this is safe to call on already-linked sources.
+            if (uploadSourceIds?.length) {
+              const { upsertPlaybookSource } = await import("@/lib/knowledge/domain-sources");
+              for (const srcId of uploadSourceIds) {
+                await upsertPlaybookSource(existingPlaybookId, srcId);
+              }
+            }
+
             // COURSE_REFERENCE projection (#338) — same as the new-course
             // branch (step 7d below). Re-applying the projection on an
             // already-set-up playbook is idempotent, so this is safe even

--- a/apps/admin/tests/lib/content-trust/playbook-source-isolation.test.ts
+++ b/apps/admin/tests/lib/content-trust/playbook-source-isolation.test.ts
@@ -73,5 +73,28 @@ describe("PlaybookSource isolation guards", () => {
       const shouldSyncLegacy = !noSourceIds?.length;
       expect(shouldSyncLegacy).toBe(true);
     });
+
+    it("create_course existing-path must link uploadSourceIds (regression for #352)", async () => {
+      // Issue #352 — when create_course hits the playbook-reuse path
+      // (duplicate name in domain), fresh ContentSources uploaded in the
+      // same wizard run must still get linked to the reused playbook via
+      // upsertPlaybookSource. Without this, the projection (#338) sees no
+      // COURSE_REFERENCE and the course is "degenerate".
+      //
+      // Static check that the existing-path in wizard-tool-executor.ts
+      // contains the same upsertPlaybookSource loop the new-path has.
+      const fs = await import("fs/promises");
+      const path = await import("path");
+      const file = path.resolve(__dirname, "../../../lib/chat/wizard-tool-executor.ts");
+      const src = await fs.readFile(file, "utf8");
+
+      // The fix block in the existing-path uses existingPlaybookId as the
+      // target. Must appear before runProjectionForPlaybook(existingPlaybookId).
+      const projIdx = src.indexOf("await runProjectionForPlaybook(existingPlaybookId)");
+      expect(projIdx).toBeGreaterThan(-1);
+      const before = src.slice(0, projIdx);
+      expect(before).toMatch(/await upsertPlaybookSource\(existingPlaybookId,\s*srcId\)/);
+      expect(before).toMatch(/if \(uploadSourceIds\?\.length\)/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #352.

When `create_course` hit the duplicate-playbook recovery path (`"playbook ... already exists in domain ... reusing"`), fresh `ContentSource`s from the current wizard run never got linked to the reused playbook. The projection layer (#338) then logged `"no COURSE_REFERENCE source linked to playbook=... — course is degenerate"` and the UI showed an empty **Authored Modules** section even though the teacher had just uploaded a COURSE_REFERENCE pack.

## Root cause

Only the new-course branch ran the `upsertPlaybookSource` loop over `uploadSourceIds` (step 7c, ~line 1384). The existing-path (reused playbook OR explicit `draftPlaybookId`, ~line 762) went straight to `runProjectionForPlaybook` without ever wiring the fresh sources in.

## Fix

Mirror step 7c into the existing-path immediately before the projection call. `upsertPlaybookSource` is idempotent so calling it on already-linked sources is a no-op.

## Test plan

- [x] New regression test in `playbook-source-isolation.test.ts` asserts the existing-path source code contains the `upsertPlaybookSource` loop guarded by `if (uploadSourceIds?.length)` and lands *before* the `runProjectionForPlaybook(existingPlaybookId)` call
- [x] Existing playbook-source-isolation + wizard-executor-helper suites pass (15 tests)
- [x] Full unit suite: 3730/3734 (same 4 pre-existing module-groups failures, unrelated)
- [ ] Smoke test on hf-dev VM after merge: create a course with a name that already exists in the same domain → uploaded COURSE_REFERENCE links to the reused playbook → Authored Modules section populates → no `[projection] ... degenerate` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)