### PR TITLE
feat(#494 Slice 2.2): module mastery formula (EMA over CallScore) + completion flip

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -37,6 +37,7 @@ import { updateCurriculumProgress, getCurriculumProgress, completeModule, update
 // initializeLessonPlanSession removed — scheduler replaces session tracking
 import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
 import { resolveCurriculumIdForPlaybook, resolveModuleByLogicalId } from "@/lib/curriculum/resolve-module";
+import { computeModuleMastery } from "@/lib/curriculum/compute-mastery";
 import { ContractRegistry } from "@/lib/contracts/registry";
 import { loadPipelineStages, PipelineStage } from "@/lib/pipeline/config";
 
@@ -1223,6 +1224,123 @@ export async function incrementModuleEvidence(
     status: nextStatus,
   });
   return { callCount: updated.callCount, created: false, skipped: false };
+}
+
+/**
+ * #494 E2 Slice 2.2 — Recompute `CallerModuleProgress.mastery` from the
+ * EMA over `CallScore` rows for (callerId, moduleId) and flip status to
+ * COMPLETED when the threshold is crossed.
+ *
+ * Called after `incrementModuleEvidence` for every module credited by the
+ * current call (Slice 1.3 bound module + Slice 1.4 coversModules fan-out).
+ * The mastery value becomes the canonical store — legacy
+ * `CallerAttribute mastery:*` writes are deprecated and will be removed
+ * in Slice 2.1.
+ *
+ * Idempotency: only writes when `mastery` or `status` actually change
+ * relative to the existing row. Re-running the pipeline on the same call
+ * with no new CallScore rows produces zero DB writes here.
+ *
+ * No-op when the row does not exist (caller never had a CallScore for
+ * this module). `incrementModuleEvidence` already created the row when a
+ * call's bound moduleId arrives; this helper is safe to call before that
+ * row exists — it simply skips.
+ *
+ * Per-call overrides (passed in from AGGREGATE):
+ *   - `masteryThreshold` — `CurriculumModule.masteryThreshold` if set, else 0.7.
+ *   - `emaHalfLifeDays`  — `Playbook.config.skillScoringEmaHalfLifeDays`.
+ *   - `minCallsToFull`   — `Playbook.config.skillMinCallsToFull`.
+ */
+export async function writeModuleMastery(
+  callerId: string,
+  moduleId: string,
+  options: {
+    masteryThreshold?: number;
+    emaHalfLifeDays?: number;
+    minCallsToFull?: number;
+  },
+  log: PipelineLogger,
+): Promise<{
+  mastery: number;
+  evidenceCount: number;
+  statusFlipped: boolean;
+  skipped: boolean;
+}> {
+  const existing = await prisma.callerModuleProgress.findUnique({
+    where: { callerId_moduleId: { callerId, moduleId } },
+    select: { id: true, mastery: true, status: true, completedAt: true },
+  });
+
+  if (!existing) {
+    // No progress row yet — caller has never had a call attributed here.
+    // `incrementModuleEvidence` creates the row when a call is attributed
+    // to this module, but is itself a no-op when `Call.curriculumModuleId`
+    // is null. Either way, there is nothing to update.
+    log.debug("writeModuleMastery skipped: no CallerModuleProgress row", {
+      callerId,
+      moduleId,
+    });
+    return { mastery: 0, evidenceCount: 0, statusFlipped: false, skipped: true };
+  }
+
+  const { mastery, evidenceCount, shouldMarkCompleted } =
+    await computeModuleMastery(prisma, {
+      callerId,
+      moduleId,
+      masteryThreshold: options.masteryThreshold,
+      emaHalfLifeDays: options.emaHalfLifeDays,
+      minCallsToFull: options.minCallsToFull,
+    });
+
+  // Idempotency: only write when mastery or status actually changes. The
+  // pipeline re-runs the AGGREGATE stage on every force=true call; without
+  // this guard each re-run would burn a write even when the EMA over the
+  // same CallScore rows produced an identical mastery value.
+  const shouldFlipToCompleted =
+    shouldMarkCompleted && existing.status !== "COMPLETED";
+  const masteryUnchanged = existing.mastery === mastery;
+
+  if (masteryUnchanged && !shouldFlipToCompleted) {
+    log.debug("writeModuleMastery skipped: no change", {
+      callerId,
+      moduleId,
+      mastery,
+      evidenceCount,
+      status: existing.status,
+    });
+    return {
+      mastery,
+      evidenceCount,
+      statusFlipped: false,
+      skipped: true,
+    };
+  }
+
+  await prisma.callerModuleProgress.update({
+    where: { id: existing.id },
+    data: {
+      mastery,
+      ...(shouldFlipToCompleted
+        ? { status: "COMPLETED", completedAt: new Date() }
+        : {}),
+    },
+  });
+
+  log.info("CallerModuleProgress mastery updated", {
+    callerId,
+    moduleId,
+    mastery,
+    evidenceCount,
+    statusFlipped: shouldFlipToCompleted,
+    previousStatus: existing.status,
+  });
+
+  return {
+    mastery,
+    evidenceCount,
+    statusFlipped: shouldFlipToCompleted,
+    skipped: false,
+  };
 }
 
 /**
@@ -2583,6 +2701,84 @@ const stageExecutors: Record<string, StageExecutor> = {
       });
     }
 
+    // 4. #494 E2 Slice 2.2 — recompute CallerModuleProgress.mastery as the
+    // EMA over CallScore rows for each credited module and flip status to
+    // COMPLETED when the per-module threshold is crossed AND minCallsToFull
+    // pieces of evidence have accumulated. CallerModuleProgress.mastery is
+    // the canonical store from this slice forward — legacy CallerAttribute
+    // mastery:* writes are deprecated (reconcile + remove in Slice 2.1).
+    //
+    // Load per-module masteryThreshold + playbook config once for the call,
+    // not per credited module — every credited module shares the same
+    // playbook + curriculum (coversModules can only fan out within the
+    // bound module's curriculum). The threshold IS per-module though, so
+    // fetch each row's value.
+    let masteryResults: Array<{
+      moduleId: string;
+      mastery: number;
+      evidenceCount: number;
+      statusFlipped: boolean;
+      skipped: boolean;
+    }> = [];
+    if (moduleEvidenceTargets.length > 0) {
+      // Playbook config drives EMA tuning. `ctx.call.playbookId` may be null
+      // for self-serve / unenrolled SIM callers — fall back to module-level
+      // defaults in that case. The keys mirror `aggregate-runner.ts` so the
+      // skill-EMA and module-mastery paths stay in lockstep.
+      let emaHalfLifeDays: number | undefined;
+      let minCallsToFull: number | undefined;
+      if (ctx.call.playbookId) {
+        const pb = await prisma.playbook.findUnique({
+          where: { id: ctx.call.playbookId },
+          select: { config: true },
+        });
+        const pbCfg = (pb?.config ?? {}) as Record<string, unknown>;
+        if (typeof pbCfg.skillScoringEmaHalfLifeDays === "number") {
+          emaHalfLifeDays = pbCfg.skillScoringEmaHalfLifeDays;
+        }
+        if (typeof pbCfg.skillMinCallsToFull === "number") {
+          minCallsToFull = pbCfg.skillMinCallsToFull;
+        }
+      }
+
+      // Per-module threshold lookup. `masteryThreshold` is a real column on
+      // CurriculumModule today; the `(m as any)` cast is defensive because
+      // older Prisma client builds in transit may not expose it.
+      const moduleRows = await prisma.curriculumModule.findMany({
+        where: { id: { in: moduleEvidenceTargets } },
+        select: { id: true, masteryThreshold: true },
+      });
+      const thresholdById = new Map<string, number | null>(
+        moduleRows.map((m) => [m.id, (m as any).masteryThreshold ?? null]),
+      );
+
+      masteryResults = await Promise.all(
+        moduleEvidenceTargets.map(async (moduleId) => {
+          const moduleThreshold = thresholdById.get(moduleId) ?? null;
+          const result = await writeModuleMastery(
+            ctx.callerId,
+            moduleId,
+            {
+              masteryThreshold:
+                typeof moduleThreshold === "number" ? moduleThreshold : undefined,
+              emaHalfLifeDays,
+              minCallsToFull,
+            },
+            ctx.log,
+          );
+          return { moduleId, ...result };
+        }),
+      );
+    }
+
+    const primaryMastery = masteryResults[0] ?? {
+      mastery: 0,
+      evidenceCount: 0,
+      statusFlipped: false,
+      skipped: true,
+    };
+    const masteryFlippedCount = masteryResults.filter((r) => r.statusFlipped).length;
+
     return {
       personalityObservationCreated: personalityResult.observationCreated,
       personalityProfileUpdated: personalityResult.profileUpdated,
@@ -2593,6 +2789,10 @@ const stageExecutors: Record<string, StageExecutor> = {
       moduleEvidenceSkipped: primaryEvidence.skipped,
       moduleEvidenceCreditedCount: moduleEvidenceTargets.length,
       moduleEvidenceCreditedModuleIds: moduleEvidenceTargets,
+      moduleMastery: primaryMastery.mastery,
+      moduleMasteryEvidenceCount: primaryMastery.evidenceCount,
+      moduleMasteryStatusFlipped: primaryMastery.statusFlipped,
+      moduleMasteryFlippedCount: masteryFlippedCount,
     };
   },
 

--- a/apps/admin/lib/curriculum/compute-mastery.ts
+++ b/apps/admin/lib/curriculum/compute-mastery.ts
@@ -1,0 +1,150 @@
+/**
+ * Module mastery computation (#494 E2 Slice 2.2).
+ *
+ * Deterministic EMA over `CallScore` rows for a (callerId, moduleId) pair.
+ * Becomes the canonical source of truth for `CallerModuleProgress.mastery`
+ * — the legacy `CallerAttribute mastery:*` writes are deprecated and will
+ * be reconciled / deleted in Slice 2.1.
+ *
+ * Formula:
+ *   - evidenceCount = count of CallScore rows for (callerId, moduleId)
+ *   - if evidenceCount < 3 → mastery = 0 (insufficient evidence)
+ *   - else: EMA across the most recent N=10 scores, time-decayed by
+ *     `exp(-ln2 * dayDelta / halfLifeDays)` against now.
+ *   - mastery is clamped to [0, 1].
+ *   - `shouldMarkCompleted` flips true when mastery >= masteryThreshold
+ *     AND evidenceCount >= minCallsToFull.
+ *
+ * Defaults: masteryThreshold=0.7, emaHalfLifeDays=14, minCallsToFull=4.
+ * Each is overridable per (module / playbook). Pipeline reads playbook
+ * config (`Playbook.config.skillScoringEmaHalfLifeDays`,
+ * `Playbook.config.skillMinCallsToFull`) — see `MEMORY.md` PROD LAUNCH
+ * CHECKLIST for the reconciled defaults.
+ *
+ * Works identically for authored courses and AI-generated curricula: both
+ * populate `CurriculumModule` + `CallScore` rows with the same schema.
+ *
+ * `CallScore.callerId` is denormalized on the row itself (no `call.callerId`
+ * relation join needed) — see `prisma/schema.prisma::CallScore`.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+/** Defaults aligned with `lib/pipeline/aggregate-runner.ts` skill-EMA path. */
+export const DEFAULT_MASTERY_THRESHOLD = 0.7;
+export const DEFAULT_EMA_HALF_LIFE_DAYS = 14;
+export const DEFAULT_MIN_CALLS_TO_FULL = 4;
+/** Window of most-recent CallScore rows folded into the EMA. */
+export const MASTERY_EMA_WINDOW = 10;
+/** Minimum CallScore rows required to compute a non-zero mastery. */
+export const MASTERY_MIN_EVIDENCE = 3;
+
+const MS_PER_DAY = 86_400_000;
+
+export interface MasteryComputationInput {
+  callerId: string;
+  moduleId: string;
+  /** Module-level override; falls back to {@link DEFAULT_MASTERY_THRESHOLD}. */
+  masteryThreshold?: number;
+  /** Playbook config override; falls back to {@link DEFAULT_EMA_HALF_LIFE_DAYS}. */
+  emaHalfLifeDays?: number;
+  /** Playbook config override; falls back to {@link DEFAULT_MIN_CALLS_TO_FULL}. */
+  minCallsToFull?: number;
+  /**
+   * Optional clock injection for deterministic tests. Defaults to `new Date()`.
+   * Mastery is anchored to "now" so the most recent score weighs ~1.0.
+   */
+  now?: Date;
+}
+
+export interface MasteryResult {
+  /** Mastery in [0, 1] — 0 when evidenceCount < {@link MASTERY_MIN_EVIDENCE}. */
+  mastery: number;
+  /** Total CallScore rows for the (callerId, moduleId) pair. */
+  evidenceCount: number;
+  /** True when mastery crosses the threshold AND minCallsToFull is satisfied. */
+  shouldMarkCompleted: boolean;
+}
+
+/**
+ * Clamp a value to [0, 1]. NaN / non-finite collapses to 0 so a malformed
+ * upstream score can't poison `CallerModuleProgress.mastery`.
+ */
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+/**
+ * Compute the EMA-derived mastery for a (callerId, moduleId) pair.
+ *
+ * Sample weight: `exp(-ln2 * (now - createdAt) / (halfLifeDays * 1 day))`.
+ * The most recent score in the window approaches weight 1.0; a score one
+ * half-life ago contributes 0.5; very old scores fade. Falls back to a
+ * uniform mean if every score sits exactly on `now` (sum of weights still
+ * non-zero by construction).
+ *
+ * Returns `mastery=0` when fewer than {@link MASTERY_MIN_EVIDENCE} CallScore
+ * rows exist — guard against a single noisy score flipping a module to
+ * COMPLETED. `shouldMarkCompleted` independently requires `minCallsToFull`
+ * pieces of evidence on top of the threshold check.
+ */
+export async function computeModuleMastery(
+  prisma: Pick<PrismaClient, "callScore">,
+  input: MasteryComputationInput,
+): Promise<MasteryResult> {
+  const masteryThreshold = input.masteryThreshold ?? DEFAULT_MASTERY_THRESHOLD;
+  const halfLifeDays = input.emaHalfLifeDays ?? DEFAULT_EMA_HALF_LIFE_DAYS;
+  const minCallsToFull = input.minCallsToFull ?? DEFAULT_MIN_CALLS_TO_FULL;
+  const nowMs = (input.now ?? new Date()).getTime();
+
+  // CallScore.callerId is denormalised (`schema.prisma::CallScore`), so we
+  // can query directly without joining through `call: { callerId }`. The
+  // moduleId column was added by E1 Slice 1.2 (#491).
+  const evidenceCount = await prisma.callScore.count({
+    where: { callerId: input.callerId, moduleId: input.moduleId },
+  });
+
+  if (evidenceCount < MASTERY_MIN_EVIDENCE) {
+    return { mastery: 0, evidenceCount, shouldMarkCompleted: false };
+  }
+
+  const recent = await prisma.callScore.findMany({
+    where: { callerId: input.callerId, moduleId: input.moduleId },
+    orderBy: { createdAt: "desc" },
+    take: MASTERY_EMA_WINDOW,
+    select: { score: true, createdAt: true },
+  });
+
+  // Guard against an empty window despite a positive count (race / mocked
+  // findMany returning undefined). Falls back to mastery=0 + no completion.
+  if (recent.length === 0) {
+    return { mastery: 0, evidenceCount, shouldMarkCompleted: false };
+  }
+
+  let weightedSum = 0;
+  let weightSum = 0;
+  const halfLifeMs = halfLifeDays * MS_PER_DAY;
+  for (const row of recent) {
+    const dtMs = Math.max(0, nowMs - row.createdAt.getTime());
+    // exp(-ln2 * dt / halfLife) — guard against halfLifeMs<=0 by treating it
+    // as "no decay" (every score weight 1.0).
+    const weight =
+      halfLifeMs > 0 ? Math.exp(-Math.LN2 * (dtMs / halfLifeMs)) : 1;
+    weightedSum += row.score * weight;
+    weightSum += weight;
+  }
+
+  // weightSum is strictly positive: recent.length >= 1 and each weight > 0
+  // (Math.exp is always positive). Defensive guard anyway in case the
+  // recent rows somehow produce a non-finite weight.
+  const rawMastery = weightSum > 0 ? weightedSum / weightSum : 0;
+  const mastery = clamp01(rawMastery);
+
+  const shouldMarkCompleted =
+    mastery >= masteryThreshold && evidenceCount >= minCallsToFull;
+
+  return { mastery, evidenceCount, shouldMarkCompleted };
+}

