### PR TITLE
feat(#687): populate page-help registry for Wizard/Courses/Learners

### DIFF
--- a/apps/admin/components/help/HelpOverlay.tsx
+++ b/apps/admin/components/help/HelpOverlay.tsx
@@ -4,8 +4,9 @@ import React, { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { X } from "lucide-react";
 import { useHelpContext } from "@/contexts/HelpContext";
+import { useSession } from "next-auth/react";
 import { useChatContext, MODE_CONFIG, type ChatMode } from "@/contexts/ChatContext";
-import { findPageHelp, type PageHelp } from "@/lib/help/page-help";
+import { getPageHelp, canSeeOperatorOnly, type PageHelp } from "@/lib/help/page-help";
 import { GLOBAL_SHORTCUTS } from "@/lib/help/global-shortcuts";
 import { useHelpKeyboard } from "@/hooks/useHelpKeyboard";
 import "./help-overlay.css";
@@ -35,8 +36,19 @@ export function HelpOverlay() {
   useHelpKeyboard();
   const { isOpen, close } = useHelpContext();
   const { isOpen: chatOpen, mode: chatMode } = useChatContext();
+  const { data: session } = useSession();
   const pathname = usePathname() || "/";
-  const pageHelp = findPageHelp(pathname);
+  const rawPageHelp = getPageHelp(pathname);
+  const isOperator = canSeeOperatorOnly(session?.user?.role as string | undefined);
+  // Filter operator-only tabs and chords so VIEWER/STUDENT/TESTER don't see
+  // affordances they can't actually use.
+  const pageHelp: PageHelp | undefined = rawPageHelp
+    ? {
+        ...rawPageHelp,
+        tabs: rawPageHelp.tabs?.filter((t) => !t.requiresOperator || isOperator),
+        chords: rawPageHelp.chords?.filter((c) => !c.requiresOperator || isOperator),
+      }
+    : undefined;
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
 

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -4,22 +4,24 @@
  * chord engine (#688), and tab hover-tooltips (#689) all read from this
  * single source.
  *
- * This file ships in #686 with the type definitions and an empty
- * registry. #687 populates it for Wizard / Courses / Learners pages.
- *
  * Letter mapping rule for chord `keys`:
  *   - First letter of the tab label is preferred
  *   - On collision, pick the next memorable letter (not next-alphabet)
  *   - Settings is always `T` (mnemonic: tuning)
  *   - Avoid prefixes `H` and `G` for second-letter assignments
+ *
+ * Collision note: Course detail uses `O` for Goals (gOals, because G is a
+ * chord prefix), which would collide with Overview=`O` on Learner detail —
+ * but they live on different routes so no runtime conflict. Document any
+ * future cross-page collision in the page's entry comment.
  */
 
 export interface PageHelp {
-  /** Route pattern. Use a literal pathname or a RegExp for parameterised routes. */
-  match: string | RegExp;
+  /** Route pattern. Literal pathname for exact match, RegExp for parameterised routes, or `{ prefix }` for prefix match. */
+  match: string | RegExp | { prefix: string };
   /** Shown in the overlay header. */
   title: string;
-  /** 1–2 sentences. What this page is for. */
+  /** 1–3 sentences. What this page is for. */
   about: string;
   /** Optional tour id from lib/tours/tour-definitions.ts. */
   tourId?: string;
@@ -38,6 +40,8 @@ export interface TabHelp {
   about: string;
   /** Optional secondary line. */
   whenToUse?: string;
+  /** When true, hide from VIEWER/STUDENT/TESTER (only show to OPERATOR+). */
+  requiresOperator?: boolean;
 }
 
 export interface ChordBinding {
@@ -46,27 +50,209 @@ export interface ChordBinding {
   action: "navigate" | "callback";
   /** Required when action === "navigate". */
   href?: string;
-  /** Required when action === "callback". The page wires it up. */
+  /** Required when action === "callback". Convention: "tab:<id>" → setActiveTab(id). The chord engine (#688) resolves callbacks via per-page registration. */
   callbackId?: string;
   /** Shown in the overlay's "Shortcuts — on this page" section. */
   label: string;
+  /** When true, hide from VIEWER/STUDENT/TESTER (only show to OPERATOR+). */
+  requiresOperator?: boolean;
 }
 
 /**
- * Registry. Populated by #687.
+ * Registry. Add new pages here. Keep entries grouped by domain.
  */
-export const PAGE_HELP: readonly PageHelp[] = [];
+export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
+  // ── Wizard ───────────────────────────────────────────────────────────
+  {
+    match: "/x/get-started-v5",
+    title: "Build Course",
+    about:
+      "Conversational wizard for designing a course. The AI interviews you about your audience, content, and goals, then composes the spec the rest of the system runs on. You can leave and resume — progress is saved at each turn.",
+    tourId: "educator-tour",
+    // V5 is conversational, not tabbed — no tabs array. Page actions only.
+    chords: [
+      { keys: "C", action: "navigate", href: "/x/courses", label: "Exit to Courses" },
+    ],
+  },
+
+  // ── Courses ──────────────────────────────────────────────────────────
+  {
+    match: "/x/courses",
+    title: "Courses",
+    about:
+      "All courses in this institution. Each course bundles a content set, a journey design, and the learners enrolled in it.",
+    chords: [
+      { keys: "N", action: "navigate", href: "/x/courses/new", label: "New course" },
+      { keys: "W", action: "navigate", href: "/x/get-started-v5", label: "Open wizard (Build Course)" },
+    ],
+  },
+  {
+    // Match /x/courses/{id} only — exclude /x/courses/{new,create,v3} so
+    // those routes fall through to the placeholder rather than misclaim
+    // "Course detail" help.
+    match: /^\/x\/courses\/(?!new(?:\/|$)|create(?:\/|$)|v3(?:\/|$))[^/]+/,
+    title: "Course detail",
+    about:
+      "Everything about one course: the content that drives sessions, the design of the journey, the curriculum's module structure, the learners enrolled, the proof points teachers track, and the goals callers work toward.",
+    tabs: [
+      {
+        id: "intelligence",
+        label: "Content",
+        about: "Source files and the extracted assertions that drive what the AI teaches.",
+        whenToUse: "When you want to add new material or check what the AI has actually learned from your uploads.",
+      },
+      {
+        id: "design",
+        label: "Design",
+        about: "Welcome flow, session flow, mid-survey, and audience — the shape of how a learner experiences the course.",
+        whenToUse: "When you want to change how sessions begin, what's asked partway through, or who the course is for.",
+      },
+      {
+        id: "curriculum",
+        label: "Curriculum",
+        about: "Module and learning-objective structure. Reorder, add, or rewrite modules and their LOs.",
+        whenToUse: "When you want to change the order learners progress through, or rename a module.",
+      },
+      {
+        id: "learners",
+        label: "Learners",
+        about: "Enrolled learners, invitations, and per-learner progress at a glance.",
+        whenToUse: "When you want to invite, remove, or pick a specific learner to drill into.",
+      },
+      {
+        id: "proof",
+        label: "Proof Points",
+        about: "Evidence the AI gathers about whether learners are mastering the material — call-by-call scoring across modules.",
+        whenToUse: "When you want to see cohort-level mastery trends or spot stuck learners.",
+      },
+      {
+        id: "goals",
+        label: "Goals",
+        about: "The goals the course is steering callers toward and how progress is measured.",
+        whenToUse: "When you want to retune what the AI is trying to achieve with each caller.",
+      },
+      {
+        id: "settings",
+        label: "Settings",
+        about: "Scheduling, AI model selection, soft-delete, and other course-level configuration.",
+        whenToUse: "When you need to change the schedule, swap the AI model, or archive the course.",
+        requiresOperator: true,
+      },
+    ],
+    chords: [
+      { keys: "C", action: "callback", callbackId: "tab:intelligence", label: "Content tab" },
+      { keys: "D", action: "callback", callbackId: "tab:design", label: "Design tab" },
+      { keys: "U", action: "callback", callbackId: "tab:curriculum", label: "Curriculum tab (cUrriculum)" },
+      { keys: "L", action: "callback", callbackId: "tab:learners", label: "Learners tab" },
+      { keys: "P", action: "callback", callbackId: "tab:proof", label: "Proof Points tab" },
+      { keys: "O", action: "callback", callbackId: "tab:goals", label: "Goals tab (gOals — G is reserved as a chord prefix)" },
+      { keys: "T", action: "callback", callbackId: "tab:settings", label: "Settings tab", requiresOperator: true },
+    ],
+  },
+
+  // ── Learners ─────────────────────────────────────────────────────────
+  {
+    match: "/x/callers",
+    title: "Learners",
+    about:
+      "All learners across all courses in this institution. Each learner has their own memory, journey progress, and call history. Learners are added by inviting them into a specific course.",
+    chords: [
+      { keys: "C", action: "navigate", href: "/x/courses", label: "Go to Courses (to invite a learner)" },
+    ],
+  },
+  {
+    match: /^\/x\/callers\/[^/]+/,
+    title: "Learner detail",
+    about:
+      "Everything about one learner: their journey position, recent calls and prompts, tuning overrides, what the AI knows about them, what they're working on, generated artifacts, and a live AI call surface.",
+    tabs: [
+      {
+        id: "overview",
+        label: "Overview",
+        about: "At-a-glance summary — uplift, recent activity, and the next session.",
+        whenToUse: "When you just want to see how this learner is doing without drilling in.",
+      },
+      {
+        id: "uplift",
+        label: "Uplift",
+        about: "Score uplift over time — how much this learner has moved across the goals you're tracking.",
+        whenToUse: "When you want concrete evidence of progress (or stagnation).",
+      },
+      {
+        id: "calls-prompts",
+        label: "Calls & Prompts",
+        about: "Every call this learner has had, with the transcript and the composed prompt that was used for each.",
+        whenToUse: "When you want to debug why the AI said what it said, or replay a session.",
+      },
+      {
+        id: "tune",
+        label: "Tune",
+        about: "Per-learner tuning overrides — chat with the AI to nudge how it behaves for this specific learner.",
+        whenToUse: "When this learner needs something different from the cohort default (slower pace, gentler tone, etc.).",
+      },
+      {
+        id: "how",
+        label: "How",
+        about: "Memories, traits, personality, and the slugs the AI uses to refer to this learner.",
+        whenToUse: "When you want to see what the AI thinks it knows about the learner, or correct a wrong memory.",
+      },
+      {
+        id: "what",
+        label: "What",
+        about: "Scores, behaviour history, goal progress, and exam-readiness signal.",
+        whenToUse: "When you want to see numbers — current scores, change over time, exam predictions.",
+      },
+      {
+        id: "artifacts",
+        label: "Artifacts",
+        about: "Generated artifacts — composed prompts, lesson plans, content packs produced for this learner.",
+        whenToUse: "When you want to inspect or download something the system generated for this learner.",
+      },
+      {
+        id: "ai-call",
+        label: "AI Call",
+        about: "Live AI call surface — start a session with this learner's exact prompt and persona right from this page.",
+        whenToUse: "When you want to see what the learner sees, or test a tuning change end-to-end.",
+      },
+    ],
+    chords: [
+      { keys: "O", action: "callback", callbackId: "tab:overview", label: "Overview tab" },
+      { keys: "U", action: "callback", callbackId: "tab:uplift", label: "Uplift tab" },
+      { keys: "C", action: "callback", callbackId: "tab:calls-prompts", label: "Calls & Prompts tab" },
+      { keys: "T", action: "callback", callbackId: "tab:tune", label: "Tune tab" },
+      { keys: "W", action: "callback", callbackId: "tab:how", label: "How tab (hoW — H is reserved as a chord prefix)" },
+      { keys: "A", action: "callback", callbackId: "tab:what", label: "What tab (whAt)" },
+      { keys: "R", action: "callback", callbackId: "tab:artifacts", label: "Artifacts tab (aRtifacts)" },
+      { keys: "I", action: "callback", callbackId: "tab:ai-call", label: "AI Call tab (aI call)" },
+    ],
+  },
+];
 
 /**
- * Match a pathname against the registry.
+ * Match a pathname against the registry. Exact match wins over prefix
+ * match wins over RegExp match.
  */
-export function findPageHelp(pathname: string): PageHelp | undefined {
-  for (const entry of PAGE_HELP) {
-    if (typeof entry.match === "string") {
-      if (entry.match === pathname) return entry;
-    } else if (entry.match.test(pathname)) {
-      return entry;
+export function getPageHelp(pathname: string): PageHelp | undefined {
+  for (const entry of PAGE_HELP_REGISTRY) {
+    if (typeof entry.match === "string" && entry.match === pathname) return entry;
+  }
+  for (const entry of PAGE_HELP_REGISTRY) {
+    if (typeof entry.match === "object" && "prefix" in entry.match) {
+      if (pathname.startsWith(entry.match.prefix)) return entry;
     }
   }
+  for (const entry of PAGE_HELP_REGISTRY) {
+    if (entry.match instanceof RegExp && entry.match.test(pathname)) return entry;
+  }
   return undefined;
+}
+
+/**
+ * Returns true when the role can see operator-only items (tabs / chords
+ * with `requiresOperator: true`). Mirrors the runtime check at
+ * apps/admin/app/x/courses/[courseId]/page.tsx:158.
+ */
+export function canSeeOperatorOnly(role: string | undefined | null): boolean {
+  if (!role) return false;
+  return role === "OPERATOR" || role === "EDUCATOR" || role === "ADMIN" || role === "SUPERADMIN";
 }

--- a/apps/admin/tests/lib/page-help.test.ts
+++ b/apps/admin/tests/lib/page-help.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  PAGE_HELP_REGISTRY,
+  getPageHelp,
+  canSeeOperatorOnly,
+} from "@/lib/help/page-help";
+
+describe("page-help registry", () => {
+  describe("getPageHelp — route matching", () => {
+    it("returns the wizard entry for exact pathname", () => {
+      const entry = getPageHelp("/x/get-started-v5");
+      expect(entry).toBeDefined();
+      expect(entry?.title).toBe("Build Course");
+      expect(entry?.tourId).toBe("educator-tour");
+    });
+
+    it("returns the Courses index entry for exact pathname", () => {
+      const entry = getPageHelp("/x/courses");
+      expect(entry).toBeDefined();
+      expect(entry?.title).toBe("Courses");
+    });
+
+    it("returns the Course detail entry for parameterised pathname with 7 tabs", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      expect(entry).toBeDefined();
+      expect(entry?.title).toBe("Course detail");
+      expect(entry?.tabs).toHaveLength(7);
+      const labels = entry?.tabs?.map((t) => t.label);
+      expect(labels).toEqual([
+        "Content",
+        "Design",
+        "Curriculum",
+        "Learners",
+        "Proof Points",
+        "Goals",
+        "Settings",
+      ]);
+    });
+
+    it("does NOT return Course detail for /x/courses/new (non-detail route)", () => {
+      const entry = getPageHelp("/x/courses/new");
+      expect(entry?.title).not.toBe("Course detail");
+    });
+
+    it("does NOT return Course detail for /x/courses/create or /x/courses/v3", () => {
+      expect(getPageHelp("/x/courses/create")?.title).not.toBe("Course detail");
+      expect(getPageHelp("/x/courses/v3")?.title).not.toBe("Course detail");
+    });
+
+    it("returns the Learner detail entry for parameterised pathname with 8 tabs", () => {
+      const entry = getPageHelp("/x/callers/xyz-789");
+      expect(entry).toBeDefined();
+      expect(entry?.title).toBe("Learner detail");
+      expect(entry?.tabs).toHaveLength(8);
+      const ids = entry?.tabs?.map((t) => t.id);
+      expect(ids).toEqual([
+        "overview",
+        "uplift",
+        "calls-prompts",
+        "tune",
+        "how",
+        "what",
+        "artifacts",
+        "ai-call",
+      ]);
+    });
+
+    it("returns the Learners index entry for exact pathname", () => {
+      const entry = getPageHelp("/x/callers");
+      expect(entry?.title).toBe("Learners");
+    });
+
+    it("returns undefined for unknown pages", () => {
+      expect(getPageHelp("/x/unknown-page")).toBeUndefined();
+      expect(getPageHelp("/x/specs")).toBeUndefined();
+      expect(getPageHelp("/")).toBeUndefined();
+    });
+  });
+
+  describe("Course detail chord mapping", () => {
+    it("uses T for Settings and marks it requiresOperator", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      const settings = entry?.chords?.find((c) => c.callbackId === "tab:settings");
+      expect(settings?.keys).toBe("T");
+      expect(settings?.requiresOperator).toBe(true);
+    });
+
+    it("uses O for Goals (gOals — G is a chord prefix)", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      const goals = entry?.chords?.find((c) => c.callbackId === "tab:goals");
+      expect(goals?.keys).toBe("O");
+    });
+
+    it("uses U for Curriculum (cUrriculum — C collides with Content)", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      const curr = entry?.chords?.find((c) => c.callbackId === "tab:curriculum");
+      expect(curr?.keys).toBe("U");
+    });
+
+    it("never assigns H or G as chord keys (those are prefixes)", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      const keys = entry?.chords?.map((c) => c.keys) ?? [];
+      expect(keys).not.toContain("H");
+      expect(keys).not.toContain("G");
+    });
+  });
+
+  describe("Learner detail chord mapping", () => {
+    it("uses W for How (hoW — H is a chord prefix)", () => {
+      const entry = getPageHelp("/x/callers/xyz-789");
+      const how = entry?.chords?.find((c) => c.callbackId === "tab:how");
+      expect(how?.keys).toBe("W");
+    });
+
+    it("uses A for What (whAt — W collides with How)", () => {
+      const entry = getPageHelp("/x/callers/xyz-789");
+      const what = entry?.chords?.find((c) => c.callbackId === "tab:what");
+      expect(what?.keys).toBe("A");
+    });
+
+    it("uses I for AI Call (aI call — A collides with What)", () => {
+      const entry = getPageHelp("/x/callers/xyz-789");
+      const aiCall = entry?.chords?.find((c) => c.callbackId === "tab:ai-call");
+      expect(aiCall?.keys).toBe("I");
+    });
+
+    it("never assigns H or G as chord keys (those are prefixes)", () => {
+      const entry = getPageHelp("/x/callers/xyz-789");
+      const keys = entry?.chords?.map((c) => c.keys) ?? [];
+      expect(keys).not.toContain("H");
+      expect(keys).not.toContain("G");
+    });
+  });
+
+  describe("canSeeOperatorOnly", () => {
+    it("allows OPERATOR, EDUCATOR, ADMIN, SUPERADMIN", () => {
+      expect(canSeeOperatorOnly("OPERATOR")).toBe(true);
+      expect(canSeeOperatorOnly("EDUCATOR")).toBe(true);
+      expect(canSeeOperatorOnly("ADMIN")).toBe(true);
+      expect(canSeeOperatorOnly("SUPERADMIN")).toBe(true);
+    });
+
+    it("blocks VIEWER, STUDENT, TESTER, DEMO, and unknown roles", () => {
+      expect(canSeeOperatorOnly("VIEWER")).toBe(false);
+      expect(canSeeOperatorOnly("STUDENT")).toBe(false);
+      expect(canSeeOperatorOnly("TESTER")).toBe(false);
+      expect(canSeeOperatorOnly("DEMO")).toBe(false);
+      expect(canSeeOperatorOnly(undefined)).toBe(false);
+      expect(canSeeOperatorOnly(null)).toBe(false);
+      expect(canSeeOperatorOnly("")).toBe(false);
+    });
+  });
+
+  describe("registry invariants", () => {
+    it("every chord key is a single uppercase letter A–Z", () => {
+      for (const entry of PAGE_HELP_REGISTRY) {
+        for (const chord of entry.chords ?? []) {
+          expect(chord.keys).toMatch(/^[A-Z]$/);
+        }
+      }
+    });
+
+    it("no two chords on the same page share the same key", () => {
+      for (const entry of PAGE_HELP_REGISTRY) {
+        const keys = (entry.chords ?? []).map((c) => c.keys);
+        expect(new Set(keys).size).toBe(keys.length);
+      }
+    });
+
+    it("every tab id is unique within a page", () => {
+      for (const entry of PAGE_HELP_REGISTRY) {
+        const ids = (entry.tabs ?? []).map((t) => t.id);
+        expect(new Set(ids).size).toBe(ids.length);
+      }
+    });
+
+    it("every navigate chord has an href and every callback chord has a callbackId", () => {
+      for (const entry of PAGE_HELP_REGISTRY) {
+        for (const chord of entry.chords ?? []) {
+          if (chord.action === "navigate") {
+            expect(chord.href).toBeTruthy();
+          } else if (chord.action === "callback") {
+            expect(chord.callbackId).toBeTruthy();
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #687 · Epic #684 · Replaces #697 (closed when stacked base merged)

## Summary
- 5 page entries: Wizard, Courses index, Course detail (7 tabs), Learners index, Learner detail (8 tabs)
- Tab \`about\` and \`whenToUse\` copy for all 15 tabs
- Chord-letter mapping per Tech-Lead-approved rules: Settings=T, Goals=O (G is a prefix), Curriculum=U (C taken), How=W (H is a prefix), What=A, Artifacts=R, AI Call=I
- \`requiresOperator\` filtering — Settings tab hidden from VIEWER/STUDENT roles
- Course-detail RegExp excludes /x/courses/{new,create,v3} so they fall through to placeholder
- 22-test vitest suite covering route matching, chord rules, role filtering, registry invariants

## Test plan
- [ ] \`?\` on /x/courses/abc-123 → Course detail overlay with 7 tabs and 7 chords
- [ ] \`?\` on /x/callers/xyz → Learner detail overlay with 8 tabs and 8 chords
- [ ] \`?\` on /x/courses/new → "No page guide yet" placeholder (not misattributed)
- [ ] \`?\` on /x/get-started-v5 → Wizard help
- [ ] Masquerade as VIEWER on Course detail → Settings tab absent
- [ ] \`npx vitest run tests/lib/page-help.test.ts\` — 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)