### PR TITLE
feat(intake): wire ageBand.adultOnly invariant + drop local enum tuple

### DIFF
--- a/apps/admin/lib/intake/specs/enrollment.intent.ts
+++ b/apps/admin/lib/intake/specs/enrollment.intent.ts
@@ -15,6 +15,8 @@ import {
   defineContract,
   field,
   // GDPR
+  ageBand,
+  AGE_BAND_VALUES,
   specialCategoryProhibition,
   // EU AI Act
   humanOversight,
@@ -32,17 +34,11 @@ const PROJECTION = "IntakeApplication" as ProjectionName;
 const ART13_REQUIREMENT_ID = "gdpr.art13.privacy-notice";
 const ART50_REQUIREMENT_ID = "eu-ai-act.art50.ai-interaction-disclosure";
 
-const AGE_RANGE_VALUES = [
-  "under-18",
-  "18-24",
-  "25-34",
-  "35-44",
-  "45-54",
-  "55-64",
-  "65-plus",
-  "prefer-not-to-say",
-] as const;
-
+// AGE_BAND_VALUES is re-exported from @tallyseal/regulations-gdpr via
+// the boundary facade. Identical tuple shape to the prior local
+// AGE_RANGE_VALUES — kept the `ageRange` field name to avoid
+// disturbing existing data, but bound to the canonical regulation
+// value set so ageBand.adultOnly accepts it without coercion.
 const CONTACT_METHOD_VALUES = ["email", "in-app"] as const;
 
 // Adult-learner basic email pattern. NOT RFC-5322 complete — we use a
@@ -121,7 +117,7 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
       }),
 
     ageRange: field
-      .enum(AGE_RANGE_VALUES)
+      .enum(AGE_BAND_VALUES)
       .optional()
       .label({ en: "Age range" })
       .askHint({ en: "Roughly what age band are you in?" }),
