### PR TITLE
feat(#564): rubric band descriptors → Parameter.config.bandThresholds

### DIFF
--- a/apps/admin/lib/wizard/__tests__/parse-rubric-bands.test.ts
+++ b/apps/admin/lib/wizard/__tests__/parse-rubric-bands.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parseRubricBands } from "@/lib/wizard/parse-rubric-bands";
+
+describe("parseRubricBands — synthetic input", () => {
+  it("parses a single RUB heading + 10-band table", () => {
+    const md = `# Rubric
+
+Some intro text.
+
+## RUB-FC: Fluency and Coherence — band descriptors
+
+| Band | Descriptor |
+| ---- | ---------- |
+| 9 | Fluent with only very occasional repetition. |
+| 8 | Fluent with only very occasional repetition. |
+| 7 | Keeps going and produces long turns without noticeable effort. |
+| 6 | Keeps going and produces long turns. |
+| 5 | Usually keeps going but relies on repetition. |
+| 4 | Unable to keep going without noticeable pauses. |
+| 3 | Frequent, sometimes long pauses. |
+| 2 | Lengthy pauses before nearly every word. |
+| 1 | Essentially none. Speech is totally incoherent. |
+| 0 | Does not attend / does not complete. |
+`;
+    const r = parseRubricBands(md);
+    expect(r.criteria).toHaveLength(1);
+    expect(r.criteria[0].code).toBe("fc");
+    expect(r.criteria[0].criterionName).toBe("Fluency and Coherence — band descriptors");
+    expect(Object.keys(r.criteria[0].bands)).toHaveLength(10);
+    expect(r.criteria[0].bands["9"]).toContain("Fluent");
+    expect(r.criteria[0].bands["0"]).toContain("Does not attend");
+    expect(r.warnings).toHaveLength(0);
+  });
+
+  it("parses multiple RUB headings independently", () => {
+    const md = `## RUB-FC: Fluency
+
+| Band | Descriptor |
+| 9 | Top FC band descriptor |
+| 5 | Mid FC band descriptor |
+
+## RUB-LR: Lexical Resource
+
+| Band | Descriptor |
+| 9 | Top LR band descriptor |
+| 5 | Mid LR band descriptor |
+`;
+    const r = parseRubricBands(md);
+    expect(r.criteria).toHaveLength(2);
+    expect(r.criteria[0].code).toBe("fc");
+    expect(r.criteria[1].code).toBe("lr");
+    expect(r.criteria[0].bands["9"]).toContain("Top FC");
+    expect(r.criteria[1].bands["9"]).toContain("Top LR");
+  });
+
+  it("stops parsing a section at a non-RUB H2 boundary", () => {
+    const md = `## RUB-FC: Fluency
+
+| Band | Descriptor |
+| 9 | Stays in scope |
+
+## Scoring rules (assessor-only)
+
+| Band | Descriptor |
+| 9 | NOT a band table — should be ignored |
+`;
+    const r = parseRubricBands(md);
+    expect(r.criteria).toHaveLength(1);
+    expect(r.criteria[0].bands["9"]).toBe("Stays in scope");
+  });
+
+  it("warns when a RUB heading has no following band table", () => {
+    const md = `## RUB-FC: Fluency
+
+Some prose but no table.
+
+## RUB-LR: Lexical
+
+| Band | Descriptor |
+| 9 | Has bands |
+`;
+    const r = parseRubricBands(md);
+    expect(r.criteria).toHaveLength(1);
+    expect(r.criteria[0].code).toBe("lr");
+    expect(r.warnings).toHaveLength(1);
+    expect(r.warnings[0]).toContain("RUB-FC");
+  });
+
+  it("skips alignment + header rows", () => {
+    const md = `## RUB-FC: Fluency
+
+| Band | Descriptor |
+| ---- | ---------- |
+| 9 | Real descriptor here |
+`;
+    const r = parseRubricBands(md);
+    expect(Object.keys(r.criteria[0].bands)).toEqual(["9"]);
+  });
+
+  it("returns empty result for input with no RUB headings", () => {
+    const r = parseRubricBands("# Just a doc\n\nNo rubric content.");
+    expect(r.criteria).toHaveLength(0);
+    expect(r.warnings).toHaveLength(0);
+  });
+
+  it("handles decimal band numbers (e.g. half-bands)", () => {
+    const md = `## RUB-FC: Fluency
+
+| Band | Descriptor |
+| 6.5 | Half-band descriptor |
+| 7 | Whole-band descriptor |
+`;
+    const r = parseRubricBands(md);
+    expect(r.criteria[0].bands["6.5"]).toContain("Half");
+    expect(r.criteria[0].bands["7"]).toContain("Whole");
+  });
+});
+
+describe("parseRubricBands — real IELTS rubric", () => {
+  const rubricPath = path.resolve(
+    __dirname,
+    "../../../../docs/external/ielts/ielts-speaking/Upload Docs/assessor-rubric.md",
+  );
+
+  it.runIf(fs.existsSync(rubricPath))(
+    "parses 4 criteria × 10 bands from the live IELTS rubric file",
+    () => {
+      const text = fs.readFileSync(rubricPath, "utf-8");
+      const r = parseRubricBands(text);
+      expect(r.criteria.map((c) => c.code)).toEqual(["fc", "lr", "gra", "p"]);
+      for (const c of r.criteria) {
+        expect(
+          Object.keys(c.bands),
+          `${c.code} should have at least 10 bands`,
+        ).toEqual(expect.arrayContaining(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]));
+      }
+      expect(r.warnings).toHaveLength(0);
+    },
+  );
+});

