### PR TITLE
fix(#423): VM branch-health pre-check for /vm-pull, /vm-dev, /vm-cp

### DIFF
--- a/.claude/commands/vm-cp.md
+++ b/.claude/commands/vm-cp.md
@@ -6,6 +6,16 @@ Commit local changes, push to remote, then pull on the hf-dev VM.
 
 **NOTE:** This updates the hf-dev VM only (localhost:3000 via SSH tunnel). It does NOT deploy to Cloud Run environments (dev/test/prod). To deploy to `dev.humanfirstfoundation.com` etc., use `/deploy`.
 
+## 0. Pre-check — local branch health (#423)
+
+Before committing, verify the LOCAL repo's branch isn't in a drifted state — accidentally cherry-picked / rebased / merged commits from elsewhere can get pushed silently.
+
+```bash
+scripts/check-vm-branch.sh allow-ahead
+```
+
+`allow-ahead` permits local-ahead-of-origin (legitimate: we're about to push). The script still aborts on diverged history, detached HEAD, or behind-origin states. Surface its output verbatim and abort `/vm-cp` if non-zero.
+
 ## 1. Check local status
 
 **IMPORTANT — Working directory:** Always run git commands from the repo root (`/Users/paulwander/projects/HF`). Use absolute paths or `cd` explicitly. Relative paths from a wrong cwd cause silent pathspec failures.

--- a/.claude/commands/vm-dev.md
+++ b/.claude/commands/vm-dev.md
@@ -6,6 +6,16 @@ Start the Next.js dev server on the hf-dev GCP VM with an SSH tunnel forwarding 
 
 **Uses a single SSH connection** — kill, start, wait for ready, then keep alive as the tunnel. No second IAP handshake.
 
+## Step 0: Pre-check — local branch health (#423)
+
+Before connecting to the VM, verify the LOCAL repo isn't in a drifted state. Run:
+
+```bash
+scripts/check-vm-branch.sh
+```
+
+If this exits non-zero, abort `/vm-dev` and surface the script's output to the user verbatim. The dev server reads the same branch state from the VM, so drift here usually means you'll be testing stale code (the #423 class of incident).
+
 ## Step 1: Kill stale local tunnels
 
 Kill any existing local SSH tunnels holding port 3000:

--- a/.claude/commands/vm-pull.md
+++ b/.claude/commands/vm-pull.md
@@ -4,6 +4,21 @@ description: Pull latest code on hf-dev VM, optionally restart dev server
 
 Pull the latest code on the hf-dev GCP VM and optionally restart the dev server.
 
+## 0. Pre-check — local branch health (#423)
+
+Before touching the VM, verify the LOCAL repo isn't in a drifted state — local commits not on origin would push stray work to the VM. Run:
+
+```bash
+scripts/check-vm-branch.sh
+```
+
+If this exits non-zero, abort `/vm-pull` and surface the script's output to the user verbatim. Common cases the script catches:
+- Local HEAD has commits not on `origin/{branch}` (a stray cherry-pick / lost rebase)
+- Local is behind origin (need a `git pull --ff-only` first)
+- Detached HEAD
+
+Pass `allow-ahead` to the script only if the user has explicitly indicated they want to push local commits as part of this run (rare for `/vm-pull`).
+
 ## 1. Pull + install (single SSH call)
 
 ```bash

--- a/scripts/check-vm-branch.sh
+++ b/scripts/check-vm-branch.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# check-vm-branch.sh — verify local branch state matches origin before VM operations.
+#
+# Catches the silent drift class of bug (#423): when local HEAD has commits not
+# on origin/{branch} (e.g. accidental cherry-pick, lost rebase, manual reset
+# pointing at a foreign commit), VM operations push/run that drift without
+# warning. Multiple incidents on 2026-05-17 traced to this.
+#
+# Exit codes:
+#   0 — local HEAD matches origin/{branch} exactly (or only legitimately ahead with pushable commits — caller can decide)
+#   1 — local has diverged (commits not on origin) — abort the caller
+#   2 — local is behind origin (uncommon — usually means caller should pull) — abort the caller
+#   3 — detached HEAD or other unrecoverable git state — abort the caller
+#
+# Usage:
+#   scripts/check-vm-branch.sh              # check current branch
+#   scripts/check-vm-branch.sh allow-ahead  # tolerate local-ahead-of-origin (e.g. before a push)
+
+set -u
+
+ALLOW_AHEAD="${1:-strict}"
+
+# Resolve current branch
+BRANCH=$(git symbolic-ref --quiet --short HEAD 2>/dev/null) || {
+  echo "❌ check-vm-branch: detached HEAD or no current branch."
+  echo "   Run 'git checkout <branch>' before any VM operation."
+  exit 3
+}
+
+# Fetch quietly so the comparison is against latest remote tip.
+# Tolerate offline / no-network — fall back to last known state.
+git fetch origin "$BRANCH" --quiet 2>/dev/null || {
+  echo "⚠️  check-vm-branch: could not fetch origin/$BRANCH (network?). Using last known remote state."
+}
+
+UPSTREAM="origin/$BRANCH"
+
+# Confirm the upstream ref exists (the branch may be local-only).
+if ! git rev-parse --verify --quiet "$UPSTREAM" >/dev/null; then
+  echo "❌ check-vm-branch: no remote branch '$UPSTREAM' exists."
+  echo "   Push the branch first ('git push -u origin $BRANCH') or switch to a tracked branch."
+  exit 1
+fi
+
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse "$UPSTREAM")
+BASE=$(git merge-base HEAD "$UPSTREAM")
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  # In sync.
+  exit 0
+fi
+
+if [ "$LOCAL" = "$BASE" ]; then
+  # Local is strictly behind remote — fast-forward needed.
+  echo "❌ check-vm-branch: $BRANCH is BEHIND $UPSTREAM."
+  echo "   Local HEAD:  $(git log --oneline -1 HEAD)"
+  echo "   Remote HEAD: $(git log --oneline -1 "$UPSTREAM")"
+  echo "   Run: git pull --ff-only"
+  exit 2
+fi
+
+if [ "$REMOTE" = "$BASE" ]; then
+  # Local is strictly ahead of remote (has unpushed commits).
+  COUNT=$(git rev-list --count "$UPSTREAM..HEAD")
+  if [ "$ALLOW_AHEAD" = "allow-ahead" ]; then
+    # Caller (e.g. /vm-cp which is about to push) is fine with this.
+    exit 0
+  fi
+  echo "❌ check-vm-branch: $BRANCH has $COUNT unpushed commit(s) not on $UPSTREAM."
+  echo "   Unpushed:"
+  git log --oneline "$UPSTREAM..HEAD" | sed 's/^/     /'
+  echo "   This may be legitimate work-in-progress, OR a stray cherry-pick/rebase that"
+  echo "   silently pulled in commits from elsewhere (the #423 class of incident)."
+  echo "   If intended: re-run with 'allow-ahead', or 'git push' first."
+  echo "   If not:     'git reset --hard $UPSTREAM' to discard the local-only commits."
+  exit 1
+fi
+
+# Both diverged: local AND remote have commits the other lacks.
+LOCAL_AHEAD=$(git rev-list --count "$UPSTREAM..HEAD")
+REMOTE_AHEAD=$(git rev-list --count "HEAD..$UPSTREAM")
+echo "❌ check-vm-branch: $BRANCH has DIVERGED from $UPSTREAM."
+echo "   Local ahead by $LOCAL_AHEAD commit(s), remote ahead by $REMOTE_AHEAD commit(s)."
+echo "   Run 'git log --oneline --graph HEAD $UPSTREAM' to inspect."
+echo "   To accept remote and discard local: 'git reset --hard $UPSTREAM'."
+echo "   To rebase local on top of remote:   'git pull --rebase'."
+exit 1


### PR DESCRIPTION
Closes #423.

## Summary

Adds `scripts/check-vm-branch.sh` — a pre-flight check that catches the silent branch-drift class of bug (three incidents on 2026-05-17, including the #418 chip mystery that took hours to diagnose).

## What changed

- `scripts/check-vm-branch.sh` — exit-coded check (0 = clean, 1 = drift, 2 = behind, 3 = detached HEAD)
- `.claude/commands/vm-pull.md` — adds Step 0 calling the script (strict mode)
- `.claude/commands/vm-dev.md` — adds Step 0 calling the script (strict mode)
- `.claude/commands/vm-cp.md`  — adds Step 0 calling the script (`allow-ahead` — push expected)

## Test plan

Smoke tests covered manually:
- ✅ Clean branch → exit 0
- ✅ Branch with no remote → exit 1 with push-first message
- ✅ Drift case (commits not on origin) → exit 1 with reset-hard suggestion
- ✅ Behind origin → exit 2 with pull --ff-only suggestion
- ✅ Detached HEAD → exit 3 with checkout suggestion
- ✅ Offline (fetch fails) → warns but uses last-known remote state

## Out of scope

- Cloud Run deploy (`/deploy`) — has its own preflight
- Auto-fixing the drift — just detects + reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)