### PR TITLE
feat(#575): composer surfaces Parameter.config.bandThresholds in prompts

### DIFF
--- a/apps/admin/lib/prompt/composition/CompositionExecutor.ts
+++ b/apps/admin/lib/prompt/composition/CompositionExecutor.ts
@@ -525,6 +525,35 @@ function buildCallerContext(context: AssembledContext): string {
     for (const t of sections.behaviorTargets.all || []) {
       parts.push(`- ${t.name}: ${(t.targetLevel || "MODERATE").toLowerCase()} (${(t.targetValue * 100).toFixed(0)}%)`);
     }
+    // #575 — Per-band descriptor reference, sourced from
+    // Parameter.config.bandThresholds (populated by #564's rubric pass).
+    // Lets the tutor/assessor cite "Band 5 LR: limited range" inline.
+    const withBands = (sections.behaviorTargets.all || []).filter(
+      (t: { bandThresholds?: Record<string, string> | null }) =>
+        t.bandThresholds && Object.keys(t.bandThresholds).length > 0,
+    );
+    if (withBands.length > 0) {
+      parts.push("\n## Skill Band Reference (rubric source)");
+      parts.push(
+        "When citing a learner's current level, anchor it to the specific band descriptor below — don't paraphrase or invent.",
+      );
+      for (const t of withBands) {
+        parts.push(`\n### ${t.name}`);
+        const entries = Object.entries(
+          t.bandThresholds as Record<string, string>,
+        )
+          .map(([band, descriptor]) => ({
+            band,
+            descriptor,
+            sortKey: parseFloat(band),
+          }))
+          .filter((e) => !Number.isNaN(e.sortKey))
+          .sort((a, b) => b.sortKey - a.sortKey);
+        for (const e of entries) {
+          parts.push(`- **Band ${e.band}:** ${e.descriptor}`);
+        }
+      }
+    }
   }
 
   // Call history

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -754,9 +754,13 @@ registerLoader("behaviorTargets", async (_callerId) => {
       parameter: {
         select: {
           name: true,
+          parameterId: true,
           interpretationLow: true,
           interpretationHigh: true,
           domainGroup: true,
+          // #575 — surface the rubric band ladder (#564) to the composer
+          // so the tutor/assessor can cite "Band 5 LR: limited range".
+          config: true,
         },
       },
     },
@@ -770,9 +774,12 @@ registerLoader("callerTargets", async (callerId) => {
       parameter: {
         select: {
           name: true,
+          parameterId: true,
           interpretationLow: true,
           interpretationHigh: true,
           domainGroup: true,
+          // #575 — see comment above.
+          config: true,
         },
       },
     },

--- a/apps/admin/lib/prompt/composition/transforms/targets.ts
+++ b/apps/admin/lib/prompt/composition/transforms/targets.ts
@@ -44,9 +44,13 @@ export interface NormalizedTarget {
   scope: string;
   parameter: {
     name: string | null;
+    parameterId?: string;
     interpretationLow: string | null;
     interpretationHigh: string | null;
     domainGroup: string | null;
+    // #575 — Parameter.config carries `bandThresholds: { [band]: descriptor }`
+    // for skill parameters once #564's rubric pass has populated them.
+    config?: Record<string, unknown> | null;
   } | null;
 }
 
@@ -179,15 +183,23 @@ registerTransform("mergeAndGroupTargets", (
   return {
     totalCount: merged.length,
     byDomain,
-    all: merged.map((t) => ({
-      parameterId: t.parameterId,
-      name: t.parameter?.name || t.parameterId,
-      targetValue: t.targetValue,
-      targetLevel: classifyValue(t.targetValue, thresholds),
-      scope: t.scope,
-      when_high: t.parameter?.interpretationHigh,
-      when_low: t.parameter?.interpretationLow,
-    })),
+    all: merged.map((t) => {
+      // #575 — surface bandThresholds (populated by #564's rubric pass) so the
+      // composed prompt can include per-band descriptor reference. Null when
+      // the parameter isn't a rubric-backed skill.
+      const cfg = (t.parameter?.config ?? null) as Record<string, unknown> | null;
+      const bandThresholds = (cfg?.bandThresholds ?? null) as Record<string, string> | null;
+      return {
+        parameterId: t.parameterId,
+        name: t.parameter?.name || t.parameterId,
+        targetValue: t.targetValue,
+        targetLevel: classifyValue(t.targetValue, thresholds),
+        scope: t.scope,
+        when_high: t.parameter?.interpretationHigh,
+        when_low: t.parameter?.interpretationLow,
+        bandThresholds,
+      };
+    }),
     // Store merged list for other transforms
     _merged: merged,
   };

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -544,6 +544,14 @@ export interface RecentCallData {
   }>;
 }
 
+/**
+ * Shape of the rubric band ladder stored on `Parameter.config.bandThresholds`
+ * by the rubric-only projection pass (#564). Keys are band numbers as strings
+ * (or stringified decimals), values are the descriptor text the assessor AI
+ * can cite. May be null/undefined for non-skill parameters.
+ */
+export type BandThresholdsMap = Record<string, string>;
+
 export interface BehaviorTargetData {
   parameterId: string;
   targetValue: number;
@@ -552,9 +560,13 @@ export interface BehaviorTargetData {
   playbookId?: string | null;
   parameter: {
     name: string | null;
+    parameterId?: string;
     interpretationLow: string | null;
     interpretationHigh: string | null;
     domainGroup: string | null;
+    // #575 — surfaced from Parameter.config so the composer can render the
+    // per-band reference table for skill_* parameters.
+    config?: Record<string, unknown> | null;
   } | null;
 }
 
@@ -564,9 +576,12 @@ export interface CallerTargetData {
   confidence: number;
   parameter: {
     name: string | null;
+    parameterId?: string;
     interpretationLow: string | null;
     interpretationHigh: string | null;
     domainGroup: string | null;
+    // #575 — see comment above.
+    config?: Record<string, unknown> | null;
   } | null;
 }
 

--- a/apps/admin/tests/lib/composition/targets-band-thresholds.test.ts
+++ b/apps/admin/tests/lib/composition/targets-band-thresholds.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for #575 — the composer surfaces `Parameter.config.bandThresholds`
+ * into the rendered prompt's "Skill Band Reference" section.
+ *
+ * Companion to #564 (which writes the field) and #565 (composer loader
+ * follow-up). Locks the data flow:
+ *   Parameter.config.bandThresholds → targets transform → composed prompt.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// Hoist a minimal prisma mock so transforms can import @/lib/prisma without
+// touching the real client.
+vi.hoisted(() => ({}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+  db: () => ({}),
+}));
+
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import "@/lib/prompt/composition/transforms/targets";
+import type {
+  AssembledContext,
+  BehaviorTargetData,
+  CallerTargetData,
+  CompositionSectionDef,
+  PlaybookData,
+} from "@/lib/prompt/composition/types";
+
+function buildContext(opts: {
+  behaviorTargets: BehaviorTargetData[];
+  callerTargets: CallerTargetData[];
+}): AssembledContext {
+  return {
+    callerId: "caller-test",
+    sharedState: { isFirstCall: false, callNumber: 3, thresholds: {} },
+    loadedData: {
+      behaviorTargets: opts.behaviorTargets,
+      callerTargets: opts.callerTargets,
+      playbooks: [{ id: "pb-1", config: { audience: "adult-professional" } }] as unknown as PlaybookData[],
+      caller: { id: "caller-test", domain: null } as unknown as never,
+    } as never,
+    resolvedSpecs: {} as never,
+    sections: {} as never,
+    specConfig: {},
+  } as unknown as AssembledContext;
+}
+
+describe("targets transform — band thresholds (#575)", () => {
+  const mergeAndGroupTargets = getTransform("mergeAndGroupTargets")!;
+
+  it("emits bandThresholds on the `all` rows when Parameter.config carries them", () => {
+    const ctx = buildContext({
+      behaviorTargets: [
+        {
+          parameterId: "skill_fluency_and_coherence_fc",
+          targetValue: 0.7,
+          confidence: 0.8,
+          scope: "PLAYBOOK",
+          playbookId: "pb-1",
+          parameter: {
+            name: "Fluency & Coherence",
+            parameterId: "skill_fluency_and_coherence_fc",
+            interpretationLow: null,
+            interpretationHigh: null,
+            domainGroup: "skill",
+            config: {
+              bandThresholds: {
+                "9": "Fluent, only very occasional repetition",
+                "5": "Usually keeps going but relies on repetition",
+              },
+            },
+          },
+        },
+      ],
+      callerTargets: [],
+    });
+    const out = mergeAndGroupTargets(
+      { behaviorTargets: ctx.loadedData.behaviorTargets, callerTargets: ctx.loadedData.callerTargets },
+      ctx,
+      {} as CompositionSectionDef,
+    );
+    expect(out.all).toHaveLength(1);
+    const t = out.all[0] as { bandThresholds: Record<string, string> | null };
+    expect(t.bandThresholds).toEqual({
+      "9": "Fluent, only very occasional repetition",
+      "5": "Usually keeps going but relies on repetition",
+    });
+  });
+
+  it("emits bandThresholds=null when Parameter.config has no bandThresholds key", () => {
+    const ctx = buildContext({
+      behaviorTargets: [
+        {
+          parameterId: "BEH-WARMTH",
+          targetValue: 0.6,
+          confidence: 0.7,
+          scope: "DOMAIN",
+          playbookId: null,
+          parameter: {
+            name: "Warmth",
+            parameterId: "BEH-WARMTH",
+            interpretationLow: "cold",
+            interpretationHigh: "warm",
+            domainGroup: "behavior",
+            config: null,
+          },
+        },
+      ],
+      callerTargets: [],
+    });
+    const out = mergeAndGroupTargets(
+      { behaviorTargets: ctx.loadedData.behaviorTargets, callerTargets: ctx.loadedData.callerTargets },
+      ctx,
+      {} as CompositionSectionDef,
+    );
+    const t = out.all[0] as { bandThresholds: Record<string, string> | null };
+    expect(t.bandThresholds).toBeNull();
+  });
+
+  it("CallerTarget bandThresholds override BehaviorTarget for the same parameter", () => {
+    const ctx = buildContext({
+      behaviorTargets: [
+        {
+          parameterId: "skill_fluency_and_coherence_fc",
+          targetValue: 0.7,
+          confidence: 0.8,
+          scope: "PLAYBOOK",
+          playbookId: "pb-1",
+          parameter: {
+            name: "Fluency & Coherence",
+            parameterId: "skill_fluency_and_coherence_fc",
+            interpretationLow: null,
+            interpretationHigh: null,
+            domainGroup: "skill",
+            config: {
+              bandThresholds: { "9": "BT-version of band 9" },
+            },
+          },
+        },
+      ],
+      callerTargets: [
+        {
+          parameterId: "skill_fluency_and_coherence_fc",
+          targetValue: 0.65,
+          confidence: 0.9,
+          parameter: {
+            name: "Fluency & Coherence",
+            parameterId: "skill_fluency_and_coherence_fc",
+            interpretationLow: null,
+            interpretationHigh: null,
+            domainGroup: "skill",
+            config: {
+              bandThresholds: { "9": "CT-version of band 9" },
+            },
+          },
+        },
+      ],
+    });
+    const out = mergeAndGroupTargets(
+      { behaviorTargets: ctx.loadedData.behaviorTargets, callerTargets: ctx.loadedData.callerTargets },
+      ctx,
+      {} as CompositionSectionDef,
+    );
+    // CallerTarget wins on scope priority.
+    const t = out.all[0] as { bandThresholds: Record<string, string> | null; scope: string };
+    expect(t.bandThresholds?.["9"]).toBe("CT-version of band 9");
+  });
+});


### PR DESCRIPTION
Closes #575. Completes the data flow started in #564:

```
rubric upload → projection → Parameter.config.bandThresholds → composed prompt
```

The assessor agent now sees the full Band 0–9 descriptor ladder for each rubric-backed skill in the prompt's new "Skill Band Reference" section. It can cite "Band 5 LR: limited range of vocabulary" inline instead of paraphrasing.

## What lands

- **`SectionDataLoader.ts`** — `behaviorTargets` + `callerTargets` loaders now select `parameter.config` (was previously truncated). Other config keys not consumed by the composer remain dormant.
- **`types.ts`** — optional `config` field on BehaviorTargetData / CallerTargetData / NormalizedTarget parameter shape. `BandThresholdsMap` typedef.
- **`transforms/targets.ts::mergeAndGroupTargets`** — extracts `bandThresholds` and emits on each `all[]` row. CallerTarget overrides BehaviorTarget for the same param (matches existing scope priority).
- **`CompositionExecutor.ts`** — emits "Skill Band Reference (rubric source)" section after the behavior_targets list when any target has band thresholds. Bands rendered descending (9 → 0).

## Tests

- `tests/lib/composition/targets-band-thresholds.test.ts` — 3 new tests (data flow, null-config back-compat, CallerTarget override priority)
- Full composition suite: **387/387**

## Test plan

- [x] `npx vitest run tests/lib/composition/` — 387/387 pass
- [ ] `/vm-cp` to deploy
- [ ] Re-compose a prompt for Caleb (`17b1b0b7-...`) and grep the result for "Skill Band Reference" — expect 4 skill sections × 10 bands each
- [ ] Re-run a Caleb sim; the assessor should now cite specific bands when scoring

## Deploy

`/vm-cp` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)