### PR TITLE
docs(strategy): D1 briefing + D2 priority TAM

### DIFF
--- a/docs/strategy/CONTINUE-HERE.md
+++ b/docs/strategy/CONTINUE-HERE.md
@@ -1,0 +1,126 @@
+# Continue Here — TAM & GTM Doc Set
+
+**Last touched:** 2026-06-04 by Paul + Claude
+**Branch:** `chore/tam-docs-d1-d2`
+**Status:** D1 + D2 shipped (V0.1). D3–D5 paused for review.
+
+---
+
+## What's done
+
+| Code | Doc | Files | Status |
+|---|---|---|---|
+| D1 | Briefing Note | `D1-briefing-note.md` + `.pdf` | **Shipped V0.1** |
+| D2 | Priority TAM Overview (Sector B + IELTS wedge) | `D2-priority-tam.md` + `.pdf` | **Shipped V0.1** |
+
+Both follow the locked spine: 5-level nomenclature (Sector → Wedge → Channel → Account → Cohort), 4-question priority frame, TAM = Sector / SAM = Channel / SOM = Account, V/E/T confidence flags, and the 7-sector portfolio (A–G).
+
+## What's locked (the spine — do not re-debate)
+
+1. **Nomenclature:** 5 levels — Sector → Wedge → Channel → Account → Cohort
+2. **Sizing map:** TAM = Sector | SAM = Channel | SOM = Account
+3. **Confidence flags:** [V] verified · [E] estimate · [T] TBD
+4. **Numbers:** always WW + UK; `-` where unknown
+5. **Sector list:** 7 sectors A–G (B and G locked as P1)
+6. **Phase-1 commitment:** Sector B / NMC speaking-band-7 wedge / IRA channel
+7. **IELTS probe success criteria:** 3 hypotheses, all must pass
+8. **SCQA (sharpened):** in D1 — do not re-edit
+9. **Doc set:** D1–D7
+
+## What's paused (resume in this order)
+
+### Next: D4 — Citation Sheet (Google Sheet)
+
+**Why next:** D1/D2 currently cite figures inline. Production-ready version needs every number to link back to a single citation sheet row.
+
+**V0 schema (build first):**
+| col | name | type | example |
+|---|---|---|---|
+| A | metric_id | text | `B.NMC.register_total` |
+| B | sector | text | `B` |
+| C | metric_name | text | NMC register total |
+| D | value_ww | text | `–` |
+| E | value_uk | text | 826k |
+| F | unit | text | registrants |
+| G | source_name | text | NMC Annual Register Report |
+| H | source_url | url | https://www.nmc.org.uk/about-us/reports-and-accounts/registration-statistics/ |
+| I | as_of_date | date | 2025-03 |
+| J | confidence | enum | V / E / T |
+| K | notes | text | – |
+
+**Seed rows:** all rows from the "Top citations" table in D2 §11 + the verified-citation table I produced earlier in chat. ~60 rows.
+
+### Next-next: D5 — Entity Lists (Google Sheet, multi-tab)
+
+**Tabs:**
+1. `IRAs` — 330 from NHS Employers Code-of-Practice list (top 8 named + tail)
+2. `Healthcare regulators` — 9 UK statutory bodies
+3. `Publishers` — 7 UK-HQ EFL publishers
+4. `Pathway providers` — 7–9 UK pathway operators
+5. `Test owners` — 5 (IELTS partners × 3, OET, PTE, Duolingo, TOEFL)
+6. `CPD bodies` — ~30 UK CPD-mandated bodies (per D2 §3 cluster build-up)
+7. `NHS Trusts (overseas-recruiting)` — top 30 by activity
+
+Columns per row: name · type · website · primary_contact_role · linkedin · status (Pipeline/Active/Lapsed) · last_touch · owner
+
+### After D4/D5: D3 — Full TAM & GTM Analysis (25–35pp)
+
+Sections to write:
+1. Executive summary (pyramid lift of D2)
+2. Methodology & nomenclature (lift D7)
+3. Each sector A–G — full deep-dive (replicate D2 §4 structure for each)
+4. Channel taxonomy — comprehensive
+5. The CPD meta-sector — body-by-body
+6. IRA outreach plan — full version
+7. The IELTS probe design — full
+8. Phase 2 / 3 / 4 forward planning
+9. Risk register — full
+10. WW expansion thesis (US/EU/APAC follow-on)
+11. Citation appendix (links to D4)
+12. Entity appendix (links to D5)
+
+### Other paused work (lower priority)
+
+- **D6** — render the ASCII TAM picture as a designed slide (Google Slides or PowerPoint). Content is already in D1 + D2.
+- **D7** — paste nomenclature standard into team wiki. Content is in D2 §2 + the chat conversation log.
+
+## Outstanding research (the verification week, before any investor share)
+
+Five ESTIMATEs to convert to VERIFIED:
+
+| # | Estimate | How to verify | Effort |
+|---|---|---|---|
+| 1 | First-attempt healthcare-IELTS pass rate ~30–40% | Pull IELTS Partners disaggregated data by occupation; OET published band distribution | 2 days |
+| 2 | Per-candidate English-prep spend £1–2.5k | 5–10 IRA exec interviews | 1 week |
+| 3 | IRA market share Top-5 ~50% | Companies House revenue for all 330 IRAs + FOI'd top-30 NHS Trust IRA contracts | 1 week |
+| 4 | OSCE-prep TAM £40–60M | NMC OSCE candidate × commercial OSCE-prep provider price points | 2 days |
+| 5 | NHS overseas-nurse net spend ~£200M / yr (NAO is gross) | FOI NHSE Workforce Training & Education programme accounts | 2 weeks |
+
+## Doc set roadmap
+
+| Code | Doc | Status |
+|---|---|---|
+| D1 | Briefing Note (2pp) | ✅ Shipped V0.1 |
+| D2 | Priority TAM Overview (~7pp) | ✅ Shipped V0.1 |
+| D3 | Full TAM & GTM Analysis (25–35pp) | ⏸ Paused — drafted in chat, not in file |
+| D4 | Citation Sheet (Google Sheet) | ⏸ Paused — schema ready |
+| D5 | Entity Lists (Google Sheet) | ⏸ Paused — schema ready |
+| D6 | TAM Picture (1-pager slide) | ⏸ ASCII shipped in D1/D2; render to slide pending |
+| D7 | Nomenclature Standard (wiki) | ⏸ Embedded in D2 §2; wiki paste pending |
+
+## How to resume
+
+When Paul wants to pick this up:
+
+```
+git checkout chore/tam-docs-d1-d2
+cat docs/strategy/CONTINUE-HERE.md
+```
+
+Then prompt: *"Resume the TAM doc set. Start with D4 (citation sheet schema + populated rows from D2 citations)."*
+
+The chat history of this session has the source material for D3 and the full D4/D5 row content — anyone restarting should re-read it before drafting D3.
+
+## Branch hygiene
+
+This branch (`chore/tam-docs-d1-d2`) is doc-only. No code, no schema, no Prisma, no API. Safe to merge to main once D1+D2 are board-approved. After merge, open a new branch for D4/D5 work to keep concerns separated.

