### PR TITLE
feat(#495 Slice 4.2): per-module status badges in picker (authored + generated)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -19,7 +19,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { requireAuth, isAuthError } from "@/lib/permissions";
+import { requireAuth, isAuthError, ROLE_LEVEL } from "@/lib/permissions";
 import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
 import { detectAuthoredModules } from "@/lib/wizard/detect-authored-modules";
 import {
@@ -29,6 +29,19 @@ import {
 import { syncAuthoredModulesToCurriculum } from "@/lib/wizard/sync-authored-modules-to-curriculum";
 import { reclassifyLearningObjectives } from "@/lib/curriculum/reclassify-los";
 import { resolveCurriculumIdForPlaybook } from "@/lib/curriculum/resolve-module";
+
+// #495 Slice 4.2 — picker status badge. Per-module progress is returned to
+// the learner picker so each tile/rail card can render Mastered / In progress
+// / Not started. The presentational vocabulary mirrors SimProgressPanel
+// (E5 #493 Slice 5.2): DB `COMPLETED` → presentational `MASTERED`. Anyone
+// without a caller scope (admin viewing the route directly with no
+// `?callerId=`) gets no `progress` field at all so the UI suppresses the
+// badge — completion is per-learner, not per-course.
+type PickerProgressStatus = "MASTERED" | "IN_PROGRESS" | "NOT_STARTED";
+interface PickerProgress {
+  status: PickerProgressStatus;
+  callCount: number;
+}
 
 // ── Body schema ──────────────────────────────────────────────────────
 
@@ -60,10 +73,15 @@ type Body = z.infer<typeof BodySchema>;
  *   field (`"authored" | "derived" | null`) is preserved for backwards
  *   compatibility with the admin AuthoredModulesPanel.
  * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, source, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification }
+ * @note #495 Slice 4.2 — each `modules[]` entry includes an optional
+ *   `progress: { status: "MASTERED"|"IN_PROGRESS"|"NOT_STARTED", callCount }`
+ *   field when the request carries a caller scope (STUDENT, or OPERATOR+
+ *   with `?callerId=…`). Admins without a caller scope receive modules
+ *   without `progress` — the picker suppresses the badge in that case.
  * @response 404 { ok: false, error: "Course not found" }
  */
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ courseId: string }> },
 ): Promise<NextResponse> {
   const auth = await requireAuth("VIEWER");
@@ -100,6 +118,31 @@ export async function GET(
       pickerSource = "generated";
     }
   }
+
+  // #495 Slice 4.2 — resolve which caller's progress (if any) to enrich
+  // the response with. STUDENT users get their own caller; OPERATOR+ may
+  // pass `?callerId=` to inspect on a learner's behalf (same convention
+  // as /api/student/module-progress). Admins without `?callerId=` get a
+  // module list with NO `progress` field — the picker hides the badge.
+  const progressByModuleId = await resolveProgressForCaller(
+    auth.session.user.role,
+    auth.session.user.id,
+    req.nextUrl.searchParams.get("callerId"),
+    courseId,
+    modulesForResponse,
+  );
+  const modulesWithProgress = progressByModuleId
+    ? modulesForResponse.map((m) => ({
+        ...m,
+        progress: progressByModuleId[m.id] ?? {
+          // Synthetic NOT_STARTED so the picker still shows a "Not started"
+          // badge for modules the caller has never opened — beats hiding
+          // the badge for the common cold-start case.
+          status: "NOT_STARTED" as PickerProgressStatus,
+          callCount: 0,
+        },
+      }))
+    : modulesForResponse;
 
   // #281 Slice 3b: per-module ContentQuestion count so the AuthoredModules
   // panel can show a "no learner-facing content" banner for modules whose
@@ -181,7 +224,10 @@ export async function GET(
     // present, generated fallback otherwise). `source` tells the UI which
     // path produced them; the legacy `moduleSource` (authored | derived)
     // is preserved unchanged for the admin AuthoredModulesPanel.
-    modules: modulesForResponse,
+    // #495 Slice 4.2 — when a caller scope is resolvable, each module
+    // gains a `progress: { status, callCount }` field so the picker can
+    // render a Mastered / In progress / Not started badge.
+    modules: modulesWithProgress,
     source: pickerSource,
     moduleDefaults: cfg.moduleDefaults ?? {},
     moduleSource: cfg.moduleSource ?? null,
@@ -257,6 +303,85 @@ async function loadGeneratedModulesAsAuthored(
     prerequisites: Array.isArray(row.prerequisites) ? row.prerequisites : [],
     position: row.sortOrder,
   }));
