### PR TITLE
fix(#590): scope curriculum-exists guard by playbookId

### DIFF
--- a/apps/admin/lib/domain/generate-content-spec.ts
+++ b/apps/admin/lib/domain/generate-content-spec.ts
@@ -118,10 +118,19 @@ export async function generateContentSpec(domainId: string, options?: GenerateCo
   // 1. Load domain + assertions via shared loader (optionally scoped to specific subjects)
   const { domain, assertions, subjectName, qualificationRef, sourceCount } = await loadDomainAssertions(domainId, tx, options?.subjectIds);
 
-  // 2. Check if curriculum already exists for THIS course's subjects (not domain-wide)
-  const curriculumFilter = options?.subjectIds?.length
+  // 2. Check if curriculum already exists for THIS course's subjects OR playbook.
+  //
+  // #590: the authored-modules path (lib/wizard/apply-projection.ts::ensureCurriculum)
+  // attaches a Curriculum to a Playbook with `playbookId` set and `subjectId = null`.
+  // The previous filter only matched by `subjectId`, so this guard missed the
+  // authored row entirely and let the AI extraction race produce a second
+  // curriculum on the same playbook (2026-05-21 IELTS incident).
+  const subjectScopedFilter = options?.subjectIds?.length
     ? { subjectId: { in: options.subjectIds } }
     : { subject: { domains: { some: { domainId } } } };
+  const curriculumFilter = options?.playbookId
+    ? { OR: [subjectScopedFilter, { playbookId: options.playbookId }] }
+    : subjectScopedFilter;
   const existingCurriculum = await p.curriculum.findFirst({
     where: curriculumFilter,
     select: { id: true },
@@ -247,8 +256,13 @@ export async function generateContentSpec(domainId: string, options?: GenerateCo
   const subjectId = options?.subjectIds?.[0];
   if (subjectId) {
     try {
+      // #590: also match by playbookId so an authored Curriculum (which has
+      // playbookId but no subjectId) is reused instead of triggering a second
+      // create on the same playbook.
       const existingCurr = await p.curriculum.findFirst({
-        where: { subjectId },
+        where: options?.playbookId
+          ? { OR: [{ subjectId }, { playbookId: options.playbookId }] }
+          : { subjectId },
         select: { id: true },
       });
       const slugify = (await import("slugify")).default;

--- a/apps/admin/tests/lib/domain/generate-content-spec.test.ts
+++ b/apps/admin/tests/lib/domain/generate-content-spec.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  curriculum: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+  domain: {
+    findUnique: vi.fn(),
+  },
+  subjectSource: {
+    findMany: vi.fn(),
+  },
+  contentAssertion: {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  playbookSubject: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("@/lib/content-trust/extract-curriculum", () => ({
+  extractCurriculumFromAssertions: vi.fn(),
+}));
+
+vi.mock("@/lib/curriculum/sync-modules", () => ({
+  syncModulesToDB: vi.fn().mockResolvedValue({ count: 0 }),
+}));
+
+import { generateContentSpec } from "@/lib/domain/generate-content-spec";
+import { extractCurriculumFromAssertions } from "@/lib/content-trust/extract-curriculum";
+
+describe("generateContentSpec — #590 idempotency vs authored curriculum", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.domain.findUnique.mockResolvedValue({
+      id: "domain-1",
+      slug: "test",
+      name: "Test Domain",
+    });
+    mockPrisma.subjectSource.findMany.mockResolvedValue([
+      {
+        sourceId: "source-1",
+        tags: [],
+        subject: { name: "Test Subject", qualificationRef: null },
+      },
+    ]);
+    mockPrisma.contentAssertion.findMany.mockResolvedValue([
+      { id: "a1", assertion: "fact one", category: "fact", chapter: null, section: null, tags: [] },
+    ]);
+  });
+
+  it("skips when an authored curriculum already exists for the playbook (no subjectId match)", async () => {
+    // Authored curriculum: has playbookId, no subjectId — the 2026-05-21 IELTS shape.
+    // The previous filter ({ subjectId: { in: [...] } }) would have missed this.
+    mockPrisma.curriculum.findFirst.mockImplementation(async ({ where }: any) => {
+      const isPlaybookScopedQuery =
+        where?.OR?.some?.((clause: any) => clause.playbookId === "pb-authored");
+      return isPlaybookScopedQuery ? { id: "curr-authored" } : null;
+    });
+
+    const result = await generateContentSpec("domain-1", {
+      subjectIds: ["subj-1"],
+      playbookId: "pb-authored",
+    });
+
+    expect(result.skipped).toContain("Curriculum already exists");
+    expect(result.addedToPlaybook).toBe(false);
+    expect(extractCurriculumFromAssertions).not.toHaveBeenCalled();
+    expect(mockPrisma.curriculum.create).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original subjectId-only filter when no playbookId is given", async () => {
+    // Non-authored / legacy callers: behavior unchanged when options.playbookId is undefined.
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-existing-via-subject" });
+
+    const result = await generateContentSpec("domain-1", {
+      subjectIds: ["subj-1"],
+    });
+
+    expect(result.skipped).toContain("Curriculum already exists");
+    const findFirstCall = mockPrisma.curriculum.findFirst.mock.calls[0][0];
+    expect(findFirstCall.where).toEqual({ subjectId: { in: ["subj-1"] } });
+    expect(findFirstCall.where.OR).toBeUndefined();
+  });
+
+  it("runs the AI path when no curriculum exists yet — non-authored case still works", async () => {
+    // The "leave 2x routes for Authored and non-Authored to work" constraint:
+    // when nothing exists yet, AI extraction must fire and produce a curriculum.
+    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+    (extractCurriculumFromAssertions as any).mockResolvedValue({
+      ok: true,
+      modules: [],
+      assertionTags: [],
+    });
+
+    const result = await generateContentSpec("domain-1", {
+      subjectIds: ["subj-1"],
+      playbookId: "pb-non-authored",
+    });
+
+    expect(extractCurriculumFromAssertions).toHaveBeenCalled();
+    expect(result.skipped).not.toContain("Curriculum already exists");
+  });
+});

--- a/apps/admin/tests/lib/seed-ielts-fixture.test.ts
+++ b/apps/admin/tests/lib/seed-ielts-fixture.test.ts
@@ -91,10 +91,11 @@ describe("IELTS seed fixture", () => {
     }
   });
 
-  it("detects 4 authored modules with stable slugs", () => {
-    expect(projection.curriculumModules).toHaveLength(4);
+  it("detects 5 authored modules with stable slugs", () => {
+    expect(projection.curriculumModules).toHaveLength(5);
     expect(projection.curriculumModules.map((m) => m.slug).sort()).toEqual([
       "baseline",
+      "mock",
       "part1",
       "part2",
       "part3",


### PR DESCRIPTION
## Summary

- Closes the race in `generateContentSpec` that let the AI extraction create a second `Curriculum` row on a playbook that already had an authored one (2026-05-21 IELTS partner-test incident, playbook `ec4127a1`).
- Extends both `curriculum.findFirst` guards (lines 122 + 250) to also match by `playbookId` when `options.playbookId` is provided — catches the authored row, which has `playbookId` but no `subjectId`.
- Legacy callers that don't pass `playbookId` see no behavior change.
- Both module-source pipelines (authored + AI-extracted) remain functional; they're now mutually exclusive at write time, with whichever creates first winning.

Plus one drift fix that came up while triaging the same incident:
- `tests/lib/seed-ielts-fixture.test.ts` updated from "4 modules" to "5 modules" — the Mock module was added by #550 (`c85d3116`) but the test was never updated.

## Test plan

- [x] `npx vitest run tests/lib/domain/generate-content-spec.test.ts` — 3/3 pass (authored-exists-skip, legacy-callers-unchanged, no-curriculum-runs-AI)
- [x] `npx vitest run tests/lib/seed-ielts-fixture.test.ts` — 11/11 pass
- [x] `npx tsc --noEmit` — zero new errors in touched files
- [ ] Manual on VM: walk through `/x/get-started-v5` with course-ref + materials, confirm only ONE curriculum attaches to the new playbook
- [ ] Manual on VM: walk through the non-authored path (no canonical course-ref uploaded), confirm AI extraction still produces its curriculum

## Notes

This is the **race-fix half** of the two-story bug surfaced in the 2026-05-21 partner-test. The companion defensive story is [#589](https://github.com/WANDERCOLTD/HF/issues/589) (Curriculum.isCanonical schema flag + filter all 22 `curricula[0]` reads), to be picked up in a separate session per Tech Lead sequencing.

The IELTS playbook `ec4127a1-2097-4ad4-8f11-af5da46c679e` was cleaned up directly in the dev DB before this fix (curriculum B deleted, 10 modules + 84 LOs gone via cascade). Once this PR ships, new courses won't end up in the same state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)