### PR TITLE
fix(#467): strip <thinking> + <scratchpad> XML from chat output

### DIFF
--- a/apps/admin/lib/chat/parse-options.ts
+++ b/apps/admin/lib/chat/parse-options.ts
@@ -223,8 +223,15 @@ function parseParameterTagOptions(text: string): ParsedOption[] | null {
 
 /**
  * Strip hallucinated XML tags from AI response text so they don't render as raw markup.
- * Handles <parameter>, <invoke>, and </invoke> tags that the AI sometimes outputs
- * in its text content instead of using proper tool_use blocks.
+ * Handles <parameter>, <invoke>, </invoke>, <thinking>, and <scratchpad> tags
+ * that the AI sometimes outputs in its text content instead of using proper
+ * tool_use / extended-thinking blocks.
+ *
+ * Note: real Anthropic extended-thinking blocks (`type: "thinking"`) are
+ * extracted server-side in `lib/ai/client.ts` and never reach this function.
+ * What this strips is hallucinated literal `<thinking>` XML in text content
+ * — observed leaking into the wizard UI on 2026-05-18 (#467).
+ *
  * Returns the cleaned text (safe for ReactMarkdown).
  */
 export function stripParameterTags(text: string): string {
@@ -232,6 +239,14 @@ export function stripParameterTags(text: string): string {
     .replace(/<parameter\s+name="[^"]*">\s*[\s\S]*?\s*<\/parameter>/g, "")
     .replace(/<invoke\s+name="[^"]*">\s*[\s\S]*?\s*<\/invoke>/g, "")
     .replace(/<\/?invoke[^>]*>/g, "")
+    .replace(/<thinking[^>]*>[\s\S]*?<\/thinking>/gi, "")
+    .replace(/<scratchpad[^>]*>[\s\S]*?<\/scratchpad>/gi, "")
+    // Unclosed opening tag (model truncated mid-block) — strip from tag to end.
+    .replace(/<thinking[^>]*>[\s\S]*$/i, "")
+    .replace(/<scratchpad[^>]*>[\s\S]*$/i, "")
+    // Stray closing tags without a matching opener.
+    .replace(/<\/thinking[^>]*>/gi, "")
+    .replace(/<\/scratchpad[^>]*>/gi, "")
     .trim();
 }
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.308",
+  "version": "0.7.309",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/chat/parse-options.test.ts
+++ b/apps/admin/tests/lib/chat/parse-options.test.ts
@@ -190,6 +190,38 @@ describe("parseOptionsFromText", () => {
     expect(stripParameterTags(text)).toBe("Here is your setup.\n\nReady?");
   });
 
+  // ── <thinking> / <scratchpad> stripping (#467) ─────
+
+  it("strips well-formed <thinking> blocks", () => {
+    const text = `<thinking>\nLet me check the rules...\n</thinking>\nHere are your options.`;
+    expect(stripParameterTags(text)).toBe("Here are your options.");
+  });
+
+  it("strips multi-paragraph <thinking> blocks", () => {
+    const text = `<thinking>\nPara 1.\n\nPara 2 with "quotes".\n\n- list\n- item\n</thinking>\n\nReady?`;
+    expect(stripParameterTags(text)).toBe("Ready?");
+  });
+
+  it("strips orphan <thinking> opening tag (truncated mid-block)", () => {
+    const text = `<thinking>\nFirst save all the`;
+    expect(stripParameterTags(text)).toBe("");
+  });
+
+  it("strips orphan </thinking> closing tag", () => {
+    const text = `Stray content.\n</thinking>\nAfter.`;
+    expect(stripParameterTags(text)).toBe("Stray content.\n\nAfter.");
+  });
+
+  it("strips <scratchpad> blocks", () => {
+    const text = `<scratchpad>internal notes</scratchpad>\nFinal answer.`;
+    expect(stripParameterTags(text)).toBe("Final answer.");
+  });
+
+  it("case-insensitive on thinking/scratchpad tags", () => {
+    const text = `<Thinking>foo</Thinking>\n<SCRATCHPAD>bar</SCRATCHPAD>\nClean.`;
+    expect(stripParameterTags(text)).toBe("Clean.");
+  });
+
   // ── Label truncation ────────────────────────────────
 
   it("truncates very long labels", () => {


### PR DESCRIPTION
Closes #467. See commit 8d047aff.