### PR TITLE
chore(lint): fix 17 inherited warnings + lock baseline at 4470

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,6 +1,6 @@
 {
   "tsc_errors": 198,
   "lint_errors": 0,
-  "lint_warnings": 4487,
+  "lint_warnings": 4470,
   "quarantined_tests": 37
 }

--- a/apps/admin/tests/api/call1-override-preview.test.ts
+++ b/apps/admin/tests/api/call1-override-preview.test.ts
@@ -32,17 +32,25 @@ vi.mock("@/lib/knowledge/domain-sources", () => ({
   getSourceIdsForPlaybook: vi.fn(),
 }));
 
+// Route handler signature is intentionally loose here — the runtime arg is
+// a NextRequest but the test injects a plain Request, and the Next types
+// don't sufficiently overlap for a direct cast.
+type GetHandler = (
+  req: unknown,
+  ctx: { params: Promise<{ courseId: string }> },
+) => Promise<Response>;
+
 describe("GET /api/courses/[id]/call1-override-preview", () => {
-  let GET: any;
-  let mockGetSourceIds: any;
+  let GET: GetHandler;
+  let mockGetSourceIds: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     mockPrisma.playbook.findUnique.mockResolvedValue({ id: "pb1" });
     const ds = await import("@/lib/knowledge/domain-sources");
-    mockGetSourceIds = ds.getSourceIdsForPlaybook;
+    mockGetSourceIds = ds.getSourceIdsForPlaybook as ReturnType<typeof vi.fn>;
     const mod = await import("@/app/api/courses/[courseId]/call1-override-preview/route");
-    GET = mod.GET;
+    GET = mod.GET as GetHandler;
   });
 
   function call() {

--- a/apps/admin/tests/api/cohorts-overview.test.ts
+++ b/apps/admin/tests/api/cohorts-overview.test.ts
@@ -28,28 +28,31 @@ const mockPrisma = {
 };
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
+type GetHandler = () => Promise<Response>;
+type Row = Record<string, unknown>;
+
 describe("GET /api/cohorts/overview", () => {
-  let GET: any;
+  let GET: GetHandler;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     const mod = await import("@/app/api/cohorts/overview/route");
-    GET = mod.GET;
+    GET = mod.GET as GetHandler;
   });
 
-  function setCohorts(cohorts: any[]) {
+  function setCohorts(cohorts: Row[]) {
     mockPrisma.cohortGroup.findMany.mockResolvedValue(cohorts);
   }
-  function setMemberships(memberships: any[]) {
+  function setMemberships(memberships: Row[]) {
     mockPrisma.callerCohortMembership.findMany.mockResolvedValue(memberships);
   }
   // First call.findMany call = last 7d; second = prior 7d
-  function setCalls(thisWeek: any[], priorWeek: any[]) {
+  function setCalls(thisWeek: Row[], priorWeek: Row[]) {
     mockPrisma.call.findMany
       .mockResolvedValueOnce(thisWeek)
       .mockResolvedValueOnce(priorWeek);
   }
-  function setMastery(rows: any[]) {
+  function setMastery(rows: Row[]) {
     mockPrisma.callerModuleProgress.findMany.mockResolvedValue(rows);
   }
 

--- a/apps/admin/tests/api/design-recompose-fanout.test.ts
+++ b/apps/admin/tests/api/design-recompose-fanout.test.ts
@@ -51,8 +51,16 @@ async function flushDynamicImports() {
   await new Promise((r) => setTimeout(r, 10));
 }
 
+// Route handler signature is intentionally loose here — the runtime arg is
+// a NextRequest but the test injects a plain Request, and the Next types
+// don't sufficiently overlap for a direct cast.
+type PutHandler = (
+  req: unknown,
+  ctx: { params: Promise<{ courseId: string }> },
+) => Promise<Response>;
+
 describe("PUT /api/courses/[id]/design — recompose fan-out (#819)", () => {
-  let PUT: any;
+  let PUT: PutHandler;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -63,7 +71,7 @@ describe("PUT /api/courses/[id]/design — recompose fan-out (#819)", () => {
       { caller: { id: "u3" } },
     ]);
     const mod = await import("@/app/api/courses/[courseId]/design/route");
-    PUT = mod.PUT;
+    PUT = mod.PUT as PutHandler;
   });
 
   function call(body: Record<string, unknown>) {

--- a/apps/admin/tests/lib/composition/activities.test.ts
+++ b/apps/admin/tests/lib/composition/activities.test.ts
@@ -268,39 +268,45 @@ describe("computeActivityToolkit transform", () => {
     };
   }
 
+  // Shape of computeActivityToolkit's return value — see lib/prompt/composition/transforms/activities.ts.
+  type ActivityToolkitResult = {
+    recommended: Array<{ id: string; channel?: string; text_template?: string }>;
+    all_available: Array<{ id: string }>;
+  };
+
   it("firstCallMode='teach_immediately' + isFirstCall=true → assessment NOT suppressed", () => {
     const ctx = makeCtxWithMode("teach_immediately", true);
-    const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef());
+    const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef()) as ActivityToolkitResult;
     // pop_quiz (assessment) should now be allowed — it'll score similar to scenario.
-    const ids = result.recommended.map((r: any) => r.id);
+    const ids = result.recommended.map((r) => r.id);
     expect(ids).toContain("pop_quiz");
   });
 
   it("firstCallMode='baseline_assessment' + isFirstCall=true → assessment NOT suppressed", () => {
     const ctx = makeCtxWithMode("baseline_assessment", true);
-    const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef());
-    const ids = result.recommended.map((r: any) => r.id);
+    const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef()) as ActivityToolkitResult;
+    const ids = result.recommended.map((r) => r.id);
     expect(ids).toContain("pop_quiz");
   });
 
   it("firstCallMode='onboarding' + isFirstCall=true → assessment SUPPRESSED", () => {
     const ctx = makeCtxWithMode("onboarding", true);
-    const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef());
-    const ids = result.recommended.map((r: any) => r.id);
+    const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef()) as ActivityToolkitResult;
+    const ids = result.recommended.map((r) => r.id);
     expect(ids).not.toContain("pop_quiz");
   });
 
   it("isFirstCall=false → assessment never suppressed (any mode)", () => {
     for (const mode of ["onboarding", "teach_immediately", "baseline_assessment"] as const) {
       const ctx = makeCtxWithMode(mode, false);
-      const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef());
+      const result = getTransform("computeActivityToolkit")!(null, ctx, makeSectionDef()) as ActivityToolkitResult;
       // Returning-call: assessment may or may not be in top-2 depending on
       // mastery/phase, but the SUPPRESSION (-2 score penalty) must not fire.
       // Easiest assertion: the all_available list still contains pop_quiz
       // and at least one assessment activity may appear in recommended.
       // Stronger: verify the score for pop_quiz isn't being penalised by
       // comparing against the all_available list shape.
-      expect(result.all_available.map((a: any) => a.id)).toContain("pop_quiz");
+      expect(result.all_available.map((a) => a.id)).toContain("pop_quiz");
     }
   });
 

