### PR TITLE
chore(topbar): remove Search/Ask trigger button — redundant with ? overlay

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -2009,10 +2009,6 @@ html.light {
   padding: 0;
 }
 
-.hf-topbar-center {
-  flex-shrink: 0;
-}
-
 .hf-topbar-right {
   display: flex;
   align-items: center;
@@ -2041,48 +2037,6 @@ html.light {
 .hf-topbar-help:focus-visible {
   outline: 2px solid var(--accent-primary);
   outline-offset: 1px;
-}
-
-/* Search trigger — looks like a muted input, acts as a button */
-.hf-topbar-search {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  height: 32px;
-  padding: 0 12px;
-  border-radius: 8px;
-  border: 1px solid var(--border-default);
-  background: var(--surface-secondary);
-  color: var(--text-muted);
-  font-size: 13px;
-  cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
-  white-space: nowrap;
-  min-width: 200px;
-}
-.hf-topbar-search:hover {
-  border-color: var(--border-strong, var(--text-muted));
-  background: var(--surface-primary);
-}
-.hf-topbar-search:focus-visible {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 1px;
-}
-
-/* Keyboard shortcut hint badge */
-.hf-topbar-kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 20px;
-  padding: 0 5px;
-  border-radius: 4px;
-  border: 1px solid var(--border-default);
-  background: var(--surface-primary);
-  color: var(--text-tertiary);
-  font-size: 11px;
-  font-family: inherit;
-  line-height: 1;
 }
 
 /* Institution context chip */
@@ -2170,20 +2124,6 @@ html.light {
 }
 .hf-topbar-domain-scope-exit:hover {
   background: color-mix(in srgb, var(--status-info-text) 25%, transparent);
-}
-
-/* Compact search for narrow viewports (< 1024px) */
-@media (max-width: 1023px) {
-  .hf-topbar-search {
-    min-width: 0;
-    padding: 0 8px;
-    width: 32px;
-    justify-content: center;
-  }
-  .hf-topbar-search-label,
-  .hf-topbar-kbd {
-    display: none;
-  }
 }
 
 /* Hide institution + domain scope chips on narrow viewports */

--- a/apps/admin/components/shared/TopBar.tsx
+++ b/apps/admin/components/shared/TopBar.tsx
@@ -5,33 +5,12 @@ import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useMasquerade } from "@/contexts/MasqueradeContext";
 import { useDomainScope } from "@/contexts/DomainScopeContext";
-import { useChatContext } from "@/contexts/ChatContext";
 import { useBreadcrumbs } from "@/hooks/useBreadcrumbs";
 import { HierarchyBreadcrumb } from "./HierarchyBreadcrumb";
 import { UserAvatar } from "./UserAvatar";
 import { UserContextMenu } from "./UserContextMenu";
-import { VenetianMask, X, Search, Building2, HelpCircle } from "lucide-react";
+import { VenetianMask, X, Building2, HelpCircle } from "lucide-react";
 import { useHelpContext } from "@/contexts/HelpContext";
-
-// ── Search Trigger ───────────────────────────────────────
-
-function SearchTrigger() {
-  const { openPanel } = useChatContext();
-  const isMac = typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent);
-
-  return (
-    <button
-      className="hf-topbar-search"
-      onClick={openPanel}
-      title={`Search or ask anything... ${isMac ? "⌘K" : "Ctrl+K"}`}
-      aria-label="Open assistant"
-    >
-      <Search size={14} />
-      <span className="hf-topbar-search-label">Search or ask...</span>
-      <kbd className="hf-topbar-kbd">{isMac ? "⌘K" : "⌃K"}</kbd>
-    </button>
-  );
-}
 
 // ── Institution Chip ─────────────────────────────────────
 
@@ -116,12 +95,7 @@ export function TopBar() {
         <HierarchyBreadcrumb segments={breadcrumbs} />
       </div>
 
-      {/* Center: search trigger */}
-      <div className="hf-topbar-center">
-        <SearchTrigger />
-      </div>
-
-      {/* Right: institution + masquerade + avatar */}
+      {/* Right: help + institution + masquerade + avatar */}
       <div className="hf-topbar-right">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Removes the standalone \`Search or ask...\` trigger from TopBar
- Cmd+K still works for power users; \`?\` HelpOverlay surfaces it on-screen for everyone else
- 88 lines deleted (2 added): trigger component, center column, search CSS, mobile breakpoint media query

## Why
The Help Overlay (#686) lists Cmd+K as a global shortcut, and the on-screen \`?\` icon button next to the avatar makes Cmd+K discoverable. The dedicated search trigger duplicated discoverability.

## Test plan
- [ ] Cmd+K still opens the chat
- [ ] \`?\` opens the help overlay and shows \`⌘K  Open AI assistant / search\`
- [ ] TopBar layout — breadcrumbs on left, help+chips+avatar on right, no center column

🤖 Generated with [Claude Code](https://claude.com/claude-code)