### PR TITLE
chore(ielts): align upload doc headers with post-#385 DocumentType subtypes

### DIFF
--- a/docs/external/ielts/ielts-speaking/Upload Docs/assessor-rubric.md
+++ b/docs/external/ielts/ielts-speaking/Upload Docs/assessor-rubric.md
@@ -1,6 +1,6 @@
 # IELTS Speaking — Assessor Rubric
 
-> **Document type:** COURSE_REFERENCE · **Intended assertion category:** `assessment_guidance` / `assessment_approach` (INSTRUCTION_CATEGORIES) · **LO systemRole if generated:** `ASSESSOR_RUBRIC` · **Question assessmentUse if generated:** `TUTOR_ONLY` · **Audience: assessor / scoring loop only**
+> **Document type:** COURSE_REFERENCE_ASSESSOR_RUBRIC · **Intended assertion category:** `assessment_guidance` / `assessment_approach` (INSTRUCTION_CATEGORIES) · **LO systemRole if generated:** `ASSESSOR_RUBRIC` · **Question assessmentUse if generated:** `TUTOR_ONLY` · **Audience: assessor / scoring loop only**
 >
 > This document defines the band descriptors used to **score** the learner. It is not learner-facing content. Nothing here becomes a learning objective the learner is taught directly, and nothing here becomes an MCQ. The tutor uses these descriptors silently in the background to score, and references them in coaching feedback by quoting specific descriptor language ("at Band 7 the examiner expects ...").
 

--- a/docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md
+++ b/docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md
@@ -1,6 +1,6 @@
 # IELTS Speaking Practice — Course Reference
 
-> **Document type:** COURSE_REFERENCE · **Dual-path parsing:** (a) `## Modules` table + `**OUT-NN:**` lines → `Playbook.config.modules` + `outcomes` directly; (b) remaining sections → `ContentAssertion` rows with INSTRUCTION_CATEGORIES · **Audience: tutor-only** (never sent to learner as media)
+> **Document type:** COURSE_REFERENCE_CANONICAL · **Dual-path parsing:** (a) `## Modules` table + `**OUT-NN:**` lines → `Playbook.config.modules` + `outcomes` directly; (b) remaining sections → `ContentAssertion` rows with INSTRUCTION_CATEGORIES · **Audience: tutor-only** (never sent to learner as media)
 
 ## Course Configuration
 

--- a/docs/external/ielts/ielts-speaking/Upload Docs/tutor-briefing.md
+++ b/docs/external/ielts/ielts-speaking/Upload Docs/tutor-briefing.md
@@ -1,6 +1,6 @@
 # IELTS Speaking — Tutor Briefing
 
-> **Document type:** COURSE_REFERENCE · **Intended assertion category:** `session_flow` / `session_metadata` / `skill_framework` (INSTRUCTION_CATEGORIES) · **LO systemRole if generated:** `TEACHING_INSTRUCTION` · **Audience: tutor-only**
+> **Document type:** COURSE_REFERENCE_TUTOR_BRIEFING · **Intended assertion category:** `session_flow` / `session_metadata` / `skill_framework` (INSTRUCTION_CATEGORIES) · **LO systemRole if generated:** `TEACHING_INSTRUCTION` · **Audience: tutor-only**
 >
 > Everything in this document is **briefing material the tutor uses to inform the learner** — test format, examiner role, timing, question shapes. The tutor explains these facts to the learner when relevant. The tutor **never quizzes** the learner on this content. None of this becomes an MCQ, an assessment item, or a learning objective the learner is scored against.
 


### PR DESCRIPTION
## Summary

3 one-line header edits — update the \`**Document type:**\` declaration on the three IELTS course-reference docs from the legacy \`COURSE_REFERENCE\` token to the post-#385 subtype names.

| File | Before | After |
|---|---|---|
| \`course-ref.md\` | \`COURSE_REFERENCE\` | \`COURSE_REFERENCE_CANONICAL\` |
| \`tutor-briefing.md\` | \`COURSE_REFERENCE\` | \`COURSE_REFERENCE_TUTOR_BRIEFING\` |
| \`assessor-rubric.md\` | \`COURSE_REFERENCE\` | \`COURSE_REFERENCE_ASSESSOR_RUBRIC\` |

The other 4 docs in \`Upload Docs/\` are already on non-legacy types (\`TEXTBOOK\` + \`QUESTION_BANK × 3\`).

## Why

- The parser at \`parse-content-declaration.ts:83-88\` accepts both legacy and subtype tokens, but the wizard-prompt.md refresh (#453) already documents these as the expected subtypes.
- The #447 ASSESSOR_RUBRIC goal-projection exclusion keys off the \`ASSESSOR_RUBRIC\` subtype specifically — declaring it explicitly makes the upload classify deterministically rather than relying on audience-signal inference from the legacy token.
- Brings the declared type in line with the post-#385 DocumentType enum.

## What does NOT change

Zero behaviour — same files, same content, same upload flow. Educators using these uploads see no difference. The classifier path that was treating these as canonical/briefing/rubric via inference now sees the explicit declaration.

## Test plan

- [x] Header grep confirms all three lines updated
- [x] Trivial diff: 3 files, +3/-3 lines
- [ ] Optional smoke: re-upload via wizard on hf-dev, confirm \`ContentSource.documentType\` lands as the subtype (was already landing there via inference)

## Deploy

\`/vm-cp\` (docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)