### PR TITLE
chore(#377): clear Tier-6 safe-noise typing cleanup

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 347,
+  "tsc_errors": 195,
   "lint_errors": 0,
   "lint_warnings": 9529,
   "quarantined_tests": 31,

--- a/apps/admin/app/api/admin/bulk-delete/job/route.ts
+++ b/apps/admin/app/api/admin/bulk-delete/job/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest) {
     if (isAuthError(authResult)) return authResult.error;
 
     const body = await request.json();
-    const { entityType, entityIds } = body;
+    const { entityType, entityIds } = body as { entityType: EntityType; entityIds: unknown };
 
     if (!entityType || !VALID_TYPES.includes(entityType)) {
       return NextResponse.json(

--- a/apps/admin/app/api/admin/bulk-delete/route.ts
+++ b/apps/admin/app/api/admin/bulk-delete/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
     if (isAuthError(authResult)) return authResult.error;
 
     const body = await request.json();
-    const { entityType, entityIds } = body;
+    const { entityType, entityIds } = body as { entityType: EntityType; entityIds: unknown };
 
     if (!entityType || !VALID_TYPES.includes(entityType)) {
       return NextResponse.json(

--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -77,8 +77,12 @@ export async function POST(request: NextRequest) {
     // Skip zod validation entirely — extract fields manually with type guards
     // (Turbopack cold-compile race prevents ANY zod usage on first request)
     const message = typeof rawBody?.message === "string" ? rawBody.message : "";
-    const entityContext = Array.isArray(rawBody?.entityContext) ? rawBody.entityContext : [];
-    const conversationHistory = Array.isArray(rawBody?.conversationHistory) ? rawBody.conversationHistory : [];
+    const entityContext: EntityBreadcrumb[] = Array.isArray(rawBody?.entityContext)
+      ? (rawBody.entityContext as EntityBreadcrumb[])
+      : [];
+    const conversationHistory: Array<{ role: string; content: string }> = Array.isArray(rawBody?.conversationHistory)
+      ? rawBody.conversationHistory
+      : [];
     const engine = typeof rawBody?.engine === "string" ? rawBody.engine : undefined;
     const requestCallId = typeof rawBody?.callId === "string" ? rawBody.callId : undefined;
     const bugContext = rawBody?.bugContext || undefined;

--- a/apps/admin/app/x/_dashboards/DashboardClient.tsx
+++ b/apps/admin/app/x/_dashboards/DashboardClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, type JSX } from "react";
 import Link from "next/link";
 import { ChevronRight, Plus } from "lucide-react";
 import { useTerminology } from "@/contexts/TerminologyContext";

--- a/apps/admin/app/x/courses/[courseId]/CohortLearningAggregate.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CohortLearningAggregate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type JSX } from 'react';
 import { BarChart3 } from 'lucide-react';
 
 interface CohortAggregateData {

--- a/apps/admin/components/callers/caller-detail/SurveySection.tsx
+++ b/apps/admin/components/callers/caller-detail/SurveySection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, type JSX } from "react";
 import { PRE_SURVEY_KEYS, POST_SURVEY_KEYS } from "@/lib/learner/survey-keys";
 import "./survey-section.css";
 

--- a/apps/admin/components/callers/caller-detail/cards/LearningTrajectoryCard.tsx
+++ b/apps/admin/components/callers/caller-detail/cards/LearningTrajectoryCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type JSX } from 'react';
 import { Sparkline } from '@/components/shared/Sparkline';
 
 interface LearningScore {

--- a/apps/admin/components/sim/PostCallProgressCard.tsx
+++ b/apps/admin/components/sim/PostCallProgressCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type JSX } from 'react';
 
 interface LearningParam {
   parameterId: string;

--- a/apps/admin/components/sim/SimProgressPanel.tsx
+++ b/apps/admin/components/sim/SimProgressPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, type JSX } from 'react';
 import { ArrowLeft, X, Target, BookOpen, Lightbulb, Phone, TrendingUp } from 'lucide-react';
 import { useStudentProgress } from '@/hooks/useStudentProgress';
 import { useJourneyPosition } from '@/hooks/useJourneyPosition';

--- a/apps/admin/lib/content-trust/extract-assertions.ts
+++ b/apps/admin/lib/content-trust/extract-assertions.ts
@@ -147,7 +147,11 @@ export async function extractTextFromPptx(buffer: Buffer): Promise<{ text: strin
  */
 export async function extractTextFromDoc(buffer: Buffer): Promise<{ text: string }> {
   // Dynamic import to avoid bundling issues
-  const WordExtractor = (await import("word-extractor")).default;
+  // word-extractor ships no type declarations — declare a minimal shape inline.
+  const mod = (await import("word-extractor")) as {
+    default: new () => { extract: (b: Buffer) => Promise<{ getBody: () => string }> };
+  };
+  const WordExtractor = mod.default;
   const extractor = new WordExtractor();
   const doc = await extractor.extract(buffer);
   return { text: doc.getBody() };

--- a/apps/admin/lib/masquerade.ts
+++ b/apps/admin/lib/masquerade.ts
@@ -49,14 +49,15 @@ export async function getMasqueradeState(): Promise<MasqueradeState | null> {
  * Check if a user role is ADMIN+ (allowed to masquerade).
  */
 export function canMasquerade(role: string): boolean {
-  return (ROLE_LEVEL[role] ?? 0) >= ROLE_LEVEL.ADMIN;
+  return ((ROLE_LEVEL as Record<string, number>)[role] ?? 0) >= ROLE_LEVEL.ADMIN;
 }
 
 /**
  * Check that a masqueraded role doesn't exceed the real user's role (prevent escalation).
  */
 export function isRoleEscalation(realRole: string, masqueradeRole: string): boolean {
-  return (ROLE_LEVEL[masqueradeRole] ?? 0) > (ROLE_LEVEL[realRole] ?? 0);
+  const lvl = ROLE_LEVEL as Record<string, number>;
+  return (lvl[masqueradeRole] ?? 0) > (lvl[realRole] ?? 0);
 }
 
 /**

--- a/apps/admin/lib/prompt/composition/transforms/visual-aids.ts
+++ b/apps/admin/lib/prompt/composition/transforms/visual-aids.ts
@@ -18,7 +18,10 @@ registerTransform("formatVisualAids", (rawData, context) => {
   if (!aids || aids.length === 0) return null;
 
   // Collect session-specific media IDs from lesson plan entry
-  const sessionMedia = context.sharedState?.lessonPlanEntry?.media;
+  const sessionMedia = context.sharedState?.lessonPlanEntry?.media as
+    | Array<{ mediaId: string }>
+    | null
+    | undefined;
   const sessionMediaIds = new Set(sessionMedia?.map((m) => m.mediaId) || []);
 
   const available = aids.map((a) => ({

--- a/apps/admin/src/components/shared/SimpleSidebarNav.tsx
+++ b/apps/admin/src/components/shared/SimpleSidebarNav.tsx
@@ -176,7 +176,7 @@ export default function SimpleSidebarNav({
   const { isMasquerading, effectiveRole } = useMasquerade();
   const userRole = isMasquerading ? effectiveRole : realRole;
   const isAdmin = realIsAdmin; // Keep admin features (layout save, masquerade trigger) based on real role
-  const effectiveIsAdmin = (ROLE_LEVEL[effectiveRole] ?? 0) >= 4; // For API calls that go through requireAuth
+  const effectiveIsAdmin = ((ROLE_LEVEL as Record<string, number>)[effectiveRole] ?? 0) >= 4; // For API calls that go through requireAuth
   const { isAdvanced } = useViewMode();
 
   // ── DB-backed visibility rules (overrides manifest requiredRole/defaultHiddenFor) ──

--- a/apps/admin/tests/api/account.test.ts
+++ b/apps/admin/tests/api/account.test.ts
@@ -28,7 +28,7 @@ const { mockPrisma, mockRequireAuth } = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/actions.test.ts
+++ b/apps/admin/tests/api/actions.test.ts
@@ -29,7 +29,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // =====================================================

--- a/apps/admin/tests/api/admin-terminology.test.ts
+++ b/apps/admin/tests/api/admin-terminology.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/prisma', () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { requireAuth, isAuthError } from '@/lib/permissions';

--- a/apps/admin/tests/api/agent-tuner-interpret.test.ts
+++ b/apps/admin/tests/api/agent-tuner-interpret.test.ts
@@ -72,7 +72,7 @@ const mockPrisma = {
   behaviorTarget: { findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 const mockAI = vi.fn();
 vi.mock("@/lib/metering/instrumented-ai", () => ({

--- a/apps/admin/tests/api/ai-config.test.ts
+++ b/apps/admin/tests/api/ai-config.test.ts
@@ -24,7 +24,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // =====================================================

--- a/apps/admin/tests/api/artifacts.test.ts
+++ b/apps/admin/tests/api/artifacts.test.ts
@@ -21,7 +21,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // =====================================================

--- a/apps/admin/tests/api/assertion-crud.test.ts
+++ b/apps/admin/tests/api/assertion-crud.test.ts
@@ -22,7 +22,7 @@ const mockPrisma = {
     findMany: vi.fn(),
   },
 };
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 // ── Helpers ────────────────────────────────────────────
 

--- a/apps/admin/tests/api/call-interject.test.ts
+++ b/apps/admin/tests/api/call-interject.test.ts
@@ -30,7 +30,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/educator-access", () => ({

--- a/apps/admin/tests/api/call-messages.test.ts
+++ b/apps/admin/tests/api/call-messages.test.ts
@@ -29,7 +29,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/caller-enrollments.test.ts
+++ b/apps/admin/tests/api/caller-enrollments.test.ts
@@ -39,7 +39,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 import { GET, POST } from "@/app/api/callers/[callerId]/enrollments/route";

--- a/apps/admin/tests/api/caller-media-history.test.ts
+++ b/apps/admin/tests/api/caller-media-history.test.ts
@@ -9,7 +9,7 @@ const mockPrisma = {
   callMessage: { findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/callers-detail.test.ts
+++ b/apps/admin/tests/api/callers-detail.test.ts
@@ -112,7 +112,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Mock external lib dependencies used by the caller detail GET route

--- a/apps/admin/tests/api/callers.test.ts
+++ b/apps/admin/tests/api/callers.test.ts
@@ -30,7 +30,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Override access-control mock to include buildScopeFilter

--- a/apps/admin/tests/api/cohort-activity.test.ts
+++ b/apps/admin/tests/api/cohort-activity.test.ts
@@ -29,7 +29,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/access-control", () => ({

--- a/apps/admin/tests/api/cohort-dashboard.test.ts
+++ b/apps/admin/tests/api/cohort-dashboard.test.ts
@@ -32,7 +32,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/access-control", () => ({

--- a/apps/admin/tests/api/cohort-invite.test.ts
+++ b/apps/admin/tests/api/cohort-invite.test.ts
@@ -27,7 +27,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/access-control", () => ({

--- a/apps/admin/tests/api/cohort-join-link.test.ts
+++ b/apps/admin/tests/api/cohort-join-link.test.ts
@@ -24,7 +24,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/access-control", () => ({

--- a/apps/admin/tests/api/cohort-members.test.ts
+++ b/apps/admin/tests/api/cohort-members.test.ts
@@ -29,7 +29,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/access-control", () => ({

--- a/apps/admin/tests/api/cohort-playbooks.test.ts
+++ b/apps/admin/tests/api/cohort-playbooks.test.ts
@@ -54,7 +54,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 import { GET, POST } from "@/app/api/cohorts/[cohortId]/playbooks/route";

--- a/apps/admin/tests/api/cohorts.test.ts
+++ b/apps/admin/tests/api/cohorts.test.ts
@@ -44,7 +44,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/access-control", () => ({

--- a/apps/admin/tests/api/content-source-extract.test.ts
+++ b/apps/admin/tests/api/content-source-extract.test.ts
@@ -67,7 +67,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { POST } from "@/app/api/content-sources/[sourceId]/extract/route";

--- a/apps/admin/tests/api/content-source-import-classify.test.ts
+++ b/apps/admin/tests/api/content-source-import-classify.test.ts
@@ -99,7 +99,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { POST } from "@/app/api/content-sources/[sourceId]/import/route";

--- a/apps/admin/tests/api/content-source-lifecycle.test.ts
+++ b/apps/admin/tests/api/content-source-lifecycle.test.ts
@@ -28,7 +28,7 @@ const mockPrisma = {
     delete: vi.fn(),
   },
 };
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 // ── Helpers ────────────────────────────────────────────
 

--- a/apps/admin/tests/api/content-source-question-review.test.ts
+++ b/apps/admin/tests/api/content-source-question-review.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { PATCH, DELETE } from "@/app/api/content-sources/[sourceId]/questions/[questionId]/route";

--- a/apps/admin/tests/api/content-source-questions.test.ts
+++ b/apps/admin/tests/api/content-source-questions.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { GET, DELETE } from "@/app/api/content-sources/[sourceId]/questions/route";

--- a/apps/admin/tests/api/content-source-structure.test.ts
+++ b/apps/admin/tests/api/content-source-structure.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/content-source-upload.test.ts
+++ b/apps/admin/tests/api/content-source-upload.test.ts
@@ -68,7 +68,7 @@ vi.mock("@/lib/prisma", () => {
     subjectMedia: { upsert: mocks.subjectMediaUpsert },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { POST } from "@/app/api/subjects/[subjectId]/upload/route";

--- a/apps/admin/tests/api/content-source-vocabulary-review.test.ts
+++ b/apps/admin/tests/api/content-source-vocabulary-review.test.ts
@@ -38,7 +38,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { PATCH, DELETE } from "@/app/api/content-sources/[sourceId]/vocabulary/[vocabId]/route";

--- a/apps/admin/tests/api/content-source-vocabulary.test.ts
+++ b/apps/admin/tests/api/content-source-vocabulary.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { GET, DELETE } from "@/app/api/content-sources/[sourceId]/vocabulary/route";

--- a/apps/admin/tests/api/course-readiness.test.ts
+++ b/apps/admin/tests/api/course-readiness.test.ts
@@ -21,7 +21,7 @@ const mockPrisma = {
     findUnique: vi.fn(),
   },
 };
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/config", () => ({
   config: {

--- a/apps/admin/tests/api/courses-setup.test.ts
+++ b/apps/admin/tests/api/courses-setup.test.ts
@@ -13,7 +13,7 @@ const mockTaskGuidance = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/ai/task-guidance", () => ({

--- a/apps/admin/tests/api/curriculum-preview.test.ts
+++ b/apps/admin/tests/api/curriculum-preview.test.ts
@@ -21,7 +21,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/domain-preview-prompt.test.ts
+++ b/apps/admin/tests/api/domain-preview-prompt.test.ts
@@ -31,7 +31,7 @@ const mockPrisma = {
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock('@/lib/permissions', () => ({

--- a/apps/admin/tests/api/domains-classroom.test.ts
+++ b/apps/admin/tests/api/domains-classroom.test.ts
@@ -30,7 +30,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/enrollment", () => ({

--- a/apps/admin/tests/api/domains.test.ts
+++ b/apps/admin/tests/api/domains.test.ts
@@ -34,7 +34,7 @@ const mockPrisma = {
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Mock auth — routes now call requireAuth() which calls auth()

--- a/apps/admin/tests/api/educator-active-calls.test.ts
+++ b/apps/admin/tests/api/educator-active-calls.test.ts
@@ -23,7 +23,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/educator-access", () => ({

--- a/apps/admin/tests/api/educator-classroom-artifacts.test.ts
+++ b/apps/admin/tests/api/educator-classroom-artifacts.test.ts
@@ -19,7 +19,7 @@ const mockPrisma = {
   },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/educator-access", () => ({
   requireEducator: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/educator-classrooms.test.ts
+++ b/apps/admin/tests/api/educator-classrooms.test.ts
@@ -46,7 +46,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/educator-dashboard.test.ts
+++ b/apps/admin/tests/api/educator-dashboard.test.ts
@@ -29,7 +29,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/educator-access", () => ({

--- a/apps/admin/tests/api/educator-invite-teacher.test.ts
+++ b/apps/admin/tests/api/educator-invite-teacher.test.ts
@@ -31,7 +31,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/educator-access", () => ({

--- a/apps/admin/tests/api/educator-playbooks.test.ts
+++ b/apps/admin/tests/api/educator-playbooks.test.ts
@@ -10,7 +10,7 @@ const mockPrisma = {
   playbook: { findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/educator-access", () => ({
   requireEducator: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/educator-readiness.test.ts
+++ b/apps/admin/tests/api/educator-readiness.test.ts
@@ -16,7 +16,7 @@ const mockPrisma = {
   caller: { count: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/educator-access", () => ({
   requireEducator: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/educator-reports.test.ts
+++ b/apps/admin/tests/api/educator-reports.test.ts
@@ -35,7 +35,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/educator-student-artifacts.test.ts
+++ b/apps/admin/tests/api/educator-student-artifacts.test.ts
@@ -15,7 +15,7 @@ const mockPrisma = {
   },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/educator-access", () => ({
   requireEducator: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/educator-student-enrollments.test.ts
+++ b/apps/admin/tests/api/educator-student-enrollments.test.ts
@@ -35,7 +35,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/educator-students.test.ts
+++ b/apps/admin/tests/api/educator-students.test.ts
@@ -36,7 +36,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/extraction-config.test.ts
+++ b/apps/admin/tests/api/extraction-config.test.ts
@@ -57,7 +57,7 @@ vi.mock("@/lib/prisma", () => {
     }),
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/goals-crud.test.ts
+++ b/apps/admin/tests/api/goals-crud.test.ts
@@ -26,7 +26,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@prisma/client", async (importOriginal) => {

--- a/apps/admin/tests/api/goals.test.ts
+++ b/apps/admin/tests/api/goals.test.ts
@@ -20,7 +20,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // =====================================================

--- a/apps/admin/tests/api/join-token.test.ts
+++ b/apps/admin/tests/api/join-token.test.ts
@@ -32,7 +32,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("next-auth/jwt", () => ({

--- a/apps/admin/tests/api/layers-diff.test.ts
+++ b/apps/admin/tests/api/layers-diff.test.ts
@@ -20,7 +20,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/lesson-plan.test.ts
+++ b/apps/admin/tests/api/lesson-plan.test.ts
@@ -18,7 +18,7 @@ const mockPrisma = {
     groupBy: vi.fn(),
   },
 };
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 const mockAICompletion = vi.fn();
 vi.mock("@/lib/metering/instrumented-ai", () => ({

--- a/apps/admin/tests/api/masquerade.test.ts
+++ b/apps/admin/tests/api/masquerade.test.ts
@@ -21,7 +21,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 const mockAuditLog = vi.fn();

--- a/apps/admin/tests/api/memories.test.ts
+++ b/apps/admin/tests/api/memories.test.ts
@@ -26,7 +26,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // =====================================================

--- a/apps/admin/tests/api/onboarding.test.ts
+++ b/apps/admin/tests/api/onboarding.test.ts
@@ -25,7 +25,7 @@ const mockPrisma = {
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Mock auth - default to passing

--- a/apps/admin/tests/api/pipeline-resilience.test.ts
+++ b/apps/admin/tests/api/pipeline-resilience.test.ts
@@ -89,7 +89,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/ai/client", () => ({

--- a/apps/admin/tests/api/pipeline.test.ts
+++ b/apps/admin/tests/api/pipeline.test.ts
@@ -84,7 +84,7 @@ const mockPrisma = {
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Mock AI client

--- a/apps/admin/tests/api/playbook-targets-suggest.test.ts
+++ b/apps/admin/tests/api/playbook-targets-suggest.test.ts
@@ -87,7 +87,7 @@ const mockPrisma = {
   behaviorTarget: { findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 const mockAI = vi.fn();
 vi.mock("@/lib/metering/instrumented-ai", () => ({

--- a/apps/admin/tests/api/sim-pipeline.test.ts
+++ b/apps/admin/tests/api/sim-pipeline.test.ts
@@ -119,7 +119,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 const mockIsEngineAvailable = vi.fn((engine: string) => engine === "mock" || engine === "claude");

--- a/apps/admin/tests/api/student-artifacts.test.ts
+++ b/apps/admin/tests/api/student-artifacts.test.ts
@@ -16,7 +16,7 @@ const mockPrisma = {
   },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/student-access", () => ({
   requireStudent: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/student-call-detail.test.ts
+++ b/apps/admin/tests/api/student-call-detail.test.ts
@@ -10,7 +10,7 @@ const mockPrisma = {
   call: { findUnique: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/student-access", () => ({
   requireStudent: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/student-calls.test.ts
+++ b/apps/admin/tests/api/student-calls.test.ts
@@ -9,7 +9,7 @@ const mockPrisma = {
   call: { findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/student-access", () => ({
   requireStudent: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/student-goals.test.ts
+++ b/apps/admin/tests/api/student-goals.test.ts
@@ -10,7 +10,7 @@ const mockPrisma = {
   goal: { create: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/student-access", () => ({
   requireStudent: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/student-media.test.ts
+++ b/apps/admin/tests/api/student-media.test.ts
@@ -9,7 +9,7 @@ const mockPrisma = {
   callMessage: { findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/student-access", () => ({
   requireStudent: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/student-progress.test.ts
+++ b/apps/admin/tests/api/student-progress.test.ts
@@ -14,7 +14,7 @@ const mockPrisma = {
   conversationArtifact: { count: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/student-access", () => ({
   requireStudent: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/student-teacher.test.ts
+++ b/apps/admin/tests/api/student-teacher.test.ts
@@ -10,7 +10,7 @@ const mockPrisma = {
   cohortGroup: { findUnique: vi.fn(), findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/student-access", () => ({
   requireStudent: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/subject-media.test.ts
+++ b/apps/admin/tests/api/subject-media.test.ts
@@ -16,7 +16,7 @@ const mockPrisma = {
   },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/subjects.test.ts
+++ b/apps/admin/tests/api/subjects.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { GET, POST } from "@/app/api/subjects/route";

--- a/apps/admin/tests/api/system-ini.test.ts
+++ b/apps/admin/tests/api/system-ini.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 // Mock config — provide defaults matching real config structure

--- a/apps/admin/tests/api/tasks-counts.test.ts
+++ b/apps/admin/tests/api/tasks-counts.test.ts
@@ -20,7 +20,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/api/testimony-export.test.ts
+++ b/apps/admin/tests/api/testimony-export.test.ts
@@ -11,7 +11,7 @@ const mockPrisma = {
   callScore: { findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/testimony-specs.test.ts
+++ b/apps/admin/tests/api/testimony-specs.test.ts
@@ -12,7 +12,7 @@ const mockPrisma = {
   callScore: { aggregate: vi.fn(), findMany: vi.fn() },
 };
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/api/vapi-assistant-request.test.ts
+++ b/apps/admin/tests/api/vapi-assistant-request.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/prisma", () => {
     composedPrompt: { findFirst: (...args: any[]) => mockComposedPromptFindFirst(...args) },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 // ── Mock config ────────────────────────────────────

--- a/apps/admin/tests/api/vapi-knowledge.test.ts
+++ b/apps/admin/tests/api/vapi-knowledge.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/prisma", () => {
     $queryRaw: (...args: any[]) => mockQueryRaw(...args),
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 // ── Mock retriever ─────────────────────────────────

--- a/apps/admin/tests/api/wizard-steps.test.ts
+++ b/apps/admin/tests/api/wizard-steps.test.ts
@@ -8,7 +8,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/lib/actions/extract-actions.test.ts
+++ b/apps/admin/tests/lib/actions/extract-actions.test.ts
@@ -19,7 +19,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 const mockMeteredAI = vi.fn();

--- a/apps/admin/tests/lib/admin-tools.test.ts
+++ b/apps/admin/tests/lib/admin-tools.test.ts
@@ -45,7 +45,7 @@ vi.mock("@/lib/prisma", () => {
     $transaction: vi.fn(),
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 vi.mock("@/lib/jobs/curriculum-runner", () => ({

--- a/apps/admin/tests/lib/aggregate-runner.test.ts
+++ b/apps/admin/tests/lib/aggregate-runner.test.ts
@@ -28,7 +28,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 const mockUpdateLearnerProfile = vi.fn();

--- a/apps/admin/tests/lib/apply-behavior-targets.test.ts
+++ b/apps/admin/tests/lib/apply-behavior-targets.test.ts
@@ -20,7 +20,7 @@ const { mockPrisma } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 // ── Import under test ──────────────────────────────────
 

--- a/apps/admin/tests/lib/artifacts/extract-artifacts.test.ts
+++ b/apps/admin/tests/lib/artifacts/extract-artifacts.test.ts
@@ -31,7 +31,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 const mockMeteredCompletion = vi.fn();

--- a/apps/admin/tests/lib/auth.test.ts
+++ b/apps/admin/tests/lib/auth.test.ts
@@ -77,7 +77,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Unmock @/lib/auth so we can test the real module (overrides global setup.ts mock)

--- a/apps/admin/tests/lib/auto-trigger.test.ts
+++ b/apps/admin/tests/lib/auto-trigger.test.ts
@@ -32,7 +32,7 @@ const mockStartCurriculumGeneration = vi.hoisted(() =>
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/ai/task-guidance", () => ({

--- a/apps/admin/tests/lib/bulk-delete.test.ts
+++ b/apps/admin/tests/lib/bulk-delete.test.ts
@@ -71,7 +71,7 @@ mockModels.$transaction = vi.fn(async (fn: any) => fn(mockModels));
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockModels,
-  db: (tx) => tx ?? mockModels,
+  db: (tx?: unknown) => tx ?? mockModels,
 }));
 
 // Mock deleteCallerData used by bulk-delete.ts

--- a/apps/admin/tests/lib/classify-document.test.ts
+++ b/apps/admin/tests/lib/classify-document.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/ai/assistant-wrapper", () => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mocks.prisma,
-  db: (tx) => tx ?? mocks.prisma,
+  db: (tx?: unknown) => tx ?? mocks.prisma,
 }));
 
 vi.mock("@/lib/system-settings", () => ({

--- a/apps/admin/tests/lib/cohort-access.test.ts
+++ b/apps/admin/tests/lib/cohort-access.test.ts
@@ -18,7 +18,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 import {

--- a/apps/admin/tests/lib/composition/identity.test.ts
+++ b/apps/admin/tests/lib/composition/identity.test.ts
@@ -9,7 +9,7 @@ const { mockPrisma } = vi.hoisted(() => ({
     },
   },
 }));
-vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx) => tx ?? mockPrisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
 
 import { resolveSpecs, resolveVoiceSpecFallback, mergeIdentitySpec } from "@/lib/prompt/composition/transforms/identity";
 import { getTransform } from "@/lib/prompt/composition/TransformRegistry";

--- a/apps/admin/tests/lib/content-trust/extract-assertions.test.ts
+++ b/apps/admin/tests/lib/content-trust/extract-assertions.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/lib/prisma", () => {
     analysisSpec: { findFirst: vi.fn().mockResolvedValue(null) },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { chunkText, extractTextFromDocx } from "@/lib/content-trust/extract-assertions";

--- a/apps/admin/tests/lib/content-trust/lesson-planner.test.ts
+++ b/apps/admin/tests/lib/content-trust/lesson-planner.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/prisma", () => {
     assertionMedia: { findMany: mocks.assertionMediaFindMany },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 vi.mock("@/lib/metering/instrumented-ai", () => ({

--- a/apps/admin/tests/lib/content-trust/link-content.test.ts
+++ b/apps/admin/tests/lib/content-trust/link-content.test.ts
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
   getContentLinkingSettings: vi.fn(),
 }));
 
-vi.mock("@/lib/prisma", () => ({ prisma: mocks.prisma, db: (tx) => tx ?? mocks.prisma }));
+vi.mock("@/lib/prisma", () => ({ prisma: mocks.prisma, db: (tx?: unknown) => tx ?? mocks.prisma }));
 vi.mock("@prisma/client", () => ({ Prisma: { sql: (strings: TemplateStringsArray, ...values: any[]) => ({ strings, values }) } }));
 vi.mock("@/lib/system-settings", () => ({
   getContentLinkingSettings: mocks.getContentLinkingSettings,

--- a/apps/admin/tests/lib/content-trust/save-assertions.test.ts
+++ b/apps/admin/tests/lib/content-trust/save-assertions.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { saveAssertions } from "@/lib/content-trust/save-assertions";

--- a/apps/admin/tests/lib/content-trust/save-questions.test.ts
+++ b/apps/admin/tests/lib/content-trust/save-questions.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { saveQuestions, deleteQuestionsForSource } from "@/lib/content-trust/save-questions";

--- a/apps/admin/tests/lib/content-trust/save-vocabulary.test.ts
+++ b/apps/admin/tests/lib/content-trust/save-vocabulary.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { saveVocabulary, deleteVocabularyForSource } from "@/lib/content-trust/save-vocabulary";

--- a/apps/admin/tests/lib/content-trust/structure-assertions.test.ts
+++ b/apps/admin/tests/lib/content-trust/structure-assertions.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 vi.mock("@/lib/metering/instrumented-ai", () => ({

--- a/apps/admin/tests/lib/contract-registry.test.ts
+++ b/apps/admin/tests/lib/contract-registry.test.ts
@@ -22,7 +22,7 @@ const mockPrisma = {
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Sample contract data

--- a/apps/admin/tests/lib/course-readiness.test.ts
+++ b/apps/admin/tests/lib/course-readiness.test.ts
@@ -38,7 +38,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/config", () => ({

--- a/apps/admin/tests/lib/curriculum-runner.test.ts
+++ b/apps/admin/tests/lib/curriculum-runner.test.ts
@@ -41,7 +41,7 @@ const mockExtractCurriculum = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/ai/task-guidance", () => ({

--- a/apps/admin/tests/lib/domain-readiness.test.ts
+++ b/apps/admin/tests/lib/domain-readiness.test.ts
@@ -34,7 +34,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // =====================================================

--- a/apps/admin/tests/lib/domain/course-setup.test.ts
+++ b/apps/admin/tests/lib/domain/course-setup.test.ts
@@ -32,7 +32,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/domain/scaffold", () => ({

--- a/apps/admin/tests/lib/educator-access.test.ts
+++ b/apps/admin/tests/lib/educator-access.test.ts
@@ -33,7 +33,7 @@ const mockIsAuthError = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/lib/embeddings.test.ts
+++ b/apps/admin/tests/lib/embeddings.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import {

--- a/apps/admin/tests/lib/enrollment-cohort.test.ts
+++ b/apps/admin/tests/lib/enrollment-cohort.test.ts
@@ -30,7 +30,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 import {

--- a/apps/admin/tests/lib/enrollment.test.ts
+++ b/apps/admin/tests/lib/enrollment.test.ts
@@ -21,7 +21,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 import {

--- a/apps/admin/tests/lib/exam-readiness.test.ts
+++ b/apps/admin/tests/lib/exam-readiness.test.ts
@@ -35,7 +35,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Mock ContractRegistry

--- a/apps/admin/tests/lib/extraction-retry.test.ts
+++ b/apps/admin/tests/lib/extraction-retry.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/prisma", () => {
     analysisSpec: { findFirst: vi.fn().mockResolvedValue(null) },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 // Mock resolve-config to return a predictable config

--- a/apps/admin/tests/lib/goals-extract.test.ts
+++ b/apps/admin/tests/lib/goals-extract.test.ts
@@ -56,7 +56,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 const mockGetConfiguredMeteredAICompletion = vi.fn();

--- a/apps/admin/tests/lib/goals-track-progress.test.ts
+++ b/apps/admin/tests/lib/goals-track-progress.test.ts
@@ -63,7 +63,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/registry", () => ({

--- a/apps/admin/tests/lib/knowledge/search-questions-vocab.test.ts
+++ b/apps/admin/tests/lib/knowledge/search-questions-vocab.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/prisma", () => {
     $queryRaw: vi.fn().mockResolvedValue([]),
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 vi.mock("@/lib/embeddings", () => ({

--- a/apps/admin/tests/lib/learner-profile.test.ts
+++ b/apps/admin/tests/lib/learner-profile.test.ts
@@ -22,7 +22,7 @@ const mockPrisma = {
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Mock ContractRegistry

--- a/apps/admin/tests/lib/pipeline-config.test.ts
+++ b/apps/admin/tests/lib/pipeline-config.test.ts
@@ -26,7 +26,7 @@ const mockPrisma = {
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/config", () => ({

--- a/apps/admin/tests/lib/pipeline/guardrails.test.ts
+++ b/apps/admin/tests/lib/pipeline/guardrails.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/prisma", () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 // ── Mock system-settings ─────────────────────────────

--- a/apps/admin/tests/lib/resolve-config-types.test.ts
+++ b/apps/admin/tests/lib/resolve-config-types.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/prisma", () => {
     playbook: { findFirst: mocks.playbookFindFirst },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 vi.mock("@/lib/config", () => ({

--- a/apps/admin/tests/lib/student-access.test.ts
+++ b/apps/admin/tests/lib/student-access.test.ts
@@ -27,7 +27,7 @@ const mockIsAuthError = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 vi.mock("@/lib/permissions", () => ({

--- a/apps/admin/tests/lib/task-guidance.test.ts
+++ b/apps/admin/tests/lib/task-guidance.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/prisma", () => {
     $transaction: (...args: any[]) => mockTransaction(...args),
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import {

--- a/apps/admin/tests/lib/terminology.test.ts
+++ b/apps/admin/tests/lib/terminology.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/lib/prisma', () => {
     },
   },
 };
-  return { ..._p, db: (tx) => tx ?? _p.prisma };
+  return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
 });
 
 import { prisma } from '@/lib/prisma';

--- a/apps/admin/tests/lib/track-progress.test.ts
+++ b/apps/admin/tests/lib/track-progress.test.ts
@@ -24,7 +24,7 @@ const mockPrisma = {
 
 vi.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 // Mock ContractRegistry

--- a/apps/admin/tests/lib/wizards/wizard-spec.test.ts
+++ b/apps/admin/tests/lib/wizards/wizard-spec.test.ts
@@ -9,7 +9,7 @@ const mockPrisma = vi.hoisted(() => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockPrisma,
-  db: (tx) => tx ?? mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
 }));
 
 describe("wizard-spec loader", () => {


### PR DESCRIPTION
## Summary

Mechanical typing cleanup for the Tier-6 safe-noise TypeScript error categories from #377. No runtime changes — only type annotations on test mocks and a handful of production sites.

- **121 × `Parameter 'tx' implicitly has 'any' type`** — typed `tx` param on `db: (tx) => tx ?? mockPrisma` test mocks as `tx?: unknown`. The mock's return is only consumed by production code (which uses the real `db(tx?: TxClient)` signature), so `unknown` is enough and avoids importing Prisma client types into 116 test files.
- **23 × `Cannot find namespace 'JSX'`** — React 19 moved the global JSX namespace. Added `type { JSX }` to the existing `react` import in 6 files (DashboardClient, CohortLearningAggregate, LearningTrajectoryCard, SurveySection, PostCallProgressCard, SimProgressPanel).
- **Remaining production-code implicit-any fixes:**
  - `app/api/chat/route.ts` — typed `entityContext` as `EntityBreadcrumb[]`, `conversationHistory` with a minimal `{ role; content }` shape.
  - `lib/masquerade.ts` and `src/components/shared/SimpleSidebarNav.tsx` — `Record<UserRole, number>` indexed with arbitrary role strings; cast through `Record<string, number>`.
  - `app/api/admin/bulk-delete/{,job/}route.ts` — narrow `entityType` via `as { entityType: EntityType; entityIds: unknown }` after the explicit `VALID_TYPES.includes()` guard.
  - `lib/prompt/composition/transforms/visual-aids.ts` — typed the consumer-side `sessionMedia` view explicitly (`media` is declared as `null` upstream but the runtime arrives as an array; cast keeps the consumer correct without rippling into the shared type).
  - `lib/content-trust/extract-assertions.ts` — inline minimal type for `word-extractor` (no `@types/word-extractor` available).

### What's NOT here

The 397 `Binding element 'page'` and 67 `Binding element 'loginAs'` errors visible locally on macOS are environment artefacts — Playwright isn't installed in this worktree, so `@playwright/test` types are missing. They do not appear on Linux where the ratchet baseline is measured. The issue's numbers were Linux-baseline numbers; locally I got the equivalent drop from the categories that actually move there.

### Rules followed

- **No `as any`** — all casts go to `unknown`, named types, or specific Record-string shapes.
- **No `// eslint-disable`** — real fixes only.
- One commit, single concern.

### Ratchet

```
tsc_errors: 347 → 195 (-152)
lint_errors: 0 (unchanged)
lint_warnings: 9529 (unchanged)
quarantined_tests: 31 (unchanged)
```

`.ratchet.json` updated and locked in this commit.

## Test plan

- [x] `npx tsc --noEmit` — 195 errors (down 152), no new errors introduced
- [x] `npx eslint --quiet apps/admin` — clean, no new warnings
- [x] `npx vitest run tests/api/account.test.ts tests/api/actions.test.ts tests/lib/admin-tools.test.ts` — 57/57 pass (sample includes both `tx`-typed mock variants)
- [x] `npm run ratchet:check` — passes with the new locked baseline
- [ ] CI runs full test suite

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)