### PR TITLE
feat(#762 Phase 1B + #748 fix): profile 02 (100 VU) + #191 evidence probe + composite --to-latest

### DIFF
--- a/.github/actions/gcp-runner-deploy/action.yml
+++ b/.github/actions/gcp-runner-deploy/action.yml
@@ -121,6 +121,12 @@ runs:
           --image=${{ steps.tags.outputs.image }} \
           --region=${{ inputs.region }} \
           --no-cpu-throttling
+        # #762 follow-up: a prior manual `update-traffic --to-revisions=X=100`
+        # pin (e.g. from a rollback) silently persists across subsequent
+        # deploys — new revisions get 0% traffic. Explicit --to-latest here
+        # ensures the freshly-built image actually receives traffic.
+        gcloud run services update-traffic ${{ inputs.service }} \
+          --region=${{ inputs.region }} --to-latest
         URL=$(gcloud run services describe ${{ inputs.service }} --region=${{ inputs.region }} --format='value(status.url)')
         echo "url=$URL" >> $GITHUB_OUTPUT
         echo "Deployed to $URL"

--- a/apps/admin/load-tests/profiles/02-market-test-target.js
+++ b/apps/admin/load-tests/profiles/02-market-test-target.js
@@ -1,0 +1,56 @@
+// Profile 2 — Market-test target capacity proof.
+// 100 VU concurrent, ramped (NOT thundering herd), 15 min total.
+//
+// Scope (Phase 1A safe): health + vapi-webhook only. AI-heavy scenarios
+// (extraction-trigger, chat-stream) are Phase 1B — they would trip OpenAI
+// 30K TPM and add no signal about the OUR app's concurrency handling.
+//
+// Pass criteria (per #762 + k6.config.js THRESHOLDS):
+//   p95 /api/health        < 200ms
+//   p95 /api/system/ready  < 500ms
+//   p95 POST vapi-webhook  < 500ms
+//   overall error rate     < 1%
+//
+// Runtime: ~16 min wall (2m ramp + 10m hold + 4m ramp-down)
+
+import { THRESHOLDS } from '../k6.config.js';
+import { healthCheck } from '../scenarios/health-check.js';
+import { vapiWebhook } from '../scenarios/vapi-webhook.js';
+
+export const options = {
+  scenarios: {
+    health: {
+      executor: 'ramping-vus',
+      exec: 'healthExec',
+      startVUs: 0,
+      stages: [
+        { duration: '2m',  target: 50 },   // 0 → 50
+        { duration: '3m',  target: 100 },  // 50 → 100
+        { duration: '10m', target: 100 },  // hold 100
+        { duration: '4m',  target: 0 },    // ramp down
+      ],
+      gracefulStop: '30s',
+    },
+    webhook: {
+      executor: 'ramping-vus',
+      exec: 'webhookExec',
+      startVUs: 0,
+      stages: [
+        { duration: '2m',  target: 50 },
+        { duration: '3m',  target: 100 },
+        { duration: '10m', target: 100 },
+        { duration: '4m',  target: 0 },
+      ],
+      gracefulStop: '30s',
+    },
+  },
+  thresholds: THRESHOLDS,
+};
+
+export function healthExec() {
+  healthCheck();
+}
+
+export function webhookExec() {
+  vapiWebhook();
+}

--- a/apps/admin/load-tests/profiles/04-prisma-singleton-probe.js
+++ b/apps/admin/load-tests/profiles/04-prisma-singleton-probe.js
@@ -1,0 +1,41 @@
+// Profile 4 — direct evidence test for #191's 22 remaining new-PrismaClient
+// routes. 50 VU for 60s, hitting 5 routes round-robin.
+//
+// Pass criteria:
+//   - Zero 5xx responses
+//   - Zero connection timeouts (status 0)
+//   - p95 < 1500ms (these are list-ish GETs, not heavy queries)
+//
+// If this FAILS, that's the direct evidence #191 needs — we then know which
+// route pattern triggers pool exhaustion, and can fix the others without
+// guessing.
+//
+// Requires SESSION_COOKIE env var (admin session cookie). Pull from your
+// browser dev tools after logging into the target env. Cookie name varies
+// by env; check Network tab.
+
+import { prismaSingletonProbe } from '../scenarios/prisma-singleton-probe.js';
+
+export const options = {
+  scenarios: {
+    probe: {
+      executor: 'ramping-vus',
+      exec: 'probeExec',
+      startVUs: 0,
+      stages: [
+        { duration: '10s', target: 50 },
+        { duration: '60s', target: 50 },
+        { duration: '10s', target: 0 },
+      ],
+      gracefulStop: '30s',
+    },
+  },
+  thresholds: {
+    'http_req_duration{scenario:prisma_probe}': ['p(95)<1500'],
+    'http_req_failed{scenario:prisma_probe}': ['rate<0.01'],
+  },
+};
+
+export function probeExec() {
+  prismaSingletonProbe();
+}

--- a/apps/admin/load-tests/scenarios/prisma-singleton-probe.js
+++ b/apps/admin/load-tests/scenarios/prisma-singleton-probe.js
@@ -1,0 +1,58 @@
+// #191 smoking-gun scenario — drives concurrent VUs against the 5 GET routes
+// that ship `new PrismaClient()` per request. Each request opens an extra
+// connection pool on its Cloud Run instance. Under enough concurrency, Cloud
+// SQL's max-connections cap is hit and we see `too many clients` / connection
+// pool timeouts.
+//
+// Confirmed offending routes from #191 (post-#767 — readiness already fixed):
+//   GET /api/calls/scores
+//   GET /api/calls/rewards
+//   GET /api/transcripts
+//   GET /api/prompt-blocks
+//   GET /api/users
+//
+// All five require auth. We send a session cookie (passed via env). Without
+// the cookie the route returns 401 and the test would pass trivially —
+// fail loud in that case.
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { baseUrl } from '../k6.config.js';
+
+const SESSION_COOKIE = __ENV.SESSION_COOKIE || '';
+
+/** Routes from #191. Tagged for per-route latency breakdown. */
+const ROUTES = [
+  { path: '/api/calls/scores', tag: 'calls_scores' },
+  { path: '/api/calls/rewards', tag: 'calls_rewards' },
+  { path: '/api/transcripts', tag: 'transcripts' },
+  { path: '/api/prompt-blocks', tag: 'prompt_blocks' },
+  { path: '/api/users', tag: 'users' },
+];
+
+export function prismaSingletonProbe() {
+  const base = baseUrl();
+  if (!SESSION_COOKIE) {
+    // Fail loudly — auth-less probes are useless
+    throw new Error('SESSION_COOKIE env var is required for prisma-singleton-probe');
+  }
+
+  // Round-robin through the 5 routes by VU iteration
+  const route = ROUTES[__ITER % ROUTES.length];
+  const headers = {
+    Cookie: SESSION_COOKIE,
+  };
+
+  const r = http.get(`${base}${route.path}`, {
+    headers,
+    tags: { scenario: 'prisma_probe', route: route.tag },
+  });
+
+  check(r, {
+    'not 401 (auth ok)': (resp) => resp.status !== 401,
+    'not 5xx': (resp) => resp.status < 500,
+    'not connection timeout': (resp) => resp.status !== 0,
+  });
+
+  sleep(0.5); // tighter pacing — we want to PUSH the pool
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.366",
+  "version": "0.7.367",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
Three things in one PR (each its own commit):

1. **Composite fix** — adds `update-traffic --to-latest` to every deploy. Prevents the silent traffic-pin bug I hit during #762 readiness investigation.
2. **Profile 02** — 100 VU × 15 min health+webhook capacity proof.
3. **Profile 04 + scenario** — 50 VU × 60s direct evidence probe for the 5 remaining `new PrismaClient()` GET routes (#191 smoking-gun test). Requires SESSION_COOKIE env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)