### PR TITLE
feat(#761 Phase 1A): operator monitor board — /x/monitor war-room view

### DIFF
--- a/apps/admin/app/api/monitor/activity/route.ts
+++ b/apps/admin/app/api/monitor/activity/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { getFailureStats } from "@/lib/ai/knowledge-accumulation";
+
+export const runtime = "nodejs";
+
+/**
+ * @api GET /api/monitor/activity
+ * @visibility internal
+ * @auth OPERATOR
+ * @tags monitoring
+ * @description Aggregated live + recent activity signals for the operator
+ *   `/x/monitor` board. Single Promise.all over existing models. No new schema.
+ *   Closes #761 Phase 1A. Phase 1B adds spend + pipeline-error counts after
+ *   UsageEvent / ComposedPrompt status semantics are confirmed.
+ * @response 200 { ok: true, liveCalls, recentCallsHour, callsToday, callersTotal, callersActive24h, callersNotCalledToday, openTickets, aiErrorsHour }
+ * @response 401 { ok: false, error: "unauthorized" }
+ */
+export async function GET() {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const now = Date.now();
+  const fiveMinAgo = new Date(now - 5 * 60 * 1000);
+  const sixtyMinAgo = new Date(now - 60 * 60 * 1000);
+  const twentyFourHoursAgo = new Date(now - 24 * 60 * 60 * 1000);
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+
+  try {
+    const [
+      liveCalls,
+      recentCallsHour,
+      callsToday,
+      callersTotal,
+      activeCallerIds24h,
+      activeCallerIdsToday,
+      openTickets,
+      aiStats,
+    ] = await Promise.all([
+      // Live = endedAt null + started recently (proxy; no real VAPI session feed)
+      prisma.call.count({
+        where: { endedAt: null, createdAt: { gte: fiveMinAgo } },
+      }),
+      // Recent feed — last 60 min, latest 20
+      prisma.call.findMany({
+        where: { createdAt: { gte: sixtyMinAgo } },
+        orderBy: { createdAt: "desc" },
+        take: 20,
+        select: {
+          id: true,
+          createdAt: true,
+          endedAt: true,
+          callerId: true,
+          playbookId: true,
+        },
+      }),
+      prisma.call.count({ where: { createdAt: { gte: todayStart } } }),
+      prisma.caller.count(),
+      // Distinct callerIds active in last 24h
+      prisma.call.findMany({
+        where: { createdAt: { gte: twentyFourHoursAgo } },
+        select: { callerId: true },
+        distinct: ["callerId"],
+      }),
+      // Distinct callerIds called today
+      prisma.call.findMany({
+        where: { createdAt: { gte: todayStart } },
+        select: { callerId: true },
+        distinct: ["callerId"],
+      }),
+      prisma.ticket.count({
+        where: { status: { in: ["OPEN", "IN_PROGRESS", "WAITING"] } },
+      }),
+      // AI errors in last hour — reuses the same helper /x/ai-errors uses
+      getFailureStats(1).catch(() => null),
+    ]);
+
+    // Enrich recent feed with caller + course names (parallel batch — cheap)
+    const callerIds = Array.from(new Set(recentCallsHour.map((c) => c.callerId).filter(Boolean))) as string[];
+    const playbookIds = Array.from(new Set(recentCallsHour.map((c) => c.playbookId).filter(Boolean))) as string[];
+    const [callerRows, playbookRows] = await Promise.all([
+      callerIds.length
+        ? prisma.caller.findMany({ where: { id: { in: callerIds } }, select: { id: true, name: true } })
+        : Promise.resolve([]),
+      playbookIds.length
+        ? prisma.playbook.findMany({ where: { id: { in: playbookIds } }, select: { id: true, name: true } })
+        : Promise.resolve([]),
+    ]);
+    const callerName = new Map(callerRows.map((c) => [c.id, c.name]));
+    const playbookName = new Map(playbookRows.map((p) => [p.id, p.name]));
+
+    return NextResponse.json({
+      ok: true,
+      liveCalls,
+      recentCallsHour: recentCallsHour.map((c) => ({
+        id: c.id,
+        callerId: c.callerId,
+        callerName: c.callerId ? callerName.get(c.callerId) ?? null : null,
+        playbookId: c.playbookId,
+        courseName: c.playbookId ? playbookName.get(c.playbookId) ?? null : null,
+        createdAt: c.createdAt,
+        endedAt: c.endedAt,
+      })),
+      callsToday,
+      callersTotal,
+      callersActive24h: activeCallerIds24h.length,
+      callersCalledToday: activeCallerIdsToday.length,
+      callersNotCalledToday: Math.max(0, callersTotal - activeCallerIdsToday.length),
+      openTickets,
+      aiErrorsHour: aiStats
+        ? {
+            count: aiStats.totalFailures ?? 0,
+            rate: aiStats.failureRate ?? 0,
+            alertThresholdExceeded: aiStats.alertThresholdExceeded ?? false,
+          }
+        : { count: 0, rate: 0, alertThresholdExceeded: false },
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error: any) {
+    console.error("[Monitor Activity Error]:", error);
+    return NextResponse.json(
+      { ok: false, error: error?.message || "Failed to load monitor activity" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/x/monitor/MonitorClient.tsx
+++ b/apps/admin/app/x/monitor/MonitorClient.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+/**
+ * #761 Phase 1A — operator war-room view.
+ * Polls /api/monitor/activity every 30s. Renders 6 stat chips + recent feed.
+ * Spend + pipeline errors deferred to Phase 1B (need UsageEvent + ComposedPrompt status confirmation).
+ */
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { ROLE_LEVEL } from "@/lib/roles";
+import "./monitor.css";
+
+interface RecentCall {
+  id: string;
+  callerId: string | null;
+  callerName: string | null;
+  playbookId: string | null;
+  courseName: string | null;
+  createdAt: string;
+  endedAt: string | null;
+}
+
+interface MonitorData {
+  ok: boolean;
+  liveCalls: number;
+  recentCallsHour: RecentCall[];
+  callsToday: number;
+  callersTotal: number;
+  callersActive24h: number;
+  callersCalledToday: number;
+  callersNotCalledToday: number;
+  openTickets: number;
+  aiErrorsHour: { count: number; rate: number; alertThresholdExceeded: boolean };
+  timestamp: string;
+}
+
+function timeAgo(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m ago`;
+}
+
+export default function MonitorClient() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [data, setData] = useState<MonitorData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loadedAt, setLoadedAt] = useState<number>(0);
+  const [pulseTick, setPulseTick] = useState(0);
+
+  // Role guard — OPERATOR+
+  useEffect(() => {
+    if (status === "loading") return;
+    const role = (session?.user?.role ?? "VIEWER") as keyof typeof ROLE_LEVEL;
+    if ((ROLE_LEVEL[role] ?? 0) < 3) {
+      router.replace("/x");
+    }
+  }, [session, status, router]);
+
+  // 30s poll
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch("/api/monitor/activity", { cache: "no-store" });
+        const json = await res.json();
+        if (cancelled) return;
+        if (json.ok) {
+          setData(json);
+          setLoadedAt(Date.now());
+          setError(null);
+        } else {
+          setError(json.error || "Failed to load");
+        }
+      } catch (e: any) {
+        if (cancelled) return;
+        setError(e?.message || "Network error");
+      }
+    }
+    load();
+    const id = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  // 1s "Last updated" ticker
+  useEffect(() => {
+    const id = setInterval(() => setPulseTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!data && !error) {
+    return (
+      <div className="hf-card hf-card-compact">
+        <span className="hf-spinner" /> Loading monitor…
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="hf-banner hf-banner-error">
+        Failed to load monitor: {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const updatedSec = Math.floor((Date.now() - loadedAt) / 1000);
+  const engagementPct = data.callersTotal > 0 ? Math.round((data.callersCalledToday / data.callersTotal) * 100) : 0;
+
+  return (
+    <div className="hf-monitor-page">
+      <div className="hf-monitor-header">
+        <h1 className="hf-page-title">Pilot Monitor</h1>
+        <span className="hf-monitor-meta" title={data.timestamp}>
+          Last updated: {updatedSec}s ago
+        </span>
+      </div>
+
+      {/* 6-chip header */}
+      <div className="hf-monitor-chips">
+        <Chip
+          label="Live now"
+          value={String(data.liveCalls)}
+          sublabel="calls"
+          tone={data.liveCalls > 0 ? "live" : "muted"}
+          dots={Math.min(data.liveCalls, 5)}
+        />
+        <Chip label="Today" value={String(data.callsToday)} sublabel="calls" tone="default" />
+        <Chip
+          label="Active"
+          value={`${data.callersCalledToday} / ${data.callersTotal}`}
+          sublabel={`${engagementPct}% engaged`}
+          tone={engagementPct >= 60 ? "good" : engagementPct >= 30 ? "warn" : "alert"}
+        />
+        <Chip
+          label="Lapsed"
+          value={String(data.callersNotCalledToday)}
+          sublabel="no call today"
+          tone={data.callersNotCalledToday === 0 ? "good" : "warn"}
+        />
+        <Chip
+          label="AI errors"
+          value={String(data.aiErrorsHour.count)}
+          sublabel={`${Math.round(data.aiErrorsHour.rate * 100)}% / 1h`}
+          tone={data.aiErrorsHour.alertThresholdExceeded ? "alert" : data.aiErrorsHour.count > 0 ? "warn" : "good"}
+        />
+        <Chip
+          label="Tickets"
+          value={String(data.openTickets)}
+          sublabel="open"
+          tone={data.openTickets > 5 ? "alert" : data.openTickets > 0 ? "warn" : "good"}
+        />
+      </div>
+
+      {/* Live feed */}
+      <div className="hf-card">
+        <div className="hf-monitor-feed-header">
+          <h2 className="hf-section-title">Live feed (last 60 min)</h2>
+          <a className="hf-monitor-link" href="/x/callers">View all callers →</a>
+        </div>
+        {data.recentCallsHour.length === 0 ? (
+          <div className="hf-empty">No calls in the last 60 minutes.</div>
+        ) : (
+          <ul className="hf-monitor-feed">
+            {data.recentCallsHour.map((c) => (
+              <li key={c.id} className="hf-monitor-feed-row">
+                <span className={`hf-monitor-dot ${c.endedAt ? "ended" : "live"}`} aria-hidden="true" />
+                <span className="hf-monitor-feed-name">
+                  {c.callerName || "(unknown caller)"}
+                </span>
+                <span className="hf-monitor-feed-when">
+                  {c.endedAt ? `ended ${timeAgo(c.endedAt)}` : `started ${timeAgo(c.createdAt)}`}
+                </span>
+                <span className="hf-monitor-feed-course">{c.courseName || ""}</span>
+                {c.callerId && (
+                  <a className="hf-monitor-link" href={`/x/callers/${c.callerId}`}>open →</a>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {error && (
+        <div className="hf-banner hf-banner-warning" style={{ marginTop: 12 }}>
+          Last refresh failed: {error}. Showing previous data.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Chip({
+  label,
+  value,
+  sublabel,
+  tone,
+  dots,
+}: {
+  label: string;
+  value: string;
+  sublabel: string;
+  tone: "default" | "live" | "good" | "warn" | "alert" | "muted";
+  dots?: number;
+}) {
+  return (
+    <div className={`hf-monitor-chip tone-${tone}`}>
+      <div className="hf-monitor-chip-label">{label}</div>
+      <div className="hf-monitor-chip-value">{value}</div>
+      <div className="hf-monitor-chip-sublabel">
+        {dots !== undefined && dots > 0 && (
+          <span aria-hidden="true" style={{ marginRight: 4 }}>
+            {"●".repeat(dots)}
+          </span>
+        )}
+        {sublabel}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/x/monitor/monitor.css
+++ b/apps/admin/app/x/monitor/monitor.css
@@ -1,0 +1,157 @@
+/* #761 Phase 1A — operator monitor board styles.
+   Uses CSS vars per HF UI rules; no hardcoded hex. */
+
+.hf-monitor-page {
+  padding: 24px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.hf-monitor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 20px;
+}
+
+.hf-monitor-meta {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hf-monitor-chips {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.hf-monitor-chip {
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: border-color 200ms ease;
+}
+
+.hf-monitor-chip.tone-live {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-primary) 30%, transparent);
+}
+
+.hf-monitor-chip.tone-good {
+  border-color: color-mix(in srgb, var(--status-success-text) 40%, var(--border-default));
+}
+
+.hf-monitor-chip.tone-warn {
+  border-color: color-mix(in srgb, var(--status-warning-text) 40%, var(--border-default));
+}
+
+.hf-monitor-chip.tone-alert {
+  border-color: var(--status-error-text);
+  background: color-mix(in srgb, var(--status-error-text) 5%, var(--surface-primary));
+}
+
+.hf-monitor-chip.tone-muted {
+  opacity: 0.7;
+}
+
+.hf-monitor-chip-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.hf-monitor-chip-value {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.1;
+}
+
+.hf-monitor-chip-sublabel {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.hf-monitor-feed-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.hf-monitor-link {
+  color: var(--accent-primary);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.hf-monitor-link:hover {
+  text-decoration: underline;
+}
+
+.hf-monitor-feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.hf-monitor-feed-row {
+  display: grid;
+  grid-template-columns: 12px 1fr auto auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 13px;
+}
+
+.hf-monitor-feed-row:last-child {
+  border-bottom: none;
+}
+
+.hf-monitor-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.hf-monitor-dot.live {
+  background: var(--status-success-text);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--status-success-text) 25%, transparent);
+  animation: hf-monitor-pulse 1.6s ease-in-out infinite;
+}
+
+.hf-monitor-dot.ended {
+  background: var(--text-muted);
+}
+
+.hf-monitor-feed-name {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.hf-monitor-feed-when {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.hf-monitor-feed-course {
+  color: var(--text-secondary);
+  white-space: nowrap;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@keyframes hf-monitor-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}

--- a/apps/admin/app/x/monitor/page.tsx
+++ b/apps/admin/app/x/monitor/page.tsx
@@ -1,0 +1,7 @@
+import MonitorClient from "./MonitorClient";
+
+export const dynamic = "force-dynamic";
+
+export default function MonitorPage() {
+  return <MonitorClient />;
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.364",
+  "version": "0.7.365",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.365",
+  "version": "0.7.366",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -64,6 +64,7 @@
   - [Memories](#memories)
   - [Messages](#messages)
   - [Metering](#metering)
+  - [Monitoring](#monitoring)
   - [Onboarding](#onboarding)
   - [Ops](#ops)
   - [Other](#other)
@@ -9035,6 +9036,26 @@ Returns usage breakdowns by caller, domain, most expensive operations, and most 
 
 ---
 
+## Monitoring
+
+### `GET` /api/monitor/activity
+
+Aggregated live + recent activity signals for the operator
+
+**Auth**: OPERATOR
+
+**Response** `200`
+```json
+{ ok: true, liveCalls, recentCallsHour, callsToday, callersTotal, callersActive24h, callersNotCalledToday, openTickets, aiErrorsHour }
+```
+
+**Response** `401`
+```json
+{ ok: false, error: "unauthorized" }
+```
+
+---
+
 ## Onboarding
 
 ### `GET` /api/onboarding
@@ -14378,8 +14399,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 445 |
-| Files with annotations | 444 |
+| Route files found | 446 |
+| Files with annotations | 445 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 


### PR DESCRIPTION
Closes #761 Phase 1A.

- New `GET /api/monitor/activity` — single Promise.all aggregator, OPERATOR-gated, no new schema
- New `/x/monitor` page — 6-chip header (Live now / Today / Active / Lapsed / AI errors / Tickets) + 60-min live feed with pulsing live-dot
- 30s polling client; 1s ticker for 'last updated'
- hf-* classes, CSS vars only, role-gated to OPERATOR+

Phase 1B (deferred):
- spend chip (UsageEvent shape verification)
- pipeline errors (ComposedPrompt status enum confirmation)
- drill-down per cohort
- click-to-replay individual call

Verify on staging once deployed: navigate to `/x/monitor` as ADMIN — should render the 6 chips + the feed (mostly empty on staging since no real callers active).

🤖 Generated with [Claude Code](https://claude.com/claude-code)