### PR TITLE
fix(#685): /help works in TUNING + visible Clear button with confirm

### DIFF
--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -186,7 +186,12 @@ export async function POST(request: NextRequest) {
     // Check for slash command
     const parsed = parseCommand(message);
     if (parsed) {
-      const result = await executeCommand(message, entityContext, mode as "DATA" | "CALL" | "BUG");
+      const result = await executeCommand(
+        message,
+        entityContext,
+        mode as "DATA" | "CALL" | "BUG" | "TUNING",
+        tuningScope,
+      );
       return NextResponse.json(result);
     }
 

--- a/apps/admin/components/chat/ChatPanel.tsx
+++ b/apps/admin/components/chat/ChatPanel.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useSession } from "next-auth/react";
 import { useChatContext, MODE_CONFIG, type ChatMode, type TuningScope } from "@/contexts/ChatContext";
 import { useEntityContext, ENTITY_COLORS, EntityBreadcrumb } from "@/contexts/EntityContext";
 import { useEntityDetection } from "@/hooks/useEntityDetection";
@@ -306,8 +307,9 @@ function ChatInput() {
 }
 
 export function ChatPanel() {
-  const { isOpen, closePanel, mode, chatLayout, setChatLayout } = useChatContext();
+  const { isOpen, closePanel, mode, chatLayout, setChatLayout, messages, clearHistory } = useChatContext();
   const { breadcrumbs } = useEntityContext();
+  const { data: session } = useSession();
 
   // Cmd+K shortcut is registered by GlobalAssistant (avoids double-toggle)
 
@@ -338,6 +340,41 @@ export function ChatPanel() {
     setChatLayout(layouts[(idx + 1) % layouts.length]);
   };
 
+  const handleClearClick = () => {
+    const userId = session?.user?.id;
+    // Source of truth is localStorage["hf.chat.history.${userId}"] — read it
+    // here so the confirm dialog reflects what's persisted, not in-memory
+    // staging that may differ during a stream.
+    let count = messages[mode]?.length ?? 0;
+    let earliestIso: string | null = null;
+    if (typeof window !== "undefined") {
+      try {
+        const key = userId ? `hf.chat.history.${userId}` : "hf.chat.history";
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          const arr = Array.isArray(parsed?.[mode]) ? parsed[mode] : [];
+          count = arr.length;
+          if (arr.length > 0 && arr[0]?.timestamp) {
+            earliestIso = arr[0].timestamp;
+          }
+        }
+      } catch {
+        // Fall back to in-memory counts; non-fatal.
+      }
+    }
+    if (count === 0) {
+      // Nothing to clear — no-op rather than a confusing dialog.
+      return;
+    }
+    const since = earliestIso ? new Date(earliestIso).toLocaleString() : "the start";
+    const ok = window.confirm(
+      `Clear ${count} message${count === 1 ? "" : "s"} from ${mode} mode (since ${since})?`
+    );
+    if (!ok) return;
+    clearHistory(mode);
+  };
+
   const panelClass = `chat-panel chat-panel--${chatLayout}${isOpen ? " chat-panel--open" : ""}`;
   const headerClass = `chat-header${chatLayout === "popout" ? " chat-header--popout" : ""}`;
 
@@ -360,6 +397,15 @@ export function ChatPanel() {
             </div>
           </div>
           <div className="chat-header-actions">
+            <button
+              onClick={handleClearClick}
+              className="chat-header-btn chat-header-btn--clear"
+              title={`Clear ${mode} chat history`}
+              aria-label={`Clear ${mode} chat history`}
+              disabled={(messages[mode]?.length ?? 0) === 0}
+            >
+              ⌫
+            </button>
             <button
               onClick={cycleLayout}
               className="chat-header-btn chat-header-btn--layout"

--- a/apps/admin/components/chat/chat-panel.css
+++ b/apps/admin/components/chat/chat-panel.css
@@ -517,6 +517,19 @@
   font-size: 16px;
 }
 
+.chat-header-btn--clear {
+  font-size: 14px;
+}
+
+.chat-header-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chat-header-btn:disabled:hover {
+  background: var(--surface-primary);
+}
+
 /* ---------------------------------------------------------------------------
    Mode Tabs (Assistant / Tuning) — #661
    --------------------------------------------------------------------------- */

--- a/apps/admin/contexts/ChatContext.tsx
+++ b/apps/admin/contexts/ChatContext.tsx
@@ -58,6 +58,10 @@ const ChatContext = createContext<ChatContextValue | null>(null);
 
 const STORAGE_KEY_PREFIX = "hf.chat.history";
 const SETTINGS_KEY_PREFIX = "hf.chat.settings";
+// Rolling trim, not an expiry. No TTL on chat history — persists until the
+// user clears it explicitly (Clear button in header or /clear command).
+// Matches Slack / ChatGPT / Linear conventions; localStorage cap (~5MB) is
+// three orders of magnitude away from being hit at 50 × 2 modes × ~2KB.
 const MAX_MESSAGES_PER_MODE = 50;
 
 function getStorageKey(userId: string | undefined): string {
@@ -350,6 +354,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
             content: data.message || data.error || "Command executed",
             metadata: { command: content.trim(), commandResult: data, isStreaming: false },
           });
