### PR TITLE
feat(#734): auto-status transitions — OPEN→IN_PROGRESS on pickup, WAITING→IN_PROGRESS on resume

### DIFF
--- a/apps/admin/app/api/tickets/[ticketId]/comments/route.ts
+++ b/apps/admin/app/api/tickets/[ticketId]/comments/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { ROLE_LEVEL } from "@/lib/roles";
 import type { UserRole } from "@prisma/client";
+import { applyAutoStatusTransition } from "@/lib/feedback/auto-status";
 
 /**
  * @api GET /api/tickets/:ticketId/comments
@@ -85,11 +86,11 @@ export async function GET(
  * @scope tickets:comments-create
  * @auth session
  * @tags tickets
- * @description Adds a comment to a ticket and updates the ticket's updatedAt timestamp. TESTER+ can comment on own tickets. Partners cannot create internal comments.
+ * @description Adds a comment to a ticket and updates the ticket's updatedAt timestamp. TESTER+ can comment on own tickets. Partners cannot create internal comments. #734 — runs `applyAutoStatusTransition` in the same transaction: OPEN→IN_PROGRESS on first non-creator comment, WAITING→IN_PROGRESS on any comment.
  * @pathParam ticketId string - The ticket ID
  * @body content string - Comment text (required)
  * @body isInternal boolean - Whether comment is internal-only (default: false)
- * @response 201 { ok: true, comment: {...} }
+ * @response 201 { ok: true, comment: {...}, autoStatus: { transitioned: boolean, from?: TicketStatus, to?: TicketStatus, autoCommentId?: string } }
  * @response 400 { ok: false, error: "Comment content is required" }
  * @response 401 { ok: false, error: "Unauthorized" }
  * @response 403 { ok: false, error: "You can only comment on your own feedback" | "Internal comments are not available" }
@@ -116,16 +117,18 @@ export async function POST(
       );
     }
 
-    // Partners can only comment on their own tickets
+    // Fetch ticket once — we need creatorId for the partner-ownership guard,
+    // status for the #734 auto-status rules, and existence either way.
+    const ticket = await prisma.ticket.findUnique({
+      where: { id: ticketId },
+      select: { id: true, creatorId: true, status: true },
+    });
+    if (!ticket) {
+      return NextResponse.json({ ok: false, error: "Ticket not found" }, { status: 404 });
+    }
+
     const roleLevel = ROLE_LEVEL[session.user.role as UserRole] ?? 0;
     if (roleLevel < 3) {
-      const ticket = await prisma.ticket.findUnique({
-        where: { id: ticketId },
-        select: { creatorId: true },
-      });
-      if (!ticket) {
-        return NextResponse.json({ ok: false, error: "Ticket not found" }, { status: 404 });
-      }
       if (ticket.creatorId !== session.user.id) {
         return NextResponse.json({ ok: false, error: "You can only comment on your own feedback" }, { status: 403 });
       }
@@ -135,38 +138,43 @@ export async function POST(
       }
     }
 
-    // Verify ticket exists (for OPERATOR+ who skip the guard above)
-    if (roleLevel >= 3) {
-      const ticket = await prisma.ticket.findUnique({
-        where: { id: ticketId },
-        select: { id: true },
-      });
-      if (!ticket) {
-        return NextResponse.json({ ok: false, error: "Ticket not found" }, { status: 404 });
-      }
-    }
-
-    const comment = await prisma.ticketComment.create({
-      data: {
-        ticketId,
-        authorId: session.user.id,
-        content: content.trim(),
-        isInternal: isInternal || false,
-      },
-      include: {
-        author: {
-          select: { id: true, name: true, email: true, image: true },
+    // #734 — comment insert + auto-status transition + auto-comment all in one
+    // transaction so a failed status update rolls the user's comment back too.
+    const { comment, autoStatusResult } = await prisma.$transaction(async (tx) => {
+      const comment = await tx.ticketComment.create({
+        data: {
+          ticketId,
+          authorId: session.user.id,
+          content: content.trim(),
+          isInternal: isInternal || false,
         },
-      },
+        include: {
+          author: {
+            select: { id: true, name: true, email: true, image: true },
+          },
+        },
+      });
+
+      // Bump ticket.updatedAt regardless of status flip.
+      await tx.ticket.update({
+        where: { id: ticketId },
+        data: { updatedAt: new Date() },
+      });
+
+      const autoStatusResult = await applyAutoStatusTransition({
+        ticketId,
+        ticketStatusBefore: ticket.status,
+        ticketCreatorId: ticket.creatorId,
+        commentAuthorId: session.user.id,
+        commentAuthorName: comment.author.name ?? comment.author.email ?? "Someone",
+        triggeredByCommentId: comment.id,
+        tx,
+      });
+
+      return { comment, autoStatusResult };
     });
 
-    // Update ticket's updatedAt
-    await prisma.ticket.update({
-      where: { id: ticketId },
-      data: { updatedAt: new Date() },
-    });
-
-    return NextResponse.json({ ok: true, comment }, { status: 201 });
+    return NextResponse.json({ ok: true, comment, autoStatus: autoStatusResult }, { status: 201 });
   } catch (error) {
     console.error("POST /api/tickets/[ticketId]/comments error:", error);
     return NextResponse.json(

--- a/apps/admin/lib/feedback/auto-status.ts
+++ b/apps/admin/lib/feedback/auto-status.ts
@@ -1,0 +1,124 @@
+/**
+ * #734 — auto status transitions on ticket activity.
+ *
+ * Rules (conservative v1):
+ *   - First comment from someone OTHER than the creator on an OPEN ticket
+ *     → status becomes IN_PROGRESS, post internal "Auto: picked up by …" comment.
+ *   - Any comment on a WAITING ticket
+ *     → status becomes IN_PROGRESS, post internal "Auto: activity resumed by …" comment.
+ *
+ * Not in v1 (parked):
+ *   - RESOLVED → CLOSED via reporter "verified" keyword (too fragile; the
+ *     Verify Fixed button in #730 covers this).
+ *   - RESOLVED → OPEN via reporter "still broken" keyword (same).
+ *   - IN_PROGRESS → WAITING after N days stale (needs a cron).
+ *
+ * Implementation notes:
+ *   - Runs inside the same prisma `$transaction` that creates the user's
+ *     comment. If the status update fails, the comment insert rolls back too.
+ *   - `where: { id, status: <prev> }` guard makes concurrent calls idempotent:
+ *     if two operators comment on an OPEN ticket within ms of each other, only
+ *     the first flips the status; the second is a no-op.
+ *   - The auto-comment is `isInternal=true` so partners don't see it.
+ *     Author = the human whose action triggered the transition (NOT a synthetic
+ *     "system" user), so audit attribution is clear.
+ *   - Audit log uses `lib/audit.ts` (string action, no Prisma enum needed).
+ */
+
+import type { Prisma, TicketStatus } from "@prisma/client";
+import { auditLog } from "@/lib/audit";
+
+// Audit string (mirrors the existing string-action pattern in lib/audit.ts —
+// no Prisma enum / migration needed).
+const AUTO_ACTION = "ticket_status_auto_changed" as const;
+
+export interface AutoStatusInput {
+  ticketId: string;
+  /** Status the ticket had immediately BEFORE this comment was inserted. */
+  ticketStatusBefore: TicketStatus;
+  /** Creator of the ticket — used to detect self-comments (skip pickup rule). */
+  ticketCreatorId: string;
+  /** Author of the new comment — drives the rules + audit attribution. */
+  commentAuthorId: string;
+  commentAuthorName: string;
+  /** The comment row that just got created — referenced from the audit metadata. */
+  triggeredByCommentId: string;
+  /** Transaction client — auto-status must run in the same tx as the comment. */
+  tx: Prisma.TransactionClient;
+}
+
+export interface AutoStatusResult {
+  transitioned: boolean;
+  from?: TicketStatus;
+  to?: TicketStatus;
+  autoCommentId?: string;
+}
+
+export async function applyAutoStatusTransition(input: AutoStatusInput): Promise<AutoStatusResult> {
+  const { ticketId, ticketStatusBefore, ticketCreatorId, commentAuthorId, commentAuthorName, triggeredByCommentId, tx } = input;
+
+  let toStatus: TicketStatus | null = null;
+  let autoBody: string | null = null;
+
+  // Rule 1 — OPEN + non-creator first comment → IN_PROGRESS
+  if (ticketStatusBefore === "OPEN" && commentAuthorId !== ticketCreatorId) {
+    toStatus = "IN_PROGRESS";
+    autoBody = `Auto: picked up by ${commentAuthorName}`;
+  }
+  // Rule 2 — WAITING + any comment → IN_PROGRESS
+  else if (ticketStatusBefore === "WAITING") {
+    toStatus = "IN_PROGRESS";
+    autoBody = `Auto: activity resumed by ${commentAuthorName}`;
+  }
+
+  if (!toStatus || !autoBody) {
+    return { transitioned: false };
+  }
+
+  // Conditional update: only flips if status is still what we expect. If a
+  // racing call already flipped it, `update.count === 0` and we bail out.
+  const updateResult = await tx.ticket.updateMany({
+    where: { id: ticketId, status: ticketStatusBefore },
+    data: { status: toStatus },
+  });
+  if (updateResult.count === 0) {
+    return { transitioned: false };
+  }
+
+  // Post the internal audit comment in the same transaction.
+  const autoComment = await tx.ticketComment.create({
+    data: {
+      ticketId,
+      authorId: commentAuthorId,
+      content: autoBody,
+      isInternal: true,
+    },
+    select: { id: true },
+  });
+
+  // Audit log — non-blocking, never throws. Called outside the tx is fine; the
+  // ticket+comment writes are already durable by the time we get here.
+  // Note: auditLog itself checks the toggle and silently no-ops when disabled.
+  auditLog({
+    userId: commentAuthorId,
+    action: AUTO_ACTION,
+    entityType: "Ticket",
+    entityId: ticketId,
+    metadata: {
+      from: ticketStatusBefore,
+      to: toStatus,
+      triggeredByCommentId,
+      autoCommentId: autoComment.id,
+      reason: ticketStatusBefore === "OPEN" ? "pickup" : "resume",
+    },
+  }).catch((err) => {
+    console.warn("[auto-status] audit log failed (non-fatal):", err);
+  });
+
+  return {
+    transitioned: true,
+    from: ticketStatusBefore,
+    to: toStatus,
+    autoCommentId: autoComment.id,
+  };
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.344",
+  "version": "0.7.345",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/lib/feedback/auto-status.test.ts
+++ b/apps/admin/tests/lib/feedback/auto-status.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #734 — applyAutoStatusTransition()
+ *
+ * Rules under test:
+ *   - OPEN + non-creator comment → IN_PROGRESS, autoBody = "Auto: picked up by …"
+ *   - OPEN + creator's OWN comment → no transition
+ *   - WAITING + any comment → IN_PROGRESS, autoBody = "Auto: activity resumed by …"
+ *   - IN_PROGRESS / RESOLVED / CLOSED → no transition
+ *   - Concurrent flip (status no longer matches) → no transition + no auto-comment
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Prisma } from "@prisma/client";
+import { applyAutoStatusTransition } from "@/lib/feedback/auto-status";
+
+// Audit module is fire-and-forget — stub so the test never hits a real DB.
+vi.mock("@/lib/audit", () => ({
+  AuditAction: {},
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+function makeTx(opts: { updateCount: number; autoCommentId?: string }): Prisma.TransactionClient {
+  const updateMany = vi.fn().mockResolvedValue({ count: opts.updateCount });
+  const create = vi.fn().mockResolvedValue({ id: opts.autoCommentId ?? "auto-1" });
+  return {
+    ticket: { updateMany },
+    ticketComment: { create },
+  } as unknown as Prisma.TransactionClient;
+}
+
+describe("applyAutoStatusTransition — pickup rule (OPEN + non-creator)", () => {
+  it("transitions OPEN → IN_PROGRESS when a non-creator comments", async () => {
+    const tx = makeTx({ updateCount: 1, autoCommentId: "auto-A" });
+    const result = await applyAutoStatusTransition({
+      ticketId: "t1",
+      ticketStatusBefore: "OPEN",
+      ticketCreatorId: "creator-x",
+      commentAuthorId: "operator-y",
+      commentAuthorName: "Ola",
+      triggeredByCommentId: "human-1",
+      tx,
+    });
+    expect(result.transitioned).toBe(true);
+    expect(result.from).toBe("OPEN");
+    expect(result.to).toBe("IN_PROGRESS");
+    expect(result.autoCommentId).toBe("auto-A");
+    // updateMany was guarded by current status
+    const updateArgs = vi.mocked(tx.ticket.updateMany).mock.calls[0][0];
+    expect(updateArgs).toEqual({ where: { id: "t1", status: "OPEN" }, data: { status: "IN_PROGRESS" } });
+    // Auto-comment is internal, attributed to the human who acted
+    const commentArgs = vi.mocked(tx.ticketComment.create).mock.calls[0][0];
+    expect(commentArgs.data).toMatchObject({
+      ticketId: "t1",
+      authorId: "operator-y",
+      isInternal: true,
+    });
+    expect(commentArgs.data.content).toContain("Auto: picked up by Ola");
+  });
+
+  it("does NOT transition when the creator comments on their own OPEN ticket", async () => {
+    const tx = makeTx({ updateCount: 0 });
+    const result = await applyAutoStatusTransition({
+      ticketId: "t1",
+      ticketStatusBefore: "OPEN",
+      ticketCreatorId: "creator-x",
+      commentAuthorId: "creator-x", // same as creator
+      commentAuthorName: "Creator",
+      triggeredByCommentId: "human-1",
+      tx,
+    });
+    expect(result).toEqual({ transitioned: false });
+    expect(tx.ticket.updateMany).not.toHaveBeenCalled();
+    expect(tx.ticketComment.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyAutoStatusTransition — resume rule (WAITING + any comment)", () => {
+  it("transitions WAITING → IN_PROGRESS on any comment (including creator's)", async () => {
+    const tx = makeTx({ updateCount: 1, autoCommentId: "auto-B" });
+    const result = await applyAutoStatusTransition({
+      ticketId: "t1",
+      ticketStatusBefore: "WAITING",
+      ticketCreatorId: "creator-x",
+      commentAuthorId: "creator-x",
+      commentAuthorName: "Creator",
+      triggeredByCommentId: "human-1",
+      tx,
+    });
+    expect(result.transitioned).toBe(true);
+    expect(result.from).toBe("WAITING");
+    expect(result.to).toBe("IN_PROGRESS");
+    const commentArgs = vi.mocked(tx.ticketComment.create).mock.calls[0][0];
+    expect(commentArgs.data.content).toContain("Auto: activity resumed by Creator");
+  });
+});
+
+describe("applyAutoStatusTransition — terminal / mid states", () => {
+  for (const status of ["IN_PROGRESS", "RESOLVED", "CLOSED"] as const) {
+    it(`no-op when status is ${status}`, async () => {
+      const tx = makeTx({ updateCount: 0 });
+      const result = await applyAutoStatusTransition({
+        ticketId: "t1",
+        ticketStatusBefore: status,
+        ticketCreatorId: "creator-x",
+        commentAuthorId: "operator-y",
+        commentAuthorName: "Ola",
+        triggeredByCommentId: "human-1",
+        tx,
+      });
+      expect(result).toEqual({ transitioned: false });
+      expect(tx.ticket.updateMany).not.toHaveBeenCalled();
+      expect(tx.ticketComment.create).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe("applyAutoStatusTransition — concurrent flip", () => {
+  it("returns transitioned=false when updateMany.count = 0 (another caller already flipped status)", async () => {
+    const tx = makeTx({ updateCount: 0 }); // simulate the race-loser
+    const result = await applyAutoStatusTransition({
+      ticketId: "t1",
+      ticketStatusBefore: "OPEN", // we *thought* it was OPEN but a concurrent comment already moved it
+      ticketCreatorId: "creator-x",
+      commentAuthorId: "operator-y",
+      commentAuthorName: "Ola",
+      triggeredByCommentId: "human-1",
+      tx,
+    });
+    expect(result).toEqual({ transitioned: false });
+    // We attempted the guarded update but didn't insert the auto-comment
+    expect(tx.ticket.updateMany).toHaveBeenCalledOnce();
+    expect(tx.ticketComment.create).not.toHaveBeenCalled();
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -13777,7 +13777,7 @@ Lists comments for a ticket with pagination. Includes author details. Internal c
 
 ### `POST` /api/tickets/:ticketId/comments
 
-Adds a comment to a ticket and updates the ticket's updatedAt timestamp. TESTER+ can comment on own tickets. Partners cannot create internal comments.
+Adds a comment to a ticket and updates the ticket's updatedAt timestamp. TESTER+ can comment on own tickets. Partners cannot create internal comments. #734 — runs `applyAutoStatusTransition` in the same transaction: OPEN→IN_PROGRESS on first non-creator comment, WAITING→IN_PROGRESS on any comment.
 
 **Auth**: Session · **Scope**: `tickets:comments-create`
 
@@ -13789,7 +13789,7 @@ Adds a comment to a ticket and updates the ticket's updatedAt timestamp. TESTER+
 
 **Response** `201`
 ```json
-{ ok: true, comment: {...} }
+{ ok: true, comment: {...}, autoStatus: { transitioned: boolean, from?: TicketStatus, to?: TicketStatus, autoCommentId?: string } }
 ```
 
 **Response** `400`


### PR DESCRIPTION
## Summary
- Two conservative rules fire when a comment is added:
  - OPEN + comment from someone **other** than the creator → IN_PROGRESS + internal "Auto: picked up by {name}" comment.
  - WAITING + any comment → IN_PROGRESS + internal "Auto: activity resumed by {name}" comment.
- All other statuses are no-ops. Reporter "verified" / "still broken" keyword reopens are deliberately NOT in v1 — too fragile; the explicit Verify Fixed button in #730 will cover those.
- Status update + auto-comment + human comment all run in **one transaction** — failed status update rolls the human's comment back too. `updateMany({where:{id,status:<prev>}})` makes concurrent commits race-safe.
- No migration. Audit string `"ticket_status_auto_changed"` slots into the existing `lib/audit.ts` pattern.

Closes #734.

## Test plan
- [x] 7/7 unit tests pass — pickup, self-pickup skip, resume, 3× no-op (IN_PROGRESS / RESOLVED / CLOSED), concurrent-flip race
- [x] tsc clean, ratchet at baseline (199 / 4468)
- [ ] Manual: open a ticket (OPEN) as the creator → admin comments → status flips to IN_PROGRESS, "Auto: picked up by …" internal note appears
- [ ] Manual: move ticket to WAITING → anyone comments → status flips to IN_PROGRESS, "Auto: activity resumed by …" note

## Out of scope (parked)
- Reporter keyword reopens / verifications (handled by #730 Verify Fixed button)
- Stale → WAITING cron (needs separate design)
- Edit-only activity (editing title/desc doesn't fire — only comments do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)