### PR TITLE
fix(#482): gate SectionDataLoader Subject fallback behind feature flag

### DIFF
--- a/apps/admin/lib/config.ts
+++ b/apps/admin/lib/config.ts
@@ -209,6 +209,18 @@ export const config = {
     get authoredModulesEnabled(): boolean {
       return optionalBool("AUTHORED_MODULES_ENABLED", false);
     },
+    /**
+     * Legacy Subject-chain fallback in SectionDataLoader.resolveContentScope
+     * (#482). When true, retains the pre-#478 behaviour: if PlaybookSource
+     * is empty, fall through to PlaybookSubject → Subject → SubjectSource,
+     * and then to a domain-wide SubjectDomain fallback. When false (default,
+     * #482-onwards), content scope resolves strictly via PlaybookSource —
+     * empty PlaybookSource means empty scope. Kept as a kill switch for one
+     * sprint in case the #481 backfill missed any legacy course.
+     */
+    get contentScopeSubjectFallbackEnabled(): boolean {
+      return optionalBool("CONTENT_SCOPE_SUBJECT_FALLBACK_ENABLED", false);
+    },
   },
 
   // ---------------------------------------------------------------------------

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -278,95 +278,118 @@ async function resolveContentScope(callerId: string): Promise<ContentScope> {
       };
     }
 
-    // FALLBACK: Legacy Subject chain (pre-migration courses without PlaybookSource)
-    const sourceSelect = {
-      select: {
-        id: true,
-        sourceId: true,
-        sortOrder: true,
-        tags: true,
-        source: { select: { documentType: true } },
-      },
-      orderBy: { sortOrder: "asc" as const },
-    } as const;
+    // LEGACY FALLBACK: Subject chain (pre-#478 courses without PlaybookSource).
+    // Disabled by default since #482. Kill switch: CONTENT_SCOPE_SUBJECT_FALLBACK_ENABLED=true.
+    // Backfill via scripts/backfill-playbook-sources-from-subjects.ts (#481).
+    if (config.features.contentScopeSubjectFallbackEnabled) {
+      const sourceSelect = {
+        select: {
+          id: true,
+          sourceId: true,
+          sortOrder: true,
+          tags: true,
+          source: { select: { documentType: true } },
+        },
+        orderBy: { sortOrder: "asc" as const },
+      } as const;
 
-    const legacySubjects = await prisma.playbookSubject.findMany({
-      where: { playbookId: { in: playbookIds } },
+      const legacySubjects = await prisma.playbookSubject.findMany({
+        where: { playbookId: { in: playbookIds } },
+        select: {
+          subject: {
+            select: {
+              id: true,
+              teachingDepth: true,
+              sources: sourceSelect,
+            },
+          },
+        },
+      });
+
+      const seenLegacy = new Set<string>();
+      const subjects = legacySubjects
+        .filter((ps) => {
+          if (seenLegacy.has(ps.subject.id)) return false;
+          seenLegacy.add(ps.subject.id);
+          return true;
+        })
+        .map((ps) => ({
+          ...ps.subject,
+          sources: ps.subject.sources.map((s) => ({
+            subjectSourceId: s.id,
+            sourceId: s.sourceId,
+            documentType: s.source?.documentType ?? null,
+            sortOrder: s.sortOrder,
+            tags: s.tags,
+          })),
+        }));
+
+      if (subjects.length > 0) {
+        console.warn(
+          `[SectionDataLoader] legacy Subject-chain fallback fired for caller ${callerId} — #481 backfill missed this playbook set`,
+        );
+        return {
+          domainId: caller.domainId,
+          subjectIds: subjects.map((s) => s.id),
+          subjects,
+          scoped: true,
+        };
+      }
+    }
+  }
+
+  // LAST-RESORT FALLBACK: domain-wide via SubjectDomain — same flag gate (#482).
+  if (config.features.contentScopeSubjectFallbackEnabled) {
+    const subjectDomains = await prisma.subjectDomain.findMany({
+      where: { domainId: caller.domainId },
       select: {
         subject: {
           select: {
             id: true,
             teachingDepth: true,
-            sources: sourceSelect,
+            sources: {
+              select: {
+                id: true,
+                sourceId: true,
+                sortOrder: true,
+                tags: true,
+                source: { select: { documentType: true } },
+              },
+              orderBy: { sortOrder: "asc" },
+            },
           },
         },
       },
     });
 
-    const seenLegacy = new Set<string>();
-    const subjects = legacySubjects
-      .filter((ps) => {
-        if (seenLegacy.has(ps.subject.id)) return false;
-        seenLegacy.add(ps.subject.id);
-        return true;
-      })
-      .map((ps) => ({
-        ...ps.subject,
-        sources: ps.subject.sources.map((s) => ({
-          subjectSourceId: s.id,
-          sourceId: s.sourceId,
-          documentType: s.source?.documentType ?? null,
-          sortOrder: s.sortOrder,
-          tags: s.tags,
-        })),
-      }));
-
-    if (subjects.length > 0) {
+    if (subjectDomains.length > 0) {
+      console.warn(
+        `[SectionDataLoader] domain-wide Subject fallback fired for caller ${callerId} — no enrollments resolve to PlaybookSource`,
+      );
       return {
         domainId: caller.domainId,
-        subjectIds: subjects.map((s) => s.id),
-        subjects,
-        scoped: true,
+        subjectIds: subjectDomains.map((sd) => sd.subject.id),
+        subjects: subjectDomains.map((sd) => ({
+          ...sd.subject,
+          sources: sd.subject.sources.map((s) => ({
+            subjectSourceId: s.id,
+            sourceId: s.sourceId,
+            documentType: s.source?.documentType ?? null,
+            sortOrder: s.sortOrder,
+            tags: s.tags,
+          })),
+        })),
+        scoped: false,
       };
     }
   }
 
-  // Last resort: domain-wide (no enrollments, or enrollments have no subjects)
-  const subjectDomains = await prisma.subjectDomain.findMany({
-    where: { domainId: caller.domainId },
-    select: {
-      subject: {
-        select: {
-          id: true,
-          teachingDepth: true,
-          sources: {
-            select: {
-              id: true,
-              sourceId: true,
-              sortOrder: true,
-              tags: true,
-              source: { select: { documentType: true } },
-            },
-            orderBy: { sortOrder: "asc" },
-          },
-        },
-      },
-    },
-  });
-
+  // Default (post-#482): empty scope. Composition transforms see no subjects
+  // / no sources and produce empty sections — better than silent cross-course leak.
   return {
     domainId: caller.domainId,
-    subjectIds: subjectDomains.map((sd) => sd.subject.id),
-    subjects: subjectDomains.map((sd) => ({
-      ...sd.subject,
-      sources: sd.subject.sources.map((s) => ({
-        subjectSourceId: s.id,
-        sourceId: s.sourceId,
-        documentType: s.source?.documentType ?? null,
-        sortOrder: s.sortOrder,
-        tags: s.tags,
-      })),
-    })),
+    subjectIds: [],
+    subjects: [],
     scoped: false,
   };
 }


### PR DESCRIPTION
Closes #482. Default OFF (post-backfill). Loud warnings on flag-enabled hits.