### PR TITLE
feat(callers): per-row 'Re-prompt' button replaces #709's header bar

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -111,8 +111,6 @@ export default function CallerDetailPage() {
   };
   const [simChatMounted, setSimChatMounted] = useState(initialTab === "ai-call");
   const [callSession, setCallSession] = useState(0);
-  const [rePrompting, setRePrompting] = useState(false);
-  const [rePromptError, setRePromptError] = useState<string | null>(null);
   // #396: parent-owned "is a call live?" flag so the SimStateBreadcrumb pill
   // reads "(Active)" while the user is mid-call instead of always "(Pre-call)".
   const [isCallActive, setIsCallActive] = useState(false);
@@ -1091,53 +1089,6 @@ export default function CallerDetailPage() {
             </div>
           ) : (
             <>
-              <div className="cdp-tune-tab-actions">
-                <button
-                  type="button"
-                  className="hf-btn hf-btn-secondary"
-                  disabled={rePrompting}
-                  onClick={async () => {
-                    setRePrompting(true);
-                    try {
-                      // Anchor the new prompt under the latest call so it
-                      // appears as a sibling on the Calls tab (per the
-                      // #642 grouping in PromptTimelineRows). Standalone
-                      // re-composes group on their own at the top.
-                      const latestCallId = (data.calls ?? [])
-                        .slice()
-                        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]?.id;
-                      const body: Record<string, unknown> = { triggerType: "manual" };
-                      if (latestCallId) body.triggerCallId = latestCallId;
-                      const res = await fetch(`/api/callers/${callerId}/compose-prompt`, {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify(body),
-                      });
-                      if (!res.ok) {
-                        const data = await res.json().catch(() => ({}));
-                        setRePromptError(data?.error || `Re-prompt failed (HTTP ${res.status})`);
-                      } else {
-                        setRePromptError(null);
-                        fetchPrompts();
-                      }
-                    } catch (e) {
-                      setRePromptError(e instanceof Error ? e.message : "Re-prompt failed");
-                    } finally {
-                      setRePrompting(false);
-                    }
-                  }}
-                >
-                  {rePrompting ? "Re-prompting..." : "Re-prompt now"}
-                </button>
-                <span className="hf-text-xs hf-text-muted hf-ml-md">
-                  {(data.calls ?? []).length > 0
-                    ? "New prompt will appear as a sibling under the latest call."
-                    : "New prompt will appear as standalone (no call yet)."}
-                </span>
-                {rePromptError && (
-                  <span className="hf-text-xs hf-ml-md" style={{ color: "var(--status-error-text)" }}>{rePromptError}</span>
-                )}
-              </div>
               <PromptTimelineRows
                 prompts={composedPrompts}
                 calls={(data.calls ?? []) as never}

--- a/apps/admin/components/callers/caller-detail-page.css
+++ b/apps/admin/components/callers/caller-detail-page.css
@@ -49,17 +49,6 @@
   padding-top: 16px;
 }
 
-/* Re-prompt action row above the timeline */
-.cdp-tune-tab-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 8px 12px;
-  background: var(--surface-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
-}
-
 /* ── Collapsible prompt preview inside tuning panel ── */
 .cdp-prompt-collapse {
   border-bottom: 1px solid var(--border-default);

--- a/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTimelineRows.tsx
@@ -556,6 +556,7 @@ export function PromptTimelineRows({
   calls,
   callScores,
   loading,
+  onRefresh,
   callerId,
 }: PromptTimelineRowsProps) {
   const groups = useMemo(() => groupPrompts(prompts), [prompts]);
@@ -629,6 +630,7 @@ export function PromptTimelineRows({
   });
   const [evalLoadingIds, setEvalLoadingIds] = useState<Set<string>>(new Set());
   const evalAbortRef = useRef<Map<string, AbortController>>(new Map());
+  const [rePromptingIds, setRePromptingIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     const refSnapshot = evalAbortRef.current;
@@ -678,6 +680,40 @@ export function PromptTimelineRows({
       });
     }
   }, [callerId]);
+
+  // Re-prompt a specific row → produces a NEW ComposedPrompt that slots in
+  // as a sibling under the same call group (per the groupPrompts logic).
+  // Lets the user A/B the current prompt against one composed with newer
+  // tuning values without losing the source for comparison.
+  const runRePrompt = useCallback(
+    async (sourcePrompt: ComposedPrompt) => {
+      setRePromptingIds((prev) => new Set(prev).add(sourcePrompt.id));
+      try {
+        const body: Record<string, unknown> = { triggerType: "manual" };
+        if (sourcePrompt.triggerCallId) body.triggerCallId = sourcePrompt.triggerCallId;
+        const res = await fetch(`/api/callers/${callerId}/compose-prompt`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data?.ok === false) {
+          console.error("[prompt-timeline] re-prompt failed:", data?.error || res.statusText);
+        } else if (onRefresh) {
+          onRefresh();
+        }
+      } catch (err) {
+        console.error("[prompt-timeline] re-prompt error:", err);
+      } finally {
+        setRePromptingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(sourcePrompt.id);
+          return next;
+        });
+      }
+    },
+    [callerId, onRefresh],
+  );
 
   if (loading) {
     return <div className="hf-empty hf-text-muted">Loading prompts…</div>;
@@ -955,6 +991,21 @@ export function PromptTimelineRows({
                             : ev
                               ? `${Math.round(ev.overall.score || 0)}/100 · re-eval`
                               : "eval"}
+                        </button>
+                        {/* Re-prompt: compose a new prompt with the latest tuning
+                            values, anchored to this prompt's call so the new row
+                            appears as a sibling in the same group. */}
+                        <button
+                          type="button"
+                          className="ptr-row-action"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (!rePromptingIds.has(p.id)) runRePrompt(p);
+                          }}
+                          disabled={rePromptingIds.has(p.id)}
+                          title="Re-compose this prompt with current tuning values — appears as a sibling under the same call"
+                        >
+                          {rePromptingIds.has(p.id) ? "re-prompting…" : "re-prompt"}
                         </button>
                       </span>
                       {isPromptOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}


### PR DESCRIPTION
Follow-up to #709. The header button always anchored to the latest call, but the real workflow is 'compare THIS prompt to one composed with current tuning'. Moved per-row.

Each prompt row now has both an `eval` and `re-prompt` button. Re-prompt POSTs with that row's `triggerCallId` → new prompt appears as a sibling under the same call group → diff visible.

Cleanup: removed the cdp-tune-tab-actions header div and the now-unused rePrompting / rePromptError state in CallerDetailPage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)