### PR TITLE
fix: admin-as-learner sim view no longer bounces to /x/callers

### DIFF
--- a/apps/admin/app/api/student/journey-position/route.ts
+++ b/apps/admin/app/api/student/journey-position/route.ts
@@ -207,11 +207,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       // learner to the picker before each session instead of straight to /x/sim.
       // returnTo includes the caller's specific conversation so the learner
       // lands back in their SIM session with ?requestedModuleId=… preserved.
+      // callerId is also passed through so the picker page's admin-no-callerId
+      // guard doesn't bounce admins simming a learner to /x/callers.
       const learningRedirect = pbConfig.modulesAuthored === true
         ? {
             type: "module_picker",
             session: 1,
-            redirect: `/x/student/${enrollment.playbook.id}/modules?returnTo=${encodeURIComponent(`/x/sim/${callerId}`)}`,
+            redirect: `/x/student/${enrollment.playbook.id}/modules?callerId=${callerId}&returnTo=${encodeURIComponent(`/x/sim/${callerId}`)}`,
           }
         : { type: "continuous", session: 1, redirect: "/x/sim" };
 
@@ -286,11 +288,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // #242 Slice 4: structured-mode courses with author-declared modules also
     // route through the picker before each session. Onboarding still gates
     // upstream — learners only reach the picker once onboarding is done.
+    // callerId is also passed through so the picker page's admin-no-callerId
+    // guard doesn't bounce admins simming a learner to /x/callers.
     const teachingRedirect = pbConfig.modulesAuthored === true
       ? {
           type: "module_picker" as const,
           session: 1,
-          redirect: `/x/student/${enrollment.playbook.id}/modules?returnTo=${encodeURIComponent(`/x/sim/${callerId}`)}`,
+          redirect: `/x/student/${enrollment.playbook.id}/modules?callerId=${callerId}&returnTo=${encodeURIComponent(`/x/sim/${callerId}`)}`,
         }
       : { type: "teaching" as const, session: 1, redirect: "/x/sim" };
 

--- a/apps/admin/hooks/useJourneyChat.ts
+++ b/apps/admin/hooks/useJourneyChat.ts
@@ -151,7 +151,11 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
   // `/x/callers`, trapping them. Sim/[callerId]/page.tsx already gives them a
   // banner CTA as the non-blocking entry — so the hook must not force the
   // redirect for them. Real students still get auto-routed to the picker.
-  const { data: session } = useSession();
+  // Wait for session hydration before deciding — initial `undefined` role
+  // would default to STUDENT and falsely trigger the non-operator redirect
+  // for admins. The init effect below holds off on resolveJourneyPosition
+  // until `sessionStatus !== 'loading'`.
+  const { data: session, status: sessionStatus } = useSession();
   const viewerRoleLevel = ROLE_LEVEL[(session?.user?.role ?? 'STUDENT') as UserRole] ?? 0;
   const viewerIsOperator = viewerRoleLevel >= 3;
 
@@ -633,6 +637,9 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
 
   // ── Init ──
   // Wait for callerRole before deciding. Only LEARNER callers have a journey.
