### PR TITLE
fix(#884): block Ready to Teach until upstream critical checks pass

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/setup-status/route.ts
@@ -10,11 +10,14 @@ import type { SetupStatusResponse, SetupStatusErrorResponse } from "./types";
  * @auth VIEWER
  * @tags courses, readiness
  * @description Returns aggregated setup status for stages 4-6 of the Course Setup Tracker.
- *   Stages 1-3 are derived client-side from data already loaded on the page.
- *   This endpoint checks: lesson plan existence, onboarding config, and prompt composability.
+ *   Stages 1-3 are derived client-side from data already loaded on the page,
+ *   but #884 S0 also exposes `hasSources` + `hasAssertions` so the client can
+ *   enforce `ready_to_teach ⇒ ∀ prior step done` without re-fetching subjects.
+ *   This endpoint checks: lesson plan existence, onboarding config, prompt
+ *   composability, and Foundation-stage signals.
  *
  * @pathParam courseId string - Playbook UUID
- * @response 200 { ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode }
+ * @response 200 { ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode, hasSources, hasAssertions }
  */
 export async function GET(
   _req: NextRequest,
@@ -132,6 +135,45 @@ export async function GET(
     });
     const promptComposable = !!composedPrompt;
 
+    // ── #884 S0 — Foundation-stage signals (hasSources / hasAssertions) ──
+    // Stages 1-3 of the Course Setup Tracker are derived client-side from
+    // subjects/sources already loaded on the page, but the client needs the
+    // server's view of "is this playbook backed by extracted content yet?"
+    // to enforce `ready_to_teach ⇒ ∀ prior step done` without trusting the
+    // partial subjects array (which can lag the actual DB state).
+    //
+    // Scope strictly by playbook (PlaybookSubject → Subject → SubjectSource →
+    // ContentAssertion). Domain-wide scoping would leak sibling-course content
+    // and falsely mark a brand-new course as "has assertions" — slug-scope
+    // invariant §4 / #407.
+    const playbookSubjectIds = await prisma.playbookSubject.findMany({
+      where: { playbookId: courseId },
+      select: { subjectId: true },
+    });
+    const subjectIdList = playbookSubjectIds.map((ps) => ps.subjectId);
+
+    let hasSources = false;
+    let hasAssertions = false;
+    if (subjectIdList.length > 0) {
+      const sourceLink = await prisma.subjectSource.findFirst({
+        where: { subjectId: { in: subjectIdList } },
+        select: { sourceId: true },
+      });
+      hasSources = !!sourceLink;
+
+      if (hasSources) {
+        const assertion = await prisma.contentAssertion.findFirst({
+          where: {
+            source: {
+              subjects: { some: { subjectId: { in: subjectIdList } } },
+            },
+          },
+          select: { id: true },
+        });
+        hasAssertions = !!assertion;
+      }
+    }
+
     // All critical = lesson plan + onboarding configured + strategies assigned (#444)
     // Prompt composition happens on first call — not an educator-facing readiness gate
     const allCriticalPass = lessonPlanBuilt && onboardingConfigured && strategiesAssigned;
@@ -156,6 +198,8 @@ export async function GET(
       activeCurriculumMode,
       strategiesAssigned,
       unstrategisedGoalCount: unstrategised,
+      hasSources,
+      hasAssertions,
     };
     return NextResponse.json(payload);
   } catch (err) {

--- a/apps/admin/app/api/courses/[courseId]/setup-status/types.ts
+++ b/apps/admin/app/api/courses/[courseId]/setup-status/types.ts
@@ -36,6 +36,25 @@ export interface SetupStatusResponse {
    */
   strategiesAssigned: boolean;
   unstrategisedGoalCount: number;
+  /**
+   * #884 S0 — stopgap "Ready to Teach" gating signals.
+   *
+   * Stages 1–3 of the Course Setup tracker (Course Created, Content Uploaded,
+   * Teaching Points Ready) are currently derived client-side from subject/source
+   * data already loaded on the page. The server exposes these booleans so the
+   * `useCourseSetupStatus` hook can enforce the invariant
+   * `ready_to_teach ⇒ ∀ prior step done` without re-fetching subjects.
+   *
+   * These are deliberately NOT folded into `allCriticalPass` — the full
+   * chain-contract refactor (S1–S2, see
+   * `docs/decisions/2026-05-26-extend-chain-contracts-to-setup-readiness.md`)
+   * decides their severity. Client enforces the dependency locally for now.
+   *
+   * - `hasSources`: at least one ContentSource linked to any Subject of this playbook
+   * - `hasAssertions`: at least one ContentAssertion extracted for those sources
+   */
+  hasSources: boolean;
+  hasAssertions: boolean;
 }
 
 /** 4xx/5xx error path — separate type so the success contract stays tight. */

--- a/apps/admin/components/shared/CourseSetupTracker.tsx
+++ b/apps/admin/components/shared/CourseSetupTracker.tsx
@@ -69,6 +69,9 @@ export function CourseSetupTracker({
           promptComposable: data.promptComposable,
           allCriticalPass: data.allCriticalPass,
           activeCurriculumMode: data.activeCurriculumMode,
+          // #884 S0 — Foundation-stage signals for "Ready to Teach" gating
+          hasSources: data.hasSources,
+          hasAssertions: data.hasAssertions,
         });
       }
     } catch (err) {

--- a/apps/admin/hooks/useCourseSetupStatus.ts
+++ b/apps/admin/hooks/useCourseSetupStatus.ts
@@ -93,6 +93,8 @@ export function useCourseSetupStatus(input: SetupStatusInput): CourseSetupStatus
     input.sessions?.plan?.estimatedSessions,
     input.readiness?.lessonPlanBuilt,
     input.readiness?.allCriticalPass,
+    input.readiness?.hasSources,
+    input.readiness?.hasAssertions,
     // input is referenced inside the memo body but its identity-changing fields
     // are tracked via the explicit deps above; a full input dep would
     // invalidate on every render.
@@ -249,18 +251,67 @@ export function deriveStages(input: SetupStatusInput): CourseSetupStatus {
     detail: onboardingOk ? 'Welcome experience ready' : 'Set up the welcome message',
   });
 
