### PR TITLE
fix(#357): revert sim auto-route — too aggressive (hotfix)

### DIFF
--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -149,18 +149,10 @@ export default function SimConversationPage() {
     router.push(`/x/student/${playbookId}/modules?${sp.toString()}`);
   }, [callerId, playbookId, router, searchParams]);
 
-  // #357: auto-route to picker on first entry when modulesAuthored=true and
-  // the learner hasn't yet picked a module for this session. Only fires once,
-  // before any past-call activity. Skip if the URL already has a
-  // requestedModuleId (picker round-trip) or no playbook.
-  const hasPastCalls = (caller?.pastCalls?.length ?? 0) > 0;
-  useEffect(() => {
-    if (!playbookId) return;
-    if (!modulesAuthored) return;
-    if (requestedModuleId) return;
-    if (hasPastCalls) return;
-    handlePickModule();
-  }, [playbookId, modulesAuthored, requestedModuleId, hasPastCalls, handlePickModule]);
+  // #357 NOTE: an earlier slice auto-routed to the picker on first entry
+  // when modulesAuthored=true. That created a trap — user couldn't get
+  // back to the sim without picking, even to test an undirected call.
+  // Reverted: the banner CTA below is the non-blocking entry instead.
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

Hotfix on top of #358 (merged). The auto-route useEffect was trapping users in the picker every time they entered the sim.

## Root cause

\`handlePickModule\` is wrapped in \`useCallback\` with deps that change on every navigation. The auto-route \`useEffect\` had \`handlePickModule\` in its deps, so it re-fired after every back-navigation. The "no past calls" gate also evaluates based on calls-with-transcript, so most sims qualified.

## Fix

- Drop the auto-route useEffect
- Keep the banner CTA (still visible, still clickable, still prominent)
- Keep the \`callerId\` threading in \`handlePickModule\`

## Test plan

- [x] Typecheck passes
- [ ] On hf-dev VM: enter sim with \`modulesAuthored=true\`, no requestedModuleId → sees banner CTA, does NOT auto-redirect
- [ ] Click the banner → routes to picker with callerId
- [ ] Back-navigate to sim → still on sim, banner shown, no forced redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)