### PR TITLE
fix(#873): close pendingChange coverage gaps across 7 admin-tool handlers

### DIFF
--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -782,6 +782,25 @@ async function handleUpdateBehaviorTarget(input: Record<string, any>) {
         error: `Parameter "${parameterId}" is not an adjustable BEHAVIOR parameter. Pick one from the catalogue in your system prompt — do not invent IDs.`,
       };
     }
+    // #873 follow-up — emit pendingChange so the tray surfaces the AI
+    // edit with `aiSuggested: true`. LEARNER-scope writes affect one
+    // caller; we set scopeId=null so the cohort preview doesn't fetch
+    // (the tray hides Toggle 2 when count=0). Toggle 1 ("Also recompose
+    // <name>") drives the recompose via the caller-in-context wired
+    // from the Tune sidebar in #857.
+    const pendingChangeLearner =
+      result.action !== "noop"
+        ? buildPendingChangePayload({
+            scope: "playbook",
+            scopeId: null,
+            scopeLabel: `Learner override`,
+            key: result.parameterId,
+            label: result.parameterId,
+            beforeValue: undefined,
+            afterValue: result.value,
+          })
+        : undefined;
+
     return {
       ok: true,
       scope: "LEARNER",
@@ -795,6 +814,7 @@ async function handleUpdateBehaviorTarget(input: Record<string, any>) {
           : result.action === "removed"
             ? `Removed the learner-scope override for ${parameterId} on this caller. The course-level value now applies. Existing sessions take effect at the next call.`
             : `Set ${parameterId} to ${result.value} for this learner only. Tuning saved — applies at the next call. In-flight sessions are not affected.`,
+      ...(pendingChangeLearner ? { pendingChange: pendingChangeLearner } : {}),
     };
   }
 
@@ -819,6 +839,24 @@ async function handleUpdateBehaviorTarget(input: Record<string, any>) {
       error: `Parameter "${parameterId}" is not an adjustable BEHAVIOR parameter. Pick one from the catalogue in your system prompt — do not invent IDs.`,
     };
   }
+  // #873 follow-up — emit pendingChange. PLAYBOOK-scope writes affect
+  // every active learner on this course; the tray's preview will fetch
+  // the cohort count. Toggle 2 stays locked OFF (aiSuggested + the A5
+  // defence-in-depth from #856). Toggle 1 + the educator's explicit
+  // override remain the path to cohort fanout.
+  const pendingChangePlaybook =
+    result.action !== "noop"
+      ? buildPendingChangePayload({
+          scope: "playbook",
+          scopeId: playbookId,
+          scopeLabel: `Course override`,
+          key: result.parameterId,
+          label: result.parameterId,
+          beforeValue: undefined,
+          afterValue: result.value,
+        })
+      : undefined;
+
   return {
     ok: true,
     scope: "PLAYBOOK",
@@ -832,6 +870,7 @@ async function handleUpdateBehaviorTarget(input: Record<string, any>) {
         : result.action === "removed"
           ? `Removed the course-level override for ${parameterId}. Tuning saved. Existing learners need re-prompting to pick up the change.`
           : `Set ${parameterId} to ${result.value} on this course. Tuning saved — applies on every learner's next call. Existing in-flight calls are not affected.`,
+    ...(pendingChangePlaybook ? { pendingChange: pendingChangePlaybook } : {}),
   };
 }
 
@@ -1250,14 +1289,32 @@ async function handleUpdateCurriculumModule(input: Record<string, any>) {
     `[admin-tools] Updated module "${existing.slug}". Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped}. Reason: ${input.reason || "(not given)"}`,
   );
 
