### PR TITLE
fix(#538): persist SchedulerDecision mode=practice for picker-locked modules

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -753,6 +753,38 @@ export async function computeSharedState(
     }
   }
 
+  // #538 — when a module is locked (picker pick or SIM --module), the
+  // scheduler block above is bypassed AND no SchedulerDecision is written.
+  // event-gate.ts then keeps reading the prior decision, which often holds
+  // `mode: "teach"` from earlier auto-cadence calls — so caller-level
+  // skill aggregation stays gated off forever on courses that use the
+  // picker. Persist a "practice" decision here so picker-driven calls
+  // pass the gate (event-gate allows `assess`/`practice` per
+  // config.scheduler.assessmentModes).
+  //
+  // "practice" is the right semantic: the learner explicitly chose a
+  // module and is actively practising it. We deliberately do not run the
+  // full pickMode() cadence — picker-driven calls sit outside the
+  // teach→practice→assess→review cycle that pickMode() drives.
+  if (lockedModule && data.caller?.id) {
+    try {
+      const { persistSchedulerDecision } = await import("@/lib/pipeline/scheduler-decision");
+      await persistSchedulerDecision(data.caller.id, {
+        mode: "practice",
+        outcomeId: null,
+        contentSourceId: null,
+        workingSetAssertionIds: [],
+        reason: `picker-locked to module "${lockedModule.slug || lockedModule.id}" — scoring allowed`,
+        callsSinceAssess: 0,
+      });
+      console.log(
+        `[modules] #538: persisted SchedulerDecision mode=practice for locked module "${lockedModule.slug || lockedModule.id}" — caller scoring gate will allow.`,
+      );
+    } catch (err) {
+      console.warn('[modules] #538: failed to persist locked-module SchedulerDecision (non-blocking):', err);
+    }
+  }
+
   // Determine review intensity based on time gap
   // Thresholds from specConfig (default: 14/7/3 days for reintroduce/deep_review/application)
   const reviewSchedule = specConfig.reviewSchedule || { reintroduce: 14, deepReview: 7, application: 3 };


### PR DESCRIPTION
## Summary

When a learner uses the Module Picker (or SIM `--module`), `computeSharedState` bypasses the entire scheduler block — including `persistSchedulerDecision`. `event-gate.ts` on the next call's EXTRACT keeps reading the previous decision, which on most courses still holds `mode: \"teach\"` from earlier auto-cadence runs. The event-gate then **denies caller-skill scoring forever once the picker is used**, even though `CallScore` rows ARE being written per call (18/call on IELTS Speaking). Learner band-score aggregation flatlines.

## Live repro (hf-dev 2026-05-19)

Caller Quinn Nakamura (`34c35b2e`) on course `e5f379ed` (IELTS Speaking Practice). 6 SIM calls with `--module=part1/part2/part3/mock`. Pipeline response on every call:

```
{ scoresCreated: 18, callerAnalysisGated: true, gate: { allow: false, mode: \"teach\", reason: \"prior decision mode=teach — no assessment evidence (allowed: assess,practice), skipping caller scoring\" } }
```

108 CallScore rows written, 0 aggregated to learner profile.

## Fix (option B from the issue body, simplified)

After the locked-module block in `computeSharedState`, persist a `mode: \"practice\"` SchedulerDecision for the caller. `practice` is in `config.scheduler.assessmentModes`, so the event-gate allows scoring on the next call.

**Semantically correct:** the learner explicitly picked a module and is actively practising it. Picker-driven calls sit outside the `teach → practice → assess → review` cycle that `pickMode()` drives, so we deliberately do NOT run the full cadence machinery — a single per-call write is enough.

Non-blocking on failure (matches the existing scheduler-side persist).

## Test plan
- [ ] On a course where the prior SchedulerDecision is `teach`, run a picker call.
- [ ] Confirm next call's pipeline returns `gate.allow: true, gate.mode: \"practice\"`.
- [ ] Confirm CallScore rows now aggregate to caller-level skill state (visible on cohort dashboard).
- [ ] No regression on auto-cadence (non-picker) calls.
- [ ] 45/45 composition module tests still pass ✓

Closes #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)