### PR TITLE
fix(chat): hide caller+playbook chips from breadcrumb stripe in DATA/TUNING

### DIFF
--- a/apps/admin/components/chat/ChatPanel.tsx
+++ b/apps/admin/components/chat/ChatPanel.tsx
@@ -20,15 +20,31 @@ const ENTITY_LABELS: Record<string, string> = {
 };
 
 // Sub-components
-function ChatBreadcrumbStripe({ breadcrumbs }: { breadcrumbs: EntityBreadcrumb[] }) {
+function ChatBreadcrumbStripe({
+  breadcrumbs,
+  hideTypes,
+}: {
+  breadcrumbs: EntityBreadcrumb[];
+  /**
+   * Types to hide from the stripe. Used by DATA + TUNING modes to suppress
+   * caller + playbook chips that the Scope toggle already shows above,
+   * while still surfacing drill-down chips like Call / Memory / Spec.
+   */
+  hideTypes?: ReadonlyArray<EntityBreadcrumb["type"]>;
+}) {
   const { clearToEntity } = useEntityContext();
 
-  // Deduplicate breadcrumbs by ID (keep first occurrence)
-  const uniqueBreadcrumbs = breadcrumbs.filter(
-    (crumb, index, self) => self.findIndex((c) => c.id === crumb.id) === index
-  );
+  // Deduplicate breadcrumbs by ID (keep first occurrence), then filter out
+  // types the parent doesn't want re-displayed.
+  const uniqueBreadcrumbs = breadcrumbs
+    .filter((crumb, index, self) => self.findIndex((c) => c.id === crumb.id) === index)
+    .filter((crumb) => !hideTypes?.includes(crumb.type));
 
   if (uniqueBreadcrumbs.length === 0) {
+    // When hideTypes is set (DATA/TUNING modes), absence of drill-down
+    // chips is normal — the Scope toggle already shows context. Render
+    // nothing instead of the "No context selected" empty state.
+    if (hideTypes && hideTypes.length > 0) return null;
     return (
       <div className="chat-breadcrumb-empty">
         No context selected - navigate to a caller or call to add context
@@ -465,8 +481,14 @@ export function ChatPanel() {
           {/* Active ticket stripe (only in DATA mode when a discussion is active) */}
           {mode === "DATA" && <DiscussingTicketStripe />}
 
-          {/* Context Breadcrumbs */}
-          <ChatBreadcrumbStripe breadcrumbs={breadcrumbs} />
+          {/* Context Breadcrumbs — in DATA/TUNING modes the Scope toggle
+              above already shows caller + playbook, so hide those types to
+              avoid duplicate display. Drill-down chips (Call, Memory,
+              Spec, etc.) still render here. */}
+          <ChatBreadcrumbStripe
+            breadcrumbs={breadcrumbs}
+            hideTypes={mode === "DATA" || mode === "TUNING" ? ["caller", "playbook"] : undefined}
+          />
 
           {/* Messages */}
           <ChatMessages />


### PR DESCRIPTION
## Summary

After #872 surfaced the Scope toggle in the Assistant tab, the breadcrumb stripe directly below it still showed the same caller + playbook — two displays of the same context (visible in screenshot from this morning).

## Change

`ChatBreadcrumbStripe` now accepts an optional `hideTypes` list. `ChatPanel` passes `["caller", "playbook"]` in DATA + TUNING modes so the Scope toggle owns those types and the stripe is reserved for drill-down chips (Call, Memory, Spec, Transcript, etc.). When DATA/TUNING and only caller/playbook are present, the stripe renders nothing — no misleading "No context selected" empty state.

CALL and BUG modes (no toggle there) get the full unfiltered stripe.

## Test plan

- [ ] Cmd+K on `/x/courses/<A>/<learner>` → Assistant tab → Scope toggle shows Learner + Course; breadcrumb stripe is empty (no doubles).
- [ ] Drill into a call → stripe re-appears with just `Call: <label>`; Scope toggle still shows Learner + Course above.
- [ ] Tune tab → same behaviour as Assistant.
- [ ] CALL / BUG modes → stripe shows all chips (toggle absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)