### PR TITLE
style: intake surface uses HF design system classes

### DIFF
--- a/apps/admin/app/intake/enrollment-crawcus/[token]/page.tsx
+++ b/apps/admin/app/intake/enrollment-crawcus/[token]/page.tsx
@@ -11,6 +11,7 @@
 // circuits on the absent token.
 
 import { EnrollmentChat } from "@/components/intake/EnrollmentChat";
+import "../../intake.css";
 
 export const dynamic = "force-dynamic";
 
@@ -22,11 +23,11 @@ export default async function EnrollmentIntakeWithTokenPage({
   const { token } = await params;
 
   return (
-    <main className="min-h-screen bg-background">
-      <div className="mx-auto max-w-6xl px-4 py-8">
-        <header className="mb-6">
-          <h1 className="text-2xl font-semibold tracking-tight">Enrolment</h1>
-          <p className="text-sm text-muted-foreground">
+    <main className="intake-page">
+      <div className="intake-container">
+        <header className="hf-mb-lg">
+          <h1 className="hf-page-title">Enrolment</h1>
+          <p className="hf-section-desc">
             Chat-driven enrolment for HumanFirst Foundation. Conversation on
             the left fills the form on the right as you go.
           </p>

--- a/apps/admin/app/intake/enrollment-crawcus/page.tsx
+++ b/apps/admin/app/intake/enrollment-crawcus/page.tsx
@@ -6,16 +6,17 @@
 // deliver status=DRAFT when NODE_ENV=production.
 
 import { EnrollmentChat } from "@/components/intake/EnrollmentChat";
+import "../intake.css";
 
 export const dynamic = "force-dynamic"; // Always render fresh — uses NextAuth session per-request
 
 export default function EnrollmentIntakePage() {
   return (
-    <main className="min-h-screen bg-background">
-      <div className="mx-auto max-w-6xl px-4 py-8">
-        <header className="mb-6">
-          <h1 className="text-2xl font-semibold tracking-tight">Enrolment</h1>
-          <p className="text-sm text-muted-foreground">
+    <main className="intake-page">
+      <div className="intake-container">
+        <header className="hf-mb-lg">
+          <h1 className="hf-page-title">Enrolment</h1>
+          <p className="hf-section-desc">
             Chat-driven enrolment for HumanFirst Foundation. Conversation on
             the left fills the form on the right as you go.
           </p>

--- a/apps/admin/app/intake/intake.css
+++ b/apps/admin/app/intake/intake.css
@@ -1,0 +1,79 @@
+/* Intake-surface chat styles.
+ *
+ * Consumes HF design-system tokens (CSS custom properties) — no
+ * hardcoded hex, no inline styles. Provides chat-bubble + thread
+ * primitives that aren't in the global `hf-*` catalogue because the
+ * intake is the only surface that needs them today. If/when V6
+ * wizard ships a chat thread, lift these into globals.css.
+ */
+
+.intake-page {
+  min-height: 100vh;
+  background: var(--surface-primary);
+}
+
+.intake-container {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 72rem;
+  padding: 32px 16px;
+}
+
+.intake-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+
+@media (min-width: 1024px) {
+  .intake-grid {
+    grid-template-columns: 1fr 22rem;
+  }
+}
+
+.intake-thread {
+  min-height: 420px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.intake-bubble {
+  max-width: 80%;
+  border-radius: 12px;
+  padding: 8px 12px;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.intake-bubble--user {
+  margin-left: auto;
+  background: var(--accent-primary);
+  color: var(--surface-primary);
+}
+
+.intake-bubble--assistant {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.intake-bubble--system {
+  background: color-mix(in srgb, var(--surface-secondary) 60%, transparent);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.intake-composer {
+  display: flex;
+  gap: 8px;
+}
+
+.intake-composer-input {
+  flex: 1;
+}

--- a/apps/admin/components/intake/EnrollmentChat.tsx
+++ b/apps/admin/components/intake/EnrollmentChat.tsx
@@ -170,27 +170,27 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
 
   if (error) {
     return (
-      <div className="rounded border border-red-300 bg-red-50 p-4 text-sm text-red-800">
+      <div className="hf-banner hf-banner-error">
         Couldn&rsquo;t start enrolment: {error}
       </div>
     );
   }
 
   if (!boot) {
-    return <div className="text-sm text-muted-foreground">Starting&hellip;</div>;
+    return <div className="hf-section-desc">Starting&hellip;</div>;
   }
 
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_22rem]">
-      <section className="flex flex-col gap-4">
+    <div className="intake-grid">
+      <section className="hf-flex hf-flex-col hf-gap-md">
         <TallysealBanner events={[...boot.events]} />
         <div
           ref={scrollRef}
-          className="min-h-[420px] max-h-[60vh] overflow-y-auto rounded border bg-card p-4 space-y-3"
+          className="intake-thread"
           data-testid="enrollment-chat-thread"
         >
           {boot.messages.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
+            <p className="hf-section-desc">
               The assistant will start the conversation when ready.
             </p>
           ) : (
@@ -206,7 +206,7 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
           }
         />
         <form
-          className="flex gap-2"
+          className="intake-composer"
           onSubmit={(e) => {
             e.preventDefault();
             send(input);
@@ -218,20 +218,20 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
             onChange={(e) => setInput(e.target.value)}
             disabled={pending}
             placeholder="Type your message…"
-            className="flex-1 rounded border px-3 py-2 text-sm"
+            className="hf-input intake-composer-input"
             data-testid="enrollment-chat-input"
           />
           <button
             type="submit"
             disabled={pending || !input.trim()}
-            className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+            className="hf-btn hf-btn-primary"
             data-testid="enrollment-chat-send"
           >
             {pending ? "Sending…" : "Send"}
           </button>
         </form>
       </section>
-      <aside className="flex flex-col gap-4">
+      <aside className="hf-flex hf-flex-col hf-gap-md">
         <ValuesPanel values={boot.values} />
         <TallysealIntentForm
           spec={EnrollmentIntake}
@@ -277,18 +277,16 @@ const VALUE_FIELD_ORDER = [
 function ValuesPanel({ values }: { values: Readonly<Record<string, unknown>> }) {
   const populated = VALUE_FIELD_ORDER.filter((k) => values[k] !== undefined && values[k] !== "");
   return (
-    <div className="rounded border bg-card p-3 text-sm" data-testid="enrollment-values-panel">
-      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Captured so far
-      </h3>
+    <div className="hf-card-compact" data-testid="enrollment-values-panel">
+      <h3 className="hf-category-label hf-mb-sm">Captured so far</h3>
       {populated.length === 0 ? (
-        <p className="text-muted-foreground">Nothing captured yet.</p>
+        <p className="hf-section-desc">Nothing captured yet.</p>
       ) : (
-        <dl className="space-y-1">
+        <dl className="hf-flex hf-flex-col hf-gap-xs">
           {populated.map((k) => (
-            <div key={k} className="flex justify-between gap-2">
-              <dt className="text-muted-foreground">{FIELD_LABELS[k] ?? k}</dt>
-              <dd className="font-medium text-foreground">{String(values[k])}</dd>
+            <div key={k} className="hf-flex hf-flex-between hf-gap-sm">
+              <dt className="hf-section-desc">{FIELD_LABELS[k] ?? k}</dt>
+              <dd>{String(values[k])}</dd>
             </div>
           ))}
         </dl>
@@ -298,14 +296,14 @@ function ValuesPanel({ values }: { values: Readonly<Record<string, unknown>> }) 
 }
 
 function ChatBubble({ role, content }: ChatMessage) {
-  const isUser = role === "user";
+  const variantClass =
+    role === "user"
+      ? "intake-bubble--user"
+      : role === "assistant"
+      ? "intake-bubble--assistant"
+      : "intake-bubble--system";
   return (
-    <div
-      data-role={role}
-      className={`max-w-[80%] rounded-lg px-3 py-2 text-sm ${
-        isUser ? "ml-auto bg-primary text-primary-foreground" : "bg-muted"
-      }`}
-    >
+    <div data-role={role} className={`intake-bubble ${variantClass}`}>
       {content}
     </div>
   );


### PR DESCRIPTION
Closes the visual debt left by Sprint C. Pure CSS hygiene, zero behaviour changes.

## Summary

Sprint C shipped the intake chat with raw Tailwind utilities + shadcn-style CSS vars — pragmatic at the spike stage, but \`.claude/rules/ui-design-system.md\` is zero-tolerance. This PR converts the three intake files to the \`hf-*\` class catalogue.

## Files touched

| File | Change |
|---|---|
| \`app/intake/enrollment-crawcus/page.tsx\` | Tailwind → \`hf-page-title\`, \`hf-section-desc\`, \`hf-mb-lg\` + \`intake-page\`, \`intake-container\` (scoped to intake.css) |
| \`app/intake/enrollment-crawcus/[token]/page.tsx\` | Same pattern, token variant |
| \`components/intake/EnrollmentChat.tsx\` | Replaces all visual utility classes with \`hf-btn\`, \`hf-input\`, \`hf-card-compact\`, \`hf-banner\`, \`hf-flex\`, \`hf-gap-*\`, etc. ChatBubble + ValuesPanel converted. |
| \`app/intake/intake.css\` (NEW) | Scoped chat-bubble + thread primitives that aren't in the global \`hf-*\` catalogue. Consumes HF tokens via \`var(--*)\`. Documented: lift to \`globals.css\` as \`hf-chat-*\` if V6 wizard ships a similar thread. |

## Verification

- ✅ \`ui-reviewer\` agent — **PASS, zero violations** across all files
- ✅ 26/26 vitests still pass
- ✅ \`tsc --noEmit\` clean on touched paths
- ✅ No behaviour changes — pure CSS swap

## Test plan

- [ ] After merge + \`/vm-pull\`: visit \`/intake/enrollment-crawcus\` and \`/intake/enrollment-crawcus/<token>\`. Visual should match HF's gold-standard surfaces (matches \`/x/**\` styling).
- [ ] Chat thread still scrolls, composer still submits, ValuesPanel still fills

## Risk

Minimal. All changes are className substitutions; the underlying React tree is unchanged.

🤖 Generated with Claude Code