### PR TITLE
feat(#809): inject page-context into DATA-mode chat prompt

### DIFF
--- a/apps/admin/app/api/chat/page-context.ts
+++ b/apps/admin/app/api/chat/page-context.ts
@@ -1,0 +1,58 @@
+/**
+ * #809 — DATA-mode pageContext parser + system-prompt block builder.
+ *
+ * Lives next to route.ts and system-prompts.ts because both consume it:
+ * route.ts parses the request body into the typed shape, system-prompts.ts
+ * renders it into a short prompt preamble.
+ */
+
+export interface PageContextHint {
+  page: string;
+  params: {
+    activeTab?: string;
+    visibleSections?: string[];
+  };
+}
+
+/**
+ * Defensive parser for the `pageContext` body field. Returns undefined when
+ * the shape is unknown so a malformed client payload can never poison the
+ * system prompt. Filters visibleSections down to plain non-empty strings.
+ */
+export function parsePageContext(raw: unknown): PageContextHint | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const obj = raw as { page?: unknown; params?: unknown };
+  if (typeof obj.page !== "string" || obj.page.length === 0) return undefined;
+  const rawParams = (obj.params && typeof obj.params === "object" ? obj.params : {}) as {
+    activeTab?: unknown;
+    visibleSections?: unknown;
+  };
+  const params: PageContextHint["params"] = {};
+  if (typeof rawParams.activeTab === "string" && rawParams.activeTab.length > 0) {
+    params.activeTab = rawParams.activeTab;
+  }
+  if (Array.isArray(rawParams.visibleSections)) {
+    const sections = rawParams.visibleSections.filter(
+      (s: unknown): s is string => typeof s === "string" && s.length > 0,
+    );
+    if (sections.length > 0) params.visibleSections = sections;
+  }
+  return { page: obj.page, params };
+}
+
+/**
+ * Short preamble naming the user's current page, active tab, and any visible
+ * sections. Built only when pageContext is present and only appended to the
+ * DATA-mode system prompt by the caller.
+ */
+export function buildPageContextBlock(pageContext: PageContextHint | undefined): string {
+  if (!pageContext?.page) return "";
+  const lines = [`Current page: ${pageContext.page}`];
+  const tabBits: string[] = [];
+  if (pageContext.params.activeTab) tabBits.push(`Active tab: ${pageContext.params.activeTab}`);
+  if (pageContext.params.visibleSections && pageContext.params.visibleSections.length > 0) {
+    tabBits.push(`Active section: ${pageContext.params.visibleSections.join(", ")}`);
+  }
+  if (tabBits.length > 0) lines.push(tabBits.join(" | "));
+  return `\n\n## Page context (what the user is looking at)\n${lines.join("\n")}`;
+}

--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import { getAIConfig } from "@/lib/ai/config-loader";
 import { classifyAIError, userMessageForError } from "@/lib/ai/error-utils";
 import { getConfiguredMeteredAICompletionStream, getConfiguredMeteredAICompletion } from "@/lib/metering";
 import { buildSystemPrompt } from "./system-prompts";
+import { parsePageContext, type PageContextHint } from "./page-context";
 import { executeCommand, parseCommand } from "@/lib/chat/commands";
 import { logAI } from "@/lib/logger";
 import { logAIInteraction } from "@/lib/ai/knowledge-accumulation";
@@ -68,6 +69,7 @@ const MAX_TOOL_ITERATIONS = 5;
  * @body engine string - AI engine to use (optional, uses default if not specified)
  * @body bugContext object - Bug report context for BUG mode (url, errors, browser, viewport, timestamp)
  * @body discussionTicketId string - UUID of an open feedback Ticket to discuss in DATA mode. When set, the assistant's system prompt includes a `## Active Ticket` block with the ticket + comment thread, institution-scoped via the creator's institutionId.
+ * @body pageContext object - DATA mode only. Shape: `{ page: string, params: { activeTab?: string, visibleSections?: string[] } }`. Identifies which page + tab + visible section the user is looking at so the assistant does not have to guess. Ignored for WIZARD/CALL/COURSE_REF/TUNING modes.
  * @response 200 text/plain (streaming response)
  * @response 400 { ok: false, error: "Message is required" }
  * @response 500 { ok: false, error: "...", errorCode: "BILLING" | "AUTH" | "RATE_LIMIT" | ... }
