### PR TITLE
refactor(#796): move AUDIENCE_TARGET_DEFAULTS into INIT-001 spec config

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/INIT-001-caller-onboarding.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/INIT-001-caller-onboarding.spec.json
@@ -140,6 +140,19 @@
             "rationale": "Low - we don't know them yet"
           }
         },
+        "audienceDefaultTargets": {
+          "_note": "#796 — audience-aware first-call defaults for parameters NOT covered by defaultTargets above. Keyed parameterId → audienceId → {value, confidence}. Audience IDs match AudienceId in lib/prompt/composition/transforms/audience.ts. 'default' is the fallback when audience is unset/unrecognised. Read by transforms/targets.ts at cascade priority 4 (below playbook firstSessionTargets, domain onboardingDefaultTargets, and INIT-001 defaultTargets).",
+          "BEH-CHALLENGE-LEVEL": {
+            "primary":             { "value": 0.3,  "confidence": 0.5 },
+            "secondary":           { "value": 0.45, "confidence": 0.4 },
+            "sixth-form":          { "value": 0.55, "confidence": 0.4 },
+            "higher-ed":           { "value": 0.6,  "confidence": 0.3 },
+            "adult-professional":  { "value": 0.55, "confidence": 0.3 },
+            "adult-casual":        { "value": 0.45, "confidence": 0.3 },
+            "mixed":               { "value": 0.5,  "confidence": 0.3 },
+            "default":             { "value": 0.5,  "confidence": 0.3 }
+          }
+        },
         "confidenceGrowthRate": 0.1,
         "minCallsForConfidence": 3
       },

--- a/apps/admin/lib/prompt/composition/transforms/targets.ts
+++ b/apps/admin/lib/prompt/composition/transforms/targets.ts
@@ -10,32 +10,6 @@ import { config } from "@/lib/config";
 import type { AudienceId } from "./audience";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 