--- a/docs/strategy/D1-briefing-note.md
+++ b/docs/strategy/D1-briefing-note.md
@@ -1,0 +1,120 @@
+---
+title: "D1 — Briefing Note"
+subtitle: "Why HFF Needs a Professional TAM and GTM"
+author: "Paul Wander"
+date: "4 June 2026"
+version: "0.1"
+---
+
+<style>
+  body { font-family: 'Helvetica Neue', Arial, sans-serif; color: #1a1a1a; line-height: 1.55; font-size: 11pt; }
+  h1 { color: #0f172a; border-bottom: 3px solid #2563eb; padding-bottom: 8px; font-size: 22pt; margin-top: 0; }
+  h2 { color: #1e3a5f; border-bottom: 1px solid #e2e8f0; padding-bottom: 4px; margin-top: 22px; font-size: 14pt; }
+  h3 { color: #334155; margin-top: 16px; font-size: 12pt; }
+  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 10pt; }
+  th, td { border: 1px solid #e2e8f0; padding: 6px 10px; text-align: left; vertical-align: top; }
+  th { background: #f1f5f9; color: #0f172a; font-weight: 600; }
+  code, pre { font-family: 'Menlo', monospace; font-size: 9.5pt; background: #f8fafc; }
+  pre { padding: 10px; border-left: 3px solid #2563eb; overflow-x: auto; }
+  blockquote { border-left: 3px solid #2563eb; padding-left: 12px; color: #334155; margin: 12px 0; }
+  .meta { font-size: 9.5pt; color: #64748b; margin-top: -8px; }
+</style>
+
+::: meta
+**Status:** Internal — Co-founders + Board  &nbsp;|&nbsp; **Owner:** Paul Wander  &nbsp;|&nbsp; **Decision asked:** Confirm Sector B commitment + IELTS probe success criteria + doc-set backbone
+:::
+
+## Situation
+
+Embarking on our Market Test, we are looking for signals to inform our Go-To-Market. The IELTS market test is the probe; we now need a framework for what it is meant to validate.
+
+## Complication
+
+We have a proliferation of GTM ideas, market analyses, and partner hypotheses. Without a single TAM frame, every conversation re-debates the basics. Without an evidenced GTM, we cannot brief partners or investors consistently. The IELTS probe will generate strong signals — but only if we have decided in advance what those signals are meant to confirm.
+
+## Question
+
+How do we choose the sector, wedge, and channel HFF commits to first, evidenced by the IELTS market test?
+
+## Answer
+
+**Commit to Sector B (Health & Care Professional Registration), the NMC speaking-band-7 wedge, the IRA channel.** Validated by an IELTS probe whose three success criteria are pre-defined. Sequence ahead of a CPD parallel-track (Sector G) and a Publisher-OEM lateral (Sector A).
+
+---
+
+## Why this matters now
+
+| | |
+|---|---|
+| **Resource discipline** | With limited team capacity we cannot run more than one Phase-1 GTM seriously. A confirmed wedge ends re-debating. |
+| **Investor readability** | Capital is moving from "AI tool" to "AI services" (Sequoia / Benchmark / a16z / YC consensus). Our TAM must be cited in *labour spend*, not software seats. |
+| **The probe is mid-flight** | Without explicit success criteria, the IELTS probe produces interesting anecdotes, not a Go/No-Go signal. |
+
+## The framework we are adopting
+
+Five-level nomenclature, used identically across all HFF documents:
+
+```
+SECTOR → WEDGE → CHANNEL → ACCOUNT → COHORT
+```
+
+Sizing maps cleanly: **TAM = Sector | SAM = Channel | SOM = Account.** Detail in *D7 — Nomenclature Standard*.
+
+## The commitment, in one sentence
+
+> *In **Sector B** (Health & Care Pro Registration), we are running the **NMC speaking-band-7 wedge** through the **IRA channel**. Phase-1 accounts are **5 named IRAs**. Pilot cohort is **50 nurses, 8 weeks**.*
+
+## Why this specific commitment
+
+| Question | Answer |
+|---|---|
+| **What sector?** | B. UK TAM **£180–290M** [E]. Recurring through OSCE / CBT / HCPC / GMC / social-care / adaptation adjacencies. |
+| **What wedge?** | NMC speaking-band-7 jump. Voice-first AI is the literal product spec. No incumbent voice-AI competitor. |
+| **Which channel?** | IRA (B2B2C employer-paid). 5 firms control ~50% of overseas-nurse flow. Sales cycle 3–6 months. |
+| **Why now?** | The IELTS probe directly validates this wedge — no leap of faith. UK contract, global delivery. |
+
+## TAM picture
+
+```
+WW IELTS prep TAM                                ~£2–3B    [V]
+└─ UK-contracted slice                          ~£300–500M [V]
+   └─ Healthcare-Employer Channel               £50–110M   [E]   ◆ HFF Phase-1
+      └─ Sector B full horizon (+adjacencies)   £180–290M  [E]
+         └─ 3-yr SOM target                     £8–20M ARR
+
+Phase-1 named accounts:
+  Yourworld  ·  HCL  ·  Sanctuary  ·  Greenstaff  ·  Globe Locums
+```
+
+## What we are NOT doing in Phase 1
+
+- D2C IELTS prep — CAC trap
+- K-12 mainstream — wrong fit; saturated
+- Corporate L&D compliance — too broad, too slow
+- Test-owner partnerships — 24-month cycle
+
+## What we are doing in parallel
+
+- **CPD probe (Sector G)** — 1 Safety/IOSH provider; low-cost test
+- **U-RES research partnership** — UCL IOE or Cambridge Education Faculty; credibility, no revenue
+
+## The IELTS Probe — Go/No-Go criteria
+
+| Hypothesis | Pass threshold |
+|---|---|
+| **Score-lift** | ≥10 percentage-point lift in speaking-7.0 pass rate vs IRA's trailing-6mo baseline |
+| **Channel** | IRA converts from interest → paid pilot in <60 days |
+| **Engagement** | ≥80% candidate session completion in 4 weeks |
+
+All 3 pass = Sector B locked. 2 of 3 = extend probe. <2 = re-evaluate sector.
+
+## Decisions asked of the board
+
+1. Confirm **Sector B / NMC band-7 wedge / IRA channel** as Phase-1 commitment.
+2. Confirm **Sector G (CPD)** parallel low-cost track via 1 Safety / NEBOSH Learning Partner test.
+3. Approve **~1 week of primary research** to convert 5 critical ESTIMATEs to VERIFIED before investor share.
+4. Approve **doc set D1–D7** as the strategy-and-evidence backbone.
+
+---
+
+*Confidence flags: **[V]** = Verified from a named public source; **[E]** = Estimate; **[T]** = TBD. Full citations in D4.*

--- a/docs/strategy/D2-priority-tam.md
+++ b/docs/strategy/D2-priority-tam.md
@@ -1,0 +1,286 @@
+---
+title: "D2 — Priority TAM Overview"
+subtitle: "Sector B (Health & Care Pro Registration) + IELTS Wedge"
+author: "Paul Wander"
+date: "4 June 2026"
+version: "0.1"
+---
+
+<style>
+  body { font-family: 'Helvetica Neue', Arial, sans-serif; color: #1a1a1a; line-height: 1.55; font-size: 11pt; }
+  h1 { color: #0f172a; border-bottom: 3px solid #2563eb; padding-bottom: 8px; font-size: 22pt; margin-top: 0; }
+  h2 { color: #1e3a5f; border-bottom: 1px solid #e2e8f0; padding-bottom: 4px; margin-top: 24px; font-size: 14pt; }
+  h3 { color: #334155; margin-top: 18px; font-size: 12pt; }
+  h4 { color: #475569; margin-top: 14px; font-size: 11pt; }
+  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 10pt; }
+  th, td { border: 1px solid #e2e8f0; padding: 6px 10px; text-align: left; vertical-align: top; }
+  th { background: #f1f5f9; color: #0f172a; font-weight: 600; }
+  code, pre { font-family: 'Menlo', monospace; font-size: 9.5pt; background: #f8fafc; }
+  pre { padding: 10px; border-left: 3px solid #2563eb; overflow-x: auto; }
+  blockquote { border-left: 3px solid #2563eb; padding-left: 12px; color: #334155; margin: 12px 0; }
+  .meta { font-size: 9.5pt; color: #64748b; margin-top: -8px; }
+</style>
+
+::: meta
+**Status:** Internal — Co-founders + Leadership; investor variant derivable  &nbsp;|&nbsp; **Owner:** Paul Wander  &nbsp;|&nbsp; **Reads with:** D1 (briefing), D6 (TAM picture), D4 (citations), D5 (entity lists)
+:::
+
+## 1. Thesis
+
+HFF commits its first 12 months to **Sector B (Health & Care Professional Registration)**, entering through the **NMC speaking-band-7 wedge** via the **IRA channel**.
+
+The UK addressable spend for English + adjacent registration prep is **£180–290M**. Phase-1 SAM through IRAs is **£40–80M** digitally substitutable. The 3-year SOM target is **£8–20M ARR**.
+
+The IELTS market test is the **probe** — designed to validate this commitment, not to discover a market.
+
+## 2. Framework
+
+Five-level nomenclature used across every HFF strategy document:
+
+| Level | Definition | Phase-1 example |
+|---|---|---|
+| Sector | Macro vertical of learning | Health & Care Professional Registration |
+| Wedge | Specific learning job we ship first | NMC speaking-band-7 jump |
+| Channel | Buyer type / route to learner | IRA (B2B2C employer-paid) |
+| Account | Named firm we contract with | Yourworld Healthcare |
+| Cohort | Specific learner group | 50 nurses, India intake, 8-week pilot |
+
+**TAM = Sector. SAM = Channel. SOM = Account.**
+
+## 3. The 7-sector portfolio
+
+| Sector | UK TAM | WW TAM | Conf | Priority |
+|---|---|---|---|---|
+| A. Adult Language Cert (IELTS / OET / TOEFL / PTE / Duolingo) | £300–500M (UK-contracted) | £2–3B | V/E | **P0 (probe)** |
+| **B. Health & Care Pro Registration** | **£180–290M** | – | E (V on inputs) | **P1 (commit)** |
+| C. University-bound Journey (pathway, pre-sessional) | £400–600M | $30–50B HE int'l student spend | V | P2 |
+| D. Regulated Pro Exams one-shot (PLAB / SQE / MRCP / ACCA / NEBOSH) | ~£500M (portfolio) | $5–8B | E | P3 |
+| E. Corporate Compliance Training | £2–4B | $30–40B | V | P4 |
+| F. K-12 Mainstream | £1.5B | $20B+ | V | P5 |
+| **G. CPD Meta-sector** | **£1.5–7.6B** | – | E | **P1 parallel** |
+
+## 4. Sector B — deep-dive
+
+### 4.1 What's in this sector
+
+The English-language gate + clinical-knowledge + clinical-exam + first-year-adaptation pipeline that every internationally-trained health professional must clear to register and remain in UK practice. Spans 9 UK statutory regulators.
+
+### 4.2 Sub-sectors
+
+| Regulator | Profession | UK registrants | Int'l joiners / yr | Source |
+|---|---|---|---|---|
+| NMC | Nurses, midwives, nursing associates | 826k [V] | 22–26k [V] | NMC Annual Register Report, Mar 2025 |
+| GMC | Doctors | 334k [V] | 14–16k (PLAB ~3k) [V] | GMC SoMEP 2024 |
+| HCPC | 15 AHPs | 340k [V] | 5–7k [V] | HCPC Annual Stats 2024 |
+| GPhC | Pharmacists | 70k [V] | 1–2k [V] | GPhC Annual Report 2024 |
+| GDC | Dentists | 120k [V] | 1–2k [V] | GDC Annual Report 2024 |
+| SWE | Social workers | 100k [V] | 2–4k [V] | SWE Annual Report 2024 |
+| GOC / GOsC / GCC | Smaller bodies | ~40k [V] | <1k [V] | Body annual reports |
+| **Total** | | **~1.83M** | **~50–60k** | – |
+
+### 4.3 Buyer types (channels) inside Sector B
+
+| Channel | Description | Phase position | Phase-1 share of spend |
+|---|---|---|---|
+| **IRA (B2B2C employer-paid)** | Outsourced agency placing nurses into Trusts | **P1 commit** | ~50% [E] |
+| NHS Trust direct | Trust-direct international recruitment | P2 | ~25% [E] |
+| NHS England Central | Bulk multi-Trust framework | P3 | ~15% [E] |
+| Candidate self-pay | Out-of-pocket prep | Deprioritise | ~10% [E] |
+
+### 4.4 TAM build-up (WW + UK)
+
+| Slice | UK | WW (where comparable) | Method | Conf |
+|---|---|---|---|---|
+| English prep — NMC nurses | £50–110M | – | 45k × £1,200 (base) → 50k × £2,200 (upper) | E |
+| OSCE clinical prep | £40–60M | – | 25k × £1.5–2.5k | E |
+| CBT knowledge prep | £10–20M | – | 25k × £400–800 | E |
+| HCPC AHP English | £6M | – | 5k × £1,200 | E |
+| GMC PLAB cohort | £6M | – | 3k × £2,000 | E |
+| Social care worker English | £18M | – | 30k × £600 | E |
+| First-year adaptation / preceptorship | £50–75M | – | 25k × £2–3k | E |
+| **Sector B total horizon** | **£180–290M** | – | Bottom-up | E (V on inputs) |
+| NHS overseas-nurse total recruitment spend (cross-check) | ~£200M / yr | – | NAO Report 2023 | V |
+| Cost per overseas nurse placement (cross-check) | £10–15k | – | NHS Confederation 2023 | V |
+
+WW figures unavailable for most rows — US/AU/CA/EU equivalents exist (CGFNS, AHPRA, etc.) but require country-by-country build. **Out of scope for Phase 1.**
+
+## 5. The IELTS wedge
+
+### 5.1 Why IELTS-as-probe
+
+IELTS is **the gating event** for the NMC English requirement (Academic 7.0; speaking + listening 7.0). HFF voice-first speaking practice is the literal product spec. There is no incumbent voice-AI competitor in the NMC/OET healthcare prep segment.
+
+### 5.2 The specific product
+
+A speaking-practice product targeting the **band-6.5 → 7.0 jump** (the most-failed sub-band for NMC candidates). Healthcare-contextualised content (medical vocabulary, ward scenarios) — bridges directly into the OET adjacency.
+
+### 5.3 Adjacencies — how Sector B grows from this wedge
+
+```
+Y1: NMC speaking English                        £50–110M
+       ↓ (same buyer, same candidate)
+Y2: OSCE clinical prep                          £40–60M
+Y2: CBT knowledge prep                          £10–20M
+       ↓
+Y3: HCPC English                                £6M
+Y3: GMC PLAB cohort                             £6M
+Y3: Social care worker English                  £18M
+Y3: First-year adaptation                       £50–75M
+```
+
+Same IRA / Trust buyer pays for all. Multi-year ACV story for any investor deck.
+
+### 5.4 ARPU & gross margin
+
+| Metric | Phase 1 |
+|---|---|
+| Pilot price | £15k for 50 candidates × 8 weeks |
+| Annual contract per IRA | £200–£300k (3–500 candidates) |
+| Blended ARPU per candidate | £600–£900 |
+| Gross margin | High (autonomous voice delivery; AI cost <£40/learner) |
+| CAC payback | <6 months (employer-paid, sponsored sale) |
+
+## 6. The IRA channel
+
+### 6.1 Why IRAs first
+
+| Reason | Detail |
+|---|---|
+| Buyer concentration | Top 5 firms control ~50% of overseas-nurse flow [E — needs FOI verification] |
+| Aligned incentive | IRA loses ~£12k per failed candidate [V via NHS Confed unit costs] |
+| Fast cycle | 3–6 months from first meeting to paid pilot |
+| No incumbent | No voice-AI competitor selling into IRAs today |
+
+### 6.2 Named Phase-1 accounts
+
+| # | Account | Why first | Source |
+|---|---|---|---|
+| 1 | Yourworld Healthcare | Largest UK IRA by nurse placement volume | NHS Employers Ethical Recruiters List [V] |
+| 2 | HCL Workforce Solutions | Bundles English + OSCE already; tech-curious | NHS Employers List [V] |
+| 3 | Sanctuary Personnel | Wide AHP + social-work flow — adjacency proof | NHS Employers List [V] |
+| 4 | Greenstaff Medical | Heavy India / Phil pipeline | NHS Employers List [V] |
+| 5 | Globe Locums | AHP-heavy (HCPC adjacency proof) | NHS Employers List [V] |
+| Tier-2 (after first 2 case studies) | BWA Medical, Pulse / BNF, Mediplacements | Mid-tier; faster decisions | NHS Employers List [V] |
+
+Total candidate firms: **~330 agencies** on NHS Employers Ethical Recruiters Code-of-Practice list [V].
+
+### 6.3 Conversion economics
+
+| Stage | Conversion target | Per IRA |
+|---|---|---|
+| Outbound → response | 15% (cold); 50% (warm intro) | – |
+| Response → discovery call | 80% | – |
+| Discovery → pilot scoping | 50% | – |
+| Pilot scoping → signed | 60% | – |
+| Pilot → paid annual | 60% (gated on success criteria) | – |
+| Cumulative top-8 outreach | ~15% of cold; warm-intro lifts to 3–5 pilots | – |
+| **Phase-1 ARR target** | **£500k–£1.2M** | from 3–5 IRAs |
+
+### 6.4 Adjacent channels (later phases)
+
+- **NHS Trust direct** (P2): 217 Trusts; lead with Barts, Imperial, Manchester FT
+- **NHS England Central framework** (P3): 1 sale, multi-Trust, 12–24 mo cycle
+
+## 7. The IELTS Probe
+
+### 7.1 Three hypotheses
+
+| Hypothesis | Pass threshold | Disconfirming evidence |
+|---|---|---|
+| **Score-lift** | ≥10 pp improvement in speaking-band-7 pass rate vs IRA's trailing-6mo baseline | <5 pp lift, or no engagement signal |
+| **Channel** | IRA converts from "interesting" to "paid pilot" in <60 days | >90 days; IRAs request unbounded due diligence |
+| **Engagement** | ≥80% candidate session completion in 4 weeks | <60% completion; high drop-off in week 1 |
+
+### 7.2 Pilot agreement (standard structure)
+
+| Term | Value |
+|---|---|
+| Cohort | 50 candidates, NMC track, speaking-band 6.0–6.5 |
+| Duration | 8 weeks |
+| Price | £15,000 flat (covers all access; no per-candidate uplift) |
+| Baseline | IRA supplies anonymised attempt-1 IELTS data, trailing 6 months |
+| Conversion trigger | All 3 hypotheses pass → annual contract at £600–£900 per candidate |
+| Fallback | 2/3 pass → 8-week extension at HFF cost. <2/3 → walk-away; HFF retains data rights |
+
+### 7.3 Decision gates after the probe
+
+| Outcome | Action |
+|---|---|
+| 3/3 pass | Lock Phase 1 — scale IRA outreach + open Trust direct (P2) |
+| Score-lift passes, channel fails | Pivot to Sector A (publisher OEM) |
+| Score-lift fails | Re-evaluate engine; freeze Sector B |
+| Engagement fails but lift passes | Add cohort / human nudge layer; re-test |
+
+## 8. Phase 1 plan (12 months, summarised)
+
+| Phase | Months | Activity | Target outcome |
+|---|---|---|---|
+| Build kit | 1 | 1-pager, ROI calculator, demo recording, MOU | All artefacts shipped |
+| Outbound — Tier 1 | 1–3 | 8 named IRAs; warm intros + cold sequence | 5 discovery calls |
+| Discovery + demos | 3–5 | Qualify, demo, scope | 3 pilots scoped |
+| Pilots running | 5–7 | 3–5 live pilots, 50 candidates each | Probe data |
+| Probe review | 7 | Read-out against 3 hypotheses | Go / No-Go |
+| Convert to paid | 7–10 | Annual contracts on success | 2–3 paid |
+| Tier-2 outbound | 10–12 | 15 mid-tier IRAs | 2 more pilots in flight |
+| **Phase-1 ARR booked** | **12** | | **£500k–£1.2M** |
+
+## 9. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| IRA builds it internally | Embed in candidate workflow before they mobilise; OSCE roadmap as lock-in |
+| Probe doesn't produce score lift fast enough | Pick band-6.5-stuck cohort (highest leverage); 4-week interim checkpoint |
+| Procurement delay | Anchor first deals at mid-tier IRAs for speed; use as proof for the larger firms |
+| NMC changes English requirement mid-pilot | Build OET parity in week 1; not IELTS-only |
+| Pass-rate baseline disputed | Require IRA to provide trailing-6mo attempt data *before* pilot signs |
+| Cohort fails 3rd hypothesis (engagement) | Layer human-coach nudge; re-test |
+| Tighter UK immigration cap shrinks pipeline | Adjacency expansion (OSCE / adaptation) reduces single-cohort dependence |
+
+## 10. What this commitment unlocks
+
+| Unlock | Trigger |
+|---|---|
+| Sector B adjacency expansion (OSCE / CBT / HCPC / GMC / social care / adaptation) | First IRA contract signs |
+| Sector A (Publisher OEM) credibility — Cambridge UP&A / Macmillan | First 2 IRA case studies published |
+| Investor narrative: "labour, not software" TAM | Score-lift data on healthcare cohort |
+| Sector C (Pathway provider) lateral — INTO / Kaplan / Study Group | Sector A win |
+| Sector G (CPD) parallel — Safety / NEBOSH wedge | Independent of Sector B; runs concurrently |
+
+## 11. Top citations (rolled up from D4)
+
+| Figure | Source | As-of | Conf |
+|---|---|---|---|
+| WW IELTS annual sittings ~3.5M | IELTS Partners "Test Taker Performance Report" (ielts.org) | 2022/23 | V |
+| WW IELTS prep market £2–3B | Grand View Research 2024 (in HFF Drive PDF) | 2024 | V |
+| NMC register 826k | NMC Annual Register Report (nmc.org.uk) | Mar 2025 | V |
+| NMC international joiners 22–26k / yr | NMC Annual Report 2023/24 + Quarterly Reports | 2023–25 | V |
+| GMC register 334k | GMC State of Medical Education and Practice (gmc-uk.org) | 2024 | V |
+| HCPC register 340k | HCPC Annual Report (hcpc-uk.org) | 2024 | V |
+| NHS overseas-nurse recruitment ~£200M / yr | NAO Report "Recovering the cost of recruitment" (nao.org.uk) | 2023 | V |
+| Cost per overseas nurse placement £10–15k | NHS Confederation (nhsconfed.org) | 2023 | V |
+| OSCE candidates ~25k / yr; 4 test centres | NMC OSCE statistics + nmc.org.uk | 2024–25 | V |
+| IRAs on Ethical Recruiters Code-of-Practice list ~330 | NHS Employers (nhsemployers.org) | 2024 quarterly | V |
+| WHO Red List source-country count 55 | WHO Health Workforce Support and Safeguards List (who.int) | 2023 | V |
+| First-attempt healthcare-IELTS pass rate ~30–40% | IELTS Partners + OET disaggregated band distribution | 2022/23 | **E — verify** |
+| Per-candidate English-prep spend £1,000–£2,500 | Bottom-up: courses + 1:1 tuition + retakes | 2025 | **E — verify** |
+| IRA market share Top-5 ~50% | Industry consensus | 2024 | **E — verify via FOI** |
+
+**Verification window (1 week of research, before any investor share):** pass rate · per-candidate spend · IRA market share · OSCE TAM · NHS overseas-nurse net spend.
+
+---
+
+## Appendix A — Doc index
+
+| Code | Title | Length | Status |
+|---|---|---|---|
+| D1 | Briefing Note | 2pp | **Shipped V0.1** |
+| **D2** | **Priority TAM Overview (this doc)** | 7pp | **Shipped V0.1** |
+| D3 | Full TAM & GTM Analysis | 25–35pp | Drafting (paused) |
+| D4 | Citation Sheet | live | V0 schema ready (paused) |
+| D5 | Entity Lists | live | V0 schema ready (paused) |
+| D6 | TAM Picture | 1pp | Shipped (in-doc; render to slide pending) |
+| D7 | Nomenclature Standard | 1pp | Shipped (in-doc; wiki page pending) |
+
+---
+
+*Confidence flags: **[V]** = Verified from a named public source; **[E]** = Estimate; **[T]** = TBD. Full citations in D4.*


### PR DESCRIPTION
## Summary
- D1 — 2pp briefing note (SCQA-led) for board + co-founders
- D2 — ~7pp priority TAM overview: Sector B (Health & Care Pro Registration), NMC speaking-band-7 wedge, IRA channel
- `CONTINUE-HERE.md` capturing what's paused (D3–D7), verification shortlist, resume instructions

Both follow the locked 5-level nomenclature (Sector / Wedge / Channel / Account / Cohort) and V/E/T confidence flagging.

## Test plan
- [x] Markdown renders cleanly
- [x] PDF export via `pandoc --pdf-engine=weasyprint` confirmed locally
- [x] No code, schema, or test impact (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)