### PR TITLE
feat(#494 Slice 2.6): diagnosticFromMock writer (post-Mock learner guidance)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -38,6 +38,7 @@ import { updateCurriculumProgress, getCurriculumProgress, completeModule, update
 import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
 import { resolveCurriculumIdForPlaybook, resolveModuleByLogicalId } from "@/lib/curriculum/resolve-module";
 import { computeModuleMastery } from "@/lib/curriculum/compute-mastery";
+import { generateDiagnosticFromMock } from "@/lib/curriculum/diagnostic-from-mock";
 import { ContractRegistry } from "@/lib/contracts/registry";
 import { loadPipelineStages, PipelineStage } from "@/lib/pipeline/config";
 
@@ -1416,6 +1417,112 @@ export async function resolveModuleEvidenceTargets(
 }
 
 /**
+ * #494 E2 Slice 2.6 — diagnosticFromMock writer.
+ *
+ * Decides whether the just-finished call is a "Mock" (bound module declares
+ * `coversModules.length >= 2`), generates a deterministic diagnostic via
+ * `generateDiagnosticFromMock`, and persists it as a single CallerAttribute
+ * row (`scope=DIAGNOSTIC`, `key=fromMock`) keyed by the existing
+ * `@@unique([callerId, key, scope])` constraint. Most recent Mock wins on
+ * subsequent runs.
+ *
+ * Failure is **not fatal**: any thrown error is logged at warn and the
+ * helper returns `{ written: false }`. The pipeline's AGGREGATE stage must
+ * continue past this point even when the diagnostic write fails — mastery
+ * writes have already succeeded and the user's progress is still durable.
+ *
+ * Returns `{ written: false }` when:
+ *   - The call has no bound `curriculumModuleId`.
+ *   - `moduleEvidenceTargets.length < 2` (a Mock by definition covers ≥2).
+ *   - The bound CurriculumModule is missing or its `coversModules.length < 2`.
+ *   - The diagnostic generator returns null (defensive duplicate of above).
+ *   - An error is thrown anywhere in the path.
+ */
+export async function writeDiagnosticFromMock(
+  callId: string,
+  callerId: string,
+  call: { id: string; playbookId: string | null; curriculumModuleId: string | null },
+  moduleEvidenceTargets: string[],
+  log: PipelineLogger,
+): Promise<{ written: boolean }> {
+  if (!call.curriculumModuleId || moduleEvidenceTargets.length < 2) {
+    return { written: false };
+  }
+  try {
+    const boundModule = await prisma.curriculumModule.findUnique({
+      where: { id: call.curriculumModuleId },
+      select: { curriculumId: true, coversModules: true },
+    });
+    const covers = boundModule
+      ? ((boundModule as any).coversModules as unknown[] | null)
+      : null;
+    const isMock = boundModule && Array.isArray(covers) && covers.length >= 2;
+    if (!isMock || !boundModule) {
+      return { written: false };
+    }
+
+    let pbConfig: Record<string, unknown> | null = null;
+    if (call.playbookId) {
+      const pb = await prisma.playbook.findUnique({
+        where: { id: call.playbookId },
+        select: { config: true },
+      });
+      pbConfig = (pb?.config as Record<string, unknown> | null) ?? null;
+    }
+
+    const diagnostic = await generateDiagnosticFromMock(prisma, {
+      callId,
+      callerId,
+      curriculumId: boundModule.curriculumId,
+      coveredModuleIds: moduleEvidenceTargets,
+      playbookConfig: pbConfig as any,
+    });
+    if (!diagnostic) return { written: false };
+
+    // CallerAttribute @@unique([callerId, key, scope]) — upsert keeps a
+    // single diagnostic row per caller; the most recent Mock overwrites.
+    await prisma.callerAttribute.upsert({
+      where: {
+        callerId_key_scope: {
+          callerId,
+          key: "fromMock",
+          scope: "DIAGNOSTIC",
+        },
+      },
+      create: {
+        callerId,
+        key: "fromMock",
+        scope: "DIAGNOSTIC",
+        valueType: "JSON",
+        stringValue: JSON.stringify(diagnostic),
+        sourceSpecSlug: "diagnostic-from-mock",
+      },
+      update: {
+        valueType: "JSON",
+        stringValue: JSON.stringify(diagnostic),
+        sourceSpecSlug: "diagnostic-from-mock",
+      },
+    });
+    log.info("diagnosticFromMock written", {
+      callId,
+      callerId,
+      focusModules: diagnostic.focusModules,
+      strengthModule: diagnostic.strengthModule,
+      weakSkill: diagnostic.weakSkill,
+    });
+    return { written: true };
+  } catch (err) {
+    // Per spec: diagnostic failure must NOT break the pipeline.
+    log.warn("diagnosticFromMock generation failed", {
+      callId,
+      callerId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { written: false };
+  }
+}
+
+/**
  * Aggregate caller personality from call scores
  * Creates/updates PersonalityObservation for the call and CallerPersonality aggregate
  *
@@ -2779,6 +2886,19 @@ const stageExecutors: Record<string, StageExecutor> = {
     };
     const masteryFlippedCount = masteryResults.filter((r) => r.statusFlipped).length;
 
+    // 5. #494 E2 Slice 2.6 — diagnosticFromMock writer. Generate + persist
+    // a learner-facing diagnostic when this call is a "Mock" (bound module
+    // declares coversModules.length >= 2). Wrapped in try/catch inside the
+    // helper — diagnostic failure MUST NOT break the pipeline.
+    const diagnosticResult = await writeDiagnosticFromMock(
+      ctx.callId,
+      ctx.callerId,
+      ctx.call,
+      moduleEvidenceTargets,
+      ctx.log,
+    );
+    const diagnosticWritten = diagnosticResult.written;
+
     return {
       personalityObservationCreated: personalityResult.observationCreated,
       personalityProfileUpdated: personalityResult.profileUpdated,
@@ -2793,6 +2913,7 @@ const stageExecutors: Record<string, StageExecutor> = {
       moduleMasteryEvidenceCount: primaryMastery.evidenceCount,
       moduleMasteryStatusFlipped: primaryMastery.statusFlipped,
       moduleMasteryFlippedCount: masteryFlippedCount,
+      diagnosticFromMockWritten: diagnosticWritten,
     };
   },
 

--- a/apps/admin/lib/curriculum/diagnostic-from-mock.ts
+++ b/apps/admin/lib/curriculum/diagnostic-from-mock.ts
@@ -1,0 +1,211 @@
+/**
+ * Diagnostic from Mock — #494 E2 Slice 2.6.
+ *
+ * After a "Mock" call (a `CurriculumModule` whose `coversModules` declares
+ * 2+ child slugs — e.g. IELTS Mock covering part1/part2/part3) finishes
+ * AGGREGATE, generate a deterministic per-learner diagnostic that tells the
+ * learner which modules to focus on next.
+ *
+ * Strategy:
+ *   1. Compute mastery for each covered module using the EMA helper.
+ *   2. Sort ascending. `focusModules` = first up to 3 (weakest). The
+ *      strongest covered module becomes `strengthModule`. When every
+ *      mastery value ties at 0 (no evidence yet, e.g. first Mock for this
+ *      caller), `strengthModule` is null — there is no signal to call out.
+ *   3. `weakSkill` = name of the lowest-scored `CallScore.parameter` from
+ *      this Mock call. Null when the call produced no scores.
+ *   4. `summary` = single-sentence canned template referencing module
+ *      titles for human readability.
+ *
+ * Persistence is the caller's responsibility — the pipeline route writes
+ * the returned diagnostic to `CallerAttribute` with scope=DIAGNOSTIC,
+ * key=fromMock. See `route.ts` AGGREGATE stage.
+ *
+ * Failure mode: returns `null` when the call shouldn't produce a
+ * diagnostic (coveredModuleIds < 2). The pipeline route additionally
+ * try/catches generation so any thrown error never fails the pipeline.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+import { computeModuleMastery } from "@/lib/curriculum/compute-mastery";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+/** Mock detection rule: a Mock attributes evidence to ≥2 child modules. */
+export const MOCK_MIN_COVERED_MODULES = 2;
+
+/** Max number of focus modules surfaced to the learner. */
+export const MAX_FOCUS_MODULES = 3;
+
+export interface DiagnosticFromMockInput {
+  callId: string;
+  callerId: string;
+  curriculumId: string;
+  /** Resolved CurriculumModule.id list — the Mock + every part it covers. */
+  coveredModuleIds: string[];
+  /** Source of `skillScoringEmaHalfLifeDays` / `skillMinCallsToFull`. */
+  playbookConfig: PlaybookConfig | null;
+}
+
+export interface DiagnosticFromMock {
+  /** Module IDs ordered weakest-first, up to {@link MAX_FOCUS_MODULES}. */
+  focusModules: string[];
+  /** Highest-mastery covered module ID, or null when no clear winner. */
+  strengthModule: string | null;
+  /** Parameter name of the lowest CallScore for this call, or null. */
+  weakSkill: string | null;
+  /** Single-sentence learner-facing summary referencing module titles. */
+  summary: string;
+  /** The Mock callId that produced this diagnostic. */
+  fromCallId: string;
+  /** ISO-8601 timestamp of when this diagnostic was generated. */
+  generatedAt: string;
+}
+
+/**
+ * Minimal PlaybookConfig fields read by this helper. PlaybookConfig is the
+ * full union of every config key the codebase touches — narrow to the EMA
+ * tuning knobs the mastery formula needs.
+ */
+type MasteryTuning = Pick<
+  PlaybookConfig,
+  never
+> & {
+  skillScoringEmaHalfLifeDays?: number;
+  skillMinCallsToFull?: number;
+};
+
+/**
+ * Generate a diagnostic from a finished Mock call's covered module set.
+ *
+ * Returns null when `coveredModuleIds.length < MOCK_MIN_COVERED_MODULES` —
+ * a Mock by definition covers ≥2 child modules; anything less is a
+ * regular call and produces no diagnostic.
+ *
+ * Deterministic: identical inputs → identical output (modulo `generatedAt`).
+ * No AI calls — purely DB-derived.
+ */
+export async function generateDiagnosticFromMock(
+  prisma: PrismaClient,
+  input: DiagnosticFromMockInput,
+): Promise<DiagnosticFromMock | null> {
+  const { callId, callerId, coveredModuleIds, playbookConfig } = input;
+
+  if (coveredModuleIds.length < MOCK_MIN_COVERED_MODULES) {
+    return null;
+  }
+
+  // Pull EMA tuning from playbook config (matches aggregate-runner / route.ts).
+  const tuning: MasteryTuning = (playbookConfig as MasteryTuning | null) ?? {};
+  const emaHalfLifeDays =
+    typeof tuning.skillScoringEmaHalfLifeDays === "number"
+      ? tuning.skillScoringEmaHalfLifeDays
+      : undefined;
+  const minCallsToFull =
+    typeof tuning.skillMinCallsToFull === "number"
+      ? tuning.skillMinCallsToFull
+      : undefined;
+
+  // 1. Compute mastery per covered module in parallel. Each row is
+  // independent — the EMA helper queries CallScore directly and does not
+  // mutate state.
+  const masteryByModule = await Promise.all(
+    coveredModuleIds.map(async (moduleId) => {
+      const result = await computeModuleMastery(prisma, {
+        callerId,
+        moduleId,
+        emaHalfLifeDays,
+        minCallsToFull,
+      });
+      return { moduleId, mastery: result.mastery };
+    }),
+  );
+
+  // 2. Sort ascending by mastery for focusModules + strengthModule. Break
+  // ties by moduleId (stable lexicographic) so the output is deterministic
+  // when masteries are equal.
+  const sorted = [...masteryByModule].sort((a, b) => {
+    if (a.mastery !== b.mastery) return a.mastery - b.mastery;
+    return a.moduleId.localeCompare(b.moduleId);
+  });
+
+  // Strongest module = last entry. Null when every mastery is 0 (no
+  // evidence yet) — without a clear winner we don't want to mislead the
+  // learner. The "all tied at 0" case is exactly "first Mock, no prior
+  // calls" which is when the diagnostic matters most.
+  const allZero = sorted.every((row) => row.mastery === 0);
+  const strengthModule = allZero ? null : sorted[sorted.length - 1]!.moduleId;
+
+  // focusModules = weakest first, capped at MAX_FOCUS_MODULES, with the
+  // strengthModule excluded so we don't tell the learner to focus on
+  // their strongest area. When strengthModule is null (all tied at 0)
+  // every covered module is fair game.
+  const eligibleForFocus = strengthModule
+    ? sorted.filter((row) => row.moduleId !== strengthModule)
+    : sorted;
+  const focusModules = eligibleForFocus
+    .slice(0, MAX_FOCUS_MODULES)
+    .map((row) => row.moduleId);
+
+  // 3. Lowest CallScore parameter for this call → weakSkill.
+  const lowestScore = await prisma.callScore.findFirst({
+    where: { callId },
+    orderBy: { score: "asc" },
+    select: { parameter: { select: { name: true } } },
+  });
+  const weakSkill = lowestScore?.parameter?.name ?? null;
+
+  // 4. Resolve module titles for the summary string. Pull every covered
+  // module title in one query, then substitute by ID.
+  const titleRows = await prisma.curriculumModule.findMany({
+    where: { id: { in: coveredModuleIds } },
+    select: { id: true, title: true },
+  });
+  const titleById = new Map<string, string>(
+    titleRows.map((row) => [row.id, row.title]),
+  );
+
+  const focusTitles = focusModules.map(
+    (id) => titleById.get(id) ?? id, // Fallback to ID when title missing.
+  );
+  const strengthTitle = strengthModule
+    ? (titleById.get(strengthModule) ?? strengthModule)
+    : null;
+
+  const summary = buildSummary(strengthTitle, focusTitles);
+
+  return {
+    focusModules,
+    strengthModule,
+    weakSkill,
+    summary,
+    fromCallId: callId,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Compose a single-sentence learner-facing summary. Two shapes:
+ *   - with strength: "On your Mock, your strongest area was X. To improve, focus next on A, B."
+ *   - without strength (all tied at 0): "On your Mock, focus next on A, B."
+ *
+ * Falls back gracefully when focusTitles is empty (defensive — by
+ * construction `coveredModuleIds.length >= 2` so focusModules always has
+ * at least 2 entries, but the empty case can arise if the title query
+ * misses every row).
+ */
+function buildSummary(
+  strengthTitle: string | null,
+  focusTitles: string[],
+): string {
+  const focusJoined = focusTitles.join(", ");
+  if (focusTitles.length === 0) {
+    return strengthTitle
+      ? `On your Mock, your strongest area was ${strengthTitle}.`
+      : `Diagnostic generated from your Mock.`;
+  }
+  if (strengthTitle) {
+    return `On your Mock, your strongest area was ${strengthTitle}. To improve, focus next on ${focusJoined}.`;
+  }
+  return `On your Mock, focus next on ${focusJoined}.`;
+}

--- a/apps/admin/tests/lib/aggregate-diagnostic-write.test.ts
+++ b/apps/admin/tests/lib/aggregate-diagnostic-write.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for `writeDiagnosticFromMock` — #494 E2 Slice 2.6 (AGGREGATE wiring).
+ *
+ * Exported from app/api/calls/[callId]/pipeline/route.ts. Called at the
+ * end of the AGGREGATE stage when the just-finished call's bound module
+ * declares `coversModules.length >= 2`. Persists a single CallerAttribute
+ * row keyed by `(callerId, key=fromMock, scope=DIAGNOSTIC)`.
+ *
+ * Coverage:
+ *  1. Mock call (coversModules = [a, b, c]) → CallerAttribute row upserted
+ *     with valid serialized DiagnosticFromMock JSON.
+ *  2. Non-mock call (coversModules empty) → no diagnostic row created.
+ *  3. Diagnostic generation throws → pipeline still returns { written: false }
+ *     and a warn is logged. The thrown error MUST NOT propagate.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// =====================================================
+// MOCKS
+// =====================================================
+
+const { mockPrisma, mockGenerateDiagnosticFromMock } = vi.hoisted(() => ({
+  mockPrisma: {
+    curriculumModule: { findUnique: vi.fn(), findMany: vi.fn() },
+    playbook: { findUnique: vi.fn() },
+    callerAttribute: { upsert: vi.fn() },
+    // Stubs referenced at route.ts module load time.
+    callerModuleProgress: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
+    callScore: { count: vi.fn(), findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    analysisSpec: { findFirst: vi.fn() },
+    call: { findUnique: vi.fn() },
+    callerMemory: { create: vi.fn() },
+    callerPersonality: { upsert: vi.fn() },
+    personalityObservation: { create: vi.fn() },
+    parameter: { findMany: vi.fn() },
+  },
+  mockGenerateDiagnosticFromMock: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/curriculum/diagnostic-from-mock", () => ({
+  generateDiagnosticFromMock: mockGenerateDiagnosticFromMock,
+}));
+
+// Avoid pulling in real AI / metering / config registries.
+vi.mock("@/lib/ai/client", () => ({
+  isEngineAvailable: vi.fn(() => true),
+}));
+vi.mock("@/lib/metering", () => ({
+  getConfiguredMeteredAICompletion: vi.fn(),
+  logMockAIUsage: vi.fn(),
+}));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(),
+  isAuthError: vi.fn(() => false),
+}));
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALL_ID = "call-mock-1";
+const CALLER_ID = "caller-1";
+const PLAYBOOK_ID = "pb-ielts";
+const CURRICULUM_ID = "curr-ielts";
+const MOCK_MODULE_ID = "mod-mock";
+const PART1_ID = "mod-part1";
+const PART2_ID = "mod-part2";
+const PART3_ID = "mod-part3";
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    getLogs: vi.fn(() => []),
+    getDuration: vi.fn(() => 0),
+  };
+}
+
+function makeCall(overrides: Partial<{
+  id: string;
+  playbookId: string | null;
+  curriculumModuleId: string | null;
+}> = {}) {
+  return {
+    id: CALL_ID,
+    playbookId: PLAYBOOK_ID,
+    curriculumModuleId: MOCK_MODULE_ID,
+    ...overrides,
+  };
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("writeDiagnosticFromMock (#494 E2 Slice 2.6)", () => {
+  let writeDiagnosticFromMock: typeof import("@/app/api/calls/[callId]/pipeline/route").writeDiagnosticFromMock;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/calls/[callId]/pipeline/route");
+    writeDiagnosticFromMock = mod.writeDiagnosticFromMock;
+  });
+
+  it("Mock call (coversModules=[a,b,c]) → CallerAttribute row upserted with serialized DiagnosticFromMock JSON", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["part1", "part2", "part3"],
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { skillScoringEmaHalfLifeDays: 14, skillMinCallsToFull: 4 },
+    });
+    const diagnostic = {
+      focusModules: [PART1_ID, PART2_ID],
+      strengthModule: PART3_ID,
+      weakSkill: "fluency",
+      summary: "On your Mock, your strongest area was Part 3. To improve, focus next on Part 1, Part 2.",
+      fromCallId: CALL_ID,
+      generatedAt: "2026-05-19T12:00:00.000Z",
+    };
+    mockGenerateDiagnosticFromMock.mockResolvedValue(diagnostic);
+    mockPrisma.callerAttribute.upsert.mockResolvedValue({});
+
+    const log = makeLogger();
+    const result = await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall(),
+      [MOCK_MODULE_ID, PART1_ID, PART2_ID, PART3_ID],
+      log as any,
+    );
+
+    expect(result.written).toBe(true);
+
+    expect(mockGenerateDiagnosticFromMock).toHaveBeenCalledWith(
+      mockPrisma,
+      expect.objectContaining({
+        callId: CALL_ID,
+        callerId: CALLER_ID,
+        curriculumId: CURRICULUM_ID,
+        coveredModuleIds: [MOCK_MODULE_ID, PART1_ID, PART2_ID, PART3_ID],
+      }),
+    );
+
+    expect(mockPrisma.callerAttribute.upsert).toHaveBeenCalledTimes(1);
+    const upsertArg = mockPrisma.callerAttribute.upsert.mock.calls[0][0];
+    expect(upsertArg.where).toEqual({
+      callerId_key_scope: {
+        callerId: CALLER_ID,
+        key: "fromMock",
+        scope: "DIAGNOSTIC",
+      },
+    });
+    // stringValue parses back to a valid DiagnosticFromMock.
+    const parsed = JSON.parse(upsertArg.create.stringValue);
+    expect(parsed).toEqual(diagnostic);
+    expect(upsertArg.create.scope).toBe("DIAGNOSTIC");
+    expect(upsertArg.create.key).toBe("fromMock");
+    expect(upsertArg.update.stringValue).toBe(upsertArg.create.stringValue);
+  });
+
+  it("non-mock call (coversModules empty) → no diagnostic row created", async () => {
+    // Bound module exists but coversModules is empty → not a Mock.
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      curriculumId: CURRICULUM_ID,
+      coversModules: [],
+    });
+
+    const log = makeLogger();
+    const result = await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall(),
+      [MOCK_MODULE_ID], // single credit — bound module only
+      log as any,
+    );
+
+    expect(result.written).toBe(false);
+    expect(mockGenerateDiagnosticFromMock).not.toHaveBeenCalled();
+    expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns { written: false } when moduleEvidenceTargets.length < 2 (early bail)", async () => {
+    const log = makeLogger();
+    const result = await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall(),
+      [MOCK_MODULE_ID],
+      log as any,
+    );
+
+    expect(result.written).toBe(false);
+    // No DB lookups at all — early return before any query.
+    expect(mockPrisma.curriculumModule.findUnique).not.toHaveBeenCalled();
+    expect(mockGenerateDiagnosticFromMock).not.toHaveBeenCalled();
+  });
+
+  it("returns { written: false } when call.curriculumModuleId is null", async () => {
+    const log = makeLogger();
+    const result = await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall({ curriculumModuleId: null }),
+      [], // no targets either
+      log as any,
+    );
+
+    expect(result.written).toBe(false);
+    expect(mockPrisma.curriculumModule.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("diagnostic generation throws → returns { written: false }, warn logged, error swallowed", async () => {
+    // Critical contract: a thrown error from the generator MUST NOT
+    // propagate out of writeDiagnosticFromMock. The pipeline must keep
+    // going so mastery writes that have already happened are durable.
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["part1", "part2", "part3"],
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: {} });
+    mockGenerateDiagnosticFromMock.mockRejectedValue(
+      new Error("compute-mastery exploded"),
+    );
+
+    const log = makeLogger();
+    const result = await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall(),
+      [MOCK_MODULE_ID, PART1_ID, PART2_ID, PART3_ID],
+      log as any,
+    );
+
+    expect(result.written).toBe(false);
+    expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("diagnosticFromMock generation failed"),
+      expect.objectContaining({
+        callId: CALL_ID,
+        callerId: CALLER_ID,
+        error: "compute-mastery exploded",
+      }),
+    );
+  });
+
+  it("CallerAttribute.upsert throws → returns { written: false }, warn logged", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["part1", "part2", "part3"],
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: {} });
+    mockGenerateDiagnosticFromMock.mockResolvedValue({
+      focusModules: [PART1_ID, PART2_ID],
+      strengthModule: PART3_ID,
+      weakSkill: "fluency",
+      summary: "...",
+      fromCallId: CALL_ID,
+      generatedAt: "2026-05-19T12:00:00.000Z",
+    });
+    mockPrisma.callerAttribute.upsert.mockRejectedValue(
+      new Error("unique violation"),
+    );
+
+    const log = makeLogger();
+    const result = await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall(),
+      [MOCK_MODULE_ID, PART1_ID, PART2_ID, PART3_ID],
+      log as any,
+    );
+
+    expect(result.written).toBe(false);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("diagnosticFromMock generation failed"),
+      expect.objectContaining({ error: "unique violation" }),
+    );
+  });
+
+  it("playbookConfig pulled from Playbook.config and forwarded to generator", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["part1", "part2"],
+    });
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: {
+        skillScoringEmaHalfLifeDays: 28,
+        skillMinCallsToFull: 8,
+      },
+    });
+    mockGenerateDiagnosticFromMock.mockResolvedValue({
+      focusModules: [PART1_ID],
+      strengthModule: PART2_ID,
+      weakSkill: "fluency",
+      summary: "...",
+      fromCallId: CALL_ID,
+      generatedAt: "2026-05-19T12:00:00.000Z",
+    });
+    mockPrisma.callerAttribute.upsert.mockResolvedValue({});
+
+    const log = makeLogger();
+    await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall(),
+      [MOCK_MODULE_ID, PART1_ID, PART2_ID],
+      log as any,
+    );
+
+    const args = mockGenerateDiagnosticFromMock.mock.calls[0][1];
+    expect(args.playbookConfig).toEqual({
+      skillScoringEmaHalfLifeDays: 28,
+      skillMinCallsToFull: 8,
+    });
+  });
+
+  it("call.playbookId null → playbookConfig passed as null, no Playbook lookup", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      curriculumId: CURRICULUM_ID,
+      coversModules: ["part1", "part2"],
+    });
+    mockGenerateDiagnosticFromMock.mockResolvedValue({
+      focusModules: [PART1_ID],
+      strengthModule: PART2_ID,
+      weakSkill: null,
+      summary: "...",
+      fromCallId: CALL_ID,
+      generatedAt: "2026-05-19T12:00:00.000Z",
+    });
+    mockPrisma.callerAttribute.upsert.mockResolvedValue({});
+
+    const log = makeLogger();
+    await writeDiagnosticFromMock(
+      CALL_ID,
+      CALLER_ID,
+      makeCall({ playbookId: null }),
+      [MOCK_MODULE_ID, PART1_ID, PART2_ID],
+      log as any,
+    );
+
+    expect(mockPrisma.playbook.findUnique).not.toHaveBeenCalled();
+    const args = mockGenerateDiagnosticFromMock.mock.calls[0][1];
+    expect(args.playbookConfig).toBeNull();
+  });
+});

