### PR TITLE
fix(#966): mount H+letter chord runner globally; remove 3 per-page mounts

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -14,6 +14,7 @@ import { PendingChangesTrayProvider } from '@/hooks/use-pending-changes-tray';
 import { PendingChangesTray } from '@/components/shared/PendingChangesTray';
 import { HelpProvider } from '@/contexts/HelpContext';
 import { HelpOverlay } from '@/components/help/HelpOverlay';
+import { ChordShortcutProvider } from '@/contexts/ChordContext';
 import { ContentJobQueueProvider, ContentJobQueue } from '@/components/shared/ContentJobQueue';
 import EnvironmentBanner from '@/components/shared/EnvironmentBanner';
 import DynamicFavicon from '@/components/shared/DynamicFavicon';
@@ -416,11 +417,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                       <PendingChangesTrayProvider>
                         <ContentJobQueueProvider>
                           <TourOverlay />
-                          <PageErrorBoundary>
-                            <Suspense fallback={null}>
-                              <LayoutInner>{children}</LayoutInner>
-                            </Suspense>
-                          </PageErrorBoundary>
+                          {/* ChordShortcutProvider wraps the page tree so
+                              ChordHintBadge consumers anywhere downstream can
+                              read activePrefix from context. Floating widgets
+                              are deliberately outside — they don't render
+                              ChordHintBadge. (#966) */}
+                          <ChordShortcutProvider>
+                            <PageErrorBoundary>
+                              <Suspense fallback={null}>
+                                <LayoutInner>{children}</LayoutInner>
+                              </Suspense>
+                            </PageErrorBoundary>
+                          </ChordShortcutProvider>
                           {/* Floating widgets — outside PageErrorBoundary so they survive page crashes */}
                           <GlobalAssistant />
                           <HelpOverlay />

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -30,7 +30,6 @@ import { useEntityContext } from '@/contexts/EntityContext';
 import { EditableTitle } from '@/components/shared/EditableTitle';
 import { StatusBadge, DomainPill } from '@/src/components/shared/EntityPill';
 import { DraggableTabs, type TabDefinition } from '@/components/shared/DraggableTabs';
-import { useChordShortcut } from '@/hooks/useChordShortcut';
 import { ChordHintBadge } from '@/components/help/ChordHintBadge';
 import { TabWithHelp } from '@/components/help/TabWithHelp';
 import { getPageHelp, getEffectiveChords } from '@/lib/help/page-help';
@@ -165,9 +164,10 @@ export default function CourseDetailPage() {
   // #global-chords — getEffectiveChords merges page bindings with the
   // global nav chords (page wins on key collision). Lookup is route-
   // templated; pathname not needed.
+  // Runner moved to ChordShortcutProvider in app/layout.tsx (#966); page only
+  // computes the displayable chord list for ChordHintBadge.
   const pageHelp = useMemo(() => getPageHelp(`/x/courses/${courseId || ""}`), [courseId]);
   const effectiveChords = useMemo(() => getEffectiveChords(`/x/courses/${courseId || ""}`), [courseId]);
-  const { activePrefix: chordActivePrefix } = useChordShortcut(effectiveChords);
   const isOperator = ['OPERATOR', 'EDUCATOR', 'ADMIN', 'SUPERADMIN'].includes((session?.user?.role as string) || '');
   const { pushEntity, setPageContext } = useEntityContext();
   const { plural } = useTerminology();
@@ -1786,7 +1786,7 @@ export default function CourseDetailPage() {
           }}
         />
       )}
-      <ChordHintBadge activePrefix={chordActivePrefix} chords={effectiveChords} />
+      <ChordHintBadge chords={effectiveChords} />
     </div>
   );
 }

--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -5,7 +5,6 @@ import { FancySelect } from "@/components/shared/FancySelect";
 import type { FancySelectOption } from "@/components/shared/FancySelect";
 import { ConversationalWizard } from "../wizard/components/ConversationalWizard";
 import type { WizardInitialContext } from "../wizard/components/ConversationalWizard";
-import { useChordShortcut } from "@/hooks/useChordShortcut";
 import { ChordHintBadge } from "@/components/help/ChordHintBadge";
 import { getEffectiveChords } from "@/lib/help/page-help";
 import "./get-started-v5.css";
