### PR TITLE
fix(#495 Slice 4.1): picker reads Curriculum.modules[] — works for both authored + AI-gen routes

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -20,7 +20,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
-import type { PlaybookConfig } from "@/lib/types/json-fields";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
 import { detectAuthoredModules } from "@/lib/wizard/detect-authored-modules";
 import {
   applyAuthoredModules,
@@ -28,6 +28,7 @@ import {
 } from "@/lib/wizard/persist-authored-modules";
 import { syncAuthoredModulesToCurriculum } from "@/lib/wizard/sync-authored-modules-to-curriculum";
 import { reclassifyLearningObjectives } from "@/lib/curriculum/reclassify-los";
+import { resolveCurriculumIdForPlaybook } from "@/lib/curriculum/resolve-module";
 
 // ── Body schema ──────────────────────────────────────────────────────
 
@@ -48,11 +49,17 @@ type Body = z.infer<typeof BodySchema>;
  * @visibility internal
  * @scope course:read
  * @auth session (VIEWER+)
- * @description Read the current authored-modules state from PlaybookConfig.
- *   Used by the Authored Modules panel in the Curriculum tab to render the
- *   catalogue without re-parsing the source document. Returns nulls/empties
- *   when no authored modules exist yet (derived path is in use).
- * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification }
+ * @description Read the current modules catalogue for a course. Prefers
+ *   author-declared modules from `Playbook.config.modules` when present
+ *   (authored path), otherwise falls back to `Curriculum.modules[]` rows
+ *   keyed via the playbook's primary curriculum (AI-generated path — #495
+ *   Slice 4.1). The fallback maps `CurriculumModule` rows into the same
+ *   `AuthoredModule` shape so the learner-facing picker is route-agnostic.
+ *   The new top-level `source` field is `"authored" | "generated" | null`
+ *   (null when no modules exist on either side); the legacy `moduleSource`
+ *   field (`"authored" | "derived" | null`) is preserved for backwards
+ *   compatibility with the admin AuthoredModulesPanel.
+ * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, source, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification }
  * @response 404 { ok: false, error: "Course not found" }
  */
 export async function GET(
@@ -77,12 +84,33 @@ export async function GET(
   const cfg = (playbook.config ?? {}) as PlaybookConfig;
   const warnings = cfg.validationWarnings ?? [];
 
+  // #495 Slice 4.1 — fallback to Curriculum.modules[] when Playbook.config
+  // has no authored modules so the learner picker works for AI-generated
+  // courses too. The authored path remains canonical: only fall through
+  // when `cfg.modules` is empty/missing AND a curriculum exists.
+  const authoredModules = (cfg.modules ?? []) as AuthoredModule[];
+  let modulesForResponse: AuthoredModule[] = authoredModules;
+  let pickerSource: "authored" | "generated" | null =
+    authoredModules.length > 0 ? "authored" : null;
+
+  if (authoredModules.length === 0) {
+    const generated = await loadGeneratedModulesAsAuthored(courseId);
+    if (generated.length > 0) {
+      modulesForResponse = generated;
+      pickerSource = "generated";
+    }
+  }
+
   // #281 Slice 3b: per-module ContentQuestion count so the AuthoredModules
   // panel can show a "no learner-facing content" banner for modules whose
   // outcomes have zero MCQs. Single groupBy across all module outcomes —
   // not a per-module loop. Keys outcomeRef → count, then we spread into
   // moduleId → count by summing each module's outcomesPrimary memberships.
-  const modulesArr = (cfg.modules ?? []) as Array<{ id: string; outcomesPrimary?: string[] }>;
+  // Drives off `modulesForResponse` so the count works for both authored
+  // and generated paths (the latter has empty outcomesPrimary today, so
+  // the count is naturally zero — but the wiring is in place if generated
+  // modules later get outcome refs).
+  const modulesArr = modulesForResponse as Array<{ id: string; outcomesPrimary?: string[] }>;
   const allOutcomeRefs = Array.from(
     new Set(modulesArr.flatMap((m) => Array.isArray(m.outcomesPrimary) ? m.outcomesPrimary : [])),
   );
@@ -149,7 +177,12 @@ export async function GET(
   return NextResponse.json({
     ok: true,
     modulesAuthored: cfg.modulesAuthored ?? null,
-    modules: cfg.modules ?? [],
+    // #495 Slice 4.1 — `modules` is the picker-ready list (authored when
+    // present, generated fallback otherwise). `source` tells the UI which
+    // path produced them; the legacy `moduleSource` (authored | derived)
+    // is preserved unchanged for the admin AuthoredModulesPanel.
+    modules: modulesForResponse,
+    source: pickerSource,
     moduleDefaults: cfg.moduleDefaults ?? {},
     moduleSource: cfg.moduleSource ?? null,
     moduleSourceRef: cfg.moduleSourceRef ?? null,
@@ -168,6 +201,62 @@ export async function GET(
     // exists yet (cold-start before classifier first runs).
     loAudienceByRef,
   });
+}
+
+/**
+ * #495 Slice 4.1 — load the playbook's primary `Curriculum.modules[]` and
+ * project them into the `AuthoredModule` shape so the learner picker can
+ * render AI-generated courses without a second code path. Returns `[]` when
+ * the playbook has no curriculum attached or the curriculum has no modules.
+ *
+ * Defaults applied here keep generated modules safely renderable:
+ *   - `learnerSelectable: true` — every generated module is offered to the learner
+ *   - `mode: "tutor"`, `frequency: "repeatable"` — neutral defaults
+ *   - `voiceBandReadout: false`, `sessionTerminal: false` — opt-in behaviours only
+ *   - `outcomesPrimary: []`, `prerequisites: []` — generated modules don't yet
+ *     declare authored outcome refs; the picker treats them as ungated
+ *
+ * The slug is used as the picker's stable `id` so progress rows (which key
+ * by CurriculumModule.slug) line up with the picker's completed/in-progress
+ * sets — same convention as the authored path.
+ */
+async function loadGeneratedModulesAsAuthored(
+  playbookId: string,
+): Promise<AuthoredModule[]> {
+  const curriculumId = await resolveCurriculumIdForPlaybook(playbookId);
+  if (!curriculumId) return [];
+
+  const rows = await prisma.curriculumModule.findMany({
+    where: { curriculumId, isActive: true },
+    orderBy: { sortOrder: "asc" },
+    select: {
+      slug: true,
+      title: true,
+      description: true,
+      sortOrder: true,
+      estimatedDurationMinutes: true,
+      prerequisites: true,
+    },
+  });
+
+  return rows.map((row): AuthoredModule => ({
+    id: row.slug,
+    label: row.title,
+    learnerSelectable: true,
+    mode: "tutor",
+    duration:
+      typeof row.estimatedDurationMinutes === "number" &&
+      row.estimatedDurationMinutes > 0
+        ? `${row.estimatedDurationMinutes} min`
+        : "Student-led",
+    scoringFired: "",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: Array.isArray(row.prerequisites) ? row.prerequisites : [],
+    position: row.sortOrder,
+  }));
 }
 
 /**

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -576,3 +576,35 @@ button.learner-picker__rail-card:hover {
   flex-wrap: wrap;
   margin-top: 4px;
 }
+
+/* #495 Slice 4.1 — student picker page layout. Lifted out of inline
+   style={{}} so the file complies with the UI design system zero-tolerance
+   rule (no static inline styles). */
+
+.learner-picker-page__header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.learner-picker-page__title {
+  margin: 0;
+}
+
+.learner-picker-page__body {
+  padding: 24px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.learner-picker-page__intro {
+  margin-bottom: 16px;
+}
+
+.learner-picker-page__banner {
+  margin-top: 16px;
+}
+
+.learner-picker-page__empty {
+  padding: 24px;
+  text-align: center;
+}

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -8,8 +8,12 @@
  * thread the selected moduleId through the call-launch flow; Slice 1 only
  * confirms the pick and surfaces a "Starting session..." toast.
  *
- * Falls back silently when modulesAuthored !== true so legacy courses are
- * unaffected (decision #3, AC: courses without authored modules are hidden).
+ * #495 Slice 4.1 — the picker works for BOTH authored AND AI-generated
+ * courses. The API (`/api/courses/[courseId]/import-modules`) now falls
+ * back to `Curriculum.modules[]` when `Playbook.config.modules` is empty,
+ * so the previous `modulesAuthored !== true` bounce has been removed.
+ * Courses with zero modules on either path show a "curriculum is being
+ * prepared" empty state instead of bouncing.
  */
 
 import { useEffect, useState, useCallback, useMemo, Suspense } from "react";
@@ -29,6 +33,12 @@ interface ModulesPayload {
   ok: boolean;
   modulesAuthored: boolean | null;
   modules: AuthoredModule[];
+  /**
+   * #495 Slice 4.1 — `"authored"` when modules came from PlaybookConfig,
+   * `"generated"` when fallen back to Curriculum.modules[], `null` when
+   * neither source has any modules yet.
+   */
+  source: "authored" | "generated" | null;
   moduleDefaults: Partial<ModuleDefaults>;
   moduleSource: ModuleSource | null;
   validationWarnings: ValidationWarning[];
@@ -134,20 +144,11 @@ function PickerContent() {
     };
   }, [courseId, buildUrl, needsCallerRedirect]);
 
-  // Fall-through guard: course has no authored modules → bounce back.
-  // `null` (never imported) and `false` (explicitly off) both hide the picker;
-  // we distinguish them only in the console log so prod telemetry can tell them apart.
-  useEffect(() => {
-    if (loading || error || !data) return;
-    if (data.modulesAuthored !== true) {
-      console.info(
-        "[picker] modulesAuthored=%s for course %s — silently bouncing",
-        data.modulesAuthored,
-        courseId,
-      );
-      router.replace(returnTo ?? "/x/sim");
-    }
-  }, [loading, error, data, returnTo, router, courseId]);
+  // #495 Slice 4.1 — the previous `modulesAuthored !== true` bounce has
+  // been removed. The API now returns modules from either Playbook.config
+  // (authored path) or Curriculum.modules[] (AI-generated fallback), and
+  // the picker renders for both. Zero modules → empty state below, not
+  // a redirect, so the learner stays oriented on the course route.
 
   const moduleById = useMemo(() => {
     const m = new Map<string, AuthoredModule>();
@@ -243,14 +244,19 @@ function PickerContent() {
     );
   }
 
-  // While the redirect effect runs, render nothing
-  if (!data || data.modulesAuthored !== true) return null;
+  // No data → nothing to render (load handler set `error` separately).
+  if (!data) return null;
+
+  // #495 Slice 4.1 — when both the authored path and the curriculum
+  // fallback yield no modules, show a "curriculum is being prepared"
+  // empty state. We previously bounced here, which left learners stuck
+  // on AI-gen courses while generation was still completing.
+  const hasModules = data.modules.length > 0;
 
   return (
     <div className="learner-picker-page">
       <header
-        className="hf-flex hf-items-center hf-gap-sm"
-        style={{ padding: "16px 24px", borderBottom: "1px solid var(--border-default)" }}
+        className="hf-flex hf-items-center hf-gap-sm learner-picker-page__header"
       >
         {returnTo && (
           <button
@@ -263,33 +269,43 @@ function PickerContent() {
           </button>
         )}
         <GraduationCap size={18} className="hf-text-muted" aria-hidden="true" />
-        <h1 className="hf-section-title" style={{ margin: 0 }}>
+        <h1 className="hf-section-title learner-picker-page__title">
           Pick your module
         </h1>
       </header>
 
-      <div style={{ padding: 24, maxWidth: 960, margin: "0 auto" }}>
-        <p className="hf-text-sm hf-text-muted" style={{ marginBottom: 16 }}>
-          Choose what you want to practise. Recommendations are advisory — pick whatever helps you most.
-        </p>
+      <div className="learner-picker-page__body">
+        {hasModules ? (
+          <>
+            <p className="hf-text-sm hf-text-muted learner-picker-page__intro">
+              Choose what you want to practise. Recommendations are advisory — pick whatever helps you most.
+            </p>
 
-        <LearnerModulePicker
-          modules={data.modules}
-          lessonPlanMode={data.lessonPlanMode}
-          completedModuleIds={completedIds}
-          inProgressModuleIds={inProgressIds}
-          onSelect={handleSelect}
-        />
+            <LearnerModulePicker
+              modules={data.modules}
+              lessonPlanMode={data.lessonPlanMode}
+              completedModuleIds={completedIds}
+              inProgressModuleIds={inProgressIds}
+              onSelect={handleSelect}
+            />
 
-        {launching && (
-          <div
-            role="status"
-            aria-live="polite"
-            className="hf-banner"
-            style={{ marginTop: 16 }}
-          >
-            <strong>Placeholder:</strong> VAPI call would start now —
-            returning to the simulator with the selected module.
+            {launching && (
+              <div
+                role="status"
+                aria-live="polite"
+                className="hf-banner learner-picker-page__banner"
+              >
+                <strong>Placeholder:</strong> VAPI call would start now —
+                returning to the simulator with the selected module.
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="hf-empty learner-picker-page__empty" role="status" aria-live="polite">
+            <p className="hf-text-sm hf-text-muted">
+              Your curriculum is being prepared. Check back in a moment —
+              modules will appear here once they're ready.
+            </p>
           </div>
         )}
       </div>

--- a/apps/admin/tests/api/import-modules-fallback.test.ts
+++ b/apps/admin/tests/api/import-modules-fallback.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the #495 Slice 4.1 fallback in
+ * GET /api/courses/[courseId]/import-modules.
+ *
+ * Covers:
+ * - Authored playbook → returns Playbook.config.modules (regression — the
+ *   existing AuthoredModulesPanel admin path must keep working).
+ * - AI-generated playbook (no Playbook.config.modules) → falls back to
+ *   CurriculumModule rows joined via the playbook's primary curriculum
+ *   and projects them into the AuthoredModule shape with source="generated".
+ * - Empty (no authored modules, no curriculum modules) → returns
+ *   { modules: [], source: null } so the picker can render the
+ *   "curriculum is being prepared" empty state instead of bouncing.
+ * - Non-existent playbook → 404 (regression).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const { mockPrisma, mockRequireAuth, mockIsAuthError } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: {
+      findUnique: vi.fn(),
+    },
+    curriculum: {
+      findFirst: vi.fn(),
+    },
+    curriculumModule: {
+      findMany: vi.fn(),
+    },
+    contentQuestion: {
+      groupBy: vi.fn(),
+    },
+    learningObjective: {
+      findMany: vi.fn(),
+    },
+  },
+  mockRequireAuth: vi.fn(),
+  mockIsAuthError: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+  isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+}));
+
+// Import AFTER mocks
+import { GET } from "@/app/api/courses/[courseId]/import-modules/route";
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeGetReq(): NextRequest {
+  return new NextRequest(
+    "http://localhost:3000/api/courses/playbook-1/import-modules",
+  );
+}
+
+const params = Promise.resolve({ courseId: "playbook-1" });
+
+const passingAuth = { session: { user: { id: "u1", role: "VIEWER" } } };
+
+beforeEach(() => {
+  mockRequireAuth.mockReset();
+  mockIsAuthError.mockReset();
+  mockPrisma.playbook.findUnique.mockReset();
+  mockPrisma.curriculum.findFirst.mockReset();
+  mockPrisma.curriculumModule.findMany.mockReset();
+  mockPrisma.contentQuestion.groupBy.mockReset();
+  mockPrisma.learningObjective.findMany.mockReset();
+
+  mockRequireAuth.mockResolvedValue(passingAuth);
+  mockIsAuthError.mockReturnValue(false);
+
+  // Default no-op responses for the secondary queries the GET handler
+  // makes after picking its module list. Each test overrides as needed.
+  mockPrisma.contentQuestion.groupBy.mockResolvedValue([]);
+  mockPrisma.learningObjective.findMany.mockResolvedValue([]);
+});
+
+// ── Regression: authored path ────────────────────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — authored regression (#495 Slice 4.1)", () => {
+  it("returns Playbook.config.modules unchanged with source='authored'", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "playbook-1",
+      config: {
+        modulesAuthored: true,
+        moduleSource: "authored",
+        modules: [
+          {
+            id: "m1",
+            label: "Module One",
+            learnerSelectable: true,
+            mode: "tutor",
+            duration: "Student-led",
+            scoringFired: "LR + GRA only",
+            voiceBandReadout: false,
+            sessionTerminal: false,
+            frequency: "repeatable",
+            outcomesPrimary: [],
+            prerequisites: [],
+          },
+        ],
+      },
+    });
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.modules).toHaveLength(1);
+    expect(body.modules[0].id).toBe("m1");
+    expect(body.modules[0].label).toBe("Module One");
+    // Legacy AuthoredModulesPanel-facing field is preserved unchanged
+    expect(body.moduleSource).toBe("authored");
+    // New picker-facing field announces the path
+    expect(body.source).toBe("authored");
+
+    // Fallback path MUST NOT be touched when authored modules exist.
+    expect(mockPrisma.curriculum.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.curriculumModule.findMany).not.toHaveBeenCalled();
+  });
+});
+
+// ── New behaviour: generated fallback ────────────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — generated fallback (#495 Slice 4.1)", () => {
+  it("falls back to CurriculumModule rows when Playbook.config.modules is empty", async () => {
+    // Playbook has no authored modules (AI-generated course shape).
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "playbook-1",
+      config: { lessonPlanMode: "continuous" },
+    });
+    // resolveCurriculumIdForPlaybook → curriculum.findFirst
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-1" });
+    // Two CurriculumModule rows scoped to the resolved curriculum.
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      {
+        slug: "mod-1",
+        title: "Intro to Topic",
+        description: "First module.",
+        sortOrder: 0,
+        estimatedDurationMinutes: 15,
+        prerequisites: [],
+      },
+      {
+        slug: "mod-2",
+        title: "Deeper Dive",
+        description: null,
+        sortOrder: 1,
+        estimatedDurationMinutes: null,
+        prerequisites: ["mod-1"],
+      },
+    ]);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.source).toBe("generated");
+    expect(body.modules).toHaveLength(2);
+
+    // Mapped into AuthoredModule shape, slug → id.
+    expect(body.modules[0]).toMatchObject({
+      id: "mod-1",
+      label: "Intro to Topic",
+      learnerSelectable: true,
+      mode: "tutor",
+      frequency: "repeatable",
+      duration: "15 min",
+      voiceBandReadout: false,
+      sessionTerminal: false,
+      outcomesPrimary: [],
+      prerequisites: [],
+      position: 0,
+    });
+
+    // Missing duration falls back to "Student-led".
+    expect(body.modules[1]).toMatchObject({
+      id: "mod-2",
+      label: "Deeper Dive",
+      duration: "Student-led",
+      prerequisites: ["mod-1"],
+      position: 1,
+    });
+
+    // Legacy fields stay at their authored-path defaults so the admin
+    // AuthoredModulesPanel can still tell the two apart.
+    expect(body.modulesAuthored).toBeNull();
+    expect(body.moduleSource).toBeNull();
+
+    // Fallback path was actually used.
+    expect(mockPrisma.curriculum.findFirst).toHaveBeenCalledOnce();
+    expect(mockPrisma.curriculumModule.findMany).toHaveBeenCalledOnce();
+    const findManyArgs = mockPrisma.curriculumModule.findMany.mock.calls[0][0];
+    expect(findManyArgs.where).toMatchObject({
+      curriculumId: "curr-1",
+      isActive: true,
+    });
+    expect(findManyArgs.orderBy).toEqual({ sortOrder: "asc" });
+  });
+});
+
+// ── Empty contract: no modules anywhere ──────────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — empty curriculum (#495 Slice 4.1)", () => {
+  it("returns { modules: [], source: null } when both paths are empty", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "playbook-1",
+      config: {},
+    });
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-1" });
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.modules).toEqual([]);
+    expect(body.source).toBeNull();
+    expect(body.modulesAuthored).toBeNull();
+  });
+
+  it("returns { modules: [], source: null } when the playbook has no curriculum", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "playbook-1",
+      config: {},
+    });
+    // No curriculum attached at all.
+    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.modules).toEqual([]);
+    expect(body.source).toBeNull();
+    // No need to fan out to curriculumModule.findMany when there is no curriculum.
+    expect(mockPrisma.curriculumModule.findMany).not.toHaveBeenCalled();
+  });
+});
+
+// ── Regression: 404 on missing playbook ──────────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — missing playbook (#495 Slice 4.1)", () => {
+  it("returns 404 when the playbook does not exist", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Course not found");
+
+    // Fallback path must never run if the playbook itself is missing.
+    expect(mockPrisma.curriculum.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.curriculumModule.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns the auth error when requireAuth fails", async () => {
+    const errorResponse = NextResponse.json(
+      { ok: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+    mockRequireAuth.mockResolvedValue({ error: errorResponse });
+    mockIsAuthError.mockReturnValue(true);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(401);
+    expect(mockPrisma.playbook.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/api/import-modules.test.ts
+++ b/apps/admin/tests/api/import-modules.test.ts
@@ -23,6 +23,16 @@ const { mockPrisma, mockRequireAuth, mockIsAuthError, mockSyncAuthored } = vi.ho
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    // #495 Slice 4.1: GET now consults Curriculum + CurriculumModule when
+    // Playbook.config.modules is empty (AI-generated fallback). These mocks
+    // default to "no curriculum / no rows" so existing authored-path tests
+    // continue to see the same response shape they did before.
+    curriculum: {
+      findFirst: vi.fn(),
+    },
+    curriculumModule: {
+      findMany: vi.fn(),
+    },
     // #245: import-modules POST now wraps the playbook update + module sync
     // in a transaction. The mock invokes the callback with a tx that proxies
     // playbook.update so existing assertions still see the call.
@@ -105,10 +115,17 @@ beforeEach(() => {
   mockIsAuthError.mockReset();
   mockPrisma.playbook.findUnique.mockReset();
   mockPrisma.playbook.update.mockReset();
+  mockPrisma.curriculum.findFirst.mockReset();
+  mockPrisma.curriculumModule.findMany.mockReset();
   mockSyncAuthored.mockReset();
 
   mockRequireAuth.mockResolvedValue(passingAuth);
   mockIsAuthError.mockReturnValue(false);
+  // #495 Slice 4.1 — default the fallback path to "no curriculum" so the
+  // authored-path tests below stay byte-for-byte equivalent to pre-#495.
+  // Tests covering the fallback live in import-modules-fallback.test.ts.
+  mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+  mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
   mockSyncAuthored.mockResolvedValue({
     curriculumId: "curr-1",
     created: 0,

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9564,13 +9564,13 @@ List all classrooms (cohort groups) assigned to a course (playbook).
 
 ### `GET` /api/courses/[courseId]/import-modules
 
-Read the current authored-modules state from PlaybookConfig.
+Read the current modules catalogue for a course. Prefers
 
 **Auth**: session (VIEWER+) · **Scope**: `course:read`
 
 **Response** `200`
 ```json
-{ ok, modulesAuthored, modules, moduleDefaults, moduleSource, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification }
+{ ok, modulesAuthored, modules, moduleDefaults, moduleSource, source, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification }
 ```
 
 **Response** `404`

--- a/docs/CONTENT-PIPELINE.md
+++ b/docs/CONTENT-PIPELINE.md
@@ -66,7 +66,7 @@ All values authoritative as of 2026-05-11. Cite the file:line in any PR that cha
 | `Playbook.config.teachingMode` (TM) | recall / comprehension / practice / syllabus | `lib/types/json-fields.ts:145` | Scheduler preset, extraction weights |
 | `Playbook.config.interactionPattern` | 8 values listed above | `lib/types/json-fields.ts:153` | Tutor voice |
 | `Playbook.config.progressionMode` | ai-led / learner-picks | `lib/wizard/graph-nodes.ts` | Module selection: scheduler vs picker |
-| `Playbook.config.modulesAuthored` | true / false / null | `lib/types/json-fields.ts` | Whether authored modules exist; null = derived from curriculum |
+| `Playbook.config.modulesAuthored` | true / false / null | `lib/types/json-fields.ts` | Whether authored modules exist; null = derived from curriculum. ⚠ **No longer gates the learner picker** (#495 Slice 4.1) — the picker reads `Playbook.config.modules` first, then falls back to `Curriculum.modules[]`. Field remains the source of truth for the admin AuthoredModulesPanel. |
 | `AuthoredModule.mode` | examiner / tutor / mixed | `lib/types/json-fields.ts:406` | Per-module behaviour (silent during answer vs supportive) |
 | `AuthoredModule.frequency` | once / repeatable / cooldown | `lib/types/json-fields.ts:407` | Module picker filter |
 | `AuthoredModule.learnerSelectable` | true / false | `lib/wizard/detect-authored-modules.ts` | Hide module from picker |
@@ -473,7 +473,7 @@ The marker is informational — `§N` section refs are NOT machine-checked. The 
 |---------|-------------|------|
 | Tutor is quizzing on test mechanics | LO classifier — is the LO `TEACHING_INSTRUCTION`? | Run reclassify-los; or edit course-ref.md to add the rule explicitly |
 | Wrong content surfacing to learner | §6 veto table — which dimension should be blocking? | Add filter at that layer |
-| Module picker empty | `Playbook.config.modules` populated? `modulesAuthored=true`? | Re-import course-ref.md OR run `import-modules` POST |
+| Module picker empty | Authored path: `Playbook.config.modules` populated? `modulesAuthored=true`? Generated path: are there `CurriculumModule` rows for the playbook's primary curriculum? | Re-import course-ref.md OR run `import-modules` POST. For AI-gen courses, `GET /api/courses/:id/import-modules` now falls back to `Curriculum.modules[]` and returns `source: "authored" \| "generated" \| null` (#495 Slice 4.1) — picker renders the "curriculum is being prepared" empty state when both paths are empty rather than bouncing the learner. |
 | Curriculum on wrong playbook | `CallerPlaybook` enrollment correct? | L5 — already fixed but check the 3 patched sites |
 | MCQ asking meta-questions | LOs that feed MCQ pool — any `TEACHING_INSTRUCTION` slipping in? | `lib/assessment/module-groups.ts` filter must exclude all `systemRole != NONE` |
 | AI sent a doc to learner | `visualAids` / `subjectSources` loader filtering | L1 — fixed 2026-05-10. `visualAids` filters tutor-only docs; `subjectSources` now exposes `tutorOnly`; `share_content` tool (`app/api/chat/tools.ts`) still gates by `isStudentVisibleDefault`. If a leak recurs, check the documentType classification on the source — `COURSE_REFERENCE` misclassified as `TEXTBOOK` will pass through. |


### PR DESCRIPTION
## Summary

- **Picker no longer bounces AI-generated courses.** `GET /api/courses/[courseId]/import-modules` now falls back to `CurriculumModule.findMany` (scoped via `resolveCurriculumIdForPlaybook`) when `Playbook.config.modules` is empty, and projects each row into the same `AuthoredModule` shape the admin `AuthoredModulesPanel` already consumes.
- **New top-level `source: "authored" | "generated" | null`** field on the response so the UI can tell the two paths apart; the legacy `moduleSource` field is unchanged so the admin `AuthoredModulesPanel` stays backwards-compatible.
- **Student page** (`/x/student/[courseId]/modules`) drops the `modulesAuthored !== true` redirect. Zero modules on either path now show a "curriculum is being prepared" empty state instead of stranding the learner.

Implements E4 Slice 4.1 of #495.

## Test plan

- [x] `tests/api/import-modules-fallback.test.ts` — six new cases:
  - authored regression (no fallback touched when `Playbook.config.modules` is present)
  - generated fallback maps slug → id, applies defaults, fills `duration`
  - both empty → `{ modules: [], source: null }`
  - playbook with no curriculum → empty, never hits `curriculumModule.findMany`
  - 404 on missing playbook
  - 401 on auth failure
- [x] `tests/api/import-modules.test.ts` — existing 15 cases extended with default mocks for the new prisma surface; all still pass.
- [x] `npx tsc --noEmit` — no errors in the changed files (only pre-existing unrelated test-fixture mismatches).
- [ ] Manual: open `/x/student/<ai-gen-course-id>/modules` — picker renders the generated modules; open `/x/student/<authored-course-id>/modules` — picker still renders the authored catalogue.

## UI to click to verify

1. Pick an AI-generated course in `/x/student/<courseId>/modules` (previously bounced) — picker should render its modules.
2. Pick an authored course (e.g. IELTS v2.2) — picker should render the catalogue exactly as before, with the same labels and badges.
3. Pick a course with zero modules on either side — should see the "Your curriculum is being prepared" empty state, not a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)