+}
+
+/**
+ * #495 Slice 4.2 — resolve a `slug → PickerProgress` map keyed by
+ * AuthoredModule.id (which equals CurriculumModule.slug by convention,
+ * matching the picker page's progress-grouping logic).
+ *
+ * Returns `null` when no caller scope is resolvable:
+ *   - STUDENT but no LEARNER Caller linked → null (treat as no-scope; the
+ *     picker simply hides the badge rather than showing every module as
+ *     "Not started", which would be misleading mid-onboarding).
+ *   - OPERATOR+ without `?callerId=` → null (admin-only direct view).
+ *   - Lower roles (TESTER/VIEWER) without `?callerId=` → null.
+ *
+ * Returns `{}` (empty object) when a caller IS resolved but has no
+ * progress rows — the GET handler then synthesises NOT_STARTED for each
+ * module so the picker can show "Not started" everywhere.
+ */
+async function resolveProgressForCaller(
+  role: string,
+  userId: string,
+  callerIdParam: string | null,
+  courseId: string,
+  modules: AuthoredModule[],
+): Promise<Record<string, PickerProgress> | null> {
+  if (modules.length === 0) return null;
+
+  const roleLevel =
+    (ROLE_LEVEL as Record<string, number | undefined>)[role] ?? 0;
+
+  let callerId: string | null = null;
+  if (role === "STUDENT") {
+    const caller = await prisma.caller.findFirst({
+      where: { userId, role: "LEARNER" },
+      select: { id: true },
+    });
+    callerId = caller?.id ?? null;
+  } else if (roleLevel >= ROLE_LEVEL.OPERATOR && callerIdParam) {
+    // Verify the requested caller is a LEARNER — same shape check
+    // `requireStudentOrAdmin` uses. We don't 404 here; we just decline
+    // to enrich, mirroring "no scope" semantics.
+    const caller = await prisma.caller.findFirst({
+      where: { id: callerIdParam, role: "LEARNER" },
+      select: { id: true },
+    });
+    callerId = caller?.id ?? null;
+  }
+
+  if (!callerId) return null;
+
+  // Scope progress rows to this Playbook's curricula so the same slug
+  // across two courses doesn't bleed in. Mirrors module-progress route.
+  const rows = await prisma.callerModuleProgress.findMany({
+    where: {
+      callerId,
+      module: { curriculum: { playbookId: courseId } },
+    },
+    select: {
+      status: true,
+      callCount: true,
+      module: { select: { slug: true } },
+    },
+  });
+
+  const bySlug: Record<string, PickerProgress> = {};
+  for (const row of rows) {
+    const slug = row.module?.slug;
+    if (!slug) continue;
+    bySlug[slug] = {
+      // DB "COMPLETED" → presentational "MASTERED" (mirrors E5 #493).
+      status: row.status === "COMPLETED"
+        ? "MASTERED"
+        : row.status === "IN_PROGRESS"
+          ? "IN_PROGRESS"
+          : "NOT_STARTED",
+      callCount: row.callCount ?? 0,
+    };
+  }
+  return bySlug;
 }
 
 /**

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -26,6 +26,9 @@ import {
   CircleDot,
   CircleDashed,
   AlertCircle,
+  CheckCircle2,
+  PlayCircle,
+  Circle,
 } from "lucide-react";
 import type { AuthoredModule } from "@/lib/types/json-fields";
 
@@ -195,6 +198,7 @@ function Tile({
       data-terminal={mod.sessionTerminal || undefined}
       data-progress={inProgress ? "in-progress" : completed ? "completed" : undefined}
     >
+      <StatusBadge progress={mod.progress} />
       <ModeIcon mode={mod.mode} />
       <div className="learner-picker__tile-body">
         <div className="learner-picker__tile-label">{mod.label}</div>
@@ -274,6 +278,7 @@ function RailLayout({
               data-progress={isComplete ? "completed" : isInProgress ? "in-progress" : undefined}
               data-terminal={m.sessionTerminal || undefined}
             >
+              <StatusBadge progress={m.progress} />
               <ModeIcon mode={m.mode} />
               <div className="learner-picker__rail-body">
                 <div className="learner-picker__rail-label">
@@ -327,4 +332,47 @@ function describeFrequency(freq: AuthoredModule["frequency"]): string {
   if (freq === "once") return "Once";
   if (freq === "cooldown") return "Cooldown";
   return "Repeatable";
+}
+
+// ── Status badge (#495 Slice 4.2) ──────────────────────────────────
+//
+// Per-module Mastered / In progress / Not started chip pinned to the
+// top-right of every tile / rail card. Source of truth is the
+// import-modules endpoint, which writes `progress` when a caller scope
+// is resolvable (STUDENT or OPERATOR+ ?callerId=). Modules without a
+// `progress` field render nothing — preserves the legacy admin-preview
+// usage (mounted inside AuthoredModulesPanel) where there's no caller.
+//
+// Icons match SimProgressPanel (CheckCircle2 / PlayCircle / Circle) so
+// the learner's surfaces stay visually consistent across the picker
+// and the in-call progress drawer.
+function StatusBadge({ progress }: { progress: AuthoredModule["progress"] }) {
+  if (!progress) return null;
+  if (progress.status === "MASTERED") {
+    return (
+      <span className="learner-picker-page__status-badge learner-picker-page__status-badge--mastered">
+        <CheckCircle2 size={12} aria-hidden="true" />
+        <span>Mastered</span>
+      </span>
+    );
+  }
+  if (progress.status === "IN_PROGRESS") {
+    return (
+      <span className="learner-picker-page__status-badge learner-picker-page__status-badge--in-progress">
+        <PlayCircle size={12} aria-hidden="true" />
+        <span>
+          In progress
+          {progress.callCount > 0 && (
+            <> ({progress.callCount} call{progress.callCount === 1 ? "" : "s"})</>
+          )}
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span className="learner-picker-page__status-badge learner-picker-page__status-badge--not-started">
+      <Circle size={12} aria-hidden="true" />
+      <span>Not started</span>
+    </span>
+  );
 }

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -418,6 +418,7 @@
 }
 
 .learner-picker__tile {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 10px;
@@ -511,6 +512,7 @@ button.learner-picker__tile:hover {
 }
 
 .learner-picker__rail-card {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 10px;
@@ -607,4 +609,49 @@ button.learner-picker__rail-card:hover {
 .learner-picker-page__empty {
   padding: 24px;
   text-align: center;
+}
+
+/* #495 Slice 4.2 — per-module status badge pinned to the top-right
+   corner of every tile / rail card. Driven by `AuthoredModule.progress`
+   which the read-side endpoint enriches per-caller. The Mastered /
+   In progress / Not started vocabulary mirrors SimProgressPanel so the
+   learner's surfaces stay consistent. Tokens come from the global
+   design system (--status-success-text / --status-warning-text /
+   --text-muted) — wa-theme tokens (--wa-amber etc.) aren't loaded on
+   this route, so the corresponding admin-surface tokens are used. */
+
+.learner-picker-page__status-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  pointer-events: none; /* purely informative — don't trap tile clicks */
+  line-height: 1.4;
+}
+
+.learner-picker-page__status-badge--mastered {
+  color: var(--status-success-text);
+  background: color-mix(in srgb, var(--status-success-text) 10%, transparent);
+  border-color: color-mix(in srgb, var(--status-success-text) 25%, transparent);
+}
+
+.learner-picker-page__status-badge--in-progress {
+  color: var(--status-warning-text);
+  background: color-mix(in srgb, var(--status-warning-text) 12%, transparent);
+  border-color: color-mix(in srgb, var(--status-warning-text) 30%, transparent);
+}
+
+.learner-picker-page__status-badge--not-started {
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 8%, transparent);
+  border-color: color-mix(in srgb, var(--text-muted) 20%, transparent);
 }

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -550,6 +550,19 @@ export interface AuthoredModule {
   prerequisites: string[];
   /** Ordinal position in a structured course's lesson plan. Optional in continuous mode. */
   position?: number;
+  /**
+   * #495 Slice 4.2 — per-caller progress for the picker badge. Populated
+   * only by the read-side picker endpoint
+   * (`GET /api/courses/[id]/import-modules`) when a caller scope is
+   * resolvable (STUDENT, or OPERATOR+ with `?callerId=`). NEVER stored on
+   * `Playbook.config.modules`; the read-side enriches it on the fly.
+   * DB `COMPLETED` is mapped to presentational `MASTERED` (mirrors E5
+   * #493 Slice 5.2 / SimProgressPanel).
+   */
+  progress?: {
+    status: "MASTERED" | "IN_PROGRESS" | "NOT_STARTED";
+    callCount: number;
+  };
 }
 
 export interface ModuleDefaults {

--- a/apps/admin/tests/api/import-modules-fallback.test.ts
+++ b/apps/admin/tests/api/import-modules-fallback.test.ts
@@ -48,6 +48,21 @@ vi.mock("@/lib/prisma", () => ({
 vi.mock("@/lib/permissions", () => ({
   requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
   isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+  // #495 Slice 4.2: the route reads ROLE_LEVEL to decide whether to
+  // enrich the response with per-module caller progress. Mirror lib/roles
+  // so this fallback-focused suite stays green without depending on
+  // @/lib/auth.
+  ROLE_LEVEL: {
+    DEMO: 0,
+    VIEWER: 1,
+    TESTER: 1,
+    STUDENT: 1,
+    SUPER_TESTER: 2,
+    OPERATOR: 3,
+    EDUCATOR: 3,
+    ADMIN: 4,
+    SUPERADMIN: 5,
+  },
 }));
 
 // Import AFTER mocks

--- a/apps/admin/tests/api/import-modules-status-badges.test.ts
+++ b/apps/admin/tests/api/import-modules-status-badges.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the #495 Slice 4.2 progress-badge enrichment in
+ * GET /api/courses/[courseId]/import-modules.
+ *
+ * Each `AuthoredModule` returned to the learner picker should carry an
+ * optional `progress: { status, callCount }` field when the request has
+ * a caller scope (STUDENT, or OPERATOR+ with `?callerId=`). Mapping is
+ *   DB status COMPLETED   → presentational MASTERED
+ *   DB status IN_PROGRESS → IN_PROGRESS
+ *   DB status NOT_STARTED → NOT_STARTED
+ *   no row found          → synthetic NOT_STARTED + callCount 0
+ * Admins without a caller scope get NO `progress` field at all — the UI
+ * suppresses the badge entirely so it never claims an unscoped state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const { mockPrisma, mockRequireAuth, mockIsAuthError } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: {
+      findUnique: vi.fn(),
+    },
+    curriculum: {
+      findFirst: vi.fn(),
+    },
+    curriculumModule: {
+      findMany: vi.fn(),
+    },
+    contentQuestion: {
+      groupBy: vi.fn(),
+    },
+    learningObjective: {
+      findMany: vi.fn(),
+    },
+    caller: {
+      findFirst: vi.fn(),
+    },
+    callerModuleProgress: {
+      findMany: vi.fn(),
+    },
+  },
+  mockRequireAuth: vi.fn(),
+  mockIsAuthError: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+  isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+  // Mirror the constants from lib/roles so the route's role-gating works
+  // without importing the real `@/lib/auth` chain in tests.
+  ROLE_LEVEL: {
+    DEMO: 0,
+    VIEWER: 1,
+    TESTER: 1,
+    STUDENT: 1,
+    SUPER_TESTER: 2,
+    OPERATOR: 3,
+    EDUCATOR: 3,
+    ADMIN: 4,
+    SUPERADMIN: 5,
+  },
+}));
+
+// Import AFTER mocks
+import { GET } from "@/app/api/courses/[courseId]/import-modules/route";
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeGetReq(query?: string): NextRequest {
+  const url = `http://localhost:3000/api/courses/playbook-1/import-modules${query ? `?${query}` : ""}`;
+  return new NextRequest(url);
+}
+
+const params = Promise.resolve({ courseId: "playbook-1" });
+
+const authoredPlaybook = {
+  id: "playbook-1",
+  config: {
+    modulesAuthored: true,
+    moduleSource: "authored",
+    modules: [
+      {
+        id: "m1",
+        label: "Module One",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "Student-led",
+        scoringFired: "LR + GRA only",
+        voiceBandReadout: false,
+        sessionTerminal: false,
+        frequency: "repeatable",
+        outcomesPrimary: [],
+        prerequisites: [],
+      },
+      {
+        id: "m2",
+        label: "Module Two",
+        learnerSelectable: true,
+        mode: "examiner",
+        duration: "20 min",
+        scoringFired: "All four",
+        voiceBandReadout: true,
+        sessionTerminal: true,
+        frequency: "once",
+        outcomesPrimary: [],
+        prerequisites: [],
+      },
+      {
+        id: "m3",
+        label: "Module Three",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "10 min",
+        scoringFired: "All four",
+        voiceBandReadout: false,
+        sessionTerminal: false,
+        frequency: "repeatable",
+        outcomesPrimary: [],
+        prerequisites: [],
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  mockRequireAuth.mockReset();
+  mockIsAuthError.mockReset();
+  mockPrisma.playbook.findUnique.mockReset();
+  mockPrisma.curriculum.findFirst.mockReset();
+  mockPrisma.curriculumModule.findMany.mockReset();
+  mockPrisma.contentQuestion.groupBy.mockReset();
+  mockPrisma.learningObjective.findMany.mockReset();
+  mockPrisma.caller.findFirst.mockReset();
+  mockPrisma.callerModuleProgress.findMany.mockReset();
+
+  mockIsAuthError.mockReturnValue(false);
+  mockPrisma.contentQuestion.groupBy.mockResolvedValue([]);
+  mockPrisma.learningObjective.findMany.mockResolvedValue([]);
+  // Fallback path should not be reached for an authored playbook, but
+  // default to safe no-ops anyway.
+  mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+  mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
+});
+
+// ── Case 1: STUDENT viewing own picker ───────────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — STUDENT progress enrichment (#495 Slice 4.2)", () => {
+  it("includes per-module progress with COMPLETED→MASTERED mapping", async () => {
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "user-student-1", role: "STUDENT" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(authoredPlaybook);
+    // Caller lookup keyed on the session user.
+    mockPrisma.caller.findFirst.mockResolvedValue({ id: "caller-1" });
+    // Two progress rows; m3 has no row → should synthesise NOT_STARTED.
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      { status: "COMPLETED", callCount: 5, module: { slug: "m1" } },
+      { status: "IN_PROGRESS", callCount: 2, module: { slug: "m2" } },
+    ]);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.modules).toHaveLength(3);
+
+    // DB COMPLETED → presentational MASTERED, callCount preserved.
+    expect(body.modules[0].progress).toEqual({
+      status: "MASTERED",
+      callCount: 5,
+    });
+    expect(body.modules[1].progress).toEqual({
+      status: "IN_PROGRESS",
+      callCount: 2,
+    });
+    // No row for m3 → synthetic NOT_STARTED row.
+    expect(body.modules[2].progress).toEqual({
+      status: "NOT_STARTED",
+      callCount: 0,
+    });
+
+    // STUDENT path resolves the caller via session.userId.
+    expect(mockPrisma.caller.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user-student-1", role: "LEARNER" },
+      select: { id: true },
+    });
+    // Progress query is scoped to this Playbook's curricula.
+    const progressArgs = mockPrisma.callerModuleProgress.findMany.mock.calls[0][0];
+    expect(progressArgs.where).toMatchObject({
+      callerId: "caller-1",
+      module: { curriculum: { playbookId: "playbook-1" } },
+    });
+  });
+});
+
+// ── Case 2: OPERATOR with ?callerId= ─────────────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — OPERATOR with callerId (#495 Slice 4.2)", () => {
+  it("enriches progress for the specified caller", async () => {
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "admin-user-1", role: "OPERATOR" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(authoredPlaybook);
+    // OPERATOR path validates the explicit callerId.
+    mockPrisma.caller.findFirst.mockResolvedValue({ id: "target-caller" });
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      { status: "COMPLETED", callCount: 3, module: { slug: "m1" } },
+    ]);
+
+    const res = await GET(makeGetReq("callerId=target-caller"), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.modules[0].progress).toEqual({
+      status: "MASTERED",
+      callCount: 3,
+    });
+    // Other modules synthesise NOT_STARTED with callCount 0.
+    expect(body.modules[1].progress).toEqual({
+      status: "NOT_STARTED",
+      callCount: 0,
+    });
+    expect(body.modules[2].progress).toEqual({
+      status: "NOT_STARTED",
+      callCount: 0,
+    });
+
+    // Caller lookup keys on the URL param, not session.userId.
+    expect(mockPrisma.caller.findFirst).toHaveBeenCalledWith({
+      where: { id: "target-caller", role: "LEARNER" },
+      select: { id: true },
+    });
+    const progressArgs = mockPrisma.callerModuleProgress.findMany.mock.calls[0][0];
+    expect(progressArgs.where).toMatchObject({
+      callerId: "target-caller",
+      module: { curriculum: { playbookId: "playbook-1" } },
+    });
+  });
+});
+
+// ── Case 3: OPERATOR without callerId — no enrichment ────────────
+
+describe("GET /api/courses/[courseId]/import-modules — OPERATOR without callerId (#495 Slice 4.2)", () => {
+  it("omits progress entirely (no caller scope)", async () => {
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "admin-user-1", role: "OPERATOR" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(authoredPlaybook);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.modules).toHaveLength(3);
+    for (const m of body.modules) {
+      expect(m.progress).toBeUndefined();
+    }
+    // Neither caller nor progress queries should fire — bail out early.
+    expect(mockPrisma.caller.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.callerModuleProgress.findMany).not.toHaveBeenCalled();
+  });
+});
+
+// ── Case 4: caller with zero progress rows ───────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — empty progress (#495 Slice 4.2)", () => {
+  it("synthesises NOT_STARTED for every module when the caller has no rows", async () => {
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "user-student-2", role: "STUDENT" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(authoredPlaybook);
+    mockPrisma.caller.findFirst.mockResolvedValue({ id: "caller-cold" });
+    // Cold-start — no progress rows yet.
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.modules).toHaveLength(3);
+    for (const m of body.modules) {
+      expect(m.progress).toEqual({
+        status: "NOT_STARTED",
+        callCount: 0,
+      });
+    }
+  });
+});