-  // ── Stage 6: Ready to Teach (gates on BOTH 4 + 5) ────
+  // ── Stage 6: Ready to Teach (gates on ALL prior stages) ────
+  //
+  // #884 S0 — "Ready to Teach gating lie" stopgap.
+  //
+  // Previously this used `readiness?.allCriticalPass` alone, which only
+  // verified stages 4-5 (lesson plan + onboarding + #444 strategies). A
+  // course with no content uploaded could show "Ready to Teach" green
+  // while stages 1-3 were still pending — banner contradicting badge.
+  //
+  // Invariant: `ready_to_teach ⇒ ∀ prior step done`.
+  //
+  // Foundation signals come from the server (`hasSources`/`hasAssertions`)
+  // so the gate doesn't trust the partial client-side subjects array.
+  // Stage 1 ("Course Created") and stage 2 ("Content Uploaded") collapse
+  // into `hasSources`; stage 3 ("Teaching Points Ready") collapses into
+  // `hasAssertions`. We also require the locally-derived stages to be
+  // `done` so a still-extracting stage 3 keeps stage 6 pending.
+  //
+  // The full chain-contract refactor (S1-S2) moves these to first-class
+  // spec checks. Until then this guard ships as a stopgap — see
+  // `docs/decisions/2026-05-26-extend-chain-contracts-to-setup-readiness.md`.
   const allCritical = readiness?.allCriticalPass ?? false;
+  const foundationFromServer =
+    (readiness?.hasSources ?? false) && (readiness?.hasAssertions ?? false);
+  const foundationFromClient =
+    stage1Done && stage2Done && stage3Status === 'done';
+  const allPriorDone = foundationFromServer && foundationFromClient && hasPlan && onboardingOk;
   const bothConfigured = hasPlan && onboardingOk;
