### PR TITLE
feat(#642): diff comparator picker + Compact mode + trigger badges

### DIFF
--- a/.claude/rules/pipeline-and-prompt.md
+++ b/.claude/rules/pipeline-and-prompt.md
@@ -12,6 +12,16 @@ paths:
 
 **Before adding a stage, runner, cross-stage DB write, guardrail, or ADAPT sub-op, read [`docs/PIPELINE.md`](../../docs/PIPELINE.md) first.** It is the single source of truth for the 7-stage table, the executor map, the parallel-batch hardcode, the SUPERVISE clamp surface, and the landmines (including: stage name ≠ `AnalysisOutputType`, `pipeline-run.ts` is legacy CLI, non-blocking `stageErrors`).
 
+## ⚠️ HARD RULE — Epic 100 chain-walk is required reading
+
+**Before editing any file under `apps/admin/lib/prompt/composition/`, `apps/admin/lib/curriculum/`, `apps/admin/lib/pipeline/`, `apps/admin/lib/content-trust/`, `apps/admin/lib/chat/wizard-tool-executor.ts`, or `apps/admin/scripts/backfill-*.ts` — read [`docs/epic-100-chain-walk.md`](../../docs/epic-100-chain-walk.md).**
+
+It traces the 6 links of the adaptive loop (COURSE → CONTENT → CURRICULUM → CALL → SCORE → ADAPT → next-call COMPOSE), names the contract at each boundary, and identifies the Epic 100 story responsible for fixing each violation. Editing chain-stage code without consulting it risks reintroducing the same class of unenforced-contract bug the epic exists to eliminate.
+
+If your change introduces a new contract or modifies an existing one between stages, **update `docs/epic-100-chain-walk.md` as part of the PR**. Stale documentation is worse than no documentation here — the doc is enforcement, not just description.
+
+**Linked:** Epic [#600](https://github.com/WANDERCOLTD/HF/issues/600), verification harness [#631](https://github.com/WANDERCOLTD/HF/issues/631).
+
 **Never cite `route.ts` by line number** — use symbol form (`route.ts::stageExecutors.<STAGE>`, `route.ts::runSpecDrivenPipeline`). The file is 2700+ lines and actively edited.
 
 ## The Adaptive Loop

--- a/apps/admin/components/callers/caller-detail/PromptsSection.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptsSection.tsx
@@ -63,6 +63,19 @@ function triggerBadge(p: ComposedPrompt): string {
   return p.triggerType || "—";
 }
 
+/** #642: CSS class suffix for the triggerType badge — drives colour. */
+function triggerColourClass(p: ComposedPrompt): string {
+  const t = (p.triggerType || "").toLowerCase();
+  if (t === "post_call" || t === "pipeline") return "ps-trigger-badge--post-call";
+  if (t === "manual") return "ps-trigger-badge--manual";
+  if (t === "tuner_fanout" || t === "tuner") return "ps-trigger-badge--tuner";
+  if (t === "analysis_complete") return "ps-trigger-badge--analysis";
+  if (t === "preview_first_call") return "ps-trigger-badge--preview";
+  if (t === "scheduled") return "ps-trigger-badge--scheduled";
+  if (t === "sim") return "ps-trigger-badge--sim";
+  return "ps-trigger-badge--default";
+}
+
 /** Compute a proper line-level diff (Myers algorithm) between two prompt texts */
 export function computeDiff(
   prev: string,
@@ -81,6 +94,65 @@ export function computeDiff(
 
   return result;
 }
+
+/**
+ * #642: collapse "same" runs to separator chips when the gap between
+ * added/removed runs is > `contextLines` "same" lines. Used by Compact diff
+ * mode so the user sees only +/- lines with helpful @@ around line N @@
+ * markers, not a wall of unchanged prose.
+ */
+type CompactDiffEntry =
+  | { kind: "line"; type: "added" | "removed"; text: string; lineNumber: number }
+  | { kind: "separator"; lineNumber: number };
+
+export function compactDiffEntries(
+  fullDiff: { type: "same" | "added" | "removed"; text: string }[],
+  contextLines = 5,
+): CompactDiffEntry[] {
+  const out: CompactDiffEntry[] = [];
+  let lineNumber = 0;
+  let consecutiveSame = 0;
+  let lastWasChange = false;
+  for (const line of fullDiff) {
+    if (line.type === "removed") {
+      // removed lines don't advance the new-file line number — fine for display
+      out.push({ kind: "line", type: "removed", text: line.text, lineNumber });
+      consecutiveSame = 0;
+      lastWasChange = true;
+      continue;
+    }
+    if (line.type === "added") {
+      lineNumber++;
+      out.push({ kind: "line", type: "added", text: line.text, lineNumber });
+      consecutiveSame = 0;
+      lastWasChange = true;
+      continue;
+    }
+    // same
+    lineNumber++;
+    consecutiveSame++;
+    if (lastWasChange && consecutiveSame > contextLines) {
+      // emit a separator at the next change boundary — track via flag
+      lastWasChange = false;
+    }
+  }
+  // Insert separator chips between non-adjacent change runs by walking again
+  const finalOut: CompactDiffEntry[] = [];
+  for (let i = 0; i < out.length; i++) {
+    const entry = out[i];
+    finalOut.push(entry);
+    if (entry.kind !== "line") continue;
+    const next = out[i + 1];
+    if (!next || next.kind !== "line") continue;
+    // Gap in line numbers > contextLines * 2 → separator
+    if (next.lineNumber - entry.lineNumber > contextLines * 2) {
+      finalOut.push({ kind: "separator", lineNumber: next.lineNumber });
+    }
+  }
+  return finalOut;
+}
+
+const COMPACT_DIFF_KEY = "hf-prompt-diff-compact";
 
 // ---------------------------------------------------------------------------
 // Main Component
@@ -112,6 +184,16 @@ export function UnifiedPromptSection({
   const [viewMode, setViewMode] = useState<"human" | "llm" | "diff">("human");
   const [llmViewMode, setLlmViewMode] = useState<"pretty" | "raw">("pretty");
   const [copiedButton, setCopiedButton] = useState<string | null>(null);
+  // #642: diff comparator + compact toggle
+  const [diffComparator, setDiffComparator] = useState<"chronological" | "sibling" | "call-input">("chronological");
+  const [compactDiff, setCompactDiff] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(COMPACT_DIFF_KEY) === "1";
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(COMPACT_DIFF_KEY, compactDiff ? "1" : "0");
+  }, [compactDiff]);
 
   // ── Eval state ──
   const [evalResult, setEvalResult] = useState<EvalResult | null>(null);
@@ -125,6 +207,62 @@ export function UnifiedPromptSection({
 
   const selected = indexed[idx] ?? null;
   const prevPrompt = idx > 0 ? indexed[idx - 1] : null;
+
+  // #642: sibling = same triggerCallId, different id. Used to surface
+  // "Variant M of K for Call N" and to drive the default Diff comparator.
+  const siblings = useMemo(() => {
+    if (!selected?.triggerCallId) return [] as typeof indexed;
+    return indexed.filter(
+      (p) => p.triggerCallId === selected.triggerCallId,
+    );
+  }, [indexed, selected]);
+  const siblingIndex = useMemo(() => {
+    if (!selected || siblings.length <= 1) return -1;
+    return siblings.findIndex((p) => p.id === selected.id);
+  }, [siblings, selected]);
+  const previousSibling = useMemo(() => {
+    if (!selected || siblings.length <= 1 || siblingIndex <= 0) return null;
+    return siblings[siblingIndex - 1];
+  }, [siblings, siblingIndex, selected]);
+  // The prompt the triggering call started with — for "Call's input prompt"
+  // comparator. We find the prompt whose status was active immediately before
+  // the triggering call (i.e. the most recent prompt composed earlier than
+  // the triggering call's createdAt). Cheap heuristic — works for the
+  // common case where there's one prompt per moment.
+  const callInputPrompt = useMemo(() => {
+    if (!selected?.triggerCall?.createdAt) return null;
+    const callTime = new Date(selected.triggerCall.createdAt).getTime();
+    let best: typeof indexed[number] | null = null;
+    for (const p of indexed) {
+      if (new Date(p.composedAt).getTime() < callTime) {
+        if (!best || new Date(p.composedAt).getTime() > new Date(best.composedAt).getTime()) {
+          best = p;
+        }
+      }
+    }
+    return best;
+  }, [indexed, selected]);
+
+  // #642: when navigating to a prompt with siblings, default the comparator
+  // to "previous sibling" — that's the question the user is actually asking
+  // ("what did my tune change vs the auto-prompt?"). Otherwise fall back to
+  // chronological.
+  useEffect(() => {
+    if (previousSibling) {
+      setDiffComparator("sibling");
+    } else {
+      setDiffComparator("chronological");
+    }
+    // Intentional: do NOT persist across navigation. Per-prompt default only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected?.id]);
+
+  // Resolve which prompt to diff against based on the current comparator.
+  const comparatorPrompt = useMemo(() => {
+    if (diffComparator === "sibling") return previousSibling;
+    if (diffComparator === "call-input") return callInputPrompt;
+    return prevPrompt;
+  }, [diffComparator, previousSibling, callInputPrompt, prevPrompt]);
 
   const copyToClipboard = (text: string, buttonId: string) => {
     navigator.clipboard.writeText(text);
@@ -219,9 +357,10 @@ export function UnifiedPromptSection({
 
   const label = promptLabel(selected, total);
   const llm = selected.llmPrompt;
-  const diffLines = viewMode === "diff" && prevPrompt
-    ? computeDiff(prevPrompt.prompt, selected.prompt)
+  const diffLines = viewMode === "diff" && comparatorPrompt
+    ? computeDiff(comparatorPrompt.prompt, selected.prompt)
     : null;
+  const compactEntries = diffLines && compactDiff ? compactDiffEntries(diffLines) : null;
 
   return (
     <div className="hf-flex-col hf-gap-20">
@@ -305,9 +444,19 @@ export function UnifiedPromptSection({
           <span className={`hf-micro-badge hf-uppercase ${selected.status === "active" ? "ps-status-badge-active" : "ps-status-badge-default"}`}>
             {selected.status}
           </span>
-          <span className="hf-micro-badge ps-status-badge-default hf-uppercase">
+          {/* #642: triggerType with colour mapping so siblings are visually distinct */}
+          <span className={`hf-micro-badge hf-uppercase ${triggerColourClass(selected)}`}>
             {triggerBadge(selected)}
           </span>
+          {/* #642: sibling indicator — "Variant M of K for Call N" */}
+          {siblings.length > 1 && siblingIndex >= 0 && (
+            <span
+              className="hf-micro-badge ps-sibling-pill"
+              title={`This prompt is variant ${siblingIndex + 1} of ${siblings.length} prompts triggered by the same call.`}
+            >
+              Variant {siblingIndex + 1} of {siblings.length}
+            </span>
+          )}
           <span className="hf-text-sm hf-text-muted">
             {new Date(selected.composedAt).toLocaleString()}
           </span>
@@ -429,30 +578,105 @@ export function UnifiedPromptSection({
         </div>
       )}
 
-      {/* ── Diff View ── */}
-      {viewMode === "diff" && diffLines && (
+      {/* ── Diff View — #642: comparator picker + Compact toggle ── */}
+      {viewMode === "diff" && (
         <div className="hf-flex-col hf-gap-lg">
-          <div className="hf-text-sm hf-text-muted">
-            Changes from #{(prevPrompt as any)?._idx} → #{selected._idx}
-          </div>
-          <div className="ps-diff-block">
-            {diffLines.map((line, i) => (
-              <div
-                key={i}
-                className={`ps-diff-line${line.type === "added" ? " ps-diff-added" : line.type === "removed" ? " ps-diff-removed" : ""}`}
+          {/* Diff toolbar */}
+          <div className="ps-diff-toolbar">
+            <div className="ps-diff-toolbar-left">
+              <span className="hf-text-xs hf-text-muted">Diff against:</span>
+              <select
+                className="hf-input ps-diff-comparator"
+                value={diffComparator}
+                onChange={(e) => setDiffComparator(e.target.value as "chronological" | "sibling" | "call-input")}
+                aria-label="Diff comparator"
               >
-                <span className="ps-diff-marker">
-                  {line.type === "added" ? "+" : line.type === "removed" ? "−" : " "}
-                </span>
-                {line.text || "\u00A0"}
-              </div>
-            ))}
+                <option value="chronological" disabled={!prevPrompt}>
+                  Previous prompt (chronological){!prevPrompt ? " — n/a" : ""}
+                </option>
+                <option value="sibling" disabled={!previousSibling}>
+                  Previous sibling (intra-call){!previousSibling ? " — n/a" : ""}
+                </option>
+                <option value="call-input" disabled={!callInputPrompt}>
+                  Call&apos;s input prompt (cross-call){!callInputPrompt ? " — n/a" : ""}
+                </option>
+              </select>
+            </div>
+            <div className="hf-toggle-group">
+              <button
+                onClick={() => setCompactDiff(false)}
+                className={`hf-toggle-btn hf-toggle-btn-sm ${!compactDiff ? "hf-toggle-btn-active" : ""}`}
+                title="Show full prompt with all lines (added/removed/same)"
+              >
+                Full
+              </button>
+              <button
+                onClick={() => setCompactDiff(true)}
+                className={`hf-toggle-btn hf-toggle-btn-sm ${compactDiff ? "hf-toggle-btn-active" : ""}`}
+                title="Show only added/removed lines with line-number separators"
+              >
+                Compact
+              </button>
+            </div>
           </div>
-        </div>
-      )}
-      {viewMode === "diff" && !prevPrompt && (
-        <div className="hf-text-sm hf-text-muted">
-          This is the first prompt — no previous version to compare.
+
+          {diffLines && comparatorPrompt && (
+            <div className="hf-text-sm hf-text-muted">
+              Changes from #{(comparatorPrompt as any)?._idx} → #{selected._idx}
+            </div>
+          )}
+
+          {/* Diff body — Full or Compact */}
+          {diffLines && !compactDiff && (
+            <div className="ps-diff-block">
+              {diffLines.map((line, i) => (
+                <div
+                  key={i}
+                  className={`ps-diff-line${line.type === "added" ? " ps-diff-added" : line.type === "removed" ? " ps-diff-removed" : ""}`}
+                >
+                  <span className="ps-diff-marker">
+                    {line.type === "added" ? "+" : line.type === "removed" ? "−" : " "}
+                  </span>
+                  {line.text || "\u00A0"}
+                </div>
+              ))}
+            </div>
+          )}
+          {compactEntries && compactDiff && (
+            <div className="ps-diff-block">
+              {compactEntries.length === 0 && (
+                <div className="hf-text-sm hf-text-muted ps-diff-empty">
+                  No changes between these two prompts.
+                </div>
+              )}
+              {compactEntries.map((entry, i) =>
+                entry.kind === "separator" ? (
+                  <div key={i} className="ps-diff-separator" aria-hidden>
+                    @@ around line {entry.lineNumber} @@
+                  </div>
+                ) : (
+                  <div
+                    key={i}
+                    className={`ps-diff-line ${entry.type === "added" ? "ps-diff-added" : "ps-diff-removed"}`}
+                  >
+                    <span className="ps-diff-marker">
+                      {entry.type === "added" ? "+" : "−"}
+                    </span>
+                    {entry.text || "\u00A0"}
+                  </div>
+                ),
+              )}
+            </div>
+          )}
+          {!diffLines && !comparatorPrompt && (
+            <div className="hf-text-sm hf-text-muted">
+              {diffComparator === "sibling"
+                ? "No earlier sibling exists for this prompt."
+                : diffComparator === "call-input"
+                  ? "No input prompt available for the triggering call."
+                  : "This is the first prompt — no previous version to compare."}
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -641,3 +641,85 @@
   border-radius: 50%;
   background: var(--status-success-text);
 }
+
+/* #642 — triggerType badge colour map */
+.ps-trigger-badge--default {
+  background: color-mix(in srgb, var(--text-muted) 14%, transparent);
+  color: var(--text-muted);
+}
+.ps-trigger-badge--post-call {
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-secondary, var(--text-muted));
+}
+.ps-trigger-badge--manual {
+  background: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+  color: var(--accent-primary);
+}
+.ps-trigger-badge--tuner {
+  background: color-mix(in srgb, var(--status-warning-text) 18%, transparent);
+  color: var(--status-warning-text);
+}
+.ps-trigger-badge--analysis {
+  background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 18%, transparent);
+  color: var(--accent-secondary, #7c6bc4);
+}
+.ps-trigger-badge--preview {
+  background: color-mix(in srgb, var(--text-placeholder) 18%, transparent);
+  color: var(--text-placeholder);
+}
+.ps-trigger-badge--scheduled {
+  background: color-mix(in srgb, var(--status-success-text) 18%, transparent);
+  color: var(--status-success-text);
+}
+.ps-trigger-badge--sim {
+  background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+  color: var(--accent-primary);
+}
+
+/* #642 — sibling indicator pill */
+.ps-sibling-pill {
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+/* #642 — diff toolbar (comparator picker + Full/Compact toggle) */
+.ps-diff-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 8px 12px;
+  background: var(--surface-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--border-default);
+}
+.ps-diff-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.ps-diff-comparator {
+  font-size: 12px;
+  padding: 4px 8px;
+  max-width: 320px;
+}
+
+/* #642 — Compact diff separator chip */
+.ps-diff-separator {
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--text-placeholder);
+  background: color-mix(in srgb, var(--text-muted) 6%, transparent);
+  padding: 2px 8px;
+  margin: 4px 0;
+  border-radius: 4px;
+  user-select: none;
+}
+.ps-diff-empty {
+  padding: 12px;
+  text-align: center;
+  font-style: italic;
+}

--- a/docs/epic-100-chain-walk.md
+++ b/docs/epic-100-chain-walk.md
@@ -1,0 +1,235 @@
+# Epic 100 — Chain-Walk Report
+
+> **Required reading** for any work touching adaptive-loop boundaries (EXTRACT, SCORE_AGENT, AGGREGATE, REWARD, ADAPT, SUPERVISE, COMPOSE).
+>
+> Generated 2026-05-22 during Epic 100 grooming. Captures the full course → learner → measures → prompts → next-call walk with per-link risk + mitigation analysis.
+>
+> Epic: [#600](https://github.com/WANDERCOLTD/HF/issues/600) | Verification harness: [#631](https://github.com/WANDERCOLTD/HF/issues/631)
+
+---
+
+## Origin
+
+A single bad transcript from caller Nico Grant (`f17d8616-3c31-4814-8de1-626fb42f16f6`) on 2026-05-22 in IELTS Prep Lab. ComposedPrompt `8acde2a1-b1b7-4767-aede-c6277f5cb68e`, Call `010312de-134e-4d0c-bcdd-c91924ea2d93`, Playbook `ec4127a1-2097-4ad4-8f11-af5da46c679e`.
+
+What looked like one bad prompt turned out to be 6 distinct unenforced contracts between adaptive-loop modules. The walk below traces each link in the loop, names the contract, identifies which Epic 100 story touches it, and assesses chain-break risk after the bundle ships.
+
+---
+
+## Executive summary
+
+The Epic 100 bundle (#604–#611, #614–#616, #631) addresses data-contract violations across the course-to-call pipeline. This walk identified **three high-impact gaps** that became follow-on stories (#614, #615, #616) and one foundational harness story (#631).
+
+**Verdict:** bundle is **safe to ship** with the verification harness landing first, the three migrations queued, and the documented merge order respected. No blocking issues; all gaps have remediation paths.
+
+**Highest-priority mitigation:** historical `CallerAttribute` lo_mastery key migration (#614) — without it, post-#611 loop closure is non-deterministic.
+
+---
+
+## The chain
+
+```
+COURSE (Playbook + Curriculum + LOs + Subjects)
+   │ defines what's taught
+   ▼
+LEARNER (Caller + Memories + Profile + Personality)
+   │ defines who's being taught
+   ▼
+MEASURES (CallScore + LO mastery + parameters + targets)
+   │ defines how progress is tracked
+   ▼
+PROMPTS (ComposedPrompt + transforms)
+   │ defines what the AI does next
+   ↑                                    │
+   └────────────────────────────────────┘
+                next call
+```
+
+---
+
+## Link 1 — COURSE → CONTENT (extraction)
+
+**Contract:** `CONTENT_EXTRACTION_V1`
+
+- **Input:** document uploaded with declared `documentType`, optional `teachMethod` override
+- **Output:** `ContentAssertion` + `ContentQuestion` rows with `teachMethod`, `assessmentUse`, `learningObjectiveId`, `linkConfidence`
+
+**Bundle issues touching this link:** #605 (teachMethod assignment), #606 (assessmentUse default), #607 (subject linkage)
+
+**Risk pre-mitigation:** MEDIUM — new courses extract cleanly; existing assertions may have legacy null `teachMethod` or divergent `assessmentUse` inference on QUESTION_BANK rows.
+
+**Mitigation:** Backfill scripts deployed pre-ship. `#606` AC: *"All `ContentQuestion` rows from QUESTION_BANK sources have `assessmentUse != null` post-migration."*
+
+**Status:** ✅ closed (audit AC + backfill in #605 / #606)
+
+---
+
+## Link 2 — CONTENT → CURRICULUM (LO linkage)
+
+**Contract:** `LO_LINKAGE_V1`
+
+- **Input:** `ContentAssertion` rows with `learningObjectiveId` + `linkConfidence`
+- **Output:** LO mastery tracking driven by correct curriculum scope
+
+**Bundle issues touching this link:** #607 (subject linkage cleans up orphan LOs)
+
+**Risk pre-mitigation:** MEDIUM-HIGH — `#607` may detach the only-host subject of some `LearningObjective` rows; existing `ContentAssertion.learningObjectiveId` becomes a dangling soft-FK (no DB-level enforcement); AGGREGATE then can't derive mastery → silent zero or runtime error.
+
+**Mitigation:** Follow-on story **#615** — extend `scripts/check-fk-consistency.ts` (CI step 5) with orphan-LO detection. Initial cleanup migration audits DEV; AGGREGATE gracefully handles missing LO (log warning, skip write).
+
+**Status:** 🟡 partial — covered by #615 (queued)
+
+---
+
+## Link 3 — CURRICULUM → CALL (compose)
+
+**Contract:** `PROMPT_COMPOSITION_V1`
+
+- **Input:** LO scope, active curriculum, playbook enrollment, content loaders scoped by `subjectSourceId`
+- **Output:** `ComposedPrompt` with teaching content, course instructions, questions, behaviour targets
+
+**Bundle issues touching this link:** #604 (criticalRules), #606 (question filter), #608 (identity), #610 (transform config)
+
+**Risk pre-mitigation:** LOW — loaders are already scoped-safe (strict `subjectSourceId IN (…)` with no null fallback per `flow-prompt-composition.md` §3). Identity and transform changes are isolated.
+
+**Mitigation:** None required — loaders already defend against scope bleed.
+
+**Status:** ✅ closed (existing defences sufficient)
+
+---
+
+## Link 4 — CALL → TRANSCRIPT → SCORE (pipeline)
+
+**Contract:** `CALL_SCORE_V1`
+
+- **Input:** transcript + ComposedPrompt parameters
+- **Output:** `CallScore` rows with canonical key form `(callId, parameterId, moduleId?)`
+
+**Bundle issues touching this link:** #611 (moduleId resolution, evidence gate, priorCallFeedback filter)
+
+**Risk pre-mitigation:** MEDIUM — #611 changes how CallScore keys are formed (some scores now carry slug-form `moduleId`, historical rows carry name-form or no moduleId). COMPOSE stage (order 100) reads CallScore rows from AGGREGATE output (order 30). If AGGREGATE produces a new key form and COMPOSE expects old form, they miss each other silently.
+
+**Mitigation:** `#611` ACs (added):
+- "After migration, all CallScore rows have a single canonical key form. Validator audit confirms zero rows with divergent forms."
+- "COMPOSE reader at `modules.ts:688` handles BOTH pre- and post-migration forms during a 2-week grace window. Cutover criterion documented."
+- "Fixes A + B + C ship in **one PR**. No partial merges."
+
+**Status:** 🟡 partial — covered by #611 (monolithic merge enforced via AC)
+
+---
+
+## Link 5 — SCORE → AGGREGATE → ADAPT (mastery tracking)
+
+**Contract:** `MASTERY_TRACKING_V1`
+
+- **Input:** `CallScore` rows + `LearningObjective` definitions
+- **Output:** mastery per LO + next-module selection
+
+**Bundle issues touching this link:** #605 (clean assertions → cleaner mastery), #607 (clean subject → clean mastery scope), indirectly #611
+
+**Risk pre-mitigation:** MEDIUM — #607 may delete LOs; AGGREGATE tries to derive mastery for a deleted LO → either drops the row silently or crashes. ADAPT's module-selection depends on mastery scope being correct; polluted scope → wrong next module.
+
+**Mitigation:** Post-#607, audit AGGREGATE's LO-mastery derivation (`#615`). Add logic: *"if LO no longer exists, skip the mastery row with logging."*
+
+**Status:** 🟡 partial — covered by #615 (queued)
+
+---
+
+## Link 6 — ADAPT → COMPOSE (loop closure)
+
+**Contract:** `CALLER_STATE_V1`
+
+- **Input:** mastery + `CallerAttribute` (memory keys) + `CallerMemory`
+- **Output:** fresh `ComposedPrompt` for next call carrying forward adaptive state
+
+**Bundle issues touching this link:** #605, #607 may introduce key-form divergence in legacy data
+
+**Risk pre-mitigation:** **HIGH** — existing `CallerAttribute` rows use old naming convention (e.g. `lo_mastery:Part 1: Familiar Topics:OUT-01`). New code may expect slug-form (`lo_mastery:part1:OUT-01`). COMPOSE loaders may skip old-form keys silently → memory loss between calls (silent data loss).
+
+**Mitigation:** **Follow-on story #614 — CRITICAL.**
+
+```sql
+SELECT COUNT(*),
+       CASE
+         WHEN "key" LIKE 'lo_mastery:%' AND "key" ~ '[A-Z ]' THEN 'old_name_form'
+         WHEN "key" LIKE 'lo_mastery:%' AND "key" !~ '[A-Z ]' THEN 'slug_form'
+         ELSE 'other'
+       END AS key_pattern
+FROM "CallerAttribute"
+WHERE "expiresAt" IS NULL OR "expiresAt" > NOW()
+GROUP BY key_pattern;
+```
+
+If `old_name_form` count > 0: migration script `scripts/migrate-caller-attribute-lo-mastery-keys.ts`:
+- Read old-form rows
+- Slugify key via `resolveModuleByLogicalId(curriculumId, name)` — same canonical resolver as #611
+- Write new row with slug-form key + `migratedFromKey` provenance in `meta`
+- Soft-delete old row (set `expiresAt = NOW()`)
+- COMPOSE reader: during grace window, try new form first, fallback to old
+
+**Estimated volume:** Query above determines. Assume 500–5,000 rows based on production call volume.
+
+**Status:** 🟡 partial — covered by #614 (queued, CRITICAL priority)
+
+---
+
+## Summary table
+
+| Link | Input → Output | Bundle issues | Risk (pre-mitigation) | Mitigation | Status |
+|------|----------------|---------------|-----------------------|------------|--------|
+| 1. COURSE → CONTENT | Doc → ContentAssertion/Question | #605, #606, #607 | M | Backfill script + AC audit | ✅ closed |
+| 2. CONTENT → CURRICULUM | Assertion → LO linkage | #607 | M-H | Post-ship FK audit + cleanup (#615) | 🟡 partial |
+| 3. CURRICULUM → CALL | LO scope → ComposedPrompt | #604, #606, #608, #610 | L | Loaders already scoped-safe | ✅ closed |
+| 4. CALL → SCORE | Transcript → CallScore key form | #611 | M | Monolithic merge + grace window (#611 ACs) | 🟡 partial |
+| 5. SCORE → ADAPT | CallScore → mastery → next module | #605, #607, #611 | M | Post-ship mastery-cleanup audit (#615) | 🟡 partial |
+| 6. ADAPT → COMPOSE | Mastery + CallerAttribute → next prompt | #605, #607 | **H** | **Historical key migration (#614)** | 🟡 partial — CRITICAL |
+
+---
+
+## Recommended ACs (applied 2026-05-22)
+
+Applied via `gh issue comment` on each child:
+
+- **#605** — backfill script + memory docs (entities.md `tutor_instruction`, ai-to-db-fk-writes.md guard entry) + lesson-plan models review
+- **#606** — `assessmentUse` in `select` not just `where` + defense-in-depth render-time filter + memory doc
+- **#607** — FK cascade audit BEFORE unlink + orphan-LO audit AFTER + cross-course regression test + memory doc
+- **#611** — MONOLITHIC merge (A+B+C in one PR) + wider scope (signature change OR move resolve to call sites + second write site) + universal evidence gate (not extension of #566 IELTS-only guard) + parameter-category filter primary (not strict moduleId) + reader stays tolerant for 2-week grace window
+- **#604** — memory doc + test debt rewrite (preamble.test.ts:149 + renderPromptSummary.test.ts:97-118) in same PR + sequencing-after-#605/#606/#607
+- **#608** — Option C / Option A scope split
+- **#610** — in-flight migration strategy (config fallback to thin code defaults if spec field absent)
+
+---
+
+## Follow-on issues opened 2026-05-22
+
+| # | Title | Severity | Effort |
+|---|-------|----------|--------|
+| **#614** | Historical CallerAttribute lo_mastery key migration | **HIGH (silent memory loss without it)** | M (~4h) |
+| **#615** | Post-#607 orphan-LO + dangling-assertion audit | MEDIUM-HIGH | S-M (~3h) |
+| **#616** | docs/CHAIN-CONTRACTS.md — single inventory of stage-to-stage contracts | MEDIUM | M (~4–6h) |
+| **#631** | Epic 100 verification harness — audit + golden-caller + evals + sim proofs + CI | **FOUNDATIONAL (blocks all)** | M (~5–6h) |
+
+---
+
+## Execution order (final)
+
+```
+#631 (verification harness — BLOCKS ALL OTHERS, lands first)
+  ↓
+#606 → #607 → #605 → #608-C → #604 → #611 (monolithic) → #614 → #615 → #608-A → #610 → #616
+```
+
+---
+
+## Reading this doc
+
+**Required reading** when working on any file in:
+
+- `apps/admin/lib/prompt/composition/` (touches links 3 + 6)
+- `apps/admin/lib/curriculum/` (touches links 1, 2, 5)
+- `apps/admin/lib/pipeline/` (touches links 4, 5)
+- `apps/admin/lib/content-trust/` (touches link 1)
+- `apps/admin/lib/chat/wizard-tool-executor.ts` (touches links 1, 2)
+- `apps/admin/scripts/backfill-*.ts` (touches links 1, 6)
+
+Before editing any of these, verify your change respects the documented contract for the affected link. If your change introduces a new contract or modifies an existing one, update this doc as part of the PR.


### PR DESCRIPTION
Partially closes #642 — sibling timeline rows in CallsPromptsTab and the arbitrary 'Pick another prompt' popover are still tracked there as follow-up slices.

## Summary
Now that #641 gave the diff area real width, this slice fills it:

### 1. Diff comparator picker
Drop-down above the diff body lets you choose what you diff against:
- `Previous prompt (chronological)` — today's default
- `Previous sibling (intra-call)` — auto-selected when the current prompt has an earlier sibling (same `triggerCallId`)
- `Call's input prompt (cross-call)` — the prompt the triggering call started with

Default flips to 'sibling' whenever a sibling exists — that's the natural question ('what did my tune change vs the auto-prompt?'). Per-prompt default, not persisted.

### 2. Compact / Full diff toggle
`localStorage.hf-prompt-diff-compact`. Compact mode filters out `same` lines and inserts `@@ around line N @@` separator chips when changes are far apart. Full mode = today's view, no regression.

### 3. TriggerType colour badges + 'Variant M of K' pill
Replaces the plain grey badge with a colour-mapped one:
`post_call` grey · `manual` blue · `tuner_fanout` amber · `analysis_complete` purple · `preview` slate · `scheduled` teal · `sim` accent.

When the current prompt has ≥1 sibling, a `Variant M of K` pill appears in the meta row.

## Files
- `PromptsSection.tsx` — sibling memos, comparator state + auto-default, Compact mode + separator-chip computation, new diff toolbar
- `prompts-section.css` — trigger-badge colour map, sibling pill, diff toolbar, separator chip

## Test plan
- [ ] On a caller with multiple prompts triggered by the same call (try a Re-Prompt → see two After Call N rows) → navigator shows 'Variant 2 of 2' pill → Diff defaults to 'Previous sibling'
- [ ] Switch comparator to 'Previous prompt (chronological)' — diff reflows
- [ ] Toggle Full / Compact — Compact hides 'same' lines, shows '@@ around line N @@' separators
- [ ] Compact preference survives a page reload (localStorage)
- [ ] First/bootstrap prompt — Diff tab shows the new 'no previous version' message
- [ ] Different trigger types render in distinct colours

## Deferred (separate slices of #642)
- Sibling rows surfaced in CallsPromptsTab call cards
- 'Pick another prompt...' arbitrary comparator popover
- Delta-summary chip (`warmth 0.4 → 0.6`)

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)