### PR TITLE
fix: composition-transforms drift — trust.ts CURRICULUM + 3 yellow items

### DIFF
--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -805,6 +805,22 @@ registerLoader("subjectSources", async (callerId, loaderConfig) => {
           qualificationBody: true,
           qualificationNumber: true,
           qualificationLevel: true,
+          // #364 follow-up: relational CurriculumModule + LearningObjective
+          // rows so the trust transform's CONTENT AUTHORITY block reads from
+          // canonical source instead of the legacy notableInfo.modules JSON
+          // blob (which the projection layer never populates).
+          modules: {
+            orderBy: { sortOrder: "asc" },
+            select: {
+              id: true,
+              slug: true,
+              title: true,
+              learningObjectives: {
+                orderBy: { ref: "asc" },
+                select: { ref: true, description: true },
+              },
+            },
+          },
         },
       },
     },
@@ -828,6 +844,18 @@ registerLoader("subjectSources", async (callerId, loaderConfig) => {
           qualificationBody: true,
           qualificationNumber: true,
           qualificationLevel: true,
+          modules: {
+            orderBy: { sortOrder: "asc" },
+            select: {
+              id: true,
+              slug: true,
+              title: true,
+              learningObjectives: {
+                orderBy: { ref: "asc" },
+                select: { ref: true, description: true },
+              },
+            },
+          },
         },
       })
     : null;

--- a/apps/admin/lib/prompt/composition/transforms/instructions.ts
+++ b/apps/admin/lib/prompt/composition/transforms/instructions.ts
@@ -9,9 +9,9 @@
  */
 
 import { registerTransform } from "../TransformRegistry";
-import { classifyValue, getAttributeValue } from "../types";
+import { classifyValue } from "../types";
 import { computePersonalityAdaptation } from "./personality";
-import type { AssembledContext, CallerAttributeData, GoalData, SubjectSourcesData } from "../types";
+import type { AssembledContext, GoalData, SubjectSourcesData } from "../types";
 import type { SpecConfig } from "@/lib/types/json-fields";
 import { resolveTeachingProfile } from "@/lib/content-trust/teaching-profiles";
 
@@ -110,7 +110,10 @@ registerTransform("computeInstructions", (
   const { sections, loadedData, sharedState, resolvedSpecs } = context;
   const { thresholds, modules, isFirstCall, moduleToReview, nextModule, completedModules } = sharedState;
   const personality = loadedData.personality;
-  const callerAttributes = loadedData.callerAttributes;
+  // callerAttributes used to drive the legacy "next_module / mastery" string-
+  // match filter — removed per composition-transforms audit. If a richer
+  // per-attribute hint surface returns it should hydrate from
+  // CallerModuleProgress (relational) instead.
   const learnerGoals = loadedData.goals;
   const curriculumName = (sharedState as Record<string, any>).curriculumName as string | null;
 
@@ -255,24 +258,18 @@ registerTransform("computeInstructions", (
         }
       }
 
-      const nextContent = callerAttributes.filter((a: CallerAttributeData) =>
-        a.key.includes("next_") || a.key.includes("ready_for")
-      );
-      const currentModule = callerAttributes.find((a: CallerAttributeData) =>
-        a.key.includes("current_module") || a.key.includes("active_module")
-      );
-      const mastery = callerAttributes.find((a: CallerAttributeData) =>
-        a.key.includes("mastery") && !a.key.includes("mastery_")
-      );
-
-      if (currentModule) parts.push(`Current module: ${getAttributeValue(currentModule)}`);
-      if (mastery) {
-        const masteryVal = getAttributeValue(mastery);
-        parts.push(`Mastery level: ${typeof masteryVal === "number" ? (masteryVal * 100).toFixed(0) + "%" : masteryVal}`);
-      }
-      if (nextContent.length > 0) {
-        parts.push(`Next content to cover: ${nextContent.map((a: CallerAttributeData) => getAttributeValue(a)).join(", ")}`);
-      }
+      // Composition transforms audit follow-up: the original code here
+      // string-matched callerAttributes for `next_*`, `current_module`,
+      // `mastery` keys — that was the pre-projection extraction scheme.
+      // Projection-era courses store this data in CallerModuleProgress
+      // (relational), so the legacy filter returned empty for every new
+      // course. The sharedState.modules / completedModules / nextModule
+      // block above already renders the primary curriculum guidance from
+      // the canonical (DB-first) modules pipeline — so removing the legacy
+      // filter only loses decorative duplication, not real signal.
+      //
+      // TODO(follow-up): if richer per-attribute hints are desired, hydrate
+      // from CallerModuleProgress rows instead of CallerAttribute keys.
 
       if (parts.length === 0) return "No curriculum progress tracked yet - start with first module.";
       return parts.join(". ");

--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -382,6 +382,15 @@ export async function computeSharedState(
         };
       }
       console.log(`[modules] Subject curriculum fallback: ${modules.length} modules from "${specSlug}"`);
+    } else if (curriculumId) {
+      // Composition transforms audit follow-up: when a Curriculum row exists
+      // but BOTH the relational CurriculumModule rows AND the legacy
+      // notableInfo.modules JSON are empty, the prompt loses its module
+      // structure silently. Warn loudly so operators can spot half-projected
+      // courses instead of letting them ship a degraded learning experience.
+      console.warn(
+        `[modules] Curriculum ${curriculumId} has neither CurriculumModule rows nor notableInfo.modules — prompt will render without module structure. Likely a half-completed projection or seed.`,
+      );
     }
   }
 