--- a/apps/admin/tests/lib/aggregate-mastery-write.test.ts
+++ b/apps/admin/tests/lib/aggregate-mastery-write.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for `writeModuleMastery` — #494 E2 Slice 2.2.
+ *
+ * Exported from app/api/calls/[callId]/pipeline/route.ts. Called by the
+ * AGGREGATE stage for each module credited with evidence on the current
+ * call, recomputes mastery via `computeModuleMastery`, and updates
+ * `CallerModuleProgress.mastery` / `status` / `completedAt`.
+ *
+ * Coverage:
+ *  1. Idempotent re-run: mastery written once, second call no-ops when
+ *     the recomputed value matches the existing row.
+ *  2. Crossing the threshold flips status from IN_PROGRESS → COMPLETED
+ *     with completedAt set.
+ *  3. No CallerModuleProgress row → no mastery write attempted (caller
+ *     never had a call attributed to this module).
+ *  4. Already-COMPLETED row does not re-stamp `completedAt`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// =====================================================
+// MOCKS
+// =====================================================
+
+const { mockPrisma, mockComputeModuleMastery } = vi.hoisted(() => ({
+  mockPrisma: {
+    callerModuleProgress: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    callScore: { count: vi.fn(), findMany: vi.fn(), create: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+    curriculumModule: { findUnique: vi.fn(), findMany: vi.fn() },
+    playbook: { findUnique: vi.fn() },
+    // Stubs referenced at route.ts module load time.
+    analysisSpec: { findFirst: vi.fn() },
+    call: { findUnique: vi.fn() },
+    callerMemory: { create: vi.fn() },
+    callerPersonality: { upsert: vi.fn() },
+    personalityObservation: { create: vi.fn() },
+    parameter: { findMany: vi.fn() },
+  },
+  mockComputeModuleMastery: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/curriculum/compute-mastery", () => ({
+  computeModuleMastery: mockComputeModuleMastery,
+}));
+
+// Avoid pulling in real AI / metering / config registries.
+vi.mock("@/lib/ai/client", () => ({
+  isEngineAvailable: vi.fn(() => true),
+}));
+vi.mock("@/lib/metering", () => ({
+  getConfiguredMeteredAICompletion: vi.fn(),
+  logMockAIUsage: vi.fn(),
+}));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(),
+  isAuthError: vi.fn(() => false),
+}));
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALLER_ID = "caller-1";
+const MODULE_ID = "mod-1";
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    getLogs: vi.fn(() => []),
+    getDuration: vi.fn(() => 0),
+  };
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("writeModuleMastery (#494 E2 Slice 2.2)", () => {
+  let writeModuleMastery: typeof import("@/app/api/calls/[callId]/pipeline/route").writeModuleMastery;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/calls/[callId]/pipeline/route");
+    writeModuleMastery = mod.writeModuleMastery;
+  });
+
+  it("skips when no CallerModuleProgress row exists", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue(null);
+
+    const log = makeLogger();
+    const result = await writeModuleMastery(CALLER_ID, MODULE_ID, {}, log as any);
+
+    expect(result).toEqual({
+      mastery: 0,
+      evidenceCount: 0,
+      statusFlipped: false,
+      skipped: true,
+    });
+    expect(mockComputeModuleMastery).not.toHaveBeenCalled();
+    expect(mockPrisma.callerModuleProgress.update).not.toHaveBeenCalled();
+  });
+
+  it("writes mastery and flips IN_PROGRESS → COMPLETED when threshold crossed", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      mastery: 0.5,
+      status: "IN_PROGRESS",
+      completedAt: null,
+    });
+    mockComputeModuleMastery.mockResolvedValue({
+      mastery: 0.85,
+      evidenceCount: 4,
+      shouldMarkCompleted: true,
+    });
+    mockPrisma.callerModuleProgress.update.mockResolvedValue({});
+
+    const log = makeLogger();
+    const result = await writeModuleMastery(
+      CALLER_ID,
+      MODULE_ID,
+      { masteryThreshold: 0.7, emaHalfLifeDays: 14, minCallsToFull: 4 },
+      log as any,
+    );
+
+    expect(result.mastery).toBe(0.85);
+    expect(result.evidenceCount).toBe(4);
+    expect(result.statusFlipped).toBe(true);
+    expect(result.skipped).toBe(false);
+
+    expect(mockComputeModuleMastery).toHaveBeenCalledWith(
+      mockPrisma,
+      expect.objectContaining({
+        callerId: CALLER_ID,
+        moduleId: MODULE_ID,
+        masteryThreshold: 0.7,
+        emaHalfLifeDays: 14,
+        minCallsToFull: 4,
+      }),
+    );
+    const updateArg = mockPrisma.callerModuleProgress.update.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ id: "prog-1" });
+    expect(updateArg.data.mastery).toBe(0.85);
+    expect(updateArg.data.status).toBe("COMPLETED");
+    expect(updateArg.data.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("is idempotent when mastery and status are unchanged", async () => {
+    // Re-running AGGREGATE on the same call → CallScore rows haven't moved,
+    // so the EMA recomputes the same value. No DB write should be issued.
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      mastery: 0.62,
+      status: "IN_PROGRESS",
+      completedAt: null,
+    });
+    mockComputeModuleMastery.mockResolvedValue({
+      mastery: 0.62,
+      evidenceCount: 3,
+      shouldMarkCompleted: false,
+    });
+
+    const log = makeLogger();
+    const result = await writeModuleMastery(CALLER_ID, MODULE_ID, {}, log as any);
+
+    expect(result).toEqual({
+      mastery: 0.62,
+      evidenceCount: 3,
+      statusFlipped: false,
+      skipped: true,
+    });
+    expect(mockPrisma.callerModuleProgress.update).not.toHaveBeenCalled();
+  });
+
+  it("updates mastery without flipping status when threshold not met", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      mastery: 0.4,
+      status: "IN_PROGRESS",
+      completedAt: null,
+    });
+    mockComputeModuleMastery.mockResolvedValue({
+      mastery: 0.55,
+      evidenceCount: 3,
+      shouldMarkCompleted: false,
+    });
+    mockPrisma.callerModuleProgress.update.mockResolvedValue({});
+
+    const log = makeLogger();
+    const result = await writeModuleMastery(CALLER_ID, MODULE_ID, {}, log as any);
+
+    expect(result.statusFlipped).toBe(false);
+    expect(result.skipped).toBe(false);
+    const updateArg = mockPrisma.callerModuleProgress.update.mock.calls[0][0];
+    expect(updateArg.data.mastery).toBe(0.55);
+    expect(updateArg.data.status).toBeUndefined();
+    expect(updateArg.data.completedAt).toBeUndefined();
+  });
+
+  it("does not re-stamp completedAt when status is already COMPLETED", async () => {
+    // Idempotency rule: once COMPLETED, downgrade is impossible and we
+    // must not overwrite the original completedAt timestamp on every
+    // subsequent call.
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      mastery: 0.9,
+      status: "COMPLETED",
+      completedAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    mockComputeModuleMastery.mockResolvedValue({
+      mastery: 0.92,
+      evidenceCount: 5,
+      shouldMarkCompleted: true,
+    });
+    mockPrisma.callerModuleProgress.update.mockResolvedValue({});
+
+    const log = makeLogger();
+    const result = await writeModuleMastery(CALLER_ID, MODULE_ID, {}, log as any);
+
+    expect(result.mastery).toBe(0.92);
+    // Mastery moved 0.9 → 0.92 so we DO write; but completedAt must NOT
+    // be touched and status stays COMPLETED.
+    expect(result.statusFlipped).toBe(false);
+    expect(result.skipped).toBe(false);
+    const updateArg = mockPrisma.callerModuleProgress.update.mock.calls[0][0];
+    expect(updateArg.data.mastery).toBe(0.92);
+    expect(updateArg.data.status).toBeUndefined();
+    expect(updateArg.data.completedAt).toBeUndefined();
+  });
+
+  it("is fully idempotent when the row is already COMPLETED and mastery matches", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      mastery: 0.92,
+      status: "COMPLETED",
+      completedAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    mockComputeModuleMastery.mockResolvedValue({
+      mastery: 0.92,
+      evidenceCount: 5,
+      shouldMarkCompleted: true,
+    });
+
+    const log = makeLogger();
+    const result = await writeModuleMastery(CALLER_ID, MODULE_ID, {}, log as any);
+
+    expect(result.skipped).toBe(true);
+    expect(mockPrisma.callerModuleProgress.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/compute-mastery.test.ts
+++ b/apps/admin/tests/lib/compute-mastery.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for `computeModuleMastery` — #494 E2 Slice 2.2.
+ *
+ * Pure EMA computation over CallScore rows for (callerId, moduleId). The
+ * function takes a `PrismaClient`-shaped argument so tests can pass a
+ * lightweight stub (no real DB). Time is injected via `now` for
+ * deterministic decay math.
+ *
+ * Coverage:
+ *  1. evidenceCount < 3 → mastery=0, shouldMarkCompleted=false.
+ *  2. 3 recent scores at 0.9 → mastery ≈ 0.9, completed (threshold 0.7, minCalls 3).
+ *  3. minCallsToFull=10 blocks completion even at high mastery.
+ *  4. Old scores fade — EMA biased toward recent.
+ *  5. Mixed scores below threshold → not completed.
+ *  6. Clamping: scores > 1 (corrupted upstream) → mastery clamped to 1.0.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  computeModuleMastery,
+  DEFAULT_EMA_HALF_LIFE_DAYS,
+  DEFAULT_MASTERY_THRESHOLD,
+  DEFAULT_MIN_CALLS_TO_FULL,
+  MASTERY_EMA_WINDOW,
+  MASTERY_MIN_EVIDENCE,
+} from "@/lib/curriculum/compute-mastery";
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALLER_ID = "caller-1";
+const MODULE_ID = "mod-1";
+// Fixed clock so the decay math is deterministic across test runs.
+const NOW = new Date("2026-05-19T12:00:00.000Z");
+const DAY = 86_400_000;
+
+function daysAgo(n: number): Date {
+  return new Date(NOW.getTime() - n * DAY);
+}
+
+/**
+ * Build a minimal Prisma stub matching the surface area used by
+ * `computeModuleMastery`: only `callScore.count` + `callScore.findMany`.
+ */
+function makePrismaStub(scores: Array<{ score: number; createdAt: Date }>) {
+  // Match the helper's "take=10, order=desc" contract: hand back the most
+  // recent first so the stub mirrors what Prisma would return.
+  const sorted = [...scores].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+  );
+  return {
+    callScore: {
+      count: vi.fn(async () => scores.length),
+      findMany: vi.fn(async (args: any) => {
+        const take = args?.take ?? scores.length;
+        return sorted.slice(0, take);
+      }),
+    },
+  } as any;
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("computeModuleMastery (#494 E2 Slice 2.2)", () => {
+  it("returns mastery=0 when evidenceCount < MASTERY_MIN_EVIDENCE", async () => {
+    const prisma = makePrismaStub([
+      { score: 0.95, createdAt: daysAgo(0) },
+      { score: 0.95, createdAt: daysAgo(1) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+
+    expect(result.evidenceCount).toBe(2);
+    expect(result.mastery).toBe(0);
+    expect(result.shouldMarkCompleted).toBe(false);
+    // findMany must not be called when we already know we're below the
+    // evidence floor — saves a round-trip on every NOT_STARTED module.
+    expect(prisma.callScore.findMany).not.toHaveBeenCalled();
+    expect(MASTERY_MIN_EVIDENCE).toBe(3);
+  });
+
+  it("marks completed when 3 recent 0.9 scores clear threshold + minCalls", async () => {
+    const prisma = makePrismaStub([
+      { score: 0.9, createdAt: daysAgo(0) },
+      { score: 0.9, createdAt: daysAgo(1) },
+      { score: 0.9, createdAt: daysAgo(2) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      masteryThreshold: 0.7,
+      minCallsToFull: 3,
+      now: NOW,
+    });
+
+    expect(result.evidenceCount).toBe(3);
+    // All scores identical → weighted mean equals the score itself.
+    expect(result.mastery).toBeCloseTo(0.9, 6);
+    expect(result.shouldMarkCompleted).toBe(true);
+  });
+
+  it("blocks completion when minCallsToFull > evidenceCount even at high mastery", async () => {
+    const prisma = makePrismaStub([
+      { score: 0.95, createdAt: daysAgo(0) },
+      { score: 0.95, createdAt: daysAgo(1) },
+      { score: 0.95, createdAt: daysAgo(2) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      masteryThreshold: 0.7,
+      minCallsToFull: 10,
+      now: NOW,
+    });
+
+    expect(result.evidenceCount).toBe(3);
+    expect(result.mastery).toBeGreaterThan(0.9);
+    expect(result.shouldMarkCompleted).toBe(false);
+  });
+
+  it("biases EMA toward recent scores when older entries are very old", async () => {
+    // One fresh 0.9 + four near-zero scores from 60 days ago. The recent
+    // score gets weight ~1.0; the old ones at 60 days with 14-day half-life
+    // weigh exp(-ln2 * 60/14) ≈ 0.05. Weighted mean should sit close to 0.9.
+    const prisma = makePrismaStub([
+      { score: 0.9, createdAt: daysAgo(0) },
+      { score: 0.1, createdAt: daysAgo(60) },
+      { score: 0.1, createdAt: daysAgo(60) },
+      { score: 0.1, createdAt: daysAgo(60) },
+      { score: 0.1, createdAt: daysAgo(60) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      emaHalfLifeDays: 14,
+      now: NOW,
+    });
+
+    expect(result.mastery).toBeGreaterThan(0.7);
+    // Sanity: a plain unweighted average of these 5 scores is 0.26, so the
+    // EMA's bias toward recent has to be doing real work.
+    const unweightedMean = (0.9 + 0.1 + 0.1 + 0.1 + 0.1) / 5;
+    expect(unweightedMean).toBeCloseTo(0.26, 6);
+    expect(result.mastery).toBeGreaterThan(unweightedMean + 0.3);
+  });
+
+  it("returns mastery below threshold for mixed 0.5/0.6/0.7 → not completed", async () => {
+    const prisma = makePrismaStub([
+      { score: 0.7, createdAt: daysAgo(0) },
+      { score: 0.6, createdAt: daysAgo(1) },
+      { score: 0.5, createdAt: daysAgo(2) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      masteryThreshold: 0.7,
+      minCallsToFull: 3,
+      now: NOW,
+    });
+
+    expect(result.evidenceCount).toBe(3);
+    // EMA biased toward recent (0.7) but the older lower scores still pull
+    // the mean below 0.7 → no completion.
+    expect(result.mastery).toBeLessThan(0.7);
+    expect(result.mastery).toBeGreaterThan(0.5);
+    expect(result.shouldMarkCompleted).toBe(false);
+  });
+
+  it("clamps mastery to [0, 1] when upstream scores overflow", async () => {
+    // A bug elsewhere could write a CallScore.score > 1 (e.g. percent vs
+    // ratio mix-up). Mastery must never propagate that.
+    const prisma = makePrismaStub([
+      { score: 1.4, createdAt: daysAgo(0) },
+      { score: 1.4, createdAt: daysAgo(1) },
+      { score: 1.4, createdAt: daysAgo(2) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+
+    expect(result.evidenceCount).toBe(3);
+    expect(result.mastery).toBe(1);
+  });
+
+  it("clamps negative weighted averages to 0", async () => {
+    const prisma = makePrismaStub([
+      { score: -0.5, createdAt: daysAgo(0) },
+      { score: -0.5, createdAt: daysAgo(1) },
+      { score: -0.5, createdAt: daysAgo(2) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+
+    expect(result.mastery).toBe(0);
+    expect(result.shouldMarkCompleted).toBe(false);
+  });
+
+  it("uses default threshold + minCalls + halfLife when overrides omitted", async () => {
+    // 4 fresh 0.85 scores — should clear the 0.7 default threshold and the
+    // default 4-call minimum, marking completed.
+    const prisma = makePrismaStub([
+      { score: 0.85, createdAt: daysAgo(0) },
+      { score: 0.85, createdAt: daysAgo(0.5) },
+      { score: 0.85, createdAt: daysAgo(1) },
+      { score: 0.85, createdAt: daysAgo(1.5) },
+    ]);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+
+    expect(DEFAULT_MASTERY_THRESHOLD).toBe(0.7);
+    expect(DEFAULT_MIN_CALLS_TO_FULL).toBe(4);
+    expect(DEFAULT_EMA_HALF_LIFE_DAYS).toBe(14);
+    expect(result.evidenceCount).toBe(4);
+    expect(result.mastery).toBeCloseTo(0.85, 2);
+    expect(result.shouldMarkCompleted).toBe(true);
+  });
+
+  it("caps the EMA window at MASTERY_EMA_WINDOW most-recent rows", async () => {
+    // 15 rows; the helper must request only the most recent 10. Older rows
+    // shouldn't poison the average even when the count column says otherwise.
+    const rows = Array.from({ length: 15 }, (_, i) => ({
+      score: i < 10 ? 0.9 : 0.1,
+      createdAt: daysAgo(i),
+    }));
+    const prisma = makePrismaStub(rows);
+
+    const result = await computeModuleMastery(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+
+    expect(result.evidenceCount).toBe(15);
+    expect(MASTERY_EMA_WINDOW).toBe(10);
+    // findMany should have been called with take=10.
+    const findManyArgs = prisma.callScore.findMany.mock.calls[0][0];
+    expect(findManyArgs.take).toBe(10);
+    // The 10 most-recent rows are all 0.9 (oldest=9 days), so mastery is
+    // very close to 0.9 — the 0.1 rows from days 10-14 aren't included.
+    expect(result.mastery).toBeGreaterThan(0.85);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `lib/curriculum/compute-mastery.ts` — deterministic EMA over `CallScore` rows for a `(callerId, moduleId)` pair. Most-recent 10 scores, half-life decay, clamped to `[0, 1]`. Mastery is `0` until at least 3 pieces of evidence have accumulated; `shouldMarkCompleted` requires both `mastery >= masteryThreshold` AND `evidenceCount >= minCallsToFull`.
- Wires `writeModuleMastery` into the pipeline AGGREGATE stage, called for every module credited by the call (bound module + Slice 1.4 `coversModules` fan-out). Updates `CallerModuleProgress.mastery` and flips `status` to `COMPLETED` with `completedAt` set when the threshold is crossed.
- `CallerModuleProgress.mastery` becomes the canonical source of truth for module mastery from this slice forward. The legacy `CallerAttribute mastery:*` writes are now duplicative and will be reconciled + removed in Slice 2.1.

Configuration:
- `CurriculumModule.masteryThreshold` (per-module override) — falls back to `0.7`.
- `Playbook.config.skillScoringEmaHalfLifeDays` — falls back to `14` days. Mirrors the skill-EMA path in `lib/pipeline/aggregate-runner.ts`.
- `Playbook.config.skillMinCallsToFull` — falls back to `4` calls. Same.

Idempotency:
- `computeModuleMastery` is pure — re-runs on the same `CallScore` set produce identical mastery.
- `writeModuleMastery` skips the `prisma.callerModuleProgress.update` write when neither `mastery` nor `status` changed.
- Already-COMPLETED rows never re-stamp `completedAt` and cannot be downgraded.

No schema change in this slice — both `CurriculumModule.masteryThreshold` and `CallerModuleProgress.mastery` columns already exist.

Ready for `/vm-cp` (no migration needed).

## Test plan

- [x] `npx vitest run tests/lib/compute-mastery.test.ts` — 9/9 passing (insufficient evidence, threshold crossing, minCalls gate, recency bias, clamping, window cap)
- [x] `npx vitest run tests/lib/aggregate-mastery-write.test.ts` — 6/6 passing (idempotent re-run, IN_PROGRESS→COMPLETED flip, missing-row skip, completed-row preservation)
- [x] `npx vitest run tests/lib/caller-module-progress-increment.test.ts tests/lib/aggregate-multi-module-evidence.test.ts` — 14/14 passing (no regression on sibling slices 1.3 + 1.4)
- [x] `npx eslint` on changed files — 0 errors
- [x] `npx tsc --noEmit` — 0 new errors introduced (5 pre-existing in `route.ts`)
- [ ] UI verification — none in this slice (server-side write only). To verify in app: run a pipeline on a call with `Call.curriculumModuleId` set, then check `CallerModuleProgress.mastery` and `status` on the affected row(s). The mastery surface in Slice 2.3+ will read this value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)