+  // #873 follow-up — emit pendingChange when the timestamp bumped. AI
+  // tool sets aiSuggested=true; the tray's defence-in-depth lock keeps
+  // Toggle 2 OFF (no cohort fanout from an AI-driven curriculum edit).
+  const fields = Object.keys(data);
+  const pendingChange =
+    timestampBumped && fields.length > 0
+      ? buildPendingChangePayload({
+          scope: "playbook",
+          scopeId: playbookId ?? null,
+          scopeLabel: `Module ${existing.slug}`,
+          key: fields[0],
+          label: fields[0],
+          beforeValue: undefined,
+          afterValue: (data as Record<string, unknown>)[fields[0]],
+        })
+      : undefined;
+
   return {
     ok: true,
     module_id: moduleId,
     playbook_id: playbookId,
-    updated_fields: Object.keys(data),
+    updated_fields: fields,
     compose_inputs_bumped: timestampBumped,
     new_state: updated,
     message: `Updated module ${existing.slug}. ${timestampBumped ? "Enrolled callers will recompose on next call." : "No playbook linked yet — no stale bump."}`,
+    ...(pendingChange ? { pendingChange } : {}),
   };
 }
 
@@ -1304,6 +1361,23 @@ async function handleUpdateAssertionLoLink(input: Record<string, any>) {
     `[admin-tools] ${loId ? "Linked" : "Cleared"} assertion ${assertionId} → LO ${loId ?? "none"}. composeInputsUpdatedAt bumped for ${playbookIds.length} playbooks. Reason: ${input.reason || "(not given)"}`,
   );
 
+  // #873 follow-up — emit pendingChange. A single source can be tied to
+  // multiple playbooks; the tray entry uses the first as the cohort
+  // preview context. Known v1 limitation: the message text quotes the
+  // accurate "N playbook(s)" count.
+  const pendingChange =
+    playbookIds.length > 0
+      ? buildPendingChangePayload({
+          scope: "playbook",
+          scopeId: playbookIds[0],
+          scopeLabel: `Assertion link`,
+          key: "learningObjectiveId",
+          label: loId ? "LO link" : "Cleared LO link",
+          beforeValue: undefined,
+          afterValue: loId ?? "(none)",
+        })
+      : undefined;
+
   return {
     ok: true,
     assertion_id: assertionId,
@@ -1312,6 +1386,7 @@ async function handleUpdateAssertionLoLink(input: Record<string, any>) {
     message: loId
       ? `Linked assertion to LO. ${playbookIds.length} playbook(s) on this source will recompose on next call.`
       : `Cleared LO link on assertion. ${playbookIds.length} playbook(s) on this source will recompose.`,
+    ...(pendingChange ? { pendingChange } : {}),
   };
 }
 
@@ -1349,12 +1424,26 @@ async function handleConfirmGoal(input: Record<string, any>) {
     `[admin-tools] Confirmed goal "${goal.name}" for caller ${goal.callerId}. Reason: ${input.reason || "(not given)"}`,
   );
 
+  // #873 follow-up — emit pendingChange. Goal lifecycle affects one
+  // caller only; scopeId=null hides Toggle 2's cohort preview. Toggle 1
+  // (caller-in-context) drives the recompose.
+  const pendingChange = buildPendingChangePayload({
+    scope: "playbook",
+    scopeId: null,
+    scopeLabel: `Goal "${goal.name}"`,
+    key: "status",
+    label: "Status",
+    beforeValue: goal.status,
+    afterValue: "COMPLETED",
+  });
+
   return {
     ok: true,
     goal_id: goalId,
     caller_id: goal.callerId,
     new_state: { status: updatedGoal.status, completedAt: updatedGoal.completedAt, progress: updatedGoal.progress },
     message: `Goal "${goal.name}" marked COMPLETED. This caller will recompose on next call.`,
+    pendingChange,
   };
 }
 
@@ -1386,11 +1475,23 @@ async function handleDismissGoal(input: Record<string, any>) {
     `[admin-tools] Dismissed completion signal for goal "${goal.name}" caller ${goal.callerId}. Reason: ${input.reason || "(not given)"}`,
   );
 
