### PR TITLE
fix: callSequence stamping + Eval-as-row UI + colour cleanup

### DIFF
--- a/apps/admin/app/api/vapi/webhook/route.ts
+++ b/apps/admin/app/api/vapi/webhook/route.ts
@@ -137,6 +137,21 @@ async function handleEndOfCallReport(message: any) {
   // prompt configured. Persist what's present, leave the rest NULL.
   const capture = extractVapiCapture(message);
 
+  // Stamp callSequence (1, 2, 3...) so the prompt timeline can label this
+  // call as "Call N". Without it, the UI shows "—" or jumps. Mirrors the
+  // pattern in sim-runner.ts / onboarding-call/route.ts. Only meaningful
+  // when callerId is known — VAPI imports without a caller link don't get
+  // a sequence (the UI doesn't show them in a per-caller timeline anyway).
+  let nextSequence: number | null = null;
+  if (callerId) {
+    const lastCall = await prisma.call.findFirst({
+      where: { callerId },
+      orderBy: { callSequence: "desc" },
+      select: { callSequence: true },
+    });
+    nextSequence = (lastCall?.callSequence ?? 0) + 1;
+  }
+
   // Create the Call record
   const newCall = await prisma.call.create({
     data: {
@@ -146,6 +161,7 @@ async function handleEndOfCallReport(message: any) {
       callerId: callerId,
       usedPromptId: usedPromptId,
       ...(playbookId ? { playbookId } : {}),
+      ...(nextSequence != null ? { callSequence: nextSequence } : {}),
       ...capture,
     },
   });

--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -618,6 +618,15 @@ export function PromptTimelineRows({
     }
     return m;
   });
+  // Tracks when each eval was last run (ISO string from server). Used for the
+  // "Evaluated {time}" label on the eval row header.
+  const [evalAts, setEvalAts] = useState<Map<string, string>>(() => {
+    const m = new Map<string, string>();
+    for (const p of prompts) {
+      if (p.evalAt) m.set(p.id, p.evalAt);
+    }
+    return m;
+  });
   const [evalLoadingIds, setEvalLoadingIds] = useState<Set<string>>(new Set());
   const evalAbortRef = useRef<Map<string, AbortController>>(new Map());
 
@@ -646,6 +655,11 @@ export function PromptTimelineRows({
       setEvalResults((prev) => {
         const next = new Map(prev);
         next.set(promptId, data.eval);
+        return next;
+      });
+      setEvalAts((prev) => {
+        const next = new Map(prev);
+        next.set(promptId, new Date().toISOString());
         return next;
       });
       setExpandedEval((prev) => new Set(prev).add(promptId));
@@ -923,21 +937,24 @@ export function PromptTimelineRows({
                         </span>
                       )}
                       <span className="ptr-row-actions">
+                        {/* When an eval exists, the score is shown on the dedicated
+                            eval row below this prompt. The prompt-row button stays
+                            visible but quiets down — its job is just "re-run". */}
                         <button
                           type="button"
-                          className={`ptr-row-action${isEvalOpen ? " ptr-row-action--open" : ""}${ev ? " ptr-row-action--has-eval" : ""}`}
+                          className={`ptr-row-action${ev ? " ptr-row-action--has-eval" : ""}${ev ? ` ptr-row-action--verdict-${ev.overall.verdict}` : ""}`}
                           onClick={(e) => {
                             e.stopPropagation();
-                            if (ev) {
-                              toggle(expandedEval, setExpandedEval, p.id);
-                            } else if (!evLoading) {
-                              runEval(p.id);
-                            }
+                            if (!evLoading) runEval(p.id);
                           }}
                           disabled={evLoading}
-                          title={ev ? "Show / hide eval" : "Run quality evaluation"}
+                          title={ev ? `Re-evaluate (current score: ${Math.round((ev.overall.score || 0) * 100)}%)` : "Run quality evaluation"}
                         >
-                          {evLoading ? "evaluating…" : ev ? (isEvalOpen ? "▾ eval" : "▸ eval") : "eval"}
+                          {evLoading
+                            ? "evaluating…"
+                            : ev
+                              ? `${Math.round((ev.overall.score || 0) * 100)}% · re-eval`
+                              : "eval"}
                         </button>
                       </span>
                       {isPromptOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
@@ -970,48 +987,72 @@ export function PromptTimelineRows({
                       </div>
                     )}
 
-                    {/* Expanded — eval body */}
-                    {isEvalOpen && ev && (
-                      <div className="ptr-row-body">
-                        <div className="ptr-eval-summary">
-                          <span className="ptr-eval-score">{Math.round((ev.overall.score || 0) * 100)}%</span>
-                          <span className={`hf-micro-badge hf-uppercase ${ev.overall.verdict === "strong" ? "ps-status-badge-active" : "ps-status-badge-default"}`}>
-                            {ev.overall.verdict}
-                          </span>
-                          <span className="hf-text-sm hf-text-muted">{ev.overall.summary}</span>
-                        </div>
-                        <ul className="ptr-eval-dims">
-                          {ev.dimensions.map((d) => (
-                            <li key={d.name} className={`ptr-eval-dim ptr-eval-dim--${d.verdict}`}>
-                              <span className="ptr-eval-dim-name">{d.name}</span>
-                              <span className="ptr-eval-dim-score">{Math.round((d.score || 0) * 100)}%</span>
-                              <span className="ptr-eval-dim-verdict">{d.verdict}</span>
-                            </li>
-                          ))}
-                        </ul>
-                        {ev.topImprovements && ev.topImprovements.length > 0 && (
-                          <div className="ptr-eval-improvements">
-                            <div className="hf-text-xs hf-text-muted">Top improvements</div>
-                            <ul>
-                              {ev.topImprovements.map((imp) => (
-                                <li key={imp.priority}>
-                                  <strong>{imp.title}</strong> — {imp.description}
-                                  {imp.adminPath && (
-                                    <>
-                                      {" "}
-                                      <a className="ptr-eval-link" href={imp.adminPath}>
-                                        {imp.adminLabel || "Open"}
-                                      </a>
-                                    </>
-                                  )}
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        )}
-                      </div>
-                    )}
                   </div>
+
+                  {/* EVAL ROW — peer row directly under the prompt row when an
+                      eval has been run. Mirrors the diff-row pattern: head
+                      always visible (so the score reads at a glance), body
+                      expands on click. Use the verdict colour to anchor the row. */}
+                  {ev && (
+                    <div className={`ptr-eval-row ptr-eval-row--${ev.overall.verdict}${isEvalOpen ? " ptr-eval-row--open" : ""}`}>
+                      <button
+                        type="button"
+                        className="ptr-eval-row-head"
+                        onClick={() => toggle(expandedEval, setExpandedEval, p.id)}
+                        aria-expanded={isEvalOpen}
+                        title={isEvalOpen ? "Hide eval body" : "Show eval body"}
+                      >
+                        <BarChart2 size={12} className="ptr-eval-row-icon" />
+                        <span className="ptr-eval-row-label">Eval</span>
+                        <span className="ptr-eval-row-score">{Math.round((ev.overall.score || 0) * 100)}%</span>
+                        <span className={`hf-micro-badge hf-uppercase ptr-eval-row-verdict ptr-eval-row-verdict--${ev.overall.verdict}`}>
+                          {ev.overall.verdict}
+                        </span>
+                        <span className="ptr-eval-row-summary" title={ev.overall.summary}>
+                          {ev.overall.summary}
+                        </span>
+                        {evalAts.get(p.id) && (
+                          <span className="ptr-eval-row-time">
+                            Evaluated {formatDate(evalAts.get(p.id)!)}
+                          </span>
+                        )}
+                        {isEvalOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                      </button>
+                      {isEvalOpen && (
+                        <div className="ptr-eval-row-body">
+                          <ul className="ptr-eval-dims">
+                            {ev.dimensions.map((d) => (
+                              <li key={d.name} className={`ptr-eval-dim ptr-eval-dim--${d.verdict}`}>
+                                <span className="ptr-eval-dim-name">{d.name}</span>
+                                <span className="ptr-eval-dim-score">{Math.round((d.score || 0) * 100)}%</span>
+                                <span className="ptr-eval-dim-verdict">{d.verdict}</span>
+                              </li>
+                            ))}
+                          </ul>
+                          {ev.topImprovements && ev.topImprovements.length > 0 && (
+                            <div className="ptr-eval-improvements">
+                              <div className="hf-text-xs hf-text-muted">Top improvements</div>
+                              <ul>
+                                {ev.topImprovements.map((imp) => (
+                                  <li key={imp.priority}>
+                                    <strong>{imp.title}</strong> — {imp.description}
+                                    {imp.adminPath && (
+                                      <>
+                                        {" "}
+                                        <a className="ptr-eval-link" href={imp.adminPath}>
+                                          {imp.adminLabel || "Open"}
+                                        </a>
+                                      </>
+                                    )}
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/apps/admin/components/callers/caller-detail/calls-prompts-tab.css
+++ b/apps/admin/components/callers/caller-detail/calls-prompts-tab.css
@@ -32,15 +32,17 @@
   font-size: 12px;
   font-weight: 600;
   font-family: inherit;
-  border: 1px solid var(--border-default);
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 25%, var(--border-default));
   border-radius: 6px;
-  background: var(--surface-secondary);
-  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--accent-primary) 6%, var(--surface-primary));
+  color: color-mix(in srgb, var(--accent-primary) 70%, var(--text-secondary));
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 .cpt-toolbar-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--surface-secondary) 70%, var(--accent-primary) 30%);
+  background: color-mix(in srgb, var(--accent-primary) 14%, var(--surface-primary));
+  color: var(--accent-primary);
+  border-color: color-mix(in srgb, var(--accent-primary) 45%, var(--border-default));
 }
 .cpt-toolbar-btn:disabled {
   opacity: 0.5;

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -642,38 +642,44 @@
   background: var(--status-success-text);
 }
 
-/* #642 — triggerType badge colour map */
+/* #642 — triggerType badge colour map.
+   #661 follow-up: bump opacities + remap grey-on-grey badges to semantic
+   colours so the timeline reads at a glance instead of as a wall of grey.
+   - post_call: was muted grey, now blue (it's the canonical pipeline output)
+   - sim: was accent-primary 14% (clashed with manual), now purple
+   - preview: was placeholder grey, now warning (tentative = warm hint) */
 .ps-trigger-badge--default {
-  background: color-mix(in srgb, var(--text-muted) 14%, transparent);
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
   color: var(--text-muted);
 }
 .ps-trigger-badge--post-call {
-  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
-  color: var(--text-secondary, var(--text-muted));
+  background: var(--badge-blue-bg);
+  color: var(--badge-blue-text);
+  border: 1px solid color-mix(in srgb, var(--badge-blue-border) 60%, transparent);
 }
 .ps-trigger-badge--manual {
-  background: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--accent-primary) 30%, transparent);
   color: var(--accent-primary);
 }
 .ps-trigger-badge--tuner {
-  background: color-mix(in srgb, var(--status-warning-text) 18%, transparent);
+  background: color-mix(in srgb, var(--status-warning-text) 30%, transparent);
   color: var(--status-warning-text);
 }
 .ps-trigger-badge--analysis {
-  background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 18%, transparent);
+  background: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 30%, transparent);
   color: var(--accent-secondary, #7c6bc4);
 }
 .ps-trigger-badge--preview {
-  background: color-mix(in srgb, var(--text-placeholder) 18%, transparent);
-  color: var(--text-placeholder);
+  background: var(--badge-yellow-bg);
+  color: var(--badge-yellow-text);
 }
 .ps-trigger-badge--scheduled {
-  background: color-mix(in srgb, var(--status-success-text) 18%, transparent);
+  background: color-mix(in srgb, var(--status-success-text) 28%, transparent);
   color: var(--status-success-text);
 }
 .ps-trigger-badge--sim {
-  background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
-  color: var(--accent-primary);
+  background: var(--badge-purple-bg);
+  color: var(--badge-purple-text);
 }
 
 /* #642 — sibling indicator pill */
@@ -777,10 +783,14 @@
   border-left: 4px solid color-mix(in srgb, var(--accent-primary) 70%, #000);
   box-shadow: 0 1px 2px color-mix(in srgb, var(--accent-primary) 24%, transparent);
 }
+/* #661 follow-up: was var(--text-muted) — looked like a disabled call group.
+   Switched to accent-secondary (purple) so sim / tuner_fanout / enrollment
+   groups visually distinguish from blue call-group headers, mirroring the
+   CALL DIFF row tint. */
 .ptr-group-header--standalone {
-  background: var(--text-muted);
-  border-left-color: color-mix(in srgb, var(--text-muted) 70%, #000);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--text-muted) 20%, transparent);
+  background: var(--accent-secondary, #7c6bc4);
+  border-left-color: color-mix(in srgb, var(--accent-secondary, #7c6bc4) 70%, #000);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--accent-secondary, #7c6bc4) 24%, transparent);
   color: var(--surface-primary, #fff);
 }
 .ptr-group-header-icon {
@@ -1182,14 +1192,132 @@
   color: var(--accent-primary);
   border-color: color-mix(in srgb, var(--accent-primary) 30%, transparent);
 }
-.ptr-row-action--has-eval::before {
-  content: "★";
-  margin-right: 2px;
+/* Has-eval button — colour follows verdict so the prompt-row pill reads
+   as a status indicator at a glance, not just "an action with a star". */
+.ptr-row-action--has-eval {
+  font-weight: 600;
+}
+.ptr-row-action--verdict-strong {
+  background: color-mix(in srgb, var(--status-success-text) 14%, transparent);
   color: var(--status-success-text);
+  border-color: color-mix(in srgb, var(--status-success-text) 40%, transparent);
+}
+.ptr-row-action--verdict-strong:hover {
+  background: color-mix(in srgb, var(--status-success-text) 22%, transparent);
+  color: var(--status-success-text);
+}
+.ptr-row-action--verdict-adequate {
+  background: color-mix(in srgb, var(--status-warning-text) 14%, transparent);
+  color: var(--status-warning-text);
+  border-color: color-mix(in srgb, var(--status-warning-text) 40%, transparent);
+}
+.ptr-row-action--verdict-adequate:hover {
+  background: color-mix(in srgb, var(--status-warning-text) 22%, transparent);
+  color: var(--status-warning-text);
+}
+.ptr-row-action--verdict-weak {
+  background: color-mix(in srgb, var(--status-error-text) 14%, transparent);
+  color: var(--status-error-text);
+  border-color: color-mix(in srgb, var(--status-error-text) 40%, transparent);
+}
+.ptr-row-action--verdict-weak:hover {
+  background: color-mix(in srgb, var(--status-error-text) 22%, transparent);
+  color: var(--status-error-text);
 }
 .ptr-row-action:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+/* ── Eval peer row (#661 follow-up) ───────────────────────────────────
+   Sits directly under the prompt row when an eval exists. Score + verdict
+   are always visible; body expands on click. Colour follows verdict. */
+.ptr-eval-row {
+  margin: 2px 0 6px 0;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.ptr-eval-row--strong {
+  border-left: 3px solid var(--status-success-text);
+  background: color-mix(in srgb, var(--status-success-bg) 60%, var(--surface-primary));
+}
+.ptr-eval-row--adequate {
+  border-left: 3px solid var(--status-warning-text);
+  background: color-mix(in srgb, var(--status-warning-bg) 60%, var(--surface-primary));
+}
+.ptr-eval-row--weak {
+  border-left: 3px solid var(--status-error-text);
+  background: color-mix(in srgb, var(--status-error-bg) 60%, var(--surface-primary));
+}
+.ptr-eval-row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+.ptr-eval-row-head:hover {
+  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+}
+.ptr-eval-row-icon {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+.ptr-eval-row-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.ptr-eval-row-score {
+  font-family: ui-monospace, monospace;
+  font-size: 14px;
+  font-weight: 700;
+}
+.ptr-eval-row--strong .ptr-eval-row-score { color: var(--status-success-text); }
+.ptr-eval-row--adequate .ptr-eval-row-score { color: var(--status-warning-text); }
+.ptr-eval-row--weak .ptr-eval-row-score { color: var(--status-error-text); }
+.ptr-eval-row-verdict--strong {
+  background: var(--status-success-bg);
+  color: var(--status-success-text);
+}
+.ptr-eval-row-verdict--adequate {
+  background: var(--status-warning-bg);
+  color: var(--status-warning-text);
+}
+.ptr-eval-row-verdict--weak {
+  background: var(--status-error-bg);
+  color: var(--status-error-text);
+}
+.ptr-eval-row-summary {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ptr-eval-row-time {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.ptr-eval-row-body {
+  padding: 8px 14px 12px 14px;
+  border-top: 1px solid var(--border-default);
+  background: var(--surface-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 .ptr-row-body {
   padding: 8px 16px 14px 16px;

--- a/apps/admin/lib/ops/transcripts-process.ts
+++ b/apps/admin/lib/ops/transcripts-process.ts
@@ -384,6 +384,19 @@ async function processFile(
         // Tolerates null — VAPI imports can legitimately predate enrollment.
         const importedPlaybookId = callerId ? await resolvePlaybookId(callerId) : null;
 
+        // Stamp callSequence (1, 2, 3...) so the prompt timeline can label
+        // this call as "Call N". Mirrors sim-runner.ts / vapi/webhook.
+        // Only meaningful when callerId is known.
+        let importedSequence: number | null = null;
+        if (callerId) {
+          const lastCall = await prisma.call.findFirst({
+            where: { callerId },
+            orderBy: { callSequence: "desc" },
+            select: { callSequence: true },
+          });
+          importedSequence = (lastCall?.callSequence ?? 0) + 1;
+        }
+
         // Create Call record
         await prisma.call.create({
           data: {
@@ -392,6 +405,7 @@ async function processFile(
             transcript,
             callerId: callerId || null,
             ...(importedPlaybookId ? { playbookId: importedPlaybookId } : {}),
+            ...(importedSequence != null ? { callSequence: importedSequence } : {}),
           }
         });
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.329",
+  "version": "0.7.330",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/scripts/backfill-call-sequence.ts
+++ b/apps/admin/scripts/backfill-call-sequence.ts
@@ -1,0 +1,119 @@
+/**
+ * Backfill Call.callSequence for rows where it is NULL.
+ *
+ * Background: VAPI webhook and the bulk transcripts-process path were not
+ * stamping callSequence at create time, so many historic Call rows have it
+ * null. The prompt timeline renders "Call N" from callSequence — null rows
+ * show as "—" or shuffle.
+ *
+ * Fix: for every callerId with at least one null callSequence, sort their
+ * calls by createdAt and assign 1..N in chronological order. Existing
+ * non-null sequences win — if some calls are already numbered, the
+ * untouched ones are folded in around them by createdAt order, taking
+ * the next free integer.
+ *
+ * Idempotent: re-running after a clean backfill is a no-op (everyone
+ * has a sequence already).
+ *
+ * Run on VM:
+ *   npx tsx scripts/backfill-call-sequence.ts            (dry-run, default)
+ *   npx tsx scripts/backfill-call-sequence.ts --execute  (apply changes)
+ */
+
+import { prisma } from "@/lib/prisma";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const execute = args.includes("--execute");
+  const dryRun = !execute;
+
+  console.log(
+    `\n=== Backfill Call.callSequence ===\n` +
+    `  mode: ${dryRun ? "DRY-RUN (pass --execute to apply)" : "EXECUTE"}\n`,
+  );
+
+  const totalNull = await prisma.call.count({
+    where: { callSequence: null, callerId: { not: null } },
+  });
+  console.log(`  calls with null callSequence + callerId: ${totalNull}`);
+
+  if (totalNull === 0) {
+    console.log("\nNothing to do.\n");
+    return;
+  }
+
+  // Find every caller that has at least one null-callSequence call. We
+  // re-sequence ALL of that caller's calls (not just the null ones) so the
+  // numbering stays monotonic in createdAt order.
+  const affected = await prisma.call.findMany({
+    where: { callSequence: null, callerId: { not: null } },
+    select: { callerId: true },
+    distinct: ["callerId"],
+  });
+  const callerIds = affected.map((c) => c.callerId!).filter((id): id is string => Boolean(id));
+  console.log(`  affected callers: ${callerIds.length}\n`);
+
+  let totalUpdated = 0;
+  let totalSkipped = 0;
+  let callersProcessed = 0;
+
+  for (const callerId of callerIds) {
+    const calls = await prisma.call.findMany({
+      where: { callerId },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      select: { id: true, callSequence: true, createdAt: true },
+    });
+
+    // Walk in chronological order. For each call, assign the next free
+    // integer. If a call already has a sequence, keep it and skip; the
+    // counter advances to one above its value to avoid collisions.
+    let counter = 0;
+    const updates: Array<{ id: string; seq: number }> = [];
+    for (const call of calls) {
+      if (call.callSequence != null) {
+        counter = Math.max(counter, call.callSequence);
+        continue;
+      }
+      counter += 1;
+      updates.push({ id: call.id, seq: counter });
+    }
+
+    if (updates.length === 0) {
+      totalSkipped += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`  caller ${callerId}: would update ${updates.length} call(s)`);
+    } else {
+      // Sequential update — small N per caller, no need for batch.
+      for (const u of updates) {
+        await prisma.call.update({
+          where: { id: u.id },
+          data: { callSequence: u.seq },
+        });
+      }
+      console.log(`  caller ${callerId}: updated ${updates.length} call(s)`);
+    }
+    totalUpdated += updates.length;
+    callersProcessed += 1;
+  }
+
+  console.log(
+    `\n=== ${dryRun ? "Dry-run" : "Done"} ===\n` +
+    `  callers processed: ${callersProcessed}\n` +
+    `  callers already complete: ${totalSkipped}\n` +
+    `  total updates ${dryRun ? "needed" : "applied"}: ${totalUpdated}\n`,
+  );
+
+  if (dryRun) {
+    console.log(`Run again with --execute to apply.\n`);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Follow-ups surfaced reviewing the #661 Tuning tab work on a real caller page (\`/x/callers/7a9562fa-...?tab=ai-call\`).

**1. Call.callSequence wasn't stamped on every Call.create path.** VAPI webhook and bulk transcripts-process both omitted it. The prompt timeline labels groups "Call N" from that field, so affected callers showed \`—\` or jumped numbers. Both paths now stamp \`nextSequence = (lastCall?.callSequence ?? 0) + 1\` matching sim-runner. New idempotent backfill script (\`scripts/backfill-call-sequence.ts\`) re-sequences historic null rows in chronological order.

**2. Eval results were persisted but invisible.** \`ComposedPrompt.evalResult\` + \`evalAt\` were already written on every \`/eval-prompt\` call, but the UI only added a tiny ★ to the eval button — score/verdict/timestamp lived inside an expand-on-click body. Hoisted the eval display into a peer row directly under each prompt row (mirrors the existing diff-row pattern). Score + verdict + "Evaluated {time}" always visible; body expands for dimensions/improvements. Eval-button on the prompt row now tinted by verdict (strong=green, adequate=amber, weak=red) with the score inline.

**3. Colour cleanup on Calls & Prompts** (drive-by per #661 review — "very grey"):
- Trigger badges remapped: post_call → blue, sim → purple, preview → yellow. Opacities 14-18% → 28-30%.
- Standalone group header: muted grey → accent-secondary.
- Toolbar buttons: faint accent-primary tint instead of pure surface-secondary.

All colours use design-system CSS vars and \`color-mix()\` — no hex.

## Test plan

- [ ] On \`/x/callers/{id}?tab=ai-call\`, every group reads "Call N · …", no "—" gaps (after backfill runs)
- [ ] New VAPI webhook calls land with \`callSequence\` set (DB check: \`SELECT callSequence FROM "Call" WHERE source = 'vapi' ORDER BY createdAt DESC LIMIT 5\`)
- [ ] Run \`npx tsx scripts/backfill-call-sequence.ts\` (dry-run) → reports counts; run with \`--execute\` → null rows get sequences
- [ ] Re-run the backfill — reports 0 updates needed (idempotent)
- [ ] Open a prompt with no eval → button says \`eval\`, neutral colour
- [ ] Click \`eval\` → button tints by verdict, peer row appears below with score + verdict + "Evaluated just now"
- [ ] Click the peer row head → body expands showing dimensions + improvements
- [ ] Click \`re-eval\` on the prompt row → eval re-runs, timestamp updates
- [ ] Trigger badges: post_call calls clearly blue, sim purple, manual/tuner distinct from each other
- [ ] Standalone group headers (sim / tuner_fanout) now purple, not grey

## Deploy

\`/vm-cp\` — no schema migration. Backfill script is opt-in (run on the VM after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)