### PR TITLE
feat(#611): canonical moduleId + universal evidence gate + module-scoped priorCallFeedback (monolithic)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -26,7 +26,7 @@ import { runAggregateSpecs } from "@/lib/pipeline/aggregate-runner";
 import { aggregateCallerMemorySummary } from "@/lib/ops/memory-extract";
 import { runAdaptSpecs as runRuleBasedAdapt } from "@/lib/pipeline/adapt-runner";
 import { runEvidencePrefilterBatch } from "@/lib/pipeline/evidence-prefilter";
-import { shouldSkipForEvidenceFirst } from "@/lib/pipeline/evidence-gate";
+import { shouldSkipForEvidenceFirst, shouldSkipForZeroEvidence } from "@/lib/pipeline/evidence-gate";
 import { validateSpecDependencies } from "@/lib/pipeline/validate-dependencies";
 import { trackGoalProgress, applyAssessmentAdaptation } from "@/lib/goals/track-progress";
 import { evaluateCheckpoints } from "@/lib/assessment/checkpoint-evaluator";
@@ -1044,6 +1044,32 @@ async function runBatchedCallerAnalysis(
           else if (hasLearnerEvidence === false) shadowEvidenceAbsent++;
           else shadowEvidenceUnknown++;
 
+          // #611 Fix B — universal zero-evidence gate. Fires regardless of
+          // playbook ID, scheduler config, or evidence-first allowlist. The
+          // existing #566 Step 3 Boaz guard (below) only activates for
+          // evidence-first playbooks, leaving every other course writing
+          // unconditional zero-scores when the scorer found no learner
+          // evidence — which is the 47-param zero-storm bug from the Nico
+          // Grant evidence call.
+          //
+          // Rule: when BOTH `hasLearnerEvidence === false` AND
+          // `evidenceQuality === 0`, drop the row. The legacy null-sentinel
+          // path (either field is null) falls through unchanged — that's
+          // the back-compat shape for prompts that pre-date evidence-aware
+          // scoring, and we MUST NOT silently drop legacy 0-scores that
+          // were the correct measurement.
+          //
+          // See: docs/epic-100-chain-walk.md (Link 4 — CALL → SCORE).
+          if (shouldSkipForZeroEvidence(hasLearnerEvidence, evidenceQuality)) {
+            log.info("#611 universal zero-evidence gate: skipping score (no learner evidence + zero quality)", {
+              callId: call.id,
+              callerId,
+              parameterId,
+              score,
+            });
+            continue;
+          }
+
           // #566 Step 3 — Boaz guard. For evidence-first playbooks, drop
           // rows where the scorer judged the learner produced no evidence.
           // The score itself is logged for audit but not persisted.
@@ -1242,9 +1268,17 @@ async function runBatchedCallerAnalysis(
             },
           );
         }
