### PR TITLE
fix(compose): tighten loadComposeConfig spec lookup to prevent archetype leak

### DIFF
--- a/apps/admin/lib/config.ts
+++ b/apps/admin/lib/config.ts
@@ -278,12 +278,22 @@ export const config = {
     },
 
     /**
-     * Compose Spec slug (default: system-compose-next-prompt)
-     * The COMPOSE spec that drives prompt composition.
-     * Can be overridden via COMPOSE_SPEC_SLUG env var.
+     * Compose Spec slug (default: spec-comp-001)
+     * The COMPOSE spec that drives prompt composition. Identifies the
+     * `AnalysisSpec` row whose `config` carries the section list,
+     * thresholds, memory caps, etc. for `executeComposition()`.
+     *
+     * Default updated 2026-05-23 — previous default
+     * "system-compose-next-prompt" had no DB row, causing
+     * `loadComposeConfig()` to fall through to a permissive findFirst
+     * that picked archetype/identity specs non-deterministically (see
+     * `loadComposeConfig.ts` long-comment for the full root-cause).
+     *
+     * Override via COMPOSE_SPEC_SLUG env var when seeding a custom
+     * composer (e.g. multi-tenant variants).
      */
     get compose(): string {
-      return optional("COMPOSE_SPEC_SLUG", "system-compose-next-prompt");
+      return optional("COMPOSE_SPEC_SLUG", "spec-comp-001");
     },
 
     /**

--- a/apps/admin/lib/prompt/composition/loadComposeConfig.ts
+++ b/apps/admin/lib/prompt/composition/loadComposeConfig.ts
@@ -38,17 +38,50 @@ export async function loadComposeConfig(overrides?: {
    */
   requestedModuleId?: string;
 }): Promise<ComposeConfig> {
-  // Try exact slug first (from config), then fallback to any active COMPOSE/SYSTEM spec
-  const composeSpec = await prisma.analysisSpec.findFirst({
+  // Resolve the COMPOSE spec.
+  //
+  // Robust-fix (2026-05-23): the prior fallback was too permissive — it
+  // matched ANY active SYSTEM-scope spec with `outputType=COMPOSE` and
+  // `domain != prompt-slugs`. On DEV that pool included identity-domain
+  // archetype + overlay specs (ADVISOR-001, COACH-001, spec-advisor-001,
+  // spec-coach-001, …) because every IDENTITY spec is seeded with
+  // `outputType="COMPOSE"` (see prisma/seed-identity-archetypes.ts).
+  // `findFirst()` without `orderBy` is non-deterministic in Postgres, so
+  // some calls landed on `spec-comp-001` (correct) and others on
+  // `spec-advisor-001` / `ADVISOR-001` (wrong) — which then surfaced as
+  // `inputs.specUsed = "spec-advisor-001"` on ComposedPrompt rows and
+  // tripped the `advisorInInputsSnapshot` audit counter. This was the
+  // root cause of the 28 historical leaks investigated as #608 follow-ups.
+  //
+  // Tightened to require `domain="prompt-composition"` — the canonical
+  // domain for COMP-* specs in seed-from-specs / seed-prompts. Identity
+  // and archetype specs use `domain="identity"`, never `prompt-composition`,
+  // so this filter excludes them by design. `orderBy: slug asc` then
+  // makes the choice deterministic when multiple compose-domain specs
+  // are active (rare; today there is only `spec-comp-001`).
+  //
+  // If the exact-slug match fails AND the fallback fires, log a warning
+  // so the env misconfiguration is visible. The 28 historical leaks were
+  // silent because no log was emitted on fallback.
+  const exactMatch = await prisma.analysisSpec.findFirst({
     where: { slug: config.specs.compose, isActive: true },
-  }) || await prisma.analysisSpec.findFirst({
+  });
+  const composeSpec = exactMatch || await prisma.analysisSpec.findFirst({
     where: {
       outputType: "COMPOSE",
       isActive: true,
       scope: "SYSTEM",
-      domain: { not: "prompt-slugs" },
+      domain: "prompt-composition",
     },
+    orderBy: { slug: "asc" },
   });
+  if (!exactMatch && composeSpec) {
+    console.warn(
+      `[loadComposeConfig] env COMPOSE_SPEC_SLUG="${config.specs.compose}" has no exact match in DB. ` +
+        `Fell back to "${composeSpec.slug}" (first SYSTEM/COMPOSE spec in domain=prompt-composition by slug asc). ` +
+        `Set COMPOSE_SPEC_SLUG to the correct slug to suppress this warning.`,
+    );
+  }
 
   const specConfig = (composeSpec?.config as SpecConfig) || {};
   const specParameters = (specConfig.parameters as Array<{ id: string; config?: Record<string, any> }>) || [];

--- a/apps/admin/tests/lib/prompt/composition/load-compose-config.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/load-compose-config.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for `loadComposeConfig` spec-lookup robustness.
+ *
+ * Root cause we're guarding against: pre-2026-05-23 the fallback query was
+ * too permissive — it matched any active SYSTEM-scope spec with
+ * `outputType: "COMPOSE"`, which included identity-domain archetypes
+ * (ADVISOR-001, COACH-001, …) and the spec-{role}-001 overlays.
+ * `findFirst()` without `orderBy` returned non-deterministically, so some
+ * compositions picked the real COMP-001 (correct) and others picked
+ * ADVISOR-001 (wrong) — surfacing as `inputs.specUsed = "spec-advisor-001"`
+ * on ComposedPrompt rows and tripping the `advisorInInputsSnapshot`
+ * audit counter.
+ *
+ * Fix: tighten the fallback to `domain: "prompt-composition"` and add
+ * `orderBy: slug asc` for determinism. The exact-slug match still wins
+ * when env is configured.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  configCompose: "spec-comp-001",
+  warn: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: { analysisSpec: { findFirst: mocks.findFirst } },
+}));
+
+vi.mock("@/lib/config", () => ({
+  config: {
+    specs: {
+      get compose() {
+        return mocks.configCompose;
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/prompt/composition/CompositionExecutor", () => ({
+  getDefaultSections: () => [],
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.configCompose = "spec-comp-001";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => mocks.warn(...args));
+});
+
+import { loadComposeConfig } from "@/lib/prompt/composition/loadComposeConfig";
+
+describe("loadComposeConfig — spec lookup robustness", () => {
+  it("uses the env-configured slug when it exists (exact-match wins)", async () => {
+    mocks.findFirst.mockResolvedValueOnce({
+      id: "1",
+      slug: "spec-comp-001",
+      config: { sections: [{ id: "x" }] },
+    });
+    const result = await loadComposeConfig();
+    expect(result.specSlug).toBe("spec-comp-001");
+    expect(mocks.findFirst).toHaveBeenCalledTimes(1);
+    expect(mocks.findFirst).toHaveBeenCalledWith({
+      where: { slug: "spec-comp-001", isActive: true },
+    });
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to domain=prompt-composition when env slug is missing", async () => {
+    mocks.findFirst.mockResolvedValueOnce(null); // exact-match miss
+    mocks.findFirst.mockResolvedValueOnce({
+      id: "2",
+      slug: "spec-comp-002",
+      config: { sections: [] },
+    });
+    const result = await loadComposeConfig();
+    expect(result.specSlug).toBe("spec-comp-002");
+    expect(mocks.findFirst).toHaveBeenCalledTimes(2);
+    expect(mocks.findFirst).toHaveBeenNthCalledWith(2, {
+      where: {
+        outputType: "COMPOSE",
+        isActive: true,
+        scope: "SYSTEM",
+        domain: "prompt-composition",
+      },
+      orderBy: { slug: "asc" },
+    });
+  });
+
+  it("does NOT match identity-domain archetypes on fallback (the root-cause bug)", async () => {
+    mocks.configCompose = "bogus-slug-does-not-exist";
+    mocks.findFirst.mockResolvedValueOnce(null); // exact-match miss
+    mocks.findFirst.mockResolvedValueOnce(null); // tightened fallback finds nothing
+    await expect(loadComposeConfig()).rejects.toThrow(/COMPOSE spec not found/);
+    expect(mocks.findFirst).toHaveBeenCalledTimes(2);
+    const fallbackCall = mocks.findFirst.mock.calls[1][0] as {
+      where: { domain: string };
+    };
+    // Critical: the fallback MUST require domain="prompt-composition" so
+    // that identity-domain archetypes (which have outputType=COMPOSE) are
+    // never matched.
+    expect(fallbackCall.where.domain).toBe("prompt-composition");
+  });
+
+  // Note: loadComposeConfig also emits a separate warning when the spec has
+  // no sections[] config (using hardcoded defaults). Our tests pass mocks
+  // with `sections: [{}]` to avoid that second warning and isolate the
+  // fallback-warning assertions.
+  it("warns when the env slug misses and fallback picks a substitute", async () => {
+    mocks.configCompose = "system-compose-next-prompt"; // legacy/broken default
+    mocks.findFirst.mockResolvedValueOnce(null);
+    mocks.findFirst.mockResolvedValueOnce({
+      id: "3",
+      slug: "spec-comp-001",
+      config: { sections: [{ id: "x" }] },
+    });
+    await loadComposeConfig();
+    expect(mocks.warn).toHaveBeenCalledTimes(1);
+    const warnMsg = String(mocks.warn.mock.calls[0][0]);
+    expect(warnMsg).toContain("loadComposeConfig");
+    expect(warnMsg).toContain("system-compose-next-prompt");
+    expect(warnMsg).toContain("spec-comp-001");
+  });
+
+  it("does NOT warn when the exact-match query succeeds", async () => {
+    mocks.findFirst.mockResolvedValueOnce({
+      id: "1",
+      slug: "spec-comp-001",
+      config: { sections: [{ id: "x" }] },
+    });
+    await loadComposeConfig();
+    // The only warn this path can emit is the fallback notice (covered by
+    // the previous test); since exact-match succeeded, no warn should fire.
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("uses orderBy slug asc on the fallback for determinism", async () => {
+    mocks.findFirst.mockResolvedValueOnce(null);
+    mocks.findFirst.mockResolvedValueOnce({
+      id: "1",
+      slug: "spec-comp-001",
+      config: { sections: [] },
+    });
+    await loadComposeConfig();
+    const fallbackCall = mocks.findFirst.mock.calls[1][0] as {
+      orderBy: { slug: string };
+    };
+    expect(fallbackCall.orderBy).toEqual({ slug: "asc" });
+  });
+});


### PR DESCRIPTION
**Root cause of the historical 28 `advisorInInputsSnapshot` leaks AND the fresh leak surfaced live on 2026-05-23.** Independent of #608-C/#608-A — different code path, same symptom.

## The bug

`loadComposeConfig()`'s fallback was too permissive:

```typescript
// old
findFirst({ outputType: "COMPOSE", isActive: true, scope: "SYSTEM",
            domain: { not: "prompt-slugs" } })
```

That pool includes EVERY identity-domain archetype (ADVISOR-001, COACH-001, …) because each is seeded with `outputType: "COMPOSE"`. `findFirst()` without `orderBy` is non-deterministic — some compositions landed on `spec-comp-001` (correct), others on `spec-advisor-001` (wrong). The wrong one tripped the audit.

## Fix (3 parts)

1. **Tighten the fallback** to `domain: "prompt-composition"` — identity specs use `domain: "identity"` and are now excluded by design.
2. **Add `orderBy: { slug: "asc" }`** so even when multiple compose-domain specs exist, the choice is deterministic.
3. **Update the config default** from `"system-compose-next-prompt"` (no DB row → always triggered fallback) to `"spec-comp-001"` (the real composer in DEV).
4. **Log a warning** when fallback fires — the 28 silent leaks happened because no log was emitted; now misconfig is visible.

## Tests

`tests/lib/prompt/composition/load-compose-config.test.ts` — 6 cases:
- exact-match wins when env slug exists
- fallback restricted to `domain: "prompt-composition"`
- identity-domain archetypes never matched on fallback
- orderBy slug asc for determinism
- warn fires on fallback
- no warn on exact-match

Local: 6/6 pass. No new TS errors.

## Verifying after merge

```
ssh hf-dev "cd ~/HF && git pull && cd apps/admin && \
  npx tsx scripts/audit-epic-100.ts"        # advisorInInputsSnapshot still 28 (historical)
# then force a recompose for any caller and re-probe:
# specUsed should now ALWAYS be spec-comp-001
# inputs JSON should no longer contain spec-advisor-001
```

After this lands, you can either leave the 28 historical leaks (forensic) or hard-delete them in a one-off — they're `status='superseded'` and don't drive any current learner behavior.

Refs #600 (Epic 100), follow-on to #608. Closes the silent non-determinism in COMPOSE-spec lookup that was the actual root cause of the audit counter never reaching 0.