### PR TITLE
fix(#953): hot-fix — use CurriculumModule.title (column isn't 'label')

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
@@ -178,7 +178,7 @@ export async function GET(
         startedAt: true,
         completedAt: true,
         updatedAt: true,
-        module: { select: { id: true, slug: true, label: true } },
+        module: { select: { id: true, slug: true, title: true } },
       },
       orderBy: { updatedAt: "desc" },
     });
@@ -230,7 +230,7 @@ export async function GET(
           return {
             moduleId: mp.module?.id ?? mp.moduleId,
             slug,
-            label: mp.module?.label ?? slug ?? mp.moduleId.slice(0, 8),
+            label: mp.module?.title ?? slug ?? mp.moduleId.slice(0, 8),
             status: mp.status,
             mastery: mp.mastery,
             callCount: mp.callCount,

--- a/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
@@ -4,10 +4,22 @@
  * @scope callers:read
  * @auth session
  * @tags callers, learning, measurement
- * @description Returns learning outcome trajectory for a caller — per-parameter scores across sessions, competency level, and checkpoint status. Only returns data for non-knowledge teaching profiles (comprehension-led, discussion-led, coaching-led).
+ * @description Returns learning trajectory for a caller. The shape adapts to
+ *   the kind of progression data the caller actually has:
+ *   - `kind: "skills"` — per-parameter score trajectory for non-knowledge
+ *     teaching profiles (comprehension-led, discussion-led, coaching-led).
+ *   - `kind: "module-mastery"` — module-by-module mastery for courses that
+ *     score against an authored module catalogue (IELTS Speaking, etc.).
+ *     Returned when the skills path is empty AND the caller has
+ *     `CallerModuleProgress` rows for the enrolled playbook.
+ *   - `null` — caller has no learning evidence yet (no scores, no module
+ *     progress, no LO mastery).
+ *
+ *   #953 — added the module-mastery branch so IELTS-style courses no longer
+ *   show an empty "Learning Trajectory" card despite having real
+ *   per-module mastery and per-LO attribute data.
  * @pathParam callerId string - The caller ID
- * @response 200 { ok: true, data: { profile, profileLabel, competencyLevel, parameters, checkpoints } }
- * @response 200 { ok: true, data: null } — No learning trajectory (knowledge profile or no scores)
+ * @response 200 { ok: true, data: SkillsTrajectory | ModuleMasteryTrajectory | null }
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -32,6 +44,11 @@ const AGG_SCOPES: Record<string, string> = {
   "coaching-led": "COACH-AGG-001",
 };
 
+// Shape of the per-LO mastery attribute key. The slug between
+// `lo_mastery:` and the LO ref is the module slug — used by the module-
+// mastery branch to attribute LO scores to their module.
+const LO_MASTERY_KEY_RE = /:lo_mastery:([^:]+):([^:]+)$/;
+
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ callerId: string }> },
@@ -41,12 +58,17 @@ export async function GET(
 
   const { callerId } = await params;
 
-  // Resolve teaching profile: caller → enrollment → playbook → subject
+  // Resolve teaching profile + playbook context: caller → enrollment →
+  // playbook → subject. We pull the playbook id + name as well so the
+  // module-mastery branch (below) can render the course name.
   const enrollment = await prisma.callerPlaybook.findFirst({
     where: { callerId, status: "ACTIVE" },
     select: {
+      playbookId: true,
       playbook: {
         select: {
+          name: true,
+          config: true,
           subjects: {
             select: { subject: { select: { teachingProfile: true } } },
             take: 1,
@@ -57,78 +79,188 @@ export async function GET(
   });
 
   const profile = enrollment?.playbook?.subjects?.[0]?.subject?.teachingProfile;
-  if (!profile || !PROFILE_PREFIXES[profile]) {
-    return NextResponse.json({ ok: true, data: null });
-  }
+  const playbookId = enrollment?.playbookId ?? null;
+  const playbookName = enrollment?.playbook?.name ?? null;
+  const playbookConfig =
+    (enrollment?.playbook?.config as Record<string, unknown> | null) ?? null;
 
-  const prefix = PROFILE_PREFIXES[profile];
-  const aggScope = AGG_SCOPES[profile];
+  // ── Branch 1: skills trajectory (existing path) ──
+  // Only fires for the three named profiles that have a matching
+  // parameter prefix + aggregator spec.
+  if (profile && PROFILE_PREFIXES[profile]) {
+    const prefix = PROFILE_PREFIXES[profile];
+    const aggScope = AGG_SCOPES[profile];
 
-  // Load CallScores for this profile's parameters across all calls (most recent first)
-  const scores = await prisma.callScore.findMany({
-    where: {
-      call: { callerId },
-      parameter: { parameterId: { startsWith: prefix } },
-    },
-    select: {
-      score: true,
-      createdAt: true,
-      parameter: { select: { parameterId: true, name: true } },
-      call: { select: { createdAt: true } },
-    },
-    orderBy: { createdAt: "asc" },
-    take: 200,
-  });
+    const scores = await prisma.callScore.findMany({
+      where: {
+        call: { callerId },
+        parameter: { parameterId: { startsWith: prefix } },
+      },
+      select: {
+        score: true,
+        createdAt: true,
+        parameter: { select: { parameterId: true, name: true } },
+        call: { select: { createdAt: true } },
+      },
+      orderBy: { createdAt: "asc" },
+      take: 200,
+    });
 
-  if (scores.length === 0) {
-    return NextResponse.json({ ok: true, data: null });
-  }
+    if (scores.length > 0) {
+      const paramMap = new Map<
+        string,
+        { name: string; scores: number[]; callDates: string[] }
+      >();
+      for (const s of scores) {
+        const pid = s.parameter.parameterId;
+        if (!paramMap.has(pid)) {
+          paramMap.set(pid, { name: s.parameter.name, scores: [], callDates: [] });
+        }
+        const entry = paramMap.get(pid)!;
+        entry.scores.push(s.score);
+        entry.callDates.push(s.call.createdAt.toISOString().split("T")[0]);
+      }
 
-  // Group scores by parameter
-  const paramMap = new Map<string, { name: string; scores: number[]; callDates: string[] }>();
-  for (const s of scores) {
-    const pid = s.parameter.parameterId;
-    if (!paramMap.has(pid)) {
-      paramMap.set(pid, { name: s.parameter.name, scores: [], callDates: [] });
+      const parameters = Array.from(paramMap.entries()).map(
+        ([parameterId, data]) => ({
+          parameterId,
+          name: data.name,
+          scores: data.scores,
+          latest: data.scores[data.scores.length - 1],
+          callDates: data.callDates,
+        }),
+      );
+
+      const competencyAttr = await prisma.callerAttribute.findFirst({
+        where: { callerId, scope: aggScope, key: "competency_level" },
+        select: { stringValue: true },
+      });
+
+      const checkpoints = await prisma.callerAttribute.findMany({
+        where: { callerId, scope: "CHECKPOINT" },
+        select: { key: true, stringValue: true, numberValue: true },
+        orderBy: { key: "asc" },
+      });
+
+      return NextResponse.json({
+        ok: true,
+        data: {
+          kind: "skills" as const,
+          profile,
+          profileLabel: PROFILE_LABELS[profile] ?? profile,
+          competencyLevel: competencyAttr?.stringValue ?? null,
+          parameters,
+          checkpoints: checkpoints.map((cp) => ({
+            key: cp.key,
+            status: cp.stringValue ?? "PENDING",
+            score: cp.numberValue,
+          })),
+        },
+      });
     }
-    const entry = paramMap.get(pid)!;
-    entry.scores.push(s.score);
-    entry.callDates.push(s.call.createdAt.toISOString().split("T")[0]);
+    // Skills path matched the profile but produced zero rows — fall
+    // through to module-mastery in case the course actually scores there.
   }
 
-  const parameters = Array.from(paramMap.entries()).map(([parameterId, data]) => ({
-    parameterId,
-    name: data.name,
-    scores: data.scores,
-    latest: data.scores[data.scores.length - 1],
-    callDates: data.callDates,
-  }));
+  // ── Branch 2: module-mastery trajectory (#953) ──
+  // Fires when the skills path is empty / not applicable AND the caller
+  // has CallerModuleProgress rows. Common for courses whose authored
+  // module catalogue (config.modules) drives scoring (IELTS Speaking,
+  // language exam prep, etc.).
+  if (playbookId) {
+    const moduleProgress = await prisma.callerModuleProgress.findMany({
+      where: { callerId },
+      select: {
+        moduleId: true,
+        status: true,
+        mastery: true,
+        callCount: true,
+        startedAt: true,
+        completedAt: true,
+        updatedAt: true,
+        module: { select: { id: true, slug: true, label: true } },
+      },
+      orderBy: { updatedAt: "desc" },
+    });
 
-  // Load aggregated competency level
-  const competencyAttr = await prisma.callerAttribute.findFirst({
-    where: { callerId, scope: aggScope, key: "competency_level" },
-    select: { stringValue: true },
-  });
+    // Authored-module labels from playbook config so we can match the
+    // module catalogue's order even when CallerModuleProgress rows came
+    // in out of sequence.
+    const authoredModules =
+      Array.isArray(playbookConfig?.modules)
+        ? (playbookConfig?.modules as Array<{ id: string; label?: string }>)
+        : [];
+    const orderBySlug = new Map<string, number>(
+      authoredModules.map((m, i) => [m.id, i]),
+    );
 
-  // Load checkpoints
-  const checkpoints = await prisma.callerAttribute.findMany({
-    where: { callerId, scope: "CHECKPOINT" },
-    select: { key: true, stringValue: true, numberValue: true },
-    orderBy: { key: "asc" },
-  });
+    if (moduleProgress.length > 0) {
+      // Roll up per-LO mastery from CallerAttribute so each module entry
+      // can surface a list of LO scores (the IELTS-equivalent of the
+      // skills branch's parameters).
+      const masteryAttrs = await prisma.callerAttribute.findMany({
+        where: {
+          callerId,
+          key: { contains: ":lo_mastery:" },
+          validUntil: null,
+        },
+        select: { key: true, numberValue: true, updatedAt: true },
+      });
+      const losByModuleSlug = new Map<
+        string,
+        Array<{ loRef: string; mastery: number; updatedAt: string }>
+      >();
+      for (const a of masteryAttrs) {
+        const match = a.key.match(LO_MASTERY_KEY_RE);
+        if (!match) continue;
+        const moduleSlug = match[1];
+        const loRef = match[2];
+        if (!losByModuleSlug.has(moduleSlug)) losByModuleSlug.set(moduleSlug, []);
+        losByModuleSlug.get(moduleSlug)!.push({
+          loRef,
+          mastery: a.numberValue ?? 0,
+          updatedAt: a.updatedAt.toISOString(),
+        });
+      }
 
-  return NextResponse.json({
-    ok: true,
-    data: {
-      profile,
-      profileLabel: PROFILE_LABELS[profile] ?? profile,
-      competencyLevel: competencyAttr?.stringValue ?? null,
-      parameters,
-      checkpoints: checkpoints.map((cp) => ({
-        key: cp.key,
-        status: cp.stringValue ?? "PENDING",
-        score: cp.numberValue,
-      })),
-    },
-  });
+      const modules = moduleProgress
+        .map((mp) => {
+          const slug = mp.module?.slug ?? null;
+          const los = slug ? losByModuleSlug.get(slug) ?? [] : [];
+          return {
+            moduleId: mp.module?.id ?? mp.moduleId,
+            slug,
+            label: mp.module?.label ?? slug ?? mp.moduleId.slice(0, 8),
+            status: mp.status,
+            mastery: mp.mastery,
+            callCount: mp.callCount,
+            startedAt: mp.startedAt?.toISOString() ?? null,
+            completedAt: mp.completedAt?.toISOString() ?? null,
+            updatedAt: mp.updatedAt.toISOString(),
+            learningOutcomes: los.sort((a, b) => a.loRef.localeCompare(b.loRef)),
+          };
+        })
+        .sort((a, b) => {
+          // Authored-module order first; then alpha by slug for anything
+          // off-catalogue (shouldn't happen, but defensive).
+          const oa = a.slug ? orderBySlug.get(a.slug) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+          const ob = b.slug ? orderBySlug.get(b.slug) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+          if (oa !== ob) return oa - ob;
+          return (a.slug ?? "").localeCompare(b.slug ?? "");
+        });
+
+      return NextResponse.json({
+        ok: true,
+        data: {
+          kind: "module-mastery" as const,
+          playbookId,
+          playbookName,
+          modules,
+        },
+      });
+    }
+  }
+
+  // No data path applies.
+  return NextResponse.json({ ok: true, data: null });
 }

--- a/apps/admin/components/callers/caller-detail/cards/LearningTrajectoryCard.tsx
+++ b/apps/admin/components/callers/caller-detail/cards/LearningTrajectoryCard.tsx
@@ -17,7 +17,8 @@ interface CheckpointStatus {
   score: number | null;
 }
 
-interface TrajectoryData {
+interface SkillsTrajectory {
+  kind: 'skills';
   profile: string;
   profileLabel: string;
   competencyLevel: string | null;
@@ -25,11 +26,33 @@ interface TrajectoryData {
   checkpoints: CheckpointStatus[];
 }
 
-const PROFILE_LABELS: Record<string, string> = {
-  'comprehension-led': 'Comprehension Skills',
-  'discussion-led': 'Discussion Skills',
-  'coaching-led': 'Coaching Progress',
-};
+interface ModuleLearningOutcome {
+  loRef: string;
+  mastery: number;
+  updatedAt: string;
+}
+
+interface ModuleProgressView {
+  moduleId: string;
+  slug: string | null;
+  label: string;
+  status: string;
+  mastery: number;
+  callCount: number;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+  learningOutcomes: ModuleLearningOutcome[];
+}
+
+interface ModuleMasteryTrajectory {
+  kind: 'module-mastery';
+  playbookId: string;
+  playbookName: string | null;
+  modules: ModuleProgressView[];
+}
+
+type TrajectoryData = SkillsTrajectory | ModuleMasteryTrajectory;
 
 const PARAM_LABELS: Record<string, string> = {
   COMP_RETRIEVAL: 'Retrieval',
@@ -56,6 +79,14 @@ const BAND_COLORS: Record<string, string> = {
   no_evidence: 'var(--text-muted)',
 };
 
+// #953 — map module status to badge color. Mirrors BAND_COLORS so the two
+// trajectory kinds feel consistent in the same card slot.
+const MODULE_STATUS_COLORS: Record<string, string> = {
+  COMPLETED: 'var(--status-success-text)',
+  IN_PROGRESS: 'var(--accent-primary)',
+  NOT_STARTED: 'var(--text-muted)',
+};
+
 export function LearningTrajectoryCard({ callerId }: { callerId: string }): JSX.Element | null {
   const [data, setData] = useState<TrajectoryData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -77,7 +108,16 @@ export function LearningTrajectoryCard({ callerId }: { callerId: string }): JSX.
     return () => { cancelled = true; };
   }, [callerId]);
 
-  if (loading || !data || data.parameters.length === 0) return null;
+  if (loading || !data) return null;
+
+  // ── #953 module-mastery variant ──────────────────────────────────────────
+  if (data.kind === 'module-mastery') {
+    if (data.modules.length === 0) return null;
+    return <ModuleMasteryView data={data} />;
+  }
+
+  // ── Skills variant (existing) ────────────────────────────────────────────
+  if (data.parameters.length === 0) return null;
 
   const bandColor = BAND_COLORS[data.competencyLevel ?? 'no_evidence'] ?? 'var(--text-muted)';
 
@@ -146,6 +186,113 @@ export function LearningTrajectoryCard({ callerId }: { callerId: string }): JSX.
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// #953 — Module-mastery variant. Surfaced for courses whose authored
+// module catalogue drives scoring (IELTS Speaking, language exam prep)
+// where the skills-trajectory parameter prefix never matches.
+function ModuleMasteryView({ data }: { data: ModuleMasteryTrajectory }): JSX.Element {
+  return (
+    <div className="hf-card" style={{ marginTop: 16 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <h3 className="hf-section-title" style={{ margin: 0 }}>Module Mastery</h3>
+        {data.playbookName && (
+          <span className="hf-text-xs hf-text-muted" style={{ fontWeight: 500 }}>
+            {data.playbookName}
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {data.modules.map((m) => {
+          const statusColor = MODULE_STATUS_COLORS[m.status] ?? 'var(--text-muted)';
+          const masteryPct = Math.round(m.mastery * 100);
+          return (
+            <div key={m.moduleId} style={{
+              padding: '10px 12px',
+              border: '1px solid var(--border-default)',
+              borderRadius: 10,
+              background: 'var(--surface-secondary)',
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, minWidth: 0 }}>
+                  <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>
+                    {m.label}
+                  </span>
+                  <span className="hf-text-xs hf-text-muted">
+                    {m.callCount} call{m.callCount === 1 ? '' : 's'}
+                  </span>
+                </div>
+                <span style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  padding: '2px 8px',
+                  borderRadius: 10,
+                  background: `color-mix(in srgb, ${statusColor} 15%, transparent)`,
+                  color: statusColor,
+                  textTransform: 'capitalize',
+                }}>
+                  {m.status.replace(/_/g, ' ').toLowerCase()}
+                </span>
+              </div>
+
+              {/* Mastery progress bar */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <div style={{
+                  flex: 1,
+                  height: 8,
+                  borderRadius: 4,
+                  background: 'var(--border-default)',
+                  overflow: 'hidden',
+                }}>
+                  <div style={{
+                    width: `${masteryPct}%`,
+                    height: '100%',
+                    background: statusColor,
+                    transition: 'width 200ms ease-out',
+                  }} />
+                </div>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', minWidth: 38, textAlign: 'right' }}>
+                  {masteryPct}%
+                </span>
+              </div>
+
+              {/* LO sub-list when present */}
+              {m.learningOutcomes.length > 0 && (
+                <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px dashed var(--border-default)' }}>
+                  <div className="hf-text-xs hf-text-muted" style={{ marginBottom: 4 }}>
+                    Learning outcomes
+                  </div>
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    {m.learningOutcomes.map((lo) => {
+                      const loPct = Math.round(lo.mastery * 100);
+                      const loColor = lo.mastery >= 0.7
+                        ? 'var(--status-success-text)'
+                        : lo.mastery > 0
+                          ? 'var(--accent-primary)'
+                          : 'var(--text-muted)';
+                      return (
+                        <span key={lo.loRef} style={{
+                          fontSize: 11,
+                          padding: '2px 8px',
+                          borderRadius: 8,
+                          background: `color-mix(in srgb, ${loColor} 12%, transparent)`,
+                          color: loColor,
+                          fontWeight: 500,
+                        }}>
+                          {lo.loRef} {loPct}%
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/admin/lib/content-trust/teaching-profiles.ts
+++ b/apps/admin/lib/content-trust/teaching-profiles.ts
@@ -222,6 +222,23 @@ const PROFILE_KEYWORDS: Record<string, TeachingProfileKey> = {
   comprehension: "comprehension-led",
   literacy: "comprehension-led",
   "creative writing": "comprehension-led",
+  // #953 — English-as-a-foreign-language exams. ESOL is the umbrella;
+  // IELTS / TOEFL / TOEIC / Cambridge (CAE/FCE/CPE) / PTE are the major
+  // brands. All map to comprehension-led: reading + close-analysis +
+  // dialogue is the right pedagogical bundle even for exams that score
+  // on speaking/writing bands. Lowercase substring match (line 295).
+  esol: "comprehension-led",
+  ielts: "comprehension-led",
+  toefl: "comprehension-led",
+  toeic: "comprehension-led",
+  cae: "comprehension-led",
+  fce: "comprehension-led",
+  cpe: "comprehension-led",
+  pte: "comprehension-led",
+  efl: "comprehension-led",
+  esl: "comprehension-led",
+  "english as a second language": "comprehension-led",
+  "english as a foreign language": "comprehension-led",
 
   // recall-led — fact-heavy subjects
   history: "recall-led",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/scripts/backfill-953-subject-teaching-profile.ts
+++ b/apps/admin/scripts/backfill-953-subject-teaching-profile.ts
@@ -1,0 +1,75 @@
+/**
+ * Backfill — #953 set `Subject.teachingProfile` from the subject name when
+ * `suggestTeachingProfile` can now resolve it.
+ *
+ * The keyword map for `suggestTeachingProfile` was extended in #953 with
+ * ESOL / IELTS / TOEFL / TOEIC / CAE / FCE / CPE / PTE / EFL / ESL +
+ * "english as a second language" / "english as a foreign language". Any
+ * existing Subject row that ended up with `teachingProfile = null`
+ * because the older map didn't recognise the name can now be repaired
+ * idempotently.
+ *
+ * Rule applied:
+ *   - For Subject rows where `teachingProfile IS NULL`, run
+ *     `suggestTeachingProfile(name)`. If it returns non-null, set the
+ *     column. If still null (genuinely unmapped subject), leave alone.
+ *   - Idempotent — re-runs are no-ops because the script targets
+ *     `teachingProfile IS NULL` only.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-953-subject-teaching-profile.ts        # apply
+ *   npx tsx scripts/backfill-953-subject-teaching-profile.ts --dry  # report only
+ */
+
+import { prisma } from "../lib/prisma";
+import { suggestTeachingProfile } from "../lib/content-trust/teaching-profiles";
+
+async function main() {
+  const dry = process.argv.includes("--dry");
+  console.log(`[backfill-953] mode=${dry ? "DRY-RUN" : "APPLY"}`);
+
+  const subjects = await prisma.subject.findMany({
+    where: { teachingProfile: null },
+    select: { id: true, name: true },
+    orderBy: { createdAt: "desc" },
+  });
+
+  console.log(`[backfill-953] inspecting ${subjects.length} subject(s) with null teachingProfile`);
+
+  const repairable: Array<{ id: string; name: string; profile: string }> = [];
+  const unmapped: Array<{ id: string; name: string }> = [];
+  for (const s of subjects) {
+    const suggested = suggestTeachingProfile(s.name);
+    if (suggested) repairable.push({ id: s.id, name: s.name, profile: suggested });
+    else unmapped.push({ id: s.id, name: s.name });
+  }
+
+  console.log(`[backfill-953] repairable: ${repairable.length}`);
+  for (const r of repairable) {
+    console.log(`  ${r.id.slice(0, 8)}  "${r.name}"  →  ${r.profile}`);
+  }
+  console.log(`[backfill-953] unmapped (left untouched): ${unmapped.length}`);
+  for (const u of unmapped.slice(0, 10)) {
+    console.log(`  ${u.id.slice(0, 8)}  "${u.name}"`);
+  }
+  if (unmapped.length > 10) console.log(`  …and ${unmapped.length - 10} more`);
+
+  if (dry || repairable.length === 0) {
+    await prisma.$disconnect();
+    return;
+  }
+
+  for (const r of repairable) {
+    await prisma.subject.update({
+      where: { id: r.id },
+      data: { teachingProfile: r.profile },
+    });
+  }
+  console.log(`[backfill-953] repaired ${repairable.length} subject row(s)`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error("[backfill-953] error:", e);
+  process.exit(1);
+});

--- a/apps/admin/tests/lib/content-trust/teaching-profiles.test.ts
+++ b/apps/admin/tests/lib/content-trust/teaching-profiles.test.ts
@@ -351,3 +351,59 @@ describe("cascade: playbook values should win over subject profile", () => {
     }
   });
 });
+
+// ── #953 suggestTeachingProfile ESOL/IELTS expansion ──
+//
+// Before the keyword expansion these subjects landed at
+// teachingProfile=null, which silently disabled the Learning Trajectory
+// card (the endpoint gates on profile ∈ {comprehension|discussion|coaching}).
+// The expansion makes ESOL-flavoured subjects resolve to comprehension-led
+// so the trajectory's existing renderer can engage. The module-mastery
+// fallback in the same PR handles the case where the profile resolves
+// but the scoring layer doesn't produce COMP_*-prefixed parameters
+// (which is true for every IELTS course today).
+
+describe("suggestTeachingProfile — #953 ESOL / IELTS keywords", () => {
+  const CASES: Array<[string, "comprehension-led"]> = [
+    ["ESOL", "comprehension-led"],
+    ["ielts", "comprehension-led"],
+    ["IELTS Speaking", "comprehension-led"],
+    ["IELTS Speaking Practice V1.0", "comprehension-led"],
+    ["TOEFL Reading Prep", "comprehension-led"],
+    ["TOEIC business", "comprehension-led"],
+    ["Cambridge CAE", "comprehension-led"],
+    ["FCE — First Certificate in English", "comprehension-led"],
+    ["CPE preparation", "comprehension-led"],
+    ["PTE Academic", "comprehension-led"],
+    ["English as a Second Language", "comprehension-led"],
+    ["English as a Foreign Language", "comprehension-led"],
+    ["EFL crash course", "comprehension-led"],
+    ["ESL conversational", "comprehension-led"],
+  ];
+
+  for (const [name, expected] of CASES) {
+    it(`maps "${name}" → ${expected}`, () => {
+      expect(suggestTeachingProfile(name)).toBe(expected);
+    });
+  }
+
+  it("returns null for subjects with no keyword hit (e.g. UFO Studies)", () => {
+    expect(suggestTeachingProfile("UFO Studies")).toBeNull();
+  });
+
+  it("returns null for empty / too-short names (existing guard)", () => {
+    expect(suggestTeachingProfile("")).toBeNull();
+    expect(suggestTeachingProfile("ab")).toBeNull();
+  });
+
+  it("prefers comprehension-led when both ESOL and another keyword collide", () => {
+    // Sanity: longer key wins per PROFILE_KEYWORD_ENTRIES sort. "english as
+    // a second language" (33 chars) beats "english" (7 chars) on the same
+    // string — both resolve to comprehension-led so the outcome is the
+    // same, but we verify the longest-first contract isn't accidentally
+    // broken by the new entries.
+    expect(suggestTeachingProfile("English as a Second Language")).toBe(
+      "comprehension-led",
+    );
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -2838,7 +2838,7 @@ Returns per-enrollment journey progress for a caller. Scheduler owns pacing —
 
 ### `GET` /api/callers/:callerId/learning-trajectory
 
-Returns learning outcome trajectory for a caller — per-parameter scores across sessions, competency level, and checkpoint status. Only returns data for non-knowledge teaching profiles (comprehension-led, discussion-led, coaching-led).
+Returns learning trajectory for a caller. The shape adapts to
 
 **Auth**: Session · **Scope**: `callers:read`
 
@@ -2848,12 +2848,7 @@ Returns learning outcome trajectory for a caller — per-parameter scores across
 
 **Response** `200`
 ```json
-{ ok: true, data: { profile, profileLabel, competencyLevel, parameters, checkpoints } }
-```
-
-**Response** `200`
-```json
-{ ok: true, data: null } — No learning trajectory (knowledge profile or no scores)
+{ ok: true, data: SkillsTrajectory | ModuleMasteryTrajectory | null }
 ```
 
 ---

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -886,7 +886,7 @@ Submit formative assessment results or record an exam result
 
 ### `GET` /api/v1/callers/:callerId/learning-trajectory
 
-Returns learning outcome trajectory for a caller — per-parameter scores across sessions, competency level, and checkpoint status. Only returns data for non-knowledge teaching profiles (comprehension-led, discussion-led, coaching-led).
+Returns learning trajectory for a caller. The shape adapts to
 
 **Auth**: Session · **Scope**: `callers:read`
 
@@ -896,12 +896,7 @@ Returns learning outcome trajectory for a caller — per-parameter scores across
 
 **Response** `200`
 ```json
-{ ok: true, data: { profile, profileLabel, competencyLevel, parameters, checkpoints } }
-```
-
-**Response** `200`
-```json
-{ ok: true, data: null } — No learning trajectory (knowledge profile or no scores)
+{ ok: true, data: SkillsTrajectory | ModuleMasteryTrajectory | null }
 ```
 
 ---


### PR DESCRIPTION
## What this fixes

Caught during live verification of #953 on the VM tonight. The new module-mastery branch I added selected \`module.label\` on \`CurriculumModule\`, but the schema column is \`title\` (e.g. \"Part 1: Familiar Topics\"). Prisma threw a field-validation error, so the route would 500 for any IELTS caller.

## Live proof of correctness

After this hot-fix, running the route's logic against caller \`89a5d05b\` returns:

\`\`\`
teachingProfile: comprehension-led
playbookName: IELTS Speaking Practice V1.0
Module progress (1):
  title=Part 1: Familiar Topics slug=part1 status=IN_PROGRESS mastery=0.667
LO mastery (2):
  OUT-02 = 0.7
  OUT-01 = 0.8
\`\`\`

That's exactly the shape the UI expects for the \`kind: \"module-mastery\"\` card.

## Why it slipped past the PR review

The unit tests cover \`suggestTeachingProfile\` keyword resolution, not the new endpoint branch. The route doesn't have integration tests against a live DB shape. Filed as #948 follow-up — the D004 bank entry should pin a Prisma-shape-validation test against the route helper.

## Version bump

0.8.5 → 0.8.6 (Gate 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)