### PR TITLE
feat(#826 Story 2/8): updatePlaybookConfig helper + ESLint rule + migrate 7 sites

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/design/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/design/route.ts
@@ -13,34 +13,21 @@
  *   (no surveys.pre write); surveys.post.enabled mirrors nps.enabled.
  *   Pass `null` for any optional override field to clear it (falls back
  *   to defaults / contract).
+ *
+ *   #826: writes go through `updatePlaybookConfig` which bumps
+ *   `Playbook.composeInputsUpdatedAt` when a COMPOSE-affecting key changes.
+ *   Downstream callers' prompts are marked stale; recompose happens
+ *   lazily at their next call-start (or immediately if educator clicks
+ *   "Recompose now" on the StalePromptPill in #831).
  * @request { welcome?: WelcomeConfig, nps?: NpsConfig, skillTierMapping?, skillScoringEmaHalfLifeDays?, skillMinCallsToFull?, progressNarrative?, offboardingSummary?, firstSessionTargets?, firstCallMode? }
- * @response 200 { ok: true }
+ * @response 200 { ok: true, configUpdated: boolean }
  * @response 404 { ok: false, error: "Course not found" }
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
 import type { WelcomeConfig, NpsConfig, PlaybookConfig } from "@/lib/types/json-fields";
-
-/**
- * #819 — keys whose presence in the request body should trigger
- * `recompose-all` fan-out after the save commits. Skill-banding and
- * NPS/welcome don't appear here because they're read at runtime via
- * their own loaders (banding via the registry, welcome by the student
- * portal — neither is baked into the deterministic ComposedPrompt).
- *
- * All four Felt-Progress / Call-1 namespaces directly affect the
- * COMPOSE-stage output for enrolled callers — without this fan-out,
- * the existing ComposedPrompt row for each caller goes stale until
- * the next pipeline call triggers a recompose naturally.
- */
-const COMPOSE_AFFECTING_KEYS = [
-  "progressNarrative",
-  "offboardingSummary",
-  "firstSessionTargets",
-  "firstCallMode",
-] as const;
 
 export async function PUT(
   req: NextRequest,
@@ -71,146 +58,112 @@ export async function PUT(
       firstCallMode?: PlaybookConfig["firstCallMode"] | null;
     };
 
-    const playbook = await prisma.playbook.findUnique({
-      where: { id: courseId },
-      select: { config: true },
-    });
+    try {
+      const { composeAffectingChanged } = await updatePlaybookConfig(
+        courseId,
+        (pbConfig) => {
+          if (body.welcome) {
+            pbConfig.welcome = body.welcome;
+          }
 
-    if (!playbook) {
-      return NextResponse.json({ ok: false, error: "Course not found" }, { status: 404 });
-    }
+          if (body.nps) {
+            pbConfig.nps = body.nps;
+          }
 
-    const pbConfig = (playbook.config ?? {}) as PlaybookConfig;
+          // #417 Story C — banding override. Pass `null` to clear (fall back
+          // to the SKILL_MEASURE_V1 contract defaults).
+          if (body.skillTierMapping !== undefined) {
+            if (body.skillTierMapping === null) {
+              delete pbConfig.skillTierMapping;
+            } else {
+              pbConfig.skillTierMapping = body.skillTierMapping;
+            }
+          }
+          if (body.skillScoringEmaHalfLifeDays !== undefined) {
+            if (body.skillScoringEmaHalfLifeDays === null) {
+              delete pbConfig.skillScoringEmaHalfLifeDays;
+            } else {
+              pbConfig.skillScoringEmaHalfLifeDays = body.skillScoringEmaHalfLifeDays;
+            }
+          }
+          if (body.skillMinCallsToFull !== undefined) {
+            if (body.skillMinCallsToFull === null) {
+              delete pbConfig.skillMinCallsToFull;
+            } else {
+              pbConfig.skillMinCallsToFull = body.skillMinCallsToFull;
+            }
+          }
 
-    if (body.welcome) {
-      pbConfig.welcome = body.welcome;
-    }
+          // #779 — Felt Progress progressNarrative. Pass `null` to clear.
+          if (body.progressNarrative !== undefined) {
+            if (body.progressNarrative === null) {
+              delete pbConfig.progressNarrative;
+            } else {
+              pbConfig.progressNarrative = body.progressNarrative;
+            }
+          }
 
-    if (body.nps) {
-      pbConfig.nps = body.nps;
-    }
+          // #780 — Felt Progress offboardingSummary.
+          if (body.offboardingSummary !== undefined) {
+            if (body.offboardingSummary === null) {
+              delete pbConfig.offboardingSummary;
+            } else {
+              pbConfig.offboardingSummary = body.offboardingSummary;
+            }
+          }
 
-    // #417 Story C — banding override. Pass `null` to clear (fall back
-    // to the SKILL_MEASURE_V1 contract defaults).
-    if (body.skillTierMapping !== undefined) {
-      if (body.skillTierMapping === null) {
-        delete pbConfig.skillTierMapping;
-      } else {
-        pbConfig.skillTierMapping = body.skillTierMapping;
-      }
-    }
-    if (body.skillScoringEmaHalfLifeDays !== undefined) {
-      if (body.skillScoringEmaHalfLifeDays === null) {
-        delete pbConfig.skillScoringEmaHalfLifeDays;
-      } else {
-        pbConfig.skillScoringEmaHalfLifeDays = body.skillScoringEmaHalfLifeDays;
-      }
-    }
-    if (body.skillMinCallsToFull !== undefined) {
-      if (body.skillMinCallsToFull === null) {
-        delete pbConfig.skillMinCallsToFull;
-      } else {
-        pbConfig.skillMinCallsToFull = body.skillMinCallsToFull;
-      }
-    }
+          // #784 (S6) — first-call BEHAVIOR target overrides.
+          if (body.firstSessionTargets !== undefined) {
+            if (
+              body.firstSessionTargets === null ||
+              Object.keys(body.firstSessionTargets).length === 0
+            ) {
+              delete pbConfig.firstSessionTargets;
+            } else {
+              pbConfig.firstSessionTargets = body.firstSessionTargets;
+            }
+          }
 
-    // #779 — Felt Progress progressNarrative. Pass `null` to clear (fall back
-    // to transform defaults). Object writes the namespace verbatim.
-    if (body.progressNarrative !== undefined) {
-      if (body.progressNarrative === null) {
-        delete pbConfig.progressNarrative;
-      } else {
-        pbConfig.progressNarrative = body.progressNarrative;
-      }
-    }
+          // #790 (S8) — first-call mode.
+          if (body.firstCallMode !== undefined) {
+            if (body.firstCallMode === null) {
+              delete pbConfig.firstCallMode;
+            } else {
+              pbConfig.firstCallMode = body.firstCallMode;
+            }
+          }
 
-    // #780 — Felt Progress offboardingSummary. Same null-clears semantics.
-    if (body.offboardingSummary !== undefined) {
-      if (body.offboardingSummary === null) {
-        delete pbConfig.offboardingSummary;
-      } else {
-        pbConfig.offboardingSummary = body.offboardingSummary;
-      }
-    }
+          // surveys.pre.enabled is COMPUTED-ONLY from welcome.*;
+          // surveys.post.enabled mirrors nps.enabled when nps is saved.
+          if (body.nps) {
+            const n = pbConfig.nps;
+            pbConfig.surveys = {
+              ...pbConfig.surveys,
+              post: {
+                enabled: !!n?.enabled,
+                questions: pbConfig.surveys?.post?.questions ?? [],
+              },
+            };
+          }
 
-    // #784 (S6) — per-playbook first-call BEHAVIOR target overrides.
-    // null or empty-object clears so the domain → INIT-001 → AUDIENCE
-    // cascade applies again.
-    if (body.firstSessionTargets !== undefined) {
+          return pbConfig;
+        },
+        { reason: "design PUT" },
+      );
+
+      return NextResponse.json({ ok: true, configUpdated: composeAffectingChanged });
+    } catch (err: unknown) {
       if (
-        body.firstSessionTargets === null ||
-        Object.keys(body.firstSessionTargets).length === 0
+        err instanceof Error &&
+        err.message.includes("not found")
       ) {
-        delete pbConfig.firstSessionTargets;
-      } else {
-        pbConfig.firstSessionTargets = body.firstSessionTargets;
+        return NextResponse.json(
+          { ok: false, error: "Course not found" },
+          { status: 404 },
+        );
       }
+      throw err;
     }
-
-    // #790 (S8) — first-call mode. null clears so the default 'onboarding'
-    // path runs in `transforms/pedagogy.ts` (byte-identical to pre-#790).
-    if (body.firstCallMode !== undefined) {
-      if (body.firstCallMode === null) {
-        delete pbConfig.firstCallMode;
-      } else {
-        pbConfig.firstCallMode = body.firstCallMode;
-      }
-    }
-
-    // surveys.pre.enabled is now COMPUTED-ONLY from welcome.* (see isPreSurveyEnabled);
-    // do NOT write it. surveys.post.enabled has no welcome-side mirror yet, so
-    // mirror from nps.enabled when nps is being saved.
-    if (body.nps) {
-      const n = pbConfig.nps;
-      pbConfig.surveys = {
-        ...pbConfig.surveys,
-        post: { enabled: !!n?.enabled, questions: pbConfig.surveys?.post?.questions ?? [] },
-      };
-    }
-
-    await prisma.playbook.update({
-      where: { id: courseId },
-      data: { config: JSON.parse(JSON.stringify(pbConfig)) },
-    });
-
-    // #819 — close the chain-contract gap: educator-tunable namespaces that
-    // flow into COMPOSE need to propagate to every active caller's
-    // ComposedPrompt row, not just the next pipeline run. Fire the existing
-    // /api/playbooks/[id]/recompose-all endpoint via the internal function
-    // path (it's bounded by pLimit(5) so even large rosters are safe).
-    // Fire-and-forget so the design save returns immediately; recompose
-    // errors are logged but don't block the educator.
-    const composeAffected = COMPOSE_AFFECTING_KEYS.some(
-      (k) => body[k] !== undefined,
-    );
-    if (composeAffected) {
-      import("@/lib/enrollment/auto-compose")
-        .then(async ({ autoComposeForCaller }) => {
-          const { getPlaybookRoster } = await import("@/lib/enrollment");
-          const pLimit = (await import("p-limit")).default;
-          const roster = await getPlaybookRoster(courseId, "ACTIVE");
-          const callerIds = roster
-            .map((r) => r.caller?.id)
-            .filter((id): id is string => !!id);
-          const limit = pLimit(5);
-          await Promise.all(
-            callerIds.map((cid) =>
-              limit(() => autoComposeForCaller(cid, courseId)),
-            ),
-          );
-          console.log(
-            `[design PUT] recompose-all fan-out complete: ${callerIds.length} callers (course ${courseId})`,
-          );
-        })
-        .catch((err) => {
-          console.error(
-            `[design PUT] recompose-all fan-out failed for course ${courseId}:`,
-            err.message,
-          );
-        });
-    }
-
-    return NextResponse.json({ ok: true, recomposed: composeAffected });
   } catch (err) {
     console.error("[design PUT]", err);
     return NextResponse.json(

--- a/apps/admin/app/api/courses/[courseId]/onboarding/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/onboarding/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
 import type { PlaybookConfig, OnboardingFlowPhases, OnboardingPhase } from "@/lib/types/json-fields";
 import { getFlowPhasesFallback } from "@/lib/fallback-settings";
 
@@ -140,34 +141,31 @@ export async function PUT(
     const body = await req.json();
     const { onboardingFlowPhases } = body as { onboardingFlowPhases: OnboardingFlowPhases | null };
 
-    // Verify playbook exists
-    const playbook = await prisma.playbook.findUnique({
-      where: { id: courseId },
-      select: { id: true, config: true },
-    });
-
-    if (!playbook) {
-      return NextResponse.json(
-        { ok: false, error: "Course not found" },
-        { status: 404 }
+    // #826 — central helper. `onboardingFlowPhases` is in
+    // COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS, so a change bumps the
+    // timestamp and downstream callers are marked stale.
+    try {
+      await updatePlaybookConfig(
+        courseId,
+        (cfg) => {
+          if (onboardingFlowPhases === null) {
+            delete cfg.onboardingFlowPhases;
+          } else {
+            cfg.onboardingFlowPhases = onboardingFlowPhases;
+          }
+          return cfg;
+        },
+        { reason: "course-onboarding PUT" },
       );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes("not found")) {
+        return NextResponse.json(
+          { ok: false, error: "Course not found" },
+          { status: 404 },
+        );
+      }
+      throw err;
     }
-
-    // Merge into existing config (preserve other config fields)
-    const existingConfig = (playbook.config || {}) as PlaybookConfig;
-    const updatedConfig: PlaybookConfig = { ...existingConfig };
-
-    if (onboardingFlowPhases === null) {
-      // Reset to institution default — remove the override
-      delete updatedConfig.onboardingFlowPhases;
-    } else {
-      updatedConfig.onboardingFlowPhases = onboardingFlowPhases;
-    }
-
-    await prisma.playbook.update({
-      where: { id: courseId },
-      data: { config: updatedConfig },
-    });
 
     const action = onboardingFlowPhases === null ? "reset to domain default" : "set course override";
     console.log(`[course-onboarding-api] ${action} for course ${courseId}`);

--- a/apps/admin/app/api/courses/[courseId]/session-flow/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/session-flow/route.ts
@@ -18,6 +18,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { config } from "@/lib/config";
 import { resolveSessionFlow } from "@/lib/session-flow/resolver";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
 import type {
   PlaybookConfig,
   OnboardingFlowPhases,
@@ -136,68 +137,66 @@ export async function PUT(
       );
     }
 
-    const playbook = await prisma.playbook.findUnique({
-      where: { id: courseId },
-      select: {
-        id: true,
-        config: true,
-      },
-    });
-    if (!playbook) {
-      return NextResponse.json(
-        { ok: false, error: "Course not found" },
-        { status: 404 },
-      );
-    }
-
-    const existing = (playbook.config ?? {}) as PlaybookConfig;
-
-    // ── Mirror sessionFlow.intake → legacy `welcome` during dual-read window ──
-    // The runtime transforms (and journey-position route, when the flag is OFF)
-    // read `playbook.config.welcome.*.enabled`. Without this mirror, edits in
-    // the Session Flow editor would silently fail when SESSION_FLOW_RESOLVER_ENABLED
-    // is false (currently the case in test/prod). Same pattern the wizard
-    // already uses for `nps.enabled` → `surveys.post.enabled`. Removed in
-    // Phase 5 (#220) once legacy fields are dropped.
-    let mirroredWelcome = existing.welcome;
-    if (body.sessionFlow?.intake) {
-      const i = body.sessionFlow.intake;
-      mirroredWelcome = {
-        goals: { enabled: i.goals.enabled },
-        aboutYou: { enabled: i.aboutYou.enabled },
-        knowledgeCheck: { enabled: i.knowledgeCheck.enabled },
-        aiIntroCall: { enabled: i.aiIntroCall.enabled },
-      };
-    }
-
-    // ── Mirror nps.enabled → surveys.post.enabled (existing wizard pattern) ──
-    let mirroredSurveys = existing.surveys;
-    if (body.nps !== undefined) {
-      mirroredSurveys = {
-        ...(existing.surveys ?? {}),
-        post: { ...(existing.surveys?.post ?? {}), enabled: body.nps.enabled },
-      };
-    }
-
-    const merged: PlaybookConfig = {
-      ...existing,
-      ...(body.lessonPlanMode !== undefined ? { lessonPlanMode: body.lessonPlanMode } : {}),
-      ...(body.welcomeMessage !== undefined ? { welcomeMessage: body.welcomeMessage ?? undefined } : {}),
-      ...(body.nps !== undefined
-        ? { nps: body.nps, ...(mirroredSurveys !== existing.surveys ? { surveys: mirroredSurveys } : {}) }
-        : {}),
-      ...(body.sessionFlow !== undefined
-        ? {
-            sessionFlow: { ...(existing.sessionFlow ?? {}), ...body.sessionFlow },
-            ...(mirroredWelcome !== existing.welcome ? { welcome: mirroredWelcome } : {}),
+    // #826 — central helper bumps composeInputsUpdatedAt when sessionFlow /
+    // welcomeMessage / lessonPlanMode (all COMPOSE_AFFECTING) change.
+    try {
+      await updatePlaybookConfig(
+        courseId,
+        (existing) => {
+          // ── Mirror sessionFlow.intake → legacy `welcome` during dual-read window ──
+          // The runtime transforms (and journey-position route, when the flag is OFF)
+          // read `playbook.config.welcome.*.enabled`. Without this mirror, edits in
+          // the Session Flow editor would silently fail when SESSION_FLOW_RESOLVER_ENABLED
+          // is false (currently the case in test/prod). Same pattern the wizard
+          // already uses for `nps.enabled` → `surveys.post.enabled`. Removed in
+          // Phase 5 (#220) once legacy fields are dropped.
+          let mirroredWelcome = existing.welcome;
+          if (body.sessionFlow?.intake) {
+            const i = body.sessionFlow.intake;
+            mirroredWelcome = {
+              goals: { enabled: i.goals.enabled },
+              aboutYou: { enabled: i.aboutYou.enabled },
+              knowledgeCheck: { enabled: i.knowledgeCheck.enabled },
+              aiIntroCall: { enabled: i.aiIntroCall.enabled },
+            };
           }
-        : {}),
-    };
 
-    await prisma.playbook.update({
-      where: { id: courseId },
-      data: { config: merged as object },
-    });
+          // ── Mirror nps.enabled → surveys.post.enabled (existing wizard pattern) ──
+          let mirroredSurveys = existing.surveys;
+          if (body.nps !== undefined) {
+            mirroredSurveys = {
+              ...(existing.surveys ?? {}),
+              post: { ...(existing.surveys?.post ?? {}), enabled: body.nps.enabled },
+            };
+          }
+
+          const merged: PlaybookConfig = {
+            ...existing,
+            ...(body.lessonPlanMode !== undefined ? { lessonPlanMode: body.lessonPlanMode } : {}),
+            ...(body.welcomeMessage !== undefined ? { welcomeMessage: body.welcomeMessage ?? undefined } : {}),
+            ...(body.nps !== undefined
+              ? { nps: body.nps, ...(mirroredSurveys !== existing.surveys ? { surveys: mirroredSurveys } : {}) }
+              : {}),
+            ...(body.sessionFlow !== undefined
+              ? {
+                  sessionFlow: { ...(existing.sessionFlow ?? {}), ...body.sessionFlow },
+                  ...(mirroredWelcome !== existing.welcome ? { welcome: mirroredWelcome } : {}),
+                }
+              : {}),
+          };
+          return merged;
+        },
+        { reason: "session-flow PUT" },
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes("not found")) {
+        return NextResponse.json(
+          { ok: false, error: "Course not found" },
+          { status: 404 },
+        );
+      }
+      throw err;
+    }
 
     // Re-resolve and return so the client can update without a second fetch.
     const updated = await prisma.playbook.findUnique({

--- a/apps/admin/app/api/courses/[courseId]/survey-config/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/survey-config/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
 import type {
   PlaybookConfig,
   OnboardingPhase,
@@ -105,73 +106,75 @@ export async function PATCH(
       triggerAfterCalls?: number;
     };
 
-    const playbook = await prisma.playbook.findUnique({
-      where: { id: courseId },
-      select: { config: true },
-    });
+    // #826 — central helper. `onboardingFlowPhases` is COMPOSE-affecting
+    // (bumps the timestamp). `offboarding.*` mutations are NOT
+    // COMPOSE-affecting today — they're consumed by the offboarding
+    // survey delivery path, not the prompt — so those mutations alone
+    // won't bump the timestamp.
+    try {
+      await updatePlaybookConfig(
+        courseId,
+        (pbConfig) => {
+          // ---- Onboarding survey steps ----
+          if (body.onboardingSurveySteps) {
+            const phases: OnboardingPhase[] = pbConfig.onboardingFlowPhases?.phases ?? [];
+            const surveyIdx = phases.findIndex(
+              (p) => p.surveySteps && p.surveySteps.length > 0,
+            );
 
-    if (!playbook) {
-      return NextResponse.json({ ok: false, error: "Course not found" }, { status: 404 });
-    }
+            if (surveyIdx >= 0) {
+              phases[surveyIdx] = { ...phases[surveyIdx], surveySteps: body.onboardingSurveySteps };
+            } else {
+              const welcomeIdx = phases.findIndex((p) => p.phase.toLowerCase() === "welcome");
+              const insertAt = welcomeIdx >= 0 ? welcomeIdx + 1 : Math.min(1, phases.length);
+              phases.splice(insertAt, 0, {
+                phase: "survey",
+                duration: "2min",
+                goals: ["Capture learner baseline"],
+                surveySteps: body.onboardingSurveySteps,
+              });
+            }
 
-    const pbConfig = (playbook.config ?? {}) as PlaybookConfig;
+            pbConfig.onboardingFlowPhases = {
+              ...pbConfig.onboardingFlowPhases,
+              phases,
+            };
+          }
 
-    // ---- Onboarding survey steps ----
-    if (body.onboardingSurveySteps) {
-      const phases: OnboardingPhase[] = pbConfig.onboardingFlowPhases?.phases ?? [];
-      const surveyIdx = phases.findIndex(
-        (p) => p.surveySteps && p.surveySteps.length > 0,
+          // ---- Offboarding survey / trigger ----
+          if (body.offboardingSurveySteps !== undefined || body.triggerAfterCalls !== undefined) {
+            const existing = (pbConfig.offboarding ?? {}) as Partial<OffboardingConfig>;
+            const existingPhases = existing.phases ?? [];
+
+            if (body.offboardingSurveySteps) {
+              if (existingPhases.length > 0) {
+                existingPhases[0] = { ...existingPhases[0], surveySteps: body.offboardingSurveySteps };
+              } else {
+                existingPhases.push({
+                  phase: "survey",
+                  duration: "3min",
+                  goals: ["Gather feedback"],
+                  surveySteps: body.offboardingSurveySteps,
+                });
+              }
+            }
+
+            pbConfig.offboarding = {
+              triggerAfterCalls: body.triggerAfterCalls ?? existing.triggerAfterCalls ?? DEFAULT_OFFBOARDING_TRIGGER,
+              phases: existingPhases,
+            } satisfies OffboardingConfig;
+          }
+
+          return pbConfig;
+        },
+        { reason: "survey-config PATCH" },
       );
-
-      if (surveyIdx >= 0) {
-        // Update existing survey phase
-        phases[surveyIdx] = { ...phases[surveyIdx], surveySteps: body.onboardingSurveySteps };
-      } else {
-        // Insert a survey phase after "welcome" (or at position 1)
-        const welcomeIdx = phases.findIndex((p) => p.phase.toLowerCase() === "welcome");
-        const insertAt = welcomeIdx >= 0 ? welcomeIdx + 1 : Math.min(1, phases.length);
-        phases.splice(insertAt, 0, {
-          phase: "survey",
-          duration: "2min",
-          goals: ["Capture learner baseline"],
-          surveySteps: body.onboardingSurveySteps,
-        });
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes("not found")) {
+        return NextResponse.json({ ok: false, error: "Course not found" }, { status: 404 });
       }
-
-      pbConfig.onboardingFlowPhases = {
-        ...pbConfig.onboardingFlowPhases,
-        phases,
-      };
+      throw err;
     }
-
-    // ---- Offboarding survey / trigger ----
-    if (body.offboardingSurveySteps !== undefined || body.triggerAfterCalls !== undefined) {
-      const existing = (pbConfig.offboarding ?? {}) as Partial<OffboardingConfig>;
-      const existingPhases = existing.phases ?? [];
-
-      if (body.offboardingSurveySteps) {
-        if (existingPhases.length > 0) {
-          existingPhases[0] = { ...existingPhases[0], surveySteps: body.offboardingSurveySteps };
-        } else {
-          existingPhases.push({
-            phase: "survey",
-            duration: "3min",
-            goals: ["Gather feedback"],
-            surveySteps: body.offboardingSurveySteps,
-          });
-        }
-      }
-
-      pbConfig.offboarding = {
-        triggerAfterCalls: body.triggerAfterCalls ?? existing.triggerAfterCalls ?? DEFAULT_OFFBOARDING_TRIGGER,
-        phases: existingPhases,
-      } satisfies OffboardingConfig;
-    }
-
-    await prisma.playbook.update({
-      where: { id: courseId },
-      data: { config: pbConfig as Record<string, unknown> },
-    });
 
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/apps/admin/app/api/playbooks/[playbookId]/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { deletePlaybookData } from "@/lib/gdpr/delete-playbook-data";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
 
 /**
  * Extract systemSpecs toggle state and configSettings from playbook.config.
@@ -274,19 +276,24 @@ export async function PATCH(
       }
 
       if (spec.scope === "SYSTEM") {
-        // Save single system spec toggle to config.systemSpecToggles
-        const currentConfig = (existing.config as Record<string, any>) || {};
-        const toggles = currentConfig.systemSpecToggles || {};
-        toggles[specId] = {
-          isEnabled: enabled,
-          configOverride: toggles[specId]?.configOverride || null,
-        };
-        await prisma.playbook.update({
-          where: { id: playbookId },
-          data: {
-            config: { ...currentConfig, systemSpecToggles: toggles },
+        // #826 — central helper. systemSpecToggles is NOT in
+        // COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS (spec resolution is a
+        // different code path), so no timestamp bump fires — but we
+        // route through the helper to maintain enforcement uniformity.
+        await updatePlaybookConfig(
+          playbookId,
+          (cfg) => {
+            const c = cfg as Record<string, any>;
+            const toggles = c.systemSpecToggles || {};
+            toggles[specId] = {
+              isEnabled: enabled,
+              configOverride: toggles[specId]?.configOverride || null,
+            };
+            c.systemSpecToggles = toggles;
+            return cfg;
           },
-        });
+          { reason: "playbook PATCH — systemSpec toggle" },
+        );
       } else {
         // Toggle domain spec via PlaybookItem
         const existingItem = await prisma.playbookItem.findFirst({
@@ -376,6 +383,7 @@ export async function PATCH(
     }
 
     // Save system spec toggles to playbook.config.systemSpecToggles
+    // #826 — not COMPOSE-affecting, routes through helper for uniformity.
     if (specs !== undefined) {
       const systemSpecToggles: Record<string, { isEnabled: boolean; configOverride: any }> = {};
       for (const s of specs as Array<{ specId: string; isEnabled: boolean; configOverride: any }>) {
@@ -384,55 +392,46 @@ export async function PATCH(
           configOverride: s.configOverride || null,
         };
       }
-      const currentConfig = (existing.config as Record<string, any>) || {};
-      await prisma.playbook.update({
-        where: { id: playbookId },
-        data: {
-          config: { ...currentConfig, systemSpecToggles },
-        },
-      });
+      await updatePlaybookConfig(
+        playbookId,
+        (cfg) => ({ ...(cfg as Record<string, unknown>), systemSpecToggles } as PlaybookConfig),
+        { reason: "playbook PATCH — specs bulk" },
+      );
     }
 
-    // Save audience to playbook.config.audience (top-level config field)
+    // Save audience to playbook.config.audience.
+    // #826 — `audience` IS COMPOSE-affecting (targets cascade reads it),
+    // so this WILL bump the timestamp.
     if (audience !== undefined) {
-      const current = await prisma.playbook.findUnique({
-        where: { id: playbookId },
-        select: { config: true },
-      });
-      const currentConfig = (current?.config as Record<string, any>) || {};
-      await prisma.playbook.update({
-        where: { id: playbookId },
-        data: { config: { ...currentConfig, audience } },
-      });
+      await updatePlaybookConfig(
+        playbookId,
+        (cfg) => ({ ...(cfg as Record<string, unknown>), audience } as PlaybookConfig),
+        { reason: "playbook PATCH — audience" },
+      );
     }
 
-    // Save config settings (memory, learning, AI, thresholds) to playbook.config.configSettings
+    // Save config settings (memory, learning, AI, thresholds) to
+    // playbook.config.configSettings.
+    // #826 — configSettings is NOT in COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS
+    // (these are runtime memory/learning rates consumed by separate
+    // pipeline modules, not the prompt composer).
     if (configSettings !== undefined) {
-      // Re-fetch to get latest config (in case specs were also updated)
-      const current = await prisma.playbook.findUnique({
-        where: { id: playbookId },
-        select: { config: true },
-      });
-      const currentConfig = (current?.config as Record<string, any>) || {};
-      await prisma.playbook.update({
-        where: { id: playbookId },
-        data: {
-          config: { ...currentConfig, configSettings },
-        },
-      });
+      await updatePlaybookConfig(
+        playbookId,
+        (cfg) => ({ ...(cfg as Record<string, unknown>), configSettings } as PlaybookConfig),
+        { reason: "playbook PATCH — configSettings" },
+      );
     }
 
-    // Merge arbitrary config fields (goals, constraints, teachingFocus, etc.)
+    // Merge arbitrary config fields (goals, constraints, teachingFocus, etc.).
+    // #826 — `goals` IS COMPOSE-affecting → bumps timestamp. Other keys
+    // depend on the COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS list.
     if (config !== undefined && typeof config === "object" && config !== null) {
-      const current = await prisma.playbook.findUnique({
-        where: { id: playbookId },
-        select: { config: true },
-      });
-      const currentConfig = (current?.config as Record<string, any>) || {};
-      await prisma.playbook.update({
-        where: { id: playbookId },
-        data: { config: { ...currentConfig, ...config } },
-      });
+      await updatePlaybookConfig(
+        playbookId,
+        (cfg) => ({ ...(cfg as Record<string, unknown>), ...config } as PlaybookConfig),
+        { reason: "playbook PATCH — arbitrary config merge" },
+      );
     }
 
     // Fetch updated playbook

--- a/apps/admin/eslint-rules/no-direct-playbook-config-write.mjs
+++ b/apps/admin/eslint-rules/no-direct-playbook-config-write.mjs
@@ -1,0 +1,114 @@
+/**
+ * #826 — Block direct writes to `Playbook.config` outside the central helper.
+ *
+ * Direct writes bypass the `composeInputsUpdatedAt` timestamp bump that
+ * `lib/playbook/update-playbook-config.ts` performs. Without the bump, the
+ * staleness check in `lib/compose/staleness.ts::isPromptStale` treats the
+ * cached prompt as fresh — the educator's tuning change silently fails to
+ * propagate to enrolled callers' next compose. This is the TUNER → COMPOSE
+ * chain-contract failure mode (see `docs/CHAIN-CONTRACTS.md` §3 Link 3).
+ *
+ * The rule flags `prisma.playbook.update({ data: { config: ... } })` and
+ * `tx.playbook.update({ data: { config: ... } })` (transaction client).
+ * It allows writes to `Playbook.update` that DON'T touch `config` (e.g.
+ * `data: { name: ... }` is fine — name isn't a compose input).
+ *
+ * Allowed files (the helper itself + seed/migration paths where no
+ * callers can be enrolled yet, plus the recompose-all escape hatch):
+ *
+ *   - `lib/playbook/update-playbook-config.ts` — the helper itself
+ *   - `prisma/seed.ts`, `prisma/seed-*.ts`, `prisma/migrations/**` — seed/migration paths
+ *   - `scripts/**` — one-shot maintenance scripts
+ *   - `app/api/playbooks/[playbookId]/recompose-all/route.ts` — manual fan-out escape hatch
+ *
+ * If you need to do a direct write for a NEW reason, document why in the
+ * code comment and add the path to the allowlist below — don't add a
+ * blanket `eslint-disable`. The allowlist is the contract.
+ */
+
+const ALLOWED_PATH_FRAGMENTS = [
+  "lib/playbook/update-playbook-config.ts",
+  "/prisma/seed",
+  "/prisma/migrations/",
+  "/scripts/",
+  "/lib/seed/",
+  "app/api/playbooks/[playbookId]/recompose-all/route.ts",
+];
+
+function isAllowedFile(filename) {
+  if (!filename) return false;
+  return ALLOWED_PATH_FRAGMENTS.some((frag) => filename.includes(frag));
+}
+
+/**
+ * Matches `prisma.playbook.update(...)` and `tx.playbook.update(...)`.
+ * Returns true if the callee is the `.update` (or `.updateMany`) method
+ * on a `.playbook` property of some object — we don't care which object.
+ */
+function isPlaybookUpdateCall(callee) {
+  if (callee?.type !== "MemberExpression") return false;
+  const method = callee.property;
+  if (method?.type !== "Identifier") return false;
+  if (method.name !== "update" && method.name !== "updateMany") return false;
+  const obj = callee.object;
+  if (obj?.type !== "MemberExpression") return false;
+  if (obj.property?.type !== "Identifier" || obj.property.name !== "playbook") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Checks if the first arg to the update call has `data: { config: ... }`.
+ * Returns true if so. Walks the AST defensively — non-ObjectExpression
+ * args (computed shapes) return false to avoid false-positive blocks.
+ */
+function callWritesConfig(node) {
+  const arg = node.arguments?.[0];
+  if (arg?.type !== "ObjectExpression") return false;
+  const dataProp = arg.properties.find(
+    (p) =>
+      p.type === "Property" &&
+      p.key.type === "Identifier" &&
+      p.key.name === "data",
+  );
+  if (!dataProp) return false;
+  if (dataProp.value.type !== "ObjectExpression") return false;
+  const configProp = dataProp.value.properties.find(
+    (p) =>
+      p.type === "Property" &&
+      p.key.type === "Identifier" &&
+      p.key.name === "config",
+  );
+  return Boolean(configProp);
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow direct writes to Playbook.config — use `updatePlaybookConfig` from `lib/playbook/update-playbook-config.ts`. See #826.",
+    },
+    schema: [],
+    messages: {
+      directConfigWrite:
+        "Direct write to `Playbook.config` bypasses `composeInputsUpdatedAt` bump — downstream staleness check will treat cached prompts as fresh and the change silently fails to propagate. Use `updatePlaybookConfig(playbookId, transformer)` from `@/lib/playbook/update-playbook-config`. See `docs/CHAIN-CONTRACTS.md` §3 Link 3 and #826.",
+    },
+  },
+  create(context) {
+    const filename = context.getFilename?.() ?? context.filename ?? "";
+    if (isAllowedFile(filename)) {
+      // Don't even register the visitor — saves a few CPU cycles on
+      // the (large) helper file and seed scripts.
+      return {};
+    }
+    return {
+      CallExpression(node) {
+        if (!isPlaybookUpdateCall(node.callee)) return;
+        if (!callWritesConfig(node)) return;
+        context.report({ node, messageId: "directConfigWrite" });
+      },
+    };
+  },
+};

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import noUnscopedSlugLookup from "./eslint-rules/no-unscoped-slug-lookup.mjs";
+import noDirectPlaybookConfigWrite from "./eslint-rules/no-direct-playbook-config-write.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -43,9 +44,19 @@ const eslintConfig = defineConfig([
           "no-unscoped-slug-lookup": noUnscopedSlugLookup,
         },
       },
+      // #826 — block direct writes to Playbook.config outside the
+      // central helper. Force every writer through updatePlaybookConfig
+      // so the TUNER → COMPOSE chain-contract (Link 3) timestamp bump
+      // cannot be skipped.
+      "hf-playbook": {
+        rules: {
+          "no-direct-config-write": noDirectPlaybookConfigWrite,
+        },
+      },
     },
     rules: {
       "hf-curriculum/no-unscoped-slug-lookup": "error",
+      "hf-playbook/no-direct-config-write": "error",
     },
   },
   // Enforce config+metering for ALL AI calls (no raw client usage)

--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -9,6 +9,8 @@
  * institutions/courses, and returning results to the AI loop.
  */
 
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+
 // ── Helpers ─────────────────────────────────────────────
 
 // Canonical wizard phase-id mapping. Used to build sessionFlow.onboarding.phases
@@ -961,10 +963,15 @@ export async function executeWizardTool(
               existingPlaybookId,
             );
 
-            await prisma.playbook.update({
-              where: { id: existingPlaybookId },
-              data: { config: JSON.parse(JSON.stringify(configUpdate)) },
-            });
+            // #826 — central helper. create_course reuse-existing path
+            // hits a playbook that MAY already have enrolled callers, so
+            // the timestamp bump (when compose-affecting keys change)
+            // marks downstream prompts as stale.
+            await updatePlaybookConfig(
+              existingPlaybookId,
+              () => configUpdate,
+              { reason: "wizard create_course (existing path)" },
+            );
 
             // #607 follow-on (2026-05-23) — the new-course branch's step 4b
             // calls `unlinkNonPrimaryPlaybookSubjects()` to enforce "exactly
@@ -1508,10 +1515,15 @@ export async function executeWizardTool(
           playbookId,
         );
 
-        await prisma.playbook.update({
-          where: { id: playbookId },
-          data: { config: JSON.parse(JSON.stringify(configUpdate)) },
-        });
+        // #826 — central helper, skipTimestamp: true because this is
+        // create_course NEW path — the playbook was created in the same
+        // wizard step and has no enrolled callers yet, so no downstream
+        // staleness to mark.
+        await updatePlaybookConfig(
+          playbookId,
+          () => configUpdate,
+          { skipTimestamp: true, reason: "wizard create_course (new path)" },
+        );
 
         // 6. Link Subject → Playbook
         await prisma.playbookSubject.upsert({
@@ -2403,10 +2415,15 @@ export async function executeWizardTool(
           configUpdate.modulesAuthored = false;
         }
 
-        await prisma.playbook.update({
-          where: { id: playbookId },
-          data: { config: JSON.parse(JSON.stringify(configUpdate)) },
-        });
+        // #826 — central helper. update_course_config is hit AFTER
+        // playbook creation, possibly with enrolled callers — timestamp
+        // bump marks downstream prompts as stale when COMPOSE-affecting
+        // keys changed.
+        await updatePlaybookConfig(
+          playbookId,
+          () => configUpdate,
+          { reason: "wizard update_course_config" },
+        );
 
         return {
           ...base,

--- a/apps/admin/lib/compose/affecting-keys.ts
+++ b/apps/admin/lib/compose/affecting-keys.ts
@@ -1,0 +1,60 @@
+/**
+ * COMPOSE-affecting playbook config keys — #826 (Story 2 of EPIC #832).
+ *
+ * Top-level keys on `Playbook.config` that flow into the composed prompt.
+ * A write that changes any of these MUST trigger a
+ * `Playbook.composeInputsUpdatedAt` bump so the staleness check in
+ * `lib/compose/staleness.ts::isPromptStale` correctly marks downstream
+ * `ComposedPrompt` rows as stale.
+ *
+ * Keys NOT in this list (e.g. `welcome`, `nps`, `skillTierMapping`,
+ * `surveys`) are read by the student portal at runtime, not baked into
+ * the deterministic ComposedPrompt — they can change without triggering
+ * a recompose.
+ *
+ * Single source of truth — imported by `updatePlaybookConfig` and any
+ * test that needs to assert the list. Do NOT inline this list anywhere
+ * else; add new keys here and the helper picks them up automatically.
+ */
+export const COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS = [
+  // Felt Progress + Call-1 namespaces (#779 / #780 / #784 / #790)
+  "progressNarrative",
+  "offboardingSummary",
+  "firstSessionTargets",
+  "firstCallMode",
+  // Session flow + welcome — used by transforms/pedagogy.ts + onboarding loader
+  "sessionFlow",
+  "welcomeMessage",
+  "onboardingFlowPhases",
+  // Audience + teaching shape — read by targets.ts + pedagogy.ts
+  "audience",
+  "teachingMode",
+  "lessonPlanMode",
+  // Goals + skill banding
+  "goals",
+  "skillTierMapping",
+] as const;
+
+export type ComposeAffectingPlaybookConfigKey =
+  (typeof COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS)[number];
+
+/**
+ * Returns true when any of the keys in `next` differ from `prev` by deep
+ * equality. Used by `updatePlaybookConfig` to decide whether to bump the
+ * timestamp.
+ *
+ * Uses JSON.stringify for deep equality — fast for the shapes we store
+ * (no Dates, no functions, no cycles). If a future config key holds
+ * such a value, this comparator needs updating.
+ */
+export function composeAffectingChanged(
+  prev: Record<string, unknown>,
+  next: Record<string, unknown>,
+): boolean {
+  for (const key of COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS) {
+    if (JSON.stringify(prev[key]) !== JSON.stringify(next[key])) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/admin/lib/domain/course-setup.ts
+++ b/apps/admin/lib/domain/course-setup.ts
@@ -10,6 +10,7 @@
 import { prisma } from "@/lib/prisma";
 import { config } from "@/lib/config";
 import { logSystem } from "@/lib/logger";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
 import slugify from "slugify";
 import { scaffoldDomain } from "@/lib/domain/scaffold";
 import { loadPersonaFlowPhases, loadPersonaArchetype, loadPersonaWelcomeTemplate } from "@/lib/domain/quick-launch";
@@ -388,36 +389,31 @@ const stepExecutors: Record<string, (ctx: CourseSetupContext, step: CourseSetupS
           mergedGoals = [...mergedGoals, ...newLOGoals];
         }
 
-        await prisma.playbook.update({
-          where: { id: scaffoldResult.playbook.id },
-          data: {
-            config: {
-              ...existingConfig,
-              ...(ctx.input.interactionPattern && { interactionPattern: ctx.input.interactionPattern }),
-              ...(ctx.input.teachingMode && { teachingMode: ctx.input.teachingMode }),
-              ...(ctx.input.subjectDiscipline && { subjectDiscipline: ctx.input.subjectDiscipline }),
-              // Plan intents — used by "Regenerate Plan" fallback
-              ...(planIntents?.sessionCount && { sessionCount: planIntents.sessionCount }),
-              ...(planIntents?.durationMins && { durationMins: planIntents.durationMins }),
-              ...(planIntents?.emphasis && { emphasis: planIntents.emphasis }),
-              ...(planIntents?.assessments && { assessments: planIntents.assessments }),
-              // Top-level fallbacks (when planIntents not provided)
-              ...(!planIntents?.sessionCount && ctx.input.sessionCount && { sessionCount: ctx.input.sessionCount }),
-              ...(!planIntents?.durationMins && ctx.input.durationMins && { durationMins: ctx.input.durationMins }),
-              ...(!planIntents?.emphasis && ctx.input.emphasis && { emphasis: ctx.input.emphasis }),
-              // Lesson plan model — used by quickstart.ts for prompt composition
-              ...(ctx.input.lessonPlanModel && { lessonPlanModel: ctx.input.lessonPlanModel }),
-              // Learning structure — structured (fixed syllabus) vs continuous (adaptive per-call)
-              ...(ctx.input.learningStructure && { learningStructure: ctx.input.learningStructure }),
-              // Course learning outcomes — the educator's stated goals (distinct from module LOs)
-              ...(ctx.input.learningOutcomes?.length && { courseLearningOutcomes: ctx.input.learningOutcomes }),
-              // GoalTemplate entries — consumed by instantiatePlaybookGoals on enrolment
-              ...(mergedGoals.length > 0 && { goals: mergedGoals }),
-              // Audience segment — per-course override (falls back to domain/system default)
-              ...(ctx.input.audience && { audience: ctx.input.audience }),
-            },
-          },
-        });
+        // #826 — central helper, skipTimestamp: true. course-setup
+        // scaffold runs BEFORE any callers can enroll; no downstream
+        // staleness to mark.
+        await updatePlaybookConfig(
+          scaffoldResult.playbook.id,
+          () => ({
+            ...existingConfig,
+            ...(ctx.input.interactionPattern && { interactionPattern: ctx.input.interactionPattern }),
+            ...(ctx.input.teachingMode && { teachingMode: ctx.input.teachingMode }),
+            ...(ctx.input.subjectDiscipline && { subjectDiscipline: ctx.input.subjectDiscipline }),
+            ...(planIntents?.sessionCount && { sessionCount: planIntents.sessionCount }),
+            ...(planIntents?.durationMins && { durationMins: planIntents.durationMins }),
+            ...(planIntents?.emphasis && { emphasis: planIntents.emphasis }),
+            ...(planIntents?.assessments && { assessments: planIntents.assessments }),
+            ...(!planIntents?.sessionCount && ctx.input.sessionCount && { sessionCount: ctx.input.sessionCount }),
+            ...(!planIntents?.durationMins && ctx.input.durationMins && { durationMins: ctx.input.durationMins }),
+            ...(!planIntents?.emphasis && ctx.input.emphasis && { emphasis: ctx.input.emphasis }),
+            ...(ctx.input.lessonPlanModel && { lessonPlanModel: ctx.input.lessonPlanModel }),
+            ...(ctx.input.learningStructure && { learningStructure: ctx.input.learningStructure }),
+            ...(ctx.input.learningOutcomes?.length && { courseLearningOutcomes: ctx.input.learningOutcomes }),
+            ...(mergedGoals.length > 0 && { goals: mergedGoals }),
+            ...(ctx.input.audience && { audience: ctx.input.audience }),
+          } as any),
+          { skipTimestamp: true, reason: "course-setup scaffold" },
+        );
       }
 
       // Link Subject to Playbook (course-scoped content retrieval)

--- a/apps/admin/lib/playbook/update-playbook-config.ts
+++ b/apps/admin/lib/playbook/update-playbook-config.ts
@@ -1,0 +1,124 @@
+/**
+ * Playbook.config writer — #826 (Story 2 of EPIC #832).
+ *
+ * Central enforcement point for writes to `Playbook.config`. Every route
+ * / chat tool / lib that mutates `Playbook.config` MUST go through this
+ * helper. The ESLint rule `hf-playbook/no-direct-config-write` blocks
+ * `prisma.playbook.update({ data: { config: ... } })` calls outside the
+ * allowlist (this file + seed/migration scripts + recompose-all).
+ *
+ * Mechanism — stamp on write, check on read (NOT eager fan-out, see
+ * `docs/CHAIN-CONTRACTS.md` §3 Link 3 sub-contract):
+ *
+ *   1. findUnique current config
+ *   2. apply transformer to a deep clone
+ *   3. diff against COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS
+ *   4. write new config; if any compose-affecting key changed AND
+ *      `skipTimestamp` is not set, ALSO write
+ *      `composeInputsUpdatedAt = new Date()`
+ *   5. return updated playbook
+ *
+ * Downstream consumers see the staleness via
+ * `lib/compose/staleness.ts::isPromptStale` at COMPOSE-entry points
+ * (autoComposeForCaller, compose-prompt route). Pipeline COMPOSE has its
+ * own carve-out — it always recomposes.
+ *
+ * ## skipTimestamp
+ *
+ * Default `false`. Set to `true` for:
+ *   - Seed scripts (no callers exist yet)
+ *   - Migration scripts (config is being established before enrolment)
+ *   - The course-setup scaffold path (pre-enrolment course creation)
+ *   - The `create_course` new-playbook branch of `wizard-tool-executor`
+ *
+ * Do NOT use `skipTimestamp: true` to "save the write" on educator
+ * tuning paths — the timestamp bump is the entire point of the helper.
+ */
+
+import { prisma } from "@/lib/prisma";
+import type { Playbook } from "@prisma/client";
+import {
+  composeAffectingChanged,
+  COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS,
+} from "@/lib/compose/affecting-keys";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+export interface UpdatePlaybookConfigOptions {
+  /**
+   * When true, suppresses the `composeInputsUpdatedAt` bump even when
+   * compose-affecting keys changed. Use for seed/migration/pre-enrolment
+   * writers only.
+   */
+  skipTimestamp?: boolean;
+  /**
+   * Diagnostic label written to the log line. Helps trace which writer
+   * is responsible for a given timestamp bump.
+   */
+  reason?: string;
+}
+
+export interface UpdatePlaybookConfigResult {
+  playbook: Playbook;
+  /** True when at least one COMPOSE-affecting key differed from the prior config. */
+  composeAffectingChanged: boolean;
+  /** True when the timestamp was bumped (composeAffectingChanged && !skipTimestamp). */
+  timestampBumped: boolean;
+}
+
+export type PlaybookConfigTransformer = (
+  current: PlaybookConfig,
+) => PlaybookConfig;
+
+export async function updatePlaybookConfig(
+  playbookId: string,
+  transformer: PlaybookConfigTransformer,
+  options: UpdatePlaybookConfigOptions = {},
+): Promise<UpdatePlaybookConfigResult> {
+  if (!playbookId) {
+    throw new Error("updatePlaybookConfig: playbookId is required");
+  }
+
+  const current = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { config: true },
+  });
+  if (!current) {
+    throw new Error(`updatePlaybookConfig: playbook ${playbookId} not found`);
+  }
+
+  const currentConfig = (current.config ?? {}) as PlaybookConfig;
+  // Deep-clone so the transformer can mutate freely without surprising
+  // the caller's reference to the original config object.
+  const nextConfig = transformer(
+    JSON.parse(JSON.stringify(currentConfig)) as PlaybookConfig,
+  );
+
+  const composeAffected = composeAffectingChanged(
+    currentConfig as Record<string, unknown>,
+    nextConfig as Record<string, unknown>,
+  );
+  const shouldBumpTimestamp = composeAffected && !options.skipTimestamp;
+
+  const playbook = await prisma.playbook.update({
+    where: { id: playbookId },
+    data: {
+      config: nextConfig as object,
+      ...(shouldBumpTimestamp && { composeInputsUpdatedAt: new Date() }),
+    },
+  });
+
+  if (shouldBumpTimestamp) {
+    console.log(
+      `[updatePlaybookConfig] composeInputsUpdatedAt bumped for ${playbookId}${options.reason ? ` (reason: ${options.reason})` : ""}`,
+    );
+  }
+
+  return {
+    playbook,
+    composeAffectingChanged: composeAffected,
+    timestampBumped: shouldBumpTimestamp,
+  };
+}
+
+// Re-export the keys list so callers / tests can introspect.
+export { COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS };

--- a/apps/admin/tests/lib/playbook/update-playbook-config.test.ts
+++ b/apps/admin/tests/lib/playbook/update-playbook-config.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for `lib/playbook/update-playbook-config.ts` — #826 Story 2.
+ *
+ * Covers the post-#825 stamp-on-write mechanism:
+ *  - compose-affecting key change → composeInputsUpdatedAt bumped
+ *  - non-compose-affecting key change → no bump
+ *  - idempotent re-save (same config) → no bump
+ *  - skipTimestamp: true → no bump even when compose-affecting changed
+ *  - multi-key diff with at least one compose-affecting → bump fires
+ *  - transformer receives a deep clone (mutating it doesn't alias the caller's ref)
+ *  - missing playbookId → throws clean error
+ *  - missing playbook row → throws clean error
+ *  - config is persisted regardless of whether timestamp bumped
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  playbook: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+describe("updatePlaybookConfig — #826 stamp-on-write helper", () => {
+  let updatePlaybookConfig: typeof import("@/lib/playbook/update-playbook-config").updatePlaybookConfig;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/lib/playbook/update-playbook-config");
+    updatePlaybookConfig = mod.updatePlaybookConfig;
+    mockPrisma.playbook.update.mockImplementation(async ({ data }) => ({
+      id: "pb1",
+      ...data,
+    }));
+  });
+
+  it("compose-affecting key change → composeInputsUpdatedAt bumped", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { firstCallMode: "onboarding" },
+    });
+    const result = await updatePlaybookConfig("pb1", (c) => ({
+      ...c,
+      firstCallMode: "baseline_assessment",
+    }));
+    expect(result.composeAffectingChanged).toBe(true);
+    expect(result.timestampBumped).toBe(true);
+    const updateArgs = mockPrisma.playbook.update.mock.calls[0][0];
+    expect(updateArgs.data.composeInputsUpdatedAt).toBeInstanceOf(Date);
+  });
+
+  it("non-compose-affecting key change → no bump", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { welcome: { greeting: "old" } },
+    });
+    const result = await updatePlaybookConfig("pb1", (c) => ({
+      ...c,
+      welcome: { greeting: "new" },
+    }));
+    expect(result.composeAffectingChanged).toBe(false);
+    expect(result.timestampBumped).toBe(false);
+    const updateArgs = mockPrisma.playbook.update.mock.calls[0][0];
+    expect(updateArgs.data.composeInputsUpdatedAt).toBeUndefined();
+  });
+
+  it("idempotent re-save (same config) → no bump", async () => {
+    const cfg = { firstCallMode: "onboarding", welcome: { greeting: "hi" } };
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: cfg });
+    const result = await updatePlaybookConfig("pb1", (c) => c);
+    expect(result.composeAffectingChanged).toBe(false);
+    expect(result.timestampBumped).toBe(false);
+  });
+
+  it("skipTimestamp: true → no bump even when compose-affecting changed", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { firstCallMode: "onboarding" },
+    });
+    const result = await updatePlaybookConfig(
+      "pb1",
+      (c) => ({ ...c, firstCallMode: "teach_immediately" }),
+      { skipTimestamp: true },
+    );
+    expect(result.composeAffectingChanged).toBe(true); // still detected
+    expect(result.timestampBumped).toBe(false); // but suppressed
+    const updateArgs = mockPrisma.playbook.update.mock.calls[0][0];
+    expect(updateArgs.data.composeInputsUpdatedAt).toBeUndefined();
+  });
+
+  it("multi-key diff: at least one compose-affecting → bump fires", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { firstCallMode: "onboarding", welcome: { greeting: "old" } },
+    });
+    const result = await updatePlaybookConfig("pb1", (c) => ({
+      ...c,
+      firstCallMode: "baseline_assessment", // compose-affecting
+      welcome: { greeting: "new" }, // not compose-affecting
+    }));
+    expect(result.composeAffectingChanged).toBe(true);
+    expect(result.timestampBumped).toBe(true);
+  });
+
+  it("transformer receives a deep clone — mutating it doesn't alias the original", async () => {
+    const originalConfig = { firstCallMode: "onboarding", nested: { a: 1 } };
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: originalConfig });
+    let receivedRef: any = null;
+    await updatePlaybookConfig("pb1", (c) => {
+      receivedRef = c;
+      c.firstCallMode = "baseline_assessment";
+      (c as any).nested.a = 999; // mutate nested
+      return c;
+    });
+    // The reference handed to the transformer is NOT the original DB row's object
+    expect(receivedRef).not.toBe(originalConfig);
+    expect(originalConfig.nested.a).toBe(1); // original is untouched
+  });
+
+  it("missing playbookId → throws clean error", async () => {
+    await expect(
+      updatePlaybookConfig("", () => ({ firstCallMode: "onboarding" })),
+    ).rejects.toThrow(/playbookId is required/);
+    expect(mockPrisma.playbook.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("missing playbook row → throws clean error", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    await expect(
+      updatePlaybookConfig("pb-missing", (c) => c),
+    ).rejects.toThrow(/playbook pb-missing not found/);
+    expect(mockPrisma.playbook.update).not.toHaveBeenCalled();
+  });
+
+  it("config persisted in the update payload regardless of timestamp", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { welcome: { greeting: "old" } },
+    });
+    await updatePlaybookConfig("pb1", (c) => ({
+      ...c,
+      welcome: { greeting: "new" },
+    }));
+    const updateArgs = mockPrisma.playbook.update.mock.calls[0][0];
+    expect(updateArgs.data.config).toEqual({ welcome: { greeting: "new" } });
+  });
+
+  it("transformer can return a brand-new object (not a mutation of the input)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      config: { firstCallMode: "onboarding" },
+    });
+    const result = await updatePlaybookConfig("pb1", () => ({
+      firstCallMode: "baseline_assessment",
+    }));
+    expect(result.composeAffectingChanged).toBe(true);
+    expect(result.timestampBumped).toBe(true);
+  });
+
+  it("null/undefined config on existing playbook treated as empty object", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: null });
+    const result = await updatePlaybookConfig("pb1", () => ({
+      firstCallMode: "baseline_assessment",
+    }));
+    expect(result.composeAffectingChanged).toBe(true);
+    expect(result.timestampBumped).toBe(true);
+  });
+});

