### PR TITLE
feat(#418): curriculum mode chip + Authored/Derived toggle

### DIFF
--- a/apps/admin/__tests__/ui/course-curriculum-tab.test.tsx
+++ b/apps/admin/__tests__/ui/course-curriculum-tab.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * CourseCurriculumTab — segmented toggle + flash fix (issue #418).
+ *
+ * Covers:
+ *  - Renders only a spinner while `activeCurriculumMode` is null (no
+ *    flash of the wrong panel on mount).
+ *  - With `activeCurriculumMode="authored"`, the Authored panel is the
+ *    default view; switching the toggle to Derived shows a preview-mode
+ *    banner and mounts CurriculumHealthTabs in read-only mode with a
+ *    reconcile-only subset of regenerate actions.
+ *  - With `activeCurriculumMode="derived"`, the Derived view (scorecard)
+ *    is default; switching to Authored shows the AuthoredModulesPanel.
+ *  - The internal McqPanel section is suppressed in preview mode on the
+ *    Authored branch (the Derived view brings its own MCQ tab).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+
+// ── Child mocks ────────────────────────────────────────────────────────
+// We stub the heavy children so we can assert on the parent's branching
+// logic without pulling in their own fetches / DOM.
+const authoredMock = vi.fn();
+const healthMock = vi.fn();
+const mcqMock = vi.fn();
+
+vi.mock("@/app/x/courses/[courseId]/_components/AuthoredModulesPanel", () => ({
+  AuthoredModulesPanel: (props: { courseId: string; isOperator: boolean }) => {
+    authoredMock(props);
+    return <div data-testid="authored-panel">authored</div>;
+  },
+}));
+
+vi.mock("@/app/x/courses/[courseId]/CurriculumHealthTabs", () => ({
+  CurriculumHealthTabs: (props: {
+    readOnly?: boolean;
+    regenerateActions?: Record<string, unknown>;
+  }) => {
+    healthMock(props);
+    return (
+      <div
+        data-testid="health-tabs"
+        data-readonly={props.readOnly ? "true" : "false"}
+        data-action-keys={
+          props.regenerateActions
+            ? Object.keys(props.regenerateActions).sort().join(",")
+            : ""
+        }
+      >
+        health
+      </div>
+    );
+  },
+  McqPanel: (props: { courseId: string }) => {
+    mcqMock(props);
+    return <div data-testid="mcq-panel">mcq</div>;
+  },
+}));
+
+// Stub fetch — scorecard endpoint is the only one the tab hits directly.
+function mockScorecard() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      ok: true,
+      scorecard: {
+        course: { id: "c1", name: "Test" },
+        curriculumId: "curr-1",
+        health: "ready",
+        studentContent: { total: 0, linkedToOutcome: 0, linkedPct: 0 },
+        assessmentItems: { total: 0, linkedToOutcome: 0, linkedPct: 0 },
+        tutorInstructions: { total: 0, linkedToOutcome: 0, linkedPct: 0 },
+        questions: { total: 0, linkedToTp: 0, linkedPct: 0 },
+        structure: {
+          activeModules: 3,
+          totalModules: 3,
+          learningOutcomes: 5,
+          outcomesWithContent: 5,
+          outcomesWithoutContent: 0,
+          garbageDescriptions: 0,
+        },
+        warnings: [],
+        scorecard: {
+          total: 0,
+          withValidRef: 0,
+          withFk: 0,
+          distinctRefs: 0,
+          orphans: 0,
+          garbageDescriptions: 0,
+          coveragePct: 0,
+          fkCoveragePct: 0,
+        },
+        loRows: { total: 5, garbageDescriptions: 0, orphanLos: 0 },
+        modules: { total: 3, active: 3 },
+      },
+    }),
+  }) as unknown as typeof fetch;
+}
+
+// Import after the mocks are registered.
+import { CourseCurriculumTab } from "@/app/x/courses/[courseId]/CourseCurriculumTab";
+
+beforeEach(() => {
+  authoredMock.mockReset();
+  healthMock.mockReset();
+  mcqMock.mockReset();
+  mockScorecard();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("CourseCurriculumTab — flash prevention (#418)", () => {
+  it("renders only a spinner while activeCurriculumMode is null", () => {
+    const { container } = render(
+      <CourseCurriculumTab
+        courseId="c1"
+        playbookId="c1"
+        isOperator={true}
+        activeCurriculumMode={null}
+      />,
+    );
+    expect(container.querySelector(".hf-spinner")).toBeInTheDocument();
+    expect(screen.queryByTestId("authored-panel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("health-tabs")).not.toBeInTheDocument();
+  });
+});
+
+describe("CourseCurriculumTab — Authored mode active", () => {
+  it("renders the Authored panel by default and exposes the toggle", async () => {
+    render(
+      <CourseCurriculumTab
+        courseId="c1"
+        playbookId="c1"
+        isOperator={true}
+        activeCurriculumMode="authored"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("authored-panel")).toBeInTheDocument();
+    });
+    // CurriculumHealthTabs is NOT mounted in the default Authored view.
+    expect(screen.queryByTestId("health-tabs")).not.toBeInTheDocument();
+    // Toggle present with both options.
+    expect(screen.getByRole("tab", { name: /Authored/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /Derived/ })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("switching to Derived shows preview banner, mounts health-tabs in readOnly with reconcile-only actions", async () => {
+    render(
+      <CourseCurriculumTab
+        courseId="c1"
+        playbookId="c1"
+        isOperator={true}
+        activeCurriculumMode="authored"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("authored-panel")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: /Derived/ }));
+    });
+
+    // Preview banner appears.
+    expect(screen.getByText(/Preview only/i)).toBeInTheDocument();
+    // Health tabs now mounted in read-only mode.
+    const tabs = await screen.findByTestId("health-tabs");
+    expect(tabs.getAttribute("data-readonly")).toBe("true");
+    // Only the link-only / idempotent actions are exposed in preview.
+    expect(tabs.getAttribute("data-action-keys")).toBe(
+      ["onReconcileTPs", "onRegenerateMcqs"].sort().join(","),
+    );
+  });
+});
+
+describe("CourseCurriculumTab — Derived mode active", () => {
+  it("renders CurriculumHealthTabs by default with full actions and readOnly=false", async () => {
+    render(
+      <CourseCurriculumTab
+        courseId="c1"
+        playbookId="c1"
+        isOperator={true}
+        activeCurriculumMode="derived"
+      />,
+    );
+    const tabs = await screen.findByTestId("health-tabs");
+    expect(tabs.getAttribute("data-readonly")).toBe("false");
+    expect(tabs.getAttribute("data-action-keys")).toBe(
+      [
+        "onReExtractInstructions",
+        "onReclassifyLos",
+        "onReconcileTPs",
+        "onRegenerateMcqs",
+        "onRegenerateModules",
+      ]
+        .sort()
+        .join(","),
+    );
+    // Authored panel is hidden in the active Derived view.
+    expect(screen.queryByTestId("authored-panel")).not.toBeInTheDocument();
+  });
+
+  it("switching to Authored shows the AuthoredModulesPanel as a preview", async () => {
+    render(
+      <CourseCurriculumTab
+        courseId="c1"
+        playbookId="c1"
+        isOperator={true}
+        activeCurriculumMode="derived"
+      />,
+    );
+    await screen.findByTestId("health-tabs");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: /Authored/ }));
+    });
+
+    expect(screen.getByTestId("authored-panel")).toBeInTheDocument();
+    expect(screen.getByText(/Preview only/i)).toBeInTheDocument();
+    // McqPanel section is hidden in preview mode on the authored branch
+    // (the user is peeking, not configuring; the active Derived view's
+    // own MCQ tab is the canonical surface).
+    expect(screen.queryByTestId("mcq-panel")).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/__tests__/ui/curriculum-health-tabs-readonly.test.tsx
+++ b/apps/admin/__tests__/ui/curriculum-health-tabs-readonly.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * CurriculumHealthTabs — `readOnly` prop suppresses the two silent
+ * auto-reconcile useEffects (issue #418).
+ *
+ * Today the component fires two background POSTs on mount whenever the
+ * scorecard reports orphans:
+ *   1. POST /api/curricula/:id/reconcile-orphans
+ *   2. POST /api/courses/:id/reconcile-mcqs
+ *
+ * When the curriculum tab renders this component in preview mode (i.e.
+ * the educator is peeking at the derived view on an authored-modules
+ * course), those silent fires must not run — they'd mutate a curriculum
+ * that isn't the active source of truth. This test holds that contract.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { CourseLinkageScorecard } from "@/lib/content-trust/validate-lo-linkage";
+import { CurriculumHealthTabs } from "@/app/x/courses/[courseId]/CurriculumHealthTabs";
+
+// ── Stubs ──────────────────────────────────────────────────────────────
+// The child panels each fire their own data-fetch on mount. Stub them
+// here so we don't pollute the fetch spy with unrelated requests.
+vi.mock("@/app/x/subjects/_components/CurriculumEditor", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("@/components/shared/AssertionDetailDrawer", () => ({
+  AssertionDetailDrawer: () => null,
+}));
+
+// ── Fixtures ───────────────────────────────────────────────────────────
+
+function scorecardWithOrphans(): CourseLinkageScorecard {
+  return {
+    course: { id: "course-1", name: "Test" },
+    curriculumId: "curr-1",
+    health: "needs_attention",
+    studentContent: { total: 10, linkedToOutcome: 5, linkedPct: 50 },
+    assessmentItems: { total: 0, linkedToOutcome: 0, linkedPct: 0 },
+    tutorInstructions: { total: 0, linkedToOutcome: 0, linkedPct: 0 },
+    // The two metrics that drive the silent fires
+    questions: { total: 8, linkedToTp: 2, linkedPct: 25 }, // 6 orphan MCQs
+    structure: {
+      activeModules: 3,
+      totalModules: 3,
+      learningOutcomes: 5,
+      outcomesWithContent: 3,
+      outcomesWithoutContent: 2, // > 0 → triggers orphan reconcile
+      garbageDescriptions: 0,
+    },
+    warnings: [],
+    scorecard: {
+      total: 10,
+      withValidRef: 5,
+      withFk: 5,
+      distinctRefs: 5,
+      orphans: 5,
+      garbageDescriptions: 0,
+      coveragePct: 50,
+      fkCoveragePct: 50,
+    },
+    loRows: { total: 5, garbageDescriptions: 0, orphanLos: 2 },
+    modules: { total: 3, active: 3 },
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("CurriculumHealthTabs — readOnly prop", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Default: every fetch resolves with an empty success payload so the
+    // panel children (which we also stub) don't throw on json().
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fires both silent reconciles on mount when readOnly is false", async () => {
+    render(
+      <CurriculumHealthTabs
+        scorecard={scorecardWithOrphans()}
+        courseId="course-1"
+        curriculumId="curr-1"
+        isOperator={true}
+        regenerating={false}
+        readOnly={false}
+      />,
+    );
+
+    await waitFor(() => {
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c) => String(c[0]),
+      );
+      expect(calls.some((u) => u.includes("/reconcile-orphans"))).toBe(true);
+      expect(calls.some((u) => u.includes("/reconcile-mcqs"))).toBe(true);
+    });
+  });
+
+  it("does NOT fire silent reconciles when readOnly is true", async () => {
+    render(
+      <CurriculumHealthTabs
+        scorecard={scorecardWithOrphans()}
+        courseId="course-1"
+        curriculumId="curr-1"
+        isOperator={true}
+        regenerating={false}
+        readOnly={true}
+      />,
+    );
+
+    // Give effects a tick to run, then assert nothing matching either
+    // reconcile URL was POSTed.
+    await new Promise((r) => setTimeout(r, 30));
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => String(c[0]),
+    );
+    expect(calls.some((u) => u.includes("/reconcile-orphans"))).toBe(false);
+    expect(calls.some((u) => u.includes("/reconcile-mcqs"))).toBe(false);
+  });
+});

