### PR TITLE
docs(strategy): D8 sales GTM plan + D1/D2 V0.2 (pagination, essay-style SCQA, glossary)

### DIFF
--- a/docs/strategy/CONTINUE-HERE.md
+++ b/docs/strategy/CONTINUE-HERE.md
@@ -1,8 +1,8 @@
 # Continue Here — TAM & GTM Doc Set
 
 **Last touched:** 2026-06-04 by Paul + Claude
-**Branch:** `chore/tam-docs-d1-d2`
-**Status:** D1 + D2 shipped (V0.1). D3–D5 paused for review.
+**Branch:** `chore/tam-docs-d8-pagination`
+**Status:** D1 + D2 re-drafted to V0.2 (essay-style SCQA in D1, pagination, glossary). D8 shipped V0.1. D3 / D4 / D5 still paused.
 
 ---
 
@@ -10,10 +10,19 @@
 
 | Code | Doc | Files | Status |
 |---|---|---|---|
-| D1 | Briefing Note | `D1-briefing-note.md` + `.pdf` | **Shipped V0.1** |
-| D2 | Priority TAM Overview (Sector B + IELTS wedge) | `D2-priority-tam.md` + `.pdf` | **Shipped V0.1** |
+| D1 | Briefing Note (essay-style, paginated, glossary) | `D1-briefing-note.md` + `.pdf` | **V0.2** |
+| D2 | Priority TAM Overview (paginated, glossary) | `D2-priority-tam.md` + `.pdf` | **V0.2** |
+| D8 | Sales GTM Plan, Phase-1 Slice (Sector B / NMC band-7 / IRA) | `D8-sales-gtm-phase1.md` + `.pdf` | **V0.1** |
 
-Both follow the locked spine: 5-level nomenclature (Sector → Wedge → Channel → Account → Cohort), 4-question priority frame, TAM = Sector / SAM = Channel / SOM = Account, V/E/T confidence flags, and the 7-sector portfolio (A–G).
+All three docs follow the locked spine: 5-level nomenclature (Sector → Wedge → Channel → Account → Cohort), 4-question priority frame, TAM = Sector / SAM = Channel / SOM = Account, V/E/T confidence flags, 7-sector portfolio (A–G), and the final-page glossary.
+
+**Formatting standards now codified:**
+- A4 page, 22 mm × 20 mm margins
+- Page numbers ("Page X of Y") bottom centre
+- Doc code bottom left, "Internal — Confidential" bottom right
+- Page-break before major sections in 7pp+ docs
+- Glossary always on its own page at the end
+- Every acronym used in the doc appears in its glossary
 
 ## What's locked (the spine — do not re-debate)
 
