### PR TITLE
fix(#953): hot-fix — use CurriculumModule.title (column isn't 'label')

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
@@ -178,7 +178,7 @@ export async function GET(
         startedAt: true,
         completedAt: true,
         updatedAt: true,
-        module: { select: { id: true, slug: true, label: true } },
+        module: { select: { id: true, slug: true, title: true } },
       },
       orderBy: { updatedAt: "desc" },
     });
@@ -230,7 +230,7 @@ export async function GET(
           return {
             moduleId: mp.module?.id ?? mp.moduleId,
             slug,
-            label: mp.module?.label ?? slug ?? mp.moduleId.slice(0, 8),
+            label: mp.module?.title ?? slug ?? mp.moduleId.slice(0, 8),
             status: mp.status,
             mastery: mp.mastery,
             callCount: mp.callCount,

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
Hot-fix on top of #953 (`ba43d39a`). Schema column is `title`, not `label` — Prisma would 500 on every IELTS caller without this. Verified live against Boaz (`89a5d05b`) on VM. 0.8.5 → 0.8.6. Closes the bug surfaced in PR #954 (closed; this is the clean cherry-pick).