### PR TITLE
feat(#642): per-diff Compact toggle + red/green row tints on CALL DIFF

### DIFF
--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -232,7 +232,7 @@ function CallDiffRow({
             </thead>
             <tbody>
               {deltas.map((d) => (
-                <tr key={d.parameterId}>
+                <tr key={d.parameterId} className={d.delta > 0 ? "ptr-row-up" : d.delta < 0 ? "ptr-row-down" : ""}>
                   <td>{d.name}</td>
                   <td>{d.from.toFixed(2)}</td>
                   <td>{d.to.toFixed(2)}</td>
@@ -556,6 +556,24 @@ export function PromptTimelineRows({
                       </button>
                       {isDiffOpen && diff && (
                         <div className="ptr-diff-row-body">
+                          <div className="ptr-diff-body-toolbar">
+                            <div className="hf-toggle-group">
+                              <button
+                                onClick={(e) => { e.stopPropagation(); setCompactDiff(false); }}
+                                className={`hf-toggle-btn hf-toggle-btn-sm ${!compactDiff ? "hf-toggle-btn-active" : ""}`}
+                                title="Show every line (added / removed / same)"
+                              >
+                                Full
+                              </button>
+                              <button
+                                onClick={(e) => { e.stopPropagation(); setCompactDiff(true); }}
+                                className={`hf-toggle-btn hf-toggle-btn-sm ${compactDiff ? "hf-toggle-btn-active" : ""}`}
+                                title="Only added / removed lines with separators"
+                              >
+                                Compact
+                              </button>
+                            </div>
+                          </div>
                           <div className="ps-diff-block">
                             {!compactDiff && diff.map((line, i) => (
                               <div

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -836,6 +836,16 @@
 }
 .ptr-cell-up { color: var(--status-success-text); font-weight: 600; }
 .ptr-cell-down { color: var(--status-error-text); font-weight: 600; }
+.ptr-row-up { background: color-mix(in srgb, var(--status-success-bg) 60%, transparent); }
+.ptr-row-down { background: color-mix(in srgb, var(--status-error-bg) 60%, transparent); }
+
+/* In-body Full/Compact toggle on each expanded prompt-diff (mirrors the
+   global toolbar at the top of the timeline — same compactDiff state). */
+.ptr-diff-body-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 6px;
+}
 
 /* #642 — CALL EFFECT summary row (top of each call group) */
 .ptr-call-effect {


### PR DESCRIPTION
Two tweaks after the styling pass:

1. **Full / Compact toggle is now visible inside each expanded prompt-diff body**, not only at the top of the timeline. All toggles read/write the same `compactDiff` state, so flipping in one place updates every open diff body.

2. **CALL DIFF table rows are tinted** — soft green for params that moved up, soft red for params that moved down. Matches the existing red/green theme on prompt-diff lines.

## Test plan
- [ ] Expand a prompt-diff in the Tune tab → small Full / Compact toggle visible top-right of the diff body
- [ ] Click Compact in that toggle → diff filters to +/− lines; the global toggle at top of timeline also reflects the change
- [ ] Open a CALL DIFF row → each row in the table is tinted green (up) or red (down); zero-delta rows have no tint

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)