### PR TITLE
fix(#510 follow-up): band-descriptor filter misses band-first prose (IELTS shape)

### DIFF
--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -1081,10 +1081,17 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
             // Deduplicate by text similarity (take first 6 unique-ish)
             const seen = new Set<string>();
             const outcomes: string[] = [];
-            // #500 guard — drop assessor-rubric band-descriptor rows
-            // ("Lexical Resource Band 8: ...") so learningOutcomes shows
-            // top-level capabilities, not measurement granularity.
-            const isBandRow = (text: string) => /\bBand\s+\d+\s*[:.]/i.test(text);
+            // #500 guard — drop assessor-rubric band-descriptor rows so
+            // learningOutcomes shows top-level capabilities, not measurement
+            // granularity. Two shapes appear in real rubrics:
+            //   - criterion-first:  "Lexical Resource Band 8: ..."
+            //   - band-first:        "Band 8 Lexical Resource: ..."
+            // The original regex only matched the criterion-first shape (colon
+            // right after the digit). IELTS rubrics use band-first; without
+            // the extra alternation the wizard hydrates 40 band rows into
+            // learningOutcomes + skillsFramework (#510 follow-up 2026-05-19).
+            const isBandRow = (text: string) =>
+              /^Band\s+\d+\b/i.test(text) || /\bBand\s+\d+\s*[:.]/i.test(text);
             for (const a of pool) {
               if (isBandRow(a.assertion)) continue;
               const key = a.assertion.toLowerCase().slice(0, 40);
@@ -1117,8 +1124,11 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
         // parseSkillsFramework reading the course-ref directly; the wizard's
         // setupData.skillsFramework hydration is best-effort UI state, safe
         // to drop the band rows here.
+        // Covers both shapes (see #510 follow-up note above):
+        //   - "Lexical Resource Band 8: ..." (criterion-first)
+        //   - "Band 8 Lexical Resource: ..." (band-first, IELTS)
         const looksLikeBandDescriptor = (text: string): boolean =>
-          /\bBand\s+\d+\s*[:.]/i.test(text);
+          /^Band\s+\d+\b/i.test(text) || /\bBand\s+\d+\s*[:.]/i.test(text);
         const skillAssertions = allAssertions
           .filter((a) => a.category === "skill_framework")
           .filter((a) => !looksLikeBandDescriptor(a.assertion));

--- a/apps/admin/lib/chat/wizard-ai-output-guard.ts
+++ b/apps/admin/lib/chat/wizard-ai-output-guard.ts
@@ -43,12 +43,17 @@ import type { GoalTemplate } from "@/lib/types/json-fields";
  * to minimise false positives on legitimate outcomes that happen to
  * mention rubric vocabulary.
  *
- * - IELTS Speaking band-descriptor lines: "Band 2 LR: Only produces…"
+ * - IELTS Speaking band-descriptor lines, both shapes:
+ *     - abbreviated:  "Band 2 LR: Only produces…"
+ *     - full prose:   "Band 8 Lexical Resource: Wide vocabulary…"
  * - Explicit calibration commentary: "A candidate can legitimately…"
  * - Tier-name colon prose: "Approaching: …", "Developing: …"
  */
 const RUBRIC_PATTERNS: ReadonlyArray<RegExp> = [
-  /^Band\s*\d+\s*[A-Z]+\s*:/i,
+  // Anchored: a learning outcome that starts with "Band <digit>" is rubric
+  // calibration, never a legitimate top-level capability. Covers both
+  // "Band 2 LR: …" (abbreviated) and "Band 8 Lexical Resource: …" (prose).
+  /^Band\s+\d+\b/i,
   /^A candidate can legitimately/i,
   /^(Approaching(?:\s+Emerging)?|Emerging|Developing|Secure)\s*[:.]/i,
 ];

--- a/apps/admin/tests/lib/chat/wizard-ai-output-guard.test.ts
+++ b/apps/admin/tests/lib/chat/wizard-ai-output-guard.test.ts
@@ -22,12 +22,31 @@ describe("guardAILearningOutcomes (#447)", () => {
     expect(result.skippedByGate).toBe(false);
   });
 
-  it("drops IELTS band-descriptor strings", () => {
+  it("drops IELTS band-descriptor strings (abbreviated form)", () => {
     const inputs = [
       "Band 2 LR: Only produces isolated words or memorised utterances",
       "Band 4 P: Uses a limited range of pronunciation features",
       "Band 2 GRA: Cannot produce basic sentence forms",
       "Band 4 FC: Unable to keep going without noticeable pauses",
+    ];
+    const result = guardAILearningOutcomes(inputs, noTemplates);
+
+    expect(result.accepted).toEqual([]);
+    expect(result.filtered).toHaveLength(4);
+    expect(result.filtered.every((f) => f.pattern.includes("Band"))).toBe(true);
+  });
+
+  // Real IELTS rubrics use the criterion in full prose rather than the
+  // abbreviated code. The original regex (`Band N <CODE>:`) missed these
+  // because the colon falls after the criterion name, not after the digit
+  // (live repro on hf-dev 2026-05-19 — wizard hydrated 40 band rows as
+  // skillsFramework entries).
+  it("drops IELTS band-descriptor strings (prose form)", () => {
+    const inputs = [
+      "Band 8 Lexical Resource: Wide vocabulary used readily and flexibly",
+      "Band 5 Grammatical Range and Accuracy: Basic sentence forms",
+      "Band 0 Fluency and Coherence: Does not attend / does not complete",
+      "Band 9 Pronunciation: Uses a full range of pronunciation features",
     ];
     const result = guardAILearningOutcomes(inputs, noTemplates);
 


### PR DESCRIPTION
## Summary

PR #510 added a regex filter to drop assessor-rubric band rows from the wizard's `learningOutcomes` / `skillsFramework` hydration. The regex (`\bBand\s+\d+\s*[:.]`) only matched the **criterion-first** shape:

> \"Lexical Resource Band 8: ...\"

Live IELTS rubrics use the **band-first** shape:

> \"Band 8 Lexical Resource: Wide vocabulary used readily and flexibly\"
> \"Band 5 Grammatical Range and Accuracy: Basic sentence forms\"
> \"Band 0 Fluency and Coherence: Does not attend / does not complete\"

The colon falls after the criterion name, not after the digit → old regex missed every entry → wizard hydrated 40 band rows as `skillsFramework` entries.

## Live repro (hf-dev 2026-05-19)

Fresh wizard on \"IELTS Speaking Practice\" with the new course-ref + assessor rubric. `setupData.skillsFramework` dump showed all 40 band descriptors as fake skills (\"Band 5 Grammatical Range and Accuracy: ...\" × 40).

## Fix

Add an anchored `^Band\s+\d+\b` alternative — a string that starts with \"Band &lt;digit&gt;\" is always rubric calibration regardless of what follows. Both filters in `ConversationalWizard.tsx` (learningOutcomes + skillsFramework) and the `RUBRIC_PATTERNS` gate in `wizard-ai-output-guard.ts` get the widened check.

The legitimate-mention case (\"Aim for IELTS Band 6 in next mock exam\") still passes — both the old and new regexes are anchored to start-of-string, so \"Aim\" leads and the match fails. Covered by existing test.

## Test plan
- [x] Added prose-form coverage to `wizard-ai-output-guard.test.ts` (11/11 pass)
- [ ] Re-extract on the IELTS course; verify `setupData.skillsFramework` ≤ 4 entries (or empty if no non-band assertions)
- [ ] Verify `learningOutcomes` no longer contains \"Band N ...\" rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)