### PR TITLE
fix(#741): docker/login-action for GAR push

### DIFF
--- a/.github/workflows/deploy-staging-quick.yml
+++ b/.github/workflows/deploy-staging-quick.yml
@@ -86,16 +86,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Authenticate to GCP
+        id: auth
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: projects/311250123759/locations/global/workloadIdentityPools/github-pool/providers/github-provider
           service_account: github-deploy@hf-admin-prod.iam.gserviceaccount.com
+          token_format: access_token
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Configure Docker
-        run: gcloud auth configure-docker europe-west2-docker.pkg.dev --quiet
+      - name: Login to Artifact Registry (Docker)
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west2-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.351",
+  "version": "0.7.352",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
GAR push from buildx needs docker/login-action — gcloud's credential helper isn't visible to the buildx context. Standard fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)