### PR TITLE
feat(#492 Slice 3.5): priorCallFeedback section in composer

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -3057,12 +3057,15 @@ const stageExecutors: Record<string, StageExecutor> = {
     // #492 Slice 3.1: thread the call row's `curriculumModuleId` (resolved
     // at call-create from `?module=<slug>` via E1 1.1) so the composer locks
     // the prompt to the picked module. When null, falls through to scheduler.
+    // #492 Slice 3.5: thread `ctx.callId` so the priorCallFeedback loader can
+    // exclude the current call from its "last attempt on this module" search.
     const composition = await executeComposition(
       ctx.callerId,
       sections,
       fullSpecConfig,
       undefined,
       ctx.call.curriculumModuleId ?? null,
+      ctx.callId,
     );
     const promptSummary = renderPromptSummary(composition.llmPrompt);
 

--- a/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
@@ -671,6 +671,21 @@
       "outputKey": "curriculum"
     },
     {
+      "id": "prior_call_feedback",
+      "name": "Prior Call Feedback",
+      "priority": 7.5,
+      "dataSource": "priorCallFeedback",
+      "activateWhen": {
+        "condition": "priorCallFeedbackExists"
+      },
+      "fallback": {
+        "action": "omit"
+      },
+      "transform": "renderPriorCallFeedback",
+      "outputKey": "priorCallFeedback",
+      "dependsOn": ["curriculum"]
+    },
+    {
       "id": "session_planning",
       "name": "Session Planning",
       "priority": 8,

--- a/apps/admin/lib/prompt/composition/CompositionExecutor.ts
+++ b/apps/admin/lib/prompt/composition/CompositionExecutor.ts
@@ -47,6 +47,7 @@ import "./transforms/retrieval-practice";
 import "./transforms/course-instructions";
 import "./transforms/audience";
 import "./transforms/offboarding";
+import "./transforms/priorCallFeedback";
 
 /**
  * Execute the full composition pipeline.
@@ -70,11 +71,18 @@ export async function executeComposition(
   specConfig: Record<string, any>,
   triggerType?: string,
   requestedModuleId?: string | null,
+  currentCallId?: string | null,
 ): Promise<CompositionResult> {
   const loadStart = Date.now();
 
   // 1. Load all data in parallel
-  const loadedData = await loadAllData(callerId, specConfig);
+  // #492 Slice 3.5: `currentCallId` + `requestedModuleId` thread the active
+  // call's module scope into the priorCallFeedback loader so it can fetch the
+  // learner's last attempt on this module (and exclude the current call).
+  const loadedData = await loadAllData(callerId, specConfig, {
+    requestedModuleId: requestedModuleId ?? null,
+    currentCallId: currentCallId ?? null,
+  });
   const loadTimeMs = Date.now() - loadStart;
 
   if (!loadedData.caller) {
@@ -305,6 +313,19 @@ function checkActivationWithReason(
         return { activated: true, reason: "First call in current domain" };
       }
       return { activated: false, reason: "Not first call in domain" };
+
+    case "priorCallFeedbackExists": {
+      // #492 Slice 3.5 — only activate when the priorCallFeedback loader found
+      // a prior call AND it produced a usable summary. The loader always
+      // returns an object so the generic `dataExists` check passes; this
+      // checks the hasFeedback flag explicitly so the section is omitted
+      // (via fallback.action: "omit") on first-attempt calls.
+      const data = (context.loadedData as any).priorCallFeedback;
+      if (data && data.hasFeedback === true && typeof data.summary === "string" && data.summary.length > 0) {
+        return { activated: true, reason: "Prior call feedback available" };
+      }
+      return { activated: false, reason: "No prior call on this module (or empty summary)" };
+    }
 
     default:
       return { activated: true, reason: `Custom condition: ${condition}` };
@@ -589,6 +610,23 @@ export function getDefaultSections(): CompositionSectionDef[] {
       fallback: { action: "null" },
       transform: "computeModuleProgress",
       outputKey: "curriculum",
+    },
+    {
+      // #492 Slice 3.5 — recap of the learner's last attempt on this module.
+      // Slots between curriculum (priority 7) and learner_goals (priority 9) so
+      // the tutor reads "what happened last time" before any goal framing.
+      // activateWhen=priorCallFeedbackExists checks loadedData.priorCallFeedback.hasFeedback,
+      // which is false on first-attempt calls — combined with fallback.action="omit"
+      // that drops the section entirely from llmPrompt rather than emitting a null block.
+      id: "prior_call_feedback",
+      name: "Prior Call Feedback",
+      priority: 7.5,
+      dataSource: "priorCallFeedback",
+      activateWhen: { condition: "priorCallFeedbackExists" },
+      fallback: { action: "omit" },
+      transform: "renderPriorCallFeedback",
+      outputKey: "priorCallFeedback",
+      dependsOn: ["curriculum"],
     },
     {
       id: "session_planning",

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -18,6 +18,7 @@ import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
 import { getSubjectsForPlaybook } from "@/lib/knowledge/domain-sources";
 import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
 import { isStudentVisibleDefault } from "@/lib/doc-type-icons";
+import { loadPriorCallFeedback } from "./loaders/priorCallFeedback";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 import type { LoadedDataContext, SystemSpecData } from "./types";
 
@@ -73,10 +74,18 @@ export function getLoader(name: string): LoaderFn | undefined {
 /**
  * Load all data sources in parallel.
  * Mirrors the Promise.all() block from route.ts lines 109-355.
+ *
+ * @param callerId - Caller to compose for
+ * @param specConfig - COMP-001 spec config
+ * @param scope - Optional call-scoped values threaded from the COMPOSE stage.
+ *   `requestedModuleId` is the `CurriculumModule.id` set on the current Call;
+ *   `currentCallId` is excluded from prior-call lookups so we never
+ *   self-reference. Both default to undefined (no priorCallFeedback emitted).
  */
 export async function loadAllData(
   callerId: string,
   specConfig: Record<string, any>,
+  scope?: { requestedModuleId?: string | null; currentCallId?: string | null },
 ): Promise<LoadedDataContext> {
   const memoriesLimit = specConfig.memoriesLimit || 50;
   const recentCallsLimit = specConfig.recentCallsLimit || 5;
@@ -106,6 +115,7 @@ export async function loadAllData(
     courseInstructions,
     openActions,
     visualAids,
+    priorCallFeedback,
   ] = await Promise.all([
     loaderRegistry.get("caller")!(callerId),
     loaderRegistry.get("memories")!(callerId, { limit: memoriesLimit }),
@@ -128,6 +138,10 @@ export async function loadAllData(
     loaderRegistry.get("courseInstructions")!(callerId, { contentScope }),
     loaderRegistry.get("openActions")!(callerId),
     loaderRegistry.get("visualAids")!(callerId, { contentScope }),
+    loaderRegistry.get("priorCallFeedback")!(callerId, {
+      moduleId: scope?.requestedModuleId ?? null,
+      currentCallId: scope?.currentCallId ?? null,
+    }),
   ]);
 
   // Filter systemSpecs by playbook's systemSpecToggles (if configured)
@@ -158,6 +172,15 @@ export async function loadAllData(
     courseInstructions: courseInstructions || [],
     openActions: openActions || [],
     visualAids: visualAids || [],
+    priorCallFeedback: priorCallFeedback || {
+      hasFeedback: false,
+      lastCallAt: null,
+      lastCallId: null,
+      weakestParameterName: null,
+      weakestParameterScore: null,
+      overallScore: null,
+      summary: null,
+    },
   };
 }
 
@@ -538,6 +561,53 @@ registerLoader("callCount", async (callerId) => {
   return prisma.call.count({
     where: { callerId, endedAt: { not: null } },
   });
+});
+
+/**
+ * #492 Slice 3.5 — recap of the learner's most recent prior call on the
+ * current module. Delegates to {@link loadPriorCallFeedback} (pure function
+ * for testability). Wrapped in try/catch so any failure (missing FK,
+ * permission glitch, etc.) just disables the section rather than breaking
+ * composition.
+ *
+ * `config.moduleId` is the `CurriculumModule.id` from the current `Call`
+ * (threaded via `loadAllData(callerId, specConfig, { requestedModuleId })`).
+ * When null/undefined the loader returns the empty shape so the
+ * `priorCallFeedback` section activation check (`dataExists` + `hasFeedback`)
+ * skips emission.
+ */
+registerLoader("priorCallFeedback", async (callerId, config) => {
+  const moduleId = config?.moduleId as string | null | undefined;
+  const currentCallId = config?.currentCallId as string | null | undefined;
+  if (!moduleId) {
+    return {
+      hasFeedback: false,
+      lastCallAt: null,
+      lastCallId: null,
+      weakestParameterName: null,
+      weakestParameterScore: null,
+      overallScore: null,
+      summary: null,
+    };
+  }
+  try {
+    return await loadPriorCallFeedback(prisma, {
+      callerId,
+      moduleId,
+      currentCallId: currentCallId ?? null,
+    });
+  } catch (err) {
+    console.warn("[priorCallFeedback] loader failed — section will be omitted:", err);
+    return {
+      hasFeedback: false,
+      lastCallAt: null,
+      lastCallId: null,
+      weakestParameterName: null,
+      weakestParameterScore: null,
+      overallScore: null,
+      summary: null,
+    };
+  }
 });
 
 registerLoader("behaviorTargets", async (_callerId) => {

--- a/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
+++ b/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
@@ -1,0 +1,214 @@
+/**
+ * priorCallFeedback loader (#492 Slice 3.5)
+ *
+ * When composing the prompt for the next call on a given module, pull a brief
+ * "since your last attempt on this module" recap so the AI tutor can reference
+ * what the learner struggled with last time.
+ *
+ * The output is consumed by the `renderPriorCallFeedback` transform and emitted
+ * as the `priorCallFeedback` section between `curriculum` and `learner_goals`.
+ *
+ * Implementation notes:
+ *   - Pure function — takes a prisma client + scope as args so it can be tested
+ *     against a mock client and reused outside the composition path.
+ *   - Single Call query + single CallScore query (no N+1).
+ *   - Safe by default: any unexpected error returns `hasFeedback: false`. The
+ *     SectionDataLoader wrapper additionally try/catches so composition is
+ *     never broken by a feedback miss.
+ *
+ * @see SectionDataLoader.registerLoader("priorCallFeedback", ...)
+ * @see transforms/priorCallFeedback.ts (renderPriorCallFeedback transform)
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+export interface PriorCallFeedbackData {
+  hasFeedback: boolean;
+  /** ISO date of the most recent prior call on this module */
+  lastCallAt: string | null;
+  lastCallId: string | null;
+  /** Lowest-scoring parameter's name */
+  weakestParameterName: string | null;
+  /** Lowest-scoring parameter's score (0–1) */
+  weakestParameterScore: number | null;
+  /** Average of all CallScore rows on the prior call (0–1) */
+  overallScore: number | null;
+  /** 1–2 sentence canned summary — friendly, with relative time */
+  summary: string | null;
+}
+
+export interface LoadPriorCallFeedbackOptions {
+  callerId: string;
+  /** CurriculumModule.id to scope the prior-call lookup */
+  moduleId: string;
+  /** Current call id to exclude from the search (so we never self-reference) */
+  currentCallId?: string | null;
+  /** Override "now" for deterministic tests */
+  now?: Date;
+}
+
+const EMPTY: PriorCallFeedbackData = {
+  hasFeedback: false,
+  lastCallAt: null,
+  lastCallId: null,
+  weakestParameterName: null,
+  weakestParameterScore: null,
+  overallScore: null,
+  summary: null,
+};
+
+/**
+ * Subset of PrismaClient used by this loader — narrows the surface so tests
+ * can pass a minimal mock object.
+ */
+type PrismaForLoader = Pick<PrismaClient, "call" | "callScore">;
+
+/**
+ * Load the prior-call feedback summary for a given caller + module.
+ *
+ * Returns {@link EMPTY} (with `hasFeedback: false`) when:
+ *   - `moduleId` or `callerId` is missing/empty
+ *   - No prior `Call` row exists for the (callerId, moduleId) pair (other than
+ *     `currentCallId`, which is excluded)
+ *   - The prior call exists but has no `CallScore` rows (still returns
+ *     `hasFeedback: true` with a friendly fallback summary — see tests)
+ */
+export async function loadPriorCallFeedback(
+  prisma: PrismaForLoader,
+  opts: LoadPriorCallFeedbackOptions,
+): Promise<PriorCallFeedbackData> {
+  const { callerId, moduleId, currentCallId, now } = opts;
+  if (!callerId || !moduleId) return EMPTY;
+
+  // 1. Most recent prior call on this module (excluding currentCallId)
+  const priorCall = await prisma.call.findFirst({
+    where: {
+      callerId,
+      curriculumModuleId: moduleId,
+      ...(currentCallId ? { id: { not: currentCallId } } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, createdAt: true },
+  });
+
+  if (!priorCall) return EMPTY;
+
+  // 2. Scores from that prior call (joined to parameter name)
+  const scores = await prisma.callScore.findMany({
+    where: { callId: priorCall.id },
+    select: {
+      score: true,
+      parameter: { select: { name: true } },
+    },
+  });
+
+  const lastCallAt = priorCall.createdAt.toISOString();
+  const relativeTime = formatRelativeTime(priorCall.createdAt, now ?? new Date());
+
+  if (scores.length === 0) {
+    return {
+      hasFeedback: true,
+      lastCallAt,
+      lastCallId: priorCall.id,
+      weakestParameterName: null,
+      weakestParameterScore: null,
+      overallScore: null,
+      summary:
+        `On your last attempt ${relativeTime} we didn't have clear score signals to learn from — let's pick up where we left off.`,
+    };
+  }
+
+  // Average overall score
+  const overallScore = scores.reduce((sum, s) => sum + (s.score ?? 0), 0) / scores.length;
+
+  // Weakest parameter — pick the lowest score; tie-break by name for determinism
+  const sortedByScore = [...scores].sort((a, b) => {
+    const sa = a.score ?? 0;
+    const sb = b.score ?? 0;
+    if (sa !== sb) return sa - sb;
+    return (a.parameter?.name ?? "").localeCompare(b.parameter?.name ?? "");
+  });
+  const weakest = sortedByScore[0];
+  const weakestParameterName = weakest.parameter?.name ?? null;
+  const weakestParameterScore = weakest.score ?? null;
+
+  const summary = buildSummary({
+    relativeTime,
+    weakestParameterName,
+    weakestParameterScore,
+    overallScore,
+  });
+
+  return {
+    hasFeedback: true,
+    lastCallAt,
+    lastCallId: priorCall.id,
+    weakestParameterName,
+    weakestParameterScore,
+    overallScore,
+    summary,
+  };
+}
+
+// =============================================================
+// Helpers
+// =============================================================
+
+/**
+ * Format a relative time like "yesterday", "3 days ago", "2 weeks ago".
+ *
+ * Uses Intl.RelativeTimeFormat so localisation hooks are in place; the
+ * caller-facing copy is still produced via deterministic template strings
+ * (see {@link buildSummary}) for predictable test assertions.
+ */
+export function formatRelativeTime(then: Date, now: Date): string {
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  const diffMs = then.getTime() - now.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  // Same calendar bucket: "today" / "yesterday" — Intl.RelativeTimeFormat with
+  // numeric:"auto" handles those words for diffDays === 0 and -1.
+  if (Math.abs(diffDays) < 7) {
+    return rtf.format(diffDays, "day");
+  }
+  const diffWeeks = Math.round(diffDays / 7);
+  if (Math.abs(diffWeeks) < 5) {
+    return rtf.format(diffWeeks, "week");
+  }
+  const diffMonths = Math.round(diffDays / 30);
+  if (Math.abs(diffMonths) < 12) {
+    return rtf.format(diffMonths, "month");
+  }
+  const diffYears = Math.round(diffDays / 365);
+  return rtf.format(diffYears, "year");
+}
+
+/**
+ * Format a 0–1 score as a one-decimal value out of 9 — matches the IELTS-style
+ * band the tutor speaks in. Bounded to [0, 9] for safety.
+ */
+function formatScoreOutOf9(score: number): string {
+  const bounded = Math.max(0, Math.min(1, score));
+  const banded = Math.round(bounded * 9 * 10) / 10;
+  return `${banded.toFixed(1)}/9`;
+}
+
+function buildSummary(args: {
+  relativeTime: string;
+  weakestParameterName: string | null;
+  weakestParameterScore: number | null;
+  overallScore: number | null;
+}): string {
+  const { relativeTime, weakestParameterName, weakestParameterScore, overallScore } = args;
+
+  if (weakestParameterName !== null && weakestParameterScore !== null) {
+    return (
+      `On your last attempt ${relativeTime}, your weakest area was ` +
+      `${weakestParameterName} (${formatScoreOutOf9(weakestParameterScore)}).`
+    );
+  }
+  if (overallScore !== null) {
+    return `On your last attempt ${relativeTime}, your overall score was ${formatScoreOutOf9(overallScore)}.`;
+  }
+  return `On your last attempt ${relativeTime}, no specific weaknesses were flagged.`;
+}

--- a/apps/admin/lib/prompt/composition/transforms/priorCallFeedback.ts
+++ b/apps/admin/lib/prompt/composition/transforms/priorCallFeedback.ts
@@ -1,0 +1,60 @@
+/**
+ * priorCallFeedback transform (#492 Slice 3.5)
+ *
+ * Reads the {@link PriorCallFeedbackData} from `loadedData.priorCallFeedback`
+ * and emits the section payload for the final prompt. Returns `null` when
+ * there is no feedback to surface so the section is dropped by the executor's
+ * "strip undefined" pass.
+ *
+ * Wire-up:
+ *   - dataSource: "priorCallFeedback"
+ *   - transform : "renderPriorCallFeedback"
+ *   - outputKey : "priorCallFeedback"
+ *   - condition : "dataExists" (the loader always returns an object — the
+ *                 transform short-circuits to `null` when hasFeedback=false)
+ *
+ * The student-facing copy is built in the loader so callers (e.g. tests, dev
+ * dashboards) get the same `summary` string the composer renders.
+ */
+
+import { registerTransform } from "../TransformRegistry";
+import type {
+  AssembledContext,
+  CompositionSectionDef,
+  PriorCallFeedbackData,
+} from "../types";
+
+export interface PriorCallFeedbackSection {
+  hasFeedback: boolean;
+  /** Markdown heading text — the tutor reads this verbatim */
+  heading: string;
+  /** 1–2 sentence canned summary (already includes relative time) */
+  summary: string;
+  lastCallAt: string | null;
+  lastCallId: string | null;
+  weakestParameterName: string | null;
+  weakestParameterScore: number | null;
+  overallScore: number | null;
+}
+
+const HEADING = "Since your last attempt on this module";
+
+registerTransform("renderPriorCallFeedback", (
+  rawData: PriorCallFeedbackData | null | undefined,
+  _context: AssembledContext,
+  _sectionDef: CompositionSectionDef,
+): PriorCallFeedbackSection | null => {
+  if (!rawData || !rawData.hasFeedback || !rawData.summary) {
+    return null;
+  }
+  return {
+    hasFeedback: true,
+    heading: HEADING,
+    summary: rawData.summary,
+    lastCallAt: rawData.lastCallAt,
+    lastCallId: rawData.lastCallId,
+    weakestParameterName: rawData.weakestParameterName,
+    weakestParameterScore: rawData.weakestParameterScore,
+    overallScore: rawData.overallScore,
+  };
+});

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -95,6 +95,23 @@ export interface LoadedDataContext {
   visualAids?: VisualAidData[];
   /** Course instructions (tutor rules) from COURSE_REFERENCE document type */
   courseInstructions?: CourseInstructionData[];
+  /**
+   * #492 Slice 3.5 — recap of the learner's most recent prior call on the
+   * current module. `hasFeedback: false` when there is no prior call (or no
+   * module scope), in which case the section is omitted from the final prompt.
+   */
+  priorCallFeedback?: PriorCallFeedbackData;
+}
+
+/** Prior-call feedback data for the current module (#492 Slice 3.5) */
+export interface PriorCallFeedbackData {
+  hasFeedback: boolean;
+  lastCallAt: string | null;
+  lastCallId: string | null;
+  weakestParameterName: string | null;
+  weakestParameterScore: number | null;
+  overallScore: number | null;
+  summary: string | null;
 }
 
 /** Visual aid data loaded for prompt and content catalog */

--- a/apps/admin/tests/lib/composition/prior-call-feedback.test.ts
+++ b/apps/admin/tests/lib/composition/prior-call-feedback.test.ts
@@ -1,0 +1,440 @@
+/**
+ * #492 Slice 3.5 — priorCallFeedback loader + transform tests.
+ *
+ * Covers:
+ *   - No prior call on the module → hasFeedback: false, no section emitted
+ *   - One prior call with scores → summary references weakest parameter +
+ *     relative time
+ *   - Prior call with zero scores → friendly fallback summary, weakest* null
+ *   - Multiple prior calls → uses the most recent (ordered by createdAt desc)
+ *   - currentCallId is excluded so we never self-reference
+ *   - The composition section is emitted when hasFeedback=true and dropped
+ *     when hasFeedback=false
+ *
+ * The loader is exercised directly with a small mock client (no Prisma
+ * coupling) so the surface is narrow and the assertions are exact.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  loadPriorCallFeedback,
+  formatRelativeTime,
+} from "@/lib/prompt/composition/loaders/priorCallFeedback";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+
+// Trigger transform registration
+import "@/lib/prompt/composition/transforms/priorCallFeedback";
+
+// =====================================================
+// Helpers
+// =====================================================
+
+/**
+ * Tiny Prisma stub that supports findFirst on Call and findMany on CallScore
+ * with deterministic data driven by the args. Each test wires up its own
+ * implementations.
+ */
+function makePrismaStub(opts: {
+  /** Pre-seeded prior calls in any order — the stub orders + filters them */
+  calls: Array<{
+    id: string;
+    callerId: string;
+    curriculumModuleId: string | null;
+    createdAt: Date;
+  }>;
+  /** Scores keyed by callId */
+  scoresByCall: Record<string, Array<{ score: number; parameter: { name: string } | null }>>;
+}) {
+  const call = {
+    findFirst: vi.fn(async ({ where, orderBy }: any) => {
+      let matches = opts.calls.filter((c) => {
+        if (where.callerId && c.callerId !== where.callerId) return false;
+        if (where.curriculumModuleId && c.curriculumModuleId !== where.curriculumModuleId) return false;
+        if (where.id?.not && c.id === where.id.not) return false;
+        return true;
+      });
+      if (orderBy?.createdAt === "desc") {
+        matches = matches.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      }
+      return matches[0] ?? null;
+    }),
+  };
+  const callScore = {
+    findMany: vi.fn(async ({ where }: any) => {
+      return opts.scoresByCall[where.callId] ?? [];
+    }),
+  };
+  return { call, callScore } as any;
+}
+
+const NOW = new Date("2026-05-19T10:00:00Z");
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+
+// =====================================================
+// Loader tests
+// =====================================================
+
+describe("loadPriorCallFeedback", () => {
+  it("returns hasFeedback: false when no prior call exists on the module", async () => {
+    const prisma = makePrismaStub({ calls: [], scoresByCall: {} });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-1",
+      moduleId: "mod-1",
+      now: NOW,
+    });
+
+    expect(result.hasFeedback).toBe(false);
+    expect(result.summary).toBeNull();
+    expect(result.lastCallId).toBeNull();
+  });
+
+  it("returns hasFeedback: false when moduleId is empty", async () => {
+    const prisma = makePrismaStub({ calls: [], scoresByCall: {} });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-1",
+      moduleId: "",
+      now: NOW,
+    });
+
+    expect(result.hasFeedback).toBe(false);
+    // Should short-circuit BEFORE calling prisma
+    expect(prisma.call.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("summarises weakest parameter + relative time when scores exist", async () => {
+    const callAt = daysAgo(3);
+    const prisma = makePrismaStub({
+      calls: [
+        { id: "call-old", callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: callAt },
+      ],
+      scoresByCall: {
+        "call-old": [
+          { score: 0.75, parameter: { name: "fluency" } },
+          { score: 0.5, parameter: { name: "pronunciation" } },
+          { score: 0.8, parameter: { name: "vocabulary" } },
+        ],
+      },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-1",
+      moduleId: "mod-1",
+      now: NOW,
+    });
+
+    expect(result.hasFeedback).toBe(true);
+    expect(result.lastCallId).toBe("call-old");
+    expect(result.lastCallAt).toBe(callAt.toISOString());
+    expect(result.weakestParameterName).toBe("pronunciation");
+    expect(result.weakestParameterScore).toBeCloseTo(0.5, 5);
+    expect(result.overallScore).toBeCloseTo((0.75 + 0.5 + 0.8) / 3, 5);
+    expect(result.summary).toContain("pronunciation");
+    expect(result.summary).toContain("3 days ago");
+    // 0.5 of 9 = 4.5
+    expect(result.summary).toContain("4.5/9");
+  });
+
+  it("falls back to friendly summary when prior call has zero scores", async () => {
+    const callAt = daysAgo(1);
+    const prisma = makePrismaStub({
+      calls: [
+        { id: "call-old", callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: callAt },
+      ],
+      scoresByCall: { "call-old": [] },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-1",
+      moduleId: "mod-1",
+      now: NOW,
+    });
+
+    expect(result.hasFeedback).toBe(true);
+    expect(result.lastCallId).toBe("call-old");
+    expect(result.weakestParameterName).toBeNull();
+    expect(result.weakestParameterScore).toBeNull();
+    expect(result.overallScore).toBeNull();
+    expect(result.summary).toMatch(/didn't have clear score signals/i);
+  });
+
+  it("uses the most recent prior call when several exist", async () => {
+    const prisma = makePrismaStub({
+      calls: [
+        { id: "call-week-ago", callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(7) },
+        { id: "call-yesterday", callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(1) },
+        { id: "call-month-ago", callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(30) },
+      ],
+      scoresByCall: {
+        "call-yesterday": [{ score: 0.6, parameter: { name: "fluency" } }],
+        "call-week-ago": [{ score: 0.4, parameter: { name: "pronunciation" } }],
+        "call-month-ago": [{ score: 0.3, parameter: { name: "vocabulary" } }],
+      },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-1",
+      moduleId: "mod-1",
+      now: NOW,
+    });
+
+    expect(result.lastCallId).toBe("call-yesterday");
+    expect(result.weakestParameterName).toBe("fluency");
+  });
+
+  it("excludes the currentCallId from the search (no self-reference)", async () => {
+    const prisma = makePrismaStub({
+      calls: [
+        // Most recent — but it's the current call. Loader must skip it.
+        { id: "call-current", callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(0) },
+        { id: "call-prior", callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(5) },
+      ],
+      scoresByCall: {
+        "call-current": [{ score: 0.9, parameter: { name: "fluency" } }],
+        "call-prior": [{ score: 0.4, parameter: { name: "pronunciation" } }],
+      },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-1",
+      moduleId: "mod-1",
+      currentCallId: "call-current",
+      now: NOW,
+    });
+
+    expect(result.lastCallId).toBe("call-prior");
+    expect(result.weakestParameterName).toBe("pronunciation");
+  });
+
+  it("ignores prior calls scoped to a different module", async () => {
+    const prisma = makePrismaStub({
+      calls: [
+        { id: "call-other-mod", callerId: "caller-1", curriculumModuleId: "mod-OTHER", createdAt: daysAgo(1) },
+      ],
+      scoresByCall: { "call-other-mod": [{ score: 0.5, parameter: { name: "anything" } }] },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-1",
+      moduleId: "mod-1",
+      now: NOW,
+    });
+
+    expect(result.hasFeedback).toBe(false);
+  });
+});
+
+// =====================================================
+// Relative time helper
+// =====================================================
+
+describe("formatRelativeTime", () => {
+  it("returns 'yesterday' for 1 day ago", () => {
+    expect(formatRelativeTime(daysAgo(1), NOW)).toBe("yesterday");
+  });
+
+  it("returns 'N days ago' for <7 days", () => {
+    expect(formatRelativeTime(daysAgo(3), NOW)).toBe("3 days ago");
+  });
+
+  it("returns 'N weeks ago' for 1-4 weeks", () => {
+    expect(formatRelativeTime(daysAgo(14), NOW)).toMatch(/2 weeks ago/);
+  });
+
+  it("returns 'N months ago' for several months", () => {
+    expect(formatRelativeTime(daysAgo(90), NOW)).toMatch(/months ago/);
+  });
+});
+
+// =====================================================
+// Transform tests (composition integration surface)
+// =====================================================
+
+describe("renderPriorCallFeedback transform", () => {
+  it("emits a section block when hasFeedback=true", () => {
+    const transform = getTransform("renderPriorCallFeedback");
+    expect(transform).toBeDefined();
+
+    const result = transform!(
+      {
+        hasFeedback: true,
+        lastCallAt: "2026-05-15T10:00:00Z",
+        lastCallId: "call-1",
+        weakestParameterName: "fluency",
+        weakestParameterScore: 0.5,
+        overallScore: 0.65,
+        summary: "On your last attempt 4 days ago, your weakest area was fluency (4.5/9).",
+      },
+      {} as any,
+      {} as any,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result.hasFeedback).toBe(true);
+    expect(result.heading).toMatch(/Since your last attempt on this module/i);
+    expect(result.summary).toContain("fluency");
+    expect(result.weakestParameterName).toBe("fluency");
+  });
+
+  it("returns null (drops the section) when hasFeedback=false", () => {
+    const transform = getTransform("renderPriorCallFeedback");
+    const result = transform!(
+      {
+        hasFeedback: false,
+        lastCallAt: null,
+        lastCallId: null,
+        weakestParameterName: null,
+        weakestParameterScore: null,
+        overallScore: null,
+        summary: null,
+      },
+      {} as any,
+      {} as any,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when raw data is missing entirely", () => {
+    const transform = getTransform("renderPriorCallFeedback");
+    expect(transform!(null, {} as any, {} as any)).toBeNull();
+    expect(transform!(undefined, {} as any, {} as any)).toBeNull();
+  });
+});
+
+// =====================================================
+// Default-sections registration (composition integration surface)
+// =====================================================
+
+describe("priorCallFeedback in getDefaultSections", () => {
+  it("registers the prior_call_feedback section between curriculum and learner_goals", async () => {
+    const { getDefaultSections } = await import("@/lib/prompt/composition/CompositionExecutor");
+    const sections = getDefaultSections();
+    const ids = sections.map((s) => s.id);
+
+    const idxCurriculum = ids.indexOf("curriculum");
+    const idxPrior = ids.indexOf("prior_call_feedback");
+    const idxGoals = ids.indexOf("learner_goals");
+
+    expect(idxCurriculum).toBeGreaterThanOrEqual(0);
+    expect(idxPrior).toBeGreaterThanOrEqual(0);
+    expect(idxGoals).toBeGreaterThanOrEqual(0);
+
+    // Order in the declaration: curriculum comes first, then prior, then goals
+    expect(idxPrior).toBeGreaterThan(idxCurriculum);
+    expect(idxPrior).toBeLessThan(idxGoals);
+
+    const section = sections[idxPrior];
+    expect(section.outputKey).toBe("priorCallFeedback");
+    expect(section.dataSource).toBe("priorCallFeedback");
+    expect(section.transform).toBe("renderPriorCallFeedback");
+    expect(section.dependsOn).toContain("curriculum");
+    // Activation = priorCallFeedbackExists guards on hasFeedback=true so the
+    // section is omitted on first-attempt calls.
+    expect(section.activateWhen.condition).toBe("priorCallFeedbackExists");
+    // fallback=omit keeps the section out of the prompt entirely when no prior call exists
+    expect(section.fallback.action).toBe("omit");
+  });
+});
+
+// =====================================================
+// Activation logic on the executor (priorCallFeedbackExists)
+// =====================================================
+
+describe("priorCallFeedbackExists activation logic", () => {
+  it("the priorCallFeedbackExists branch activates only when hasFeedback=true and summary non-empty", async () => {
+    // We exercise the activation by importing the section + a minimal fake
+    // context. The checkActivationWithReason function is not exported, so we
+    // test the contract via the full executor in the next describe.
+    // (See "section is emitted/omitted via executor" below.)
+    expect(true).toBe(true);
+  });
+
+  it("section is emitted when hasFeedback=true and omitted otherwise (executor end-to-end)", async () => {
+    // Stub out loadAllData so we can drive priorCallFeedback directly while
+    // keeping the rest of the executor logic real. The stub is scoped via
+    // vi.doMock so other tests in this file are unaffected.
+    vi.resetModules();
+    const baseLoaded = {
+      caller: { id: "caller-1", name: "Test", email: null, phone: null, externalId: null, domain: null },
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      callCount: 0,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [],
+      systemSpecs: [],
+      onboardingSpec: null,
+      onboardingSession: null,
+      subjectSources: null,
+      curriculumAssertions: [],
+      curriculumQuestions: [],
+      curriculumVocabulary: [],
+      courseInstructions: [],
+      openActions: [],
+      visualAids: [],
+    };
+
+    vi.doMock("@/lib/prompt/composition/SectionDataLoader", async () => {
+      const actual: any = await vi.importActual("@/lib/prompt/composition/SectionDataLoader");
+      return {
+        ...actual,
+        loadAllData: vi.fn().mockImplementation(async (_id: string, _cfg: any, scope: any) => {
+          // Return the priorCallFeedback shape from scope-supplied flag (read
+          // via a global the test sets) — keeps both branches in one mock.
+          const hasFb = (globalThis as any).__TEST_PRIOR_FB__ as boolean;
+          return {
+            ...baseLoaded,
+            priorCallFeedback: hasFb
+              ? {
+                  hasFeedback: true,
+                  lastCallAt: "2026-05-15T10:00:00Z",
+                  lastCallId: "call-old",
+                  weakestParameterName: "fluency",
+                  weakestParameterScore: 0.5,
+                  overallScore: 0.65,
+                  summary: "On your last attempt yesterday, your weakest area was fluency (4.5/9).",
+                }
+              : {
+                  hasFeedback: false,
+                  lastCallAt: null,
+                  lastCallId: null,
+                  weakestParameterName: null,
+                  weakestParameterScore: null,
+                  overallScore: null,
+                  summary: null,
+                },
+          };
+        }),
+      };
+    });
+
+    const { executeComposition, getDefaultSections } = await import(
+      "@/lib/prompt/composition/CompositionExecutor"
+    );
+    const sections = getDefaultSections();
+    const minimalConfig = {};
+
+    // ── Case 1: hasFeedback = true → section appears in llmPrompt ──
+    (globalThis as any).__TEST_PRIOR_FB__ = true;
+    const result1 = await executeComposition("caller-1", sections, minimalConfig, undefined, "mod-1", "call-current");
+    expect(result1.metadata.sectionsActivated).toContain("prior_call_feedback");
+    expect(result1.llmPrompt.priorCallFeedback).toBeDefined();
+    expect(result1.llmPrompt.priorCallFeedback.summary).toContain("fluency");
+    expect(result1.llmPrompt.priorCallFeedback.heading).toMatch(/Since your last attempt/);
+
+    // ── Case 2: hasFeedback = false → section is OMITTED from llmPrompt ──
+    (globalThis as any).__TEST_PRIOR_FB__ = false;
+    const result2 = await executeComposition("caller-1", sections, minimalConfig, undefined, null, "call-current");
+    expect(result2.metadata.sectionsSkipped).toContain("prior_call_feedback");
+    expect(result2.llmPrompt.priorCallFeedback).toBeUndefined();
+
+    // Clean up
+    delete (globalThis as any).__TEST_PRIOR_FB__;
+    vi.doUnmock("@/lib/prompt/composition/SectionDataLoader");
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary
- New `priorCallFeedback` composition section between `curriculum` and `learner_goals` that recaps the learner's most recent prior call on the active module (weakest parameter + score + friendly relative time).
- New pure loader `lib/prompt/composition/loaders/priorCallFeedback.ts` — single Call query + single CallScore query, excludes the current call so we never self-reference. Wrapped in try/catch so loader failure never breaks composition.
- New activation condition `priorCallFeedbackExists` + `fallback.action: "omit"` so the section is dropped entirely on first-attempt calls (no `priorCallFeedback: null` noise in `llmPrompt`).
- COMPOSE stage in `app/api/calls/[callId]/pipeline/route.ts` now threads `ctx.callId` so the loader can exclude the current call.
- COMP-001 seed JSON kept in sync with `getDefaultSections()` — `seed-sync.test.ts` passes.

## Test plan
- [x] `npx vitest run tests/lib/composition/prior-call-feedback.test.ts tests/lib/composition/modules.test.ts tests/lib/composition/modules-requested-module.test.ts` — 67/67 pass
- [x] `npx vitest run tests/lib/composition tests/lib/prompt/composition` — 352/352 pass (no regressions)
- [x] `npx tsc --noEmit` — no new errors in changed files
- [ ] Manual: run a learner through a module twice on `dev`, confirm second-call prompt contains `priorCallFeedback` block with last-attempt summary

Closes #492 (Slice 3.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)