### PR TITLE
chore: PID lock — hard block on destructive git from secondary claude sessions

### DIFF
--- a/.claude/hooks/git-lock-enforcer.sh
+++ b/.claude/hooks/git-lock-enforcer.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# PreToolUse:Bash hook — block destructive git ops from secondary
+# claude sessions sharing the same working tree.
+#
+# Companion to session-start.sh (claims primary) and stop-release-lock.sh
+# (releases on session end). Design: feedback_concurrent_claude_pidlock_design.md.
+#
+# Lock semantics:
+#   - One lock per cwd hash → worktrees get independent locks, both primary
+#   - Lock content: "<claude-pid>:<hostname>:<claim-epoch>"
+#   - Primary: lock PID matches this session's claude PID → all git ops allowed
+#   - Secondary: lock PID belongs to a peer (alive, same host) → destructive
+#     git ops blocked with exit 2 + actionable message
+#   - Stale lock: PID dead or different host → take over silently
+#
+# Escape hatch: set HF_FORCE_GIT=1 to bypass the block (operator override).
+#
+# Exit codes:
+#   0 — allow the tool call
+#   2 — block the tool call (claude renders stdout to the user)
+#
+# Input: JSON on stdin describing the tool call. We read only `tool_input.command`.
+
+set -u
+
+# Lock key = sha256 of the working-tree top. `git rev-parse --show-toplevel`
+# returns a different path for each worktree (per `git worktree add ...`),
+# so concurrent claude sessions in distinct worktrees get distinct locks
+# and both run as primary in their own tree. Fall back to $PWD if not in
+# a git tree (lock is harmlessly orphaned in that case).
+TREE_TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")
+LOCK_KEY=$(printf '%s' "$TREE_TOPLEVEL" | shasum -a 256 | head -c8)
+LOCK="/tmp/claude-lock-$LOCK_KEY"
+
+# Read the incoming tool call payload (Claude Code passes JSON on stdin).
+PAYLOAD=$(cat 2>/dev/null || true)
+
+# Extract the bash command being attempted. Tolerant of missing jq.
+if command -v jq >/dev/null 2>&1; then
+  CMD=$(printf '%s' "$PAYLOAD" | jq -r '.tool_input.command // empty' 2>/dev/null)
+else
+  CMD=$(printf '%s' "$PAYLOAD" | sed -n 's/.*"command":[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
+
+# Only inspect git commands. Anything non-git → allow.
+case "$CMD" in
+  *git*) ;;
+  *) exit 0 ;;
+esac
+
+# Operator override.
+if [ "${HF_FORCE_GIT:-0}" = "1" ]; then
+  exit 0
+fi
+
+# No lock file → we're the only known session (session-start may not yet
+# have claimed). Allow — letting through is safer than over-blocking.
+if [ ! -f "$LOCK" ]; then
+  exit 0
+fi
+
+LOCK_CONTENT=$(cat "$LOCK" 2>/dev/null || true)
+LOCK_PID=$(printf '%s' "$LOCK_CONTENT" | cut -d: -f1)
+LOCK_HOST=$(printf '%s' "$LOCK_CONTENT" | cut -d: -f2)
+
+# Malformed lock → treat as no lock.
+if [ -z "$LOCK_PID" ] || [ -z "$LOCK_HOST" ]; then
+  exit 0
+fi
+
+# Lock owned by a different host (shared NFS scenario) → ignore.
+if [ "$LOCK_HOST" != "$(hostname)" ]; then
+  exit 0
+fi
+
+# Walk up the process tree to find a claude PID (hook bash → claude).
+# $PPID is this script's parent (bash), $PPID's parent is the invoking
+# process. On Claude Code that's the claude session.
+MY_PPID="$PPID"
+MY_CLAUDE_PID=$(ps -o ppid= -p "$MY_PPID" 2>/dev/null | tr -d ' ')
+
+# Primary mode → lock PID matches our claude session.
+if [ "$LOCK_PID" = "$MY_CLAUDE_PID" ] || [ "$LOCK_PID" = "$MY_PPID" ]; then
+  exit 0
+fi
+
+# Check if the lock PID is alive.
+if ! kill -0 "$LOCK_PID" 2>/dev/null; then
+  # Stale lock → reclaim silently for this session.
+  echo "$MY_CLAUDE_PID:$(hostname):$(date -u +%s)" > "$LOCK" 2>/dev/null || true
+  exit 0
+fi
+
+# Secondary mode. Block destructive git ops only — allow read-only git
+# commands (status, log, diff, show, branch, rev-parse, fetch).
+# Match the command at word boundaries.
+case "$CMD" in
+  *"git checkout"*|*"git switch"*|*"git reset --hard"*|*"git pull"*|*"git merge"*|*"git rebase"*|*"git stash pop"*|*"git stash apply"*|*"git stash drop"*|*"git clean"*|*"git branch -f"*|*"git branch -D"*|*"git push --force"*|*"git push -f"*)
+    cat <<EOF
+🚫 Another claude session (PID $LOCK_PID) owns this working tree.
+   This session is in SECONDARY mode — destructive git ops are blocked
+   to prevent the peer's HEAD from being swapped under them.
+
+   Attempted: $CMD
+
+   To work concurrently, spawn an isolated worktree:
+     git worktree add ../HF-myrole feat/your-branch
+     cd ../HF-myrole
+   Then start claude there. Lock is keyed on cwd hash → each worktree
+   gets its own primary slot.
+
+   Operator override (one-shot): set HF_FORCE_GIT=1 in the environment
+   before the tool call. Use only if you've confirmed the peer session
+   is finished or you accept the HEAD-swap risk.
+EOF
+    exit 2
+    ;;
+esac
+
+# Read-only git command → allow.
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,6 +1,37 @@
 #!/bin/bash
