### PR TITLE
chore(#451 follow-up): stop auto-seeding IELTS playbook

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.307",
+  "version": "0.7.308",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/prisma/seed-full.ts
+++ b/apps/admin/prisma/seed-full.ts
@@ -43,7 +43,14 @@ import { main as seedDemoLogins } from "./seed-demo-logins";
 import { main as seedGolden } from "./seed-golden";
 import { main as seedIdentityArchetypes } from "./seed-identity-archetypes";
 import { main as seedDemoCourse } from "./seed-demo-course";
-import { main as seedIeltsCourse } from "./seed-ielts-course";
+// IELTS playbook is no longer seeded — it lives behind the wizard upload-doc
+// flow (`docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md`), which
+// is the realistic path teachers use. Auto-seeding produced a duplicate
+// playbook with diverging targetValue (6.5 vs the upload doc's 7.0) and
+// confused fresh-env testing. The seed-ielts-course module + parser-only
+// fixture test are kept as a regression guard on the projection parser.
+// See #463 follow-up.
+// import { main as seedIeltsCourse } from "./seed-ielts-course";
 
 type Profile = "core" | "demo" | "test" | "full" | "golden";
 
@@ -69,11 +76,6 @@ const ALL_STEPS: Step[] = [
 
   // ── Demo + Full (demo course with 8 learners) ──────────
   { name: "seed-demo-course", fn: seedDemoCourse, profiles: ["demo", "full"] },
-
-  // ── Demo + Full (IELTS playbook via live projection pipeline) ──
-  // Story B: demonstrates end-to-end course derivation from a Course
-  // Reference markdown — no hand-rolled rows, parser + applier only.
-  { name: "seed-ielts-course", fn: seedIeltsCourse, profiles: ["demo", "full"] },
 
   // ── Test + Full only (e2e fixtures — NOT in demo) ──────
   { name: "seed-e2e", fn: seedE2E, profiles: ["test", "full"] },


### PR DESCRIPTION
## Summary

Removes the `seed-ielts-course` step from `seed-full.ts`. The IELTS playbook now lives behind the wizard upload-doc flow only (`docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md`, declaring `Target band: 7.0`).

## Why

PR #451 auto-seeded an IELTS playbook so fresh envs had something to inspect. PR #462 then added per-skill `Target band: 7.0` to the upload-set course-ref. Net result on every `db:seed`: two same-named "IELTS Speaking Practice" rows with diverging targetValues (seeded = 0.65, wizard = 0.70), bypassing the realistic teacher flow.

Going wizard-only is cleaner. The seed-ielts module + parser-only fixture test stay as regression guard on the projection parser.

## Test plan
- [x] `npm run test -- tests/lib/seed-ielts-fixture.test.ts` (11/11 pass — parser test reads fixture from disk, no DB)
- [ ] Post-merge: `npm run db:reset && npm run db:seed` produces zero IELTS playbooks
- [ ] Post-merge: wizard upload of the IELTS course-ref creates a playbook with `targetValue=0.70` + `Reach Band 7.0 on …` goal names

🤖 Generated with [Claude Code](https://claude.com/claude-code)