### PR TITLE
chore(welcomes): refresh archetype + wizard welcome copy; drop "what brings you here today"

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor.ts
@@ -2482,10 +2482,16 @@ export async function executeWizardTool(
       const subjectClause = subjectDiscipline ? ` in ${subjectDiscipline}` : "";
       const materialsClause = physicalMaterials ? ` Have your ${physicalMaterials} nearby if you can.` : "";
 
+      // Voice principle: assume the learner picked this course for a reason.
+      // Don't ask "what brings you here" / "what would you like to start with" —
+      // they're here to learn the named subject. The course-context branch opens
+      // with a calibration question that gets us into the subject; the open
+      // (conversational-guide) branch keeps the chatty no-agenda framing for
+      // Community Hub-style routes.
       const isConvGuide = interactionPattern === "conversational-guide";
       const suggestion = isConvGuide
-        ? `Hi! I'm really glad you called. I'm here to ${stylePhrase}. No agenda, no pressure — just a good chat. What's been on your mind lately?`
-        : `Hi! I'm your tutor for ${courseName}${subjectClause}. I'm here to ${stylePhrase}.${materialsClause} What would you like to start with today?`;
+        ? `Hi — really glad you called. I'm here to ${stylePhrase}. No agenda, no rush — let's just see where the conversation goes. What's been on your mind lately?`
+        : `Hi — I'm your tutor for ${courseName}${subjectClause}. I'm here to ${stylePhrase}.${materialsClause} To get us started: when you think about this, what do you already feel comfortable with, and where does it get fuzzy?`;
 
       return {
         ...base,

--- a/apps/admin/prisma/seed-identity-archetypes.ts
+++ b/apps/admin/prisma/seed-identity-archetypes.ts
@@ -46,7 +46,12 @@ const ARCHETYPES: ArchetypeSpec[] = [
         "Scaffold complexity — break concepts into manageable steps",
         "Match language complexity to the learner's demonstrated level"
       ],
-      welcomeTemplate: "Welcome! I'm really glad you're here. I'll be your tutor, and my goal is to make learning feel like a conversation, not a lecture. We'll go at your pace, and I'll adapt to how you learn best. What topic or subject brought you here today?"
+      // Course context: assume the learner picked this course for a reason — don't
+      // ask "what brings you here". Set the tone, then open with a Socratic prompt
+      // that gets us into the actual subject straight away.
+      welcomeTemplate: "Welcome — really glad you're here. I'm your tutor for this, and we'll go at your pace. To get us started: when you think about this topic, what do you already feel comfortable with, and where does it get fuzzy?",
+      // Community Hub context: no specific course in mind, so open-ended is right.
+      welcomeTemplateCommunity: "Hello! I'm here as your tutor — happy to dig into anything you're curious about. What's caught your interest today?"
     }
   },
   {
@@ -66,7 +71,8 @@ const ARCHETYPES: ArchetypeSpec[] = [
         "Challenge assumptions respectfully",
         "Hold people to what they said they'd do"
       ],
-      welcomeTemplate: "Welcome aboard! I'm excited to work with you. My role is to help you think through challenges and develop strategies that work for you. What's on your mind today — what would be most helpful to focus on?"
+      welcomeTemplate: "Welcome — let's get to work. I'm your coach for this, and my job is helping you turn what you learn here into things you actually do differently. Before we dive in: what's the specific situation you most want this to help with?",
+      welcomeTemplateCommunity: "Welcome aboard. I'm here as a thinking partner — let's sharpen up whatever's on your mind. What are you chewing on?"
     }
   },
   {
@@ -86,7 +92,8 @@ const ARCHETYPES: ArchetypeSpec[] = [
         "Match their energy and pace",
         "Never push toward solutions unless they ask"
       ],
-      welcomeTemplate: "Hello! It's wonderful to meet you. I'm here to be a thoughtful conversation partner — someone to explore ideas with, share stories, or just chat. What would you like to talk about today?"
+      welcomeTemplate: "Hi — lovely to meet you. I'm here as your companion through this. No agenda, no rush — we go at your pace. To start: what drew you to this topic?",
+      welcomeTemplateCommunity: "Hello! It's wonderful to meet you. I'm here to be a thoughtful conversation partner — share a story, explore an idea, or just chat. What would you like to talk about today?"
     }
   },
   {
@@ -106,7 +113,8 @@ const ARCHETYPES: ArchetypeSpec[] = [
         "Translate jargon into plain language",
         "Never speculate; if uncertain, say so clearly"
       ],
-      welcomeTemplate: "Welcome. I'm here to help guide you through this. I'll give you clear information, walk you through the steps, and make sure you understand what's happening at each stage. What brings you here today?"
+      welcomeTemplate: "Welcome. I'm here to guide you through this — clear steps, plain language, no surprises. Let's get oriented: what part of this do you most want to understand first?",
+      welcomeTemplateCommunity: "Welcome. I'm here to help you understand things clearly — plain language, no jargon. What can I help you with today?"
     }
   },
   {
@@ -126,7 +134,8 @@ const ARCHETYPES: ArchetypeSpec[] = [
         "Acknowledge emotional weight before moving to analysis",
         "Help them see patterns across time — the bigger picture"
       ],
-      welcomeTemplate: "It's really good to meet you. I've been looking forward to this. I'm here as a long-term thinking partner — someone to help you see the bigger picture and navigate the road ahead. What's the most important thing on your mind right now?"
+      welcomeTemplate: "It's good to meet you. I'm here as your mentor through this — someone to help you see the bigger picture and what it means for you. To start us off: what's the bigger thing you're hoping this opens up?",
+      welcomeTemplateCommunity: "It's really good to meet you. I'm here as a long-term thinking partner — happy to think through whatever's important to you. What's the most important thing on your mind right now?"
     }
   },
   {
@@ -146,7 +155,10 @@ const ARCHETYPES: ArchetypeSpec[] = [
         "Summarise and reflect back before moving on",
         "Name dynamics that might be blocking progress"
       ],
-      welcomeTemplate: "Welcome, everyone. I'm here to help us have a productive and inclusive conversation. My job is to make sure everyone has space to contribute and we make real progress together. Let's start by hearing from each of you — what's most on your mind today?"
+      // Facilitator in 1:1 course context = process-keeper for the individual learner.
+      // (The group-oriented variant lives below in welcomeTemplateCommunity.)
+      welcomeTemplate: "Welcome. I'm here to help you work through this — keeping us on track, surfacing different angles, and helping you arrive at your own understanding. Where would you like to begin?",
+      welcomeTemplateCommunity: "Welcome, everyone. I'm here to help us have a productive and inclusive conversation. My job is to make sure every voice is heard. Let's start by hearing from each of you — what's most on your mind today?"
     }
   },
   {
@@ -167,7 +179,8 @@ const ARCHETYPES: ArchetypeSpec[] = [
         "Always flag speculation as speculation — never bluff",
         "Always signpost professional advice when stakes are high"
       ],
-      welcomeTemplate: "Hello. I'm here to give you accurate, structured information and clear recommendations. I'll be direct and precise — let me know if you need more detail on anything. What would you like to work through today?"
+      welcomeTemplate: "Hello. I'm your advisor for this — accurate, structured, direct. Before I get into it: tell me where you're coming at this from, so I can pitch what I cover at the right level.",
+      welcomeTemplateCommunity: "Hello. I'm here to give you accurate, structured information and clear recommendations. What would you like to work through today?"
     }
   }
 ];


