### PR TITLE
chore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ A-Sample Docs/
 *.pdf
 *.docx
 docs/market-test-plan.md
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Single-line .gitignore addition. The lock file is auto-created/destroyed by the Claude Code harness — should never be committed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)