### PR TITLE
chore(#986): allow-list /api/system/db-target in route-auth-coverage test

### DIFF
--- a/apps/admin/tests/lib/route-auth-coverage.test.ts
+++ b/apps/admin/tests/lib/route-auth-coverage.test.ts
@@ -26,6 +26,7 @@ const PUBLIC_ROUTES = new Set([
   "app/api/health/route.ts",
   "app/api/ready/route.ts",
   "app/api/system/readiness/route.ts",
+  "app/api/system/db-target/route.ts",  // Returns live runtime DATABASE_URL target — used by status-bar chip + /db-route verification (#986)
   "app/api/invite/route.ts",         // Accept invite (token-based, not session)
   "app/api/invite/accept/route.ts",
   "app/api/invite/verify/route.ts",  // Token-based invite verification (no session)


### PR DESCRIPTION
Follow-up to #986. The route is intentionally public (status-bar chip + /db-route verification, no sensitive data). Test is quarantined so this doesn't unblock anything today — keeps the allowlist in sync for when it un-quarantines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)