### PR TITLE
feat(#566): step 2 — evidence pre-filter (shadow)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -25,6 +25,7 @@ import { requireAuth, isAuthError } from "@/lib/permissions";
 import { runAggregateSpecs } from "@/lib/pipeline/aggregate-runner";
 import { aggregateCallerMemorySummary } from "@/lib/ops/memory-extract";
 import { runAdaptSpecs as runRuleBasedAdapt } from "@/lib/pipeline/adapt-runner";
+import { runEvidencePrefilterBatch } from "@/lib/pipeline/evidence-prefilter";
 import { validateSpecDependencies } from "@/lib/pipeline/validate-dependencies";
 import { trackGoalProgress, applyAssessmentAdaptation } from "@/lib/goals/track-progress";
 import { evaluateCheckpoints } from "@/lib/assessment/checkpoint-evaluator";
@@ -958,6 +959,29 @@ async function runBatchedCallerAnalysis(
     const timeouts = await getAITimeoutSettings();
     const assessPromptInstructions = assessmentSpec ? (assessmentSpec.config as SpecConfig)?.promptInstructions : null;
     const prompt = buildBatchedCallerPrompt(transcript, measureParams, learnActions, transcriptLimit, moduleContext, assessPromptInstructions);
+
+    // #566 Step 2 — Evidence pre-filter shadow pass. Logs which params the
+    // deterministic check WOULD have skipped before the scorer LLM runs.
+    // Never actually skips — Step 3 wires the decision into the gate.
+    try {
+      const paramsForPrefilter = await prisma.parameter.findMany({
+        where: { parameterId: { in: measureParams.map((p) => p.parameterId) } },
+        select: { parameterId: true, name: true, definition: true, config: true },
+      });
+      const { summary: prefilterSummary } = runEvidencePrefilterBatch(
+        transcript,
+        paramsForPrefilter,
+      );
+      log.info("Evidence pre-filter shadow telemetry", {
+        callId: call.id,
+        callerId,
+        ...prefilterSummary,
+      });
+    } catch (err: any) {
+      log.warn("Evidence pre-filter shadow pass failed (non-blocking)", {
+        error: err?.message ?? "unknown",
+      });
+    }
 
     try {
       const result = await getConfiguredMeteredAICompletion({

--- a/apps/admin/lib/pipeline/evidence-prefilter.ts
+++ b/apps/admin/lib/pipeline/evidence-prefilter.ts
@@ -1,0 +1,235 @@
+/**
+ * Evidence pre-filter — Step 2 of the mode-kill epic (#566).
+ *
+ * Cheap deterministic check that runs BEFORE the scorer LLM:
+ *   "Does the learner-side transcript contain any tokens that could
+ *    plausibly evidence this parameter?"
+ *
+ * In Step 2 this is SHADOW ONLY — we log the decision but never skip the
+ * scorer. Lets us validate keyword coverage against what the scorer LLM
+ * judges (he/eq fields from Step 1) over a 24-hour window before Step 3
+ * trusts the pre-filter to gate scoring.
+ *
+ * Keyword cascade (highest priority first):
+ *   1. `Parameter.config.evidenceKeywords` — admin-curated string[]
+ *   2. Auto-derived tokens from `Parameter.name + Parameter.definition`
+ *      (lowercased, stopwords removed, dedup, cached in-process)
+ *   3. Fallback — when neither is present, returns `{ skip: false,
+ *      reason: "no-keywords-defined" }`. The pre-filter never skips on
+ *      missing data; it defers to the LLM and surfaces the gap via the
+ *      shadow log so we can backfill curated lists where it matters.
+ *
+ * The pre-filter NEVER decides anything in Step 2. It only reports.
+ */
+
+const STOPWORDS = new Set<string>([
+  "a", "an", "and", "are", "as", "at", "be", "but", "by", "can", "for",
+  "from", "has", "have", "he", "her", "him", "his", "how", "i", "in",
+  "is", "it", "its", "of", "on", "or", "she", "so", "that", "the",
+  "their", "them", "they", "this", "to", "was", "we", "were", "what",
+  "when", "which", "who", "why", "will", "with", "you", "your", "if",
+  "not", "no", "do", "does", "did", "any", "all", "some", "more",
+  "one", "two", "three", "much", "many",
+]);
+
+/**
+ * Compact representation of a Parameter for pre-filter purposes. The
+ * shape is intentionally minimal so callers can build it from any
+ * Prisma select they already have.
+ */
+export interface PrefilterParameter {
+  parameterId: string;
+  name?: string | null;
+  definition?: string | null;
+  /** `Parameter.config` JSON payload — may contain `evidenceKeywords`. */
+  config?: unknown;
+}
+
+export interface PrefilterDecision {
+  /** True when the pre-filter judges no scoreable evidence exists. */
+  skip: boolean;
+  /** Brief reason for the decision — surfaces in shadow logs. */
+  reason: string;
+  /** Word count from the learner-side ("User:") of the transcript. */
+  learnerWordCount: number;
+  /** Keywords that matched the learner-side text, capped at 8. */
+  matchedKeywords: string[];
+  /** Keyword source actually used — useful for debugging. */
+  source: "admin-override" | "auto-derived" | "missing";
+}
+
+const _autoDerivedCache = new Map<string, string[]>();
+
+/**
+ * Returns the keyword list to test against the transcript. Cached per
+ * parameterId for the lifetime of the process.
+ */
+export function getEvidenceKeywords(param: PrefilterParameter): {
+  keywords: string[];
+  source: PrefilterDecision["source"];
+} {
+  // 1. Admin override on Parameter.config.evidenceKeywords
+  if (param.config && typeof param.config === "object" && !Array.isArray(param.config)) {
+    const cfg = param.config as Record<string, unknown>;
+    const override = cfg.evidenceKeywords;
+    if (Array.isArray(override)) {
+      const cleaned = override
+        .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+        .map((s) => s.toLowerCase());
+      if (cleaned.length > 0) return { keywords: cleaned, source: "admin-override" };
+    }
+  }
+
+  // 2. Auto-derived from name + definition
+  const cached = _autoDerivedCache.get(param.parameterId);
+  if (cached) return { keywords: cached, source: "auto-derived" };
+
+  const fields: string[] = [];
+  if (typeof param.name === "string") fields.push(param.name);
+  if (typeof param.definition === "string") fields.push(param.definition);
+  const combined = fields.join(" ").toLowerCase();
+  const tokens = combined
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+  const dedup = [...new Set(tokens)];
+
+  if (dedup.length > 0) {
+    _autoDerivedCache.set(param.parameterId, dedup);
+    return { keywords: dedup, source: "auto-derived" };
+  }
+
+  return { keywords: [], source: "missing" };
+}
+
+/**
+ * Splits a transcript into the User-side text only. Pattern matches the
+ * "User: ..." / "Assistant: ..." line shape produced by every Call writer
+ * (sim-drive-call.ts, VAPI webhook, manual ingestion).
+ */
+export function extractLearnerText(transcript: string | null | undefined): string {
+  if (!transcript) return "";
+  const lines = transcript.split(/\r?\n+/);
+  const learnerLines: string[] = [];
+  let currentRole: "user" | "assistant" | "other" = "other";
+  for (const line of lines) {
+    const userMatch = /^\s*User\s*:\s*(.*)$/i.exec(line);
+    if (userMatch) {
+      currentRole = "user";
+      if (userMatch[1].trim()) learnerLines.push(userMatch[1]);
+      continue;
+    }
+    const assistantMatch = /^\s*Assistant\s*:\s*(.*)$/i.exec(line);
+    if (assistantMatch) {
+      currentRole = "assistant";
+      continue;
+    }
+    if (currentRole === "user" && line.trim()) {
+      learnerLines.push(line.trim());
+    }
+  }
+  return learnerLines.join("\n");
+}
+
+/**
+ * Runs the pre-filter for one parameter against one transcript.
+ * In Step 2 the `skip` flag is advisory — the scorer LLM still runs
+ * on every parameter regardless of this decision.
+ */
+export function checkEvidence(
+  transcript: string | null | undefined,
+  param: PrefilterParameter,
+  opts: { minLearnerWords?: number } = {},
+): PrefilterDecision {
+  const learnerText = extractLearnerText(transcript);
+  const learnerWordCount = learnerText.split(/\s+/).filter(Boolean).length;
+  const { keywords, source } = getEvidenceKeywords(param);
+
+  if (source === "missing") {
+    return {
+      skip: false,
+      reason: "no-keywords-defined",
+      learnerWordCount,
+      matchedKeywords: [],
+      source,
+    };
+  }
+
+  const minLearnerWords = opts.minLearnerWords ?? 10;
+  if (learnerWordCount < minLearnerWords) {
+    return {
+      skip: true,
+      reason: `learner-too-quiet (${learnerWordCount} < ${minLearnerWords} words)`,
+      learnerWordCount,
+      matchedKeywords: [],
+      source,
+    };
+  }
+
+  const haystack = learnerText.toLowerCase();
+  const matchedKeywords: string[] = [];
+  for (const kw of keywords) {
+    if (matchedKeywords.length >= 8) break;
+    if (haystack.includes(kw)) matchedKeywords.push(kw);
+  }
+
+  if (matchedKeywords.length === 0) {
+    return {
+      skip: true,
+      reason: "no-keyword-match",
+      learnerWordCount,
+      matchedKeywords,
+      source,
+    };
+  }
+
+  return {
+    skip: false,
+    reason: `matched ${matchedKeywords.length}/${keywords.length}`,
+    learnerWordCount,
+    matchedKeywords,
+    source,
+  };
+}
+
+/**
+ * Batched helper — runs the pre-filter against a list of parameters and
+ * aggregates counts for the shadow telemetry log.
+ */
+export interface PrefilterBatchSummary {
+  total: number;
+  wouldSkip: number;
+  wouldRun: number;
+  byReason: Record<string, number>;
+  bySource: Record<PrefilterDecision["source"], number>;
+}
+
+export function runEvidencePrefilterBatch(
+  transcript: string | null | undefined,
+  params: PrefilterParameter[],
+  opts: { minLearnerWords?: number } = {},
+): { decisions: Array<PrefilterDecision & { parameterId: string }>; summary: PrefilterBatchSummary } {
+  const decisions: Array<PrefilterDecision & { parameterId: string }> = [];
+  const summary: PrefilterBatchSummary = {
+    total: params.length,
+    wouldSkip: 0,
+    wouldRun: 0,
+    byReason: {},
+    bySource: { "admin-override": 0, "auto-derived": 0, missing: 0 },
+  };
+  for (const p of params) {
+    const d = checkEvidence(transcript, p, opts);
+    decisions.push({ parameterId: p.parameterId, ...d });
+    if (d.skip) summary.wouldSkip++;
+    else summary.wouldRun++;
+    summary.byReason[d.reason] = (summary.byReason[d.reason] ?? 0) + 1;
+    summary.bySource[d.source]++;
+  }
+  return { decisions, summary };
+}
+
+/** Test-only: clear the auto-derived cache between vitest cases. */
+export function __resetEvidenceKeywordCache(): void {
+  _autoDerivedCache.clear();
+}

--- a/apps/admin/tests/lib/pipeline/evidence-prefilter.test.ts
+++ b/apps/admin/tests/lib/pipeline/evidence-prefilter.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for `lib/pipeline/evidence-prefilter.ts` — Step 2 of mode-kill #566.
+ *
+ * The pre-filter is shadow-only in Step 2; these tests assert decision
+ * shape, transcript splitting, and the keyword cascade. Step 3 will add
+ * decision-correctness assertions against real Caleb sims.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  checkEvidence,
+  extractLearnerText,
+  getEvidenceKeywords,
+  runEvidencePrefilterBatch,
+  __resetEvidenceKeywordCache,
+} from "@/lib/pipeline/evidence-prefilter";
+
+beforeEach(() => {
+  __resetEvidenceKeywordCache();
+});
+
+const SAMPLE_TRANSCRIPT = `User: Hello, I work as a receptionist in a hotel in Warsaw.
+Assistant: Great — tell me more about your day.
+
+User: I greet guests, answer phone, check people in. Sometimes is busy, sometimes not.
+Assistant: How long have you been doing this?
+User: Almost two years, I think.
+Assistant: That's a lot of practice.`;
+
+const TUTOR_HEAVY_TRANSCRIPT = `User: hi
+Assistant: Let's discuss the importance of vocabulary in IELTS Speaking. Vocabulary is a wide-ranging topic that includes lexical resource, idiomatic expressions, paraphrasing, and topic-specific terms. When examiners assess your lexical resource, they look for variety, precision, and natural use of less common vocabulary items.`;
+
+describe("extractLearnerText", () => {
+  it("returns concatenated user-side lines only", () => {
+    const learner = extractLearnerText(SAMPLE_TRANSCRIPT);
+    expect(learner).toContain("Hello, I work as a receptionist");
+    expect(learner).toContain("Almost two years");
+    expect(learner).not.toContain("Great — tell me more");
+    expect(learner).not.toContain("That's a lot of practice");
+  });
+
+  it("returns empty string for null/undefined/empty transcript", () => {
+    expect(extractLearnerText(null)).toBe("");
+    expect(extractLearnerText(undefined)).toBe("");
+    expect(extractLearnerText("")).toBe("");
+  });
+
+  it("handles single-block transcript with no role tags", () => {
+    expect(extractLearnerText("Just some prose with no User: or Assistant: tags.")).toBe("");
+  });
+
+  it("preserves multi-line user replies until next role switch", () => {
+    const multiLine = `User: Line one
+Line two of same reply
+Assistant: switch
+User: Single line`;
+    const learner = extractLearnerText(multiLine);
+    expect(learner).toContain("Line one");
+    expect(learner).toContain("Line two of same reply");
+    expect(learner).toContain("Single line");
+    expect(learner).not.toContain("switch");
+  });
+});
+
+describe("getEvidenceKeywords — cascade", () => {
+  it("uses admin override when Parameter.config.evidenceKeywords is set", () => {
+    const result = getEvidenceKeywords({
+      parameterId: "TEST-1",
+      name: "Some Parameter",
+      definition: "Something abstract",
+      config: { evidenceKeywords: ["custom", "override", "keywords"] },
+    });
+    expect(result.source).toBe("admin-override");
+    expect(result.keywords).toEqual(["custom", "override", "keywords"]);
+  });
+
+  it("ignores empty/non-string entries in admin override and falls back to auto-derived", () => {
+    const result = getEvidenceKeywords({
+      parameterId: "TEST-2",
+      name: "Lexical Resource",
+      definition: "Vocabulary breadth and precision",
+      config: { evidenceKeywords: ["", "   ", 42, null] },
+    });
+    expect(result.source).toBe("auto-derived");
+    expect(result.keywords).toContain("lexical");
+    expect(result.keywords).toContain("resource");
+    expect(result.keywords).toContain("vocabulary");
+  });
+
+  it("auto-derives from name + definition, removing stopwords and short tokens", () => {
+    const result = getEvidenceKeywords({
+      parameterId: "TEST-3",
+      name: "Fluency and Coherence",
+      definition: "How smoothly the speaker maintains flow",
+    });
+    expect(result.source).toBe("auto-derived");
+    expect(result.keywords).toContain("fluency");
+    expect(result.keywords).toContain("coherence");
+    expect(result.keywords).toContain("smoothly");
+    // Stopwords (the, and, how) should be filtered
+    expect(result.keywords).not.toContain("the");
+    expect(result.keywords).not.toContain("and");
+    expect(result.keywords).not.toContain("how");
+  });
+
+  it("returns missing when no name/definition available", () => {
+    const result = getEvidenceKeywords({ parameterId: "TEST-4" });
+    expect(result.source).toBe("missing");
+    expect(result.keywords).toEqual([]);
+  });
+
+  it("caches auto-derived keywords per parameterId", () => {
+    const first = getEvidenceKeywords({
+      parameterId: "TEST-CACHE",
+      name: "Cached Param",
+      definition: "First definition",
+    });
+    // Subsequent call with different definition should hit cache and return same result
+    const second = getEvidenceKeywords({
+      parameterId: "TEST-CACHE",
+      name: "Different Name",
+      definition: "Different definition entirely",
+    });
+    expect(second.keywords).toEqual(first.keywords);
+  });
+});
+
+describe("checkEvidence — decision shape", () => {
+  it("returns no-keywords-defined when param has nothing to derive from", () => {
+    const result = checkEvidence(SAMPLE_TRANSCRIPT, { parameterId: "BARE" });
+    expect(result.skip).toBe(false); // never skips on missing data
+    expect(result.reason).toBe("no-keywords-defined");
+    expect(result.source).toBe("missing");
+  });
+
+  it("returns learner-too-quiet when learner word count below threshold", () => {
+    const result = checkEvidence("User: hi\nAssistant: long boring stuff", {
+      parameterId: "QUIET-TEST",
+      name: "Engagement",
+      definition: "How engaged the caller is in conversation",
+    }, { minLearnerWords: 5 });
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain("learner-too-quiet");
+  });
+
+  it("matches keywords from the learner side", () => {
+    const result = checkEvidence(SAMPLE_TRANSCRIPT, {
+      parameterId: "HOTEL-WORK",
+      name: "Workplace Context",
+      definition: "References to job, work, hotel, receptionist",
+    });
+    expect(result.skip).toBe(false);
+    expect(result.matchedKeywords.length).toBeGreaterThan(0);
+    expect(result.matchedKeywords).toEqual(
+      expect.arrayContaining(["work"]),
+    );
+  });
+
+  it("returns no-keyword-match when learner speech does not contain any keyword", () => {
+    const result = checkEvidence(SAMPLE_TRANSCRIPT, {
+      parameterId: "ASTRONAUT",
+      name: "Astrophysics Vocabulary",
+      definition: "References to galaxies nebulae quasars black holes",
+    });
+    expect(result.skip).toBe(true);
+    expect(result.reason).toBe("no-keyword-match");
+    expect(result.matchedKeywords).toEqual([]);
+  });
+
+  it("Boaz-shape: tutor-only vocabulary discussion produces no learner-side match", () => {
+    // The original bug shape — COMP_VOCABULARY scored high in a teach-only
+    // session. With evidence pre-filter, the learner says only "hi" so the
+    // pre-filter should mark this as skip even though the tutor talks
+    // extensively about vocabulary.
+    const result = checkEvidence(TUTOR_HEAVY_TRANSCRIPT, {
+      parameterId: "COMP_VOCABULARY",
+      name: "Comprehension Vocabulary",
+      definition: "Vocabulary breadth lexical resource paraphrasing",
+    }, { minLearnerWords: 5 });
+    expect(result.skip).toBe(true);
+    expect(["learner-too-quiet", "no-keyword-match"]).toContain(
+      result.reason.split(" ")[0],
+    );
+  });
+});
+
+describe("runEvidencePrefilterBatch — aggregate summary", () => {
+  it("tallies wouldSkip vs wouldRun across params", () => {
+    const params = [
+      { parameterId: "WORK", name: "Work", definition: "job hotel receptionist" },
+      { parameterId: "SPACE", name: "Space", definition: "galaxies nebulae" },
+      { parameterId: "BARE", name: null, definition: null },
+    ];
+    const result = runEvidencePrefilterBatch(SAMPLE_TRANSCRIPT, params);
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.wouldSkip + result.summary.wouldRun).toBe(3);
+    expect(result.decisions).toHaveLength(3);
+  });
+
+  it("counts sources correctly when mixed", () => {
+    const params = [
+      { parameterId: "P1", name: "Hotel Work", definition: "work hotel", config: { evidenceKeywords: ["hotel", "work"] } },
+      { parameterId: "P2", name: "Greeting", definition: "hello greeting" },
+      { parameterId: "P3" },
+    ];
+    const result = runEvidencePrefilterBatch(SAMPLE_TRANSCRIPT, params);
+    expect(result.summary.bySource["admin-override"]).toBe(1);
+    expect(result.summary.bySource["auto-derived"]).toBe(1);
+    expect(result.summary.bySource.missing).toBe(1);
+  });
+});


### PR DESCRIPTION
Step 2 of the mode-kill epic (#566). Pure function module that judges per-parameter whether the LEARNER's side of the transcript contains scoreable evidence — without invoking the scorer LLM. Shadow-only in this PR — logs decisions but never skips. Step 3 wires the decision into the IELTS-scoped gate.

**Stacked on PR #569 (Step 1).** Will rebase onto main when #569 merges.

## What lands

- **`lib/pipeline/evidence-prefilter.ts`** — pure functional module, no DB writes:
  - `extractLearnerText` — splits transcript on `User:` / `Assistant:` markers, returns user-side text only
  - `getEvidenceKeywords` — 3-layer cascade:
    1. `Parameter.config.evidenceKeywords` (admin override; takes priority)
    2. Auto-derived tokens from `Parameter.name + Parameter.definition` (lowercase, stopword-filtered, cached per param ID)
    3. `missing` source — fallback when neither is present; pre-filter defers to LLM
  - `checkEvidence` — per-parameter decision: `{ skip, reason, learnerWordCount, matchedKeywords, source }`
  - `runEvidencePrefilterBatch` — batched runner + aggregate `summary` for telemetry
  - `__resetEvidenceKeywordCache` — vitest hook
- **Pipeline wiring** — `pipeline.measure` invokes the batched pre-filter and logs telemetry just before the scorer LLM call. Scorer still runs on every parameter in Step 2; Step 3 trusts the decision for IELTS playbooks.

## Boaz contract test

A tutor-heavy transcript with a one-word learner reply produces `{ skip: true, reason: "learner-too-quiet" }`. This is exactly the shape that produced the original hallucinated `COMP_VOCABULARY = 0.85` score that motivated the mode-gate in the first place. The deterministic pre-filter catches it without an LLM round-trip.

## Where keyword values come from

| Layer | Source | This PR |
|---|---|---|
| 1 | `Parameter.config.evidenceKeywords` (admin override) | Reserved; not seeded yet. Step 3 seeds the 4 IELTS skill params. |
| 2 | Auto-derived from `name + definition` | Default for every parameter. Computed once, cached. |
| 3 | `missing` | Fallback; pre-filter defers to LLM (never skips on missing data). |

## Tests

`tests/lib/pipeline/evidence-prefilter.test.ts` — 16 new tests across:
- Transcript splitting (multi-line, missing tags, null safety)
- Keyword cascade (override → auto-derived → missing)
- Decision shape (learner-too-quiet, no-keyword-match, matched)
- Boaz S1-S4 shape reproduction
- Batch aggregation

All 16/16 pass.

## Rollback

Pure additive. Revert this commit + delete the module file. No DB writes, no migrations. Pipeline behavior identical to Step 1 without the new log line.

## Test plan

- [x] `npx vitest run tests/lib/pipeline/evidence-prefilter.test.ts` — 16/16
- [ ] `/vm-cp` to deploy on dev VM
- [ ] Re-run Caleb's 3-sim sequence; verify `Evidence pre-filter shadow telemetry` log line appears with sensible `wouldSkip` / `wouldRun` counts
- [ ] Cross-validate: compare pre-filter `wouldSkip` decisions against scorer-LLM `hasLearnerEvidence` (Step 1 shadow data) — should agree most of the time

## Deploy command

**`/vm-cp`** — no migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)