+
+  // Status: only 'done' when EVERY prior gate passes AND server agrees
+  // (`allCriticalPass`). 'active' when configure-stage is done but
+  // foundation is still catching up. 'pending' otherwise.
+  let stage6Status: StageStatus;
+  let stage6Detail: string;
+  if (allCritical && allPriorDone) {
+    stage6Status = 'done';
+    stage6Detail = 'Ready for practice calls';
+  } else if (bothConfigured && !foundationFromServer) {
+    // The lying-banner case: stages 4-5 done but content/extraction missing.
+    stage6Status = 'pending';
+    stage6Detail = !readiness?.hasSources
+      ? 'Upload content to unlock'
+      : 'Waiting for teaching points to be extracted';
+  } else if (bothConfigured && !foundationFromClient) {
+    // Server says content exists but client-derived stages 1-3 not all 'done'
+    // (e.g. extraction still active). Hold the gate.
+    stage6Status = 'pending';
+    stage6Detail = 'Finishing content extraction...';
+  } else if (bothConfigured) {
+    stage6Status = 'active';
+    stage6Detail = 'Running final checks...';
+  } else {
+    stage6Status = 'pending';
+    stage6Detail = 'Complete steps 4 and 5';
+  }
+
   stages.push({
     number: 6,
     label: 'Ready to Teach',
-    status: allCritical ? 'done' : bothConfigured ? 'active' : 'pending',
-    detail: allCritical
-      ? 'Ready for practice calls'
-      : bothConfigured
-        ? 'Running final checks...'
-        : 'Complete steps 4 and 5',
+    status: stage6Status,
+    detail: stage6Detail,
   });
 
   // ── Summary ────────────────────────────────────────

