### PR TITLE
docs: wizard prompt template + rubric template + slim IELTS wizard prompt

### DIFF
--- a/a-sample-docs/assessor-rubric-template.md
+++ b/a-sample-docs/assessor-rubric-template.md
@@ -1,0 +1,164 @@
+<!--
+HF Assessor Rubric Template — v1.0 (2026-05-21)
+
+WHAT THIS FILE IS
+The per-band descriptor reference for a skill-EMA / rubric-anchored
+course (IELTS, NHS AfC, CEFR, professional certifications, etc.). Upload
+this ALONGSIDE `course-ref.md` so the projection's rubric-only pass
+(#564) can extract per-band descriptors and write them onto each skill
+Parameter's `config.bandThresholds`.
+
+WHAT THE PIPELINE READS FROM IT
+1. Front-matter `hf-document-type: COURSE_REFERENCE_ASSESSOR_RUBRIC` →
+   tells the classifier this is a rubric (excluded from goal projection
+   per #447, but consumed by the rubric pass per #564).
+2. `## RUB-<CODE>: <Criterion Name>` headings →
+   one per skill, where <CODE> matches the (CODE) parenthetical on the
+   corresponding `### SKILL-NN` heading in `course-ref.md`. E.g.:
+       course-ref.md:  ### SKILL-01: Fluency & Coherence (FC)
+       this file:      ## RUB-FC: Fluency and Coherence — band descriptors
+   The CODE binds the rubric to the Parameter via suffix match
+   (`skill_fluency_and_coherence_fc`) OR name-derived fallback
+   (`skill_fluency_and_coherence`) — see PR #581.
+3. `| Band | Descriptor |` tables under each RUB heading →
+   one row per band. Band column accepts integers (`9`, `8`, ..., `0`)
+   or decimals (`6.5`). Non-numeric keys (`A1`, `Emerging`) are NOT
+   accepted today — see issue #582 for the widening story.
+
+WHAT THE PROJECTION WRITES TO THE DB
+- For each `## RUB-<CODE>:` section: `Parameter.config.bandThresholds`
+  is populated with `{ "<bandNumber>": "<descriptor text>", ... }` on the
+  matched skill Parameter.
+- NO Goal rows are created from this file. NO BehaviorTarget rows. NO
+  CurriculumModule rows. NO LearningObjective rows. (The course-ref's
+  skills framework is the authoritative source for those — see #447.)
+
+WHAT THE COMPOSED PROMPT GAINS
+- `llmPrompt.behaviorTargets[].bandThresholds` carries the band ladder
+  to the tutor / assessor agent at compose time (see PR #578) — the AI
+  can cite "Band 5 LR: limited range of vocabulary" inline instead of
+  paraphrasing.
+
+ALLOWED-VALUES REJECTION POLICY
+- Unknown values for `hf-document-type` log a warning and fall back to
+  AI inference. Use the exact string `COURSE_REFERENCE_ASSESSOR_RUBRIC`.
+- Tables with header rows / alignment rows / non-numeric keys are silently
+  skipped — verify your tables look like the worked example below.
+
+SEE ALSO
+- `course-reference-template.md` — companion (the COURSE_REFERENCE body)
+- `wizard-prompt-template.md` — the chat paste-block + file list
+- `docs/CONTENT-PIPELINE.md §4` — rubric-only band-descriptor pass spec
+- `apps/admin/docs-archive/bdd-specs/contracts/SKILL_MEASURE_V1.contract.json` — the contract documenting where band descriptors are stored
+-->
+---
+hf-document-type: COURSE_REFERENCE_ASSESSOR_RUBRIC
+hf-default-category: skill_framework
+hf-audience: tutor-only
+hf-lo-system-role: ASSESSOR_RUBRIC
+---
+
+# [example] [Course Name] — Assessor Rubric
+
+> **Document type:** COURSE_REFERENCE_ASSESSOR_RUBRIC · **Audience:** assessor + tutor-hidden (never sent to learner) · **Format:** per-band descriptors for the criteria declared in `course-ref.md`'s Skills Framework.
+
+---
+
+## Criterion key
+
+> This optional table maps numeric IDs to RUB codes for cross-reference. Useful for educators but ignored by the parser — the contract is the `(CODE)` parenthetical on each `### SKILL-NN` in `course-ref.md` matching the `RUB-<CODE>` heading below.
+
+| # | Criterion name | RUB code | Maps to skill parameter |
+|---|---|---|---|
+| 1 | [example] Fluency and Coherence | FC | skill_fluency_and_coherence (or _fc suffix on legacy projection) |
+| 2 | [example] Lexical Resource | LR | skill_lexical_resource |
+| 3 | [example] Grammatical Range and Accuracy | GRA | skill_grammatical_range_and_accuracy |
+| 4 | [example] Pronunciation | P | skill_pronunciation |
+
+---
+
+## RUB-FC: [example] Fluency and Coherence — band descriptors
+
+> **MANDATORY:** This heading pattern is what the parser keys on. The format is `## RUB-<CODE>: <Name> — band descriptors` (the `— band descriptors` suffix is optional but conventional). The CODE must match the `(CODE)` parenthetical on the corresponding `### SKILL-NN` heading in `course-ref.md`.
+
+| Band | Descriptor |
+| ---- | ---------- |
+| 9 | [example] Top-band descriptor. What does a Band 9 learner sound like on this criterion? Be specific — the tutor cites these strings verbatim. |
+| 8 | [example] Descriptor — typically a small step down from 9. |
+| 7 | [example] Descriptor — the most commonly-cited band in coaching ("you're at 6, aim for 7"). |
+| 6 | [example] Descriptor. |
+| 5 | [example] Descriptor. |
+| 4 | [example] Descriptor. |
+| 3 | [example] Descriptor. |
+| 2 | [example] Descriptor. |
+| 1 | [example] Descriptor — the floor. |
+| 0 | [example] Descriptor — non-attempt / non-completion. |
+
+---
+
+## RUB-LR: [example] Lexical Resource — band descriptors
+
+| Band | Descriptor |
+| ---- | ---------- |
+| 9 | [example] Wide range of vocabulary with very natural and precise use. Rare minor errors only as slips of the tongue. |
+| ... | ... |
+| 0 | [example] Does not attend / does not complete. |
+
+---
+
+## RUB-GRA: [example] Grammatical Range and Accuracy — band descriptors
+
+| Band | Descriptor |
+| ---- | ---------- |
+| 9 | [example] ... |
+| ... | ... |
+| 0 | [example] ... |
+
+---
+
+## RUB-P: [example] Pronunciation — band descriptors
+
+| Band | Descriptor |
+| ---- | ---------- |
+| 9 | [example] ... |
+| ... | ... |
+| 0 | [example] ... |
+
+---
+
+## Scoring rules (assessor-only — NOT projected to learner-facing surfaces)
+
+> Free-text rules that govern how the assessor agent scores. The
+> classifier extracts these as `assessment_approach` ContentAssertion
+> rows that feed into the MEASURE spec at score time — they do NOT
+> create Goals or BehaviorTargets.
+
+- [example] Score each criterion separately and surface the four-number breakdown internally before averaging.
+- [example] Always cite a specific descriptor phrase when justifying a score (e.g. "Band 5 — 'limited range of more complex structures'").
+- [example] Audio-only criteria (Pronunciation) are skipped when the transcript is text-only — `hasLearnerEvidence: false` will be returned and the row dropped by the Boaz guard (#566).
+- [example] On the first 2 calls, the running EMA is capped at 0.5 — a single perfect call can't pin a learner to Secure. See `SKILL_MEASURE_V1.contract.json::config.minCallsToFull`.
+
+---
+
+## Compression rules for tutor delivery (assessor → tutor framing)
+
+> How the assessor's verdict reaches the learner via the tutor.
+> Extracted as `communication_rule` assertions.
+
+- [example] Tutor never reads a band score aloud on Call 1. The first criterion + band is introduced on Call 2 per the course-ref's Disclosure Schedule.
+- [example] When citing a band, the tutor names ONE criterion at a time and ties it to a specific evidence quote from the learner's most recent turn.
+
+---
+
+## Verification
+
+After upload, verify in the DB that the rubric pass ran:
+
+```sql
+SELECT "parameterId", jsonb_pretty(config)
+FROM "Parameter"
+WHERE "parameterId" LIKE 'skill_%'
+  AND config ? 'bandThresholds';
+```
+
+Expect: 4 rows (or N — one per `### SKILL-NN` in your course-ref), each with `config.bandThresholds` containing one entry per `| <band> | <descriptor> |` row above. If any of the 4 are missing, check the wizard's Sources panel for `[apply-projection] writeBandThresholds: no skill parameter matched RUB codes [...]` warnings.

--- a/a-sample-docs/wizard-prompt-template.md
+++ b/a-sample-docs/wizard-prompt-template.md
@@ -1,0 +1,144 @@
+# Wizard Prompt Template
+
+Paste this template into the V5 wizard chat (`/x/get-started-v5`). Fill in
+the bracketed `[example]` fields with your course's specifics. Upload the
+documents listed in the "Files to upload" section.
+
+> **Last refreshed:** 2026-05-21 (post-#581 evidence-first auto-detect)
+
+---
+
+## Why this template exists
+
+The wizard chat reads the markdown you upload and projects it into the DB.
+Most teaching rules — Call 1 special behaviour, skill descriptors, rubric
+bands, brief-never-quiz policies — live INSIDE `course-ref.md` and get
+projected automatically. **Don't repeat them in the prompt block** —
+duplication tempts you to drift the two copies apart.
+
+The chat prompt does five things and only five things:
+1. Names the institution / course
+2. Names the audience and target band
+3. Picks the teaching approach (one of nine enums)
+4. Declares progression mode (chip-click only — see below)
+5. Lists the files you're about to upload
+
+Everything else is in the documents.
+
+---
+
+## MANDATORY fields (the wizard will not finish setup without these)
+
+| Field | Allowed values | Where the wizard learns it |
+|---|---|---|
+| `Institution name` | free text | this prompt |
+| `Course name` | free text | this prompt OR `course-ref.md` |
+| `Subject discipline` | free text | this prompt OR `course-ref.md` |
+| `audience` | `primary` \| `secondary` \| `sixth-form` \| `higher-ed` \| `adult-professional` \| `adult-casual` \| `mixed` | this prompt OR `course-ref.md` |
+| `interactionPattern` (teaching approach) | `socratic` \| `directive` \| `advisory` \| `coaching` \| `companion` \| `facilitation` \| `reflective` \| `open` \| `conversational-guide` | this prompt OR `course-ref.md` |
+| `progressionMode` | `learner-picks` \| `ai-led` | **Chip-click only**, never via prompt text — wizard surfaces a 2-option picker |
+| `welcomeFlow` (4 keys) | bool × 4 (Goals / About You / Knowledge Check / AI Intro) | Wizard prompts via checklist; user clicks |
+
+## RECOMMENDED fields (set them or accept defaults)
+
+| Field | Default if omitted | Notes |
+|---|---|---|
+| `sessionCount` | open-ended (no cap) | For continuous courses, leave open |
+| `durationMins` | system default | Only specify if you have a strict cadence |
+| `teachingMode` | `comprehension` | `recall` \| `comprehension` \| `practice` \| `syllabus` |
+| `planEmphasis` | `balanced` | `breadth` \| `balanced` \| `depth` |
+| `npsEnabled` | wizard prompts | Single end-of-course satisfaction survey |
+
+## OPT-IN: scoring mode
+
+| Field | Allowed values | When to set |
+|---|---|---|
+| `hf-scoring-mode` (front-matter in `course-ref.md`) | `evidence-first` (only) | Skill-EMA courses with per-band rubrics (IELTS, NHS AfC, CEFR, etc.) |
+
+**If your course has a separate `assessor-rubric.md` upload, set `hf-scoring-mode: evidence-first` in `course-ref.md`'s front-matter.** Without this declaration, the new playbook falls back to the legacy mode-gate and your skill scores may include rubric-prose hallucinations.
+
+---
+
+## Paste-block (copy this; replace `[example]` fields)
+
+```text
+I'm setting up a [example] course.
+
+Institution: [example] [Name]
+Type: [example] [school / lab / company / university]
+Subject: [example] [discipline]
+Course name: [example] [name]
+Audience: [example] [primary | secondary | sixth-form | higher-ed | adult-professional | adult-casual | mixed]
+
+The learners are [example] [one-paragraph profile — age, prior knowledge,
+motivation, target outcome].
+
+Teaching approach: [example] [socratic | directive | advisory | coaching | companion | facilitation | reflective | open | conversational-guide] — [example] [one-sentence rationale].
+
+Calls: [example] [open-ended | soft cap ~N × M minutes]
+Coverage: [example] [breadth | balanced | depth]
+Assessment style: [example] [formal | informal]
+
+progressionMode: I'll pick this from the chip picker when you offer it.
+(DO NOT call update_setup with progressionMode — chip-click writes setupData
+client-side. DO NOT call update_setup with modulesAuthored or constraints —
+both rejected at the tool layer.)
+
+Teaching rules, Call 1 special behaviour, skill descriptors, rubric bands,
+and any session-specific overrides are all declared in the documents I'm
+about to upload — extract them via assertion + projection, don't ask me
+to re-type them.
+
+I have [example] [N] teaching documents to upload — see the table I'll paste
+after this message, or the file list in the Sources panel.
+```
+
+---
+
+## Files to upload — minimum vs. recommended
+
+### Minimum (any course)
+- `course-ref.md` — tutor-only config + skills framework + outcomes (use `course-reference-template.md`)
+
+### Recommended for skill-EMA / rubric-anchored courses (IELTS, NHS, CEFR, etc.)
+- `course-ref.md` — as above, with `hf-scoring-mode: evidence-first` front-matter
+- `assessor-rubric.md` — per-band descriptors (use `assessor-rubric-template.md`)
+
+### Optional supplementary
+- `tutor-briefing.md` — test format facts the tutor briefs but never quizzes
+- `<subject>-language-toolkit.md` — learner-facing phrase repertoire (`TEXTBOOK`)
+- One or more `*-question-bank-*.md` files — practice prompts (`QUESTION_BANK`)
+- Worksheets / past papers / exemplars — graded source material
+
+---
+
+## What the wizard does NOT need re-typed
+
+Every item in this list is already inside `course-ref.md` and gets projected
+automatically. DO NOT paste these into the wizard chat:
+
+- Call 1 special rules / first-session warm-up policy
+- Brief-never-quiz / coaching-not-lecturing rules
+- Skills framework names + tier descriptors (`### SKILL-NN`)
+- Per-skill target band (`**Target band:** N.N`)
+- Module catalogue + per-module outcomes (`## Modules` table + `**OUT-NN:**`)
+- Session-scope overrides (`**Session scope:** 1` / `2+`)
+- Pedagogy preset / lessonPlanMode / cadence preferences
+- Disclosure schedule for criteria across calls
+
+---
+
+## Post-upload checklist (educator verifies these landed)
+
+After the wizard completes, navigate to `/x/callers/<new-caller-id>` and
+verify in the new caller's first call:
+
+- [ ] `Playbook.config.scoringMode === "evidence-first"` (if `hf-scoring-mode` was declared) — verifies via DB or wizard's Sources panel
+- [ ] Skill `Parameter` rows created with `parameterId LIKE 'skill_*'`
+- [ ] Rubric pass populated `Parameter.config.bandThresholds` (4× skills × N bands) — if rubric was uploaded
+- [ ] `Goal` rows: N ACHIEVE (`isAssessmentTarget: true`) + M LEARN per outcome
+- [ ] Curriculum modules created with stable slugs
+- [ ] After first call: SkillBandStripCard on caller's Overview tab shows BandChips for each measured skill
+
+If any are missing, check the wizard's Sources panel for parse warnings —
+typo'd front-matter keys, ignored declared values, etc. surface there.

--- a/docs/external/ielts/ielts-speaking/wizard-prompt.md
+++ b/docs/external/ielts/ielts-speaking/wizard-prompt.md
@@ -1,12 +1,17 @@
 # IELTS Speaking Practice — Wizard Prompt
 
-Paste this prompt into the V5 wizard chat. Upload the 7 docs from `Upload Docs/` when prompted.
+Paste the block below into the V5 wizard chat. Upload the 7 docs from
+`Upload Docs/` when prompted.
 
-> **Last refreshed:** 2026-05-18. Aligned with #417 per-skill scoring pipeline, #441/#442 banding UI tail, #447 rubric-projection guard, #448 eager `CallerTarget` placeholders, and #449 VAPI payload capture.
+> **Last refreshed:** 2026-05-21. Aligned with: #417 per-skill scoring, #441/#442 banding UI, #447 rubric-projection guard, #448 eager `CallerTarget` placeholders, #449 VAPI capture, #564 rubric → `Parameter.config.bandThresholds`, #566 mode-kill / evidence-first gate, #574 rubric pass, #578 composer reads bandThresholds, #580 per-learner UI surfaces, #581 evidence-first auto-detect (front-matter `hf-scoring-mode`).
+
+See [`a-sample-docs/wizard-prompt-template.md`](../../../a-sample-docs/wizard-prompt-template.md) for the GENERIC template + the "what NOT to repeat in the prompt" guide.
 
 ---
 
-## Wizard prompt
+## Wizard prompt (paste this; nothing more)
+
+The teaching rules, Call 1 special behaviour, skill descriptors, brief-never-quiz policy, and disclosure schedule are ALREADY DECLARED in `course-ref.md` and get projected automatically. Do not paste them here.
 
 ```
 I'm setting up an IELTS Speaking preparation course.
@@ -26,53 +31,25 @@ Teaching approach: socratic — the student speaks, the AI examines and coaches
 through targeted questions. Never answer for the student.
 
 Calls: soft cap ~12 × 20 minutes.
+Coverage: depth — better to master two Speaking Parts than skim all three.
+Assessment style: formal — track band scores per criterion across calls.
 
 progressionMode: learner-picks — the learner picks one of four modules at the
-start of each call from Call 2 onwards (Part 1: Familiar Topics, Part 2: Long
-Turn, Part 3: Abstract Discussion, Full Mock Exam). The four modules and the
-eight OUT-NN learner outcomes are authored in course-ref.md — the Module
-Catalogue parser will pick them up automatically when course-ref.md is uploaded.
-Do **not** call update_setup with `modulesAuthored` or `constraints` — both are
-rejected at the wizard tool layer. `modulesAuthored` is a derived PlaybookConfig
-field written server-side; `constraints` is not on the setupData allow-list.
-Also do **not** call update_setup with `progressionMode` — that field is
-chip-click only: the wizard must call `show_options` with `dataKey:
-"progressionMode"` and the chip click writes setupData client-side.
-Authored-module status is set by the course-ref.md parser; voice rules and
-tutor principles flow in via course-ref.md sections (Teaching Approach, First
-Call Special Rules, Disclosure Schedule).
+start of each call from Call 2 onwards. The four modules and the eight OUT-NN
+learner outcomes are authored in course-ref.md.
 
-Coverage: depth — better to master two Speaking Parts than skim all three.
+DO NOT call update_setup with `progressionMode`, `modulesAuthored`, or
+`constraints` — `progressionMode` is chip-click only (wizard must call
+show_options with dataKey="progressionMode"); the other two are rejected at
+the tool layer. All teaching rules (First Call Special Rules, Disclosure
+Schedule, Brief-Never-Quiz, voice rules, session-scope overrides) live in
+course-ref.md and project automatically — do not re-state them.
 
-Assessment style: formal — track band scores per criterion across calls
-(Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy,
-Pronunciation), but **never name them on Call 1**.
-
-Voice rule for Call 1 (onboarding): the tutor must NOT name the four criteria,
-explain the band scale, or score explicitly. Call 1 is a Part-1-only topic
-warm-up (work / study / hometown / hobbies). The four criteria are introduced
-one per call across Calls 2–5 per the Disclosure Schedule in `course-ref.md`.
-Please extract the "First Call (Onboarding) — Special Rules" section and the
-"Disclosure Schedule" as `sessionOverrides` entries with `section: "1"` and
-`section: "2+"` respectively, so the per-call filtering in
-`course-instructions.ts:matchesSessionRange()` honours the call-number scope at
-runtime. The "What This Course Is" and "Skills Framework" sections in
-`course-ref.md` are tagged `**Session scope:** 2+` — extract those as
-`session_override` with `section: "2+"`, not as always-on `session_flow` /
-`skill_framework`.
-
-Brief-never-quiz rule: facts about the test itself (number of parts, timing,
-examiner role, scoring mechanics) live in `tutor-briefing.md` as
-TEACHING_INSTRUCTION material. The tutor uses these silently to run the format
-and explains them in passing when relevant — the tutor **never** quizzes the
-learner on them. Every question the tutor asks the learner is a real
-conversational or examination question on the topic at hand, drawn from the
-Part 1 / 2 / 3 question banks.
-
-I have 7 teaching documents to upload covering: course config + modules + outcomes
-(course-ref.md), tutor briefing facts (tutor-briefing.md), assessor band
-descriptors (assessor-rubric.md), learner phrase repertoire (language-toolkit),
-and three Part-specific question banks.
+I have 7 teaching documents to upload covering: course config + modules +
+outcomes (course-ref.md, with `hf-scoring-mode: evidence-first` declared),
+tutor briefing facts (tutor-briefing.md), assessor band descriptors
+(assessor-rubric.md), learner phrase repertoire (language-toolkit), and
+three Part-specific question banks.
 ```
 
 ---


### PR DESCRIPTION
Three doc artefacts for fresh-course onboarding:

1. **`wizard-prompt-template.md`** — generic chat paste-block template (MANDATORY / RECOMMENDED / OPT-IN fields with allowed values; explicit "don't repeat course-ref content" list)
2. **`assessor-rubric-template.md`** — companion template documenting RUB heading contract + table format with worked example
3. **IELTS wizard-prompt.md** — trimmed ~22 lines of content duplicated from course-ref.md

Followed by #582 (wider rubric parser) and #584 (post-projection health report) as separate stories.

Deploy: `/vm-cp` (no schema change).