### PR TITLE
chore(#561): proof scripts for sim-call verification of #554 + #561

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -475,6 +475,49 @@ export async function computeSharedState(
       });
   }
 
+  // ── #266 Slice 1 + #554 Fix 2: per-learner module attempt data ──
+  // Hoisted above the moduleToReview gate so `hasAttemptData` can short-circuit
+  // the modules[0] fallback for true zero-progress learners. Without this gate,
+  // a brand-new caller (zero CallerModuleProgress, zero recentCalls) would have
+  // moduleToReview resolve to modules[0] and downstream pedagogy emits a
+  // "review your baseline work" block before any call exists.
+  // `pbConfig` is also consumed by isFinalSession logic further down — declare
+  // once at function scope, reuse.
+  const pbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, any>;
+  const sessionCount = pbConfig.sessionCount as number | undefined;
+  let moduleAttemptCounts: SharedComputedState["moduleAttemptCounts"] = undefined;
+  let hasAttemptData = false;
+  if (pbConfig.modulesAuthored === true && curriculumId && data.caller?.id) {
+    try {
+      const rows = await prisma.callerModuleProgress.findMany({
+        where: {
+          callerId: data.caller.id,
+          module: { curriculumId },
+        },
+        select: {
+          moduleId: true,
+          callCount: true,
+          status: true,
+          completedAt: true,
+        },
+      });
+      moduleAttemptCounts = {};
+      for (const row of rows) {
+        moduleAttemptCounts[row.moduleId] = {
+          callCount: row.callCount,
+          status: (row.status as "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED") ?? "NOT_STARTED",
+          completedAt: row.completedAt,
+        };
+        if (row.callCount > 0) hasAttemptData = true;
+      }
+      console.log(
+        `[modules] #266: loaded ${rows.length} CallerModuleProgress rows; hasAttemptData=${hasAttemptData}`,
+      );
+    } catch (err) {
+      console.warn("[modules] #266: callerModuleProgress query failed (non-blocking):", err);
+    }
+  }
+
   // Estimate progress: if no explicit tracking, assume ~1 module per 2 calls
   const estimatedProgress = completedModules.size > 0
     ? completedModules.size
@@ -487,8 +530,17 @@ export async function computeSharedState(
       ))
     : Math.max(0, estimatedProgress - 1);
 
-  // Module to review = last completed (or first if no progress)
-  const moduleToReview = modules[lastCompletedIndex] || modules[0] || null;
+  // Module to review — gated on real evidence of prior activity (any of:
+  // a completed module, a CallerModuleProgress row with callCount > 0, or any
+  // prior call in this caller's history). Without this gate, lastCompletedIndex
+  // defaults to 0 so `modules[lastCompletedIndex]` ALWAYS resolves to modules[0]
+  // and downstream pedagogy emits a "review your baseline work" block before
+  // any call exists. See #554 Fix 2.
+  const hasAnyPriorActivity =
+    completedModules.size > 0 || hasAttemptData || data.recentCalls.length > 0;
+  const moduleToReview = hasAnyPriorActivity
+    ? (modules[lastCompletedIndex] || modules[0] || null)
+    : null;
 
   // Next module = one after last completed
   const nextModuleIndex = lastCompletedIndex + 1;
