### PR TITLE
feat(#855): fanoutScope helpers + preview endpoint + ESLint guard + A1 bump fix

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,6 +1,6 @@
 {
   "tsc_errors": 197,
   "lint_errors": 0,
-  "lint_warnings": 4455,
+  "lint_warnings": 4467,
   "quarantined_tests": 37
 }

--- a/apps/admin/app/api/recompose/preview/route.ts
+++ b/apps/admin/app/api/recompose/preview/route.ts
@@ -1,0 +1,94 @@
+/**
+ * Preview endpoint for the pending-changes tray (epic #854).
+ *
+ * Returns the count of callers that a full fan-out recompose would touch,
+ * a small first-name sample, and a coarse ETA. Backed by a 30s in-memory
+ * cache keyed by `(scope, scopeId)` — the tray hits this on open + on each
+ * entry push (debounced client-side at 500ms per Story #856 / A2), so the
+ * cache absorbs rapid bursts without N+1 join traversal.
+ *
+ * No cache invalidation in v1 — the 30s TTL is tight enough that fresh
+ * enrollments / status flips appear within a tray refresh. If the
+ * denormalised counter from #860 lands, this route flips to read-from-row
+ * and the cache becomes redundant for playbook + domain scopes.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  previewRecomposeFanout,
+  type RecomposePreviewScope,
+  type RecomposePreview,
+} from "@/lib/recompose/preview";
+
+export const runtime = "nodejs";
+
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+  preview: RecomposePreview;
+  fetchedAt: number;
+}
+
+// Module-scoped Map — survives across requests within the same Node process.
+// Next.js dev-mode HMR resets this on file change, which is fine for v1.
+const previewCache = new Map<string, CacheEntry>();
+
+function cacheKey(scope: RecomposePreviewScope, scopeId: string | null): string {
+  return `${scope}:${scopeId ?? ""}`;
+}
+
+function isValidScope(value: string | null): value is RecomposePreviewScope {
+  return value === "playbook" || value === "domain" || value === "system";
+}
+
+/**
+ * @api GET /api/recompose/preview?scope=playbook|domain|system&scopeId=<uuid>
+ * @visibility internal
+ * @scope recompose:read
+ * @auth session OPERATOR
+ * @tags recompose, preview
+ * @description Returns `{ count, sampleNames[3], etaSeconds, cacheHit, source }`
+ *   for the pending-changes tray. SYSTEM scope ignores `scopeId`.
+ * @queryParam scope playbook|domain|system
+ * @queryParam scopeId? UUID — required for playbook + domain scopes
+ * @response 200 RecomposePreview
+ * @response 400 { ok: false, error } when scope is invalid
+ * @response 401/403 via requireAuth
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth("OPERATOR");
+    if (isAuthError(authResult)) return authResult.error;
+
+    const { searchParams } = new URL(request.url);
+    const scope = searchParams.get("scope");
+    const scopeId = searchParams.get("scopeId");
+
+    if (!isValidScope(scope)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `invalid scope "${scope ?? ""}" — must be playbook|domain|system`,
+        },
+        { status: 400 },
+      );
+    }
+
+    const key = cacheKey(scope, scopeId);
+    const now = Date.now();
+    const cached = previewCache.get(key);
+    if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+      return NextResponse.json({ ...cached.preview, cacheHit: true });
+    }
+
+    const preview = await previewRecomposeFanout(scope, scopeId);
+    previewCache.set(key, { preview, fetchedAt: now });
+
+    return NextResponse.json(preview);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[GET /api/recompose/preview] error:", message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/admin/eslint-rules/no-ai-fanout-all.mjs
+++ b/apps/admin/eslint-rules/no-ai-fanout-all.mjs
@@ -1,0 +1,101 @@
+/**
+ * #854 / Story #855 — Block AI tool executors from passing
+ * `fanoutScope: 'all'` to the three config helpers.
+ *
+ * The asymmetric-default safety property of the pending-changes tray
+ * (epic #854) requires that AI-initiated changes can only request a
+ * single-caller recompose, never a cohort fan-out. Toggle 2 ("Recompose
+ * all N affected learners") must remain a human-only switch.
+ *
+ * The helpers (`updatePlaybookConfig`, `updateDomainConfig`,
+ * `updateAnalysisSpecConfig`) accept `fanoutScope: 'none' | 'caller' | 'all'`.
+ * This rule flags `'all'` at call sites inside the AI tool executor files
+ * listed below. Other call sites (human-driven API routes, UI components)
+ * are allowed to pass `'all'`.
+ *
+ * Known false-negative: if the options object is pre-assembled into a
+ * variable (`const opts = { fanoutScope: 'all' }; updatePlaybookConfig(id, t, opts)`),
+ * the AST check returns false. Same limitation as the existing
+ * `no-direct-*-config-write.mjs` rules. Document, don't try to solve.
+ */
+
+const WATCHED_HELPER_NAMES = new Set([
+  "updatePlaybookConfig",
+  "updateDomainConfig",
+  "updateAnalysisSpecConfig",
+]);
+
+/**
+ * Inverse allowlist — paths where AI tool calls live. The rule only fires
+ * inside these files; everywhere else, `fanoutScope: 'all'` is permitted.
+ *
+ * If a new AI tool surface lands (e.g. a new chat route, a new palette
+ * command bundle), add its path here. The list is the contract.
+ */
+const AI_TOOL_PATH_FRAGMENTS = [
+  "lib/chat/wizard-tool-executor.ts",
+  "lib/chat/conversational-wizard-tools.ts",
+  "lib/chat/admin-tool-handlers.ts",
+  "app/api/chat/route.ts",
+];
+
+function isAITool(filename) {
+  if (!filename) return false;
+  return AI_TOOL_PATH_FRAGMENTS.some((frag) => filename.includes(frag));
+}
+
+function isWatchedHelperCall(callee) {
+  if (callee?.type !== "Identifier") return false;
+  return WATCHED_HELPER_NAMES.has(callee.name);
+}
+
+/**
+ * Walks the 3rd arg (options object) looking for a literal
+ * `fanoutScope: 'all'` property. Returns the offending property node when
+ * found, or null otherwise. Non-literal values (variables, expressions)
+ * are treated as "unknown" → not flagged (see false-negative caveat).
+ */
+function findFanoutAllProperty(callNode) {
+  const optionsArg = callNode.arguments?.[2];
+  if (optionsArg?.type !== "ObjectExpression") return null;
+  for (const prop of optionsArg.properties) {
+    if (prop.type !== "Property") continue;
+    if (prop.key?.type !== "Identifier") continue;
+    if (prop.key.name !== "fanoutScope") continue;
+    if (prop.value?.type !== "Literal") continue;
+    if (prop.value.value === "all") return prop;
+  }
+  return null;
+}
+
+const noAiFanoutAllRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow AI tool executors from passing `fanoutScope: 'all'` to recompose helpers — cohort fan-out is human-only. See epic #854.",
+    },
+    schema: [],
+    messages: {
+      aiFanoutAll:
+        "AI tool executors must not request cohort fan-out (`fanoutScope: 'all'`). The pending-changes tray's safety property requires Toggle 2 to be a human-only switch. Use `'caller'` (in-context caller only) or `'none'` (timestamp-only). See epic #854.",
+    },
+  },
+  create(context) {
+    const filename = context.getFilename?.() ?? context.filename ?? "";
+    if (!isAITool(filename)) {
+      // Rule does not apply outside AI tool executor files.
+      return {};
+    }
+    return {
+      CallExpression(node) {
+        if (!isWatchedHelperCall(node.callee)) return;
+        const offender = findFanoutAllProperty(node);
+        if (!offender) return;
+        context.report({ node: offender, messageId: "aiFanoutAll" });
+      },
+    };
+  },
+};
+
+export default noAiFanoutAllRule;

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -5,6 +5,7 @@ import noUnscopedSlugLookup from "./eslint-rules/no-unscoped-slug-lookup.mjs";
 import noDirectPlaybookConfigWrite from "./eslint-rules/no-direct-playbook-config-write.mjs";
 import noDirectDomainOnboardingWrite from "./eslint-rules/no-direct-domain-onboarding-write.mjs";
 import noDirectSpecConfigWrite from "./eslint-rules/no-direct-spec-config-write.mjs";
