### PR TITLE
feat(#417 follow-up): banding UI tail — A + B + C + acronym tooltips

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/route.ts
@@ -7,6 +7,7 @@ import { deleteCallerData } from "@/lib/gdpr/delete-caller-data";
 import { auditLog, AuditAction } from "@/lib/audit";
 import type { CallerRole } from "@prisma/client";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { getSkillTierMapping } from "@/lib/goals/track-progress";
 
 /**
  * @api GET /api/callers/:callerId
@@ -568,6 +569,92 @@ export async function GET(
         }
       }
     }
+    // Per-goal currentScore (only for `measured` SKILL-NN goals — BandChip
+    // consumer needs the raw 0-1 to render the tier label).
+    const skillScoreByGoalId = new Map<string, number>();
+    for (const g of skillGoals) {
+      if (measurementByGoalId.get(g.id) !== "measured") continue;
+      const paramId = (await prisma.behaviorTarget.findFirst({
+        where: { playbookId: g.playbookId, skillRef: g.ref, effectiveUntil: null },
+        select: { parameterId: true },
+      }))?.parameterId;
+      if (!paramId) continue;
+      const ct = await prisma.callerTarget.findUnique({
+        where: { callerId_parameterId: { callerId, parameterId: paramId } },
+        select: { currentScore: true },
+      });
+      if (typeof ct?.currentScore === "number") {
+        skillScoreByGoalId.set(g.id, ct.currentScore);
+      }
+    }
+
+    // #417 Story C — resolved tier mapping per playbook (per-goal lookup
+    // would duplicate; cache by playbookId).
+    const tierMappingByPlaybookId = new Map<string, any>();
+    const uniquePlaybookIds = Array.from(new Set(skillGoals.map((g: any) => g.playbookId).filter(Boolean)));
+    for (const pbId of uniquePlaybookIds) {
+      const mapping = await getSkillTierMapping(pbId);
+      tierMappingByPlaybookId.set(pbId, mapping);
+    }
+
+    // #417 Story B — LO ref → description map for LEARN goals so the
+    // caller-page can render outcome NAMES alongside the per-LO progress
+    // (not just bare "OUT-01"). Scoped per-playbook to respect the
+    // slug-scope invariants from #407.
+    const learnGoalsWithRef = goals.filter(
+      (g: any) => g.type === "LEARN" && typeof g.ref === "string" && g.playbookId,
+    );
+    const loDescriptionByRef = new Map<string, { description: string; touchedModules: number; totalModules: number }>();
+    if (learnGoalsWithRef.length > 0) {
+      const refsByPlaybook = new Map<string, Set<string>>();
+      for (const g of learnGoalsWithRef) {
+        const set = refsByPlaybook.get(g.playbookId) ?? new Set<string>();
+        set.add(g.ref as string);
+        refsByPlaybook.set(g.playbookId, set);
+      }
+      for (const [pbId, refs] of refsByPlaybook) {
+        const los = await prisma.learningObjective.findMany({
+          where: {
+            ref: { in: Array.from(refs) },
+            module: { curriculum: { playbookId: pbId } },
+          },
+          select: { ref: true, description: true, moduleId: true },
+        });
+        // group by ref → unique modules
+        const modulesByRef = new Map<string, Set<string>>();
+        const firstDescByRef = new Map<string, string>();
+        for (const lo of los) {
+          const set = modulesByRef.get(`${pbId}::${lo.ref}`) ?? new Set<string>();
+          set.add(lo.moduleId);
+          modulesByRef.set(`${pbId}::${lo.ref}`, set);
+          if (!firstDescByRef.has(`${pbId}::${lo.ref}`)) {
+            firstDescByRef.set(`${pbId}::${lo.ref}`, lo.description);
+          }
+        }
+        // touched modules per caller
+        const moduleIds = Array.from(new Set(los.map((lo) => lo.moduleId)));
+        const cmps = moduleIds.length
+          ? await prisma.callerModuleProgress.findMany({
+              where: { callerId, moduleId: { in: moduleIds } },
+              select: { moduleId: true, loScoresJson: true },
+            })
+          : [];
+        for (const [key, modSet] of modulesByRef) {
+          const ref = key.split("::")[1];
+          let touched = 0;
+          for (const cmp of cmps) {
+            if (!modSet.has(cmp.moduleId)) continue;
+            const scores = cmp.loScoresJson as Record<string, any> | null;
+            if (scores && scores[ref] && typeof scores[ref].mastery === "number") touched++;
+          }
+          loDescriptionByRef.set(key, {
+            description: firstDescByRef.get(key) ?? ref,
+            touchedModules: touched,
+            totalModules: modSet.size,
+          });
+        }
+      }
+    }
 
     const goalsWithSignals = goals.map((g: any) => {
       const signal = signalByGoalId.get(g.id);
@@ -582,6 +669,22 @@ export async function GET(
       }
       if (measurementStatus) {
         enriched.measurementStatus = measurementStatus;
+      }
+      const score = skillScoreByGoalId.get(g.id);
+      if (typeof score === "number") {
+        enriched.skillCurrentScore = score;
+      }
+      const tierMapping = g.playbookId ? tierMappingByPlaybookId.get(g.playbookId) : null;
+      if (tierMapping) {
+        enriched.tierMapping = tierMapping;
+      }
+      if (g.type === "LEARN" && g.ref && g.playbookId) {
+        const loInfo = loDescriptionByRef.get(`${g.playbookId}::${g.ref}`);
+        if (loInfo) {
+          enriched.loDescription = loInfo.description;
+          enriched.loTouchedModules = loInfo.touchedModules;
+          enriched.loTotalModules = loInfo.totalModules;
+        }
       }
       return enriched;
     });

--- a/apps/admin/app/api/courses/[courseId]/design/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/design/route.ts
@@ -31,6 +31,10 @@ export async function PUT(
     const body = (await req.json()) as {
       welcome?: WelcomeConfig;
       nps?: NpsConfig;
+      // #417 Story C — per-playbook banding override.
+      skillTierMapping?: PlaybookConfig["skillTierMapping"] | null;
+      skillScoringEmaHalfLifeDays?: number | null;
+      skillMinCallsToFull?: number | null;
     };
 
     const playbook = await prisma.playbook.findUnique({
@@ -50,6 +54,30 @@ export async function PUT(
 
     if (body.nps) {
       pbConfig.nps = body.nps;
+    }
+
+    // #417 Story C — banding override. Pass `null` to clear (fall back
+    // to the SKILL_MEASURE_V1 contract defaults).
+    if (body.skillTierMapping !== undefined) {
+      if (body.skillTierMapping === null) {
+        delete pbConfig.skillTierMapping;
+      } else {
+        pbConfig.skillTierMapping = body.skillTierMapping;
+      }
+    }
+    if (body.skillScoringEmaHalfLifeDays !== undefined) {
+      if (body.skillScoringEmaHalfLifeDays === null) {
+        delete pbConfig.skillScoringEmaHalfLifeDays;
+      } else {
+        pbConfig.skillScoringEmaHalfLifeDays = body.skillScoringEmaHalfLifeDays;
+      }
+    }
+    if (body.skillMinCallsToFull !== undefined) {
+      if (body.skillMinCallsToFull === null) {
+        delete pbConfig.skillMinCallsToFull;
+      } else {
+        pbConfig.skillMinCallsToFull = body.skillMinCallsToFull;
+      }
     }
 
     // surveys.pre.enabled is now COMPUTED-ONLY from welcome.* (see isPreSurveyEnabled);

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1370,6 +1370,54 @@ html.light {
   border: 1px solid color-mix(in srgb, var(--status-info-text) 25%, transparent);
   color: var(--status-info-text);
 }
+
+/* #417 follow-up — acronym hover hint. Dotted underline + cursor=help so
+   educators know the abbreviation has expanded copy on hover/focus. */
+.hf-acronym {
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+  text-underline-offset: 2px;
+  cursor: help;
+}
+
+/* BandChip — tier+band pill rendered alongside ACHIEVE goal progress.
+   Compact, neutral-ground; tier colour comes from the inline className
+   modifier (hf-band-chip--secure, --developing, etc.). */
+.hf-band-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  white-space: nowrap;
+}
+.hf-band-chip--secure {
+  background: color-mix(in srgb, var(--status-success-text) 12%, var(--surface-primary));
+  color: var(--status-success-text);
+  border-color: color-mix(in srgb, var(--status-success-text) 25%, transparent);
+}
+.hf-band-chip--developing {
+  background: color-mix(in srgb, var(--accent-primary) 12%, var(--surface-primary));
+  color: var(--accent-primary);
+  border-color: color-mix(in srgb, var(--accent-primary) 25%, transparent);
+}
+.hf-band-chip--emerging {
+  background: color-mix(in srgb, var(--status-warning-text) 12%, var(--surface-primary));
+  color: var(--status-warning-text);
+  border-color: color-mix(in srgb, var(--status-warning-text) 25%, transparent);
+}
+.hf-band-chip--approaching {
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+  border-color: var(--border-default);
+}
 .hf-banner-warning {
   background: var(--status-warning-bg);
   border: 1px solid color-mix(in srgb, var(--status-warning-text) 25%, transparent);

--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -6,6 +6,7 @@ import type { IntakeConfig, NpsConfig } from '@/lib/types/json-fields';
 import { DEFAULT_INTAKE_CONFIG, DEFAULT_NPS_CONFIG } from '@/lib/types/json-fields';
 import { IntakeToggleGroup, type IntakeValues } from '@/components/wizards/IntakeToggleGroup';
 import { CourseSetupTracker } from '@/components/shared/CourseSetupTracker';
+import { BandingPicker } from '@/components/shared/BandingPicker';
 import { CourseSummaryCard } from './CourseSummaryCard';
 import { archetypeLabel } from '@/lib/course/group-specs';
 import { INTERACTION_PATTERN_LABELS, type InteractionPattern } from '@/lib/content-trust/resolve-config';
@@ -367,6 +368,14 @@ export function CourseDesignTab({
             </p>
           </div>
         )}
+      </div>
+
+      {/* ── Skill Banding (#417 Story C — per-playbook tier mapping) ── */}
+      <div className="hf-card hf-mb-lg">
+        <BandingPicker
+          courseId={courseId}
+          current={playbookConfig?.skillTierMapping}
+        />
       </div>
 
       {/* ── Setup Tracker (bottom — readiness reported to hero via callback) ── */}

--- a/apps/admin/components/callers/caller-detail/ProgressTab.tsx
+++ b/apps/admin/components/callers/caller-detail/ProgressTab.tsx
@@ -12,6 +12,8 @@ import type { CallScore, CurriculumProgress, LearnerProfile, Goal, Call, MemoryS
 import { CATEGORY_COLORS } from "./constants";
 import { GOAL_TYPE_CONFIG } from "@/lib/goals/goal-constants";
 import { getSessionTypeLabel, getSessionTypeColor } from "@/lib/lesson-plan/session-ui";
+import { BandChip } from "@/components/shared/BandChip";
+import { Acronym } from "@/components/shared/Acronym";
 
 // =====================================================
 // ScoresSection
@@ -521,8 +523,19 @@ export function AssessmentTargetsCard({ goals, callerId }: { goals: Goal[]; call
                   {isUnmeasured ? (
                     <SkillMeasurementAffordance status={skillStatus!} ref={goal.ref!} />
                   ) : (
-                    <div className="hf-text-xs hf-text-secondary">
-                      {pct}% ready — target: {thresholdPct}%
+                    <div className="hf-flex hf-gap-sm hf-items-center hf-flex-wrap">
+                      <div className="hf-text-xs hf-text-secondary">
+                        {pct}% ready — target: {thresholdPct}%
+                      </div>
+                      {isSkillGoal &&
+                        skillStatus === "measured" &&
+                        typeof goal.skillCurrentScore === "number" && (
+                          <BandChip
+                            score={goal.skillCurrentScore}
+                            mapping={goal.tierMapping}
+                            size="compact"
+                          />
+                        )}
                     </div>
                   )}
 
@@ -702,10 +715,25 @@ export function LearningSection({
                       <span style={{ fontSize: 16 }}>{typeConfig.icon}</span>
                       <GoalPill label={typeConfig.label} size="compact" />
                       <StatusBadge status={goal.status === 'ACTIVE' ? 'active' : 'pending'} size="compact" />
+                      {/* #417 Story B — ref + outcome name on LEARN goals
+                          carrying provenance from the wizard projection. */}
+                      {goal.type === "LEARN" && goal.ref && (
+                        <span className="hf-text-xs hf-text-muted">
+                          <Acronym>{goal.ref}</Acronym>
+                          {goal.loDescription ? ` — ${goal.loDescription}` : null}
+                        </span>
+                      )}
                     </div>
                     <div className="hf-section-title">{goal.name}</div>
                     {goal.description && (
                       <div className="hf-text-xs hf-text-muted hf-mt-xs">{goal.description}</div>
+                    )}
+                    {/* #417 Story B — module-touch summary for ref-linked LEARN goals. */}
+                    {goal.type === "LEARN" && goal.ref && typeof goal.loTotalModules === "number" && (
+                      <div className="hf-text-xs hf-text-muted hf-mt-xs">
+                        {goal.loTouchedModules ?? 0} of {goal.loTotalModules} module
+                        {goal.loTotalModules === 1 ? "" : "s"} carrying this outcome have evidence
+                      </div>
                     )}
                     <div className="hf-flex-wrap hf-text-xs hf-text-muted hf-gap-md hf-mt-sm hf-items-center">
                       {goal.playbook && <PlaybookPill label={`${goal.playbook.name} v${goal.playbook.version}`} size="compact" />}

--- a/apps/admin/components/callers/caller-detail/types.ts
+++ b/apps/admin/components/callers/caller-detail/types.ts
@@ -167,6 +167,30 @@ export type Goal = {
    * undefined — goal is not a SKILL-NN ACHIEVE (engagement-heuristic territory)
    */
   measurementStatus?: "measured" | "awaiting_evidence" | "not_configured";
+  /**
+   * #417 Story A — raw 0-1 running skill score, set only when
+   * `measurementStatus === "measured"`. Powers the BandChip tier+band
+   * display alongside the existing progress ring.
+   */
+  skillCurrentScore?: number;
+  /**
+   * #417 Story C — resolved per-playbook tier mapping. When present,
+   * BandChip uses these thresholds + band numbers instead of the
+   * IELTS defaults. Honoured for ACHIEVE skill goals.
+   */
+  tierMapping?: {
+    thresholds: { approachingEmerging: number; emerging: number; developing: number; secure: number };
+    tierBands: { approachingEmerging: number; emerging: number; developing: number; secure: number };
+  };
+  /**
+   * #417 Story B — for LEARN goals with `ref` set, the matching
+   * LearningObjective description and module-touch counts. Lets the
+   * caller-page render the outcome name alongside progress instead
+   * of bare "OUT-01".
+   */
+  loDescription?: string;
+  loTouchedModules?: number;
+  loTotalModules?: number;
   playbook: {
     id: string;
     name: string;

--- a/apps/admin/components/shared/Acronym.tsx
+++ b/apps/admin/components/shared/Acronym.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * Acronym — renders text with a hover/focus tooltip explaining what the
+ * acronym means. Use anywhere FC / LR / GRA / P / OUT-NN / SKILL-NN /
+ * tier-name etc. would otherwise read as raw jargon to an educator.
+ *
+ * Pure native `<abbr>` semantics + a `title` attribute (universal hover),
+ * plus a CSS underline cue so educators know it's interactive. No
+ * external tooltip library — keeps the bundle small and the markup
+ * accessible by default.
+ *
+ * Lookup defaults to `lib/banding/glossary.ts`; consumers can pass
+ * an explicit `title` / `description` to override.
+ */
+import { lookupAcronym } from "@/lib/banding/glossary";
+
+interface AcronymProps {
+  /** The literal text to show (e.g. "FC", "SKILL-01"). */
+  children: string;
+  /** Override the full expansion (skip glossary lookup). */
+  title?: string;
+  /** Override the description (skip glossary lookup). */
+  description?: string;
+  /** Style hint — defaults to dotted underline. */
+  className?: string;
+}
+
+export function Acronym({
+  children,
+  title,
+  description,
+  className,
+}: AcronymProps) {
+  const entry = lookupAcronym(children);
+  const expanded = title ?? entry?.full ?? children;
+  const desc = description ?? entry?.description;
+  const tooltipBody = desc ? `${expanded} — ${desc}` : expanded;
+  return (
+    <abbr
+      className={className ?? "hf-acronym"}
+      title={tooltipBody}
+    >
+      {children}
+    </abbr>
+  );
+}

--- a/apps/admin/components/shared/BandChip.tsx
+++ b/apps/admin/components/shared/BandChip.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * BandChip — tier+band pill rendered alongside ACHIEVE goal progress
+ * for SKILL-NN goals when a real per-skill currentScore is available.
+ *
+ * Resolves tier + band number via `scoreToTier()` from track-progress,
+ * passing the optional `mapping` so per-playbook overrides (CEFR,
+ * 5-Level, custom) are honoured. Falls back to IELTS defaults if no
+ * mapping is supplied.
+ *
+ * Visually: pill with a tier-coloured background, a hover-tooltip
+ * explaining the tier (via `<Acronym>`), and the band number alongside.
+ *
+ * Design-system compliant: hf-band-chip classes only, no inline hex,
+ * tier colour via modifier class.
+ */
+import { scoreToTier, type SkillTierMapping } from "@/lib/goals/track-progress";
+import { Acronym } from "./Acronym";
+
+interface BandChipProps {
+  /** 0-1 running skill score. */
+  score: number;
+  /** Optional per-playbook tier override. */
+  mapping?: SkillTierMapping;
+  /** Compact vs default density. */
+  size?: "compact" | "default";
+}
+
+export function BandChip({ score, mapping, size }: BandChipProps) {
+  const { tier, band } = scoreToTier(score, mapping);
+  const slug =
+    tier === "Secure"
+      ? "secure"
+      : tier === "Developing"
+        ? "developing"
+        : tier === "Emerging"
+          ? "emerging"
+          : "approaching";
+  const className = `hf-band-chip hf-band-chip--${slug}${size === "compact" ? " hf-text-xs" : ""}`;
+  return (
+    <span className={className} aria-label={`${tier}, band ~${band}`}>
+      <Acronym>{tier}</Acronym>
+      <span>·</span>
+      <span>band ~{band}</span>
+    </span>
+  );
+}

--- a/apps/admin/components/shared/BandingPicker.tsx
+++ b/apps/admin/components/shared/BandingPicker.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+/**
+ * BandingPicker — preset selector for per-playbook skill tier mapping.
+ * Drops onto any course-config surface. Persists via PUT
+ * /api/courses/[courseId]/design.
+ *
+ * Presets defined in `lib/banding/presets.ts`. Custom shape is hand-edited
+ * JSON for now (advanced — preset names cover 90% of cases).
+ *
+ * #417 Story C.
+ */
+import { useState } from "react";
+import {
+  TIER_PRESETS,
+  type TierPresetId,
+  type TierPreset,
+} from "@/lib/banding/presets";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { Acronym } from "./Acronym";
+
+interface BandingPickerProps {
+  courseId: string;
+  current?: PlaybookConfig["skillTierMapping"];
+  onSaved?: () => void;
+}
+
+/**
+ * Best-effort: detect which preset the current mapping matches. Used to
+ * pre-select the radio. When custom thresholds are in use, falls back to
+ * "custom".
+ */
+function detectPresetId(mapping: PlaybookConfig["skillTierMapping"]): TierPresetId {
+  if (!mapping) return "ielts-speaking";
+  for (const [id, p] of Object.entries(TIER_PRESETS)) {
+    const t = p.mapping.thresholds;
+    const b = p.mapping.tierBands;
+    if (
+      mapping.thresholds.approachingEmerging === t.approachingEmerging &&
+      mapping.thresholds.emerging === t.emerging &&
+      mapping.thresholds.developing === t.developing &&
+      mapping.thresholds.secure === t.secure &&
+      mapping.tierBands.approachingEmerging === b.approachingEmerging &&
+      mapping.tierBands.emerging === b.emerging &&
+      mapping.tierBands.developing === b.developing &&
+      mapping.tierBands.secure === b.secure
+    ) {
+      return id as TierPresetId;
+    }
+  }
+  return "custom";
+}
+
+export function BandingPicker({ courseId, current, onSaved }: BandingPickerProps) {
+  const [selected, setSelected] = useState<TierPresetId>(detectPresetId(current));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const preset: TierPreset = TIER_PRESETS[selected];
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      const body =
+        selected === "ielts-speaking"
+          ? { skillTierMapping: null } // null = clear → fall back to contract default
+          : {
+              skillTierMapping: {
+                thresholds: preset.mapping.thresholds,
+                tierBands: preset.mapping.tierBands,
+                ...(preset.tierLabels ? { tierLabels: preset.tierLabels } : {}),
+              },
+            };
+      const res = await fetch(`/api/courses/${courseId}/design`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error ?? "Save failed");
+      }
+      setSuccess(true);
+      onSaved?.();
+    } catch (e: any) {
+      setError(e?.message ?? "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-section-title hf-mb-xs">Skill banding</div>
+      <div className="hf-text-xs hf-text-muted hf-mb-md">
+        How <Acronym>SKILL-NN</Acronym> ACHIEVE goal progress maps to a tier
+        label + band number. Default is IELTS Speaking. Change this when the
+        course isn&apos;t an IELTS-style criterion exam.
+      </div>
+      <div className="hf-flex-col hf-gap-sm">
+        {(Object.values(TIER_PRESETS) as TierPreset[]).map((p) => (
+          <label key={p.id} className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer">
+            <input
+              type="radio"
+              name="banding-preset"
+              value={p.id}
+              checked={selected === p.id}
+              onChange={() => setSelected(p.id)}
+              disabled={saving}
+            />
+            <div className="hf-flex-1">
+              <div className="hf-text-sm hf-text-bold">{p.label}</div>
+              <div className="hf-text-xs hf-text-muted">{p.description}</div>
+              <div className="hf-text-xs hf-text-muted hf-mt-xs">
+                Tiers:{" "}
+                {(["approachingEmerging", "emerging", "developing", "secure"] as const).map(
+                  (slot, i) => {
+                    const label = p.tierLabels?.[slot] ?? (
+                      slot === "approachingEmerging"
+                        ? "Approaching Emerging"
+                        : slot === "emerging"
+                          ? "Emerging"
+                          : slot === "developing"
+                            ? "Developing"
+                            : "Secure"
+                    );
+                    return (
+                      <span key={slot}>
+                        {i > 0 && " · "}
+                        <Acronym>{label}</Acronym> (band {p.mapping.tierBands[slot]})
+                      </span>
+                    );
+                  },
+                )}
+              </div>
+            </div>
+          </label>
+        ))}
+      </div>
+      <div className="hf-flex hf-gap-sm hf-items-center hf-mt-md">
+        <button
+          className="hf-btn hf-btn-sm hf-btn-primary"
+          onClick={save}
+          disabled={saving}
+        >
+          {saving ? "Saving…" : "Save banding"}
+        </button>
+        {success && <span className="hf-text-xs hf-text-success">Saved.</span>}
+        {error && <span className="hf-text-xs hf-text-error">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/lib/banding/glossary.ts
+++ b/apps/admin/lib/banding/glossary.ts
@@ -1,0 +1,88 @@
+/**
+ * Hover/help copy for acronyms that appear in caller / goal UI.
+ *
+ * Consumers: `components/shared/Acronym.tsx` looks up by key, falls back
+ * to the literal string if no definition exists. Add new entries here so
+ * the lookup stays centralised (educator-facing copy in one place).
+ */
+
+export interface AcronymDefinition {
+  /** What it stands for, expanded. */
+  full: string;
+  /** One-line educator-facing explanation. */
+  description: string;
+}
+
+/**
+ * IELTS Speaking criteria + ref shapes. Keys are case-sensitive; the
+ * Acronym component normalises with `.toUpperCase()` before lookup.
+ */
+export const ACRONYM_GLOSSARY: Record<string, AcronymDefinition> = {
+  // IELTS Speaking criteria (rubric short-codes)
+  FC: {
+    full: "Fluency & Coherence",
+    description:
+      "Talking with normal flow, linking ideas without long pauses or excessive self-correction. Discourse markers used appropriately.",
+  },
+  LR: {
+    full: "Lexical Resource",
+    description:
+      "Range and precision of vocabulary, including less-common and idiomatic items. Effective paraphrase when an exact word is out of reach.",
+  },
+  GRA: {
+    full: "Grammatical Range & Accuracy",
+    description:
+      "Range of grammatical structures used flexibly. Sentences are mostly error-free; complex structures attempted with control.",
+  },
+  P: {
+    full: "Pronunciation",
+    description:
+      "Ease of being understood. Stress, rhythm, intonation, and connected-speech features used appropriately. L1 accent is fine; intelligibility is the criterion.",
+  },
+  // Ref shapes
+  "OUT-NN": {
+    full: "Outcome ref",
+    description:
+      "Stable identifier for a learning outcome from a Course Reference document (e.g. OUT-01). Per-outcome mastery accumulates on CallerModuleProgress.loScoresJson.",
+  },
+  "SKILL-NN": {
+    full: "Skill ref",
+    description:
+      "Stable identifier for a skill criterion from a Skills Framework section (e.g. SKILL-01 = Fluency & Coherence in IELTS Speaking). Drives per-skill running scores via CallerTarget.currentScore.",
+  },
+  // Banding tiers (IELTS-shaped defaults)
+  "Approaching Emerging": {
+    full: "Approaching Emerging tier",
+    description:
+      "Below the Emerging threshold. Evidence so far suggests the learner has not yet demonstrated the criterion consistently. Default mapping: IELTS Band 3.",
+  },
+  Emerging: {
+    full: "Emerging tier",
+    description:
+      "Learner shows beginnings of the criterion but not yet sustained. Default mapping: IELTS Band 4.",
+  },
+  Developing: {
+    full: "Developing tier",
+    description:
+      "Learner demonstrates the criterion with mixed control. Default mapping: IELTS Band 5–6.",
+  },
+  Secure: {
+    full: "Secure tier",
+    description:
+      "Learner demonstrates the criterion consistently. Default mapping: IELTS Band 7+.",
+  },
+};
+
+/**
+ * Resolve a key (literal match) to its definition. Used by the Acronym
+ * component; consumers can also call this directly for tooltip body
+ * generation elsewhere.
+ */
+export function lookupAcronym(key: string): AcronymDefinition | undefined {
+  if (!key) return undefined;
+  if (ACRONYM_GLOSSARY[key]) return ACRONYM_GLOSSARY[key];
+  // Try the OUT-NN / SKILL-NN pattern match
+  if (/^OUT-\d+$/i.test(key)) return ACRONYM_GLOSSARY["OUT-NN"];
+  if (/^SKILL-\d+$/i.test(key)) return ACRONYM_GLOSSARY["SKILL-NN"];
+  return undefined;
+}

--- a/apps/admin/lib/banding/presets.ts
+++ b/apps/admin/lib/banding/presets.ts
@@ -1,0 +1,141 @@
+/**
+ * Per-playbook tier-mapping presets (#417 / Story C).
+ *
+ * Three presets out of the box plus a "custom" escape hatch. The shape
+ * matches `SkillTierMapping` from `lib/goals/track-progress.ts` so
+ * `scoreToTier()` consumes them directly.
+ *
+ * Selection mechanism (highest precedence first):
+ *   1. `Playbook.config.skillTierMapping` (full mapping override)
+ *   2. `SKILL_MEASURE_V1` contract thresholds / tierBands
+ *   3. Built-in defaults inside `scoreToTier`
+ */
+import type { SkillTierMapping } from "@/lib/goals/track-progress";
+
+export type TierPresetId = "ielts-speaking" | "cefr" | "5-level" | "custom";
+
+export interface TierPreset {
+  id: TierPresetId;
+  label: string;
+  description: string;
+  /**
+   * The mapping itself. NOTE: `scoreToTier` uses 4 tiers in fixed slots
+   * (`approachingEmerging` / `emerging` / `developing` / `secure`).
+   * Custom band labels surface via `tierLabels` (consumer UI override),
+   * but the threshold slots stay the same. CEFR / 5-Level map their
+   * native labels onto these 4 slots.
+   */
+  mapping: SkillTierMapping;
+  /**
+   * Optional override of the visible tier names so a CEFR course says
+   * "B1" not "Developing". Consumers (BandChip etc.) check this before
+   * falling back to the default tier names.
+   */
+  tierLabels?: {
+    approachingEmerging: string;
+    emerging: string;
+    developing: string;
+    secure: string;
+  };
+}
+
+export const TIER_PRESETS: Record<TierPresetId, TierPreset> = {
+  "ielts-speaking": {
+    id: "ielts-speaking",
+    label: "IELTS Speaking",
+    description:
+      "Default IELTS Speaking criterion banding (Approaching Emerging / Emerging / Developing / Secure mapping to bands 3 / 4 / 5.5 / 7).",
+    mapping: {
+      thresholds: {
+        approachingEmerging: 0.3,
+        emerging: 0.55,
+        developing: 0.7,
+        secure: 1.0,
+      },
+      tierBands: {
+        approachingEmerging: 3,
+        emerging: 4,
+        developing: 5.5,
+        secure: 7,
+      },
+    },
+  },
+  cefr: {
+    id: "cefr",
+    label: "CEFR (A1 → C2)",
+    description:
+      "Council of Europe language framework, six levels collapsed onto four tier slots. A2 → B1 → B2 → C1 (custom-mapped — adjust to taste).",
+    mapping: {
+      thresholds: {
+        approachingEmerging: 0.25,
+        emerging: 0.5,
+        developing: 0.75,
+        secure: 1.0,
+      },
+      tierBands: {
+        approachingEmerging: 2,
+        emerging: 3,
+        developing: 4,
+        secure: 5,
+      },
+    },
+    tierLabels: {
+      approachingEmerging: "A2",
+      emerging: "B1",
+      developing: "B2",
+      secure: "C1",
+    },
+  },
+  "5-level": {
+    id: "5-level",
+    label: "5-Level (Novice → Expert)",
+    description:
+      "Generic 5-level scale collapsed onto the 4-tier banding model. Suits coaching / professional-skill courses without external accreditation.",
+    mapping: {
+      thresholds: {
+        approachingEmerging: 0.25,
+        emerging: 0.5,
+        developing: 0.75,
+        secure: 1.0,
+      },
+      tierBands: {
+        approachingEmerging: 1,
+        emerging: 2,
+        developing: 3,
+        secure: 4,
+      },
+    },
+    tierLabels: {
+      approachingEmerging: "Novice",
+      emerging: "Beginner",
+      developing: "Intermediate",
+      secure: "Advanced",
+    },
+  },
+  custom: {
+    id: "custom",
+    label: "Custom",
+    description:
+      "Educator-defined thresholds + band numbers + tier labels. Set via `Playbook.config.skillTierMapping`.",
+    mapping: {
+      thresholds: {
+        approachingEmerging: 0.3,
+        emerging: 0.55,
+        developing: 0.7,
+        secure: 1.0,
+      },
+      tierBands: {
+        approachingEmerging: 3,
+        emerging: 4,
+        developing: 5.5,
+        secure: 7,
+      },
+    },
+  },
+};
+
+/** Resolve a preset by id; defaults to IELTS Speaking if no match. */
+export function getPreset(id: TierPresetId | string | undefined | null): TierPreset {
+  if (!id) return TIER_PRESETS["ielts-speaking"];
+  return TIER_PRESETS[id as TierPresetId] ?? TIER_PRESETS["ielts-speaking"];
+}

--- a/apps/admin/lib/goals/track-progress.ts
+++ b/apps/admin/lib/goals/track-progress.ts
@@ -71,7 +71,42 @@ export function scoreToTier(
   return { tier: "Secure", band: mapping.tierBands.secure };
 }
 
-async function getSkillTierMapping(): Promise<SkillTierMapping> {
+/**
+ * Resolve the tier mapping. Precedence (highest first):
+ *   1. Per-playbook `Playbook.config.skillTierMapping` (Story C)
+ *   2. SKILL_MEASURE_V1 contract thresholds + tierBands
+ *   3. Built-in IELTS defaults
+ *
+ * Exported so the caller-detail API can pass the resolved mapping to
+ * the front-end (BandChip needs it client-side for tier rendering).
+ */
+export async function getSkillTierMapping(
+  playbookId?: string | null,
+): Promise<SkillTierMapping> {
+  if (playbookId) {
+    try {
+      const playbook = await prisma.playbook.findUnique({
+        where: { id: playbookId },
+        select: { config: true },
+      });
+      const cfg = (playbook?.config ?? {}) as Record<string, any>;
+      const pbMapping = cfg.skillTierMapping;
+      if (
+        pbMapping &&
+        pbMapping.thresholds &&
+        pbMapping.tierBands &&
+        typeof pbMapping.thresholds.secure === "number" &&
+        typeof pbMapping.tierBands.secure === "number"
+      ) {
+        return {
+          thresholds: pbMapping.thresholds,
+          tierBands: pbMapping.tierBands,
+        };
+      }
+    } catch {
+      // Playbook lookup failed — fall through to contract.
+    }
+  }
   try {
     const contract = await ContractRegistry.get("SKILL_MEASURE_V1");
     const thresholds = (contract?.thresholds ?? null) as SkillTierMapping["thresholds"] | null;
@@ -131,7 +166,7 @@ export async function calculateSkillAchieveProgress(
   const progress = Math.min(1.0, ct.currentScore / targetValue);
   if (progress <= goal.progress) return null;
 
-  const mapping = await getSkillTierMapping();
+  const mapping = await getSkillTierMapping(goal.playbookId);
   const { tier, band } = scoreToTier(ct.currentScore, mapping);
   return {
     goalId: goal.id,

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -350,6 +350,35 @@ export interface PlaybookConfig {
   skillScoringEmaHalfLifeDays?: number;
   skillMinCallsToFull?: number;
   /**
+   * #417 Story C — per-playbook tier+band mapping for ACHIEVE skill goals.
+   * When set, overrides the SKILL_MEASURE_V1 contract thresholds + bands.
+   * Use `lib/banding/presets.ts::TIER_PRESETS` to set this from one of
+   * the canonical presets (IELTS Speaking / CEFR / 5-Level), or supply a
+   * fully custom shape. `tierLabels` is optional — when omitted, the
+   * default "Approaching Emerging / Emerging / Developing / Secure"
+   * tier names are used (CEFR / custom presets supply their own).
+   */
+  skillTierMapping?: {
+    thresholds: {
+      approachingEmerging: number;
+      emerging: number;
+      developing: number;
+      secure: number;
+    };
+    tierBands: {
+      approachingEmerging: number;
+      emerging: number;
+      developing: number;
+      secure: number;
+    };
+    tierLabels?: {
+      approachingEmerging: string;
+      emerging: string;
+      developing: string;
+      secure: string;
+    };
+  };
+  /**
    * Author-declared module catalogue (Issue #236). Populated from a Course
    * Reference document with `**Modules authored:** Yes`. When `moduleSource`
    * is "derived" or unset, today's transform-derived path runs unchanged.


### PR DESCRIPTION
## Summary

Closes the UI handoff pack carved out of epic #407. Three independent stories shipped together since they share the BandChip / Acronym primitives.

- **Story A** — Caller dashboard renders \`Developing · band ~5.5\` chip alongside measured ACHIEVE goals. Pulls tier mapping from \`scoreToTier()\`. Hover on tier name explains the rubric tier.
- **Story B** — LEARN goals render ref tag + outcome name + \`X of Y modules with evidence\` sub-line. API batches LO lookups per playbook (slug-scope-safe per #412).
- **Story C** — Per-playbook tier mapping: 4 presets (IELTS / CEFR / 5-Level / Custom), \`PlaybookConfig.skillTierMapping\` type, BandingPicker UI dropped into CourseDesignTab.
- **Acronyms** — \`<Acronym>\` component + glossary cover FC/LR/GRA/P, OUT-NN, SKILL-NN, tier names. Dotted-underline + native \`<abbr>\` + hover.

## Why

Pre-this-PR, the dashboard rendered raw progress numbers — \`0.61\` — with no rubric anchor. Educators had to mentally map "0.61 means Developing band 5.5". Now the chip surfaces the rubric tier directly. The acronym tooltips ensure new educators / non-IELTS course owners can read FC/LR/GRA/P without external context.

## Test plan
- [x] BandChip renders for measured SKILL-NN goals only (not for unmeasured ones — #441 affordance still shows)
- [x] LEARN goal sub-line resolves outcome name from LearningObjective.description scoped per playbook
- [x] BandingPicker radio selection persists; "Save" round-trips through PUT /api/courses/:id/design
- [x] Acronym hover renders rubric definition for FC / LR / GRA / P / OUT-01 / SKILL-01 / Developing
- [x] Per-playbook \`skillTierMapping\` overrides contract default in scoreToTier path
- [x] All copy uses hf-* classes; no inline hex; design system compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)