### PR TITLE
chore: lock ratchet baseline after Tier-1 cleanup (611 → 604)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,6 +1,6 @@
 {
-  "tsc_errors": 611,
+  "tsc_errors": 604,
   "lint_errors": 0,
-  "lint_warnings": 9601,
+  "lint_warnings": 9591,
   "quarantined_tests": 31
 }


### PR DESCRIPTION
Locks the lower Linux baseline after #367. No code changes.