### PR TITLE
fix(#354): use ?tab=ai-call (not ?section) on test-learner redirect

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseLearnersTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseLearnersTab.tsx
@@ -199,7 +199,7 @@ export function CourseLearnersTab({ courseId, initialJoinToken, studentProgress 
       });
       const data = await res.json();
       if (data.ok) {
-        const url = `/x/callers/${data.callerId}?section=ai-call`;
+        const url = `/x/callers/${data.callerId}?tab=ai-call`;
         if (newTab && !newTab.closed) {
           newTab.location.href = url;
         } else {


### PR DESCRIPTION
## Summary

Closes #354.

One-character fix. \`handleCreateTestLearner\` in \`CourseLearnersTab\` redirected to \`/x/callers/<id>?section=ai-call\`, but \`CallerDetailPage\` reads the tab from \`searchParams.get("tab")\`. The \`section\` param was silently dropped and the user landed on whichever tab was last in localStorage. From there, the module picker had no \`callerId\` context, so the learner dropdown rendered empty.

## Fix

\`\`\`diff
-        const url = \`/x/callers/\${data.callerId}?section=ai-call\`;
+        const url = \`/x/callers/\${data.callerId}?tab=ai-call\`;
\`\`\`

## Out of scope (follow-up)

The dropdown-vs-sessionStorage \"session reverts to a different learner\" bug is architectural — the module picker shouldn't have a learner dropdown at all when every legitimate entry knows the caller. Filing as a separate story for proper grooming.

## Test plan

- [x] No other \`section=ai-call\` references in the codebase (grep)
- [x] Typecheck passes
- [ ] On hf-dev VM: \"New test learner\" → lands on caller detail page \"AI Call\" tab (not \"What\")
- [ ] Sim flow stays attached to the just-created learner

🤖 Generated with [Claude Code](https://claude.com/claude-code)