### PR TITLE
feat(#857): close the only auto-fanout site + wire tray Save & apply

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,6 +1,6 @@
 {
   "tsc_errors": 197,
   "lint_errors": 0,
-  "lint_warnings": 4470,
+  "lint_warnings": 4468,
   "quarantined_tests": 37
 }

--- a/apps/admin/app/api/recompose/apply/route.ts
+++ b/apps/admin/app/api/recompose/apply/route.ts
@@ -1,0 +1,235 @@
+/**
+ * Apply pending changes from the PendingChangesTray (epic #854 / Story #857).
+ *
+ * The tray accumulates compose-affecting settings edits across surfaces.
+ * Underlying writes happen at push time (each surface writes immediately
+ * — this is the simplified v1 model documented in the epic body). The
+ * tray's Save & apply button calls THIS endpoint to act on the toggle
+ * decisions:
+ *
+ *   • Toggle 1 (per-caller): call `autoComposeForCaller(callerId, playbookId)`
+ *     — recomposes only the caller-in-context, single network operation.
+ *
+ *   • Toggle 2 (cohort fan-out): POST to
+ *     `/api/playbooks/[playbookId]/recompose-all` for each unique
+ *     playbook scope referenced by the entries. Story #858 wraps this
+ *     with a UserTask job record + progress toast.
+ *
+ *   • PENDING_CHANGES_APPLIED audit row is written regardless of which
+ *     toggles fired — gives an auditable record of every Save & apply,
+ *     including the decision to NOT fan out.
+ *
+ * AI-safety server-side enforcement (defence-in-depth):
+ *   If ANY entry in the payload has `aiSuggested: true`, the cohort
+ *   fan-out (Toggle 2) is rejected. The ESLint rule
+ *   `hf-recompose/no-ai-fanout-all` is the build-time guard; this is
+ *   the runtime guard for the case where an AI somehow bypasses the
+ *   rule (variable-assembled options, dynamic imports, etc.).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { auditLog, AuditAction } from "@/lib/audit";
+import { autoComposeForCaller } from "@/lib/enrollment/auto-compose";
+
+export const runtime = "nodejs";
+
+const trayEntrySchema = z
+  .object({
+    id: z.string(),
+    key: z.string(),
+    label: z.string(),
+    scopeLabel: z.string(),
+    beforeValue: z.string(),
+    afterValue: z.string(),
+    scope: z.enum(["playbook", "domain", "system"]),
+    scopeId: z.string().nullable(),
+    aiSuggested: z.boolean(),
+    fanoutScope: z.enum(["none", "caller", "all"]),
+  })
+  .strict();
+
+const callerInContextSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+  })
+  .strict();
+
+const bodySchema = z
+  .object({
+    entries: z.array(trayEntrySchema).min(1),
+    toggleCaller: z.boolean(),
+    toggleAll: z.boolean(),
+    callerInContext: callerInContextSchema.nullable(),
+  })
+  .strict();
+
+type ApplyResult = {
+  ok: true;
+  audited: boolean;
+  callerRecomposed: boolean;
+  cohortRecomposeAttempts: Array<{
+    playbookId: string;
+    ok: boolean;
+    total?: number;
+    succeeded?: number;
+    failed?: number;
+    error?: string;
+  }>;
+};
+
+function uniquePlaybookScopeIds(entries: z.infer<typeof trayEntrySchema>[]): string[] {
+  const ids = new Set<string>();
+  for (const e of entries) {
+    if (e.scope === "playbook" && e.scopeId) ids.add(e.scopeId);
+  }
+  return [...ids];
+}
+
+/**
+ * @api POST /api/recompose/apply
+ * @visibility internal
+ * @scope recompose:write
+ * @auth session OPERATOR
+ * @tags recompose
+ * @description Acts on the toggle decisions from the PendingChangesTray's
+ *   Save & apply button. Underlying writes already happened at push time;
+ *   this endpoint only triggers recompose paths + emits the audit row.
+ * @body { entries: TrayEntry[]; toggleCaller: bool; toggleAll: bool; callerInContext: {id,name}|null }
+ * @response 200 { ok, audited, callerRecomposed, cohortRecomposeAttempts[] }
+ * @response 400 { ok: false, error } — invalid body or AI-safety violation
+ * @response 401/403 via requireAuth
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth("OPERATOR");
+    if (isAuthError(authResult)) return authResult.error;
+    const { session } = authResult;
+
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: parsed.error.message },
+        { status: 400 },
+      );
+    }
+    const { entries, toggleCaller, toggleAll, callerInContext } = parsed.data;
+
+    // AI-safety defence-in-depth — block cohort fan-out when any entry
+    // came from an AI surface. The ESLint rule blocks `fanoutScope: 'all'`
+    // at AI tool call sites; this catches the case where AI-sourced
+    // entries land in the tray and a (compromised or buggy) UI tries to
+    // sneak Toggle 2 ON.
+    const hasAiSuggested = entries.some((e) => e.aiSuggested);
+    if (hasAiSuggested && toggleAll) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            "Cohort fan-out is disabled when any pending change is AI-suggested. Save with Toggle 2 off, then enable manually if needed.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const result: ApplyResult = {
+      ok: true,
+      audited: false,
+      callerRecomposed: false,
+      cohortRecomposeAttempts: [],
+    };
+
+    // ── Toggle 1: per-caller recompose ───────────────────────────────
+    if (toggleCaller && callerInContext) {
+      // Prefer a playbook id from the entries to scope the recompose;
+      // fall back to no playbook id (autoComposeForCaller handles both).
+      const firstPlaybookId =
+        entries.find((e) => e.scope === "playbook" && e.scopeId)?.scopeId ?? null;
+      try {
+        await autoComposeForCaller(callerInContext.id, firstPlaybookId);
+        result.callerRecomposed = true;
+      } catch (err: unknown) {
+        // Non-fatal — log + audit, return false so the client can show a
+        // partial-success message instead of failing the whole save.
+        console.warn(
+          "[recompose/apply] autoComposeForCaller failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    // ── Toggle 2: cohort fan-out per unique playbook scope ───────────
+    if (toggleAll) {
+      const playbookIds = uniquePlaybookScopeIds(entries);
+      for (const playbookId of playbookIds) {
+        try {
+          const url = new URL(
+            `/api/playbooks/${playbookId}/recompose-all`,
+            request.url,
+          );
+          const res = await fetch(url, {
+            method: "POST",
+            // Forward auth cookies so the downstream route sees the
+            // same session as this one.
+            headers: { cookie: request.headers.get("cookie") ?? "" },
+          });
+          const json = (await res.json().catch(() => ({}))) as Record<
+            string,
+            unknown
+          >;
+          result.cohortRecomposeAttempts.push({
+            playbookId,
+            ok: Boolean(json.ok),
+            total: typeof json.total === "number" ? json.total : undefined,
+            succeeded:
+              typeof json.succeeded === "number" ? json.succeeded : undefined,
+            failed: typeof json.failed === "number" ? json.failed : undefined,
+            error:
+              typeof json.error === "string" ? json.error : undefined,
+          });
+        } catch (err: unknown) {
+          result.cohortRecomposeAttempts.push({
+            playbookId,
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+
+    // ── Audit (always) — A9 ──────────────────────────────────────────
+    try {
+      await auditLog({
+        userId: session.user.id,
+        userEmail: session.user.email ?? undefined,
+        action: AuditAction.PENDING_CHANGES_APPLIED,
+        entityType: "PendingChanges",
+        entityId: undefined,
+        metadata: {
+          entryCount: entries.length,
+          aiSuggestedCount: entries.filter((e) => e.aiSuggested).length,
+          toggleCaller,
+          toggleAll,
+          callerRecomposed: result.callerRecomposed,
+          cohortRecomposePlaybookIds: uniquePlaybookScopeIds(entries),
+          callerInContextId: callerInContext?.id ?? null,
+        },
+      });
+      result.audited = true;
+    } catch (err: unknown) {
+      // Audit failures should not block the user — log and move on.
+      console.warn(
+        "[recompose/apply] audit log failed:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[POST /api/recompose/apply] error:", message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { X, RotateCcw, ChevronDown, ChevronRight } from "lucide-react";
 import "./prompt-tuner.css";
+import { usePendingChangesTray } from "@/hooks/use-pending-changes-tray";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -208,6 +209,19 @@ export function PromptTunerSidebar({
     if (!playbookId || !open) return;
     void refreshParameters();
   }, [playbookId, open, refreshParameters]);
+
+  // #857 — feed the pending-changes tray with caller-in-context while the
+  // sidebar is open. The tray's Toggle 1 ("Also recompose <name>") uses
+  // this to render the caller's name + default ON. Cleared on close.
+  const { push: trayPush, setCallerInContext: traySetCaller } = usePendingChangesTray();
+  useEffect(() => {
+    if (!open) return;
+    if (!callerId || !callerName) return;
+    traySetCaller({ id: callerId, name: callerName });
+    return () => {
+      traySetCaller(null);
+    };
+  }, [open, callerId, callerName, traySetCaller]);
 
   // --- Locally remember what we just applied ---
   //
@@ -636,27 +650,42 @@ export function PromptTunerSidebar({
         }));
       }
 
-      // 3. #598 Slice 2 — selective recompose.
-      //    Most config changes (Approach, cadence, decay) land in DB and take
-      //    effect on the next call lazily via the #825 stamp-and-check
-      //    pattern. The mastery threshold is special — a change there should
-      //    warm-recompose every active learner's prompt now so the new
-      //    threshold lands on in-flight prompts. Gated on `c.recompose === true`
-      //    so the no-op-on-save knobs stay cheap.
-      const shouldRecompose = pendingChanges.some((c) => c.recompose === true);
-      if (shouldRecompose) {
-        try {
-          await fetch(`/api/playbooks/${playbookId}/recompose-all`, { method: "POST" });
-        } catch (recomposeErr) {
-          // Non-fatal — the writes landed, will pick up lazily.
-          console.warn("[tuner] recompose-all call failed (non-blocking):", recomposeErr);
-        }
-        setApplyResult(
-          "Tuning saved. Active learners' prompts are being warmed in the background.",
-        );
-      } else {
-        setApplyResult("Tuning saved. Takes effect on the next call.");
+      // 3. #857 — push each change into the global PendingChangesTray.
+      //
+      //    Previously this branch auto-POSTed `/recompose-all` when any
+      //    pending change carried `recompose: true` (mastery threshold).
+      //    That silent fan-out is now opt-in via the tray's Toggle 2 —
+      //    the safety property of epic #854. Cohort recompose happens
+      //    only when the educator explicitly clicks Save & apply on the
+      //    tray with Toggle 2 ON; per-caller recompose via Toggle 1.
+      //
+      //    Underlying writes (sections 1 and 2 above) still happen
+      //    immediately at handleApply time. The tray entries serve as
+      //    visualisation + the gate for the fan-out decision.
+      for (const c of pendingChanges) {
+        const trayKey = c.tolerancesConfigKey
+          ? `tolerances.${c.tolerancesConfigKey}`
+          : c.configKey ?? c.parameterId ?? c.key;
+        trayPush({
+          key: trayKey,
+          label: c.label,
+          scopeLabel: `Course ${playbookId.slice(0, 8)}`,
+          beforeValue: c.oldValue,
+          afterValue: c.newValue,
+          scope: "playbook",
+          scopeId: playbookId,
+          aiSuggested: false,
+          // Mastery-threshold-class changes carried `recompose: true`
+          // historically. The tray's A6 pre-check reads the `key` against
+          // FANOUT_CLASS_PLAYBOOK_KEYS so the toggle defaults ON for
+          // those — preserving the old expectation without bypassing
+          // the educator's explicit click.
+          fanoutScope: c.recompose ? "caller" : "none",
+        });
       }
+      setApplyResult(
+        "Tuning saved. Review the pending changes tray (bottom-right) to recompose now, or wait for the next call.",
+      );
 
       // 4. Re-fetch parameters from the API so `effectiveValue` reflects the
       //    newly-saved values, and clear the draft so the PENDING CHANGES list
@@ -701,6 +730,7 @@ export function PromptTunerSidebar({
   }, [
     playbookId, callerId, callerName, pendingChanges, onApplied, scope,
     refreshParameters, refreshCourseTolerances, courseTolerances, draftCourseTolerances,
+    trayPush,
   ]);
 
   // --- Toggle group collapse ---

--- a/apps/admin/components/shared/PendingChangesTray.tsx
+++ b/apps/admin/components/shared/PendingChangesTray.tsx
@@ -97,6 +97,8 @@ export function PendingChangesTray(): React.ReactElement | null {
   const [preview, setPreview] = useState<PreviewState>(ZERO_PREVIEW);
   const [toggleCaller, setToggleCaller] = useState(true);
   const [toggleAll, setToggleAll] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const hasAiSuggested = useMemo(
     () => entries.some((e) => e.aiSuggested),
@@ -269,21 +271,54 @@ export function PendingChangesTray(): React.ReactElement | null {
             )}
           </div>
 
+          {saveError && (
+            <p className="hf-pending-tray-ai-warning" role="alert">
+              ⚠ {saveError}
+            </p>
+          )}
+
           <div className="hf-pending-tray-actions">
             <button
               type="button"
               className="hf-pending-tray-discard"
               onClick={clear}
+              disabled={saving}
             >
               Discard all
             </button>
             <button
               type="button"
               className="hf-pending-tray-save"
-              disabled
-              title="Save & apply lands in Story #857 — this tray currently accumulates entries only."
+              disabled={saving}
+              onClick={async () => {
+                setSaving(true);
+                setSaveError(null);
+                try {
+                  const res = await fetch("/api/recompose/apply", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      entries,
+                      toggleCaller: Boolean(callerInContext) && toggleCaller,
+                      toggleAll: !toggle2Locked && effectiveToggleAll,
+                      callerInContext,
+                    }),
+                  });
+                  const json = (await res.json()) as { ok?: boolean; error?: string };
+                  if (!res.ok || !json.ok) {
+                    throw new Error(json.error || `Apply failed (${res.status})`);
+                  }
+                  clear();
+                  // Reset toggle state for next batch
+                  setToggleAllUserTouched(false);
+                } catch (err: unknown) {
+                  setSaveError(err instanceof Error ? err.message : String(err));
+                } finally {
+                  setSaving(false);
+                }
+              }}
             >
-              Save &amp; apply (#857)
+              {saving ? "Applying…" : "Save & apply"}
             </button>
           </div>
         </>

--- a/apps/admin/tests/api/recompose-apply.test.ts
+++ b/apps/admin/tests/api/recompose-apply.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for POST /api/recompose/apply (epic #854 / Story #857).
+ *
+ * Asserts:
+ *   - AI-safety rejection when any entry is aiSuggested and toggleAll is true
+ *   - Toggle 1 invokes autoComposeForCaller
+ *   - Toggle 2 POSTs to each unique playbook's recompose-all endpoint
+ *   - PENDING_CHANGES_APPLIED audit row written regardless of toggles
+ *   - Body validation rejects unknown shapes
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn().mockResolvedValue({
+    session: {
+      user: { id: "u-test", email: "test@example.com", role: "OPERATOR" },
+    },
+  }),
+  isAuthError: vi.fn().mockReturnValue(false),
+}));
+
+const auditLogMock = vi.fn();
+vi.mock("@/lib/audit", () => ({
+  auditLog: auditLogMock,
+  AuditAction: {
+    PENDING_CHANGES_APPLIED: "pending_changes_applied",
+  },
+}));
+
+const autoComposeMock = vi.fn();
+vi.mock("@/lib/enrollment/auto-compose", () => ({
+  autoComposeForCaller: autoComposeMock,
+}));
+
+// Mock fetch for the recompose-all cohort calls
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+// Lazy import after mocks
+let POST: typeof import("@/app/api/recompose/apply/route").POST;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  autoComposeMock.mockResolvedValue(undefined);
+  auditLogMock.mockResolvedValue(undefined);
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({ ok: true, total: 5, succeeded: 5, failed: 0 }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+  ({ POST } = await import("@/app/api/recompose/apply/route"));
+});
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/recompose/apply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", cookie: "session=test" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "e-1",
+    key: "tolerances.masteryThreshold",
+    label: "Mastery threshold",
+    scopeLabel: "Course IELTS Prep",
+    beforeValue: "0.7",
+    afterValue: "0.6",
+    scope: "playbook" as const,
+    scopeId: "pb-1",
+    aiSuggested: false,
+    fanoutScope: "none" as const,
+    ...overrides,
+  };
+}
+
+describe("POST /api/recompose/apply", () => {
+  it("rejects body with empty entries array", async () => {
+    const res = await POST(
+      makeRequest({
+        entries: [],
+        toggleCaller: false,
+        toggleAll: false,
+        callerInContext: null,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("AI-safety: rejects when any entry is aiSuggested and toggleAll is true", async () => {
+    const res = await POST(
+      makeRequest({
+        entries: [makeEntry({ aiSuggested: true })],
+        toggleCaller: false,
+        toggleAll: true,
+        callerInContext: null,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/AI-suggested/i);
+    expect(autoComposeMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("AI-safety: allows aiSuggested entries when toggleAll is false", async () => {
+    const res = await POST(
+      makeRequest({
+        entries: [makeEntry({ aiSuggested: true })],
+        toggleCaller: false,
+        toggleAll: false,
+        callerInContext: null,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+
+  it("Toggle 1 (toggleCaller) invokes autoComposeForCaller with playbook from first entry", async () => {
+    const res = await POST(
+      makeRequest({
+        entries: [makeEntry({ scopeId: "pb-7" })],
+        toggleCaller: true,
+        toggleAll: false,
+        callerInContext: { id: "c-1", name: "Mary" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(autoComposeMock).toHaveBeenCalledWith("c-1", "pb-7");
+    const json = await res.json();
+    expect(json.callerRecomposed).toBe(true);
+  });
+
+  it("Toggle 1 is a no-op when callerInContext is null", async () => {
+    const res = await POST(
+      makeRequest({
+        entries: [makeEntry()],
+        toggleCaller: true,
+        toggleAll: false,
+        callerInContext: null,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(autoComposeMock).not.toHaveBeenCalled();
+  });
+
+  it("Toggle 2 (toggleAll) POSTs to recompose-all for each unique playbook scope", async () => {
+    const res = await POST(
+      makeRequest({
+        entries: [
+          makeEntry({ id: "e-1", scopeId: "pb-1" }),
+          makeEntry({ id: "e-2", scopeId: "pb-2" }),
+          makeEntry({ id: "e-3", scopeId: "pb-1" }), // dup — should NOT trigger 3rd call
+        ],
+        toggleCaller: false,
+        toggleAll: true,
+        callerInContext: null,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const calls = fetchMock.mock.calls;
+    const calledUrls = calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes("/api/playbooks/pb-1/recompose-all"))).toBe(true);
+    expect(calledUrls.some((u) => u.includes("/api/playbooks/pb-2/recompose-all"))).toBe(true);
+    const json = await res.json();
+    expect(json.cohortRecomposeAttempts).toHaveLength(2);
+  });
+
+  it("Toggle 2 forwards cookie header to downstream recompose-all", async () => {
+    await POST(
+      makeRequest({
+        entries: [makeEntry()],
+        toggleCaller: false,
+        toggleAll: true,
+        callerInContext: null,
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalled();
+    const fetchOpts = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((fetchOpts.headers as Record<string, string>).cookie).toBe("session=test");
+  });
+
+  it("PENDING_CHANGES_APPLIED audit row written even when both toggles are off", async () => {
+    await POST(
+      makeRequest({
+        entries: [makeEntry()],
+        toggleCaller: false,
+        toggleAll: false,
+        callerInContext: null,
+      }),
+    );
+    expect(auditLogMock).toHaveBeenCalledTimes(1);
+    const entry = auditLogMock.mock.calls[0][0];
+    expect(entry.action).toBe("pending_changes_applied");
+    expect(entry.metadata.entryCount).toBe(1);
+    expect(entry.metadata.toggleCaller).toBe(false);
+    expect(entry.metadata.toggleAll).toBe(false);
+    expect(entry.metadata.aiSuggestedCount).toBe(0);
+  });
+
+  it("audit row carries aiSuggestedCount + cohortRecomposePlaybookIds", async () => {
+    await POST(
+      makeRequest({
+        entries: [
+          makeEntry({ id: "e-1", scopeId: "pb-1", aiSuggested: true }),
+          makeEntry({ id: "e-2", scopeId: "pb-2", aiSuggested: false }),
+        ],
+        toggleCaller: false,
+        toggleAll: false,
+        callerInContext: null,
+      }),
+    );
+    const entry = auditLogMock.mock.calls[0][0];
+    expect(entry.metadata.aiSuggestedCount).toBe(1);
+    expect(entry.metadata.cohortRecomposePlaybookIds.sort()).toEqual(["pb-1", "pb-2"]);
+  });
+
+  it("audit failure does not block the response", async () => {
+    auditLogMock.mockRejectedValueOnce(new Error("audit DB down"));
+    const res = await POST(
+      makeRequest({
+        entries: [makeEntry()],
+        toggleCaller: false,
+        toggleAll: false,
+        callerInContext: null,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.audited).toBe(false);
+    expect(json.ok).toBe(true);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -11979,6 +11979,24 @@ Post-call pipeline endpoint that orchestrates call analysis. Receives call
 
 ## Recompose
 
+### `POST` /api/recompose/apply
+
+Acts on the toggle decisions from the PendingChangesTray's
+
+**Auth**: session OPERATOR · **Scope**: `recompose:write`
+
+**Response** `200`
+```json
+{ ok, audited, callerRecomposed, cohortRecomposeAttempts[] }
+```
+
+**Response** `400`
+```json
+{ ok: false, error } — invalid body or AI-safety violation
+```
+
+---
+
 ### `GET` /api/recompose/preview?scope=playbook|domain|system&scopeId=<uuid>
 
 Returns `{ count, sampleNames[3], etaSeconds, cacheHit, source }`
@@ -14497,8 +14515,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 451 |
-| Files with annotations | 450 |
+| Route files found | 452 |
+| Files with annotations | 451 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 


### PR DESCRIPTION
Story #857 of epic #854 — the safety-property delivery. AI-surface migrations deferred to #873.

## Discovery → reduced scope

Audit during this story showed **`PromptTunerSidebar:649` was the ONLY auto-fanout call site in the codebase.** Course Design, Cmd+K, wizard chat, and page chat all write-then-stop (timestamp bump + lazy recompose via `isPromptStale` on next caller touchpoint). So the epic's safety property — "no silent cohort recompose" — only required cutting that one line. The "push from every surface for visualisation" work for AI surfaces is filed as **#873** (non-blocking follow-up).

## Summary

- **Cut the line-649 auto-fanout in `PromptTunerSidebar.tsx`** — writes still happen immediately on Apply, but cohort recompose is now opt-in via the tray's Toggle 2.
- **Tune sidebar → tray bridge**: after successful save, each `PendingChange` pushes to the tray (`recompose: true` maps to `fanoutScope: 'caller'` so `FANOUT_CLASS_PLAYBOOK_KEYS` pre-checks Toggle 2). Caller-in-context set on sidebar open, cleared on close.
- **`POST /api/recompose/apply`** new endpoint backing the tray's Save & apply:
  - Toggle 1 → `autoComposeForCaller(callerInContext.id, playbookId)`
  - Toggle 2 → POSTs to `/api/playbooks/[id]/recompose-all` for each unique playbook scope (deduped)
  - Always emits `AuditAction.PENDING_CHANGES_APPLIED` (A9)
  - **AI-safety defence-in-depth**: 400 when any entry is `aiSuggested` and `toggleAll: true`. Complements the ESLint build-time guard from #855.
- **`PendingChangesTray` Save & apply button** wired — POSTs to the new endpoint, clears the tray on success, surfaces errors inline.

## Test plan

- [x] `npx tsc --noEmit` — no new errors (197 baseline preserved)
- [x] `npm run ratchet:check` — passes (baseline lowered 4470 → 4468; -2 inherited warnings cleaned by the sidebar refactor)
- [x] 33/33 tests pass — `recompose-apply.test.ts` (10) + `use-pending-changes-tray.test.tsx` (13) + `PendingChangesTray.test.tsx` (10)
- [ ] Smoke: open caller-detail Tune sidebar, change mastery threshold → save → tray appears bottom-right with the change pre-checking Toggle 2 ON. Click Save & apply → tray empties, network shows POST /api/recompose/apply → POST /api/playbooks/[id]/recompose-all.
- [ ] Smoke: change a non-fanout-class knob (cadence) → tray shows entry, Toggle 2 OFF default, Toggle 1 ON default with caller name.
- [ ] Smoke: Discard all → tray vanishes, no network calls.

## Two commits, deliberately separate

1. `chore(lint): lock ratchet baseline at 4468` — sidebar refactor cleaned up two inherited warnings as a side effect
2. `feat(#857): close the only auto-fanout site + wire tray Save & apply`

Scope-enforcer-clean. Squash on merge.

## Not in this PR

- AI-surface migrations (Cmd+K / wizard chat / page chat push to tray with `aiSuggested: true`) → **#873**
- UserTask fan-out job record + progress toast + bulk stale sweep → **#858**

Deploy: `/vm-cp` (no migration).

Epic: #854
Story: #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)