@@ -24,23 +33,24 @@ Both follow the locked spine: 5-level nomenclature (Sector → Wedge → Channel
 5. **Sector list:** 7 sectors A–G (B and G locked as P1)
 6. **Phase-1 commitment:** Sector B / NMC speaking-band-7 wedge / IRA channel
 7. **IELTS probe success criteria:** 3 hypotheses, all must pass
-8. **SCQA (sharpened):** in D1 — do not re-edit
-9. **Doc set:** D1–D7
+8. **Doc set:** D1 (briefing) · D2 (priority TAM) · D3 (full analysis) · D4 (citations) · D5 (entity lists) · D6 (TAM picture slide) · D7 (nomenclature wiki) · D8 (sales GTM plan)
+9. **Pagination + glossary** standard applies to every published doc
 
 ## What's paused (resume in this order)
 
 ### Next: D4 — Citation Sheet (Google Sheet)
 
-**Why next:** D1/D2 currently cite figures inline. Production-ready version needs every number to link back to a single citation sheet row.
+**Why next:** D1 / D2 / D8 currently cite figures inline. Production-ready version needs every number to link back to a single citation sheet row.
 
 **V0 schema (build first):**
+
 | col | name | type | example |
 |---|---|---|---|
 | A | metric_id | text | `B.NMC.register_total` |
 | B | sector | text | `B` |
 | C | metric_name | text | NMC register total |
 | D | value_ww | text | `–` |
-| E | value_uk | text | 826k |
+| E | value_uk | text | 826 k |
 | F | unit | text | registrants |
 | G | source_name | text | NMC Annual Register Report |
 | H | source_url | url | https://www.nmc.org.uk/about-us/reports-and-accounts/registration-statistics/ |
@@ -48,41 +58,44 @@ Both follow the locked spine: 5-level nomenclature (Sector → Wedge → Channel
 | J | confidence | enum | V / E / T |
 | K | notes | text | – |
 
-**Seed rows:** all rows from the "Top citations" table in D2 §11 + the verified-citation table I produced earlier in chat. ~60 rows.
+**Seed rows:** all rows from the "Top citations" table in D2 §11 + the verified-citation table from the chat history. ~60 rows.
 
 ### Next-next: D5 — Entity Lists (Google Sheet, multi-tab)
 
 **Tabs:**
-1. `IRAs` — 330 from NHS Employers Code-of-Practice list (top 8 named + tail)
-2. `Healthcare regulators` — 9 UK statutory bodies
+
+1. `IRAs` — 330 from NHS Employers Code-of-Practice list (top 13 named from D8 §3 + tail)
+2. `Healthcare regulators` — 9 UK statutory bodies (from D2 §4.2)
 3. `Publishers` — 7 UK-HQ EFL publishers
 4. `Pathway providers` — 7–9 UK pathway operators
-5. `Test owners` — 5 (IELTS partners × 3, OET, PTE, Duolingo, TOEFL)
-6. `CPD bodies` — ~30 UK CPD-mandated bodies (per D2 §3 cluster build-up)
+5. `Test owners` — 5 (IELTS partners × 3, OET, PTE, DET, TOEFL)
+6. `CPD bodies` — ~30 UK CPD-mandated bodies
 7. `NHS Trusts (overseas-recruiting)` — top 30 by activity
 
-Columns per row: name · type · website · primary_contact_role · linkedin · status (Pipeline/Active/Lapsed) · last_touch · owner
+Columns per row: name · type · website · primary_contact_role · linkedin · status (Pipeline / Active / Lapsed) · last_touch · owner
 
-### After D4/D5: D3 — Full TAM & GTM Analysis (25–35pp)
+### After D4 / D5: D3 — Full TAM & GTM Analysis (25–35 pp)
 
 Sections to write:
-1. Executive summary (pyramid lift of D2)
-2. Methodology & nomenclature (lift D7)
-3. Each sector A–G — full deep-dive (replicate D2 §4 structure for each)
+
+1. Executive summary (pyramid-lift of D2)
+2. Methodology + nomenclature (lift D7)
+3. Each Sector A–G — full deep-dive (replicate D2 §4 structure for each)
 4. Channel taxonomy — comprehensive
-5. The CPD meta-sector — body-by-body
-6. IRA outreach plan — full version
-7. The IELTS probe design — full
+5. CPD meta-sector — body-by-body
+6. IRA outreach plan — full version (parallel to D8)
+7. IELTS probe design — full
 8. Phase 2 / 3 / 4 forward planning
 9. Risk register — full
-10. WW expansion thesis (US/EU/APAC follow-on)
+10. WW expansion thesis (US / EU / APAC follow-on)
 11. Citation appendix (links to D4)
 12. Entity appendix (links to D5)
+13. Glossary
 
 ### Other paused work (lower priority)
 
-- **D6** — render the ASCII TAM picture as a designed slide (Google Slides or PowerPoint). Content is already in D1 + D2.
-- **D7** — paste nomenclature standard into team wiki. Content is in D2 §2 + the chat conversation log.
+- **D6** — render the ASCII TAM picture as a designed slide. Content is in D1 + D2.
+- **D7** — paste nomenclature standard into team wiki. Content is in D2 §2 + chat history.
 
 ## Outstanding research (the verification week, before any investor share)
 
@@ -91,36 +104,31 @@ Five ESTIMATEs to convert to VERIFIED:
 | # | Estimate | How to verify | Effort |
 |---|---|---|---|
 | 1 | First-attempt healthcare-IELTS pass rate ~30–40% | Pull IELTS Partners disaggregated data by occupation; OET published band distribution | 2 days |
-| 2 | Per-candidate English-prep spend £1–2.5k | 5–10 IRA exec interviews | 1 week |
+| 2 | Per-candidate English-prep spend £1–2.5 k | 5–10 IRA exec interviews | 1 week |
 | 3 | IRA market share Top-5 ~50% | Companies House revenue for all 330 IRAs + FOI'd top-30 NHS Trust IRA contracts | 1 week |
-| 4 | OSCE-prep TAM £40–60M | NMC OSCE candidate × commercial OSCE-prep provider price points | 2 days |
-| 5 | NHS overseas-nurse net spend ~£200M / yr (NAO is gross) | FOI NHSE Workforce Training & Education programme accounts | 2 weeks |
+| 4 | OSCE-prep TAM £40–60 m | NMC OSCE candidate × commercial OSCE-prep provider price points | 2 days |
+| 5 | NHS overseas-nurse net spend ~£200 m / yr (NAO is gross) | FOI NHSE Workforce Training & Education programme accounts | 2 weeks |
 
-## Doc set roadmap
+## How to regenerate the PDFs
 
-| Code | Doc | Status |
-|---|---|---|
-| D1 | Briefing Note (2pp) | ✅ Shipped V0.1 |
-| D2 | Priority TAM Overview (~7pp) | ✅ Shipped V0.1 |
-| D3 | Full TAM & GTM Analysis (25–35pp) | ⏸ Paused — drafted in chat, not in file |
-| D4 | Citation Sheet (Google Sheet) | ⏸ Paused — schema ready |
-| D5 | Entity Lists (Google Sheet) | ⏸ Paused — schema ready |
-| D6 | TAM Picture (1-pager slide) | ⏸ ASCII shipped in D1/D2; render to slide pending |
-| D7 | Nomenclature Standard (wiki) | ⏸ Embedded in D2 §2; wiki paste pending |
+From the strategy directory:
+
+```bash
+cd docs/strategy
+for f in D1-briefing-note D2-priority-tam D8-sales-gtm-phase1; do
+  pandoc $f.md -o $f.pdf --pdf-engine=weasyprint --standalone
+done
+```
 
 ## How to resume
 
-When Paul wants to pick this up:
-
 ```
-git checkout chore/tam-docs-d1-d2
+git checkout chore/tam-docs-d8-pagination     # or merge to main first
 cat docs/strategy/CONTINUE-HERE.md
 ```
 
-Then prompt: *"Resume the TAM doc set. Start with D4 (citation sheet schema + populated rows from D2 citations)."*
-
-The chat history of this session has the source material for D3 and the full D4/D5 row content — anyone restarting should re-read it before drafting D3.
+Then prompt: *"Resume the TAM doc set. Start with D4 (citation sheet schema + populated rows from D2 / D8 citations)."*
 
 ## Branch hygiene
 
-This branch (`chore/tam-docs-d1-d2`) is doc-only. No code, no schema, no Prisma, no API. Safe to merge to main once D1+D2 are board-approved. After merge, open a new branch for D4/D5 work to keep concerns separated.
+This branch (`chore/tam-docs-d8-pagination`) is doc-only. No code, no schema, no Prisma, no API. Safe to merge to main once board-approved. After merge, open a new branch for D3 / D4 / D5 work to keep concerns separated.

--- a/docs/strategy/D1-briefing-note.md
+++ b/docs/strategy/D1-briefing-note.md
@@ -3,84 +3,100 @@ title: "D1 — Briefing Note"
 subtitle: "Why HFF Needs a Professional TAM and GTM"
 author: "Paul Wander"
 date: "4 June 2026"
-version: "0.1"
+version: "0.2"
 ---
 
 <style>
+  @page {
+    size: A4;
+    margin: 22mm 20mm 22mm 20mm;
+    @bottom-center {
+      content: "Page " counter(page) " of " counter(pages);
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+    @bottom-left {
+      content: "HFF Strategy — D1";
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+    @bottom-right {
+      content: "Internal — Confidential";
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+  }
   body { font-family: 'Helvetica Neue', Arial, sans-serif; color: #1a1a1a; line-height: 1.55; font-size: 11pt; }
   h1 { color: #0f172a; border-bottom: 3px solid #2563eb; padding-bottom: 8px; font-size: 22pt; margin-top: 0; }
-  h2 { color: #1e3a5f; border-bottom: 1px solid #e2e8f0; padding-bottom: 4px; margin-top: 22px; font-size: 14pt; }
-  h3 { color: #334155; margin-top: 16px; font-size: 12pt; }
-  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 10pt; }
+  h2 { color: #1e3a5f; border-bottom: 1px solid #e2e8f0; padding-bottom: 4px; margin-top: 22px; font-size: 14pt; page-break-after: avoid; }
+  h3 { color: #334155; margin-top: 16px; font-size: 12pt; page-break-after: avoid; }
+  p { margin: 8px 0; }
+  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 10pt; page-break-inside: avoid; }
   th, td { border: 1px solid #e2e8f0; padding: 6px 10px; text-align: left; vertical-align: top; }
   th { background: #f1f5f9; color: #0f172a; font-weight: 600; }
   code, pre { font-family: 'Menlo', monospace; font-size: 9.5pt; background: #f8fafc; }
-  pre { padding: 10px; border-left: 3px solid #2563eb; overflow-x: auto; }
-  blockquote { border-left: 3px solid #2563eb; padding-left: 12px; color: #334155; margin: 12px 0; }
-  .meta { font-size: 9.5pt; color: #64748b; margin-top: -8px; }
+  pre { padding: 10px; border-left: 3px solid #2563eb; page-break-inside: avoid; }
+  blockquote { border-left: 3px solid #2563eb; padding-left: 12px; color: #334155; margin: 12px 0; font-style: italic; }
+  .meta { font-size: 9.5pt; color: #64748b; margin-top: -8px; margin-bottom: 16px; }
+  .page-break { page-break-before: always; }
+  .glossary { font-size: 9.5pt; }
+  .glossary dt { font-weight: 600; color: #1e3a5f; }
+  .glossary dd { margin: 0 0 4px 16px; }
 </style>
 
 ::: meta
-**Status:** Internal — Co-founders + Board  &nbsp;|&nbsp; **Owner:** Paul Wander  &nbsp;|&nbsp; **Decision asked:** Confirm Sector B commitment + IELTS probe success criteria + doc-set backbone
+**Status:** Internal — Co-founders + Board   |   **Owner:** Paul Wander   |   **Decision asked:** confirm Sector B commitment, IELTS probe success criteria, and the doc-set backbone.
 :::
 
-## Situation
+## Context and ask
 
-Embarking on our Market Test, we are looking for signals to inform our Go-To-Market. The IELTS market test is the probe; we now need a framework for what it is meant to validate.
+HFF is embarking on its first formal Market Test. The test will produce strong signals — but signals are only useful if we have decided in advance what they are meant to validate. This briefing exists to settle that question before the test runs much further.
 
-## Complication
+The pressure to settle it comes from two directions. Internally, HFF has accumulated a proliferation of Go-To-Market hypotheses, market analyses, and partner concepts. Every meeting tends to re-debate the basics: which market, which buyer, which wedge. Without a single Total Addressable Market frame and a single piece of Go-To-Market language, we cannot brief partners or investors consistently, and the team cannot run discipline-led execution. Externally, the IELTS market test is already in motion. Without pre-agreed success criteria, it will produce interesting anecdotes rather than a clear Go or No-Go signal — and we will have wasted the most valuable evidence-generation window we have.
 
-We have a proliferation of GTM ideas, market analyses, and partner hypotheses. Without a single TAM frame, every conversation re-debates the basics. Without an evidenced GTM, we cannot brief partners or investors consistently. The IELTS probe will generate strong signals — but only if we have decided in advance what those signals are meant to confirm.
+The question this briefing answers is therefore narrow and operational: which Sector, which Wedge, and which Channel should HFF commit to first, and what evidence from the IELTS market test will confirm that choice?
 
-## Question
-
-How do we choose the sector, wedge, and channel HFF commits to first, evidenced by the IELTS market test?
-
-## Answer
-
-**Commit to Sector B (Health & Care Professional Registration), the NMC speaking-band-7 wedge, the IRA channel.** Validated by an IELTS probe whose three success criteria are pre-defined. Sequence ahead of a CPD parallel-track (Sector G) and a Publisher-OEM lateral (Sector A).
-
----
+The recommendation is to commit to **Sector B (Health & Care Professional Registration)**, entered through the **Nursing and Midwifery Council speaking-band-7 wedge**, via the **International Recruitment Agency channel**. The IELTS probe — with three pre-agreed success criteria — is the validation event. Continuing Professional Development work runs in parallel as a low-cost second probe in the Safety sub-sector. Every other Sector waits.
 
 ## Why this matters now
 
 | | |
 |---|---|
-| **Resource discipline** | With limited team capacity we cannot run more than one Phase-1 GTM seriously. A confirmed wedge ends re-debating. |
-| **Investor readability** | Capital is moving from "AI tool" to "AI services" (Sequoia / Benchmark / a16z / YC consensus). Our TAM must be cited in *labour spend*, not software seats. |
-| **The probe is mid-flight** | Without explicit success criteria, the IELTS probe produces interesting anecdotes, not a Go/No-Go signal. |
+| **Resource discipline** | With limited team capacity we cannot run more than one Phase-1 GTM seriously. A confirmed Wedge ends re-debating. |
+| **Investor readability** | Capital is moving from "AI tool" to "AI services" (Sequoia, Benchmark, Andreessen Horowitz, Y Combinator consensus). Our TAM must be cited in *labour spend*, not software seats. |
+| **The probe is mid-flight** | Without explicit success criteria, the IELTS probe produces interesting anecdotes, not a Go or No-Go signal. |
 
 ## The framework we are adopting
 
-Five-level nomenclature, used identically across all HFF documents:
+All HFF strategy documents will use a single five-level model:
 
 ```
-SECTOR → WEDGE → CHANNEL → ACCOUNT → COHORT
+SECTOR  →  WEDGE  →  CHANNEL  →  ACCOUNT  →  COHORT
 ```
 
-Sizing maps cleanly: **TAM = Sector | SAM = Channel | SOM = Account.** Detail in *D7 — Nomenclature Standard*.
+Sizing maps cleanly: **TAM = Sector | SAM = Channel | SOM = Account.** The full nomenclature standard is in *D7*.
 
 ## The commitment, in one sentence
 
-> *In **Sector B** (Health & Care Pro Registration), we are running the **NMC speaking-band-7 wedge** through the **IRA channel**. Phase-1 accounts are **5 named IRAs**. Pilot cohort is **50 nurses, 8 weeks**.*
+> *In **Sector B** (Health & Care Pro Registration), we are running the **NMC speaking-band-7 Wedge** through the **IRA Channel**. Phase-1 Accounts are **5 named IRAs**. Pilot Cohort is **50 nurses, 8 weeks**.*
 
 ## Why this specific commitment
 
 | Question | Answer |
 |---|---|
-| **What sector?** | B. UK TAM **£180–290M** [E]. Recurring through OSCE / CBT / HCPC / GMC / social-care / adaptation adjacencies. |
-| **What wedge?** | NMC speaking-band-7 jump. Voice-first AI is the literal product spec. No incumbent voice-AI competitor. |
-| **Which channel?** | IRA (B2B2C employer-paid). 5 firms control ~50% of overseas-nurse flow. Sales cycle 3–6 months. |
-| **Why now?** | The IELTS probe directly validates this wedge — no leap of faith. UK contract, global delivery. |
+| **What Sector?** | B. UK TAM **£180–290 m** [E]. Recurring through OSCE / CBT / HCPC / GMC / social-care / adaptation adjacencies. |
+| **What Wedge?** | NMC speaking-band-7 jump. Voice-first AI is the literal product spec. No incumbent voice-AI competitor. |
+| **Which Channel?** | IRA (B2B2C employer-paid). 5 firms control ~50% of overseas-nurse flow. Sales cycle 3–6 months. |
+| **Why now?** | The IELTS probe directly validates this Wedge — no leap of faith. UK contract, global delivery. |
 
 ## TAM picture
 
 ```
-WW IELTS prep TAM                                ~£2–3B    [V]
-└─ UK-contracted slice                          ~£300–500M [V]
-   └─ Healthcare-Employer Channel               £50–110M   [E]   ◆ HFF Phase-1
-      └─ Sector B full horizon (+adjacencies)   £180–290M  [E]
-         └─ 3-yr SOM target                     £8–20M ARR
+WW IELTS prep TAM                                ~£2–3 bn    [V]
+└─ UK-contracted slice                           ~£300–500 m [V]
+   └─ Healthcare-Employer Channel                £50–110 m   [E]   ◆ HFF Phase-1
+      └─ Sector B full horizon (+adjacencies)    £180–290 m  [E]
+         └─ 3-yr SOM target                      £8–20 m ARR
 
 Phase-1 named accounts:
   Yourworld  ·  HCL  ·  Sanctuary  ·  Greenstaff  ·  Globe Locums
@@ -88,33 +104,71 @@ Phase-1 named accounts:
 
 ## What we are NOT doing in Phase 1
 
-- D2C IELTS prep — CAC trap
+- Direct-to-Candidate IELTS prep — Customer Acquisition Cost trap
 - K-12 mainstream — wrong fit; saturated
 - Corporate L&D compliance — too broad, too slow
 - Test-owner partnerships — 24-month cycle
 
 ## What we are doing in parallel
 
-- **CPD probe (Sector G)** — 1 Safety/IOSH provider; low-cost test
+- **CPD probe (Sector G)** — one Safety / IOSH provider; low-cost test
 - **U-RES research partnership** — UCL IOE or Cambridge Education Faculty; credibility, no revenue
 
-## The IELTS Probe — Go/No-Go criteria
+## The IELTS Probe — Go / No-Go criteria
 
 | Hypothesis | Pass threshold |
 |---|---|
-| **Score-lift** | ≥10 percentage-point lift in speaking-7.0 pass rate vs IRA's trailing-6mo baseline |
-| **Channel** | IRA converts from interest → paid pilot in <60 days |
-| **Engagement** | ≥80% candidate session completion in 4 weeks |
+| **Score-lift** | ≥10 percentage-point lift in speaking-7.0 pass rate vs IRA's trailing-6-month baseline |
+| **Channel** | IRA converts from interest to paid pilot in under 60 days |
+| **Engagement** | ≥80% candidate session-completion in 4 weeks |
 
-All 3 pass = Sector B locked. 2 of 3 = extend probe. <2 = re-evaluate sector.
+All three pass = Sector B locked. Two of three = extend probe. Fewer than two = re-evaluate Sector.
 
 ## Decisions asked of the board
 
-1. Confirm **Sector B / NMC band-7 wedge / IRA channel** as Phase-1 commitment.
-2. Confirm **Sector G (CPD)** parallel low-cost track via 1 Safety / NEBOSH Learning Partner test.
-3. Approve **~1 week of primary research** to convert 5 critical ESTIMATEs to VERIFIED before investor share.
-4. Approve **doc set D1–D7** as the strategy-and-evidence backbone.
-
----
+1. Confirm **Sector B / NMC band-7 Wedge / IRA Channel** as Phase-1 commitment.
+2. Confirm **Sector G (CPD)** parallel low-cost track via one Safety / NEBOSH Learning Partner test.
+3. Approve **~1 week of primary research** to convert five critical ESTIMATEs to VERIFIED before investor share.
+4. Approve **doc set D1–D8** as the strategy-and-evidence backbone.
 
 *Confidence flags: **[V]** = Verified from a named public source; **[E]** = Estimate; **[T]** = TBD. Full citations in D4.*
+
+<div class="page-break"></div>
+
+## Glossary
+
+<dl class="glossary">
+<dt>ACV</dt><dd>Annual Contract Value</dd>
+<dt>AHP</dt><dd>Allied Health Professional</dd>
+<dt>APAC</dt><dd>Asia-Pacific region</dd>
+<dt>ARPU</dt><dd>Average Revenue Per User</dd>
+<dt>ARR</dt><dd>Annual Recurring Revenue</dd>
+<dt>B2B / B2B2C / B2C / B2G</dt><dd>Business-to-Business / Business-to-Business-to-Consumer / Business-to-Consumer / Business-to-Government</dd>
+<dt>CAC</dt><dd>Customer Acquisition Cost</dd>
+<dt>CBT</dt><dd>Computer-Based Test (NMC knowledge test taken before OSCE)</dd>
+<dt>CPD</dt><dd>Continuing Professional Development</dd>
+<dt>D1 – D8</dt><dd>HFF strategy document codes (see <em>D2 Appendix A</em>)</dd>
+<dt>GMC</dt><dd>General Medical Council (UK doctor regulator)</dd>
+<dt>GTM</dt><dd>Go-To-Market</dd>
+<dt>HCPC</dt><dd>Health and Care Professions Council (UK regulator for 15 allied health professions)</dd>
+<dt>HFF</dt><dd>Human First Foundation</dd>
+<dt>IELTS</dt><dd>International English Language Testing System</dd>
+<dt>IOE</dt><dd>Institute of Education (UCL)</dd>
+<dt>IOSH</dt><dd>Institution of Occupational Safety and Health</dd>
+<dt>IRA</dt><dd>International Recruitment Agency (private firm placing overseas health workers into UK employers)</dd>
+<dt>L&amp;D</dt><dd>Learning and Development</dd>
+<dt>NEBOSH</dt><dd>National Examination Board in Occupational Safety and Health</dd>
+<dt>NMC</dt><dd>Nursing and Midwifery Council (UK regulator for nurses and midwives)</dd>
+<dt>OET</dt><dd>Occupational English Test (healthcare-contextualised English assessment)</dd>
+<dt>OSCE</dt><dd>Objective Structured Clinical Examination (NMC clinical exam taken in UK after registration)</dd>
+<dt>P0 – P5</dt><dd>HFF Priority codes (P0 = active probe; P1 = commit; P5 = deprioritise)</dd>
+<dt>SAM</dt><dd>Serviceable Addressable Market</dd>
+<dt>Sector A – G</dt><dd>HFF Sector codes (A = Adult Language Cert; B = Health &amp; Care Pro Registration; C = University-Bound Journey; D = Regulated Pro Exams one-shot; E = Corporate Compliance Training; F = K-12 Mainstream; G = CPD Meta-sector)</dd>
+<dt>SOM</dt><dd>Serviceable Obtainable Market</dd>
+<dt>TAM</dt><dd>Total Addressable Market</dd>
+<dt>UCL</dt><dd>University College London</dd>
+<dt>UK</dt><dd>United Kingdom</dd>
+<dt>U-RES</dt><dd>University Research / Innovation arm (one of six university buyer sub-types in HFF nomenclature)</dd>
+<dt>V / E / T</dt><dd>Confidence flags — Verified / Estimate / TBD</dd>
+<dt>WW</dt><dd>Worldwide</dd>
+</dl>

--- a/docs/strategy/D2-priority-tam.md
+++ b/docs/strategy/D2-priority-tam.md
@@ -3,33 +3,59 @@ title: "D2 — Priority TAM Overview"
 subtitle: "Sector B (Health & Care Pro Registration) + IELTS Wedge"
 author: "Paul Wander"
 date: "4 June 2026"
-version: "0.1"
+version: "0.2"
 ---
 
 <style>
+  @page {
+    size: A4;
+    margin: 22mm 20mm 22mm 20mm;
+    @bottom-center {
+      content: "Page " counter(page) " of " counter(pages);
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+    @bottom-left {
+      content: "HFF Strategy — D2";
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+    @bottom-right {
+      content: "Internal — Confidential";
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+  }
   body { font-family: 'Helvetica Neue', Arial, sans-serif; color: #1a1a1a; line-height: 1.55; font-size: 11pt; }
   h1 { color: #0f172a; border-bottom: 3px solid #2563eb; padding-bottom: 8px; font-size: 22pt; margin-top: 0; }
-  h2 { color: #1e3a5f; border-bottom: 1px solid #e2e8f0; padding-bottom: 4px; margin-top: 24px; font-size: 14pt; }
-  h3 { color: #334155; margin-top: 18px; font-size: 12pt; }
-  h4 { color: #475569; margin-top: 14px; font-size: 11pt; }
-  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 10pt; }
+  h2 { color: #1e3a5f; border-bottom: 1px solid #e2e8f0; padding-bottom: 4px; margin-top: 24px; font-size: 14pt; page-break-after: avoid; }
+  h3 { color: #334155; margin-top: 18px; font-size: 12pt; page-break-after: avoid; }
+  h4 { color: #475569; margin-top: 14px; font-size: 11pt; page-break-after: avoid; }
+  p { margin: 8px 0; }
+  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 10pt; page-break-inside: avoid; }
   th, td { border: 1px solid #e2e8f0; padding: 6px 10px; text-align: left; vertical-align: top; }
   th { background: #f1f5f9; color: #0f172a; font-weight: 600; }
   code, pre { font-family: 'Menlo', monospace; font-size: 9.5pt; background: #f8fafc; }
-  pre { padding: 10px; border-left: 3px solid #2563eb; overflow-x: auto; }
+  pre { padding: 10px; border-left: 3px solid #2563eb; page-break-inside: avoid; }
   blockquote { border-left: 3px solid #2563eb; padding-left: 12px; color: #334155; margin: 12px 0; }
-  .meta { font-size: 9.5pt; color: #64748b; margin-top: -8px; }
+  .meta { font-size: 9.5pt; color: #64748b; margin-top: -8px; margin-bottom: 16px; }
+  .page-break { page-break-before: always; }
+  .glossary { font-size: 9.5pt; }
+  .glossary dt { font-weight: 600; color: #1e3a5f; }
+  .glossary dd { margin: 0 0 4px 16px; }
+  /* Major section page-break for longer doc */
+  h2.section-break { page-break-before: always; }
 </style>
 
 ::: meta
-**Status:** Internal — Co-founders + Leadership; investor variant derivable  &nbsp;|&nbsp; **Owner:** Paul Wander  &nbsp;|&nbsp; **Reads with:** D1 (briefing), D6 (TAM picture), D4 (citations), D5 (entity lists)
+**Status:** Internal — Co-founders + Leadership; investor variant derivable   |   **Owner:** Paul Wander   |   **Reads with:** D1 (briefing), D6 (TAM picture), D4 (citations), D5 (entity lists), D8 (sales GTM plan).
 :::
 
 ## 1. Thesis
 
-HFF commits its first 12 months to **Sector B (Health & Care Professional Registration)**, entering through the **NMC speaking-band-7 wedge** via the **IRA channel**.
+HFF commits its first 12 months to **Sector B (Health & Care Professional Registration)**, entering through the **NMC speaking-band-7 Wedge** via the **IRA Channel**.
 
-The UK addressable spend for English + adjacent registration prep is **£180–290M**. Phase-1 SAM through IRAs is **£40–80M** digitally substitutable. The 3-year SOM target is **£8–20M ARR**.
+The UK addressable spend for English + adjacent registration prep is **£180–290 m**. Phase-1 SAM through IRAs is **£40–80 m** digitally substitutable. The 3-year SOM target is **£8–20 m ARR**.
 
 The IELTS market test is the **probe** — designed to validate this commitment, not to discover a market.
 
@@ -47,21 +73,21 @@ Five-level nomenclature used across every HFF strategy document:
 
 **TAM = Sector. SAM = Channel. SOM = Account.**
 
-## 3. The 7-sector portfolio
+## 3. The 7-Sector portfolio
 
 | Sector | UK TAM | WW TAM | Conf | Priority |
 |---|---|---|---|---|
-| A. Adult Language Cert (IELTS / OET / TOEFL / PTE / Duolingo) | £300–500M (UK-contracted) | £2–3B | V/E | **P0 (probe)** |
-| **B. Health & Care Pro Registration** | **£180–290M** | – | E (V on inputs) | **P1 (commit)** |
-| C. University-bound Journey (pathway, pre-sessional) | £400–600M | $30–50B HE int'l student spend | V | P2 |
-| D. Regulated Pro Exams one-shot (PLAB / SQE / MRCP / ACCA / NEBOSH) | ~£500M (portfolio) | $5–8B | E | P3 |
-| E. Corporate Compliance Training | £2–4B | $30–40B | V | P4 |
-| F. K-12 Mainstream | £1.5B | $20B+ | V | P5 |
-| **G. CPD Meta-sector** | **£1.5–7.6B** | – | E | **P1 parallel** |
+| A. Adult Language Cert (IELTS / OET / TOEFL / PTE / DET) | £300–500 m (UK-contracted) | £2–3 bn | V/E | **P0 (probe)** |
+| **B. Health & Care Pro Registration** | **£180–290 m** | – | E (V on inputs) | **P1 (commit)** |
+| C. University-bound Journey (pathway, pre-sessional) | £400–600 m | $30–50 bn HE int'l student spend | V | P2 |
+| D. Regulated Pro Exams one-shot (PLAB / SQE / MRCP / ACCA / NEBOSH) | ~£500 m (portfolio) | $5–8 bn | E | P3 |
+| E. Corporate Compliance Training | £2–4 bn | $30–40 bn | V | P4 |
+| F. K-12 Mainstream | £1.5 bn | $20 bn+ | V | P5 |
+| **G. CPD Meta-sector** | **£1.5–7.6 bn** | – | E | **P1 parallel** |
 
-## 4. Sector B — deep-dive
+<h2 class="section-break">4. Sector B — deep-dive</h2>
 
-### 4.1 What's in this sector
+### 4.1 What's in this Sector
 
 The English-language gate + clinical-knowledge + clinical-exam + first-year-adaptation pipeline that every internationally-trained health professional must clear to register and remain in UK practice. Spans 9 UK statutory regulators.
 
@@ -69,16 +95,16 @@ The English-language gate + clinical-knowledge + clinical-exam + first-year-adap
 
 | Regulator | Profession | UK registrants | Int'l joiners / yr | Source |
 |---|---|---|---|---|
-| NMC | Nurses, midwives, nursing associates | 826k [V] | 22–26k [V] | NMC Annual Register Report, Mar 2025 |
-| GMC | Doctors | 334k [V] | 14–16k (PLAB ~3k) [V] | GMC SoMEP 2024 |
-| HCPC | 15 AHPs | 340k [V] | 5–7k [V] | HCPC Annual Stats 2024 |
-| GPhC | Pharmacists | 70k [V] | 1–2k [V] | GPhC Annual Report 2024 |
-| GDC | Dentists | 120k [V] | 1–2k [V] | GDC Annual Report 2024 |
-| SWE | Social workers | 100k [V] | 2–4k [V] | SWE Annual Report 2024 |
-| GOC / GOsC / GCC | Smaller bodies | ~40k [V] | <1k [V] | Body annual reports |
-| **Total** | | **~1.83M** | **~50–60k** | – |
+| NMC | Nurses, midwives, nursing associates | 826 k [V] | 22–26 k [V] | NMC Annual Register Report, Mar 2025 |
+| GMC | Doctors | 334 k [V] | 14–16 k (PLAB ~3 k) [V] | GMC SoMEP 2024 |
+| HCPC | 15 AHPs | 340 k [V] | 5–7 k [V] | HCPC Annual Stats 2024 |
+| GPhC | Pharmacists | 70 k [V] | 1–2 k [V] | GPhC Annual Report 2024 |
+| GDC | Dentists | 120 k [V] | 1–2 k [V] | GDC Annual Report 2024 |
+| SWE | Social workers | 100 k [V] | 2–4 k [V] | SWE Annual Report 2024 |
+| GOC / GOsC / GCC | Smaller bodies | ~40 k [V] | <1 k [V] | Body annual reports |
+| **Total** | | **~1.83 m** | **~50–60 k** | – |
 
-### 4.3 Buyer types (channels) inside Sector B
+### 4.3 Buyer types (Channels) inside Sector B
 
 | Channel | Description | Phase position | Phase-1 share of spend |
 |---|---|---|---|
@@ -91,20 +117,20 @@ The English-language gate + clinical-knowledge + clinical-exam + first-year-adap
 
 | Slice | UK | WW (where comparable) | Method | Conf |
 |---|---|---|---|---|
-| English prep — NMC nurses | £50–110M | – | 45k × £1,200 (base) → 50k × £2,200 (upper) | E |
-| OSCE clinical prep | £40–60M | – | 25k × £1.5–2.5k | E |
-| CBT knowledge prep | £10–20M | – | 25k × £400–800 | E |
-| HCPC AHP English | £6M | – | 5k × £1,200 | E |
-| GMC PLAB cohort | £6M | – | 3k × £2,000 | E |
-| Social care worker English | £18M | – | 30k × £600 | E |
-| First-year adaptation / preceptorship | £50–75M | – | 25k × £2–3k | E |
-| **Sector B total horizon** | **£180–290M** | – | Bottom-up | E (V on inputs) |
-| NHS overseas-nurse total recruitment spend (cross-check) | ~£200M / yr | – | NAO Report 2023 | V |
-| Cost per overseas nurse placement (cross-check) | £10–15k | – | NHS Confederation 2023 | V |
+| English prep — NMC nurses | £50–110 m | – | 45 k × £1,200 (base) → 50 k × £2,200 (upper) | E |
+| OSCE clinical prep | £40–60 m | – | 25 k × £1.5–2.5 k | E |
+| CBT knowledge prep | £10–20 m | – | 25 k × £400–800 | E |
+| HCPC AHP English | £6 m | – | 5 k × £1,200 | E |
+| GMC PLAB cohort | £6 m | – | 3 k × £2,000 | E |
+| Social care worker English | £18 m | – | 30 k × £600 | E |
+| First-year adaptation / preceptorship | £50–75 m | – | 25 k × £2–3 k | E |
+| **Sector B total horizon** | **£180–290 m** | – | Bottom-up | E (V on inputs) |
+| NHS overseas-nurse total recruitment spend (cross-check) | ~£200 m / yr | – | NAO Report 2023 | V |
+| Cost per overseas nurse placement (cross-check) | £10–15 k | – | NHS Confederation 2023 | V |
 
 WW figures unavailable for most rows — US/AU/CA/EU equivalents exist (CGFNS, AHPRA, etc.) but require country-by-country build. **Out of scope for Phase 1.**
 
-## 5. The IELTS wedge
+<h2 class="section-break">5. The IELTS Wedge</h2>
 
 ### 5.1 Why IELTS-as-probe
 
@@ -114,18 +140,18 @@ IELTS is **the gating event** for the NMC English requirement (Academic 7.0; spe
 
 A speaking-practice product targeting the **band-6.5 → 7.0 jump** (the most-failed sub-band for NMC candidates). Healthcare-contextualised content (medical vocabulary, ward scenarios) — bridges directly into the OET adjacency.
 
-### 5.3 Adjacencies — how Sector B grows from this wedge
+### 5.3 Adjacencies — how Sector B grows from this Wedge
 
 ```
-Y1: NMC speaking English                        £50–110M
+Y1: NMC speaking English                         £50–110 m
        ↓ (same buyer, same candidate)
-Y2: OSCE clinical prep                          £40–60M
-Y2: CBT knowledge prep                          £10–20M
+Y2: OSCE clinical prep                           £40–60 m
+Y2: CBT knowledge prep                           £10–20 m
        ↓
-Y3: HCPC English                                £6M
-Y3: GMC PLAB cohort                             £6M
-Y3: Social care worker English                  £18M
-Y3: First-year adaptation                       £50–75M
+Y3: HCPC English                                 £6 m
+Y3: GMC PLAB cohort                              £6 m
+Y3: Social care worker English                   £18 m
+Y3: First-year adaptation                        £50–75 m
 ```
 
 Same IRA / Trust buyer pays for all. Multi-year ACV story for any investor deck.
@@ -134,24 +160,24 @@ Same IRA / Trust buyer pays for all. Multi-year ACV story for any investor deck.
 
 | Metric | Phase 1 |
 |---|---|
-| Pilot price | £15k for 50 candidates × 8 weeks |
-| Annual contract per IRA | £200–£300k (3–500 candidates) |
-| Blended ARPU per candidate | £600–£900 |
+| Pilot price | £15 k for 50 candidates × 8 weeks |
+| Annual contract per IRA | £200–300 k (3–500 candidates) |
+| Blended ARPU per candidate | £600–900 |
 | Gross margin | High (autonomous voice delivery; AI cost <£40/learner) |
 | CAC payback | <6 months (employer-paid, sponsored sale) |
 
-## 6. The IRA channel
+<h2 class="section-break">6. The IRA Channel</h2>
 
 ### 6.1 Why IRAs first
 
 | Reason | Detail |
 |---|---|
 | Buyer concentration | Top 5 firms control ~50% of overseas-nurse flow [E — needs FOI verification] |
-| Aligned incentive | IRA loses ~£12k per failed candidate [V via NHS Confed unit costs] |
+| Aligned incentive | IRA loses ~£12 k per failed candidate [V via NHS Confed unit costs] |
 | Fast cycle | 3–6 months from first meeting to paid pilot |
 | No incumbent | No voice-AI competitor selling into IRAs today |
 
-### 6.2 Named Phase-1 accounts
+### 6.2 Named Phase-1 Accounts
 
 | # | Account | Why first | Source |
 |---|---|---|---|
@@ -174,22 +200,22 @@ Total candidate firms: **~330 agencies** on NHS Employers Ethical Recruiters Cod
 | Pilot scoping → signed | 60% | – |
 | Pilot → paid annual | 60% (gated on success criteria) | – |
 | Cumulative top-8 outreach | ~15% of cold; warm-intro lifts to 3–5 pilots | – |
-| **Phase-1 ARR target** | **£500k–£1.2M** | from 3–5 IRAs |
+| **Phase-1 ARR target** | **£500 k – £1.2 m** | from 3–5 IRAs |
 
-### 6.4 Adjacent channels (later phases)
+### 6.4 Adjacent Channels (later Phases)
 
 - **NHS Trust direct** (P2): 217 Trusts; lead with Barts, Imperial, Manchester FT
 - **NHS England Central framework** (P3): 1 sale, multi-Trust, 12–24 mo cycle
 
-## 7. The IELTS Probe
+<h2 class="section-break">7. The IELTS Probe</h2>
 
 ### 7.1 Three hypotheses
 
 | Hypothesis | Pass threshold | Disconfirming evidence |
 |---|---|---|
-| **Score-lift** | ≥10 pp improvement in speaking-band-7 pass rate vs IRA's trailing-6mo baseline | <5 pp lift, or no engagement signal |
+| **Score-lift** | ≥10 pp improvement in speaking-band-7 pass rate vs IRA's trailing-6-mo baseline | <5 pp lift, or no engagement signal |
 | **Channel** | IRA converts from "interesting" to "paid pilot" in <60 days | >90 days; IRAs request unbounded due diligence |
-| **Engagement** | ≥80% candidate session completion in 4 weeks | <60% completion; high drop-off in week 1 |
+| **Engagement** | ≥80% candidate session-completion in 4 weeks | <60% completion; high drop-off in week 1 |
 
 ### 7.2 Pilot agreement (standard structure)
 
@@ -211,7 +237,7 @@ Total candidate firms: **~330 agencies** on NHS Employers Ethical Recruiters Cod
 | Score-lift fails | Re-evaluate engine; freeze Sector B |
 | Engagement fails but lift passes | Add cohort / human nudge layer; re-test |
 
-## 8. Phase 1 plan (12 months, summarised)
+<h2 class="section-break">8. Phase 1 plan (12 months, summarised)</h2>
 
 | Phase | Months | Activity | Target outcome |
 |---|---|---|---|
@@ -222,7 +248,7 @@ Total candidate firms: **~330 agencies** on NHS Employers Ethical Recruiters Cod
 | Probe review | 7 | Read-out against 3 hypotheses | Go / No-Go |
 | Convert to paid | 7–10 | Annual contracts on success | 2–3 paid |
 | Tier-2 outbound | 10–12 | 15 mid-tier IRAs | 2 more pilots in flight |
-| **Phase-1 ARR booked** | **12** | | **£500k–£1.2M** |
+| **Phase-1 ARR booked** | **12** | | **£500 k – £1.2 m** |
 
 ## 9. Risks and mitigations
 
@@ -232,7 +258,7 @@ Total candidate firms: **~330 agencies** on NHS Employers Ethical Recruiters Cod
 | Probe doesn't produce score lift fast enough | Pick band-6.5-stuck cohort (highest leverage); 4-week interim checkpoint |
 | Procurement delay | Anchor first deals at mid-tier IRAs for speed; use as proof for the larger firms |
 | NMC changes English requirement mid-pilot | Build OET parity in week 1; not IELTS-only |
-| Pass-rate baseline disputed | Require IRA to provide trailing-6mo attempt data *before* pilot signs |
+| Pass-rate baseline disputed | Require IRA to provide trailing-6-mo attempt data *before* pilot signs |
 | Cohort fails 3rd hypothesis (engagement) | Layer human-coach nudge; re-test |
 | Tighter UK immigration cap shrinks pipeline | Adjacency expansion (OSCE / adaptation) reduces single-cohort dependence |
 
@@ -244,21 +270,21 @@ Total candidate firms: **~330 agencies** on NHS Employers Ethical Recruiters Cod
 | Sector A (Publisher OEM) credibility — Cambridge UP&A / Macmillan | First 2 IRA case studies published |
 | Investor narrative: "labour, not software" TAM | Score-lift data on healthcare cohort |
 | Sector C (Pathway provider) lateral — INTO / Kaplan / Study Group | Sector A win |
-| Sector G (CPD) parallel — Safety / NEBOSH wedge | Independent of Sector B; runs concurrently |
+| Sector G (CPD) parallel — Safety / NEBOSH Wedge | Independent of Sector B; runs concurrently |
 
-## 11. Top citations (rolled up from D4)
+<h2 class="section-break">11. Top citations (rolled up from D4)</h2>
 
 | Figure | Source | As-of | Conf |
 |---|---|---|---|
-| WW IELTS annual sittings ~3.5M | IELTS Partners "Test Taker Performance Report" (ielts.org) | 2022/23 | V |
-| WW IELTS prep market £2–3B | Grand View Research 2024 (in HFF Drive PDF) | 2024 | V |
-| NMC register 826k | NMC Annual Register Report (nmc.org.uk) | Mar 2025 | V |
-| NMC international joiners 22–26k / yr | NMC Annual Report 2023/24 + Quarterly Reports | 2023–25 | V |
-| GMC register 334k | GMC State of Medical Education and Practice (gmc-uk.org) | 2024 | V |
-| HCPC register 340k | HCPC Annual Report (hcpc-uk.org) | 2024 | V |
-| NHS overseas-nurse recruitment ~£200M / yr | NAO Report "Recovering the cost of recruitment" (nao.org.uk) | 2023 | V |
-| Cost per overseas nurse placement £10–15k | NHS Confederation (nhsconfed.org) | 2023 | V |
-| OSCE candidates ~25k / yr; 4 test centres | NMC OSCE statistics + nmc.org.uk | 2024–25 | V |
+| WW IELTS annual sittings ~3.5 m | IELTS Partners "Test Taker Performance Report" (ielts.org) | 2022/23 | V |
+| WW IELTS prep market £2–3 bn | Grand View Research 2024 (in HFF Drive PDF) | 2024 | V |
+| NMC register 826 k | NMC Annual Register Report (nmc.org.uk) | Mar 2025 | V |
+| NMC international joiners 22–26 k / yr | NMC Annual Report 2023/24 + Quarterly Reports | 2023–25 | V |
+| GMC register 334 k | GMC State of Medical Education and Practice (gmc-uk.org) | 2024 | V |
+| HCPC register 340 k | HCPC Annual Report (hcpc-uk.org) | 2024 | V |
+| NHS overseas-nurse recruitment ~£200 m / yr | NAO Report "Recovering the cost of recruitment" (nao.org.uk) | 2023 | V |
+| Cost per overseas nurse placement £10–15 k | NHS Confederation (nhsconfed.org) | 2023 | V |
+| OSCE candidates ~25 k / yr; 4 test centres | NMC OSCE statistics + nmc.org.uk | 2024–25 | V |
 | IRAs on Ethical Recruiters Code-of-Practice list ~330 | NHS Employers (nhsemployers.org) | 2024 quarterly | V |
 | WHO Red List source-country count 55 | WHO Health Workforce Support and Safeguards List (who.int) | 2023 | V |
 | First-attempt healthcare-IELTS pass rate ~30–40% | IELTS Partners + OET disaggregated band distribution | 2022/23 | **E — verify** |
@@ -267,20 +293,90 @@ Total candidate firms: **~330 agencies** on NHS Employers Ethical Recruiters Cod
 
 **Verification window (1 week of research, before any investor share):** pass rate · per-candidate spend · IRA market share · OSCE TAM · NHS overseas-nurse net spend.
 
----
+<div class="page-break"></div>
 
 ## Appendix A — Doc index
 
 | Code | Title | Length | Status |
 |---|---|---|---|
-| D1 | Briefing Note | 2pp | **Shipped V0.1** |
-| **D2** | **Priority TAM Overview (this doc)** | 7pp | **Shipped V0.1** |
-| D3 | Full TAM & GTM Analysis | 25–35pp | Drafting (paused) |
+| D1 | Briefing Note | 2 pp | **Shipped V0.2** |
+| **D2** | **Priority TAM Overview (this doc)** | ~8 pp | **Shipped V0.2** |
+| D3 | Full TAM & GTM Analysis | 25–35 pp | Drafting (paused) |
 | D4 | Citation Sheet | live | V0 schema ready (paused) |
 | D5 | Entity Lists | live | V0 schema ready (paused) |
-| D6 | TAM Picture | 1pp | Shipped (in-doc; render to slide pending) |
-| D7 | Nomenclature Standard | 1pp | Shipped (in-doc; wiki page pending) |
+| D6 | TAM Picture | 1 pp | Embedded in D1 §TAM picture; render to slide pending |
+| D7 | Nomenclature Standard | 1 pp | Embedded in D2 §2; wiki paste pending |
+| **D8** | **Sales GTM Plan — Phase-1 Slice** | ~15 pp | **Shipped V0.1** |
 
----
+<div class="page-break"></div>
 
-*Confidence flags: **[V]** = Verified from a named public source; **[E]** = Estimate; **[T]** = TBD. Full citations in D4.*
+## Glossary
+
+<dl class="glossary">
+<dt>ACCA</dt><dd>Association of Chartered Certified Accountants</dd>
+<dt>ACV</dt><dd>Annual Contract Value</dd>
+<dt>AHP</dt><dd>Allied Health Professional</dd>
+<dt>AHPRA</dt><dd>Australian Health Practitioner Regulation Agency</dd>
+<dt>APAC</dt><dd>Asia-Pacific region</dd>
+<dt>ARPU</dt><dd>Average Revenue Per User</dd>
+<dt>ARR</dt><dd>Annual Recurring Revenue</dd>
+<dt>B2B / B2B2C / B2C / B2G</dt><dd>Business-to-Business / Business-to-Business-to-Consumer / Business-to-Consumer / Business-to-Government</dd>
+<dt>BNF</dt><dd>BNF Group (parent of Pulse, an IRA)</dd>
+<dt>CAC</dt><dd>Customer Acquisition Cost</dd>
+<dt>CBT</dt><dd>Computer-Based Test (NMC knowledge test taken before OSCE)</dd>
+<dt>CGFNS</dt><dd>Commission on Graduates of Foreign Nursing Schools (USA)</dd>
+<dt>CPD</dt><dd>Continuing Professional Development</dd>
+<dt>D1 – D8</dt><dd>HFF strategy document codes (see Appendix A)</dd>
+<dt>DET</dt><dd>Duolingo English Test</dd>
+<dt>EU</dt><dd>European Union</dd>
+<dt>FOI</dt><dd>Freedom of Information (request to a public body)</dd>
+<dt>GCC</dt><dd>General Chiropractic Council</dd>
+<dt>GDC</dt><dd>General Dental Council</dd>
+<dt>GMC</dt><dd>General Medical Council (UK doctor regulator)</dd>
+<dt>GOC</dt><dd>General Optical Council</dd>
+<dt>GOsC</dt><dd>General Osteopathic Council</dd>
+<dt>GPhC</dt><dd>General Pharmaceutical Council</dd>
+<dt>GTM</dt><dd>Go-To-Market</dd>
+<dt>HCA</dt><dd>Hospital Corporation of America (UK private hospital group)</dd>
+<dt>HCPC</dt><dd>Health and Care Professions Council (UK regulator for 15 allied health professions)</dd>
+<dt>HE</dt><dd>Higher Education</dd>
+<dt>HEE</dt><dd>Health Education England (now merged into NHSE Workforce, Training &amp; Education)</dd>
+<dt>HFF</dt><dd>Human First Foundation</dd>
+<dt>ICAEW</dt><dd>Institute of Chartered Accountants in England and Wales</dd>
+<dt>ICP</dt><dd>Ideal Customer Profile</dd>
+<dt>IELTS</dt><dd>International English Language Testing System</dd>
+<dt>INTO</dt><dd>INTO University Partnerships (UK pathway provider)</dd>
+<dt>IOSH</dt><dd>Institution of Occupational Safety and Health</dd>
+<dt>IRA</dt><dd>International Recruitment Agency (private firm placing overseas health workers into UK employers)</dd>
+<dt>K-12</dt><dd>School education, ages 5–18 (US/UK schooling phase term)</dd>
+<dt>L&amp;D</dt><dd>Learning and Development</dd>
+<dt>MRCP</dt><dd>Membership of the Royal Colleges of Physicians</dd>
+<dt>NAO</dt><dd>National Audit Office (UK)</dd>
+<dt>NEBOSH</dt><dd>National Examination Board in Occupational Safety and Health</dd>
+<dt>NHS</dt><dd>National Health Service (UK)</dd>
+<dt>NHSE</dt><dd>NHS England</dd>
+<dt>NMC</dt><dd>Nursing and Midwifery Council (UK regulator for nurses and midwives)</dd>
+<dt>OEM</dt><dd>Original Equipment Manufacturer (here, a publisher embedding HFF inside their branded product)</dd>
+<dt>OET</dt><dd>Occupational English Test (healthcare-contextualised English assessment)</dd>
+<dt>OSCE</dt><dd>Objective Structured Clinical Examination (NMC clinical exam taken in UK after registration)</dd>
+<dt>P0 – P5</dt><dd>HFF Priority codes (P0 = active probe; P1 = commit; P5 = deprioritise)</dd>
+<dt>PLAB</dt><dd>Professional and Linguistic Assessments Board (GMC entry exam for international doctors)</dd>
+<dt>pp</dt><dd>Percentage points</dd>
+<dt>PTE</dt><dd>Pearson Test of English</dd>
+<dt>ROI</dt><dd>Return on Investment</dd>
+<dt>SAM</dt><dd>Serviceable Addressable Market</dd>
+<dt>Sector A – G</dt><dd>HFF Sector codes (A = Adult Language Cert; B = Health &amp; Care Pro Registration; C = University-Bound Journey; D = Regulated Pro Exams one-shot; E = Corporate Compliance Training; F = K-12 Mainstream; G = CPD Meta-sector)</dd>
+<dt>SOM</dt><dd>Serviceable Obtainable Market</dd>
+<dt>SoMEP</dt><dd>State of Medical Education and Practice in the UK (GMC annual report)</dd>
+<dt>SQE</dt><dd>Solicitors Qualifying Examination</dd>
+<dt>SWE</dt><dd>Social Work England</dd>
+<dt>TAM</dt><dd>Total Addressable Market</dd>
+<dt>TOEFL</dt><dd>Test of English as a Foreign Language</dd>
+<dt>UCL</dt><dd>University College London</dd>
+<dt>UP&amp;A</dt><dd>Cambridge University Press &amp; Assessment</dd>
+<dt>UK / US</dt><dd>United Kingdom / United States</dd>
+<dt>U-RES</dt><dd>University Research / Innovation arm (one of six university buyer sub-types in HFF nomenclature)</dd>
+<dt>V / E / T</dt><dd>Confidence flags — Verified / Estimate / TBD</dd>
+<dt>WHO</dt><dd>World Health Organization</dd>
+<dt>WW</dt><dd>Worldwide</dd>
+</dl>

--- a/docs/strategy/D8-sales-gtm-phase1.md
+++ b/docs/strategy/D8-sales-gtm-phase1.md
@@ -1,0 +1,492 @@
+---
+title: "D8 — Sales GTM Plan, Phase-1 Slice"
+subtitle: "Sector B · NMC Speaking-Band-7 Wedge · IRA Channel"
+author: "Paul Wander"
+date: "4 June 2026"
+version: "0.1"
+---
+
+<style>
+  @page {
+    size: A4;
+    margin: 22mm 20mm 22mm 20mm;
+    @bottom-center {
+      content: "Page " counter(page) " of " counter(pages);
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+    @bottom-left {
+      content: "HFF Strategy — D8";
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+    @bottom-right {
+      content: "Internal — Confidential";
+      font-size: 8pt; color: #94a3b8;
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+    }
+  }
+  body { font-family: 'Helvetica Neue', Arial, sans-serif; color: #1a1a1a; line-height: 1.55; font-size: 11pt; }
+  h1 { color: #0f172a; border-bottom: 3px solid #2563eb; padding-bottom: 8px; font-size: 22pt; margin-top: 0; }
+  h2 { color: #1e3a5f; border-bottom: 1px solid #e2e8f0; padding-bottom: 4px; margin-top: 24px; font-size: 14pt; page-break-after: avoid; }
+  h3 { color: #334155; margin-top: 18px; font-size: 12pt; page-break-after: avoid; }
+  h4 { color: #475569; margin-top: 14px; font-size: 11pt; page-break-after: avoid; }
+  p { margin: 8px 0; }
+  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 10pt; page-break-inside: avoid; }
+  th, td { border: 1px solid #e2e8f0; padding: 6px 10px; text-align: left; vertical-align: top; }
+  th { background: #f1f5f9; color: #0f172a; font-weight: 600; }
+  code, pre { font-family: 'Menlo', monospace; font-size: 9.5pt; background: #f8fafc; }
+  pre { padding: 10px; border-left: 3px solid #2563eb; page-break-inside: avoid; }
+  blockquote { border-left: 3px solid #2563eb; padding-left: 12px; color: #334155; margin: 12px 0; font-style: italic; }
+  .meta { font-size: 9.5pt; color: #64748b; margin-top: -8px; margin-bottom: 16px; }
+  .page-break { page-break-before: always; }
+  h2.section-break { page-break-before: always; }
+  .email { background: #f8fafc; border-left: 3px solid #2563eb; padding: 12px 16px; margin: 12px 0; font-size: 10pt; page-break-inside: avoid; }
+  .email .hdr { font-family: 'Menlo', monospace; font-size: 9pt; color: #475569; margin-bottom: 8px; }
+  .email .body { white-space: pre-wrap; }
+  .glossary { font-size: 9.5pt; }
+  .glossary dt { font-weight: 600; color: #1e3a5f; }
+  .glossary dd { margin: 0 0 4px 16px; }
+</style>
+
+::: meta
+**Status:** Internal — Sales & Commercial; never share externally   |   **Owner:** Paul Wander   |   **Reads with:** D1 (briefing), D2 (priority TAM), D5 (entity lists).
+:::
+
+## 1. Slice definition
+
+This plan is the **operational front-end** of the Phase-1 commitment locked in D1 and D2.
+
+| Level | Value |
+|---|---|
+| Sector | B — Health & Care Professional Registration |
+| Wedge | NMC speaking-band-7 jump |
+| Channel | IRA (B2B2C employer-paid) |
+| Accounts (Tier 1) | Yourworld · HCL · Sanctuary · Greenstaff · Globe Locums |
+| Cohort | 50 nurses × 8 weeks × £15 k pilot |
+| Phase-1 ARR target | £500 k – £1.2 m |
+| 3-yr SOM target | £8–20 m |
+
+## 2. Key value proposition
+
+**Headline:**
+> *Cut your IELTS-7.0 candidate stall by 40%. Each stuck nurse costs you £12 k of sunk recruitment. We move 1 in 4 plateaued candidates over the line — contractually.*
+
+| Layer | Statement |
+|---|---|
+| **Problem** | 30–40% of overseas nurses fail first-attempt IELTS speaking 7.0 [E]. Each failed candidate represents ~£12 k of unrecovered recruitment + relocation cost [V — NHS Confederation]. |
+| **Cause** | The bottleneck is *speaking practice* — band-9 examiners don't scale, candidates can't get 3 daily 15-minute practice sessions. |
+| **Promise** | HFF voice AI delivers unlimited, NMC-spec speaking practice 24/7 across time zones. ≥10 pp lift in pass rate, contractually committed. |
+| **Proof** | Pilot evidence from cohort N [post-pilot]. Outcome-locked pilot agreement. |
+| **Why us** | The only voice-first AI built specifically for the 6.5 → 7.0 NMC jump. No incumbent. |
+
+**Anti-message — what we deliberately don't say:** "AI tutor", "personalised learning", "LLM-powered". Speak to P&L, not pedagogy.
+
+<h2 class="section-break">3. Target Accounts aligned to TAM</h2>
+
+Sourced from the **NHS Employers Code-of-Practice "Ethical Recruiters" list** (~330 agencies, public, refreshed quarterly). Three tiers by Phase entry.
+
+### Tier 1 — Phase-1 outbound (months 1–3)
+
+| # | Account | Likely ARR | Why first | Source |
+|---|---|---|---|---|
+| 1 | Yourworld Healthcare | £200–300 k | Largest UK IRA by nurse-placement volume | NHS Employers List [V] |
+| 2 | HCL Workforce Solutions | £200–300 k | Already bundles English + OSCE; tech-curious | NHS Employers List [V] |
+| 3 | Sanctuary Personnel | £150–250 k | Wide AHP + social-work flow → adjacency proof | NHS Employers List [V] |
+| 4 | Greenstaff Medical | £150–250 k | Heavy India / Philippines pipeline | NHS Employers List [V] |
+| 5 | Globe Locums | £100–200 k | AHP-heavy (HCPC adjacency proof) | NHS Employers List [V] |
+
+### Tier 2 — Phase-1 mid (months 3–6, post-first-case-study)
+
+| # | Account | Profile |
+|---|---|---|
+| 6 | BWA Medical | Mid-sized, agile, willing to pilot |
+| 7 | Pulse (BNF Group) | Diversified, financial discipline |
+| 8 | Mediplacements | Strong Filipino pipeline |
+| 9 | Trinity Group | Mid-tier, ops-led |
+| 10 | Reed Health | Brand recognition; large mid-tier |
+| 11 | Compass Associates | Specialist segments |
+| 12 | HealthCare 21 | Mid-tier nurse + AHP |
+| 13 | Mediserve UK | Compliance-disciplined |
+
+### Tier 3 — Phase-2 (months 6–12)
+
+Remaining ~315 agencies on the Code-of-Practice list. Touched only after first 2 Tier-1 contracts close and case studies are published. Triggered by inbound rather than outbound.
+
+### Adjacent target sets (held in reserve, **not Phase-1**)
+
+- 217 NHS Trusts (direct-recruiting) — lead with Barts, Imperial, Manchester FT
+- NHS England Workforce, Training & Education central programme
+- Private hospital groups (HCA, Bupa, Spire, Nuffield, Ramsay)
+
+<h2 class="section-break">4. Decision-maker personas</h2>
+
+Five personas inside every Tier-1 IRA. Different message for each.
+
+| Role | Title examples | Cares about | Owns | Message hook |
+|---|---|---|---|---|
+| **Economic buyer** | Head of International Recruitment, Director Healthcare Recruitment, COO | Cost-per-placement, pipeline conversion, P&L | Budget approval | "£12 k per failed candidate; we recover X per quarter" |
+| **Process owner** | Director of Operations, Head of Candidate Journey | Workflow integration, ops headcount | Implementation | "Plugs into your existing onboarding, no platform change" |
+| **Buyer-influencer** | Head of Talent / TA Director | Pass-rate KPIs, candidate NPS | Reporting | "Live dashboard, anonymised candidate progress, board-ready reports" |
+| **Blocker** | Compliance Lead, Head of Governance | NHS Code of Practice, GDPR, NMC alignment | Vetoing | "WHO-Red-List aware, NMC-spec, full audit trail" |
+| **Champion** | Candidate Experience Lead, Pastoral Lead | Candidate outcomes, stress, retention | Internal advocacy | "Candidates get 24/7 practice — they say it's the calmest part of their journey" |
+
+## 5. Messaging by stage
+
+| Stage | Message centre of gravity |
+|---|---|
+| Awareness | "Every IRA loses 1 in 3 nurses at IELTS speaking. Solvable." |
+| Interest | "We move band 6.5 → 7.0 in 4 weeks." |
+| Discovery | "Send us your trailing-6-month pass rate. We'll show the £k you're leaving on the table." |
+| Pilot | "50 candidates, 8 weeks, £15 k flat, outcome-locked." |
+| Conversion | "Lift of N pp on your cohort. Annual contract at £700 / candidate triggers." |
+| Renewal / expand | "Same buyer, same candidates, next bottleneck: OSCE." |
+
+<h2 class="section-break">6. Campaign ideas</h2>
+
+Eight plays. Mix of outbound, content, event, partnership.
+
+| # | Campaign name | Type | Mechanic | Stage targeted | Effort |
+|---|---|---|---|---|---|
+| C1 | **"Pass-Rate Recovery Calculator"** | ROI tool + outbound | Public Google Sheet. IRA inputs intake, pass rate, cost-per-failure. Outputs recoverable £. Share-token + booking-link CTA. | Awareness → Discovery | Low — 1 day to build, ongoing |
+| C2 | **"The £12 k Conversation"** | Thought leadership | LinkedIn carousel series. Founder voice. Targets IRA exec feeds. Drumbeat 1/week for 12 weeks. | Awareness → Interest | Medium — 12 posts |
+| C3 | **"Healthcare-IELTS Speaking Lab"** | Demo asset | Recorded 8-min sample session with a band-6.5 candidate. Showable in any pitch. | Interest → Discovery | Low — 1 recording session |
+| C4 | **"From 6.5 to 7.0 in 4 weeks"** | Case study | Anonymised candidate journey from first pilot. Becomes the lead asset post-month-7. | Discovery → Pilot | Medium — needs pilot data |
+| C5 | **RCN International Recruitment Conference booth** | Event | Small booth + 3 founder talks proposed. The annual gathering of the buyer set. | All stages | High — ~£8 k + 3 days |
+| C6 | **NHS Confed International Recruitment WG content drop** | Partnership | Pitch to write a 1-page brief for the WG quarterly digest. Reaches Trust-direct buyers in advance of Phase 2. | Awareness | Low — 1 piece |
+| C7 | **Diaspora HR Network warm-intro programme** | Network | Identify Indian / Filipino HR managers who've moved between IRAs (the connective tissue). 30–50 named individuals. Coffee or LinkedIn. | Interest → Discovery | Medium — ongoing |
+| C8 | **"Trailing-6-month Audit"** | Lead-gen offer | Free anonymised audit of an IRA's last 6 months of IELTS attempts. Output: a 2-page report. Cost to HFF: ~£2 k per audit. Lock-in for pilot. | Discovery → Pilot | Medium — per-prospect |
+
+<h2 class="section-break">7. Email sequence — full copy</h2>
+
+Five emails covering the full prospect journey. Send sequence: E1 → E2 → (discovery call) → E3 → (pilot signs) → E4 → E5.
+
+### E1 — Cold outbound (Day 0)
+
+::: email
+**From:** Paul Wander (HFF)
+**To:** \[First name\], Head of International Recruitment, \[IRA name\]
+**Subject:** 1 in 3 nurses stuck at IELTS speaking — solvable?
+
+Hi \[First name\],
+
+I'm guessing roughly 1 in 3 of your nurse candidates plateau at IELTS speaking 6.5 — and that each one stuck represents north of £10 k of sunk recruitment cost.
+
+We've built a voice-first AI coach that targets the specific 6.5 → 7.0 jump for NMC candidates. We're running paid 50-candidate pilots with IRAs this quarter, contractually committed to a 10-point pass-rate lift.
+
+Worth a 20-min call to compare with what you do today?
+
+Paul
+\[Sig + 1-pager attached\]
+:::
+
+### E2 — Follow-up (Day 5)
+
+::: email
+**From:** Paul Wander (HFF)
+**To:** Same
+**Subject:** Re: IELTS-speaking stall
+
+Quick follow-up — happy to send the recorded 8-min sample session so you can hear what the coach sounds like before any call.
+
+What's your trailing-6-month pass rate for first-attempt IELTS-speaking 7.0? If it's where I expect (35–45%), we're talking ~£100 k+ of unrecovered prep cost annually that we can move.
+
+\[Link to "Pass-Rate Recovery Calculator"\]
+
+Paul
+:::
+
+### E3 — Post-discovery (Day 7 after the call)
+
+::: email
+**From:** Paul Wander (HFF)
+**To:** Economic buyer + champion at IRA
+**Subject:** Your numbers — £\[X\] recoverable annually + pilot agreement
+
+Hi \[First name\],
+
+Thanks for the call. Plugging your numbers into the calculator:
+
+- Intake: \[X candidates / year\]
+- Current first-attempt speaking-7.0 pass rate: \[Y\]%
+- Avg cost-per-failed-candidate: £\[Z\]
+- Annual sunk cost from failures: **£\[A\]**
+
+Our 10-percentage-point pass-rate lift recovers ~£\[B\] / year of that. HFF cost at \[per-candidate rate\] = £\[C\]. **Net annual saving: ~£\[A-C\].**
+
+To validate this on your cohort, I've attached our standard 8-week, 50-candidate pilot agreement:
+• £15 k flat
+• Three pass-rate / engagement criteria (in the doc)
+• If we miss the lift target, we extend at our cost.
+
+Pilots launching in \[month\]. Spaces are limited to 5 IRAs in this wave. Confirm by \[date\] to be in.
+
+Paul
+:::
+
+### E4 — Pilot mid-point (Week 4 of pilot)
+
+::: email
+**From:** HFF Customer Success
+**To:** Process owner + champion at IRA
+**Subject:** \[IRA\] cohort — Week 4 update
+
+Hi \[First name\],
+
+Quick midway update on the cohort:
+
+- Candidates active: \[N / 50\]
+- Session-completion rate: \[X\]% (target ≥80%)
+- Avg speaking practice hours per candidate: \[Y\]
+- Provisional Week-4 speaking-band estimate vs. baseline: +\[Z\] pp
+
+A few stories worth sharing — \[1 candidate vignette\].
+
+Next milestone: Week 6 mock IELTS speaking. Week-8 official sittings booked for \[date range\].
+
+Anything you want us to focus on in the second half?
+
+\[Name\]
+:::
+
+### E5 — Pilot outcome + contract offer (Week 8)
+
+::: email
+**From:** Paul Wander (HFF)
+**To:** Economic buyer + champion at IRA
+**Subject:** \[IRA\] pilot results + annual contract offer
+
+Hi \[First name\],
+
+Pilot wrap-up read-out attached. Headlines:
+
+- **Speaking-7.0 pass rate: \[X\]%** vs. your trailing-6-month baseline of \[Y\]% — **+\[Z\] pp lift** (target ≥10 pp ✓)
+- **Session completion: \[A\]%** (target ≥80% ✓)
+- **Candidate NPS: \[B\]** (target ≥40 ✓)
+
+That triggers the annual-contract conversion clause in the pilot agreement.
+
+Proposed annual structure:
+• 12-month term, auto-renew
+• \[X\] candidates / year at £\[per-candidate\] = **£\[total\] ARR**
+• OSCE-prep module available from month 7 at £\[Y\] / candidate (the next bottleneck after English)
+• Live ops dashboard for your governance team
+
+Happy to walk through with your finance and ops leads. Available \[3 dates\].
+
+Paul
+:::
+
+<h2 class="section-break">8. Objection handling</h2>
+
+| Objection | Response |
+|---|---|
+| *"We already do this in-house"* | "How many of your candidates plateau at 6.5? What's your in-house cost-per-candidate-hour of speaking practice? Most IRAs find in-house caps at ~2 hours of practice per candidate per week — we deliver 21." |
+| *"Our pass rate is fine"* | "Send us your trailing-6-month figures. If our lift would be under 5 pp, we walk away — no cost to you." |
+| *"We can't share candidate data"* | "Pilot baseline uses anonymised attempt-1 IELTS bands. No PII required for the success measurement." |
+| *"Procurement takes 6 months"* | "Pilot runs on a 2-page MOU. Full contract only triggers on conversion." |
+| *"What if it doesn't work?"* | "2/3 hypotheses pass → 8-week extension at HFF cost. <2/3 → walk-away with no further obligation." |
+| *"You're not endorsed by NMC"* | "Correct — NMC does not endorse providers. Neither do GMC or SRA. The validation here is pass-rate lift evidenced on cohort data, not regulator badge." |
+| *"AI tutors don't really work"* | "Ours has narrow scope — the band 6.5 → 7.0 speaking jump. Not general purpose. Listen to the 8-minute sample." |
+| *"GDPR concerns"* | "Pilot data lives on UK-region infrastructure. Anonymised baseline. Full DPA on contract conversion. We sign your data-processing terms." |
+
+## 9. Pilot → paid conversion path
+
+Specified in D2 §7.2. Operational re-statement for sales-ops:
+
+```
+Discovery call → ROI calibration → Demo + sample → Pilot MOU (2 pp) →
+  Pilot kickoff (W0) → Mid-point review (W4) → Outcome read-out (W8) →
+    Pass criteria met        → Annual contract auto-triggers
+    Pass criteria 2/3        → Extension at HFF cost
+    Pass criteria <2/3       → Walk away; HFF retains data rights
+```
+
+Annual contract template tiered by candidate volume: **£600 / candidate** (volume tier) → **£900 / candidate** (lower tier). 12-month auto-renew, 90-day notice. OSCE adjacency option from month 7.
+
+<h2 class="section-break">10. KPI dashboard</h2>
+
+| Metric | Week 4 | Week 12 | Week 26 | Week 52 |
+|---|---|---|---|---|
+| Outbound touches | 24 | 60 | 150 | 300 |
+| Discovery calls | 3 | 10 | 30 | 60 |
+| Demos delivered | 1 | 6 | 22 | 45 |
+| Pilots signed | 0 | 2 | 5 | 8 |
+| Pilots running | 0 | 1 | 4 | 6 |
+| Pilots converted to paid | 0 | 0 | 2 | 5 |
+| ARR booked | £0 | £15 k pilots | £300 k+ paid | £500 k – £1.2 m paid |
+
+Weekly review cadence; quarterly board roll-up.
+
+## 11. Resource needs
+
+| Role | Time |
+|---|---|
+| Founder / commercial lead | ~50% for 12 mo |
+| BD ops (junior) | Full-time |
+| Education lead | ~30% (pilot design) |
+| Engineering | ~20% (IRA reporting dashboard) |
+| Healthcare-recruitment advisor (retainer) | 2 days / mo, £3–5 k / mo |
+| External tools | Sales Navigator (£90 / mo), HubSpot or Pipedrive (£50 / mo), Loom (£10 / mo) |
+
+## 12. Risks and mitigations
+
+Carried verbatim from D2 §9 — no new risks for this slice. Key sales-specific addition:
+
+| Risk | Mitigation |
+|---|---|
+| Tier-1 IRA pilot stalls in procurement | Anchor first 2 deals in Tier-2 (BWA, Mediplacements) for speed; use as case studies for the larger firms |
+| Decision-maker churn at IRA mid-cycle | Identify 2 sponsors per account (economic buyer + champion); CRM-track both |
+| Demo asset feels "too polished" → trust gap | Use real candidate voice (with consent) in C3 sample, not synthetic |
+
+<div class="page-break"></div>
+
+## Appendix A — Pilot MOU template (2 pp)
+
+```
+PARTIES        [IRA] and HumanFirst Foundation
+COHORT         50 candidates, NMC track, speaking-band 6.0–6.5
+DURATION       8 weeks from kickoff
+PRICE          £15,000 flat (covers all access; no per-candidate uplift)
+BASELINE       IRA supplies anonymised attempt-1 IELTS data
+               for trailing 6 months
+SUCCESS GATES  (i)  ≥10 pp lift in speaking-7.0 pass rate
+                    vs trailing baseline
+               (ii) ≥80% candidate session-completion
+               (iii) Candidate NPS ≥40
+CONVERSION     All 3 gates met → annual contract at £600–900
+                    per candidate auto-triggers (IRA option)
+               2 of 3 gates met → 8-week extension at HFF cost
+               <2 gates → walk-away, HFF retains data rights
+DATA           HFF retains transcript + score-lift data;
+               IRA gets aggregated reporting only
+IP             HFF owns engine; IRA owns candidate relationship
+EXIT           30-day notice either side during pilot
+GOVERNING LAW  England and Wales
+```
+
+## Appendix B — ROI calculator schema
+
+**Inputs (IRA-supplied):**
+
+| Cell | Field |
+|---|---|
+| A | Annual nurse-candidate intake |
+| B | Trailing-6-mo first-attempt IELTS-speaking-7.0 pass rate (%) |
+| C | Avg cost-per-failed-candidate (sunk prep + retake + visa-extension risk) |
+| D | Current English-prep spend per candidate |
+
+**Outputs (calculated):**
+
+| Cell | Formula | Meaning |
+|---|---|---|
+| E | =A × (1 − B) | Candidates failing first attempt / year |
+| F | =E × C | Annual sunk cost from failures |
+| G | =B + 10 pp | HFF-projected new pass rate |
+| H | =A × 0.10 | Candidates now passing (delta) |
+| I | =H × C | Annual cost recovered |
+| J | =A × £700 | HFF annual contract cost |
+| K | =I − J | **Net annual saving** |
+| L | =J / (K / 12) | Payback in months |
+
+**Worked example** (mid-tier IRA, 800 nurses / yr, 40% pass rate, £12 k cost-per-failure):
+Annual sunk cost £5.76 m → HFF lift saves ~£960 k → HFF cost ~£560 k → **net saving ~£400 k → payback < 1 month**.
+
+<div class="page-break"></div>
+
+## Appendix C — Event / conference calendar
+
+| Event | Frequency | Why we go |
+|---|---|---|
+| RCN International Recruitment Conference | Annual (June) | The buyer set in one room |
+| NHS Confederation Annual Conference | Annual (June) | Trust-direct buyers + NHSE central commissioners |
+| REC Healthcare Sector Group meetings | Quarterly | IRA exec community |
+| OET Healthcare Forum | Annual | Endorsement pathway |
+| Cambridge IELTS Partners events | Periodic | Publisher / test-owner relationships |
+| HSJ International Recruitment Awards | Annual | Visibility / case-study amplification |
+| Westminster Health Forum — international workforce | Periodic | Policy buyer briefing |
+
+## Appendix D — Doc index
+
+| Code | Title | Status |
+|---|---|---|
+| D1 | Briefing Note | Shipped V0.2 |
+| D2 | Priority TAM Overview | Shipped V0.2 |
+| D3 | Full TAM & GTM Analysis | Paused |
+| D4 | Citation Sheet | Paused |
+| D5 | Entity Lists | Paused |
+| D6 | TAM Picture | Embedded in D1 / D2 |
+| D7 | Nomenclature Standard | Embedded in D2 §2 |
+| **D8** | **Sales GTM Plan (this doc)** | **Shipped V0.1** |
+
+<div class="page-break"></div>
+
+## Glossary
+
+<dl class="glossary">
+<dt>ACV</dt><dd>Annual Contract Value</dd>
+<dt>AHP</dt><dd>Allied Health Professional</dd>
+<dt>APAC</dt><dd>Asia-Pacific region</dd>
+<dt>ARPU</dt><dd>Average Revenue Per User</dd>
+<dt>ARR</dt><dd>Annual Recurring Revenue</dd>
+<dt>B2B / B2B2C / B2C / B2G</dt><dd>Business-to-Business / Business-to-Business-to-Consumer / Business-to-Consumer / Business-to-Government</dd>
+<dt>BD</dt><dd>Business Development</dd>
+<dt>BNF</dt><dd>BNF Group (parent of Pulse, an IRA)</dd>
+<dt>BWA</dt><dd>BWA Medical (IRA)</dd>
+<dt>C1 – C8</dt><dd>Campaign codes within this doc</dd>
+<dt>CAC</dt><dd>Customer Acquisition Cost</dd>
+<dt>CBT</dt><dd>Computer-Based Test (NMC knowledge test taken before OSCE)</dd>
+<dt>Confed</dt><dd>NHS Confederation (membership body for NHS organisations)</dd>
+<dt>CPD</dt><dd>Continuing Professional Development</dd>
+<dt>CRM</dt><dd>Customer Relationship Management (sales software)</dd>
+<dt>CTA</dt><dd>Call to Action</dd>
+<dt>D1 – D8</dt><dd>HFF strategy document codes (see Appendix D)</dd>
+<dt>DPA</dt><dd>Data Processing Agreement (GDPR-related contractual term)</dd>
+<dt>E1 – E5</dt><dd>Email codes within the §7 sequence</dd>
+<dt>FT</dt><dd>NHS Foundation Trust</dd>
+<dt>GDPR</dt><dd>General Data Protection Regulation (UK / EU data law)</dd>
+<dt>GMC</dt><dd>General Medical Council (UK doctor regulator)</dd>
+<dt>GTM</dt><dd>Go-To-Market</dd>
+<dt>HCA</dt><dd>Hospital Corporation of America (UK private hospital group)</dd>
+<dt>HCL</dt><dd>HCL Workforce Solutions (IRA)</dd>
+<dt>HCPC</dt><dd>Health and Care Professions Council (UK regulator for 15 allied health professions)</dd>
+<dt>HFF</dt><dd>Human First Foundation</dd>
+<dt>HSJ</dt><dd>Health Service Journal (UK trade press)</dd>
+<dt>IELTS</dt><dd>International English Language Testing System</dd>
+<dt>IRA</dt><dd>International Recruitment Agency</dd>
+<dt>IP</dt><dd>Intellectual Property</dd>
+<dt>KPI</dt><dd>Key Performance Indicator</dd>
+<dt>L&amp;D</dt><dd>Learning and Development</dd>
+<dt>LLM</dt><dd>Large Language Model</dd>
+<dt>MOU</dt><dd>Memorandum of Understanding</dd>
+<dt>mo</dt><dd>Month</dd>
+<dt>NHS</dt><dd>National Health Service (UK)</dd>
+<dt>NHSE</dt><dd>NHS England</dd>
+<dt>NMC</dt><dd>Nursing and Midwifery Council (UK regulator for nurses and midwives)</dd>
+<dt>NPS</dt><dd>Net Promoter Score</dd>
+<dt>OEM</dt><dd>Original Equipment Manufacturer (here, a publisher embedding HFF inside their branded product)</dd>
+<dt>OET</dt><dd>Occupational English Test (healthcare-contextualised English assessment)</dd>
+<dt>OSCE</dt><dd>Objective Structured Clinical Examination (NMC clinical exam taken in UK after registration)</dd>
+<dt>P&amp;L</dt><dd>Profit and Loss</dd>
+<dt>P0 – P5</dt><dd>HFF Priority codes (P0 = active probe; P1 = commit; P5 = deprioritise)</dd>
+<dt>PII</dt><dd>Personally Identifiable Information</dd>
+<dt>pp</dt><dd>Percentage points</dd>
+<dt>RCN</dt><dd>Royal College of Nursing</dd>
+<dt>REC</dt><dd>Recruitment & Employment Confederation (UK trade body)</dd>
+<dt>ROI</dt><dd>Return on Investment</dd>
+<dt>SAM</dt><dd>Serviceable Addressable Market</dd>
+<dt>Sector A – G</dt><dd>HFF Sector codes (A = Adult Language Cert; B = Health &amp; Care Pro Registration; C = University-Bound Journey; D = Regulated Pro Exams one-shot; E = Corporate Compliance Training; F = K-12 Mainstream; G = CPD Meta-sector)</dd>
+<dt>Sig</dt><dd>Email signature block</dd>
+<dt>SOM</dt><dd>Serviceable Obtainable Market</dd>
+<dt>SQE</dt><dd>Solicitors Qualifying Examination</dd>
+<dt>SRA</dt><dd>Solicitors Regulation Authority</dd>
+<dt>TA</dt><dd>Talent Acquisition</dd>
+<dt>TAM</dt><dd>Total Addressable Market</dd>
+<dt>Tier 1 / 2 / 3</dt><dd>Account-prioritisation tiers within this doc (1 = Phase-1 outbound; 2 = mid; 3 = long-tail)</dd>
+<dt>UK</dt><dd>United Kingdom</dd>
+<dt>V / E / T</dt><dd>Confidence flags — Verified / Estimate / TBD</dd>
+<dt>W4 / W8 / W12 / W26 / W52</dt><dd>Week 4 / 8 / 12 / 26 / 52</dd>
+<dt>WG</dt><dd>Working Group</dd>
+<dt>WHO</dt><dd>World Health Organization</dd>
+<dt>WW</dt><dd>Worldwide</dd>
+</dl>


### PR DESCRIPTION
## Summary

- **D8 (new)** — Sales GTM Plan for the Phase-1 slice (Sector B / NMC band-7 / IRA channel). Includes value prop, Tier 1–3 IRA accounts, 5 personas, 8 campaigns, 5 full email-copy drafts, objection handling, pilot→paid path, KPI dashboard, MOU template, ROI calculator schema, conference calendar.
- **D1 V0.2** — re-written in essay style (SCQA labels removed in favour of prose). Pagination + glossary as final page.
- **D2 V0.2** — pagination + page-break-before on major sections. Comprehensive glossary as final page.
- **CONTINUE-HERE.md** — updated for V0.2 status, PDF regen instructions, pause list.

## Standards now codified across all strategy docs

- A4 page, 22 mm × 20 mm margins
- "Page X of Y" footer + doc-code + "Internal — Confidential" mark
- Page-break before major sections in 7pp+ docs
- Glossary on its own page at the end — every acronym/code used in the doc

## Test plan
- [x] Markdown renders cleanly
- [x] PDF export via `pandoc --pdf-engine=weasyprint` confirmed
- [x] No code, schema, or test impact (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)