### PR TITLE
fix(tours): restore manifest bindings after sidebar prune (#7f49c460 fallout)

### DIFF
--- a/apps/admin/lib/sidebar/tour-anchors.json
+++ b/apps/admin/lib/sidebar/tour-anchors.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "_tour-anchors",
+    "title": "Tour Anchors (not rendered)",
+    "items": [
+      { "id": "manage-callers", "href": "/x/callers", "label": "Callers", "icon": "User", "roleVariants": { "EDUCATOR": { "href": "/x/educator/students" } } },
+      { "id": "manage-cohorts", "href": "/x/cohorts", "label": "Classrooms", "icon": "School", "roleVariants": { "EDUCATOR": { "href": "/x/educator/classrooms" } } },
+      { "id": "domains", "href": "/x/domains", "label": "Domains", "icon": "Globe" },
+      { "id": "playbooks", "href": "/x/playbooks", "label": "Playbooks", "icon": "BookOpen" },
+      { "id": "subjects", "href": "/x/subjects", "label": "Subjects", "icon": "Library" },
+      { "id": "ai-config", "href": "/x/ai-config", "label": "AI Config", "icon": "Bot" },
+      { "id": "team", "href": "/x/users", "label": "Team", "icon": "Users" },
+      { "id": "edu-try", "href": "/x/educator/try", "label": "Try It", "icon": "PlayCircle" },
+      { "id": "edu-reports", "href": "/x/educator/reports", "label": "Reports", "icon": "TrendingUp" },
+      { "id": "stu-stuff", "href": "/x/student/stuff", "label": "Dashboard", "icon": "Backpack" },
+      { "id": "stu-progress", "href": "/x/student/progress", "label": "Progress", "icon": "TrendingUp" },
+      { "id": "stu-calls", "href": "/x/student/calls", "label": "Sessions", "icon": "Phone" },
+      { "id": "stu-teacher", "href": "/x/student/teacher", "label": "Mentor", "icon": "GraduationCap" },
+      { "id": "sim", "href": "/x/sim", "label": "Learn", "icon": "MessageCircle" },
+      { "id": "analytics", "href": "/x/analytics", "label": "Analytics", "icon": "TrendingUp" }
+    ]
+  }
+]

--- a/apps/admin/lib/tours/manifest-resolver.ts
+++ b/apps/admin/lib/tours/manifest-resolver.ts
@@ -4,9 +4,17 @@
  * Resolves stable manifest item IDs to current href/label/icon values.
  * Tours reference item IDs instead of hardcoding hrefs — when the sidebar
  * manifest changes, tours follow automatically.
+ *
+ * Sources, merged in order (sidebar wins on id collision):
+ *   1. lib/sidebar/sidebar-manifest.json — items rendered in the visible
+ *      sidebar
+ *   2. lib/sidebar/tour-anchors.json — items the tours reference but the
+ *      simplified sidebar (#7f49c460) no longer renders. Keeps tours
+ *      working without re-polluting the visible nav.
  */
 
 import manifest from "@/lib/sidebar/sidebar-manifest.json";
+import tourAnchors from "@/lib/sidebar/tour-anchors.json";
 
 interface ManifestItemInfo {
   id: string;
@@ -24,23 +32,29 @@ export interface ResolvedItem {
   sectionId: string;
 }
 
-// Build lookup map once at module load
+// Build lookup map once at module load. Sidebar manifest first so its
+// entries take precedence if a tour-anchor id collides.
 const ITEM_MAP = new Map<string, ManifestItemInfo>();
 
-for (const section of manifest) {
-  for (const item of section.items) {
-    if ((item as any).id) {
-      ITEM_MAP.set((item as any).id, {
-        id: (item as any).id,
+function indexSections(sections: typeof manifest | typeof tourAnchors): void {
+  for (const section of sections) {
+    for (const item of section.items) {
+      const itemId = (item as { id?: string }).id;
+      if (!itemId || ITEM_MAP.has(itemId)) continue;
+      ITEM_MAP.set(itemId, {
+        id: itemId,
         href: item.href,
         label: item.label,
-        icon: item.icon,
+        icon: (item as { icon?: string }).icon,
         sectionId: section.id,
-        roleVariants: (item as any).roleVariants,
+        roleVariants: (item as { roleVariants?: ManifestItemInfo["roleVariants"] }).roleVariants,
       });
     }
   }
 }
+
+indexSections(manifest);
+indexSections(tourAnchors);
 
 /**
  * Resolve a manifest item ID to its current info.


### PR DESCRIPTION
## Problem
#7f49c460 simplified the sidebar to 6 items in one section. The tours module still references 15+ items (manage-cohorts, domains, playbooks, sim, analytics, edu-try, stu-progress, …) — those lookups now return null. Result: 3 of 4 tour-manifest-binding tests fail, and the educator/admin/student tours silently break at runtime.

## Fix
- New file \`lib/sidebar/tour-anchors.json\` — non-rendering item registry with the 15 items the tours still need, hrefs intact, EDUCATOR roleVariant preserved on manage-cohorts.
- \`manifest-resolver.ts\` now indexes both \`sidebar-manifest.json\` and \`tour-anchors.json\`. Sidebar wins on id collision.
- \`SimpleSidebarNav.tsx\` untouched → visible sidebar shape unchanged.

## Test plan
- [x] \`npx vitest run tests/lib/tour-manifest-binding.test.ts\` — 4/4 pass
- [ ] /x/educator → start educator tour → "Manage cohorts" step navigates correctly
- [ ] Visible sidebar still shows only the 6 items from #7f49c460

🤖 Generated with [Claude Code](https://claude.com/claude-code)