### PR TITLE
feat(#686): HelpOverlay + ? keypress + TopBar help button

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -2020,6 +2020,29 @@ html.light {
   flex-shrink: 0;
 }
 
+/* Help button — opens the Help Overlay (#686) */
+.hf-topbar-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  background: var(--surface-primary);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+.hf-topbar-help:hover {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+.hf-topbar-help:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+
 /* Search trigger — looks like a muted input, acts as a button */
 .hf-topbar-search {
   display: inline-flex;

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -10,6 +10,8 @@ import { TerminologyProvider } from '@/contexts/TerminologyContext';
 import { GuidanceProvider } from '@/contexts/GuidanceContext';
 import { GlobalAssistantProvider } from '@/contexts/AssistantContext';
 import { GlobalAssistant } from '@/components/shared/GlobalAssistant';
+import { HelpProvider } from '@/contexts/HelpContext';
+import { HelpOverlay } from '@/components/help/HelpOverlay';
 import { ContentJobQueueProvider, ContentJobQueue } from '@/components/shared/ContentJobQueue';
 import EnvironmentBanner from '@/components/shared/EnvironmentBanner';
 import DynamicFavicon from '@/components/shared/DynamicFavicon';
@@ -373,6 +375,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <ViewModeProvider>
               <EntityProvider>
                 <GuidanceProvider>
+                  <HelpProvider>
                   <ChatProvider>
                     <GlobalAssistantProvider>
                       <ContentJobQueueProvider>
@@ -384,11 +387,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                         </PageErrorBoundary>
                         {/* Floating widgets — outside PageErrorBoundary so they survive page crashes */}
                         <GlobalAssistant />
+                        <HelpOverlay />
                         <ContentJobQueue />
                         <BugReportButton />
                       </ContentJobQueueProvider>
                     </GlobalAssistantProvider>
                   </ChatProvider>
+                  </HelpProvider>
                 </GuidanceProvider>
               </EntityProvider>
               </ViewModeProvider>

--- a/apps/admin/components/help/HelpOverlay.tsx
+++ b/apps/admin/components/help/HelpOverlay.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { X } from "lucide-react";
+import { useHelpContext } from "@/contexts/HelpContext";
+import { useChatContext, MODE_CONFIG, type ChatMode } from "@/contexts/ChatContext";
+import { findPageHelp, type PageHelp } from "@/lib/help/page-help";
+import { GLOBAL_SHORTCUTS } from "@/lib/help/global-shortcuts";
+import { useHelpKeyboard } from "@/hooks/useHelpKeyboard";
+import "./help-overlay.css";
+
+// Chat commands surfaced in the overlay's "Chat commands" section. Sourced
+// from lib/chat/commands.ts — kept as a static mirror here because that file
+// is server-side (imports prisma). Update both if you add or remove commands.
+const CHAT_COMMAND_HELP: Record<ChatMode, Array<{ name: string; description: string }>> = {
+  DATA: [
+    { name: "/help", description: "Show available commands" },
+    { name: "/clear", description: "Clear chat history for this mode" },
+    { name: "/context", description: "Show current entity context" },
+    { name: "/memories", description: "Show memories for current caller" },
+    { name: "/buildprompt", description: "Show the composed prompt for current caller" },
+    { name: "/caller", description: "Show information about the current caller" },
+  ],
+  TUNING: [
+    { name: "/help", description: "Show available commands" },
+    { name: "/clear", description: "Clear chat history for this mode" },
+    { name: "/context", description: "Show current entity context" },
+    { name: "/scope", description: "Show current tuning scope (LEARNER or PLAYBOOK)" },
+    { name: "/params", description: "List tunable parameters for current context" },
+  ],
+};
+
+export function HelpOverlay() {
+  useHelpKeyboard();
+  const { isOpen, close } = useHelpContext();
+  const { isOpen: chatOpen, mode: chatMode } = useChatContext();
+  const pathname = usePathname() || "/";
+  const pageHelp = findPageHelp(pathname);
+  const closeBtnRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) closeBtnRef.current?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const trap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !panelRef.current) return;
+      const focusables = panelRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", trap);
+    return () => document.removeEventListener("keydown", trap);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="help-overlay-title"
+      data-help-overlay-root
+      className="help-overlay-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div ref={panelRef} className="help-overlay-panel" onClick={(e) => e.stopPropagation()}>
+        <header className="help-overlay-header">
+          <h2 id="help-overlay-title" className="help-overlay-title">
+            Help — {pageHelp?.title ?? "This page"}
+          </h2>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={close}
+            className="help-overlay-close"
+            aria-label="Close help"
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="help-overlay-body">
+          <Section title="About this page">
+            {pageHelp ? (
+              <p className="help-overlay-about">{pageHelp.about}</p>
+            ) : (
+              <p className="help-overlay-empty">No page guide yet for this route.</p>
+            )}
+          </Section>
+
+          <Section title="Tabs">
+            {pageHelp?.tabs?.length ? (
+              <dl className="help-overlay-tabs">
+                {pageHelp.tabs.map((t) => (
+                  <React.Fragment key={t.id}>
+                    <dt className="help-overlay-tab-label">{t.label}</dt>
+                    <dd className="help-overlay-tab-about">
+                      {t.about}
+                      {t.whenToUse ? <span className="help-overlay-tab-when"> {t.whenToUse}</span> : null}
+                    </dd>
+                  </React.Fragment>
+                ))}
+              </dl>
+            ) : (
+              <p className="help-overlay-empty">No tabs on this page.</p>
+            )}
+          </Section>
+
+          <Section title="Shortcuts — on this page">
+            {pageHelp?.chords?.length ? (
+              <ShortcutList items={pageHelp.chords.map((c) => ({ keys: `H ${c.keys} · G ${c.keys}`, description: c.label }))} />
+            ) : (
+              <p className="help-overlay-empty">No page-specific shortcuts.</p>
+            )}
+          </Section>
+
+          <Section title="Shortcuts — global">
+            <ShortcutList items={[...GLOBAL_SHORTCUTS]} />
+          </Section>
+
+          {chatOpen && (
+            <Section title={`Chat commands  ·  ${MODE_CONFIG[chatMode]?.label ?? chatMode} mode`}>
+              <dl className="help-overlay-tabs">
+                {(CHAT_COMMAND_HELP[chatMode] ?? []).map((c) => (
+                  <React.Fragment key={c.name}>
+                    <dt className="help-overlay-tab-label">
+                      <code>{c.name}</code>
+                    </dt>
+                    <dd className="help-overlay-tab-about">{c.description}</dd>
+                  </React.Fragment>
+                ))}
+              </dl>
+            </Section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="help-overlay-section">
+      <h3 className="help-overlay-section-title">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function ShortcutList({ items }: { items: Array<{ keys: string; description: string }> }) {
+  return (
+    <dl className="help-overlay-shortcuts">
+      {items.map((s, i) => (
+        <React.Fragment key={`${s.keys}-${i}`}>
+          <dt className="help-overlay-shortcut-keys">
+            <kbd>{s.keys}</kbd>
+          </dt>
+          <dd className="help-overlay-shortcut-desc">{s.description}</dd>
+        </React.Fragment>
+      ))}
+    </dl>
+  );
+}
+
+// Re-export the type so other modules can import it from here if convenient.
+export type { PageHelp };

--- a/apps/admin/components/help/help-overlay.css
+++ b/apps/admin/components/help/help-overlay.css
@@ -1,0 +1,145 @@
+.help-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 64px 24px 24px;
+  background: color-mix(in srgb, var(--text-primary) 40%, transparent);
+  overflow-y: auto;
+}
+
+.help-overlay-panel {
+  width: 100%;
+  max-width: 720px;
+  max-height: calc(100dvh - 96px);
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 16px;
+  box-shadow: 0 24px 64px color-mix(in srgb, var(--text-primary) 24%, transparent);
+  overflow: hidden;
+}
+
+.help-overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+}
+
+.help-overlay-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.help-overlay-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--surface-primary);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.help-overlay-close:hover {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.help-overlay-body {
+  padding: 16px 24px 24px;
+  overflow-y: auto;
+}
+
+.help-overlay-section {
+  margin-bottom: 24px;
+}
+
+.help-overlay-section:last-child {
+  margin-bottom: 0;
+}
+
+.help-overlay-section-title {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.help-overlay-about {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.help-overlay-empty {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.help-overlay-tabs,
+.help-overlay-shortcuts {
+  display: grid;
+  grid-template-columns: minmax(120px, max-content) 1fr;
+  gap: 6px 16px;
+  margin: 0;
+}
+
+.help-overlay-tab-label {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.help-overlay-tab-about {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-primary);
+}
+
+.help-overlay-tab-when {
+  display: block;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.help-overlay-shortcut-keys {
+  margin: 0;
+}
+
+.help-overlay-shortcut-keys kbd {
+  display: inline-block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  padding: 2px 8px;
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.help-overlay-shortcut-desc {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-primary);
+  align-self: center;
+}

--- a/apps/admin/components/shared/TopBar.tsx
+++ b/apps/admin/components/shared/TopBar.tsx
@@ -10,7 +10,8 @@ import { useBreadcrumbs } from "@/hooks/useBreadcrumbs";
 import { HierarchyBreadcrumb } from "./HierarchyBreadcrumb";
 import { UserAvatar } from "./UserAvatar";
 import { UserContextMenu } from "./UserContextMenu";
-import { VenetianMask, X, Search, Building2 } from "lucide-react";
+import { VenetianMask, X, Search, Building2, HelpCircle } from "lucide-react";
+import { useHelpContext } from "@/contexts/HelpContext";
 
 // ── Search Trigger ───────────────────────────────────────
 
@@ -92,6 +93,7 @@ export function TopBar() {
   const { data: session } = useSession();
   const [showMenu, setShowMenu] = useState(false);
   const { masquerade, isMasquerading, stopMasquerade } = useMasquerade();
+  const { toggle: toggleHelp } = useHelpContext();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const breadcrumbs = useBreadcrumbs();
 
@@ -121,6 +123,15 @@ export function TopBar() {
 
       {/* Right: institution + masquerade + avatar */}
       <div className="hf-topbar-right">
+        <button
+          type="button"
+          onClick={toggleHelp}
+          className="hf-topbar-help"
+          title="Help (?)"
+          aria-label="Open help"
+        >
+          <HelpCircle size={16} />
+        </button>
         <InstitutionChip />
         <DomainScopeChip />
 

--- a/apps/admin/contexts/HelpContext.tsx
+++ b/apps/admin/contexts/HelpContext.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useState } from "react";
+
+interface HelpContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+const HelpContext = createContext<HelpContextValue | null>(null);
+
+export function HelpProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((v) => !v), []);
+  return (
+    <HelpContext.Provider value={{ isOpen, open, close, toggle }}>
+      {children}
+    </HelpContext.Provider>
+  );
+}
+
+export function useHelpContext(): HelpContextValue {
+  const ctx = useContext(HelpContext);
+  if (!ctx) throw new Error("useHelpContext must be used within HelpProvider");
+  return ctx;
+}

--- a/apps/admin/hooks/useHelpKeyboard.ts
+++ b/apps/admin/hooks/useHelpKeyboard.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect } from "react";
+import { isFocusBlocked } from "@/lib/help/isFocusBlocked";
+import { useHelpContext } from "@/contexts/HelpContext";
+
+/**
+ * Global `?` keypress → toggle Help Overlay.
+ *
+ * Guards:
+ *   - Skipped when focus is inside INPUT / TEXTAREA / contenteditable
+ *     (isFocusBlocked) — typing `?` into a chat message must not trigger
+ *   - Skipped when any other dialog/modal is already open (prevents
+ *     stacking on top of an existing modal)
+ *
+ * Closes via Escape, second `?` press, or the X button in the overlay.
+ */
+export function useHelpKeyboard() {
+  const { isOpen, toggle, close } = useHelpContext();
+
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        e.stopPropagation();
+        close();
+        return;
+      }
+      if (e.key !== "?") return;
+      if (isFocusBlocked(e)) return;
+      if (!isOpen) {
+        const otherDialog = document.querySelector('[role="dialog"][data-help-overlay-root]');
+        const anyDialog = document.querySelector('[role="dialog"]');
+        if (anyDialog && !otherDialog) return;
+      }
+      e.preventDefault();
+      toggle();
+    };
+    window.addEventListener("keydown", handle);
+    return () => window.removeEventListener("keydown", handle);
+  }, [isOpen, toggle, close]);
+}

