### PR TITLE
fix(#642): sticky toolbar — Compact/Full stays reachable while scrolling

### DIFF
--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -713,13 +713,21 @@
   flex-direction: column;
   gap: 20px;
 }
+/* Sticky — keeps the Compact/Full toggle (+ counts) reachable as the user
+   scrolls a long timeline. Stays anchored to the top of the viewport. */
 .ptr-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 4px 10px;
-  background: transparent;
-  border: none;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--surface-primary) 92%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  position: sticky;
+  top: 44px;
+  z-index: 5;
 }
 .ptr-toolbar-counts {
   font-size: 11px;


### PR DESCRIPTION
User feedback: 'compact/full button no good it scrolls off page'.

Made the toolbar `position: sticky` so it pins to the top of the viewport (`top: 44px` to clear the caller-detail tab bar) as the user scrolls. The Compact/Full toggle is now one click away regardless of scroll position. Added a subtle backdrop blur + 92% surface tint so it doesn't look gluey against the content scrolling beneath it.

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)