### PR TITLE
chore(#726): StatusBar always shows DB target chip

### DIFF
--- a/apps/admin/components/shared/EnvironmentBanner.tsx
+++ b/apps/admin/components/shared/EnvironmentBanner.tsx
@@ -65,8 +65,16 @@ if (!ENV_CONFIG) {
 /** Canonical env name (SANDBOX/STAGING/PILOT/PROD) */
 export const envCanonical = ENV_CANONICAL;
 
-/** DB target ('sandbox' | 'staging' | 'pilot' | null) — set when sandbox VM is pointed at a non-sandbox DB */
+/** Raw DB target ('sandbox'|'staging'|'pilot') or null if NEXT_PUBLIC_DB_TARGET unset */
 export const envDbTarget: string | null = DB_TARGET || null;
+
+/** Effective DB target — falls back to env name when NEXT_PUBLIC_DB_TARGET is unset.
+ *  So the StatusBar can always show "DB:sandbox" / "DB:staging" / "DB:pilot" without
+ *  requiring every env's .env.local to explicitly set NEXT_PUBLIC_DB_TARGET. */
+export const envDbEffective: string = (DB_TARGET || ENV_CANONICAL).toLowerCase();
+
+/** True when sandbox VM is pointed at a DB that does NOT match its env (the loaded-gun case) */
+export const isDbSwitched: boolean = !!DB_TARGET && DB_TARGET.toUpperCase() !== ENV_CANONICAL;
 
 /** Whether an environment badge should be shown */
 export const showEnvBanner = ENV_CONFIG != null;

--- a/apps/admin/components/shared/StatusBar.tsx
+++ b/apps/admin/components/shared/StatusBar.tsx
@@ -26,7 +26,7 @@ import { ROLE_LEVEL } from '@/lib/roles';
 import { useBranding } from '@/contexts/BrandingContext';
 import { useMasquerade } from '@/contexts/MasqueradeContext';
 import { useErrorCapture } from '@/contexts/ErrorCaptureContext';
-import { envLabel, envSidebarColor, envTextColor, showEnvBanner, envDbTarget, envCanonical, dbTargetColor } from './EnvironmentBanner';
+import { envLabel, envSidebarColor, envTextColor, showEnvBanner, envDbEffective, isDbSwitched, dbTargetColor } from './EnvironmentBanner';
 import { JobsPopup } from './JobsPopup';
 import { HealthPopup } from './HealthPopup';
 import type { IniResult } from './HealthPopup';
@@ -297,10 +297,12 @@ export function StatusBar() {
         {/* Environment badge → /x/settings
             Single chip when env matches DB target (default).
             Two-part chip [SANDBOX | DB→PILOT] when sandbox VM is pointed at another env's DB. */}
+        {/* ENV badge — always shows env code + effective DB.
+            Default (matched):  "SANDBOX · DB:sandbox"
+            Switched (loaded gun): "SANDBOX · DB→PILOT" with right half tinted target color */}
         {showEnvBanner && envLabel && envSidebarColor && (() => {
-          const baseLabel = envLabel;
-          const switched = !!envDbTarget && envDbTarget.toUpperCase() !== envCanonical;
-          const targetColor = switched ? dbTargetColor(envDbTarget) : null;
+          const dbColor = isDbSwitched ? dbTargetColor(envDbEffective) : null;
+          const dbLabel = isDbSwitched ? `DB→${envDbEffective.toUpperCase()}` : `DB:${envDbEffective}`;
           return (
             <span
               className="hf-status-env-badge hf-status-clickable"
@@ -309,17 +311,13 @@ export function StatusBar() {
                 ...(envTextColor ? { color: envTextColor } : {}),
               }}
               onClick={() => router.push('/x/settings')}
-              title={switched ? `${envCanonical} code, DB pointed at ${envDbTarget?.toUpperCase()}` : 'View settings'}
+              title={isDbSwitched ? `${envLabel} code, DB pointed at ${envDbEffective.toUpperCase()}` : `${envLabel} · DB:${envDbEffective}`}
             >
-              {baseLabel}
-              {switched && targetColor && (
-                <>
-                  <span aria-hidden="true" style={{ opacity: 0.5, marginInline: 4 }}>|</span>
-                  <span style={{ background: targetColor, color: 'var(--surface-primary)', borderRadius: 4, padding: '0 4px' }}>
-                    DB→{envDbTarget?.toUpperCase()}
-                  </span>
-                </>
-              )}
+              {envLabel}
+              <span aria-hidden="true" style={{ opacity: 0.5, marginInline: 4 }}>·</span>
+              <span style={dbColor ? { background: dbColor, color: 'var(--surface-primary)', borderRadius: 4, padding: '0 4px' } : { opacity: 0.85 }}>
+                {dbLabel}
+              </span>
             </span>
           );
         })()}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.347",
+  "version": "0.7.348",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
Follow-up to #739. Always renders `SANDBOX · DB:sandbox` (muted when matched, tinted when DB-switched). User feedback: needed visibility of which DB at all times, not just when switched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)