### PR TITLE
fix(#486): replace subjectId with playbookId in course-readiness

### DIFF
--- a/apps/admin/app/api/domains/[domainId]/course-readiness/route.ts
+++ b/apps/admin/app/api/domains/[domainId]/course-readiness/route.ts
@@ -16,7 +16,8 @@ export const runtime = "nodejs";
  * @pathParam domainId string - The domain ID to check readiness for
  * @queryParam callerId string - Test caller ID (for prompt composition check)
  * @queryParam sourceId string - Content source ID (for assertion review link)
- * @queryParam subjectId string - Subject ID (for lesson plan link)
+ * @queryParam playbookId string - Playbook (course) ID — for lesson plan link
+ * @queryParam subjectId string - DEPRECATED (#486): historical Subject-scoped link. Accepted with a server log; remove caller use in favour of playbookId.
  * @response 200 { ok: true, domainId, ready, score, level, checks[], criticalPassed, criticalTotal, recommendedPassed, recommendedTotal }
  * @response 500 { ok: false, error: string }
  */
@@ -32,7 +33,13 @@ export async function GET(
     const url = new URL(request.url);
     const callerId = url.searchParams.get("callerId") || undefined;
     const sourceId = url.searchParams.get("sourceId") || undefined;
-    const subjectId = url.searchParams.get("subjectId") || undefined;
+    const playbookId = url.searchParams.get("playbookId") || undefined;
+    const subjectIdLegacy = url.searchParams.get("subjectId") || undefined;
+    if (subjectIdLegacy) {
+      console.warn(
+        `[course-readiness] deprecated subjectId query param received (#486) — caller should pass playbookId instead. domainId=${domainId} subjectId=${subjectIdLegacy}`,
+      );
+    }
 
     // Detect domain kind to select the right readiness spec
     const domain = await prisma.domain.findUnique({
@@ -44,7 +51,7 @@ export async function GET(
       : config.specs.courseReady;
 
     const result = await checkCourseReadiness(
-      { domainId, callerId, sourceId, subjectId },
+      { domainId, callerId, sourceId, playbookId, subjectId: subjectIdLegacy },
       specSlug,
     );
 

--- a/apps/admin/app/x/quick-launch/page.tsx
+++ b/apps/admin/app/x/quick-launch/page.tsx
@@ -706,7 +706,7 @@ export default function QuickLaunchPage() {
     setChecksLoading(true);
     try {
       const params = new URLSearchParams({ callerId: result.callerId });
-      if (result.subjectId) params.set("subjectId", result.subjectId);
+      if (result.playbookId) params.set("playbookId", result.playbookId);
       const res = await fetch(`/api/domains/${result.domainId}/course-readiness?${params}`);
       const data = await res.json();
       if (data.ok) {

--- a/apps/admin/docs-archive/bdd-specs/COURSE-READY-001-course-readiness.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/COURSE-READY-001-course-readiness.spec.json
@@ -50,7 +50,7 @@
             "description": "Check the generated lesson plan — session types, order, and module mapping",
             "severity": "recommended",
             "query": "lesson_plan",
-            "fixAction": { "label": "Review Plan", "hrefTemplate": "/x/subjects/${subjectId}" }
+            "fixAction": { "label": "Review Plan", "hrefTemplate": "/x/courses/${playbookId}?tab=curriculum" }
           },
           {
             "id": "onboarding_configured",

--- a/apps/admin/lib/domain/course-readiness.ts
+++ b/apps/admin/lib/domain/course-readiness.ts
@@ -55,8 +55,10 @@ export interface CourseReadinessContext {
   domainId: string;
   callerId?: string;
   sourceId?: string;
-  subjectId?: string;
+  playbookId?: string;
   curriculumId?: string;
+  /** @deprecated #486 — use playbookId. Retained to avoid runtime breakage during the dual-read window; do not add new callers. */
+  subjectId?: string;
 }
 
 // =====================================================
@@ -104,7 +106,7 @@ export async function loadCourseReadinessChecks(specSlug?: string): Promise<Cour
       description: "Check the generated curriculum structure",
       severity: "recommended",
       query: "lesson_plan",
-      fixAction: { label: "Review Plan", hrefTemplate: "/x/subjects?id=${subjectId}" },
+      fixAction: { label: "Review Plan", hrefTemplate: "/x/courses/${playbookId}?tab=curriculum" },
     },
     {
       id: "onboarding_configured",


### PR DESCRIPTION
Closes #486. Spec-config JSON-encoded Subject ref + route + UI caller updated.