### PR TITLE
fix(#642): only the FIRST null-trigger group is 'Bootstrap'; standalone for the rest

### DIFF
--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -447,8 +447,16 @@ export function PromptTimelineRows({
       {/* ── Groups ── */}
       {groups.map((group, groupIdx) => {
         const call = group.callId ? callsById.get(group.callId) : null;
+        // #642 — only the FIRST chronological null-triggerCallId group is
+        // a real Bootstrap (initial enrollment prompt). Later null groups
+        // are standalone recomposes (sim / TUNER_FANOUT / manual / etc.)
+        // and get labelled by their dominant triggerType.
+        const isFirstNullGroup = group.callId == null && groups.findIndex((g) => g.callId == null) === groupIdx;
+        const dominantTrigger = group.prompts[0]?.triggerType || "—";
         const header = group.callId == null
-          ? "Bootstrap"
+          ? (isFirstNullGroup
+              ? "Bootstrap"
+              : `Standalone · ${dominantTrigger.toLowerCase().replace(/_/g, " ")} · ${formatDate(group.prompts[0].composedAt)}`)
           : call
             ? `Call ${call.callSequence ?? "—"} · ${formatDate(call.createdAt)}`
             : `Triggered by call ${group.callId.slice(0, 8)}…`;
@@ -494,11 +502,15 @@ export function PromptTimelineRows({
                 </span>
               )}
             </header>
-            {/* CALL EFFECT summary — input → final active in this group */}
+            {/* Group effect summary — input → final active in this group.
+                Labelled "Call effect" for call groups, "Group effect" for
+                standalone (sim / TUNER_FANOUT / enrollment) groups. */}
             {callEffect && inputPrompt && activeInGroup && (
-              <div className="ptr-call-effect" title={`Net change from the prompt this call started with to the active prompt after it (${group.prompts.length} generated)`}>
+              <div className="ptr-call-effect" title={`Net change from input to the active prompt after this group (${group.prompts.length} generated)`}>
                 <Activity size={12} />
-                <span className="ptr-call-effect-label">Call effect</span>
+                <span className="ptr-call-effect-label">
+                  {call ? "Call effect" : "Group effect"}
+                </span>
                 <span className="ptr-call-effect-from">Input #{indexMap.get(inputPrompt.id) ?? "?"}</span>
                 <span className="ptr-call-effect-arrow">→</span>
                 <span className="ptr-call-effect-to">Active #{indexMap.get(activeInGroup.id) ?? "?"}</span>


### PR DESCRIPTION
## Bug
User screenshot showed `BOOTSTRAP` appearing mid-timeline between Call 13's post-call prompt and a sequence of TUNER_FANOUT prompts:

```
#20 SIM
CALL 13 · TODAY 10:53 AM
   Input #20 → Generated #21
   #21 POST_CALL
BOOTSTRAP   ← wrong
   Input #21 → Generated #22
   #22 SIM
```

## Root cause
Any group of prompts with `triggerCallId = null` was getting the 'Bootstrap' header. DB query on this caller shows many such prompts: `enrollment`, `sim` (repeatedly), `TUNER_FANOUT` — only the first (enrollment) is the real bootstrap.

## Fix
- First chronological null-trigger group → still 'Bootstrap'
- Later null-trigger groups → 'Standalone · <triggerType> · <date>' so the user can tell sim recomposes apart from TUNER_FANOUT applies apart from the initial bootstrap
- The 'Call effect' summary row is relabelled 'Group effect' for standalone (non-call) groups — 'call effect' is misleading when no call triggered the group

## Test plan
- [ ] Tune tab on the caller from the screenshot — only the FIRST group at the very top says 'Bootstrap'
- [ ] Mid-timeline standalone groups say 'Standalone · sim · ...' or 'Standalone · tuner fanout · ...'
- [ ] Call groups still say 'Call N · Today HH:MM'
- [ ] Standalone groups' effect row says 'Group effect'
- [ ] Call groups' effect row still says 'Call effect'

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)