### PR TITLE
fix(#396): wire activeCall through SimChat → breadcrumb

### DIFF
--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -61,6 +61,9 @@ export default function SimConversationPage() {
   // banner can display a human label instead of the raw id.
   const [authoredModules, setAuthoredModules] = useState<Array<{ id: string; label?: string }>>([]);
   const [error, setError] = useState<string | null>(null);
+  // #396: parent-owned "is a call live?" flag so the SimStateBreadcrumb pill
+  // reads "(Active)" while the user is mid-call instead of always "(Pre-call)".
+  const [isCallActive, setIsCallActive] = useState(false);
 
   // Journey chat — unified WhatsApp-style survey/onboarding/teaching flow
   // Only runs for LEARNER callers; waits for caller data before deciding.
@@ -183,6 +186,7 @@ export default function SimConversationPage() {
     <>
       <SimStateBreadcrumb
         pastCallCount={caller.pastCalls.length}
+        activeCall={isCallActive}
         requestedModuleId={requestedModuleId ?? null}
         modules={authoredModules}
         onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
@@ -212,6 +216,7 @@ export default function SimConversationPage() {
         forceFirstCall={forceFirstCall || undefined}
         onBack={isDesktop ? undefined : () => router.push('/x/sim')}
         onCallEnd={isStudent ? handleStudentCallEnd : undefined}
+        onCallStateChange={setIsCallActive}
         onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
         requestedModuleId={requestedModuleId}
         journey={journey}

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -89,6 +89,9 @@ export default function CallerDetailPage() {
   };
   const [simChatMounted, setSimChatMounted] = useState(initialTab === "ai-call");
   const [callSession, setCallSession] = useState(0);
+  // #396: parent-owned "is a call live?" flag so the SimStateBreadcrumb pill
+  // reads "(Active)" while the user is mid-call instead of always "(Pre-call)".
+  const [isCallActive, setIsCallActive] = useState(false);
   if (activeSection === "ai-call" && !simChatMounted) setSimChatMounted(true);
 
   // Dynamic parameter display configuration (fetched from database)
@@ -1160,6 +1163,7 @@ export default function CallerDetailPage() {
               signals as /x/sim/[id]. */}
           <SimStateBreadcrumb
             pastCallCount={(data?.calls ?? []).filter((c: { transcript?: string | null }) => c.transcript?.trim()).length}
+            activeCall={isCallActive}
             requestedModuleId={requestedModuleId ?? null}
             modules={authoredModules}
             onPickModule={
@@ -1200,6 +1204,7 @@ export default function CallerDetailPage() {
               fetchPrompts();
             }}
             onNewCall={() => setCallSession(prev => prev + 1)}
+            onCallStateChange={setIsCallActive}
             onPickModule={
               modulesAuthored && selectedPlaybookId && selectedPlaybookId !== "all"
                 ? handlePickModule

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -49,6 +49,17 @@ export interface SimChatProps {
   onCallEnd?: () => void;
   onNewCall?: () => void;
   onBack?: () => void;
+  /**
+   * Notifies the parent when the call goes active or back to a non-active
+   * state. "Active" means `callPhase === 'active'` with at least one message
+   * exchanged (i.e. the greeting has streamed). Issue #396 — drives the
+   * SimStateBreadcrumb "(Active)" vs "(Pre-call)" pill.
+   *
+   * Race-safe: the `false` transition fires alongside `onCallEnd?.()` inside
+   * `handleEndCall` rather than tracking `callPhase === 'ended'` so the
+   * breadcrumb doesn't snap back to "Pre-call" before post-call UI settles.
+   */
+  onCallStateChange?: (active: boolean) => void;
   /** When set, renders a "Pick module" header button (Issue #242 SIM-first mount) */
   onPickModule?: () => void;
   /**
@@ -128,6 +139,7 @@ export function SimChat({
   onCallEnd,
   onNewCall,
   onBack,
+  onCallStateChange,
   onPickModule,
   requestedModuleId,
   journey,
@@ -180,6 +192,20 @@ export function SimChat({
   useEffect(() => {
     return () => { abortRef.current?.abort(); };
   }, []);
+
+  // #396: notify the parent when the call is truly "active" — i.e. the
+  // greeting has streamed and at least one message exists. Mirrors the same
+  // truth value the WhatsAppHeader uses on line below for `callActive`.
+  // The `false` transition for end-call is fired in handleEndCall alongside
+  // onCallEnd?.() so post-call UI doesn't flash through "Pre-call".
+  const lastCallActiveFiredRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    if (!onCallStateChange) return;
+    const active = callPhase === 'active' && messages.length > 0;
+    if (lastCallActiveFiredRef.current === active) return;
+    lastCallActiveFiredRef.current = active;
+    onCallStateChange(active);
+  }, [callPhase, messages.length, onCallStateChange]);
 
   // Parse past calls into grouped history — one group per call, never merged
   const historyGroups: HistoryGroup[] = useMemo(() => {
@@ -751,7 +777,13 @@ export function SimChat({
       setCallEndedAt(new Date());
 
       // Notify parent (refresh data, etc.)
+      // #396: fire onCallStateChange(false) here — NOT on the raw `ended`
+      // phase transition — so the breadcrumb stays "Active" through any
+      // post-call UI settle and only flips back once the call is fully
+      // wrapped. Sync the ref so the watcher effect won't re-fire.
       onCallEnd?.();
+      lastCallActiveFiredRef.current = false;
+      onCallStateChange?.(false);
       journey?.onCallEnd();
 
       // Standalone mode with no pipeline: navigate back
@@ -762,7 +794,7 @@ export function SimChat({
       showToast('Failed to save call');
       setIsEnding(false);
     }
-  }, [callId, callerId, messages, runPipeline, showToast, onCallEnd, onBack, journey]);
+  }, [callId, callerId, messages, runPipeline, showToast, onCallEnd, onCallStateChange, onBack, journey]);
 
   const isEmbedded = mode === 'embedded';
 


### PR DESCRIPTION
## Summary

Fixes #396 — the `Now: Call #N (Pre-call|Active)` breadcrumb on the AI Call tab and `/x/sim/[callerId]` was always reading "(Pre-call)". The `SimStateBreadcrumb` component accepted an `activeCall` prop but neither consumer was passing it, so the default `false` was always in effect.

Tech Lead picked option (a) — callback prop, mirroring the existing `onCallEnd` pattern.

- `SimChat` exposes `onCallStateChange?: (active: boolean) => void`
- Truth value: `callPhase === 'active' && messages.length > 0`
- Fired alongside `onCallEnd?.()` in `handleEndCall` (not on the raw `setCallPhase('ended')` transition — avoids breadcrumb snapping to "Pre-call" before post-call UI settles)
- Equality-guard ref suppresses redundant fires

Both `CallerDetailPage.tsx` and `app/x/sim/[callerId]/page.tsx` now hold an `isCallActive` state and thread it through the breadcrumb.

## Test plan

- [ ] Open caller detail → AI Call tab → start a call → breadcrumb shows "(Active)"
- [ ] End the call → breadcrumb shows "(Pre-call)"
- [ ] Repeat on `/x/sim/[callerId]` standalone view
- [ ] Caller-detail vitest suite: `npm run test -- __tests__/pages/caller-detail.test.tsx` (20/20 pre-verified)

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)