### PR TITLE
fix(#899): PID-lock ancestor walk now climbs to claude, not shell

### DIFF
--- a/.claude/hooks/__tests__/test-find-claude-ancestor.sh
+++ b/.claude/hooks/__tests__/test-find-claude-ancestor.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Test the find_claude_ancestor helper duplicated into
+# session-start.sh and git-lock-enforcer.sh (#899). Exits non-zero on
+# any failure. macOS bash 3.2 compatible (no associative arrays).
+#
+# Strategy: override `ps` via a shim function that returns fabricated
+# comm/ppid values keyed by PID via dynamic variable names, and assert
+# the helper climbs to the right ancestor.
+
+set -u
+
+PASS=0
+FAIL=0
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+pass() { echo "pass: $1"; PASS=$((PASS + 1)); }
+
+# Reset mock table — unset all MOCK_COMM_* / MOCK_PPID_* vars.
+mock_reset() {
+  local v
+  for v in $(compgen -v | grep -E '^MOCK_(COMM|PPID)_'); do
+    unset "$v"
+  done
+}
+
+mock_set() {
+  # mock_set <pid> <comm> <ppid>
+  eval "MOCK_COMM_$1=\"\$2\""
+  eval "MOCK_PPID_$1=\"\$3\""
+}
+
+# Shim `ps` for the helper. Honours only the patterns the helper uses:
+#   ps -o comm= -p <pid>
+#   ps -o ppid= -p <pid>
+ps() {
+  local field="" pid=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o) field="$2"; shift 2 ;;
+      -p) pid="$2"; shift 2 ;;
+      *)  shift ;;
+    esac
+  done
+  case "$field" in
+    comm=) eval "printf '%s\n' \"\${MOCK_COMM_${pid}:-}\"" ;;
+    ppid=) eval "printf '%s\n' \"\${MOCK_PPID_${pid}:-}\"" ;;
+  esac
+}
+
+# Helper under test — duplicated verbatim from the hooks so any future
+# divergence here is caught by the suite.
+find_claude_ancestor() {
+  local pid="${1:-$PPID}"
+  local max_hops=20
+  local hop=0
+  local comm
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$hop" -lt "$max_hops" ]; do
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ' | sed 's|.*/||')
+    if [ "$comm" = "claude" ]; then
+      echo "$pid"
+      return 0
+    fi
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    hop=$((hop + 1))
+  done
+  ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' '
+}
+
+# --- Test 1: climbs past wrapper shell to claude ancestor ---
+# Chain: 1000(bash hook) -> 999(zsh wrapper) -> 998(claude) -> 1(init)
+mock_reset
+mock_set 1000 "bash"   999
+mock_set 999  "-zsh"   998
+mock_set 998  "claude" 1
+got=$(find_claude_ancestor 1000)
+[ "$got" = "998" ] && pass "climbs past zsh wrapper to claude (got 998)" \
+                   || fail "test 1: expected 998, got '$got'"
+
+# --- Test 2: works with /path/to/claude (basename strip) ---
+mock_reset
+mock_set 2000 "bash"             1999
+mock_set 1999 "-zsh"             1998
+mock_set 1998 "/usr/bin/claude"  1
+got=$(find_claude_ancestor 2000)
+[ "$got" = "1998" ] && pass "strips path prefix from comm (got 1998)" \
+                    || fail "test 2: expected 1998, got '$got'"
+
+# --- Test 3: no claude in ancestry — fallback to one-step walk from $PPID ---
+mock_reset
+mock_set 3000 "bash"  2999
+mock_set 2999 "-zsh"  2998
+mock_set 2998 "login" 1
+# Set the fallback target — ps -o ppid= -p $PPID returns 42424242.
+mock_set "$PPID" "any" 42424242
+got=$(find_claude_ancestor 3000)
+[ "$got" = "42424242" ] && pass "fallback to one-step walk when no claude (got 42424242)" \
+                        || fail "test 3: expected 42424242, got '$got'"
+
+# --- Test 4: max_hops bounds — long chain with no claude exits cleanly ---
+# Build a 25-deep chain (all bash); helper must terminate via max_hops
+# rather than infinite-loop, then fall back to the $PPID walk.
+mock_reset
+i=4000
+while [ "$i" -le 4024 ]; do
+  mock_set "$i" "bash" $((i - 1))
+  i=$((i + 1))
+done
+mock_set "$PPID" "any" 99999999
+got=$(find_claude_ancestor 4024)
+[ "$got" = "99999999" ] && pass "max_hops bound prevents infinite climb (got 99999999)" \
+                        || fail "test 4: expected 99999999, got '$got'"
+
+# --- Test 5: PID dies mid-walk — empty ppid terminates loop ---
+mock_reset
+mock_set 5000 "bash" 4999
+mock_set 4999 "-zsh" ""           # parent vanished
+mock_set "$PPID" "any" 55555555
+got=$(find_claude_ancestor 5000)
+[ "$got" = "55555555" ] && pass "empty ppid mid-walk falls through to fallback (got 55555555)" \
+                        || fail "test 5: expected 55555555, got '$got'"
+
+# --- Test 6: helper finds claude even when caller is itself the claude pid ---
+mock_reset
+mock_set 6000 "claude" 1
+got=$(find_claude_ancestor 6000)
+[ "$got" = "6000" ] && pass "returns starting PID when it is already claude (got 6000)" \
+                    || fail "test 6: expected 6000, got '$got'"
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/git-lock-enforcer.sh
+++ b/.claude/hooks/git-lock-enforcer.sh
@@ -73,11 +73,38 @@ if [ "$LOCK_HOST" != "$(hostname)" ]; then
   exit 0
 fi
 