--- a/apps/admin/tests/lib/diagnostic-from-mock.test.ts
+++ b/apps/admin/tests/lib/diagnostic-from-mock.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for `generateDiagnosticFromMock` — #494 E2 Slice 2.6.
+ *
+ * Deterministic per-learner diagnostic generated after a Mock call's
+ * AGGREGATE stage. Inputs: the covered module set + the call's CallScore
+ * rows. Outputs: weakest-first focusModules + strongest strengthModule +
+ * lowest-scored skill name + canned summary string.
+ *
+ * Coverage:
+ *  1. coveredModuleIds < 2 → returns null (not a Mock).
+ *  2. Three modules with mastery [0.3, 0.6, 0.8] → focus = two weakest,
+ *     strength = strongest.
+ *  3. All masteries tied at 0 → strengthModule = null (no clear winner).
+ *  4. No CallScore rows for the call → weakSkill = null.
+ *  5. Summary references the module titles.
+ *  6. generatedAt is ISO and within ±1s of Date.now().
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  generateDiagnosticFromMock,
+  MAX_FOCUS_MODULES,
+  MOCK_MIN_COVERED_MODULES,
+} from "@/lib/curriculum/diagnostic-from-mock";
+
+// =====================================================
+// MOCKS
+// =====================================================
+
+// `generateDiagnosticFromMock` calls `computeModuleMastery` internally — mock
+// it so we can drive the mastery values per module without seeding CallScore
+// rows. The helper itself is exhaustively tested in compute-mastery.test.ts.
+vi.mock("@/lib/curriculum/compute-mastery", () => ({
+  computeModuleMastery: vi.fn(),
+}));
+
+import { computeModuleMastery } from "@/lib/curriculum/compute-mastery";
+
+const mockComputeMastery = computeModuleMastery as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+// =====================================================
+// FIXTURES
+// =====================================================
+
+const CALL_ID = "call-mock-1";
+const CALLER_ID = "caller-1";
+const CURRICULUM_ID = "curr-ielts";
+const MOD_A = "mod-a";
+const MOD_B = "mod-b";
+const MOD_C = "mod-c";
+
+/**
+ * Build a minimal Prisma stub matching the surface area used by
+ * `generateDiagnosticFromMock`: callScore.findFirst + curriculumModule.findMany.
+ */
+function makePrismaStub(opts: {
+  lowestScoreParameterName?: string | null;
+  moduleTitles?: Record<string, string>;
+}) {
+  const titles = opts.moduleTitles ?? {};
+  return {
+    callScore: {
+      findFirst: vi.fn(async () => {
+        if (opts.lowestScoreParameterName === undefined) return null;
+        if (opts.lowestScoreParameterName === null) return null;
+        return { parameter: { name: opts.lowestScoreParameterName } };
+      }),
+    },
+    curriculumModule: {
+      findMany: vi.fn(async (args: any) => {
+        const ids: string[] = args?.where?.id?.in ?? [];
+        return ids.map((id) => ({ id, title: titles[id] ?? id }));
+      }),
+    },
+  } as any;
+}
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("generateDiagnosticFromMock (#494 E2 Slice 2.6)", () => {
+  it("constants are sensible", () => {
+    expect(MOCK_MIN_COVERED_MODULES).toBe(2);
+    expect(MAX_FOCUS_MODULES).toBe(3);
+  });
+
+  it("returns null when coveredModuleIds.length < MOCK_MIN_COVERED_MODULES", async () => {
+    // One module covered → not a Mock, no diagnostic.
+    const prisma = makePrismaStub({});
+    mockComputeMastery.mockClear();
+
+    const result = await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_A],
+      playbookConfig: null,
+    });
+
+    expect(result).toBeNull();
+    expect(mockComputeMastery).not.toHaveBeenCalled();
+  });
+
+  it("sorts by mastery ascending: focusModules = two weakest, strengthModule = strongest", async () => {
+    // Mastery: a=0.3, b=0.6, c=0.8 → focus=[a,b], strength=c.
+    mockComputeMastery.mockImplementation(
+      async (_p: unknown, args: { moduleId: string }) => {
+        const map: Record<string, number> = {
+          [MOD_A]: 0.3,
+          [MOD_B]: 0.6,
+          [MOD_C]: 0.8,
+        };
+        return {
+          mastery: map[args.moduleId] ?? 0,
+          evidenceCount: 5,
+          shouldMarkCompleted: false,
+        };
+      },
+    );
+    const prisma = makePrismaStub({
+      lowestScoreParameterName: "fluency",
+      moduleTitles: {
+        [MOD_A]: "Part 1",
+        [MOD_B]: "Part 2",
+        [MOD_C]: "Part 3",
+      },
+    });
+
+    const result = await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_C, MOD_A, MOD_B], // unsorted input
+      playbookConfig: null,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.focusModules).toEqual([MOD_A, MOD_B]);
+    expect(result!.strengthModule).toBe(MOD_C);
+    expect(result!.fromCallId).toBe(CALL_ID);
+  });
+
+  it("strengthModule = null when every covered mastery is tied at 0", async () => {
+    // First Mock for a caller with no prior calls → every module's mastery is
+    // 0 (insufficient evidence). No clear winner to surface as a strength.
+    mockComputeMastery.mockResolvedValue({
+      mastery: 0,
+      evidenceCount: 0,
+      shouldMarkCompleted: false,
+    });
+    const prisma = makePrismaStub({
+      lowestScoreParameterName: null,
+      moduleTitles: { [MOD_A]: "A", [MOD_B]: "B", [MOD_C]: "C" },
+    });
+
+    const result = await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_A, MOD_B, MOD_C],
+      playbookConfig: null,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.strengthModule).toBeNull();
+    // focusModules still produced — deterministically ordered by moduleId
+    // when masteries tie (stable sort by ID).
+    expect(result!.focusModules.length).toBeGreaterThan(0);
+    expect(result!.focusModules.length).toBeLessThanOrEqual(MAX_FOCUS_MODULES);
+  });
+
+  it("weakSkill = null when no CallScore rows exist for the call", async () => {
+    mockComputeMastery.mockResolvedValue({
+      mastery: 0.5,
+      evidenceCount: 3,
+      shouldMarkCompleted: false,
+    });
+    const prisma = makePrismaStub({
+      lowestScoreParameterName: null, // simulates findFirst → null
+      moduleTitles: { [MOD_A]: "A", [MOD_B]: "B" },
+    });
+
+    const result = await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_A, MOD_B],
+      playbookConfig: null,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.weakSkill).toBeNull();
+  });
+
+  it("summary string substitutes the module titles", async () => {
+    mockComputeMastery.mockImplementation(
+      async (_p: unknown, args: { moduleId: string }) => {
+        const map: Record<string, number> = {
+          [MOD_A]: 0.2,
+          [MOD_B]: 0.5,
+          [MOD_C]: 0.9,
+        };
+        return {
+          mastery: map[args.moduleId] ?? 0,
+          evidenceCount: 4,
+          shouldMarkCompleted: false,
+        };
+      },
+    );
+    const prisma = makePrismaStub({
+      lowestScoreParameterName: "pronunciation",
+      moduleTitles: {
+        [MOD_A]: "Speaking Part 1",
+        [MOD_B]: "Speaking Part 2",
+        [MOD_C]: "Speaking Part 3",
+      },
+    });
+
+    const result = await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_A, MOD_B, MOD_C],
+      playbookConfig: null,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.summary).toContain("Speaking Part 3"); // strength
+    expect(result!.summary).toContain("Speaking Part 1"); // focus
+    expect(result!.summary).toContain("Speaking Part 2"); // focus
+  });
+
+  it("generatedAt is a valid ISO timestamp within ±1s of Date.now()", async () => {
+    mockComputeMastery.mockResolvedValue({
+      mastery: 0.5,
+      evidenceCount: 3,
+      shouldMarkCompleted: false,
+    });
+    const prisma = makePrismaStub({
+      lowestScoreParameterName: "fluency",
+      moduleTitles: { [MOD_A]: "A", [MOD_B]: "B" },
+    });
+
+    const before = Date.now();
+    const result = await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_A, MOD_B],
+      playbookConfig: null,
+    });
+    const after = Date.now();
+
+    expect(result).not.toBeNull();
+    const parsed = Date.parse(result!.generatedAt);
+    expect(Number.isFinite(parsed)).toBe(true);
+    expect(parsed).toBeGreaterThanOrEqual(before - 1000);
+    expect(parsed).toBeLessThanOrEqual(after + 1000);
+    // ISO format sanity (contains 'T' + 'Z' or offset)
+    expect(result!.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("caps focusModules at MAX_FOCUS_MODULES even with many covered", async () => {
+    // 5 covered modules with strictly increasing mastery — focus should be
+    // exactly the first 3 (weakest), strength is the highest.
+    const MOD_D = "mod-d";
+    const MOD_E = "mod-e";
+    const masteries: Record<string, number> = {
+      [MOD_A]: 0.1,
+      [MOD_B]: 0.2,
+      [MOD_C]: 0.4,
+      [MOD_D]: 0.7,
+      [MOD_E]: 0.9,
+    };
+    mockComputeMastery.mockImplementation(
+      async (_p: unknown, args: { moduleId: string }) => ({
+        mastery: masteries[args.moduleId] ?? 0,
+        evidenceCount: 4,
+        shouldMarkCompleted: false,
+      }),
+    );
+    const prisma = makePrismaStub({
+      lowestScoreParameterName: "fluency",
+      moduleTitles: {},
+    });
+
+    const result = await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_A, MOD_B, MOD_C, MOD_D, MOD_E],
+      playbookConfig: null,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.focusModules).toHaveLength(MAX_FOCUS_MODULES);
+    expect(result!.focusModules).toEqual([MOD_A, MOD_B, MOD_C]);
+    expect(result!.strengthModule).toBe(MOD_E);
+  });
+
+  it("propagates playbookConfig EMA tuning to computeModuleMastery", async () => {
+    mockComputeMastery.mockResolvedValue({
+      mastery: 0.5,
+      evidenceCount: 3,
+      shouldMarkCompleted: false,
+    });
+    const prisma = makePrismaStub({
+      lowestScoreParameterName: "fluency",
+      moduleTitles: { [MOD_A]: "A", [MOD_B]: "B" },
+    });
+
+    await generateDiagnosticFromMock(prisma, {
+      callId: CALL_ID,
+      callerId: CALLER_ID,
+      curriculumId: CURRICULUM_ID,
+      coveredModuleIds: [MOD_A, MOD_B],
+      playbookConfig: {
+        skillScoringEmaHalfLifeDays: 21,
+        skillMinCallsToFull: 6,
+      } as any,
+    });
+
+    expect(mockComputeMastery).toHaveBeenCalledWith(
+      prisma,
+      expect.objectContaining({
+        emaHalfLifeDays: 21,
+        minCallsToFull: 6,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2.6 of the module-mastery epic (#494). After a Mock call's AGGREGATE stage finishes, we now generate and persist a deterministic per-learner diagnostic that tells the student which modules to focus on next.

- New helper `lib/curriculum/diagnostic-from-mock.ts::generateDiagnosticFromMock` computes per-module mastery via the existing `computeModuleMastery` EMA helper, sorts ascending, picks weakest-first `focusModules` (capped at 3, excluding the strongest module), reads the lowest-scored `CallScore.parameter.name` as `weakSkill`, and composes a single-sentence canned summary referencing module titles. Returns null when `coveredModuleIds.length < 2`.
- New helper `writeDiagnosticFromMock` (exported from the pipeline route) decides whether the just-finished call is a Mock (`coversModules.length >= 2`), calls the generator, and upserts a single `CallerAttribute` row keyed by `(callerId, key=fromMock, scope=DIAGNOSTIC)`. Wrapped in try/catch so a downstream failure logs warn and returns `{ written: false }` instead of breaking the pipeline.
- AGGREGATE stage in `app/api/calls/[callId]/pipeline/route.ts` calls `writeDiagnosticFromMock` after the `writeModuleMastery` fan-out and surfaces `diagnosticFromMockWritten` in the stage result.

`/api/student/progress` wiring + UI is intentionally NOT changed — that's slice 5.3.

## Test plan

- [x] `npx vitest run tests/lib/diagnostic-from-mock.test.ts tests/lib/aggregate-diagnostic-write.test.ts tests/lib/caller-module-progress-increment.test.ts tests/lib/aggregate-multi-module-evidence.test.ts tests/lib/aggregate-mastery-write.test.ts` — 37/37 green (17 new + 20 neighbour regression).
- [x] `npx tsc --noEmit` — no new errors on changed files.
- [ ] Manual smoke after deploy: complete a Mock call on an IELTS course, confirm a `CallerAttribute` row exists with `scope=DIAGNOSTIC`, `key=fromMock`, `stringValue` parsing to a valid `DiagnosticFromMock` payload (verify via Prisma Studio or DB GUI). Slice 5.3 will surface this on the student progress page.

UI to click: nothing yet — plumbing only. Slice 5.3 wires `/api/student/progress` and the student UI banner.

Ready for `/vm-cp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)