### PR TITLE
fix(#970): mount ChordHintBadge globally; popup helper appears on every page

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -15,6 +15,7 @@ import { PendingChangesTray } from '@/components/shared/PendingChangesTray';
 import { HelpProvider } from '@/contexts/HelpContext';
 import { HelpOverlay } from '@/components/help/HelpOverlay';
 import { ChordShortcutProvider } from '@/contexts/ChordContext';
+import { ChordHintBadge } from '@/components/help/ChordHintBadge';
 import { ContentJobQueueProvider, ContentJobQueue } from '@/components/shared/ContentJobQueue';
 import EnvironmentBanner from '@/components/shared/EnvironmentBanner';
 import DynamicFavicon from '@/components/shared/DynamicFavicon';
@@ -418,16 +419,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                         <ContentJobQueueProvider>
                           <TourOverlay />
                           {/* ChordShortcutProvider wraps the page tree so
-                              ChordHintBadge consumers anywhere downstream can
-                              read activePrefix from context. Floating widgets
-                              are deliberately outside — they don't render
-                              ChordHintBadge. (#966) */}
+                              ChordHintBadge can read activePrefix + chords
+                              from context. ChordHintBadge mounted inside the
+                              provider as a sibling of {children} — appears
+                              globally whenever a chord is armed (#966, #970). */}
                           <ChordShortcutProvider>
                             <PageErrorBoundary>
                               <Suspense fallback={null}>
                                 <LayoutInner>{children}</LayoutInner>
                               </Suspense>
                             </PageErrorBoundary>
+                            <ChordHintBadge />
                           </ChordShortcutProvider>
                           {/* Floating widgets — outside PageErrorBoundary so they survive page crashes */}
                           <GlobalAssistant />

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -30,9 +30,8 @@ import { useEntityContext } from '@/contexts/EntityContext';
 import { EditableTitle } from '@/components/shared/EditableTitle';
 import { StatusBadge, DomainPill } from '@/src/components/shared/EntityPill';
 import { DraggableTabs, type TabDefinition } from '@/components/shared/DraggableTabs';
-import { ChordHintBadge } from '@/components/help/ChordHintBadge';
 import { TabWithHelp } from '@/components/help/TabWithHelp';
-import { getPageHelp, getEffectiveChords } from '@/lib/help/page-help';
+import { getPageHelp } from '@/lib/help/page-help';
 import { type TPItem, type SessionOption } from '@/components/shared/SessionTPList';
 import {
   groupSpecs,
@@ -161,13 +160,9 @@ export default function CourseDetailPage() {
   const searchParams = useSearchParams();
   const { data: session } = useSession();
   // #688 — chord shortcuts (H/G + key) for tab navigation.
-  // #global-chords — getEffectiveChords merges page bindings with the
-  // global nav chords (page wins on key collision). Lookup is route-
-  // templated; pathname not needed.
-  // Runner moved to ChordShortcutProvider in app/layout.tsx (#966); page only
-  // computes the displayable chord list for ChordHintBadge.
+  // Page-help registry for tab tooltips. Chord runner + badge are global
+  // (ChordShortcutProvider + ChordHintBadge in app/layout.tsx, #966 / #970).
   const pageHelp = useMemo(() => getPageHelp(`/x/courses/${courseId || ""}`), [courseId]);
-  const effectiveChords = useMemo(() => getEffectiveChords(`/x/courses/${courseId || ""}`), [courseId]);
   const isOperator = ['OPERATOR', 'EDUCATOR', 'ADMIN', 'SUPERADMIN'].includes((session?.user?.role as string) || '');
   const { pushEntity, setPageContext } = useEntityContext();
   const { plural } = useTerminology();
@@ -1786,7 +1781,6 @@ export default function CourseDetailPage() {
           }}
         />
       )}
-      <ChordHintBadge chords={effectiveChords} />
     </div>
   );
 }

--- a/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
+++ b/apps/admin/app/x/get-started-v5/V5WizardWithSelector.tsx
@@ -5,8 +5,6 @@ import { FancySelect } from "@/components/shared/FancySelect";
 import type { FancySelectOption } from "@/components/shared/FancySelect";
 import { ConversationalWizard } from "../wizard/components/ConversationalWizard";
 import type { WizardInitialContext } from "../wizard/components/ConversationalWizard";
-import { ChordHintBadge } from "@/components/help/ChordHintBadge";
-import { getEffectiveChords } from "@/lib/help/page-help";
 import "./get-started-v5.css";
 
 /* ── Types ──────────────────────────────────────────────── */
