### PR TITLE
fix: stop double-rendering assessment-target goals on caller What tab

### DIFF
--- a/apps/admin/components/callers/caller-detail/ProgressTab.tsx
+++ b/apps/admin/components/callers/caller-detail/ProgressTab.tsx
@@ -560,8 +560,12 @@ export function LearningSection({
     not_started: { primary: "var(--text-muted)", glow: "var(--text-muted)" },
   };
 
-  const activeGoals = goals?.filter(g => g.status === 'ACTIVE' || g.status === 'PAUSED') || [];
-  const archivedGoals = goals?.filter(g => g.status === 'ARCHIVED' || g.status === 'COMPLETED') || [];
+  // #357 follow-up: goals where isAssessmentTarget=true are already rendered
+  // by AssessmentTargetsCard above this section. Filter them out here so the
+  // user doesn't see two copies of the same "Reach Secure on …" goal.
+  const nonAssessmentGoals = goals?.filter(g => !g.isAssessmentTarget) ?? [];
+  const activeGoals = nonAssessmentGoals.filter(g => g.status === 'ACTIVE' || g.status === 'PAUSED');
+  const archivedGoals = nonAssessmentGoals.filter(g => g.status === 'ARCHIVED' || g.status === 'COMPLETED');
 
   return (
     <div className="hf-flex-col hf-gap-20">


### PR DESCRIPTION
## Summary

User reported on the Quincy Rinaldi "What" tab: 8 \"Reach Secure on …\" entries visible, suggesting accumulation or duplicate enrollment.

## Verified via DB query

\`\`\`
Caller: Quincy Rinaldi (7e429080-…) created 2026-05-14T10:32
Enrollments: 1 — pb=1958800f "IELTS Speaking Practice"
Goals: 18 total
"Reach Secure on …" goals: 4 (P / GRA / LR / FC — one per IELTS criterion)
\`\`\`

So 8 visible cards = 4 underlying goals rendered twice in the UI:

1. **AssessmentTargetsCard** (top, unbadged) — filters \`isAssessmentTarget=true\` and shows progress ring + Mark-as-achieved
2. **LearningSection** (bottom, badged with "IELTS Speaking Practice v1.0") — was rendering ALL goals, including the assessment ones

## Fix

In \`LearningSection\`, filter out \`isAssessmentTarget=true\` before computing active / archived lists. Those goals belong to AssessmentTargetsCard.

## Test plan

- [x] Typecheck clean (3 pre-existing \`calls is possibly undefined\` errors unaffected)
- [ ] On hf-dev VM: Quincy Rinaldi's What tab shows 4 "Reach Secure on …" cards (in AssessmentTargets), NOT 8

## Side-note explaining the "v1.0" badge

Not the user's input — \`Playbook.version\` defaults to \`"v1.0"\` via the schema (\`prisma/schema.prisma:1949\`). Every fresh playbook gets that label automatically. The badge appends version to name as \`<name> v<version>\`. Not a bug — just intentional versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)