### PR TITLE
test+fix(epic-100): smoke-tier-1-3 follow-ups + test updates for #661 + #163-phase-2

### DIFF
--- a/apps/admin/__tests__/ui/curriculum-health-tabs-readonly.test.tsx
+++ b/apps/admin/__tests__/ui/curriculum-health-tabs-readonly.test.tsx
@@ -1,15 +1,21 @@
 /**
- * CurriculumHealthTabs — `readOnly` prop suppresses the two silent
- * auto-reconcile useEffects (issue #418).
+ * CurriculumHealthTabs — `readOnly` prop suppresses the silent
+ * auto-reconcile useEffect (issue #418).
  *
- * Today the component fires two background POSTs on mount whenever the
- * scorecard reports orphans:
- *   1. POST /api/curricula/:id/reconcile-orphans
- *   2. POST /api/courses/:id/reconcile-mcqs
+ * The component fires one background POST on mount whenever the
+ * scorecard reports outcomes-without-content:
+ *   POST /api/curricula/:id/reconcile-orphans
+ *
+ * (#163 Phase 2 moved the MCQ reconcile into `McqPanel` itself so it
+ * also fires for authored-modules courses that mount McqPanel
+ * standalone. McqPanel only renders here when activeTab='questions',
+ * which this test never switches to, so the MCQ reconcile is out of
+ * scope. McqPanel still respects its own `readOnly` prop — covered
+ * by McqPanel's own tests.)
  *
  * When the curriculum tab renders this component in preview mode (i.e.
  * the educator is peeking at the derived view on an authored-modules
- * course), those silent fires must not run — they'd mutate a curriculum
+ * course), the silent fire must not run — it'd mutate a curriculum
  * that isn't the active source of truth. This test holds that contract.
  */
 
@@ -83,7 +89,7 @@ describe("CurriculumHealthTabs — readOnly prop", () => {
     vi.restoreAllMocks();
   });
 
