### PR TITLE
chore: fix two stale main-branch unit tests (setup-status auth mock + Learner-detail tab labels)

### DIFF
--- a/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
+++ b/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
@@ -29,7 +29,20 @@ describe("buildPageFeatureCatalogue", () => {
 
   it("lists every tab label registered for Learner detail", () => {
     const out = buildPageFeatureCatalogue("/x/callers/caller-xyz");
-    for (const label of ["Overview", "Uplift", "Calls", "Tune", "How", "What", "Artifacts", "AI Call"]) {
+    // Source of truth: lib/help/page-help.ts → Learner detail entry. The
+    // older labels {How, What, Artifacts, AI Call} were renamed/merged
+    // into {Profile, Call} (ids `how`, `ai-call`); What + Artifacts were
+    // removed. Keep this list in step with the registry's `label` fields.
+    for (const label of [
+      "Overview",
+      "Calls",
+      "Tune",
+      "Progress",
+      "Uplift",
+      "Session Flow",
+      "Profile",
+      "Call",
+    ]) {
       expect(out).toContain(label);
     }
   });

--- a/apps/admin/tests/api/setup-status-authored-modules.test.ts
+++ b/apps/admin/tests/api/setup-status-authored-modules.test.ts
@@ -222,7 +222,10 @@ describe("setup-status — activeCurriculumMode (issue #418)", () => {
 describe("setup-status — auth and 404 still behave (regression)", () => {
   it("returns the auth error when requireAuth fails", async () => {
     const errorResponse = NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
-    mockRequireAuth.mockResolvedValue(errorResponse);
+    // requireAuth returns an AuthFailure shape `{ error: NextResponse }` on
+    // failure — NOT the bare response. The route handler does
+    // `return user.error;`, so the mock must mirror the wrapped shape.
+    mockRequireAuth.mockResolvedValue({ error: errorResponse });
     mockIsAuthError.mockReturnValue(true);
 
     const res = (await GET(makeReq(), { params })) as NextResponse;


### PR DESCRIPTION
Clears the two Unit Tests failures that have been red on main for the last several runs (pre-existing tech debt, surfaced during the PR #994 merge). Neither is a behaviour regression — both are test-suite drift the relevant prior PRs didn't catch.

## What's fixed

### `tests/api/setup-status-authored-modules.test.ts:229`
**"returns the auth error when requireAuth fails"**

Mock returned a bare \`NextResponse\`, but \`lib/permissions.requireAuth\` wraps failures as \`{ error: NextResponse }\` (the \`AuthFailure\` shape). The route handler does \`return user.error;\`, so the mock made it return \`undefined\` and the assertion crashed on \`res.status\`.

Fix: wrap the mocked response in \`{ error: ... }\` to mirror reality.

### \`lib/chat/__tests__/page-feature-catalogue.test.ts:33\`
**"lists every tab label registered for Learner detail"**

Tab labels in \`lib/help/page-help.ts\` were renamed:
- "How" → "Profile" (id \`how\`)
- "AI Call" → "Call" (id \`ai-call\`)
- "What" and "Artifacts" removed entirely

Test still asserted the old labels.

Fix: align with current registry (Overview, Calls, Tune, Progress, Uplift, Session Flow, Profile, Call).

## Scope

| | |
|---|---|
| Files touched | 2 (both test files only) |
| Production code | unchanged |
| Lint warnings | 4441 (== baseline) |
| Tests added | 0 — fixed existing |
| Tests passing locally | 24/24 across both files |

## Test plan

- [ ] `npx vitest run tests/api/setup-status-authored-modules.test.ts lib/chat/__tests__/page-feature-catalogue.test.ts` — 24/24 pass
- [ ] CI Unit Tests goes green (closes the recurring red on main)

🤖 Generated with Claude Code