### PR TITLE
perf(#974): composite indexes for market-test hot paths

### DIFF
--- a/apps/admin/prisma/migrations/20260529_974_perf_market_test_indexes/migration.sql
+++ b/apps/admin/prisma/migrations/20260529_974_perf_market_test_indexes/migration.sql
@@ -1,0 +1,61 @@
+-- #974 — Composite indexes for market-test hot paths.
+--
+-- Audit identified 4 critical hot-path queries on the platform that currently
+-- use single-column index scans + merge joins. Under 100+ concurrent caller
+-- load during the market test, this would compound. Each composite below
+-- collapses a multi-column filter to a single index seek.
+--
+-- All operations are additive CREATE INDEX statements. No destructive
+-- operations. No data migration. Safe on a non-empty database.
+--
+-- Postgres builds indexes with an exclusive lock by default — for tables
+-- with 100k+ rows, expect ~10-30s blocking during the build. For staging
+-- this is acceptable; for prod, consider CREATE INDEX CONCURRENTLY in a
+-- custom migration (Prisma does not generate CONCURRENTLY by default).
+--
+-- After deploy, run `ANALYZE <table>` if the query planner doesn't pick up
+-- the new indexes immediately (rare, but possible if pg_stat_user_tables
+-- shows stale statistics).
+--
+-- Verified hot paths:
+--   - CallScore composite — caller detail learning-trajectory, cohort-learning,
+--     AGGREGATE pipeline stage
+--   - CallerAttribute composite — cohort-learning (3× per query), survey,
+--     export
+--   - CallerModuleProgress composite — learning-trajectory ORDER BY
+--     updatedAt DESC
+--   - Caller composite — operator dashboards / admin views
+--   - Call composite — paged reverse-chronological call history under load
+--
+-- Redundant single-column index removals (CallScore.parameterId,
+-- CallerAttribute.key, CallerAttribute.scope) are intentionally OUT OF SCOPE
+-- of this migration. Handle as a cleanup migration after EXPLAIN-verification
+-- shows the composites are actually being chosen by the planner on staging.
+
+-- CallScore.@@index([callerId, parameterId])
+-- Single biggest market-test perf win. Fires on every caller detail load +
+-- every AGGREGATE pipeline stage + every cohort-learning query.
+CREATE INDEX "CallScore_callerId_parameterId_idx" ON "CallScore"("callerId", "parameterId");
+
+-- CallerAttribute.@@index([callerId, scope, key])
+-- Cohort-learning fires this 3× per query (pre-survey + post-survey +
+-- competency bands). Leading callerId + scope as second column lets the
+-- (callerId, scope) prefix lookup (CHECKPOINT enumerations) use this index
+-- too.
+CREATE INDEX "CallerAttribute_callerId_scope_key_idx" ON "CallerAttribute"("callerId", "scope", "key");
+
+-- CallerModuleProgress.@@index([callerId, updatedAt])
+-- Learning trajectory orders by updatedAt DESC; current single-column
+-- callerId index requires a sort step under load. Composite serves the
+-- ORDER BY directly.
+CREATE INDEX "CallerModuleProgress_callerId_updatedAt_idx" ON "CallerModuleProgress"("callerId", "updatedAt");
+
+-- Caller.@@index([domainId, role])
+-- Operator dashboards filter by (domain, role); avoids merge join between
+-- two single-column scans.
+CREATE INDEX "Caller_domainId_role_idx" ON "Caller"("domainId", "role");
+
+-- Call.@@index([callerId, createdAt])
+-- Paged call history is reverse-chronological per caller. Composite serves
+-- the ORDER BY without a sort step.
+CREATE INDEX "Call_callerId_createdAt_idx" ON "Call"("callerId", "createdAt");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -943,6 +943,9 @@ model Caller {
   @@index([role])
   @@index([cohortGroupId])
   @@index([supervisorCallerId])
+  // #974 — operator dashboards filter callers by (domain, role) — composite
+  // avoids merge join between the two single-column scans.
+  @@index([domainId, role])
 }
 
 // ExcludedCaller - Phone numbers/IDs to skip during transcript import
@@ -1200,6 +1203,11 @@ model CallerAttribute {
   @@index([key])
   @@index([scope])
   @@index([validUntil])
+  // #974 — composite for the (callerId, scope, key) hot path: cohort-learning
+  // fires this 3× per query (pre/post survey + competency); learning-trajectory
+  // fires the (callerId, scope) prefix for CHECKPOINT lookups. Leading-callerId
+  // + scope as second column lets both query shapes use this index.
+  @@index([callerId, scope, key])
 }
 
 // Goal - Represents a caller's objective (learn, achieve, connect, etc.)
@@ -1449,7 +1457,7 @@ model Call {
   vapiDurationSeconds   Float?
   vapiEndedReason       String?
   vapiCostUsd           Float?
-  vapiAnalysisSummary   String?  @db.Text
+  vapiAnalysisSummary   String? @db.Text
   vapiStructuredData    Json?
   vapiSuccessEvaluation String?
 
@@ -1461,6 +1469,10 @@ model Call {
   @@index([playbookId])
   @@index([curriculumModuleId])
   @@index([requestedModuleId])
+  // #974 — call history is paged reverse-chronologically per caller. The
+  // single-column callerId index requires a sort step; this composite
+  // serves the ORDER BY directly under load.
+  @@index([callerId, createdAt])
 }
 
 model CallMessage {
@@ -1513,7 +1525,7 @@ model CallScore {
   // evidenceQuality — 0..1 confidence in the evidence quantity/quality
   // (independent of confidence in the score itself).
   hasLearnerEvidence Boolean? // null = legacy path; true/false = scorer judged evidence
-  evidenceQuality    Float?   // 0..1, null when not assessed
+  evidenceQuality    Float? // 0..1, null when not assessed
 
   // Spec-driven scoring
   analysisSpecId String? // Which AnalysisSpec was used
@@ -1546,6 +1558,11 @@ model CallScore {
   @@index([analysisSpecId])
   @@index([scoredAt])
   @@index([moduleId])
+  // #974 — composite for the (callerId, parameterId) hot path: caller
+  // detail learning-trajectory, cohort-learning, and AGGREGATE stage all
+  // filter on this pair. Currently uses two single-column scans + merge
+  // join under load. Single biggest market-test perf win.
+  @@index([callerId, parameterId])
 }
 
 // =========================
@@ -2518,6 +2535,9 @@ model CallerModuleProgress {
   @@unique([callerId, moduleId])
   @@index([callerId, status])
   @@index([moduleId])
+  // #974 — learning-trajectory orders by updatedAt: desc; currently scans
+  // by callerId then sorts. Composite avoids the sort step under load.
+  @@index([callerId, updatedAt])
 }
 
 // Top-level spec: defines a category of analysis


### PR DESCRIPTION
## Summary

Bundle B from the perf work. 5 composite indexes that collapse multi-column filters from hot read paths to single index seeks. Targets the queries that will compound under 100+ concurrent caller load during the market test.

Closes #974.

## Indexes added

| Table | Composite | Why |
|---|---|---|
| **CallScore** | \`@@index([callerId, parameterId])\` | **Biggest single win.** Every caller detail load + every AGGREGATE pipeline stage + every cohort-learning query. |
| **CallerAttribute** | \`@@index([callerId, scope, key])\` | Cohort-learning fires this 3× per query. Leading prefix also serves CHECKPOINT enumeration. |
| **CallerModuleProgress** | \`@@index([callerId, updatedAt])\` | Learning trajectory ORDER BY updatedAt DESC — composite eliminates sort step. |
| **Caller** | \`@@index([domainId, role])\` | Operator dashboards / admin views. |
| **Call** | \`@@index([callerId, createdAt])\` | Paged reverse-chronological call history under load. |

## Audit recommendation skipped

\`LearningObjective.@@index([moduleId, ref])\` was on the audit list, but \`LearningObjective\` **already has** \`@@unique([moduleId, ref])\` which provides the same index. Adding a duplicate would be wasteful. Confirmed by inspection.

## Verification

- [x] \`npx prisma validate\` — schema is valid
- [x] \`npx prisma format\` — schema formatted cleanly
- [x] All operations are additive \`CREATE INDEX\` statements — no destructive operations, no data migration
- [x] Migration is a single file: \`20260529_974_perf_market_test_indexes/migration.sql\`
- [x] Migration commentary explains expected build time (~10–30s) and CONCURRENTLY caveat for prod

## Out of scope (intentional)

- **Redundant index removals** (\`CallScore.parameterId\`, \`CallerAttribute.key\`, \`CallerAttribute.scope\`) — handle as cleanup PR after EXPLAIN-verification confirms the composites are being chosen by the planner on staging
- Query refactoring (\`{ call: { callerId } }\` → \`{ callerId }\` direct) — separate PR
- Schema redesign — none of the queries are misshapen; indexing is sufficient

## Deploy

\`/vm-cpp\` (migration required).

## Post-deploy verification

- [ ] Run \`EXPLAIN ANALYZE\` against staging on the CallScore hot query — plan should show \`Index Scan on CallScore_callerId_parameterId_idx\` instead of \`BitmapAnd\` over two single-column scans
- [ ] If planner doesn't pick up the new indexes immediately, run \`ANALYZE CallScore; ANALYZE CallerAttribute; ANALYZE CallerModuleProgress; ANALYZE Caller; ANALYZE Call;\` to refresh statistics

🤖 Generated with [Claude Code](https://claude.com/claude-code)