### PR TITLE
feat(#566): step 0 — EVIDENCE_FIRST_SCORING flag + per-playbook override

### DIFF
--- a/apps/admin/config/evidence-first-playbooks.json
+++ b/apps/admin/config/evidence-first-playbooks.json
@@ -1,0 +1,10 @@
+{
+  "_meta": {
+    "purpose": "Per-playbook override list for the mode-kill epic (#566). Playbook IDs listed here route through the new evidence-aware gate (introduced in Step 3) instead of the legacy mode-based event-gate. Empty in Step 0 — no playbook is opted in yet. Step 3 adds the IELTS Speaking Practice playbook as the first canary.",
+    "epic": "#566",
+    "step": 0,
+    "lastUpdated": "2026-05-20",
+    "rollback": "Edit this file to [] and redeploy; mode gate resumes for all playbooks within 30 seconds."
+  },
+  "playbookIds": []
+}

--- a/apps/admin/lib/config.ts
+++ b/apps/admin/lib/config.ts
@@ -13,6 +13,17 @@
  */
 
 // =============================================================================
+// Module-scoped caches
+// =============================================================================
+
+/**
+ * Mode-kill epic #566 — cache for the per-playbook override list. Read once
+ * from disk on first access, then re-used for the process lifetime. Restart
+ * the dev server to pick up changes to evidence-first-playbooks.json.
+ */
+let _evidenceFirstPlaybookCache: string[] | null = null;
+
+// =============================================================================
 // Helpers
 // =============================================================================
 
@@ -597,12 +608,64 @@ export const config = {
      * scoring in EXTRACT. Default "assess,practice" — only score when the prior
      * decision explicitly requested assessment or retrieval practice.
      * Override: SCHEDULER_ASSESSMENT_MODES=assess,practice,review
+     *
+     * Deprecated in #566 (mode-kill epic). Step 3+ routes IELTS-listed
+     * playbooks through evidence-aware gating instead. This list survives for
+     * legacy playbooks until Step 8 deletes the mode gate entirely.
      */
     get assessmentModes(): string[] {
       return optional("SCHEDULER_ASSESSMENT_MODES", "assess,practice")
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean);
+    },
+
+    /**
+     * Mode-kill epic #566 — Step 0 flag.
+     *
+     * When true, playbooks in `evidenceFirstPlaybooks` use the new
+     * evidence-aware gate (introduced in Step 3) instead of the legacy
+     * mode-based gate (event-gate.ts). When false, all playbooks use the
+     * mode gate regardless of the override list.
+     *
+     * Default OFF in Step 0 — no behavior change. Step 3 flips it to true
+     * via env override on dev VM. Step 7 flips it globally.
+     *
+     * Override: EVIDENCE_FIRST_SCORING_ENABLED=true
+     */
+    get evidenceFirstEnabled(): boolean {
+      return optional("EVIDENCE_FIRST_SCORING_ENABLED", "false") === "true";
+    },
+
+    /**
+     * Mode-kill epic #566 — Step 0 per-playbook override list.
+     *
+     * Playbook IDs in `apps/admin/config/evidence-first-playbooks.json` route
+     * through the evidence-aware gate when `evidenceFirstEnabled` is true.
+     * The IELTS Speaking Practice playbook is the first canary — see #566 for
+     * the rollout plan.
+     *
+     * Cached in-process. Restart required to pick up changes.
+     */
+    get evidenceFirstPlaybooks(): string[] {
+      if (_evidenceFirstPlaybookCache !== null) return _evidenceFirstPlaybookCache;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const fs = require("fs") as typeof import("fs");
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const path = require("path") as typeof import("path");
+        const file = path.resolve(process.cwd(), "config/evidence-first-playbooks.json");
+        if (!fs.existsSync(file)) {
+          _evidenceFirstPlaybookCache = [];
+          return _evidenceFirstPlaybookCache;
+        }
+        const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as { playbookIds?: string[] };
+        _evidenceFirstPlaybookCache = Array.isArray(parsed.playbookIds) ? parsed.playbookIds : [];
+        return _evidenceFirstPlaybookCache;
+      } catch {
+        _evidenceFirstPlaybookCache = [];
+        return _evidenceFirstPlaybookCache;
+      }
     },
   },
 

