### PR TITLE
fix(#762): summariser streams + per-scenario failure-status breakdown

### DIFF
--- a/apps/admin/load-tests/summarise.ts
+++ b/apps/admin/load-tests/summarise.ts
@@ -3,10 +3,15 @@
  * Reads a k6 --out json file and prints a verdict per scenario.
  * Pass/fail per threshold defined in k6.config.js.
  *
+ * Streams the input file line-by-line (a 100-VU × 15-min run produces
+ * 80MB+, hitting Node's max string length on naive readFileSync). #762
+ * Phase 1B fix.
+ *
  * Usage:
  *   npx tsx summarise.ts results/run-1779634000.json
  */
-import { readFileSync } from 'node:fs';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 
 const file = process.argv[2];
 if (!file) {
@@ -26,35 +31,50 @@ const TARGETS: Record<string, { p95?: number; label: string }> = {
 interface Sample {
   type: string;
   metric: string;
-  data: { time: string; value: number; tags?: { scenario?: string } };
+  data: { time: string; value: number; tags?: { scenario?: string; status?: string } };
 }
-
-const lines = readFileSync(file, 'utf8').split('\n').filter(Boolean);
-const points: Sample[] = lines
-  .map((l) => {
-    try {
-      return JSON.parse(l) as Sample;
-    } catch {
-      return null;
-    }
-  })
-  .filter((p): p is Sample => p !== null && p.type === 'Point');
 
 const durations: Record<string, number[]> = {};
 const failures: Record<string, number> = {};
 const totals: Record<string, number> = {};
+// #762 Phase 1B — track failures by HTTP status for triage
+const failuresByStatus: Record<string, Record<string, number>> = {};
 
-for (const p of points) {
-  const scen = p.data.tags?.scenario;
-  if (!scen) continue;
-  if (p.metric === 'http_req_duration') {
-    (durations[scen] ??= []).push(p.data.value);
-  }
-  if (p.metric === 'http_req_failed') {
-    totals[scen] = (totals[scen] ?? 0) + 1;
-    if (p.data.value === 1) failures[scen] = (failures[scen] ?? 0) + 1;
+async function readPoints() {
+  const rl = createInterface({ input: createReadStream(file, { encoding: 'utf8' }), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line) continue;
+    let p: Sample | null;
+    try {
+      p = JSON.parse(line) as Sample;
+    } catch {
+      continue;
+    }
+    if (!p || p.type !== 'Point') continue;
+    const scen = p.data.tags?.scenario;
+    if (!scen) continue;
+    if (p.metric === 'http_req_duration') {
+      (durations[scen] ??= []).push(p.data.value);
+    }
+    if (p.metric === 'http_req_failed') {
+      totals[scen] = (totals[scen] ?? 0) + 1;
+      if (p.data.value === 1) {
+        failures[scen] = (failures[scen] ?? 0) + 1;
+        const status = p.data.tags?.status || 'unknown';
+        (failuresByStatus[scen] ??= {})[status] = (failuresByStatus[scen]?.[status] ?? 0) + 1;
+      }
+    }
   }
 }
+
+readPoints().then(() => {
+  printSummary();
+}).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+
+function printSummary() {
 
 function pct(arr: number[], p: number): number {
   if (arr.length === 0) return 0;
@@ -87,5 +107,16 @@ for (const [scen, samples] of Object.entries(durations)) {
   );
 }
 
+// Per-scenario failure breakdown by HTTP status (helps triage 4xx vs 5xx vs 0/timeout)
+for (const [scen, byStatus] of Object.entries(failuresByStatus)) {
+  const top = Object.entries(byStatus).sort((a, b) => b[1] - a[1]);
+  if (top.length > 0) {
+    const breakdown = top.map(([s, n]) => `${s}=${n}`).join(' ');
+    console.log(`  ${scen.padEnd(38)} failure breakdown by status: ${breakdown}`);
+  }
+}
+
 console.log(`\nOverall: ${overall}`);
 process.exit(overall === 'FAIL' ? 1 : 0);
+}
+

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.367",
+  "version": "0.7.368",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
Two related fixes after the first Profile 02 run:

1. **Stream input** — 80MB+ JSON output from a 100-VU run blew Node's max string size on readFileSync. Now reads line-by-line via readline.
2. **Failure breakdown by HTTP status** — Profile 02's 4.54% error rate was diagnosed in seconds: all 10,880 failures were HTTP 429s distributed uniformly across scenarios, meaning gateway rate-limit (Cloudflare or Cloud Run service-level) — not app failure. Re-running against direct Cloud Run URL to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)