### PR TITLE
feat(#642): CALL DIFF rows + Call Effect summary + clearer cross-call labels

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -1082,6 +1082,7 @@ export default function CallerDetailPage() {
               <PromptTimelineRows
                 prompts={composedPrompts}
                 calls={(data.calls ?? []) as never}
+                callScores={(data.scores ?? []) as never}
                 loading={promptsLoading}
                 onRefresh={fetchPrompts}
                 callerId={callerId}

--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -23,9 +23,9 @@
  */
 
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { ChevronDown, ChevronRight, Star, Circle } from "lucide-react";
+import { ChevronDown, ChevronRight, Star, Circle, Activity } from "lucide-react";
 import { computeDiff, compactDiffEntries } from "./PromptsSection";
-import type { Call, ComposedPrompt } from "./types";
+import type { Call, CallScore, ComposedPrompt } from "./types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -146,14 +146,150 @@ interface EvalResult {
 interface PromptTimelineRowsProps {
   prompts: ComposedPrompt[];
   calls: Call[];
+  callScores?: CallScore[];
   loading: boolean;
   onRefresh: () => void;
   callerId: string;
 }
 
+/** Delta = (toCall avg) − (fromCall avg) per parameter present in both. */
+interface CallScoreDelta {
+  parameterId: string;
+  name: string;
+  from: number;
+  to: number;
+  delta: number;
+}
+
+function computeCallDiff(
+  fromCall: Call,
+  toCall: Call,
+  scoresByCall: Map<string, Map<string, { avg: number; name: string }>>,
+): CallScoreDelta[] {
+  const fromScores = scoresByCall.get(fromCall.id);
+  const toScores = scoresByCall.get(toCall.id);
+  if (!fromScores || !toScores) return [];
+  const out: CallScoreDelta[] = [];
+  for (const [pid, fv] of fromScores) {
+    const tv = toScores.get(pid);
+    if (!tv) continue;
+    const delta = tv.avg - fv.avg;
+    out.push({ parameterId: pid, name: fv.name || tv.name, from: fv.avg, to: tv.avg, delta });
+  }
+  // Sort by magnitude — largest movers first
+  out.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+  return out;
+}
+
+function CallDiffRow({
+  fromCall,
+  toCall,
+  deltas,
+}: {
+  fromCall: Call;
+  toCall: Call;
+  deltas: CallScoreDelta[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  if (deltas.length === 0) return null;
+  const elapsedMs = new Date(toCall.createdAt).getTime() - new Date(fromCall.createdAt).getTime();
+  const elapsed = formatElapsed(elapsedMs);
+  const top = deltas.slice(0, 3);
+  const rest = deltas.length - top.length;
+  return (
+    <div className={`ptr-call-diff${expanded ? " ptr-call-diff--open" : ""}`}>
+      <button
+        className="ptr-call-diff-head"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        title={`Score deltas from Call ${fromCall.callSequence ?? "?"} to Call ${toCall.callSequence ?? "?"}`}
+      >
+        {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <span className="ptr-call-diff-label">
+          Call diff · Call {fromCall.callSequence ?? "?"} → Call {toCall.callSequence ?? "?"}
+        </span>
+        <span className="ptr-call-diff-summary">
+          {top.map((d) => (
+            <span key={d.parameterId} className={`ptr-call-diff-chip${d.delta > 0 ? " ptr-call-diff-chip--up" : d.delta < 0 ? " ptr-call-diff-chip--down" : ""}`}>
+              {d.name} {d.delta >= 0 ? "+" : ""}{d.delta.toFixed(2)}
+            </span>
+          ))}
+          {rest > 0 && <span className="ptr-call-diff-more">+{rest} more</span>}
+        </span>
+        {elapsed && <span className="ptr-call-diff-elapsed">{elapsed} elapsed</span>}
+      </button>
+      {expanded && (
+        <div className="ptr-call-diff-body">
+          <table className="ptr-call-diff-table">
+            <thead>
+              <tr>
+                <th>Parameter</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Δ</th>
+              </tr>
+            </thead>
+            <tbody>
+              {deltas.map((d) => (
+                <tr key={d.parameterId}>
+                  <td>{d.name}</td>
+                  <td>{d.from.toFixed(2)}</td>
+                  <td>{d.to.toFixed(2)}</td>
+                  <td className={d.delta > 0 ? "ptr-cell-up" : d.delta < 0 ? "ptr-cell-down" : ""}>
+                    {d.delta >= 0 ? "+" : ""}{d.delta.toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatElapsed(ms: number): string {
+  if (ms <= 0) return "";
+  const min = Math.round(ms / 60_000);
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  const rest = min % 60;
+  if (h < 24) return rest === 0 ? `${h}h` : `${h}h ${rest}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d`;
+}
+
+/** Per-call rolled-up scores for the MVP CALL DIFF. Param → average score. */
+function rollupScoresByCall(scores: CallScore[]): Map<string, Map<string, { avg: number; name: string }>> {
+  const byCall = new Map<string, Map<string, { sum: number; count: number; name: string }>>();
+  for (const s of scores) {
+    if (!s.callId || typeof s.score !== "number") continue;
+    if (!byCall.has(s.callId)) byCall.set(s.callId, new Map());
+    const callMap = byCall.get(s.callId)!;
+    const existing = callMap.get(s.parameterId);
+    if (existing) {
+      existing.sum += s.score;
+      existing.count += 1;
+    } else {
+      callMap.set(s.parameterId, { sum: s.score, count: 1, name: s.parameter?.name || s.parameterId });
+    }
+  }
+  // Convert sums to averages
+  const out = new Map<string, Map<string, { avg: number; name: string }>>();
+  for (const [callId, params] of byCall) {
+    const avg = new Map<string, { avg: number; name: string }>();
+    for (const [pid, v] of params) {
+      avg.set(pid, { avg: v.sum / v.count, name: v.name });
+    }
+    out.set(callId, avg);
+  }
+  return out;
+}
+
 export function PromptTimelineRows({
   prompts,
   calls,
+  callScores,
   loading,
   callerId,
 }: PromptTimelineRowsProps) {
@@ -170,6 +306,10 @@ export function PromptTimelineRows({
     for (const c of calls) m.set(c.id, c);
     return m;
   }, [calls]);
+  const scoresByCall = useMemo(
+    () => rollupScoresByCall(callScores ?? []),
+    [callScores],
+  );
 
   // Auto-expand the latest active prompt's row
   const latestActiveId = useMemo(() => {
@@ -304,15 +444,45 @@ export function PromptTimelineRows({
       </div>
 
       {/* ── Groups ── */}
-      {groups.map((group) => {
+      {groups.map((group, groupIdx) => {
         const call = group.callId ? callsById.get(group.callId) : null;
         const header = group.callId == null
           ? "Bootstrap"
           : call
             ? `Call ${call.callSequence ?? "—"} · ${formatDate(call.createdAt)}`
             : `Triggered by call ${group.callId.slice(0, 8)}…`;
+
+        // #642 — CALL DIFF row: state-delta between this call and the previous one.
+        // Only renders when both calls have scored params we can compare.
+        const prevGroup = groupIdx > 0 ? groups[groupIdx - 1] : null;
+        const prevCall = prevGroup?.callId ? callsById.get(prevGroup.callId) : null;
+        const callDiff = call && prevCall
+          ? computeCallDiff(prevCall, call, scoresByCall)
+          : null;
+
+        // #642 — CALL EFFECT summary: input prompt (last chrono before group) → final active in group.
+        // Shows the net change this call produced, regardless of how many prompts were generated.
+        const firstInGroup = group.prompts[0];
+        const inputPrompt = firstInGroup
+          ? chrono[chrono.findIndex((p) => p.id === firstInGroup.id) - 1] ?? null
+          : null;
+        const activeInGroup = group.prompts.find((p) => p.status === "active") ?? group.prompts[group.prompts.length - 1];
+        const callEffect = inputPrompt && activeInGroup && inputPrompt.id !== activeInGroup.id
+          ? computeDiff(inputPrompt.prompt, activeInGroup.prompt)
+          : null;
+        const callEffectAdded = callEffect ? callEffect.filter((d) => d.type === "added").length : 0;
+        const callEffectRemoved = callEffect ? callEffect.filter((d) => d.type === "removed").length : 0;
+
         return (
           <section key={group.callId ?? "bootstrap"} className="ptr-group">
+            {/* CALL DIFF row — between consecutive call groups */}
+            {callDiff && callDiff.length > 0 && (
+              <CallDiffRow
+                fromCall={prevCall!}
+                toCall={call!}
+                deltas={callDiff}
+              />
+            )}
             <header className="ptr-group-header">
               <span className="ptr-group-title">{header}</span>
               {call && (
@@ -323,6 +493,23 @@ export function PromptTimelineRows({
                 </span>
               )}
             </header>
+            {/* CALL EFFECT summary — input → final active in this group */}
+            {callEffect && inputPrompt && activeInGroup && (
+              <div className="ptr-call-effect" title={`Net change from the prompt this call started with to the active prompt after it (${group.prompts.length} generated)`}>
+                <Activity size={12} />
+                <span className="ptr-call-effect-label">Call effect</span>
+                <span className="ptr-call-effect-from">Input #{indexMap.get(inputPrompt.id) ?? "?"}</span>
+                <span className="ptr-call-effect-arrow">→</span>
+                <span className="ptr-call-effect-to">Active #{indexMap.get(activeInGroup.id) ?? "?"}</span>
+                <span className="ptr-diff-chip">
+                  <span className="ptr-diff-chip-added">+{callEffectAdded}</span>
+                  <span className="ptr-diff-chip-removed">−{callEffectRemoved}</span>
+                </span>
+                <span className="ptr-call-effect-note">
+                  net of {group.prompts.length} generated
+                </span>
+              </div>
+            )}
             {group.prompts.map((p) => {
               const idxN = indexMap.get(p.id) ?? -1;
               const comparator = comparatorFor(p, group.prompts, chrono);
@@ -353,14 +540,16 @@ export function PromptTimelineRows({
                       >
                         {isDiffOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
                         <span className="ptr-diff-row-label">
-                          Prompt diff #{compIdx} → #{idxN}
+                          {isSibling
+                            ? `Sibling diff #${compIdx} → #${idxN}`
+                            : `Input #${compIdx} → Generated #${idxN}`}
                         </span>
                         <span className="ptr-diff-chip">
                           <span className="ptr-diff-chip-added">+{added}</span>
                           <span className="ptr-diff-chip-removed">−{removed}</span>
                         </span>
                         <span className="ptr-diff-row-kind">
-                          {isSibling ? "intra-call sibling" : "cross-call"}
+                          {isSibling ? "intra-call (sibling)" : "post-call generation"}
                         </span>
                       </button>
                       {isDiffOpen && diff && (

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -759,6 +759,113 @@
   flex-direction: column;
   gap: 4px;
 }
+
+/* #642 — CALL DIFF row (between consecutive call groups) */
+.ptr-call-diff {
+  margin: 4px 0;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 4%, var(--surface-primary));
+  border: 1px dashed color-mix(in srgb, var(--accent-secondary, #7c6bc4) 30%, transparent);
+}
+.ptr-call-diff--open { border-style: solid; }
+.ptr-call-diff-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+.ptr-call-diff-head:hover { background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 8%, transparent); }
+.ptr-call-diff-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-secondary, #7c6bc4);
+  font-size: 11px;
+}
+.ptr-call-diff-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.ptr-call-diff-chip {
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--text-muted) 8%, transparent);
+}
+.ptr-call-diff-chip--up { color: var(--status-success-text); }
+.ptr-call-diff-chip--down { color: var(--status-error-text); }
+.ptr-call-diff-more {
+  font-size: 11px;
+  color: var(--text-placeholder);
+  font-style: italic;
+}
+.ptr-call-diff-elapsed {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-placeholder);
+}
+.ptr-call-diff-body { padding: 0 12px 10px 28px; }
+.ptr-call-diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.ptr-call-diff-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-default);
+  padding: 4px 8px;
+}
+.ptr-call-diff-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-default) 60%, transparent);
+  font-family: ui-monospace, monospace;
+}
+.ptr-cell-up { color: var(--status-success-text); font-weight: 600; }
+.ptr-cell-down { color: var(--status-error-text); font-weight: 600; }
+
+/* #642 — CALL EFFECT summary row (top of each call group) */
+.ptr-call-effect {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  padding: 6px 12px;
+  margin: 4px 0 4px 24px;
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+  border-left: 3px solid color-mix(in srgb, var(--accent-primary) 50%, transparent);
+  border-radius: 0 6px 6px 0;
+  flex-wrap: wrap;
+}
+.ptr-call-effect-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-primary);
+  font-size: 11px;
+}
+.ptr-call-effect-from,
+.ptr-call-effect-to {
+  font-family: ui-monospace, monospace;
+  color: var(--text-muted);
+}
+.ptr-call-effect-arrow { color: var(--text-placeholder); }
+.ptr-call-effect-note {
+  font-size: 11px;
+  color: var(--text-placeholder);
+  font-style: italic;
+}
 /* #642 — Prompt diff row (sits between prompt rows) */
 .ptr-diff-row {
   margin-left: 36px;


### PR DESCRIPTION
Partially closes #642. Remaining (separate slice): BehaviorMeasurement / reward / memory deltas — need a /api/callers/[id]/call-summary endpoint.

## Three additions

### 1. CALL DIFF row between consecutive call groups
Per-parameter score deltas computed from page-loaded `data.scores`. Top movers as chips, click to expand a full table. Elapsed time between calls also shown.

```
─── CALL DIFF · Call 6 → Call 7 ──────────────
   warmth +0.20    comp_recall +0.05    pace 0.00       19m elapsed
   ▸ See all moved params
```

### 2. Call Effect summary at top of each call group
Net change this call produced — diff between Input (prompt the call started with) and Active (the prompt that drives the NEXT call). One scannable summary per call.

```
─── Call 7 Today 14:23 ───────────────────────
   📐 Call effect · Input #18 → Active #25  +4/−1  (net of 2 generated)
   ▸ Input #18 → Generated #19 (post-call)  +3/−1
   ⚪ #19 post_call ...
   ▸ Generated #19 → #20 (sibling)          +1/−0
   ★ #20 tuner ...
```

### 3. Clearer cross-call diff labels
Was: `Prompt diff #18 → #19  cross-call`. Now: `Input #18 → Generated #19  post-call generation`. Sibling rows now say `Sibling diff` + `intra-call (sibling)`.

## Test plan
- [ ] Tune tab on a caller with ≥2 calls and scored params → CALL DIFF row appears between consecutive call groups
- [ ] Click CALL DIFF chip → table of all moved params shows
- [ ] Each call group has a Call Effect line at the top
- [ ] If only one prompt was generated for a call, Call Effect = same as the single Input→Generated row
- [ ] Cross-call labels read 'Input #X → Generated #Y'
- [ ] No CALL DIFF row before bootstrap or first call (no prior to compare)

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)