### PR TITLE
fix: proactive MCQ reconcile at upload + backfill for historic orphans

### DIFF
--- a/apps/admin/lib/content-trust/save-questions.ts
+++ b/apps/admin/lib/content-trust/save-questions.ts
@@ -183,7 +183,59 @@ export async function saveQuestions(
     );
   }
 
+  // Fire-and-forget AI reconcile so freshly-imported question banks land
+  // with `assertionId` populated, instead of relying on a later UI visit
+  // to trigger McqPanel's auto-reconcile. Looks up every playbook that
+  // contains this source and runs `reconcileQuestionAssertions` per
+  // course. Errors swallowed — this is best-effort polish; the McqPanel
+  // auto-reconcile remains the safety net.
+  if (toCreate.length > 0) {
+    void triggerReconcileForSource(sourceId);
+  }
+
   return { created: toCreate.length, duplicatesSkipped, semanticDuplicatesSkipped };
+}
+
+/**
+ * Look up every playbook attached to a source and fire the AI MCQ
+ * reconcile for each (fire-and-forget, errors logged).
+ *
+ * Sources can be linked to N playbooks via PlaybookSource. After a
+ * question import, every linked course has a fresh batch of
+ * `assertionId = null` rows and is a candidate for reconciliation.
+ *
+ * Dynamic import keeps the heavier AI dependencies (embeddings) out of
+ * the hot-path module graph for callers that never trigger this.
+ */
+async function triggerReconcileForSource(sourceId: string): Promise<void> {
+  try {
+    const links = await prisma.playbookSource.findMany({
+      where: { sourceId },
+      select: { playbookId: true },
+    });
+    if (links.length === 0) return;
+    const { reconcileQuestionAssertions } = await import("./reconcile-question-linkage");
+    for (const link of links) {
+      // Fire-and-forget per course — don't block the import response on
+      // potentially slow AI calls. Stagger naturally via the await.
+      reconcileQuestionAssertions(link.playbookId)
+        .then((res) => {
+          if (res.scanned > 0) {
+            console.log(
+              `[save-questions] post-import reconcile course=${link.playbookId}: scanned=${res.scanned} matched=${res.matched} unmatched=${res.unmatched}`,
+            );
+          }
+        })
+        .catch((err) => {
+          console.warn(
+            `[save-questions] post-import reconcile failed for course=${link.playbookId}:`,
+            err?.message || err,
+          );
+        });
+    }
+  } catch (err: any) {
+    console.warn(`[save-questions] triggerReconcileForSource(${sourceId}) failed:`, err?.message || err);
+  }
 }
 
 /**

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.335",
+  "version": "0.7.336",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/scripts/backfill-mcq-reconcile.ts
+++ b/apps/admin/scripts/backfill-mcq-reconcile.ts
@@ -1,0 +1,136 @@
+/**
+ * Backfill: run AI MCQ reconciliation across every course that currently
+ * has orphan `ContentQuestion` rows (assertionId IS NULL) AND has at
+ * least one `ContentAssertion` in scope to link against.
+ *
+ * Why: until #690 the auto-reconcile only fired on the derived-curriculum
+ * branch in the UI; authored-modules courses never reconciled. #690 fixes
+ * the going-forward path, but historic courses still sit with orphans until
+ * an educator opens each one. This script proactively walks the DB and
+ * runs the reconciler course-by-course.
+ *
+ * Idempotent: re-running after a clean pass is a near-no-op (only
+ * rows newly added since the last run get re-evaluated).
+ *
+ * Run on VM:
+ *   npx tsx scripts/backfill-mcq-reconcile.ts            (dry-run, default)
+ *   npx tsx scripts/backfill-mcq-reconcile.ts --execute  (apply changes)
+ *   npx tsx scripts/backfill-mcq-reconcile.ts --course <courseId>  (single course)
+ */
+
+import { prisma } from "@/lib/prisma";
+import { reconcileQuestionAssertions } from "@/lib/content-trust/reconcile-question-linkage";
+import { getSourceIdsForPlaybook } from "@/lib/knowledge/domain-sources";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const execute = args.includes("--execute");
+  const dryRun = !execute;
+  const courseFlagIdx = args.indexOf("--course");
+  const explicitCourseId =
+    courseFlagIdx >= 0 && args[courseFlagIdx + 1] ? args[courseFlagIdx + 1] : null;
+
+  console.log(
+    `\n=== Backfill MCQ reconcile ===\n` +
+    `  mode: ${dryRun ? "DRY-RUN (pass --execute to apply)" : "EXECUTE"}\n` +
+    (explicitCourseId ? `  course filter: ${explicitCourseId}\n` : ""),
+  );
+
+  // 1. Find every Playbook (course). When --course is set, scope to just one.
+  const playbooks = await prisma.playbook.findMany({
+    where: explicitCourseId ? { id: explicitCourseId } : {},
+    select: { id: true, name: true, status: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (playbooks.length === 0) {
+    console.log("No playbooks matched the filter.\n");
+    return;
+  }
+  console.log(`  inspecting ${playbooks.length} playbook(s)...\n`);
+
+  let coursesProcessed = 0;
+  let coursesSkippedNoOrphans = 0;
+  let coursesSkippedNoCandidates = 0;
+  let totalScanned = 0;
+  let totalMatched = 0;
+  let totalUnmatched = 0;
+  let totalErrored = 0;
+
+  for (const pb of playbooks) {
+    const sourceIds = await getSourceIdsForPlaybook(pb.id);
+    if (sourceIds.length === 0) {
+      continue;
+    }
+
+    // Cheap pre-checks — skip courses with nothing to reconcile.
+    const [orphanCount, candidateCount] = await Promise.all([
+      prisma.contentQuestion.count({
+        where: { sourceId: { in: sourceIds }, assertionId: null },
+      }),
+      prisma.contentAssertion.count({ where: { sourceId: { in: sourceIds } } }),
+    ]);
+
+    if (orphanCount === 0) {
+      coursesSkippedNoOrphans += 1;
+      continue;
+    }
+    if (candidateCount === 0) {
+      // Pure question-bank course — no teaching points to match against.
+      // The reconciler would return 0 matches; no point spending the API call.
+      console.log(
+        `  ${pb.id.slice(0, 8)}…  ${pb.name}: ${orphanCount} orphan(s), 0 TPs → skipped (no candidates)`,
+      );
+      coursesSkippedNoCandidates += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(
+        `  ${pb.id.slice(0, 8)}…  ${pb.name}: ${orphanCount} orphan(s), ${candidateCount} candidate TP(s) → would reconcile`,
+      );
+      coursesProcessed += 1;
+      continue;
+    }
+
+    try {
+      console.log(
+        `  ${pb.id.slice(0, 8)}…  ${pb.name}: reconciling ${orphanCount} orphan(s)…`,
+      );
+      const res = await reconcileQuestionAssertions(pb.id);
+      totalScanned += res.scanned;
+      totalMatched += res.matched;
+      totalUnmatched += res.unmatched;
+      coursesProcessed += 1;
+      console.log(
+        `    → scanned=${res.scanned}  matched=${res.matched}  unmatched=${res.unmatched}  invalidRefs=${res.invalidRefs}`,
+      );
+    } catch (err: any) {
+      totalErrored += 1;
+      console.warn(`    ! error: ${err?.message || err}`);
+    }
+  }
+
+  console.log(
+    `\n=== ${dryRun ? "Dry-run" : "Done"} ===\n` +
+    `  courses processed: ${coursesProcessed}\n` +
+    `  courses skipped (no orphans): ${coursesSkippedNoOrphans}\n` +
+    `  courses skipped (no candidate TPs): ${coursesSkippedNoCandidates}\n` +
+    (dryRun ? "" :
+      `  total scanned: ${totalScanned}\n` +
+      `  total matched: ${totalMatched}\n` +
+      `  total unmatched: ${totalUnmatched}\n` +
+      `  errored: ${totalErrored}\n`),
+  );
+
+  if (dryRun) {
+    console.log(`Run again with --execute to apply.\n`);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Two highest-leverage follow-ups to #690 (the UI auto-reconcile that lifts into McqPanel). With these in place, authored-modules courses don't depend on an educator opening the Curriculum tab to get their question banks linked.

### 1. Proactive trigger from \`saveQuestions\`

After \`saveQuestions\` persists ≥1 ContentQuestion row, fire-and-forget \`reconcileQuestionAssertions\` for every playbook attached to that source via PlaybookSource. New question-bank imports land already-linked (or as close as the AI can get) instead of stuck with \`assertionId = null\` until a UI visit.

- Dynamic import of the reconciler keeps embedding dependencies off the hot path for callers that don't trigger it
- Errors swallowed + logged; never blocks the upload response
- Existing \`save-questions.test.ts\` (mocked Prisma) still passes 10/10

### 2. Backfill script for the lag

\`scripts/backfill-mcq-reconcile.ts\` walks every Playbook with orphan ContentQuestion rows AND at least one ContentAssertion in scope, runs the reconciler course-by-course.

- Dry-run by default; \`--execute\` to apply
- Skips "pure question-bank" courses (no candidate TPs) to save embedding spend
- \`--course <id>\` to scope to one course
- Idempotent

## Test plan

- [ ] On hf-dev, run \`npx tsx scripts/backfill-mcq-reconcile.ts\` (dry-run) → reports which courses would be reconciled
- [ ] Run with \`--execute\` → courses reconcile, MCQs flip from "unlinked" to linked TP refs
- [ ] Re-run → reports 0 new updates (idempotent)
- [ ] Upload a new question bank to a course → check server logs for \`[save-questions] post-import reconcile course=…\` line within a few seconds of the upload
- [ ] Open that course's Curriculum tab → MCQs already linked (no manual reconcile needed)

## Deploy

\`/vm-cp\` — no schema change. Run the backfill on the VM after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)