### PR TITLE
feat(#642): per-trigger icons on prompt rows + compact top-right diff toggle

### DIFF
--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { ChevronDown, ChevronRight, Star, Circle, Activity, GitCompare, FileText } from "lucide-react";
+import { ChevronDown, ChevronRight, Star, Circle, Activity, GitCompare, FileText, Phone, MonitorPlay, SlidersHorizontal, Sparkles, Clock, CheckCircle2, Eye, User } from "lucide-react";
 import { computeDiff, compactDiffEntries } from "./PromptsSection";
 import type { Call, CallScore, ComposedPrompt } from "./types";
 
@@ -51,6 +51,21 @@ function triggerLabel(p: ComposedPrompt): string {
   if (t === "post_call" || t === "pipeline") return "post call";
   if (t === "tuner_fanout") return "tuner";
   return p.triggerType || "—";
+}
+
+/** #642 — triggerType → icon. Makes it obvious where a prompt came from at a glance. */
+function TriggerIcon({ p, size = 13 }: { p: ComposedPrompt; size?: number }) {
+  const t = (p.triggerType || "").toLowerCase();
+  const cls = "ptr-row-icon";
+  if (t === "post_call" || t === "pipeline") return <Phone size={size} className={cls} />;
+  if (t === "sim") return <MonitorPlay size={size} className={cls} />;
+  if (t === "tuner_fanout" || t === "tuner") return <SlidersHorizontal size={size} className={cls} />;
+  if (t === "enrollment") return <Sparkles size={size} className={cls} />;
+  if (t === "scheduled") return <Clock size={size} className={cls} />;
+  if (t === "analysis_complete") return <CheckCircle2 size={size} className={cls} />;
+  if (t === "preview_first_call") return <Eye size={size} className={cls} />;
+  if (t === "manual") return <User size={size} className={cls} />;
+  return <FileText size={size} className={cls} />;
 }
 
 /** Group prompts by triggerCallId. null group = bootstrap. */
@@ -419,29 +434,20 @@ export function PromptTimelineRows({
 
   return (
     <div className="ptr-root">
-      {/* ── Toolbar ── */}
+      {/* ── Toolbar (single tight strip) ── */}
       <div className="ptr-toolbar">
         <div className="ptr-toolbar-counts">
-          <span>{prompts.length} prompts</span>
-          <span aria-hidden> · </span>
-          <span>{groups.length} groups</span>
+          {prompts.length} prompts · {groups.length} groups
         </div>
-        <div className="hf-toggle-group">
-          <button
-            onClick={() => setCompactDiff(false)}
-            className={`hf-toggle-btn hf-toggle-btn-sm ${!compactDiff ? "hf-toggle-btn-active" : ""}`}
-            title="Diff shows the full prompt body with added/removed/same lines"
-          >
-            Full diff
-          </button>
-          <button
-            onClick={() => setCompactDiff(true)}
-            className={`hf-toggle-btn hf-toggle-btn-sm ${compactDiff ? "hf-toggle-btn-active" : ""}`}
-            title="Diff shows only added/removed lines with @@ separators"
-          >
-            Compact diff
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={() => setCompactDiff(!compactDiff)}
+          className="ptr-toolbar-toggle"
+          title={compactDiff ? "Switch to Full diff (show every line)" : "Switch to Compact diff (only added/removed)"}
+          aria-pressed={compactDiff}
+        >
+          <GitCompare size={11} /> {compactDiff ? "Compact" : "Full"}
+        </button>
       </div>
 
       {/* ── Groups ── */}
@@ -568,24 +574,6 @@ export function PromptTimelineRows({
                       </button>
                       {isDiffOpen && diff && (
                         <div className="ptr-diff-row-body">
-                          <div className="ptr-diff-body-toolbar">
-                            <div className="hf-toggle-group">
-                              <button
-                                onClick={(e) => { e.stopPropagation(); setCompactDiff(false); }}
-                                className={`hf-toggle-btn hf-toggle-btn-sm ${!compactDiff ? "hf-toggle-btn-active" : ""}`}
-                                title="Show every line (added / removed / same)"
-                              >
-                                Full
-                              </button>
-                              <button
-                                onClick={(e) => { e.stopPropagation(); setCompactDiff(true); }}
-                                className={`hf-toggle-btn hf-toggle-btn-sm ${compactDiff ? "hf-toggle-btn-active" : ""}`}
-                                title="Only added / removed lines with separators"
-                              >
-                                Compact
-                              </button>
-                            </div>
-                          </div>
                           <div className="ps-diff-block">
                             {!compactDiff && diff.map((line, i) => (
                               <div
@@ -636,7 +624,7 @@ export function PromptTimelineRows({
                       aria-expanded={isPromptOpen}
                       title={isPromptOpen ? "Hide prompt body" : "Show prompt body"}
                     >
-                      <FileText size={13} className="ptr-row-icon" />
+                      <TriggerIcon p={p} />
                       <span className="ptr-row-marker" title={isActive ? "Active — drives the next call" : "Superseded"}>
                         {isActive ? <Star size={14} className="ptr-star" /> : <Circle size={10} className="ptr-circle" />}
                       </span>

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -717,14 +717,33 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  background: var(--surface-secondary);
-  border-radius: 8px;
-  border: 1px solid var(--border-default);
+  padding: 4px 10px;
+  background: transparent;
+  border: none;
 }
 .ptr-toolbar-counts {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--text-muted);
+}
+.ptr-toolbar-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: inherit;
+}
+.ptr-toolbar-toggle:hover { background: var(--surface-secondary); color: var(--text-primary); }
+.ptr-toolbar-toggle[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent-primary) 30%, var(--border-default));
+  color: var(--accent-primary);
 }
 .ptr-group {
   display: flex;


### PR DESCRIPTION
Two UX polish items from feedback:

## 1. Diff toggle no longer takes a full strip
Was: `[Full diff] [Compact diff]` two-button group hogging a row.
Now: single pill button top-right of the timeline. Click toggles between Full and Compact, accent-primary tinted when Compact is active. The per-expanded-diff toolbar inside each diff body is **removed** — it was redundant with the global one and ate a row of vertical space.

## 2. Prompt rows now show a trigger-specific icon
Was: generic `FileText` on every prompt row.
Now: icon maps to triggerType, so the source is obvious at a glance:

| triggerType | icon |
|---|---|
| `post_call` / `pipeline` | 📞 Phone |
| `sim` | 🖥️ MonitorPlay |
| `tuner_fanout` | 🎚️ SlidersHorizontal |
| `enrollment` | ✨ Sparkles |
| `manual` | 👤 User |
| `scheduled` | 🕒 Clock |
| `analysis_complete` | ✓ CheckCircle2 |
| `preview_first_call` | 👁 Eye |

## Test plan
- [ ] Tune tab — toolbar at the very top is a single tight strip: counts on left, single pill button `Full | Compact` top-right
- [ ] Clicking the pill toggles between Full and Compact; pill highlights accent-primary when Compact is active
- [ ] No per-body Full/Compact toolbar inside expanded diff bodies anymore
- [ ] Each prompt row shows a different icon by triggerType (Phone for post_call, MonitorPlay for sim, etc.)
- [ ] Hover/active states still work on the prompt rows

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)