### PR TITLE
fix(wizard): cohort lookup scoped by playbookId, not name — stops same-named courses inheriting prior cohorts

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -1780,10 +1780,24 @@ export async function executeWizardTool(
         }
         const caller = await createTestCaller(callerName, false);
 
-        // 9d. Create or reuse "Test Learners" cohort so the course has a join link
+        // 9d. Create or reuse "Test Learners" cohort so the course has a join link.
+        //
+        // SCOPE BY PLAYBOOK, NOT BY NAME. Previously this looked up the cohort
+        // by (domainId, name) so a brand-new playbook would silently reuse the
+        // cohort of an earlier same-named playbook in the same domain — and
+        // inherit its entire member list. Live repro on hf-dev 2026-05-19:
+        // "IELTS Speaking Practice" was the 13th playbook of that name in
+        // the IELTS Prep Lab domain; the cohort created on 2026-05-10 had
+        // accumulated 4 leaked members across the prior runs.
+        //
+        // Scoping by playbook means: brand-new playbookId has no
+        // CohortPlaybook link yet → findFirst returns null → fresh cohort
+        // gets created. Re-runs of create_course on the SAME playbookId
+        // find the prior cohort and reuse it (the legitimate case the
+        // findFirst was added for).
         const cohortName = `${courseName} — Test Learners`;
         let cohort = await prisma.cohortGroup.findFirst({
-          where: { domainId, name: cohortName },
+          where: { playbooks: { some: { playbookId } } },
         });
         let joinToken = cohort?.joinToken || "";
         if (!cohort) {


### PR DESCRIPTION
## Summary

When `create_course` ran on a brand-new playbook in a domain that already had a same-named playbook, the wizard's \"Test Learners\" cohort logic looked up the cohort by `(domainId, name)`. That matched the OLD playbook's cohort. The new playbook then got linked to that cohort via `cohortPlaybook.upsert`, inheriting its entire member list.

## Live repro (hf-dev 2026-05-19)

```
Domain:   \"IELTS Prep Lab\"     (existing, reused)
Playbook: b5a9829a-...         (fresh, created 20:22:28 today)
Cohort:   6c8db437-...         (created 2026-05-10, 4 prior runs ago)
Members:  Maren Novak + Xena Yilmaz (today's new)
          Val Sharma + Henrik Vasquez (2026-05-18 leak)
          Tessa Ikeda + Jasper Tremblay (2026-05-18 leak)
```

User reaction: *\"Course has CALLERS FROM YESTERDAY??\"*

## Fix

Scope the `findFirst` by `playbooks: { some: { playbookId } }` instead of by `(domainId, name)`. Result:

- Brand-new `playbookId` has no `CohortPlaybook` link yet → returns null → fresh cohort with fresh joinToken gets created.
- `create_course` re-runs on the SAME `playbookId` find the prior cohort via the FK and correctly reuse it (preserves the re-edit-draft case the original findFirst was added for).

Old cohorts in the domain are unaffected — they keep their prior members. New playbooks no longer get bolted onto them.

## Note: existing course unaffected

Playbook `b5a9829a` (created before this PR) is still linked to the leaked cohort. Either drop + recreate, or apply manual surgery (detach `CohortPlaybook` + create fresh cohort). Future new courses get clean cohorts automatically.

## Test plan
- [ ] Create a new course in a domain where a same-named playbook already exists; confirm new cohort is created with 0 prior members.
- [ ] Re-run `create_course` on an existing draft playbook; confirm cohort + joinToken are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)