### PR TITLE
fix(#554): resolve outcome refs + gate moduleToReview on attempt evidence

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -475,6 +475,49 @@ export async function computeSharedState(
       });
   }
 
+  // ── #266 Slice 1 + #554 Fix 2: per-learner module attempt data ──
+  // Hoisted above the moduleToReview gate so `hasAttemptData` can short-circuit
+  // the modules[0] fallback for true zero-progress learners. Without this gate,
+  // a brand-new caller (zero CallerModuleProgress, zero recentCalls) would have
+  // moduleToReview resolve to modules[0] and downstream pedagogy emits a
+  // "review your baseline work" block before any call exists.
+  // `pbConfig` is also consumed by isFinalSession logic further down — declare
+  // once at function scope, reuse.
+  const pbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, any>;
+  const sessionCount = pbConfig.sessionCount as number | undefined;
+  let moduleAttemptCounts: SharedComputedState["moduleAttemptCounts"] = undefined;
+  let hasAttemptData = false;
+  if (pbConfig.modulesAuthored === true && curriculumId && data.caller?.id) {
+    try {
+      const rows = await prisma.callerModuleProgress.findMany({
+        where: {
+          callerId: data.caller.id,
+          module: { curriculumId },
+        },
+        select: {
+          moduleId: true,
+          callCount: true,
+          status: true,
+          completedAt: true,
+        },
+      });
+      moduleAttemptCounts = {};
+      for (const row of rows) {
+        moduleAttemptCounts[row.moduleId] = {
+          callCount: row.callCount,
+          status: (row.status as "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED") ?? "NOT_STARTED",
+          completedAt: row.completedAt,
+        };
+        if (row.callCount > 0) hasAttemptData = true;
+      }
+      console.log(
+        `[modules] #266: loaded ${rows.length} CallerModuleProgress rows; hasAttemptData=${hasAttemptData}`,
+      );
+    } catch (err) {
+      console.warn("[modules] #266: callerModuleProgress query failed (non-blocking):", err);
+    }
+  }
+
   // Estimate progress: if no explicit tracking, assume ~1 module per 2 calls
   const estimatedProgress = completedModules.size > 0
     ? completedModules.size
@@ -487,8 +530,17 @@ export async function computeSharedState(
       ))
     : Math.max(0, estimatedProgress - 1);
 
-  // Module to review = last completed (or first if no progress)
-  const moduleToReview = modules[lastCompletedIndex] || modules[0] || null;
+  // Module to review — gated on real evidence of prior activity (any of:
+  // a completed module, a CallerModuleProgress row with callCount > 0, or any
+  // prior call in this caller's history). Without this gate, lastCompletedIndex
+  // defaults to 0 so `modules[lastCompletedIndex]` ALWAYS resolves to modules[0]
+  // and downstream pedagogy emits a "review your baseline work" block before
+  // any call exists. See #554 Fix 2.
+  const hasAnyPriorActivity =
+    completedModules.size > 0 || hasAttemptData || data.recentCalls.length > 0;
+  const moduleToReview = hasAnyPriorActivity
+    ? (modules[lastCompletedIndex] || modules[0] || null)
+    : null;
 
   // Next module = one after last completed
   const nextModuleIndex = lastCompletedIndex + 1;
