### PR TITLE
feat(#385): Slice 1 Phase 1 — DocumentType subtypes (schema + helper)

### DIFF
--- a/apps/admin/lib/doc-type-icons.ts
+++ b/apps/admin/lib/doc-type-icons.ts
@@ -182,12 +182,35 @@ const STUDENT_VISIBLE_DOC_TYPES = new Set([
 /**
  * Document types that stay teacher-only by default — these are for tutor
  * guidance and would confuse students. Teacher can still override per-file.
+ *
+ * #385 Slice 1: all three COURSE_REFERENCE_* subtypes inherit the teacher-
+ * only default. Forgetting any of them re-opens the visual-aids leak path
+ * (L1) where rubric content could surface in the learner chat.
  */
 const TEACHER_ONLY_DOC_TYPES = new Set([
-  "COURSE_REFERENCE",  // Tutor methodology / course delivery guide
-  "LESSON_PLAN",        // Teacher-facing plans
-  "QUESTION_BANK",      // Tutor playbook with tiered model answers
-  "POLICY_DOCUMENT",    // Regulatory / compliance reference
+  "COURSE_REFERENCE",                  // Legacy coarse type
+  "COURSE_REFERENCE_CANONICAL",        // Master course-reference doc
+  "COURSE_REFERENCE_TUTOR_BRIEFING",   // Coaching strategy / edge cases
+  "COURSE_REFERENCE_ASSESSOR_RUBRIC",  // Band descriptors / scoring criteria
+  "LESSON_PLAN",                       // Teacher-facing plans
+  "QUESTION_BANK",                     // Tutor playbook with tiered model answers
+  "POLICY_DOCUMENT",                   // Regulatory / compliance reference
+]);
+
+/**
+ * The full set of COURSE_REFERENCE-family document types. Use this helper
+ * anywhere code currently checks `documentType === "COURSE_REFERENCE"` to
+ * keep new subtypes in scope without re-listing them at every callsite.
+ *
+ * #385 Slice 1. The legacy flat `COURSE_REFERENCE` value is included for
+ * back-compat with existing ContentSource rows. New classifier output
+ * should produce a subtype, not the flat value.
+ */
+const COURSE_REFERENCE_TYPES = new Set([
+  "COURSE_REFERENCE",
+  "COURSE_REFERENCE_CANONICAL",
+  "COURSE_REFERENCE_TUTOR_BRIEFING",
+  "COURSE_REFERENCE_ASSESSOR_RUBRIC",
 ]);
 
 /** Should this document type be shared with students by default? */
@@ -198,6 +221,16 @@ export function isStudentVisibleDefault(documentType: string): boolean {
 /** Should this document type stay teacher-only? */
 export function isTeacherOnlyDocType(documentType: string): boolean {
   return TEACHER_ONLY_DOC_TYPES.has(documentType);
+}
+
+/**
+ * Is this document type any of the COURSE_REFERENCE family — legacy flat
+ * `COURSE_REFERENCE` or any of the three Slice-1 subtypes? Use in place
+ * of literal `documentType === "COURSE_REFERENCE"` checks at reader
+ * call sites to stay forward-compatible during the Slice 1 rollout.
+ */
+export function isCourseReferenceType(documentType: string | null | undefined): boolean {
+  return typeof documentType === "string" && COURSE_REFERENCE_TYPES.has(documentType);
 }
 
 /**

--- a/apps/admin/lib/validation/schemas.ts
+++ b/apps/admin/lib/validation/schemas.ts
@@ -59,7 +59,7 @@ const entityBreadcrumbSchema = z.object({
   type: z.string(),
   id: z.string(),
   label: z.string(),
-  data: z.record(z.unknown()).optional(),
+  data: z.record(z.string(), z.unknown()).optional(),
 });
 
 /** POST /api/chat */
@@ -88,5 +88,5 @@ export const chatRequestSchema = z.object({
     viewport: z.string(),
     timestamp: z.number(),
   }).optional(),
-  setupData: z.record(z.unknown()).optional(),
+  setupData: z.record(z.string(), z.unknown()).optional(),
 });

--- a/apps/admin/lib/wizard/__tests__/persist-authored-modules.test.ts
+++ b/apps/admin/lib/wizard/__tests__/persist-authored-modules.test.ts
@@ -30,6 +30,7 @@ describe("applyAuthoredModules", () => {
       modulesAuthored: null,
       modules: [],
       moduleDefaults: {},
+      outcomes: {},
       validationWarnings: [],
       detectedFrom: [],
     };
@@ -50,6 +51,7 @@ describe("applyAuthoredModules", () => {
       modulesAuthored: false,
       modules: [],
       moduleDefaults: {},
+      outcomes: {},
       validationWarnings: [],
       detectedFrom: ['header: "Modules authored: No"'],
     };
@@ -68,6 +70,7 @@ describe("applyAuthoredModules", () => {
       modulesAuthored: true,
       modules: [sampleModule],
       moduleDefaults: { mode: "tutor", correctionStyle: "single_issue_loop" },
+      outcomes: {},
       validationWarnings: [],
       detectedFrom: ["parsed 1 module(s) from catalogue"],
     };
@@ -87,6 +90,7 @@ describe("applyAuthoredModules", () => {
       modulesAuthored: true,
       modules: [sampleModule],
       moduleDefaults: {},
+      outcomes: {},
       validationWarnings: [],
       detectedFrom: [],
     };
@@ -105,6 +109,7 @@ describe("applyAuthoredModules", () => {
       modulesAuthored: true,
       modules: [sampleModule],
       moduleDefaults: { mode: "tutor", correctionStyle: "single_issue_loop" },
+      outcomes: {},
       validationWarnings: [],
       detectedFrom: [],
     };
@@ -126,6 +131,7 @@ describe("applyAuthoredModules", () => {
       modulesAuthored: true,
       modules: [sampleModule],
       moduleDefaults: {},
+      outcomes: {},
       validationWarnings: [],
       detectedFrom: [],
     };
@@ -139,6 +145,7 @@ describe("applyAuthoredModules", () => {
       modulesAuthored: true,
       modules: [sampleModule],
       moduleDefaults: {},
+      outcomes: {},
       validationWarnings: [
         {
           code: "MODULE_FIELD_DEFAULTED",
@@ -162,6 +169,7 @@ describe("hasBlockingErrors", () => {
         modulesAuthored: true,
         modules: [],
         moduleDefaults: {},
+        outcomes: {},
         validationWarnings: [],
         detectedFrom: [],
       }),
@@ -174,6 +182,7 @@ describe("hasBlockingErrors", () => {
         modulesAuthored: true,
         modules: [],
         moduleDefaults: {},
+        outcomes: {},
         validationWarnings: [
           { code: "X", message: "x", severity: "warning" },
         ],
@@ -188,6 +197,7 @@ describe("hasBlockingErrors", () => {
         modulesAuthored: true,
         modules: [],
         moduleDefaults: {},
+        outcomes: {},
         validationWarnings: [
           { code: "X", message: "x", severity: "warning" },
           { code: "Y", message: "y", severity: "error" },

--- a/apps/admin/prisma/migrations/20260515_385_course_reference_subtypes/migration.sql
+++ b/apps/admin/prisma/migrations/20260515_385_course_reference_subtypes/migration.sql
@@ -1,0 +1,19 @@
+-- #385 Slice 1 — DocumentType subtypes for COURSE_REFERENCE.
+--
+-- Splits the coarse COURSE_REFERENCE type into three audience-scoped
+-- subtypes so the projection / loaders / classifier can route content
+-- by source provenance rather than relying on AI classification alone.
+-- See https://github.com/WANDERCOLTD/HF/issues/385 for the full design.
+--
+-- Phase 1: additive only. No row UPDATEs in this migration.
+-- Existing COURSE_REFERENCE rows remain valid. Classifier producers and
+-- reader sweep land in subsequent phases.
+--
+-- Postgres requires ALTER TYPE ADD VALUE to be its own statement (not
+-- in a transaction with subsequent uses of the new value). Each ADD
+-- runs as its own implicit transaction. The IF NOT EXISTS clause makes
+-- this migration idempotent for re-runs.
+
+ALTER TYPE "DocumentType" ADD VALUE IF NOT EXISTS 'COURSE_REFERENCE_CANONICAL';
+ALTER TYPE "DocumentType" ADD VALUE IF NOT EXISTS 'COURSE_REFERENCE_TUTOR_BRIEFING';
+ALTER TYPE "DocumentType" ADD VALUE IF NOT EXISTS 'COURSE_REFERENCE_ASSESSOR_RUBRIC';

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -52,8 +52,11 @@ enum DocumentType {
   POLICY_DOCUMENT // Regulatory/compliance/safety procedure (Pest Control, HACCP)
   READING_PASSAGE // Standalone reading text — learner reads before/during session (no questions)
   QUESTION_BANK // Tutor reference: skill-mapped questions with tiered model responses + guidance
-  // --- Course Reference (1) ---
-  COURSE_REFERENCE // Tutor instruction doc: skills framework, session flow, scaffolding rules. NOT student content.
+  // --- Course Reference (1 legacy + 3 subtypes, #385 Slice 1) ---
+  COURSE_REFERENCE // Tutor instruction doc — legacy coarse type (kept for back-compat; new uploads should land in one of the subtypes below)
+  COURSE_REFERENCE_CANONICAL // Master course-reference doc: modules table + OUT-NN headings + skills framework. Mixed learner + tutor audience.
+  COURSE_REFERENCE_TUTOR_BRIEFING // Coaching strategy / edge cases / session-flow rules. Tutor-internal only — never reaches learner chat.
+  COURSE_REFERENCE_ASSESSOR_RUBRIC // Band descriptors / scoring criteria. Assessor + tutor-hidden — never reaches learner chat.
 }
 
 // Question types for ContentQuestion model


### PR DESCRIPTION
## Summary

**Phase 1 of #385 Slice 1 — additive enum extension + helper, no producers/readers updated yet.**

| Change | Detail |
|---|---|
| Schema | Adds 3 new `DocumentType` values: `COURSE_REFERENCE_CANONICAL`, `COURSE_REFERENCE_TUTOR_BRIEFING`, `COURSE_REFERENCE_ASSESSOR_RUBRIC`. Legacy `COURSE_REFERENCE` preserved. |
| Migration | `ALTER TYPE ADD VALUE IF NOT EXISTS` × 3 — additive, idempotent |
| Code | `lib/doc-type-icons.ts`: `TEACHER_ONLY_DOC_TYPES` extended to cover all three subtypes (guards against L1 visual-aids leak regression); new `isCourseReferenceType()` helper for forward-compat reader checks |
| Side effect fixes | Zod v4 `z.record` signature in `validation/schemas.ts`; missing `outcomes` field on `DetectedAuthoredModules` test fixtures. tsc 195 → 185. |

## ⚠️ Schema migration — needs `/vm-cpp` deploy

This PR adds enum values. **Postgres requires `ALTER TYPE ADD VALUE` outside a transaction**; Prisma's migration runner handles this with `IF NOT EXISTS` clauses (idempotent on re-run). After merge, run `/vm-cpp` on the VM so `prisma migrate dev` picks up the new migration.

## Out of scope (future phases)

- **Phase 2**: Classifier produces subtypes (currently still only emits legacy `COURSE_REFERENCE`)
- **Phase 3**: Reader sweep — 55+ files reference the literal (per TL audit)
- **Phase 4**: Backfill existing rows to subtypes
- **Phase 5**: Seeded BDD specs + evals + `CONTENT-PIPELINE.md` updates
- Slice 2 (`sourceDocumentType` column) + Slice 3b (subtype-aware guards)

## Test plan

- [x] tsc baseline: 195 → 185 (10 below floor)
- [x] All 16 affected tests pass (`persist-authored-modules.test.ts` × 10, `wizard-onboarding-phases.test.ts` × 6)
- [ ] `/vm-cpp` runs cleanly — migration applies, no enum-value-in-transaction error
- [ ] After merge: classifier still produces legacy `COURSE_REFERENCE` (no behaviour change yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)