### PR TITLE
fix: hero 0% Mastery — resolve curriculum by playbookId

### DIFF
--- a/apps/admin/lib/prompt/compose-content-section.ts
+++ b/apps/admin/lib/prompt/compose-content-section.ts
@@ -134,7 +134,8 @@ export async function composeContentSection(
   const progress = await loadCallerProgress(
     callerId,
     contentSpec.slug,
-    metadata.progressKey
+    metadata.progressKey,
+    playbook?.id ?? null,
   );
 
   // 5. Enhance modules with progress status
@@ -293,7 +294,8 @@ function sortModules(
 async function loadCallerProgress(
   callerId: string,
   specSlug: string,
-  progressKey: string
+  progressKey: string,
+  playbookId: string | null = null,
 ): Promise<CurriculumProgress> {
   // Get storage keys from contract
   const storageKeys = await ContractRegistry.getStorageKeys('CURRICULUM_PROGRESS_V1');
@@ -348,10 +350,18 @@ async function loadCallerProgress(
   // LEGACY_MASTERY_FALLBACK_ENABLED (default off). See
   // apps/admin/docs/mastery-store-migration.md.
   try {
-    const curriculum = await prisma.curriculum.findFirst({
-      where: { slug: specSlug },
-      select: { id: true },
-    });
+    // Prefer playbookId lookup — wizard-generated curricula use slugs like
+    // `course-<playbookId>-<timestamp>` that don't match the content spec slug.
+    // Fall back to spec slug for content-spec-seeded curricula.
+    const curriculum = playbookId
+      ? await prisma.curriculum.findFirst({
+          where: { playbookId },
+          select: { id: true },
+        })
+      : await prisma.curriculum.findFirst({
+          where: { slug: specSlug },
+          select: { id: true },
+        });
     if (curriculum) {
       const moduleRows = await prisma.curriculumModule.findMany({
         where: { curriculumId: curriculum.id },

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.317",
+  "version": "0.7.318",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary
- Hero `AtAGlanceCard` was showing 0% Mastery even when `CallerModuleProgress` had real values (Caleb: part1=1.0, part2=0.52, part3=0.54, mock=0.59 — confirmed via SQL audit).
- Root cause: `composeContentSection` called `loadCallerProgress(callerId, contentSpec.slug, progressKey)`, which did `prisma.curriculum.findFirst({ where: { slug: specSlug } })`. Wizard-generated curricula use slugs like `course-<playbookId>-<timestamp>` that don't match the content spec slug — lookup returned null, `modulesMastery` stayed empty, hero averaged to 0%.
- Fix: pass `playbook?.id` through to `loadCallerProgress` and prefer `where: { playbookId }`; fall back to slug lookup for content-spec-seeded curricula.

## Test plan
- [x] SQL audit confirms DB-side data is correct on caller `17b1b0b7`
- [ ] `/vm-cp` to dev VM
- [ ] Reload `/x/callers/17b1b0b7-4837-4ece-9ae5-f94a967e5ff9` — hero should show ~63% Mastery (mean of 1.0, 0.52, 0.54, 0.59)
- [ ] Confirm Overview module strip shows correct per-module mastery

🤖 Generated with [Claude Code](https://claude.com/claude-code)