### PR TITLE
chore(#598 followup): TODO comments on 3 surviving hardcoded 0.7 reads in compose-content-section.ts

### DIFF
--- a/apps/admin/lib/prompt/compose-content-section.ts
+++ b/apps/admin/lib/prompt/compose-content-section.ts
@@ -600,6 +600,12 @@ async function composeContentFromSubject(
 
         const progress = await loadCallerProgress(callerId, pbCurr.slug, "current_module", enrolledPbId);
         const contractThresholds = await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1");
+        // TODO(#598 Slice 1 follow-up): migrate to resolveMasteryThreshold()
+        // once `lib/tolerance/resolve-tolerance.ts` ships. The cascade there
+        // covers the 7 layers (caller → playbook → preset → spec config →
+        // ContractRegistry → hardcoded 0.7) — this 2-layer fallback is the
+        // last surviving direct read of `0.7` outside `transforms/modules.ts`.
+        // See docs/decisions/2026-05-22-tolerance-placement.md.
         const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
         const enrichedModules = enrichModulesWithProgress(modules, progress, masteryThreshold);
         const nextModule = enrichedModules.find((m) => m.status !== "completed") || null;
@@ -638,6 +644,12 @@ async function composeContentFromSubject(
 
         const progress = await loadCallerProgress(callerId, pbCurr.slug, "current_module");
         const contractThresholds = await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1");
+        // TODO(#598 Slice 1 follow-up): migrate to resolveMasteryThreshold()
+        // once `lib/tolerance/resolve-tolerance.ts` ships. The cascade there
+        // covers the 7 layers (caller → playbook → preset → spec config →
+        // ContractRegistry → hardcoded 0.7) — this 2-layer fallback is the
+        // last surviving direct read of `0.7` outside `transforms/modules.ts`.
+        // See docs/decisions/2026-05-22-tolerance-placement.md.
         const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
         const enrichedModules = enrichModulesWithProgress(modules, progress, masteryThreshold);
         const nextModule = enrichedModules.find((m) => m.status !== "completed") || null;
@@ -705,6 +717,12 @@ async function composeContentFromSubject(
     const progress = await loadCallerProgress(callerId, curriculum.slug, "current_module");
 
     // Get mastery threshold from contract (not hardcoded)
+    // TODO(#598 Slice 1 follow-up): migrate to resolveMasteryThreshold()
+    // once `lib/tolerance/resolve-tolerance.ts` ships. The cascade there
+    // covers the 7 layers (caller → playbook → preset → spec config →
+    // ContractRegistry → hardcoded 0.7) — this 2-layer fallback is the
+    // last surviving direct read of `0.7` outside `transforms/modules.ts`.
+    // See docs/decisions/2026-05-22-tolerance-placement.md.
     const contractThresholds = await ContractRegistry.getThresholds('CURRICULUM_PROGRESS_V1');
     const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
 


### PR DESCRIPTION
## Summary
Adds inline TODO comments at the 3 surviving `?? 0.7` reads in `apps/admin/lib/prompt/compose-content-section.ts` (lines ~603, ~641, ~709) so a grep for `resolveMasteryThreshold` post-#598 Slice 1 finds them immediately.

These were intentionally out of scope for #598 Slice 1 per the v6 issue body. This commit just documents the migration target inline so the followup chore isn't invisible.

## Test plan
- Comment-only — zero behaviour change.
- `npx tsc --noEmit` unchanged
- `npm run ratchet:check` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)