### PR TITLE
feat(#494 Slice 2.4): per-module progression fields (prerequisites, terminal, coversModules, masteryThreshold)

### DIFF
--- a/apps/admin/lib/curriculum/course-completion.ts
+++ b/apps/admin/lib/curriculum/course-completion.ts
@@ -65,3 +65,73 @@ export function readCourseFlags(
 
   return { strictPrerequisites, completionMode };
 }
+
+/**
+ * Default mastery threshold applied when neither the module nor the playbook
+ * sets one. 0.7 matches IELTS-style "borderline secure" floor and is the
+ * fallback used across the picker / completion checks.
+ */
+export const DEFAULT_MASTERY_THRESHOLD = 0.7;
+
+/**
+ * Resolved per-module progression flags. Always fully populated — defaults
+ * applied for any missing or null field. Callers (recommend-module, picker,
+ * isCourseComplete) read this rather than touching raw module rows.
+ */
+export interface ModuleFlags {
+  prerequisites: string[];
+  terminal: boolean;
+  coversModules: string[];
+  masteryThreshold: number;
+}
+
+/**
+ * Shape accepted by `readModuleFlags` — narrow enough that both Prisma's
+ * `CurriculumModule` row and the JSON `AuthoredModule` shape satisfy it
+ * (after the right field aliases at the call site). All four inputs are
+ * optional + nullable so the helper is safe against legacy data and
+ * partially-populated JSON blobs.
+ */
+export interface ReadableModuleFlags {
+  prerequisites?: string[] | null;
+  terminal?: boolean | null;
+  coversModules?: string[] | null;
+  masteryThreshold?: number | null;
+}
+
+/**
+ * Read per-module progression flags from a `CurriculumModule` row (or an
+ * `AuthoredModule`-shaped JSON object), applying defaults for any missing
+ * or null value.
+ *
+ *   - `prerequisites`     → `[]` when null/undefined
+ *   - `terminal`          → `false` when null/undefined
+ *   - `coversModules`     → `[]` when null/undefined
+ *   - `masteryThreshold`  → `playbookDefaultThreshold` (default 0.7) when null
+ *
+ * `playbookDefaultThreshold` is the per-playbook fallback — callers that have
+ * a playbook-level threshold available (e.g. from `Playbook.config`) should
+ * pass it; otherwise the function-level default of 0.7 applies.
+ *
+ * Defensive only: this helper does NOT validate that prerequisite or
+ * coversModules slugs exist on the playbook. That's the picker's job
+ * (Slice 2.5).
+ */
+export function readModuleFlags(
+  module: ReadableModuleFlags,
+  playbookDefaultThreshold: number = DEFAULT_MASTERY_THRESHOLD,
+): ModuleFlags {
+  const prerequisites = Array.isArray(module.prerequisites)
+    ? module.prerequisites
+    : [];
+  const terminal = typeof module.terminal === "boolean" ? module.terminal : false;
+  const coversModules = Array.isArray(module.coversModules)
+    ? module.coversModules
+    : [];
+  const masteryThreshold =
+    typeof module.masteryThreshold === "number"
+      ? module.masteryThreshold
+      : playbookDefaultThreshold;
+
+  return { prerequisites, terminal, coversModules, masteryThreshold };
+}

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -563,6 +563,30 @@ export interface AuthoredModule {
     status: "MASTERED" | "IN_PROGRESS" | "NOT_STARTED";
     callCount: number;
   };
+  /**
+   * #494 E2 Slice 2.4 — progression flags mirrored on `CurriculumModule`.
+   *
+   * `terminal` (default false): course-complete trigger when
+   *   `Playbook.config.completionMode === "terminal-only"`. The terminal
+   *   module's mastery flips the course done. Distinct from the existing
+   *   `sessionTerminal` flag, which is about ending the current session.
+   *
+   * `coversModules` (default []): slug list of sibling modules whose
+   *   evidence this module's calls ALSO count toward — IELTS Mock Exam
+   *   produces scores attributed to part1/part2/part3 simultaneously.
+   *
+   * `masteryThreshold` (default null = use playbook-level 0.7):
+   *   per-module override for the score required to mark this module
+   *   MASTERED. Mirrors `CurriculumModule.masteryThreshold`.
+   *
+   * All three are optional on the authored JSON shape because authors
+   * may omit them; the defensive reader in
+   * `lib/curriculum/course-completion.ts::readModuleFlags()` fills
+   * defaults at read time.
+   */
+  terminal?: boolean;
+  coversModules?: string[];
+  masteryThreshold?: number;
 }
 
 export interface ModuleDefaults {

--- a/apps/admin/prisma/migrations/20260519_494_module_progression_fields/migration.sql
+++ b/apps/admin/prisma/migrations/20260519_494_module_progression_fields/migration.sql
@@ -1,0 +1,28 @@
+-- #494 E2 Slice 2.4 — per-module progression fields.
+--
+-- Adds two new columns to CurriculumModule so module-mastery progression
+-- (terminal-module course-complete + Mock-covers-part1/2/3 attribution) is
+-- backed by real columns instead of defensive `(module as any)` reads:
+--
+--   * `terminal`       — course-complete trigger when
+--                        Playbook.config.completionMode === "terminal-only".
+--   * `coversModules`  — slug list of modules whose evidence this module's
+--                        calls ALSO count toward (Mock covers part1/2/3).
+--
+-- `masteryThreshold` (Float?) and `prerequisites` (text[]) already exist on
+-- CurriculumModule from earlier slices — only the two new columns are added
+-- here.
+--
+-- Safe to run on a populated prod DB:
+--   * Both columns use IF NOT EXISTS.
+--   * `terminal` is NOT NULL with a literal default (false), so existing
+--     rows backfill to false without a separate UPDATE.
+--   * `coversModules` is NOT NULL with default `{}::text[]` — Prisma's
+--     standard pattern for String[] columns. Existing rows backfill to []
+--     automatically.
+
+ALTER TABLE "CurriculumModule"
+  ADD COLUMN IF NOT EXISTS "terminal" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "CurriculumModule"
+  ADD COLUMN IF NOT EXISTS "coversModules" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -2348,6 +2348,14 @@ model CurriculumModule {
   keyTerms                 String[]
   assessmentCriteria       String[]
 
+  // #494 E2 Slice 2.4 — module progression flags.
+  // `terminal` = course-complete trigger when Playbook.config.completionMode === "terminal-only".
+  // `coversModules` = slug list of modules whose evidence this module's calls
+  //   also count toward (e.g. IELTS Mock Exam covers part1/part2/part3).
+  // Read via `lib/curriculum/course-completion.ts::readModuleFlags()`.
+  terminal      Boolean  @default(false)
+  coversModules String[]
+
   // Lifecycle
   isActive  Boolean  @default(true)
   createdAt DateTime @default(now())

--- a/apps/admin/tests/lib/module-flags-defaults.test.ts
+++ b/apps/admin/tests/lib/module-flags-defaults.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for `readModuleFlags()` in `lib/curriculum/course-completion.ts`
+ * (#494 E2 Slice 2.4).
+ *
+ * Covers defaulting behaviour for the four per-module progression fields
+ * provisioned in this slice:
+ *   - `prerequisites`     (String[])  default []
+ *   - `terminal`          (Boolean)   default false
+ *   - `coversModules`     (String[])  default []
+ *   - `masteryThreshold`  (Float?)    default = playbook-level (0.7)
+ *
+ * Both the Prisma `CurriculumModule` row and the `AuthoredModule` JSON
+ * shape satisfy the `ReadableModuleFlags` input — this helper is the
+ * single read-site so downstream callers (recommend-module, picker,
+ * isCourseComplete) share one default story.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  DEFAULT_MASTERY_THRESHOLD,
+  readModuleFlags,
+} from "@/lib/curriculum/course-completion";
+
+describe("readModuleFlags", () => {
+  it("returns defaults when every field is null", () => {
+    expect(
+      readModuleFlags({
+        prerequisites: null,
+        terminal: null,
+        coversModules: null,
+        masteryThreshold: null,
+      }),
+    ).toEqual({
+      prerequisites: [],
+      terminal: false,
+      coversModules: [],
+      masteryThreshold: 0.7,
+    });
+  });
+
+  it("returns defaults when every field is undefined", () => {
+    expect(readModuleFlags({})).toEqual({
+      prerequisites: [],
+      terminal: false,
+      coversModules: [],
+      masteryThreshold: 0.7,
+    });
+  });
+
+  it("passes through empty arrays unchanged", () => {
+    expect(
+      readModuleFlags({
+        prerequisites: [],
+        terminal: false,
+        coversModules: [],
+        masteryThreshold: null,
+      }),
+    ).toEqual({
+      prerequisites: [],
+      terminal: false,
+      coversModules: [],
+      masteryThreshold: 0.7,
+    });
+  });
+
+  it("passes filled prerequisites + coversModules verbatim", () => {
+    const flags = readModuleFlags({
+      prerequisites: ["part1", "part2"],
+      terminal: true,
+      coversModules: ["part1", "part2", "part3"],
+      masteryThreshold: 0.85,
+    });
+    expect(flags).toEqual({
+      prerequisites: ["part1", "part2"],
+      terminal: true,
+      coversModules: ["part1", "part2", "part3"],
+      masteryThreshold: 0.85,
+    });
+  });
+
+  it("falls back to playbook-level default when masteryThreshold is null", () => {
+    expect(
+      readModuleFlags(
+        { masteryThreshold: null },
+        0.8, // playbook-level override
+      ).masteryThreshold,
+    ).toBe(0.8);
+  });
+
+  it("falls back to playbook-level default when masteryThreshold is undefined", () => {
+    expect(readModuleFlags({}, 0.65).masteryThreshold).toBe(0.65);
+  });
+
+  it("falls back to function-level 0.7 when no playbook default is passed", () => {
+    expect(readModuleFlags({}).masteryThreshold).toBe(
+      DEFAULT_MASTERY_THRESHOLD,
+    );
+    expect(DEFAULT_MASTERY_THRESHOLD).toBe(0.7);
+  });
+
+  it("returns the module's masteryThreshold verbatim when set, ignoring playbook default", () => {
+    expect(
+      readModuleFlags({ masteryThreshold: 0.55 }, 0.9).masteryThreshold,
+    ).toBe(0.55);
+  });
+
+  it("treats a non-array prerequisites value as []", () => {
+    // Defensive: legacy / hand-edited JSON could leak a non-array through
+    // the `as any` casts in some call sites. The reader must not propagate
+    // garbage downstream.
+    const flags = readModuleFlags({
+      prerequisites: "part1" as unknown as string[],
+    });
+    expect(flags.prerequisites).toEqual([]);
+  });
+
+  it("treats a non-array coversModules value as []", () => {
+    const flags = readModuleFlags({
+      coversModules: { 0: "part1" } as unknown as string[],
+    });
+    expect(flags.coversModules).toEqual([]);
+  });
+
+  it("treats a non-boolean terminal as false", () => {
+    const flags = readModuleFlags({
+      terminal: "true" as unknown as boolean,
+    });
+    expect(flags.terminal).toBe(false);
+  });
+
+  it("accepts a Prisma-style row shape (extra fields ignored)", () => {
+    // Sanity check: the helper's `ReadableModuleFlags` shape is loose enough
+    // that a real CurriculumModule row passes through with only the four
+    // relevant fields read.
+    const moduleRow = {
+      id: "abc",
+      curriculumId: "cur-1",
+      slug: "part2",
+      title: "Part 2",
+      prerequisites: ["part1"],
+      terminal: false,
+      coversModules: [],
+      masteryThreshold: 0.75,
+    };
+    expect(readModuleFlags(moduleRow)).toEqual({
+      prerequisites: ["part1"],
+      terminal: false,
+      coversModules: [],
+      masteryThreshold: 0.75,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

E2 Slice 2.4 of the module-mastery epic (#494). Provisions the data shape that
slices 1.4 and 2.5 currently read via defensive ``(module as any)`` casts.

- **Schema** — adds ``terminal Boolean @default(false)`` and ``coversModules String[]`` to ``CurriculumModule``. ``prerequisites`` and ``masteryThreshold`` already existed there.
- **AuthoredModule JSON** — adds ``terminal?``, ``coversModules?``, ``masteryThreshold?`` (optional) so authored and AI-generated routes share the same vocabulary. ``prerequisites`` was already present.
- **Defensive reader** — new ``readModuleFlags(module, playbookDefault?)`` in ``lib/curriculum/course-completion.ts``. Single read-site for the four flags. Accepts either a Prisma row or an ``AuthoredModule`` JSON shape; null / undefined / non-array inputs fall back to safe defaults. ``masteryThreshold`` defaults to ``playbookDefaultThreshold`` (0.7) when not set on the module.
- **Migration** — ``20260519_494_module_progression_fields/migration.sql``. Additive only, ``IF NOT EXISTS`` on both column adds, literal defaults so existing rows backfill without a separate UPDATE. Safe on populated prod.

## Out of scope

This slice deliberately does **NOT** touch the existing ``(module as any)`` reads in ``recommendNextModule.ts`` or ``pipeline/route.ts`` — those still compile and behave correctly against the now-real columns. A later sweep will replace them with calls through ``readModuleFlags()``.

## Deploy

``/vm-cpp`` (schema migration).

## Test plan

- [x] ``npx vitest run tests/lib/module-flags-defaults.test.ts`` — 12 / 12 green (null inputs, undefined inputs, empty arrays, filled arrays, masteryThreshold null → playbook default, masteryThreshold null → function default 0.7, masteryThreshold passthrough, non-array prerequisites / coversModules defensively coerced to [], non-boolean terminal coerced to false, real Prisma-shaped row).
- [x] ``npx vitest run tests/lib/course-flags-defaults.test.ts`` — 10 / 10 green (regression check on the existing helper in the same file).
- [x] ``npx tsc --noEmit`` — no errors on the changed files (``course-completion.ts``, ``json-fields.ts``, schema-generated client). Pre-existing unrelated errors in other test files unchanged.
- [x] ``npx prisma format`` + ``npx prisma generate`` — clean.
- [ ] After ``/vm-cpp``: run ``\\\\dt CurriculumModule`` on dev DB and confirm ``terminal`` + ``coversModules`` columns are present with correct defaults.
- [ ] UI: nothing to click in this slice — plumbing only. Slice 2.5 picker and 2.7 ``isCourseComplete`` will exercise the columns.

Closes #494 Slice 2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)