-# SessionStart hook — show quick context on session open
-# Outputs JSON with "message" field that Claude sees
+# SessionStart hook — show quick context on session open + claim the
+# working-tree lock so peer claude sessions sharing this tree see the
+# block. Per memory/feedback_concurrent_claude_pidlock_design.md.
+# Outputs JSON with "message" field that Claude sees.
+
+# Derive the working-tree lock key BEFORE cd, so worktree sessions
+# (which start in their own tree, not /Users/paulwander/projects/HF)
+# get a per-worktree key. Companion hooks (git-lock-enforcer.sh,
+# stop-release-lock.sh) compute the same way.
+TREE_TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")
+LOCK_KEY=$(printf '%s' "$TREE_TOPLEVEL" | shasum -a 256 | head -c8)
+LOCK="/tmp/claude-lock-$LOCK_KEY"
+
+# Walk one level up from this script's bash → the claude PID (our PPID
+# is the bash, PPID's parent is claude).
+MY_CLAUDE_PID=$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')
+LOCK_CONTENT="${MY_CLAUDE_PID:-$PPID}:$(hostname):$(date -u +%s)"
+
+# Try atomic claim. noclobber refuses to overwrite existing locks.
+if (set -o noclobber; echo "$LOCK_CONTENT" > "$LOCK") 2>/dev/null; then
+  LOCK_ROLE="primary"
+else
+  # Existing lock — read it and decide.
+  EXISTING_PID=$(cut -d: -f1 < "$LOCK" 2>/dev/null)
+  EXISTING_HOST=$(cut -d: -f2 < "$LOCK" 2>/dev/null)
+  if [ "$EXISTING_HOST" = "$(hostname)" ] && kill -0 "$EXISTING_PID" 2>/dev/null; then
+    LOCK_ROLE="secondary"
+  else
+    # Stale (dead PID or different host) → take over.
+    echo "$LOCK_CONTENT" > "$LOCK"
+    LOCK_ROLE="primary (reclaimed stale)"
+  fi
+fi
 
 cd /Users/paulwander/projects/HF || exit 0
 
@@ -28,6 +59,13 @@ if [ "$DIRTY" -gt 0 ]; then
 fi
 if [ "$PEER_COUNT" -gt 1 ]; then
   MSG="${MSG}🚨 $PEER_COUNT concurrent claude processes detected. They share this working tree — peer 'git checkout' calls will swap HEAD under you. Treat any unexplained branch change as confirmation. See memory/feedback_concurrent_claude_processes.md for recovery. "
+fi
+# Tell claude which lock role it claimed so it surfaces the right
+# expectations to the user.
+if [ "$LOCK_ROLE" = "secondary" ]; then
+  MSG="${MSG}🔒 SECONDARY claude session — destructive git ops (checkout/switch/reset/pull/merge/rebase/stash pop/clean/branch -f/push -f) are blocked in this tree. Spawn an isolated worktree to work concurrently: \`git worktree add ../HF-myrole feat/your-branch && cd ../HF-myrole\` then start claude there. Operator override per command: HF_FORCE_GIT=1. "
+elif [ "$LOCK_ROLE" = "primary (reclaimed stale)" ]; then
+  MSG="${MSG}🔒 Reclaimed a stale lock (previous owner gone). This session is now PRIMARY. "
 fi
 
 echo "$MSG"

