### PR TITLE
feat(#635): widen tuning panel on Calls & Prompts (MVP CSS slice)

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -983,7 +983,10 @@ export default function CallerDetailPage() {
       </div>
 
       {/* Section Content */}
-      <div className="cdp-body">
+      {/* #635: widen the tuning panel when on Calls & Prompts so the prompt
+          preview / diff / eval are actually legible. The `--split` modifier
+          rebalances the two-column layout via CSS. */}
+      <div className={`cdp-body${tunerOpen && activeSection === "calls-prompts" ? " cdp-body--split" : ""}`}>
       <div className="cdp-content">
       {activeSection === "overview" && (
         <>

--- a/apps/admin/components/callers/caller-detail-page.css
+++ b/apps/admin/components/callers/caller-detail-page.css
@@ -35,6 +35,17 @@
   flex-direction: column;
 }
 
+/* #635: on the Calls & Prompts tab with Tune ON, give the panel ~half the
+   width on wide screens so the prompt body and diff are readable. The call
+   cards on the left adapt to the remaining space (still wide enough for the
+   standard accordion). Below 1280px the panel falls back to the 420px lane
+   so we never crush the call cards on narrower laptops. */
+@media (min-width: 1280px) {
+  .cdp-body--split .cdp-tuning-panel {
+    width: clamp(560px, 48vw, 820px);
+  }
+}
+
 /* ── Collapsible prompt preview inside tuning panel ── */
 .cdp-prompt-collapse {
   border-bottom: 1px solid var(--border-default);


### PR DESCRIPTION
Partially closes #635 — the deeper toolbar refactor (narrow LHS + per-call buttons in right pane) is still tracked in the issue.

## Summary
CSS-only. When on the Calls & Prompts tab with Tune ON, the tuning panel grows from `420px` to `clamp(560px, 48vw, 820px)` on viewports `>= 1280px`. Below that breakpoint the panel keeps the 420px lane so call cards still fit on narrower laptops.

## Why
Today the Prompt Preview lives inside a 420px panel and the body / diff wrap to 4-5 chars per line — illegible on the screenshot the user took today.

## Test plan
- [ ] `/x/callers/<id>` → Calls & Prompts tab → Tune ON (≥ 1280px viewport) → tuning panel is now ~50% wide, prompt body + diff readable
- [ ] Tune OFF → layout returns to today
- [ ] Switch to Overview / Profile / Progress / etc. tabs → no change (only Calls & Prompts triggers the split)
- [ ] On a narrower laptop (<1280px) → panel stays at 420px (no crushed call cards)

## Out of scope (follow-ups still tracked in #635)
- Narrowing the LHS Calls list to a label-only column
- Surfacing per-call Analyze / Prompt buttons in a right-pane toolbar bound to the selected call

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)