### PR TITLE
fix: triage trio — Key Facts tile (#456) + authored-module CMP (#284) + IELTS cert spec (#457)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -188,6 +188,89 @@ async function loadCurrentModuleContext(
     });
   }
 
+  // ── #284 Path 0b: authored-module fallback ──
+  // Authored-module playbooks (modulesAuthored=true) store the canonical
+  // module catalogue in `Playbook.config.modules[]`. When the caller has no
+  // `requestedModuleId` (every VAPI background call) we never used to look
+  // here — Path 1's CONTENT-spec lookup misses, Path 2's curriculum.notableInfo
+  // is empty, and the function returned null. Result: `learningAssessment`
+  // never fires and `CallerModuleProgress` never gets written. That's the
+  // bug Soren Guzmán surfaced (6 calls, 0 CMP rows, all 8 module bars at 0).
+  //
+  // Recipe: read the authored catalogue, find the caller's progress, pick
+  // the first non-completed module, and build the moduleContext from its
+  // `outcomesPrimary` refs (filtered the same way as the picker path).
+  {
+    const pb = await prisma.playbook.findUnique({
+      where: { id: resolvedPlaybookId },
+      select: {
+        config: true,
+        curricula: {
+          orderBy: { createdAt: "asc" },
+          take: 1,
+          select: { id: true, slug: true },
+        },
+      },
+    });
+    const cfg = (pb?.config ?? {}) as Record<string, any>;
+    const modulesAuthored = cfg.modulesAuthored === true;
+    const authored = Array.isArray(cfg.modules) ? cfg.modules : [];
+
+    if (modulesAuthored && authored.length > 0) {
+      // Pick the first non-completed module via CMP; first authored entry if
+      // none seen yet. Order matches the curriculum's authored sequence.
+      const cmps = await prisma.callerModuleProgress.findMany({
+        where: { callerId },
+        select: { moduleId: true, mastery: true },
+      });
+      const masteryByModuleId = new Map(cmps.map((c) => [c.moduleId, c.mastery]));
+      const masteryThreshold = 0.7;
+      const next =
+        authored.find((m: any) => (masteryByModuleId.get(m?.id) ?? 0) < masteryThreshold) ??
+        authored[0];
+
+      const allRefs: string[] = Array.isArray(next?.outcomesPrimary)
+        ? next.outcomesPrimary
+        : [];
+      let filteredRefs = allRefs;
+      if (allRefs.length > 0 && pb?.curricula[0]?.id) {
+        try {
+          const excluded = await prisma.learningObjective.findMany({
+            where: {
+              module: { curriculumId: pb.curricula[0].id },
+              ref: { in: allRefs },
+              systemRole: { in: ["ASSESSOR_RUBRIC", "SCORE_EXPLAINER", "TEACHING_INSTRUCTION"] },
+            },
+            select: { ref: true },
+          });
+          const drop = new Set(excluded.map((lo) => lo.ref));
+          if (drop.size > 0) {
+            filteredRefs = allRefs.filter((r) => !drop.has(r));
+          }
+        } catch (err: any) {
+          log.warn("Path 0b: systemRole filter failed; passing all refs", { error: err?.message });
+        }
+      }
+
+      log.info("Module context from authored catalogue (#284 Path 0b)", {
+        playbookId: resolvedPlaybookId,
+        moduleId: next?.id,
+        loCount: filteredRefs.length,
+        seenModules: cmps.length,
+      });
+      return {
+        specSlug:
+          pb?.curricula[0]?.slug ??
+          `playbook-${resolvedPlaybookId.slice(0, 8)}-modules`,
+        moduleId: next?.id,
+        moduleName: next?.label || next?.id,
+        learningOutcomes: filteredRefs,
+        masteryThreshold,
+        allModuleIds: authored.map((m: any) => m?.id).filter(Boolean),
+      };
+    }
+  }
+
   // Path 1: CONTENT spec via the caller's enrolled playbook
   const playbook = await prisma.playbook.findUnique({
     where: { id: resolvedPlaybookId },

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -1121,7 +1121,7 @@ export default function CallerDetailPage() {
               { id: "scores", label: "Scores", icon: <BarChart3 size={13} />, count: new Set(data.scores?.map((s: any) => s.parameterId)).size || 0 },
               { id: "behaviour", label: "Behaviour", icon: <Brain size={13} />, count: (data.counts.callerTargets || 0) + (data.counts.measurements || 0) },
               { id: "goals", label: "Goals", icon: <Target size={13} />, count: data.counts.activeGoals || 0 },
-              { id: "topics", label: "Topics", icon: <BookOpen size={13} />, count: (data.memorySummary?.topicCount || 0) + (data.counts.keyFacts || 0) },
+              { id: "topics", label: "Topics", icon: <BookOpen size={13} />, count: (data.memorySummary?.topicCount || 0) + (data.memorySummary?.factCount || 0) },
               ...(hasExamData ? [{ id: "exam" as const, label: "Exam", icon: <ClipboardCheck size={13} /> }] : []),
               ...(hasPlanData ? [{ id: "plan" as const, label: "Plan", icon: <CheckSquare size={13} /> }] : []),
             ]}
@@ -1138,7 +1138,7 @@ export default function CallerDetailPage() {
             <LearningSection curriculum={data.curriculum} learnerProfile={data.learnerProfile} goals={data.goals} callerId={callerId} />
           )}
           {progressVis.topics !== false && (
-            <TopicsCoveredSection memorySummary={data.memorySummary} keyFactCount={data.counts.keyFacts || 0} />
+            <TopicsCoveredSection memorySummary={data.memorySummary} keyFactCount={data.memorySummary?.factCount ?? 0} />
           )}
           {progressVis.exam !== false && <ExamReadinessSection callerId={callerId} onDataLoaded={setHasExamData} />}
           {progressVis.plan !== false && <PlanProgressSection callerId={callerId} calls={data.calls} domainId={data.caller?.domainId} onDataLoaded={setHasPlanData} />}