-/**
- * Audience-aware default targets for parameters not covered by INIT-001.
- * Keyed by parameterId → audienceId → { value, confidence }.
- * "default" is the fallback when audience is unset or unrecognized.
- *
- * TODO(composition-transforms-audit): Move to INIT-001 spec config
- * (audience-keyed `defaultTargets`) so educators can tune these via the
- * admin UI instead of requiring a code change. Currently educator-tuned
- * `BEH-CHALLENGE-LEVEL` targets via projection/wizard get shadowed by
- * these hardcoded numbers on first-call when no caller-scoped target
- * exists yet. Filed as a separate follow-up — the audit found this is
- * latent fragility, not a current user-visible bug.
- */
-const AUDIENCE_TARGET_DEFAULTS: Record<string, Partial<Record<AudienceId | "default", { value: number; confidence: number }>>> = {
-  "BEH-CHALLENGE-LEVEL": {
-    primary:             { value: 0.3, confidence: 0.5 },
-    secondary:           { value: 0.45, confidence: 0.4 },
-    "sixth-form":        { value: 0.55, confidence: 0.4 },
-    "higher-ed":         { value: 0.6, confidence: 0.3 },
-    "adult-professional": { value: 0.55, confidence: 0.3 },
-    "adult-casual":      { value: 0.45, confidence: 0.3 },
-    mixed:               { value: 0.5, confidence: 0.3 },
-    default:             { value: 0.5, confidence: 0.3 },
-  },
-};
-
 /** Normalized target type that works for both CallerTarget and BehaviorTarget */
 export interface NormalizedTarget {
   parameterId: string;
@@ -81,8 +55,8 @@ registerTransform("mergeAndGroupTargets", (
   // Priority (highest first):
   //   1. Playbook.config.firstSessionTargets — #784 (S6) per-playbook override
   //   2. Domain.onboardingDefaultTargets
-  //   3. INIT-001 fallback
-  //   4. AUDIENCE_TARGET_DEFAULTS (still runs below as the last resort)
+  //   3. INIT-001 fallback (onboardingSpec.config.defaultTargets)
+  //   4. INIT-001.audienceDefaultTargets — #796 (was hardcoded AUDIENCE_TARGET_DEFAULTS const)
   if (isFirstCall) {
     const existingParams = new Set(merged.map(t => t.parameterId));
 
@@ -153,36 +127,42 @@ registerTransform("mergeAndGroupTargets", (
       console.log(`[targets] First call: injected ${Object.keys(defaultTargets).length - existingParams.size} defaults from ${source}`);
     }
 
-    // Inject audience-aware defaults for parameters in AUDIENCE_TARGET_DEFAULTS
-    // that still don't have a target after domain/INIT-001 defaults
-    const playbookConfig = (playbooks?.[0] as any)?.config;
-    const audience: AudienceId = playbookConfig?.audience || "mixed";
-    const updatedExistingParams = new Set(merged.map(t => t.parameterId));
-    let audienceInjected = 0;
+    // Inject audience-aware defaults from INIT-001.audienceDefaultTargets for
+    // parameters still missing after domain / INIT-001 defaults (#796 — was
+    // hardcoded AUDIENCE_TARGET_DEFAULTS in this file; now educator-tunable via
+    // the INIT-001 spec config).
+    const audienceDefaults = onboardingSpec?.config?.audienceDefaultTargets;
+    if (audienceDefaults) {
+      const playbookConfig = (playbooks?.[0] as any)?.config;
+      const audience: AudienceId = playbookConfig?.audience || "mixed";
+      const updatedExistingParams = new Set(merged.map(t => t.parameterId));
+      let audienceInjected = 0;
 
-    for (const [paramId, audienceMap] of Object.entries(AUDIENCE_TARGET_DEFAULTS)) {
-      if (updatedExistingParams.has(paramId)) continue;
-      const defaults = audienceMap[audience] || audienceMap.default;
-      if (!defaults) continue;
+      for (const [paramId, audienceMap] of Object.entries(audienceDefaults)) {
+        if (paramId.startsWith("_")) continue; // skip metadata keys (e.g. _note)
+        if (updatedExistingParams.has(paramId)) continue;
+        const defaults = audienceMap[audience] || audienceMap.default;
+        if (!defaults) continue;
 
-      merged.push({
-        parameterId: paramId,
-        targetValue: defaults.value,
-        confidence: defaults.confidence,
-        source: "BehaviorTarget",
-        scope: "AUDIENCE_DEFAULT",
-        parameter: {
-          name: paramId.replace("BEH-", "").replace(/-/g, " ").toLowerCase(),
-          interpretationLow: null,
-          interpretationHigh: null,
-          domainGroup: "Audience Defaults",
-        },
-      });
-      audienceInjected++;
-    }
+        merged.push({
+          parameterId: paramId,
+          targetValue: defaults.value,
+          confidence: defaults.confidence,
+          source: "BehaviorTarget",
+          scope: "AUDIENCE_DEFAULT",
+          parameter: {
+            name: paramId.replace("BEH-", "").replace(/-/g, " ").toLowerCase(),
+            interpretationLow: null,
+            interpretationHigh: null,
+            domainGroup: "Audience Defaults",
+          },
+        });
+        audienceInjected++;
+      }
 
-    if (audienceInjected > 0) {
-      console.log(`[targets] First call: injected ${audienceInjected} audience-aware defaults for audience=${audience}`);
+      if (audienceInjected > 0) {
+        console.log(`[targets] First call: injected ${audienceInjected} audience-aware defaults (INIT-001.audienceDefaultTargets) for audience=${audience}`);
+      }
     }
   }
 

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -285,6 +285,18 @@ export interface OnboardingSpecData {
       confidence: number;
       rationale?: string;
     }>;
+    /**
+     * #796 — Audience-aware first-call defaults for parameters NOT covered by
+     * `defaultTargets`. Keyed parameterId → audienceId → {value, confidence}.
+     * Read by `transforms/targets.ts` at cascade priority 4 (below playbook
+     * firstSessionTargets, domain onboardingDefaultTargets, and `defaultTargets`).
+     * Replaces the former hardcoded `AUDIENCE_TARGET_DEFAULTS` const so educators
+     * can tune via INIT-001 instead of a code change.
+     */
+    audienceDefaultTargets?: Record<string, Record<string, {
+      value: number;
+      confidence: number;
+    }>>;
     /** First call flow phases */
     firstCallFlow?: {
       phases: Array<{

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.370",
+  "version": "0.7.371",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/lib/composition/targets.test.ts
+++ b/apps/admin/tests/lib/composition/targets.test.ts
@@ -332,6 +332,14 @@ describe("mergeAndGroupTargets transform", () => {
               "BEH-WARMTH": { value: 0.6, confidence: 0.5 },
               "BEH-DIRECTNESS": { value: 0.4, confidence: 0.5 },
             },
+            // #796 — audience defaults now live on the INIT-001 spec config
+            // (was a hardcoded const in transforms/targets.ts).
+            audienceDefaultTargets: {
+              "BEH-CHALLENGE-LEVEL": {
+                mixed:   { value: 0.5, confidence: 0.3 },
+                default: { value: 0.5, confidence: 0.3 },
+              },
+            },
           },
         },
       },

--- a/apps/admin/tests/lib/prompt/composition/targets-first-session.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/targets-first-session.test.ts
@@ -53,6 +53,22 @@ interface MakeCtxOpts {
   isFirstCall?: boolean;
 }
 
+// #796 — audience defaults moved from a hardcoded const in targets.ts to
+// INIT-001.audienceDefaultTargets. The test ctx must inject this in the
+// onboardingSpec mock to keep covering the same cascade behaviour.
+const MOCK_AUDIENCE_DEFAULTS = {
+  "BEH-CHALLENGE-LEVEL": {
+    primary:              { value: 0.3,  confidence: 0.5 },
+    secondary:            { value: 0.45, confidence: 0.4 },
+    "sixth-form":         { value: 0.55, confidence: 0.4 },
+    "higher-ed":          { value: 0.6,  confidence: 0.3 },
+    "adult-professional": { value: 0.55, confidence: 0.3 },
+    "adult-casual":       { value: 0.45, confidence: 0.3 },
+    mixed:                { value: 0.5,  confidence: 0.3 },
+    default:              { value: 0.5,  confidence: 0.3 },
+  },
+};
+
 function makeContext(opts: MakeCtxOpts = {}): AssembledContext {
   const playbookConfig: PlaybookConfig = opts.firstSessionTargets
     ? { firstSessionTargets: opts.firstSessionTargets }
@@ -82,7 +98,14 @@ function makeContext(opts: MakeCtxOpts = {}): AssembledContext {
         },
       ] as unknown as AssembledContext["loadedData"]["playbooks"],
       systemSpecs: [],
-      onboardingSpec: null,
+      onboardingSpec: {
+        id: "init-001",
+        slug: "init-001",
+        name: "Caller Onboarding",
+        config: {
+          audienceDefaultTargets: MOCK_AUDIENCE_DEFAULTS,
+        },
+      } as AssembledContext["loadedData"]["onboardingSpec"],
     },
     resolvedSpecs: {} as AssembledContext["resolvedSpecs"],
     specConfig: {},
@@ -193,8 +216,9 @@ describe("mergeAndGroupTargets — firstSessionTargets (#784 S6)", () => {
   });
 
   it("precedes the audience-default for the same parameter (priority 1 wins)", () => {
-    // AUDIENCE_TARGET_DEFAULTS has a default for BEH-CHALLENGE-LEVEL — when the
-    // playbook overrides it, the audience injection must skip that paramId.
+    // INIT-001.audienceDefaultTargets has a default for BEH-CHALLENGE-LEVEL —
+    // when the playbook overrides it, the audience injection must skip that
+    // paramId. (#796: was hardcoded AUDIENCE_TARGET_DEFAULTS const.)
     const ctx = makeContext({
       firstSessionTargets: {
         "BEH-CHALLENGE-LEVEL": { value: 0.9 },
@@ -212,5 +236,39 @@ describe("mergeAndGroupTargets — firstSessionTargets (#784 S6)", () => {
     // Only one entry — audience default did NOT also fire for this paramId.
     const matching = result.all.filter((t) => t.parameterId === "BEH-CHALLENGE-LEVEL");
     expect(matching).toHaveLength(1);
+  });
+
+  // #796 — cascade-order guard. Ensures the four-priority cascade (1: playbook
+  // firstSessionTargets → 2: domain onboardingDefaultTargets → 3: INIT-001
+  // defaultTargets → 4: INIT-001.audienceDefaultTargets) stays in this order
+  // after the AUDIENCE_TARGET_DEFAULTS const → spec-config migration.
+  it("priority 4: INIT-001.audienceDefaultTargets injects only when no higher cascade layer covered the param", () => {
+    // Bare context — no playbook firstSessionTargets, no domain defaults, no
+    // INIT-001 defaultTargets entry for BEH-CHALLENGE-LEVEL. Only the audience
+    // default (priority 4) should fire.
+    const ctx = makeContext({});
+    const result = transform!(
+      { behaviorTargets: [], callerTargets: [] },
+      ctx,
+      STUB_SECTION,
+    ) as TargetsOutput;
+    const challenge = result.all.find((t) => t.parameterId === "BEH-CHALLENGE-LEVEL");
+    expect(challenge).toBeDefined();
+    expect(challenge!.scope).toBe("AUDIENCE_DEFAULT");
+    // 'mixed' audience default = 0.5 per MOCK_AUDIENCE_DEFAULTS
+    expect(challenge!.targetValue).toBe(0.5);
+  });
+
+  it("priority 4 skips metadata keys (e.g. _note) in audienceDefaultTargets", () => {
+    // Authors of the INIT-001 spec JSON sometimes add `_note` or other metadata
+    // keys alongside the real parameter keys. The cascade must skip these.
+    const ctx = makeContext({});
+    const result = transform!(
+      { behaviorTargets: [], callerTargets: [] },
+      ctx,
+      STUB_SECTION,
+    ) as TargetsOutput;
+    const metaEntry = result.all.find((t) => t.parameterId.startsWith("_"));
+    expect(metaEntry).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #796. First of three call-1 modifiability cleanups handed off from the Felt Progress epic.

Removes the hardcoded `AUDIENCE_TARGET_DEFAULTS` const from
`apps/admin/lib/prompt/composition/transforms/targets.ts` and reads
`onboardingSpec.config.audienceDefaultTargets` instead. Cascade order
unchanged (priority 4: below playbook firstSessionTargets → domain
onboardingDefaultTargets → INIT-001 defaultTargets → INIT-001
audienceDefaultTargets).

Educators can now tune audience-aware first-call defaults via the
INIT-001 spec without a code change. Closes the
`TODO(composition-transforms-audit)` comment.

## Changes

- **`transforms/targets.ts`** — const removed, read site now sources
  from `onboardingSpec.config.audienceDefaultTargets`. Skips metadata
  keys prefixed with `_` (spec JSON convention). Cascade comment
  updated to name the new source.
- **`OnboardingSpecData.config`** (`lib/prompt/composition/types.ts`)
  — new `audienceDefaultTargets` field typed as
  `Record<paramId, Record<audienceId, {value, confidence}>>`.
- **`INIT-001-caller-onboarding.spec.json`** — `audienceDefaultTargets`
  block added alongside `defaultTargets` with byte-identical values to
  the removed const.
- **Tests** — two existing tests updated to inject mock
  `audienceDefaultTargets` (they implicitly relied on the const firing).
  Two new guard tests in `targets-first-session.test.ts`:
  - priority 4 fires only when no higher cascade layer covered the param
  - metadata keys (e.g. `_note`) are skipped

## Verification

- ✅ `tests/lib/composition/targets.test.ts` (17) + `targets-first-session.test.ts` (8) — 25/25 pass
- ✅ Full composition suite — 481/481 pass
- ✅ `tsc --noEmit` clean on touched files

## Deploy

`/vm-cp` + `npm run db:seed` (no schema migration). Seed is idempotent
— existing DBs pick up the new INIT-001 key on next seed run.

## Risk

First-call target injection is on the hot path; the guard test now
explicitly asserts priority-4 cascade order so a future regression
fails loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)