+          if (data?.action === "execute" && data?.data?.clearHistory) {
+            const targetMode = data.data.clearHistory as ChatMode;
+            setMessages((prev) => ({ ...prev, [targetMode]: [] }));
+          }
         } catch (err) {
           updateMessage(assistantId, {
             content: `Error executing command: ${err instanceof Error ? err.message : "Unknown error"}`,

--- a/apps/admin/lib/chat/commands.ts
+++ b/apps/admin/lib/chat/commands.ts
@@ -1,7 +1,10 @@
 import { prisma } from "@/lib/prisma";
 import { MemoryCategory } from "@prisma/client";
 
-type ChatMode = "DATA" | "CALL" | "BUG";
+// Reconciled with the live ChatContext.tsx type ("DATA" | "TUNING").
+// BUG and CALL are legacy API modes still routed through this command pipeline;
+// keep them in the union so the cast in app/api/chat/route.ts stays type-safe.
+type ChatMode = "DATA" | "CALL" | "BUG" | "TUNING";
 
 interface EntityBreadcrumb {
   type: string;
@@ -13,6 +16,7 @@ interface EntityBreadcrumb {
 interface CommandContext {
   entityContext: EntityBreadcrumb[];
   mode: ChatMode;
+  tuningScope?: "LEARNER" | "PLAYBOOK";
 }
 
 interface CommandResult {
@@ -58,7 +62,8 @@ function findCommand(commandName: string): ChatCommand | undefined {
 export async function executeCommand(
   input: string,
   entityContext: EntityBreadcrumb[],
-  mode: ChatMode
+  mode: ChatMode,
+  tuningScope?: "LEARNER" | "PLAYBOOK"
 ): Promise<CommandResult> {
   const parsed = parseCommand(input);
   if (!parsed) {
@@ -81,7 +86,7 @@ export async function executeCommand(
   }
 
   try {
-    return await command.execute(parsed.args, { entityContext, mode });
+    return await command.execute(parsed.args, { entityContext, mode, tuningScope });
   } catch (error) {
     return {
       ok: false,
@@ -100,7 +105,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["?", "commands"],
     description: "Show available commands",
     usage: "/help [command]",
-    modes: ["DATA", "CALL"],
+    modes: ["DATA", "CALL", "TUNING"],
     execute: async (args, ctx) => {
       const specificCommand = args[0];
       if (specificCommand) {
@@ -133,7 +138,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["ctx"],
     description: "Show current entity context",
     usage: "/context",
-    modes: ["DATA", "CALL"],
+    modes: ["DATA", "CALL", "TUNING"],
     execute: async (args, ctx) => {
       if (ctx.entityContext.length === 0) {
         return {
@@ -162,7 +167,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["reset"],
     description: "Clear chat history for current mode",
     usage: "/clear",
-    modes: ["DATA", "CALL"],
+    modes: ["DATA", "CALL", "TUNING"],
     execute: async (args, ctx) => {
       return {
         ok: true,
@@ -348,6 +353,54 @@ const COMMANDS: ChatCommand[] = [
         ok: true,
         message: lines.join("\n"),
         data: caller,
+        action: "display",
+      };
+    },
+  },
+
+  {
+    name: "scope",
+    aliases: [],
+    description: "Show current tuning scope (LEARNER or PLAYBOOK)",
+    usage: "/scope",
+    modes: ["TUNING"],
+    execute: async (_args, ctx) => {
+      const scope = ctx.tuningScope ?? "PLAYBOOK";
+      const explainer =
+        scope === "LEARNER"
+          ? "Changes apply to the selected learner only."
+          : "Changes apply to the whole course.";
+      return {
+        ok: true,
+        message: `**Scope: ${scope}**\n\n${explainer}\n\nFlip with the toggle at the top of the Tuning tab.`,
+        action: "display",
+      };
+    },
+  },
+
+  {
+    name: "params",
+    aliases: ["parameters"],
+    description: "List tunable parameters for current context",
+    usage: "/params",
+    modes: ["TUNING"],
+    execute: async (_args, ctx) => {
+      const scope = ctx.tuningScope ?? "PLAYBOOK";
+      const lines = [
+        `**Tunable parameters — ${scope} scope**`,
+        "",
+        "Full per-context parameter discovery is coming with the tuning",
+        "registry. For now, ask the assistant directly:",
+        "",
+        "• \"Which parameters can I tune for this learner?\"",
+        "• \"Show me the playbook config keys I can override.\"",
+        "",
+        "The assistant has tool access to the live parameter set and will",
+        "return the current value plus the safe range.",
+      ];
+      return {
+        ok: true,
+        message: lines.join("\n"),
         action: "display",
       };
     },


### PR DESCRIPTION
Closes #685 · Epic #684

## Summary
- Reconciles `ChatMode` type in `lib/chat/commands.ts` with live `ChatContext` (`DATA | CALL | BUG | TUNING`)
- Widens `/help`, `/clear`, `/context` to TUNING mode
- Adds TUNING-only `/scope` and `/params`
- Wires `action: "execute"` so `/clear` actually clears (latent bug)
- Adds Clear (⌫) button to chat header with confirm dialog showing "{N} messages since {date}"
- Documents intentional no-TTL on chat persistence

## Test plan
- [ ] Open chat → switch to Tuning tab → type `/help` → expect command list, not "not available in TUNING mode"
- [ ] `/scope` in TUNING → returns LEARNER or PLAYBOOK
- [ ] `/params` in TUNING → returns stub copy
- [ ] Click ⌫ in chat header → confirm shows "{N} messages since {date}" → OK clears, Cancel doesn't
- [ ] ⌫ is disabled when chat history is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)