### PR TITLE
fix: green main after #925 — 3 stale tests + tsc ratchet

### DIFF
--- a/apps/admin/tests/api/callers-effective-behavior-targets.test.ts
+++ b/apps/admin/tests/api/callers-effective-behavior-targets.test.ts
@@ -49,10 +49,8 @@ function makeParams() {
   return Promise.resolve({ callerId: GOLDEN_CALLER_ID });
 }
 
-type RouteHandler = (req: unknown, ctx: { params: Promise<{ callerId: string }> }) => Promise<Response>;
-
 describe("/api/callers/[callerId]/effective-behavior-targets — GET (#911)", () => {
-  let GET: RouteHandler;
+  let GET: typeof import("../../app/api/callers/[callerId]/effective-behavior-targets/route").GET;
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/apps/admin/tests/api/chat-tuning-update-target.test.ts
+++ b/apps/admin/tests/api/chat-tuning-update-target.test.ts
@@ -135,7 +135,15 @@ describe("update_behavior_target chat tool handler", () => {
   });
 
   it("returns a 'playbook not found' error for an unknown playbookId", async () => {
-    mockPrisma.playbook.findUnique.mockResolvedValueOnce(null);
+    // #925 — the handler now calls `prisma.playbook.findUnique` TWICE for a
+    // PLAYBOOK-scope write: once at the top of the handler to populate the
+    // tray entry's friendly scopeLabel, then again inside `writeBehaviorTarget`
+    // to validate the FK before the write. `mockResolvedValueOnce(null)` only
+    // covers the first call, so the second one falls back to the default
+    // `{ id: "pb-1" }` from beforeEach and the write actually succeeds —
+    // hiding the missing-playbook error. Use `mockResolvedValue` so BOTH
+    // lookups see the row as missing.
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
 
     const raw = await executeAdminTool(
       "update_behavior_target",

--- a/apps/admin/tests/lib/admin-tools-pending-change.test.ts
+++ b/apps/admin/tests/lib/admin-tools-pending-change.test.ts
@@ -59,6 +59,16 @@ describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () =
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // #925 added cheap-lookup `prisma.caller.findUnique` and
+    // `prisma.playbook.findUnique` calls inside `handleUpdateBehaviorTarget`
+    // to populate the tray entry's friendly scopeLabel (`Learner <name>` /
+    // `Course <name>`). The lookup is `.catch(() => null)`-guarded but the
+    // mock still has to return a Promise — bare `vi.fn()` resolves to
+    // `undefined`, and `undefined.catch` throws synchronously before the
+    // catch handler fires. Each test that needs a specific name can override
+    // these in its own body.
+    mockPrisma.caller.findUnique.mockResolvedValue(null);
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
     const mod = await import("@/lib/chat/admin-tool-handlers");
     executeAdminTool = mod.executeAdminTool;
   });

--- a/apps/admin/tests/lib/tolerance/memory-decay-scale.test.ts
+++ b/apps/admin/tests/lib/tolerance/memory-decay-scale.test.ts
@@ -62,9 +62,11 @@ describe("applyDecay with memoryDecayScale", () => {
 
   it("rejects non-finite / out-of-range scales by clamping to [0.1, 1.0]", () => {
     const m = mem();
-    expect(applyDecay(m, Number.NaN)).toBe(applyDecay(m, 1.0));
-    expect(applyDecay(m, 2.0)).toBe(applyDecay(m, 1.0));
-    expect(applyDecay(m, 0)).toBe(applyDecay(m, 0.1));
+    expect(applyDecay(m, Number.NaN)).toBeCloseTo(applyDecay(m, 1.0), 5);
+    expect(applyDecay(m, 2.0)).toBeCloseTo(applyDecay(m, 1.0), 5);
+    // FP-noise robust comparison: clamp(0)=0.1 and clamp(0.1)=0.1 both pipe
+    // through Math.pow with `daysSince/30` — sub-ε differences are expected.
+    expect(applyDecay(m, 0)).toBeCloseTo(applyDecay(m, 0.1), 5);
   });
 
   it("memory with no extractedAt is unaffected by any scale", () => {


### PR DESCRIPTION
## Summary

PR #925 ("Tune sidebar reads BehaviorTarget through canonical resolver") merged at 08:59 today and left `main` red. This PR greens it with test-only changes.

Four failures on CI's full-suite run (passing in isolation, hence missed pre-merge):

1. `tests/lib/admin-tools-pending-change.test.ts:73` — `result.ok` was `undefined`
2. `tests/lib/admin-tools-pending-change.test.ts:89` — `result.pendingChange` was `undefined`
3. `tests/api/chat-tuning-update-target.test.ts:153` — `parsed.error` was `undefined`
4. `tests/lib/tolerance/memory-decay-scale.test.ts:67` — `0.095 !== 0.09499999991372744`

Plus a tsc ratchet violation (+1 over baseline 197), origin in #925's new test file.

## What broke

#925 added two cheap-lookup prisma calls inside `handleUpdateBehaviorTarget` so the AI-side tray entry's `scopeLabel` reads `"Learner <name>"` / `"Course <name>"` instead of a generic `"override"`. Both lookups are `.catch(() => null)`-guarded, but the existing test fixtures didn't accommodate them:

| Test file | Stale assumption | Reality post-#925 |
|---|---|---|
| `admin-tools-pending-change.test.ts` | `prisma.caller.findUnique` and `prisma.playbook.findUnique` mocked as bare `vi.fn()` (returns `undefined`) | `undefined.catch(...)` throws synchronously before the catch handler fires; `executeAdminTool`'s outer try/catch swallows it and returns `{ error: ... }` instead of `{ ok: true, pendingChange }` |
| `chat-tuning-update-target.test.ts:138` | `mockResolvedValueOnce(null)` covers exactly one call to `prisma.playbook.findUnique` | Handler now calls it twice (scopeLabel + FK check); the second call falls back to `beforeEach`'s `{ id: "pb-1" }` and the write succeeds, hiding the not-found error |

Both adjustments preserve test intent. Production code (`admin-tool-handlers.ts`) is intentional and not modified — the new tray-push contract is what we want; the tests were stale.

The memory-decay-scale flake is pre-existing FP arithmetic noise — `Math.pow(decay, daysSince/30)` produces sub-ε differences across `clamp(0)` and `clamp(0.1)` even though both clamp to `0.1`. Replaced the three `.toBe()` assertions in the clamping test with `.toBeCloseTo(..., 5)` (5 decimal places is well within domain tolerance). Other `.toBe()` calls in the file compare same-path results or short-circuits with no arithmetic — left alone.

The tsc +1 was in `tests/api/callers-effective-behavior-targets.test.ts:81`: a hand-rolled `RouteHandler` type with `req: unknown` and `Promise<Response>` didn't match the actual `(req: NextRequest, ...) => Promise<NextResponse>` route signature. Replaced with `typeof import("...").GET` so the test tracks the route automatically.

## Test plan

- [x] `npm run test -- tests/lib/admin-tools-pending-change tests/api/chat-tuning-update-target tests/lib/tolerance/memory-decay-scale` → 24/24 pass
- [x] `npm run test` (full suite, sequential) → 4981 passed, 16 skipped, 0 failed
- [x] `npx tsc --noEmit` → 197 errors (back to baseline)
- [x] `npm run ratchet:check` → all four metrics green (tsc 197, lint 0/4432, quarantined 37)
- [ ] Wait for CI Test Suite job to confirm green on this branch

## Out of scope

- No production code change. `admin-tool-handlers.ts` is untouched — the new `Learner <name>` / `Course <name>` scopeLabel contract is intentional.
- Did not sweep the codebase for other FP `.toBe()` patterns — only fixed the one assertion that flaked + audited siblings in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)