### PR TITLE
fix(#492 Slice 3.1): accept requestedModuleId arg in computeSharedState

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -340,6 +340,7 @@ export async function computeSharedState(
   resolvedSpecs: ResolvedSpecs,
   specConfig: Record<string, any>,
   triggerType?: string,
+  requestedModuleIdArg?: string | null,
 ): Promise<SharedComputedState> {
   const channel: 'text' | 'voice' = triggerType === 'sim' ? 'text' : 'voice';
   // DB-first: try CurriculumModule records before JSON paths
@@ -511,8 +512,33 @@ export async function computeSharedState(
   // narrate the wrong module. Symmetric to the pipeline-side override at
   // pipeline/route.ts:108 (mastery scoring for end-of-call).
   let lockedModule: ModuleData | null = null;
+
+  // #492 Slice 3.1 — DB-id route. `requestedModuleIdArg` is a
+  // `CurriculumModule.id` threaded from `Call.curriculumModuleId` via
+  // executeComposition. It is the most explicit signal (the pipeline
+  // resolved the slug → id at call-create) so it wins over the
+  // authored-id specConfig path. Match against the loaded `modules[]`
+  // (which are CurriculumModule rows for DB-curricula and
+  // notableInfo.modules for the subject-fallback path) by `id` or `slug`.
+  if (requestedModuleIdArg) {
+    const matchById = modules.find(
+      (m) => m.id === requestedModuleIdArg || m.slug === requestedModuleIdArg,
+    );
+    if (matchById) {
+      lockedModule = matchById;
+      nextModule = matchById;
+      console.log(
+        `[modules] #492 Slice 3.1: locked to CurriculumModule "${matchById.slug || matchById.id}" (id="${requestedModuleIdArg}") — scheduler BYPASSED.`,
+      );
+    } else {
+      console.warn(
+        `[modules] #492 Slice 3.1: requestedModuleIdArg "${requestedModuleIdArg}" does not resolve to any CurriculumModule in the active curriculum — falling through to specConfig / scheduler.`,
+      );
+    }
+  }
+
   const requestedModuleId = (specConfig.requestedModuleId as string | undefined) || undefined;
-  if (requestedModuleId) {
+  if (!lockedModule && requestedModuleId) {
     // Match against Playbook.config.modules (the authored shape). The picker
     // emits the AuthoredModule.id as ?requestedModuleId=… so we match on id.
     // pbConfig is declared further down (line ~672) for the isFinalSession


### PR DESCRIPTION
## Summary

PR #526 threaded `requestedModuleId` through `executeComposition` → `computeSharedState`, but the receiving signature only declared 4 params. The 5th arg was silently dropped, so every composed prompt locked to the curriculum's first incomplete module regardless of the picker / `--module=<slug>` pick.

The 7 tests added in PR #526 (`tests/lib/composition/modules-requested-module.test.ts`) were written against the intended behaviour and failed against the live impl — but only 5/7 happened to pass by accident (no-op behaviour matched the regression / falsy paths). The 2 hard assertions on `lockedModule?.id === "MOD-2"` failed silently in CI noise.

## Symptom (verified on hf-dev)

6-call SIM sequence on the IELTS Speaking course (caller Quinn Nakamura). Calls 3–6 picked `part1`, `part2`, `part3`, `mock` via `--module=<slug>`. All 6 composed prompts came back with `currentModuleSlug: \"part1\"`.

```
17:52:46  fbc451b3  req=-      curr=-         prompt=6adca170  currentModuleSlug=part1
17:55:19  dc7c6404  req=-      curr=-         prompt=c46c83f5  currentModuleSlug=part1
17:56:44  aa59f96d  req=part1  curr=beb3cc06  prompt=6ff8d8e1  currentModuleSlug=part1
17:58:49  4dbadd98  req=part2  curr=de7507c6  prompt=950b6bc7  currentModuleSlug=part1  ❌
18:00:41  8a958f3a  req=part3  curr=e68f6c0e  prompt=5388d2e8  currentModuleSlug=part1  ❌
18:02:14  bb0950de  req=mock   curr=c822b297  prompt=d8e3d99b  currentModuleSlug=part1  ❌
```

`Call.curriculumModuleId` was resolved correctly on every call. `CallScore` rows were written. The drop-off was the composer.

## Fix

`computeSharedState` now declares `requestedModuleIdArg?: string | null` as the 5th param. New DB-id branch runs before the existing `specConfig.requestedModuleId` (authored-id) branch — when set, matches against the loaded `modules[]` by `id` or `slug` (covers both the DB-curricula `CurriculumModule` shape and the subject-fallback `notableInfo.modules` shape). On match: locks + bypasses scheduler, mirroring the authored-id path. On miss: warns and falls through, preserving prior behaviour.

## Test plan

- [x] 7/7 in `tests/lib/composition/modules-requested-module.test.ts` pass (were 5/7 before)
- [x] 38/38 in `tests/lib/composition/modules.test.ts` still pass (no regression on the authored-id path)
- [x] 348/348 across the composition suite still pass (1 unrelated pre-existing test-file load failure on `course-complete.test.ts`)
- [ ] Re-run hf-dev SIM and confirm `currentModuleSlug` shifts with `--module=<slug>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)