### PR TITLE
fix(#491 Slice 1.2): CallScore.moduleId + multi-attribute unique constraint

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -471,6 +471,7 @@ async function runBatchedCallerAnalysis(
     transcript: string | null;
     playbookId?: string | null;
     requestedModuleId?: string | null;
+    curriculumModuleId?: string | null;
   },
   callerId: string,
   engine: AIEngine,
@@ -681,6 +682,10 @@ async function runBatchedCallerAnalysis(
             callId: call.id,
             callerId,
             parameterId: param.parameterId,
+            // #491 Slice 1.2 — attribute the score to the module this call covered.
+            // Null for non-attributed calls (legacy / no module pick); a partial
+            // unique index keeps one-score-per-(callId, parameterId) in that case.
+            ...(call.curriculumModuleId ? { moduleId: call.curriculumModuleId } : {}),
             score,
             confidence: 0.7,
             evidence: ["Mock batched scoring"],
@@ -755,6 +760,8 @@ async function runBatchedCallerAnalysis(
                 callId: call.id,
                 callerId,
                 parameterId,
+                // #491 Slice 1.2 — module attribution (see note above).
+                ...(call.curriculumModuleId ? { moduleId: call.curriculumModuleId } : {}),
                 score,
                 confidence,
                 reasoning,
@@ -1379,7 +1386,16 @@ async function computeAdapt(
           });
         } else {
           await prisma.callScore.create({
-            data: { callId, callerId, parameterId: deltaParameterId, score: deltaScore, confidence: 0.9, scoredBy: "adapt_v1" },
+            data: {
+              callId,
+              callerId,
+              parameterId: deltaParameterId,
+              // #491 Slice 1.2 — delta scores inherit the source call's module attribution.
+              ...(currentCall.curriculumModuleId ? { moduleId: currentCall.curriculumModuleId } : {}),
+              score: deltaScore,
+              confidence: 0.9,
+              scoredBy: "adapt_v1",
+            },
           });
         }
         deltasComputed++;
@@ -2751,7 +2767,7 @@ export async function POST(
     // Load call
     const call = await prisma.call.findUnique({
       where: { id: callId },
-      select: { id: true, transcript: true, playbookId: true, requestedModuleId: true },
+      select: { id: true, transcript: true, playbookId: true, requestedModuleId: true, curriculumModuleId: true },
     });
 
     if (!call) {

--- a/apps/admin/prisma/migrations/20260519_491_callscore_module_id/migration.sql
+++ b/apps/admin/prisma/migrations/20260519_491_callscore_module_id/migration.sql
@@ -1,0 +1,40 @@
+-- #491 Slice 1.2 — multi-attribute attribution for CallScore.
+--
+-- Mock-style calls cover multiple sub-modules (Part 1 + Part 2 + Part 3) in
+-- one transcript. The pipeline writes a CallScore PER skill PER sub-module
+-- (so 4 skills × 3 sub-parts = 12 scores from one Mock). The existing
+-- `@@unique([callId, parameterId])` constraint prevented this — adding
+-- moduleId to the key allows the same skill parameter to be scored multiple
+-- times within one call, once per attributed module.
+--
+-- Postgres treats NULLs as distinct in unique constraints by default. Legacy
+-- single-module calls have moduleId=NULL; the constraint must STILL enforce
+-- one-score-per-(callId, parameterId) for those, OR risk duplicate writes
+-- from pipeline force-reruns. A partial unique index covers that case.
+
+-- 1. Add the nullable moduleId column + FK
+ALTER TABLE "CallScore" ADD COLUMN IF NOT EXISTS "moduleId" TEXT;
+
+ALTER TABLE "CallScore"
+  ADD CONSTRAINT "CallScore_moduleId_fkey"
+  FOREIGN KEY ("moduleId") REFERENCES "CurriculumModule"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX IF NOT EXISTS "CallScore_moduleId_idx" ON "CallScore"("moduleId");
+
+-- 2. Drop the old (callId, parameterId) unique constraint.
+ALTER TABLE "CallScore" DROP CONSTRAINT IF EXISTS "CallScore_callId_parameterId_key";
+
+-- 3. New unique constraint includes moduleId. Postgres' default NULL handling
+--    means rows with moduleId=NULL won't collide against each other under this
+--    constraint, so we add a partial index to preserve legacy uniqueness.
+ALTER TABLE "CallScore"
+  ADD CONSTRAINT "CallScore_callId_parameterId_moduleId_key"
+  UNIQUE ("callId", "parameterId", "moduleId");
+
+-- Partial index: enforce one-score-per-(callId, parameterId) when moduleId IS NULL
+-- (legacy + single-module calls). Without this, a pipeline force-rerun could
+-- write two rows with the same (callId, parameterId, NULL) and both succeed.
+CREATE UNIQUE INDEX IF NOT EXISTS "CallScore_callId_parameterId_null_module_key"
+  ON "CallScore"("callId", "parameterId")
+  WHERE "moduleId" IS NULL;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -1473,6 +1473,13 @@ model CallScore {
   callerId    String? // Denormalized for efficient queries
   parameterId String
 
+  // #491 Slice 1.2 — which curriculum module this score is attributed to.
+  // For single-module calls this mirrors Call.curriculumModuleId.
+  // For multi-attribute modules (e.g. Mock Exam which covers Part 1/2/3),
+  // the same (callId, parameterId) pair can produce SEPARATE scores per
+  // sub-module — see the unique constraint below.
+  moduleId String?
+
   // Scoring result
   score      Float
   confidence Float    @default(0.5)
@@ -1487,17 +1494,29 @@ model CallScore {
   createdAt DateTime @default(now())
 
   // Relations
-  call         Call          @relation(fields: [callId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  caller       Caller?       @relation(fields: [callerId], references: [id], onDelete: SetNull)
-  parameter    Parameter     @relation(fields: [parameterId], references: [parameterId], onDelete: Restrict, onUpdate: Cascade)
-  analysisSpec AnalysisSpec? @relation(fields: [analysisSpecId], references: [id], onDelete: SetNull)
+  call             Call              @relation(fields: [callId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  caller           Caller?           @relation(fields: [callerId], references: [id], onDelete: SetNull)
+  parameter        Parameter         @relation(fields: [parameterId], references: [parameterId], onDelete: Restrict, onUpdate: Cascade)
+  analysisSpec     AnalysisSpec?     @relation(fields: [analysisSpecId], references: [id], onDelete: SetNull)
+  curriculumModule CurriculumModule? @relation(fields: [moduleId], references: [id], onDelete: SetNull)
 
-  @@unique([callId, parameterId])
+  // #491 Slice 1.2 — multi-attribute attribution: one Mock call writes 12
+  // scores (4 skills × 3 sub-parts). The unique key now includes moduleId so
+  // the same (callId, parameterId) can repeat across moduleIds.
+  //
+  // Postgres treats NULLs as distinct in unique constraints by default —
+  // two rows with the same (callId, parameterId) and BOTH moduleId=NULL
+  // would NOT collide. Legacy callers (pre-#491 / single-module calls
+  // without an attribution) keep moduleId=NULL and need the old behaviour
+  // of "one score per (callId, parameterId)". A partial unique index
+  // enforces that.
+  @@unique([callId, parameterId, moduleId])
   @@index([callId])
   @@index([parameterId])
   @@index([callerId], map: "CallScore_userId_idx")
   @@index([analysisSpecId])
   @@index([scoredAt])
+  @@index([moduleId])
 }
 
 // =========================
@@ -2338,6 +2357,7 @@ model CurriculumModule {
   learningObjectives LearningObjective[]
   callerProgress     CallerModuleProgress[]
   calls              Call[]
+  callScores         CallScore[] // #491 Slice 1.2 — multi-attribute scoring
 
   // Projection provenance (#338, NEW courses since 2026-05-12). When this
   // module row was written by applyProjection() from a COURSE_REFERENCE doc's


### PR DESCRIPTION
Closes E1 Slice 1.2 of #491. Tech-lead at #480#issuecomment-4486294547 flagged the original @@unique([callId, parameterId]) as a showstopper for multi-attribute attribution.

**Migration impact:** adds CallScore.moduleId column + FK + index, drops old unique, adds new @@unique([callId, parameterId, moduleId]) + partial unique index (callId, parameterId) WHERE moduleId IS NULL for legacy null-handling.

**Deploy path:** `/vm-cpp` (schema change). Will need migration run on VM dev DB.

Refs #491, #480.