### PR TITLE
chore: cleanup stale SessionFlowTimeline refs + tab=journey deep links

### DIFF
--- a/apps/admin/app/x/caller-graph/[callerId]/page.tsx
+++ b/apps/admin/app/x/caller-graph/[callerId]/page.tsx
@@ -246,7 +246,7 @@ export default function CallerGraphPage() {
         router.push(`/x/domains?id=${id}`);
         break;
       case "call":
-        router.push(`/x/callers/${callerId}?tab=journey`);
+        router.push(`/x/callers/${callerId}?tab=calls-prompts`);
         break;
       case "goal":
         router.push(`/x/callers/${callerId}?tab=what`);

--- a/apps/admin/app/x/cohorts/[cohortId]/page.tsx
+++ b/apps/admin/app/x/cohorts/[cohortId]/page.tsx
@@ -705,7 +705,7 @@ function ActivityTab({ cohortId }: { cohortId: string }) {
         {activity.map((item) => (
           <Link
             key={item.id}
-            href={`/x/callers/${item.callerId}?tab=journey`}
+            href={`/x/callers/${item.callerId}?tab=calls-prompts`}
             className="hf-link-unstyled"
           >
             <div className="hf-activity-row">

--- a/apps/admin/components/session-flow/SessionFlowEditor.tsx
+++ b/apps/admin/components/session-flow/SessionFlowEditor.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 /**
- * Session Flow Editor — writable variant of the Timeline.
+ * Session Flow Editor — writable variant of the timeline.
  *
- * Same BEFORE / DURING / AFTER structure as SessionFlowTimeline (#223),
- * but each row that supports editing has an [Edit ▸] button that opens
- * a side drawer with a small form. Saves via PUT /api/courses/[courseId]/session-flow.
+ * BEFORE / DURING / AFTER structure; each editable row has an [Edit ▸]
+ * button that opens a side drawer with a small form. Saves via
+ * PUT /api/courses/[courseId]/session-flow.
  *
  * Drawers ship one at a time. Initial set: Sessions (course mode picker).
  * Subsequent commits add NPS picker, KC delivery mode, etc.
  *
- * @see SessionFlowTimeline.tsx
+ * Originally shared `SessionFlowTimeline.tsx` (#223) with `SessionFlowProgress`,
+ * but the shared component had no second consumer and was deleted in #374.
+ *
+ * @see SessionFlowProgress.tsx — caller-facing read-only variant
  * @see app/api/courses/[courseId]/session-flow/route.ts
  */
 

--- a/apps/admin/components/session-flow/SessionFlowProgress.tsx
+++ b/apps/admin/components/session-flow/SessionFlowProgress.tsx
@@ -15,7 +15,7 @@
  * resolved Session Flow plus per-stop progress derived from
  * OnboardingSession + Call rows + CallerAttribute records.
  *
- * @see SessionFlowTimeline.tsx
+ * @see SessionFlowEditor.tsx — course-facing writable variant
  * @see app/api/callers/[callerId]/session-flow-progress/route.ts
  */
 
@@ -108,7 +108,7 @@ export function SessionFlowProgress({ callerId }: SessionFlowProgressProps) {
 
   useEffect(() => {
     let cancelled = false;
-    // Standard fetch-on-mount pattern — see SessionFlowTimeline for matching note.
+    // Standard fetch-on-mount pattern.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     setError(null);


### PR DESCRIPTION
## Summary
Loose-ends sweep after #148 / #628 (retry — PR #633 was hijacked by a race).

- Drop `@see SessionFlowTimeline.tsx` references in `SessionFlowEditor.tsx` + `SessionFlowProgress.tsx` — the shared component was deleted in #374. Replaced with cross-references between the two surviving variants.
- Remove a stale inline "see SessionFlowTimeline for matching note" comment in the fetch effect.
- Replace 2 cosmetic `?tab=journey` deep links with the canonical `?tab=calls-prompts` (`tabRedirects` was masking these silently).

No behaviour change. Pure doc + canonicalization.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Clicking a cohort activity row or caller-graph call node still opens the calls view (now via canonical slug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)