### PR TITLE
fix(#990): recover the 4 chip-hook consumer files that were dropped from #986

### DIFF
--- a/apps/admin/components/shared/EnvironmentBanner.tsx
+++ b/apps/admin/components/shared/EnvironmentBanner.tsx
@@ -7,7 +7,7 @@
  * Exports env color/label for StatusBar badge, AccountPanel, and login page.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * Environment detection — set via NEXT_PUBLIC_APP_ENV in .env/.env.local
@@ -96,6 +96,40 @@ export function dbTargetColor(target: string | null): string | null {
   if (!target) return null;
   const key = target.toUpperCase();
   return ENV_COLORS[key]?.sidebar ?? null;
+}
+
+/**
+ * Hook: read the DB target from /api/system/db-target (runtime DATABASE_URL).
+ * Falls back to the build-baked NEXT_PUBLIC_DB_TARGET / NEXT_PUBLIC_APP_ENV
+ * for the initial render so server-rendered HTML doesn't flicker.
+ *
+ * Use this instead of the build-baked `envDbTarget` / `envDbEffective` /
+ * `isDbSwitched` constants when the value needs to follow a live
+ * `/db-route` secret-rebind. The constants are still exported for callers
+ * that don't care about live updates (e.g. analytics).
+ */
+export function useDbState(): {
+  dbTarget: string | null;
+  dbEffective: string;
+  isDbSwitched: boolean;
+} {
+  const [dbTarget, setDbTarget] = useState<string | null>(envDbTarget);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/system/db-target')
+      .then((r) => r.json())
+      .then((d) => {
+        if (cancelled) return;
+        if (d?.ok && typeof d.dbTarget === 'string') setDbTarget(d.dbTarget);
+      })
+      .catch(() => { /* non-fatal — falls back to build-baked value */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  const dbEffective = (dbTarget || ENV_CANONICAL).toLowerCase();
+  const isDbSwitched = !!dbTarget && dbTarget.toUpperCase() !== ENV_CANONICAL;
+  return { dbTarget, dbEffective, isDbSwitched };
 }
 
 /** Whether we're running on localhost/VM (vs Cloud Run) — detected at runtime */

--- a/apps/admin/components/shared/StatusBar.tsx
+++ b/apps/admin/components/shared/StatusBar.tsx
@@ -26,7 +26,7 @@ import { ROLE_LEVEL } from '@/lib/roles';
 import { useBranding } from '@/contexts/BrandingContext';
 import { useMasquerade } from '@/contexts/MasqueradeContext';
 import { useErrorCapture } from '@/contexts/ErrorCaptureContext';
-import { envLabel, envSidebarColor, envTextColor, showEnvBanner, envDbEffective, isDbSwitched, dbTargetColor } from './EnvironmentBanner';
+import { envLabel, envSidebarColor, envTextColor, showEnvBanner, dbTargetColor, useDbState } from './EnvironmentBanner';
 import { JobsPopup } from './JobsPopup';
 import { HealthPopup } from './HealthPopup';
 import type { IniResult } from './HealthPopup';
@@ -77,6 +77,7 @@ export function StatusBar() {
   const { branding, loading: brandingLoading } = useBranding();
   const { isMasquerading, masquerade, stopMasquerade } = useMasquerade();
   const { errorCount } = useErrorCapture();
+  const { dbEffective, isDbSwitched } = useDbState();
 
   const router = useRouter();
 
@@ -301,8 +302,8 @@ export function StatusBar() {
             Default (matched):  "SANDBOX · DB:sandbox"
             Switched (loaded gun): "SANDBOX · DB→PILOT" with right half tinted target color */}
         {showEnvBanner && envLabel && envSidebarColor && (() => {
-          const dbColor = isDbSwitched ? dbTargetColor(envDbEffective) : null;
-          const dbLabel = isDbSwitched ? `DB→${envDbEffective.toUpperCase()}` : `DB:${envDbEffective}`;
+          const dbColor = isDbSwitched ? dbTargetColor(dbEffective) : null;
+          const dbLabel = isDbSwitched ? `DB→${dbEffective.toUpperCase()}` : `DB:${dbEffective}`;
           return (
             <span
               className="hf-status-env-badge hf-status-clickable"
@@ -311,7 +312,7 @@ export function StatusBar() {
                 ...(envTextColor ? { color: envTextColor } : {}),
               }}
               onClick={() => router.push('/x/settings')}
-              title={isDbSwitched ? `${envLabel} code, DB pointed at ${envDbEffective.toUpperCase()}` : `${envLabel} · DB:${envDbEffective}`}
+              title={isDbSwitched ? `${envLabel} code, DB pointed at ${dbEffective.toUpperCase()}` : `${envLabel} · DB:${dbEffective}`}
             >
               {envLabel}
               <span aria-hidden="true" style={{ opacity: 0.5, marginInline: 4 }}>·</span>

--- a/apps/admin/components/shared/UserAvatar.tsx
+++ b/apps/admin/components/shared/UserAvatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { envDbTarget, dbTargetColor, envCanonical } from "./EnvironmentBanner";
+import { dbTargetColor, useDbState } from "./EnvironmentBanner";
 
 export const ROLE_COLORS: Record<string, string> = {
   SUPERADMIN: "var(--status-error-text)",
@@ -68,6 +68,8 @@ export function UserAvatar({
   className,
   style,
 }: UserAvatarProps) {
+  const { dbTarget: liveDbTarget, isDbSwitched } = useDbState();
+
   // Custom initials take priority, then auto-compute from name
   const displayInitials = initials?.trim() || computeInitials(name);
 
@@ -86,10 +88,7 @@ export function UserAvatar({
   // DB-target ring: when sandbox VM is pointed at a non-sandbox DB (staging/pilot),
   // ring color matches that env. When DB matches env (default), no ring.
   // The ring is the loaded-gun guard — visible on every avatar instance, can't be missed.
-  const ringTarget =
-    envDbTarget && envDbTarget.toUpperCase() !== envCanonical
-      ? envDbTarget
-      : null;
+  const ringTarget = isDbSwitched ? liveDbTarget : null;
   const ringColor = dbTargetColor(ringTarget);
   const ringShadow = ringColor
     ? `0 0 0 2px var(--surface-primary), 0 0 0 4px ${ringColor}`

--- a/apps/admin/components/shared/UserContextMenu.tsx
+++ b/apps/admin/components/shared/UserContextMenu.tsx
@@ -28,7 +28,7 @@ import { useMasquerade } from "@/contexts/MasqueradeContext";
 import { useDomainScope } from "@/contexts/DomainScopeContext";
 import { ROLE_LEVEL } from "@/lib/roles";
 import { UserAvatar, ROLE_COLORS } from "./UserAvatar";
-import { envLabel, envSidebarColor, envTextColor, showEnvBanner, envDbEffective, isDbSwitched, dbTargetColor } from "./EnvironmentBanner";
+import { envLabel, envSidebarColor, envTextColor, showEnvBanner, dbTargetColor, useDbState } from "./EnvironmentBanner";
 
 const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION;
 
@@ -66,6 +66,7 @@ export function UserContextMenu({
 }: UserContextMenuProps) {
   const { data: session } = useSession();
   const { preference: theme, setPreference: setTheme } = useTheme();
+  const { dbEffective, isDbSwitched } = useDbState();
   const [appearanceOpen, setAppearanceOpen] = useState(false);
   const [stepInOpen, setStepInOpen] = useState(false);
   const [stepInSearch, setStepInSearch] = useState("");
@@ -445,7 +446,7 @@ export function UserContextMenu({
                   alignItems: "center",
                   gap: 4,
                 }}
-                title={isDbSwitched ? `${envLabel} code, DB pointed at ${envDbEffective.toUpperCase()}` : `${envLabel} · DB:${envDbEffective}`}
+                title={isDbSwitched ? `${envLabel} code, DB pointed at ${dbEffective.toUpperCase()}` : `${envLabel} · DB:${dbEffective}`}
               >
                 {envLabel}
                 <span aria-hidden="true" style={{ opacity: 0.5 }}>·</span>
@@ -453,7 +454,7 @@ export function UserContextMenu({
                   style={
                     isDbSwitched
                       ? {
-                          background: dbTargetColor(envDbEffective) || undefined,
+                          background: dbTargetColor(dbEffective) || undefined,
                           color: "var(--surface-primary)",
                           borderRadius: 3,
                           padding: "0 4px",
@@ -461,7 +462,7 @@ export function UserContextMenu({
                       : { opacity: 0.85 }
                   }
                 >
-                  {isDbSwitched ? `DB→${envDbEffective.toUpperCase()}` : `DB:${envDbEffective}`}
+                  {isDbSwitched ? `DB→${dbEffective.toUpperCase()}` : `DB:${dbEffective}`}
                 </span>
               </span>
             )}


### PR DESCRIPTION
Recovery PR. PR #986 was meant to switch StatusBar/UserAvatar/UserContextMenu/EnvironmentBanner to a runtime-fetched useDbState() hook. My git add command had a bad path prefix that aborted the add, so only the API route + test + skill got staged. The 4 component files have been sitting uncommitted for 8 hours while we kept deploying the same broken bundle.

Closes the actual loop on #986 + #988 + #989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)