### PR TITLE
feat(#479): per-section character-count log at compose time

### DIFF
--- a/apps/admin/lib/prompt/composition/CompositionExecutor.ts
+++ b/apps/admin/lib/prompt/composition/CompositionExecutor.ts
@@ -229,6 +229,33 @@ export async function executeComposition(
   // Add agent identity summary
   llmPrompt.agentIdentitySummary = buildAgentIdentitySummary(resolvedSpecs);
 
+  // #479 — per-section character-count observability. The composed prompt
+  // grew from 86K → 119K across 6 calls on hf-dev IELTS Speaking, sitting
+  // near the OpenAI 30K TPM tier ceiling. Before trimming anything we need
+  // to know which sections actually dominate. This log emits a sorted
+  // breakdown so the next trim PR can target with confidence instead of
+  // guessing. Counted on the JSON-stringified value of each section after
+  // strip-internal — what actually goes into the prompt downstream.
+  try {
+    const sectionSizes: Array<{ key: string; chars: number }> = [];
+    let totalChars = 0;
+    for (const [key, value] of Object.entries(llmPrompt)) {
+      if (key === "_version" || key === "_format") continue;
+      const chars = typeof value === "string" ? value.length : JSON.stringify(value).length;
+      sectionSizes.push({ key, chars });
+      totalChars += chars;
+    }
+    sectionSizes.sort((a, b) => b.chars - a.chars);
+    const lines = [`[compose-sizes] total=${totalChars} chars across ${sectionSizes.length} sections`];
+    for (const s of sectionSizes) {
+      const pct = totalChars > 0 ? Math.round((s.chars / totalChars) * 100) : 0;
+      lines.push(`  ${String(s.chars).padStart(7)} (${String(pct).padStart(2)}%)  ${s.key}`);
+    }
+    console.log(lines.join("\n"));
+  } catch (err) {
+    console.warn("[compose-sizes] failed to compute section breakdown:", err);
+  }
+
   // 8. Build callerContext markdown (for LLM prompt and storage)
   const callerContext = buildCallerContext(context);
 


### PR DESCRIPTION
## Summary

Diagnostic-first step on #479 (107K composed prompt → OpenAI 30K TPM rate-limit risk). Adds a per-section character-count log after assembly so the next trim PR targets the real heavy hitter with confidence.

The Explore-agent investigation [posted on the issue](https://github.com/WANDERCOLTD/HF/issues/479#issuecomment-4492152700) ranked candidates by expected savings, but the top recommendation (truncate \`teaching_content\` assertions to 200 chars) turned out to be a near-no-op for IELTS — most assertions are <200 chars already. Sibling-module thinning (#492 Slice 3.2) is already live at \`modules.ts:1014-1033\`. Without per-section numbers we'd be guessing.

## What you'll see in logs

After every compose:

```
[compose-sizes] total=119558 chars across 24 sections
     32140 (27%)  teachingContent
     18210 (15%)  courseInstructions
      9403 ( 8%)  memories
       ...
```

## Cost / risk

- One \`JSON.stringify\` per section + one \`console.log\` per compose
- **Zero behavioural change** to the prompt itself
- No content trimmed

## Next step

Run a few SIM calls, read the breakdown, ship a targeted trim PR with confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)