### PR TITLE
feat(#357): SimStateBreadcrumb — call/state/module pills above sim chat

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1410,6 +1410,51 @@ html.light {
   transform: translateY(1px);
 }
 
+/* Sim state breadcrumb (#357) — call/state/module pills above the chat */
+.hf-sim-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: var(--surface-secondary);
+  border-bottom: 1px solid var(--border-default);
+}
+.hf-sim-breadcrumb-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  font-weight: 500;
+  line-height: 1.4;
+}
+.hf-sim-breadcrumb-sep {
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+.hf-sim-breadcrumb-pill-action {
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.hf-sim-breadcrumb-pill-action:hover {
+  background: color-mix(in srgb, var(--accent-primary) 8%, var(--surface-primary));
+  border-color: color-mix(in srgb, var(--accent-primary) 35%, var(--border-default));
+}
+.hf-sim-breadcrumb-pill-action:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+.hf-sim-breadcrumb-pill-focus {
+  background: color-mix(in srgb, var(--status-info-bg) 70%, var(--surface-primary));
+  border-color: color-mix(in srgb, var(--status-info-text) 30%, var(--border-default));
+  color: var(--status-info-text);
+}
+
 /* Hierarchy Breadcrumb */
 .hf-breadcrumb {
   display: flex;

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -10,6 +10,7 @@ import { useJourneyChat } from '@/hooks/useJourneyChat';
 import { deriveParameterMap } from '@/lib/agent-tuner/derive';
 import type { AgentTunerPill } from '@/lib/agent-tuner/types';
 import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from '@/components/sim/ModulePickerBanners';
+import { SimStateBreadcrumb } from '@/components/sim/SimStateBreadcrumb';
 
 interface PastCall {
   transcript: string;
@@ -180,6 +181,12 @@ export default function SimConversationPage() {
 
   return (
     <>
+      <SimStateBreadcrumb
+        pastCallCount={caller.pastCalls.length}
+        requestedModuleId={requestedModuleId ?? null}
+        modules={authoredModules}
+        onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
+      />
       {requestedModuleId ? (
         <ModulePickerSelectionBanner
           moduleId={requestedModuleId}

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -12,6 +12,7 @@ import { SectionSelector, useSectionVisibility } from "@/components/shared/Secti
 import { CallerDomainSection } from "@/components/callers/CallerDomainSection";
 import { SimChat } from "@/components/sim/SimChat";
 import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from "@/components/sim/ModulePickerBanners";
+import { SimStateBreadcrumb } from "@/components/sim/SimStateBreadcrumb";
 import '@/app/x/sim/sim.css';
 import './caller-detail-page.css';
 import './caller-detail/lens.css';
@@ -1154,8 +1155,19 @@ export default function CallerDetailPage() {
 
       {simChatMounted && (
         <div className={activeSection === "ai-call" ? undefined : "hf-hidden"}>
-          {/* #357: mirror the sim-view module-picker banners so the admin
-              caller-detail surface gives the same signals as /x/sim/[id]. */}
+          {/* #357: mirror the sim-view module-picker banners + state
+              breadcrumb so the admin caller-detail surface gives the same
+              signals as /x/sim/[id]. */}
+          <SimStateBreadcrumb
+            pastCallCount={(data?.calls ?? []).filter((c: { transcript?: string | null }) => c.transcript?.trim()).length}
+            requestedModuleId={requestedModuleId ?? null}
+            modules={authoredModules}
+            onPickModule={
+              modulesAuthored && selectedPlaybookId && selectedPlaybookId !== "all"
+                ? handlePickModule
+                : undefined
+            }
+          />
           {requestedModuleId ? (
             <ModulePickerSelectionBanner
               moduleId={requestedModuleId}

--- a/apps/admin/components/sim/SimStateBreadcrumb.tsx
+++ b/apps/admin/components/sim/SimStateBreadcrumb.tsx
@@ -1,0 +1,69 @@
+/**
+ * Sim state breadcrumb — surfaces the call-state info that previously lived
+ * only inside the composed system prompt (call number, module focus). Renders
+ * above the chat area on both the standalone sim view and the admin caller
+ * detail AI Call tab so the user always knows which call they are in and
+ * which module is in focus.
+ *
+ * Issue #357. Session / phase pills are intentionally deferred — they need
+ * compose-prompt response wiring that doesn't exist yet on these surfaces.
+ */
+
+interface AuthoredModule {
+  id: string;
+  label?: string;
+}
+
+interface SimStateBreadcrumbProps {
+  /** Number of past calls (with transcript). The next call is this + 1. */
+  pastCallCount: number;
+  /** True if a call is currently active (POST /calls returned, not ended). */
+  activeCall?: boolean;
+  /** Module id chosen by the picker for this session, if any. */
+  requestedModuleId?: string | null;
+  /** Authored module list — used to resolve the picked id to a human label. */
+  modules?: AuthoredModule[];
+  /** When set, the Module pill is interactive — clicking opens the picker. */
+  onPickModule?: () => void;
+}
+
+export function SimStateBreadcrumb({
+  pastCallCount,
+  activeCall = false,
+  requestedModuleId,
+  modules = [],
+  onPickModule,
+}: SimStateBreadcrumbProps) {
+  const callLabel = activeCall
+    ? `Call #${pastCallCount + 1} (active)`
+    : pastCallCount === 0
+      ? "Call #1 (next)"
+      : `Call #${pastCallCount + 1} (next)`;
+
+  const stateLabel = activeCall ? "Active" : pastCallCount === 0 ? "Pre-call" : "Between calls";
+
+  const matched = requestedModuleId ? modules.find((m) => m.id === requestedModuleId) : undefined;
+  const moduleLabel = matched?.label || requestedModuleId || "Pick a module →";
+  const moduleHasFocus = Boolean(requestedModuleId);
+
+  return (
+    <div className="hf-sim-breadcrumb" role="navigation" aria-label="Sim call state">
+      <span className="hf-sim-breadcrumb-pill">{callLabel}</span>
+      <span className="hf-sim-breadcrumb-sep">·</span>
+      <span className="hf-sim-breadcrumb-pill">{stateLabel}</span>
+      <span className="hf-sim-breadcrumb-sep">·</span>
+      {onPickModule ? (
+        <button
+          type="button"
+          onClick={onPickModule}
+          className={`hf-sim-breadcrumb-pill hf-sim-breadcrumb-pill-action${moduleHasFocus ? " hf-sim-breadcrumb-pill-focus" : ""}`}
+          aria-label={moduleHasFocus ? `Change module — currently ${moduleLabel}` : "Pick a module"}
+        >
+          Module: {moduleLabel}
+        </button>
+      ) : (
+        <span className="hf-sim-breadcrumb-pill">Module: {moduleLabel}</span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #357 (final slice).

User reported they missed being in a pre-call welcome flow because the UI surfaced no call-state info. All this state already lived in the composed system prompt (\`Caller: ... (call #1)\`, \`Type: FIRST_CALL\`, \`Curriculum: 0/4 modules\`) but never made it to the screen.

## New component

\`components/sim/SimStateBreadcrumb.tsx\` — three pills above the chat:

\`\`\`
[ Call #N (next|active) ]  ·  [ Pre-call | Active | Between calls ]  ·  [ Module: <name> or "Pick a module →" ]
\`\`\`

The Module pill is **interactive** when \`modulesAuthored=true\` — clicking opens the picker, reusing the same \`handlePickModule\` as the banner CTA and the header Layers icon. Three visible entry points, one lever.

## Mounted on both surfaces

- \`/x/sim/[callerId]\` — standalone sim view
- \`/x/callers/[id]?tab=ai-call\` — admin caller-detail AI Call tab

## Deferred (out of scope)

- Session / phase pills — would need compose-prompt response wiring that doesn't currently flow to these surfaces. Worth a follow-up if you want richer state visibility.
- Intro-line in system prompt announcing the picker — held because you said you'd tune the welcome template wording yourself.

## Test plan

- [x] Typecheck — no new errors (pre-existing \`callerTargets\` failures unaffected)
- [ ] On hf-dev VM: visit \`/x/sim/<callerId>\` for a learner-picks course → see three pills above chat. Module pill is interactive.
- [ ] Visit \`/x/callers/<id>?tab=ai-call\` → same three pills, same interactivity
- [ ] Pick a module → Module pill updates to the selected name and gets the "focus" visual treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)