### PR TITLE
chore(sim): drop Layers Pick-module icon from chat header

### DIFF
--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -217,7 +217,6 @@ export default function SimConversationPage() {
         onBack={isDesktop ? undefined : () => router.push('/x/sim')}
         onCallEnd={isStudent ? handleStudentCallEnd : undefined}
         onCallStateChange={setIsCallActive}
-        onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
         requestedModuleId={requestedModuleId}
         journey={journey}
         onNameChange={(next) => setCaller((prev) => (prev ? { ...prev, name: next } : prev))}

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -1330,11 +1330,6 @@ export default function CallerDetailPage() {
             }}
             onNewCall={() => setCallSession(prev => prev + 1)}
             onCallStateChange={setIsCallActive}
-            onPickModule={
-              modulesAuthored && selectedPlaybookId && selectedPlaybookId !== "all"
-                ? handlePickModule
-                : undefined
-            }
             requestedModuleId={requestedModuleId}
           />
         </div>

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -60,8 +60,6 @@ export interface SimChatProps {
    * breadcrumb doesn't snap back to "Pre-call" before post-call UI settles.
    */
   onCallStateChange?: (active: boolean) => void;
-  /** When set, renders a "Pick module" header button (Issue #242 SIM-first mount) */
-  onPickModule?: () => void;
   /**
    * #242 Slice 2: learner's pre-call module pick from the picker. When set,
    * forwarded to POST /api/callers/[id]/calls so the pipeline's module
@@ -146,7 +144,6 @@ export function SimChat({
   onNewCall,
   onBack,
   onCallStateChange,
-  onPickModule,
   requestedModuleId,
   journey,
   onNameChange,
@@ -858,7 +855,6 @@ export function SimChat({
           setShowMediaLibrary(false);
         }}
         progressPanelActive={showProgressPanel}
-        onPickModule={onPickModule}
         onAdminPanel={isOperator ? () => { setShowAdminPanel(prev => !prev); setShowProgressPanel(false); } : undefined}
         adminPanelActive={showAdminPanel}
       />

--- a/apps/admin/components/sim/WhatsAppHeader.tsx
+++ b/apps/admin/components/sim/WhatsAppHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, PhoneOff, FolderOpen, Mic, Settings, TrendingUp, Layers } from 'lucide-react';
+import { ArrowLeft, PhoneOff, FolderOpen, Mic, Settings, TrendingUp } from 'lucide-react';
 import { EditableTitle } from '@/components/shared/EditableTitle';
 
 interface WhatsAppHeaderProps {
@@ -21,7 +21,6 @@ interface WhatsAppHeaderProps {
   onVoiceToggle?: () => void;
   onAdminPanel?: () => void;
   onProgressPanel?: () => void;
-  onPickModule?: () => void;
   mediaLibraryActive?: boolean;
   voiceActive?: boolean;
   callActive?: boolean;
@@ -30,7 +29,7 @@ interface WhatsAppHeaderProps {
   avatarColor?: string;
 }
 
-export function WhatsAppHeader({ title, subtitle, onBack, onEndCall, onMediaLibrary, onAvatarClick, onTitleEdit, titleEditDisabled, onVoiceToggle, onAdminPanel, onProgressPanel, onPickModule, mediaLibraryActive, voiceActive, callActive, adminPanelActive, progressPanelActive, avatarColor = 'var(--text-muted)' }: WhatsAppHeaderProps) {
+export function WhatsAppHeader({ title, subtitle, onBack, onEndCall, onMediaLibrary, onAvatarClick, onTitleEdit, titleEditDisabled, onVoiceToggle, onAdminPanel, onProgressPanel, mediaLibraryActive, voiceActive, callActive, adminPanelActive, progressPanelActive, avatarColor = 'var(--text-muted)' }: WhatsAppHeaderProps) {
   const initials = title.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
 
   return (
@@ -112,16 +111,6 @@ export function WhatsAppHeader({ title, subtitle, onBack, onEndCall, onMediaLibr
           style={{ color: progressPanelActive ? 'var(--wa-green-primary)' : undefined }}
         >
           <TrendingUp size={20} />
-        </button>
-      )}
-      {onPickModule && (
-        <button
-          className="wa-back-btn"
-          onClick={onPickModule}
-          aria-label="Pick a module to practise"
-          title="Pick module"
-        >
-          <Layers size={20} />
         </button>
       )}
       {onAdminPanel && (


### PR DESCRIPTION
Removes redundant entry point. "Pick a module →" link in the banner above remains. Header is now 3 visually distinct icons.

## Summary

- Drops the `<Layers size={20} />` button from `WhatsAppHeader` — it duplicated the prominent "Pick a module →" blue banner directly above the header, and visually clashed with the adjacent `TrendingUp` Progress icon (#917 follow-up).
- Removes the now-dead `onPickModule` prop from `SimChat` and its two call sites (`app/x/sim/[callerId]/page.tsx` + `components/callers/CallerDetailPage.tsx`). The banner-side wiring through `SimStateBreadcrumb` / `ModulePickerInviteBanner` is untouched.
- Net: 4 files, +2 / −23.

## Test plan

- [ ] Open `/x/sim/[id]` and `/x/callers/[id]` AI Call tab — confirm the "Pick a module →" blue banner above the chat still appears and still navigates to the picker.
- [ ] Header now reads `[FolderOpen] [TrendingUp] [Settings]` — three visually distinct icons, no Layers.
- [ ] Click TrendingUp → Progress panel opens (was being mistaken for the Layers icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)