### PR TITLE
fix(#928): scope CallerAttribute lo_mastery reads by current curriculum spec

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -716,19 +716,26 @@ export async function computeSharedState(
 
         // Build LO mastery map from existing CallerAttributes.
         //
-        // #611 GRACE WINDOW — the `includes(':lo_mastery:')` match is
-        // INTENTIONALLY tolerant. After Fix A landed, new writes always use
-        // canonical slug-form keys (`curriculum:<spec>:lo_mastery:<slug>:<loRef>`),
-        // but historical rows still carry the broken name-form key
-        // (`...:lo_mastery:Part 1: Familiar Topics:OUT-01`). A stricter
-        // matcher here would silently drop those legacy rows from the
-        // prompt — that's a regression worse than the dual-key bug.
+        // #928 — Scope the read to the CURRENT curriculum spec slug. The
+        // loader at SectionDataLoader fetches all CURRICULUM-scope rows for
+        // the caller with no per-playbook filter, so a learner enrolled in
+        // multiple courses would otherwise bleed mastery rows from a sibling
+        // course into this prompt (key form: `curriculum:<spec>:lo_mastery:...`).
+        // The `specSlug` local is guaranteed truthy here by the enclosing
+        // `if (modules.length > 0 && specSlug && curriculumId && !lockedModule)`
+        // gate at line ~684.
         //
-        // Reader-tightening is a follow-on story (#614 historical key
-        // migration → then reader switch). Until that migration completes,
-        // this match stays tolerant. Do NOT tighten without first verifying
-        // `callerAttributeOldKeyFormCount` audit counter is 0 across all
-        // environments.
+        // #611 GRACE WINDOW — the post-prefix `split(':lo_mastery:')[1]`
+        // suffix extraction stays INTENTIONALLY tolerant. After Fix A
+        // landed, new writes use canonical slug-form keys
+        // (`curriculum:<spec>:lo_mastery:<slug>:<loRef>`), but historical
+        // rows still carry the broken name-form key
+        // (`curriculum:<spec>:lo_mastery:Part 1: Familiar Topics:OUT-01`).
+        // The prefix tightening below still captures both shapes — they
+        // share the same `curriculum:<spec>:lo_mastery:` prefix and only
+        // differ in the module-segment form. Do NOT tighten the suffix
+        // split without first verifying `callerAttributeOldKeyFormCount`
+        // audit counter (audit-epic-100.ts) is 0 across all environments.
         //
         // #614 status: drain script lives at
         // `scripts/migrate-caller-attribute-lo-mastery-keys.ts`
@@ -736,12 +743,13 @@ export async function computeSharedState(
         // rows via `validUntil = NOW()` after inserting the canonical row
         // (or merging max-value when the canonical row already exists).
         // Once `callerAttributeOldKeyFormCount` reads 0 in dev/test/prod,
-        // open the reader-tightening follow-on to switch this match to a
-        // slug-only regex and to mirror the change in
-        // `transforms/retrieval-practice.ts:71`.
+        // open the reader-tightening follow-on to drop the suffix
+        // tolerance and mirror the change in
+        // `transforms/retrieval-practice.ts` + `transforms/progress-narrative.ts`.
+        const loMasteryPrefix = `curriculum:${specSlug}:lo_mastery:`;
         const loMasteryMap: Record<string, number> = {};
         for (const attr of data.callerAttributes) {
-          if (attr.key.includes(':lo_mastery:') && attr.scope === 'CURRICULUM') {
+          if (attr.key.startsWith(loMasteryPrefix) && attr.scope === 'CURRICULUM') {
             const suffix = attr.key.split(':lo_mastery:')[1];
             if (suffix && suffix.length > 0 && attr.numberValue != null) {
               loMasteryMap[suffix] = attr.numberValue;

--- a/apps/admin/lib/prompt/composition/transforms/progress-narrative.ts
+++ b/apps/admin/lib/prompt/composition/transforms/progress-narrative.ts
@@ -60,16 +60,33 @@ registerTransform("computeProgressNarrative", (
   const minScoreDelta =
     typeof settings.minScoreDelta === "number" ? settings.minScoreDelta : DEFAULTS.minScoreDelta;
 
-  // Rebuild loMasteryMap from CallerAttributes. The tolerant ":lo_mastery:"
-  // match is intentional during the #611/#614 grace window — see the long
-  // explanatory comment at transforms/modules.ts ~line 687. Reader-tightening
-  // is gated on `callerAttributeOldKeyFormCount` audit counter reaching 0.
+  // Rebuild loMasteryMap from CallerAttributes.
+  //
+  // #928 — Scope the read to the CURRENT curriculum spec slug to prevent
+  // cross-course bleed (the loader fetches all CURRICULUM-scope rows for
+  // the caller with no per-playbook filter). When `curriculumSpecSlug` is
+  // unset (legacy spec without a DB Curriculum row), the map degrades to
+  // empty — same behaviour as a caller with no measured mastery in this
+  // course, so the narrative simply returns null below.
+  //
+  // The post-prefix `split(":lo_mastery:")` suffix extraction remains
+  // tolerant of legacy name-form module segments — both shapes share the
+  // `curriculum:<spec>:lo_mastery:` prefix. Reader-tightening of the
+  // suffix is gated on `callerAttributeOldKeyFormCount` audit counter
+  // reaching 0 across all environments. See the long comment at
+  // `transforms/modules.ts` (#928 / #611 block) for the full rationale.
+  const curriculumSpecSlug = sharedState.curriculumSpecSlug ?? "";
+  const loMasteryPrefix = curriculumSpecSlug
+    ? `curriculum:${curriculumSpecSlug}:lo_mastery:`
+    : "";
   const loMasteryMap: Record<string, number> = {};
-  for (const attr of loadedData.callerAttributes ?? []) {
-    if (attr.key.includes(":lo_mastery:") && attr.scope === "CURRICULUM") {
-      const suffix = attr.key.split(":lo_mastery:")[1];
-      if (suffix && suffix.length > 0 && attr.numberValue != null) {
-        loMasteryMap[suffix] = attr.numberValue;
+  if (loMasteryPrefix) {
+    for (const attr of loadedData.callerAttributes ?? []) {
+      if (attr.key.startsWith(loMasteryPrefix) && attr.scope === "CURRICULUM") {
+        const suffix = attr.key.split(":lo_mastery:")[1];
+        if (suffix && suffix.length > 0 && attr.numberValue != null) {
+          loMasteryMap[suffix] = attr.numberValue;
+        }
       }
     }
   }

--- a/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
+++ b/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
@@ -66,16 +66,35 @@ registerTransform(
     const minQuestions = (retrievalConfig?.minQuestions as number) ?? 1;
 
     // ── Compute information need (v1: coverage gap only) ──
+    //
+    // #928 — Scope the read to the CURRENT curriculum spec slug to prevent
+    // cross-course bleed (loader fetches all CURRICULUM-scope rows for the
+    // caller). When `curriculumSpecSlug` is unset (legacy spec without a
+    // DB Curriculum row), the map degrades to empty — same behaviour as a
+    // caller with zero recorded mastery.
+    //
+    // #611 GRACE WINDOW — the post-prefix `split(":lo_mastery:")` suffix
+    // extraction remains tolerant of legacy name-form module segments.
+    // Both shapes share the `curriculum:<spec>:lo_mastery:` prefix, so the
+    // tightening preserves legacy rows from this curriculum. Drain pending
+    // via `scripts/migrate-caller-attribute-lo-mastery-keys.ts` (#614);
+    // remove the suffix tolerance in the follow-on once
+    // `callerAttributeOldKeyFormCount` audit counter reads 0 everywhere.
+    const curriculumSpecSlug = sharedState.curriculumSpecSlug ?? "";
+    const loMasteryPrefix = curriculumSpecSlug
+      ? `curriculum:${curriculumSpecSlug}:lo_mastery:`
+      : "";
     const loMasteryMap = {} as Record<string, number>;
-    for (const attr of loadedData.callerAttributes) {
-      // #611 GRACE WINDOW — mirrors the tolerant matcher in
-      // `transforms/modules.ts:702` (see that block's long comment).
-      // Drain pending via `scripts/migrate-caller-attribute-lo-mastery-keys.ts`
-      // (#614); tighten this matcher in the follow-on once
-      // `callerAttributeOldKeyFormCount` audit counter reads 0 everywhere.
-      if (attr.key.includes(":lo_mastery:") && attr.scope === "CURRICULUM" && attr.numberValue != null) {
-        const suffix = attr.key.split(":lo_mastery:")[1];
-        if (suffix) loMasteryMap[suffix] = attr.numberValue;
+    if (loMasteryPrefix) {
+      for (const attr of loadedData.callerAttributes) {
+        if (
+          attr.key.startsWith(loMasteryPrefix) &&
+          attr.scope === "CURRICULUM" &&
+          attr.numberValue != null
+        ) {
+          const suffix = attr.key.split(":lo_mastery:")[1];
+          if (suffix) loMasteryMap[suffix] = attr.numberValue;
+        }
       }
     }
     const totalLOs = sharedState.workingSet?.selectedLOs?.length

--- a/apps/admin/tests/lib/prompt/composition/progress-narrative.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/progress-narrative.test.ts
@@ -38,6 +38,11 @@ function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedCo
     thresholds: { high: 0.65, low: 0.35 },
     isFinalSession: false,
     callNumber: 2,
+    // #928 — every CallerAttribute lo_mastery row carries a curriculum-spec
+    // prefix; the reader scopes by sharedState.curriculumSpecSlug. Default
+    // to the slug used by the `attr` helper below so the existing tests
+    // (which exercise gating logic, not scoping) keep passing.
+    curriculumSpecSlug: "IELTS-SPEAKING",
     ...overrides,
   };
 }
@@ -52,9 +57,14 @@ function makeContext(opts: {
   callNumber?: number;
   attributes?: AttrLike[];
   config?: PlaybookConfig["progressNarrative"];
+  curriculumSpecSlug?: string | undefined;
 }): AssembledContext {
+  const sharedOverrides: Partial<SharedComputedState> = { callNumber: opts.callNumber ?? 2 };
+  if (Object.prototype.hasOwnProperty.call(opts, "curriculumSpecSlug")) {
+    sharedOverrides.curriculumSpecSlug = opts.curriculumSpecSlug;
+  }
   return {
-    sharedState: makeSharedState({ callNumber: opts.callNumber ?? 2 }),
+    sharedState: makeSharedState(sharedOverrides),
     sections: {},
     loadedData: {
       caller: null,
@@ -234,5 +244,44 @@ describe("computeProgressNarrative", () => {
       ],
     });
     expect(transform!(null, ctx, STUB_SECTION)).toBeNull();
+  });
+
+  describe("#928 — cross-course scoping by curriculumSpecSlug", () => {
+    it("ignores lo_mastery rows whose key prefix names a different curriculum spec", () => {
+      // Caller is enrolled in both spec-A (IELTS-SPEAKING — current) and
+      // spec-B (WNF). Rows tagged with spec-B must not pollute the prompt
+      // composed for spec-A.
+      const ctx = makeContext({
+        // currentSpec defaults to IELTS-SPEAKING via makeSharedState
+        attributes: [
+          // Sibling course — must be filtered out
+          {
+            key: "curriculum:WNF:lo_mastery:part1:OUT-01",
+            scope: "CURRICULUM",
+            numberValue: 0.95,
+          },
+          // Current course — must surface
+          attr("part1:OUT-02", 0.6),
+        ],
+      });
+      const result = transform!(null, ctx, STUB_SECTION) as {
+        observations: Array<{ loRef: string; score: number }>;
+      } | null;
+      expect(result).not.toBeNull();
+      // Only the current-curriculum row survives. The sibling-course row's
+      // score (0.95) would have outranked the local 0.6 if it bled through.
+      expect(result!.observations).toHaveLength(1);
+      expect(result!.observations[0].loRef).toBe("OUT-02");
+      expect(result!.observations[0].score).toBeCloseTo(0.6);
+    });
+
+    it("returns null when curriculumSpecSlug is undefined (graceful degrade, no throw)", () => {
+      const ctx = makeContext({
+        curriculumSpecSlug: undefined,
+        attributes: [attr("part1:OUT-01", 0.9)],
+      });
+      // No throw, no observations — same shape as a caller with zero mastery.
+      expect(transform!(null, ctx, STUB_SECTION)).toBeNull();
+    });
   });
 });

--- a/docs/epic-100-chain-walk.md
+++ b/docs/epic-100-chain-walk.md
@@ -171,6 +171,10 @@ If `old_name_form` count > 0: migration script `scripts/migrate-caller-attribute
 
 **Status:** 🟡 partial — covered by #614 (queued, CRITICAL priority)
 
+**Read-site scoping (#928, 2026-05-27):** the three COMPOSE-stage transforms that rebuild `loMasteryMap` from `CallerAttributes` (`transforms/modules.ts`, `transforms/retrieval-practice.ts`, `transforms/progress-narrative.ts`) now filter with `attr.key.startsWith('curriculum:<currentSpecSlug>:lo_mastery:')` instead of a plain `.includes(':lo_mastery:')` substring match. This prevents cross-course bleed when a learner is enrolled in multiple playbooks with different curriculum specs. The post-prefix suffix split stays tolerant during the #614 grace window — legacy name-form rows share the same `curriculum:<spec>:lo_mastery:` prefix, so the tightening preserves them.
+
+**Residual:** same-spec bleed (two playbooks sharing one curriculum spec slug) is still possible. The structural fix — re-key to `playbook:<playbookId>:lo_mastery:*` with a #614-style drain — is deferred to the planned "Curriculum→Playbook collapse" epic.
+
 ---
 
 ## Summary table


### PR DESCRIPTION
## Summary

- Tighten three COMPOSE-stage `loMasteryMap` readers from `attr.key.includes(':lo_mastery:')` to `attr.key.startsWith('curriculum:<currentSpec>:lo_mastery:')`, preventing cross-course bleed when a learner is enrolled in multiple playbooks.
- `modules.ts` uses the local `specSlug` (already guarded by the scheduler-run condition); `retrieval-practice.ts` + `progress-narrative.ts` read `sharedState.curriculumSpecSlug` (published by `modules.ts` and guaranteed by `dependsOn: ["curriculum"]`).
- Suffix `split(':lo_mastery:')` tolerance preserved — legacy name-form rows from the #611/#614 grace window share the same `curriculum:<spec>:lo_mastery:` prefix.
- Adds two unit tests (cross-spec bleed; `curriculumSpecSlug` undefined graceful degrade) and updates `docs/epic-100-chain-walk.md` Link 6.

## Test plan

- [x] `vitest run tests/lib/composition tests/lib/prompt/composition` — 510/510 pass
- [x] `tsc --noEmit` — clean on the four touched files (one pre-existing error in `lib/curriculum/sync-modules.ts` from #925, unrelated)
- [x] `eslint` — 0 errors, all warnings pre-existing
- [ ] Post-deploy: verify on a multi-course learner that the prompt for course A does not contain mastery rows whose `key` starts with `curriculum:<courseB-spec>:`

## Out of scope

- DB-level filtering in `SectionDataLoader` (structural fix in the planned Curriculum→Playbook collapse epic)
- Same-spec multi-playbook bleed (re-key to `playbook:<id>:lo_mastery:*`, same epic)

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)