+        // #611 Fix A — drop the `learning.moduleId ||` fallback. The AI's
+        // echoed moduleId is not trusted for DB writes (it has appeared as
+        // a display name like "Part 1: Familiar Topics" or a raw UUID in
+        // production calls, producing dual lo_mastery keys for the same LO).
+        // The host-side `moduleContext.moduleId` is the canonical slug —
+        // resolved from caller context BEFORE the prompt was composed —
+        // and is the only value safe to bake into mastery keys.
+        // See: docs/epic-100-chain-walk.md (Link 4 — CALL → SCORE).
         learningAssessment = {
           specSlug: moduleContext.specSlug,
-          moduleId: learning.moduleId || moduleContext.moduleId,
+          moduleId: moduleContext.moduleId,
           overallMastery,
           outcomes,
           masteryThreshold: moduleContext.masteryThreshold,
@@ -2600,6 +2634,17 @@ async function trackCurriculumAfterCall(
     const { specSlug, moduleId, overallMastery, outcomes, masteryThreshold, allModuleIds } = learningAssessment;
 
     try {
+      // #611 Fix A — resolve curriculumId for this specSlug + thread it
+      // through to `updateCurriculumProgress`. The loMastery write path
+      // then canonicalises `moduleId` to slug form before constructing
+      // the storage key, eliminating the dual-key bug (name-form +
+      // slug-form for the same LO). See docs/epic-100-chain-walk.md
+      // (Link 4) and lib/curriculum/track-progress.ts::updateCurriculumProgress.
+      const curriculumForSpec = await prisma.curriculum.findFirst({
+        where: { slug: specSlug },
+        select: { id: true },
+      });
+
       // Write mastery score for this module + per-LO outcomes.
       // `callId` threads through so `updateModuleMastery` can apply the
       // #547 idempotency guard — the canonical AGGREGATE-stage
@@ -2610,6 +2655,7 @@ async function trackCurriculumAfterCall(
         loMastery: Object.keys(outcomes).length > 0 ? { moduleId, outcomes } : undefined,
         lastAccessedAt: new Date(),
         callId,
+        curriculumId: curriculumForSpec?.id ?? null,
       });
       log.info(`Mastery written for ${specSlug}:${moduleId}`, { mastery: overallMastery, threshold: masteryThreshold, loCount: Object.keys(outcomes).length });
 

--- a/apps/admin/lib/curriculum/resolve-module.ts
+++ b/apps/admin/lib/curriculum/resolve-module.ts
@@ -64,6 +64,65 @@ export async function resolveModuleByLogicalId(
 }
 
 /**
+ * #611 Fix A — canonical moduleId resolution for AGGREGATE-stage writers.
+ *
+ * Returns the verified `CurriculumModule.slug` for a module given any
+ * logical identifier (slug, UUID, or display-name guess). The slug is the
+ * canonical form for the `{moduleId}` token in `lo_mastery:*` storage keys
+ * (and any other contract that requires per-curriculum stability).
+ *
+ * Returns null when the module cannot be resolved within the given
+ * curriculum — callers MUST treat that as a failure and either log+skip
+ * or throw, never fall back to writing the unresolved string into a key.
+ *
+ * Throws on empty `curriculumId` (mirrors `resolveModuleByLogicalId`).
+ *
+ * See: docs/epic-100-chain-walk.md (Link 4 — CALL → SCORE; Link 6 — ADAPT → COMPOSE)
+ *      docs-archive/bdd-specs/contracts/CURRICULUM_PROGRESS_V1.contract.json
+ */
+export async function resolveModuleSlug(
+  curriculumId: string,
+  slugOrIdOrName: string | null | undefined,
+): Promise<string | null> {
+  if (!curriculumId) {
+    throw new Error(
+      "resolveModuleSlug: curriculumId is required. " +
+        "Unscoped slug lookups corrupt cross-playbook FKs — see #407.",
+    );
+  }
+  if (!slugOrIdOrName) return null;
+
+  // Case 1: UUID — look up by id (scoped) and return the slug.
+  if (UUID_RE.test(slugOrIdOrName)) {
+    const row = await prisma.curriculumModule.findFirst({
+      where: { id: slugOrIdOrName, curriculumId },
+      select: { slug: true },
+    });
+    return row?.slug ?? null;
+  }
+
+  // Case 2: slug — verify it exists in this curriculum, return as-is.
+  const direct = await prisma.curriculumModule.findFirst({
+    where: { curriculumId, slug: slugOrIdOrName },
+    select: { slug: true },
+  });
+  if (direct) return direct.slug;
+
+  // Case 3: display title — AI sometimes echoes the module's `title` field
+  // verbatim instead of its slug (e.g. "Part 1: Familiar Topics" instead of
+  // "part1"). Last-resort case-insensitive lookup by title. If multiple
+  // modules in this curriculum share a title (shouldn't happen, but possible)
+  // we refuse rather than guess.
+  const byTitle = await prisma.curriculumModule.findMany({
+    where: { curriculumId, title: { equals: slugOrIdOrName, mode: "insensitive" } },
+    select: { slug: true },
+    take: 2,
+  });
+  if (byTitle.length === 1) return byTitle[0].slug;
+  return null;
+}
+
+/**
  * Resolve the canonical `Curriculum.id` attached to a `Playbook`. Pairs
  * with `resolveModuleByLogicalId()` — the two-step chain (playbook →
  * curriculum → module) is the supported way to derive a module FK from

--- a/apps/admin/lib/curriculum/track-progress.ts
+++ b/apps/admin/lib/curriculum/track-progress.ts
@@ -16,7 +16,7 @@
 import { prisma } from "@/lib/prisma";
 import { ContractRegistry } from "@/lib/contracts/registry";
 import { getTrustSettings, TRUST_DEFAULTS } from "@/lib/system-settings";
-import { resolveModuleByLogicalId } from "@/lib/curriculum/resolve-module";
+import { resolveModuleByLogicalId, resolveModuleSlug } from "@/lib/curriculum/resolve-module";
 
 interface ProgressUpdate {
   currentModuleId?: string;
@@ -30,6 +30,18 @@ interface ProgressUpdate {
    * has already counted this call, the legacy increment is skipped.
    */
   callId?: string;
+  /**
+   * #611 Fix A — when provided, `loMastery.moduleId` is resolved through
+   * `resolveModuleSlug(curriculumId, moduleId)` before being used as the
+   * `{moduleId}` token in the `lo_mastery:*` storage key. This enforces the
+   * canonical key contract (slug form) and prevents AI-echoed display names
+   * from being baked into per-LO mastery keys (the dual-key bug surfaced
+   * by the Nico Grant evidence call).
+   *
+   * Falsy = legacy behaviour (no resolution, key uses the raw moduleId).
+   * See: docs/epic-100-chain-walk.md (Link 4 / Link 6).
+   */
+  curriculumId?: string | null;
 }
 
 /**
@@ -140,31 +152,63 @@ export async function updateCurriculumProgress(
     }
   }
 
-  // Update per-LO mastery outcomes
+  // Update per-LO mastery outcomes.
+  //
+  // #611 Fix A — when `curriculumId` is provided, resolve the raw moduleId
+  // (which the AI may have echoed back as either a slug, UUID, or display
+  // name) to its canonical slug before constructing the storage key. This
+  // is the AI-to-DB guard for the lo_mastery key contract: AI proposes a
+  // moduleId, host validates/canonicalises, key uses the verified slug.
+  //
+  // If resolution fails (moduleId doesn't exist in this curriculum) we log
+  // and skip rather than write a corrupt key. The reader in
+  // `transforms/modules.ts` uses a tolerant `includes(':lo_mastery:')`
+  // match so historical rows still surface — skipping a new bad write
+  // doesn't lose data, it prevents the dual-key drift from recurring.
+  //
+  // Falsy `curriculumId` → legacy behaviour (use the raw moduleId). Once all
+  // callers thread curriculumId through, the fallback path can be removed
+  // (tracked as a follow-on once data migration is complete).
   if (updates.loMastery) {
-    for (const [loRef, score] of Object.entries(updates.loMastery.outcomes)) {
-      const key = await buildStorageKey(specSlug, 'loMastery', updates.loMastery.moduleId, loRef);
-      writes.push(
-        prisma.callerAttribute.upsert({
-          where: {
-            callerId_key_scope: {
+    let canonicalModuleId: string | null = updates.loMastery.moduleId;
+    if (updates.curriculumId && updates.loMastery.moduleId) {
+      canonicalModuleId = await resolveModuleSlug(
+        updates.curriculumId,
+        updates.loMastery.moduleId,
+      );
+      if (!canonicalModuleId) {
+        console.warn(
+          `[track-progress] #611 — refusing lo_mastery write: ` +
+            `cannot resolve moduleId "${updates.loMastery.moduleId}" in curriculum ${updates.curriculumId}. ` +
+            `${Object.keys(updates.loMastery.outcomes).length} LO outcome(s) skipped.`,
+        );
+      }
+    }
+    if (canonicalModuleId) {
+      for (const [loRef, score] of Object.entries(updates.loMastery.outcomes)) {
+        const key = await buildStorageKey(specSlug, 'loMastery', canonicalModuleId, loRef);
+        writes.push(
+          prisma.callerAttribute.upsert({
+            where: {
+              callerId_key_scope: {
+                callerId,
+                key,
+                scope: 'CURRICULUM',
+              },
+            },
+            create: {
               callerId,
               key,
               scope: 'CURRICULUM',
+              valueType: 'NUMBER',
+              numberValue: score,
             },
-          },
-          create: {
-            callerId,
-            key,
-            scope: 'CURRICULUM',
-            valueType: 'NUMBER',
-            numberValue: score,
-          },
-          update: {
-            numberValue: score,
-          },
-        })
-      );
+            update: {
+              numberValue: score,
+            },
+          })
+        );
+      }
     }
   }
 

--- a/apps/admin/lib/pipeline/evidence-gate.ts
+++ b/apps/admin/lib/pipeline/evidence-gate.ts
@@ -58,3 +58,28 @@ export function shouldSkipForEvidenceFirst(
   }
   return false;
 }
+
+/**
+ * #611 Fix B — universal zero-evidence gate. Returns true when a CallScore
+ * row should be dropped because the scorer LLM explicitly reported the
+ * learner produced no evidence AND the evidence quality is zero. Fires
+ * regardless of playbook ID, scheduler config, or evidence-first allowlist.
+ *
+ * Distinguished from `shouldSkipForEvidenceFirst`:
+ *   - That guard is OPT-IN by playbook (evidence-first allowlist + config).
+ *   - This guard is UNIVERSAL — every playbook gets it.
+ *
+ * Legacy null-sentinel path (either field is null) returns false so prompts
+ * that pre-date evidence-aware scoring keep their existing semantics —
+ * silently dropping legitimate-zero rows on legacy prompts would be a
+ * regression we cannot tolerate.
+ *
+ * See: docs/epic-100-chain-walk.md (Link 4 — CALL → SCORE)
+ *      gh issue view 611 (Symptom 2 — 47-param zero-storm)
+ */
+export function shouldSkipForZeroEvidence(
+  hasLearnerEvidence: boolean | null,
+  evidenceQuality: number | null,
+): boolean {
+  return hasLearnerEvidence === false && evidenceQuality === 0;
+}

--- a/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
+++ b/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
@@ -93,19 +93,57 @@ export async function loadPriorCallFeedback(
 
   if (!priorCall) return EMPTY;
 
-  // 2. Scores from that prior call (joined to parameter name)
-  const scores = await prisma.callScore.findMany({
+  // 2. Scores from that prior call (joined to parameter name + parameterId)
+  const allScores = await prisma.callScore.findMany({
     where: { callId: priorCall.id },
     select: {
       score: true,
-      parameter: { select: { name: true } },
+      moduleId: true,
+      parameterId: true,
+      parameter: { select: { name: true, parameterId: true } },
     },
   });
+
+  // #611 Fix C — relevance filter for "weakest area" selection.
+  //
+  // The pre-#611 behaviour picked the lowest-scoring parameter across the
+  // FULL CallScore set, including coaching parameters (`action_commitment`,
+  // `goal_clarity`, …) that wandered into the AGGREGATE batch and scored 0
+  // in the zero-storm bug. That surfaced "your weakest area was
+  // action_commitment (0.0/9)" in the priorCallFeedback summary on an IELTS
+  // playbook — nonsense.
+  //
+  // Strategy (primary = category filter):
+  //   1. If the prior call has any `skill_*` parameters, restrict the
+  //      weakest-area pick to those (skill-domain relevance).
+  //   2. If `CallScore.moduleId` matches the current module on any of those
+  //      skill rows, prefer those (module-domain relevance).
+  //   3. Otherwise fall back to the full set (pure coaching playbooks have
+  //      no skill params; this keeps the legacy behaviour for them).
+  //
+  // Why NOT a strict `moduleId: moduleId` where-clause on the query:
+  // `CallScore.moduleId` is `String?` (nullable). A strict filter would
+  // silently drop legitimate null-moduleId rows. The post-filter approach
+  // surfaces both null and matching-moduleId rows for the relevance pick
+  // while keeping the full set for the overall-score average.
+  //
+  // See: docs/epic-100-chain-walk.md (Link 5 — SCORE → ADAPT)
+  //      gh issue view 611 (Symptom 3 — irrelevant param in priorCallFeedback)
+  const skillScores = allScores.filter((s) =>
+    (s.parameterId ?? s.parameter?.parameterId ?? "").startsWith("skill_"),
+  );
+  const moduleSkillScores = skillScores.filter((s) => s.moduleId === moduleId);
+  const relevanceCandidates =
+    moduleSkillScores.length > 0
+      ? moduleSkillScores
+      : skillScores.length > 0
+        ? skillScores
+        : allScores;
 
   const lastCallAt = priorCall.createdAt.toISOString();
   const relativeTime = formatRelativeTime(priorCall.createdAt, now ?? new Date());
 
-  if (scores.length === 0) {
+  if (allScores.length === 0) {
     return {
       hasFeedback: true,
       lastCallAt,
@@ -118,19 +156,21 @@ export async function loadPriorCallFeedback(
     };
   }
 
-  // Average overall score
-  const overallScore = scores.reduce((sum, s) => sum + (s.score ?? 0), 0) / scores.length;
+  // Average overall score — uses ALL rows (full prior-call summary).
+  const overallScore = allScores.reduce((sum, s) => sum + (s.score ?? 0), 0) / allScores.length;
 
-  // Weakest parameter — pick the lowest score; tie-break by name for determinism
-  const sortedByScore = [...scores].sort((a, b) => {
+  // Weakest parameter — pick from the relevance-filtered candidates so
+  // coaching params never surface as "weakest area" on a skill playbook.
+  // Tie-break by name for determinism.
+  const sortedByScore = [...relevanceCandidates].sort((a, b) => {
     const sa = a.score ?? 0;
     const sb = b.score ?? 0;
     if (sa !== sb) return sa - sb;
     return (a.parameter?.name ?? "").localeCompare(b.parameter?.name ?? "");
   });
   const weakest = sortedByScore[0];
-  const weakestParameterName = weakest.parameter?.name ?? null;
-  const weakestParameterScore = weakest.score ?? null;
+  const weakestParameterName = weakest?.parameter?.name ?? null;
+  const weakestParameterScore = weakest?.score ?? null;
 
   const summary = buildSummary({
     relativeTime,

--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -682,7 +682,21 @@ export async function computeSharedState(
       if (callerId && assertionIds.length > 0 && dbLOs.length > 0) {
         const tpProgress = await getTpProgressBatch(callerId, specSlug, assertionIds);
 
-        // Build LO mastery map from existing CallerAttributes
+        // Build LO mastery map from existing CallerAttributes.
+        //
+        // #611 GRACE WINDOW — the `includes(':lo_mastery:')` match is
+        // INTENTIONALLY tolerant. After Fix A landed, new writes always use
+        // canonical slug-form keys (`curriculum:<spec>:lo_mastery:<slug>:<loRef>`),
+        // but historical rows still carry the broken name-form key
+        // (`...:lo_mastery:Part 1: Familiar Topics:OUT-01`). A stricter
+        // matcher here would silently drop those legacy rows from the
+        // prompt — that's a regression worse than the dual-key bug.
+        //
+        // Reader-tightening is a follow-on story (#614 historical key
+        // migration → then reader switch). Until that migration completes,
+        // this match stays tolerant. Do NOT tighten without first verifying
+        // `callerAttributeOldKeyFormCount` audit counter is 0 across all
+        // environments.
         const loMasteryMap: Record<string, number> = {};
         for (const attr of data.callerAttributes) {
           if (attr.key.includes(':lo_mastery:') && attr.scope === 'CURRICULUM') {

--- a/apps/admin/tests/lib/composition/prior-call-feedback-relevance.test.ts
+++ b/apps/admin/tests/lib/composition/prior-call-feedback-relevance.test.ts
@@ -1,0 +1,246 @@
+/**
+ * #611 Fix C — priorCallFeedback relevance filter regression tests.
+ *
+ * Asserts that the "weakest area" summary never names a coaching
+ * parameter as weakest when the prior CallScore set is mixed
+ * (skill_* + coaching params).
+ *
+ * Strategy under test:
+ *   1. If the prior call has any `skill_*` parameters, the weakest pick
+ *      MUST come from that subset (skill-domain relevance).
+ *   2. If `CallScore.moduleId` matches the current module on any skill
+ *      row, prefer those (module-domain relevance).
+ *   3. If no skill params exist (pure coaching playbook), fall back to
+ *      the full set (legacy behaviour preserved).
+ *
+ * See: docs/epic-100-chain-walk.md (Link 5 — SCORE → ADAPT)
+ *      gh issue view 611 (Symptom 3 — irrelevant param in priorCallFeedback)
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { loadPriorCallFeedback } from "@/lib/prompt/composition/loaders/priorCallFeedback";
+
+interface ScoreRow {
+  score: number;
+  moduleId: string | null;
+  parameterId: string;
+  parameter: { name: string; parameterId: string } | null;
+}
+
+function makePrismaStub(opts: {
+  calls: Array<{
+    id: string;
+    callerId: string;
+    curriculumModuleId: string | null;
+    createdAt: Date;
+  }>;
+  scoresByCall: Record<string, ScoreRow[]>;
+}) {
+  const call = {
+    findFirst: vi.fn(async ({ where, orderBy }: any) => {
+      let matches = opts.calls.filter((c) => {
+        if (where.callerId && c.callerId !== where.callerId) return false;
+        if (where.curriculumModuleId && c.curriculumModuleId !== where.curriculumModuleId) return false;
+        if (where.id?.not && c.id === where.id.not) return false;
+        return true;
+      });
+      if (orderBy?.createdAt === "desc") {
+        matches = matches.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      }
+      return matches[0] ?? null;
+    }),
+  };
+  const callScore = {
+    findMany: vi.fn(async ({ where }: any) => {
+      return opts.scoresByCall[where.callId] ?? [];
+    }),
+  };
+  return { call, callScore } as any;
+}
+
+const NOW = new Date("2026-05-22T10:00:00Z");
+const yesterday = new Date(NOW.getTime() - 24 * 60 * 60 * 1000);
+
+describe("#611 Fix C — priorCallFeedback weakest-area relevance", () => {
+  it("ignores coaching params when picking weakest area on a skill playbook", async () => {
+    // Nico Grant evidence shape — coaching params (action_commitment,
+    // goal_clarity) scored 0 in the zero-storm; skill params have real
+    // band scores. Pre-#611 behaviour picked action_commitment (0.0). The
+    // fix must restrict the pick to skill_* params.
+    const prisma = makePrismaStub({
+      calls: [
+        {
+          id: "call-prior",
+          callerId: "caller-nico",
+          curriculumModuleId: "mod-mock",
+          createdAt: yesterday,
+        },
+      ],
+      scoresByCall: {
+        "call-prior": [
+          {
+            score: 0,
+            moduleId: null,
+            parameterId: "action_commitment",
+            parameter: { name: "Action Commitment", parameterId: "action_commitment" },
+          },
+          {
+            score: 0,
+            moduleId: null,
+            parameterId: "goal_clarity",
+            parameter: { name: "Goal Clarity", parameterId: "goal_clarity" },
+          },
+          {
+            score: 0.6,
+            moduleId: "mod-mock",
+            parameterId: "skill_pronunciation",
+            parameter: { name: "Pronunciation", parameterId: "skill_pronunciation" },
+          },
+          {
+            score: 0.4,
+            moduleId: "mod-mock",
+            parameterId: "skill_fluency",
+            parameter: { name: "Fluency", parameterId: "skill_fluency" },
+          },
+        ],
+      },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "caller-nico",
+      moduleId: "mod-mock",
+      now: NOW,
+    });
+
+    expect(result.hasFeedback).toBe(true);
+    // Weakest area must be Fluency (skill_, lowest at 0.4), NOT action_commitment (0.0)
+    expect(result.weakestParameterName).toBe("Fluency");
+    expect(result.weakestParameterScore).toBe(0.4);
+    expect(result.summary).toContain("Fluency");
+    expect(result.summary).not.toContain("Action Commitment");
+    expect(result.summary).not.toContain("Goal Clarity");
+  });
+
+  it("prefers module-scoped skill rows when both module-matched and unscoped skill rows exist", async () => {
+    const prisma = makePrismaStub({
+      calls: [
+        {
+          id: "call-prior",
+          callerId: "c1",
+          curriculumModuleId: "mod-active",
+          createdAt: yesterday,
+        },
+      ],
+      scoresByCall: {
+        "call-prior": [
+          // Other-module skill row — lower score, but irrelevant to current module
+          {
+            score: 0.2,
+            moduleId: "mod-other",
+            parameterId: "skill_pronunciation",
+            parameter: { name: "Pronunciation", parameterId: "skill_pronunciation" },
+          },
+          // Current-module skill row — higher score but module-relevant
+          {
+            score: 0.5,
+            moduleId: "mod-active",
+            parameterId: "skill_fluency",
+            parameter: { name: "Fluency", parameterId: "skill_fluency" },
+          },
+        ],
+      },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "c1",
+      moduleId: "mod-active",
+      now: NOW,
+    });
+
+    // Should pick Fluency (current module) even though Pronunciation has lower score
+    expect(result.weakestParameterName).toBe("Fluency");
+  });
+
+  it("falls back to all-rows when prior call has no skill_* params (pure coaching playbook)", async () => {
+    // Coaching-only playbook — no skill_* rows; legacy behaviour must
+    // still work (weakest pick from full set).
+    const prisma = makePrismaStub({
+      calls: [
+        {
+          id: "call-prior",
+          callerId: "c1",
+          curriculumModuleId: "mod-coaching",
+          createdAt: yesterday,
+        },
+      ],
+      scoresByCall: {
+        "call-prior": [
+          {
+            score: 0.3,
+            moduleId: null,
+            parameterId: "action_commitment",
+            parameter: { name: "Action Commitment", parameterId: "action_commitment" },
+          },
+          {
+            score: 0.7,
+            moduleId: null,
+            parameterId: "goal_clarity",
+            parameter: { name: "Goal Clarity", parameterId: "goal_clarity" },
+          },
+        ],
+      },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "c1",
+      moduleId: "mod-coaching",
+      now: NOW,
+    });
+
+    // Legacy behaviour: lowest of the full set
+    expect(result.weakestParameterName).toBe("Action Commitment");
+  });
+
+  it("computes overallScore across the FULL set, not just relevance candidates", async () => {
+    // Defensive contract: overallScore averages everything (it's a
+    // session-level snapshot). The relevance filter only affects the
+    // weakest-area pick.
+    const prisma = makePrismaStub({
+      calls: [
+        {
+          id: "call-prior",
+          callerId: "c1",
+          curriculumModuleId: "mod-1",
+          createdAt: yesterday,
+        },
+      ],
+      scoresByCall: {
+        "call-prior": [
+          {
+            score: 0.0,
+            moduleId: null,
+            parameterId: "action_commitment",
+            parameter: { name: "Action Commitment", parameterId: "action_commitment" },
+          },
+          {
+            score: 1.0,
+            moduleId: "mod-1",
+            parameterId: "skill_fluency",
+            parameter: { name: "Fluency", parameterId: "skill_fluency" },
+          },
+        ],
+      },
+    });
+
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: "c1",
+      moduleId: "mod-1",
+      now: NOW,
+    });
+
+    // overall = (0.0 + 1.0) / 2 = 0.5 — includes the coaching row in the average
+    expect(result.overallScore).toBeCloseTo(0.5);
+    // weakest-area pick = Fluency (only skill row); coaching ignored
+    expect(result.weakestParameterName).toBe("Fluency");
+  });
+});

--- a/apps/admin/tests/lib/pipeline/evidence-gate-zero-evidence.test.ts
+++ b/apps/admin/tests/lib/pipeline/evidence-gate-zero-evidence.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for `shouldSkipForZeroEvidence` — #611 Fix B universal zero-evidence gate.
+ *
+ * Distinguished from `shouldSkipForEvidenceFirst` (#566 Step 3) which is
+ * opt-in per playbook. The universal gate fires regardless of playbook
+ * config and protects every course from the 47-param zero-storm bug.
+ *
+ * See: docs/epic-100-chain-walk.md (Link 4 — CALL → SCORE)
+ *      gh issue view 611
+ */
+
+import { describe, it, expect } from "vitest";
+import { shouldSkipForZeroEvidence } from "@/lib/pipeline/evidence-gate";
+
+describe("shouldSkipForZeroEvidence — universal #611 Fix B gate", () => {
+  it("DROPS rows with hasLearnerEvidence=false AND evidenceQuality=0", () => {
+    // The exact zero-storm shape — scorer reported no learner evidence,
+    // zero quality, and the legacy code wrote the row anyway with score=0.
+    expect(shouldSkipForZeroEvidence(false, 0)).toBe(true);
+  });
+
+  it("KEEPS rows with hasLearnerEvidence=false but evidenceQuality>0", () => {
+    // Edge case: scorer says no learner evidence but assigns non-zero
+    // quality. This is rare but valid (e.g. learner gave a one-word answer
+    // that the AI counted as partial signal). Universal gate does NOT drop;
+    // the #566 evidence-first guard may still drop these for IELTS-class
+    // playbooks via a separate rule.
+    expect(shouldSkipForZeroEvidence(false, 0.3)).toBe(false);
+    expect(shouldSkipForZeroEvidence(false, 0.5)).toBe(false);
+    expect(shouldSkipForZeroEvidence(false, 1.0)).toBe(false);
+  });
+
+  it("KEEPS rows with hasLearnerEvidence=true regardless of quality", () => {
+    expect(shouldSkipForZeroEvidence(true, 0)).toBe(false);
+    expect(shouldSkipForZeroEvidence(true, 0.5)).toBe(false);
+    expect(shouldSkipForZeroEvidence(true, 1.0)).toBe(false);
+  });
+
+  it("KEEPS legacy null-sentinel rows (back-compat with old prompt format)", () => {
+    // Critical: pre-evidence-aware prompts return null for both fields.
+    // The universal gate MUST NOT drop those — many of them are
+    // legitimate-zero measurements from older calls, and silently losing
+    // them would be a worse regression than the bug we're fixing.
+    expect(shouldSkipForZeroEvidence(null, null)).toBe(false);
+    expect(shouldSkipForZeroEvidence(null, 0)).toBe(false);
+    expect(shouldSkipForZeroEvidence(null, 0.5)).toBe(false);
+    expect(shouldSkipForZeroEvidence(false, null)).toBe(false);
+    expect(shouldSkipForZeroEvidence(true, null)).toBe(false);
+  });
+
+  it("is playbook-agnostic — no playbookId argument", () => {
+    // Type assertion + behavioural check — confirm the function signature
+    // does not depend on playbook context (that's `shouldSkipForEvidenceFirst`).
+    expect(shouldSkipForZeroEvidence.length).toBe(2);
+  });
+});

--- a/apps/admin/tests/lib/track-progress-canonical-key.test.ts
+++ b/apps/admin/tests/lib/track-progress-canonical-key.test.ts
@@ -1,0 +1,174 @@
+/**
+ * #611 Fix A — track-progress.ts canonical moduleId resolution tests.
+ *
+ * Asserts that `updateCurriculumProgress` writes the lo_mastery key using
+ * the canonical CurriculumModule.slug, NOT the raw moduleId passed in
+ * (which may be an AI-echoed display name like "Part 1: Familiar Topics"
+ * or a UUID). Without resolution, the same LO ends up with two
+ * CallerAttribute rows under different keys — the dual-key bug from the
+ * Nico Grant evidence call.
+ *
+ * See: docs/epic-100-chain-walk.md (Link 4 — CALL → SCORE, Link 6 — ADAPT → COMPOSE)
+ *      gh issue view 611 (Symptom 1 — dual lo_mastery key contracts)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockPrisma = {
+  callerAttribute: {
+    upsert: vi.fn(),
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  curriculum: {
+    findFirst: vi.fn().mockResolvedValue(null),
+  },
+  curriculumModule: {
+    findFirst: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  callerModuleProgress: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+const mockGetKeyPattern = vi.fn();
+const mockGetStorageKeys = vi.fn();
+vi.mock("@/lib/contracts/registry", () => ({
+  ContractRegistry: {
+    getKeyPattern: (...args: any[]) => mockGetKeyPattern(...args),
+    getStorageKeys: (...args: any[]) => mockGetStorageKeys(...args),
+  },
+}));
+
+vi.mock("@/lib/system-settings", () => ({
+  getTrustSettings: vi.fn().mockResolvedValue({}),
+  TRUST_DEFAULTS: {},
+}));
+
+const CURRICULUM_KEY_PATTERN = "curriculum:{specSlug}:{key}";
+const CURRICULUM_STORAGE_KEYS = {
+  currentModule: "current_module",
+  mastery: "mastery:{moduleId}",
+  loMastery: "lo_mastery:{moduleId}:{loRef}",
+  lastAccessed: "last_accessed",
+};
+
+describe("#611 Fix A — canonical moduleId in lo_mastery storage keys", () => {
+  let updateCurriculumProgress: Function;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    mockGetKeyPattern.mockResolvedValue(CURRICULUM_KEY_PATTERN);
+    mockGetStorageKeys.mockResolvedValue(CURRICULUM_STORAGE_KEYS);
+    mockPrisma.callerAttribute.upsert.mockResolvedValue({});
+    mockPrisma.callerAttribute.findMany.mockResolvedValue([]);
+    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+
+    const mod = await import("@/lib/curriculum/track-progress");
+    updateCurriculumProgress = mod.updateCurriculumProgress;
+  });
+
+  it("resolves a display-name moduleId to its canonical slug before key construction", async () => {
+    // AI echoes "Part 1: Familiar Topics" instead of the slug "part1".
+    // resolveModuleSlug looks up by title (case-insensitive) and returns "part1".
+    mockPrisma.curriculumModule.findFirst.mockResolvedValueOnce(null); // direct slug match fails
+    mockPrisma.curriculumModule.findMany.mockResolvedValueOnce([{ slug: "part1" }]); // title match succeeds
+
+    await updateCurriculumProgress("caller-nico", "ielts-curriculum", {
+      curriculumId: "cur-xyz",
+      loMastery: {
+        moduleId: "Part 1: Familiar Topics",
+        outcomes: { "OUT-01": 0.9 },
+      },
+    });
+
+    const upserts = mockPrisma.callerAttribute.upsert.mock.calls.map((c: any) => c[0]);
+    const loMasteryUpsert = upserts.find((u: any) =>
+      u.where.callerId_key_scope.key.includes(":lo_mastery:"),
+    );
+    expect(loMasteryUpsert).toBeDefined();
+    // Canonical slug "part1", NOT the display name "Part 1: Familiar Topics"
+    expect(loMasteryUpsert.where.callerId_key_scope.key).toBe(
+      "curriculum:ielts-curriculum:lo_mastery:part1:OUT-01",
+    );
+  });
+
+  it("uses the slug as-is when AI already returns the canonical form", async () => {
+    // Happy path — AI returns "part1" directly. resolveModuleSlug finds it
+    // by (curriculumId, slug) lookup and returns "part1".
+    mockPrisma.curriculumModule.findFirst.mockResolvedValueOnce({ slug: "part1" });
+
+    await updateCurriculumProgress("caller-nico", "ielts-curriculum", {
+      curriculumId: "cur-xyz",
+      loMastery: {
+        moduleId: "part1",
+        outcomes: { "OUT-01": 0.75 },
+      },
+    });
+
+    const upserts = mockPrisma.callerAttribute.upsert.mock.calls.map((c: any) => c[0]);
+    const loMasteryUpsert = upserts.find((u: any) =>
+      u.where.callerId_key_scope.key.includes(":lo_mastery:"),
+    );
+    expect(loMasteryUpsert.where.callerId_key_scope.key).toBe(
+      "curriculum:ielts-curriculum:lo_mastery:part1:OUT-01",
+    );
+  });
+
+  it("refuses to write when moduleId cannot be resolved in the curriculum", async () => {
+    // Neither slug match nor title match — module doesn't exist in this
+    // curriculum. resolveModuleSlug returns null; the write is skipped.
+    mockPrisma.curriculumModule.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.curriculumModule.findMany.mockResolvedValueOnce([]);
+
+    await updateCurriculumProgress("caller-nico", "ielts-curriculum", {
+      curriculumId: "cur-xyz",
+      loMastery: {
+        moduleId: "ghost-module",
+        outcomes: { "OUT-01": 0.5 },
+      },
+    });
+
+    const loMasteryUpserts = mockPrisma.callerAttribute.upsert.mock.calls.filter(
+      (c: any) => c[0].where.callerId_key_scope.key.includes(":lo_mastery:"),
+    );
+    // No lo_mastery rows written — refusing to write a corrupt key is the
+    // contract under #611.
+    expect(loMasteryUpserts).toHaveLength(0);
+  });
+
+  it("falls back to the raw moduleId when curriculumId is not provided (legacy callers)", async () => {
+    // Callers that haven't been migrated yet must not break. The function
+    // skips resolution and uses the raw moduleId — same as legacy behaviour.
+    await updateCurriculumProgress("caller-nico", "ielts-curriculum", {
+      loMastery: {
+        moduleId: "raw-id",
+        outcomes: { "OUT-01": 0.6 },
+      },
+    });
+
+    const upserts = mockPrisma.callerAttribute.upsert.mock.calls.map((c: any) => c[0]);
+    const loMasteryUpsert = upserts.find((u: any) =>
+      u.where.callerId_key_scope.key.includes(":lo_mastery:"),
+    );
+    expect(loMasteryUpsert.where.callerId_key_scope.key).toBe(
+      "curriculum:ielts-curriculum:lo_mastery:raw-id:OUT-01",
+    );
+    // curriculumModule.findFirst NOT called — no resolution attempt
+    expect(mockPrisma.curriculumModule.findFirst).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Tier 1 / Story 3 of [Epic 100](https://github.com/WANDERCOLTD/HF/issues/600). **MONOLITHIC** merge per the tech-lead review — Fixes A, B, and C are structurally interdependent and ship together. A half-fixed loop is worse than today's state (canonical writes mixed with tolerant reader = irreversible drift).

**Depends on PR #648 (Tier 1 / Story 2 — #606 TUTOR_ONLY filter) which itself depends on PR #646 (Tier 1 / Story 1 — #631 verification harness).** This branch is stacked on `feat/606-tutor-only-filter`.

## Fix A — canonical moduleId resolution at AGGREGATE writers

| | |
|---|---|
| Symptom | Dual `lo_mastery:*` CallerAttribute rows for the same LO under name-form + slug-form keys |
| Root cause | AI echoes `learning.moduleId` as slug, UUID, or display name; AGGREGATE writers bake the raw value into the storage key |
| Fix | New `resolveModuleSlug(curriculumId, slugOrIdOrName)` helper. Threaded through `updateCurriculumProgress` via new optional `curriculumId` field on `ProgressUpdate`. Two route.ts call sites updated. AI-echo fallback dropped at `runBatchedCallerAnalysis`. |
| Symbol path | `route.ts::stageExecutors.AGGREGATE → runBatchedCallerAnalysis`, `lib/curriculum/track-progress.ts::updateCurriculumProgress`, `lib/curriculum/resolve-module.ts::resolveModuleSlug` |

## Fix B — universal zero-evidence gate

| | |
|---|---|
| Symptom | 47-param zero-storm — every CallScore for one call scored 0 |
| Root cause | No `hasEvidence`-style gate for non-evidence-first playbooks; existing `#566 Step 3` Boaz guard is opt-in via `config.scheduler.evidenceFirstEnabled` + hardcoded allowlist |
| Fix | New `shouldSkipForZeroEvidence(hasLearnerEvidence, evidenceQuality)` — drops rows where BOTH are explicit `false` / `0`. Universal — fires regardless of playbook ID or scheduler config. Distinct from `shouldSkipForEvidenceFirst`. Legacy null-sentinel rows fall through unchanged (back-compat with pre-evidence-aware prompts). |
| Symbol path | `route.ts::runBatchedCallerAnalysis` (the CallScore write block at lines ~1027), `lib/pipeline/evidence-gate.ts::shouldSkipForZeroEvidence` |

## Fix C — module-scoped priorCallFeedback weakest-area pick

| | |
|---|---|
| Symptom | priorCallFeedback summary names `action_commitment` (coaching param) as weakest area on an IELTS playbook |
| Root cause | `loadPriorCallFeedback` picks lowest-scoring parameter across the full CallScore set, including coaching params that landed in the zero-storm |
| Fix | Relevance filter: prefer `skill_*` params (skill-domain) → within those prefer rows whose `moduleId` matches current module (module-domain) → fall back to full set for pure coaching playbooks. NOT a strict `moduleId: moduleId` where-clause — would silently drop legitimate null-moduleId rows. `overallScore` still averages the full set. |
| Symbol path | `lib/prompt/composition/loaders/priorCallFeedback.ts::loadPriorCallFeedback` |

## Backward compatibility

- `transforms/modules.ts` reader (`includes(':lo_mastery:')` match) — **NOT tightened** in this PR. Grace window per AC: historical name-form rows still surface via the tolerant match until #614 (historical key migration) lands. Comment block added above the match documenting the contract.

## Tech-lead corrections applied (all 5 ACs)

- [x] MONOLITHIC merge — A + B + C in one PR (this one)
- [x] Fix A — `updateCurriculumProgress` grew a `curriculumId` parameter (option a per review); BOTH route.ts call sites fixed (~1247 AI-echo drop + ~2608 resolution thread-through)
- [x] Fix B — new universal zero-evidence branch, NOT an extension of `shouldSkipForEvidenceFirst`
- [x] Fix C — primary mechanism is parameter-CATEGORY filter (`skill_*` prefix), NOT a strict `moduleId: moduleId` where-clause
- [x] Reader stays tolerant — comment block added; tightening deferred to #614 follow-on

## Tests

- `apps/admin/tests/lib/track-progress-canonical-key.test.ts` — 4 tests
- `apps/admin/tests/lib/pipeline/evidence-gate-zero-evidence.test.ts` — 5 tests
- `apps/admin/tests/lib/composition/prior-call-feedback-relevance.test.ts` — 4 tests

All 13 new tests pass. Broader regression (`pipeline/` + `composition/` + `track-progress*`) — 560/560 green. `npx tsc` introduces no new errors. `npx eslint` exits 0 on touched files.

## Memory + docs

- `memory/flow-pipeline.md` — AGGREGATE stage section documents canonical moduleId + universal evidence gate
- `memory/entities.md` — slug-scope invariants section documents canonical `lo_mastery:*` key shape
- `memory/ai-to-db-fk-writes.md` — three new entries (Fix A / Fix B / Fix C)

## Audit counter movement (post-VM run)

- `dualLoMasteryKeysSameLO` → 0 (new writes use canonical slug)
- `callScoreZeroStorms` → 0 (universal gate prevents the storm at source)
- priorCallFeedback weakest-area: no longer surfaces coaching params on skill playbooks (verified by `sim-canonical-call.ts`)

## UI to verify

After deploy, click into a returning IELTS caller at `/x/playbook/<id>/calls/prompts` and:
1. Inspect the `priorCallFeedback.summary` section — should name a `skill_*` parameter (Pronunciation, Fluency, etc.), never `action_commitment` or `goal_clarity`.
2. Run a fresh sim-call from `/x/sim` and confirm the new CallScore rows do NOT show 40+ identical zeros.
3. Inspect CallerAttribute rows for that caller — `lo_mastery:*` keys should use module slug only.

## Deploy

Ready for `/vm-cp` after merge — code-only, no migrations.

Closes #611
Part of #600
Depends on PR #648 (#606 — Tier 1 Story 2)
Depends on PR #646 (#631 — Tier 1 Story 1)