### PR TITLE
chore(ci): block on AI-CAPABILITIES.md drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,15 @@ jobs:
       - name: KNOWLEDGE-MAP.md ratchet
         run: npm run docs:knowledge-map:ci
 
+      # AI-CAPABILITIES.md drift guard (#866). Blocking. The doc is
+      # auto-derived from lib/chat/admin-tools.ts (the registry the AI
+      # reads at every chat turn). If a tool is added/changed/removed
+      # without regenerating, the doc silently lies — and humans rely
+      # on it to know which Cmd+K calls exist. Regen with
+      # `npm run docs:ai-capabilities`.
+      - name: AI-CAPABILITIES.md drift guard
+        run: npm run docs:ai-capabilities:check
+
   # Job 2: Unit Tests
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
## Summary

Promotes the `docs:ai-capabilities:check` command (added in #866) from "available script" to "blocking CI guard". Mirrors the existing `docs:knowledge-map:ci` treatment.

If a developer adds, changes, or removes a tool in `lib/chat/admin-tools.ts` without running `npm run docs:ai-capabilities`, CI now fails with a clear regen instruction. Closes the SPoT enforcement loop.

## Why blocking, not warn-only

The doc is what humans rely on to know which Cmd+K calls exist. The registry is what the AI reads. If they drift, one of them silently lies. Hard fail is correct.

## Test plan

- [x] Local `npm run docs:ai-capabilities:check` passes against current main
- [ ] CI passes on this branch (auto-merge will gate on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)