--- a/apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts
+++ b/apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts
@@ -35,8 +35,11 @@ vi.mock("@/lib/content-trust/extract-assertions", () => ({
   extractTextFromBuffer: mockExtractTextFromBuffer,
 }));
 
+const mockWriteBandThresholds = vi.fn().mockResolvedValue({ parametersUpdated: 0, unmatchedCodes: [] });
+
 vi.mock("../apply-projection", () => ({
   applyProjection: mockApplyProjection,
+  writeBandThresholds: mockWriteBandThresholds,
 }));
 
 // ── Suite ──────────────────────────────────────────────────────────────────
@@ -46,11 +49,37 @@ beforeEach(() => {
   mockStorageDownload.mockReset();
   mockExtractTextFromBuffer.mockReset();
   mockApplyProjection.mockReset();
+  mockWriteBandThresholds.mockReset();
+  mockWriteBandThresholds.mockResolvedValue({ parametersUpdated: 0, unmatchedCodes: [] });
+
+  // #564 — every test exercises TWO findMany calls (COURSE_REFERENCE pass +
+  // ASSESSOR_RUBRIC pass). Mock the COURSE_REFERENCE side per-test via
+  // setSources(); the ASSESSOR_RUBRIC side defaults to empty unless a test
+  // calls setRubricSources().
+  mockPrismaState.playbookSource.findMany.mockImplementation((args: any) => {
+    const docType = args?.where?.source?.documentType;
+    if (docType === "COURSE_REFERENCE_ASSESSOR_RUBRIC") {
+      return Promise.resolve(testState.rubricSources);
+    }
+    return Promise.resolve(testState.courseRefSources);
+  });
 });
