### PR TITLE
feat(#689): tab hover-tooltips sourced from page-help registry

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -32,6 +32,7 @@ import { StatusBadge, DomainPill } from '@/src/components/shared/EntityPill';
 import { DraggableTabs, type TabDefinition } from '@/components/shared/DraggableTabs';
 import { useChordShortcut } from '@/hooks/useChordShortcut';
 import { ChordHintBadge } from '@/components/help/ChordHintBadge';
+import { TabWithHelp } from '@/components/help/TabWithHelp';
 import { getPageHelp } from '@/lib/help/page-help';
 import { type TPItem, type SessionOption } from '@/components/shared/SessionTPList';
 import {
@@ -381,13 +382,13 @@ export default function CourseDetailPage() {
   }, [sessions]);
 
   const tabs: TabDefinition[] = useMemo(() => [
-    { id: 'intelligence', label: 'Content', icon: <BookMarked size={14} />, count: totalSources || null },
-    { id: 'design', label: 'Design', icon: <Wand2 size={14} /> },
-    { id: 'curriculum', label: 'Curriculum', icon: <GraduationCap size={14} /> },
-    { id: 'learners', label: 'Learners', icon: <Users2 size={14} /> },
-    { id: 'proof', label: 'Proof Points', icon: <BarChart3 size={14} /> },
-    { id: 'goals', label: 'Goals', icon: <Target size={14} /> },
-    ...(isOperator ? [{ id: 'settings', label: 'Settings', icon: <SettingsIcon size={14} /> }] : []),
+    { id: 'intelligence', label: <TabWithHelp tabId="intelligence">Content</TabWithHelp>, icon: <BookMarked size={14} />, count: totalSources || null },
+    { id: 'design', label: <TabWithHelp tabId="design">Design</TabWithHelp>, icon: <Wand2 size={14} /> },
+    { id: 'curriculum', label: <TabWithHelp tabId="curriculum">Curriculum</TabWithHelp>, icon: <GraduationCap size={14} /> },
+    { id: 'learners', label: <TabWithHelp tabId="learners">Learners</TabWithHelp>, icon: <Users2 size={14} /> },
+    { id: 'proof', label: <TabWithHelp tabId="proof">Proof Points</TabWithHelp>, icon: <BarChart3 size={14} /> },
+    { id: 'goals', label: <TabWithHelp tabId="goals">Goals</TabWithHelp>, icon: <Target size={14} /> },
+    ...(isOperator ? [{ id: 'settings', label: <TabWithHelp tabId="settings">Settings</TabWithHelp>, icon: <SettingsIcon size={14} /> }] : []),
   ], [totalSources, isOperator, sessions]);
 
   // Sync active tab from URL on popstate (browser back/forward)

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -20,6 +20,7 @@ import './caller-detail/prompt-tuner.css';
 import { useAssistant, useAssistantKeyboardShortcut } from "@/hooks/useAssistant";
 import { useChordShortcut } from "@/hooks/useChordShortcut";
 import { ChordHintBadge } from "@/components/help/ChordHintBadge";
+import { TabWithHelp } from "@/components/help/TabWithHelp";
 import { getPageHelp } from "@/lib/help/page-help";
 
 // Extracted sub-components
@@ -613,16 +614,16 @@ export default function CallerDetailPage() {
   // Tabs affected by pipeline processing (will show pulsing indicator)
   const processingTabs = new Set<SectionId>(["calls-prompts", "how", "what", "uplift", "artifacts"]);
 
-  const sections: { id: SectionId; label: string; icon: React.ReactNode; count?: number; special?: boolean; group: "history" | "caller" | "shared" | "action" }[] = [
-    { id: "overview", label: "Overview", icon: <span aria-hidden>🧭</span>, group: "shared" },
-    { id: "calls-prompts", label: "Calls", icon: <Phone size={13} />, count: data.counts.calls, group: "history" },
-    { id: "tune", label: "Tune", icon: <SlidersHorizontal size={13} />, count: data.counts.prompts || undefined, group: "caller" },
-    { id: "how", label: "Profile", icon: <User size={13} />, count: (data.counts.memories || 0) + (data.counts.observations || 0), group: "caller" },
-    { id: "what", label: "Progress", icon: <Gauge size={13} />, count: (new Set(data.scores?.map((s: any) => s.parameterId)).size || 0) + (data.counts.callerTargets || 0) + (data.counts.measurements || 0), group: "shared" },
-    { id: "artifacts", label: "Artifacts", icon: <BookMarked size={13} />, count: (data.counts.artifacts || 0) + (data.counts.actions || 0), group: "shared" },
-    { id: "uplift", label: "Uplift", icon: <TrendingUp size={13} />, group: "shared" },
+  const sections: { id: SectionId; label: React.ReactNode; icon: React.ReactNode; count?: number; special?: boolean; group: "history" | "caller" | "shared" | "action" }[] = [
+    { id: "overview", label: <TabWithHelp tabId="overview">Overview</TabWithHelp>, icon: <span aria-hidden>🧭</span>, group: "shared" },
+    { id: "calls-prompts", label: <TabWithHelp tabId="calls-prompts">Calls</TabWithHelp>, icon: <Phone size={13} />, count: data.counts.calls, group: "history" },
+    { id: "tune", label: <TabWithHelp tabId="tune">Tune</TabWithHelp>, icon: <SlidersHorizontal size={13} />, count: data.counts.prompts || undefined, group: "caller" },
+    { id: "how", label: <TabWithHelp tabId="how">Profile</TabWithHelp>, icon: <User size={13} />, count: (data.counts.memories || 0) + (data.counts.observations || 0), group: "caller" },
+    { id: "what", label: <TabWithHelp tabId="what">Progress</TabWithHelp>, icon: <Gauge size={13} />, count: (new Set(data.scores?.map((s: any) => s.parameterId)).size || 0) + (data.counts.callerTargets || 0) + (data.counts.measurements || 0), group: "shared" },
+    { id: "artifacts", label: <TabWithHelp tabId="artifacts">Artifacts</TabWithHelp>, icon: <BookMarked size={13} />, count: (data.counts.artifacts || 0) + (data.counts.actions || 0), group: "shared" },
+    { id: "uplift", label: <TabWithHelp tabId="uplift">Uplift</TabWithHelp>, icon: <TrendingUp size={13} />, group: "shared" },
     { id: "session-flow", label: "Session Flow", icon: <SlidersHorizontal size={13} />, group: "shared" },
-    { id: "ai-call", label: "Call", icon: <PlayCircle size={13} />, special: true, group: "action" },
+    { id: "ai-call", label: <TabWithHelp tabId="ai-call">Call</TabWithHelp>, icon: <PlayCircle size={13} />, special: true, group: "action" },
   ];
 
   return (

--- a/apps/admin/components/help/TabWithHelp.tsx
+++ b/apps/admin/components/help/TabWithHelp.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import { Tooltip } from "@/components/shared/Tooltip";
+import { useTabTooltip } from "@/hooks/useTabTooltip";
+
+interface TabWithHelpProps {
+  /** Stable id matching TabHelp.id in lib/help/page-help.ts */
+  tabId: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps a tab label with a delayed-hover tooltip sourced from the
+ * page-help registry. No (i) icon — the label itself is the hover
+ * target (Linear-style).
+ */
+export function TabWithHelp({ tabId, children }: TabWithHelpProps): React.ReactElement {
+  const { about, whenToUse } = useTabTooltip(tabId);
+  if (!about) {
+    return <>{children}</> as React.ReactElement;
+  }
+  const content = (
+    <>
+      {about}
+      {whenToUse ? <span className="hf-tooltip-when">{whenToUse}</span> : null}
+    </>
+  );
+  return <Tooltip content={content}>{children}</Tooltip>;
+}

--- a/apps/admin/components/shared/Tooltip.tsx
+++ b/apps/admin/components/shared/Tooltip.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import "./tooltip.css";
+
+interface TooltipProps {
+  /** Tooltip body — string or arbitrary node. */
+  content: React.ReactNode;
+  /** Delay before showing on hover. Default 500ms — matches the Linear pattern. */
+  delayMs?: number;
+  /** Side-effect-free wrap around any single child element. */
+  children: React.ReactNode;
+}
+
+/**
+ * Canonical delayed-hover tooltip primitive (#689).
+ *
+ * 500ms delay before show prevents flicker on quick mouse-overs; disappears
+ * immediately on mouse-leave. Pure CSS positioning + animation. Uses CSS
+ * vars only — no hardcoded hex, no inline styles for static properties.
+ *
+ * Replaces ad-hoc tooltip impls in AIConfigButton.tsx and SpecRoleBadge.tsx
+ * (their migration is out of scope per the #689 spec).
+ */
+export function Tooltip({ content, delayMs = 500, children }: TooltipProps): React.ReactElement {
+  const [visible, setVisible] = useState(false);
+  const showTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelShow = useCallback(() => {
+    if (showTimerRef.current) {
+      clearTimeout(showTimerRef.current);
+      showTimerRef.current = null;
+    }
+  }, []);
+
+  const handleEnter = useCallback(() => {
+    cancelShow();
+    showTimerRef.current = setTimeout(() => setVisible(true), delayMs);
+  }, [cancelShow, delayMs]);
+
+  const handleLeave = useCallback(() => {
+    cancelShow();
+    setVisible(false);
+  }, [cancelShow]);
+
+  // Clean up on unmount.
+  useEffect(() => cancelShow, [cancelShow]);
+
+  // Render nothing extra when content is empty — keeps DOM tidy for
+  // tabs with no registry entry (#689 AC: "Tabs with no registry entry
+  // show no tooltip").
+  const hasContent = content !== null && content !== undefined && content !== "";
+
+  return (
+    <span
+      className="hf-tooltip-wrap"
+      onMouseEnter={hasContent ? handleEnter : undefined}
+      onMouseLeave={hasContent ? handleLeave : undefined}
+      onFocus={hasContent ? handleEnter : undefined}
+      onBlur={hasContent ? handleLeave : undefined}
+    >
+      {children}
+      {hasContent && visible && (
+        <span className="hf-tooltip-bubble" role="tooltip">
+          {content}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/admin/components/shared/tooltip.css
+++ b/apps/admin/components/shared/tooltip.css
@@ -1,0 +1,49 @@
+.hf-tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.hf-tooltip-bubble {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  min-width: 200px;
+  max-width: 320px;
+  padding: 8px 12px;
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--text-primary) 16%, transparent);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: left;
+  white-space: normal;
+  pointer-events: none;
+  animation: hf-tooltip-in 100ms ease-out;
+}
+
+.hf-tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--border-default);
+}
+
+.hf-tooltip-when {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+@keyframes hf-tooltip-in {
+  from { opacity: 0; transform: translate(-50%, 4px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}

--- a/apps/admin/hooks/useTabTooltip.ts
+++ b/apps/admin/hooks/useTabTooltip.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { getPageHelp } from "@/lib/help/page-help";
+
+interface TabTooltipContent {
+  about?: string;
+  whenToUse?: string;
+}
+
+/**
+ * Look up a tab's tooltip content from the page-help registry (#687).
+ *
+ * Returns {} when the current path has no registered help entry or when the
+ * tabId isn't in that entry's tabs list — the calling component renders no
+ * tooltip in that case (per #689 AC).
+ */
+export function useTabTooltip(tabId: string): TabTooltipContent {
+  const pathname = usePathname() || "/";
+  const pageHelp = getPageHelp(pathname);
+  if (!pageHelp?.tabs) return {};
+  const tab = pageHelp.tabs.find((t) => t.id === tabId);
+  if (!tab) return {};
+  return {
+    about: tab.about,
+    whenToUse: tab.whenToUse,
+  };
+}

--- a/apps/admin/tests/components/Tooltip.test.tsx
+++ b/apps/admin/tests/components/Tooltip.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tooltip primitive (#689) — delayed-hover, dismiss-on-leave behaviour.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
+import React from "react";
+import { Tooltip } from "@/components/shared/Tooltip";
+
+describe("Tooltip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not show before delay", () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="Hello">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(getByText("Trigger").parentElement!);
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(queryByRole("tooltip")).toBeNull();
+  });
+
+  it("shows after 500ms hover (default delay)", () => {
+    const { getByText, queryByRole, getByRole } = render(
+      <Tooltip content="Hello">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(getByText("Trigger").parentElement!);
+    act(() => { vi.advanceTimersByTime(550); });
+    expect(queryByRole("tooltip")).not.toBeNull();
+    expect(getByRole("tooltip").textContent).toBe("Hello");
+  });
+
+  it("hides immediately on mouse-leave", () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="Hello">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+    const wrap = getByText("Trigger").parentElement!;
+    fireEvent.mouseEnter(wrap);
+    act(() => { vi.advanceTimersByTime(550); });
+    expect(queryByRole("tooltip")).not.toBeNull();
+    fireEvent.mouseLeave(wrap);
+    expect(queryByRole("tooltip")).toBeNull();
+  });
+
+  it("cancels pending show when mouse leaves before delay completes", () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="Hello">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+    const wrap = getByText("Trigger").parentElement!;
+    fireEvent.mouseEnter(wrap);
+    act(() => { vi.advanceTimersByTime(200); });
+    fireEvent.mouseLeave(wrap);
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(queryByRole("tooltip")).toBeNull();
+  });
+
+  it("renders no tooltip wrapper handlers when content is empty", () => {
+    // Empty content should NOT trigger a visible tooltip even after hover.
+    const { getByText, queryByRole } = render(
+      <Tooltip content="">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+    const wrap = getByText("Trigger").parentElement!;
+    fireEvent.mouseEnter(wrap);
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(queryByRole("tooltip")).toBeNull();
+  });
+
+  it("respects custom delayMs", () => {
+    const { getByText, queryByRole } = render(
+      <Tooltip content="Quick" delayMs={100}>
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(getByText("Trigger").parentElement!);
+    act(() => { vi.advanceTimersByTime(150); });
+    expect(queryByRole("tooltip")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #689. New `<Tooltip>` canonical primitive + `<TabWithHelp>` wrapper + `useTabTooltip` hook. Wired into Course detail and Learner detail. 6 unit tests for the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)