### PR TITLE
fix(#733): move router.push out of setExpandedId updater

### DIFF
--- a/apps/admin/app/x/feedback/page.tsx
+++ b/apps/admin/app/x/feedback/page.tsx
@@ -117,23 +117,28 @@ export default function FeedbackPage(): React.ReactElement {
   }, [searched, sortKey]);
 
   const toggleExpand = useCallback((id: string) => {
-    setExpandedId((prev) => {
-      const next = prev === id ? null : id;
-      // Push the ticket id into the URL so Cmd+K, refresh, and back-button
-      // all see the same state. Replace when collapsing so the back-button
-      // doesn't get a no-op entry.
-      const params = new URLSearchParams(searchParams?.toString() ?? "");
-      if (next) {
-        params.set("ticket", next);
-        router.push(`${pathname}?${params.toString()}`, { scroll: false });
-      } else {
-        params.delete("ticket");
-        const qs = params.toString();
-        router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-      }
-      return next;
-    });
-  }, [router, pathname, searchParams]);
+    // Compute the next value OUTSIDE the state updater. Calling router.push
+    // inside a setState updater triggers React's "Cannot update a component
+    // while rendering a different component" warning because the updater
+    // function runs during render. Reading `expandedId` from closure is
+    // fine here — the click handler runs after render, so the closure is
+    // already up to date for this event.
+    const next = expandedId === id ? null : id;
+    setExpandedId(next);
+
+    // Push the ticket id into the URL so Cmd+K, refresh, and back-button
+    // all see the same state. Replace when collapsing so the back-button
+    // doesn't get a no-op entry.
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    if (next) {
+      params.set("ticket", next);
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    } else {
+      params.delete("ticket");
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    }
+  }, [expandedId, router, pathname, searchParams]);
 
   // Keep `expandedId` in sync with the URL when it changes from elsewhere
   // (e.g. user hits back, or someone deep-links into a ticket).

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.345",
+  "version": "0.7.346",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary
- React was warning "Cannot update a component (Router) while rendering a different component (FeedbackPage)" — `router.push` was inside the `setExpandedId` updater.
- Updater functions can run during React's reconciliation pass; triggering another component's state from there is an anti-pattern.
- Compute `next` from the `expandedId` closure value, call `setExpandedId(next)` plain, then push the URL as a normal side-effect after.

## Test plan
- [x] tsc clean, 14/14 ticket-context tests pass
- [ ] Manual on localhost:3000: click a ticket row → no console warning, row expands, URL gets `?ticket=…`
- [ ] Click another row → no warning, first row collapses, URL updates
- [ ] Refresh with `?ticket=<uuid>` → row auto-expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)