--- a/apps/admin/tests/api/import-modules.test.ts
+++ b/apps/admin/tests/api/import-modules.test.ts
@@ -55,6 +55,21 @@ vi.mock("@/lib/prisma", () => ({
 vi.mock("@/lib/permissions", () => ({
   requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
   isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+  // #495 Slice 4.2: the route reads ROLE_LEVEL to decide whether to
+  // enrich the response with per-module caller progress (admins need
+  // `?callerId=`, students get auto-resolved). Mirror lib/roles so the
+  // existing tests stay unaffected without depending on @/lib/auth.
+  ROLE_LEVEL: {
+    DEMO: 0,
+    VIEWER: 1,
+    TESTER: 1,
+    STUDENT: 1,
+    SUPER_TESTER: 2,
+    OPERATOR: 3,
+    EDUCATOR: 3,
+    ADMIN: 4,
+    SUPERADMIN: 5,
+  },
 }));
 
 // #245: sync helper mocked so route tests stay focused on routing/persistence.


### PR DESCRIPTION
## Summary

- API `GET /api/courses/[id]/import-modules` enriches each `AuthoredModule` with optional `progress: { status, callCount }` when a caller scope is resolvable (STUDENT session or OPERATOR+ via `?callerId=`). Admins without a caller scope get no `progress` field, so the badge is suppressed
- UI: new `StatusBadge` in `LearnerModulePicker` pinned top-right of every tile and rail card. Renders Mastered (green check) / In progress (amber play, with "(N calls)" suffix when applicable) / Not started (grey circle). Icons match `SimProgressPanel`, tokens come from the global design system (`--status-success-text`, `--status-warning-text`, `--text-muted`) — no inline static styles, no new hex
- Works for **both** authored AND AI-generated courses because the read-side keys on `AuthoredModule.id` which already equals `CurriculumModule.slug` after Slice 4.1
- DB `COMPLETED` → presentational `MASTERED` mirrors E5 #493 Slice 5.2

## Test plan

- [x] `tests/api/import-modules-status-badges.test.ts` — 4 cases covering STUDENT enrichment, OPERATOR+`?callerId=`, OPERATOR without callerId (no enrichment), cold-start caller (synthetic NOT_STARTED). All green.
- [x] Existing `import-modules.test.ts` (15 tests) and `import-modules-fallback.test.ts` (6 tests) still pass — updated their `@/lib/permissions` mock to include `ROLE_LEVEL` so the new role-gated helper has the constants it needs.
- [x] `learner-module-picker.test.tsx` (21 tests) still green after adding `<StatusBadge>` to both tile + rail.
- [x] `npx tsc --noEmit` clean on all changed files.
- [x] `npx eslint <changed files>` — zero new errors / warnings (3 pre-existing warnings on lines I didn't touch).
- [ ] UI verification: open `/x/student/[courseId]/modules?callerId=…` for both an authored course (e.g. IELTS) and an AI-generated course; confirm Mastered / In progress / Not started badges render top-right of each tile/rail card with correct colours.

Ready for `/vm-cp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)