--- a/apps/admin/tests/api/setup-status-authored-modules.test.ts
+++ b/apps/admin/tests/api/setup-status-authored-modules.test.ts
@@ -33,6 +33,13 @@ const { mockPrisma, mockRequireAuth, mockIsAuthError } = vi.hoisted(() => ({
     goal: {
       count: vi.fn(),
     },
+    // #884 S0 — Foundation-stage signals (hasSources / hasAssertions).
+    subjectSource: {
+      findFirst: vi.fn(),
+    },
+    contentAssertion: {
+      findFirst: vi.fn(),
+    },
   },
   mockRequireAuth: vi.fn(),
   mockIsAuthError: vi.fn(),
@@ -65,6 +72,8 @@ beforeEach(() => {
   mockPrisma.curriculum.findFirst.mockReset();
   mockPrisma.composedPrompt.findFirst.mockReset();
   mockPrisma.goal.count.mockReset();
+  mockPrisma.subjectSource.findFirst.mockReset();
+  mockPrisma.contentAssertion.findFirst.mockReset();
 
   mockRequireAuth.mockResolvedValue(passingAuth);
   mockIsAuthError.mockReturnValue(false);
@@ -74,6 +83,11 @@ beforeEach(() => {
   mockPrisma.composedPrompt.findFirst.mockResolvedValue(null);
   // #444 — default: 0 unstrategised goals (course is strategy-clean).
   mockPrisma.goal.count.mockResolvedValue(0);
+  // #884 S0 — default: course has subjects but no sources/assertions yet
+  // (fresh-create state). Individual tests override.
+  mockPrisma.playbookSubject.findMany.mockResolvedValue([]);
+  mockPrisma.subjectSource.findFirst.mockResolvedValue(null);
+  mockPrisma.contentAssertion.findFirst.mockResolvedValue(null);
 });
 
 function basePlaybook(configOverrides: Record<string, unknown> = {}) {
@@ -220,5 +234,79 @@ describe("setup-status — auth and 404 still behave (regression)", () => {
     mockPrisma.playbook.findUnique.mockResolvedValue(null);
     const res = (await GET(makeReq(), { params })) as NextResponse;
     expect(res.status).toBe(404);
+  });
+});
+
+// =====================================================
+// #884 S0 — Foundation-stage signals (hasSources / hasAssertions)
+// =====================================================
+
+describe("setup-status — #884 S0 Foundation-stage signals", () => {
+  it("returns hasSources=false, hasAssertions=false for a fresh course with no subjects", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(basePlaybook());
+    mockPrisma.playbookSubject.findMany.mockResolvedValue([]);
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+
+    expect(body.hasSources).toBe(false);
+    expect(body.hasAssertions).toBe(false);
+    // Sanity: lying-bug guard — `allCriticalPass` may still be true when
+    // onboarding + lesson plan pass, but the client uses hasSources/
+    // hasAssertions to override stage 6. The server intentionally does NOT
+    // fold Foundation into allCriticalPass (full contract refactor — S1/S2).
+    expect(body.allCriticalPass).toBe(true);
+  });
+
+  it("returns hasSources=true, hasAssertions=false while extraction is still running", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(basePlaybook());
+    mockPrisma.playbookSubject.findMany.mockResolvedValue([{ subjectId: "sub-1" }]);
+    mockPrisma.subjectSource.findFirst.mockResolvedValue({ sourceId: "src-1" });
+    mockPrisma.contentAssertion.findFirst.mockResolvedValue(null);
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+
+    expect(body.hasSources).toBe(true);
+    expect(body.hasAssertions).toBe(false);
+  });
+
+  it("returns hasSources=true, hasAssertions=true for a fully-extracted course", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(basePlaybook());
+    mockPrisma.playbookSubject.findMany.mockResolvedValue([{ subjectId: "sub-1" }]);
+    mockPrisma.subjectSource.findFirst.mockResolvedValue({ sourceId: "src-1" });
+    mockPrisma.contentAssertion.findFirst.mockResolvedValue({ id: "a-1" });
+
+    const res = (await GET(makeReq(), { params })) as NextResponse;
+    const body = await res.json();
+
+    expect(body.hasSources).toBe(true);
+    expect(body.hasAssertions).toBe(true);
+  });
+
+  it("scopes by playbook (not domain) — slug-scope invariant #407", async () => {
+    // Two subjects linked to this playbook
+    mockPrisma.playbook.findUnique.mockResolvedValue(basePlaybook());
+    mockPrisma.playbookSubject.findMany.mockResolvedValue([
+      { subjectId: "sub-A" },
+      { subjectId: "sub-B" },
+    ]);
+    mockPrisma.subjectSource.findFirst.mockResolvedValue({ sourceId: "src-1" });
+    mockPrisma.contentAssertion.findFirst.mockResolvedValue({ id: "a-1" });
+
+    await GET(makeReq(), { params });
+
+    // playbookSubject query must filter on this playbook only
+    expect(mockPrisma.playbookSubject.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { playbookId: "playbook-1" },
+      }),
+    );
+    // subjectSource query must use the resolved subject IDs (not domain or other heuristic)
+    expect(mockPrisma.subjectSource.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { subjectId: { in: ["sub-A", "sub-B"] } },
+      }),
+    );
   });
 });

