### PR TITLE
chore(#561): exclude aggregator skill params from proof PASS criterion

### DIFF
--- a/apps/admin/scripts/proof-561-band-thresholds.ts
+++ b/apps/admin/scripts/proof-561-band-thresholds.ts
@@ -36,16 +36,22 @@ async function findIeltsLikePlaybook(): Promise<{ id: string; name: string } | n
 
 async function reportSkillParams(): Promise<{
   pass: boolean;
-  rows: Array<{ paramId: string; criterionCode: string | null; bandCount: number; sample: string }>;
+  rows: Array<{ paramId: string; criterionCode: string | null; bandCount: number; sample: string; rubricScored: boolean }>;
 }> {
   // Parameter rows are globally scoped (no playbookId column). All skill_*
   // parameters live in one registry; bandThresholds are merged onto their
   // config JSON by writeBandThresholds().
+  //
+  // PASS criterion is over RUBRIC-SCORED params only. Internal aggregator
+  // params (e.g. skill_ema_aggregate) deliberately carry no bandThresholds
+  // and would create false negatives.
   const params = await prisma.parameter.findMany({
     where: { parameterId: { startsWith: "skill_" } },
     select: { parameterId: true, config: true },
     orderBy: { parameterId: "asc" },
   });
+
+  const isAggregator = (id: string) => /aggregate|aggregator|_ema$|_meta$/i.test(id);
 
   const rows = params.map((p) => {
     const cfg = (p.config ?? {}) as ParamConfig;
@@ -59,10 +65,12 @@ async function reportSkillParams(): Promise<{
       criterionCode: m ? m[1] : null,
       bandCount,
       sample,
+      rubricScored: !isAggregator(p.parameterId),
     };
   });
 
-  const pass = rows.length > 0 && rows.every((r) => r.bandCount >= 9);
+  const rubricRows = rows.filter((r) => r.rubricScored);
+  const pass = rubricRows.length > 0 && rubricRows.every((r) => r.bandCount >= 9);
   return { pass, rows };
 }
 
@@ -94,9 +102,10 @@ async function main() {
   const before = await reportSkillParams();
   console.log(`${before.rows.length} skill parameter(s) found (global registry):`);
   for (const r of before.rows) {
-    console.log(`  - ${r.paramId.padEnd(30)} bands=${String(r.bandCount).padStart(2)}  ${r.sample}`);
+    const tag = r.rubricScored ? "" : "  [aggregator — no bands expected]";
+    console.log(`  - ${r.paramId.padEnd(42)} bands=${String(r.bandCount).padStart(2)}  ${r.sample}${tag}`);
   }
-  console.log(`  → ${before.pass ? "PASS" : "FAIL"} (need ≥9 bands per skill param)`);
+  console.log(`  → ${before.pass ? "PASS" : "FAIL"} (need ≥9 bands on every rubric-scored skill param)`);
 
   if (before.pass) {
     console.log();
@@ -125,9 +134,10 @@ async function main() {
   console.log("=== AFTER ===");
   const after = await reportSkillParams();
   for (const r of after.rows) {
-    console.log(`  - ${r.paramId.padEnd(30)} bands=${String(r.bandCount).padStart(2)}  ${r.sample}`);
+    const tag = r.rubricScored ? "" : "  [aggregator — no bands expected]";
+    console.log(`  - ${r.paramId.padEnd(42)} bands=${String(r.bandCount).padStart(2)}  ${r.sample}${tag}`);
   }
-  console.log(`  → ${after.pass ? "PASS" : "FAIL"} (need ≥9 bands per skill param)`);
+  console.log(`  → ${after.pass ? "PASS" : "FAIL"} (need ≥9 bands on every rubric-scored skill param)`);
 
   process.exit(after.pass ? 0 : 1);
 }


### PR DESCRIPTION
Live-run on hf-dev DEV showed proof-561 reporting FAIL because \`skill_ema_aggregate\` (internal EMA aggregator) has no bandThresholds — but that's correct: aggregators are not rubric-scored.

The 4 actual IELTS rubric skill params (\`fluency_and_coherence_fc\`, \`grammatical_range_and_accuracy_gra\`, \`lexical_resource_lr\`, \`pronunciation_p\`) all carry 10 bands.

Filter aggregator params out of the PASS criterion; still show them in output tagged \`[aggregator — no bands expected]\`.

Follow-up to #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)