### PR TITLE
chore: ratchet fix — vi.mocked() in section-data-loader test (+ 0.7.342)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.341",
+  "version": "0.7.342",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/lib/composition/section-data-loader.test.ts
+++ b/apps/admin/tests/lib/composition/section-data-loader.test.ts
@@ -237,22 +237,24 @@ describe("behaviorTargets loader — #713 bug 4 cross-learner scope=CALLER filte
   });
 
   it("filters scope=CALLER targets to those whose callerIdentity belongs to the caller", async () => {
-    (prisma.behaviorTarget.findMany as any).mockResolvedValue([]);
+    vi.mocked(prisma.behaviorTarget.findMany).mockResolvedValue([]);
     await getLoader("behaviorTargets")!("caller-A");
 
     // Inspect the `where` clause that was passed to prisma
-    const call = (prisma.behaviorTarget.findMany as any).mock.calls[0][0];
-    expect(call.where).toMatchObject({ effectiveUntil: null });
-    expect(call.where.OR).toEqual([
+    const call = vi.mocked(prisma.behaviorTarget.findMany).mock.calls[0][0];
+    expect(call?.where).toMatchObject({ effectiveUntil: null });
+    expect(call?.where?.OR).toEqual([
       { scope: { not: "CALLER" } },
       { callerIdentity: { callerId: "caller-A" } },
     ]);
   });
 
   it("does not surface scope=CALLER targets belonging to other callers", async () => {
+    type OrClause = { scope?: { not?: string }; callerIdentity?: { callerId?: string } };
+    type FindManyArgs = { where?: { OR?: OrClause[] } };
     // Simulate Bob asking for his targets; the DB filter should ensure
     // Alice's scope=CALLER row never even enters the result set.
-    (prisma.behaviorTarget.findMany as any).mockImplementation((args: any) => {
+    vi.mocked(prisma.behaviorTarget.findMany).mockImplementation(((args: FindManyArgs) => {
       const all = [
         // Alice's per-caller tune
         { id: "bt-alice", scope: "CALLER", targetValue: 0.9, callerIdentityId: "ident-alice", callerIdentity: { callerId: "alice" }, parameter: { parameterId: "BEH-WARMTH" } },
@@ -266,14 +268,14 @@ describe("behaviorTargets loader — #713 bug 4 cross-learner scope=CALLER filte
       return Promise.resolve(
         all.filter((t) => {
           if (orClauses.length === 0) return true;
-          return orClauses.some((c: any) => {
+          return orClauses.some((c: OrClause) => {
             if (c.scope?.not && t.scope !== c.scope.not) return true;
             if (c.callerIdentity?.callerId && t.callerIdentity?.callerId === c.callerIdentity.callerId) return true;
             return false;
           });
         }),
       );
-    });
+    }) as never);
 
     const bobTargets = await getLoader("behaviorTargets")!("bob");
     const ids = (bobTargets as Array<{ id: string }>).map((t) => t.id);


### PR DESCRIPTION
## Summary
- 5 net-new `as any` / `: any` annotations crept into the `behaviorTargets` test block added by #713, pushing `lint_warnings` 4468 → 4473 and blocking `/deploy:gate dev`.
- Replaced with `vi.mocked()` and a local `FindManyArgs` / `OrClause` shape — same 6 tests pass.
- Version bumped 0.7.341 → 0.7.342.

## Why now
Testers blocked on missing bootstrap prompts in DEV. Root cause is DEV being ~12 commits behind `main` (missing #682 `loadComposeConfig` fix + `7031c3c4` `Call.callSequence` fix). This PR clears the ratchet so `/deploy` to DEV can proceed.

## Test plan
- [x] `npx eslint tests/lib/composition/section-data-loader.test.ts` → 11 warnings (== baseline)
- [x] `npx vitest run tests/lib/composition/section-data-loader.test.ts` → 6/6 pass
- [ ] After merge: full `/deploy` to DEV unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)