### PR TITLE
feat(#752): chord trigger menu — show available follow-up keys

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -1744,7 +1744,7 @@ export default function CourseDetailPage() {
           }}
         />
       )}
-      <ChordHintBadge activePrefix={chordActivePrefix} />
+      <ChordHintBadge activePrefix={chordActivePrefix} chords={effectiveChords} />
     </div>
   );
 }

--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -191,7 +191,7 @@ export function V5WizardWithSelector({
         userRole={userRole}
         wizardVersion="v5"
       />
-      <ChordHintBadge activePrefix={chordActivePrefix} />
+      <ChordHintBadge activePrefix={chordActivePrefix} chords={wizardChords} />
     </>
   );
 }

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -1319,7 +1319,7 @@ export default function CallerDetailPage() {
       )}
       </div>{/* cdp-content */}
       </div>{/* cdp-body */}
-      <ChordHintBadge activePrefix={chordActivePrefix} />
+      <ChordHintBadge activePrefix={chordActivePrefix} chords={effectiveChords} />
     </div>
   );
 }

--- a/apps/admin/components/help/ChordHintBadge.tsx
+++ b/apps/admin/components/help/ChordHintBadge.tsx
@@ -2,23 +2,58 @@
 
 import React from "react";
 import "./chord-hint-badge.css";
+import type { ChordBinding } from "@/lib/help/page-help";
 
 interface ChordHintBadgeProps {
   /** "H" or "G" while a chord is armed; null otherwise. */
   activePrefix: string | null;
+  /**
+   * #752 — optional list of available chord bindings at the current location.
+   * When provided, the badge renders each `[letter] — label` so users can
+   * discover what's reachable. When omitted (back-compat for callers not yet
+   * wired), falls back to the original "press next key…" hint.
+   */
+  chords?: readonly ChordBinding[];
 }
 
 /**
  * Transient badge shown while a chord is armed (after H or G, before the
  * second key). Disappears when the chord completes, times out, or resets.
+ *
+ * When `chords` is provided, shows the available follow-up letters as a
+ * discoverable list — replaces the "press next key…" fallback.
  */
-export function ChordHintBadge({ activePrefix }: ChordHintBadgeProps): React.ReactElement | null {
+export function ChordHintBadge({
+  activePrefix,
+  chords,
+}: ChordHintBadgeProps): React.ReactElement | null {
   if (!activePrefix) return null;
+
+  const hasChords = chords && chords.length > 0;
+
   return (
     <div className="hf-chord-hint" role="status" aria-live="polite">
-      <kbd>{activePrefix}</kbd>
-      <span className="hf-chord-hint-sep">·</span>
-      <span className="hf-chord-hint-hint">press next key…</span>
+      <div className="hf-chord-hint-row">
+        <kbd>{activePrefix}</kbd>
+        <span className="hf-chord-hint-sep">·</span>
+        {hasChords ? (
+          <span className="hf-chord-hint-hint">press next key — or:</span>
+        ) : (
+          <span className="hf-chord-hint-hint">press next key…</span>
+        )}
+      </div>
+      {hasChords && (
+        <dl className="hf-chord-hint-list">
+          {chords!.map((c) => (
+            <div className="hf-chord-hint-item" key={c.keys}>
+              <dt>
+                <kbd>{c.keys}</kbd>
+              </dt>
+              <dd>{c.label}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
     </div>
   );
 }

--- a/apps/admin/components/help/chord-hint-badge.css
+++ b/apps/admin/components/help/chord-hint-badge.css
@@ -4,9 +4,10 @@
   left: 24px;
   z-index: 9500;
   display: inline-flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
-  padding: 8px 14px;
+  padding: 10px 14px;
   background: var(--surface-primary);
   border: 1px solid var(--border-default);
   border-radius: 8px;
@@ -14,6 +15,13 @@
   font-size: 13px;
   color: var(--text-primary);
   animation: hf-chord-hint-in 120ms ease-out;
+  max-width: 320px;
+}
+
+.hf-chord-hint-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .hf-chord-hint kbd {
@@ -37,6 +45,30 @@
 .hf-chord-hint-hint {
   color: var(--text-muted);
   font-size: 12px;
+}
+
+.hf-chord-hint-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 10px;
+  margin: 2px 0 0;
+  padding: 0;
+  width: 100%;
+}
+
+.hf-chord-hint-item {
+  display: contents;
+}
+
+.hf-chord-hint-list dt {
+  margin: 0;
+}
+
+.hf-chord-hint-list dd {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-primary);
+  align-self: center;
 }
 
 @keyframes hf-chord-hint-in {


### PR DESCRIPTION
Closes #752. ChordHintBadge gains an optional chords prop, 3 callers wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)