### PR TITLE
chore(tallyseal-bridge): add TALLYSEAL_BRIDGE_DEV_SECRET to .env.example

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -289,3 +289,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 #   - Verify HF_KB_PATH points to a valid, writable directory
 #
 # =============================================================================
+
+# Phase 1 admin-bridge dev-mode auth — bearer secret for
+# bridgeAuthFromStaticKey at /api/tallyseal-bridge/*.
+# Generate with: openssl rand -hex 16
+# Phase 2 retires this when bridgeAuthFromOidc lands.
+TALLYSEAL_BRIDGE_DEV_SECRET=


### PR DESCRIPTION
## Summary

Adds the `TALLYSEAL_BRIDGE_DEV_SECRET` env var to `apps/admin/.env.example`. Noted as a follow-up TODO in PR #1030 — local Claude path perms blocked the original edit; landing as a separate one-line commit.

Phase 1 admin-bridge dev-mode auth env var. Phase 2 retires when `bridgeAuthFromOidc` lands (depends on tallyseal-side OIDC IdP wiring).

## Test plan
- [x] `.env.example` parses (no syntax)
- [x] Comment block explains generation (`openssl rand -hex 16`) + Phase 2 sunset

Follow-up to #1030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)