### PR TITLE
fix(#456): Key Facts tile reads CallerMemory.FACT, not ConversationArtifact

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/route.ts
@@ -352,7 +352,24 @@ export async function GET(
       }).then(results => results.length),
       prisma.conversationArtifact.count({ where: { callerId: callerId } }),
       prisma.callAction.count({ where: { callerId: callerId, status: { in: ["PENDING", "IN_PROGRESS"] } } }),
-      prisma.conversationArtifact.count({ where: { callerId: callerId, type: "KEY_FACT" } }),
+      // #456: count CallerMemory.FACT — mirrors how Topics Discussed reads
+      // CallerMemory.TOPIC, so the two tiles stay consistent. The previous
+      // source (ConversationArtifact.KEY_FACT) is a separate artifact-
+      // delivery system that IELTS / most current playbooks do not emit,
+      // so the tile read 0 even when extraction populated CallerMemory.
+      // Apply the same supersededById / expiresAt filters as memoryCount to
+      // avoid double-counting expired or replaced rows.
+      prisma.callerMemory.count({
+        where: {
+          callerId: callerId,
+          category: "FACT",
+          supersededById: null,
+          OR: [
+            { expiresAt: null },
+            { expiresAt: { gt: new Date() } },
+          ],
+        },
+      }),
     ]);
 
     // Get behavior targets count for this caller


### PR DESCRIPTION
## Summary

The Key Facts tile on the caller Overview/Topics tab always showed 0 even when EXTRACT was writing learner facts. Root cause was a data-source mismatch: the count came from `ConversationArtifact.count({ type: \"KEY_FACT\" })`, but IELTS Speaking and most current playbooks don't emit `ConversationArtifact` rows of that type. EXTRACT writes them as `CallerMemory` rows with `category = FACT` (MEM-001 LEARN actions) — exactly how the neighbouring Topics Discussed tile is sourced (`CallerMemory.category = TOPIC`).

## Change

`app/api/callers/[callerId]/route.ts:355` swaps the `keyFactCount` query from `ConversationArtifact` → `CallerMemory.count({ category: \"FACT\" })`, with the same `supersededById` / `expiresAt` filters as the existing `memoryCount` so expired/superseded rows are not double-counted.

Closes #456.

## Test plan

- [ ] Open caller detail page for any caller with completed calls on IELTS Speaking (or any playbook with MEM-001 LEARN actions)
- [ ] Confirm Key Facts tile now shows the same count as the Facts chip in the profile sidebar
- [ ] Confirm Topics Discussed tile still shows correct count (regression check — same query shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)