### PR TITLE
chore(test-bank): enforce 'consult before testing' + register #929 entries (D002/D003) + L9 placeholder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,25 @@ Memory: [feedback_concurrent_claude_processes.md](~/.claude/projects/-Users-paul
 
 ---
 
+## ⚠️ MANDATORY: Test Bank first — every structural test must register
+
+[`docs/TEST-BANK.md`](docs/TEST-BANK.md) is the curated catalog of high-signal tests that defend named invariants (chain contracts, AI-to-DB guards, slug-scope rules, etc.). It is the **first place to look** when you need to know whether a property is already pinned, and the **only place a structural test counts as "done"**.
+
+**Two rules — both non-negotiable:**
+
+1. **Before designing or running any test plan, consult the Test Bank.** Search `docs/TEST-BANK.md` for entries tagged with the area you're touching. If an entry exists, run it first (single-file vitest is faster than the full suite and the docstring tells you the failure mode). If you propose new test cases, check whether they'd duplicate or extend an existing entry — extending wins over duplicating.
+
+2. **Every new structural test must add an entry to the Test Bank in the same PR.** "Structural" = defends a named invariant, a chain-contract link, an AI-to-DB guard, or pins a known landmine. Use the template at the bottom of `TEST-BANK.md`. Tag the `describe(...)` block with the issue number so `grep #NNN` finds both the entry and the test. PRs that ship structural tests without a bank entry are incomplete.
+
+**Exemptions:**
+
+- Pure unit tests for new helpers with no architectural invariant attached (e.g. testing a date-format util) don't need a bank entry.
+- Snapshot tests, e2e flows, and ad-hoc smoke checks are not bank-worthy by design (see `TEST-BANK.md` § "Not bank-worthy").
+
+**Why this rule exists:** without a curated catalog, structural tests rot — devs can't find them when triaging, can't tell what they defend, and write duplicates. The bank turns "the test exists" into "the test is *discoverable, named, and re-runnable*."
+
+---
+
 ## ⚠️ MANDATORY: Use qmd and hf-graph — NOT grep, NOT glob
 
 **This is non-negotiable. Before searching, reading, or navigating any code in this repo:**

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/docs/TEST-BANK.md
+++ b/docs/TEST-BANK.md
@@ -94,6 +94,60 @@ Mixing tags is fine. `describe("buildLoMasteryMap (#928 scoping helper)", ...)` 
 
 ---
 
