### PR TITLE
fix(#989): scope sim service worker to /x/sim/, unregister wide-scope leak

### DIFF
--- a/apps/admin/app/x/sim/layout.tsx
+++ b/apps/admin/app/x/sim/layout.tsx
@@ -15,9 +15,22 @@ export default function SimLayout({ children }: { children: React.ReactNode }) {
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
 
   useEffect(() => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js').catch(() => {});
-    }
+    if (!('serviceWorker' in navigator)) return;
+    // #989 — clean up any prior root-scoped registration from when sw.js was
+    // registered without `scope`. Without this, existing browsers keep the
+    // wide-scope SW intercepting fetches across the admin chrome (e.g. the
+    // /x/courses status-bar chip ended up serving stale JS for hours).
+    navigator.serviceWorker.getRegistrations()
+      .then((regs) => {
+        regs.forEach((reg) => {
+          if (!reg.scope.includes('/x/sim/')) {
+            reg.unregister().catch(() => {});
+          }
+        });
+      })
+      .catch(() => { /* non-fatal */ });
+    navigator.serviceWorker.register('/sw.js', { scope: '/x/sim/' })
+      .catch(() => {});
   }, []);
 
   function onResizeMouseDown(e: React.MouseEvent) {


### PR DESCRIPTION
## Summary
- Adds `scope: '/x/sim/'` to the `navigator.serviceWorker.register('/sw.js')` call in `app/x/sim/layout.tsx`
- Before registering, evicts any pre-existing root-scoped SW from prior visits (via `getRegistrations()` + filter on scope not under `/x/sim/`)

## Why
The default scope is the SW's directory (`/`), so the sim SW was intercepting **every** request across `dev.humanfirstfoundation.com`. Caught while debugging why #986's chip-runtime fix wasn't visible after deploy — the new bundle had shipped but Safari was serving the old one out of the wide-scope SW cache.

## Test plan
- [x] `npx tsc --noEmit` clean on touched file
- [ ] Manual: visit `/x/sim` (registers SW with scope /x/sim/), then `/x/courses`, confirm DevTools > Application > Service Workers shows ONE registration scoped to `/x/sim/`, and `/api/system/db-target` returns a fresh value not a SW-cached one
- [ ] Manual: pre-fix browser with the wide-scope SW → load any page → SW gets unregistered → on next load only the narrow one remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)