@@ -60,9 +58,8 @@ export function V5WizardWithSelector({
   const isSuperAdmin = userRole === "SUPERADMIN";
 
   // #688 — chord shortcuts (page-specific C=Exit + global nav chords).
-  // Runner moved to ChordShortcutProvider in app/layout.tsx (#966); page only
-  // computes the displayable chord list for ChordHintBadge.
-  const wizardChords = getEffectiveChords("/x/get-started-v5");
+  // Runner + badge are global (ChordShortcutProvider + ChordHintBadge in
+  // app/layout.tsx, #966 / #970). No per-page wiring needed.
 
   // Fetch institution list on mount
   useEffect(() => {
@@ -233,7 +230,6 @@ export function V5WizardWithSelector({
         wizardVersion="v5"
         onStartOver={handleStartOver}
       />
-      <ChordHintBadge chords={wizardChords} />
     </>
   );
 }

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -18,9 +18,8 @@ import './caller-detail-page.css';
 import './caller-detail/lens.css';
 import './caller-detail/prompt-tuner.css';
 import { useAssistant, useAssistantKeyboardShortcut } from "@/hooks/useAssistant";
-import { ChordHintBadge } from "@/components/help/ChordHintBadge";
 import { TabWithHelp } from "@/components/help/TabWithHelp";
-import { getPageHelp, getEffectiveChords } from "@/lib/help/page-help";
+import { getPageHelp } from "@/lib/help/page-help";
 
 // Extracted sub-components
 import { ProcessingNotice } from "./caller-detail/CallsTab";
@@ -129,11 +128,9 @@ export default function CallerDetailPage() {
   const [data, setData] = useState<CallerData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // #688 — chord shortcuts (H/G + key) for tab navigation + globals.
-  // Runner moved to ChordShortcutProvider in app/layout.tsx (#966); page only
-  // computes the displayable chord list for ChordHintBadge.
+  // #688 — page-help registry for tab tooltips. Chord runner + badge are
+  // global (ChordShortcutProvider + ChordHintBadge in app/layout.tsx, #966 / #970).
   const pageHelp = useMemo(() => getPageHelp(`/x/callers/${callerId}`), [callerId]);
-  const effectiveChords = useMemo(() => getEffectiveChords(`/x/callers/${callerId}`), [callerId]);
 
   const [activeSection, _setActiveSection] = useState<SectionId>(initialTab);
   // Refs mirror the latest active tab + visible sections so the long-lived
@@ -1464,7 +1461,6 @@ export default function CallerDetailPage() {
       )}
       </div>{/* cdp-content */}
       </div>{/* cdp-body */}
-      <ChordHintBadge chords={effectiveChords} />
     </div>
   );
 }

--- a/apps/admin/components/help/ChordHintBadge.tsx
+++ b/apps/admin/components/help/ChordHintBadge.tsx
@@ -2,37 +2,24 @@
 
 import React from "react";
 import "./chord-hint-badge.css";
-import type { ChordBinding } from "@/lib/help/page-help";
 import { useChordContext } from "@/contexts/ChordContext";
-
-interface ChordHintBadgeProps {
-  /**
-   * #752 — optional list of available chord bindings at the current location.
-   * When provided, the badge renders each `[letter] — label` so users can
-   * discover what's reachable. When omitted (back-compat for callers not yet
-   * wired), falls back to the original "press next key…" hint.
-   */
-  chords?: readonly ChordBinding[];
-}
 
 /**
  * Transient badge shown while a chord is armed (after H or G, before the
  * second key). Disappears when the chord completes, times out, or resets.
  *
- * Reads `activePrefix` from `ChordContext` (provided globally by
- * `ChordShortcutProvider` in `app/layout.tsx`). Pages that render this
- * badge no longer need to mount `useChordShortcut` themselves (#966).
+ * Reads both `activePrefix` and `chords` from `ChordContext` (provided
+ * globally by `ChordShortcutProvider` in `app/layout.tsx`).
  *
- * When `chords` is provided, shows the available follow-up letters as a
- * discoverable list — replaces the "press next key…" fallback.
+ * Mounted once globally in `app/layout.tsx` alongside `HelpOverlay` (#970).
+ * No per-page wiring required — the badge appears anywhere the user is
+ * when they arm a chord with H or G.
  */
-export function ChordHintBadge({
-  chords,
-}: ChordHintBadgeProps): React.ReactElement | null {
-  const { activePrefix } = useChordContext();
+export function ChordHintBadge(): React.ReactElement | null {
+  const { activePrefix, chords } = useChordContext();
   if (!activePrefix) return null;
 
-  const hasChords = chords && chords.length > 0;
+  const hasChords = chords.length > 0;
 
   return (
     <div className="hf-chord-hint" role="status" aria-live="polite">
@@ -47,7 +34,7 @@ export function ChordHintBadge({
       </div>
       {hasChords && (
         <dl className="hf-chord-hint-list">
-          {chords!.map((c) => (
+          {chords.map((c) => (
             <div className="hf-chord-hint-item" key={c.keys}>
               <dt>
                 <kbd>{c.keys}</kbd>

--- a/apps/admin/contexts/ChordContext.tsx
+++ b/apps/admin/contexts/ChordContext.tsx
@@ -13,12 +13,17 @@ import {
 interface ChordContextValue {
   /** "H" or "G" while a chord is armed; null otherwise. */
   activePrefix: string | null;
+  /** The chord bindings available at the current pathname, post operator-filter. */
+  chords: readonly ChordBinding[];
 }
 
-const ChordContext = createContext<ChordContextValue>({ activePrefix: null });
+const ChordContext = createContext<ChordContextValue>({
+  activePrefix: null,
+  chords: [],
+});
 
 /**
- * Global H+letter / G+letter chord runner + context provider (#966).
+ * Global H+letter / G+letter chord runner + context provider (#966, #970).
  *
  * Mounted once in `app/layout.tsx` wrapping the page tree. Drives the
  * `useChordShortcut` engine against the active pathname's `PAGE_HELP_REGISTRY`
@@ -26,14 +31,12 @@ const ChordContext = createContext<ChordContextValue>({ activePrefix: null });
  * `requiresOperator` chords by session role using `canSeeOperatorOnly`
  * — same gate the help overlay already applies for display.
  *
- * Exposes `activePrefix` via context so `ChordHintBadge` consumers anywhere
- * in the page tree can react to chord-armed state without prop-drilling
- * through every layer.
+ * Exposes both `activePrefix` and the current `chords` list via context so
+ * `ChordHintBadge` (also globally mounted, #970) can render its hint UI
+ * anywhere in the page tree without per-page wiring.
  *
- * Replaces the 3 per-page mounts that lived in CallerDetailPage,
- * courses/[courseId]/page, and V5WizardWithSelector — those pages now
- * register their bindings via PAGE_HELP_REGISTRY only, with no
- * useChordShortcut call of their own.
+ * Replaces the 3 per-page runner mounts that previously lived in
+ * CallerDetailPage, courses/[courseId]/page, and V5WizardWithSelector.
  */
 export function ChordShortcutProvider({
   children,
@@ -55,17 +58,21 @@ export function ChordShortcutProvider({
     [pathname, isOperator],
   );
   const { activePrefix } = useChordShortcut(effectiveChords);
+  // Stable context value so consumers (e.g. ChordHintBadge) only re-render on
+  // meaningful state changes — not on every parent re-render.
+  const value = useMemo<ChordContextValue>(
+    () => ({ activePrefix, chords: effectiveChords }),
+    [activePrefix, effectiveChords],
+  );
   return (
-    <ChordContext.Provider value={{ activePrefix }}>
-      {children}
-    </ChordContext.Provider>
+    <ChordContext.Provider value={value}>{children}</ChordContext.Provider>
   );
 }
 
 /**
  * Subscribe to the global chord state. Safe to call outside the provider —
- * returns `{ activePrefix: null }` by default so badges in detached test
- * harnesses don't throw.
+ * returns `{ activePrefix: null, chords: [] }` by default so badges in
+ * detached test harnesses don't throw.
  */
 export function useChordContext(): ChordContextValue {
   return useContext(ChordContext);


### PR DESCRIPTION
## Summary

Follow-up to #966 / #967. The chord *runner* went global in #967, but the visual feedback badge stayed per-page. On list pages (\`/x/callers\`, \`/x/courses\`) pressing H armed the chord and the navigation fired — but there was no popup helper, just silence until the second key.

Closes #970.

## Diff

- \`ChordContext\` now exposes \`{ activePrefix, chords }\` (was \`{ activePrefix }\`)
- \`ChordHintBadge\` reads both from \`useChordContext()\`; \`chords\` prop dropped
- \`<ChordHintBadge />\` mounted once globally in \`app/layout.tsx\` inside \`ChordShortcutProvider\`
- 3 per-page renders removed; 3 obsolete \`effectiveChords\` / \`wizardChords\` useMemo declarations removed
- Page-level \`pageHelp\` useMemo kept where still used for tab tooltips

## Verification

- [x] Exactly 1 \`<ChordHintBadge\` mount in the codebase — \`app/layout.tsx:432\`. Grep-verified.
- [x] 14/14 chord hook tests pass
- [x] Targeted tsc — no new type errors (same 5 pre-existing on main)
- [x] Context value memoised so badge doesn't re-render on parent re-renders

## UI test plan

- [ ] \`/x/callers\` — press H, popup helper appears showing available chord list. Press C → navigates to \`/x/courses\`. **Was broken before this PR.**
- [ ] \`/x/courses\` — press H, popup appears. Press N → \`/x/courses/new\`. Press W → \`/x/get-started-v5\`. **Was broken before this PR.**
- [ ] \`/x/callers/[id]\` — press H, popup appears (same UX as before — regression check)
- [ ] \`/x/courses/[id]\` — press H, popup appears (regression check)
- [ ] \`/x/get-started-v5\` — press H, popup appears (regression check)
- [ ] \`?\` key still toggles Help Overlay everywhere (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)