### PR TITLE
fix(wizard): detector reads full source text, not 2KB textSample

### DIFF
--- a/apps/admin/app/api/content-sources/[sourceId]/raw-text/route.ts
+++ b/apps/admin/app/api/content-sources/[sourceId]/raw-text/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { getStorageAdapter } from "@/lib/storage";
+import { extractTextFromBuffer } from "@/lib/content-trust/extract-assertions";
+
+type RouteParams = { params: Promise<{ sourceId: string }> };
+
+/**
+ * @api GET /api/content-sources/:sourceId/raw-text
+ * @visibility internal
+ * @scope content-sources:read
+ * @auth session
+ * @tags content-trust, wizard
+ * @description Returns the FULL extracted text of a ContentSource by re-running
+ *   the text extractor against the linked MediaAsset. Distinct from
+ *   `GET /api/content-sources/:sourceId` which returns `textSample` truncated
+ *   to ~2000 chars (set at ingest time).
+ *
+ *   Purpose (wizard fix): `detectAuthoredModules` needs the full document text
+ *   to parse the `## Modules` table — most course-refs put the table well past
+ *   the 2KB textSample cutoff (e.g. the IELTS Speaking course-ref has it at
+ *   char 20,490). Without this endpoint, the wizard mis-reports
+ *   `curriculumPath = "generated"` for courses that DO declare a module
+ *   catalogue, then defaults the progressionMode picker the wrong way and
+ *   tells the AI "no module catalogue found" via the GROUND TRUTH overlay.
+ *
+ * @pathParam sourceId string - ContentSource ID
+ * @response 200 { ok: true, text: string, byteLength: number, mediaAssetId: string | null }
+ * @response 404 { ok: false, error: "not-found" | "no-media-asset" }
+ * @response 500 { ok: false, error: string }
+ */
+export async function GET(_req: Request, { params }: RouteParams) {
+  try {
+    const auth = await requireAuth("VIEWER");
+    if (isAuthError(auth)) return auth.error;
+
+    const { sourceId } = await params;
+
+    const source = await prisma.contentSource.findUnique({
+      where: { id: sourceId },
+      select: {
+        id: true,
+        mediaAssets: {
+          select: { id: true, storageKey: true, fileName: true },
+          take: 1,
+          orderBy: { createdAt: "desc" },
+        },
+      },
+    });
+
+    if (!source) {
+      return NextResponse.json({ ok: false, error: "not-found" }, { status: 404 });
+    }
+    const media = source.mediaAssets[0];
+    if (!media) {
+      return NextResponse.json({ ok: false, error: "no-media-asset" }, { status: 404 });
+    }
+
+    const storage = getStorageAdapter();
+    const buffer = await storage.download(media.storageKey);
+    const { text } = await extractTextFromBuffer(buffer, media.fileName);
+
+    return NextResponse.json({
+      ok: true,
+      text: text ?? "",
+      byteLength: text ? Buffer.byteLength(text, "utf8") : 0,
+      mediaAssetId: media.id,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -958,15 +958,31 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
           const { detectPedagogy, hasPedagogy } = await import("@/lib/wizard/detect-pedagogy");
           const joinedAssertions = allAssertions.map((a) => a.assertion).join("\n");
 
-          // Also fetch textSample from course reference sources — the raw first
-          // ~1000 chars preserve the original phrasing that regex detection needs.
-          // The extractor paraphrases assertions, so "Call duration: 12-15 minutes"
-          // becomes something the regex can't match.
+          // Fetch the FULL extracted text of each course-ref source. textSample
+          // is truncated at 2KB by ingest; the `## Modules` table typically sits
+          // far beyond that (the IELTS Speaking course-ref has it at char ~20,500).
+          // Without full text, `detectAuthoredModules` parses the header
+          // declaration but not the catalogue table → wizard mis-flags
+          // `curriculumPath: "generated"` for courses that declare authored
+          // modules. The /raw-text endpoint re-extracts from storage to return
+          // the entire body. Falls back to textSample if the raw-text fetch fails
+          // (network blip, storage outage) so the wizard degrades rather than
+          // breaks.
           let rawSourceText = "";
           for (const idx of courseRefIndices) {
             const sid = sourceIds[idx];
             if (!sid) continue;
             try {
+              const fullRes = await fetch(`/api/content-sources/${sid}/raw-text`);
+              if (fullRes.ok) {
+                const fullData = await fullRes.json();
+                if (fullData.ok && typeof fullData.text === "string" && fullData.text.length > 0) {
+                  rawSourceText += fullData.text + "\n";
+                  continue;
+                }
+              }
+              // Fallback: textSample (truncated). Better than nothing for the
+              // header declaration even if the catalogue table is missed.
               const rawRes = await fetch(`/api/content-sources/${sid}`);
               if (rawRes.ok) {
                 const rawData = await rawRes.json();

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -4874,6 +4874,33 @@ Mark multiple questions as reviewed in a single transaction.
 
 ---
 
+### `GET` /api/content-sources/:sourceId/raw-text
+
+Returns the FULL extracted text of a ContentSource by re-running
+
+**Auth**: Session · **Scope**: `content-sources:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| sourceId | path | string | Yes | ContentSource ID |
+
+**Response** `200`
+```json
+{ ok: true, text: string, byteLength: number, mediaAssetId: string | null }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "not-found" | "no-media-asset" }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `POST` /api/content-sources/:sourceId/unarchive
 
 Restore an archived content source (set active, clear archivedAt).
@@ -14343,8 +14370,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 444 |
-| Files with annotations | 443 |
+| Route files found | 445 |
+| Files with annotations | 444 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 


### PR DESCRIPTION
Closes the wizard's curriculumPath misreporting for course-refs whose `## Modules` table sits past char 2000 (e.g. IELTS Speaking at char ~20,500). See commit for full diagnosis.