### PR TITLE
feat(#495 Slice 4.6): hard-lock modal + locked tile state (strictPrerequisites=true)

### DIFF
--- a/apps/admin/__tests__/ui/learner-module-picker-hard-lock.test.tsx
+++ b/apps/admin/__tests__/ui/learner-module-picker-hard-lock.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * Tests for the #495 Slice 4.6 hard-lock modal + locked-tile state in
+ * LearnerModulePicker.
+ *
+ * When `strictPrerequisites === true` AND a learner clicks a module
+ * whose prereqs aren't all MASTERED, the picker intercepts the click
+ * and shows a dismiss-only modal. There is NO "Continue anyway"
+ * affordance in strict mode — the only escape is to dismiss and pick
+ * a prereq instead.
+ *
+ * Visual cues on each locked tile:
+ *   - `learner-picker-page__tile--locked` (or rail-card equivalent)
+ *   - a small grey Lock icon in the top-LEFT corner
+ *   - the recommended-next badge is SUPPRESSED on locked tiles
+ *
+ * Soft-warning path (`strictPrerequisites === false`) is covered in
+ * `learner-module-picker-soft-warning.test.tsx` and is unchanged by
+ * this slice — we don't re-test it here.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LearnerModulePicker } from "@/app/x/courses/[courseId]/_components/LearnerModulePicker";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+
+function mod(over: Partial<AuthoredModule>): AuthoredModule {
+  return {
+    id: "m",
+    label: "Module",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "Student-led",
+    scoringFired: "LR + GRA",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: [],
+    ...over,
+  };
+}
+
+const FIXTURE: AuthoredModule[] = [
+  mod({
+    id: "m1",
+    label: "Module One",
+    progress: { status: "MASTERED", callCount: 4 },
+  }),
+  mod({
+    id: "m2",
+    label: "Module Two",
+    prerequisites: ["m1"],
+    progress: { status: "NOT_STARTED", callCount: 0 },
+  }),
+  mod({
+    id: "m3",
+    label: "Module Three",
+    prerequisites: ["m2"],
+    progress: { status: "NOT_STARTED", callCount: 0 },
+  }),
+];
+
+function getTile(container: HTMLElement, label: string): HTMLButtonElement {
+  const btn = Array.from(
+    container.querySelectorAll("button.learner-picker__tile"),
+  ).find((b) => b.textContent?.includes(label)) as HTMLButtonElement;
+  expect(btn, `tile for ${label}`).toBeTruthy();
+  return btn;
+}
+
+describe("LearnerModulePicker — hard-lock modal (#495 Slice 4.6)", () => {
+  it("opens the hard-lock modal when prereqs are NOT mastered and strictPrerequisites=true", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={onSelect}
+        strictPrerequisites={true}
+      />,
+    );
+
+    fireEvent.click(getTile(container, "Module Three"));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/Complete these first/i)).toBeInTheDocument();
+    // Unmet prereq title appears in the bulleted list (scoped to dialog
+    // so it doesn't collide with the tile label outside).
+    const listItems = dialog.querySelectorAll(
+      ".learner-picker-page__hardlock-modal-list li",
+    );
+    const itemTexts = Array.from(listItems).map((li) => li.textContent);
+    expect(itemTexts).toContain("Module Two");
+    // Original handler must NOT have fired
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("hard-lock modal exposes NO 'Continue anyway' affordance — only OK", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={onSelect}
+        strictPrerequisites={true}
+      />,
+    );
+
+    fireEvent.click(getTile(container, "Module Three"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // No "Continue anyway" button in strict mode
+    expect(
+      screen.queryByRole("button", { name: /continue/i }),
+    ).not.toBeInTheDocument();
+    // Single OK affordance is present
+    expect(
+      screen.getByRole("button", { name: /OK, take me back/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking 'OK, take me back' closes the modal WITHOUT calling onSelect", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={onSelect}
+        strictPrerequisites={true}
+      />,
+    );
+
+    fireEvent.click(getTile(container, "Module Three"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /OK, take me back/i }),
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Escape dismisses the hard-lock modal", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={onSelect}
+        strictPrerequisites={true}
+      />,
+    );
+
+    fireEvent.click(getTile(container, "Module Three"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("backdrop click dismisses the hard-lock modal", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={onSelect}
+        strictPrerequisites={true}
+      />,
+    );
+
+    fireEvent.click(getTile(container, "Module Three"));
+    const backdrop = container.querySelector(
+      ".learner-picker-page__hardlock-modal-backdrop",
+    ) as HTMLElement;
+    expect(backdrop).toBeTruthy();
+    fireEvent.click(backdrop);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("forwards to onSelect immediately when prereqs ARE mastered (even with strictPrerequisites=true)", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={onSelect}
+        strictPrerequisites={true}
+      />,
+    );
+
+    // m2's only prereq is m1, which is MASTERED → click should pass through.
+    fireEvent.click(getTile(container, "Module Two"));
+
+    expect(onSelect).toHaveBeenCalledWith("m2");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("locked tile carries the --locked class + a visible Lock icon", () => {
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={vi.fn()}
+        strictPrerequisites={true}
+      />,
+    );
+
+    const m3 = getTile(container, "Module Three");
+    expect(m3.classList.contains("learner-picker-page__tile--locked")).toBe(
+      true,
+    );
+    expect(m3.getAttribute("data-locked")).toBe("true");
+    // The lock badge sits inside the tile
+    const lockBadge = m3.querySelector(".learner-picker-page__lock-badge");
+    expect(lockBadge).toBeTruthy();
+    // Tooltip is present
+    expect(m3.getAttribute("title")).toBe("Complete the prereqs first");
+  });
+
+  it("recommended-next badge is suppressed on a locked tile", () => {
+    // Force the upstream to pick a locked module — defence-in-depth: the
+    // recommender shouldn't do this, but the picker must defend itself.
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={vi.fn()}
+        strictPrerequisites={true}
+        recommendedModuleId="m3"
+        recommendedReason="next-in-sequence"
+      />,
+    );
+
+    const m3 = getTile(container, "Module Three");
+    expect(m3.querySelector(".learner-picker-page__lock-badge")).toBeTruthy();
+    expect(
+      m3.querySelector(".learner-picker-page__recommended-badge"),
+    ).toBeNull();
+    expect(m3.getAttribute("data-recommended")).toBeNull();
+  });
+
+  it("does NOT add the --locked class when strictPrerequisites=false", () => {
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={vi.fn()}
+        strictPrerequisites={false}
+      />,
+    );
+
+    const m3 = getTile(container, "Module Three");
+    expect(m3.classList.contains("learner-picker-page__tile--locked")).toBe(
+      false,
+    );
+    expect(m3.querySelector(".learner-picker-page__lock-badge")).toBeNull();
+  });
+
+  it("hard-lock modal has correct ARIA attributes", () => {
+    const { container } = render(
+      <LearnerModulePicker
+        modules={FIXTURE}
+        lessonPlanMode="continuous"
+        onSelect={vi.fn()}
+        strictPrerequisites={true}
+      />,
+    );
+
+    fireEvent.click(getTile(container, "Module Three"));
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute(
+      "aria-labelledby",
+      "picker-prereq-hard-lock-title",
+    );
+    const title = container.querySelector("#picker-prereq-hard-lock-title");
+    expect(title).toBeTruthy();
+  });
+
+  it("works on the rail layout (structured mode) — locked rail card gets the locked class + Lock icon", () => {
+    const ordered = FIXTURE.map((m, i) => ({ ...m, position: i + 1 }));
+    const { container } = render(
+      <LearnerModulePicker
+        modules={ordered}
+        lessonPlanMode="structured"
+        onSelect={vi.fn()}
+        strictPrerequisites={true}
+      />,
+    );
+
+    const railCards = Array.from(
+      container.querySelectorAll("button.learner-picker__rail-card"),
+    );
+    const m3Card = railCards.find((c) =>
+      c.textContent?.includes("Module Three"),
+    ) as HTMLButtonElement;
+    expect(m3Card).toBeTruthy();
+    expect(
+      m3Card.classList.contains("learner-picker-page__rail-card--locked"),
+    ).toBe(true);
+    expect(
+      m3Card.querySelector(".learner-picker-page__lock-badge"),
+    ).toBeTruthy();
+  });
+});

--- a/apps/admin/__tests__/ui/learner-module-picker-soft-warning.test.tsx
+++ b/apps/admin/__tests__/ui/learner-module-picker-soft-warning.test.tsx
@@ -231,10 +231,12 @@ describe("LearnerModulePicker — soft-warning modal (#495 Slice 4.5)", () => {
     expect(title).toBeTruthy();
   });
 
-  it("falls through to the soft-warning modal when strictPrerequisites=true (slice 4.6 placeholder)", () => {
-    // Until slice 4.6 lands, strict-mode unmet prereqs use the same soft-
-    // warning UX so the learner is never silently blocked. This test
-    // pins that contract.
+  it("does NOT show the soft-warning modal when strictPrerequisites=true (Slice 4.6 routes to hard-lock instead)", () => {
+    // From Slice 4.6 onwards, strict-mode unmet-prereq clicks open the
+    // hard-lock modal (dismiss-only) — NOT the soft-warning modal. This
+    // test pins that the soft-warning shell is no longer used in strict
+    // mode. The hard-lock variant has dedicated coverage in
+    // `learner-module-picker-hard-lock.test.tsx`.
     const onSelect = vi.fn();
     const { container } = render(
       <LearnerModulePicker
@@ -249,6 +251,11 @@ describe("LearnerModulePicker — soft-warning modal (#495 Slice 4.5)", () => {
       container.querySelectorAll("button.learner-picker__tile"),
     ).find((b) => b.textContent?.includes("Module Three")) as HTMLButtonElement;
     fireEvent.click(m3Button);
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // A dialog DOES open (the hard-lock variant) — assert by title to
+    // distinguish it from the soft-warning shell.
+    expect(
+      screen.queryByText(/Heads up — you haven't completed the prereqs/i),
+    ).not.toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -31,12 +31,14 @@ import {
   PlayCircle,
   Circle,
   Sparkles,
+  Lock,
 } from "lucide-react";
 import type { AuthoredModule } from "@/lib/types/json-fields";
 import {
   PrereqsSoftWarningModal,
   type UnmetPrereq,
 } from "./PrereqsSoftWarningModal";
+import { PrereqsHardLockModal } from "./PrereqsHardLockModal";
 
 export type PickerLayout = "tiles" | "rail";
 
@@ -80,11 +82,14 @@ interface LearnerModulePickerProps {
    */
   recommendedReason?: string | null;
   /**
-   * #495 Slice 4.5 — when `false` (default), clicking a module whose
+   * #495 Slice 4.5/4.6 — when `false` (default), clicking a module whose
    * prereqs aren't all MASTERED triggers a soft-warning modal before the
-   * picker calls `onSelect`. When `true`, slice 4.6 will hard-lock the
-   * tile; until that ships the picker falls through to the same soft-
-   * warning modal so the learner is never silently blocked.
+   * picker calls `onSelect` (Slice 4.5). When `true`, the picker hard-
+   * locks the tile: clicking opens a dismiss-only modal that points the
+   * learner at the unmet prereqs, and the tile itself renders a quiet
+   * lock badge + desaturate so it's obvious the click did something
+   * (Slice 4.6). The recommended-next badge is suppressed for any
+   * locked tile so the two affordances never contradict each other.
    *
    * Source of truth is the import-modules endpoint's top-level
    * `strictPrerequisites` field (mirrors
@@ -111,6 +116,14 @@ export function LearnerModulePicker({
     unmetPrereqs: UnmetPrereq[];
   } | null>(null);
 
+  // #495 Slice 4.6 — pending pick blocked by hard-lock (strict mode +
+  // unmet prereqs). The hard-lock modal renders with a single dismiss
+  // button; onSelect is never forwarded.
+  const [pendingHardLock, setPendingHardLock] = useState<{
+    module: AuthoredModule;
+    unmetPrereqs: UnmetPrereq[];
+  } | null>(null);
+
   // Index modules by id so we can resolve unmet prereq slugs → friendly
   // titles for the modal's bulleted list without prop-drilling.
   const modulesById = useMemo(() => {
@@ -122,12 +135,30 @@ export function LearnerModulePicker({
   const completed = useMemo(() => new Set(completedModuleIds), [completedModuleIds]);
   const inProgress = useMemo(() => new Set(inProgressModuleIds), [inProgressModuleIds]);
 
+  // Pre-compute the set of locked module ids — modules whose prereqs
+  // aren't all MASTERED while the course runs in strict mode. Drives
+  // the tile-level lock badge + desaturate (Slice 4.6) AND suppresses
+  // the recommended-next badge on the same tile so the two affordances
+  // never contradict each other. Empty set when `strictPrerequisites`
+  // is false → tiles stay un-decorated and Slice 4.5's soft-warning
+  // path is untouched.
+  const lockedModuleIds = useMemo(() => {
+    if (!strictPrerequisites) return new Set<string>();
+    const locked = new Set<string>();
+    for (const m of modules) {
+      const unmet = computeUnmetPrereqs(m, modulesById);
+      if (unmet.length > 0) locked.add(m.id);
+    }
+    return locked;
+  }, [strictPrerequisites, modules, modulesById]);
+
   // Wrap the parent's onSelect: when prereqs are unmet, intercept the
-  // click and stage the modal. When they're satisfied (or there are
-  // none), fall through immediately. Mastery is the gate, not mere
-  // completion — `progress.status === "MASTERED"` matches the picker's
-  // existing vocabulary (Slice 4.2) and the recommender's policy
-  // (#494 Slice 2.5).
+  // click. Strict mode → hard-lock modal (Slice 4.6, dismiss-only).
+  // Lenient mode → soft-warning modal (Slice 4.5, "Continue anyway"
+  // forwards). No unmet prereqs → fall through immediately. Mastery is
+  // the gate, not mere completion — `progress.status === "MASTERED"`
+  // matches the picker's existing vocabulary (Slice 4.2) and the
+  // recommender's policy (#494 Slice 2.5).
   const handlePick = useCallback(
     (moduleId: string) => {
       if (!onSelect) return;
@@ -141,11 +172,10 @@ export function LearnerModulePicker({
         onSelect(moduleId);
         return;
       }
-      // TODO: 4.6 hard-lock — when `strictPrerequisites === true`, render
-      // a lock affordance on the tile + block the click entirely. Until
-      // that slice lands we fall through to the same soft-warning modal
-      // so the learner is never silently blocked.
-      void strictPrerequisites;
+      if (strictPrerequisites) {
+        setPendingHardLock({ module: mod, unmetPrereqs: unmet });
+        return;
+      }
       setPendingSoftWarn({ module: mod, unmetPrereqs: unmet });
     },
     [onSelect, modulesById, strictPrerequisites],
@@ -163,6 +193,10 @@ export function LearnerModulePicker({
 
   const handleSoftWarnCancel = useCallback(() => {
     setPendingSoftWarn(null);
+  }, []);
+
+  const handleHardLockDismiss = useCallback(() => {
+    setPendingHardLock(null);
   }, []);
 
   const visible = modules.filter((m) => m.learnerSelectable !== false);
@@ -192,6 +226,7 @@ export function LearnerModulePicker({
           onSelect={layoutOnSelect}
           recommendedModuleId={recommendedModuleId}
           recommendedReason={recommendedReason}
+          lockedModuleIds={lockedModuleIds}
         />
       ) : (
         <TilesLayout
@@ -201,6 +236,7 @@ export function LearnerModulePicker({
           onSelect={layoutOnSelect}
           recommendedModuleId={recommendedModuleId}
           recommendedReason={recommendedReason}
+          lockedModuleIds={lockedModuleIds}
         />
       )}
       {pendingSoftWarn && (
@@ -209,6 +245,13 @@ export function LearnerModulePicker({
           unmetPrereqs={pendingSoftWarn.unmetPrereqs}
           onContinue={handleSoftWarnContinue}
           onCancel={handleSoftWarnCancel}
+        />
+      )}
+      {pendingHardLock && (
+        <PrereqsHardLockModal
+          module={pendingHardLock.module}
+          unmetPrereqs={pendingHardLock.unmetPrereqs}
+          onDismiss={handleHardLockDismiss}
         />
       )}
     </div>
@@ -247,6 +290,7 @@ function TilesLayout({
   onSelect,
   recommendedModuleId,
   recommendedReason,
+  lockedModuleIds,
 }: {
   modules: AuthoredModule[];
   completed: Set<string>;
@@ -254,6 +298,7 @@ function TilesLayout({
   onSelect?: (id: string) => void;
   recommendedModuleId: string | null;
   recommendedReason: string | null;
+  lockedModuleIds: Set<string>;
 }) {
   // Hide `frequency: once` modules already completed (e.g. Baseline).
   // Repeatable + completed stays visible so learners can retake.
@@ -275,6 +320,7 @@ function TilesLayout({
             onSelect={onSelect}
             isRecommended={m.id === recommendedModuleId}
             recommendedReason={recommendedReason}
+            isLocked={lockedModuleIds.has(m.id)}
           />
         ))}
       </div>
@@ -302,6 +348,7 @@ function TilesLayout({
               onSelect={onSelect}
               isRecommended={m.id === recommendedModuleId}
               recommendedReason={recommendedReason}
+              isLocked={lockedModuleIds.has(m.id)}
             />
           ))}
         </Section>
@@ -317,6 +364,7 @@ function TilesLayout({
               onSelect={onSelect}
               isRecommended={m.id === recommendedModuleId}
               recommendedReason={recommendedReason}
+              isLocked={lockedModuleIds.has(m.id)}
             />
           ))}
         </Section>
@@ -332,6 +380,7 @@ function TilesLayout({
               onSelect={onSelect}
               isRecommended={m.id === recommendedModuleId}
               recommendedReason={recommendedReason}
+              isLocked={lockedModuleIds.has(m.id)}
             />
           ))}
         </Section>
@@ -356,6 +405,7 @@ function Tile({
   onSelect,
   isRecommended,
   recommendedReason,
+  isLocked,
 }: {
   mod: AuthoredModule;
   inProgress: boolean;
@@ -363,23 +413,33 @@ function Tile({
   onSelect?: (id: string) => void;
   isRecommended: boolean;
   recommendedReason: string | null;
+  isLocked: boolean;
 }) {
   const Tag = onSelect ? "button" : "div";
   // Suppress the recommended badge for mastered modules — defence in depth
   // against an upstream that recommends something already MASTERED.
   // `recommendNextModule()` filters those out, but the picker shouldn't
   // double-decorate a Mastered tile if a stale payload slips through.
+  // Also suppress when the tile is locked (Slice 4.6): the lock badge
+  // takes the top-LEFT corner and "recommended-next" would contradict
+  // the lock affordance even if the recommender slipped up.
   const showRecommended =
-    isRecommended && mod.progress?.status !== "MASTERED";
+    isRecommended && mod.progress?.status !== "MASTERED" && !isLocked;
+  const className = isLocked
+    ? "learner-picker__tile learner-picker-page__tile--locked"
+    : "learner-picker__tile";
   return (
     <Tag
       type={onSelect ? "button" : undefined}
-      className="learner-picker__tile"
+      className={className}
       onClick={onSelect ? () => onSelect(mod.id) : undefined}
       data-terminal={mod.sessionTerminal || undefined}
       data-progress={inProgress ? "in-progress" : completed ? "completed" : undefined}
       data-recommended={showRecommended || undefined}
+      data-locked={isLocked || undefined}
+      title={isLocked ? "Complete the prereqs first" : undefined}
     >
+      {isLocked && <LockBadge />}
       {showRecommended && <RecommendedBadge reason={recommendedReason} />}
       <StatusBadge progress={mod.progress} />
       <ModeIcon mode={mod.mode} />
@@ -426,6 +486,7 @@ function RailLayout({
   onSelect,
   recommendedModuleId,
   recommendedReason,
+  lockedModuleIds,
 }: {
   modules: AuthoredModule[];
   completed: Set<string>;
@@ -433,6 +494,7 @@ function RailLayout({
   onSelect?: (id: string) => void;
   recommendedModuleId: string | null;
   recommendedReason: string | null;
+  lockedModuleIds: Set<string>;
 }) {
   // Sort by `position` if provided, otherwise preserve catalogue order.
   const ordered = [...modules].sort((a, b) => {
@@ -446,14 +508,23 @@ function RailLayout({
       {ordered.map((m, i) => {
         const isComplete = completed.has(m.id);
         const isInProgress = inProgress.has(m.id) && !isComplete;
+        const isLocked = lockedModuleIds.has(m.id);
         const Tag = onSelect ? "button" : "div";
         const prereqsUnmet = m.prerequisites.filter((p) => !completed.has(p));
         const advisoryHint =
           prereqsUnmet.length > 0
             ? `Recommended after ${prereqsUnmet.join(", ")}`
             : null;
+        // Suppress the recommended-next badge on locked cards — same
+        // reasoning as the tile layout: a hard-locked card cannot be the
+        // recommendation, even if upstream slipped one through.
         const showRecommended =
-          m.id === recommendedModuleId && m.progress?.status !== "MASTERED";
+          m.id === recommendedModuleId &&
+          m.progress?.status !== "MASTERED" &&
+          !isLocked;
+        const cardClassName = isLocked
+          ? "learner-picker__rail-card learner-picker-page__rail-card--locked"
+          : "learner-picker__rail-card";
 
         return (
           <li key={m.id} className="learner-picker__rail-item">
@@ -462,12 +533,15 @@ function RailLayout({
             </div>
             <Tag
               type={onSelect ? "button" : undefined}
-              className="learner-picker__rail-card"
+              className={cardClassName}
               onClick={onSelect ? () => onSelect(m.id) : undefined}
               data-progress={isComplete ? "completed" : isInProgress ? "in-progress" : undefined}
               data-terminal={m.sessionTerminal || undefined}
               data-recommended={showRecommended || undefined}
+              data-locked={isLocked || undefined}
+              title={isLocked ? "Complete the prereqs first" : undefined}
             >
+              {isLocked && <LockBadge />}
               {showRecommended && <RecommendedBadge reason={recommendedReason} />}
               <StatusBadge progress={m.progress} />
               <ModeIcon mode={m.mode} />
@@ -592,6 +666,26 @@ function RecommendedBadge({ reason }: { reason: string | null }) {
     >
       <Sparkles size={12} aria-hidden="true" />
       <span>Recommended next</span>
+    </span>
+  );
+}
+
+// ── Lock badge (#495 Slice 4.6) ────────────────────────────────────
+//
+// Quiet grey pill pinned to the top-LEFT of any tile / rail card the
+// learner can't yet take (strict-prereq mode + unmet prereqs). Sits in
+// the same corner as the "Recommended next" badge — the two are mutually
+// exclusive, so a locked tile never shows the green recommendation pill
+// (see suppression logic in Tile / RailLayout). The badge is purely
+// decorative — the tile itself stays clickable so the hard-lock modal
+// can explain WHY it's locked.
+function LockBadge() {
+  return (
+    <span
+      className="learner-picker-page__lock-badge"
+      aria-label="Locked — complete the prereqs first"
+    >
+      <Lock size={12} aria-hidden="true" />
     </span>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/_components/PrereqsHardLockModal.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PrereqsHardLockModal.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * PrereqsHardLockModal — #495 E4 Slice 4.6.
+ *
+ * Hard-lock variant of {@link PrereqsSoftWarningModal}. Shown when a
+ * learner clicks a module whose suggested prereqs are not yet mastered
+ * AND the course's `strictPrerequisites` flag is `true`. Unlike the
+ * soft-warning modal, there is NO "Continue anyway" escape hatch — the
+ * single primary action just dismisses the dialog so the learner can
+ * pick one of the highlighted prerequisites instead.
+ *
+ * Microcopy is intentionally educator-friendly: the word "locked" is
+ * kept out of the title (it appears as a quiet badge on the tile), and
+ * the body redirects the learner toward the next concrete step rather
+ * than berating them for choosing wrong.
+ *
+ * Accessibility:
+ *   - `role="dialog"` + `aria-modal="true"`
+ *   - `aria-labelledby` points at the heading
+ *   - Backdrop click and Escape both dismiss
+ *   - Auto-focus the dismiss button so screen readers land on the only
+ *     actionable affordance
+ */
+
+import { useEffect, useRef } from "react";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+import type { UnmetPrereq } from "./PrereqsSoftWarningModal";
+
+interface PrereqsHardLockModalProps {
+  module: AuthoredModule;
+  unmetPrereqs: UnmetPrereq[];
+  onDismiss: () => void;
+}
+
+export function PrereqsHardLockModal({
+  module: mod,
+  unmetPrereqs,
+  onDismiss,
+}: PrereqsHardLockModalProps) {
+  const dismissBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the single action on mount so keyboard / SR users land on
+  // the only affordance the modal offers.
+  useEffect(() => {
+    dismissBtnRef.current?.focus();
+  }, []);
+
+  // Escape dismisses. Bound at the document level so the handler still
+  // fires when focus has moved off the modal's own subtree.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onDismiss();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onDismiss]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="picker-prereq-hard-lock-title"
+      className="learner-picker-page__hardlock-modal-backdrop"
+      onClick={onDismiss}
+    >
+      <div
+        className="learner-picker-page__hardlock-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="picker-prereq-hard-lock-title"
+          className="learner-picker-page__hardlock-modal-title"
+        >
+          Complete these first
+        </h2>
+        <p className="learner-picker-page__hardlock-modal-body">
+          <strong>{mod.label}</strong> is locked until you&apos;ve completed:
+        </p>
+        <ul className="learner-picker-page__hardlock-modal-list">
+          {unmetPrereqs.map((p) => (
+            <li key={p.slug}>{p.title}</li>
+          ))}
+        </ul>
+        <p className="learner-picker-page__hardlock-modal-body">
+          Click one of those to start there.
+        </p>
+        <div className="learner-picker-page__hardlock-modal-actions">
+          <button
+            type="button"
+            ref={dismissBtnRef}
+            className="learner-picker-page__hardlock-modal-btn learner-picker-page__hardlock-modal-btn--primary"
+            onClick={onDismiss}
+            aria-label="OK, take me back to the picker"
+          >
+            OK, take me back
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/authored-modules-panel.css
@@ -796,3 +796,128 @@ button.learner-picker__rail-card:hover {
   border-color: color-mix(in srgb, var(--text-primary) 25%, var(--border-default));
   outline: none;
 }
+
+/* #495 Slice 4.6 — hard-lock affordances.
+   Used when `strictPrerequisites === true` AND a candidate module has
+   unmet prereqs. The tile/rail card stays clickable so the hard-lock
+   modal can explain WHY it's gated; the badge + desaturate are purely
+   visual cues so the learner doesn't think their click broke. We share
+   the same modal shell as the soft warning but tint it amber to lean
+   "important info" rather than the soft-warning's neutral palette. */
+
+.learner-picker-page__tile--locked,
+.learner-picker-page__rail-card--locked {
+  opacity: 0.6;
+  filter: saturate(0.7);
+}
+
+.learner-picker-page__tile--locked:hover,
+.learner-picker-page__tile--locked:focus-visible,
+.learner-picker-page__rail-card--locked:hover,
+.learner-picker-page__rail-card--locked:focus-visible {
+  /* Restore a little on hover so the learner still sees their click
+     was registered — no pointer-events: none. */
+  opacity: 0.75;
+}
+
+.learner-picker-page__lock-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 20%, transparent);
+  color: var(--text-muted);
+  border: 1px solid color-mix(in srgb, var(--text-muted) 30%, transparent);
+  pointer-events: none; /* purely decorative — tile click stays unblocked */
+}
+
+.learner-picker-page__hardlock-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--text-primary) 50%, transparent);
+  z-index: 100;
+}
+
+.learner-picker-page__hardlock-modal {
+  max-width: 460px;
+  width: 90%;
+  padding: 24px;
+  border-radius: 16px;
+  background: var(--surface-primary);
+  /* Subtle amber border so the modal reads as a stop sign without
+     resorting to error-red — the learner hasn't done anything wrong. */
+  border-top: 4px solid var(--status-warning-text, var(--accent-primary));
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--text-primary) 25%, transparent);
+}
+
+.learner-picker-page__hardlock-modal-title {
+  margin: 0 0 12px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.learner-picker-page__hardlock-modal-body {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.learner-picker-page__hardlock-modal-list {
+  margin: 0 0 16px 0;
+  padding-left: 20px;
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.learner-picker-page__hardlock-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.learner-picker-page__hardlock-modal-btn {
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+/* Single dismiss button — amber-tinted accent so it reads as the only
+   action without screaming "error". Picks up status-warning-text from
+   the admin tokens, falling back to the brand accent if the route
+   doesn't load the warning palette. */
+.learner-picker-page__hardlock-modal-btn--primary {
+  color: var(--surface-primary);
+  background: var(--status-warning-text, var(--accent-primary));
+  border-color: var(--status-warning-text, var(--accent-primary));
+}
+
+.learner-picker-page__hardlock-modal-btn--primary:hover,
+.learner-picker-page__hardlock-modal-btn--primary:focus-visible {
+  background: color-mix(
+    in srgb,
+    var(--status-warning-text, var(--accent-primary)) 85%,
+    var(--text-primary)
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--status-warning-text, var(--accent-primary)) 85%,
+    var(--text-primary)
+  );
+  outline: none;
+}


### PR DESCRIPTION
## Summary

Implements **E4 Slice 4.6** of the module-mastery epic (#495). When a
course runs with `strictPrerequisites=true` AND a learner clicks a
module whose prereqs aren't all MASTERED, the picker now opens a
dismiss-only modal — no "Continue anyway" escape hatch — and the tile
itself wears a quiet lock affordance so the learner sees their click
landed.

- New `PrereqsHardLockModal` component (dismiss-only) — title
  "Complete these first", body lists unmet prereq titles, single
  "OK, take me back" button. Backdrop + Escape also dismiss.
- `LearnerModulePicker` branches in `handlePick`:
  `strictPrerequisites=true` + unmet → hard-lock modal;
  `strictPrerequisites=false` + unmet → existing soft-warning modal
  (Slice 4.5, unchanged); no unmet → original handler.
- Locked tiles get `learner-picker-page__tile--locked` /
  `__rail-card--locked` (opacity 0.6, slight desaturate) plus a small
  grey `Lock` icon top-left. Tiles stay clickable so the modal can
  explain WHY they're gated. Tooltip: "Complete the prereqs first".
- Recommended-next badge is suppressed on any locked tile.
- Modal CSS reuses the Slice 4.5 shell but tinted amber
  (`--status-warning-text`) for emphasis without going error-red.
- Works on both tile (continuous) AND rail (structured) layouts.
- Both course routes (authored + AI-generated) inherit via the shared
  picker.

## ASCII mockups

### Locked tile (continuous layout)

```
┌──────────────────────────────────────┐
│ [Lock]              [Not started]    │   ← grey lock badge top-left
│  icon                                 │     status badge top-right
│                                       │
│  Module Three                         │
│  Student-led · Repeatable             │
│                                       │
│  (tile opacity 0.6, desaturate 0.7)   │   ← visual lock cue
└──────────────────────────────────────┘
   ↳ hover: opacity nudges to 0.75
   ↳ click: opens hard-lock modal (below)
   ↳ title="Complete the prereqs first"
```

A locked tile NEVER shows the green "Recommended next" badge, even if
upstream slips one through — defence-in-depth.

### Locked rail card (structured layout)

```
①─┐  ┌─────────────────────────────────┐
   │  │ [Lock]            [Not started] │
   │  │  Module Three                    │
   │  │  Student-led · Repeatable        │
   │  │  (opacity 0.6, desaturate 0.7)   │
   │  └─────────────────────────────────┘
```

### Hard-lock modal (dismiss-only)

```
       ┌────────────────────────────────────────┐
       │ ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔ (amber bar)    │
       │                                         │
       │   Complete these first                  │
       │                                         │
       │   Module Three is locked until you've   │
       │   completed:                            │
       │                                         │
       │     • Module Two                        │
       │                                         │
       │   Click one of those to start there.    │
       │                                         │
       │                  [ OK, take me back ]   │
       └────────────────────────────────────────┘
```

- Single primary button — no "Continue anyway".
- Backdrop click + Escape also dismiss.
- `role="dialog"`, `aria-modal="true"`,
  `aria-labelledby="picker-prereq-hard-lock-title"`.
- Focus lands on the OK button on mount.

## Test plan

- [x] Unit: `__tests__/ui/learner-module-picker-hard-lock.test.tsx` —
      11 new tests covering modal open/close, no Continue-anyway,
      Escape + backdrop dismiss, locked-tile class + lock icon,
      recommended badge suppression, rail layout, ARIA.
- [x] Unit: `__tests__/ui/learner-module-picker-soft-warning.test.tsx`
      — updated to pin that the soft shell is NOT used in strict mode
      (the dialog that opens is the hard-lock variant, distinguished
      by title). All 8 existing soft-warning tests still pass.
- [x] Unit: `__tests__/ui/learner-module-picker.test.tsx` — 21
      baseline tests still green.
- [x] `npx tsc --noEmit` clean on changed files.
- [x] `npx eslint` clean on changed files.
- [ ] Manual verify on `/x/courses/<id>` after `/vm-cp` — flip
      `strictPrerequisites` on a test course, confirm tile lock state
      + modal copy + dismiss flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)