### PR TITLE
chore: add b@test.com + e@test.com partner SUPERADMIN seed users

### DIFF
--- a/apps/admin/prisma/seed-clean.ts
+++ b/apps/admin/prisma/seed-clean.ts
@@ -386,6 +386,33 @@ async function createInfrastructure() {
   });
   console.log(`   ✓ Admin user ready: eldar.gilad@gmail.com (SUPERADMIN)`);
 
+  // Partner test accounts (short-email aliases for easier login)
+  await prisma.user.upsert({
+    where: { email: "b@test.com" },
+    update: { passwordHash, role: "SUPERADMIN", isActive: true },
+    create: {
+      email: "b@test.com",
+      name: "B Test",
+      role: "SUPERADMIN",
+      isActive: true,
+      passwordHash,
+    },
+  });
+  console.log(`   ✓ Admin user ready: b@test.com (SUPERADMIN)`);
+
+  await prisma.user.upsert({
+    where: { email: "e@test.com" },
+    update: { passwordHash, role: "SUPERADMIN", isActive: true },
+    create: {
+      email: "e@test.com",
+      name: "E Test",
+      role: "SUPERADMIN",
+      isActive: true,
+      passwordHash,
+    },
+  });
+  console.log(`   ✓ Admin user ready: e@test.com (SUPERADMIN)`);
+
   // NOTE: Default domain and playbook creation removed
   // Use seed-domains.ts and BDD-based seeding for proper domain/playbook setup
   console.log("   ℹ️  Skipping default domain/playbook creation");

--- a/apps/admin/prisma/seed-educator-demo.ts
+++ b/apps/admin/prisma/seed-educator-demo.ts
@@ -2150,6 +2150,33 @@ export async function main(externalPrisma?: PrismaClient) {
   });
   console.log("   ✓ Admin user ready: eldar.gilad@gmail.com (SUPERADMIN)");
 
+  // Partner test accounts (short-email aliases for easier login)
+  await prisma.user.upsert({
+    where: { email: "b@test.com" },
+    update: { passwordHash: boazHash, role: "SUPERADMIN", isActive: true },
+    create: {
+      email: "b@test.com",
+      name: "B Test",
+      role: "SUPERADMIN",
+      isActive: true,
+      passwordHash: boazHash,
+    },
+  });
+  console.log("   ✓ Admin user ready: b@test.com (SUPERADMIN)");
+
+  await prisma.user.upsert({
+    where: { email: "e@test.com" },
+    update: { passwordHash: boazHash, role: "SUPERADMIN", isActive: true },
+    create: {
+      email: "e@test.com",
+      name: "E Test",
+      role: "SUPERADMIN",
+      isActive: true,
+      passwordHash: boazHash,
+    },
+  });
+  console.log("   ✓ Admin user ready: e@test.com (SUPERADMIN)");
+
   const subjectMap = await createSubjects();
   await createParameters();
   const schoolMap = await createSchools(subjectMap);


### PR DESCRIPTION
## Summary
Adds two short-email test accounts for partner login during market test:
- `b@test.com` (B Test) SUPERADMIN
- `e@test.com` (E Test) SUPERADMIN

Uses the same `SEED_ADMIN_PASSWORD` env pattern as the existing `boaz@tal.biz` / `eldar.gilad@gmail.com` upserts. Defaults to `admin123` in dev; required env in production.

Mirrored across `prisma/seed-clean.ts` and `prisma/seed-educator-demo.ts` so both base seed and demo seed provision the accounts.

## Test plan
- [ ] Merge → on DEV VM run `/vm-seed` → confirm both accounts log in with `admin123`
- [ ] Confirm both are listed as SUPERADMIN in admin user list

🤖 Generated with [Claude Code](https://claude.com/claude-code)