### PR TITLE
fix(intake): welcome message mentions age range

### DIFF
--- a/apps/admin/app/api/intake/bootstrap/route.ts
+++ b/apps/admin/app/api/intake/bootstrap/route.ts
@@ -97,7 +97,7 @@ export async function POST(req: NextRequest) {
   // into session values, emit a ClassroomResolved custom event so the
   // enrollment.classroom-resolved post-Contract is satisfied.
   let welcomeMessage =
-    "Welcome — I'll get you enrolled. I'll need your first name, last name and email. What's your first name?";
+    "Welcome — I'll get you enrolled. I'll need your first name, last name, age range (optional) and email. What's your first name?";
   if (body.classroomToken) {
     const origin = req.nextUrl.origin;
     const joinRes = await fetch(`${origin}/api/join/${body.classroomToken}`, {
@@ -128,7 +128,7 @@ export async function POST(req: NextRequest) {
       purpose: PURPOSE.courseDelivery,
       dataSubjectIds: [subjectId],
     });
-    welcomeMessage = `Welcome — you're enrolling in "${classroomName}". I'll need your first name, last name and email. What's your first name?`;
+    welcomeMessage = `Welcome — you're enrolling in "${classroomName}". I'll need your first name, last name, age range (optional) and email. What's your first name?`;
   }
 
   appendMessage(session, "system", welcomeMessage);


### PR DESCRIPTION
Trivial 2-line fix. The AI's first message promised "first name, last name and email" — locking it into a 3-field plan that overrode the system-prompt's "ask for age range after lastName" instruction. Welcome now mentions age range as optional.