### PR TITLE
fix(#819): design route fans out recompose on COMPOSE-affecting saves + CHAIN-CONTRACTS row

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/design/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/design/route.ts
@@ -23,6 +23,25 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import type { WelcomeConfig, NpsConfig, PlaybookConfig } from "@/lib/types/json-fields";
 
+/**
+ * #819 — keys whose presence in the request body should trigger
+ * `recompose-all` fan-out after the save commits. Skill-banding and
+ * NPS/welcome don't appear here because they're read at runtime via
+ * their own loaders (banding via the registry, welcome by the student
+ * portal — neither is baked into the deterministic ComposedPrompt).
+ *
+ * All four Felt-Progress / Call-1 namespaces directly affect the
+ * COMPOSE-stage output for enrolled callers — without this fan-out,
+ * the existing ComposedPrompt row for each caller goes stale until
+ * the next pipeline call triggers a recompose naturally.
+ */
+const COMPOSE_AFFECTING_KEYS = [
+  "progressNarrative",
+  "offboardingSummary",
+  "firstSessionTargets",
+  "firstCallMode",
+] as const;
+
 export async function PUT(
   req: NextRequest,
   { params }: { params: Promise<{ courseId: string }> },
@@ -154,7 +173,44 @@ export async function PUT(
       data: { config: JSON.parse(JSON.stringify(pbConfig)) },
     });
 
-    return NextResponse.json({ ok: true });
+    // #819 — close the chain-contract gap: educator-tunable namespaces that
+    // flow into COMPOSE need to propagate to every active caller's
+    // ComposedPrompt row, not just the next pipeline run. Fire the existing
+    // /api/playbooks/[id]/recompose-all endpoint via the internal function
+    // path (it's bounded by pLimit(5) so even large rosters are safe).
+    // Fire-and-forget so the design save returns immediately; recompose
+    // errors are logged but don't block the educator.
+    const composeAffected = COMPOSE_AFFECTING_KEYS.some(
+      (k) => body[k] !== undefined,
+    );
+    if (composeAffected) {
+      import("@/lib/enrollment/auto-compose")
+        .then(async ({ autoComposeForCaller }) => {
+          const { getPlaybookRoster } = await import("@/lib/enrollment");
+          const pLimit = (await import("p-limit")).default;
+          const roster = await getPlaybookRoster(courseId, "ACTIVE");
+          const callerIds = roster
+            .map((r) => r.caller?.id)
+            .filter((id): id is string => !!id);
+          const limit = pLimit(5);
+          await Promise.all(
+            callerIds.map((cid) =>
+              limit(() => autoComposeForCaller(cid, courseId)),
+            ),
+          );
+          console.log(
+            `[design PUT] recompose-all fan-out complete: ${callerIds.length} callers (course ${courseId})`,
+          );
+        })
+        .catch((err) => {
+          console.error(
+            `[design PUT] recompose-all fan-out failed for course ${courseId}:`,
+            err.message,
+          );
+        });
+    }
+
+    return NextResponse.json({ ok: true, recomposed: composeAffected });
   } catch (err) {
     console.error("[design PUT]", err);
     return NextResponse.json(

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.7.375",
+  "version": "0.7.376",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/api/design-recompose-fanout.test.ts
+++ b/apps/admin/tests/api/design-recompose-fanout.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for PUT /api/courses/[id]/design — #819 chain-contract gap fix.
+ *
+ * Covers the new behaviour:
+ *  - Saving a COMPOSE-affecting namespace triggers recompose-all fan-out
+ *    (autoComposeForCaller invoked for every ACTIVE roster entry).
+ *  - Saving ONLY non-compose-affecting fields (welcome / nps / banding)
+ *    does NOT trigger fan-out — bandwidth preservation.
+ *  - 404 still flows when playbook missing (no compose fan-out either).
+ *  - Response carries `recomposed: boolean` so the UI can surface the
+ *    "propagating to N callers" status.
+ *
+ * Fan-out is fire-and-forget — we await the dynamic import promise chain
+ * by waiting for `autoComposeForCaller` to have been called the expected
+ * number of times before the test assertions run.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn().mockResolvedValue({
+    session: { user: { id: "op1", role: "OPERATOR" } },
+  }),
+  isAuthError: vi.fn((result: Record<string, unknown>) => "error" in result),
+}));
+
+const mockPrisma = {
+  playbook: {
+    findUnique: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+  },
+  callerPlaybook: { findMany: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: () => mockPrisma }));
+
+const mockAutoCompose = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/enrollment/auto-compose", () => ({
+  autoComposeForCaller: mockAutoCompose,
+}));
+
+const mockGetRoster = vi.fn();
+vi.mock("@/lib/enrollment", () => ({
+  getPlaybookRoster: mockGetRoster,
+}));
+
+async function flushDynamicImports() {
+  // Allow the fire-and-forget import chain to resolve fully.
+  // Two microtask ticks: one for the dynamic import, one for the
+  // inner await chain.
+  await new Promise((r) => setTimeout(r, 10));
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+describe("PUT /api/courses/[id]/design — recompose fan-out (#819)", () => {
+  let PUT: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: {} });
+    mockGetRoster.mockResolvedValue([
+      { caller: { id: "u1" } },
+      { caller: { id: "u2" } },
+      { caller: { id: "u3" } },
+    ]);
+    const mod = await import("@/app/api/courses/[courseId]/design/route");
+    PUT = mod.PUT;
+  });
+
+  function call(body: Record<string, unknown>) {
+    return PUT(
+      new Request("http://localhost/api/courses/pb1/design", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+      { params: Promise.resolve({ courseId: "pb1" }) },
+    );
+  }
+
+  it("firstCallMode change triggers fan-out across the active roster", async () => {
+    const res = await call({ firstCallMode: "baseline_assessment" });
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, recomposed: true });
+
+    await flushDynamicImports();
+    expect(mockGetRoster).toHaveBeenCalledWith("pb1", "ACTIVE");
+    expect(mockAutoCompose).toHaveBeenCalledTimes(3);
+    expect(mockAutoCompose).toHaveBeenCalledWith("u1", "pb1");
+    expect(mockAutoCompose).toHaveBeenCalledWith("u2", "pb1");
+    expect(mockAutoCompose).toHaveBeenCalledWith("u3", "pb1");
+  });
+
+  it("firstSessionTargets change triggers fan-out", async () => {
+    const res = await call({
+      firstSessionTargets: { "BEH-WARMTH": { value: 0.8 } },
+    });
+    const json = await res.json();
+    expect(json.recomposed).toBe(true);
+    await flushDynamicImports();
+    expect(mockAutoCompose).toHaveBeenCalledTimes(3);
+  });
+
+  it("progressNarrative change triggers fan-out", async () => {
+    const res = await call({ progressNarrative: { enabled: false } });
+    const json = await res.json();
+    expect(json.recomposed).toBe(true);
+    await flushDynamicImports();
+    expect(mockAutoCompose).toHaveBeenCalledTimes(3);
+  });
+
+  it("offboardingSummary change triggers fan-out", async () => {
+    const res = await call({ offboardingSummary: { enabled: false } });
+    const json = await res.json();
+    expect(json.recomposed).toBe(true);
+    await flushDynamicImports();
+    expect(mockAutoCompose).toHaveBeenCalledTimes(3);
+  });
+
+  it("nullable clear (firstCallMode: null) also triggers fan-out", async () => {
+    // Clearing back to default IS a compose-affecting change — without
+    // fan-out the existing prompt for each caller would still carry the
+    // previous override.
+    const res = await call({ firstCallMode: null });
+    const json = await res.json();
+    expect(json.recomposed).toBe(true);
+    await flushDynamicImports();
+    expect(mockAutoCompose).toHaveBeenCalledTimes(3);
+  });
+
+  it("welcome / nps / banding-only saves do NOT trigger fan-out", async () => {
+    const res = await call({
+      welcome: { goals: { enabled: true }, aboutYou: { enabled: true }, knowledgeCheck: { enabled: false }, aiIntroCall: { enabled: false } },
+      nps: { enabled: true, trigger: "mastery", threshold: 80 },
+      skillTierMapping: null,
+    });
+    const json = await res.json();
+    expect(json.recomposed).toBe(false);
+    await flushDynamicImports();
+    expect(mockAutoCompose).not.toHaveBeenCalled();
+    expect(mockGetRoster).not.toHaveBeenCalled();
+  });
+
+  it("missing playbook → 404, no fan-out", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    const res = await call({ firstCallMode: "teach_immediately" });
+    expect(res.status).toBe(404);
+    await flushDynamicImports();
+    expect(mockAutoCompose).not.toHaveBeenCalled();
+  });
+
+  it("empty roster: response still returns ok, no autoCompose calls", async () => {
+    mockGetRoster.mockResolvedValue([]);
+    const res = await call({ firstCallMode: "onboarding" });
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, recomposed: true });
+    await flushDynamicImports();
+    expect(mockGetRoster).toHaveBeenCalledWith("pb1", "ACTIVE");
+    expect(mockAutoCompose).not.toHaveBeenCalled();
+  });
+});

