### PR TITLE
feat(#784 + #790): Felt Progress + Call 1 settings UI + firstCallMode

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/design/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/design/route.ts
@@ -6,13 +6,14 @@
  * @tags course, design, welcome, nps, felt-progress
  * @description Save student experience design config. Writes to
  *   Playbook.config.welcome, Playbook.config.nps, the #417 skill-banding
- *   overrides, and the Felt Progress namespaces (#779 progressNarrative,
- *   #780 offboardingSummary).
+ *   overrides, the Felt Progress namespaces (#779 progressNarrative,
+ *   #780 offboardingSummary), and the S6/S8 first-call knobs (#784
+ *   firstSessionTargets, #790 firstCallMode).
  *   Pre-survey gating is computed from welcome.* via isPreSurveyEnabled
  *   (no surveys.pre write); surveys.post.enabled mirrors nps.enabled.
  *   Pass `null` for any optional override field to clear it (falls back
  *   to defaults / contract).
- * @request { welcome?: WelcomeConfig, nps?: NpsConfig, skillTierMapping?, skillScoringEmaHalfLifeDays?, skillMinCallsToFull?, progressNarrative?, offboardingSummary? }
+ * @request { welcome?: WelcomeConfig, nps?: NpsConfig, skillTierMapping?, skillScoringEmaHalfLifeDays?, skillMinCallsToFull?, progressNarrative?, offboardingSummary?, firstSessionTargets?, firstCallMode? }
  * @response 200 { ok: true }
  * @response 404 { ok: false, error: "Course not found" }
  */
@@ -43,6 +44,12 @@ export async function PUT(
       progressNarrative?: PlaybookConfig["progressNarrative"] | null;
       // #780 — Felt Progress S2. Same shape: object writes; null clears.
       offboardingSummary?: PlaybookConfig["offboardingSummary"] | null;
+      // #784 (S6) — per-playbook first-call BEHAVIOR target overrides.
+      // Object writes; null clears the namespace (falls back to domain defaults).
+      firstSessionTargets?: PlaybookConfig["firstSessionTargets"] | null;
+      // #790 (S8) — first-call mode override. String writes; null clears
+      // (falls back to default 'onboarding' behaviour).
+      firstCallMode?: PlaybookConfig["firstCallMode"] | null;
     };
 
     const playbook = await prisma.playbook.findUnique({
@@ -104,6 +111,30 @@ export async function PUT(
         delete pbConfig.offboardingSummary;
       } else {
         pbConfig.offboardingSummary = body.offboardingSummary;
+      }
+    }
+
+    // #784 (S6) — per-playbook first-call BEHAVIOR target overrides.
+    // null or empty-object clears so the domain → INIT-001 → AUDIENCE
+    // cascade applies again.
+    if (body.firstSessionTargets !== undefined) {
+      if (
+        body.firstSessionTargets === null ||
+        Object.keys(body.firstSessionTargets).length === 0
+      ) {
+        delete pbConfig.firstSessionTargets;
+      } else {
+        pbConfig.firstSessionTargets = body.firstSessionTargets;
+      }
+    }
+
+    // #790 (S8) — first-call mode. null clears so the default 'onboarding'
+    // path runs in `transforms/pedagogy.ts` (byte-identical to pre-#790).
+    if (body.firstCallMode !== undefined) {
+      if (body.firstCallMode === null) {
+        delete pbConfig.firstCallMode;
+      } else {
+        pbConfig.firstCallMode = body.firstCallMode;
       }
     }
 

--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -3,6 +3,8 @@
 import { SessionFlowEditor } from '@/components/session-flow/SessionFlowEditor';
 import { CourseSetupTracker } from '@/components/shared/CourseSetupTracker';
 import { BandingPicker } from '@/components/shared/BandingPicker';
+import { FeltProgressSettings } from '@/components/course-design/FeltProgressSettings';
+import { FirstSessionSettings } from '@/components/course-design/FirstSessionSettings';
 import { CourseSummaryCard } from './CourseSummaryCard';
 import { archetypeLabel } from '@/lib/course/group-specs';
 import { INTERACTION_PATTERN_LABELS, type InteractionPattern } from '@/lib/content-trust/resolve-config';
@@ -131,6 +133,16 @@ export function CourseDesignTab({
       */}
       <div className="hf-card hf-mb-lg">
         <SessionFlowEditor courseId={courseId} />
+      </div>
+
+      {/* ── Felt Progress controls (#784 S6 Section 1 — #779 + #780 namespaces) ── */}
+      <div className="hf-card hf-mb-lg">
+        <FeltProgressSettings courseId={courseId} playbookConfig={pbConfig} />
+      </div>
+
+      {/* ── Call 1 / First Session settings (#784 S6 Section 2 + #790 S8) ── */}
+      <div className="hf-card hf-mb-lg">
+        <FirstSessionSettings courseId={courseId} playbookConfig={pbConfig} />
       </div>
 
       {/* ── Skill Banding (#417 Story C — per-playbook tier mapping) ── */}

--- a/apps/admin/components/course-design/FeltProgressSettings.tsx
+++ b/apps/admin/components/course-design/FeltProgressSettings.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+/**
+ * FeltProgressSettings — Section 1 of #784 (Felt Progress S6).
+ *
+ * Bundles the 9 controls for the two Felt-Progress namespaces that land
+ * during this epic: progressNarrative (#779, mid-call acknowledgement) and
+ * offboardingSummary (#780, structured end-of-course summary). Single
+ * editor, single Save button, single write to PUT /api/courses/[id]/design.
+ *
+ * Same self-contained component pattern as `BandingPicker`. Reads the
+ * playbook config from props, persists the relevant subtree to the design
+ * route. Defaults shown in UI mirror the transform-side defaults so a fresh
+ * course displays the same checkboxes it actually runs.
+ */
+
+import { useState } from "react";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+interface FeltProgressSettingsProps {
+  courseId: string;
+  playbookConfig?: PlaybookConfig | Record<string, unknown> | null;
+  onSaved?: () => void;
+}
+
+// Defaults mirror the transform-side defaults
+// (lib/prompt/composition/transforms/progress-narrative.ts +
+// transforms/offboarding.ts). Keeping them aligned means the UI never
+// misrepresents what the AI will actually do for an unset course.
+const PROGRESS_DEFAULTS = {
+  enabled: true,
+  cadence: "on_threshold_crossing" as const,
+  minScoreDelta: 0.1,
+  skipFirstCall: true,
+};
+
+const OFFBOARDING_DEFAULTS = {
+  enabled: true,
+  cadence: "final_only" as const,
+  includeModuleMastery: true,
+  includeGoalProgress: true,
+  includeSkillCurrentScore: true,
+};
+
+export function FeltProgressSettings({
+  courseId,
+  playbookConfig,
+  onSaved,
+}: FeltProgressSettingsProps): React.ReactElement {
+  const cfg = (playbookConfig ?? {}) as PlaybookConfig;
+  const pn = cfg.progressNarrative ?? {};
+  const ob = cfg.offboardingSummary ?? {};
+
+  // ── progressNarrative state ─────────────────────────────────────────────
+  const [pnEnabled, setPnEnabled] = useState<boolean>(pn.enabled ?? PROGRESS_DEFAULTS.enabled);
+  const [pnCadence, setPnCadence] = useState<"every_call" | "on_threshold_crossing">(
+    pn.cadence ?? PROGRESS_DEFAULTS.cadence,
+  );
+  const [pnDelta, setPnDelta] = useState<number>(pn.minScoreDelta ?? PROGRESS_DEFAULTS.minScoreDelta);
+  const [pnSkipFirst, setPnSkipFirst] = useState<boolean>(
+    pn.skipFirstCall ?? PROGRESS_DEFAULTS.skipFirstCall,
+  );
+
+  // ── offboardingSummary state ────────────────────────────────────────────
+  const [obEnabled, setObEnabled] = useState<boolean>(ob.enabled ?? OFFBOARDING_DEFAULTS.enabled);
+  const [obCadence, setObCadence] = useState<"final_only" | "every_session_with_data">(
+    ob.cadence ?? OFFBOARDING_DEFAULTS.cadence,
+  );
+  const [obIncMastery, setObIncMastery] = useState<boolean>(
+    ob.includeModuleMastery ?? OFFBOARDING_DEFAULTS.includeModuleMastery,
+  );
+  const [obIncGoals, setObIncGoals] = useState<boolean>(
+    ob.includeGoalProgress ?? OFFBOARDING_DEFAULTS.includeGoalProgress,
+  );
+  const [obIncSkills, setObIncSkills] = useState<boolean>(
+    ob.includeSkillCurrentScore ?? OFFBOARDING_DEFAULTS.includeSkillCurrentScore,
+  );
+
+  // ── persistence ─────────────────────────────────────────────────────────
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      const body = {
+        progressNarrative: {
+          enabled: pnEnabled,
+          cadence: pnCadence,
+          minScoreDelta: pnDelta,
+          skipFirstCall: pnSkipFirst,
+        },
+        offboardingSummary: {
+          enabled: obEnabled,
+          cadence: obCadence,
+          includeModuleMastery: obIncMastery,
+          includeGoalProgress: obIncGoals,
+          includeSkillCurrentScore: obIncSkills,
+        },
+      };
+      const res = await fetch(`/api/courses/${courseId}/design`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error ?? "Save failed");
+      }
+      setSuccess(true);
+      onSaved?.();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="hf-section-title hf-mb-xs">Felt progress</div>
+      <div className="hf-text-xs hf-text-muted hf-mb-md">
+        Controls how the AI acknowledges progress mid-call and summarises the
+        learner&apos;s journey at the end of the course. Defaults are sensible
+        — adjust only when the course needs a different rhythm.
+      </div>
+
+      {/* ── Mid-call progress mentions ─────────────────────────────── */}
+      <div className="hf-mb-lg">
+        <label className="hf-flex hf-gap-sm hf-items-center hf-cursor-pointer">
+          <input
+            type="checkbox"
+            checked={pnEnabled}
+            onChange={(e) => setPnEnabled(e.target.checked)}
+            disabled={saving}
+          />
+          <span className="hf-text-sm hf-text-bold">Mid-call progress mentions</span>
+        </label>
+        <div className="hf-text-xs hf-text-muted hf-mb-sm">
+          When should the AI acknowledge improvement mid-conversation?
+        </div>
+
+        <div className="hf-flex-col hf-gap-xs hf-mb-sm">
+          <label className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer">
+            <input
+              type="radio"
+              name="pn-cadence"
+              value="on_threshold_crossing"
+              checked={pnCadence === "on_threshold_crossing"}
+              onChange={() => setPnCadence("on_threshold_crossing")}
+              disabled={saving || !pnEnabled}
+            />
+            <div>
+              <div className="hf-text-sm">On threshold crossing</div>
+              <div className="hf-text-xs hf-text-muted">
+                Only when a notable score moves above the threshold below.
+              </div>
+            </div>
+          </label>
+          <label className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer">
+            <input
+              type="radio"
+              name="pn-cadence"
+              value="every_call"
+              checked={pnCadence === "every_call"}
+              onChange={() => setPnCadence("every_call")}
+              disabled={saving || !pnEnabled}
+            />
+            <div>
+              <div className="hf-text-sm">Every call</div>
+              <div className="hf-text-xs hf-text-muted">
+                Whenever any score exists. Use sparingly — most courses prefer threshold crossing.
+              </div>
+            </div>
+          </label>
+        </div>
+
+        <div className="hf-mb-sm">
+          <label className="hf-label hf-text-xs">
+            Notable improvement threshold: <span className="hf-text-bold">{pnDelta.toFixed(2)}</span>
+          </label>
+          <input
+            type="range"
+            min={0.01}
+            max={0.5}
+            step={0.01}
+            value={pnDelta}
+            onChange={(e) => setPnDelta(parseFloat(e.target.value))}
+            disabled={saving || !pnEnabled || pnCadence !== "on_threshold_crossing"}
+            className="hf-input"
+          />
+          <div className="hf-text-xs hf-text-muted">
+            A learning-objective score must reach at least this value to be acknowledged.
+          </div>
+        </div>
+
+        <label className="hf-flex hf-gap-sm hf-items-center hf-cursor-pointer">
+          <input
+            type="checkbox"
+            checked={pnSkipFirst}
+            onChange={(e) => setPnSkipFirst(e.target.checked)}
+            disabled={saving || !pnEnabled}
+          />
+          <span className="hf-text-sm">Skip on first call</span>
+        </label>
+      </div>
+
+      {/* ── End-of-course summary ──────────────────────────────────── */}
+      <div className="hf-mb-lg">
+        <label className="hf-flex hf-gap-sm hf-items-center hf-cursor-pointer">
+          <input
+            type="checkbox"
+            checked={obEnabled}
+            onChange={(e) => setObEnabled(e.target.checked)}
+            disabled={saving}
+          />
+          <span className="hf-text-sm hf-text-bold">End-of-course summary</span>
+        </label>
+        <div className="hf-text-xs hf-text-muted hf-mb-sm">
+          When does the AI deliver the structured progress summary?
+        </div>
+
+        <div className="hf-flex-col hf-gap-xs hf-mb-sm">
+          <label className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer">
+            <input
+              type="radio"
+              name="ob-cadence"
+              value="final_only"
+              checked={obCadence === "final_only"}
+              onChange={() => setObCadence("final_only")}
+              disabled={saving || !obEnabled}
+            />
+            <div>
+              <div className="hf-text-sm">Final session only</div>
+              <div className="hf-text-xs hf-text-muted">Default. Saves the celebration for the end.</div>
+            </div>
+          </label>
+          <label className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer">
+            <input
+              type="radio"
+              name="ob-cadence"
+              value="every_session_with_data"
+              checked={obCadence === "every_session_with_data"}
+              onChange={() => setObCadence("every_session_with_data")}
+              disabled={saving || !obEnabled}
+            />
+            <div>
+              <div className="hf-text-sm">Every session with data</div>
+              <div className="hf-text-xs hf-text-muted">
+                Brief progress acknowledgement at the end of each session from call 2.
+              </div>
+            </div>
+          </label>
+        </div>
+
+        <div className="hf-text-xs hf-text-muted hf-mb-xs">Include in summary</div>
+        <div className="hf-flex-col hf-gap-xs">
+          <label className="hf-flex hf-gap-sm hf-items-center hf-cursor-pointer">
+            <input
+              type="checkbox"
+              checked={obIncMastery}
+              onChange={(e) => setObIncMastery(e.target.checked)}
+              disabled={saving || !obEnabled}
+            />
+            <span className="hf-text-sm">Module mastery</span>
+          </label>
+          <label className="hf-flex hf-gap-sm hf-items-center hf-cursor-pointer">
+            <input
+              type="checkbox"
+              checked={obIncGoals}
+              onChange={(e) => setObIncGoals(e.target.checked)}
+              disabled={saving || !obEnabled}
+            />
+            <span className="hf-text-sm">Goal progress</span>
+          </label>
+          <label className="hf-flex hf-gap-sm hf-items-center hf-cursor-pointer">
+            <input
+              type="checkbox"
+              checked={obIncSkills}
+              onChange={(e) => setObIncSkills(e.target.checked)}
+              disabled={saving || !obEnabled}
+            />
+            <span className="hf-text-sm">Skill scores</span>
+          </label>
+        </div>
+      </div>
+
+      <div className="hf-flex hf-gap-sm hf-items-center">
+        <button
+          className="hf-btn hf-btn-sm hf-btn-primary"
+          onClick={save}
+          disabled={saving}
+        >
+          {saving ? "Saving…" : "Save Felt Progress"}
+        </button>
+        {success && <span className="hf-text-xs hf-text-success">Saved.</span>}
+        {error && <span className="hf-text-xs hf-text-error">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/course-design/FirstSessionSettings.tsx
+++ b/apps/admin/components/course-design/FirstSessionSettings.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+/**
+ * FirstSessionSettings — Section 2 of #784 (Felt Progress S6) plus the
+ * #790 (S8) firstCallMode radio.
+ *
+ * Two responsibilities:
+ *   1. A read-only signpost table listing the six first-session controls
+ *      owned by `SessionFlowEditor` — discoverability only, no API calls.
+ *   2. The genuinely-new knobs:
+ *        - `firstCallMode` (#790 S8) — onboarding / teach_immediately /
+ *          baseline_assessment radio
+ *        - `firstSessionTargets` (#784 S6) — per-playbook first-call
+ *          BEHAVIOR target overrides; repeater rows with parameter +
+ *          value slider
+ *
+ * Single Save button persists firstCallMode + firstSessionTargets to
+ * PUT /api/courses/[id]/design.
+ *
+ * Parameter picker: uses a small hardcoded list of common BEHAVIOR
+ * parameter IDs rather than plumbing `loadAdjustableParameters()` from
+ * server -> client (the server helper hits Prisma). When the educator needs
+ * a less-common parameter, AgentTuner remains the canonical entry. This
+ * keeps the component self-contained — matching the BandingPicker pattern.
+ */
+
+import { useState } from "react";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+// Hardcoded fallback list — covers the common first-call tuning surface.
+// Kept short on purpose; the AgentTuner is the rich entry-point. If a
+// course needs a parameter not in this list, an educator can add it via
+// AgentTuner and the runtime will honour it because the design route
+// accepts any parameterId key in `firstSessionTargets`.
+const COMMON_BEHAVIOR_PARAMS: ReadonlyArray<{ id: string; label: string }> = [
+  { id: "BEH-WARMTH", label: "Warmth" },
+  { id: "BEH-CHALLENGE-LEVEL", label: "Challenge level" },
+  { id: "BEH-PACING", label: "Pacing" },
+  { id: "BEH-DEPTH", label: "Depth" },
+];
+
+interface FirstSessionSettingsProps {
+  courseId: string;
+  playbookConfig?: PlaybookConfig | Record<string, unknown> | null;
+  onSaved?: () => void;
+}
+
+type FirstCallMode = "onboarding" | "teach_immediately" | "baseline_assessment";
+
+interface TargetOverrideRow {
+  parameterId: string;
+  value: number;
+}
+
+const FIRST_CALL_MODE_OPTIONS: Array<{
+  value: FirstCallMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "onboarding",
+    label: "Onboarding (default)",
+    description:
+      "Introduce the course, set expectations, gather goals. Teaching begins from call 2.",
+  },
+  {
+    value: "teach_immediately",
+    label: "Teach immediately",
+    description:
+      "Skip onboarding chatter. Apply the course's teaching mode from the very first call. Best for repeat learners or intensive programmes.",
+  },
+  {
+    value: "baseline_assessment",
+    label: "Baseline assessment",
+    description:
+      "First call captures diagnostic data only — no teaching content. The AI scores against learning objectives and sets a baseline for progress tracking. Works best with an authored curriculum.",
+  },
+];
+
+function readSignpostState(cfg: PlaybookConfig): Array<{ label: string; value: string }> {
+  // Source priority: new sessionFlow.intake shape -> legacy welcome shape.
+  // Both surfaces are kept in sync by SessionFlowEditor during the dual-
+  // read window — reading both keeps the signpost honest even when the
+  // course hasn't been re-saved on the new shape yet.
+  const intake = cfg.sessionFlow?.intake;
+  const welcome = cfg.welcome;
+
+  const askGoals = intake?.goals?.enabled ?? welcome?.goals?.enabled ?? true;
+  const askAboutYou = intake?.aboutYou?.enabled ?? welcome?.aboutYou?.enabled ?? true;
+  const askKnowledge = intake?.knowledgeCheck?.enabled ?? welcome?.knowledgeCheck?.enabled ?? false;
+  const kcMode = intake?.knowledgeCheck?.deliveryMode;
+  const aiIntro = intake?.aiIntroCall?.enabled ?? welcome?.aiIntroCall?.enabled ?? false;
+  const hasWelcomeMessage = typeof cfg.welcomeMessage === "string" && cfg.welcomeMessage.trim().length > 0;
+  const hasOnboardingPhases =
+    (cfg.sessionFlow?.onboarding?.phases?.length ?? 0) > 0 ||
+    (cfg.onboardingFlowPhases?.phases?.length ?? 0) > 0;
+
+  return [
+    { label: "Goals question", value: askGoals ? "On" : "Off" },
+    { label: "About You", value: askAboutYou ? "On" : "Off" },
+    {
+      label: "Knowledge Check",
+      value: askKnowledge ? `On${kcMode ? ` (${kcMode})` : ""}` : "Off",
+    },
+    { label: "AI Intro Call", value: aiIntro ? "On" : "Off" },
+    { label: "Welcome message override", value: hasWelcomeMessage ? "Set" : "—" },
+    { label: "Onboarding phases", value: hasOnboardingPhases ? "Configured" : "—" },
+  ];
+}
+
+export function FirstSessionSettings({
+  courseId,
+  playbookConfig,
+  onSaved,
+}: FirstSessionSettingsProps): React.ReactElement {
+  const cfg = (playbookConfig ?? {}) as PlaybookConfig;
+
+  const initialMode: FirstCallMode = (cfg.firstCallMode as FirstCallMode | undefined) ?? "onboarding";
+  const initialRows: TargetOverrideRow[] = Object.entries(cfg.firstSessionTargets ?? {}).map(
+    ([parameterId, v]) => ({ parameterId, value: v.value }),
+  );
+
+  const [mode, setMode] = useState<FirstCallMode>(initialMode);
+  const [rows, setRows] = useState<TargetOverrideRow[]>(initialRows);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const signpost = readSignpostState(cfg);
+
+  function addOverride() {
+    // Pick the first parameter not already present, or fall back to first option.
+    const used = new Set(rows.map((r) => r.parameterId));
+    const next = COMMON_BEHAVIOR_PARAMS.find((p) => !used.has(p.id)) ?? COMMON_BEHAVIOR_PARAMS[0];
+    setRows([...rows, { parameterId: next.id, value: 0.5 }]);
+  }
+
+  function updateRow(index: number, patch: Partial<TargetOverrideRow>) {
+    setRows(rows.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+  }
+
+  function removeRow(index: number) {
+    setRows(rows.filter((_, i) => i !== index));
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      // Coalesce rows into the record shape the route + transform expect.
+      // Empty rows array → null body field, which the route uses to delete
+      // the namespace so the domain default cascade runs again.
+      const targets: Record<string, { value: number; confidence?: number }> = {};
+      for (const r of rows) {
+        targets[r.parameterId] = { value: r.value };
+      }
+
+      const body = {
+        firstCallMode: mode,
+        firstSessionTargets: rows.length > 0 ? targets : null,
+      };
+      const res = await fetch(`/api/courses/${courseId}/design`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error ?? "Save failed");
+      }
+      setSuccess(true);
+      onSaved?.();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="hf-section-title hf-mb-xs">Call 1 / First session</div>
+      <div className="hf-text-xs hf-text-muted hf-mb-md">
+        How the learner&apos;s first call is configured. Some controls live
+        in the Session Flow editor above — the table below shows their
+        current state for reference.
+      </div>
+
+      {/* ── Signpost: read-only summary of SessionFlowEditor state ───────── */}
+      <div className="hf-mb-lg">
+        <div className="hf-text-xs hf-text-muted hf-mb-xs">
+          Owned by Session Flow editor — scroll up to edit
+        </div>
+        <div className="hf-card-compact">
+          {signpost.map((row) => (
+            <div
+              key={row.label}
+              className="hf-flex hf-gap-sm hf-items-center hf-list-row"
+            >
+              <div className="hf-flex-1 hf-text-sm">{row.label}</div>
+              <div className="hf-text-xs hf-text-muted">{row.value}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── firstCallMode radio group (#790 S8) ───────────────────────────── */}
+      <div className="hf-mb-lg">
+        <div className="hf-text-sm hf-text-bold hf-mb-xs">
+          How should the AI approach the learner&apos;s first call?
+        </div>
+        <div className="hf-flex-col hf-gap-sm">
+          {FIRST_CALL_MODE_OPTIONS.map((opt) => (
+            <label
+              key={opt.value}
+              className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer"
+            >
+              <input
+                type="radio"
+                name="first-call-mode"
+                value={opt.value}
+                checked={mode === opt.value}
+                onChange={() => setMode(opt.value)}
+                disabled={saving}
+              />
+              <div className="hf-flex-1">
+                <div className="hf-text-sm hf-text-bold">{opt.label}</div>
+                <div className="hf-text-xs hf-text-muted">{opt.description}</div>
+              </div>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* ── firstSessionTargets repeater (#784 S6) ────────────────────────── */}
+      <div className="hf-mb-lg">
+        <div className="hf-text-sm hf-text-bold hf-mb-xs">First-call AI behaviour targets</div>
+        <div className="hf-text-xs hf-text-muted hf-mb-sm">
+          Sets the AI&apos;s starting parameters before any caller data
+          exists. Falls back to domain defaults when not set.
+        </div>
+
+        {rows.length === 0 ? (
+          <div className="hf-empty hf-text-xs hf-text-muted hf-mb-sm">
+            No overrides set — domain defaults apply.
+          </div>
+        ) : (
+          <div className="hf-flex-col hf-gap-sm hf-mb-sm">
+            {rows.map((row, i) => (
+              <div
+                key={`${row.parameterId}-${i}`}
+                className="hf-flex hf-gap-sm hf-items-center"
+              >
+                <select
+                  className="hf-input"
+                  value={row.parameterId}
+                  onChange={(e) => updateRow(i, { parameterId: e.target.value })}
+                  disabled={saving}
+                >
+                  {COMMON_BEHAVIOR_PARAMS.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.label} ({p.id})
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  value={row.value}
+                  onChange={(e) => updateRow(i, { value: parseFloat(e.target.value) })}
+                  disabled={saving}
+                  className="hf-input"
+                />
+                <span className="hf-text-xs hf-text-muted">{row.value.toFixed(2)}</span>
+                <button
+                  type="button"
+                  className="hf-btn hf-btn-sm hf-btn-destructive"
+                  onClick={() => removeRow(i)}
+                  disabled={saving}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="hf-btn hf-btn-sm hf-btn-secondary"
+          onClick={addOverride}
+          disabled={saving}
+        >
+          + Add first-call target override
+        </button>
+      </div>
+
+      <div className="hf-flex hf-gap-sm hf-items-center">
+        <button
+          className="hf-btn hf-btn-sm hf-btn-primary"
+          onClick={save}
+          disabled={saving}
+        >
+          {saving ? "Saving…" : "Save First Session"}
+        </button>
+        {success && <span className="hf-text-xs hf-text-success">Saved.</span>}
+        {error && <span className="hf-text-xs hf-text-error">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/evals/felt-progress/README.md
+++ b/apps/admin/evals/felt-progress/README.md
@@ -13,6 +13,7 @@ new behaviour is detectable, and the eval stays in CI as a regression net.
 |------|-------|----------|
 | `progress-narrative-gates.yaml` | #779 (S1) | progressNarrative section is omitted when no evidence, enabled=false, or call 1; emitted with strict-rule guidance when evidence is present |
 | `offboarding-summary.yaml` | #780 (S2) | offboarding emits structured progressSummary (modules + goals + skills) with cite-only-verbatim guidance; null-guards when no data; per-field includes work |
+| `s8-first-call-mode.yaml` | #790 (S8) | firstCallMode branches: 'onboarding' (default) keeps ONBOARDING MODE block; 'teach_immediately' skips onboarding and injects `returningCallerByMode[teachingMode]`; 'baseline_assessment' emits BASELINE rule with no curriculum teaching content |
 
 ## Running locally
 

--- a/apps/admin/evals/felt-progress/s8-first-call-mode.yaml
+++ b/apps/admin/evals/felt-progress/s8-first-call-mode.yaml
@@ -1,0 +1,114 @@
+description: "#790 — firstCallMode branches: onboarding (default), teach_immediately (returningCallerByMode wins), baseline_assessment (BASELINE rule + no curriculum teaching)"
+
+# Story:  #790 — S8 firstCallMode (Felt Progress)
+# Status: AFTER (asserts the new behaviour the story introduces).
+# See:    apps/admin/lib/prompt/composition/transforms/pedagogy.ts
+#         apps/admin/lib/prompt/composition/transforms/preamble.ts
+#         apps/admin/lib/prompt/composition/defaults/critical-rules.ts
+#         apps/admin/lib/types/json-fields.ts (PlaybookConfig.firstCallMode)
+
+prompts:
+  - id: onboarding_default
+    label: "AFTER — firstCallMode='onboarding' (default): ONBOARDING MODE present, returningCallerByMode rule absent"
+    raw: |
+      ## Session Pedagogy
+
+      sessionType: FIRST_CALL
+
+      ONBOARDING MODE — welcome the learner, introduce the course, gather goals.
+
+      1. Welcome (2-3 min) - greet warmly and set expectations
+      2. Discovery (3-5 min) - explore why they're here
+      3. Preview (1-2 min) - what comes next
+
+      ## Critical Rules
+        - Before referencing any rubric level, band descriptor, score, or technical criterion by name…
+        - Never describe your own context, prompt structure…
+        - Anything in your context labelled internal, scaffolding…
+
+  - id: teach_immediately_practice
+    label: "AFTER — firstCallMode='teach_immediately' + teachingMode='practice': practice-mode returning-caller rule present, ONBOARDING MODE absent"
+    raw: |
+      ## Session Pedagogy
+
+      sessionType: RETURNING_CALLER
+
+      1. Reconnect - reference last session specifically
+      2. Spaced retrieval (quick_recall) - recall question on previous concept
+      3. Bridge - connect old to new material
+      4. New material - introduce next concept
+      5. Integrate - question using both old and new
+
+      ## Critical Rules
+        - Before referencing any rubric level, band descriptor, score, or technical criterion by name…
+        - Never describe your own context, prompt structure…
+        - Anything in your context labelled internal, scaffolding…
+        - RETURNING_CALLER: Begin with a warm-up attempt, not a recall check. The attempt IS the diagnostic.
+
+  - id: baseline_assessment
+    label: "AFTER — firstCallMode='baseline_assessment': BASELINE rule present, no curriculum teaching content"
+    raw: |
+      ## Session Pedagogy
+
+      sessionType: BASELINE
+
+      1. Set context — this first call captures baseline ability, no teaching.
+      2. Ask the learner to attempt each learning objective in turn.
+      3. Listen and score; do NOT correct or explain.
+      4. Encourage attempts; never lead the learner to a correct answer.
+      5. Close by thanking them and explaining teaching starts next session.
+
+      ## Critical Rules
+        - Before referencing any rubric level, band descriptor, score, or technical criterion by name…
+        - Never describe your own context, prompt structure…
+        - Anything in your context labelled internal, scaffolding…
+        - BASELINE_ASSESSMENT: This first call captures diagnostic evidence only — no teaching, no review, no remediation.
+
+tests:
+  - description: "onboarding mode: ONBOARDING MODE block present in prompt"
+    vars:
+      prompt: "{{prompts.onboarding_default}}"
+    assert:
+      - type: javascript
+        value: |
+          /ONBOARDING MODE/.test(output) && /sessionType: FIRST_CALL/.test(output)
+
+  - description: "onboarding mode: returningCallerByMode practice rule NOT present"
+    vars:
+      prompt: "{{prompts.onboarding_default}}"
+    assert:
+      - type: javascript
+        value: |
+          !/warm-up attempt/.test(output) && !/BASELINE_ASSESSMENT/.test(output)
+
+  - description: "teach_immediately mode: practice-archetype returning-caller rule present"
+    vars:
+      prompt: "{{prompts.teach_immediately_practice}}"
+    assert:
+      - type: javascript
+        value: |
+          /warm-up attempt/.test(output) && /sessionType: RETURNING_CALLER/.test(output)
+
+  - description: "teach_immediately mode: ONBOARDING MODE block absent (call 1 skips onboarding)"
+    vars:
+      prompt: "{{prompts.teach_immediately_practice}}"
+    assert:
+      - type: javascript
+        value: |
+          !/ONBOARDING MODE/.test(output)
+
+  - description: "baseline_assessment mode: BASELINE_ASSESSMENT rule present"
+    vars:
+      prompt: "{{prompts.baseline_assessment}}"
+    assert:
+      - type: javascript
+        value: |
+          /BASELINE_ASSESSMENT/.test(output) && /sessionType: BASELINE/.test(output)
+
+  - description: "baseline_assessment mode: no curriculum teaching content (no 'New material', no 'Spaced retrieval')"
+    vars:
+      prompt: "{{prompts.baseline_assessment}}"
+    assert:
+      - type: javascript
+        value: |
+          !/New material/.test(output) && !/Spaced retrieval/.test(output) && !/ONBOARDING MODE/.test(output)

--- a/apps/admin/lib/prompt/composition/defaults/critical-rules.ts
+++ b/apps/admin/lib/prompt/composition/defaults/critical-rules.ts
@@ -47,3 +47,16 @@ export const RETURNING_CALLER_BY_MODE: Record<TeachingMode, string> = {
   practice:
     "RETURNING_CALLER: Begin with a warm-up attempt, not a recall check. The attempt IS the diagnostic.",
 };
+
+/**
+ * #790 (S8) — Critical rule injected on call 1 when
+ * `Playbook.config.firstCallMode === 'baseline_assessment'`. Bypasses both
+ * the onboarding intro AND the teaching-mode-specific returning-caller
+ * rule. The session is diagnostic-only: capture baseline scores against
+ * learning objectives, no teaching content, no review.
+ *
+ * Override path: `prompt_preamble.config.criticalRules.baselineAssessment`
+ * in COMP-001 spec config.
+ */
+export const BASELINE_ASSESSMENT_RULE =
+  "BASELINE_ASSESSMENT: This first call captures diagnostic evidence only — no teaching, no review, no remediation. Ask the learner to demonstrate their current ability against the learning objectives in turn; score what you observe. Do not correct mistakes, do not explain answers, do not introduce new material. The purpose is to establish where the learner starts so progress can be measured. Encourage attempts but never lead the learner to a correct answer.";

--- a/apps/admin/lib/prompt/composition/transforms/pedagogy.ts
+++ b/apps/admin/lib/prompt/composition/transforms/pedagogy.ts
@@ -105,6 +105,17 @@ registerTransform("computeSessionPedagogy", (
   // First playbook's config for course-level onboarding override
   const primaryPlaybook = context.loadedData.playbooks?.[0];
 
+  // #790 (S8) — first-call mode override. Default 'onboarding' preserves
+  // existing behaviour byte-for-byte. `teach_immediately` skips the
+  // ONBOARDING MODE branch so the returning-caller flow runs on call 1.
+  // `baseline_assessment` swaps in a diagnostic-only branch with no
+  // curriculum teaching content. See lib/types/json-fields.ts.
+  const firstCallMode =
+    ((primaryPlaybook as { config?: { firstCallMode?: "onboarding" | "teach_immediately" | "baseline_assessment" } })?.config?.firstCallMode) ?? "onboarding";
+  const isFirstCallAny = isFirstCall || isFirstCallInDomain;
+  const isOnboardingFirstCall = isFirstCallAny && firstCallMode === "onboarding";
+  const isBaselineFirstCall = isFirstCallAny && firstCallMode === "baseline_assessment";
+
   const plan: {
     sessionType: string;
     flow: string[];
@@ -124,16 +135,48 @@ registerTransform("computeSessionPedagogy", (
     /** Post-coverage guidance — what to do when all TPs are covered */
     postCoverageGuidance?: string;
   } = {
-    sessionType: isFirstCall ? "FIRST_CALL" : "RETURNING_CALLER",
+    // #790 (S8) — sessionType now reflects firstCallMode on call 1:
+    //   onboarding (default) → FIRST_CALL (current behaviour)
+    //   baseline_assessment  → BASELINE
+    //   teach_immediately    → RETURNING_CALLER (treat call 1 as returning)
+    sessionType: isOnboardingFirstCall
+      ? "FIRST_CALL"
+      : isBaselineFirstCall
+        ? "BASELINE"
+        : "RETURNING_CALLER",
     flow: [],
     principles: [],
   };
 
   // =========================================================================
-  // THREE-WAY BRANCH: Onboarding / Lesson Plan / Generic Returning Caller
+  // FOUR-WAY BRANCH: Baseline / Onboarding / Lesson Plan / Generic Returning Caller
+  //
+  // #790 (S8) — `firstCallMode` selects between Baseline and Onboarding on
+  // call 1. `teach_immediately` falls THROUGH this if-chain entirely so the
+  // scheduler / returning-caller path runs on call 1 with no first-call
+  // override flow. `baseline_assessment` short-circuits with a diagnostic-
+  // only flow that ignores any curriculum teaching content.
   // =========================================================================
 
-  if (isFirstCall || isFirstCallInDomain) {
+  if (isBaselineFirstCall) {
+    // === BASELINE ASSESSMENT MODE (#790 S8) ===
+    // Diagnostic-only first call: capture baseline scores against learning
+    // objectives, no teaching content, no correction. The corresponding
+    // critical rule (BASELINE_ASSESSMENT_RULE) is injected by preamble.ts.
+    plan.flow = [
+      "1. Set context — this first call captures baseline ability, no teaching.",
+      "2. Ask the learner to attempt each learning objective in turn.",
+      "3. Listen and score; do NOT correct or explain.",
+      "4. Encourage attempts; never lead the learner to a correct answer.",
+      "5. Close by thanking them and explaining teaching starts next session.",
+    ];
+    plan.principles = [
+      "No teaching, no review, no remediation on this call.",
+      "Score every learning objective you observe.",
+      "Encourage attempts; never give the answer.",
+    ];
+    console.log("[pedagogy] firstCallMode=baseline_assessment — diagnostic-only flow");
+  } else if (isOnboardingFirstCall) {
     // === ONBOARDING MODE ===
     const firstModule = modules[0];
 
@@ -441,7 +484,10 @@ registerTransform("computeSessionPedagogy", (
   // =========================================================================
   // POST-COVERAGE GUIDANCE — what to do when all TPs are covered
   // =========================================================================
-  const isTeachingSession = hasCurriculum && !isFirstCall && !isFirstCallInDomain
+  // #790 (S8) — `teach_immediately` IS a teaching session on call 1, but
+  // `onboarding` and `baseline_assessment` are not. The exclusion now keys
+  // off the firstCallMode-aware flags computed above, not raw isFirstCall.
+  const isTeachingSession = hasCurriculum && !isOnboardingFirstCall && !isBaselineFirstCall
     && plan.sessionType !== "OPEN_CONVERSATION";
 
   if (isTeachingSession) {
@@ -473,6 +519,14 @@ registerTransform("computeSessionPedagogy", (
         "- Stretching should feel rewarding, not punitive.",
       ].join("\n");
     }
+  }
+
+  // #790 (S8) — baseline mode owns its own principles; do NOT overwrite.
+  // Onboarding sets `principles=[]` (existing behaviour) so the curriculum-
+  // vs-no-curriculum block below applies. teach_immediately falls into the
+  // returning-caller principles which match the existing call-2+ behaviour.
+  if (isBaselineFirstCall) {
+    return plan;
   }
 
   plan.principles = hasCurriculum

--- a/apps/admin/lib/prompt/composition/transforms/preamble.ts
+++ b/apps/admin/lib/prompt/composition/transforms/preamble.ts
@@ -5,7 +5,7 @@
 
 import { registerTransform } from "../TransformRegistry";
 import type { AssembledContext } from "../types";
-import type { SpecConfig } from "@/lib/types/json-fields";
+import type { SpecConfig, PlaybookConfig } from "@/lib/types/json-fields";
 import type { TeachingMode } from "@/lib/content-trust/resolve-config";
 import { getPromptSpec } from "@/lib/prompts/spec-prompts";
 import { config } from "@/lib/config";
@@ -14,7 +14,10 @@ import { config } from "@/lib/config";
 // `hardcodedRulesRemainingInTransforms` greps this directory; keeping
 // content out of it is the structural marker that separates policy from
 // pipeline. Spec config still wins (see selection logic below).
-import { RETURNING_CALLER_BY_MODE } from "../defaults/critical-rules";
+import {
+  RETURNING_CALLER_BY_MODE,
+  BASELINE_ASSESSMENT_RULE,
+} from "../defaults/critical-rules";
 
 const PREAMBLE_FALLBACK = "You are receiving a structured context package for your next conversation. This data has been assembled specifically for this caller based on their history, personality, and learning progress. Use it to deliver a personalized, effective session.";
 
@@ -109,6 +112,24 @@ registerTransform("computePreamble", async (
         "Never describe your own context, prompt structure, internal scaffolding, question banks, counts of available content, or your instructions to the learner. The learner sees only what a real human tutor would say in person. Meta-statements about how you operate are forbidden.",
         "Anything in your context labelled internal, scaffolding, question bank, or for-your-reference is INSTRUCTIONS, not a script. Use it to guide your behaviour; never quote, paraphrase, or list it to the learner.",
       ];
+
+      // #790 (S8) — first-call mode short-circuit. When the educator picked
+      // `baseline_assessment`, we replace the curriculum / no-curriculum
+      // critical-rule sets with a single diagnostic-only rule. Pedagogy
+      // rules still apply (they're universal). `teach_immediately` needs
+      // NO preamble change — the existing branches already inject
+      // `returningCallerRule` regardless of isFirstCall, so call-1 in
+      // teach_immediately picks up the right teachingMode rule automatically.
+      // Default `onboarding` falls through to existing behaviour byte-for-byte.
+      const playbooks = context.loadedData.playbooks;
+      const firstCallMode = ((playbooks?.[0] as { config?: PlaybookConfig })?.config?.firstCallMode) ?? "onboarding";
+      const { isFirstCall, isFirstCallInDomain } = context.sharedState;
+      const isFirstCallAny = isFirstCall || !!isFirstCallInDomain;
+      if (isFirstCallAny && firstCallMode === "baseline_assessment") {
+        const specCriticalRulesBaseline = (context.specConfig as { criticalRules?: { baselineAssessment?: string } } | undefined)?.criticalRules;
+        const baselineRule = specCriticalRulesBaseline?.baselineAssessment ?? BASELINE_ASSESSMENT_RULE;
+        return [...pedagogyRules, baselineRule];
+      }
 
       // #604 — pick the RETURNING_CALLER rule by archetype (playbook
       // teachingMode). Spec-config override wins (COMP-001

--- a/apps/admin/lib/prompt/composition/transforms/targets.ts
+++ b/apps/admin/lib/prompt/composition/transforms/targets.ts
@@ -8,6 +8,7 @@ import { classifyValue } from "../types";
 import type { AssembledContext, BehaviorTargetData, CallerTargetData, CompositionSectionDef } from "../types";
 import { config } from "@/lib/config";
 import type { AudienceId } from "./audience";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
 
 /**
  * Audience-aware default targets for parameters not covered by INIT-001.
@@ -77,9 +78,50 @@ registerTransform("mergeAndGroupTargets", (
   let merged = mergeTargets(behaviorTargets, callerTargets, playbookIds);
 
   // ONBOARDING: Inject first-call defaults for missing parameters
-  // Priority: Domain.onboardingDefaultTargets > INIT-001 fallback
+  // Priority (highest first):
+  //   1. Playbook.config.firstSessionTargets — #784 (S6) per-playbook override
+  //   2. Domain.onboardingDefaultTargets
+  //   3. INIT-001 fallback
+  //   4. AUDIENCE_TARGET_DEFAULTS (still runs below as the last resort)
   if (isFirstCall) {
     const existingParams = new Set(merged.map(t => t.parameterId));
+
+    // #784 (S6) — per-playbook first-call BEHAVIOR target overrides at NEW
+    // priority 1. Educator-tuned; sits above the domain default cascade.
+    // Existing CallerTargets / educator-locked BehaviorTargets are still
+    // honoured (they're already in `existingParams` from the merge above),
+    // so a learner who has been scored on call 2+ is never reset to
+    // first-call defaults — the gate is `isFirstCall === true`.
+    const firstSessionTargets = (
+      (playbooks?.[0] as { config?: PlaybookConfig })?.config?.firstSessionTargets
+    ) as PlaybookConfig["firstSessionTargets"] | undefined;
+    if (firstSessionTargets) {
+      let playbookFirstSessionInjected = 0;
+      for (const [paramId, overrides] of Object.entries(firstSessionTargets)) {
+        if (paramId.startsWith("_")) continue;
+        if (existingParams.has(paramId)) continue;
+        merged.push({
+          parameterId: paramId,
+          targetValue: overrides.value,
+          confidence: overrides.confidence ?? 0.8,
+          source: "BehaviorTarget",
+          scope: "PLAYBOOK_FIRST_SESSION",
+          parameter: {
+            name: paramId.replace("BEH-", "").replace(/-/g, " ").toLowerCase(),
+            interpretationLow: null,
+            interpretationHigh: null,
+            domainGroup: "First Call Defaults",
+          },
+        });
+        existingParams.add(paramId);
+        playbookFirstSessionInjected++;
+      }
+      if (playbookFirstSessionInjected > 0) {
+        console.log(
+          `[targets] First call: injected ${playbookFirstSessionInjected} playbook-level firstSessionTargets (Playbook.config.firstSessionTargets)`,
+        );
+      }
+    }
 
     // Try Domain onboarding defaults first
     const domain = context.loadedData.caller?.domain;

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -455,6 +455,28 @@ export interface PlaybookConfig {
     includeSkillCurrentScore?: boolean;
   };
   /**
+   * #784 (S6) — per-playbook first-call BEHAVIOR target overrides. Read by
+   * `transforms/targets.ts::mergeAndGroupTargets` at NEW priority 1, above
+   * `Domain.onboardingDefaultTargets`. When unset, the existing cascade
+   * (domain → INIT-001 → AUDIENCE_TARGET_DEFAULTS) applies.
+   *
+   * Keyed by `Parameter.parameterId` (e.g. `BEH-WARMTH`). `value` in [0,1];
+   * `confidence` defaults to 0.8 when omitted.
+   */
+  firstSessionTargets?: Record<string, { value: number; confidence?: number }>;
+  /**
+   * #790 (S8) — first-call mode override. Today every first call is forced
+   * into ONBOARDING MODE in `transforms/pedagogy.ts` regardless of
+   * `teachingMode`. This knob lets the educator pick:
+   *   - `'onboarding'` (default) — current behaviour, byte-identical output
+   *   - `'teach_immediately'` — bypass ONBOARDING MODE; call 1 runs the
+   *     `teachingMode`-branched returning-caller flow; preamble injects
+   *     `returningCallerByMode[teachingMode]`
+   *   - `'baseline_assessment'` — first call captures diagnostic only;
+   *     no curriculum teaching; new baseline critical rule injected
+   */
+  firstCallMode?: "onboarding" | "teach_immediately" | "baseline_assessment";
+  /**
    * #494 E2 Slice 2.3 — when the picker should hard-lock terminal modules with
    * unmet prerequisites vs. show a soft-warning override modal. Default false
    * (soft warning), per IELTS learner-picks ethos. Set true for assessment

--- a/apps/admin/tests/lib/prompt/composition/pedagogy-first-call-mode.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/pedagogy-first-call-mode.test.ts
@@ -1,0 +1,169 @@
+/**
+ * pedagogy transform — #790 (S8) firstCallMode branching.
+ *
+ * Three modes:
+ *   - 'onboarding' (default) → sessionType === "FIRST_CALL", existing
+ *     ONBOARDING MODE branch runs
+ *   - 'teach_immediately' → sessionType === "RETURNING_CALLER",
+ *     ONBOARDING MODE branch SKIPPED on call 1
+ *   - 'baseline_assessment' → sessionType === "BASELINE", new diagnostic
+ *     flow emitted, principles overridden
+ *
+ * Pattern mirrors progress-narrative.test.ts. We don't snapshot the full
+ * onboarding flow — just check the sessionType + flow signatures that
+ * distinguish each mode.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import "@/lib/prompt/composition/transforms/pedagogy";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type {
+  AssembledContext,
+  SharedComputedState,
+  CompositionSectionDef,
+} from "@/lib/prompt/composition/types";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
+  return {
+    channel: "text",
+    modules: [],
+    isFirstCall: true,
+    daysSinceLastCall: 0,
+    completedModules: new Set<string>(),
+    estimatedProgress: 0,
+    lastCompletedIndex: -1,
+    moduleToReview: null,
+    nextModule: null,
+    reviewType: "quick_recall",
+    reviewReason: "",
+    thresholds: { high: 0.65, low: 0.35 },
+    isFinalSession: false,
+    callNumber: 1,
+    ...overrides,
+  };
+}
+
+function makeContext(opts: {
+  firstCallMode?: PlaybookConfig["firstCallMode"];
+  teachingMode?: string;
+  hasCurriculum?: boolean;
+} = {}): AssembledContext {
+  const playbookConfig: PlaybookConfig = {};
+  if (opts.firstCallMode) playbookConfig.firstCallMode = opts.firstCallMode;
+  if (opts.teachingMode) playbookConfig.teachingMode = opts.teachingMode;
+
+  // Stubbed modules → hasCurriculum=true so the returning-caller branch is
+  // available for teach_immediately.
+  const modules = opts.hasCurriculum
+    ? ([
+        { id: "m1", name: "Part 1", description: "intro" },
+      ] as unknown as SharedComputedState["modules"])
+    : ([] as unknown as SharedComputedState["modules"]);
+
+  return {
+    sharedState: makeSharedState({ modules }),
+    sections: {
+      teachingContent: opts.hasCurriculum ? { hasTeachingContent: true } : {},
+    },
+    loadedData: {
+      caller: null,
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      callCount: 0,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [
+        {
+          id: "p1",
+          name: "Test Playbook",
+          status: "PUBLISHED",
+          config: playbookConfig,
+          domain: null,
+          items: [],
+        },
+      ] as unknown as AssembledContext["loadedData"]["playbooks"],
+      systemSpecs: [],
+      onboardingSpec: null,
+    },
+    resolvedSpecs: {} as AssembledContext["resolvedSpecs"],
+    specConfig: {},
+  };
+}
+
+const STUB_SECTION: CompositionSectionDef = {
+  id: "instructions_pedagogy",
+  name: "Session Pedagogy",
+  priority: 9.0,
+  dataSource: "_assembled",
+  activateWhen: { condition: "always" },
+  fallback: { action: "null" },
+  transform: "computeSessionPedagogy",
+  outputKey: "instructions_pedagogy",
+};
+
+interface PedagogyPlan {
+  sessionType: string;
+  flow: string[];
+  principles: string[];
+  firstCallPhases?: Array<{ phase: string }>;
+}
+
+const transform = getTransform("computeSessionPedagogy")!;
+
+describe("computeSessionPedagogy — #790 firstCallMode branching", () => {
+  it("default 'onboarding' mode → sessionType=FIRST_CALL with onboarding flow", () => {
+    const ctx = makeContext({ hasCurriculum: true });
+    const plan = transform(null, ctx, STUB_SECTION) as PedagogyPlan;
+    expect(plan.sessionType).toBe("FIRST_CALL");
+    // Onboarding flow starts with welcome/intro — never "Set context — this
+    // first call captures baseline ability" (the baseline-mode opener).
+    expect(plan.flow.join("\n")).not.toMatch(/this first call captures baseline/i);
+  });
+
+  it("'teach_immediately' mode → skips ONBOARDING MODE on call 1; sessionType=RETURNING_CALLER", () => {
+    const ctx = makeContext({
+      firstCallMode: "teach_immediately",
+      hasCurriculum: true,
+    });
+    const plan = transform(null, ctx, STUB_SECTION) as PedagogyPlan;
+    expect(plan.sessionType).toBe("RETURNING_CALLER");
+    // Flow is from the returning-caller branch ("Reconnect - reference last session...")
+    expect(plan.flow.join("\n")).toMatch(/reconnect/i);
+    // ONBOARDING MODE phases must NOT be populated.
+    expect(plan.firstCallPhases).toBeUndefined();
+  });
+
+  it("'baseline_assessment' mode → sessionType=BASELINE with diagnostic flow", () => {
+    const ctx = makeContext({
+      firstCallMode: "baseline_assessment",
+      hasCurriculum: true,
+    });
+    const plan = transform(null, ctx, STUB_SECTION) as PedagogyPlan;
+    expect(plan.sessionType).toBe("BASELINE");
+    const flowText = plan.flow.join("\n");
+    expect(flowText).toMatch(/this first call captures baseline/i);
+    expect(flowText).toMatch(/score what you observe|listen and score/i);
+    // Baseline principles override the curriculum/no-curriculum principles
+    // block — must contain the "no teaching" line.
+    expect(plan.principles.join("\n")).toMatch(/no teaching, no review/i);
+  });
+
+  it("'baseline_assessment' does not flow into the teaching-session post-coverage block", () => {
+    const ctx = makeContext({
+      firstCallMode: "baseline_assessment",
+      hasCurriculum: true,
+    });
+    const plan = transform(null, ctx, STUB_SECTION) as PedagogyPlan & {
+      postCoverageGuidance?: string;
+    };
+    // post-coverage block is only added when isTeachingSession is true;
+    // baseline mode must not be a teaching session.
+    expect(plan.postCoverageGuidance).toBeUndefined();
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/preamble-first-call-mode.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/preamble-first-call-mode.test.ts
@@ -1,0 +1,150 @@
+/**
+ * preamble transform — #790 (S8) firstCallMode-driven critical-rule choice.
+ *
+ * Three cases:
+ *   - 'baseline_assessment' on call 1 → BASELINE_ASSESSMENT_RULE injected;
+ *     returningCallerByMode rule NOT injected
+ *   - 'teach_immediately' on call 1 with teachingMode='practice' →
+ *     returningCallerByMode[practice] rule injected (the existing branch
+ *     already does this regardless of isFirstCall — verified by reading
+ *     preamble.ts; this test guards against regression)
+ *   - 'onboarding' (default) on call 1 → BASELINE_ASSESSMENT_RULE NOT
+ *     injected; existing rule set unchanged
+ *
+ * The transform is registered async — we await its result.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// Stub the spec-prompts lookup so the test doesn't hit the DB; the preamble
+// systemInstruction string isn't what we're testing here.
+vi.mock("@/lib/prompts/spec-prompts", () => ({
+  getPromptSpec: vi.fn(async () => "stubbed system instruction"),
+}));
+
+import "@/lib/prompt/composition/transforms/preamble";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type {
+  AssembledContext,
+  SharedComputedState,
+  CompositionSectionDef,
+} from "@/lib/prompt/composition/types";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
+  return {
+    channel: "text",
+    modules: [
+      { id: "m1", name: "Module 1", description: "test" } as unknown as SharedComputedState["modules"][number],
+    ],
+    isFirstCall: true,
+    daysSinceLastCall: 0,
+    completedModules: new Set<string>(),
+    estimatedProgress: 0,
+    lastCompletedIndex: -1,
+    moduleToReview: null,
+    nextModule: null,
+    reviewType: "quick_recall",
+    reviewReason: "",
+    thresholds: { high: 0.65, low: 0.35 },
+    isFinalSession: false,
+    callNumber: 1,
+    ...overrides,
+  };
+}
+
+function makeContext(opts: {
+  firstCallMode?: PlaybookConfig["firstCallMode"];
+  teachingMode?: string;
+} = {}): AssembledContext {
+  const playbookConfig: PlaybookConfig = {};
+  if (opts.firstCallMode) playbookConfig.firstCallMode = opts.firstCallMode;
+  if (opts.teachingMode) playbookConfig.teachingMode = opts.teachingMode;
+
+  return {
+    sharedState: makeSharedState(),
+    sections: {
+      teachingContent: { hasTeachingContent: true },
+    },
+    loadedData: {
+      caller: null,
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      callCount: 0,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [
+        {
+          id: "p1",
+          name: "Test Playbook",
+          status: "PUBLISHED",
+          config: playbookConfig,
+          domain: null,
+          items: [],
+        },
+      ] as unknown as AssembledContext["loadedData"]["playbooks"],
+      systemSpecs: [],
+      onboardingSpec: null,
+    },
+    resolvedSpecs: {
+      voiceSpec: null,
+    } as unknown as AssembledContext["resolvedSpecs"],
+    specConfig: {},
+  };
+}
+
+const STUB_SECTION: CompositionSectionDef = {
+  id: "_preamble",
+  name: "Preamble",
+  priority: 1.0,
+  dataSource: "_assembled",
+  activateWhen: { condition: "always" },
+  fallback: { action: "null" },
+  transform: "computePreamble",
+  outputKey: "_preamble",
+};
+
+interface PreambleOutput {
+  criticalRules: string[];
+}
+
+const transform = getTransform("computePreamble")!;
+
+describe("computePreamble — #790 firstCallMode critical-rule selection", () => {
+  it("'baseline_assessment' on call 1 injects BASELINE_ASSESSMENT_RULE", async () => {
+    const ctx = makeContext({ firstCallMode: "baseline_assessment" });
+    const out = (await transform(null, ctx, STUB_SECTION)) as PreambleOutput;
+    const rulesText = out.criticalRules.join("\n");
+    expect(rulesText).toMatch(/BASELINE_ASSESSMENT/);
+    expect(rulesText).toMatch(/diagnostic evidence only/i);
+    // Returning-caller rule must NOT be in the list (short-circuit semantics).
+    expect(rulesText).not.toMatch(/RETURNING_CALLER/);
+  });
+
+  it("'teach_immediately' on call 1 injects the returningCallerByMode rule", async () => {
+    const ctx = makeContext({
+      firstCallMode: "teach_immediately",
+      teachingMode: "practice",
+    });
+    const out = (await transform(null, ctx, STUB_SECTION)) as PreambleOutput;
+    const rulesText = out.criticalRules.join("\n");
+    // 'practice' archetype RETURNING_CALLER rule contains "warm-up attempt".
+    expect(rulesText).toMatch(/warm-up attempt/i);
+    // Baseline rule must NOT be in the list.
+    expect(rulesText).not.toMatch(/BASELINE_ASSESSMENT/);
+  });
+
+  it("default 'onboarding' on call 1 does NOT inject baseline rule (preserves existing behaviour)", async () => {
+    const ctx = makeContext({}); // firstCallMode unset → default 'onboarding'
+    const out = (await transform(null, ctx, STUB_SECTION)) as PreambleOutput;
+    const rulesText = out.criticalRules.join("\n");
+    expect(rulesText).not.toMatch(/BASELINE_ASSESSMENT/);
+    // The pedagogy rules still come through — sanity check we didn't break
+    // the universal rule set.
+    expect(rulesText).toMatch(/Before referencing any rubric level/);
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/targets-first-session.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/targets-first-session.test.ts
@@ -1,0 +1,216 @@
+/**
+ * targets transform — #784 (S6) firstSessionTargets priority-1 injection.
+ *
+ * Covers `Playbook.config.firstSessionTargets` reading at NEW priority 1
+ * (above Domain.onboardingDefaultTargets) on the first-call path in
+ * `mergeAndGroupTargets`. Pattern mirrors progress-narrative.test.ts.
+ *
+ * Cases:
+ *   - No firstSessionTargets → existing domain cascade unchanged
+ *   - firstSessionTargets present → injected at PLAYBOOK_FIRST_SESSION scope
+ *   - Existing CallerTarget for the same parameter → override NOT applied
+ *     (learner-scoped score still wins; first-call defaults only fill gaps)
+ *   - When isFirstCall === false → no override (only fires on call 1)
+ */
+
+import { describe, it, expect } from "vitest";
+
+import "@/lib/prompt/composition/transforms/targets";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type {
+  AssembledContext,
+  SharedComputedState,
+  CompositionSectionDef,
+  BehaviorTargetData,
+  CallerTargetData,
+} from "@/lib/prompt/composition/types";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
+  return {
+    channel: "text",
+    modules: [],
+    isFirstCall: true,
+    daysSinceLastCall: 0,
+    completedModules: new Set<string>(),
+    estimatedProgress: 0,
+    lastCompletedIndex: -1,
+    moduleToReview: null,
+    nextModule: null,
+    reviewType: "quick_recall",
+    reviewReason: "",
+    thresholds: { high: 0.65, low: 0.35 },
+    isFinalSession: false,
+    callNumber: 1,
+    ...overrides,
+  };
+}
+
+interface MakeCtxOpts {
+  firstSessionTargets?: PlaybookConfig["firstSessionTargets"];
+  behaviorTargets?: BehaviorTargetData[];
+  callerTargets?: CallerTargetData[];
+  isFirstCall?: boolean;
+}
+
+function makeContext(opts: MakeCtxOpts = {}): AssembledContext {
+  const playbookConfig: PlaybookConfig = opts.firstSessionTargets
+    ? { firstSessionTargets: opts.firstSessionTargets }
+    : {};
+  return {
+    sharedState: makeSharedState({ isFirstCall: opts.isFirstCall ?? true }),
+    sections: {},
+    loadedData: {
+      caller: null,
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      callCount: 0,
+      behaviorTargets: (opts.behaviorTargets ?? []) as unknown as AssembledContext["loadedData"]["behaviorTargets"],
+      callerTargets: (opts.callerTargets ?? []) as unknown as AssembledContext["loadedData"]["callerTargets"],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [
+        {
+          id: "p1",
+          name: "Test Playbook",
+          status: "PUBLISHED",
+          config: playbookConfig,
+          domain: null,
+          items: [],
+        },
+      ] as unknown as AssembledContext["loadedData"]["playbooks"],
+      systemSpecs: [],
+      onboardingSpec: null,
+    },
+    resolvedSpecs: {} as AssembledContext["resolvedSpecs"],
+    specConfig: {},
+  };
+}
+
+const STUB_SECTION: CompositionSectionDef = {
+  id: "behavior_targets",
+  name: "Behavior Targets",
+  priority: 8.0,
+  dataSource: "_assembled",
+  activateWhen: { condition: "always" },
+  fallback: { action: "null" },
+  transform: "mergeAndGroupTargets",
+  outputKey: "behaviorTargets",
+};
+
+const transform = getTransform("mergeAndGroupTargets");
+
+interface TargetsOutput {
+  all: Array<{ parameterId: string; targetValue: number; scope: string }>;
+  totalCount: number;
+}
+
+describe("mergeAndGroupTargets — firstSessionTargets (#784 S6)", () => {
+  it("is registered", () => {
+    expect(transform).toBeDefined();
+  });
+
+  it("does not inject anything when firstSessionTargets is absent (config cascade only)", () => {
+    const ctx = makeContext({});
+    const result = transform!(
+      { behaviorTargets: [], callerTargets: [] },
+      ctx,
+      STUB_SECTION,
+    ) as TargetsOutput;
+    // No playbook overrides, but the audience-default block still fires
+    // (AUDIENCE_TARGET_DEFAULTS), so we look for the ABSENCE of the new
+    // scope label rather than zero total.
+    const playbookScoped = result.all.filter((t) => t.scope === "PLAYBOOK_FIRST_SESSION");
+    expect(playbookScoped).toHaveLength(0);
+  });
+
+  it("injects a per-playbook first-call override at PLAYBOOK_FIRST_SESSION scope", () => {
+    const ctx = makeContext({
+      firstSessionTargets: {
+        "BEH-WARMTH": { value: 0.85 },
+      },
+    });
+    const result = transform!(
+      { behaviorTargets: [], callerTargets: [] },
+      ctx,
+      STUB_SECTION,
+    ) as TargetsOutput;
+    const warmth = result.all.find((t) => t.parameterId === "BEH-WARMTH");
+    expect(warmth).toBeDefined();
+    expect(warmth!.targetValue).toBe(0.85);
+    expect(warmth!.scope).toBe("PLAYBOOK_FIRST_SESSION");
+  });
+
+  it("does NOT override an existing CallerTarget for the same parameter", () => {
+    // A learner already scored on this parameter — first-call defaults must
+    // fill gaps, never overwrite the learner-personalised value.
+    const callerTarget = {
+      parameterId: "BEH-WARMTH",
+      targetValue: 0.3,
+      confidence: 0.9,
+      parameter: {
+        name: "warmth",
+        parameterId: "BEH-WARMTH",
+        interpretationLow: null,
+        interpretationHigh: null,
+        domainGroup: "Behaviour",
+      },
+    } as unknown as CallerTargetData;
+
+    const ctx = makeContext({
+      callerTargets: [callerTarget],
+      firstSessionTargets: {
+        "BEH-WARMTH": { value: 0.85 },
+      },
+    });
+    const result = transform!(
+      { behaviorTargets: [], callerTargets: [callerTarget] },
+      ctx,
+      STUB_SECTION,
+    ) as TargetsOutput;
+    const warmth = result.all.find((t) => t.parameterId === "BEH-WARMTH");
+    expect(warmth).toBeDefined();
+    expect(warmth!.targetValue).toBe(0.3);
+    expect(warmth!.scope).toBe("CALLER_PERSONALIZED");
+  });
+
+  it("does not inject overrides when isFirstCall is false", () => {
+    const ctx = makeContext({
+      isFirstCall: false,
+      firstSessionTargets: {
+        "BEH-WARMTH": { value: 0.85 },
+      },
+    });
+    const result = transform!(
+      { behaviorTargets: [], callerTargets: [] },
+      ctx,
+      STUB_SECTION,
+    ) as TargetsOutput;
+    const playbookScoped = result.all.filter((t) => t.scope === "PLAYBOOK_FIRST_SESSION");
+    expect(playbookScoped).toHaveLength(0);
+  });
+
+  it("precedes the audience-default for the same parameter (priority 1 wins)", () => {
+    // AUDIENCE_TARGET_DEFAULTS has a default for BEH-CHALLENGE-LEVEL — when the
+    // playbook overrides it, the audience injection must skip that paramId.
+    const ctx = makeContext({
+      firstSessionTargets: {
+        "BEH-CHALLENGE-LEVEL": { value: 0.9 },
+      },
+    });
+    const result = transform!(
+      { behaviorTargets: [], callerTargets: [] },
+      ctx,
+      STUB_SECTION,
+    ) as TargetsOutput;
+    const challenge = result.all.find((t) => t.parameterId === "BEH-CHALLENGE-LEVEL");
+    expect(challenge).toBeDefined();
+    expect(challenge!.targetValue).toBe(0.9);
+    expect(challenge!.scope).toBe("PLAYBOOK_FIRST_SESSION");
+    // Only one entry — audience default did NOT also fire for this paramId.
+    const matching = result.all.filter((t) => t.parameterId === "BEH-CHALLENGE-LEVEL");
+    expect(matching).toHaveLength(1);
+  });
+});

--- a/docs/PROMPT-COMPOSITION.md
+++ b/docs/PROMPT-COMPOSITION.md
@@ -128,7 +128,7 @@ All declared in `transforms/*.ts` via `registerTransform("<name>", fn)`. `Compos
 |------|-------------------------|----------------------------------------|------------------------|
 | `personality.ts` | `mapPersonalityTraits` | `personality` | `loadedData.personality` |
 | `memories.ts` | `deduplicateAndGroupMemories`, `deduplicateMemories`, `groupMemoriesByCategory`, `scoreMemoryRelevance` | `memories` | `loadedData.memories` |
-| `targets.ts` | `mergeAndGroupTargets` | `behaviorTargets` | `loadedData.behaviorTargets` + `callerTargets` |
+| `targets.ts` | `mergeAndGroupTargets` | `behaviorTargets` | `loadedData.behaviorTargets` + `callerTargets`; on first call (`isFirstCall===true`), injects `Playbook.config.firstSessionTargets` (#784 S6) at NEW priority 1 (`PLAYBOOK_FIRST_SESSION` scope) above `Domain.onboardingDefaultTargets` → INIT-001 → `AUDIENCE_TARGET_DEFAULTS` |
 | `modules.ts` | `computeModuleProgress` (+ `computeSharedState` helper used pre-section-loop) | `curriculum` | `_assembled`; reads `CallerModuleProgress` directly (non-blocking) |
 | `identity.ts` | `extractIdentitySpec` (+ `resolveSpecs`, `resolveVoiceSpecFallback`, `mergeIdentitySpec`, `applyGroupToneOverride` helpers) | `identity` | `_assembled` → `resolvedSpecs.identitySpec` |
 | `simple.ts` | `mapLearnerProfile`, `computeCallHistory`, `filterSessionAttributes`, `mapGoals`, `computeDomainContext` | `learnerProfile`, `callHistory`, `sessionPlanning`, `learnerGoals`, `domain` | Various `loadedData.*` |
@@ -143,14 +143,14 @@ All declared in `transforms/*.ts` via `registerTransform("<name>", fn)`. `Compos
 | `teaching-style.ts` | `computeTeachingStyle` | `teachingStyle` | `_assembled` (identity archetype + curriculum) |
 | `audience.ts` | `computeAudienceGuidance` | `audienceGuidance` | `_assembled` |
 | `activities.ts` | `computeActivityToolkit` | `activityToolkit` | `_assembled` (personality + curriculum + pedagogy) |
-| `pedagogy.ts` | `computeSessionPedagogy` | `instructions_pedagogy` | `_assembled` — picks onboardingFlowSource: Playbook → Domain → Spec |
+| `pedagogy.ts` | `computeSessionPedagogy` | `instructions_pedagogy` | `_assembled` — picks onboardingFlowSource: Playbook → Domain → Spec. **#790 (S8)** `Playbook.config.firstCallMode` branches call 1: `onboarding` (default, byte-identical) → `sessionType=FIRST_CALL` + ONBOARDING MODE flow; `teach_immediately` → ONBOARDING MODE branch SKIPPED, `sessionType=RETURNING_CALLER`, scheduler / generic-returning flow runs on call 1; `baseline_assessment` → `sessionType=BASELINE` + diagnostic-only flow + principles override (no teaching, no review, no remediation) |
 | `offboarding.ts` | `computeOffboarding` (**async**) | `offboarding` | `_assembled` + `CallerModuleProgress` query — gated by `Playbook.config.offboardingSummary` (#780 Felt Progress S2); cadence picks `final_only` (default, gated on `sharedState.isFinalSession`) or `every_session_with_data`; emits structured `progressSummary` with modules / goals / skills when data exists, null-guards to generic guidance otherwise |
 | `progress-narrative.ts` | `computeProgressNarrative` | `progressNarrative` | `_assembled` — gated by `Playbook.config.progressNarrative` (#779 Felt Progress S1); rebuilds `loMasteryMap` from `callerAttributes`, surfaces top 3 LO refs as evidence for mid-call acknowledgement |
 | `voice.ts` | `computeVoiceGuidance` | `instructions_voice` | `_assembled` + `resolvedSpecs.voiceSpec` |
 | `instructions.ts` | `computeInstructions` | `instructions` | `_assembled` (depends on every prior content / pedagogy / voice section) |
 | `actions.ts` | `formatActions` | (embedded inside `instructions`) | `loadedData.openActions` |
 | `quickstart.ts` | `computeQuickStart` | `_quickStart` | `_assembled` (caller_info + memories + targets + curriculum + goals + identity) |
-| `preamble.ts` | `computePreamble` | `_preamble` | `_assembled` (identity only) |
+| `preamble.ts` | `computePreamble` | `_preamble` | `_assembled` (identity only). **#790 (S8)** `criticalRules` short-circuits on `Playbook.config.firstCallMode === 'baseline_assessment'` (call 1) to inject `BASELINE_ASSESSMENT_RULE` (override path: `prompt_preamble.config.criticalRules.baselineAssessment`). `teach_immediately` requires no preamble change — the existing branches already inject `returningCallerByMode[teachingMode]` regardless of `isFirstCall`. Default `onboarding` preserves byte-identical pre-#790 output |
 
 `_quickStart` and `_preamble` are prefixed with `_` so the executor strips them from the final `llmPrompt` JSON output — they're consumed by `instructions.ts` and `renderPromptSummary.ts` but not exposed as top-level sections.
 


### PR DESCRIPTION
Bundled S6 (#784) + S8 (#790) per user decision. Part of Felt Progress epic #778. Wave 1 + Wave 2.

## Summary
- **FeltProgressSettings.tsx** — 9-control card surfacing S1 (`progressNarrative`) + S2 (`offboardingSummary`)
- **FirstSessionSettings.tsx** — signpost table to SessionFlowEditor + `firstCallMode` radio + `firstSessionTargets` repeater
- **`Playbook.config.firstSessionTargets`** — per-playbook first-call BEHAVIOR target overrides at NEW priority 1, above Domain defaults
- **`Playbook.config.firstCallMode`** — enum (`onboarding` | `teach_immediately` | `baseline_assessment`). Default `'onboarding'` is byte-identical to today
- **Transforms touched**: `targets.ts` (priority-1 injection), `pedagogy.ts` (3-way branch nested inside isFirstCall gate), `preamble.ts` (baseline rule short-circuit)
- **`BASELINE_ASSESSMENT_RULE`** added to `defaults/critical-rules.ts`
- `PUT /api/courses/[courseId]/design` accepts both new fields with null-clears semantics

Closes #784
Closes #790

## Test plan
- [x] 13 new unit tests across 3 files (targets-first-session, pedagogy-first-call-mode, preamble-first-call-mode)
- [x] 57 existing composition tests still pass (no regression)
- [x] Promptfoo eval `evals/felt-progress/s8-first-call-mode.yaml` — 3 prompts × 2 assertions
- [ ] End-to-end smoke on hf-dev: open `/x/courses/[id]` → Design tab → see new Felt Progress + Call 1 cards; toggle and save; verify in Prisma Studio that `Playbook.config.*` carries the new fields; trigger a compose and confirm the prompt shape changes per mode

## Stack
**Targets `feat/780-offboarding-summary`** (PR #789). Merge order: #788 (S1) → #789 (S2) → this PR.

## Assumptions
1. Parameter picker uses hardcoded 4-item BEHAVIOR list (`BEH-WARMTH`, `BEH-CHALLENGE-LEVEL`, `BEH-PACING`, `BEH-DEPTH`) — documented inline. Easy upgrade path once S7 (AgentTuner awareness #785) ships.
2. \`teach_immediately\` needs no preamble code change — existing \`returningCallerRule\` selection runs regardless of \`isFirstCall\`.
3. Default \`firstCallMode = 'onboarding'\` preserves byte-identical output to today.

## Out of scope
- Course-ref \`session_override\` assertions (modifiable via re-uploading course-ref markdown, not a clickable UI knob)
- \`Domain.onboardingDefaultTargets\` / \`Domain.onboardingFlowPhases\` (domain-level, admin-only)
- INIT-001 \`firstCallFlow.phases\` (system spec)
- \`activities.ts\` first-call assessment suppression (flagged for separate story)

## Deploy
\`/vm-cp\` — no schema migration. \`Playbook.config\` is a JSON field; new keys land within it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)