### PR TITLE
fix(#492 Slice 3.4): surface currentModule teaching instructions as top-level field

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -855,6 +855,21 @@ registerTransform("computeModuleProgress", (
     COMPLETED: "done",
   };
 
+  // #492 Slice 3.4 — surface the current module's TEACHING_INSTRUCTION LOs
+  // as a top-level first-class field. Per `loadModulesFromDB` they're parked
+  // inside `assessorOutcomes.teachingInstruction[]` for every module, and
+  // post-Slice-3.2 sibling thinning strips that body from non-current modules.
+  // Hoisting the current module's instructions to the top means the tutor
+  // can find per-module guidance in <1 second of context scanning — instead
+  // of digging through the modules array. Empty array when no current module
+  // resolves, when the module has no instructions, or when the module isn't
+  // DB-loaded (Subject-fallback path doesn't populate assessorOutcomes).
+  const currentModule = currentModuleKey
+    ? modules.find((m: ModuleData) => (m.slug || m.id || '') === currentModuleKey)
+    : null;
+  const currentModuleTeachingInstructions: string[] =
+    currentModule?.assessorOutcomes?.teachingInstruction ?? [];
+
   return {
     name: (sharedState as Record<string, any>).curriculumName || null,
     hasData: curriculumAttrs.length > 0 || modules.length > 0,
@@ -866,6 +881,9 @@ registerTransform("computeModuleProgress", (
     masteryThreshold,
     // #266 Slice 1: gates module-aware opening line in _quickStart.first_line
     hasAttemptData,
+    // #492 Slice 3.4 — top-level tutor guidance for the active module.
+    currentModuleSlug: currentModuleKey,
+    currentModuleTeachingInstructions,
     modules: modules.map((m: ModuleData, idx: number) => {
       const learnerProgress = m.id ? moduleAttemptCounts?.[m.id] : undefined;
       const callCount = learnerProgress?.callCount ?? 0;

--- a/apps/admin/tests/lib/composition/modules.test.ts
+++ b/apps/admin/tests/lib/composition/modules.test.ts
@@ -544,6 +544,62 @@ describe("computeModuleProgress transform", () => {
     expect(out.modules[0].description).toBeUndefined();
   });
 
+  // ── #492 Slice 3.4: surface currentModuleTeachingInstructions ──
+
+  it("surfaces currentModule.assessorOutcomes.teachingInstruction[] as top-level field", () => {
+    const modules: ModuleData[] = [
+      {
+        id: "m-1", slug: "part1", name: "Part 1",
+        assessorOutcomes: {
+          rubric: [],
+          itemGenSpec: [],
+          scoreExplainer: [],
+          teachingInstruction: ["Scaffold hometown questions", "Allow short pauses"],
+        },
+      },
+      {
+        id: "m-2", slug: "part2", name: "Part 2",
+        assessorOutcomes: {
+          rubric: [],
+          itemGenSpec: [],
+          scoreExplainer: [],
+          teachingInstruction: ["Give 1-minute prep", "Cover all 4 bullets"],
+        },
+      },
+    ];
+    const ctx = makeContext(modules, undefined, false);
+    ctx.sharedState.nextModule = modules[1]; // Part 2 is current
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.currentModuleSlug).toBe("part2");
+    expect(out.currentModuleTeachingInstructions).toEqual([
+      "Give 1-minute prep",
+      "Cover all 4 bullets",
+    ]);
+  });
+
+  it("returns empty array for currentModuleTeachingInstructions when no current module", () => {
+    const modules: ModuleData[] = [
+      { id: "m-1", slug: "part1", name: "Part 1" },
+    ];
+    const ctx = makeContext(modules, undefined, false);
+    ctx.sharedState.nextModule = null;
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.currentModuleSlug).toBeNull();
+    expect(out.currentModuleTeachingInstructions).toEqual([]);
+  });
+
+  it("returns empty array when current module has no assessorOutcomes (Subject fallback path)", () => {
+    const modules: ModuleData[] = [
+      // No assessorOutcomes — typical for Subject-curriculum fallback modules
+      { id: "m-1", slug: "part1", name: "Part 1" },
+    ];
+    const ctx = makeContext(modules, undefined, false);
+    ctx.sharedState.nextModule = modules[0];
+    const out: any = transform({}, ctx, {} as any);
+    expect(out.currentModuleSlug).toBe("part1");
+    expect(out.currentModuleTeachingInstructions).toEqual([]);
+  });
+
   it("falls back to thin-everything when no current module is identifiable", () => {
     const modules: ModuleData[] = [
       { id: "m-1", slug: "part1", name: "Part 1", description: "d1", content: { x: 1 } as any },


### PR DESCRIPTION
Closes E3 Slice 3.4 of #492. Hoists per-module TEACHING_INSTRUCTION LOs from `modules[N].assessorOutcomes.teachingInstruction` to a top-level `currentModuleTeachingInstructions` field. Tutor can find guidance for the active module in <1 second instead of nested traversal.

Pairs with #503 (Slice 3.2 sibling thinning) — together: less noise + easier discovery.

37/37 tests pass. Refs #492, #479.