### PR TITLE
fix(dockerfile): COPY vendor/ before npm ci so file:vendor/*.tgz resolves

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -24,6 +24,13 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
+# Tallyseal packages are vendored as local tarballs (items 12+13 onward).
+# package-lock.json carries `file:vendor/tallyseal/*.tgz` references — npm ci
+# resolves these against the working directory, so vendor/ MUST exist BEFORE
+# the install. Pre-2026-06-04 this directory was empty so the bug stayed
+# latent; #1012 added 13 file: references and #1013 resynced the lock, which
+# is when Cloud Build started failing with ENOENT on the tarballs.
+COPY vendor ./vendor
 RUN npm ci
 # Prisma generate happens once here so all downstream targets share the cached client.
 COPY prisma ./prisma


### PR DESCRIPTION
Cloud Build for STAGING fails ENOENT on tallyseal tarballs because the `deps` stage runs `npm ci` before vendor/ is copied. Lock file has 13 `file:vendor/tallyseal/*.tgz` references (post #1012 + #1013). Fix inserts `COPY vendor ./vendor` between the package files COPY and `npm ci`. Unblocks #1010 sweep deploy. Refs #1012 #1013.