### PR TITLE
chore(ratchet): replace any[] with unknown[] in learner-scope test mock

### DIFF
--- a/apps/admin/tests/lib/learner-scope.test.ts
+++ b/apps/admin/tests/lib/learner-scope.test.ts
@@ -17,7 +17,7 @@ const mockCallerFindFirst = vi.fn();
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     caller: {
-      findFirst: (...args: any[]) => mockCallerFindFirst(...args),
+      findFirst: (...args: unknown[]) => mockCallerFindFirst(...args),
     },
   },
 }));


### PR DESCRIPTION
Restores lint_warnings baseline 4441 (was 4442 after #983 merged). Single-line typing fix in the Prisma findFirst mock signature. Unblocks STAGING deploy gate.

## Test plan
- [x] `npx vitest run tests/lib/learner-scope.test.ts` — 9/9 pass
- [x] `npm run ratchet:check` — lint_warnings 4441 (== baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)