### PR TITLE
feat(#566): step 1 — evidence-aware scorer (shadow)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -440,8 +440,12 @@ PARAMS TO SCORE: ${paramList}
 FACTS TO EXTRACT (use the suggested keys, extract EVERY fact mentioned including names, pets, family, preferences):
 ${learnList}${learningSection}
 
+For each param, also include EVIDENCE FIELDS:
+- "he" (hasLearnerEvidence): true if the LEARNER's own utterances contain scoreable evidence for this param. false if the score is inferred from the tutor's prose only.
+- "eq" (evidenceQuality): 0-1 confidence that the LEARNER produced enough material to score this param. 0 = nothing scoreable, 1 = abundant evidence.
+
 Return compact JSON:
-{"scores":{"PARAM-ID":{"s":0.75,"c":0.8},...},"memories":[{"cat":"RELATIONSHIP","key":"family_pet","val":"dog called Fred","c":0.9,"e":"my dog is called Fred"},...]${learningJsonHint}}`;
+{"scores":{"PARAM-ID":{"s":0.75,"c":0.8,"he":true,"eq":0.7},...},"memories":[{"cat":"RELATIONSHIP","key":"family_pet","val":"dog called Fred","c":0.9,"e":"my dog is called Fred"},...]${learningJsonHint}}`;
 }
 
 /**
@@ -636,6 +640,21 @@ async function runPerSegmentScoring(
             : Math.max(0, Math.min(1, scoreData?.score ?? scoreData?.s ?? 0.5));
         const confidence = Math.max(0, Math.min(1, scoreData?.confidence ?? scoreData?.c ?? 0.7));
         const reasoning: string | undefined = scoreData?.reasoning ?? scoreData?.r ?? undefined;
+        // #566 Step 1 — evidence-aware fields. The IELTS per-segment prompt
+        // does not yet ask for these; leave null until the prompt is updated.
+        // Pattern matches the batched scorer for forward compatibility.
+        const hasLearnerEvidence =
+          typeof scoreData?.he === "boolean"
+            ? scoreData.he
+            : typeof scoreData?.hasLearnerEvidence === "boolean"
+              ? scoreData.hasLearnerEvidence
+              : null;
+        const evidenceQuality =
+          typeof scoreData?.eq === "number"
+            ? Math.max(0, Math.min(1, scoreData.eq))
+            : typeof scoreData?.evidenceQuality === "number"
+              ? Math.max(0, Math.min(1, scoreData.evidenceQuality))
+              : null;
 
         const existing = await prisma.callScore.findFirst({
           where: { callId: call.id, parameterId, moduleId: segmentModuleId },
@@ -650,6 +669,8 @@ async function runPerSegmentScoring(
               evidence: [`Segment: ${segment.slug}`],
               scoredBy: `${engine}_segment_v1`,
               scoredAt: new Date(),
+              hasLearnerEvidence,
+              evidenceQuality,
             },
           });
         } else {
@@ -664,6 +685,8 @@ async function runPerSegmentScoring(
               reasoning,
               evidence: [`Segment: ${segment.slug}`],
               scoredBy: `${engine}_segment_v1`,
+              hasLearnerEvidence,
+              evidenceQuality,
             },
           });
           segmentScoresCreated++;
@@ -892,6 +915,10 @@ async function runBatchedCallerAnalysis(
             evidence: ["Mock batched scoring"],
             scoredBy: "mock_batched_v1",
             scoredAt: new Date(),
+            // #566 Step 1 — mock engine has no LLM reasoning; leave evidence
+            // fields null (legacy path semantics per schema comment).
+            hasLearnerEvidence: null,
+            evidenceQuality: null,
           },
         });
       } else {
@@ -908,6 +935,9 @@ async function runBatchedCallerAnalysis(
             confidence: 0.7,
             evidence: ["Mock batched scoring"],
             scoredBy: "mock_batched_v1",
+            // #566 Step 1 — null sentinels (see above).
+            hasLearnerEvidence: null,
+            evidenceQuality: null,
           },
         });
       }
@@ -950,11 +980,31 @@ async function runBatchedCallerAnalysis(
       }
 
       // Store scores (handle both full and compact keys: score/s, confidence/c, reasoning/r)
+      // #566 Step 1 — also accept evidence-aware fields (he/hasLearnerEvidence, eq/evidenceQuality).
+      // Both fields default to null when the scorer LLM omits them (back-compat with old responses).
+      let shadowEvidencePresent = 0;
+      let shadowEvidenceAbsent = 0;
+      let shadowEvidenceUnknown = 0;
       if (parsed.scores) {
         for (const [parameterId, scoreData] of Object.entries(parsed.scores as Record<string, any>)) {
           const score = Math.max(0, Math.min(1, scoreData.score ?? scoreData.s ?? 0.5));
           const confidence = Math.max(0, Math.min(1, scoreData.confidence ?? scoreData.c ?? 0.7));
           const reasoning: string | undefined = scoreData.reasoning ?? scoreData.r ?? undefined;
+          const hasLearnerEvidence =
+            typeof scoreData.he === "boolean"
+              ? scoreData.he
+              : typeof scoreData.hasLearnerEvidence === "boolean"
+                ? scoreData.hasLearnerEvidence
+                : null;
+          const evidenceQuality =
+            typeof scoreData.eq === "number"
+              ? Math.max(0, Math.min(1, scoreData.eq))
+              : typeof scoreData.evidenceQuality === "number"
+                ? Math.max(0, Math.min(1, scoreData.evidenceQuality))
+                : null;
+          if (hasLearnerEvidence === true) shadowEvidencePresent++;
+          else if (hasLearnerEvidence === false) shadowEvidenceAbsent++;
+          else shadowEvidenceUnknown++;
 
           // Check if score already exists for this call+parameter
           const existing = await prisma.callScore.findFirst({
@@ -970,6 +1020,8 @@ async function runBatchedCallerAnalysis(
                 evidence: ["AI batched analysis"],
                 scoredBy: `${engine}_batched_v2`,
                 scoredAt: new Date(),
+                hasLearnerEvidence,
+                evidenceQuality,
               },
             });
           } else {
@@ -985,11 +1037,24 @@ async function runBatchedCallerAnalysis(
                 reasoning,
                 evidence: ["AI batched analysis"],
                 scoredBy: `${engine}_batched_v2`,
+                hasLearnerEvidence,
+                evidenceQuality,
               },
             });
           }
           scoresCreated++;
         }
+        // #566 Step 1 — shadow log of evidence-field coverage. Records what
+        // the scorer reported about learner-side evidence without changing
+        // any decision yet. Step 3 will use these counts to validate the
+        // evidence-aware gate before flipping IELTS playbooks over.
+        log.info("Evidence-aware scoring shadow telemetry", {
+          callId: call.id,
+          callerId,
+          present: shadowEvidencePresent,
+          absent: shadowEvidenceAbsent,
+          unknown: shadowEvidenceUnknown,
+        });
       }
 
       // #491 Slice 1.5 — per-part MEASURE for multi-attribute modules.

--- a/apps/admin/prisma/migrations/20260520_566_callscore_evidence_fields/migration.sql
+++ b/apps/admin/prisma/migrations/20260520_566_callscore_evidence_fields/migration.sql
@@ -1,0 +1,14 @@
+-- #566 Step 1: add nullable evidence-aware fields to CallScore.
+--
+-- Shadow fields populated by the batched scorer when the LLM returns the
+-- new `he` / `eq` keys. Legacy code paths (mock engine, segment runner with
+-- old prompt shape) leave them null. Step 3 of the mode-kill epic uses
+-- these fields to route IELTS-listed playbooks through an evidence-driven
+-- gate instead of the legacy mode-based gate.
+--
+-- Pure additive migration — no defaults, no backfill, no constraint
+-- changes. Safe under concurrent writes.
+
+ALTER TABLE "CallScore"
+  ADD COLUMN "hasLearnerEvidence" BOOLEAN,
+  ADD COLUMN "evidenceQuality" DOUBLE PRECISION;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -1486,6 +1486,22 @@ model CallScore {
   evidence   String[] // Array of evidence quotes
   reasoning  String?  @db.Text // LLM's reasoning for the score
 
+  // #566 Step 1 — evidence-aware scoring (shadow fields).
+  //
+  // Both fields are nullable in Step 1 because they are written ONLY by the
+  // new scorer prompt; legacy paths (mock engine, segment runner, etc.) leave
+  // them null. The mode-gate epic uses them in Step 3 to route IELTS-listed
+  // playbooks through an evidence-driven decision instead of mode-based.
+  //
+  // hasLearnerEvidence — true when the scorer LLM judged that the learner-side
+  // transcript contains scoreable evidence for this parameter. false when the
+  // score was derived from tutor prose only (Boaz S1-S4 hallucination shape).
+  //
+  // evidenceQuality — 0..1 confidence in the evidence quantity/quality
+  // (independent of confidence in the score itself).
+  hasLearnerEvidence Boolean? // null = legacy path; true/false = scorer judged evidence
+  evidenceQuality    Float?   // 0..1, null when not assessed
+
   // Spec-driven scoring
   analysisSpecId String? // Which AnalysisSpec was used
   scoredAt       DateTime @default(now())


### PR DESCRIPTION
Step 1 of the mode-kill epic (#566). Asks the scorer LLM to also return per-parameter evidence judgements; persists them as nullable shadow fields on CallScore. No decision flips yet — legacy mode-gate still drives allow/deny.

(Original PR #568 was auto-closed when Step 0's branch was deleted on merge. This is the same commit, rebased onto main.)

## What lands

- **Prisma migration `20260520_566_callscore_evidence_fields`** — adds two nullable columns to CallScore:
  - `hasLearnerEvidence` BOOLEAN — true when scorer judged the learner-side transcript contains scoreable evidence
  - `evidenceQuality` DOUBLE PRECISION — 0..1 confidence in evidence quantity/quality
  - Pure additive, no backfill, safe under concurrent writes
- **`buildBatchedCallerPrompt`** asks the scorer for `he` (boolean) and `eq` (0-1) on each parameter
- **Three CallScore write sites** plumb the new fields:
  - Real-engine batched path (`pipeline.measure`) parses + persists
  - Per-segment IELTS path accepts the fields for forward compat
  - Mock engine path explicitly writes null (legacy semantics)
- **Shadow telemetry log** per call: `{ present, absent, unknown }` counts

## Why

Boaz S1-S4 (`COMP_VOCABULARY = 0.85` in teach-only sessions) was the gate's reason for existing. With evidence-aware scoring, the scorer itself refuses to inflate scores when the learner hasn't produced evidence — making the mode-based gate redundant. Step 3 flips IELTS to evidence-driven; Step 8 removes the gate.

## Tests

- config: 76/76
- event-gate: 5/5
- adapt-runner: 28/28
- Combined: 139/139

No new tsc errors.

## Test plan

- [x] `npx vitest run tests/lib/config.test.ts tests/lib/pipeline/`
- [ ] `/vm-cpp` for the migration
- [ ] Re-run Caleb sim; observe shadow telemetry + DB rows with populated evidence fields
- [ ] Manually review any score with `hasLearnerEvidence=false but score > 0.5` (Goodhart signal)

## Deploy

`/vm-cpp` — schema migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)