### PR TITLE
chore(callers): rename 'Calls & Prompts' tab → 'Calls'

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -580,7 +580,7 @@ export default function CallerDetailPage() {
 
   const sections: { id: SectionId; label: string; icon: React.ReactNode; count?: number; special?: boolean; group: "history" | "caller" | "shared" | "action" }[] = [
     { id: "overview", label: "Overview", icon: <span aria-hidden>🧭</span>, group: "shared" },
-    { id: "calls-prompts", label: "Calls & Prompts", icon: <Phone size={13} />, count: data.counts.calls, group: "history" },
+    { id: "calls-prompts", label: "Calls", icon: <Phone size={13} />, count: data.counts.calls, group: "history" },
     { id: "tune", label: "Tune", icon: <SlidersHorizontal size={13} />, count: data.counts.prompts || undefined, group: "caller" },
     { id: "how", label: "Profile", icon: <User size={13} />, count: (data.counts.memories || 0) + (data.counts.observations || 0), group: "caller" },
     { id: "what", label: "Progress", icon: <Gauge size={13} />, count: (new Set(data.scores?.map((s: any) => s.parameterId)).size || 0) + (data.counts.callerTargets || 0) + (data.counts.measurements || 0), group: "shared" },

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -180,7 +180,7 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       },
       {
         id: "calls-prompts",
-        label: "Calls & Prompts",
+        label: "Calls",
         about: "Every call this learner has had, with the transcript and the composed prompt that was used for each.",
         whenToUse: "When you want to debug why the AI said what it said, or replay a session.",
       },
@@ -218,7 +218,7 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
     chords: [
       { keys: "O", action: "callback", callbackId: "tab:overview", label: "Overview tab" },
       { keys: "U", action: "callback", callbackId: "tab:uplift", label: "Uplift tab" },
-      { keys: "C", action: "callback", callbackId: "tab:calls-prompts", label: "Calls & Prompts tab" },
+      { keys: "C", action: "callback", callbackId: "tab:calls-prompts", label: "Calls tab" },
       { keys: "T", action: "callback", callbackId: "tab:tune", label: "Tune tab" },
       { keys: "W", action: "callback", callbackId: "tab:how", label: "How tab (hoW — H is reserved as a chord prefix)" },
       { keys: "A", action: "callback", callbackId: "tab:what", label: "What tab (whAt)" },


### PR DESCRIPTION
Cleaner, shorter label on Learner detail page. Tab id stays `calls-prompts` so URL `?tab=calls-prompts` and localStorage selection survive. Also updated page-help.ts so the Help overlay matches.

## Test plan
- [ ] /x/callers/<id> → tab strip shows 'Calls' not 'Calls & Prompts'
- [ ] Bookmarks with ?tab=calls-prompts still open the right tab
- [ ] ? overlay on /x/callers/<id> lists 'Calls' tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)