### PR TITLE
feat(#493 Slice 5.5): EducatorProgressView (parallel read-only mirror of learner progress)

### DIFF
--- a/apps/admin/app/x/educator/educator.css
+++ b/apps/admin/app/x/educator/educator.css
@@ -452,3 +452,378 @@
   border-radius: 12px;
   font-size: 14px;
 }
+
+/* ────────────────────────────────────────────────────────────────────
+   #493 Slice 5.5 — EducatorProgressView
+   Read-only mirror of SimProgressPanel for the educator portal.
+   Admin-shell tokens only. No celebratory styling — analytical tone.
+   ──────────────────────────────────────────────────────────────────── */
+
+.epv-section-wrapper {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.epv-heading {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+.epv-root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.epv-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 48px;
+}
+
+.epv-section {
+  margin-bottom: 0;
+}
+
+.epv-section-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.epv-section-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  line-height: 1.45;
+}
+
+/* Subtle info badges — sit inline next to section titles + module rows */
+.epv-info-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+/* Course-complete stat row (NOT a hero) */
+.epv-course-complete {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+  font-size: 13px;
+}
+
+.epv-course-complete-icon {
+  color: var(--status-success-text);
+  flex-shrink: 0;
+}
+
+.epv-course-complete-label {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.epv-course-complete-value {
+  color: var(--text-primary);
+}
+
+/* Progress bar */
+.epv-progress-bar {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--surface-secondary);
+  overflow: hidden;
+}
+
+.epv-progress-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  background: var(--accent-primary);
+  transition: width 0.4s ease;
+}
+
+/* Focus areas (post-Mock diagnostic) */
+.epv-focus-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.epv-focus-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--surface-secondary);
+  font-size: 13px;
+}
+
+.epv-focus-icon {
+  flex-shrink: 0;
+}
+
+.epv-focus-strength .epv-focus-icon {
+  color: var(--status-success-text);
+}
+
+.epv-focus-next .epv-focus-icon {
+  color: var(--accent-primary);
+}
+
+.epv-focus-weak .epv-focus-icon {
+  color: var(--status-warning-text);
+}
+
+.epv-focus-label {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.epv-focus-value {
+  color: var(--text-primary);
+}
+
+/* Modules — read-only rows */
+.epv-modules {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.epv-module-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--surface-secondary);
+  flex-wrap: wrap;
+}
+
+.epv-module-icon {
+  flex-shrink: 0;
+}
+
+.epv-module-mastered .epv-module-icon {
+  color: var(--status-success-text);
+}
+
+.epv-module-in-progress .epv-module-icon {
+  color: var(--accent-primary);
+}
+
+.epv-module-not-started .epv-module-icon {
+  color: var(--text-muted);
+}
+
+.epv-module-title {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 120px;
+}
+
+.epv-module-mastered .epv-module-title {
+  font-weight: 600;
+}
+
+.epv-module-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.epv-module-mastered .epv-module-status-badge {
+  background: color-mix(in srgb, var(--status-success-text) 12%, transparent);
+  color: var(--status-success-text);
+}
+
+.epv-module-in-progress .epv-module-status-badge {
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  color: var(--accent-primary);
+}
+
+.epv-module-not-started .epv-module-status-badge {
+  background: var(--surface-tertiary, var(--surface-secondary));
+  color: var(--text-muted);
+}
+
+.epv-module-mastery-badge {
+  font-variant-numeric: tabular-nums;
+}
+
+.epv-module-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Goals */
+.epv-goals {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.epv-goal-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.epv-goal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.epv-goal-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.epv-goal-name {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.epv-goal-pct {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.epv-goal-bar {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--surface-secondary);
+  overflow: hidden;
+}
+
+.epv-goal-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent-primary);
+  transition: width 0.4s ease;
+}
+
+/* Stats grid */
+.epv-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.epv-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 10px;
+  background: var(--surface-secondary);
+}
+
+.epv-stat-icon {
+  color: var(--text-secondary);
+}
+
+.epv-stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.epv-stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+/* Test scores */
+.epv-test-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.epv-test-score {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.epv-test-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.epv-test-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.epv-test-value.epv-test-post {
+  color: var(--status-success-text);
+}
+
+.epv-test-arrow {
+  font-size: 18px;
+  color: var(--text-muted);
+}
+
+/* Recent topics */
+.epv-topic-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.epv-topic-item {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--surface-secondary);
+  color: var(--text-secondary);
+  font-size: 12px;
+}