+### 002 — Wizard Start Over re-anchors to user's home domain
+
+| Field | Value |
+|---|---|
+| **File** | `apps/admin/tests/api/user-wizard-context.test.ts` |
+| **Subject** | `apps/admin/app/api/user/wizard-context/route.ts::GET` |
+| **Defends** | Slice A of #929 — the wizard's Start Over button MUST re-anchor `initialContext.domainId` to the logged-in user's home domain (respecting `User.assignedDomainId` first, then institution's primary domain), not the picker's previous selection or an amendment-mode course's domain. |
+| **Issue / origin** | [#929](https://github.com/WANDERCOLTD/HF/issues/929) — Start Over locked to institution picker / kept stale amendment-mode course domain. |
+| **Failure mode it pins** | Non-SUPERADMIN educator opens the wizard via `?courseId=<existing>`. The amendment-mode course's domain seeds `existingDomainId`. They click Start Over, expecting a fresh attempt — but the wizard re-uses the SAME amendment-mode `initialContext`, so the next attempt is anchored to the WRONG domain. Real harm: the AI's domain-scoped tools (resolve-institution, course-by-name lookups) all operate against the prior course's domain rather than the educator's home tenant. |
+| **What it proves** | 5 properties: home domain returned when `assignedDomainId` is null (falls back to institution's primary, ordered by `createdAt` asc); `assignedDomainId` wins when set; SUPERADMIN-like sessions (no `institutionId`) get `context: null`; institutions with no active domains get `context: null`; missing/inactive institution gets `context: null`. |
+| **How to run** | `cd apps/admin && npx vitest run tests/api/user-wizard-context.test.ts` |
+| **When to re-run** | Any change to `/api/user/wizard-context/route.ts`, `V5WizardWithSelector.tsx`'s `handleStartOver`, `ConversationalWizard.tsx`'s `onStartOver` prop wiring, or the resolution chain in `app/x/get-started-v5/page.tsx:45-73` that this endpoint mirrors. |
+| **Status** | ✅ green (5/5, 2026-05-27) |
+| **Owner area** | Wizard / Build Course |
+| **Related** | `#929` epic · entry 003 (companion B2-slice draft cleanup) |
+
+---
+
+### 003 — Wizard discard-draft marks abandoned playbook without breaking resume
+
+| Field | Value |
+|---|---|
+| **File** | `apps/admin/tests/api/wizard-discard-draft.test.ts` |
+| **Subject** | `apps/admin/app/api/wizard/discard-draft/route.ts::POST` + `lib/chat/wizard-tool-executor.ts::resolveCourseByName` |
+| **Defends** | Slice B2 of #929 — Start Over fires-and-forgets a discard POST that marks the in-progress Playbook abandoned via `config.wizardAbandonedAt` + name suffix `[abandoned <ts>]`. `resolveCourseByName` must filter abandoned drafts so the next attempt with the same course name does NOT silently resume the half-built playbook. |
+| **Issue / origin** | [#929](https://github.com/WANDERCOLTD/HF/issues/929) Slice B2 — abandoned drafts resurfaced on the next attempt via partial-name match. |
+| **Failure mode it pins** | Educator starts "IELTS Speaking Practice", AI calls `create_course`, a `Playbook { status: DRAFT, modules: [] }` lands in the DB. Educator hits Start Over (didn't like the AI's choices). New attempt with the same course name. Pre-fix: `resolveCourseByName` finds the abandoned draft, returns it as an `autoCommit: true` exact match, the new attempt now amends a half-built playbook with no modules → `mark_complete` blocks on `_count.modules > 0`. Educator stuck. |
+| **What it proves** | 10 properties: DRAFT playbook gets name suffix + `config.wizardAbandonedAt` set; PUBLISHED/ARCHIVED skipped (defensive); non-SUPERADMIN blocked from discarding cross-tenant drafts (institutionId guard); SUPERADMIN bypasses the institutionId guard; CALLER + DEMO_CALLER rows soft-deleted via `archivedAt`; already-archived callers skipped; empty body → `discarded: null` (graceful, not an error); zod strict mode rejects unknown fields with 400; non-UUID rejected with 400; institution/domain rows NEVER touched. |
+| **How to run** | `cd apps/admin && npx vitest run tests/api/wizard-discard-draft.test.ts` |
+| **When to re-run** | Any change to `/api/wizard/discard-draft/route.ts`, `resolveCourseByName`'s abandoned-filter, `ConversationalWizard.handleStartOver`'s fire-and-forget POST, or the `wizardAbandonedAt` config key shape. |
+| **Status** | ✅ green (10/10, 2026-05-27) |
+| **Owner area** | Wizard / Build Course |
+| **Related** | `#929` epic · entry 002 (companion A-slice domain re-anchor) · `lib/chat/wizard-tool-executor.ts::resolveCourseByName` |
+
+---
+
+### 004 — `/x/sim/[callerId]` auto-resolves playbookId from enrollments
+
+> **Status:** ❌ NOT YET WRITTEN. Filed as part of #948 follow-up.
+> The fix shipped in #947 has no isolated test — the resolution lives in a React effect.
+> Tracking issue lists the work: extract `lib/caller/resolve-active-playbook.ts` helper, unit-test the pick rule, then this entry becomes a green unit-level proof.
+
+| Field | Value |
+|---|---|
+| **File** | `apps/admin/tests/lib/caller/resolve-active-playbook.test.ts` *(to be created)* |
+| **Subject** | `apps/admin/lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId` *(to be extracted from `app/x/sim/[callerId]/page.tsx` + `CallerDetailPage:386-398`)* |
+| **Defends** | L9 — learner-facing module-picker reachability. Every page that mounts a session on a Playbook with `modulesAuthored=true` MUST resolve the active `playbookId` before rendering, falling back through: URL → caller's single ACTIVE enrollment → most-recently-enrolled ACTIVE. |
+| **Issue / origin** | [#948](https://github.com/WANDERCOLTD/HF/issues/948) — file-able follow-up to the `/x/sim` picker-missing bug fix (#947). |
+| **Failure mode it pins** | Brand-new learner enrolled in IELTS Speaking Practice (4 authored modules) opens `/x/sim/[callerId]` without `?playbookId=...`. Pre-fix: no banner, no header icon, no entry to the picker — learner silently routed to an unfocused session. |
+| **What it should prove** | 1 ACTIVE enrollment → that playbookId; 2+ ACTIVE → most-recently-enrolled (sorted desc by `enrolledAt`); 0 ACTIVE → null; URL override always wins over enrollment lookup; non-ACTIVE enrollments (PAUSED/ENDED) excluded from the candidate pool. |
+| **Status** | 🔴 not yet implemented |
+| **Owner area** | Caller / Sim / Learner-Facing UX |
+| **Related** | `#929` (separate Start Over fix) · `#940` (perpetrator that exposed the gap) · `arch-checker` rule pending |
+
 ---
 
 ## Live-DB Demos


### PR DESCRIPTION
## Why now

Tonight I designed a 3-call learner walkthrough test plan without consulting \`docs/TEST-BANK.md\` first. The operator pointed out the gap. The bank exists to be the *first place* you look for structural tests — without a rule that says \"check it first, register every new one\", it rots.

## What changes

- **CLAUDE.md** — new MANDATORY section above the qmd-first rule. Two non-negotiables: (1) consult Test Bank before any test plan, (2) every new structural test adds an entry in the same PR.
- **TEST-BANK.md** —
  - Entry 002: \`user-wizard-context.test.ts\` (#929 Slice A) — 5/5 green
  - Entry 003: \`wizard-discard-draft.test.ts\` (#929 Slice B2) — 10/10 green
  - Entry 004: 🔴 placeholder for the L9 helper extract from #948 follow-up
- **package.json** bump 0.8.1 → 0.8.2 (Gate 7 satisfaction for next deploy)

Exempts pure-util unit tests + snapshot/e2e from the bank rule (see CLAUDE.md text).

## Test plan

- [ ] Confirm \`docs/TEST-BANK.md\` now lists 4 entries (1 from main + 3 from this PR)
- [ ] Confirm the new CLAUDE.md section appears between concurrent-claude rule and qmd-first rule
- [ ] Next time someone adds a structural test without registering — gut-check that the new rule would catch the omission in code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)