### PR TITLE
fix(#713): close 3 of 4 AI-tuning bugs (cross-learner leak + educator overrides + learner-level visibility)

### DIFF
--- a/apps/admin/lib/chat/tuning-system-prompt.ts
+++ b/apps/admin/lib/chat/tuning-system-prompt.ts
@@ -249,6 +249,40 @@ function buildActiveScopeBlock(
 }
 
 /** Format the active entity context for the TUNING prompt. */
+/**
+ * #713 bug 1 — surface LEARNER-level overrides so the AI doesn't claim
+ * "Diego has no learner-level setting" when his CallerTarget says
+ * otherwise. Each row is labelled MANUAL_OVERRIDE (educator set) or
+ * ADAPTED (system set via ADAPT/AGGREGATE) so the AI can warn the
+ * educator before stomping on an ADAPT result.
+ */
+function buildLearnerOverridesBlock(
+  overrides: Array<{ parameterId: string; targetValue: number; origin: "MANUAL_OVERRIDE" | "ADAPTED" }>,
+  entityContext: EntityBreadcrumb[] | undefined,
+): string {
+  const caller = entityContext?.find((e) => e.type === "caller");
+  if (!caller) {
+    return "\n\n## Learner-level Overrides\n\n_No learner in context — values shown in the catalogue above are course-effective only._";
+  }
+  if (overrides.length === 0) {
+    return `\n\n## Learner-level Overrides (${caller.label})\n\nNo per-learner overrides for this caller. The course-effective values in the catalogue apply.`;
+  }
+  const lines = [
+    `\n\n## Learner-level Overrides (${caller.label})`,
+    "",
+    "Values here OVERRIDE the course-effective catalogue for this learner. Two origins:",
+    "- **MANUAL_OVERRIDE** — set by an educator via Tune sidebar or Cmd+K chat. Wins over everything.",
+    "- **ADAPTED** — set by the ADAPT pipeline stage based on call evidence. Wins over course defaults, BUT a fresh MANUAL_OVERRIDE will replace it.",
+    "",
+    "**Before tuning a parameter listed here at PLAYBOOK scope, warn the educator: their course-level change will be shadowed for this learner. Ask if they want to clear the override.**",
+    "",
+  ];
+  for (const o of overrides) {
+    lines.push(`- ${o.parameterId} = ${o.targetValue} (${o.origin})`);
+  }
+  return lines.join("\n");
+}
+
 function buildActiveCourseBlock(entityContext: EntityBreadcrumb[] | undefined): string {
   if (!entityContext || entityContext.length === 0) {
     return `\n\n## Active Context\n\n_No entity context. Ask the educator which course they want to tune before calling \`update_behavior_target\`._`;
@@ -293,6 +327,60 @@ async function loadPlaybookOverrides(playbookId: string | undefined): Promise<Ma
 }
 
 /**
+ * #713 bug 1 — load LEARNER-level overrides for a caller. Returns merged
+ * view of:
+ *   - BehaviorTarget(scope=CALLER, source=MANUAL|TUNING_CHAT) — educator
+ *     overrides set via Tune sidebar or Cmd+K chat
+ *   - CallerTarget — system-managed per-learner state (ADAPT, AGGREGATE)
+ *
+ * Both sources surface so the AI can distinguish "this was an explicit
+ * educator setting" from "this is the system's adapted value", and can
+ * answer "what is X for this learner?" without missing rows.
+ */
+interface LearnerOverride {
+  parameterId: string;
+  targetValue: number;
+  origin: "MANUAL_OVERRIDE" | "ADAPTED";
+}
+
+async function loadCallerOverrides(callerId: string | undefined): Promise<LearnerOverride[]> {
+  if (!callerId) return [];
+  const [callerTargets, behaviorTargets] = await Promise.all([
+    prisma.callerTarget.findMany({
+      where: { callerId },
+      select: { parameterId: true, targetValue: true },
+    }),
+    prisma.behaviorTarget.findMany({
+      where: {
+        scope: "CALLER",
+        effectiveUntil: null,
+        callerIdentity: { callerId },
+        source: { in: ["MANUAL", "TUNING_CHAT"] },
+      },
+      select: { parameterId: true, targetValue: true, source: true },
+    }),
+  ]);
+
+  // Educator overrides win over CallerTarget (mirrors mergeTargets logic).
+  const result = new Map<string, LearnerOverride>();
+  for (const ct of callerTargets) {
+    result.set(ct.parameterId, {
+      parameterId: ct.parameterId,
+      targetValue: ct.targetValue,
+      origin: "ADAPTED",
+    });
+  }
+  for (const bt of behaviorTargets) {
+    result.set(bt.parameterId, {
+      parameterId: bt.parameterId,
+      targetValue: bt.targetValue,
+      origin: "MANUAL_OVERRIDE",
+    });
+  }
+  return Array.from(result.values());
+}
+
+/**
  * Build the TUNING mode system prompt with live parameter + contract context.
  */
 export async function buildTuningSystemPrompt(options: BuildTuningPromptOptions = {}): Promise<string> {
@@ -302,16 +390,20 @@ export async function buildTuningSystemPrompt(options: BuildTuningPromptOptions 
   );
 
   const playbookId = options.entityContext?.find((e) => e.type === "playbook")?.id;
+  const callerId = options.entityContext?.find((e) => e.type === "caller")?.id;
   const overrides = await loadPlaybookOverrides(playbookId);
 
-  const [{ params }, contracts] = await Promise.all([
+  const [{ params }, contracts, learnerOverrides] = await Promise.all([
     loadAdjustableParameters(overrides),
     ContractRegistry.listContracts(),
+    loadCallerOverrides(callerId),
   ]);
 
   const paramBlock = params.length > 0
     ? `\n\n## Behaviour Parameter Catalogue (${params.length} adjustable)\n\nValues shown are the **CURRENT effective value on the active course** (PLAYBOOK overrides applied over SYSTEM defaults). If you just called the tool, the new value is reflected here on the next turn. Use these as your starting point when mapping plain-language requests to numeric targets — if the educator asks for 0.15 and the catalogue already shows 0.15, the change is already in place.\n\n${formatParameterList(params)}`
     : "\n\n## Behaviour Parameters\n\n_No adjustable behaviour parameters found in the database._";
+
+  const learnerBlock = buildLearnerOverridesBlock(learnerOverrides, options.entityContext);
 
   const contractBlock = formatContractCatalogue(contracts);
 
@@ -333,7 +425,7 @@ Each stage is spec-driven. Behaviour-target changes you make take effect at the 
   const scopeBlock = buildActiveScopeBlock(options.tuningScope, options.entityContext);
   const activeBlock = buildActiveCourseBlock(options.entityContext);
 
-  return basePrompt + scopeBlock + activeBlock + paramBlock + contractBlock + pipelineBlock;
+  return basePrompt + scopeBlock + activeBlock + paramBlock + learnerBlock + contractBlock + pipelineBlock;
 }
 
 /**

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -745,10 +745,21 @@ registerLoader("interleaveReview", async (callerId, config) => {
   }
 });
 
-registerLoader("behaviorTargets", async (_callerId) => {
+registerLoader("behaviorTargets", async (callerId) => {
+  // #713 bug 4 — scope=CALLER targets must be filtered to THIS caller.
+  // Pre-fix this loader returned ALL non-expired BehaviorTargets across the
+  // institution, including scope=CALLER rows belonging to other learners.
+  // Cross-learner leak: Alice's per-caller tune influenced Bob's compose.
+  // Non-CALLER scopes (SYSTEM / PLAYBOOK / SEGMENT) still pass through —
+  // their broad applicability is intentional and mergeTargets filters
+  // PLAYBOOK targets against the active playbook stack downstream.
   return prisma.behaviorTarget.findMany({
     where: {
       effectiveUntil: null,
+      OR: [
+        { scope: { not: "CALLER" } },
+        { callerIdentity: { callerId } },
+      ],
     },
     include: {
       parameter: {

--- a/apps/admin/lib/prompt/composition/transforms/targets.ts
+++ b/apps/admin/lib/prompt/composition/transforms/targets.ts
@@ -217,7 +217,8 @@ export function mergeTargets(
   const byParameter = new Map<string, NormalizedTarget>();
   const playbookIdSet = new Set(playbookIds);
 
-  // CallerTargets first (highest priority)
+  // CallerTargets first (system-managed per-learner state — ADAPT / AGGREGATE
+  // / goal tracking write here). Treated as the baseline per-learner value.
   for (const ct of callerTargets) {
     byParameter.set(ct.parameterId, {
       parameterId: ct.parameterId,
@@ -236,9 +237,39 @@ export function mergeTargets(
     SYSTEM: 1,
   };
 
-  // Fill in with BehaviorTargets for missing parameters
+  // #713 bug 2 — educator-set BehaviorTarget(scope=CALLER, source MANUAL or
+  // TUNING_CHAT) must override the system-managed CallerTarget. Pre-fix the
+  // CallerTarget always won, which made every Cmd+K tune at LEARNER scope
+  // structurally invisible. Manual intent now wins over LEARNED / SEED.
+  const isEducatorOverride = (t: BehaviorTargetData) =>
+    t.scope === "CALLER" && (t.source === "MANUAL" || t.source === "TUNING_CHAT");
+
+  // First pass: apply educator overrides (highest priority). These win over
+  // CallerTargets and over system-set BehaviorTargets alike. Track which
+  // parameters were set this way so the second pass can't overwrite them
+  // even if a higher-scope system target also exists.
+  const lockedByEducator = new Set<string>();
   for (const target of behaviorTargets) {
-    if (byParameter.has(target.parameterId) && byParameter.get(target.parameterId)?.source === "CallerTarget") {
+    if (!isEducatorOverride(target)) continue;
+    byParameter.set(target.parameterId, {
+      parameterId: target.parameterId,
+      targetValue: target.targetValue,
+      confidence: target.confidence,
+      source: "BehaviorTarget",
+      scope: target.scope,
+      parameter: target.parameter,
+    });
+    lockedByEducator.add(target.parameterId);
+  }
+
+  // Fill in with remaining BehaviorTargets for missing/lower-priority params.
+  for (const target of behaviorTargets) {
+    if (isEducatorOverride(target)) continue;  // already applied
+    if (lockedByEducator.has(target.parameterId)) continue;  // educator override locks this param
+    if (
+      byParameter.has(target.parameterId) &&
+      byParameter.get(target.parameterId)?.source === "CallerTarget"
+    ) {
       continue;
     }
 

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -566,6 +566,10 @@ export interface BehaviorTargetData {
   confidence: number;
   scope: string;
   playbookId?: string | null;
+  // #713 bug 2 — source distinguishes educator-set (MANUAL / TUNING_CHAT)
+  // from system-set (SEED / LEARNED) targets. mergeTargets uses this to
+  // let manual scope=CALLER tunes override the system's CallerTarget.
+  source?: "SEED" | "LEARNED" | "MANUAL" | "TUNING_CHAT" | null;
   parameter: {
     name: string | null;
     parameterId?: string;

--- a/apps/admin/tests/lib/composition/section-data-loader.test.ts
+++ b/apps/admin/tests/lib/composition/section-data-loader.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/prisma", () => {
     callerPlaybook: { findMany: vi.fn() },
     playbookSubject: { findMany: vi.fn() },
     playbookSource: { findMany: vi.fn() },
+    behaviorTarget: { findMany: vi.fn() },
   };
   return { prisma: mock, db: () => mock };
 });
@@ -227,5 +228,57 @@ describe("subjectSources loader — documentType + tutorOnly hint", () => {
     expect(cref.tutorOnly).toBe(true);
     expect(textbook.documentType).toBe("TEXTBOOK");
     expect(cref.documentType).toBe("COURSE_REFERENCE");
+  });
+});
+
+describe("behaviorTargets loader — #713 bug 4 cross-learner scope=CALLER filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("filters scope=CALLER targets to those whose callerIdentity belongs to the caller", async () => {
+    (prisma.behaviorTarget.findMany as any).mockResolvedValue([]);
+    await getLoader("behaviorTargets")!("caller-A");
+
+    // Inspect the `where` clause that was passed to prisma
+    const call = (prisma.behaviorTarget.findMany as any).mock.calls[0][0];
+    expect(call.where).toMatchObject({ effectiveUntil: null });
+    expect(call.where.OR).toEqual([
+      { scope: { not: "CALLER" } },
+      { callerIdentity: { callerId: "caller-A" } },
+    ]);
+  });
+
+  it("does not surface scope=CALLER targets belonging to other callers", async () => {
+    // Simulate Bob asking for his targets; the DB filter should ensure
+    // Alice's scope=CALLER row never even enters the result set.
+    (prisma.behaviorTarget.findMany as any).mockImplementation((args: any) => {
+      const all = [
+        // Alice's per-caller tune
+        { id: "bt-alice", scope: "CALLER", targetValue: 0.9, callerIdentityId: "ident-alice", callerIdentity: { callerId: "alice" }, parameter: { parameterId: "BEH-WARMTH" } },
+        // PLAYBOOK target (broad — should appear for Bob)
+        { id: "bt-pb", scope: "PLAYBOOK", targetValue: 0.4, playbookId: "pb1", parameter: { parameterId: "BEH-WARMTH" } },
+        // Bob's own per-caller tune
+        { id: "bt-bob", scope: "CALLER", targetValue: 0.7, callerIdentityId: "ident-bob", callerIdentity: { callerId: "bob" }, parameter: { parameterId: "BEH-WARMTH" } },
+      ];
+      // Mimic the OR filter from the real implementation
+      const orClauses = args?.where?.OR ?? [];
+      return Promise.resolve(
+        all.filter((t) => {
+          if (orClauses.length === 0) return true;
+          return orClauses.some((c: any) => {
+            if (c.scope?.not && t.scope !== c.scope.not) return true;
+            if (c.callerIdentity?.callerId && t.callerIdentity?.callerId === c.callerIdentity.callerId) return true;
+            return false;
+          });
+        }),
+      );
+    });
+
+    const bobTargets = await getLoader("behaviorTargets")!("bob");
+    const ids = (bobTargets as Array<{ id: string }>).map((t) => t.id);
+    expect(ids).toContain("bt-bob");      // Bob sees his own
+    expect(ids).toContain("bt-pb");        // Playbook target still applies broadly
+    expect(ids).not.toContain("bt-alice"); // Alice's row is filtered out
   });
 });

--- a/apps/admin/tests/lib/composition/targets.test.ts
+++ b/apps/admin/tests/lib/composition/targets.test.ts
@@ -191,6 +191,89 @@ describe("mergeTargets", () => {
     expect(result[0].targetValue).toBe(0.99);
     expect(result[0].source).toBe("CallerTarget");
   });
+
+  describe("#713 bug 2 — educator override (scope=CALLER, source=MANUAL/TUNING_CHAT) wins over CallerTarget", () => {
+    it("TUNING_CHAT scope=CALLER overrides CallerTarget for the same parameter", () => {
+      const educatorTune = makeBehaviorTarget({
+        parameterId: "P1",
+        scope: "CALLER",
+        source: "TUNING_CHAT",
+        targetValue: 0.2,
+      });
+      const ct = makeCallerTarget({ parameterId: "P1", targetValue: 0.9 });
+
+      const result = mergeTargets([educatorTune], [ct], []);
+      expect(result).toHaveLength(1);
+      expect(result[0].targetValue).toBe(0.2);
+      expect(result[0].source).toBe("BehaviorTarget");
+      expect(result[0].scope).toBe("CALLER");
+    });
+
+    it("MANUAL scope=CALLER overrides CallerTarget for the same parameter", () => {
+      const sidebarTune = makeBehaviorTarget({
+        parameterId: "P1",
+        scope: "CALLER",
+        source: "MANUAL",
+        targetValue: 0.15,
+      });
+      const ct = makeCallerTarget({ parameterId: "P1", targetValue: 0.85 });
+
+      const result = mergeTargets([sidebarTune], [ct], []);
+      expect(result[0].targetValue).toBe(0.15);
+      expect(result[0].source).toBe("BehaviorTarget");
+    });
+
+    it("LEARNED scope=CALLER does NOT override CallerTarget (only MANUAL/TUNING_CHAT do)", () => {
+      const adapted = makeBehaviorTarget({
+        parameterId: "P1",
+        scope: "CALLER",
+        source: "LEARNED",
+        targetValue: 0.3,
+      });
+      const ct = makeCallerTarget({ parameterId: "P1", targetValue: 0.9 });
+
+      const result = mergeTargets([adapted], [ct], []);
+      expect(result[0].targetValue).toBe(0.9);
+      expect(result[0].source).toBe("CallerTarget");
+    });
+
+    it("educator override at scope=CALLER also wins over PLAYBOOK target", () => {
+      const playbookTune = makeBehaviorTarget({
+        parameterId: "P1",
+        scope: "PLAYBOOK",
+        playbookId: "pb-1",
+        targetValue: 0.6,
+      });
+      const educatorTune = makeBehaviorTarget({
+        parameterId: "P1",
+        scope: "CALLER",
+        source: "TUNING_CHAT",
+        targetValue: 0.2,
+      });
+
+      const result = mergeTargets([playbookTune, educatorTune], [], ["pb-1"]);
+      expect(result[0].targetValue).toBe(0.2);
+    });
+
+    it("educator override and CallerTarget on different params both surface", () => {
+      const educatorTune = makeBehaviorTarget({
+        parameterId: "P1",
+        scope: "CALLER",
+        source: "TUNING_CHAT",
+        targetValue: 0.2,
+      });
+      const ct = makeCallerTarget({ parameterId: "P2", targetValue: 0.9 });
+
+      const result = mergeTargets([educatorTune], [ct], []);
+      expect(result).toHaveLength(2);
+      const p1 = result.find((r) => r.parameterId === "P1")!;
+      const p2 = result.find((r) => r.parameterId === "P2")!;
+      expect(p1.source).toBe("BehaviorTarget");
+      expect(p1.targetValue).toBe(0.2);
+      expect(p2.source).toBe("CallerTarget");
+      expect(p2.targetValue).toBe(0.9);
+    });
+  });
 });
 
 // =====================================================


### PR DESCRIPTION
Closes #713 bugs 1, 2, 4. Bug 3 (system prompt teaching merge precedence) is implicitly covered by the new learner-overrides block; can be tightened in a follow-up if QA finds gaps.

## TL;DR
- **Cross-learner leak fixed** — scope=CALLER targets no longer surface in other learners' compositions
- **Educator tunes now take effect** — MANUAL/TUNING_CHAT writes win over CallerTarget (the system-managed table)
- **AI can see learner overrides** — Cmd+K tuning chat will no longer claim 'no learner-level setting' when CallerTarget exists

## Diff
- \`SectionDataLoader.ts\` — WHERE clause filters scope=CALLER by callerIdentityId
- \`transforms/targets.ts\` — two-pass merge, MANUAL/TUNING_CHAT scope=CALLER beats CallerTarget
- \`types.ts\` — BehaviorTargetData gets optional \`source\` field
- \`tuning-system-prompt.ts\` — new 'Learner-level Overrides' block with MANUAL_OVERRIDE vs ADAPTED labels + shadowing-warning guidance

## Test plan
- [x] \`npx vitest run tests/lib/composition/\` — 409/409 pass
- [ ] Smoke on hf-dev: open Cmd+K on a caller, ask 'what about {learner} setting?' — should now return their CallerTarget value
- [ ] Open Cmd+K, change BEH-WARMTH at LEARNER scope → re-prompt → diff visible
- [ ] Verify no cross-learner leak: Alice's per-caller tune doesn't show in Bob's prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)