### PR TITLE
fix(#836 follow-up): ops/compute-reward + ops/update-targets — fanout across all CallerIdentity rows

### DIFF
--- a/apps/admin/lib/ops/compute-reward.ts
+++ b/apps/admin/lib/ops/compute-reward.ts
@@ -140,9 +140,25 @@ interface ComputeRewardResult {
 /**
  * Load effective targets for a caller identity, merging SYSTEM → SEGMENT → CALLER
  */
+/**
+ * Load effective targets for a call by composing SYSTEM → SEGMENT → CALLER
+ * scopes, with later layers overriding earlier ones per parameter.
+ *
+ * #836 fanout contract — `BehaviorTarget.callerIdentityId` references
+ * `CallerIdentity.id`, NOT `Caller.id`. A caller may have multiple identities
+ * (one per channel) and BehaviorTarget overrides may sit on any of them. We
+ * fan out via the full `callerIdentityIds[]` list, collect all matching rows,
+ * and resolve cross-identity conflicts by picking **MAX targetValue** per
+ * parameter — same tie-break as `lib/tolerance/resolve-tolerance.ts` so reads
+ * are consistent across both call paths. Pre-fix this used `identities?.[0]?.id`
+ * and silently ignored overrides written to any non-first identity.
+ *
+ * Segment fanout uses the same shape — every identity's `segmentId` is
+ * considered, deduplicated, and queried with `segmentId: { in: ... }`.
+ */
 async function loadEffectiveTargets(
-  callerIdentityId: string | null,
-  segmentId: string | null
+  callerIdentityIds: string[],
+  segmentIds: string[]
 ): Promise<Map<string, EffectiveTarget>> {
   const targets = new Map<string, EffectiveTarget>();
 
@@ -164,45 +180,62 @@ async function loadEffectiveTargets(
     });
   }
 
-  // Load SEGMENT targets (override system)
-  if (segmentId) {
+  // Load SEGMENT targets (override system) — fan out across all segments the
+  // caller's identities belong to. MAX per parameter.
+  if (segmentIds.length > 0) {
     const segmentTargets = await prisma.behaviorTarget.findMany({
       where: {
         scope: BehaviorTargetScope.SEGMENT,
-        segmentId,
+        segmentId: { in: segmentIds },
         effectiveUntil: null,
       },
     });
 
     for (const t of segmentTargets) {
-      targets.set(t.parameterId, {
-        parameterId: t.parameterId,
-        targetValue: t.targetValue,
-        confidence: t.confidence,
-        scope: t.scope,
-        source: t.source,
-      });
+      const existing = targets.get(t.parameterId);
+      if (
+        !existing ||
+        existing.scope !== BehaviorTargetScope.SEGMENT ||
+        t.targetValue > existing.targetValue
+      ) {
+        targets.set(t.parameterId, {
+          parameterId: t.parameterId,
+          targetValue: t.targetValue,
+          confidence: t.confidence,
+          scope: t.scope,
+          source: t.source,
+        });
+      }
     }
   }
 
-  // Load CALLER targets (override segment/system)
-  if (callerIdentityId) {
+  // Load CALLER targets (override segment/system) — fan out across all caller
+  // identities. MAX per parameter so a higher per-identity override can't be
+  // silently undercut by a stale lower value on a different identity.
+  if (callerIdentityIds.length > 0) {
     const callerTargets = await prisma.behaviorTarget.findMany({
       where: {
         scope: BehaviorTargetScope.CALLER,
-        callerIdentityId,
+        callerIdentityId: { in: callerIdentityIds },
         effectiveUntil: null,
       },
     });
 
     for (const t of callerTargets) {
-      targets.set(t.parameterId, {
-        parameterId: t.parameterId,
-        targetValue: t.targetValue,
-        confidence: t.confidence,
-        scope: t.scope,
-        source: t.source,
-      });
+      const existing = targets.get(t.parameterId);
+      if (
+        !existing ||
+        existing.scope !== BehaviorTargetScope.CALLER ||
+        t.targetValue > existing.targetValue
+      ) {
+        targets.set(t.parameterId, {
+          parameterId: t.parameterId,
+          targetValue: t.targetValue,
+          confidence: t.confidence,
+          scope: t.scope,
+          source: t.source,
+        });
+      }
     }
   }
 
@@ -344,8 +377,11 @@ export async function computeReward(
       behaviorMeasurements: true,
       caller: {
         include: {
+          // #836 fanout — load ALL identities so loadEffectiveTargets can
+          // resolve per-identity CALLER + SEGMENT targets and MAX over them.
+          // Pre-fix this had `take: 1`, which silently dropped overrides on
+          // any non-first identity.
           callerIdentities: {
-            take: 1,
             include: {
               segment: true,
             },
@@ -372,13 +408,17 @@ export async function computeReward(
     try {
       result.callsProcessed++;
 
-      // Get caller context
-      const callerIdentity = call.caller?.callerIdentities?.[0];
-      const callerIdentityId = callerIdentity?.id || null;
-      const segmentId = callerIdentity?.segmentId || null;
+      // #836 fanout — collect every CallerIdentity.id + unique segmentId
+      // attached to this caller. `loadEffectiveTargets` does the fanout query
+      // and the MAX-per-parameter tie-break across identities.
+      const identities = call.caller?.callerIdentities ?? [];
+      const callerIdentityIds = identities.map((i) => i.id);
+      const segmentIds = Array.from(
+        new Set(identities.map((i) => i.segmentId).filter((s): s is string => !!s)),
+      );
 
       // Load effective targets
-      const targets = await loadEffectiveTargets(callerIdentityId, segmentId);
+      const targets = await loadEffectiveTargets(callerIdentityIds, segmentIds);
 
       if (targets.size === 0) {
         if (verbose) console.log(`Call ${call.id}: No targets found, using defaults`);

--- a/apps/admin/lib/ops/update-targets.ts
+++ b/apps/admin/lib/ops/update-targets.ts
@@ -229,9 +229,10 @@ export async function updateTargets(
         include: {
           caller: {
             include: {
-              callerIdentities: {
-                take: 1,
-              },
+              // #836 fanout — load ALL identities so the CALLER write below
+              // creates one BehaviorTarget per identity. Pre-fix `take: 1`
+              // meant only an arbitrary identity received the new target.
+              callerIdentities: true,
             },
           },
         },
@@ -257,7 +258,14 @@ export async function updateTargets(
     try {
       result.rewardsProcessed++;
 
-      const callerIdentityId = reward.call.caller?.callerIdentities?.[0]?.id || null;
+      // #836 fanout — write the LEARNED target to EVERY CallerIdentity row for
+      // this caller so subsequent reads (via `lib/tolerance/resolve-tolerance.ts`
+      // or `loadEffectiveTargets`, both of which fan out + MAX) see a consistent
+      // value regardless of which identity the next call comes in on. Pre-fix
+      // this picked `identities?.[0]?.id` and silently skipped every other
+      // identity, producing drift between channels.
+      const callerIdentityIds: string[] =
+        reward.call.caller?.callerIdentities?.map((i) => i.id) ?? [];
       const effectiveTargets = reward.effectiveTargets as Record<string, any>;
       const parameterDiffs = reward.parameterDiffs as Record<string, any>;
 
@@ -300,45 +308,50 @@ export async function updateTargets(
           continue;
         }
 
-        // Determine scope for new target (CALLER if we have one, otherwise keep original scope)
-        const newScope = callerIdentityId ? BehaviorTargetScope.CALLER : (scope as BehaviorTargetScope);
+        // Determine scope for new target (CALLER if we have at least one
+        // identity, otherwise keep original scope)
+        const newScope =
+          callerIdentityIds.length > 0
+            ? BehaviorTargetScope.CALLER
+            : (scope as BehaviorTargetScope);
 
-        // Create new target (or update existing CALLER target)
-        if (callerIdentityId && newScope === BehaviorTargetScope.CALLER) {
-          // Check for existing CALLER target
-          const existingTarget = await prisma.behaviorTarget.findFirst({
-            where: {
-              parameterId,
-              callerIdentityId,
-              scope: BehaviorTargetScope.CALLER,
-              effectiveUntil: null,
-            },
-          });
-
-          if (existingTarget) {
-            // Supersede existing target
-            await prisma.behaviorTarget.update({
-              where: { id: existingTarget.id },
-              data: { effectiveUntil: new Date() },
+        // Create new target (or update existing CALLER target). Fan out per
+        // identity so writes are consistent with the MAX-tie-break reader.
+        if (callerIdentityIds.length > 0 && newScope === BehaviorTargetScope.CALLER) {
+          for (const identityId of callerIdentityIds) {
+            const existingTarget = await prisma.behaviorTarget.findFirst({
+              where: {
+                parameterId,
+                callerIdentityId: identityId,
+                scope: BehaviorTargetScope.CALLER,
+                effectiveUntil: null,
+              },
             });
-            result.targetsUpdated++;
-          }
 
-          // Create new target
-          await prisma.behaviorTarget.create({
-            data: {
-              parameterId,
-              scope: BehaviorTargetScope.CALLER,
-              callerIdentityId,
-              targetValue: adjustment.newTarget,
-              confidence: adjustment.newConfidence,
-              source: BehaviorTargetSource.LEARNED,
-              observationCount: 1,
-              lastLearnedAt: new Date(),
-              supersededById: existingTarget?.id,
-            },
-          });
-          result.targetsCreated++;
+            if (existingTarget) {
+              // Supersede existing target
+              await prisma.behaviorTarget.update({
+                where: { id: existingTarget.id },
+                data: { effectiveUntil: new Date() },
+              });
+              result.targetsUpdated++;
+            }
+
+            await prisma.behaviorTarget.create({
+              data: {
+                parameterId,
+                scope: BehaviorTargetScope.CALLER,
+                callerIdentityId: identityId,
+                targetValue: adjustment.newTarget,
+                confidence: adjustment.newConfidence,
+                source: BehaviorTargetSource.LEARNED,
+                observationCount: 1,
+                lastLearnedAt: new Date(),
+                supersededById: existingTarget?.id,
+              },
+            });
+            result.targetsCreated++;
+          }
         } else {
           // For SYSTEM/SEGMENT targets, we just record the update but don't modify
           // (Those should be updated through aggregate analysis, not individual calls)


### PR DESCRIPTION
Follow-up to #836 (which fixed the resolver). Tech Lead's review flagged two adjacent ops sites that had the **correct FK type** but the **wrong identity semantics** — both picked `caller.callerIdentities?.[0]?.id` arbitrarily, silently ignoring other identities.

## What changed

| Site | Before | After |
|---|---|---|
| `lib/ops/compute-reward.ts::loadEffectiveTargets` | single `callerIdentityId` arg, `take: 1` on prisma include | accepts `callerIdentityIds: string[]`, loads ALL identities, queries SEGMENT + CALLER with `{ in: ids }`, MAX-merges per parameter |
| `lib/ops/update-targets.ts` per-parameter LEARNED write | wrote new CALLER target to `identities?.[0]?.id` only | wraps supersede+create in `for (id of identityIds)` — each identity gets its own LEARNED row |

Mirrors the write-side fanout in `lib/agent-tuner/write-target.ts::writeCallerBehaviorTarget` and aligns the LEARNED-source path with the same fanout + MAX discipline as the manual-source path.

**Output byte-identical for single-identity callers** (the common case in hf_sandbox today). Behaviour only differs when a caller has 2+ identities.

## Live verification of the underlying contract (#836 main fix)

Run on hf_sandbox before this PR was written:

```
Step A baseline (no BTs)             → 0.7   contract-registry
Step B BT(id[0], 0.55)               → 0.55  caller-behavior-target  ✓ fanout
Step C + BT(id[1], 0.81)             → 0.81  MAX wins (0.81 > 0.55)
Step D bump id[0] BT to 0.93         → 0.93  MAX flips to id[0]
Cleanup                              → 0.7   baseline restored
```

## Pre-existing lint failures on main (not this PR)

CI lint will fail because main has 7 pre-existing `hf-playbook/no-direct-config-write` errors, missed when #837 landed the rule. They are in:
- `app/api/courses/[courseId]/import-modules/route.ts`
- `lib/goals/sync-constraints-from-reference.ts`
- `lib/goals/sync-goals-from-reference.ts`
- `lib/wizard/apply-projection.ts`

These are NOT introduced by this PR — none touch `lib/ops/`. Resolution should be a separate PR migrating those four sites to `updatePlaybookConfig()`, or bumping `.ratchet.json` to acknowledge the gap.

## Quality gates

- `tsc --noEmit`: 198 errors == baseline
- ESLint on touched files: **0 errors**, 10 warnings (all pre-existing in the file, not from me)
- Tolerance suite: 28/28 pass (unchanged by this PR)
- Lint warnings: 4468 == baseline

## Deploy

`/vm-cp` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)