### PR TITLE
feat(intake): ask for ageRange + explicit "I read this" disclosure ack

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -55,25 +55,27 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // claude-opus-4-7 + claude-sonnet-4-6 — keep this list in step with
 // lib/intake/compliance.ts ai.allowedModels.
 const INTAKE_MODEL = "claude-sonnet-4-6";
-const INTAKE_PROMPT_VERSION = "intake/v0.2.0-DRAFT";
+const INTAKE_PROMPT_VERSION = "intake/v0.3.0-DRAFT";
 const INTAKE_MAX_COST_USD = 0.5; // == compliance.ai.costCeilingPerIntent
 
 const UPDATE_SETUP_TOOL: ToolDefinition = specToUpdateSetupTool(EnrollmentIntake, {
   excludeFields: INTERNAL_FIELDS,
 });
 
-const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Politely capture the learner's first name, last name, and email address.
+const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Politely capture the learner's first name, last name, and email address — and once those are in, optionally collect their age range.
 
 How to capture:
 - When the learner shares one or more field values — even multiple in a single message — call the \`update-setup\` tool with every value they provided. Pass each value under its field key (firstName / lastName / email / displayName / preferredContactMethod / marketingOptIn / accessibilityNote / ageRange / timezone). Omit fields they did not share.
 - Never invent values. Only capture what the learner explicitly stated.
 - Email must look like X@Y.Z. If it doesn't, do not capture it — ask them to try again.
+- For ageRange, accept ONLY one of these exact values: '18-24' / '25-34' / '35-44' / '45-54' / '55-64' / '65-plus' / 'prefer-not-to-say'. (HumanFirst is adult-only; 'under-18' is not valid and the system will reject it.) If the learner gives a specific age (e.g. "I'm 32"), map it to the right band. If they decline or say "prefer not to say", capture 'prefer-not-to-say'.
 
 How to reply (in the same turn as the tool call, when applicable):
 - Be warm, concise, professional. No emoji. No filler.
 - One short sentence per reply.
-- If you still need fields: prompt for the next missing one (firstName → lastName → email).
+- Ask in this order, one field at a time: firstName → lastName → ageRange → email. (Email is asked LAST because the enrolment commits as soon as it's captured.)
 - If a greeting or affirmation ("hi", "ok", "yes") arrives in place of a name, re-prompt for that name. Do not capture greetings.
+- ageRange is optional. Ask once after lastName; if the learner skips, declines, or asks why, accept it gracefully and move on to email.
 - When all three required fields (firstName, lastName, email) are captured, confirm the enrolment is being submitted and that a confirmation email will follow.`;
 
 const AFFIRMATION_RE = /^(hi|hello|hey|yo|ok|okay|sure|yes|yeah|yep|y|n|no|nope|start)\b[!.,? ]*$/i;

