### PR TITLE
feat(#606): TUTOR_ONLY filter on curriculumQuestions loader (stacks on #631)

### DIFF
--- a/apps/admin/evals/epic-100/no-tutor-training-mcq.yaml
+++ b/apps/admin/evals/epic-100/no-tutor-training-mcq.yaml
@@ -1,15 +1,25 @@
 description: "#606 — TUTOR_ONLY MCQs must not appear in learner PRACTICE QUESTIONS"
 
 # Story:  #606 — root-cause: tutor-training MCQs leaking into learner PRACTICE QUESTIONS section
-# Status: BEFORE (asserts the broken behaviour — TUTOR_ONLY rows in practiceQuestions — is detectable)
-# Flip:   when #606 merges, swap `flip-after-merge.tests` into `tests`.
+# Status: AFTER (asserts the FIXED behaviour — TUTOR_ONLY rows excluded from practiceQuestions).
+#         BEFORE assertions preserved in `archive-before:` as the historical detection of the bug.
 # See:    docs/epic-100-chain-walk.md (Link 3 — CURRICULUM → CALL)
 #         apps/admin/lib/prompt/composition/SectionDataLoader.ts::registerLoader("curriculumQuestions")
 #         apps/admin/lib/prompt/composition/transforms/teaching-content.ts (practiceQuestions filter)
+#         Regression test: apps/admin/tests/lib/composition/loader-tutor-only.test.ts
 
 prompts:
-  - id: before
-    label: "Broken — TUTOR_ONLY MCQ appears in practiceQuestions"
+  - id: after
+    label: "Fixed — TUTOR_ONLY MCQ filtered at loader + transform"
+    raw: |
+      ## PRACTICE QUESTIONS (2)
+
+      1. What is your home town like?
+
+      2. Describe a typical day in your life.
+
+  - id: archive-before
+    label: "Historical record — broken prompt the bug exhibited (kept as a regression sentinel)"
     raw: |
       ## PRACTICE QUESTIONS (3)
 
@@ -23,36 +33,24 @@ prompts:
 
       3. Describe a typical day in your life.
 
-  - id: after
-    label: "Fixed — TUTOR_ONLY MCQ filtered at loader + transform"
-    raw: |
-      ## PRACTICE QUESTIONS (2)
-
-      1. What is your home town like?
-
-      2. Describe a typical day in your life.
-
 tests:
-  # BEFORE: assert the broken-prompt shape is detectable.
-  # The pre-#606 prompt contains a meta-pedagogy question targeting the tutor,
-  # not the learner. This is the leak the loader filter exists to prevent.
-  - description: "Before #606 lands — broken prompt contains tutor-targeted MCQ"
+  - description: "After #606 lands — practiceQuestions contains no tutor-pedagogy MCQs"
     vars:
-      prompt: "{{prompts.before}}"
+      prompt: "{{prompts.after}}"
     assert:
       - type: javascript
         value: |
-          output.includes("What should the tutor do next") ||
-          output.includes("[Answer:")
+          !output.includes("What should the tutor do next") &&
+          !output.includes("[Answer:")
 
-flip-after-merge:
-  description: "Once #606 merges, the assertion below replaces the BEFORE assertion in `tests:`"
+archive-before:
+  description: "Historical detection — if these assertions PASS again, the bug has returned."
   tests:
-    - description: "After #606 lands — practiceQuestions contains no tutor-pedagogy MCQs"
+    - description: "BEFORE-mode assertion preserved as a regression sentinel"
       vars:
-        prompt: "{{prompts.after}}"
+        prompt: "{{prompts.archive-before}}"
       assert:
         - type: javascript
           value: |
-            !output.includes("What should the tutor do next") &&
-            !output.includes("[Answer:")
+            output.includes("What should the tutor do next") ||
+            output.includes("[Answer:")

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -1260,14 +1260,27 @@ registerLoader("curriculumQuestions", async (_callerId, loaderConfig) => {
   );
   if (sourceIds.length === 0) return [];
 
+  // #606 / Epic 100 Link 3 (CURRICULUM → CALL) — TUTOR_ONLY contract enforcement.
+  // The `assessmentUse: TUTOR_ONLY` value semantically means "never render to
+  // learner". This guard is the read-side equivalent of the write-side coercion
+  // already in `save-questions.ts` (TUTOR_QUESTION → assessmentUse=TUTOR_ONLY).
+  // Defense-in-depth: `transforms/teaching-content.ts` re-filters at render
+  // time so a loader regression cannot leak TUTOR_ONLY rows to learners.
+  // See: docs/epic-100-chain-walk.md, gh issue view 606
   return prisma.contentQuestion.findMany({
-    where: { sourceId: { in: [...new Set(sourceIds)] } },
+    where: {
+      sourceId: { in: [...new Set(sourceIds)] },
+      assessmentUse: { not: "TUTOR_ONLY" },
+    },
     orderBy: [{ sortOrder: "asc" }],
     take: 100,
     select: {
       id: true,
       questionText: true,
       questionType: true,
+      // assessmentUse MUST be selected so the render-time defense-in-depth
+      // filter in transforms/teaching-content.ts can re-check this value.
+      assessmentUse: true,
       options: true,
       correctAnswer: true,
       chapter: true,

--- a/apps/admin/lib/prompt/composition/transforms/teaching-content.ts
+++ b/apps/admin/lib/prompt/composition/transforms/teaching-content.ts
@@ -597,9 +597,21 @@ registerTransform("renderTeachingContent", (
   // All questions for this curriculum (session-scoped filtering removed with lesson plans)
   const questions = context.loadedData.curriculumQuestions || [];
 
-  // Split questions by type: TUTOR_QUESTION (skill-mapped with tiered responses) vs MCQ/TRUE_FALSE (practice)
+  // Split questions by type: TUTOR_QUESTION (skill-mapped with tiered responses) vs MCQ/TRUE_FALSE (practice).
+  //
+  // #606 / Epic 100 Link 3 — Defense-in-depth TUTOR_ONLY filter.
+  // The curriculumQuestions loader already excludes assessmentUse=TUTOR_ONLY at the
+  // query boundary (see SectionDataLoader.ts::registerLoader("curriculumQuestions")).
+  // This render-time guard re-enforces the contract so a loader regression cannot
+  // leak a TUTOR_ONLY MCQ into the learner-facing PRACTICE QUESTIONS section.
+  // The two filters MUST stay aligned — both belong to the same contract.
+  // See: docs/epic-100-chain-walk.md, gh issue view 606
+  const isTutorOnly = (q: { assessmentUse?: string | null | undefined }) =>
+    q.assessmentUse === "TUTOR_ONLY";
   const tutorQuestions = questions.filter((q) => q.questionType === "TUTOR_QUESTION");
-  const practiceQuestions = questions.filter((q) => q.questionType !== "TUTOR_QUESTION");
+  const practiceQuestions = questions.filter(
+    (q) => q.questionType !== "TUTOR_QUESTION" && !isTutorOnly(q),
+  );
 
   let questionsSection = "";
 

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -247,6 +247,14 @@ export interface CurriculumQuestionData {
   id: string;
   questionText: string;
   questionType: string;
+  /**
+   * #606 — TUTOR_ONLY contract surface. Selected by the `curriculumQuestions`
+   * loader so the render-time defense-in-depth filter in
+   * `transforms/teaching-content.ts` can re-enforce "never render TUTOR_ONLY
+   * rows to learners".
+   * See: docs/epic-100-chain-walk.md (Link 3 — CURRICULUM → CALL).
+   */
+  assessmentUse?: string | null;
   options: any;
   correctAnswer: string | null;
   chapter: string | null;

--- a/apps/admin/tests/lib/composition/loader-tutor-only.test.ts
+++ b/apps/admin/tests/lib/composition/loader-tutor-only.test.ts
@@ -1,0 +1,254 @@
+/**
+ * #606 — TUTOR_ONLY filter regression net.
+ *
+ * Verifies that `ContentQuestion` rows tagged `assessmentUse=TUTOR_ONLY` (or
+ * `questionType=TUTOR_QUESTION`) never reach the learner-facing PRACTICE
+ * QUESTIONS section of the composed teaching content.
+ *
+ * Two layers of defense both need to hold:
+ *   1. Loader filter — `SectionDataLoader.ts::registerLoader("curriculumQuestions")`
+ *      excludes `assessmentUse: { not: "TUTOR_ONLY" }` at the query boundary.
+ *      (Tested indirectly — this file feeds the transform pre-filtered data.)
+ *   2. Render-time filter — `transforms/teaching-content.ts` re-excludes
+ *      TUTOR_ONLY rows when splitting into `practiceQuestions`. This is the
+ *      defense-in-depth guard that protects against a loader regression.
+ *
+ * The render-time check is what this test pins.
+ *
+ * See: docs/epic-100-chain-walk.md (Link 3 — CURRICULUM → CALL)
+ *      gh issue view 606
+ */
+
+import { describe, it, expect } from "vitest";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type {
+  AssembledContext,
+  CompositionSectionDef,
+  CurriculumAssertionData,
+  CurriculumQuestionData,
+} from "@/lib/prompt/composition/types";
+
+// Trigger transform registration
+import "@/lib/prompt/composition/transforms/teaching-content";
+
+function makeSectionDef(): CompositionSectionDef {
+  return {
+    id: "teaching-content",
+    name: "Teaching Content",
+    priority: 5,
+    dataSource: "_assembled",
+    activateWhen: { condition: "always" },
+    fallback: { action: "omit" },
+    transform: "renderTeachingContent",
+    outputKey: "teaching.content",
+  };
+}
+
+function makeAssertion(overrides: Partial<CurriculumAssertionData> = {}): CurriculumAssertionData {
+  return {
+    id: "a-1",
+    assertion: "Speak in full sentences when answering Part 1 questions.",
+    category: "fact",
+    chapter: "Part 1",
+    section: null,
+    pageRef: null,
+    tags: [],
+    trustLevel: null,
+    examRelevance: 0.8,
+    learningOutcomeRef: null,
+    learningObjectiveId: null,
+    sourceName: "Test Source",
+    sourceTrustLevel: "vetted",
+    sourceId: "src-1",
+    sourceOrder: 0,
+    sourceDocumentType: "TEXTBOOK",
+    ...overrides,
+  } as unknown as CurriculumAssertionData;
+}
+
+function makeQuestion(overrides: Partial<CurriculumQuestionData> = {}): CurriculumQuestionData {
+  return {
+    id: "q-1",
+    questionText: "What is your hometown like?",
+    questionType: "MCQ",
+    assessmentUse: null,
+    options: null,
+    correctAnswer: null,
+    chapter: null,
+    learningOutcomeRef: null,
+    difficulty: null,
+    skillRef: null,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function makeContext(
+  questions: CurriculumQuestionData[],
+  assertions: CurriculumAssertionData[] = [makeAssertion()],
+): AssembledContext {
+  return {
+    loadedData: {
+      caller: { id: "c1", name: "Test", email: null, phone: null, externalId: null, domain: null },
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      callCount: 1,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [],
+      systemSpecs: [],
+      onboardingSpec: null,
+      onboardingSession: null,
+      subjectSources: null,
+      curriculumAssertions: assertions,
+      curriculumQuestions: questions,
+    },
+    sections: {},
+    resolvedSpecs: { identitySpec: null, voiceSpec: null },
+    sharedState: {
+      modules: [],
+      isFirstCall: false,
+      isFirstCallInDomain: false,
+      daysSinceLastCall: 1,
+      completedModules: new Set(),
+      estimatedProgress: 0,
+      lastCompletedIndex: -1,
+      moduleToReview: null,
+      nextModule: null,
+      reviewType: null,
+      reviewReason: null,
+      thresholds: { high: 0.65, low: 0.35 },
+      callNumber: 1,
+      channel: "voice" as const,
+      isFinalSession: false,
+      schedulerDecision: null,
+      lessonPlanEntry: null,
+    },
+    specConfig: {},
+  } as unknown as AssembledContext;
+}
+
+describe("#606 — TUTOR_ONLY contract enforcement at render time", () => {
+  it("transform is registered", () => {
+    expect(getTransform("renderTeachingContent")).toBeDefined();
+  });
+
+  it("excludes assessmentUse=TUTOR_ONLY questions from PRACTICE QUESTIONS", () => {
+    const transform = getTransform("renderTeachingContent")!;
+    const questions: CurriculumQuestionData[] = [
+      makeQuestion({
+        id: "q-tutor-only",
+        questionText: "A student answers with one sentence — what should the tutor do next?",
+        questionType: "MCQ",
+        assessmentUse: "TUTOR_ONLY",
+        correctAnswer: "B",
+      }),
+      makeQuestion({
+        id: "q-practice",
+        questionText: "What is your hometown like?",
+        questionType: "MCQ",
+        assessmentUse: null,
+      }),
+    ];
+    const context = makeContext(questions);
+    const result = transform({}, context, makeSectionDef()) as {
+      teachingPoints: string | null;
+    };
+    const rendered = result.teachingPoints ?? "";
+
+    expect(rendered).toContain("What is your hometown like?");
+    // The TUTOR_ONLY row's question MUST NOT appear in the learner prompt.
+    expect(rendered).not.toContain("what should the tutor do next");
+    // Defense-in-depth check: the meta-pedagogy "[Answer: B]" giveaway must
+    // also not leak through (the practice question has no correctAnswer set).
+    expect(rendered).not.toContain("[Answer: B]");
+  });
+
+  it("excludes questionType=TUTOR_QUESTION from PRACTICE QUESTIONS (existing contract)", () => {
+    const transform = getTransform("renderTeachingContent")!;
+    const questions: CurriculumQuestionData[] = [
+      makeQuestion({
+        id: "q-tutor-question",
+        questionText: "Ask the learner to compare two photos.",
+        questionType: "TUTOR_QUESTION",
+        assessmentUse: null,
+        skillRef: "SKILL-001:fluency",
+      }),
+      makeQuestion({
+        id: "q-practice",
+        questionText: "Describe a typical day in your life.",
+        questionType: "MCQ",
+        assessmentUse: null,
+      }),
+    ];
+    const context = makeContext(questions);
+    const result = transform({}, context, makeSectionDef()) as {
+      teachingPoints: string | null;
+    };
+    const rendered = result.teachingPoints ?? "";
+
+    expect(rendered).toContain("Describe a typical day in your life.");
+    // TUTOR_QUESTION goes to TUTOR QUESTIONS section, not PRACTICE QUESTIONS.
+    expect(rendered).toContain("TUTOR QUESTIONS");
+    // PRACTICE QUESTIONS section should not contain the tutor-question text.
+    const practiceSection = rendered.split("PRACTICE QUESTIONS")[1] ?? "";
+    expect(practiceSection).not.toContain("Ask the learner to compare two photos.");
+  });
+
+  it("renders learner-facing questions when assessmentUse is null or non-TUTOR_ONLY", () => {
+    const transform = getTransform("renderTeachingContent")!;
+    const questions: CurriculumQuestionData[] = [
+      makeQuestion({ id: "q1", questionText: "Q-A", questionType: "MCQ", assessmentUse: null }),
+      makeQuestion({
+        id: "q2",
+        questionText: "Q-B",
+        questionType: "MCQ",
+        assessmentUse: "ASSESSMENT",
+      }),
+      makeQuestion({
+        id: "q3",
+        questionText: "Q-C",
+        questionType: "TRUE_FALSE",
+        assessmentUse: "PRACTICE",
+      }),
+    ];
+    const context = makeContext(questions);
+    const result = transform({}, context, makeSectionDef()) as {
+      teachingPoints: string | null;
+    };
+    const rendered = result.teachingPoints ?? "";
+
+    expect(rendered).toContain("PRACTICE QUESTIONS (3)");
+    expect(rendered).toContain("Q-A");
+    expect(rendered).toContain("Q-B");
+    expect(rendered).toContain("Q-C");
+  });
+
+  it("emits empty practice section when ALL questions are TUTOR_ONLY", () => {
+    const transform = getTransform("renderTeachingContent")!;
+    const questions: CurriculumQuestionData[] = [
+      makeQuestion({
+        id: "q1",
+        questionText: "Tutor pedagogy Q1",
+        assessmentUse: "TUTOR_ONLY",
+      }),
+      makeQuestion({
+        id: "q2",
+        questionText: "Tutor pedagogy Q2",
+        assessmentUse: "TUTOR_ONLY",
+      }),
+    ];
+    const context = makeContext(questions);
+    const result = transform({}, context, makeSectionDef()) as {
+      teachingPoints: string | null;
+    };
+    const rendered = result.teachingPoints ?? "";
+
+    expect(rendered).not.toContain("PRACTICE QUESTIONS");
+    expect(rendered).not.toContain("Tutor pedagogy");
+  });
+});


### PR DESCRIPTION
## Summary

Tier 1 / Story 2 of [Epic 100](https://github.com/WANDERCOLTD/HF/issues/600). Two-layer enforcement of the TUTOR_ONLY audience contract on `ContentQuestion` rows — closes the leak surface that put tutor-pedagogy MCQs ("what should the tutor do next?") into the learner-facing PRACTICE QUESTIONS section.

**Depends on PR #646 (Tier 1 / Story 1 — verification harness for #631).** This branch is stacked on `feat/631-epic-100-verification-harness`.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Loader filter | `apps/admin/lib/prompt/composition/SectionDataLoader.ts` | `curriculumQuestions` loader: `where` now excludes `assessmentUse: { not: "TUTOR_ONLY" }`; `assessmentUse: true` added to `select` so downstream can re-check |
| Render-time filter (defense-in-depth) | `apps/admin/lib/prompt/composition/transforms/teaching-content.ts` | `practiceQuestions` now also excludes `assessmentUse === "TUTOR_ONLY"` — protects against future loader regression |
| Type | `apps/admin/lib/prompt/composition/types.ts` | `CurriculumQuestionData.assessmentUse?: string \| null` |
| Test | `apps/admin/tests/lib/composition/loader-tutor-only.test.ts` | Five vitest cases pinning the render-time contract |
| Eval | `apps/admin/evals/epic-100/no-tutor-training-mcq.yaml` | Flipped BEFORE-mode → AFTER-mode; old assertions preserved in `archive-before:` block as a regression sentinel |
| Memory | `memory/ai-to-db-fk-writes.md` | Defense-in-depth layers table updated with the new entry |

## Acceptance criteria

### Symptom fix
- [x] Tutor-pedagogy MCQs no longer reach learner — verified by vitest
- [x] Re-importing the 23 deleted IELTS rows would re-trigger the loader filter; no leak

### Correctness
- [x] `curriculumQuestions` loader `where` excludes `assessmentUse: TUTOR_ONLY`
- [x] `assessmentUse` added to loader `select` list
- [x] `teaching-content.ts` `practiceQuestions` filter also checks `assessmentUse !== "TUTOR_ONLY"`

### Regression prevention
- [x] Vitest: TUTOR_ONLY does not appear in rendered `questionsSection`
- [x] Vitest: TUTOR_QUESTION existing contract still passes
- [x] Promptfoo eval flipped to AFTER-mode
- [x] `visualAids` loader `isTutorOnlyDocumentType()` guard (line ~1500) is unchanged

### Chain-coherence additions (from the comment on #606)
- [x] **AC** — Both `assessmentUse: true` (select) AND `assessmentUse: { not: "TUTOR_ONLY" }` (where) present. Pre-flight grep confirms.
- [x] **AC** — Render-time defense-in-depth filter added to `transforms/teaching-content.ts`
- [x] **AC** — Memory doc updated (`memory/ai-to-db-fk-writes.md`)

### Definition of done
- [x] No migration needed (filter only, no schema change)
- [ ] `/vm-cp` after merge

## Test plan

- [x] `npm run test -- tests/lib/composition/loader-tutor-only.test.ts` — 5/5 pass
- [x] `npm run test -- tests/lib/composition/` — 397/397 pass (no regressions)
- [x] `npx tsc --noEmit` — no NEW errors
- [x] `npx eslint` on touched files — exit 0
- [ ] On VM after deploy: re-snap audit baseline; `tutorOnlyQuestionsRenderedToLearner` → 0

## UI to verify

After deploy, click into any IELTS Prep Lab caller's composed prompt at `/x/playbook/<id>/calls/prompts` (or wherever the prompt viewer lives). The PRACTICE QUESTIONS section should contain only learner-facing items — no "what should the tutor do next" or `[Answer: X]` style MCQs.

## Deploy

Ready for `/vm-cp` after merge — code-only, no migrations.

Closes #606
Part of #600
Depends on PR #646 (#631 — Tier 1 Story 1)