@@ -149,20 +145,7 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
 
   contracts: {
     pre: [
-      // 1. Adult-only — rejects under-18 selection. Provides Phase 1
-      //    rejection-path coverage; emits ContractViolation event.
-      defineContract({
-        id: "enrollment.adult-only",
-        description: {
-          en: "Enrolment is restricted to learners 18 and over. Selecting 'under-18' rejects the application before commit.",
-        },
-        predicate: ({ value }) => {
-          const age = value<string>("ageRange");
-          return age !== "under-18";
-        },
-      }),
-
-      // 2. GDPR Art 13 — privacy notice must be delivered before any
+      // 1. GDPR Art 13 — privacy notice must be delivered before any
       //    field-capturing turn fires.
       defineContract({
         id: "enrollment.pre.privacy-notice-delivered",
@@ -178,7 +161,7 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
         },
       }),
 
-      // 3. EU AI Act Art 50(1) — AI-interaction disclosure must be
+      // 2. EU AI Act Art 50(1) — AI-interaction disclosure must be
       //    delivered before any AI-mediated turn fires.
       aiInteractionDisclosure({
         disclosureRequirementId: ART50_REQUIREMENT_ID,
@@ -186,6 +169,17 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
     ],
 
     invariants: [
+      // 3. Adult-only — snapshot must never contain ageRange === 'under-18'.
+      //    Regulation-pack factory (regulations-gdpr 0.3.x ageBand.adultOnly)
+      //    replaces the prior home-grown enrollment.adult-only contract:
+      //    same semantic, plus regulation-pack provenance + held as an
+      //    invariant rather than a pre-condition (so a post-capture write
+      //    of 'under-18' cannot slip past). Permits 'prefer-not-to-say'
+      //    as defensible adult-only posture. Spread because adultOnly()
+      //    returns Contract[] (sibling factories return a single Contract
+      //    — inconsistency tracked for tallyseal feedback).
+      ...ageBand.adultOnly({ ageBandField: "ageRange" }),
+
       // 4. email format invariant — distinct from .validates() because
       //    it is named, citable, and recorded as a ContractEvaluationResult.
       defineContract({

--- a/apps/admin/lib/intake/tallyseal/regulations.ts
+++ b/apps/admin/lib/intake/tallyseal/regulations.ts
@@ -17,6 +17,13 @@ export {
   GDPR_VERSION,
   // Article 8 — child consent
   minorConsent,
+  // Age-band invariant factories (regulations-gdpr 0.3.x).
+  // ageBand.adultOnly rejects 'under-18' as snapshot invariant.
+  // AGE_BAND_VALUES is the canonical 8-value tuple to feed field.enum.
+  ageBand,
+  ageBandField,
+  AGE_BAND_VALUES,
+  isMinorBand,
   // Article 22 — solely automated decision-making + Art 9 special-category
   specialCategoryProhibition,
   solelyAutomatedDecision,
@@ -27,6 +34,7 @@ export {
   gdprPersonalDataDefaults,
   gdprSpecialCategoryDefaults,
 } from "@tallyseal/regulations-gdpr";
+export type { AgeBandValue } from "@tallyseal/regulations-gdpr";
 
 // ── EU AI Act ───────────────────────────────────────────────────────
 export {

--- a/apps/admin/tests/intake/contracts.test.ts
+++ b/apps/admin/tests/intake/contracts.test.ts
@@ -1,7 +1,8 @@
 // Sprint C — Contract predicate behaviour tests.
 //
 // Each test exercises ONE Contract by constructing the minimal ctx
-// it needs. Reads adult-only, privacy-notice-delivered, email-format
+// it needs. Reads gdpr.ageBand.adultOnly (regulations-gdpr 0.3.x),
+// enrollment.pre.privacy-notice-delivered, enrollment.email.format-valid
 // from EnrollmentIntake.
 
 import { describe, it, expect } from "vitest";
@@ -18,8 +19,8 @@ function predicateById(id: string): (ctx: unknown) => boolean {
   return c.predicate as (ctx: unknown) => boolean;
 }
 
-describe("enrollment.adult-only Contract", () => {
-  const predicate = predicateById("enrollment.adult-only");
+describe("gdpr.ageBand.adultOnly Contract", () => {
+  const predicate = predicateById("gdpr.ageBand.adultOnly");
 
   it("rejects ageRange='under-18'", () => {
     const ctx = mkCtx({ ageRange: "under-18" });

--- a/apps/admin/tests/intake/spec.test.ts
+++ b/apps/admin/tests/intake/spec.test.ts
@@ -48,9 +48,9 @@ describe("EnrollmentIntake spec", () => {
     expect(EnrollmentIntake.readiness(ctx)).toBe(false);
   });
 
-  it("declares 3 pre + 2 invariant + 2 post Contracts (post #7 added for classroom routing)", () => {
-    expect(EnrollmentIntake.contracts?.pre?.length).toBe(3);
-    expect(EnrollmentIntake.contracts?.invariants?.length).toBe(2);
+  it("declares 2 pre + 3 invariant + 2 post Contracts (adult-only moved to invariants via regulations-gdpr 0.3.x ageBand.adultOnly)", () => {
+    expect(EnrollmentIntake.contracts?.pre?.length).toBe(2);
+    expect(EnrollmentIntake.contracts?.invariants?.length).toBe(3);
     expect(EnrollmentIntake.contracts?.post?.length).toBe(2);
   });
 
@@ -61,7 +61,7 @@ describe("EnrollmentIntake spec", () => {
       ...(EnrollmentIntake.contracts?.post ?? []),
     ];
     const ids = all.map((c) => c.id);
-    expect(ids).toContain("enrollment.adult-only");
+    expect(ids).toContain("gdpr.ageBand.adultOnly");
     expect(ids).toContain("enrollment.pre.privacy-notice-delivered");
     expect(ids).toContain("enrollment.email.format-valid");
   });


### PR DESCRIPTION
## Summary

Replaces HF's home-grown \`enrollment.adult-only\` Contract in \`EnrollmentIntake\` with \`ageBand.adultOnly({ ageBandField: 'ageRange' })\` from \`@tallyseal/regulations-gdpr@0.3.x\`. Same semantic, plus regulation-pack provenance (cites GDPR Art. 8 §1).

**Pre → Invariants:** the prior pre-contract only checked at session start, so a later AI tool call writing \`ageRange='under-18'\` into the snapshot would slip past. As an invariant the predicate holds throughout the session — strictly stronger guarantee.

Local \`AGE_RANGE_VALUES\` tuple dropped — \`AGE_BAND_VALUES\` from the regulation pack is byte-identical and is the canonical enum source.

## Findings filed for tallyseal

\`ageBand.adultOnly()\` returns \`Contract[]\` where sibling factories (\`specialCategoryProhibition\`, \`humanOversight\`) return a single \`Contract\`. Inconsistent API — spread used locally. Filed alongside items 17-20.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test -- --run tests/intake/\` — 39/39 pass (incl. 13 new spec-tools, 14 contract behaviour, 6 spec shape, etc.)
- [ ] **VM smoke** — pick \`ageRange='under-18'\` at intake, confirm commit-gate rejects with \`gdpr.ageBand.adultOnly\` violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)