### PR TITLE
docs(ielts): declare per-skill Target band 7.0 in upload-set course-ref

### DIFF
--- a/docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md
+++ b/docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md
@@ -69,6 +69,8 @@ The four IELTS Speaking band criteria map directly to the tutor's skill framewor
 
 The ability to speak at length without noticeable effort, with logical organisation and appropriate use of cohesive devices.
 
+**Target band:** 7.0
+
 - **Emerging:** Long pauses; frequent self-correction; ideas are disconnected; no use of discourse markers
 - **Developing:** Generally maintains flow with some hesitation; ideas are connected but sometimes jump; basic discourse markers used ("and", "but", "so")
 - **Secure:** Speaks fluently with rare hesitation; ideas are fully developed and logically sequenced; varied discourse markers used naturally ("having said that", "what I mean is", "on top of that")
@@ -76,6 +78,8 @@ The ability to speak at length without noticeable effort, with logical organisat
 ### SKILL-02: Lexical Resource (LR)
 
 The ability to use vocabulary with flexibility and precision, including less common and idiomatic items.
+
+**Target band:** 7.0
 
 - **Emerging:** Limited to high-frequency words; repetitive; word choice errors impede meaning; no paraphrasing
 - **Developing:** Some topic-specific vocabulary; attempts less common words with occasional inaccuracy; some effective paraphrasing
@@ -85,6 +89,8 @@ The ability to use vocabulary with flexibility and precision, including less com
 
 The ability to use a range of grammatical structures accurately and flexibly in speech.
 
+**Target band:** 7.0
+
 - **Emerging:** Mostly simple sentences; frequent errors in complex structures; errors impede understanding
 - **Developing:** Mix of simple and complex sentences; errors in complex structures but meaning is clear; some self-correction
 - **Secure:** Wide range of structures produced flexibly; majority of sentences are error-free; errors are rare and self-corrected
@@ -92,6 +98,8 @@ The ability to use a range of grammatical structures accurately and flexibly in 
 ### SKILL-04: Pronunciation (P)
 
 The ability to be understood with ease, using a range of pronunciation features (stress, rhythm, intonation, connected speech).
+
+**Target band:** 7.0
 
 - **Emerging:** Frequently unintelligible; limited control of phonological features; L1 interference causes communication breakdown
 - **Developing:** Generally intelligible; some mispronunciations but rarely impede understanding; some control of stress and intonation


### PR DESCRIPTION
## Summary

Adds \`**Target band:** 7.0\` under each of SKILL-01..SKILL-04 in the educator-facing \`Upload Docs/course-ref.md\`. Placement matches the seed fixtures — directly after the skill's definition paragraph, before the tier bullets.

## What it does (once upstream parser lands)

Consumed by the per-skill Target band projector at commit \`66715638\` (currently on \`fix/migration-domain-table-missing\`, pending merge). When that lands:

\`\`\`
**Target band:** 7.0
  → BehaviorTarget.targetValue = 0.70
  → ACHIEVE goal name: "Reach Band 7.0 on Fluency and Coherence"
  → BandPill denominator: 100% = Band 7.0 (not the Secure ceiling)
\`\`\`

## Why 7.0 uniform

- **Honest to course copy** — Course Overview line 32 targets Band 6.5–7.5; 7.0 is the literal midpoint
- **Real-world threshold** — 7.0 is the common entry bar for UK universities + medical/professional registration (both stated learner motivations in this course-ref)
- **Template legibility** — single number; educators search-and-replace per cohort if they need 6.5 or 7.5

Differentiated (FC 7.0, LR 7.0, GRA 6.5, P 6.5) was the alternative — rejected to avoid imposing "P caps adult L2 learners" as institutional wisdom before educators have run their first cohort.

## Seed-vs-upload divergence is deliberate

| | Target band | Purpose |
|---|---|---|
| \`apps/admin/tests/fixtures/course-reference-ielts-v2.2.md\` (seed) | 6.5 uniform | Demo / screenshots — 100% completion fires faster |
| \`docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md\` (upload) | **7.0 uniform** ← this PR | Realistic educator default |

## Order-of-merge

This PR is a no-op until \`66715638\` merges (projector currently ignores the line). After both are on main, the next re-projection (re-upload or seed reset) flips \`BehaviorTarget.targetValue\` from \`1.0\` → \`0.70\` in-place via the existing diff logic in \`apply-projection.ts\`.

## Test plan

- [x] All 4 \`**Target band:** 7.0\` lines inserted at correct positions (grep'd 72/82/92/102)
- [x] Diff: +8 lines (4 blank + 4 target lines), 0 deletions
- [ ] Post-merge of both this and \`66715638\`: re-upload via wizard on hf-dev, confirm \`BehaviorTarget.targetValue\` is \`0.70\` for all 4 IELTS skills, ACHIEVE goal name reads "Reach Band 7.0 on …"

## Deploy

\`/vm-cp\` (docs only). No migration. Behavioural effect deferred until \`66715638\` lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)