--- a/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
@@ -13,7 +13,7 @@ import { requireAuth, isAuthError } from "@/lib/permissions";
  *   This endpoint checks: lesson plan existence, onboarding config, and prompt composability.
  *
  * @pathParam courseId string - Playbook UUID
- * @response 200 { ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, details }
+ * @response 200 { ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode, details }
  */
 export async function GET(
   _req: NextRequest,
@@ -123,12 +123,21 @@ export async function GET(
     // Prompt composition happens on first call — not an educator-facing readiness gate
     const allCriticalPass = lessonPlanBuilt && onboardingConfigured;
 
+    // ── Curriculum mode (issue #418) ────────────────────
+    // Authored = Course Reference module catalogue is the source of truth.
+    // Derived = AI extraction generates modules from uploaded content.
+    // null/false `modulesAuthored` is treated as derived (matches the
+    // existing behaviour in `CourseCurriculumTab` and the wizard default).
+    const activeCurriculumMode: "authored" | "derived" =
+      pbConfig.modulesAuthored === true ? "authored" : "derived";
+
     return NextResponse.json({
       ok: true,
       lessonPlanBuilt,
       onboardingConfigured,
       promptComposable,
       allCriticalPass,
+      activeCurriculumMode,
     });
   } catch (err) {
     console.error("[setup-status] Error:", err);

--- a/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseCurriculumTab.tsx
@@ -13,6 +13,11 @@
  * The scorecard + regenerate flow are the structural prevention for the
  * incident #137 root cause: the curriculum was invisible, so its rot went
  * unnoticed. Making it visible + fixable from one screen is the fix.
+ *
+ * #418: explicit viewMode toggle + flash fix. The page passes
+ * `activeCurriculumMode` (resolved from setup-status) and we gate the body
+ * on it — so the wrong panel never mounts first on Authored courses. A
+ * segmented toggle lets educators peek at the other view in read-only mode.
  */
 
 import { useState, useEffect, useCallback } from "react";
@@ -36,6 +41,13 @@ interface CourseCurriculumTabProps {
   curriculumId?: string | null;
   isOperator: boolean;
   onSwitchTab?: (tab: string) => void;
+  /**
+   * #418 — the source of truth for which curriculum mode is active.
+   * Resolved by the parent course page via the setup-status endpoint and
+   * passed down. While null we render only a spinner so the wrong panel
+   * never flashes on mount.
+   */
+  activeCurriculumMode: "authored" | "derived" | null;
 }
 
 interface RegenerateResponse {
@@ -57,6 +69,7 @@ export function CourseCurriculumTab({
   curriculumId: curriculumIdProp,
   isOperator,
   onSwitchTab,
+  activeCurriculumMode,
 }: CourseCurriculumTabProps) {
   const [scorecard, setScorecard] = useState<CourseLinkageScorecard | null>(null);
   const [loading, setLoading] = useState(true);
@@ -65,10 +78,16 @@ export function CourseCurriculumTab({
   const [regenerating, setRegenerating] = useState(false);
   const [regenResult, setRegenResult] = useState<RegenerateResponse | null>(null);
 
-  // #253-follow-up: when authored modules are the source of truth, the
-  // derived/regen catalogue is noise — hide it. AuthoredModulesPanel signals
-  // its loaded state so we know which view to render.
-  const [modulesAuthored, setModulesAuthored] = useState<boolean | null>(null);
+  // #418 — explicit toggle between "authored" and "derived" views. Defaults
+  // to whatever the page reports as the active mode; educator can flip to
+  // preview the other view (read-only). Stays null while the parent is
+  // still resolving the mode.
+  const [viewMode, setViewMode] = useState<"authored" | "derived" | null>(null);
+  useEffect(() => {
+    if (activeCurriculumMode && viewMode === null) {
+      setViewMode(activeCurriculumMode);
+    }
+  }, [activeCurriculumMode, viewMode]);
 
   // Authoritative curriculum id comes from the scorecard response. Until that
   // loads, fall back to the hint passed in by the course page.
@@ -174,7 +193,7 @@ export function CourseCurriculumTab({
   }, [curriculumId, loadScorecard]);
 
   // ── Regenerate actions bundle ─────────────────────────────
-  const regenerateActions: RegenerateActions | undefined = isOperator ? {
+  const fullRegenerateActions: RegenerateActions | undefined = isOperator ? {
     onRegenerateModules: handleRegenerate,
     onReconcileTPs: handleReconcileTPs,
     onRegenerateMcqs: handleRegenerateMcqs,
@@ -182,10 +201,28 @@ export function CourseCurriculumTab({
     onReclassifyLos: handleReclassifyLos,
   } : undefined;
 
+  // In preview mode (peeking at the inactive view), expose only the
+  // link-only / idempotent actions — never the destructive regen/extract.
+  const previewRegenerateActions: RegenerateActions | undefined = isOperator ? {
+    onReconcileTPs: handleReconcileTPs,
+    onRegenerateMcqs: handleRegenerateMcqs,
+  } : undefined;
+
   // ── Render ─────────────────────────────────────────────────
-  // Wait for the scorecard fetch before deciding whether a curriculum exists —
-  // the scorecard response is the authoritative source. If the scorecard
-  // returns and curriculumId is still null, surface the empty state.
+  // #418 — gate on activeCurriculumMode before mounting any panel so the
+  // Authored view doesn't flash through Derived on mount. The old guard
+  // (`loading && !scorecard`) returned the spinner only briefly, then
+  // proceeded with `modulesAuthored === null`, which caused the flash.
+  if (activeCurriculumMode === null || viewMode === null) {
+    return (
+      <div className="hf-stack-md">
+        <div className="hf-spinner" />
+      </div>
+    );
+  }
+
+  // While the scorecard fetch is still in flight on a fresh mount, also
+  // show the spinner — the body needs both signals.
   if (loading && !scorecard) {
     return (
       <div className="hf-stack-md">
@@ -194,47 +231,89 @@ export function CourseCurriculumTab({
     );
   }
 
-  if (!curriculumId) {
-    // Authored modules live on Playbook.config and don't depend on a
-    // generated curriculum, so we still surface the panel here. The
-    // "no curriculum" empty state lives below the panel.
+  const isPreview = viewMode !== activeCurriculumMode;
+
+  // ── Header: segmented toggle + preview banner ─────────────
+  const header = (
+    <div className="curriculum-mode-toolbar">
+      <ModeToggle
+        viewMode={viewMode}
+        activeMode={activeCurriculumMode}
+        onChange={(m) => setViewMode(m)}
+      />
+      {isPreview && (
+        <div className="hf-banner hf-banner-info curriculum-mode-preview-banner">
+          <span>
+            Preview only — this is what {viewMode === "derived" ? "AI extraction" : "the Course Reference"} would produce.{" "}
+            <strong>{activeCurriculumMode === "authored" ? "Authored" : "Derived"} modules</strong> are in use for this course.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+
+  // ── Authored panel branch ─────────────────────────────────
+  if (viewMode === "authored") {
+    // Empty-state edge case: if activeMode is "authored" but
+    // PlaybookConfig.modules is empty (declared "Yes" with no valid table),
+    // AuthoredModulesPanel already renders its own empty state — we
+    // intentionally leave that path to the child.
     return (
       <div className="hf-stack-md">
+        {header}
+        {error && <div className="hf-banner hf-banner-error">{error}</div>}
         <AuthoredModulesPanel
           courseId={playbookId ?? courseId}
           isOperator={isOperator}
         />
+        {/* For authored-modules courses: show ONLY the MCQ list (the part
+            educators actually need to see) without the scorecard / regen
+            affordances. Renders standalone via the exported McqPanel.
+            Suppressed in preview mode — the derived view below has its
+            own MCQ panel inside CurriculumHealthTabs. */}
+        {!isPreview && (
+          <section className="hf-card curriculum-mode-mcq-section">
+            <header className="curriculum-mode-mcq-header">
+              <h3 className="hf-section-title curriculum-mode-mcq-title">
+                Generated questions
+              </h3>
+              <span className="hf-text-xs hf-text-muted">
+                MCQs created from your uploaded learner-facing content. Trust badge per row indicates provenance.
+              </span>
+            </header>
+            <McqPanel courseId={courseId} />
+          </section>
+        )}
+        {regenResult && (
+          <RegenerateResult result={regenResult} onSwitchTab={onSwitchTab} />
+        )}
+      </div>
+    );
+  }
+
+  // ── Derived panel branch ──────────────────────────────────
+  // Either Derived is the active mode (full actions) or the user is peeking
+  // at Derived on an Authored course (read-only, subset of actions).
+  return (
+    <div className="hf-stack-md">
+      {header}
+      {error && <div className="hf-banner hf-banner-error">{error}</div>}
+
+      {!curriculumId && (
         <div className="hf-empty">
           <p className="hf-text-sm hf-text-muted">
             No curriculum yet. Upload content on the Content tab to generate one.
           </p>
         </div>
-      </div>
-    );
-  }
+      )}
 
-  // #208: Curriculum exists but has zero modules — surface a recovery CTA
-  // before the rest of the scorecard renders, so educators don't see a
-  // health card with no actionable next step.
-  // Authored-modules courses are excluded: their structure is educator-
-  // authored and "Regenerate curriculum" would clobber it. The
-  // AuthoredModules panel (above) is the right surface for them.
-  const hasZeroModules =
-    !!curriculumId
-    && (scorecard?.structure?.activeModules ?? 0) === 0
-    && modulesAuthored !== true;
-
-  return (
-    <div className="hf-stack-md">
-      {error && <div className="hf-banner hf-banner-error">{error}</div>}
-
-      <AuthoredModulesPanel
-        courseId={playbookId ?? courseId}
-        isOperator={isOperator}
-        onModulesAuthoredChange={setModulesAuthored}
-      />
-
-      {hasZeroModules && (
+      {/* #208: Curriculum exists but has zero modules — surface a recovery CTA
+          before the rest of the scorecard renders, so educators don't see a
+          health card with no actionable next step. Suppressed in preview
+          mode (the CTA would clobber the authored modules). */}
+      {!isPreview
+        && !!curriculumId
+        && (scorecard?.structure?.activeModules ?? 0) === 0 && (
         <div className="hf-banner hf-banner-warning">
           <div>
             <AlertTriangle size={14} />
@@ -255,43 +334,65 @@ export function CourseCurriculumTab({
         </div>
       )}
 
-      {/* Derived/regen view — hidden when authored modules are the source.
-          The scorecard + regenerate affordances are meaningless for authored
-          courses (the educator authored the structure; auto-regen would
-          clobber it). #256 originally hid the entire CurriculumHealthTabs,
-          which inadvertently hid the MCQ list too — educators on authored
-          courses had no path to view their generated questions. */}
-      {scorecard && modulesAuthored !== true && (
+      {scorecard && curriculumId && (
         <CurriculumHealthTabs
           scorecard={scorecard}
           courseId={courseId}
           curriculumId={curriculumId}
           isOperator={isOperator}
-          regenerateActions={regenerateActions}
+          regenerateActions={isPreview ? previewRegenerateActions : fullRegenerateActions}
           regenerating={regenerating}
           onScorecardRefresh={loadScorecard}
+          readOnly={isPreview}
         />
       )}
 
-      {/* For authored-modules courses: show ONLY the MCQ list (the part
-          educators actually need to see) without the scorecard / regen
-          affordances. Renders standalone via the exported McqPanel. */}
-      {modulesAuthored === true && (
-        <section className="hf-card" style={{ marginTop: 16 }}>
-          <header className="hf-flex hf-items-center hf-gap-8" style={{ marginBottom: 12 }}>
-            <h3 className="hf-section-title" style={{ margin: 0 }}>Generated questions</h3>
-            <span className="hf-text-xs hf-text-muted">
-              MCQs created from your uploaded learner-facing content. Trust badge per row indicates provenance.
-            </span>
-          </header>
-          <McqPanel courseId={courseId} />
-        </section>
-      )}
-
-      {/* Regeneration result */}
       {regenResult && (
         <RegenerateResult result={regenResult} onSwitchTab={onSwitchTab} />
       )}
+    </div>
+  );
+}
+
+// ── Mode toggle (#418) ───────────────────────────────────────
+//
+// Segmented control between Authored and Derived. The active mode (the
+// one driving the course at runtime) gets an "Active" tag so peeking at
+// the other mode never reads as a setting change.
+function ModeToggle({
+  viewMode,
+  activeMode,
+  onChange,
+}: {
+  viewMode: "authored" | "derived";
+  activeMode: "authored" | "derived";
+  onChange: (mode: "authored" | "derived") => void;
+}) {
+  return (
+    <div className="curriculum-mode-toggle" role="tablist" aria-label="Curriculum source">
+      {(["authored", "derived"] as const).map((mode) => {
+        const isActive = viewMode === mode;
+        const isRuntime = activeMode === mode;
+        return (
+          <button
+            key={mode}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            className={`curriculum-mode-toggle__btn${isActive ? " curriculum-mode-toggle__btn--selected" : ""}`}
+            onClick={() => onChange(mode)}
+          >
+            <span className="curriculum-mode-toggle__label">
+              {mode === "authored" ? "Authored" : "Derived"}
+            </span>
+            {isRuntime && (
+              <span className="curriculum-mode-toggle__tag" aria-label="active mode">
+                Active
+              </span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/CurriculumHealthTabs.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CurriculumHealthTabs.tsx
@@ -92,6 +92,15 @@ interface Props {
    * re-fetch the scorecard so coverage dots update.
    */
   onScorecardRefresh?: () => void;
+  /**
+   * Issue #418 — when true, suppress the silent auto-reconcile useEffects
+   * (orphans + MCQs). The parent uses this for preview-mode rendering on
+   * authored-modules courses so that opening the Curriculum tab can't
+   * mutate a curriculum that isn't the active source of truth. Manual
+   * reconcile handlers still work — only the on-mount background fires
+   * are gated.
+   */
+  readOnly?: boolean;
 }
 
 // ── Regenerate Dropdown ─────────────────────────────────
@@ -246,6 +255,7 @@ export function CurriculumHealthTabs({
   onRegenerate,
   regenerating,
   onScorecardRefresh,
+  readOnly = false,
 }: Props) {
   const defaultTab = pickDefaultTab(scorecard);
   const [activeTab, setActiveTab] = useState<TabKey>(defaultTab);
@@ -261,6 +271,9 @@ export function CurriculumHealthTabs({
   // already reconciled this curriculum within the 5-minute client window.
   // Fires once per curriculumId per 5 minutes via localStorage.
   useEffect(() => {
+    // #418 — skip in read-only/preview mode so peeking at derived-mode on
+    // an authored-modules course never mutates the curriculum.
+    if (readOnly) return;
     if (!curriculumId || scorecard.structure.outcomesWithoutContent === 0) return;
     const key = `reconcile:${curriculumId}:lastRunAt`;
     const lastRun = Number(localStorage.getItem(key) || "0");
@@ -276,11 +289,13 @@ export function CurriculumHealthTabs({
         }
       })
       .catch(() => {});
-  }, [curriculumId, scorecard.structure.outcomesWithoutContent, onScorecardRefresh]);
+  }, [curriculumId, scorecard.structure.outcomesWithoutContent, onScorecardRefresh, readOnly]);
 
   // #163 Phase 2 — silent background MCQ reconcile. Fires on mount when the
   // course has orphan MCQs and the 5-min client cooldown has expired.
   useEffect(() => {
+    // #418 — same read-only gate as the orphan reconcile above.
+    if (readOnly) return;
     if (!courseId || mcqOrphans === 0) return;
     const key = `reconcile-mcqs:${courseId}:lastRunAt`;
     const lastRun = Number(localStorage.getItem(key) || "0");
@@ -294,7 +309,7 @@ export function CurriculumHealthTabs({
         }
       })
       .catch(() => {});
-  }, [courseId, mcqOrphans, onScorecardRefresh]);
+  }, [courseId, mcqOrphans, onScorecardRefresh, readOnly]);
 
   const handleReconcileMcqs = async () => {
     if (reconcilingMcqs) return;

--- a/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
@@ -75,14 +75,6 @@ interface AuthoredModulesState {
 interface AuthoredModulesPanelProps {
   courseId: string;
   isOperator: boolean;
-  /**
-   * Fires whenever the panel learns the value of `modulesAuthored` from the
-   * server (after fetch / re-import). Used by the parent CurriculumTab to
-   * hide the derived/regen view when authored modules are in play. `null` =
-   * never imported, `false` = explicitly opted out, `true` = authored modules
-   * are the source of truth for this course.
-   */
-  onModulesAuthoredChange?: (value: boolean | null) => void;
 }
 
 const EMPTY_STATE: AuthoredModulesState = {
@@ -102,7 +94,6 @@ const EMPTY_STATE: AuthoredModulesState = {
 export function AuthoredModulesPanel({
   courseId,
   isOperator,
-  onModulesAuthoredChange,
 }: AuthoredModulesPanelProps) {
   const [state, setState] = useState<AuthoredModulesState>(EMPTY_STATE);
   const [loading, setLoading] = useState(true);
@@ -132,13 +123,12 @@ export function AuthoredModulesPanel({
         loAudienceByRef: (data as unknown as { loAudienceByRef?: Record<string, LoAudienceInfo> })
           .loAudienceByRef ?? {},
       });
-      onModulesAuthoredChange?.(data.modulesAuthored);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setLoading(false);
     }
-  }, [courseId, onModulesAuthoredChange]);
+  }, [courseId]);
 
   useEffect(() => {
     load();

--- a/apps/admin/app/x/courses/[courseId]/course-curriculum-tab.css
+++ b/apps/admin/app/x/courses/[courseId]/course-curriculum-tab.css
@@ -9,6 +9,89 @@
   gap: 16px;
 }
 
+/* ═══════════════════════════════════════════════════════
+   #418 — Curriculum mode toolbar (segmented toggle + preview)
+   ═══════════════════════════════════════════════════════ */
+
+.curriculum-mode-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.curriculum-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  padding: 2px;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  align-self: flex-start;
+}
+
+.curriculum-mode-toggle__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.curriculum-mode-toggle__btn:hover {
+  color: var(--text-primary);
+}
+
+.curriculum-mode-toggle__btn--selected {
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 8%, transparent);
+}
+
+.curriculum-mode-toggle__label {
+  letter-spacing: 0.02em;
+}
+
+.curriculum-mode-toggle__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--status-success-text) 14%, transparent);
+  color: var(--status-success-text);
+}
+
+.curriculum-mode-preview-banner {
+  font-size: 12px;
+}
+
+.curriculum-mode-mcq-section {
+  margin-top: 16px;
+}
+
+.curriculum-mode-mcq-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.curriculum-mode-mcq-title {
+  margin: 0;
+}
+
 .curriculum-scorecard {
   display: flex;
   flex-direction: column;

--- a/apps/admin/app/x/courses/[courseId]/course-detail.css
+++ b/apps/admin/app/x/courses/[courseId]/course-detail.css
@@ -613,6 +613,16 @@
   letter-spacing: 0.02em;
   white-space: nowrap;
   border: 1px solid var(--border-default);
+  /* When the pill is a <button> (e.g. CurriculumSourcePill / unset state),
+     normalise out the browser's native button styling so it matches the
+     <span> variants. Spans ignore these declarations harmlessly. */
+  font-family: inherit;
+  cursor: pointer;
+}
+
+/* Non-clickable variants (rendered as <span>) drop the pointer cursor. */
+span.cd-progression-pill {
+  cursor: default;
 }
 
 .cd-progression-pill--learner {
@@ -636,4 +646,13 @@
 
 .cd-progression-pill--unset:hover {
   background: color-mix(in srgb, var(--status-warning-text, var(--accent-primary)) 18%, transparent);
+}
+
+/* Button-as-pill hover for the Curriculum source variants (#418). */
+button.cd-progression-pill--learner:hover {
+  background: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+}
+
+button.cd-progression-pill--ai:hover {
+  background: color-mix(in srgb, var(--text-muted) 14%, transparent);
 }

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -228,6 +228,12 @@ export default function CourseDetailPage() {
     setSetupReadiness(prev => (prev?.completedCount === count && prev?.allComplete === all) ? prev : { completedCount: count, allComplete: all });
   }, []);
 
+  // #418 — which curriculum source is in effect (authored vs derived).
+  // Loaded once from setup-status so the header chip and the curriculum
+  // tab can resolve `activeMode` without a render flash. Null until first
+  // fetch resolves.
+  const [activeCurriculumMode, setActiveCurriculumMode] = useState<"authored" | "derived" | null>(null);
+
   // Settings actions
   const [publishing, setPublishing] = useState(false);
   const [archiving, setArchiving] = useState(false);
@@ -298,6 +304,26 @@ export default function CourseDetailPage() {
       .catch(() => {})
       .finally(() => setSessionFlowLoaded(true));
   }, [courseId, activeTab, sessionFlowLoaded]);
+
+  // ── #418 — resolve active curriculum mode once, eagerly ──
+  // Fetches the same setup-status endpoint as CourseSetupTracker but only
+  // pulls the curriculum-mode flag. Drives the header chip and the
+  // Curriculum tab's initial view, so it must run before the tab mounts to
+  // avoid a flash of the wrong panel.
+  useEffect(() => {
+    if (!courseId) return;
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/setup-status`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data.ok && (data.activeCurriculumMode === "authored" || data.activeCurriculumMode === "derived")) {
+          setActiveCurriculumMode(data.activeCurriculumMode);
+        }
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [courseId]);
 
   // ── Derived Data ─────────────────────────────────────
   const specGroups = useMemo(() => {
@@ -1011,6 +1037,10 @@ export default function CourseDetailPage() {
             <ProgressionModePill
               modulesAuthored={(detail.config as Record<string, unknown> | null | undefined)?.modulesAuthored as boolean | null | undefined}
               onClickWhenUnset={() => router.push(`/x/courses/${detail.id}?tab=curriculum`)}
+            />
+            <CurriculumSourcePill
+              mode={activeCurriculumMode}
+              onClick={() => router.push(`/x/courses/${detail.id}?tab=curriculum`)}
             />
           </div>
           <div className="hf-flex hf-gap-sm hf-items-center">
@@ -1735,6 +1765,41 @@ function ProgressionModePill({
       title="Click to choose how learners progress (AI-led or learner-picks)"
     >
       Mode not set
+    </button>
+  );
+}
+
+// ── Curriculum source pill (#418) ────────────────────────────────────
+//
+// Sits next to ProgressionModePill in the course header. Reads
+// `activeCurriculumMode` from the setup-status endpoint so educators can
+// see at a glance whether modules come from a Course Reference document
+// (Authored) or AI extraction from uploaded content (Derived). Clicking
+// routes to the Curriculum tab — same UX convention as ProgressionModePill.
+//
+// Rendering nothing while `mode` is null keeps the header stable until the
+// fetch resolves (no flash from Derived → Authored on slow networks).
+function CurriculumSourcePill({
+  mode,
+  onClick,
+}: {
+  mode: "authored" | "derived" | null;
+  onClick: () => void;
+}) {
+  if (mode === null) return null;
+  const label = mode === "authored" ? "Curriculum: Authored" : "Curriculum: Derived";
+  const title =
+    mode === "authored"
+      ? "Modules come from a Course Reference document. Click to view the catalogue."
+      : "Modules are derived by AI from your uploaded content. Click to view the curriculum.";
+  return (
+    <button
+      type="button"
+      className={`cd-progression-pill cd-progression-pill--${mode === "authored" ? "learner" : "ai"}`}
+      onClick={onClick}
+      title={title}
+    >
+      {label}
     </button>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -1412,6 +1412,7 @@ export default function CourseDetailPage() {
           playbookId={courseId!}
           curriculumId={sessions?.curriculumId ?? null}
           isOperator={isOperator}
+          activeCurriculumMode={activeCurriculumMode}
           onSwitchTab={(tab) => {
             setActiveTab(tab);
             router.replace(`?tab=${tab}`, { scroll: false });

--- a/apps/admin/components/shared/CourseSetupTracker.tsx
+++ b/apps/admin/components/shared/CourseSetupTracker.tsx
@@ -68,6 +68,7 @@ export function CourseSetupTracker({
           onboardingConfigured: data.onboardingConfigured,
           promptComposable: data.promptComposable,
           allCriticalPass: data.allCriticalPass,
+          activeCurriculumMode: data.activeCurriculumMode,
         });
       }
     } catch (err) {

--- a/apps/admin/hooks/useCourseSetupStatus.ts
+++ b/apps/admin/hooks/useCourseSetupStatus.ts
@@ -70,6 +70,14 @@ export interface SetupStatusInput {
     onboardingConfigured: boolean;
     promptComposable: boolean;
     allCriticalPass: boolean;
+    /**
+     * Issue #418 — which curriculum source is in effect.
+     * "authored" = Course Reference module catalogue drives modules.
+     * "derived"  = AI extraction generates modules from uploaded content.
+     * Optional for backwards compatibility with older callers that
+     * synthesise their own readiness object.
+     */
+    activeCurriculumMode?: "authored" | "derived";
   } | null;
 }
 

--- a/apps/admin/tests/api/setup-status-authored-modules.test.ts
+++ b/apps/admin/tests/api/setup-status-authored-modules.test.ts
@@ -164,6 +164,40 @@ describe("setup-status — authored-modules branch (continuous course)", () => {
   });
 });
 
+describe("setup-status — activeCurriculumMode (issue #418)", () => {
+  it("returns 'authored' when modulesAuthored=true", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(
+      basePlaybook({
+        modulesAuthored: true,
+        moduleSource: "authored",
+        modules: [{ id: "m1" }],
+      }),
+    );
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.activeCurriculumMode).toBe("authored");
+  });
+
+  it("returns 'derived' when modulesAuthored=false (author opted out)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(
+      basePlaybook({ modulesAuthored: false, moduleSource: "derived" }),
+    );
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.activeCurriculumMode).toBe("derived");
+  });
+
+  it("returns 'derived' when modulesAuthored is unset (default behaviour)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(basePlaybook());
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+    expect(body.activeCurriculumMode).toBe("derived");
+  });
+});
+
 describe("setup-status — auth and 404 still behave (regression)", () => {
   it("returns the auth error when requireAuth fails", async () => {
     const errorResponse = NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -5593,7 +5593,7 @@ Returns aggregated setup status for stages 4-6 of the Course Setup Tracker.
 
 **Response** `200`
 ```json
-{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, details }
+{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode, details }
 ```
 
 ---

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -2604,7 +2604,7 @@ Returns aggregated setup status for stages 4-6 of the Course Setup Tracker.
 
 **Response** `200`
 ```json
-{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, details }
+{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode, details }
 ```
 
 ---


### PR DESCRIPTION
Closes #418

## Summary

- New `Curriculum: Authored | Derived` chip in the course header, sibling to `[Active]` and `[Learner picks]` (orthogonal axes).
- Segmented "view" toggle at the top of the Curriculum tab — flip between the Authored Modules panel and the Derived `CurriculumHealthTabs` regardless of which one is active on the course.
- Non-active mode renders in **preview** with a `readOnly` prop that suppresses the two silent auto-reconcile useEffects. The `Reconcile…` dropdown still works but only exposes the link-only actions (`Reconcile TPs`, `Reconcile MCQs`); destructive actions (Regenerate, Reset, Reclassify, Re-extract) are hidden.
- Flash fix: parent now hoists `activeCurriculumMode` from the `/setup-status` endpoint and gates the body on it being resolved — one spinner, no UI swap.

## What changed (4 commits, one concern each)

| Commit | Concern |
|---|---|
| `81924487` | `activeCurriculumMode` field on `/setup-status` + hook type |
| `b583a8a3` | `readOnly?: boolean` prop on `CurriculumHealthTabs` (gates silent useEffects) |
| `497d1262` | `CurriculumSourcePill` in course header |
| `a75a3e6e` | `viewMode` state + initial-render gate (flash fix) + `AuthoredModulesPanel` callback removed |

## Test plan

- [x] 23/23 unit tests pass (`setup-status-authored-modules`, `course-curriculum-tab`, `authored-modules-panel`, `curriculum-health-tabs-readonly`)
- [x] `npx tsc --noEmit` — 0 new TS errors
- [x] `npm run lint` — 0 new lint errors
- [x] Manual: Authored course (IELTS Speaking Practice) shows new chip, no flash, toggle works, preview mode hides destructive actions
- [ ] Manual on a Derived course post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)