### PR TITLE
feat(callers): Tune-tab Re-prompt button + URL-sync active tab

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -98,9 +98,21 @@ export default function CallerDetailPage() {
   const setActiveSection = (id: SectionId) => {
     _setActiveSection(id);
     try { window.localStorage.setItem(lastTabKey, id); } catch {}
+    // Mirror the active tab to the URL so reload restores it. Without
+    // this the URL's stale ?tab= wins over localStorage on reload and the
+    // user gets bounced back to whichever tab they originally landed on.
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("tab") !== id) {
+        params.set("tab", id);
+        router.replace(`?${params.toString()}`, { scroll: false });
+      }
+    }
   };
   const [simChatMounted, setSimChatMounted] = useState(initialTab === "ai-call");
   const [callSession, setCallSession] = useState(0);
+  const [rePrompting, setRePrompting] = useState(false);
+  const [rePromptError, setRePromptError] = useState<string | null>(null);
   // #396: parent-owned "is a call live?" flag so the SimStateBreadcrumb pill
   // reads "(Active)" while the user is mid-call instead of always "(Pre-call)".
   const [isCallActive, setIsCallActive] = useState(false);
@@ -1079,6 +1091,53 @@ export default function CallerDetailPage() {
             </div>
           ) : (
             <>
+              <div className="cdp-tune-tab-actions">
+                <button
+                  type="button"
+                  className="hf-btn hf-btn-secondary"
+                  disabled={rePrompting}
+                  onClick={async () => {
+                    setRePrompting(true);
+                    try {
+                      // Anchor the new prompt under the latest call so it
+                      // appears as a sibling on the Calls tab (per the
+                      // #642 grouping in PromptTimelineRows). Standalone
+                      // re-composes group on their own at the top.
+                      const latestCallId = (data.calls ?? [])
+                        .slice()
+                        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]?.id;
+                      const body: Record<string, unknown> = { triggerType: "manual" };
+                      if (latestCallId) body.triggerCallId = latestCallId;
+                      const res = await fetch(`/api/callers/${callerId}/compose-prompt`, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify(body),
+                      });
+                      if (!res.ok) {
+                        const data = await res.json().catch(() => ({}));
+                        setRePromptError(data?.error || `Re-prompt failed (HTTP ${res.status})`);
+                      } else {
+                        setRePromptError(null);
+                        fetchPrompts();
+                      }
+                    } catch (e) {
+                      setRePromptError(e instanceof Error ? e.message : "Re-prompt failed");
+                    } finally {
+                      setRePrompting(false);
+                    }
+                  }}
+                >
+                  {rePrompting ? "Re-prompting..." : "Re-prompt now"}
+                </button>
+                <span className="hf-text-xs hf-text-muted hf-ml-md">
+                  {(data.calls ?? []).length > 0
+                    ? "New prompt will appear as a sibling under the latest call."
+                    : "New prompt will appear as standalone (no call yet)."}
+                </span>
+                {rePromptError && (
+                  <span className="hf-text-xs hf-ml-md" style={{ color: "var(--status-error-text)" }}>{rePromptError}</span>
+                )}
+              </div>
               <PromptTimelineRows
                 prompts={composedPrompts}
                 calls={(data.calls ?? []) as never}

--- a/apps/admin/components/callers/caller-detail-page.css
+++ b/apps/admin/components/callers/caller-detail-page.css
@@ -49,6 +49,17 @@
   padding-top: 16px;
 }
 
+/* Re-prompt action row above the timeline */
+.cdp-tune-tab-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+}
+
 /* ── Collapsible prompt preview inside tuning panel ── */
 .cdp-prompt-collapse {
   border-bottom: 1px solid var(--border-default);


### PR DESCRIPTION
Two small UX wins on /x/callers/[callerId].

## 1. Re-prompt button on Tune tab
Surfaces the recompose action right next to the tuner. Anchors the new prompt under the latest call (triggerCallId) so the new prompt shows up as a SIBLING under that call group on both the Tune tab AND the Calls & Prompts tab (per #642 grouping). Disabled while in-flight, inline error surface.

## 2. URL-sync active tab (fix)
`setActiveSection` now also writes `?tab=<id>` to the URL. Previously, the stale URL won on reload and bounced the user back to whichever tab they originally landed on (or the 'what' default). Already the pattern on /x/courses/[courseId].

## Bonus: WARMTH-shadowing investigation
Caller 3c4dd6a5 (Diego) has a CallerTarget BEH-WARMTH=0.7. That LEARNER override wins over the PLAYBOOK BehaviorTarget changes per `transforms/targets.ts:212` merge logic. Filing a follow-up issue to surface scope-shadowing warnings in the Tune UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)