### PR TITLE
fix(#873): parse stringified tool result — ROOT CAUSE of empty tray from chat

### DIFF
--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -12,7 +12,7 @@ import { requireAuth, isAuthError } from "@/lib/permissions";
 // zod imported dynamically inside handler — see chatSchema below
 import { ADMIN_TOOLS } from "@/lib/chat/admin-tools";
 import { executeAdminTool } from "@/lib/chat/admin-tool-handlers";
-import { hasPendingChangePayload, type PendingChangePayload } from "@/lib/chat/pending-change-payload";
+import { extractPendingChangeFromToolResult, type PendingChangePayload } from "@/lib/chat/pending-change-payload";
 
 // TUNING mode gets a narrow tool surface — behaviour-target writer + playbook
 // config writer. Broader admin tools stay in DATA mode where they belong.
@@ -428,8 +428,12 @@ async function handleDataModeWithTools(
       });
       // #873 — collect any pendingChange payload so the client renderer
       // can push it into the PendingChangesTray with `aiSuggested: true`.
-      if (hasPendingChangePayload(result)) {
-        pendingChanges.push(result.pendingChange);
+      // `result` is a JSON-stringified blob (executeAdminTool calls
+      // truncateResult → JSON.stringify) — must parse before extraction.
+      // Silent on parse failure (truncated tool results are accepted).
+      const pendingChange = extractPendingChangeFromToolResult(result);
+      if (pendingChange) {
+        pendingChanges.push(pendingChange);
       }
     }
 
@@ -529,8 +533,10 @@ async function handleTuningModeWithTools(
         content: result,
       });
       // #873 — surface pendingChange to the client via response header.
-      if (hasPendingChangePayload(result)) {
-        pendingChanges.push(result.pendingChange);
+      // `result` is a JSON-stringified blob — must parse before extraction.
+      const pendingChange = extractPendingChangeFromToolResult(result);
+      if (pendingChange) {
+        pendingChanges.push(pendingChange);
       }
     }
 

--- a/apps/admin/lib/chat/pending-change-payload.ts
+++ b/apps/admin/lib/chat/pending-change-payload.ts
@@ -79,6 +79,34 @@ function stringifyValue(v: unknown): string {
 }
 
 /**
+ * Extract a pendingChange payload from a stringified tool result.
+ *
+ * `lib/chat/admin-tool-handlers.ts::executeAdminTool` returns a JSON-
+ * stringified blob (so the AI loop can append it as a tool_result block).
+ * The chat route needs to pluck pendingChange OUT of that string before
+ * the result goes back to the model — otherwise the AI sees the field
+ * (harmless but noisy) and the client gets nothing in the
+ * X-Pending-Changes header.
+ *
+ * Defensive on parse failure: tool results may be truncated at
+ * MAX_RESULT_LENGTH (3000) producing invalid JSON. In that case we
+ * silently return null — accepting that very-long tool results lose
+ * their tray push as a v1 limitation.
+ */
+export function extractPendingChangeFromToolResult(
+  toolResultString: string,
+): PendingChangePayload | null {
+  if (typeof toolResultString !== "string") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(toolResultString);
+  } catch {
+    return null;
+  }
+  return hasPendingChangePayload(parsed) ? parsed.pendingChange : null;
+}
+
+/**
  * Type guard — detects whether a chat tool result carries a pending-change
  * payload. Tool results are heterogenous shapes; this narrows safely.
  */

--- a/apps/admin/tests/lib/chat/pending-change-payload.test.ts
+++ b/apps/admin/tests/lib/chat/pending-change-payload.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildPendingChangePayload,
   hasPendingChangePayload,
