### PR TITLE
fix(#978): wizard picker dedup — suppress bubble, move chips + actions onto picker

### DIFF
--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -782,7 +782,15 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
       const postExtras = filteredExtras.filter((m) => m.systemType === "success-card");
 
       let finalMessages = [...newMessages, ...preExtras];
-      if (response.content) {
+      // #978 Slice 1 — when this turn emits a stream-form picker (OptionsCard),
+      // suppress the redundant assistant text bubble. The picker already carries
+      // the question + options + Confirm/Skip footer; the bubble was restating
+      // the same prompt word-for-word. FieldPicker mode (renders above input
+      // bar) is explicitly out of scope per AC-FieldPicker-Scope.
+      const hasStreamFormPicker = preExtras.some(
+        (m) => m.systemType === "options" && m.optionsPanel?.fieldPicker !== true,
+      );
+      if (response.content && !hasStreamFormPicker) {
         finalMessages = [...finalMessages, {
           id: uid(),
           role: "assistant" as const,

--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -1674,6 +1674,19 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
                       // still pick an option from the same picker.
                       handleSend(label);
                     }}
+                    // #978 Slice 3 — ... actions menu mounted on picker with
+                    // a subset of decision-shaped actions only. Copy/Quote are
+                    // intentionally excluded — they would operate on the
+                    // picker's question text, which is not sensible UX.
+                    messageActions={
+                      <MessageActions
+                        message={{ content: msg.optionsPanel.question }}
+                        onSend={(t) => handleSend(t)}
+                        onPrefill={(t) => setInputValue(t)}
+                        onFocusInput={() => inputRef.current?.focus()}
+                        actionsSubset={["correct", "more", "skip"]}
+                      />
+                    }
                   />
                 </div>
               );

--- a/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
+++ b/apps/admin/app/x/wizard/components/ConversationalWizard.tsx
@@ -518,6 +518,24 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
           && (t.input as { mode?: string; dataKey?: string })?.dataKey === "_welcomePhases",
       );
 
+      // #978 Slice 2 — when a stream-form picker (non-fieldPicker, non-welcomePhases)
+      // co-emits with show_suggestions on the same turn, the chip rail attaches to
+      // the picker footer instead of floating below the chat. The welcome-phases
+      // guard above is respected: that checklist intentionally drops chips and that
+      // precedent stays untouched.
+      const streamFormPickerCall = toolCalls.find(
+        (t) => t.name === "show_options"
+          && (t.input as { fieldPicker?: boolean; dataKey?: string })?.fieldPicker !== true
+          && (t.input as { fieldPicker?: boolean; dataKey?: string })?.dataKey !== "_welcomePhases",
+      );
+      const coEmittedSuggestionsCall = streamFormPickerCall
+        ? toolCalls.find((t) => t.name === "show_suggestions")
+        : undefined;
+      const chipsAttachedToPicker: string[] | null =
+        coEmittedSuggestionsCall && !hasWelcomePhasesChecklist
+          ? ((coEmittedSuggestionsCall.input as { suggestions?: string[] })?.suggestions ?? null)
+          : null;
+
       for (const tc of toolCalls) {
         switch (tc.name) {
           case "update_setup": {
@@ -558,6 +576,9 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
           case "show_suggestions": {
             // welcome-flow checklist owns the decision surface — drop redundant chips
             if (hasWelcomePhasesChecklist) break;
+            // #978 Slice 2 — if these chips were attached to a co-emitted picker
+            // above, skip the floating rail so they don't render twice.
+            if (chipsAttachedToPicker) break;
             const items = tc.input.suggestions as string[];
             const question = tc.input.question as string | undefined;
             if (items?.length) setSuggestions({ question, items });
@@ -605,12 +626,20 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
               // Field picker renders above the input bar, not in the message stream
               setFieldPickerPanel(tc.input as unknown as OptionsPanel);
             } else {
+              // #978 Slice 2 — attach co-emitted suggestion chips to the panel so
+              // they render inside the picker footer (vs. floating rail). Only
+              // fires for non-welcomePhases stream-form pickers.
+              const rawPanel = tc.input as unknown as OptionsPanel;
+              const panelWithChips: OptionsPanel =
+                chipsAttachedToPicker && rawPanel.dataKey !== "_welcomePhases"
+                  ? { ...rawPanel, suggestionChips: chipsAttachedToPicker }
+                  : rawPanel;
               extras.push({
                 id: uid(),
                 role: "system",
                 systemType: "options",
                 content: tc.input.question as string,
-                optionsPanel: tc.input as unknown as OptionsPanel,
+                optionsPanel: panelWithChips,
               });
             }
             break;
@@ -1637,6 +1666,13 @@ export function ConversationalWizard({ initialContext, userRole, wizardVersion =
                         prev.map((m) => m.id === msg.id ? { ...m, resolved: true } : m),
                       );
                       setTimeout(() => inputRef.current?.focus(), 50);
+                    }}
+                    onChipClick={(label) => {
+                      // #978 Slice 2 — chip click sends label to AI, same as the
+                      // legacy floating rail. Picker is NOT marked resolved so a
+                      // user who clicks a chip and then changes their mind can
+                      // still pick an option from the same picker.
+                      handleSend(label);
                     }}
                   />
                 </div>

--- a/apps/admin/app/x/wizard/components/MessageActions.tsx
+++ b/apps/admin/app/x/wizard/components/MessageActions.tsx
@@ -16,11 +16,22 @@ export interface MessageActionsMessage {
   content: string;
 }
 
+export type MessageActionId = "correct" | "more" | "skip" | "copy" | "quote";
+
 interface MessageActionsProps {
   message: MessageActionsMessage;
   onSend: (text: string) => void;
   onPrefill: (text: string) => void;
   onFocusInput: () => void;
+  /**
+   * #978 Slice 3 — when the actions menu mounts on an OptionsCard picker
+   * (not on an assistant bubble), the available actions are limited. Copy
+   * and Quote would operate on `message.content` (the picker's question text)
+   * which isn't sensible UX. Pass `["correct", "more", "skip"]` to scope to
+   * decision-shaped actions only.
+   * Default (undefined) preserves the legacy full menu on assistant bubbles.
+   */
+  actionsSubset?: MessageActionId[];
 }
 
 // ── Helpers ───────────────────────────────────────────────
@@ -34,7 +45,7 @@ const COPY_FEEDBACK_MS = 1800;
 
 // ── Component ─────────────────────────────────────────────
 
-export function MessageActions({ message, onSend, onPrefill, onFocusInput }: MessageActionsProps) {
+export function MessageActions({ message, onSend, onPrefill, onFocusInput, actionsSubset }: MessageActionsProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
@@ -42,7 +53,7 @@ export function MessageActions({ message, onSend, onPrefill, onFocusInput }: Mes
   const menuRef = useRef<HTMLDivElement>(null);
   const [focusedIndex, setFocusedIndex] = useState(-1);
 
-  const actions = [
+  const allActions = [
     { id: "correct", label: "That's not right", icon: AlertCircle },
     { id: "more", label: "Tell me more", icon: HelpCircle },
     { id: "skip", label: "Move on", icon: ChevronsRight },
@@ -50,6 +61,12 @@ export function MessageActions({ message, onSend, onPrefill, onFocusInput }: Mes
     { id: "copy", label: "Copy", icon: Copy },
     { id: "quote", label: "Quote & reply", icon: Quote },
   ] as const;
+
+  // #978 Slice 3 — filter to subset when provided. Drop the divider if both
+  // sides become empty after filtering.
+  const actions = actionsSubset
+    ? allActions.filter((a) => a.id !== "divider" && (actionsSubset as readonly string[]).includes(a.id))
+    : allActions;
 
   const actionItems = actions.filter((a) => a.id !== "divider") as Array<{ id: string; label: string; icon: React.ComponentType<{ size?: number }> }>;
 

--- a/apps/admin/app/x/wizard/components/OptionsCard.tsx
+++ b/apps/admin/app/x/wizard/components/OptionsCard.tsx
@@ -9,7 +9,7 @@
  * Full keyboard navigation: ↑↓ navigate, Space toggle, Enter confirm, Esc dismiss.
  */
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, type ReactNode } from "react";
 import { Pencil, ChevronLeft, ChevronRight } from "lucide-react";
 
 // ── Types ────────────────────────────────────────────────
@@ -45,13 +45,20 @@ interface OptionsCardProps {
   onSomethingElse: () => void;
   /** #978 Slice 2 — invoked when the user clicks a co-located suggestion chip. */
   onChipClick?: (label: string) => void;
+  /**
+   * #978 Slice 3 — optional ... actions menu rendered in the footer right
+   * slot. Caller fully constructs the element (typically a `<MessageActions>`
+   * with `actionsSubset={["correct","more","skip"]}`) so OptionsCard stays
+   * decoupled from MessageActions and its onSend/onPrefill plumbing.
+   */
+  messageActions?: ReactNode;
 }
 
 const PAGE_SIZE = 6;
 
 // ── Component ────────────────────────────────────────────
 
-export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse, onChipClick }: OptionsCardProps) {
+export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse, onChipClick, messageActions }: OptionsCardProps) {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [page, setPage] = useState(0);
@@ -293,12 +300,16 @@ export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse, onChipCl
               </button>
             )}
           </div>
-          <div className="cv4-options-hints">
-            <span>↑↓ navigate</span>
-            <span>·</span>
-            <span>{panel.mode === "checklist" ? "Space toggle" : "Enter select"}</span>
-            <span>·</span>
-            <span>Esc dismiss</span>
+          <div className="cv4-options-footer-right">
+            <div className="cv4-options-hints">
+              <span>↑↓ navigate</span>
+              <span>·</span>
+              <span>{panel.mode === "checklist" ? "Space toggle" : "Enter select"}</span>
+              <span>·</span>
+              <span>Esc dismiss</span>
+            </div>
+            {/* #978 Slice 3 — ... actions menu (subset). */}
+            {messageActions}
           </div>
         </div>
       )}

--- a/apps/admin/app/x/wizard/components/OptionsCard.tsx
+++ b/apps/admin/app/x/wizard/components/OptionsCard.tsx
@@ -28,6 +28,14 @@ export interface OptionsPanel {
   required?: boolean;
   fieldPicker?: boolean;
   options: OptionDef[];
+  /**
+   * #978 Slice 2 — when a turn emits this stream-form picker AND a
+   * co-occurring `show_suggestions` chip rail, the chip labels are attached
+   * here so they render inside the picker footer instead of as a separate
+   * floating rail below the picker. Only set by `processToolCalls` for
+   * non-fieldPicker, non-_welcomePhases pickers.
+   */
+  suggestionChips?: string[];
 }
 
 interface OptionsCardProps {
@@ -35,13 +43,15 @@ interface OptionsCardProps {
   onSelect: (value: string | string[], displayText: string) => void;
   onSkip: () => void;
   onSomethingElse: () => void;
+  /** #978 Slice 2 — invoked when the user clicks a co-located suggestion chip. */
+  onChipClick?: (label: string) => void;
 }
 
 const PAGE_SIZE = 6;
 
 // ── Component ────────────────────────────────────────────
 
-export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse }: OptionsCardProps) {
+export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse, onChipClick }: OptionsCardProps) {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [page, setPage] = useState(0);
@@ -290,6 +300,25 @@ export function OptionsCard({ panel, onSelect, onSkip, onSomethingElse }: Option
             <span>·</span>
             <span>Esc dismiss</span>
           </div>
+        </div>
+      )}
+
+      {/* #978 Slice 2 — co-located suggestion chips. Render below the standard
+          footer so the picker visually owns the decision surface AND the
+          recommended next moves ("Continue", "I have a question", etc.) sit
+          right under it instead of floating at the chat bottom. */}
+      {panel.suggestionChips && panel.suggestionChips.length > 0 && onChipClick && (
+        <div className="cv4-options-suggestion-chips">
+          {panel.suggestionChips.map((label) => (
+            <button
+              key={label}
+              type="button"
+              className="cv4-suggestion-chip"
+              onClick={() => onChipClick(label)}
+            >
+              {label}
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/apps/admin/app/x/wizard/wizard.css
+++ b/apps/admin/app/x/wizard/wizard.css
@@ -1205,6 +1205,15 @@
   background: var(--surface-secondary);
 }
 
+/* #978 Slice 3 — footer-right wrapper holds the keyboard hints + the
+   ... actions menu trigger. Keeps both on the same line as the existing
+   footer-left controls (Confirm / Something else / Skip). */
+.cv4-options-footer-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .cv4-options-footer-left {
   display: flex;
   align-items: center;

--- a/apps/admin/app/x/wizard/wizard.css
+++ b/apps/admin/app/x/wizard/wizard.css
@@ -1195,6 +1195,16 @@
   background: var(--surface-secondary);
 }
 
+/* #978 Slice 2 — co-located suggestion chips below the picker footer. */
+.cv4-options-suggestion-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 16px 10px;
+  border-top: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+}
+
 .cv4-options-footer-left {
   display: flex;
   align-items: center;

--- a/apps/admin/tests/wizard/options-card-message-actions.test.tsx
+++ b/apps/admin/tests/wizard/options-card-message-actions.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * OptionsCard + MessageActions — #978 Slice 3
+ *
+ * Verifies the DOM-level contract that the harness predictor can only assert
+ * indirectly: when the OptionsCard receives a `messageActions` element built
+ * from MessageActions with `actionsSubset={["correct","more","skip"]}`, the
+ * opened menu contains exactly those three items — Copy and Quote are NOT
+ * present (they would operate on `panel.question`, which isn't sensible UX).
+ *
+ * Also covers the keyboard QA gate raised by Tech Lead:
+ * `AC-Escape-Collision` — Esc inside an open MessageActions menu must close
+ * the menu without triggering OptionsCard's `onSomethingElse` dismissal.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
+import React from "react";
+import { OptionsCard, type OptionsPanel } from "@/app/x/wizard/components/OptionsCard";
+import { MessageActions } from "@/app/x/wizard/components/MessageActions";
+
+function makePanel(overrides: Partial<OptionsPanel> = {}): OptionsPanel {
+  return {
+    question: "How should learners progress?",
+    dataKey: "progressionMode",
+    mode: "radio",
+    fieldPicker: false,
+    options: [
+      { value: "learner-picks", label: "Let learners pick", description: "" },
+      { value: "ai-led", label: "AI directs", description: "" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("OptionsCard + MessageActions — #978 Slice 3", () => {
+  it("mounts MessageActions in the footer with subset (no Copy / Quote)", () => {
+    const onSelect = vi.fn();
+    const onSkip = vi.fn();
+    const onSomethingElse = vi.fn();
+    const onSend = vi.fn();
+    const onPrefill = vi.fn();
+    const onFocusInput = vi.fn();
+
+    const { getByLabelText, queryByText } = render(
+      <OptionsCard
+        panel={makePanel()}
+        onSelect={onSelect}
+        onSkip={onSkip}
+        onSomethingElse={onSomethingElse}
+        messageActions={
+          <MessageActions
+            message={{ content: "How should learners progress?" }}
+            onSend={onSend}
+            onPrefill={onPrefill}
+            onFocusInput={onFocusInput}
+            actionsSubset={["correct", "more", "skip"]}
+          />
+        }
+      />,
+    );
+
+    // Trigger is present on the picker footer
+    const trigger = getByLabelText(/Message actions/i);
+    expect(trigger).toBeTruthy();
+
+    // Open the menu
+    fireEvent.click(trigger);
+
+    // Subset items are present
+    expect(queryByText("That's not right")).not.toBeNull();
+    expect(queryByText("Tell me more")).not.toBeNull();
+    expect(queryByText("Move on")).not.toBeNull();
+
+    // Excluded items are NOT present
+    expect(queryByText("Copy")).toBeNull();
+    expect(queryByText("Quote & reply")).toBeNull();
+  });
+
+  it("renders without messageActions when prop is omitted (backwards-compatible)", () => {
+    const { queryByLabelText } = render(
+      <OptionsCard
+        panel={makePanel()}
+        onSelect={vi.fn()}
+        onSkip={vi.fn()}
+        onSomethingElse={vi.fn()}
+      />,
+    );
+    expect(queryByLabelText(/Message actions/i)).toBeNull();
+  });
+
+  it("AC-Escape-Collision: Esc inside open MessageActions does NOT dismiss the picker", () => {
+    const onSomethingElse = vi.fn();
+    const onSend = vi.fn();
+
+    const { getByLabelText, queryByRole } = render(
+      <OptionsCard
+        panel={makePanel()}
+        onSelect={vi.fn()}
+        onSkip={vi.fn()}
+        onSomethingElse={onSomethingElse}
+        messageActions={
+          <MessageActions
+            message={{ content: "q" }}
+            onSend={onSend}
+            onPrefill={vi.fn()}
+            onFocusInput={vi.fn()}
+            actionsSubset={["correct", "more", "skip"]}
+          />
+        }
+      />,
+    );
+
+    // Open the actions menu
+    fireEvent.click(getByLabelText(/Message actions/i));
+    const menu = queryByRole("menu");
+    expect(menu).not.toBeNull();
+
+    // Press Escape — MessageActions handler uses capture-phase + stopPropagation,
+    // so OptionsCard's Esc (which fires onSomethingElse) must NOT fire.
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+
+    // Menu closed
+    expect(queryByRole("menu")).toBeNull();
+    // Picker still alive (onSomethingElse not called)
+    expect(onSomethingElse).not.toHaveBeenCalled();
+  });
+
+  it("renders co-located suggestion chips when panel.suggestionChips set (slice 2 + 3 together)", () => {
+    const onChipClick = vi.fn();
+    const { getByText } = render(
+      <OptionsCard
+        panel={makePanel({ suggestionChips: ["Continue", "Something else"] })}
+        onSelect={vi.fn()}
+        onSkip={vi.fn()}
+        onSomethingElse={vi.fn()}
+        onChipClick={onChipClick}
+        messageActions={
+          <MessageActions
+            message={{ content: "q" }}
+            onSend={vi.fn()}
+            onPrefill={vi.fn()}
+            onFocusInput={vi.fn()}
+            actionsSubset={["correct", "more", "skip"]}
+          />
+        }
+      />,
+    );
+
+    fireEvent.click(getByText("Continue"));
+    expect(onChipClick).toHaveBeenCalledWith("Continue");
+  });
+});

--- a/apps/admin/tests/wizard/picker-dedup-harness.test.ts
+++ b/apps/admin/tests/wizard/picker-dedup-harness.test.ts
@@ -174,8 +174,10 @@ interface RenderPlan {
     fieldPicker: boolean;
     optionCount: number;
   } | null;
-  /** Suggestion chips on this turn */
+  /** Suggestion chips floating rail at bottom of chat (legacy location). */
   suggestionChips: string[] | null;
+  /** #978 Slice 2 — chips attached to the picker footer (new location). */
+  pickerChips: string[] | null;
   /** Whether ... MessageActions menu would render alongside assistant bubble */
   messageActionsOnAssistantBubble: boolean;
 }
@@ -185,17 +187,18 @@ interface RenderPlan {
 /**
  * Mirrors `ConversationalWizard.tsx` `handleSend` assembly + `processToolCalls`.
  *
- * Current state: slice 1 applied (assistant bubble suppressed when a stream-form
- * picker is present on the same turn). Slice 2 (chip rail under picker) and
- * slice 3 (MessageActions on picker) update this function further.
+ * Current state: slices 1 + 2 applied. Slice 3 (MessageActions on picker)
+ * updates this function further.
  *
  * Rules in force:
  *   - show_options with fieldPicker=true → fieldPickerPanel (NOT in stream)
  *   - show_options without fieldPicker → systemType:"options" in stream
  *   - response.content non-empty AND no stream-form picker → assistant bubble (SLICE 1)
- *   - show_suggestions → bottom-of-stream rail (suggestions state)
- *   - _welcomePhases checklist → drops co-emitted show_suggestions
- *   - MessageActions menu renders on assistant bubble
+ *   - _welcomePhases checklist → drops co-emitted show_suggestions (precedent)
+ *   - Stream-form non-welcomePhases picker + co-emitted show_suggestions →
+ *     chips attach to picker footer (pickerChips); floating rail suppressed (SLICE 2)
+ *   - All other show_suggestions → floating rail (suggestionChips)
+ *   - MessageActions menu renders on assistant bubble (today; slice 3 will add to picker)
  */
 function predictRenderPlan(api: ApiResponse): RenderPlan {
   const optionsCalls = api.toolCalls.filter((t) => t.name === "show_options");
@@ -209,6 +212,16 @@ function predictRenderPlan(api: ApiResponse): RenderPlan {
 
   // Pick the picker that surfaces this turn — stream-form preferred.
   const pickerSource = streamOptionsCall ?? fieldPickerCall;
+
+  // SLICE 2 — chips attach to picker iff: stream-form picker present, NOT
+  // welcome-phases, AND show_suggestions co-emitted this turn.
+  const streamFormPickerNonWelcome =
+    streamOptionsCall && streamOptionsCall.input.dataKey !== "_welcomePhases";
+  const pickerChips: string[] | null =
+    streamFormPickerNonWelcome && suggestionsCall && !hasWelcomePhasesChecklist
+      ? (suggestionsCall.input.suggestions as string[] | undefined) ?? null
+      : null;
+
   const picker: RenderPlan["picker"] = pickerSource
     ? {
         question: String(pickerSource.input.question ?? ""),
@@ -220,8 +233,10 @@ function predictRenderPlan(api: ApiResponse): RenderPlan {
       }
     : null;
 
+  // Floating rail: chips suppressed when attached to a picker, or when
+  // welcome-phases dropped them.
   const suggestionChips =
-    suggestionsCall && !hasWelcomePhasesChecklist
+    suggestionsCall && !hasWelcomePhasesChecklist && !pickerChips
       ? (suggestionsCall.input.suggestions as string[] | undefined) ?? null
       : null;
 
@@ -234,6 +249,7 @@ function predictRenderPlan(api: ApiResponse): RenderPlan {
     hasAssistantBubble,
     picker,
     suggestionChips,
+    pickerChips,
     messageActionsOnAssistantBubble: hasAssistantBubble,
   };
 }
@@ -528,9 +544,9 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
       expect.any(Object),
     );
 
-    // ── ASSERT: render-plan after slice 1 (assistant bubble suppressed) ──
+    // ── ASSERT: render-plan after slices 1 + 2 ───────────────────────
 
-    // Turn 1: picker present → assistant bubble SUPPRESSED (was duplicated)
+    // Turn 1: picker present → assistant bubble SUPPRESSED (slice 1)
     expect(turnLog[0].render).toEqual({
       hasAssistantBubble: false,
       picker: expect.objectContaining({
@@ -538,11 +554,12 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
         fieldPicker: false,
       }),
       suggestionChips: null,
+      pickerChips: null,
       messageActionsOnAssistantBubble: false,
     });
 
-    // Turn 4: THE picker turn — bubble suppressed; chip rail stays for now
-    // (slice 2 will move it under the picker)
+    // Turn 4: THE picker turn — bubble suppressed (slice 1), chips moved
+    // under picker (slice 2) — floating rail empty
     expect(turnLog[3].render).toEqual({
       hasAssistantBubble: false,
       picker: expect.objectContaining({
@@ -551,7 +568,8 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
         mode: "radio",
         optionCount: 2,
       }),
-      suggestionChips: ["Continue", "I have a question", "Something else"],
+      suggestionChips: null,
+      pickerChips: ["Continue", "I have a question", "Something else"],
       messageActionsOnAssistantBubble: false,
     });
 
@@ -560,10 +578,12 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
       hasAssistantBubble: true,
       picker: null,
       suggestionChips: null,
+      pickerChips: null,
       messageActionsOnAssistantBubble: true,
     });
   });
 
+  // Slice 2 — chips under picker
   it("welcome-phases checklist drops co-emitted chips (existing precedent)", async () => {
     queueCompletions([
       {
@@ -594,9 +614,11 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
     const api = await postChat("Tell me about welcome", [], {});
     const render = predictRenderPlan(api);
 
-    // Picker present, chips suppressed by _welcomePhases guard
+    // Picker present, chips suppressed by _welcomePhases guard (slice 2
+    // must NOT reintroduce chips on this turn — AC-WelcomePhases-Preservation).
     expect(render.picker).not.toBeNull();
     expect(render.suggestionChips).toBeNull();
+    expect(render.pickerChips).toBeNull();
   });
 
   it("fieldPicker=true panel renders above input bar (not in stream-form preExtras)", async () => {
@@ -705,6 +727,117 @@ describe("Wizard picker dedup — slice 1 (assistant bubble suppression)", () =>
     const render = predictRenderPlan(api);
     expect(render.hasAssistantBubble).toBe(false);
     expect(render.picker).not.toBeNull();
+    expect(render.pickerChips).toBeNull();
     expect(render.messageActionsOnAssistantBubble).toBe(false);
+  });
+});
+
+describe("Wizard picker dedup — slice 2 (chip rail under picker)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAIConfig.mockResolvedValue({
+      engine: "claude",
+      model: "claude-sonnet-4-5-20250929",
+      maxTokens: 4096,
+      temperature: 0.7,
+    });
+    mockEvaluateGraph.mockResolvedValue({
+      promptSection: "",
+      blockedFields: [],
+      completedFields: [],
+    });
+    mockBuildSystemPrompt.mockResolvedValue("V5 SYSTEM PROMPT");
+    mockGetSubjects.mockResolvedValue([]);
+    mockExecuteWizardTool.mockResolvedValue({
+      tool_use_id: "x",
+      content: "ok",
+      is_error: false,
+    });
+  });
+
+  it("stream-form picker + co-emitted chips: chips ATTACH to picker, floating rail empty", async () => {
+    queueCompletions([
+      {
+        content: "Pick progression mode",
+        toolUses: [
+          {
+            id: "p-1",
+            name: "show_options",
+            input: {
+              question: "How should learners progress?",
+              dataKey: "progressionMode",
+              mode: "radio",
+              fieldPicker: false,
+              options: [
+                { value: "learner-picks", label: "Let learners pick", description: "" },
+                { value: "ai-led", label: "AI directs", description: "" },
+              ],
+            },
+          },
+          {
+            id: "s-1",
+            name: "show_suggestions",
+            input: { suggestions: ["Continue", "Something else"] },
+          },
+        ],
+      },
+    ]);
+    const api = await postChat("ready", [], {});
+    const render = predictRenderPlan(api);
+    expect(render.picker).not.toBeNull();
+    expect(render.pickerChips).toEqual(["Continue", "Something else"]);
+    expect(render.suggestionChips).toBeNull();
+  });
+
+  it("show_suggestions WITHOUT picker: floating rail renders normally (regression)", async () => {
+    queueCompletions([
+      {
+        content: "What next?",
+        toolUses: [
+          {
+            id: "s-1",
+            name: "show_suggestions",
+            input: { suggestions: ["A", "B"] },
+          },
+        ],
+      },
+    ]);
+    const api = await postChat("hi", [], {});
+    const render = predictRenderPlan(api);
+    expect(render.picker).toBeNull();
+    expect(render.suggestionChips).toEqual(["A", "B"]);
+    expect(render.pickerChips).toBeNull();
+  });
+
+  it("fieldPicker + chips: chips do NOT attach to picker (out of scope)", async () => {
+    queueCompletions([
+      {
+        content: "Pick something",
+        toolUses: [
+          {
+            id: "fp-1",
+            name: "show_options",
+            input: {
+              question: "Pick",
+              dataKey: "typeSlug",
+              mode: "radio",
+              fieldPicker: true,
+              options: [{ value: "a", label: "A", description: "" }],
+            },
+          },
+          {
+            id: "s-1",
+            name: "show_suggestions",
+            input: { suggestions: ["Continue"] },
+          },
+        ],
+      },
+    ]);
+    const api = await postChat("hi", [], {});
+    const render = predictRenderPlan(api);
+    // FieldPicker is out of scope for slice 2 — chips stay as floating rail
+    expect(render.picker?.fieldPicker).toBe(true);
+    expect(render.pickerChips).toBeNull();
+    expect(render.suggestionChips).toEqual(["Continue"]);
   });
 });

--- a/apps/admin/tests/wizard/picker-dedup-harness.test.ts
+++ b/apps/admin/tests/wizard/picker-dedup-harness.test.ts
@@ -1,0 +1,710 @@
+/**
+ * Wizard Picker Dedup Harness — #978
+ *
+ * Drives the V5 wizard chat through `/api/chat` (WIZARD mode) across a scripted
+ * 5-turn course-build conversation and stops at `create_course`. Mocks the AI
+ * client so tool-call sequences are deterministic and the test runs in <1s.
+ *
+ * Purpose
+ *   1. Baseline the API contract (`{ content, toolCalls }`) per turn so the
+ *      three picker-dedup slices can verify the server-side response shape
+ *      is unchanged.
+ *   2. Run a small `predictRenderPlan(...)` derived from today's client-side
+ *      assembly logic (`ConversationalWizard.tsx` `handleSend` lines 765-805,
+ *      `processToolCalls` lines 506-636). Each slice will update the predictor
+ *      to match the new behavior; the diff between slices IS the spec.
+ *
+ * What this test does NOT cover
+ *   - Full React render. The client logic is replicated as a pure function in
+ *     this file (`predictRenderPlan`). A separate unit test on any extracted
+ *     helper covers the in-component branches.
+ *   - Real LLM behavior. The system prompt is exercised but the model output
+ *     is canned.
+ *   - DB writes for `create_course`. Mocked at the executor boundary.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── MOCKS (must precede route import) ────────────────────────────────────
+
+const { mockCompletion, mockExecuteWizardTool, mockGetAIConfig, mockEvaluateGraph,
+  mockBuildSystemPrompt, mockGetSubjects } = vi.hoisted(() => ({
+  mockCompletion: vi.fn(),
+  mockExecuteWizardTool: vi.fn(),
+  mockGetAIConfig: vi.fn(),
+  mockEvaluateGraph: vi.fn(),
+  mockBuildSystemPrompt: vi.fn(),
+  mockGetSubjects: vi.fn(),
+}));
+
+vi.mock("@/lib/metering", () => ({
+  getConfiguredMeteredAICompletion: mockCompletion,
+  getConfiguredMeteredAICompletionStream: vi.fn(),
+  logMockAIUsage: vi.fn(),
+}));
+
+vi.mock("@/lib/chat/wizard-tool-executor", () => ({
+  executeWizardTool: mockExecuteWizardTool,
+}));
+
+vi.mock("@/lib/ai/config-loader", () => ({
+  getAIConfig: mockGetAIConfig,
+}));
+
+vi.mock("@/lib/wizard/graph-evaluator", () => ({
+  evaluateGraph: mockEvaluateGraph,
+  buildGraphFallback: vi.fn(() => ""),
+}));
+
+vi.mock("@/lib/chat/v5-system-prompt", () => ({
+  buildV5SystemPrompt: mockBuildSystemPrompt,
+}));
+
+vi.mock("@/lib/system-settings", () => ({
+  getKnowledgeRetrievalSettings: vi.fn(async () => ({ enabled: false })),
+  getSubjectsCatalog: mockGetSubjects,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    session: { user: { id: "test-user", role: "OPERATOR" } },
+  })),
+  isAuthError: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/ai/knowledge-accumulation", () => ({
+  logAIInteraction: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logAI: vi.fn(),
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// chat/route imports many siblings — stub the ones that touch DB.
+vi.mock("@/app/api/chat/system-prompts", () => ({
+  buildSystemPrompt: vi.fn(async () => "system"),
+}));
+vi.mock("@/app/api/chat/page-context", () => ({
+  parsePageContext: vi.fn(() => null),
+}));
+vi.mock("@/app/api/chat/tray-reflection", () => ({
+  parseTrayReflections: vi.fn(() => []),
+  buildReflectionMessages: vi.fn(() => []),
+}));
+vi.mock("@/lib/chat/commands", () => ({
+  executeCommand: vi.fn(),
+  parseCommand: vi.fn(() => null),
+}));
+vi.mock("@/app/api/chat/tools", () => ({
+  CHAT_TOOLS: [],
+  executeToolCall: vi.fn(),
+  buildContentCatalog: vi.fn(async () => ({})),
+}));
+vi.mock("@/lib/chat/admin-tools", () => ({ ADMIN_TOOLS: [] }));
+vi.mock("@/lib/chat/admin-tool-handlers", () => ({
+  executeAdminTool: vi.fn(),
+}));
+vi.mock("@/lib/chat/pending-change-payload", () => ({
+  extractPendingChangeFromToolResult: vi.fn(() => null),
+}));
+vi.mock("@/lib/chat/course-ref-tools", () => ({ COURSE_REF_TOOLS: [] }));
+vi.mock("@/lib/chat/course-ref-system-prompt", () => ({
+  buildCourseRefSystemPrompt: vi.fn(async () => "system"),
+}));
+vi.mock("@/lib/chat/course-ref-tool-handlers", () => ({
+  executeCourseRefTool: vi.fn(),
+}));
+vi.mock("@/lib/chat/conversational-wizard-tools", () => ({
+  CONVERSATIONAL_TOOLS: [],
+}));
+vi.mock("@/lib/embeddings", () => ({ embedText: vi.fn() }));
+vi.mock("@/lib/knowledge/retriever", () => ({
+  retrieveKnowledgeForPrompt: vi.fn(async () => null),
+}));
+vi.mock("@/lib/knowledge/domain-sources", () => ({
+  getSourceIdsForDomain: vi.fn(async () => []),
+  getSourceIdsForPlaybook: vi.fn(async () => []),
+}));
+vi.mock("@/lib/enrollment/resolve-playbook", () => ({
+  resolvePlaybookId: vi.fn(async () => null),
+}));
+vi.mock("@/lib/knowledge/assertions", () => ({
+  searchAssertionsHybrid: vi.fn(async () => []),
+  searchAssertions: vi.fn(async () => []),
+  searchCallerMemories: vi.fn(async () => []),
+  formatAssertion: vi.fn(() => ""),
+}));
+vi.mock("@/lib/ai/client", () => ({
+  isEngineAvailable: vi.fn(() => true),
+}));
+vi.mock("@/lib/ai/error-utils", () => ({
+  classifyAIError: vi.fn(() => ({ code: "UNKNOWN" })),
+  userMessageForError: vi.fn(() => "error"),
+}));
+
+// ─── TYPES ────────────────────────────────────────────────────────────────
+
+interface CannedToolUse {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface CannedResponse {
+  content: string;
+  toolUses?: CannedToolUse[];
+  rawContentBlocks?: unknown[];
+}
+
+interface ApiResponse {
+  content: string;
+  toolCalls: Array<{ name: string; input: Record<string, unknown> }>;
+  toolCallCount: number;
+}
+
+interface RenderPlan {
+  /** Does the assistant text bubble appear in the message stream? */
+  hasAssistantBubble: boolean;
+  /** Picker present on this turn (stream-form or fieldPicker) */
+  picker: {
+    question: string;
+    mode: "radio" | "checklist";
+    fieldPicker: boolean;
+    optionCount: number;
+  } | null;
+  /** Suggestion chips on this turn */
+  suggestionChips: string[] | null;
+  /** Whether ... MessageActions menu would render alongside assistant bubble */
+  messageActionsOnAssistantBubble: boolean;
+}
+
+// ─── PREDICTOR (mirrors handleSend assembly + processToolCalls — TODAY) ───
+
+/**
+ * Mirrors `ConversationalWizard.tsx` `handleSend` assembly + `processToolCalls`.
+ *
+ * Current state: slice 1 applied (assistant bubble suppressed when a stream-form
+ * picker is present on the same turn). Slice 2 (chip rail under picker) and
+ * slice 3 (MessageActions on picker) update this function further.
+ *
+ * Rules in force:
+ *   - show_options with fieldPicker=true → fieldPickerPanel (NOT in stream)
+ *   - show_options without fieldPicker → systemType:"options" in stream
+ *   - response.content non-empty AND no stream-form picker → assistant bubble (SLICE 1)
+ *   - show_suggestions → bottom-of-stream rail (suggestions state)
+ *   - _welcomePhases checklist → drops co-emitted show_suggestions
+ *   - MessageActions menu renders on assistant bubble
+ */
+function predictRenderPlan(api: ApiResponse): RenderPlan {
+  const optionsCalls = api.toolCalls.filter((t) => t.name === "show_options");
+  const streamOptionsCall = optionsCalls.find((t) => t.input.fieldPicker !== true);
+  const fieldPickerCall = optionsCalls.find((t) => t.input.fieldPicker === true);
+  const suggestionsCall = api.toolCalls.find((t) => t.name === "show_suggestions");
+
+  const hasWelcomePhasesChecklist = optionsCalls.some(
+    (t) => t.input.mode === "checklist" && t.input.dataKey === "_welcomePhases",
+  );
+
+  // Pick the picker that surfaces this turn — stream-form preferred.
+  const pickerSource = streamOptionsCall ?? fieldPickerCall;
+  const picker: RenderPlan["picker"] = pickerSource
+    ? {
+        question: String(pickerSource.input.question ?? ""),
+        mode: pickerSource.input.mode === "checklist" ? "checklist" : "radio",
+        fieldPicker: pickerSource.input.fieldPicker === true,
+        optionCount: Array.isArray(pickerSource.input.options)
+          ? (pickerSource.input.options as unknown[]).length
+          : 0,
+      }
+    : null;
+
+  const suggestionChips =
+    suggestionsCall && !hasWelcomePhasesChecklist
+      ? (suggestionsCall.input.suggestions as string[] | undefined) ?? null
+      : null;
+
+  // SLICE 1: suppress assistant bubble when a stream-form picker is on the
+  // same turn. FieldPicker turns are out of scope (AC-FieldPicker-Scope).
+  const hasStreamFormPicker = streamOptionsCall !== undefined;
+  const hasAssistantBubble = api.content.length > 0 && !hasStreamFormPicker;
+
+  return {
+    hasAssistantBubble,
+    picker,
+    suggestionChips,
+    messageActionsOnAssistantBubble: hasAssistantBubble,
+  };
+}
+
+// ─── HELPERS ──────────────────────────────────────────────────────────────
+
+/**
+ * Queue canned AI responses for the next `postChat` call. After any response
+ * that includes toolUses, an empty `end_turn` follow-up is auto-appended — the
+ * wizard tool loop always calls the AI once more to give it a chance to ack
+ * the tool results, and without a queued follow-up the mock returns undefined
+ * and the route 500s.
+ */
+function queueCompletions(responses: CannedResponse[]) {
+  mockCompletion.mockReset();
+  for (const r of responses) {
+    mockCompletion.mockResolvedValueOnce({
+      content: r.content,
+      engine: "claude",
+      model: "claude-sonnet-4-5-20250929",
+      stopReason: r.toolUses?.length ? "tool_use" : "end_turn",
+      toolUses: r.toolUses ?? [],
+      rawContentBlocks: r.rawContentBlocks ?? [
+        ...(r.content ? [{ type: "text", text: r.content }] : []),
+        ...(r.toolUses ?? []).map((t) => ({
+          type: "tool_use",
+          id: t.id,
+          name: t.name,
+          input: t.input,
+        })),
+      ],
+    });
+    if (r.toolUses && r.toolUses.length > 0) {
+      // Auto follow-up: tool loop calls AI again after executing tools.
+      mockCompletion.mockResolvedValueOnce({
+        content: "",
+        engine: "claude",
+        model: "claude-sonnet-4-5-20250929",
+        stopReason: "end_turn",
+        toolUses: [],
+        rawContentBlocks: [],
+      });
+    }
+  }
+}
+
+async function postChat(message: string, conversationHistory: Array<{ role: string; content: string }>, setupData: Record<string, unknown>): Promise<ApiResponse> {
+  const { POST } = await import("@/app/api/chat/route");
+  const req = new NextRequest("http://localhost/api/chat", {
+    method: "POST",
+    body: JSON.stringify({
+      mode: "WIZARD",
+      message,
+      conversationHistory,
+      setupData,
+      entityContext: [],
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const res = await POST(req);
+  const body = await res.json();
+  if (res.status !== 200) {
+    throw new Error(`postChat ${res.status}: ${JSON.stringify(body)}`);
+  }
+  return body as ApiResponse;
+}
+
+// ─── TESTS ────────────────────────────────────────────────────────────────
+
+describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAIConfig.mockResolvedValue({
+      engine: "claude",
+      model: "claude-sonnet-4-5-20250929",
+      maxTokens: 4096,
+      temperature: 0.7,
+    });
+    mockEvaluateGraph.mockResolvedValue({
+      promptSection: "",
+      blockedFields: [],
+      completedFields: [],
+    });
+    mockBuildSystemPrompt.mockResolvedValue("V5 SYSTEM PROMPT");
+    mockGetSubjects.mockResolvedValue([]);
+    // Default executor — never called for show_* tools, only for update_setup
+    // and create_course. Returns minimal success shape.
+    mockExecuteWizardTool.mockImplementation(async (name: string) => ({
+      tool_use_id: "x",
+      content: "ok",
+      is_error: false,
+      ...(name === "create_course"
+        ? { setupDataPatch: { draftPlaybookId: "pb-test", courseName: "Test Course" } }
+        : {}),
+    }));
+  });
+
+  it("drives 5 scripted turns and stops at create_course", async () => {
+    const history: Array<{ role: string; content: string }> = [];
+    let setupData: Record<string, unknown> = {};
+    const turnLog: Array<{ user: string; api: ApiResponse; render: RenderPlan }> = [];
+
+    // ── Turn 1: typeSlug picker ───────────────────────────────────────
+    queueCompletions([
+      {
+        content: "What kind of course are you building?",
+        toolUses: [
+          {
+            id: "t1-1",
+            name: "show_options",
+            input: {
+              question: "What kind of course are you building?",
+              dataKey: "typeSlug",
+              mode: "radio",
+              fieldPicker: false,
+              options: [
+                { value: "language", label: "Language", description: "" },
+                { value: "professional", label: "Professional skills", description: "" },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    let api = await postChat("I want to build a course", history, setupData);
+    history.push({ role: "user", content: "I want to build a course" });
+    history.push({ role: "assistant", content: api.content });
+    turnLog.push({ user: "I want to build a course", api, render: predictRenderPlan(api) });
+
+    // ── Turn 2: audience picker ───────────────────────────────────────
+    setupData = { ...setupData, typeSlug: "language" };
+    queueCompletions([
+      {
+        content: "Great — language. Who's the audience?",
+        toolUses: [
+          {
+            id: "t2-1",
+            name: "show_options",
+            input: {
+              question: "Who's the audience?",
+              dataKey: "audience",
+              mode: "radio",
+              fieldPicker: false,
+              options: [
+                { value: "ielts-prep", label: "IELTS prep", description: "" },
+                { value: "business-english", label: "Business English", description: "" },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    api = await postChat("Language", history, setupData);
+    history.push({ role: "user", content: "Language" });
+    history.push({ role: "assistant", content: api.content });
+    turnLog.push({ user: "Language", api, render: predictRenderPlan(api) });
+
+    // ── Turn 3: goals checklist + co-emitted chips ────────────────────
+    setupData = { ...setupData, audience: "ielts-prep" };
+    queueCompletions([
+      {
+        content: "IELTS prep — what are the learner goals?",
+        toolUses: [
+          {
+            id: "t3-1",
+            name: "show_options",
+            input: {
+              question: "What goals should learners hit?",
+              dataKey: "learningOutcomes",
+              mode: "checklist",
+              fieldPicker: false,
+              options: [
+                { value: "band-7", label: "Band 7 overall", description: "" },
+                { value: "fluency", label: "Speaking fluency", description: "" },
+              ],
+            },
+          },
+          {
+            id: "t3-2",
+            name: "show_suggestions",
+            input: {
+              suggestions: ["Sounds right", "Something else", "Skip"],
+            },
+          },
+        ],
+      },
+    ]);
+    api = await postChat("IELTS prep", history, setupData);
+    history.push({ role: "user", content: "IELTS prep" });
+    history.push({ role: "assistant", content: api.content });
+    turnLog.push({ user: "IELTS prep", api, render: predictRenderPlan(api) });
+
+    // ── Turn 4: progressionMode picker (THE picker turn — fix #978) ───
+    setupData = { ...setupData, learningOutcomes: ["band-7", "fluency"] };
+    queueCompletions([
+      {
+        content: "Your course-ref doc declares a module catalogue. How should learners progress?",
+        toolUses: [
+          {
+            id: "t4-1",
+            name: "show_options",
+            input: {
+              question: "Your course-ref doc declares a module catalogue. How should learners progress?",
+              dataKey: "progressionMode",
+              mode: "radio",
+              fieldPicker: false,
+              options: [
+                {
+                  value: "learner-picks",
+                  label: "Let learners pick from a menu",
+                  description: "",
+                  recommended: true,
+                },
+                { value: "ai-led", label: "AI directs the sequence", description: "" },
+              ],
+            },
+          },
+          {
+            id: "t4-2",
+            name: "show_suggestions",
+            input: {
+              suggestions: ["Continue", "I have a question", "Something else"],
+            },
+          },
+        ],
+      },
+    ]);
+    api = await postChat("Band 7 + fluency", history, setupData);
+    history.push({ role: "user", content: "Band 7 + fluency" });
+    history.push({ role: "assistant", content: api.content });
+    turnLog.push({ user: "Band 7 + fluency", api, render: predictRenderPlan(api) });
+
+    // ── Turn 5: create_course (STOP) ──────────────────────────────────
+    setupData = { ...setupData, progressionMode: "learner-picks" };
+    queueCompletions([
+      {
+        content: "Building your course now…",
+        toolUses: [
+          {
+            id: "t5-1",
+            name: "create_course",
+            input: {
+              courseName: "IELTS Prep Lab",
+              typeSlug: "language",
+              audience: "ielts-prep",
+            },
+          },
+        ],
+      },
+    ]);
+    api = await postChat("Let learners pick", history, setupData);
+    turnLog.push({ user: "Let learners pick", api, render: predictRenderPlan(api) });
+
+    // ── ASSERT: per-turn API shape (the stable contract) ──────────────
+
+    expect(turnLog).toHaveLength(5);
+
+    // Turn 1 — picker on typeSlug
+    expect(turnLog[0].api.toolCalls).toEqual([
+      expect.objectContaining({ name: "show_options" }),
+    ]);
+    expect(turnLog[0].api.content).toBe("What kind of course are you building?");
+
+    // Turn 2 — picker on audience
+    expect(turnLog[1].api.toolCalls).toEqual([
+      expect.objectContaining({ name: "show_options" }),
+    ]);
+
+    // Turn 3 — picker + chips
+    expect(turnLog[2].api.toolCalls.map((t) => t.name).sort()).toEqual([
+      "show_options",
+      "show_suggestions",
+    ]);
+
+    // Turn 4 — THE picker turn — picker + chips co-emit
+    expect(turnLog[3].api.toolCalls.map((t) => t.name).sort()).toEqual([
+      "show_options",
+      "show_suggestions",
+    ]);
+    const t4Options = turnLog[3].api.toolCalls.find((t) => t.name === "show_options")!;
+    expect(t4Options.input.dataKey).toBe("progressionMode");
+    expect((t4Options.input.options as unknown[]).length).toBe(2);
+
+    // Turn 5 — create_course fires and STOPS
+    expect(turnLog[4].api.toolCalls).toEqual([
+      expect.objectContaining({ name: "create_course" }),
+    ]);
+    expect(mockExecuteWizardTool).toHaveBeenCalledWith(
+      "create_course",
+      expect.objectContaining({ courseName: "IELTS Prep Lab" }),
+      "test-user",
+      expect.any(Object),
+    );
+
+    // ── ASSERT: render-plan after slice 1 (assistant bubble suppressed) ──
+
+    // Turn 1: picker present → assistant bubble SUPPRESSED (was duplicated)
+    expect(turnLog[0].render).toEqual({
+      hasAssistantBubble: false,
+      picker: expect.objectContaining({
+        question: "What kind of course are you building?",
+        fieldPicker: false,
+      }),
+      suggestionChips: null,
+      messageActionsOnAssistantBubble: false,
+    });
+
+    // Turn 4: THE picker turn — bubble suppressed; chip rail stays for now
+    // (slice 2 will move it under the picker)
+    expect(turnLog[3].render).toEqual({
+      hasAssistantBubble: false,
+      picker: expect.objectContaining({
+        question: expect.stringContaining("module catalogue"),
+        fieldPicker: false,
+        mode: "radio",
+        optionCount: 2,
+      }),
+      suggestionChips: ["Continue", "I have a question", "Something else"],
+      messageActionsOnAssistantBubble: false,
+    });
+
+    // Turn 5: no picker — assistant bubble RENDERS (regression check)
+    expect(turnLog[4].render).toEqual({
+      hasAssistantBubble: true,
+      picker: null,
+      suggestionChips: null,
+      messageActionsOnAssistantBubble: true,
+    });
+  });
+
+  it("welcome-phases checklist drops co-emitted chips (existing precedent)", async () => {
+    queueCompletions([
+      {
+        content: "What welcome moments do you want?",
+        toolUses: [
+          {
+            id: "wp-1",
+            name: "show_options",
+            input: {
+              question: "What welcome moments do you want?",
+              dataKey: "_welcomePhases",
+              mode: "checklist",
+              fieldPicker: false,
+              options: [
+                { value: "goals", label: "Goals", description: "" },
+                { value: "intro", label: "AI Introduction", description: "" },
+              ],
+            },
+          },
+          {
+            id: "wp-2",
+            name: "show_suggestions",
+            input: { suggestions: ["This should be dropped"] },
+          },
+        ],
+      },
+    ]);
+    const api = await postChat("Tell me about welcome", [], {});
+    const render = predictRenderPlan(api);
+
+    // Picker present, chips suppressed by _welcomePhases guard
+    expect(render.picker).not.toBeNull();
+    expect(render.suggestionChips).toBeNull();
+  });
+
+  it("fieldPicker=true panel renders above input bar (not in stream-form preExtras)", async () => {
+    queueCompletions([
+      {
+        content: "Pick a course type",
+        toolUses: [
+          {
+            id: "fp-1",
+            name: "show_options",
+            input: {
+              question: "Pick a course type",
+              dataKey: "typeSlug",
+              mode: "radio",
+              fieldPicker: true,
+              options: [{ value: "language", label: "Language", description: "" }],
+            },
+          },
+        ],
+      },
+    ]);
+    const api = await postChat("ready", [], {});
+    const render = predictRenderPlan(api);
+
+    expect(render.picker?.fieldPicker).toBe(true);
+    // AC-FieldPicker-Scope: slice 1 MUST NOT touch fieldPicker turns. The
+    // assistant bubble still renders alongside the fieldPicker panel.
+    expect(render.hasAssistantBubble).toBe(true);
+  });
+});
+
+describe("Wizard picker dedup — slice 1 (assistant bubble suppression)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAIConfig.mockResolvedValue({
+      engine: "claude",
+      model: "claude-sonnet-4-5-20250929",
+      maxTokens: 4096,
+      temperature: 0.7,
+    });
+    mockEvaluateGraph.mockResolvedValue({
+      promptSection: "",
+      blockedFields: [],
+      completedFields: [],
+    });
+    mockBuildSystemPrompt.mockResolvedValue("V5 SYSTEM PROMPT");
+    mockGetSubjects.mockResolvedValue([]);
+    mockExecuteWizardTool.mockResolvedValue({
+      tool_use_id: "x",
+      content: "ok",
+      is_error: false,
+    });
+  });
+
+  it("non-picker turn: assistant bubble + menu render normally (regression)", async () => {
+    queueCompletions([
+      { content: "Pure prose, no tools.", toolUses: [] },
+    ]);
+    const api = await postChat("hi", [], {});
+    const render = predictRenderPlan(api);
+    expect(render.hasAssistantBubble).toBe(true);
+    expect(render.picker).toBeNull();
+    expect(render.messageActionsOnAssistantBubble).toBe(true);
+  });
+
+  it("show_suggestions alone (no picker): chips render, bubble renders", async () => {
+    queueCompletions([
+      {
+        content: "Pick one:",
+        toolUses: [
+          {
+            id: "s-1",
+            name: "show_suggestions",
+            input: { suggestions: ["A", "B", "C"] },
+          },
+        ],
+      },
+    ]);
+    const api = await postChat("hi", [], {});
+    const render = predictRenderPlan(api);
+    expect(render.hasAssistantBubble).toBe(true);
+    expect(render.picker).toBeNull();
+    expect(render.suggestionChips).toEqual(["A", "B", "C"]);
+  });
+
+  it("stream-form picker only (no chips): bubble suppressed, picker rendered", async () => {
+    queueCompletions([
+      {
+        content: "What kind?",
+        toolUses: [
+          {
+            id: "p-1",
+            name: "show_options",
+            input: {
+              question: "What kind?",
+              dataKey: "typeSlug",
+              mode: "radio",
+              fieldPicker: false,
+              options: [{ value: "a", label: "A", description: "" }],
+            },
+          },
+        ],
+      },
+    ]);
+    const api = await postChat("hi", [], {});
+    const render = predictRenderPlan(api);
+    expect(render.hasAssistantBubble).toBe(false);
+    expect(render.picker).not.toBeNull();
+    expect(render.messageActionsOnAssistantBubble).toBe(false);
+  });
+});

--- a/apps/admin/tests/wizard/picker-dedup-harness.test.ts
+++ b/apps/admin/tests/wizard/picker-dedup-harness.test.ts
@@ -180,6 +180,12 @@ interface RenderPlan {
   pickerChips: string[] | null;
   /** Whether ... MessageActions menu would render alongside assistant bubble */
   messageActionsOnAssistantBubble: boolean;
+  /**
+   * #978 Slice 3 — ... MessageActions menu mounted on stream-form pickers
+   * with a subset (`correct`, `more`, `skip` only). Null when no picker or
+   * fieldPicker (out of scope for this story).
+   */
+  messageActionsOnPicker: ("correct" | "more" | "skip")[] | null;
 }
 
 // ─── PREDICTOR (mirrors handleSend assembly + processToolCalls — TODAY) ───
@@ -245,12 +251,18 @@ function predictRenderPlan(api: ApiResponse): RenderPlan {
   const hasStreamFormPicker = streamOptionsCall !== undefined;
   const hasAssistantBubble = api.content.length > 0 && !hasStreamFormPicker;
 
+  // SLICE 3: when a stream-form picker is on the turn, the OptionsCard mounts
+  // MessageActions with the decision subset. FieldPicker is out of scope.
+  const messageActionsOnPicker: RenderPlan["messageActionsOnPicker"] =
+    hasStreamFormPicker ? ["correct", "more", "skip"] : null;
+
   return {
     hasAssistantBubble,
     picker,
     suggestionChips,
     pickerChips,
     messageActionsOnAssistantBubble: hasAssistantBubble,
+    messageActionsOnPicker,
   };
 }
 
@@ -544,9 +556,10 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
       expect.any(Object),
     );
 
-    // ── ASSERT: render-plan after slices 1 + 2 ───────────────────────
+    // ── ASSERT: render-plan after slices 1 + 2 + 3 ───────────────────
 
-    // Turn 1: picker present → assistant bubble SUPPRESSED (slice 1)
+    // Turn 1: picker present → assistant bubble SUPPRESSED (slice 1),
+    // ... menu mounted on picker with subset (slice 3)
     expect(turnLog[0].render).toEqual({
       hasAssistantBubble: false,
       picker: expect.objectContaining({
@@ -556,10 +569,13 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
       suggestionChips: null,
       pickerChips: null,
       messageActionsOnAssistantBubble: false,
+      messageActionsOnPicker: ["correct", "more", "skip"],
     });
 
-    // Turn 4: THE picker turn — bubble suppressed (slice 1), chips moved
-    // under picker (slice 2) — floating rail empty
+    // Turn 4: THE picker turn — all three slices visible together:
+    // - bubble suppressed (slice 1)
+    // - chips under picker (slice 2)
+    // - ... menu subset on picker (slice 3)
     expect(turnLog[3].render).toEqual({
       hasAssistantBubble: false,
       picker: expect.objectContaining({
@@ -571,15 +587,17 @@ describe("Wizard picker dedup harness — #978 baseline (pre-slice-1)", () => {
       suggestionChips: null,
       pickerChips: ["Continue", "I have a question", "Something else"],
       messageActionsOnAssistantBubble: false,
+      messageActionsOnPicker: ["correct", "more", "skip"],
     });
 
-    // Turn 5: no picker — assistant bubble RENDERS (regression check)
+    // Turn 5: no picker — assistant bubble RENDERS, ... menu on bubble (legacy)
     expect(turnLog[4].render).toEqual({
       hasAssistantBubble: true,
       picker: null,
       suggestionChips: null,
       pickerChips: null,
       messageActionsOnAssistantBubble: true,
+      messageActionsOnPicker: null,
     });
   });
 


### PR DESCRIPTION
## Summary

Three-slice hygiene fix for the V5 wizard chat. When the wizard emits a stream-form picker (`show_options` with `fieldPicker !== true`), it previously also rendered:
- An assistant text bubble below the picker restating the same question word-for-word
- A floating chip rail at the bottom of the chat
- A `...` actions menu on the assistant bubble (not on the picker)

The picker is self-contained — the bubble was pure duplication. This PR:
1. **Slice 1** — suppresses the duplicate assistant bubble on stream-form picker turns
2. **Slice 2** — attaches the chip rail to the picker footer (instead of floating at chat bottom)
3. **Slice 3** — mounts the `...` actions menu on the picker with a decision-shaped subset (Copy/Quote excluded; they'd operate on `panel.question` which isn't sensible UX)

Each slice is a separate commit and can be reverted independently.

## Scope guards (per Tech Lead review)

- **AC-FieldPicker-Scope** — fieldPicker mode (renders above input bar) is OUT OF SCOPE. Untouched throughout.
- **AC-WelcomePhases-Preservation** — the `_welcomePhases` checklist intentionally drops co-emitted chips today; that precedent is preserved.
- **AC-MessageActions-Subset** — picker mounts only `correct`/`more`/`skip` actions. Copy and Quote remain on assistant bubbles only.
- **AC-Escape-Collision** — Esc inside an open MessageActions menu closes the menu without dismissing the picker (capture-phase + stopPropagation in MessageActions; verified by RTL test).

## What MUST NOT change (covered by regression tests)

- Non-picker assistant messages — full render, full `...` menu (Copy/Quote retained)
- Non-picker chip rails (show_suggestions without co-emitted picker) — floating rail unchanged
- `show_options` server-side contract — server + system prompt untouched
- `_welcomePhases` welcome flow — drops chips today, still drops chips after this PR

## Test plan

- [x] **New wizard API harness** at `apps/admin/tests/wizard/picker-dedup-harness.test.ts` — drives `/api/chat` POST (WIZARD mode) through 5 scripted turns (typeSlug → audience → goals → progressionMode → create_course) with mocked AI client. Captures per-turn API response and runs `predictRenderPlan()` mirroring `handleSend` + `processToolCalls` assembly. 9/9 pass in ~265ms.
- [x] **New RTL test** at `apps/admin/tests/wizard/options-card-message-actions.test.tsx` — verifies the actual DOM contract: subset menu renders without Copy/Quote, OptionsCard works without messageActions prop (back-compat), Escape-collision QA gate, slice 2 + 3 together. 4/4 pass.
- [x] **Adjacent regression** — `tests/lib/session-flow/` (88) + `tests/components/` (131) all pass (219/219).
- [x] **Type check clean** on all touched files (ConversationalWizard, OptionsCard, MessageActions, wizard.css, both test files).
- [x] **VM eyeball** on `/x/get-started-v5` — pending operator confirmation (this PR).

## Files

| File | Change |
|---|---|
| `apps/admin/app/x/wizard/components/ConversationalWizard.tsx` | Slice 1: bubble suppress check. Slice 2: co-emission detect + attach chips to panel + skip floating rail. Slice 3: pass MessageActions to OptionsCard. |
| `apps/admin/app/x/wizard/components/OptionsCard.tsx` | Slice 2: `suggestionChips?` field + `onChipClick?` prop + chip render. Slice 3: `messageActions?` ReactNode slot + footer-right wrapper. |
| `apps/admin/app/x/wizard/components/MessageActions.tsx` | Slice 3: `actionsSubset?: MessageActionId[]` prop filters action list. |
| `apps/admin/app/x/wizard/wizard.css` | Slice 2: `.cv4-options-suggestion-chips`. Slice 3: `.cv4-options-footer-right`. CSS vars only, no hex. |
| `apps/admin/tests/wizard/picker-dedup-harness.test.ts` | New — full 5-turn harness + slice-specific describe blocks. |
| `apps/admin/tests/wizard/options-card-message-actions.test.tsx` | New — 4 RTL tests covering the slice 3 DOM contract + Esc gate. |

## UI verification (on localhost:3000 via /vm-cp tunnel)

Navigate to `/x/get-started-v5`, drive a course conversation to the progression-mode picker. Verify:
1. No narrative bubble below the picker card
2. Chips attached to picker footer (not floating at chat bottom)
3. `...` menu on picker shows only "That's not right / Tell me more / Move on"
4. Non-picker assistant messages still show the full `...` menu with Copy / Quote

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)