### PR TITLE
feat(#753 Tier 1): mobile admin header — avatar + UserContextMenu

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -19,7 +19,10 @@ import { TourOverlay } from '@/src/components/shared/TourOverlay';
 import { ErrorCaptureProvider } from '@/contexts/ErrorCaptureContext';
 import { BugReportButton } from '@/components/shared/BugReportButton';
 import { StatusBar } from '@/components/shared/StatusBar';
+import { UserAvatar, computeInitials } from '@/components/shared/UserAvatar';
+import { UserContextMenu } from '@/components/shared/UserContextMenu';
 import { useResponsive } from '@/hooks/useResponsive';
+import { useSession } from 'next-auth/react';
 import { Menu, PanelLeft } from 'lucide-react';
 import './globals.css';
 
@@ -84,6 +87,10 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
   const [sidebarWidth, setSidebarWidth] = useState<number>(DEFAULT_SIDEBAR_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  // #753 — mobile header avatar menu
+  const mobileAvatarRef = useRef<HTMLButtonElement>(null);
+  const [mobileAvatarOpen, setMobileAvatarOpen] = useState(false);
+  const { data: mobileSession } = useSession();
   const resizeRef = useRef<HTMLDivElement>(null);
   const { isOpen, chatLayout } = useChatContext();
   const { isMobile, showDesktop } = useResponsive();
@@ -245,7 +252,31 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
               {branding.name}
             </span>
           )}
+          {/* #753 — push avatar to right + open UserContextMenu on tap so
+              mobile admins can reach version/env/role/sign-out (StatusBar +
+              TopBar are desktop-only). */}
+          {mobileSession?.user && (
+            <button
+              ref={mobileAvatarRef}
+              onClick={() => setMobileAvatarOpen((v) => !v)}
+              className="ml-auto rounded-full transition-opacity hover:opacity-80"
+              aria-label="Open account menu"
+              style={{ background: 'transparent', border: 'none', padding: 0, cursor: 'pointer' }}
+            >
+              <UserAvatar
+                name={mobileSession.user.name || mobileSession.user.email || 'User'}
+                initials={mobileSession.user.avatarInitials}
+                role={mobileSession.user.role}
+                size={32}
+              />
+            </button>
+          )}
         </header>
+        <UserContextMenu
+          isOpen={mobileAvatarOpen}
+          onClose={() => setMobileAvatarOpen(false)}
+          anchorRef={mobileAvatarRef}
+        />
 
         {/* Mobile sidebar overlay */}
         {mobileMenuOpen && (

--- a/apps/admin/components/shared/UserContextMenu.tsx
+++ b/apps/admin/components/shared/UserContextMenu.tsx
@@ -28,6 +28,9 @@ import { useMasquerade } from "@/contexts/MasqueradeContext";
 import { useDomainScope } from "@/contexts/DomainScopeContext";
 import { ROLE_LEVEL } from "@/lib/roles";
 import { UserAvatar, ROLE_COLORS } from "./UserAvatar";
+import { envLabel, envSidebarColor, envTextColor, showEnvBanner, envDbEffective, isDbSwitched, dbTargetColor } from "./EnvironmentBanner";
+
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION;
 
 interface UserContextMenuProps {
   isOpen: boolean;
@@ -384,15 +387,18 @@ export function UserContextMenu({
         style={{ background: "transparent" }}
       />
 
-      {/* Menu popover — fixed position calculated from anchor button */}
+      {/* Menu popover — fixed position calculated from anchor button.
+          #753: max-height + scroll so iPhone (667px) doesn't lose menu items
+          below the viewport. */}
       <div
         ref={menuRef}
-        className="fixed z-50 w-72 rounded-xl border overflow-hidden"
+        className="fixed z-50 w-72 rounded-xl border overflow-y-auto"
         style={{
           background: "var(--surface-primary)",
           borderColor: "var(--border-default)",
           top: pos.top + 4,
           right: pos.right,
+          maxHeight: `calc(100dvh - ${pos.top + 16}px)`,
           boxShadow:
             "0 20px 40px rgba(0, 0, 0, 0.12), 0 4px 12px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04)",
         }}
@@ -420,6 +426,50 @@ export function UserContextMenu({
                 {roleLabel}
               </div>
             </div>
+          </div>
+
+          {/* #753: env + version row — surfaces what StatusBar shows on
+              desktop, since StatusBar is hidden on mobile. Visible all viewports. */}
+          <div className="mt-3 flex items-center gap-2 text-xs">
+            {showEnvBanner && envLabel && envSidebarColor && (
+              <span
+                className="hf-status-env-badge"
+                style={{
+                  background: envSidebarColor,
+                  ...(envTextColor ? { color: envTextColor } : { color: "var(--surface-primary)" }),
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  fontWeight: 600,
+                  fontSize: 11,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+                title={isDbSwitched ? `${envLabel} code, DB pointed at ${envDbEffective.toUpperCase()}` : `${envLabel} · DB:${envDbEffective}`}
+              >
+                {envLabel}
+                <span aria-hidden="true" style={{ opacity: 0.5 }}>·</span>
+                <span
+                  style={
+                    isDbSwitched
+                      ? {
+                          background: dbTargetColor(envDbEffective) || undefined,
+                          color: "var(--surface-primary)",
+                          borderRadius: 3,
+                          padding: "0 4px",
+                        }
+                      : { opacity: 0.85 }
+                  }
+                >
+                  {isDbSwitched ? `DB→${envDbEffective.toUpperCase()}` : `DB:${envDbEffective}`}
+                </span>
+              </span>
+            )}
+            {APP_VERSION && (
+              <span style={{ color: "var(--text-muted)", marginLeft: "auto" }}>
+                v{APP_VERSION}
+              </span>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Closes #753 Tier 1. Avatar button in mobile header opens UserContextMenu; env+version surfaced in menu header. Tier 2 (tables) tracked in follow-up ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)