### PR TITLE
feat(#923): scheduler reason text becomes learner-facing copy

### DIFF
--- a/apps/admin/lib/pipeline/scheduler-reasons.ts
+++ b/apps/admin/lib/pipeline/scheduler-reasons.ts
@@ -1,0 +1,61 @@
+/**
+ * scheduler-reasons.ts — #923.
+ *
+ * Single source of truth for the `reason` string written into every
+ * SchedulerDecision (and from there into `CallerAttribute.jsonValue.reason`,
+ * scope `CURRICULUM`, key `scheduler:last_decision`).
+ *
+ * The reason field is read by learner-facing UI (SimProgressPanel "Today's
+ * call" section, #917). Pre-#923, writer sites emitted debugger-style log
+ * breadcrumbs ("scheduler: empty working set (0 LOs, 300 TPs) — fallback teach
+ * mode") that leaked verbatim to learners. This module enforces a two-rule
+ * contract:
+ *
+ *   1. Every reason reads as a complete sentence addressed to the learner.
+ *   2. No reason starts with a lowercase log-prefix (e.g. `scheduler:`,
+ *      `adapt:`, `reward:`). Regression-test contract: must not match
+ *      `/^[a-z][a-z_-]*:\s/`.
+ *
+ * Internal diagnostic context (preset name, working-set counts, mode reason)
+ * stays in `console.log` at the call sites — developers read those; learners
+ * read this.
+ *
+ * If you add a new code path in scheduler.ts or scheduler-decision callers,
+ * add a constant here. Do NOT build reason strings inline.
+ */
+
+import type { SchedulerMode } from "./scheduler-decision";
+
+/**
+ * Static reason strings — used whenever the code path is unambiguous and
+ * doesn't depend on runtime values.
+ */
+export const SCHEDULER_REASONS = {
+  /** Empty working set — fallback to teach mode (scheduler.ts:97). */
+  emptyWorkingSetFallback:
+    "Picking up where we left off — focusing on new material.",
+  /** Picker-locked module path — #538 (modules.ts:967). */
+  pickerLockedModule:
+    "Working on the module you picked — practising at your own pace.",
+} as const;
+
+/**
+ * Learner-facing copy for the happy-path scheduler decision (scheduler.ts:160).
+ * Keyed by the mode the scheduler chose. Each string is a complete sentence
+ * that tells the learner what this call is about without naming presets,
+ * counts, or internal cadence state.
+ */
+export const SCHEDULER_MODE_REASONS: Record<SchedulerMode, string> = {
+  teach: "We're moving on to something new today.",
+  review: "Reviewing the tricky parts from your last call.",
+  assess: "Time for a quick checkpoint to see how you're doing.",
+  practice: "You've got the basics — let's practise putting them together.",
+};
+
+/**
+ * Resolve the learner-facing reason for a given mode. Pure helper so call
+ * sites don't reach into the map directly.
+ */
+export function reasonForMode(mode: SchedulerMode): string {
+  return SCHEDULER_MODE_REASONS[mode];
+}

--- a/apps/admin/lib/pipeline/scheduler.ts
+++ b/apps/admin/lib/pipeline/scheduler.ts
@@ -30,6 +30,7 @@
 import { selectWorkingSet, type WorkingSetInput, type WorkingSetResult } from "@/lib/curriculum/working-set-selector";
 import type { SchedulerDecision, SchedulerMode } from "./scheduler-decision";
 import type { SchedulerPolicy } from "./scheduler-presets";
+import { SCHEDULER_REASONS, reasonForMode } from "./scheduler-reasons";
 
 export interface SchedulerState {
   /** Candidate-pool inputs — forwarded to `selectWorkingSet`. */
@@ -88,13 +89,17 @@ export function selectNextExchange(
 
   // ── Empty-pool fallback ──
   if (ws.assertionIds.length === 0 || ws.selectedLOs.length === 0) {
+    // Diagnostic context for developers — never reaches the learner.
+    console.log(
+      `[scheduler] Empty working set (${ws.totalLOs} LOs, ${ws.totalTps} TPs) — falling back to teach mode.`,
+    );
     return {
       decision: {
         mode: "teach",
         outcomeId: null,
         contentSourceId: null,
         workingSetAssertionIds: [],
-        reason: `scheduler: empty working set (${ws.totalLOs} LOs, ${ws.totalTps} TPs) — fallback teach mode`,
+        reason: SCHEDULER_REASONS.emptyWorkingSetFallback,
         writtenAt: new Date().toISOString(),
       },
       workingSet: ws,
@@ -157,13 +162,15 @@ export function selectNextExchange(
   scoredLOs.sort((a, b) => b.score - a.score);
   const picked = scoredLOs[0].lo;
 
-  const reason = [
-    `scheduler:${policy.name.toLowerCase()}`,
-    `mode=${mode} (${modeReason})`,
-    `outcome=${picked.ref} (${picked.status})`,
-    `pool=${ws.selectedLOs.length}LOs/${ws.assertionIds.length}TPs`,
+  // Diagnostic trace for developers — preset, mode, outcome and pool sizes.
+  // Never reaches the learner (#923). The persisted `reason` below is the
+  // learner-facing string read by SimProgressPanel.
+  console.log(
+    `[scheduler] ${policy.name.toLowerCase()} | mode=${mode} (${modeReason}) | ` +
+    `outcome=${picked.ref} (${picked.status}) | ` +
+    `pool=${ws.selectedLOs.length}LOs/${ws.assertionIds.length}TPs | ` +
     `callsSinceAssess=${callsSinceLastAssess}`,
-  ].join(" | ");
+  );
 
   return {
     decision: {
@@ -173,7 +180,7 @@ export function selectNextExchange(
       // on the shape for forward compatibility.
       contentSourceId: null,
       workingSetAssertionIds: ws.assertionIds,
-      reason,
+      reason: reasonForMode(mode),
       writtenAt: new Date().toISOString(),
     },
     workingSet: ws,

--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -959,12 +959,13 @@ export async function computeSharedState(
   if (lockedModule && data.caller?.id) {
     try {
       const { persistSchedulerDecision } = await import("@/lib/pipeline/scheduler-decision");
+      const { SCHEDULER_REASONS } = await import("@/lib/pipeline/scheduler-reasons");
       await persistSchedulerDecision(data.caller.id, {
         mode: "practice",
         outcomeId: null,
         contentSourceId: null,
         workingSetAssertionIds: [],
-        reason: `picker-locked to module "${lockedModule.slug || lockedModule.id}" — scoring allowed`,
+        reason: SCHEDULER_REASONS.pickerLockedModule,
         callsSinceAssess: 0,
       });
       console.log(

--- a/apps/admin/tests/lib/pipeline/scheduler-reasons.test.ts
+++ b/apps/admin/tests/lib/pipeline/scheduler-reasons.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  SCHEDULER_REASONS,
+  SCHEDULER_MODE_REASONS,
+  reasonForMode,
+} from "@/lib/pipeline/scheduler-reasons";
+import type { SchedulerMode } from "@/lib/pipeline/scheduler-decision";
+
+/**
+ * #923 — scheduler `reason` strings are surfaced to learners via
+ * SimProgressPanel ("Today's call" section). The contract:
+ *
+ *   1. Each reason reads as a complete sentence addressed to the learner.
+ *   2. No reason starts with a lowercase log-prefix (e.g. `scheduler:`,
+ *      `adapt:`, `reward:`). Regression-test contract:
+ *      `/^[a-z][a-z_-]*:\s/` must not match.
+ *
+ * This file enforces both the constants module AND the writer source files
+ * (so a future contributor who inlines a `reason: "scheduler: ..."` string
+ * fails the build).
+ */
+
+const LOG_PREFIX = /^[a-z][a-z_-]*:\s/;
+
+/** Strings any reasonable reader would call "log jargon, not learner copy". */
+const FORBIDDEN_JARGON = [
+  "working set",
+  "fallback teach mode",
+  "scoring allowed",
+  "scheduler:",
+  "callsSinceAssess",
+  "callsSinceLastAssess",
+  "retrieval cadence",
+];
+
+describe("SCHEDULER_REASONS — constants module (#923)", () => {
+  const allReasons: string[] = [
+    ...Object.values(SCHEDULER_REASONS),
+    ...Object.values(SCHEDULER_MODE_REASONS),
+  ];
+
+  it.each(allReasons)("'%s' does not start with a log-style prefix", (reason) => {
+    expect(reason).not.toMatch(LOG_PREFIX);
+  });
+
+  it.each(allReasons)("'%s' reads as a complete sentence (ends with . or !)", (reason) => {
+    // Allow `.`, `!`, or `?` as terminal punctuation. Em-dash mid-sentence is fine.
+    expect(reason).toMatch(/[.!?]$/);
+  });
+
+  it.each(allReasons)("'%s' is short enough for SimProgressPanel (<= 100 chars)", (reason) => {
+    expect(reason.length).toBeLessThanOrEqual(100);
+  });
+
+  it.each(allReasons)("'%s' contains no internal jargon", (reason) => {
+    const lower = reason.toLowerCase();
+    const hits = FORBIDDEN_JARGON.filter((term) => lower.includes(term.toLowerCase()));
+    expect(hits).toEqual([]);
+  });
+
+  it.each(allReasons)("'%s' contains no parenthesised internal counts", (reason) => {
+    // Things like "(0 LOs, 300 TPs)" or "(2/3)" leak internal state to the learner.
+    expect(reason).not.toMatch(/\(\s*\d/);
+  });
+
+  it("reasonForMode resolves every SchedulerMode", () => {
+    const modes: SchedulerMode[] = ["teach", "review", "assess", "practice"];
+    for (const m of modes) {
+      const r = reasonForMode(m);
+      expect(r).toBe(SCHEDULER_MODE_REASONS[m]);
+      expect(r).toBeTruthy();
+    }
+  });
+});
+
+describe("scheduler writer sources — no inline log-prefixed reasons (#923)", () => {
+  // Static analysis: scan the scheduler writer source files for any
+  // `reason: '…'` / `reason: "…"` / `reason: \`…\`` literal that starts with
+  // a lowercase log-style prefix. This is the regression contract — if a
+  // future change inlines `reason: "scheduler: ..."` again, this test fails.
+  const FORBIDDEN_INLINE = /reason\s*:\s*['"`][a-z][a-z_-]*:\s/g;
+
+  // Paths are resolved relative to the apps/admin cwd (vitest is run from
+  // apps/admin per the project's `npm run test` script).
+  const files = [
+    "lib/pipeline/scheduler.ts",
+    "lib/pipeline/scheduler-decision.ts",
+    "lib/pipeline/scheduler-reasons.ts",
+    "lib/prompt/composition/transforms/modules.ts",
+  ];
+
+  it.each(files)("%s contains no log-prefixed inline reason literals", (rel) => {
+    const abs = path.join(process.cwd(), rel);
+    expect(fs.existsSync(abs)).toBe(true);
+    const src = fs.readFileSync(abs, "utf-8");
+    const matches = src.match(FORBIDDEN_INLINE);
+    expect(matches).toBeNull();
+  });
+});

--- a/apps/admin/tests/lib/pipeline/scheduler.test.ts
+++ b/apps/admin/tests/lib/pipeline/scheduler.test.ts
@@ -10,6 +10,7 @@ import {
   ALL_PRESETS,
   getPresetForPlaybook,
 } from "@/lib/pipeline/scheduler-presets";
+import { SCHEDULER_REASONS, SCHEDULER_MODE_REASONS } from "@/lib/pipeline/scheduler-reasons";
 import type { WorkingSetInput } from "@/lib/curriculum/working-set-selector";
 
 function makeAssertion(id: string, loId: string, order = 0) {
@@ -157,14 +158,16 @@ describe("selectNextExchange — fallbacks", () => {
     expect(decision.mode).toBe("teach");
     expect(decision.outcomeId).toBeNull();
     expect(decision.workingSetAssertionIds).toEqual([]);
-    expect(decision.reason).toMatch(/empty working set/);
+    // #923 — empty-set fallback emits learner-facing copy, not dev jargon.
+    expect(decision.reason).toBe(SCHEDULER_REASONS.emptyWorkingSetFallback);
   });
 
-  it("emits a reason trace on every decision", () => {
+  it("emits learner-facing reason copy keyed by mode (#923)", () => {
     const { decision } = selectNextExchange(makeState(), BALANCED);
-    expect(decision.reason).toMatch(/scheduler:balanced/);
-    expect(decision.reason).toMatch(/mode=/);
-    expect(decision.reason).toMatch(/outcome=/);
+    // The reason must be the learner-facing string for the chosen mode —
+    // not a debugger-style log line. Regression guard for #923.
+    expect(decision.reason).toBe(SCHEDULER_MODE_REASONS[decision.mode]);
+    expect(decision.reason).not.toMatch(/^[a-z][a-z_-]*:\s/);
   });
 
   it("contentSourceId is null in v1", () => {


### PR DESCRIPTION
## Summary

The scheduler's `reason` field — surfaced to learners on `SimProgressPanel` ("Today's call" section) per #917 — used to read like debugger log breadcrumbs. Example observed on golden caller Nico Grant:

> `scheduler: empty working set (0 LOs, 300 TPs) — fallback teach mode`

This PR fixes it at the writer side. All three reason write sites in the scheduler now emit learner-facing prose; an extracted constants module + a static-analysis regression test prevent regressions.

Closes #923.

## Audit (3 write sites)

| # | Site | When | Old (dev) | New (learner) |
|---|------|------|-----------|----------------|
| 1 | `scheduler.ts:97` | Empty working-set fallback | `scheduler: empty working set (X LOs, Y TPs) — fallback teach mode` | `Picking up where we left off — focusing on new material.` |
| 2 | `scheduler.ts:160` | Happy-path decision (every call) | `scheduler:<preset> \| mode=X (reason) \| outcome=Y (status) \| pool=NLOs/MTPs \| callsSinceAssess=K` | Keyed by mode: `We're moving on to something new today.` / `Reviewing the tricky parts from your last call.` / `Time for a quick checkpoint to see how you're doing.` / `You've got the basics — let's practise putting them together.` |
| 3 | `transforms/modules.ts:967` | Picker-locked module path (#538) | `picker-locked to module "..." — scoring allowed` | `Working on the module you picked — practising at your own pace.` |

All diagnostic detail (preset name, mode reason, working-set counts, cadence counter, picked outcome ref) is preserved in `console.log` lines for developers, just no longer poisons the persisted `reason`.

## Option B chosen (constants module)

Three write sites in two files, with five distinct outputs (4 modes + fallback + picker-locked). A single source-of-truth at `apps/admin/lib/pipeline/scheduler-reasons.ts` made the contract enforceable both at runtime (typed lookup by `SchedulerMode`) and at build time (the regression test scans the constants module + writer sources).

## Regression test

`apps/admin/tests/lib/pipeline/scheduler-reasons.test.ts` enforces two layers:

1. Every value in `SCHEDULER_REASONS` and `SCHEDULER_MODE_REASONS` is a complete sentence (`/[.!?]$/`), ≤100 chars, contains no internal jargon (`working set`, `scheduler:`, `callsSinceAssess`, etc.), and does **not** match `/^[a-z][a-z_-]*:\s/`.
2. Static analysis of `scheduler.ts`, `scheduler-decision.ts`, `scheduler-reasons.ts`, `transforms/modules.ts`: any inline `reason: '<log-prefix>: ...'` literal fails the test.

If a future contributor re-introduces a log-prefixed reason inline, the build breaks.

## Existing tests updated

`apps/admin/tests/lib/pipeline/scheduler.test.ts` previously asserted on the old dev-jargon format:

```ts
expect(decision.reason).toMatch(/scheduler:balanced/);
expect(decision.reason).toMatch(/mode=/);
expect(decision.reason).toMatch(/outcome=/);
expect(decision.reason).toMatch(/empty working set/);
```

Updated to assert against the new constants and to explicitly verify the log-prefix regex does **not** match.

## Runtime verification

Nico's pipeline (`f17d8616-3c31-4814-8de1-626fb42f16f6`) — to be re-run on hf-dev after `/vm-cp`. Expected: `CallerAttribute.jsonValue.reason` on `scheduler:last_decision` reads `Picking up where we left off — focusing on new material.` instead of the old `scheduler: empty working set …` string.

## Test plan

- [x] `npx vitest run tests/lib/pipeline/scheduler.test.ts tests/lib/pipeline/scheduler-reasons.test.ts` — 58/58 pass
- [x] `npx vitest run` (full suite) — 4945 passed, 16 skipped, 0 failed
- [x] `npx tsc --noEmit` — no new errors (baseline 156 unchanged)
- [x] `npx eslint` on touched files — 0 errors
- [ ] Post-deploy: re-run Nico's pipeline on hf-dev, inspect `scheduler:last_decision` jsonValue.reason on `SimProgressPanel`

## Out of scope (per #923)

- Multi-curriculum writer fix (#919)
- Slice 2 sanitiser changes in #920 (stays as defence-in-depth for IDENTIFIER leakage)
- Internationalisation of reason copy

## Deploy

`/vm-cp` — no migration, no env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)