### PR TITLE
feat(help): freshness guard for PAGE_HELP_REGISTRY + Felt Progress (#810)

### DIFF
--- a/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
+++ b/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
@@ -47,7 +47,12 @@ describe("buildPageFeatureCatalogue", () => {
     expect(out).toMatch(/\*\*Settings\*\*.*operator-only/);
   });
 
-  it("stays under ~500-token budget (2000 chars proxy) for every registered page", () => {
+  it("stays under ~700-token budget (2800 chars proxy) for every registered page", () => {
+    // #810 raised the cap from ~500 tokens (2000 chars) to ~700 tokens (2800
+    // chars). The Design tab now exports 5 named `sections` (Felt Progress,
+    // Tolerances, etc.) so the AI can answer section-level questions, which
+    // costs ~120 extra tokens per render. Cheap given DATA-mode runs Sonnet
+    // 4.5 — the grounding wins are worth more than the bytes.
     const routes = [
       "/x/get-started-v5",
       "/x/courses",
@@ -59,8 +64,8 @@ describe("buildPageFeatureCatalogue", () => {
       const out = buildPageFeatureCatalogue(route);
       expect(
         out.length,
-        `${route} catalogue exceeded 2000-char budget (got ${out.length})`,
-      ).toBeLessThanOrEqual(2000);
+        `${route} catalogue exceeded 2800-char budget (got ${out.length})`,
+      ).toBeLessThanOrEqual(2800);
     }
   });
 });

--- a/apps/admin/lib/chat/page-feature-catalogue.ts
+++ b/apps/admin/lib/chat/page-feature-catalogue.ts
@@ -16,6 +16,11 @@
  * omitted — it largely restates the `about` field for the human reader and
  * pushed Course detail (7 tabs) over budget. The `about` field alone is
  * enough for the assistant to answer "what is the X tab?".
+ *
+ * #810: `tab.sections` (named `<CollapsibleCard>` blocks like Felt Progress on
+ * the Design tab) are rendered as a nested bullet under their parent tab so
+ * the assistant can answer "tell me about Felt Progress" the same way it
+ * answers tab-level questions.
  */
 
 import { getPageHelp } from "@/lib/help/page-help";
@@ -35,6 +40,11 @@ export function buildPageFeatureCatalogue(pathname: string | undefined): string 
     for (const tab of help.tabs) {
       const operatorMark = tab.requiresOperator ? " _(operator-only)_" : "";
       lines.push(`- **${tab.label}** (\`${tab.id}\`)${operatorMark} — ${tab.about}`);
+      if (tab.sections && tab.sections.length > 0) {
+        for (const section of tab.sections) {
+          lines.push(`    - **${section.title}** — ${section.about}`);
+        }
+      }
     }
   }
 

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -1,8 +1,8 @@
 /**
  * Page-scoped help registry. Each route declares its title, about copy,
  * tab explanations, and chord bindings here. The Help Overlay (#686),
- * chord engine (#688), and tab hover-tooltips (#689) all read from this
- * single source.
+ * chord engine (#688), tab hover-tooltips (#689), and DATA-mode AI
+ * assistant catalogue (#812) all read from this single source.
  *
  * Letter mapping rule for chord `keys`:
  *   - First letter of the tab label is preferred
@@ -14,6 +14,19 @@
  * chord prefix), which would collide with Overview=`O` on Learner detail —
  * but they live on different routes so no runtime conflict. Document any
  * future cross-page collision in the page's entry comment.
+ *
+ * Freshness rule (#810):
+ *   When shipping a new tab OR a new named section (a `<CollapsibleCard>`
+ *   on a tabbed page) on any route covered by this registry, add the entry
+ *   here in the SAME PR. Felt Progress (#779/#780/#784/#790/#795 →
+ *   epic #808) is the canonical example of what happens when you don't:
+ *   the section shipped, the Help modal didn't know, and the AI assistant
+ *   answered "I don't see that section" when users asked about it.
+ *
+ *   `tests/lib/page-help.test.ts` enforces this for the Design tab by
+ *   parsing `CourseDesignTab.tsx` and asserting every `<CollapsibleCard
+ *   title="X">` has a matching entry in `tabs.find(design).sections[]`.
+ *   Mirror the test for new tabbed pages that grow named sections.
  */
 
 export interface PageHelp {
@@ -42,6 +55,24 @@ export interface TabHelp {
   whenToUse?: string;
   /** When true, hide from VIEWER/STUDENT/TESTER (only show to OPERATOR+). */
   requiresOperator?: boolean;
+  /**
+   * Named sections inside the tab — usually `<CollapsibleCard title="X">`
+   * blocks. Populated only when the tab grows non-trivial sub-features the
+   * AI assistant and Help modal need to know about. The freshness test
+   * (#810) parses the source TSX and fails CI if a new card ships without
+   * a matching entry here.
+   */
+  sections?: SectionHelp[];
+}
+
+export interface SectionHelp {
+  /**
+   * MUST match the `<CollapsibleCard title="...">` string in the source
+   * exactly — the freshness test compares titles by exact equality.
+   */
+  title: string;
+  /** 1–2 sentences. What this section is for in plain English. */
+  about: string;
 }
 
 export interface ChordBinding {
@@ -104,8 +135,30 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       {
         id: "design",
         label: "Design",
-        about: "Welcome flow, session flow, mid-survey, audience, and tolerances — the shape of how a learner experiences the course. Tolerances cover the mastery threshold (how high a learner has to score before the AI moves on), retrieval cadence (how often the AI fires recall questions), and memory decay scale (how fast prior-call memories fade).",
-        whenToUse: "When you want to change how sessions begin, what's asked partway through, who the course is for, or how strict the AI is about mastery before advancing.",
+        about: "Welcome flow, session flow, Felt Progress acknowledgements, first-session behaviour, tolerances, and skill banding — the shape of how a learner experiences the course. Tolerances cover the mastery threshold (how high a learner has to score before the AI moves on), retrieval cadence (how often the AI fires recall questions), and memory decay scale (how fast prior-call memories fade).",
+        whenToUse: "When you want to change how sessions begin, what's acknowledged mid-call, how Call 1 behaves differently from later calls, who the course is for, or how strict the AI is about mastery before advancing.",
+        sections: [
+          {
+            title: "Session Flow",
+            about: "Canonical session-flow editor — before / during / after phases, intake, NPS, welcome. Absorbed from the retired Session Flow tab.",
+          },
+          {
+            title: "Felt Progress",
+            about: "Mid-call acknowledgement cues + structured offboarding summary. Lets the AI say 'here's what we covered today' before hanging up so learners feel forward motion. Shipped across #779, #780, #784, #790, #795.",
+          },
+          {
+            title: "Call 1 / First Session",
+            about: "First-session-only behaviour: firstCallMode preset, behaviour-target overrides for the opening call, and a course-ref preview of what the AI will say.",
+          },
+          {
+            title: "Tolerances",
+            about: "Course-default Mastery Threshold (how high a learner scores before the AI advances), Retrieval Cadence Override (how often recall questions fire), and Memory Decay Scale (how fast prior-call memories fade). The per-learner Mastery Threshold override lives in PromptTunerSidebar on the caller page.",
+          },
+          {
+            title: "Skill Banding",
+            about: "Per-course tier-mapping override for skill scoring. Lets a course use a stricter or gentler banding curve than the system default.",
+          },
+        ],
       },
       {
         id: "curriculum",

--- a/apps/admin/tests/lib/page-help.test.ts
+++ b/apps/admin/tests/lib/page-help.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
 import {
   PAGE_HELP_REGISTRY,
   getPageHelp,
@@ -148,6 +150,62 @@ describe("page-help registry", () => {
       expect(canSeeOperatorOnly(undefined)).toBe(false);
       expect(canSeeOperatorOnly(null)).toBe(false);
       expect(canSeeOperatorOnly("")).toBe(false);
+    });
+  });
+
+  /**
+   * #810 freshness guard.
+   *
+   * The Felt Progress regression (epic #808) shipped a new `<CollapsibleCard
+   * title="Felt Progress">` on the Design tab across 5 PRs without anyone
+   * updating PAGE_HELP_REGISTRY. The Help modal stayed silent; the DATA-mode
+   * AI assistant answered "I don't see that section". This block parses the
+   * source TSX for every `<CollapsibleCard title="X">` on the Design tab and
+   * asserts each title is registered under `tabs.find(design).sections[]`.
+   *
+   * To extend to a new tabbed page: copy the parse block, point `sourceFile`
+   * at the tab component, and add the registry assertion.
+   */
+  describe("freshness guard — Course detail Design tab (#810)", () => {
+    const sourceFile = path.resolve(
+      __dirname,
+      "../../app/x/courses/[courseId]/CourseDesignTab.tsx",
+    );
+    const source = fs.readFileSync(sourceFile, "utf-8");
+    const cardTitles = Array.from(
+      source.matchAll(/<CollapsibleCard\s+title="([^"]+)"/g),
+      (m) => m[1],
+    );
+
+    it("source parse finds at least one CollapsibleCard (sanity)", () => {
+      expect(cardTitles.length).toBeGreaterThan(0);
+    });
+
+    it("every CollapsibleCard rendered on the Design tab has a registry entry", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      const designTab = entry?.tabs?.find((t) => t.id === "design");
+      expect(designTab, "Design tab missing from Course detail registry").toBeDefined();
+      const registeredTitles = (designTab?.sections ?? []).map((s) => s.title);
+      for (const title of cardTitles) {
+        expect(
+          registeredTitles,
+          `CourseDesignTab.tsx renders <CollapsibleCard title="${title}"> but no matching entry exists in PAGE_HELP_REGISTRY → tabs[design].sections. Add it to apps/admin/lib/help/page-help.ts so the Help modal and AI assistant know about it.`,
+        ).toContain(title);
+      }
+    });
+
+    it("Design tab `about` mentions Felt Progress so the Help modal surfaces it without HelpOverlay changes", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      const designTab = entry?.tabs?.find((t) => t.id === "design");
+      expect(designTab?.about.toLowerCase()).toContain("felt progress");
+    });
+
+    it("the Felt Progress section explicitly exists in the registry", () => {
+      const entry = getPageHelp("/x/courses/abc-123");
+      const designTab = entry?.tabs?.find((t) => t.id === "design");
+      const feltProgress = designTab?.sections?.find((s) => s.title === "Felt Progress");
+      expect(feltProgress).toBeDefined();
+      expect(feltProgress?.about.length).toBeGreaterThan(20);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #810. Felt Progress shipped across 5 PRs on the Course detail Design tab (#779/#780/#784/#790/#795) without anyone updating `PAGE_HELP_REGISTRY`. Help modal stayed silent, AI assistant answered "I don't see that section". This PR adds a structural section model + CI guard so the next Felt-Progress-class omission fails the build.

- `lib/help/page-help.ts` — new `SectionHelp` interface, optional `tabs[].sections?`. Course detail Design tab declares its 5 cards (Session Flow, Felt Progress, Call 1 / First Session, Tolerances, Skill Banding). Design tab `about` updated to mention Felt Progress so the Help modal surfaces it without `HelpOverlay.tsx` changes. Header convention comment added.
- `tests/lib/page-help.test.ts` — new `freshness guard` describe block (3 assertions) parses `<CollapsibleCard title="X">` from `CourseDesignTab.tsx` and fails CI when a registered card lacks a registry entry. Error message points the author at the file to update.
- `lib/chat/page-feature-catalogue.ts` (#812 carry-along) — render `tab.sections` as nested bullets so the DATA-mode AI assistant can answer section-level questions. Catalogue budget raised 500 → 700 tokens.

## Verified
- 35/35 tests pass (`tests/lib/page-help.test.ts` + `lib/chat/__tests__/page-feature-catalogue.test.ts`).
- Proof: removed Felt Progress from registry → freshness guard fails with `CourseDesignTab.tsx renders <CollapsibleCard title="Felt Progress"> but no matching entry exists … Add it to apps/admin/lib/help/page-help.ts`. Restored → pass.

## Test plan
- [x] Vitest passes locally
- [ ] After merge: open `/x/courses/<id>` → press `?` → Design tab description mentions Felt Progress
- [ ] Cmd+K on same page → DATA mode → ask "tell me about Felt Progress" — assistant describes mid-call ack + offboarding summary, no more "I don't see that"
- [ ] Future check: add a new `<CollapsibleCard title="Something">` to `CourseDesignTab.tsx` without registry update → CI fails with the actionable message

🤖 Generated with [Claude Code](https://claude.com/claude-code)