@@ -116,6 +118,10 @@ export async function POST(request: NextRequest) {
     // digest when the user is on `/x/feedback` without a specific ticket.
     const pageHintRoute: string | undefined =
       typeof rawBody?.pageHint?.route === "string" ? rawBody.pageHint.route : undefined;
+    // #809 — DATA mode only. Explicit page + tab + visible section context so
+    // the assistant doesn't say "I don't see that section" when the user is
+    // staring at it. Parsed defensively — unknown shapes silently drop.
+    const pageContext: PageContextHint | undefined = parsePageContext(rawBody?.pageContext);
 
     if (!message) {
       return NextResponse.json({ ok: false, error: "Message is required" }, { status: 400 });
@@ -243,7 +249,7 @@ export async function POST(request: NextRequest) {
       userRole,
       userInstitutionId,
       tuningScope,
-      { discussionTicketId, sessionUserId: authResult.session.user.id, pageHintRoute },
+      { discussionTicketId, sessionUserId: authResult.session.user.id, pageHintRoute, pageContext },
     );
 
     // Prepare messages with conversation history

--- a/apps/admin/app/api/chat/system-prompts.ts
+++ b/apps/admin/app/api/chat/system-prompts.ts
@@ -7,6 +7,9 @@ import { buildTuningSystemPrompt, type TuningScope } from "@/lib/chat/tuning-sys
 import { loadTicketContext, loadRecentTicketsDigest } from "@/lib/chat/ticket-context";
 import { getPromptSpec } from "@/lib/prompts/spec-prompts";
 import { config } from "@/lib/config";
+import { buildPageContextBlock, type PageContextHint } from "./page-context";
+
+export type { PageContextHint };
 
 type ChatMode = "DATA" | "CALL" | "BUG" | "TUNING";
 
@@ -91,6 +94,13 @@ export interface BuildSystemPromptOptions {
    * than hallucinate. Only fires when `discussionTicketId` is unset.
    */
   pageHintRoute?: string;
+  /**
+   * #809 — DATA mode only. Explicit page + tab + section context injected
+   * as a short preamble so the assistant doesn't say "I don't see that
+   * section" when the user is staring at it. Ignored in WIZARD / CALL /
+   * COURSE_REF / TUNING modes.
+   */
+  pageContext?: PageContextHint;
 }
 
 export async function buildSystemPrompt(
@@ -131,7 +141,8 @@ export async function buildSystemPrompt(
         buildTicketDiscussionBlock(options, userRole, institutionId),
         buildFeedbackListHintBlock(options, userRole, institutionId),
       ]);
-      return { prompt: dataPrompt + "\n\n" + tuningContext + termBlock + runtimeBlock + `\n\n${baseContext}` + ticketBlock + listHintBlock };
+      const pageBlock = buildPageContextBlock(options?.pageContext);
+      return { prompt: dataPrompt + "\n\n" + tuningContext + termBlock + runtimeBlock + pageBlock + `\n\n${baseContext}` + ticketBlock + listHintBlock };
     }
     case "TUNING": {
       // TUNING mode: catalogue + truthfulness rules + scope-aware write tools.

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -169,7 +169,7 @@ export default function CourseDetailPage() {
   const effectiveChords = useMemo(() => getEffectiveChords(`/x/courses/${courseId || ""}`), [courseId]);
   const { activePrefix: chordActivePrefix } = useChordShortcut(effectiveChords);
   const isOperator = ['OPERATOR', 'EDUCATOR', 'ADMIN', 'SUPERADMIN'].includes((session?.user?.role as string) || '');
-  const { pushEntity } = useEntityContext();
+  const { pushEntity, setPageContext } = useEntityContext();
   const { plural } = useTerminology();
 
   // ── State ──────────────────────────────────────────
@@ -404,6 +404,16 @@ export default function CourseDetailPage() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
+
+  // #809 — tell the DATA-mode assistant which course + tab the user is on
+  // so it can answer "what tab am I on?" and "tell me about Felt Progress"
+  // without saying "I don't see that section". The path string matches the
+  // pathname (resolved courseId, not the route template) so ChatContext's
+  // stale-route guard treats it as live.
+  useEffect(() => {
+    if (!courseId) return;
+    setPageContext(`/x/courses/${courseId}`, { activeTab });
+  }, [courseId, activeTab, setPageContext]);
 
   // ── Tab change: lazy load lesson plan data ──
   const handleTabChange = useCallback((tab: string) => {

--- a/apps/admin/contexts/ChatContext.tsx
+++ b/apps/admin/contexts/ChatContext.tsx
@@ -375,6 +375,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               ...(mode === "TUNING" ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
               ...(pathname && (mode === "DATA" || mode === "TUNING") ? { pageHint: { route: pathname } } : {}),
+              ...(mode === "DATA" && entityContext.pageContext?.page
+                ? { pageContext: entityContext.pageContext }
+                : {}),
             }),
           });
 
@@ -430,6 +433,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               ...(mode === "TUNING" ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
               ...(pathname && (mode === "DATA" || mode === "TUNING") ? { pageHint: { route: pathname } } : {}),
+              ...(mode === "DATA" && entityContext.pageContext?.page
+                ? { pageContext: entityContext.pageContext }
+                : {}),
             }),
             signal: abortControllerRef.current.signal,
           });
