### PR TITLE
feat(intake): post-commit recap + scrollable Chain-of-Custody panel

### DIFF
--- a/apps/admin/app/api/intake/audit-bundle/[intentId]/route.ts
+++ b/apps/admin/app/api/intake/audit-bundle/[intentId]/route.ts
@@ -1,0 +1,62 @@
+// GET /api/intake/audit-bundle/[intentId]
+//
+// Returns the composed AuditBundle for an intake session.
+//   - default: application/json (the full bundle as a single object)
+//   - ?format=jsonl: newline-delimited events + meta, suitable for
+//     piping to `npx crawcus-verify` (once TKT-VERIFIER-1a ships)
+//
+// Public: same posture as /api/intake/session/[intentId] — the
+// intentId is the bearer secret.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  composeIntakeAuditBundle,
+  SessionNotFoundError,
+} from "@/lib/intake/audit-bundle";
+import type { IntentId } from "@/lib/intake/tallyseal";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ intentId: string }> },
+): Promise<NextResponse> {
+  const { intentId } = await context.params;
+  if (!intentId) {
+    return NextResponse.json({ error: "missing intentId" }, { status: 400 });
+  }
+
+  let bundle;
+  try {
+    bundle = composeIntakeAuditBundle({ intentId: intentId as IntentId });
+  } catch (e) {
+    if (e instanceof SessionNotFoundError) {
+      return NextResponse.json({ error: "session not found" }, { status: 404 });
+    }
+    throw e;
+  }
+
+  const format = req.nextUrl.searchParams.get("format");
+  if (format === "jsonl") {
+    // One JSON object per line. First line is the bundle meta sans
+    // events; subsequent lines are events in order. Round-trip-safe
+    // with `JSON.parse` per line — matches the wire format the
+    // verifier CLI will consume.
+    const { events, ...meta } = bundle as unknown as {
+      events?: unknown[];
+    } & Record<string, unknown>;
+    const lines = [
+      JSON.stringify({ kind: "BundleMeta", ...meta }),
+      ...(Array.isArray(events) ? events.map((e) => JSON.stringify(e)) : []),
+    ];
+    return new NextResponse(lines.join("\n") + "\n", {
+      status: 200,
+      headers: {
+        "content-type": "application/x-ndjson",
+        "content-disposition": `attachment; filename="enrollment-${intentId}.jsonl"`,
+      },
+    });
+  }
+
+  return NextResponse.json(bundle);
+}

--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -159,16 +159,15 @@ export async function POST(req: NextRequest) {
     });
     session.state = "committed";
 
+    // Always route through /intake/done so the learner can review
+    // the audit trail before continuing. /intake/done passes the
+    // captured fields on to /join/[token] when a token is present
+    // (preserving the existing join flow); the platform-level demo
+    // path (no token) stops at /intake/done with bundle download.
+    const doneParams = new URLSearchParams({ intentId: session.intentId });
     const classroomToken = session.values.classroomToken as string | undefined;
-    if (classroomToken) {
-      const firstName = session.values.firstName as string | undefined;
-      const lastName = session.values.lastName as string | undefined;
-      const email = session.values.email as string | undefined;
-      if (firstName && lastName && email) {
-        const params = new URLSearchParams({ firstName, lastName, email });
-        redirectUrl = `/join/${classroomToken}?${params.toString()}`;
-      }
-    }
+    if (classroomToken) doneParams.set("token", classroomToken);
+    redirectUrl = `/intake/done?${doneParams.toString()}`;
   }
 
   return NextResponse.json({

--- a/apps/admin/app/api/intake/session/[intentId]/route.ts
+++ b/apps/admin/app/api/intake/session/[intentId]/route.ts
@@ -1,0 +1,38 @@
+// GET /api/intake/session/[intentId]
+//
+// Read-only snapshot of an intake session for the post-commit recap
+// page. Returns events, values, messages — same shape the bootstrap
+// + chat-turn responses carry, so the consumer (e.g. /intake/done)
+// can render the full CoC without holding a chat connection.
+//
+// Public: the intake surface is pre-auth. The intentId acts as a
+// random-secret bearer; lookup-by-id is the only way to read.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/intake/session-store";
+import type { IntentId } from "@/lib/intake/tallyseal";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ intentId: string }> },
+): Promise<NextResponse> {
+  const { intentId } = await context.params;
+  if (!intentId) {
+    return NextResponse.json({ error: "missing intentId" }, { status: 400 });
+  }
+  const session = getSession(intentId as IntentId);
+  if (!session) {
+    return NextResponse.json({ error: "session not found" }, { status: 404 });
+  }
+  return NextResponse.json({
+    intentId: session.intentId,
+    state: session.state,
+    events: session.events,
+    values: session.values,
+    messages: session.messages,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+  });
+}

