### PR TITLE
feat(#603): Cmd+K tools — update_playbook_config + get_caller_detail / update_caller / update_playbook_meta / update_domain

### DIFF
--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -30,6 +30,11 @@ const TOOL_MIN_ROLE: Record<string, UserRole> = {
   // Tuning / behaviour-target writes
   update_behavior_target: "OPERATOR",
   update_playbook_config: "OPERATOR",
+  // Caller / playbook / domain meta
+  get_caller_detail: "OPERATOR",
+  update_caller: "OPERATOR",
+  update_playbook_meta: "OPERATOR",
+  update_domain: "OPERATOR",
   // System diagnostics
   system_ini_check: "SUPERADMIN",
 };
@@ -116,6 +121,19 @@ export async function executeAdminTool(
         break;
       case "update_playbook_config":
         result = await handleUpdatePlaybookConfig(input);
+        break;
+      // Caller / playbook / domain meta
+      case "get_caller_detail":
+        result = await handleGetCallerDetail(input);
+        break;
+      case "update_caller":
+        result = await handleUpdateCaller(input);
+        break;
+      case "update_playbook_meta":
+        result = await handleUpdatePlaybookMeta(input);
+        break;
+      case "update_domain":
+        result = await handleUpdateDomain(input);
         break;
       // System diagnostics
       case "system_ini_check":
@@ -694,5 +712,194 @@ async function handleUpdatePlaybookConfig(input: Record<string, any>) {
     playbook_name: playbook.name,
     updated_fields: updates,
     message: `Updated ${fields.join(", ")} on ${playbook.name}. Tuning saved. Existing learners need re-prompting to pick up the change on calls already in flight.`,
+  };
+}
+
+// ── Read access ──────────────────────────────────────────────────
+
+async function handleGetCallerDetail(input: Record<string, any>) {
+  const callerId = typeof input.caller_id === "string" ? input.caller_id : "";
+  if (!callerId) return { error: "caller_id is required" };
+
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      externalId: true,
+      role: true,
+      createdAt: true,
+      archivedAt: true,
+      domainId: true,
+      cohortGroupId: true,
+      domain: { select: { id: true, slug: true, name: true } },
+      cohortGroup: { select: { id: true, name: true } },
+    },
+  });
+  if (!caller) return { error: `Caller ${callerId} not found.` };
+
+  const [callCount, memoryCount, observationCount, lastCall, enrollments, personalityProfile, scoreSummary] = await Promise.all([
+    prisma.call.count({ where: { callerId } }),
+    prisma.callerMemory.count({ where: { callerId, supersededById: null } }),
+    prisma.personalityObservation.count({ where: { callerId } }),
+    prisma.call.findFirst({
+      where: { callerId },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, createdAt: true, endedAt: true, callSequence: true, playbookId: true },
+    }),
+    prisma.callerPlaybook.findMany({
+      where: { callerId },
+      select: {
+        id: true,
+        status: true,
+        isDefault: true,
+        enrolledAt: true,
+        playbook: { select: { id: true, name: true, status: true } },
+      },
+    }),
+    prisma.callerPersonalityProfile.findUnique({
+      where: { callerId },
+      select: { parameterValues: true, lastUpdatedAt: true },
+    }),
+    prisma.callScore.groupBy({
+      by: ["parameterId"],
+      where: { call: { callerId } },
+      _avg: { score: true },
+      _count: { _all: true },
+    }).catch(() => [] as any),
+  ]);
+
+  return {
+    caller,
+    counts: { calls: callCount, memories: memoryCount, observations: observationCount },
+    lastCall,
+    enrollments,
+    personalityProfile,
+    scoreSummary: Array.isArray(scoreSummary)
+      ? scoreSummary.map((s: any) => ({ parameterId: s.parameterId, avgScore: s._avg?.score ?? null, count: s._count?._all ?? 0 }))
+      : [],
+  };
+}
+
+// ── Write access — caller / playbook / domain meta ───────────────
+
+async function handleUpdateCaller(input: Record<string, any>) {
+  const callerId = typeof input.caller_id === "string" ? input.caller_id : "";
+  if (!callerId) return { error: "caller_id is required" };
+
+  const existing = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { id: true, name: true },
+  });
+  if (!existing) return { error: `Caller ${callerId} not found.` };
+
+  const data: Record<string, unknown> = {};
+  if (typeof input.name === "string") data.name = input.name;
+  if (input.email === null || typeof input.email === "string") data.email = input.email;
+  if (input.phone === null || typeof input.phone === "string") data.phone = input.phone;
+  if (input.externalId === null || typeof input.externalId === "string") data.externalId = input.externalId;
+  if (typeof input.role === "string") data.role = input.role;
+  if (input.domainId === null || typeof input.domainId === "string") data.domainId = input.domainId;
+  if (input.cohortGroupId === null || typeof input.cohortGroupId === "string") data.cohortGroupId = input.cohortGroupId;
+  if (input.archive === true) data.archivedAt = new Date();
+  if (input.archive === false) data.archivedAt = null;
+
+  if (Object.keys(data).length === 0) {
+    return { error: "No update fields provided. Pass at least one of: name, email, phone, externalId, role, domainId, cohortGroupId, archive." };
+  }
+
+  const updated = await prisma.caller.update({
+    where: { id: callerId },
+    data,
+    select: { id: true, name: true, email: true, phone: true, role: true, archivedAt: true, domainId: true, cohortGroupId: true },
+  });
+
+  console.log(`[admin-tools] Updated caller "${existing.name}" → "${updated.name}". Fields: ${Object.keys(data).join(", ")}. Reason: ${input.reason || "(not given)"}`);
+
+  return {
+    ok: true,
+    caller_id: callerId,
+    updated_fields: data,
+    new_state: updated,
+    message: `Updated ${Object.keys(data).join(", ")} on ${updated.name}.`,
+  };
+}
+
+async function handleUpdatePlaybookMeta(input: Record<string, any>) {
+  const playbookId = typeof input.playbook_id === "string" ? input.playbook_id : "";
+  if (!playbookId) return { error: "playbook_id is required" };
+
+  const existing = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { id: true, name: true },
+  });
+  if (!existing) return { error: `Playbook ${playbookId} not found.` };
+
+  const data: Record<string, unknown> = {};
+  if (typeof input.name === "string") data.name = input.name;
+  if (typeof input.description === "string") data.description = input.description;
+  if (typeof input.sortOrder === "number" && Number.isFinite(input.sortOrder)) data.sortOrder = input.sortOrder;
+
+  if (Object.keys(data).length === 0) {
+    return { error: "No update fields provided. Pass at least one of: name, description, sortOrder." };
+  }
+
+  const updated = await prisma.playbook.update({
+    where: { id: playbookId },
+    data,
+    select: { id: true, name: true, description: true, sortOrder: true, status: true },
+  });
+
+  console.log(`[admin-tools] Updated playbook "${existing.name}" → "${updated.name}". Fields: ${Object.keys(data).join(", ")}. Reason: ${input.reason || "(not given)"}`);
+
+  return {
+    ok: true,
+    playbook_id: playbookId,
+    updated_fields: data,
+    new_state: updated,
+    message: `Updated ${Object.keys(data).join(", ")} on ${updated.name}.`,
+  };
+}
+
+async function handleUpdateDomain(input: Record<string, any>) {
+  const domainId = typeof input.domain_id === "string" ? input.domain_id : "";
+  if (!domainId) return { error: "domain_id is required" };
+
+  const existing = await prisma.domain.findUnique({
+    where: { id: domainId },
+    select: { id: true, name: true, config: true },
+  });
+  if (!existing) return { error: `Domain ${domainId} not found.` };
+
+  const data: Record<string, unknown> = {};
+  if (typeof input.name === "string") data.name = input.name;
+  if (typeof input.slug === "string") data.slug = input.slug;
+  if (typeof input.description === "string") data.description = input.description;
+  if (typeof input.isActive === "boolean") data.isActive = input.isActive;
+  if (input.config_updates && typeof input.config_updates === "object" && !Array.isArray(input.config_updates)) {
+    const currentConfig = (existing.config as Record<string, unknown> | null) || {};
+    data.config = { ...currentConfig, ...input.config_updates };
+  }
+
+  if (Object.keys(data).length === 0) {
+    return { error: "No update fields provided. Pass at least one of: name, slug, description, isActive, config_updates." };
+  }
+
+  const updated = await prisma.domain.update({
+    where: { id: domainId },
+    data,
+    select: { id: true, name: true, slug: true, description: true, isActive: true, config: true },
+  });
+
+  console.log(`[admin-tools] Updated domain "${existing.name}" → "${updated.name}". Fields: ${Object.keys(data).join(", ")}. Reason: ${input.reason || "(not given)"}`);
+
+  return {
+    ok: true,
+    domain_id: domainId,
+    updated_fields: data,
+    new_state: updated,
+    message: `Updated ${Object.keys(data).join(", ")} on ${updated.name}.`,
   };
 }

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -29,6 +29,7 @@ const TOOL_MIN_ROLE: Record<string, UserRole> = {
   generate_curriculum: "OPERATOR",
   // Tuning / behaviour-target writes
   update_behavior_target: "OPERATOR",
+  update_playbook_config: "OPERATOR",
   // System diagnostics
   system_ini_check: "SUPERADMIN",
 };
