### PR TITLE
chore: rename 'Felt Progress' section to 'Progress Signals'

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -137,9 +137,10 @@ export function CourseDesignTab({
         <SessionFlowEditor courseId={courseId} />
       </CollapsibleCard>
 
-      {/* ── Felt Progress controls (#784 S6 Section 1 — #779 + #780 namespaces) ── */}
+      {/* ── Progress Signals controls (#784 S6 Section 1 — #779 + #780 namespaces;
+          internally still the "Felt Progress" epic) ── */}
       <CollapsibleCard
-        title="Felt Progress"
+        title="Progress Signals"
         hint="Mid-call acknowledgement + structured offboarding summary"
         className="hf-mb-lg"
       >

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -406,10 +406,11 @@ export default function CourseDetailPage() {
   }, [searchParams]);
 
   // #809 — tell the DATA-mode assistant which course + tab the user is on
-  // so it can answer "what tab am I on?" and "tell me about Felt Progress"
-  // without saying "I don't see that section". The path string matches the
-  // pathname (resolved courseId, not the route template) so ChatContext's
-  // stale-route guard treats it as live.
+  // so it can answer "what tab am I on?" and "tell me about Progress Signals"
+  // (the user-visible name; internally still the Felt Progress epic) without
+  // saying "I don't see that section". The path string matches the pathname
+  // (resolved courseId, not the route template) so ChatContext's stale-route
+  // guard treats it as live.
   useEffect(() => {
     if (!courseId) return;
     setPageContext(`/x/courses/${courseId}`, { activeTab });

--- a/apps/admin/components/course-design/FeltProgressSettings.tsx
+++ b/apps/admin/components/course-design/FeltProgressSettings.tsx
@@ -293,7 +293,7 @@ export function FeltProgressSettings({
           onClick={save}
           disabled={saving}
         >
-          {saving ? "Saving…" : "Save Felt Progress"}
+          {saving ? "Saving…" : "Save Progress Signals"}
         </button>
         {success && <span className="hf-text-xs hf-text-success">Saved.</span>}
         {error && <span className="hf-text-xs hf-text-error">{error}</span>}

--- a/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
+++ b/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
@@ -49,7 +49,7 @@ describe("buildPageFeatureCatalogue", () => {
 
   it("stays under ~700-token budget (2800 chars proxy) for every registered page", () => {
     // #810 raised the cap from ~500 tokens (2000 chars) to ~700 tokens (2800
-    // chars). The Design tab now exports 5 named `sections` (Felt Progress,
+    // chars). The Design tab now exports 5 named `sections` (Progress Signals,
     // Tolerances, etc.) so the AI can answer section-level questions, which
     // costs ~120 extra tokens per render. Cheap given DATA-mode runs Sonnet
     // 4.5 — the grounding wins are worth more than the bytes.

--- a/apps/admin/lib/chat/page-feature-catalogue.ts
+++ b/apps/admin/lib/chat/page-feature-catalogue.ts
@@ -8,7 +8,7 @@
  *     and what each one is for (static feature inventory)
  *
  * Together the assistant knows both *where* the user is and *what exists* on
- * the page, so questions like "tell me about Felt Progress" stop returning
+ * the page, so questions like "tell me about Progress Signals" stop returning
  * "I don't see that section" — the registry is the single source of truth.
  *
  * Token budget: stays under ~500 tokens (2000-char proxy) for any single page
@@ -17,10 +17,10 @@
  * pushed Course detail (7 tabs) over budget. The `about` field alone is
  * enough for the assistant to answer "what is the X tab?".
  *
- * #810: `tab.sections` (named `<CollapsibleCard>` blocks like Felt Progress on
- * the Design tab) are rendered as a nested bullet under their parent tab so
- * the assistant can answer "tell me about Felt Progress" the same way it
- * answers tab-level questions.
+ * #810: `tab.sections` (named `<CollapsibleCard>` blocks like Progress Signals
+ * on the Design tab) are rendered as a nested bullet under their parent tab
+ * so the assistant can answer "tell me about Progress Signals" the same way
+ * it answers tab-level questions.
  */
 
 import { getPageHelp } from "@/lib/help/page-help";

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -135,7 +135,7 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       {
         id: "design",
         label: "Design",
-        about: "Welcome flow, session flow, Felt Progress acknowledgements, first-session behaviour, tolerances, and skill banding — the shape of how a learner experiences the course. Tolerances cover the mastery threshold (how high a learner has to score before the AI moves on), retrieval cadence (how often the AI fires recall questions), and memory decay scale (how fast prior-call memories fade).",
+        about: "Welcome flow, session flow, Progress Signals acknowledgements, first-session behaviour, tolerances, and skill banding — the shape of how a learner experiences the course. Tolerances cover the mastery threshold (how high a learner has to score before the AI moves on), retrieval cadence (how often the AI fires recall questions), and memory decay scale (how fast prior-call memories fade).",
         whenToUse: "When you want to change how sessions begin, what's acknowledged mid-call, how Call 1 behaves differently from later calls, who the course is for, or how strict the AI is about mastery before advancing.",
         sections: [
           {
@@ -143,8 +143,8 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
             about: "Canonical session-flow editor — before / during / after phases, intake, NPS, welcome. Absorbed from the retired Session Flow tab.",
           },
           {
-            title: "Felt Progress",
-            about: "Mid-call acknowledgement cues + structured offboarding summary. Lets the AI say 'here's what we covered today' before hanging up so learners feel forward motion. Shipped across #779, #780, #784, #790, #795.",
+            title: "Progress Signals",
+            about: "Mid-call acknowledgement cues + structured offboarding summary. Lets the AI say 'here's what we covered today' before hanging up so learners feel forward motion. Internally referred to as the Felt Progress epic (#779, #780, #784, #790, #795).",
           },
           {
             title: "Call 1 / First Session",

--- a/apps/admin/tests/lib/page-help.test.ts
+++ b/apps/admin/tests/lib/page-help.test.ts
@@ -194,18 +194,18 @@ describe("page-help registry", () => {
       }
     });
 
-    it("Design tab `about` mentions Felt Progress so the Help modal surfaces it without HelpOverlay changes", () => {
+    it("Design tab `about` mentions Progress Signals so the Help modal surfaces it without HelpOverlay changes", () => {
       const entry = getPageHelp("/x/courses/abc-123");
       const designTab = entry?.tabs?.find((t) => t.id === "design");
-      expect(designTab?.about.toLowerCase()).toContain("felt progress");
+      expect(designTab?.about.toLowerCase()).toContain("progress signals");
     });
 
-    it("the Felt Progress section explicitly exists in the registry", () => {
+    it("the Progress Signals section explicitly exists in the registry", () => {
       const entry = getPageHelp("/x/courses/abc-123");
       const designTab = entry?.tabs?.find((t) => t.id === "design");
-      const feltProgress = designTab?.sections?.find((s) => s.title === "Felt Progress");
-      expect(feltProgress).toBeDefined();
-      expect(feltProgress?.about.length).toBeGreaterThan(20);
+      const progressSignals = designTab?.sections?.find((s) => s.title === "Progress Signals");
+      expect(progressSignals).toBeDefined();
+      expect(progressSignals?.about.length).toBeGreaterThan(20);
     });
   });
 


### PR DESCRIPTION
## Summary

Pre-staging UI polish. The CollapsibleCard on the Course Design tab was titled \"Felt Progress\" — accurate research term but jargon-y for educators editing settings. Renamed to **Progress Signals**.

- 5 user-visible strings updated (section title, Save button, help registry copy)
- 2 test assertions updated to match
- Internal namespace keys (\`progressNarrative\`, \`offboardingSummary\`), file names, component names, transform code, and historical epic-name comments are unchanged — zero schema churn

## Test plan

- [ ] Navigate to a course's Design tab, confirm the section reads \"Progress Signals\"
- [ ] Click Save inside that section, confirm button says \"Save Progress Signals\"
- [ ] Open the Help modal (?) on the Design tab, confirm the \"Progress Signals\" section appears
- [ ] DATA-mode AI assistant: ask \"tell me about Progress Signals\" — should describe mid-call acknowledgement + structured offboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)