### PR TITLE
chore(test-bank): add D002 — 3-call learner progression smoke + 0.8.3 bump

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/docs/TEST-BANK.md
+++ b/docs/TEST-BANK.md
@@ -174,6 +174,27 @@ field evidence that a fix is live.
 
 ---
 
+### D002 — 3-call learner progression smoke (IELTS, real pipeline)
+
+> **Status:** 🟡 ad-hoc shell sequence verified live; needs scriptifying into `scripts/demo-3call-cohort.ts` per the bank rule. Filed as part of #950 acceptance criteria.
+
+| Field | Value |
+|---|---|
+| **Script** | `apps/admin/scripts/demo-3call-cohort.ts` *(to be created — see "How to run" for the current manual sequence)* |
+| **Subject** | End-to-end adaptive loop: pre-call composer → AI-vs-AI sim → 7-stage pipeline (EXTRACT → AGGREGATE → REWARD → ADAPT → SUPERVISE → COMPOSE) → next-call composer. |
+| **Defends** | Three chain properties at once: (1) call sequencing — each completed call receives `callSequence` and links to `previousCallId` (loop-edge integrity); (2) ComposedPrompt freshness — each pipeline run produces a new `ComposedPrompt` with `triggerType=pipeline` whose `triggerCallId` points at the call that produced it; (3) learning progression — `CallerAttribute lo_mastery:*` accumulates non-zero values across calls AND `CallerModuleProgress.mastery` rises in lockstep on EMA-derived modules. |
+| **Issue / origin** | [#950](https://github.com/WANDERCOLTD/HF/issues/950) (surfaced the `writeModuleMastery` status-promotion bug). Originally a manual operator request 2026-05-27 to verify the full adaptive loop end-to-end on freshly-merged code (post-#929 / post-#945 / post-#947). |
+| **Failure mode it pins** | (a) Pipeline silently fails for one of the three stages and the next call composes against stale state. (b) `triggerCallId` mis-links or the chain breaks mid-cohort. (c) Mastery numbers never move — adaptive loop is a no-op. (d) Status writers race producing a "mastery > 0 + status = NOT_STARTED" stuck row (the exact bug #950 catches). |
+| **What it should prove (when scriptified)** | 1 fresh learner created + enrolled in IELTS Speaking Practice; bootstrap ComposedPrompt persisted; 3 calls run with `--module=part1,part2,part3` and 5–6 turns each; between each call, helper polls for a NEW `ComposedPrompt` row with `triggerCallId === <previous call.id>` (don't proceed until COMPOSE has actually run); after all 3 calls, snap state and assert: (i) 3 `Call` rows with `endedAt` set, (ii) 3 pipeline-triggered `ComposedPrompt` rows whose `triggerCallId`s match the 3 calls in order, (iii) per-module `CallerModuleProgress.mastery > 0` AND `status === 'IN_PROGRESS'` AND `callCount === 1` (or 2 for any module hit twice), (iv) at least one `CallerAttribute lo_mastery:*` row per module that received scorable turns. |
+| **How to run** *(current — manual sequence; replace once scriptified)* | `gcloud compute ssh hf-dev --zone=europe-west2-a --tunnel-through-iap -- bash` then on VM: `cd ~/HF/apps/admin && npx tsx scripts/_e2e-bootstrap.ts <callerId> <playbookId>` to seed initial prompt, then `npx tsx scripts/sim-drive-call.ts --persona="..." --turns=5 --module=part1 <callerId> "Call1"` repeating for part2/part3 between each call run `npx tsx scripts/_e2e-state.ts <callerId>` to confirm a new `ComposedPrompt` whose `triggerCallId` matches the just-completed call. |
+| **Known transient failures** | Anthropic API 529 "overloaded" mid-stream — the cohort script must retry the failed call (current sim-drive-call.ts crashes; the wrapper should catch + re-fire). Observed once during the 2026-05-27 verification on Call 3. |
+| **Safety** | Creates a new caller per run with a unique `externalId = e2e-3call-<timestamp>`. Each run is isolated — no cleanup needed unless storage is constrained. Idempotent re-runs spawn fresh rows; no row is ever updated by this script. |
+| **Last verified** | 2026-05-27 — ran against hf-dev with caller `e2024d48-7594-43ea-b762-c2451b400843` (Test Learner 3Call). Calls 1+2 succeeded inline, Call 3 failed Anthropic 529 then succeeded on retry. Pipeline chain green: 3 active `pipeline`-trigger ComposedPrompts in order. Mastery moved on part1 (0.69) + part3 (0.62). Anomaly captured: part2's `CallerModuleProgress.status` stuck at `NOT_STARTED` despite `mastery=0.62` — see #950. |
+| **Owner area** | Adaptive Loop / Pipeline |
+| **Related** | #950 (status-promotion bug surfaced by this demo) · #948 (learner-page reachability — separate trapdoor) · `lib/test-harness/sim-runner.ts` (in-process UI sim) · `scripts/sim-cohort.ts` (multi-call orchestrator) · `flow-call-lifecycle.md` (the chain this defends) |
+
+---
+
 ## Template for a new entry
 
 ```markdown


### PR DESCRIPTION
## Summary

Captures tonight's manual 3-call cohort run against caller \`e2024d48\` as Test Bank entry **D002**. Status 🟡 — ad-hoc shell sequence is documented in the entry; scriptifying \`scripts/demo-3call-cohort.ts\` is on tomorrow's queue per the bank rule shipped in #949.

## What we proved live

| Property | Result |
|---|---|
| Pipeline chain integrity | ✅ 3 \`pipeline\`-triggered ComposedPrompts in order, each \`triggerCallId\` matches its previous Call |
| LO mastery accumulating | ✅ part1: OUT-01=0.8 OUT-02=0.7 / part3: OUT-06=0.6 OUT-07=0.6 |
| Module mastery moving | ✅ part1 0.69 / part3 0.62 |
| Module status promotion | ❌ part2 stuck at \`NOT_STARTED\` despite mastery=0.62 — see #950 |

#950 has a one-line fix proposal for \`writeModuleMastery\` + companion unit + cohort regression test.

## Why this PR is doc-only + bump

The D002 entry is the contract; the scriptified version + the #950 code-fix go in a follow-up PR tomorrow. Bumping 0.8.2 → 0.8.3 so Gate 7 doesn't block the next deploy.

## Test plan

- [ ] Confirm \`docs/TEST-BANK.md\` now has D002 under \"Live-DB Demos\" with status 🟡
- [ ] Read the D002 entry standalone — does it explain how to re-run the cohort manually without referring to this PR?
- [ ] #950 follow-up: scriptify D002 + ship the writeModuleMastery fix + cohort regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)