--- a/apps/admin/lib/prompt/composition/transforms/targets.ts
+++ b/apps/admin/lib/prompt/composition/transforms/targets.ts
@@ -14,8 +14,13 @@ import type { AudienceId } from "./audience";
  * Keyed by parameterId → audienceId → { value, confidence }.
  * "default" is the fallback when audience is unset or unrecognized.
  *
- * TODO: Move to INIT-001 spec config (audience-keyed defaultTargets) so educators
- * can tune these via the admin UI instead of requiring a code change.
+ * TODO(composition-transforms-audit): Move to INIT-001 spec config
+ * (audience-keyed `defaultTargets`) so educators can tune these via the
+ * admin UI instead of requiring a code change. Currently educator-tuned
+ * `BEH-CHALLENGE-LEVEL` targets via projection/wizard get shadowed by
+ * these hardcoded numbers on first-call when no caller-scoped target
+ * exists yet. Filed as a separate follow-up — the audit found this is
+ * latent fragility, not a current user-visible bug.
  */
 const AUDIENCE_TARGET_DEFAULTS: Record<string, Partial<Record<AudienceId | "default", { value: number; confidence: number }>>> = {
   "BEH-CHALLENGE-LEVEL": {

--- a/apps/admin/lib/prompt/composition/transforms/trust.ts
+++ b/apps/admin/lib/prompt/composition/transforms/trust.ts
@@ -216,8 +216,34 @@ function buildSubjectTrustContext(subjectData: { subjects: any[] }) {
       if (w) freshnessWarnings.push({ ...w, message: `"${src.name}": ${w.message}` });
     }
 
-    // Include curriculum modules summary if available
-    if (subject.curriculum?.notableInfo?.modules) {
+    // Include curriculum modules summary if available.
+    //
+    // Source-of-truth precedence (mirrors #364):
+    //   1. Relational CurriculumModule rows (populated by the projection
+    //      layer, #338). The loader now hydrates these on
+    //      subject.curriculum.modules.
+    //   2. Legacy Curriculum.notableInfo.modules JSON blob — kept as a
+    //      fallback for seed-only / pre-projection courses.
+    //
+    // Without (1), every projection-created course silently dropped this
+    // CURRICULUM block from the AI's CONTENT AUTHORITY section.
+    const relationalModules =
+      (subject.curriculum as { modules?: Array<{ id: string; slug: string; title: string; learningObjectives: Array<{ ref: string; description: string | null }> }> } | null)?.modules ?? [];
+    if (relationalModules.length > 0) {
+      authorityLines.push(`\n  CURRICULUM (${relationalModules.length} modules):`);
+      for (const mod of relationalModules) {
+        authorityLines.push(`    ${mod.slug || mod.id}: ${mod.title}`);
+        const los = mod.learningObjectives;
+        if (los.length > 0) {
+          for (const lo of los.slice(0, 3)) {
+            authorityLines.push(`      - ${lo.description || lo.ref}`);
+          }
+          if (los.length > 3) {
+            authorityLines.push(`      ... and ${los.length - 3} more`);
+          }
+        }
+      }
+    } else if (subject.curriculum?.notableInfo?.modules) {
       const modules = subject.curriculum.notableInfo.modules;
       authorityLines.push(`\n  CURRICULUM (${modules.length} modules):`);
       for (const mod of modules) {


### PR DESCRIPTION
## Summary

Follow-up to #364 driven by a full audit of all 24 composition transforms. Yesterday's PR #364 fixed the curriculum-section drift; this PR fixes the only other transform with the same shape, plus three latent fragilities flagged by the audit.

## 🔴 Active bug fixed

**\`transforms/trust.ts\`** — The CONTENT AUTHORITY section of the system prompt rendered the curriculum module summary from \`subject.curriculum.notableInfo.modules\` (legacy JSON). The projection layer writes to relational \`CurriculumModule\` rows and never populates notableInfo. For every projection-created course, the AI tutor's source-trust block silently lost its curriculum overview.

Fix: SectionDataLoader now hydrates relational modules + LOs; trust.ts reads them, falls back to legacy for seed-only data.

## 🟡 Hardened (no current symptom but were latent)

| File | Change |
|---|---|
| \`transforms/modules.ts\` | Added structured \`console.warn\` when both relational + legacy module sources are empty (half-completed projection state) |
| \`transforms/instructions.ts\` | Removed dead pre-projection string-match filter on callerAttributes. Primary curriculum guidance already rendered from sharedState.modules. |
| \`transforms/targets.ts\` | Sharpened TODO on \`AUDIENCE_TARGET_DEFAULTS\` — educator-tuned values get shadowed by these hardcoded numbers. Filed as separate follow-up. |

## Audit summary

24 transforms reviewed. 20 clean, 3 yellow (this PR), 1 red (this PR). No other transform reads from a stale JSON-blob source today.

## Test plan

- [x] Typecheck clean (tsc baseline unchanged)
- [ ] Linux CI ratchet — confirm lint count not over baseline 9529
- [ ] On hf-dev VM: verify CONTENT AUTHORITY section in a composed prompt now includes the CURRICULUM block for a projection-created course

🤖 Generated with [Claude Code](https://claude.com/claude-code)