@@ -541,8 +593,9 @@ export async function computeSharedState(
   if (!lockedModule && requestedModuleId) {
     // Match against Playbook.config.modules (the authored shape). The picker
     // emits the AuthoredModule.id as ?requestedModuleId=… so we match on id.
-    // pbConfig is declared further down (line ~672) for the isFinalSession
-    // logic — read directly here to avoid temporal-dead-zone gymnastics.
+    // `pbConfig` is now declared earlier (just before moduleToReview) but kept
+    // as a local `lockedPbConfig` here for the `unknown`-typed cast — the
+    // authored-module shape is more permissive than the `any`-cast pbConfig.
     const lockedPbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, unknown>;
     const authored = (Array.isArray(lockedPbConfig.modules) ? lockedPbConfig.modules : []) as Array<{
       id?: string;
@@ -553,13 +606,31 @@ export async function computeSharedState(
     }>;
     const match = authored.find((m) => m?.id === requestedModuleId);
     if (match) {
+      // #554 Fix 1: outcomesPrimary holds bare refs ("OUT-01"). Resolve each
+      // through lockedPbConfig.outcomes (Record<ref,text>) so the composed
+      // prompt narrates the human statement, not the opaque ref id. Missing
+      // entries fall back to the bare ref + console.warn — never silently
+      // drop, so authoring mistakes are visible in logs.
+      const outcomesMap = lockedPbConfig.outcomes as Record<string, string> | undefined;
+      const resolveOutcome = (ref: string): string => {
+        const text = outcomesMap?.[ref];
+        if (!text) {
+          console.warn(
+            `[modules] #554 Fix 1: outcome ref "${ref}" not found in Playbook.config.outcomes — passing through bare ref`,
+          );
+          return ref;
+        }
+        return text;
+      };
       lockedModule = {
         id: match.id,
         slug: match.id || "",
         // AuthoredModule has `label` not `name`; map for downstream `ModuleData` consumers.
         name: match.label || match.id || requestedModuleId,
         description: null,
-        learningOutcomes: Array.isArray(match.outcomesPrimary) ? (match.outcomesPrimary as string[]) : undefined,
+        learningOutcomes: Array.isArray(match.outcomesPrimary)
+          ? (match.outcomesPrimary as string[]).map(resolveOutcome)
+          : undefined,
         prerequisites: Array.isArray(match.prerequisites) ? (match.prerequisites as string[]) : undefined,
         content: match.content,
       };
@@ -803,48 +874,9 @@ export async function computeSharedState(
 
   const thresholds = specConfig.thresholds || { high: 0.65, low: 0.35 };
 
-  // Determine if this is the final teaching session
-  const pbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, any>;
-  const sessionCount = pbConfig.sessionCount as number | undefined;
-
-  // ── #266 Slice 1: per-learner module progress (authored courses only) ──
-  // Source of truth for "you've done Baseline twice" narratives. Reads
-  // CallerModuleProgress, which is incremented inside updateModuleMastery
-  // (track-progress.ts) at session end — so the count the tutor sees at the
-  // start of a session reflects completed sessions only. Indexed on
-  // [callerId, status] (schema.prisma) → cheap.
-  let moduleAttemptCounts: SharedComputedState["moduleAttemptCounts"] = undefined;
-  let hasAttemptData = false;
-  if (pbConfig.modulesAuthored === true && curriculumId && data.caller?.id) {
-    try {
-      const rows = await prisma.callerModuleProgress.findMany({
-        where: {
-          callerId: data.caller.id,
-          module: { curriculumId },
-        },
-        select: {
-          moduleId: true,
-          callCount: true,
-          status: true,
-          completedAt: true,
-        },
-      });
-      moduleAttemptCounts = {};
-      for (const row of rows) {
-        moduleAttemptCounts[row.moduleId] = {
-          callCount: row.callCount,
-          status: (row.status as "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED") ?? "NOT_STARTED",
-          completedAt: row.completedAt,
-        };
-        if (row.callCount > 0) hasAttemptData = true;
-      }
-      console.log(
-        `[modules] #266: loaded ${rows.length} CallerModuleProgress rows; hasAttemptData=${hasAttemptData}`,
-      );
-    } catch (err) {
-      console.warn("[modules] #266: callerModuleProgress query failed (non-blocking):", err);
-    }
-  }
+  // pbConfig + sessionCount + moduleAttemptCounts + hasAttemptData are all
+  // hoisted above moduleToReview (see #554 Fix 2). Reused here for
+  // isFinalSession + returned shared state.
 
   const callNumber = data.recentCalls.length + 1; // 1-based: this is the Nth call
   const isFinalByBudget = !!(sessionCount && sessionCount > 0 && callNumber >= sessionCount);

--- a/apps/admin/scripts/proof-554-modules-fix.ts
+++ b/apps/admin/scripts/proof-554-modules-fix.ts
@@ -1,0 +1,195 @@
+/**
+ * Proof script for #554 — outcome ref resolution + moduleToReview gating.
+ *
+ * Runs `computeSharedState` against real DB data and verifies:
+ *
+ *   FIX 1 — lockedModule.learningOutcomes contains resolved statement text,
+ *            not bare "OUT-NN" refs.
+ *   FIX 2 — for a caller with zero CallerModuleProgress + zero recentCalls,
+ *            moduleToReview === null (no "review your baseline" hallucination
+ *            before any call exists).
+ *
+ * Usage (from apps/admin/):
+ *   npx tsx scripts/proof-554-modules-fix.ts                    # auto-pick IELTS playbook + a fresh caller
+ *   npx tsx scripts/proof-554-modules-fix.ts --playbook <id>    # specific playbook
+ *   npx tsx scripts/proof-554-modules-fix.ts --caller <id>      # specific caller
+ *
+ * The script prints PASS/FAIL per fix and exits non-zero on failure.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { loadAllData } from "@/lib/prompt/composition/SectionDataLoader";
+import { computeSharedState } from "@/lib/prompt/composition/transforms/modules";
+
+const OUT_REF = /^OUT-\d+$/i;
+
+async function pickPlaybook(targetId: string | null): Promise<{
+  id: string;
+  name: string;
+  modulesAuthored: boolean;
+  firstAuthoredModuleId: string | null;
+  outcomesCount: number;
+} | null> {
+  const pb = targetId
+    ? await prisma.playbook.findUnique({
+        where: { id: targetId },
+        select: { id: true, name: true, config: true },
+      })
+    : await prisma.playbook.findFirst({
+        where: {
+          OR: [
+            { name: { contains: "IELTS", mode: "insensitive" } },
+            { name: { contains: "ielts", mode: "insensitive" } },
+          ],
+        },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, name: true, config: true },
+      });
+  if (!pb) return null;
+  const cfg = (pb.config ?? {}) as {
+    modulesAuthored?: boolean;
+    modules?: Array<{ id?: string; outcomesPrimary?: unknown }>;
+    outcomes?: Record<string, string>;
+  };
+  const firstAuthored = (cfg.modules ?? []).find(
+    (m) => m && typeof m.id === "string" && Array.isArray(m.outcomesPrimary) && (m.outcomesPrimary as unknown[]).length > 0,
+  );
+  return {
+    id: pb.id,
+    name: pb.name,
+    modulesAuthored: cfg.modulesAuthored === true,
+    firstAuthoredModuleId: firstAuthored?.id ?? null,
+    outcomesCount: Object.keys(cfg.outcomes ?? {}).length,
+  };
+}
+
+async function pickCaller(targetId: string | null, playbookId: string): Promise<{ id: string; name: string | null } | null> {
+  if (targetId) {
+    return prisma.caller.findUnique({ where: { id: targetId }, select: { id: true, name: true } });
+  }
+  // Prefer a caller enrolled on this playbook with zero calls (cleanest
+  // zero-progress proof for Fix 2). Relation on Caller is `enrollments`
+  // (CallerPlaybook[]); call count comes from `Call` rows by callerId.
+  const candidates = await prisma.caller.findMany({
+    select: { id: true, name: true },
+    where: { enrollments: { some: { playbookId } } },
+    take: 50,
+  });
+  for (const c of candidates) {
+    const callCount = await prisma.call.count({ where: { callerId: c.id } });
+    if (callCount === 0) return c;
+  }
+  return candidates[0] ?? null;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const playbookFlag = args.indexOf("--playbook");
+  const callerFlag = args.indexOf("--caller");
+  const targetPlaybookId = playbookFlag !== -1 ? args[playbookFlag + 1] : null;
+  const targetCallerId = callerFlag !== -1 ? args[callerFlag + 1] : null;
+
+  const playbook = await pickPlaybook(targetPlaybookId);
+  if (!playbook) {
+    console.log("[proof-554] No IELTS-like playbook found.");
+    process.exit(1);
+  }
+  if (!playbook.modulesAuthored) {
+    console.log(`[proof-554] Playbook ${playbook.id} (${playbook.name}) is NOT modulesAuthored.`);
+    console.log("[proof-554] Fix 1 only applies to authored courses. Pass --playbook for an authored one.");
+    process.exit(1);
+  }
+  if (!playbook.firstAuthoredModuleId) {
+    console.log(`[proof-554] Playbook ${playbook.id} has no authored module with outcomesPrimary refs.`);
+    process.exit(1);
+  }
+  if (playbook.outcomesCount === 0) {
+    console.log(`[proof-554] Playbook ${playbook.id} has empty Playbook.config.outcomes — refs cannot resolve.`);
+    console.log("[proof-554] (This is a content-side gap, not a code-side gap — Fix 1 still applies once outcomes are authored.)");
+  }
+
+  const caller = await pickCaller(targetCallerId, playbook.id);
+  if (!caller) {
+    console.log(`[proof-554] No caller found enrolled on playbook ${playbook.id}.`);
+    process.exit(1);
+  }
+
+  console.log(`[proof-554] playbook: ${playbook.id} (${playbook.name})`);
+  console.log(`[proof-554] caller:   ${caller.id} (${caller.name ?? "(unnamed)"})`);
+  console.log(`[proof-554] authored module: ${playbook.firstAuthoredModuleId}`);
+  console.log(`[proof-554] outcomes map size: ${playbook.outcomesCount}`);
+  console.log();
+
+  // ── Fix 1 proof — requestedModuleId path resolves refs to text ─────────
+  console.log("=== FIX 1 — outcome ref resolution ===");
+  const data1 = await loadAllData(caller.id, {}, { requestedModuleId: playbook.firstAuthoredModuleId });
+  const result1 = await computeSharedState(
+    data1,
+    { identitySpec: null, voiceSpec: null },
+    { requestedModuleId: playbook.firstAuthoredModuleId },
+    "proof-554",
+  );
+  console.log(`lockedModule.id: ${result1.lockedModule?.id ?? "(null)"}`);
+  console.log(`lockedModule.learningOutcomes:`);
+  const outcomes = result1.lockedModule?.learningOutcomes ?? [];
+  for (const o of outcomes) {
+    console.log(`  - ${o.slice(0, 100)}${o.length > 100 ? "..." : ""}`);
+  }
+  const bareRefs = outcomes.filter((o) => OUT_REF.test(o));
+  const fix1Pass = result1.lockedModule !== null && outcomes.length > 0 && bareRefs.length === 0;
+  if (bareRefs.length > 0) {
+    console.log(`  → FAIL (${bareRefs.length} bare ref(s) leaked through: ${bareRefs.join(", ")})`);
+    console.log(`     Most likely cause: Playbook.config.outcomes is missing entries for these refs.`);
+  } else if (outcomes.length === 0) {
+    console.log(`  → FAIL (no learningOutcomes returned — module has no outcomesPrimary?)`);
+  } else {
+    console.log(`  → PASS (all ${outcomes.length} refs resolved to statement text)`);
+  }
+  console.log();
+
+  // ── Fix 2 proof — zero-progress caller → moduleToReview is null ──────
+  console.log("=== FIX 2 — moduleToReview gate ===");
+  // Reuse the loaded data but DROP recentCalls + clear completedModules paths
+  // by querying CallerModuleProgress count to confirm true zero-progress state.
+  const cmpCount = await prisma.callerModuleProgress.count({
+    where: { callerId: caller.id },
+  });
+  console.log(`CallerModuleProgress rows for this caller: ${cmpCount}`);
+  console.log(`recentCalls length: ${data1.recentCalls.length}`);
+
+  // Run without requestedModuleId so the module-pick path is the default.
+  const result2 = await computeSharedState(data1, { identitySpec: null, voiceSpec: null }, {}, "proof-554");
+  console.log(`moduleToReview: ${result2.moduleToReview?.id ?? "(null)"}`);
+  console.log(`nextModule:     ${result2.nextModule?.id ?? "(null)"}`);
+
+  const trueZeroProgress = cmpCount === 0 && data1.recentCalls.length === 0;
+  let fix2Pass: boolean;
+  if (trueZeroProgress) {
+    fix2Pass = result2.moduleToReview === null;
+    console.log(
+      `  → ${fix2Pass ? "PASS" : "FAIL"} (zero-progress caller, expect moduleToReview === null)`,
+    );
+  } else {
+    // Selected caller has progress — confirm review still resolves (regression guard).
+    fix2Pass = result2.moduleToReview !== null;
+    console.log(
+      `  → ${fix2Pass ? "PASS" : "FAIL"} (caller has prior activity, expect moduleToReview non-null)`,
+    );
+    console.log(
+      `     (For the true-null proof, pick a caller with zero CallerModuleProgress AND zero recentCalls.)`,
+    );
+  }
+
+  console.log();
+  console.log("=== SUMMARY ===");
+  console.log(`Fix 1 (outcome refs resolved):   ${fix1Pass ? "PASS" : "FAIL"}`);
+  console.log(`Fix 2 (review gate):             ${fix2Pass ? "PASS" : "FAIL"}`);
+  process.exit(fix1Pass && fix2Pass ? 0 : 1);
+}
+
+main()
+  .catch((err) => {
+    console.error("[proof-554] error:", err);
+    process.exit(2);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/admin/scripts/proof-561-band-thresholds.ts
+++ b/apps/admin/scripts/proof-561-band-thresholds.ts
@@ -1,0 +1,140 @@
+/**
+ * Proof script for #561 — band descriptors → Parameter.config.bandThresholds
+ *
+ * The systemic fix called out by #561 was shipped as #564 + 6c0fd172. This
+ * script verifies on a live DB that the rubric-only projection pass actually
+ * populates `Parameter.config.bandThresholds` for skill parameters.
+ *
+ * Usage (from apps/admin/):
+ *   npx tsx scripts/proof-561-band-thresholds.ts                 # report current state
+ *   npx tsx scripts/proof-561-band-thresholds.ts --reproject     # also run rubric pass
+ *   npx tsx scripts/proof-561-band-thresholds.ts --playbook ID   # target a specific playbook
+ *
+ * Output is a per-Parameter table: criterion code, band count, sample band
+ * descriptor. PASS = all skill parameters carry ≥10 band entries (typical
+ * IELTS rubric). FAIL = any skill parameter has bandThresholds = null/empty.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { runProjectionForPlaybook } from "@/lib/wizard/run-projection-for-playbook";
+
+type ParamConfig = { bandThresholds?: Record<string, string> | null; [k: string]: unknown };
+
+async function findIeltsLikePlaybook(): Promise<{ id: string; name: string } | null> {
+  const candidate = await prisma.playbook.findFirst({
+    where: {
+      OR: [
+        { name: { contains: "IELTS", mode: "insensitive" } },
+        { name: { contains: "ielts", mode: "insensitive" } },
+      ],
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, name: true },
+  });
+  return candidate ?? null;
+}
+
+async function reportSkillParams(): Promise<{
+  pass: boolean;
+  rows: Array<{ paramId: string; criterionCode: string | null; bandCount: number; sample: string }>;
+}> {
+  // Parameter rows are globally scoped (no playbookId column). All skill_*
+  // parameters live in one registry; bandThresholds are merged onto their
+  // config JSON by writeBandThresholds().
+  const params = await prisma.parameter.findMany({
+    where: { parameterId: { startsWith: "skill_" } },
+    select: { parameterId: true, config: true },
+    orderBy: { parameterId: "asc" },
+  });
+
+  const rows = params.map((p) => {
+    const cfg = (p.config ?? {}) as ParamConfig;
+    const bt = cfg.bandThresholds ?? null;
+    const bandCount = bt && typeof bt === "object" ? Object.keys(bt).length : 0;
+    const firstKey = bt && bandCount > 0 ? Object.keys(bt)[0] : null;
+    const sample = firstKey ? `band ${firstKey}: ${bt![firstKey].slice(0, 60)}...` : "(none)";
+    const m = /^skill_([a-z0-9]+)/.exec(p.parameterId);
+    return {
+      paramId: p.parameterId,
+      criterionCode: m ? m[1] : null,
+      bandCount,
+      sample,
+    };
+  });
+
+  const pass = rows.length > 0 && rows.every((r) => r.bandCount >= 9);
+  return { pass, rows };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const wantReproject = args.includes("--reproject");
+  const playbookFlag = args.indexOf("--playbook");
+  const targetId = playbookFlag !== -1 ? args[playbookFlag + 1] : null;
+
+  let playbook: { id: string; name: string } | null = null;
+  if (targetId) {
+    playbook = await prisma.playbook.findUnique({
+      where: { id: targetId },
+      select: { id: true, name: true },
+    });
+  } else {
+    playbook = await findIeltsLikePlaybook();
+  }
+
+  if (!playbook) {
+    console.log("[proof-561] No IELTS-like playbook found in DB.");
+    console.log("Hint: pass --playbook <id> to target a specific playbook, or create an IELTS course first.");
+    process.exit(1);
+  }
+
+  console.log(`[proof-561] target playbook: ${playbook.id} (${playbook.name})`);
+  console.log();
+  console.log("=== BEFORE ===");
+  const before = await reportSkillParams();
+  console.log(`${before.rows.length} skill parameter(s) found (global registry):`);
+  for (const r of before.rows) {
+    console.log(`  - ${r.paramId.padEnd(30)} bands=${String(r.bandCount).padStart(2)}  ${r.sample}`);
+  }
+  console.log(`  → ${before.pass ? "PASS" : "FAIL"} (need ≥9 bands per skill param)`);
+
+  if (before.pass) {
+    console.log();
+    console.log("[proof-561] bandThresholds already populated — #561 verified on this playbook.");
+    process.exit(0);
+  }
+
+  if (!wantReproject) {
+    console.log();
+    console.log("[proof-561] bandThresholds NOT populated. Re-run with --reproject to trigger");
+    console.log("[proof-561] the rubric pass and verify it lands.");
+    process.exit(1);
+  }
+
+  console.log();
+  console.log("=== RE-PROJECTING ===");
+  const result = await runProjectionForPlaybook(playbook.id);
+  console.log(`appliedSources: ${result.appliedSources.length}`);
+  console.log(`rubricBandsApplied:`);
+  for (const r of result.rubricBandsApplied) {
+    console.log(`  - source=${r.sourceContentId.slice(0, 8)} (${r.sourceName})`);
+    console.log(`    parametersUpdated=${r.parametersUpdated} unmatchedCodes=[${r.unmatchedCodes.join(", ")}]`);
+  }
+
+  console.log();
+  console.log("=== AFTER ===");
+  const after = await reportSkillParams();
+  for (const r of after.rows) {
+    console.log(`  - ${r.paramId.padEnd(30)} bands=${String(r.bandCount).padStart(2)}  ${r.sample}`);
+  }
+  console.log(`  → ${after.pass ? "PASS" : "FAIL"} (need ≥9 bands per skill param)`);
+
+  process.exit(after.pass ? 0 : 1);
+}
+
+main()
+  .catch((err) => {
+    console.error("[proof-561] error:", err);
+    process.exit(2);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/admin/tests/lib/composition/modules-requested-module.test.ts
+++ b/apps/admin/tests/lib/composition/modules-requested-module.test.ts
@@ -178,8 +178,10 @@ describe("computeSharedState — #492 Slice 3.1 requestedModuleId arg", () => {
     const result = await computeSharedState(data, specs, {}, undefined, "MOD-DOES-NOT-EXIST");
 
     expect(result.lockedModule).toBeNull();
-    // Existing fallback: with no progress, moduleToReview=MOD-1 and nextModule=MOD-2.
-    expect(result.moduleToReview?.id).toBe("MOD-1");
+    // #554 Fix 2: zero progress + zero recent calls → moduleToReview is null
+    // (no "review your baseline" hallucination before any call exists).
+    // nextModule still resolves to MOD-2 — frontier pick is independent.
+    expect(result.moduleToReview).toBeNull();
     expect(result.nextModule?.id).toBe("MOD-2");
     // Warning surfaced so wizard/route bugs are visible in dev.
     expect(warnSpy).toHaveBeenCalledWith(
@@ -199,8 +201,9 @@ describe("computeSharedState — #492 Slice 3.1 requestedModuleId arg", () => {
     expect(withUndefinedArg.lockedModule).toBeNull();
     expect(withNullArg.lockedModule).toBeNull();
 
-    // Stable pick — without any override, MOD-1 is moduleToReview, MOD-2 is next.
-    expect(withoutArg.moduleToReview?.id).toBe("MOD-1");
+    // #554 Fix 2: zero-progress + zero recentCalls → moduleToReview is null.
+    // nextModule still resolves to MOD-2 (frontier pick is independent).
+    expect(withoutArg.moduleToReview).toBeNull();
     expect(withoutArg.nextModule?.id).toBe("MOD-2");
     expect(withUndefinedArg.nextModule?.id).toBe("MOD-2");
     expect(withNullArg.nextModule?.id).toBe("MOD-2");
@@ -277,6 +280,184 @@ describe("computeSharedState — #492 Slice 3.1 requestedModuleId arg", () => {
     );
     expect(result.lockedModule?.id).toBe("part1");
     expect(result.nextModule?.id).toBe("part1");
+  });
+});
+
+// =====================================================
+// #554 Fix 1: outcomesPrimary refs are resolved to statement text
+// =====================================================
+
+describe("computeSharedState — #554 Fix 1 outcome ref resolution", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  const dataWithAuthoredOutcomes = () =>
+    makeLoadedData({
+      playbooks: [
+        {
+          id: "pb-1",
+          name: "IELTS",
+          isActive: true,
+          isLatest: true,
+          config: {
+            modulesAuthored: true,
+            modules: [
+              {
+                id: "part1",
+                label: "Part 1",
+                outcomesPrimary: ["OUT-01", "OUT-02"],
+              },
+              {
+                id: "part2",
+                label: "Part 2",
+                outcomesPrimary: ["OUT-03"],
+              },
+            ],
+            outcomes: {
+              "OUT-01": "Extends Part 1 answers to 2-3 sentence minimum",
+              "OUT-02": "Uses topic-specific vocabulary in introductions",
+              "OUT-03": "Sustains a long-turn answer for at least 90 seconds",
+            },
+          } as any,
+        } as any,
+      ],
+    });
+
+  it("resolves outcomesPrimary refs through lockedPbConfig.outcomes", async () => {
+    const data = dataWithAuthoredOutcomes();
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, { requestedModuleId: "part1" });
+
+    expect(result.lockedModule?.id).toBe("part1");
+    // Resolved text — not bare refs.
+    expect(result.lockedModule?.learningOutcomes).toEqual([
+      "Extends Part 1 answers to 2-3 sentence minimum",
+      "Uses topic-specific vocabulary in introductions",
+    ]);
+    // No warning — every ref resolved cleanly.
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("outcome ref"),
+    );
+  });
+
+  it("falls back to bare ref + console.warn when an outcome ref is not in the map", async () => {
+    const data = makeLoadedData({
+      playbooks: [
+        {
+          id: "pb-1",
+          name: "IELTS",
+          isActive: true,
+          isLatest: true,
+          config: {
+            modulesAuthored: true,
+            modules: [
+              {
+                id: "part1",
+                label: "Part 1",
+                outcomesPrimary: ["OUT-01", "OUT-MISSING"],
+              },
+            ],
+            outcomes: {
+              "OUT-01": "Extends Part 1 answers to 2-3 sentence minimum",
+            },
+          } as any,
+        } as any,
+      ],
+    });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, { requestedModuleId: "part1" });
+
+    expect(result.lockedModule?.learningOutcomes).toEqual([
+      "Extends Part 1 answers to 2-3 sentence minimum",
+      "OUT-MISSING",
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('outcome ref "OUT-MISSING"'),
+    );
+  });
+
+  it("leaves learningOutcomes undefined when outcomesPrimary is not an array", async () => {
+    const data = makeLoadedData({
+      playbooks: [
+        {
+          id: "pb-1",
+          name: "IELTS",
+          isActive: true,
+          isLatest: true,
+          config: {
+            modulesAuthored: true,
+            modules: [{ id: "part1", label: "Part 1" }],
+            outcomes: { "OUT-01": "text" },
+          } as any,
+        } as any,
+      ],
+    });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, { requestedModuleId: "part1" });
+
+    expect(result.lockedModule?.id).toBe("part1");
+    expect(result.lockedModule?.learningOutcomes).toBeUndefined();
+  });
+});
+
+// =====================================================
+// #554 Fix 2: moduleToReview gated on attempt evidence
+// =====================================================
+
+describe("computeSharedState — #554 Fix 2 moduleToReview gating", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("null moduleToReview when no completed modules AND no recent calls", async () => {
+    const data = makeLoadedData({ subjectSources: subjectSourcesWithModules as any });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, {});
+
+    expect(result.completedModules.size).toBe(0);
+    expect(data.recentCalls.length).toBe(0);
+    expect(result.moduleToReview).toBeNull();
+  });
+
+  it("non-null moduleToReview when caller has at least one recentCall (regression guard for continuous-mode)", async () => {
+    const data = makeLoadedData({
+      subjectSources: subjectSourcesWithModules as any,
+      recentCalls: [
+        {
+          id: "call-prev",
+          createdAt: new Date(),
+          notes: null,
+          summary: null,
+          score: null,
+          callerId: "caller-1",
+          domain: null,
+        } as any,
+      ],
+    });
+    const specs = makeResolvedSpecs();
+    const result = await computeSharedState(data, specs, {});
+
+    // With at least one prior call, the modules[0] fallback is allowed.
+    expect(result.moduleToReview?.id).toBe("MOD-1");
   });
 });
 

--- a/apps/admin/tests/lib/composition/modules.test.ts
+++ b/apps/admin/tests/lib/composition/modules.test.ts
@@ -206,9 +206,11 @@ describe("computeSharedState", () => {
       const specs = makeResolvedSpecs();
       const result = await computeSharedState(data, specs, {});
 
-      // With no calls/mastery, MOD-1 is moduleToReview (index 0) and nextModule is MOD-2 (index 1)
-      expect(result.moduleToReview).toBeDefined();
-      expect(result.moduleToReview!.id).toBe("MOD-1");
+      // #554 Fix 2: with zero progress AND zero recent calls, moduleToReview
+      // is null — no "review your baseline" hallucination for a brand-new
+      // learner. nextModule still resolves to MOD-2 (frontier pick is
+      // independent of the review gate).
+      expect(result.moduleToReview).toBeNull();
       expect(result.nextModule).toBeDefined();
       expect(result.nextModule!.id).toBe("MOD-2");
     });


### PR DESCRIPTION
## Summary

Stacked on top of #595. Adds two runtime proof scripts so the IELTS playbook can be verified end-to-end on a live DB.

## Background — #561 already substantively fixed

The systemic fix for #561 (root-cause: skillsFramework band descriptors never landing on `Parameter.config.bandThresholds`) shipped previously as:

- **#564** (`5fae538a feat(#564)`) — `parseRubricBands` + `writeBandThresholds` + rubric-only second projection pass
- **6c0fd172** — name-fallback matcher for fresh courses with unsuffixed parameter IDs

Wiring confirmed: `targets.ts:191` already surfaces `Parameter.config.bandThresholds` into the composition. All 17/17 tests in `lib/wizard/__tests__/run-projection-for-playbook.test.ts` + `parse-rubric-bands.test.ts` pass.

What was missing: **a way to verify on a real DB that the rubric pass actually populates bandThresholds for a given IELTS playbook.**

## What this PR adds

- `scripts/proof-554-modules-fix.ts` — runs `computeSharedState` against real DB data, asserts outcome refs resolve and zero-progress callers get `moduleToReview === null`
- `scripts/proof-561-band-thresholds.ts` — reports per-Parameter bandThresholds counts; pass `--reproject` to trigger the rubric pass on a stale IELTS playbook and re-check

## Usage (from `apps/admin/`)

```
npx tsx scripts/proof-554-modules-fix.ts
npx tsx scripts/proof-561-band-thresholds.ts             # report-only
npx tsx scripts/proof-561-band-thresholds.ts --reproject # trigger rubric pass + re-check
```

## Test plan
- [ ] Run both scripts on local dev DB → both PASS on a current IELTS playbook
- [ ] If a pre-#564 IELTS playbook has empty bandThresholds, `--reproject` populates them

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)