### PR TITLE
fix(#420): capture welcomeMessage on chip click + typed custom greeting

### DIFF
--- a/apps/admin/evals/wizard/v5-welcome-message-capture.yaml
+++ b/apps/admin/evals/wizard/v5-welcome-message-capture.yaml
@@ -1,0 +1,138 @@
+description: "Wizard V5 — welcomeMessage capture from chip click + typed text (#420)"
+
+# Run with: npx promptfoo eval -c evals/wizard/v5-welcome-message-capture.yaml --no-cache
+#
+# Tests rule 5e in v5-system-prompt.ts: when the educator either clicks "Use this"
+# on a suggested welcome message OR types their own custom greeting, the AI MUST
+# call update_setup({welcomeMessage: "..."}) to persist it. The chip click does NOT
+# auto-save; only update_setup writes the field.
+
+prompts:
+  - id: v5-welcome-message-capture-prompt
+    label: "V5 — welcomeMessage capture rule 5e"
+    raw: |
+      You are the HumanFirst Studio setup assistant.
+
+      ## How you communicate
+      - **Bold the opening concept of each sentence or bullet.**
+      - NEVER expose internal field names like `welcomeMessage` or `setupData.*`.
+      - NEVER output XML tags in your text responses.
+
+      ## Rules
+
+      1. Call update_setup EVERY time you learn new information.
+
+      5e. **WELCOME MESSAGE CAPTURE (#420).** When you call `suggest_welcome_message`
+          and the educator clicks "Use this" (or any affirmative), you MUST immediately
+          call `update_setup({ fields: { welcomeMessage: "<the exact text you just suggested>" } })`
+          to persist it. The chip click does NOT auto-save the suggestion — only
+          `update_setup` writes the field. Similarly, when the educator TYPES a custom
+          welcome greeting (any sentence that reads like a learner-facing salutation —
+          "Welcome to my IELTS class...", "Hi there, I'm so glad you're here...",
+          "Hello and welcome..."), capture it via
+          `update_setup({ fields: { welcomeMessage: "<their text>" } })` on the SAME turn.
+          If the educator clicks "Skip welcome", call
+          `update_setup({ fields: { welcomeSkipped: true } })`.
+
+      ---
+      Setup state: {{setupState}}
+      Conversation so far: {{conversationContext}}
+      The educator says: {{userMessage}}
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 1500
+      tools:
+        - name: update_setup
+          description: "Save collected setup fields"
+          input_schema:
+            type: object
+            properties:
+              fields:
+                type: object
+                additionalProperties: true
+            required: [fields]
+        - name: show_suggestions
+          description: "Show clickable quick-reply chips"
+          input_schema:
+            type: object
+            properties:
+              question: { type: string }
+              suggestions: { type: array, items: { type: string } }
+            required: [question, suggestions]
+
+tests:
+
+  # ── Test A — chip click "Use this" persists the suggested welcome ──
+
+  - description: "Test A — educator clicks 'Use this' → AI calls update_setup with welcomeMessage = the suggested text"
+    vars:
+      setupState: |
+        courseName: GCSE Biology. subjectDiscipline: Biology. audience: secondary.
+        interactionPattern: socratic. personalityPreset: socratic-mentor.
+        welcomeMessage: (unset)
+      conversationContext: |
+        AI just called suggest_welcome_message and offered:
+        "Welcome to GCSE Biology. I'm your AI tutor — we'll work through cells, genetics,
+        ecology, and evolution together. Ask me anything anytime."
+        Then surfaced chips ["Use this", "Tweak it", "Skip welcome"].
+      userMessage: "Use this"
+    assert:
+      - type: llm-rubric
+        value: |
+          Response calls update_setup with a fields object that includes welcomeMessage.
+          The welcomeMessage value matches (or is substantially the same as) the AI's
+          previously suggested text — i.e. it starts with "Welcome to GCSE Biology" and
+          mentions tutor / topics. Does NOT save a generic default.
+
+  # ── Test B — typed custom welcome captured ──
+
+  - description: "Test B — educator types a custom welcome → AI calls update_setup({welcomeMessage}) on the same turn"
+    vars:
+      setupState: |
+        courseName: IELTS Speaking Practice. subjectDiscipline: ESOL. audience: higher-ed.
+        interactionPattern: socratic. welcomeMessage: (unset)
+      conversationContext: |
+        AI suggested a default welcome and asked educator to confirm or change.
+        Educator clicked "Tweak it" and is now typing their preferred version.
+      userMessage: "Welcome to my IELTS class. I'm here to help you crush Band 7+ in Speaking. Let's get started."
+    assert:
+      - type: llm-rubric
+        value: |
+          Response calls update_setup with a fields object that contains a welcomeMessage
+          field whose value is "Welcome to my IELTS class. I'm here to help you crush
+          Band 7+ in Speaking. Let's get started." (or string-for-string equivalent —
+          the educator's exact text). Does NOT paraphrase, summarise, or replace the
+          educator's wording. Does NOT save welcomeMessage as a generic default.
+
+  # ── Test C — "Skip welcome" chip persists welcomeSkipped ──
+
+  - description: "Test C — educator clicks 'Skip welcome' → AI calls update_setup({welcomeSkipped: true})"
+    vars:
+      setupState: |
+        courseName: ESL Conversation. welcomeMessage: (unset). welcomeSkipped: (unset)
+      conversationContext: |
+        AI suggested a welcome and offered ["Use this", "Tweak it", "Skip welcome"].
+      userMessage: "Skip welcome"
+    assert:
+      - type: llm-rubric
+        value: |
+          Response calls update_setup with fields containing welcomeSkipped: true.
+          Does NOT save a welcomeMessage value (skip means no welcome, not a default).
+
+  # ── Test D — typed greeting WITHOUT explicit "welcome to" still captured ──
+
+  - description: "Test D — educator types a greeting in different phrasing → still captured as welcomeMessage"
+    vars:
+      setupState: |
+        courseName: KS2 SATs Maths. audience: primary. welcomeMessage: (unset)
+      conversationContext: |
+        AI just asked the educator for their preferred welcome greeting.
+      userMessage: "Hi there! I'm so glad you decided to practice maths with me today. We'll have fun with numbers."
+    assert:
+      - type: llm-rubric
+        value: |
+          Response calls update_setup with fields.welcomeMessage = the educator's exact
+          typed greeting (or near-identical string). Recognises the friendly greeting
+          shape ("Hi there! I'm so glad...") as a welcome message and captures it.

--- a/apps/admin/lib/chat/v5-system-prompt.ts
+++ b/apps/admin/lib/chat/v5-system-prompt.ts
@@ -510,6 +510,18 @@ A skipped field is SATISFIED — never ask about it again.
     \`update_setup({ fields: { welcomeGoals: bool, welcomeAboutYou: bool, welcomeKnowledgeCheck: bool, welcomeAiIntro: bool } })\` —
     all four keys, explicit booleans. Never skip this step. Never call \`create_course\` before all
     four welcome keys are explicitly set. See "Welcome flow proposal" section above for format.
+5e. **WELCOME MESSAGE CAPTURE (#420).** When you call \`suggest_welcome_message\` and the educator
+    clicks "Use this" (or any affirmative), you MUST immediately call
+    \`update_setup({ fields: { welcomeMessage: "<the exact text you just suggested>" } })\` to
+    persist it. The chip click does NOT auto-save the suggestion — only \`update_setup\` writes the
+    field. Similarly, when the educator TYPES a custom welcome greeting (any sentence that reads
+    like a learner-facing salutation — "Welcome to my IELTS class...", "Hi there, I'm so glad
+    you're here...", "Hello and welcome..."), capture it via \`update_setup({ fields: { welcomeMessage: "<their text>" } })\`
+    on the SAME turn. Rule 1 covers this in theory but in practice you under-capture
+    \`welcomeMessage\` — make it explicit here. If the educator clicks "Skip welcome", call
+    \`update_setup({ fields: { welcomeSkipped: true } })\` per the Skipping rules above. Phase 5
+    summary's "Welcome:" line reads from \`setupData.welcomeMessage\`; an empty value means the
+    learner will hear a default greeting, which is rarely what the educator intended.
 6. NEVER re-ask something already collected.
 7. For content upload, the user drops files into the Teaching Materials panel on the right.
 8. Entity resolution: the system auto-resolves names against the database.


### PR DESCRIPTION
Closes #420.

## Summary

The wizard's `suggest_welcome_message` flow offered "Use this / Tweak it / Skip welcome" chips, but neither path reliably saved the educator's welcome message to `Playbook.config.welcomeMessage` — it ended up as a generic AI synthesis. Surfaced during #398 end-to-end testing.

## Root cause

Prompt-only. The chip click sent text as a user message, but no rule in `v5-system-prompt.ts` directed the AI to call `update_setup({welcomeMessage: …})` to persist. Rule 1 ("call update_setup EVERY time you learn new information") was too generic — the AI deprioritised the optional field.

## Fix

Add **Rule 5e** to `v5-system-prompt.ts` (immediately after rule 5c — welcome flow toggles). Explicitly directs the AI to:

- Save the suggested text on "Use this" chip click
- Save the educator's typed text when it reads like a learner-facing greeting
- Save `welcomeSkipped: true` on "Skip welcome"

No code changes — the tool, executor, and flush paths already work correctly. The bug was purely AI under-prioritisation.

## Test plan

- [x] Rule 5e added between 5c and rule 6 in `v5-system-prompt.ts`
- [x] New promptfoo eval `evals/wizard/v5-welcome-message-capture.yaml` with 4 cases:
  - A: chip-click "Use this" → AI persists suggested text
  - B: typed custom greeting after "Tweak it" → AI persists exact text
  - C: "Skip welcome" → AI saves `welcomeSkipped: true`
  - D: alternative phrasing ("Hi there!" greeting) → still captured
- [x] 16 existing v5-system-prompt unit tests pass
- [ ] Cloud Build + deploy to DEV after merge
- [ ] Live verification on hf-dev: type custom welcome → check `Playbook.config.welcomeMessage`

## Out of scope

- Welcome flow toggles (`welcomeGoals`/`welcomeAboutYou`/`welcomeKnowledgeCheck`/`welcomeAiIntro`) — those work correctly
- The system-default tutor onboarding script — separate behaviour layer

## Related

- #398 (parent context) — surfaced during the same end-to-end test as PR #419

## Deploy

`/vm-cp` — prompt-only, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)