### PR TITLE
feat(#688): useChordShortcut hook + H/G chord engine wired to 3 pages

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -30,6 +30,9 @@ import { useEntityContext } from '@/contexts/EntityContext';
 import { EditableTitle } from '@/components/shared/EditableTitle';
 import { StatusBadge, DomainPill } from '@/src/components/shared/EntityPill';
 import { DraggableTabs, type TabDefinition } from '@/components/shared/DraggableTabs';
+import { useChordShortcut } from '@/hooks/useChordShortcut';
+import { ChordHintBadge } from '@/components/help/ChordHintBadge';
+import { getPageHelp } from '@/lib/help/page-help';
 import { type TPItem, type SessionOption } from '@/components/shared/SessionTPList';
 import {
   groupSpecs,
@@ -155,6 +158,10 @@ export default function CourseDetailPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: session } = useSession();
+  // #688 — chord shortcuts (H/G + key) for tab navigation.
+  // Lookup is route-templated; pathname not needed.
+  const pageHelp = useMemo(() => getPageHelp(`/x/courses/${courseId || ""}`), [courseId]);
+  const { activePrefix: chordActivePrefix } = useChordShortcut(pageHelp?.chords);
   const isOperator = ['OPERATOR', 'EDUCATOR', 'ADMIN', 'SUPERADMIN'].includes((session?.user?.role as string) || '');
   const { pushEntity } = useEntityContext();
   const { plural } = useTerminology();
@@ -480,6 +487,23 @@ export default function CourseDetailPage() {
     handleTabChange(activeTab);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courseId, activeTab, handleTabChange]);
+
+  // ── #688 — listen for chord-driven tab switches ──
+  // Convention: chord engine dispatches `hf:chord:tab:<id>`. Pages map that
+  // to their tab setter without a global prop-drill.
+  useEffect(() => {
+    const tabIds = (pageHelp?.tabs ?? []).map((t) => t.id);
+    const handlers: Array<{ name: string; fn: EventListener }> = [];
+    for (const id of tabIds) {
+      const name = `hf:chord:tab:${id}`;
+      const fn: EventListener = () => handleTabChange(id);
+      window.addEventListener(name, fn);
+      handlers.push({ name, fn });
+    }
+    return () => {
+      for (const { name, fn } of handlers) window.removeEventListener(name, fn);
+    };
+  }, [pageHelp, handleTabChange]);
 
   // ── Action Handlers ──────────────────────────────────
   const handlePublish = async () => {
@@ -1714,6 +1738,7 @@ export default function CourseDetailPage() {
           }}
         />
       )}
+      <ChordHintBadge activePrefix={chordActivePrefix} />
     </div>
   );
 }

--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -5,6 +5,9 @@ import { FancySelect } from "@/components/shared/FancySelect";
 import type { FancySelectOption } from "@/components/shared/FancySelect";
 import { ConversationalWizard } from "../wizard/components/ConversationalWizard";
 import type { WizardInitialContext } from "../wizard/components/ConversationalWizard";
+import { useChordShortcut } from "@/hooks/useChordShortcut";
+import { ChordHintBadge } from "@/components/help/ChordHintBadge";
+import { getPageHelp } from "@/lib/help/page-help";
 import "./get-started-v5.css";
 
 /* ── Types ──────────────────────────────────────────────── */
