### PR TITLE
feat(#710): Tune sidebar warns when PLAYBOOK change is shadowed for this learner

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/behavior-targets/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/behavior-targets/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { writeCallerBehaviorTarget } from "@/lib/agent-tuner/write-target";
+import { prisma } from "@/lib/prisma";
 
 export const runtime = "nodejs";
 
@@ -77,6 +78,75 @@ export async function PATCH(
     console.error("Error updating caller behavior targets:", error);
     return NextResponse.json(
       { ok: false, error: error?.message || "Failed to update caller targets" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * @api GET /api/callers/:callerId/behavior-targets
+ * @visibility internal
+ * @scope callers:read
+ * @auth session
+ * @tags callers, targets
+ * @description Return the per-learner behaviour-target overrides for a caller —
+ *   both MANUAL/TUNING_CHAT scope=CALLER BehaviorTargets (educator-set) AND
+ *   CallerTarget rows (system-managed via ADAPT/AGGREGATE). Used by the Tune
+ *   sidebar (#710) to surface shadow warnings when an educator is about to
+ *   tune at PLAYBOOK scope on a parameter this learner has overridden.
+ * @pathParam callerId string - Caller UUID
+ * @response 200 { ok: true, overrides: Array<{ parameterId, targetValue, origin }> }
+ *   where origin is "MANUAL_OVERRIDE" (educator) or "ADAPTED" (system).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ callerId: string }> },
+) {
+  try {
+    const authResult = await requireAuth("OPERATOR");
+    if (isAuthError(authResult)) return authResult.error;
+
+    const { callerId } = await params;
+
+    const [callerTargets, behaviorTargets] = await Promise.all([
+      prisma.callerTarget.findMany({
+        where: { callerId },
+        select: { parameterId: true, targetValue: true, lastUpdatedAt: true },
+      }),
+      prisma.behaviorTarget.findMany({
+        where: {
+          scope: "CALLER",
+          effectiveUntil: null,
+          callerIdentity: { callerId },
+          source: { in: ["MANUAL", "TUNING_CHAT"] },
+        },
+        select: { parameterId: true, targetValue: true, source: true, updatedAt: true },
+      }),
+    ]);
+
+    const byParam = new Map<string, { parameterId: string; targetValue: number; origin: "MANUAL_OVERRIDE" | "ADAPTED"; updatedAt: string }>();
+    for (const ct of callerTargets) {
+      byParam.set(ct.parameterId, {
+        parameterId: ct.parameterId,
+        targetValue: ct.targetValue,
+        origin: "ADAPTED",
+        updatedAt: ct.lastUpdatedAt?.toISOString() ?? new Date(0).toISOString(),
+      });
+    }
+    for (const bt of behaviorTargets) {
+      byParam.set(bt.parameterId, {
+        parameterId: bt.parameterId,
+        targetValue: bt.targetValue,
+        origin: "MANUAL_OVERRIDE",
+        updatedAt: bt.updatedAt.toISOString(),
+      });
+    }
+
+    return NextResponse.json({ ok: true, overrides: Array.from(byParam.values()) });
+  } catch (error: any) {
+    console.error("Error reading caller behavior targets:", error);
+    return NextResponse.json(
+      { ok: false, error: error?.message || "Failed to read caller targets" },
       { status: 500 },
     );
   }

--- a/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
@@ -237,6 +237,28 @@ export function PromptTunerSidebar({
   const [applyResult, setApplyResult] = useState<string | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [activeLearnerCount, setActiveLearnerCount] = useState<number | null>(null);
+  // #710 — surface LEARNER-level overrides on this caller so a PLAYBOOK-scope
+  // change can warn when it'll be silently shadowed for the active learner.
+  const [learnerOverrides, setLearnerOverrides] = useState<
+    Array<{ parameterId: string; targetValue: number; origin: "MANUAL_OVERRIDE" | "ADAPTED"; updatedAt: string }>
+  >([]);
+
+  useEffect(() => {
+    if (!callerId || !open) return;
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/behavior-targets`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data?.ok && Array.isArray(data.overrides)) {
+          setLearnerOverrides(data.overrides);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, open]);
 
   // Fetch ACTIVE enrollment count so the Apply button can show consequence up front.
   useEffect(() => {
@@ -724,6 +746,27 @@ export function PromptTunerSidebar({
             {applyResult}
           </div>
         )}
+        {/* #710 — shadowing warning when PLAYBOOK-scope change targets a parameter
+            this learner already has a per-learner override on. */}
+        {scope === "course" && (() => {
+          const shadowed = pendingChanges
+            .filter((c) => c.type === "target" && c.parameterId)
+            .map((c) => learnerOverrides.find((o) => o.parameterId === c.parameterId))
+            .filter((o): o is NonNullable<typeof o> => o != null);
+          if (shadowed.length === 0) return null;
+          const manualCount = shadowed.filter((o) => o.origin === "MANUAL_OVERRIDE").length;
+          const adaptedCount = shadowed.filter((o) => o.origin === "ADAPTED").length;
+          const parts: string[] = [];
+          if (manualCount > 0) parts.push(`${manualCount} manual override${manualCount === 1 ? "" : "s"}`);
+          if (adaptedCount > 0) parts.push(`${adaptedCount} ADAPT result${adaptedCount === 1 ? "" : "s"}`);
+          return (
+            <div className="hf-banner hf-banner-warning ps-tuner-error">
+              <strong>Will be shadowed for {callerName || "this learner"}.</strong>{" "}
+              {parts.join(" and ")} on the same parameter{shadowed.length === 1 ? "" : "s"} ({shadowed.map((o) => o.parameterId).join(", ")}){" "}
+              will keep winning over this PLAYBOOK change. Other learners on this course are unaffected — switch to learner scope if you want this to land for {callerName || "this learner"}.
+            </div>
+          );
+        })()}
           </>
         )}
       </div>

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -2497,6 +2497,23 @@ Get all media assets available for sharing with a caller, based on their domain'
 
 ---
 
+### `GET` /api/callers/:callerId/behavior-targets
+
+Return the per-learner behaviour-target overrides for a caller —
+
+**Auth**: Session · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | Caller UUID |
+
+**Response** `200`
+```json
+{ ok: true, overrides: Array<{ parameterId, targetValue, origin }> }
+```
+
+---
+
 ### `PATCH` /api/callers/:callerId/behavior-targets
 
 Update CALLER-scoped behavior targets for a single caller. The server


### PR DESCRIPTION
Closes #710. Sidebar reads the active learner's overrides on open, computes overlap with pending PLAYBOOK changes, surfaces a warning banner before Apply.

New endpoint: `GET /api/callers/[callerId]/behavior-targets` returns the merged overrides (MANUAL_OVERRIDE + ADAPTED). Same data shape the system prompt uses in #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)