### PR TITLE
feat(#492 Slice 3.3): interleaveReview composition section (spaced-review nudge)

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
@@ -701,6 +701,21 @@
       "dependsOn": ["curriculum"]
     },
     {
+      "id": "interleave_review",
+      "name": "Review Opportunity (Spaced Retrieval)",
+      "priority": 7.8,
+      "dataSource": "interleaveReview",
+      "activateWhen": {
+        "condition": "interleaveReviewExists"
+      },
+      "fallback": {
+        "action": "omit"
+      },
+      "transform": "renderInterleaveReview",
+      "outputKey": "interleaveReview",
+      "dependsOn": ["curriculum"]
+    },
+    {
       "id": "session_planning",
       "name": "Session Planning",
       "priority": 8,

--- a/apps/admin/lib/prompt/composition/CompositionExecutor.ts
+++ b/apps/admin/lib/prompt/composition/CompositionExecutor.ts
@@ -49,6 +49,7 @@ import "./transforms/audience";
 import "./transforms/offboarding";
 import "./transforms/priorCallFeedback";
 import "./transforms/mockDiagnostic";
+import "./transforms/interleaveReview";
 
 /**
  * Execute the full composition pipeline.
@@ -338,6 +339,26 @@ function checkActivationWithReason(
         return { activated: true, reason: "Mock diagnostic available" };
       }
       return { activated: false, reason: "No mock diagnostic for this caller" };
+    }
+
+    case "interleaveReviewExists": {
+      // #492 E3 Slice 3.3 — only activate when the interleaveReview loader
+      // identified a stale mastered module to nudge for review. Activation
+      // gates on hasReview === true AND a non-empty summary so the section
+      // is OMITTED when: no active module, < 2 mastered modules, every
+      // mastered module called recently, or playbookConfig is suppressing
+      // via a high minDays. fallback.action="omit" drops the section
+      // entirely from llmPrompt.
+      const data = (context.loadedData as any).interleaveReview;
+      if (
+        data &&
+        data.hasReview === true &&
+        typeof data.summary === "string" &&
+        data.summary.length > 0
+      ) {
+        return { activated: true, reason: "Stale mastered module available for review" };
+      }
+      return { activated: false, reason: "No stale mastered modules to review" };
     }
 
     default:
@@ -658,6 +679,24 @@ export function getDefaultSections(): CompositionSectionDef[] {
       fallback: { action: "omit" },
       transform: "renderMockDiagnostic",
       outputKey: "mockDiagnostic",
+      dependsOn: ["curriculum"],
+    },
+    {
+      // #492 E3 Slice 3.3 — spaced-review nudge for mastered modules. Slots
+      // between mock_diagnostic (7.6) and session_planning (8) — i.e. AFTER
+      // the post-Mock diagnostic block and BEFORE learner_goals. The block
+      // is a soft cue, not a directive: the tutor decides whether to weave
+      // it into the conversation. Activation gates on
+      // interleaveReview.hasReview === true; fallback=omit drops the
+      // section entirely when there's nothing stale to nudge for.
+      id: "interleave_review",
+      name: "Review Opportunity (Spaced Retrieval)",
+      priority: 7.8,
+      dataSource: "interleaveReview",
+      activateWhen: { condition: "interleaveReviewExists" },
+      fallback: { action: "omit" },
+      transform: "renderInterleaveReview",
+      outputKey: "interleaveReview",
       dependsOn: ["curriculum"],
     },
     {

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -20,6 +20,7 @@ import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
 import { isStudentVisibleDefault } from "@/lib/doc-type-icons";
 import { loadPriorCallFeedback } from "./loaders/priorCallFeedback";
 import { loadMockDiagnostic } from "./loaders/mockDiagnostic";
+import { loadInterleaveReview } from "./loaders/interleaveReview";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 import type { LoadedDataContext, SystemSpecData } from "./types";
 
@@ -118,6 +119,7 @@ export async function loadAllData(
     visualAids,
     priorCallFeedback,
     mockDiagnostic,
+    interleaveReview,
   ] = await Promise.all([
     loaderRegistry.get("caller")!(callerId),
     loaderRegistry.get("memories")!(callerId, { limit: memoriesLimit }),
@@ -146,6 +148,9 @@ export async function loadAllData(
     }),
     loaderRegistry.get("mockDiagnostic")!(callerId, {
       currentCallId: scope?.currentCallId ?? null,
+    }),
+    loaderRegistry.get("interleaveReview")!(callerId, {
+      currentModuleId: scope?.requestedModuleId ?? null,
     }),
   ]);
 
@@ -195,6 +200,13 @@ export async function loadAllData(
       fromCallId: null,
       generatedAt: null,
       ageInDays: null,
+    },
+    interleaveReview: interleaveReview || {
+      hasReview: false,
+      candidateModule: null,
+      daysSinceLastCall: null,
+      mastery: null,
+      summary: null,
     },
   };
 }
@@ -651,6 +663,62 @@ registerLoader("mockDiagnostic", async (callerId, config) => {
       fromCallId: null,
       generatedAt: null,
       ageInDays: null,
+    };
+  }
+});
+
+/**
+ * #492 E3 Slice 3.3 — spaced-review nudge for mastered modules. Surfaces a
+ * short "Review opportunity" block referencing a mastered module the learner
+ * hasn't seen in `interleaveReviewMinDays` (default 3) so spaced retrieval
+ * keeps long-term memory fresh.
+ *
+ * Reads playbookConfig from the caller's first ACTIVE enrollment so the
+ * loader can stay parallel — it does NOT depend on the playbooks loader
+ * (which would require sequencing). The extra read is one row keyed by
+ * (callerId, status) → cheap.
+ */
+registerLoader("interleaveReview", async (callerId, config) => {
+  const currentModuleId = (config?.currentModuleId as string | null | undefined) ?? null;
+  if (!currentModuleId) {
+    return {
+      hasReview: false,
+      candidateModule: null,
+      daysSinceLastCall: null,
+      mastery: null,
+      summary: null,
+    };
+  }
+  try {
+    // Resolve playbookConfig defensively so the minDays threshold can be
+    // overridden per-course. Falls back to the loader's default (3 days) when
+    // no enrollment / no config exists.
+    let playbookConfig: PlaybookConfig | null = null;
+    try {
+      const enrollment = await prisma.callerPlaybook.findFirst({
+        where: { callerId, status: "ACTIVE" },
+        select: { playbook: { select: { config: true } } },
+      });
+      playbookConfig = (enrollment?.playbook?.config ?? null) as PlaybookConfig | null;
+    } catch (innerErr) {
+      console.warn(
+        "[interleaveReview] playbookConfig lookup failed — using defaults:",
+        innerErr,
+      );
+    }
+    return await loadInterleaveReview(prisma, {
+      callerId,
+      currentModuleId,
+      playbookConfig,
+    });
+  } catch (err) {
+    console.warn("[interleaveReview] loader failed — section will be omitted:", err);
+    return {
+      hasReview: false,
+      candidateModule: null,
+      daysSinceLastCall: null,
+      mastery: null,
+      summary: null,
     };
   }
 });

--- a/apps/admin/lib/prompt/composition/loaders/interleaveReview.ts
+++ b/apps/admin/lib/prompt/composition/loaders/interleaveReview.ts
@@ -1,0 +1,259 @@
+/**
+ * interleaveReview loader (#492 E3 Slice 3.3)
+ *
+ * Implements the **spaced-review nudge** half of the interleaving strategy.
+ * Without this, modules the learner has mastered effectively vanish from the
+ * picker recommendation flow and are never refreshed — research on spaced
+ * retrieval shows that even a brief review check-in dramatically improves
+ * long-term retention.
+ *
+ * Why a composer-only nudge (Path A) rather than a picker switch (Path B):
+ *   - Picker semantics stay predictable for the rest of the codebase that
+ *     reads `recommendNextModule()`. We do NOT divert the learner into a
+ *     mastered module wholesale.
+ *   - The tutor sees a soft cue ("Consider a brief review check-in") and can
+ *     decide whether to weave it into the conversation. The block is a hint,
+ *     not a directive.
+ *
+ * Selection algorithm (see {@link loadInterleaveReview}):
+ *   1. Load every `CallerModuleProgress` for this caller with `status="COMPLETED"`
+ *      (excluding `currentModuleId`).
+ *   2. Throttle: require ≥ 2 mastered modules. With 0 or 1 mastered there is
+ *      nothing meaningful to interleave with — emit nothing.
+ *   3. For each candidate, look up the latest `Call` for `(callerId, moduleId)`
+ *      to get `lastCallAt`.
+ *   4. Filter to modules where `(now - lastCallAt).days >= minDays`
+ *      (default 3, configurable via `playbookConfig.interleaveReviewMinDays`).
+ *   5. Pick the candidate with the OLDEST `lastCallAt` (stalest first).
+ *   6. Build a short tutor-facing summary referencing title + day count.
+ *
+ * Safety:
+ *   - All failure paths return the empty shape. The SectionDataLoader wrapper
+ *     additionally try/catches so a slow/broken progress row never breaks
+ *     composition.
+ *   - Excludes `currentModuleId` from candidates — the active module is
+ *     trivially "not stale" and isn't a review opportunity.
+ *   - When `currentModuleId === null` (no active module) → `hasReview: false`.
+ *     The nudge only makes sense alongside an active module.
+ *
+ * Wire-up:
+ *   - dataSource : "interleaveReview"
+ *   - transform  : "renderInterleaveReview"
+ *   - outputKey  : "interleaveReview"
+ *   - activation : "interleaveReviewExists" (hasReview === true)
+ *   - fallback   : { action: "omit" }
+ *
+ * @see transforms/interleaveReview.ts (renderer)
+ * @see CompositionExecutor.ts (section registration, activation branch)
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+export interface InterleaveReviewData {
+  hasReview: boolean;
+  candidateModule: { id: string; slug: string; title: string } | null;
+  daysSinceLastCall: number | null;
+  mastery: number | null;
+  summary: string | null;
+}
+
+export interface LoadInterleaveReviewOptions {
+  callerId: string;
+  /** The CurriculumModule.id of the active module for this call. Required —
+   *  when null the nudge is suppressed (nothing to pair the review with). */
+  currentModuleId: string | null;
+  /** Playbook config — read defensively for `interleaveReviewMinDays`. */
+  playbookConfig: PlaybookConfig | null | undefined;
+  /** Override "now" for deterministic tests. */
+  now?: Date;
+}
+
+const EMPTY: InterleaveReviewData = {
+  hasReview: false,
+  candidateModule: null,
+  daysSinceLastCall: null,
+  mastery: null,
+  summary: null,
+};
+
+/** Default freshness threshold — modules called within this many days are NOT stale. */
+const DEFAULT_MIN_DAYS = 3;
+
+/** Floor count of mastered modules before an interleave nudge makes sense. */
+const MIN_MASTERED_FOR_REVIEW = 2;
+
+/**
+ * Subset of PrismaClient used by this loader — narrows the surface so tests
+ * can pass a minimal mock object.
+ */
+type PrismaForLoader = Pick<
+  PrismaClient,
+  "callerModuleProgress" | "call" | "curriculumModule"
+>;
+
+/**
+ * Read `playbookConfig.interleaveReviewMinDays`, falling back to
+ * {@link DEFAULT_MIN_DAYS}. Defensive: ignores non-finite / negative values
+ * and any non-object playbookConfig.
+ */
+function readMinDays(playbookConfig: PlaybookConfig | null | undefined): number {
+  if (!playbookConfig || typeof playbookConfig !== "object") return DEFAULT_MIN_DAYS;
+  const raw = (playbookConfig as Record<string, unknown>).interleaveReviewMinDays;
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return DEFAULT_MIN_DAYS;
+  return raw;
+}
+
+/**
+ * Load a single stale mastered-module review opportunity for `callerId`.
+ *
+ * Returns {@link EMPTY} (with `hasReview: false`) when:
+ *   - `callerId` is empty
+ *   - `currentModuleId` is null
+ *   - Fewer than {@link MIN_MASTERED_FOR_REVIEW} mastered modules exist
+ *   - No mastered module has been silent for ≥ `minDays`
+ */
+export async function loadInterleaveReview(
+  prisma: PrismaForLoader,
+  opts: LoadInterleaveReviewOptions,
+): Promise<InterleaveReviewData> {
+  const { callerId, currentModuleId, playbookConfig, now } = opts;
+  if (!callerId) return EMPTY;
+  // Throttle: the nudge only makes sense when there's an active module to
+  // pair the review with.
+  if (!currentModuleId) return EMPTY;
+
+  // 1. Load every COMPLETED progress row for this caller, excluding the
+  // current module. The exclusion happens in the DB query rather than
+  // post-filter so the result-set stays small even with many mastered
+  // modules. NOT_STARTED / IN_PROGRESS rows are not interleave candidates.
+  const completedRows = await prisma.callerModuleProgress.findMany({
+    where: {
+      callerId,
+      status: "COMPLETED",
+      moduleId: { not: currentModuleId },
+    },
+    select: {
+      moduleId: true,
+      mastery: true,
+      lastCallId: true,
+    },
+  });
+
+  // Throttle: need ≥ 2 mastered modules for interleave to make sense. With 0
+  // or 1, there's nothing meaningfully different from "just keep going".
+  if (completedRows.length < MIN_MASTERED_FOR_REVIEW) return EMPTY;
+
+  const candidateModuleIds = completedRows.map((r) => r.moduleId);
+
+  // 2. Resolve last-call timestamps in a single query — group by moduleId,
+  // take the latest createdAt per module. Prisma doesn't support windowed
+  // SELECTs cleanly, so we fetch the relevant calls and reduce in JS. The
+  // candidate set is already capped by the COMPLETED filter so the result
+  // is bounded.
+  const calls = await prisma.call.findMany({
+    where: {
+      callerId,
+      curriculumModuleId: { in: candidateModuleIds },
+    },
+    select: { curriculumModuleId: true, createdAt: true },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const latestByModule = new Map<string, Date>();
+  for (const c of calls) {
+    if (!c.curriculumModuleId) continue;
+    if (!latestByModule.has(c.curriculumModuleId)) {
+      latestByModule.set(c.curriculumModuleId, c.createdAt);
+    }
+  }
+
+  // 3. Filter to stale candidates (lastCallAt older than threshold).
+  const minDays = readMinDays(playbookConfig);
+  const nowDate = now ?? new Date();
+  const nowMs = nowDate.getTime();
+
+  interface StaleCandidate {
+    moduleId: string;
+    mastery: number;
+    lastCallAt: Date;
+    daysSinceLastCall: number;
+  }
+  const stale: StaleCandidate[] = [];
+
+  for (const row of completedRows) {
+    const lastCallAt = latestByModule.get(row.moduleId);
+    if (!lastCallAt) continue; // No call history → skip (shouldn't happen for COMPLETED, but defensive).
+    const daysSinceLastCall = Math.floor((nowMs - lastCallAt.getTime()) / 86_400_000);
+    if (daysSinceLastCall < minDays) continue;
+    stale.push({
+      moduleId: row.moduleId,
+      mastery: row.mastery,
+      lastCallAt,
+      daysSinceLastCall,
+    });
+  }
+
+  if (stale.length === 0) return EMPTY;
+
+  // 4. Pick the OLDEST lastCallAt — i.e. the module most starved of review.
+  // Tie-break by moduleId for determinism (alphabetic — keeps tests stable).
+  stale.sort((a, b) => {
+    const diff = a.lastCallAt.getTime() - b.lastCallAt.getTime();
+    if (diff !== 0) return diff;
+    return a.moduleId.localeCompare(b.moduleId);
+  });
+  const chosen = stale[0];
+
+  // 5. Resolve module title (single row).
+  const moduleRow = await prisma.curriculumModule.findUnique({
+    where: { id: chosen.moduleId },
+    select: { id: true, slug: true, title: true },
+  });
+
+  // If the module was deleted between the progress query and now (very
+  // unusual), drop the section rather than emit a broken reference.
+  if (!moduleRow) return EMPTY;
+
+  const summary = buildSummary({
+    title: moduleRow.title,
+    daysSinceLastCall: chosen.daysSinceLastCall,
+  });
+
+  return {
+    hasReview: true,
+    candidateModule: {
+      id: moduleRow.id,
+      slug: moduleRow.slug,
+      title: moduleRow.title,
+    },
+    daysSinceLastCall: chosen.daysSinceLastCall,
+    mastery: chosen.mastery,
+    summary,
+  };
+}
+
+// =============================================================
+// Helpers
+// =============================================================
+
+/**
+ * Tutor-facing summary. Deliberately a NUDGE, not a directive — the tutor
+ * decides whether to weave it in. Format follows the slice 3.3 contract:
+ *
+ *   "It's been {N} days since the learner last practised {title}.
+ *    Consider a brief review check-in."
+ *
+ * Singular/plural day-count for natural reading.
+ */
+export function buildSummary(args: {
+  title: string;
+  daysSinceLastCall: number;
+}): string {
+  const { title, daysSinceLastCall } = args;
+  const days = daysSinceLastCall === 1 ? "1 day" : `${daysSinceLastCall} days`;
+  return (
+    `It's been ${days} since the learner last practised ${title}. ` +
+    `Consider a brief review check-in.`
+  );
+}

--- a/apps/admin/lib/prompt/composition/transforms/interleaveReview.ts
+++ b/apps/admin/lib/prompt/composition/transforms/interleaveReview.ts
@@ -1,0 +1,63 @@
+/**
+ * interleaveReview transform (#492 E3 Slice 3.3)
+ *
+ * Reads {@link InterleaveReviewData} from `loadedData.interleaveReview` and
+ * emits the markdown block the tutor will see. Returns `null` when there is
+ * no review to surface — combined with `fallback.action: "omit"` on the
+ * section definition, the executor's "strip undefined" pass drops the
+ * section entirely from `llmPrompt`.
+ *
+ * Output shape (consumed by the LLM prompt assembler):
+ *   {
+ *     hasReview: true,
+ *     heading: "Review opportunity",
+ *     body: "## Review opportunity\n\nIt's been 5 days since the learner last practised Part 1.\nConsider a brief review check-in.",
+ *     summary: "It's been 5 days since the learner last practised Part 1. Consider a brief review check-in.",
+ *     candidateSlug: "ielts-part-1",
+ *     daysSinceLastCall: 5,
+ *   }
+ *
+ * The tone is intentionally NEUTRAL / OPPORTUNITY — "Consider a brief review
+ * check-in", not "review Part 1 next". The tutor decides whether to weave it
+ * into the conversation; we never override the active module.
+ *
+ * @see loaders/interleaveReview.ts
+ */
+
+import { registerTransform } from "../TransformRegistry";
+import type { AssembledContext, CompositionSectionDef } from "../types";
+import type { InterleaveReviewData } from "../loaders/interleaveReview";
+
+export interface InterleaveReviewSection {
+  hasReview: boolean;
+  /** Markdown heading text — the tutor reads this verbatim. */
+  heading: string;
+  /** Fully assembled markdown block — heading + body. */
+  body: string;
+  /** 1-sentence tutor-facing summary (already includes day count). */
+  summary: string;
+  /** Slug of the mastered module being suggested for review. */
+  candidateSlug: string | null;
+  daysSinceLastCall: number | null;
+}
+
+const HEADING = "Review opportunity";
+
+registerTransform("renderInterleaveReview", (
+  rawData: InterleaveReviewData | null | undefined,
+  _context: AssembledContext,
+  _sectionDef: CompositionSectionDef,
+): InterleaveReviewSection | null => {
+  if (!rawData || !rawData.hasReview || !rawData.summary) {
+    return null;
+  }
+  const body = `## ${HEADING}\n\n${rawData.summary}`;
+  return {
+    hasReview: true,
+    heading: HEADING,
+    body,
+    summary: rawData.summary,
+    candidateSlug: rawData.candidateModule?.slug ?? null,
+    daysSinceLastCall: rawData.daysSinceLastCall,
+  };
+});

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -109,6 +109,13 @@ export interface LoadedDataContext {
    * cases.
    */
   mockDiagnostic?: MockDiagnosticData;
+  /**
+   * #492 E3 Slice 3.3 — spaced-review nudge. `hasReview: false` when there's
+   * no active module, fewer than 2 mastered modules, or no mastered module
+   * has been silent for the freshness threshold. Section is omitted in those
+   * cases.
+   */
+  interleaveReview?: InterleaveReviewData;
 }
 
 /** Prior-call feedback data for the current module (#492 Slice 3.5) */
@@ -139,6 +146,15 @@ export interface MockDiagnosticData {
   fromCallId: string | null;
   generatedAt: string | null;
   ageInDays: number | null;
+}
+
+/** Spaced-review nudge data (#492 E3 Slice 3.3) */
+export interface InterleaveReviewData {
+  hasReview: boolean;
+  candidateModule: { id: string; slug: string; title: string } | null;
+  daysSinceLastCall: number | null;
+  mastery: number | null;
+  summary: string | null;
 }
 
 /** Visual aid data loaded for prompt and content catalog */

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -422,6 +422,15 @@ export interface PlaybookConfig {
    */
   strictPrerequisites?: boolean;
   /**
+   * #492 E3 Slice 3.3 — minimum freshness threshold (in days) for the
+   * interleave-review nudge. A mastered module qualifies for review when its
+   * last call was at least `interleaveReviewMinDays` days ago. Default 3
+   * (matches the typical 2-3 day spacing window). Set higher (~7) for
+   * deeper-cycle courses, lower (~1) for daily-drill courses. Read by
+   * `lib/prompt/composition/loaders/interleaveReview.ts`.
+   */
+  interleaveReviewMinDays?: number;
+  /**
    * #494 E2 Slice 2.3 — when the course counts as "done":
    *   - "terminal-only" (default): the playbook's terminal module mastered
    *   - "all-modules": every module in the catalogue must be MASTERED

--- a/apps/admin/tests/lib/composition/interleave-review.test.ts
+++ b/apps/admin/tests/lib/composition/interleave-review.test.ts
@@ -1,0 +1,614 @@
+/**
+ * #492 E3 Slice 3.3 — interleaveReview loader + transform + composition wiring tests.
+ *
+ * Covers:
+ *   - No mastered modules → hasReview: false
+ *   - One mastered module → hasReview: false (need ≥ 2 for interleave to make sense)
+ *   - Two mastered, both last-called < 3 days ago → hasReview: false
+ *   - Two mastered, one last-called 5 days ago → that one chosen
+ *   - Three mastered, all stale → OLDEST lastCallAt chosen
+ *   - currentModuleId === null → hasReview: false (no anchor to nudge alongside)
+ *   - currentModuleId matches a mastered module → that one excluded from candidates
+ *   - playbookConfig.interleaveReviewMinDays = 7 → modules < 7 days stale don't qualify
+ *   - Summary references title + day count (singular "1 day" / plural "N days")
+ *   - Transform: emits a block on hasReview=true, returns null when false
+ *   - Composition: section appears in llmPrompt when present, omitted otherwise
+ *   - getDefaultSections registers interleave_review between mock_diagnostic
+ *     and session_planning
+ *
+ * The loader is exercised directly with a small mock client (no Prisma
+ * coupling) so the surface is narrow and the assertions are exact.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  loadInterleaveReview,
+  buildSummary,
+} from "@/lib/prompt/composition/loaders/interleaveReview";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+
+// Trigger transform registration
+import "@/lib/prompt/composition/transforms/interleaveReview";
+
+// =====================================================
+// Helpers
+// =====================================================
+
+interface FakeProgressRow {
+  callerId: string;
+  moduleId: string;
+  status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+  mastery: number;
+  lastCallId: string | null;
+}
+
+interface FakeCallRow {
+  callerId: string;
+  curriculumModuleId: string | null;
+  createdAt: Date;
+}
+
+interface FakeModuleRow {
+  id: string;
+  slug: string;
+  title: string;
+}
+
+function makePrismaStub(opts: {
+  progress?: FakeProgressRow[];
+  calls?: FakeCallRow[];
+  modules?: FakeModuleRow[];
+}) {
+  const progress = opts.progress ?? [];
+  const calls = opts.calls ?? [];
+  const modules = opts.modules ?? [];
+
+  const callerModuleProgress = {
+    findMany: vi.fn(async ({ where }: any) => {
+      return progress.filter((row) => {
+        if (where.callerId && row.callerId !== where.callerId) return false;
+        if (where.status && row.status !== where.status) return false;
+        if (where.moduleId?.not && row.moduleId === where.moduleId.not) return false;
+        return true;
+      });
+    }),
+  };
+  const call = {
+    findMany: vi.fn(async ({ where, orderBy }: any) => {
+      let matches = calls.filter((c) => {
+        if (where.callerId && c.callerId !== where.callerId) return false;
+        if (where.curriculumModuleId?.in) {
+          if (
+            !c.curriculumModuleId ||
+            !where.curriculumModuleId.in.includes(c.curriculumModuleId)
+          ) {
+            return false;
+          }
+        }
+        return true;
+      });
+      if (orderBy?.createdAt === "desc") {
+        matches = [...matches].sort(
+          (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+        );
+      }
+      return matches;
+    }),
+  };
+  const curriculumModule = {
+    findUnique: vi.fn(async ({ where }: any) => {
+      return modules.find((m) => m.id === where.id) ?? null;
+    }),
+  };
+  return { callerModuleProgress, call, curriculumModule } as any;
+}
+
+const NOW = new Date("2026-05-19T10:00:00Z");
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+
+const M1: FakeModuleRow = { id: "mod-1", slug: "intro", title: "Introduction" };
+const M2: FakeModuleRow = { id: "mod-2", slug: "fluency", title: "Fluency Practice" };
+const M3: FakeModuleRow = { id: "mod-3", slug: "grammar", title: "Grammar Drill" };
+const MCUR: FakeModuleRow = { id: "mod-current", slug: "current", title: "Current Module" };
+
+// =====================================================
+// Loader tests
+// =====================================================
+
+describe("loadInterleaveReview", () => {
+  it("returns hasReview: false when no modules are mastered", async () => {
+    const prisma = makePrismaStub({ progress: [] });
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(false);
+    expect(result.summary).toBeNull();
+    expect(result.candidateModule).toBeNull();
+  });
+
+  it("returns hasReview: false when only one module is mastered (need >= 2)", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        {
+          callerId: "caller-1",
+          moduleId: "mod-1",
+          status: "COMPLETED",
+          mastery: 0.9,
+          lastCallId: "call-a",
+        },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(30) },
+      ],
+      modules: [M1],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(false);
+  });
+
+  it("returns hasReview: false when all mastered modules called within minDays", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(1) },
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(2) },
+      ],
+      modules: [M1, M2],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(false);
+  });
+
+  it("picks the stale mastered module when one qualifies", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+      ],
+      calls: [
+        // mod-1 last-called 5 days ago (stale), mod-2 last-called 1 day ago (fresh)
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(5) },
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(1) },
+      ],
+      modules: [M1, M2],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(true);
+    expect(result.candidateModule).not.toBeNull();
+    expect(result.candidateModule!.id).toBe("mod-1");
+    expect(result.candidateModule!.title).toBe("Introduction");
+    expect(result.daysSinceLastCall).toBe(5);
+    expect(result.mastery).toBeCloseTo(0.9, 5);
+    expect(result.summary).toContain("Introduction");
+    expect(result.summary).toContain("5 days");
+  });
+
+  it("picks the OLDEST stale module when several qualify", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+        { callerId: "caller-1", moduleId: "mod-3", status: "COMPLETED", mastery: 0.95, lastCallId: "cc" },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(5) },
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(10) }, // OLDEST
+        { callerId: "caller-1", curriculumModuleId: "mod-3", createdAt: daysAgo(7) },
+      ],
+      modules: [M1, M2, M3],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(true);
+    expect(result.candidateModule!.id).toBe("mod-2");
+    expect(result.daysSinceLastCall).toBe(10);
+  });
+
+  it("returns hasReview: false when currentModuleId is null", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(30) },
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(30) },
+      ],
+      modules: [M1, M2],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: null,
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(false);
+    // Short-circuit: must NOT hit the DB when no active module.
+    expect(prisma.callerModuleProgress.findMany).not.toHaveBeenCalled();
+  });
+
+  it("excludes currentModuleId from candidates when it matches a mastered module", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        // mod-1 is mastered AND is the active module — must NOT be picked
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+        { callerId: "caller-1", moduleId: "mod-3", status: "COMPLETED", mastery: 0.92, lastCallId: "cc" },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(100) }, // oldest, but excluded
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(10) },
+        { callerId: "caller-1", curriculumModuleId: "mod-3", createdAt: daysAgo(20) },
+      ],
+      modules: [M1, M2, M3],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-1", // mod-1 is "current" — exclude it
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(true);
+    expect(result.candidateModule!.id).toBe("mod-3"); // oldest among remaining (mod-2 = 10d, mod-3 = 20d)
+  });
+
+  it("respects playbookConfig.interleaveReviewMinDays override (7-day threshold)", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+      ],
+      calls: [
+        // 5 days ago — would qualify under default (3) but NOT under 7-day threshold
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(5) },
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(4) },
+      ],
+      modules: [M1, M2],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: { interleaveReviewMinDays: 7 } as any,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(false);
+  });
+
+  it("uses default minDays=3 when playbookConfig is empty/invalid", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(4) }, // qualifies (>=3)
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(2) }, // doesn't (<3)
+      ],
+      modules: [M1, M2],
+    });
+
+    // Invalid config (negative) should fall back to default
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: { interleaveReviewMinDays: -1 } as any,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(true);
+    expect(result.candidateModule!.id).toBe("mod-1");
+  });
+
+  it("ignores NOT_STARTED and IN_PROGRESS modules", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        // Only COMPLETED rows should count
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "IN_PROGRESS", mastery: 0.5, lastCallId: "cb" },
+        { callerId: "caller-1", moduleId: "mod-3", status: "NOT_STARTED", mastery: 0, lastCallId: null },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(30) },
+      ],
+      modules: [M1, M2, M3],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    // Only 1 COMPLETED → throttle says no
+    expect(result.hasReview).toBe(false);
+  });
+
+  it("returns hasReview: false when candidate module was deleted between queries", async () => {
+    const prisma = makePrismaStub({
+      progress: [
+        { callerId: "caller-1", moduleId: "mod-1", status: "COMPLETED", mastery: 0.9, lastCallId: "ca" },
+        { callerId: "caller-1", moduleId: "mod-2", status: "COMPLETED", mastery: 0.85, lastCallId: "cb" },
+      ],
+      calls: [
+        { callerId: "caller-1", curriculumModuleId: "mod-1", createdAt: daysAgo(30) },
+        { callerId: "caller-1", curriculumModuleId: "mod-2", createdAt: daysAgo(5) },
+      ],
+      // mod-1 is the chosen one but it's NOT in the modules table (deleted)
+      modules: [M2],
+    });
+
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "caller-1",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(false);
+  });
+
+  it("returns hasReview: false when callerId is empty", async () => {
+    const prisma = makePrismaStub({ progress: [] });
+    const result = await loadInterleaveReview(prisma, {
+      callerId: "",
+      currentModuleId: "mod-current",
+      playbookConfig: null,
+      now: NOW,
+    });
+
+    expect(result.hasReview).toBe(false);
+    expect(prisma.callerModuleProgress.findMany).not.toHaveBeenCalled();
+  });
+});
+
+// =====================================================
+// Summary builder helper
+// =====================================================
+
+describe("buildSummary", () => {
+  it("uses singular '1 day' for daysSinceLastCall = 1", () => {
+    expect(buildSummary({ title: "Part 1", daysSinceLastCall: 1 })).toContain("1 day ");
+    expect(buildSummary({ title: "Part 1", daysSinceLastCall: 1 })).not.toContain("1 days");
+  });
+
+  it("uses plural 'N days' for daysSinceLastCall > 1", () => {
+    expect(buildSummary({ title: "Part 2", daysSinceLastCall: 5 })).toContain("5 days");
+  });
+
+  it("references the module title and includes the 'Consider' nudge phrase", () => {
+    const summary = buildSummary({ title: "Grammar Drill", daysSinceLastCall: 7 });
+    expect(summary).toContain("Grammar Drill");
+    expect(summary).toMatch(/Consider a brief review check-in/i);
+  });
+});
+
+// =====================================================
+// Transform tests
+// =====================================================
+
+describe("renderInterleaveReview transform", () => {
+  it("emits a section block when hasReview=true", () => {
+    const transform = getTransform("renderInterleaveReview");
+    expect(transform).toBeDefined();
+
+    const result = transform!(
+      {
+        hasReview: true,
+        candidateModule: { id: "mod-1", slug: "intro", title: "Introduction" },
+        daysSinceLastCall: 5,
+        mastery: 0.9,
+        summary: "It's been 5 days since the learner last practised Introduction. Consider a brief review check-in.",
+      },
+      {} as any,
+      {} as any,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.hasReview).toBe(true);
+    expect(result!.heading).toBe("Review opportunity");
+    expect(result!.body).toContain("## Review opportunity");
+    expect(result!.body).toContain("Introduction");
+    expect(result!.summary).toContain("5 days");
+    expect(result!.candidateSlug).toBe("intro");
+    expect(result!.daysSinceLastCall).toBe(5);
+  });
+
+  it("returns null when hasReview=false", () => {
+    const transform = getTransform("renderInterleaveReview");
+    const result = transform!(
+      {
+        hasReview: false,
+        candidateModule: null,
+        daysSinceLastCall: null,
+        mastery: null,
+        summary: null,
+      },
+      {} as any,
+      {} as any,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when raw data is missing entirely", () => {
+    const transform = getTransform("renderInterleaveReview");
+    expect(transform!(null, {} as any, {} as any)).toBeNull();
+    expect(transform!(undefined, {} as any, {} as any)).toBeNull();
+  });
+});
+
+// =====================================================
+// Default-sections registration
+// =====================================================
+
+describe("interleaveReview in getDefaultSections", () => {
+  it("registers interleave_review between mock_diagnostic and session_planning", async () => {
+    const { getDefaultSections } = await import("@/lib/prompt/composition/CompositionExecutor");
+    const sections = getDefaultSections();
+    const ids = sections.map((s) => s.id);
+
+    const idxMock = ids.indexOf("mock_diagnostic");
+    const idxInterleave = ids.indexOf("interleave_review");
+    const idxSessionPlanning = ids.indexOf("session_planning");
+    const idxGoals = ids.indexOf("learner_goals");
+
+    expect(idxMock).toBeGreaterThanOrEqual(0);
+    expect(idxInterleave).toBeGreaterThanOrEqual(0);
+    expect(idxSessionPlanning).toBeGreaterThanOrEqual(0);
+    expect(idxGoals).toBeGreaterThanOrEqual(0);
+
+    expect(idxInterleave).toBeGreaterThan(idxMock);
+    expect(idxInterleave).toBeLessThan(idxGoals);
+
+    const section = sections[idxInterleave];
+    expect(section.outputKey).toBe("interleaveReview");
+    expect(section.dataSource).toBe("interleaveReview");
+    expect(section.transform).toBe("renderInterleaveReview");
+    expect(section.dependsOn).toContain("curriculum");
+    expect(section.activateWhen.condition).toBe("interleaveReviewExists");
+    expect(section.fallback.action).toBe("omit");
+    expect(section.priority).toBe(7.8);
+  });
+});
+
+// =====================================================
+// Composition integration (end-to-end via executor)
+// =====================================================
+
+describe("interleaveReviewExists activation (executor end-to-end)", () => {
+  it("section is emitted when hasReview=true and omitted otherwise", async () => {
+    vi.resetModules();
+    const baseLoaded = {
+      caller: { id: "caller-1", name: "Test", email: null, phone: null, externalId: null, domain: null },
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      callCount: 0,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [],
+      systemSpecs: [],
+      onboardingSpec: null,
+      onboardingSession: null,
+      subjectSources: null,
+      curriculumAssertions: [],
+      curriculumQuestions: [],
+      curriculumVocabulary: [],
+      courseInstructions: [],
+      openActions: [],
+      visualAids: [],
+    };
+
+    vi.doMock("@/lib/prompt/composition/SectionDataLoader", async () => {
+      const actual: any = await vi.importActual("@/lib/prompt/composition/SectionDataLoader");
+      return {
+        ...actual,
+        loadAllData: vi.fn().mockImplementation(async () => {
+          const hasReview = (globalThis as any).__TEST_INTERLEAVE__ as boolean;
+          return {
+            ...baseLoaded,
+            interleaveReview: hasReview
+              ? {
+                  hasReview: true,
+                  candidateModule: { id: "mod-1", slug: "intro", title: "Introduction" },
+                  daysSinceLastCall: 5,
+                  mastery: 0.9,
+                  summary:
+                    "It's been 5 days since the learner last practised Introduction. Consider a brief review check-in.",
+                }
+              : {
+                  hasReview: false,
+                  candidateModule: null,
+                  daysSinceLastCall: null,
+                  mastery: null,
+                  summary: null,
+                },
+          };
+        }),
+      };
+    });
+
+    const { executeComposition, getDefaultSections } = await import(
+      "@/lib/prompt/composition/CompositionExecutor"
+    );
+    const sections = getDefaultSections();
+    const minimalConfig = {};
+
+    // Case 1: hasReview=true → section appears
+    (globalThis as any).__TEST_INTERLEAVE__ = true;
+    const result1 = await executeComposition(
+      "caller-1",
+      sections,
+      minimalConfig,
+      undefined,
+      "mod-current",
+      "call-1",
+    );
+    expect(result1.metadata.sectionsActivated).toContain("interleave_review");
+    expect(result1.llmPrompt.interleaveReview).toBeDefined();
+    expect(result1.llmPrompt.interleaveReview.summary).toContain("Introduction");
+    expect(result1.llmPrompt.interleaveReview.heading).toBe("Review opportunity");
+    expect(result1.llmPrompt.interleaveReview.body).toContain("## Review opportunity");
+
+    // Case 2: hasReview=false → section omitted
+    (globalThis as any).__TEST_INTERLEAVE__ = false;
+    const result2 = await executeComposition(
+      "caller-1",
+      sections,
+      minimalConfig,
+      undefined,
+      "mod-current",
+      "call-1",
+    );
+    expect(result2.metadata.sectionsSkipped).toContain("interleave_review");
+    expect(result2.llmPrompt.interleaveReview).toBeUndefined();
+
+    delete (globalThis as any).__TEST_INTERLEAVE__;
+    vi.doUnmock("@/lib/prompt/composition/SectionDataLoader");
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

- **New loader** `lib/prompt/composition/loaders/interleaveReview.ts` selects the most stale mastered module (lastCallAt > 3 days ago, configurable via `playbookConfig.interleaveReviewMinDays`). Requires ≥ 2 mastered modules + active `currentModuleId`.
- **New transform** emits `## Review opportunity` block only when a candidate exists. Tutor-facing language is a NUDGE, not a directive.
- **Section registered** between `mockDiagnostic` and `session_planning` (priority 7.8).
- **Works for BOTH authored and AI-generated courses** — uses `CallerModuleProgress` + `Call.curriculumModuleId` which both routes populate.
- **Try/catch** the loader — failure must not break composition.

## Test plan

- [x] 20 unit + integration test cases all green
- [x] Existing composition tests still pass
- [x] tsc clean on changed files
- [x] COMP-001 seed kept in sync

## Notes

Original agent stalled on qmd embed step before push — recovered by the human, tests verified locally first.

Co-authored with Claude Opus 4.7 (1M context)