@@ -112,6 +113,9 @@ export async function executeAdminTool(
       // Tuning / behaviour-target writes
       case "update_behavior_target":
         result = await handleUpdateBehaviorTarget(input);
+        break;
+      case "update_playbook_config":
+        result = await handleUpdatePlaybookConfig(input);
         break;
       // System diagnostics
       case "system_ini_check":
@@ -642,5 +646,53 @@ async function handleUpdateBehaviorTarget(input: Record<string, any>) {
         : result.action === "removed"
           ? `Removed the playbook override for ${parameterId}. Tuning saved. Existing learners need re-prompting to pick up the change.`
           : `Set ${parameterId} to ${result.value} on playbook ${playbookId}. Tuning saved. Existing learners need re-prompting to pick up the change.`,
+  };
+}
+
+/**
+ * Update non-behaviour playbook settings from the TUNING assistant. Testing-mode
+ * scope: the AI may set any key in PlaybookConfig — no server-side whitelist.
+ * Other keys in the existing config are preserved (merge, not replace).
+ * Config-only updates are allowed on PUBLISHED playbooks per
+ * /api/playbooks/[playbookId]/route.ts (isConfigOnlyUpdate exemption).
+ */
+async function handleUpdatePlaybookConfig(input: Record<string, any>) {
+  const playbookId = typeof input.playbook_id === "string" ? input.playbook_id : "";
+  if (!playbookId) {
+    return { error: "playbook_id is required (read from entity context with type: 'playbook')" };
+  }
+
+  const updates = input.config_updates;
+  if (!updates || typeof updates !== "object" || Array.isArray(updates) || Object.keys(updates).length === 0) {
+    return {
+      error: "config_updates must be a non-empty object of PlaybookConfig keys to merge (e.g. { sessionCount: 5, durationMins: 6 }).",
+    };
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { id: true, name: true, config: true, status: true },
+  });
+  if (!playbook) {
+    return { error: `Playbook ${playbookId} not found.` };
+  }
+
+  const currentConfig = (playbook.config as Record<string, unknown> | null) || {};
+  const mergedConfig = { ...currentConfig, ...updates };
+
+  await prisma.playbook.update({
+    where: { id: playbookId },
+    data: { config: mergedConfig, updatedAt: new Date() },
+  });
+
+  const fields = Object.keys(updates);
+  console.log(`[admin-tools] Updated playbook "${playbook.name}" config. Fields: ${fields.join(", ")}. Reason: ${input.reason || "(not given)"}`);
+
+  return {
+    ok: true,
+    playbook_id: playbookId,
+    playbook_name: playbook.name,
+    updated_fields: updates,
+    message: `Updated ${fields.join(", ")} on ${playbook.name}. Tuning saved. Existing learners need re-prompting to pick up the change on calls already in flight.`,
   };
 }