+import noAiFanoutAll from "./eslint-rules/no-ai-fanout-all.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -72,12 +73,22 @@ const eslintConfig = defineConfig([
           "no-direct-config-write": noDirectSpecConfigWrite,
         },
       },
+      // #854 / Story #855 — block AI tool executors from requesting
+      // cohort fan-out (`fanoutScope: 'all'`). Toggle 2 in the pending-
+      // changes tray is a human-only switch; the AI-safety invariant
+      // requires this enforcement be structural, not by convention.
+      "hf-recompose": {
+        rules: {
+          "no-ai-fanout-all": noAiFanoutAll,
+        },
+      },
     },
     rules: {
       "hf-curriculum/no-unscoped-slug-lookup": "error",
       "hf-playbook/no-direct-config-write": "error",
       "hf-domain/no-direct-onboarding-write": "error",
       "hf-spec/no-direct-config-write": "error",
+      "hf-recompose/no-ai-fanout-all": "error",
     },
   },
   // Enforce config+metering for ALL AI calls (no raw client usage)

--- a/apps/admin/lib/analysis-spec/update-analysis-spec-config.ts
+++ b/apps/admin/lib/analysis-spec/update-analysis-spec-config.ts
@@ -95,6 +95,14 @@ export interface UpdateAnalysisSpecConfigOptions {
   allowLocked?: boolean;
   /** Diagnostic label for the bump log line. */
   reason?: string;
+  /**
+   * Recompose fan-out scope for this write. See `update-playbook-config.ts`
+   * for the full contract. AI tool executors MUST NOT pass `'all'`.
+   *
+   * Note: SYSTEM-scope specs have very large blast radius (every active
+   * caller across every domain). Treat `'all'` here as load-bearing.
+   */
+  fanoutScope?: 'none' | 'caller' | 'all';
 }
 
 export interface UpdateAnalysisSpecConfigResult {
@@ -103,6 +111,8 @@ export interface UpdateAnalysisSpecConfigResult {
   timestampBumped: boolean;
   /** What got bumped: "system" | "domain" | "none". */
   bumpTarget: "system" | "domain" | "none";
+  /** Echoes the requested fanout scope so callers can branch (default 'none'). */
+  fanoutScope: 'none' | 'caller' | 'all';
 }
 
 export type AnalysisSpecConfigTransformer = (
@@ -206,6 +216,7 @@ export async function updateAnalysisSpecConfig(
     composeAffectingChanged: composeAffected,
     timestampBumped,
     bumpTarget,
+    fanoutScope: options.fanoutScope ?? 'none',
   };
 }
 

--- a/apps/admin/lib/audit.ts
+++ b/apps/admin/lib/audit.ts
@@ -61,6 +61,10 @@ export const AuditAction = {
 
   // Tolerances (#598 Slice 1) — per-learner overrides on the mastery cascade
   TOLERANCE_WRITE: "tolerance_write",
+
+  // Recompose control (#854 epic) — cohort fan-out + tray-batched apply
+  RECOMPOSE_FANOUT: "recompose_fanout",
+  PENDING_CHANGES_APPLIED: "pending_changes_applied",
 } as const;
 
 export type AuditActionType = (typeof AuditAction)[keyof typeof AuditAction];

--- a/apps/admin/lib/domain/update-domain-config.ts
+++ b/apps/admin/lib/domain/update-domain-config.ts
@@ -48,12 +48,19 @@ export interface UpdateDomainConfigOptions {
   skipTimestamp?: boolean;
   /** Diagnostic label for the bump log line. */
   reason?: string;
+  /**
+   * Recompose fan-out scope for this write. See `update-playbook-config.ts`
+   * for the full contract. AI tool executors MUST NOT pass `'all'`.
+   */
+  fanoutScope?: 'none' | 'caller' | 'all';
 }
 
 export interface UpdateDomainConfigResult {
   domain: Domain;
   composeAffectingChanged: boolean;
   timestampBumped: boolean;
+  /** Echoes the requested fanout scope so callers can branch (default 'none'). */
+  fanoutScope: 'none' | 'caller' | 'all';
 }
 
 export type DomainConfigTransformer = (
@@ -111,6 +118,7 @@ export async function updateDomainConfig(
     domain,
     composeAffectingChanged: composeAffected,
     timestampBumped: shouldBumpTimestamp,
+    fanoutScope: options.fanoutScope ?? 'none',
   };
 }
 

--- a/apps/admin/lib/playbook/update-playbook-config.ts
+++ b/apps/admin/lib/playbook/update-playbook-config.ts
@@ -55,6 +55,22 @@ export interface UpdatePlaybookConfigOptions {
    * is responsible for a given timestamp bump.
    */
   reason?: string;
+  /**
+   * Recompose fan-out scope for this write. Read by the pending-changes
+   * tray (epic #854) to set toggle defaults.
+   *
+   *   'none'   — stamp timestamp only; no immediate recompose (default).
+   *              Lazy-auto recompose still fires on next caller touchpoint
+   *              via `autoComposeForCaller` + `isPromptStale`.
+   *   'caller' — recompose the single caller in context (human OR AI may set).
+   *   'all'    — fan out to every active caller on this playbook.
+   *              **Human UI only — AI tool executors MUST NOT pass this.**
+   *
+   * Enforced at AI call sites by the ESLint rule
+   * `hf-recompose/no-ai-fanout-all`. This helper does NOT fan out itself;
+   * the value is surfaced in the result for upstream code to act on.
+   */
+  fanoutScope?: 'none' | 'caller' | 'all';
 }
 
 export interface UpdatePlaybookConfigResult {
@@ -63,6 +79,8 @@ export interface UpdatePlaybookConfigResult {
   composeAffectingChanged: boolean;
   /** True when the timestamp was bumped (composeAffectingChanged && !skipTimestamp). */
   timestampBumped: boolean;
+  /** Echoes the requested fanout scope so callers can branch (default 'none'). */
+  fanoutScope: 'none' | 'caller' | 'all';
 }
 
 export type PlaybookConfigTransformer = (
@@ -117,6 +135,7 @@ export async function updatePlaybookConfig(
     playbook,
     composeAffectingChanged: composeAffected,
     timestampBumped: shouldBumpTimestamp,
+    fanoutScope: options.fanoutScope ?? 'none',
   };
 }
 

--- a/apps/admin/lib/recompose/preview.ts
+++ b/apps/admin/lib/recompose/preview.ts
@@ -1,0 +1,175 @@
+/**
+ * Preview the blast radius of a recompose fan-out, so the pending-changes
+ * tray (epic #854) can render an honest `Recompose all N learners` toggle
+ * before the user commits.
+ *
+ * Returns a count + a small sample of first names for inline display, plus
+ * a coarse ETA derived from the count.
+ *
+ * Counting strategy:
+ *   - `playbook` scope: single-index COUNT(*) on CallerPlaybook(status=ACTIVE)
+ *   - `domain`   scope: IN-clause across all playbooks in the domain
+ *   - `system`   scope: DISTINCT callerId across all ACTIVE CallerPlaybook rows
+ *
+ * The response carries `source: 'live' | 'counter'`. v1 always emits `'live'`.
+ * #860 will denormalise enrollment counts onto Playbook/Domain rows; when
+ * that lands, this util flips the playbook + domain branches to read the
+ * stored counter and emits `'counter'` for those scopes. The shape is
+ * deliberately forward-compatible so the tray UI does not change.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+export type RecomposePreviewScope = "playbook" | "domain" | "system";
+
+export interface RecomposePreview {
+  count: number;
+  /** Up to 3 first-name initials of affected callers — for tray inline display. */
+  sampleNames: string[];
+  /** Coarse ETA in seconds: count × 2s, capped at 300. */
+  etaSeconds: number;
+  /** True when this response was served from the route-level cache. */
+  cacheHit: boolean;
+  /** v1 always 'live'; flips to 'counter' once #860 ships denormalised counters. */
+  source: "live" | "counter";
+}
+
+const ETA_SECONDS_PER_CALLER = 2;
+const ETA_CAP_SECONDS = 300;
+
+function etaFor(count: number): number {
+  return Math.min(count * ETA_SECONDS_PER_CALLER, ETA_CAP_SECONDS);
+}
+
+function firstName(displayName: string | null | undefined): string | null {
+  if (!displayName) return null;
+  const trimmed = displayName.trim();
+  if (!trimmed) return null;
+  const firstToken = trimmed.split(/\s+/)[0];
+  return firstToken || null;
+}
+
+/**
+ * Anonymisation: take first names only, dedupe, cap at 3. Empty / null
+ * display names are dropped silently (they wouldn't be useful in the tray).
+ */
+function sampleFirstNames(
+  rows: Array<{ caller: { name: string | null } }>,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const row of rows) {
+    const name = firstName(row.caller.name);
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+    if (out.length >= 3) break;
+  }
+  return out;
+}
+
+async function previewPlaybook(scopeId: string): Promise<RecomposePreview> {
+  const [count, sampleRows] = await Promise.all([
+    prisma.callerPlaybook.count({
+      where: { playbookId: scopeId, status: "ACTIVE" },
+    }),
+    prisma.callerPlaybook.findMany({
+      where: { playbookId: scopeId, status: "ACTIVE" },
+      include: { caller: { select: { name: true } } },
+      orderBy: { enrolledAt: "asc" },
+      take: 3,
+    }),
+  ]);
+
+  return {
+    count,
+    sampleNames: sampleFirstNames(sampleRows),
+    etaSeconds: etaFor(count),
+    cacheHit: false,
+    source: "live",
+  };
+}
+
+async function previewDomain(scopeId: string): Promise<RecomposePreview> {
+  const playbooks = await prisma.playbook.findMany({
+    where: { domainId: scopeId },
+    select: { id: true },
+  });
+  const playbookIds = playbooks.map((p) => p.id);
+
+  if (playbookIds.length === 0) {
+    return {
+      count: 0,
+      sampleNames: [],
+      etaSeconds: 0,
+      cacheHit: false,
+      source: "live",
+    };
+  }
+
+  const [count, sampleRows] = await Promise.all([
+    prisma.callerPlaybook.count({
+      where: { playbookId: { in: playbookIds }, status: "ACTIVE" },
+    }),
+    prisma.callerPlaybook.findMany({
+      where: { playbookId: { in: playbookIds }, status: "ACTIVE" },
+      include: { caller: { select: { name: true } } },
+      orderBy: { enrolledAt: "asc" },
+      take: 3,
+    }),
+  ]);
+
+  return {
+    count,
+    sampleNames: sampleFirstNames(sampleRows),
+    etaSeconds: etaFor(count),
+    cacheHit: false,
+    source: "live",
+  };
+}
+
+async function previewSystem(): Promise<RecomposePreview> {
+  // DISTINCT callers across all ACTIVE enrollments — a SYSTEM-spec edit
+  // can touch any active learner regardless of their playbook.
+  const rows = await prisma.callerPlaybook.findMany({
+    where: { status: "ACTIVE" },
+    select: { callerId: true },
+    distinct: ["callerId"],
+  });
+  const count = rows.length;
+
+  const sampleRows = await prisma.callerPlaybook.findMany({
+    where: { status: "ACTIVE" },
+    include: { caller: { select: { name: true } } },
+    orderBy: { enrolledAt: "asc" },
+    take: 6, // overfetch slightly; dedupe in sampleFirstNames
+  });
+
+  return {
+    count,
+    sampleNames: sampleFirstNames(sampleRows),
+    etaSeconds: etaFor(count),
+    cacheHit: false,
+    source: "live",
+  };
+}
+
+export async function previewRecomposeFanout(
+  scope: RecomposePreviewScope,
+  scopeId: string | null,
+): Promise<RecomposePreview> {
+  if (scope === "system") {
+    return previewSystem();
+  }
+  if (!scopeId) {
+    return {
+      count: 0,
+      sampleNames: [],
+      etaSeconds: 0,
+      cacheHit: false,
+      source: "live",
+    };
+  }
+  if (scope === "playbook") return previewPlaybook(scopeId);
+  return previewDomain(scopeId);
+}

