### PR TITLE
chore(#865): PR 2 — rules-of-hooks triage (13 instances)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,6 +1,6 @@
 {
   "tsc_errors": 197,
   "lint_errors": 0,
-  "lint_warnings": 4441,
+  "lint_warnings": 4432,
   "quarantined_tests": 37
 }

--- a/apps/admin/app/x/courses/_components/CourseSetupWizard.tsx
+++ b/apps/admin/app/x/courses/_components/CourseSetupWizard.tsx
@@ -32,6 +32,23 @@ export function CourseSetupWizard({ onComplete }: CourseSetupWizardProps) {
   // Warn on browser refresh/close when user has started filling in data
   useUnsavedGuard(!!getData<string>('courseName'));
 
+  // Hooks must run unconditionally; the early-return guards below depend on `state`,
+  // so hoist all useCallback declarations above them. The captured callbacks
+  // (`nextStep`, `prevStep`, `endFlow`) are stable identities from StepFlowContext,
+  // so the guard branch never causes them to capture stale values. (#865 PR 2)
+  const handleNext = useCallback(() => {
+    nextStep();
+  }, [nextStep]);
+
+  const handlePrev = useCallback(() => {
+    prevStep();
+  }, [prevStep]);
+
+  const handleEndFlow = useCallback(() => {
+    endFlow();
+    onComplete?.();
+  }, [endFlow, onComplete]);
+
   if (!state || !state.active) {
     return <div>Loading wizard...</div>;
   }
@@ -48,19 +65,6 @@ export function CourseSetupWizard({ onComplete }: CourseSetupWizardProps) {
   };
 
   const StepComponent = steps[currentStepId];
-
-  const handleNext = useCallback(() => {
-    nextStep();
-  }, [nextStep]);
-
-  const handlePrev = useCallback(() => {
-    prevStep();
-  }, [prevStep]);
-
-  const handleEndFlow = useCallback(() => {
-    endFlow();
-    onComplete?.();
-  }, [endFlow, onComplete]);
 
   if (!StepComponent) {
     return <div>Unknown step: {currentStepId}</div>;

--- a/apps/admin/components/shared/CategoryTreemap.tsx
+++ b/apps/admin/components/shared/CategoryTreemap.tsx
@@ -147,9 +147,11 @@ export function CategoryTreemap({
   categoryItems?: Record<string, string[]>;
   className?: string;
 }): React.ReactElement | null {
-  const total = Object.values(categoryCounts).reduce((s, c) => s + c, 0);
-  if (total === 0) return null;
-
+  // Hooks must run unconditionally. The `total === 0` early-return previously
+  // sat above these four hooks, which violated rules-of-hooks. The hooks have
+  // no inputs that depend on `total`, so it's safe to hoist them above the
+  // guard — when total is 0 we still construct the empty hover state, then
+  // bail out of rendering. (#865 PR 2)
   const containerRef = useRef<HTMLDivElement>(null);
   const [hovered, setHovered] = useState<{
     cat: string;
@@ -165,6 +167,9 @@ export function CategoryTreemap({
   const handleMouseLeave = useCallback(() => {
     setHovered(null);
   }, []);
+
+  const total = Object.values(categoryCounts).reduce((s, c) => s + c, 0);
+  if (total === 0) return null;
 
   const entries = Object.entries(categoryCounts)
     .filter(([, c]) => c > 0)

--- a/apps/admin/components/shared/GenomeBrowser.tsx
+++ b/apps/admin/components/shared/GenomeBrowser.tsx
@@ -169,6 +169,36 @@ export function GenomeBrowser({ data, onSessionClick, onCategoryClick, onAsserti
     return { pre, teaching, post };
   }, [data.journeyStops, effectiveStart, effectiveEnd]);
 
+  // Visible learning outcomes (clipped to window)
+  // Hoisted above the `teachingSessionCount === 0` early return so hook order
+  // stays stable across re-renders. (#865 PR 2)
+  const visibleLOs = useMemo(
+    () =>
+      data.learningOutcomes
+        .map((lo, i) => {
+          const cs = Math.max(lo.sessionStart, effectiveStart);
+          const ce = Math.min(lo.sessionEnd, effectiveEnd);
+          if (ce < cs) return null;
+          return { lo, originalIndex: i, clippedStart: cs, clippedEnd: ce };
+        })
+        .filter((x): x is { lo: (typeof data.learningOutcomes)[number]; originalIndex: number; clippedStart: number; clippedEnd: number } => x !== null),
+    [data.learningOutcomes, effectiveStart, effectiveEnd],
+  );
+
+  // Visible modules (clipped to window) — hoisted above early return for same reason.
+  const visibleModules = useMemo(
+    () =>
+      data.modules
+        .map((mod, i) => {
+          const cs = Math.max(mod.sessionStart, effectiveStart);
+          const ce = Math.min(mod.sessionEnd, effectiveEnd);
+          if (ce < cs) return null;
+          return { mod, originalIndex: i, clippedStart: cs, clippedEnd: ce };
+        })
+        .filter((x): x is { mod: (typeof data.modules)[number]; originalIndex: number; clippedStart: number; clippedEnd: number } => x !== null),
+    [data.modules, effectiveStart, effectiveEnd],
+  );
+
   if (data.teachingSessionCount === 0) {
     return (
       <div className="genome-empty">
@@ -186,34 +216,6 @@ export function GenomeBrowser({ data, onSessionClick, onCategoryClick, onAsserti
 
   // Column index helpers — grid column 1 = label, visible session `s` → column `s - effectiveStart + 2`.
   const colForSession = (s: number) => s - effectiveStart + 2;
-
-  // Visible learning outcomes (clipped to window)
-  const visibleLOs = useMemo(
-    () =>
-      data.learningOutcomes
-        .map((lo, i) => {
-          const cs = Math.max(lo.sessionStart, effectiveStart);
-          const ce = Math.min(lo.sessionEnd, effectiveEnd);
-          if (ce < cs) return null;
-          return { lo, originalIndex: i, clippedStart: cs, clippedEnd: ce };
-        })
-        .filter((x): x is { lo: (typeof data.learningOutcomes)[number]; originalIndex: number; clippedStart: number; clippedEnd: number } => x !== null),
-    [data.learningOutcomes, effectiveStart, effectiveEnd],
-  );
-
-  // Visible modules (clipped to window)
-  const visibleModules = useMemo(
-    () =>
-      data.modules
-        .map((mod, i) => {
-          const cs = Math.max(mod.sessionStart, effectiveStart);
-          const ce = Math.min(mod.sessionEnd, effectiveEnd);
-          if (ce < cs) return null;
-          return { mod, originalIndex: i, clippedStart: cs, clippedEnd: ce };
-        })
-        .filter((x): x is { mod: (typeof data.modules)[number]; originalIndex: number; clippedStart: number; clippedEnd: number } => x !== null),
-    [data.modules, effectiveStart, effectiveEnd],
-  );
 
   const canPrev = paged && effectiveStart > 1;
   const canNext = paged && effectiveEnd < sessionCount;

--- a/apps/admin/components/shared/UnifiedAssistantPanel.tsx
+++ b/apps/admin/components/shared/UnifiedAssistantPanel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Copy, Trash2, X as XIcon } from "lucide-react";
 import { useChatContext } from "@/contexts/ChatContext";
 import { useEntityContext } from "@/contexts/EntityContext";
-import { useGlobalAssistant } from "@/contexts/AssistantContext";
+import { useOptionalGlobalAssistant } from "@/contexts/AssistantContext";
 import type { LayoutMode } from "@/contexts/AssistantContext";
 import { useResponsive } from "@/hooks/useResponsive";
 import "./unified-assistant-panel.css";
@@ -148,14 +148,11 @@ export function UnifiedAssistantPanel({
   const chatContext = useChatContext();
   const entityContext = useEntityContext();
 
-  // Try to access global assistant context (optional - only available when used in GlobalAssistant)
-  let globalAssistant;
-  try {
-    globalAssistant = useGlobalAssistant();
-  } catch {
-    // Not in GlobalAssistant context, that's okay
-    globalAssistant = null;
-  }
+  // Optional global assistant context. Returns null when the panel is mounted
+  // outside GlobalAssistantProvider (legacy pages: /x/specs, /x/domains, …).
+  // useOptionalGlobalAssistant is the no-throw sibling of useGlobalAssistant
+  // and is safe to call unconditionally — satisfies rules-of-hooks. (#865 PR 2)
+  const globalAssistant = useOptionalGlobalAssistant();
 
   // Responsive detection for mobile adaptations
   const { isMobile } = useResponsive();

--- a/apps/admin/contexts/AssistantContext.tsx
+++ b/apps/admin/contexts/AssistantContext.tsx
@@ -104,3 +104,15 @@ export function useGlobalAssistant(): GlobalAssistantContextValue {
   }
   return context;
 }
+
+/**
+ * Like {@link useGlobalAssistant} but returns `null` instead of throwing when
+ * the provider is absent. Use this when a component wants the assistant
+ * features if present but renders correctly outside the provider (e.g.
+ * UnifiedAssistantPanel, which can be mounted standalone on legacy pages).
+ *
+ * Always called unconditionally — satisfies react-hooks/rules-of-hooks. (#865)
+ */
+export function useOptionalGlobalAssistant(): GlobalAssistantContextValue | null {
+  return useContext(GlobalAssistantContext);
+}

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -194,6 +194,24 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/ban-ts-comment": "warn",
     },
   },
+  // Playwright e2e fixtures are not React. Playwright's `use(value)` is the
+  // fixture-callback parameter, not React's `use` hook — the rules-of-hooks
+  // parser misidentifies it because the identifier matches `use*`. Disable
+  // the React Hooks rules for the e2e tree so the false positives go away
+  // without touching the fixtures themselves. (#865 PR 2)
+  {
+    files: ["e2e/**/*.{ts,tsx}", "e2e/**/*.{js,jsx,mjs,cjs}"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off",
+      "react-hooks/exhaustive-deps": "off",
+      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/immutability": "off",
+      "react-hooks/refs": "off",
+      "react-hooks/preserve-manual-memoization": "off",
+      "react-hooks/static-components": "off",
+      "react-hooks/purity": "off",
+    },
+  },
   // Archived code is read-only by definition — turn off entirely.
   {
     files: ["_archived/**/*.{ts,tsx}", "_archived/**/*.{js,jsx,mjs,cjs}"],


### PR DESCRIPTION
Closes part of #865 (PR 2 of 4 in the hook lint sweep epic).

## What this PR does

Triage every `react-hooks/rules-of-hooks` warning individually. Conditional hook calls are runtime crashes, not style noise — no batch suppression accepted. Each of the 13 was either fixed structurally or addressed via a scoped ESLint override (for genuine false positives only).

## Triage table — all 13 rows resolved

| # | File:Line | Status |
|---|-----------|--------|
| 1 | `app/x/courses/_components/CourseSetupWizard.tsx:52` | **fixed** — `useCallback` hoisted above the `!state \|\| !state.active` early-return |
| 2 | `app/x/courses/_components/CourseSetupWizard.tsx:56` | **fixed** — same hoist as #1 |
| 3 | `app/x/courses/_components/CourseSetupWizard.tsx:60` | **fixed** — same hoist as #1 |
| 4 | `components/shared/CategoryTreemap.tsx:153` | **fixed** — `useRef` hoisted above the `total === 0` early-return |
| 5 | `components/shared/CategoryTreemap.tsx:154` | **fixed** — `useState` hoisted above the `total === 0` early-return |
| 6 | `components/shared/CategoryTreemap.tsx:160` | **fixed** — `useCallback` hoisted above the `total === 0` early-return |
| 7 | `components/shared/CategoryTreemap.tsx:165` | **fixed** — `useCallback` hoisted above the `total === 0` early-return |
| 8 | `components/shared/GenomeBrowser.tsx:191` | **fixed** — `teachingSessionCount === 0` early-return moved BELOW the `visibleLOs` memo so hook order is stable |
| 9 | `components/shared/GenomeBrowser.tsx:205` | **fixed** — same approach as #8, `visibleModules` memo |
| 10 | `components/shared/UnifiedAssistantPanel.tsx:154` | **fixed** — `try/catch` around `useGlobalAssistant()` replaced with new `useOptionalGlobalAssistant()` sibling that returns `null` instead of throwing. Called unconditionally. No suppression. |
| 11 | `e2e/fixtures/auth.fixture.ts:34` | **false positive — addressed via ESLint override.** Playwright's `use(fixture)` callback param, not React's `use` hook. Scoped `react-hooks/*: "off"` for `e2e/**` in `eslint.config.mjs`. |
| 12 | `e2e/fixtures/auth.fixture.ts:44` | **false positive — addressed via ESLint override.** Same as #11. |
| 13 | `e2e/fixtures/auth.fixture.ts:64` | **false positive — addressed via ESLint override.** Same as #11. |

## Hook warning counts

| Rule | Before | After | Delta |
|------|--------|-------|-------|
| `react-hooks/rules-of-hooks` | 13 | **0** | -13 |
| `react-hooks/set-state-in-effect` | 84 | 84 | 0 |
| `react-hooks/exhaustive-deps` | 92 | 92 | 0 |
| `react-hooks/refs` | 14 | 18 | **+4** (see note) |
| `react-hooks/immutability` | 2 | 2 | 0 |
| **Total `lint_warnings`** | **4441** | **4432** | **-9** |

**About the +4 `react-hooks/refs` unmask:** these are real, pre-existing bugs in `components/shared/CategoryTreemap.tsx` (lines 216, 223 — reading `containerRef.current` inside JSX). The linter previously short-circuited downstream analysis on this file because of the rules-of-hooks violation that this PR fixes. Now that hook order is stable, the analyzer can see the JSX and flags the refs accesses. **These are PR 3 scope** (the `react-hooks/refs` sweep). They are tracked under #865 and will be resolved there.

Net `lint_warnings` delta is therefore **-9**, not -13. `.ratchet.json` updated to **4432** to reflect the new honest baseline.

## `useTaskPoll` adjacency in `GenomeBrowser.tsx`

**NO** — explicitly checked. The file imports only `useState`, `useRef`, `useCallback`, `useMemo`, and `CSSProperties` from `react`. It does not import or use `useTaskPoll` or any polling hook. The two memo hoists carry zero phantom-polling risk.

## Wizard 1:5 hotspot ratio — `CourseSetupWizard.tsx`

Looked carefully at the early-return condition `if (!state || !state.active)`. This fires on the very first render when `useStepFlow()` returns an empty/inactive state (e.g. when the wizard mount races the StepFlowContext provider's initial state hydration). It IS a hot path — not defensive code — but it triggers BEFORE any user has interacted, so there's no stale-closure risk: the three callbacks captured (`nextStep`, `prevStep`, `endFlow`) are stable identities from the context. The hoist is safe.

No near-miss bug found in this file.

## Architectural refactor

One: added `useOptionalGlobalAssistant()` in `contexts/AssistantContext.tsx` as a no-throw sibling of `useGlobalAssistant()`. This is the idiomatic React pattern for context consumers that work both inside and outside their Provider — preferable to the previous try/catch hack. The original `useGlobalAssistant()` is untouched for all existing call-sites; only `UnifiedAssistantPanel` (the legacy panel mounted on pages without GlobalAssistantProvider) switches to the optional variant.

## Suppress comment inventory

**Zero new `// eslint-disable-next-line` comments added in this PR.**

The Playwright fixture false positives are addressed via a scoped `files: ["e2e/**/*.{ts,tsx}", ...]` entry in `eslint.config.mjs` (turning the rules off for the e2e tree only), NOT via per-line suppression. The fixture files themselves are untouched.

## Verification

- [x] `npx tsc --noEmit`: 197 errors (== baseline, unchanged)
- [x] `npm run lint`: 0 errors, 4432 warnings
- [x] `npm test`: 4829 passing / 16 skipped / 0 failed
- [x] `npm run ratchet:check`: all 4 metrics at baseline (`lint_warnings` bumped down to 4432)
- [x] Hook-warning recount: `react-hooks/rules-of-hooks` = **0**

## Manual smoke checklist

Each touched component must render once to verify no immediate regression:

- [ ] `/x/courses/new` — open Course Setup Wizard, step through Intent → Content. The three hoisted callbacks (`handleNext`, `handlePrev`, `handleEndFlow`) wire to the Loading state's progress stepper.
- [ ] `/x/dashboard` (or any page showing `<CategoryTreemap>`) — confirm the treemap renders, hover one cell to verify the hover card still appears (uses the hoisted `containerRef`/`hovered` state).
- [ ] `/x/courses/[id]` (Course Intelligence tab → Genome view) — render the genome browser for a course that has a lesson plan (visible bars) AND for one that doesn't (empty state). Both should render correctly.
- [ ] `/x/specs` — open the Unified Assistant Panel (legacy `<UnifiedAssistantPanel>` mount). Verify panel opens, layout dropdown does NOT appear (no GlobalAssistant provider on /x/specs, so `useOptionalGlobalAssistant()` returns null).
- [ ] If GlobalAssistantProvider IS available (e.g. inside `/x/courses/[id]`), confirm the layout-mode dropdown DOES appear in `UnifiedAssistantPanel` (`globalAssistant != null`).
- [ ] `npm run test:e2e` — Playwright fixtures `auth.fixture.ts` should still work end-to-end (the ESLint override doesn't change runtime behavior, but worth a smoke).

## Deploy

`/vm-cp` — no migration, no schema change, no env-var change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)