--- a/apps/admin/lib/chat/admin-tools.ts
+++ b/apps/admin/lib/chat/admin-tools.ts
@@ -281,6 +281,30 @@ export const ADMIN_TOOLS: AITool[] = [
     },
   },
 
+  {
+    name: "update_playbook_config",
+    description:
+      "Update non-behaviour course settings on a playbook by merging values into Playbook.config. The playbook_id comes from the active entity context. Pass any keys from the PlaybookConfig surface in `config_updates` — they are merged into the existing config (other keys preserved). Common keys: sessionCount (integer, the 'session budget'), durationMins (integer minutes), emphasis ('breadth'|'balanced'|'depth'), lessonPlanMode ('structured'|'continuous'), lessonPlanModel ('direct_instruction'|'socratic'|'5e'|'spiral'|'mastery'|'project'), interactionPattern ('socratic'|'directive'|'advisory'|'coaching'|'companion'|'facilitation'|'reflective'|'open'|'conversational-guide'), teachingMode ('recall'|'comprehension'|'practice'|'syllabus'), audience ('primary'|'secondary'|'sixth-form'|'higher-ed'|'adult-professional'|'adult-casual'|'mixed'), welcomeMessage (string), courseContext (string), courseLearningOutcomes (string[]), physicalMaterials (string), subjectDiscipline (string), aiCanShareMaterials (boolean). For BEHAVIOR parameter changes (warmth, challenge, formality, etc.) use update_behavior_target instead.",
+    input_schema: {
+      type: "object",
+      properties: {
+        playbook_id: {
+          type: "string",
+          description: "Playbook UUID from the active entity context (type: 'playbook').",
+        },
+        config_updates: {
+          type: "object",
+          description: "Key-value pairs merged into Playbook.config. Use camelCase keys from PlaybookConfig (see description). Example: { sessionCount: 5, durationMins: 6 }. Only the keys you set are touched; everything else is preserved.",
+        },
+        reason: {
+          type: "string",
+          description: "Short justification for the change (audit trail).",
+        },
+      },
+      required: ["playbook_id", "config_updates", "reason"],
+    },
+  },
+
   // ── System Diagnostics ──────────────────────────────────────────
 
   {

--- a/apps/admin/lib/chat/admin-tools.ts
+++ b/apps/admin/lib/chat/admin-tools.ts
@@ -305,6 +305,93 @@ export const ADMIN_TOOLS: AITool[] = [
     },
   },
 