+  // #873 follow-up — emit pendingChange (caller-only, scopeId=null).
+  const pendingChange = buildPendingChangePayload({
+    scope: "playbook",
+    scopeId: null,
+    scopeLabel: `Goal "${goal.name}"`,
+    key: "completionSignal",
+    label: "Completion signal",
+    beforeValue: undefined,
+    afterValue: "dismissed",
+  });
+
   return {
     ok: true,
     goal_id: goalId,
     caller_id: goal.callerId,
     message: `Completion signal for "${goal.name}" dismissed. This caller will recompose on next call.`,
+    pendingChange,
   };
 }
 
@@ -1721,13 +1822,29 @@ async function handleUpdateLearningObjective(input: Record<string, any>) {
     `[admin-tools] Updated LO ${existing.ref}. Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped}. Reason: ${input.reason || "(not given)"}`,
   );
 
+  // #873 follow-up — emit pendingChange when the timestamp bumped.
+  const loFields = Object.keys(data);
+  const pendingChange =
+    timestampBumped && loFields.length > 0
+      ? buildPendingChangePayload({
+          scope: "playbook",
+          scopeId: null, // playbookId resolved earlier but not surfaced here; cohort preview suppressed
+          scopeLabel: `LO ${existing.ref}`,
+          key: loFields[0],
+          label: loFields[0],
+          beforeValue: undefined,
+          afterValue: (data as Record<string, unknown>)[loFields[0]],
+        })
+      : undefined;
+
   return {
     ok: true,
     learning_objective_id: loId,
-    updated_fields: Object.keys(data),
+    updated_fields: loFields,
     compose_inputs_bumped: timestampBumped,
     new_state: updated,
     message: `Updated ${existing.ref}. ${timestampBumped ? "Enrolled callers will recompose on next call." : ""}`.trim(),
+    ...(pendingChange ? { pendingChange } : {}),
   };
 }
 
@@ -1778,13 +1895,29 @@ async function handleUpdateCurriculumMetadata(input: Record<string, any>) {
     `[admin-tools] Updated curriculum "${existing.name}" → "${updated.name}". Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped}. Reason: ${input.reason || "(not given)"}`,
   );
 
+  // #873 follow-up — emit pendingChange when the timestamp bumped.
+  const curFields = Object.keys(data);
+  const pendingChange =
+    timestampBumped && curFields.length > 0
+      ? buildPendingChangePayload({
+          scope: "playbook",
+          scopeId: existing.playbookId,
+          scopeLabel: `Curriculum ${existing.name}`,
+          key: curFields[0],
+          label: curFields[0],
+          beforeValue: undefined,
+          afterValue: (data as Record<string, unknown>)[curFields[0]],
+        })
+      : undefined;
+
   return {
     ok: true,
     curriculum_id: curriculumId,
-    updated_fields: Object.keys(data),
+    updated_fields: curFields,
     compose_inputs_bumped: timestampBumped,
     new_state: updated,
     message: `Updated ${updated.name}. ${timestampBumped ? "Enrolled callers will recompose on next call." : "No playbook linked yet — no stale bump."}`.trim(),
+    ...(pendingChange ? { pendingChange } : {}),
   };
 }
 

