### PR TITLE
fix: Call.endedAt stamping + Goals toggle data-staleness

### DIFF
--- a/apps/admin/app/api/vapi/webhook/route.ts
+++ b/apps/admin/app/api/vapi/webhook/route.ts
@@ -152,6 +152,13 @@ async function handleEndOfCallReport(message: any) {
     nextSequence = (lastCall?.callSequence ?? 0) + 1;
   }
 
+  // Stamp endedAt — `end-of-call-report` means the call has just ended,
+  // so this is the canonical end time. Without it, the composer's
+  // recentCalls / callCount loaders (filter: endedAt != null) silently
+  // exclude every VAPI call, leaving `callNumber` stuck at 1 and session-
+  // specific rules never advancing. Equivalent to `createdAt` for VAPI.
+  const endedAt = new Date();
+
   // Create the Call record
   const newCall = await prisma.call.create({
     data: {
@@ -160,6 +167,7 @@ async function handleEndOfCallReport(message: any) {
       transcript: transcript || "(no transcript)",
       callerId: callerId,
       usedPromptId: usedPromptId,
+      endedAt,
       ...(playbookId ? { playbookId } : {}),
       ...(nextSequence != null ? { callSequence: nextSequence } : {}),
       ...capture,

--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -120,33 +120,53 @@ export function CourseDesignTab({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [activeState, setActiveState] = useState<FlowState>('WELCOME');
 
-  // Load config from playbook — prefer canonical sessionFlow.intake, fall back
-  // to legacy `welcome` shape (matches resolveSessionFlow precedence).
+  // Load config via GET /api/courses/[courseId]/session-flow — the same
+  // resolved endpoint SessionFlowEditor uses. Reading the page-level
+  // `playbookConfig` prop directly causes drift: SessionFlowEditor saves
+  // an intake change → server updates → SessionFlowEditor re-fetches
+  // fresh, but the page's `detail.config` (passed down here) stays at
+  // the value loaded on mount. The two tabs then disagree until the
+  // page is reloaded. Single shared GET keeps both tabs honest.
   useEffect(() => {
-    if (!playbookConfig) return;
-    const sf = (playbookConfig.sessionFlow as { intake?: Partial<IntakeConfig> } | undefined);
-    if (sf?.intake) {
-      setIntake({ ...DEFAULT_INTAKE_CONFIG, ...sf.intake } as IntakeConfig);
-    } else if (playbookConfig.welcome) {
-      const w = playbookConfig.welcome as {
-        goals?: { enabled?: boolean };
-        aboutYou?: { enabled?: boolean };
-        knowledgeCheck?: { enabled?: boolean };
-        aiIntroCall?: { enabled?: boolean };
-      };
-      setIntake({
-        goals: { enabled: w.goals?.enabled ?? DEFAULT_INTAKE_CONFIG.goals.enabled },
-        aboutYou: { enabled: w.aboutYou?.enabled ?? DEFAULT_INTAKE_CONFIG.aboutYou.enabled },
-        knowledgeCheck: {
-          enabled: w.knowledgeCheck?.enabled ?? DEFAULT_INTAKE_CONFIG.knowledgeCheck.enabled,
-          deliveryMode: DEFAULT_INTAKE_CONFIG.knowledgeCheck.deliveryMode,
-        },
-        aiIntroCall: { enabled: w.aiIntroCall?.enabled ?? DEFAULT_INTAKE_CONFIG.aiIntroCall.enabled },
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/session-flow`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled || !data?.ok || !data.sessionFlow?.intake) return;
+        setIntake({ ...DEFAULT_INTAKE_CONFIG, ...data.sessionFlow.intake });
+      })
+      .catch(() => {
+        // Soft fall back to the page's playbookConfig prop if the API
+        // call fails — better to show stale data than nothing.
+        if (cancelled || !playbookConfig) return;
+        const sf = (playbookConfig.sessionFlow as { intake?: Partial<IntakeConfig> } | undefined);
+        if (sf?.intake) {
+          setIntake({ ...DEFAULT_INTAKE_CONFIG, ...sf.intake } as IntakeConfig);
+        } else if (playbookConfig.welcome) {
+          const w = playbookConfig.welcome as {
+            goals?: { enabled?: boolean };
+            aboutYou?: { enabled?: boolean };
+            knowledgeCheck?: { enabled?: boolean };
+            aiIntroCall?: { enabled?: boolean };
+          };
+          setIntake({
+            goals: { enabled: w.goals?.enabled ?? DEFAULT_INTAKE_CONFIG.goals.enabled },
+            aboutYou: { enabled: w.aboutYou?.enabled ?? DEFAULT_INTAKE_CONFIG.aboutYou.enabled },
+            knowledgeCheck: {
+              enabled: w.knowledgeCheck?.enabled ?? DEFAULT_INTAKE_CONFIG.knowledgeCheck.enabled,
+              deliveryMode: DEFAULT_INTAKE_CONFIG.knowledgeCheck.deliveryMode,
+            },
+            aiIntroCall: { enabled: w.aiIntroCall?.enabled ?? DEFAULT_INTAKE_CONFIG.aiIntroCall.enabled },
+          });
+        }
       });
-    }
-    if (playbookConfig.nps) {
-      setNps({ ...DEFAULT_NPS_CONFIG, ...(playbookConfig.nps as Partial<NpsConfig>) });
-    }
+    return () => { cancelled = true; };
+  }, [courseId, playbookConfig]);
+
+  // NPS comes from the same playbookConfig (no session-flow API surface yet).
+  useEffect(() => {
+    if (!playbookConfig?.nps) return;
+    setNps({ ...DEFAULT_NPS_CONFIG, ...(playbookConfig.nps as Partial<NpsConfig>) });
   }, [playbookConfig]);
 
   // Persist via the session-flow route. That route writes both

--- a/apps/admin/lib/ops/transcripts-process.ts
+++ b/apps/admin/lib/ops/transcripts-process.ts
@@ -397,13 +397,16 @@ async function processFile(
           importedSequence = (lastCall?.callSequence ?? 0) + 1;
         }
 
-        // Create Call record
+        // Create Call record. `endedAt` set to now: this is a bulk import
+        // of historical completed calls, so the composer must include them
+        // in callCount / recentCalls (filter: endedAt != null).
         await prisma.call.create({
           data: {
             source: "VAPI",
             externalId: externalId || null,
             transcript,
             callerId: callerId || null,
+            endedAt: new Date(),
             ...(importedPlaybookId ? { playbookId: importedPlaybookId } : {}),
             ...(importedSequence != null ? { callSequence: importedSequence } : {}),
           }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.331",
+  "version": "0.7.332",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/scripts/backfill-call-endedat.ts
+++ b/apps/admin/scripts/backfill-call-endedat.ts
@@ -1,0 +1,91 @@
+/**
+ * Backfill Call.endedAt for completed historical rows where it is NULL.
+ *
+ * Background: the VAPI webhook (`end-of-call-report`) and the bulk
+ * transcripts-process path were not stamping `endedAt` at create time. The
+ * composer's loaders (`callCount` + `recentCalls`) filter `endedAt: { not: null }`,
+ * so every real VAPI call silently dropped out — leaving `callNumber` stuck
+ * at 1 forever for those learners.
+ *
+ * Fix: for every Call with `endedAt IS NULL` AND a non-empty transcript
+ * (i.e. a call that actually happened, not a pre-call placeholder), set
+ * `endedAt = createdAt`. Onboarding-call placeholder rows (created BEFORE
+ * the conversation, empty transcript) are correctly skipped.
+ *
+ * Idempotent: re-running after a clean backfill is a no-op.
+ *
+ * Run on VM:
+ *   npx tsx scripts/backfill-call-endedat.ts            (dry-run, default)
+ *   npx tsx scripts/backfill-call-endedat.ts --execute  (apply changes)
+ */
+
+import { prisma } from "@/lib/prisma";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const execute = args.includes("--execute");
+  const dryRun = !execute;
+
+  console.log(
+    `\n=== Backfill Call.endedAt ===\n` +
+    `  mode: ${dryRun ? "DRY-RUN (pass --execute to apply)" : "EXECUTE"}\n`,
+  );
+
+  // Filter: endedAt is null AND transcript is meaningful. "(no transcript)"
+  // is the VAPI webhook placeholder when nothing was captured — those rows
+  // represent a real call that completed but with no audio/text, so they
+  // should still get endedAt. Empty string is the onboarding-call
+  // placeholder (created BEFORE the call) — skip those.
+  const totalNull = await prisma.call.count({
+    where: {
+      endedAt: null,
+      transcript: { not: "" },
+    },
+  });
+  console.log(`  calls with null endedAt + non-empty transcript: ${totalNull}`);
+
+  if (totalNull === 0) {
+    console.log("\nNothing to do.\n");
+    return;
+  }
+
+  // Sample the affected rows for transparency.
+  const sample = await prisma.call.findMany({
+    where: { endedAt: null, transcript: { not: "" } },
+    select: { id: true, source: true, createdAt: true, callerId: true },
+    orderBy: { createdAt: "asc" },
+    take: 5,
+  });
+  console.log(`  sample (first 5):`);
+  for (const c of sample) {
+    console.log(
+      `    ${c.id.slice(0, 8)}…  source=${c.source}  created=${c.createdAt.toISOString()}  caller=${c.callerId?.slice(0, 8) ?? "(none)"}`,
+    );
+  }
+
+  if (dryRun) {
+    console.log(`\nWould set endedAt = createdAt on ${totalNull} call(s).\n`);
+    console.log(`Run again with --execute to apply.\n`);
+    return;
+  }
+
+  // Apply in a single raw UPDATE — much faster than per-row update for
+  // potentially thousands of historical rows. The condition mirrors the
+  // count above. Onboarding-call placeholders (empty transcript) are
+  // untouched.
+  const updated = await prisma.$executeRaw`
+    UPDATE "Call"
+    SET    "endedAt" = "createdAt"
+    WHERE  "endedAt" IS NULL
+      AND  "transcript" != ''
+  `;
+
+  console.log(`\n=== Done ===\n  rows updated: ${updated}\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Two follow-ups from the prompt-number investigation.

### 1. \`Call.endedAt\` was never set by VAPI webhook or bulk import

The composer's loaders filter \`endedAt: { not: null }\` to count completed calls. VAPI webhook (\`end-of-call-report\`) and \`lib/ops/transcripts-process\` didn't stamp \`endedAt\`, so:

- \`callCount\` returned 0 for every real VAPI learner
- \`recentCalls\` was empty for every real VAPI learner
- \`callNumber\` stuck at 1 → "This is call 1" forever in the prompt body
- Session-specific rules (course-instructions, session_override) never advanced

Fixed by stamping \`endedAt: new Date()\` at create time in both paths. For VAPI the webhook fires AT end-of-call, so \`endedAt ≈ createdAt\` is correct. Onboarding-call placeholders (created BEFORE the call, empty transcript) intentionally still get null \`endedAt\` — they're not "completed" yet.

New backfill script \`scripts/backfill-call-endedat.ts\` updates historic rows in a single \`UPDATE\`. Filtered on non-empty transcript so onboarding placeholders are correctly skipped. Idempotent.

### 2. Goals / About You toggles disagreed between two Course tabs

Two surfaces edit the same \`sessionFlow.intake\` data:
- **Session Flow tab** (\`SessionFlowEditor\`) fetches \`/api/courses/{id}/session-flow\` on mount and re-fetches after every save
- **Welcome Flow Phases** (\`CourseDesignTab\`) read the \`playbookConfig\` prop from the parent page — loaded once at page mount, never refreshed

Result: the two tabs diverged after the first edit. Defaults of \`goals.enabled = true\` + \`aboutYou.enabled = true\` made the staleness visible specifically on those two toggles, while \`knowledgeCheck\`/\`aiIntroCall\` (defaults: false) coincidentally agreed.

Fix: \`CourseDesignTab\` now fetches from the same session-flow GET endpoint \`SessionFlowEditor\` uses. Soft fallback to \`playbookConfig\` prop if the API call fails.

## Test plan

- [ ] On hf-dev, run \`npx tsx scripts/backfill-call-endedat.ts\` (dry-run) → reports the count
- [ ] Run with \`--execute\` → updates apply, second run reports 0 (idempotent)
- [ ] Trigger a sim/real call → new Call row has \`endedAt\` set
- [ ] On a caller with ≥2 calls, open Session Flow tab + Welcome Flow Phases tab → both show identical Goals/About You toggle states
- [ ] Toggle Goals OFF in Session Flow tab → switch to Welcome Flow Phases → also reads OFF (no stale data)
- [ ] Toggle Goals back ON in Welcome Flow Phases → switch to Session Flow → reads ON
- [ ] Prompt body for a learner past their 5th VAPI call now reads "This is call N" (not 1)

## Deploy

\`/vm-cp\` — no schema, but run the backfill on the VM after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)