@@ -504,7 +510,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         abortControllerRef.current = null;
       }
     },
-    [mode, tuningScope, discussionTicketId, pathname, isStreaming, entityContext.breadcrumbs, messages, addMessage, updateMessage, appendToMessage]
+    [mode, tuningScope, discussionTicketId, pathname, isStreaming, entityContext.breadcrumbs, entityContext.pageContext, messages, addMessage, updateMessage, appendToMessage]
   );
 
   const value: ChatContextValue = {

--- a/apps/admin/contexts/EntityContext.tsx
+++ b/apps/admin/contexts/EntityContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
 
 // Entity types that can be tracked in breadcrumbs
 export type EntityType = "caller" | "call" | "spec" | "playbook" | "domain" | "transcript" | "memory" | "flow" | "subject" | "source";
@@ -73,6 +74,7 @@ export function EntityProvider({ children }: { children: React.ReactNode }) {
   const [breadcrumbs, setBreadcrumbs] = useState<EntityBreadcrumb[]>([]);
   const [pageContext, setPageContextState] = useState<PageContext>({ page: "", params: {} });
   const [initialized, setInitialized] = useState(false);
+  const pathname = usePathname();
 
   // Load persisted context on mount
   useEffect(() => {
@@ -80,6 +82,14 @@ export function EntityProvider({ children }: { children: React.ReactNode }) {
     setBreadcrumbs(persisted);
     setInitialized(true);
   }, []);
+
+  // #809 — reset pageContext when the route changes so a previous page's tab
+  // or section state cannot bleed into the next page's chat payload. Pages
+  // that own a tab/section setting call setPageContext() in their own effect
+  // after this reset fires; pages that don't simply leave it blank.
+  useEffect(() => {
+    setPageContextState({ page: "", params: {} });
+  }, [pathname]);
 
   // Reset entity context when user changes (login/logout/switch)
   useEffect(() => {

--- a/apps/admin/tests/api/chat-page-context.test.ts
+++ b/apps/admin/tests/api/chat-page-context.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { parsePageContext, buildPageContextBlock } from "@/app/api/chat/page-context";
+
+describe("parsePageContext (#809)", () => {
+  it("returns undefined for nullish / non-object input", () => {
+    expect(parsePageContext(undefined)).toBeUndefined();
+    expect(parsePageContext(null)).toBeUndefined();
+    expect(parsePageContext("oops")).toBeUndefined();
+    expect(parsePageContext(42)).toBeUndefined();
+  });
+
+  it("returns undefined when page is missing or empty", () => {
+    expect(parsePageContext({})).toBeUndefined();
+    expect(parsePageContext({ page: "" })).toBeUndefined();
+    expect(parsePageContext({ page: 123, params: {} })).toBeUndefined();
+  });
+
+  it("parses a minimal payload with only page", () => {
+    expect(parsePageContext({ page: "/x/courses/abc" })).toEqual({
+      page: "/x/courses/abc",
+      params: {},
+    });
+  });
+
+  it("parses activeTab when present", () => {
+    expect(
+      parsePageContext({ page: "/x/courses/abc", params: { activeTab: "design" } }),
+    ).toEqual({
+      page: "/x/courses/abc",
+      params: { activeTab: "design" },
+    });
+  });
+
+  it("filters non-string entries out of visibleSections", () => {
+    const result = parsePageContext({
+      page: "/x/courses/abc",
+      params: { visibleSections: ["felt-progress", 1, null, "", "first-call"] },
+    });
+    expect(result?.params.visibleSections).toEqual(["felt-progress", "first-call"]);
+  });
+
+  it("drops an empty visibleSections array", () => {
+    const result = parsePageContext({
+      page: "/x/courses/abc",
+      params: { visibleSections: [] },
+    });
+    expect(result?.params.visibleSections).toBeUndefined();
+  });
+
+  it("ignores empty activeTab", () => {
+    const result = parsePageContext({
+      page: "/x/courses/abc",
+      params: { activeTab: "" },
+    });
+    expect(result?.params.activeTab).toBeUndefined();
+  });
+});
+
+describe("buildPageContextBlock (#809)", () => {
+  it("returns empty string when pageContext is undefined", () => {
+    expect(buildPageContextBlock(undefined)).toBe("");
+  });
+
+  it("returns empty string when page is empty", () => {
+    expect(buildPageContextBlock({ page: "", params: {} })).toBe("");
+  });
+
+  it("renders the page line only when no params are present", () => {
+    const block = buildPageContextBlock({ page: "/x/courses/abc", params: {} });
+    expect(block).toContain("## Page context (what the user is looking at)");
+    expect(block).toContain("Current page: /x/courses/abc");
+    expect(block).not.toContain("Active tab");
+    expect(block).not.toContain("Active section");
+  });
+
+  it("renders activeTab in the second line", () => {
+    const block = buildPageContextBlock({
+      page: "/x/courses/abc",
+      params: { activeTab: "design" },
+    });
+    expect(block).toContain("Current page: /x/courses/abc");
+    expect(block).toContain("Active tab: design");
+  });
+
+  it("joins visibleSections with commas", () => {
+    const block = buildPageContextBlock({
+      page: "/x/courses/abc",
+      params: { activeTab: "design", visibleSections: ["felt-progress", "first-call"] },
+    });
+    expect(block).toContain("Active tab: design");
+    expect(block).toContain("Active section: felt-progress, first-call");
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -3377,6 +3377,7 @@ Sends a message to the AI chat assistant. Supports DATA mode (tool calling for d
 | engine | body | string | No | AI engine to use (optional, uses default if not specified) |
 | bugContext | body | object | No | Bug report context for BUG mode (url, errors, browser, viewport, timestamp) |
 | discussionTicketId | body | string | No | UUID of an open feedback Ticket to discuss in DATA mode. When set, the assistant's system prompt includes a `## Active Ticket` block with the ticket + comment thread, institution-scoped via the creator's institutionId. |
+| pageContext | body | object | No | DATA mode only. Shape: `{ page: string, params: { activeTab?: string, visibleSections?: string[] } }`. Identifies which page + tab + visible section the user is looking at so the assistant does not have to guess. Ignored for WIZARD/CALL/COURSE_REF/TUNING modes. |
 
 **Response** `200`
 ```json


### PR DESCRIPTION
## Summary
- Sends `pageContext` (page + activeTab + visibleSections) from the chat panel to `/api/chat` and injects a short "what the user is looking at" preamble into the DATA-mode system prompt — WIZARD / CALL / COURSE_REF / TUNING are untouched.
- Course detail page calls `setPageContext` on `courseId` / `activeTab` change; EntityContext resets pageContext on route change so a previous course's tab cannot bleed into another course's chat.
- New shared helper `app/api/chat/page-context.ts` (parse + render) with 12 unit tests; existing 32 chat tests still pass.

Closes #809

## Test plan
- [ ] Course → Design tab → ask DATA chat "what tab am I on?" → reply names `design`
- [ ] Same course/tab → "tell me about Felt Progress" → reply does NOT say "I don't see that section"
- [ ] Switch tab to Curriculum → "what tab am I on?" → reply names `curriculum`
- [ ] Navigate Course A → Course B without re-opening chat → "what course am I looking at?" → names Course B
- [ ] Navigate course → `/x/feedback` → chat works normally; no stale course tab leaks; feedback digest still fires
- [ ] WIZARD-mode wizard chat continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)