### PR DESCRIPTION
## Summary

Refresh the default welcome-message copy across both surfaces that produce it. The current copy ends with some variant of "what brings you here today?" / "what would you like to start with?" — aimless for a learner who explicitly enrolled in a specific course.

Two commits, one concern each (commit-msg hook enforces this):

1. **`prisma/seed-identity-archetypes.ts`** — Rewrites all 7 archetype \`welcomeTemplate\` strings (TUT-001, COACH-001, COMPANION-001, GUIDE-001, MENTOR-001, FACILITATOR-001, ADVISOR-001) to be course-context-aware. Each opens with relationship + tone, then a calibration question that gets into the actual subject. Adds a new \`welcomeTemplateCommunity\` field for Community Hub routes (preserves the open-ended chatty framing for that context).
2. **`lib/chat/wizard-tool-executor.ts::suggest_welcome_message`** — Updates the V5 wizard's inline "Use this" chip template to match the new voice. The course-context branch gets the calibration-question pattern. The \`conversational-guide\` branch (Community Hub equivalent in the wizard surface) keeps its open framing.

## Voice principle

- **Course context**: assume the learner picked this course for a reason. Don't ask "what brings you here". Open with a question that gets us into the subject — e.g. *"when you think about this topic, what do you already feel comfortable with, and where does it get fuzzy?"* for the Tutor.
- **Community Hub context**: no specific course in mind, so open-ended is right — e.g. *"What's caught your interest today?"*.

## Sample diff — Tutor (TUT-001)

**Before:**
> Welcome! I'm really glad you're here. I'll be your tutor, and my goal is to make learning feel like a conversation, not a lecture. We'll go at your pace, and I'll adapt to how you learn best. **What topic or subject brought you here today?**

**After (course):**
> Welcome — really glad you're here. I'm your tutor for this, and we'll go at your pace. To get us started: **when you think about this topic, what do you already feel comfortable with, and where does it get fuzzy?**

**After (community — new):**
> Hello! I'm here as your tutor — happy to dig into anything you're curious about. What's caught your interest today?

## Out of scope (follow-up)

- **Resolver wiring** — \`lib/session-flow/resolver.ts::resolveWelcomeMessage\` and \`lib/domain/quick-launch.ts::resolveWelcomeTemplate\` currently only read \`welcomeTemplate\`. A follow-up will pick \`welcomeTemplateCommunity\` for community-kind domains. The field is seeded ready for that.
- **Existing courses** — those that already saved a \`Playbook.config.welcomeMessage\` are unchanged. The educator can clear the field in the Session Flow → Welcome message panel to fall through to the new template, or type new copy directly.

## Verification

- [x] Targeted \`tsc\` on touched files: 0 new type errors (6 pre-existing in \`wizard-tool-executor.ts\` are unrelated, same as on \`origin/main\`)
- [x] Targeted \`eslint\`: 0 errors
- [x] All 7 archetype \`welcomeTemplate\` strings no longer ask "what brings you here today" / "what would you like to start with"
- [x] All 7 archetype \`welcomeTemplateCommunity\` strings preserve open-ended community framing
- [x] V5 wizard's \`conversational-guide\` branch retains chatty no-agenda framing

## Deploy / apply

- \`/vm-cp\` to ship the code
- On hf-dev VM: \`cd ~/HF/apps/admin && npx tsx prisma/seed-identity-archetypes.ts\` to apply the seed (idempotent upsert)
- Staging gets the new copy on next deploy (the seed-identity-archetypes script runs as part of the seed job, OR can be triggered standalone via Cloud Run Job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)