### PR TITLE
feat(intake): propagate ageRange from intake → Caller via CallerAttribute

### DIFF
--- a/apps/admin/app/api/join/[token]/route.ts
+++ b/apps/admin/app/api/join/[token]/route.ts
@@ -133,7 +133,20 @@ export async function POST(
   const body = await request.json();
   const v = validateBody(joinPostSchema, body);
   if (!v.ok) return v.error;
-  const { firstName, lastName, email, playbookId, skipOnboarding } = v.data;
+  const { firstName, lastName, email, ageRange, playbookId, skipOnboarding } = v.data;
+
+  // Defence-in-depth against URL tampering. The intake spec's
+  // `ageBand.adultOnly()` invariant already rejects `under-18` before
+  // ProjectionCommit fires (see `apps/admin/lib/intake/specs/enrollment.intent.ts`
+  // line ~186), so this should never legitimately reach the endpoint.
+  // If it does, refuse the join — the compliance trail must record
+  // adult declaration only. See #1036.
+  if (ageRange === "under-18") {
+    return NextResponse.json(
+      { ok: false, error: "Under-18 enrollment is not supported via this flow." },
+      { status: 400 }
+    );
+  }
 
   // Don't overwrite session cookie for admins/operators testing the join flow
   const skipCookie = await hasHigherRoleSession(request);
@@ -235,6 +248,25 @@ export async function POST(
       },
     });
 
+    // Persist the declared age band as a CallerAttribute for the
+    // compliance trail — #1036. The `intake.ageRange` key + GLOBAL
+    // scope mirror existing person-level attributes; valueType STRING
+    // because AGE_BAND_VALUES is an enum tuple of strings.
+    if (ageRange) {
+      await prisma.callerAttribute.upsert({
+        where: { callerId_key_scope: { callerId: newCaller.id, key: "intake.ageRange", scope: "GLOBAL" } },
+        create: {
+          callerId: newCaller.id,
+          key: "intake.ageRange",
+          scope: "GLOBAL",
+          valueType: "STRING",
+          stringValue: ageRange,
+          sourceSpecSlug: "EnrollmentIntake",
+        },
+        update: { stringValue: ageRange },
+      });
+    }
+
     // Create join table membership
     await prisma.callerCohortMembership.create({
       data: { callerId: newCaller.id, cohortGroupId: cohort.id },
@@ -296,6 +328,24 @@ export async function POST(
         externalId: `join-${newUser.id}`,
       },
     });
