### PR TITLE
fix(#702 follow-up): block client-side auto-pick of first institution for SUPERADMIN

### DIFF
--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -67,8 +67,11 @@ export function V5WizardWithSelector({
         if (cancelled) return;
         const list: InstitutionFromAPI[] = data.institutions ?? [];
         setInstitutions(list);
-        // If no default was set server-side, pick first from list
-        if (!selectedId && list.length > 0) setSelectedId(list[0].id);
+        // If no default was set server-side, pick first from list — but never
+        // for SUPERADMIN (#702 fix only worked server-side; the client auto-
+        // pick was silently restoring Abacus as the alphabetically-first
+        // tenant). SUPERADMIN must make an explicit choice.
+        if (!selectedId && list.length > 0 && !isSuperAdmin) setSelectedId(list[0].id);
       })
       .catch(() => {})
       .finally(() => { if (!cancelled) setLoading(false); });


### PR DESCRIPTION
Follow-up to #702. The server-side fix passed `defaultInstitution=null` but the wizard's client `useEffect` then auto-picked `institutions[0]` (alphabetically Abacus). One-line fix.

## Test plan
- [ ] Log in as admin@test.com → /x/get-started-v5 → selector reads 'Pick an organisation...' empty, no chat yet
- [ ] Pick an institution → chat initialises with that one
- [ ] Log in as non-SUPERADMIN → behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)