### PR TITLE
feat(seed): blank-ielts profile — partner-test bootstrap

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -186,6 +186,7 @@ Options:
 2. **demo** — Clean demo data (golden school + demo course + demo logins, no e2e junk)
 3. **full** — Everything including e2e fixtures (DEV/TEST only)
 4. **core** — Specs + contracts only (safe for PROD)
+5. **blank-ielts** — Specs + "IELTS Prep Lab" institution only (no courses, no callers) — partner-test bootstrap
 
 If the user picks a seed profile, rebuild the seed image and run the seed job:
 
@@ -254,6 +255,7 @@ Options:
 2. **full** — Everything including e2e fixtures
 3. **core** — Specs + contracts only
 4. **golden** — Specs + 1 clean institution (Abacus Academy)
+5. **blank-ielts** — Specs + IELTS Prep Lab institution only (no courses, no callers)
 
 **Guard:** Block `full` or `demo` for PROD. Block `core` for DEV (likely not what you want — warn and confirm).
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.320",
+  "version": "0.7.321",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/prisma/seed-blank-ielts.ts
+++ b/apps/admin/prisma/seed-blank-ielts.ts
@@ -1,0 +1,112 @@
+/**
+ * Blank IELTS Seed — Foundation only, no courses, no callers
+ *
+ * Creates the "IELTS Prep Lab" institution + matching domain and links all
+ * existing SUPERADMIN users to it. Intended for the partner-test environment:
+ * teachers log in, see one clean institution, and build courses from scratch
+ * via the wizard.
+ *
+ * Creates:
+ *   1 institution: "IELTS Prep Lab" (school type, slug: ielts-prep-lab)
+ *   1 domain:      "IELTS Prep Lab" (slug: ielts-prep-lab)
+ *   SUPERADMIN users linked (institutionId + activeInstitutionId)
+ *
+ * Does NOT create: playbooks, curricula, callers, demo content.
+ *
+ * Non-PROD only — refuses to run when NEXT_PUBLIC_APP_ENV=LIVE.
+ *
+ * Usage:
+ *   SEED_PROFILE=blank-ielts npx tsx prisma/seed-full.ts --reset
+ *   npx tsx prisma/seed-blank-ielts.ts          # standalone
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const INSTITUTION_NAME = "IELTS Prep Lab";
+const INSTITUTION_SLUG = "ielts-prep-lab";
+
+const DEFAULT_FLOW_PHASES = [
+  { phase: "greeting", label: "Greeting & welcome" },
+  { phase: "rapport", label: "Build rapport" },
+  { phase: "assessment", label: "Quick assessment" },
+  { phase: "teaching", label: "Teaching interaction" },
+  { phase: "summary", label: "Session summary" },
+];
+
+export async function main(externalPrisma?: PrismaClient): Promise<void> {
+  const env = process.env.NEXT_PUBLIC_APP_ENV || process.env.NODE_ENV;
+  if (env === "LIVE" || env === "production") {
+    console.log("  ⛔ Skipping blank-ielts seed — PROD environment detected");
+    return;
+  }
+
+  const prisma = externalPrisma || new PrismaClient();
+
+  console.log(`\n  🧪 Seeding blank ${INSTITUTION_NAME} foundation...\n`);
+
+  const instType = await prisma.institutionType.findUnique({ where: { slug: "school" } });
+  if (!instType) {
+    console.warn("  ⚠ Institution type 'school' not found — run seed-institution-types first");
+    if (!externalPrisma) await prisma.$disconnect();
+    return;
+  }
+
+  const institution = await prisma.institution.upsert({
+    where: { slug: INSTITUTION_SLUG },
+    update: {
+      name: INSTITUTION_NAME,
+      typeId: instType.id,
+      welcomeMessage:
+        `Welcome to ${INSTITUTION_NAME}! Build a course, invite learners, and watch them progress.`,
+    },
+    create: {
+      name: INSTITUTION_NAME,
+      slug: INSTITUTION_SLUG,
+      typeId: instType.id,
+      primaryColor: "#1F1B4A",
+      secondaryColor: "#F5B856",
+      welcomeMessage:
+        `Welcome to ${INSTITUTION_NAME}! Build a course, invite learners, and watch them progress.`,
+    },
+  });
+  console.log(`    + Institution: ${institution.name}`);
+
+  const domain = await prisma.domain.upsert({
+    where: { slug: INSTITUTION_SLUG },
+    update: {
+      name: INSTITUTION_NAME,
+      description: "IELTS Speaking preparation — Parts 1, 2, 3 and full mock exam.",
+      institutionId: institution.id,
+      isActive: true,
+      onboardingFlowPhases: DEFAULT_FLOW_PHASES,
+    },
+    create: {
+      slug: INSTITUTION_SLUG,
+      name: INSTITUTION_NAME,
+      description: "IELTS Speaking preparation — Parts 1, 2, 3 and full mock exam.",
+      isActive: true,
+      institutionId: institution.id,
+      onboardingFlowPhases: DEFAULT_FLOW_PHASES,
+    },
+  });
+  console.log(`    + Domain: ${domain.name}`);
+
+  const linkCount = await prisma.user.updateMany({
+    where: { role: "SUPERADMIN" },
+    data: { institutionId: institution.id, activeInstitutionId: institution.id },
+  });
+  console.log(`    + SUPERADMIN users linked: ${linkCount.count}`);
+
+  console.log(`\n  ✓ Blank ${INSTITUTION_NAME} ready — partners can now build courses via the wizard\n`);
+
+  if (!externalPrisma) {
+    await prisma.$disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error("Blank IELTS seed failed:", e);
+    process.exit(1);
+  });
+}

--- a/apps/admin/prisma/seed-full.ts
+++ b/apps/admin/prisma/seed-full.ts
@@ -12,13 +12,15 @@
  *   SEED_PROFILE=full npx tsx prisma/seed-full.ts     # DEV/VM — everything (default)
  *   SEED_PROFILE=demo npx tsx prisma/seed-full.ts     # DEMO — clean demo data, no e2e junk
  *   SEED_PROFILE=golden npx tsx prisma/seed-full.ts   # Golden path — clean minimal demo data
+ *   SEED_PROFILE=blank-ielts npx tsx prisma/seed-full.ts --reset  # Partner-test — IELTS Prep Lab only
  *
  * Profiles:
- *   core    — Specs, archetypes, institution types, run configs, dedup (PROD)
- *   demo    — Core + golden school + demo course + demo logins, NO e2e fixtures
- *   test    — Everything in core + e2e fixtures + demo logins (TEST)
- *   full    — Everything in test + golden school + demo course (DEV/VM)
- *   golden  — Specs + institution types + 1 clean institution (demo golden path)
+ *   core        — Specs, archetypes, institution types, run configs, dedup (PROD)
+ *   demo        — Core + golden school + demo course + demo logins, NO e2e fixtures
+ *   test        — Everything in core + e2e fixtures + demo logins (TEST)
+ *   full        — Everything in test + golden school + demo course (DEV/VM)
+ *   golden      — Specs + institution types + 1 clean institution (demo golden path)
+ *   blank-ielts — Specs + IELTS Prep Lab institution (no courses, no callers) — partner test
  *
  * Steps (full profile):
  *   1.  seed-clean              → 51 specs, 160 params, admin user, contracts
@@ -43,6 +45,7 @@ import { main as seedDemoLogins } from "./seed-demo-logins";
 import { main as seedGolden } from "./seed-golden";
 import { main as seedIdentityArchetypes } from "./seed-identity-archetypes";
 import { main as seedDemoCourse } from "./seed-demo-course";
+import { main as seedBlankIelts } from "./seed-blank-ielts";
 // IELTS playbook is no longer seeded — it lives behind the wizard upload-doc
 // flow (`docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md`), which
 // is the realistic path teachers use. Auto-seeding produced a duplicate
@@ -52,7 +55,7 @@ import { main as seedDemoCourse } from "./seed-demo-course";
 // See #463 follow-up.
 // import { main as seedIeltsCourse } from "./seed-ielts-course";
 
-type Profile = "core" | "demo" | "test" | "full" | "golden";
+type Profile = "core" | "demo" | "test" | "full" | "golden" | "blank-ielts";
 
 interface Step {
   name: string;
@@ -62,17 +65,20 @@ interface Step {
 }
 
 const ALL_STEPS: Step[] = [
-  // ── Foundation (runs in every profile including golden) ─
+  // ── Foundation (runs in every profile including golden + blank-ielts) ─
   { name: "seed-clean", fn: seedClean },
   { name: "seed-identity-archetypes", fn: seedIdentityArchetypes },
   { name: "seed-institution-types", fn: seedInstitutionTypes },
 
-  // ── Core (runs in core/demo/test/full but NOT golden) ───
-  { name: "seed-run-configs", fn: seedRunConfigs, profiles: ["core", "demo", "test", "full"] },
-  { name: "seed (dedup)", fn: seedDedup, profiles: ["core", "demo", "test", "full"] },
+  // ── Core (runs in core/demo/test/full but NOT golden or blank-ielts) ──
+  { name: "seed-run-configs", fn: seedRunConfigs, profiles: ["core", "demo", "test", "full", "blank-ielts"] },
+  { name: "seed (dedup)", fn: seedDedup, profiles: ["core", "demo", "test", "full", "blank-ielts"] },
 
   // ── Golden (Abacus Academy — additive when in full/demo, cleanup skipped) ──
   { name: "seed-golden", fn: seedGolden, profiles: ["golden", "demo", "full"] },
+
+  // ── Blank IELTS (single "IELTS Prep Lab" institution, no courses, no callers) ──
+  { name: "seed-blank-ielts", fn: seedBlankIelts, profiles: ["blank-ielts"] },
 
   // ── Demo + Full (demo course with 8 learners) ──────────
   { name: "seed-demo-course", fn: seedDemoCourse, profiles: ["demo", "full"] },
@@ -86,7 +92,10 @@ const ALL_STEPS: Step[] = [
 
 function getProfile(): Profile {
   const val = process.env.SEED_PROFILE || "full";
-  if (val === "core" || val === "demo" || val === "test" || val === "full" || val === "golden") return val;
+  if (
+    val === "core" || val === "demo" || val === "test" || val === "full"
+    || val === "golden" || val === "blank-ielts"
+  ) return val;
   console.warn(`Invalid SEED_PROFILE "${val}", defaulting to "full"`);
   return "full";
 }
@@ -104,8 +113,8 @@ async function main() {
   const profile = getProfile();
   const steps = filterSteps(profile);
 
-  // Golden/demo profiles force SEED_MODE=prod so seed-clean skips transcript imports
-  if ((profile === "golden" || profile === "demo") && !process.env.SEED_MODE) {
+  // Golden/demo/blank-ielts profiles force SEED_MODE=prod so seed-clean skips transcript imports
+  if ((profile === "golden" || profile === "demo" || profile === "blank-ielts") && !process.env.SEED_MODE) {
     process.env.SEED_MODE = "prod";
   }
 


### PR DESCRIPTION
## Summary
Adds a new `SEED_PROFILE=blank-ielts` for the partner-test bootstrap. Partners log in to a clean institution and build courses via the wizard — no demo content, no fixtures.

## What lands when this profile runs
| | |
|---|---|
| Specs + params + contracts | ✓ (foundation) |
| Identity archetypes, institution types, run configs | ✓ (foundation) |
| 3 SUPERADMIN users (admin@test.com / boaz / eldar) | ✓ (from seed-clean) |
| **Institution: "IELTS Prep Lab"** (school, slug `ielts-prep-lab`) | ✓ new |
| **Domain: "IELTS Prep Lab"** (slug `ielts-prep-lab`) | ✓ new |
| SUPERADMINs linked via `institutionId` + `activeInstitutionId` | ✓ new |
| Playbooks / Curricula / Callers / demo content | ✗ none |

## Files
- `apps/admin/prisma/seed-blank-ielts.ts` — new
- `apps/admin/prisma/seed-full.ts` — wire new profile into orchestrator
- `.claude/commands/deploy.md` — add to picker (steps 4 + section 5)

## Test plan
- [x] `tsc --noEmit` clean for new files
- [ ] Run `SEED_PROFILE=blank-ielts npx tsx prisma/seed-full.ts --reset` against VM dev DB
- [ ] Verify: 1 institution row, 1 domain row, 3 users with `institutionId` set, 0 playbooks, 0 callers
- [ ] Log in as `admin@test.com` → wizard loads with IELTS Prep Lab pre-selected → start "build new course"
- [ ] Cloud deploy with this profile picks up cleanly

## Non-goals
- Doesn't seed any rubric / course-ref documents — partners upload these via the V5 wizard
- Doesn't pre-create a playbook — partners create via wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)