### PR TITLE
fix(#849): PID lock regex word boundaries + orphan-non-claude reclaim

### DIFF
--- a/.claude/hooks/git-lock-enforcer.sh
+++ b/.claude/hooks/git-lock-enforcer.sh
@@ -84,18 +84,40 @@ if [ "$LOCK_PID" = "$MY_CLAUDE_PID" ] || [ "$LOCK_PID" = "$MY_PPID" ]; then
   exit 0
 fi
 
-# Check if the lock PID is alive.
+# Check if the lock PID is alive AND a claude process. An alive PID that
+# isn't a claude (e.g. an orphan zsh, Finder) is a stale lock — the previous
+# claude crashed before its Stop hook released the lock, and the OS later
+# reassigned the PID to something unrelated. Without the comm check the
+# hook would forever treat that lock as a live peer and block this session.
+# (Bug fix on top of #849, reported during the cleanup pass that followed
+#  the merge.)
+LOCK_PROC=$(ps -o comm= -p "$LOCK_PID" 2>/dev/null | tr -d ' ')
 if ! kill -0 "$LOCK_PID" 2>/dev/null; then
-  # Stale lock → reclaim silently for this session.
+  # Stale lock (dead PID) → reclaim silently for this session.
   echo "$MY_CLAUDE_PID:$(hostname):$(date -u +%s)" > "$LOCK" 2>/dev/null || true
   exit 0
 fi
+case "$LOCK_PROC" in
+  claude|*/claude)
+    : # Live claude — fall through to secondary-mode check below.
+    ;;
+  *)
+    # Live PID but not a claude — orphan lock. Reclaim silently.
+    echo "$MY_CLAUDE_PID:$(hostname):$(date -u +%s)" > "$LOCK" 2>/dev/null || true
+    exit 0
+    ;;
+esac
 
 # Secondary mode. Block destructive git ops only — allow read-only git
-# commands (status, log, diff, show, branch, rev-parse, fetch).
-# Match the command at word boundaries.
-case "$CMD" in
-  *"git checkout"*|*"git switch"*|*"git reset --hard"*|*"git pull"*|*"git merge"*|*"git rebase"*|*"git stash pop"*|*"git stash apply"*|*"git stash drop"*|*"git clean"*|*"git branch -f"*|*"git branch -D"*|*"git push --force"*|*"git push -f"*)
+# commands (status, log, diff, show, branch -list, rev-parse, fetch).
+#
+# Match keywords at word boundaries via a regex with bash's =~ operator
+# (shell glob patterns in `case` substring-match and would over-block —
+# e.g. `*"git merge"*` matches `git merge-base`, which is a read).
+# Each alternative is anchored on the trailing side by space or
+# end-of-string so the keyword can't be part of a longer command name.
+GIT_BLOCK_RE='git[[:space:]]+(checkout|switch|reset[[:space:]]+--hard|pull|merge|rebase|stash[[:space:]]+(pop|apply|drop)|clean|branch[[:space:]]+-[fD]|push[[:space:]]+(--force|-f))([[:space:]]|$)'
+if [[ "$CMD" =~ $GIT_BLOCK_RE ]]; then
     cat <<EOF
 🚫 Another claude session (PID $LOCK_PID) owns this working tree.
    This session is in SECONDARY mode — destructive git ops are blocked
@@ -114,8 +136,7 @@ case "$CMD" in
    is finished or you accept the HEAD-swap risk.
 EOF
     exit 2
-    ;;
-esac
+fi
 
 # Read-only git command → allow.
 exit 0


### PR DESCRIPTION
Two false-positive bugs in the #849 PID lock surfaced during the housekeeping pass right after it merged. Both were blocking the lock-owner's OWN claude session from legitimate git operations.

## Bug 1 — `git merge-base` blocked as if it were `git merge`

The block list used shell-glob `case` patterns like `*"git merge"*` which substring-match. `git merge-base --is-ancestor X Y` (a read-only ancestry check) matched the `merge` pattern and was rejected with exit 2. Same class affects `git rebase --abort` and any git verb that prefixes one of the blocked tokens.

**Fix:** switch from glob `case` to bash `[[ $CMD =~ regex ]]` with each blocked keyword anchored on the trailing side by `[[:space:]]|$`. `merge` doesn't match `merge-base` any more.

## Bug 2 — Orphan lock owned by a non-claude PID blocks forever

When a previous claude session crashes before its Stop hook releases the lock, the OS may later reassign the PID to an unrelated process (observed: a stray `-zsh` from a Finder-spawned shell). The pre-fix hook only checked `kill -0 $LOCK_PID` for liveness — a live-but-unrelated PID was treated as a live peer claude, leaving every subsequent claude stuck in SECONDARY mode until manual `rm /tmp/claude-lock-*`.

**Fix:** also check `ps -o comm= -p $LOCK_PID`. If comm isn't `claude` or `*/claude`, reclaim the lock silently. Lock takeover now matches the design intent: a lock represents a LIVE CLAUDE peer, not a live arbitrary process.

## Both bugs flagged by #849 itself

The merge commit's body even documented this: *"tests left stale lock entries pointing at random live PIDs (e.g. Finder), which then blocked the test session's own git commands."* The fix was deferred at the time. This PR ships it for real. Bug 1 was a fresh discovery during the same cleanup.

## Verified

| Test | Pre-fix | Post-fix |
|---|---|---|
| `git merge-base --is-ancestor A B` | exit 2 ❌ | exit 0 ✓ |
| `git merge feature` with a dead lock-PID | exit 0 (reclaim) ✓ | exit 0 (reclaim) ✓ |
| `git status` | exit 0 ✓ | exit 0 ✓ |
| Lock owned by live non-claude PID (zsh / Finder) | **exit 2 ❌** (blocks forever) | **exit 0** (reclaim) ✓ |

## Quality gates

- `bash -n` clean
- No new tests added (existing infra doesn't have a test harness for the bash hooks; the design doc `feedback_concurrent_claude_pidlock_design.md` documents the contract). Shell-level smoke tests above served as verification.
- No `apps/admin/` changes — pure hook script — so tsc / ratchet unchanged.

## Built in a worktree

`git worktree add ../HF-849-fixes origin/main` per the discipline that #849 itself enforces. Branch `fix/849-pid-lock-regex-and-orphan`.

## Deploy

No deploy needed — hooks effective on next session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)