-# Walk up the process tree to find a claude PID (hook bash → claude).
-# $PPID is this script's parent (bash), $PPID's parent is the invoking
-# process. On Claude Code that's the claude session.
+# Climb the process tree until we find an ancestor whose comm is
+# `claude`. Claude Code's hook execution layers a wrapper shell between
+# this script and the claude session, so a one-step `ps -o ppid=` walk
+# lands on the shell (comm `-zsh`) — not on claude. That used to
+# silently mask all protection: the lock owner would be a shell PID,
+# the orphan-reclaim path below would fire, the lock would be rewritten
+# with another shell PID, and we'd exit 0 on every git command. See
+# #899 for the live evidence.
+#
+# Fallback: if no claude ancestor is found within max_hops (e.g. when
+# the hook is invoked manually for testing), preserve original
+# behaviour by returning the one-step PPID-walk result. Duplicated from
+# session-start.sh — these are bash hooks with no module system.
+find_claude_ancestor() {
+  local pid="${1:-$PPID}"
+  local max_hops=20
+  local hop=0
+  local comm
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$hop" -lt "$max_hops" ]; do
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ' | sed 's|.*/||')
+    if [ "$comm" = "claude" ]; then
+      echo "$pid"
+      return 0
+    fi
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    hop=$((hop + 1))
+  done
+  ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' '
+}
+
 MY_PPID="$PPID"
-MY_CLAUDE_PID=$(ps -o ppid= -p "$MY_PPID" 2>/dev/null | tr -d ' ')
+MY_CLAUDE_PID=$(find_claude_ancestor "$MY_PPID")
 
 # Primary mode → lock PID matches our claude session.
 if [ "$LOCK_PID" = "$MY_CLAUDE_PID" ] || [ "$LOCK_PID" = "$MY_PPID" ]; then

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -12,9 +12,36 @@ TREE_TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")
 LOCK_KEY=$(printf '%s' "$TREE_TOPLEVEL" | shasum -a 256 | head -c8)
 LOCK="/tmp/claude-lock-$LOCK_KEY"
 
-# Walk one level up from this script's bash → the claude PID (our PPID
-# is the bash, PPID's parent is claude).
-MY_CLAUDE_PID=$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')
+# Climb the process tree until we find an ancestor whose comm is
+# `claude`. Claude Code's hook execution layers a wrapper shell between
+# this script and the claude session, so a one-step `ps -o ppid=` walk
+# lands on the shell (comm `-zsh`) — not on claude. That used to
+# silently break the orphan-reclaim path in git-lock-enforcer.sh, which
+# would then rewrite the lock with another shell PID and exit 0,
+# disabling all protection. See #899 for the live evidence.
+#
+# Fallback: if no claude ancestor is found within max_hops (e.g. when
+# the hook is invoked manually for testing), preserve original
+# behaviour by returning the one-step PPID-walk result.
+find_claude_ancestor() {
+  local pid="${1:-$PPID}"
+  local max_hops=20
+  local hop=0
+  local comm
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$hop" -lt "$max_hops" ]; do
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ' | sed 's|.*/||')
+    if [ "$comm" = "claude" ]; then
+      echo "$pid"
+      return 0
+    fi
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    hop=$((hop + 1))
+  done
+  # Fallback to original one-step walk.
+  ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' '
+}
+
+MY_CLAUDE_PID=$(find_claude_ancestor "$PPID")
 LOCK_CONTENT="${MY_CLAUDE_PID:-$PPID}:$(hostname):$(date -u +%s)"
 
 # Try atomic claim. noclobber refuses to overwrite existing locks.

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -48,6 +48,7 @@
     "test:e2e:ui": "NODE_ENV=test playwright test --ui",
     "test:e2e:debug": "NODE_ENV=test playwright test --debug",
     "test:e2e:setup": "bash scripts/setup-test-db.sh",
