### PR TITLE
fix(sim): load .env.local with override so secret matches dev server

### DIFF
--- a/apps/admin/scripts/sim-drive-call.ts
+++ b/apps/admin/scripts/sim-drive-call.ts
@@ -26,14 +26,22 @@
  *   5. Fire pipeline (currently blocked by middleware secret — UI workaround)
  */
 
-// Load .env BEFORE importing config — otherwise process.env.INTERNAL_API_SECRET
-// is undefined when this script runs as standalone tsx (Next.js auto-loads .env
-// for the dev server, but plain tsx doesn't). Without it, config.security.
-// internalApiSecret falls back to a dev placeholder that doesn't match what
-// the running dev server has, so the pipeline POST hits the auth-required
-// branch in middleware.ts:103 and gets redirected to /login (HTML response).
-// (Pipeline-fire failure observed in 2026-05-19 SIM run, course e5f379ed.)
-import "dotenv/config";
+// Load env files in Next.js precedence order BEFORE importing config:
+//   1. .env.local  (highest — overrides everything in dev)
+//   2. .env        (base)
+// Next.js dev server auto-loads .env.local + .env. Plain tsx doesn't load
+// any env file, AND `dotenv/config` (the easy way) only loads .env — not
+// .env.local. When the two files contain DIFFERENT INTERNAL_API_SECRET
+// values (as on hf-dev 2026-05-19), the SIM script ends up sending the
+// `.env` secret while the dev server validates against the `.env.local`
+// secret → mismatch → middleware redirects to /login → SIM gets HTML.
+//
+// Use `dotenv.config({path, override})` so .env.local wins, mirroring
+// Next.js behaviour. (Pipeline-fire failure observed in SIM run on
+// course e5f379ed.)
+import { config as loadDotenv } from "dotenv";
+loadDotenv({ path: ".env.local", override: true });
+loadDotenv({ path: ".env" });
 import { prisma } from "@/lib/prisma";
 import { getConfiguredMeteredAICompletion } from "@/lib/metering";
 import { config } from "@/lib/config";


### PR DESCRIPTION
## Summary

Fixes the actual root cause of pipeline-fire returning HTML (login redirect) in SIM driver runs.

## Why PR #517 wasn't enough

PR #517 added `import \"dotenv/config\"` which only loads `.env`. But Next.js dev server precedence is `.env.local` > `.env`, and on hf-dev the two files contain different `INTERNAL_API_SECRET` values. The dev server validates against `.env.local` (e095b54c…), but the SIM script was sending `.env`'s value (cfaddb1d…) — mismatch → middleware redirect → SIM gets login HTML.

## Change

Use explicit `dotenv.config({path, override})` to load `.env.local` first (with override) then `.env` as base — mirroring Next.js dev server behaviour.

## Test plan
- [ ] Pull on hf-dev
- [ ] Re-run `tsx scripts/sim-drive-call.ts ...` — confirm pipeline returns JSON not HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)