### PR TITLE
fix(#918): carry forward planned-but-uncovered TPs to next call

### DIFF
--- a/apps/admin/lib/curriculum/working-set-selector.ts
+++ b/apps/admin/lib/curriculum/working-set-selector.ts
@@ -28,6 +28,37 @@ export interface WorkingSetInput {
   callDurationMins: number;
   /** Mastery threshold for "mastered" status (default 0.7) */
   masteryThreshold: number;
+  /**
+   * #918 — Assertion IDs that the prior call planned (`workingSetAssertionIds`)
+   * but never covered (`tp_status` still `not_started` after the prior pipeline
+   * run). When non-empty, LOs containing these TPs are boosted in the review +
+   * new-LO ranking so a learner who hung up mid-call does not silently skip
+   * the planned-but-undelivered content.
+   *
+   * Caller responsibilities (see `lib/prompt/composition/transforms/modules.ts`):
+   *   - Diff prior `workingSetAssertionIds` against `tpMasteryMap` and pass the
+   *     set difference here.
+   *   - On the picker-locked path (prior decision had empty workingSet), pass
+   *     `[]` so no carry-forward fires — that lane is educator/learner-driven
+   *     and shouldn't blend with the system's autonomous catch-up.
+   *
+   * Empty / undefined → no effect (byte-identical to pre-#918 ranking).
+   */
+  priorPlannedAssertionIds?: string[];
+  /**
+   * #918 — Magnitude of the carry-forward priority bump. Default `0.5`.
+   * Zero disables the feature even when `priorPlannedAssertionIds` is non-empty.
+   *
+   * Applied as a mastery shift: an LO's effective mastery for ranking purposes
+   * is reduced by `carryForwardBoost × carryForwardScore`, where
+   * `carryForwardScore` is the fraction of the LO's child TPs that appear in
+   * `priorPlannedAssertionIds` (0..1). A fully-planned-uncovered LO gets the
+   * full boost; partial overlap gets a proportional bump.
+   *
+   * @bucket 1 (course parameter, see Playbook.config.tolerances.carryForwardBoost)
+   * @see docs/decisions/2026-05-22-tolerance-placement.md
+   */
+  carryForwardBoost?: number;
 }
 
 export interface AssertionRef {
@@ -91,7 +122,12 @@ interface LOWithMeta extends LORef {
   mastery: number;
   status: "mastered" | "in_progress" | "not_started";
   weight: number;  // cost against budget
+  /** #918 — fraction of childTps that appear in `priorPlannedAssertionIds` (0..1). */
+  carryForwardScore: number;
 }
+
+/** Default boost magnitude when caller doesn't override. */
+const DEFAULT_CARRY_FORWARD_BOOST = 0.5;
 
 /**
  * Compute LO budget based on call duration.
@@ -144,10 +180,21 @@ export function selectWorkingSet(input: WorkingSetInput): WorkingSetResult {
     assertions, learningObjectives, modules,
     tpMasteryMap, loMasteryMap,
     callDurationMins, masteryThreshold,
+    priorPlannedAssertionIds,
+    carryForwardBoost,
   } = input;
 
   const loBudget = computeLoBudget(callDurationMins);
   const maxTps = computeMaxTps(callDurationMins);
+
+  // #918 — Carry-forward set. Empty when no prior call, when prior call was
+  // picker-locked, or when the prior call covered everything. In all three
+  // cases the ranking below collapses to the pre-#918 behaviour.
+  const carryForwardSet = new Set(priorPlannedAssertionIds ?? []);
+  const effectiveBoost =
+    carryForwardSet.size > 0 && carryForwardBoost == null
+      ? DEFAULT_CARRY_FORWARD_BOOST
+      : (carryForwardBoost ?? 0);
 
   // ── STEP 1: Build LO graph ──
 
@@ -197,7 +244,15 @@ export function selectWorkingSet(input: WorkingSetInput): WorkingSetResult {
     const isReview = status === "in_progress";
     const weight = computeLoWeight(childTps.length, isReview);
 
-    loGraph.push({ ...lo, childTps, mastery, status, weight });
+    // #918 — carry-forward score = fraction of childTps that appear in the
+    // prior call's planned-but-uncovered set. Used in ranking below; zero
+    // when the feature is off (empty set or boost = 0).
+    const carryForwardScore =
+      carryForwardSet.size === 0
+        ? 0
+        : childTps.filter((tp) => carryForwardSet.has(tp.id)).length / childTps.length;
+
+    loGraph.push({ ...lo, childTps, mastery, status, weight, carryForwardScore });
   }
 
   // Build module completion map
@@ -209,11 +264,19 @@ export function selectWorkingSet(input: WorkingSetInput): WorkingSetResult {
   }
 
   // ── STEP 2: Select review LO (at most 1) ──
+  //
+  // #918 — effective mastery for ranking is shifted down by
+  // `effectiveBoost × carryForwardScore`. A fully-planned-uncovered LO
+  // (score=1.0) at the default 0.5 boost gets a -0.5 shift; partial overlap
+  // gets a proportional shift. When no carry-forward is in play the shift is
+  // zero and ranking collapses to the pre-#918 weakest-first order.
+  const effectiveMastery = (lo: LOWithMeta): number =>
+    lo.mastery - effectiveBoost * lo.carryForwardScore;
 
   let reviewLO: LOWithMeta | null = null;
   const reviewCandidates = loGraph
     .filter((lo) => lo.status === "in_progress" && lo.mastery < (lo.masteryThreshold ?? masteryThreshold))
-    .sort((a, b) => a.mastery - b.mastery);  // weakest first
+    .sort((a, b) => effectiveMastery(a) - effectiveMastery(b));  // weakest (after boost) first
 
   if (reviewCandidates.length > 0) {
     reviewLO = reviewCandidates[0];
@@ -242,9 +305,17 @@ export function selectWorkingSet(input: WorkingSetInput): WorkingSetResult {
 
     if (!frontierModuleId) frontierModuleId = mod.id;
 
+    // #918 — within a frontier module, prefer not_started LOs that carry
+    // forward planned-but-uncovered TPs. Secondary sort by the original
+    // `sortOrder` so courses without carry-forward keep their authored order.
     const moduleLOs = loGraph
       .filter((lo) => lo.moduleId === mod.id && lo.status === "not_started")
-      .sort((a, b) => a.sortOrder - b.sortOrder);
+      .sort((a, b) => {
+        const carryDiff =
+          effectiveBoost > 0 ? b.carryForwardScore - a.carryForwardScore : 0;
+        if (carryDiff !== 0) return carryDiff;
+        return a.sortOrder - b.sortOrder;
+      });
 
     for (const lo of moduleLOs) {
       if (remainingBudget <= 0 || tpCount + lo.childTps.length > maxTps) break;

--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -794,6 +794,40 @@ export async function computeSharedState(
           pendingCount = 0;
         }
 
+        // #918 — Carry-forward planned-but-uncovered TPs.
+        //
+        // Diff the prior call's `workingSetAssertionIds` (what the scheduler
+        // planned) against the post-pipeline `tpProgress` (what EXTRACT/AGGREGATE
+        // moved off `not_started`). The result is the set of TPs the prior call
+        // committed to teaching but never reached — typically because the
+        // learner hung up early, ran out of time, or skipped ahead.
+        //
+        // Suppression: when prior decision was picker-locked (workingSetAssertionIds
+        // is empty by design at modules.ts:929+), the diff is empty and no
+        // boost fires. That lane is educator/learner-driven and shouldn't
+        // blend with the system's autonomous catch-up.
+        const priorPlannedAssertionIds: string[] =
+          priorDecision?.workingSetAssertionIds
+            ?.filter((tpId) => {
+              const status = tpProgress[tpId]?.status;
+              // "uncovered" = still not_started after the prior pipeline run.
+              // in_progress / mastered means the learner did see it (we have
+              // some signal, even partial), so carry-forward is unnecessary.
+              return status === undefined || status === "not_started";
+            }) ?? [];
+
+        // #918 — Course-level boost magnitude. Cascades through the
+        // Playbook.config.tolerances block per the #598 tolerance-placement ADR.
+        // `selectWorkingSet` applies its own DEFAULT_CARRY_FORWARD_BOOST when
+        // this is undefined AND the set is non-empty.
+        const carryForwardBoost = pbConfig.tolerances?.carryForwardBoost;
+        if (priorPlannedAssertionIds.length > 0) {
+          console.log(
+            `[modules] #918 carry-forward: ${priorPlannedAssertionIds.length} planned-but-uncovered TP(s) from prior call. ` +
+            `boost=${carryForwardBoost ?? "default"}, suppressed=${priorDecision?.workingSetAssertionIds?.length === 0}`,
+          );
+        }
+
         const { decision, workingSet: wsResult } = selectNextExchange(
           {
             workingSetInput: {
@@ -824,6 +858,9 @@ export async function computeSharedState(
               loMasteryMap,
               callDurationMins,
               masteryThreshold: threshold,
+              // #918 — pass carry-forward signal into the candidate-pool layer
+              priorPlannedAssertionIds,
+              carryForwardBoost,
             },
             priorDecision,
             callsSinceLastAssess: pendingCount,

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -525,6 +525,11 @@ export interface PlaybookConfig {
    * - `memoryDecayScale` — @bucket 1 only. 0.1–1.0 multiplier applied to
    *   `CATEGORY_DECAY_DEFAULTS` in `transforms/memories.ts::applyDecay`.
    *   Per-learner override intentionally NOT in scope (course-wide rhythm).
+   * - `carryForwardBoost` — @bucket 1 only. #918. Magnitude of the priority
+   *   bump given to TPs that were planned in the prior call but never
+   *   covered (learner hangup, time ran out, etc.). 0 disables the feature.
+   *   Default `0.5` in `selectWorkingSet`. Per-learner override NOT in scope —
+   *   carry-forward is a course-wide pacing decision.
    *
    * @see docs/decisions/2026-05-22-tolerance-placement.md
    */
@@ -532,6 +537,7 @@ export interface PlaybookConfig {
     masteryThreshold?: number;
     retrievalCadenceOverride?: number;
     memoryDecayScale?: number;
+    carryForwardBoost?: number;
   };
   /**
    * #598 Slice 1 — Additional first-call overrides. Companion to

--- a/apps/admin/tests/lib/working-set-selector.test.ts
+++ b/apps/admin/tests/lib/working-set-selector.test.ts
@@ -303,4 +303,183 @@ describe("selectWorkingSet", () => {
       expect(r1.selectedLOs.map((lo) => lo.id)).toEqual(r2.selectedLOs.map((lo) => lo.id));
     });
   });
+
+  // ── #918 carry-forward (planned-but-uncovered) ──────────────────
+
+  describe("#918 carry-forward planned-but-uncovered TPs", () => {
+    it("boost on: an in_progress LO whose unstarted TP was prior-planned wins over a stronger one without carry-forward", () => {
+      // Two in_progress LOs in different modules so they don't share the
+      // module-ordering tiebreaker. Both below threshold (qualify as review
+      // candidates). lo3 has lower raw mastery but no carry-forward; lo1 has
+      // higher raw mastery but one of its TPs was planned-and-uncovered.
+      // With boost=0.5 and half its TPs in the set, lo1's effective mastery
+      // drops by 0.25, pulling it below lo3.
+      const input = makeInput({
+        tpMasteryMap: makeTpMap({
+          // lo1: mastery 0.45 raw; one TP not_started + one in_progress
+          tp1: { status: "not_started", mastery: 0 },
+          tp2: { status: "in_progress", mastery: 0.9 },
+          // lo3 (m2): mastery 0.30 raw; both TPs in_progress
+          tp5: { status: "in_progress", mastery: 0.30 },
+          tp6: { status: "in_progress", mastery: 0.30 },
+        }),
+        loMasteryMap: { "m1:LO1": 0.45, "m2:LO3": 0.30 },
+        priorPlannedAssertionIds: ["tp1"],
+        carryForwardBoost: 0.5,
+        callDurationMins: 10,  // tiny budget — only 1 review LO will be picked
+      });
+      const result = selectWorkingSet(input);
+      const reviewLO = result.selectedLOs.find((lo) => lo.status === "review");
+      expect(reviewLO?.ref).toBe("LO1");
+    });
+
+    it("boost off (carryForwardBoost: 0): ranking matches pre-#918 weakest-first behaviour", () => {
+      const baseTpMap = makeTpMap({
+        tp1: { status: "not_started", mastery: 0 },
+        tp2: { status: "in_progress", mastery: 0.9 },
+        tp5: { status: "in_progress", mastery: 0.30 },
+        tp6: { status: "in_progress", mastery: 0.30 },
+      });
+      const baseMastery = { "m1:LO1": 0.45, "m2:LO3": 0.30 };
+
+      // Without carry-forward boost, the weakest LO (lo3) should win
+      const noBoost = selectWorkingSet(
+        makeInput({
+          tpMasteryMap: baseTpMap,
+          loMasteryMap: baseMastery,
+          priorPlannedAssertionIds: ["tp1"],
+          carryForwardBoost: 0,
+          callDurationMins: 10,
+        }),
+      );
+      const reviewLO = noBoost.selectedLOs.find((lo) => lo.status === "review");
+      expect(reviewLO?.ref).toBe("LO3");
+    });
+
+    it("empty priorPlannedAssertionIds: byte-identical to pre-#918 behaviour (regression guard)", () => {
+      const tpMap = makeTpMap({
+        tp1: { status: "in_progress", mastery: 0.3 },
+        tp2: { status: "in_progress", mastery: 0.3 },
+        tp5: { status: "in_progress", mastery: 0.6 },
+        tp6: { status: "in_progress", mastery: 0.6 },
+      });
+      const without = selectWorkingSet(makeInput({ tpMasteryMap: tpMap }));
+      const withEmpty = selectWorkingSet(
+        makeInput({
+          tpMasteryMap: tpMap,
+          priorPlannedAssertionIds: [],
+          carryForwardBoost: 0.5,
+        }),
+      );
+      expect(withEmpty.assertionIds).toEqual(without.assertionIds);
+      expect(withEmpty.selectedLOs.map((lo) => lo.id)).toEqual(without.selectedLOs.map((lo) => lo.id));
+    });
+
+    it("picker-locked prior decision (empty workingSetAssertionIds): suppression — no boost fires", () => {
+      // Picker-locked path at modules.ts:929 persists workingSetAssertionIds: [].
+      // Caller (modules.ts) passes [] to selectWorkingSet, which then runs
+      // pre-#918 weakest-first ranking.
+      const tpMap = makeTpMap({
+        tp1: { status: "not_started", mastery: 0 },
+        tp2: { status: "in_progress", mastery: 0.9 },
+        tp5: { status: "in_progress", mastery: 0.30 },
+        tp6: { status: "in_progress", mastery: 0.30 },
+      });
+      const result = selectWorkingSet(
+        makeInput({
+          tpMasteryMap: tpMap,
+          loMasteryMap: { "m1:LO1": 0.45, "m2:LO3": 0.30 },
+          // Picker-locked → caller passes empty array
+          priorPlannedAssertionIds: [],
+          carryForwardBoost: 0.5,
+          callDurationMins: 10,
+        }),
+      );
+      const reviewLO = result.selectedLOs.find((lo) => lo.status === "review");
+      // Without carry-forward, weakest (lo3) wins as before
+      expect(reviewLO?.ref).toBe("LO3");
+    });
+
+    it("first call (no priorDecision → caller passes undefined): no crash, behaves like pre-#918", () => {
+      const result = selectWorkingSet(
+        makeInput({
+          // priorPlannedAssertionIds omitted entirely
+          carryForwardBoost: 0.5,
+        }),
+      );
+      expect(result.selectedLOs.length).toBeGreaterThan(0);
+      // Fresh-start: m1 frontier still picked
+      expect(result.frontierModuleId).toBe("m1");
+    });
+
+    it("default boost (0.5) applies when caller passes set but no explicit boost", () => {
+      // Same shape as the first test but carryForwardBoost is undefined.
+      const result = selectWorkingSet(
+        makeInput({
+          tpMasteryMap: makeTpMap({
+            tp1: { status: "not_started", mastery: 0 },
+            tp2: { status: "in_progress", mastery: 0.9 },
+            tp5: { status: "in_progress", mastery: 0.30 },
+            tp6: { status: "in_progress", mastery: 0.30 },
+          }),
+          loMasteryMap: { "m1:LO1": 0.45, "m2:LO3": 0.30 },
+          priorPlannedAssertionIds: ["tp1"],
+          callDurationMins: 10,
+          // carryForwardBoost intentionally undefined — should default to 0.5
+        }),
+      );
+      const reviewLO = result.selectedLOs.find((lo) => lo.status === "review");
+      expect(reviewLO?.ref).toBe("LO1");
+    });
+
+    it("new-LO selection within a frontier module: prefers LO with carry-forward TP over its sibling", () => {
+      // Both lo1 and lo2 are not_started in m1. Without carry-forward, lo1
+      // wins on sortOrder. With carry-forward pointing at lo2's TPs, lo2 wins.
+      const baseInput = makeInput({
+        callDurationMins: 10,  // small budget → 1 new LO from frontier
+      });
+
+      const sortOrderResult = selectWorkingSet(baseInput);
+      const sortOrderNewLO = sortOrderResult.selectedLOs.find((lo) => lo.status === "new");
+      expect(sortOrderNewLO?.ref).toBe("LO1");
+
+      const carryResult = selectWorkingSet({
+        ...baseInput,
+        priorPlannedAssertionIds: ["tp3"],  // tp3 belongs to lo2
+        carryForwardBoost: 0.5,
+      });
+      const carryNewLO = carryResult.selectedLOs.find((lo) => lo.status === "new");
+      expect(carryNewLO?.ref).toBe("LO2");
+    });
+
+    it("TPs already moved past not_started are NOT carried forward (caller responsibility doc check)", () => {
+      // This test documents the contract that modules.ts is responsible for:
+      // it only passes TPs whose status is `not_started` (or unknown). Inside
+      // selectWorkingSet, all TPs in the set boost regardless of mastery —
+      // verifying the upstream filter is critical.
+      //
+      // Even when an in_progress TP slips through, the boost still applies to
+      // its LO. That's fine — by then the LO is already in_progress, which
+      // means review-candidacy is already in scope. The boost just reinforces.
+      const result = selectWorkingSet(
+        makeInput({
+          tpMasteryMap: makeTpMap({
+            tp1: { status: "in_progress", mastery: 0.4 },
+            tp2: { status: "in_progress", mastery: 0.4 },
+            tp5: { status: "in_progress", mastery: 0.3 },
+            tp6: { status: "in_progress", mastery: 0.3 },
+          }),
+          loMasteryMap: { "m1:LO1": 0.4, "m2:LO3": 0.3 },
+          // Caller "should" have filtered tp1 out (it's in_progress, not
+          // not_started) — but if they didn't, the boost still works defensively.
+          priorPlannedAssertionIds: ["tp1"],
+          carryForwardBoost: 0.5,
+          callDurationMins: 10,
+        }),
+      );
+      const reviewLO = result.selectedLOs.find((lo) => lo.status === "review");
+      // lo1: 0.4 - 0.5*0.5 = 0.15; lo3: 0.3 - 0 = 0.3. lo1 wins.
+      expect(reviewLO?.ref).toBe("LO1");
+    });
+  });
 });

--- a/docs/CHAIN-CONTRACTS.md
+++ b/docs/CHAIN-CONTRACTS.md
@@ -188,6 +188,20 @@ Format per link:
 | **Audit counter** | `dualLoMasteryKeysSameLO` (informational), `callerAttributeOldKeyFormCount` (target 0 after #614). |
 | **Reinforced by** | #614 + reader-tightening follow-on (post-drain). |
 
+#### Link 6.a — COMPOSE → COMPOSE (carry-forward, #918)
+
+| Field | Value |
+|---|---|
+| **Producer** | COMPOSE writes `SchedulerDecision.workingSetAssertionIds` to `CallerAttribute(scope=CURRICULUM, key="scheduler:last_decision")` via `persistSchedulerDecision` (Scheduler v1 Slice 1, #155). |
+| **Consumer** | Next COMPOSE call's `transforms/modules.ts` — reads `priorDecision.workingSetAssertionIds`, diffs against `tpProgress` to compute `priorPlannedAssertionIds` (TPs the prior call planned but never moved past `not_started`), passes into `selectWorkingSet` as `WorkingSetInput.priorPlannedAssertionIds`. **This is the first bi-directional contract on the loop closure link** — same producer + consumer stage. |
+| **Data shape** | `SchedulerDecision.workingSetAssertionIds: string[]` (assertion IDs only, no LO refs); diff result is a subset. |
+| **DataContract slug** | None — uses the existing `scheduler:last_decision` CallerAttribute payload. |
+| **Enforcement** | `tpProgress` filter at the diff site uses `status === undefined \|\| status === "not_started"` (conservative — any progress signal counts as "covered"). Picker-locked path at `modules.ts:929+` deliberately writes `workingSetAssertionIds: []`, suppressing carry-forward for educator/learner-driven sessions. |
+| **Test** | `tests/lib/working-set-selector.test.ts` `#918 carry-forward` describe block — 8 cases incl. picker-locked-suppression + first-call-no-crash + boost-off-regression. |
+| **Memory doc** | `docs/PIPELINE.md` §4.2 COMPOSE; `lib/curriculum/working-set-selector.ts::WorkingSetInput` JSDoc. |
+| **Audit counter** | None added — `effectiveBoost > 0 && priorPlannedAssertionIds.length > 0` fires a structured `console.log` from `modules.ts` instead. Add a counter to `scripts/audit-epic-100.ts` only if the loop produces miscount evidence in production. |
+| **Reinforced by** | #918. Tolerance entry at `Playbook.config.tolerances.carryForwardBoost` follows the #598 Slice 1 ADR placement (`@bucket 1 — Course parameter`, no per-learner override). |
+
 ---
 
 ## 3a. Authoring-time contracts

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -127,9 +127,13 @@ ADAPT        reads:  CallerPersonalityProfile, transcript, Goal
              writes: CallTarget, CallerTarget, Goal, GoalProgress
 SUPERVISE    reads:  CallTarget, CallerTarget
              writes: clamped CallTarget, aggregated CallerTarget
-COMPOSE      reads:  CallerMemory, CallerPersonalityProfile, Goal, CallerTarget
-             writes: ComposedPrompt
+COMPOSE      reads:  CallerMemory, CallerPersonalityProfile, Goal, CallerTarget,
+                     CallerAttribute(scope=CURRICULUM, key="scheduler:last_decision")  ← #918
+             writes: ComposedPrompt,
+                     CallerAttribute(scope=CURRICULUM, key="scheduler:last_decision")  ← bi-directional
 ```
+
+**#918 COMPOSE bi-directional read.** Since #918 (carry-forward of planned-but-uncovered TPs), COMPOSE reads the *prior call's* `scheduler:last_decision` CallerAttribute to identify TPs the scheduler planned but the EXTRACT-side mastery signal shows were never reached (status still `not_started`). Those TP IDs are passed into `selectWorkingSet` as `WorkingSetInput.priorPlannedAssertionIds` and boost their containing LO in the working-set ranking. Caller responsibility (in `transforms/modules.ts`): diff `priorDecision.workingSetAssertionIds` against `tpProgress` *before* calling `selectWorkingSet`; the picker-locked path at `modules.ts:929+` writes an empty workingSet which naturally suppresses carry-forward on the next call. See `docs/CHAIN-CONTRACTS.md` Link 6.a for the full contract.
 
 **#417 cross-stage AGGREGATE write — note for reviewers.** SKILL-AGG-001
 (SYSTEM-scope AGGREGATE spec) uses a new `AggregationRule.method =


### PR DESCRIPTION
## Summary

When a learner hangs up mid-session, the scheduler had planned N teaching points but EXTRACT only marks M < N as touched. Pre-#918 the next call's `selectWorkingSet` had no signal about the (N - M) planned-but-uncovered TPs and could skip them again — silently losing content the system thought it covered, and degrading the mastery signal that drives the core market-test question ("is the student improving?").

This PR closes the loop. COMPOSE now reads the prior call's `SchedulerDecision.workingSetAssertionIds` (already persisted since Scheduler v1 Slice 1 / #155), diffs it against `tpProgress`, and boosts LOs containing still-uncovered TPs.

## Bi-directional contract

Link 6 (ADAPT → COMPOSE loop closure) now has a same-stage sub-contract: COMPOSE reads what the prior COMPOSE wrote. Documented as Link 6.a in `docs/CHAIN-CONTRACTS.md` + `docs/PIPELINE.md` §4.2.

## Tech Lead corrections applied

1. ✅ `carryForwardBoost` lives on `WorkingSetInput`, NOT `SchedulerPolicy` — α–η weights apply to outcome ranking *after* `selectWorkingSet` returns
2. ✅ Picker-locked sessions (modules.ts:929+ writes empty workingSet) naturally suppress carry-forward — documented decision + unit test
3. ✅ `CHAIN-CONTRACTS.md` Link 6.a sub-row added in this PR (not deferred)

## Test plan

- [x] **8 new vitest cases** covering: boost on/off, byte-identical regression guard on empty set, picker-locked suppression, first-call no-crash, default boost (0.5), new-LO frontier preference, defensive boost on already-progressing TPs
- [x] **25/25** existing working-set-selector tests pass unchanged
- [x] **28/28** scheduler tests pass unchanged
- [x] **163/163** modules tests pass unchanged
- [x] **Ratchet:** tsc 197 (== baseline), lint errors 0, lint warnings 4432 (== baseline), quarantined 37 (== baseline) — all green

## UI to verify after deploy

**Nothing visible — it's a scheduler-side fix.** End-to-end smoke (sandbox):
1. Start a call on a continuous-mode playbook, let the scheduler plan a working set
2. Hang up after the AI has covered only 1-2 TPs (others remain `not_started`)
3. Start the next call — look at the composed prompt's working set or check `[modules] #918 carry-forward: N planned-but-uncovered TP(s)` log line
4. Confirm the uncovered TPs from call 1 appear in call 2's working set (would not have without this fix)

## Blast zone

Affects every returning call's working-set selection. Mitigated by:
- Empty `priorPlannedAssertionIds` → byte-identical to pre-#918 ranking (regression-tested)
- `carryForwardBoost = 0` disables feature without code change
- Picker-locked path automatically suppresses
- All existing 216 tests pass without modification

## Deploy

`/vm-cp` (no schema migration — uses existing `CallerAttribute` rows and types).

Closes #918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)