### PR TITLE
feat(#641): promote Prompt Tuner to its own tab

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -69,15 +69,27 @@ export default function CallerDetailPage() {
     transcripts: "calls-prompts", prompt: "calls-prompts",
   };
   const rawTab = searchParams.get("tab");
-  const validTabs: SectionId[] = ["overview", "uplift", "calls-prompts", "how", "what", "artifacts", "ai-call"];
+  const validTabs: SectionId[] = ["overview", "uplift", "calls-prompts", "tune", "how", "what", "artifacts", "ai-call"];
   const mappedTab = rawTab ? (tabRedirects[rawTab] || rawTab) as SectionId : null;
   const lastTabKey = `hf.caller-tab.${callerId}`;
   const savedTab = typeof window !== "undefined" ? window.localStorage.getItem(lastTabKey) as SectionId | null : null;
+  // #641: migrate from the old slide-out toggle (`hf.tuner.open.<callerId>`).
+  // If the user had Tune open last visit AND no explicit ?tab= is set, send
+  // them to the new Tune tab and drop the old key so we never honor it twice.
+  const legacyTunerOpenKey = `hf.tuner.open.${callerId}`;
+  const legacyTunerOpen = typeof window !== "undefined"
+    ? window.localStorage.getItem(legacyTunerOpenKey) === "1"
+    : false;
+  if (typeof window !== "undefined" && legacyTunerOpen) {
+    window.localStorage.removeItem(legacyTunerOpenKey);
+  }
   const initialTab: SectionId = mappedTab && validTabs.includes(mappedTab)
     ? mappedTab
-    : savedTab && validTabs.includes(savedTab)
-      ? savedTab
-      : "what";
+    : (!rawTab && legacyTunerOpen)
+      ? "tune"
+      : savedTab && validTabs.includes(savedTab)
+        ? savedTab
+        : "what";
 
   const [data, setData] = useState<CallerData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -128,24 +140,9 @@ export default function CallerDetailPage() {
   // Expanded states
   const [expandedCall, setExpandedCall] = useState<string | null>(null);
   const [expandedMemory, setExpandedMemory] = useState<string | null>(null);
-  // Tuner panel state — persisted per caller
-  const tunerStorageKey = `hf.tuner.open.${callerId}`;
-  const [tunerOpen, setTunerOpen] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(tunerStorageKey) === "1";
-  });
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(tunerStorageKey, tunerOpen ? "1" : "0");
-  }, [tunerOpen, tunerStorageKey]);
-  useEffect(() => {
-    if (!tunerOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setTunerOpen(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [tunerOpen]);
+  // #641: tuner state moved from a slide-out toggle to a top-level tab. The
+  // legacy `hf.tuner.open.<callerId>` localStorage key is migrated to a
+  // deep-link to ?tab=tune on next visit (see initialTab resolution above).
   const [appliedChanges, setAppliedChanges] = useState<{ label: string; oldValue: string; newValue: string }[] | null>(null);
 
   // Bulk pipeline actions (exposed by CallsPromptsTab for tab-bar buttons)
@@ -584,6 +581,7 @@ export default function CallerDetailPage() {
   const sections: { id: SectionId; label: string; icon: React.ReactNode; count?: number; special?: boolean; group: "history" | "caller" | "shared" | "action" }[] = [
     { id: "overview", label: "Overview", icon: <span aria-hidden>🧭</span>, group: "shared" },
     { id: "calls-prompts", label: "Calls & Prompts", icon: <Phone size={13} />, count: data.counts.calls, group: "history" },
+    { id: "tune", label: "Tune", icon: <SlidersHorizontal size={13} />, count: data.counts.prompts || undefined, group: "caller" },
     { id: "how", label: "Profile", icon: <User size={13} />, count: (data.counts.memories || 0) + (data.counts.observations || 0), group: "caller" },
     { id: "what", label: "Progress", icon: <Gauge size={13} />, count: (new Set(data.scores?.map((s: any) => s.parameterId)).size || 0) + (data.counts.callerTargets || 0) + (data.counts.measurements || 0), group: "shared" },
     { id: "artifacts", label: "Artifacts", icon: <BookMarked size={13} />, count: (data.counts.artifacts || 0) + (data.counts.actions || 0), group: "shared" },
@@ -969,24 +967,12 @@ export default function CallerDetailPage() {
               </button>
             </>
           )}
-          {composedPrompts.length > 0 && (
-            <button
-              onClick={() => setTunerOpen(!tunerOpen)}
-              title="Adjust teaching style and behaviour targets"
-              className={`cdp-tune-btn${tunerOpen ? " cdp-tune-btn--active" : ""}`}
-            >
-              <SlidersHorizontal size={14} />
-              Tune
-            </button>
-          )}
+          {/* #641: Tune is a top-level tab now — the old slide-out toggle was removed. */}
         </div>
       </div>
 
       {/* Section Content */}
-      {/* #635: widen the tuning panel when on Calls & Prompts so the prompt
-          preview / diff / eval are actually legible. The `--split` modifier
-          rebalances the two-column layout via CSS. */}
-      <div className={`cdp-body${tunerOpen && activeSection === "calls-prompts" ? " cdp-body--split" : ""}`}>
+      <div className="cdp-body">
       <div className="cdp-content">
       {activeSection === "overview" && (
         <>
@@ -1077,6 +1063,54 @@ export default function CallerDetailPage() {
             fetchPrompts();
           }}
         />
+      )}
+
+      {/* #641: Tune is its own tab now — full-width prompt preview + tuner. */}
+      {activeSection === "tune" && (
+        <div className="cdp-tune-tab">
+          {composedPrompts.length === 0 ? (
+            <div className="hf-empty-dashed">
+              <div className="hf-empty-state-icon hf-mb-md">🎛️</div>
+              <div className="hf-empty-state-title">No Prompts Yet</div>
+              <div className="hf-text-sm hf-text-muted hf-mt-sm hf-empty-hint-centered">
+                Run the pipeline on a call (Calls &amp; Prompts tab) to generate the first prompt. Once it exists you can tune it from here.
+              </div>
+            </div>
+          ) : (
+            <>
+              <UnifiedPromptSection
+                prompts={composedPrompts}
+                loading={promptsLoading}
+                onRefresh={fetchPrompts}
+                callerId={callerId}
+                appliedChanges={appliedChanges}
+                onDismissApplied={() => setAppliedChanges(null)}
+              />
+              <div className="cdp-tune-tab-tuner">
+                <PromptTunerSidebar
+                  inline
+                  open
+                  llmPrompt={composedPrompts[composedPrompts.length - 1]?.llmPrompt ?? null}
+                  callerId={callerId}
+                  callerName={data.caller.name || "Learner"}
+                  playbookId={
+                    selectedPlaybookId !== "all"
+                      ? selectedPlaybookId
+                      : (data.publishedPlaybookId ?? null)
+                  }
+                  onApplied={(changes) => {
+                    setAppliedChanges(changes.map((c) => ({
+                      label: c.label,
+                      oldValue: c.oldValue,
+                      newValue: c.newValue,
+                    })));
+                    fetchPrompts();
+                  }}
+                />
+              </div>
+            </>
+          )}
+        </div>
       )}
 
       {activeSection === "how" && (
@@ -1246,49 +1280,6 @@ export default function CallerDetailPage() {
         </div>
       )}
       </div>{/* cdp-content */}
-
-      {/* Tuning panel — inline slide-out, stays open across tab switches */}
-      {tunerOpen && composedPrompts.length > 0 && (
-        <div className="cdp-tuning-panel">
-          <details className="cdp-prompt-collapse">
-            <summary className="cdp-prompt-collapse-toggle">
-              Prompt Preview
-              <span className="cdp-prompt-collapse-hint">#{composedPrompts.length}</span>
-            </summary>
-            <div className="cdp-prompt-collapse-body">
-              <UnifiedPromptSection
-                prompts={composedPrompts}
-                loading={promptsLoading}
-                onRefresh={fetchPrompts}
-                callerId={callerId}
-                appliedChanges={appliedChanges}
-                onDismissApplied={() => setAppliedChanges(null)}
-              />
-            </div>
-          </details>
-          <PromptTunerSidebar
-            inline
-            open
-            llmPrompt={composedPrompts[composedPrompts.length - 1]?.llmPrompt ?? null}
-            callerId={callerId}
-            callerName={data.caller.name || "Learner"}
-            playbookId={
-              selectedPlaybookId !== "all"
-                ? selectedPlaybookId
-                : (data.publishedPlaybookId ?? null)
-            }
-            onApplied={(changes) => {
-              setAppliedChanges(changes.map((c) => ({
-                label: c.label,
-                oldValue: c.oldValue,
-                newValue: c.newValue,
-              })));
-              fetchPrompts();
-            }}
-            onClose={() => setTunerOpen(false)}
-          />
-        </div>
-      )}
       </div>{/* cdp-body */}
     </div>
   );

--- a/apps/admin/components/callers/caller-detail-page.css
+++ b/apps/admin/components/callers/caller-detail-page.css
@@ -35,15 +35,18 @@
   flex-direction: column;
 }
 
-/* #635: on the Calls & Prompts tab with Tune ON, give the panel ~half the
-   width on wide screens so the prompt body and diff are readable. The call
-   cards on the left adapt to the remaining space (still wide enough for the
-   standard accordion). Below 1280px the panel falls back to the 420px lane
-   so we never crush the call cards on narrower laptops. */
-@media (min-width: 1280px) {
-  .cdp-body--split .cdp-tuning-panel {
-    width: clamp(560px, 48vw, 820px);
-  }
+/* #641: Tune is its own tab now. Both the prompt preview and the tuner
+   stack vertically and fill the full content width. The legacy
+   `.cdp-body--split` modifier from #635 was removed alongside the slide-out
+   toggle — the new tab gets all the room it needs by default. */
+.cdp-tune-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.cdp-tune-tab-tuner {
+  border-top: 1px solid var(--border-default);
+  padding-top: 16px;
 }
 
 /* ── Collapsible prompt preview inside tuning panel ── */

--- a/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
@@ -42,7 +42,12 @@ export interface PromptTunerSidebarProps {
   callerName: string;
   playbookId: string | null;
   onApplied: (changes: PendingChange[]) => void;
-  onClose: () => void;
+  /**
+   * Required for the fixed-sidebar mode (rendered when `inline` is false) so
+   * the X button can dismiss the overlay. Optional in inline mode — the host
+   * (e.g. the #641 Tune tab) controls visibility via tab routing.
+   */
+  onClose?: () => void;
   /** Render inline (inside a panel) instead of as a fixed sidebar overlay */
   inline?: boolean;
 }

--- a/apps/admin/components/callers/caller-detail/types.ts
+++ b/apps/admin/components/callers/caller-detail/types.ts
@@ -250,7 +250,7 @@ export type CallerData = {
   };
 };
 
-export type SectionId = "overview" | "uplift" | "calls-prompts" | "how" | "what" | "artifacts" | "ai-call" | "session-flow";
+export type SectionId = "overview" | "uplift" | "calls-prompts" | "tune" | "how" | "what" | "artifacts" | "ai-call" | "session-flow";
 
 // ---------------------------------------------------------------------------
 // Uplift tab types — computed from existing models, no new DB tables


### PR DESCRIPTION
Closes #641. Supersedes the deeper-refactor direction in #635.

## Summary
The Prompt Tuner moves from a 420px slide-out panel to a top-level tab. Full viewport width for the prompt preview, diff, eval, and the tuner sliders.

## Changes
- New `SectionId` value `'tune'` + tab in the bar (icon: SlidersHorizontal)
- `activeSection === 'tune'` renders `UnifiedPromptSection` + `PromptTunerSidebar` (inline mode) stacked vertically, full width
- Tune toggle button on Calls & Prompts removed
- `tunerOpen` state + Escape handler + localStorage sync removed
- `.cdp-body--split` modifier from #635 removed (no longer needed)
- `PromptTunerSidebar.onClose` is now optional — inline mode has no X button
- Legacy `hf.tuner.open.<callerId>` localStorage migrated: if `'1'` and no explicit `?tab=` in URL, redirect to `tab=tune` once, then drop the key
- Empty state when no composed prompts exist

## Test plan
- [ ] `/x/callers/<id>` → click Tune tab → full-width prompt preview + tuner below
- [ ] Diff body / eval body now legible end-to-end without wrapping
- [ ] Old `/x/callers/<id>?tab=calls-prompts` works (no slide-out, no Tune button)
- [ ] User who had Tune open last visit lands on Tune tab automatically (one-shot migration)
- [ ] After the migration fires, the localStorage key is gone (verify via DevTools)
- [ ] `?tab=tune` in the URL deep-links correctly
- [ ] Empty state shows the friendly hint when caller has no prompts yet
- [ ] Apply changes from the tuner → prompts refetch, applied-changes banner shows on the prompt preview

Tests: 4228 pass locally, no new tsc / eslint findings.

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)