### PR TITLE
feat(#385): Slice 1 Phase 2 — classifier emits subtypes via deterministic overrides

### DIFF
--- a/apps/admin/lib/content-trust/classify-document.ts
+++ b/apps/admin/lib/content-trust/classify-document.ts
@@ -73,19 +73,25 @@ const FILENAME_TYPE_HINTS: Array<{
   type: DocumentType;
   role: "passage" | "questions" | "reference" | "pedagogy";
 }> = [
-  { pattern: /course[_-]?ref(erence)?/i, type: "COURSE_REFERENCE", role: "pedagogy" },
-  { pattern: /tutor[_-]?(guide|instruction|playbook|handbook|manual)/i, type: "COURSE_REFERENCE", role: "pedagogy" },
-  { pattern: /teaching[_-]?(guide|approach|method(ology)?)/i, type: "COURSE_REFERENCE", role: "pedagogy" },
-  { pattern: /delivery[_-]?(guide|handbook)/i, type: "COURSE_REFERENCE", role: "pedagogy" },
-  // #276 Slice 1: assessment rubric / band descriptor docs are tutor-facing
-  // scoring criteria — NOT learner content. Misclassified as TEXTBOOK they
-  // leak into MCQ generation and produce questions ABOUT the rubric ("How
-  // many assessment criteria are there?", "Why do Band 9 speakers hesitate?")
-  // instead of testing actual skill. Anchor them to COURSE_REFERENCE.
-  { pattern: /band[_-]?descriptor/i, type: "COURSE_REFERENCE", role: "pedagogy" },
-  { pattern: /(assessment|scoring|marking)[_-]?(rubric|criteria|descriptor)/i, type: "COURSE_REFERENCE", role: "pedagogy" },
-  { pattern: /band[_-]?score(s)?/i, type: "COURSE_REFERENCE", role: "pedagogy" },
-  { pattern: /(ielts|cefr|toefl|toeic)[_-]?(rubric|descriptor|band|score)/i, type: "COURSE_REFERENCE", role: "pedagogy" },
+  // #385 Slice 1 Phase 2 — filename hints now resolve to subtypes when the
+  // pattern is specific enough to know the audience scope. The legacy flat
+  // COURSE_REFERENCE value is reserved for AI output that doesn't trigger
+  // any deterministic override; the reader sweep accepts both via
+  // isCourseReferenceType() helper.
+  { pattern: /course[_-]?ref(erence)?/i, type: "COURSE_REFERENCE_CANONICAL", role: "pedagogy" },
+  { pattern: /tutor[_-]?(guide|instruction|playbook|handbook|manual|briefing)/i, type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" },
+  { pattern: /teaching[_-]?(guide|approach|method(ology)?)/i, type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" },
+  { pattern: /delivery[_-]?(guide|handbook)/i, type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" },
+  // Assessment rubric / band descriptor docs are tutor-facing scoring criteria
+  // — NOT learner content. Misclassified as TEXTBOOK they leak into MCQ
+  // generation and produce questions ABOUT the rubric ("How many assessment
+  // criteria are there?", "Why do Band 9 speakers hesitate?") instead of
+  // testing actual skill. Anchor them to ASSESSOR_RUBRIC so audience-routing
+  // can hide them from learner chat (#317 + #385).
+  { pattern: /band[_-]?descriptor/i, type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" },
+  { pattern: /(assessment|scoring|marking)[_-]?(rubric|criteria|descriptor)/i, type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" },
+  { pattern: /band[_-]?score(s)?/i, type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" },
+  { pattern: /(ielts|cefr|toefl|toeic)[_-]?(rubric|descriptor|band|score)/i, type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" },
   { pattern: /question[_-]?bank/i, type: "QUESTION_BANK", role: "questions" },
   { pattern: /reading[_-]?passage/i, type: "READING_PASSAGE", role: "passage" },
   { pattern: /lesson[_-]?plan/i, type: "LESSON_PLAN", role: "pedagogy" },
@@ -503,27 +509,31 @@ export async function classifyDocument(
       return overriddenResult;
     }
 
-    // #276 Slice 1: content-based rubric override. When the text sample is
-    // unmistakably a tutor-facing rubric (band descriptors, scoring criteria)
-    // but the AI returned a generic learner-facing type (TEXTBOOK / REFERENCE
-    // / CURRICULUM), force COURSE_REFERENCE so the MCQ exclusion gate fires.
-    // Filename-hint already ran above; this catches the generic-filename case.
+    // #276 Slice 1 + #385 Slice 1 Phase 2 — content-based rubric override.
+    // When the text sample is unmistakably a tutor-facing rubric (band
+    // descriptors, scoring criteria) but the AI returned a generic learner-
+    // facing type (TEXTBOOK / REFERENCE / CURRICULUM), force the
+    // COURSE_REFERENCE_ASSESSOR_RUBRIC subtype so the MCQ exclusion gate
+    // fires AND the audience-routing layer can keep rubric out of learner
+    // chat. Filename-hint already ran above; this catches the
+    // generic-filename case.
     if (
       documentType !== "COURSE_REFERENCE" &&
+      documentType !== "COURSE_REFERENCE_ASSESSOR_RUBRIC" &&
       ["TEXTBOOK", "REFERENCE", "CURRICULUM"].includes(documentType) &&
       isRubricContent(sample)
     ) {
       console.log(
-        `[classify-document] Rubric content override: ${fileName} AI=${documentType} → COURSE_REFERENCE (rubric markers detected in sample)`,
+        `[classify-document] Rubric content override: ${fileName} AI=${documentType} → COURSE_REFERENCE_ASSESSOR_RUBRIC (rubric markers detected in sample)`,
       );
       const overriddenResult: ClassificationResult = {
-        documentType: "COURSE_REFERENCE" as DocumentType,
+        documentType: "COURSE_REFERENCE_ASSESSOR_RUBRIC" as DocumentType,
         confidence: Math.max(confidence, 0.85),
-        reasoning: `${parsed.reasoning || "No reasoning provided"} [Content signal: rubric markers detected (band descriptors / scoring criteria) → COURSE_REFERENCE]`,
+        reasoning: `${parsed.reasoning || "No reasoning provided"} [Content signal: rubric markers detected (band descriptors / scoring criteria) → COURSE_REFERENCE_ASSESSOR_RUBRIC]`,
         declaration: declaration.hasDeclaration ? declaration : undefined,
       };
       logAI("content-trust.classify:result", `Classify ${fileName}`, JSON.stringify(overriddenResult), {
-        fileName, documentType: "COURSE_REFERENCE", confidence: overriddenResult.confidence, contentOverride: true,
+        fileName, documentType: "COURSE_REFERENCE_ASSESSOR_RUBRIC", confidence: overriddenResult.confidence, contentOverride: true,
       });
       return overriddenResult;
     }

--- a/apps/admin/lib/content-trust/resolve-config.ts
+++ b/apps/admin/lib/content-trust/resolve-config.ts
@@ -33,7 +33,25 @@ export interface ExtractionCategory {
   description: string;
 }
 
-export type DocumentType = "CURRICULUM" | "TEXTBOOK" | "WORKSHEET" | "EXAMPLE" | "ASSESSMENT" | "REFERENCE" | "COMPREHENSION" | "LESSON_PLAN" | "POLICY_DOCUMENT" | "READING_PASSAGE" | "QUESTION_BANK" | "COURSE_REFERENCE";
+export type DocumentType =
+  | "CURRICULUM"
+  | "TEXTBOOK"
+  | "WORKSHEET"
+  | "EXAMPLE"
+  | "ASSESSMENT"
+  | "REFERENCE"
+  | "COMPREHENSION"
+  | "LESSON_PLAN"
+  | "POLICY_DOCUMENT"
+  | "READING_PASSAGE"
+  | "QUESTION_BANK"
+  | "COURSE_REFERENCE"
+  // #385 Slice 1 — audience-scoped subtypes; emitted by classify-document
+  // pattern overrides. Legacy COURSE_REFERENCE remains valid for AI output
+  // that doesn't trigger a deterministic subtype mapping.
+  | "COURSE_REFERENCE_CANONICAL"
+  | "COURSE_REFERENCE_TUTOR_BRIEFING"
+  | "COURSE_REFERENCE_ASSESSOR_RUBRIC";
 
 /**
  * Categories that represent tutor instructions (how to teach),

--- a/apps/admin/tests/lib/classify-document.test.ts
+++ b/apps/admin/tests/lib/classify-document.test.ts
@@ -301,13 +301,19 @@ describe("classifyDocument", () => {
       makeConfig(),
     );
 
-    expect(result.documentType).toBe("COURSE_REFERENCE");
+    // #385 Slice 1 Phase 2: filename "course-reference" now maps to the
+    // CANONICAL subtype, not the legacy flat value. Override fires when AI
+    // returns legacy COURSE_REFERENCE because the filename gives us a more
+    // specific subtype — refining-the-class is the correct behaviour.
+    expect(result.documentType).toBe("COURSE_REFERENCE_CANONICAL");
     expect(result.confidence).toBeGreaterThanOrEqual(0.85);
     expect(result.reasoning).toContain("Filename signal");
   });
 
-  it("does NOT override when AI classification matches filename hint", async () => {
-    // AI correctly says COURSE_REFERENCE — no override needed
+  it("refines legacy COURSE_REFERENCE to the CANONICAL subtype when filename signals it", async () => {
+    // AI returns the legacy flat COURSE_REFERENCE; filename hint resolves
+    // to the CANONICAL subtype. Override fires to upgrade the class — the
+    // hint is strictly more specific than the AI output (#385 Slice 1 Phase 2).
     mockAIReturn({
       documentType: "COURSE_REFERENCE",
       confidence: 0.92,
@@ -320,11 +326,9 @@ describe("classifyDocument", () => {
       makeConfig(),
     );
 
-    expect(result.documentType).toBe("COURSE_REFERENCE");
-    expect(result.confidence).toBe(0.92);
-    expect(result.reasoning).toBe("tutor instruction document");
-    // No "[Filename signal" annotation since AI got it right
-    expect(result.reasoning).not.toContain("Filename signal");
+    expect(result.documentType).toBe("COURSE_REFERENCE_CANONICAL");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.85);
+    expect(result.reasoning).toContain("Filename signal");
   });
 
   it("overrides question-bank filename when AI says TEXTBOOK", async () => {

--- a/apps/admin/tests/lib/content-trust/classify-document.test.ts
+++ b/apps/admin/tests/lib/content-trust/classify-document.test.ts
@@ -61,42 +61,42 @@ describe("buildMultiPointSample", () => {
 describe("filenameTypeHint", () => {
   it("detects course-reference in filename", () => {
     const hint = filenameTypeHint("11plus-english-course-reference.md");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_CANONICAL", role: "pedagogy" });
   });
 
   it("detects course_reference with underscore", () => {
     const hint = filenameTypeHint("biology_course_reference.pdf");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_CANONICAL", role: "pedagogy" });
   });
 
   it("detects course-ref shorthand", () => {
     const hint = filenameTypeHint("maths-course-ref.docx");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_CANONICAL", role: "pedagogy" });
   });
 
   it("detects tutor-guide", () => {
     const hint = filenameTypeHint("english-tutor-guide.pdf");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" });
   });
 
   it("detects tutor_handbook", () => {
     const hint = filenameTypeHint("science_tutor_handbook.md");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" });
   });
 
   it("detects teaching-guide", () => {
     const hint = filenameTypeHint("Teaching-Guide-Year5.pdf");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" });
   });
 
   it("detects teaching-methodology", () => {
     const hint = filenameTypeHint("reading-teaching-methodology.docx");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" });
   });
 
   it("detects delivery-guide", () => {
     const hint = filenameTypeHint("11plus-delivery-guide.pdf");
-    expect(hint).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(hint).toEqual({ type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" });
   });
 
   it("detects question-bank", () => {
@@ -137,32 +137,32 @@ describe("filenameTypeHint", () => {
   });
 
   it("is case-insensitive", () => {
-    expect(filenameTypeHint("COURSE-REFERENCE.PDF")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
-    expect(filenameTypeHint("Tutor-Guide.docx")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(filenameTypeHint("COURSE-REFERENCE.PDF")).toEqual({ type: "COURSE_REFERENCE_CANONICAL", role: "pedagogy" });
+    expect(filenameTypeHint("Tutor-Guide.docx")).toEqual({ type: "COURSE_REFERENCE_TUTOR_BRIEFING", role: "pedagogy" });
     expect(filenameTypeHint("QUESTION_BANK.pdf")).toEqual({ type: "QUESTION_BANK", role: "questions" });
   });
 
-  // ── #276 Slice 1: rubric / band-descriptor filename hints ──
+  // ── #276 Slice 1 + #385 Slice 1 Phase 2: rubric / band-descriptor filename hints route to ASSESSOR_RUBRIC ──
 
   it("detects band-descriptor filenames", () => {
-    expect(filenameTypeHint("IELTS-Band-Descriptors.pdf")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
-    expect(filenameTypeHint("speaking_band_descriptor.docx")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(filenameTypeHint("IELTS-Band-Descriptors.pdf")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
+    expect(filenameTypeHint("speaking_band_descriptor.docx")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
   });
 
   it("detects assessment / scoring / marking rubric filenames", () => {
-    expect(filenameTypeHint("assessment-rubric.pdf")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
-    expect(filenameTypeHint("scoring_criteria.docx")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
-    expect(filenameTypeHint("marking-criteria-2024.pdf")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(filenameTypeHint("assessment-rubric.pdf")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
+    expect(filenameTypeHint("scoring_criteria.docx")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
+    expect(filenameTypeHint("marking-criteria-2024.pdf")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
   });
 
   it("detects exam-specific rubric filenames (IELTS / CEFR / TOEFL)", () => {
-    expect(filenameTypeHint("ielts-rubric.pdf")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
-    expect(filenameTypeHint("CEFR-descriptor.docx")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
-    expect(filenameTypeHint("toefl_band.pdf")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(filenameTypeHint("ielts-rubric.pdf")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
+    expect(filenameTypeHint("CEFR-descriptor.docx")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
+    expect(filenameTypeHint("toefl_band.pdf")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
   });
 
   it("detects band-score filenames", () => {
-    expect(filenameTypeHint("band-scores.pdf")).toEqual({ type: "COURSE_REFERENCE", role: "pedagogy" });
+    expect(filenameTypeHint("band-scores.pdf")).toEqual({ type: "COURSE_REFERENCE_ASSESSOR_RUBRIC", role: "pedagogy" });
   });
 });
 


### PR DESCRIPTION
## Summary

**Phase 2 of #385 Slice 1.** Classifier's deterministic post-AI override layer now resolves to the audience-scoped subtypes when the signal is specific enough. AI prompt unchanged — still emits legacy `COURSE_REFERENCE`; the post-AI layer refines.

## Mapping

| Signal | Result |
|---|---|
| Filename: `course-ref(erence)` | `COURSE_REFERENCE_CANONICAL` |
| Filename: `tutor-(guide\|playbook\|briefing\|...)` | `COURSE_REFERENCE_TUTOR_BRIEFING` |
| Filename: `teaching-(guide\|methodology)`, `delivery-(guide\|handbook)` | `COURSE_REFERENCE_TUTOR_BRIEFING` |
| Filename: `band-descriptor`, `band-score(s)`, `(assessment\|scoring\|marking)-(rubric\|criteria\|descriptor)`, exam-specific rubric names | `COURSE_REFERENCE_ASSESSOR_RUBRIC` |
| Content shape: `isRubricContent()` returns true | `COURSE_REFERENCE_ASSESSOR_RUBRIC` |

Override also fires when AI returns the legacy flat `COURSE_REFERENCE` — refining the class is correct because the filename/content signal is strictly more specific than the AI's coarse output.

## Test plan

- [x] 52/52 classifier tests pass with updated subtype expectations
- [x] tsc: 185 → 182 (3 below floor)
- [ ] Re-upload IELTS sources on a fresh wizard — `assessor-rubric` should classify to `COURSE_REFERENCE_ASSESSOR_RUBRIC`, `tutor-briefing` to `COURSE_REFERENCE_TUTOR_BRIEFING`, `course-ref` to `COURSE_REFERENCE_CANONICAL`

## Deploy

`/vm-cp` — no schema change; Phase 1's migration is already applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)