### PR TITLE
fix(#492 Slice 3.2): thin sibling modules in computeModuleProgress

### DIFF
--- a/apps/admin/evals/wizard/v5-skills-not-bands.yaml
+++ b/apps/admin/evals/wizard/v5-skills-not-bands.yaml
@@ -1,0 +1,132 @@
+description: "Wizard V5 — ONE skill per criterion (NOT one per band) for graded rubrics (#500 PR-2)"
+
+# Run with: npx promptfoo eval -c evals/wizard/v5-skills-not-bands.yaml --no-cache
+#
+# When the educator uploads an IELTS-style rubric (4 criteria × 10 bands = 40 rows),
+# the wizard AI MUST emit exactly 4 skills with `bands` populated — NEVER 40 skills.
+# The system-prompt rule lives in v5-system-prompt.ts §"Skills Framework" with
+# the critical "⚠️ CRITICAL — ONE skill per top-level criterion" callout.
+#
+# Regression target: the IELTS Speaking incident on 2026-05-19 where setupData.skillsFramework
+# arrived at the Launch step with 40 entries, one per assessor-rubric band row.
+
+prompts:
+  - id: v5-skills-not-bands-prompt
+    label: "V5 — skills framework rejects per-band entries"
+    raw: |
+      You are the HumanFirst Studio setup assistant.
+
+      ## How you communicate
+      - **Bold the opening concept of each sentence or bullet.**
+      - NEVER expose internal field names like `setupData.*`.
+
+      ## Skills Framework (next when graph suggests skillsFramework)
+      Ask: "What core skills are you developing in this course?"
+      For EACH skill (the **top-level capability** — e.g. "Fluency & Coherence", "Reading Comprehension", "Clinical Reasoning"), capture:
+      - **Name** and brief description
+      - **3 proficiency tiers**: Emerging (just starting), Developing (gaining confidence), Secure (mastered)
+      - **Optional `bands` map** — ONLY if the course uses a graded numeric rubric (IELTS bands 0–9, CEFR A1–C2, NHS AfC bands, professional certification levels). Record per-band descriptors keyed by band number.
+      Probe: "What does 'just starting' look like for [skill]? And when they're confident?"
+      Also ask: "How do you know a student is progressing?" (tracking dimensions for learner model)
+      **Minimum depth: 3 skills, all 3 tiers per skill. Probe until you reach this.**
+
+      ⚠️ **CRITICAL — ONE skill per top-level criterion, NOT one per band.**
+      If the uploaded docs contain a graded rubric (e.g. assessor-rubric.md with bands 0–9 for each criterion), the rubric's individual band rows are NOT separate skills. They are **measurements** on a single skill. A 4-criterion × 10-band IELTS rubric produces FOUR skills with `bands` populated — NEVER 40 skills. Treating each band row as a skill is the common failure mode — refuse to do it.
+
+      Save as: update_setup({ fields: { skillsFramework: [{ id: "SKILL-01", name: "Fluency & Coherence", description: "...", tiers: { emerging: "...", developing: "...", secure: "..." }, bands: { 0: "Does not attend", 1: "Speech is incoherent", 9: "Fluent with only occasional self-correction" } }] } })
+
+      ---
+      Setup state: {{setupState}}
+      Conversation so far: {{conversationContext}}
+      The educator says: {{userMessage}}
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 4000
+      tools:
+        - name: update_setup
+          description: "Save collected setup fields."
+          input_schema:
+            type: object
+            properties:
+              fields:
+                type: object
+                additionalProperties: true
+            required: [fields]
+
+tests:
+
+  # ── Test A — IELTS rubric pasted as user content → 4 skills, not 40 ──
+
+  - description: "Test A — IELTS-style rubric input produces 4 skills with bands, NOT 40 skills"
+    vars:
+      setupState: |
+        Course: IELTS Speaking Practice. Subject: ESOL. Audience: higher-ed.
+        Approach: socratic. Sessions: 12 × 20 min. Course-ref digest present
+        (51 assertions across 4 criteria with 10 bands each). skillsFramework: (unset).
+      conversationContext: |
+        Educator just uploaded an assessor-rubric document with band descriptors
+        for Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy,
+        and Pronunciation (4 criteria × 10 bands each = 40 rows). The graph
+        suggests skillsFramework is the next node to handle.
+      userMessage: |
+        Here's the rubric content extracted from the document:
+
+        ## RUB-FC: Fluency and Coherence — band descriptors
+        | 9 | Fluent with only very occasional repetition. |
+        | 8 | Fluent with only very occasional repetition. |
+        | 7 | Keeps going and produces long turns without noticeable effort. |
+        | 0 | Does not attend / does not complete. |
+
+        ## RUB-LR: Lexical Resource — band descriptors
+        | 9 | Total flexibility and precise use in all contexts. |
+        | 7 | Vocabulary resources flexibly used to discuss a variety of topics. |
+        | 0 | Does not attend / does not complete. |
+
+        ## RUB-GRA: Grammatical Range and Accuracy — band descriptors
+        | 9 | Full range of structures, naturally and appropriately. |
+        | 7 | Wide range of structures, frequent error-free sentences. |
+        | 0 | Does not attend / does not complete. |
+
+        ## RUB-P: Pronunciation — band descriptors
+        | 9 | Uses a full range of pronunciation features. |
+        | 7 | Pronunciation features are used effectively. |
+        | 0 | Does not attend / does not complete. |
+
+        Please populate the skills framework from this.
+    assert:
+      - type: llm-rubric
+        value: |
+          The response calls update_setup with `skillsFramework` containing EXACTLY 4 entries
+          (one per criterion: Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy,
+          Pronunciation) — NOT 40 entries (one per band row). Each skill MAY carry a `bands`
+          map with band-number → descriptor entries (e.g. `bands: { 9: "...", 0: "..." }`).
+          The response MUST NOT emit skills whose names start with "Band " (e.g. "Band 9 Fluency"
+          is the failure pattern — refuse). Each skill SHOULD have tiers (emerging/developing/secure)
+          summarising the bands.
+      - type: not-icontains
+        value: '"name": "Band '
+      - type: not-icontains
+        value: '"name":"Band '
+
+  # ── Test B — non-rubric course (no bands, just tiers) ──
+
+  - description: "Test B — non-rubric course produces skills with tiers only, no bands"
+    vars:
+      setupState: |
+        Course: Theme Comprehension. Subject: English Literature. Audience: primary.
+        Approach: socratic. Sessions: 5 × 15 min. skillsFramework: (unset).
+      conversationContext: |
+        No rubric uploaded. The graph suggests skillsFramework.
+      userMessage: |
+        The course develops three skills: theme identification, evidence selection,
+        and connecting themes across passages. Just three skills with descriptions of
+        what beginners, intermediate, and advanced learners look like.
+    assert:
+      - type: llm-rubric
+        value: |
+          The response calls update_setup with `skillsFramework` containing 3 entries,
+          each with `tiers` populated (emerging, developing, secure). Bands map is NOT
+          required (no graded rubric in this course); it may be absent or empty.
+          Each skill name is a top-level capability, NOT a band-level descriptor.

--- a/apps/admin/lib/chat/conversational-wizard-tools.ts
+++ b/apps/admin/lib/chat/conversational-wizard-tools.ts
@@ -28,7 +28,9 @@ export const CONVERSATIONAL_TOOLS: AITool[] = [
       "edgeCases, assessmentBoundaries. " +
       "progressionMode = 'ai-led' (scheduler picks each call) or 'learner-picks' (learner picks from a menu). " +
       "courseRefEnabled = set to true when user wants detailed teaching guide. " +
-      "skillsFramework = array of { id, name, description?, tiers: { emerging, developing, secure } }. " +
+      "skillsFramework = array of { id, name, description?, tiers: { emerging, developing, secure }, bands?: Record<number, string> }. " +
+      "ONE entry per top-level skill criterion, never one per band — see system prompt §Skills Framework. " +
+      "bands populated only when the course uses a numeric graded rubric (IELTS, CEFR, NHS). " +
       "teachingPrinciples = { corePrinciples: string[], sessionStructure?: { phases: [] }, techniquesBySkill?: [] }. " +
       "coursePhases = array of { name, sessions?, goal?, tutorBehaviour?: [], exitCriteria?: [], checkpoints?: [] }. " +
       "edgeCases = array of { scenario, response }. " +

--- a/apps/admin/lib/chat/v5-system-prompt.ts
+++ b/apps/admin/lib/chat/v5-system-prompt.ts
@@ -363,13 +363,18 @@ Save all pedagogy data via update_setup with the section key.
 
 ### Skills Framework (next when graph suggests skillsFramework)
 Ask: "What core skills are you developing in this course?"
-For EACH skill, capture:
+For EACH skill (the **top-level capability** — e.g. "Fluency & Coherence", "Reading Comprehension", "Clinical Reasoning"), capture:
 - **Name** and brief description
 - **3 proficiency tiers**: Emerging (just starting), Developing (gaining confidence), Secure (mastered)
+- **Optional \`bands\` map** — ONLY if the course uses a graded numeric rubric (IELTS bands 0–9, CEFR A1–C2, NHS AfC bands, professional certification levels). Record per-band descriptors keyed by band number.
 Probe: "What does 'just starting' look like for [skill]? And when they're confident?"
 Also ask: "How do you know a student is progressing?" (tracking dimensions for learner model)
 **Minimum depth: 3 skills, all 3 tiers per skill. Probe until you reach this.**
-Save as: update_setup({ fields: { skillsFramework: [{ id: "SKILL-01", name: "...", tiers: { emerging: "...", developing: "...", secure: "..." } }] } })
+
+⚠️ **CRITICAL — ONE skill per top-level criterion, NOT one per band.**
+If the uploaded docs contain a graded rubric (e.g. assessor-rubric.md with bands 0–9 for each criterion), the rubric's individual band rows are NOT separate skills. They are **measurements** on a single skill. A 4-criterion × 10-band IELTS rubric produces FOUR skills with \`bands\` populated — NEVER 40 skills. Treating each band row as a skill is the common failure mode — refuse to do it.
+
+Save as: update_setup({ fields: { skillsFramework: [{ id: "SKILL-01", name: "Fluency & Coherence", description: "...", tiers: { emerging: "...", developing: "...", secure: "..." }, bands: { 0: "Does not attend", 1: "Speech is incoherent", 9: "Fluent with only occasional self-correction" } }] } })
 
 ### Teaching Principles (next when graph suggests teachingPrinciples)
 Ask: "You chose [interactionPattern] — what are your core teaching rules?"

--- a/apps/admin/lib/content-trust/course-ref-to-assertions.ts
+++ b/apps/admin/lib/content-trust/course-ref-to-assertions.ts
@@ -52,6 +52,9 @@ export interface CourseRefData {
       developing?: string;
       secure?: string;
     };
+    /** Per-band descriptor map (#500 PR-2). Persisted into the generated
+     * COURSE_REFERENCE markdown so the projection re-parses on create_course. */
+    bands?: Record<number, string>;
   }>;
   skillDependencies?: string[];
   teachingApproach?: {

--- a/apps/admin/lib/content-trust/course-ref-to-markdown.ts
+++ b/apps/admin/lib/content-trust/course-ref-to-markdown.ts
@@ -106,6 +106,18 @@ export function renderCourseRefMarkdown(data: CourseRefData): string {
         if (skill.tiers.developing) lines.push(`- **Developing:** ${skill.tiers.developing}`);
         if (skill.tiers.secure) lines.push(`- **Secure:** ${skill.tiers.secure}`);
       }
+      // #500 PR-2 — render per-band descriptors as bullets so the projection
+      // parser (BAND_LINE in project-course-reference.ts) picks them back up
+      // at create_course time and writes into Parameter.config.bandThresholds.
+      if (skill.bands && Object.keys(skill.bands).length > 0) {
+        lines.push("");
+        const sortedBands = Object.entries(skill.bands)
+          .map(([k, v]) => [Number(k), v] as const)
+          .sort((a, b) => b[0] - a[0]);
+        for (const [bandNum, descriptor] of sortedBands) {
+          lines.push(`- **Band ${bandNum}:** ${descriptor}`);
+        }
+      }
       lines.push("");
     }
     if (data.skillDependencies?.length) {

--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -807,6 +807,16 @@ registerTransform("computeModuleProgress", (
   const callerAttributes = loadedData.callerAttributes;
   const totalCallCount = loadedData.callCount;
   const masteryThreshold = (sharedState as Record<string, any>).curriculumMetadata?.masteryThreshold ?? 0.7;
+  // #492 Slice 3.2: identify the CURRENT module for this call so siblings can
+  // be emitted with a thin shape (no `description` / `content` body). The
+  // tutor only needs full TP/LO text for the module being taught right now —
+  // sibling bodies bloat the prompt by ~6–12KB on a 4-module course. Current
+  // module = lockedModule (picker pick) | nextModule (scheduler choice).
+  const lockedModule = (sharedState as Record<string, any>).lockedModule as ModuleData | null;
+  const currentModuleKey: string | null =
+    (lockedModule && (lockedModule.slug || lockedModule.id || '')) ||
+    (nextModule && (nextModule.slug || nextModule.id || '')) ||
+    null;
 
   const curriculumAttrs = callerAttributes.filter((a: CallerAttributeData) =>
     a.key.includes("module") ||
@@ -867,15 +877,22 @@ registerTransform("computeModuleProgress", (
           : learnerStatus === "IN_PROGRESS" ? "in_progress"
           : learnerStatus === "NOT_STARTED" ? "not_started"
           : getModuleStatus(m, idx);
+      const moduleKey = m.slug || m.id || '';
+      // #492 Slice 3.2: sibling modules get a thin shape — drop `description`
+      // and `content` (the heavy fields). Tutor only needs full body text for
+      // the current module. Saves ~6–12KB per compose. The full body lives on
+      // the top-level `nextModule` block emitted below for the current module.
+      const isCurrentModule = currentModuleKey !== null && moduleKey === currentModuleKey;
       return {
         id: m.id,
-        slug: m.slug || m.id || '',
+        slug: moduleKey,
         name: m.name,
-        description: m.description,
+        ...(isCurrentModule ? { description: m.description } : {}),
         order: m.sortOrder ?? m.sequence,
         prerequisites: m.prerequisites,
         masteryThreshold: m.masteryThreshold ?? masteryThreshold,
         isCompleted: renderedStatus === "completed",
+        isCurrent: isCurrentModule,
         status: renderedStatus,
         // #266 Slice 1: per-learner attempt count (0 when no progress row, or when modulesAuthored !== true)
         callCount,
@@ -883,8 +900,8 @@ registerTransform("computeModuleProgress", (
           learnerStatus
             ?? (renderedStatus === "completed" ? "COMPLETED" : renderedStatus === "in_progress" ? "IN_PROGRESS" : "NOT_STARTED")
         ],
-        // Include module content for LLM context
-        content: m.content,
+        // Include module content for LLM context — full only for currentModule.
+        ...(isCurrentModule ? { content: m.content } : {}),
       };
     }),
     nextModule: nextModule ? {

--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -108,13 +108,26 @@ async function upsertParameters(
   let created = 0;
 
   for (const p of parameters) {
+    // #500 PR-2 — persist bandThresholds on Parameter.config when present so
+    // the MEASURE spec runtime (PR-5) can hydrate per-band scoring anchors.
+    const config = p.bandThresholds && Object.keys(p.bandThresholds).length > 0
+      ? { bandThresholds: p.bandThresholds }
+      : undefined;
+
     const existing = await tx.parameter.findUnique({
       where: { parameterId: p.name },
-      select: { parameterId: true },
+      select: { parameterId: true, config: true },
     });
 
     if (existing) {
       map.set(p.name, existing.parameterId);
+      // Keep config in sync if the doc gained or changed bandThresholds.
+      if (config) {
+        await tx.parameter.update({
+          where: { parameterId: p.name },
+          data: { config: config as any },
+        });
+      }
       continue;
     }
 
@@ -130,6 +143,7 @@ async function upsertParameters(
         computedBy: `course-ref:${sourceContentId}`,
         parameterType: "BEHAVIOR",
         isAdjustable: true,
+        ...(config ? { config: config as any } : {}),
       },
     });
     map.set(p.name, p.name);

--- a/apps/admin/lib/wizard/project-course-reference.ts
+++ b/apps/admin/lib/wizard/project-course-reference.ts
@@ -133,6 +133,13 @@ export interface ProjectedParameter {
   name: string;
   type: "BEHAVIOR";
   description?: string;
+  /**
+   * Optional per-band descriptor text (#500 PR-2). Written to
+   * Parameter.config.bandThresholds by the applier. Present for skill
+   * parameters that wrap a graded rubric (IELTS bands 0–9, CEFR, NHS AfC);
+   * absent for skills with only tier descriptors (Emerging/Developing/Secure).
+   */
+  bandThresholds?: Record<number, string>;
 }
 
 /**
@@ -200,6 +207,13 @@ export interface ParsedSkill {
    * by `mapSkillsToAchieveAndTargets`. Absent = aim for Secure (1.0).
    */
   targetBand?: number;
+  /**
+   * Per-band descriptor map (#500 PR-2). Two accepted forms inside a
+   * `### SKILL-NN` section: `**Band N:** descriptor` bullets, or markdown
+   * table rows `| N | descriptor |`. Keys are integer band numbers.
+   * Empty/absent when the skill has no graded rubric.
+   */
+  bandThresholds?: Record<number, string>;
 }
 
 export interface SkillsFrameworkResult {
@@ -211,6 +225,11 @@ const SKILL_HEADING = /^###\s+(SKILL-\d+)\s*:\s*(.+?)\s*$/;
 // Tier format accepts both v3.0 (`**Emerging:**`) and v2.2 (`**Emerging.**`)
 // punctuation styles. The captured text follows the closing `**`.
 const TIER_LINE = /^\s*[-*]\s*\*\*\s*(Emerging|Developing|Secure)\s*[:.]\s*\*\*\s*(.+?)\s*$/i;
+// Per-band descriptor bullet (#500 PR-2). Form: `- **Band 9:** descriptor`
+const BAND_LINE = /^\s*[-*]?\s*\*{0,2}\s*Band\s+(\d+(?:\.\d+)?)\s*\*{0,2}\s*[:.]\s*\*{0,2}\s*(.+?)\s*$/i;
+// Markdown table row carrying a band descriptor (#500 PR-2). Form: `| 9 | descriptor |`
+// First cell must be a plain integer — skips header + alignment rows.
+const BAND_TABLE_ROW = /^\s*\|\s*(\d+)\s*\|\s*(.+?)\s*\|\s*$/;
 // Per-skill target band declaration. Accepts punctuation/bold variants:
 //   `**Target band:** 6.5`     (colon inside bold)
 //   `**Target band**: 6.5`     (colon outside bold)
@@ -289,6 +308,28 @@ export function parseSkillsFramework(bodyText: string): SkillsFrameworkResult {
       const parsed = Number(bandMatch[1]);
       if (Number.isFinite(parsed) && parsed > 0) {
         current.targetBand = parsed;
+      }
+      continue;
+    }
+
+    // Per-band threshold capture (#500 PR-2). `**Band N:** desc` OR `| N | desc |`.
+    const bandLineMatch = line.match(BAND_LINE);
+    if (bandLineMatch && Number.isInteger(Number(bandLineMatch[1]))) {
+      captureDescription = false;
+      const bandNum = Number(bandLineMatch[1]);
+      if (Number.isFinite(bandNum) && bandNum >= 0 && bandNum <= 9) {
+        current.bandThresholds ??= {};
+        current.bandThresholds[bandNum] = bandLineMatch[2].trim();
+      }
+      continue;
+    }
+    const bandTableMatch = line.match(BAND_TABLE_ROW);
+    if (bandTableMatch) {
+      captureDescription = false;
+      const bandNum = Number(bandTableMatch[1]);
+      if (Number.isFinite(bandNum) && bandNum >= 0 && bandNum <= 9) {
+        current.bandThresholds ??= {};
+        current.bandThresholds[bandNum] = bandTableMatch[2].trim();
       }
       continue;
     }
@@ -443,6 +484,9 @@ function mapSkillsToAchieveAndTargets(skills: ParsedSkill[]): {
       name: paramName,
       type: "BEHAVIOR",
       description: skill.description,
+      // #500 PR-2 — pass band thresholds through; applier writes them into
+      // Parameter.config.bandThresholds. Only present for graded-rubric skills.
+      bandThresholds: skill.bandThresholds,
     });
 
     achieveGoals.push({

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.312",
+  "version": "0.7.313",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/admin/tests/lib/composition/modules.test.ts
+++ b/apps/admin/tests/lib/composition/modules.test.ts
@@ -502,6 +502,64 @@ describe("computeModuleProgress transform", () => {
     expect(out.modules[0].status).toBe("not_started");
     expect(out.modules[0].statusLabel).toBe("not started");
   });
+
+  // ── #492 Slice 3.2: sibling-module thinning ──
+
+  it("emits full shape (description + content) for the current module only", () => {
+    const modules: ModuleData[] = [
+      { id: "m-1", slug: "part1", name: "Part 1", description: "Part 1 desc", content: { teachingPlan: "long body…" } as any },
+      { id: "m-2", slug: "part2", name: "Part 2", description: "Part 2 desc", content: { teachingPlan: "long body…" } as any },
+      { id: "m-3", slug: "part3", name: "Part 3", description: "Part 3 desc", content: { teachingPlan: "long body…" } as any },
+    ];
+    const ctx = makeContext(modules, undefined, false);
+    // Mark Part 2 as the current via nextModule
+    ctx.sharedState.nextModule = modules[1];
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.modules).toHaveLength(3);
+    // Current module (Part 2): full body
+    expect(out.modules[1]).toMatchObject({ slug: "part2", isCurrent: true });
+    expect(out.modules[1].description).toBe("Part 2 desc");
+    expect(out.modules[1].content).toBeDefined();
+    // Siblings: NO description, NO content
+    expect(out.modules[0]).toMatchObject({ slug: "part1", isCurrent: false });
+    expect(out.modules[0].description).toBeUndefined();
+    expect(out.modules[0].content).toBeUndefined();
+    expect(out.modules[2]).toMatchObject({ slug: "part3", isCurrent: false });
+    expect(out.modules[2].description).toBeUndefined();
+    expect(out.modules[2].content).toBeUndefined();
+  });
+
+  it("respects lockedModule over nextModule when both present (picker wins)", () => {
+    const modules: ModuleData[] = [
+      { id: "m-1", slug: "part1", name: "Part 1", description: "d1", content: { x: 1 } as any },
+      { id: "m-2", slug: "part2", name: "Part 2", description: "d2", content: { x: 2 } as any },
+    ];
+    const ctx = makeContext(modules, undefined, false);
+    ctx.sharedState.nextModule = modules[0]; // scheduler picks Part 1
+    ctx.sharedState.lockedModule = modules[1]; // picker picks Part 2
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.modules[0].isCurrent).toBe(false); // Part 1 thinned
+    expect(out.modules[1].isCurrent).toBe(true);  // Part 2 full (picker wins)
+    expect(out.modules[1].description).toBe("d2");
+    expect(out.modules[0].description).toBeUndefined();
+  });
+
+  it("falls back to thin-everything when no current module is identifiable", () => {
+    const modules: ModuleData[] = [
+      { id: "m-1", slug: "part1", name: "Part 1", description: "d1", content: { x: 1 } as any },
+      { id: "m-2", slug: "part2", name: "Part 2", description: "d2", content: { x: 2 } as any },
+    ];
+    const ctx = makeContext(modules, undefined, false);
+    // No nextModule, no lockedModule → currentModuleKey=null → ALL siblings (thin)
+    ctx.sharedState.nextModule = null;
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.modules[0].isCurrent).toBe(false);
+    expect(out.modules[1].isCurrent).toBe(false);
+    expect(out.modules[0].description).toBeUndefined();
+    expect(out.modules[1].description).toBeUndefined();
+    expect(out.modules[0].content).toBeUndefined();
+    expect(out.modules[1].content).toBeUndefined();
+  });
 });
 
 // resolveLessonPlanMode tests removed — function deleted.


### PR DESCRIPTION
Closes E3 Slice 3.2 of #492. Pairs with #499 (E1 Slice 1.1) — combined ROI ~36KB cut from composed prompt.

Sibling modules now get a thin shape: drops description + content, keeps id/slug/name/status/callCount/statusLabel/prerequisites. `isCurrent` flag added for consumer detection. Current module = lockedModule (picker) | nextModule (scheduler) | null (fallback to thin-everything).

Guard-checker CLEAN. `__teachingDepth` landmine on curriculumAssertions confirmed unaffected. 34/34 tests pass.

Refs #492, #479.