--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -189,6 +189,85 @@ export async function main(prisma: PrismaClient): Promise<void> {
     }
   }
 
+  // ── 5. CONTENT-role spec for trust-weighted certification progress (#457) ──
+  // `computeTrustWeightedProgress` reads module trust levels off a CONTENT
+  // spec's `config.modules[].sourceRefs[].trustLevel`. Without this spec the
+  // certification card on the caller page shows "0 of 0 modules count toward
+  // L3+". The 4 IELTS Speaking modules are official Cambridge IELTS rubric
+  // content → `PUBLISHED_REFERENCE` (weight 1.0, above the 0.80 L3+ cert
+  // threshold). Single CONTENT spec scoped to this playbook, idempotent upsert.
+  const playbookForModules = await prisma.playbook.findUnique({
+    where: { id: playbook.id },
+    select: { config: true },
+  });
+  const authoredModules = Array.isArray(
+    (playbookForModules?.config as Record<string, any>)?.modules,
+  )
+    ? ((playbookForModules!.config as Record<string, any>).modules as Array<{ id: string }>)
+    : [];
+  if (authoredModules.length > 0) {
+    const contentSpecSlug = `ielts-speaking-content`;
+    const contentSpec = await prisma.analysisSpec.upsert({
+      where: { slug: contentSpecSlug },
+      update: {
+        config: {
+          modules: authoredModules.map((m) => ({
+            id: m.id,
+            sourceRefs: [{ trustLevel: "PUBLISHED_REFERENCE" }],
+          })),
+        },
+        isDirty: false,
+        compiledAt: new Date(),
+        isActive: true,
+      },
+      create: {
+        slug: contentSpecSlug,
+        name: "IELTS Speaking Practice — Content",
+        description:
+          "CONTENT-role spec listing curriculum modules and their source trust levels for L3+ certification progress (#457).",
+        scope: "DOMAIN",
+        specType: "DOMAIN",
+        specRole: "CONTENT",
+        outputType: "MEASURE",
+        domain: "ielts-speaking",
+        isActive: true,
+        isDirty: false,
+        compiledAt: new Date(),
+        config: {
+          modules: authoredModules.map((m) => ({
+            id: m.id,
+            sourceRefs: [{ trustLevel: "PUBLISHED_REFERENCE" }],
+          })),
+        },
+      },
+      select: { id: true, slug: true },
+    });
+    // PlaybookItem has no (playbookId, specId) unique constraint, so we
+    // pre-check before creating. Idempotent on re-seed.
+    const existingLink = await prisma.playbookItem.findFirst({
+      where: { playbookId: playbook.id, specId: contentSpec.id },
+      select: { id: true },
+    });
+    if (existingLink) {
+      await prisma.playbookItem.update({
+        where: { id: existingLink.id },
+        data: { isEnabled: true },
+      });
+    } else {
+      await prisma.playbookItem.create({
+        data: {
+          playbookId: playbook.id,
+          specId: contentSpec.id,
+          itemType: "SPEC",
+          isEnabled: true,
+        },
+      });
+    }
+    console.log(
+      `  Content spec: ${contentSpec.slug} (${authoredModules.length} modules @ PUBLISHED_REFERENCE)`,
+    );
+  }
+
   console.log("✓ IELTS Speaking Practice seeded");
 }
 


### PR DESCRIPTION
## Summary

Three independent bug fixes — all surfaced from Soren Guzmán's caller page.

| Issue | Fix |
|-------|-----|
| **#456** Key Facts tile always 0 | One-line UI fix — read `memorySummary.factCount` instead of `data.counts.keyFacts` (wrong source table) |
| **#284** Module bars all 0% despite 6 calls | New Path 0b in `loadCurrentModuleContext` — authored-module playbooks without `requestedModuleId` now resolve their current module from `playbook.config.modules[]` + CMP mastery, so `learningAssessment` fires and CMP gets written |
| **#457** IELTS cert 0/0 modules count | Seed adds a CONTENT-role `AnalysisSpec` for IELTS Speaking with `PUBLISHED_REFERENCE` trust level on all 4 modules → `computeTrustWeightedProgress` returns non-zero |

## Why these matter together

#284 is the upstream feeder for #444's `lo_rollup` strategy. Without it, every LEARN goal on every authored IELTS course was stuck at "awaiting first call evidence" forever — even though the EXTRACT stage was writing `CallScore` rows. #456 is the cosmetic companion that makes the caller page tell the truth. #457 unlocks the cert-progress card which was rendering "0 of 0 modules count toward certification" for every authored course.

## Test plan

- [ ] Re-seed IELTS course (`tsx prisma/seed-ielts-course.ts`) — confirm new CONTENT spec lands with 4 modules @ PUBLISHED_REFERENCE
- [ ] Run pipeline on a Soren call — `CallerModuleProgress` rows appear with `loScoresJson` populated for OUT-NN refs
- [ ] Refresh Soren caller page — Key Facts tile shows a count > 0, LEARN goal sliders show actual mastery (not all-0), cert card shows "X of 4 modules"
- [ ] Pre-existing IELTS callers without `requestedModuleId` still get a moduleContext from Path 0b

🤖 Generated with [Claude Code](https://claude.com/claude-code)