--- a/apps/admin/tests/lib/playbook/update-playbook-config.test.ts
+++ b/apps/admin/tests/lib/playbook/update-playbook-config.test.ts
@@ -52,11 +52,11 @@ describe("updatePlaybookConfig — #826 stamp-on-write helper", () => {
 
   it("non-compose-affecting key change → no bump", async () => {
     mockPrisma.playbook.findUnique.mockResolvedValue({
-      config: { welcome: { greeting: "old" } },
+      config: { skillScoringEmaHalfLifeDays: 14 },
     });
     const result = await updatePlaybookConfig("pb1", (c) => ({
       ...c,
-      welcome: { greeting: "new" },
+      skillScoringEmaHalfLifeDays: 28,
     }));
     expect(result.composeAffectingChanged).toBe(false);
     expect(result.timestampBumped).toBe(false);
@@ -65,7 +65,7 @@ describe("updatePlaybookConfig — #826 stamp-on-write helper", () => {
   });
 
   it("idempotent re-save (same config) → no bump", async () => {
-    const cfg = { firstCallMode: "onboarding", welcome: { greeting: "hi" } };
+    const cfg = { firstCallMode: "onboarding" as const, skillScoringEmaHalfLifeDays: 14 };
     mockPrisma.playbook.findUnique.mockResolvedValue({ config: cfg });
     const result = await updatePlaybookConfig("pb1", (c) => c);
     expect(result.composeAffectingChanged).toBe(false);
@@ -89,12 +89,12 @@ describe("updatePlaybookConfig — #826 stamp-on-write helper", () => {
 
   it("multi-key diff: at least one compose-affecting → bump fires", async () => {
     mockPrisma.playbook.findUnique.mockResolvedValue({
-      config: { firstCallMode: "onboarding", welcome: { greeting: "old" } },
+      config: { firstCallMode: "onboarding" as const, skillScoringEmaHalfLifeDays: 14 },
     });
     const result = await updatePlaybookConfig("pb1", (c) => ({
       ...c,
       firstCallMode: "baseline_assessment", // compose-affecting
-      welcome: { greeting: "new" }, // not compose-affecting
+      skillScoringEmaHalfLifeDays: 28, // not compose-affecting
     }));
     expect(result.composeAffectingChanged).toBe(true);
     expect(result.timestampBumped).toBe(true);

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -5157,7 +5157,7 @@ Save student experience design config. Writes to
 
 **Response** `200`
 ```json
-{ ok: true }
+{ ok: true, configUpdated: boolean }
 ```
 
 **Response** `404`


### PR DESCRIPTION
## Summary

Story 2 of EPIC #832. Replaces the eager fan-out approach (#820, closed) with stamp-on-write: every write to \`Playbook.config\` goes through \`updatePlaybookConfig\`, which bumps \`Playbook.composeInputsUpdatedAt\` when a COMPOSE-affecting key changes. The staleness check from #825 handles propagation lazily at read time.

**Closes #826.**

## What lands

### New
- \`lib/compose/affecting-keys.ts\` — \`COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS\` const + \`composeAffectingChanged()\` deep-diff helper. Single source of truth.
- \`lib/playbook/update-playbook-config.ts\` — central writer. Reads current, applies transformer to deep clone, diffs, writes, conditionally bumps timestamp.
- \`eslint-rules/no-direct-playbook-config-write.mjs\` (severity: error) — blocks \`prisma.playbook.update({data:{config:...}})\` outside the allowlist (helper itself, seed scripts, migrations, lib/seed, scripts, recompose-all endpoint).
- \`tests/lib/playbook/update-playbook-config.test.ts\` — 11 cases.

### Migrated (7 sites)
- \`PUT /api/courses/[id]/design\` — replaces #819 inline fan-out; response shape changed \`recomposed\` → \`configUpdated\`.
- \`PUT /api/courses/[id]/session-flow\`
- \`PUT /api/courses/[id]/onboarding\`
- \`PATCH /api/courses/[id]/survey-config\`
- \`PATCH /api/playbooks/[id]\` — 4 sub-sites (single systemSpec toggle, bulk specs, audience, configSettings, arbitrary merge)
- \`lib/chat/wizard-tool-executor.ts\` — 3 sites (\`create_course\` reuse-existing, \`create_course\` new-playbook with \`skipTimestamp\`, \`update_course_config\`)
- \`lib/domain/course-setup.ts\` scaffold path (1 of 2 sites; site 2 is Story 3 #827 scope)

## Test plan

- [x] 11/11 unit tests on the helper pass
- [x] Lint: 0 \`hf-playbook/no-direct-config-write\` errors on the 7 migrated files
- [ ] \`npm run lint\` overall still red — Story 3 (#827) migrates the remaining 8 sites; ESLint rule will go fully green when #827 lands
- [x] Per-table TS errors on touched files clear

## Deploy

\`/vm-cp\` — no migration (Story 1 owns the schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)