### PR TITLE
chore(tier-2): clear 11 schema-drift routes (~47 tsc errors)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -259,6 +259,11 @@ async function loadCurrentModuleContext(
   }
 
   // Path 3: Domain-wide Subject curriculum fallback (legacy)
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { domainId: true },
+  });
+  if (!caller?.domainId) return null;
   const subjectDomains = await prisma.subjectDomain.findMany({
     where: { domainId: caller.domainId },
     include: {
@@ -1837,6 +1842,11 @@ async function trackCurriculumAfterCall(
   // Subject curriculum fallback — assign first module if no CONTENT spec found (legacy)
   if (!updated) {
     try {
+      const caller = await prisma.caller.findUnique({
+        where: { id: callerId },
+        select: { domainId: true },
+      });
+      if (!caller?.domainId) return false;
       const subjectDomains = await prisma.subjectDomain.findMany({
         where: { domainId: caller.domainId },
         include: {

--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -710,13 +710,18 @@ async function handleWizardModeWithTools(
       // (don't rely on the AI remembering to call update_setup after creation/resolution)
       if (!result.is_error) {
         // 1. Entity resolution: autoInjectFields from update_setup (institution/course/subject resolution)
-        if (result.autoInjectFields && Object.keys(result.autoInjectFields).length > 0) {
+        //    Only WizardToolResult carries this — CourseRefToolResult never sets it.
+        const autoInjectFields =
+          mode !== "COURSE_REF"
+            ? (result as { autoInjectFields?: Record<string, unknown> }).autoInjectFields
+            : undefined;
+        if (autoInjectFields && Object.keys(autoInjectFields).length > 0) {
           allToolCalls.push({
             name: "update_setup",
-            input: { fields: result.autoInjectFields },
+            input: { fields: autoInjectFields },
           });
           // Also merge into running state for later tools in this iteration
-          Object.assign(mergedSetupData, result.autoInjectFields);
+          Object.assign(mergedSetupData, autoInjectFields);
         }
         // 2. Creation tools: extract IDs from JSON result
         try {

--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -236,15 +236,16 @@ export async function POST(
   // the pipeline's slug-based `updateModuleMastery` can write progress for
   // authored modules. Wrapped in a transaction so the playbook and module
   // tables stay in sync if either write fails.
-  let syncResult: Awaited<ReturnType<typeof syncAuthoredModulesToCurriculum>> | null = null;
+  type SyncResultT = Awaited<ReturnType<typeof syncAuthoredModulesToCurriculum>>;
+  let syncResult: SyncResultT | null = null;
   if (changed) {
-    await prisma.$transaction(async (tx) => {
+    syncResult = await prisma.$transaction(async (tx): Promise<SyncResultT | null> => {
       await tx.playbook.update({
         where: { id: courseId },
         data: { config: nextConfig as object },
       });
       if (detected.modulesAuthored === true && detected.modules.length > 0) {
-        syncResult = await syncAuthoredModulesToCurriculum(
+        return await syncAuthoredModulesToCurriculum(
           tx,
           courseId,
           detected.modules,
@@ -255,6 +256,7 @@ export async function POST(
           detected.outcomes,
         );
       }
+      return null;
     });
   }
 

--- a/apps/admin/app/api/courses/[courseId]/re-extract/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/re-extract/route.ts
@@ -37,7 +37,7 @@ export async function POST(
     const parsed = bodySchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { ok: false, error: parsed.error.errors[0]?.message || "Invalid request" },
+        { ok: false, error: parsed.error.issues[0]?.message || "Invalid request" },
         { status: 400 },
       );
     }

--- a/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
@@ -280,6 +280,8 @@ async function runBackgroundLessonPlanGeneration(
         description: true,
         notableInfo: true,
         subjectId: true,
+        playbookId: true,
+        deliveryConfig: true,
       },
     });
 
@@ -676,7 +678,7 @@ export async function POST(
     // Verify curriculum exists
     const curriculum = await prisma.curriculum.findUnique({
       where: { id: curriculumId },
-      select: { id: true, notableInfo: true, deliveryConfig: true, subjectId: true },
+      select: { id: true, notableInfo: true, deliveryConfig: true, subjectId: true, playbookId: true },
     });
 
     if (!curriculum) {

--- a/apps/admin/app/api/domains/[domainId]/knowledge-map/route.ts
+++ b/apps/admin/app/api/domains/[domainId]/knowledge-map/route.ts
@@ -51,19 +51,20 @@ export async function GET(
 
     // Get sources — prefer playbookId (PlaybookSource), fall back to subjectIds
     let sources: { id: string; name: string }[];
+    let playbookSourceIds: string[] | null = null;
+    const subjectFilter = subjectIds?.length
+      ? { subject: { id: { in: subjectIds }, domains: { some: { domainId } } } }
+      : { subject: { domains: { some: { domainId } } } };
     if (playbookId) {
       const { getSourceIdsForPlaybook } = await import("@/lib/knowledge/domain-sources");
-      const ids = await getSourceIdsForPlaybook(playbookId);
-      sources = ids.length > 0
+      playbookSourceIds = await getSourceIdsForPlaybook(playbookId);
+      sources = playbookSourceIds.length > 0
         ? await prisma.contentSource.findMany({
-            where: { id: { in: ids }, assertions: { some: { depth: { not: null } } } },
+            where: { id: { in: playbookSourceIds }, assertions: { some: { depth: { not: null } } } },
             select: { id: true, name: true },
           })
         : [];
     } else {
-      const subjectFilter = subjectIds?.length
-        ? { subject: { id: { in: subjectIds }, domains: { some: { domainId } } } }
-        : { subject: { domains: { some: { domainId } } } };
       sources = await prisma.contentSource.findMany({
         where: {
           subjects: { some: subjectFilter },
@@ -130,10 +131,12 @@ export async function GET(
       };
     });
 
-    // Get total source count for domain (including unstructured)
-    const totalSources = await prisma.contentSource.count({
-      where: { subjects: { some: subjectFilter } },
-    });
+    // Get total source count for the scope (including unstructured)
+    const totalSources = playbookSourceIds !== null
+      ? playbookSourceIds.length
+      : await prisma.contentSource.count({
+          where: { subjects: { some: subjectFilter } },
+        });
 
     return NextResponse.json({
       ok: true,

--- a/apps/admin/app/api/ops/[opid]/parameters/[id]/route.ts
+++ b/apps/admin/app/api/ops/[opid]/parameters/[id]/route.ts
@@ -48,7 +48,7 @@ function coerceNullableString(v: unknown): string | null | undefined {
 async function getParameterFlat(parameterId: string) {
   const p = await prisma.parameter.findUnique({
     where: { parameterId },
-    include: { tags: { include: { tag: true } }, mappings: true },
+    include: { tags: { include: { tag: true } } },
   });
   if (!p) return null;
 
@@ -224,7 +224,7 @@ export async function PATCH(req: Request, ctx: RouteCtx) {
 
       const full = await tx.parameter.findUnique({
         where: { parameterId: id },
-        include: { tags: { include: { tag: true } }, mappings: true },
+        include: { tags: { include: { tag: true } } },
       });
       if (!full) throw Object.assign(new Error("Not found"), { status: 404 });
 

--- a/apps/admin/app/api/prompt-blocks/[id]/route.ts
+++ b/apps/admin/app/api/prompt-blocks/[id]/route.ts
@@ -28,22 +28,12 @@ export async function GET(
 
     const { id } = await params;
 
+    // Stacks model was removed from the schema; `usedInStacks` is now always
+    // empty. Kept in the response shape for backward compatibility with
+    // clients that still read it.
     const block = await prisma.promptBlock.findFirst({
       where: {
         OR: [{ id }, { slug: id }],
-      },
-      include: {
-        stackItems: {
-          include: {
-            stack: {
-              select: {
-                id: true,
-                name: true,
-                status: true,
-              },
-            },
-          },
-        },
       },
     });
 
@@ -58,8 +48,7 @@ export async function GET(
       ok: true,
       block: {
         ...block,
-        usedInStacks: block.stackItems.map((si) => si.stack),
-        stackItems: undefined,
+        usedInStacks: [],
       },
     });
   } catch (error: any) {
@@ -155,12 +144,11 @@ export async function DELETE(
 
     const { id } = await params;
 
+    // Stacks model was removed from the schema, so there is no longer a
+    // "block is in use" gate — DELETE is unconditional.
     const existing = await prisma.promptBlock.findFirst({
       where: {
         OR: [{ id }, { slug: id }],
-      },
-      include: {
-        _count: { select: { stackItems: true } },
       },
     });
 
@@ -168,16 +156,6 @@ export async function DELETE(
       return NextResponse.json(
         { ok: false, error: "Prompt block not found" },
         { status: 404 }
-      );
-    }
-
-    if (existing._count.stackItems > 0) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: `Cannot delete block used in ${existing._count.stackItems} stack(s). Remove from stacks first or deactivate instead.`,
-        },
-        { status: 400 }
       );
     }
 

--- a/apps/admin/app/api/prompt-slugs/[id]/route.ts
+++ b/apps/admin/app/api/prompt-slugs/[id]/route.ts
@@ -28,6 +28,9 @@ export async function GET(
 
     const { id } = await params;
 
+    // Stacks model was removed from the schema; `usedInStacks` is now always
+    // empty. Kept in the response shape for backward compatibility with
+    // clients that still read it.
     const promptSlug = await prisma.promptSlug.findFirst({
       where: {
         OR: [{ id }, { slug: id }],
@@ -51,17 +54,6 @@ export async function GET(
         ranges: {
           orderBy: { sortOrder: "asc" },
         },
-        stackItems: {
-          include: {
-            stack: {
-              select: {
-                id: true,
-                name: true,
-                status: true,
-              },
-            },
-          },
-        },
       },
     });
 
@@ -76,8 +68,7 @@ export async function GET(
       ok: true,
       slug: {
         ...promptSlug,
-        usedInStacks: promptSlug.stackItems.map((si) => si.stack),
-        stackItems: undefined,
+        usedInStacks: [],
       },
     });
   } catch (error: any) {
@@ -274,12 +265,11 @@ export async function DELETE(
 
     const { id } = await params;
 
+    // Stacks model was removed from the schema, so there is no longer a
+    // "slug is in use" gate — DELETE is unconditional.
     const existing = await prisma.promptSlug.findFirst({
       where: {
         OR: [{ id }, { slug: id }],
-      },
-      include: {
-        _count: { select: { stackItems: true } },
       },
     });
 
@@ -287,16 +277,6 @@ export async function DELETE(
       return NextResponse.json(
         { ok: false, error: "Dynamic prompt not found" },
         { status: 404 }
-      );
-    }
-
-    if (existing._count.stackItems > 0) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: `Cannot delete dynamic prompt used in ${existing._count.stackItems} stack(s). Remove from stacks first or deactivate instead.`,
-        },
-        { status: 400 }
       );
     }
 

--- a/apps/admin/app/api/prompt-slugs/route.ts
+++ b/apps/admin/app/api/prompt-slugs/route.ts
@@ -63,9 +63,6 @@ export async function GET(req: Request) {
         ranges: {
           orderBy: { sortOrder: "asc" },
         },
-        _count: {
-          select: { stackItems: true },
-        },
       },
     });
 
@@ -79,14 +76,14 @@ export async function GET(req: Request) {
       orderBy: [{ domainGroup: "asc" }, { name: "asc" }],
     });
 
+    // Stacks model was removed from the schema; usageCount is always 0.
     return NextResponse.json({
       ok: true,
       slugs: slugs.map((s) => ({
         ...s,
-        usageCount: s._count.stackItems,
+        usageCount: 0,
         rangeCount: s.ranges.length,
         parameterCount: s.parameters.length,
-        _count: undefined,
       })),
       parameters,
     });

--- a/apps/admin/app/api/student/assessment-questions/route.ts
+++ b/apps/admin/app/api/student/assessment-questions/route.ts
@@ -21,6 +21,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
 import { buildPreTest, buildPreTestForPlaybook, buildPostTest, buildComprehensionPostTest } from "@/lib/assessment/pre-test-builder";
@@ -80,13 +81,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   // pre_test — resolve enrolled playbook and curriculum
   const enrollment = await prisma.callerPlaybook.findFirst({
     where: { callerId, status: "ACTIVE" },
-    select: {
-      playbookId: true,
+    include: {
       playbook: {
         select: {
           config: true,
           curricula: {
-            where: { deliveryConfig: { not: null } },
+            where: { deliveryConfig: { not: Prisma.JsonNull } },
             select: { id: true },
             take: 1,
           },

--- a/apps/admin/app/api/student/journey-position/route.ts
+++ b/apps/admin/app/api/student/journey-position/route.ts
@@ -12,6 +12,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
 import { DEFAULT_NPS_CONFIG } from "@/lib/types/json-fields";
@@ -57,13 +58,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const [enrollment, onboardingSession] = await Promise.all([
       prisma.callerPlaybook.findFirst({
         where: { callerId, status: "ACTIVE" },
-        select: {
+        include: {
           playbook: {
             select: {
               id: true,
               config: true,
               curricula: {
-                where: { deliveryConfig: { not: null } },
+                where: { deliveryConfig: { not: Prisma.JsonNull } },
                 select: { id: true, slug: true, deliveryConfig: true },
                 take: 1,
               },


### PR DESCRIPTION
## Summary

Sweep the 11 Tier-2 schema-drift orphans flagged by tsc after the PlaybookSource migration and downstream schema edits. Closes #368.

- tsc baseline dropped from **575 → 528** on this branch (-47 errors; target was ~30)
- All 12 files in scope are clean per `npx tsc --noEmit | grep <file>`
- `npm run ratchet:check` passes with all metrics at or below baseline

## Per-file fixes

| File | Fix |
|------|-----|
| `calls/[callId]/pipeline/route.ts` | rename missed `caller` → `callerId` (2 sites); fetch `caller.domainId` via prisma |
| `curricula/[curriculumId]/lesson-plan/route.ts` | add `playbookId` + `deliveryConfig` to both Curriculum selects |
| `student/assessment-questions/route.ts` + `student/journey-position/route.ts` | switch `select` → `include` for `playbook` on CallerPlaybook; fix `deliveryConfig: { not: null }` → `{ not: Prisma.JsonNull }` |
| `chat/route.ts` | `autoInjectFields` lives on `WizardToolResult`, not `CourseRefToolResult` — narrow access by mode |
| `courses/[courseId]/import-modules/route.ts` | capture transaction return value so TS narrows `syncResult.curriculumId` correctly |
| `courses/[courseId]/re-extract/route.ts` | `ZodError.errors` → `.issues` (Zod v4 rename) |
| `domains/[domainId]/knowledge-map/route.ts` | hoist `subjectFilter` out of the else branch; reuse for `totalSources` count (playbookId branch uses its own id list) |
| `ops/[opid]/parameters/[id]/route.ts` | drop `mappings: true` from Parameter include (relation removed from schema) |
| `prompt-blocks/[id]/route.ts` + `prompt-slugs/[id]/route.ts` + `prompt-slugs/route.ts` | Stack model was removed; drop `stackItems` include + `_count.stackItems` gating; response keeps `usedInStacks: []` / `usageCount: 0` for backward compat |

## Notes for reviewers

- **Stacks removal**: Three routes contained "in-use" delete gates referencing the now-removed `Stack` / `PromptBlockStackItem` model. Deletes are now unconditional. Response shapes preserve `usedInStacks` (always `[]`) and `usageCount` (always `0`) so existing clients won't crash. If the gate is still desired conceptually, it should be re-introduced against whatever the new "in-use" signal is (out of scope here).
- **Prisma JSON null semantics**: Two `deliveryConfig: { not: null }` filters needed `Prisma.JsonNull` — caught and fixed alongside the `include` refactor.

## Test plan

- [ ] `npx tsc --noEmit` shows no errors in the 12 touched files
- [ ] `npm run ratchet:check` passes (it does — 528 < 604 baseline)
- [ ] Spot-check `/api/prompt-blocks/:id` GET + DELETE behavior on dev
- [ ] Spot-check `/api/prompt-slugs` list page renders without `usageCount` regression
- [ ] Spot-check `/api/student/journey-position` still resolves enrollment for a learner