### PR TITLE
fix: stop module-picker auto-redirect trap on /x/sim for admins

### DIFF
--- a/apps/admin/hooks/useJourneyChat.ts
+++ b/apps/admin/hooks/useJourneyChat.ts
@@ -10,6 +10,9 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { ROLE_LEVEL } from '@/lib/roles';
+import type { UserRole } from '@prisma/client';
 import type { SurveyStep } from '@/components/student/ChatSurvey';
 import type { SurveyStepConfig } from '@/lib/types/json-fields';
 import { SURVEY_SCOPES, POST_SURVEY_KEYS } from '@/lib/learner/survey-keys';
@@ -143,6 +146,14 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
   // (treated as "already picked, proceed to teaching") so we don't loop.
   const router = useRouter();
   const searchParams = useSearchParams();
+  // Operator/admin viewers (level >= 3) are simming, not learning. The picker
+  // page rejects them with no `?callerId=` in the URL and bounces to
+  // `/x/callers`, trapping them. Sim/[callerId]/page.tsx already gives them a
+  // banner CTA as the non-blocking entry — so the hook must not force the
+  // redirect for them. Real students still get auto-routed to the picker.
+  const { data: session } = useSession();
+  const viewerRoleLevel = ROLE_LEVEL[(session?.user?.role ?? 'STUDENT') as UserRole] ?? 0;
+  const viewerIsOperator = viewerRoleLevel >= 3;
 
   const [items, setItems] = useState<ChatItem[]>([]);
   const [state, setState] = useState<JourneyState>('loading');
@@ -493,6 +504,11 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
         // teach. Without this guard the picker → SIM round-trip loops.
         const alreadyPicked = !!searchParams?.get('requestedModuleId');
         if (alreadyPicked) {
+          setState('teaching');
+        } else if (viewerIsOperator) {
+          // Operator/admin simming: don't auto-route — the banner CTA on the
+          // sim page is the non-blocking entry. Auto-routing traps admins on
+          // /x/callers because the picker page requires `?callerId=` in URL.
           setState('teaching');
         } else if (data.nextStop.redirect) {
           router.push(data.nextStop.redirect);


### PR DESCRIPTION
## Summary
- \`hooks/useJourneyChat.ts:489-498\` auto-routed every viewer to the module-picker when \`journey-position\` returned \`nextStop.type === 'module_picker'\`. Real STUDENTs were fine; admins/operators landed on the picker without \`?callerId=\` and were bounced to \`/x/callers\`, trapping them away from sim.
- Skip the auto-redirect when session role level >= 3 (OPERATOR+). The banner CTA in \`sim/[callerId]/page.tsx\` already provides the non-blocking manual entry — matches the intent already stated in the page comment "Reverted: the banner CTA below is the non-blocking entry instead".

## Test plan
- [ ] Log in as SUPERADMIN on desktop → \`/x/sim\` → stays on \`/x/sim/<callerId>\` (no flick to \`/x/callers\`)
- [ ] Click the "Pick a module" banner — opens the picker, can navigate back via returnTo
- [ ] Log in as STUDENT → \`/x/sim\` → still auto-routed to the picker when a pick is required
- [ ] URL with \`?requestedModuleId=...\` short-circuit still works (no infinite loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)