### PR TITLE
fix(#491 Slice 1.4): multi-module evidence fan-out via coversModules

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -1226,6 +1226,78 @@ export async function incrementModuleEvidence(
 }
 
 /**
+ * #491 Slice 1.4 — Resolve the set of CurriculumModule ids that should be
+ * credited with evidence (callCount++) for this call.
+ *
+ * Always includes the call's bound `curriculumModuleId` (Slice 1.3). When the
+ * bound module declares a `coversModules: string[]` array (authored per-module
+ * concept — "this Mock covers part1/part2/part3"), each slug is resolved
+ * against the call's curriculum and added to the set. Unresolved slugs (typo,
+ * deleted module) are logged and skipped — the caller still gets credit for
+ * the bound module + every slug that did resolve.
+ *
+ * The schema field `coversModules` arrives in Slice 2.4. Until then it is read
+ * via `(module as any).coversModules` and treated as `[]` when absent — every
+ * existing authored / AI-generated module simply falls back to single-credit
+ * behaviour, identical to Slice 1.3.
+ *
+ * Returns a deduped array of `CurriculumModule.id` values. The bound moduleId
+ * is always position 0 when present so callers can distinguish "primary" from
+ * "fan-out" in logs.
+ */
+export async function resolveModuleEvidenceTargets(
+  call: { id: string; playbookId: string | null; curriculumModuleId: string | null },
+  log: PipelineLogger,
+): Promise<string[]> {
+  const boundModuleId = call.curriculumModuleId;
+  if (!boundModuleId) return [];
+
+  const credits: string[] = [boundModuleId];
+  const seen = new Set<string>([boundModuleId]);
+
+  const boundModule = await prisma.curriculumModule.findUnique({
+    where: { id: boundModuleId },
+    select: { id: true, slug: true, curriculumId: true },
+  });
+  if (!boundModule) {
+    log.warn("resolveModuleEvidenceTargets: bound CurriculumModule not found", {
+      callId: call.id,
+      moduleId: boundModuleId,
+    });
+    return credits;
+  }
+
+  // `coversModules` is authored metadata; DB column lands in Slice 2.4. Cast
+  // through `any` and treat missing/undefined as the empty array so this code
+  // is a no-op for every module that hasn't declared the field.
+  const coversModules: unknown = (boundModule as any).coversModules;
+  if (!Array.isArray(coversModules) || coversModules.length === 0) {
+    return credits;
+  }
+
+  const slugs = coversModules.filter((s): s is string => typeof s === "string" && s.length > 0);
+  if (slugs.length === 0) return credits;
+
+  for (const slug of slugs) {
+    const resolved = await resolveModuleByLogicalId(boundModule.curriculumId, slug);
+    if (!resolved) {
+      log.warn("resolveModuleEvidenceTargets: coversModules slug did not resolve", {
+        callId: call.id,
+        boundModuleId,
+        curriculumId: boundModule.curriculumId,
+        unresolvedSlug: slug,
+      });
+      continue;
+    }
+    if (seen.has(resolved.id)) continue;
+    seen.add(resolved.id);
+    credits.push(resolved.id);
+  }
+
+  return credits;
+}
+
+/**
  * Aggregate caller personality from call scores
  * Creates/updates PersonalityObservation for the call and CallerPersonality aggregate
  *
@@ -2485,25 +2557,42 @@ const stageExecutors: Record<string, StageExecutor> = {
       errors: aggregateResult.errors
     });
 
-    // 3. #491 Slice 1.3 — increment CallerModuleProgress.callCount for the
-    // module this call was attributed to (Slice 1.1 wrote curriculumModuleId
-    // at call-create; Slice 1.2 wrote it on every CallScore). Idempotent on
-    // pipeline force-rerun via the lastCallId check inside the helper.
-    const evidenceResult = await incrementModuleEvidence(
-      ctx.callId,
-      ctx.callerId,
-      ctx.call.curriculumModuleId,
-      ctx.log
+    // 3. #491 Slice 1.3 + 1.4 — increment CallerModuleProgress.callCount for
+    // every module credited by this call. Slice 1.3 credited only the bound
+    // module (`Call.curriculumModuleId`); Slice 1.4 fans out via the bound
+    // module's `coversModules: string[]` declaration so an IELTS Mock counts
+    // as evidence for part1 + part2 + part3 in addition to "mock" itself.
+    // Idempotent on pipeline force-rerun via the lastCallId check inside the
+    // helper. Per-segment CallScore attribution is Slice 1.5.
+    const moduleEvidenceTargets = await resolveModuleEvidenceTargets(ctx.call, ctx.log);
+    const evidenceResults = await Promise.all(
+      moduleEvidenceTargets.map((moduleId) =>
+        incrementModuleEvidence(ctx.callId, ctx.callerId, moduleId, ctx.log),
+      ),
     );
+    // Primary (bound module) is always position 0 — preserve the Slice 1.3
+    // summary fields so downstream consumers don't break, then add a fan-out
+    // count for observability.
+    const primaryEvidence = evidenceResults[0] ?? { callCount: -1, created: false, skipped: true };
+    if (moduleEvidenceTargets.length > 1) {
+      ctx.log.info("Module evidence fan-out applied", {
+        callId: ctx.callId,
+        boundModuleId: ctx.call.curriculumModuleId,
+        creditedModuleIds: moduleEvidenceTargets,
+        creditedCount: moduleEvidenceTargets.length,
+      });
+    }
 
     return {
       personalityObservationCreated: personalityResult.observationCreated,
       personalityProfileUpdated: personalityResult.profileUpdated,
       aggregateSpecsRun: aggregateResult.specsRun,
       profileUpdates: aggregateResult.profileUpdates,
-      moduleEvidenceCallCount: evidenceResult.callCount,
-      moduleEvidenceCreated: evidenceResult.created,
-      moduleEvidenceSkipped: evidenceResult.skipped,
+      moduleEvidenceCallCount: primaryEvidence.callCount,
+      moduleEvidenceCreated: primaryEvidence.created,
+      moduleEvidenceSkipped: primaryEvidence.skipped,
+      moduleEvidenceCreditedCount: moduleEvidenceTargets.length,
+      moduleEvidenceCreditedModuleIds: moduleEvidenceTargets,
     };
   },
 

--- a/apps/admin/tests/lib/aggregate-multi-module-evidence.test.ts
+++ b/apps/admin/tests/lib/aggregate-multi-module-evidence.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests for resolveModuleEvidenceTargets — #491 Slice 1.4
+ *
+ * Exported from app/api/calls/[callId]/pipeline/route.ts. Used by the
+ * AGGREGATE stage to build the deduped set of CurriculumModule ids that
+ * should receive callCount evidence for this call. Slice 1.3 credited only
+ * the bound module (`Call.curriculumModuleId`); Slice 1.4 fans out via the
+ * authored `coversModules: string[]` array on the bound module so an IELTS
+ * Mock counts as evidence for part1 + part2 + part3.
+ *
+ * Coverage:
+ *  - Mock module with coversModules=[part1,part2,part3] → 4 credits (mock + 3 parts).
+ *  - Authored module with coversModules undefined → 1 credit (regression of 1.3).
+ *  - AI-authored module with coversModules=[] → 1 credit (regression of 1.3).
+ *  - coversModules contains an unknown slug → warn + skip, credit the rest.
+ *  - call.curriculumModuleId null → empty credit set, no DB hits.
+ *  - Bound CurriculumModule row missing → log warn + return [bound] only.
+ *  - Duplicate slug in coversModules → deduped.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// =====================================================
+// MOCKS
+// =====================================================
+
+const { mockPrisma, mockResolveModuleByLogicalId } = vi.hoisted(() => ({
+  mockPrisma: {
+    callerModuleProgress: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    curriculumModule: {
+      findUnique: vi.fn(),
+    },
+    // Unused but referenced at route module load time.
+    analysisSpec: { findFirst: vi.fn() },
+    call: { findUnique: vi.fn() },
+    callScore: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), findMany: vi.fn() },
+    callerMemory: { create: vi.fn() },
+    callerPersonality: { upsert: vi.fn() },
+    personalityObservation: { create: vi.fn() },
+    parameter: { findMany: vi.fn() },
+  },
+  mockResolveModuleByLogicalId: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/curriculum/resolve-module", () => ({
+  resolveModuleByLogicalId: mockResolveModuleByLogicalId,
+  resolveCurriculumIdForPlaybook: vi.fn(),
+}));
+
+// Avoid pulling in real AI / metering / config registries when the route
+// module loads.
+vi.mock("@/lib/ai/client", () => ({
+  isEngineAvailable: vi.fn(() => true),
+}));
+vi.mock("@/lib/metering", () => ({
+  getConfiguredMeteredAICompletion: vi.fn(),
+  logMockAIUsage: vi.fn(),
+}));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(),
+  isAuthError: vi.fn(() => false),
+}));
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALL_ID = "call-1";
+const CURRICULUM_ID = "curr-ielts";
+const MOCK_MODULE_ID = "mod-mock-uuid";
+const PART1_MODULE_ID = "mod-part1-uuid";
+const PART2_MODULE_ID = "mod-part2-uuid";
+const PART3_MODULE_ID = "mod-part3-uuid";
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    getLogs: vi.fn(() => []),
+    getDuration: vi.fn(() => 0),
+  };
+}
+
+function makeCall(overrides: Partial<{ id: string; playbookId: string | null; curriculumModuleId: string | null }> = {}) {
+  return {
+    id: CALL_ID,
+    playbookId: "pb-ielts",
+    curriculumModuleId: MOCK_MODULE_ID,
+    ...overrides,
+  };
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("resolveModuleEvidenceTargets (#491 Slice 1.4)", () => {
+  let resolveModuleEvidenceTargets: typeof import("@/app/api/calls/[callId]/pipeline/route").resolveModuleEvidenceTargets;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/calls/[callId]/pipeline/route");
+    resolveModuleEvidenceTargets = mod.resolveModuleEvidenceTargets;
+  });
+
+  it("fans out for a Mock with coversModules=[part1,part2,part3] (4 credits)", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: MOCK_MODULE_ID,
+      slug: "mock",
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["part1", "part2", "part3"],
+    });
+    mockResolveModuleByLogicalId.mockImplementation(async (_curriculumId: string, slug: string) => {
+      if (slug === "part1") return { id: PART1_MODULE_ID };
+      if (slug === "part2") return { id: PART2_MODULE_ID };
+      if (slug === "part3") return { id: PART3_MODULE_ID };
+      return null;
+    });
+
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(makeCall(), log as any);
+
+    expect(targets).toEqual([
+      MOCK_MODULE_ID,
+      PART1_MODULE_ID,
+      PART2_MODULE_ID,
+      PART3_MODULE_ID,
+    ]);
+    expect(mockResolveModuleByLogicalId).toHaveBeenCalledTimes(3);
+    expect(mockResolveModuleByLogicalId).toHaveBeenCalledWith(CURRICULUM_ID, "part1");
+    expect(mockResolveModuleByLogicalId).toHaveBeenCalledWith(CURRICULUM_ID, "part2");
+    expect(mockResolveModuleByLogicalId).toHaveBeenCalledWith(CURRICULUM_ID, "part3");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("authored module with coversModules undefined → single credit (Slice 1.3 regression)", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: MOCK_MODULE_ID,
+      slug: "mod-1",
+      curriculumId: CURRICULUM_ID,
+      // coversModules omitted entirely
+    });
+
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(makeCall(), log as any);
+
+    expect(targets).toEqual([MOCK_MODULE_ID]);
+    expect(mockResolveModuleByLogicalId).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("AI-generated module with coversModules=[] → single credit (Slice 1.3 regression)", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: MOCK_MODULE_ID,
+      slug: "mod-ai",
+      curriculumId: CURRICULUM_ID,
+      coversModules: [],
+    });
+
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(makeCall(), log as any);
+
+    expect(targets).toEqual([MOCK_MODULE_ID]);
+    expect(mockResolveModuleByLogicalId).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs and skips an unresolved coversModules slug, credits the rest", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: MOCK_MODULE_ID,
+      slug: "mock",
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["part1", "part-typo", "part3"],
+    });
+    mockResolveModuleByLogicalId.mockImplementation(async (_curriculumId: string, slug: string) => {
+      if (slug === "part1") return { id: PART1_MODULE_ID };
+      if (slug === "part3") return { id: PART3_MODULE_ID };
+      return null; // part-typo doesn't resolve
+    });
+
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(makeCall(), log as any);
+
+    expect(targets).toEqual([MOCK_MODULE_ID, PART1_MODULE_ID, PART3_MODULE_ID]);
+    expect(mockResolveModuleByLogicalId).toHaveBeenCalledTimes(3);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("coversModules slug did not resolve"),
+      expect.objectContaining({
+        callId: CALL_ID,
+        boundModuleId: MOCK_MODULE_ID,
+        curriculumId: CURRICULUM_ID,
+        unresolvedSlug: "part-typo",
+      }),
+    );
+  });
+
+  it("returns empty when call.curriculumModuleId is null (no DB lookups)", async () => {
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(
+      makeCall({ curriculumModuleId: null }),
+      log as any,
+    );
+
+    expect(targets).toEqual([]);
+    expect(mockPrisma.curriculumModule.findUnique).not.toHaveBeenCalled();
+    expect(mockResolveModuleByLogicalId).not.toHaveBeenCalled();
+  });
+
+  it("warns and returns [bound] when the bound CurriculumModule row is missing", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue(null);
+
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(makeCall(), log as any);
+
+    expect(targets).toEqual([MOCK_MODULE_ID]);
+    expect(mockResolveModuleByLogicalId).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("bound CurriculumModule not found"),
+      expect.objectContaining({ callId: CALL_ID, moduleId: MOCK_MODULE_ID }),
+    );
+  });
+
+  it("dedupes when coversModules resolves to the bound module or a repeat", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: MOCK_MODULE_ID,
+      slug: "mock",
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["mock", "part1", "part1"], // self-ref + duplicate
+    });
+    mockResolveModuleByLogicalId.mockImplementation(async (_curriculumId: string, slug: string) => {
+      if (slug === "mock") return { id: MOCK_MODULE_ID };
+      if (slug === "part1") return { id: PART1_MODULE_ID };
+      return null;
+    });
+
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(makeCall(), log as any);
+
+    expect(targets).toEqual([MOCK_MODULE_ID, PART1_MODULE_ID]);
+  });
+
+  it("ignores non-string entries in coversModules (defensive against bad seed data)", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: MOCK_MODULE_ID,
+      slug: "mock",
+      curriculumId: CURRICULUM_ID,
+      // Bad authoring data — Prisma string[] would catch this at DB layer once
+      // Slice 2.4 lands, but the helper is defensive in the meantime.
+      coversModules: ["part1", null, "", 42],
+    });
+    mockResolveModuleByLogicalId.mockImplementation(async (_curriculumId: string, slug: string) => {
+      if (slug === "part1") return { id: PART1_MODULE_ID };
+      return null;
+    });
+
+    const log = makeLogger();
+    const targets = await resolveModuleEvidenceTargets(makeCall(), log as any);
+
+    expect(targets).toEqual([MOCK_MODULE_ID, PART1_MODULE_ID]);
+    expect(mockResolveModuleByLogicalId).toHaveBeenCalledTimes(1);
+    expect(mockResolveModuleByLogicalId).toHaveBeenCalledWith(CURRICULUM_ID, "part1");
+  });
+});


### PR DESCRIPTION
## Summary
- AGGREGATE stage now credits **every** module a call covers, not just the bound one. An IELTS Mock call (Part1+Part2+Part3) bumps `CallerModuleProgress.callCount` for all four modules (mock + 3 parts) instead of one.
- Driven by a new per-module authoring concept `coversModules?: string[]` declared on the bound `CurriculumModule`. The DB column lands in Slice 2.4; for now it's read via `(module as any).coversModules` and treated as `[]` when absent, so every existing course preserves the single-credit Slice 1.3 behaviour.
- For authored courses the `coversModules` declaration becomes the author-time source of truth once Slice 2.4 adds the schema field. For AI-generated courses the field arrives via generator output on the same schema.

## What changed
- `apps/admin/app/api/calls/[callId]/pipeline/route.ts`
  - New exported helper `resolveModuleEvidenceTargets(call, log)` resolves the deduped set of `CurriculumModule.id`s to credit. Always includes the bound moduleId; resolves each `coversModules` slug via `resolveModuleByLogicalId(curriculumId, slug)` (#407 scope-safe); logs+skips unresolvable slugs.
  - AGGREGATE stage maps the credit set through the existing `incrementModuleEvidence` helper (idempotent on force-rerun via `lastCallId`). Primary (bound) module stays at position 0 so Slice 1.3 summary fields (`moduleEvidenceCallCount`/`Created`/`Skipped`) remain the bound module's row; adds `moduleEvidenceCreditedCount` + `moduleEvidenceCreditedModuleIds` for observability.
- `apps/admin/tests/lib/aggregate-multi-module-evidence.test.ts` (new)
  - 8 cases: Mock fan-out (4 credits), `coversModules` undefined → single credit (1.3 regression), `coversModules=[]` → single credit (1.3 regression), unresolvable slug → warn+skip+credit rest, null bound module → empty set, bound row missing → bound-only + warn, dedup (self-ref + duplicate slug), defensive non-string filtering.

## Not in this slice (deliberate)
- Schema (DB column for `coversModules`) — Slice 2.4.
- `CallScore.moduleId` fan-out — the score-segmenter that attributes per-segment scores to the right module is Slice 1.5. CallScore writes still pass `moduleId: call.curriculumModuleId` at all three sites, untouched here.

## Test plan
- [x] `npx vitest run tests/lib/aggregate-multi-module-evidence.test.ts tests/lib/caller-module-progress-increment.test.ts` — all 14 pass (8 new + 6 existing).
- [x] `npx tsc --noEmit` — no new errors on changed files (pre-existing errors on lines 1110 + 2250-2252 confirmed against `origin/main`).
- [ ] Manual: once Slice 2.4 lands the DB column, seed a Mock module with `coversModules: ["part1","part2","part3"]` and confirm a single Mock call bumps callCount on all four modules in `/x/caller/{id}/progress`.
- [ ] Manual: confirm existing IELTS courses without `coversModules` still bump exactly one row (regression of Slice 1.3 behaviour).

Closes #491 (slice 1.4 only — epic remains open).