### PR TITLE
feat(#500 PR-1): add Parameter.config JSON column for bandThresholds

### DIFF
--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -30,6 +30,33 @@
 export type SpecConfig = Record<string, any>;
 
 // ---------------------------------------------------------------------------
+// Parameter.config Json? fields (#500 — bands-as-thresholds)
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured config bag on the Parameter row.
+ *
+ * Lives in `Parameter.config` (Json?). Currently carries `bandThresholds`
+ * for SKILL parameters that wrap a graded rubric (IELTS Speaking bands,
+ * CEFR levels, NHS AfC bands, professional certification levels, etc.).
+ *
+ * `bandThresholds` keys the band number (typically 0–9 for IELTS, 1–6 for
+ * CEFR, etc.) to the descriptor text the LLM uses at MEASURE time to
+ * justify a per-call score. ONE Parameter per skill criterion; the bands
+ * are thresholds within that Parameter — never separate parameters.
+ *
+ * Optional. Skill parameters with no rubric (Secret Garden, Intro Psych
+ * style courses) leave it undefined; MEASURE prompt falls back to the
+ * tier descriptors inlined in the AnalysisAction.description.
+ */
+export interface ParameterConfig {
+  /** Per-band descriptor text. Key = band number; value = descriptor. */
+  bandThresholds?: Record<number, string>;
+  /** Future-proofing: arbitrary additional keys allowed. */
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
 // RewardScore Json? fields
 // ---------------------------------------------------------------------------
 

--- a/apps/admin/prisma/migrations/20260519_500_parameter_config/migration.sql
+++ b/apps/admin/prisma/migrations/20260519_500_parameter_config/migration.sql
@@ -1,0 +1,8 @@
+-- #500 PR-1: add structured config bag to Parameter
+-- Holds bandThresholds map (band number → descriptor text) for SKILL
+-- parameters that wrap a graded rubric (IELTS, CEFR, NHS AfC, etc.).
+-- Future-proofed as a JSON column so additional config keys can be added
+-- without further migrations. Pattern mirrors AnalysisSpec.config,
+-- Playbook.config, Goal.assessmentConfig. See lib/types/json-fields.ts::ParameterConfig.
+-- Nullable, no default — backfill is not required.
+ALTER TABLE "Parameter" ADD COLUMN IF NOT EXISTS "config" JSONB;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -302,6 +302,15 @@ model Parameter {
   aliases       String[]  @default([]) // Alternative names for this parameter
   defaultTarget Float     @default(0.5) // Default target value (0-1 scale)
 
+  // Structured config bag (#500 PR-1). Shape lives in
+  // lib/types/json-fields.ts::ParameterConfig. Current keys:
+  //   bandThresholds?: Record<number, string>  ← per-band descriptor text
+  //                                              for skill parameters that
+  //                                              wrap a graded rubric
+  //                                              (IELTS, CEFR, NHS AfC, etc.)
+  // Pattern mirrors AnalysisSpec.config / Playbook.config / Goal.assessmentConfig.
+  config Json?
+
   @@index([sourceFeatureSetId])
   @@index([isCanonical])
   @@index([deprecatedAt])


### PR DESCRIPTION
Part of #500. Schema migration only — no behaviour change. Subsequent PRs (PR-2 parser/prompt, PR-3 4-Parameter collapse, PR-4 backfill, PR-5 MEASURE runtime) depend on this. /vm-cpp required for deploy.