### PR TITLE
fix: composeContentSection reads CurriculumModule rows (the 0/0 modules bug)

### DIFF
--- a/apps/admin/lib/prompt/compose-content-section.ts
+++ b/apps/admin/lib/prompt/compose-content-section.ts
@@ -473,37 +473,111 @@ async function composeContentFromSubject(
   callerId: string,
   domainId: string
 ): Promise<ContentSection> {
-  // Try playbook curriculum first (direct link)
+  // Try playbook curriculum first (direct link). Source-of-truth precedence:
+  //   1. Relational CurriculumModule rows (populated by the projection layer
+  //      added in #338). When this branch fires, the UI no longer reports
+  //      "0/0 modules" on every goal card just because the legacy
+  //      notableInfo.modules blob hasn't been populated.
+  //   2. Legacy Curriculum.notableInfo.modules JSON (kept for back-compat
+  //      with seed data that pre-dates the relational model).
   const { resolvePlaybookId } = await import("@/lib/enrollment/resolve-playbook");
   const enrolledPbId = await resolvePlaybookId(callerId);
   if (enrolledPbId) {
     const pbCurr = await prisma.curriculum.findFirst({
       where: { playbookId: enrolledPbId },
       orderBy: { updatedAt: "desc" },
-      select: { slug: true, name: true, notableInfo: true },
+      select: {
+        slug: true,
+        name: true,
+        notableInfo: true,
+        modules: {
+          orderBy: { sortOrder: "asc" },
+          select: {
+            id: true,
+            slug: true,
+            title: true,
+            description: true,
+            sortOrder: true,
+          },
+        },
+      },
     });
-    if (pbCurr?.notableInfo) {
+
+    if (pbCurr) {
+      // Path 1 — relational CurriculumModule rows.
+      const relationalModules = pbCurr.modules ?? [];
+      if (relationalModules.length > 0) {
+        const modules: CurriculumModule[] = relationalModules.map((m, idx) => ({
+          id: m.id,
+          name: m.title || `Module ${idx + 1}`,
+          description: m.description ?? "",
+          content: m,
+          sequence: m.sortOrder ?? idx,
+          prerequisites: [],
+          status: "not_started" as const,
+          mastery: 0,
+        }));
+
+        const progress = await loadCallerProgress(callerId, pbCurr.slug, "current_module");
+        const contractThresholds = await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1");
+        const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
+        const enrichedModules = enrichModulesWithProgress(modules, progress, masteryThreshold);
+        const nextModule = enrichedModules.find((m) => m.status !== "completed") || null;
+        const nextContent = nextModule
+          ? [{ moduleId: nextModule.id, moduleName: nextModule.name, content: nextModule.content }]
+          : [];
+
+        return {
+          name: pbCurr.name,
+          hasData: true,
+          modules: enrichedModules,
+          nextModule: nextModule?.id || null,
+          nextContent,
+          totalModules: modules.length,
+          completedCount: enrichedModules.filter((m) => m.status === "completed").length,
+          coveredModules: enrichedModules.filter((m) => m.status !== "not_started").map((m) => m.id),
+          currentProgress: progress,
+          completedModules: enrichedModules.filter((m) => m.status === "completed").map((m) => m.id),
+          estimatedProgress: calculateProgress(enrichedModules),
+        };
+      }
+
+      // Path 2 — legacy notableInfo.modules JSON.
       const rawModules = (pbCurr.notableInfo as any)?.modules;
       if (Array.isArray(rawModules) && rawModules.length > 0) {
         const modules: CurriculumModule[] = rawModules.map((m: any, idx: number) => ({
           id: m.id,
-          slug: m.slug || m.id,
-          title: m.name || m.title || `Module ${idx + 1}`,
-          description: m.description,
-          sortOrder: idx,
-          keyTerms: m.keyTerms || [],
-          learningOutcomes: (m.learningOutcomes || []).map((lo: any) =>
-            typeof lo === "string" ? lo : lo.description || lo.ref || String(lo),
-          ),
+          name: m.title || m.name || m.id,
+          description: m.description || "",
+          content: m,
+          sequence: m.sortOrder ?? idx,
+          prerequisites: [],
+          status: "not_started" as const,
+          mastery: 0,
         }));
 
-        const progress = await getCurriculumProgress(callerId, pbCurr.slug);
-        return buildContentSection(
-          { slug: pbCurr.slug, name: pbCurr.name },
-          modules,
-          progress,
-          callerId,
-        );
+        const progress = await loadCallerProgress(callerId, pbCurr.slug, "current_module");
+        const contractThresholds = await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1");
+        const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
+        const enrichedModules = enrichModulesWithProgress(modules, progress, masteryThreshold);
+        const nextModule = enrichedModules.find((m) => m.status !== "completed") || null;
+        const nextContent = nextModule
+          ? [{ moduleId: nextModule.id, moduleName: nextModule.name, content: nextModule.content }]
+          : [];
+
+        return {
+          name: pbCurr.name,
+          hasData: true,
+          modules: enrichedModules,
+          nextModule: nextModule?.id || null,
+          nextContent,
+          totalModules: modules.length,
+          completedCount: enrichedModules.filter((m) => m.status === "completed").length,
+          coveredModules: enrichedModules.filter((m) => m.status !== "not_started").map((m) => m.id),
+          currentProgress: progress,
+          completedModules: enrichedModules.filter((m) => m.status === "completed").map((m) => m.id),
+          estimatedProgress: calculateProgress(enrichedModules),
+        };
       }
     }
   }


### PR DESCRIPTION
## Summary

User reported on Quincy Rinaldi's caller "What" tab: every goal card showed \`0% — 0/0 modules\` even though the playbook had 4 \`CurriculumModule\` rows (Part 1 / Part 2 / Part 3 / Full Mock Exam) created by the projection layer (#338).

## Root cause

\`composeContentSection\` (which feeds \`caller.curriculum\` to the UI) read modules from \`Curriculum.notableInfo.modules\` JSON blob **only**. The projection layer writes modules to the relational \`CurriculumModule\` table instead, so \`notableInfo\` stays empty and the UI sees zero modules.

Side-finding: the original \`notableInfo\` branch in \`composeContentFromSubject\` called helper functions (\`getCurriculumProgress\`, \`buildContentSection\`) that don't exist in this codebase — dead code never exercised in practice.

## Fix

- Add a relational-first path to the playbook-curriculum block. Reads \`CurriculumModule\` rows directly via Prisma include and runs the same enrichment pipeline as the lower (working) branch.
- Rewrite the legacy \`notableInfo\` path to use the same enrichment so both produce consistent shapes — and replace the dead helper references with real \`loadCallerProgress\` + \`enrichModulesWithProgress\`.

## Expected result

For Quincy Rinaldi and any caller in a projection-created playbook, the What tab now shows \`0/4 modules\` (or whatever the real count is). Mastery values stay 0 until calls produce \`CallerModuleProgress\` rows — that's expected.

## Out of scope (will file as a follow-up)

- LearningObjectives are not yet linked to CurriculumModule rows by the projection. Even after this fix, module-level mastery measurements may not flow correctly when real calls happen. A separate story to wire the projection's LO output into module relations.

## Test plan

- [x] Typecheck clean
- [ ] On hf-dev VM: visit Quincy Rinaldi's What tab → goal cards show \`0/4 modules\` not \`0/0\`
- [ ] Other callers in legacy (\`notableInfo\`-driven) playbooks still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)