--- a/apps/admin/app/api/intake/disclosure-acknowledge/route.ts
+++ b/apps/admin/app/api/intake/disclosure-acknowledge/route.ts
@@ -1,0 +1,91 @@
+// POST /api/intake/disclosure-acknowledge
+//
+// Affirmative acknowledgement of a delivered disclosure — the
+// learner clicked "I have read this". Distinct from the passive
+// DisclosureSignal (scroll-read evidence): this event is the
+// canonical "subject confirmed receipt" record.
+//
+// Emits a DisclosureAcknowledged event linked by `acknowledges` to
+// the DisclosureDelivered event the controller wrote at bootstrap
+// time for the matching requirementId. Idempotent — re-clicking
+// returns 200 with `alreadyAcknowledged: true` and does not write
+// a duplicate event.
+//
+// IMPORTANT: this is NOT consent. The Art 13 disclosure is purely
+// informational (controller obligation under contract lawful basis).
+// Acknowledgement is additional audit evidence the subject saw the
+// notice; it does not change the lawful basis.
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  appendEvent,
+  getSession,
+  PURPOSE,
+} from "@/lib/intake/session-store";
+import type { EventId, IntentId, SubjectId } from "@/lib/intake/tallyseal";
+
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  intentId: z.string().min(1),
+  requirementId: z.string().min(1),
+  chatSessionId: z.string().min(1).max(120),
+});
+
+export async function POST(req: NextRequest) {
+  let body: z.infer<typeof BodySchema>;
+  try {
+    body = BodySchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  }
+
+  const session = getSession(body.intentId as IntentId);
+  if (!session) {
+    return NextResponse.json({ error: "session not found" }, { status: 404 });
+  }
+
+  // Find the DisclosureDelivered event we're acknowledging — the
+  // most recent one matching this requirementId.
+  const delivered = [...session.events]
+    .reverse()
+    .find((e) => {
+      if (e.kind !== "DisclosureDelivered") return false;
+      const payload = (e as { payload?: { requirementId?: string } }).payload;
+      return payload?.requirementId === body.requirementId;
+    }) as { id: EventId; payload?: { requirementId?: string } } | undefined;
+
+  if (!delivered) {
+    return NextResponse.json(
+      { error: "no DisclosureDelivered event for that requirementId" },
+      { status: 409 },
+    );
+  }
+
+  // Idempotency: if an Acknowledged event already exists for this
+  // delivered.id, return it without writing a duplicate.
+  const existingAck = session.events.find((e) => {
+    if (e.kind !== "DisclosureAcknowledged") return false;
+    const payload = (e as { payload?: { acknowledges?: string } }).payload;
+    return payload?.acknowledges === delivered.id;
+  });
+  if (existingAck) {
+    return NextResponse.json({ ok: true, alreadyAcknowledged: true });
+  }
+
+  const subjectId = `intake-subject-${body.chatSessionId}` as SubjectId;
+  appendEvent(session, {
+    kind: "DisclosureAcknowledged",
+    payload: {
+      disclosureId: `disc_${body.requirementId}`,
+      subject: subjectId,
+      acknowledges: delivered.id,
+    },
+    lawfulBasis: "contract",
+    purpose: PURPOSE.courseDelivery,
+    dataSubjectIds: [subjectId],
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/admin/app/intake/intake.css
+++ b/apps/admin/app/intake/intake.css
@@ -84,7 +84,7 @@
 }
 
 .intake-notice-body {
-  margin-top: 12px;
+  margin-top: 0;
   max-height: 240px;
   overflow-y: auto;
   white-space: pre-wrap;
@@ -92,6 +92,40 @@
   font-size: 0.875rem;
   line-height: 1.5;
   color: var(--text-primary);
+}
+
+.intake-notice-card {
+  border: 1px solid var(--border-default);
+  border-radius: 16px;
+  background: var(--surface-secondary);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.intake-notice-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.intake-notice-card-title {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.intake-notice-card-foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.intake-notice-acked {
+  color: var(--status-success-text);
+  font-weight: 600;
+  font-size: 0.875rem;
 }
 
 .intake-composer {

--- a/apps/admin/components/intake/EnrollmentChat.tsx
+++ b/apps/admin/components/intake/EnrollmentChat.tsx
@@ -232,10 +232,24 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
             matches what the learner reads. TallysealBanner renders
             event-chips only; the actual notice text must be surfaced
             here for the read-signal to mean anything. */}
-        <details className="intake-notice" data-testid="intake-art13-notice">
-          <summary>Privacy Notice (GDPR Art. 13) — click to expand</summary>
-          <pre className="intake-notice-body">{ART13_NOTICE_BODY}</pre>
-        </details>
+        <DisclosureNoticeCard
+          intentId={boot.intentId}
+          chatSessionId={boot.chatSessionId}
+          requirementId={ART13_REQUIREMENT_ID}
+          body={ART13_NOTICE_BODY}
+          acknowledged={hasAcknowledgement(boot.events, ART13_REQUIREMENT_ID)}
+          onAcknowledged={() => {
+            // Optimistic refresh — re-fetch the snapshot via the next
+            // chat turn or by re-bootstrapping the events. Cheapest:
+            // refetch session events directly.
+            void fetch(`/api/intake/session/${encodeURIComponent(boot.intentId)}`)
+              .then((r) => r.json())
+              .then((data) => {
+                setBoot((b) => (b ? { ...b, events: rehydrateEvents(data.events) } : b));
+              })
+              .catch(() => {});
+          }}
+        />
         <div
           ref={scrollRef}
           className="intake-thread"
@@ -345,6 +359,99 @@ function ValuesPanel({ values }: { values: Readonly<Record<string, unknown>> }) 
       )}
     </div>
   );
+}
+
+interface DisclosureNoticeCardProps {
+  readonly intentId: string;
+  readonly chatSessionId: string;
+  readonly requirementId: string;
+  readonly body: string;
+  readonly acknowledged: boolean;
+  readonly onAcknowledged: () => void;
+}
+
+function DisclosureNoticeCard({
+  intentId,
+  chatSessionId,
+  requirementId,
+  body,
+  acknowledged,
+  onAcknowledged,
+}: DisclosureNoticeCardProps) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function ack() {
+    if (pending || acknowledged) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/intake/disclosure-acknowledge", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ intentId, chatSessionId, requirementId }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => `${res.status}`);
+        throw new Error(text);
+      }
+      onAcknowledged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "acknowledge failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section className="intake-notice-card" data-testid="intake-art13-notice">
+      <header className="intake-notice-card-head">
+        <span className="intake-notice-card-title">Privacy Notice (GDPR Art. 13)</span>
+      </header>
+      <pre className="intake-notice-body">{body}</pre>
+      <footer className="intake-notice-card-foot">
+        {acknowledged ? (
+          <span className="intake-notice-acked" data-testid="intake-art13-acked">
+            ✓ You confirmed you read this notice
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary"
+            onClick={ack}
+            disabled={pending}
+            data-testid="intake-art13-ack-btn"
+          >
+            {pending ? "Confirming…" : "I have read this notice"}
+          </button>
+        )}
+        {error ? <span className="hf-banner hf-banner-error">{error}</span> : null}
+      </footer>
+    </section>
+  );
+}
+
+function hasAcknowledgement(events: readonly Event[], requirementId: string): boolean {
+  // Walk events for a DisclosureAcknowledged whose `acknowledges`
+  // EventId points to a DisclosureDelivered carrying this
+  // requirementId. Avoids assuming any particular event order.
+  const deliveredIds = new Set<string>();
+  for (const e of events) {
+    if (e.kind === "DisclosureDelivered") {
+      const payload = (e as { payload?: { requirementId?: string } }).payload;
+      if (payload?.requirementId === requirementId) {
+        const id = (e as { id?: string }).id;
+        if (id) deliveredIds.add(id);
+      }
+    }
+  }
+  for (const e of events) {
+    if (e.kind === "DisclosureAcknowledged") {
+      const payload = (e as { payload?: { acknowledges?: string } }).payload;
+      if (payload?.acknowledges && deliveredIds.has(payload.acknowledges)) return true;
+    }
+  }
+  return false;
 }
 
 function ChatBubble({ role, content }: ChatMessage) {

--- a/apps/admin/e2e/tests/intake/enrollment-crawcus.spec.ts
+++ b/apps/admin/e2e/tests/intake/enrollment-crawcus.spec.ts
@@ -103,6 +103,17 @@ test.describe("intake/enrollment-crawcus", () => {
     await expect(page.locator("body")).toContainText(email);
   });
 
+  test("acknowledge button emits DisclosureAcknowledged + flips to confirmation pill", async ({ page }) => {
+    await page.goto(ROUTE);
+    const btn = page.getByTestId("intake-art13-ack-btn");
+    await expect(btn).toBeVisible({ timeout: 15_000 });
+    await btn.click();
+    await expect(page.getByTestId("intake-art13-acked")).toBeVisible({ timeout: 10_000 });
+    // Re-acknowledging is idempotent — the button is gone, no error
+    // banner appears.
+    await expect(page.getByTestId("intake-art13-ack-btn")).toHaveCount(0);
+  });
+
   test("does not render the 4 internal field keys on the learner form", async ({ page }) => {
     await page.goto(ROUTE);
     await expect(page.getByTestId("enrollment-chat-input")).toBeVisible({ timeout: 15_000 });

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -14584,10 +14584,10 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 464 |
+| Route files found | 465 |
 | Files with annotations | 457 |
-| Files missing annotations | 7 |
-| Coverage | 98.5% |
+| Files missing annotations | 8 |
+| Coverage | 98.3% |
 
 ### Files missing `@api` annotations
 
@@ -14596,5 +14596,6 @@ orchestration between services) and are never exposed externally.
 - `app/api/intake/audit-bundle/route.ts`
 - `app/api/intake/bootstrap/route.ts`
 - `app/api/intake/chat/route.ts`
+- `app/api/intake/disclosure-acknowledge/route.ts`
 - `app/api/intake/disclosure-signal/route.ts`
 - `app/api/intake/session/[intentId]/route.ts`


### PR DESCRIPTION
## Summary

Two surfaces extended in the intake chat:

1. **Ask for age range.** System prompt updated so the AI asks for \`ageRange\` after lastName, before email. Email asked LAST because capturing it triggers commit. Bumped \`INTAKE_PROMPT_VERSION\` → \`v0.3.0-DRAFT\` so audit provenance reflects the change.

2. **Explicit \"I have read this notice\" affirmative ack.** New canonical \`DisclosureAcknowledged\` event path distinct from the passive \`DisclosureSignal\` scroll evidence. UI: replaces the collapsed \`<details>\` with an always-expanded notice card with a button below; once clicked, flips to a ✓ confirmation pill. Idempotent on the server.

## Doctrine note

The affirmative ack is NOT consent. Art 13 disclosure is informational (controller obligation under contract lawful basis); ack is additional audit evidence the subject saw the notice. SIGNAL-not-gate doctrine still governs the scroll path. Both events land in the log; auditor sees the full timeline.

## How it'll look on the page

- Disclosure card shows the full Art 13 body upfront (no collapse) + an \"I have read this notice\" button
- Click → \`DisclosureAcknowledged\` event lands → pill turns ✓
- Chat assistant proceeds: firstName → lastName → ageRange (optional) → email → commit → /intake/done recap

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test -- --run tests/intake/\` — 39/39 unit pass
- [ ] e2e (4 prior + 1 new = 5 checks) — needs vm-cp then re-run
- [ ] Manual smoke: paste \"I'm Peter Jones\" → AI asks for age → \"prefer not to say\" → AI asks for email → \"peter@…\" → commit → /intake/done

🤖 Generated with [Claude Code](https://claude.com/claude-code)