### PR TITLE
feat(#494 Slice 2.5): recommendNextModule helper

### DIFF
--- a/apps/admin/lib/curriculum/recommend-next-module.ts
+++ b/apps/admin/lib/curriculum/recommend-next-module.ts
@@ -1,0 +1,178 @@
+/**
+ * recommendNextModule — #494 E2 Slice 2.5
+ *
+ * Picks the next `CurriculumModule` a learner should attempt within a given
+ * curriculum. Works uniformly for BOTH authored courses (modules listed in
+ * `Playbook.config.modules` and synced into `CurriculumModule` rows by
+ * `sync-modules`) and AI-generated courses (modules extracted into
+ * `Curriculum.modules` directly), because both routes ultimately produce
+ * `CurriculumModule` rows attached to a `Curriculum`.
+ *
+ * Algorithm (in priority order):
+ *
+ *   1. Find the first non-mastered module in `sortOrder` whose prerequisites
+ *      (a list of sibling slugs) are all `COMPLETED` → "next-in-sequence".
+ *   2. If `strictPrerequisites === false` AND step 1 returned nothing, return
+ *      the first non-mastered module ignoring prerequisites →
+ *      "first-unstarted".
+ *   3. If nothing above AND any module is `IN_PROGRESS`, return the
+ *      lowest-sortOrder IN_PROGRESS module → "interleave-review".
+ *   4. Otherwise return null (course effectively complete, or no modules).
+ *
+ * NOTE: `prerequisites` is declared on `CurriculumModule` in the schema as
+ * `String[]` (slug list). Slice 2.4 will populate / surface it through the
+ * authoring UI; for now it may be absent on legacy rows. We read it through
+ * `(module as any).prerequisites ?? []` so this helper is safe to ship ahead
+ * of 2.4.
+ *
+ * No DB writes here — pure read + recommendation.
+ */
+import { prisma } from "@/lib/prisma";
+import { readCourseFlags } from "@/lib/curriculum/course-completion";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+export interface RecommendedModule {
+  moduleId: string;
+  slug: string;
+  title: string;
+  reason:
+    | "next-in-sequence"
+    | "weakest-not-mastered"
+    | "first-unstarted"
+    | "interleave-review";
+}
+
+export interface RecommendInput {
+  callerId: string;
+  curriculumId: string;
+  playbookConfig: PlaybookConfig | null;
+}
+
+type ProgressStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+
+interface ModuleRow {
+  id: string;
+  slug: string;
+  title: string;
+  sortOrder: number;
+  // Cast defensively — see file header. Slice 2.4 will guarantee this field.
+  prerequisites?: string[];
+}
+
+/**
+ * Resolve the next module for a learner within a curriculum. Returns `null`
+ * when the course has no modules or every module is mastered.
+ *
+ * Safe for both authored and AI-generated routes: both write
+ * `CurriculumModule` rows.
+ */
+export async function recommendNextModule(
+  input: RecommendInput,
+): Promise<RecommendedModule | null> {
+  const { callerId, curriculumId, playbookConfig } = input;
+
+  if (!callerId || !curriculumId) return null;
+
+  const { strictPrerequisites } = readCourseFlags(playbookConfig);
+
+  // 1. Load all modules for this curriculum, in teaching order.
+  const modules = (await prisma.curriculumModule.findMany({
+    where: { curriculumId, isActive: true },
+    orderBy: { sortOrder: "asc" },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      sortOrder: true,
+      prerequisites: true,
+    },
+  })) as unknown as ModuleRow[];
+
+  if (modules.length === 0) return null;
+
+  // 2. Load progress rows; index by moduleId.
+  const progressRows = await prisma.callerModuleProgress.findMany({
+    where: { callerId, moduleId: { in: modules.map((m) => m.id) } },
+    select: { moduleId: true, status: true },
+  });
+
+  const statusById = new Map<string, ProgressStatus>();
+  for (const row of progressRows) {
+    statusById.set(row.moduleId, normaliseStatus(row.status));
+  }
+
+  // Slug → status helper (prerequisites are referenced by slug).
+  const statusBySlug = new Map<string, ProgressStatus>();
+  for (const m of modules) {
+    statusBySlug.set(m.slug, statusById.get(m.id) ?? "NOT_STARTED");
+  }
+
+  // 3. Pick: first non-mastered module whose prereqs are all mastered.
+  const nonMastered = modules.filter(
+    (m) => (statusById.get(m.id) ?? "NOT_STARTED") !== "COMPLETED",
+  );
+
+  if (nonMastered.length === 0) {
+    // Every module mastered.
+    return null;
+  }
+
+  const reachable = nonMastered.find((m) => {
+    const prereqs = readPrerequisites(m);
+    return prereqs.every((slug) => statusBySlug.get(slug) === "COMPLETED");
+  });
+
+  if (reachable) {
+    return {
+      moduleId: reachable.id,
+      slug: reachable.slug,
+      title: reachable.title,
+      reason: "next-in-sequence",
+    };
+  }
+
+  // 4. Soft-prereq fallback: if strict=false, ignore prereqs and pick lowest
+  // sortOrder non-mastered.
+  if (!strictPrerequisites) {
+    const fallback = nonMastered[0];
+    return {
+      moduleId: fallback.id,
+      slug: fallback.slug,
+      title: fallback.title,
+      reason: "first-unstarted",
+    };
+  }
+
+  // 5. Interleave-review: nothing reachable, but learner has work mid-flight.
+  const inProgress = nonMastered.find(
+    (m) => (statusById.get(m.id) ?? "NOT_STARTED") === "IN_PROGRESS",
+  );
+  if (inProgress) {
+    return {
+      moduleId: inProgress.id,
+      slug: inProgress.slug,
+      title: inProgress.title,
+      reason: "interleave-review",
+    };
+  }
+
+  // Strict mode + every remaining module is gated by an unmet prereq + no
+  // IN_PROGRESS to fall back on. Course is structurally stuck — return null
+  // and let the caller surface a "blocked" UI rather than silently pick a
+  // gated module.
+  return null;
+}
+
+function normaliseStatus(raw: string | null | undefined): ProgressStatus {
+  if (raw === "COMPLETED" || raw === "IN_PROGRESS" || raw === "NOT_STARTED") {
+    return raw;
+  }
+  return "NOT_STARTED";
+}
+
+function readPrerequisites(m: ModuleRow): string[] {
+  // Defensive cast — slice 2.4 will land the canonical field. Until then
+  // legacy rows may omit it.
+  const raw = (m as { prerequisites?: unknown }).prerequisites;
+  return Array.isArray(raw) ? raw.filter((s): s is string => typeof s === "string") : [];
+}

