### PR TITLE
chore(wizard): SUPERADMIN must explicitly pick organisation + clearer label

### DIFF
--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -135,14 +135,14 @@ export function V5WizardWithSelector({
         <div className="v5-institution-bar">
           {showInstitutionSelector && (
             <div>
-              <label className="hf-text-xs hf-text-muted">Organisation</label>
+              <label className="hf-text-xs hf-text-muted">Build course for...</label>
               <FancySelect
                 value={selectedId}
                 onChange={setSelectedId}
                 options={instOptions}
                 searchable
                 loading={loading}
-                placeholder="Select organisation..."
+                placeholder="Pick an organisation..."
               />
             </div>
           )}

--- a/apps/admin/app/x/get-started-v5/page.tsx
+++ b/apps/admin/app/x/get-started-v5/page.tsx
@@ -27,6 +27,26 @@ export default async function GetStartedV5Page({
     return <V5WizardWithSelector defaultInstitution={null} userRole={user.role} defaultCourseId={courseIdParam} courses={[]} />;
   }
 
+  // SUPERADMIN is platform-scope — even when seeded with an institutionId
+  // (e.g. admin@test.com → Abacus Academy), force an explicit pick via the
+  // selector rather than silently scaffolding a course onto someone else's
+  // tenant. Other roles still get their assigned institution pre-loaded.
+  if (user.role === "SUPERADMIN") {
+    return <V5WizardWithSelector defaultInstitution={null} userRole={user.role} defaultCourseId={courseIdParam} courses={[]} />;
+  }
+
+  // TODO(institution-lock): non-SUPERADMIN users running the wizard must be
+  // hard-locked to their session.user.institutionId — they should never see
+  // the organisation selector, regardless of how many institutions they have
+  // access to via UserInstitution joins. Today the selector is hidden when
+  // V5WizardWithSelector sees `institutions.length < 2`, but that's a UX
+  // signal, not a security guard. The wizard accepts a selected id from the
+  // client and trusts it. Tighten by either:
+  //   (a) drop the institution selector entirely for non-SUPERADMIN, OR
+  //   (b) enforce institutionId === session.user.institutionId in the
+  //       create-course API for non-SUPERADMIN roles.
+  // Track via GitHub issue if you want it in the backlog.
+
   const institution = await prisma.institution.findUnique({
     where: { id: institutionId, isActive: true },
     select: {


### PR DESCRIPTION
## Summary
- **SUPERADMIN no longer pre-selects their seeded institution.** Forces an explicit pick via the selector, avoiding silent course creation in someone else's tenant (e.g. admin@test.com → Abacus Academy)
- **Renamed selector label** \`Organisation\` → \`Build course for...\` and placeholder \`Select organisation...\` → \`Pick an organisation...\` so the action is unambiguous
- **TODO(institution-lock) added** for the follow-up: non-SUPERADMIN users today have the selector hidden by UX (\`institutions.length < 2\`) but the client-sent id is still trusted by create-course APIs. Needs hardening: either drop the selector entirely for non-SUPERADMIN, or enforce \`institutionId === session.user.institutionId\` server-side

## Why localised in the wizard (not the seed)
Touching admin@test.com's seeded institutionId could regress any API that scopes queries by \`session.user.institutionId\` without a SUPERADMIN bypass. This fix is one conditional in \`page.tsx\` — the wizard already handles \`defaultInstitution: null\` correctly.

## Test plan
- [ ] Log in as admin@test.com → open /x/get-started-v5 → selector shows, no institution pre-filled
- [ ] Log in as a non-SUPERADMIN (teach@abacus.com) → wizard pre-loads their institution as before
- [ ] Selector label reads \`Build course for...\` with placeholder \`Pick an organisation...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)