### PR TITLE
feat(#357): banner CTA + auto-route + callerId on sim picker (slice 1)

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1391,6 +1391,25 @@ html.light {
   margin-left: 12px;
 }
 
+/* Clickable banner (acts as a CTA) — used on the sim page module-picker invite */
+.hf-banner-clickable {
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  user-select: none;
+  transition: background 120ms ease, transform 120ms ease;
+}
+.hf-banner-clickable:hover {
+  background: color-mix(in srgb, var(--status-info-bg) 60%, var(--status-info-text) 8%);
+}
+.hf-banner-clickable:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+.hf-banner-clickable:active {
+  transform: translateY(1px);
+}
+
 /* Hierarchy Breadcrumb */
 .hf-breadcrumb {
   display: flex;

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -143,8 +143,24 @@ export default function SimConversationPage() {
     const carryParams = new URLSearchParams(searchParams.toString());
     carryParams.delete('requestedModuleId');
     sp.set('returnTo', `/x/sim/${callerId}${carryParams.toString() ? `?${carryParams.toString()}` : ''}`);
+    // #357: thread callerId so the picker page can use it instead of the
+    // (now-being-removed in #356) sessionStorage dropdown fallback.
+    sp.set('callerId', callerId);
     router.push(`/x/student/${playbookId}/modules?${sp.toString()}`);
   }, [callerId, playbookId, router, searchParams]);
+
+  // #357: auto-route to picker on first entry when modulesAuthored=true and
+  // the learner hasn't yet picked a module for this session. Only fires once,
+  // before any past-call activity. Skip if the URL already has a
+  // requestedModuleId (picker round-trip) or no playbook.
+  const hasPastCalls = (caller?.pastCalls?.length ?? 0) > 0;
+  useEffect(() => {
+    if (!playbookId) return;
+    if (!modulesAuthored) return;
+    if (requestedModuleId) return;
+    if (hasPastCalls) return;
+    handlePickModule();
+  }, [playbookId, modulesAuthored, requestedModuleId, hasPastCalls, handlePickModule]);
 
   if (error) {
     return (
@@ -171,12 +187,17 @@ export default function SimConversationPage() {
 
   return (
     <>
-      {requestedModuleId && (
+      {requestedModuleId ? (
         <ModulePickerSelectionBanner
           moduleId={requestedModuleId}
           modules={authoredModules}
         />
-      )}
+      ) : modulesAuthored && playbookId ? (
+        <ModulePickerInviteBanner
+          moduleCount={authoredModules.length}
+          onPick={handlePickModule}
+        />
+      ) : null}
       <SimChat
         callerId={callerId}
         callerName={caller.name}
@@ -231,6 +252,43 @@ function ModulePickerSelectionBanner({
       <strong>Module selected:</strong>
       <span>
         This session will focus on <strong>{label}</strong>. Mastery will be tracked against this module.
+      </span>
+    </div>
+  );
+}
+
+/**
+ * #357: invite banner — shown when the course has authored modules but the
+ * learner hasn't picked one yet for this session. Entire row is a button
+ * so the banner is itself the CTA (was the user's UX feedback: don't show
+ * a passive banner alongside an obscure header icon — let the banner be
+ * the picker entry).
+ */
+function ModulePickerInviteBanner({
+  moduleCount,
+  onPick,
+}: {
+  moduleCount: number;
+  onPick: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onPick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onPick();
+        }
+      }}
+      className="hf-banner hf-banner-info hf-flex hf-items-center hf-gap-8 hf-banner-clickable"
+      aria-label="Pick a module to focus this session"
+    >
+      <strong>Pick a module →</strong>
+      <span>
+        Focus this session on one of {moduleCount > 0 ? `${moduleCount} ` : ''}
+        authored modules so mastery is tracked. Or continue and the system will choose.
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #357 (partial — first slice).

Three coupled fixes on \`/x/sim/[callerId]\`:

1. **\`ModulePickerInviteBanner\`** — pre-pick banner that *is* the CTA. The whole row is \`role=button\`, keyboard-activatable, routes to the picker. Replaces the empty no-banner state that left users with only the obscure Layers icon in the header.

2. **Auto-route on first call** — \`useEffect\` pushes to the picker when \`modulesAuthored=true\`, no \`requestedModuleId\`, and zero past calls. Learner lands in the picker instead of starting an undirected call.

3. **\`handlePickModule\` threads \`?callerId=\`** — closes the gap flagged in #356's audit (no more sessionStorage fallback needed for caller identity).

## Out of scope (follow-up commits or separate PR)

- Status breadcrumb pills above sim chat (Call # · Session · Phase · Module)
- Learner-friendly intro line in system prompt announcing the picker

## Test plan

- [x] Typecheck: no new errors
- [x] Existing playbook-source-isolation regression test still green
- [ ] On hf-dev VM: create a course in learner-picks mode → new test learner → sim auto-opens picker → click a module → returns to sim with focused module
- [ ] Verify the banner is keyboard-activatable (Tab → Enter)
- [ ] Verify courses with \`modulesAuthored=false\` (AI-led) are unaffected

## UI rules

- No inline \`style={}\` for static properties; new \`.hf-banner-clickable\` CSS class added with hover/focus/active states
- Reuses existing \`hf-banner\` / \`hf-banner-info\` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)