### PR TITLE
chore(#185): PlaybookSource Phase 6 — drop legacy Subject fallbacks [STALE, NEEDS REBASE]

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/media/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/media/route.ts
@@ -30,13 +30,13 @@ export async function GET(
   const limit = rawLimit !== null ? Math.min(Math.max(Number(rawLimit), 0), 200) : 50;
   const offset = Number(url.searchParams.get("offset")) || 0;
 
-  // Verify course exists and get linked subjects
+  // Verify course exists and get linked sources (Phase 6: PlaybookSource is authoritative)
   const playbook = await prisma.playbook.findUnique({
     where: { id: courseId },
     select: {
       id: true,
-      subjects: {
-        select: { subjectId: true },
+      sources: {
+        select: { sourceId: true },
       },
     },
   });
@@ -45,9 +45,9 @@ export async function GET(
     return NextResponse.json({ ok: false, error: "Course not found" }, { status: 404 });
   }
 
-  const subjectIds = playbook.subjects.map((s) => s.subjectId);
+  const sourceIds = playbook.sources.map((s) => s.sourceId);
 
-  if (subjectIds.length === 0) {
+  if (sourceIds.length === 0) {
     return NextResponse.json({ ok: true, media: [], total: 0 });
   }
 
@@ -59,9 +59,9 @@ export async function GET(
   };
   const mimePrefix = typeFilter ? mimeFilter[typeFilter] : undefined;
 
-  // Query MediaAssets through SubjectMedia junction
+  // Query MediaAssets directly via sourceId (no SubjectMedia hop)
   const where = {
-    subjects: { some: { subjectId: { in: subjectIds } } },
+    sourceId: { in: sourceIds },
     ...(mimePrefix
       ? mimePrefix.endsWith("/")
         ? { mimeType: { startsWith: mimePrefix } }
@@ -96,12 +96,6 @@ export async function GET(
         source: {
           select: { id: true, name: true },
         },
-        subjects: {
-          where: { subjectId: { in: subjectIds } },
-          select: {
-            subject: { select: { id: true, name: true } },
-          },
-        },
       },
     }),
     prisma.mediaAsset.count({ where }),
@@ -121,7 +115,7 @@ export async function GET(
     createdAt: m.createdAt.toISOString(),
     sourceName: m.source?.name || null,
     sourceId: m.source?.id || null,
-    subjectName: m.subjects[0]?.subject?.name || null,
+    subjectName: null,
   }));
 
   return NextResponse.json({ ok: true, media: result, total });

--- a/apps/admin/app/api/student/courses/route.ts
+++ b/apps/admin/app/api/student/courses/route.ts
@@ -29,14 +29,6 @@ export async function GET(request: NextRequest) {
           domain: {
             select: { name: true },
           },
-          subjects: {
-            take: 1,
-            select: {
-              subject: {
-                select: { name: true },
-              },
-            },
-          },
         },
       },
     },
