### PR TITLE
feat: collapsible section headers — Course at a Glance + Settings sections

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -90,7 +90,9 @@ export function CourseDesignTab({
 
   return (
     <div className="hf-mt-lg">
-      {/* ── Summary (absorbed from Overview) ── */}
+      {/* ── Summary (absorbed from Overview) ──
+          Collapsed by default — see CourseSummaryCard. `persistKey` lets each
+          course remember its own preference. */}
       {detail && (
         <>
           <CourseSummaryCard
@@ -112,6 +114,7 @@ export function CourseDesignTab({
             version={String(detail.version ?? '1')}
             subjectNames={(subjects || []).map(s => s.name)}
             onNavigate={onNavigate || (() => {})}
+            persistKey={courseId}
           />
         </>
       )}

--- a/apps/admin/app/x/courses/[courseId]/CourseSummaryCard.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseSummaryCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useState, useEffect, useCallback } from 'react';
 import {
   Users2, Target, Sparkles, PlayCircle, BookMarked,
-  ChevronRight, FileText,
+  ChevronRight, ChevronDown, FileText,
 } from 'lucide-react';
 import { GOAL_TYPE_CONFIG } from '@/lib/goals/goal-constants';
 import { CONTENT_CATEGORIES, CATEGORY_ORDER } from '@/lib/content-categories';
@@ -40,6 +41,8 @@ export type CourseSummaryCardProps = {
   subjectNames: string[];
   // Navigation
   onNavigate: (tab: string) => void;
+  /** Used as the localStorage suffix for collapse persistence — typically the courseId. */
+  persistKey?: string;
 };
 
 // ── Helpers ────────────────────────────────────────
@@ -89,6 +92,7 @@ export function CourseSummaryCard({
   version,
   subjectNames,
   onNavigate,
+  persistKey,
 }: CourseSummaryCardProps): React.ReactElement {
   const hasIdentity = interactionPattern || audienceLabel || teachingMode;
   const hasContent = subjectCount > 0 || totalTPs > 0 || totalSources > 0;
@@ -98,12 +102,51 @@ export function CourseSummaryCard({
   // Unique goal types for badge pills
   const goalTypes = [...new Set(goals.map(g => g.type))];
 
+  // Collapsed by default — the card takes ~400px on the Design tab and
+  // most educators don't need to see it on every page load. Per-course
+  // preference persists via the supplied persistKey (typically courseId).
+  const storageKey = persistKey ? `hf.course.section.${persistKey}.glance` : null;
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || !storageKey) return true;
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored === 'open') return false;
+      if (stored === 'collapsed') return true;
+      return true; // default: collapsed
+    } catch {
+      return true;
+    }
+  });
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(storageKey, collapsed ? 'collapsed' : 'open');
+    } catch {
+      // ignore
+    }
+  }, [collapsed, storageKey]);
+  const toggle = useCallback(() => setCollapsed((c) => !c), []);
+
   return (
     <div className="hf-card-compact csc-card">
-      <div className="csc-header">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        className="csc-header"
+        style={{
+          background: 'transparent', border: 'none', width: '100%',
+          textAlign: 'left', cursor: 'pointer', display: 'flex',
+          alignItems: 'center', gap: 6, padding: 0,
+        }}
+      >
+        {collapsed
+          ? <ChevronRight size={14} className="hf-text-muted" />
+          : <ChevronDown size={14} className="hf-text-muted" />}
         <span className="hf-text-xs hf-text-bold hf-text-muted hf-uppercase">Course at a Glance</span>
-      </div>
+      </button>
 
+      {!collapsed && (
       <div className="csc-body">
         {!hasAnyRow && (
           <div className="hf-text-sm hf-text-muted csc-empty">
@@ -249,8 +292,9 @@ export function CourseSummaryCard({
           </SummaryRow>
         )}
       </div>
+      )}
 
-      {/* ── Footer ─────────────────────────────────── */}
+      {/* ── Footer (always visible, gives a quick "Draft / v1" cue even when collapsed) */}
       <div className="csc-footer">
         <span className="hf-text-xs hf-text-muted">
           {publishedAt

--- a/apps/admin/app/x/courses/[courseId]/SectionHeader.tsx
+++ b/apps/admin/app/x/courses/[courseId]/SectionHeader.tsx
@@ -1,19 +1,107 @@
-export function SectionHeader({ title, icon: Icon, subtitle, actions }: {
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+/**
+ * SectionHeader — title + icon for a logical block on a course page.
+ *
+ * When `collapsible` is set, the header turns into a button: clicking
+ * toggles the content (passed as children) and the open/closed state is
+ * persisted to localStorage so it sticks across sessions. `persistKey`
+ * is appended to a stable namespace; pass something unique per course
+ * + section so different courses can have different defaults.
+ */
+export function SectionHeader({
+  title, icon: Icon, subtitle, actions,
+  collapsible = false,
+  defaultCollapsed = false,
+  persistKey,
+  children,
+}: {
   title: string;
   icon: React.ComponentType<{ size?: number; className?: string }>;
   subtitle?: string;
   actions?: React.ReactNode;
+  /** When true, the header toggles a content panel and persists state. */
+  collapsible?: boolean;
+  /** Initial state when no persisted value exists. */
+  defaultCollapsed?: boolean;
+  /** Storage key suffix — combined with a stable prefix. */
+  persistKey?: string;
+  /** Content to show / hide when collapsible. Ignored when not collapsible. */
+  children?: React.ReactNode;
 }) {
-  return (
-    <div className={subtitle ? 'hf-flex-col hf-mb-md hf-section-divider' : 'hf-flex hf-gap-sm hf-items-center hf-mb-md hf-section-divider'}>
-      <div className="hf-flex hf-gap-sm hf-items-center hf-flex-1">
-        <Icon size={18} className="hf-text-muted" />
-        <h2 className="hf-section-title hf-mb-0">{title}</h2>
+  const storageKey = persistKey ? `hf.course.section.${persistKey}` : null;
+
+  // Initialise from localStorage when collapsible; otherwise no state needed.
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (!collapsible) return false;
+    if (typeof window === 'undefined' || !storageKey) return defaultCollapsed;
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored === 'open') return false;
+      if (stored === 'collapsed') return true;
+      return defaultCollapsed;
+    } catch {
+      return defaultCollapsed;
+    }
+  });
+
+  // Persist when the user toggles.
+  useEffect(() => {
+    if (!collapsible || !storageKey || typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(storageKey, collapsed ? 'collapsed' : 'open');
+    } catch {
+      // ignore
+    }
+  }, [collapsed, collapsible, storageKey]);
+
+  const toggle = useCallback(() => setCollapsed((c) => !c), []);
+
+  // Non-collapsible — original rendering preserved.
+  if (!collapsible) {
+    return (
+      <div className={subtitle ? 'hf-flex-col hf-mb-md hf-section-divider' : 'hf-flex hf-gap-sm hf-items-center hf-mb-md hf-section-divider'}>
+        <div className="hf-flex hf-gap-sm hf-items-center hf-flex-1">
+          <Icon size={18} className="hf-text-muted" />
+          <h2 className="hf-section-title hf-mb-0">{title}</h2>
+        </div>
+        {actions}
+        {subtitle && (
+          <p className="hf-text-xs hf-text-muted hf-mt-xs hf-mb-0">{subtitle}</p>
+        )}
       </div>
-      {actions}
-      {subtitle && (
-        <p className="hf-text-xs hf-text-muted hf-mt-xs hf-mb-0">{subtitle}</p>
-      )}
-    </div>
+    );
+  }
+
+  // Collapsible — header is a button, optional content panel below.
+  return (
+    <>
+      <div className={subtitle ? 'hf-flex-col hf-mb-md hf-section-divider' : 'hf-flex hf-gap-sm hf-items-center hf-mb-md hf-section-divider'}>
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          className="hf-flex hf-gap-sm hf-items-center hf-flex-1"
+          style={{
+            background: 'transparent', border: 'none', padding: 0, margin: 0,
+            cursor: 'pointer', textAlign: 'left',
+          }}
+        >
+          {collapsed
+            ? <ChevronRight size={16} className="hf-text-muted" />
+            : <ChevronDown size={16} className="hf-text-muted" />}
+          <Icon size={18} className="hf-text-muted" />
+          <h2 className="hf-section-title hf-mb-0">{title}</h2>
+        </button>
+        {actions}
+        {subtitle && (
+          <p className="hf-text-xs hf-text-muted hf-mt-xs hf-mb-0">{subtitle}</p>
+        )}
+      </div>
+      {!collapsed && children}
+    </>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -1391,10 +1391,13 @@ export default function CourseDetailPage() {
                 title="Every Session"
                 icon={Sparkles}
                 subtitle="How sessions 2+ are structured (from your course reference)"
-              />
-              <div className="hf-card-compact hf-mb-lg">
-                <SessionFlowPipeline items={sessionFlowItems} />
-              </div>
+                collapsible
+                persistKey={`${courseId}.every-session`}
+              >
+                <div className="hf-card-compact hf-mb-lg">
+                  <SessionFlowPipeline items={sessionFlowItems} />
+                </div>
+              </SectionHeader>
             </div>
           )}
         </>
@@ -1526,7 +1529,7 @@ export default function CourseDetailPage() {
               </div>
 
               {/* ── Course Configuration ─────────────────── */}
-              <SectionHeader title="Course Configuration" icon={Zap} />
+              <SectionHeader title="Course Configuration" icon={Zap} collapsible persistKey={`${courseId}.config`}>
               <div className="hf-card hf-mb-lg">
                 {configLoading ? (
                   <div className="hf-flex hf-items-center hf-gap-sm hf-text-xs hf-text-muted">
@@ -1567,9 +1570,10 @@ export default function CourseDetailPage() {
                   <p className="hf-text-xs hf-text-muted">Configuration not available</p>
                 )}
               </div>
+              </SectionHeader>
 
               {/* ── Teaching Identity ────────────────── */}
-              <SectionHeader title="Teaching Identity" icon={Sparkles} />
+              <SectionHeader title="Teaching Identity" icon={Sparkles} collapsible persistKey={`${courseId}.identity`}>
               <div className="hf-card hf-mb-lg">
                 <div className="hf-grid-2col hf-gap-sm">
                   {([
@@ -1606,6 +1610,7 @@ export default function CourseDetailPage() {
                   })()}
                 </div>
               </div>
+              </SectionHeader>
 
               {detail.status === 'DRAFT' && (
                 <>
@@ -1630,17 +1635,18 @@ export default function CourseDetailPage() {
                 </>
               )}
 
-              <SectionHeader title="Metadata" icon={FileText} />
-              <div className="hf-card">
-                <div className="hf-flex hf-gap-lg hf-text-xs hf-text-muted hf-flex-wrap">
-                  <span>ID: <span className="hf-mono">{detail.id.slice(0, 8)}...</span></span>
-                  <span>Created: {new Date(detail.createdAt).toLocaleDateString()}</span>
-                  <span>Updated: {new Date(detail.updatedAt).toLocaleDateString()}</span>
-                  {detail.publishedAt && (
-                    <span>Published: {new Date(detail.publishedAt).toLocaleDateString()}</span>
-                  )}
+              <SectionHeader title="Metadata" icon={FileText} collapsible defaultCollapsed persistKey={`${courseId}.metadata`}>
+                <div className="hf-card">
+                  <div className="hf-flex hf-gap-lg hf-text-xs hf-text-muted hf-flex-wrap">
+                    <span>ID: <span className="hf-mono">{detail.id.slice(0, 8)}...</span></span>
+                    <span>Created: {new Date(detail.createdAt).toLocaleDateString()}</span>
+                    <span>Updated: {new Date(detail.updatedAt).toLocaleDateString()}</span>
+                    {detail.publishedAt && (
+                      <span>Published: {new Date(detail.publishedAt).toLocaleDateString()}</span>
+                    )}
+                  </div>
                 </div>
-              </div>
+              </SectionHeader>
             </>
           ) : (
             <div className="hf-banner hf-banner-info">

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.333",
+  "version": "0.7.334",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary

- **Course at a Glance** (CourseSummaryCard on the Design tab) was taking ~400px on first paint — now defaults to **collapsed**, with a chevron button to expand. Footer line ("Draft / v1") stays visible even when collapsed.
- **SectionHeader** gained optional \`collapsible\` + \`defaultCollapsed\` + \`persistKey\` props. When collapsible, the header is a button; the content is passed as children; state persists to localStorage so it sticks across sessions.
- Opted in on:
  - Design tab → **Every Session** (course-reference flow) — collapsible
  - Settings tab → **Course Configuration** — collapsible
  - Settings tab → **Teaching Identity** — collapsible
  - Settings tab → **Metadata** — collapsible, defaults to **collapsed**
- Left un-collapsible: **Status**, **Danger Zone** — short and operational, collapsing them just adds friction.

Per-course persistence (\`hf.course.section.<courseId>.<section>\`) so each course remembers its own preferences.

## Test plan

- [ ] Open Design tab on a course → \"Course at a Glance\" is collapsed by default; chevron is on the left of the header
- [ ] Click the header → expands, showing all 5 rows
- [ ] Reload page → state preserved (still expanded)
- [ ] Open a different course → that course's state is independent
- [ ] Open Settings tab → Course Configuration / Teaching Identity / Metadata each have chevrons; Status / Danger Zone do not
- [ ] Collapse Course Configuration → reload → still collapsed
- [ ] No console errors, no layout shift

## Deploy

\`/vm-cp\` — no schema, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)