### PR TITLE
fix(#948): /x/sim auto-resolves playbookId from caller's enrollments

### DIFF
--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -33,7 +33,19 @@ export default function SimConversationPage() {
   const isStudent = session?.user?.role === 'STUDENT';
   const sessionGoal = searchParams.get('goal') || undefined;
   const expectedDomainId = searchParams.get('domainId') || undefined;
-  const playbookId = searchParams.get('playbookId') || undefined;
+  // #948 — `playbookId` may be missing from the URL when a learner lands
+  // directly on /x/sim/[callerId]. Without it the playbook fetch below
+  // never fires, so `modulesAuthored` stays false and the module-picker
+  // banner never renders even for a caller enrolled on a course with an
+  // authored module catalogue. Resolve it from enrollments instead — same
+  // logic as `CallerDetailPage:386-398`: single active enrollment → that
+  // playbook; multiple → most-recently enrolled.
+  //
+  // URL wins (deep-link from elsewhere); enrollment-resolved fallback only
+  // applies when URL has nothing. Derived sync, so no setState-in-effect.
+  const urlPlaybookId = searchParams.get('playbookId') || undefined;
+  const [enrollmentPlaybookId, setEnrollmentPlaybookId] = useState<string | undefined>(undefined);
+  const playbookId = urlPlaybookId ?? enrollmentPlaybookId;
   const communityName = searchParams.get('communityName') || undefined;
   const forceFirstCall = searchParams.get('forceFirstCall') === 'true';
   // #242 Slice 2 placeholder: surface the moduleId chosen in the picker.
@@ -68,6 +80,36 @@ export default function SimConversationPage() {
   // Journey chat — unified WhatsApp-style survey/onboarding/teaching flow
   // Only runs for LEARNER callers; waits for caller data before deciding.
   const journey = useJourneyChat({ callerId, forceFirstCall, callerRole: caller?.role });
+
+  // #948 — auto-resolve playbookId from the caller's active enrollments
+  // when the URL didn't pass one explicitly. Mirrors CallerDetailPage's
+  // auto-pick rule so the same caller behaves the same way on either page.
+  useEffect(() => {
+    if (urlPlaybookId) return; // URL already provided it — playbookId derives from it directly
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/enrollments`)
+      .then((r) => r.json())
+      .then((result) => {
+        if (cancelled || !result?.ok) return;
+        const active = (result.enrollments || []).filter(
+          (e: { status?: string }) => e.status === 'ACTIVE',
+        );
+        if (active.length === 0) return; // no enrollments — nothing to resolve
+        if (active.length === 1) {
+          setEnrollmentPlaybookId(active[0].playbookId);
+          return;
+        }
+        // Multiple active enrollments — pick most-recently enrolled (same
+        // tie-break as CallerDetailPage:393-398).
+        const sorted = [...active].sort(
+          (a: { enrolledAt: string }, b: { enrolledAt: string }) =>
+            new Date(b.enrolledAt).getTime() - new Date(a.enrolledAt).getTime(),
+        );
+        setEnrollmentPlaybookId(sorted[0].playbookId);
+      })
+      .catch(() => { /* non-fatal: page still renders, just without module picker */ });
+    return () => { cancelled = true; };
+  }, [callerId, urlPlaybookId]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Why this hurts

Brand-new caller, enrolled in IELTS Speaking Practice (\`modulesAuthored=true\`, 4 modules, \`progressionMode=learner-picks\`). Visit \`/x/sim/[callerId]\` directly (no \`?playbookId=\`). Result: no module-picker banner, no header icon, no way for the learner to focus their session on a module. Mastery can't be tracked, the system silently picks for them.

Side-by-side with the admin tab equivalent (\`/x/callers/[id]?tab=ai-call\`) which DOES show the picker because \`CallerDetailPage.tsx:386-398\` auto-resolves the playbookId from enrollments.

## Was this PR #940?

No. Pre-#940 the header icon was gated by the same \`modulesAuthored && playbookId\` condition that hides the banner here. The icon would have been hidden too. PR #940 reduced the visual duplication when the banner DOES render; the underlying \`playbookId\` resolution gap has been there since the page was written.

## Fix

Mirror CallerDetailPage's enrollment auto-pick:
- URL has \`playbookId\` → deep-link wins
- URL empty → fetch \`/api/callers/[id]/enrollments\` → 1 ACTIVE = that one; 2+ = most-recently enrolled

\`playbookId = urlPlaybookId ?? enrollmentPlaybookId\` (derived sync, no setState-in-effect).

## Systemic prevention (out of scope here, see commit footer)

Adding a chain-contract entry and an arch-checker rule for \"every module-capable learner-facing page MUST resolve playbookId before render\". Will open a separate issue.

## Test plan

- [ ] Localhost: visit \`/x/sim/<learner-with-1-IELTS-enrollment>\` → blue \"Pick a module →\" banner appears (4 modules)
- [ ] Localhost: visit \`/x/sim/<learner>?playbookId=<other>\` → URL wins
- [ ] Localhost: visit \`/x/sim/<learner-with-0-enrollments>\` → renders without banner (no regression)
- [ ] Admin caller-detail page unchanged (separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)