### PR TITLE
chore(#376): clear Tier-5 signature drift (~120 errors)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,7 +1,7 @@
 {
-  "tsc_errors": 567,
+  "tsc_errors": 347,
   "lint_errors": 0,
-  "lint_warnings": 9531,
+  "lint_warnings": 9529,
   "quarantined_tests": 31,
   "_comment_knip": "knip baseline (post #369): 0 unused files, ~109 unused exports, 14 unused exported types, 2 duplicate exports. Run 'cd apps/admin && npm run knip:ci' to verify; lock new counts here when knip changes."
 }

--- a/apps/admin/app/x/educator/page.tsx
+++ b/apps/admin/app/x/educator/page.tsx
@@ -265,7 +265,7 @@ export default function EducatorDashboard() {
     );
   }
 
-  const stats = data?.stats ?? { classroomCount: 0, totalStudents: 0, activeThisWeek: 0 };
+  const stats = data?.stats ?? { departmentCount: 0, courseCount: 0, classroomCount: 0, totalStudents: 0, activeThisWeek: 0 };
   const hasClassrooms = stats.classroomCount > 0;
   const viewingSchoolName = selectedInstitutionId
     ? institutions.find((i) => i.id === selectedInstitutionId)?.name

--- a/apps/admin/app/x/educator/settings/AIPersonalitySection.tsx
+++ b/apps/admin/app/x/educator/settings/AIPersonalitySection.tsx
@@ -30,7 +30,7 @@ export function AIPersonalitySection({ domainId, canEdit }: Props) {
   const [teachPreset, setTeachPreset] = useState<string>("clear-instructor");
   const [loading, setLoading] = useState(true);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const loadPresets = useCallback(async () => {
     if (!domainId) { setLoading(false); return; }

--- a/apps/admin/app/x/educator/settings/BrandingSection.tsx
+++ b/apps/admin/app/x/educator/settings/BrandingSection.tsx
@@ -30,8 +30,8 @@ export function BrandingSection({ institution, canEdit, onSaved }: Props) {
   const [welcomeMessage, setWelcomeMessage] = useState(institution.welcomeMessage || "");
 
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
-  const debounceTimer = useRef<ReturnType<typeof setTimeout>>();
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const save = async (body: Record<string, string | null>) => {
     setSaveStatus("saving");

--- a/apps/admin/app/x/educator/settings/CourseDefaultsSection.tsx
+++ b/apps/admin/app/x/educator/settings/CourseDefaultsSection.tsx
@@ -40,7 +40,7 @@ export function CourseDefaultsSection({ domainId, canEdit }: Props) {
   const [defaults, setDefaults] = useState<DefaultsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Form state
   const [sessionCount, setSessionCount] = useState<number | null>(null);

--- a/apps/admin/app/x/educator/settings/LearnersSection.tsx
+++ b/apps/admin/app/x/educator/settings/LearnersSection.tsx
@@ -13,7 +13,7 @@ export function LearnersSection({ domainId, canEdit }: Props) {
   const [audience, setAudience] = useState<AudienceId>("mixed");
   const [loading, setLoading] = useState(true);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const loadDefaults = useCallback(async () => {
     if (!domainId) { setLoading(false); return; }

--- a/apps/admin/app/x/educator/settings/TerminologySection.tsx
+++ b/apps/admin/app/x/educator/settings/TerminologySection.tsx
@@ -22,7 +22,7 @@ export function TerminologySection({ canEdit }: Props) {
   const [showCustomize, setShowCustomize] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const resolvedTerms = resolveTerminology({ preset: termPreset, overrides: termOverrides });
 

--- a/apps/admin/app/x/educator/settings/WelcomeSection.tsx
+++ b/apps/admin/app/x/educator/settings/WelcomeSection.tsx
@@ -12,8 +12,8 @@ export function WelcomeSection({ domainId, canEdit }: Props) {
   const [welcome, setWelcome] = useState("");
   const [loading, setLoading] = useState(true);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
-  const debounceTimer = useRef<ReturnType<typeof setTimeout>>();
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const loadWelcome = useCallback(async () => {
     if (!domainId) { setLoading(false); return; }

--- a/apps/admin/app/x/student/welcome/page.tsx
+++ b/apps/admin/app/x/student/welcome/page.tsx
@@ -13,7 +13,7 @@ export default function WelcomeSurveyPage(): React.ReactElement {
 
   return (
     <WelcomeSurveyFlow
-      onComplete={() => router.replace(resolveRedirect())}
+      onComplete={() => router.replace(resolveRedirect(undefined))}
       onAlreadyDone={() => router.push("/x/student")}
     />
   );

--- a/apps/admin/app/x/subjects/_components/SubjectDetail.tsx
+++ b/apps/admin/app/x/subjects/_components/SubjectDetail.tsx
@@ -73,6 +73,7 @@ type SubjectSource = {
     trustLevel: string;
     documentType: string;
     documentTypeSource: string | null;
+    extractorVersion: number | null;
     _count: { assertions: number };
   };
 };

--- a/apps/admin/components/shared/ContentJobQueue.tsx
+++ b/apps/admin/components/shared/ContentJobQueue.tsx
@@ -67,6 +67,7 @@ const BackgroundTaskQueueContext = createContext<BackgroundTaskQueueContextValue
   jobs: [],
   addExtractionJob: () => {},
   addCurriculumJob: () => {},
+  addCurriculumEnrichmentJob: () => {},
   addCourseSetupJob: () => {},
   addSnapshotJob: () => {},
   addBulkDeleteJob: () => {},

--- a/apps/admin/e2e/tests/_archived/content-sources/content-sources-wizard.spec.ts
+++ b/apps/admin/e2e/tests/_archived/content-sources/content-sources-wizard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures';
+import { test, expect } from '../../../fixtures';
 
 test.describe('Content Sources Wizard', () => {
   test.beforeEach(async ({ page, loginAs }) => {

--- a/apps/admin/e2e/tests/_archived/content-wizard/content-wizard.spec.ts
+++ b/apps/admin/e2e/tests/_archived/content-wizard/content-wizard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures';
+import { test, expect } from '../../../fixtures';
 
 /**
  * Content Sources & Subject Detail E2E Tests

--- a/apps/admin/e2e/tests/_archived/courses/course-setup.spec.ts
+++ b/apps/admin/e2e/tests/_archived/courses/course-setup.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures';
+import { test, expect } from '../../../fixtures';
 
 test.describe('Course Setup Wizard', () => {
   test.beforeEach(async ({ page, loginAs }) => {

--- a/apps/admin/e2e/tests/_archived/demonstrate/demonstrate-flow.spec.ts
+++ b/apps/admin/e2e/tests/_archived/demonstrate/demonstrate-flow.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures';
-import { TeachPage } from '../../page-objects';
+import { test, expect } from '../../../fixtures';
+import { TeachPage } from '../../../page-objects';
 
 /**
  * Teach Flow Tests

--- a/apps/admin/e2e/tests/_archived/demonstrate/demonstrate.spec.ts
+++ b/apps/admin/e2e/tests/_archived/demonstrate/demonstrate.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures';
-import { TeachPage } from '../../page-objects';
+import { test, expect } from '../../../fixtures';
+import { TeachPage } from '../../../page-objects';
 
 /**
  * Teach Page Tests

--- a/apps/admin/lib/ai/system-context.ts
+++ b/apps/admin/lib/ai/system-context.ts
@@ -91,7 +91,7 @@ interface DomainContext {
 
 interface CallerContext {
   id: string;
-  name: string;
+  name: string | null;
   lastCallAt?: Date;
   totalCalls: number;
 }
@@ -124,7 +124,7 @@ interface PersonaContext {
 
 interface GoalContext {
   callerId: string;
-  callerName: string;
+  callerName: string | null;
   goalType: string;
   title: string;
   status: string;

--- a/apps/admin/src/components/shared/SimpleSidebarNav.tsx
+++ b/apps/admin/src/components/shared/SimpleSidebarNav.tsx
@@ -822,11 +822,13 @@ export default function SimpleSidebarNav({
                         )}
                         <span className="truncate">{item.label}</span>
                         {(rawItem as any).wizard && (
-                          <Sparkles
-                            className="w-[11px] h-[11px] flex-shrink-0 ml-0.5"
-                            style={{ color: "var(--status-warning-text)", opacity: 0.75 }}
-                            title="Guided flow"
-                          />
+                          <span title="Guided flow" className="inline-flex">
+                            <Sparkles
+                              className="w-[11px] h-[11px] flex-shrink-0 ml-0.5"
+                              style={{ color: "var(--status-warning-text)", opacity: 0.75 }}
+                              aria-label="Guided flow"
+                            />
+                          </span>
                         )}
                         {(rawItem as any).tag && (
                           <span

--- a/apps/admin/tests/api/channel-config.test.ts
+++ b/apps/admin/tests/api/channel-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
 
 const mockPrisma = {
   channelConfig: {
@@ -8,7 +9,7 @@ const mockPrisma = {
   },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn().mockResolvedValue({
@@ -60,7 +61,7 @@ describe("/api/settings/channels", () => {
       });
 
       const { POST } = await import("@/app/api/settings/channels/route");
-      const request = new Request("http://localhost/api/settings/channels", {
+      const request = new NextRequest("http://localhost/api/settings/channels", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -82,7 +83,7 @@ describe("/api/settings/channels", () => {
 
     it("returns 400 when channelType missing", async () => {
       const { POST } = await import("@/app/api/settings/channels/route");
-      const request = new Request("http://localhost/api/settings/channels", {
+      const request = new NextRequest("http://localhost/api/settings/channels", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ isEnabled: true }),
@@ -99,7 +100,7 @@ describe("/api/settings/channels", () => {
   describe("DELETE", () => {
     it("deletes a channel config by id", async () => {
       const { DELETE } = await import("@/app/api/settings/channels/route");
-      const request = new Request("http://localhost/api/settings/channels", {
+      const request = new NextRequest("http://localhost/api/settings/channels", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: "cc-1" }),
@@ -117,7 +118,7 @@ describe("/api/settings/channels", () => {
 
     it("returns 400 when id missing", async () => {
       const { DELETE } = await import("@/app/api/settings/channels/route");
-      const request = new Request("http://localhost/api/settings/channels", {
+      const request = new NextRequest("http://localhost/api/settings/channels", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),

--- a/apps/admin/tests/api/communities.test.ts
+++ b/apps/admin/tests/api/communities.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
 
 // =====================================================
 // MOCK SETUP
@@ -39,7 +40,7 @@ const { mockPrisma, mockRequireAuth } = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({
@@ -86,7 +87,7 @@ const mockIdentitySpecs = [
 ];
 
 /** Helper for Next.js 16 params pattern */
-const p = (obj: Record<string, string>) => ({ params: Promise.resolve(obj) });
+const p = <T extends Record<string, string>>(obj: T) => ({ params: Promise.resolve(obj) });
 
 // =====================================================
 // TESTS
@@ -106,7 +107,7 @@ describe("/api/communities", () => {
     it("lists all communities", async () => {
       mockPrisma.domain.findMany.mockResolvedValue([mockCommunity]);
 
-      const req = new Request("http://localhost/api/communities");
+      const req = new NextRequest("http://localhost/api/communities");
       const res = await getCommunitiesList(req);
       const body = await res.json();
 
@@ -117,7 +118,7 @@ describe("/api/communities", () => {
     });
 
     it("filters by kind=COMMUNITY", async () => {
-      await getCommunitiesList(new Request("http://localhost/api/communities"));
+      await getCommunitiesList(new NextRequest("http://localhost/api/communities"));
 
       expect(mockPrisma.domain.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -133,14 +134,14 @@ describe("/api/communities", () => {
       const { isAuthError } = await import("@/lib/permissions") as any;
       isAuthError.mockReturnValueOnce(true);
 
-      const res = await getCommunitiesList(new Request("http://localhost/api/communities"));
+      const res = await getCommunitiesList(new NextRequest("http://localhost/api/communities"));
       expect(res.status).toBe(403);
     });
 
     it("returns empty list when no communities exist", async () => {
       mockPrisma.domain.findMany.mockResolvedValue([]);
 
-      const req = new Request("http://localhost/api/communities");
+      const req = new NextRequest("http://localhost/api/communities");
       const res = await getCommunitiesList(req);
       const body = await res.json();
 
@@ -155,7 +156,7 @@ describe("/api/communities", () => {
       mockPrisma.domain.findUnique.mockResolvedValue(mockCommunity);
       mockPrisma.analysisSpec.findMany.mockResolvedValue(mockIdentitySpecs);
 
-      const req = new Request("http://localhost/api/communities/comm-1");
+      const req = new NextRequest("http://localhost/api/communities/comm-1");
       const res = await getCommunity(req, p({ communityId: "comm-1" }));
       const body = await res.json();
 
@@ -176,7 +177,7 @@ describe("/api/communities", () => {
     it("returns 404 if community not found", async () => {
       mockPrisma.domain.findUnique.mockResolvedValue(null);
 
-      const req = new Request("http://localhost/api/communities/nonexistent");
+      const req = new NextRequest("http://localhost/api/communities/nonexistent");
       const res = await getCommunity(req, p({ communityId: "nonexistent" }));
       const body = await res.json();
 
@@ -191,7 +192,7 @@ describe("/api/communities", () => {
         kind: "INSTITUTION",
       });
 
-      const req = new Request("http://localhost/api/communities/comm-1");
+      const req = new NextRequest("http://localhost/api/communities/comm-1");
       const res = await getCommunity(req, p({ communityId: "comm-1" }));
       const body = await res.json();
 
@@ -206,7 +207,7 @@ describe("/api/communities", () => {
       mockPrisma.domain.findUnique.mockResolvedValue(mockCommunity);
       mockPrisma.domain.update.mockResolvedValue(updated);
 
-      const req = new Request("http://localhost/api/communities/comm-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "New Name" }),
@@ -229,7 +230,7 @@ describe("/api/communities", () => {
       mockPrisma.domain.findUnique.mockResolvedValue(mockCommunity);
       mockPrisma.domain.update.mockResolvedValue(updated);
 
-      const req = new Request("http://localhost/api/communities/comm-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ onboardingWelcome: "New Welcome" }),
@@ -256,7 +257,7 @@ describe("/api/communities", () => {
       mockPrisma.domain.findUnique.mockResolvedValue(mockCommunity);
       mockPrisma.domain.update.mockResolvedValue(updated);
 
-      const req = new Request("http://localhost/api/communities/comm-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -285,7 +286,7 @@ describe("/api/communities", () => {
       mockPrisma.domain.findUnique.mockResolvedValue(mockCommunity);
       mockPrisma.domain.update.mockResolvedValue(updated);
 
-      const req = new Request("http://localhost/api/communities/comm-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ onboardingFlowPhases: phases }),
@@ -305,7 +306,7 @@ describe("/api/communities", () => {
     it("returns 400 if no fields to update", async () => {
       mockPrisma.domain.findUnique.mockResolvedValue(mockCommunity);
 
-      const req = new Request("http://localhost/api/communities/comm-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -321,7 +322,7 @@ describe("/api/communities", () => {
     it("returns 404 if community not found", async () => {
       mockPrisma.domain.findUnique.mockResolvedValue(null);
 
-      const req = new Request("http://localhost/api/communities/nonexistent", {
+      const req = new NextRequest("http://localhost/api/communities/nonexistent", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "New Name" }),
@@ -343,7 +344,7 @@ describe("/api/communities", () => {
         isActive: false,
       });
 
-      const req = new Request("http://localhost/api/communities/comm-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1", {
         method: "DELETE",
       });
 
@@ -360,7 +361,7 @@ describe("/api/communities", () => {
     it("returns 404 if community not found", async () => {
       mockPrisma.domain.findUnique.mockResolvedValue(null);
 
-      const req = new Request("http://localhost/api/communities/nonexistent", {
+      const req = new NextRequest("http://localhost/api/communities/nonexistent", {
         method: "DELETE",
       });
 
@@ -379,7 +380,7 @@ describe("/api/communities", () => {
       isAuthError.mockReturnValueOnce(true);
 
       const res = await deleteCommunity(
-        new Request("http://localhost/api/communities/comm-1", { method: "DELETE" }),
+        new NextRequest("http://localhost/api/communities/comm-1", { method: "DELETE" }),
         p({ communityId: "comm-1" })
       );
 
@@ -406,7 +407,7 @@ describe("/api/communities", () => {
         email: "charlie@test.com",
       });
 
-      const req = new Request("http://localhost/api/communities/comm-1/members", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1/members", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ callerId: "caller-3" }),
@@ -427,7 +428,7 @@ describe("/api/communities", () => {
     it("returns 400 if callerId missing", async () => {
       mockPrisma.domain.findUnique.mockResolvedValue({ kind: "COMMUNITY" });
 
-      const req = new Request("http://localhost/api/communities/comm-1/members", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1/members", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -443,7 +444,7 @@ describe("/api/communities", () => {
     it("returns 404 if community not found", async () => {
       mockPrisma.domain.findUnique.mockResolvedValue(null);
 
-      const req = new Request("http://localhost/api/communities/nonexistent/members", {
+      const req = new NextRequest("http://localhost/api/communities/nonexistent/members", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ callerId: "caller-3" }),
@@ -460,7 +461,7 @@ describe("/api/communities", () => {
       mockPrisma.domain.findUnique.mockResolvedValue({ kind: "COMMUNITY" });
       mockPrisma.caller.findUnique.mockResolvedValue(null);
 
-      const req = new Request("http://localhost/api/communities/comm-1/members", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1/members", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ callerId: "nonexistent" }),
@@ -482,7 +483,7 @@ describe("/api/communities", () => {
         domainId: "comm-1",
       });
 
-      const req = new Request("http://localhost/api/communities/comm-1/members", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1/members", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ callerId: "caller-1" }),
@@ -504,7 +505,7 @@ describe("/api/communities", () => {
       });
       mockPrisma.caller.update.mockResolvedValue({});
 
-      const req = new Request("http://localhost/api/communities/comm-1/members/caller-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1/members/caller-1", {
         method: "DELETE",
       });
 
@@ -521,7 +522,7 @@ describe("/api/communities", () => {
     it("returns 404 if community not found", async () => {
       mockPrisma.domain.findUnique.mockResolvedValue(null);
 
-      const req = new Request("http://localhost/api/communities/nonexistent/members/caller-1", {
+      const req = new NextRequest("http://localhost/api/communities/nonexistent/members/caller-1", {
         method: "DELETE",
       });
 
@@ -538,7 +539,7 @@ describe("/api/communities", () => {
         domainId: "other-domain",
       });
 
-      const req = new Request("http://localhost/api/communities/comm-1/members/caller-1", {
+      const req = new NextRequest("http://localhost/api/communities/comm-1/members/caller-1", {
         method: "DELETE",
       });
 

--- a/apps/admin/tests/api/institution-types.test.ts
+++ b/apps/admin/tests/api/institution-types.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
 
 // Mock auth
 vi.mock('@/lib/permissions', () => ({
@@ -18,7 +19,7 @@ vi.mock('@/lib/prisma', () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx: unknown) => tx ?? _p.prisma };
 });
 
 // Mock terminology cache
@@ -97,7 +98,7 @@ describe('POST /api/admin/institution-types', () => {
   });
 
   it('should require name', async () => {
-    const req = new Request('http://localhost/api/admin/institution-types', {
+    const req = new NextRequest('http://localhost/api/admin/institution-types', {
       method: 'POST',
       body: JSON.stringify({ slug: 'test', terminology: VALID_TERMINOLOGY }),
     });
@@ -110,7 +111,7 @@ describe('POST /api/admin/institution-types', () => {
   });
 
   it('should require slug', async () => {
-    const req = new Request('http://localhost/api/admin/institution-types', {
+    const req = new NextRequest('http://localhost/api/admin/institution-types', {
       method: 'POST',
       body: JSON.stringify({ name: 'Test', terminology: VALID_TERMINOLOGY }),
     });
@@ -123,7 +124,7 @@ describe('POST /api/admin/institution-types', () => {
   });
 
   it('should validate slug format', async () => {
-    const req = new Request('http://localhost/api/admin/institution-types', {
+    const req = new NextRequest('http://localhost/api/admin/institution-types', {
       method: 'POST',
       body: JSON.stringify({
         name: 'Test',
@@ -140,7 +141,7 @@ describe('POST /api/admin/institution-types', () => {
   });
 
   it('should require all 7 terminology keys', async () => {
-    const req = new Request('http://localhost/api/admin/institution-types', {
+    const req = new NextRequest('http://localhost/api/admin/institution-types', {
       method: 'POST',
       body: JSON.stringify({
         name: 'Test',
@@ -159,7 +160,7 @@ describe('POST /api/admin/institution-types', () => {
   it('should reject duplicate slug', async () => {
     vi.mocked(prisma.institutionType.findUnique).mockResolvedValue({ id: 'existing' } as any);
 
-    const req = new Request('http://localhost/api/admin/institution-types', {
+    const req = new NextRequest('http://localhost/api/admin/institution-types', {
       method: 'POST',
       body: JSON.stringify({
         name: 'Duplicate',
@@ -184,7 +185,7 @@ describe('POST /api/admin/institution-types', () => {
       terminology: VALID_TERMINOLOGY,
     } as any);
 
-    const req = new Request('http://localhost/api/admin/institution-types', {
+    const req = new NextRequest('http://localhost/api/admin/institution-types', {
       method: 'POST',
       body: JSON.stringify({
         name: 'University',

--- a/apps/admin/tests/api/media-serve.test.ts
+++ b/apps/admin/tests/api/media-serve.test.ts
@@ -12,7 +12,7 @@ const mockPrisma = {
   },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn().mockResolvedValue({
@@ -100,7 +100,7 @@ describe("/api/media/[id]", () => {
 
       const { DELETE } = await import("@/app/api/media/[id]/route");
 
-      const request = new Request("http://localhost/api/media/media-1", { method: "DELETE" });
+      const request = new NextRequest("http://localhost/api/media/media-1", { method: "DELETE" });
       const response = await DELETE(request, {
         params: Promise.resolve({ id: "media-1" }),
       });
@@ -117,7 +117,7 @@ describe("/api/media/[id]", () => {
 
       const { DELETE } = await import("@/app/api/media/[id]/route");
 
-      const request = new Request("http://localhost/api/media/nope", { method: "DELETE" });
+      const request = new NextRequest("http://localhost/api/media/nope", { method: "DELETE" });
       const response = await DELETE(request, {
         params: Promise.resolve({ id: "nope" }),
       });
@@ -160,7 +160,7 @@ describe("/api/media/[id]", () => {
       const formData = new FormData();
       formData.append("file", new File(["new content"], "new-photo.png", { type: "image/png" }));
 
-      const request = new Request("http://localhost/api/media/media-1", {
+      const request = new NextRequest("http://localhost/api/media/media-1", {
         method: "PATCH",
         body: formData,
       });
@@ -186,7 +186,7 @@ describe("/api/media/[id]", () => {
       const formData = new FormData();
       formData.append("file", new File(["data"], "test.png", { type: "image/png" }));
 
-      const request = new Request("http://localhost/api/media/nope", {
+      const request = new NextRequest("http://localhost/api/media/nope", {
         method: "PATCH",
         body: formData,
       });
@@ -206,7 +206,7 @@ describe("/api/media/[id]", () => {
       const { PATCH } = await import("@/app/api/media/[id]/route");
 
       const formData = new FormData();
-      const request = new Request("http://localhost/api/media/media-1", {
+      const request = new NextRequest("http://localhost/api/media/media-1", {
         method: "PATCH",
         body: formData,
       });
@@ -229,7 +229,7 @@ describe("/api/media/[id]", () => {
       const formData = new FormData();
       formData.append("file", new File(["data"], "evil.exe", { type: "application/x-msdownload" }));
 
-      const request = new Request("http://localhost/api/media/media-1", {
+      const request = new NextRequest("http://localhost/api/media/media-1", {
         method: "PATCH",
         body: formData,
       });
@@ -253,7 +253,7 @@ describe("/api/media/[id]", () => {
       const formData = new FormData();
       formData.append("file", new File(["same"], "same.png", { type: "image/png" }));
 
-      const request = new Request("http://localhost/api/media/media-1", {
+      const request = new NextRequest("http://localhost/api/media/media-1", {
         method: "PATCH",
         body: formData,
       });
@@ -278,7 +278,7 @@ describe("/api/media/[id]", () => {
       const formData = new FormData();
       formData.append("file", new File(["data"], "dup.png", { type: "image/png" }));
 
-      const request = new Request("http://localhost/api/media/media-1", {
+      const request = new NextRequest("http://localhost/api/media/media-1", {
         method: "PATCH",
         body: formData,
       });

--- a/apps/admin/tests/api/media-upload.test.ts
+++ b/apps/admin/tests/api/media-upload.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
 
 // Local mocks
 const mockPrisma = {
@@ -15,7 +16,7 @@ const mockPrisma = {
 const mockIsAllowedMimeType = vi.fn().mockReturnValue(true);
 const mockIsAllowedFileSize = vi.fn().mockReturnValue(true);
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn().mockResolvedValue({
@@ -65,7 +66,7 @@ describe("POST /api/media/upload", () => {
     const formData = new FormData();
     formData.append("file", new File(["hello"], "test.png", { type: "image/png" }));
 
-    const request = new Request("http://localhost/api/media/upload", {
+    const request = new NextRequest("http://localhost/api/media/upload", {
       method: "POST",
       body: formData,
     });
@@ -93,7 +94,7 @@ describe("POST /api/media/upload", () => {
     const formData = new FormData();
     formData.append("file", new File(["hello"], "duplicate.png", { type: "image/png" }));
 
-    const request = new Request("http://localhost/api/media/upload", {
+    const request = new NextRequest("http://localhost/api/media/upload", {
       method: "POST",
       body: formData,
     });
@@ -111,7 +112,7 @@ describe("POST /api/media/upload", () => {
     const { POST } = await import("@/app/api/media/upload/route");
 
     const formData = new FormData();
-    const request = new Request("http://localhost/api/media/upload", {
+    const request = new NextRequest("http://localhost/api/media/upload", {
       method: "POST",
       body: formData,
     });
@@ -132,7 +133,7 @@ describe("POST /api/media/upload", () => {
     const formData = new FormData();
     formData.append("file", new File(["data"], "evil.exe", { type: "application/x-msdownload" }));
 
-    const request = new Request("http://localhost/api/media/upload", {
+    const request = new NextRequest("http://localhost/api/media/upload", {
       method: "POST",
       body: formData,
     });
@@ -153,7 +154,7 @@ describe("POST /api/media/upload", () => {
     const formData = new FormData();
     formData.append("file", new File(["data"], "big.png", { type: "image/png" }));
 
-    const request = new Request("http://localhost/api/media/upload", {
+    const request = new NextRequest("http://localhost/api/media/upload", {
       method: "POST",
       body: formData,
     });
@@ -182,7 +183,7 @@ describe("POST /api/media/upload", () => {
     formData.append("file", new File(["data"], "test.png", { type: "image/png" }));
     formData.append("subjectId", "subject-1");
 
-    const request = new Request("http://localhost/api/media/upload", {
+    const request = new NextRequest("http://localhost/api/media/upload", {
       method: "POST",
       body: formData,
     });

--- a/apps/admin/tests/lib/prompt/composition/offboarding.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/offboarding.test.ts
@@ -15,6 +15,7 @@ import type { AssembledContext, SharedComputedState, CompositionSectionDef } fro
 /** Minimal shared state with overridable fields */
 function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
   return {
+    channel: "text",
     modules: [],
     isFirstCall: false,
     daysSinceLastCall: 0,
@@ -27,6 +28,7 @@ function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedCo
     reviewReason: "",
     thresholds: { high: 0.65, low: 0.35 },
     isFinalSession: false,
+    callNumber: 1,
     ...overrides,
   };
 }


### PR DESCRIPTION
Closes #376

## Summary

Sweeps signature-drift errors across five clusters that were causing ~120 tsc errors.

| Cluster | Count | Fix |
|---------|-------|-----|
| `Request` -> `NextRequest` | 48 | Switched 5 api tests to use `new NextRequest(...)` instead of `new Request(...)` |
| `Expected 1 arg, got 0` | 9 | `useRef<T>()` now passes explicit `undefined` initialiser (React 19); `resolveRedirect()` gets explicit arg |
| Property-shape mismatches | 4 | Extended fallback stats object, added missing fields (`extractorVersion`, `addCurriculumEnrichmentJob`), relaxed `CallerContext.name` / `GoalContext.callerName` to `string \| null`, wrapped lucide icon in `<span title>` |
| Missing `../../fixtures` | 5 | Archived e2e tests two dirs deeper than active ones; fixed import paths |
| Offboarding test fixture | 1 | Added required `channel` and `callNumber` fields |

## Numbers

- **tsc_errors**: 567 -> 347 (-220 below previous baseline)
- **lint_warnings**: 9531 -> 9529 (no new warnings)
- **lint_errors**: 0 (unchanged)
- `.ratchet.json` locked to the new floor

## Discipline

- No `as any` casts introduced
- No `eslint-disable` comments
- All test mocks typed (`db: (tx: unknown)` instead of implicit-any)

## Test plan

- [x] `npm run ratchet:check` — all 4 metrics pass at new baseline
- [x] `npx vitest run` on the 5 touched test files — 49 passed (1 file quarantined)
- [x] `npx tsc --noEmit` — clean on all touched files; only pre-existing errors remain in the codebase

Stacks on top of Tier 4 (#378).

Generated with [Claude Code](https://claude.com/claude-code)