### PR TITLE
feat(#599): Slice 1 — AI-synthesized prior-call recap engine + safety rails

### DIFF
--- a/apps/admin/evals/tutor/prior-call-recap-v2.yaml
+++ b/apps/admin/evals/tutor/prior-call-recap-v2.yaml
@@ -1,0 +1,165 @@
+description: "Prior-Call Recap v2 — AI-synthesized depth picker (#599 Slice 1)"
+
+# Mirrors the system prompt in
+# `apps/admin/lib/prompt/composition/loaders/synthesizePriorCallRecap.ts`.
+# Validates that:
+#   - `standard` produces 2-3 sentences, no raw numeric scores, encouraging
+#   - `rich` produces 3-4 sentences and references the transcript moment
+#   - `minimal` fallback is byte-equivalent to the templated baseline (no AI)
+#   - Daily-cap fallback returns the templated baseline verbatim
+
+prompts:
+  - id: recap-standard
+    label: "Standard depth — 2-3 sentence diagnosis + re-entry angle"
+    raw: |
+      You are a coaching consultant briefing a 1:1 tutor on a returning learner.
+      Your job is to write a brief, encouraging diagnosis of the learner's last attempt that the tutor will read just before greeting the learner.
+      Speak about the learner in the third person. Be specific, kind, and forward-looking.
+
+      Hard rules:
+      - Do NOT include raw numeric scores or fractions (e.g. '5.2/9', '0.4'). Translate to qualitative language.
+      - Do NOT congratulate or commiserate excessively. One light affective beat at most.
+      - Do NOT speculate about the learner's emotions beyond what the evidence supports.
+      - Output plain prose. No bullets, no headers, no markdown.
+      - Produce 2 to 3 sentences. Cover: what they struggled with, the likely cause in plain language, and one concrete re-entry angle the tutor can use.
+
+      Learner: {{callerName}}
+      Weakest area on last attempt: {{weakestArea}}
+      Last attempt at: {{lastCallAt}}
+      Templated baseline summary: {{templatedSummary}}
+
+  - id: recap-rich
+    label: "Rich depth — 3-4 sentences + transcript observation"
+    raw: |
+      You are a coaching consultant briefing a 1:1 tutor on a returning learner.
+      Your job is to write a brief, encouraging diagnosis of the learner's last attempt that the tutor will read just before greeting the learner.
+      Speak about the learner in the third person. Be specific, kind, and forward-looking.
+
+      Hard rules:
+      - Do NOT include raw numeric scores or fractions (e.g. '5.2/9', '0.4'). Translate to qualitative language.
+      - Do NOT congratulate or commiserate excessively. One light affective beat at most.
+      - Do NOT speculate about the learner's emotions beyond what the evidence supports.
+      - Output plain prose. No bullets, no headers, no markdown.
+      - Produce 3 to 4 sentences. Cover: what they struggled with, the likely cause, one transcript-grounded observation (cite the moment without quoting at length), and one concrete re-entry angle.
+
+      Learner: {{callerName}}
+      Weakest area on last attempt: {{weakestArea}}
+      Last attempt at: {{lastCallAt}}
+      Templated baseline summary: {{templatedSummary}}
+
+      Transcript excerpt (most recent first ~6000 chars):
+      {{transcript}}
+
+providers:
+  - id: anthropic:messages:claude-haiku-4-5-20251001
+    config:
+      max_tokens: 600
+      temperature: 0.4
+
+tests:
+  # ── Fixture 1: Standard IELTS fluency struggle ───────────────────────────
+  - description: "Standard — IELTS fluency miss with templated baseline"
+    prompts: [recap-standard]
+    vars:
+      callerName: "Aria"
+      weakestArea: "Fluency"
+      lastCallAt: "2026-05-25T09:00:00Z"
+      templatedSummary: "On your last attempt yesterday, your weakest area was Fluency."
+    assert:
+      - type: javascript
+        value: |
+          const text = String(output).trim();
+          // 2-3 sentences. Counted by terminal punctuation.
+          const sentences = (text.match(/[.!?](?:\s|$)/g) || []).length;
+          if (sentences < 2 || sentences > 3) {
+            return { pass: false, score: 0, reason: `Expected 2-3 sentences, got ${sentences}: ${text}` };
+          }
+          // No raw numeric scores like 5.2/9 or 0.4
+          if (/\d+\.\d+/.test(text)) {
+            return { pass: false, score: 0, reason: `Raw numeric score detected: ${text}` };
+          }
+          return true;
+      - type: llm-rubric
+        value: "Names fluency as the area to focus on, suggests a likely cause in plain language, and offers one concrete re-entry angle for the tutor (e.g. start with a low-stakes warmup). Encouraging tone, not punitive."
+
+  # ── Fixture 2: Rich vocab miss with transcript ───────────────────────────
+  - description: "Rich — vocabulary miss with transcript-grounded observation"
+    prompts: [recap-rich]
+    vars:
+      callerName: "Bryn"
+      weakestArea: "Vocabulary"
+      lastCallAt: "2026-05-24T14:00:00Z"
+      templatedSummary: "On your last attempt 2 days ago, your weakest area was Vocabulary."
+      transcript: |
+        Tutor: Tell me about a memorable journey.
+        Learner: I went to Cornwall. It was nice. We had a... a... I can't remember the word. The big rocks by the sea?
+        Tutor: Cliffs?
+        Learner: Yes, cliffs. The cliffs were big. And the sea was blue.
+        Tutor: What made the trip memorable?
+        Learner: I don't know how to say it. It was a feeling. Quiet but happy.
+        Tutor: Serene? Peaceful?
+        Learner: Peaceful. Yes. The day was peaceful.
+    assert:
+      - type: javascript
+        value: |
+          const text = String(output).trim();
+          // 3-4 sentences. (Allow up to 5 — generation variance.)
+          const sentences = (text.match(/[.!?](?:\s|$)/g) || []).length;
+          if (sentences < 3 || sentences > 5) {
+            return { pass: false, score: 0, reason: `Expected 3-5 sentences, got ${sentences}: ${text}` };
+          }
+          if (/\d+\.\d+/.test(text)) {
+            return { pass: false, score: 0, reason: `Raw numeric score detected: ${text}` };
+          }
+          return true;
+      - type: llm-rubric
+        value: "References a concrete moment from the transcript (e.g. struggling to recall 'cliffs' or 'peaceful'), names a likely cause (word retrieval / range), and offers a re-entry angle that uses the moment as a bridge. Names Bryn or 'the learner' consistently."
+
+  # ── Fixture 3: Minimal fallback — templated baseline only (no AI call) ───
+  - description: "Minimal fallback — templated baseline returned verbatim, no AI"
+    prompts: [recap-standard]
+    vars:
+      callerName: "Tess"
+      weakestArea: "(none — no scores yet)"
+      lastCallAt: "2026-05-26T08:00:00Z"
+      templatedSummary: "On your last attempt earlier today we didn't have clear score signals to learn from — let's pick up where we left off."
+    assert:
+      # The synthesizer's `minimal` depth short-circuits to the templated path
+      # without calling the model. This fixture is here to lock in the
+      # *expectation* that the runtime never invokes synthesis at minimal —
+      # the model output (if the eval ran anyway) should still NOT introduce
+      # raw scores or contradict the templated baseline.
+      - type: javascript
+        value: |
+          const text = String(output).trim();
+          if (/\d+\.\d+/.test(text)) {
+            return { pass: false, score: 0, reason: `Numeric score introduced in minimal fallback: ${text}` };
+          }
+          return true;
+      - type: llm-rubric
+        value: "Either echoes the templated baseline or produces something gently encouraging that does NOT invent a weakness when none is in the evidence."
+
+  # ── Fixture 4: Daily-cap fallback — templated output ─────────────────────
+  - description: "Daily-cap fallback — would return templated baseline at runtime"
+    prompts: [recap-standard]
+    vars:
+      callerName: "Otto"
+      weakestArea: "Grammar"
+      lastCallAt: "2026-05-24T11:00:00Z"
+      templatedSummary: "On your last attempt 2 days ago, your weakest area was Grammar."
+    assert:
+      # When the per-playbook daily cap is hit at runtime, the loader falls
+      # back to the templated baseline — no AI call fires. This fixture
+      # exercises the *content* the templated baseline would produce so
+      # changes to the template surface in the eval rather than at compose-
+      # time. (The fall-back behaviour itself is covered by the vitest
+      # gate tests in `prior-call-feedback-synthesis.test.ts`.)
+      - type: javascript
+        value: |
+          const text = String(output).trim();
+          if (/\d+\.\d+/.test(text)) {
+            return { pass: false, score: 0, reason: `Raw numeric score in cap-fallback path: ${text}` };
+          }
+          return true;
+      - type: llm-rubric
+        value: "Names grammar as the area to focus on without inventing numbers; offers an actionable re-entry angle the tutor could use."

--- a/apps/admin/lib/ai/call-points.ts
+++ b/apps/admin/lib/ai/call-points.ts
@@ -135,6 +135,17 @@ export const CALL_POINTS: CallPointDef[] = [
     defaults: { provider: "claude", model: config.ai.claude.model },
   },
   {
+    // #599 Slice 1 — AI-synthesized prior-call recap. Brief 2-4 sentence
+    // diagnosis of the learner's last attempt on this module, consumed by
+    // the `priorCallFeedback` composer section. Light model is sufficient
+    // (input is a small structured summary + optional 6KB transcript slice).
+    id: "compose.prior-call-recap",
+    label: "Prompt Composition - Prior-Call Recap",
+    description: "Synthesizes a brief diagnosis of the learner's last attempt for the next-call prompt",
+    category: "conversation",
+    defaults: { provider: "claude", model: config.ai.claude.lightModel, temperature: 0.4, maxTokens: 600, timeoutMs: 20_000 },
+  },
+  {
     id: "test-harness.system",
     label: "Test Harness - System Agent",
     description: "System agent turns in simulated conversations",

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -890,11 +890,88 @@ async function handleUpdateBehaviorTarget(input: Record<string, any>) {
 }
 
 /**
+ * #599 Slice 1 — AI-surface validation/clamp for the `priorCallRecap` block
+ * on inbound `update_playbook_config` writes. Two defensive checks:
+ *   1. `depth` must be one of `"minimal" | "standard" | "rich"`. Unknown
+ *      values (`"Maximum"`, numbers, `null`) are rejected with a clear
+ *      message so the model can self-correct.
+ *   2. `dailyCap` is clamped to `[0, PRIOR_CALL_RECAP_DAILY_CAP_MAX]` and
+ *      coerced to an integer. A `console.warn` fires when clamping kicks
+ *      in so operators can spot model hallucinations in the logs.
+ *
+ * Returns either `{ normalised }` (the same shape as the input, with
+ * `priorCallRecap` cleaned) or `{ error }` with a human-readable message
+ * suitable for echoing back to the model.
+ */
+const VALID_RECAP_DEPTHS = new Set(["minimal", "standard", "rich"]);
+
+/** Exported for unit tests. Returned shape is the same one the handler echoes back to the model. */
+export function validatePriorCallRecapUpdates(
+  updates: Record<string, unknown>,
+): { normalised: Record<string, unknown>; error?: undefined } | { normalised?: undefined; error: string } {
+  if (!Object.prototype.hasOwnProperty.call(updates, "priorCallRecap")) {
+    return { normalised: updates };
+  }
+  const raw = updates.priorCallRecap;
+  // Allow explicit `null` to clear the field — merge target picks it up.
+  if (raw === null) {
+    return { normalised: updates };
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      error:
+        "priorCallRecap must be an object of shape { enabled: boolean; depth?: 'minimal'|'standard'|'rich'; dailyCap?: number }.",
+    };
+  }
+  const value = raw as Record<string, unknown>;
+
+  const cleaned: Record<string, unknown> = {};
+
+  if (Object.prototype.hasOwnProperty.call(value, "enabled")) {
+    if (typeof value.enabled !== "boolean") {
+      return { error: "priorCallRecap.enabled must be a boolean." };
+    }
+    cleaned.enabled = value.enabled;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(value, "depth")) {
+    if (typeof value.depth !== "string" || !VALID_RECAP_DEPTHS.has(value.depth)) {
+      return {
+        error: `priorCallRecap.depth must be one of 'minimal', 'standard', 'rich' — got ${JSON.stringify(value.depth)}.`,
+      };
+    }
+    cleaned.depth = value.depth;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(value, "dailyCap")) {
+    const dailyCap = value.dailyCap;
+    if (typeof dailyCap !== "number" || !Number.isFinite(dailyCap)) {
+      return { error: "priorCallRecap.dailyCap must be a finite number." };
+    }
+    const PRIOR_CALL_RECAP_DAILY_CAP_MAX = 500;
+    const clamped = Math.min(Math.max(0, Math.floor(dailyCap)), PRIOR_CALL_RECAP_DAILY_CAP_MAX);
+    if (clamped !== dailyCap) {
+      console.warn(
+        `[admin-tool] update_playbook_config: priorCallRecap.dailyCap clamped ${dailyCap} → ${clamped} (limit: ${PRIOR_CALL_RECAP_DAILY_CAP_MAX}).`,
+      );
+    }
+    cleaned.dailyCap = clamped;
+  }
+
+  return { normalised: { ...updates, priorCallRecap: cleaned } };
+}
+
+/**
  * Update non-behaviour playbook settings from the TUNING assistant. Testing-mode
  * scope: the AI may set any key in PlaybookConfig — no server-side whitelist.
  * Other keys in the existing config are preserved (merge, not replace).
  * Config-only updates are allowed on PUBLISHED playbooks per
  * /api/playbooks/[playbookId]/route.ts (isConfigOnlyUpdate exemption).
+ *
+ * #599 Slice 1 — AI-surface safety rails for `priorCallRecap`:
+ *   - `depth` enum validated; unknown values rejected with a clear error.
+ *   - `dailyCap` server-side clamped to `[0, 500]` with a console.warn.
+ * See `validatePriorCallRecapUpdates` below.
  */
 async function handleUpdatePlaybookConfig(input: Record<string, any>) {
   const playbookId = typeof input.playbook_id === "string" ? input.playbook_id : "";
@@ -902,12 +979,20 @@ async function handleUpdatePlaybookConfig(input: Record<string, any>) {
     return { error: "playbook_id is required (read from entity context with type: 'playbook')" };
   }
 
-  const updates = input.config_updates;
-  if (!updates || typeof updates !== "object" || Array.isArray(updates) || Object.keys(updates).length === 0) {
+  const rawUpdates = input.config_updates;
+  if (!rawUpdates || typeof rawUpdates !== "object" || Array.isArray(rawUpdates) || Object.keys(rawUpdates).length === 0) {
     return {
       error: "config_updates must be a non-empty object of PlaybookConfig keys to merge (e.g. { sessionCount: 5, durationMins: 6 }).",
     };
   }
+
+  // #599 Slice 1 — validate + clamp priorCallRecap before write so a
+  // hallucinated enum or out-of-range number cannot slip through tray review.
+  const safety = validatePriorCallRecapUpdates(rawUpdates);
+  if (safety.error) {
+    return { error: safety.error };
+  }
+  const updates = safety.normalised as Record<string, unknown>;
 
   const playbook = await prisma.playbook.findUnique({
     where: { id: playbookId },

--- a/apps/admin/lib/chat/ai-forbidden-fields.ts
+++ b/apps/admin/lib/chat/ai-forbidden-fields.ts
@@ -65,6 +65,17 @@ export const AI_FORBIDDEN_FIELDS: Record<string, readonly string[]> = {
   // ContentAssertion soft-FK; changing it through AI would silently
   // break assertion linkage.
   learning_objective: ["ref", "moduleId", "deletedAt"],
+
+  // SystemSetting — global / cross-tenant configuration. No AI tool
+  // currently writes to this table; this entry is a tripwire so any future
+  // `update_system_setting`-style tool that exposes one of these keys to
+  // the model gets caught by the meta-test. (#599 Slice 1.)
+  //
+  // `prior_call_recap.allowlist` gates which playbooks receive the
+  // AI-synthesized recap path — it must remain an ops-admin-only knob so
+  // synthesis cannot be unblocked from the chat surface. See the loader
+  // gate in lib/prompt/composition/loaders/priorCallFeedback.ts.
+  system_setting: ["prior_call_recap.allowlist"],
 };
 
 /**

--- a/apps/admin/lib/metering/instrumented-ai.ts
+++ b/apps/admin/lib/metering/instrumented-ai.ts
@@ -33,6 +33,14 @@ export interface MeteringContext {
   entityLabel?: string;
   wizardName?: string;
   wizardStep?: string;
+  /**
+   * Extra key/value pairs merged into the `UsageEvent.metadata` JSON column
+   * when the auto-metering fires. Used by features that need to filter
+   * usage rows by a specific attribute (e.g. #599 daily cap query filters
+   * `metadata->>'playbookId'`). Cache-token keys, if present, are layered
+   * on top by the metering helper and take precedence on conflict.
+   */
+  extraMetadata?: Record<string, unknown>;
 }
 
 /**
@@ -58,12 +66,18 @@ export async function getMeteredAICompletion(
       callerId: context?.callerId,
       callId: context?.callId,
       sourceOp: context?.sourceOp,
-      metadata: result.usage.cacheReadTokens || result.usage.cacheCreationTokens
-        ? {
-            cacheReadTokens: result.usage.cacheReadTokens,
-            cacheCreationTokens: result.usage.cacheCreationTokens,
-          }
-        : undefined,
+      metadata:
+        context?.extraMetadata || result.usage.cacheReadTokens || result.usage.cacheCreationTokens
+          ? {
+              ...(context?.extraMetadata ?? {}),
+              ...(result.usage.cacheReadTokens || result.usage.cacheCreationTokens
+                ? {
+                    cacheReadTokens: result.usage.cacheReadTokens,
+                    cacheCreationTokens: result.usage.cacheCreationTokens,
+                  }
+                : {}),
+            }
+          : undefined,
     }).catch((error) => {
       console.error("[metering] Failed to log AI usage:", error);
     });

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -665,10 +665,26 @@ registerLoader("priorCallFeedback", async (callerId, config) => {
     };
   }
   try {
+    // #599 Slice 1 — resolve playbookId + config from the current Call so the
+    // synthesis gate sequence has the inputs it needs. When currentCallId is
+    // absent (preview / forceFirstCall path), the loader falls through to the
+    // templated path; no DB lookup is needed.
+    let playbookId: string | null = null;
+    let playbookConfig: PlaybookConfig | null = null;
+    if (currentCallId) {
+      const call = await prisma.call.findUnique({
+        where: { id: currentCallId },
+        select: { playbookId: true, playbook: { select: { config: true } } },
+      });
+      playbookId = call?.playbookId ?? null;
+      playbookConfig = (call?.playbook?.config as PlaybookConfig | null) ?? null;
+    }
     return await loadPriorCallFeedback(prisma, {
       callerId,
       moduleId,
       currentCallId: currentCallId ?? null,
+      playbookId,
+      playbookConfig,
     });
   } catch (err) {
     console.warn("[priorCallFeedback] loader failed — section will be omitted:", err);

--- a/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
+++ b/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
@@ -1,5 +1,5 @@
 /**
- * priorCallFeedback loader (#492 Slice 3.5)
+ * priorCallFeedback loader (#492 Slice 3.5 + #599 Slice 1)
  *
  * When composing the prompt for the next call on a given module, pull a brief
  * "since your last attempt on this module" recap so the AI tutor can reference
@@ -11,16 +11,68 @@
  * Implementation notes:
  *   - Pure function — takes a prisma client + scope as args so it can be tested
  *     against a mock client and reused outside the composition path.
- *   - Single Call query + single CallScore query (no N+1).
- *   - Safe by default: any unexpected error returns `hasFeedback: false`. The
- *     SectionDataLoader wrapper additionally try/catches so composition is
- *     never broken by a feedback miss.
+ *   - Single Call query + single CallScore query (no N+1) for the templated
+ *     path. The synthesis path adds: optional Caller lookup, optional Call
+ *     transcript fetch, SystemSetting allowlist check, UsageEvent cap count,
+ *     ComposedPrompt cache read, AuditLog write — all behind feature gates.
+ *   - Safe by default: any unexpected error returns `hasFeedback: false`.
+ *     Synthesis failures degrade to the templated path (caught in the loader).
+ *
+ * **#599 Slice 1 — synthesis wrapping.** When `opts.playbookConfig?.priorCallRecap`
+ * opts in (and every gate passes), the loader replaces the templated summary
+ * with an AI-synthesized version. Gates fire in order:
+ *   1. `process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED === "true"` (kill switch)
+ *   2. `playbookConfig.priorCallRecap.enabled === true`
+ *   3. `SystemSetting prior_call_recap.allowlist` contains `playbookId`
+ *   4. `UsageEvent` count for today < `dailyCap`
+ *   5. Depth dispatch: `minimal` short-circuits to templated path (no AI call)
+ *   6. Cache read: existing `ComposedPrompt.recapSynthesisCache.depth` match → hit
+ *   7. Synthesize → audit log → return
+ *
+ * Cache writes happen at persist time — see `lib/prompt/composition/persist.ts`,
+ * which reads `synthesizedRecap` off the loader output and writes it to
+ * `ComposedPrompt.recapSynthesisCache`.
  *
  * @see SectionDataLoader.registerLoader("priorCallFeedback", ...)
  * @see transforms/priorCallFeedback.ts (renderPriorCallFeedback transform)
+ * @see loaders/synthesizePriorCallRecap.ts (synthesis function)
  */
 
 import type { PrismaClient } from "@prisma/client";
+import type { PlaybookConfig, PriorCallRecapDepth } from "@/lib/types/json-fields";
+import { synthesizePriorCallRecap, RICH_TRANSCRIPT_SLICE_LIMIT } from "./synthesizePriorCallRecap";
+
+/** Server-side ceiling on `priorCallRecap.dailyCap`. Anything larger is treated as this. */
+export const PRIOR_CALL_RECAP_DAILY_CAP_MAX = 500;
+
+/** Default per-playbook cap when `priorCallRecap.dailyCap` is absent. */
+export const PRIOR_CALL_RECAP_DAILY_CAP_DEFAULT = 50;
+
+/** SystemSetting key holding the JSON-encoded playbookId allowlist. */
+export const PRIOR_CALL_RECAP_ALLOWLIST_KEY = "prior_call_recap.allowlist";
+
+/** UsageEvent.sourceOp value emitted by the synthesis AI call. */
+export const PRIOR_CALL_RECAP_SOURCE_OP = "compose.prior-call-recap";
+
+/** AuditLog.action values written by the gate sequence. */
+export const PRIOR_CALL_RECAP_ACTIONS = {
+  synthesized: "prior-call-recap-synthesized",
+  allowlistEmpty: "prior-call-recap-allowlist-empty",
+  capExceeded: "prior-call-recap-cap-exceeded",
+} as const;
+
+export interface PriorCallRecapCacheEntry {
+  depth: PriorCallRecapDepth;
+  text: string;
+  cachedAt: string;
+}
+
+export interface SynthesizedRecapResult {
+  depth: PriorCallRecapDepth;
+  text: string;
+  cachedAt: string;
+  cachedHit: boolean;
+}
 
 export interface PriorCallFeedbackData {
   hasFeedback: boolean;
@@ -35,6 +87,13 @@ export interface PriorCallFeedbackData {
   overallScore: number | null;
   /** 1–2 sentence canned summary — friendly, with relative time */
   summary: string | null;
+  /**
+   * #599 Slice 1 — when the AI synthesis path ran (or returned a cache hit),
+   * the resolved depth + text. Null on the templated path (every gate-blocked
+   * scenario, plus `depth: "minimal"`). Persisted to
+   * `ComposedPrompt.recapSynthesisCache` by `persistComposedPrompt`.
+   */
+  synthesizedRecap?: SynthesizedRecapResult | null;
 }
 
 export interface LoadPriorCallFeedbackOptions {
@@ -45,6 +104,17 @@ export interface LoadPriorCallFeedbackOptions {
   currentCallId?: string | null;
   /** Override "now" for deterministic tests */
   now?: Date;
+  /**
+   * #599 Slice 1 — playbook being composed for. Required for the synthesis
+   * gate sequence (allowlist + daily cap + cache key). When absent, the
+   * loader runs the templated path only.
+   */
+  playbookId?: string | null;
+  /**
+   * #599 Slice 1 — playbook config feeding `priorCallRecap` gates. Pass
+   * `null` (or omit) to bypass synthesis entirely (templated path only).
+   */
+  playbookConfig?: PlaybookConfig | null;
 }
 
 const EMPTY: PriorCallFeedbackData = {
@@ -59,9 +129,13 @@ const EMPTY: PriorCallFeedbackData = {
 
 /**
  * Subset of PrismaClient used by this loader — narrows the surface so tests
- * can pass a minimal mock object.
+ * can pass a minimal mock object. #599 Slice 1 widens the surface to cover
+ * the synthesis gates.
  */
-type PrismaForLoader = Pick<PrismaClient, "call" | "callScore">;
+type PrismaForLoader = Pick<
+  PrismaClient,
+  "call" | "callScore" | "systemSetting" | "usageEvent" | "composedPrompt" | "auditLog" | "caller"
+>;
 
 /**
  * Load the prior-call feedback summary for a given caller + module.
@@ -179,7 +253,7 @@ export async function loadPriorCallFeedback(
     overallScore,
   });
 
-  return {
+  const templated: PriorCallFeedbackData = {
     hasFeedback: true,
     lastCallAt,
     lastCallId: priorCall.id,
@@ -188,6 +262,270 @@ export async function loadPriorCallFeedback(
     overallScore,
     summary,
   };
+
+  // #599 Slice 1 — opt-in AI synthesis path. Failures degrade silently to
+  // the templated path so a flaky AI call cannot break composition.
+  let synthesizedRecap: SynthesizedRecapResult | null = null;
+  try {
+    synthesizedRecap = await maybeSynthesizeRecap(prisma, opts, templated);
+  } catch (err) {
+    console.warn("[priorCallFeedback] synthesis failed — falling back to templated path:", err);
+  }
+
+  return { ...templated, synthesizedRecap };
+}
+
+// =============================================================
+// #599 Slice 1 — synthesis gate sequence
+// =============================================================
+
+/**
+ * Resolves the AI-synthesized recap when every gate passes. Returns null on
+ * any gate miss (templated path wins), null on `minimal` depth (no AI), and
+ * the full result on cache hit or synth success.
+ *
+ * Side-effects: writes UsageEvent (via the metering helper inside the
+ * synthesizer) and AuditLog rows (synth-success / allowlist-empty / cap-exceeded).
+ */
+async function maybeSynthesizeRecap(
+  prisma: PrismaForLoader,
+  opts: LoadPriorCallFeedbackOptions,
+  templated: PriorCallFeedbackData,
+): Promise<SynthesizedRecapResult | null> {
+  if (!templated.hasFeedback) return null;
+
+  // Gate 1 — kill switch (env var, strict string compare).
+  if (process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED !== "true") return null;
+
+  // Gate 2 — playbook config opt-in.
+  const recapCfg = opts.playbookConfig?.priorCallRecap;
+  if (!recapCfg?.enabled) return null;
+
+  const depth: PriorCallRecapDepth = recapCfg.depth ?? "minimal";
+  // `minimal` depth is documented as "no AI call". Short-circuit before
+  // running the allowlist / cap queries.
+  if (depth === "minimal") return null;
+
+  const playbookId = opts.playbookId ?? null;
+  if (!playbookId) return null;
+
+  // Gate 3 — allowlist. Absent row AND empty array both block (safe default).
+  const allowlistCheck = await checkAllowlist(prisma, playbookId);
+  if (!allowlistCheck.allowed) {
+    await maybeWriteOncePerDayAudit(
+      prisma,
+      PRIOR_CALL_RECAP_ACTIONS.allowlistEmpty,
+      playbookId,
+      { cause: allowlistCheck.cause, depth },
+      opts.now ?? new Date(),
+    );
+    return null;
+  }
+
+  // Gate 4 — daily cap. Use the same clamp the AI-surface handler uses.
+  const requestedCap = recapCfg.dailyCap ?? PRIOR_CALL_RECAP_DAILY_CAP_DEFAULT;
+  const cap = Math.min(Math.max(0, requestedCap), PRIOR_CALL_RECAP_DAILY_CAP_MAX);
+  const usedToday = await countSynthesisUsageToday(prisma, playbookId, opts.now ?? new Date());
+  if (usedToday >= cap) {
+    await prisma.auditLog.create({
+      data: {
+        action: PRIOR_CALL_RECAP_ACTIONS.capExceeded,
+        entityType: "Playbook",
+        entityId: playbookId,
+        metadata: { playbookId, dailyCap: cap, usedToday, depth },
+      },
+    });
+    return null;
+  }
+
+  // Gate 5 — cache read. Existing ComposedPrompt for this triggerCallId with
+  // a matching depth → reuse text (no AI call, no audit row).
+  if (opts.currentCallId) {
+    const cached = await readCachedRecap(prisma, {
+      callerId: opts.callerId,
+      triggerCallId: opts.currentCallId,
+      playbookId,
+      depth,
+    });
+    if (cached) {
+      return { ...cached, cachedHit: true };
+    }
+  }
+
+  // Gate 6 — synthesize.
+  const callerName = await fetchCallerFirstName(prisma, opts.callerId);
+  const transcript =
+    depth === "rich" && templated.lastCallId
+      ? await fetchTranscript(prisma, templated.lastCallId)
+      : null;
+
+  const result = await synthesizePriorCallRecap({
+    feedback: templated,
+    depth,
+    callerName,
+    transcript: transcript ? transcript.slice(0, RICH_TRANSCRIPT_SLICE_LIMIT) : null,
+    callId: opts.currentCallId ?? undefined,
+    callerId: opts.callerId,
+    playbookId,
+  });
+
+  // Audit log — every synthesis (cache-miss).
+  await prisma.auditLog.create({
+    data: {
+      action: PRIOR_CALL_RECAP_ACTIONS.synthesized,
+      entityType: "Call",
+      entityId: opts.currentCallId ?? "",
+      metadata: {
+        callId: opts.currentCallId ?? null,
+        depth,
+        playbookId,
+        cachedHit: false,
+        tokensUsed: result.tokensUsed,
+        latencyMs: result.latencyMs,
+        outputText: result.text,
+      },
+    },
+  });
+
+  return {
+    depth,
+    text: result.text,
+    cachedAt: (opts.now ?? new Date()).toISOString(),
+    cachedHit: false,
+  };
+}
+
+interface AllowlistResult {
+  allowed: boolean;
+  cause?: "row-absent" | "empty-array" | "not-in-list";
+}
+
+async function checkAllowlist(
+  prisma: PrismaForLoader,
+  playbookId: string,
+): Promise<AllowlistResult> {
+  const row = await prisma.systemSetting.findUnique({
+    where: { key: PRIOR_CALL_RECAP_ALLOWLIST_KEY },
+    select: { value: true },
+  });
+  if (!row) return { allowed: false, cause: "row-absent" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.value);
+  } catch {
+    return { allowed: false, cause: "empty-array" };
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return { allowed: false, cause: "empty-array" };
+  }
+  if (!parsed.includes(playbookId)) {
+    return { allowed: false, cause: "not-in-list" };
+  }
+  return { allowed: true };
+}
+
+async function countSynthesisUsageToday(
+  prisma: PrismaForLoader,
+  playbookId: string,
+  now: Date,
+): Promise<number> {
+  const startOfUtcDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const rows = await prisma.usageEvent.findMany({
+    where: {
+      sourceOp: PRIOR_CALL_RECAP_SOURCE_OP,
+      createdAt: { gte: startOfUtcDay },
+    },
+    select: { metadata: true },
+  });
+  return rows.filter((r) => {
+    const md = (r.metadata ?? {}) as Record<string, unknown>;
+    return md.playbookId === playbookId;
+  }).length;
+}
+
+interface CachedRecapKey {
+  callerId: string;
+  triggerCallId: string;
+  playbookId: string;
+  depth: PriorCallRecapDepth;
+}
+
+async function readCachedRecap(
+  prisma: PrismaForLoader,
+  key: CachedRecapKey,
+): Promise<PriorCallRecapCacheEntry | null> {
+  const row = await prisma.composedPrompt.findFirst({
+    where: {
+      callerId: key.callerId,
+      triggerCallId: key.triggerCallId,
+      playbookId: key.playbookId,
+    },
+    orderBy: { composedAt: "desc" },
+    select: { recapSynthesisCache: true },
+  });
+  if (!row?.recapSynthesisCache) return null;
+  const cache = row.recapSynthesisCache as unknown as PriorCallRecapCacheEntry;
+  if (
+    !cache ||
+    typeof cache !== "object" ||
+    cache.depth !== key.depth ||
+    typeof cache.text !== "string"
+  ) {
+    return null;
+  }
+  return cache;
+}
+
+async function maybeWriteOncePerDayAudit(
+  prisma: PrismaForLoader,
+  action: string,
+  playbookId: string,
+  metadata: Record<string, unknown>,
+  now: Date,
+): Promise<void> {
+  const startOfUtcDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const existing = await prisma.auditLog.findFirst({
+    where: {
+      action,
+      entityType: "Playbook",
+      entityId: playbookId,
+      createdAt: { gte: startOfUtcDay },
+    },
+    select: { id: true },
+  });
+  if (existing) return;
+  await prisma.auditLog.create({
+    data: {
+      action,
+      entityType: "Playbook",
+      entityId: playbookId,
+      metadata: { playbookId, ...metadata },
+    },
+  });
+}
+
+async function fetchCallerFirstName(
+  prisma: PrismaForLoader,
+  callerId: string,
+): Promise<string | null> {
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { name: true },
+  });
+  if (!caller?.name) return null;
+  return caller.name.split(/\s+/)[0] ?? null;
+}
+
+async function fetchTranscript(
+  prisma: PrismaForLoader,
+  callId: string,
+): Promise<string | null> {
+  const call = await prisma.call.findUnique({
+    where: { id: callId },
+    select: { transcript: true },
+  });
+  return call?.transcript ?? null;
 }
 
 // =============================================================

--- a/apps/admin/lib/prompt/composition/loaders/synthesizePriorCallRecap.ts
+++ b/apps/admin/lib/prompt/composition/loaders/synthesizePriorCallRecap.ts
@@ -1,0 +1,178 @@
+/**
+ * synthesizePriorCallRecap (#599 Slice 1)
+ *
+ * AI-synthesized prior-call recap. Wraps the templated path from
+ * `loadPriorCallFeedback` (#492 Slice 3.5) with a brief diagnosis that names
+ * the likely cause and offers a concrete re-entry angle — the moment of
+ * highest cold-start friction on call 2+.
+ *
+ * Depth semantics:
+ *   - "minimal" — no AI call. Returns the existing templated `summary`
+ *     verbatim. Used as the safe-default fallback for every blocked gate
+ *     (env var off, allowlist absent, daily cap exceeded, etc.).
+ *   - "standard" — 2–3 sentences, score + likely cause + re-entry. No raw
+ *     numeric scores in the output text (the eval asserts no `\d+\.\d+`).
+ *   - "rich" — 3–4 sentences + one transcript-grounded observation.
+ *     Transcript is hard-sliced at 6000 chars by the caller.
+ *
+ * Cascade discipline:
+ *   - Uses `getConfiguredMeteredAICompletion` with `callPoint:
+ *     "compose.prior-call-recap"`. **No explicit maxTokens/temperature**
+ *     are passed at the call site — registry defaults in `lib/ai/call-points.ts`
+ *     and DB AIConfig drive the cascade.
+ *
+ * @see lib/prompt/composition/loaders/priorCallFeedback.ts (the wrapper that
+ *   gates this function behind env var → enabled → allowlist → daily cap)
+ */
+
+import { getConfiguredMeteredAICompletion } from "@/lib/metering";
+import type { PriorCallFeedbackData } from "./priorCallFeedback";
+import type { PriorCallRecapDepth } from "@/lib/types/json-fields";
+
+/**
+ * Maximum transcript slice fed to the synthesis prompt for the "rich" depth.
+ * Bounded so a single rich synthesis call never exceeds the call-point token
+ * budget regardless of source transcript length.
+ */
+export const RICH_TRANSCRIPT_SLICE_LIMIT = 6000;
+
+export interface SynthesizePriorCallRecapInput {
+  feedback: PriorCallFeedbackData;
+  depth: PriorCallRecapDepth;
+  /** Caller's first name, used for personalisation. Optional. */
+  callerName?: string | null;
+  /**
+   * Full transcript of the prior call. Only consulted for `depth: "rich"`;
+   * the function slices it to {@link RICH_TRANSCRIPT_SLICE_LIMIT} chars
+   * regardless of incoming length.
+   */
+  transcript?: string | null;
+  /** Metering context — current call being composed for. */
+  callId?: string;
+  callerId?: string;
+  /**
+   * Playbook being composed for. Threaded into `UsageEvent.metadata` so the
+   * daily-cap query (`metadata->>'playbookId'`) can scope counts per course.
+   */
+  playbookId?: string;
+}
+
+export interface SynthesizePriorCallRecapResult {
+  text: string;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+const MINIMAL_RESULT_TOKENS = 0;
+
+/**
+ * Synthesize a prior-call recap at the requested depth.
+ *
+ * For `depth: "minimal"`, returns the existing templated `feedback.summary`
+ * with `tokensUsed: 0` — no AI call is made. The caller's gate sequence
+ * relies on this for the safe fallback path.
+ *
+ * For `standard` and `rich`, fires the configured AI call point with the
+ * appropriate prompt shape. Failures throw — the caller is expected to
+ * try/catch and fall back to the templated path on error (matching the
+ * existing `SectionDataLoader` safe-by-default policy).
+ */
+export async function synthesizePriorCallRecap(
+  input: SynthesizePriorCallRecapInput,
+): Promise<SynthesizePriorCallRecapResult> {
+  const started = Date.now();
+
+  if (input.depth === "minimal") {
+    return {
+      text: input.feedback.summary ?? "",
+      tokensUsed: MINIMAL_RESULT_TOKENS,
+      latencyMs: Date.now() - started,
+    };
+  }
+
+  const { systemPrompt, userPrompt } = buildSynthesisPrompt(input);
+
+  const aiResult = await getConfiguredMeteredAICompletion(
+    {
+      callPoint: "compose.prior-call-recap",
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+    },
+    {
+      callId: input.callId,
+      callerId: input.callerId,
+      sourceOp: "compose.prior-call-recap",
+      // Daily-cap scoping. The loader's gate query filters UsageEvent rows by
+      // `sourceOp = 'compose.prior-call-recap' AND metadata->>'playbookId' = $id`.
+      extraMetadata: input.playbookId ? { playbookId: input.playbookId } : undefined,
+    },
+  );
+
+  const tokensUsed =
+    (aiResult.usage?.inputTokens ?? 0) + (aiResult.usage?.outputTokens ?? 0);
+
+  return {
+    text: aiResult.content.trim(),
+    tokensUsed,
+    latencyMs: Date.now() - started,
+  };
+}
+
+// =============================================================
+// Prompt construction
+// =============================================================
+
+interface BuiltPrompt {
+  systemPrompt: string;
+  userPrompt: string;
+}
+
+function buildSynthesisPrompt(
+  input: SynthesizePriorCallRecapInput,
+): BuiltPrompt {
+  const { feedback, depth, callerName, transcript } = input;
+
+  const learnerLabel = callerName ? callerName : "the learner";
+
+  const systemPrompt = [
+    "You are a coaching consultant briefing a 1:1 tutor on a returning learner.",
+    "Your job is to write a brief, encouraging diagnosis of the learner's last attempt that the tutor will read just before greeting the learner.",
+    "Speak about the learner in the third person. Be specific, kind, and forward-looking.",
+    "",
+    "Hard rules:",
+    "- Do NOT include raw numeric scores or fractions (e.g. '5.2/9', '0.4'). Translate to qualitative language.",
+    "- Do NOT congratulate or commiserate excessively. One light affective beat at most.",
+    "- Do NOT speculate about the learner's emotions beyond what the evidence supports.",
+    "- Output plain prose. No bullets, no headers, no markdown.",
+    depth === "standard"
+      ? "- Produce 2 to 3 sentences. Cover: what they struggled with, the likely cause in plain language, and one concrete re-entry angle the tutor can use."
+      : "- Produce 3 to 4 sentences. Cover: what they struggled with, the likely cause, one transcript-grounded observation (cite the moment without quoting at length), and one concrete re-entry angle.",
+  ].join("\n");
+
+  const evidenceLines: string[] = [];
+  evidenceLines.push(`Learner: ${learnerLabel}`);
+  if (feedback.weakestParameterName) {
+    evidenceLines.push(
+      `Weakest area on last attempt: ${feedback.weakestParameterName}`,
+    );
+  }
+  if (feedback.lastCallAt) {
+    evidenceLines.push(`Last attempt at: ${feedback.lastCallAt}`);
+  }
+  if (feedback.summary) {
+    evidenceLines.push(`Templated baseline summary: ${feedback.summary}`);
+  }
+
+  if (depth === "rich" && transcript) {
+    const sliced = transcript.slice(0, RICH_TRANSCRIPT_SLICE_LIMIT);
+    evidenceLines.push("");
+    evidenceLines.push("Transcript excerpt (most recent first ~6000 chars):");
+    evidenceLines.push(sliced);
+  }
+
+  const userPrompt = evidenceLines.join("\n");
+
+  return { systemPrompt, userPrompt };
+}

--- a/apps/admin/lib/prompt/composition/persist.ts
+++ b/apps/admin/lib/prompt/composition/persist.ts
@@ -70,6 +70,19 @@ export async function persistComposedPrompt(
 
   const p = db(tx);
 
+  // #599 Slice 1 — populate the recap cache column when the loader produced
+  // a synthesized recap. The loader writes the AI call + audit row; persist
+  // just stores the cached text alongside the new prompt row so subsequent
+  // composes for the same triggerCallId can short-circuit.
+  const synthesizedRecap = composition.loadedData?.priorCallFeedback?.synthesizedRecap ?? null;
+  const recapSynthesisCache = synthesizedRecap
+    ? {
+        depth: synthesizedRecap.depth,
+        text: synthesizedRecap.text,
+        cachedAt: synthesizedRecap.cachedAt,
+      }
+    : undefined;
+
   const composedPrompt = await p.composedPrompt.create({
     data: {
       callerId,
@@ -80,6 +93,7 @@ export async function persistComposedPrompt(
       triggerCallId: triggerCallId || null,
       model: "deterministic",
       status: "active",
+      ...(recapSynthesisCache ? { recapSynthesisCache } : {}),
       inputs: {
         callerContext,
         memoriesCount: loadedData.memories.length,

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -147,6 +147,18 @@ export interface PriorCallFeedbackData {
   weakestParameterScore: number | null;
   overallScore: number | null;
   summary: string | null;
+  /**
+   * #599 Slice 1 — when the AI synthesis path produced (or cache-hit) a
+   * recap, the resolved depth + text. Null on every gate-blocked /
+   * templated-path scenario. `persistComposedPrompt` reads this and writes
+   * it to `ComposedPrompt.recapSynthesisCache`.
+   */
+  synthesizedRecap?: {
+    depth: "minimal" | "standard" | "rich";
+    text: string;
+    cachedAt: string;
+    cachedHit: boolean;
+  } | null;
 }
 
 /** Mock diagnostic module ref (#492 Slice 3.6) */

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -310,6 +310,21 @@ export const DEFAULT_OFFBOARDING_CONFIG: OffboardingConfig = {
 export type WelcomeToggles = IntakeConfig;
 
 /**
+ * #599 Slice 1 — depth picker for the AI-synthesized prior-call recap.
+ *
+ * - `minimal` — no AI call; returns the existing templated summary from
+ *   `loadPriorCallFeedback` (the #492 Slice 3.5 path). Byte-identical to
+ *   today's output.
+ * - `standard` — 2–3 sentences: score + likely cause + re-entry suggestion.
+ *   No raw numeric scores in the output text.
+ * - `rich` — 3–4 sentences + one transcript-grounded observation. Sliced
+ *   from `call.transcript[0..6000]` to bound the AI input.
+ *
+ * See `lib/prompt/composition/loaders/synthesizePriorCallRecap.ts`.
+ */
+export type PriorCallRecapDepth = "minimal" | "standard" | "rich";
+
+/**
  * Tunable course-level configuration for a Playbook.
  *
  * **Tolerance placement contract:** every new field on this interface MUST be
@@ -534,6 +549,39 @@ export interface PlaybookConfig {
   firstCall?: {
     durationMinsOverride?: number;
     introducePedagogy?: boolean;
+  };
+  /**
+   * #599 Slice 1 — AI-synthesized prior-call recap (`priorCallFeedback` v2).
+   *
+   * @bucket 1 — Course parameter. No per-learner override (the recap is
+   * derived per-(caller,module) but the *depth choice* is course-wide; a
+   * per-learner depth would defeat predictable cost behaviour).
+   *
+   * - `enabled` — required when the field is present. Defaults to `false`
+   *   when the whole key is absent. When false, loader returns the
+   *   templated minimal path (#492 Slice 3.5 behaviour) — no AI call.
+   * - `depth` — picker for synthesis depth. See {@link PriorCallRecapDepth}.
+   *   When absent on `enabled: true`, defaults to `"minimal"` (still no
+   *   AI call — explicit opt-in to standard/rich required).
+   * - `dailyCap` — per-playbook per-UTC-day cap on synthesis calls. Default
+   *   50. Server-side clamp at 500 (see `update_playbook_config` handler).
+   *   When the cap is hit, the loader falls back to the templated path and
+   *   writes an `AuditLog` row `action: "prior-call-recap-cap-exceeded"`.
+   *
+   * **Allowlist authority lives in `SystemSetting`**, NOT on this config.
+   * The allowlist is admin-only (no AI tool writes it) — see
+   * `lib/chat/ai-forbidden-fields.ts` for the structural guard.
+   *
+   * **Kill switch** is `process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED`
+   * (strict `=== "true"`). Absent or any other value → templated path.
+   *
+   * @see docs/decisions/2026-05-22-tolerance-placement.md
+   * @see lib/prompt/composition/loaders/synthesizePriorCallRecap.ts
+   */
+  priorCallRecap?: {
+    enabled: boolean;
+    depth?: PriorCallRecapDepth;
+    dailyCap?: number;
   };
   /**
    * #494 E2 Slice 2.3 — when the picker should hard-lock terminal modules with

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -3182,6 +3182,12 @@ model ComposedPrompt {
   evalResult Json? // { overall, dimensions, topImprovements }
   evalAt     DateTime? // When the eval was last run
 
+  // #599 Slice 1 — AI-synthesized prior-call recap cache.
+  // Shape: { depth: "minimal" | "standard" | "rich"; text: string; cachedAt: string }
+  // One entry per ComposedPrompt row. On depth mismatch, overwritten by next synthesis.
+  // See lib/prompt/composition/loaders/synthesizePriorCallRecap.ts
+  recapSynthesisCache Json?
+
   // Timestamps
   composedAt DateTime  @default(now())
   expiresAt  DateTime? // Optional expiration

--- a/apps/admin/tests/lib/chat/admin-tool-handlers-prior-call-recap-validation.test.ts
+++ b/apps/admin/tests/lib/chat/admin-tool-handlers-prior-call-recap-validation.test.ts
@@ -1,0 +1,146 @@
+/**
+ * #599 Slice 1 — AI-surface safety rails on `update_playbook_config` for
+ * the `priorCallRecap` block.
+ *
+ * These tests exercise the validator/clamp directly without spinning up the
+ * full handler dispatch. The complementary meta-test in
+ * `tests/lib/admin-tools-no-forbidden-fields.test.ts` covers the
+ * `system_setting` forbidden-fields entry that backs the allowlist tripwire.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { validatePriorCallRecapUpdates } from "@/lib/chat/admin-tool-handlers";
+
+describe("validatePriorCallRecapUpdates — pass-through cases", () => {
+  it("returns updates unchanged when priorCallRecap is absent", () => {
+    const result = validatePriorCallRecapUpdates({ sessionCount: 5, durationMins: 6 });
+    expect(result).toEqual({ normalised: { sessionCount: 5, durationMins: 6 } });
+  });
+
+  it("allows explicit null to clear the field", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: null });
+    expect(result.error).toBeUndefined();
+    expect(result.normalised).toEqual({ priorCallRecap: null });
+  });
+});
+
+describe("validatePriorCallRecapUpdates — shape validation", () => {
+  it("rejects array shape", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: [] });
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("priorCallRecap must be an object");
+  });
+
+  it("rejects string shape", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: "rich" });
+    expect(result.error).toContain("priorCallRecap must be an object");
+  });
+
+  it("rejects non-boolean enabled", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { enabled: "yes" } });
+    expect(result.error).toContain("priorCallRecap.enabled must be a boolean");
+  });
+});
+
+describe("validatePriorCallRecapUpdates — depth enum validation", () => {
+  it("accepts 'minimal'", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { depth: "minimal" } });
+    expect(result.error).toBeUndefined();
+    expect(result.normalised?.priorCallRecap).toEqual({ depth: "minimal" });
+  });
+
+  it("accepts 'standard'", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { depth: "standard" } });
+    expect(result.normalised?.priorCallRecap).toEqual({ depth: "standard" });
+  });
+
+  it("accepts 'rich'", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { depth: "rich" } });
+    expect(result.normalised?.priorCallRecap).toEqual({ depth: "rich" });
+  });
+
+  it.each([
+    ["Maximum"],
+    ["RICH"],
+    [""],
+    ["minimal "],
+  ])("rejects unknown depth %j", (depth) => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { depth } });
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("priorCallRecap.depth must be one of");
+  });
+
+  it("rejects non-string depth (number)", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { depth: 1 } });
+    expect(result.error).toBeDefined();
+  });
+
+  it("rejects null depth", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { depth: null } });
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe("validatePriorCallRecapUpdates — dailyCap clamp", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("passes through in-range values unchanged", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { dailyCap: 100 } });
+    expect(result.error).toBeUndefined();
+    expect((result.normalised?.priorCallRecap as { dailyCap: number }).dailyCap).toBe(100);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("clamps over-limit values to 500 and warns", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { dailyCap: 99999 } });
+    expect(result.error).toBeUndefined();
+    expect((result.normalised?.priorCallRecap as { dailyCap: number }).dailyCap).toBe(500);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toMatch(/clamped 99999 → 500/);
+  });
+
+  it("clamps negatives to 0 and warns", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { dailyCap: -5 } });
+    expect((result.normalised?.priorCallRecap as { dailyCap: number }).dailyCap).toBe(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("floors fractional values", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { dailyCap: 12.9 } });
+    expect((result.normalised?.priorCallRecap as { dailyCap: number }).dailyCap).toBe(12);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects non-finite numbers", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { dailyCap: Number.POSITIVE_INFINITY } });
+    expect(result.error).toContain("priorCallRecap.dailyCap must be a finite number");
+  });
+
+  it("rejects non-number dailyCap", () => {
+    const result = validatePriorCallRecapUpdates({ priorCallRecap: { dailyCap: "50" } });
+    expect(result.error).toContain("priorCallRecap.dailyCap must be a finite number");
+  });
+});
+
+describe("validatePriorCallRecapUpdates — composite update", () => {
+  it("normalises a full {enabled, depth, dailyCap} block and preserves siblings", () => {
+    const result = validatePriorCallRecapUpdates({
+      sessionCount: 5,
+      priorCallRecap: { enabled: true, depth: "rich", dailyCap: 30 },
+      durationMins: 6,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.normalised).toEqual({
+      sessionCount: 5,
+      priorCallRecap: { enabled: true, depth: "rich", dailyCap: 30 },
+      durationMins: 6,
+    });
+  });
+});

--- a/apps/admin/tests/lib/composition/prior-call-feedback-synthesis.test.ts
+++ b/apps/admin/tests/lib/composition/prior-call-feedback-synthesis.test.ts
@@ -1,0 +1,477 @@
+/**
+ * #599 Slice 1 — priorCallFeedback synthesis gate tests.
+ *
+ * Covers the wrap-around-the-templated-path that turns a brief AI-synthesized
+ * recap on when every safety gate passes. The templated path itself is
+ * covered by `prior-call-feedback.test.ts` (#492 Slice 3.5).
+ *
+ * Mocks `synthesizePriorCallRecap` directly so the gates can be exercised
+ * without any real AI plumbing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/prompt/composition/loaders/synthesizePriorCallRecap", () => ({
+  synthesizePriorCallRecap: vi.fn(async (input: {
+    feedback: { weakestParameterName: string | null };
+    depth: string;
+    callerName?: string | null;
+  }) => ({
+    text: `synth(${input.depth}):${input.feedback.weakestParameterName ?? "no-weak"}:${input.callerName ?? "anon"}`,
+    tokensUsed: 42,
+    latencyMs: 17,
+  })),
+  RICH_TRANSCRIPT_SLICE_LIMIT: 6000,
+}));
+
+import { loadPriorCallFeedback } from "@/lib/prompt/composition/loaders/priorCallFeedback";
+import { synthesizePriorCallRecap } from "@/lib/prompt/composition/loaders/synthesizePriorCallRecap";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+const synthMock = synthesizePriorCallRecap as unknown as ReturnType<typeof vi.fn>;
+
+const NOW = new Date("2026-05-26T10:00:00Z");
+const PRIOR_CALL_AT = new Date("2026-05-25T09:00:00Z");
+const PLAYBOOK_ID = "pb-1";
+const CALLER_ID = "caller-1";
+const MODULE_ID = "mod-1";
+const CURRENT_CALL_ID = "call-current";
+const PRIOR_CALL_ID = "call-prior";
+
+interface StubOptions {
+  allowlist?: string | null; // JSON string, or null = row absent
+  usageEventsToday?: Array<Record<string, unknown>>;
+  cachedRecap?: { depth: string; text: string; cachedAt: string } | null;
+  callerName?: string | null;
+  transcript?: string | null;
+}
+
+function makePrismaStub(stub: StubOptions = {}) {
+  const auditWrites: Array<Record<string, unknown>> = [];
+  return {
+    auditWrites,
+    call: {
+      findFirst: vi.fn(async () => ({ id: PRIOR_CALL_ID, createdAt: PRIOR_CALL_AT })),
+      findUnique: vi.fn(async () => (stub.transcript !== undefined ? { transcript: stub.transcript } : null)),
+    },
+    callScore: {
+      findMany: vi.fn(async () => [
+        { score: 0.55, moduleId: MODULE_ID, parameterId: "skill_fluency", parameter: { name: "Fluency", parameterId: "skill_fluency" } },
+        { score: 0.72, moduleId: MODULE_ID, parameterId: "skill_grammar", parameter: { name: "Grammar", parameterId: "skill_grammar" } },
+      ]),
+    },
+    systemSetting: {
+      findUnique: vi.fn(async () =>
+        stub.allowlist === null || stub.allowlist === undefined ? null : { value: stub.allowlist },
+      ),
+    },
+    usageEvent: {
+      findMany: vi.fn(async () => stub.usageEventsToday ?? []),
+    },
+    composedPrompt: {
+      findFirst: vi.fn(async () =>
+        stub.cachedRecap ? { recapSynthesisCache: stub.cachedRecap } : null,
+      ),
+    },
+    auditLog: {
+      findFirst: vi.fn(async () => null),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        auditWrites.push(data);
+        return data;
+      }),
+    },
+    caller: {
+      findUnique: vi.fn(async () => (stub.callerName !== undefined ? { name: stub.callerName } : null)),
+    },
+  } as unknown as Parameters<typeof loadPriorCallFeedback>[0] & {
+    auditWrites: Array<Record<string, unknown>>;
+    systemSetting: { findUnique: ReturnType<typeof vi.fn> };
+  };
+}
+
+function withRecap(
+  recap: NonNullable<PlaybookConfig["priorCallRecap"]>,
+): PlaybookConfig {
+  return { priorCallRecap: recap } as PlaybookConfig;
+}
+
+beforeEach(() => {
+  synthMock.mockClear();
+});
+
+afterEach(() => {
+  delete process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED;
+});
+
+describe("priorCallFeedback synthesis — kill-switch gate", () => {
+  it("env var absent → no synth, no AI call, no audit row", async () => {
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(result.hasFeedback).toBe(true);
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+    expect(prisma.auditWrites).toHaveLength(0);
+  });
+
+  it("env var === 'false' (string) → still no synth", async () => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "false";
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("priorCallFeedback synthesis — enabled flag", () => {
+  it("enabled: false → no synth even with env var on and allowlist match", async () => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: false, depth: "standard" }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+  });
+
+  it("missing priorCallRecap block → no synth (default off)", async () => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: {} as PlaybookConfig,
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("priorCallFeedback synthesis — depth dispatch", () => {
+  beforeEach(() => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+  });
+
+  it("depth: minimal → no AI call, no allowlist query, no audit row", async () => {
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "minimal" }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+    expect(prisma.systemSetting.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("depth absent on enabled: true → defaults to minimal (no AI)", async () => {
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("priorCallFeedback synthesis — allowlist gate", () => {
+  beforeEach(() => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+  });
+
+  it("SystemSetting row absent → blocked, audit row 'row-absent' once per day", async () => {
+    const prisma = makePrismaStub({ allowlist: null });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+    expect(prisma.auditWrites).toHaveLength(1);
+    expect(prisma.auditWrites[0]).toMatchObject({
+      action: "prior-call-recap-allowlist-empty",
+      entityType: "Playbook",
+      entityId: PLAYBOOK_ID,
+    });
+    expect((prisma.auditWrites[0].metadata as { cause: string }).cause).toBe("row-absent");
+  });
+
+  it("empty array → blocked with cause 'empty-array'", async () => {
+    const prisma = makePrismaStub({ allowlist: "[]" });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(prisma.auditWrites[0]).toMatchObject({ action: "prior-call-recap-allowlist-empty" });
+    expect((prisma.auditWrites[0].metadata as { cause: string }).cause).toBe("empty-array");
+  });
+
+  it("non-empty allowlist without playbookId → blocked, no audit row needed", async () => {
+    const prisma = makePrismaStub({ allowlist: JSON.stringify(["other-pb"]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+  });
+
+  it("playbookId present in allowlist → proceeds to synth", async () => {
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(synthMock).toHaveBeenCalledTimes(1);
+    expect(result.synthesizedRecap?.text).toContain("synth(standard)");
+    expect(result.synthesizedRecap?.cachedHit).toBe(false);
+  });
+});
+
+describe("priorCallFeedback synthesis — daily cap", () => {
+  beforeEach(() => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+  });
+
+  it("over cap → blocked + audit 'prior-call-recap-cap-exceeded'", async () => {
+    const usage = Array.from({ length: 50 }, () => ({ metadata: { playbookId: PLAYBOOK_ID } }));
+    const prisma = makePrismaStub({
+      allowlist: JSON.stringify([PLAYBOOK_ID]),
+      usageEventsToday: usage,
+    });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+    expect(prisma.auditWrites[0]).toMatchObject({ action: "prior-call-recap-cap-exceeded" });
+  });
+
+  it("under cap → proceeds; metadata-filtered count ignores other playbooks", async () => {
+    const usage = [
+      ...Array.from({ length: 49 }, () => ({ metadata: { playbookId: PLAYBOOK_ID } })),
+      ...Array.from({ length: 999 }, () => ({ metadata: { playbookId: "other" } })),
+    ];
+    const prisma = makePrismaStub({
+      allowlist: JSON.stringify([PLAYBOOK_ID]),
+      usageEventsToday: usage,
+    });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(synthMock).toHaveBeenCalledTimes(1);
+    expect(result.synthesizedRecap?.cachedHit).toBe(false);
+  });
+
+  it("custom dailyCap honoured", async () => {
+    const usage = Array.from({ length: 3 }, () => ({ metadata: { playbookId: PLAYBOOK_ID } }));
+    const prisma = makePrismaStub({
+      allowlist: JSON.stringify([PLAYBOOK_ID]),
+      usageEventsToday: usage,
+    });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard", dailyCap: 3 }),
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(prisma.auditWrites[0]).toMatchObject({ action: "prior-call-recap-cap-exceeded" });
+  });
+});
+
+describe("priorCallFeedback synthesis — cache layer", () => {
+  beforeEach(() => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+  });
+
+  it("cache hit on matching depth → returns cached text, no AI call", async () => {
+    const prisma = makePrismaStub({
+      allowlist: JSON.stringify([PLAYBOOK_ID]),
+      cachedRecap: { depth: "standard", text: "cached recap text", cachedAt: "2026-05-26T09:00:00Z" },
+    });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(synthMock).not.toHaveBeenCalled();
+    expect(result.synthesizedRecap?.cachedHit).toBe(true);
+    expect(result.synthesizedRecap?.text).toBe("cached recap text");
+    // No audit row on cache hit
+    expect(prisma.auditWrites).toHaveLength(0);
+  });
+
+  it("cache exists at wrong depth → MISS, synth runs again", async () => {
+    const prisma = makePrismaStub({
+      allowlist: JSON.stringify([PLAYBOOK_ID]),
+      cachedRecap: { depth: "minimal", text: "stale", cachedAt: "2026-05-26T08:00:00Z" },
+    });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(synthMock).toHaveBeenCalledTimes(1);
+    expect(result.synthesizedRecap?.cachedHit).toBe(false);
+  });
+});
+
+describe("priorCallFeedback synthesis — audit log on success", () => {
+  beforeEach(() => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+  });
+
+  it("writes 'prior-call-recap-synthesized' with telemetry metadata", async () => {
+    const prisma = makePrismaStub({
+      allowlist: JSON.stringify([PLAYBOOK_ID]),
+      callerName: "Aria Test",
+    });
+    await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(prisma.auditWrites).toHaveLength(1);
+    const row = prisma.auditWrites[0];
+    expect(row.action).toBe("prior-call-recap-synthesized");
+    expect(row.entityType).toBe("Call");
+    expect(row.entityId).toBe(CURRENT_CALL_ID);
+    expect(row.metadata).toMatchObject({
+      depth: "standard",
+      playbookId: PLAYBOOK_ID,
+      cachedHit: false,
+      tokensUsed: 42,
+      latencyMs: 17,
+    });
+    expect((row.metadata as { outputText: string }).outputText).toContain("synth(standard)");
+  });
+
+  it("rich depth passes transcript slice; caller's first name extracted", async () => {
+    const longTranscript = "x".repeat(8000);
+    const prisma = makePrismaStub({
+      allowlist: JSON.stringify([PLAYBOOK_ID]),
+      callerName: "Bryn Test-User",
+      transcript: longTranscript,
+    });
+    await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+      playbookConfig: withRecap({ enabled: true, depth: "rich" }),
+    });
+    expect(synthMock).toHaveBeenCalledTimes(1);
+    const callArgs = synthMock.mock.calls[0][0] as {
+      depth: string;
+      callerName: string;
+      transcript: string;
+    };
+    expect(callArgs.depth).toBe("rich");
+    expect(callArgs.callerName).toBe("Bryn");
+    expect(callArgs.transcript).toBeTruthy();
+    expect(callArgs.transcript.length).toBeLessThanOrEqual(6000);
+  });
+});
+
+describe("priorCallFeedback synthesis — no playbook context", () => {
+  beforeEach(() => {
+    process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED = "true";
+  });
+
+  it("playbookId omitted → falls through to templated path", async () => {
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      // intentionally no playbookId
+      playbookConfig: withRecap({ enabled: true, depth: "standard" }),
+    });
+    expect(result.hasFeedback).toBe(true);
+    expect(result.synthesizedRecap).toBeNull();
+    expect(synthMock).not.toHaveBeenCalled();
+  });
+
+  it("playbookConfig omitted → templated path; no DB lookups for synth gates", async () => {
+    const prisma = makePrismaStub({ allowlist: JSON.stringify([PLAYBOOK_ID]) });
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      currentCallId: CURRENT_CALL_ID,
+      now: NOW,
+      playbookId: PLAYBOOK_ID,
+    });
+    expect(result.synthesizedRecap).toBeNull();
+    expect(prisma.systemSetting.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/docs/PROMPT-COMPOSITION.md
+++ b/docs/PROMPT-COMPOSITION.md
@@ -105,6 +105,7 @@ All declared in `SectionDataLoader.ts` via `registerLoader("<name>", async (call
 | `courseInstructions` | `contentScope` | `ContentAssertion` (`category IN INSTRUCTION_CATEGORIES` OR `sourceId IN COURSE_REFERENCE`); plus `LearningObjective` where `systemRole=TEACHING_INSTRUCTION` (since #317) | `courseInstructions` | TEACHING_INSTRUCTION LOs are rebadged with `category="teaching_rule"` so the render path is unchanged. |
 | `openActions` | `callerId` | `CallAction` (PENDING / IN_PROGRESS, top 10) | (formatted via `formatActions`, surfaced inside `instructions`) | — |
 | `visualAids` | `contentScope` | `SubjectMedia` (`mimeType startsWith "image/"`, top 20) + chapter join via `AssertionMedia` | `visualAids` | Post-filtered by `isTutorOnlyDocumentType`; logs `[visualAids] Filtered N` (see L3). |
+| `priorCallFeedback` | `callerId`, `moduleId`, `currentCallId` (from `Call.curriculumModuleId`) | `Call.findFirst` (prior on module, excludes currentCallId) + `CallScore.findMany`; **#599 Slice 1** widens to `SystemSetting`, `UsageEvent`, `ComposedPrompt`, `AuditLog`, `Caller` for the synthesis gate sequence | `priorCallFeedback` | Templated path (`hasFeedback: true/false`) is #492 Slice 3.5; AI-synthesized recap is opt-in per-playbook (see §3.2 below). Failures in the synthesis path degrade silently to the templated text. |
 
 ### 3.1 `resolveContentScope` — three-tier resolution
 
@@ -117,6 +118,22 @@ Order:
 3. **Domain-wide last resort** — no enrollments at all → all `SubjectDomain` rows for `caller.domainId`. `scoped: false`. **Intentional for unenrolled previewing, structurally leaky for multi-course domains** (ENTITIES.md §4.3, E8).
 
 Anti-bleed invariant: when `subjectSourceIds` is non-empty, `curriculumAssertions` uses a strict `subjectSourceId IN (…)` filter with **no null fallback**. Adding `OR subjectSourceId IS NULL` revives Leak B (ENTITIES.md §9, E2).
+
+### 3.2 `priorCallFeedback` — synthesis gate sequence (#599 Slice 1)
+
+The templated path (#492 Slice 3.5) is the safe default. An AI-synthesized recap replaces the templated summary **only** when every safety gate passes, in order:
+
+1. **Kill switch** — `process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED === "true"` (strict string compare). Absent or any other value → templated path. Documented inline on `PlaybookConfig.priorCallRecap` JSDoc.
+2. **Playbook opt-in** — `Playbook.config.priorCallRecap.enabled === true`. Default `false` (the whole block is omitted on day-1 playbooks).
+3. **Allowlist** — `SystemSetting prior_call_recap.allowlist` value (JSON-encoded `string[]` of playbookIds). **Absent row AND empty array both block every playbook** — safe-by-default. Admin-only write (no AI tool reaches `SystemSetting`; the `system_setting` entry in `AI_FORBIDDEN_FIELDS` is a structural tripwire for any future tool that tries).
+4. **Daily cap** — counts today's `UsageEvent.sourceOp = 'compose.prior-call-recap'` rows where `metadata->>'playbookId'` matches. Compared against `Playbook.config.priorCallRecap.dailyCap` (default 50, server-side clamped to `[0, 500]` at the AI-surface handler). Over-cap → templated path + `AuditLog action: prior-call-recap-cap-exceeded`.
+5. **Depth dispatch** — `minimal` short-circuits to the templated path (no AI). `standard` → 2-3 sentence diagnosis, `rich` → 3-4 sentences + transcript-grounded observation (transcript sliced to 6000 chars).
+6. **Cache** — most recent `ComposedPrompt` for `(callerId, triggerCallId, playbookId)` checked; if `recapSynthesisCache.depth === requestedDepth`, the cached text is returned with `cachedHit: true` and no AI call fires. On depth mismatch, the next synthesis overwrites the cache via `persistComposedPrompt` (one entry per ComposedPrompt row — no stale-depth retention).
+7. **Synthesis + audit** — `synthesizePriorCallRecap()` fires the configured AI call point `compose.prior-call-recap` (cascade-only — no explicit `maxTokens`/`temperature`). On success: `AuditLog action: prior-call-recap-synthesized` with `{callId, depth, playbookId, cachedHit, tokensUsed, latencyMs, outputText}`.
+
+Gates 1, 2, 3, 4, 6 fall back to the templated path; the loader returns `synthesizedRecap: null` in those cases. `persist.ts::persistComposedPrompt` reads `loadedData.priorCallFeedback.synthesizedRecap` and writes it to `ComposedPrompt.recapSynthesisCache` when present.
+
+**Where the writes go.** Course settings (`enabled`, `depth`, `dailyCap`) flow through the educator UI on the Course detail page → "Course Configuration" section, and via the AI assistant's `update_playbook_config` tool. The tool handler validates inbound `priorCallRecap.depth` against the typed enum and clamps `dailyCap` server-side before the write reaches the pendingChange tray (#854).
 
 ---
 


### PR DESCRIPTION
## Summary

Slice 1 of #599 — opt-in AI synthesis that turns the templated "weakest area was Fluency" recap into 2-4 sentences naming the likely cause and offering a concrete re-entry angle for the tutor.

**Templated path remains the safe default** for every gate-blocked scenario. No real callers receive an AI recap until: (a) ops sets `PRIOR_CALL_RECAP_SYNTHESIS_ENABLED=true`, (b) an admin adds the playbook to `SystemSetting prior_call_recap.allowlist`, and (c) an educator flips `Playbook.config.priorCallRecap.enabled` and picks `standard` or `rich`.

## Gates (loader runs in order; first miss → templated path)

1. `process.env.PRIOR_CALL_RECAP_SYNTHESIS_ENABLED === "true"` — strict
2. `Playbook.config.priorCallRecap.enabled === true` — default off
3. `SystemSetting prior_call_recap.allowlist` contains `playbookId` — absent OR empty array blocks all (safe default)
4. `UsageEvent` count today (filtered by `metadata->>'playbookId'`) < `dailyCap` (default 50, server-clamped to ≤500)
5. Depth: `minimal` short-circuits to templated; `standard` / `rich` proceed
6. `ComposedPrompt.recapSynthesisCache.depth === requestedDepth` → cache hit, no AI call
7. Synthesize via `compose.prior-call-recap` call point (cascade-only AI params)

## AI-surface safety rails

- `update_playbook_config` handler validates `priorCallRecap.depth` against the typed enum
- Server-side `Math.min(dailyCap, 500)` clamp with `console.warn` on hit
- `AI_FORBIDDEN_FIELDS.system_setting = ["prior_call_recap.allowlist"]` — tripwire for any future tool that exposes the allowlist key to the AI
- All writes flow through `update_playbook_config` → pendingChange tray (epic #854 guard layer)

## Schema

```prisma
model ComposedPrompt {
  ...
  recapSynthesisCache Json?  // { depth, text, cachedAt } — one entry, overwritten on depth mismatch
}
```

Migration name: `add-composed-prompt-recap-cache`. **Deploy via `/vm-cpp`.**

## Test plan

- [x] **Vitest** — `npm run test -- composition admin-tools` → 677/677 pass
  - 19 cases on synthesis gates (env, enabled, allowlist absent/empty/match, daily cap, depth dispatch, cache hit/miss, audit rows)
  - 21 cases on the AI-surface validator (enum + clamp + shape)
  - 17 existing prior-call-feedback tests still pass (no regression on templated path)
- [x] **tsc --noEmit** — 197 errors (== baseline, unchanged)
- [x] **ratchet:check** — all 4 metrics green (tsc, lint errors, lint warnings, quarantined tests)
- [x] **Promptfoo eval** at `apps/admin/evals/tutor/prior-call-recap-v2.yaml` — 4 fixtures (standard IELTS fluency, rich vocab miss, minimal fallback, daily-cap fallback). Asserts sentence count, no raw scores, encouraging tone.
- [ ] **Post-merge admin task**: create `SystemSetting` row `prior_call_recap.allowlist = []` (empty → still blocks; admin adds playbookIds when ready)

## UI to verify after deploy

**Nothing yet — plumbing only.** Slice 2 (#599) adds the depth picker on the Course detail page → Course Configuration section. Slice 1 ships dormant.

End-to-end smoke (sandbox only):
1. Set `PRIOR_CALL_RECAP_SYNTHESIS_ENABLED=true` on VM
2. `INSERT INTO "SystemSetting"(key, value) VALUES('prior_call_recap.allowlist', '["<playbookId>"]')`
3. Prisma Studio → set `Playbook.config.priorCallRecap = { "enabled": true, "depth": "standard" }`
4. Run a 2nd call on that playbook → composed prompt's `priorCallFeedback` section should carry an AI-synthesized recap (verifiable via `AuditLog action = 'prior-call-recap-synthesized'` and `ComposedPrompt.recapSynthesisCache`)

## Edge cases handled

| Scenario | Handled by |
|---|---|
| Homepage AI request "enable recap for IELTS Prep" | `update_playbook_config` requires `playbook_id` in entity context (existing); future Slice 2 adds disambiguation flow |
| Invalid depth enum (`"Maximum"`) | Handler rejects with clear error |
| Hallucinated `dailyCap: 99999` | Clamped to 500 with `console.warn` |
| Future SystemSetting tool leaks allowlist key | `AI_FORBIDDEN_FIELDS` meta-test catches at CI |
| Cross-playbook fan-out from AI | Already blocked by epic #854 (`no-ai-fanout-all` + tray runtime check) |
| Synthesis failure / network blip | Silent fallback to templated path |

Closes #599 (Slice 1). Slice 2 (educator UI on Course detail page) follows once #166 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)