### PR TITLE
fix(#387): preserve wizard chat history across hard refresh

### DIFF
--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -1307,9 +1307,19 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
     if (!isActive || initialised.current) return;
     initialised.current = true;
 
-    // Always start fresh — stale sessionStorage causes more UX issues than it solves.
-    // The wizard is short enough that resuming mid-conversation is rarely needed.
-    sessionStorage.removeItem(storageKey(storageScope));
+    // #387 — preserve chat history across hard refresh. The previous behaviour
+    // unconditionally cleared sessionStorage here, which meant a user mid-
+    // wizard who hit refresh lost their transcript (the bag in
+    // hf.stepflow.state survived, but the chat key got overwritten with a
+    // bare greeting). The intentional reset path is handleStartOver, not
+    // this mount effect.
+    const restored = loadHistory(storageScope);
+    if (restored.length > 0) {
+      setMessages(restored);
+      scrollToBottom();
+      setTimeout(() => inputRef.current?.focus(), 150);
+      return;
+    }
 
     const hasContext = !!initialContext;
     const greeting: Message = {


### PR DESCRIPTION
## Summary

Closes #387 — the init effect was unconditionally clearing sessionStorage before saving a fresh greeting, overwriting any saved chat history on hard refresh. Now gated on `loadHistory()` returning empty; the intentional reset path (`handleStartOver`) is untouched.

## Why the bag survived but the chat didn't (the actual root cause)

`hf.stepflow.state` (the bag) is owned by StepFlowContext and only cleared via `clearData()`. The mount effect at `ConversationalWizard.tsx:1312` was clearing `gs-v5-*-history` (the chat key) every time — even when the user just refreshed mid-wizard. The BA's trace at #387 confirmed: not a race, a deliberate-but-wrong design.

## Test plan

- [x] tsc clean (no new errors; total 185 unchanged)
- [ ] Mid-wizard refresh restores chat + bag together
- [ ] "Start over" button still clears both correctly (handleStartOver unchanged)
- [ ] Fresh wizard with no prior state still shows the greeting

## Deploy

`/vm-cp` — no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)