### PR TITLE
feat(#733): URL-sync ticket detail + Cmd+K context-aware + sticky actions

### DIFF
--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -112,6 +112,10 @@ export async function POST(request: NextRequest) {
       typeof rawBody?.discussionTicketId === "string" && rawBody.discussionTicketId.length > 0
         ? rawBody.discussionTicketId
         : undefined;
+    // #733 — small route hint so DATA mode can inject a "Feedback list mode"
+    // digest when the user is on `/x/feedback` without a specific ticket.
+    const pageHintRoute: string | undefined =
+      typeof rawBody?.pageHint?.route === "string" ? rawBody.pageHint.route : undefined;
 
     if (!message) {
       return NextResponse.json({ ok: false, error: "Message is required" }, { status: 400 });
@@ -239,7 +243,7 @@ export async function POST(request: NextRequest) {
       userRole,
       userInstitutionId,
       tuningScope,
-      { discussionTicketId, sessionUserId: authResult.session.user.id },
+      { discussionTicketId, sessionUserId: authResult.session.user.id, pageHintRoute },
     );
 
     // Prepare messages with conversation history

--- a/apps/admin/app/api/chat/system-prompts.ts
+++ b/apps/admin/app/api/chat/system-prompts.ts
@@ -4,7 +4,7 @@ import type { PlaybookConfig } from "@/lib/types/json-fields";
 import { resolveSourceFiles, getClaudeMdContext, type BugContext } from "@/lib/chat/bug-context";
 import { resolveTerminology, TECHNICAL_TERMS, type TermMap } from "@/lib/terminology";
 import { buildTuningSystemPrompt, type TuningScope } from "@/lib/chat/tuning-system-prompt";
-import { loadTicketContext } from "@/lib/chat/ticket-context";
+import { loadTicketContext, loadRecentTicketsDigest } from "@/lib/chat/ticket-context";
 import { getPromptSpec } from "@/lib/prompts/spec-prompts";
 import { config } from "@/lib/config";
 
@@ -59,6 +59,13 @@ export interface BuildSystemPromptOptions {
   discussionTicketId?: string;
   /** Required when discussionTicketId is set — institution-scope guard. */
   sessionUserId?: string;
+  /**
+   * #733 — when the user is on `/x/feedback` without a specific ticket
+   * selected, append a "Feedback list mode" digest with the 5 most recent
+   * OPEN/IN_PROGRESS tickets so the assistant can ask "which one?" rather
+   * than hallucinate. Only fires when `discussionTicketId` is unset.
+   */
+  pageHintRoute?: string;
 }
 
 export async function buildSystemPrompt(
@@ -90,12 +97,13 @@ export async function buildSystemPrompt(
       // errors. See #603 follow-up (the chat panel only exposes DATA mode
       // — MODE_CONFIG in ChatContext.tsx has no TUNING tab — so this is
       // the path every Cmd+K message takes).
-      const [dataPrompt, tuningContext, ticketBlock] = await Promise.all([
+      const [dataPrompt, tuningContext, ticketBlock, listHintBlock] = await Promise.all([
         getPromptSpec(config.specs.chatDataHelper, DATA_SYSTEM_PROMPT),
         buildTuningSystemPrompt({ entityContext }),
         buildTicketDiscussionBlock(options, userRole, institutionId),
+        buildFeedbackListHintBlock(options, userRole, institutionId),
       ]);
-      return { prompt: dataPrompt + "\n\n" + tuningContext + termBlock + `\n\n${baseContext}` + ticketBlock };
+      return { prompt: dataPrompt + "\n\n" + tuningContext + termBlock + `\n\n${baseContext}` + ticketBlock + listHintBlock };
     }
     case "TUNING": {
       // TUNING mode: catalogue + truthfulness rules + scope-aware write tools.
@@ -110,6 +118,27 @@ export async function buildSystemPrompt(
     case "BUG":
       return { prompt: await buildBugDiagnosisPrompt(entityContext, bugContext, termBlock) };
   }
+}
+
+/**
+ * #733 — when the user is on `/x/feedback` without a selected ticket, inject
+ * a short digest of recent OPEN/IN_PROGRESS tickets so the assistant can ask
+ * "which one?" instead of guessing. Only fires when no discussionTicketId is
+ * set (otherwise the Active Ticket block already gives full context).
+ */
+async function buildFeedbackListHintBlock(
+  options: BuildSystemPromptOptions | undefined,
+  userRole: string | undefined,
+  institutionId: string | null | undefined,
+): Promise<string> {
+  if (!options?.pageHintRoute || options.pageHintRoute !== "/x/feedback") return "";
+  if (options.discussionTicketId) return ""; // active ticket → no need for the digest
+  const block = await loadRecentTicketsDigest(
+    institutionId ?? null,
+    userRole === "SUPERADMIN",
+    5,
+  );
+  return `\n\n${block}`;
 }
 
 /**

--- a/apps/admin/app/x/feedback/feedback.css
+++ b/apps/admin/app/x/feedback/feedback.css
@@ -207,16 +207,54 @@
   border-top: none;
   border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
-  padding: 16px 20px;
   margin-bottom: 2px;
+  /* #733 — outer padding moved to .pfb-detail-body-content so the sticky
+     actions bar sits flush with the panel edges and stays full-width. */
+  padding: 0;
+}
+
+/* #733 — sticky actions bar above the scrollable content. */
+.pfb-detail-actions-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 20px;
+  background: var(--surface-primary);
+  border-bottom: 1px solid var(--border-default);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.pfb-detail-actions-sticky-left,
+.pfb-detail-actions-sticky-right {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.pfb-detail-status-select {
+  max-width: 180px;
 }
 
 .pfb-detail-section {
   margin-bottom: 16px;
+  /* #733 — horizontal padding lives on the section so the sticky actions bar
+     above can sit flush with the panel edges. */
+  padding: 0 20px;
+}
+
+.pfb-detail-section:first-of-type {
+  padding-top: 16px;
 }
 
 .pfb-detail-section:last-child {
   margin-bottom: 0;
+  padding-bottom: 16px;
 }
 
 .pfb-detail-label {

--- a/apps/admin/app/x/feedback/page.tsx
+++ b/apps/admin/app/x/feedback/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from "react";
 import { useSession } from "next-auth/react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import type { Ticket, TicketStatus, TicketCategory, TicketComment } from "@/types/tickets";
 import { formatRelativeTime, getUserInitials, getCategoryIcon } from "@/utils/formatters";
@@ -61,8 +62,13 @@ export default function FeedbackPage(): React.ReactElement {
   const [search, setSearch] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("newest");
 
-  // Detail panel
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  // Detail panel — URL-synced (#733) so refresh + back-button work and Cmd+K
+  // can pick up the active ticket without an extra click.
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlTicketId = searchParams?.get("ticket") ?? null;
+  const [expandedId, setExpandedId] = useState<string | null>(urlTicketId);
 
   // Modal
   const [showSubmit, setShowSubmit] = useState(false);
@@ -111,8 +117,29 @@ export default function FeedbackPage(): React.ReactElement {
   }, [searched, sortKey]);
 
   const toggleExpand = useCallback((id: string) => {
-    setExpandedId((prev) => (prev === id ? null : id));
-  }, []);
+    setExpandedId((prev) => {
+      const next = prev === id ? null : id;
+      // Push the ticket id into the URL so Cmd+K, refresh, and back-button
+      // all see the same state. Replace when collapsing so the back-button
+      // doesn't get a no-op entry.
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
+      if (next) {
+        params.set("ticket", next);
+        router.push(`${pathname}?${params.toString()}`, { scroll: false });
+      } else {
+        params.delete("ticket");
+        const qs = params.toString();
+        router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      }
+      return next;
+    });
+  }, [router, pathname, searchParams]);
+
+  // Keep `expandedId` in sync with the URL when it changes from elsewhere
+  // (e.g. user hits back, or someone deep-links into a ticket).
+  useEffect(() => {
+    setExpandedId(urlTicketId);
+  }, [urlTicketId]);
 
   const isOwn = useCallback((ticket: Ticket): boolean => ticket.creatorId === userId, [userId]);
 
@@ -127,13 +154,13 @@ export default function FeedbackPage(): React.ReactElement {
               <div className="pfb-tabs">
                 <button
                   className={`pfb-tab${activeTab === "mine" ? " active" : ""}`}
-                  onClick={() => { setActiveTab("mine"); setExpandedId(null); }}
+                  onClick={() => { setActiveTab("mine"); setExpandedId(null); router.replace(pathname, { scroll: false }); }}
                 >
                   Mine
                 </button>
                 <button
                   className={`pfb-tab${activeTab === "all" ? " active" : ""}`}
-                  onClick={() => { setActiveTab("all"); setExpandedId(null); }}
+                  onClick={() => { setActiveTab("all"); setExpandedId(null); router.replace(pathname, { scroll: false }); }}
                 >
                   All
                 </button>
@@ -378,11 +405,14 @@ function FeedbackDetail({
 
   const canEdit = isOwn && ticket?.status === "OPEN";
 
-  // #727 v1 — "Discuss with AI" wires this ticket into the Assistant's system
-  // prompt. Clear when the panel unmounts so a stale ticketId doesn't leak
-  // into a follow-up DATA-mode chat the user opens from elsewhere.
+  // #727 v1 + #733 — when a ticket detail is open, the Assistant should already
+  // know about it the moment the user opens chat (Cmd+K). Set the discussion
+  // ticket as soon as the ticket data loads and clear it on unmount.
   const chat = useChatContext();
   useEffect(() => {
+    if (ticket) {
+      chat.setDiscussionTicket(ticket.id, ticket.ticketNumber ?? null);
+    }
     return () => {
       // Only clear if this panel set the discussion — guard against racing
       // a second panel that hasn't unmounted yet.
@@ -391,7 +421,7 @@ function FeedbackDetail({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ticketId]);
+  }, [ticketId, ticket?.id, ticket?.ticketNumber]);
 
   const handleDiscussWithAI = (): void => {
     if (!ticket) return;
@@ -487,13 +517,22 @@ function FeedbackDetail({
 
   return (
     <div className="pfb-detail">
-      {/* Admin status control — OPERATOR+ only, not gated on OPEN */}
-      {isAdmin && (
-        <div className="pfb-detail-section">
-          <div className="pfb-detail-label">Status</div>
-          <div className="pfb-status-control">
+      {/* #733 — sticky actions bar: stays visible at the top of the detail
+          panel regardless of how long the description / comment thread grows.
+          Discuss with AI + status (admin) live on the left, Edit / Delete /
+          Close on the right. */}
+      <div className="pfb-detail-actions-sticky">
+        <div className="pfb-detail-actions-sticky-left">
+          <button
+            className="hf-btn hf-btn-primary"
+            onClick={handleDiscussWithAI}
+            title="Open the AI Assistant with this ticket loaded as context"
+          >
+            ✦ Discuss with AI
+          </button>
+          {isAdmin && (
             <select
-              className="hf-input"
+              className="hf-input pfb-detail-status-select"
               value={ticket.status}
               onChange={(e) => handleStatusChange(e.target.value as TicketStatus)}
               disabled={submitting}
@@ -505,9 +544,24 @@ function FeedbackDetail({
                 </option>
               ))}
             </select>
-          </div>
+          )}
         </div>
-      )}
+        <div className="pfb-detail-actions-sticky-right">
+          {canEdit && !editing && (
+            <button className="hf-btn hf-btn-secondary" onClick={startEdit}>
+              Edit
+            </button>
+          )}
+          {canDelete && (
+            <button className="hf-btn hf-btn-destructive" onClick={handleDelete} disabled={submitting}>
+              {confirmDelete ? "Confirm delete?" : "Delete"}
+            </button>
+          )}
+          <button className="hf-btn hf-btn-secondary" onClick={onClose} title="Close detail">
+            ✕
+          </button>
+        </div>
+      </div>
 
       {/* Description */}
       <div className="pfb-detail-section">
@@ -595,29 +649,6 @@ function FeedbackDetail({
         </div>
       )}
 
-      {/* Actions bar */}
-      <div className="pfb-detail-actions">
-        <button
-          className="hf-btn hf-btn-primary"
-          onClick={handleDiscussWithAI}
-          title="Open the AI Assistant with this ticket loaded as context"
-        >
-          ✦ Discuss with AI
-        </button>
-        {canEdit && !editing && (
-          <button className="hf-btn hf-btn-secondary" onClick={startEdit}>
-            Edit
-          </button>
-        )}
-        {canDelete && (
-          <button className="hf-btn hf-btn-destructive" onClick={handleDelete} disabled={submitting}>
-            {confirmDelete ? "Confirm delete?" : "Delete"}
-          </button>
-        )}
-        <button className="hf-btn hf-btn-secondary" onClick={onClose}>
-          Close
-        </button>
-      </div>
     </div>
   );
 }

--- a/apps/admin/contexts/ChatContext.tsx
+++ b/apps/admin/contexts/ChatContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
 import { EntityBreadcrumb, useEntityContext } from "./EntityContext";
 
 export type ChatMode = "DATA" | "TUNING";
@@ -198,6 +199,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
   // Get entity context for including in messages
   const entityContext = useEntityContext();
+  // #733 — route hint lets the chat API inject a small "Feedback list mode"
+  // digest when the user is on /x/feedback without a specific ticket open.
+  const pathname = usePathname();
 
   // Load persisted state on mount or when user changes
   useEffect(() => {
@@ -370,6 +374,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               isCommand: true,
               ...(mode === "TUNING" ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
+              ...(mode === "DATA" && pathname ? { pageHint: { route: pathname } } : {}),
             }),
           });
 
@@ -424,6 +429,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               conversationHistory: history,
               ...(mode === "TUNING" ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
+              ...(mode === "DATA" && pathname ? { pageHint: { route: pathname } } : {}),
             }),
             signal: abortControllerRef.current.signal,
           });
@@ -498,7 +504,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         abortControllerRef.current = null;
       }
     },
-    [mode, tuningScope, discussionTicketId, isStreaming, entityContext.breadcrumbs, messages, addMessage, updateMessage, appendToMessage]
+    [mode, tuningScope, discussionTicketId, pathname, isStreaming, entityContext.breadcrumbs, messages, addMessage, updateMessage, appendToMessage]
   );
 
   const value: ChatContextValue = {

--- a/apps/admin/lib/chat/ticket-context.ts
+++ b/apps/admin/lib/chat/ticket-context.ts
@@ -1,4 +1,60 @@
 /**
+ * #733 — when the user opens the chat on `/x/feedback` without a specific
+ * ticket selected (list view), inject a small digest of recent OPEN /
+ * IN_PROGRESS tickets so the assistant can ask "which one?" instead of
+ * pretending to know. Scope-guarded: non-SUPERADMIN sees only tickets from
+ * users in their own institution.
+ */
+export async function loadRecentTicketsDigest(
+  sessionInstitutionId: string | null,
+  isSuperadmin: boolean,
+  limit: number = 5,
+): Promise<string> {
+  const tickets = await prisma.ticket.findMany({
+    where: {
+      status: { in: ["OPEN", "IN_PROGRESS"] },
+      ...(isSuperadmin ? {} : sessionInstitutionId
+        ? { creator: { institutionId: sessionInstitutionId } }
+        : { id: "__never__" }), // No institution → see nothing
+    },
+    orderBy: { updatedAt: "desc" },
+    take: limit,
+    select: {
+      ticketNumber: true,
+      title: true,
+      status: true,
+      category: true,
+      updatedAt: true,
+      creator: { select: { name: true, email: true } },
+    },
+  });
+
+  if (tickets.length === 0) {
+    return [
+      "## Feedback list mode",
+      "",
+      "The user is on the Feedback list page. There are NO open or in-progress tickets visible to them.",
+      "If they ask about tickets, say so politely.",
+    ].join("\n");
+  }
+
+  const lines: string[] = [
+    "## Feedback list mode",
+    "",
+    "The user is on the Feedback list page and has NOT selected a specific ticket.",
+    `Here are the ${tickets.length} most recently updated OPEN / IN_PROGRESS tickets:`,
+    "",
+  ];
+  for (const t of tickets) {
+    const who = t.creator.name ?? t.creator.email;
+    lines.push(`- **#${t.ticketNumber}** [${t.status}] ${t.category} — "${t.title.slice(0, 80)}" (by ${who}, updated ${t.updatedAt.toISOString()})`);
+  }
+  lines.push("");
+  lines.push("**When the user asks about a ticket**: ask which one (by number), or list these for them to pick. Do not invent a ticket they didn't reference. Once they pick one, suggest they expand it on the page so the assistant gets full context (description + comments + screenshot).");
+  return lines.join("\n");
+}
+
+/**
  * Loads a Ticket + comment thread for injection into the Assistant's system
  * prompt when the user clicks "Discuss with AI" on a feedback ticket.
  *

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.343",
+  "version": "0.7.344",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/lib/chat/ticket-context.test.ts
+++ b/apps/admin/tests/lib/chat/ticket-context.test.ts
@@ -11,11 +11,11 @@
  *   - Ticket whose creator has no institutionId returns reason=no_creator_institution for non-SUPERADMIN
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { loadTicketContext } from "@/lib/chat/ticket-context";
+import { loadTicketContext, loadRecentTicketsDigest } from "@/lib/chat/ticket-context";
 
 vi.mock("@/lib/prisma", () => {
   const mock = {
-    ticket: { findUnique: vi.fn() },
+    ticket: { findUnique: vi.fn(), findMany: vi.fn() },
   };
   return { prisma: mock };
 });
@@ -212,5 +212,49 @@ describe("loadTicketContext — comment filter + truncation", () => {
       // It should contain the truncation marker
       expect(result.block).toContain("…");
     }
+  });
+});
+
+describe("loadRecentTicketsDigest — #733 list-mode hint", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders a digest with the 5 most-recent OPEN/IN_PROGRESS tickets", async () => {
+    vi.mocked(prisma.ticket.findMany).mockResolvedValue([
+      { ticketNumber: 12, title: "Login broken", status: "OPEN", category: "BUG", updatedAt: new Date("2026-05-24T08:00:00Z"), creator: { name: "Pat", email: "p@x" } },
+      { ticketNumber: 11, title: "Suggestion: dark mode", status: "IN_PROGRESS", category: "FEATURE", updatedAt: new Date("2026-05-23T20:00:00Z"), creator: { name: "Sam", email: "s@x" } },
+    ] as never);
+    const block = await loadRecentTicketsDigest("inst-A", false, 5);
+    expect(block).toContain("Feedback list mode");
+    expect(block).toContain("#12");
+    expect(block).toContain("Login broken");
+    expect(block).toContain("#11");
+    expect(block).toContain("ask which one");
+  });
+
+  it("returns an explicit 'no tickets' block when none match", async () => {
+    vi.mocked(prisma.ticket.findMany).mockResolvedValue([] as never);
+    const block = await loadRecentTicketsDigest("inst-A", false, 5);
+    expect(block).toContain("NO open or in-progress tickets");
+  });
+
+  it("scopes by creator.institutionId for non-SUPERADMIN", async () => {
+    vi.mocked(prisma.ticket.findMany).mockResolvedValue([] as never);
+    await loadRecentTicketsDigest("inst-A", false, 5);
+    const callArgs = vi.mocked(prisma.ticket.findMany).mock.calls[0][0] as { where: Record<string, unknown> };
+    expect(callArgs.where).toMatchObject({ creator: { institutionId: "inst-A" } });
+  });
+
+  it("SUPERADMIN sees all institutions (no creator scope)", async () => {
+    vi.mocked(prisma.ticket.findMany).mockResolvedValue([] as never);
+    await loadRecentTicketsDigest("inst-A", true, 5);
+    const callArgs = vi.mocked(prisma.ticket.findMany).mock.calls[0][0] as { where: Record<string, unknown> };
+    expect(callArgs.where).not.toHaveProperty("creator");
+  });
+
+  it("returns the 'no creator institution' fallback (id=__never__) when session has no institution", async () => {
+    vi.mocked(prisma.ticket.findMany).mockResolvedValue([] as never);
+    await loadRecentTicketsDigest(null, false, 5);
+    const callArgs = vi.mocked(prisma.ticket.findMany).mock.calls[0][0] as { where: Record<string, unknown> };
+    expect(callArgs.where).toMatchObject({ id: "__never__" });
   });
 });


### PR DESCRIPTION
## Summary
- `?ticket=<uuid>` is now in the URL — refresh, back-button, deep-link all work.
- `FeedbackDetail` sets `discussionTicketId` on mount, so Cmd+K opens chat with the ticket already loaded (no extra click).
- New `loadRecentTicketsDigest()` builds a short list-mode hint for the DATA prompt when on `/x/feedback` without a ticket open — the model asks "which one?" instead of hallucinating.
- Action bar (Discuss with AI / status / Edit / Delete / Close) lifted from the bottom into a sticky top bar — Close no longer scrolls off-screen on long tickets.

Closes #733.

## Test plan
- [x] 14/14 ticket-context tests pass
- [x] tsc clean on touched files (199 total, -12 under baseline)
- [x] ratchet at baseline (no new lint warnings)
- [ ] Manual UI on localhost:3000:
  - [ ] Open ticket → URL shows `?ticket=<uuid>` → refresh → ticket auto-expands
  - [ ] Open ticket → Cmd+K → stripe shows "✦ Discussing ticket #N" immediately
  - [ ] On list with no ticket open → Cmd+K → ask "tell me about a ticket" → AI lists recent ones
  - [ ] Action bar stays pinned at the top while scrolling long content

🤖 Generated with [Claude Code](https://claude.com/claude-code)