### PR TITLE
chore(#814): swap to shared Prisma singleton in PromptTemplateCompiler

### DIFF
--- a/apps/admin/lib/prompt/PromptTemplateCompiler.ts
+++ b/apps/admin/lib/prompt/PromptTemplateCompiler.ts
@@ -26,10 +26,9 @@
  *    {{#if low}}Be direct and efficient.{{/if}}"
  */
 
-import { PrismaClient, MemoryCategory } from "@prisma/client";
+import { MemoryCategory } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 import { getMemoriesByCategory } from "@/lib/constants";
-
-const prisma = new PrismaClient();
 
 export interface TemplateContext {
   // For MEASURE specs


### PR DESCRIPTION
## Summary
- Drop the isolated `new PrismaClient()` in `apps/admin/lib/prompt/PromptTemplateCompiler.ts`
- Use the shared `@/lib/prisma` singleton — single connection pool, unified instrumentation

Surfaced by 2026-05-25 chain audit (#814 story 1).

## Test plan
- [x] `npx tsc --noEmit` — clean for this change (pre-existing unrelated errors only)
- [x] `npm run test -- prompt-template-compiler` — 72/72 pass
- [x] `npm run test -- compose-prompt` (downstream consumer) — 32/32 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)