### PR TITLE
fix(#476): skip auto-trigger when COURSE_REFERENCE_CANONICAL declares Modules authored

### DIFF
--- a/apps/admin/lib/jobs/auto-trigger.ts
+++ b/apps/admin/lib/jobs/auto-trigger.ts
@@ -8,6 +8,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { startCurriculumGeneration } from "./curriculum-runner";
+import { detectAuthoredModules } from "@/lib/wizard/detect-authored-modules";
 
 /**
  * Check if all extractions for a subject are done and auto-trigger
@@ -72,6 +73,41 @@ export async function checkAutoTriggerCurriculum(
       console.log(
         `[auto-trigger] Skipping curriculum generation — playbook ${pbSubject.playbookId} has authored modules. ` +
         `applyProjection() owns the CurriculumModule write path for this playbook.`,
+      );
+      return null;
+    }
+  }
+
+  // 3c. #476 — extraction completes BEFORE create_course, so #469's playbook
+  // lookup returns null and the LLM runner wins the race against the doc-side
+  // applyProjection. Detect the "Modules authored: Yes" declaration directly
+  // from the COURSE_REFERENCE_CANONICAL source's textSample (first ~1000 chars,
+  // where the canonical template's `## Course Configuration` preamble lives).
+  // detectAuthoredModules is pure regex, stateless, no AI call.
+  const canonicalSources = await prisma.subjectSource.findMany({
+    where: {
+      subjectId,
+      source: {
+        documentType: { in: ["COURSE_REFERENCE_CANONICAL", "COURSE_REFERENCE"] },
+        textSample: { not: null },
+      },
+    },
+    select: {
+      source: { select: { id: true, slug: true, textSample: true } },
+    },
+  });
+  for (const { source } of canonicalSources) {
+    if (!source.textSample) continue;
+    const detected = detectAuthoredModules(source.textSample);
+    // Use the header flag directly — table-row parse failures are a
+    // create_course-time concern, not a reason to fire the LLM generator.
+    // Once the educator declares "Modules authored: Yes" the runner must
+    // step out of the way.
+    if (detected.modulesAuthored === true) {
+      console.log(
+        `[auto-trigger] Skipping curriculum generation — source ${source.slug} declares ` +
+        `**Modules authored: Yes** (parsed ${detected.modules.length} module(s)). ` +
+        `applyProjection() will write the authored catalogue at create_course time.`,
       );
       return null;
     }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.311",
+  "version": "0.7.312",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/auto-trigger-modules-authored.test.ts
+++ b/apps/admin/tests/lib/auto-trigger-modules-authored.test.ts
@@ -13,6 +13,7 @@ const mockPrisma = vi.hoisted(() => ({
   $queryRaw: vi.fn().mockResolvedValue([{ count: BigInt(0) }]),
   contentAssertion: { count: vi.fn().mockResolvedValue(1) },
   playbookSubject: { findFirst: vi.fn() },
+  subjectSource: { findMany: vi.fn().mockResolvedValue([]) },
   subject: { findUnique: vi.fn().mockResolvedValue({ name: "Test Subject" }) },
 }));
 

--- a/apps/admin/tests/lib/auto-trigger-pre-create-modules-authored.test.ts
+++ b/apps/admin/tests/lib/auto-trigger-pre-create-modules-authored.test.ts
@@ -1,0 +1,150 @@
+/**
+ * #476 — auto-trigger.ts pre-create_course modulesAuthored guard.
+ *
+ * Extraction completes before create_course, so #469's playbook lookup
+ * returns null and the LLM runner fires anyway. This guard reads the
+ * "Modules authored: Yes" declaration directly from the COURSE_REFERENCE_
+ * CANONICAL source's textSample, BEFORE any playbook exists.
+ *
+ * Live IELTS run 2026-05-18 produced 11 spurious modules because of this
+ * race — the LLM curriculum landed on the auto-created ESOL subject and
+ * drove the tutor to lecture about exam format instead of running practice.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  $queryRaw: vi.fn().mockResolvedValue([{ count: BigInt(0) }]),
+  contentAssertion: { count: vi.fn().mockResolvedValue(1) },
+  playbookSubject: { findFirst: vi.fn().mockResolvedValue(null) },
+  subjectSource: { findMany: vi.fn().mockResolvedValue([]) },
+  subject: { findUnique: vi.fn().mockResolvedValue({ name: "Test Subject" }) },
+}));
+
+const mockStartCurriculumGeneration = vi.hoisted(() => vi.fn().mockResolvedValue("task-auto"));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/jobs/curriculum-runner", () => ({
+  startCurriculumGeneration: (...args: unknown[]) => mockStartCurriculumGeneration(...args),
+}));
+
+import { checkAutoTriggerCurriculum } from "@/lib/jobs/auto-trigger";
+
+const SAMPLE_WITH_AUTHORED = `# IELTS Speaking Practice — Course Reference
+
+## Course Configuration
+
+**Modules authored:** Yes
+
+## Modules
+
+### Module Catalogue
+
+| id | title | outcomesPrimary |
+| --- | --- | --- |
+| baseline | Part 1: Familiar Topics | OUT-01, OUT-02 |
+| part2 | Part 2: Long Turn | OUT-03 |
+`;
+
+const SAMPLE_NO_AUTHORED = `# IELTS Speaking Practice — Course Reference
+
+## Course Configuration
+
+**Modules authored:** No
+
+This course uses AI-generated module structure.
+`;
+
+const SAMPLE_PARTIAL = `# Some Course
+
+## Course Configuration
+
+**Modules authored:** Partial
+
+## Modules
+
+### Module Catalogue
+
+| id | title | outcomesPrimary |
+| --- | --- | --- |
+| mod-1 | Module One | OUT-01 |
+`;
+
+describe("auto-trigger pre-create_course modulesAuthored guard (#476)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.$queryRaw.mockResolvedValue([{ count: BigInt(0) }]);
+    mockPrisma.contentAssertion.count.mockResolvedValue(1);
+    mockPrisma.subject.findUnique.mockResolvedValue({ name: "IELTS Speaking Practice" });
+    mockPrisma.playbookSubject.findFirst.mockResolvedValue(null); // no playbook yet
+  });
+
+  it("returns null when source textSample declares Modules authored: Yes", async () => {
+    mockPrisma.subjectSource.findMany.mockResolvedValue([
+      { source: { id: "src-1", slug: "course-ref", textSample: SAMPLE_WITH_AUTHORED } },
+    ]);
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBeNull();
+    expect(mockStartCurriculumGeneration).not.toHaveBeenCalled();
+  });
+
+  it("returns null when 'Partial' is declared with at least one module", async () => {
+    mockPrisma.subjectSource.findMany.mockResolvedValue([
+      { source: { id: "src-1", slug: "course-ref", textSample: SAMPLE_PARTIAL } },
+    ]);
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBeNull();
+    expect(mockStartCurriculumGeneration).not.toHaveBeenCalled();
+  });
+
+  it("fires curriculum generation when source textSample declares Modules authored: No", async () => {
+    mockPrisma.subjectSource.findMany.mockResolvedValue([
+      { source: { id: "src-1", slug: "course-ref", textSample: SAMPLE_NO_AUTHORED } },
+    ]);
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBe("task-auto");
+    expect(mockStartCurriculumGeneration).toHaveBeenCalled();
+  });
+
+  it("fires curriculum generation when no COURSE_REFERENCE source exists", async () => {
+    mockPrisma.subjectSource.findMany.mockResolvedValue([]);
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBe("task-auto");
+    expect(mockStartCurriculumGeneration).toHaveBeenCalled();
+  });
+
+  it("returns null when ANY linked canonical source declares authored modules (multi-source)", async () => {
+    mockPrisma.subjectSource.findMany.mockResolvedValue([
+      { source: { id: "src-1", slug: "older-course-ref", textSample: SAMPLE_NO_AUTHORED } },
+      { source: { id: "src-2", slug: "course-ref", textSample: SAMPLE_WITH_AUTHORED } },
+    ]);
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBeNull();
+    expect(mockStartCurriculumGeneration).not.toHaveBeenCalled();
+  });
+
+  it("skips sources with null textSample (no crash, no false skip)", async () => {
+    mockPrisma.subjectSource.findMany.mockResolvedValue([
+      { source: { id: "src-1", slug: "no-sample", textSample: null } },
+    ]);
+
+    const result = await checkAutoTriggerCurriculum("sub-1", "user-1");
+
+    expect(result).toBe("task-auto");
+    expect(mockStartCurriculumGeneration).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #476. Upstream guard for the race condition #469 didn't catch.