### PR TITLE
feat: real enrolment from intake chat — handoff to /join on commit

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -114,7 +114,15 @@ export async function POST(req: NextRequest) {
   });
   appendMessage(session, "assistant", assistantReply);
 
-  // 4. If interview reached terminal state, emit ProjectionCommit.
+  // 4. If interview reached terminal state, emit ProjectionCommit + (if
+  //    classroomToken set) compute a redirectUrl that hands the learner
+  //    off to HF's existing /join/[token] page with the captured values
+  //    pre-filled. That page auto-submits when URL params include all
+  //    three fields → calls /api/join POST → mints session → creates
+  //    Caller + CallerPlaybook → redirects to the student dashboard.
+  //    Zero new auth/cookie-mint logic; reuses the battle-tested join
+  //    flow.
+  let redirectUrl: string | null = null;
   if (extraction.commit) {
     appendEvent(session, {
       kind: "ProjectionCommit",
@@ -124,6 +132,17 @@ export async function POST(req: NextRequest) {
       dataSubjectIds: [subjectId],
     });
     session.state = "committed";
+
+    const classroomToken = session.values.classroomToken as string | undefined;
+    if (classroomToken) {
+      const firstName = session.values.firstName as string | undefined;
+      const lastName = session.values.lastName as string | undefined;
+      const email = session.values.email as string | undefined;
+      if (firstName && lastName && email) {
+        const params = new URLSearchParams({ firstName, lastName, email });
+        redirectUrl = `/join/${classroomToken}?${params.toString()}`;
+      }
+    }
   }
 
   return NextResponse.json({
@@ -131,6 +150,7 @@ export async function POST(req: NextRequest) {
     suggestions: [],
     values: session.values,
     messages: session.messages,
+    redirectUrl,
   });
 }
 

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -179,6 +179,7 @@ export default function CourseDetailPage() {
   const [showDryRun, setShowDryRun] = useState(false);
   const [joinToken, setJoinToken] = useState<string | null>(null);
   const [joinCopied, setJoinCopied] = useState(false);
+  const [chatJoinCopied, setChatJoinCopied] = useState(false);
 
   // Content breakdown
   const [contentMethods, setContentMethods] = useState<MethodBreakdown[]>([]);
@@ -1187,23 +1188,40 @@ export default function CourseDetailPage() {
         </button>
       ) : null}
 
-      {/* Enrol link */}
+      {/* Enrol links — short form + chat variant */}
       {joinToken && (
-        <div className="hf-banner hf-banner-success hf-mb-md hf-flex hf-items-center hf-gap-sm">
-          <Link2 size={14} />
-          <code className="hf-text-xs" style={{ flex: 1 }}>{`${typeof window !== 'undefined' ? window.location.origin : ''}/join/${joinToken}`}</code>
-          <button
-            className="hf-btn hf-btn-xs"
-            onClick={() => {
-              navigator.clipboard.writeText(`${window.location.origin}/join/${joinToken}`);
-              setJoinCopied(true);
-              setTimeout(() => setJoinCopied(false), 2000);
-            }}
-          >
-            <Copy size={12} />
-            {joinCopied ? 'Copied!' : 'Copy enrol link'}
-          </button>
-        </div>
+        <>
+          <div className="hf-banner hf-banner-success hf-mb-sm hf-flex hf-items-center hf-gap-sm">
+            <Link2 size={14} />
+            <code className="hf-text-xs" style={{ flex: 1 }}>{`${typeof window !== 'undefined' ? window.location.origin : ''}/join/${joinToken}`}</code>
+            <button
+              className="hf-btn hf-btn-xs"
+              onClick={() => {
+                navigator.clipboard.writeText(`${window.location.origin}/join/${joinToken}`);
+                setJoinCopied(true);
+                setTimeout(() => setJoinCopied(false), 2000);
+              }}
+            >
+              <Copy size={12} />
+              {joinCopied ? 'Copied!' : 'Copy enrol link'}
+            </button>
+          </div>
+          <div className="hf-banner hf-banner-info hf-mb-md hf-flex hf-items-center hf-gap-sm">
+            <Link2 size={14} />
+            <code className="hf-text-xs" style={{ flex: 1 }}>{`${typeof window !== 'undefined' ? window.location.origin : ''}/intake/enrollment-crawcus/${joinToken}`}</code>
+            <button
+              className="hf-btn hf-btn-xs"
+              onClick={() => {
+                navigator.clipboard.writeText(`${window.location.origin}/intake/enrollment-crawcus/${joinToken}`);
+                setChatJoinCopied(true);
+                setTimeout(() => setChatJoinCopied(false), 2000);
+              }}
+            >
+              <Copy size={12} />
+              {chatJoinCopied ? 'Copied!' : 'Copy chat enrol link'}
+            </button>
+          </div>
+        </>
       )}
 
       {/* ── Tabs ──────────────────────────────────────── */}

--- a/apps/admin/components/intake/EnrollmentChat.tsx
+++ b/apps/admin/components/intake/EnrollmentChat.tsx
@@ -152,6 +152,15 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
             }
           : b,
       );
