### PR TITLE
fix(chat): dedupe entity chips by type + surface Scope toggle in Assistant tab

### DIFF
--- a/apps/admin/app/api/chat/system-prompts.ts
+++ b/apps/admin/app/api/chat/system-prompts.ts
@@ -138,7 +138,11 @@ export async function buildSystemPrompt(
       // the path every Cmd+K message takes).
       const [dataPrompt, tuningContext, ticketBlock, listHintBlock] = await Promise.all([
         getPromptSpec(config.specs.chatDataHelper, DATA_SYSTEM_PROMPT),
-        buildTuningSystemPrompt({ entityContext }),
+        // Pass tuningScope so DATA mode's shared tuning catalogue knows the
+        // active scope picked from the Assistant tab's Scope toggle. Without
+        // this the model had to infer scope from the chip stack, which
+        // failed whenever the stack contained multiple caller/playbook ids.
+        buildTuningSystemPrompt({ entityContext, tuningScope }),
         buildTicketDiscussionBlock(options, userRole, institutionId),
         buildFeedbackListHintBlock(options, userRole, institutionId),
       ]);

--- a/apps/admin/components/chat/ChatPanel.tsx
+++ b/apps/admin/components/chat/ChatPanel.tsx
@@ -454,8 +454,13 @@ export function ChatPanel() {
           {/* Mode tabs (Assistant / Tuning) */}
           <ChatModeTabs />
 
-          {/* Tuning scope toggle (only in TUNING mode) */}
-          {mode === "TUNING" && <TuningScopeToggle />}
+          {/* Tuning scope toggle — shown in both DATA (Assistant) and TUNING
+              modes so write operations always have unambiguous scope
+              regardless of which tab the user is in. DATA mode previously
+              relied on the chip stack alone, which the model couldn't
+              disambiguate when the stack accumulated multiple
+              callers/playbooks across navigation. */}
+          {(mode === "DATA" || mode === "TUNING") && <TuningScopeToggle />}
 
           {/* Active ticket stripe (only in DATA mode when a discussion is active) */}
           {mode === "DATA" && <DiscussingTicketStripe />}

--- a/apps/admin/contexts/ChatContext.tsx
+++ b/apps/admin/contexts/ChatContext.tsx
@@ -372,7 +372,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               mode,
               entityContext: entityContext.breadcrumbs,
               isCommand: true,
-              ...(mode === "TUNING" ? { tuningScope } : {}),
+              ...(mode === "DATA" || mode === "TUNING" ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
               ...(pathname && (mode === "DATA" || mode === "TUNING") ? { pageHint: { route: pathname } } : {}),
               ...(mode === "DATA" && entityContext.pageContext?.page
@@ -430,7 +430,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               mode,
               entityContext: entityContext.breadcrumbs,
               conversationHistory: history,
-              ...(mode === "TUNING" ? { tuningScope } : {}),
+              ...(mode === "DATA" || mode === "TUNING" ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
               ...(pathname && (mode === "DATA" || mode === "TUNING") ? { pageHint: { route: pathname } } : {}),
               ...(mode === "DATA" && entityContext.pageContext?.page

--- a/apps/admin/contexts/EntityContext.tsx
+++ b/apps/admin/contexts/EntityContext.tsx
@@ -66,6 +66,44 @@ function persistContext(breadcrumbs: EntityBreadcrumb[]): void {
   }
 }
 
+/**
+ * Pure reducer for pushEntity — exported for unit tests.
+ *
+ * Rules, in order:
+ *   1. Same id already at the end → no-op (idempotent re-push).
+ *   2. Otherwise → remove any entry with the same id OR the same type,
+ *      then append the new entity at the end.
+ *
+ * Net invariant: at most one entity of each type is in the stack at any
+ * time, and the pushed entity is always last.
+ *
+ * Two design deltas vs the original implementation:
+ *
+ *   (a) Dedupe by type runs across the WHOLE stack, not just the last
+ *       slot. Pre-fix: `Course A → Learner X (publishedPlaybook A) →
+ *       Learner Y (publishedPlaybook B)` ended up as `[playbook A,
+ *       caller Y, playbook B]` (two playbook chips, the source of the
+ *       "which scope?" ambiguity in DATA-mode AI Assistant). Post-fix:
+ *       always exactly one of each leaf type.
+ *
+ *   (b) The previous "slice-to-existing on same id" rule has been
+ *       removed. It conflated page-load pushes (CallerDetailPage pushes
+ *       caller + publishedPlaybook on mount) with back-stack navigation,
+ *       which truncated co-present entities of other types. Pages that
+ *       genuinely want back-nav should use `clearToEntity()` directly.
+ *       Re-pushing an existing id now just moves that entity to the end.
+ */
+export function computeNextBreadcrumbs(
+  prev: EntityBreadcrumb[],
+  entity: EntityBreadcrumb,
+): EntityBreadcrumb[] {
+  if (prev.length > 0 && prev[prev.length - 1].id === entity.id) {
+    return prev;
+  }
+  const cleaned = prev.filter((e) => e.id !== entity.id && e.type !== entity.type);
+  return [...cleaned, entity];
+}
+
 export function EntityProvider({ children }: { children: React.ReactNode }) {
   const { data: session } = useSession();
   const userId = session?.user?.id;
@@ -112,27 +150,7 @@ export function EntityProvider({ children }: { children: React.ReactNode }) {
   const currentEntity = breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1] : null;
 
   const pushEntity = useCallback((entity: EntityBreadcrumb) => {
-    setBreadcrumbs((prev) => {
-      // Don't add duplicate if same entity is already at the end
-      if (prev.length > 0 && prev[prev.length - 1].id === entity.id) {
-        return prev;
-      }
-
-      // Check if entity already exists in the stack - if so, clear to it
-      const existingIndex = prev.findIndex((e) => e.id === entity.id);
-      if (existingIndex >= 0) {
-        return prev.slice(0, existingIndex + 1);
-      }
-
-      // If the last entity is the same type, replace it (e.g., Caller A → Caller B)
-      // This prevents stacking multiple entities of the same type
-      if (prev.length > 0 && prev[prev.length - 1].type === entity.type) {
-        return [...prev.slice(0, -1), entity];
-      }
-
-      // Different type - add to breadcrumb trail (e.g., Caller → Call)
-      return [...prev, entity];
-    });
+    setBreadcrumbs((prev) => computeNextBreadcrumbs(prev, entity));
   }, []);
 
   const popEntity = useCallback(() => {

--- a/apps/admin/contexts/__tests__/entity-context-dedupe.test.ts
+++ b/apps/admin/contexts/__tests__/entity-context-dedupe.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { computeNextBreadcrumbs, type EntityBreadcrumb } from "../EntityContext";
+
+const playbook = (id: string, label = id): EntityBreadcrumb => ({
+  type: "playbook",
+  id,
+  label,
+});
+const caller = (id: string, label = id): EntityBreadcrumb => ({
+  type: "caller",
+  id,
+  label,
+});
+const call = (id: string, label = id): EntityBreadcrumb => ({
+  type: "call",
+  id,
+  label,
+});
+
+describe("computeNextBreadcrumbs — dedupe by type across the whole stack", () => {
+  it("returns the same array when the pushed entity already sits at the end", () => {
+    const prev = [playbook("p1"), caller("c1")];
+    const next = computeNextBreadcrumbs(prev, caller("c1"));
+    expect(next).toBe(prev);
+  });
+
+  it("re-pushing an existing id moves it to the end and keeps co-present entities of other types", () => {
+    // Behaviour change: the previous "slice-to-existing" rule dropped any
+    // entries AFTER the re-pushed entity. That truncated the caller chip
+    // when CallerDetailPage re-pushed the playbook the user came from
+    // (publishedPlaybookId === current stack's playbook). Now: the
+    // re-pushed entity moves to the end; entities of OTHER types stay.
+    const prev = [playbook("p1"), caller("c1"), call("call-a")];
+    const next = computeNextBreadcrumbs(prev, caller("c1"));
+    expect(next.map((b) => b.id)).toEqual(["p1", "call-a", "c1"]);
+  });
+
+  it("REGRESSION: CallerDetailPage's caller-then-playbook push pattern keeps both chips even when the playbook is already in the stack", () => {
+    // The exact failure mode that motivated this fix. User arrives at a
+    // learner page from the playbook page → stack starts as [playbook p1].
+    // CallerDetailPage pushes caller(c1) then playbook(p1).
+    let stack: EntityBreadcrumb[] = [playbook("p1")];
+    stack = computeNextBreadcrumbs(stack, caller("c1"));
+    stack = computeNextBreadcrumbs(stack, playbook("p1"));
+    expect(stack.map((b) => b.type)).toEqual(["caller", "playbook"]);
+    expect(stack.find((b) => b.type === "caller")?.id).toBe("c1");
+    expect(stack.find((b) => b.type === "playbook")?.id).toBe("p1");
+  });
+
+  it("REGRESSION: replaces an earlier same-type entity even when a different type is between (the doubled-chip bug)", () => {
+    // The failing path: Course p1 → Learner c1 (publishedPlaybook p1) →
+    // Learner c2 (publishedPlaybook p2). CallerDetailPage pushes caller-
+    // then-playbook; the playbook push lands on a caller (different type)
+    // and used to append. End state used to be
+    // [playbook p1, caller c2, playbook p2] — two playbook chips.
+    const prev = [playbook("p1"), caller("c2")];
+    const next = computeNextBreadcrumbs(prev, playbook("p2"));
+    expect(next.map((b) => b.id)).toEqual(["c2", "p2"]);
+    // Caller stays, old playbook is gone, new playbook is on top.
+    expect(next.filter((b) => b.type === "playbook")).toHaveLength(1);
+  });
+
+  it("REGRESSION: two-course-two-learner navigation never accumulates more than one chip per type", () => {
+    // Simulate exactly the screenshot: visit Course A, Learner X on A,
+    // Course B, Learner Y on B. Net invariant: 1 playbook + 1 caller.
+    let stack: EntityBreadcrumb[] = [];
+    // 1. Open Course A
+    stack = computeNextBreadcrumbs(stack, playbook("course-A"));
+    // 2. Open Learner X on Course A (CallerDetailPage pushes caller then publishedPlaybook)
+    stack = computeNextBreadcrumbs(stack, caller("learner-X"));
+    stack = computeNextBreadcrumbs(stack, playbook("course-A")); // publishedPlaybook same as current
+    // 3. Open Course B
+    stack = computeNextBreadcrumbs(stack, playbook("course-B"));
+    // 4. Open Learner Y (publishedPlaybook B)
+    stack = computeNextBreadcrumbs(stack, caller("learner-Y"));
+    stack = computeNextBreadcrumbs(stack, playbook("course-B"));
+
+    expect(stack.filter((b) => b.type === "playbook")).toHaveLength(1);
+    expect(stack.filter((b) => b.type === "caller")).toHaveLength(1);
+    expect(stack.find((b) => b.type === "playbook")?.id).toBe("course-B");
+    expect(stack.find((b) => b.type === "caller")?.id).toBe("learner-Y");
+  });
+
+  it("keeps drill-down hierarchy: caller + call coexist as different types", () => {
+    let stack: EntityBreadcrumb[] = [];
+    stack = computeNextBreadcrumbs(stack, caller("c1"));
+    stack = computeNextBreadcrumbs(stack, call("call-1"));
+    expect(stack.map((b) => `${b.type}:${b.id}`)).toEqual(["caller:c1", "call:call-1"]);
+  });
+
+  it("replaces a call with a newer call when both are pushed in succession", () => {
+    let stack: EntityBreadcrumb[] = [caller("c1"), call("call-1")];
+    stack = computeNextBreadcrumbs(stack, call("call-2"));
+    expect(stack.map((b) => `${b.type}:${b.id}`)).toEqual(["caller:c1", "call:call-2"]);
+  });
+
+  it("appends the first entity to an empty stack", () => {
+    const next = computeNextBreadcrumbs([], playbook("p1"));
+    expect(next).toEqual([playbook("p1")]);
+  });
+
+  it("Course A → Learner X drill-down keeps both (different types) with playbook chip preserved", () => {
+    let stack: EntityBreadcrumb[] = [];
+    stack = computeNextBreadcrumbs(stack, playbook("p1"));
+    stack = computeNextBreadcrumbs(stack, caller("c1"));
+    expect(stack.map((b) => b.type)).toEqual(["playbook", "caller"]);
+  });
+});


### PR DESCRIPTION
## Summary

Two related fixes for the "AI Assistant doesn't know which course/learner the user is on" bug observed today.

### A. Chip stack accumulates doubles across navigation

`EntityContext.pushEntity` deduped same-type only against the LAST slot, so

`Course A → Learner X (publishedPlaybook A) → Learner Y (publishedPlaybook B)`

ended up as `[playbook A, caller Y, playbook B]` because CallerDetailPage pushes caller-then-playbook, and the playbook push saw a caller at the end (different type) and appended. After two course-learner visits you got two course chips + two learner chips, and DATA-mode AI Assistant asked "which scope?" because the entity context block carried both ids.

### B. Scope toggle was Tune-only

DATA mode (Assistant tab) had to infer scope from the chip stack alone — which (A) made impossible. TUNING mode worked because its `Learner / Course` radio was the source of truth there. Both tabs already share the write tools (`update_behavior_target` etc.), so giving Assistant the toggle removes the structural reason Tune exists as a separate tab.

## Changes

**A — `contexts/EntityContext.tsx`**
- Extracted `computeNextBreadcrumbs(prev, entity)` as a pure exported reducer.
- New rule: same id at end → no-op; otherwise filter out any entry with the same id OR same type, then append. Invariant: at most one of each type, pushed entity is always last.
- Removed the previous "slice-to-existing on same id" rule (it conflated page-load pushes with back-stack nav and dropped co-present entities). `clearToEntity()` remains the API for explicit back-nav.

**B — three wiring points**
- `components/chat/ChatPanel.tsx:458` — Scope toggle renders in both DATA and TUNING modes (was TUNING only).
- `contexts/ChatContext.tsx:375, 433` — `tuningScope` is sent to `/api/chat` for both modes (was TUNING only).
- `app/api/chat/system-prompts.ts:141` — DATA case passes `tuningScope` into `buildTuningSystemPrompt` (which already accepted it as optional).

## Tests

9 new unit tests in `contexts/__tests__/entity-context-dedupe.test.ts`, all passing:
- No-op when pushed id is already at the end
- Re-pushing an id moves it to the end, keeps other-type entries
- **Regression: two-course-two-learner navigation never accumulates more than one chip per type**
- **Regression: CallerDetailPage's caller-then-playbook pattern keeps both chips even when the playbook id is already in the stack**
- Drill-down hierarchy (caller + call as different types) still works
- Empty stack push, same-type replacement, etc.

`npx tsc --noEmit` clean on touched files.

## UI to verify after merge

1. `/x/courses/<A>` → click Learner X → click Learner Y on Course B. Chip stack shows exactly one course + one learner (current page's), no doubles.
2. Cmd+K → Assistant tab — Scope toggle is now visible above messages (was Tune-tab-only). Defaults to `Learner` when a caller is in the stack, `Course` otherwise.
3. With Scope=Learner Y in Assistant, ask "change warmth to 0.9 for this caller" — model uses the toggle's scope directly, no "which scope?" follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)