### PR TITLE
fix(#726): revert compressed-caching=true (Kaniko OOM)

### DIFF
--- a/apps/admin/cloudbuild-all.yaml
+++ b/apps/admin/cloudbuild-all.yaml
@@ -27,8 +27,8 @@ steps:
       - '--cache-repo=europe-west2-docker.pkg.dev/hf-admin-prod/hf-docker/hf-shared-cache'
       - '--cache-ttl=720h'
       - '--snapshot-mode=redo'
-      # #726 Phase 2G: enable compressed caching — faster cache push/pull
-      - '--compressed-caching=true'
+      # #726 Phase 2G reverted: compressed-caching=true OOM'd Kaniko at npm ci snapshot
+      - '--compressed-caching=false'
 
   # --- Step 2: seed (parallel with runner — deps layer cached from step 1) ---
   - id: seed
@@ -43,8 +43,8 @@ steps:
       - '--cache-repo=europe-west2-docker.pkg.dev/hf-admin-prod/hf-docker/hf-shared-cache'
       - '--cache-ttl=720h'
       - '--snapshot-mode=redo'
-      # #726 Phase 2G: enable compressed caching — faster cache push/pull
-      - '--compressed-caching=true'
+      # #726 Phase 2G reverted: compressed-caching=true OOM'd Kaniko at npm ci snapshot
+      - '--compressed-caching=false'
 
   # --- Step 3: runner (parallel with seed — deps layer cached from step 1) ---
   - id: runner
@@ -59,8 +59,8 @@ steps:
       - '--cache-repo=europe-west2-docker.pkg.dev/hf-admin-prod/hf-docker/hf-shared-cache'
       - '--cache-ttl=720h'
       - '--snapshot-mode=redo'
-      # #726 Phase 2G: enable compressed caching — faster cache push/pull
-      - '--compressed-caching=true'
+      # #726 Phase 2G reverted: compressed-caching=true OOM'd Kaniko at npm ci snapshot
+      - '--compressed-caching=false'
       - '--build-arg=NEXT_PUBLIC_APP_ENV=${_APP_ENV}'
       - '--build-arg=NODE_OPTIONS=--max-old-space-size=4096'
 

--- a/apps/admin/cloudbuild-runner.yaml
+++ b/apps/admin/cloudbuild-runner.yaml
@@ -22,8 +22,9 @@ steps:
       - '--cache-repo=europe-west2-docker.pkg.dev/hf-admin-prod/hf-docker/hf-shared-cache'
       - '--cache-ttl=720h'
       - '--snapshotMode=redo'
-      # #726 Phase 2G: enable compressed caching — faster cache push/pull
-      - '--compressed-caching=true'
+      # #726 Phase 2G reverted: compressed-caching=true OOM'd Kaniko at npm ci snapshot
+      # (node_modules layer too large to fit compressed in 32GB). Stays false for now.
+      - '--compressed-caching=false'
       - '--build-arg=NEXT_PUBLIC_APP_ENV=${_APP_ENV}'
       - '--build-arg=NODE_OPTIONS=--max-old-space-size=4096'
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.348",
+  "version": "0.7.349",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
Reverts the compressed-caching=true change from PR #737 — Kaniko was killed during `npm ci` snapshot because the node_modules layer is too big to fit compressed in 32GB RAM. Build 66a2b06e failed with exit 137 (OOM).

Net wins from Phase 2G (layer reorder, prisma generate in deps, tighter .dockerignore, runner stage prisma drop) all remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)