--- a/apps/admin/app/intake/done/page.tsx
+++ b/apps/admin/app/intake/done/page.tsx
@@ -1,0 +1,35 @@
+// Post-commit recap surface — what the learner sees AFTER the chat
+// hits readiness and emits ProjectionCommit.
+//
+// Shows: captured values, the full Chain of Custody (scrollable),
+// download button for the audit bundle (jsonl ready for the verifier
+// CLI), and a "Continue to course" button that hands off to HF's
+// /join/[token] route. No redirect happens automatically — the
+// learner reviews the audit trail before continuing (or simply
+// closes the tab; the bundle is still composable from intentId).
+
+import { Suspense } from "react";
+import { IntakeDoneClient } from "@/components/intake/IntakeDoneClient";
+import "../intake.css";
+
+export const dynamic = "force-dynamic";
+
+export default function IntakeDonePage() {
+  return (
+    <main className="intake-page">
+      <div className="intake-container">
+        <header className="hf-mb-lg">
+          <h1 className="hf-page-title">Enrolment complete</h1>
+          <p className="hf-section-desc">
+            Your enrolment has been recorded. Below is the full audit trail —
+            every event, hash-chained — that we will hand to your course
+            provider. Download it for your records, then continue.
+          </p>
+        </header>
+        <Suspense fallback={<div className="hf-section-desc">Loading…</div>}>
+          <IntakeDoneClient />
+        </Suspense>
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/app/intake/intake.css
+++ b/apps/admin/app/intake/intake.css
@@ -107,3 +107,162 @@
 .intake-composer button[type="submit"] {
   align-self: flex-end;
 }
+
+/* ── Post-commit recap (/intake/done) ──────────────────────────── */
+
+.intake-done-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+
+@media (min-width: 1024px) {
+  .intake-done-grid {
+    grid-template-columns: 22rem 1fr;
+  }
+}
+
+.intake-done-values {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+}
+
+.intake-done-value-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.intake-done-value-row:last-child {
+  border-bottom: none;
+}
+
+.intake-done-value-row dt {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.intake-done-value-row dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.intake-done-actions {
+  flex-wrap: wrap;
+}
+
+/* ── Chain-of-Custody panel ────────────────────────────────────── */
+
+.intake-coc {
+  border: 1px solid var(--border-default);
+  border-radius: 16px;
+  background: var(--surface-primary);
+  padding: 16px;
+}
+
+.intake-coc-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.intake-coc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.intake-coc-empty {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  padding: 12px 0;
+}
+
+.intake-coc-row {
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: var(--surface-secondary);
+}
+
+.intake-coc-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+}
+
+.intake-coc-kind {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.intake-coc-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.intake-coc-dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 6px 12px;
+  margin: 0 0 6px;
+}
+
+.intake-coc-field {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+}
+
+.intake-coc-field dt {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.intake-coc-field dd {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-primary);
+}
+
+.intake-coc-field[data-status="broken"] dd {
+  color: var(--status-error-text);
+  font-weight: 600;
+}
+
+.intake-coc-payload {
+  margin-top: 8px;
+  font-size: 0.75rem;
+}
+
+.intake-coc-payload summary {
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.intake-coc-payload pre {
+  margin-top: 6px;
+  padding: 8px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 0.7rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/apps/admin/components/intake/IntakeCoCPanel.tsx
+++ b/apps/admin/components/intake/IntakeCoCPanel.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+// IntakeCoCPanel — scrollable Chain-of-Custody view over the intake
+// event log. Renders one card per Event with the canonical fields
+// auditors care about: kind / version / timestamp / actor / lawful
+// basis / purpose / prevHash / contentHash / payload summary / AI
+// provenance (when present).
+//
+// Pure presentation; no fetch, no mutations — give it events + an
+// optional title and it renders. The chain link is visualised by
+// rendering each event's prevHash as a small chip that should match
+// the previous event's contentHash.
+
+import type { Event } from "@/lib/intake/tallyseal";
+
+interface IntakeCoCPanelProps {
+  readonly events: readonly Event[];
+  readonly title?: string;
+  readonly maxHeightPx?: number;
+}
+
+export function IntakeCoCPanel({
+  events,
+  title = "Chain of Custody",
+  maxHeightPx = 420,
+}: IntakeCoCPanelProps) {
+  return (
+    <section className="intake-coc" data-testid="intake-coc-panel">
+      <header className="intake-coc-header">
+        <h3 className="hf-section-title">{title}</h3>
+        <span className="hf-section-desc">{events.length} event{events.length === 1 ? "" : "s"}</span>
+      </header>
+      <ol className="intake-coc-list" style={{ maxHeight: `${maxHeightPx}px` }}>
+        {events.length === 0 ? (
+          <li className="intake-coc-empty">No events yet.</li>
+        ) : (
+          events.map((e, i) => (
+            <CoCRow
+              key={e.id}
+              event={e}
+              prevContentHash={i === 0 ? null : (events[i - 1] as { contentHash?: string }).contentHash ?? null}
+            />
+          ))
+        )}
+      </ol>
+    </section>
+  );
+}
+
+interface CoCRowProps {
+  readonly event: Event;
+  readonly prevContentHash: string | null;
+}
+
+function CoCRow({ event, prevContentHash }: CoCRowProps) {
+  const e = event as unknown as {
+    id: string;
+    kind: string;
+    version: number;
+    timestamp: Date | string;
+    actor?: { id?: string };
+    lawfulBasis?: string;
+    purpose?: string;
+    prevHash?: string;
+    contentHash?: string;
+    payload?: unknown;
+    ai?: { model?: string; tokensIn?: number; tokensOut?: number; costUsd?: number };
+  };
+  const ts = typeof e.timestamp === "string" ? new Date(e.timestamp) : e.timestamp;
+  const chainOk = prevContentHash === null || e.prevHash === prevContentHash;
+  return (
+    <li className="intake-coc-row" data-event-kind={e.kind}>
+      <div className="intake-coc-row-head">
+        <span className="intake-coc-kind">{e.kind}</span>
+        <span className="intake-coc-meta">
+          v{e.version} · {ts instanceof Date ? ts.toISOString() : String(ts)}
+        </span>
+      </div>
+      <dl className="intake-coc-dl">
+        {e.lawfulBasis ? <Field label="lawfulBasis" value={e.lawfulBasis} /> : null}
+        {e.purpose ? <Field label="purpose" value={e.purpose} /> : null}
+        {e.actor?.id ? <Field label="actor" value={e.actor.id} /> : null}
+        <Field
+          label="prevHash"
+          value={short(e.prevHash)}
+          status={chainOk ? "ok" : "broken"}
+          title={e.prevHash ?? ""}
+        />
+        <Field label="contentHash" value={short(e.contentHash)} title={e.contentHash ?? ""} />
+        {e.ai ? (
+          <Field
+            label="ai"
+            value={`${e.ai.model ?? "?"} · in:${e.ai.tokensIn ?? 0} out:${e.ai.tokensOut ?? 0} · $${(e.ai.costUsd ?? 0).toFixed(6)}`}
+          />
+        ) : null}
+      </dl>
+      {e.payload !== undefined ? (
+        <details className="intake-coc-payload">
+          <summary>payload</summary>
+          <pre>{JSON.stringify(e.payload, null, 2)}</pre>
+        </details>
+      ) : null}
+    </li>
+  );
+}
+
+interface FieldProps {
+  readonly label: string;
+  readonly value: string;
+  readonly title?: string;
+  readonly status?: "ok" | "broken";
+}
+
+function Field({ label, value, title, status }: FieldProps) {
+  return (
+    <div className="intake-coc-field" data-status={status ?? "neutral"}>
+      <dt>{label}</dt>
+      <dd title={title}>{value}</dd>
+    </div>
+  );
+}
+
+function short(hash: string | undefined): string {
+  if (!hash) return "—";
+  if (hash.length <= 12) return hash;
+  return `${hash.slice(0, 8)}…${hash.slice(-4)}`;
+}

--- a/apps/admin/components/intake/IntakeDoneClient.tsx
+++ b/apps/admin/components/intake/IntakeDoneClient.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+// Client-side recap shell — fetches the session snapshot, renders
+// the CoC + summary + actions. Reads ?intentId= + ?token= from URL.
+//
+// On "Continue to course": navigates to /join/[token]?firstName=…
+// which is the existing battle-tested join flow (creates Caller +
+// CallerPlaybook). If no token, the "Continue" button is hidden —
+// the platform-level demo path stops here.
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { IntakeCoCPanel } from "./IntakeCoCPanel";
+import type { Event } from "@/lib/intake/tallyseal";
+
+interface SessionSnapshot {
+  readonly intentId: string;
+  readonly state: string;
+  readonly events: readonly Event[];
+  readonly values: Readonly<Record<string, unknown>>;
+}
+
+const VALUES_DISPLAY: ReadonlyArray<readonly [string, string]> = [
+  ["firstName", "First name"],
+  ["lastName", "Last name"],
+  ["email", "Email"],
+  ["displayName", "Display name"],
+  ["timezone", "Timezone"],
+  ["preferredContactMethod", "Preferred contact"],
+  ["marketingOptIn", "Marketing opt-in"],
+  ["accessibilityNote", "Accessibility note"],
+  ["ageRange", "Age range"],
+];
+
+export function IntakeDoneClient() {
+  const params = useSearchParams();
+  const intentId = params.get("intentId");
+  const token = params.get("token");
+  const [snapshot, setSnapshot] = useState<SessionSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!intentId) {
+      setError("missing intentId");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/intake/session/${encodeURIComponent(intentId)}`);
+        if (!res.ok) {
+          const text = await res.text().catch(() => `${res.status}`);
+          throw new Error(`session fetch failed: ${text}`);
+        }
+        const data = (await res.json()) as SessionSnapshot;
+        if (!cancelled) setSnapshot(data);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "load failed");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [intentId]);
+
+  if (error) {
+    return <div className="hf-banner hf-banner-error" data-testid="intake-done-error">{error}</div>;
+  }
+  if (!snapshot) {
+    return <div className="hf-section-desc">Loading audit trail…</div>;
+  }
+
+  const captured = VALUES_DISPLAY.filter(([k]) => snapshot.values[k] !== undefined);
+  const continueUrl = token ? buildContinueUrl(token, snapshot.values) : null;
+  const bundleUrl = `/api/intake/audit-bundle/${encodeURIComponent(intentId!)}?format=jsonl`;
+
+  return (
+    <div className="intake-done-grid">
+      <section className="hf-flex hf-flex-col hf-gap-md">
+        <div className="hf-card hf-card-compact" data-testid="intake-done-summary">
+          <h2 className="hf-section-title">Captured</h2>
+          <dl className="intake-done-values">
+            {captured.length === 0 ? (
+              <dd className="hf-section-desc">No values captured.</dd>
+            ) : (
+              captured.map(([k, label]) => (
+                <div key={k} className="intake-done-value-row">
+                  <dt>{label}</dt>
+                  <dd>{String(snapshot.values[k])}</dd>
+                </div>
+              ))
+            )}
+          </dl>
+        </div>
+
+        <div className="hf-flex hf-gap-sm intake-done-actions" data-testid="intake-done-actions">
+          <a
+            className="hf-btn hf-btn-secondary"
+            href={bundleUrl}
+            download
+            data-testid="intake-done-download"
+          >
+            Download audit bundle (.jsonl)
+          </a>
+          {continueUrl ? (
+            <a
+              className="hf-btn hf-btn-primary"
+              href={continueUrl}
+              data-testid="intake-done-continue"
+            >
+              Continue to course
+            </a>
+          ) : null}
+        </div>
+      </section>
+
+      <aside className="hf-flex hf-flex-col hf-gap-md">
+        <IntakeCoCPanel events={snapshot.events} />
+      </aside>
+    </div>
+  );
+}
+
+function buildContinueUrl(token: string, values: Readonly<Record<string, unknown>>): string {
+  const params = new URLSearchParams();
+  const firstName = values.firstName;
+  const lastName = values.lastName;
+  const email = values.email;
+  if (typeof firstName === "string") params.set("firstName", firstName);
+  if (typeof lastName === "string") params.set("lastName", lastName);
+  if (typeof email === "string") params.set("email", email);
+  const qs = params.toString();
+  return `/join/${encodeURIComponent(token)}${qs ? `?${qs}` : ""}`;
+}

--- a/apps/admin/e2e/tests/intake/enrollment-crawcus.spec.ts
+++ b/apps/admin/e2e/tests/intake/enrollment-crawcus.spec.ts
@@ -85,6 +85,24 @@ test.describe("intake/enrollment-crawcus", () => {
     await expect(page.locator("body")).toContainText("Privacy Notice", { timeout: 5_000 });
   });
 
+  test("redirects to /intake/done with intentId after enrolment completes", async ({ page }) => {
+    const email = makeEmail();
+    await page.goto(ROUTE);
+    const input = page.getByTestId("enrollment-chat-input");
+    await expect(input).toBeEnabled({ timeout: 15_000 });
+    await input.fill(`I'm Peter Jones and my email is ${email}.`);
+    await page.getByTestId("enrollment-chat-send").click();
+
+    // Wait for the chat client to follow data.redirectUrl → /intake/done?…
+    await page.waitForURL(/\/intake\/done\?intentId=/, { timeout: 30_000 });
+
+    // The recap page renders the captured values + actions + CoC.
+    await expect(page.getByTestId("intake-done-summary")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("intake-coc-panel")).toBeVisible();
+    await expect(page.getByTestId("intake-done-download")).toBeVisible();
+    await expect(page.locator("body")).toContainText(email);
+  });
+
   test("does not render the 4 internal field keys on the learner form", async ({ page }) => {
     await page.goto(ROUTE);
     await expect(page.getByTestId("enrollment-chat-input")).toBeVisible({ timeout: 15_000 });

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -14584,15 +14584,17 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 462 |
+| Route files found | 464 |
 | Files with annotations | 457 |
-| Files missing annotations | 5 |
-| Coverage | 98.9% |
+| Files missing annotations | 7 |
+| Coverage | 98.5% |
 
 ### Files missing `@api` annotations
 
 - `app/api/demonstrate/suggest/route.ts`
+- `app/api/intake/audit-bundle/[intentId]/route.ts`
 - `app/api/intake/audit-bundle/route.ts`
 - `app/api/intake/bootstrap/route.ts`
 - `app/api/intake/chat/route.ts`
 - `app/api/intake/disclosure-signal/route.ts`
+- `app/api/intake/session/[intentId]/route.ts`


### PR DESCRIPTION
## Summary

Surface crawcus outputs on the enrolment page — the learner now lands on a recap surface after \`ProjectionCommit\` with the full audit trail, captured values, audit-bundle download, and a continue-to-course button.

**4 commits, one concern each:**

1. \`feat(intake): API — session snapshot + audit-bundle download\` — GET routes for the recap page (\`/api/intake/session/[intentId]\` and \`/api/intake/audit-bundle/[intentId]?format=jsonl\`).
2. \`feat(intake): post-commit recap surface — /intake/done + IntakeCoCPanel\` — new page + scrollable CoC component showing every event with hash-chain visualisation.
3. \`feat(intake): chat redirects to /intake/done after commit\` — replaces the direct \`/join/[token]?…\` redirect with \`/intake/done?intentId=…&token=…\`. Preserves the join handoff via the \"Continue to course\" button.
4. \`test(e2e): cover /intake/done redirect + recap surface\` — 4th check in enrollment-crawcus.spec.ts.

## What the learner sees

After capturing all 3 required fields → chat assistant confirms \"submitting…\" → browser follows \`redirectUrl\` to \`/intake/done\`:

- **Summary card** (LHS): captured first name / last name / email / any optional fields
- **Chain of Custody panel** (RHS, scrollable, max-height 420px): every event with kind / version / timestamp / actor / lawful basis / purpose / **prevHash → contentHash** chain visible per row; broken chain renders red
- **Download audit bundle (.jsonl)** button: streams the bundle in wire format, ready for the upcoming \`npx crawcus-verify\` CLI (TKT-VERIFIER-1a, ~4-5 days tallyseal)
- **Continue to course** button: hands off to \`/join/[token]?firstName=…\` — existing battle-tested flow

Platform-level demo path (no \`?token\`): stops at /intake/done with bundle download, no \"Continue\" button.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test -- --run tests/intake/\` — 39/39 unit tests pass
- [x] e2e (3 prior + 1 new = 4 checks) passes locally; will re-run against VM after vm-cp

🤖 Generated with [Claude Code](https://claude.com/claude-code)