### PR TITLE
feat(#428): shared response types pilot — setup-status route + hook

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import type { SetupStatusResponse, SetupStatusErrorResponse } from "./types";
 
 /**
  * @api GET /api/courses/:courseId/setup-status
@@ -128,22 +129,27 @@ export async function GET(
     // Derived = AI extraction generates modules from uploaded content.
     // null/false `modulesAuthored` is treated as derived (matches the
     // existing behaviour in `CourseCurriculumTab` and the wizard default).
-    const activeCurriculumMode: "authored" | "derived" =
+    const activeCurriculumMode: SetupStatusResponse["activeCurriculumMode"] =
       pbConfig.modulesAuthored === true ? "authored" : "derived";
 
-    return NextResponse.json({
+    // Build the payload as a typed constant first so a missing/extra/renamed
+    // field becomes a tsc error here — not a silent runtime drift the way
+    // #418 silently shipped a broken chip. Pattern proposed in #428.
+    const payload: SetupStatusResponse = {
       ok: true,
       lessonPlanBuilt,
       onboardingConfigured,
       promptComposable,
       allCriticalPass,
       activeCurriculumMode,
-    });
+    };
+    return NextResponse.json(payload);
   } catch (err) {
     console.error("[setup-status] Error:", err);
-    return NextResponse.json(
-      { ok: false, error: "Failed to check setup status" },
-      { status: 500 },
-    );
+    const errorPayload: SetupStatusErrorResponse = {
+      ok: false,
+      error: "Failed to check setup status",
+    };
+    return NextResponse.json(errorPayload, { status: 500 });
   }
 }

--- a/apps/admin/app/api/courses/[courseId]/setup-status/types.ts
+++ b/apps/admin/app/api/courses/[courseId]/setup-status/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Single-source-of-truth response type for GET /api/courses/[courseId]/setup-status.
+ *
+ * Shared between the route handler (its `NextResponse.json` payload conforms
+ * to this) and the consumer hook (`useCourseSetupStatus`'s `readiness` input
+ * extends this). Drift between server and client becomes a TypeScript error
+ * instead of a silent runtime mystery.
+ *
+ * Pattern proposed in #428 (#418 silently shipped a broken chip when the route
+ * stopped returning `activeCurriculumMode`; the hook still expected it; no
+ * compile-time check caught the drift). Pilot for a codebase-wide sweep.
+ */
+
+export type ActiveCurriculumMode = "authored" | "derived";
+
+export interface SetupStatusResponse {
+  ok: true;
+  lessonPlanBuilt: boolean;
+  onboardingConfigured: boolean;
+  promptComposable: boolean;
+  allCriticalPass: boolean;
+  /**
+   * Issue #418 — which curriculum source is in effect.
+   * - "authored" = Course Reference module catalogue drives modules
+   * - "derived"  = AI extraction generates modules from uploaded content
+   *
+   * Drives the `CurriculumSourcePill` in the course header and the
+   * `ModeToggle` in the Curriculum tab.
+   */
+  activeCurriculumMode: ActiveCurriculumMode;
+}
+
+/** 4xx/5xx error path — separate type so the success contract stays tight. */
+export interface SetupStatusErrorResponse {
+  ok: false;
+  error: string;
+}

--- a/apps/admin/hooks/useCourseSetupStatus.ts
+++ b/apps/admin/hooks/useCourseSetupStatus.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import type { SourceStatusData } from '@/components/shared/SourceStatusDots';
+import type { SetupStatusResponse } from '@/app/api/courses/[courseId]/setup-status/types';
 
 // ── Types ──────────────────────────────────────────────
 
@@ -64,21 +65,16 @@ export interface SetupStatusInput {
     } | null;
   } | null;
 
-  /** Readiness data from /api/courses/:id/setup-status or inline */
-  readiness: {
-    lessonPlanBuilt?: boolean;
-    onboardingConfigured: boolean;
-    promptComposable: boolean;
-    allCriticalPass: boolean;
-    /**
-     * Issue #418 — which curriculum source is in effect.
-     * "authored" = Course Reference module catalogue drives modules.
-     * "derived"  = AI extraction generates modules from uploaded content.
-     * Optional for backwards compatibility with older callers that
-     * synthesise their own readiness object.
-     */
-    activeCurriculumMode?: "authored" | "derived";
-  } | null;
+  /**
+   * Readiness data from /api/courses/:id/setup-status or synthesised inline.
+   *
+   * #428 — sourced from the route's exported `SetupStatusResponse` type
+   * (without the `ok` discriminator, since callers that synthesise readiness
+   * inline don't include it). Fields stay optional here because legacy callers
+   * may pass partial objects; the shared type guarantees field NAMES/TYPES
+   * match the server but doesn't force the consumer to handle every field.
+   */
+  readiness: Partial<Omit<SetupStatusResponse, "ok">> | null;
 }
 
 // ── Hook ──────────────────────────────────────────────