--- a/.claude/hooks/stop-release-lock.sh
+++ b/.claude/hooks/stop-release-lock.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Stop hook — release the working-tree lock if this session owns it.
+#
+# Companion to git-lock-enforcer.sh and session-start.sh. Design:
+# feedback_concurrent_claude_pidlock_design.md.
+#
+# If the lock file's recorded PID is our claude session, delete it so
+# the next session in this cwd can claim primary cleanly. If it's a
+# different (alive) PID, leave it alone — that's a peer we don't own.
+#
+# Never errors — stop hooks should be silent on the happy path.
+
+set -u
+
+TREE_TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")
+LOCK_KEY=$(printf '%s' "$TREE_TOPLEVEL" | shasum -a 256 | head -c8)
+LOCK="/tmp/claude-lock-$LOCK_KEY"
+
+[ -f "$LOCK" ] || exit 0
+
+LOCK_PID=$(cut -d: -f1 < "$LOCK" 2>/dev/null)
+[ -n "$LOCK_PID" ] || exit 0
+
+MY_PPID="$PPID"
+MY_CLAUDE_PID=$(ps -o ppid= -p "$MY_PPID" 2>/dev/null | tr -d ' ')
+
+if [ "$LOCK_PID" = "$MY_CLAUDE_PID" ] || [ "$LOCK_PID" = "$MY_PPID" ]; then
+  rm -f "$LOCK"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,11 @@
             "type": "command",
             "command": "/Users/paulwander/projects/HF/.claude/hooks/branch-drift-detector.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "/Users/paulwander/projects/HF/.claude/hooks/git-lock-enforcer.sh",
+            "timeout": 3
           }
         ]
       }
