### PR TITLE
chore(help): refresh page-help registry for Tolerances UI (#843 + #851)

### DIFF
--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -104,8 +104,8 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       {
         id: "design",
         label: "Design",
-        about: "Welcome flow, session flow, mid-survey, and audience — the shape of how a learner experiences the course.",
-        whenToUse: "When you want to change how sessions begin, what's asked partway through, or who the course is for.",
+        about: "Welcome flow, session flow, mid-survey, audience, and tolerances — the shape of how a learner experiences the course. Tolerances cover the mastery threshold (how high a learner has to score before the AI moves on), retrieval cadence (how often the AI fires recall questions), and memory decay scale (how fast prior-call memories fade).",
+        whenToUse: "When you want to change how sessions begin, what's asked partway through, who the course is for, or how strict the AI is about mastery before advancing.",
       },
       {
         id: "curriculum",
@@ -187,8 +187,8 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       {
         id: "tune",
         label: "Tune",
-        about: "Per-learner tuning overrides — chat with the AI to nudge how it behaves for this specific learner.",
-        whenToUse: "When this learner needs something different from the cohort default (slower pace, gentler tone, etc.).",
+        about: "Per-learner tuning overrides. Two surfaces: (1) the EQ-style sidebar with behaviour-target dials (warmth, challenge, etc.), an Approach picker (style/audience/mode), and a per-learner mastery threshold slider; (2) the Cmd+K Tuning chat for guided nudges. Saves at learner scope only affect this caller; saves at course scope cascade to everyone enrolled.",
+        whenToUse: "When this learner needs something different from the cohort default — slower pace, gentler tone, a lower or higher mastery bar before advancing.",
       },
       {
         id: "how",


### PR DESCRIPTION
Two `about` / `whenToUse` strings in `lib/help/page-help.ts` were stale after this session's Tolerances work.

## What changed

| Page / tab | Before | After |
|---|---|---|
| Course detail → **Design** | "Welcome flow, session flow, mid-survey, and audience" | "Welcome flow, session flow, mid-survey, audience, **and tolerances** — the shape of how a learner experiences the course. Tolerances cover the mastery threshold, retrieval cadence, and memory decay scale." |
| Learner detail → **Tune** | "Per-learner tuning overrides — chat with the AI" | "Per-learner tuning overrides. Two surfaces: (1) the EQ-style sidebar with behaviour-target dials, an Approach picker, and a **per-learner mastery threshold slider**; (2) the Cmd+K Tuning chat for guided nudges." |

## Why this matters

`PAGE_HELP_REGISTRY` feeds three surfaces:
1. The Help Overlay (#686) shown on `H ?`
2. Tab hover-tooltips (#689)
3. DATA-mode chat context injection (#813) — the AI Assistant reads from this when answering "where do I configure X"

Stale entries silently mislead all three. Refreshing here lands the new feature names everywhere at once.

## No CI guard caught this

The freshness guard story is **#812** (open, parented under epic #808). Until that ships, refreshing help on every shipping UI change is a manual rule. Two visible escapes from this session — Course Design Tolerances section + Tune sidebar Tolerances slider — are documented now; future UI work should follow the same discipline.

## Quality gates

- `npm run test tests/lib/page-help.test.ts` → 22/22 pass (route matching + chord rules unchanged)
- `npm run ratchet:check` → all four metrics at baseline
- No schema / route / chord changes

## Deploy

No deploy needed — text-only. Effective immediately on merge for new sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)