### PR TITLE
fix(#491 Slice 1.3): CallerModuleProgress.callCount auto-increment in AGGREGATE

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -1138,6 +1138,94 @@ async function computeReward(
 }
 
 /**
+ * #491 Slice 1.3 — Increment CallerModuleProgress.callCount for the module
+ * this call was attributed to. Runs at the end of AGGREGATE so it stays
+ * consistent with the CallScore.moduleId writes from Slice 1.2.
+ *
+ * Idempotency: pipeline force-rerun must not double-count. We track the
+ * last call that touched this row via `lastCallId`. If the current call
+ * already incremented this row, we no-op. The pipeline is serial per
+ * callId, so the read-then-write window is safe.
+ *
+ * Status transitions:
+ * - missing row     → create with callCount=1, status=IN_PROGRESS, startedAt=now
+ * - NOT_STARTED row → bump to IN_PROGRESS + increment
+ * - IN_PROGRESS row → increment, status unchanged
+ * - COMPLETED row   → increment, status unchanged (don't reopen)
+ *
+ * Returns the new callCount for logging / test assertions; -1 indicates
+ * a no-op (null moduleId or idempotent skip).
+ */
+export async function incrementModuleEvidence(
+  callId: string,
+  callerId: string,
+  moduleId: string | null,
+  log: PipelineLogger
+): Promise<{ callCount: number; created: boolean; skipped: boolean }> {
+  if (!moduleId) {
+    log.debug("incrementModuleEvidence skipped: no moduleId attribution", { callId, callerId });
+    return { callCount: -1, created: false, skipped: true };
+  }
+
+  const existing = await prisma.callerModuleProgress.findUnique({
+    where: { callerId_moduleId: { callerId, moduleId } },
+    select: { id: true, callCount: true, lastCallId: true, status: true },
+  });
+
+  if (!existing) {
+    const created = await prisma.callerModuleProgress.create({
+      data: {
+        callerId,
+        moduleId,
+        callCount: 1,
+        status: "IN_PROGRESS",
+        startedAt: new Date(),
+        lastCallId: callId,
+      },
+      select: { callCount: true },
+    });
+    log.info("CallerModuleProgress created (first call on module)", {
+      callerId,
+      moduleId,
+      callCount: created.callCount,
+    });
+    return { callCount: created.callCount, created: true, skipped: false };
+  }
+
+  // Idempotency: this exact call already incremented this row.
+  if (existing.lastCallId === callId && existing.callCount > 0) {
+    log.info("CallerModuleProgress increment skipped (idempotent re-run)", {
+      callerId,
+      moduleId,
+      callId,
+      callCount: existing.callCount,
+    });
+    return { callCount: existing.callCount, created: false, skipped: true };
+  }
+
+  // Preserve COMPLETED; promote NOT_STARTED to IN_PROGRESS; leave IN_PROGRESS as-is.
+  const nextStatus = existing.status === "NOT_STARTED" ? "IN_PROGRESS" : existing.status;
+  const updated = await prisma.callerModuleProgress.update({
+    where: { id: existing.id },
+    data: {
+      callCount: { increment: 1 },
+      lastCallId: callId,
+      status: nextStatus,
+      ...(existing.status === "NOT_STARTED" && !existing.lastCallId ? { startedAt: new Date() } : {}),
+    },
+    select: { callCount: true },
+  });
+  log.info("CallerModuleProgress incremented", {
+    callerId,
+    moduleId,
+    callId,
+    callCount: updated.callCount,
+    status: nextStatus,
+  });
+  return { callCount: updated.callCount, created: false, skipped: false };
+}
+
+/**
  * Aggregate caller personality from call scores
  * Creates/updates PersonalityObservation for the call and CallerPersonality aggregate
  *
@@ -2172,7 +2260,7 @@ async function updateTpMasteryAfterCall(
 interface PipelineContext {
   callId: string;
   callerId: string;
-  call: { id: string; transcript: string | null; playbookId: string | null; requestedModuleId: string | null };
+  call: { id: string; transcript: string | null; playbookId: string | null; requestedModuleId: string | null; curriculumModuleId: string | null };
   engine: AIEngine;
   guardrails: GuardrailsConfig;
   pipelineStages: PipelineStage[];
@@ -2397,11 +2485,25 @@ const stageExecutors: Record<string, StageExecutor> = {
       errors: aggregateResult.errors
     });
 
+    // 3. #491 Slice 1.3 — increment CallerModuleProgress.callCount for the
+    // module this call was attributed to (Slice 1.1 wrote curriculumModuleId
+    // at call-create; Slice 1.2 wrote it on every CallScore). Idempotent on
+    // pipeline force-rerun via the lastCallId check inside the helper.
+    const evidenceResult = await incrementModuleEvidence(
+      ctx.callId,
+      ctx.callerId,
+      ctx.call.curriculumModuleId,
+      ctx.log
+    );
+
     return {
       personalityObservationCreated: personalityResult.observationCreated,
       personalityProfileUpdated: personalityResult.profileUpdated,
       aggregateSpecsRun: aggregateResult.specsRun,
       profileUpdates: aggregateResult.profileUpdates,
+      moduleEvidenceCallCount: evidenceResult.callCount,
+      moduleEvidenceCreated: evidenceResult.created,
+      moduleEvidenceSkipped: evidenceResult.skipped,
     };
   },
 

--- a/apps/admin/tests/lib/caller-module-progress-increment.test.ts
+++ b/apps/admin/tests/lib/caller-module-progress-increment.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for incrementModuleEvidence — #491 Slice 1.3
+ *
+ * Exported from app/api/calls/[callId]/pipeline/route.ts. Runs at the end
+ * of the AGGREGATE stage and bumps CallerModuleProgress.callCount for the
+ * module that this call was attributed to (`Call.curriculumModuleId`).
+ *
+ * Coverage:
+ *  - First call: creates a row with callCount=1, status=IN_PROGRESS.
+ *  - Idempotent re-run (same callId): no increment, returns existing count.
+ *  - Second call (different callId): bumps callCount to 2, updates lastCallId.
+ *  - COMPLETED module: increments callCount but leaves status COMPLETED.
+ *  - NOT_STARTED row: promotes to IN_PROGRESS on first increment.
+ *  - Null moduleId: no-op (no row created).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// =====================================================
+// MOCKS
+// =====================================================
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    callerModuleProgress: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    // Unused by incrementModuleEvidence but referenced at module load
+    // time by sibling helpers in route.ts. Provide bare stubs so the
+    // module under test can be imported without ESM errors.
+    analysisSpec: { findFirst: vi.fn() },
+    call: { findUnique: vi.fn() },
+    callScore: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), findMany: vi.fn() },
+    callerMemory: { create: vi.fn() },
+    callerPersonality: { upsert: vi.fn() },
+    personalityObservation: { create: vi.fn() },
+    parameter: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+// Avoid pulling in real AI / metering / config registries when the route
+// module loads.
+vi.mock("@/lib/ai/client", () => ({
+  isEngineAvailable: vi.fn(() => true),
+}));
+vi.mock("@/lib/metering", () => ({
+  getConfiguredMeteredAICompletion: vi.fn(),
+  logMockAIUsage: vi.fn(),
+}));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(),
+  isAuthError: vi.fn(() => false),
+}));
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALLER_ID = "caller-1";
+const MODULE_ID = "mod-1";
+const CALL_ID_A = "call-A";
+const CALL_ID_B = "call-B";
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    getLogs: vi.fn(() => []),
+    getDuration: vi.fn(() => 0),
+  };
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("incrementModuleEvidence (#491 Slice 1.3)", () => {
+  let incrementModuleEvidence: typeof import("@/app/api/calls/[callId]/pipeline/route").incrementModuleEvidence;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/calls/[callId]/pipeline/route");
+    incrementModuleEvidence = mod.incrementModuleEvidence;
+  });
+
+  it("creates a new row with callCount=1 when no progress exists", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue(null);
+    mockPrisma.callerModuleProgress.create.mockResolvedValue({ callCount: 1 });
+
+    const log = makeLogger();
+    const result = await incrementModuleEvidence(CALL_ID_A, CALLER_ID, MODULE_ID, log as any);
+
+    expect(result).toEqual({ callCount: 1, created: true, skipped: false });
+    expect(mockPrisma.callerModuleProgress.findUnique).toHaveBeenCalledWith({
+      where: { callerId_moduleId: { callerId: CALLER_ID, moduleId: MODULE_ID } },
+      select: { id: true, callCount: true, lastCallId: true, status: true },
+    });
+    expect(mockPrisma.callerModuleProgress.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        callerId: CALLER_ID,
+        moduleId: MODULE_ID,
+        callCount: 1,
+        status: "IN_PROGRESS",
+        lastCallId: CALL_ID_A,
+        startedAt: expect.any(Date),
+      }),
+      select: { callCount: true },
+    });
+    expect(mockPrisma.callerModuleProgress.update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent when the same call re-runs the pipeline", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      callCount: 1,
+      lastCallId: CALL_ID_A, // same call already counted
+      status: "IN_PROGRESS",
+    });
+
+    const log = makeLogger();
+    const result = await incrementModuleEvidence(CALL_ID_A, CALLER_ID, MODULE_ID, log as any);
+
+    expect(result).toEqual({ callCount: 1, created: false, skipped: true });
+    expect(mockPrisma.callerModuleProgress.create).not.toHaveBeenCalled();
+    expect(mockPrisma.callerModuleProgress.update).not.toHaveBeenCalled();
+  });
+
+  it("increments to 2 when a different call touches the same module", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      callCount: 1,
+      lastCallId: CALL_ID_A,
+      status: "IN_PROGRESS",
+    });
+    mockPrisma.callerModuleProgress.update.mockResolvedValue({ callCount: 2 });
+
+    const log = makeLogger();
+    const result = await incrementModuleEvidence(CALL_ID_B, CALLER_ID, MODULE_ID, log as any);
+
+    expect(result).toEqual({ callCount: 2, created: false, skipped: false });
+    expect(mockPrisma.callerModuleProgress.update).toHaveBeenCalledWith({
+      where: { id: "prog-1" },
+      data: expect.objectContaining({
+        callCount: { increment: 1 },
+        lastCallId: CALL_ID_B,
+        status: "IN_PROGRESS",
+      }),
+      select: { callCount: true },
+    });
+  });
+
+  it("preserves COMPLETED status while still incrementing the evidence count", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      callCount: 5,
+      lastCallId: "earlier-call",
+      status: "COMPLETED",
+    });
+    mockPrisma.callerModuleProgress.update.mockResolvedValue({ callCount: 6 });
+
+    const log = makeLogger();
+    const result = await incrementModuleEvidence(CALL_ID_B, CALLER_ID, MODULE_ID, log as any);
+
+    expect(result).toEqual({ callCount: 6, created: false, skipped: false });
+    const updateArg = mockPrisma.callerModuleProgress.update.mock.calls[0][0];
+    expect(updateArg.data.status).toBe("COMPLETED");
+    expect(updateArg.data.callCount).toEqual({ increment: 1 });
+    expect(updateArg.data.lastCallId).toBe(CALL_ID_B);
+  });
+
+  it("promotes NOT_STARTED rows to IN_PROGRESS on first increment", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      callCount: 0,
+      lastCallId: null,
+      status: "NOT_STARTED",
+    });
+    mockPrisma.callerModuleProgress.update.mockResolvedValue({ callCount: 1 });
+
+    const log = makeLogger();
+    const result = await incrementModuleEvidence(CALL_ID_A, CALLER_ID, MODULE_ID, log as any);
+
+    expect(result.callCount).toBe(1);
+    const updateArg = mockPrisma.callerModuleProgress.update.mock.calls[0][0];
+    expect(updateArg.data.status).toBe("IN_PROGRESS");
+    expect(updateArg.data.startedAt).toBeInstanceOf(Date);
+  });
+
+  it("is a no-op when moduleId is null (no attribution)", async () => {
+    const log = makeLogger();
+    const result = await incrementModuleEvidence(CALL_ID_A, CALLER_ID, null, log as any);
+
+    expect(result).toEqual({ callCount: -1, created: false, skipped: true });
+    expect(mockPrisma.callerModuleProgress.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.callerModuleProgress.create).not.toHaveBeenCalled();
+    expect(mockPrisma.callerModuleProgress.update).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining("no moduleId attribution"),
+      expect.objectContaining({ callId: CALL_ID_A, callerId: CALLER_ID })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- New `incrementModuleEvidence()` helper bumps `CallerModuleProgress.callCount` at the end of the pipeline AGGREGATE stage, using the `Call.curriculumModuleId` attribution stamped by #499 (Slice 1.1) and #504 (Slice 1.2).
- Idempotent on pipeline force-rerun: re-running for the same `callId` is a no-op (checked via `lastCallId === callId && callCount > 0`).
- Status transitions: `NOT_STARTED → IN_PROGRESS` on first touch; `COMPLETED` rows still increment but stay COMPLETED (don't reopen); null `moduleId` is a logged no-op.

## What changed

- `app/api/calls/[callId]/pipeline/route.ts`
  - Adds the `incrementModuleEvidence()` helper (exported for direct testing) next to `aggregatePersonality`.
  - Wires it into the AGGREGATE stage executor after generic AGGREGATE specs run.
  - Extends `PipelineContext.call` type with `curriculumModuleId` (the handler already selects it).
- `tests/lib/caller-module-progress-increment.test.ts` — 6 focused vitest cases covering all five status transitions + the idempotent re-run case. Mocks Prisma in the same style as `apply-behavior-targets.test.ts`.

## Idempotency model

| Scenario | Outcome |
|----------|---------|
| First call attributed to module | row created, `callCount = 1`, `status = IN_PROGRESS` |
| Same callId re-runs pipeline | no-op, returns existing count |
| Second call (new callId) on same module | `callCount = 2`, `lastCallId` updated |
| Module already COMPLETED | `callCount` increments, status preserved |
| `NOT_STARTED` row | promoted to `IN_PROGRESS`, increment |
| `curriculumModuleId === null` | debug-logged no-op (no row created) |

The pipeline is serial per callId, so the read-then-write window is safe — no concurrent writes possible for the same `(callerId, moduleId)` pair from this path.

## Test plan

- [x] `npx vitest run tests/lib/caller-module-progress-increment.test.ts` — 6/6 pass.
- [x] `npx tsc --noEmit` — no new type errors (4 pre-existing pipeline route errors unrelated to this change).
- [x] `npx eslint` on changed files — no new errors.
- [ ] On hf-dev: trigger pipeline on a module-attributed call and confirm `CallerModuleProgress.callCount` increments + `lastCallId` updates.
- [ ] Force-rerun the same pipeline; confirm `callCount` does not change.
- [ ] Trigger pipeline on a call with no `curriculumModuleId`; confirm no row created.

Closes part of #491 (E1 Slice 1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)