### PR TITLE
fix(wizard): FK race preflight + auto prisma generate on dev start

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -981,7 +981,10 @@ export async function executeWizardTool(
             // course shows up as "degenerate". `upsertPlaybookSource` is
             // idempotent so this is safe to call on already-linked sources.
             if (uploadSourceIds?.length) {
-              const { upsertPlaybookSource } = await import("@/lib/knowledge/domain-sources");
+              // Pre-flight FK race guard (see new-course branch step 7c).
+              const { preflightPlaybookSourceIds, upsertPlaybookSource } =
+                await import("@/lib/knowledge/domain-sources");
+              await preflightPlaybookSourceIds(uploadSourceIds);
               for (const srcId of uploadSourceIds) {
                 await upsertPlaybookSource(existingPlaybookId, srcId);
               }
@@ -1569,7 +1572,10 @@ export async function executeWizardTool(
         //     When ingest provides sourceIds directly, create PlaybookSource without
         //     needing the Subject → SubjectSource chain.
         if (uploadSourceIds?.length) {
-          const { upsertPlaybookSource } = await import("@/lib/knowledge/domain-sources");
+          // Pre-flight FK race guard (incident 2026-05-19, course e5f379ed).
+          const { preflightPlaybookSourceIds, upsertPlaybookSource } =
+            await import("@/lib/knowledge/domain-sources");
+          await preflightPlaybookSourceIds(uploadSourceIds);
           for (const srcId of uploadSourceIds) {
             await upsertPlaybookSource(playbookId, srcId);
           }

--- a/apps/admin/lib/domain/course-setup.ts
+++ b/apps/admin/lib/domain/course-setup.ts
@@ -534,9 +534,12 @@ const stepExecutors: Record<string, (ctx: CourseSetupContext, step: CourseSetupS
       }
     }
 
-    // Phase 5: Direct PlaybookSource creation from sourceIds (bypasses Subject chain)
+    // Phase 5: Direct PlaybookSource creation from sourceIds (bypasses Subject chain).
+    // Pre-flight FK race guard — see preflightPlaybookSourceIds doc comment.
     if (ctx.input.sourceIds?.length && scaffoldResult.playbook) {
-      const { upsertPlaybookSource } = await import("@/lib/knowledge/domain-sources");
+      const { preflightPlaybookSourceIds, upsertPlaybookSource } =
+        await import("@/lib/knowledge/domain-sources");
+      await preflightPlaybookSourceIds(ctx.input.sourceIds);
       for (const srcId of ctx.input.sourceIds) {
         await upsertPlaybookSource(scaffoldResult.playbook.id, srcId);
       }

--- a/apps/admin/lib/knowledge/domain-sources.ts
+++ b/apps/admin/lib/knowledge/domain-sources.ts
@@ -74,6 +74,47 @@ export async function syncPlaybookSources(
 }
 
 /**
+ * Pre-flight check: verify every sourceId is committed as a ContentSource
+ * row before attempting `upsertPlaybookSource(playbookId, sourceId)` loops.
+ *
+ * Background (2026-05-19 incident, course e5f379ed): the wizard's Launch
+ * fires create_course immediately after the upload step. Extraction commits
+ * ContentSource rows on the order of 100–300ms per file once classification
+ * completes. If the user clicks Launch before the LAST few files commit,
+ * upsertPlaybookSource throws `PlaybookSource_sourceId_fkey` and aborts
+ * the whole create flow, leaving a half-built playbook.
+ *
+ * Strategy: check, retry once after 500ms, then fail loud with the missing
+ * IDs so the operator knows which uploads stalled. Retry-once is enough for
+ * the typical timing — anything still missing after 500ms indicates a real
+ * problem (deleted source, stalled extraction) not a race.
+ */
+export async function preflightPlaybookSourceIds(sourceIds: string[]): Promise<void> {
+  if (sourceIds.length === 0) return;
+  const verify = async (): Promise<string[]> => {
+    const existing = await prisma.contentSource.findMany({
+      where: { id: { in: sourceIds } },
+      select: { id: true },
+    });
+    const existingIds = new Set(existing.map((s) => s.id));
+    return sourceIds.filter((id) => !existingIds.has(id));
+  };
+  let missing = await verify();
+  if (missing.length > 0) {
+    console.warn(
+      `[preflightPlaybookSourceIds] ${missing.length} sourceId(s) not yet committed — retrying after 500ms: ${missing.join(", ")}`,
+    );
+    await new Promise((r) => setTimeout(r, 500));
+    missing = await verify();
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Pre-flight failed: ${missing.length} source(s) never committed as ContentSource. Missing IDs: ${missing.join(", ")}. Extraction may have stalled or sources were deleted. Re-upload the affected files and try again.`,
+    );
+  }
+}
+
+/**
  * Upsert a single PlaybookSource row. Call when a new SubjectSource is created
  * and the playbookId is known.
  */

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.315",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "npx prisma generate && next dev",
     "dev:share": "./scripts/dev-share.sh",
     "devX": "pkill -9 -f 'next dev' || true && pkill -9 -f 'next-server' || true && lsof -ti:3000 2>/dev/null | xargs kill -9 2>/dev/null || true && rm -rf .next && npm run dev",
     "devT": "vitest run",


### PR DESCRIPTION
From 2026-05-19 incident on course e5f379ed. See commit for full diagnosis. Two independent fixes — one prevents the FK race that aborted create_course mid-build, the other prevents the stale-Prisma-client class of bug that broke projection silently.