### PR TITLE
ux(#912): rename tray "Save & apply" to honest recompose CTAs + remove "Discard all" (PR 3 of 3 for #909)

### DIFF
--- a/apps/admin/components/shared/PendingChangesTray.tsx
+++ b/apps/admin/components/shared/PendingChangesTray.tsx
@@ -4,22 +4,28 @@
  * Pending Changes Tray (epic #854 / Story #856).
  *
  * Non-modal tray pinned to the bottom-right of the viewport. Renders the
- * list of accumulated settings edits + the asymmetric-default toggles +
- * Save & apply / Discard all actions.
+ * list of accumulated settings edits + two explicit recompose CTAs:
  *
- * Toggle 1 — "Also recompose <caller name>":
- *   - Visible only when `callerInContext !== null`
- *   - Default ON (asymmetric — single-caller recompose is cheap + expected)
+ *   - "Recompose this learner" — fires only the per-caller path
+ *     (`toggleCaller: true, toggleAll: false`). Disabled when
+ *     `callerInContext` is null.
  *
- * Toggle 2 — "Recompose all N affected learners":
- *   - Default OFF (the safety property of this epic)
- *   - Hidden when N = 0
- *   - **Disabled** when any entry is `aiSuggested: true` (A5 — AI safety
- *     defence-in-depth)
- *   - **Pre-checked ON** when any entry's `key` is in
- *     `FANOUT_CLASS_PLAYBOOK_KEYS` (A6 — preserves the historical
- *     `recompose: true` behaviour for mastery-threshold-class knobs).
- *     Still user-overridable to OFF.
+ *   - "Recompose entire cohort" — fires only the cohort fan-out path
+ *     (`toggleCaller: false, toggleAll: true`). Disabled when any entry
+ *     is `aiSuggested: true` (A5 — AI safety defence-in-depth; epic #854
+ *     safety property). Also disabled when no cohort is affected
+ *     (`preview.count === 0`).
+ *
+ * Both buttons POST to the same `/api/recompose/apply` endpoint. The
+ * server-side guard at `apply/route.ts:125-126` rejects
+ * `aiSuggested + toggleAll` regardless of button label, so the UI gate
+ * is one of five layers (see `.claude/rules/ai-to-db-guard.md`).
+ *
+ * Why no "Save" / "Discard all"? The tray is Model A — writes already
+ * committed at push time. Labels named for transactional semantics
+ * misled educators into thinking "Discard all" would roll back DB
+ * state. See `docs/decisions/2026-05-26-tray-model-a-semantics.md` and
+ * issue #912 for the rename rationale.
  *
  * Preview fetch:
  *   - Fired on tray open + on entry set change (debounced 500ms)
@@ -38,9 +44,6 @@ import {
   type TrayEntry,
   type TrayEntryScope,
 } from "@/hooks/use-pending-changes-tray";
-import {
-  shouldPreCheckFanout,
-} from "@/lib/recompose/fanout-class-keys";
 import { useChatContext } from "@/contexts/ChatContext";
 import "./pending-changes-tray.css";
 
@@ -97,6 +100,9 @@ const ZERO_PREVIEW: PreviewState = {
 
 const PREVIEW_DEBOUNCE_MS = 500;
 
+const COHORT_AI_BLOCKED_TOOLTIP =
+  "AI-suggested changes can't fan out — recompose this learner only";
+
 /**
  * Pick the dominant scope across all entries for the preview fetch.
  * Priority: system > domain > playbook. SYSTEM wins because a single
@@ -132,10 +138,8 @@ export function PendingChangesTray(): React.ReactElement | null {
   const { isOpen: chatOpen, chatLayout } = useChatContext();
   const [collapsed, setCollapsed] = useState(false);
   const [preview, setPreview] = useState<PreviewState>(ZERO_PREVIEW);
-  const [toggleCaller, setToggleCaller] = useState(true);
-  const [toggleAll, setToggleAll] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
 
   const { right: trayRight, bottom: trayBottom } = trayOffsets(chatOpen, chatLayout);
 
@@ -143,25 +147,6 @@ export function PendingChangesTray(): React.ReactElement | null {
     () => entries.some((e) => e.aiSuggested),
     [entries],
   );
-  const preCheckAll = useMemo(
-    () => shouldPreCheckFanout(entries.map((e) => e.key)),
-    [entries],
-  );
-
-  // Toggle defaults derive from the current state, not a one-time mount.
-  // When entries flip from non-fanout-class → fanout-class, Toggle 2's
-  // default flips ON. The user can still override with an explicit click.
-  // Track whether the user has manually touched Toggle 2 — if so, respect
-  // their choice over the derived default.
-  const [toggleAllUserTouched, setToggleAllUserTouched] = useState(false);
-  useEffect(() => {
-    if (toggleAllUserTouched) return;
-    setToggleAll(preCheckAll);
-  }, [preCheckAll, toggleAllUserTouched]);
-
-  // AI-mixed defence-in-depth: force OFF + lock regardless of pre-check.
-  const toggle2Locked = hasAiSuggested;
-  const effectiveToggleAll = toggle2Locked ? false : toggleAll;
 
   // Preview fetch — debounced. Cancels on entry change before debounce fires.
   useEffect(() => {
@@ -214,6 +199,62 @@ export function PendingChangesTray(): React.ReactElement | null {
       ? ` + ${preview.count - preview.sampleNames.length} more`
       : "";
 
+  const learnerButtonDisabled = applying || !callerInContext;
+  const cohortButtonDisabled =
+    applying || hasAiSuggested || preview.count === 0;
+  const cohortButtonTooltip = hasAiSuggested
+    ? COHORT_AI_BLOCKED_TOOLTIP
+    : preview.count === 0
+      ? "No affected cohort detected for these changes"
+      : undefined;
+
+  async function applyRecompose(target: "caller" | "cohort"): Promise<void> {
+    setApplying(true);
+    setApplyError(null);
+    const decisionToggleCaller = target === "caller" && Boolean(callerInContext);
+    const decisionToggleAll = target === "cohort" && !hasAiSuggested;
+    try {
+      const res = await fetch("/api/recompose/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          entries,
+          toggleCaller: decisionToggleCaller,
+          toggleAll: decisionToggleAll,
+          callerInContext,
+        }),
+      });
+      const json = (await res.json()) as { ok?: boolean; error?: string };
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error || `Apply failed (${res.status})`);
+      }
+      // #873 follow-up — emit bidirectional reflection event BEFORE
+      // clearing the tray so we still have entry data.
+      const snapshot = entries.map((e) => ({
+        label: e.label,
+        scopeLabel: e.scopeLabel,
+        beforeValue: e.beforeValue,
+        afterValue: e.afterValue,
+      }));
+      window.dispatchEvent(
+        new CustomEvent("hf:tray-applied", {
+          detail: {
+            entries: snapshot,
+            toggleCaller: decisionToggleCaller,
+            toggleAll: decisionToggleAll,
+            callerInContext: callerInContext?.name ?? null,
+            decidedAt: new Date().toISOString(),
+          },
+        }),
+      );
+      clear();
+    } catch (err: unknown) {
+      setApplyError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
+    }
+  }
+
   return (
     <div
       className="hf-pending-tray"
@@ -260,7 +301,8 @@ export function PendingChangesTray(): React.ReactElement | null {
                   type="button"
                   className="hf-pending-tray-remove"
                   onClick={() => remove(e.id)}
-                  aria-label={`Remove ${e.label} from pending changes`}
+                  aria-label={`Dismiss ${e.label}`}
+                  title="Dismiss"
                 >
                   ×
                 </button>
@@ -268,148 +310,54 @@ export function PendingChangesTray(): React.ReactElement | null {
             ))}
           </ul>
 
-          <div className="hf-pending-tray-toggles">
-            {callerInContext && (
-              <label className="hf-pending-tray-toggle">
-                <input
-                  type="checkbox"
-                  checked={toggleCaller}
-                  onChange={(e) => setToggleCaller(e.target.checked)}
-                />
-                <span>
-                  Also recompose {callerInContext.name} now (~2s)
-                </span>
-              </label>
-            )}
+          {preview.count > 0 && (
+            <div className="hf-pending-tray-cohort-info">
+              <span>
+                Cohort affected: {preview.count} learner
+                {preview.count === 1 ? "" : "s"} ({formatEta(preview.etaSeconds)})
+                {samplePreview && (
+                  <span className="hf-pending-tray-sample">
+                    {" "}— {samplePreview}{moreAffected}
+                  </span>
+                )}
+              </span>
+            </div>
+          )}
 
-            {preview.count > 0 && (
-              <label
-                className={`hf-pending-tray-toggle ${toggle2Locked ? "is-locked" : ""}`}
-                title={
-                  toggle2Locked
-                    ? "AI-suggested changes cannot trigger a full cohort recompose. Save without Toggle 2, then enable manually if needed."
-                    : preCheckAll
-                      ? "Pre-checked — this change historically fanned out to the full cohort automatically."
-                      : undefined
-                }
-              >
-                <input
-                  type="checkbox"
-                  checked={effectiveToggleAll}
-                  disabled={toggle2Locked}
-                  onChange={(e) => {
-                    setToggleAllUserTouched(true);
-                    setToggleAll(e.target.checked);
-                  }}
-                />
-                <span>
-                  Recompose all {preview.count} affected learner
-                  {preview.count === 1 ? "" : "s"} ({formatEta(preview.etaSeconds)})
-                  {samplePreview && (
-                    <span className="hf-pending-tray-sample">
-                      {" "}— {samplePreview}{moreAffected}
-                    </span>
-                  )}
-                </span>
-              </label>
-            )}
+          {hasAiSuggested && (
+            <p className="hf-pending-tray-ai-warning">
+              ⚠ AI-suggested change present — cohort recompose is disabled.
+            </p>
+          )}
 
-            {toggle2Locked && (
-              <p className="hf-pending-tray-ai-warning">
-                ⚠ AI-suggested change present — cohort fanout is disabled.
-              </p>
-            )}
-          </div>
-
-          {saveError && (
+          {applyError && (
             <p className="hf-pending-tray-ai-warning" role="alert">
-              ⚠ {saveError}
+              ⚠ {applyError}
             </p>
           )}
 
           <div className="hf-pending-tray-actions">
             <button
               type="button"
-              className="hf-pending-tray-discard"
-              onClick={() => {
-                // #873 follow-up — emit bidirectional reflection event so
-                // ChatContext can tell the AI what the user did on the
-                // next chat turn. Capture entry snapshot BEFORE clearing.
-                const snapshot = entries.map((e) => ({
-                  label: e.label,
-                  scopeLabel: e.scopeLabel,
-                  beforeValue: e.beforeValue,
-                  afterValue: e.afterValue,
-                }));
-                window.dispatchEvent(
-                  new CustomEvent("hf:tray-discarded", {
-                    detail: {
-                      entries: snapshot,
-                      callerInContext: callerInContext?.name ?? null,
-                      decidedAt: new Date().toISOString(),
-                    },
-                  }),
-                );
-                clear();
-              }}
-              disabled={saving}
+              className="hf-pending-tray-recompose-learner"
+              disabled={learnerButtonDisabled}
+              title={
+                !callerInContext
+                  ? "Open a learner to recompose just their prompt"
+                  : undefined
+              }
+              onClick={() => applyRecompose("caller")}
             >
-              Discard all
+              {applying ? "Applying…" : "Recompose this learner"}
             </button>
             <button
               type="button"
-              className="hf-pending-tray-save"
-              disabled={saving}
-              onClick={async () => {
-                setSaving(true);
-                setSaveError(null);
-                const decisionToggleCaller = Boolean(callerInContext) && toggleCaller;
-                const decisionToggleAll = !toggle2Locked && effectiveToggleAll;
-                try {
-                  const res = await fetch("/api/recompose/apply", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                      entries,
-                      toggleCaller: decisionToggleCaller,
-                      toggleAll: decisionToggleAll,
-                      callerInContext,
-                    }),
-                  });
-                  const json = (await res.json()) as { ok?: boolean; error?: string };
-                  if (!res.ok || !json.ok) {
-                    throw new Error(json.error || `Apply failed (${res.status})`);
-                  }
-                  // #873 follow-up — emit bidirectional reflection event
-                  // BEFORE clearing the tray so we still have entry data.
-                  const snapshot = entries.map((e) => ({
-                    label: e.label,
-                    scopeLabel: e.scopeLabel,
-                    beforeValue: e.beforeValue,
-                    afterValue: e.afterValue,
-                  }));
-                  window.dispatchEvent(
-                    new CustomEvent("hf:tray-applied", {
-                      detail: {
-                        entries: snapshot,
-                        toggleCaller: decisionToggleCaller,
-                        toggleAll: decisionToggleAll,
-                        callerInContext: callerInContext?.name ?? null,
-                        decidedAt: new Date().toISOString(),
-                      },
-                    }),
-                  );
-                  clear();
-                  // Reset toggle state for next batch
-                  setToggleAllUserTouched(false);
-                } catch (err: unknown) {
-                  setSaveError(err instanceof Error ? err.message : String(err));
-                } finally {
-                  setSaving(false);
-                }
-              }}
+              className="hf-pending-tray-recompose-cohort"
+              disabled={cohortButtonDisabled}
+              title={cohortButtonTooltip}
+              onClick={() => applyRecompose("cohort")}
             >
-              {saving ? "Applying…" : "Save & apply"}
+              {applying ? "Applying…" : "Recompose entire cohort"}
             </button>
           </div>
         </>

--- a/apps/admin/components/shared/pending-changes-tray.css
+++ b/apps/admin/components/shared/pending-changes-tray.css
@@ -190,8 +190,8 @@
   background: color-mix(in srgb, var(--surface-secondary) 40%, var(--surface-primary));
 }
 
-.hf-pending-tray-discard,
-.hf-pending-tray-save {
+.hf-pending-tray-recompose-learner,
+.hf-pending-tray-recompose-cohort {
   padding: 6px 12px;
   font-size: 12px;
   font-weight: 500;
@@ -200,27 +200,34 @@
   border: 1px solid var(--border-default);
 }
 
-.hf-pending-tray-discard {
-  background: transparent;
-  color: var(--text-secondary);
-}
-
-.hf-pending-tray-discard:hover {
-  background: color-mix(in srgb, var(--text-primary) 6%, transparent);
-  color: var(--text-primary);
-}
-
-.hf-pending-tray-save {
+.hf-pending-tray-recompose-learner {
   background: var(--accent-primary);
   color: var(--surface-primary);
   border-color: var(--accent-primary);
 }
 
-.hf-pending-tray-save:hover:not(:disabled) {
+.hf-pending-tray-recompose-learner:hover:not(:disabled) {
   background: color-mix(in srgb, var(--accent-primary) 85%, var(--text-primary));
 }
 
-.hf-pending-tray-save:disabled {
-  opacity: 0.6;
+.hf-pending-tray-recompose-cohort {
+  background: transparent;
+  color: var(--text-primary);
+}
+
+.hf-pending-tray-recompose-cohort:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--text-primary) 6%, transparent);
+}
+
+.hf-pending-tray-recompose-learner:disabled,
+.hf-pending-tray-recompose-cohort:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
+}
+
+.hf-pending-tray-cohort-info {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+  color: var(--text-secondary);
 }

--- a/apps/admin/tests/components/shared/PendingChangesTray.test.tsx
+++ b/apps/admin/tests/components/shared/PendingChangesTray.test.tsx
@@ -1,14 +1,15 @@
 /**
- * PendingChangesTray (epic #854 / Story #856).
+ * PendingChangesTray (epic #854 / Story #856; renamed in #912).
  *
  * Asserts:
  *   - Returns null when no entries
  *   - Renders entries with diff + AI badge
- *   - Toggle 1 hidden without caller-in-context, visible + ON-default with one
- *   - Toggle 2 OFF-default for non-fanout-class keys
- *   - Toggle 2 pre-checked ON for fanout-class keys (A6 — mastery threshold)
- *   - Toggle 2 disabled + forced OFF when any entry has aiSuggested (A5)
- *   - Discard all clears entries
+ *   - No tray button contains "Save" or "Discard" (#912 — Model A honesty)
+ *   - "Recompose this learner" + "Recompose entire cohort" CTAs render
+ *   - Learner button disabled without caller-in-context
+ *   - Cohort button disabled (with AI tooltip) when any entry aiSuggested
+ *   - Cohort button enabled when all entries non-AI + cohort > 0
+ *   - Per-row dismiss button tooltip reads "Dismiss"
  *   - Remove button removes a single entry
  */
 
@@ -131,6 +132,12 @@ function fanoutClassEntry(overrides: Partial<TrayEntry> = {}): Omit<TrayEntry, "
   };
 }
 
+async function waitForPreview(): Promise<void> {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 600));
+  });
+}
+
 describe("PendingChangesTray", () => {
   it("renders nothing when no entries", () => {
     const { queryByTestId } = render(<TestHarness />);
@@ -139,9 +146,7 @@ describe("PendingChangesTray", () => {
 
   it("renders entries with scope, label, and diff", async () => {
     const { findByTestId, getByText } = render(
-      <TestHarness
-        setupEntries={(push) => push(nonFanoutEntry())}
-      />,
+      <TestHarness setupEntries={(push) => push(nonFanoutEntry())} />,
     );
     await findByTestId("pending-changes-tray");
     expect(getByText("Domain Acme")).toBeInTheDocument();
@@ -152,108 +157,100 @@ describe("PendingChangesTray", () => {
   it("shows AI badge for ai-suggested entries", async () => {
     const { findByText } = render(
       <TestHarness
-        setupEntries={(push) =>
-          push(nonFanoutEntry({ aiSuggested: true }))
-        }
+        setupEntries={(push) => push(nonFanoutEntry({ aiSuggested: true }))}
       />,
     );
     expect(await findByText("AI")).toBeInTheDocument();
   });
 
-  it("Toggle 1 is hidden when no caller-in-context", async () => {
-    const { findByTestId, queryByText } = render(
-      <TestHarness
-        setupEntries={(push) => push(nonFanoutEntry())}
-      />,
-    );
-    await findByTestId("pending-changes-tray");
-    expect(queryByText(/Also recompose/i)).toBeNull();
-  });
-
-  it("Toggle 1 visible + checked when caller-in-context set", async () => {
-    const { findByLabelText } = render(
+  it("never renders a button labelled 'Save' or 'Discard' (#912 Model A)", async () => {
+    const { findByTestId, queryAllByRole } = render(
       <TestHarness
         setupCaller={{ id: "c-1", name: "Mary Smith" }}
         setupEntries={(push) => push(nonFanoutEntry())}
       />,
     );
-    const cb = (await findByLabelText(
-      /Also recompose Mary Smith/i,
-    )) as HTMLInputElement;
-    expect(cb.checked).toBe(true);
+    await findByTestId("pending-changes-tray");
+    await waitForPreview();
+    const buttons = queryAllByRole("button");
+    for (const btn of buttons) {
+      const text = (btn.textContent || "").toLowerCase();
+      const label = (btn.getAttribute("aria-label") || "").toLowerCase();
+      expect(text).not.toMatch(/\bsave\b/);
+      expect(label).not.toMatch(/\bsave\b/);
+      expect(text).not.toMatch(/\bdiscard\b/);
+      expect(label).not.toMatch(/\bdiscard\b/);
+    }
   });
 
-  it("Toggle 2 is OFF by default for non-fanout-class entry", async () => {
-    const { findByLabelText } = render(
+  it("renders 'Recompose this learner' and 'Recompose entire cohort' CTAs", async () => {
+    const { findByRole, findByTestId } = render(
       <TestHarness
+        setupCaller={{ id: "c-1", name: "Mary Smith" }}
         setupEntries={(push) => push(nonFanoutEntry())}
       />,
     );
-    // Wait for preview to render (count > 0 → toggle 2 visible)
-    await act(async () => {
-      await Promise.resolve();
-      await new Promise((r) => setTimeout(r, 600));
-    });
-    const cb = (await findByLabelText(
-      /Recompose all/i,
-    )) as HTMLInputElement;
-    expect(cb.checked).toBe(false);
+    await findByTestId("pending-changes-tray");
+    await waitForPreview();
+    expect(
+      await findByRole("button", { name: /Recompose this learner/i }),
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("button", { name: /Recompose entire cohort/i }),
+    ).toBeInTheDocument();
   });
 
-  it("Toggle 2 is pre-checked ON for fanout-class entry (A6)", async () => {
-    const { findByLabelText } = render(
-      <TestHarness
-        setupEntries={(push) => push(fanoutClassEntry())}
-      />,
+  it("'Recompose this learner' is disabled without caller-in-context", async () => {
+    const { findByRole, findByTestId } = render(
+      <TestHarness setupEntries={(push) => push(nonFanoutEntry())} />,
     );
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 600));
-    });
-    const cb = (await findByLabelText(
-      /Recompose all/i,
-    )) as HTMLInputElement;
-    expect(cb.checked).toBe(true);
+    await findByTestId("pending-changes-tray");
+    await waitForPreview();
+    const btn = (await findByRole("button", {
+      name: /Recompose this learner/i,
+    })) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
   });
 
-  it("Toggle 2 is disabled + OFF when any entry is aiSuggested (A5)", async () => {
-    const { findByLabelText, findByText } = render(
+  it("'Recompose entire cohort' is disabled (AI tooltip) when any entry is aiSuggested", async () => {
+    const { findByRole, findByText } = render(
       <TestHarness
+        setupCaller={{ id: "c-1", name: "Mary Smith" }}
         setupEntries={(push) => {
-          push(fanoutClassEntry()); // would normally pre-check Toggle 2
-          push(nonFanoutEntry({ aiSuggested: true })); // forces lock
+          push(fanoutClassEntry());
+          push(nonFanoutEntry({ aiSuggested: true }));
         }}
       />,
     );
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 600));
-    });
-    const cb = (await findByLabelText(
-      /Recompose all/i,
-    )) as HTMLInputElement;
-    expect(cb.disabled).toBe(true);
-    expect(cb.checked).toBe(false);
-    // Warning copy surfaces
+    await waitForPreview();
+    const btn = (await findByRole("button", {
+      name: /Recompose entire cohort/i,
+    })) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute("title")).toMatch(
+      /AI-suggested changes can't fan out/i,
+    );
     expect(
       await findByText(/AI-suggested change present/i),
     ).toBeInTheDocument();
   });
 
-  it("Discard all clears every entry", async () => {
-    const { findByText, queryByTestId } = render(
+  it("'Recompose entire cohort' is enabled when all entries are non-AI and cohort > 0", async () => {
+    const { findByRole } = render(
       <TestHarness
-        setupEntries={(push) => {
-          push(nonFanoutEntry({ key: "k-1" }));
-          push(nonFanoutEntry({ key: "k-2" }));
-        }}
+        setupCaller={{ id: "c-1", name: "Mary Smith" }}
+        setupEntries={(push) => push(nonFanoutEntry())}
       />,
     );
-    const discardBtn = await findByText("Discard all");
-    fireEvent.click(discardBtn);
-    expect(queryByTestId("pending-changes-tray")).toBeNull();
+    await waitForPreview();
+    const btn = (await findByRole("button", {
+      name: /Recompose entire cohort/i,
+    })) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
   });
 
-  it("remove button on an entry removes only that entry", async () => {
-    const { findAllByLabelText, getByText } = render(
+  it("per-row dismiss button has aria-label 'Dismiss <label>' and title 'Dismiss'", async () => {
+    const { findAllByRole } = render(
       <TestHarness
         setupEntries={(push) => {
           push(nonFanoutEntry({ key: "k-1", label: "Label 1" }));
@@ -261,10 +258,24 @@ describe("PendingChangesTray", () => {
         }}
       />,
     );
-    const removeButtons = await findAllByLabelText(/Remove /i);
-    expect(removeButtons).toHaveLength(2);
-    fireEvent.click(removeButtons[0]);
-    // After removing one, the other label still shows
+    const dismissButtons = await findAllByRole("button", { name: /^Dismiss / });
+    expect(dismissButtons).toHaveLength(2);
+    for (const btn of dismissButtons) {
+      expect(btn.getAttribute("title")).toBe("Dismiss");
+    }
+  });
+
+  it("dismiss button removes only that entry", async () => {
+    const { findAllByRole, getByText } = render(
+      <TestHarness
+        setupEntries={(push) => {
+          push(nonFanoutEntry({ key: "k-1", label: "Label 1" }));
+          push(nonFanoutEntry({ key: "k-2", label: "Label 2" }));
+        }}
+      />,
+    );
+    const dismissButtons = await findAllByRole("button", { name: /^Dismiss / });
+    fireEvent.click(dismissButtons[0]);
     expect(getByText("Label 2")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

PR 3 of 3 in epic #909 (authoring-side read parity for chain contracts). Builds on merged #914 (PR 1) and #925 (PR 2).

- **Remove "Discard all"** — the underlying writes already committed at push time (Model A per [ADR](../blob/main/docs/decisions/2026-05-26-tray-model-a-semantics.md)). The label promised DB rollback the code never delivered.
- **Rename "Save & apply" into two explicit CTAs** that reflect what Toggle 1 / Toggle 2 already meant in the data model:
  - **"Recompose this learner"** — POSTs `{toggleCaller: true, toggleAll: false}`. Disabled when there is no `callerInContext`.
  - **"Recompose entire cohort"** — POSTs `{toggleCaller: false, toggleAll: true}`. Disabled (with tooltip `"AI-suggested changes can't fan out — recompose this learner only"`) when any entry is `aiSuggested: true`. Epic #854 safety property preserved.
- **Per-row `×` tooltip** → `"Dismiss"` (was `"Remove"` / `"Discard"`).
- Both buttons hit the existing `POST /api/recompose/apply` — **no new route, no new direct callers**. The server-side AI-safety guard at `app/api/recompose/apply/route.ts:125-126` is byte-identical to `main` and still rejects `aiSuggested + toggleAll`.

## Files touched (3)

- `apps/admin/components/shared/PendingChangesTray.tsx`
- `apps/admin/components/shared/pending-changes-tray.css` (button class rename + new cohort-info row)
- `apps/admin/tests/components/shared/PendingChangesTray.test.tsx`

`hooks/use-pending-changes-tray.tsx` untouched. `clear()` semantics unchanged (still client-side notification-feed clear).

## Test plan

- [x] `npm run test -- PendingChangesTray` — 10/10 pass
- [x] `npm run test -- pending-changes-tray` (hook tests) — 16/16 pass without changes
- [x] `npx tsc --noEmit` — no new errors in tray files
- [x] `npx eslint components/shared/PendingChangesTray.tsx tests/components/shared/PendingChangesTray.test.tsx` — clean
- [x] `npx tsx scripts/audit-epic-100.ts --json` — `authoringBehTargetBypassCount = 0` (no #911 regression)
- [x] `git diff origin/main -- apps/admin/app/api/recompose/apply/route.ts` — empty diff (AI-safety guard byte-identical)
- [ ] Manual smoke on hf-dev VM: push a non-AI tray entry → both buttons enabled; push an AI-suggested entry → cohort disabled with tooltip; dismiss button per row

Closes #912. References epic #909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)