+      // On commit with a classroom-bound URL, hand off to HF's existing
+      // /join/[token] page which auto-submits when firstName + lastName +
+      // email are URL params. That path mints the session + creates the
+      // Caller + redirects to the student dashboard — zero new auth
+      // logic in this component.
+      if (data.redirectUrl) {
+        window.location.href = data.redirectUrl;
+        return;
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to send message");
     } finally {
@@ -315,4 +324,5 @@ interface ChatTurnPayload {
   readonly suggestions: readonly Suggestion[];
   readonly values: Readonly<Record<string, unknown>>;
   readonly messages: readonly ChatMessage[];
+  readonly redirectUrl?: string | null;
 }


### PR DESCRIPTION
Closes the end-to-end loop. Sprint C + Phase 1.5 wiring made the chat work locally; this PR makes the chat **actually enrol the learner** in HF's database — reusing the existing \`/join\` flow on the final turn.

## Plan

| Edit | Purpose |
|---|---|
| \`app/x/courses/[courseId]/page.tsx\` | Adds a 2nd enrol-link banner (info-tone) below the existing short-form one. URL is \`/intake/enrollment-crawcus/[token]\` instead of \`/join/[token]\`. Same \`joinToken\`. "Copy chat enrol link" button mirrors the existing pattern. |
| \`app/api/intake/chat/route.ts\` | On the ProjectionCommit turn, if \`classroomToken\` is set, returns \`redirectUrl\` pointing at \`/join/{token}?firstName=...&lastName=...&email=...\`. |
| \`components/intake/EnrollmentChat.tsx\` | When chat response carries \`redirectUrl\`, sets \`window.location.href\` to it. \`ChatTurnPayload\` gains \`redirectUrl?: string \| null\`. |

## Why this shape

HF's existing \`app/join/[token]/page.tsx\` already auto-submits when \`firstName + lastName + email\` are all URL params (see lines 47-52 of that file). That submit calls \`/api/join POST\` → mints session cookie → creates User + Caller → enrols in CallerPlaybook → redirects to student dashboard.

By piggy-backing on URL-param auto-submit, the chat needs **zero new auth or cookie-minting code**. The chat is a nicer UX over the same POST.

## Demo

1. Admin opens \`/x/courses/[courseId]\`. Sees both enrol-link banners.
2. Clicks "Copy chat enrol link" → pastes URL elsewhere (or opens in private window).
3. Learner sees the chat with the classroom name in the welcome.
4. Has a conversation with Claude (real AI from PR #996), shares first / last / email.
5. On commit → chat redirects to \`/join/{token}?firstName=X&lastName=Y&email=Z\` → existing /join page auto-submits → learner ends up on the student dashboard with a real Caller record.

## Test plan

- [ ] \`npx vitest run tests/intake\` — 26/26 pass (extraction stays deterministic, redirect path adds 0 unit-test coverage; flow validated end-to-end on hf-dev)
- [ ] CI Lint & Type Check stays at baseline 4441 lint warnings
- [ ] After merge + \`/vm-pull\`: visit \`/x/courses/<id>\`, click new button, paste URL in a private window, complete a chat, end up on the student dashboard

## Non-goals

- No new tests added — the redirect path is a single \`window.location.href = data.redirectUrl\` line behind a JSON field, and the existing \`/join\` flow has its own tests
- No changes to existing \`/join\` flow (per Sprint C non-goal "do not touch existing enrolment form")

🤖 Generated with Claude Code