### PR TITLE
feat(#762 Phase 1A): k6 load-test harness — baseline profile

### DIFF
--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# #762 load-test secrets + run output
+load-tests/.env.load-test
+load-tests/fixtures/last-seed.json
+
 # dependencies
 /node_modules
 /.pnp

--- a/apps/admin/load-tests/README.md
+++ b/apps/admin/load-tests/README.md
@@ -1,0 +1,124 @@
+# HF Load Tests
+
+k6-based HTTP load-test harness for HF's API surface. Tests run against the **staging** env (`staging.humanfirstfoundation.com` after #726 Phase 4, currently still at `dev.humanfirstfoundation.com`). Never against pilot or prod with real data.
+
+Closes #762 Phase 1. See issue for full background, audit links, and risk register.
+
+## Prerequisites
+
+```bash
+brew install k6                # one-time
+node --version                 # 20+ for fixture scripts
+```
+
+## Required env vars
+
+Create `apps/admin/load-tests/.env.load-test` (gitignored — copy from `.env.load-test.example`):
+
+```sh
+STAGING_BASE_URL=https://dev.humanfirstfoundation.com   # canonical for now; flips to staging.* in #726 Phase 4
+LOAD_TEST_INTERNAL_SECRET=...                            # matches INTERNAL_API_SECRET on staging (pipeline scenario)
+VAPI_WEBHOOK_SECRET=...                                  # matches VAPI_WEBHOOK_SECRET on staging
+LOAD_TEST_CALLER_ID=...                                  # pre-seeded test caller (set by fixtures/seed)
+RATE_LIMIT_DISABLED=true                                 # required during load runs; reset after
+```
+
+> **Rate-limiter** (#189): the in-memory per-IP limiter is 5 req/15min. Load tests WILL trip it unless `RATE_LIMIT_DISABLED=true` is set on the staging Cloud Run service for the duration of the run. **Unset it after.** Document the on/off in `results/RUN_LOG.md`.
+
+> **VAPI webhook secret** (#762 open question): if `VAPI_WEBHOOK_SECRET` is unset on staging, the verifier passes through in dev mode — webhook scenario is trivially green. Confirm the secret is set before relying on `vapi-webhook.js` results.
+
+## Running
+
+```bash
+# From repo root
+cd apps/admin/load-tests
+
+# 1. Seed test fixtures (caller, course, etc.)
+npx tsx fixtures/seed-load-test-data.ts --env=staging --callers=10
+
+# 2. Run a profile
+k6 run --env BASE_URL=$STAGING_BASE_URL --env VAPI_SECRET=$VAPI_WEBHOOK_SECRET --out json=results/run-$(date +%s).json profiles/01-baseline.js
+
+# 3. Summarise
+npx tsx summarise.ts results/run-LATEST.json
+
+# 4. Teardown
+npx tsx fixtures/teardown-load-test-data.ts --env=staging
+```
+
+## Profiles
+
+| File | VUs | Duration | What it exercises | When to run |
+|------|-----|----------|---------------------|-------------|
+| `profiles/01-baseline.js` | 10 | 5 min | health + readiness + webhook | Pre-deploy smoke, anytime |
+| `profiles/02-market-test-target.js` | 100 | 30 min | all scenarios | Before market test launch |
+| `profiles/03-burst-stress.js` | 50 in 60s | ~7 min total | webhook burst | Recovery-time check |
+
+## Scenarios
+
+| File | Target | Notes |
+|------|--------|-------|
+| `scenarios/health-check.js` | `/api/health`, `/api/system/readiness` | No auth needed |
+| `scenarios/vapi-webhook.js` | `POST /api/vapi/webhook` | HMAC-SHA256 signed (matches `lib/vapi/auth.ts`) |
+| `scenarios/pipeline-trigger.js` | `POST /api/calls/[id]/pipeline` | Internal secret auth — TBD Phase 1B |
+| `scenarios/chat-stream.js` | `POST /api/chat` | Streaming reads — TBD Phase 1B |
+| `scenarios/extraction-trigger.js` | `POST /api/courses/[id]/re-extract` | Needs seeded course — TBD Phase 1B |
+| `scenarios/prisma-singleton-probe.js` | 5 routes from #191 | 50 VU concurrent — TBD Phase 1B (the #191 smoking-gun test) |
+
+## Reading results
+
+```bash
+npx tsx summarise.ts results/run-1779634000.json
+```
+
+Output:
+```
+Scenario: health-check
+  /api/health        p50=42ms  p95=88ms  p99=121ms  errors=0/1247  PASS (target <200ms)
+  /api/system/ready  p50=89ms  p95=312ms p99=487ms  errors=0/1247  PASS (target <500ms)
+Scenario: vapi-webhook
+  POST /api/vapi/webhook  p50=210ms p95=380ms p99=620ms  errors=2/847  WARN (target <500ms p95; 0.24% err)
+Overall: PASS (baseline profile)
+```
+
+## Escalation when Profile 1 fails
+
+Per #762 open question 2 — any threshold failure on the baseline profile is a market-test blocker. Sequence:
+
+1. Capture the run JSON + Cloud Run logs (`gcloud logging read --service=hf-admin-dev --limit=200`)
+2. If DB pool errors appear (`too many clients`, `connection pool timeout`) — file a fix PR against #191 (`new PrismaClient()` → shared singleton on the 23 offending routes)
+3. If AI 429 errors appear — escalate to #479 (prompt trimming) + #188 (instance-level AI cap)
+4. Re-run Profile 1; do not promote to Profile 2 until baseline is clean
+
+## Out of scope
+
+- Real VAPI voice calls — only synthetic webhook posts
+- Browser-based testing — HTTP API only
+- Production / pilot env testing — staging only
+- CI regression gate — Phase 3 follow-on story
+
+## Files
+
+```
+load-tests/
+├── README.md                       (this file)
+├── .env.load-test.example          (template — copy + fill)
+├── k6.config.js                    (shared thresholds + env plumbing)
+├── summarise.ts                    (Node script — reads k6 JSON, prints verdict)
+├── profiles/
+│   ├── 01-baseline.js              (10 VU × 5 min — Phase 1A ✅)
+│   ├── 02-market-test-target.js    (100 VU × 30 min — Phase 1B)
+│   └── 03-burst-stress.js          (50 VU in 60s — Phase 1B)
+├── scenarios/
+│   ├── health-check.js             (Phase 1A ✅)
+│   ├── vapi-webhook.js             (Phase 1A ✅)
+│   ├── pipeline-trigger.js         (Phase 1B)
+│   ├── chat-stream.js              (Phase 1B)
+│   ├── extraction-trigger.js       (Phase 1B)
+│   └── prisma-singleton-probe.js   (Phase 1B — #191 smoking-gun test)
+├── fixtures/
+│   ├── seed-load-test-data.ts      (Phase 1A ✅ — minimal: N callers)
+│   └── teardown-load-test-data.ts  (Phase 1A ✅)
+└── results/                        (gitignored except RUN_LOG.md)
+    └── RUN_LOG.md                  (one entry per run — date, env, profile, verdict)
+```

--- a/apps/admin/load-tests/fixtures/seed-load-test-data.ts
+++ b/apps/admin/load-tests/fixtures/seed-load-test-data.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env tsx
+/**
+ * Seed N test callers on the target env via direct Prisma.
+ *
+ * Hard-guarded with --env=staging. Refuses pilot/prod.
+ *
+ * Output: prints the created caller IDs (write the first to .env.load-test
+ * as LOAD_TEST_CALLER_ID).
+ */
+import { PrismaClient } from '@prisma/client';
+
+const args = process.argv.slice(2);
+const envArg = args.find((a) => a.startsWith('--env='))?.split('=')[1];
+const callersArg = Number(args.find((a) => a.startsWith('--callers='))?.split('=')[1] ?? '10');
+
+if (envArg !== 'staging') {
+  console.error('error: --env=staging is required. (pilot/prod refused — load tests stage-only)');
+  process.exit(2);
+}
+
+const url = process.env.DATABASE_URL || '';
+if (!url.includes('hf_staging') && !url.includes('hf_dev')) {
+  console.error('error: DATABASE_URL does not point at hf_staging (or transitional hf_dev). got:', url.replace(/:[^:@]+@/, ':***@'));
+  process.exit(2);
+}
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log(`Seeding ${callersArg} load-test callers on staging…`);
+  const created: { id: string; name: string }[] = [];
+  for (let i = 0; i < callersArg; i++) {
+    const name = `loadtest-${Date.now()}-${i}`;
+    const caller = await prisma.callerIdentity.create({
+      data: {
+        name,
+        email: `${name}@load-test.local`,
+        // Minimal fields — load tests don't need playbook enrollment for the
+        // Phase 1A scenarios (health + webhook). Pipeline/extraction scenarios
+        // in Phase 1B will need richer setup.
+      },
+      select: { id: true, name: true },
+    });
+    created.push(caller);
+  }
+  console.log(`\nCreated ${created.length} callers. Set LOAD_TEST_CALLER_ID in .env.load-test:\n`);
+  console.log(`LOAD_TEST_CALLER_ID=${created[0].id}\n`);
+  console.log(`All IDs (for teardown reference — saved to fixtures/last-seed.json):`);
+  console.log(JSON.stringify(created, null, 2));
+
+  // Save manifest for idempotent teardown
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const manifestPath = path.resolve(__dirname, 'last-seed.json');
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify({ env: envArg, createdAt: new Date().toISOString(), callers: created }, null, 2),
+  );
+  console.log(`\nManifest: ${manifestPath}`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/admin/load-tests/fixtures/teardown-load-test-data.ts
+++ b/apps/admin/load-tests/fixtures/teardown-load-test-data.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env tsx
+/**
+ * Teardown — deletes everything `seed-load-test-data.ts` created.
+ * Idempotent: safe to run multiple times. Reads last-seed.json manifest.
+ */
+import { PrismaClient } from '@prisma/client';
+
+const args = process.argv.slice(2);
+const envArg = args.find((a) => a.startsWith('--env='))?.split('=')[1];
+
+if (envArg !== 'staging') {
+  console.error('error: --env=staging is required.');
+  process.exit(2);
+}
+
+const url = process.env.DATABASE_URL || '';
+if (!url.includes('hf_staging') && !url.includes('hf_dev')) {
+  console.error('error: DATABASE_URL does not point at hf_staging (or transitional hf_dev).');
+  process.exit(2);
+}
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const manifestPath = path.resolve(__dirname, 'last-seed.json');
+  let manifest: { callers: { id: string; name: string }[] } | null = null;
+
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf8');
+    manifest = JSON.parse(raw);
+  } catch {
+    // No manifest — fall back to name-pattern delete
+    console.log('No last-seed.json manifest; falling back to name pattern "loadtest-%"');
+  }
+
+  if (manifest) {
+    const ids = manifest.callers.map((c) => c.id);
+    const r = await prisma.callerIdentity.deleteMany({ where: { id: { in: ids } } });
+    console.log(`Deleted ${r.count} callers from manifest.`);
+  } else {
+    const r = await prisma.callerIdentity.deleteMany({ where: { name: { startsWith: 'loadtest-' } } });
+    console.log(`Deleted ${r.count} callers by name pattern.`);
+  }
+
+  // Best-effort manifest cleanup
+  try {
+    await fs.unlink(manifestPath);
+  } catch {
+    /* OK if not present */
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/admin/load-tests/k6.config.js
+++ b/apps/admin/load-tests/k6.config.js
@@ -1,0 +1,36 @@
+// Shared k6 thresholds + env plumbing. Imported by every profile.
+// Closes #762 Phase 1.
+
+/** Pass criteria — per #762 ACs. */
+export const THRESHOLDS = {
+  // Probes
+  'http_req_duration{scenario:health}': ['p(95)<200'],
+  'http_req_duration{scenario:readiness}': ['p(95)<500'],
+
+  // Webhook (HMAC-signed)
+  'http_req_duration{scenario:vapi_webhook}': ['p(95)<500'],
+
+  // Pipeline (Phase 1B — not exercised here)
+  'http_req_duration{scenario:pipeline}': ['p(95)<2000'],
+
+  // Aggregate error budget
+  'http_req_failed': ['rate<0.01'],
+};
+
+/** Env-var helpers — k6 exposes `__ENV` for cli/--env arguments. */
+export function baseUrl() {
+  const u = __ENV.BASE_URL;
+  if (!u) throw new Error('BASE_URL env var is required (e.g. --env BASE_URL=https://dev.humanfirstfoundation.com)');
+  if (u.includes('pilot.') || u.includes('app.') || u.includes('lab.')) {
+    throw new Error('Refusing to run against pilot/prod URL: ' + u);
+  }
+  return u.replace(/\/$/, '');
+}
+
+export function vapiSecret() {
+  return __ENV.VAPI_SECRET || ''; // empty = dev passthrough on staging when VAPI_WEBHOOK_SECRET unset
+}
+
+export function callerId() {
+  return __ENV.CALLER_ID || ''; // optional — only used by scenarios that need a real caller
+}

--- a/apps/admin/load-tests/profiles/01-baseline.js
+++ b/apps/admin/load-tests/profiles/01-baseline.js
@@ -1,0 +1,46 @@
+// Profile 1 — Baseline. 10 VU × 5 min. Cheap, runnable any time.
+// Pass criteria (per #762 + k6.config.js THRESHOLDS):
+//   p95 /api/health        < 200ms
+//   p95 /api/system/ready  < 500ms
+//   p95 POST /api/vapi/webhook < 500ms
+//   overall error rate     < 1%
+
+import { THRESHOLDS } from '../k6.config.js';
+import { healthCheck } from '../scenarios/health-check.js';
+import { vapiWebhook } from '../scenarios/vapi-webhook.js';
+
+export const options = {
+  scenarios: {
+    health: {
+      executor: 'ramping-vus',
+      exec: 'healthExec',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 10 },
+        { duration: '4m',  target: 10 },
+        { duration: '30s', target: 0 },
+      ],
+      gracefulStop: '30s',
+    },
+    webhook: {
+      executor: 'ramping-vus',
+      exec: 'webhookExec',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 10 },
+        { duration: '4m',  target: 10 },
+        { duration: '30s', target: 0 },
+      ],
+      gracefulStop: '30s',
+    },
+  },
+  thresholds: THRESHOLDS,
+};
+
+export function healthExec() {
+  healthCheck();
+}
+
+export function webhookExec() {
+  vapiWebhook();
+}