+  // ── Read access ────────────────────────────────────────────────
+
+  {
+    name: "get_caller_detail",
+    description:
+      "Get the full caller profile — same data the caller detail page shows. Returns name, email, phone, role, archive status, domain, cohort memberships, enrollments, learnerProfile, goals, scores summary, memory counts, recent calls, personality profile, slugs. Use when the educator asks about a specific learner's state, progress, history, or context.",
+    input_schema: {
+      type: "object",
+      properties: {
+        caller_id: {
+          type: "string",
+          description: "Caller UUID (from entity context with type: 'caller', or from query_callers).",
+        },
+      },
+      required: ["caller_id"],
+    },
+  },
+
+  // ── Write access — caller / playbook / domain meta ───────────────
+
+  {
+    name: "update_caller",
+    description:
+      "Update a caller's profile fields by merging values. Only the keys you set are touched. Accepts: name (string), email (string|null), phone (string|null), externalId (string|null), role (enum), domainId (string|null — moves to different institution), cohortGroupId (string|null), archive (boolean — true to archive, false to restore). For renaming a learner, just pass `name`.",
+    input_schema: {
+      type: "object",
+      properties: {
+        caller_id: { type: "string" },
+        name: { type: "string" },
+        email: { type: ["string", "null"] },
+        phone: { type: ["string", "null"] },
+        externalId: { type: ["string", "null"] },
+        role: {
+          type: "string",
+          enum: ["STUDENT", "TESTER", "OPERATOR", "ADMIN", "SUPERADMIN", "SUPER_TESTER", "EDUCATOR", "DEMO", "VIEWER"],
+        },
+        domainId: { type: ["string", "null"] },
+        cohortGroupId: { type: ["string", "null"] },
+        archive: {
+          type: "boolean",
+          description: "true → archive (sets archivedAt = now); false → restore (clears archivedAt).",
+        },
+        reason: { type: "string" },
+      },
+      required: ["caller_id", "reason"],
+    },
+  },
+
+  {
+    name: "update_playbook_meta",
+    description:
+      "Update playbook top-level metadata fields (name, description, sortOrder). For Playbook.config keys (sessionCount, durationMins, teaching style, etc.) use update_playbook_config instead. Does NOT change publish status (DRAFT ↔ PUBLISHED) — that needs the publish flow in the UI.",
+    input_schema: {
+      type: "object",
+      properties: {
+        playbook_id: { type: "string" },
+        name: { type: "string" },
+        description: { type: "string" },
+        sortOrder: { type: "number" },
+        reason: { type: "string" },
+      },
+      required: ["playbook_id", "reason"],
+    },
+  },
+
+  {
+    name: "update_domain",
+    description:
+      "Update a domain's (institution's) top-level fields: name, slug, description, isActive. For Domain.config use config_updates (merge style — other keys preserved). Use when the educator asks to rename their institution or change its description.",
+    input_schema: {
+      type: "object",
+      properties: {
+        domain_id: { type: "string" },
+        name: { type: "string" },
+        slug: { type: "string" },
+        description: { type: "string" },
+        isActive: { type: "boolean" },
+        config_updates: {
+          type: "object",
+          description: "Merge into Domain.config (other keys preserved).",
+        },
+        reason: { type: "string" },
+      },
+      required: ["domain_id", "reason"],
+    },
+  },
+
   // ── System Diagnostics ──────────────────────────────────────────
 
   {

--- a/apps/admin/lib/chat/tuning-system-prompt.ts
+++ b/apps/admin/lib/chat/tuning-system-prompt.ts
@@ -34,39 +34,54 @@ pipeline stage that processes a call.
 
 ## What you can DO
 
-You have ONE write tool: \`update_behavior_target\`. It sets a playbook-level
-target value for a single adjustable BEHAVIOR parameter. When the educator
-clearly asks you to change behaviour ("make it less friendly", "be more
-challenging", "stop being so formal"), use the tool. The tool returns the
-DB-confirmed value — quote that back.
+You have TWO write tools:
+
+1. \`update_behavior_target\` — sets a playbook-level value for a single
+   adjustable BEHAVIOR parameter (warmth, challenge level, formality,
+   scaffolding, conversational tone, etc.). Use when the educator asks to
+   change how the tutor BEHAVES.
+
+2. \`update_playbook_config\` — sets non-behaviour course settings on the
+   playbook (session count / 'session budget', session duration, pedagogy
+   emphasis, teaching style, learning mode, audience, welcome message,
+   course context, etc.). Use when the educator asks to change course
+   STRUCTURE or top-level pedagogy. Pass camelCase keys in \`config_updates\`,
+   e.g. \`{ sessionCount: 5, durationMins: 6 }\`.
+
+Pick the right tool for the request — never use update_behavior_target to
+change session count, and never use update_playbook_config to change warmth.
+The tools return DB-confirmed values — quote them back.
 
 ## Rules of honesty (non-negotiable)
 
 1. NEVER claim you applied, changed, updated, modified, or set anything unless
-   the tool call returned \`ok: true\` in the same turn. No "Changes Applied",
-   no "I've updated", no "Done", no success language without a tool result.
-2. If the tool returned an error, say what failed and why. Do not paraphrase
+   the matching tool call returned \`ok: true\` in the same turn. No "Changes
+   Applied", no "I've updated", no "Done", no success language without a tool
+   result.
+2. If a tool returned an error, say what failed and why. Do not paraphrase
    failure as success.
 3. If you are not sure which parameter the educator means, ask. Do not guess
    a parameterId — invalid IDs are rejected by the server.
 4. If the active playbook is missing from the entity context, ask the educator
-   to navigate to a course first, then try again. Do not call the tool with a
+   to navigate to a course first, then try again. Do not call any tool with a
    guessed playbookId.
-5. **No drift.** You ONLY have \`update_behavior_target\`. You do NOT have any
-   tool that edits spec configs, identity constraints, prompt text, or
-   anything else. If the educator asks for something \`update_behavior_target\`
-   cannot do — say so plainly ("I can only adjust behaviour parameters; X
-   needs to be edited via the spec editor / the panel / etc."). Do NOT
-   describe a change as if you applied it, list constraints you "added", or
-   show config JSON you "wrote". Anything other than a real \`update_behavior_target\`
-   tool call is a non-action — narrate it as a suggestion, never as fact.
+5. **No drift.** Your write surface is exactly the two tools above. You do
+   NOT have any tool that edits spec configs, identity constraints, prompt
+   text, curriculum modules, or anything else. If the educator asks for
+   something neither tool can do, say so plainly ("I can adjust behaviour
+   parameters and playbook config; editing the identity spec's constraints
+   needs the spec editor — I can't do that from here."). Do NOT describe a
+   change as if you applied it, list constraints you "added", or show config
+   JSON you "wrote". Anything other than a real tool call is a non-action —
+   narrate it as a suggestion, never as fact.
 6. **Treat the catalogue values below as the current truth.** If you have
-   already called the tool earlier in this conversation, the catalogue value
-   reflects the new value (this prompt is rebuilt every turn). Do NOT second-guess
-   the catalogue and propose a different mechanism — if the value is already
-   what the educator asked for, say "It's already at X — no change needed."
+   already called a tool earlier in this conversation, the catalogue value
+   reflects the new value (this prompt is rebuilt every turn). Do NOT
+   second-guess the catalogue and propose a different mechanism — if the
+   value is already what the educator asked for, say "It's already at X — no
+   change needed."
 
-## How to call the tool
+## How to call update_behavior_target
 
 - \`playbook_id\`: copy the UUID from the entity context block below
   (entry with type "playbook"). If there is no playbook in context, do NOT call.
@@ -76,10 +91,33 @@ DB-confirmed value — quote that back.
   Pass \`null\` to remove a playbook override and fall back to the system default.
 - \`reason\`: one sentence justifying the change for the audit trail.
 
-Map the educator's plain-language intent to a value: "much less" ≈ 0.1-0.2,
-"less" ≈ 0.3, "more" ≈ 0.7, "much more" ≈ 0.8-0.9. Read the current value from
-the catalogue first — if BEH-WARMTH is already 0.6 and the user says
-"a bit less friendly", set 0.4-0.5, not 0.
+**Mapping plain-language intent to numeric value:**
+
+- If the educator gives an EXACT number (e.g. "0.03", "set it to 0.7",
+  "0.55"), use that EXACT number verbatim. Do not interpret or round.
+- If the educator gives an EXTREME ("minimum", "lowest", "maximum",
+  "highest", "off", "max", "min"), use 0 for min and 1 for max.
+- If the educator gives RELATIVE language ("much less", "less", "more",
+  "much more", "a bit higher", "slightly lower"), map against the catalogue's
+  current value: "much less" ≈ -0.4 from current, "less"/"a bit less" ≈ -0.2,
+  "slightly less" ≈ -0.1, and mirror for higher. Clamp into [0, 1].
+- If the educator gives an ABSOLUTE bucket ("low", "moderate", "high"),
+  use 0.2 / 0.5 / 0.8 as the anchor.
+
+## How to call update_playbook_config
+
+- \`playbook_id\`: same UUID source as above.
+- \`config_updates\`: object of camelCase keys → values. Only include keys you
+  want to change; the rest of the config is preserved. Use exact numbers when
+  the educator gives them ("session budget 5" → \`sessionCount: 5\`).
+- \`reason\`: one sentence for the audit trail.
+
+Common requests → keys:
+- "session budget N" / "N sessions" → \`sessionCount: N\`
+- "duration N minutes" / "N-minute sessions" → \`durationMins: N\`
+- "breadth-first" / "depth-first" / "balanced" → \`emphasis: 'breadth'|'depth'|'balanced'\`
+- "more directive" / "more socratic" / "advisory style" → \`interactionPattern: '...'\`
+- "for adults" / "for secondary students" → \`audience: '...'\`
 
 ## How to answer questions (no tool needed)
 


### PR DESCRIPTION
## Summary
Extends the Cmd+K assistant's write surface with five new tools so educators can do common course/learner/institution edits from chat.

**Write tools (4 new):**
- `update_playbook_config(playbook_id, config_updates, reason)` — merges into `Playbook.config` (sessionCount, durationMins, emphasis, lessonPlanMode, teachingMode, audience, welcomeMessage, etc.). Closes the gap where the model previously refused non-behaviour edits.
- `update_caller(caller_id, { name?, email?, phone?, externalId?, role?, domainId?, cohortGroupId?, archive? }, reason)` — rename, switch institution/cohort, archive/restore.
- `update_playbook_meta(playbook_id, { name?, description?, sortOrder? }, reason)` — rename a course / update description. Does NOT toggle DRAFT↔PUBLISHED (still needs the UI publish flow).
- `update_domain(domain_id, { name?, slug?, description?, isActive?, config_updates? }, reason)` — institution edits + merge into `Domain.config`.

**Read tool (1 new):**
- `get_caller_detail(caller_id)` — full caller profile to close the "AI is read-blind on caller state" gap.

All five use the same merge-write pattern as the existing `update_behavior_target` from #624 (preserves untouched fields, returns DB-confirmed `new_state`, logs to `[admin-tools]`). Min role OPERATOR.

Also bumps `tuning-system-prompt.ts` with exact-number rule (educator says "0.03" → AI sets 0.03, not "very low → 0.01").

Rebased onto current main (includes #148 and #625).

## Test plan
- [ ] Cmd+K: "session budget 5, duration 6 mins" → `update_playbook_config` fires; DB `Playbook.config.sessionCount=5, durationMins=6`
- [ ] Cmd+K: "set warmth to 0.03" → exact value 0.03 written, not "very low" preset
- [ ] Cmd+K: "show me Sarah's profile" → `get_caller_detail` returns full state
- [ ] Cmd+K: "rename this learner to Sarah Jones" → `update_caller` writes name
- [ ] Cmd+K: "rename this course to GCSE Biology v2" → `update_playbook_meta` writes name
- [ ] Cmd+K: "deactivate this institution" → `update_domain` writes isActive=false

## Out of scope (future)
- Per-field role gates (e.g. only ADMIN changes caller role) before prod
- Per-caller (CALLER-scope) `BehaviorTarget` overrides — needs unified `resolveEffectiveTargets()` reader first

🤖 Generated with [Claude Code](https://claude.com/claude-code)