### PR TITLE
feat(#948): L9 chain contract + resolveActivePlaybookId helper + arch-checker rule + integration test

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/active-playbook/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/active-playbook/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { resolveActivePlaybookId } from "@/lib/caller/resolve-active-playbook";
+
+/**
+ * @api GET /api/callers/:callerId/active-playbook
+ * @visibility public
+ * @scope callers:read
+ * @auth session
+ * @tags callers, enrollments
+ * @description Resolve the active playbookId for a caller via the canonical
+ *   L9 fallback chain (URL override → single ACTIVE enrollment → most-recently
+ *   enrolled ACTIVE → null). Wraps `lib/caller/resolve-active-playbook.ts` so
+ *   client-side learner-facing pages have a single endpoint to call instead
+ *   of duplicating the pick rule. See `docs/CHAIN-CONTRACTS.md` Link L9.
+ * @pathParam callerId string - The caller ID
+ * @queryParam playbookId string? - Optional URL override; wins when non-empty
+ * @response 200 { ok: true, playbookId: string | null }
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ callerId: string }> }
+) {
+  const authResult = await requireAuth("VIEWER");
+  if (isAuthError(authResult)) return authResult.error;
+
+  const { callerId } = await params;
+  const url = new URL(req.url);
+  const override = url.searchParams.get("playbookId");
+
+  const playbookId = await resolveActivePlaybookId(callerId, override);
+
+  return NextResponse.json({ ok: true, playbookId });
+}

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -82,30 +82,20 @@ export default function SimConversationPage() {
   const journey = useJourneyChat({ callerId, forceFirstCall, callerRole: caller?.role });
 
   // #948 — auto-resolve playbookId from the caller's active enrollments
-  // when the URL didn't pass one explicitly. Mirrors CallerDetailPage's
-  // auto-pick rule so the same caller behaves the same way on either page.
+  // when the URL didn't pass one explicitly. Delegates to the shared L9
+  // resolver via `/api/callers/[id]/active-playbook` so the pick rule lives
+  // in one place. See docs/CHAIN-CONTRACTS.md Link L9 + the helper at
+  // lib/caller/resolve-active-playbook.ts.
   useEffect(() => {
     if (urlPlaybookId) return; // URL already provided it — playbookId derives from it directly
     let cancelled = false;
-    fetch(`/api/callers/${callerId}/enrollments`)
+    fetch(`/api/callers/${callerId}/active-playbook`)
       .then((r) => r.json())
       .then((result) => {
         if (cancelled || !result?.ok) return;
-        const active = (result.enrollments || []).filter(
-          (e: { status?: string }) => e.status === 'ACTIVE',
-        );
-        if (active.length === 0) return; // no enrollments — nothing to resolve
-        if (active.length === 1) {
-          setEnrollmentPlaybookId(active[0].playbookId);
-          return;
+        if (result.playbookId) {
+          setEnrollmentPlaybookId(result.playbookId);
         }
-        // Multiple active enrollments — pick most-recently enrolled (same
-        // tie-break as CallerDetailPage:393-398).
-        const sorted = [...active].sort(
-          (a: { enrolledAt: string }, b: { enrolledAt: string }) =>
-            new Date(b.enrolledAt).getTime() - new Date(a.enrolledAt).getTime(),
-        );
-        setEnrollmentPlaybookId(sorted[0].playbookId);
       })
       .catch(() => { /* non-fatal: page still renders, just without module picker */ });
     return () => { cancelled = true; };

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -380,6 +380,16 @@ export default function CallerDetailPage() {
       .catch((e) => console.warn("[CallerDetail] Failed to load prompts:", e));
 
     // Fetch enrollments for course filter
+    //
+    // NOTE on divergence from the L9 chain contract (docs/CHAIN-CONTRACTS.md):
+    // this page needs the FULL enrollment list (rendered as a course-filter
+    // dropdown elsewhere on the page), not just the resolved playbookId — so
+    // it can't reduce to a `/active-playbook` call without losing the list.
+    // The auto-pick rule below MUST stay byte-identical to
+    // `lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId` —
+    // any drift breaks the L9 invariant ("same caller behaves the same way
+    // on either page"). This admin page is out of scope for the arch-checker
+    // Check G (learner-facing only); the lint rule does not catch this site.
     fetch(`/api/callers/${callerId}/enrollments`)
       .then((r) => r.json())
       .then((result) => {
@@ -387,7 +397,8 @@ export default function CallerDetailPage() {
           const active = (result.enrollments || []).filter((e: Enrollment) => e.status === "ACTIVE");
           setEnrollments(active);
           setEnrollmentCount(active.length);
-          // Auto-select: 1 course → that course; 2+ → most recent by enrolledAt
+          // Auto-select: 1 course → that course; 2+ → most recent by enrolledAt.
+          // MUST match resolveActivePlaybookId() — keep these branches in sync.
           if (active.length === 1) {
             setSelectedPlaybookId(active[0].playbookId);
           } else if (active.length > 1) {

--- a/apps/admin/lib/caller/resolve-active-playbook.ts
+++ b/apps/admin/lib/caller/resolve-active-playbook.ts
@@ -1,0 +1,69 @@
+/**
+ * resolveActivePlaybookId — canonical fallback chain for "which playbook is
+ * this caller talking about RIGHT NOW?" used by every learner-facing page
+ * that mounts a session on a Playbook.
+ *
+ * Resolution order (matches L9 chain contract in `docs/CHAIN-CONTRACTS.md`):
+ *
+ *   1. `urlOverride` — when the URL passed `?playbookId=<id>` (deep-link from
+ *      picker / wizard / preview). URL always wins, even if the id points at
+ *      a non-ACTIVE enrollment, because legitimate deep-links exist for
+ *      paused-but-being-viewed playbooks.
+ *
+ *   2. Single ACTIVE `CallerPlaybook` enrollment → that `playbookId`.
+ *
+ *   3. Multiple ACTIVE → most-recently-enrolled wins (`ORDER BY enrolledAt
+ *      DESC`). Same tie-break rule as `CallerDetailPage.tsx:386-398`.
+ *
+ *   4. Zero ACTIVE enrollments → `null`. The page is responsible for
+ *      rendering a learner-readable empty state (NOT a silent no-op — the
+ *      whole point of contract L9 is preventing silent unreachability).
+ *
+ * Non-ACTIVE enrollment statuses (`PAUSED`, `COMPLETED`, `DROPPED`, etc.) are
+ * excluded from the candidate pool at the SQL layer.
+ *
+ * Issue: #948 — extracted from `app/x/sim/[callerId]/page.tsx` (and the
+ * sibling auto-pick rule in `components/callers/CallerDetailPage.tsx`) so the
+ * arch-checker rule has a single import to point at.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Resolve the playbookId a caller's session should mount on.
+ *
+ * @param callerId - The caller whose enrollments to inspect.
+ * @param urlOverride - Optional `?playbookId=` query-param value. Wins when
+ *   non-empty. Pass `null` or `undefined` to fall through to enrollments.
+ * @returns The resolved `playbookId`, or `null` when no enrollment exists
+ *   and the URL didn't pass one.
+ */
+export async function resolveActivePlaybookId(
+  callerId: string,
+  urlOverride?: string | null,
+): Promise<string | null> {
+  // 1. URL wins — even if it points at a non-ACTIVE enrollment. Deep-link
+  // semantics are the caller's responsibility, not ours.
+  if (typeof urlOverride === "string" && urlOverride.length > 0) {
+    return urlOverride;
+  }
+
+  // 2-4. Fall through to enrollment lookup.
+  const enrollments = await prisma.callerPlaybook.findMany({
+    where: { callerId, status: "ACTIVE" },
+    orderBy: { enrolledAt: "desc" },
+    select: { playbookId: true },
+  });
+
+  if (enrollments.length === 0) {
+    // No ACTIVE enrollments — page must render a learner-readable empty
+    // state (NOT silently swallow the missing picker).
+    return null;
+  }
+
+  // length === 1: that single ACTIVE enrollment.
+  // length >= 2: most-recently-enrolled wins (orderBy desc returns it
+  // first). Identical tie-break to CallerDetailPage:393-398 — so the same
+  // caller behaves the same way on either page.
+  return enrollments[0].playbookId;
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/integration/journey/learner-picker-reachability.integration.test.ts
+++ b/apps/admin/tests/integration/journey/learner-picker-reachability.integration.test.ts
@@ -1,0 +1,304 @@
+/**
+ * #948 / L9 — Learner-Facing Module Picker Reachability — integration test
+ *
+ * Pins the L9 chain contract (`docs/CHAIN-CONTRACTS.md`) against live DB
+ * data. Walks four shapes of learner state and verifies the resolver's
+ * decision matches the contract for each shape.
+ *
+ * Tests run DB-only (no server needed). Each test owns its rows under
+ * uniquely-prefixed `externalId`s so concurrent test runs don't collide
+ * and each test cleans up its own rows in `afterAll`.
+ *
+ * Acceptance criteria pinned:
+ *
+ *   1. Learner with 1 ACTIVE enrollment on a `modulesAuthored=true`
+ *      playbook → resolver returns that playbookId; subsequent playbook
+ *      fetch surfaces `modules` for the banner.
+ *
+ *   2. Learner with 2+ ACTIVE enrollments (different `enrolledAt`) →
+ *      resolver picks the most-recently-enrolled.
+ *
+ *   3. Learner with 0 ACTIVE enrollments → resolver returns `null`
+ *      (page would render empty state, not crash).
+ *
+ *   4. Learner with 1 ACTIVE enrollment on `modulesAuthored=false`
+ *      playbook → resolver still returns that playbookId (it doesn't
+ *      gate on `modulesAuthored`); the banner-gating happens downstream
+ *      in the page component, not in the resolver.
+ *
+ * FK landmine: pre-fix, `educator-journey.integration.test.ts:406` tripped
+ * on `prisma.caller.upsert` with a non-existent `userId`. The Caller →
+ * User FK is enforced. For LEARNER-role callers in these fixtures we leave
+ * `userId` null — these are sim-only callers, not portal users.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import { resolveActivePlaybookId } from "@/lib/caller/resolve-active-playbook";
+
+const prisma = new PrismaClient();
+
+// Per-run unique prefix so concurrent CI jobs don't fight over rows.
+const RUN_ID = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const PREFIX = `e2e-journey-l9-${RUN_ID}`;
+
+interface L9Fixtures {
+  domainId: string;
+  // Test 1 — 1 ACTIVE, modulesAuthored=true
+  callerSingleActiveId: string;
+  playbookAuthoredId: string;
+  // Test 2 — 2 ACTIVE enrollments, different enrolledAt
+  callerMultiActiveId: string;
+  playbookOlderId: string;
+  playbookNewerId: string;
+  // Test 3 — 0 ACTIVE enrollments
+  callerNoEnrollmentId: string;
+  // Test 4 — 1 ACTIVE on modulesAuthored=false
+  callerSingleUnauthoredId: string;
+  playbookUnauthoredId: string;
+}
+
+let fixtures: L9Fixtures;
+
+async function ensurePlaybook(
+  name: string,
+  domainId: string,
+  modulesAuthored: boolean,
+  modules: Array<{ id: string; label: string }> | null,
+): Promise<{ id: string }> {
+  return prisma.playbook.create({
+    data: {
+      name,
+      description: `L9 integration test playbook (${name})`,
+      domainId,
+      status: "PUBLISHED",
+      publishedAt: new Date(),
+      config: {
+        ...(modulesAuthored ? { modulesAuthored: true } : { modulesAuthored: false }),
+        ...(modules ? { modules } : {}),
+      },
+    },
+    select: { id: true },
+  });
+}
+
+async function ensureCaller(
+  index: number,
+  domainId: string,
+  name: string,
+): Promise<{ id: string; externalId: string | null }> {
+  const externalId = `${PREFIX}-${index}-${name}`;
+  return prisma.caller.create({
+    data: {
+      externalId,
+      name: `L9 Test ${name}`,
+      phone: `+1-555-${String(index).padStart(3, "0")}-L9XX`,
+      domainId,
+      role: "LEARNER",
+      // userId intentionally left null — these are sim-only callers, not
+      // portal users; setting a non-existent userId crashes the FK
+      // (educator-journey landmine 2026-05-27).
+    },
+    select: { id: true, externalId: true },
+  });
+}
+
+beforeAll(async () => {
+  // 1. Single integration-test domain (shared across all test cases).
+  const domain = await prisma.domain.upsert({
+    where: { slug: `${PREFIX}-domain` },
+    create: {
+      slug: `${PREFIX}-domain`,
+      name: "L9 Integration Test Domain",
+      description: "Owned by learner-picker-reachability.integration.test.ts. Auto-deleted at end of suite.",
+      isActive: true,
+    },
+    update: {},
+  });
+
+  // 2. Three playbooks: authored (4 modules), authored older + authored newer (multi-enrollment case), unauthored.
+  const playbookAuthored = await ensurePlaybook(
+    `${PREFIX}-authored-pb`,
+    domain.id,
+    true,
+    [
+      { id: "part1", label: "Part 1: Familiar Topics" },
+      { id: "part2", label: "Part 2: Long Turn" },
+      { id: "part3", label: "Part 3: Discussion" },
+      { id: "review", label: "Part 4: Review" },
+    ],
+  );
+  const playbookOlder = await ensurePlaybook(
+    `${PREFIX}-older-pb`,
+    domain.id,
+    true,
+    [{ id: "m1", label: "Older Module" }],
+  );
+  const playbookNewer = await ensurePlaybook(
+    `${PREFIX}-newer-pb`,
+    domain.id,
+    true,
+    [{ id: "m1", label: "Newer Module" }],
+  );
+  const playbookUnauthored = await ensurePlaybook(
+    `${PREFIX}-unauthored-pb`,
+    domain.id,
+    false,
+    null,
+  );
+
+  // 3. Four callers — one per L9 shape.
+  const callerSingleActive = await ensureCaller(1, domain.id, "single-active");
+  const callerMultiActive = await ensureCaller(2, domain.id, "multi-active");
+  const callerNoEnrollment = await ensureCaller(3, domain.id, "no-enrollment");
+  const callerSingleUnauthored = await ensureCaller(4, domain.id, "single-unauthored");
+
+  // 4. Enrollments.
+  // 4a — Test 1: 1 ACTIVE on authored playbook.
+  await prisma.callerPlaybook.create({
+    data: {
+      callerId: callerSingleActive.id,
+      playbookId: playbookAuthored.id,
+      status: "ACTIVE",
+      enrolledBy: PREFIX,
+      isDefault: true,
+    },
+  });
+
+  // 4b — Test 2: 2 ACTIVE, different enrolledAt.
+  // Insert "older" first with explicit older enrolledAt, then "newer".
+  const olderEnrolledAt = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
+  const newerEnrolledAt = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000); // 1 day ago
+  await prisma.callerPlaybook.create({
+    data: {
+      callerId: callerMultiActive.id,
+      playbookId: playbookOlder.id,
+      status: "ACTIVE",
+      enrolledBy: PREFIX,
+      enrolledAt: olderEnrolledAt,
+    },
+  });
+  await prisma.callerPlaybook.create({
+    data: {
+      callerId: callerMultiActive.id,
+      playbookId: playbookNewer.id,
+      status: "ACTIVE",
+      enrolledBy: PREFIX,
+      enrolledAt: newerEnrolledAt,
+      isDefault: true,
+    },
+  });
+
+  // 4c — Test 3: zero enrollments (intentionally empty).
+
+  // 4d — Test 4: 1 ACTIVE on unauthored playbook.
+  await prisma.callerPlaybook.create({
+    data: {
+      callerId: callerSingleUnauthored.id,
+      playbookId: playbookUnauthored.id,
+      status: "ACTIVE",
+      enrolledBy: PREFIX,
+      isDefault: true,
+    },
+  });
+
+  fixtures = {
+    domainId: domain.id,
+    callerSingleActiveId: callerSingleActive.id,
+    playbookAuthoredId: playbookAuthored.id,
+    callerMultiActiveId: callerMultiActive.id,
+    playbookOlderId: playbookOlder.id,
+    playbookNewerId: playbookNewer.id,
+    callerNoEnrollmentId: callerNoEnrollment.id,
+    callerSingleUnauthoredId: callerSingleUnauthored.id,
+    playbookUnauthoredId: playbookUnauthored.id,
+  };
+});
+
+afterAll(async () => {
+  // FK-safe cleanup — children first.
+  const callerIds = [
+    fixtures.callerSingleActiveId,
+    fixtures.callerMultiActiveId,
+    fixtures.callerNoEnrollmentId,
+    fixtures.callerSingleUnauthoredId,
+  ];
+  const playbookIds = [
+    fixtures.playbookAuthoredId,
+    fixtures.playbookOlderId,
+    fixtures.playbookNewerId,
+    fixtures.playbookUnauthoredId,
+  ];
+
+  await prisma.callerPlaybook.deleteMany({ where: { callerId: { in: callerIds } } });
+  await prisma.composedPrompt.deleteMany({ where: { callerId: { in: callerIds } } });
+  await prisma.caller.deleteMany({ where: { id: { in: callerIds } } });
+  await prisma.playbook.deleteMany({ where: { id: { in: playbookIds } } });
+  await prisma.domain.deleteMany({ where: { id: fixtures.domainId } });
+  await prisma.$disconnect();
+});
+
+describe("#948 / L9 — learner-picker-reachability (integration)", () => {
+  it("Test 1 — 1 ACTIVE enrollment on modulesAuthored=true → resolver returns that playbookId", async () => {
+    const result = await resolveActivePlaybookId(fixtures.callerSingleActiveId);
+
+    expect(result).toBe(fixtures.playbookAuthoredId);
+
+    // Confirm the downstream banner-gating data is present (the page would
+    // fetch /api/playbooks/[id] to read this). We assert directly off the
+    // DB row to keep the test DB-only.
+    const playbook = await prisma.playbook.findUnique({
+      where: { id: result! },
+      select: { config: true },
+    });
+    expect(playbook).not.toBeNull();
+    const config = playbook!.config as { modulesAuthored?: boolean; modules?: unknown[] };
+    expect(config.modulesAuthored).toBe(true);
+    expect(Array.isArray(config.modules)).toBe(true);
+    expect((config.modules as unknown[]).length).toBe(4);
+  });
+
+  it("Test 2 — 2 ACTIVE enrollments → resolver picks the more recent (most-recently-enrolled wins)", async () => {
+    const result = await resolveActivePlaybookId(fixtures.callerMultiActiveId);
+
+    expect(result).toBe(fixtures.playbookNewerId);
+    expect(result).not.toBe(fixtures.playbookOlderId);
+  });
+
+  it("Test 3 — 0 ACTIVE enrollments → resolver returns null (not crash, not undefined)", async () => {
+    const result = await resolveActivePlaybookId(fixtures.callerNoEnrollmentId);
+
+    expect(result).toBeNull();
+  });
+
+  it("Test 4 — 1 ACTIVE on modulesAuthored=false → resolver returns playbookId; downstream banner gating handles modulesAuthored separately", async () => {
+    const result = await resolveActivePlaybookId(fixtures.callerSingleUnauthoredId);
+
+    expect(result).toBe(fixtures.playbookUnauthoredId);
+
+    // Confirm the banner WOULD NOT fire — modulesAuthored=false. The
+    // resolver is correct (returns the playbookId), the page's downstream
+    // conditional is what suppresses the banner. Both behaviours are part
+    // of the L9 contract: resolver doesn't gate on modulesAuthored; page
+    // does.
+    const playbook = await prisma.playbook.findUnique({
+      where: { id: result! },
+      select: { config: true },
+    });
+    expect(playbook).not.toBeNull();
+    const config = playbook!.config as { modulesAuthored?: boolean };
+    expect(config.modulesAuthored).toBe(false);
+  });
+
+  it("URL override branch — wins even when enrollments differ (deep-link semantics)", async () => {
+    // Caller is enrolled in playbookAuthored only, but we pass a different
+    // id as the override. The override wins per L9 step 1.
+    const result = await resolveActivePlaybookId(
+      fixtures.callerSingleActiveId,
+      fixtures.playbookOlderId,
+    );
+
+    expect(result).toBe(fixtures.playbookOlderId);
+    expect(result).not.toBe(fixtures.playbookAuthoredId);
+  });
+});

--- a/apps/admin/tests/lib/caller/resolve-active-playbook.test.ts
+++ b/apps/admin/tests/lib/caller/resolve-active-playbook.test.ts
@@ -1,0 +1,218 @@
+/**
+ * #948 — L9 chain contract: learner-facing module-picker reachability.
+ *
+ * Acceptance criteria pinned by these tests (per the bank entry D003):
+ *   1. URL override always wins, even when enrollments differ.
+ *   2. 1 ACTIVE enrollment → that playbookId.
+ *   3. 2+ ACTIVE → most-recently-enrolled (sort by enrolledAt DESC).
+ *   4. 0 ACTIVE → null (NOT undefined, NOT a crash — page renders empty state).
+ *   5. Non-ACTIVE enrollments (PAUSED, COMPLETED, DROPPED) excluded from
+ *      the candidate pool (the SQL `where: { status: 'ACTIVE' }` filter does
+ *      this; we assert by spying on the prisma call).
+ *   6. Empty / undefined / null urlOverride → falls through to enrollment
+ *      branch (not treated as a literal override).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const findManyMock = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    callerPlaybook: { findMany: findManyMock },
+  },
+  db: () => ({ callerPlaybook: { findMany: findManyMock } }),
+}));
+
+beforeEach(() => {
+  findManyMock.mockReset();
+});
+
+describe("#948 / L9 — resolveActivePlaybookId", () => {
+  describe("URL override branch", () => {
+    it("returns the urlOverride verbatim when non-empty (single ACTIVE enrollment ignored)", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([
+        { playbookId: "enrolled-pb-1" },
+      ]);
+
+      const result = await resolveActivePlaybookId("caller-1", "url-pb-99");
+
+      expect(result).toBe("url-pb-99");
+      // Override wins — no DB read needed.
+      expect(findManyMock).not.toHaveBeenCalled();
+    });
+
+    it("returns the urlOverride even when MULTIPLE ACTIVE enrollments exist", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([
+        { playbookId: "enrolled-pb-1" },
+        { playbookId: "enrolled-pb-2" },
+      ]);
+
+      const result = await resolveActivePlaybookId("caller-1", "deep-link-pb");
+
+      expect(result).toBe("deep-link-pb");
+      expect(findManyMock).not.toHaveBeenCalled();
+    });
+
+    it("returns the urlOverride even when ZERO active enrollments exist (legit preview deep-link)", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([]);
+
+      const result = await resolveActivePlaybookId("caller-1", "preview-pb");
+
+      expect(result).toBe("preview-pb");
+      expect(findManyMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Empty / nullish urlOverride falls through", () => {
+    it("treats undefined urlOverride as 'no override' and reads enrollments", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([{ playbookId: "enrolled-pb-1" }]);
+
+      const result = await resolveActivePlaybookId("caller-1", undefined);
+
+      expect(result).toBe("enrolled-pb-1");
+      expect(findManyMock).toHaveBeenCalledOnce();
+    });
+
+    it("treats null urlOverride as 'no override' and reads enrollments", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([{ playbookId: "enrolled-pb-1" }]);
+
+      const result = await resolveActivePlaybookId("caller-1", null);
+
+      expect(result).toBe("enrolled-pb-1");
+      expect(findManyMock).toHaveBeenCalledOnce();
+    });
+
+    it("treats empty-string urlOverride as 'no override' and reads enrollments", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([{ playbookId: "enrolled-pb-1" }]);
+
+      const result = await resolveActivePlaybookId("caller-1", "");
+
+      expect(result).toBe("enrolled-pb-1");
+      expect(findManyMock).toHaveBeenCalledOnce();
+    });
+
+    it("omitted urlOverride argument falls through to enrollments", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([{ playbookId: "enrolled-pb-1" }]);
+
+      const result = await resolveActivePlaybookId("caller-1");
+
+      expect(result).toBe("enrolled-pb-1");
+      expect(findManyMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("Enrollment fallback branch — SQL filter shape", () => {
+    it("scopes the findMany call to callerId + status=ACTIVE + ordered by enrolledAt DESC", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([{ playbookId: "pb-1" }]);
+
+      await resolveActivePlaybookId("caller-xyz");
+
+      expect(findManyMock).toHaveBeenCalledWith({
+        where: { callerId: "caller-xyz", status: "ACTIVE" },
+        orderBy: { enrolledAt: "desc" },
+        select: { playbookId: true },
+      });
+    });
+  });
+
+  describe("Enrollment fallback branch — pick rules", () => {
+    it("1 ACTIVE enrollment → returns that playbookId", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([{ playbookId: "single-pb" }]);
+
+      const result = await resolveActivePlaybookId("caller-1");
+
+      expect(result).toBe("single-pb");
+    });
+
+    it("2+ ACTIVE → returns most-recently-enrolled (prisma returns DESC; index 0 wins)", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      // The helper relies on `orderBy: { enrolledAt: 'desc' }` to surface
+      // the newest at index 0 — so the mock returns rows in that order.
+      findManyMock.mockResolvedValue([
+        { playbookId: "newest-pb" },     // most-recently enrolled
+        { playbookId: "older-pb" },
+        { playbookId: "oldest-pb" },
+      ]);
+
+      const result = await resolveActivePlaybookId("caller-1");
+
+      expect(result).toBe("newest-pb");
+    });
+
+    it("0 ACTIVE → null (never undefined, never a crash)", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([]);
+
+      const result = await resolveActivePlaybookId("caller-orphan");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("Non-ACTIVE statuses excluded from candidate pool", () => {
+    it("PAUSED / COMPLETED / DROPPED rows do not reach the helper because the SQL filter excludes them", async () => {
+      // The `where: { status: 'ACTIVE' }` clause is what does the filtering
+      // server-side. Verify by passing only ACTIVE rows to the helper (as
+      // Prisma would) AND asserting the where clause carries the filter.
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      findManyMock.mockResolvedValue([{ playbookId: "active-pb" }]);
+
+      const result = await resolveActivePlaybookId("caller-mixed");
+
+      // Helper picked the ACTIVE row (PAUSED/COMPLETED never returned by SQL).
+      expect(result).toBe("active-pb");
+      // And the SQL guarantees the filter applies.
+      expect(findManyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: "ACTIVE" }),
+        }),
+      );
+    });
+
+    it("returns null when EVERY enrollment is non-ACTIVE (SQL returns empty)", async () => {
+      const { resolveActivePlaybookId } = await import(
+        "@/lib/caller/resolve-active-playbook"
+      );
+      // In real life prisma would return [] because the WHERE filters them.
+      findManyMock.mockResolvedValue([]);
+
+      const result = await resolveActivePlaybookId("caller-all-paused");
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -2415,6 +2415,23 @@ Update a call action (status, notes, assignee, priority, dueAt).
 
 ---
 
+### `GET` /api/callers/:callerId/active-playbook
+
+Resolve the active playbookId for a caller via the canonical
+
+**Auth**: Session · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | The caller ID |
+
+**Response** `200`
+```json
+{ ok: true, playbookId: string | null }
+```
+
+---
+
 ### `GET` /api/callers/:callerId/aggregate
 
 Get available AGGREGATE specs for a caller. Returns all active specs with outputType AGGREGATE that can be run.
@@ -14554,8 +14571,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 456 |
-| Files with annotations | 455 |
+| Route files found | 457 |
+| Files with annotations | 456 |
 | Files missing annotations | 1 |
 | Coverage | 99.8% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -648,6 +648,23 @@ Update a call action (status, notes, assignee, priority, dueAt).
 
 ---
 
+### `GET` /api/v1/callers/:callerId/active-playbook
+
+Resolve the active playbookId for a caller via the canonical
+
+**Auth**: Session · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | The caller ID |
+
+**Response** `200`
+```json
+{ ok: true, playbookId: string | null }
+```
+
+---
+
 ### `GET` /api/v1/callers/:callerId/aggregate
 
 Get available AGGREGATE specs for a caller. Returns all active specs with outputType AGGREGATE that can be run.

--- a/docs/CHAIN-CONTRACTS.md
+++ b/docs/CHAIN-CONTRACTS.md
@@ -280,6 +280,31 @@ The links above cover pipeline-internal (3) and authoring-time (3a) boundaries. 
 
 ---
 
+### Link L9 — Learner-Facing Module Picker Reachability
+
+**Every learner-facing page that mounts a session on a Playbook with `config.modulesAuthored = true` MUST resolve the active `playbookId` before rendering the chat surface.** Resolution falls back through:
+
+1. `?playbookId=` URL param (deep-link from picker, wizard, etc.)
+2. The caller's single ACTIVE `CallerPlaybook` enrollment
+3. The caller's most-recently-enrolled ACTIVE playbook (`orderBy: enrolledAt desc`)
+
+A page that mounts without a resolved `playbookId` either renders a learner-readable "no enrollment" empty state OR is unreachable from learner navigation. **Never** a silent no-op (no banner, no picker, no error).
+
+| Field | Value |
+|---|---|
+| **Producer** | The fallback chain itself — implemented as the shared resolver `apps/admin/lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId(callerId, urlOverride?)` and its API wrapper `app/api/callers/[callerId]/active-playbook/route.ts`. Single source of truth for the L9 pick rule. |
+| **Consumer** | Every learner-facing page that mounts a chat / call surface on a Playbook. Today: `apps/admin/app/x/sim/[callerId]/page.tsx`. Future: any new `/x/sim/**` or `/x/student/**` page that reads `?playbookId=` and renders module-aware UI. |
+| **Defends against** | The silent-reachability class of bug exemplified by #948 / PR #947: a learner deep-links into `/x/sim/[callerId]` without `?playbookId=`, the page reads URL only, `playbookId` stays `undefined`, the downstream playbook fetch never fires, `modulesAuthored` stays `false`, and the module-picker banner conditional silently no-ops — even though the learner has exactly one ACTIVE enrollment on a playbook with an authored module catalogue. No banner, no error, no entry to the picker. |
+| **Invariant** | A learner with at least one ACTIVE enrollment lands on a page that resolves `playbookId` from enrollments when the URL didn't pass one. A learner with zero ACTIVE enrollments lands on a page that renders an explicit empty state. There is no third "page silently mounts with no picker and no error" outcome. |
+| **Enforcement** | Three layers: (1) **Shared helper** — `lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId` is the canonical pick rule; the admin-side `CallerDetailPage.tsx:386-401` carries an inline copy with a JSDoc note pinning it to the helper (must stay byte-identical). (2) **API wrapper** — `/api/callers/[callerId]/active-playbook` so client-side learner pages have a single endpoint instead of duplicating the resolver in React effects. (3) **`.claude/agents/arch-checker.md` Check G** — static check across `apps/admin/app/x/sim/**/page.tsx` + `apps/admin/app/x/student/**/page.tsx`: any file that reads `searchParams.get('playbookId')` MUST also use the helper or hit the endpoint. Soft warning today; promote to error once no violations remain. |
+| **Test** | `apps/admin/tests/lib/caller/resolve-active-playbook.test.ts` (13 cases — URL override always wins; 1/2+/0 ACTIVE branches; non-ACTIVE excluded; SQL shape pin; nullish-override fall-through). `apps/admin/tests/integration/journey/learner-picker-reachability.integration.test.ts` (live-DB end-to-end on 4 caller shapes). |
+| **DataContract slug** | None — the contract is the shape of the pick rule, not the shape of a DB row. (If a third learner-facing surface ever needs the rule with a different scope, this becomes a candidate for `LEARNER_SESSION_MOUNT_V1`.) |
+| **Memory doc** | This row; JSDoc at `lib/caller/resolve-active-playbook.ts`; `docs/TEST-BANK.md` entries D003 (unit) + D004 (integration). |
+| **Related** | #947 (the fix that exposed the gap) · #948 (this follow-up that pins the contract) · `docs/TEST-BANK.md` D003 + D004. |
+| **Reinforced by** | #948 — this PR. |
+
+---
+
 ## 4. DataContract registry
 
 The runtime DataContract registry (`lib/contracts/`) is the DB-backed source of truth for storage-key patterns. Contract files live in `apps/admin/docs-archive/bdd-specs/contracts/` and are seeded into `DataContract` rows on `db:seed`.
@@ -323,6 +348,8 @@ If a chain row above references "DataContract slug: implicit" and the contract i
 | TBD  | #819 | 3 (sub-contract) | PUT /api/courses/[id]/design fans out recompose-all when COMPOSE-affecting namespaces change — closes the stale-prompt-after-tuner-save gap |
 | #920 | #917 | 3c | New learner-facing API + SimProgressPanel "Today's call" section; sanitizer + multi-curriculum + stale guards |
 | #924 | #923 | 3c | Scheduler reason copy constants module + regression test against log-prefixed reasons |
+| #947 | #948 (fix) | L9 | `/x/sim/[callerId]` auto-resolves playbookId from caller's enrollments when URL has none |
+| TBD  | #948 (this PR) | L9 | Chain contract + shared `resolveActivePlaybookId` helper + `/api/callers/[id]/active-playbook` endpoint + arch-checker Check G + integration journey test |
 
 ---
 
@@ -351,6 +378,7 @@ If a chain row above references "DataContract slug: implicit" and the contract i
 
 | Date | Change |
 |---|---|
+| 2026-05-27 | **Link L9 added — learner-facing module-picker reachability (#948).** Pins the silent-reachability invariant exposed by PR #947's `/x/sim` fix. Every learner-facing page that mounts a session on a Playbook MUST resolve `playbookId` via the canonical fallback (URL → single ACTIVE enrollment → most-recently enrolled ACTIVE → empty state). Shared helper at `lib/caller/resolve-active-playbook.ts` + API wrapper at `/api/callers/[id]/active-playbook` + arch-checker Check G (soft warn) + integration journey test on 4 caller shapes + 13-case vitest. Defends against a learner deep-linking into the sim view, missing the picker silently, and being unable to focus a session. |
 | 2026-05-27 | **Section 3c added — learner-surfacing contracts. Link L1: scheduler → learner (PRs #920 (#917 Slice 2) + #924 (#923 writer copy)).** First pipeline→learner contract boundary: scheduler `reason` field, written to `CallerAttribute` during COMPOSE, exposed via `GET /api/student/scheduler-decision` and rendered in SimProgressPanel. Five-layer enforcement (writer copy constants + build-time regression + route sanitizer + strict response shape + multi-curriculum/stale guards). Known gap #919 (multi-curriculum writer key shape) documented at read-time guard, pending writer-side fix. |
 | 2026-05-23 | Initial canonical inventory created post-Epic 100 (#616). Captures the 6 chain links + active DataContract slugs + the 13 Epic 100 PRs that reinforced them. |
 | 2026-05-26 | **Link 3a added — authoring-side read parity (#910 / epic #909).** Sister contract to Link 3 FK invariant. Any UI surface displaying a scope-cascaded value must read through `lib/tolerance/resolve-tolerance.ts` (or the bulk wrapper landing in #911). Ad-hoc two-endpoint cascade-merge in components is forbidden. New audit counter `authoringBehTargetBypassCount` (CI step 6) — today 1 (`PromptTunerSidebar.tsx`, fixed by #911); target 0. Arch-checker Check F enforces at review time (soft warning, promoted to error once #911 lands). Caught empirically 2026-05-26 — sidebar showed course-level value after a learner-scope save because the in-component merge ignored the separately-fetched learner overrides. |

--- a/docs/TEST-BANK.md
+++ b/docs/TEST-BANK.md
@@ -130,23 +130,39 @@ Mixing tags is fine. `describe("buildLoMasteryMap (#928 scoping helper)", ...)` 
 
 ---
 
-### 004 — `/x/sim/[callerId]` auto-resolves playbookId from enrollments
-
-> **Status:** ❌ NOT YET WRITTEN. Filed as part of #948 follow-up.
-> The fix shipped in #947 has no isolated test — the resolution lives in a React effect.
-> Tracking issue lists the work: extract `lib/caller/resolve-active-playbook.ts` helper, unit-test the pick rule, then this entry becomes a green unit-level proof.
+### 003 — `resolveActivePlaybookId` L9 fallback chain
 
 | Field | Value |
 |---|---|
-| **File** | `apps/admin/tests/lib/caller/resolve-active-playbook.test.ts` *(to be created)* |
-| **Subject** | `apps/admin/lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId` *(to be extracted from `app/x/sim/[callerId]/page.tsx` + `CallerDetailPage:386-398`)* |
-| **Defends** | L9 — learner-facing module-picker reachability. Every page that mounts a session on a Playbook with `modulesAuthored=true` MUST resolve the active `playbookId` before rendering, falling back through: URL → caller's single ACTIVE enrollment → most-recently-enrolled ACTIVE. |
-| **Issue / origin** | [#948](https://github.com/WANDERCOLTD/HF/issues/948) — file-able follow-up to the `/x/sim` picker-missing bug fix (#947). |
-| **Failure mode it pins** | Brand-new learner enrolled in IELTS Speaking Practice (4 authored modules) opens `/x/sim/[callerId]` without `?playbookId=...`. Pre-fix: no banner, no header icon, no entry to the picker — learner silently routed to an unfocused session. |
-| **What it should prove** | 1 ACTIVE enrollment → that playbookId; 2+ ACTIVE → most-recently-enrolled (sorted desc by `enrolledAt`); 0 ACTIVE → null; URL override always wins over enrollment lookup; non-ACTIVE enrollments (PAUSED/ENDED) excluded from the candidate pool. |
-| **Status** | 🔴 not yet implemented |
+| **File** | `apps/admin/tests/lib/caller/resolve-active-playbook.test.ts` |
+| **Subject** | `apps/admin/lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId` |
+| **Defends** | L9 — learner-facing module-picker reachability. Every page that mounts a session on a Playbook MUST resolve the active `playbookId` before rendering, falling back through: URL → caller's single ACTIVE enrollment → most-recently-enrolled ACTIVE → null (empty state, never silent no-op). |
+| **Issue / origin** | [#948](https://github.com/WANDERCOLTD/HF/issues/948) — pins the contract introduced in PR #947 (fix) as a reusable helper + unit test. |
+| **Failure mode it pins** | Brand-new learner enrolled in IELTS Speaking Practice (4 authored modules) opens `/x/sim/[callerId]` without `?playbookId=...`. Pre-fix: no banner, no header icon, no entry to the picker — learner silently routed to an unfocused session. The next learner-facing page that reads `searchParams.get('playbookId')` without the helper would re-open the trapdoor. |
+| **What it proves** | 13 properties: URL override always wins (1 ACTIVE / 2+ ACTIVE / 0 ACTIVE — all 3 cases); undefined/null/empty-string/omitted urlOverride falls through to enrollment branch (4 cases); SQL shape pin — findMany called with `where: { callerId, status: 'ACTIVE' }`, `orderBy: { enrolledAt: 'desc' }`, `select: { playbookId: true }`; 1 ACTIVE → that playbookId; 2+ ACTIVE → most-recently-enrolled (prisma returns DESC, helper picks index 0); 0 ACTIVE → null (not undefined, not crash); non-ACTIVE statuses excluded by SQL filter (PAUSED/COMPLETED/DROPPED don't reach the helper); empty result → null. |
+| **How to run** | `cd apps/admin && npx vitest run tests/lib/caller/resolve-active-playbook.test.ts` |
+| **When to re-run** | Any change to `lib/caller/resolve-active-playbook.ts`, the inline pick logic at `components/callers/CallerDetailPage.tsx:386-401` (must stay byte-identical to the helper), the active-playbook endpoint route, or the `/x/sim/[callerId]/page.tsx` resolver wiring. |
+| **Status** | ✅ green (13/13, 2026-05-27) |
 | **Owner area** | Caller / Sim / Learner-Facing UX |
-| **Related** | `#929` (separate Start Over fix) · `#940` (perpetrator that exposed the gap) · `arch-checker` rule pending |
+| **Related** | `#947` (the fix that exposed the gap) · `#948` (this contract pin) · entry 004 (live-DB integration sibling) · `docs/CHAIN-CONTRACTS.md` Link L9 · `.claude/agents/arch-checker.md` Check G (planned) · `docs/arch-check-g-learner-page-playbook-resolution.md` (Check G rule statement, written here because the agent file is currently write-protected) |
+
+---
+
+### 004 — Learner picker reachability — live-DB integration
+
+| Field | Value |
+|---|---|
+| **File** | `apps/admin/tests/integration/journey/learner-picker-reachability.integration.test.ts` |
+| **Subject** | `apps/admin/lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId` against the live VM DB (DB-only, no server). |
+| **Defends** | L9 — learner-facing module-picker reachability, proved end-to-end on real DB rows. Sibling to bank entry 003 (unit-level proof). |
+| **Issue / origin** | [#948](https://github.com/WANDERCOLTD/HF/issues/948) — same contract as 003; this entry pins the integration view. |
+| **Failure mode it pins** | Same class as 003 — but proven against real Prisma + real DB rows (per-run unique prefix + FK-safe cleanup) rather than a mocked findMany. Defends against schema-level regressions that the unit test's mock wouldn't catch (e.g. an enum rename of `CallerPlaybook.status`, an `enrolledAt` semantic change, a FK constraint addition). |
+| **What it proves** | 5 properties on 4 caller shapes: (1) 1 ACTIVE on `modulesAuthored=true` playbook → resolver returns that playbookId AND playbook config carries `modulesAuthored=true` + 4 modules (banner-data invariant); (2) 2 ACTIVE enrollments with different `enrolledAt` (7d ago vs 1d ago) → resolver picks the newer; (3) 0 ACTIVE → resolver returns null (no crash); (4) 1 ACTIVE on `modulesAuthored=false` → resolver still returns playbookId, downstream config confirms `modulesAuthored=false` (resolver doesn't gate on it; page does); (5) URL override wins over enrollment even when the override targets a different playbook. |
+| **How to run** | `cd apps/admin && npm run test:integration -- tests/integration/journey/learner-picker-reachability.integration.test.ts` |
+| **When to re-run** | Same as entry 003, plus: any schema migration touching `Caller` / `CallerPlaybook` / `Playbook.config`; any change to FK constraints affecting `CallerPlaybook` rows. |
+| **Status** | 🟢 written, awaiting first live-DB run on hf-dev (2026-05-27) |
+| **Owner area** | Caller / Sim / Learner-Facing UX |
+| **Related** | Bank entry 003 (unit-level sibling) · `docs/CHAIN-CONTRACTS.md` Link L9 · `tests/integration/journey/fixtures.ts` (shared journey pattern) · `educator-journey.integration.test.ts:406` (FK landmine documented in the test file header) |
 
 ---
 

--- a/docs/arch-check-g-learner-page-playbook-resolution.md
+++ b/docs/arch-check-g-learner-page-playbook-resolution.md
@@ -1,0 +1,78 @@
+# Arch-Check G — Learner-Facing Page Playbook Resolution (L9)
+
+> Static check + path-scoped rule for `apps/admin/app/x/sim/**/page.tsx` and `apps/admin/app/x/student/**/page.tsx`. Add to `arch-checker.md` Step 2 as Check G when that file is editable; until then this doc IS the canonical statement of the rule and the arch-checker should consult it inline when checking learner-facing page diffs.
+
+## The invariant being defended
+
+Every learner-facing page that mounts a session on a Playbook MUST resolve `playbookId` via the canonical L9 fallback chain:
+
+1. `?playbookId=` URL param (deep-link from picker, wizard, etc.)
+2. The caller's single ACTIVE `CallerPlaybook` enrollment
+3. The caller's most-recently-enrolled ACTIVE playbook (`orderBy: enrolledAt desc`)
+4. `null` → render a learner-readable empty state (NOT a silent no-op)
+
+See `docs/CHAIN-CONTRACTS.md` Link L9 for the contract details.
+
+## The detection step
+
+For any change under `apps/admin/app/x/sim/**/page.tsx` OR `apps/admin/app/x/student/**/page.tsx` that reads `searchParams.get('playbookId')`:
+
+```bash
+# Find every learner-facing page reading the URL param:
+grep -rn "searchParams.get(['\"]playbookId['\"])" \
+  apps/admin/app/x/sim apps/admin/app/x/student 2>/dev/null
+```
+
+For each matching file, the same file MUST ALSO contain either:
+
+- An import of `resolveActivePlaybookId` from `@/lib/caller/resolve-active-playbook` (server-side resolution), OR
+- A fetch to `/api/callers/[...]/active-playbook` (client-side resolution via the API wrapper).
+
+```bash
+# Verify each matching learner-facing page also uses the helper or endpoint:
+grep -E "resolveActivePlaybookId|/api/callers/.*active-playbook" <file>
+```
+
+## The fail signal
+
+If a learner-facing page reads the URL param without using the helper or endpoint, emit a **FAIL** with the file path, the line number of the URL read, and this one-line remediation:
+
+> *"Use `resolveActivePlaybookId(callerId, searchParams.get('playbookId'))` server-side, or `fetch('/api/callers/<id>/active-playbook?playbookId=<override>')` client-side. See `docs/CHAIN-CONTRACTS.md` Link L9 — every learner-facing page MUST resolve `playbookId` via the canonical fallback chain (URL → single ACTIVE enrollment → most-recently enrolled ACTIVE → null). Silent no-ops are forbidden."*
+
+## What FAILs the rule
+
+Hard fail (not a soft warning — silent no-ops on learner surfaces are the failure mode this defends against; there is no grace window):
+
+- New learner-facing page under `/x/sim/**` or `/x/student/**` that reads `searchParams.get('playbookId')` without the helper / endpoint
+- Refactor that drops the helper / endpoint but keeps the URL read
+- A new helper that hides the URL read behind a wrapper which itself doesn't go through `resolveActivePlaybookId`
+
+## Scope notes
+
+- Pages OUTSIDE `/x/sim/**` and `/x/student/**` are NOT learner-facing — this check does not apply (e.g. `apps/admin/components/callers/CallerDetailPage.tsx` is admin UI; the inline auto-pick logic at lines 386-401 there is acceptable but carries a JSDoc note keeping it byte-identical to the helper).
+- A page that does NOT read `searchParams.get('playbookId')` is not in scope (pages that derive `playbookId` purely from session context or route params don't need the URL-fallback chain).
+
+## Rationale
+
+Caught empirically by #947 / #948. Pre-fix, `/x/sim/[callerId]` showed no module picker, no banner, no error when a learner deep-linked without `?playbookId=`, because the page read only the URL and the playbook fetch never fired. The shared helper + this static check prevent the same trapdoor from re-opening on the next learner-facing page.
+
+## Manual verification — broken-page sanity check
+
+To prove the rule actually catches violations, drop this snippet temporarily into a learner-facing page (DO NOT commit):
+
+```tsx
+// @ts-expect-error — DO NOT COMMIT — rule self-test only
+const playbookId = searchParams.get('playbookId');
+// (no import of resolveActivePlaybookId, no fetch to /active-playbook)
+```
+
+Run the detection commands above — the first `grep` should match the new file, the second `grep` against that file should return no match, and the rule should FAIL. Delete the snippet before committing.
+
+## Related
+
+- `lib/caller/resolve-active-playbook.ts` — canonical helper.
+- `app/api/callers/[callerId]/active-playbook/route.ts` — API wrapper.
+- `tests/lib/caller/resolve-active-playbook.test.ts` — 13-case unit test (`docs/TEST-BANK.md` D003).
+- `tests/integration/journey/learner-picker-reachability.integration.test.ts` — live-DB end-to-end (`docs/TEST-BANK.md` D004).
+- `docs/CHAIN-CONTRACTS.md` Link L9 — contract row.
+- `.claude/agents/arch-checker.md` Checks A-F — sibling architectural checks (Check G belongs here logically; written into this doc because the agent file is currently write-protected from the worktree).


### PR DESCRIPTION
## Summary

Pins the L9 chain contract surfaced by PR #947's `/x/sim` fix. The fix patched the symptom (learner deep-linking into `/x/sim/[callerId]` showing no module picker); this PR pins the contract so the same trapdoor cannot re-open on the next learner-facing page.

Closes #948.

## What lands — 5 parts

**1. Chain contract (docs)** — `docs/CHAIN-CONTRACTS.md` Link L9. Every learner-facing page that mounts a session on a Playbook with `config.modulesAuthored=true` MUST resolve the active `playbookId` before rendering the chat surface. Fallback chain: `?playbookId=` URL param → caller's single ACTIVE enrollment → caller's most-recently enrolled ACTIVE playbook → null (learner-readable empty state, never silent no-op).

**2. Shared helper + API wrapper** — `apps/admin/lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId(callerId, urlOverride?)` (server-side Prisma). Wrapped by `app/api/callers/[callerId]/active-playbook/route.ts` (`requireAuth("VIEWER")`) so the existing client-side `/x/sim/[callerId]/page.tsx` can call it cleanly without changing the helper's signature. The sim page now uses the new endpoint instead of duplicating the pick rule in a React effect. `CallerDetailPage.tsx:386-401` left as-is (needs the FULL enrollment list for a separate UI surface) but carries a JSDoc note keeping the inline branches byte-identical to the helper.

**3. arch-checker Check G** — `docs/arch-check-g-learner-page-playbook-resolution.md`. The `.claude/agents/arch-checker.md` file is currently write-protected from this worktree, so the doc IS the canonical statement of Check G; copy/paste into the arch-checker's Step 2 block when that file is editable. Detects any file under `/x/sim/**/page.tsx` or `/x/student/**/page.tsx` that reads `searchParams.get('playbookId')` without ALSO using the helper or endpoint. Hard FAIL (not soft) — silent no-ops are the failure mode this defends against.

**4. Unit test (D003)** — `tests/lib/caller/resolve-active-playbook.test.ts`, 13 cases, all green:

- URL override always wins (1 / 2+ / 0 ACTIVE — 3 cases)
- Nullish urlOverride falls through (undefined / null / "" / omitted — 4 cases)
- SQL shape pin (where + orderBy + select)
- 1 ACTIVE → that playbookId
- 2+ ACTIVE → most-recently enrolled (Prisma returns DESC, index 0 wins)
- 0 ACTIVE → null (not undefined, not crash)
- Non-ACTIVE statuses excluded by SQL filter

**5. Integration test (D004) + bank entries** — `tests/integration/journey/learner-picker-reachability.integration.test.ts`, 5 cases across 4 caller shapes against the live VM DB (DB-only, no server). Per-run unique `externalId` prefix + FK-safe `afterAll` cleanup. Avoids the `educator-journey.integration.test.ts:406` FK landmine (LEARNER callers get `userId: null`, not a non-existent string). `docs/TEST-BANK.md` D003 promoted from 🔴 placeholder to 🟢 (13/13 green); new D004 entry added.

## Verification

- Unit tests: `cd apps/admin && npx vitest run tests/lib/caller/resolve-active-playbook.test.ts` → **13/13 green**.
- Typecheck: zero new errors on any file I touched (pre-existing errors elsewhere on main are unchanged).
- Lint: zero errors on new + modified files; 3 pre-existing `no-explicit-any` warnings on `sim/page.tsx` lines I didn't touch.
- Arch-check G self-test: created a simulated broken page under `/tmp/arch-check-g-fail-test/app/x/sim/test-broken/page.tsx` reading the URL param without the helper; the rule's detection commands FAILed on it as expected; temp page deleted before commit. No test-page artefacts in the PR diff.
- Backward compat: existing fix flow on `/x/sim/[callerId]` (1 ACTIVE learner → blue "Pick a module" banner) still works because the endpoint returns the same playbookId the inline logic was deriving. `CallerDetailPage` enrollment fetch unchanged (just annotated).

## Test plan

- [x] Unit tests: 13/13 green
- [x] Typecheck: clean on new files
- [x] Lint: clean on new files
- [x] Arch-checker Check G: self-tested against a simulated broken page (FAILed as expected; temp page deleted)
- [x] Backward compat: existing sim + caller-detail pages preserve behaviour
- [ ] Integration test (D004): live DB — awaiting first run on hf-dev VM
- [ ] Manual: deep-link `/x/sim/<learner-with-1-IELTS-enrollment>` (no `?playbookId=`) on staging once Phase 4 is up; verify blue "Pick a module" banner renders

## Where to click to verify

The new endpoint is server-side glue with no UI of its own. To verify the user-visible behaviour:

1. Log in as a SUPERADMIN or as a LEARNER with an IELTS enrollment.
2. Navigate to `/x/sim/<learnerCallerId>` **with no query params** (intentionally omit `?playbookId=...`).
3. The blue **"Pick a module →"** banner must render with the 4 IELTS modules. Pre-#947 the banner was missing; this PR keeps that fix and pins it as a contract.

If the banner is missing for a single-ACTIVE-enrollment learner, the helper has a bug. If a deep-link with a different `?playbookId=<other>` is used, the URL must win and the page must render that playbook's modules.

## Out of scope

- Touching `/x/student/**` pages — none currently read `searchParams.get('playbookId')`, verified by grep.
- Refactoring `CallerDetailPage` beyond JSDoc annotations (it needs the full enrollment list for a separate UI surface).
- Promoting Check G to a hard CI lint rule — first run as a review-time check; promote once arch-checker.md is editable from worktrees.
- Staging deploy — operator's call.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>