### PR TITLE
fix(#605): widen audit to catch any non-tutor_instruction teachMethod

### DIFF
--- a/apps/admin/scripts/audit-epic-100.ts
+++ b/apps/admin/scripts/audit-epic-100.ts
@@ -117,14 +117,14 @@ const counters: CounterDefinition[] = [
     },
   },
 
-  /* #605 — recall_quiz auto-tagged on tutor-instruction assertions */
+  /* #605 — any learner-facing teachMethod on tutor-instruction assertions */
   {
     key: "recallQuizOnInstructionCategories",
     story: "#605",
     kind: "invariant",
     target: 0,
     description:
-      "ContentAssertion rows whose category is an INSTRUCTION_CATEGORY but whose teachMethod is 'recall_quiz' (should be 'tutor_instruction').",
+      "ContentAssertion rows whose category is an INSTRUCTION_CATEGORY but whose teachMethod is NOT 'tutor_instruction' (includes null and any learner-facing method like 'recall_quiz' / 'guided_discussion' / etc.).",
     query: async () => {
       // Imported from lib/content-trust/resolve-config so this counter cannot
       // drift from the canonical INSTRUCTION_CATEGORIES list. Pre-#605 this
@@ -132,13 +132,34 @@ const counters: CounterDefinition[] = [
       // ("tutor_briefing", "tutor_instruction", "tutor_note") — values that
       // never appeared in any ContentAssertion.category, so the counter
       // silently read 0 even while real INSTRUCTION_CATEGORIES rows were
-      // mis-tagged recall_quiz.
-      return prisma.contentAssertion.count({
-        where: {
-          category: { in: [...INSTRUCTION_CATEGORIES] },
-          teachMethod: "recall_quiz",
-        },
-      });
+      // mis-tagged.
+      //
+      // #605 follow-on (2026-05-23): the original query only matched
+      // `teachMethod = "recall_quiz"`. The IELTS V1.0 wizard run on
+      // 2026-05-23 surfaced 53 INSTRUCTION_CATEGORIES rows tagged
+      // `guided_discussion` from legacy QUESTION_BANK sources — same
+      // problem class (learner-facing method on a tutor-instruction
+      // category) but a different value. The narrow counter reported 0
+      // while real violations sat there. Widened to "anything that isn't
+      // tutor_instruction" — matches what the runtime guard
+      // `assertNoLearnerMethodOnInstructionCategory()` catches at
+      // extraction boundaries. NULL is treated as a violation too (it
+      // means the row was never run through the guard, e.g. legacy
+      // assertions extracted before #605 shipped) so the backfill script
+      // (`scripts/backfill-teach-methods.ts` pass 2) drains it on the
+      // next run.
+      //
+      // Counter key preserved (`recallQuizOnInstructionCategories`) for
+      // back-compat with the baseline JSON fixture and prior digests;
+      // the description above is the source of truth for what it
+      // measures now.
+      const rows = await prisma.$queryRaw<Array<{ count: bigint }>>`
+        SELECT COUNT(*)::bigint AS count
+        FROM "ContentAssertion"
+        WHERE category = ANY(${[...INSTRUCTION_CATEGORIES]}::text[])
+          AND ("teachMethod" IS NULL OR "teachMethod" != 'tutor_instruction')
+      `;
+      return Number(rows[0]?.count ?? 0);
     },
   },
 

--- a/apps/admin/tests/fixtures/epic-100-audit-baseline.json
+++ b/apps/admin/tests/fixtures/epic-100-audit-baseline.json
@@ -15,10 +15,10 @@
       "key": "recallQuizOnInstructionCategories",
       "story": "#605",
       "kind": "invariant",
-      "count": 0,
+      "count": 88,
       "target": 0,
-      "status": "pass",
-      "description": "ContentAssertion rows whose category is an INSTRUCTION_CATEGORY but whose teachMethod is 'recall_quiz' (should be 'tutor_instruction')."
+      "status": "fail",
+      "description": "ContentAssertion rows whose category is an INSTRUCTION_CATEGORY but whose teachMethod is NOT 'tutor_instruction' (includes null and any learner-facing method like 'recall_quiz' / 'guided_discussion' / etc.). Widened from the narrow recall_quiz-only query on 2026-05-23 after a wizard run surfaced 53 guided_discussion violations on legacy QUESTION_BANK sources. Drains via `scripts/backfill-teach-methods.ts` pass 2; re-snap this baseline after running --apply on DEV."
     },
     {
       "key": "tutorOnlyQuestionsLeakSurface",


### PR DESCRIPTION
Audit-only fix. The #605 runtime guard is still working correctly — this PR widens the **audit counter** to honestly report violations.

## Caught live on 2026-05-23

A wizard run for IELTS V1.0 surfaced 53 INSTRUCTION_CATEGORIES rows tagged `guided_discussion` (from legacy QUESTION_BANK sources extracted on 2026-05-22, before #605 shipped). The narrow audit query only matched `teachMethod = "recall_quiz"` and reported `0`. Hole in the audit, not in the guard.

## Fix

Widen the query from `teachMethod = 'recall_quiz'` to `teachMethod IS NULL OR teachMethod != 'tutor_instruction'`. Matches what the runtime guard `assertNoLearnerMethodOnInstructionCategory()` catches at every extraction boundary. NULL is treated as a violation because it means the row never went through the guard (e.g. pre-#605 legacy).

## Verified on DEV

| Query | Count on DEV |
|---|---|
| Old narrow (`recall_quiz` only) | 0 |
| **New wide (any non-`tutor_instruction`)** | **88** (53 from today's IELTS V1.0 + ~35 historical from other courses) |

Counter key preserved (`recallQuizOnInstructionCategories`) for baseline-JSON back-compat; the description is now the source of truth.

## Baseline JSON

Updated to honest `count: 88, status: fail` with a re-snap instruction. After the next `scripts/backfill-teach-methods.ts --apply` on each env, re-snap the baseline.

## Drain

Existing data: `npx tsx apps/admin/scripts/backfill-teach-methods.ts --apply` (pass 2 already covers this shape — it uses `NOT: { teachMethod: "tutor_instruction" }`).

## Test plan

- [x] Verified on DEV — widened query catches 88 violations the narrow one missed
- [ ] CI checks
- [ ] Post-merge: backfill `--apply` on DEV → audit re-runs at 0 → re-snap baseline

Refs #600 (Epic 100), #605.