@@ -541,8 +593,9 @@ export async function computeSharedState(
   if (!lockedModule && requestedModuleId) {
     // Match against Playbook.config.modules (the authored shape). The picker
     // emits the AuthoredModule.id as ?requestedModuleId=… so we match on id.
-    // pbConfig is declared further down (line ~672) for the isFinalSession
-    // logic — read directly here to avoid temporal-dead-zone gymnastics.
+    // `pbConfig` is now declared earlier (just before moduleToReview) but kept
+    // as a local `lockedPbConfig` here for the `unknown`-typed cast — the
+    // authored-module shape is more permissive than the `any`-cast pbConfig.
     const lockedPbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, unknown>;
     const authored = (Array.isArray(lockedPbConfig.modules) ? lockedPbConfig.modules : []) as Array<{
       id?: string;
@@ -553,13 +606,31 @@ export async function computeSharedState(
     }>;
     const match = authored.find((m) => m?.id === requestedModuleId);
     if (match) {
+      // #554 Fix 1: outcomesPrimary holds bare refs ("OUT-01"). Resolve each
+      // through lockedPbConfig.outcomes (Record<ref,text>) so the composed
+      // prompt narrates the human statement, not the opaque ref id. Missing
+      // entries fall back to the bare ref + console.warn — never silently
+      // drop, so authoring mistakes are visible in logs.
+      const outcomesMap = lockedPbConfig.outcomes as Record<string, string> | undefined;
+      const resolveOutcome = (ref: string): string => {
+        const text = outcomesMap?.[ref];
+        if (!text) {
+          console.warn(
+            `[modules] #554 Fix 1: outcome ref "${ref}" not found in Playbook.config.outcomes — passing through bare ref`,
+          );
+          return ref;
+        }
+        return text;
+      };
       lockedModule = {
         id: match.id,
         slug: match.id || "",
         // AuthoredModule has `label` not `name`; map for downstream `ModuleData` consumers.
         name: match.label || match.id || requestedModuleId,
         description: null,
-        learningOutcomes: Array.isArray(match.outcomesPrimary) ? (match.outcomesPrimary as string[]) : undefined,
+        learningOutcomes: Array.isArray(match.outcomesPrimary)
+          ? (match.outcomesPrimary as string[]).map(resolveOutcome)
+          : undefined,
         prerequisites: Array.isArray(match.prerequisites) ? (match.prerequisites as string[]) : undefined,
         content: match.content,
       };
@@ -803,48 +874,9 @@ export async function computeSharedState(
 
   const thresholds = specConfig.thresholds || { high: 0.65, low: 0.35 };
 
-  // Determine if this is the final teaching session
-  const pbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, any>;
-  const sessionCount = pbConfig.sessionCount as number | undefined;
-
-  // ── #266 Slice 1: per-learner module progress (authored courses only) ──
-  // Source of truth for "you've done Baseline twice" narratives. Reads
-  // CallerModuleProgress, which is incremented inside updateModuleMastery
-  // (track-progress.ts) at session end — so the count the tutor sees at the
-  // start of a session reflects completed sessions only. Indexed on
-  // [callerId, status] (schema.prisma) → cheap.
-  let moduleAttemptCounts: SharedComputedState["moduleAttemptCounts"] = undefined;
-  let hasAttemptData = false;
-  if (pbConfig.modulesAuthored === true && curriculumId && data.caller?.id) {
-    try {
-      const rows = await prisma.callerModuleProgress.findMany({
-        where: {
-          callerId: data.caller.id,
-          module: { curriculumId },
-        },
-        select: {
-          moduleId: true,
-          callCount: true,
-          status: true,
-          completedAt: true,
-        },
-      });
-      moduleAttemptCounts = {};
-      for (const row of rows) {
-        moduleAttemptCounts[row.moduleId] = {
-          callCount: row.callCount,
-          status: (row.status as "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED") ?? "NOT_STARTED",
-          completedAt: row.completedAt,
-        };
-        if (row.callCount > 0) hasAttemptData = true;
-      }
-      console.log(
-        `[modules] #266: loaded ${rows.length} CallerModuleProgress rows; hasAttemptData=${hasAttemptData}`,
-      );
-    } catch (err) {
-      console.warn("[modules] #266: callerModuleProgress query failed (non-blocking):", err);
-    }
-  }
+  // pbConfig + sessionCount + moduleAttemptCounts + hasAttemptData are all
+  // hoisted above moduleToReview (see #554 Fix 2). Reused here for
+  // isFinalSession + returned shared state.
 
   const callNumber = data.recentCalls.length + 1; // 1-based: this is the Nth call
   const isFinalByBudget = !!(sessionCount && sessionCount > 0 && callNumber >= sessionCount);

--- a/apps/admin/tests/lib/composition/modules-requested-module.test.ts
+++ b/apps/admin/tests/lib/composition/modules-requested-module.test.ts
@@ -178,8 +178,10 @@ describe("computeSharedState — #492 Slice 3.1 requestedModuleId arg", () => {
     const result = await computeSharedState(data, specs, {}, undefined, "MOD-DOES-NOT-EXIST");
 
     expect(result.lockedModule).toBeNull();
-    // Existing fallback: with no progress, moduleToReview=MOD-1 and nextModule=MOD-2.
-    expect(result.moduleToReview?.id).toBe("MOD-1");
+    // #554 Fix 2: zero progress + zero recent calls → moduleToReview is null
+    // (no "review your baseline" hallucination before any call exists).
+    // nextModule still resolves to MOD-2 — frontier pick is independent.
+    expect(result.moduleToReview).toBeNull();
     expect(result.nextModule?.id).toBe("MOD-2");
     // Warning surfaced so wizard/route bugs are visible in dev.
     expect(warnSpy).toHaveBeenCalledWith(
@@ -199,8 +201,9 @@ describe("computeSharedState — #492 Slice 3.1 requestedModuleId arg", () => {
     expect(withUndefinedArg.lockedModule).toBeNull();
     expect(withNullArg.lockedModule).toBeNull();
 
-    // Stable pick — without any override, MOD-1 is moduleToReview, MOD-2 is next.
-    expect(withoutArg.moduleToReview?.id).toBe("MOD-1");
+    // #554 Fix 2: zero-progress + zero recentCalls → moduleToReview is null.
+    // nextModule still resolves to MOD-2 (frontier pick is independent).
+    expect(withoutArg.moduleToReview).toBeNull();
     expect(withoutArg.nextModule?.id).toBe("MOD-2");
     expect(withUndefinedArg.nextModule?.id).toBe("MOD-2");
     expect(withNullArg.nextModule?.id).toBe("MOD-2");
@@ -277,6 +280,184 @@ describe("computeSharedState — #492 Slice 3.1 requestedModuleId arg", () => {
     );
     expect(result.lockedModule?.id).toBe("part1");
     expect(result.nextModule?.id).toBe("part1");
+  });
+});
+
+// =====================================================
+// #554 Fix 1: outcomesPrimary refs are resolved to statement text
+// =====================================================
+
+describe("computeSharedState — #554 Fix 1 outcome ref resolution", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  const dataWithAuthoredOutcomes = () =>
+    makeLoadedData({
+      playbooks: [
+        {
+          id: "pb-1",
+          name: "IELTS",
+          isActive: true,
+          isLatest: true,
+          config: {
+            modulesAuthored: true,
+            modules: [
+              {
+                id: "part1",
+                label: "Part 1",
+                outcomesPrimary: ["OUT-01", "OUT-02"],
+              },
+              {
+                id: "part2",
+                label: "Part 2",
+                outcomesPrimary: ["OUT-03"],
+              },
+            ],
+            outcomes: {
+              "OUT-01": "Extends Part 1 answers to 2-3 sentence minimum",
+              "OUT-02": "Uses topic-specific vocabulary in introductions",
+              "OUT-03": "Sustains a long-turn answer for at least 90 seconds",
+            },
+          } as any,
+        } as any,
+      ],
+    });
+
+  it("resolves outcomesPrimary refs through lockedPbConfig.outcomes", async () => {
+    const data = dataWithAuthoredOutcomes();
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, { requestedModuleId: "part1" });
+
+    expect(result.lockedModule?.id).toBe("part1");
+    // Resolved text — not bare refs.
+    expect(result.lockedModule?.learningOutcomes).toEqual([
+      "Extends Part 1 answers to 2-3 sentence minimum",
+      "Uses topic-specific vocabulary in introductions",
+    ]);
+    // No warning — every ref resolved cleanly.
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("outcome ref"),
+    );
+  });
+
+  it("falls back to bare ref + console.warn when an outcome ref is not in the map", async () => {
+    const data = makeLoadedData({
+      playbooks: [
+        {
+          id: "pb-1",
+          name: "IELTS",
+          isActive: true,
+          isLatest: true,
+          config: {
+            modulesAuthored: true,
+            modules: [
+              {
+                id: "part1",
+                label: "Part 1",
+                outcomesPrimary: ["OUT-01", "OUT-MISSING"],
+              },
+            ],
+            outcomes: {
+              "OUT-01": "Extends Part 1 answers to 2-3 sentence minimum",
+            },
+          } as any,
+        } as any,
+      ],
+    });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, { requestedModuleId: "part1" });
+
+    expect(result.lockedModule?.learningOutcomes).toEqual([
+      "Extends Part 1 answers to 2-3 sentence minimum",
+      "OUT-MISSING",
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('outcome ref "OUT-MISSING"'),
+    );
+  });
+
+  it("leaves learningOutcomes undefined when outcomesPrimary is not an array", async () => {
+    const data = makeLoadedData({
+      playbooks: [
+        {
+          id: "pb-1",
+          name: "IELTS",
+          isActive: true,
+          isLatest: true,
+          config: {
+            modulesAuthored: true,
+            modules: [{ id: "part1", label: "Part 1" }],
+            outcomes: { "OUT-01": "text" },
+          } as any,
+        } as any,
+      ],
+    });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, { requestedModuleId: "part1" });
+
+    expect(result.lockedModule?.id).toBe("part1");
+    expect(result.lockedModule?.learningOutcomes).toBeUndefined();
+  });
+});
+
+// =====================================================
+// #554 Fix 2: moduleToReview gated on attempt evidence
+// =====================================================
+
+describe("computeSharedState — #554 Fix 2 moduleToReview gating", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("null moduleToReview when no completed modules AND no recent calls", async () => {
+    const data = makeLoadedData({ subjectSources: subjectSourcesWithModules as any });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, {});
+
+    expect(result.completedModules.size).toBe(0);
+    expect(data.recentCalls.length).toBe(0);
+    expect(result.moduleToReview).toBeNull();
+  });
+
+  it("non-null moduleToReview when caller has at least one recentCall (regression guard for continuous-mode)", async () => {
+    const data = makeLoadedData({
+      subjectSources: subjectSourcesWithModules as any,
+      recentCalls: [
+        {
+          id: "call-prev",
+          createdAt: new Date(),
+          notes: null,
+          summary: null,
+          score: null,
+          callerId: "caller-1",
+          domain: null,
+        } as any,
+      ],
+    });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, {});
+
+    // With at least one prior call, the modules[0] fallback is allowed.
+    expect(result.moduleToReview?.id).toBe("MOD-1");
   });
 });
 