-  it("fires both silent reconciles on mount when readOnly is false", async () => {
+  it("fires the orphan-outcome reconcile on mount when readOnly is false", async () => {
     render(
       <CurriculumHealthTabs
         scorecard={scorecardWithOrphans()}
@@ -100,11 +106,10 @@ describe("CurriculumHealthTabs — readOnly prop", () => {
         (c) => String(c[0]),
       );
       expect(calls.some((u) => u.includes("/reconcile-orphans"))).toBe(true);
-      expect(calls.some((u) => u.includes("/reconcile-mcqs"))).toBe(true);
     });
   });
 
-  it("does NOT fire silent reconciles when readOnly is true", async () => {
+  it("does NOT fire the orphan-outcome reconcile when readOnly is true", async () => {
     render(
       <CurriculumHealthTabs
         scorecard={scorecardWithOrphans()}
@@ -116,13 +121,12 @@ describe("CurriculumHealthTabs — readOnly prop", () => {
       />,
     );
 
-    // Give effects a tick to run, then assert nothing matching either
+    // Give effects a tick to run, then assert nothing matching the
     // reconcile URL was POSTed.
     await new Promise((r) => setTimeout(r, 30));
     const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map(
       (c) => String(c[0]),
     );
     expect(calls.some((u) => u.includes("/reconcile-orphans"))).toBe(false);
-    expect(calls.some((u) => u.includes("/reconcile-mcqs"))).toBe(false);
   });
 });

--- a/apps/admin/scripts/smoke-tier-1-3.ts
+++ b/apps/admin/scripts/smoke-tier-1-3.ts
@@ -1,0 +1,391 @@
+/**
+ * Tier 1-3 invariant smoke check.
+ *
+ * Bundles the ad-hoc probes used during the 2026-05-23 Brynn / IELTS V1.0
+ * verification into one re-runnable command. Designed to run post-deploy
+ * (or on a cron) to catch any regression in:
+ *
+ *   - Audit counters (`scripts/audit-epic-100.ts`)
+ *   - Per-playbook invariants — exactly one course-scoped PlaybookSubject,
+ *     identity chain free of advisor leaks, all INSTRUCTION_CATEGORIES
+ *     assertions tagged `tutor_instruction`, content reachable via
+ *     PlaybookSource.
+ *   - Per-caller invariants — active ComposedPrompt uses `spec-comp-001`
+ *     (not an archetype slug), no advisor in inputs, `lo_mastery:` keys
+ *     in canonical slug-form, archetype-aware critical rule present.
+ *
+ * Usage:
+ *   npx tsx scripts/smoke-tier-1-3.ts
+ *   npx tsx scripts/smoke-tier-1-3.ts --playbook eb6bc79e --caller 4b5ecdc4
+ *   npx tsx scripts/smoke-tier-1-3.ts --playbook eb6bc79e,abc123 --caller xyz789
+ *   npx tsx scripts/smoke-tier-1-3.ts --json
+ *   npx tsx scripts/smoke-tier-1-3.ts --strict     # informational counters also fail
+ *
+ * Exit codes:
+ *   0 — all invariant checks passed
+ *   1 — at least one invariant failed
+ *   2 — could not run audit subprocess (audit is the foundation; without
+ *       it the per-playbook / per-caller checks are still meaningful but
+ *       the overall report is incomplete)
+ *
+ * If `--playbook` and `--caller` are both omitted, the script auto-picks:
+ *   - up to 5 most-recently-modified PUBLISHED playbooks
+ *   - up to 10 callers with an active ComposedPrompt
+ * That makes it useful as a default health check without needing fixture
+ * IDs. CI / cron should pass explicit IDs to keep noise constant.
+ *
+ * See:
+ *   docs/CHAIN-CONTRACTS.md (the invariants this guards)
+ *   scripts/audit-epic-100.ts (the per-counter source of truth)
+ *   .claude/rules/ai-to-db-guard.md
+ */
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { prisma } from "@/lib/prisma";
+import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
+
+type CheckStatus = "pass" | "fail" | "skip";
+interface Check {
+  scope: string;            // e.g. "audit", "playbook:eb6bc79e", "caller:4b5ecdc4"
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+}
+
+interface AuditCounter {
+  key: string;
+  story: string;
+  kind: "invariant" | "informational";
+  count: number;
+  target: number;
+  status: "pass" | "fail" | "info" | "skipped";
+  description: string;
+}
+
+interface CliFlags {
+  playbookIds: string[];
+  callerIds: string[];
+  json: boolean;
+  strict: boolean;
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = { playbookIds: [], callerIds: [], json: false, strict: false };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") flags.json = true;
+    else if (arg === "--strict") flags.strict = true;
+    else if (arg === "--playbook") flags.playbookIds.push(...(argv[++i] ?? "").split(",").filter(Boolean));
+    else if (arg === "--caller") flags.callerIds.push(...(argv[++i] ?? "").split(",").filter(Boolean));
+    else if (arg.startsWith("--playbook=")) flags.playbookIds.push(...arg.slice("--playbook=".length).split(",").filter(Boolean));
+    else if (arg.startsWith("--caller=")) flags.callerIds.push(...arg.slice("--caller=".length).split(",").filter(Boolean));
+  }
+  return flags;
+}
+
+// ── Section 1: audit counters via subprocess ──────────────────────────
+async function runAuditSection(strict: boolean): Promise<Check[]> {
+  const checks: Check[] = [];
+  try {
+    const scriptPath = path.resolve(__dirname, "audit-epic-100.ts");
+    const json = execSync(`npx tsx ${scriptPath} --json`, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    }).toString();
+    const parsed = JSON.parse(json) as { counters: AuditCounter[] };
+    for (const c of parsed.counters) {
+      const isFailure =
+        c.kind === "invariant"
+          ? c.count > c.target
+          : strict
+            ? c.count > c.target
+            : false;
+      checks.push({
+        scope: "audit",
+        name: `${c.story} ${c.key}`,
+        status: isFailure ? "fail" : "pass",
+        detail: `count=${c.count} target=${c.target} (${c.kind})`,
+      });
+    }
+  } catch (err: any) {
+    checks.push({
+      scope: "audit",
+      name: "audit-epic-100 subprocess",
+      status: "skip",
+      detail: `Could not run audit: ${err?.message?.slice(0, 200) ?? String(err)}`,
+    });
+  }
+  return checks;
+}
+
+// ── Section 2: per-playbook checks ────────────────────────────────────
+async function checkPlaybook(playbookId: string): Promise<Check[]> {
+  const checks: Check[] = [];
+  const scope = `playbook:${playbookId.slice(0, 8)}`;
+
+  const pb = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: {
+      id: true,
+      name: true,
+      domainId: true,
+      config: true,
+      subjects: { select: { subjectId: true, subject: { select: { slug: true, name: true } } } },
+      items: { select: { spec: { select: { slug: true, specRole: true, extendsAgent: true } } } },
+    },
+  });
+  if (!pb) {
+    checks.push({ scope, name: "exists", status: "fail", detail: "playbook not found" });
+    return checks;
+  }
+
+  // #607 — exactly one PlaybookSubject, course-scoped
+  const dom = await prisma.domain.findUnique({ where: { id: pb.domainId! }, select: { slug: true } });
+  const slugify = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "").replace(/^-|-$/g, "");
+  const expectedPrefix = `${dom?.slug ?? "?"}-${slugify(pb.name)}-`;
+  const courseScopedCount = pb.subjects.filter((ps) =>
+    ps.subject.slug.startsWith(expectedPrefix),
+  ).length;
+  checks.push({
+    scope,
+    name: "#607 PlaybookSubject count == 1",
+    status: pb.subjects.length === 1 ? "pass" : "fail",
+    detail: `found ${pb.subjects.length}: ${pb.subjects.map((s) => `"${s.subject.name}"`).join(", ")}`,
+  });
+  if (pb.subjects.length === 1 && courseScopedCount === 0) {
+    // Non-course-scoped sole subject is OK if it's a legacy course; just
+    // surface it as info, not a fail. The slug heuristic differs from the
+    // wizard's own slugify (npm slugify drops periods entirely while our
+    // simple regex maps non-alnum → ""), so equality isn't guaranteed.
+    checks.push({
+      scope,
+      name: "#607 sole subject is course-scoped (informational)",
+      status: "pass",
+      detail: `sole subject slug "${pb.subjects[0].subject.slug}" doesn't start with "${expectedPrefix}" — likely a slugifier-style mismatch, not a true violation`,
+    });
+  }
+
+  // #608 — identity chain does not include the advisor archetype
+  const identityItem = pb.items.find((i) => i.spec?.specRole === "IDENTITY");
+  const extendsAdvisor = identityItem?.spec?.extendsAgent?.toUpperCase().includes("ADVISOR-001");
+  checks.push({
+    scope,
+    name: "#608 identity does not extend ADVISOR-001",
+    status: extendsAdvisor ? "fail" : "pass",
+    detail: `identity=${identityItem?.spec?.slug ?? "(none)"}, extendsAgent=${identityItem?.spec?.extendsAgent ?? "(none)"}`,
+  });
+
+  // Content reachability via PlaybookSource (the canonical content boundary)
+  const ps = await prisma.playbookSource.findMany({
+    where: { playbookId },
+    select: { sourceId: true },
+  });
+  checks.push({
+    scope,
+    name: "PlaybookSource rows present (content boundary)",
+    status: ps.length > 0 ? "pass" : "fail",
+    detail: `${ps.length} sources linked`,
+  });
+  const sourceIds = ps.map((r) => r.sourceId);
+
+  // #605 — every INSTRUCTION_CATEGORY assertion is tagged tutor_instruction
+  if (sourceIds.length > 0) {
+    const bad = await prisma.contentAssertion.count({
+      where: {
+        sourceId: { in: sourceIds },
+        category: { in: [...INSTRUCTION_CATEGORIES] },
+        NOT: { teachMethod: "tutor_instruction" },
+      },
+    });
+    const total = await prisma.contentAssertion.count({
+      where: {
+        sourceId: { in: sourceIds },
+        category: { in: [...INSTRUCTION_CATEGORIES] },
+      },
+    });
+    checks.push({
+      scope,
+      name: "#605 INSTRUCTION_CATEGORIES all tutor_instruction",
+      status: bad === 0 ? "pass" : "fail",
+      detail: `${total - bad}/${total} correctly tagged; ${bad} violations`,
+    });
+  }
+
+  return checks;
+}
+
+// ── Section 3: per-caller checks ──────────────────────────────────────
+async function checkCaller(callerId: string): Promise<Check[]> {
+  const checks: Check[] = [];
+  const scope = `caller:${callerId.slice(0, 8)}`;
+
+  const cp = await prisma.composedPrompt.findFirst({
+    where: { callerId, status: "active" },
+    orderBy: { composedAt: "desc" },
+    select: { id: true, prompt: true, inputs: true, composedAt: true, playbookId: true },
+  });
+  if (!cp) {
+    checks.push({ scope, name: "active ComposedPrompt", status: "skip", detail: "no active prompt" });
+    return checks;
+  }
+
+  const inputs = cp.inputs as { specUsed?: string; identitySpec?: string } | null;
+  const inputsText = JSON.stringify(cp.inputs);
+
+  // loadComposeConfig fix — specUsed must be the real COMP spec, never an archetype
+  const archetypeSpecUsed = (inputs?.specUsed ?? "").toLowerCase().match(
+    /^(spec-(advisor|tut|coach|companion|guide|mentor|facilitator)-001|(advisor|tut|coach|companion|guide|mentor|facilitator)-001)$/,
+  );
+  checks.push({
+    scope,
+    name: "loadComposeConfig: specUsed is not an archetype slug",
+    status: archetypeSpecUsed ? "fail" : "pass",
+    detail: `specUsed="${inputs?.specUsed ?? "(missing)"}"`,
+  });
+
+  // #608 — inputs JSON does not contain advisor archetype string
+  checks.push({
+    scope,
+    name: "#608 inputs JSON has no spec-advisor-001",
+    status: inputsText.includes("spec-advisor-001") ? "fail" : "pass",
+    detail: `prompt id=${cp.id.slice(0, 8)} composedAt=${cp.composedAt.toISOString()}`,
+  });
+
+  // #608 — rendered prompt does not contain the advisor role string
+  const lower = cp.prompt.toLowerCase();
+  checks.push({
+    scope,
+    name: "#608 rendered prompt has no evidence-based-advisor text",
+    status: lower.includes("evidence-based advisor") ? "fail" : "pass",
+  });
+  checks.push({
+    scope,
+    name: "#608 rendered prompt has no ADVISOR-001 literal",
+    status: cp.prompt.includes("ADVISOR-001") ? "fail" : "pass",
+  });
+
+  // #607 — exactly one CONTENT AUTHORITY block
+  const caBlocks = (cp.prompt.match(/CONTENT AUTHORITY/g) ?? []).length;
+  checks.push({
+    scope,
+    name: "#607 single CONTENT AUTHORITY block",
+    status: caBlocks === 1 ? "pass" : caBlocks === 0 ? "skip" : "fail",
+    detail: `${caBlocks} blocks`,
+  });
+
+  // #604 — critical rules contain the archetype-aware RETURNING_CALLER rule
+  // Practice mode → warm-up; recall/comprehension/syllabus → ALWAYS review.
+  // We can't reliably know the mode from the caller alone, so just assert
+  // EXACTLY ONE of the two variants is present (never both, never neither).
+  const hasWarmUp = lower.includes("warm-up attempt");
+  const hasReview = lower.includes("always review before new material");
+  checks.push({
+    scope,
+    name: "#604 exactly one RETURNING_CALLER variant present",
+    status: hasWarmUp !== hasReview ? "pass" : "fail",
+    detail: `warm-up=${hasWarmUp} reviewFirst=${hasReview}`,
+  });
+
+  // #611 — all active lo_mastery keys are slug-form
+  const ca = await prisma.callerAttribute.findMany({
+    where: { callerId, key: { contains: ":lo_mastery:" }, validUntil: null },
+    select: { key: true },
+  });
+  let slug = 0;
+  let name = 0;
+  for (const a of ca) {
+    const suffix = a.key.split(":lo_mastery:")[1] ?? "";
+    const moduleToken = suffix.split(":")[0] ?? "";
+    if (/[A-Z ]/.test(moduleToken)) name++;
+    else slug++;
+  }
+  checks.push({
+    scope,
+    name: "#611 lo_mastery keys all slug-form",
+    status: name === 0 ? "pass" : "fail",
+    detail: `${slug} slug-form, ${name} legacy name-form`,
+  });
+
+  return checks;
+}
+
+// ── Auto-pick fixtures when no explicit IDs given ─────────────────────
+async function autoPickPlaybooks(): Promise<string[]> {
+  const rows = await prisma.playbook.findMany({
+    where: { status: "PUBLISHED" },
+    orderBy: { updatedAt: "desc" },
+    take: 5,
+    select: { id: true },
+  });
+  return rows.map((r) => r.id);
+}
+
+async function autoPickCallers(): Promise<string[]> {
+  const rows = await prisma.composedPrompt.findMany({
+    where: { status: "active" },
+    orderBy: { composedAt: "desc" },
+    take: 10,
+    distinct: ["callerId"],
+    select: { callerId: true },
+  });
+  return rows.map((r) => r.callerId);
+}
+
+// ── Output ────────────────────────────────────────────────────────────
+function formatHuman(checks: Check[]): string {
+  const lines: string[] = ["[smoke] Tier 1-3 invariant check"];
+  let pass = 0;
+  let fail = 0;
+  let skip = 0;
+  const byScope = new Map<string, Check[]>();
+  for (const c of checks) {
+    if (!byScope.has(c.scope)) byScope.set(c.scope, []);
+    byScope.get(c.scope)!.push(c);
+  }
+  for (const [scope, scopeChecks] of byScope) {
+    lines.push(`  ── ${scope} ──`);
+    for (const c of scopeChecks) {
+      const icon = c.status === "pass" ? "✓" : c.status === "fail" ? "✗" : "?";
+      const line = `    ${icon} ${c.name}${c.detail ? "  — " + c.detail : ""}`;
+      lines.push(line);
+      if (c.status === "pass") pass++;
+      else if (c.status === "fail") fail++;
+      else skip++;
+    }
+  }
+  lines.push("");
+  lines.push(`[smoke] ${pass} ✓  ${fail} ✗  ${skip} skipped`);
+  if (fail > 0) lines.push(`[smoke] FAILED — ${fail} invariant breach(es). See above.`);
+  else lines.push(`[smoke] All invariants holding.`);
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv);
+  const checks: Check[] = [];
+
+  checks.push(...(await runAuditSection(flags.strict)));
+
+  const playbookIds =
+    flags.playbookIds.length > 0 ? flags.playbookIds : await autoPickPlaybooks();
+  const callerIds = flags.callerIds.length > 0 ? flags.callerIds : await autoPickCallers();
+
+  for (const id of playbookIds) checks.push(...(await checkPlaybook(id)));
+  for (const id of callerIds) checks.push(...(await checkCaller(id)));
+
+  const failures = checks.filter((c) => c.status === "fail");
+
+  if (flags.json) {
+    console.log(JSON.stringify({ checks, summary: { pass: checks.filter((c) => c.status === "pass").length, fail: failures.length, skip: checks.filter((c) => c.status === "skip").length } }, null, 2));
+  } else {
+    console.log(formatHuman(checks));
+  }
+
+  await prisma.$disconnect();
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("[smoke] uncaught error:", err);
+  process.exit(2);
+});

