### PR TITLE
feat(#385): Slice 1 Phase 3 — reader sweep accepts all four COURSE_REFERENCE* values

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -1004,7 +1004,14 @@ export async function executeWizardTool(
                     select: { sourceId: true, source: { select: { documentType: true } } },
                   });
                   for (const ps of packSources) {
-                    if (ps.source.documentType === "COURSE_REFERENCE" || ps.source.documentType === "POLICY_DOCUMENT") {
+                    // #385 Slice 1 Phase 3 — bridge all four COURSE_REFERENCE* values.
+              if (
+                ps.source.documentType === "COURSE_REFERENCE" ||
+                ps.source.documentType === "COURSE_REFERENCE_CANONICAL" ||
+                ps.source.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+                ps.source.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC" ||
+                ps.source.documentType === "POLICY_DOCUMENT"
+              ) {
                       const existingLink = await prisma.subjectSource.findFirst({
                         where: { subjectId: existingPbSubject.subjectId, sourceId: ps.sourceId },
                       });
@@ -1414,7 +1421,14 @@ export async function executeWizardTool(
               select: { sourceId: true, source: { select: { documentType: true } } },
             });
             for (const ps of packSources) {
-              if (ps.source.documentType === "COURSE_REFERENCE" || ps.source.documentType === "POLICY_DOCUMENT") {
+              // #385 Slice 1 Phase 3 — bridge all four COURSE_REFERENCE* values.
+              if (
+                ps.source.documentType === "COURSE_REFERENCE" ||
+                ps.source.documentType === "COURSE_REFERENCE_CANONICAL" ||
+                ps.source.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+                ps.source.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC" ||
+                ps.source.documentType === "POLICY_DOCUMENT"
+              ) {
                 const existingLink = await prisma.subjectSource.findFirst({
                   where: { subjectId: subject.id, sourceId: ps.sourceId },
                 });

--- a/apps/admin/lib/content-trust/dedup-source.ts
+++ b/apps/admin/lib/content-trust/dedup-source.ts
@@ -58,7 +58,12 @@ export async function findDuplicateSource(
   // COURSE_REFERENCE documents are course-specific by nature — their assertions
   // contain tutor instructions scoped to a single course. Never share them across
   // subjects, even within the same institution. Only dedup within the same subject.
-  const isCourseRef = documentType === "COURSE_REFERENCE";
+  // #385 Slice 1 Phase 3 — accept all four COURSE_REFERENCE* values.
+  const isCourseRef =
+    documentType === "COURSE_REFERENCE" ||
+    documentType === "COURSE_REFERENCE_CANONICAL" ||
+    documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+    documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC";
 
   const institutionId = await resolveInstitutionId(subjectId);
 

--- a/apps/admin/lib/content-trust/extract-assertions.ts
+++ b/apps/admin/lib/content-trust/extract-assertions.ts
@@ -343,7 +343,12 @@ async function extractFromChunk(
     ? options.documentType.replace(/_/g, " ").toLowerCase()
     : "training";
 
-  const isCourseRef = options.documentType === "COURSE_REFERENCE";
+  // #385 Slice 1 Phase 3 — accept all four COURSE_REFERENCE* values.
+  const isCourseRef =
+    options.documentType === "COURSE_REFERENCE" ||
+    options.documentType === "COURSE_REFERENCE_CANONICAL" ||
+    options.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+    options.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC";
 
   // For non-COURSE_REFERENCE documents, hint that tutor instructions may be present
   const instructionHint = !isCourseRef
@@ -591,7 +596,13 @@ export async function extractAssertions(
   // Info: note if a COURSE_REFERENCE doc contains student-facing content.
   // These now flow through to curriculum loaders (no longer orphaned),
   // but we still surface the count as an informational note.
-  if (options.documentType === "COURSE_REFERENCE") {
+  // #385 Slice 1 Phase 3 — match legacy COURSE_REFERENCE + all three subtypes.
+  if (
+    options.documentType === "COURSE_REFERENCE" ||
+    options.documentType === "COURSE_REFERENCE_CANONICAL" ||
+    options.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+    options.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC"
+  ) {
     const instructionCatSet = new Set<string>(INSTRUCTION_CATEGORIES);
     const contentAssertions = deduplicated.filter((a) => !instructionCatSet.has(a.category));
     if (contentAssertions.length > 0) {

--- a/apps/admin/lib/content-trust/extractors/generic-extractor.ts
+++ b/apps/admin/lib/content-trust/extractors/generic-extractor.ts
@@ -37,7 +37,12 @@ export class GenericExtractor extends DocumentExtractor {
     const { extraction } = config;
     const validCategoryIds = new Set(extraction.categories.map((c) => c.id));
 
-    const isCourseRef = this.documentType === "COURSE_REFERENCE";
+    // #385 Slice 1 Phase 3 — accept all four COURSE_REFERENCE* values.
+    const isCourseRef =
+      this.documentType === "COURSE_REFERENCE" ||
+      this.documentType === "COURSE_REFERENCE_CANONICAL" ||
+      this.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+      this.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC";
     const qualRef = context.qualificationRef ? `${context.qualificationRef} ` : "";
 
     const openingLine = isCourseRef

--- a/apps/admin/lib/content-trust/parse-content-declaration.ts
+++ b/apps/admin/lib/content-trust/parse-content-declaration.ts
@@ -81,6 +81,11 @@ const DOCUMENT_TYPES: ReadonlySet<DocumentType> = new Set<DocumentType>([
   "READING_PASSAGE",
   "QUESTION_BANK",
   "COURSE_REFERENCE",
+  // #385 Slice 1 Phase 3 — accept the three subtypes from explicit
+  // hf-document-type front-matter declarations as well.
+  "COURSE_REFERENCE_CANONICAL",
+  "COURSE_REFERENCE_TUTOR_BRIEFING",
+  "COURSE_REFERENCE_ASSESSOR_RUBRIC",
 ]);
 
 const LO_SYSTEM_ROLES: ReadonlySet<LoSystemRole> = new Set<LoSystemRole>([

--- a/apps/admin/lib/content-trust/validate-lo-linkage.ts
+++ b/apps/admin/lib/content-trust/validate-lo-linkage.ts
@@ -257,7 +257,15 @@ export async function computeCourseLinkageScorecard(courseId: string): Promise<C
         select: { id: true, documentType: true },
       })
     : [];
-  const TUTOR_ONLY_DOC_TYPES = new Set(["COURSE_REFERENCE", "LESSON_PLAN", "POLICY_DOCUMENT"]);
+  // #385 Slice 1 Phase 3 — subtypes inherit tutor-only status.
+  const TUTOR_ONLY_DOC_TYPES = new Set([
+    "COURSE_REFERENCE",
+    "COURSE_REFERENCE_CANONICAL",
+    "COURSE_REFERENCE_TUTOR_BRIEFING",
+    "COURSE_REFERENCE_ASSESSOR_RUBRIC",
+    "LESSON_PLAN",
+    "POLICY_DOCUMENT",
+  ]);
   const ASSESSMENT_DOC_TYPES = new Set(["QUESTION_BANK", "ASSESSMENT"]);
   const tutorSourceIds = new Set(
     sources

--- a/apps/admin/lib/content-trust/validate-manifest.ts
+++ b/apps/admin/lib/content-trust/validate-manifest.ts
@@ -47,6 +47,10 @@ interface ValidationResult {
 /** Document types that are NEVER a subject — always pedagogy/supporting material */
 const PEDAGOGY_DOC_TYPES = new Set([
   "COURSE_REFERENCE",
+  // #385 Slice 1 Phase 3 — subtypes inherit pedagogy-not-subject status.
+  "COURSE_REFERENCE_CANONICAL",
+  "COURSE_REFERENCE_TUTOR_BRIEFING",
+  "COURSE_REFERENCE_ASSESSOR_RUBRIC",
   "LESSON_PLAN",
   "POLICY_DOCUMENT",
 ]);

--- a/apps/admin/lib/goals/sync-constraints-from-reference.ts
+++ b/apps/admin/lib/goals/sync-constraints-from-reference.ts
@@ -41,7 +41,16 @@ export async function syncConstraintsFromReference(
     where: { id: sourceId },
     select: { id: true, documentType: true },
   });
-  if (!source || source.documentType !== "COURSE_REFERENCE") return result;
+  // #385 Slice 1 Phase 3 — accept all four COURSE_REFERENCE* values.
+  if (
+    !source ||
+    !(
+      source.documentType === "COURSE_REFERENCE" ||
+      source.documentType === "COURSE_REFERENCE_CANONICAL" ||
+      source.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+      source.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC"
+    )
+  ) return result;
 
   // 2. Get edge_case + teaching_rule assertions that express prohibitions
   const assertions = await prisma.contentAssertion.findMany({

--- a/apps/admin/lib/goals/sync-goals-from-reference.ts
+++ b/apps/admin/lib/goals/sync-goals-from-reference.ts
@@ -39,7 +39,16 @@ export async function syncGoalsFromReference(
     where: { id: sourceId },
     select: { id: true, documentType: true },
   });
-  if (!source || source.documentType !== "COURSE_REFERENCE") return result;
+  // #385 Slice 1 Phase 3 — accept all four COURSE_REFERENCE* values.
+  if (
+    !source ||
+    !(
+      source.documentType === "COURSE_REFERENCE" ||
+      source.documentType === "COURSE_REFERENCE_CANONICAL" ||
+      source.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+      source.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC"
+    )
+  ) return result;
 
   // 2. Get assessment_approach assertions from this source
   const assertions = await prisma.contentAssertion.findMany({

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -1097,7 +1097,17 @@ registerLoader("courseInstructions", async (_callerId, loaderConfig) => {
   for (const s of scope.subjects) {
     for (const ss of s.sources) {
       sourceIds.push(ss.sourceId);
-      if (ss.documentType === "COURSE_REFERENCE") courseRefSourceIds.push(ss.sourceId);
+      // #385 Slice 1 Phase 3 — match the legacy literal + all three subtypes
+      // (CANONICAL / TUTOR_BRIEFING / ASSESSOR_RUBRIC) so newly-classified
+      // sources still receive the COURSE_REFERENCE-wide assertion path.
+      if (
+        ss.documentType === "COURSE_REFERENCE" ||
+        ss.documentType === "COURSE_REFERENCE_CANONICAL" ||
+        ss.documentType === "COURSE_REFERENCE_TUTOR_BRIEFING" ||
+        ss.documentType === "COURSE_REFERENCE_ASSESSOR_RUBRIC"
+      ) {
+        courseRefSourceIds.push(ss.sourceId);
+      }
     }
   }
   if (sourceIds.length === 0) return [];

--- a/apps/admin/lib/wizard/run-projection-for-playbook.ts
+++ b/apps/admin/lib/wizard/run-projection-for-playbook.ts
@@ -39,10 +39,18 @@ export interface RunProjectionResult {
  * Throws only on truly unexpected DB errors.
  */
 export async function runProjectionForPlaybook(playbookId: string): Promise<RunProjectionResult> {
+  // #385 Slice 1 Phase 3 — accept legacy COURSE_REFERENCE + the three
+  // subtypes emitted by the classifier in Phase 2. The projection logic
+  // itself is agnostic to which subtype the source carries; projection
+  // runs the same parsers against any course-reference-family doc.
   const links = await prisma.playbookSource.findMany({
     where: {
       playbookId,
-      source: { documentType: "COURSE_REFERENCE" },
+      source: {
+        documentType: {
+          in: ["COURSE_REFERENCE", "COURSE_REFERENCE_CANONICAL", "COURSE_REFERENCE_TUTOR_BRIEFING", "COURSE_REFERENCE_ASSESSOR_RUBRIC"],
+        },
+      },
     },
     select: {
       source: {


### PR DESCRIPTION
## Summary

**Phase 3 of #385 Slice 1.** After Phase 2 the classifier produces three subtypes, but readers still filter on the legacy literal. Without this sweep, projection silently skips subtype sources (= degenerate course on every new wizard run that uses real filenames).

11 files updated. Pattern: each reader's `documentType === "COURSE_REFERENCE"` check or Prisma filter is widened to accept all four `COURSE_REFERENCE*` values.

## Files

| File | Why it matters |
|---|---|
| `lib/wizard/run-projection-for-playbook.ts` | **FATAL fix** — projection FK filter now matches subtype sources |
| `lib/prompt/composition/SectionDataLoader.ts` | `courseInstructions` loader's tutor-config widening now applies to subtypes |
| `lib/chat/wizard-tool-executor.ts` | Both `create_course` source-bridging sites |
| `lib/content-trust/dedup-source.ts` | Cross-subject dedup boundary |
| `lib/content-trust/extract-assertions.ts` | Two prompt-shape gates (×2) |
| `lib/content-trust/extractors/generic-extractor.ts` | Tutor-prompt phrasing gate |
| `lib/content-trust/parse-content-declaration.ts` | `hf-document-type` allow-list |
| `lib/content-trust/validate-manifest.ts` | `PEDAGOGY_DOC_TYPES` set |
| `lib/content-trust/validate-lo-linkage.ts` | `TUTOR_ONLY_DOC_TYPES` set |
| `lib/goals/sync-goals-from-reference.ts` | source filter |
| `lib/goals/sync-constraints-from-reference.ts` | source filter |

## Writers untouched

Code paths that CREATE ContentSource rows with the literal `"COURSE_REFERENCE"` value are intentionally left alone — the classifier owns subtype emission now. Auto-upgrading existing writers is Phase 4 (backfill) territory.

## Test plan

- [x] 365 content-trust + classifier tests pass
- [x] tsc 182 unchanged
- [ ] Re-upload your three IELTS docs end-to-end → projection fires → 4 modules + 11 LOs

🤖 Generated with [Claude Code](https://claude.com/claude-code)