### PR TITLE
chore(#598 followup): migrate 3 mastery threshold reads in compose-content-section to resolveMasteryThreshold()

### DIFF
--- a/apps/admin/lib/prompt/compose-content-section.ts
+++ b/apps/admin/lib/prompt/compose-content-section.ts
@@ -16,6 +16,7 @@
 import { prisma } from "@/lib/prisma";
 import { ContractRegistry } from "@/lib/contracts/registry";
 import { CURRICULUM_REQUIRED_FIELDS } from "@/lib/curriculum/constants";
+import { resolveMasteryThreshold } from "@/lib/tolerance/resolve-tolerance";
 import type { SpecConfig } from "@/lib/types/json-fields";
 
 interface CurriculumMetadata {
@@ -581,6 +582,19 @@ async function composeContentFromSubject(
     });
 
     if (pbCurr) {
+      // #598 Slice 1 follow-up — single tolerance-cascade resolution covers
+      // both Path 1 and Path 2 below. Pulls Playbook.config once for layers
+      // 2–4 of the cascade (per-playbook target, tolerances field, preset).
+      const playbookForResolve = await prisma.playbook.findUnique({
+        where: { id: enrolledPbId },
+        select: { config: true },
+      });
+      const masteryThreshold = await resolveMasteryThreshold({
+        callerId,
+        playbookId: enrolledPbId,
+        playbookConfig: (playbookForResolve?.config as Record<string, unknown>) ?? null,
+      });
+
       // Path 1 — relational CurriculumModule rows.
       const relationalModules = pbCurr.modules ?? [];
       if (relationalModules.length > 0) {
@@ -599,14 +613,6 @@ async function composeContentFromSubject(
         }));
 
         const progress = await loadCallerProgress(callerId, pbCurr.slug, "current_module", enrolledPbId);
-        const contractThresholds = await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1");
-        // TODO(#598 Slice 1 follow-up): migrate to resolveMasteryThreshold()
-        // once `lib/tolerance/resolve-tolerance.ts` ships. The cascade there
-        // covers the 7 layers (caller → playbook → preset → spec config →
-        // ContractRegistry → hardcoded 0.7) — this 2-layer fallback is the
-        // last surviving direct read of `0.7` outside `transforms/modules.ts`.
-        // See docs/decisions/2026-05-22-tolerance-placement.md.
-        const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
         const enrichedModules = enrichModulesWithProgress(modules, progress, masteryThreshold);
         const nextModule = enrichedModules.find((m) => m.status !== "completed") || null;
         const nextContent = nextModule
@@ -643,14 +649,6 @@ async function composeContentFromSubject(
         }));
 
         const progress = await loadCallerProgress(callerId, pbCurr.slug, "current_module");
-        const contractThresholds = await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1");
-        // TODO(#598 Slice 1 follow-up): migrate to resolveMasteryThreshold()
-        // once `lib/tolerance/resolve-tolerance.ts` ships. The cascade there
-        // covers the 7 layers (caller → playbook → preset → spec config →
-        // ContractRegistry → hardcoded 0.7) — this 2-layer fallback is the
-        // last surviving direct read of `0.7` outside `transforms/modules.ts`.
-        // See docs/decisions/2026-05-22-tolerance-placement.md.
-        const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
         const enrichedModules = enrichModulesWithProgress(modules, progress, masteryThreshold);
         const nextModule = enrichedModules.find((m) => m.status !== "completed") || null;
         const nextContent = nextModule
@@ -716,15 +714,11 @@ async function composeContentFromSubject(
     // Load progress using contract-defined keys
     const progress = await loadCallerProgress(callerId, curriculum.slug, "current_module");
 
-    // Get mastery threshold from contract (not hardcoded)
-    // TODO(#598 Slice 1 follow-up): migrate to resolveMasteryThreshold()
-    // once `lib/tolerance/resolve-tolerance.ts` ships. The cascade there
-    // covers the 7 layers (caller → playbook → preset → spec config →
-    // ContractRegistry → hardcoded 0.7) — this 2-layer fallback is the
-    // last surviving direct read of `0.7` outside `transforms/modules.ts`.
-    // See docs/decisions/2026-05-22-tolerance-placement.md.
-    const contractThresholds = await ContractRegistry.getThresholds('CURRICULUM_PROGRESS_V1');
-    const masteryThreshold = contractThresholds?.masteryComplete ?? 0.7;
+    // #598 Slice 1 follow-up — subject-domain fallback path. No playbook is
+    // resolved here (this branch fires when there's no PlaybookCurriculum),
+    // so the cascade naturally degrades through layers 5→6→7 (specConfig →
+    // ContractRegistry → 0.7). Per-caller targets at layer 1 still apply.
+    const masteryThreshold = await resolveMasteryThreshold({ callerId });
 
     // Enrich modules with progress
     const enrichedModules = enrichModulesWithProgress(modules, progress, masteryThreshold);


### PR DESCRIPTION
## Summary

Closes the chore parked in `handoff-598-599-slice-1.md` (landmine #4) — replaces the last 3 surviving `?? 0.7` mastery threshold reads outside `transforms/modules.ts` with the 7-layer tolerance cascade resolver shipped in #598 Slice 1 (PR #833).

- **Paths 1 + 2** (playbook curriculum, relational + legacy `notableInfo`): single hoisted `resolveMasteryThreshold()` call inside `if (pbCurr)`, fetches `Playbook.config` once for cascade layers 2–4.
- **Subject-domain fallback path**: resolver with `callerId` only — degrades through layers 5→6→7 since no playbook context is available there.

Removes the 3 TODO blocks added in PR #824 (commit `cd7e6409`).

See `docs/decisions/2026-05-22-tolerance-placement.md`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` — no new warnings (14 pre-existing untouched)
- [x] `npm run test -- tolerance` — 27/27 pass in isolation
- [x] Behaviorally identical for callers with no overrides; surfaces real per-caller / per-playbook overrides set via the #598 Slice 2 tolerances API
- [ ] Smoke: caller-detail page → "Content" section module completion states render unchanged for un-tuned callers

Deploy: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)