+  // Also wait for session hydration: an unresolved session defaults the role
+  // to STUDENT, which makes `viewerIsOperator` false and trips the module_picker
+  // redirect for admins simming a learner — bouncing them to /x/callers.
   useEffect(() => {
     if (forceFirstCall) {
       setState('bypassed');
@@ -646,9 +653,14 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
       setState('bypassed');
       return;
     }
+    if (sessionStatus === 'loading') {
+      // Don't make journey-position decisions while session is loading —
+      // viewer role is unknown until next-auth resolves.
+      return;
+    }
     resolveJourneyPosition();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [callerRole, forceFirstCall]);
+  }, [callerRole, forceFirstCall, sessionStatus]);
 
   return {
     items,

--- a/apps/admin/tests/api/journey-position-module-picker.test.ts
+++ b/apps/admin/tests/api/journey-position-module-picker.test.ts
@@ -112,7 +112,13 @@ describe("journey-position — #242 Slice 4 picker routing", () => {
     expect(body.ok).toBe(true);
     expect(body.nextStop.type).toBe("module_picker");
     expect(body.nextStop.redirect).toBe(
-      `/x/student/${PLAYBOOK_ID}/modules?returnTo=${encodeURIComponent(`/x/sim/${CALLER_ID}`)}`,
+      `/x/student/${PLAYBOOK_ID}/modules?callerId=${CALLER_ID}&returnTo=${encodeURIComponent(`/x/sim/${CALLER_ID}`)}`,
+    );
+    // Admin-as-learner trap fix: callerId must be present so the picker page's
+    // admin-no-callerId guard doesn't bounce to /x/callers.
+    expect(body.nextStop.redirect).toContain(`callerId=${CALLER_ID}`);
+    expect(body.nextStop.redirect).toContain(
+      `returnTo=${encodeURIComponent(`/x/sim/${CALLER_ID}`)}`,
     );
   });
 
@@ -171,8 +177,11 @@ describe("journey-position — #242 Slice 4 picker routing", () => {
 
     expect(body.nextStop.type).toBe("module_picker");
     expect(body.nextStop.redirect).toBe(
-      `/x/student/${PLAYBOOK_ID}/modules?returnTo=${encodeURIComponent(`/x/sim/${CALLER_ID}`)}`,
+      `/x/student/${PLAYBOOK_ID}/modules?callerId=${CALLER_ID}&returnTo=${encodeURIComponent(`/x/sim/${CALLER_ID}`)}`,
     );
+    // Admin-as-learner trap fix: callerId must be present so the picker page's
+    // admin-no-callerId guard doesn't bounce to /x/callers.
+    expect(body.nextStop.redirect).toContain(`callerId=${CALLER_ID}`);
   });
 
   it("structured + modulesAuthored=true + onboarding NOT done → onboarding still gates picker", async () => {

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -14548,8 +14548,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 453 |
-| Files with annotations | 452 |
+| Route files found | 454 |
+| Files with annotations | 453 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 


### PR DESCRIPTION
## Summary

Admins clicking a caller in `/x/sim` sidebar were being bounced to `/x/callers`. Two independent bugs combined into a redirect trap; this PR fixes both (belt-and-suspenders — either alone closes the trap).

## The trace

1. Click Freddy → `/x/sim/{callerId}` mounts
2. `useJourneyChat` fires; `useSession()` returns `{ data: undefined, status: 'loading' }`
3. Role defaults to `STUDENT` → `viewerIsOperator = false`
4. journey-position API returns `module_picker` with redirect `/x/student/{playbookId}/modules?returnTo=/x/sim/{callerId}` — **no `callerId` query param**
5. Non-operator branch fires `router.push(data.nextStop.redirect)`
6. Picker page sees admin without `?callerId=` in URL → `router.replace('/x/callers?returnTo=...')`
7. Admin lands on `/x/callers` LIST

## Fix A — gate on session hydration in `useJourneyChat`

`apps/admin/hooks/useJourneyChat.ts`

Destructure `status` from `useSession()` and skip `resolveJourneyPosition` while `status === 'loading'`. Added `sessionStatus` to the init effect's dependency array so it re-runs once session resolves. Without this, the very first render makes the journey-position decision with an unresolved (defaulted-to-STUDENT) role, falsely flagging admins as learners.

## Fix B — append `callerId` to the journey-position redirect URL

`apps/admin/app/api/student/journey-position/route.ts`

Both `module_picker` emit sites (LEARNING-state branch line 216, default teaching-state branch line 297) now build the redirect as:

```
/x/student/{playbookId}/modules?callerId={callerId}&returnTo=/x/sim/{callerId}
```

Harmless for real learners (their session resolves callerId regardless of the URL param) and decisive for admins (the picker page's admin-no-callerId guard no longer fires).

## Test plan

- [x] `npx tsc --noEmit` — no new errors from modified files (pre-existing repo errors unchanged)
- [x] `vitest run tests/api/journey-position-module-picker.test.ts` — all 7 tests pass with updated URL assertions
- [x] `eslint hooks/useJourneyChat.ts app/api/student/journey-position/route.ts tests/api/journey-position-module-picker.test.ts` — no new warnings (2 pre-existing exhaustive-deps warnings unchanged)
- [ ] Manual: as admin, click a caller in `/x/sim` sidebar → stays on sim chat, doesn't bounce to `/x/callers`
- [ ] Manual: as real learner, journey-position still routes to picker when `modulesAuthored=true`

## Tests added / modified

- Updated `tests/api/journey-position-module-picker.test.ts` — two URL assertions now expect `callerId=...&returnTo=...`. Added explicit `.toContain('callerId=...')` assertions documenting why the param matters.
- No `useJourneyChat` test file exists in the repo. Per spec ("If no test file exists, skip — note in PR"), skipped adding one for the session-hydration gate. Manual verification covers it.

## Deploy

`/vm-cp` (no migrations, no env changes — code-only).

## Closes

(No issue — surfaced in chat.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)