### PR TITLE
feat(#357): banner consistency — mount picker banners on CallerDetailPage

### DIFF
--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -9,6 +9,7 @@ import { SimChat } from '@/components/sim/SimChat';
 import { useJourneyChat } from '@/hooks/useJourneyChat';
 import { deriveParameterMap } from '@/lib/agent-tuner/derive';
 import type { AgentTunerPill } from '@/lib/agent-tuner/types';
+import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from '@/components/sim/ModulePickerBanners';
 
 interface PastCall {
   transcript: string;
@@ -212,76 +213,5 @@ export default function SimConversationPage() {
   );
 }
 
-/**
- * Selection banner — confirms which module the learner picked. The id is
- * forwarded to POST /api/callers/[id]/calls and persisted as
- * Call.requestedModuleId so the pipeline overrides the scheduler-selected
- * module when computing mastery (#242 Slice 2). The compose-prompt route
- * also reads it (#274 Slice A) to drive the tutor's opening narrative.
- *
- * #274 Slice C:
- * - Replaced inline styles with `hf-banner hf-banner-info` classes
- *   (Guard 6, ui-design-system rule).
- * - Copy: "Next session" → "This session" (the picker's choice IS for
- *   THIS session, not the next one).
- * - Resolves module label from authored config; falls back to id.
- */
-function ModulePickerSelectionBanner({
-  moduleId,
-  modules,
-}: {
-  moduleId: string;
-  modules: Array<{ id: string; label?: string }>;
-}) {
-  const matched = modules.find((m) => m.id === moduleId);
-  const label = matched?.label || moduleId;
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      className="hf-banner hf-banner-info hf-flex hf-items-center hf-gap-8"
-    >
-      <strong>Module selected:</strong>
-      <span>
-        This session will focus on <strong>{label}</strong>. Mastery will be tracked against this module.
-      </span>
-    </div>
-  );
-}
-
-/**
- * #357: invite banner — shown when the course has authored modules but the
- * learner hasn't picked one yet for this session. Entire row is a button
- * so the banner is itself the CTA (was the user's UX feedback: don't show
- * a passive banner alongside an obscure header icon — let the banner be
- * the picker entry).
- */
-function ModulePickerInviteBanner({
-  moduleCount,
-  onPick,
-}: {
-  moduleCount: number;
-  onPick: () => void;
-}) {
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onPick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onPick();
-        }
-      }}
-      className="hf-banner hf-banner-info hf-flex hf-items-center hf-gap-8 hf-banner-clickable"
-      aria-label="Pick a module to focus this session"
-    >
-      <strong>Pick a module →</strong>
-      <span>
-        Focus this session on one of {moduleCount > 0 ? `${moduleCount} ` : ''}
-        authored modules so mastery is tracked. Or continue and the system will choose.
-      </span>
-    </div>
-  );
-}
+// Banner components moved to components/sim/ModulePickerBanners.tsx (#357)
+// so the admin caller-detail surface can reuse them.

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -11,6 +11,7 @@ import { FancySelect, type FancySelectOption } from "@/components/shared/FancySe
 import { SectionSelector, useSectionVisibility } from "@/components/shared/SectionSelector";
 import { CallerDomainSection } from "@/components/callers/CallerDomainSection";
 import { SimChat } from "@/components/sim/SimChat";
+import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from "@/components/sim/ModulePickerBanners";
 import '@/app/x/sim/sim.css';
 import './caller-detail-page.css';
 import './caller-detail/lens.css';