--- a/apps/admin/scripts/smoke-tier-1-3.ts
+++ b/apps/admin/scripts/smoke-tier-1-3.ts
@@ -39,7 +39,7 @@
  *   scripts/audit-epic-100.ts (the per-counter source of truth)
  *   .claude/rules/ai-to-db-guard.md
  */
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { prisma } from "@/lib/prisma";
 import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
@@ -88,11 +88,22 @@ async function runAuditSection(strict: boolean): Promise<Check[]> {
   const checks: Check[] = [];
   try {
     const scriptPath = path.resolve(__dirname, "audit-epic-100.ts");
-    const json = execSync(`npx tsx ${scriptPath} --json`, {
+    // audit-epic-100 exits non-zero when invariants fail; that's expected
+    // signal, not "could not run". Use spawnSync so we always get stdout.
+    const result = spawnSync("npx", ["tsx", scriptPath, "--json"], {
       stdio: ["ignore", "pipe", "pipe"],
       env: process.env,
-    }).toString();
-    const parsed = JSON.parse(json) as { counters: AuditCounter[] };
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    if (result.error) throw result.error;
+    const stdout = result.stdout ?? "";
+    if (!stdout.trim()) {
+      throw new Error(
+        `audit produced no stdout (exit=${result.status}, stderr=${(result.stderr || "").slice(0, 200)})`,
+      );
+    }
+    const parsed = JSON.parse(stdout) as { counters: AuditCounter[] };
     for (const c of parsed.counters) {
       const isFailure =
         c.kind === "invariant"

--- a/apps/admin/tests/api/chat-tuning-update-target.test.ts
+++ b/apps/admin/tests/api/chat-tuning-update-target.test.ts
@@ -49,6 +49,7 @@ describe("update_behavior_target chat tool handler", () => {
     const raw = await executeAdminTool(
       "update_behavior_target",
       {
+        scope: "PLAYBOOK",
         playbook_id: "pb-1",
         parameter_id: "BEH-WARMTH",
         target_value: 0.4,
@@ -69,7 +70,7 @@ describe("update_behavior_target chat tool handler", () => {
         playbookId: "pb-1",
         scope: "PLAYBOOK",
         targetValue: 0.4,
-        source: "MANUAL",
+        source: "TUNING_CHAT",
       }),
     });
   });
@@ -78,6 +79,7 @@ describe("update_behavior_target chat tool handler", () => {
     const raw = await executeAdminTool(
       "update_behavior_target",
       {
+        scope: "PLAYBOOK",
         playbook_id: "pb-1",
         parameter_id: "BEH-MADE-UP",
         target_value: 0.5,
@@ -95,6 +97,7 @@ describe("update_behavior_target chat tool handler", () => {
     await executeAdminTool(
       "update_behavior_target",
       {
+        scope: "PLAYBOOK",
         playbook_id: "pb-1",
         parameter_id: "BEH-WARMTH",
         target_value: 1.7,
@@ -114,6 +117,7 @@ describe("update_behavior_target chat tool handler", () => {
     const raw = await executeAdminTool(
       "update_behavior_target",
       {
+        scope: "PLAYBOOK",
         playbook_id: "pb-1",
         parameter_id: "BEH-WARMTH",
         target_value: null,
@@ -136,6 +140,7 @@ describe("update_behavior_target chat tool handler", () => {
     const raw = await executeAdminTool(
       "update_behavior_target",
       {
+        scope: "PLAYBOOK",
         playbook_id: "pb-missing",
         parameter_id: "BEH-WARMTH",
         target_value: 0.5,
@@ -152,14 +157,14 @@ describe("update_behavior_target chat tool handler", () => {
   it("requires playbook_id and parameter_id strings", async () => {
     const raw1 = await executeAdminTool(
       "update_behavior_target",
-      { playbook_id: "", parameter_id: "BEH-WARMTH", target_value: 0.5, reason: "x" },
+      { scope: "PLAYBOOK", playbook_id: "", parameter_id: "BEH-WARMTH", target_value: 0.5, reason: "x" },
       "OPERATOR",
     );
     expect(JSON.parse(raw1).error).toContain("playbook_id");
 
     const raw2 = await executeAdminTool(
       "update_behavior_target",
-      { playbook_id: "pb-1", parameter_id: "", target_value: 0.5, reason: "x" },
+      { scope: "PLAYBOOK", playbook_id: "pb-1", parameter_id: "", target_value: 0.5, reason: "x" },
       "OPERATOR",
     );
     expect(JSON.parse(raw2).error).toContain("parameter_id");
@@ -171,6 +176,7 @@ describe("update_behavior_target chat tool handler", () => {
     const raw = await executeAdminTool(
       "update_behavior_target",
       {
+        scope: "PLAYBOOK",
         playbook_id: "pb-1",
         parameter_id: "BEH-WARMTH",
         target_value: "high",
@@ -186,6 +192,7 @@ describe("update_behavior_target chat tool handler", () => {
     const raw = await executeAdminTool(
       "update_behavior_target",
       {
+        scope: "PLAYBOOK",
         playbook_id: "pb-1",
         parameter_id: "BEH-WARMTH",
         target_value: 0.5,

--- a/apps/admin/tests/lib/config.test.ts
+++ b/apps/admin/tests/lib/config.test.ts
@@ -47,7 +47,12 @@ describe("config.specs — canonical spec slugs", () => {
 
   it("has correct default for compose", () => {
     vi.stubEnv("COMPOSE_SPEC_SLUG", "");
-    expect(config.specs.compose).toBe("system-compose-next-prompt");
+    // PR #682 (2026-05-23): default changed from the legacy
+    // "system-compose-next-prompt" to "spec-comp-001". The legacy slug
+    // had no matching spec in the DB and was the trigger for the
+    // loadComposeConfig fallback that occasionally landed on
+    // spec-advisor-001 (the #608 leak root cause).
+    expect(config.specs.compose).toBe("spec-comp-001");
   });
 
   it("has correct default for voicePattern", () => {


### PR DESCRIPTION
Recovered work from local branch \`feat/smoke-tier-1-3-harness\` — three commits that were authored after #694 merged and never got their own PR.

## Commits

| SHA | Message |
|---|---|
| 4fcdc902 | fix(epic-100): smoke captures audit stdout when invariants fail |
| 15b5ef07 | test(epic-100): config.test asserts new COMPOSE_SPEC_SLUG default |
| cff78a73 | test: update chat-tuning + curriculum-health tests for #661 + #163-phase-2 |

Note: \`47ed8c2b\` (smoke-tier-1-3.ts itself) is already on main as #694 — git will skip it.

## Why now
Audit of stale local branches before deploying to DEV. These commits are believed to unblock the failing tour-manifest + terminology preflight tests (which appeared after the sidebar restructure + #661 cmdk-tuning landed on main without these companion test updates).

## Test plan
- [ ] \`npx vitest run tests/lib/terminology.test.ts\` passes
- [ ] \`npx vitest run tests/ui/tour-manifest-binding.test.ts\` passes
- [ ] \`npx vitest run tests/api/chat-tuning-update-target.test.ts\` passes
- [ ] No regressions in epic-100 smoke (\`npx tsx scripts/smoke-tier-1-3.ts\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)