--- a/apps/admin/tests/lib/recommend-next-module.test.ts
+++ b/apps/admin/tests/lib/recommend-next-module.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for recommendNextModule — #494 E2 Slice 2.5
+ *
+ * Pure read helper: given a curriculum and a learner's
+ * CallerModuleProgress, return the next module to attempt. Algorithm:
+ *
+ *   1. First non-mastered module whose prerequisites are all mastered
+ *      → "next-in-sequence".
+ *   2. Otherwise, if `strictPrerequisites === false`, lowest-sortOrder
+ *      non-mastered → "first-unstarted".
+ *   3. Otherwise lowest-sortOrder IN_PROGRESS → "interleave-review".
+ *   4. Otherwise null (all mastered, or strictly blocked).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+// =====================================================
+// MOCKS
+// =====================================================
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    curriculumModule: {
+      findMany: vi.fn(),
+    },
+    callerModuleProgress: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALLER_ID = "caller-1";
+const CURRICULUM_ID = "curr-1";
+
+interface FakeModule {
+  id: string;
+  slug: string;
+  title: string;
+  sortOrder: number;
+  prerequisites?: string[];
+}
+
+interface FakeProgress {
+  moduleId: string;
+  status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+}
+
+function setup(modules: FakeModule[], progress: FakeProgress[]) {
+  mockPrisma.curriculumModule.findMany.mockResolvedValue(modules as never);
+  mockPrisma.callerModuleProgress.findMany.mockResolvedValue(progress as never);
+}
+
+function mkModule(
+  slug: string,
+  sortOrder: number,
+  opts: { prerequisites?: string[]; title?: string } = {},
+): FakeModule {
+  return {
+    id: `mod-${slug}`,
+    slug,
+    title: opts.title ?? `Module ${slug}`,
+    sortOrder,
+    prerequisites: opts.prerequisites,
+  };
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("recommendNextModule (#494 Slice 2.5)", () => {
+  let recommendNextModule: typeof import("@/lib/curriculum/recommend-next-module").recommendNextModule;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/lib/curriculum/recommend-next-module");
+    recommendNextModule = mod.recommendNextModule;
+  });
+
+  it("returns null when the curriculum has no modules", async () => {
+    setup([], []);
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns module[0] as next-in-sequence when nothing is done", async () => {
+    setup(
+      [mkModule("m1", 0), mkModule("m2", 1), mkModule("m3", 2)],
+      [],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    expect(result).toEqual({
+      moduleId: "mod-m1",
+      slug: "m1",
+      title: "Module m1",
+      reason: "next-in-sequence",
+    });
+  });
+
+  it("skips a mastered module and returns the next one as next-in-sequence", async () => {
+    setup(
+      [mkModule("m1", 0), mkModule("m2", 1), mkModule("m3", 2)],
+      [{ moduleId: "mod-m1", status: "COMPLETED" }],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    expect(result?.slug).toBe("m2");
+    expect(result?.reason).toBe("next-in-sequence");
+  });
+
+  it("returns the unmet prereq itself when strictPrerequisites=true blocks the later module", async () => {
+    setup(
+      [
+        mkModule("m1", 0),
+        mkModule("m2", 1, { prerequisites: ["m1"] }),
+      ],
+      [],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { strictPrerequisites: true } as PlaybookConfig,
+    });
+    // m1 itself has no unmet prereqs, so it's the next-in-sequence pick.
+    expect(result?.slug).toBe("m1");
+    expect(result?.reason).toBe("next-in-sequence");
+  });
+
+  it("returns the lowest-sortOrder module first when strictPrerequisites=false (same shape)", async () => {
+    setup(
+      [
+        mkModule("m1", 0),
+        mkModule("m2", 1, { prerequisites: ["m1"] }),
+      ],
+      [],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { strictPrerequisites: false } as PlaybookConfig,
+    });
+    // Step 1 still finds m1 (no prereqs, not mastered) — reason stays
+    // next-in-sequence. The strict flag only changes behaviour when step 1
+    // fails to find any reachable module.
+    expect(result?.slug).toBe("m1");
+    expect(result?.reason).toBe("next-in-sequence");
+  });
+
+  it("returns the terminal module when all non-terminal modules are mastered", async () => {
+    setup(
+      [
+        mkModule("m1", 0),
+        mkModule("m2", 1),
+        mkModule("mock", 2, { prerequisites: ["m1", "m2"] }),
+      ],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED" },
+        { moduleId: "mod-m2", status: "COMPLETED" },
+      ],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { strictPrerequisites: true } as PlaybookConfig,
+    });
+    expect(result?.slug).toBe("mock");
+    expect(result?.reason).toBe("next-in-sequence");
+  });
+
+  it("returns null when every module is mastered", async () => {
+    setup(
+      [mkModule("m1", 0), mkModule("m2", 1)],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED" },
+        { moduleId: "mod-m2", status: "COMPLETED" },
+      ],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns IN_PROGRESS as interleave-review when strict=true gates every NOT_STARTED via unmet prereqs", async () => {
+    // m1 IN_PROGRESS (not mastered → can't satisfy prereqs).
+    // m2 + m3 NOT_STARTED but both require m1 → gated.
+    // Strict mode + no reachable NOT_STARTED → fall back to in-progress.
+    setup(
+      [
+        mkModule("m1", 0),
+        mkModule("m2", 1, { prerequisites: ["m1"] }),
+        mkModule("m3", 2, { prerequisites: ["m1"] }),
+      ],
+      [{ moduleId: "mod-m1", status: "IN_PROGRESS" }],
+    );
+
+    // Force step 1 (next-in-sequence) to fail by mastering nothing yet
+    // making m1 unreachable. To exercise the interleave branch we need
+    // m1 to ALSO have an unmet prereq — re-shape:
+    setup(
+      [
+        mkModule("m0", 0), // gate — not mastered, no prereqs
+        mkModule("m1", 1, {
+          prerequisites: ["m0"], // unmet (m0 not mastered)
+        }),
+      ],
+      // m1 is IN_PROGRESS but gated by m0.
+      [{ moduleId: "mod-m1", status: "IN_PROGRESS" }],
+    );
+    // With this shape, step 1 returns m0 (no prereqs, not mastered) →
+    // next-in-sequence. interleave-review only fires when EVERY
+    // non-mastered module has an unmet prereq. Reshape once more so even
+    // m0 is unreachable: give m0 a prereq on a hypothetical "ghost" slug
+    // not in the curriculum.
+    setup(
+      [
+        mkModule("m0", 0, { prerequisites: ["ghost"] }), // unmet
+        mkModule("m1", 1, {
+          prerequisites: ["m0"], // unmet
+        }),
+      ],
+      [{ moduleId: "mod-m1", status: "IN_PROGRESS" }],
+    );
+
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { strictPrerequisites: true } as PlaybookConfig,
+    });
+    expect(result).toEqual({
+      moduleId: "mod-m1",
+      slug: "m1",
+      title: "Module m1",
+      reason: "interleave-review",
+    });
+  });
+
+  it("returns null (not interleave-review) when strict=true blocks everything and no module is IN_PROGRESS", async () => {
+    setup(
+      [
+        mkModule("m0", 0, { prerequisites: ["ghost"] }),
+        mkModule("m1", 1, { prerequisites: ["m0"] }),
+      ],
+      [],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { strictPrerequisites: true } as PlaybookConfig,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns first-unstarted when strict=false AND every module is gated by an unmet prereq", async () => {
+    setup(
+      [
+        mkModule("m0", 0, { prerequisites: ["ghost"] }),
+        mkModule("m1", 1, { prerequisites: ["m0"] }),
+      ],
+      [],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { strictPrerequisites: false } as PlaybookConfig,
+    });
+    expect(result).toEqual({
+      moduleId: "mod-m0",
+      slug: "m0",
+      title: "Module m0",
+      reason: "first-unstarted",
+    });
+  });
+
+  it("treats absent prerequisites field on a module as no prereqs", async () => {
+    // Legacy row pre-slice-2.4 — prerequisites omitted. Should NOT block.
+    setup(
+      [
+        { id: "mod-m1", slug: "m1", title: "Module m1", sortOrder: 0 },
+        { id: "mod-m2", slug: "m2", title: "Module m2", sortOrder: 1 },
+      ],
+      [],
+    );
+    const result = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    expect(result?.slug).toBe("m1");
+    expect(result?.reason).toBe("next-in-sequence");
+  });
+
+  it("returns null when callerId or curriculumId is empty", async () => {
+    const a = await recommendNextModule({
+      callerId: "",
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    const b = await recommendNextModule({
+      callerId: CALLER_ID,
+      curriculumId: "",
+      playbookConfig: null,
+    });
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+    expect(mockPrisma.curriculumModule.findMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Pure read helper `recommendNextModule()` that picks the next `CurriculumModule` a learner should attempt within a given curriculum. Foundation for the picker / journey-rail wiring in later 2.x slices.

**Works for BOTH authored AND AI-generated courses** because both paths ultimately produce `CurriculumModule` rows attached to a `Curriculum` — authored via `sync-modules` from `Playbook.config.modules`, AI-generated via the extraction pipeline writing `Curriculum.modules[]` directly. The helper queries `CurriculumModule` and is route-agnostic.

## Algorithm (priority order)

1. **`next-in-sequence`** — first non-mastered module in `sortOrder` whose prerequisites (sibling slugs) are all `COMPLETED`.
2. **`first-unstarted`** — if `strictPrerequisites === false` and step 1 found nothing, pick the lowest-`sortOrder` non-mastered module ignoring prereqs.
3. **`interleave-review`** — if every non-mastered module is gated by an unmet prereq (strict mode) but one is `IN_PROGRESS`, return that.
4. **`null`** — course complete, or strictly blocked with no IN_PROGRESS fallback.

`strictPrerequisites` is read from `Playbook.config` via the existing `readCourseFlags()` helper (Slice 2.3).

## Notes

- `prerequisites` field on `CurriculumModule` is read defensively (`(module as any).prerequisites ?? []`) so this lands ahead of Slice 2.4 which populates it through the authoring UI. Schema already declares it as `String[]`.
- No DB writes. No callers are wired here — that's later 2.x work.
- ESLint slug-scope rule satisfied: all lookups are scoped by `curriculumId`.

## Test plan

- [x] 12 vitest tests, all green: `npx vitest run tests/lib/recommend-next-module.test.ts`
- [x] `npx tsc --noEmit` clean on new files
- [x] Empty curriculum → null
- [x] Linear sequence pick + skip-mastered
- [x] Strict prereq blocks later module, returns the prereq itself as next-in-sequence
- [x] Terminal module pick when all earlier mastered
- [x] All mastered → null
- [x] Interleave-review only when strict-mode every module is gated AND one IN_PROGRESS exists
- [x] first-unstarted under soft strict when everything is gated
- [x] Legacy rows without `prerequisites` field handled

## UI to click

Nothing yet — plumbing only. Wiring lands in later 2.x slices (#494).

🤖 Generated with [Claude Code](https://claude.com/claude-code)