@@ -56,6 +59,10 @@ export function V5WizardWithSelector({
   const [loading, setLoading] = useState(false);
 
   const isSuperAdmin = userRole === "SUPERADMIN";
+
+  // #688 — chord shortcuts (only the C=Exit chord on this route).
+  const wizardPageHelp = getPageHelp("/x/get-started-v5");
+  const { activePrefix: chordActivePrefix } = useChordShortcut(wizardPageHelp?.chords);
 
   // Fetch institution list on mount
   useEffect(() => {
@@ -180,6 +187,7 @@ export function V5WizardWithSelector({
         userRole={userRole}
         wizardVersion="v5"
       />
+      <ChordHintBadge activePrefix={chordActivePrefix} />
     </>
   );
 }

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -18,6 +18,9 @@ import './caller-detail-page.css';
 import './caller-detail/lens.css';
 import './caller-detail/prompt-tuner.css';
 import { useAssistant, useAssistantKeyboardShortcut } from "@/hooks/useAssistant";
+import { useChordShortcut } from "@/hooks/useChordShortcut";
+import { ChordHintBadge } from "@/components/help/ChordHintBadge";
+import { getPageHelp } from "@/lib/help/page-help";
 
 // Extracted sub-components
 import { ProcessingNotice } from "./caller-detail/CallsTab";
@@ -94,6 +97,10 @@ export default function CallerDetailPage() {
   const [data, setData] = useState<CallerData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // #688 — chord shortcuts (H/G + key) for tab navigation.
+  const pageHelp = useMemo(() => getPageHelp(`/x/callers/${callerId}`), [callerId]);
+  const { activePrefix: chordActivePrefix } = useChordShortcut(pageHelp?.chords);
+
   const [activeSection, _setActiveSection] = useState<SectionId>(initialTab);
   const setActiveSection = (id: SectionId) => {
     _setActiveSection(id);
@@ -561,6 +568,24 @@ export default function CallerDetailPage() {
       fetchPrompts();
     }
   }, [fetchPrompts, composedPrompts.length]);
+
+  // #688 — listen for chord-driven tab switches. Convention: chord engine
+  // dispatches `hf:chord:tab:<id>`. Map id → SectionId via the registry.
+  useEffect(() => {
+    const tabIds = (pageHelp?.tabs ?? []).map((t) => t.id);
+    const handlers: Array<{ name: string; fn: EventListener }> = [];
+    for (const id of tabIds) {
+      const name = `hf:chord:tab:${id}`;
+      const fn: EventListener = () => setActiveSection(id as SectionId);
+      window.addEventListener(name, fn);
+      handlers.push({ name, fn });
+    }
+    return () => {
+      for (const { name, fn } of handlers) window.removeEventListener(name, fn);
+    };
+  // setActiveSection is intentionally a stable reference via the closure.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageHelp]);
 
   const getCallerLabel = (caller: CallerProfile | undefined) => {
     if (!caller) return "Unknown";
@@ -1292,6 +1317,7 @@ export default function CallerDetailPage() {
       )}
       </div>{/* cdp-content */}
       </div>{/* cdp-body */}
+      <ChordHintBadge activePrefix={chordActivePrefix} />
     </div>
   );
 }

--- a/apps/admin/components/help/ChordHintBadge.tsx
+++ b/apps/admin/components/help/ChordHintBadge.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+import "./chord-hint-badge.css";
+
+interface ChordHintBadgeProps {
+  /** "H" or "G" while a chord is armed; null otherwise. */
+  activePrefix: string | null;
+}
+
+/**
+ * Transient badge shown while a chord is armed (after H or G, before the
+ * second key). Disappears when the chord completes, times out, or resets.
+ */
+export function ChordHintBadge({ activePrefix }: ChordHintBadgeProps): React.ReactElement | null {
+  if (!activePrefix) return null;
+  return (
+    <div className="hf-chord-hint" role="status" aria-live="polite">
+      <kbd>{activePrefix}</kbd>
+      <span className="hf-chord-hint-sep">·</span>
+      <span className="hf-chord-hint-hint">press next key…</span>
+    </div>
+  );
+}

--- a/apps/admin/components/help/chord-hint-badge.css
+++ b/apps/admin/components/help/chord-hint-badge.css
@@ -1,0 +1,45 @@
+.hf-chord-hint {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  z-index: 9500;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--text-primary) 16%, transparent);
+  font-size: 13px;
+  color: var(--text-primary);
+  animation: hf-chord-hint-in 120ms ease-out;
+}
+
+.hf-chord-hint kbd {
+  display: inline-block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+  min-width: 18px;
+  text-align: center;
+}
+
+.hf-chord-hint-sep {
+  color: var(--text-muted);
+}
+
+.hf-chord-hint-hint {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+@keyframes hf-chord-hint-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/apps/admin/hooks/useChordShortcut.ts
+++ b/apps/admin/hooks/useChordShortcut.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { isFocusBlocked } from "@/lib/help/isFocusBlocked";
+import type { ChordBinding } from "@/lib/help/page-help";
+
+interface ChordOptions {
+  /** Accepted bare prefix keys (case-insensitive). Default: ["h", "g"]. */
+  prefixKeys?: string[];
+  /** Timeout in ms before a partial chord resets. Default: 1500. */
+  timeoutMs?: number;
+}
+
+interface ChordState {
+  /** Active prefix while waiting for the second key, null otherwise. */
+  activePrefix: string | null;
+}
+
+/**
+ * Chord shortcut engine — listens for `<prefix> <key>` sequences, e.g.
+ *   H + C  → navigate to the Content tab
+ *   G + L  → navigate to Learners
+ *
+ * Bare keypresses only — `Cmd+H` / `Cmd+G` are not intercepted. The first key
+ * "soft arms" the chord (no preventDefault), the second key consumes the
+ * input only if it resolves to a binding. Unmatched second keys reset
+ * silently.
+ *
+ * Pages mount this hook with the ChordBinding[] for their route from
+ * lib/help/page-help.ts. Navigate-action chords push the href; callback-
+ * action chords dispatch a custom event `hf:chord:{callbackId}` that the
+ * page listens for (avoids prop-drilling setActiveTab through the tree).
+ */
+export function useChordShortcut(
+  chords: ChordBinding[] | undefined,
+  options: ChordOptions = {},
+): ChordState {
+  const router = useRouter();
+  // Memoise so the effect's dep array doesn't see a fresh array every render
+  // — without this, every state update tears down the listener AND clears
+  // the in-flight chord timer.
+  const prefixKeys = useMemo(
+    () => (options.prefixKeys ?? ["h", "g"]).map((k) => k.toLowerCase()),
+    [options.prefixKeys],
+  );
+  const timeoutMs = options.timeoutMs ?? 1500;
+
+  // Mirror activePrefix into a ref so the keydown handler always sees the
+  // current value — without a ref, two synchronous keypresses (e.g. test
+  // act() blocks, or fast typists) read a stale closure and the second key
+  // is mistakenly treated as a first key.
+  const [activePrefix, setActivePrefix] = useState<string | null>(null);
+  const activePrefixRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const armPrefix = useCallback((prefix: string | null) => {
+    activePrefixRef.current = prefix;
+    setActivePrefix(prefix);
+  }, []);
+
+  const reset = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    armPrefix(null);
+  }, [armPrefix]);
+
+  useEffect(() => {
+    if (!chords || chords.length === 0) return;
+
+    const handle = (e: KeyboardEvent) => {
+      // Skip when typing or when a dialog is open. Dialogs include the help
+      // overlay, prereq modals, etc.
+      if (isFocusBlocked(e)) return;
+      if (document.querySelector('[role="dialog"]')) return;
+
+      // Only bare keypresses — modifiers route to other handlers
+      // (Cmd+G → /x/get-started-v5 via app/layout.tsx:148-160 etc.).
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const key = e.key.toLowerCase();
+      const current = activePrefixRef.current;
+
+      // Escape resets any pending chord.
+      if (e.key === "Escape" && current) {
+        reset();
+        return;
+      }
+
+      // First key: prefix-arm.
+      if (current === null) {
+        if (prefixKeys.includes(key)) {
+          // Soft arm — do NOT preventDefault. Per the issue's coexistence
+          // note, the prefix must remain a no-op for any other handler.
+          armPrefix(key.toUpperCase());
+          if (timerRef.current) clearTimeout(timerRef.current);
+          timerRef.current = setTimeout(() => {
+            armPrefix(null);
+            timerRef.current = null;
+          }, timeoutMs);
+        }
+        return;
+      }
+
+      // Second key: resolve against bindings.
+      const upperKey = key.toUpperCase();
+      const match = chords.find((c) => c.keys.toUpperCase() === upperKey);
+      if (!match) {
+        // Unmapped key — reset silently. The educator will see the chord
+        // badge disappear; no error.
+        reset();
+        return;
+      }
+
+      // Consume the chord — both pre and stop now that we have a real action.
+      e.preventDefault();
+      e.stopPropagation();
+      reset();
+
+      if (match.action === "navigate" && match.href) {
+        router.push(match.href);
+      } else if (match.action === "callback" && match.callbackId) {
+        // Pages listen for `hf:chord:tab:<id>` and call their setActiveTab.
+        window.dispatchEvent(new CustomEvent(`hf:chord:${match.callbackId}`));
+      }
+    };
+
+    window.addEventListener("keydown", handle);
+    return () => {
+      window.removeEventListener("keydown", handle);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [chords, prefixKeys, timeoutMs, armPrefix, reset, router]);
+
+  return { activePrefix };
+}

--- a/apps/admin/tests/hooks/useChordShortcut.test.ts
+++ b/apps/admin/tests/hooks/useChordShortcut.test.ts
@@ -1,0 +1,165 @@
+/**
+ * useChordShortcut — chord state machine + binding resolution
+ *
+ * Tests the H/G + key chord engine from #688:
+ *   - bare prefix arms (no modifier accepted)
+ *   - second key resolves to a binding via lib/help/page-help.ts
+ *   - timeout resets silently
+ *   - unmapped second key resets silently
+ *   - focus-blocked targets skip the listener entirely
+ *   - active dialog skips
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useChordShortcut } from "@/hooks/useChordShortcut";
+import type { ChordBinding } from "@/lib/help/page-help";
+
+const pushMock = vi.fn();
+// Return a stable router object — a fresh object per render would make
+// useChordShortcut's effect dep array see a new reference each time and
+// tear down the in-flight chord timer.
+const stableRouter = { push: pushMock, replace: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn(), prefetch: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+}));
+
+function fireKey(key: string, modifiers: { meta?: boolean; ctrl?: boolean; alt?: boolean; target?: HTMLElement } = {}): void {
+  const ev = new KeyboardEvent("keydown", {
+    key,
+    metaKey: !!modifiers.meta,
+    ctrlKey: !!modifiers.ctrl,
+    altKey: !!modifiers.alt,
+    bubbles: true,
+    cancelable: true,
+  });
+  if (modifiers.target) {
+    Object.defineProperty(ev, "target", { value: modifiers.target });
+  }
+  window.dispatchEvent(ev);
+}
+
+const navigateChords: ChordBinding[] = [
+  { keys: "C", action: "navigate", href: "/x/courses", label: "Courses" },
+  { keys: "L", action: "navigate", href: "/x/learners", label: "Learners" },
+];
+
+const callbackChords: ChordBinding[] = [
+  { keys: "C", action: "callback", callbackId: "tab:content", label: "Content tab" },
+  { keys: "D", action: "callback", callbackId: "tab:design", label: "Design tab" },
+];
+
+describe("useChordShortcut", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("activePrefix is null at rest", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    expect(result.current.activePrefix).toBeNull();
+  });
+
+  it("arms on bare 'h' keypress and sets activePrefix to 'H'", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("h"); });
+    expect(result.current.activePrefix).toBe("H");
+  });
+
+  it("arms on bare 'g' keypress too — Gmail muscle memory", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("g"); });
+    expect(result.current.activePrefix).toBe("G");
+  });
+
+  it("does NOT arm on Cmd+G — Cmd+G belongs to the layout handler", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("g", { meta: true }); });
+    expect(result.current.activePrefix).toBeNull();
+  });
+
+  it("does NOT arm on Ctrl+H either", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("h", { ctrl: true }); });
+    expect(result.current.activePrefix).toBeNull();
+  });
+
+  it("H + C navigates to the bound href and clears the prefix", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("h"); });
+    expect(result.current.activePrefix).toBe("H");
+    act(() => { fireKey("c"); });
+    expect(pushMock).toHaveBeenCalledWith("/x/courses");
+    expect(result.current.activePrefix).toBeNull();
+  });
+
+  it("G + L navigates correctly — both prefixes share the binding table", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("g"); fireKey("l"); });
+    expect(pushMock).toHaveBeenCalledWith("/x/learners");
+    expect(result.current.activePrefix).toBeNull();
+  });
+
+  it("callback chord dispatches hf:chord:<callbackId> event", () => {
+    const listener = vi.fn();
+    window.addEventListener("hf:chord:tab:content", listener);
+    renderHook(() => useChordShortcut(callbackChords));
+    act(() => { fireKey("h"); fireKey("c"); });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(pushMock).not.toHaveBeenCalled();
+    window.removeEventListener("hf:chord:tab:content", listener);
+  });
+
+  it("unmapped second key resets silently — no navigation, no event", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("h"); fireKey("z"); });
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(result.current.activePrefix).toBeNull();
+  });
+
+  it("times out after 1.5 s — second key after timeout starts a fresh chord", () => {
+    renderHook(() => useChordShortcut(navigateChords));
+    // Arm with H, wait past timeout, then press C — should NOT navigate
+    // because the chord engine forgot the H by then.
+    act(() => { fireKey("h"); });
+    act(() => { vi.advanceTimersByTime(1600); });
+    act(() => { fireKey("c"); });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("Escape resets an armed prefix", () => {
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("h"); });
+    act(() => { fireKey("Escape"); });
+    expect(result.current.activePrefix).toBeNull();
+  });
+
+  it("skips when focus is in an INPUT element", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("h", { target: input }); });
+    expect(result.current.activePrefix).toBeNull();
+    document.body.removeChild(input);
+  });
+
+  it("skips when a role=dialog element is in the DOM", () => {
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+    const { result } = renderHook(() => useChordShortcut(navigateChords));
+    act(() => { fireKey("h"); });
+    expect(result.current.activePrefix).toBeNull();
+    document.body.removeChild(dialog);
+  });
+
+  it("no chords → hook does nothing (graceful empty)", () => {
+    const { result } = renderHook(() => useChordShortcut([]));
+    act(() => { fireKey("h"); fireKey("c"); });
+    expect(result.current.activePrefix).toBeNull();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #688. Chord engine reads bindings from `lib/help/page-help.ts` (#687) and wires up the Wizard, Course detail, and Learner detail pages. 14 unit tests; ChordHintBadge for visual feedback; `Cmd+G` stays bound to the layout's nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)