--- a/docs/CHAIN-CONTRACTS.md
+++ b/docs/CHAIN-CONTRACTS.md
@@ -104,7 +104,19 @@ Format per link:
 | **Test** | `tests/lib/prompt/composition/identity-resolve-specs.test.ts` (9 cases for #608-C); `tests/lib/preamble-archetype.test.ts` (16 cases for #604); `tests/lib/composition/renderPromptSummary.test.ts`. |
 | **Memory doc** | `docs/PROMPT-COMPOSITION.md` §3 loaders + §4 transforms + §9 landmines L8/L8b/L9/L10. |
 | **Audit counter** | `advisorInInputsSnapshot` (target 0 after #608-A applies), `playbooksWithoutTeachingMode` (target 0 — operator data), `hardcodedRulesRemainingInTransforms` (target 0). |
-| **Reinforced by** | #604, #607, #608-C, #608-A, #610. |
+| **Reinforced by** | #604, #607, #608-C, #608-A, #610, #819 (settings-change fan-out). |
+
+#### Link 3 sub-contract — TUNER → COMPOSE (settings-change propagation, #819)
+
+| Field | Value |
+|---|---|
+| **Producer** | `PUT /api/courses/[id]/design` writes to `Playbook.config.{progressNarrative,offboardingSummary,firstSessionTargets,firstCallMode}` and fan-outs to `autoComposeForCaller` for every ACTIVE roster entry. |
+| **Consumer** | Same as Link 3 main row — `ComposedPrompt` rows downstream. |
+| **Invariant** | When an educator changes a COMPOSE-affecting playbook namespace, every active caller's ComposedPrompt MUST be refreshed before their next call — never stale-on-save. The fan-out uses `pLimit(5)` so even large rosters complete bounded. |
+| **Enforcement** | `COMPOSE_AFFECTING_KEYS` const in the design route gates the fan-out; PUT response carries `recomposed: boolean` so the UI can surface "propagating to N callers". Standalone `POST /api/playbooks/[id]/recompose-all` remains the manual escape hatch. |
+| **Test** | `tests/api/design-recompose-fanout.test.ts` (8 cases — each compose-affecting field triggers; welcome/nps/banding do NOT trigger; 404 + empty roster paths). |
+| **Memory doc** | This row; `app/api/courses/[courseId]/design/route.ts` JSDoc references the COMPOSE_AFFECTING_KEYS list. |
+| **Reinforced by** | #819. |
 
 ---
 
@@ -196,6 +208,7 @@ If a chain row above references "DataContract slug: implicit" and the contract i
 | #670 | #610 | 3 | `defaults/` directory convention — transforms hold mechanics, content lives elsewhere |
 | #671 | #608-A | 3 | `AnalysisSpec.isArchetype` schema field + loader filter |
 | #672 | #616 | (this doc) | Single inventory of chain contracts |
+| TBD  | #819 | 3 (sub-contract) | PUT /api/courses/[id]/design fans out recompose-all when COMPOSE-affecting namespaces change — closes the stale-prompt-after-tuner-save gap |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the chain-contract gap surfaced during the post-Felt-Progress audit (Link 3, CURRICULUM → CALL):

**Before:** `PUT /api/courses/[id]/design` wrote the four educator-tunable namespaces (`progressNarrative`, `offboardingSummary`, `firstSessionTargets`, `firstCallMode`) to `Playbook.config` and returned. Existing ComposedPrompt rows for every enrolled caller stayed stale until the next pipeline run triggered a recompose naturally. For `firstCallMode` in particular — relevant only on call 1 — a learner enrolled before the educator flipped to `baseline_assessment` would still get an onboarding-mode bootstrap prompt.

**After:** the design route fans out `autoComposeForCaller` across every ACTIVE roster entry via `pLimit(5)` whenever any of the four `COMPOSE_AFFECTING_KEYS` is present in the request body. Fire-and-forget — save returns immediately with `{ ok: true, recomposed: boolean }` so the UI can surface "propagating to N callers". Non-compose-affecting saves (welcome / nps / banding) skip the fan-out.

## CHAIN-CONTRACTS compliance

- New sub-contract row added to Link 3 (`docs/CHAIN-CONTRACTS.md`) documenting Producer / Invariant / Enforcement / Test / Memory doc / Reinforced-by per the §6 pre-change checklist
- Appended to §5 recent reinforcements log
- Standalone `POST /api/playbooks/[id]/recompose-all` remains the manual escape hatch

## Test plan

- [x] `tests/api/design-recompose-fanout.test.ts` — 8 cases, all green
  - 4× compose-affecting field × fan-out triggered
  - Null clear still triggers fan-out (clearing IS a propagating change)
  - Welcome/nps/banding don't trigger
  - 404 path doesn't trigger
  - Empty roster handled
- [x] `npx tsc --noEmit` clean on touched files
- [x] `npm run ctl check` Epic 100 audit — all invariants at or below target

## Risk

Low. Fire-and-forget pattern; errors logged not thrown. `pLimit(5)` bounds even large rosters. Default behaviour for an empty roster is a single console log + no work. The standalone recompose-all endpoint already exists with the same pattern — this just wires the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)