--- a/apps/admin/load-tests/results/.gitignore
+++ b/apps/admin/load-tests/results/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!../RUN_LOG.md

--- a/apps/admin/load-tests/results/RUN_LOG.md
+++ b/apps/admin/load-tests/results/RUN_LOG.md
@@ -1,0 +1,7 @@
+# Load-test run log
+
+One entry per run. Append-only.
+
+| Date | Env | Profile | Verdict | Notes |
+|------|-----|---------|---------|-------|
+| _no runs yet_ | — | — | — | Harness shipped #762 Phase 1A. First run pending. |

--- a/apps/admin/load-tests/scenarios/health-check.js
+++ b/apps/admin/load-tests/scenarios/health-check.js
@@ -1,0 +1,26 @@
+// Health + readiness probes. No auth needed. Cheap latency anchor.
+// k6 scenarios run inside a VU loop — caller sets the iteration cadence.
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { baseUrl } from '../k6.config.js';
+
+export function healthCheck() {
+  const base = baseUrl();
+
+  // /api/health — 200ms p95 target
+  const h = http.get(`${base}/api/health`, { tags: { scenario: 'health' } });
+  check(h, {
+    'health 200': (r) => r.status === 200,
+    'health body ok': (r) => r.json('ok') === true,
+  });
+
+  // /api/system/readiness — 500ms p95 target (hits DB)
+  const r = http.get(`${base}/api/system/readiness`, { tags: { scenario: 'readiness' } });
+  check(r, {
+    'readiness 200': (resp) => resp.status === 200,
+    'readiness db connected': (resp) => resp.json('checks.database.ok') === true,
+  });
+
+  sleep(1); // 1s pacing between iterations per VU
+}