--- a/apps/admin/tests/lib/composition/section-data-loader.test.ts
+++ b/apps/admin/tests/lib/composition/section-data-loader.test.ts
@@ -349,10 +349,10 @@ describe("curriculumAssertions loader — teachingDepth typed field (#814)", () 
   }
 
   it("Case 1 — returns the playbook-configured teachingDepth on the result object", async () => {
-    (prisma.contentAssertion.findMany as any).mockResolvedValue([
+    vi.mocked(prisma.contentAssertion.findMany).mockResolvedValue([
       makeRawAssertion("a1"),
       makeRawAssertion("a2"),
-    ]);
+    ] as never);
 
     const loader = getLoader("curriculumAssertions");
     expect(loader).toBeDefined();
@@ -368,9 +368,9 @@ describe("curriculumAssertions loader — teachingDepth typed field (#814)", () 
   });
 
   it("Case 2 — defaults teachingDepth to null when no subject sets it", async () => {
-    (prisma.contentAssertion.findMany as any).mockResolvedValue([
+    vi.mocked(prisma.contentAssertion.findMany).mockResolvedValue([
       makeRawAssertion("a1"),
-    ]);
+    ] as never);
 
     const result = await getLoader("curriculumAssertions")!(
       "caller-1",
@@ -382,11 +382,11 @@ describe("curriculumAssertions loader — teachingDepth typed field (#814)", () 
   });
 
   it("Case 3 — teachingDepth survives a downstream .filter() on the result (regression for the array-property hack)", async () => {
-    (prisma.contentAssertion.findMany as any).mockResolvedValue([
+    vi.mocked(prisma.contentAssertion.findMany).mockResolvedValue([
       makeRawAssertion("a1"),
       makeRawAssertion("a2"),
       makeRawAssertion("a3"),
-    ]);
+    ] as never);
 
     const result = await getLoader("curriculumAssertions")!(
       "caller-1",
@@ -403,10 +403,10 @@ describe("curriculumAssertions loader — teachingDepth typed field (#814)", () 
   });
 
   it("Case 4 — teachingDepth survives a downstream .map() on the result", async () => {
-    (prisma.contentAssertion.findMany as any).mockResolvedValue([
+    vi.mocked(prisma.contentAssertion.findMany).mockResolvedValue([
       makeRawAssertion("a1"),
       makeRawAssertion("a2"),
-    ]);
+    ] as never);
 
     const result = await getLoader("curriculumAssertions")!(
       "caller-1",


### PR DESCRIPTION
## Summary

- Restored the lint baseline to a meaningful floor after the recent drift: `.ratchet.json` `lint_warnings` 4487 → 4470 (-17).
- 17 of 18 newly-introduced warnings since the 2026-05-25 baseline lock are fixed in place; the 18th is formally accepted as debt with a follow-up TODO in the commit body.
- Drift originated across 5 PRs (#801, #802, #803, #813, #815, #817) — none of them updated `.ratchet.json`, so #817 absorbed the cumulative drift in two follow-up commits. This PR resets that to a real floor.

## Fixes by source PR

| Source | File | Fix |
|---|---|---|
| #802 | `tests/api/call1-override-preview.test.ts` | Typed dynamic-import refs |
| #803 | `tests/api/cohorts-overview.test.ts` | Typed dynamic-import + helper-fn `Row[]` aliases |
| #815 | `tests/api/design-recompose-fanout.test.ts` | Typed `PUT` handler (req kept `unknown` for Request/NextRequest mismatch) |
| #801 | `tests/lib/composition/activities.test.ts` | Introduced `ActivityToolkitResult` local alias, cast `result` once per test |
| #817 | `tests/lib/composition/section-data-loader.test.ts` | Switched 4 new `(prisma.X as any)` mocks to `vi.mocked(prisma.X).mockResolvedValue([...] as never)` |

## Accepted as debt (1)

- `#813` `contexts/EntityContext.tsx:91` — `react-hooks/set-state-in-effect` on the new `useEffect(() => setPageContextState({...}), [pathname])`. Fixing it cleanly is a >50-line refactor crossing the page-context contract surface. Baseline absorbs.

## Test plan

- [x] `npm run lint` → 4470 (was 4487)
- [x] `npx tsc --noEmit` → 198 errors (unchanged from baseline)
- [x] `npm run ratchet:check` → all 4 metrics ✅
- [x] `vitest run` on the 5 affected test files → 46 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)