### PR TITLE
feat(#798): course-ref call-1 read-only preview in FirstSessionSettings

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/call1-override-preview/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/call1-override-preview/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { getSourceIdsForPlaybook } from "@/lib/knowledge/domain-sources";
+
+export const runtime = "nodejs";
+
+const TRUNCATE_LEN = 120;
+const MAX_SAMPLES = 3;
+
+/**
+ * @api GET /api/courses/[courseId]/call1-override-preview
+ * @visibility internal
+ * @scope course:read
+ * @auth session (OPERATOR+)
+ * @tags course, design, felt-progress, call-1
+ * @description Read-only preview of `ContentAssertion` rows scoped to this
+ *   course's content surface with `category = 'session_override'` AND
+ *   `section = '1'` (exact match). These assertions REPLACE
+ *   `onboardingFlowPhases` entirely on call 1 (Layer 0 in
+ *   `transforms/pedagogy.ts::deriveSessionOverridePhases`). Surfaced in
+ *   `FirstSessionSettings` so educators can see "what does my course-ref
+ *   actually do on call 1?" without opening the source markdown.
+ *
+ *   Exact-match only: assertions with `section = '1-3'` etc. ALSO apply
+ *   to call 1 at runtime (via `matchesSessionRange`) but are not shown
+ *   here — the response includes `rangeFormCount` so the UI can render
+ *   a "range-form assertions not shown" disclaimer when relevant.
+ * @response 200 {
+ *   ok: true,
+ *   count: number,
+ *   samples: Array<{ id: string, ref: string | null, text: string, truncated: boolean }>,
+ *   rangeFormCount: number,
+ * }
+ * @response 404 { ok: false, error: "Course not found" }
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const { courseId } = await params;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    select: { id: true },
+  });
+  if (!playbook) {
+    return NextResponse.json({ ok: false, error: "Course not found" }, { status: 404 });
+  }
+
+  const sourceIds = await getSourceIdsForPlaybook(courseId);
+  if (sourceIds.length === 0) {
+    return NextResponse.json({ ok: true, count: 0, samples: [], rangeFormCount: 0 });
+  }
+
+  const [exactMatch, rangeFormCount] = await Promise.all([
+    prisma.contentAssertion.findMany({
+      where: {
+        sourceId: { in: sourceIds },
+        category: "session_override",
+        section: "1",
+      },
+      select: { id: true, learningOutcomeRef: true, assertion: true },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.contentAssertion.count({
+      where: {
+        sourceId: { in: sourceIds },
+        category: "session_override",
+        section: { contains: "-" },
+      },
+    }),
+  ]);
+
+  const samples = exactMatch.slice(0, MAX_SAMPLES).map((a) => {
+    const truncated = a.assertion.length > TRUNCATE_LEN;
+    return {
+      id: a.id,
+      ref: a.learningOutcomeRef,
+      text: truncated ? `${a.assertion.slice(0, TRUNCATE_LEN)}…` : a.assertion,
+      truncated,
+    };
+  });
+
+  return NextResponse.json({
+    ok: true,
+    count: exactMatch.length,
+    samples,
+    rangeFormCount,
+  });
+}

--- a/apps/admin/components/course-design/FirstSessionSettings.tsx
+++ b/apps/admin/components/course-design/FirstSessionSettings.tsx
@@ -24,8 +24,20 @@
  * keeps the component self-contained — matching the BandingPicker pattern.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+interface Call1OverrideSample {
+  id: string;
+  ref: string | null;
+  text: string;
+  truncated: boolean;
+}
+interface Call1OverridePreview {
+  count: number;
+  samples: Call1OverrideSample[];
+  rangeFormCount: number;
+}
 
 // Hardcoded fallback list — covers the common first-call tuning surface.
 // Kept short on purpose; the AgentTuner is the rich entry-point. If a
@@ -125,6 +137,28 @@ export function FirstSessionSettings({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+
+  // #798 — course-ref Layer-0 override preview. Read-only fetch on mount.
+  const [courseRefPreview, setCourseRefPreview] = useState<Call1OverridePreview | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetch(`/api/courses/${courseId}/call1-override-preview`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (!alive || !json?.ok) return;
+        setCourseRefPreview({
+          count: json.count,
+          samples: json.samples,
+          rangeFormCount: json.rangeFormCount,
+        });
+      })
+      .catch(() => {
+        /* preview is non-critical — silently no-op on error */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [courseId]);
 
   const signpost = readSignpostState(cfg);
 