--- a/apps/admin/app/x/educator/students/[id]/page.tsx
+++ b/apps/admin/app/x/educator/students/[id]/page.tsx
@@ -5,6 +5,8 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { SendArtifactModal } from "@/components/educator/SendArtifactModal";
 import { StudentEnrollmentsSection } from "@/components/educator/StudentEnrollmentsSection";
+import { EducatorProgressView } from "@/components/educator/EducatorProgressView";
+import "../../educator.css";
 
 interface StudentDetail {
   id: string;
@@ -347,6 +349,15 @@ export default function StudentDetailPage() {
           )}
         </div>
       </div>
+
+      {/* #493 Slice 5.5 — Progress section. Educator-side parallel mirror of
+          the learner's SimProgressPanel. READ-ONLY: same hook + API as the
+          learner panel, but framed analytically (no celebration, no module
+          click handlers). */}
+      <section className="epv-section-wrapper">
+        <h2 className="epv-heading">Progress</h2>
+        <EducatorProgressView callerId={id} />
+      </section>
 
       {/* Course Enrolments */}
       <StudentEnrollmentsSection studentId={id} domainId={student.domain?.id} />

--- a/apps/admin/components/educator/EducatorProgressView.tsx
+++ b/apps/admin/components/educator/EducatorProgressView.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+/**
+ * #493 Slice 5.5 — Educator-side parallel mirror of the learner's
+ * SimProgressPanel.
+ *
+ * - Reads from the SAME `/api/student/progress?callerId=X` endpoint via the
+ *   SAME `useStudentProgress` hook the learner panel uses. Single source of
+ *   truth — no parallel data paths.
+ * - Read-only. No click handlers on module rows, no recommended-next chip,
+ *   no celebratory hero.
+ * - Educator tone: analytical, calm, factual. Course completion shows as a
+ *   stat line, not a hero card. Mastery thresholds + EMA values are surfaced
+ *   as informational badges next to module bars.
+ * - Uses admin shell `hf-*` classes only (NOT learner-chat `wa-*` classes).
+ * - All non-dynamic visual styling lives in `app/x/educator/educator.css`
+ *   under the `.epv-*` namespace. Inline `style={{}}` only for runtime widths.
+ */
+
+import type { JSX } from 'react';
+import {
+  Award,
+  BookOpen,
+  CheckCircle2,
+  Circle,
+  Lightbulb,
+  PlayCircle,
+  Phone,
+  Target,
+  TrendingUp,
+} from 'lucide-react';
+import { useStudentProgress } from '@/hooks/useStudentProgress';
+
+interface EducatorProgressViewProps {
+  callerId: string;
+}
+
+/** #493 Slice 5.5 — humanise the completion mode into educator-facing copy. */
+function describeCompletionMode(mode: 'all-modules' | 'terminal-only' | 'any'): string {
+  if (mode === 'terminal-only') return 'Learner finished the terminal module of this course.';
+  if (mode === 'all-modules') return 'Learner mastered every module.';
+  return 'Learner completed at least one module of an open-ended course.';
+}
+
+/** #493 Slice 5.5 — format an ISO date with `Intl.DateTimeFormat`, medium style. */
+function formatCompletedAt(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d);
+}
+
+/** #493 Slice 5.5 — format an EMA mastery value against its threshold. */
+function formatMasteryBadge(mastery: number, threshold: number): string {
+  return `EMA mastery ${mastery.toFixed(2)} / ${threshold.toFixed(2)} threshold`;
+}
+
+export function EducatorProgressView({ callerId }: EducatorProgressViewProps): JSX.Element {
+  const { data, loading, error } = useStudentProgress(callerId);
+
+  if (loading) {
+    return (
+      <div className="epv-loading" data-testid="epv-loading">
+        <div className="hf-spinner" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="hf-banner hf-banner-error" data-testid="epv-error">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="hf-empty" data-testid="epv-empty">
+        No progress data available for this learner.
+      </div>
+    );
+  }
+
+  const noActivity =
+    data.goals.length === 0 &&
+    data.totalCalls === 0 &&
+    data.topicCount === 0 &&
+    (!data.modules || data.modules.length === 0);
+
+  if (noActivity) {
+    return (
+      <div className="hf-empty" data-testid="epv-empty">
+        No progress data yet. Learner has not started any practice sessions.
+      </div>
+    );
+  }
+
+  const masteredCount = data.modules?.filter((m) => m.status === 'MASTERED').length ?? 0;
+  const totalModules = data.modules?.length ?? 0;
+
+  return (
+    <div className="epv-root" data-testid="epv-root">
+      {/* #493 Slice 5.5 — Course completion as a stat row, NOT a celebratory
+          hero. Educator gets a one-line factual readout: status + date. */}
+      {data.courseComplete?.complete && (
+        <div className="epv-course-complete" data-testid="epv-course-complete">
+          <Award size={16} className="epv-course-complete-icon" aria-hidden />
+          <span className="epv-course-complete-label">Status:</span>
+          <span className="epv-course-complete-value">
+            Course complete
+            {data.courseComplete.completedAt
+              ? ` — completed ${formatCompletedAt(data.courseComplete.completedAt)}`
+              : ''}
+          </span>
+          <span className="epv-info-badge" title={describeCompletionMode(data.courseComplete.mode)}>
+            {data.courseComplete.mode}
+          </span>
+        </div>
+      )}
+
+      {/* #493 Slice 5.5 — Progress / Journey section. Same data shape as the
+          learner panel, but framed as "progress against journey", not "your
+          journey". */}
+      {totalModules > 0 && (
+        <div className="hf-card-compact epv-section">
+          <div className="hf-section-title epv-section-title">
+            Progress
+            <span className="epv-info-badge">
+              {masteredCount} / {totalModules} modules mastered
+            </span>
+          </div>
+          <div className="epv-progress-bar">
+            <div
+              className="epv-progress-bar-fill"
+              style={{
+                width: `${totalModules > 0 ? (masteredCount / totalModules) * 100 : 0}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* #493 Slice 5.5 — Focus areas from the most-recent Mock diagnostic.
+          Same source as the learner panel (`diagnosticFromMock`), but framed
+          for the educator as "what to coach next". */}
+      {data.diagnosticFromMock && (
+        <div className="hf-card-compact epv-section" data-testid="epv-diagnostic">
+          <div className="hf-section-title epv-section-title">
+            Last Mock diagnostic
+          </div>
+          {data.diagnosticFromMock.summary && (
+            <div className="epv-section-desc">{data.diagnosticFromMock.summary}</div>
+          )}
+          <div className="epv-focus-list">
+            {data.diagnosticFromMock.strengthModule && (
+              <div className="epv-focus-row epv-focus-strength">
+                <CheckCircle2 size={14} className="epv-focus-icon" aria-hidden />
+                <span className="epv-focus-label">Strength:</span>
+                <span className="epv-focus-value">{data.diagnosticFromMock.strengthModule.title}</span>
+              </div>
+            )}
+            {data.diagnosticFromMock.focusModules.map((m) => (
+              <div key={m.id} className="epv-focus-row epv-focus-next">
+                <PlayCircle size={14} className="epv-focus-icon" aria-hidden />
+                <span className="epv-focus-label">Focus next:</span>
+                <span className="epv-focus-value">{m.title}</span>
+              </div>
+            ))}
+            {data.diagnosticFromMock.weakSkill && (
+              <div className="epv-focus-row epv-focus-weak">
+                <Lightbulb size={14} className="epv-focus-icon" aria-hidden />
+                <span className="epv-focus-label">Weakest skill:</span>
+                <span className="epv-focus-value">{data.diagnosticFromMock.weakSkill}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* #493 Slice 5.5 — Modules section. READ-ONLY status rows — no click
+          handlers, no recommended-next badge. Each row carries an EMA-mastery
+          info badge so the educator can see exactly how far below threshold
+          the learner is. */}
+      {totalModules > 0 && (
+        <div className="hf-card-compact epv-section" data-testid="epv-modules">
+          <div className="hf-section-title epv-section-title">
+            Modules
+            <span className="epv-info-badge">{totalModules} total</span>
+          </div>
+          <div className="epv-modules">
+            {data.modules.map((m) => {
+              const StatusIcon =
+                m.status === 'MASTERED'
+                  ? CheckCircle2
+                  : m.status === 'IN_PROGRESS'
+                    ? PlayCircle
+                    : Circle;
+              const statusClass =
+                m.status === 'MASTERED'
+                  ? 'epv-module-mastered'
+                  : m.status === 'IN_PROGRESS'
+                    ? 'epv-module-in-progress'
+                    : 'epv-module-not-started';
+              const statusLabel =
+                m.status === 'MASTERED'
+                  ? 'Mastered'
+                  : m.status === 'IN_PROGRESS'
+                    ? 'In progress'
+                    : 'Not started';
+              return (
+                <div key={m.id} className={`epv-module-row ${statusClass}`}>
+                  <StatusIcon size={14} className="epv-module-icon" aria-hidden />
+                  <span className="epv-module-title">{m.title}</span>
+                  <span className="epv-module-status-badge">{statusLabel}</span>
+                  <span className="epv-info-badge epv-module-mastery-badge">
+                    {formatMasteryBadge(m.mastery, m.masteryThreshold)}
+                  </span>
+                  <span className="epv-module-meta">
+                    {m.callCount > 0
+                      ? `${m.callCount} call${m.callCount === 1 ? '' : 's'}`
+                      : '—'}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* #493 Slice 5.5 — Goals section. Identical data shape to learner side,
+          rendered with neutral admin-shell styling. */}
+      {data.goals.length > 0 && (
+        <div className="hf-card-compact epv-section" data-testid="epv-goals">
+          <div className="hf-section-title epv-section-title">
+            Goals
+            <span className="epv-info-badge">{data.goals.length} active</span>
+          </div>
+          <div className="epv-goals">
+            {data.goals.map((goal) => (
+              <div key={goal.id} className="epv-goal-row">
+                <div className="epv-goal-header">
+                  <Target size={14} className="epv-goal-icon" aria-hidden />
+                  <span className="epv-goal-name">{goal.name}</span>
+                  <span className="epv-goal-pct">{Math.round(goal.progress * 100)}%</span>
+                </div>
+                <div className="epv-goal-bar">
+                  <div
+                    className="epv-goal-bar-fill"
+                    style={{ width: `${goal.progress * 100}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* #493 Slice 5.5 — Stats grid. Same four metrics as the learner panel. */}
+      <div className="hf-card-compact epv-section" data-testid="epv-stats">
+        <div className="hf-section-title epv-section-title">Stats</div>
+        <div className="epv-stat-grid">
+          <div className="epv-stat">
+            <Phone size={16} className="epv-stat-icon" aria-hidden />
+            <span className="epv-stat-value">{data.totalCalls}</span>
+            <span className="epv-stat-label">Calls</span>
+          </div>
+          <div className="epv-stat">
+            <BookOpen size={16} className="epv-stat-icon" aria-hidden />
+            <span className="epv-stat-value">{data.topicCount}</span>
+            <span className="epv-stat-label">Topics</span>
+          </div>
+          <div className="epv-stat">
+            <Lightbulb size={16} className="epv-stat-icon" aria-hidden />
+            <span className="epv-stat-value">{data.keyFactCount}</span>
+            <span className="epv-stat-label">Key facts</span>
+          </div>
+          {data.testScores.uplift && (
+            <div className="epv-stat">
+              <TrendingUp size={16} className="epv-stat-icon" aria-hidden />
+              <span className="epv-stat-value">
+                +{Math.round(data.testScores.uplift.absolute)}%
+              </span>
+              <span className="epv-stat-label">Uplift</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* #493 Slice 5.5 — Test scores section. */}
+      {(data.testScores.preTest != null || data.testScores.postTest != null) && (
+        <div className="hf-card-compact epv-section" data-testid="epv-test-scores">
+          <div className="hf-section-title epv-section-title">Test scores</div>
+          <div className="epv-test-row">
+            {data.testScores.preTest != null && (
+              <div className="epv-test-score">
+                <span className="epv-test-label">Pre-test</span>
+                <span className="epv-test-value">
+                  {Math.round(data.testScores.preTest)}%
+                </span>
+              </div>
+            )}
+            {data.testScores.preTest != null && data.testScores.postTest != null && (
+              <span className="epv-test-arrow" aria-hidden>
+                →
+              </span>
+            )}
+            {data.testScores.postTest != null && (
+              <div className="epv-test-score">
+                <span className="epv-test-label">Post-test</span>
+                <span className="epv-test-value epv-test-post">
+                  {Math.round(data.testScores.postTest)}%
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* #493 Slice 5.5 — Recent topics. */}
+      {data.topTopics.length > 0 && (
+        <div className="hf-card-compact epv-section" data-testid="epv-recent-topics">
+          <div className="hf-section-title epv-section-title">Recent topics</div>
+          <div className="epv-topic-list">
+            {data.topTopics.slice(0, 5).map((t) => (
+              <div key={t.topic} className="epv-topic-item">
+                {t.topic}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/tests/components/EducatorProgressView.test.tsx
+++ b/apps/admin/tests/components/EducatorProgressView.test.tsx
@@ -1,0 +1,296 @@
+/**
+ * #493 Slice 5.5 — Tests for EducatorProgressView.
+ *
+ * The component is the educator-side READ-ONLY mirror of SimProgressPanel.
+ * It reuses the same `useStudentProgress` hook, so we mock the hook and
+ * assert presentation only — no API contact.
+ *
+ * Coverage:
+ *   - Loading state shows hf-spinner
+ *   - Error state shows error message in hf-banner-error
+ *   - Null / empty data shows hf-empty
+ *   - Course-complete renders as a stat line, NOT a celebratory hero
+ *   - Modules render with status badges (Mastered / In progress / Not started)
+ *   - Diagnostic-from-mock renders strength, focus-next, weak-skill
+ *   - Goals, Stats, Test scores, Recent topics all render when present
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { StudentProgress } from "@/hooks/useStudentProgress";
+
+// ── Hook mock ──────────────────────────────────────────────────────
+// Configurable per-test by mutating the `mockResult` object before render.
+
+interface HookResult {
+  data: StudentProgress | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+const mockResult: HookResult = {
+  data: null,
+  loading: false,
+  error: null,
+  refresh: () => {},
+};
+
+vi.mock("@/hooks/useStudentProgress", () => ({
+  useStudentProgress: () => mockResult,
+}));
+
+// Import AFTER the mock is registered so the component picks up the mock.
+import { EducatorProgressView } from "@/components/educator/EducatorProgressView";
+
+// ── Fixtures ───────────────────────────────────────────────────────
+
+const FULL_DATA: StudentProgress = {
+  goals: [
+    { id: "g1", name: "Reach Band 7 overall", type: "BAND", progress: 0.4, description: null },
+  ],
+  totalCalls: 8,
+  topicCount: 3,
+  keyFactCount: 12,
+  topTopics: [
+    { topic: "Education", lastMentioned: "2026-05-10" },
+    { topic: "Family", lastMentioned: "2026-05-09" },
+  ],
+  testScores: {
+    preTest: 55,
+    postTest: 72,
+    uplift: { absolute: 17, normalised: null },
+  },
+  classroom: "Cohort A",
+  domain: "ielts",
+  teacherName: "Alex",
+  institutionName: "Test Academy",
+  modules: [
+    {
+      id: "m1",
+      slug: "part-1",
+      title: "Part 1: Familiar Topics",
+      status: "MASTERED",
+      callCount: 4,
+      mastery: 0.82,
+      masteryThreshold: 0.7,
+      completedAt: "2026-05-12T10:00:00Z",
+    },
+    {
+      id: "m2",
+      slug: "part-2",
+      title: "Part 2: Long Turn",
+      status: "IN_PROGRESS",
+      callCount: 2,
+      mastery: 0.55,
+      masteryThreshold: 0.7,
+      completedAt: null,
+    },
+    {
+      id: "m3",
+      slug: "part-3",
+      title: "Part 3: Discussion",
+      status: "NOT_STARTED",
+      callCount: 0,
+      mastery: 0,
+      masteryThreshold: 0.7,
+      completedAt: null,
+    },
+  ],
+  diagnosticFromMock: {
+    focusModules: [
+      { id: "m3", slug: "part-3", title: "Part 3: Discussion" },
+    ],
+    strengthModule: { id: "m1", slug: "part-1", title: "Part 1: Familiar Topics" },
+    weakSkill: "pronunciation",
+    summary: "Strongest in Part 1; focus next on Part 3.",
+    fromCallId: "call-123",
+    generatedAt: "2026-05-12T10:00:00Z",
+  },
+  courseComplete: null,
+};
+
+function resetHook(): void {
+  mockResult.data = null;
+  mockResult.loading = false;
+  mockResult.error = null;
+  mockResult.refresh = () => {};
+}
+
+beforeEach(() => {
+  resetHook();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("EducatorProgressView — loading / error / empty", () => {
+  it("renders the hf-spinner while loading", () => {
+    mockResult.loading = true;
+    const { container } = render(<EducatorProgressView callerId="c1" />);
+    expect(container.querySelector(".hf-spinner")).not.toBeNull();
+  });
+
+  it("renders an error banner when the hook reports an error", () => {
+    mockResult.error = "Failed to load progress (500)";
+    render(<EducatorProgressView callerId="c1" />);
+    expect(screen.getByTestId("epv-error")).toHaveTextContent(
+      /Failed to load progress \(500\)/i,
+    );
+  });
+
+  it("renders hf-empty when data is null", () => {
+    mockResult.data = null;
+    render(<EducatorProgressView callerId="c1" />);
+    expect(screen.getByTestId("epv-empty")).toBeInTheDocument();
+  });
+
+  it("renders hf-empty when learner has no activity at all", () => {
+    mockResult.data = {
+      ...FULL_DATA,
+      goals: [],
+      totalCalls: 0,
+      topicCount: 0,
+      modules: [],
+      diagnosticFromMock: null,
+      courseComplete: null,
+      testScores: { preTest: null, postTest: null, uplift: null },
+      topTopics: [],
+    };
+    render(<EducatorProgressView callerId="c1" />);
+    expect(screen.getByTestId("epv-empty")).toHaveTextContent(
+      /No progress data yet/i,
+    );
+  });
+});
+
+describe("EducatorProgressView — course completion", () => {
+  it("renders course-complete as a stat line, NOT a celebratory hero", () => {
+    mockResult.data = {
+      ...FULL_DATA,
+      courseComplete: {
+        complete: true,
+        mode: "terminal-only",
+        completedAt: "2026-03-15T00:00:00Z",
+      },
+    };
+    render(<EducatorProgressView callerId="c1" />);
+    const row = screen.getByTestId("epv-course-complete");
+    expect(row).toHaveTextContent(/Course complete/i);
+    expect(row).toHaveTextContent(/completed/i);
+    // Assert this is NOT the learner-side hero: no "Course complete!" with
+    // exclamation, no celebratory wa-progress-course-complete class.
+    expect(row.className).toMatch(/epv-course-complete/);
+    expect(row.className).not.toMatch(/wa-progress-course-complete/);
+    expect(row.textContent ?? "").not.toMatch(/Course complete!/);
+  });
+
+  it("does not render the course-complete row when complete=false", () => {
+    mockResult.data = {
+      ...FULL_DATA,
+      courseComplete: { complete: false, mode: "terminal-only", completedAt: null },
+    };
+    render(<EducatorProgressView callerId="c1" />);
+    expect(screen.queryByTestId("epv-course-complete")).toBeNull();
+  });
+});
+
+describe("EducatorProgressView — modules section", () => {
+  it("renders one row per module with the correct status badge", () => {
+    mockResult.data = FULL_DATA;
+    render(<EducatorProgressView callerId="c1" />);
+    const section = screen.getByTestId("epv-modules");
+    expect(section).toHaveTextContent("Part 1: Familiar Topics");
+    expect(section).toHaveTextContent("Part 2: Long Turn");
+    expect(section).toHaveTextContent("Part 3: Discussion");
+    expect(section).toHaveTextContent(/Mastered/);
+    expect(section).toHaveTextContent(/In progress/);
+    expect(section).toHaveTextContent(/Not started/);
+  });
+
+  it("surfaces the EMA-mastery info badge per module row", () => {
+    mockResult.data = FULL_DATA;
+    render(<EducatorProgressView callerId="c1" />);
+    const section = screen.getByTestId("epv-modules");
+    // EMA values come from fixture: 0.82 / 0.70 threshold, 0.55 / 0.70, 0.00 / 0.70
+    expect(section).toHaveTextContent(/EMA mastery 0\.82 \/ 0\.70 threshold/);
+    expect(section).toHaveTextContent(/EMA mastery 0\.55 \/ 0\.70 threshold/);
+  });
+});
+
+describe("EducatorProgressView — diagnostic from mock", () => {
+  it("renders the diagnostic section with strength + focus-next + weak-skill", () => {
+    mockResult.data = FULL_DATA;
+    render(<EducatorProgressView callerId="c1" />);
+    const section = screen.getByTestId("epv-diagnostic");
+    expect(section).toHaveTextContent(/Last Mock diagnostic/i);
+    expect(section).toHaveTextContent(/Strongest in Part 1/i);
+    expect(section).toHaveTextContent(/Strength:/);
+    expect(section).toHaveTextContent("Part 1: Familiar Topics");
+    expect(section).toHaveTextContent(/Focus next:/);
+    expect(section).toHaveTextContent("Part 3: Discussion");
+    expect(section).toHaveTextContent(/Weakest skill:/);
+    expect(section).toHaveTextContent("pronunciation");
+  });
+
+  it("omits the diagnostic section entirely when null", () => {
+    mockResult.data = { ...FULL_DATA, diagnosticFromMock: null };
+    render(<EducatorProgressView callerId="c1" />);
+    expect(screen.queryByTestId("epv-diagnostic")).toBeNull();
+  });
+});
+
+describe("EducatorProgressView — goals / stats / test scores / topics", () => {
+  it("renders goals when present", () => {
+    mockResult.data = FULL_DATA;
+    render(<EducatorProgressView callerId="c1" />);
+    const goals = screen.getByTestId("epv-goals");
+    expect(goals).toHaveTextContent("Reach Band 7 overall");
+    expect(goals).toHaveTextContent("40%");
+  });
+
+  it("renders the stats grid with calls / topics / key facts", () => {
+    mockResult.data = FULL_DATA;
+    render(<EducatorProgressView callerId="c1" />);
+    const stats = screen.getByTestId("epv-stats");
+    expect(stats).toHaveTextContent(/Calls/);
+    expect(stats).toHaveTextContent(/Topics/);
+    expect(stats).toHaveTextContent(/Key facts/);
+    expect(stats).toHaveTextContent("8");
+    expect(stats).toHaveTextContent("12");
+  });
+
+  it("renders test scores when pre/post exist", () => {
+    mockResult.data = FULL_DATA;
+    render(<EducatorProgressView callerId="c1" />);
+    const tests = screen.getByTestId("epv-test-scores");
+    expect(tests).toHaveTextContent(/Pre-test/);
+    expect(tests).toHaveTextContent(/Post-test/);
+    expect(tests).toHaveTextContent("55%");
+    expect(tests).toHaveTextContent("72%");
+  });
+
+  it("renders recent topics when present", () => {
+    mockResult.data = FULL_DATA;
+    render(<EducatorProgressView callerId="c1" />);
+    const topics = screen.getByTestId("epv-recent-topics");
+    expect(topics).toHaveTextContent("Education");
+    expect(topics).toHaveTextContent("Family");
+  });
+
+  it("omits sections that have no data", () => {
+    mockResult.data = {
+      ...FULL_DATA,
+      goals: [],
+      testScores: { preTest: null, postTest: null, uplift: null },
+      topTopics: [],
+      diagnosticFromMock: null,
+    };
+    render(<EducatorProgressView callerId="c1" />);
+    expect(screen.queryByTestId("epv-goals")).toBeNull();
+    expect(screen.queryByTestId("epv-test-scores")).toBeNull();
+    expect(screen.queryByTestId("epv-recent-topics")).toBeNull();
+    expect(screen.queryByTestId("epv-diagnostic")).toBeNull();
+    // Modules section still present because fixture has modules.
+    expect(screen.getByTestId("epv-modules")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

E5 Slice 5.5 — educator-side parallel view of the learner's module progress.

- Builds `EducatorProgressView` at `apps/admin/components/educator/EducatorProgressView.tsx` — a read-only mirror of `SimProgressPanel`. Reuses the same `useStudentProgress` hook + `/api/student/progress?callerId=X` endpoint (OPERATOR+ scope), so there is only ever ONE data path.
- Embeds it under a "Progress" heading on the existing learner-detail page: `apps/admin/app/x/educator/students/[id]/page.tsx`. No new route — the canonical learner-detail page already lives here.
- Educator tone, NOT learner celebration: course completion renders as a stat line (not a hero), modules carry an "EMA mastery X.XX / Y.YY threshold" info badge per row, recommended-next is intentionally NOT surfaced (that's the learner picker's job).

## ASCII mockup

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  ← Students                                                                 │
│  ┌───────────────────────────────────────────────────────────────────────┐  │
│  │ (A) Aisha Patel    Cohort A · ielts · Joined 12 Mar 2026  [Send Content]│
│  └───────────────────────────────────────────────────────────────────────┘  │
│  [Total Calls: 8]   [Goals Completed: 1]   [Last Call: 12 May]              │
│  ┌─ Call History ─────────────┐  ┌─ Learning Goals ────────────────────────┐│
│  │ 12 May 14:32              │  │ Reach Band 7 overall          40% ACTIVE││
│  │ 11 May 19:05              │  │ ████░░░░░░                              ││
│  │ ...                       │  │                                          ││
│  └────────────────────────────┘  └──────────────────────────────────────────┘│
│                                                                             │
│  PROGRESS  ← new heading                                                    │
│  ┌─ Status: Course complete — completed 15 Mar 2026   [terminal-only] ────┐ │
│  └────────────────────────────────────────────────────────────────────────┘ │
│  ┌─ Progress  [2 / 3 modules mastered] ─────────────────────────────────┐  │
│  │ ██████████████████████░░░░░░░░░░░                                    │  │
│  └──────────────────────────────────────────────────────────────────────┘  │
│  ┌─ Last Mock diagnostic ──────────────────────────────────────────────┐   │
│  │ Strongest in Part 1; focus next on Part 3.                          │   │
│  │ ✓ Strength:    Part 1: Familiar Topics                              │   │
│  │ ▶ Focus next:  Part 3: Discussion                                   │   │
│  │ 💡 Weakest skill: pronunciation                                     │   │
│  └──────────────────────────────────────────────────────────────────────┘   │
│  ┌─ Modules  [3 total] ──────────────────────────────────────────────────┐  │
│  │ ✓  Part 1: Familiar Topics  [Mastered]   [EMA 0.82 / 0.70]   4 calls │  │
│  │ ▶  Part 2: Long Turn        [In progress][EMA 0.55 / 0.70]   2 calls │  │
│  │ ○  Part 3: Discussion       [Not started][EMA 0.00 / 0.70]   —      │  │
│  └──────────────────────────────────────────────────────────────────────┘  │
│  ┌─ Goals · Stats · Test scores · Recent topics ────────────────────────┐  │
│  │ (same data shape as the learner panel; admin-shell styling)           │  │
│  └──────────────────────────────────────────────────────────────────────┘  │
│                                                                             │
│  COURSE ENROLMENTS  (existing section, unchanged)                           │
└─────────────────────────────────────────────────────────────────────────────┘
```

**Learner-detail page where it's embedded:**
`apps/admin/app/x/educator/students/[id]/page.tsx`

## Design system

- `hf-*` classes only (admin shell): `hf-card-compact`, `hf-section-title`, `hf-spinner`, `hf-empty`, `hf-banner-error`.
- New CSS namespaced `.epv-*` lives in `apps/admin/app/x/educator/educator.css` — no separate stylesheet, no inline static styles.
- Inline `style` only for runtime widths (progress bars, goal bars).

## Test plan

- [x] `npx vitest run tests/components/EducatorProgressView.test.tsx` — 15/15 pass
- [x] `npx eslint` on changed files — clean
- [x] `npx tsc --noEmit` — no new errors in changed files
- [ ] Manual check: log in as EDUCATOR, navigate to `/x/educator/students/<callerId>`, scroll to Progress — verify the panel renders with modules, focus areas, goals, and stats. Confirm course-complete (when applicable) appears as a one-line stat row, NOT a hero.
- [ ] Manual check: works for both authored IELTS courses and AI-generated courses (data plumbing already handles both — same API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)