### PR TITLE
feat(#721): per-row + bulk download for course sources

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/content-sources/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/content-sources/route.ts
@@ -11,9 +11,10 @@ import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
  * @tags courses, content-trust
  * @description Returns a flat list of content sources linked to this course via PlaybookSource.
  *   No subject grouping — sources are course-scoped. Includes per-source assertion counts
- *   split into content vs instruction categories.
+ *   split into content vs instruction categories, plus the latest MediaAsset id + fileName
+ *   so the UI can render a download link via `/api/media/:id`.
  * @pathParam courseId string - Playbook UUID
- * @response 200 { ok, sources, course, totals }
+ * @response 200 { ok, sources: Array<{ id, name, documentType, extractorVersion, assertionCount, contentAssertionCount, instructionAssertionCount, sortOrder, tags, mediaAssetId, mediaFileName }>, course, totals }
  * @response 404 { ok: false, error }
  */
 export async function GET(
@@ -59,6 +60,11 @@ export async function GET(
             documentType: true,
             extractorVersion: true,
             _count: { select: { assertions: true } },
+            mediaAssets: {
+              select: { id: true, fileName: true },
+              take: 1,
+              orderBy: { createdAt: "desc" },
+            },
           },
         },
       },
@@ -87,6 +93,7 @@ export async function GET(
     const sources = playbookSources.map((ps) => {
       const assertionCount = ps.source._count.assertions;
       const instructionCount = instrMap.get(ps.sourceId) || 0;
+      const media = ps.source.mediaAssets[0] ?? null;
       return {
         id: ps.source.id,
         name: ps.source.name,
@@ -97,6 +104,8 @@ export async function GET(
         instructionAssertionCount: instructionCount,
         sortOrder: ps.sortOrder,
         tags: ps.tags,
+        mediaAssetId: media?.id ?? null,
+        mediaFileName: media?.fileName ?? null,
       };
     });
 

--- a/apps/admin/app/x/courses/[courseId]/CourseIntelligenceTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseIntelligenceTab.tsx
@@ -17,7 +17,7 @@ import Link from 'next/link';
 import {
   BookMarked, AlertTriangle, Zap, RefreshCw,
   Map as MapIcon, ChevronDown,
-  Plus, Trash2, Upload,
+  Plus, Trash2, Upload, Download,
 } from 'lucide-react';
 import { getDocTypeInfo } from '@/lib/doc-type-icons';
 import { CONTENT_CATEGORIES, getCategoryStyle } from '@/lib/content-categories';
@@ -40,6 +40,8 @@ type SourceItem = {
   instructionAssertionCount: number;
   sortOrder: number;
   tags: string[];
+  mediaAssetId: string | null;
+  mediaFileName: string | null;
 };
 
 type SubjectSummary = {
@@ -274,8 +276,10 @@ function GroupedAssertionList({ items, groupBy, drawerAssertionId, onSelect }: {
 
 /**
  * Single row in the Sources list. Renders the doc-type icon, source name,
- * type badge, and assertion count link to the source detail page. For
- * operators, shows two icon-only action buttons:
+ * type badge, and assertion count link to the source detail page. Shows a
+ * Download icon (any role) when a MediaAsset is attached, and Extract +
+ * Delete icons for operators:
+ *  - Download: links to /api/media/[id] (Content-Disposition: attachment)
  *  - Extract: re-runs assertion extraction on the source (POST /content-sources/[id]/extract)
  *  - Delete: hard cascade delete (DELETE /content-sources/[id]/permanent)
  *
@@ -309,28 +313,42 @@ function SourceRow({
           <span className="ci-source-count">{src.assertionCount}</span>
         )}
       </Link>
-      {isOperator && (
-        <div className="ci-source-actions">
-          <button
+      <div className="ci-source-actions">
+        {src.mediaAssetId && (
+          <a
             className="hf-btn hf-btn-xs hf-btn-icon"
-            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onExtract(); }}
-            disabled={busy}
-            title="Re-extract assertions from this source"
-            aria-label={`Extract ${src.name}`}
+            href={`/api/media/${src.mediaAssetId}`}
+            download={src.mediaFileName ?? src.name}
+            onClick={(e) => e.stopPropagation()}
+            title={`Download ${src.mediaFileName ?? src.name}`}
+            aria-label={`Download ${src.mediaFileName ?? src.name}`}
           >
-            <RefreshCw size={12} />
-          </button>
-          <button
-            className="hf-btn hf-btn-xs hf-btn-icon hf-btn-danger"
-            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDelete(); }}
-            disabled={busy}
-            title="Delete this source and all its extracted content (cascade)"
-            aria-label={`Delete ${src.name}`}
-          >
-            <Trash2 size={12} />
-          </button>
-        </div>
-      )}
+            <Download size={12} />
+          </a>
+        )}
+        {isOperator && (
+          <>
+            <button
+              className="hf-btn hf-btn-xs hf-btn-icon"
+              onClick={(e) => { e.preventDefault(); e.stopPropagation(); onExtract(); }}
+              disabled={busy}
+              title="Re-extract assertions from this source"
+              aria-label={`Extract ${src.name}`}
+            >
+              <RefreshCw size={12} />
+            </button>
+            <button
+              className="hf-btn hf-btn-xs hf-btn-icon hf-btn-danger"
+              onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDelete(); }}
+              disabled={busy}
+              title="Delete this source and all its extracted content (cascade)"
+              aria-label={`Delete ${src.name}`}
+            >
+              <Trash2 size={12} />
+            </button>
+          </>
+        )}
+      </div>
     </div>
   );
 }
@@ -592,6 +610,34 @@ export function CourseIntelligenceTab({
     return { courseGuideSources: guides, otherSources: others, allSources: [...guides, ...others] };
   }, [courseSources]);
 
+  // ── Download all (#721) ──────────────────────────────
+  // Sequential <a download> clicks — no zip dep, no new endpoint. Chrome
+  // throttles bulk downloads to ~10 simultaneous, so we space them.
+  const downloadableSources = useMemo(
+    () => allSources.filter((s) => !!s.mediaAssetId),
+    [allSources],
+  );
+  const [downloadingAll, setDownloadingAll] = useState(false);
+  const handleDownloadAll = useCallback(async () => {
+    if (downloadableSources.length === 0) return;
+    setDownloadingAll(true);
+    try {
+      for (const src of downloadableSources) {
+        const a = document.createElement("a");
+        a.href = `/api/media/${src.mediaAssetId}`;
+        a.download = src.mediaFileName ?? src.name;
+        a.rel = "noopener";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        // 250ms gap keeps Chrome from collapsing identical-filename downloads
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    } finally {
+      setDownloadingAll(false);
+    }
+  }, [downloadableSources]);
+
   // ── Auto-assign handler ──────────────────────────────
   const handleBackfill = useCallback(async () => {
     setBackfilling(true);
@@ -672,41 +718,55 @@ export function CourseIntelligenceTab({
             <span className="ci-panel-title">
               <BookMarked size={14} /> Sources ({allSources.length})
             </span>
-            {isOperator && (
-              <div className="hf-flex hf-items-center hf-gap-xs">
-                {/* Hidden file input — opened by the + button. */}
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  multiple
-                  accept=".pdf,.docx,.txt,.md,.markdown,.json"
-                  className="hf-hidden"
-                  onChange={(e) => {
-                    const picked = Array.from(e.target.files ?? []);
-                    if (picked.length > 0) handleFiles(picked);
-                    e.target.value = ""; // allow re-picking the same file
-                  }}
-                />
+            <div className="hf-flex hf-items-center hf-gap-xs">
+              {downloadableSources.length > 0 && (
                 <button
-                  className="hf-btn hf-btn-xs hf-btn-primary hf-flex hf-items-center hf-gap-xs"
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={uploading || !primarySubjectId}
-                  title={primarySubjectId ? "Upload a file to this course" : "No subject linked yet"}
+                  className="hf-btn hf-btn-xs hf-btn-secondary hf-flex hf-items-center hf-gap-xs"
+                  onClick={handleDownloadAll}
+                  disabled={downloadingAll}
+                  title={`Download all ${downloadableSources.length} source file${downloadableSources.length === 1 ? "" : "s"}`}
+                  aria-label="Download all source files"
                 >
-                  <Plus size={12} />
-                  Add
+                  <Download size={12} />
+                  {downloadingAll ? "Downloading…" : "Download all"}
                 </button>
-                {allSources.length > 0 && (
+              )}
+              {isOperator && (
+                <>
+                  {/* Hidden file input — opened by the + button. */}
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    multiple
+                    accept=".pdf,.docx,.txt,.md,.markdown,.json"
+                    className="hf-hidden"
+                    onChange={(e) => {
+                      const picked = Array.from(e.target.files ?? []);
+                      if (picked.length > 0) handleFiles(picked);
+                      e.target.value = ""; // allow re-picking the same file
+                    }}
+                  />
                   <button
-                    className="hf-btn hf-btn-xs hf-btn-secondary hf-flex hf-items-center hf-gap-xs"
-                    onClick={() => setShowReExtract(true)}
+                    className="hf-btn hf-btn-xs hf-btn-primary hf-flex hf-items-center hf-gap-xs"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploading || !primarySubjectId}
+                    title={primarySubjectId ? "Upload a file to this course" : "No subject linked yet"}
                   >
-                    <RefreshCw size={12} />
-                    Re-extract
+                    <Plus size={12} />
+                    Add
                   </button>
-                )}
-              </div>
-            )}
+                  {allSources.length > 0 && (
+                    <button
+                      className="hf-btn hf-btn-xs hf-btn-secondary hf-flex hf-items-center hf-gap-xs"
+                      onClick={() => setShowReExtract(true)}
+                    >
+                      <RefreshCw size={12} />
+                      Re-extract
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
           </div>
           {opError && (
             <div className="hf-banner hf-banner-error hf-text-xs" role="alert">

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -95,6 +95,8 @@ type SourceItem = {
   instructionAssertionCount: number;
   sortOrder: number;
   tags: string[];
+  mediaAssetId: string | null;
+  mediaFileName: string | null;
 };
 
 type SubjectSummary = {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.340",
+  "version": "0.7.341",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -5313,7 +5313,7 @@ Returns a flat list of content sources linked to this course via PlaybookSource.
 
 **Response** `200`
 ```json
-{ ok, sources, course, totals }
+{ ok, sources: Array<{ id, name, documentType, extractorVersion, assertionCount, contentAssertionCount, instructionAssertionCount, sortOrder, tags, mediaAssetId, mediaFileName }>, course, totals }
 ```
 
 **Response** `404`


### PR DESCRIPTION
## Summary
- Adds a Download icon to each Sources row on the Course Intelligence tab — hover-revealed, all roles, links to `/api/media/[id]` (existing endpoint, VIEWER auth, `Content-Disposition: attachment`)
- Adds a "Download all" button in the Sources panel header — sequential `<a download>` clicks spaced 250ms apart, no zip dep
- API route `/api/courses/[courseId]/content-sources` now returns `mediaAssetId` + `mediaFileName` per source

## Why this approach
No new endpoint, no new deps. Per-row click is a pure frontend change; bulk uses sequential downloads since the testers need to grab a handful of files, not 50. If we hit Chrome's bulk-download throttle we can upgrade to a server-streamed zip later.

Closes #721

## Test plan
- [ ] Visit `/x/courses/[any-courseId]?tab=intelligence`
- [ ] Hover a Sources row → Download icon appears, click → file downloads with original filename
- [ ] Click "Download all" in panel header → each source file downloads in sequence
- [ ] Sources with no `MediaAsset` show no per-row Download icon (hidden, not disabled)
- [ ] Row click on name/badge still navigates to source detail page (download icon doesn't bubble)

🤖 Generated with [Claude Code](https://claude.com/claude-code)