### PR TITLE
feat(#642): prompt-row header click-to-expand + preview + visual distinction from diff rows

### DIFF
--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { ChevronDown, ChevronRight, Star, Circle, Activity, GitCompare } from "lucide-react";
+import { ChevronDown, ChevronRight, Star, Circle, Activity, GitCompare, FileText } from "lucide-react";
 import { computeDiff, compactDiffEntries } from "./PromptsSection";
 import type { Call, CallScore, ComposedPrompt } from "./types";
 
@@ -626,9 +626,17 @@ export function PromptTimelineRows({
                     </div>
                   )}
 
-                  {/* PROMPT ROW */}
+                  {/* PROMPT ROW — entire head click-toggles the body.
+                      Distinct from diff rows via FileText icon + accent-primary tint. */}
                   <div className={`ptr-row${isActive ? " ptr-row--active" : ""}`}>
-                    <div className="ptr-row-head">
+                    <button
+                      type="button"
+                      className="ptr-row-head"
+                      onClick={() => toggle(expandedPrompt, setExpandedPrompt, p.id)}
+                      aria-expanded={isPromptOpen}
+                      title={isPromptOpen ? "Hide prompt body" : "Show prompt body"}
+                    >
+                      <FileText size={13} className="ptr-row-icon" />
                       <span className="ptr-row-marker" title={isActive ? "Active — drives the next call" : "Superseded"}>
                         {isActive ? <Star size={14} className="ptr-star" /> : <Circle size={10} className="ptr-circle" />}
                       </span>
@@ -637,18 +645,18 @@ export function PromptTimelineRows({
                         {triggerLabel(p)}
                       </span>
                       <span className="ptr-row-time">{formatDate(p.composedAt)}</span>
-                      <div className="ptr-row-actions">
+                      {!isPromptOpen && p.prompt && (
+                        <span className="ptr-row-preview" title={p.prompt.slice(0, 200)}>
+                          {p.prompt.slice(0, 80).replace(/\s+/g, " ")}
+                          {p.prompt.length > 80 ? "…" : ""}
+                        </span>
+                      )}
+                      <span className="ptr-row-actions" onClick={(e) => e.stopPropagation()}>
                         <button
-                          className={`ptr-row-action${isPromptOpen ? " ptr-row-action--open" : ""}`}
-                          onClick={() => toggle(expandedPrompt, setExpandedPrompt, p.id)}
-                          title="Show prompt body"
-                        >
-                          {isPromptOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                          prompt
-                        </button>
-                        <button
+                          type="button"
                           className={`ptr-row-action${isEvalOpen ? " ptr-row-action--open" : ""}${ev ? " ptr-row-action--has-eval" : ""}`}
-                          onClick={() => {
+                          onClick={(e) => {
+                            e.stopPropagation();
                             if (ev) {
                               toggle(expandedEval, setExpandedEval, p.id);
                             } else if (!evLoading) {
@@ -660,8 +668,9 @@ export function PromptTimelineRows({
                         >
                           {evLoading ? "evaluating…" : ev ? (isEvalOpen ? "▾ eval" : "▸ eval") : "eval"}
                         </button>
-                      </div>
-                    </div>
+                      </span>
+                      {isPromptOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                    </button>
 
                     {/* Expanded — prompt body */}
                     {isPromptOpen && (

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -940,24 +940,48 @@
 .ptr-row--active {
   border-color: color-mix(in srgb, var(--accent-primary) 40%, transparent);
 }
-/* Mirrors .cpt-accordion-header — surface-secondary, 600 weight, hover blend */
+/* PROMPT row head — click-toggles body, distinct from diff rows via
+   FileText icon + accent-primary tint. Mirrors .cpt-accordion-header. */
 .ptr-row-head {
   display: flex;
   align-items: center;
   gap: 8px;
   width: 100%;
   padding: 8px 12px;
-  background: var(--surface-secondary);
+  background: color-mix(in srgb, var(--accent-primary) 6%, var(--surface-secondary));
   border: none;
-  cursor: default;
+  cursor: pointer;
   text-align: left;
   font-size: 12px;
   font-weight: 600;
   color: var(--text-primary);
   flex-wrap: wrap;
+  font-family: inherit;
+}
+.ptr-row-head:hover {
+  background: color-mix(in srgb, var(--accent-primary) 14%, var(--surface-secondary));
 }
 .ptr-row--active .ptr-row-head {
-  background: color-mix(in srgb, var(--accent-primary) 8%, var(--surface-secondary));
+  background: color-mix(in srgb, var(--accent-primary) 18%, var(--surface-secondary));
+}
+.ptr-row--active .ptr-row-head:hover {
+  background: color-mix(in srgb, var(--accent-primary) 24%, var(--surface-secondary));
+}
+.ptr-row-icon {
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}
+.ptr-row-preview {
+  flex: 1;
+  min-width: 100px;
+  font-weight: 400;
+  font-style: italic;
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-left: 4px;
 }
 .ptr-row-marker {
   display: inline-flex;


### PR DESCRIPTION
User feedback after the cpt-accordion styling pass:
> 'we need to see Prompt rows, surely? currently i only see DIFF rows??'
> 'also could do with nice row header colours, icons etc....all row item headers click to expand/colapse'

The prompt rows ARE rendered today but they look almost identical to diff rows because both share `surface-secondary` background. Fixing the visual + interaction:

## Changes
- **Whole prompt-row head is now a button**. Clicking anywhere on the head toggles the prompt body. Matches the diff + call-diff click-to-expand pattern. No more separate '▸ prompt' button.
- **FileText icon** at the start signals 'this is a prompt'.
- **accent-primary tint** on the prompt-row head: 6% baseline → 14% hover → 18% when active → 24% active hover. Diff rows keep the neutral surface-secondary tone so the two row types are obvious at a glance.
- **Inline preview**: when the body is collapsed, the first ~80 characters of the prompt text show as italic muted text in the row head — makes a collapsed row useful right away.
- 'eval' action button is retained because evaluating is a separate action from expanding the body.
- Chevron at the end (cpt-accordion pattern).

## Result
- Prompt rows: blue-tinted, FileText icon, italic preview text
- Prompt-diff rows: neutral surface-secondary, GitCompare icon, +A/−B chip
- CALL DIFF rows: purple-tinted, Activity icon
- Call group headers: borderless section labels

## Test plan
- [ ] Tune tab: each prompt row is visually distinct from the diff row(s) before/after it
- [ ] Click anywhere on a prompt row head → prompt body expands; click again → collapses
- [ ] Active prompt row has a noticeably stronger blue tint
- [ ] Collapsed rows show the first ~80 chars of prompt text inline
- [ ] Eval button still works without expanding the prompt body

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)