### PR TITLE
feat(#566): step 3 — flip IELTS evidence-first

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -26,6 +26,32 @@ import { runAggregateSpecs } from "@/lib/pipeline/aggregate-runner";
 import { aggregateCallerMemorySummary } from "@/lib/ops/memory-extract";
 import { runAdaptSpecs as runRuleBasedAdapt } from "@/lib/pipeline/adapt-runner";
 import { runEvidencePrefilterBatch } from "@/lib/pipeline/evidence-prefilter";
+import { isEvidenceFirstPlaybook } from "@/lib/pipeline/event-gate";
+
+/**
+ * #566 Step 3 — Boaz guard for evidence-first playbooks.
+ *
+ * When a playbook is opted into evidence-first scoring, the scorer's
+ * `hasLearnerEvidence` + `evidenceQuality` fields determine whether the
+ * row is persisted. Rows where the scorer judged "no learner evidence"
+ * AND assigned a non-trivial score are dropped — these are the Boaz
+ * S1-S4 shape (tutor-prose hallucinated as learner skill).
+ *
+ * Returns true when the row should be skipped, false when it should be
+ * persisted. Mode-gate playbooks always return false (no skip).
+ */
+const EVIDENCE_FIRST_BOAZ_THRESHOLD = 0.4;
+function shouldSkipForEvidenceFirst(
+  playbookId: string | null | undefined,
+  hasLearnerEvidence: boolean | null,
+  evidenceQuality: number | null,
+): boolean {
+  if (!isEvidenceFirstPlaybook(playbookId)) return false;
+  if (hasLearnerEvidence === false) return true;
+  if (hasLearnerEvidence === null) return false; // legacy paths
+  if (typeof evidenceQuality === "number" && evidenceQuality < EVIDENCE_FIRST_BOAZ_THRESHOLD) return true;
+  return false;
+}
 import { validateSpecDependencies } from "@/lib/pipeline/validate-dependencies";
 import { trackGoalProgress, applyAssessmentAdaptation } from "@/lib/goals/track-progress";
 import { evaluateCheckpoints } from "@/lib/assessment/checkpoint-evaluator";
@@ -1029,6 +1055,21 @@ async function runBatchedCallerAnalysis(
           if (hasLearnerEvidence === true) shadowEvidencePresent++;
           else if (hasLearnerEvidence === false) shadowEvidenceAbsent++;
           else shadowEvidenceUnknown++;
+
+          // #566 Step 3 — Boaz guard. For evidence-first playbooks, drop
+          // rows where the scorer judged the learner produced no evidence.
+          // The score itself is logged for audit but not persisted.
+          if (shouldSkipForEvidenceFirst(call.playbookId, hasLearnerEvidence, evidenceQuality)) {
+            log.info("Evidence-first Boaz guard: skipping score (no learner evidence)", {
+              callId: call.id,
+              callerId,
+              parameterId,
+              score,
+              hasLearnerEvidence,
+              evidenceQuality,
+            });
+            continue;
+          }
 
           // Check if score already exists for this call+parameter
           const existing = await prisma.callScore.findFirst({
@@ -2985,7 +3026,9 @@ const stageExecutors: Record<string, StageExecutor> = {
     // caller analysis enables: same function, zero params to score, full LEARN
     // path intact. Previously the whole call was skipped and memories were
     // silently dropped on every teach-mode call.
-    const gate = await shouldRunCallerAnalysis(ctx.callerId);
+    // #566 Step 3 — pass playbookId so evidence-first playbooks short-circuit
+    // the mode gate. Non-listed playbooks keep the legacy mode-based decision.
+    const gate = await shouldRunCallerAnalysis(ctx.callerId, ctx.call.playbookId);
 
     // #491 Slice 1.5 — Mock-style calls (bound module declares
     // `coversModules`) are explicit assessment events by definition.

--- a/apps/admin/config/evidence-first-playbooks.json
+++ b/apps/admin/config/evidence-first-playbooks.json
@@ -1,10 +1,16 @@
 {
   "_meta": {
-    "purpose": "Per-playbook override list for the mode-kill epic (#566). Playbook IDs listed here route through the new evidence-aware gate (introduced in Step 3) instead of the legacy mode-based event-gate. Empty in Step 0 — no playbook is opted in yet. Step 3 adds the IELTS Speaking Practice playbook as the first canary.",
+    "purpose": "Per-playbook override list for the mode-kill epic (#566). Playbook IDs listed here route through the new evidence-aware gate (introduced in Step 3) instead of the legacy mode-based event-gate. Step 3 opts the IELTS Speaking Practice playbook in as the first canary.",
     "epic": "#566",
-    "step": 0,
+    "step": 3,
     "lastUpdated": "2026-05-20",
-    "rollback": "Edit this file to [] and redeploy; mode gate resumes for all playbooks within 30 seconds."
+    "rollback": "Edit this file to set playbookIds to [] and redeploy; mode gate resumes for all playbooks within 30 seconds.",
+    "envFlagRequired": "EVIDENCE_FIRST_SCORING_ENABLED=true must also be set on the VM, or this list is ignored."
   },
-  "playbookIds": []
+  "playbookIds": [
+    "e460cd6f-0d0c-4948-9d8e-1ce696d4dfd3"
+  ],
+  "_notes": {
+    "e460cd6f-0d0c-4948-9d8e-1ce696d4dfd3": "IELTS Speaking Practice — Caleb Jaffe + Leo Pascual enrolled. Reference course for the mode-kill validation."
+  }
 }

--- a/apps/admin/lib/pipeline/event-gate.ts
+++ b/apps/admin/lib/pipeline/event-gate.ts
@@ -19,17 +19,51 @@ import { readSchedulerDecision, type SchedulerMode } from "./scheduler-decision"
  *
  * Slices 2 and 3 replace the per-mode allow/deny with per-paramId gating once
  * the real scheduler can emit a working set tagged with assessment coverage.
+ *
+ * Mode-kill epic #566 — Step 3:
+ *   When the call's playbook is listed in `evidence-first-playbooks.json`
+ *   AND the global flag `EVIDENCE_FIRST_SCORING_ENABLED` is true, this gate
+ *   short-circuits to allow=true with mode="evidence-first". The downstream
+ *   scorer + persistence layer enforces per-parameter Boaz protection using
+ *   the `hasLearnerEvidence` field (Step 1) and the pre-filter (Step 2).
+ *   The legacy mode-gate is preserved for all other playbooks.
  */
 
 export interface EventGateResult {
   allow: boolean;
-  mode: SchedulerMode | "unknown";
+  mode: SchedulerMode | "unknown" | "evidence-first";
   reason: string;
+}
+
+/**
+ * Determines whether the given playbook should bypass the mode-based gate
+ * and route through evidence-first per-parameter scoring instead.
+ *
+ * Returns true only when:
+ *   1. `EVIDENCE_FIRST_SCORING_ENABLED` env flag is "true"
+ *   2. `playbookId` is non-null AND present in `evidence-first-playbooks.json`
+ *
+ * Either condition false → returns false → legacy mode-gate handles the call.
+ */
+export function isEvidenceFirstPlaybook(playbookId: string | null | undefined): boolean {
+  if (!playbookId) return false;
+  if (!config.scheduler.evidenceFirstEnabled) return false;
+  return config.scheduler.evidenceFirstPlaybooks.includes(playbookId);
 }
 
 export async function shouldRunCallerAnalysis(
   callerId: string,
+  playbookId?: string | null,
 ): Promise<EventGateResult> {
+  // #566 Step 3 — evidence-first override.
+  if (isEvidenceFirstPlaybook(playbookId)) {
+    return {
+      allow: true,
+      mode: "evidence-first",
+      reason: `playbook ${playbookId} is opted into evidence-first scoring — per-parameter decisions delegated to scorer (hasLearnerEvidence) and pre-filter`,
+    };
+  }
+
   const prior = await readSchedulerDecision(callerId);
 
   if (!prior) {

--- a/apps/admin/tests/lib/pipeline/event-gate.test.ts
+++ b/apps/admin/tests/lib/pipeline/event-gate.test.ts
@@ -8,17 +8,24 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+// #566 Step 3 — mock includes the new evidenceFirst* fields. Hoisted so
+// vi.mock can reference it (vi.mock factories are hoisted above imports).
+const { mockSchedulerConfig } = vi.hoisted(() => ({
+  mockSchedulerConfig: {
+    assessmentModes: ["assess", "practice"],
+    placeholderMode: "teach",
+    evidenceFirstEnabled: false,
+    evidenceFirstPlaybooks: [] as string[],
+  },
+}));
 vi.mock("@/lib/config", () => ({
   config: {
-    scheduler: {
-      assessmentModes: ["assess", "practice"],
-      placeholderMode: "teach",
-    },
+    scheduler: mockSchedulerConfig,
   },
 }));
 
 import { prisma } from "@/lib/prisma";
-import { shouldRunCallerAnalysis } from "@/lib/pipeline/event-gate";
+import { shouldRunCallerAnalysis, isEvidenceFirstPlaybook } from "@/lib/pipeline/event-gate";
 
 const mockFindUnique = prisma.callerAttribute.findUnique as ReturnType<typeof vi.fn>;
 
@@ -63,6 +70,82 @@ describe("event-gate.shouldRunCallerAnalysis", () => {
   });
 
   it("allows scoring when prior decision was practice mode", async () => {
+    mockFindUnique.mockResolvedValue({
+      jsonValue: { mode: "practice", reason: "", writtenAt: "" },
+    });
+    const result = await shouldRunCallerAnalysis("caller-1");
+    expect(result.allow).toBe(true);
+    expect(result.mode).toBe("practice");
+  });
+});
+
+// =============================================================================
+// Mode-kill epic #566 — Step 3: evidence-first override
+// =============================================================================
+
+describe("event-gate — evidence-first playbook override (#566 Step 3)", () => {
+  beforeEach(() => {
+    mockFindUnique.mockReset();
+    mockSchedulerConfig.evidenceFirstEnabled = false;
+    mockSchedulerConfig.evidenceFirstPlaybooks = [];
+  });
+
+  it("isEvidenceFirstPlaybook returns false when flag is off", () => {
+    mockSchedulerConfig.evidenceFirstEnabled = false;
+    mockSchedulerConfig.evidenceFirstPlaybooks = ["pb-1"];
+    expect(isEvidenceFirstPlaybook("pb-1")).toBe(false);
+  });
+
+  it("isEvidenceFirstPlaybook returns false when playbook not in list", () => {
+    mockSchedulerConfig.evidenceFirstEnabled = true;
+    mockSchedulerConfig.evidenceFirstPlaybooks = ["pb-1"];
+    expect(isEvidenceFirstPlaybook("pb-2")).toBe(false);
+  });
+
+  it("isEvidenceFirstPlaybook returns true when flag is on AND playbook is listed", () => {
+    mockSchedulerConfig.evidenceFirstEnabled = true;
+    mockSchedulerConfig.evidenceFirstPlaybooks = ["pb-1"];
+    expect(isEvidenceFirstPlaybook("pb-1")).toBe(true);
+  });
+
+  it("isEvidenceFirstPlaybook returns false for null/undefined playbookId", () => {
+    mockSchedulerConfig.evidenceFirstEnabled = true;
+    mockSchedulerConfig.evidenceFirstPlaybooks = ["pb-1"];
+    expect(isEvidenceFirstPlaybook(null)).toBe(false);
+    expect(isEvidenceFirstPlaybook(undefined)).toBe(false);
+  });
+
+  it("evidence-first playbook short-circuits the mode gate even when prior is teach", async () => {
+    mockSchedulerConfig.evidenceFirstEnabled = true;
+    mockSchedulerConfig.evidenceFirstPlaybooks = ["pb-evidence-first"];
+    // Even if the prior decision is teach (which would normally block), the
+    // evidence-first override allows the call through. The downstream
+    // per-parameter Boaz guard decides whether each score is persisted.
+    mockFindUnique.mockResolvedValue({
+      jsonValue: { mode: "teach", reason: "", writtenAt: "" },
+    });
+    const result = await shouldRunCallerAnalysis("caller-1", "pb-evidence-first");
+    expect(result.allow).toBe(true);
+    expect(result.mode).toBe("evidence-first");
+    expect(result.reason).toMatch(/evidence-first/i);
+    // Verify the prior lookup was NOT consulted (gate short-circuited)
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("non-listed playbook still uses mode gate when evidence-first flag is on", async () => {
+    mockSchedulerConfig.evidenceFirstEnabled = true;
+    mockSchedulerConfig.evidenceFirstPlaybooks = ["pb-evidence-first"];
+    mockFindUnique.mockResolvedValue({
+      jsonValue: { mode: "teach", reason: "", writtenAt: "" },
+    });
+    const result = await shouldRunCallerAnalysis("caller-1", "pb-legacy");
+    expect(result.allow).toBe(false); // mode gate denies teach
+    expect(result.mode).toBe("teach");
+  });
+
+  it("no playbookId passed → mode gate applies (legacy callers)", async () => {
+    mockSchedulerConfig.evidenceFirstEnabled = true;
+    mockSchedulerConfig.evidenceFirstPlaybooks = ["pb-evidence-first"];
     mockFindUnique.mockResolvedValue({
       jsonValue: { mode: "practice", reason: "", writtenAt: "" },
     });


### PR DESCRIPTION
Step 3 — the first behaviour-changing PR in the mode-kill epic (#566). Flips the IELTS Speaking Practice playbook (e460cd6f...) to use evidence-aware per-parameter gating instead of the legacy call-level mode gate. All other playbooks keep the legacy mode gate.

## What flips for IELTS

- Calls that the prior mode gate would block (e.g. `mode=teach` after a teaching session) now run the scorer.
- Per-skill scores with real learner evidence (`hasLearnerEvidence: true`) persist.
- Per-skill scores hallucinated from tutor prose (`hasLearnerEvidence: false` OR `evidenceQuality < 0.4`) are dropped, with an audit log.
- Boaz S1-S4 stays fixed — by a SHARPER mechanism. The decision moves from "what was the prior call's mode?" to "did THIS learner produce evidence for THIS parameter on THIS call?"

## What stays unchanged for other playbooks

- Legacy mode gate (`shouldRunCallerAnalysis`) returns identical decisions.
- New evidence fields (`hasLearnerEvidence`, `evidenceQuality`) populate but are advisory only.
- Boaz guard short-circuits to "no skip" for non-listed playbooks.

## Live validation already captured

Caleb's last sim (before Step 3 active) recorded **skill_pronunciation: score=0.60, he=false, eq=0.30** — a textbook Boaz pattern. The scorer correctly flagged that text-mode Caleb has no audio-derived pronunciation evidence, but still wrote 0.60. With Step 3 active, this row would not persist. That's the unit-test-in-production for this PR.

## Activation requires BOTH

1. `config/evidence-first-playbooks.json` lists the playbook ID ✓ (this PR)
2. `EVIDENCE_FIRST_SCORING_ENABLED=true` on the VM (manual env edit)

If only one is set, behaviour is identical to today. If both: IELTS routes through evidence-aware path. Removing either side rolls back in under 30s.

## Rollback

- Edit `config/evidence-first-playbooks.json` → set `playbookIds: []` → redeploy
- OR unset `EVIDENCE_FIRST_SCORING_ENABLED` on the VM → restart dev server

## Tests

- event-gate: 5 → 12 (added 7 evidence-first cases incl. flag-off paths, playbook-not-listed, short-circuit verification)
- All 104/104 pass across config + event-gate + evidence-prefilter
- No tsc regressions

## Test plan

- [x] `npx vitest run tests/lib/pipeline/event-gate.test.ts` — 12/12
- [ ] `/vm-cp` to deploy
- [ ] Manually set `EVIDENCE_FIRST_SCORING_ENABLED=true` in VM's `.env.local`
- [ ] Restart dev server (flag is read at request time but JSON cache is per-process)
- [ ] Re-run Caleb's 3-sim sequence; verify:
  - Calls 1+2 (previously gated to `mode=teach`) now run the scorer
  - Pronunciation score does NOT persist when transcript is text-only
  - All other IELTS skill scores DO persist when learner evidence exists
  - Audit log shows `Evidence-first Boaz guard: skipping score` for the hallucinated cases

## Deploy command

**`/vm-cp` + manual env edit.** No migration. Flag must be set on the VM before evidence-first takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)