### PR TITLE
fix(#642): bootstrap key collision + Tune-tab styling to cpt-accordion pattern

### DIFF
--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { ChevronDown, ChevronRight, Star, Circle, Activity } from "lucide-react";
+import { ChevronDown, ChevronRight, Star, Circle, Activity, GitCompare } from "lucide-react";
 import { computeDiff, compactDiffEntries } from "./PromptsSection";
 import type { Call, CallScore, ComposedPrompt } from "./types";
 
@@ -204,7 +204,7 @@ function CallDiffRow({
         aria-expanded={expanded}
         title={`Score deltas from Call ${fromCall.callSequence ?? "?"} to Call ${toCall.callSequence ?? "?"}`}
       >
-        {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <Activity size={13} />
         <span className="ptr-call-diff-label">
           Call diff · Call {fromCall.callSequence ?? "?"} → Call {toCall.callSequence ?? "?"}
         </span>
@@ -217,6 +217,7 @@ function CallDiffRow({
           {rest > 0 && <span className="ptr-call-diff-more">+{rest} more</span>}
         </span>
         {elapsed && <span className="ptr-call-diff-elapsed">{elapsed} elapsed</span>}
+        {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
       </button>
       {expanded && (
         <div className="ptr-call-diff-body">
@@ -474,7 +475,7 @@ export function PromptTimelineRows({
         const callEffectRemoved = callEffect ? callEffect.filter((d) => d.type === "removed").length : 0;
 
         return (
-          <section key={group.callId ?? "bootstrap"} className="ptr-group">
+          <section key={`${group.callId ?? "bootstrap"}-${groupIdx}`} className="ptr-group">
             {/* CALL DIFF row — between consecutive call groups */}
             {callDiff && callDiff.length > 0 && (
               <CallDiffRow
@@ -538,7 +539,7 @@ export function PromptTimelineRows({
                         aria-expanded={isDiffOpen}
                         title={isDiffOpen ? "Hide diff" : "Show diff body"}
                       >
-                        {isDiffOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                        <GitCompare size={12} />
                         <span className="ptr-diff-row-label">
                           {isSibling
                             ? `Sibling diff #${compIdx} → #${idxN}`
@@ -551,6 +552,7 @@ export function PromptTimelineRows({
                         <span className="ptr-diff-row-kind">
                           {isSibling ? "intra-call (sibling)" : "post-call generation"}
                         </span>
+                        {isDiffOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
                       </button>
                       {isDiffOpen && diff && (
                         <div className="ptr-diff-row-body">

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -761,27 +761,29 @@
 }
 
 /* #642 — CALL DIFF row (between consecutive call groups) */
+/* CALL DIFF row — uses cpt-accordion-card chrome, accent-secondary tint */
 .ptr-call-diff {
   margin: 4px 0;
   border-radius: 8px;
-  background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 4%, var(--surface-primary));
-  border: 1px dashed color-mix(in srgb, var(--accent-secondary, #7c6bc4) 30%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-secondary, #7c6bc4) 40%, var(--border-default));
+  overflow: hidden;
 }
-.ptr-call-diff--open { border-style: solid; }
 .ptr-call-diff-head {
   display: flex;
   align-items: center;
   gap: 8px;
   width: 100%;
-  background: transparent;
+  background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 8%, var(--surface-secondary));
   border: none;
   padding: 8px 12px;
   text-align: left;
   cursor: pointer;
   flex-wrap: wrap;
   font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
 }
-.ptr-call-diff-head:hover { background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 8%, transparent); }
+.ptr-call-diff-head:hover { background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 14%, var(--surface-secondary)); }
 .ptr-call-diff-label {
   font-weight: 700;
   text-transform: uppercase;
@@ -866,44 +868,56 @@
   color: var(--text-placeholder);
   font-style: italic;
 }
-/* #642 — Prompt diff row (sits between prompt rows) */
+/* #642 — Prompt diff row (sits between prompt rows). Uses cpt-accordion
+   chrome to match the Calls & Prompts tab feel, with a dashed indent so
+   it visually reads as a connector between two prompts. */
 .ptr-diff-row {
   margin-left: 36px;
   border-left: 2px dashed color-mix(in srgb, var(--text-muted) 30%, transparent);
-  padding-left: 10px;
+  padding-left: 8px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
 }
 .ptr-diff-row-head {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 8px;
-  background: transparent;
-  border: none;
-  padding: 4px 0;
+  width: 100%;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  padding: 6px 10px;
   font-size: 11px;
-  color: var(--text-muted);
+  font-weight: 600;
+  color: var(--text-primary);
   cursor: pointer;
   text-align: left;
-  width: fit-content;
+  flex-wrap: wrap;
 }
 .ptr-diff-row-head:hover {
-  color: var(--text-primary);
+  background: color-mix(in srgb, var(--surface-secondary) 80%, var(--accent-primary) 20%);
+}
+.ptr-diff-row--open .ptr-diff-row-head {
+  border-radius: 6px 6px 0 0;
 }
 .ptr-diff-row-label {
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
 }
 .ptr-diff-row-kind {
   font-size: 10px;
   font-style: italic;
   color: var(--text-placeholder);
+  margin-left: auto;
 }
 .ptr-diff-row-body {
-  padding: 6px 12px 10px 0;
+  border: 1px solid var(--border-default);
+  border-top: none;
+  border-radius: 0 0 6px 6px;
+  padding: 10px;
+  background: var(--surface-primary);
 }
+/* Mirrors .cpt-accordion-card shape from Calls & Prompts tab */
 .ptr-row {
   display: flex;
   flex-direction: column;
@@ -911,17 +925,29 @@
   border-radius: 8px;
   background: var(--surface-primary);
   margin-left: 24px;
+  overflow: hidden;
 }
 .ptr-row--active {
   border-color: color-mix(in srgb, var(--accent-primary) 40%, transparent);
-  background: color-mix(in srgb, var(--accent-primary) 4%, var(--surface-primary));
 }
+/* Mirrors .cpt-accordion-header — surface-secondary, 600 weight, hover blend */
 .ptr-row-head {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--surface-secondary);
+  border: none;
+  cursor: default;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
   flex-wrap: wrap;
+}
+.ptr-row--active .ptr-row-head {
+  background: color-mix(in srgb, var(--accent-primary) 8%, var(--surface-secondary));
 }
 .ptr-row-marker {
   display: inline-flex;


### PR DESCRIPTION
Bundled fix for two issues spotted on the live Tune tab.

## 1. React duplicate-key warning
`Encountered two children with the same key, bootstrap` when a caller has multiple non-consecutive prompts with `triggerCallId = null`. `groupPrompts()` correctly emits separate groups but both used `'bootstrap'` as the React key. Fixed by including `groupIdx` in the key.

## 2. Header expander styling matches Calls & Prompts
User feedback: 'rose' (the accordion expander look) on the Tune tab should match the Calls & Prompts tab. Aligned to the `cpt-accordion-*` pattern:

- **`.ptr-row-head`** — surface-secondary background, 600 weight, hover blend. Active prompt rows blend accent-primary into the header bg.
- **`.ptr-diff-row-head`** — proper accordion-header chip: surface-secondary bg, 1px border, hover blend, rounded corners that flatten the bottom when expanded. Chevron moved to the END of the row. `GitCompare` icon at the start.
- **`.ptr-call-diff-head`** — same treatment with accent-secondary tint so CALL DIFFs stay visually distinct from PROMPT DIFFs. `Activity` icon at start, chevron at end.

## Test plan
- [ ] Tune tab on a caller with multiple bootstrap-style prompts — no React duplicate-key warning in console
- [ ] Headers on Tune tab visually echo the Calls & Prompts tab accordions (surface-secondary bg, hover blend, chevron at end)
- [ ] Active prompt row's header is tinted accent-primary
- [ ] CALL DIFF rows have a purple/violet tint
- [ ] Click any diff or call-diff header — expands; click again — collapses

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)