### PR TITLE
feat(#494 Slice 2.7): isCourseComplete predicate (all-modules / terminal-only / any)

### DIFF
--- a/apps/admin/lib/curriculum/is-course-complete.ts
+++ b/apps/admin/lib/curriculum/is-course-complete.ts
@@ -1,0 +1,206 @@
+/**
+ * isCourseComplete — #494 E2 Slice 2.7
+ *
+ * Pure read predicate: given a learner and a curriculum, decide whether the
+ * course is "done" under the course-level `completionMode` flag.
+ *
+ * Three modes (see `lib/curriculum/course-completion.ts::readCourseFlags`):
+ *
+ *   - `"all-modules"`   → every authored module must be COMPLETED.
+ *   - `"terminal-only"` → at least one module with `terminal === true` is
+ *     COMPLETED. Default. The IELTS-style "mock exam" pattern.
+ *   - `"any"`           → any one module COMPLETED ends the course (open-ended
+ *     / exploratory courses).
+ *
+ * Works uniformly for BOTH authored and AI-generated routes because both write
+ * `CurriculumModule` rows + `CallerModuleProgress` rows.
+ *
+ * No DB writes. Pure recommendation/predicate — the route layer is responsible
+ * for projecting this into a `courseComplete` field on a response payload
+ * (downstream slice E5 5.4).
+ *
+ * `prisma` is injected so the helper is straightforward to unit-test without a
+ * live DB.
+ */
+import type { PrismaClient } from "@prisma/client";
+import {
+  readCourseFlags,
+  readModuleFlags,
+  type CompletionMode,
+} from "@/lib/curriculum/course-completion";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+export interface IsCourseCompleteInput {
+  callerId: string;
+  curriculumId: string;
+  playbookConfig: PlaybookConfig | null;
+}
+
+export interface IsCourseCompleteResult {
+  complete: boolean;
+  mode: CompletionMode;
+  /**
+   * ISO timestamp of the moment the course transitioned to complete — taken as
+   * `max(completedAt)` across the modules that triggered completion. `null`
+   * whenever `complete === false`.
+   */
+  completedAt: string | null;
+  /**
+   * Module IDs whose COMPLETED state drove the verdict:
+   *   - `all-modules`   → every module in the curriculum.
+   *   - `terminal-only` → completed terminal modules (often one, can be many).
+   *   - `any`           → every COMPLETED module.
+   * Empty when `complete === false`.
+   */
+  triggeringModuleIds: string[];
+}
+
+type ProgressStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+
+interface ModuleRow {
+  id: string;
+  slug: string;
+  terminal?: boolean | null;
+  prerequisites?: string[] | null;
+  coversModules?: string[] | null;
+  masteryThreshold?: number | null;
+}
+
+interface ProgressRow {
+  moduleId: string;
+  status: string | null;
+  completedAt: Date | null;
+}
+
+/**
+ * Compute whether the learner has completed the course under the configured
+ * `completionMode`. Pure read — no DB writes.
+ */
+export async function isCourseComplete(
+  prisma: PrismaClient,
+  input: IsCourseCompleteInput,
+): Promise<IsCourseCompleteResult> {
+  const { callerId, curriculumId, playbookConfig } = input;
+
+  const { completionMode } = readCourseFlags(playbookConfig);
+
+  const empty: IsCourseCompleteResult = {
+    complete: false,
+    mode: completionMode,
+    completedAt: null,
+    triggeringModuleIds: [],
+  };
+
+  if (!callerId || !curriculumId) return empty;
+
+  // Load all active modules for this curriculum. We need module-level flags
+  // (`terminal`, `masteryThreshold`, etc.) — read them through `readModuleFlags`
+  // for default-safe access.
+  const modules = (await prisma.curriculumModule.findMany({
+    where: { curriculumId, isActive: true },
+    select: {
+      id: true,
+      slug: true,
+      terminal: true,
+      prerequisites: true,
+      coversModules: true,
+      masteryThreshold: true,
+    },
+  })) as unknown as ModuleRow[];
+
+  if (modules.length === 0) return empty;
+
+  // Load progress rows for this learner across these modules.
+  const progressRows = (await prisma.callerModuleProgress.findMany({
+    where: { callerId, moduleId: { in: modules.map((m) => m.id) } },
+    select: { moduleId: true, status: true, completedAt: true },
+  })) as unknown as ProgressRow[];
+
+  const progressById = new Map<string, ProgressRow>();
+  for (const row of progressRows) {
+    progressById.set(row.moduleId, row);
+  }
+
+  const isCompleted = (moduleId: string): boolean =>
+    normaliseStatus(progressById.get(moduleId)?.status) === "COMPLETED";
+
+  const completedAtOf = (moduleId: string): Date | null =>
+    progressById.get(moduleId)?.completedAt ?? null;
+
+  switch (completionMode) {
+    case "all-modules": {
+      const everyComplete = modules.every((m) => isCompleted(m.id));
+      if (!everyComplete) return { ...empty, mode: "all-modules" };
+      const triggeringModuleIds = modules.map((m) => m.id);
+      const completedAt = maxIso(triggeringModuleIds.map(completedAtOf));
+      return {
+        complete: true,
+        mode: "all-modules",
+        completedAt,
+        triggeringModuleIds,
+      };
+    }
+
+    case "terminal-only": {
+      const terminalModules = modules.filter(
+        (m) => readModuleFlags(m).terminal,
+      );
+      if (terminalModules.length === 0) {
+        console.warn(
+          "[is-course-complete] terminal-only mode with no terminal modules",
+        );
+        return { ...empty, mode: "terminal-only" };
+      }
+      const completedTerminals = terminalModules.filter((m) =>
+        isCompleted(m.id),
+      );
+      if (completedTerminals.length === 0) {
+        return { ...empty, mode: "terminal-only" };
+      }
+      const triggeringModuleIds = completedTerminals.map((m) => m.id);
+      const completedAt = maxIso(triggeringModuleIds.map(completedAtOf));
+      return {
+        complete: true,
+        mode: "terminal-only",
+        completedAt,
+        triggeringModuleIds,
+      };
+    }
+
+    case "any": {
+      const completedModules = modules.filter((m) => isCompleted(m.id));
+      if (completedModules.length === 0) return { ...empty, mode: "any" };
+      const triggeringModuleIds = completedModules.map((m) => m.id);
+      const completedAt = maxIso(triggeringModuleIds.map(completedAtOf));
+      return {
+        complete: true,
+        mode: "any",
+        completedAt,
+        triggeringModuleIds,
+      };
+    }
+  }
+}
+
+function normaliseStatus(raw: string | null | undefined): ProgressStatus {
+  if (raw === "COMPLETED" || raw === "IN_PROGRESS" || raw === "NOT_STARTED") {
+    return raw;
+  }
+  return "NOT_STARTED";
+}
+
+/**
+ * Pick the latest non-null completedAt and return as ISO. Returns `null` when
+ * no input contains a valid date (e.g. a COMPLETED row whose `completedAt` was
+ * never populated by legacy data).
+ */
+function maxIso(dates: Array<Date | null>): string | null {
+  let max: Date | null = null;
+  for (const d of dates) {
+    if (!d) continue;
+    if (max === null || d.getTime() > max.getTime()) {
+      max = d;
+    }
+  }
+  return max ? max.toISOString() : null;
+}

--- a/apps/admin/tests/lib/is-course-complete.test.ts
+++ b/apps/admin/tests/lib/is-course-complete.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for isCourseComplete — #494 E2 Slice 2.7
+ *
+ * Pure predicate: given a learner + curriculum + course-level completionMode,
+ * decide whether the course is "done". Three modes:
+ *
+ *   - "all-modules"   → every module COMPLETED
+ *   - "terminal-only" → at least one terminal module COMPLETED (default)
+ *   - "any"           → at least one module COMPLETED
+ *
+ * Mocks Prisma — no DB.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { isCourseComplete } from "@/lib/curriculum/is-course-complete";
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALLER_ID = "caller-1";
+const CURRICULUM_ID = "curr-1";
+
+interface FakeModule {
+  id: string;
+  slug: string;
+  terminal?: boolean;
+  prerequisites?: string[];
+  coversModules?: string[];
+  masteryThreshold?: number | null;
+}
+
+interface FakeProgress {
+  moduleId: string;
+  status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+  completedAt?: Date | null;
+}
+
+function mkModule(
+  slug: string,
+  opts: { terminal?: boolean; prerequisites?: string[] } = {},
+): FakeModule {
+  return {
+    id: `mod-${slug}`,
+    slug,
+    terminal: opts.terminal ?? false,
+    prerequisites: opts.prerequisites ?? [],
+    coversModules: [],
+    masteryThreshold: null,
+  };
+}
+
+function mkPrisma(
+  modules: FakeModule[],
+  progress: FakeProgress[],
+): {
+  prisma: PrismaClient;
+  moduleFindMany: ReturnType<typeof vi.fn>;
+  progressFindMany: ReturnType<typeof vi.fn>;
+} {
+  const moduleFindMany = vi.fn().mockResolvedValue(modules);
+  const progressFindMany = vi.fn().mockResolvedValue(
+    progress.map((p) => ({
+      moduleId: p.moduleId,
+      status: p.status,
+      completedAt: p.completedAt ?? null,
+    })),
+  );
+  const prisma = {
+    curriculumModule: { findMany: moduleFindMany },
+    callerModuleProgress: { findMany: progressFindMany },
+  } as unknown as PrismaClient;
+  return { prisma, moduleFindMany, progressFindMany };
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("isCourseComplete (#494 Slice 2.7)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns not-complete for a curriculum with zero modules", async () => {
+    const { prisma } = mkPrisma([], []);
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "all-modules" } as PlaybookConfig,
+    });
+    expect(result).toEqual({
+      complete: false,
+      mode: "all-modules",
+      completedAt: null,
+      triggeringModuleIds: [],
+    });
+  });
+
+  it('all-modules: every module COMPLETED → complete, triggeringModuleIds = all', async () => {
+    const t1 = new Date("2026-01-02T10:00:00.000Z");
+    const t2 = new Date("2026-01-03T10:00:00.000Z");
+    const { prisma } = mkPrisma(
+      [mkModule("m1"), mkModule("m2")],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED", completedAt: t1 },
+        { moduleId: "mod-m2", status: "COMPLETED", completedAt: t2 },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "all-modules" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(true);
+    expect(result.mode).toBe("all-modules");
+    expect(result.triggeringModuleIds.sort()).toEqual(["mod-m1", "mod-m2"]);
+    expect(result.completedAt).toBe(t2.toISOString());
+  });
+
+  it("all-modules: one IN_PROGRESS → not complete", async () => {
+    const { prisma } = mkPrisma(
+      [mkModule("m1"), mkModule("m2")],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED", completedAt: new Date() },
+        { moduleId: "mod-m2", status: "IN_PROGRESS" },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "all-modules" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(false);
+    expect(result.triggeringModuleIds).toEqual([]);
+    expect(result.completedAt).toBeNull();
+  });
+
+  it("terminal-only: terminal module COMPLETED → complete, triggering = [terminal]", async () => {
+    const t = new Date("2026-02-10T09:30:00.000Z");
+    const { prisma } = mkPrisma(
+      [
+        mkModule("m1"),
+        mkModule("mock", { terminal: true }),
+      ],
+      [
+        { moduleId: "mod-m1", status: "IN_PROGRESS" },
+        { moduleId: "mod-mock", status: "COMPLETED", completedAt: t },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "terminal-only" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(true);
+    expect(result.mode).toBe("terminal-only");
+    expect(result.triggeringModuleIds).toEqual(["mod-mock"]);
+    expect(result.completedAt).toBe(t.toISOString());
+  });
+
+  it("terminal-only: terminal NOT_STARTED but others COMPLETED → not complete", async () => {
+    const { prisma } = mkPrisma(
+      [
+        mkModule("m1"),
+        mkModule("m2"),
+        mkModule("mock", { terminal: true }),
+      ],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED", completedAt: new Date() },
+        { moduleId: "mod-m2", status: "COMPLETED", completedAt: new Date() },
+        { moduleId: "mod-mock", status: "NOT_STARTED" },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "terminal-only" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(false);
+    expect(result.triggeringModuleIds).toEqual([]);
+  });
+
+  it("terminal-only: no module is marked terminal → not complete + console.warn", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { prisma } = mkPrisma(
+      [mkModule("m1"), mkModule("m2")],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED", completedAt: new Date() },
+        { moduleId: "mod-m2", status: "COMPLETED", completedAt: new Date() },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "terminal-only" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(false);
+    expect(result.mode).toBe("terminal-only");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[is-course-complete] terminal-only mode with no terminal modules",
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("terminal-only: multiple terminals, only one COMPLETED → complete, triggering = [that one]", async () => {
+    const t = new Date("2026-03-01T12:00:00.000Z");
+    const { prisma } = mkPrisma(
+      [
+        mkModule("speak-mock", { terminal: true }),
+        mkModule("write-mock", { terminal: true }),
+      ],
+      [
+        { moduleId: "mod-speak-mock", status: "COMPLETED", completedAt: t },
+        { moduleId: "mod-write-mock", status: "NOT_STARTED" },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "terminal-only" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(true);
+    expect(result.triggeringModuleIds).toEqual(["mod-speak-mock"]);
+    expect(result.completedAt).toBe(t.toISOString());
+  });
+
+  it('"any": zero completed → not complete', async () => {
+    const { prisma } = mkPrisma(
+      [mkModule("m1"), mkModule("m2")],
+      [{ moduleId: "mod-m1", status: "IN_PROGRESS" }],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "any" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(false);
+    expect(result.mode).toBe("any");
+  });
+
+  it('"any": one COMPLETED → complete, triggering = [that one]', async () => {
+    const t = new Date("2026-04-15T14:22:00.000Z");
+    const { prisma } = mkPrisma(
+      [mkModule("m1"), mkModule("m2"), mkModule("m3")],
+      [
+        { moduleId: "mod-m1", status: "NOT_STARTED" },
+        { moduleId: "mod-m2", status: "COMPLETED", completedAt: t },
+        { moduleId: "mod-m3", status: "IN_PROGRESS" },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "any" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(true);
+    expect(result.mode).toBe("any");
+    expect(result.triggeringModuleIds).toEqual(["mod-m2"]);
+    expect(result.completedAt).toBe(t.toISOString());
+  });
+
+  it("completedAt is the latest among triggering completedAts (any mode)", async () => {
+    const early = new Date("2026-05-01T00:00:00.000Z");
+    const mid = new Date("2026-05-10T00:00:00.000Z");
+    const late = new Date("2026-05-19T00:00:00.000Z");
+    const { prisma } = mkPrisma(
+      [mkModule("m1"), mkModule("m2"), mkModule("m3")],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED", completedAt: early },
+        { moduleId: "mod-m2", status: "COMPLETED", completedAt: late },
+        { moduleId: "mod-m3", status: "COMPLETED", completedAt: mid },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: { completionMode: "any" } as PlaybookConfig,
+    });
+    expect(result.complete).toBe(true);
+    expect(result.completedAt).toBe(late.toISOString());
+  });
+
+  it("defaults completionMode to 'terminal-only' when playbookConfig is null", async () => {
+    const t = new Date("2026-05-19T08:00:00.000Z");
+    const { prisma } = mkPrisma(
+      [mkModule("m1"), mkModule("final", { terminal: true })],
+      [
+        { moduleId: "mod-m1", status: "COMPLETED", completedAt: new Date() },
+        { moduleId: "mod-final", status: "COMPLETED", completedAt: t },
+      ],
+    );
+    const result = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    expect(result.mode).toBe("terminal-only");
+    expect(result.complete).toBe(true);
+    expect(result.triggeringModuleIds).toEqual(["mod-final"]);
+    expect(result.completedAt).toBe(t.toISOString());
+  });
+
+  it("returns not-complete when callerId or curriculumId is empty (no DB calls)", async () => {
+    const { prisma, moduleFindMany, progressFindMany } = mkPrisma([], []);
+    const a = await isCourseComplete(prisma, {
+      callerId: "",
+      curriculumId: CURRICULUM_ID,
+      playbookConfig: null,
+    });
+    const b = await isCourseComplete(prisma, {
+      callerId: CALLER_ID,
+      curriculumId: "",
+      playbookConfig: null,
+    });
+    expect(a.complete).toBe(false);
+    expect(b.complete).toBe(false);
+    expect(moduleFindMany).not.toHaveBeenCalled();
+    expect(progressFindMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Pure read helper at `apps/admin/lib/curriculum/is-course-complete.ts` that decides whether a learner has finished a course under the configured `Playbook.config.completionMode`.

```ts
isCourseComplete(prisma, { callerId, curriculumId, playbookConfig })
// → { complete, mode, completedAt, triggeringModuleIds }
```

Three completion modes (resolved via `readCourseFlags()` from slice 2.3):

| Mode | Triggers when |
|------|---------------|
| `"all-modules"` | every module in the curriculum is COMPLETED |
| `"terminal-only"` (default) | at least one module with `terminal === true` is COMPLETED |
| `"any"` | any module is COMPLETED |

`completedAt` is `max(completedAt)` across the triggering modules (`null` when not complete). `triggeringModuleIds` lists the module IDs whose state drove the verdict.

Works for BOTH authored and AI-generated routes because both populate `CurriculumModule` + `CallerModuleProgress` rows. No DB writes — pure predicate.

Reads module/course flags through `readModuleFlags()` / `readCourseFlags()` for default-safe access, matching the pattern used by `recommendNextModule` (slice 2.5).

## Scope

- **New file only** — does NOT touch `/api/student/progress`. Wiring the predicate into the `courseComplete` response field is downstream slice E5 5.4.
- No overlap with `recommendNextModule` or `compute-mastery` — sibling helpers.

## Edge cases handled

- Zero modules → `complete: false`
- `terminal-only` with no module marked `terminal` → `complete: false` + `console.warn` (course-authoring bug, recoverable)
- Empty `callerId` / `curriculumId` → no DB calls, `complete: false`
- Legacy `CallerModuleProgress` rows without `completedAt` are skipped in the `max()` (returns null only if no triggering row has a date)
- `playbookConfig === null` → falls back to `"terminal-only"` default

## Test plan

- [x] 12 unit tests in `apps/admin/tests/lib/is-course-complete.test.ts` — green (`npx vitest run tests/lib/is-course-complete.test.ts`)
- [x] tsc clean on changed files (pre-existing errors in `__tests__/*` and other files are unrelated)
- [ ] Manual verification: nothing — plumbing only. UI verification will follow with slice E5 5.4 once the predicate is wired into `/api/student/progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)