### PR TITLE
fix(wizard): COURSE_REFERENCE filter matches only exact type, skipping canonical/briefing variants

### DIFF
--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -806,11 +806,14 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
       const uploadOverrides = { lastUploadClassifications: data.classifications };
       pendingUploadRef.current = { text: "Teaching materials uploaded", overrides: uploadOverrides };
 
-      // Show typing dots immediately. If any file is COURSE_REFERENCE, use
-      // "course-ref-analysing" which persists through extraction → digest → AI
-      // narration. Otherwise "upload-draining" clears once the drain fires.
+      // Show typing dots immediately. If any file is a COURSE_REFERENCE* variant
+      // (COURSE_REFERENCE, COURSE_REFERENCE_CANONICAL, COURSE_REFERENCE_TUTOR_BRIEFING,
+      // ...), use "course-ref-analysing" which persists through extraction →
+      // digest → AI narration. Otherwise "upload-draining" clears once the
+      // drain fires.
       const hasCourseRef = data.classifications.some(
-        (c: { documentType: string }) => c.documentType === "COURSE_REFERENCE",
+        (c: { documentType: string }) =>
+          typeof c.documentType === "string" && c.documentType.startsWith("COURSE_REFERENCE"),
       );
       setBusyReason(hasCourseRef ? "course-ref-analysing" : "upload-draining");
       scrollToBottom();
@@ -854,8 +857,17 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
       const sourceIds = getData<string[]>("uploadSourceIds");
       if (!classifications || !sourceIds) { setBusyReason(null); return; }
 
+      // Match any COURSE_REFERENCE* variant — the classifier emits
+      // COURSE_REFERENCE, COURSE_REFERENCE_CANONICAL, COURSE_REFERENCE_TUTOR_BRIEFING,
+      // and other subtypes. The canonical doc (where `## Modules` lives)
+      // is usually COURSE_REFERENCE_CANONICAL, so an exact-match filter
+      // silently skipped it and ran `detectAuthoredModules` on text that
+      // never included the module table → curriculumPath mis-flagged as
+      // "generated" for IELTS-style courses (live repro 2026-05-19).
+      const isCourseRefType = (t: string): boolean =>
+        typeof t === "string" && t.startsWith("COURSE_REFERENCE");
       const courseRefIndices = classifications
-        .map((c, i) => c.documentType === "COURSE_REFERENCE" ? i : -1)
+        .map((c, i) => isCourseRefType(c.documentType) ? i : -1)
         .filter((i) => i >= 0);
       if (courseRefIndices.length === 0) {
         // Non-COURSE_REFERENCE extraction done — show a quiet status in chat


### PR DESCRIPTION
## Summary

Wizard's `detectAuthoredModules` / `detectPedagogy` pipeline was running against text aggregated from only the docs whose `documentType === \"COURSE_REFERENCE\"` (exact match). The classifier emits four shapes:

- `COURSE_REFERENCE` (assessor rubrics, support material)
- `COURSE_REFERENCE_CANONICAL` (the authored course-ref doc — where `## Modules` lives)
- `COURSE_REFERENCE_TUTOR_BRIEFING` (briefing material)
- other `COURSE_REFERENCE_*` subtypes

The exact-match filter silently skipped the canonical doc.

## Symptom (live hf-dev 2026-05-19)

Wizard \"IELTS Prep Lab\". User uploaded 7 docs. Three were `COURSE_REFERENCE*`:

```
uploadSourceIds[4] (course-ref.md)        documentType=COURSE_REFERENCE_CANONICAL — SKIPPED
uploadSourceIds[5] (tutor-briefing.md)    documentType=COURSE_REFERENCE_TUTOR_BRIEFING — SKIPPED
uploadSourceIds[6] (assessor-rubric.md)   documentType=COURSE_REFERENCE — only one fetched
```

Result:
- `setupData.curriculumPath: \"generated\"` (wrong — course-ref declared authored modules)
- GROUND TRUTH overlay told the AI \"no module catalogue found\"
- User-visible: \"where are the MODULES?\"

Server-side projection was unaffected — `runProjectionForPlaybook` reads full text directly via the storage adapter for every source. So authored modules WOULD have landed in DB at `create_course` time. The bug was the wizard-side detection + GROUND TRUTH overlay.

## Fix

Use `documentType.startsWith(\"COURSE_REFERENCE\")` at both call sites:

- `hasCourseRef` gate (drives `course-ref-analysing` busy state).
- `courseRefIndices` builder (drives `/raw-text` fetches → `detectAuthoredModules` + `detectPedagogy`).

## Test plan

- [ ] Hard-reset the wizard (`sessionStorage.clear()`).
- [ ] Re-upload IELTS Prep Lab's 7 docs.
- [ ] Confirm `/raw-text` is fetched for all 3 course-ref-shaped sources (server log).
- [ ] Confirm `setupData.curriculumPath === \"authored\"`.
- [ ] Confirm wizard AI references authored modules with confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)