+    "test:hooks": "bash ../../.claude/hooks/__tests__/test-find-claude-ancestor.sh",
     "test:all": "npm run test && npm run test:integration && npm run test:e2e",
     "playwright:install": "playwright install --with-deps",
     "db:reset": "tsx prisma/reset.ts",


### PR DESCRIPTION
## Summary

Fixes #899 — a latent bug in the PID-lock concurrency protection built across #841 / #849 / #861 / #870. The protection was silently a no-op: every session reclaimed the lock on every git command, so peer sessions could `git checkout` freely with no block firing.

## Root cause

Both `session-start.sh` and `git-lock-enforcer.sh` did a one-step walk to identify the current session's claude PID:

```bash
MY_CLAUDE_PID=$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')
```

In Claude Code's hook execution, `$PPID` is the hook's bash and its parent is a `-zsh` wrapper shell — not the claude session. So:

1. session-start wrote a SHELL PID into the lock file.
2. git-lock-enforcer's same (wrong) walk produced another shell PID, didn't match the lock owner, fell through to the orphan-reclaim path added in #861.
3. Orphan path checks `ps -o comm= -p $LOCK_PID`. With a shell PID in the lock, comm is `-zsh`, never `claude` — so it always fired, silently rewriting the lock with yet another shell PID and exiting 0.
4. **Net: zero blocking. Every session reclaimed the lock on every git command.**

## Live pre-fix evidence (main worktree, PID 28605 session)

```
$ cat /tmp/claude-lock-8b95fbdd
97845:MacBookAir.lan:1779806878
$ ps -p 97845 -o pid,ppid,comm
  PID  PPID COMM
97845 97843 -zsh        <-- should be `claude`
```

## Fix

`find_claude_ancestor` helper climbs the process tree until it finds a process whose `comm` is `claude` (20-hop safety net, fallback to the original one-step walk when claude isn't an ancestor, e.g. manual testing).

Applied verbatim to both hooks — duplicated rather than sourced because bash hooks have no module system. The orphan-reclaim path is preserved unchanged for its legitimate case (claude died → OS reassigned PID); the fix just stops triggering that path falsely.

## Post-fix verification (same worktree)

```
Lock file: /tmp/claude-lock-ff49deca
Content:   28621:MacBookAir.lan:...
$ ps -p 28621 -o comm=
claude    <-- correct
```

Synthetic peer-owned lock (PID 62064, another live claude) → enforcer exits 2 with the block message. My own lock (PID 28621) → enforcer exits 0. Read-only git (status/log/diff/branch/rev-parse/fetch) all exit 0 in secondary mode. Genuinely-stale lock (dead PID) → still reclaims silently and stores the correct claude PID.

## Test plan

- [x] `npm run test:hooks` from `apps/admin/` — 6/6 pass (bash 3.2 compatible, no associative arrays)
- [x] Manual: session-start hook lock file contains a real `claude` PID (was `-zsh` pre-fix)
- [x] Manual: synthetic peer-owned lock blocks `git checkout main` with exit 2 + block message
- [x] Manual: own-session lock allows `git checkout main` (exit 0, primary mode)
- [x] Manual: read-only git ops (`status`, `log`, `diff`, `branch`, `rev-parse`, `fetch --dry-run`) all exit 0 even in secondary mode
- [x] Manual: dead-PID orphan-reclaim path still fires and rewrites lock to current claude PID
- [ ] Reviewer: open a second `claude` session in `/Users/paulwander/projects/HF` (main repo), attempt `git checkout main` — expect block with the actionable message

## Acceptance

- Lock format unchanged (`pid:hostname:timestamp`)
- Lock path unchanged (`/tmp/claude-lock-<sha8>`)
- `HF_FORCE_GIT=1` operator override unchanged
- Orphan-reclaim path unchanged for genuinely dead PIDs
- Read-only git pass-through unchanged

## Test cases added

`.claude/hooks/__tests__/test-find-claude-ancestor.sh`:

1. Climbs past wrapper shell to claude ancestor
2. Strips `/path/to/` prefix from comm before comparing
3. Falls back to one-step walk when no claude in ancestry
4. `max_hops` safety net prevents infinite climb on cycles
5. Empty ppid mid-walk falls through to fallback cleanly
6. Returns the starting PID when called on the claude PID itself

Closes #899. Follows #841, #849, #861, #870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)