### PR TITLE
fix(#478): boundary-guard syncPlaybookSources to stop subject content leak

### DIFF
--- a/apps/admin/lib/knowledge/domain-sources.ts
+++ b/apps/admin/lib/knowledge/domain-sources.ts
@@ -20,10 +20,38 @@ import { isStudentVisibleDefault } from "@/lib/doc-type-icons";
  * Sync PlaybookSource rows for a playbook from its SubjectSource chain.
  * Call after creating/updating PlaybookSubject or SubjectSource links.
  * Idempotent — upserts with ON CONFLICT DO NOTHING semantics.
+ *
+ * Inheritance boundary (#478): only SubjectSource rows created AFTER the
+ * playbook are synced by default. Without this guard, the wizard linking a
+ * new course to an existing Subject (e.g. shared "ESOL" subject) silently
+ * propagates every historical SubjectSource into the new playbook —
+ * including stale rows from prior experiments. Sources attached to the
+ * subject as part of (or after) course creation cross the boundary and
+ * sync as intended.
+ *
+ * For deliberate re-sync of all historical subject content (e.g. backfill
+ * scripts, admin tooling), pass `{ includePreExisting: true }`.
  */
-export async function syncPlaybookSources(playbookId: string, subjectId: string): Promise<number> {
+export async function syncPlaybookSources(
+  playbookId: string,
+  subjectId: string,
+  opts?: { includePreExisting?: boolean },
+): Promise<number> {
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { createdAt: true },
+  });
+  if (!playbook) {
+    console.warn(`[syncPlaybookSources] playbook ${playbookId} not found — nothing synced`);
+    return 0;
+  }
+
+  const where = opts?.includePreExisting
+    ? { subjectId }
+    : { subjectId, createdAt: { gte: playbook.createdAt } };
+
   const subjectSources = await prisma.subjectSource.findMany({
-    where: { subjectId },
+    where,
     select: { sourceId: true, sortOrder: true, tags: true, trustLevelOverride: true },
   });
 

--- a/apps/admin/tests/lib/knowledge/sync-playbook-sources.test.ts
+++ b/apps/admin/tests/lib/knowledge/sync-playbook-sources.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for syncPlaybookSources inheritance boundary (#478).
+ *
+ * Background: the wizard creating a new course can link the playbook to an
+ * existing Subject (e.g. a shared "ESOL" subject). Before #478,
+ * syncPlaybookSources copied EVERY SubjectSource row on that subject into
+ * the new playbook's PlaybookSource rows — including stale content from
+ * prior wizard experiments. The reported incident: a freshly-created IELTS
+ * course inherited an old course-ref attached to ESOL by an unrelated run.
+ *
+ * The fix: by default, only SubjectSource rows created AFTER playbook.createdAt
+ * are synced. `{ includePreExisting: true }` opts out for backfill scripts.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  playbook: {
+    findUnique: vi.fn(),
+  },
+  subjectSource: {
+    findMany: vi.fn(),
+  },
+  playbookSource: {
+    upsert: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+import { syncPlaybookSources } from "@/lib/knowledge/domain-sources";
+
+describe("syncPlaybookSources — inheritance boundary (#478)", () => {
+  const PLAYBOOK_ID = "pb-new-course";
+  const SUBJECT_ID = "subj-shared";
+  const PLAYBOOK_CREATED_AT = new Date("2026-05-18T15:49:00.000Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.playbook.findUnique.mockResolvedValue({ createdAt: PLAYBOOK_CREATED_AT });
+    mockPrisma.subjectSource.findMany.mockResolvedValue([]);
+  });
+
+  it("default behaviour: only syncs SubjectSource rows created at-or-after playbook.createdAt", async () => {
+    await syncPlaybookSources(PLAYBOOK_ID, SUBJECT_ID);
+
+    expect(mockPrisma.subjectSource.findMany).toHaveBeenCalledTimes(1);
+    const call = mockPrisma.subjectSource.findMany.mock.calls[0][0];
+    expect(call.where).toEqual({
+      subjectId: SUBJECT_ID,
+      createdAt: { gte: PLAYBOOK_CREATED_AT },
+    });
+  });
+
+  it("includePreExisting=true: lifts the boundary — syncs every SubjectSource on the subject", async () => {
+    await syncPlaybookSources(PLAYBOOK_ID, SUBJECT_ID, { includePreExisting: true });
+
+    expect(mockPrisma.subjectSource.findMany).toHaveBeenCalledTimes(1);
+    const call = mockPrisma.subjectSource.findMany.mock.calls[0][0];
+    expect(call.where).toEqual({ subjectId: SUBJECT_ID });
+    expect(call.where.createdAt).toBeUndefined();
+  });
+
+  it("returns 0 and skips upserts when playbook does not exist", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+
+    const synced = await syncPlaybookSources(PLAYBOOK_ID, SUBJECT_ID);
+
+    expect(synced).toBe(0);
+    expect(mockPrisma.subjectSource.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.playbookSource.upsert).not.toHaveBeenCalled();
+  });
+
+  it("upserts one PlaybookSource per returned SubjectSource (preserving sortOrder/tags/trustLevelOverride)", async () => {
+    mockPrisma.subjectSource.findMany.mockResolvedValue([
+      { sourceId: "src-new-1", sortOrder: 0, tags: ["content"], trustLevelOverride: null },
+      { sourceId: "src-new-2", sortOrder: 1, tags: ["content", "syllabus"], trustLevelOverride: "VERIFIED" },
+    ]);
+
+    const synced = await syncPlaybookSources(PLAYBOOK_ID, SUBJECT_ID);
+
+    expect(synced).toBe(2);
+    expect(mockPrisma.playbookSource.upsert).toHaveBeenCalledTimes(2);
+    const firstCall = mockPrisma.playbookSource.upsert.mock.calls[0][0];
+    expect(firstCall.create).toEqual({
+      playbookId: PLAYBOOK_ID,
+      sourceId: "src-new-1",
+      sortOrder: 0,
+      tags: ["content"],
+      trustLevelOverride: null,
+    });
+    expect(firstCall.update).toEqual({});
+  });
+
+  it("ESOL leak regression: pre-existing SubjectSource rows do NOT propagate to a fresh playbook", async () => {
+    // Prisma applies the createdAt filter at the DB level, so the mock just
+    // verifies the filter is constructed — and that no pre-existing rows
+    // sneak through under the default opts.
+    mockPrisma.subjectSource.findMany.mockImplementation(async ({ where }: any) => {
+      const all = [
+        // Pre-existing row from a prior wizard experiment (stale ESOL course-ref)
+        { sourceId: "src-stale-courseref", createdAt: new Date("2026-05-18T15:20:00.000Z"), sortOrder: 0, tags: ["content"], trustLevelOverride: null },
+        // Fresh row attached as part of this wizard run
+        { sourceId: "src-fresh-question-bank", createdAt: new Date("2026-05-18T15:49:30.000Z"), sortOrder: 0, tags: ["content"], trustLevelOverride: null },
+      ];
+      const gte = where?.createdAt?.gte;
+      return gte ? all.filter((r) => r.createdAt.getTime() >= gte.getTime()) : all;
+    });
+
+    const synced = await syncPlaybookSources(PLAYBOOK_ID, SUBJECT_ID);
+
+    expect(synced).toBe(1);
+    const syncedSourceIds = mockPrisma.playbookSource.upsert.mock.calls.map(
+      (call) => call[0].create.sourceId,
+    );
+    expect(syncedSourceIds).toEqual(["src-fresh-question-bank"]);
+    expect(syncedSourceIds).not.toContain("src-stale-courseref");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the immediate **write-side** leak vector for the Subject taxonomy-vs-content split (#478). When the wizard linked a new course to a shared existing Subject (e.g. ESOL), \`syncPlaybookSources\` silently copied EVERY historical SubjectSource row into the new PlaybookSource — including stale rows from prior wizard experiments. Reported via the IELTS Speaking incident.

**Fix:** By default, only sync SubjectSource rows created at-or-after the playbook's \`createdAt\`. Sources attached as part of (or after) course creation cross the boundary as intended; pre-existing rows do not. Added \`{ includePreExisting: true }\` opt-out for deliberate backfill / admin tooling.

## What this does NOT solve

This is a partial fix for #478 — the multi-sprint deprecation track for the read-side and JSON-config leaks lives in child stories #481-#486 (groomed + ready for sprint).

## Test plan

- [x] 5 unit tests pass (\`tests/lib/knowledge/sync-playbook-sources.test.ts\`): default boundary, opt-out, missing playbook, upsert fidelity, ESOL regression
- [x] Related test \`tests/lib/content-trust/playbook-source-isolation.test.ts\` still passes
- [x] Type-check clean on changed files
- [ ] DEV smoke: create a new course via wizard against a shared Subject, confirm no historical sources inherited

🤖 Generated with [Claude Code](https://claude.com/claude-code)