### PR TITLE
fix: prompt 'Call N' was capped at 6 (recentCallsLimit)

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -902,7 +902,15 @@ export async function computeSharedState(
   // hoisted above moduleToReview (see #554 Fix 2). Reused here for
   // isFinalSession + returned shared state.
 
-  const callNumber = data.recentCalls.length + 1; // 1-based: this is the Nth call
+  // 1-based: this is the Nth call about to be composed.
+  //
+  // Must use `data.callCount` (full count from the loader), NOT
+  // `data.recentCalls.length` — the latter is CAPPED at `recentCallsLimit`
+  // (default 5). Anyone past their 5th call previously got the wrong number
+  // baked into the prompt body (quickstart.ts:651 "This is call X — the final
+  // session") AND wrong session-specific rules selected by
+  // course-instructions / pedagogy session-range matching.
+  const callNumber = data.callCount + 1;
   const isFinalByBudget = !!(sessionCount && sessionCount > 0 && callNumber >= sessionCount);
   const isFinalByScheduler = schedulerTotalLOs > 0 && schedulerTotalMastered >= schedulerTotalLOs;
   const isFinalByModules = modules.length > 0 && completedModules.size >= modules.length;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.330",
+  "version": "0.7.331",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary

Follow-up to the callSequence work — found a related bug while looking for "Call N" surfaces in the prompt.

`callNumber` inside the composer (used to write "This is call X — the final session" into the prompt body, and to pick session-specific course instructions / pedagogy rules) was derived from \`data.recentCalls.length + 1\`. \`recentCalls\` is capped at \`recentCallsLimit\` (default 5), so anyone past their 5th call got the wrong session number in the prompt and the wrong session-specific rules selected.

Fixed by using \`data.callCount\` instead. Same data source, just not capped. Equivalent at ≤5 calls; correct at >5.

## What was unaffected

The user-facing "Call #N with this caller" at the top of the rendered prompt (\`renderPromptSummary.ts:243, 821\`) reads \`callHistory.totalCalls\` which was already built from \`callCount\` (\`simple.ts:33\`). That line was always correct — the bug was deeper, in the session-specific behavioural rules.

## Test plan

- [ ] Compose a prompt for a caller with ≥6 completed calls (\`endedAt != null\`) → log/header in the prompt body shows the correct call number, not 6
- [ ] A course with session_override rules ("session 7" or "calls 6-10") fires correctly for the affected calls
- [ ] No regression for callers with ≤5 calls

## Deploy

\`/vm-cp\` — no schema, no script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)