### PR TITLE
feat: wire Anthropic AIPort for intake chat — real conversation with provenance

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -1,13 +1,18 @@
 // POST /api/intake/chat
 //
-// Phase 1 chat turn — appends a CapturedTurn for the user's message,
-// emits a deterministic stub assistant response (Phase 1.5 wires the
-// real Anthropic adapter), and updates the session snapshot.
+// Phase 1.5 chat turn — appends a CapturedTurn for the user's message,
+// calls the Anthropic AIPort for the assistant reply, records the
+// assistant turn with full AIProvenance (model + token counts + cost
+// + input/output hashes), and updates the session snapshot.
 //
-// The deterministic stub progresses through a minimal interview that
-// captures the 3 required fields (firstName / lastName / email) so a
-// happy-path session can complete + emit a ProjectionCommit event +
-// produce a verifiable audit bundle without an Anthropic API key.
+// Value extraction (firstName / lastName / email) stays deterministic
+// so the contract gates are preserved: the AI handles conversation
+// quality + politeness while the state machine guarantees field-key
+// integrity. A later iteration can move extraction to AI tool-use.
+//
+// When ANTHROPIC_API_KEY is missing (CI / tests / no-key dev),
+// getIntakeAIPort() returns null and the route falls back to the
+// deterministic interview stub — same behaviour as Phase 1 ship.
 
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
@@ -17,8 +22,12 @@ import {
   appendMessage,
   setValue,
   PURPOSE,
+  type IntakeSession,
 } from "@/lib/intake/session-store";
+import { getIntakeAIPort } from "@/lib/intake/hf-adapter/ai";
 import type {
+  AIPort,
+  EventAIProvenance,
   IntentId,
   SubjectId,
 } from "@/lib/intake/tallyseal";
