### PR TITLE
chore(#726): StatusBar shows 'SANDBOX' not 'VM'

### DIFF
--- a/apps/admin/components/shared/EnvironmentBanner.tsx
+++ b/apps/admin/components/shared/EnvironmentBanner.tsx
@@ -103,16 +103,11 @@ export function isLocalhost(): boolean {
 export default function EnvironmentBanner() {
   useEffect(() => {
     if (ENV_CANONICAL === 'PROD') return;
-    const isLocal = isLocalhost();
-    let label: string;
-    if (isLocal) {
-      // VM. If DB is switched to another env, show "VM→PILOT" / "VM→STAGING".
-      const target = (envDbTarget || '').toUpperCase();
-      label = target && target !== 'SANDBOX' ? `VM→${target}` : 'VM';
-    } else {
-      label = ENV_CANONICAL;
-    }
-    const base = document.title.replace(/^\[(VM|VM→\w+|SANDBOX|STAGING|PILOT|PROD|DEV|TEST|STG|LIVE)\]\s*/, '');
+    // Tab label uses the canonical env name. When the VM is pointed at a
+    // different env's DB (via /db-switch), show the arrow form: "SANDBOX→PILOT".
+    const target = (envDbTarget || '').toUpperCase();
+    const label = target && target !== ENV_CANONICAL ? `${ENV_CANONICAL}→${target}` : ENV_CANONICAL;
+    const base = document.title.replace(/^\[(VM|VM→\w+|SANDBOX|SANDBOX→\w+|STAGING|STAGING→\w+|PILOT|PILOT→\w+|PROD|DEV|TEST|STG|LIVE)\]\s*/, '');
     document.title = `[${label}] ${base || 'HFF'}`;
   }, []);
 

--- a/apps/admin/components/shared/StatusBar.tsx
+++ b/apps/admin/components/shared/StatusBar.tsx
@@ -26,7 +26,7 @@ import { ROLE_LEVEL } from '@/lib/roles';
 import { useBranding } from '@/contexts/BrandingContext';
 import { useMasquerade } from '@/contexts/MasqueradeContext';
 import { useErrorCapture } from '@/contexts/ErrorCaptureContext';
-import { envLabel, envSidebarColor, envTextColor, showEnvBanner, isLocalhost, envDbTarget, envCanonical, dbTargetColor } from './EnvironmentBanner';
+import { envLabel, envSidebarColor, envTextColor, showEnvBanner, envDbTarget, envCanonical, dbTargetColor } from './EnvironmentBanner';
 import { JobsPopup } from './JobsPopup';
 import { HealthPopup } from './HealthPopup';
 import type { IniResult } from './HealthPopup';
@@ -298,8 +298,7 @@ export function StatusBar() {
             Single chip when env matches DB target (default).
             Two-part chip [SANDBOX | DB→PILOT] when sandbox VM is pointed at another env's DB. */}
         {showEnvBanner && envLabel && envSidebarColor && (() => {
-          const onVm = isLocalhost();
-          const baseLabel = onVm && envCanonical === 'SANDBOX' ? 'VM' : envLabel;
+          const baseLabel = envLabel;
           const switched = !!envDbTarget && envDbTarget.toUpperCase() !== envCanonical;
           const targetColor = switched ? dbTargetColor(envDbTarget) : null;
           return (

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.346",
+  "version": "0.7.347",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary

Follow-up to #737. The env badge was abbreviating to `VM` when on localhost + sandbox env — but you asked for the env name and the abbreviation hid it. Show `SANDBOX` instead. Same fix for browser tab title prefix.

After `/db-switch pilot`, badge reads `SANDBOX | DB→PILOT` (already correct from #737) and tab title now reads `[SANDBOX→PILOT]` (was `[VM→PILOT]`).

## Files

- `components/shared/StatusBar.tsx` — drop `isLocalhost && SANDBOX → 'VM'` rename
- `components/shared/EnvironmentBanner.tsx` — same for title prefix; updated regex to strip new variants

## Test plan

- [ ] Hard reload localhost:3000 — StatusBar reads `SANDBOX` (not `VM`)
- [ ] Browser tab title reads `[SANDBOX] HFF` (not `[VM]` or stale `[DEV]`)
- [ ] After Phase 4 + /db-switch, tab reads `[SANDBOX→STAGING]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)