+
+const testState: { courseRefSources: unknown[]; rubricSources: unknown[] } = {
+  courseRefSources: [],
+  rubricSources: [],
+};
+const setSources = (sources: unknown[]) => {
+  testState.courseRefSources = sources;
+  testState.rubricSources = [];
+};
+const setRubricSources = (sources: unknown[]) => {
+  testState.rubricSources = sources;
+};
 
 describe("runProjectionForPlaybook", () => {
   it("returns degenerate=true when no COURSE_REFERENCE source is linked", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([]);
+    setSources([]);
 
     const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
     const result = await runProjectionForPlaybook(PLAYBOOK_ID);
@@ -62,7 +91,7 @@ describe("runProjectionForPlaybook", () => {
   });
 
   it("skips a source with no MediaAsset and logs the reason", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([
+    setSources([
       {
         source: {
           id: "src-1",
@@ -84,7 +113,7 @@ describe("runProjectionForPlaybook", () => {
   });
 
   it("skips a source whose storage download throws (extraction race)", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([
+    setSources([
       {
         source: {
           id: "src-2",
@@ -105,7 +134,7 @@ describe("runProjectionForPlaybook", () => {
   });
 
   it("skips a source whose extracted text is empty", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([
+    setSources([
       {
         source: {
           id: "src-3",
@@ -126,7 +155,7 @@ describe("runProjectionForPlaybook", () => {
   });
 
   it("loads, projects, and applies an IELTS COURSE_REFERENCE — expect 4 BTs + 5 modules", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([
+    setSources([
       {
         source: {
           id: "src-ielts",
@@ -173,7 +202,7 @@ describe("runProjectionForPlaybook", () => {
   });
 
   it("logs LO counts alongside params/bt/cm/goals in the applied line (#365)", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([
+    setSources([
       {
         source: {
           id: "src-ielts",
@@ -217,7 +246,7 @@ describe("runProjectionForPlaybook", () => {
   });
 
   it("excludes COURSE_REFERENCE_ASSESSOR_RUBRIC from the documentType filter (#447)", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([]);
+    setSources([]);
 
     const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
     await runProjectionForPlaybook(PLAYBOOK_ID);
@@ -232,7 +261,7 @@ describe("runProjectionForPlaybook", () => {
   });
 
   it("applies multiple COURSE_REFERENCE sources in order, accumulating results", async () => {
-    mockPrismaState.playbookSource.findMany.mockResolvedValue([
+    setSources([
       {
         source: {
           id: "src-a",
@@ -272,5 +301,143 @@ describe("runProjectionForPlaybook", () => {
 
     expect(result.appliedSources.map((s) => s.sourceContentId)).toEqual(["src-a", "src-b"]);
     expect(mockApplyProjection).toHaveBeenCalledTimes(2);
+  });
+
+  // ── #564 — rubric-only second pass ────────────────────────────────────────
+
+  it("runs the rubric pass alongside the main pass when an ASSESSOR_RUBRIC source is linked", async () => {
+    setSources([
+      {
+        source: {
+          id: "src-courseref",
+          name: "IELTS Course-ref",
+          mediaAssets: [{ storageKey: "ck", fileName: "course-ref.md" }],
+        },
+      },
+    ]);
+    setRubricSources([
+      {
+        source: {
+          id: "src-rubric",
+          name: "IELTS Rubric",
+          mediaAssets: [{ storageKey: "rk", fileName: "assessor-rubric.md" }],
+        },
+      },
+    ]);
+    // Course-ref text triggers normal projection; rubric text has RUB-FC heading + table
+    mockStorageDownload.mockImplementation((key: string) =>
+      key === "rk"
+        ? Promise.resolve(
+            Buffer.from(`## RUB-FC: Fluency
+
+| Band | Descriptor |
+| 9 | Top FC band |
+| 5 | Mid FC band |
+`),
+          )
+        : Promise.resolve(Buffer.from(IELTS_V22)),
+    );
+    mockExtractTextFromBuffer.mockImplementation((buffer: Buffer) => ({
+      text: buffer.toString("utf-8"),
+      fileType: "text",
+    }));
+    mockApplyProjection.mockResolvedValue({
+      parametersUpserted: 4,
+      behaviorTargetsCreated: 4,
+      behaviorTargetsUpdated: 0,
+      behaviorTargetsRemoved: 0,
+      curriculumModulesCreated: 5,
+      curriculumModulesUpdated: 0,
+      curriculumModulesRemoved: 0,
+      learningObjectivesCreated: 27,
+      learningObjectivesUpdated: 0,
+      learningObjectivesRemoved: 0,
+      goalTemplatesWritten: 25,
+      curriculumId: "curr-1",
+      measureSpecId: "spec-1",
+      measureTriggerCount: 1,
+      warnings: [],
+      noop: false,
+    });
+    mockWriteBandThresholds.mockResolvedValue({
+      parametersUpdated: 1,
+      unmatchedCodes: [],
+    });
+
+    const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
+    const result = await runProjectionForPlaybook(PLAYBOOK_ID);
+
+    // Main pass succeeded
+    expect(result.appliedSources.map((s) => s.sourceContentId)).toEqual(["src-courseref"]);
+    // Rubric pass invoked writeBandThresholds with the parsed FC band map
+    expect(mockWriteBandThresholds).toHaveBeenCalledTimes(1);
+    const writeCall = mockWriteBandThresholds.mock.calls[0];
+    expect(writeCall[0]).toEqual({ playbookId: PLAYBOOK_ID, sourceContentId: "src-rubric" });
+    const bandMap = writeCall[1] as Map<string, Record<string, string>>;
+    expect(bandMap.has("fc")).toBe(true);
+    expect(bandMap.get("fc")?.["9"]).toContain("Top FC");
+    // Result reports the rubric pass outcome
+    expect(result.rubricBandsApplied).toEqual([
+      {
+        sourceContentId: "src-rubric",
+        sourceName: "IELTS Rubric",
+        parametersUpdated: 1,
+        unmatchedCodes: [],
+      },
+    ]);
+  });
+
+  it("logs zero rubric activity when no RUB-* sections are found in a rubric source", async () => {
+    setSources([
+      {
+        source: {
+          id: "src-courseref",
+          name: "IELTS Course-ref",
+          mediaAssets: [{ storageKey: "ck", fileName: "course-ref.md" }],
+        },
+      },
+    ]);
+    setRubricSources([
+      {
+        source: {
+          id: "src-rubric",
+          name: "Boring rubric",
+          mediaAssets: [{ storageKey: "rk", fileName: "boring.md" }],
+        },
+      },
+    ]);
+    mockStorageDownload.mockImplementation((key: string) =>
+      key === "rk"
+        ? Promise.resolve(Buffer.from("# No RUB headings here\n\nJust prose."))
+        : Promise.resolve(Buffer.from(IELTS_V22)),
+    );
+    mockExtractTextFromBuffer.mockImplementation((buffer: Buffer) => ({
+      text: buffer.toString("utf-8"),
+      fileType: "text",
+    }));
+    mockApplyProjection.mockResolvedValue({
+      parametersUpserted: 0,
+      behaviorTargetsCreated: 0,
+      behaviorTargetsUpdated: 0,
+      behaviorTargetsRemoved: 0,
+      curriculumModulesCreated: 0,
+      curriculumModulesUpdated: 0,
+      curriculumModulesRemoved: 0,
+      learningObjectivesCreated: 0,
+      learningObjectivesUpdated: 0,
+      learningObjectivesRemoved: 0,
+      goalTemplatesWritten: 0,
+      curriculumId: "curr-1",
+      measureSpecId: null,
+      measureTriggerCount: 0,
+      warnings: [],
+      noop: true,
+    });
+
+    const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
+    const result = await runProjectionForPlaybook(PLAYBOOK_ID);
+
+    expect(mockWriteBandThresholds).not.toHaveBeenCalled();
+    expect(result.rubricBandsApplied).toEqual([]);
   });
 });

--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -706,3 +706,82 @@ export async function applyProjection(
     };
   });
 }
+
+
+// ── Rubric band-thresholds writer (#564) ────────────────────────────────────
+
+/**
+ * Mapping from rubric criterion code (e.g. "fc") to its band → descriptor
+ * lookup. Built by parseRubricBands() and consumed by writeBandThresholds()
+ * to update Parameter.config on existing skill parameters.
+ */
+export type RubricBandMap = Map<string, Record<string, string>>;
+
+export interface WriteBandThresholdsResult {
+  parametersUpdated: number;
+  /** Codes for which no matching skill parameter was found. */
+  unmatchedCodes: string[];
+}
+
+/**
+ * Apply per-band descriptor maps to existing skill Parameter rows.
+ *
+ * Matching strategy: for each criterion code (e.g. "fc"), find the unique
+ * skill parameter whose `parameterId` ends with `_<code>` (case-insensitive),
+ * scoped to `parameterId LIKE 'skill_%'` to avoid false positives.
+ *
+ * Idempotent: re-running with the same input produces no changes beyond
+ * `updatedAt`. Never creates new parameters — matches against existing
+ * ones written by the main projection pass.
+ *
+ * Issue #564.
+ */
+export async function writeBandThresholds(
+  options: { playbookId: string; sourceContentId: string },
+  bandMap: RubricBandMap,
+): Promise<WriteBandThresholdsResult> {
+  if (bandMap.size === 0) {
+    return { parametersUpdated: 0, unmatchedCodes: [] };
+  }
+
+  const result: WriteBandThresholdsResult = {
+    parametersUpdated: 0,
+    unmatchedCodes: [],
+  };
+
+  // Pull all skill parameters in one query — small set (≤ a dozen rows).
+  const skillParams = await prisma.parameter.findMany({
+    where: { parameterId: { startsWith: "skill_" } },
+    select: { parameterId: true, config: true },
+  });
+
+  for (const [code, bands] of bandMap) {
+    const suffix = `_${code.toLowerCase()}`;
+    const match = skillParams.find((p) => p.parameterId.toLowerCase().endsWith(suffix));
+    if (!match) {
+      result.unmatchedCodes.push(code);
+      continue;
+    }
+
+    const existing = (match.config as Record<string, unknown> | null) ?? {};
+    const merged = {
+      ...existing,
+      bandThresholds: bands,
+    };
+
+    await prisma.parameter.update({
+      where: { parameterId: match.parameterId },
+      data: { config: merged as Prisma.InputJsonValue },
+    });
+    result.parametersUpdated += 1;
+  }
+
+  if (result.unmatchedCodes.length > 0) {
+    console.warn(
+      `[apply-projection] writeBandThresholds: no skill parameter matched RUB codes ` +
+        `[${result.unmatchedCodes.join(", ")}] (playbook=${options.playbookId} source=${options.sourceContentId})`,
+    );
+  }
+
+  return result;
+}

--- a/apps/admin/lib/wizard/parse-rubric-bands.ts
+++ b/apps/admin/lib/wizard/parse-rubric-bands.ts
@@ -1,0 +1,102 @@
+/**
+ * parse-rubric-bands.ts
+ *
+ * Pure parser for COURSE_REFERENCE_ASSESSOR_RUBRIC markdown documents.
+ * Extracts per-criterion Band 0–9 descriptor tables and returns them keyed
+ * by RUB code (e.g. "FC", "LR", "GRA", "P" for IELTS Speaking). Used by
+ * the rubric-only second projection pass to populate
+ * `Parameter.config.bandThresholds` on skill parameters.
+ *
+ * Stays pure: no DB calls, no AI, no side effects. Composable with
+ * `run-projection-for-playbook.ts::runProjectionForPlaybook`.
+ *
+ * Issue #564 (builds the implementation called out in #561).
+ *
+ * @canonical-doc docs/CONTENT-PIPELINE.md §4 Phase 2.5 — rubric-only pass
+ */
+
+const RUB_HEADING = /^##\s+RUB-([A-Za-z0-9]+)\s*:\s*(.+?)\s*$/;
+const BAND_TABLE_ROW = /^\s*\|\s*(\d+(?:\.\d+)?)\s*\|\s*(.+?)\s*\|\s*$/;
+// Any other H2 heading ends the current rubric section.
+const SECTION_BOUNDARY = /^##\s+/;
+
+/** One per RUB-XX heading — `code` is the suffix tag, `bands` is band→text. */
+export interface ParsedRubricCriterion {
+  /** Lowercased rubric code, e.g. "fc", "lr", "gra", "p". */
+  code: string;
+  /** Original criterion name from the heading, for logs and warnings. */
+  criterionName: string;
+  /** Band number → descriptor text. Bands may be integers or decimals. */
+  bands: Record<string, string>;
+}
+
+export interface ParseRubricBandsResult {
+  criteria: ParsedRubricCriterion[];
+  /**
+   * Soft warnings emitted by the parser — e.g. a heading with no following
+   * band table. Surfaced by the caller for log visibility; never thrown.
+   */
+  warnings: string[];
+}
+
+/**
+ * Scan a rubric markdown body for `## RUB-XX: Criterion Name` headings
+ * followed by `| Band | Descriptor |` tables. Returns one ParsedRubricCriterion
+ * per heading.
+ *
+ * The function is forgiving:
+ *   - extra prose lines between heading and table are skipped
+ *   - the `| Band | Descriptor |` header row + alignment row are tolerated
+ *   - a rubric section ending without a table is reported as a warning
+ *     (rather than dropped silently)
+ */
+export function parseRubricBands(bodyText: string): ParseRubricBandsResult {
+  const lines = bodyText.split(/\r?\n/);
+  const criteria: ParsedRubricCriterion[] = [];
+  const warnings: string[] = [];
+
+  let current: ParsedRubricCriterion | null = null;
+
+  const flush = () => {
+    if (!current) return;
+    if (Object.keys(current.bands).length === 0) {
+      warnings.push(
+        `RUB-${current.code.toUpperCase()} (${current.criterionName}) — no band rows parsed`,
+      );
+    } else {
+      criteria.push(current);
+    }
+    current = null;
+  };
+
+  for (const line of lines) {
+    const heading = RUB_HEADING.exec(line);
+    if (heading) {
+      flush();
+      current = {
+        code: heading[1].toLowerCase(),
+        criterionName: heading[2].trim(),
+        bands: {},
+      };
+      continue;
+    }
+    if (current && SECTION_BOUNDARY.test(line)) {
+      flush();
+      continue;
+    }
+    if (!current) continue;
+
+    const row = BAND_TABLE_ROW.exec(line);
+    if (!row) continue;
+    const band = row[1];
+    const descriptor = row[2].trim();
+    // Skip alignment + header rows (e.g. `|-----|` or `| Band | Descriptor |`).
+    if (/^[-:|\s]+$/.test(descriptor)) continue;
+    if (/^Descriptor$/i.test(descriptor)) continue;
+    if (descriptor.length < 5) continue;
+    current.bands[band] = descriptor;
+  }
+
+  flush();
+  return { criteria, warnings };
+}

--- a/apps/admin/lib/wizard/run-projection-for-playbook.ts
+++ b/apps/admin/lib/wizard/run-projection-for-playbook.ts
@@ -18,8 +18,14 @@
 import { prisma } from "@/lib/prisma";
 import { getStorageAdapter } from "@/lib/storage";
 import { extractTextFromBuffer } from "@/lib/content-trust/extract-assertions";
-import { applyProjection, type ApplyProjectionResult } from "./apply-projection";
+import {
+  applyProjection,
+  writeBandThresholds,
+  type ApplyProjectionResult,
+  type RubricBandMap,
+} from "./apply-projection";
 import { projectCourseReference } from "./project-course-reference";
+import { parseRubricBands } from "./parse-rubric-bands";
 
 export interface RunProjectionResult {
   playbookId: string;
@@ -29,6 +35,17 @@ export interface RunProjectionResult {
   skippedSources: Array<{ sourceContentId: string; sourceName: string; reason: string }>;
   /** True when no COURSE_REFERENCE source is linked at all — course is degenerate. */
   degenerate: boolean;
+  /**
+   * #564 — Rubric-only second pass results. Tracks which
+   * COURSE_REFERENCE_ASSESSOR_RUBRIC sources contributed band thresholds and
+   * how many Parameter.config.bandThresholds writes landed.
+   */
+  rubricBandsApplied: Array<{
+    sourceContentId: string;
+    sourceName: string;
+    parametersUpdated: number;
+    unmatchedCodes: string[];
+  }>;
 }
 
 /**
@@ -71,7 +88,7 @@ export async function runProjectionForPlaybook(playbookId: string): Promise<RunP
     console.warn(
       `[projection] no COURSE_REFERENCE source linked to playbook=${playbookId} — course is degenerate (no Goals/BehaviorTargets/CurriculumModule derived). See docs/CONTENT-PIPELINE.md §4 Phase 2.5.`,
     );
-    return { playbookId, appliedSources: [], skippedSources: [], degenerate: true };
+    return { playbookId, appliedSources: [], skippedSources: [], degenerate: true, rubricBandsApplied: [] };
   }
 
   const appliedSources: RunProjectionResult["appliedSources"] = [];
@@ -146,10 +163,105 @@ export async function runProjectionForPlaybook(playbookId: string): Promise<RunP
     });
   }
 
+  // ── #564 — Rubric-only second pass ───────────────────────────────────────
+  //
+  // Load COURSE_REFERENCE_ASSESSOR_RUBRIC sources and feed their band
+  // descriptor tables into Parameter.config.bandThresholds via the writer
+  // helper. Goal templates / curriculum / behavior targets are NOT touched
+  // by this pass — those exclusions from the main loop above remain
+  // intentional (see #447 fix-chain).
+  const rubricBandsApplied: RunProjectionResult["rubricBandsApplied"] = [];
+  const rubricLinks = await prisma.playbookSource.findMany({
+    where: {
+      playbookId,
+      source: { documentType: "COURSE_REFERENCE_ASSESSOR_RUBRIC" },
+    },
+    select: {
+      source: {
+        select: {
+          id: true,
+          name: true,
+          mediaAssets: { select: { storageKey: true, fileName: true }, take: 1 },
+        },
+      },
+    },
+  });
+
+  for (const link of rubricLinks) {
+    const source = link.source;
+    const media = source.mediaAssets[0];
+    if (!media) {
+      console.warn(
+        `[projection] rubric pass: skipping source=${source.id} (${source.name}) — no MediaAsset`,
+      );
+      skippedSources.push({
+        sourceContentId: source.id,
+        sourceName: source.name,
+        reason: "rubric-no-media-asset",
+      });
+      continue;
+    }
+    let text = "";
+    try {
+      const buffer = await storage.download(media.storageKey);
+      const extracted = await extractTextFromBuffer(buffer, media.fileName);
+      text = extracted.text ?? "";
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[projection] rubric pass: failed to load text for source=${source.id}: ${msg}`,
+      );
+      skippedSources.push({
+        sourceContentId: source.id,
+        sourceName: source.name,
+        reason: `rubric-load-failed: ${msg}`,
+      });
+      continue;
+    }
+    if (!text.trim()) continue;
+
+    const parsed = parseRubricBands(text);
+    if (parsed.warnings.length > 0) {
+      for (const w of parsed.warnings) {
+        console.warn(`[projection] rubric pass (${source.id}): ${w}`);
+      }
+    }
+    if (parsed.criteria.length === 0) {
+      console.log(
+        `[projection] rubric pass: no RUB-* sections found in source=${source.id} (${source.name})`,
+      );
+      continue;
+    }
+
+    const bandMap: RubricBandMap = new Map(
+      parsed.criteria.map((c) => [c.code, c.bands]),
+    );
+    const writeResult = await writeBandThresholds(
+      { playbookId, sourceContentId: source.id },
+      bandMap,
+    );
+
+    console.log(
+      `[projection] rubric pass: source=${source.id} (${source.name}) ` +
+        `wrote bandThresholds to ${writeResult.parametersUpdated}/${bandMap.size} parameter(s) ` +
+        (writeResult.unmatchedCodes.length > 0
+          ? `(unmatched: ${writeResult.unmatchedCodes.join(", ")})`
+          : ""),
+    );
+
+    rubricBandsApplied.push({
+      sourceContentId: source.id,
+      sourceName: source.name,
+      parametersUpdated: writeResult.parametersUpdated,
+      unmatchedCodes: writeResult.unmatchedCodes,
+    });
+  }
+
   return {
     playbookId,
     appliedSources,
     skippedSources,
     degenerate: false,
+    rubricBandsApplied,
   };
 }


### PR DESCRIPTION
Closes #564. Parent root-cause: #561.

## What lands

- **`lib/wizard/parse-rubric-bands.ts`** — pure parser. Scans `## RUB-XX: Criterion` headings + `| Band | Descriptor |` tables. Returns parsed criteria keyed by RUB code (fc/lr/gra/p), each with band → descriptor map. No DB calls, no AI.
- **`apply-projection.ts: writeBandThresholds()`** — matches RUB codes to existing skill Parameter rows by suffix (`_fc` matches `skill_fluency_and_coherence_fc`). Upserts `Parameter.config.bandThresholds`. Idempotent. Unmatched codes logged as warnings.
- **`run-projection-for-playbook.ts`** — second projection pass after the main COURSE_REFERENCE loop. Queries `COURSE_REFERENCE_ASSESSOR_RUBRIC` sources, parses each, writes band thresholds. Purely additive — NO Goal mutations, NO curriculum mutations. The #447 rubric exclusion from goal generation stays intact.

## Tests

- `parse-rubric-bands.test.ts` — 7 unit tests + 1 live-IELTS-file test (skipped if file path doesn't resolve from runner cwd)
- `run-projection-for-playbook.test.ts` — refactored mock to filter by documentType (more reality-accurate). Added 2 new tests for the rubric pass (positive + no-RUB-sections negative)
- **Total: 172/172 wizard tests pass**

## Slug matching

The IELTS playbook on dev has 4 skill Parameter rows with `_fc` / `_lr` / `_gra` / `_p` suffixes. The rubric file uses `## RUB-FC:` / `## RUB-LR:` etc. headings. Matching: extract code from heading, find Parameter where `parameterId` ends with `_<code>` (case-insensitive, scoped to `skill_*`). Confirmed against `e460cd6f`'s skill params.

## Scope discipline — what's NOT in this PR

- **Assessor AI loader reading bandThresholds at compose time.** With this PR the data is IN PLACE on Parameter.config. The composer loader (`lib/prompt/composition/loaders/`) doesn't yet read it. That's a separate follow-up story. Without it, the assessor still won't quote "Band 5 LR" at compose time. But the data finally exists.
- Educator UI rendering of band descriptors.
- Other rubric formats (CEFR, NHS AfC).

## Rollback

Pure additive. Revert this commit, delete the new files. Existing `Parameter.config` rows that gained bandThresholds will keep them (additive write); a follow-up clean-up could null them, but they don't break anything.

## Test plan

- [x] `npx vitest run lib/wizard/` — 172/172 pass
- [ ] `/vm-cp` to deploy
- [ ] On VM, manually re-run projection on the IELTS playbook:
  ```
  npx tsx -e 'import {runProjectionForPlaybook} from "@/lib/wizard/run-projection-for-playbook"; runProjectionForPlaybook("e460cd6f-0d0c-4948-9d8e-1ce696d4dfd3").then(r => console.log(JSON.stringify(r, null, 2)))'
  ```
- [ ] Query: `SELECT "parameterId", config FROM "Parameter" WHERE "parameterId" LIKE 'skill_%_fc' OR "parameterId" LIKE 'skill_%_lr' OR "parameterId" LIKE 'skill_%_gra' OR "parameterId" LIKE 'skill_%_p';` — expect 4 rows with non-null `config.bandThresholds`

## Deploy command

**`/vm-cp`** — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)