### PR TITLE
fix(#547): idempotency guard on legacy updateModuleMastery callCount

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -2205,17 +2205,23 @@ async function trackCurriculumAfterCall(
     masteryThreshold: number;
     allModuleIds: string[];
   } | null,
+  callId?: string,
 ): Promise<boolean> {
   // If we have a learning assessment, write mastery and potentially advance
   if (learningAssessment) {
     const { specSlug, moduleId, overallMastery, outcomes, masteryThreshold, allModuleIds } = learningAssessment;
 
     try {
-      // Write mastery score for this module + per-LO outcomes
+      // Write mastery score for this module + per-LO outcomes.
+      // `callId` threads through so `updateModuleMastery` can apply the
+      // #547 idempotency guard — the canonical AGGREGATE-stage
+      // `incrementModuleEvidence` has typically already counted this
+      // call by the time we get here.
       await updateCurriculumProgress(callerId, specSlug, {
         moduleMastery: { [moduleId]: overallMastery },
         loMastery: Object.keys(outcomes).length > 0 ? { moduleId, outcomes } : undefined,
         lastAccessedAt: new Date(),
+        callId,
       });
       log.info(`Mastery written for ${specSlug}:${moduleId}`, { mastery: overallMastery, threshold: masteryThreshold, loCount: Object.keys(outcomes).length });
 
@@ -2645,7 +2651,7 @@ const stageExecutors: Record<string, StageExecutor> = {
     const [currSettled, onboardSettled, lessonSettled, artifactSettled, actionSettled] =
       await Promise.allSettled([
         // 1. Curriculum progress + CurriculumModule FK write
-        trackCurriculumAfterCall(ctx.callerId, ctx.log, callerResult.learningAssessment)
+        trackCurriculumAfterCall(ctx.callerId, ctx.log, callerResult.learningAssessment, ctx.callId)
           .then(async (updated) => {
             if (callerResult.learningAssessment?.moduleId) {
               // Two-step scope chain (#407): caller → playbook → curriculum →

--- a/apps/admin/lib/curriculum/track-progress.ts
+++ b/apps/admin/lib/curriculum/track-progress.ts
@@ -24,6 +24,12 @@ interface ProgressUpdate {
   /** Per-LO mastery outcomes for a specific module */
   loMastery?: { moduleId: string; outcomes: Record<string, number> };
   lastAccessedAt?: Date;
+  /**
+   * The Call.id that triggered this update. Used by `updateModuleMastery`
+   * for idempotency (#547) — when the canonical `incrementModuleEvidence`
+   * has already counted this call, the legacy increment is skipped.
+   */
+  callId?: string;
 }
 
 /**
@@ -216,7 +222,7 @@ export async function updateCurriculumProgress(
             curriculum.id,
             moduleId,
             mastery,
-            undefined,
+            updates.callId,
             loScoresForThisModule,
           );
         } catch {
@@ -348,10 +354,29 @@ export async function updateModuleMastery(
 
   const existing = await prisma.callerModuleProgress.findUnique({
     where: { callerId_moduleId: { callerId, moduleId: resolvedModuleId } },
-    select: { callCount: true, loScoresJson: true },
+    select: { callCount: true, loScoresJson: true, lastCallId: true },
   });
 
-  const effectiveCallCount = (existing?.callCount ?? 0) + 1;
+  // #547 — idempotency guard mirroring incrementModuleEvidence at
+  // route.ts:1198. Both writers (canonical incrementModuleEvidence in
+  // AGGREGATE, this legacy updateModuleMastery via the
+  // learningAssessment path) fire for the same call. Without this
+  // guard the legacy path double-counted callCount whenever the AI's
+  // learningAssessment.moduleId matched the bound module — a single
+  // SIM call ended up with callCount=2 on part1 in 2026-05-19's
+  // testing. Skipping the increment when this exact callId already
+  // touched the row matches the canonical path's semantics.
+  const alreadyCounted =
+    !!callId && existing?.lastCallId === callId && (existing.callCount ?? 0) > 0;
+
+  // For the LO-derived mastery branch we need the post-increment
+  // callCount to feed `capMasteryByCallCount`. If we're skipping the
+  // increment because the canonical path already counted this call,
+  // we still use the current row count — both writers see the same
+  // total.
+  const effectiveCallCount = alreadyCounted
+    ? existing!.callCount
+    : (existing?.callCount ?? 0) + 1;
 
   let finalMastery: number;
   let nextLoScoresJson: LoScoresMap | undefined;
@@ -399,7 +424,11 @@ export async function updateModuleMastery(
       status,
       completedAt: finalMastery >= 1.0 ? new Date() : null,
       lastCallId: callId || undefined,
-      callCount: { increment: 1 },
+      // #547 — guarded increment: skip when canonical
+      // incrementModuleEvidence already counted this call. Preserves
+      // loScoresJson + mastery updates on every call (LEARN goal
+      // progress / LO coverage UI keep working).
+      ...(alreadyCounted ? {} : { callCount: { increment: 1 } }),
       ...(nextLoScoresJson ? { loScoresJson: nextLoScoresJson } : {}),
     },
   });

--- a/apps/admin/tests/lib/update-module-mastery-idempotency.test.ts
+++ b/apps/admin/tests/lib/update-module-mastery-idempotency.test.ts
@@ -1,0 +1,161 @@
+/**
+ * #547 — `updateModuleMastery` idempotency guard.
+ *
+ * Locks in the behaviour that the legacy mastery write path does NOT
+ * double-count `callCount` when the canonical `incrementModuleEvidence`
+ * has already counted this exact call. Two writers, one row, one
+ * increment per call.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    callerModuleProgress: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/curriculum/resolve-module", () => ({
+  resolveModuleByLogicalId: vi.fn(async (_curriculumId: string, slug: string) => ({
+    id: `uuid-for-${slug}`,
+    slug,
+  })),
+  resolveCurriculumIdForPlaybook: vi.fn(),
+}));
+
+import { updateModuleMastery } from "@/lib/curriculum/track-progress";
+
+describe("#547 updateModuleMastery idempotency", () => {
+  beforeEach(() => {
+    mockPrisma.callerModuleProgress.findUnique.mockReset();
+    mockPrisma.callerModuleProgress.upsert.mockReset();
+  });
+
+  it("creates the row with callCount=1 on first ever call", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue(null);
+    mockPrisma.callerModuleProgress.upsert.mockResolvedValue({});
+
+    await updateModuleMastery(
+      "caller-1",
+      "curriculum-1",
+      "part1",
+      0.6,
+      "call-1",
+    );
+
+    expect(mockPrisma.callerModuleProgress.upsert).toHaveBeenCalledTimes(1);
+    const args = mockPrisma.callerModuleProgress.upsert.mock.calls[0][0];
+    expect(args.create.callCount).toBe(1);
+    expect(args.update).toHaveProperty("callCount"); // standard increment path
+  });
+
+  it("SKIPS the increment when the canonical path already counted this call", async () => {
+    // Canonical incrementModuleEvidence ran first and set lastCallId
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      callCount: 1,
+      loScoresJson: null,
+      lastCallId: "call-1",
+    });
+    mockPrisma.callerModuleProgress.upsert.mockResolvedValue({});
+
+    await updateModuleMastery(
+      "caller-1",
+      "curriculum-1",
+      "part1",
+      0.6,
+      "call-1", // same callId as the existing row's lastCallId
+    );
+
+    const args = mockPrisma.callerModuleProgress.upsert.mock.calls[0][0];
+    // The update branch must NOT contain a callCount field
+    expect(args.update).not.toHaveProperty("callCount");
+    // Mastery + status still update
+    expect(args.update).toHaveProperty("mastery");
+    expect(args.update).toHaveProperty("status");
+  });
+
+  it("INCREMENTS when the row exists but this is a different call", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      callCount: 1,
+      loScoresJson: null,
+      lastCallId: "prior-call",
+    });
+    mockPrisma.callerModuleProgress.upsert.mockResolvedValue({});
+
+    await updateModuleMastery(
+      "caller-1",
+      "curriculum-1",
+      "part1",
+      0.6,
+      "call-2", // different from existing lastCallId
+    );
+
+    const args = mockPrisma.callerModuleProgress.upsert.mock.calls[0][0];
+    expect(args.update.callCount).toEqual({ increment: 1 });
+  });
+
+  it("INCREMENTS when callId is not provided (legacy call sites without #547 plumbing)", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      callCount: 5,
+      loScoresJson: null,
+      lastCallId: "some-earlier-call",
+    });
+    mockPrisma.callerModuleProgress.upsert.mockResolvedValue({});
+
+    // No callId passed
+    await updateModuleMastery("caller-1", "curriculum-1", "part1", 0.6);
+
+    const args = mockPrisma.callerModuleProgress.upsert.mock.calls[0][0];
+    expect(args.update.callCount).toEqual({ increment: 1 });
+  });
+
+  it("INCREMENTS when callId matches but existing callCount is 0 (transitional rows)", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      callCount: 0,
+      loScoresJson: null,
+      lastCallId: "call-1",
+    });
+    mockPrisma.callerModuleProgress.upsert.mockResolvedValue({});
+
+    await updateModuleMastery(
+      "caller-1",
+      "curriculum-1",
+      "part1",
+      0.6,
+      "call-1",
+    );
+
+    const args = mockPrisma.callerModuleProgress.upsert.mock.calls[0][0];
+    expect(args.update.callCount).toEqual({ increment: 1 });
+  });
+
+  it("loScoresJson is written on every call regardless of idempotency skip", async () => {
+    mockPrisma.callerModuleProgress.findUnique.mockResolvedValue({
+      callCount: 1,
+      loScoresJson: { "LO-01": { mastery: 0.5, callCount: 1 } },
+      lastCallId: "call-1",
+    });
+    mockPrisma.callerModuleProgress.upsert.mockResolvedValue({});
+
+    await updateModuleMastery(
+      "caller-1",
+      "curriculum-1",
+      "part1",
+      0.6,
+      "call-1", // same callId — increment skipped
+      { "LO-01": 0.7 },
+    );
+
+    const args = mockPrisma.callerModuleProgress.upsert.mock.calls[0][0];
+    expect(args.update).not.toHaveProperty("callCount");
+    expect(args.update).toHaveProperty("loScoresJson");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #547. Stops the double-count on `CallerModuleProgress.callCount` by adding a `lastCallId` idempotency guard inside `updateModuleMastery` — mirroring the canonical `incrementModuleEvidence` guard at `route.ts:1198`.

## What changed

- `lib/curriculum/track-progress.ts::updateModuleMastery` — reads `(callCount, lastCallId)` first; skips `callCount: { increment: 1 }` when the canonical path already counted this call. Mastery, status, and `loScoresJson` updates continue on every call (preserves LEARN goal progress + LO coverage UI readers).
- `ProgressUpdate` interface — adds optional `callId` field.
- `app/api/calls/[callId]/pipeline/route.ts` — `trackCurriculumAfterCall` now accepts `callId` and threads it through `updateCurriculumProgress`.
- New tests: `tests/lib/update-module-mastery-idempotency.test.ts` (6 cases).

## Test plan

- [x] `npx vitest run tests/lib/update-module-mastery-idempotency.test.ts` — 6/6 pass
- [x] `npx vitest run tests/lib/mastery-store-consolidation.test.ts tests/lib/caller-module-progress-increment.test.ts tests/lib/aggregate-mastery-write.test.ts` — 21/21 (no regressions on mastery readers/writers)
- [ ] Post-deploy: SIM x1 call on caller `7e84ac73-...` → assert `CallerModuleProgress.callCount = 1` (not 2)

## Deploy command

`/vm-cp` — no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)