### PR TITLE
fix(#608-A): migration ALTER targets correct table name (BddFeature)

### DIFF
--- a/apps/admin/prisma/migrations/20260523_608a_analysis_spec_is_archetype/migration.sql
+++ b/apps/admin/prisma/migrations/20260523_608a_analysis_spec_is_archetype/migration.sql
@@ -5,6 +5,13 @@
 -- for the `extendsAgent` inheritance chain in `mergeIdentitySpec`) from
 -- runtime fallback IDENTITY specs.
 --
+-- IMPORTANT: the Prisma model `AnalysisSpec` is `@@map("BddFeature")` —
+-- the actual DB table is `BddFeature` (legacy name preserved during a
+-- prior rename, see schema.prisma comment at line 2512 + the @@map
+-- directive at line 2638). Always ALTER the underlying table, not the
+-- model alias. The field has no `@map` so the column name is
+-- `isArchetype` verbatim.
+--
 -- After this migration:
 --   - `seed-identity-archetypes.ts` sets `isArchetype = true` for all 5 archetypes.
 --   - The `systemSpecs` loader filters `isArchetype: false`, so archetypes
@@ -17,5 +24,5 @@
 -- Pure additive — no defaults that need backfill, no constraint changes.
 -- Existing rows get `isArchetype = false` via the column default; the seed
 -- script will flip the 5 archetype rows to `true` on next reseed.
-ALTER TABLE "AnalysisSpec"
+ALTER TABLE "BddFeature"
   ADD COLUMN "isArchetype" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
Hotfix on top of #671: my migration used `ALTER TABLE "AnalysisSpec"` but the Prisma model `AnalysisSpec` is `@@map("BddFeature")` — the actual DB table is `BddFeature` (legacy preserved). Confirmed by DEV deploy failure (`relation "AnalysisSpec" does not exist`); fixed to ALTER the underlying table. The loader filter + seed code paths from #671 are correct as-is — Prisma client translates `prisma.analysisSpec.*` calls automatically.

DEV state: failed migration was marked `--rolled-back` so the runner is unstuck. After this PR lands, re-running `npx prisma migrate deploy` will apply the corrected SQL.

Refs #608-A, fixes the deploy step from PR #671.