### PR TITLE
feat(#493 Slices 5.3 + 5.4): Focus areas + Course complete sections in SimProgressPanel

### DIFF
--- a/apps/admin/app/api/student/progress/route.ts
+++ b/apps/admin/app/api/student/progress/route.ts
@@ -9,6 +9,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
 import { SURVEY_SCOPES } from "@/lib/learner/survey-keys";
+import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
+import { resolveCurriculumIdForPlaybook } from "@/lib/curriculum/resolve-module";
+import { isCourseComplete } from "@/lib/curriculum/is-course-complete";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
 
 const SURVEY_ATTR_SCOPES = [
   SURVEY_SCOPES.PERSONALITY, SURVEY_SCOPES.PRE, SURVEY_SCOPES.POST,
@@ -26,7 +30,7 @@ export async function GET(request: NextRequest) {
   // we surface those for the panel to render coloured chips per module.
   // Module status is mapped at this boundary: DB "COMPLETED" → presentational
   // "MASTERED" (E5 vocabulary); other statuses pass through verbatim.
-  const [profile, goals, callCount, caller, memorySummary, keyFactCount, surveyAttrs, moduleProgress] = await Promise.all([
+  const [profile, goals, callCount, caller, memorySummary, keyFactCount, surveyAttrs, moduleProgress, diagnosticAttr] = await Promise.all([
     prisma.callerPersonalityProfile.findUnique({
       where: { callerId },
       select: { parameterValues: true, lastUpdatedAt: true, callsUsed: true },
@@ -105,6 +109,13 @@ export async function GET(request: NextRequest) {
       },
       orderBy: { module: { sortOrder: "asc" } },
     }),
+    // #493 Slice 5.3 — latest diagnosticFromMock written by E2 AGGREGATE.
+    // Sorted by updatedAt so the most recent Mock's diagnostic wins.
+    prisma.callerAttribute.findFirst({
+      where: { callerId, scope: "DIAGNOSTIC", key: "fromMock" },
+      orderBy: { updatedAt: "desc" },
+      select: { stringValue: true, updatedAt: true },
+    }),
   ]);
 
   // ── Build survey buckets ──
@@ -148,6 +159,18 @@ export async function GET(request: NextRequest) {
   // Prefer join table memberships, fall back to legacy FK
   const primaryCohort = caller?.cohortMemberships?.[0]?.cohortGroup ?? caller?.cohortGroup;
 
+  // #493 Slice 5.3 — parse the latest DIAGNOSTIC/fromMock attribute, then
+  // resolve its module IDs into `{id, slug, title}` triples so the panel can
+  // render titles directly. The writer stores just IDs (see
+  // `generateDiagnosticFromMock` in lib/curriculum/diagnostic-from-mock.ts);
+  // resolution lives at this API boundary to keep the writer cheap.
+  const diagnosticFromMock = await resolveDiagnosticFromMock(diagnosticAttr);
+
+  // #493 Slice 5.4 — compute course-complete verdict using the learner's
+  // resolved playbook → curriculum. Works uniformly for authored + AI-generated
+  // routes because both write `CurriculumModule` + `CallerModuleProgress` rows.
+  const courseComplete = await resolveCourseComplete(callerId);
+
   return NextResponse.json({
     ok: true,
     profile: profile
@@ -186,9 +209,132 @@ export async function GET(request: NextRequest) {
     },
     // #493 Slice 5.1 — per-module progress for SimProgressPanel Modules section
     modules,
-    // #493 Slice 5.3 — populated by E2 once diagnosticFromMock lands. Null until then.
-    diagnosticFromMock: null,
-    // #493 Slice 5.4 — populated by E2 once isCourseComplete() lands. Null until then.
-    courseComplete: null,
+    // #493 Slice 5.3 — latest diagnostic written by E2 AGGREGATE after a Mock call.
+    diagnosticFromMock,
+    // #493 Slice 5.4 — current course-complete verdict from isCourseComplete().
+    courseComplete,
   });
+}
+
+interface ModuleRef {
+  id: string;
+  slug: string;
+  title: string;
+}
+
+interface DiagnosticFromMockResponse {
+  focusModules: ModuleRef[];
+  strengthModule: ModuleRef | null;
+  weakSkill: string | null;
+  summary: string;
+  fromCallId: string;
+  generatedAt: string;
+}
+
+/**
+ * Parse the latest DIAGNOSTIC/fromMock CallerAttribute and resolve its
+ * module IDs into `{id, slug, title}` triples. Returns null when:
+ *   - no row exists yet (no Mock call has completed); or
+ *   - the stored JSON is malformed (logged warn — defensive).
+ *
+ * Deleted modules are silently dropped from focusModules (UI shouldn't crash);
+ * a deleted strengthModule becomes null.
+ */
+async function resolveDiagnosticFromMock(
+  attr: { stringValue: string | null; updatedAt: Date } | null,
+): Promise<DiagnosticFromMockResponse | null> {
+  if (!attr || !attr.stringValue) return null;
+
+  let parsed: {
+    focusModules?: unknown;
+    strengthModule?: unknown;
+    weakSkill?: unknown;
+    summary?: unknown;
+    fromCallId?: unknown;
+    generatedAt?: unknown;
+  };
+  try {
+    parsed = JSON.parse(attr.stringValue);
+  } catch (err) {
+    console.warn(
+      "[student/progress] Failed to parse DIAGNOSTIC/fromMock stringValue as JSON",
+      (err as Error).message,
+    );
+    return null;
+  }
+
+  const focusIds = Array.isArray(parsed.focusModules)
+    ? parsed.focusModules.filter((v): v is string => typeof v === "string")
+    : [];
+  const strengthId =
+    typeof parsed.strengthModule === "string" ? parsed.strengthModule : null;
+  const allIds = [...focusIds];
+  if (strengthId) allIds.push(strengthId);
+
+  // Resolve module IDs → {id, slug, title}. Missing rows (deleted modules)
+  // simply don't appear in the map → dropped from focus list.
+  const modulesRefs = allIds.length
+    ? await prisma.curriculumModule.findMany({
+        where: { id: { in: allIds } },
+        select: { id: true, slug: true, title: true },
+      })
+    : [];
+  const byId = new Map<string, ModuleRef>(modulesRefs.map((m) => [m.id, m]));
+
+  const focusModules = focusIds
+    .map((id) => byId.get(id))
+    .filter((m): m is ModuleRef => m !== undefined);
+  const strengthModule = strengthId ? byId.get(strengthId) ?? null : null;
+
+  return {
+    focusModules,
+    strengthModule,
+    weakSkill: typeof parsed.weakSkill === "string" ? parsed.weakSkill : null,
+    summary: typeof parsed.summary === "string" ? parsed.summary : "",
+    fromCallId:
+      typeof parsed.fromCallId === "string" ? parsed.fromCallId : "",
+    generatedAt:
+      typeof parsed.generatedAt === "string"
+        ? parsed.generatedAt
+        : attr.updatedAt.toISOString(),
+  };
+}
+
+interface CourseCompleteResponse {
+  complete: boolean;
+  mode: "all-modules" | "terminal-only" | "any";
+  completedAt: string | null;
+}
+
+/**
+ * Resolve the caller's playbook → curriculum → completion verdict. Returns null
+ * when the caller has no resolved playbook or curriculum yet (new learner who
+ * hasn't enrolled, or a course that hasn't been synced to CurriculumModule).
+ */
+async function resolveCourseComplete(
+  callerId: string,
+): Promise<CourseCompleteResponse | null> {
+  const playbookId = await resolvePlaybookId(callerId);
+  if (!playbookId) return null;
+
+  const curriculumId = await resolveCurriculumIdForPlaybook(playbookId);
+  if (!curriculumId) return null;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { config: true },
+  });
+  const playbookConfig = (playbook?.config ?? null) as PlaybookConfig | null;
+
+  const verdict = await isCourseComplete(prisma, {
+    callerId,
+    curriculumId,
+    playbookConfig,
+  });
+  // Drop triggeringModuleIds from the API surface — UI only needs the hero.
+  return {
+    complete: verdict.complete,
+    mode: verdict.mode,
+    completedAt: verdict.completedAt,
+  };
 }

--- a/apps/admin/app/x/sim/sim.css
+++ b/apps/admin/app/x/sim/sim.css
@@ -1831,6 +1831,83 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* #493 Slice 5.3 — Focus areas (post-Mock diagnostic). Rendered above the
+   Modules section. One row per signal — strength (green), focus-next (amber),
+   weak-skill (muted). Each row reuses the section gap + 8/6 padding so it
+   visually rhymes with module rows. */
+.wa-progress-focus-section {
+  gap: 8px;
+}
+
+.wa-progress-focus-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--wa-text-secondary) 6%, transparent);
+  font-size: 13px;
+  color: var(--wa-text-primary);
+}
+
+.wa-progress-focus-icon {
+  flex-shrink: 0;
+}
+
+.wa-progress-focus-strength .wa-progress-focus-icon {
+  color: var(--wa-green-primary);
+}
+
+.wa-progress-focus-next .wa-progress-focus-icon {
+  color: var(--wa-amber);
+}
+
+.wa-progress-focus-weak .wa-progress-focus-icon {
+  color: var(--wa-text-secondary);
+}
+
+/* #493 Slice 5.4 — Course Complete hero. Rendered FIRST in the panel when
+   the completion predicate flips. Green-tinted card with celebratory icon +
+   title + subtitle + plain-English description of the completion mode. */
+.wa-progress-course-complete {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 20px 16px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--wa-green-primary) 12%, transparent);
+  text-align: center;
+}
+
+.wa-progress-course-complete-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--wa-green-primary);
+  color: var(--surface-primary);
+  margin-bottom: 4px;
+}
+
+.wa-progress-course-complete-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--wa-text-primary);
+}
+
+.wa-progress-course-complete-subtitle {
+  font-size: 13px;
+  color: var(--wa-text-primary);
+}
+
+.wa-progress-course-complete-desc {
+  font-size: 12px;
+  color: var(--wa-text-secondary);
+}
+
 /* Stats grid */
 .wa-progress-stat-grid {
   display: grid;

--- a/apps/admin/components/sim/SimProgressPanel.tsx
+++ b/apps/admin/components/sim/SimProgressPanel.tsx
@@ -1,9 +1,24 @@
 'use client';
 
 import { useEffect, type JSX } from 'react';
-import { ArrowLeft, X, Target, BookOpen, Lightbulb, Phone, TrendingUp, CheckCircle2, Circle, PlayCircle } from 'lucide-react';
+import { ArrowLeft, X, Target, BookOpen, Lightbulb, Phone, TrendingUp, CheckCircle2, Circle, PlayCircle, Award } from 'lucide-react';
 import { useStudentProgress } from '@/hooks/useStudentProgress';
 import { useJourneyPosition } from '@/hooks/useJourneyPosition';
+
+/** #493 Slice 5.4 — humanise the completion mode into educator-friendly copy. */
+function describeCompletionMode(mode: 'all-modules' | 'terminal-only' | 'any'): string {
+  if (mode === 'terminal-only') return 'You finished the final module of this course.';
+  if (mode === 'all-modules') return 'You mastered every module.';
+  return 'You completed your first module — keep going to master the rest.';
+}
+
+/** #493 Slice 5.4 — format an ISO date with `Intl.DateTimeFormat`, medium style. */
+function formatCompletedAt(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d);
+}
 
 interface SimProgressPanelProps {
   onClose: () => void;
@@ -51,6 +66,28 @@ export function SimProgressPanel({ onClose, callerId }: SimProgressPanelProps): 
 
         {!loading && !error && data && (
           <>
+            {/* #493 Slice 5.4 — Course Complete hero. Rendered FIRST when the
+                course-completion predicate returns complete=true. Educator-
+                friendly copy varies by completionMode (terminal-only is the
+                IELTS-style default; all-modules covers strict-mastery courses;
+                any covers open-ended / exploratory courses). */}
+            {data.courseComplete?.complete && (
+              <div className="wa-progress-course-complete">
+                <div className="wa-progress-course-complete-icon">
+                  <Award size={28} />
+                </div>
+                <div className="wa-progress-course-complete-title">Course complete!</div>
+                {data.courseComplete.completedAt && (
+                  <div className="wa-progress-course-complete-subtitle">
+                    You completed this course on {formatCompletedAt(data.courseComplete.completedAt)}.
+                  </div>
+                )}
+                <div className="wa-progress-course-complete-desc">
+                  {describeCompletionMode(data.courseComplete.mode)}
+                </div>
+              </div>
+            )}
+
             {/* Journey progress */}
             {position && position.totalStops > 0 && (
               <div className="wa-progress-section">
@@ -75,6 +112,40 @@ export function SimProgressPanel({ onClose, callerId }: SimProgressPanelProps): 
                     }
                   </span>
                 </div>
+              </div>
+            )}
+
+            {/* #493 Slice 5.3 — Focus areas section. Higher signal than the
+                module roster post-Mock, so rendered ABOVE Modules. Shows the
+                summary sentence, then a strength/focus-next/weak-skill list.
+                Each item is conditional — strength + weak skill may be null on
+                the very first Mock when there's no prior evidence. */}
+            {data.diagnosticFromMock && (
+              <div className="wa-progress-section wa-progress-focus-section">
+                <div className="wa-progress-section-title">Focus areas</div>
+                {data.diagnosticFromMock.summary && (
+                  <div className="wa-progress-empty">
+                    {data.diagnosticFromMock.summary}
+                  </div>
+                )}
+                {data.diagnosticFromMock.strengthModule && (
+                  <div className="wa-progress-focus-row wa-progress-focus-strength">
+                    <CheckCircle2 size={14} className="wa-progress-focus-icon" />
+                    <span>{data.diagnosticFromMock.strengthModule.title}</span>
+                  </div>
+                )}
+                {data.diagnosticFromMock.focusModules.map((m) => (
+                  <div key={m.id} className="wa-progress-focus-row wa-progress-focus-next">
+                    <PlayCircle size={14} className="wa-progress-focus-icon" />
+                    <span>{m.title}</span>
+                  </div>
+                ))}
+                {data.diagnosticFromMock.weakSkill && (
+                  <div className="wa-progress-focus-row wa-progress-focus-weak">
+                    <Lightbulb size={14} className="wa-progress-focus-icon" />
+                    <span>{data.diagnosticFromMock.weakSkill}</span>
+                  </div>
+                )}
               </div>
             )}
 

--- a/apps/admin/hooks/useStudentProgress.ts
+++ b/apps/admin/hooks/useStudentProgress.ts
@@ -29,10 +29,18 @@ export interface StudentModuleProgress {
 
 /**
  * #493 Slice 5.3 — populated by E2 ADAPT after a Mock call. Null until then.
+ * Module IDs from the writer are resolved at the API boundary into
+ * `{id, slug, title}` triples so the panel can render titles directly.
  */
+export interface StudentModuleRef {
+  id: string;
+  slug: string;
+  title: string;
+}
+
 export interface StudentDiagnosticFromMock {
-  focusModules: string[];
-  strengthModule: string | null;
+  focusModules: StudentModuleRef[];
+  strengthModule: StudentModuleRef | null;
   weakSkill: string | null;
   summary: string;
   fromCallId: string;

--- a/apps/admin/tests/api/student-progress-course-complete.test.ts
+++ b/apps/admin/tests/api/student-progress-course-complete.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #493 Slice 5.4 — student/progress route now calls `isCourseComplete()` and
+ * surfaces the verdict as `courseComplete: { complete, mode, completedAt }`
+ * for the SimProgressPanel Course Complete hero.
+ *
+ * Covered cases:
+ *   - No modules completed → complete: false (terminal-only default)
+ *   - terminal-only mode + terminal module completed → complete: true
+ *   - all-modules mode + every module complete → complete: true
+ *   - playbookConfig null → defaults to terminal-only
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  callerPersonalityProfile: { findUnique: vi.fn() },
+  goal: { findMany: vi.fn() },
+  call: { count: vi.fn() },
+  caller: { findUnique: vi.fn() },
+  callerMemorySummary: { findUnique: vi.fn() },
+  conversationArtifact: { count: vi.fn() },
+  callerAttribute: { findMany: vi.fn(), findFirst: vi.fn() },
+  callerModuleProgress: { findMany: vi.fn() },
+  curriculumModule: { findMany: vi.fn() },
+  playbook: { findUnique: vi.fn() },
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/student-access", () => ({
+  requireStudentOrAdmin: vi.fn().mockResolvedValue({
+    session: { user: { id: "stu-user-1", role: "STUDENT" } },
+    callerId: "stu-caller-1",
+    cohortGroupId: "cohort-1",
+    cohortGroupIds: ["cohort-1"],
+    institutionId: null,
+  }),
+  isStudentAuthError: vi.fn((r: Record<string, unknown>) => "error" in r),
+}));
+
+vi.mock("@/lib/enrollment/resolve-playbook", () => ({
+  resolvePlaybookId: vi.fn().mockResolvedValue("playbook-1"),
+}));
+vi.mock("@/lib/curriculum/resolve-module", () => ({
+  resolveCurriculumIdForPlaybook: vi.fn().mockResolvedValue("curriculum-1"),
+}));
+
+function resetDefaults(): void {
+  mockPrisma.callerPersonalityProfile.findUnique.mockResolvedValue(null);
+  mockPrisma.goal.findMany.mockResolvedValue([]);
+  mockPrisma.call.count.mockResolvedValue(0);
+  mockPrisma.caller.findUnique.mockResolvedValue({ name: "Alice", cohortGroup: null, cohortMemberships: [] });
+  mockPrisma.callerMemorySummary.findUnique.mockResolvedValue(null);
+  mockPrisma.conversationArtifact.count.mockResolvedValue(0);
+  mockPrisma.callerAttribute.findMany.mockResolvedValue([]);
+  mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+  mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
+  mockPrisma.callerAttribute.findFirst.mockResolvedValue(null);
+}
+
+describe("GET /api/student/progress — courseComplete (#493 Slice 5.4)", () => {
+  let GET: typeof import("@/app/api/student/progress/route").GET;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    resetDefaults();
+    const mod = await import("@/app/api/student/progress/route");
+    GET = mod.GET;
+  });
+
+  it("returns complete: false when no modules are completed", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { completionMode: "terminal-only" },
+    });
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      { id: "mod-1", slug: "part1", terminal: false, prerequisites: [], coversModules: [], masteryThreshold: 0.7 },
+      { id: "mod-mock", slug: "mock", terminal: true, prerequisites: [], coversModules: [], masteryThreshold: 0.7 },
+    ]);
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.courseComplete).toMatchObject({
+      complete: false,
+      mode: "terminal-only",
+      completedAt: null,
+    });
+  });
+
+  it("returns complete: true when terminal-only mode + terminal module is completed", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { completionMode: "terminal-only" },
+    });
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      { id: "mod-1", slug: "part1", terminal: false, prerequisites: [], coversModules: [], masteryThreshold: 0.7 },
+      { id: "mod-mock", slug: "mock", terminal: true, prerequisites: [], coversModules: [], masteryThreshold: 0.7 },
+    ]);
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      {
+        moduleId: "mod-mock",
+        status: "COMPLETED",
+        mastery: 0.9,
+        callCount: 3,
+        completedAt: new Date("2026-05-18T10:00:00Z"),
+        module: { id: "mod-mock", slug: "mock", title: "Mock", sortOrder: 99, masteryThreshold: 0.7 },
+      },
+    ]);
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.courseComplete).toMatchObject({
+      complete: true,
+      mode: "terminal-only",
+    });
+    expect(body.courseComplete.completedAt).toBe("2026-05-18T10:00:00.000Z");
+    // triggeringModuleIds is intentionally dropped from the API surface
+    expect(body.courseComplete.triggeringModuleIds).toBeUndefined();
+  });
+
+  it("returns complete: true when all-modules mode + every module is completed", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { completionMode: "all-modules" },
+    });
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      { id: "mod-1", slug: "part1", terminal: false, prerequisites: [], coversModules: [], masteryThreshold: 0.7 },
+      { id: "mod-2", slug: "part2", terminal: false, prerequisites: [], coversModules: [], masteryThreshold: 0.7 },
+    ]);
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      {
+        moduleId: "mod-1",
+        status: "COMPLETED",
+        mastery: 0.9,
+        callCount: 2,
+        completedAt: new Date("2026-05-17T10:00:00Z"),
+        module: { id: "mod-1", slug: "part1", title: "Part 1", sortOrder: 1, masteryThreshold: 0.7 },
+      },
+      {
+        moduleId: "mod-2",
+        status: "COMPLETED",
+        mastery: 0.9,
+        callCount: 2,
+        completedAt: new Date("2026-05-18T10:00:00Z"),
+        module: { id: "mod-2", slug: "part2", title: "Part 2", sortOrder: 2, masteryThreshold: 0.7 },
+      },
+    ]);
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.courseComplete).toMatchObject({
+      complete: true,
+      mode: "all-modules",
+    });
+    expect(body.courseComplete.completedAt).toBe("2026-05-18T10:00:00.000Z");
+  });
+
+  it("defaults to terminal-only when playbookConfig is null", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: null });
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      { id: "mod-mock", slug: "mock", terminal: true, prerequisites: [], coversModules: [], masteryThreshold: 0.7 },
+    ]);
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.courseComplete).toMatchObject({
+      complete: false,
+      mode: "terminal-only",
+    });
+  });
+});