--- a/apps/admin/load-tests/scenarios/vapi-webhook.js
+++ b/apps/admin/load-tests/scenarios/vapi-webhook.js
@@ -1,0 +1,55 @@
+// VAPI end-of-call-report simulator. HMAC-SHA256 signed to match
+// lib/vapi/auth.ts::verifyVapiRequest.
+//
+// Synthetic payloads only — does NOT trigger a real voice call.
+
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import { check, sleep } from 'k6';
+import { baseUrl, vapiSecret } from '../k6.config.js';
+
+/** Build a minimal end-of-call-report payload matching the webhook schema. */
+function buildPayload(iter) {
+  return JSON.stringify({
+    message: {
+      type: 'end-of-call-report',
+      call: {
+        id: `load-test-call-${__VU}-${iter}-${Date.now()}`,
+        startedAt: new Date(Date.now() - 60000).toISOString(),
+        endedAt: new Date().toISOString(),
+      },
+      transcript: 'Load test synthetic transcript. The learner said hello and the tutor responded.',
+      endedReason: 'customer-ended-call',
+    },
+  });
+}
+
+/** HMAC-SHA256 sign — k6 native crypto, no Node dependency. */
+function signPayload(body, secret) {
+  if (!secret) return ''; // empty = dev passthrough on staging
+  return crypto.hmac('sha256', secret, body, 'hex');
+}
+
+export function vapiWebhook() {
+  const base = baseUrl();
+  const secret = vapiSecret();
+  const payload = buildPayload(__ITER);
+  const signature = signPayload(payload, secret);
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(signature ? { 'x-vapi-signature': signature } : {}),
+  };
+
+  const r = http.post(`${base}/api/vapi/webhook`, payload, {
+    headers,
+    tags: { scenario: 'vapi_webhook' },
+  });
+
+  check(r, {
+    'webhook 200': (resp) => resp.status === 200,
+    'webhook not 401': (resp) => resp.status !== 401, // 401 = HMAC mismatch — fail loud
+  });
+
+  sleep(1);
+}