--- a/apps/admin/tests/hooks/useCourseSetupStatus.test.ts
+++ b/apps/admin/tests/hooks/useCourseSetupStatus.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for `deriveStages` — the pure function backing the
+ * `useCourseSetupStatus` React hook.
+ *
+ * Focus: #884 S0 — "Ready to Teach gating lie" stopgap.
+ *
+ * Invariant: `ready_to_teach ⇒ ∀ prior step done`. Stage 6 (the "Ready to
+ * Teach" gate) MUST NOT report `done` while any of stages 1–5 is still
+ * pending/active, even if the server reports `allCriticalPass=true`.
+ *
+ * Prior behaviour: stage 6 was driven solely by `readiness.allCriticalPass`,
+ * which only verifies stages 4–5 (lesson plan + onboarding + #444
+ * strategies). A course with no content uploaded could show Stage 6 green
+ * while Stage 2/3 were still pending — the banner contradicting the badge.
+ */
+
+import { describe, it, expect } from "vitest";
+import { deriveStages, type SetupStatusInput } from "@/hooks/useCourseSetupStatus";
+
+// ── Fixture helpers ───────────────────────────────────
+
+const PLAYBOOK_ID = "playbook-1";
+
+function makeInput(overrides: Partial<SetupStatusInput> = {}): SetupStatusInput {
+  return {
+    detail: {
+      id: PLAYBOOK_ID,
+      name: "IELTS Speaking",
+      status: "DRAFT",
+      domain: { id: "dom-1", name: "ELT" },
+      config: {},
+    },
+    subjects: [],
+    sourceStatusMap: {},
+    sessions: null,
+    readiness: null,
+    ...overrides,
+  };
+}
+
+/** A subject with N sources (and optional assertions). */
+function subjectWithSources(opts: {
+  sourceCount: number;
+  assertionCount?: number;
+}) {
+  return {
+    id: "sub-1",
+    name: "ELT",
+    sourceCount: opts.sourceCount,
+    assertionCount: opts.assertionCount ?? 0,
+    sources: Array.from({ length: opts.sourceCount }).map((_, i) => ({
+      id: `src-${i + 1}`,
+      name: `Source ${i + 1}`,
+      documentType: "TEXTBOOK",
+      assertionCount: 0,
+    })),
+  };
+}
+
+/** sourceStatusMap entries reporting extraction state for each source. */
+function sourceStatusMap(opts: {
+  sourceIds: string[];
+  jobStatus: "extracting" | "done" | "pending" | "error" | "importing";
+  assertionsEach?: number;
+}): SetupStatusInput["sourceStatusMap"] {
+  return Object.fromEntries(
+    opts.sourceIds.map((id) => [
+      id,
+      {
+        jobStatus: opts.jobStatus,
+        assertionCount: opts.assertionsEach ?? 0,
+        questionCount: 0,
+        vocabularyCount: 0,
+        embeddedCount: 0,
+        structuredCount: 0,
+      },
+    ]),
+  );
+}
+
+// =====================================================
+// #884 S0 — stage 6 ("Ready to Teach") gating
+// =====================================================
+
+describe("deriveStages — #884 S0 Ready to Teach dependency gate", () => {
+  it("stage 6 stays pending when allCriticalPass=true but hasSources=false (Foundation missing)", () => {
+    const input = makeInput({
+      // Server: lesson plan + onboarding configured, critical passed
+      readiness: {
+        lessonPlanBuilt: true,
+        onboardingConfigured: true,
+        allCriticalPass: true,
+        hasSources: false,
+        hasAssertions: false,
+      },
+    });
+
+    const { stages } = deriveStages(input);
+    const stage6 = stages.find((s) => s.number === 6)!;
+
+    expect(stage6.status).toBe("pending");
+    expect(stage6.label).toBe("Ready to Teach");
+    // Detail should hint why it's blocked
+    expect(stage6.detail.toLowerCase()).toContain("upload");
+  });
+
+  it("stage 6 stays pending when hasSources=true but hasAssertions=false (extraction still running)", () => {
+    const input = makeInput({
+      // Some content uploaded — but no teaching points extracted yet
+      subjects: [subjectWithSources({ sourceCount: 1 })],
+      sourceStatusMap: sourceStatusMap({
+        sourceIds: ["src-1"],
+        jobStatus: "extracting",
+        assertionsEach: 0,
+      }),
+      readiness: {
+        lessonPlanBuilt: true,
+        onboardingConfigured: true,
+        allCriticalPass: true,
+        hasSources: true,
+        hasAssertions: false,
+      },
+    });
+
+    const { stages } = deriveStages(input);
+    const stage6 = stages.find((s) => s.number === 6)!;
+
+    expect(stage6.status).toBe("pending");
+    // Detail should reference extraction / teaching points
+    expect(stage6.detail.toLowerCase()).toMatch(/extract|teaching point/);
+  });
+
+  it("stage 6 stays pending when Foundation passes server-side but client stages 1-3 not all done (multi-source mid-extraction)", () => {
+    // A race we want to defend against: server may report hasAssertions=true
+    // because at least ONE source has finished, but a second source is still
+    // mid-extraction. Stage 3 is then 'active', not 'done', and Stage 6 must
+    // hold the gate even though the server's `allCriticalPass` is true.
+    const input = makeInput({
+      subjects: [
+        {
+          id: "sub-1",
+          name: "ELT",
+          sourceCount: 2,
+          assertionCount: 0,
+          sources: [
+            { id: "src-1", name: "Source 1", documentType: "TEXTBOOK", assertionCount: 0 },
+            { id: "src-2", name: "Source 2", documentType: "TEXTBOOK", assertionCount: 0 },
+          ],
+        },
+      ],
+      sourceStatusMap: {
+        // src-1 finished — produced some assertions
+        "src-1": {
+          jobStatus: "done",
+          assertionCount: 5,
+          questionCount: 0,
+          vocabularyCount: 0,
+          embeddedCount: 0,
+          structuredCount: 0,
+        },
+        // src-2 still extracting, no assertions yet
+        "src-2": {
+          jobStatus: "extracting",
+          assertionCount: 0,
+          questionCount: 0,
+          vocabularyCount: 0,
+          embeddedCount: 0,
+          structuredCount: 0,
+        },
+      },
+      readiness: {
+        lessonPlanBuilt: true,
+        onboardingConfigured: true,
+        allCriticalPass: true,
+        // Server has seen the src-1 assertions land
+        hasSources: true,
+        hasAssertions: true,
+      },
+    });
+
+    const { stages } = deriveStages(input);
+    const stage3 = stages.find((s) => s.number === 3)!;
+    const stage6 = stages.find((s) => s.number === 6)!;
+
+    // Stage 3 is 'active' because src-2 is still extracting (anyExtracting=true).
+    expect(stage3.status).toBe("active");
+    // Stage 6 must hold even though server thinks Foundation is satisfied.
+    expect(stage6.status).toBe("pending");
+  });
+
+  it("stage 6 goes done when ALL prior gates pass AND server confirms allCriticalPass", () => {
+    const input = makeInput({
+      subjects: [subjectWithSources({ sourceCount: 1, assertionCount: 12 })],
+      sourceStatusMap: sourceStatusMap({
+        sourceIds: ["src-1"],
+        jobStatus: "done",
+        assertionsEach: 12,
+      }),
+      readiness: {
+        lessonPlanBuilt: true,
+        onboardingConfigured: true,
+        allCriticalPass: true,
+        hasSources: true,
+        hasAssertions: true,
+      },
+    });
+
+    const { stages, allComplete } = deriveStages(input);
+    const stage6 = stages.find((s) => s.number === 6)!;
+
+    expect(stage6.status).toBe("done");
+    expect(stage6.detail.toLowerCase()).toContain("ready");
+    expect(allComplete).toBe(true);
+  });
+
+  it("stage 6 reports 'pending' (not 'done') when configure-stage is done but Foundation booleans undefined", () => {
+    // Legacy / pre-migration response that doesn't include hasSources/hasAssertions.
+    // We must default to the safe path: gate stays pending.
+    const input = makeInput({
+      readiness: {
+        lessonPlanBuilt: true,
+        onboardingConfigured: true,
+        allCriticalPass: true,
+        // hasSources / hasAssertions intentionally omitted
+      },
+    });
+
+    const { stages } = deriveStages(input);
+    const stage6 = stages.find((s) => s.number === 6)!;
+
+    // With Foundation booleans missing the gate stays pending — fail closed.
+    expect(stage6.status).toBe("pending");
+  });
+});
+
+// =====================================================
+// Regression: existing behaviour preserved
+// =====================================================
+
+describe("deriveStages — regression checks unchanged by #884 S0", () => {
+  it("stage 6 still active (not done) when configure-stage done but allCriticalPass=false", () => {
+    const input = makeInput({
+      subjects: [subjectWithSources({ sourceCount: 1, assertionCount: 12 })],
+      sourceStatusMap: sourceStatusMap({
+        sourceIds: ["src-1"],
+        jobStatus: "done",
+        assertionsEach: 12,
+      }),
+      readiness: {
+        lessonPlanBuilt: true,
+        onboardingConfigured: true,
+        // allCriticalPass false — strategy assignment pending (#444)
+        allCriticalPass: false,
+        hasSources: true,
+        hasAssertions: true,
+      },
+    });
+
+    const { stages } = deriveStages(input);
+    const stage6 = stages.find((s) => s.number === 6)!;
+
+    // Server gate still failing → 'active' (running final checks).
+    expect(stage6.status).toBe("active");
+  });
+
+  it("returns 6 stages with correct labels (structure unchanged)", () => {
+    const input = makeInput();
+    const { stages } = deriveStages(input);
+
+    expect(stages).toHaveLength(6);
+    expect(stages.map((s) => s.label)).toEqual([
+      "Course Created",
+      "Content Uploaded",
+      "Teaching Points Ready",
+      "Lesson Plan Built",
+      "Tutor Configured",
+      "Ready to Teach",
+    ]);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -5717,7 +5717,7 @@ Returns aggregated setup status for stages 4-6 of the Course Setup Tracker.
 
 **Response** `200`
 ```json
-{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode }
+{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode, hasSources, hasAssertions }
 ```
 
 ---

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -2604,7 +2604,7 @@ Returns aggregated setup status for stages 4-6 of the Course Setup Tracker.
 
 **Response** `200`
 ```json
-{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode }
+{ ok, lessonPlanBuilt, onboardingConfigured, promptComposable, allCriticalPass, activeCurriculumMode, hasSources, hasAssertions }
 ```
 
 ---


### PR DESCRIPTION
## Summary

S0 stopgap from epic #883. Closes #884.

The Course Setup panel ("Course Design" tab) reported "Ready to Teach" green while upstream Foundation stages were still pending or extracting — because `useCourseSetupStatus.deriveStages` keyed stage 6 status off `readiness.allCriticalPass` alone, and the server's `allCriticalPass` only verifies stages 4–5. No invariant enforced `ready_to_teach ⇒ ∀ prior step`.

Fix in three layers:

1. **Server (`setup-status/route.ts`)** — extends payload with `hasSources` + `hasAssertions`, playbook-scoped via `PlaybookSubject → Subject → SubjectSource → ContentAssertion` (honours #407 slug-scope invariant). Not folded into `allCriticalPass` — that's the deferred S2 contract refactor. Server exposes the signal; client enforces the dependency.
2. **Types (`setup-status/types.ts`)** — `SetupStatusResponse` adds the two booleans; drift becomes a `tsc` error.
3. **Hook (`useCourseSetupStatus.ts::deriveStages`)** — stage 6 requires Foundation (`hasSources` + `hasAssertions` + stages 1–3 done) **plus** configure-stage (`hasPlan` + `onboardingOk`) **plus** server's `allCriticalPass`. Fails closed when Foundation booleans are absent (legacy payloads). `detail` text now names the blocker ("Upload content to unlock" / "Waiting for teaching points to be extracted" / "Finishing content extraction...").

`CourseSetupTracker.tsx` passes the new fields through `setReadiness`.

**Deferred via ADR** `docs/decisions/2026-05-26-extend-chain-contracts-to-setup-readiness.md`: COURSE-READY-002 spec, audit-epic-100.ts counters, panel restructure. This PR is the minimum stopgap; not a contract refactor.

## Test plan

- [x] 7 new hook test cases in `tests/hooks/useCourseSetupStatus.test.ts`
- [x] 4 new API test cases in `tests/api/setup-status-authored-modules.test.ts`
- [x] All 26 affected tests pass
- [x] tsc clean, ESLint clean (no new warnings)
- [x] guard-checker CLEAN (14 guards)
- [x] standards-checker READY TO MERGE
- [ ] **IELTS non-regression** (Nico Grant `f17d8616-3c31-4814-8de1-626fb42f16f6`) — verify stage 6 still green on their course post-deploy
- [ ] Manual: course with no content uploaded → stage 6 shows pending with "Upload content to unlock"
- [ ] Manual: course mid-extraction → stage 6 shows "Finishing content extraction..."
- [ ] Manual: fully-configured course → stage 6 green as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)