### PR TITLE
chore(topbar): rename Search trigger to 'Search or ask...'

### DIFF
--- a/apps/admin/components/shared/TopBar.tsx
+++ b/apps/admin/components/shared/TopBar.tsx
@@ -23,11 +23,11 @@ function SearchTrigger() {
     <button
       className="hf-topbar-search"
       onClick={openPanel}
-      title={`Search or jump to... ${isMac ? "⌘K" : "Ctrl+K"}`}
-      aria-label="Open search"
+      title={`Search or ask anything... ${isMac ? "⌘K" : "Ctrl+K"}`}
+      aria-label="Open assistant"
     >
       <Search size={14} />
-      <span className="hf-topbar-search-label">Search...</span>
+      <span className="hf-topbar-search-label">Search or ask...</span>
       <kbd className="hf-topbar-kbd">{isMac ? "⌘K" : "⌃K"}</kbd>
     </button>
   );


### PR DESCRIPTION
## Summary
- Renames the TopBar trigger button from \`Search...\` to \`Search or ask...\` to reflect what clicking it actually does (opens the AI chat panel, which handles both keyword lookups via tool calls and natural-language Q&A)
- Updates tooltip and aria-label to match
- Mirrors the pattern Notion / Linear / Stripe adopted when adding AI to their command palettes

## Test plan
- [ ] Open any /x/ page → top bar shows \`Search or ask... ⌘K\`
- [ ] Click it → chat panel opens (existing behaviour)
- [ ] Hover → tooltip reads \`Search or ask anything... ⌘K\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)