### PR TITLE
feat(#495 Slice 4.3): "Recommended next" badge in picker (both routes)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -29,6 +29,7 @@ import {
 import { syncAuthoredModulesToCurriculum } from "@/lib/wizard/sync-authored-modules-to-curriculum";
 import { reclassifyLearningObjectives } from "@/lib/curriculum/reclassify-los";
 import { resolveCurriculumIdForPlaybook } from "@/lib/curriculum/resolve-module";
+import { recommendNextModule } from "@/lib/curriculum/recommend-next-module";
 
 // #495 Slice 4.2 — picker status badge. Per-module progress is returned to
 // the learner picker so each tile/rail card can render Mastered / In progress
@@ -72,12 +73,18 @@ type Body = z.infer<typeof BodySchema>;
  *   (null when no modules exist on either side); the legacy `moduleSource`
  *   field (`"authored" | "derived" | null`) is preserved for backwards
  *   compatibility with the admin AuthoredModulesPanel.
- * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, source, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification }
+ * @response 200 { ok, modulesAuthored, modules, moduleDefaults, moduleSource, source, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification, recommendedModuleId, recommendedReason }
  * @note #495 Slice 4.2 — each `modules[]` entry includes an optional
  *   `progress: { status: "MASTERED"|"IN_PROGRESS"|"NOT_STARTED", callCount }`
  *   field when the request carries a caller scope (STUDENT, or OPERATOR+
  *   with `?callerId=…`). Admins without a caller scope receive modules
  *   without `progress` — the picker suppresses the badge in that case.