+  extractPendingChangeFromToolResult,
 } from "@/lib/chat/pending-change-payload";
 
 describe("buildPendingChangePayload", () => {
@@ -137,5 +138,55 @@ describe("hasPendingChangePayload type guard", () => {
       pendingChange: { ...valid.pendingChange, scope: "system" as const, scopeId: null },
     };
     expect(hasPendingChangePayload(ok)).toBe(true);
+  });
+});
+
+describe("extractPendingChangeFromToolResult (chat-route bridge)", () => {
+  const validPayload = {
+    key: "k",
+    label: "L",
+    scopeLabel: "S",
+    beforeValue: "0.7",
+    afterValue: "0.6",
+    scope: "playbook" as const,
+    scopeId: "pb-1",
+    fanoutScope: "caller" as const,
+  };
+
+  it("extracts pendingChange from a stringified tool result", () => {
+    const toolResult = JSON.stringify({
+      ok: true,
+      message: "done",
+      pendingChange: validPayload,
+    });
+    const extracted = extractPendingChangeFromToolResult(toolResult);
+    expect(extracted).toEqual(validPayload);
+  });
+
+  it("returns null when the string has no pendingChange field", () => {
+    const toolResult = JSON.stringify({ ok: true, message: "no payload" });
+    expect(extractPendingChangeFromToolResult(toolResult)).toBeNull();
+  });
+
+  it("returns null for truncated / malformed JSON (3000+ char results)", () => {
+    // Simulates `truncateResult`'s "json.slice(0, 3000) + '... (truncated)'"
+    const truncated = '{"ok":true,"pendingChange":{"key":"k","label":"L"... (truncated)';
+    expect(extractPendingChangeFromToolResult(truncated)).toBeNull();
+  });
+
+  it("returns null when input is not a string", () => {
+    // Defensive against future signature drift
+    expect(extractPendingChangeFromToolResult(null as unknown as string)).toBeNull();
+    expect(
+      extractPendingChangeFromToolResult({ pendingChange: validPayload } as unknown as string),
+    ).toBeNull();
+  });
+
+  it("returns null when pendingChange exists but has wrong shape", () => {
+    const toolResult = JSON.stringify({
+      ok: true,
+      pendingChange: { key: 42 /* should be string */ },
+    });
+    expect(extractPendingChangeFromToolResult(toolResult)).toBeNull();
   });
 });


### PR DESCRIPTION
**ROOT CAUSE** of "changes applied but no tray" — the bug that's persisted across #878 + #881.

## What was broken

`executeAdminTool` returns a **JSON-stringified blob** (via `truncateResult` → `JSON.stringify`) so the AI loop can append it as a `tool_result` content block. But the chat route's `hasPendingChangePayload(result)` check assumed `result` was an object — `typeof obj === "object"` fails on strings, so the type guard always returned false. **Header `X-Pending-Changes` was never set.**

The bug shipped in **#878** (chat route initial wiring), survived **#881** (added 7 more emission sites on the handler side), and only got caught when the user reported persistent "changes applied but no tray" with a second screenshot.

## Why existing tests didn't catch it

Every test invoked the handler directly and `JSON.parse`d the return — they exercised the handler in isolation. **No test crossed the route↔handler boundary** with the stringification step in the middle. Filing the integration-test gap as a TODO.

## Fix

New helper `extractPendingChangeFromToolResult(str)`:
- `JSON.parse` the string (silent on parse failure to handle truncated >3000-char results)
- Run through the existing `hasPendingChangePayload` type-guard
- Return the payload or null

Chat route's DATA + TUNING mode tool loops swap the broken `hasPendingChangePayload(result)` for `extractPendingChangeFromToolResult(result)`.

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] `npm run ratchet:check` — passes (4468)
- [x] **124/124 tests pass** across 8 files (5 new extractor tests + everything else green)
- [ ] Smoke: chat → "Set Brynn's mastery threshold to 0.55" → **tray now appears** with `(AI)` badge

After this PR merges, the user's screenshot scenario actually works end-to-end for the first time.

Deploy: `/vm-cp` (no migration).

Epic: #854
Story: #873 (root-cause fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