--- a/docs/decisions/2026-05-17-shared-route-types.md
+++ b/docs/decisions/2026-05-17-shared-route-types.md
@@ -1,0 +1,98 @@
+# Shared TypeScript types between API routes and their consumers
+
+**Date**: 2026-05-17
+**Status**: Pilot (Phase 1) — see #428 for sweep plan
+**Context**: Issue #428, prior incidents #418 / #420 / #424
+
+## Decision
+
+Every API route under `apps/admin/app/api/**/route.ts` exports its success-path
+response shape as a TypeScript interface in a **colocated `types.ts`** file.
+Both the route handler AND every client-side consumer (hook, component) import
+this single source of truth.
+
+```
+apps/admin/app/api/courses/[courseId]/setup-status/
+├── route.ts       ← imports + returns the typed shape
+└── types.ts       ← single source of truth for the response
+
+apps/admin/hooks/
+└── useCourseSetupStatus.ts   ← imports the same type from the route folder
+```
+
+## Why
+
+#418 shipped a "Curriculum: Authored / Derived" chip that silently never
+rendered for ~6 hours in production. The client-side hook read
+`activeCurriculumMode` from `/api/courses/[courseId]/setup-status` but the
+route had stopped returning the field. **There was no compile-time link
+between the two**, so the drift was invisible until manually reported.
+
+- The `@api @response` JSDoc was the only spec — drifted from reality
+- #424 / PR #426 added a *runtime* test that catches this at test time
+- This ADR adds a **compile-time** check: drift → tsc error → PR fails CI
+  before it can merge
+
+The runtime test stays as belt-and-braces.
+
+## Pattern (route side)
+
+```ts
+// app/api/courses/[courseId]/setup-status/types.ts
+export interface SetupStatusResponse {
+  ok: true;
+  lessonPlanBuilt: boolean;
+  // ...
+  activeCurriculumMode: "authored" | "derived";
+}
+
+// app/api/courses/[courseId]/setup-status/route.ts
+import type { SetupStatusResponse, SetupStatusErrorResponse } from "./types";
+
+// Build payload as typed const FIRST, then pass to NextResponse.json.
+// `NextResponse.json` itself accepts unknown — the typed const is what
+// pins the shape. Missing/extra/renamed fields become tsc errors here.
+const payload: SetupStatusResponse = { ok: true, /* ... */ };
+return NextResponse.json(payload);
+```
+
+## Pattern (consumer side)
+
+```ts
+// hooks/useCourseSetupStatus.ts
+import type { SetupStatusResponse } from "@/app/api/courses/[courseId]/setup-status/types";
+
+// Use Partial/Omit/Pick to express subset relationships when needed.
+// Here: callers can synthesise inline readiness (no `ok` field) and may
+// pass partial shapes (legacy migration), so we use:
+readiness: Partial<Omit<SetupStatusResponse, "ok">> | null;
+```
+
+When the route adds/removes/renames a field, the hook's import breaks at
+compile time. No more silent runtime drift.
+
+## Negative test (proves the discipline)
+
+After the pilot landed, a deliberate mutation was tested:
+
+1. Rename `activeCurriculumMode` → `currentMode` in `types.ts`
+2. `npx tsc --noEmit` fails:
+   - In `route.ts`: property doesn't exist on `SetupStatusResponse`
+   - In `useCourseSetupStatus.ts`: the inline `readiness?.activeCurriculumMode` reads disappear from autocomplete
+   - In `CurriculumSourcePill` / `ModeToggle`: their reads fail
+
+This is exactly the early-fail behaviour #418 was missing.
+
+## Out of scope (this pilot)
+
+- Phase 2 sweep across every API route — separate follow-up issues per `/api` subtree
+- Phase 3 enforcement (ESLint rule that every `route.ts` has a colocated `types.ts`)
+- Removing `@api @response` JSDoc — that stays as human-readable docs
+- Auto-generating types from OpenAPI / route handler return type — heavier change
+
+## Related
+
+- #418 — silently-shipped broken chip (root incident)
+- #424 / PR #426 — runtime contract test (catches same drift at test time)
+- #423 / PR #425 — VM branch-health (catches the WHERE-is-code variant)
+- #428 — Phase 1 pilot tracking issue (this ADR's primary reference)


### PR DESCRIPTION
Refs #428 (Phase 1 of 3).

## Summary

Pilots a colocated `types.ts` file alongside each API route. The route handler and every client consumer (hook, component) import the same type. Drift between server and client becomes a `tsc` error.

Pattern proven on `GET /api/courses/[courseId]/setup-status` + `useCourseSetupStatus`. Once reviewed + merged, Phase 2 sweep follows per `/api` subtree.

## Why

#418 silently shipped a broken chip because the route stopped returning a field the hook still read. No compile-time check caught it. #424 / PR #426 added a runtime contract test for this class of bug; this PR adds the *compile-time* layer (defence in depth).

## Pattern

- `app/api/courses/[courseId]/setup-status/types.ts` — new file, exports `SetupStatusResponse` + `SetupStatusErrorResponse`
- `route.ts` — builds payload as a typed `const` before passing to `NextResponse.json`; missing/renamed fields fail `tsc` at the route
- `useCourseSetupStatus.ts` — reads `Partial<Omit<SetupStatusResponse, "ok">>` from the same type module; tsc fails if the route drops a field the hook needs
- `docs/decisions/2026-05-17-shared-route-types.md` — ADR

## Test plan

- [x] `tsc --noEmit` passes locally
- [x] Negative test: rename `activeCurriculumMode` in types.ts → tsc fails in both route.ts AND useCourseSetupStatus.ts (exactly the early-fail behaviour #418 was missing)
- [x] No runtime behaviour change — pilot is types-only

## Out of scope

- Phase 2 sweep across every API route — separate follow-up issues per `/api` subtree (tracked in #428)
- Phase 3 ESLint rule enforcing colocated `types.ts` — separate issue
- Removing `@api @response` JSDoc — stays as human-readable docs

## Related

- #418 — root incident (silently broken chip)
- #424 / PR #426 — runtime contract test (catches same drift at test time)
- #423 / PR #425 — VM branch-health (catches WHERE-is-code variant)

## Deploy

`/vm-cp` — types-only, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)