--- a/apps/admin/tests/lib/admin-tools-pending-change.test.ts
+++ b/apps/admin/tests/lib/admin-tools-pending-change.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the #873 follow-up — pendingChange emission across every
+ * compose-affecting admin tool handler.
+ *
+ * Per CHAIN-CONTRACTS Link 3, the producer set is: Playbook.config,
+ * Domain.config, AnalysisSpec.config, BehaviorTarget, curriculum / LO /
+ * assertion writes, goal lifecycle. Each of those handlers MUST emit a
+ * `pendingChange` payload in its result when the timestamp bumped so
+ * the chat route's `X-Pending-Changes` header carries it to the client
+ * and the tray picks it up with `aiSuggested: true`.
+ *
+ * One test per migrated handler asserting the contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  playbook: { findUnique: vi.fn(), update: vi.fn() },
+  caller: { findUnique: vi.fn(), update: vi.fn() },
+  callerAttribute: { findFirst: vi.fn(), update: vi.fn() },
+  curriculum: { findUnique: vi.fn(), update: vi.fn(), findFirst: vi.fn() },
+  curriculumModule: { findUnique: vi.fn(), update: vi.fn() },
+  learningObjective: { findUnique: vi.fn(), update: vi.fn() },
+  contentAssertion: { update: vi.fn() },
+  goal: { findUnique: vi.fn(), update: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+vi.mock("@/lib/compose/bump-timestamp", () => ({
+  bumpPlaybookComposeTimestamp: vi.fn(),
+  bumpCallerComposeTimestamp: vi.fn(),
+}));
+
+// Resolve helpers — stub to return predictable playbook IDs.
+// Both helpers live in lib/curriculum/resolve-playbook-for-curriculum.ts.
+vi.mock("@/lib/curriculum/resolve-playbook-for-curriculum", () => ({
+  resolvePlaybookIdForCurriculum: vi.fn(async () => "pb-1"),
+  resolvePlaybookIdsForContentSource: vi.fn(async () => ["pb-1", "pb-2"]),
+}));
+
+// BehaviorTarget writer (used by update_behavior_target handler)
+vi.mock("@/lib/agent-tuner/write-target", () => ({
+  writeBehaviorTarget: vi.fn(async () => ({
+    ok: true,
+    parameterId: "BEH-WARMTH",
+    action: "updated",
+    value: 0.7,
+  })),
+  writeCallerBehaviorTarget: vi.fn(async () => ({
+    ok: true,
+    parameterId: "TOL-MASTERY-THRESHOLD",
+    action: "updated",
+    value: 0.55,
+  })),
+}));
+
+describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () => {
+  let executeAdminTool: typeof import("@/lib/chat/admin-tool-handlers").executeAdminTool;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/lib/chat/admin-tool-handlers");
+    executeAdminTool = mod.executeAdminTool;
+  });
+
+  it("update_behavior_target LEARNER emits pendingChange (scopeId=null)", async () => {
+    const raw = await executeAdminTool(
+      "update_behavior_target",
+      { scope: "LEARNER", caller_id: "c-1", parameter_id: "TOL-MASTERY-THRESHOLD", target_value: 0.55 },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.ok).toBe(true);
+    expect(result.pendingChange).toMatchObject({
+      key: "TOL-MASTERY-THRESHOLD",
+      scope: "playbook",
+      scopeId: null,
+      fanoutScope: "caller",
+    });
+  });
+
+  it("update_behavior_target PLAYBOOK emits pendingChange with playbookId", async () => {
+    const raw = await executeAdminTool(
+      "update_behavior_target",
+      { scope: "PLAYBOOK", playbook_id: "pb-7", parameter_id: "BEH-WARMTH", target_value: 0.7 },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.pendingChange).toMatchObject({
+      scope: "playbook",
+      scopeId: "pb-7",
+      fanoutScope: "caller",
+    });
+  });
+
+  it("update_curriculum_module emits pendingChange when playbook resolves", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: "mod-1",
+      slug: "intro",
+      title: "Intro",
+      curriculumId: "cur-1",
+    });
+    mockPrisma.curriculumModule.update.mockResolvedValue({
+      id: "mod-1",
+      slug: "intro",
+      title: "Intro 2",
+    });
+    const raw = await executeAdminTool(
+      "update_curriculum_module",
+      { module_id: "mod-1", title: "Intro 2" },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.compose_inputs_bumped).toBe(true);
+    expect(result.pendingChange).toMatchObject({
+      key: "title",
+      scope: "playbook",
+      scopeId: "pb-1",
+    });
+  });
+
+  it("update_assertion_lo_link emits pendingChange with first playbook", async () => {
+    mockPrisma.contentAssertion.update.mockResolvedValue({
+      id: "a-1",
+      sourceId: "src-1",
+      learningObjectiveId: "lo-1",
+      learningOutcomeRef: "LO-1",
+      linkConfidence: 1.0,
+    });
+    mockPrisma.learningObjective.findUnique.mockResolvedValue({ id: "lo-1", ref: "LO-1" });
+    const raw = await executeAdminTool(
+      "update_assertion_lo_link",
+      { assertion_id: "a-1", learning_objective_id: "lo-1" },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.pendingChange).toMatchObject({
+      scope: "playbook",
+      scopeId: "pb-1",
+      key: "learningObjectiveId",
+    });
+  });
+
+  it("confirm_goal emits pendingChange (caller-only, scopeId=null)", async () => {
+    mockPrisma.goal.findUnique.mockResolvedValue({
+      id: "g-1",
+      name: "Goal A",
+      callerId: "c-1",
+      isAssessmentTarget: false,
+      status: "PENDING",
+    });
+    mockPrisma.callerAttribute.findFirst.mockResolvedValue({ id: "ca-1" });
+    mockPrisma.goal.update.mockResolvedValue({
+      status: "COMPLETED",
+      completedAt: new Date("2026-05-26"),
+      progress: 1.0,
+    });
+    const raw = await executeAdminTool("confirm_goal", { goal_id: "g-1" }, "OPERATOR");
+    const result = JSON.parse(raw);
+    expect(result.pendingChange).toMatchObject({
+      key: "status",
+      scope: "playbook",
+      scopeId: null,
+      fanoutScope: "caller",
+    });
+    expect(result.pendingChange.afterValue).toBe("COMPLETED");
+  });
+
+  it("dismiss_goal emits pendingChange (caller-only)", async () => {
+    mockPrisma.goal.findUnique.mockResolvedValue({
+      id: "g-1",
+      name: "Goal A",
+      callerId: "c-1",
+    });
+    mockPrisma.callerAttribute.findFirst.mockResolvedValue({ id: "ca-1" });
+    mockPrisma.callerAttribute.update.mockResolvedValue({});
+    const raw = await executeAdminTool("dismiss_goal", { goal_id: "g-1" }, "OPERATOR");
+    const result = JSON.parse(raw);
+    expect(result.pendingChange).toMatchObject({
+      key: "completionSignal",
+      scope: "playbook",
+      scopeId: null,
+    });
+  });
+
+  it("update_learning_objective emits pendingChange when bumped", async () => {
+    mockPrisma.learningObjective.findUnique.mockResolvedValue({
+      id: "lo-1",
+      ref: "LO-1",
+      moduleId: "mod-1",
+      module: { curriculumId: "cur-1" },
+    });
+    mockPrisma.learningObjective.update.mockResolvedValue({
+      id: "lo-1",
+      ref: "LO-1",
+      description: "Revised",
+    });
+    const raw = await executeAdminTool(
+      "update_learning_objective",
+      { learning_objective_id: "lo-1", description: "Revised" },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.compose_inputs_bumped).toBe(true);
+    expect(result.pendingChange).toMatchObject({
+      key: "description",
+      scope: "playbook",
+    });
+  });
+
+  it("update_curriculum_metadata emits pendingChange with playbookId from curriculum", async () => {
+    mockPrisma.curriculum.findUnique.mockResolvedValue({
+      id: "cur-1",
+      name: "Old",
+      playbookId: "pb-9",
+    });
+    mockPrisma.curriculum.update.mockResolvedValue({
+      id: "cur-1",
+      name: "New",
+      description: null,
+      sourceTitle: null,
+      sourceYear: null,
+      authors: [],
+    });
+    const raw = await executeAdminTool(
+      "update_curriculum_metadata",
+      { curriculum_id: "cur-1", name: "New" },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.pendingChange).toMatchObject({
+      scope: "playbook",
+      scopeId: "pb-9",
+      key: "name",
+    });
+  });
+
+  it("does NOT emit pendingChange when timestamp didn't bump (no playbook linked)", async () => {
+    mockPrisma.curriculumModule.findUnique.mockResolvedValue({
+      id: "mod-1",
+      slug: "intro",
+      title: "Intro",
+      curriculumId: "cur-orphan",
+    });
+    // Override the resolve mock to return null (no playbook linked).
+    const { resolvePlaybookIdForCurriculum } = await import(
+      "@/lib/curriculum/resolve-playbook-for-curriculum"
+    );
+    (resolvePlaybookIdForCurriculum as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    mockPrisma.curriculumModule.update.mockResolvedValue({
+      id: "mod-1",
+      slug: "intro",
+      title: "Renamed",
+    });
+    const raw = await executeAdminTool(
+      "update_curriculum_module",
+      { module_id: "mod-1", title: "Renamed" },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.compose_inputs_bumped).toBe(false);
+    // pendingChange field should be absent (or undefined)
+    expect(result.pendingChange).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Coverage-gap fix for #873.

## Background

#873 shipped pendingChange emission in `admin-tool-handlers.ts` for 3 handlers (`updatePlaybookConfig`, `updateDomainConfig`, `updateAnalysisSpecConfig`) — but missed **every other compose-affecting handler**. User surfaced this with a screenshot: AI changed a BehaviorTarget tolerance via the chat, the change applied, but no tray appeared.

Per CHAIN-CONTRACTS Link 3 (AI write paths sub-contract), the compose-affecting producer set is broader than just the 3 config helpers. This PR closes that gap.

## What ships

`pendingChange` emission added to 7 more handlers in `admin-tool-handlers.ts`:

| Handler | Scope | scopeId | Why |
|---|---|---|---|
| `update_behavior_target` LEARNER | playbook | **null** | Caller-only blast radius; Toggle 1 drives recompose |
| `update_behavior_target` PLAYBOOK | playbook | playbookId | Cohort blast radius; Toggle 2 stays disabled (A5) |
| `update_curriculum_module` | playbook | resolved | Cohort blast radius |
| `update_assertion_lo_link` | playbook | first of N | Multi-playbook; first one wins (known v1 limitation) |
| `confirm_goal` / `dismiss_goal` | playbook | **null** | Caller-only |
| `update_learning_objective` | playbook | (null in v1) | Cohort but playbookId not surfaced at call site |
| `update_curriculum_metadata` | playbook | curriculum.playbookId | Cohort |

All `aiSuggested: true` (server side `/api/recompose/apply` enforces this — Toggle 2 cannot fire from AI-touched batches per A5).

## Out of scope

- `handleAddContentAssertions` / `handleCreateSubjectWithSource` / `handleLinkSubjectToDomain` / `handleGenerateCurriculum` — they don't call `bump*` directly (projection layer does the bump async). No emission point.
- `handleUpdateCaller` / `handleUpdatePlaybookMeta` — non-compose fields only.
- `conversational-wizard-tools.ts` + `course-ref-tools.ts` — 15 tools across 2 registries. Lower priority (wizard is pre-enrollment); file as #873b if needed.

## Tests

- New `tests/lib/admin-tools-pending-change.test.ts` — 9 tests, one per migrated handler + negative case.
- All **119 related tests pass** across 8 files (9 new + 64 existing admin-tools + 46 tray/payload tests).

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] `npm run ratchet:check` — passes (4468, baseline preserved)
- [x] 119/119 tests pass
- [ ] Smoke (matches earlier screenshot): chat → "Set Brynn's mastery threshold to 0.55" → tray appears bottom-right with (AI) badge, Toggle 2 locked OFF, Save & apply recomposes Brynn

Deploy: `/vm-cp` (no migration).

Epic: #854
Story: #873 (coverage-gap fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
