### PR TITLE
fix(#703): hard-lock non-SUPERADMIN to their institutionId in the wizard

### DIFF
--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -126,6 +126,32 @@ export async function POST(request: NextRequest) {
     // WIZARD mode: handle early (has its own system prompt, no slash commands)
     if (mode === "WIZARD") {
       const userId = authResult.session.user.id;
+
+      // #703 — non-SUPERADMIN users are hard-locked to their session's
+      // institutionId. Even if the client somehow sends a different
+      // institutionId in setupData (modified bundle, multi-institution
+      // join, etc.), reject before any AI call or DB write touches the
+      // wrong tenant. SUPERADMIN keeps the platform-wide ability to pick.
+      if (userRole !== "SUPERADMIN") {
+        const sessionInstitutionId = authResult.session.user.institutionId;
+        const claimedInstitutionId = (setupData as Record<string, unknown> | undefined)?.institutionId;
+        if (
+          typeof claimedInstitutionId === "string" &&
+          claimedInstitutionId.length > 0 &&
+          sessionInstitutionId &&
+          claimedInstitutionId !== sessionInstitutionId
+        ) {
+          return NextResponse.json(
+            {
+              ok: false,
+              error: "Forbidden — you can only build courses within your own institution.",
+              errorCode: "INSTITUTION_MISMATCH",
+            },
+            { status: 403 },
+          );
+        }
+      }
+
       const subjectsCatalog = await getSubjectsCatalog();
       const graphEval = evaluateGraph(setupData || {});
       const turnCount = conversationHistory.filter((m: { role: string }) => m.role === "user").length;

--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -85,8 +85,12 @@ export function V5WizardWithSelector({
     return () => { cancelled = true; };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Show institution selector for SUPERADMIN always, or anyone with 2+ institutions
-  const showInstitutionSelector = isSuperAdmin || institutions.length >= 2;
+  // #703 — Show institution selector ONLY for SUPERADMIN. Non-SUPERADMIN
+  // users are hard-locked to their own session.user.institutionId. Even
+  // when they appear in multiple institutions via UserInstitution joins,
+  // the wizard does not give them a switcher — the server-side guard in
+  // /api/chat (WIZARD mode) is the second line of defense.
+  const showInstitutionSelector = isSuperAdmin;
 
   // Show course selector when courses exist
   const showCourseSelector = courses.length > 0;

--- a/apps/admin/app/x/get-started-v5/page.tsx
+++ b/apps/admin/app/x/get-started-v5/page.tsx
@@ -35,17 +35,12 @@ export default async function GetStartedV5Page({
     return <V5WizardWithSelector defaultInstitution={null} userRole={user.role} defaultCourseId={courseIdParam} courses={[]} />;
   }
 
-  // TODO(institution-lock): non-SUPERADMIN users running the wizard must be
-  // hard-locked to their session.user.institutionId — they should never see
-  // the organisation selector, regardless of how many institutions they have
-  // access to via UserInstitution joins. Today the selector is hidden when
-  // V5WizardWithSelector sees `institutions.length < 2`, but that's a UX
-  // signal, not a security guard. The wizard accepts a selected id from the
-  // client and trusts it. Tighten by either:
-  //   (a) drop the institution selector entirely for non-SUPERADMIN, OR
-  //   (b) enforce institutionId === session.user.institutionId in the
-  //       create-course API for non-SUPERADMIN roles.
-  // Track via GitHub issue if you want it in the backlog.
+  // #703 — institution lock for non-SUPERADMIN is enforced two ways:
+  //   (a) V5WizardWithSelector hides the institution selector unless
+  //       userRole === "SUPERADMIN", so the affordance to switch is gone.
+  //   (b) /api/chat (WIZARD mode) rejects requests whose setupData
+  //       institutionId differs from session.user.institutionId with a
+  //       403 (errorCode INSTITUTION_MISMATCH).
 
   const institution = await prisma.institution.findUnique({
     where: { id: institutionId, isActive: true },


### PR DESCRIPTION
Closes #703. Two-layer defence: UI hides the selector for non-SUPERADMIN, /api/chat WIZARD mode rejects mismatched institutionId in setupData with 403 INSTITUTION_MISMATCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)