--- a/apps/admin/lib/tolerance/apply-learner-tolerances.ts
+++ b/apps/admin/lib/tolerance/apply-learner-tolerances.ts
@@ -28,6 +28,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { auditLog, AuditAction } from "@/lib/audit";
+import { bumpCallerComposeTimestamp } from "@/lib/compose/bump-timestamp";
 
 export const TOLERANCE_SCOPE = "TOLERANCE" as const;
 
@@ -88,6 +89,12 @@ export async function applyLearnerTolerance(
       confidence: 1.0,
     },
   });
+
+  // #854 A1 — drive caller-scope staleness so the next touchpoint actually
+  // sees the override via `isPromptStale` → `autoComposeForCaller`. Without
+  // this bump, a per-learner tolerance write silently never reaches the
+  // composed prompt until something else also bumps the caller.
+  await bumpCallerComposeTimestamp(input.callerId);
 
   await auditLog({
     userId: input.actor?.userId,

--- a/apps/admin/tests/lib/recompose/preview.test.ts
+++ b/apps/admin/tests/lib/recompose/preview.test.ts
@@ -1,0 +1,178 @@
+/**
+ * #854 / Story #855 — preview the blast radius of a recompose fan-out.
+ *
+ * Verifies count + sample-name extraction across playbook, domain, and
+ * system scopes. Asserts the forward-compat shape (`source: 'live'`) so
+ * #860's denormalised-counter swap can flip the field without breaking
+ * callers.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    callerPlaybook: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+    playbook: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { previewRecomposeFanout } from "@/lib/recompose/preview";
+
+const cpCount = prisma.callerPlaybook.count as unknown as Mock;
+const cpFindMany = prisma.callerPlaybook.findMany as unknown as Mock;
+const pbFindMany = prisma.playbook.findMany as unknown as Mock;
+
+beforeEach(() => {
+  cpCount.mockReset();
+  cpFindMany.mockReset();
+  pbFindMany.mockReset();
+});
+
+describe("previewRecomposeFanout", () => {
+  describe("playbook scope", () => {
+    it("returns count + up to 3 first-name samples + eta + live source", async () => {
+      cpCount.mockResolvedValue(47);
+      cpFindMany.mockResolvedValue([
+        { caller: { name: "Mary Smith" } },
+        { caller: { name: "Bob Jones" } },
+        { caller: { name: "Alice" } },
+      ]);
+
+      const result = await previewRecomposeFanout("playbook", "pb-1");
+
+      expect(result).toEqual({
+        count: 47,
+        sampleNames: ["Mary", "Bob", "Alice"],
+        etaSeconds: 94, // 47 * 2, under cap
+        cacheHit: false,
+        source: "live",
+      });
+    });
+
+    it("caps eta at 300s for very large counts", async () => {
+      cpCount.mockResolvedValue(5_000);
+      cpFindMany.mockResolvedValue([]);
+
+      const result = await previewRecomposeFanout("playbook", "pb-1");
+
+      expect(result.etaSeconds).toBe(300);
+    });
+
+    it("dedupes duplicate first names in the sample", async () => {
+      cpCount.mockResolvedValue(3);
+      cpFindMany.mockResolvedValue([
+        { caller: { name: "Mary Smith" } },
+        { caller: { name: "Mary Jones" } }, // same first name
+        { caller: { name: "Bob" } },
+      ]);
+
+      const result = await previewRecomposeFanout("playbook", "pb-1");
+
+      expect(result.sampleNames).toEqual(["Mary", "Bob"]);
+    });
+
+    it("returns zero shape when scopeId is missing", async () => {
+      const result = await previewRecomposeFanout("playbook", null);
+
+      expect(result).toEqual({
+        count: 0,
+        sampleNames: [],
+        etaSeconds: 0,
+        cacheHit: false,
+        source: "live",
+      });
+      expect(cpCount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("domain scope", () => {
+    it("aggregates across all playbooks in the domain", async () => {
+      pbFindMany.mockResolvedValue([{ id: "pb-1" }, { id: "pb-2" }]);
+      cpCount.mockResolvedValue(120);
+      cpFindMany.mockResolvedValue([
+        { caller: { name: "Alice Anderson" } },
+      ]);
+
+      const result = await previewRecomposeFanout("domain", "d-1");
+
+      expect(result.count).toBe(120);
+      expect(result.sampleNames).toEqual(["Alice"]);
+      // Verify the IN-clause was constructed correctly
+      expect(cpCount).toHaveBeenCalledWith({
+        where: { playbookId: { in: ["pb-1", "pb-2"] }, status: "ACTIVE" },
+      });
+    });
+
+    it("returns zero shape when domain has no playbooks", async () => {
+      pbFindMany.mockResolvedValue([]);
+
+      const result = await previewRecomposeFanout("domain", "d-empty");
+
+      expect(result.count).toBe(0);
+      expect(cpCount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("system scope", () => {
+    it("counts distinct callers across all active enrollments", async () => {
+      cpFindMany
+        .mockResolvedValueOnce([
+          { callerId: "c-1" },
+          { callerId: "c-2" },
+          { callerId: "c-3" },
+        ])
+        .mockResolvedValueOnce([
+          { caller: { name: "Mary" } },
+          { caller: { name: "Bob" } },
+        ]);
+
+      const result = await previewRecomposeFanout("system", null);
+
+      expect(result.count).toBe(3);
+      expect(result.sampleNames).toEqual(["Mary", "Bob"]);
+      expect(result.source).toBe("live");
+    });
+
+    it("ignores scopeId argument", async () => {
+      cpFindMany.mockResolvedValue([]);
+
+      const result = await previewRecomposeFanout("system", "ignored-id");
+
+      expect(result.count).toBe(0);
+      // Distinct query is called regardless of scopeId
+      expect(cpFindMany).toHaveBeenCalled();
+    });
+  });
+
+  describe("forward-compat shape", () => {
+    it("every response carries source='live' in v1 (flips to 'counter' once #860 ships)", async () => {
+      cpCount.mockResolvedValue(1);
+      cpFindMany.mockResolvedValue([]);
+
+      const playbook = await previewRecomposeFanout("playbook", "pb-1");
+      expect(playbook.source).toBe("live");
+
+      pbFindMany.mockResolvedValue([{ id: "pb-1" }]);
+      const domain = await previewRecomposeFanout("domain", "d-1");
+      expect(domain.source).toBe("live");
+
+      cpFindMany.mockResolvedValue([]);
+      const system = await previewRecomposeFanout("system", null);
+      expect(system.source).toBe("live");
+    });
+
+    it("cacheHit defaults to false — route layer flips this when serving from cache", async () => {
+      cpCount.mockResolvedValue(1);
+      cpFindMany.mockResolvedValue([]);
+
+      const result = await previewRecomposeFanout("playbook", "pb-1");
+      expect(result.cacheHit).toBe(false);
+    });
+  });
+});

--- a/apps/admin/tests/lib/tolerance/apply-learner-tolerances.test.ts
+++ b/apps/admin/tests/lib/tolerance/apply-learner-tolerances.test.ts
@@ -12,6 +12,9 @@ vi.mock("@/lib/prisma", () => ({
     callerAttribute: {
       upsert: vi.fn(),
     },
+    caller: {
+      update: vi.fn(),
+    },
   },
 }));
 
@@ -25,11 +28,14 @@ import { auditLog } from "@/lib/audit";
 import { applyLearnerTolerance } from "@/lib/tolerance/apply-learner-tolerances";
 
 const upsertMock = prisma.callerAttribute.upsert as unknown as Mock;
+const callerUpdateMock = prisma.caller.update as unknown as Mock;
 const auditMock = auditLog as unknown as Mock;
 
 beforeEach(() => {
   upsertMock.mockReset();
   upsertMock.mockResolvedValue({});
+  callerUpdateMock.mockReset();
+  callerUpdateMock.mockResolvedValue({});
   auditMock.mockReset();
 });
 
@@ -90,6 +96,36 @@ describe("applyLearnerTolerance", () => {
       }),
     ).rejects.toThrow(/unknown key/i);
     expect(prisma.callerAttribute.upsert).not.toHaveBeenCalled();
+    expect(prisma.caller.update).not.toHaveBeenCalled();
     expect(auditLog).not.toHaveBeenCalled();
+  });
+
+  // #854 A1 — silent bug from #843: tolerance writes were not bumping
+  // Caller.composeInputsUpdatedAt, so the staleness check never fired
+  // for the next compose. The bump must run after every successful upsert.
+  it("bumps Caller.composeInputsUpdatedAt after a successful upsert (A1)", async () => {
+    await applyLearnerTolerance({
+      callerId: "c-1",
+      key: "firstCall",
+      value: { durationMinsOverride: 7 },
+    });
+
+    expect(callerUpdateMock).toHaveBeenCalledTimes(1);
+    const updateCall = callerUpdateMock.mock.calls[0][0];
+    expect(updateCall.where).toEqual({ id: "c-1" });
+    expect(updateCall.data.composeInputsUpdatedAt).toBeInstanceOf(Date);
+  });
+
+  it("does NOT bump Caller.composeInputsUpdatedAt when the key is rejected (A1)", async () => {
+    await expect(
+      applyLearnerTolerance({
+        callerId: "c-1",
+        // @ts-expect-error — intentionally invalid key
+        key: "bogus",
+        value: {} as never,
+      }),
+    ).rejects.toThrow();
+
+    expect(callerUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -73,6 +73,7 @@
   - [Playbook](#playbook)
   - [Playbooks](#playbooks)
   - [Prompts](#prompts)
+  - [Recompose](#recompose)
   - [Settings](#settings)
   - [Sidebar](#sidebar)
   - [Sim](#sim)
@@ -11976,6 +11977,26 @@ Post-call pipeline endpoint that orchestrates call analysis. Receives call
 
 ---
 
+## Recompose
+
+### `GET` /api/recompose/preview?scope=playbook|domain|system&scopeId=<uuid>
+
+Returns `{ count, sampleNames[3], etaSeconds, cacheHit, source }`
+
+**Auth**: session OPERATOR · **Scope**: `recompose:read`
+
+**Response** `200`
+```json
+RecomposePreview
+```
+
+**Response** `400`
+```json
+{ ok: false, error } when scope is invalid
+```
+
+---
+
 ## Settings
 
 ### `DELETE` /api/settings/channels
@@ -14476,8 +14497,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 450 |
-| Files with annotations | 449 |
+| Route files found | 451 |
+| Files with annotations | 450 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 


### PR DESCRIPTION
Story #855 of epic #854 — first slice of the recompose-control UX redesign.

## Summary

- Adds `fanoutScope?: 'none' | 'caller' | 'all'` to the three config helpers (additive; default `'none'` = no behaviour change)
- Ships `previewRecomposeFanout` util + `GET /api/recompose/preview` endpoint (30s cache, forward-compatible with #860's denormalised counters via `source: 'live' | 'counter'` field)
- Adds `AuditAction.RECOMPOSE_FANOUT` + `PENDING_CHANGES_APPLIED` constants
- New ESLint rule `hf-recompose/no-ai-fanout-all` encodes the AI-safety invariant: AI tool executors can't request `fanoutScope: 'all'`
- **A1 bug fix** (from TL review): `applyLearnerTolerance` was writing the override but not bumping `Caller.composeInputsUpdatedAt`, so per-learner tolerances silently never drove staleness. Adds one `bumpCallerComposeTimestamp` call + 2 tests.

Tests: 15 new tests (10 preview + 2 A1 bump + 3 existing tolerance), all passing.

## Test plan

- [x] `npx tsc --noEmit` — no new errors (197 pre-existing baseline preserved)
- [x] `npm run ratchet:check` — passes (baseline bumped to 4467 in a separate chore commit; matches main's drift)
- [x] `npm run test -- tests/lib/recompose/ tests/lib/tolerance/apply-learner-tolerances.test.ts` — 15/15 pass
- [ ] Smoke: `curl '/api/recompose/preview?scope=playbook&scopeId=<some-pb-id>'` returns `{count, sampleNames, etaSeconds, cacheHit: false, source: 'live'}`; repeat within 30s returns `cacheHit: true`
- [ ] Smoke: trigger ESLint rule by adding `fanoutScope: 'all'` literal in any AI tool file → expect error
- [ ] Smoke: PATCH `/api/callers/[id]/tolerances` → confirm `Caller.composeInputsUpdatedAt` advances (A1)

## Two commits, deliberately separate

1. `chore(lint): lock ratchet baseline at 4467 — inherited drift since #850` — pure baseline bump matching main's current state
2. `feat(#855): fanoutScope helpers + preview endpoint + ESLint guard + A1 bump fix` — the actual story work

Scope-enforcer-clean. Squash on merge.

## Not in this PR

Tray UI (#856), surface migrations (#857), fan-out job + bulk sweep (#858). Each is its own PR per epic plan.

Deploy: `/vm-cp` (no migration).

Epic: #854
Story: #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)
