### PR TITLE
feat: SKILL-NN ACHIEVE goals — measurement-status affordance, not noise

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/route.ts
@@ -502,11 +502,88 @@ export async function GET(
     const signalByGoalId = new Map(
       pendingSignals.map((s: any) => [s.key.replace("goal_completion_signal:", ""), s])
     );
+
+    // #417 follow-up — measurementStatus for SKILL-NN ACHIEVE goals.
+    // Three states:
+    //   "measured"          — BehaviorTarget exists AND caller has currentScore evidence
+    //   "awaiting_evidence" — BehaviorTarget exists but no CallerTarget.currentScore yet
+    //   "not_configured"    — Goal ref is SKILL-NN but no BehaviorTarget with that
+    //                         skillRef exists in this playbook (legacy course that
+    //                         hasn't been wizard-projected). Caller sees a
+    //                         "Re-project to enable skill scoring" affordance
+    //                         instead of a misleading engagement-heuristic value.
+    type MeasurementStatus = "measured" | "awaiting_evidence" | "not_configured";
+    const skillGoals = goals.filter(
+      (g: any) =>
+        g.type === "ACHIEVE" &&
+        typeof g.ref === "string" &&
+        g.ref.startsWith("SKILL-") &&
+        g.playbookId,
+    );
+    const measurementByGoalId = new Map<string, MeasurementStatus>();
+    if (skillGoals.length > 0) {
+      // Group by (playbookId, ref) — one BehaviorTarget lookup per pair.
+      const byPlaybook = new Map<string, Set<string>>();
+      for (const g of skillGoals) {
+        const set = byPlaybook.get(g.playbookId) ?? new Set<string>();
+        set.add(g.ref as string);
+        byPlaybook.set(g.playbookId, set);
+      }
+      // Resolve skillRef → parameterId per playbook.
+      const refToParam = new Map<string, string>(); // key = `${playbookId}::${ref}`
+      for (const [playbookId, refs] of byPlaybook) {
+        const bts = await prisma.behaviorTarget.findMany({
+          where: {
+            playbookId,
+            skillRef: { in: Array.from(refs) },
+            effectiveUntil: null,
+          },
+          select: { skillRef: true, parameterId: true },
+        });
+        for (const bt of bts) {
+          if (bt.skillRef) refToParam.set(`${playbookId}::${bt.skillRef}`, bt.parameterId);
+        }
+      }
+      // Pull CallerTarget for every resolved param.
+      const paramIds = Array.from(new Set(Array.from(refToParam.values())));
+      const cts = paramIds.length > 0
+        ? await prisma.callerTarget.findMany({
+            where: { callerId, parameterId: { in: paramIds } },
+            select: { parameterId: true, currentScore: true, callsUsed: true },
+          })
+        : [];
+      const measuredParams = new Set(
+        cts
+          .filter((ct) => ct.currentScore !== null && (ct.callsUsed ?? 0) > 0)
+          .map((ct) => ct.parameterId),
+      );
+      for (const g of skillGoals) {
+        const paramId = refToParam.get(`${g.playbookId}::${g.ref}`);
+        if (!paramId) {
+          measurementByGoalId.set(g.id, "not_configured");
+        } else if (measuredParams.has(paramId)) {
+          measurementByGoalId.set(g.id, "measured");
+        } else {
+          measurementByGoalId.set(g.id, "awaiting_evidence");
+        }
+      }
+    }
+
     const goalsWithSignals = goals.map((g: any) => {
       const signal = signalByGoalId.get(g.id);
-      return signal
-        ? { ...g, pendingSignal: { id: signal.id, evidence: signal.stringValue, createdAt: signal.createdAt } }
-        : g;
+      const measurementStatus = measurementByGoalId.get(g.id);
+      const enriched: any = { ...g };
+      if (signal) {
+        enriched.pendingSignal = {
+          id: signal.id,
+          evidence: signal.stringValue,
+          createdAt: signal.createdAt,
+        };
+      }
+      if (measurementStatus) {
+        enriched.measurementStatus = measurementStatus;
+      }
+      return enriched;
     });
 
     return NextResponse.json({

--- a/apps/admin/components/callers/caller-detail/ProgressTab.tsx
+++ b/apps/admin/components/callers/caller-detail/ProgressTab.tsx
@@ -400,6 +400,48 @@ function ProgressRing({ progress, size = 64, strokeWidth = 5, color }: { progres
   );
 }
 
+/**
+ * #417 follow-up — affordance shown in place of the misleading raw-progress
+ * value when a SKILL-NN ACHIEVE goal has no real measurement evidence yet.
+ *
+ * Two states:
+ *  - "awaiting_evidence": BehaviorTarget exists, just no scores accumulated
+ *  - "not_configured":   playbook has no BehaviorTarget for this skillRef
+ *                        (legacy course pre-#417 — re-project to enable)
+ *
+ * Copy is educator-facing: tells them WHY the value is blank and WHAT to do.
+ */
+function SkillMeasurementAffordance({
+  status,
+  ref,
+}: {
+  status: "awaiting_evidence" | "not_configured";
+  ref: string;
+}) {
+  if (status === "awaiting_evidence") {
+    return (
+      <div className="hf-banner hf-banner-info hf-mt-xs">
+        <div className="hf-text-xs">
+          <strong>Awaiting first call evidence</strong> — this skill ({ref}) is
+          part of the course&apos;s framework but the learner hasn&apos;t been
+          scored on it yet. Progress will populate after their next call.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="hf-banner hf-banner-warning hf-mt-xs">
+      <div className="hf-text-xs">
+        <strong>Skill scoring not configured</strong> — this goal references{" "}
+        {ref} but the course has no skills framework wired in. The previous
+        progress value reflected transcript keywords, not actual skill
+        measurement. <strong>Re-project the course through the wizard</strong>{" "}
+        with a Skills Framework section to enable per-call per-skill scoring.
+      </div>
+    </div>
+  );
+}
+
 // =====================================================
 // AssessmentTargetsCard
 // =====================================================
@@ -441,19 +483,31 @@ export function AssessmentTargetsCard({ goals, callerId }: { goals: Goal[]; call
           const isNearReady = goal.progress >= threshold * 0.85;
           const isCompleted = goal.status === "COMPLETED";
           const hasPending = !!goal.pendingSignal;
+          // #417 follow-up — SKILL-NN goals carry a measurementStatus so the
+          // UI can distinguish "real per-skill score" from "engagement-heuristic
+          // noise" for legacy / not-yet-projected courses.
+          const isSkillGoal = typeof goal.ref === "string" && goal.ref.startsWith("SKILL-");
+          const skillStatus = goal.measurementStatus;
+          const isUnmeasured = isSkillGoal && skillStatus && skillStatus !== "measured";
 
-          const progressColor = isCompleted
-            ? "var(--status-success-text)"
-            : isNearReady
-              ? "var(--accent-primary)"
-              : goal.progress < 0.3
-                ? "var(--status-error-text)"
-                : "var(--status-warning-text)";
+          const progressColor = isUnmeasured
+            ? "var(--text-muted)"
+            : isCompleted
+              ? "var(--status-success-text)"
+              : isNearReady
+                ? "var(--accent-primary)"
+                : goal.progress < 0.3
+                  ? "var(--status-error-text)"
+                  : "var(--status-warning-text)";
 
           return (
             <div key={goal.id} className="hf-card-compact">
               <div className="hf-flex hf-gap-lg">
-                <ProgressRing progress={goal.progress} size={64} color={progressColor} />
+                <ProgressRing
+                  progress={isUnmeasured ? 0 : goal.progress}
+                  size={64}
+                  color={progressColor}
+                />
                 <div className="hf-flex-1">
                   <div className="hf-flex hf-gap-sm hf-mb-xs hf-items-center">
                     <span className="hf-section-title">{goal.name}</span>
@@ -464,12 +518,18 @@ export function AssessmentTargetsCard({ goals, callerId }: { goals: Goal[]; call
                   {goal.description && (
                     <div className="hf-text-xs hf-text-muted hf-mb-xs">{goal.description}</div>
                   )}
-                  <div className="hf-text-xs hf-text-secondary">
-                    {pct}% ready — target: {thresholdPct}%
-                  </div>
+                  {isUnmeasured ? (
+                    <SkillMeasurementAffordance status={skillStatus!} ref={goal.ref!} />
+                  ) : (
+                    <div className="hf-text-xs hf-text-secondary">
+                      {pct}% ready — target: {thresholdPct}%
+                    </div>
+                  )}
 
-                  {/* Pending self-report signal */}
-                  {hasPending && !isCompleted && (
+                  {/* Pending self-report signal (suppressed when unmeasured —
+                      we don't want educators confirming a score they haven't
+                      actually seen real evidence for) */}
+                  {hasPending && !isCompleted && !isUnmeasured && (
                     <div className="hf-flex hf-gap-sm hf-mt-sm hf-items-center hf-p-sm hf-border-radius-md"
                       style={{ background: "var(--status-warning-bg)", border: "1px solid var(--status-warning-border)" }}>
                       <span className="hf-text-xs hf-text-warning hf-flex-1">
@@ -495,8 +555,9 @@ export function AssessmentTargetsCard({ goals, callerId }: { goals: Goal[]; call
                     </div>
                   )}
 
-                  {/* Manual completion for goals without self-report */}
-                  {!hasPending && !isCompleted && (
+                  {/* Manual completion for goals without self-report
+                      (suppressed when unmeasured) */}
+                  {!hasPending && !isCompleted && !isUnmeasured && (
                     <button
                       className="hf-btn hf-btn-sm hf-btn-outline hf-mt-sm"
                       onClick={() => handleAction(goal.id, "confirm")}

--- a/apps/admin/components/callers/caller-detail/types.ts
+++ b/apps/admin/components/callers/caller-detail/types.ts
@@ -156,6 +156,17 @@ export type Goal = {
   isAssessmentTarget: boolean;
   assessmentConfig: { threshold?: number; [key: string]: any } | null;
   pendingSignal?: { id: string; evidence: string | null; createdAt: string } | null;
+  /** #417 — provenance ref ("SKILL-01", "OUT-02"); NULL for legacy goals. */
+  ref?: string | null;
+  /**
+   * #417 follow-up — measurement state for SKILL-NN ACHIEVE goals.
+   * "measured" — caller has CallerTarget.currentScore evidence
+   * "awaiting_evidence" — playbook has the BehaviorTarget but no scores yet
+   * "not_configured" — playbook has no BehaviorTarget for this skillRef
+   *                    (legacy course needs re-projection to enable scoring)
+   * undefined — goal is not a SKILL-NN ACHIEVE (engagement-heuristic territory)
+   */
+  measurementStatus?: "measured" | "awaiting_evidence" | "not_configured";
   playbook: {
     id: string;
     name: string;


### PR DESCRIPTION
## Summary

Follow-up to #417 closing the misleading-engagement-noise gap raised in conversation: legacy / non-wizard-projected playbooks were showing ACHIEVE goals named "Reach Secure on FC/LR/GRA/P" with raw progress numbers that came from transcript keyword presence, NOT from any actual skill measurement.

Three states surfaced per SKILL-NN ACHIEVE goal:

- **measured** → unchanged (progress ring + tier+band-shaped copy)
- **awaiting_evidence** → dimmed ring + "Awaiting first call evidence" banner (BehaviorTarget exists, no caller score yet)
- **not_configured** → dimmed ring + "Skill scoring not configured — re-project the course" banner (legacy playbook, no BehaviorTarget for this skillRef)

\`measurementStatus\` computed on the caller API and consumed by \`ProgressTab.tsx::AssessmentTargetsCard\`.

## Why

The conversation flagged that educators reading the dashboard would interpret a 0.39 value on Opal's "Reach Secure on Fluency & Coherence" goal as "she's at 39% of Secure" — when in reality (pre-#417) it was a keyword count. Now they see the truth: "Skill scoring not configured — re-project" with a clear self-serve action.

## Test plan
- [x] Backend enrichment: 3 states derived correctly from BT + CallerTarget shape
- [x] UI affordance renders for not_configured + awaiting_evidence; normal layout for measured
- [x] Non-SKILL-NN ACHIEVE goals unchanged (CHANGE, hand-authored, exam-readiness)
- [x] "Mark as achieved" + pending-signal suppressed when unmeasured (no false confirmation)
- [x] Uses hf-banner-info / hf-banner-warning per design system

## Files
- \`app/api/callers/[callerId]/route.ts\` — measurementStatus enrichment
- \`components/callers/caller-detail/ProgressTab.tsx\` — affordance + dimmed ring
- \`components/callers/caller-detail/types.ts\` — \`measurementStatus\` + \`ref\` type fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)