### PR TITLE
chore(ui): collapse Design tab sections + add Cohorts to sidebar

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -3,6 +3,7 @@
 import { SessionFlowEditor } from '@/components/session-flow/SessionFlowEditor';
 import { CourseSetupTracker } from '@/components/shared/CourseSetupTracker';
 import { BandingPicker } from '@/components/shared/BandingPicker';
+import { CollapsibleCard } from '@/components/shared/CollapsibleCard';
 import { FeltProgressSettings } from '@/components/course-design/FeltProgressSettings';
 import { FirstSessionSettings } from '@/components/course-design/FirstSessionSettings';
 import { CourseSummaryCard } from './CourseSummaryCard';
@@ -121,37 +122,49 @@ export function CourseDesignTab({
         </>
       )}
 
-      {/* ── Session Flow (canonical editor — absorbed from retired tab) ── */}
-      {/*
-        The Session Flow tab was retired in favour of one canonical editor
-        on the Design tab. SessionFlowEditor owns its own data fetching
-        (GET /api/courses/:id/session-flow) and persistence, so we mount it
-        directly — no prop plumbing, no duplicate state. The earlier
-        "Student Experience Flow" pill-row card was a styled subset of the
-        same data; it's gone because every educator-visible setting it
-        offered is also here, in the more complete form.
-      */}
-      <div className="hf-card hf-mb-lg">
+      {/* ── Session Flow (canonical editor — absorbed from retired tab) ──
+          The Session Flow tab was retired in favour of one canonical editor
+          on the Design tab. SessionFlowEditor owns its own data fetching
+          (GET /api/courses/:id/session-flow) and persistence, so we mount it
+          directly — no prop plumbing, no duplicate state. */}
+      <CollapsibleCard
+        title="Session Flow"
+        hint="Before / during / after phases, intake, NPS, welcome"
+        defaultOpen
+        className="hf-mb-lg"
+      >
         <SessionFlowEditor courseId={courseId} />
-      </div>
+      </CollapsibleCard>
 
       {/* ── Felt Progress controls (#784 S6 Section 1 — #779 + #780 namespaces) ── */}
-      <div className="hf-card hf-mb-lg">
+      <CollapsibleCard
+        title="Felt Progress"
+        hint="Mid-call acknowledgement + structured offboarding summary"
+        className="hf-mb-lg"
+      >
         <FeltProgressSettings courseId={courseId} playbookConfig={pbConfig} />
-      </div>
+      </CollapsibleCard>
 
       {/* ── Call 1 / First Session settings (#784 S6 Section 2 + #790 S8) ── */}
-      <div className="hf-card hf-mb-lg">
+      <CollapsibleCard
+        title="Call 1 / First Session"
+        hint="firstCallMode, behaviour targets, course-ref preview"
+        className="hf-mb-lg"
+      >
         <FirstSessionSettings courseId={courseId} playbookConfig={pbConfig} />
-      </div>
+      </CollapsibleCard>
 
       {/* ── Skill Banding (#417 Story C — per-playbook tier mapping) ── */}
-      <div className="hf-card hf-mb-lg">
+      <CollapsibleCard
+        title="Skill Banding"
+        hint="Per-course tier mapping override"
+        className="hf-mb-lg"
+      >
         <BandingPicker
           courseId={courseId}
           current={playbookConfig?.skillTierMapping}
         />
-      </div>
+      </CollapsibleCard>
 
       {/* ── Setup Tracker (bottom — readiness reported to hero via callback) ── */}
       {detail && (

--- a/apps/admin/components/course-design/FeltProgressSettings.tsx
+++ b/apps/admin/components/course-design/FeltProgressSettings.tsx
@@ -121,7 +121,6 @@ export function FeltProgressSettings({
 
   return (
     <div>
-      <div className="hf-section-title hf-mb-xs">Felt progress</div>
       <div className="hf-text-xs hf-text-muted hf-mb-md">
         Controls how the AI acknowledges progress mid-call and summarises the
         learner&apos;s journey at the end of the course. Defaults are sensible

--- a/apps/admin/components/course-design/FirstSessionSettings.tsx
+++ b/apps/admin/components/course-design/FirstSessionSettings.tsx
@@ -214,7 +214,6 @@ export function FirstSessionSettings({
 
   return (
     <div>
-      <div className="hf-section-title hf-mb-xs">Call 1 / First session</div>
       <div className="hf-text-xs hf-text-muted hf-mb-md">
         How the learner&apos;s first call is configured. Some controls live
         in the Session Flow editor above — the table below shows their

--- a/apps/admin/components/shared/BandingPicker.tsx
+++ b/apps/admin/components/shared/BandingPicker.tsx
@@ -94,7 +94,6 @@ export function BandingPicker({ courseId, current, onSaved }: BandingPickerProps
 
   return (
     <div className="hf-card-compact">
-      <div className="hf-section-title hf-mb-xs">Skill banding</div>
       <div className="hf-text-xs hf-text-muted hf-mb-md">
         How <Acronym>SKILL-NN</Acronym> ACHIEVE goal progress maps to a tier
         label + band number. Default is IELTS Speaking. Change this when the

--- a/apps/admin/lib/sidebar/sidebar-manifest.json
+++ b/apps/admin/lib/sidebar/sidebar-manifest.json
@@ -7,7 +7,8 @@
       { "id": "demo-sim", "href": "/x/sim", "label": "Learn", "icon": "MessageCircle", "shortcutHint": "⌘S" },
       { "id": "demo-callers", "href": "/x/callers", "label": "Callers", "icon": "User", "shortcutHint": "⌘L" },
       { "id": "demo-courses", "href": "/x/courses", "label": "Courses", "icon": "BookOpen", "terminologyLabel": "playbook_plural" },
-      { "id": "demo-feedback", "href": "/x/feedback", "label": "Feedback", "icon": "MessageSquarePlus" }
+      { "id": "demo-feedback", "href": "/x/feedback", "label": "Feedback", "icon": "MessageSquarePlus" },
+      { "id": "demo-cohorts", "href": "/x/cohorts", "label": "Cohorts", "icon": "School" }
     ]
   }
 ]

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.374",
+  "version": "0.7.375",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary

Two small UI polish items from user feedback:

1. **Design tab sections wrap in CollapsibleCard** — Session Flow,
   Felt Progress, Call 1 / First Session, Skill Banding now have
   expand/collapse via the existing house-style component (entire
   header row is the toggle button). Session Flow defaults open;
   the other three default closed. Setup Tracker (status panel)
   left as-is.
2. **Cohorts added to sidebar** — `/x/cohorts` as the last item,
   below Feedback, using the School icon.

Duplicate inline section titles removed from FeltProgressSettings,
FirstSessionSettings, and BandingPicker (the wrapper title is now
the disclosure label). Intro paragraphs preserved.

## Test plan

- [ ] `/x/courses/<id>?tab=design` — four cards have chevron headers,
      Session Flow defaults open
- [ ] Click any header anywhere on the row → toggles
- [ ] Sidebar shows Cohorts as the last item, links to `/x/cohorts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)