### PR TITLE
fix(#469): skip AI curriculum generation when modulesAuthored=true

### DIFF
--- a/apps/admin/lib/jobs/auto-trigger.ts
+++ b/apps/admin/lib/jobs/auto-trigger.ts
@@ -56,6 +56,27 @@ export async function checkAutoTriggerCurriculum(
     return null; // Nothing to generate from
   }
 
+  // 3b. #469 — skip auto-trigger when the playbook has authored modules.
+  // applyProjection() (run from create_course + republish) owns the
+  // CurriculumModule write path for authored catalogues. Firing the LLM
+  // generator here would compete with that path and produce spurious
+  // modules from QUESTION_BANK assertions.
+  const pbSubject = await prisma.playbookSubject.findFirst({
+    where: { subjectId },
+    orderBy: { createdAt: "asc" },
+    select: { playbookId: true, playbook: { select: { config: true } } },
+  });
+  if (pbSubject?.playbook?.config) {
+    const pbConfig = pbSubject.playbook.config as Record<string, unknown>;
+    if (pbConfig.modulesAuthored === true) {
+      console.log(
+        `[auto-trigger] Skipping curriculum generation — playbook ${pbSubject.playbookId} has authored modules. ` +
+        `applyProjection() owns the CurriculumModule write path for this playbook.`,
+      );
+      return null;
+    }
+  }
+
   // 4. Look up subject name
   const subject = await prisma.subject.findUnique({
     where: { id: subjectId },

--- a/apps/admin/lib/jobs/curriculum-runner.ts
+++ b/apps/admin/lib/jobs/curriculum-runner.ts
@@ -100,15 +100,46 @@ async function runCurriculumGeneration(
   const assertionIdByIndexObj: Record<string, string> = {};
   assertions.forEach((a, i) => { assertionIdByIndexObj[String(i + 1)] = a.id; });
 
-  // Prefer playbook.config.subjectDiscipline over subject.name for AI prompt
+  // Prefer playbook.config.subjectDiscipline over subject.name for AI prompt.
+  // ALSO: #469 — short-circuit when the playbook has authored modules. The
+  // wizard's applyProjection() path (via syncAuthoredModulesToCurriculum) is
+  // the correct write path for authored catalogues; the LLM generator would
+  // produce spurious clusters from QUESTION_BANK assertions instead.
   let disciplineName = subjectName;
+  let modulesAuthored = false;
+  let playbookId: string | undefined;
   const pbSubject = await prisma.playbookSubject.findFirst({
     where: { subjectId },
-    select: { playbook: { select: { config: true } } },
+    orderBy: { createdAt: "asc" },
+    select: { playbookId: true, playbook: { select: { config: true } } },
   });
   if (pbSubject?.playbook?.config) {
     const pbConfig = pbSubject.playbook.config as Record<string, unknown>;
     if (pbConfig.subjectDiscipline) disciplineName = pbConfig.subjectDiscipline as string;
+    modulesAuthored = pbConfig.modulesAuthored === true;
+    playbookId = pbSubject.playbookId;
+  }
+
+  if (modulesAuthored) {
+    console.log(
+      `[curriculum-runner] Skipping AI generation — authored modules present on playbook ${playbookId}. ` +
+      `applyProjection() owns the CurriculumModule write path for this playbook.`,
+    );
+    await updateTaskProgress(taskId, {
+      currentStep: 3,
+      context: {
+        outputKind: "authored-passthrough",
+        persisted: false,
+        persistedAt: null,
+        playbookId,
+        summary: {
+          subject: { id: subjectId, name: subjectName },
+          reason: "Playbook.config.modulesAuthored === true — AI generation skipped",
+        },
+      },
+    });
+    await completeTask(taskId);
+    return;
   }
 
   const result = await extractCurriculumFromAssertions(

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.308",
+  "version": "0.7.309",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/auto-trigger-modules-authored.test.ts
+++ b/apps/admin/tests/lib/auto-trigger-modules-authored.test.ts
@@ -1,0 +1,84 @@
+/**
+ * #469 — auto-trigger.ts modulesAuthored guard.
+ *
+ * checkAutoTriggerCurriculum() must NOT fire startCurriculumGeneration
+ * when the playbook attached to the subject has authored modules. The
+ * wizard's applyProjection() path is the canonical write path for
+ * authored catalogues.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  $queryRaw: vi.fn().mockResolvedValue([{ count: BigInt(0) }]),
+  contentAssertion: { count: vi.fn().mockResolvedValue(1) },
+  playbookSubject: { findFirst: vi.fn() },
+  subject: { findUnique: vi.fn().mockResolvedValue({ name: "Test Subject" }) },
+}));
+
+const mockStartCurriculumGeneration = vi.hoisted(() => vi.fn().mockResolvedValue("task-auto"));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/jobs/curriculum-runner", () => ({
+  startCurriculumGeneration: (...args: unknown[]) => mockStartCurriculumGeneration(...args),
+}));
+
+import { checkAutoTriggerCurriculum } from "@/lib/jobs/auto-trigger";
+
+describe("auto-trigger modulesAuthored guard (#469)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.$queryRaw.mockResolvedValue([{ count: BigInt(0) }]);
+    mockPrisma.contentAssertion.count.mockResolvedValue(1);
+    mockPrisma.subject.findUnique.mockResolvedValue({ name: "Test Subject" });
+  });
+
+  it("returns null when playbook.config.modulesAuthored === true", async () => {
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue({
+      playbookId: "pb-authored",
+      playbook: { config: { modulesAuthored: true } },
+    });
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBeNull();
+    expect(mockStartCurriculumGeneration).not.toHaveBeenCalled();
+  });
+
+  it("fires curriculum generation when modulesAuthored === false", async () => {
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue({
+      playbookId: "pb-1",
+      playbook: { config: { modulesAuthored: false } },
+    });
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBe("task-auto");
+    expect(mockStartCurriculumGeneration).toHaveBeenCalledWith("sub-1", "Test Subject", "user-1");
+  });
+
+  it("fires curriculum generation when no playbook is linked", async () => {
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue(null);
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBe("task-auto");
+    expect(mockStartCurriculumGeneration).toHaveBeenCalled();
+  });
+
+  it("fires curriculum generation when modulesAuthored is undefined (legacy)", async () => {
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue({
+      playbookId: "pb-legacy",
+      playbook: { config: { subjectDiscipline: "Maths" } },
+    });
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBe("task-auto");
+    expect(mockStartCurriculumGeneration).toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/curriculum-runner-modules-authored.test.ts
+++ b/apps/admin/tests/lib/curriculum-runner-modules-authored.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #469 — curriculum-runner.ts modulesAuthored guard.
+ *
+ * When the playbook attached to the subject declares
+ * `Playbook.config.modulesAuthored === true`, the runner must NOT call
+ * the LLM curriculum generator. The wizard's applyProjection() path
+ * (via syncAuthoredModulesToCurriculum) is the correct write path for
+ * authored catalogues; running the LLM here would produce spurious
+ * topic-frame clusters from QUESTION_BANK assertions instead.
+ *
+ * Live IELTS wizard run 2026-05-18 produced 11 modules instead of the
+ * 4 authored modules because this guard was missing.
+ *
+ * This file is named distinctly from `curriculum-runner.test.ts` (which
+ * is in the vitest test-debt exclude list at vitest.config.ts:50).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  subject: { findUnique: vi.fn() },
+  subjectSource: { findMany: vi.fn() },
+  contentAssertion: { findMany: vi.fn() },
+  playbookSubject: { findFirst: vi.fn() },
+  userTask: { update: vi.fn() },
+}));
+
+const mockStartTaskTracking = vi.hoisted(() => vi.fn().mockResolvedValue("task-469"));
+const mockUpdateTaskProgress = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockCompleteTask = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockFailTask = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockExtractCurriculum = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/ai/task-guidance", () => ({
+  startTaskTracking: (...args: unknown[]) => mockStartTaskTracking(...args),
+  updateTaskProgress: (...args: unknown[]) => mockUpdateTaskProgress(...args),
+  completeTask: (...args: unknown[]) => mockCompleteTask(...args),
+  failTask: (...args: unknown[]) => mockFailTask(...args),
+}));
+
+vi.mock("@/lib/content-trust/extract-curriculum", () => ({
+  extractCurriculumFromAssertions: (...args: unknown[]) => mockExtractCurriculum(...args),
+}));
+
+import { startCurriculumGeneration } from "@/lib/jobs/curriculum-runner";
+
+async function flushMicrotasks() {
+  await new Promise((r) => setTimeout(r, 50));
+}
+
+function setupAssertionsLoaded() {
+  mockPrisma.subject.findUnique.mockResolvedValue({
+    id: "sub-1",
+    qualificationRef: null,
+  });
+  mockPrisma.subjectSource.findMany.mockResolvedValue([{ sourceId: "src-1" }]);
+  mockPrisma.contentAssertion.findMany.mockResolvedValue([
+    { id: "a1", assertion: "Test assertion", category: "fact", chapter: null, section: null, tags: [] },
+  ]);
+}
+
+describe("curriculum-runner modulesAuthored guard (#469)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExtractCurriculum.mockResolvedValue({ ok: true, modules: [{ title: "M" }], warnings: [] });
+  });
+
+  it("skips AI generation when playbook.config.modulesAuthored === true", async () => {
+    setupAssertionsLoaded();
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue({
+      playbookId: "pb-authored",
+      playbook: { config: { modulesAuthored: true, subjectDiscipline: "IELTS Speaking" } },
+    });
+
+    await startCurriculumGeneration("sub-1", "IELTS Speaking Practice", "user-1");
+    await flushMicrotasks();
+
+    expect(mockExtractCurriculum).not.toHaveBeenCalled();
+    expect(mockCompleteTask).toHaveBeenCalledWith("task-469");
+    expect(mockUpdateTaskProgress).toHaveBeenLastCalledWith("task-469", expect.objectContaining({
+      context: expect.objectContaining({
+        outputKind: "authored-passthrough",
+        persisted: false,
+        playbookId: "pb-authored",
+      }),
+    }));
+  });
+
+  it("runs AI generation when modulesAuthored === false", async () => {
+    setupAssertionsLoaded();
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue({
+      playbookId: "pb-1",
+      playbook: { config: { modulesAuthored: false } },
+    });
+
+    await startCurriculumGeneration("sub-1", "Food Safety L2", "user-1");
+    await flushMicrotasks();
+
+    expect(mockExtractCurriculum).toHaveBeenCalled();
+  });
+
+  it("runs AI generation when no playbook is linked to subject", async () => {
+    setupAssertionsLoaded();
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue(null);
+
+    await startCurriculumGeneration("sub-1", "Untitled", "user-1");
+    await flushMicrotasks();
+
+    expect(mockExtractCurriculum).toHaveBeenCalled();
+  });
+
+  it("runs AI generation when modulesAuthored is undefined (legacy playbooks)", async () => {
+    setupAssertionsLoaded();
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue({
+      playbookId: "pb-legacy",
+      playbook: { config: { subjectDiscipline: "Mathematics" } },
+    });
+
+    await startCurriculumGeneration("sub-1", "Mathematics", "user-1");
+    await flushMicrotasks();
+
+    expect(mockExtractCurriculum).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #469. See commit 04d8da2a.