--- a/apps/admin/load-tests/summarise.ts
+++ b/apps/admin/load-tests/summarise.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env tsx
+/**
+ * Reads a k6 --out json file and prints a verdict per scenario.
+ * Pass/fail per threshold defined in k6.config.js.
+ *
+ * Usage:
+ *   npx tsx summarise.ts results/run-1779634000.json
+ */
+import { readFileSync } from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: tsx summarise.ts <k6-output.json>');
+  process.exit(2);
+}
+
+// Thresholds mirror k6.config.js — kept in sync manually for now.
+// k6's JSON output emits one 'Point' per data sample; we re-derive percentiles ourselves.
+const TARGETS: Record<string, { p95?: number; label: string }> = {
+  health: { p95: 200, label: '/api/health' },
+  readiness: { p95: 500, label: '/api/system/readiness' },
+  vapi_webhook: { p95: 500, label: 'POST /api/vapi/webhook' },
+  pipeline: { p95: 2000, label: 'POST /api/calls/[id]/pipeline' },
+};
+
+interface Sample {
+  type: string;
+  metric: string;
+  data: { time: string; value: number; tags?: { scenario?: string } };
+}
+
+const lines = readFileSync(file, 'utf8').split('\n').filter(Boolean);
+const points: Sample[] = lines
+  .map((l) => {
+    try {
+      return JSON.parse(l) as Sample;
+    } catch {
+      return null;
+    }
+  })
+  .filter((p): p is Sample => p !== null && p.type === 'Point');
+
+const durations: Record<string, number[]> = {};
+const failures: Record<string, number> = {};
+const totals: Record<string, number> = {};
+
+for (const p of points) {
+  const scen = p.data.tags?.scenario;
+  if (!scen) continue;
+  if (p.metric === 'http_req_duration') {
+    (durations[scen] ??= []).push(p.data.value);
+  }
+  if (p.metric === 'http_req_failed') {
+    totals[scen] = (totals[scen] ?? 0) + 1;
+    if (p.data.value === 1) failures[scen] = (failures[scen] ?? 0) + 1;
+  }
+}
+
+function pct(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((sorted.length * p) / 100));
+  return Math.round(sorted[idx]);
+}
+
+let overall = 'PASS';
+for (const [scen, samples] of Object.entries(durations)) {
+  const target = TARGETS[scen];
+  const p50 = pct(samples, 50);
+  const p95 = pct(samples, 95);
+  const p99 = pct(samples, 99);
+  const errN = failures[scen] ?? 0;
+  const totN = totals[scen] ?? samples.length;
+  const errRate = totN > 0 ? errN / totN : 0;
+
+  const verdict =
+    target?.p95 && p95 > target.p95 ? 'FAIL'
+    : errRate > 0.01 ? 'WARN'
+    : 'PASS';
+  if (verdict === 'FAIL') overall = 'FAIL';
+  else if (verdict === 'WARN' && overall !== 'FAIL') overall = 'WARN';
+
+  const label = target?.label ?? scen;
+  console.log(
+    `  ${label.padEnd(38)} p50=${String(p50).padStart(4)}ms  p95=${String(p95).padStart(4)}ms  p99=${String(p99).padStart(4)}ms  errors=${errN}/${totN}  ${verdict}` +
+    (target?.p95 ? ` (target p95<${target.p95}ms)` : ''),
+  );
+}
+
+console.log(`\nOverall: ${overall}`);
+process.exit(overall === 'FAIL' ? 1 : 0);

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.360",
+  "version": "0.7.361",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
Closes #762 Phase 1A. Ships the harness; first run pending env-var setup (see README).

Phase 1B follow-up: profiles/02-market-test-target.js, profiles/03-burst-stress.js, scenarios/pipeline-trigger.js, scenarios/chat-stream.js, scenarios/extraction-trigger.js, scenarios/prisma-singleton-probe.js (the #191 smoking-gun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)