+ * @note #495 Slice 4.3 — top-level `recommendedModuleId` + `recommendedReason`
+ *   identify the single module `recommendNextModule()` suggests the learner
+ *   attempt next (or null when no caller scope / every module mastered).
+ *   The picker UI surfaces a "Recommended next" badge on that tile only —
+ *   no per-module mutation, so any other consumer of the response keeps a
+ *   stable `progress` shape.
  * @response 404 { ok: false, error: "Course not found" }
  */
 export async function GET(
@@ -124,13 +131,15 @@ export async function GET(
   // pass `?callerId=` to inspect on a learner's behalf (same convention
   // as /api/student/module-progress). Admins without `?callerId=` get a
   // module list with NO `progress` field — the picker hides the badge.
-  const progressByModuleId = await resolveProgressForCaller(
+  const callerId = await resolveCallerIdForRequest(
     auth.session.user.role,
     auth.session.user.id,
     req.nextUrl.searchParams.get("callerId"),
-    courseId,
-    modulesForResponse,
   );
+  const progressByModuleId =
+    callerId && modulesForResponse.length > 0
+      ? await loadProgressForCaller(callerId, courseId)
+      : null;
   const modulesWithProgress = progressByModuleId
     ? modulesForResponse.map((m) => ({
         ...m,
@@ -143,6 +152,38 @@ export async function GET(
         },
       }))
     : modulesForResponse;
+
+  // #495 Slice 4.3 — compute the single "Recommended next" module for the
+  // resolved caller. Top-level fields so the picker can find the tile
+  // without mutating per-module rows (keeps the `progress` shape stable
+  // for any other consumer). Skipped entirely when there is no caller
+  // scope — admins viewing the route directly get nulls, matching the
+  // progress-enrichment policy.
+  let recommendedModuleId: string | null = null;
+  let recommendedReason: string | null = null;
+  if (callerId && modulesForResponse.length > 0) {
+    const curriculumIdForReco = await resolveCurriculumIdForPlaybook(courseId);
+    if (curriculumIdForReco) {
+      const reco = await recommendNextModule({
+        callerId,
+        curriculumId: curriculumIdForReco,
+        playbookConfig: cfg,
+      });
+      if (reco) {
+        // `recommendNextModule` returns the CurriculumModule slug (which
+        // by convention matches AuthoredModule.id for both authored and
+        // generated paths). Map back to the picker's id so the client
+        // matches against `module.id`.
+        const matched = modulesForResponse.find(
+          (m) => m.id === reco.slug || m.id === reco.moduleId,
+        );
+        if (matched) {
+          recommendedModuleId = matched.id;
+          recommendedReason = reco.reason;
+        }
+      }
+    }
+  }
 
   // #281 Slice 3b: per-module ContentQuestion count so the AuthoredModules
   // panel can show a "no learner-facing content" banner for modules whose
@@ -246,6 +287,12 @@ export async function GET(
     // performanceStatement, humanOverridden }). Empty when no curriculum
     // exists yet (cold-start before classifier first runs).
     loAudienceByRef,
+    // #495 Slice 4.3 — top-level "Recommended next" hint. null when no
+    // caller scope is resolvable or `recommendNextModule()` had nothing to
+    // suggest (every module mastered, or strict-prereq deadlock with no
+    // IN_PROGRESS fallback). The picker highlights the matching tile.
+    recommendedModuleId,
+    recommendedReason,
   });
 }
 
@@ -306,41 +353,31 @@ async function loadGeneratedModulesAsAuthored(
 }
 
 /**
- * #495 Slice 4.2 — resolve a `slug → PickerProgress` map keyed by
- * AuthoredModule.id (which equals CurriculumModule.slug by convention,
- * matching the picker page's progress-grouping logic).
- *
- * Returns `null` when no caller scope is resolvable:
+ * #495 Slice 4.2 / 4.3 — resolve the caller whose progress + recommendation
+ * the GET response should be scoped to. Returns `null` when no caller scope
+ * is resolvable:
  *   - STUDENT but no LEARNER Caller linked → null (treat as no-scope; the
  *     picker simply hides the badge rather than showing every module as
  *     "Not started", which would be misleading mid-onboarding).
  *   - OPERATOR+ without `?callerId=` → null (admin-only direct view).
  *   - Lower roles (TESTER/VIEWER) without `?callerId=` → null.
- *
- * Returns `{}` (empty object) when a caller IS resolved but has no
- * progress rows — the GET handler then synthesises NOT_STARTED for each
- * module so the picker can show "Not started" everywhere.
  */
-async function resolveProgressForCaller(
+async function resolveCallerIdForRequest(
   role: string,
   userId: string,
   callerIdParam: string | null,
-  courseId: string,
-  modules: AuthoredModule[],
-): Promise<Record<string, PickerProgress> | null> {
-  if (modules.length === 0) return null;
-
+): Promise<string | null> {
   const roleLevel =
     (ROLE_LEVEL as Record<string, number | undefined>)[role] ?? 0;
 
-  let callerId: string | null = null;
   if (role === "STUDENT") {
     const caller = await prisma.caller.findFirst({
       where: { userId, role: "LEARNER" },
       select: { id: true },
     });
-    callerId = caller?.id ?? null;
-  } else if (roleLevel >= ROLE_LEVEL.OPERATOR && callerIdParam) {
+    return caller?.id ?? null;
+  }
+  if (roleLevel >= ROLE_LEVEL.OPERATOR && callerIdParam) {
     // Verify the requested caller is a LEARNER — same shape check
     // `requireStudentOrAdmin` uses. We don't 404 here; we just decline
     // to enrich, mirroring "no scope" semantics.
@@ -348,11 +385,26 @@ async function resolveProgressForCaller(
       where: { id: callerIdParam, role: "LEARNER" },
       select: { id: true },
     });
-    callerId = caller?.id ?? null;
+    return caller?.id ?? null;
   }
+  return null;
+}
 
-  if (!callerId) return null;
-
+/**
+ * #495 Slice 4.2 — load progress rows for `callerId` scoped to the given
+ * playbook's curricula and project them into a `slug → PickerProgress`
+ * map. The slug is used as the picker-key because AuthoredModule.id
+ * equals CurriculumModule.slug by convention (mirrors the picker page's
+ * progress-grouping logic).
+ *
+ * Returns `{}` (empty object) when the caller has no progress rows yet —
+ * the GET handler then synthesises NOT_STARTED for each module so the
+ * picker can show "Not started" everywhere.
+ */
+async function loadProgressForCaller(
+  callerId: string,
+  courseId: string,
+): Promise<Record<string, PickerProgress>> {
   // Scope progress rows to this Playbook's curricula so the same slug
   // across two courses doesn't bleed in. Mirrors module-progress route.
   const rows = await prisma.callerModuleProgress.findMany({

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -29,6 +29,7 @@ import {
   CheckCircle2,
   PlayCircle,
   Circle,
+  Sparkles,
 } from "lucide-react";
 import type { AuthoredModule } from "@/lib/types/json-fields";
 
@@ -57,6 +58,22 @@ interface LearnerModulePickerProps {
    * "Start" affordance is hidden.
    */
   onSelect?: (moduleId: string) => void;
+  /**
+   * #495 Slice 4.3 — id of the single module the system recommends the
+   * learner attempt next. Source of truth is the import-modules endpoint
+   * (top-level `recommendedModuleId`). When set, the matching tile/rail
+   * card renders a prominent "Recommended next" badge in its top-LEFT
+   * corner (the per-module status badge remains in the top-RIGHT). The
+   * recommendation is advisory only — every learner-selectable module
+   * stays clickable. Null / undefined hides the badge entirely.
+   */
+  recommendedModuleId?: string | null;
+  /**
+   * #495 Slice 4.3 — human-readable reason from `recommendNextModule()`:
+   * "next-in-sequence" | "weakest-not-mastered" | "first-unstarted" |
+   * "interleave-review". Surfaced as the badge's tooltip via `title=`.
+   */
+  recommendedReason?: string | null;
 }
 
 export function LearnerModulePicker({
@@ -65,6 +82,8 @@ export function LearnerModulePicker({
   completedModuleIds = [],
   inProgressModuleIds = [],
   onSelect,
+  recommendedModuleId = null,
+  recommendedReason = null,
 }: LearnerModulePickerProps) {
   const visible = modules.filter((m) => m.learnerSelectable !== false);
   if (visible.length === 0) {
@@ -90,6 +109,8 @@ export function LearnerModulePicker({
           completed={completed}
           inProgress={inProgress}
           onSelect={onSelect}
+          recommendedModuleId={recommendedModuleId}
+          recommendedReason={recommendedReason}
         />
       ) : (
         <TilesLayout
@@ -97,6 +118,8 @@ export function LearnerModulePicker({
           completed={completed}
           inProgress={inProgress}
           onSelect={onSelect}
+          recommendedModuleId={recommendedModuleId}
+          recommendedReason={recommendedReason}
         />
       )}
     </div>
@@ -110,11 +133,15 @@ function TilesLayout({
   completed,
   inProgress,
   onSelect,
+  recommendedModuleId,
+  recommendedReason,
 }: {
   modules: AuthoredModule[];
   completed: Set<string>;
   inProgress: Set<string>;
   onSelect?: (id: string) => void;
+  recommendedModuleId: string | null;
+  recommendedReason: string | null;
 }) {
   // Hide `frequency: once` modules already completed (e.g. Baseline).
   // Repeatable + completed stays visible so learners can retake.
@@ -128,7 +155,15 @@ function TilesLayout({
     return (
       <div className="learner-picker__tiles">
         {eligible.map((m) => (
-          <Tile key={m.id} mod={m} inProgress={false} completed={false} onSelect={onSelect} />
+          <Tile
+            key={m.id}
+            mod={m}
+            inProgress={false}
+            completed={false}
+            onSelect={onSelect}
+            isRecommended={m.id === recommendedModuleId}
+            recommendedReason={recommendedReason}
+          />
         ))}
       </div>
     );
@@ -147,21 +182,45 @@ function TilesLayout({
       {upNextMods.length > 0 && (
         <Section title="Up next">
           {upNextMods.map((m) => (
-            <Tile key={m.id} mod={m} inProgress={false} completed={false} onSelect={onSelect} />
+            <Tile
+              key={m.id}
+              mod={m}
+              inProgress={false}
+              completed={false}
+              onSelect={onSelect}
+              isRecommended={m.id === recommendedModuleId}
+              recommendedReason={recommendedReason}
+            />
           ))}
         </Section>
       )}
       {inProgressMods.length > 0 && (
         <Section title="In progress">
           {inProgressMods.map((m) => (
-            <Tile key={m.id} mod={m} inProgress completed={false} onSelect={onSelect} />
+            <Tile
+              key={m.id}
+              mod={m}
+              inProgress
+              completed={false}
+              onSelect={onSelect}
+              isRecommended={m.id === recommendedModuleId}
+              recommendedReason={recommendedReason}
+            />
           ))}
         </Section>
       )}
       {completedMods.length > 0 && (
         <Section title="Completed">
           {completedMods.map((m) => (
-            <Tile key={m.id} mod={m} inProgress={false} completed onSelect={onSelect} />
+            <Tile
+              key={m.id}
+              mod={m}
+              inProgress={false}
+              completed
+              onSelect={onSelect}
+              isRecommended={m.id === recommendedModuleId}
+              recommendedReason={recommendedReason}
+            />
           ))}
         </Section>
       )}
@@ -183,13 +242,23 @@ function Tile({
   inProgress,
   completed,
   onSelect,
+  isRecommended,
+  recommendedReason,
 }: {
   mod: AuthoredModule;
   inProgress: boolean;
   completed: boolean;
   onSelect?: (id: string) => void;
+  isRecommended: boolean;
+  recommendedReason: string | null;
 }) {
   const Tag = onSelect ? "button" : "div";
+  // Suppress the recommended badge for mastered modules — defence in depth
+  // against an upstream that recommends something already MASTERED.
+  // `recommendNextModule()` filters those out, but the picker shouldn't
+  // double-decorate a Mastered tile if a stale payload slips through.
+  const showRecommended =
+    isRecommended && mod.progress?.status !== "MASTERED";
   return (
     <Tag
       type={onSelect ? "button" : undefined}
@@ -197,7 +266,9 @@ function Tile({
       onClick={onSelect ? () => onSelect(mod.id) : undefined}
       data-terminal={mod.sessionTerminal || undefined}
       data-progress={inProgress ? "in-progress" : completed ? "completed" : undefined}
+      data-recommended={showRecommended || undefined}
     >
+      {showRecommended && <RecommendedBadge reason={recommendedReason} />}
       <StatusBadge progress={mod.progress} />
       <ModeIcon mode={mod.mode} />
       <div className="learner-picker__tile-body">
@@ -241,11 +312,15 @@ function RailLayout({
   completed,
   inProgress,
   onSelect,
+  recommendedModuleId,
+  recommendedReason,
 }: {
   modules: AuthoredModule[];
   completed: Set<string>;
   inProgress: Set<string>;
   onSelect?: (id: string) => void;
+  recommendedModuleId: string | null;
+  recommendedReason: string | null;
 }) {
   // Sort by `position` if provided, otherwise preserve catalogue order.
   const ordered = [...modules].sort((a, b) => {
@@ -265,6 +340,8 @@ function RailLayout({
           prereqsUnmet.length > 0
             ? `Recommended after ${prereqsUnmet.join(", ")}`
             : null;
+        const showRecommended =
+          m.id === recommendedModuleId && m.progress?.status !== "MASTERED";
 
         return (
           <li key={m.id} className="learner-picker__rail-item">
@@ -277,7 +354,9 @@ function RailLayout({
               onClick={onSelect ? () => onSelect(m.id) : undefined}
               data-progress={isComplete ? "completed" : isInProgress ? "in-progress" : undefined}
               data-terminal={m.sessionTerminal || undefined}
+              data-recommended={showRecommended || undefined}
             >
+              {showRecommended && <RecommendedBadge reason={recommendedReason} />}
               <StatusBadge progress={m.progress} />
               <ModeIcon mode={m.mode} />
               <div className="learner-picker__rail-body">
@@ -375,4 +454,47 @@ function StatusBadge({ progress }: { progress: AuthoredModule["progress"] }) {
       <span>Not started</span>
     </span>
   );
+}
+
+// ── Recommended-next badge (#495 Slice 4.3) ────────────────────────
+//
+// Prominent green pill pinned to the top-LEFT of the single module the
+// system recommends the learner attempt next. Sits opposite the Mastered
+// / In progress / Not started status chip (top-right) so the two never
+// overlap. Source of truth is the import-modules endpoint's top-level
+// `recommendedModuleId` field; we don't compute it client-side.
+//
+// The badge is advisory: it doesn't gate, doesn't disable the tile, and
+// doesn't change click behaviour. `recommendNextModule()` returns null
+// for fully-mastered courses so the badge is implicitly suppressed there;
+// Tile / rail-card render guards add a defensive check against the
+// MASTERED status anyway. Tooltip surfaces the human-readable reason
+// (Next in sequence / First not started / etc.) via the `title` attribute.
+function RecommendedBadge({ reason }: { reason: string | null }) {
+  const tooltip = describeRecommendedReason(reason);
+  return (
+    <span
+      className="learner-picker-page__recommended-badge"
+      title={tooltip}
+      aria-label={`Recommended next — ${tooltip}`}
+    >
+      <Sparkles size={12} aria-hidden="true" />
+      <span>Recommended next</span>
+    </span>
+  );
+}
+
+function describeRecommendedReason(reason: string | null): string {
+  switch (reason) {
+    case "next-in-sequence":
+      return "Next in sequence";
+    case "weakest-not-mastered":
+      return "Weakest area";
+    case "first-unstarted":
+      return "First not started";
+    case "interleave-review":
+      return "Interleave review";
+    default:
+      return "Recommended for you";
+  }
 }

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -655,3 +655,47 @@ button.learner-picker__rail-card:hover {
   background: color-mix(in srgb, var(--text-muted) 8%, transparent);
   border-color: color-mix(in srgb, var(--text-muted) 20%, transparent);
 }
+
+/* #495 Slice 4.3 — "Recommended next" badge pinned to the top-LEFT of
+   the single recommended tile / rail card, opposite the status badge
+   (top-RIGHT). Visually more prominent than the status chip: solid
+   green pill with white text using --status-success-text as the brand
+   green for this route (wa-theme tokens aren't loaded outside the
+   learner portal proper, so we mirror the status-success pair already
+   used in this stylesheet). The badge is purely informative — picker
+   interaction stays on the parent tile. */
+
+.learner-picker-page__recommended-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+  color: var(--surface-primary);
+  background: var(--status-success-text);
+  border: 1px solid color-mix(in srgb, var(--status-success-text) 60%, transparent);
+  pointer-events: none; /* informative — tile click stays on the tag */
+  line-height: 1.4;
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--status-success-text) 25%, transparent);
+}
+
+/* Subtle accent on the host tile / rail-card so the recommended pick
+   reads at a glance even before a learner notices the badge. Uses the
+   same green token so the visual story stays unified. */
+
+.learner-picker__tile[data-recommended] {
+  border-color: color-mix(in srgb, var(--status-success-text) 45%, var(--border-default));
+  background: color-mix(in srgb, var(--status-success-text) 3%, var(--surface-primary));
+}
+
+.learner-picker__rail-card[data-recommended] {
+  border-color: color-mix(in srgb, var(--status-success-text) 45%, var(--border-default));
+  background: color-mix(in srgb, var(--status-success-text) 3%, var(--surface-primary));
+}

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -44,6 +44,14 @@ interface ModulesPayload {
   validationWarnings: ValidationWarning[];
   hasErrors: boolean;
   lessonPlanMode: "structured" | "continuous" | null;
+  /**
+   * #495 Slice 4.3 — id of the single module `recommendNextModule()`
+   * suggests the learner attempt next. Null when no caller scope is
+   * resolvable or every module is mastered. Threaded straight into the
+   * picker so it can highlight the matching tile.
+   */
+  recommendedModuleId?: string | null;
+  recommendedReason?: string | null;
 }
 
 interface ProgressRow {
@@ -287,6 +295,8 @@ function PickerContent() {
               completedModuleIds={completedIds}
               inProgressModuleIds={inProgressIds}
               onSelect={handleSelect}
+              recommendedModuleId={data.recommendedModuleId ?? null}
+              recommendedReason={data.recommendedReason ?? null}
             />
 
             {launching && (

--- a/apps/admin/tests/api/import-modules-fallback.test.ts
+++ b/apps/admin/tests/api/import-modules-fallback.test.ts
@@ -65,6 +65,14 @@ vi.mock("@/lib/permissions", () => ({
   },
 }));
 
+// #495 Slice 4.3: recommendation helper is stubbed to "no recommendation"
+// because this suite's auth fixture is a VIEWER with no callerId — the
+// route bails out before calling the helper, but stubbing it keeps any
+// future regression contained.
+vi.mock("@/lib/curriculum/recommend-next-module", () => ({
+  recommendNextModule: vi.fn().mockResolvedValue(null),
+}));
+
 // Import AFTER mocks
 import { GET } from "@/app/api/courses/[courseId]/import-modules/route";
 

--- a/apps/admin/tests/api/import-modules-recommendation.test.ts
+++ b/apps/admin/tests/api/import-modules-recommendation.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for the #495 Slice 4.3 "Recommended next" overlay in
+ * GET /api/courses/[courseId]/import-modules.
+ *
+ * The route adds two top-level fields keyed by the same caller scope used
+ * for progress enrichment (#495 Slice 4.2):
+ *   - `recommendedModuleId: string | null`
+ *   - `recommendedReason:   string | null`
+ *
+ * Values come from `recommendNextModule()` (#494 Slice 2.5). The helper is
+ * mocked here so the suite stays focused on the route's wiring: caller
+ * resolution → curriculum lookup → invoke helper → slug-to-id projection.
+ *
+ * Four cases cover the surface area:
+ *   1. Linear curriculum, M1 mastered → reco = M2, reason "next-in-sequence".
+ *   2. All mastered → helper returns null → reco = null.
+ *   3. Admin without `?callerId=` → no caller scope → reco = null + helper
+ *      never invoked.
+ *   4. `strictPrerequisites=true`, M2's prereqs unmet → reco = M1.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const {
+  mockPrisma,
+  mockRequireAuth,
+  mockIsAuthError,
+  mockRecommendNextModule,
+} = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: {
+      findUnique: vi.fn(),
+    },
+    curriculum: {
+      findFirst: vi.fn(),
+    },
+    curriculumModule: {
+      findMany: vi.fn(),
+    },
+    contentQuestion: {
+      groupBy: vi.fn(),
+    },
+    learningObjective: {
+      findMany: vi.fn(),
+    },
+    caller: {
+      findFirst: vi.fn(),
+    },
+    callerModuleProgress: {
+      findMany: vi.fn(),
+    },
+  },
+  mockRequireAuth: vi.fn(),
+  mockIsAuthError: vi.fn(),
+  mockRecommendNextModule: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+  isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+  ROLE_LEVEL: {
+    DEMO: 0,
+    VIEWER: 1,
+    TESTER: 1,
+    STUDENT: 1,
+    SUPER_TESTER: 2,
+    OPERATOR: 3,
+    EDUCATOR: 3,
+    ADMIN: 4,
+    SUPERADMIN: 5,
+  },
+}));
+
+vi.mock("@/lib/curriculum/recommend-next-module", () => ({
+  recommendNextModule: (...args: unknown[]) => mockRecommendNextModule(...args),
+}));
+
+// Import AFTER mocks
+import { GET } from "@/app/api/courses/[courseId]/import-modules/route";
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeGetReq(query?: string): NextRequest {
+  const url = `http://localhost:3000/api/courses/playbook-1/import-modules${query ? `?${query}` : ""}`;
+  return new NextRequest(url);
+}
+
+const params = Promise.resolve({ courseId: "playbook-1" });
+
+// Three linear modules — slugs match AuthoredModule.id by convention so the
+// route's slug-to-id mapping is exercised against the authored shape.
+const linearPlaybook = {
+  id: "playbook-1",
+  config: {
+    modulesAuthored: true,
+    moduleSource: "authored",
+    modules: [
+      {
+        id: "m1",
+        label: "Module One",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "Student-led",
+        scoringFired: "LR + GRA only",
+        voiceBandReadout: false,
+        sessionTerminal: false,
+        frequency: "repeatable",
+        outcomesPrimary: [],
+        prerequisites: [],
+      },
+      {
+        id: "m2",
+        label: "Module Two",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "20 min",
+        scoringFired: "All four",
+        voiceBandReadout: false,
+        sessionTerminal: false,
+        frequency: "repeatable",
+        outcomesPrimary: [],
+        prerequisites: ["m1"],
+      },
+      {
+        id: "m3",
+        label: "Module Three",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "10 min",
+        scoringFired: "All four",
+        voiceBandReadout: false,
+        sessionTerminal: false,
+        frequency: "repeatable",
+        outcomesPrimary: [],
+        prerequisites: ["m2"],
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  mockRequireAuth.mockReset();
+  mockIsAuthError.mockReset();
+  mockPrisma.playbook.findUnique.mockReset();
+  mockPrisma.curriculum.findFirst.mockReset();
+  mockPrisma.curriculumModule.findMany.mockReset();
+  mockPrisma.contentQuestion.groupBy.mockReset();
+  mockPrisma.learningObjective.findMany.mockReset();
+  mockPrisma.caller.findFirst.mockReset();
+  mockPrisma.callerModuleProgress.findMany.mockReset();
+  mockRecommendNextModule.mockReset();
+
+  mockIsAuthError.mockReturnValue(false);
+  mockPrisma.contentQuestion.groupBy.mockResolvedValue([]);
+  mockPrisma.learningObjective.findMany.mockResolvedValue([]);
+  // Default curriculum resolution returns a real id so recommendNextModule
+  // gets invoked. Individual cases override as needed.
+  mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-1" });
+  mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
+  mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+});
+
+// ── Case 1: linear curriculum, M1 mastered → reco = M2 ───────────
+
+describe("GET /api/courses/[courseId]/import-modules — linear next-in-sequence (#495 Slice 4.3)", () => {
+  it("returns recommendedModuleId=M2 and recommendedReason=next-in-sequence", async () => {
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "user-student-1", role: "STUDENT" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(linearPlaybook);
+    mockPrisma.caller.findFirst.mockResolvedValue({ id: "caller-1" });
+    // M1 mastered, M2/M3 not started.
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      { status: "COMPLETED", callCount: 5, module: { slug: "m1" } },
+    ]);
+    // Helper returns the M2 row — slug used as picker id.
+    mockRecommendNextModule.mockResolvedValue({
+      moduleId: "curr-mod-m2",
+      slug: "m2",
+      title: "Module Two",
+      reason: "next-in-sequence",
+    });
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.recommendedModuleId).toBe("m2");
+    expect(body.recommendedReason).toBe("next-in-sequence");
+
+    // Helper invoked with the resolved caller + curriculum + config.
+    expect(mockRecommendNextModule).toHaveBeenCalledOnce();
+    const arg = mockRecommendNextModule.mock.calls[0][0];
+    expect(arg.callerId).toBe("caller-1");
+    expect(arg.curriculumId).toBe("curr-1");
+    expect(arg.playbookConfig).toBeDefined();
+  });
+});
+
+// ── Case 2: all mastered → reco = null ───────────────────────────
+
+describe("GET /api/courses/[courseId]/import-modules — all mastered (#495 Slice 4.3)", () => {
+  it("returns recommendedModuleId=null when recommendNextModule returns null", async () => {
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "user-student-2", role: "STUDENT" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(linearPlaybook);
+    mockPrisma.caller.findFirst.mockResolvedValue({ id: "caller-2" });
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      { status: "COMPLETED", callCount: 5, module: { slug: "m1" } },
+      { status: "COMPLETED", callCount: 4, module: { slug: "m2" } },
+      { status: "COMPLETED", callCount: 6, module: { slug: "m3" } },
+    ]);
+    // Helper returns null — every module already mastered.
+    mockRecommendNextModule.mockResolvedValue(null);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.recommendedModuleId).toBeNull();
+    expect(body.recommendedReason).toBeNull();
+    // Helper still invoked — the null branch is the helper's decision,
+    // not a short-circuit in the route.
+    expect(mockRecommendNextModule).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Case 3: admin without ?callerId= → no scope, no reco ─────────
+
+describe("GET /api/courses/[courseId]/import-modules — admin without callerId (#495 Slice 4.3)", () => {
+  it("returns recommendedModuleId=null and never invokes recommendNextModule", async () => {
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "admin-user-1", role: "OPERATOR" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(linearPlaybook);
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.recommendedModuleId).toBeNull();
+    expect(body.recommendedReason).toBeNull();
+    // No caller scope ⇒ no curriculum lookup, no helper call. The route
+    // bails before invoking either.
+    expect(mockRecommendNextModule).not.toHaveBeenCalled();
+    expect(mockPrisma.caller.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+// ── Case 4: strictPrerequisites=true, M2 prereqs unmet → reco = M1 ─
+
+describe("GET /api/courses/[courseId]/import-modules — strict prereqs (#495 Slice 4.3)", () => {
+  it("recommends M1 when strict mode would otherwise gate M2", async () => {
+    const strictPlaybook = {
+      id: "playbook-1",
+      config: {
+        ...linearPlaybook.config,
+        strictPrerequisites: true,
+      },
+    };
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "user-student-3", role: "STUDENT" } },
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue(strictPlaybook);
+    mockPrisma.caller.findFirst.mockResolvedValue({ id: "caller-3" });
+    // Cold-start — nothing mastered yet, so M2's "m1" prereq is unmet.
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+    // Helper picks M1 — the lowest sortOrder with all prereqs satisfied
+    // (trivially: none). The route forwards the slug.
+    mockRecommendNextModule.mockResolvedValue({
+      moduleId: "curr-mod-m1",
+      slug: "m1",
+      title: "Module One",
+      reason: "next-in-sequence",
+    });
+
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.recommendedModuleId).toBe("m1");
+    expect(body.recommendedReason).toBe("next-in-sequence");
+
+    // The route passes the full config through so the helper sees
+    // strictPrerequisites=true and applies the right policy.
+    expect(mockRecommendNextModule).toHaveBeenCalledOnce();
+    const arg = mockRecommendNextModule.mock.calls[0][0];
+    expect(arg.playbookConfig?.strictPrerequisites).toBe(true);
+  });
+});

--- a/apps/admin/tests/api/import-modules-status-badges.test.ts
+++ b/apps/admin/tests/api/import-modules-status-badges.test.ts
@@ -68,6 +68,13 @@ vi.mock("@/lib/permissions", () => ({
   },
 }));
 
+// #495 Slice 4.3: this suite is focused on progress-badge enrichment, not
+// the recommendation overlay. Stub the helper to null so the route's new
+// top-level fields stay `null` and existing assertions are unaffected.
+vi.mock("@/lib/curriculum/recommend-next-module", () => ({
+  recommendNextModule: vi.fn().mockResolvedValue(null),
+}));
+
 // Import AFTER mocks
 import { GET } from "@/app/api/courses/[courseId]/import-modules/route";
 

--- a/apps/admin/tests/api/import-modules.test.ts
+++ b/apps/admin/tests/api/import-modules.test.ts
@@ -17,7 +17,13 @@ import { NextRequest, NextResponse } from "next/server";
 // vi.mock() is hoisted above all imports and `const` declarations.
 // Use vi.hoisted() so the mock instances exist by the time vi.mock factories run.
 
-const { mockPrisma, mockRequireAuth, mockIsAuthError, mockSyncAuthored } = vi.hoisted(() => ({
+const {
+  mockPrisma,
+  mockRequireAuth,
+  mockIsAuthError,
+  mockSyncAuthored,
+  mockRecommendNextModule,
+} = vi.hoisted(() => ({
   mockPrisma: {
     playbook: {
       findUnique: vi.fn(),
@@ -46,6 +52,7 @@ const { mockPrisma, mockRequireAuth, mockIsAuthError, mockSyncAuthored } = vi.ho
   mockRequireAuth: vi.fn(),
   mockIsAuthError: vi.fn(),
   mockSyncAuthored: vi.fn(),
+  mockRecommendNextModule: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -76,6 +83,14 @@ vi.mock("@/lib/permissions", () => ({
 // The helper has its own dedicated unit test file.
 vi.mock("@/lib/wizard/sync-authored-modules-to-curriculum", () => ({
   syncAuthoredModulesToCurriculum: (...args: unknown[]) => mockSyncAuthored(...args),
+}));
+
+// #495 Slice 4.3 — recommendation helper mocked so existing tests don't need
+// to know about it. Defaulted to `null` in `beforeEach` so the response keeps
+// `recommendedModuleId: null` (which existing assertions ignore). The dedicated
+// test file (import-modules-recommendation.test.ts) overrides this mock.
+vi.mock("@/lib/curriculum/recommend-next-module", () => ({
+  recommendNextModule: (...args: unknown[]) => mockRecommendNextModule(...args),
 }));
 
 // Import AFTER mocks
@@ -133,6 +148,11 @@ beforeEach(() => {
   mockPrisma.curriculum.findFirst.mockReset();
   mockPrisma.curriculumModule.findMany.mockReset();
   mockSyncAuthored.mockReset();
+  mockRecommendNextModule.mockReset();
+  // Default to "no recommendation" so existing GET tests keep their
+  // pre-#495-Slice-4.3 response shape (modulo the new top-level fields,
+  // which are null when this helper returns null).
+  mockRecommendNextModule.mockResolvedValue(null);
 
   mockRequireAuth.mockResolvedValue(passingAuth);
   mockIsAuthError.mockReturnValue(false);

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9570,7 +9570,7 @@ Read the current modules catalogue for a course. Prefers
 
 **Response** `200`
 ```json
-{ ok, modulesAuthored, modules, moduleDefaults, moduleSource, source, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification }
+{ ok, modulesAuthored, modules, moduleDefaults, moduleSource, source, moduleSourceRef, validationWarnings, hasErrors, outcomes, detectedFrom, persisted, curriculumSync, classification, recommendedModuleId, recommendedReason }
 ```
 
 **Response** `404`


### PR DESCRIPTION
## Summary

- **API**: `import-modules` GET now calls `recommendNextModule()` and returns top-level `recommendedModuleId` + `recommendedReason` when caller scope is resolvable. Admins without `?callerId` get null/null (no recommendation surfaced).
- **UI**: `LearnerModulePicker` renders a green pill badge in the top-LEFT of the recommended module's tile/rail-card (Sparkles icon + tooltip with reason). The existing status badge from 4.2 (top-right) stays unchanged.
- Works seamlessly for **both routes** — authored and AI-generated — because the recommender keys off `CurriculumModule` rows which both routes populate.

## Test plan

- [x] 4 new cases in `import-modules-recommendation.test.ts` (linear seq, all-mastered, admin without callerId, strictPrerequisites)
- [x] 21 existing import-modules tests still pass
- [x] tsc clean, eslint clean on changed files

## Notes

Original agent hit Anthropic rate limit before pushing — recovered by the human, tests verified locally before push.

Co-authored with Claude Opus 4.7 (1M context)