### PR TITLE
feat: ContentQuestion.linkReconciledAt TTL — stop retrying hopeless orphans

### DIFF
--- a/apps/admin/lib/content-trust/reconcile-question-linkage.ts
+++ b/apps/admin/lib/content-trust/reconcile-question-linkage.ts
@@ -52,9 +52,23 @@ export async function reconcileQuestionAssertions(courseId: string): Promise<Que
   const sourceIds = await getSourceIdsForPlaybook(courseId);
   if (sourceIds.length === 0) return empty;
 
-  // 2. Load orphan questions (no assertionId yet)
+  // 2. Load orphan questions (no assertionId yet) that we haven't already
+  //    tried recently. `linkReconciledAt` is stamped on every row the
+  //    reconciler scans, regardless of match — so rows that returned no
+  //    match last time sit out for the TTL window before we burn another
+  //    embedding call on them. When an educator adds new TPs the window
+  //    expires and we retry naturally.
+  const reconcileTtlDays = 7;
+  const ttlCutoff = new Date(Date.now() - reconcileTtlDays * 24 * 60 * 60 * 1000);
   const orphans = await prisma.contentQuestion.findMany({
-    where: { sourceId: { in: sourceIds }, assertionId: null },
+    where: {
+      sourceId: { in: sourceIds },
+      assertionId: null,
+      OR: [
+        { linkReconciledAt: null },
+        { linkReconciledAt: { lt: ttlCutoff } },
+      ],
+    },
     select: {
       id: true,
       questionText: true,
@@ -106,6 +120,25 @@ export async function reconcileQuestionAssertions(courseId: string): Promise<Que
     childLabel: "multiple-choice questions",
     parentLabel: "teaching points",
   });
+
+  // Stamp linkReconciledAt on EVERY row we scanned, matched or not. This
+  // is the TTL marker that lets future runs skip rows we've already
+  // evaluated. Failures here are non-fatal — the next reconcile will
+  // just see them as eligible again, which is correct behaviour.
+  if (orphans.length > 0) {
+    try {
+      const now = new Date();
+      await prisma.contentQuestion.updateMany({
+        where: { id: { in: orphans.map((o) => o.id) } },
+        data: { linkReconciledAt: now },
+      });
+    } catch (err: any) {
+      console.warn(
+        `[reconcile-question-linkage] course=${courseId}: failed to stamp linkReconciledAt:`,
+        err?.message || err,
+      );
+    }
+  }
 
   console.log(
     `[reconcile-question-linkage] course=${courseId}: scanned=${result.scanned} ` +

--- a/apps/admin/lib/content-trust/save-questions.ts
+++ b/apps/admin/lib/content-trust/save-questions.ts
@@ -253,9 +253,20 @@ function scheduleReconcileForCourse(courseId: string): void {
 
 async function runReconcileForCourse(courseId: string): Promise<void> {
   try {
-    // Guard 1: any orphans to reconcile?
+    // Guard 1: any orphans to reconcile? Count only rows the reconciler is
+    // *eligible* to scan — null assertionId AND linkReconciledAt is null or
+    // older than the TTL window. Rows locked out by the 7-day TTL aren't
+    // worth firing a reconcile for.
+    const ttlCutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const orphanCount = await prisma.contentQuestion.count({
-      where: { assertionId: null, source: { playbookSources: { some: { playbookId: courseId } } } },
+      where: {
+        assertionId: null,
+        OR: [
+          { linkReconciledAt: null },
+          { linkReconciledAt: { lt: ttlCutoff } },
+        ],
+        source: { playbookSources: { some: { playbookId: courseId } } },
+      },
     });
     if (orphanCount === 0) return;
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.337",
+  "version": "0.7.338",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/prisma/migrations/20260523_content_question_link_reconciled_at/migration.sql
+++ b/apps/admin/prisma/migrations/20260523_content_question_link_reconciled_at/migration.sql
@@ -1,0 +1,13 @@
+-- Add ContentQuestion.linkReconciledAt — TTL marker for the AI MCQ reconciler.
+--
+-- Background: the reconciler retried every orphan on every scheduled run,
+-- repeatedly burning embedding spend on rows the AI had already declined
+-- to match. This column records "we last looked at this row at X" so
+-- subsequent reconciles can skip rows attempted within the last ~7 days.
+--
+-- Pure additive — nullable column, no default, no backfill needed. Existing
+-- rows stay null and are eligible for one more attempt; from then on the
+-- reconciler stamps the timestamp each time it scans a row.
+
+ALTER TABLE "ContentQuestion"
+  ADD COLUMN "linkReconciledAt" TIMESTAMP(3);

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -3990,6 +3990,13 @@ model ContentQuestion {
   assertionId String?
   assertion   ContentAssertion? @relation(fields: [assertionId], references: [id], onDelete: SetNull)
 
+  // Last time the AI reconciler scanned this row, regardless of whether
+  // it matched. `reconcile-question-linkage.ts` uses this to skip rows it
+  // tried recently — prevents repeat AI spend on orphans that have no
+  // candidate teaching point. TTL ~7 days so when an educator adds new
+  // TPs the orphans get re-evaluated eventually.
+  linkReconciledAt DateTime?
+
   // Curriculum reference
   learningOutcomeRef String?
   skillRef           String? // Comprehension skill ref (e.g., "SKILL-01:Retrieval", "SKILL-05:Language Effect")


### PR DESCRIPTION
## Summary

Last piece of the MCQ reconcile robustness work. Until now every reconcile re-evaluated every orphan including ones the AI had already declined to match. The 390 unmatched orphans on hf-dev would burn embedding spend on every reconcile run.

New nullable column \`ContentQuestion.linkReconciledAt\` is stamped on every row the reconciler scans (match or no match). Subsequent reconciles filter \`linkReconciledAt IS NULL OR linkReconciledAt < now - 7 days\`. Existing rows start null and are eligible for one more attempt; thereafter the timestamp gates retries.

7-day TTL: long enough for educators' "I'll add more TPs tomorrow" flow to re-evaluate naturally, short enough that "we tried this and the AI said no" cools off quickly. Tunable later if real usage shows a different sweet spot.

The orphan-count guard in \`save-questions.ts::runReconcileForCourse\` also applies the TTL filter — if every orphan in a course is locked out, the trigger silently no-ops.

## Migration

Pure additive (\`ALTER TABLE ... ADD COLUMN\`), no backfill, safe under concurrent writes.

## Combined system state

After #690 (UI auto-fire) + #691 (post-upload trigger) + #692 (debounce + candidate guard) + this:

- **Robust**: fires on upload + UI visit + manual button + backfill script
- **Frugal**: deduped per-course (debounce), candidate-count guarded, orphan-count guarded, TTL-gated

## Test plan

- [ ] Run \`backfill-mcq-reconcile.ts\` on hf-dev → reconciler fires for unmatched rows, but a second run immediately after should report 0 scanned (TTL kicks in)
- [ ] Wait 7+ days (or manually clear linkReconciledAt) → next run scans the same rows again
- [ ] New uploads still get reconciled (linkReconciledAt is null for new rows)
- [ ] save-questions.test.ts stays at 10/10 pass

## Deploy

\`/vm-cpp\` — schema migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)