+
+    // Persist the declared age band as a CallerAttribute for the
+    // compliance trail — #1036. Same pattern as the existing-user path
+    // above; here we write inside the user+caller transaction.
+    if (ageRange) {
+      await tx.callerAttribute.upsert({
+        where: { callerId_key_scope: { callerId: newCaller.id, key: "intake.ageRange", scope: "GLOBAL" } },
+        create: {
+          callerId: newCaller.id,
+          key: "intake.ageRange",
+          scope: "GLOBAL",
+          valueType: "STRING",
+          stringValue: ageRange,
+          sourceSpecSlug: "EnrollmentIntake",
+        },
+        update: { stringValue: ageRange },
+      });
+    }
 
     // Create join table membership
     await tx.callerCohortMembership.create({

--- a/apps/admin/app/join/[token]/page.tsx
+++ b/apps/admin/app/join/[token]/page.tsx
@@ -109,6 +109,7 @@ export default function JoinPage() {
           firstName,
           lastName,
           email,
+          ...(searchParams.get("ageRange") ? { ageRange: searchParams.get("ageRange") } : {}),
           ...(searchParams.get("course") ? { playbookId: searchParams.get("course") } : {}),
           ...(searchParams.get("skipOnboarding") === "true" ? { skipOnboarding: true } : {}),
         }),

--- a/apps/admin/components/intake/IntakeDoneClient.tsx
+++ b/apps/admin/components/intake/IntakeDoneClient.tsx
@@ -126,9 +126,15 @@ function buildContinueUrl(token: string, values: Readonly<Record<string, unknown
   const firstName = values.firstName;
   const lastName = values.lastName;
   const email = values.email;
+  const ageRange = values.ageRange;
   if (typeof firstName === "string") params.set("firstName", firstName);
   if (typeof lastName === "string") params.set("lastName", lastName);
   if (typeof email === "string") params.set("email", email);
+  // ageRange propagation per #1036 — persisted as CallerAttribute
+  // `intake.ageRange` on /join/[token] POST. `under-18` is rejected by
+  // `ageBand.adultOnly()` at intake, so this should never be present
+  // as that value, but the route handler defends against URL tampering.
+  if (typeof ageRange === "string") params.set("ageRange", ageRange);
   const qs = params.toString();
   return `/join/${encodeURIComponent(token)}${qs ? `?${qs}` : ""}`;
 }

--- a/apps/admin/lib/validation/schemas.ts
+++ b/apps/admin/lib/validation/schemas.ts
@@ -13,6 +13,24 @@ export const emailSchema = z.string().email("Invalid email address").max(254).tr
 export const nameSchema = z.string().min(1, "Name is required").max(100).trim();
 export const tokenSchema = z.string().min(1, "Token is required").max(256);
 
+/**
+ * GDPR age-band enum. Source of truth: `AGE_BAND_VALUES` from
+ * `@tallyseal/regulations-gdpr` (re-exported via `@/lib/intake/tallyseal`).
+ * Inlined here to keep `lib/validation/` free of intake/tallyseal coupling.
+ * Keep in sync if the upstream tuple changes.
+ */
+const AGE_BAND_VALUES = [
+  "under-18",
+  "18-24",
+  "25-34",
+  "35-44",
+  "45-54",
+  "55-64",
+  "65-plus",
+  "prefer-not-to-say",
+] as const;
+export const ageBandSchema = z.enum(AGE_BAND_VALUES);
+
 // ---------------------------------------------------------------------------
 // Route-specific schemas
 // ---------------------------------------------------------------------------
@@ -29,6 +47,16 @@ export const joinPostSchema = z.object({
   firstName: nameSchema,
   lastName: nameSchema,
   email: emailSchema,
+  /**
+   * Age band declared at intake. Propagated to `CallerAttribute` keyed
+   * `intake.ageRange` (scope `GLOBAL`) so the adult-only declaration
+   * has a persisted compliance trail post-handoff. `under-18` is the
+   * `ageBand.adultOnly()` rejected value — the intake spec gate
+   * (`isReady()` in `/api/intake/chat`) blocks it before the user
+   * reaches this endpoint; the route handler still defensively rejects
+   * it here against URL tampering. See #1036.
+   */
+  ageRange: ageBandSchema.optional(),
   /** Enroll in a specific course (playbook) instead of all cohort playbooks */
   playbookId: z.string().uuid().optional(),
   /** Skip onboarding wizard + surveys — go straight to teaching */

--- a/apps/admin/tests/api/join-token-agerange.test.ts
+++ b/apps/admin/tests/api/join-token-agerange.test.ts
@@ -18,6 +18,19 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 // MOCK SETUP
 // =====================================================
 
+/** Build a Request with a NextRequest-shaped `cookies.get()` stub. */
+function makeRequest(body: Record<string, unknown>): Request {
+  const req = new Request("http://localhost/api/join/validtok", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+  Object.defineProperty(req, "cookies", {
+    value: { get: () => undefined },
+  });
+  return req;
+}
+
 const mockPrisma = {
   cohortGroup: {
     findUnique: vi.fn(),
@@ -89,15 +102,11 @@ describe("/api/join/[token] — ageRange propagation (#1036)", () => {
     );
 
     const { POST } = await import("../../app/api/join/[token]/route");
-    const request = new Request("http://localhost/api/join/validtok", {
-      method: "POST",
-      body: JSON.stringify({
-        firstName: "Tessa",
-        lastName: "Bloom",
-        email: "tessa@example.com",
-        ageRange: "25-34",
-      }),
-      headers: { "Content-Type": "application/json" },
+    const request = makeRequest({
+      firstName: "Tessa",
+      lastName: "Bloom",
+      email: "tessa@example.com",
+      ageRange: "25-34",
     });
     await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
 
@@ -125,15 +134,11 @@ describe("/api/join/[token] — ageRange propagation (#1036)", () => {
 
   it("returns 400 for ageRange=under-18 (defence-in-depth vs URL tampering)", async () => {
     const { POST } = await import("../../app/api/join/[token]/route");
-    const request = new Request("http://localhost/api/join/validtok", {
-      method: "POST",
-      body: JSON.stringify({
-        firstName: "Tessa",
-        lastName: "Bloom",
-        email: "tessa@example.com",
-        ageRange: "under-18",
-      }),
-      headers: { "Content-Type": "application/json" },
+    const request = makeRequest({
+      firstName: "Tessa",
+      lastName: "Bloom",
+      email: "tessa@example.com",
+      ageRange: "under-18",
     });
     const response = await POST(request as never, {
       params: Promise.resolve({ token: "validtok" }),
@@ -165,14 +170,10 @@ describe("/api/join/[token] — ageRange propagation (#1036)", () => {
     );
 
     const { POST } = await import("../../app/api/join/[token]/route");
-    const request = new Request("http://localhost/api/join/validtok", {
-      method: "POST",
-      body: JSON.stringify({
-        firstName: "Alice",
-        lastName: "Smith",
-        email: "alice@school.com",
-      }),
-      headers: { "Content-Type": "application/json" },
+    const request = makeRequest({
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@school.com",
     });
     await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
 

--- a/apps/admin/tests/api/join-token-agerange.test.ts
+++ b/apps/admin/tests/api/join-token-agerange.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for #1036 — ageRange propagation through /api/join/[token].
+ *
+ * Lives in its own file because `tests/api/join-token.test.ts` is in
+ * the vitest quarantine list (ratchet `quarantined_tests` baseline 37).
+ * Keeping the #1036 surface unquarantined ensures regressions to the
+ * propagation gap surface immediately in CI.
+ *
+ * Covered behaviours:
+ *   1. Valid ageRange → CallerAttribute.upsert with intake.ageRange key
+ *   2. ageRange === "under-18" → 400 BEFORE any DB lookup (defence-in-depth)
+ *   3. Omitted ageRange → no CallerAttribute write (back-compat preserved)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// =====================================================
+// MOCK SETUP
+// =====================================================
+
+const mockPrisma = {
+  cohortGroup: {
+    findUnique: vi.fn(),
+  },
+  user: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+  },
+  caller: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+  callerCohortMembership: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+  callerAttribute: {
+    upsert: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+  db: (tx?: unknown) => tx ?? mockPrisma,
+}));
+
+vi.mock("next-auth/jwt", () => ({
+  encode: vi.fn().mockResolvedValue("mock-jwt-token"),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ ok: true }),
+  getClientIP: vi.fn().mockReturnValue("127.0.0.1"),
+}));
+
+vi.mock("@/lib/enrollment", () => ({
+  enrollCaller: vi.fn().mockResolvedValue(undefined),
+  enrollCallerInCohortPlaybooks: vi.fn().mockResolvedValue(undefined),
+}));
+
+// =====================================================
+// TESTS
+// =====================================================
+
+describe("/api/join/[token] — ageRange propagation (#1036)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.NEXTAUTH_SECRET = "test-secret";
+  });
+
+  it("writes intake.ageRange CallerAttribute when ageRange is provided (new-user path)", async () => {
+    mockPrisma.cohortGroup.findUnique.mockResolvedValue({
+      id: "cohort-1",
+      name: "Year 10",
+      isActive: true,
+      joinToken: "validtok",
+      domainId: "domain-1",
+      domain: { id: "domain-1" },
+    });
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue({ id: "new-user-1", email: "tessa@example.com" });
+    mockPrisma.caller.create.mockResolvedValue({ id: "new-caller-1" });
+    mockPrisma.callerAttribute.upsert.mockResolvedValue({});
+    mockPrisma.callerCohortMembership.create.mockResolvedValue({});
+    mockPrisma.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma),
+    );
+
+    const { POST } = await import("../../app/api/join/[token]/route");
+    const request = new Request("http://localhost/api/join/validtok", {
+      method: "POST",
+      body: JSON.stringify({
+        firstName: "Tessa",
+        lastName: "Bloom",
+        email: "tessa@example.com",
+        ageRange: "25-34",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
+
+    expect(mockPrisma.callerAttribute.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          callerId_key_scope: {
+            callerId: "new-caller-1",
+            key: "intake.ageRange",
+            scope: "GLOBAL",
+          },
+        },
+        create: expect.objectContaining({
+          callerId: "new-caller-1",
+          key: "intake.ageRange",
+          scope: "GLOBAL",
+          valueType: "STRING",
+          stringValue: "25-34",
+          sourceSpecSlug: "EnrollmentIntake",
+        }),
+        update: { stringValue: "25-34" },
+      }),
+    );
+  });
+
+  it("returns 400 for ageRange=under-18 (defence-in-depth vs URL tampering)", async () => {
+    const { POST } = await import("../../app/api/join/[token]/route");
+    const request = new Request("http://localhost/api/join/validtok", {
+      method: "POST",
+      body: JSON.stringify({
+        firstName: "Tessa",
+        lastName: "Bloom",
+        email: "tessa@example.com",
+        ageRange: "under-18",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const response = await POST(request as never, {
+      params: Promise.resolve({ token: "validtok" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("Under-18");
+    // Proves the gate fires BEFORE any DB lookup.
+    expect(mockPrisma.cohortGroup.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
+  });
+
+  it("skips CallerAttribute write when ageRange is omitted", async () => {
+    mockPrisma.cohortGroup.findUnique.mockResolvedValue({
+      id: "cohort-1",
+      name: "Year 10",
+      isActive: true,
+      joinToken: "validtok",
+      domainId: "domain-1",
+      domain: { id: "domain-1" },
+    });
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue({ id: "new-user-1", email: "alice@school.com" });
+    mockPrisma.caller.create.mockResolvedValue({ id: "new-caller-1" });
+    mockPrisma.callerCohortMembership.create.mockResolvedValue({});
+    mockPrisma.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma),
+    );
+
+    const { POST } = await import("../../app/api/join/[token]/route");
+    const request = new Request("http://localhost/api/join/validtok", {
+      method: "POST",
+      body: JSON.stringify({
+        firstName: "Alice",
+        lastName: "Smith",
+        email: "alice@school.com",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
+
+    expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/api/join-token.test.ts
+++ b/apps/admin/tests/api/join-token.test.ts
@@ -27,6 +27,9 @@ const mockPrisma = {
     findFirst: vi.fn(),
     create: vi.fn(),
   },
+  callerAttribute: {
+    upsert: vi.fn(),
+  },
   $transaction: vi.fn(),
 };
 
@@ -402,6 +405,106 @@ describe("/api/join/[token]", () => {
 
       expect(response.status).toBe(404);
       expect(data.error).toBe("Invalid or expired join link");
+    });
+
+    // ===================================================
+    // #1036 — ageRange propagation to CallerAttribute
+    // ===================================================
+    it("#1036 — writes intake.ageRange CallerAttribute when ageRange is provided (new-user path)", async () => {
+      mockPrisma.cohortGroup.findUnique.mockResolvedValue({
+        id: "cohort-1",
+        name: "Year 10",
+        isActive: true,
+        joinToken: "validtok",
+        domainId: "domain-1",
+        domain: { id: "domain-1" },
+      });
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({ id: "new-user-1", email: "tessa@example.com" });
+      mockPrisma.caller.create.mockResolvedValue({ id: "new-caller-1" });
+      mockPrisma.callerAttribute.upsert.mockResolvedValue({});
+      mockPrisma.callerCohortMembership.create.mockResolvedValue({});
+      mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma));
+
+      const { POST } = await import("../../app/api/join/[token]/route");
+      const request = new Request("http://localhost/api/join/validtok", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "Tessa",
+          lastName: "Bloom",
+          email: "tessa@example.com",
+          ageRange: "25-34",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
+
+      expect(mockPrisma.callerAttribute.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { callerId_key_scope: { callerId: "new-caller-1", key: "intake.ageRange", scope: "GLOBAL" } },
+          create: expect.objectContaining({
+            callerId: "new-caller-1",
+            key: "intake.ageRange",
+            scope: "GLOBAL",
+            valueType: "STRING",
+            stringValue: "25-34",
+            sourceSpecSlug: "EnrollmentIntake",
+          }),
+          update: { stringValue: "25-34" },
+        }),
+      );
+    });
+
+    it("#1036 — returns 400 for ageRange=under-18 (defence-in-depth vs URL tampering)", async () => {
+      const { POST } = await import("../../app/api/join/[token]/route");
+      const request = new Request("http://localhost/api/join/validtok", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "Tessa",
+          lastName: "Bloom",
+          email: "tessa@example.com",
+          ageRange: "under-18",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain("Under-18");
+      // Defence-in-depth fires BEFORE any DB lookup — proves the gate runs early.
+      expect(mockPrisma.cohortGroup.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
+    });
+
+    it("#1036 — skips CallerAttribute write when ageRange is omitted", async () => {
+      mockPrisma.cohortGroup.findUnique.mockResolvedValue({
+        id: "cohort-1",
+        name: "Year 10",
+        isActive: true,
+        joinToken: "validtok",
+        domainId: "domain-1",
+        domain: { id: "domain-1" },
+      });
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({ id: "new-user-1", email: "alice@school.com" });
+      mockPrisma.caller.create.mockResolvedValue({ id: "new-caller-1" });
+      mockPrisma.callerCohortMembership.create.mockResolvedValue({});
+      mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma));
+
+      const { POST } = await import("../../app/api/join/[token]/route");
+      const request = new Request("http://localhost/api/join/validtok", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "Alice",
+          lastName: "Smith",
+          email: "alice@school.com",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
+
+      expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/admin/tests/api/join-token.test.ts
+++ b/apps/admin/tests/api/join-token.test.ts
@@ -27,9 +27,6 @@ const mockPrisma = {
     findFirst: vi.fn(),
     create: vi.fn(),
   },
-  callerAttribute: {
-    upsert: vi.fn(),
-  },
   $transaction: vi.fn(),
 };
 
@@ -405,106 +402,6 @@ describe("/api/join/[token]", () => {
 
       expect(response.status).toBe(404);
       expect(data.error).toBe("Invalid or expired join link");
-    });
-
-    // ===================================================
-    // #1036 — ageRange propagation to CallerAttribute
-    // ===================================================
-    it("#1036 — writes intake.ageRange CallerAttribute when ageRange is provided (new-user path)", async () => {
-      mockPrisma.cohortGroup.findUnique.mockResolvedValue({
-        id: "cohort-1",
-        name: "Year 10",
-        isActive: true,
-        joinToken: "validtok",
-        domainId: "domain-1",
-        domain: { id: "domain-1" },
-      });
-      mockPrisma.user.findUnique.mockResolvedValue(null);
-      mockPrisma.user.create.mockResolvedValue({ id: "new-user-1", email: "tessa@example.com" });
-      mockPrisma.caller.create.mockResolvedValue({ id: "new-caller-1" });
-      mockPrisma.callerAttribute.upsert.mockResolvedValue({});
-      mockPrisma.callerCohortMembership.create.mockResolvedValue({});
-      mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma));
-
-      const { POST } = await import("../../app/api/join/[token]/route");
-      const request = new Request("http://localhost/api/join/validtok", {
-        method: "POST",
-        body: JSON.stringify({
-          firstName: "Tessa",
-          lastName: "Bloom",
-          email: "tessa@example.com",
-          ageRange: "25-34",
-        }),
-        headers: { "Content-Type": "application/json" },
-      });
-      await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
-
-      expect(mockPrisma.callerAttribute.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { callerId_key_scope: { callerId: "new-caller-1", key: "intake.ageRange", scope: "GLOBAL" } },
-          create: expect.objectContaining({
-            callerId: "new-caller-1",
-            key: "intake.ageRange",
-            scope: "GLOBAL",
-            valueType: "STRING",
-            stringValue: "25-34",
-            sourceSpecSlug: "EnrollmentIntake",
-          }),
-          update: { stringValue: "25-34" },
-        }),
-      );
-    });
-
-    it("#1036 — returns 400 for ageRange=under-18 (defence-in-depth vs URL tampering)", async () => {
-      const { POST } = await import("../../app/api/join/[token]/route");
-      const request = new Request("http://localhost/api/join/validtok", {
-        method: "POST",
-        body: JSON.stringify({
-          firstName: "Tessa",
-          lastName: "Bloom",
-          email: "tessa@example.com",
-          ageRange: "under-18",
-        }),
-        headers: { "Content-Type": "application/json" },
-      });
-      const response = await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
-      const data = await response.json();
-
-      expect(response.status).toBe(400);
-      expect(data.error).toContain("Under-18");
-      // Defence-in-depth fires BEFORE any DB lookup — proves the gate runs early.
-      expect(mockPrisma.cohortGroup.findUnique).not.toHaveBeenCalled();
-      expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
-    });
-
-    it("#1036 — skips CallerAttribute write when ageRange is omitted", async () => {
-      mockPrisma.cohortGroup.findUnique.mockResolvedValue({
-        id: "cohort-1",
-        name: "Year 10",
-        isActive: true,
-        joinToken: "validtok",
-        domainId: "domain-1",
-        domain: { id: "domain-1" },
-      });
-      mockPrisma.user.findUnique.mockResolvedValue(null);
-      mockPrisma.user.create.mockResolvedValue({ id: "new-user-1", email: "alice@school.com" });
-      mockPrisma.caller.create.mockResolvedValue({ id: "new-caller-1" });
-      mockPrisma.callerCohortMembership.create.mockResolvedValue({});
-      mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => unknown) => fn(mockPrisma));
-
-      const { POST } = await import("../../app/api/join/[token]/route");
-      const request = new Request("http://localhost/api/join/validtok", {
-        method: "POST",
-        body: JSON.stringify({
-          firstName: "Alice",
-          lastName: "Smith",
-          email: "alice@school.com",
-        }),
-        headers: { "Content-Type": "application/json" },
-      });
-      await POST(request as never, { params: Promise.resolve({ token: "validtok" }) });
-
-      expect(mockPrisma.callerAttribute.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/admin/tests/lib/validation.test.ts
+++ b/apps/admin/tests/lib/validation.test.ts
@@ -84,6 +84,49 @@ describe("lib/validation", () => {
         expect(result.data.email).toBe("jane@example.com");
       }
     });
+
+    // #1036 — ageRange propagation
+    it("accepts a valid GDPR age band", () => {
+      const result = validateBody(joinPostSchema, {
+        firstName: "Tessa",
+        lastName: "Bloom",
+        email: "tessa@example.com",
+        ageRange: "25-34",
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.data.ageRange).toBe("25-34");
+    });
+
+    it("treats ageRange as optional", () => {
+      const result = validateBody(joinPostSchema, {
+        firstName: "Tessa",
+        lastName: "Bloom",
+        email: "tessa@example.com",
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.data.ageRange).toBeUndefined();
+    });
+
+    it("rejects an invalid age-band string", () => {
+      const result = validateBody(joinPostSchema, {
+        firstName: "Tessa",
+        lastName: "Bloom",
+        email: "tessa@example.com",
+        ageRange: "twenty-something",
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("accepts under-18 at schema level (route handler enforces the adult-only policy)", () => {
+      const result = validateBody(joinPostSchema, {
+        firstName: "Tessa",
+        lastName: "Bloom",
+        email: "tessa@example.com",
+        ageRange: "under-18",
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.data.ageRange).toBe("under-18");
+    });
   });
 
   describe("authLoginSchema", () => {


### PR DESCRIPTION
## Summary

Closes the last-mile gap from the 3-day ageRange arc (#1000/#1004/#1005/#1007): the spec captures + validates `ageRange` (incl. `adultOnly` invariant), but the value never reached `Caller`. `IntakeDoneClient`'s `buildContinueUrl` dropped it, `joinPostSchema` silently discarded it, and `/api/join/[token]` never persisted.

## Schema choice — Option C (CallerAttribute), per TL review on #1036

| | |
|---|---|
| Key | `"intake.ageRange"` |
| Scope | `"GLOBAL"` |
| valueType | `"STRING"` |
| sourceSpecSlug | `"EnrollmentIntake"` |
| Migration | **None** — `Caller` table untouched → `/vm-cp` |

Rejected Option A (`Caller.ageRange String?` column) — would add nullable column to a hot table for an intake-flow-only field. CallerAttribute is the existing pattern for person-level soft fields.

## Four wire-up sites

1. `components/intake/IntakeDoneClient.tsx` — `buildContinueUrl` adds `ageRange` to query
2. `app/join/[token]/page.tsx` — POSTs `ageRange` via existing optional-spread pattern
3. `lib/validation/schemas.ts` — `ageBandSchema` (8-value GDPR enum) + `joinPostSchema.ageRange`
4. `app/api/join/[token]/route.ts` — under-18 defence-in-depth (400) + `CallerAttribute.upsert` on **both** new-caller paths (existing-user + new-user transaction)

## Defence-in-depth: under-18

The intake spec's `ageBand.adultOnly()` rejects `under-18` before `ProjectionCommit` fires. If a tampered URL bypasses this and POSTs `ageRange=under-18` directly to `/api/join/[token]`, the route handler returns **400** _before any DB lookup_, preserving the compliance trail.

## Test plan

- [x] `tests/lib/validation.test.ts` — 4 `joinPostSchema` cases (valid band, optional, invalid string, under-18 at schema level)
- [x] `tests/api/join-token-agerange.test.ts` — 3 route-level cases (CallerAttribute.upsert with correct shape, under-18 → 400 with no DB call, omitted → no upsert)
- [x] All 16 tests pass on hf-dev (13 validation + 3 route)
- [x] tsc clean on changed files
- [ ] Smoke: real intake flow with `ageRange=25-34` → join → verify Caller has `intake.ageRange` attribute (post-merge in dev)
- [ ] Smoke: `?ageRange=under-18` URL tampering → 400 (post-merge)

## Quarantine note

`tests/api/join-token.test.ts` is in the vitest quarantine list (ratchet `quarantined_tests` baseline 37). New tests landed at `tests/api/join-token-agerange.test.ts` so regressions surface immediately rather than being silently quarantined.

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)