@@ -110,6 +111,9 @@ export default function CallerDetailPage() {
   // #253-follow-up: surface "Pick module" header button when the active
   // playbook has authored modules. Mirrors /x/sim/[callerId] wiring.
   const [modulesAuthored, setModulesAuthored] = useState<boolean>(false);
+  // #357: authored modules — needed so the selection banner can resolve a
+  // human label for the module id rather than show the raw id.
+  const [authoredModules, setAuthoredModules] = useState<Array<{ id: string; label?: string }>>([]);
   const requestedModuleId = searchParams.get("requestedModuleId") || undefined;
   const [progressVis, toggleProgressVis] = useSectionVisibility("caller-progress", {
     scores: true, behaviour: true, goals: true, exam: true,
@@ -408,9 +412,18 @@ export default function CallerDetailPage() {
         if (cancelled || !pbData?.ok) return;
         const cfg = (pbData.playbook?.config as Record<string, unknown> | null) ?? {};
         setModulesAuthored(cfg.modulesAuthored === true);
+        // #357: also surface the authored module list for the banner label.
+        if (Array.isArray(cfg.modules)) {
+          setAuthoredModules(cfg.modules as Array<{ id: string; label?: string }>);
+        } else {
+          setAuthoredModules([]);
+        }
       })
       .catch(() => {
-        if (!cancelled) setModulesAuthored(false);
+        if (!cancelled) {
+          setModulesAuthored(false);
+          setAuthoredModules([]);
+        }
       });
     return () => {
       cancelled = true;
@@ -1141,6 +1154,19 @@ export default function CallerDetailPage() {
 
       {simChatMounted && (
         <div className={activeSection === "ai-call" ? undefined : "hf-hidden"}>
+          {/* #357: mirror the sim-view module-picker banners so the admin
+              caller-detail surface gives the same signals as /x/sim/[id]. */}
+          {requestedModuleId ? (
+            <ModulePickerSelectionBanner
+              moduleId={requestedModuleId}
+              modules={authoredModules}
+            />
+          ) : modulesAuthored && selectedPlaybookId && selectedPlaybookId !== "all" ? (
+            <ModulePickerInviteBanner
+              moduleCount={authoredModules.length}
+              onPick={handlePickModule}
+            />
+          ) : null}
           <SimChat
             key={callSession}
             callerId={callerId}

--- a/apps/admin/components/sim/ModulePickerBanners.tsx
+++ b/apps/admin/components/sim/ModulePickerBanners.tsx
@@ -1,0 +1,74 @@
+/**
+ * Module-picker banners — shared between the standalone sim view
+ * (/x/sim/[callerId]) and the admin caller detail page's AI Call tab
+ * (CallerDetailPage). Each surface mounts the same components so the
+ * learner sees identical state regardless of the route they entered from.
+ *
+ * - ModulePickerSelectionBanner — renders when a module was just picked
+ *   (URL carries ?requestedModuleId=). Confirms the choice and resolves
+ *   the human label from the authored module config.
+ * - ModulePickerInviteBanner — renders when no module is picked yet but
+ *   modulesAuthored=true on the playbook. The entire row is role=button,
+ *   keyboard-activatable, and routes to the picker on click. Replaces the
+ *   prior pattern where the only entry was an obscure header Layers icon.
+ *
+ * Issue #357.
+ */
+
+interface AuthoredModule {
+  id: string;
+  label?: string;
+}
+
+export function ModulePickerSelectionBanner({
+  moduleId,
+  modules,
+}: {
+  moduleId: string;
+  modules: AuthoredModule[];
+}) {
+  const matched = modules.find((m) => m.id === moduleId);
+  const label = matched?.label || moduleId;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="hf-banner hf-banner-info hf-flex hf-items-center hf-gap-8"
+    >
+      <strong>Module selected:</strong>
+      <span>
+        This session will focus on <strong>{label}</strong>. Mastery will be tracked against this module.
+      </span>
+    </div>
+  );
+}
+
+export function ModulePickerInviteBanner({
+  moduleCount,
+  onPick,
+}: {
+  moduleCount: number;
+  onPick: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onPick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onPick();
+        }
+      }}
+      className="hf-banner hf-banner-info hf-flex hf-items-center hf-gap-8 hf-banner-clickable"
+      aria-label="Pick a module to focus this session"
+    >
+      <strong>Pick a module →</strong>
+      <span>
+        Focus this session on one of {moduleCount > 0 ? `${moduleCount} ` : ""}
+        authored modules so mastery is tracked. Or continue and the system will choose.
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes part of #357. User reported on live VM that the admin caller-detail AI Call tab showed no banners despite \`?requestedModuleId=part1\` in the URL and \`modulesAuthored=true\` on the playbook — exactly the inconsistency #357 was filed to fix.

## Changes

1. **Extract** \`ModulePickerSelectionBanner\` + \`ModulePickerInviteBanner\` from \`app/x/sim/[callerId]/page.tsx\` into a shared module at \`components/sim/ModulePickerBanners.tsx\`. Semantics unchanged on the sim page.
2. **Mount** the same banners on \`CallerDetailPage\` above the embedded \`<SimChat />\`. Conditions mirror the sim page exactly.
3. **Load \`authoredModules\`** on CallerDetailPage (was only loading the \`modulesAuthored\` boolean) so the selection banner can show a human label, not the raw id.

## Test plan

- [x] Typecheck — no new errors (pre-existing \`callerTargets\` failures unaffected)
- [x] Existing tests pass
- [ ] On hf-dev VM: visit \`/x/callers/<id>?tab=ai-call\` for a caller in a learner-picks course → see the invite banner
- [ ] Visit with \`&requestedModuleId=<id>\` → see the selection banner with the module's label
- [ ] Confirm \`/x/sim/[callerId]\` still renders the same banners as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)