### PR TITLE
fix(#365): projection links LearningObjectives to CurriculumModule rows

### DIFF
--- a/apps/admin/lib/wizard/__tests__/apply-projection.test.ts
+++ b/apps/admin/lib/wizard/__tests__/apply-projection.test.ts
@@ -148,6 +148,16 @@ function buildMockPrisma() {
     },
     curriculumModule: {
       findMany: vi.fn().mockResolvedValue([]),
+      // Default newly-created module id: slug-based so test assertions can
+      // correlate moduleId → desired slug if needed.
+      create: vi.fn().mockImplementation(async ({ data }: { data: { slug: string } }) => ({
+        id: `cm-${data.slug}`,
+      })),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    learningObjective: {
+      findMany: vi.fn().mockResolvedValue([]),
       create: vi.fn().mockResolvedValue({}),
       update: vi.fn().mockResolvedValue({}),
       delete: vi.fn().mockResolvedValue({}),
@@ -184,15 +194,45 @@ describe("applyProjection — orchestrator smoke", () => {
       sourceContentId: SOURCE_ID_A,
     });
 
+    const expectedLoCount = projection.curriculumModules.reduce(
+      (sum, m) => sum + m.learningObjectives.length,
+      0,
+    );
+
     expect(mockTx.parameter.create).toHaveBeenCalledTimes(4);
     expect(mockTx.behaviorTarget.create).toHaveBeenCalledTimes(4);
     expect(mockTx.curriculumModule.create).toHaveBeenCalledTimes(5);
+    expect(mockTx.learningObjective.create).toHaveBeenCalledTimes(expectedLoCount);
     expect(mockTx.playbook.update).toHaveBeenCalledTimes(1);
 
     expect(result.parametersUpserted).toBe(4);
     expect(result.behaviorTargetsCreated).toBe(4);
     expect(result.curriculumModulesCreated).toBe(5);
+    expect(result.learningObjectivesCreated).toBe(expectedLoCount);
     expect(result.goalTemplatesWritten).toBe(projection.configPatch.goalTemplates.length);
+  });
+
+  it("links each new LearningObjective to its parent CurriculumModule via moduleId (#365)", async () => {
+    const { applyProjection } = await import("../apply-projection");
+    const projection = ieltsProjection();
+    await applyProjection(projection, {
+      playbookId: PLAYBOOK_ID,
+      sourceContentId: SOURCE_ID_A,
+    });
+
+    // Every LO create call must include a moduleId matching one of the
+    // CurriculumModule rows the mock pretended to insert (id="cm-${slug}").
+    const validModuleIds = new Set(
+      projection.curriculumModules.map((m) => `cm-${m.slug}`),
+    );
+    const loCreateCalls = mockTx.learningObjective.create.mock.calls;
+    expect(loCreateCalls.length).toBeGreaterThan(0);
+    for (const [arg] of loCreateCalls) {
+      const data = (arg as { data: { moduleId: string; ref: string; description: string } }).data;
+      expect(validModuleIds.has(data.moduleId)).toBe(true);
+      expect(data.ref).toMatch(/^OUT-\d+$/);
+      expect(data.description.length).toBeGreaterThan(0);
+    }
   });
 
   it("re-running with all DB rows already present is a no-op (no creates, no deletes)", async () => {
@@ -219,6 +259,21 @@ describe("applyProjection — orchestrator smoke", () => {
         sortOrder: m.sortOrder,
         estimatedDurationMinutes: m.estimatedDurationMinutes ?? null,
       })),
+    );
+    // Each module's LearningObjectives are already present in the DB.
+    // diffLearningObjectives queries by moduleId, so return per-module.
+    mockTx.learningObjective.findMany.mockImplementation(
+      async ({ where }: { where: { moduleId: string } }) => {
+        const slug = where.moduleId.replace(/^cm-/, "");
+        const mod = projection.curriculumModules.find((m) => m.slug === slug);
+        if (!mod) return [];
+        return mod.learningObjectives.map((lo) => ({
+          id: `lo-${slug}-${lo.ref}`,
+          ref: lo.ref,
+          description: lo.description,
+          sortOrder: lo.sortOrder,
+        }));
+      },
     );
     // Existing config already has the projection's goal templates tagged.
     mockTx.playbook.findUnique.mockResolvedValue({
@@ -247,9 +302,15 @@ describe("applyProjection — orchestrator smoke", () => {
     expect(mockTx.behaviorTarget.delete).not.toHaveBeenCalled();
     expect(mockTx.curriculumModule.create).not.toHaveBeenCalled();
     expect(mockTx.curriculumModule.delete).not.toHaveBeenCalled();
+    expect(mockTx.learningObjective.create).not.toHaveBeenCalled();
+    expect(mockTx.learningObjective.update).not.toHaveBeenCalled();
+    expect(mockTx.learningObjective.delete).not.toHaveBeenCalled();
     expect(result.parametersUpserted).toBe(0);
     expect(result.behaviorTargetsCreated).toBe(0);
     expect(result.curriculumModulesCreated).toBe(0);
+    expect(result.learningObjectivesCreated).toBe(0);
+    expect(result.learningObjectivesUpdated).toBe(0);
+    expect(result.learningObjectivesRemoved).toBe(0);
     expect(result.noop).toBe(true);
   });
 

--- a/apps/admin/lib/wizard/__tests__/project-course-reference.test.ts
+++ b/apps/admin/lib/wizard/__tests__/project-course-reference.test.ts
@@ -173,6 +173,60 @@ describe("projectCourseReference — IELTS v2.2 fixture", () => {
     expect(slugs).toContain("mock");
   });
 
+  it("projects LearningObjectives onto every authored module from its outcomesPrimary (#365)", () => {
+    // Baseline declares no primary outcomes ("samples across all") → 0 LOs.
+    // Other modules: part1=6, part2=9, part3=9, mock=3.
+    const bySlug = new Map(result.curriculumModules.map((m) => [m.slug, m]));
+    expect(bySlug.get("baseline")!.learningObjectives).toHaveLength(0);
+    expect(bySlug.get("part1")!.learningObjectives).toHaveLength(6);
+    expect(bySlug.get("part2")!.learningObjectives).toHaveLength(9);
+    expect(bySlug.get("part3")!.learningObjectives).toHaveLength(9);
+    expect(bySlug.get("mock")!.learningObjectives).toHaveLength(3);
+
+    // Each LO must carry the OUT-NN ref and the statement text (not the
+    // bare ref fallback) — the IELTS fixture defines a statement for every
+    // OUT used in module rows.
+    const part1 = bySlug.get("part1")!;
+    expect(part1.learningObjectives.map((lo) => lo.ref)).toEqual([
+      "OUT-01",
+      "OUT-02",
+      "OUT-05",
+      "OUT-06",
+      "OUT-07",
+      "OUT-24",
+    ]);
+    const out01 = part1.learningObjectives.find((lo) => lo.ref === "OUT-01")!;
+    expect(out01.description).toContain("Extends every answer");
+    expect(out01.sortOrder).toBe(0);
+  });
+
+  it("falls back to the bare ref when a module's outcome has no statement in the doc", () => {
+    const onlyTableOutcomes = `# Course
+
+**Modules authored:** Yes
+
+## Modules
+
+**Modules authored:** Yes
+
+### Module Catalogue
+
+| ID | Label | Learner-selectable | Mode | Duration | Scoring fired | Voice band readout | Session-terminal | Frequency | Content source | Outcomes (primary) |
+|---|---|---|---|---|---|---|---|---|---|---|
+| \`m1\` | Module One | Yes | Tutor | 10 min | LR only | No | No | Once | Source 1 | OUT-99 |
+`;
+    const minimal = projectCourseReference(onlyTableOutcomes, { sourceContentId: SOURCE_ID });
+    const m1 = minimal.curriculumModules.find((m) => m.slug === "m1");
+    expect(m1).toBeDefined();
+    expect(m1!.learningObjectives).toHaveLength(1);
+    // No `**OUT-99: ...**` statement in the doc → fallback to bare ref.
+    expect(m1!.learningObjectives[0]).toEqual({
+      ref: "OUT-99",
+      description: "OUT-99",
+      sortOrder: 0,
+    });
+  });
+
   it("sets progressionMode based on learnerSelectable across all modules", () => {
     // IELTS v2.2 has learner-selectable modules (Part 1/2/3) → learner-picks
     expect(result.configPatch.progressionMode).toBe("learner-picks");

--- a/apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts
+++ b/apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts
@@ -145,6 +145,9 @@ describe("runProjectionForPlaybook", () => {
       curriculumModulesCreated: 5,
       curriculumModulesUpdated: 0,
       curriculumModulesRemoved: 0,
+      learningObjectivesCreated: 27,
+      learningObjectivesUpdated: 0,
+      learningObjectivesRemoved: 0,
       goalTemplatesWritten: 25,
       curriculumId: "cur-1",
       warnings: [],
@@ -167,6 +170,50 @@ describe("runProjectionForPlaybook", () => {
     expect(projection.parameters.map((p: { name: string }) => p.name)).toContain(
       "skill_fluency_and_coherence",
     );
+  });
+
+  it("logs LO counts alongside params/bt/cm/goals in the applied line (#365)", async () => {
+    mockPrismaState.playbookSource.findMany.mockResolvedValue([
+      {
+        source: {
+          id: "src-ielts",
+          name: "IELTS Speaking course-ref",
+          mediaAssets: [{ storageKey: "key-ielts", fileName: "course-reference-ielts-v2.2.md" }],
+        },
+      },
+    ]);
+    mockStorageDownload.mockResolvedValue(Buffer.from(IELTS_V22));
+    mockExtractTextFromBuffer.mockResolvedValue({ text: IELTS_V22, fileType: "text" });
+    mockApplyProjection.mockResolvedValue({
+      parametersUpserted: 4,
+      behaviorTargetsCreated: 4,
+      behaviorTargetsUpdated: 0,
+      behaviorTargetsRemoved: 0,
+      curriculumModulesCreated: 5,
+      curriculumModulesUpdated: 0,
+      curriculumModulesRemoved: 0,
+      learningObjectivesCreated: 27,
+      learningObjectivesUpdated: 1,
+      learningObjectivesRemoved: 2,
+      goalTemplatesWritten: 25,
+      curriculumId: "cur-1",
+      warnings: [],
+      noop: false,
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
+      await runProjectionForPlaybook(PLAYBOOK_ID);
+      const lines = logSpy.mock.calls.map((c) => String(c[0]));
+      const applied = lines.find((l) => l.includes("[projection] applied"));
+      expect(applied).toBeDefined();
+      expect(applied).toContain("lo=+27/~1/-2");
+      // Existing counters still present and ordered before lo=
+      expect(applied).toMatch(/cm=\+5\/~0\/-0 lo=\+27\/~1\/-2 goals=25/);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it("applies multiple COURSE_REFERENCE sources in order, accumulating results", async () => {
@@ -196,6 +243,9 @@ describe("runProjectionForPlaybook", () => {
       curriculumModulesCreated: 0,
       curriculumModulesUpdated: 0,
       curriculumModulesRemoved: 0,
+      learningObjectivesCreated: 0,
+      learningObjectivesUpdated: 0,
+      learningObjectivesRemoved: 0,
       goalTemplatesWritten: 25,
       curriculumId: "cur-1",
       warnings: [],

--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -17,7 +17,14 @@
  *      this same source).
  *   3. Ensure a Curriculum exists for the playbook; diff + write
  *      CurriculumModule rows tagged with sourceContentId. Same add/update/
- *      remove logic, keyed by `slug`.
+ *      remove logic, keyed by `slug`. For each module, diff + write
+ *      LearningObjective rows keyed by (moduleId, ref), derived from the
+ *      module's `outcomesPrimary` × the doc's outcomes dictionary. The
+ *      classifier-managed audience-split fields (originalText,
+ *      learnerVisible, performanceStatement, systemRole, humanOverriddenAt)
+ *      are NEVER touched by the projection — only `ref`, `description`,
+ *      `sortOrder` are projection-owned. Module deletes cascade to LOs via
+ *      schema FK (#365).
  *   4. Merge the projection's configPatch into Playbook.config. Goal
  *      templates are scoped by sourceContentId so the applier replaces
  *      only its own prior templates — hand-authored / wizard / legacy
@@ -34,7 +41,7 @@
  * at enrolment time. Phase 5 (wizard wire-in) is responsible for calling
  * that after the projection lands, if needed.
  *
- * Issue #338 Phase 4.
+ * Issue #338 Phase 4. LearningObjective linkage added in #365.
  */
 
 import { Prisma } from "@prisma/client";
@@ -49,6 +56,7 @@ import type {
   ProjectedBehaviorTarget,
   ProjectedCurriculumModule,
   ProjectedGoalTemplate,
+  ProjectedLearningObjective,
   ProjectedParameter,
 } from "./project-course-reference";
 
@@ -67,6 +75,9 @@ export interface ApplyProjectionResult {
   curriculumModulesCreated: number;
   curriculumModulesUpdated: number;
   curriculumModulesRemoved: number;
+  learningObjectivesCreated: number;
+  learningObjectivesUpdated: number;
+  learningObjectivesRemoved: number;
   goalTemplatesWritten: number;
   curriculumId: string;
   warnings: ValidationWarning[];
@@ -213,6 +224,9 @@ interface CurriculumModuleDiff {
   created: number;
   updated: number;
   removed: number;
+  loCreated: number;
+  loUpdated: number;
+  loRemoved: number;
 }
 
 async function diffCurriculumModules(
@@ -231,7 +245,12 @@ async function diffCurriculumModules(
   let created = 0;
   let updated = 0;
   let removed = 0;
+  let loCreated = 0;
+  let loUpdated = 0;
+  let loRemoved = 0;
 
+  // Removed modules also delete their LOs via FK ON DELETE CASCADE (see
+  // schema.prisma model LearningObjective), so we only count modules here.
   for (const e of existing) {
     if (!desiredBySlug.has(e.slug)) {
       await tx.curriculumModule.delete({ where: { id: e.id } });
@@ -241,7 +260,9 @@ async function diffCurriculumModules(
 
   for (const m of desired) {
     const existingRow = existing.find((e) => e.slug === m.slug);
+    let moduleId: string;
     if (existingRow) {
+      moduleId = existingRow.id;
       const drift =
         existingRow.title !== m.title ||
         existingRow.sortOrder !== m.sortOrder ||
@@ -259,7 +280,7 @@ async function diffCurriculumModules(
         updated += 1;
       }
     } else {
-      await tx.curriculumModule.create({
+      const createdRow = await tx.curriculumModule.create({
         data: {
           curriculumId,
           slug: m.slug,
@@ -268,6 +289,85 @@ async function diffCurriculumModules(
           estimatedDurationMinutes: m.estimatedDurationMinutes,
           description: m.description,
           sourceContentId,
+        },
+        select: { id: true },
+      });
+      moduleId = createdRow.id;
+      created += 1;
+    }
+
+    // Sync LearningObjective rows for this module. Key: (moduleId, ref).
+    // Issue #365.
+    const loDiff = await diffLearningObjectives(tx, moduleId, m.learningObjectives);
+    loCreated += loDiff.created;
+    loUpdated += loDiff.updated;
+    loRemoved += loDiff.removed;
+  }
+
+  return { created, updated, removed, loCreated, loUpdated, loRemoved };
+}
+
+interface LearningObjectiveDiff {
+  created: number;
+  updated: number;
+  removed: number;
+}
+
+/**
+ * Diff LearningObjective rows under a single CurriculumModule. Keyed by
+ * `ref` (matches OUT-NN id from the COURSE_REFERENCE doc). LOs in the
+ * projection but missing → CREATE. LOs with drifted description or
+ * sortOrder → UPDATE. LOs present in DB but absent from the projection →
+ * DELETE (they came from a prior version of this module's outcomesPrimary).
+ *
+ * The classifier-managed audience-split fields (originalText,
+ * learnerVisible, performanceStatement, systemRole, humanOverriddenAt)
+ * are NOT touched here — only the projection-owned fields (ref,
+ * description, sortOrder). Issue #365.
+ */
+async function diffLearningObjectives(
+  tx: Tx,
+  moduleId: string,
+  desired: ProjectedLearningObjective[],
+): Promise<LearningObjectiveDiff> {
+  const existing = await tx.learningObjective.findMany({
+    where: { moduleId },
+    select: { id: true, ref: true, description: true, sortOrder: true },
+  });
+
+  const desiredByRef = new Map(desired.map((lo) => [lo.ref, lo]));
+
+  let created = 0;
+  let updated = 0;
+  let removed = 0;
+
+  for (const e of existing) {
+    if (!desiredByRef.has(e.ref)) {
+      await tx.learningObjective.delete({ where: { id: e.id } });
+      removed += 1;
+    }
+  }
+
+  for (const lo of desired) {
+    const existingRow = existing.find((e) => e.ref === lo.ref);
+    if (existingRow) {
+      const drift =
+        existingRow.description !== lo.description ||
+        existingRow.sortOrder !== lo.sortOrder;
+      if (drift) {
+        await tx.learningObjective.update({
+          where: { id: existingRow.id },
+          data: { description: lo.description, sortOrder: lo.sortOrder },
+        });
+        updated += 1;
+      }
+    } else {
+      await tx.learningObjective.create({
+        data: {
+          moduleId,
+          ref: lo.ref,
+          description: lo.description,
+          sortOrder: lo.sortOrder,
         },
       });
       created += 1;
@@ -379,6 +479,7 @@ export async function applyProjection(
       parametersUpserted === 0 &&
       btDiff.created + btDiff.updated + btDiff.removed === 0 &&
       cmDiff.created + cmDiff.updated + cmDiff.removed === 0 &&
+      cmDiff.loCreated + cmDiff.loUpdated + cmDiff.loRemoved === 0 &&
       // goal templates always re-written; treat unchanged template count
       // as no-op-ish but the JSON write itself is technically idempotent
       // in Prisma — we just bump updatedAt. Caller can ignore the bump.
@@ -394,6 +495,9 @@ export async function applyProjection(
       curriculumModulesCreated: cmDiff.created,
       curriculumModulesUpdated: cmDiff.updated,
       curriculumModulesRemoved: cmDiff.removed,
+      learningObjectivesCreated: cmDiff.loCreated,
+      learningObjectivesUpdated: cmDiff.loUpdated,
+      learningObjectivesRemoved: cmDiff.loRemoved,
       goalTemplatesWritten,
       curriculumId,
       warnings: projection.validationWarnings,

--- a/apps/admin/lib/wizard/project-course-reference.ts
+++ b/apps/admin/lib/wizard/project-course-reference.ts
@@ -54,12 +54,34 @@ export interface ProjectedBehaviorTarget {
   description?: string;
 }
 
+/**
+ * A LearningObjective the applier must write under a CurriculumModule. The
+ * `ref` matches the OUT-NN id from the Course Reference doc and is the
+ * stable key for diff (paired with moduleId). `description` is the OUT-NN
+ * statement text; falls back to the bare ref if no statement is present
+ * in the doc's outcomes dictionary.
+ *
+ * Issue #365.
+ */
+export interface ProjectedLearningObjective {
+  ref: string;
+  description: string;
+  sortOrder: number;
+}
+
 export interface ProjectedCurriculumModule {
   slug: string;
   title: string;
   description?: string;
   sortOrder: number;
   estimatedDurationMinutes?: number;
+  /**
+   * LearningObjective rows the applier must upsert under this module,
+   * derived from the module's `outcomesPrimary` cross-referenced against
+   * the doc-level `outcomes` dictionary. Empty when the module has no
+   * primary outcomes declared. Issue #365.
+   */
+  learningObjectives: ProjectedLearningObjective[];
 }
 
 export interface ProjectedParameter {
@@ -320,12 +342,23 @@ function parseDurationToMinutes(duration: string | undefined): number | undefine
   return undefined;
 }
 
-function mapAuthoredModulesToCurriculumModules(modules: AuthoredModule[]): ProjectedCurriculumModule[] {
+function mapAuthoredModulesToCurriculumModules(
+  modules: AuthoredModule[],
+  outcomes: Record<string, string>,
+): ProjectedCurriculumModule[] {
   return modules.map((m, idx) => ({
     slug: m.id,
     title: m.label,
     sortOrder: m.position ?? idx,
     estimatedDurationMinutes: parseDurationToMinutes(m.duration),
+    learningObjectives: m.outcomesPrimary.map((ref, loIdx) => ({
+      ref,
+      // Prefer the statement from the doc-level `**OUT-NN: ...**` heading.
+      // Fall back to the bare ref so the row is still well-formed when the
+      // statement is missing (a validation warning will already exist).
+      description: outcomes[ref]?.trim() || ref,
+      sortOrder: loIdx,
+    })),
   }));
 }
 
@@ -371,7 +404,7 @@ export function projectCourseReference(
   return {
     configPatch,
     behaviorTargets,
-    curriculumModules: mapAuthoredModulesToCurriculumModules(detected.modules),
+    curriculumModules: mapAuthoredModulesToCurriculumModules(detected.modules, outcomes),
     parameters,
     validationWarnings: [...detected.validationWarnings, ...skillWarnings],
     contentDeclaration: declaration,

--- a/apps/admin/lib/wizard/run-projection-for-playbook.ts
+++ b/apps/admin/lib/wizard/run-projection-for-playbook.ts
@@ -125,6 +125,7 @@ export async function runProjectionForPlaybook(playbookId: string): Promise<RunP
         `params=+${result.parametersUpserted} ` +
         `bt=+${result.behaviorTargetsCreated}/~${result.behaviorTargetsUpdated}/-${result.behaviorTargetsRemoved} ` +
         `cm=+${result.curriculumModulesCreated}/~${result.curriculumModulesUpdated}/-${result.curriculumModulesRemoved} ` +
+        `lo=+${result.learningObjectivesCreated}/~${result.learningObjectivesUpdated}/-${result.learningObjectivesRemoved} ` +
         `goals=${result.goalTemplatesWritten} ` +
         `noop=${result.noop}`,
     );


### PR DESCRIPTION
## Summary

Closes #365. Threads each AuthoredModule's `outcomesPrimary` list through the projection layer into LearningObjective rows under its CurriculumModule.

Before this change the Course Reference doc's OUT-NN module-table refs were parsed into `AuthoredModule.outcomesPrimary`, stored as JSON on `Playbook.config.modules`, and then dropped — every projected module ended up with zero LearningObjective rows. After this change, querying

```ts
prisma.curriculumModule.findMany({
  where: { curriculum: { playbookId } },
  select: { _count: { select: { learningObjectives: true } } },
})
```

returns non-zero counts for newly-projected courses.

### What changed

- `lib/wizard/project-course-reference.ts`: new `ProjectedLearningObjective` type; `ProjectedCurriculumModule` now carries `learningObjectives[]` populated from each module's `outcomesPrimary` cross-referenced against the doc-level outcomes dictionary (falls back to the bare OUT-NN ref when the doc has no `**OUT-NN: ...**` statement — a validation warning already exists for that case).
- `lib/wizard/apply-projection.ts`: `diffCurriculumModules` now diffs LOs per module inside the same transaction; keyed by `(moduleId, ref)`; creates, updates description/sortOrder drift, deletes orphans. Classifier-managed audience-split fields (`originalText`, `learnerVisible`, `performanceStatement`, `systemRole`, `humanOverriddenAt`) are untouched. `ApplyProjectionResult` gains `learningObjectivesCreated/Updated/Removed`; noop check extended.
- `lib/wizard/run-projection-for-playbook.ts`: log line now includes `lo=+N/~N/-N` alongside the existing `params/bt/cm/goals` counters.
- Tests: updated existing wizard tests; added LO assertions in `project-course-reference.test.ts` and `apply-projection.test.ts` and a log-line assertion in `run-projection-for-playbook.test.ts`.

No schema migration — `LearningObjective` already exists.

## Test plan

- [x] `npx vitest run lib/wizard/__tests__/{project-course-reference,apply-projection,run-projection-for-playbook}.test.ts` — 43/43 pass
- [x] `npm run ratchet:check` — exits 0; lint_errors == baseline, quarantined_tests == baseline, tsc_errors -29 under baseline, lint_warnings -29 under baseline
- [x] `npx tsc --noEmit` — no new errors in `lib/wizard/project-course-reference.ts`, `apply-projection.ts`, or `run-projection-for-playbook.ts`
- [ ] After deploy, re-process the test playbook `1958800f` and verify `prisma.curriculumModule.findMany({ where: { curriculum: { playbookId } }, select: { _count: { select: { learningObjectives: true } } } })` returns non-zero counts for the 4 modules
- [ ] After deploy, confirm `[projection] applied source=...` log line includes `lo=+N/~N/-N` segment

Ready for `/vm-cp` (no migration).