--- a/apps/admin/tests/api/student-progress-diagnostic.test.ts
+++ b/apps/admin/tests/api/student-progress-diagnostic.test.ts
@@ -1,0 +1,199 @@
+/**
+ * #493 Slice 5.3 — student/progress route now reads the latest
+ * DIAGNOSTIC/fromMock `CallerAttribute` (written by E2 AGGREGATE) and resolves
+ * its module IDs into `{id, slug, title}` triples for the SimProgressPanel
+ * Focus Areas section.
+ *
+ * Covered cases:
+ *   - No DIAGNOSTIC row → diagnosticFromMock null
+ *   - Valid DIAGNOSTIC row → IDs resolve to title triples
+ *   - Malformed JSON → logs warn, returns null
+ *   - strengthModule null in storage → strengthModule null in response
+ *   - A focusModules ID whose CurriculumModule was deleted → entry dropped
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  callerPersonalityProfile: { findUnique: vi.fn() },
+  goal: { findMany: vi.fn() },
+  call: { count: vi.fn() },
+  caller: { findUnique: vi.fn() },
+  callerMemorySummary: { findUnique: vi.fn() },
+  conversationArtifact: { count: vi.fn() },
+  callerAttribute: { findMany: vi.fn(), findFirst: vi.fn() },
+  callerModuleProgress: { findMany: vi.fn() },
+  curriculumModule: { findMany: vi.fn() },
+  playbook: { findUnique: vi.fn() },
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/student-access", () => ({
+  requireStudentOrAdmin: vi.fn().mockResolvedValue({
+    session: { user: { id: "stu-user-1", role: "STUDENT" } },
+    callerId: "stu-caller-1",
+    cohortGroupId: "cohort-1",
+    cohortGroupIds: ["cohort-1"],
+    institutionId: null,
+  }),
+  isStudentAuthError: vi.fn((r: Record<string, unknown>) => "error" in r),
+}));
+
+// resolvePlaybookId / resolveCurriculumIdForPlaybook / isCourseComplete are
+// called by the same route — stub them to return null so the diagnostic
+// path is exercised independently of the course-complete path.
+vi.mock("@/lib/enrollment/resolve-playbook", () => ({
+  resolvePlaybookId: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/lib/curriculum/resolve-module", () => ({
+  resolveCurriculumIdForPlaybook: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/lib/curriculum/is-course-complete", () => ({
+  isCourseComplete: vi.fn().mockResolvedValue({
+    complete: false,
+    mode: "terminal-only",
+    completedAt: null,
+    triggeringModuleIds: [],
+  }),
+}));
+
+function resetDefaults(): void {
+  mockPrisma.callerPersonalityProfile.findUnique.mockResolvedValue(null);
+  mockPrisma.goal.findMany.mockResolvedValue([]);
+  mockPrisma.call.count.mockResolvedValue(0);
+  mockPrisma.caller.findUnique.mockResolvedValue({ name: "Alice", cohortGroup: null, cohortMemberships: [] });
+  mockPrisma.callerMemorySummary.findUnique.mockResolvedValue(null);
+  mockPrisma.conversationArtifact.count.mockResolvedValue(0);
+  mockPrisma.callerAttribute.findMany.mockResolvedValue([]);
+  mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+  mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
+  mockPrisma.playbook.findUnique.mockResolvedValue(null);
+}
+
+describe("GET /api/student/progress — diagnosticFromMock (#493 Slice 5.3)", () => {
+  let GET: typeof import("@/app/api/student/progress/route").GET;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    resetDefaults();
+    const mod = await import("@/app/api/student/progress/route");
+    GET = mod.GET;
+  });
+
+  it("returns null when no DIAGNOSTIC row exists", async () => {
+    mockPrisma.callerAttribute.findFirst.mockResolvedValue(null);
+
+    const res = await GET({} as unknown as Request as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.diagnosticFromMock).toBeNull();
+  });
+
+  it("resolves module IDs to {id, slug, title} triples", async () => {
+    mockPrisma.callerAttribute.findFirst.mockResolvedValue({
+      stringValue: JSON.stringify({
+        focusModules: ["mod-part1", "mod-part2"],
+        strengthModule: "mod-part3",
+        weakSkill: "fluency",
+        summary: "On your Mock, your strongest area was Part 3. To improve, focus next on Part 1, Part 2.",
+        fromCallId: "call-mock-1",
+        generatedAt: "2026-05-19T10:00:00Z",
+      }),
+      updatedAt: new Date("2026-05-19T10:00:00Z"),
+    });
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      { id: "mod-part1", slug: "part1", title: "Part 1" },
+      { id: "mod-part2", slug: "part2", title: "Part 2" },
+      { id: "mod-part3", slug: "part3", title: "Part 3" },
+    ]);
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.diagnosticFromMock).toMatchObject({
+      focusModules: [
+        { id: "mod-part1", slug: "part1", title: "Part 1" },
+        { id: "mod-part2", slug: "part2", title: "Part 2" },
+      ],
+      strengthModule: { id: "mod-part3", slug: "part3", title: "Part 3" },
+      weakSkill: "fluency",
+      fromCallId: "call-mock-1",
+    });
+    expect(body.diagnosticFromMock.summary).toContain("Part 3");
+  });
+
+  it("logs warn and returns null when stringValue is malformed JSON", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockPrisma.callerAttribute.findFirst.mockResolvedValue({
+      stringValue: "not-json{",
+      updatedAt: new Date(),
+    });
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.diagnosticFromMock).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("returns strengthModule null when stored strengthModule is null", async () => {
+    mockPrisma.callerAttribute.findFirst.mockResolvedValue({
+      stringValue: JSON.stringify({
+        focusModules: ["mod-part1"],
+        strengthModule: null,
+        weakSkill: null,
+        summary: "On your Mock, focus next on Part 1.",
+        fromCallId: "call-mock-2",
+        generatedAt: "2026-05-19T10:00:00Z",
+      }),
+      updatedAt: new Date("2026-05-19T10:00:00Z"),
+    });
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      { id: "mod-part1", slug: "part1", title: "Part 1" },
+    ]);
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.diagnosticFromMock.strengthModule).toBeNull();
+    expect(body.diagnosticFromMock.weakSkill).toBeNull();
+    expect(body.diagnosticFromMock.focusModules).toHaveLength(1);
+  });
+
+  it("drops focus entries whose CurriculumModule has been deleted", async () => {
+    mockPrisma.callerAttribute.findFirst.mockResolvedValue({
+      stringValue: JSON.stringify({
+        focusModules: ["mod-part1", "mod-deleted"],
+        strengthModule: "mod-part3",
+        weakSkill: "fluency",
+        summary: "Diagnostic summary",
+        fromCallId: "call-mock-3",
+        generatedAt: "2026-05-19T10:00:00Z",
+      }),
+      updatedAt: new Date("2026-05-19T10:00:00Z"),
+    });
+    // mod-deleted is missing from the resolver result
+    mockPrisma.curriculumModule.findMany.mockResolvedValue([
+      { id: "mod-part1", slug: "part1", title: "Part 1" },
+      { id: "mod-part3", slug: "part3", title: "Part 3" },
+    ]);
+
+    const res = await GET({} as unknown as Parameters<typeof GET>[0]);
+    const body = await res.json();
+
+    expect(body.diagnosticFromMock.focusModules).toEqual([
+      { id: "mod-part1", slug: "part1", title: "Part 1" },
+    ]);
+    expect(body.diagnosticFromMock.strengthModule).toEqual({
+      id: "mod-part3",
+      slug: "part3",
+      title: "Part 3",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Wires `/api/student/progress` to read the latest DIAGNOSTIC/fromMock `CallerAttribute` (written by E2 AGGREGATE) and resolve its module IDs into `{id, slug, title}` triples — replaces the `diagnosticFromMock: null` placeholder.
- Wires the same route to compute course completion via `isCourseComplete(prisma, { callerId, curriculumId, playbookConfig })` against the caller's resolved playbook+curriculum — replaces the `courseComplete: null` placeholder. `triggeringModuleIds` is dropped from the API surface (UI doesn't need it).
- `useStudentProgress` interface: `focusModules` + `strengthModule` carry resolved `{id, slug, title}` triples instead of bare IDs.
- `SimProgressPanel` renders:
  - **Course Complete hero** as the FIRST section when `courseComplete.complete === true`. Educator-friendly copy per `completionMode`. Date via `Intl.DateTimeFormat({ dateStyle: 'medium' })`.
  - **Focus Areas** section between Journey and Modules when `diagnosticFromMock != null`. Summary card + strength (green check) / focus-next (amber play) / weak-skill (lightbulb).
- New CSS in `sim.css` reuses `--wa-green-primary`, `--wa-amber`, `--wa-text-*`, `--surface-primary` — no new hex, no inline static styles.

## ASCII mockup (panel scroll order, post-Mock + course-complete state)

```
┌──────────────────────────────────────────────┐
│ ←  Progress                              ✕   │
├──────────────────────────────────────────────┤
│                                              │
│            ╭────────────╮                    │
│            │     🏆     │   ← --wa-green-    │
│            ╰────────────╯       primary bg   │
│           Course complete!                   │
│   You completed this course on 18 May 2026.  │
│   You finished the final module of this      │
│   course.                                    │
│                                              │
│ ─ PROGRESS ─                                 │
│ █████████████░░░░  72% mastered              │
│                                              │
│ ─ FOCUS AREAS ─                              │
│   On your Mock, your strongest area was      │
│   Part 3. To improve, focus next on Part 1,  │
│   Part 2.                                    │
│   ┌────────────────────────────────────────┐ │
│   │ ✓  Part 3                              │ │  ← strength (green)
│   ├────────────────────────────────────────┤ │
│   │ ▶  Part 1                              │ │  ← focus next (amber)
│   ├────────────────────────────────────────┤ │
│   │ ▶  Part 2                              │ │
│   ├────────────────────────────────────────┤ │
│   │ 💡  fluency                            │ │  ← weak skill
│   └────────────────────────────────────────┘ │
│                                              │
│ ─ MODULES (3) ─                              │
│   ✓ Part 1            2 calls                │
│   ▶ Part 2            1 call                 │
│   ○ Mock              —                      │
│                                              │
│ ─ GOALS / STATS / TEST SCORES … (unchanged)  │
└──────────────────────────────────────────────┘
```

When no Mock has run yet, Focus Areas is omitted. When the course isn't complete, the hero is omitted — every other section renders as before.

## Test plan

- [ ] `cd apps/admin && npx vitest run tests/api/student-progress` passes (3 files, 14 cases — 5 diagnostic + 4 course-complete + 5 module-status mapper).
- [ ] In a browser with a learner who has a DIAGNOSTIC/fromMock CallerAttribute, opening the SimProgressPanel renders the Focus Areas section above Modules.
- [ ] In a browser with a learner whose terminal module is COMPLETED, opening the panel shows the Course Complete hero as the first section with the correct date format.
- [ ] Deleted-module robustness: if a `focusModules` ID points at a deleted CurriculumModule, that row is dropped silently (no client crash).
- [ ] Malformed JSON in the CallerAttribute logs a warn and returns `diagnosticFromMock: null` — verified by unit test.

Closes part of #493 (E5 Slices 5.3 + 5.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)