### PR TITLE
chore(shortcuts): drop Cmd+L — return the address bar to the browser

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -147,7 +147,10 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
     }
   }, [sidebarWidth, collapsed]);
 
-  // Global keyboard shortcuts for top-nav items
+  // Global keyboard shortcuts for top-nav items.
+  // Cmd+L intentionally NOT bound — the browser owns Cmd+L for the address
+  // bar; reclaiming it broke muscle memory. Use H/G+L (the global chord) or
+  // the sidebar to reach Learners.
   useEffect(() => {
     const handleGlobalKeyDown = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
@@ -155,7 +158,6 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
       if (key === 'g') { e.preventDefault(); router.push('/x/get-started-v5'); }
       else if (key === 'd') { e.preventDefault(); router.push('/x/educator'); }
       else if (key === 's') { e.preventDefault(); router.push('/x/sim'); }
-      else if (key === 'l') { e.preventDefault(); router.push('/x/callers'); }
     };
     window.addEventListener('keydown', handleGlobalKeyDown);
     return () => window.removeEventListener('keydown', handleGlobalKeyDown);

--- a/apps/admin/lib/help/global-shortcuts.ts
+++ b/apps/admin/lib/help/global-shortcuts.ts
@@ -20,7 +20,7 @@ export const GLOBAL_SHORTCUTS: readonly GlobalShortcut[] = [
   { keys: "⌘G", description: "Build Course (wizard)" },
   { keys: "⌘D", description: "Educator dashboard" },
   { keys: "⌘S", description: "Sim / Learn surface" },
-  { keys: "⌘L", description: "Learners" },
+  // ⌘L intentionally left to the browser (address bar). Use H/G+L instead.
 
   // Chord prefix
   { keys: "H + key  ·  G + key", description: "Two-key navigation chord (see list below)" },


### PR DESCRIPTION
User feedback: Cmd+L overriding the browser address bar broke muscle memory. H/G+L chord or sidebar still reach Learners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)