@@ -297,6 +331,58 @@ export function FirstSessionSettings({
           + Add first-call target override
         </button>
       </div>
+
+      {/* ── #798: read-only preview of course-ref Layer-0 call-1 overrides ── */}
+      {courseRefPreview && (
+        <div className="hf-mb-lg">
+          <div className="hf-text-sm hf-text-bold hf-mb-xs">From your course-ref</div>
+          {courseRefPreview.count === 0 ? (
+            <div className="hf-text-xs hf-text-muted">
+              Your course-ref has no call-1 specific instructions. Call 1 uses
+              the cascade above.
+            </div>
+          ) : (
+            <>
+              <div className="hf-text-xs hf-text-muted hf-mb-xs">
+                Your course-ref defines {courseRefPreview.count} call-1
+                instruction{courseRefPreview.count === 1 ? "" : "s"}. These
+                REPLACE the onboarding flow entirely on call 1 (highest
+                priority).
+              </div>
+              <ul className="hf-card-compact hf-text-xs hf-mb-xs">
+                {courseRefPreview.samples.map((s) => (
+                  <li key={s.id} className="hf-list-row">
+                    {s.ref ? <span className="hf-text-muted">[{s.ref}] </span> : null}
+                    {s.text}
+                  </li>
+                ))}
+                {courseRefPreview.count > courseRefPreview.samples.length && (
+                  <li className="hf-list-row hf-text-muted">
+                    …and {courseRefPreview.count - courseRefPreview.samples.length}{" "}
+                    more
+                  </li>
+                )}
+              </ul>
+              <div className="hf-text-xs hf-text-muted">
+                Edit by updating your course-ref doc →{" "}
+                <a
+                  href={`/x/courses/${courseId}?tab=content`}
+                  className="hf-link"
+                >
+                  Subject sources
+                </a>
+              </div>
+              {courseRefPreview.rangeFormCount > 0 && (
+                <div className="hf-text-xs hf-text-muted hf-mt-xs">
+                  Note: range-form assertions (e.g. &ldquo;1-3&rdquo;,
+                  &ldquo;1-5&rdquo;) that also apply to call 1 aren&apos;t shown
+                  here — view all course-ref instructions in the sources tab.
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
 
       <div className="hf-flex hf-gap-sm hf-items-center">
         <button

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.372",
+  "version": "0.7.373",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/api/call1-override-preview.test.ts
+++ b/apps/admin/tests/api/call1-override-preview.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for GET /api/courses/[courseId]/call1-override-preview — #798.
+ *
+ * Coverage:
+ *  - Auth: requireAuth("OPERATOR") gate (mocked allow)
+ *  - 404 when playbook missing
+ *  - Empty when playbook has no sources
+ *  - Returns count + samples (truncated to 120 chars, max 3) for exact `section="1"`
+ *  - rangeFormCount captures `section` containing "-" (e.g. "1-3")
+ *  - Range-form assertions are NOT included in samples (exact-match only)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn().mockResolvedValue({
+    session: { user: { id: "u1", email: "op@test.com", role: "OPERATOR" } },
+  }),
+  isAuthError: vi.fn((result: Record<string, unknown>) => "error" in result),
+}));
+
+const mockPrisma = {
+  playbook: { findUnique: vi.fn() },
+  contentAssertion: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+vi.mock("@/lib/knowledge/domain-sources", () => ({
+  getSourceIdsForPlaybook: vi.fn(),
+}));
+
+describe("GET /api/courses/[id]/call1-override-preview", () => {
+  let GET: any;
+  let mockGetSourceIds: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockPrisma.playbook.findUnique.mockResolvedValue({ id: "pb1" });
+    const ds = await import("@/lib/knowledge/domain-sources");
+    mockGetSourceIds = ds.getSourceIdsForPlaybook;
+    const mod = await import("@/app/api/courses/[courseId]/call1-override-preview/route");
+    GET = mod.GET;
+  });
+
+  function call() {
+    return GET(
+      new Request("http://localhost/api/courses/pb1/call1-override-preview"),
+      { params: Promise.resolve({ courseId: "pb1" }) },
+    );
+  }
+
+  it("404 when playbook missing", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    const res = await call();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns empty when playbook has no scoped sources", async () => {
+    mockGetSourceIds.mockResolvedValue([]);
+    const res = await call();
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, count: 0, samples: [], rangeFormCount: 0 });
+    // Did NOT hit assertion queries
+    expect(mockPrisma.contentAssertion.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.contentAssertion.count).not.toHaveBeenCalled();
+  });
+
+  it("returns count + truncated samples for exact section='1' matches", async () => {
+    mockGetSourceIds.mockResolvedValue(["src-1", "src-2"]);
+    const longText = "x".repeat(200);
+    mockPrisma.contentAssertion.findMany.mockResolvedValue([
+      { id: "a1", learningOutcomeRef: "LO-1", assertion: "Short fact" },
+      { id: "a2", learningOutcomeRef: null, assertion: longText },
+      { id: "a3", learningOutcomeRef: "LO-3", assertion: "Another" },
+      { id: "a4", learningOutcomeRef: null, assertion: "Fourth — beyond samples cap" },
+    ]);
+    mockPrisma.contentAssertion.count.mockResolvedValue(0);
+
+    const res = await call();
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.count).toBe(4);
+    expect(json.samples).toHaveLength(3); // cap = MAX_SAMPLES
+    expect(json.samples[0]).toEqual({ id: "a1", ref: "LO-1", text: "Short fact", truncated: false });
+    // Long text truncated to 120 + ellipsis
+    expect(json.samples[1].truncated).toBe(true);
+    expect(json.samples[1].text.length).toBe(121); // 120 chars + "…"
+    expect(json.samples[1].text.endsWith("…")).toBe(true);
+    expect(json.rangeFormCount).toBe(0);
+  });
+
+  it("rangeFormCount counts assertions with section containing '-' (e.g. '1-3')", async () => {
+    mockGetSourceIds.mockResolvedValue(["src-1"]);
+    mockPrisma.contentAssertion.findMany.mockResolvedValue([]);
+    mockPrisma.contentAssertion.count.mockResolvedValue(5);
+
+    const res = await call();
+    const json = await res.json();
+    expect(json.count).toBe(0); // no exact-match samples
+    expect(json.rangeFormCount).toBe(5);
+
+    // Verify the range-form query used `section: { contains: '-' }`
+    const countCall = mockPrisma.contentAssertion.count.mock.calls[0][0];
+    expect(countCall.where.sourceId).toEqual({ in: ["src-1"] });
+    expect(countCall.where.category).toBe("session_override");
+    expect(countCall.where.section).toEqual({ contains: "-" });
+  });
+
+  it("exact-match query uses section: '1' (string equality, not range)", async () => {
+    mockGetSourceIds.mockResolvedValue(["src-1"]);
+    mockPrisma.contentAssertion.findMany.mockResolvedValue([]);
+    mockPrisma.contentAssertion.count.mockResolvedValue(0);
+
+    await call();
+    const findCall = mockPrisma.contentAssertion.findMany.mock.calls[0][0];
+    expect(findCall.where.sourceId).toEqual({ in: ["src-1"] });
+    expect(findCall.where.category).toBe("session_override");
+    expect(findCall.where.section).toBe("1"); // exact string, NOT a range matcher
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -5130,6 +5130,24 @@ Find all COURSE_REFERENCE sources for a course and trigger
 
 ## Course
 
+### `GET` /api/courses/[courseId]/call1-override-preview
+
+Read-only preview of `ContentAssertion` rows scoped to this
+
+**Auth**: session (OPERATOR+) · **Scope**: `course:read`
+
+**Response** `200`
+```json
+{
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+---
+
 ### `PUT` /api/courses/[courseId]/design
 
 Save student experience design config. Writes to
@@ -14412,8 +14430,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 447 |
-| Files with annotations | 446 |
+| Route files found | 448 |
+| Files with annotations | 447 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 


### PR DESCRIPTION
## Summary

Closes #798. Third of three call-1 modifiability cleanups handed off from the Felt Progress epic.

Course-ref markdown docs can carry `**Session scope:** 1` sections that
get extracted as `ContentAssertion` rows with
`category = 'session_override'` + `section = '1'`. At compose time,
these REPLACE `onboardingFlowPhases` entirely on call 1 (Layer 0 in
`transforms/pedagogy.ts::deriveSessionOverridePhases`). Educators had
no visibility into "what does my course-ref actually do on call 1?"
without opening the source markdown. After #784/#795 shipped, this was
the one remaining mystery layer.

## Changes

- **New endpoint**: `GET /api/courses/[id]/call1-override-preview`
  - Auth: `requireAuth("OPERATOR")`
  - Scope: `getSourceIdsForPlaybook(courseId)` (covers PlaybookSource
    primary + PlaybookSubject fallback + domain-wide last resort)
  - Returns `{ ok, count, samples: [{ id, ref, text, truncated }],
    rangeFormCount }`
  - Samples: first 3, 120-char text cap with `…` truncation marker,
    `learningOutcomeRef` exposed as `ref`
  - `rangeFormCount`: count of assertions with `section` containing
    `-` (e.g. `'1-3'`) — these ALSO apply to call 1 at runtime via
    `matchesSessionRange` but are NOT in samples (exact-match query)
  - 404 on missing playbook; empty preview when playbook has no
    scoped sources (no Prisma assertion query fired in that case)
- **UI**: `FirstSessionSettings.tsx` adds a "From your course-ref"
  sub-section between the firstSessionTargets repeater and Save:
  - Empty state: "Your course-ref has no call-1 specific instructions.
    Call 1 uses the cascade above."
  - N>0: count line + bulleted samples (optionally prefixed by ref) +
    "Edit by updating your course-ref doc → Subject sources" link
    (`?tab=content`, the valid tab name)
  - Disclaimer (only when `rangeFormCount > 0`): "Note: range-form
    assertions (e.g. '1-3', '1-5') that also apply to call 1 aren't
    shown here — view all course-ref instructions in the sources tab."
- Read-only — no save button, no API write, no schema migration.
- Fetch is non-critical — silent no-op on error rather than blocking
  the rest of the form.

## Tests

5 new route tests in `tests/api/call1-override-preview.test.ts`:
- 404 when playbook missing
- Empty when no scoped sources (and no Prisma queries fire)
- Returns count + samples with truncation (long-text edge case)
- `rangeFormCount` query uses `section: { contains: '-' }`
- Exact-match query uses `section: '1'` (string equality, NOT range)

All 5 pass.

## Deploy

`/vm-cp` (no schema migration).

## Risk

Low. Pure read surface. Scope-leak risk addressed by using the
existing `getSourceIdsForPlaybook` helper (same scope as the rest of
the course-content reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)