### PR TITLE
feat(#357): breadcrumb pills — Now / Next / Module

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1454,6 +1454,13 @@ html.light {
   border-color: color-mix(in srgb, var(--status-info-text) 30%, var(--border-default));
   color: var(--status-info-text);
 }
+/* Highlight the current pill so the Now/Next distinction is obvious */
+.hf-sim-breadcrumb-pill-current {
+  background: color-mix(in srgb, var(--status-success-bg) 60%, var(--surface-primary));
+  border-color: color-mix(in srgb, var(--status-success-text) 35%, var(--border-default));
+  color: var(--status-success-text);
+  font-weight: 600;
+}
 
 /* Hierarchy Breadcrumb */
 .hf-breadcrumb {

--- a/apps/admin/components/sim/SimStateBreadcrumb.tsx
+++ b/apps/admin/components/sim/SimStateBreadcrumb.tsx
@@ -1,12 +1,19 @@
 /**
  * Sim state breadcrumb — surfaces the call-state info that previously lived
- * only inside the composed system prompt (call number, module focus). Renders
- * above the chat area on both the standalone sim view and the admin caller
- * detail AI Call tab so the user always knows which call they are in and
- * which module is in focus.
+ * only inside the composed system prompt. Renders above the chat area on
+ * both the standalone sim view and the admin caller detail AI Call tab.
  *
- * Issue #357. Session / phase pills are intentionally deferred — they need
- * compose-prompt response wiring that doesn't exist yet on these surfaces.
+ * Three pills:
+ *
+ *   [ Now: Call #N (Pre-call|Active) ]  ·  [ Next: Call #N+1 ]  ·  [ Module: <name> | Pick a module → ]
+ *
+ * "Now" answers "which call am I in, and what's its state right now". "Next"
+ * tells the user what call is queued after this one. The Module pill is
+ * interactive when modulesAuthored=true.
+ *
+ * Issue #357. Session / phase sub-pills are intentionally deferred — they
+ * need compose-prompt response wiring that doesn't exist yet on these
+ * surfaces.
  */
 
 interface AuthoredModule {
@@ -15,9 +22,9 @@ interface AuthoredModule {
 }
 
 interface SimStateBreadcrumbProps {
-  /** Number of past calls (with transcript). The next call is this + 1. */
+  /** Number of past calls (with transcript). */
   pastCallCount: number;
-  /** True if a call is currently active (POST /calls returned, not ended). */
+  /** True if a call is currently active (not yet ended). */
   activeCall?: boolean;
   /** Module id chosen by the picker for this session, if any. */
   requestedModuleId?: string | null;
@@ -34,23 +41,24 @@ export function SimStateBreadcrumb({
   modules = [],
   onPickModule,
 }: SimStateBreadcrumbProps) {
-  const callLabel = activeCall
-    ? `Call #${pastCallCount + 1} (active)`
-    : pastCallCount === 0
-      ? "Call #1 (next)"
-      : `Call #${pastCallCount + 1} (next)`;
-
-  const stateLabel = activeCall ? "Active" : pastCallCount === 0 ? "Pre-call" : "Between calls";
+  // The "current" call is the one being conducted right now (active) OR the
+  // one the learner is about to start (pre-call). It's the same number in
+  // either case — what differs is the state label.
+  const currentCallNumber = pastCallCount + 1;
+  const nextCallNumber = currentCallNumber + 1;
+  const stateLabel = activeCall ? "Active" : "Pre-call";
 
   const matched = requestedModuleId ? modules.find((m) => m.id === requestedModuleId) : undefined;
-  const moduleLabel = matched?.label || requestedModuleId || "Pick a module →";
   const moduleHasFocus = Boolean(requestedModuleId);
+  const moduleLabel = matched?.label || requestedModuleId;
 
   return (
     <div className="hf-sim-breadcrumb" role="navigation" aria-label="Sim call state">
-      <span className="hf-sim-breadcrumb-pill">{callLabel}</span>
+      <span className="hf-sim-breadcrumb-pill hf-sim-breadcrumb-pill-current">
+        Now: Call #{currentCallNumber} ({stateLabel})
+      </span>
       <span className="hf-sim-breadcrumb-sep">·</span>
-      <span className="hf-sim-breadcrumb-pill">{stateLabel}</span>
+      <span className="hf-sim-breadcrumb-pill">Next: Call #{nextCallNumber}</span>
       <span className="hf-sim-breadcrumb-sep">·</span>
       {onPickModule ? (
         <button
@@ -59,11 +67,13 @@ export function SimStateBreadcrumb({
           className={`hf-sim-breadcrumb-pill hf-sim-breadcrumb-pill-action${moduleHasFocus ? " hf-sim-breadcrumb-pill-focus" : ""}`}
           aria-label={moduleHasFocus ? `Change module — currently ${moduleLabel}` : "Pick a module"}
         >
-          Module: {moduleLabel}
+          {moduleHasFocus ? `Module: ${moduleLabel}` : "Pick a module →"}
         </button>
-      ) : (
-        <span className="hf-sim-breadcrumb-pill">Module: {moduleLabel}</span>
-      )}
+      ) : moduleHasFocus ? (
+        <span className="hf-sim-breadcrumb-pill hf-sim-breadcrumb-pill-focus">
+          Module: {moduleLabel}
+        </span>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Polish on top of #361. After live testing, the original pill set wasn't self-explanatory — user asked "what are these chips saying?" Reworked into Now / Next / Module:

\`\`\`
Before:  [ Call #1 (next) ]  ·  [ Pre-call ]  ·  [ Module: Pick a module → ]
After:   [ Now: Call #1 (Pre-call) ]  ·  [ Next: Call #2 ]  ·  [ Pick a module → ]
\`\`\`

## Changes

- Collapse state pill into the Now pill — state is always describing the current call
- Add dedicated **Next** pill — answers "what's after this one"
- Highlight the **current** pill with success-coloured token so Now/Next is visible at a glance
- Drop redundant "Module: " prefix on the empty-state CTA (reads as a bare "Pick a module →")
- Keep "Module: <name>" prefix once a module is picked

## Test plan

- [x] Typecheck clean
- [ ] On hf-dev VM: open sim with no past calls, no module → see `Now: Call #1 (Pre-call)` + `Next: Call #2` + `Pick a module →`
- [ ] Pick a module → third pill flips to `Module: <name>` with focus colour
- [ ] Start a call → first pill flips to `Now: Call #1 (Active)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)