### PR TITLE
refactor(#928): three COMPOSE transforms delegate to buildLoMasteryMap helper

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/modules.ts
+++ b/apps/admin/lib/prompt/composition/transforms/modules.ts
@@ -10,6 +10,7 @@
  */
 
 import { registerTransform } from "../TransformRegistry";
+import { buildLoMasteryMap } from "../lo-mastery-map";
 import { getAttributeValue } from "../types";
 import type {
   LoadedDataContext,
@@ -714,48 +715,13 @@ export async function computeSharedState(
       if (callerId && assertionIds.length > 0 && dbLOs.length > 0) {
         const tpProgress = await getTpProgressBatch(callerId, specSlug, assertionIds);
 
-        // Build LO mastery map from existing CallerAttributes.
-        //
-        // #928 — Scope the read to the CURRENT curriculum spec slug. The
-        // loader at SectionDataLoader fetches all CURRICULUM-scope rows for
-        // the caller with no per-playbook filter, so a learner enrolled in
-        // multiple courses would otherwise bleed mastery rows from a sibling
-        // course into this prompt (key form: `curriculum:<spec>:lo_mastery:...`).
+        // Build LO mastery map from existing CallerAttributes — scoped to the
+        // current curriculum spec slug to prevent cross-course bleed (#928).
         // The `specSlug` local is guaranteed truthy here by the enclosing
-        // `if (modules.length > 0 && specSlug && curriculumId && !lockedModule)`
-        // gate at line ~684.
-        //
-        // #611 GRACE WINDOW — the post-prefix `split(':lo_mastery:')[1]`
-        // suffix extraction stays INTENTIONALLY tolerant. After Fix A
-        // landed, new writes use canonical slug-form keys
-        // (`curriculum:<spec>:lo_mastery:<slug>:<loRef>`), but historical
-        // rows still carry the broken name-form key
-        // (`curriculum:<spec>:lo_mastery:Part 1: Familiar Topics:OUT-01`).
-        // The prefix tightening below still captures both shapes — they
-        // share the same `curriculum:<spec>:lo_mastery:` prefix and only
-        // differ in the module-segment form. Do NOT tighten the suffix
-        // split without first verifying `callerAttributeOldKeyFormCount`
-        // audit counter (audit-epic-100.ts) is 0 across all environments.
-        //
-        // #614 status: drain script lives at
-        // `scripts/migrate-caller-attribute-lo-mastery-keys.ts`
-        // (`--apply` to write; dry-run by default). It soft-deletes legacy
-        // rows via `validUntil = NOW()` after inserting the canonical row
-        // (or merging max-value when the canonical row already exists).
-        // Once `callerAttributeOldKeyFormCount` reads 0 in dev/test/prod,
-        // open the reader-tightening follow-on to drop the suffix
-        // tolerance and mirror the change in
-        // `transforms/retrieval-practice.ts` + `transforms/progress-narrative.ts`.
-        const loMasteryPrefix = `curriculum:${specSlug}:lo_mastery:`;
-        const loMasteryMap: Record<string, number> = {};
-        for (const attr of data.callerAttributes) {
-          if (attr.key.startsWith(loMasteryPrefix) && attr.scope === 'CURRICULUM') {
-            const suffix = attr.key.split(':lo_mastery:')[1];
-            if (suffix && suffix.length > 0 && attr.numberValue != null) {
-              loMasteryMap[suffix] = attr.numberValue;
-            }
-          }
-        }
+        // `modules.length > 0 && specSlug && curriculumId && !lockedModule`
+        // gate (~line 684). Behaviour contract + grace-window rationale live
+        // in `lib/prompt/composition/lo-mastery-map.ts`.
+        const loMasteryMap = buildLoMasteryMap(data.callerAttributes, specSlug);
 
         const pbConfig = (data.playbooks?.[0]?.config || {}) as Record<string, any>;
         // #598 Slice 1 — call-1 may override duration via firstCall.durationMinsOverride.

--- a/apps/admin/lib/prompt/composition/transforms/progress-narrative.ts
+++ b/apps/admin/lib/prompt/composition/transforms/progress-narrative.ts
@@ -16,6 +16,7 @@
  */
 
 import { registerTransform } from "../TransformRegistry";
+import { buildLoMasteryMap } from "../lo-mastery-map";
 import type { AssembledContext } from "../types";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 
@@ -60,36 +61,13 @@ registerTransform("computeProgressNarrative", (
   const minScoreDelta =
     typeof settings.minScoreDelta === "number" ? settings.minScoreDelta : DEFAULTS.minScoreDelta;
 
-  // Rebuild loMasteryMap from CallerAttributes.
-  //
-  // #928 — Scope the read to the CURRENT curriculum spec slug to prevent
-  // cross-course bleed (the loader fetches all CURRICULUM-scope rows for
-  // the caller with no per-playbook filter). When `curriculumSpecSlug` is
-  // unset (legacy spec without a DB Curriculum row), the map degrades to
-  // empty — same behaviour as a caller with no measured mastery in this
-  // course, so the narrative simply returns null below.
-  //
-  // The post-prefix `split(":lo_mastery:")` suffix extraction remains
-  // tolerant of legacy name-form module segments — both shapes share the
-  // `curriculum:<spec>:lo_mastery:` prefix. Reader-tightening of the
-  // suffix is gated on `callerAttributeOldKeyFormCount` audit counter
-  // reaching 0 across all environments. See the long comment at
-  // `transforms/modules.ts` (#928 / #611 block) for the full rationale.
-  const curriculumSpecSlug = sharedState.curriculumSpecSlug ?? "";
-  const loMasteryPrefix = curriculumSpecSlug
-    ? `curriculum:${curriculumSpecSlug}:lo_mastery:`
-    : "";
-  const loMasteryMap: Record<string, number> = {};
-  if (loMasteryPrefix) {
-    for (const attr of loadedData.callerAttributes ?? []) {
-      if (attr.key.startsWith(loMasteryPrefix) && attr.scope === "CURRICULUM") {
-        const suffix = attr.key.split(":lo_mastery:")[1];
-        if (suffix && suffix.length > 0 && attr.numberValue != null) {
-          loMasteryMap[suffix] = attr.numberValue;
-        }
-      }
-    }
-  }
+  // Rebuild loMasteryMap from CallerAttributes — scoped to the current
+  // curriculum spec slug (#928); behaviour contract + grace-window rationale
+  // live in `lib/prompt/composition/lo-mastery-map.ts`.
+  const loMasteryMap = buildLoMasteryMap(
+    loadedData.callerAttributes,
+    sharedState.curriculumSpecSlug,
+  );
 
   const candidates: ProgressObservation[] = Object.entries(loMasteryMap)
     .filter(([, score]) => {

--- a/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
+++ b/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
@@ -16,6 +16,7 @@
  */
 
 import { registerTransform } from "../TransformRegistry";
+import { buildLoMasteryMap } from "../lo-mastery-map";
 import type { AssembledContext, CompositionSectionDef } from "../types";
 import { computeInformationNeed, deriveQuestionCount } from "@/lib/assessment/information-need";
 import { selectRetrievalQuestions, type RetrievalQuestion } from "@/lib/assessment/retrieval-question-selector";
@@ -66,37 +67,12 @@ registerTransform(
     const minQuestions = (retrievalConfig?.minQuestions as number) ?? 1;
 
     // ── Compute information need (v1: coverage gap only) ──
-    //
-    // #928 — Scope the read to the CURRENT curriculum spec slug to prevent
-    // cross-course bleed (loader fetches all CURRICULUM-scope rows for the
-    // caller). When `curriculumSpecSlug` is unset (legacy spec without a
-    // DB Curriculum row), the map degrades to empty — same behaviour as a
-    // caller with zero recorded mastery.
-    //
-    // #611 GRACE WINDOW — the post-prefix `split(":lo_mastery:")` suffix
-    // extraction remains tolerant of legacy name-form module segments.
-    // Both shapes share the `curriculum:<spec>:lo_mastery:` prefix, so the
-    // tightening preserves legacy rows from this curriculum. Drain pending
-    // via `scripts/migrate-caller-attribute-lo-mastery-keys.ts` (#614);
-    // remove the suffix tolerance in the follow-on once
-    // `callerAttributeOldKeyFormCount` audit counter reads 0 everywhere.
-    const curriculumSpecSlug = sharedState.curriculumSpecSlug ?? "";
-    const loMasteryPrefix = curriculumSpecSlug
-      ? `curriculum:${curriculumSpecSlug}:lo_mastery:`
-      : "";
-    const loMasteryMap = {} as Record<string, number>;
-    if (loMasteryPrefix) {
-      for (const attr of loadedData.callerAttributes) {
-        if (
-          attr.key.startsWith(loMasteryPrefix) &&
-          attr.scope === "CURRICULUM" &&
-          attr.numberValue != null
-        ) {
-          const suffix = attr.key.split(":lo_mastery:")[1];
-          if (suffix) loMasteryMap[suffix] = attr.numberValue;
-        }
-      }
-    }
+    // Scoped to the current curriculum spec slug (#928); behaviour contract
+    // + grace-window rationale live in `lib/prompt/composition/lo-mastery-map.ts`.
+    const loMasteryMap = buildLoMasteryMap(
+      loadedData.callerAttributes,
+      sharedState.curriculumSpecSlug,
+    );
     const totalLOs = sharedState.workingSet?.selectedLOs?.length
       ? (sharedState as any).workingSet?.totalLOs ?? sharedState.workingSet.selectedLOs.length
       : 0;


### PR DESCRIPTION
## Summary

- Replaces the duplicate 11-line loMasteryMap-building body in `transforms/modules.ts`, `transforms/retrieval-practice.ts`, and `transforms/progress-narrative.ts` with a single call into `buildLoMasteryMap` (shipped in #936).
- Net: **-102 / +22**. Same behaviour, one canonical place for the #611/#614 grace-window comment, and the 13-property unit suite in #936 now defends all three readers.

## Base branch

Targets `refactor/928-lo-mastery-helper` (PR #936). Once that lands, GitHub will auto-rebase this onto `main`.

## Test plan

- [x] `vitest run tests/lib/composition tests/lib/prompt/composition` → 523/523 pass (same suite as #936)
- [x] `tsc --noEmit` clean on touched files
- [ ] Manual re-read of each transform call-site to confirm same arguments / no behaviour drift

## Related

- #936 — the helper + bank entry this PR consumes
- #928 (merged) — original cross-course bleed fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)