### PR TITLE
fix(#931): generate missing migration for ComposedPrompt.recapSynthesisCache

### DIFF
--- a/apps/admin/prisma/migrations/20260527_931_recap_synthesis_cache/migration.sql
+++ b/apps/admin/prisma/migrations/20260527_931_recap_synthesis_cache/migration.sql
@@ -1,0 +1,16 @@
+-- #931 — AI-synthesized prior-call recap cache.
+--
+-- Backfills the migration missing from PR #915 (#599 Slice 1), which added
+-- ComposedPrompt.recapSynthesisCache to schema.prisma without committing the
+-- corresponding migration file. Compose-prompt endpoint was 500ing with
+-- Prisma P2022 (column does not exist) on environments where #915 shipped
+-- without `migrate dev` regenerating the migration list.
+--
+-- Shape: { depth: "minimal" | "standard" | "rich"; text: string; cachedAt: string }
+-- See lib/prompt/composition/loaders/synthesizePriorCallRecap.ts
+--
+-- Non-destructive: nullable column, no backfill required. Postgres ADD COLUMN
+-- of a nullable column with no default is a metadata-only operation, safe on
+-- non-empty tables.
+
+ALTER TABLE "ComposedPrompt" ADD COLUMN "recapSynthesisCache" JSONB;


### PR DESCRIPTION
## Summary

- Adds the migration file missing from #915 for `ComposedPrompt.recapSynthesisCache`
- Forward-only nullable `ADD COLUMN ... JSONB`, no backfill needed
- Unblocks compose-prompt endpoint (currently 500ing with `P2022` on hf-dev)

## Test plan

- [ ] After merge, deploy via `/vm-cpp` so the migration runs on hf-dev
- [ ] Confirm `npx prisma migrate status` lists `20260527_931_recap_synthesis_cache` as applied
- [ ] Hit `GET /api/callers/[id]/compose-prompt?limit=50` and confirm 200 response
- [ ] Existing `ComposedPrompt` rows untouched (NULL in the new column)

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)