### PR TITLE
feat(chat): inject page feature catalogue into DATA mode (#812)

### DIFF
--- a/apps/admin/app/api/chat/system-prompts.ts
+++ b/apps/admin/app/api/chat/system-prompts.ts
@@ -8,6 +8,7 @@ import { loadTicketContext, loadRecentTicketsDigest } from "@/lib/chat/ticket-co
 import { getPromptSpec } from "@/lib/prompts/spec-prompts";
 import { config } from "@/lib/config";
 import { buildPageContextBlock, type PageContextHint } from "./page-context";
+import { buildPageFeatureCatalogue } from "@/lib/chat/page-feature-catalogue";
 
 export type { PageContextHint };
 
@@ -142,7 +143,8 @@ export async function buildSystemPrompt(
         buildFeedbackListHintBlock(options, userRole, institutionId),
       ]);
       const pageBlock = buildPageContextBlock(options?.pageContext);
-      return { prompt: dataPrompt + "\n\n" + tuningContext + termBlock + runtimeBlock + pageBlock + `\n\n${baseContext}` + ticketBlock + listHintBlock };
+      const featureCatalogueBlock = buildPageFeatureCatalogue(options?.pageHintRoute);
+      return { prompt: dataPrompt + "\n\n" + tuningContext + termBlock + runtimeBlock + pageBlock + featureCatalogueBlock + `\n\n${baseContext}` + ticketBlock + listHintBlock };
     }
     case "TUNING": {
       // TUNING mode: catalogue + truthfulness rules + scope-aware write tools.

--- a/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
+++ b/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { buildPageFeatureCatalogue } from "../page-feature-catalogue";
+
+describe("buildPageFeatureCatalogue", () => {
+  it("returns empty string for unknown route", () => {
+    expect(buildPageFeatureCatalogue("/does-not-exist")).toBe("");
+  });
+
+  it("returns empty string when pathname is undefined", () => {
+    expect(buildPageFeatureCatalogue(undefined)).toBe("");
+  });
+
+  it("returns empty string when pathname is empty", () => {
+    expect(buildPageFeatureCatalogue("")).toBe("");
+  });
+
+  it("renders the page title + about for a known tabbed route", () => {
+    const out = buildPageFeatureCatalogue("/x/courses/abc-123");
+    expect(out).toContain("Course detail");
+    expect(out).toContain("PAGE_HELP_REGISTRY");
+  });
+
+  it("lists every tab label registered for Course detail", () => {
+    const out = buildPageFeatureCatalogue("/x/courses/abc-123");
+    for (const label of ["Content", "Design", "Curriculum", "Learners", "Proof Points", "Goals", "Settings"]) {
+      expect(out).toContain(label);
+    }
+  });
+
+  it("lists every tab label registered for Learner detail", () => {
+    const out = buildPageFeatureCatalogue("/x/callers/caller-xyz");
+    for (const label of ["Overview", "Uplift", "Calls", "Tune", "How", "What", "Artifacts", "AI Call"]) {
+      expect(out).toContain(label);
+    }
+  });
+
+  it("renders an entry for the Courses index (no tabs)", () => {
+    const out = buildPageFeatureCatalogue("/x/courses");
+    expect(out).toContain("Courses");
+    // No tabs registered for /x/courses — the Tabs section must NOT appear.
+    expect(out).not.toContain("Tabs on this page");
+  });
+
+  it("flags operator-only tabs", () => {
+    const out = buildPageFeatureCatalogue("/x/courses/abc-123");
+    // Settings is operator-only on Course detail.
+    expect(out).toMatch(/\*\*Settings\*\*.*operator-only/);
+  });
+
+  it("stays under ~500-token budget (2000 chars proxy) for every registered page", () => {
+    const routes = [
+      "/x/get-started-v5",
+      "/x/courses",
+      "/x/courses/abc-123",
+      "/x/callers",
+      "/x/callers/learner-xyz",
+    ];
+    for (const route of routes) {
+      const out = buildPageFeatureCatalogue(route);
+      expect(
+        out.length,
+        `${route} catalogue exceeded 2000-char budget (got ${out.length})`,
+      ).toBeLessThanOrEqual(2000);
+    }
+  });
+});

--- a/apps/admin/lib/chat/page-feature-catalogue.ts
+++ b/apps/admin/lib/chat/page-feature-catalogue.ts
@@ -1,0 +1,42 @@
+/**
+ * #812 — DATA-mode feature catalogue: serialise the matching PAGE_HELP_REGISTRY
+ * entry for the user's current route into a block the assistant can read.
+ *
+ * Why a separate block from #809's `pageContext`:
+ *   - #809 says "the user is on /x/courses/abc, on the Design tab" (live state)
+ *   - #812 says "this page has these tabs: Content, Design, Curriculum, …"
+ *     and what each one is for (static feature inventory)
+ *
+ * Together the assistant knows both *where* the user is and *what exists* on
+ * the page, so questions like "tell me about Felt Progress" stop returning
+ * "I don't see that section" — the registry is the single source of truth.
+ *
+ * Token budget: stays under ~500 tokens (2000-char proxy) for any single page
+ * in PAGE_HELP_REGISTRY. The `whenToUse` hover-help line is deliberately
+ * omitted — it largely restates the `about` field for the human reader and
+ * pushed Course detail (7 tabs) over budget. The `about` field alone is
+ * enough for the assistant to answer "what is the X tab?".
+ */
+
+import { getPageHelp } from "@/lib/help/page-help";
+
+export function buildPageFeatureCatalogue(pathname: string | undefined): string {
+  if (!pathname) return "";
+  const help = getPageHelp(pathname);
+  if (!help) return "";
+
+  const lines: string[] = [
+    `## Page features (from PAGE_HELP_REGISTRY)`,
+    `Page: **${help.title}** — ${help.about}`,
+  ];
+
+  if (help.tabs && help.tabs.length > 0) {
+    lines.push("", `Tabs on this page:`);
+    for (const tab of help.tabs) {
+      const operatorMark = tab.requiresOperator ? " _(operator-only)_" : "";
+      lines.push(`- **${tab.label}** (\`${tab.id}\`)${operatorMark} — ${tab.about}`);
+    }
+  }
+
+  return `\n\n${lines.join("\n")}`;
+}


### PR DESCRIPTION
## Summary

Closes #812. DATA-mode AI assistant previously had no idea what tabs/sections existed on the user's current page — it would answer "I don't see that section" when asked about visible UI. PAGE_HELP_REGISTRY was the single source of truth for page features but nothing on the AI side consumed it.

- `lib/chat/page-feature-catalogue.ts` — new `buildPageFeatureCatalogue(pathname)` helper. Reads `getPageHelp()` and serialises page title + tab inventory (label, id, about, operator-only flag) into a markdown block.
- `app/api/chat/system-prompts.ts` — wired into DATA mode only, keyed on the existing `pageHintRoute`. WIZARD / CALL / TUNING / BUG modes unchanged.
- 9 unit tests including a per-page token-budget assertion (Course detail renders to ~350 tokens, well under the 500 cap).

Complementary to #809 (page-context says *where* the user is; this says *what exists* on the page).

## Test plan
- [x] `npm run test -- lib/chat/__tests__/page-feature-catalogue.test.ts` — 9/9 pass
- [ ] After merge: open Cmd+K on `/x/courses/<id>` → DATA mode → ask "what tabs are on this page?" — assistant lists Content, Design, Curriculum, Learners, Proof Points, Goals, Settings from the registry
- [ ] Same on `/x/callers/<id>` — assistant lists Overview, Uplift, Calls, Tune, How, What, Artifacts, AI Call
- [ ] Open a CALL sim — confirm no `## Page features` block leaks into the voice prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)