### PR TITLE
fix(intake): make ageRange required so AI can't skip it

### DIFF
--- a/apps/admin/app/api/intake/bootstrap/route.ts
+++ b/apps/admin/app/api/intake/bootstrap/route.ts
@@ -97,7 +97,7 @@ export async function POST(req: NextRequest) {
   // into session values, emit a ClassroomResolved custom event so the
   // enrollment.classroom-resolved post-Contract is satisfied.
   let welcomeMessage =
-    "Welcome — I'll get you enrolled. I'll need your first name, last name, age range (optional) and email. What's your first name?";
+    "Welcome — I'll get you enrolled. I'll need four things: your first name, last name, age range, and email. What's your first name?";
   if (body.classroomToken) {
     const origin = req.nextUrl.origin;
     const joinRes = await fetch(`${origin}/api/join/${body.classroomToken}`, {
@@ -128,7 +128,7 @@ export async function POST(req: NextRequest) {
       purpose: PURPOSE.courseDelivery,
       dataSubjectIds: [subjectId],
     });
-    welcomeMessage = `Welcome — you're enrolling in "${classroomName}". I'll need your first name, last name, age range (optional) and email. What's your first name?`;
+    welcomeMessage = `Welcome — you're enrolling in "${classroomName}". I'll need four things: your first name, last name, age range, and email. What's your first name?`;
   }
 
   appendMessage(session, "system", welcomeMessage);

--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -55,28 +55,28 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // claude-opus-4-7 + claude-sonnet-4-6 — keep this list in step with
 // lib/intake/compliance.ts ai.allowedModels.
 const INTAKE_MODEL = "claude-sonnet-4-6";
-const INTAKE_PROMPT_VERSION = "intake/v0.3.0-DRAFT";
+const INTAKE_PROMPT_VERSION = "intake/v0.4.0-DRAFT";
 const INTAKE_MAX_COST_USD = 0.5; // == compliance.ai.costCeilingPerIntent
 
 const UPDATE_SETUP_TOOL: ToolDefinition = specToUpdateSetupTool(EnrollmentIntake, {
   excludeFields: INTERNAL_FIELDS,
 });
 
-const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Politely capture the learner's first name, last name, and email address — and once those are in, optionally collect their age range.
+const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Politely capture FOUR required values from the learner: first name, last name, age range, and email.
 
 How to capture:
-- When the learner shares one or more field values — even multiple in a single message — call the \`update-setup\` tool with every value they provided. Pass each value under its field key (firstName / lastName / email / displayName / preferredContactMethod / marketingOptIn / accessibilityNote / ageRange / timezone). Omit fields they did not share.
+- When the learner shares one or more field values — even multiple in a single message — call the \`update-setup\` tool with every value they provided. Pass each value under its field key (firstName / lastName / email / ageRange / displayName / preferredContactMethod / marketingOptIn / accessibilityNote / timezone). Omit fields they did not share.
 - Never invent values. Only capture what the learner explicitly stated.
 - Email must look like X@Y.Z. If it doesn't, do not capture it — ask them to try again.
-- For ageRange, accept ONLY one of these exact values: '18-24' / '25-34' / '35-44' / '45-54' / '55-64' / '65-plus' / 'prefer-not-to-say'. (HumanFirst is adult-only; 'under-18' is not valid and the system will reject it.) If the learner gives a specific age (e.g. "I'm 32"), map it to the right band. If they decline or say "prefer not to say", capture 'prefer-not-to-say'.
+- For ageRange, accept ONLY one of these exact values: '18-24' / '25-34' / '35-44' / '45-54' / '55-64' / '65-plus' / 'prefer-not-to-say'. (HumanFirst is adult-only; 'under-18' is not valid and the system will reject it.) If the learner gives a specific age (e.g. "I'm 32"), map it to the right band. If they decline, refuse to say, or ask why, capture 'prefer-not-to-say'.
 
 How to reply (in the same turn as the tool call, when applicable):
 - Be warm, concise, professional. No emoji. No filler.
 - One short sentence per reply.
-- Ask in this order, one field at a time: firstName → lastName → ageRange → email. (Email is asked LAST because the enrolment commits as soon as it's captured.)
+- Ask in this STRICT order, one field at a time: firstName → lastName → ageRange → email. (Email is asked LAST because the enrolment commits as soon as all four required values are in.)
 - If a greeting or affirmation ("hi", "ok", "yes") arrives in place of a name, re-prompt for that name. Do not capture greetings.
-- ageRange is optional. Ask once after lastName; if the learner skips, declines, or asks why, accept it gracefully and move on to email.
-- When all three required fields (firstName, lastName, email) are captured, confirm the enrolment is being submitted and that a confirmation email will follow.`;
+- ageRange is REQUIRED. Do not skip it. After capturing lastName, your next reply MUST ask for the learner's age range. If they decline, capture 'prefer-not-to-say' and then move to email. Do not ask for email before ageRange has a value.
+- When all four required fields (firstName, lastName, ageRange, email) are captured, confirm the enrolment is being submitted and that a confirmation email will follow.`;
 
 const AFFIRMATION_RE = /^(hi|hello|hey|yo|ok|okay|sure|yes|yeah|yep|y|n|no|nope|start)\b[!.,? ]*$/i;
 
@@ -192,7 +192,7 @@ function isReady(values: Record<string, unknown>): boolean {
     const v = values[k];
     return v !== undefined && v !== null && v !== "";
   };
-  return has("firstName") && has("lastName") && has("email");
+  return has("firstName") && has("lastName") && has("email") && has("ageRange");
 }
 
 // ── AI call — passes the `update-setup` tool ───────────────────────

--- a/apps/admin/e2e/tests/intake/enrollment-crawcus.spec.ts
+++ b/apps/admin/e2e/tests/intake/enrollment-crawcus.spec.ts
@@ -43,7 +43,7 @@ function makeEmail(): string {
 }
 
 test.describe("intake/enrollment-crawcus", () => {
-  test("captures firstName + lastName + email from a single multi-field paste", async ({ page }) => {
+  test("captures all 4 required fields from a single multi-field paste", async ({ page }) => {
     const email = makeEmail();
 
     await page.goto(ROUTE);
@@ -57,21 +57,64 @@ test.describe("intake/enrollment-crawcus", () => {
     await expect(input).toBeEnabled();
     await expect(page.getByTestId("enrollment-chat-thread")).toBeVisible();
 
-    // 3. Send the multi-field paste in one message. With items 12+13
-    //    spec-driven tool calling, the AI should call `update-setup`
-    //    with all three fields populated atomically.
+    // 3. Multi-field paste including ageRange (required after the
+    //    .required() flip). The AI must call update-setup with all
+    //    four required values atomically.
     const sendBtn = page.getByTestId("enrollment-chat-send");
-    await input.fill(`Hello — I'm Peter Jones and my email is ${email}.`);
+    await input.fill(`Hi — I'm Peter Jones, age 32, email ${email}.`);
     await sendBtn.click();
 
-    // 4. Wait for the assistant turn to land + the values panel to
-    //    reflect all three captured fields. We poll the page text
-    //    rather than a specific element because ValuesPanel renders
-    //    captured values as a compact summary list.
+    // 4. Values panel reflects all 4 captured fields. age 32 → '25-34'.
     const valuesPanel = page.locator("body");
     await expect(valuesPanel).toContainText("Peter", { timeout: 30_000 });
     await expect(valuesPanel).toContainText("Jones", { timeout: 30_000 });
     await expect(valuesPanel).toContainText(email, { timeout: 30_000 });
+    await expect(valuesPanel).toContainText("25-34", { timeout: 30_000 });
+  });
+
+  test("step-by-step flow — AI asks for age range after lastName, before email", async ({ page }) => {
+    // This is the test that catches the class of bug "the AI ignored
+    // the system prompt's ask-order instruction". A pure multi-field
+    // paste test would never surface it because the user does the
+    // ordering work itself.
+    const email = makeEmail();
+    await page.goto(ROUTE);
+
+    const input = page.getByTestId("enrollment-chat-input");
+    const sendBtn = page.getByTestId("enrollment-chat-send");
+    await expect(input).toBeEnabled({ timeout: 15_000 });
+
+    // Turn 1 — firstName only.
+    await input.fill("Peter");
+    await sendBtn.click();
+    await expect(page.locator("body")).toContainText("Peter", { timeout: 20_000 });
+
+    // Turn 2 — lastName only. The AI's NEXT reply must mention "age"
+    // (per system prompt v0.4 + bootstrap welcome v0.8.13 onwards) or
+    // ageRange is silently being skipped — the regression class.
+    await expect(input).toBeEnabled({ timeout: 20_000 });
+    await input.fill("Jones");
+    await sendBtn.click();
+    await expect(page.locator("body")).toContainText("Jones", { timeout: 20_000 });
+    // Look for "age" in the assistant's reply. Case-insensitive so
+    // "Age range", "your age band", etc. all match.
+    await expect(page.locator('[data-role="assistant"]').last()).toContainText(/age/i, {
+      timeout: 30_000,
+    });
+
+    // Turn 3 — decline ageRange ("prefer not to say"). The AI should
+    // capture 'prefer-not-to-say' and move to email.
+    await expect(input).toBeEnabled({ timeout: 20_000 });
+    await input.fill("prefer not to say");
+    await sendBtn.click();
+    await expect(page.locator("body")).toContainText("prefer-not-to-say", { timeout: 30_000 });
+
+    // Turn 4 — email. Commit + redirect to /intake/done.
+    await expect(input).toBeEnabled({ timeout: 20_000 });
+    await input.fill(email);
+    await sendBtn.click();
+    await page.waitForURL(/\/intake\/done\?intentId=/, { timeout: 30_000 });
+    await expect(page.locator("body")).toContainText(email);
   });
 
   test("renders the Art 13 disclosure banner with notice text", async ({ page }) => {
@@ -90,7 +133,7 @@ test.describe("intake/enrollment-crawcus", () => {
     await page.goto(ROUTE);
     const input = page.getByTestId("enrollment-chat-input");
     await expect(input).toBeEnabled({ timeout: 15_000 });
-    await input.fill(`I'm Peter Jones and my email is ${email}.`);
+    await input.fill(`I'm Peter Jones, age 32, email ${email}.`);
     await page.getByTestId("enrollment-chat-send").click();
 
     // Wait for the chat client to follow data.redirectUrl → /intake/done?…

--- a/apps/admin/lib/intake/specs/enrollment.intent.ts
+++ b/apps/admin/lib/intake/specs/enrollment.intent.ts
@@ -132,9 +132,9 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
 
     ageRange: field
       .enum(AGE_BAND_VALUES)
-      .optional()
+      .required()
       .label({ en: "Age range" })
-      .askHint({ en: "Roughly what age band are you in?" }),
+      .askHint({ en: "Roughly what age band are you in? (You can say 'prefer not to say'.)" }),
 
     // ── Internal — Art 9 gate machinery ───────────────────────────
     // Populated by the spec's reducer / AI tool layer (not user input)
@@ -154,7 +154,7 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
 
   readiness: (ctx: unknown) => {
     const { has } = ctx as { has: (...keys: string[]) => boolean };
-    return has("firstName", "lastName", "email");
+    return has("firstName", "lastName", "email", "ageRange");
   },
 
   contracts: {

--- a/apps/admin/tests/intake/spec.test.ts
+++ b/apps/admin/tests/intake/spec.test.ts
@@ -36,14 +36,20 @@ describe("EnrollmentIntake spec", () => {
     expect(EnrollmentIntake.classification).toBe("standard");
   });
 
-  it("readiness fires on firstName + lastName + email", () => {
-    const present = new Set(["firstName", "lastName", "email"]);
+  it("readiness fires on firstName + lastName + email + ageRange", () => {
+    const present = new Set(["firstName", "lastName", "email", "ageRange"]);
     const ctx = { has: (...keys: string[]) => keys.every((k) => present.has(k)) };
     expect(EnrollmentIntake.readiness(ctx)).toBe(true);
   });
 
   it("readiness fails when email missing", () => {
-    const present = new Set(["firstName", "lastName"]);
+    const present = new Set(["firstName", "lastName", "ageRange"]);
+    const ctx = { has: (...keys: string[]) => keys.every((k) => present.has(k)) };
+    expect(EnrollmentIntake.readiness(ctx)).toBe(false);
+  });
+
+  it("readiness fails when ageRange missing — required so AI must ask", () => {
+    const present = new Set(["firstName", "lastName", "email"]);
     const ctx = { has: (...keys: string[]) => keys.every((k) => present.has(k)) };
     expect(EnrollmentIntake.readiness(ctx)).toBe(false);
   });


### PR DESCRIPTION
Structural fix — polite prompts weren't enough. `ageRange` is now `.required()` and in the readiness predicate. Email-capture no longer triggers commit when ageRange is missing, so the AI is forced to ask. 'prefer-not-to-say' is the structural escape valve. Tests updated (40/40 pass).