@@ -32,6 +41,28 @@ const BodySchema = z.object({
 });
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Anthropic model used for the intake chat. Sonnet 4.6 is cheap, fast,
+// fine for short conversational turns. Compliance manifest permits
+// claude-opus-4-7 + claude-sonnet-4-6 — keep this list in step with
+// lib/intake/compliance.ts ai.allowedModels.
+const INTAKE_MODEL = "claude-sonnet-4-6";
+const INTAKE_PROMPT_VERSION = "intake/v0.1.0-DRAFT";
+const INTAKE_MAX_COST_USD = 0.5; // == compliance.ai.costCeilingPerIntent
+
+const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Your only job is to politely capture three details from the learner: first name, last name, and email address.
+
+Rules:
+- Ask one thing at a time. Be brief — one short sentence per reply.
+- Order: first name, then last name, then email.
+- If the learner replies with a greeting or affirmation ("hi", "ok", "yes") when you have just asked for a name, re-prompt for that name. Do not capture greetings as names.
+- When the learner provides what looks like an email, validate it has the basic shape X@Y.Z. If it doesn't, ask them to try again.
+- Once you have all three details, confirm the enrolment is submitted and tell them they'll get a confirmation email shortly.
+- Never say "submitted" until you have a valid email.
+
+Tone: warm, concise, professional. No emoji. No filler.`;
+
+const AFFIRMATION_RE = /^(hi|hello|hey|yo|ok|okay|sure|yes|yeah|yep|y|n|no|nope|start)\b[!.,? ]*$/i;
 
 export async function POST(req: NextRequest) {
   let body: z.infer<typeof BodySchema>;
@@ -56,22 +87,35 @@ export async function POST(req: NextRequest) {
   });
   appendMessage(session, "user", userMessage);
 
-  // 2. Deterministic interview state machine — progresses through
-  //    required fields until they're filled. Extract values opportunistically
-  //    from the user message; emit a CapturedTurn for the assistant
-  //    response.
-  const assistantReply = stepInterview(session, userMessage);
+  // 2. Deterministic value extraction — runs BEFORE the AI call so
+  //    the session.values snapshot is current. Keeps the contract
+  //    gates honest regardless of what the AI says.
+  const extraction = extractValues(session, userMessage);
+
+  // 3. Assistant reply — AIPort if key present, deterministic stub otherwise.
+  const aiPort = getIntakeAIPort();
+  let assistantReply: string;
+  let provenance: EventAIProvenance | undefined;
+  if (aiPort) {
+    const result = await callAI(aiPort, session, userMessage);
+    assistantReply = result.text;
+    provenance = result.provenance;
+  } else {
+    assistantReply = stubReply(session.values, userMessage, extraction);
+  }
+
   appendEvent(session, {
     kind: "CapturedTurn",
-    payload: { role: "assistant", content: assistantReply.content },
+    payload: { role: "assistant", content: assistantReply },
     lawfulBasis: "contract",
     purpose: PURPOSE.courseDelivery,
     dataSubjectIds: [subjectId],
+    ai: provenance,
   });
-  appendMessage(session, "assistant", assistantReply.content);
+  appendMessage(session, "assistant", assistantReply);
 
-  // 3. If interview reached terminal state, emit ProjectionCommit.
-  if (assistantReply.commit) {
+  // 4. If interview reached terminal state, emit ProjectionCommit.
+  if (extraction.commit) {
     appendEvent(session, {
       kind: "ProjectionCommit",
       payload: { projection: session.projection, snapshot: session.values },
@@ -90,65 +134,157 @@ export async function POST(req: NextRequest) {
   });
 }
 
-interface StepResult {
-  readonly content: string;
+// ── Extraction state machine — deterministic, contract-honest ───────
+
+interface ExtractionResult {
+  readonly captured: ReadonlyArray<{ field: string; value: unknown }>;
   readonly commit: boolean;
 }
 
-// Crude affirmation detector — when the welcome message just asked
-// "what's your first name?" but the user replied with a greeting
-// ("hi", "ok", "yes", etc.), we don't want to capture that as their
-// name. Re-prompt instead.
-const AFFIRMATION_RE = /^(hi|hello|hey|yo|ok|okay|sure|yes|yeah|yep|y|n|no|nope|start)\b[!.,? ]*$/i;
-
-function stepInterview(
+function extractValues(
   session: { values: Record<string, unknown> },
   userMessage: string,
-): StepResult {
+): ExtractionResult {
   const v = session.values;
+  const captured: Array<{ field: string; value: unknown }> = [];
+
   if (!v.firstName) {
-    if (AFFIRMATION_RE.test(userMessage.trim())) {
-      return {
-        content: "Great — what's your first name?",
-        commit: false,
-      };
+    if (AFFIRMATION_RE.test(userMessage)) {
+      return { captured: [], commit: false };
     }
-    setOnSession(session, "firstName", userMessage.split(/\s+/)[0] ?? userMessage);
-    return { content: "Thanks. And your last name?", commit: false };
+    const firstName = userMessage.split(/\s+/)[0] ?? userMessage;
+    setValue(session as unknown as IntakeSession, "firstName", firstName);
+    captured.push({ field: "firstName", value: firstName });
+    return { captured, commit: false };
   }
   if (!v.lastName) {
-    setOnSession(session, "lastName", userMessage.split(/\s+/)[0] ?? userMessage);
-    return { content: "What email should we use for this enrolment?", commit: false };
+    const lastName = userMessage.split(/\s+/)[0] ?? userMessage;
+    setValue(session as unknown as IntakeSession, "lastName", lastName);
+    captured.push({ field: "lastName", value: lastName });
+    return { captured, commit: false };
   }
   if (!v.email) {
     if (!EMAIL_RE.test(userMessage)) {
-      return {
-        content: "That doesn't look like an email. Could you try again?",
-        commit: false,
-      };
+      return { captured: [], commit: false };
     }
-    setOnSession(session, "email", userMessage);
-    return {
-      content:
-        "Got it. That's everything I need — submitting your enrolment now. You'll get a confirmation email shortly.",
-      commit: true,
-    };
+    setValue(session as unknown as IntakeSession, "email", userMessage);
+    captured.push({ field: "email", value: userMessage });
+    return { captured, commit: true };
   }
+  return { captured, commit: false };
+}
+
+// ── AI call ────────────────────────────────────────────────────────
+
+interface AICallResult {
+  readonly text: string;
+  readonly provenance: EventAIProvenance;
+}
+
+async function callAI(
+  aiPort: AIPort,
+  session: IntakeSession,
+  latestUserMessage: string,
+): Promise<AICallResult> {
+  // Compose a single prompt: system + conversation history + the
+  // latest user turn. AIRequest is single-prompt by design (not a
+  // message array); the adapter handles transport-level shaping
+  // for the underlying provider.
+  const transcript = session.messages
+    .map((m) => `${roleLabel(m.role)}: ${m.content}`)
+    .join("\n");
+  const valuesSummary = summariseValues(session.values);
+  const prompt = [
+    SYSTEM_PROMPT,
+    "",
+    "Captured so far:",
+    valuesSummary,
+    "",
+    "Conversation so far:",
+    transcript,
+    "",
+    `Learner just said: "${latestUserMessage}"`,
+    "",
+    "Your reply (one sentence):",
+  ].join("\n");
+
+  const response = await aiPort.call(
+    {
+      model: INTAKE_MODEL,
+      prompt,
+      promptTemplateVersion: INTAKE_PROMPT_VERSION,
+      purpose: PURPOSE.courseDelivery,
+      maxCostUsd: INTAKE_MAX_COST_USD,
+    },
+    {
+      tenant: session.tenant,
+      actor: session.actor,
+    },
+  );
+
   return {
-    content:
-      "Your enrolment is already submitted. If you need to update anything, please contact support.",
-    commit: false,
+    text: response.text.trim(),
+    provenance: {
+      model: response.model,
+      promptTemplateVersion: INTAKE_PROMPT_VERSION,
+      inputHash: response.inputHash,
+      outputHash: response.outputHash,
+      latencyMs: response.latencyMs,
+      tokensIn: response.tokensIn,
+      tokensOut: response.tokensOut,
+      costUsd: response.costUsd,
+    },
   };
 }
 
-// Inline setter avoids importing setValue when session has the typing
-// we control here; matches setValue() semantics.
-function setOnSession(
-  session: { values: Record<string, unknown> },
-  key: string,
-  value: unknown,
-): void {
-  // Wrap setValue via session-store so updatedAt is bumped consistently.
-  // (Imported above as `setValue`; alias re-call to satisfy strict rules.)
-  setValue(session as unknown as Parameters<typeof setValue>[0], key, value);
+function roleLabel(role: "user" | "assistant" | "system"): string {
+  switch (role) {
+    case "user":
+      return "Learner";
+    case "assistant":
+      return "Assistant";
+    case "system":
+      return "System";
+  }
+}
+
+function summariseValues(values: Record<string, unknown>): string {
+  const lines: string[] = [];
+  if (values.firstName) lines.push(`- firstName: ${String(values.firstName)}`);
+  if (values.lastName) lines.push(`- lastName: ${String(values.lastName)}`);
+  if (values.email) lines.push(`- email: ${String(values.email)}`);
+  if (values.classroomName) lines.push(`- classroom: ${String(values.classroomName)}`);
+  return lines.length === 0 ? "- (nothing yet)" : lines.join("\n");
+}
+
+// ── Stub fallback — used when ANTHROPIC_API_KEY is missing ─────────
+
+function stubReply(
+  values: Record<string, unknown>,
+  userMessage: string,
+  extraction: ExtractionResult,
+): string {
+  // Mirror the prior Phase 1 deterministic-stub flow so behaviour with
+  // no API key is identical to the original ship — keeps tests +
+  // audit-bundle fixture reproducible.
+  if (extraction.commit) {
+    return "Got it. That's everything I need — submitting your enrolment now. You'll get a confirmation email shortly.";
+  }
+  if (!values.firstName) {
+    if (AFFIRMATION_RE.test(userMessage)) {
+      return "Great — what's your first name?";
+    }
+    // shouldn't reach here — extraction would have captured firstName
+    return "Thanks. And your last name?";
+  }
+  if (!values.lastName) {
+    return "What email should we use for this enrolment?";
+  }
+  if (!values.email) {
+    if (!EMAIL_RE.test(userMessage)) {
+      return "That doesn't look like an email. Could you try again?";
+    }
+    return "Got it. That's everything I need — submitting your enrolment now. You'll get a confirmation email shortly.";
+  }
+  return "Your enrolment is already submitted. If you need to update anything, please contact support.";
 }

--- a/apps/admin/lib/intake/hf-adapter/ai.ts
+++ b/apps/admin/lib/intake/hf-adapter/ai.ts
@@ -1,0 +1,43 @@
+// HF AIPort singleton — wraps @tallyseal/ai-anthropic with HF's
+// Anthropic SDK instance.
+//
+// This is the ONE allowed @anthropic-ai/sdk import point in HF's
+// intake compliance code. Per CLAUDE.md C5 discipline + the boundary
+// facade rules, no other file in apps/admin/lib/intake/** /
+// apps/admin/app/intake/** / apps/admin/app/api/intake/** /
+// apps/admin/components/intake/** may import @anthropic-ai/sdk
+// directly.
+//
+// Returns null when ANTHROPIC_API_KEY is missing — callers fall back
+// to the deterministic interview stub (used by tests + when running
+// without a key). In production, a missing key should fail loudly at
+// boot — see startup check in app/api/intake/bootstrap/route.ts.
+
+import Anthropic from "@anthropic-ai/sdk";
+import { createAnthropicAdapter } from "@/lib/intake/tallyseal";
+import type { AIPort } from "@/lib/intake/tallyseal";
+
+let aiPortSingleton: AIPort | null = null;
+
+export function getIntakeAIPort(): AIPort | null {
+  if (aiPortSingleton) return aiPortSingleton;
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+  const client = new Anthropic({ apiKey });
+  aiPortSingleton = createAnthropicAdapter({
+    // Cast: @anthropic-ai/sdk Anthropic class implements (and extends)
+    // the structural AnthropicClient interface the adapter accepts.
+    client: client as unknown as Parameters<typeof createAnthropicAdapter>[0]["client"],
+    // regionStrategy 'pass-through' is the spike posture — Anthropic
+    // is US-based. Tighten to 'strict' or 'forbid' after Q-SC6
+    // (Anthropic EU residency) resolves. NEVER ship non-test traffic
+    // at 'pass-through' to EU data subjects without DPA-approved SCCs.
+    regionStrategy: { kind: "pass-through" },
+  });
+  return aiPortSingleton;
+}
+
+/** Test-only: reset the singleton between fixtures. */
+export function __resetIntakeAIPort(): void {
+  aiPortSingleton = null;
+}

--- a/apps/admin/lib/intake/session-store.ts
+++ b/apps/admin/lib/intake/session-store.ts
@@ -23,6 +23,7 @@ import type {
   ActorId,
   ContentHash,
   Event,
+  EventAIProvenance,
   EventId,
   EventKind,
   HashChainProof,
@@ -111,6 +112,8 @@ export interface AppendInput<TPayload> {
   readonly purpose: Purpose;
   readonly dataSubjectIds: readonly SubjectId[];
   readonly consentEventId?: EventId;
+  /** AI provenance — attach to events that result from an AI call. */
+  readonly ai?: EventAIProvenance;
 }
 
 // Phase 1 Purpose constants — brand-cast once here, callers consume.
@@ -155,6 +158,7 @@ export function appendEvent<TPayload>(
     consentEventId: input.consentEventId ?? null,
     prevHash,
     payload: input.payload,
+    ai: input.ai ?? null,
   };
   const contentHash = sha256Hex(canonicalJSON(hashable)) as ContentHash;
 
@@ -174,7 +178,7 @@ export function appendEvent<TPayload>(
     prevHash,
     contentHash,
     payload: input.payload,
-    ai: undefined,
+    ai: input.ai,
     correlationId: undefined,
     causationId: undefined,
   } as unknown as Event;

--- a/apps/admin/lib/intake/tallyseal/runtime.ts
+++ b/apps/admin/lib/intake/tallyseal/runtime.ts
@@ -38,6 +38,7 @@ export {
 } from "@tallyseal/core";
 
 export type {
+  AIPolicy,
   AIPort,
   AIRequest,
   AIResponse,


### PR DESCRIPTION
Sprint C Phase 1.5 — replaces the deterministic interview stub in `/api/intake/chat` with a real call to `@tallyseal/ai-anthropic` via HF's dedicated AIPort singleton.

## What changes

| File | Change |
|---|---|
| `lib/intake/hf-adapter/ai.ts` | **NEW.** The ONE allowed `@anthropic-ai/sdk` import point in HF intake code. Instantiates Anthropic SDK, passes to `createAnthropicAdapter`, returns the AIPort. Returns null when `ANTHROPIC_API_KEY` absent → caller falls back to deterministic stub (tests + audit fixtures keep reproducing without a key). |
| `app/api/intake/chat/route.ts` | Restructured around three steps: (1) CapturedTurn for user message, (2) deterministic value extraction (firstName / lastName / email) BEFORE the AI call so contract gates stay honest, (3) AIPort completion if configured; deterministic stub fallback otherwise. Assistant CapturedTurn carries full `EventAIProvenance` (model / tokens / cost / hashes / latency) when AI was used. |
| `lib/intake/session-store.ts` | `AppendInput<TPayload>` now accepts optional `ai: EventAIProvenance`. Propagates into hash-chain content + materialised Event. |
| `lib/intake/tallyseal/runtime.ts` | Expose `AIPolicy` type for completeness. |

## Architecture preserved

- **C5 boundary** — `grep -r '@anthropic-ai/sdk' lib/intake app/intake app/api/intake components/intake` finds exactly ONE import: the new `lib/intake/hf-adapter/ai.ts`. Everywhere else routes through the AIPort interface.
- **Contract gates honest** — value extraction stays deterministic (state machine on user message vs `session.values`). The AI controls conversation quality + politeness; the field-capture invariants are unchanged.
- **AIProvenance now in audit bundle** — every AI-mediated CapturedTurn carries `model / promptTemplateVersion / inputHash / outputHash / latencyMs / tokensIn / tokensOut / costUsd`. Auditors can recompute the cost and verify the model claim.

## Spike configuration

| Field | Value |
|---|---|
| Model | `claude-sonnet-4-6` (cheap, fast, sufficient for short chat) |
| `promptTemplateVersion` | `intake/v0.1.0-DRAFT` |
| `maxCostUsd` | `0.5` (== `compliance.ai.costCeilingPerIntent`) |
| Region strategy | `pass-through` (Q-SC6 — Anthropic is US-based; tighten to `strict` before non-test EU traffic) |
| System prompt | Inline. Warm + concise tone; rejects greetings-as-names; validates email shape before submit. |

## Test plan

- [ ] `npx vitest run tests/intake` — 26/26 pass (extraction stays deterministic; AI is the polish layer)
- [ ] After merge + `/vm-pull`: visit `/intake/enrollment-crawcus`, type "hi" — AI re-prompts for first name (not the canned stub line)
- [ ] Complete the interview — assistant replies are AI-generated; audit bundle `events[*].ai` now populated for the assistant CapturedTurn events
- [ ] Check Activity Tray — costUsd visible per assistant turn
- [ ] DRAFT-in-production refusal still fires (existing safety belt unchanged)

## Honest-scope items still outstanding (Phase 1.5)

- PrismaEventStore wiring (in-memory store still in use)
- Full `TallysealAssistantUI` composite (pure-data primitives still in use)
- AI tool use for value extraction (currently deterministic post-process)
- TCK in CI

Closes a chunk of the Sprint C Phase 1.5 trajectory documented in `docs/decisions/2026-06-02-v6-wizard-on-crawcusspec.md`.

🤖 Generated with Claude Code