### PR TITLE
fix: surface Start Over button at greeting (proper-refresh affordance)

### DIFF
--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -1737,8 +1737,10 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
             )}
           </div>
 
-          {/* Start over — hidden when launched (moved into success card) */}
-          {messages.length > 1 && !launched && (
+          {/* Start over — always visible until launch (proper-refresh button per user request).
+              Calls handleStartOver which clears the chat key + the bag in hf.stepflow.state,
+              i.e. the opposite of hard refresh (which now preserves state after #390). */}
+          {!launched && (
             <div className="cv4-start-over-row">
               {confirmReset ? (
                 <>


### PR DESCRIPTION
## Summary

After #390 (hard refresh preserves wizard state), users need a deliberate "nuke and start fresh" affordance. The existing Start Over button was gated on `messages.length > 1` — invisible at the greeting, which is exactly when a user arriving with stale sessionStorage needs it most.

Drop the message-count gate; keep the confirm flow. `handleStartOver` clears both the chat-history key and the bag in `hf.stepflow.state`.

## Test plan

- [x] tsc clean (185 unchanged)
- [ ] Button visible at greeting (no chat yet)
- [ ] Confirm-flow still works (no accidental clicks)
- [ ] Button still hides after `launched`

## Deploy

`/vm-cp` — UI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)