### PR TITLE
feat(#415 #416): FK consistency CI check + memory/canonical-doc updates

### DIFF
--- a/.claude/rules/ai-to-db-guard.md
+++ b/.claude/rules/ai-to-db-guard.md
@@ -24,6 +24,8 @@ Any code path where:
 | Parent-child relationships | FK exists in DB before write |
 | Parameter/key names | Validate against known set from DB |
 | Destructive operations (delete + rebuild) | Wrap in transaction, validate new data before deleting old |
+| Module / LO identity by slug / ref | Use `resolveModuleByLogicalId(curriculumId, slug)` from `lib/curriculum/resolve-module.ts` — never bare `findFirst({where:{slug}})`. Slugs are per-parent unique, not global (#407). |
+| Pipeline FK writes driven by AI output | `Call.curriculumModuleId` and `CallerModuleProgress.moduleId` are written from AI-returned slugs (`learningAssessment.moduleId`). Must scope by `playbookId → curriculumId` before resolving the slug. ESLint rule `hf-curriculum/no-unscoped-slug-lookup` blocks regressions. |
 
 ## Pattern: Validate-then-write
 
@@ -49,6 +51,9 @@ for (const group of validated.groups) {
 | Pipeline `callScore` | Numeric clamping `[0, 1]` | Score overflow |
 | Pipeline `callTarget` | `validateTargets()` guardrail pass | Target value outside safe range |
 | `generate-groups` | `validateGroupType()` whitelist | Invalid group type enum |
+| `lib/curriculum/resolve-module.ts` | `resolveModuleByLogicalId(curriculumId, slug)` — throws when curriculumId is empty | AI-returned slugs from `learningAssessment.moduleId` resolving to a cross-playbook CurriculumModule (#407 Opal/Freya/Tessa). |
+| `eslint-rules/no-unscoped-slug-lookup.mjs` | Custom ESLint rule, error severity | New `prisma.curriculumModule.find*({where:{slug,...}})` without `curriculumId`. Same for `learningObjective` + `ref` + `moduleId`. (#411) |
+| `scripts/check-fk-consistency.ts` (CI step 5) | SQL queries for cross-playbook leaks | Bad data reaching dev/staging from a slipped-through code path (#415). |
 
 ## Known Gaps (tech debt)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ All commands run from `apps/admin/` unless noted.
 ### Health & Status
 ```bash
 npm run ctl ok           # Quick health check (git, types, MCP, server)
-npm run ctl check        # Full checks (lint + types + tests + integration)
+npm run ctl check        # Full checks: lint → tsc → unit → integration → FK consistency (slug-scope #407 / #415)
 npm run ctl dev:status   # Dev server status
 ```
 

--- a/apps/admin/cli/control.ts
+++ b/apps/admin/cli/control.ts
@@ -548,24 +548,27 @@ program
 
 program
   .command('check')
-  .description('Run all checks (lint + type check + tests)')
+  .description('Run all checks (lint + type check + tests + FK consistency)')
   .action(async () => {
     log('\n🔍 Running All Checks\n', colors.bright);
 
-    info('1/4: Linting...');
+    info('1/5: Linting...');
     exec('npm run lint');
 
-    info('2/4: Type checking...');
+    info('2/5: Type checking...');
     exec('npx tsc --noEmit');
 
-    info('3/4: Unit tests...');
+    info('3/5: Unit tests...');
     exec('npm run test');
 
-    info('4/4: Integration tests...');
+    info('4/5: Integration tests...');
     await runTestsWithServer(
       'npm run test:integration',
       'Running integration tests...'
     );
+
+    info('5/5: FK consistency (slug-scope #407 guard)...');
+    exec('npx tsx scripts/check-fk-consistency.ts');
 
     success('All checks passed!');
   });

--- a/apps/admin/scripts/check-fk-consistency.ts
+++ b/apps/admin/scripts/check-fk-consistency.ts
@@ -1,0 +1,157 @@
+/**
+ * #415 — FK consistency check.
+ *
+ * SQL-level guard for the cross-playbook FK-leak class of bug (#407).
+ * Runs three queries against the configured database and exits non-zero
+ * when any row leaks. Used as part of `npm run ctl check` so CI fails
+ * before bad data reaches staging.
+ *
+ * Idempotent + read-only. If the database is unreachable, exits 0 with
+ * a warning so unrelated CI steps aren't blocked.
+ *
+ * Exit codes:
+ *   0  — all queries returned 0 rows OR database unreachable (warning)
+ *   1  — at least one query returned rows; report printed to stdout
+ */
+
+import { prisma } from "@/lib/prisma";
+
+interface CheckRow {
+  id: string;
+  detail?: Record<string, unknown>;
+}
+
+interface CheckResult {
+  name: string;
+  description: string;
+  rows: CheckRow[];
+}
+
+async function runChecks(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  // Query 1 — cross-playbook CallerModuleProgress.
+  // Detects a CallerModuleProgress row pointing at a module whose curriculum
+  // belongs to a different playbook than the caller's active enrolment.
+  const cmpLeaks = await prisma.$queryRaw<
+    Array<{ id: string; callerId: string; moduleId: string; cur_playbookId: string | null; cp_playbookId: string | null }>
+  >`
+    SELECT cmp."id", cmp."callerId", cmp."moduleId",
+           cur."playbookId" AS cur_playbookId, cp."playbookId" AS cp_playbookId
+    FROM "CallerModuleProgress" cmp
+    JOIN "CurriculumModule" cm ON cm.id = cmp."moduleId"
+    JOIN "Curriculum" cur ON cur.id = cm."curriculumId"
+    LEFT JOIN "CallerPlaybook" cp ON cp."callerId" = cmp."callerId" AND cp.status = 'ACTIVE'
+    WHERE cur."playbookId" IS DISTINCT FROM cp."playbookId"
+  `;
+  results.push({
+    name: "cross-playbook-caller-module-progress",
+    description:
+      "CallerModuleProgress.moduleId points at a CurriculumModule whose curriculum.playbookId differs from the caller's active CallerPlaybook.playbookId.",
+    rows: cmpLeaks.map((r) => ({
+      id: r.id,
+      detail: {
+        callerId: r.callerId,
+        moduleId: r.moduleId,
+        moduleOwnerPlaybook: r.cur_playbookId,
+        callerEnrolledPlaybook: r.cp_playbookId,
+      },
+    })),
+  });
+
+  // Query 2 — cross-playbook Call.curriculumModuleId.
+  const callLeaks = await prisma.$queryRaw<
+    Array<{ id: string; callerId: string; curriculumModuleId: string; cur_playbookId: string; cp_playbookId: string }>
+  >`
+    SELECT c."id", c."callerId", c."curriculumModuleId",
+           cur."playbookId" AS cur_playbookId, cp."playbookId" AS cp_playbookId
+    FROM "Call" c
+    JOIN "CurriculumModule" cm ON cm.id = c."curriculumModuleId"
+    JOIN "Curriculum" cur ON cur.id = cm."curriculumId"
+    JOIN "CallerPlaybook" cp ON cp."callerId" = c."callerId" AND cp.status = 'ACTIVE'
+    WHERE cur."playbookId" IS DISTINCT FROM cp."playbookId"
+  `;
+  results.push({
+    name: "cross-playbook-call-curriculum-module-id",
+    description:
+      "Call.curriculumModuleId points at a module whose curriculum belongs to a different playbook than the caller's active enrolment.",
+    rows: callLeaks.map((r) => ({
+      id: r.id,
+      detail: {
+        callerId: r.callerId,
+        curriculumModuleId: r.curriculumModuleId,
+        moduleOwnerPlaybook: r.cur_playbookId,
+        callerEnrolledPlaybook: r.cp_playbookId,
+      },
+    })),
+  });
+
+  // Query 3 — orphaned CallerModuleProgress (moduleId not in any CurriculumModule).
+  // Should be impossible via FK but added as a belt-and-braces invariant — if
+  // someone disables the FK or runs a TRUNCATE the rule still catches it.
+  const orphans = await prisma.$queryRaw<Array<{ id: string }>>`
+    SELECT cmp."id" FROM "CallerModuleProgress" cmp
+    LEFT JOIN "CurriculumModule" cm ON cm.id = cmp."moduleId"
+    WHERE cm.id IS NULL
+  `;
+  results.push({
+    name: "orphaned-caller-module-progress",
+    description: "CallerModuleProgress.moduleId references a CurriculumModule that no longer exists.",
+    rows: orphans.map((r) => ({ id: r.id })),
+  });
+
+  return results;
+}
+
+function printReport(results: CheckResult[]): boolean {
+  let anyLeaks = false;
+  console.log("\n=== #415 FK consistency check (slug-scope epic #407) ===\n");
+  for (const r of results) {
+    if (r.rows.length === 0) {
+      console.log(`  ✓ ${r.name} — 0 rows`);
+      continue;
+    }
+    anyLeaks = true;
+    console.log(`  ✗ ${r.name} — ${r.rows.length} row(s) leak`);
+    console.log(`    ${r.description}`);
+    for (const row of r.rows.slice(0, 10)) {
+      console.log(`      • id=${row.id}${row.detail ? ` ${JSON.stringify(row.detail)}` : ""}`);
+    }
+    if (r.rows.length > 10) {
+      console.log(`      … (+${r.rows.length - 10} more)`);
+    }
+  }
+  console.log("");
+  return anyLeaks;
+}
+
+async function main() {
+  let results: CheckResult[];
+  try {
+    results = await runChecks();
+  } catch (err: any) {
+    // Database unreachable (no DATABASE_URL, network blocked, etc). Don't
+    // fail unrelated CI steps; emit a warning and exit 0.
+    console.warn(
+      `[check-fk-consistency] WARNING: database unreachable (${err?.message ?? String(err)}). Skipping checks.`,
+    );
+    await prisma.$disconnect().catch(() => undefined);
+    process.exit(0);
+  }
+
+  const anyLeaks = printReport(results);
+  await prisma.$disconnect();
+
+  if (anyLeaks) {
+    console.error(
+      "[check-fk-consistency] FAILED — see report above. See epic #407 for context on the slug-scope bug class.",
+    );
+    process.exit(1);
+  }
+  console.log("[check-fk-consistency] All checks passed.");
+}
+
+main().catch((err) => {
+  console.error("[check-fk-consistency] uncaught error:", err);
+  process.exit(1);
+});

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -114,11 +114,13 @@ No runtime error in any of these cases. The only sentry is reviewer discipline.
 ### 4.2 Cross-stage data flow
 
 ```
-EXTRACT      writes: CallScore (MEASURE specs), CallerMemory (LEARN specs)
+EXTRACT      writes: CallScore (MEASURE specs), CallerMemory (LEARN specs),
+                     Call.curriculumModuleId, CallerModuleProgress (post-analysis branch, #409)
 SCORE_AGENT  writes: BehaviorMeasurement (MEASURE_AGENT specs)
 AGGREGATE    reads:  CallScore
              writes: PersonalityObservation, CallerPersonality,
-                     CallerPersonalityProfile, LearnerProfile
+                     CallerPersonalityProfile, LearnerProfile,
+                     CallerTarget.currentScore + lastScoredAt (skill_* params, #417 SKILL-AGG-001)
 REWARD       reads:  BehaviorMeasurement, BehaviorTarget
              writes: RewardScore
 ADAPT        reads:  CallerPersonalityProfile, transcript, Goal
@@ -128,6 +130,22 @@ SUPERVISE    reads:  CallTarget, CallerTarget
 COMPOSE      reads:  CallerMemory, CallerPersonalityProfile, Goal, CallerTarget
              writes: ComposedPrompt
 ```
+
+**#417 cross-stage AGGREGATE write — note for reviewers.** SKILL-AGG-001
+(SYSTEM-scope AGGREGATE spec) uses a new `AggregationRule.method =
+"ema_to_caller_target"` that writes `CallerTarget.currentScore` +
+`lastScoredAt` for any CallScore on a parameter matching the rule's
+`sourceParameterPattern` (defaults to `skill_*`). Idempotency guard:
+each CallScore is applied only when `CallScore.createdAt >
+CallerTarget.lastScoredAt`, defending against #405 force=true re-runs.
+
+**#409 EXTRACT FK writes — must use scoped resolver.** Both
+`Call.curriculumModuleId` and `CallerModuleProgress.moduleId` are
+written from AI-returned slugs (e.g. `learningAssessment.moduleId =
+"part1"`). All writes go through `lib/curriculum/resolve-module.ts::
+resolveModuleByLogicalId(curriculumId, slug)` — the helper throws on
+empty curriculumId. ESLint rule `hf-curriculum/no-unscoped-slug-lookup`
+(error severity) blocks regressions.
 
 Use this as the dependency map when adding a new write. If your new stage produces a row, the next stage that reads it must be downstream in `order`.
 


### PR DESCRIPTION
## Summary

Closes the #407 slug-scope epic with the CI guard + documentation layer.

### #415 — CI consistency check
- New \`apps/admin/scripts/check-fk-consistency.ts\` runs 3 SQL queries:
  1. Cross-playbook \`CallerModuleProgress\` (CMP.moduleId → module belongs to a different playbook than caller's enrolment)
  2. Cross-playbook \`Call.curriculumModuleId\` (same shape)
  3. Orphaned CallerModuleProgress (moduleId doesn't FK to any CurriculumModule)
- Exits 1 if any leak; prints actionable report; exits 0 with warning if DB unreachable (won't break unrelated CI)
- Wired as step 5 of \`npm run ctl check\` after lint, tsc, unit, integration
- \`CLAUDE.md\` Health & Status section updated

### #416 — Memory + canonical-doc updates
- \`memory/entities.md\`: new "Slug-scope invariants" section listing every slug-bearing entity, its required parent scope, the schema constraint (if any), and which guard covers it
- \`memory/ai-to-db-fk-writes.md\` (new): full inventory of every AI/wizard → DB FK write boundary in the runtime + setup paths. For each: driving signal, guard, pre-#407 gap
- \`memory/flow-pipeline.md\`: AGGREGATE writes now document \`CallerTarget.currentScore\` (SKILL-AGG-001 #417); EXTRACT writes \`Call.curriculumModuleId\` + \`CallerModuleProgress\` via the scoped resolver. ESLint rule referenced
- \`memory/MEMORY.md\`: index pointer to \`ai-to-db-fk-writes.md\`
- \`.claude/rules/ai-to-db-guard.md\`: two new "Required Checks" rows (module/LO slug-by-ref, pipeline FK writes from AI); three new "Existing Guards" rows (resolver, ESLint rule, CI consistency)
- \`docs/PIPELINE.md §4.2\`: cross-stage data flow updated to include the new AGGREGATE → CallerTarget write and the EXTRACT FK writes via \`resolveModuleByLogicalId\`

## Why

Mechanical + documentary closure of the slug-scope class. The CI check is what should have existed since #397 — it would have caught the Opal corruption immediately.

## Part of epic #407 — LAST in the chain.

PR sequence: #409 → #408 → #412 → #411 → #413 → #414 → #417 → **#415/#416**.

Closes #415 and #416.

## Test plan
- [x] CI check runs against dev DB — all 3 queries return 0 rows (✓)
- [x] CI check exits 0 with warning when DATABASE_URL is unset (won't break PR CI on machines without DB access)
- [x] \`npm run ctl check\` runs step 5 successfully
- [x] Memory + docs render correctly in their canonical paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)