--- a/apps/admin/tests/lib/composition/modules.test.ts
+++ b/apps/admin/tests/lib/composition/modules.test.ts
@@ -206,9 +206,11 @@ describe("computeSharedState", () => {
       const specs = makeResolvedSpecs();
       const result = await computeSharedState(data, specs, {});
 
-      // With no calls/mastery, MOD-1 is moduleToReview (index 0) and nextModule is MOD-2 (index 1)
-      expect(result.moduleToReview).toBeDefined();
-      expect(result.moduleToReview!.id).toBe("MOD-1");
+      // #554 Fix 2: with zero progress AND zero recent calls, moduleToReview
+      // is null — no "review your baseline" hallucination for a brand-new
+      // learner. nextModule still resolves to MOD-2 (frontier pick is
+      // independent of the review gate).
+      expect(result.moduleToReview).toBeNull();
       expect(result.nextModule).toBeDefined();
       expect(result.nextModule!.id).toBe("MOD-2");
     });


### PR DESCRIPTION
## Summary

Two narrow first-call bugs in `modules.ts` that hit authored IELTS UX:

1. **Bare `OUT-NN` refs in composed prompts** — `learningOutcomes` passed bare ref ids instead of resolved statements; the AI hallucinated fallback IELTS content.
2. **"Review your baseline" before any call exists** — `moduleToReview` defaulted to `modules[0]` for any caller because `lastCompletedIndex` defaulted to 0.

## Changes

- Resolve `outcomesPrimary` refs through `Playbook.config.outcomes` with bare-ref + `console.warn` fallback for misses.
- Hoist `pbConfig` + `moduleAttemptCounts` query above the review gate so `hasAttemptData` is available; `moduleToReview === null` when no prior activity (completedModules / hasAttemptData / recentCalls all empty).

## Tests

- 3 new tests for outcome ref resolution (resolved / missing-ref fallback / non-array passthrough)
- 2 new tests for review-gate (null for zero-progress / non-null when recentCalls > 0 — continuous-mode regression guard)
- Updated 3 pre-existing tests that asserted the buggy modules[0] fallback for zero-progress callers
- All 392 composition tests pass; 4210/4226 unit tests pass (16 pre-existing skips)

## Test plan
- [ ] Run `npx tsx scripts/proof-554-modules-fix.ts` (from \`apps/admin/\`) — should report PASS/PASS against the IELTS playbook on the dev DB
- [ ] Manually fire a first call for a brand-new IELTS learner → tutor does NOT open with "review your baseline work" wording
- [ ] Inspect composed prompt for a `requestedModuleId` call → no bare `OUT-NN` tokens

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)