--- a/apps/admin/tests/lib/config.test.ts
+++ b/apps/admin/tests/lib/config.test.ts
@@ -517,3 +517,40 @@ describe("getConfigSummary", () => {
     expect(polling).toHaveProperty("statusPollMs");
   });
 });
+
+// =============================================================================
+// Mode-kill epic #566 — Step 0 evidence-first flags
+// =============================================================================
+
+describe("scheduler.evidenceFirstEnabled (#566 Step 0)", () => {
+  it("defaults to false when env var is unset", () => {
+    vi.stubEnv("EVIDENCE_FIRST_SCORING_ENABLED", "");
+    expect(config.scheduler.evidenceFirstEnabled).toBe(false);
+  });
+
+  it("returns true when env var is exactly 'true'", () => {
+    vi.stubEnv("EVIDENCE_FIRST_SCORING_ENABLED", "true");
+    expect(config.scheduler.evidenceFirstEnabled).toBe(true);
+  });
+
+  it("returns false for any non-'true' value", () => {
+    vi.stubEnv("EVIDENCE_FIRST_SCORING_ENABLED", "1");
+    expect(config.scheduler.evidenceFirstEnabled).toBe(false);
+    vi.stubEnv("EVIDENCE_FIRST_SCORING_ENABLED", "yes");
+    expect(config.scheduler.evidenceFirstEnabled).toBe(false);
+  });
+});
+
+describe("scheduler.evidenceFirstPlaybooks (#566 Step 0)", () => {
+  it("returns array (may be empty in Step 0; populated in Step 3)", () => {
+    const ids = config.scheduler.evidenceFirstPlaybooks;
+    expect(Array.isArray(ids)).toBe(true);
+  });
+
+  it("never throws when override file is malformed or missing", () => {
+    // The getter reads from disk once per process; subsequent calls hit cache.
+    // We can't easily simulate "missing file" mid-test without reloading the
+    // module, but we CAN assert the getter never throws on any call shape.
+    expect(() => config.scheduler.evidenceFirstPlaybooks).not.toThrow();
+  });
+});


### PR DESCRIPTION
First commit of the mode-kill epic (#566). Pure scaffolding — adds flag + override file infrastructure for Steps 1-3 to wire against. No runtime behavior change in this commit.

## What lands

- `config.scheduler.evidenceFirstEnabled` (env: `EVIDENCE_FIRST_SCORING_ENABLED`, default false)
- `config.scheduler.evidenceFirstPlaybooks` (reads `apps/admin/config/evidence-first-playbooks.json`)
- Module-scoped cache for the override list (one disk read per process)
- `config/evidence-first-playbooks.json` with empty `playbookIds` array + rollback docs

Until Step 3 flips the IELTS playbook into the override list, the legacy mode-gate (`event-gate.ts`) handles every playbook unchanged.

## Why now

Today's empirical sim (3 calls against Caleb on the IELTS playbook) showed: only the mock call scores domain-skill params (FC/LR/GRA/P). Teach-mode calls produce zero IELTS skill data despite scoreable learner evidence in every transcript. Architectural fix planned in epic #566 — kill mode as a gate, replace with evidence-aware scoring.

## Rollback

Baseline tagged at `pre-mode-kill-baseline` (commit before this branch). Every step in the epic can revert to that tag without DB migration. This commit alone is a no-op revert (delete the new files + flag, behavior identical).

## Tests

`tests/lib/config.test.ts` 71 → 76 (5 new tests on the flags). Pre-existing tests green.

## Test plan

- [x] `npx vitest run tests/lib/config.test.ts` — 76/76 pass
- [ ] Local merge + `/vm-cp` — verify env var loading on dev VM
- [ ] Confirm no runtime change by re-running Caleb sim and observing identical scoring behavior

## Deploy command

`/vm-cp` — no migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)