@@ -61,8 +60,9 @@ export function V5WizardWithSelector({
   const isSuperAdmin = userRole === "SUPERADMIN";
 
   // #688 — chord shortcuts (page-specific C=Exit + global nav chords).
+  // Runner moved to ChordShortcutProvider in app/layout.tsx (#966); page only
+  // computes the displayable chord list for ChordHintBadge.
   const wizardChords = getEffectiveChords("/x/get-started-v5");
-  const { activePrefix: chordActivePrefix } = useChordShortcut(wizardChords);
 
   // Fetch institution list on mount
   useEffect(() => {
@@ -233,7 +233,7 @@ export function V5WizardWithSelector({
         wizardVersion="v5"
         onStartOver={handleStartOver}
       />
-      <ChordHintBadge activePrefix={chordActivePrefix} chords={wizardChords} />
+      <ChordHintBadge chords={wizardChords} />
     </>
   );
 }

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -18,7 +18,6 @@ import './caller-detail-page.css';
 import './caller-detail/lens.css';
 import './caller-detail/prompt-tuner.css';
 import { useAssistant, useAssistantKeyboardShortcut } from "@/hooks/useAssistant";
-import { useChordShortcut } from "@/hooks/useChordShortcut";
 import { ChordHintBadge } from "@/components/help/ChordHintBadge";
 import { TabWithHelp } from "@/components/help/TabWithHelp";
 import { getPageHelp, getEffectiveChords } from "@/lib/help/page-help";
@@ -131,9 +130,10 @@ export default function CallerDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // #688 — chord shortcuts (H/G + key) for tab navigation + globals.
+  // Runner moved to ChordShortcutProvider in app/layout.tsx (#966); page only
+  // computes the displayable chord list for ChordHintBadge.
   const pageHelp = useMemo(() => getPageHelp(`/x/callers/${callerId}`), [callerId]);
   const effectiveChords = useMemo(() => getEffectiveChords(`/x/callers/${callerId}`), [callerId]);
-  const { activePrefix: chordActivePrefix } = useChordShortcut(effectiveChords);
 
   const [activeSection, _setActiveSection] = useState<SectionId>(initialTab);
   // Refs mirror the latest active tab + visible sections so the long-lived
@@ -1464,7 +1464,7 @@ export default function CallerDetailPage() {
       )}
       </div>{/* cdp-content */}
       </div>{/* cdp-body */}
-      <ChordHintBadge activePrefix={chordActivePrefix} chords={effectiveChords} />
+      <ChordHintBadge chords={effectiveChords} />
     </div>
   );
 }

--- a/apps/admin/components/help/ChordHintBadge.tsx
+++ b/apps/admin/components/help/ChordHintBadge.tsx
@@ -3,10 +3,9 @@
 import React from "react";
 import "./chord-hint-badge.css";
 import type { ChordBinding } from "@/lib/help/page-help";
+import { useChordContext } from "@/contexts/ChordContext";
 
 interface ChordHintBadgeProps {
-  /** "H" or "G" while a chord is armed; null otherwise. */
-  activePrefix: string | null;
   /**
    * #752 — optional list of available chord bindings at the current location.
    * When provided, the badge renders each `[letter] — label` so users can
@@ -20,13 +19,17 @@ interface ChordHintBadgeProps {
  * Transient badge shown while a chord is armed (after H or G, before the
  * second key). Disappears when the chord completes, times out, or resets.
  *
+ * Reads `activePrefix` from `ChordContext` (provided globally by
+ * `ChordShortcutProvider` in `app/layout.tsx`). Pages that render this
+ * badge no longer need to mount `useChordShortcut` themselves (#966).
+ *
  * When `chords` is provided, shows the available follow-up letters as a
  * discoverable list — replaces the "press next key…" fallback.
  */
 export function ChordHintBadge({
-  activePrefix,
   chords,
 }: ChordHintBadgeProps): React.ReactElement | null {
+  const { activePrefix } = useChordContext();
   if (!activePrefix) return null;
 
   const hasChords = chords && chords.length > 0;

--- a/apps/admin/contexts/ChordContext.tsx
+++ b/apps/admin/contexts/ChordContext.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React, { createContext, useContext, useMemo } from "react";
+import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useChordShortcut } from "@/hooks/useChordShortcut";
+import {
+  canSeeOperatorOnly,
+  getEffectiveChords,
+  type ChordBinding,
+} from "@/lib/help/page-help";
+
+interface ChordContextValue {
+  /** "H" or "G" while a chord is armed; null otherwise. */
+  activePrefix: string | null;
+}
+
+const ChordContext = createContext<ChordContextValue>({ activePrefix: null });
+
+/**
+ * Global H+letter / G+letter chord runner + context provider (#966).
+ *
+ * Mounted once in `app/layout.tsx` wrapping the page tree. Drives the
+ * `useChordShortcut` engine against the active pathname's `PAGE_HELP_REGISTRY`
+ * entries plus `GLOBAL_CHORDS` (combined via `getEffectiveChords`). Filters
+ * `requiresOperator` chords by session role using `canSeeOperatorOnly`
+ * — same gate the help overlay already applies for display.
+ *
+ * Exposes `activePrefix` via context so `ChordHintBadge` consumers anywhere
+ * in the page tree can react to chord-armed state without prop-drilling
+ * through every layer.
+ *
+ * Replaces the 3 per-page mounts that lived in CallerDetailPage,
+ * courses/[courseId]/page, and V5WizardWithSelector — those pages now
+ * register their bindings via PAGE_HELP_REGISTRY only, with no
+ * useChordShortcut call of their own.
+ */
+export function ChordShortcutProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const pathname = usePathname() || "/";
+  const { data: session } = useSession();
+  const isOperator = canSeeOperatorOnly(
+    session?.user?.role as string | undefined,
+  );
+  // Memoise so useChordShortcut's effect only re-registers the keydown
+  // listener on real route or role changes — not on every render.
+  const effectiveChords = useMemo<ChordBinding[]>(
+    () =>
+      getEffectiveChords(pathname).filter(
+        (c) => !c.requiresOperator || isOperator,
+      ),
+    [pathname, isOperator],
+  );
+  const { activePrefix } = useChordShortcut(effectiveChords);
+  return (
+    <ChordContext.Provider value={{ activePrefix }}>
+      {children}
+    </ChordContext.Provider>
+  );
+}
+
+/**
+ * Subscribe to the global chord state. Safe to call outside the provider —
+ * returns `{ activePrefix: null }` by default so badges in detached test
+ * harnesses don't throw.
+ */
+export function useChordContext(): ChordContextValue {
+  return useContext(ChordContext);
+}


### PR DESCRIPTION
## Summary

Fixes the H+letter chord shortcut being silently dead on list pages (`/x/callers`, `/x/courses`). `PAGE_HELP_REGISTRY` had entries for those pages, but no `useChordShortcut` consumer was mounted to act on them. This moves the chord runner from per-page mounts to a global mount in `app/layout.tsx`.

Closes #966.

## Verification

- [x] **Exactly 1 invocation of `useChordShortcut(`** in the codebase, in \`contexts/ChordContext.tsx:57\`. Grep-verified.
- [x] **`getEffectiveChords(pathname)` wrapped in `useMemo([pathname, isOperator])`** in \`ChordShortcutProvider\` so the keydown listener doesn't churn on every render.
- [x] **`ChordContext.Provider` wraps \`{children}\` in \`app/layout.tsx\`** so page-tree \`ChordHintBadge\` consumers can subscribe.
- [x] **`requiresOperator` chords filtered** via \`canSeeOperatorOnly(session.user.role)\` — same gate \`HelpOverlay\` applies for display, now applied to execution.
- [x] **3 per-page mounts removed** — \`useChordShortcut\` imports + calls deleted from \`CallerDetailPage.tsx\`, \`courses/[courseId]/page.tsx\`, \`V5WizardWithSelector.tsx\`. Page-level \`effectiveChords\` useMemo kept for badge display.
- [x] **`ChordHintBadge` reads from context** via \`useChordContext()\`; \`activePrefix\` prop dropped from all 3 callsites.
- [x] **Existing dialog guard preserved** — chord runner still skips when any \`[role="dialog"]\` is open (no carve-out needed since help overlay = "do not fire" is correct).
- [x] **\`?\` key still toggles Help Overlay** — \`useHelpKeyboard\` unchanged, mounted globally as before.
- [x] **Cmd+Arrow / Option+Shift+Arrow tab cycling on CallerDetail unaffected** — different keydown handler at \`CallerDetailPage.tsx:644\`, untouched.
- [x] **\`tests/hooks/useChordShortcut.test.ts\`** — 14/14 pass.
- [x] **Targeted tsc on touched files** — no new type errors. (Pre-existing errors on CallerDetailPage and courses/page.tsx confirmed present on origin/main too — unrelated.)

## How to verify in UI

1. \`/x/callers\` (list) — press \`?\`, confirm Help Overlay shows \`H+C — Go to Courses\`. Press \`H\` then \`C\`. Navigates to \`/x/courses\`. **This was broken before this PR.**
2. \`/x/courses\` (list) — press \`H\` then \`N\` → navigates to \`/x/courses/new\`. Press \`H\` then \`W\` → navigates to \`/x/get-started-v5\`. **Both broken before.**
3. \`/x/callers/[id]\` — press \`H\` then \`O\` → jumps to Overview tab. **Still works** (no regression).
4. \`/x/courses/[id]\` — press \`H\` then any registered letter → still works.
5. \`/x/get-started-v5\` (wizard) — chord still works.

## Test plan

- [ ] Manual smoke against localhost:3000 covering the 5 routes above
- [ ] After merge, regression-check by spinning through \`/x/callers\`, \`/x/courses\`, and any \`/x/callers/[id]\` page

## Files changed

- **New:** \`apps/admin/contexts/ChordContext.tsx\` — provider + hook
- **Modified (5):** \`app/layout.tsx\` (mount), \`components/help/ChordHintBadge.tsx\` (read from context), \`components/callers/CallerDetailPage.tsx\` (remove mount), \`app/x/courses/[courseId]/page.tsx\` (remove mount), \`app/x/get-started-v5/V5WizardWithSelector.tsx\` (remove mount)

6 files, +100 / -17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)