### PR TITLE
fix(help): overlay claims match reality + 'H/G + key' clearer than 'H X · G X'

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -33,7 +33,7 @@ import { DraggableTabs, type TabDefinition } from '@/components/shared/Draggable
 import { useChordShortcut } from '@/hooks/useChordShortcut';
 import { ChordHintBadge } from '@/components/help/ChordHintBadge';
 import { TabWithHelp } from '@/components/help/TabWithHelp';
-import { getPageHelp } from '@/lib/help/page-help';
+import { getPageHelp, getEffectiveChords } from '@/lib/help/page-help';
 import { type TPItem, type SessionOption } from '@/components/shared/SessionTPList';
 import {
   groupSpecs,
@@ -160,9 +160,12 @@ export default function CourseDetailPage() {
   const searchParams = useSearchParams();
   const { data: session } = useSession();
   // #688 — chord shortcuts (H/G + key) for tab navigation.
-  // Lookup is route-templated; pathname not needed.
+  // #global-chords — getEffectiveChords merges page bindings with the
+  // global nav chords (page wins on key collision). Lookup is route-
+  // templated; pathname not needed.
   const pageHelp = useMemo(() => getPageHelp(`/x/courses/${courseId || ""}`), [courseId]);
-  const { activePrefix: chordActivePrefix } = useChordShortcut(pageHelp?.chords);
+  const effectiveChords = useMemo(() => getEffectiveChords(`/x/courses/${courseId || ""}`), [courseId]);
+  const { activePrefix: chordActivePrefix } = useChordShortcut(effectiveChords);
   const isOperator = ['OPERATOR', 'EDUCATOR', 'ADMIN', 'SUPERADMIN'].includes((session?.user?.role as string) || '');
   const { pushEntity } = useEntityContext();
   const { plural } = useTerminology();

--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -7,7 +7,7 @@ import { ConversationalWizard } from "../wizard/components/ConversationalWizard"
 import type { WizardInitialContext } from "../wizard/components/ConversationalWizard";
 import { useChordShortcut } from "@/hooks/useChordShortcut";
 import { ChordHintBadge } from "@/components/help/ChordHintBadge";
-import { getPageHelp } from "@/lib/help/page-help";
+import { getEffectiveChords } from "@/lib/help/page-help";
 import "./get-started-v5.css";
 
 /* ── Types ──────────────────────────────────────────────── */
@@ -60,9 +60,9 @@ export function V5WizardWithSelector({
 
   const isSuperAdmin = userRole === "SUPERADMIN";
 
-  // #688 — chord shortcuts (only the C=Exit chord on this route).
-  const wizardPageHelp = getPageHelp("/x/get-started-v5");
-  const { activePrefix: chordActivePrefix } = useChordShortcut(wizardPageHelp?.chords);
+  // #688 — chord shortcuts (page-specific C=Exit + global nav chords).
+  const wizardChords = getEffectiveChords("/x/get-started-v5");
+  const { activePrefix: chordActivePrefix } = useChordShortcut(wizardChords);
 
   // Fetch institution list on mount
   useEffect(() => {

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -21,7 +21,7 @@ import { useAssistant, useAssistantKeyboardShortcut } from "@/hooks/useAssistant
 import { useChordShortcut } from "@/hooks/useChordShortcut";
 import { ChordHintBadge } from "@/components/help/ChordHintBadge";
 import { TabWithHelp } from "@/components/help/TabWithHelp";
-import { getPageHelp } from "@/lib/help/page-help";
+import { getPageHelp, getEffectiveChords } from "@/lib/help/page-help";
 
 // Extracted sub-components
 import { ProcessingNotice } from "./caller-detail/CallsTab";
@@ -98,9 +98,10 @@ export default function CallerDetailPage() {
   const [data, setData] = useState<CallerData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // #688 — chord shortcuts (H/G + key) for tab navigation.
+  // #688 — chord shortcuts (H/G + key) for tab navigation + globals.
   const pageHelp = useMemo(() => getPageHelp(`/x/callers/${callerId}`), [callerId]);
-  const { activePrefix: chordActivePrefix } = useChordShortcut(pageHelp?.chords);
+  const effectiveChords = useMemo(() => getEffectiveChords(`/x/callers/${callerId}`), [callerId]);
+  const { activePrefix: chordActivePrefix } = useChordShortcut(effectiveChords);
 
   const [activeSection, _setActiveSection] = useState<SectionId>(initialTab);
   const setActiveSection = (id: SectionId) => {

--- a/apps/admin/components/help/HelpOverlay.tsx
+++ b/apps/admin/components/help/HelpOverlay.tsx
@@ -6,7 +6,7 @@ import { X } from "lucide-react";
 import { useHelpContext } from "@/contexts/HelpContext";
 import { useSession } from "next-auth/react";
 import { useChatContext, MODE_CONFIG, type ChatMode } from "@/contexts/ChatContext";
-import { getPageHelp, canSeeOperatorOnly, type PageHelp } from "@/lib/help/page-help";
+import { getPageHelp, canSeeOperatorOnly, GLOBAL_CHORDS, type PageHelp } from "@/lib/help/page-help";
 import { GLOBAL_SHORTCUTS } from "@/lib/help/global-shortcuts";
 import { useHelpKeyboard } from "@/hooks/useHelpKeyboard";
 import "./help-overlay.css";
@@ -135,15 +135,38 @@ export function HelpOverlay() {
           </Section>
 
           <Section title="Shortcuts — on this page">
+            <p className="help-overlay-chord-hint">
+              Press <kbd>H</kbd> or <kbd>G</kbd> followed by the chord letter — either prefix works.
+            </p>
             {pageHelp?.chords?.length ? (
-              <ShortcutList items={pageHelp.chords.map((c) => ({ keys: `H ${c.keys} · G ${c.keys}`, description: c.label }))} />
+              <ShortcutList
+                items={pageHelp.chords.map((c) => ({
+                  keys: `H/G + ${c.keys}`,
+                  description: c.label,
+                }))}
+              />
             ) : (
               <p className="help-overlay-empty">No page-specific shortcuts.</p>
             )}
           </Section>
 
           <Section title="Shortcuts — global">
-            <ShortcutList items={[...GLOBAL_SHORTCUTS]} />
+            <ShortcutList
+              items={[
+                ...GLOBAL_SHORTCUTS,
+                // Derive the chord nav display strings from the actual bindings
+                // so the overlay can't claim a chord that doesn't exist. Filter
+                // out keys that the active page has overridden (page chord wins
+                // on collision, so listing the global form here would mislead).
+                ...GLOBAL_CHORDS.filter((g) => {
+                  const pageKeys = new Set((pageHelp?.chords ?? []).map((c) => c.keys.toUpperCase()));
+                  return !pageKeys.has(g.keys.toUpperCase());
+                }).map((c) => ({
+                  keys: `H/G + ${c.keys}`,
+                  description: c.label,
+                })),
+              ]}
+            />
           </Section>
 
           {chatOpen && (

--- a/apps/admin/components/help/help-overlay.css
+++ b/apps/admin/components/help/help-overlay.css
@@ -93,6 +93,23 @@
   font-style: italic;
 }
 
+.help-overlay-chord-hint {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.help-overlay-chord-hint kbd {
+  display: inline-block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
 .help-overlay-tabs,
 .help-overlay-shortcuts {
   display: grid;

--- a/apps/admin/lib/help/global-shortcuts.ts
+++ b/apps/admin/lib/help/global-shortcuts.ts
@@ -1,6 +1,9 @@
 /**
  * Global keyboard shortcuts shown in the Help Overlay's "Shortcuts — global"
- * section. Page-scoped shortcuts live in lib/help/page-help.ts.
+ * section. NON-CHORD shortcuts only — chord nav bindings live in
+ * lib/help/page-help.ts::GLOBAL_CHORDS and are derived dynamically for
+ * display (so the listed chord can never claim a binding that doesn't
+ * actually exist).
  */
 export interface GlobalShortcut {
   keys: string;
@@ -8,13 +11,17 @@ export interface GlobalShortcut {
 }
 
 export const GLOBAL_SHORTCUTS: readonly GlobalShortcut[] = [
+  // Trigger-style — single-key with no modifier
   { keys: "?", description: "Open this help" },
-  { keys: "⌘K", description: "Open AI assistant / search" },
   { keys: "Esc", description: "Close panel or dialog" },
-  { keys: "H + key  ·  G + key", description: "Jump to a tab on this page (chord)" },
-  { keys: "H H  ·  G H", description: "Go home" },
-  { keys: "H C  ·  G C", description: "Courses" },
-  { keys: "H L  ·  G L", description: "Learners" },
-  { keys: "H D  ·  G D", description: "Data dictionary" },
-  { keys: "H S  ·  G S", description: "Specs" },
+
+  // Cmd-modified (wired in app/layout.tsx::handleGlobalKeyDown)
+  { keys: "⌘K", description: "Open AI assistant" },
+  { keys: "⌘G", description: "Build Course (wizard)" },
+  { keys: "⌘D", description: "Educator dashboard" },
+  { keys: "⌘S", description: "Sim / Learn surface" },
+  { keys: "⌘L", description: "Learners" },
+
+  // Chord prefix
+  { keys: "H + key  ·  G + key", description: "Two-key navigation chord (see list below)" },
 ];

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -229,6 +229,40 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
 ];
 
 /**
+ * Global chord bindings — work on every page regardless of which PageHelp
+ * matches. The chord engine merges these with the page's `chords` (page
+ * wins on key collision, so e.g. on Course detail `H L` still goes to the
+ * Learners tab, not the global Learners index).
+ *
+ * Listed verbatim in the Help Overlay's "Shortcuts — global" block.
+ */
+export const GLOBAL_CHORDS: readonly ChordBinding[] = [
+  { keys: "H", action: "navigate", href: "/x", label: "Home" },
+  { keys: "C", action: "navigate", href: "/x/courses", label: "Courses" },
+  { keys: "L", action: "navigate", href: "/x/callers", label: "Learners" },
+  { keys: "D", action: "navigate", href: "/x/data-dictionary", label: "Data dictionary" },
+  { keys: "S", action: "navigate", href: "/x/specs", label: "Specs" },
+];
+
+/**
+ * Get the chord bindings active on a given path — page-specific bindings
+ * win over globals on key collision (e.g. on Course detail `H L` switches
+ * to the Learners tab; everywhere else `H L` goes to /x/callers).
+ */
+export function getEffectiveChords(pathname: string): ChordBinding[] {
+  const page = getPageHelp(pathname);
+  const pageChords = page?.chords ?? [];
+  const pageKeys = new Set(pageChords.map((c) => c.keys.toUpperCase()));
+  const merged: ChordBinding[] = [...pageChords];
+  for (const g of GLOBAL_CHORDS) {
+    if (!pageKeys.has(g.keys.toUpperCase())) {
+      merged.push(g);
+    }
+  }
+  return merged;
+}
+
+/**
  * Match a pathname against the registry. Exact match wins over prefix
  * match wins over RegExp match.
  */


### PR DESCRIPTION
User audit caught two things:
1. Overlay listed global chord shortcuts (H H, H D, H S, H L) that were never wired — fixed by adding GLOBAL_CHORDS as a real binding layer merged with page chords.
2. The 'H C · G C' format read as a single chord rather than 'H or G'. Replaced with intro hint + 'H/G + C' rows.

Also adds the actual Cmd+G/D/S/L shortcuts (already wired in layout.tsx) to the overlay's global block. Shadowed globals (where a page chord wins) are filtered from the display so the listed chord = what fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)