--- a/apps/admin/lib/help/global-shortcuts.ts
+++ b/apps/admin/lib/help/global-shortcuts.ts
@@ -1,0 +1,20 @@
+/**
+ * Global keyboard shortcuts shown in the Help Overlay's "Shortcuts — global"
+ * section. Page-scoped shortcuts live in lib/help/page-help.ts.
+ */
+export interface GlobalShortcut {
+  keys: string;
+  description: string;
+}
+
+export const GLOBAL_SHORTCUTS: readonly GlobalShortcut[] = [
+  { keys: "?", description: "Open this help" },
+  { keys: "⌘K", description: "Open AI assistant / search" },
+  { keys: "Esc", description: "Close panel or dialog" },
+  { keys: "H + key  ·  G + key", description: "Jump to a tab on this page (chord)" },
+  { keys: "H H  ·  G H", description: "Go home" },
+  { keys: "H C  ·  G C", description: "Courses" },
+  { keys: "H L  ·  G L", description: "Learners" },
+  { keys: "H D  ·  G D", description: "Data dictionary" },
+  { keys: "H S  ·  G S", description: "Specs" },
+];

--- a/apps/admin/lib/help/isFocusBlocked.ts
+++ b/apps/admin/lib/help/isFocusBlocked.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared focus guard for global keyboard handlers.
+ *
+ * Returns true when the keypress originated from an editable surface
+ * (INPUT, TEXTAREA, or contenteditable element). Global shortcuts —
+ * the `?` help overlay (#686) and the H/G chord engine (#688) — must
+ * use this to avoid hijacking a user who is just typing text.
+ *
+ * Escape hatch: any element with `data-hf-allow-chord` overrides the
+ * block (rare; used by surfaces that want global shortcuts even when
+ * the user is technically focused inside them).
+ */
+export function isFocusBlocked(event: KeyboardEvent): boolean {
+  const target = event.target as HTMLElement | null;
+  if (!target) return false;
+  if (target.dataset?.hfAllowChord !== undefined) return false;
+
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -1,0 +1,72 @@
+/**
+ * Page-scoped help registry. Each route declares its title, about copy,
+ * tab explanations, and chord bindings here. The Help Overlay (#686),
+ * chord engine (#688), and tab hover-tooltips (#689) all read from this
+ * single source.
+ *
+ * This file ships in #686 with the type definitions and an empty
+ * registry. #687 populates it for Wizard / Courses / Learners pages.
+ *
+ * Letter mapping rule for chord `keys`:
+ *   - First letter of the tab label is preferred
+ *   - On collision, pick the next memorable letter (not next-alphabet)
+ *   - Settings is always `T` (mnemonic: tuning)
+ *   - Avoid prefixes `H` and `G` for second-letter assignments
+ */
+
+export interface PageHelp {
+  /** Route pattern. Use a literal pathname or a RegExp for parameterised routes. */
+  match: string | RegExp;
+  /** Shown in the overlay header. */
+  title: string;
+  /** 1–2 sentences. What this page is for. */
+  about: string;
+  /** Optional tour id from lib/tours/tour-definitions.ts. */
+  tourId?: string;
+  /** Per-tab explanations. Omit for pages with no tabs. */
+  tabs?: TabHelp[];
+  /** Page-scoped chords. The chord engine prepends H or G. */
+  chords?: ChordBinding[];
+}
+
+export interface TabHelp {
+  /** Stable id; matches the tab system on the page (URL ?tab=, useState, pathname). */
+  id: string;
+  /** Human-readable label as it appears in the tab strip. */
+  label: string;
+  /** What's in this tab. */
+  about: string;
+  /** Optional secondary line. */
+  whenToUse?: string;
+}
+
+export interface ChordBinding {
+  /** Single letter A–Z. Capital. */
+  keys: string;
+  action: "navigate" | "callback";
+  /** Required when action === "navigate". */
+  href?: string;
+  /** Required when action === "callback". The page wires it up. */
+  callbackId?: string;
+  /** Shown in the overlay's "Shortcuts — on this page" section. */
+  label: string;
+}
+
+/**
+ * Registry. Populated by #687.
+ */
+export const PAGE_HELP: readonly PageHelp[] = [];
+
+/**
+ * Match a pathname against the registry.
+ */
+export function findPageHelp(pathname: string): PageHelp | undefined {
+  for (const entry of PAGE_HELP) {
+    if (typeof entry.match === "string") {
+      if (entry.match === pathname) return entry;
+    } else if (entry.match.test(pathname)) {
+      return entry;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Closes #686 · Epic #684 · Blocks #687, #688, #689

## Summary
- `?` keypress opens a contextual help overlay (focus-guarded — does not fire when typing in an input/textarea/contenteditable)
- `?` button added to TopBar right slot
- Five-section overlay: About / Tabs / Page Shortcuts / Global Shortcuts / Chat Commands
- Chat Commands section only renders when chat panel is open
- Shared `lib/help/isFocusBlocked.ts` utility (will also be consumed by chord engine in #688)
- Empty registry stub (`lib/help/page-help.ts`) — populated in #687
- ESC, X button, backdrop click, second `?` all close. Minimal focus trap inside the panel.

## Test plan
- [ ] `?` opens overlay on any /x/ page
- [ ] `?` while typing in chat does NOT open
- [ ] `?` with an existing dialog open (e.g. prereqs warning) does NOT stack
- [ ] TopBar `?` button toggles overlay
- [ ] ESC closes
- [ ] With chat open in DATA mode, overlay shows DATA-mode commands
- [ ] With chat open in TUNING mode, overlay shows TUNING-mode commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)