@@ -68,7 +60,7 @@ export async function GET(request: NextRequest) {
   const result = enrollments.map((e) => ({
     id: e.id,
     playbookId: e.playbookId,
-    courseName: e.playbook.name || e.playbook.subjects[0]?.subject?.name || "Untitled Course",
+    courseName: e.playbook.name || "Untitled Course",
     institutionName: e.playbook.domain?.name || null,
     status: e.status,
     isDefault: e.isDefault,

--- a/apps/admin/app/api/student/materials/route.ts
+++ b/apps/admin/app/api/student/materials/route.ts
@@ -48,26 +48,19 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: true, courseName: null, materials: [] });
   }
 
-  // Get playbook name and its subjects
+  // Get playbook name (content scope resolved via PlaybookSource below)
   const playbook = await prisma.playbook.findUnique({
     where: { id: playbookId },
-    select: {
-      name: true,
-      subjects: {
-        select: { subjectId: true },
-      },
-    },
+    select: { name: true },
   });
   if (!playbook) {
     return NextResponse.json({ ok: true, courseName: null, materials: [] });
   }
 
-  const subjectIds = playbook.subjects.map((s) => s.subjectId);
-
-  // Find student-visible SubjectSources
-  const subjectSources = await prisma.subjectSource.findMany({
+  // Find student-visible PlaybookSources (Phase 6: PlaybookSource is authoritative)
+  const playbookSources = await prisma.playbookSource.findMany({
     where: {
-      subjectId: { in: subjectIds },
+      playbookId,
       tags: { has: "student-material" },
     },
     include: {
@@ -110,8 +103,8 @@ export async function GET(request: NextRequest) {
 
   // Build response — no answer keys in questions
   const materials: SessionMaterial[] = await Promise.all(
-    subjectSources.map(async (ss) => {
-      const media = ss.source.mediaAssets[0];
+    playbookSources.map(async (ps) => {
+      const media = ps.source.mediaAssets[0];
       let publicUrl: string | null = null;
 
       if (media) {
@@ -123,10 +116,10 @@ export async function GET(request: NextRequest) {
       }
 
       return {
-        sourceId: ss.source.id,
-        sourceName: ss.source.name,
-        documentType: ss.source.documentType,
-        sortOrder: ss.sortOrder,
+        sourceId: ps.source.id,
+        sourceName: ps.source.name,
+        documentType: ps.source.documentType,
+        sortOrder: ps.sortOrder,
         media: media
           ? {
               id: media.id,
@@ -135,12 +128,12 @@ export async function GET(request: NextRequest) {
               publicUrl: publicUrl!,
             }
           : null,
-        vocabulary: ss.source.vocabulary.map((v) => ({
+        vocabulary: ps.source.vocabulary.map((v) => ({
           term: v.term,
           definition: v.definition,
           partOfSpeech: v.partOfSpeech,
         })),
-        questions: ss.source.questions.map((q) => ({
+        questions: ps.source.questions.map((q) => ({
           text: q.questionText,
           type: q.questionType,
         })),

--- a/apps/admin/lib/gdpr/delete-subject-data.ts
+++ b/apps/admin/lib/gdpr/delete-subject-data.ts
@@ -26,7 +26,12 @@ export interface SubjectDeletionCounts {
 
 /**
  * Find ContentSource IDs that are only linked to the given subject(s)
- * and no others. These become orphaned after subject deletion.
+ * and not retained by any other subject or playbook. These become orphaned
+ * after subject deletion.
+ *
+ * A source is NOT orphaned if it is linked to:
+ *   - any subject not in `subjectIds` (via SubjectSource), OR
+ *   - any playbook (via PlaybookSource — Phase 6 authoritative content scope).
  */
 export async function findOrphanedSources(
   subjectIds: string[]
@@ -40,18 +45,28 @@ export async function findOrphanedSources(
 
   if (sourceIds.length === 0) return [];
 
-  // Find which of those sources are also linked to other subjects
-  const sharedSources = await prisma.subjectSource.findMany({
-    where: {
-      sourceId: { in: sourceIds },
-      subjectId: { notIn: subjectIds },
-    },
-    select: { sourceId: true },
-  });
-  const sharedSet = new Set(sharedSources.map((s) => s.sourceId));
+  // Find which of those sources are retained elsewhere — by other subjects
+  // OR by any playbook directly via PlaybookSource (Phase 6).
+  const [sharedBySubject, sharedByPlaybook] = await Promise.all([
+    prisma.subjectSource.findMany({
+      where: {
+        sourceId: { in: sourceIds },
+        subjectId: { notIn: subjectIds },
+      },
+      select: { sourceId: true },
+    }),
+    prisma.playbookSource.findMany({
+      where: { sourceId: { in: sourceIds } },
+      select: { sourceId: true },
+    }),
+  ]);
+  const retainedSet = new Set([
+    ...sharedBySubject.map((s) => s.sourceId),
+    ...sharedByPlaybook.map((s) => s.sourceId),
+  ]);
 
-  // Return sources NOT shared with other subjects
-  return sourceIds.filter((id) => !sharedSet.has(id));
+  // Return sources NOT retained by another subject or any playbook
+  return sourceIds.filter((id) => !retainedSet.has(id));
 }
 
 /**

--- a/apps/admin/lib/knowledge/domain-sources.ts
+++ b/apps/admin/lib/knowledge/domain-sources.ts
@@ -1,16 +1,21 @@
 /**
  * Domain / Playbook → Content Source Resolution
  *
- * Resolves content source IDs via two join paths:
+ * Resolves content source IDs:
  *
- * Domain-wide:  Domain → SubjectDomain → Subject → SubjectSource → ContentSource
- * Course-scoped: Playbook → PlaybookSubject → Subject → SubjectSource → ContentSource
+ * Course-scoped:  Playbook → PlaybookSource → ContentSource    (Phase 6: authoritative)
+ * Domain-wide:    Domain   → SubjectDomain → Subject → SubjectSource → ContentSource
  *
  * Used by VAPI knowledge endpoint, call sim, prompt composition, and
  * content-breakdown API to scope content retrieval.
  *
- * Playbook-scoped functions fall back to domain-wide when no
- * PlaybookSubject records exist (backward compat for older courses).
+ * Phase 6 (this file): Course-scoped resolution uses PlaybookSource only.
+ * No fallback to the legacy PlaybookSubject → Subject → SubjectSource chain
+ * and no fallback to domain-wide. A course without PlaybookSource rows is
+ * treated as having no content scope (returns empty).
+ *
+ * Domain-wide resolution still uses the Subject taxonomy chain — that is
+ * the only way to express "all sources in this domain regardless of course".
  */
 
 import { prisma } from "@/lib/prisma";
@@ -91,55 +96,39 @@ export async function getSourceIdsForDomain(domainId: string): Promise<string[]>
 }
 
 /**
- * Get all ContentSource IDs linked to a playbook (course) via PlaybookSubject.
- * Falls back to domain-wide sources if no PlaybookSubject records exist.
- * Returns deduplicated array. Returns empty array if no sources found.
+ * Get all ContentSource IDs linked to a playbook (course) via PlaybookSource.
+ * Returns deduplicated array. Returns empty array if the course has no
+ * PlaybookSource rows — no fallback to Subject chain or domain-wide.
  */
 export async function getSourceIdsForPlaybook(playbookId: string): Promise<string[]> {
-  // 1. PRIMARY: PlaybookSource (direct link — Phase 3a)
   const playbookSources = await prisma.playbookSource.findMany({
     where: { playbookId },
     select: { sourceId: true },
   });
 
-  if (playbookSources.length > 0) {
-    return [...new Set(playbookSources.map((ps) => ps.sourceId))];
-  }
-
-  // 2. FALLBACK: Legacy Subject chain (pre-migration courses without PlaybookSource rows)
-  const playbookSubjects = await prisma.playbookSubject.findMany({
-    where: { playbookId },
-    select: {
-      subject: {
-        select: {
-          sources: { select: { sourceId: true } },
-        },
-      },
-    },
-  });
-
-  if (playbookSubjects.length > 0) {
-    const sourceIds = playbookSubjects.flatMap((ps) =>
-      ps.subject.sources.map((s) => s.sourceId)
-    );
-    return [...new Set(sourceIds)];
-  }
-
-  // 3. Fallback: domain-wide (backward compat for pre-scoping courses)
-  const playbook = await prisma.playbook.findUnique({
-    where: { id: playbookId },
-    select: { domainId: true },
-  });
-  if (!playbook?.domainId) return [];
-
-  return getSourceIdsForDomain(playbook.domainId);
+  return [...new Set(playbookSources.map((ps) => ps.sourceId))];
 }
 
 /**
- * Resolve subject scope for a playbook: course-scoped with domain fallback.
- * Returns subject data with sources, teachingDepth, and whether scoping was applied.
+ * Resolve subject scope for a playbook.
+ *
+ * Phase 6: PlaybookSource is the authoritative content scope. PlaybookSubject
+ * is read only for taxonomy metadata (subject.id, teachingDepth). No fallback
+ * to the legacy Subject → SubjectSource chain and no fallback to domain-wide.
+ * A course without PlaybookSource rows returns no sources.
+ *
+ * Returns:
+ *   - subjects: taxonomy entries from PlaybookSubject; sources are attached
+ *     to the first subject for backward compat with transforms that read
+ *     subjects[0].sources. If a course has PlaybookSource but no
+ *     PlaybookSubject, a synthetic empty-id subject carries the sources.
+ *   - scoped: always true when sources exist (kept in the return shape for
+ *     compatibility with callers that check it).
  */
-export async function getSubjectsForPlaybook(playbookId: string, domainId: string): Promise<{
+export async function getSubjectsForPlaybook(
+  playbookId: string,
+  _domainId: string,
+): Promise<{
   subjects: Array<{
     id: string;
     teachingDepth: number | null;
@@ -153,129 +142,50 @@ export async function getSubjectsForPlaybook(playbookId: string, domainId: strin
   }>;
   scoped: boolean;
 }> {
-  // 1. PRIMARY: PlaybookSource for content + PlaybookSubject for metadata
-  const playbookSources = await prisma.playbookSource.findMany({
-    where: { playbookId },
-    select: {
-      sourceId: true,
-      sortOrder: true,
-      tags: true,
-      source: { select: { documentType: true } },
-    },
-    orderBy: { sortOrder: "asc" },
-  });
-
-  if (playbookSources.length > 0) {
-    // Get subject metadata from PlaybookSubject (taxonomy, teachingDepth)
-    const playbookSubjects = await prisma.playbookSubject.findMany({
+  const [playbookSources, playbookSubjects] = await Promise.all([
+    prisma.playbookSource.findMany({
+      where: { playbookId },
+      select: {
+        sourceId: true,
+        sortOrder: true,
+        tags: true,
+        source: { select: { documentType: true } },
+      },
+      orderBy: { sortOrder: "asc" },
+    }),
+    prisma.playbookSubject.findMany({
       where: { playbookId },
       select: { subject: { select: { id: true, teachingDepth: true } } },
-    });
+    }),
+  ]);
 
-    // Build subjects with sources from PlaybookSource, metadata from PlaybookSubject
-    // All sources belong to the playbook (not a specific subject), so we attach them
-    // to the first subject for backward compat with transforms that read subjects[0].sources
-    const subjects = playbookSubjects.map((ps, idx) => ({
-      ...ps.subject,
-      sources: idx === 0
-        ? playbookSources.map((s) => ({
-            subjectSourceId: "", // Not applicable for PlaybookSource path
-            sourceId: s.sourceId,
-            documentType: s.source?.documentType ?? null,
-            sortOrder: s.sortOrder,
-            tags: s.tags,
-          }))
-        : [], // Only first subject carries sources (content is course-scoped, not subject-scoped)
-    }));
-
-    // If no PlaybookSubject exists (edge case), synthesize a minimal subject entry
-    if (subjects.length === 0) {
-      return {
-        subjects: [{
-          id: "",
-          teachingDepth: null,
-          sources: playbookSources.map((s) => ({
-            subjectSourceId: "",
-            sourceId: s.sourceId,
-            documentType: s.source?.documentType ?? null,
-            sortOrder: s.sortOrder,
-            tags: s.tags,
-          })),
-        }],
-        scoped: true,
-      };
-    }
-
-    return { subjects, scoped: true };
+  if (playbookSources.length === 0 && playbookSubjects.length === 0) {
+    return { subjects: [], scoped: true };
   }
 
-  // 2. FALLBACK: Legacy Subject chain (pre-migration courses)
-  const sourceSelect = {
-    select: {
-      id: true,
-      sourceId: true,
-      sortOrder: true,
-      tags: true,
-      source: { select: { documentType: true } },
-    },
-    orderBy: { sortOrder: "asc" as const },
-  } as const;
+  const sources = playbookSources.map((s) => ({
+    subjectSourceId: "", // No SubjectSource hop in Phase 6
+    sourceId: s.sourceId,
+    documentType: s.source?.documentType ?? null,
+    sortOrder: s.sortOrder,
+    tags: s.tags,
+  }));
 
-  const playbookSubjectsLegacy = await prisma.playbookSubject.findMany({
-    where: { playbookId },
-    select: {
-      subject: {
-        select: {
-          id: true,
-          teachingDepth: true,
-          sources: sourceSelect,
-        },
-      },
-    },
-  });
-
-  if (playbookSubjectsLegacy.length > 0) {
+  // Attach all sources to the first subject for backward compat with
+  // transforms that read subjects[0].sources. If no PlaybookSubject, synthesize one.
+  if (playbookSubjects.length === 0) {
     return {
-      subjects: playbookSubjectsLegacy.map((ps) => ({
-        ...ps.subject,
-        sources: ps.subject.sources.map((s) => ({
-          subjectSourceId: s.id,
-          sourceId: s.sourceId,
-          documentType: s.source?.documentType ?? null,
-          sortOrder: s.sortOrder,
-          tags: s.tags,
-        })),
-      })),
+      subjects: [{ id: "", teachingDepth: null, sources }],
       scoped: true,
     };
   }
 
-  // 3. Fallback: domain-wide
-  const subjectDomains = await prisma.subjectDomain.findMany({
-    where: { domainId },
-    select: {
-      subject: {
-        select: {
-          id: true,
-          teachingDepth: true,
-          sources: sourceSelect,
-        },
-      },
-    },
-  });
-
   return {
-    subjects: subjectDomains.map((sd) => ({
-      ...sd.subject,
-      sources: sd.subject.sources.map((s) => ({
-        subjectSourceId: s.id,
-        sourceId: s.sourceId,
-        documentType: s.source?.documentType ?? null,
-        sortOrder: s.sortOrder,
-        tags: s.tags,
-      })),
+    subjects: playbookSubjects.map((ps, idx) => ({
+      ...ps.subject,
+      sources: idx === 0 ? sources : [],
     })),
-    scoped: false,
+    scoped: true,
   };
 }
 

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -254,96 +254,17 @@ async function resolveContentScope(callerId: string): Promise<ContentScope> {
       };
     }
 
-    // FALLBACK: Legacy Subject chain (pre-migration courses without PlaybookSource)
-    const sourceSelect = {
-      select: {
-        id: true,
-        sourceId: true,
-        sortOrder: true,
-        tags: true,
-        source: { select: { documentType: true } },
-      },
-      orderBy: { sortOrder: "asc" as const },
-    } as const;
-
-    const legacySubjects = await prisma.playbookSubject.findMany({
-      where: { playbookId: { in: playbookIds } },
-      select: {
-        subject: {
-          select: {
-            id: true,
-            teachingDepth: true,
-            sources: sourceSelect,
-          },
-        },
-      },
-    });
-
-    const seenLegacy = new Set<string>();
-    const subjects = legacySubjects
-      .filter((ps) => {
-        if (seenLegacy.has(ps.subject.id)) return false;
-        seenLegacy.add(ps.subject.id);
-        return true;
-      })
-      .map((ps) => ({
-        ...ps.subject,
-        sources: ps.subject.sources.map((s) => ({
-          subjectSourceId: s.id,
-          sourceId: s.sourceId,
-          documentType: s.source?.documentType ?? null,
-          sortOrder: s.sortOrder,
-          tags: s.tags,
-        })),
-      }));
-
-    if (subjects.length > 0) {
-      return {
-        domainId: caller.domainId,
-        subjectIds: subjects.map((s) => s.id),
-        subjects,
-        scoped: true,
-      };
-    }
   }
 
-  // Last resort: domain-wide (no enrollments, or enrollments have no subjects)
-  const subjectDomains = await prisma.subjectDomain.findMany({
-    where: { domainId: caller.domainId },
-    select: {
-      subject: {
-        select: {
-          id: true,
-          teachingDepth: true,
-          sources: {
-            select: {
-              id: true,
-              sourceId: true,
-              sortOrder: true,
-              tags: true,
-              source: { select: { documentType: true } },
-            },
-            orderBy: { sortOrder: "asc" },
-          },
-        },
-      },
-    },
-  });
-
+  // Phase 6: PlaybookSource is the only content-scoping path. A caller with
+  // no resolvable playbook + no enrolled-course PlaybookSource gets no
+  // content scope. Domain-wide Subject fallback is intentionally removed —
+  // unenrolled callers see no course content.
   return {
     domainId: caller.domainId,
-    subjectIds: subjectDomains.map((sd) => sd.subject.id),
-    subjects: subjectDomains.map((sd) => ({
-      ...sd.subject,
-      sources: sd.subject.sources.map((s) => ({
-        subjectSourceId: s.id,
-        sourceId: s.sourceId,
-        documentType: s.source?.documentType ?? null,
-        sortOrder: s.sortOrder,
-        tags: s.tags,
-      })),
-    })),
-    scoped: false,
+    subjectIds: [],
+    subjects: [],
+    scoped: true,
   };
 }
 

--- a/apps/admin/prisma/seed-educator-demo.ts
+++ b/apps/admin/prisma/seed-educator-demo.ts
@@ -1704,7 +1704,8 @@ const SPAG_ASSERTIONS = [
 
 async function createContentSources(
   schoolMap: Map<string, string>,
-  subjectMap: Map<string, string>
+  subjectMap: Map<string, string>,
+  playbookMap: Map<string, string>
 ): Promise<Map<string, string>> {
   console.log("  Creating content sources...");
   const sourceMap = new Map<string, string>(); // "schoolSlug/subjectSlug" → sourceId
@@ -1713,6 +1714,8 @@ async function createContentSources(
   const spagSubjectId = subjectMap.get("spag")!;
 
   for (const school of SCHOOLS) {
+    const playbookId = playbookMap.get(school.slug);
+
     // CC syllabus
     const ccSource = await prisma.contentSource.create({
       data: {
@@ -1730,10 +1733,16 @@ async function createContentSources(
     });
     sourceMap.set(`${school.slug}/creative-comprehension`, ccSource.id);
 
-    // Link CC source to CC subject
+    // Link CC source to CC subject (taxonomy)
     await prisma.subjectSource.create({
       data: { subjectId: ccSubjectId, sourceId: ccSource.id },
     });
+    // Link CC source to school's playbook (Phase 6: authoritative content scope)
+    if (playbookId) {
+      await prisma.playbookSource.create({
+        data: { playbookId, sourceId: ccSource.id, tags: ["content"] },
+      });
+    }
 
     // SPAG syllabus
     const spagSource = await prisma.contentSource.create({
@@ -1752,10 +1761,16 @@ async function createContentSources(
     });
     sourceMap.set(`${school.slug}/spag`, spagSource.id);
 
-    // Link SPAG source to SPAG subject
+    // Link SPAG source to SPAG subject (taxonomy)
     await prisma.subjectSource.create({
       data: { subjectId: spagSubjectId, sourceId: spagSource.id },
     });
+    // Link SPAG source to school's playbook (Phase 6: authoritative content scope)
+    if (playbookId) {
+      await prisma.playbookSource.create({
+        data: { playbookId, sourceId: spagSource.id, tags: ["content"] },
+      });
+    }
 
     console.log(`    ${school.name}: CC syllabus + SPAG guide`);
   }
@@ -2164,7 +2179,7 @@ export async function main(externalPrisma?: PrismaClient) {
 
   // Playbooks, content, onboarding, enrollments (makes schools "Ready for learners")
   const playbookMap = await createPlaybooks(schoolMap);
-  const sourceMap = await createContentSources(schoolMap, subjectMap);
+  const sourceMap = await createContentSources(schoolMap, subjectMap, playbookMap);
   const totalAssertions = await createContentAssertions(sourceMap);
   await createOnboarding(schoolMap, subjectMap, teacherMap);
   const { callerEnrollments, cohortEnrollments } = await createEnrollments(pupils, playbookMap, classroomMap);

--- a/apps/admin/prisma/seed-holographic-demo.ts
+++ b/apps/admin/prisma/seed-holographic-demo.ts
@@ -1138,6 +1138,34 @@ async function createPeople(
 // ORCHESTRATE ONE DOMAIN
 // ══════════════════════════════════════════════════════════
 
+// Phase 6: PlaybookSource is the authoritative content scope. After playbook
+// + SubjectSource creation, mirror SubjectSource rows into PlaybookSource so
+// loaders that no longer fall back through Subject still see this seed's content.
+async function syncPlaybookSourcesForDomain(
+  playbookId: string,
+  subjectMap: Map<string, string>,
+): Promise<void> {
+  for (const subjectId of subjectMap.values()) {
+    const subjectSources = await prisma.subjectSource.findMany({
+      where: { subjectId },
+      select: { sourceId: true, sortOrder: true, tags: true, trustLevelOverride: true },
+    });
+    for (const ss of subjectSources) {
+      await prisma.playbookSource.upsert({
+        where: { playbookId_sourceId: { playbookId, sourceId: ss.sourceId } },
+        create: {
+          playbookId,
+          sourceId: ss.sourceId,
+          sortOrder: ss.sortOrder,
+          tags: ss.tags,
+          trustLevelOverride: ss.trustLevelOverride,
+        },
+        update: {},
+      });
+    }
+  }
+}
+
 async function seedDomain(cfg: DomainConfig): Promise<{
   assertions: number;
   teachers: number;
@@ -1152,6 +1180,7 @@ async function seedDomain(cfg: DomainConfig): Promise<{
   const sourceMap = await createSources(cfg, subjectMap);
   const assertions = await createAssertions(cfg, sourceMap);
   const playbookId = await createPlaybook(cfg, domainId, subjectMap);
+  await syncPlaybookSourcesForDomain(playbookId, subjectMap);
   await createChannels(cfg, domainId);
   const people = await createPeople(cfg, domainId, playbookId);
 

--- a/apps/admin/tests/integration/journey/content-isolation.integration.test.ts
+++ b/apps/admin/tests/integration/journey/content-isolation.integration.test.ts
@@ -315,7 +315,7 @@ async function seedIsolationFixtures(): Promise<IsolationFixtures> {
     });
   }
 
-  // 7. PlaybookSubject links
+  // 7. PlaybookSubject links (taxonomy)
   await prisma.playbookSubject.upsert({
     where: { playbookId_subjectId: { playbookId: playbookA.id, subjectId: subjectA.id } },
     create: { playbookId: playbookA.id, subjectId: subjectA.id },
@@ -327,6 +327,22 @@ async function seedIsolationFixtures(): Promise<IsolationFixtures> {
     create: { playbookId: playbookB.id, subjectId: subjectB.id },
     update: {},
   });
+
+  // 7b. PlaybookSource links (content scoping — Phase 6 authoritative path)
+  // Course A: sourceAOnly + sharedSource
+  // Course B: sharedSource + sourceBOnly
+  for (const [pbId, srcId, sortOrder] of [
+    [playbookA.id, sourceAOnly.id, 0],
+    [playbookA.id, sharedSource.id, 1],
+    [playbookB.id, sharedSource.id, 0],
+    [playbookB.id, sourceBOnly.id, 1],
+  ] as const) {
+    await prisma.playbookSource.upsert({
+      where: { playbookId_sourceId: { playbookId: pbId, sourceId: srcId } },
+      create: { playbookId: pbId, sourceId: srcId, tags: ["content"], sortOrder },
+      update: {},
+    });
+  }
 
   // 8. Two callers, each enrolled in one course
   const callerA = await prisma.caller.upsert({

--- a/apps/admin/tests/lib/bulk-delete.test.ts
+++ b/apps/admin/tests/lib/bulk-delete.test.ts
@@ -35,6 +35,7 @@ const MODEL_NAMES = [
   "playbook",
   "playbookItem",
   "playbookSubject",
+  "playbookSource",
   "curriculum",
   "subjectSource",
   "subjectDomain",


### PR DESCRIPTION
> **Status:** DRAFT — branch is ~2 weeks stale (1 commit ahead, ~655 files diff vs main). Pushed for preservation; **needs rebase onto current main + retest before review**. Open this PR if you want to resume Phase 6 work.

Closes #185
Refs #180 #181

## Summary
PlaybookSource is now the single content-scoping path. Removes the
`PlaybookSubject → Subject → SubjectSource` fallback from
`domain-sources`, `SectionDataLoader`, and three student/course routes,
and the domain-wide last-resort branch from `resolveContentScope`.

Unenrolled callers now see no course content (intentional — strict
course isolation).

## Changes
- `lib/knowledge/domain-sources`: `getSourceIdsForPlaybook` + `getSubjectsForPlaybook` query PlaybookSource only
- `lib/prompt/composition/SectionDataLoader.resolveContentScope`: remove FALLBACK + last-resort tiers
- `api/courses/[courseId]/media`: query MediaAsset by sourceId via PlaybookSource (was SubjectMedia junction by subjectId)
- `api/student/materials`: query PlaybookSource directly
- `api/student/courses`: drop `subjects[0]?.subject?.name` fallback
- `lib/gdpr/findOrphanedSources`: also retain sources linked via PlaybookSource (otherwise course-only sources falsely orphaned)
- `prisma/seed-holographic-demo` + `seed-educator-demo`: mirror SubjectSource → PlaybookSource so seeds populate the new path
- `tests/integration/journey/content-isolation`: fixture creates PlaybookSource rows (test relies on no-fallback behaviour)
- `tests/lib/bulk-delete`: add playbookSource to mock model list

## Deferred to follow-up
- Part C band-aid commit reversals (not validated by tech-lead this pass)
- Part D admin/utility audit

## Rebase notes
Before resuming, expect conflicts in:
- SectionDataLoader (major refactors since)
- Seed scripts
- Integration test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)