@@ -65,6 +70,10 @@
           {
             "type": "command",
             "command": "/Users/paulwander/projects/HF/.claude/hooks/stop-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": "/Users/paulwander/projects/HF/.claude/hooks/stop-release-lock.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,17 +94,18 @@ If you discover work has started on `main`, stop and move it: `git checkout -b <
 
 **Rules:**
 
-1. **Check at session start.** The `SessionStart` hook prints `🚨 N concurrent claude processes detected` when peers exist. Treat it as a hard warning — every `git status` claim is suspect until proven.
-2. **`PreToolUse:Bash` runs the drift detector.** It snapshots HEAD per session and surfaces a loud warning when HEAD drifts between Bash calls without an explicit checkout/reset/pull in the current call. Read the warning — it's the smoking gun for peer interference.
-3. **If you spawn peer agents that touch code, use `isolation: "worktree"` on the `Agent` tool.** Each parallel agent then gets its own `git worktree add ../HF-feat-X feat/X-…` checkout. The `Agent` tool already supports this. Never spawn code-touching agents into the shared working tree.
-4. **Recovery when drift hits:**
+1. **Check at session start.** The `SessionStart` hook prints `🚨 N concurrent claude processes detected` when peers exist, and also reports the working-tree lock role (PRIMARY / SECONDARY / RECLAIMED). Treat the SECONDARY banner as a hard signal — destructive git in this tree will be blocked.
+2. **`PreToolUse:Bash` runs two hooks:** `branch-drift-detector.sh` (warn-only, fires on unexplained HEAD swap between tool calls) and `git-lock-enforcer.sh` (hard block on destructive git from secondary sessions — `checkout`, `switch`, `reset --hard`, `pull`, `merge`, `rebase`, `stash pop/apply/drop`, `clean`, `branch -f/-D`, `push --force`). Read-only git (`status`, `log`, `diff`, `branch`, `rev-parse`, `fetch`) and all non-git commands always pass.
+3. **If you spawn peer agents that touch code, use `isolation: "worktree"` on the `Agent` tool.** Each parallel agent then gets its own `git worktree add ../HF-feat-X feat/X-…` checkout. The lock is keyed on `git rev-parse --show-toplevel`, so every worktree is its own PRIMARY slot — concurrent worktree sessions never block each other.
+4. **Operator override (one-shot):** export `HF_FORCE_GIT=1` before the blocked command. Use only when you have confirmed the peer is finished or you accept the HEAD-swap risk.
+5. **Recovery when drift hits anyway:**
    - `git stash --include-untracked -m '<work-description>'`
    - `git reflog | head -10` — find your last known-good HEAD (the one *before* the unexplained `checkout: moving from X to Y`)
    - `git branch -f <correct-branch> <commit>` and `git checkout <correct-branch>`
    - `git stash pop` — should apply cleanly since the working tree is at the expected base
-5. **Don't shell out to `pkill claude` to fix this.** Peer sessions may be doing legitimate work the operator launched intentionally. Ask before killing.
+6. **Don't shell out to `pkill claude` to fix this.** Peer sessions may be doing legitimate work the operator launched intentionally. Ask before killing.
 
-Memory: [feedback_concurrent_claude_processes.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/feedback_concurrent_claude_processes.md).
+Memory: [feedback_concurrent_claude_processes.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/feedback_concurrent_claude_processes.md), [feedback_concurrent_claude_pidlock_design.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/feedback_concurrent_claude_pidlock_design.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #841. The drift detector that just merged tells you HEAD swapped *after the fact*. This PR **prevents** it by blocking destructive git ops from secondary claude sessions sharing the same working tree.

Per the design in `memory/feedback_concurrent_claude_pidlock_design.md`.

## What changed

| File | Change |
|------|--------|
| `.claude/hooks/session-start.sh` | Atomic noclobber claim of `/tmp/claude-lock-<key>` BEFORE the existing cd-and-status logic. Reports `PRIMARY` / `SECONDARY` / `RECLAIMED` role in the session-start message |
| `.claude/hooks/git-lock-enforcer.sh` (NEW) | `PreToolUse:Bash` hook. Allows all non-git and read-only git. Blocks (exit 2 + actionable text) destructive git when the lock is owned by a peer alive on this host |
| `.claude/hooks/stop-release-lock.sh` (NEW) | `Stop` hook. Releases the lock only when this session owns it |
| `.claude/settings.json` | Wires both new hooks |
| `CLAUDE.md` | Rewritten §"No concurrent claude sessions" |

## Lock key

`sha256(git rev-parse --show-toplevel) | head -c8`. **Worktrees get distinct keys** — concurrent worktree-isolated sessions never block each other. Same-tree concurrent sessions clash on the same key → one is primary, the other is secondary.

## Blocked commands (destructive git only)

`checkout`, `switch`, `reset --hard`, `pull`, `merge`, `rebase`, `stash pop`, `stash apply`, `stash drop`, `clean`, `branch -f`, `branch -D`, `push --force`, `push -f`.

Read-only git (`status`, `log`, `diff`, `show`, `branch`, `rev-parse`, `fetch`) and all non-git commands always pass.

## Block message

```
🚫 Another claude session (PID X) owns this working tree.
   This session is in SECONDARY mode — destructive git ops are blocked
   to prevent the peer's HEAD from being swapped under them.

   Attempted: git checkout main

   To work concurrently, spawn an isolated worktree:
     git worktree add ../HF-myrole feat/your-branch
     cd ../HF-myrole
   Then start claude there.

   Operator override (one-shot): set HF_FORCE_GIT=1 in the environment
   before the tool call.
```

## Smoke tests (verified in shipping session)

| Scenario | Expected | Got |
|----------|----------|-----|
| No lock → read-only and destructive git | both allowed | ✓ |
| Same-host live alien PID → `git checkout` | blocked, exit 2 | ✓ |
| `HF_FORCE_GIT=1` → `git checkout` | bypass | ✓ |
| Stale (dead) PID → `git checkout` | silent takeover | ✓ |
| Different host (NFS scenario) → block | ignored | ✓ |
| Secondary → read-only git | allowed | ✓ |
| Secondary → non-git command | allowed | ✓ |
| Stop hook with own PID | removes lock | ✓ |
| Stop hook with foreign PID | leaves lock | ✓ |

The enforcer also self-validated in production: a leftover stale lock from one of the tests pointed at a random live PID (Finder), and the next Bash tool call from this same session was correctly blocked. Meta-validation.

## Memory

`feedback_concurrent_claude_pidlock_design.md` updated to `SHIPPED 2026-05-26` with two correctness deltas from the original design:
1. Lock key uses `git rev-parse --show-toplevel` (worktree-aware) rather than raw `$PWD`.
2. PID identification walks one level up via `ps -o ppid= -p $PPID` to identify the claude session, not the bash subshell.

## Deploy

`/vm-cp` (hook scripts only; no app code).

## Test plan

- [x] Smoke tests in shipping session
- [ ] Open a second claude in this same repo path → it should see `🔒 SECONDARY` in session-start banner + `git checkout` should hit the block
- [ ] Open a third claude in a `git worktree add ../HF-test` directory → it should claim PRIMARY in its own tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)