### PR TITLE
feat: Course Variant API + button (#1034)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -145,11 +145,10 @@ async function loadCurrentModuleContext(
       let filteredRefs = allRefs;
       if (allRefs.length > 0) {
         try {
-          const curriculumId = (await prisma.curriculum.findFirst({
-            where: { playbookId: resolvedPlaybookId },
-            orderBy: { createdAt: "asc" },
-            select: { id: true },
-          }))?.id;
+          // #1034 — resolveCurriculumIdForPlaybook reads PlaybookCurriculum
+          // first (variant Playbooks share the parent's Curriculum) and
+          // falls back to the deprecated Curriculum.playbookId column.
+          const curriculumId = await resolveCurriculumIdForPlaybook(resolvedPlaybookId);
           if (curriculumId) {
             const excluded = await prisma.learningObjective.findMany({
               where: {
@@ -329,7 +328,15 @@ async function loadCurrentModuleContext(
 
   // Path 2: Playbook curriculum (direct link via playbookId)
   if (resolvedPlaybookId) {
-    const pbCurriculum = await prisma.curriculum.findFirst({
+    // #1034 — PlaybookCurriculum-first read; falls back to deprecated
+    // Curriculum.playbookId column. Variant Playbooks share the parent's
+    // Curriculum via a `linked` row.
+    const pbcLink = await prisma.playbookCurriculum.findFirst({
+      where: { playbookId: resolvedPlaybookId },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: { curriculum: { select: { slug: true, notableInfo: true } } },
+    });
+    const pbCurriculum = pbcLink?.curriculum ?? await prisma.curriculum.findFirst({
       where: { playbookId: resolvedPlaybookId },
       orderBy: { updatedAt: "desc" },
       select: { slug: true, notableInfo: true },
@@ -2776,7 +2783,13 @@ async function trackCurriculumAfterCall(
     try {
       const enrolledPbId = await resolvePlaybookId(callerId);
       if (enrolledPbId) {
-        const pbCurr = await prisma.curriculum.findFirst({
+        // #1034 — PlaybookCurriculum-first read with deprecated-column fallback.
+        const pbcLink = await prisma.playbookCurriculum.findFirst({
+          where: { playbookId: enrolledPbId },
+          orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+          select: { curriculum: { select: { slug: true, notableInfo: true } } },
+        });
+        const pbCurr = pbcLink?.curriculum ?? await prisma.curriculum.findFirst({
           where: { playbookId: enrolledPbId },
           orderBy: { updatedAt: "desc" },
           select: { slug: true, notableInfo: true },
@@ -2926,7 +2939,13 @@ async function updateTpMasteryAfterCall(
   // Try playbook curriculum first (direct link)
   const enrolledPbForAssess = await resolvePlaybookId(callerId);
   if (enrolledPbForAssess) {
-    const pbCurr = await prisma.curriculum.findFirst({
+    // #1034 — PlaybookCurriculum-first read with deprecated-column fallback.
+    const pbcLink = await prisma.playbookCurriculum.findFirst({
+      where: { playbookId: enrolledPbForAssess },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: { curriculum: { select: { slug: true } } },
+    });
+    const pbCurr = pbcLink?.curriculum ?? await prisma.curriculum.findFirst({
       where: { playbookId: enrolledPbForAssess },
       orderBy: { updatedAt: "desc" },
       select: { slug: true },

--- a/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
@@ -257,8 +257,9 @@ export async function PUT(
 
     // #834 — lesson plan flows into compose via the modules / curriculum
     // loaders (session bucketing, target LOs, assertion routing). Bump.
-    const playbookId = await resolvePlaybookIdForCurriculum(curriculumId);
-    if (playbookId) await bumpPlaybookComposeTimestamp(playbookId);
+    // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
+    const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+    for (const pbId of playbookIds) await bumpPlaybookComposeTimestamp(pbId);
 
     return NextResponse.json({ ok: true, plan, entries: plan.entries, ...(staleWarning ? { warning: staleWarning } : {}) });
   } catch (error: any) {

--- a/apps/admin/app/api/curricula/[curriculumId]/modules/[moduleId]/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/modules/[moduleId]/route.ts
@@ -225,8 +225,9 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     // #834 — CurriculumModule + LearningObjective flow into the composed
     // prompt via the curriculum / modules loaders. Bump the owning
     // Playbook so the staleness check picks this up on next call.
-    const playbookId = await resolvePlaybookIdForCurriculum(curriculumId);
-    if (playbookId) await bumpPlaybookComposeTimestamp(playbookId);
+    // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
+    const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+    for (const pbId of playbookIds) await bumpPlaybookComposeTimestamp(pbId);
 
     return NextResponse.json({ ok: true, module: result });
   } catch (error: any) {
@@ -258,8 +259,9 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
     await prisma.curriculumModule.delete({ where: { id: moduleId } });
 
     // #834 — deletion changes which modules feed into compose.
-    const playbookId = await resolvePlaybookIdForCurriculum(curriculumId);
-    if (playbookId) await bumpPlaybookComposeTimestamp(playbookId);
+    // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
+    const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+    for (const pbId of playbookIds) await bumpPlaybookComposeTimestamp(pbId);
 
     return NextResponse.json({ ok: true });
   } catch (error: any) {

--- a/apps/admin/app/api/curricula/[curriculumId]/modules/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/modules/route.ts
@@ -243,8 +243,9 @@ export async function POST(req: NextRequest, { params }: Params) {
 
     // #834 — bulk upsert may have created, updated, or rewritten LOs.
     // Stamp the owning playbook so callers recompose on next call.
-    const playbookId = await resolvePlaybookIdForCurriculum(curriculumId);
-    if (playbookId) await bumpPlaybookComposeTimestamp(playbookId);
+    // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
+    const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+    for (const pbId of playbookIds) await bumpPlaybookComposeTimestamp(pbId);
 
     return NextResponse.json({ ok: true, modules, count: result.length }, { status: 201 });
   } catch (error: any) {
@@ -280,8 +281,9 @@ export async function PUT(req: NextRequest, { params }: Params) {
     );
 
     // #834 — sortOrder feeds into modules-loader scheduling. Bump.
-    const playbookId = await resolvePlaybookIdForCurriculum(curriculumId);
-    if (playbookId) await bumpPlaybookComposeTimestamp(playbookId);
+    // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
+    const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+    for (const pbId of playbookIds) await bumpPlaybookComposeTimestamp(pbId);
 
     return NextResponse.json({ ok: true });
   } catch (error: any) {

--- a/apps/admin/app/api/playbooks/[playbookId]/variant/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/variant/route.ts
@@ -1,0 +1,94 @@
+/**
+ * @api POST /api/playbooks/:playbookId/variant
+ * @visibility public
+ * @scope playbook:write
+ * @auth session (OPERATOR or higher)
+ * @tags playbooks, variants, course-product-line
+ * @description Create a sibling Variant Playbook against the parent's
+ *   shared Curriculum + Subject + Source library. Variants share content
+ *   authority but carry their own teaching profile (Pop Quiz / Revision
+ *   Aid / Exam Assessment). Mastery flows across siblings via shared
+ *   CurriculumModule UUIDs — see CC-E in docs/chain-contracts.md. #1034.
+ * @pathParam playbookId string - The PARENT Playbook to sibling-clone.
+ * @body name string - Display name for the new variant Course (required, max 200).
+ * @body preset "revision"|"popquiz"|"exam" - Optional teaching-profile preset (config seed only — forward-declared keys, no runtime effect yet).
+ * @body reason string - Free-form audit trail note (optional).
+ * @response 201 { ok: true, variantPlaybookId: string, sharedCurriculumId: string|null, subjectLinks: number, sourceLinks: number, unlinkedDuplicateSubjects: number }
+ * @response 400 { ok: false, error: string }
+ * @response 401 { ok: false, error: "Unauthorized" }
+ * @response 404 { ok: false, error: "Parent Playbook not found" }
+ * @response 500 { ok: false, error: string }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { createPlaybookVariant, type VariantPreset } from "@/lib/playbooks/create-variant";
+
+const bodySchema = z.object({
+  name: z.string().trim().min(1, "name is required").max(200, "name must be 200 chars or fewer"),
+  preset: z.enum(["revision", "popquiz", "exam"]).optional(),
+  reason: z.string().trim().max(500).optional(),
+}).strict();
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ playbookId: string }> },
+) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const { playbookId: parentPlaybookId } = await params;
+  if (!parentPlaybookId) {
+    return NextResponse.json(
+      { ok: false, error: "playbookId path parameter is required" },
+      { status: 400 },
+    );
+  }
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    const raw = await request.json();
+    body = bodySchema.parse(raw);
+  } catch (e: unknown) {
+    const message = e instanceof z.ZodError
+      ? e.errors.map((issue) => issue.message).join("; ")
+      : (e instanceof Error ? e.message : "Invalid JSON body");
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
+
+  try {
+    const result = await createPlaybookVariant({
+      parentPlaybookId,
+      name: body.name,
+      preset: body.preset as VariantPreset | undefined,
+      actorUserId: auth.session.user.id,
+      reason: body.reason,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        variantPlaybookId: result.variantPlaybookId,
+        sharedCurriculumId: result.sharedCurriculumId,
+        subjectLinks: result.subjectLinks,
+        sourceLinks: result.sourceLinks,
+        unlinkedDuplicateSubjects: result.unlinkedDuplicateSubjects,
+      },
+      { status: 201 },
+    );
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (message.includes("not found")) {
+      return NextResponse.json(
+        { ok: false, error: message },
+        { status: 404 },
+      );
+    }
+    console.error("[playbooks/:id/variant] POST error:", e);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -177,6 +177,12 @@ export default function CourseDetailPage() {
   const [showSimModal, setShowSimModal] = useState(false);
   const [showFullRegen, setShowFullRegen] = useState(false);
   const [showDryRun, setShowDryRun] = useState(false);
+  // #1034 — Create Variant flow
+  const [showVariantModal, setShowVariantModal] = useState(false);
+  const [variantName, setVariantName] = useState('');
+  const [variantPreset, setVariantPreset] = useState<'' | 'revision' | 'popquiz' | 'exam'>('');
+  const [variantCreating, setVariantCreating] = useState(false);
+  const [variantError, setVariantError] = useState<string | null>(null);
   const [joinToken, setJoinToken] = useState<string | null>(null);
   const [joinCopied, setJoinCopied] = useState(false);
   const [chatJoinCopied, setChatJoinCopied] = useState(false);
@@ -627,6 +633,42 @@ export default function CourseDetailPage() {
     } finally {
       setDeleting(false);
       setShowDeleteConfirm(false);
+    }
+  };
+
+  // ── Create Variant handler (#1034) ──
+  // Creates a sibling Course sharing the parent's Curriculum + Subjects +
+  // Sources. The new Course gets its own teaching profile (Pop Quiz /
+  // Revision Aid / Exam Assessment via preset) but Caller mastery flows
+  // naturally between siblings — same shared CurriculumModule UUIDs.
+  const handleCreateVariant = async () => {
+    if (!detail) return;
+    const name = variantName.trim();
+    if (!name) {
+      setVariantError('Variant name is required.');
+      return;
+    }
+    setVariantCreating(true);
+    setVariantError(null);
+    try {
+      const res = await fetch(`/api/playbooks/${detail.id}/variant`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          ...(variantPreset ? { preset: variantPreset } : {}),
+        }),
+      });
+      const data = await res.json();
+      if (res.ok && data.ok) {
+        router.push(`/x/courses/${data.variantPlaybookId}`);
+      } else {
+        setVariantError(data.error || `Failed (status ${res.status})`);
+      }
+    } catch (e) {
+      setVariantError(e instanceof Error ? e.message : 'Create Variant failed');
+    } finally {
+      setVariantCreating(false);
     }
   };
 
@@ -1147,6 +1189,21 @@ export default function CourseDetailPage() {
             <PlayCircle size={14} />
             Try It
           </button>
+          {isOperator && (
+            <button
+              className="hf-btn hf-btn-secondary hf-nowrap"
+              onClick={() => {
+                setVariantName('');
+                setVariantPreset('');
+                setVariantError(null);
+                setShowVariantModal(true);
+              }}
+              title="Create a sibling Course sharing this Course's content but with a different teaching profile (Pop Quiz, Revision Aid, Exam Assessment)"
+            >
+              <Copy size={14} />
+              Create Variant
+            </button>
+          )}
           <Link
             href={`/x/playbooks/${detail.id}`}
             className="hf-btn hf-btn-secondary hf-nowrap"
@@ -1803,6 +1860,93 @@ export default function CourseDetailPage() {
             window.location.reload();
           }}
         />
+      )}
+
+      {/* #1034 — Create Variant modal */}
+      {showVariantModal && detail && (
+        <div
+          className="hf-modal-overlay"
+          onClick={() => !variantCreating && setShowVariantModal(false)}
+        >
+          <div
+            className="hf-modal"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="hf-modal-header">
+              <h3 className="hf-modal-title">Create Variant Course</h3>
+              <button
+                className="hf-btn-ghost hf-text-sm"
+                onClick={() => setShowVariantModal(false)}
+                disabled={variantCreating}
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="hf-modal-body">
+              <p className="hf-text-sm hf-text-muted hf-mb-md">
+                Creates a sibling Course that shares <strong>{detail.name}</strong>&rsquo;s
+                Curriculum, Subjects, and Sources. Learner mastery flows naturally
+                between the two — the variant carries its own teaching profile.
+              </p>
+
+              <label className="hf-label hf-mb-xs" htmlFor="variant-name">
+                Variant Course name
+              </label>
+              <input
+                id="variant-name"
+                type="text"
+                className="hf-input hf-w-full hf-mb-md"
+                placeholder="Pop Quiz — The Standard"
+                value={variantName}
+                onChange={(e) => setVariantName(e.target.value)}
+                disabled={variantCreating}
+                autoFocus
+                maxLength={200}
+              />
+
+              <label className="hf-label hf-mb-xs" htmlFor="variant-preset">
+                Teaching profile preset (optional)
+              </label>
+              <select
+                id="variant-preset"
+                className="hf-select hf-w-full hf-mb-md"
+                value={variantPreset}
+                onChange={(e) =>
+                  setVariantPreset(e.target.value as '' | 'revision' | 'popquiz' | 'exam')
+                }
+                disabled={variantCreating}
+              >
+                <option value="">None — empty config</option>
+                <option value="revision">Revision Aid (coaching-led, ~25 min)</option>
+                <option value="popquiz">Pop Quiz (assessment-led, ~8 min)</option>
+                <option value="exam">Exam Assessment (discussion-led, ~35 min)</option>
+              </select>
+
+              {variantError && (
+                <p className="hf-text-sm hf-text-error hf-mb-md" role="alert">
+                  {variantError}
+                </p>
+              )}
+            </div>
+            <div className="hf-modal-footer">
+              <button
+                className="hf-btn hf-btn-secondary"
+                onClick={() => setShowVariantModal(false)}
+                disabled={variantCreating}
+              >
+                Cancel
+              </button>
+              <button
+                className="hf-btn hf-btn-primary"
+                onClick={handleCreateVariant}
+                disabled={variantCreating || !variantName.trim()}
+              >
+                {variantCreating ? 'Creating…' : 'Create Variant'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -1785,11 +1785,11 @@ async function handleListCurriculumModules(input: Record<string, any>) {
   }
 
   if (!curriculumId && playbookId) {
-    const curr = await prisma.curriculum.findFirst({
-      where: { playbookId },
-      select: { id: true },
-    });
-    if (!curr) {
+    // #1034 — variant Playbooks share the parent's Curriculum via
+    // PlaybookCurriculum; the helper handles both paths.
+    const { resolveCurriculumIdForPlaybook } = await import("@/lib/curriculum/resolve-module");
+    const resolved = await resolveCurriculumIdForPlaybook(playbookId);
+    if (!resolved) {
       return {
         ok: true,
         playbook_id: playbookId,
@@ -1799,7 +1799,7 @@ async function handleListCurriculumModules(input: Record<string, any>) {
         note: "No Curriculum linked to this playbook yet.",
       };
     }
-    curriculumId = curr.id;
+    curriculumId = resolved;
   }
 
   const modules = await prisma.curriculumModule.findMany({
@@ -1992,9 +1992,12 @@ async function handleUpdateCurriculumMetadata(input: Record<string, any>) {
   const curriculumId = typeof input.curriculum_id === "string" ? input.curriculum_id : "";
   if (!curriculumId) return { error: "curriculum_id is required" };
 
+  // #1034 — Don't read the deprecated `playbookId` column directly;
+  // resolve all sibling Playbooks via PlaybookCurriculum so the staleness
+  // bump fans out across the variant Course product line.
   const existing = await prisma.curriculum.findUnique({
     where: { id: curriculumId },
-    select: { id: true, name: true, playbookId: true },
+    select: { id: true, name: true },
   });
   if (!existing) return { error: `Curriculum ${curriculumId} not found.` };
 
@@ -2025,14 +2028,18 @@ async function handleUpdateCurriculumMetadata(input: Record<string, any>) {
     },
   });
 
+  // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
+  // pendingChange.scopeId is the representative (first = primary by ordering).
+  const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+  const representativePlaybookId: string | null = playbookIds[0] ?? null;
   let timestampBumped = false;
-  if (existing.playbookId) {
-    await bumpPlaybookComposeTimestamp(existing.playbookId);
+  for (const pbId of playbookIds) {
+    await bumpPlaybookComposeTimestamp(pbId);
     timestampBumped = true;
   }
 
   console.log(
-    `[admin-tools] Updated curriculum "${existing.name}" → "${updated.name}". Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped}. Reason: ${input.reason || "(not given)"}`,
+    `[admin-tools] Updated curriculum "${existing.name}" → "${updated.name}". Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped} (${playbookIds.length} sibling${playbookIds.length === 1 ? "" : "s"}). Reason: ${input.reason || "(not given)"}`,
   );
 
   // #873 follow-up — emit pendingChange when the timestamp bumped.
@@ -2041,7 +2048,7 @@ async function handleUpdateCurriculumMetadata(input: Record<string, any>) {
     timestampBumped && curFields.length > 0
       ? buildPendingChangePayload({
           scope: "playbook",
-          scopeId: existing.playbookId,
+          scopeId: representativePlaybookId,
           scopeLabel: `Curriculum ${existing.name}`,
           key: curFields[0],
           label: curFields[0],

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -1408,15 +1408,20 @@ async function handleUpdateCurriculumModule(input: Record<string, any>) {
     },
   });
 
-  const playbookId = await resolvePlaybookIdForCurriculum(existing.curriculumId);
+  // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
+  // The pendingChange payload below is scoped to the representative (first =
+  // primary by ordering of resolvePlaybookIdForCurriculum) so tray notifications
+  // stay focused, while the staleness bump fans out to every sibling.
+  const playbookIds = await resolvePlaybookIdForCurriculum(existing.curriculumId);
+  const playbookId: string | null = playbookIds[0] ?? null;
   let timestampBumped = false;
-  if (playbookId) {
-    await bumpPlaybookComposeTimestamp(playbookId);
+  for (const pbId of playbookIds) {
+    await bumpPlaybookComposeTimestamp(pbId);
     timestampBumped = true;
   }
 
   console.log(
-    `[admin-tools] Updated module "${existing.slug}". Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped}. Reason: ${input.reason || "(not given)"}`,
+    `[admin-tools] Updated module "${existing.slug}". Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped} (${playbookIds.length} sibling${playbookIds.length === 1 ? "" : "s"}). Reason: ${input.reason || "(not given)"}`,
   );
 
   // #873 follow-up — emit pendingChange when the timestamp bumped. AI
@@ -1941,17 +1946,20 @@ async function handleUpdateLearningObjective(input: Record<string, any>) {
     },
   });
 
+  // #1034 — CC-B fanout: bump every sibling Playbook sharing this Curriculum.
   let timestampBumped = false;
+  let siblingCount = 0;
   if (existing.module?.curriculumId) {
-    const playbookId = await resolvePlaybookIdForCurriculum(existing.module.curriculumId);
-    if (playbookId) {
-      await bumpPlaybookComposeTimestamp(playbookId);
+    const playbookIds = await resolvePlaybookIdForCurriculum(existing.module.curriculumId);
+    siblingCount = playbookIds.length;
+    for (const pbId of playbookIds) {
+      await bumpPlaybookComposeTimestamp(pbId);
       timestampBumped = true;
     }
   }
 
   console.log(
-    `[admin-tools] Updated LO ${existing.ref}. Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped}. Reason: ${input.reason || "(not given)"}`,
+    `[admin-tools] Updated LO ${existing.ref}. Fields: ${Object.keys(data).join(", ")}. composeInputsUpdatedAt bumped: ${timestampBumped} (${siblingCount} sibling${siblingCount === 1 ? "" : "s"}). Reason: ${input.reason || "(not given)"}`,
   );
 
   // #873 follow-up — emit pendingChange when the timestamp bumped.

--- a/apps/admin/lib/compose/bump-curriculum-fanout.ts
+++ b/apps/admin/lib/compose/bump-curriculum-fanout.ts
@@ -1,0 +1,70 @@
+/**
+ * Curriculum mutation fanout — CC-B (#1034).
+ *
+ * When a Curriculum-affecting mutation lands (LO write, module rename,
+ * assertion edit, lesson plan change), the compose-input staleness signal
+ * must reach EVERY sibling Playbook sharing the Curriculum via
+ * `PlaybookCurriculum`, not just the primary owner.
+ *
+ * Variant Playbooks (Pop Quiz, Revision Aid, Exam Assessment built from
+ * one Curriculum) all read the same `CurriculumModule.id` rows; when the
+ * teacher edits an LO, every variant's next call must recompose with the
+ * new content. Without fanout, only the primary Playbook would see the
+ * change and learners on the variants would receive stale prompts until
+ * an unrelated bump arrived.
+ *
+ * Extends the #825 stamp-on-write pattern documented in
+ * `lib/compose/staleness.ts` and `docs/chain-contracts.md` (Link 3
+ * sub-contract). Pipeline-internal writes do NOT bump (carve-out in
+ * `lib/compose/bump-timestamp.ts`) — only teacher / wizard / admin
+ * mutations call this fanout helper.
+ *
+ * Use this in NEW Curriculum-affecting write sites. Existing callers
+ * (#1034 Task 3) inline the equivalent resolve-then-loop pattern; they
+ * can migrate opportunistically.
+ */
+
+import {
+  resolvePlaybookIdForCurriculum,
+  resolvePlaybookIdForCurriculumModule,
+} from "@/lib/curriculum/resolve-playbook-for-curriculum";
+import { bumpPlaybookComposeTimestamp } from "./bump-timestamp";
+
+export interface FanoutResult {
+  /** Number of sibling Playbooks whose composeInputsUpdatedAt was bumped. */
+  count: number;
+  /** Representative Playbook (primary by ordering) — useful as the pendingChange.scopeId. */
+  representativePlaybookId: string | null;
+}
+
+/**
+ * Bump composeInputsUpdatedAt on every sibling Playbook linked to this
+ * Curriculum via `PlaybookCurriculum`. Falls back to the deprecated
+ * `Curriculum.playbookId` column when no join rows exist (transition).
+ */
+export async function bumpCurriculumComposeFanout(
+  curriculumId: string,
+): Promise<FanoutResult> {
+  const ids = await resolvePlaybookIdForCurriculum(curriculumId);
+  for (const id of ids) await bumpPlaybookComposeTimestamp(id);
+  return {
+    count: ids.length,
+    representativePlaybookId: ids[0] ?? null,
+  };
+}
+
+/**
+ * Bump composeInputsUpdatedAt on every sibling Playbook linked to the
+ * Curriculum that owns this CurriculumModule. Used by write sites that
+ * hold a `moduleId` (e.g. LO writes, module-scoped behaviour edits).
+ */
+export async function bumpCurriculumModuleComposeFanout(
+  moduleId: string,
+): Promise<FanoutResult> {
+  const ids = await resolvePlaybookIdForCurriculumModule(moduleId);
+  for (const id of ids) await bumpPlaybookComposeTimestamp(id);
+  return {
+    count: ids.length,
+    representativePlaybookId: ids[0] ?? null,
+  };
+}

--- a/apps/admin/lib/curriculum/resolve-module.ts
+++ b/apps/admin/lib/curriculum/resolve-module.ts
@@ -139,6 +139,24 @@ export async function resolveCurriculumIdForPlaybook(
   playbookId: string | null | undefined,
 ): Promise<string | null> {
   if (!playbookId) return null;
+
+  // #1034 — Prefer PlaybookCurriculum (join table). A variant Playbook has a
+  // `linked` row pointing at the parent's Curriculum; reading the deprecated
+  // Curriculum.playbookId column would silently miss it and the pipeline
+  // would skip module-aware composition for every variant Call.
+  // Order: primary before linked, then oldest first — matches the
+  // pre-#1034 convention of "the oldest Curriculum for this Playbook."
+  const join = await prisma.playbookCurriculum.findFirst({
+    where: { playbookId },
+    orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+    select: { curriculumId: true },
+  });
+  if (join) return join.curriculumId;
+
+  // Fallback: deprecated Curriculum.playbookId column. Rollback safety
+  // during the #1034 → #1038 transition window — covers the narrow case
+  // where a Curriculum write site hasn't yet been updated to dual-write.
+  // Dropped in #1038.
   const row = await prisma.curriculum.findFirst({
     where: { playbookId },
     orderBy: { createdAt: "asc" },

--- a/apps/admin/lib/curriculum/resolve-playbook-for-curriculum.ts
+++ b/apps/admin/lib/curriculum/resolve-playbook-for-curriculum.ts
@@ -1,46 +1,82 @@
 /**
- * Resolves the parent `Playbook.id` for a curriculum-side write site, so
- * the caller can invoke `bumpPlaybookComposeTimestamp` and propagate
- * compose-input staleness.
+ * Resolves the parent `Playbook.id`(s) for a curriculum-side write site, so
+ * the caller can invoke `bumpPlaybookComposeTimestamp` for each one and
+ * propagate compose-input staleness across all sibling Playbooks sharing
+ * the Curriculum.
  *
- * Three resolution paths exist depending on what FK the writer already
- * holds:
+ * Four resolution paths exist depending on what FK the writer holds:
  *
- *   1. From a `curriculumId` — `Curriculum.playbookId` (single FK).
- *   2. From a `curriculumModuleId` — `CurriculumModule → Curriculum →
- *      playbookId`.
+ *   1. From a `curriculumId` — every PlaybookCurriculum row pointing at
+ *      this curriculum (one Curriculum may be shared by N Playbooks).
+ *   2. From a `curriculumModuleId` — `CurriculumModule → Curriculum →`
+ *      then resolve as (1).
  *   3. From a `sourceId` — every `PlaybookSource` row pointing at this
  *      source (one source can be linked to multiple playbooks).
+ *   4. From a `specId` (AnalysisSpec) — every `PlaybookItem` row linking
+ *      this spec.
  *
- * Returns `string[]` for paths (3) and a single `string | null` for
- * paths (1) + (2). Callers always loop `for (const id of ids) await
- * bumpPlaybookComposeTimestamp(id)` — single-bump callers pass `[id]`.
+ * **All paths return `string[]`** so callers always iterate:
+ *
+ *     const ids = await resolvePlaybookIdForCurriculum(curriculumId);
+ *     for (const id of ids) await bumpPlaybookComposeTimestamp(id);
+ *
+ * Pre-#1034 paths (1) and (2) returned `string | null`. After #1034 they
+ * return `string[]` because variant Playbooks (CC-B fanout) require every
+ * sibling to receive the staleness bump.
  *
  * #834 — Story 8 of EPIC #832.
+ * #1034 — CC-B fanout: variant Playbooks share a Curriculum via
+ *         `PlaybookCurriculum`; mutations must fan out to all siblings.
  */
 
 import { prisma } from "@/lib/prisma";
 
+/**
+ * Returns every `Playbook.id` linked to this Curriculum via `PlaybookCurriculum`
+ * (siblings sharing the Curriculum). Falls back to the deprecated
+ * `Curriculum.playbookId` column if no join rows exist (transition safety).
+ *
+ * Signature changed from `string | null` to `string[]` in #1034 so a
+ * single Curriculum mutation can bump compose staleness on all siblings.
+ * Empty array when no playbook is linked.
+ */
 export async function resolvePlaybookIdForCurriculum(
   curriculumId: string,
-): Promise<string | null> {
-  if (!curriculumId) return null;
+): Promise<string[]> {
+  if (!curriculumId) return [];
+
+  const joins = await prisma.playbookCurriculum.findMany({
+    where: { curriculumId },
+    select: { playbookId: true },
+  });
+  if (joins.length > 0) return joins.map((j) => j.playbookId);
+
+  // Fallback: deprecated Curriculum.playbookId column. Dropped in #1038.
   const row = await prisma.curriculum.findUnique({
     where: { id: curriculumId },
     select: { playbookId: true },
   });
-  return row?.playbookId ?? null;
+  return row?.playbookId ? [row.playbookId] : [];
 }
 
+/**
+ * Returns every `Playbook.id` linked to the Curriculum that owns this
+ * CurriculumModule (siblings sharing the Curriculum).
+ *
+ * Signature changed from `string | null` to `string[]` in #1034.
+ */
 export async function resolvePlaybookIdForCurriculumModule(
   curriculumModuleId: string,
-): Promise<string | null> {
-  if (!curriculumModuleId) return null;
+): Promise<string[]> {
+  if (!curriculumModuleId) return [];
+
   const row = await prisma.curriculumModule.findUnique({
     where: { id: curriculumModuleId },
-    select: { curriculum: { select: { playbookId: true } } },
+    select: { curriculumId: true },
   });
-  return row?.curriculum?.playbookId ?? null;
+  if (!row?.curriculumId) return [];
+
+  return resolvePlaybookIdForCurriculum(row.curriculumId);
 }
 
 export async function resolvePlaybookIdsForContentSource(

--- a/apps/admin/lib/playbooks/create-variant.ts
+++ b/apps/admin/lib/playbooks/create-variant.ts
@@ -1,0 +1,263 @@
+/**
+ * Course Variant — creates a sibling Playbook against a parent's shared
+ * Curriculum + Subject + Source library (#1034).
+ *
+ * A variant Playbook is a new Course with the same content authority as
+ * its parent but a different teaching profile (Pop Quiz, Revision Aid,
+ * Exam Assessment). All variants of one parent share:
+ *   • one Curriculum (via PlaybookCurriculum `linked` role)
+ *   • the same Subject set (via PlaybookSubject rows)
+ *   • the same ContentSource set (via PlaybookSource rows)
+ *
+ * Mastery flows naturally across siblings for the same Caller because:
+ *   • `CallerAttribute.lo_mastery:{moduleSlug}:{loRef}` is slug-keyed
+ *     (#611) — same Curriculum → same moduleSlug → shared row
+ *   • `CallerModuleProgress` is `@@unique([callerId, moduleId])` — same
+ *     CurriculumModule UUID across siblings → shared row
+ *
+ * This is the funnel mechanism: a learner who hits a gap in Pop Quiz
+ * will see Revision Aid open directly on the weak LO, and Exam
+ * Assessment will score against the same mastery state. See CC-E in
+ * `docs/chain-contracts.md`.
+ *
+ * Chain contracts written:
+ *   • CC-A — PlaybookCurriculum row with role='linked'
+ *
+ * Out of scope (deferred):
+ *   • Curriculum cloning — variants NEVER write CurriculumModule rows.
+ *     The shared moduleId UUID is what makes the funnel work.
+ *   • PlaybookConfig preset wiring — the five preset config keys are
+ *     forward-declared and have no runtime effect today.
+ *   • Cohort/Invite — caller layers handle enrolment separately.
+ */
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { unlinkNonPrimaryPlaybookSubjects } from "@/lib/knowledge/cleanup-placeholder-subjects";
+import { auditLog, AuditAction } from "@/lib/audit";
+
+export type VariantPreset = "revision" | "popquiz" | "exam";
+
+export interface CreateVariantInput {
+  /** The Playbook to sibling-clone. Must exist and have a primary Curriculum link. */
+  parentPlaybookId: string;
+  /** Display name for the new variant Course (e.g. "Pop Quiz — The Standard"). */
+  name: string;
+  /** Optional teaching-profile preset. Stored as JSON on Playbook.config; no runtime effect today (forward-declared keys). */
+  preset?: VariantPreset;
+  /** The User performing the create — for audit trail. */
+  actorUserId: string;
+  /** Free-form reason captured in the audit row. */
+  reason?: string;
+}
+
+export interface CreateVariantResult {
+  /** ID of the new variant Playbook. */
+  variantPlaybookId: string;
+  /** Curriculum the variant shares with its parent (null if parent had no Curriculum). */
+  sharedCurriculumId: string | null;
+  /** Number of PlaybookSubject links created on the variant. */
+  subjectLinks: number;
+  /** Number of PlaybookSource links created on the variant. */
+  sourceLinks: number;
+  /** Number of PlaybookSubject rows unlinked by the #607 invariant guard (usually 0). */
+  unlinkedDuplicateSubjects: number;
+}
+
+/**
+ * Preset PlaybookConfig seeds. All five keys (teachingProfile,
+ * bloomLevelOverride, useFreshMastery, modelTier, welcomeMessage)
+ * are forward-declared per the #1034 TL review — stored on
+ * Playbook.config as JSON but not read by the runtime today. Cost
+ * tiering (modelTier) and Bloom override (bloomLevelOverride) ship
+ * in follow-up stories.
+ */
+const PRESET_CONFIGS: Record<VariantPreset, Prisma.JsonObject> = {
+  revision: {
+    teachingProfile: "coaching-led",
+    welcomeMessage: "Welcome back. Let's revise what you've covered.",
+    maxCallDurationSeconds: 1500,
+    modelTier: "sonnet",
+    bloomLevelOverride: { floor: "L2", ceiling: "L4" },
+  },
+  popquiz: {
+    teachingProfile: "assessment-led",
+    welcomeMessage: "Ready for a quick check? Let's see what's stuck.",
+    maxCallDurationSeconds: 600,
+    modelTier: "haiku",
+    scope: "single-module",
+    bloomLevelOverride: { floor: "L1", ceiling: "L3" },
+  },
+  exam: {
+    teachingProfile: "discussion-led",
+    welcomeMessage: "This is a mock assessment. Treat each prompt like an exam scenario.",
+    maxCallDurationSeconds: 2400,
+    modelTier: "sonnet",
+    bloomLevelOverride: { floor: "L3", ceiling: "L5" },
+    useFreshMastery: true,
+  },
+};
+
+const TX_TIMEOUT_MS = 15_000;
+
+export async function createPlaybookVariant(
+  input: CreateVariantInput,
+): Promise<CreateVariantResult> {
+  const { parentPlaybookId, name, preset, actorUserId, reason } = input;
+
+  if (!parentPlaybookId) throw new Error("parentPlaybookId is required");
+  if (!name?.trim()) throw new Error("name is required");
+  if (!actorUserId) throw new Error("actorUserId is required");
+
+  const config: Prisma.JsonObject = preset ? PRESET_CONFIGS[preset] : {};
+
+  // Resolve parent + shared resources OUTSIDE the transaction. Reads are
+  // safe to do upfront and they shrink the tx window.
+  const parent = await prisma.playbook.findUnique({
+    where: { id: parentPlaybookId },
+    select: {
+      id: true,
+      name: true,
+      domainId: true,
+      groupId: true,
+      sortOrder: true,
+      playbookCurricula: {
+        // Primary first so the variant always links to the canonical
+        // Curriculum, not a stray. Multiple primary rows shouldn't
+        // exist (Curriculum.playbookId is single-FK + we backfill 1:1).
+        orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+        take: 1,
+        select: { curriculumId: true },
+      },
+      subjects: {
+        orderBy: { createdAt: "asc" },
+        select: { subjectId: true },
+      },
+      playbookSources: {
+        select: {
+          sourceId: true,
+          sortOrder: true,
+          tags: true,
+          trustLevelOverride: true,
+        },
+      },
+    },
+  });
+  if (!parent) {
+    throw new Error(`Parent Playbook ${parentPlaybookId} not found`);
+  }
+
+  const sharedCurriculumId = parent.playbookCurricula[0]?.curriculumId ?? null;
+  const primarySubjectId = parent.subjects[0]?.subjectId ?? null;
+
+  // All writes in a single transaction. Interactive form is required —
+  // each step depends on the variant Playbook ID returned by step 1.
+  const result = await prisma.$transaction(
+    async (tx) => {
+      // Step 1 — create the variant Playbook row.
+      const variant = await tx.playbook.create({
+        data: {
+          name: name.trim(),
+          domainId: parent.domainId,
+          groupId: parent.groupId,
+          sortOrder: parent.sortOrder + 1,
+          status: "DRAFT",
+          config,
+          // parentVersionId stays null — siblings, not versions.
+        },
+        select: { id: true },
+      });
+
+      // Step 2 — link the shared Curriculum via a `linked` row (CC-A).
+      // Variant does NOT clone CurriculumModule rows; the funnel depends
+      // on shared module UUIDs.
+      if (sharedCurriculumId) {
+        await tx.playbookCurriculum.create({
+          data: {
+            playbookId: variant.id,
+            curriculumId: sharedCurriculumId,
+            role: "linked",
+          },
+        });
+      }
+
+      // Step 3 — link parent's Subjects (clone the join rows, not the Subjects).
+      // skipDuplicates safe-guards against any racing data; per-row create
+      // keeps audit cleaner than createMany for low cardinality.
+      let subjectLinks = 0;
+      for (const ps of parent.subjects) {
+        await tx.playbookSubject.create({
+          data: {
+            playbookId: variant.id,
+            subjectId: ps.subjectId,
+          },
+        });
+        subjectLinks++;
+      }
+
+      // Step 4 — link parent's Sources (clone the join rows, not the Sources).
+      let sourceLinks = 0;
+      for (const psrc of parent.playbookSources) {
+        await tx.playbookSource.create({
+          data: {
+            playbookId: variant.id,
+            sourceId: psrc.sourceId,
+            sortOrder: psrc.sortOrder,
+            tags: psrc.tags,
+            trustLevelOverride: psrc.trustLevelOverride,
+          },
+        });
+        sourceLinks++;
+      }
+
+      return {
+        variantPlaybookId: variant.id,
+        subjectLinks,
+        sourceLinks,
+      };
+    },
+    { timeout: TX_TIMEOUT_MS },
+  );
+
+  // POST-tx — invariant guard from #607. The helper uses `prisma` not
+  // `tx`, so it must run after commit. Removes any non-primary duplicate
+  // PlaybookSubject rows on the variant (defence-in-depth: if the parent
+  // had stale duplicates, the variant's copies are pruned to match the
+  // #607 invariant "exactly one PlaybookSubject per playbook"). Skipped
+  // when the parent had no Subjects.
+  let unlinkedDuplicateSubjects = 0;
+  if (primarySubjectId) {
+    const unlink = await unlinkNonPrimaryPlaybookSubjects(
+      result.variantPlaybookId,
+      primarySubjectId,
+    );
+    unlinkedDuplicateSubjects = unlink.removed;
+  }
+
+  // POST-tx — audit row. CREATED_PLAYBOOK + variant metadata so the
+  // audit log surfaces sibling provenance.
+  await auditLog({
+    userId: actorUserId,
+    action: AuditAction.CREATED_PLAYBOOK,
+    entityType: "Playbook",
+    entityId: result.variantPlaybookId,
+    metadata: {
+      kind: "variant",
+      parentPlaybookId,
+      sharedCurriculumId,
+      preset: preset ?? null,
+      subjectLinks: result.subjectLinks,
+      sourceLinks: result.sourceLinks,
+      unlinkedDuplicateSubjects,
+      reason: reason ?? null,
+    },
+  });
+
+  return {
+    variantPlaybookId: result.variantPlaybookId,
+    sharedCurriculumId,
+    subjectLinks: result.subjectLinks,
+    sourceLinks: result.sourceLinks,
+    unlinkedDuplicateSubjects,
+  };
+}

--- a/apps/admin/lib/prompt/compose-content-section.ts
+++ b/apps/admin/lib/prompt/compose-content-section.ts
@@ -370,15 +370,25 @@ async function loadCallerProgress(
     // Prefer playbookId lookup — wizard-generated curricula use slugs like
     // `course-<playbookId>-<timestamp>` that don't match the content spec slug.
     // Fall back to spec slug for content-spec-seeded curricula.
-    const curriculum = playbookId
-      ? await prisma.curriculum.findFirst({
-          where: { playbookId },
-          select: { id: true },
-        })
-      : await prisma.curriculum.findFirst({
-          where: { slug: specSlug },
-          select: { id: true },
-        });
+    // #1034 — playbookId path reads PlaybookCurriculum first (variant
+    // Playbooks share the parent's Curriculum), falls back to deprecated column.
+    let curriculum: { id: string } | null = null;
+    if (playbookId) {
+      const pbcLink = await prisma.playbookCurriculum.findFirst({
+        where: { playbookId },
+        orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+        select: { curriculum: { select: { id: true } } },
+      });
+      curriculum = pbcLink?.curriculum ?? await prisma.curriculum.findFirst({
+        where: { playbookId },
+        select: { id: true },
+      });
+    } else {
+      curriculum = await prisma.curriculum.findFirst({
+        where: { slug: specSlug },
+        select: { id: true },
+      });
+    }
     if (curriculum) {
       const moduleRows = await prisma.curriculumModule.findMany({
         where: { curriculumId: curriculum.id },
@@ -561,24 +571,31 @@ async function composeContentFromSubject(
   const { resolvePlaybookId } = await import("@/lib/enrollment/resolve-playbook");
   const enrolledPbId = await resolvePlaybookId(callerId);
   if (enrolledPbId) {
-    const pbCurr = await prisma.curriculum.findFirst({
-      where: { playbookId: enrolledPbId },
-      orderBy: { updatedAt: "desc" },
-      select: {
-        slug: true,
-        name: true,
-        notableInfo: true,
-        modules: {
-          orderBy: { sortOrder: "asc" },
-          select: {
-            id: true,
-            slug: true,
-            title: true,
-            description: true,
-            sortOrder: true,
-          },
+    // #1034 — PlaybookCurriculum-first read with deprecated-column fallback.
+    const pbCurrSelect = {
+      slug: true,
+      name: true,
+      notableInfo: true,
+      modules: {
+        orderBy: { sortOrder: "asc" as const },
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          description: true,
+          sortOrder: true,
         },
       },
+    };
+    const pbcLink = await prisma.playbookCurriculum.findFirst({
+      where: { playbookId: enrolledPbId },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: { curriculum: { select: pbCurrSelect } },
+    });
+    const pbCurr = pbcLink?.curriculum ?? await prisma.curriculum.findFirst({
+      where: { playbookId: enrolledPbId },
+      orderBy: { updatedAt: "desc" },
+      select: pbCurrSelect,
     });
 
     if (pbCurr) {

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -11,6 +11,7 @@
  * @canonical-doc docs/ENTITIES.md §4
  */
 
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { config } from "@/lib/config";
 import { getLearnerProfile } from "@/lib/learner/profile";
@@ -1123,37 +1124,47 @@ registerLoader("subjectSources", async (callerId, loaderConfig) => {
 
   if (subjects.length === 0) return null;
 
-  // Prefer curriculum from playbook (direct link) over subject.curricula
-  const playbookCurriculum = scope.playbookId
-    ? await prisma.curriculum.findFirst({
-        where: { playbookId: scope.playbookId },
-        orderBy: { updatedAt: "desc" },
-        select: {
-          id: true,
-          slug: true,
-          name: true,
-          description: true,
-          notableInfo: true,
-          deliveryConfig: true,
-          trustLevel: true,
-          qualificationBody: true,
-          qualificationNumber: true,
-          qualificationLevel: true,
-          modules: {
-            orderBy: { sortOrder: "asc" },
-            select: {
-              id: true,
-              slug: true,
-              title: true,
-              learningObjectives: {
-                orderBy: { ref: "asc" },
-                select: { ref: true, description: true },
-              },
-            },
-          },
+  // Prefer curriculum from playbook (direct link) over subject.curricula.
+  // #1034 — PlaybookCurriculum-first read; variant Playbooks share the
+  // parent's Curriculum via a `linked` row. Falls back to the deprecated
+  // Curriculum.playbookId column for transition safety.
+  const curriculumSelect = {
+    id: true,
+    slug: true,
+    name: true,
+    description: true,
+    notableInfo: true,
+    deliveryConfig: true,
+    trustLevel: true,
+    qualificationBody: true,
+    qualificationNumber: true,
+    qualificationLevel: true,
+    modules: {
+      orderBy: { sortOrder: "asc" as const },
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        learningObjectives: {
+          orderBy: { ref: "asc" as const },
+          select: { ref: true, description: true },
         },
-      })
-    : null;
+      },
+    },
+  };
+  let playbookCurriculum = null as Prisma.CurriculumGetPayload<{ select: typeof curriculumSelect }> | null;
+  if (scope.playbookId) {
+    const pbcLink = await prisma.playbookCurriculum.findFirst({
+      where: { playbookId: scope.playbookId },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: { curriculum: { select: curriculumSelect } },
+    });
+    playbookCurriculum = pbcLink?.curriculum ?? await prisma.curriculum.findFirst({
+      where: { playbookId: scope.playbookId },
+      orderBy: { updatedAt: "desc" },
+      select: curriculumSelect,
+    });
+  }
 
   return {
     subjects: subjects.map((subject) => ({

--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -233,19 +233,50 @@ async function ensureCurriculum(
   tx: Tx,
   playbookId: string,
 ): Promise<{ id: string; created: boolean }> {
+  // #1034 — Prefer PlaybookCurriculum (join). Variant Playbooks may already
+  // be linked to the parent's Curriculum via a `linked` row; in that case
+  // the wizard projection should target the SHARED Curriculum, not create
+  // a fork. Falls back to the deprecated Curriculum.playbookId column.
+  const existingLink = await tx.playbookCurriculum.findFirst({
+    where: { playbookId },
+    orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+    select: { curriculumId: true },
+  });
+  if (existingLink) return { id: existingLink.curriculumId, created: false };
+
   const existing = await tx.curriculum.findFirst({
     where: { playbookId },
     select: { id: true },
   });
-  if (existing) return { id: existing.id, created: false };
+  if (existing) {
+    // Heal: legacy Curriculum exists but no join row yet — backfill the
+    // join inside the same transaction so subsequent reads pick it up.
+    await tx.playbookCurriculum.upsert({
+      where: { playbookId_curriculumId: { playbookId, curriculumId: existing.id } },
+      create: { playbookId, curriculumId: existing.id, role: "primary" },
+      update: {},
+    });
+    return { id: existing.id, created: false };
+  }
 
   const created = await tx.curriculum.create({
     data: {
       slug: `course-${playbookId.slice(0, 8)}-${Date.now()}`,
       name: "Authored modules",
+      // #1034 — Keep the deprecated owner pointer in sync with the join row
+      // for one release (dropped in #1038). Two-write divergence is a real
+      // bug class — both rows MUST land in this same transaction.
       playbookId,
     },
     select: { id: true },
+  });
+  // #1034 — Write the primary PlaybookCurriculum row in the same transaction.
+  await tx.playbookCurriculum.create({
+    data: {
+      playbookId,
+      curriculumId: created.id,
+      role: "primary",
+    },
   });
   return { id: created.id, created: true };
 }

--- a/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
+++ b/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
@@ -61,14 +61,20 @@ export async function syncAuthoredModulesToCurriculum(
    */
   outcomes?: Record<string, string>,
 ): Promise<SyncResult> {
-  // Pick or create the primary curriculum for this course. "Primary" =
-  // earliest by createdAt; explicit primary-curriculum support is a
-  // separate ticket per #245's out-of-scope list.
+  // Pick or create the primary curriculum for this course.
+  // #1034 — Read PlaybookCurriculum first (variant Playbooks share the
+  // parent's Curriculum via a `linked` row). Falls back to the deprecated
+  // Curriculum.playbookId relation for transition safety.
   const playbook = await tx.playbook.findUnique({
     where: { id: playbookId },
     select: {
       id: true,
       name: true,
+      playbookCurricula: {
+        orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+        take: 1,
+        select: { curriculumId: true },
+      },
       curricula: {
         orderBy: { createdAt: "asc" },
         take: 1,
@@ -80,15 +86,27 @@ export async function syncAuthoredModulesToCurriculum(
     throw new Error(`Playbook ${playbookId} not found`);
   }
 
-  let curriculumId = playbook.curricula[0]?.id ?? null;
+  let curriculumId: string | null =
+    playbook.playbookCurricula[0]?.curriculumId ??
+    playbook.curricula[0]?.id ??
+    null;
   if (!curriculumId) {
     const created = await tx.curriculum.create({
       data: {
         name: `${playbook.name} — Modules`,
         slug: `playbook-${playbookId.slice(0, 8)}-modules`,
+        // #1034 — Keep deprecated owner pointer in sync with PlaybookCurriculum
+        // for one release (dropped in #1038). Same-tx dual-write.
         playbookId,
       },
       select: { id: true },
+    });
+    await tx.playbookCurriculum.create({
+      data: {
+        playbookId,
+        curriculumId: created.id,
+        role: "primary",
+      },
     });
     curriculumId = created.id;
   }

--- a/apps/admin/prisma/migrations/20260604_2046_1034_add_playbook_curriculum_join/migration.sql
+++ b/apps/admin/prisma/migrations/20260604_2046_1034_add_playbook_curriculum_join/migration.sql
@@ -1,0 +1,62 @@
+-- #1034 — PlaybookCurriculum join table for Course Variant
+--
+-- Adds many-to-many between Playbook and Curriculum so that sibling
+-- Variant Playbooks can share a Curriculum with their parent. Backfills
+-- one `primary` row per existing Curriculum.playbookId. The legacy
+-- Curriculum.playbookId column is kept as a deprecated owner pointer
+-- for one release and is dropped in follow-up #1038.
+--
+-- Chain contracts (see docs/chain-contracts.md):
+--   CC-A: Playbook → Curriculum linkage (this table is the data shape)
+--   CC-B: Curriculum mutation fanout (index on curriculumId enables fast read)
+
+-- CreateEnum
+CREATE TYPE "PlaybookCurriculumRole" AS ENUM ('primary', 'linked');
+
+-- CreateTable
+CREATE TABLE "PlaybookCurriculum" (
+    "id" TEXT NOT NULL,
+    "playbookId" TEXT NOT NULL,
+    "curriculumId" TEXT NOT NULL,
+    "role" "PlaybookCurriculumRole" NOT NULL DEFAULT 'primary',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PlaybookCurriculum_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlaybookCurriculum_playbookId_curriculumId_key" ON "PlaybookCurriculum"("playbookId", "curriculumId");
+
+-- CreateIndex
+CREATE INDEX "PlaybookCurriculum_curriculumId_idx" ON "PlaybookCurriculum"("curriculumId");
+
+-- CreateIndex
+CREATE INDEX "PlaybookCurriculum_playbookId_idx" ON "PlaybookCurriculum"("playbookId");
+
+-- AddForeignKey
+ALTER TABLE "PlaybookCurriculum"
+  ADD CONSTRAINT "PlaybookCurriculum_playbookId_fkey"
+  FOREIGN KEY ("playbookId") REFERENCES "Playbook"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey — RESTRICT: a Curriculum cannot be dropped while a Playbook
+-- still links to it; the operator must explicitly unlink (or drop the
+-- Playbook side first) so siblings don't lose their shared content silently.
+ALTER TABLE "PlaybookCurriculum"
+  ADD CONSTRAINT "PlaybookCurriculum_curriculumId_fkey"
+  FOREIGN KEY ("curriculumId") REFERENCES "Curriculum"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Backfill: one PlaybookCurriculum{role:'primary'} row per existing
+-- Curriculum where playbookId IS NOT NULL. Idempotent under the unique
+-- constraint, so safe to re-run if the migration is replayed.
+INSERT INTO "PlaybookCurriculum" ("id", "playbookId", "curriculumId", "role", "createdAt")
+SELECT
+  gen_random_uuid()::TEXT,
+  "playbookId",
+  "id",
+  'primary'::"PlaybookCurriculumRole",
+  CURRENT_TIMESTAMP
+FROM "Curriculum"
+WHERE "playbookId" IS NOT NULL
+ON CONFLICT ("playbookId", "curriculumId") DO NOTHING;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -2354,7 +2354,9 @@ model Curriculum {
   subjectId String?
   subject   Subject? @relation(fields: [subjectId], references: [id], onDelete: SetNull)
 
-  // Course linkage (replaces Subject → Curriculum chain)
+  /// @deprecated #1034 — kept as primary-owner pointer during PlaybookCurriculum
+  /// rollout. Readers MUST prefer PlaybookCurriculum (any role) and only fall
+  /// back to this column if the join table returns nothing. Dropped in #1038.
   playbookId String?
   playbook   Playbook? @relation("PlaybookCurricula", fields: [playbookId], references: [id], onDelete: SetNull)
 
@@ -2363,6 +2365,11 @@ model Curriculum {
 
   // First-class modules (replaces JSON notableInfo.modules)
   modules CurriculumModule[]
+
+  // #1034 — many-to-many link to Playbooks (primary owner + linked siblings).
+  // Source-of-truth for the variant Course product line. Replaces direct
+  // Curriculum.playbookId read on the hot Call path.
+  playbookLinks PlaybookCurriculum[]
 
   @@index([slug])
   @@index([sourceSpecId])
@@ -2832,8 +2839,14 @@ model Playbook {
   // Direct content scoping — which content sources belong to this course
   playbookSources PlaybookSource[]
 
-  // Curricula owned by this course (replaces Subject → Curriculum chain)
+  /// @deprecated #1034 — direct Curriculum.playbookId is the legacy
+  /// primary-owner pointer. Prefer reading via playbookCurricula. Dropped in #1038.
   curricula Curriculum[] @relation("PlaybookCurricula")
+
+  // #1034 — many-to-many link to Curricula. Variant Playbooks share a
+  // Curriculum with their parent via a `linked` row; the parent owns a
+  // `primary` row. Required for the variant Course product line.
+  playbookCurricula PlaybookCurriculum[]
 
   // Inverse relations for course scoping
   calls           Call[]           @relation("PlaybookCalls")
@@ -4249,6 +4262,38 @@ model PlaybookSource {
   @@unique([playbookId, sourceId])
   @@index([playbookId])
   @@index([sourceId])
+}
+
+// #1034 — Role of a PlaybookCurriculum link.
+//   primary — the owning Playbook of this Curriculum (one per Curriculum).
+//             Backfilled from the legacy Curriculum.playbookId column.
+//   linked  — a sibling Variant Playbook sharing the primary's Curriculum.
+//             Multiple per Curriculum allowed. Mastery flows across all
+//             linked + primary siblings for the same Caller because
+//             CallerModuleProgress is keyed on (callerId, moduleId UUID).
+enum PlaybookCurriculumRole {
+  primary
+  linked
+}
+
+// #1034 — Many-to-many between Playbook and Curriculum.
+// Replaces the direct Curriculum.playbookId FK on the hot Call path.
+// Primary row backfilled per existing Curriculum.playbookId on migration.
+// Variant route writes a `linked` row pointing at the parent's Curriculum.
+model PlaybookCurriculum {
+  id           String @id @default(uuid())
+  playbookId   String
+  playbook     Playbook @relation(fields: [playbookId], references: [id], onDelete: Cascade)
+  curriculumId String
+  curriculum   Curriculum @relation(fields: [curriculumId], references: [id], onDelete: Restrict)
+
+  role         PlaybookCurriculumRole @default(primary)
+
+  createdAt DateTime @default(now())
+
+  @@unique([playbookId, curriculumId])
+  @@index([curriculumId]) // CC-B fanout: bump all sibling Playbooks for a Curriculum
+  @@index([playbookId])   // variant lookup: which Curriculum does this Playbook read?
 }
 
 // =============================================================================

--- a/apps/admin/scripts/sim-drive-call.ts
+++ b/apps/admin/scripts/sim-drive-call.ts
@@ -116,6 +116,21 @@ async function main() {
   }
   const playbookId = cp.playbookId;
 
+  // #1034 CC-F — fail-fast pre-flight: confirm the Playbook is linked to
+  // a Curriculum (via PlaybookCurriculum or the deprecated
+  // Curriculum.playbookId column). A sim against an un-linked Playbook
+  // would silently produce a malformed Call (no module context). Better
+  // to refuse early with a clear error than to record a misleading run.
+  const preflightCurriculumId = await resolveCurriculumIdForPlaybook(playbookId);
+  if (!preflightCurriculumId) {
+    console.error(
+      `[sim-drive] PREFLIGHT FAIL — playbook ${playbookId} is not linked to a Curriculum ` +
+      `(neither via PlaybookCurriculum nor the deprecated Curriculum.playbookId column). ` +
+      `Wire a Curriculum to this Playbook before running a sim. See docs/chain-contracts.md CC-F.`,
+    );
+    process.exit(2);
+  }
+
   console.log(`\n=== SIM: ${label} → ${caller.name} (${caller.id.slice(0, 8)}) ===`);
   if (moduleSlug) console.log(`Pre-call module pick: ${moduleSlug}`);
 
@@ -140,10 +155,9 @@ async function main() {
   //    the VAPI / normal call-create path does in production.
   let curriculumModuleId: string | null = null;
   if (moduleSlug) {
-    const curriculumId = await resolveCurriculumIdForPlaybook(playbookId);
-    if (!curriculumId) {
-      console.warn(`[sim-drive] playbook ${playbookId} has no curriculum — leaving curriculumModuleId null`);
-    } else {
+    // Reuse the preflight result — already non-null thanks to CC-F above.
+    const curriculumId = preflightCurriculumId;
+    {
       const resolved = await resolveModuleByLogicalId(curriculumId, moduleSlug);
       if (!resolved) {
         console.warn(`[sim-drive] module slug "${moduleSlug}" not found in curriculum ${curriculumId.slice(0, 8)} — leaving curriculumModuleId null`);

--- a/apps/admin/tests/integration/journey/course-variant-funnel.integration.test.ts
+++ b/apps/admin/tests/integration/journey/course-variant-funnel.integration.test.ts
@@ -75,7 +75,7 @@ beforeAll(async () => {
     create: {
       slug: DOMAIN_SLUG,
       name: `${PFX} domain`,
-      kind: "STANDARD",
+      kind: "INSTITUTION",
     },
     select: { id: true },
   });
@@ -149,27 +149,40 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // Cleanup in FK-safe order. Cascade handles most of the join rows.
-  await prisma.callerAttribute.deleteMany({ where: { key: { startsWith: `lo_mastery:${MODULE_SLUG_A}:` } } });
-  await prisma.callerAttribute.deleteMany({ where: { key: { startsWith: `lo_mastery:${MODULE_SLUG_B}:` } } });
-  await prisma.caller.deleteMany({ where: { name: { startsWith: PFX } } });
+  // Guard against partial-setup runs — if beforeAll threw mid-way, undefined
+  // FKs would turn deleteMany() into "match-everything" and nuke unrelated rows.
+  try {
+    if (curriculumId) {
+      await prisma.callerAttribute.deleteMany({
+        where: { key: { startsWith: `lo_mastery:${MODULE_SLUG_A}:` } },
+      });
+      await prisma.callerAttribute.deleteMany({
+        where: { key: { startsWith: `lo_mastery:${MODULE_SLUG_B}:` } },
+      });
+      await prisma.caller.deleteMany({ where: { name: { startsWith: PFX } } });
+    }
 
-  // Drop variant Playbooks (cascade clears PlaybookCurriculum + Subject + Source links).
-  await prisma.playbook.deleteMany({
-    where: {
-      OR: [
-        { name: { startsWith: PFX } },
-        { id: parentPlaybookId },
-      ],
-    },
-  });
-  // PlaybookCurriculum primary row was cascaded; Curriculum + Modules remain.
-  await prisma.curriculumModule.deleteMany({ where: { curriculumId } });
-  await prisma.curriculum.delete({ where: { id: curriculumId } });
-  await prisma.subject.delete({ where: { id: subjectId } });
-  await prisma.domain.delete({ where: { id: domainId } });
-  await prisma.user.delete({ where: { id: actorUserId } });
-  await prisma.$disconnect();
+    // Drop variant + parent Playbooks (cascade clears PlaybookCurriculum +
+    // Subject + Source links). Scope to our prefix so dangling Playbooks
+    // from a half-failed run still get cleaned.
+    await prisma.playbook.deleteMany({
+      where: {
+        OR: [
+          { name: { startsWith: PFX } },
+          ...(parentPlaybookId ? [{ id: parentPlaybookId }] : []),
+        ],
+      },
+    });
+    if (curriculumId) {
+      await prisma.curriculumModule.deleteMany({ where: { curriculumId } });
+      await prisma.curriculum.delete({ where: { id: curriculumId } }).catch(() => {});
+    }
+    if (subjectId) await prisma.subject.delete({ where: { id: subjectId } }).catch(() => {});
+    if (domainId) await prisma.domain.delete({ where: { id: domainId } }).catch(() => {});
+    if (actorUserId) await prisma.user.delete({ where: { id: actorUserId } }).catch(() => {});
+  } finally {
+    await prisma.$disconnect();
+  }
 });
 
 describe("#1034 Course Variant funnel — CHAIN tests", () => {

--- a/apps/admin/tests/integration/journey/course-variant-funnel.integration.test.ts
+++ b/apps/admin/tests/integration/journey/course-variant-funnel.integration.test.ts
@@ -1,0 +1,369 @@
+/**
+ * #1034 — Course Variant funnel — integration test (CHAIN tests).
+ *
+ * Pins three chain contracts (CC-A, CC-D, CC-E) against live DB data:
+ *
+ *   CC-A — Playbook → Curriculum linkage (PlaybookCurriculum).
+ *          Pre-snapshot the parent's resource set; create variant;
+ *          post-snapshot proves: + 1 Playbook row, + 1 PlaybookCurriculum
+ *          row with role='linked', SAME curriculumId, ZERO new
+ *          CurriculumModule rows (funnel depends on shared UUIDs).
+ *
+ *   CC-D — Call → COMPOSE Curriculum resolution. The variant Playbook
+ *          MUST resolve to the parent's Curriculum via
+ *          `resolveCurriculumIdForPlaybook`. Pre-#1034 this query went
+ *          to the deprecated `Curriculum.playbookId` column directly and
+ *          silently returned null for variants → pipeline skipped
+ *          module-aware composition. TL hard-block regression pinned here.
+ *
+ *   CC-E — AGGREGATE → cross-Playbook mastery scope (INTENTIONAL).
+ *          A `lo_mastery:{moduleSlug}:{loRef}` CallerAttribute written
+ *          from sibling A's pipeline is the SAME ROW when sibling B's
+ *          pipeline reads it. This is the funnel mechanism (Pop Quiz
+ *          finds gap → Revision Aid teaches → Exam Assessment certifies)
+ *          and must not be "fixed" as a bug.
+ *
+ * Tests run DB-only (no server needed). Each test owns its rows under
+ * uniquely-prefixed slugs so concurrent test runs don't collide.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import { createPlaybookVariant } from "@/lib/playbooks/create-variant";
+import { resolveCurriculumIdForPlaybook } from "@/lib/curriculum/resolve-module";
+import {
+  resolvePlaybookIdForCurriculum,
+  resolvePlaybookIdForCurriculumModule,
+} from "@/lib/curriculum/resolve-playbook-for-curriculum";
+
+const prisma = new PrismaClient();
+
+const PFX = "1034-cv-funnel";
+const DOMAIN_SLUG = `${PFX}-domain`;
+const PARENT_PB_NAME = `${PFX}-parent-playbook`;
+const CURRICULUM_SLUG = `${PFX}-curriculum`;
+const MODULE_SLUG_A = `${PFX}-module-a`;
+const MODULE_SLUG_B = `${PFX}-module-b`;
+const SUBJECT_SLUG = `${PFX}-subject`;
+
+let actorUserId: string;
+let domainId: string;
+let parentPlaybookId: string;
+let curriculumId: string;
+let moduleAId: string;
+let moduleBId: string;
+let subjectId: string;
+
+beforeAll(async () => {
+  // Seed: User actor (audit FK), Domain, Subject, Curriculum, 2 modules,
+  // parent Playbook, PlaybookSubject link, PlaybookCurriculum primary row.
+  const actor = await prisma.user.upsert({
+    where: { email: `${PFX}-actor@test.local` },
+    update: {},
+    create: {
+      email: `${PFX}-actor@test.local`,
+      name: "1034 CV Funnel Actor",
+      role: "OPERATOR",
+    },
+    select: { id: true },
+  });
+  actorUserId = actor.id;
+
+  const domain = await prisma.domain.upsert({
+    where: { slug: DOMAIN_SLUG },
+    update: {},
+    create: {
+      slug: DOMAIN_SLUG,
+      name: `${PFX} domain`,
+      kind: "STANDARD",
+    },
+    select: { id: true },
+  });
+  domainId = domain.id;
+
+  const subject = await prisma.subject.upsert({
+    where: { slug: SUBJECT_SLUG },
+    update: {},
+    create: {
+      slug: SUBJECT_SLUG,
+      name: `${PFX} subject`,
+    },
+    select: { id: true },
+  });
+  subjectId = subject.id;
+
+  const parent = await prisma.playbook.create({
+    data: {
+      name: PARENT_PB_NAME,
+      domainId,
+      status: "DRAFT",
+    },
+    select: { id: true },
+  });
+  parentPlaybookId = parent.id;
+
+  const curriculum = await prisma.curriculum.create({
+    data: {
+      slug: CURRICULUM_SLUG,
+      name: `${PFX} curriculum`,
+      playbookId: parentPlaybookId, // deprecated column — kept for transition
+    },
+    select: { id: true },
+  });
+  curriculumId = curriculum.id;
+
+  // Primary PlaybookCurriculum row (mirrors the wizard dual-write behaviour).
+  await prisma.playbookCurriculum.create({
+    data: {
+      playbookId: parentPlaybookId,
+      curriculumId,
+      role: "primary",
+    },
+  });
+
+  const modA = await prisma.curriculumModule.create({
+    data: {
+      curriculumId,
+      slug: MODULE_SLUG_A,
+      title: "Module A",
+      sortOrder: 0,
+    },
+    select: { id: true },
+  });
+  moduleAId = modA.id;
+
+  const modB = await prisma.curriculumModule.create({
+    data: {
+      curriculumId,
+      slug: MODULE_SLUG_B,
+      title: "Module B",
+      sortOrder: 1,
+    },
+    select: { id: true },
+  });
+  moduleBId = modB.id;
+
+  await prisma.playbookSubject.create({
+    data: { playbookId: parentPlaybookId, subjectId },
+  });
+});
+
+afterAll(async () => {
+  // Cleanup in FK-safe order. Cascade handles most of the join rows.
+  await prisma.callerAttribute.deleteMany({ where: { key: { startsWith: `lo_mastery:${MODULE_SLUG_A}:` } } });
+  await prisma.callerAttribute.deleteMany({ where: { key: { startsWith: `lo_mastery:${MODULE_SLUG_B}:` } } });
+  await prisma.caller.deleteMany({ where: { name: { startsWith: PFX } } });
+
+  // Drop variant Playbooks (cascade clears PlaybookCurriculum + Subject + Source links).
+  await prisma.playbook.deleteMany({
+    where: {
+      OR: [
+        { name: { startsWith: PFX } },
+        { id: parentPlaybookId },
+      ],
+    },
+  });
+  // PlaybookCurriculum primary row was cascaded; Curriculum + Modules remain.
+  await prisma.curriculumModule.deleteMany({ where: { curriculumId } });
+  await prisma.curriculum.delete({ where: { id: curriculumId } });
+  await prisma.subject.delete({ where: { id: subjectId } });
+  await prisma.domain.delete({ where: { id: domainId } });
+  await prisma.user.delete({ where: { id: actorUserId } });
+  await prisma.$disconnect();
+});
+
+describe("#1034 Course Variant funnel — CHAIN tests", () => {
+  describe("CC-A — variant route writes correct join row, shares Curriculum", () => {
+    it("PRE/POST snapshot — variant creation adds 1 Playbook + 1 linked PlaybookCurriculum, ZERO new CurriculumModule rows", async () => {
+      // PRE-snapshot.
+      const pre = {
+        playbookCount: await prisma.playbook.count(),
+        joinCount: await prisma.playbookCurriculum.count({
+          where: { curriculumId },
+        }),
+        moduleIds: (
+          await prisma.curriculumModule.findMany({
+            where: { curriculumId },
+            select: { id: true },
+            orderBy: { sortOrder: "asc" },
+          })
+        ).map((m) => m.id),
+      };
+
+      // ACTION.
+      const result = await createPlaybookVariant({
+        parentPlaybookId,
+        name: `${PFX}-variant-popquiz`,
+        preset: "popquiz",
+        actorUserId,
+        reason: "CC-A snapshot test",
+      });
+
+      // POST-snapshot.
+      const post = {
+        playbookCount: await prisma.playbook.count(),
+        joinCount: await prisma.playbookCurriculum.count({
+          where: { curriculumId },
+        }),
+        moduleIds: (
+          await prisma.curriculumModule.findMany({
+            where: { curriculumId },
+            select: { id: true },
+            orderBy: { sortOrder: "asc" },
+          })
+        ).map((m) => m.id),
+      };
+
+      expect(post.playbookCount).toBe(pre.playbookCount + 1);
+      expect(post.joinCount).toBe(pre.joinCount + 1);
+      // Funnel depends on SHARED moduleId UUIDs — variant must not clone.
+      expect(post.moduleIds).toEqual(pre.moduleIds);
+
+      // Variant's PlaybookCurriculum row is role='linked' (not primary).
+      const variantLink = await prisma.playbookCurriculum.findUnique({
+        where: {
+          playbookId_curriculumId: {
+            playbookId: result.variantPlaybookId,
+            curriculumId,
+          },
+        },
+        select: { role: true, curriculumId: true },
+      });
+      expect(variantLink?.role).toBe("linked");
+      expect(variantLink?.curriculumId).toBe(curriculumId);
+
+      // Result surface: shared Curriculum, mirrored Subject link.
+      expect(result.sharedCurriculumId).toBe(curriculumId);
+      expect(result.subjectLinks).toBe(1);
+    });
+  });
+
+  describe("CC-D — pipeline COMPOSE resolves variant to PARENT's Curriculum", () => {
+    it("REGRESSION (TL hard-block #1): resolveCurriculumIdForPlaybook returns the SAME Curriculum for parent and variant", async () => {
+      const variant = await createPlaybookVariant({
+        parentPlaybookId,
+        name: `${PFX}-variant-revision`,
+        preset: "revision",
+        actorUserId,
+      });
+
+      const parentResolved = await resolveCurriculumIdForPlaybook(parentPlaybookId);
+      const variantResolved = await resolveCurriculumIdForPlaybook(variant.variantPlaybookId);
+
+      expect(parentResolved).toBe(curriculumId);
+      // Pre-#1034 this returned null — pipeline silently skipped module-aware
+      // composition for every variant Call. CC-D pins the fix.
+      expect(variantResolved).toBe(curriculumId);
+      expect(variantResolved).toBe(parentResolved);
+    });
+  });
+
+  describe("CC-B — curriculum mutation fanout: resolvePlaybookIdForCurriculum returns ALL siblings", () => {
+    it("returns parent + every variant for a shared Curriculum", async () => {
+      // Build a 3-Course product line (parent + 2 variants).
+      const v1 = await createPlaybookVariant({
+        parentPlaybookId,
+        name: `${PFX}-variant-cc-b-1`,
+        actorUserId,
+      });
+      const v2 = await createPlaybookVariant({
+        parentPlaybookId,
+        name: `${PFX}-variant-cc-b-2`,
+        actorUserId,
+      });
+
+      const siblings = await resolvePlaybookIdForCurriculum(curriculumId);
+      expect(siblings).toContain(parentPlaybookId);
+      expect(siblings).toContain(v1.variantPlaybookId);
+      expect(siblings).toContain(v2.variantPlaybookId);
+      // No duplicates.
+      expect(new Set(siblings).size).toBe(siblings.length);
+
+      // …and from the module side.
+      const modSiblings = await resolvePlaybookIdForCurriculumModule(moduleAId);
+      expect(modSiblings).toContain(parentPlaybookId);
+      expect(modSiblings).toContain(v1.variantPlaybookId);
+      expect(modSiblings).toContain(v2.variantPlaybookId);
+    });
+  });
+
+  describe("CC-E — cross-Playbook mastery scope (INTENTIONAL)", () => {
+    it("PRE/POST snapshot — lo_mastery written for Caller via sibling A is the SAME ROW when sibling B reads it", async () => {
+      // Seed a learner Caller (LEARNER role, no User FK — sim-only).
+      const caller = await prisma.caller.create({
+        data: {
+          name: `${PFX}-learner`,
+          role: "LEARNER",
+          domainId,
+        },
+        select: { id: true },
+      });
+
+      // Build sibling A. Reads/writes use the slug-keyed mastery key
+      // shape per #611 — `lo_mastery:{moduleSlug}:{loRef}`. Slug comes
+      // from CurriculumModule.slug; siblings share the slug because
+      // they share the CurriculumModule row.
+      const siblingA = await createPlaybookVariant({
+        parentPlaybookId,
+        name: `${PFX}-variant-cc-e-A`,
+        preset: "popquiz",
+        actorUserId,
+      });
+      const siblingB = await createPlaybookVariant({
+        parentPlaybookId,
+        name: `${PFX}-variant-cc-e-B`,
+        preset: "revision",
+        actorUserId,
+      });
+
+      // PRE-snapshot: no mastery row yet for this Caller × LO.
+      const masteryKey = `lo_mastery:${MODULE_SLUG_A}:LO2.3`;
+      const pre = await prisma.callerAttribute.findFirst({
+        where: { callerId: caller.id, key: masteryKey },
+        select: { id: true },
+      });
+      expect(pre).toBeNull();
+
+      // ACTION 1: simulate sibling A's pipeline writing mastery 0.2.
+      const writtenFromA = await prisma.callerAttribute.create({
+        data: {
+          callerId: caller.id,
+          key: masteryKey,
+          scope: "GLOBAL",
+          valueType: "NUMBER",
+          numberValue: 0.2,
+        },
+        select: { id: true, numberValue: true },
+      });
+
+      // ACTION 2: simulate sibling B's pipeline READING the same key.
+      // Pipeline reads are scoped by callerId + key — NOT by playbookId.
+      // That's the CC-E invariant: the row is shared across siblings.
+      const readFromB = await prisma.callerAttribute.findFirst({
+        where: { callerId: caller.id, key: masteryKey },
+        select: { id: true, numberValue: true },
+      });
+
+      expect(readFromB).not.toBeNull();
+      expect(readFromB?.id).toBe(writtenFromA.id); // SAME ROW.
+      expect(readFromB?.numberValue).toBe(0.2);
+
+      // ACTION 3: sibling B updates the same row to 0.7 (caught-up mastery).
+      await prisma.callerAttribute.update({
+        where: { id: writtenFromA.id },
+        data: { numberValue: 0.7 },
+      });
+
+      // ACTION 4: now sibling A reads again — sees B's update.
+      const readFromAAfterB = await prisma.callerAttribute.findFirst({
+        where: { callerId: caller.id, key: masteryKey },
+        select: { id: true, numberValue: true },
+      });
+      expect(readFromAAfterB?.id).toBe(writtenFromA.id);
+      expect(readFromAAfterB?.numberValue).toBe(0.7);
+
+      // Sanity — variant Playbook IDs are distinct.
+      expect(siblingA.variantPlaybookId).not.toBe(siblingB.variantPlaybookId);
+    });
+  });
+});

--- a/apps/admin/tests/lib/admin-tools-pending-change.test.ts
+++ b/apps/admin/tests/lib/admin-tools-pending-change.test.ts
@@ -33,8 +33,9 @@ vi.mock("@/lib/compose/bump-timestamp", () => ({
 
 // Resolve helpers — stub to return predictable playbook IDs.
 // Both helpers live in lib/curriculum/resolve-playbook-for-curriculum.ts.
+// #1034 — `resolvePlaybookIdForCurriculum` now returns `string[]` for CC-B fanout.
 vi.mock("@/lib/curriculum/resolve-playbook-for-curriculum", () => ({
-  resolvePlaybookIdForCurriculum: vi.fn(async () => "pb-1"),
+  resolvePlaybookIdForCurriculum: vi.fn(async () => ["pb-1"]),
   resolvePlaybookIdsForContentSource: vi.fn(async () => ["pb-1", "pb-2"]),
 }));
 
@@ -252,11 +253,12 @@ describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () =
       title: "Intro",
       curriculumId: "cur-orphan",
     });
-    // Override the resolve mock to return null (no playbook linked).
+    // Override the resolve mock to return [] (no playbook linked).
+    // #1034 — empty array = no siblings to fan out to.
     const { resolvePlaybookIdForCurriculum } = await import(
       "@/lib/curriculum/resolve-playbook-for-curriculum"
     );
-    (resolvePlaybookIdForCurriculum as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    (resolvePlaybookIdForCurriculum as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
     mockPrisma.curriculumModule.update.mockResolvedValue({
       id: "mod-1",
       slug: "intro",

--- a/apps/admin/tests/lib/compose/bump-curriculum-fanout.test.ts
+++ b/apps/admin/tests/lib/compose/bump-curriculum-fanout.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for `lib/compose/bump-curriculum-fanout.ts` — CC-B (#1034).
+ *
+ * Verifies that a Curriculum-affecting mutation fans the
+ * compose-inputs-updated bump out to every sibling Playbook sharing the
+ * Curriculum (variant Course product line). Without fanout, learners on
+ * variant Courses would receive stale prompts after teacher edits.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockBumpPlaybookComposeTimestamp = vi.fn();
+vi.mock("@/lib/compose/bump-timestamp", () => ({
+  bumpPlaybookComposeTimestamp: mockBumpPlaybookComposeTimestamp,
+}));
+
+const mockResolvePlaybookIdForCurriculum = vi.fn();
+const mockResolvePlaybookIdForCurriculumModule = vi.fn();
+vi.mock("@/lib/curriculum/resolve-playbook-for-curriculum", () => ({
+  resolvePlaybookIdForCurriculum: mockResolvePlaybookIdForCurriculum,
+  resolvePlaybookIdForCurriculumModule: mockResolvePlaybookIdForCurriculumModule,
+}));
+
+describe("bumpCurriculumComposeFanout — CC-B (#1034)", () => {
+  let mod: typeof import("@/lib/compose/bump-curriculum-fanout");
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mod = await import("@/lib/compose/bump-curriculum-fanout");
+  });
+
+  it("bumps every sibling Playbook returned by the resolver", async () => {
+    mockResolvePlaybookIdForCurriculum.mockResolvedValue([
+      "pb-primary",
+      "pb-popquiz",
+      "pb-exam",
+    ]);
+    const result = await mod.bumpCurriculumComposeFanout("c-shared");
+    expect(result.count).toBe(3);
+    expect(result.representativePlaybookId).toBe("pb-primary");
+    expect(mockBumpPlaybookComposeTimestamp).toHaveBeenCalledTimes(3);
+    expect(mockBumpPlaybookComposeTimestamp).toHaveBeenNthCalledWith(1, "pb-primary");
+    expect(mockBumpPlaybookComposeTimestamp).toHaveBeenNthCalledWith(2, "pb-popquiz");
+    expect(mockBumpPlaybookComposeTimestamp).toHaveBeenNthCalledWith(3, "pb-exam");
+  });
+
+  it("returns count 0 + null representative when no siblings linked", async () => {
+    mockResolvePlaybookIdForCurriculum.mockResolvedValue([]);
+    const result = await mod.bumpCurriculumComposeFanout("c-orphan");
+    expect(result.count).toBe(0);
+    expect(result.representativePlaybookId).toBeNull();
+    expect(mockBumpPlaybookComposeTimestamp).not.toHaveBeenCalled();
+  });
+
+  it("treats single-sibling case identically — count 1, that Playbook is the representative", async () => {
+    mockResolvePlaybookIdForCurriculum.mockResolvedValue(["pb-only"]);
+    const result = await mod.bumpCurriculumComposeFanout("c-1");
+    expect(result.count).toBe(1);
+    expect(result.representativePlaybookId).toBe("pb-only");
+    expect(mockBumpPlaybookComposeTimestamp).toHaveBeenCalledExactlyOnceWith("pb-only");
+  });
+});
+
+describe("bumpCurriculumModuleComposeFanout — CC-B (#1034)", () => {
+  let mod: typeof import("@/lib/compose/bump-curriculum-fanout");
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mod = await import("@/lib/compose/bump-curriculum-fanout");
+  });
+
+  it("walks moduleId → curriculum → siblings and bumps each", async () => {
+    mockResolvePlaybookIdForCurriculumModule.mockResolvedValue([
+      "pb-primary",
+      "pb-variant",
+    ]);
+    const result = await mod.bumpCurriculumModuleComposeFanout("mod-1");
+    expect(result.count).toBe(2);
+    expect(result.representativePlaybookId).toBe("pb-primary");
+    expect(mockBumpPlaybookComposeTimestamp).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-op when moduleId resolves to no Playbooks", async () => {
+    mockResolvePlaybookIdForCurriculumModule.mockResolvedValue([]);
+    const result = await mod.bumpCurriculumModuleComposeFanout("mod-orphan");
+    expect(result.count).toBe(0);
+    expect(result.representativePlaybookId).toBeNull();
+    expect(mockBumpPlaybookComposeTimestamp).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/curriculum/resolve-curriculum-for-playbook.test.ts
+++ b/apps/admin/tests/lib/curriculum/resolve-curriculum-for-playbook.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for `lib/curriculum/resolve-module.ts::resolveCurriculumIdForPlaybook`.
+ * #1034 — TL hard-block regression: a variant Playbook's Curriculum must be
+ * resolved via PlaybookCurriculum (join), not via the deprecated
+ * Curriculum.playbookId column. Without this, the pipeline at
+ * `app/api/calls/[callId]/pipeline/route.ts:148` would silently skip
+ * module-aware composition for every variant Call.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  playbookCurriculum: { findFirst: vi.fn() },
+  curriculum: { findFirst: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+describe("resolveCurriculumIdForPlaybook — #1034", () => {
+  let mod: typeof import("@/lib/curriculum/resolve-module");
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mod = await import("@/lib/curriculum/resolve-module");
+  });
+
+  it("reads PlaybookCurriculum first — primary row resolves to the shared Curriculum", async () => {
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue({
+      curriculumId: "c-shared",
+    });
+    await expect(
+      mod.resolveCurriculumIdForPlaybook("pb-primary"),
+    ).resolves.toBe("c-shared");
+    // Must not fall through to the deprecated column when join row exists.
+    expect(mockPrisma.curriculum.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION (TL block #1): variant Playbook's linked row resolves to PARENT's Curriculum", async () => {
+    // A variant Playbook has a PlaybookCurriculum row with role='linked'
+    // pointing at the parent's Curriculum. The pre-#1034 implementation
+    // queried Curriculum.playbookId directly and returned null for variants
+    // — pipeline COMPOSE then silently skipped module-aware composition.
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue({
+      curriculumId: "c-parent-owned",
+    });
+    await expect(
+      mod.resolveCurriculumIdForPlaybook("pb-variant"),
+    ).resolves.toBe("c-parent-owned");
+    expect(mockPrisma.playbookCurriculum.findFirst).toHaveBeenCalledWith({
+      where: { playbookId: "pb-variant" },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: { curriculumId: true },
+    });
+  });
+
+  it("falls back to deprecated Curriculum.playbookId only when no join row exists", async () => {
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue(null);
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "c-legacy" });
+    await expect(
+      mod.resolveCurriculumIdForPlaybook("pb-legacy"),
+    ).resolves.toBe("c-legacy");
+  });
+
+  it("returns null when neither join nor deprecated column matches", async () => {
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue(null);
+    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+    await expect(
+      mod.resolveCurriculumIdForPlaybook("pb-orphan"),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null on falsy input without touching the DB", async () => {
+    await expect(mod.resolveCurriculumIdForPlaybook(null)).resolves.toBeNull();
+    await expect(mod.resolveCurriculumIdForPlaybook(undefined)).resolves.toBeNull();
+    await expect(mod.resolveCurriculumIdForPlaybook("")).resolves.toBeNull();
+    expect(mockPrisma.playbookCurriculum.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.curriculum.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/curriculum/resolve-playbook-for-curriculum.test.ts
+++ b/apps/admin/tests/lib/curriculum/resolve-playbook-for-curriculum.test.ts
@@ -1,5 +1,7 @@
 /**
  * Tests for `lib/curriculum/resolve-playbook-for-curriculum.ts` — #834.
+ * Updated for #1034: `resolvePlaybookIdForCurriculum` and `…ForCurriculumModule`
+ * now return `string[]` (CC-B fanout across sibling Playbooks sharing a Curriculum).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -7,12 +9,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockPrisma = {
   curriculum: { findUnique: vi.fn() },
   curriculumModule: { findUnique: vi.fn() },
+  playbookCurriculum: { findMany: vi.fn() },
   playbookSource: { findMany: vi.fn() },
   playbookItem: { findMany: vi.fn() },
 };
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
-describe("resolvePlaybookForCurriculum — #834", () => {
+describe("resolvePlaybookForCurriculum — #834 / #1034", () => {
   let mod: typeof import("@/lib/curriculum/resolve-playbook-for-curriculum");
 
   beforeEach(async () => {
@@ -20,43 +23,80 @@ describe("resolvePlaybookForCurriculum — #834", () => {
     mod = await import("@/lib/curriculum/resolve-playbook-for-curriculum");
   });
 
-  describe("resolvePlaybookIdForCurriculum", () => {
-    it("returns the playbookId from the curriculum row", async () => {
-      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: "pb-1" });
-      await expect(mod.resolvePlaybookIdForCurriculum("c1")).resolves.toBe("pb-1");
+  describe("resolvePlaybookIdForCurriculum (#1034 — returns string[])", () => {
+    it("returns every Playbook linked via PlaybookCurriculum", async () => {
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([
+        { playbookId: "pb-primary" },
+        { playbookId: "pb-variant-1" },
+        { playbookId: "pb-variant-2" },
+      ]);
+      await expect(
+        mod.resolvePlaybookIdForCurriculum("c1"),
+      ).resolves.toEqual(["pb-primary", "pb-variant-1", "pb-variant-2"]);
+      // Should not hit the fallback when join rows exist.
+      expect(mockPrisma.curriculum.findUnique).not.toHaveBeenCalled();
     });
 
-    it("returns null when curriculum has no playbook FK", async () => {
+    it("falls back to deprecated Curriculum.playbookId column when no join rows", async () => {
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
+      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: "pb-legacy" });
+      await expect(
+        mod.resolvePlaybookIdForCurriculum("c1"),
+      ).resolves.toEqual(["pb-legacy"]);
+    });
+
+    it("returns empty array when no join row and no deprecated column value", async () => {
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
       mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: null });
-      await expect(mod.resolvePlaybookIdForCurriculum("c1")).resolves.toBeNull();
+      await expect(mod.resolvePlaybookIdForCurriculum("c1")).resolves.toEqual([]);
     });
 
-    it("returns null when curriculum not found", async () => {
+    it("returns empty array when curriculum not found", async () => {
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
       mockPrisma.curriculum.findUnique.mockResolvedValue(null);
-      await expect(mod.resolvePlaybookIdForCurriculum("missing")).resolves.toBeNull();
+      await expect(mod.resolvePlaybookIdForCurriculum("missing")).resolves.toEqual([]);
     });
 
-    it("returns null on empty input", async () => {
-      await expect(mod.resolvePlaybookIdForCurriculum("")).resolves.toBeNull();
+    it("returns empty array on empty input without touching the DB", async () => {
+      await expect(mod.resolvePlaybookIdForCurriculum("")).resolves.toEqual([]);
+      expect(mockPrisma.playbookCurriculum.findMany).not.toHaveBeenCalled();
       expect(mockPrisma.curriculum.findUnique).not.toHaveBeenCalled();
     });
   });
 
-  describe("resolvePlaybookIdForCurriculumModule", () => {
-    it("walks module → curriculum → playbookId", async () => {
-      mockPrisma.curriculumModule.findUnique.mockResolvedValue({
-        curriculum: { playbookId: "pb-x" },
-      });
-      await expect(mod.resolvePlaybookIdForCurriculumModule("m1")).resolves.toBe("pb-x");
+  describe("resolvePlaybookIdForCurriculumModule (#1034 — returns string[])", () => {
+    it("walks module → curriculum → playbookCurriculum siblings", async () => {
+      mockPrisma.curriculumModule.findUnique.mockResolvedValue({ curriculumId: "c-shared" });
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([
+        { playbookId: "pb-primary" },
+        { playbookId: "pb-linked" },
+      ]);
+      await expect(
+        mod.resolvePlaybookIdForCurriculumModule("m1"),
+      ).resolves.toEqual(["pb-primary", "pb-linked"]);
     });
 
-    it("returns null when module has no parent or no FK", async () => {
+    it("falls through to the deprecated column when join is empty", async () => {
+      mockPrisma.curriculumModule.findUnique.mockResolvedValue({ curriculumId: "c-shared" });
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
+      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: "pb-legacy" });
+      await expect(
+        mod.resolvePlaybookIdForCurriculumModule("m1"),
+      ).resolves.toEqual(["pb-legacy"]);
+    });
+
+    it("returns empty array when module not found", async () => {
       mockPrisma.curriculumModule.findUnique.mockResolvedValue(null);
-      await expect(mod.resolvePlaybookIdForCurriculumModule("missing")).resolves.toBeNull();
+      await expect(mod.resolvePlaybookIdForCurriculumModule("missing")).resolves.toEqual([]);
+    });
+
+    it("returns empty array when module has no curriculumId", async () => {
+      mockPrisma.curriculumModule.findUnique.mockResolvedValue({ curriculumId: null });
+      await expect(mod.resolvePlaybookIdForCurriculumModule("m1")).resolves.toEqual([]);
     });
   });
 
-  describe("resolvePlaybookIdsForContentSource", () => {
+  describe("resolvePlaybookIdsForContentSource (unchanged)", () => {
     it("returns every PlaybookSource linkage for the source", async () => {
       mockPrisma.playbookSource.findMany.mockResolvedValue([
         { playbookId: "pb-1" },
@@ -73,7 +113,7 @@ describe("resolvePlaybookForCurriculum — #834", () => {
     });
   });
 
-  describe("resolvePlaybookIdsForAnalysisSpec", () => {
+  describe("resolvePlaybookIdsForAnalysisSpec (unchanged)", () => {
     it("returns every PlaybookItem linkage with non-null playbookId", async () => {
       mockPrisma.playbookItem.findMany.mockResolvedValue([
         { playbookId: "pb-1" },

--- a/apps/admin/tests/lib/playbooks/create-variant.test.ts
+++ b/apps/admin/tests/lib/playbooks/create-variant.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for `lib/playbooks/create-variant.ts` — #1034.
+ *
+ * Verifies the central invariants of variant creation:
+ *   • Curriculum is LINKED via PlaybookCurriculum{role:'linked'}, never cloned.
+ *   • CurriculumModule rows are NEVER written (mastery shared via UUID).
+ *   • Subjects + Sources mirror parent's join rows.
+ *   • All writes happen inside a single $transaction.
+ *   • #607 invariant guard (unlinkNonPrimaryPlaybookSubjects) is called.
+ *   • Audit row is written with `kind: "variant"` + provenance metadata.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const txInteractive = vi.fn(async (fn: (tx: any) => any) => fn(mockTx));
+
+const mockPrisma = {
+  playbook: { findUnique: vi.fn() },
+  $transaction: txInteractive,
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockTx = {
+  playbook: { create: vi.fn() },
+  playbookCurriculum: { create: vi.fn() },
+  playbookSubject: { create: vi.fn() },
+  playbookSource: { create: vi.fn() },
+  // Variant must NEVER write CurriculumModule — sentinel for regression.
+  curriculumModule: { create: vi.fn() },
+  curriculum: { create: vi.fn() },
+};
+
+const mockUnlink = vi.fn(async () => ({ removed: 0, displaced: [] }));
+vi.mock("@/lib/knowledge/cleanup-placeholder-subjects", () => ({
+  unlinkNonPrimaryPlaybookSubjects: mockUnlink,
+}));
+
+const mockAudit = vi.fn();
+vi.mock("@/lib/audit", () => ({
+  auditLog: mockAudit,
+  AuditAction: {
+    CREATED_PLAYBOOK: "created_playbook",
+  },
+}));
+
+describe("createPlaybookVariant — #1034", () => {
+  let mod: typeof import("@/lib/playbooks/create-variant");
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mod = await import("@/lib/playbooks/create-variant");
+
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "pb-parent",
+      name: "The Standard — Foundation",
+      domainId: "dom-1",
+      groupId: "grp-1",
+      sortOrder: 5,
+      playbookCurricula: [{ curriculumId: "c-shared" }],
+      subjects: [{ subjectId: "subj-primary" }],
+      playbookSources: [
+        {
+          sourceId: "src-1",
+          sortOrder: 0,
+          tags: ["content"],
+          trustLevelOverride: null,
+        },
+      ],
+    });
+    mockTx.playbook.create.mockResolvedValue({ id: "pb-variant" });
+  });
+
+  it("creates a variant Playbook, linked Curriculum, mirrored Subjects and Sources", async () => {
+    const result = await mod.createPlaybookVariant({
+      parentPlaybookId: "pb-parent",
+      name: "Pop Quiz — The Standard",
+      preset: "popquiz",
+      actorUserId: "user-1",
+      reason: "spawn from parent",
+    });
+
+    expect(result.variantPlaybookId).toBe("pb-variant");
+    expect(result.sharedCurriculumId).toBe("c-shared");
+    expect(result.subjectLinks).toBe(1);
+    expect(result.sourceLinks).toBe(1);
+
+    // Variant Playbook row
+    expect(mockTx.playbook.create).toHaveBeenCalledExactlyOnceWith({
+      data: expect.objectContaining({
+        name: "Pop Quiz — The Standard",
+        domainId: "dom-1",
+        groupId: "grp-1",
+        sortOrder: 6,
+        status: "DRAFT",
+        config: expect.objectContaining({
+          teachingProfile: "assessment-led",
+          modelTier: "haiku",
+        }),
+      }),
+      select: { id: true },
+    });
+
+    // PlaybookCurriculum row — role='linked', NOT 'primary'
+    expect(mockTx.playbookCurriculum.create).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        playbookId: "pb-variant",
+        curriculumId: "c-shared",
+        role: "linked",
+      },
+    });
+
+    // PlaybookSubject mirror
+    expect(mockTx.playbookSubject.create).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        playbookId: "pb-variant",
+        subjectId: "subj-primary",
+      },
+    });
+
+    // PlaybookSource mirror
+    expect(mockTx.playbookSource.create).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        playbookId: "pb-variant",
+        sourceId: "src-1",
+        sortOrder: 0,
+        tags: ["content"],
+        trustLevelOverride: null,
+      },
+    });
+  });
+
+  it("REGRESSION (CC-A invariant): NEVER writes CurriculumModule or Curriculum on the variant path", async () => {
+    await mod.createPlaybookVariant({
+      parentPlaybookId: "pb-parent",
+      name: "Variant X",
+      actorUserId: "user-1",
+    });
+    expect(mockTx.curriculumModule.create).not.toHaveBeenCalled();
+    expect(mockTx.curriculum.create).not.toHaveBeenCalled();
+  });
+
+  it("runs all writes inside one $transaction (interactive form)", async () => {
+    await mod.createPlaybookVariant({
+      parentPlaybookId: "pb-parent",
+      name: "Variant X",
+      actorUserId: "user-1",
+    });
+    expect(mockPrisma.$transaction).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Function),
+      expect.objectContaining({ timeout: 15_000 }),
+    );
+  });
+
+  it("calls unlinkNonPrimaryPlaybookSubjects after tx commit (#607 invariant guard)", async () => {
+    await mod.createPlaybookVariant({
+      parentPlaybookId: "pb-parent",
+      name: "Variant X",
+      actorUserId: "user-1",
+    });
+    expect(mockUnlink).toHaveBeenCalledExactlyOnceWith("pb-variant", "subj-primary");
+  });
+
+  it("writes audit row with variant provenance metadata", async () => {
+    await mod.createPlaybookVariant({
+      parentPlaybookId: "pb-parent",
+      name: "Variant X",
+      preset: "exam",
+      actorUserId: "user-1",
+      reason: "build exam tier",
+    });
+    expect(mockAudit).toHaveBeenCalledExactlyOnceWith({
+      userId: "user-1",
+      action: "created_playbook",
+      entityType: "Playbook",
+      entityId: "pb-variant",
+      metadata: expect.objectContaining({
+        kind: "variant",
+        parentPlaybookId: "pb-parent",
+        sharedCurriculumId: "c-shared",
+        preset: "exam",
+        reason: "build exam tier",
+      }),
+    });
+  });
+
+  it("preset=undefined seeds an empty config (forward-declared keys absent)", async () => {
+    await mod.createPlaybookVariant({
+      parentPlaybookId: "pb-parent",
+      name: "Variant X",
+      actorUserId: "user-1",
+    });
+    const data = mockTx.playbook.create.mock.calls[0][0].data;
+    expect(data.config).toEqual({});
+  });
+
+  it("skips PlaybookCurriculum write when parent has no Curriculum (graceful)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "pb-parent",
+      name: "Parent without curriculum",
+      domainId: "dom-1",
+      groupId: null,
+      sortOrder: 0,
+      playbookCurricula: [],
+      subjects: [],
+      playbookSources: [],
+    });
+
+    const result = await mod.createPlaybookVariant({
+      parentPlaybookId: "pb-parent",
+      name: "Variant X",
+      actorUserId: "user-1",
+    });
+    expect(result.sharedCurriculumId).toBeNull();
+    expect(mockTx.playbookCurriculum.create).not.toHaveBeenCalled();
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it("throws when parent Playbook is missing", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    await expect(
+      mod.createPlaybookVariant({
+        parentPlaybookId: "pb-missing",
+        name: "Variant X",
+        actorUserId: "user-1",
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it("throws on empty name", async () => {
+    await expect(
+      mod.createPlaybookVariant({
+        parentPlaybookId: "pb-parent",
+        name: "   ",
+        actorUserId: "user-1",
+      }),
+    ).rejects.toThrow(/name is required/);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -11472,6 +11472,45 @@ Returns all triggers and actions across all specs in this playbook,
 
 ---
 
+### `POST` /api/playbooks/:playbookId/variant
+
+Create a sibling Variant Playbook against the parent's
+
+**Auth**: session (OPERATOR or higher) · **Scope**: `playbook:write`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| playbookId | path | string | Yes | The PARENT Playbook to sibling-clone. |
+| name | body | string | No | Display name for the new variant Course (required, max 200). |
+| reason | body | string | No | Free-form audit trail note (optional). |
+
+**Response** `201`
+```json
+{ ok: true, variantPlaybookId: string, sharedCurriculumId: string|null, subjectLinks: number, sourceLinks: number, unlinkedDuplicateSubjects: number }
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `401`
+```json
+{ ok: false, error: "Unauthorized" }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Parent Playbook not found" }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `GET` /api/playbooks/available-items
 
 Get all active specs (by scope) and prompt templates available for building playbooks
@@ -14584,8 +14623,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 466 |
-| Files with annotations | 457 |
+| Route files found | 467 |
+| Files with annotations | 458 |
 | Files missing annotations | 9 |
 | Coverage | 98.1% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -4141,6 +4141,45 @@ Returns a hierarchical tree structure of the playbook including domain,
 
 ---
 
+### `POST` /api/v1/playbooks/:playbookId/variant
+
+Create a sibling Variant Playbook against the parent's
+
+**Auth**: session (OPERATOR or higher) · **Scope**: `playbook:write`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| playbookId | path | string | Yes | The PARENT Playbook to sibling-clone. |
+| name | body | string | No | Display name for the new variant Course (required, max 200). |
+| reason | body | string | No | Free-form audit trail note (optional). |
+
+**Response** `201`
+```json
+{ ok: true, variantPlaybookId: string, sharedCurriculumId: string|null, subjectLinks: number, sourceLinks: number, unlinkedDuplicateSubjects: number }
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `401`
+```json
+{ ok: false, error: "Unauthorized" }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Parent Playbook not found" }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ## Prompts
 
 ### `GET` /api/v1/prompt/compose-from-specs

--- a/docs/CHAIN-CONTRACTS.md
+++ b/docs/CHAIN-CONTRACTS.md
@@ -326,6 +326,99 @@ A page that mounts without a resolved `playbookId` either renders a learner-read
 
 ---
 
+## 3d. Course Variant product line (#1034)
+
+The Variant product line lets one Curriculum back N sibling Playbooks (Pop Quiz, Revision Aid, Exam Assessment) — same content authority, different teaching profile. CallerModuleProgress and `lo_mastery:*` flow naturally across siblings for the same Caller; the funnel (Pop Quiz finds gap → Revision Aid teaches → Exam Assessment certifies) is a runtime emergent of the shared CurriculumModule UUIDs.
+
+This section documents the six producer→consumer contracts that the variant work introduced. Treat each row as load-bearing for the funnel: violation means a sibling silently sees stale content or a foreign mastery state.
+
+### CC-A — Playbook → Curriculum linkage (PlaybookCurriculum)
+
+| Field | Value |
+|---|---|
+| **Producer** | `lib/wizard/apply-projection.ts::ensureCurriculum`, `lib/wizard/sync-authored-modules-to-curriculum.ts`, `lib/playbooks/create-variant.ts::createPlaybookVariant` |
+| **Consumer** | `lib/curriculum/resolve-module.ts::resolveCurriculumIdForPlaybook` (called by pipeline `route.ts:148`, COMPOSE loaders, admin tools); `lib/curriculum/resolve-playbook-for-curriculum.ts::resolvePlaybookIdForCurriculum` (called by curriculum-side writes for CC-B) |
+| **Data shape** | `PlaybookCurriculum{playbookId, curriculumId, role}` where `role ∈ {primary, linked}`. `@@unique([playbookId, curriculumId])`. Exactly one `primary` row per Curriculum (backfilled 1:1 from legacy `Curriculum.playbookId`). N `linked` rows per Curriculum allowed — that's the variant count. |
+| **DataContract slug** | implicit |
+| **Enforcement** | DB `@@unique` constraint; `createPlaybookVariant` writes `role='linked'` (never `primary`); wizard write sites dual-write `Curriculum.playbookId` (deprecated owner ptr) + `PlaybookCurriculum{role:'primary'}` row in the same `prisma.$transaction`. `resolveCurriculumIdForPlaybook` reads the join first and falls back to the deprecated column for transition safety. |
+| **Test** | `tests/lib/curriculum/resolve-curriculum-for-playbook.test.ts` (5 cases — pins TL hard-block #1 regression: variant Playbook's `linked` row resolves to PARENT's Curriculum); `tests/lib/playbooks/create-variant.test.ts` (10 cases — pins CC-A invariants: writes `role:'linked'`, NEVER writes CurriculumModule or Curriculum). |
+| **Memory doc** | `docs/ENTITIES.md` (Playbook + Curriculum relations); follow-up `#1038` drops the deprecated `Curriculum.playbookId` column once readers complete migration. |
+| **Audit counter** | TBD — propose `variantSiblingsWithoutPrimary` once #1038 lands (target 0). |
+| **Reinforced by** | #1034 (this story). |
+
+### CC-B — Curriculum mutation fanout (composeInputsUpdatedAt across siblings)
+
+| Field | Value |
+|---|---|
+| **Producer** | Any helper that mutates a Curriculum-scope compose-affecting field (LO write, module rename, lesson plan replace, assertion → LO link). Wired in: `app/api/curricula/[curriculumId]/lesson-plan/route.ts`, `app/api/curricula/[curriculumId]/modules/[moduleId]/route.ts` (PATCH + DELETE), `app/api/curricula/[curriculumId]/modules/route.ts` (POST + PUT), `lib/chat/admin-tool-handlers.ts` (3 sites). |
+| **Consumer** | `lib/compose/staleness.ts::isPromptStale` at every sibling Playbook's COMPOSE call-start. |
+| **Data shape** | `Playbook.composeInputsUpdatedAt` (DateTime) — one bump per sibling per Curriculum mutation. Driven by `resolvePlaybookIdForCurriculum(curriculumId) → string[]` (the array of every sibling) iterated through `bumpPlaybookComposeTimestamp(playbookId)`. |
+| **Invariant** | Every sibling Playbook sharing the mutated Curriculum MUST have its `composeInputsUpdatedAt` bumped before the next call. Variant Courses become stale TOGETHER when the teacher edits an LO. |
+| **Enforcement** | `resolvePlaybookIdForCurriculum` and `resolvePlaybookIdForCurriculumModule` return `string[]` (changed from `string|null` in #1034). Inline loops at the 7 caller sites + the canonical helper `lib/compose/bump-curriculum-fanout.ts::bumpCurriculumComposeFanout` for new write sites. |
+| **Pipeline carve-out** | Inherits the #825 carve-out: pipeline-internal writes do NOT bump (the unconditional pipeline COMPOSE handles them). Fanout only fires for teacher / wizard / admin mutations. |
+| **Test** | `tests/lib/curriculum/resolve-playbook-for-curriculum.test.ts` (signature change + multi-sibling resolution); `tests/lib/compose/bump-curriculum-fanout.test.ts` (5 cases — multi-sibling bump, empty-siblings no-op, single-sibling, module-walk variant). |
+| **Memory doc** | This sub-section + `lib/compose/bump-curriculum-fanout.ts` header. |
+| **Audit counter** | TBD — propose `curriculumMutationMissedSiblings` once #1038 lands (target 0). |
+| **Reinforced by** | #1034 (extends #825 / #834). |
+
+### CC-C — Enrollment → Call.playbookId scoping (per-Course entry surfaces)
+
+| Field | Value |
+|---|---|
+| **Producer** | Enrollment surfaces — `Invite.playbookId` non-null FK (existing). Each sibling Course gets its own join URL (`/join/[token]`), its own dashboard card, its own Quick-Launch deep link. |
+| **Consumer** | Call start (Sim, VAPI, web voice, phone) → sets `Call.playbookId` to the entry-surface's Playbook. Pipeline reads `Call.playbookId` for all downstream stages. |
+| **Data shape** | `Call.playbookId` (existing FK). One Call belongs to exactly one Playbook for its entire lifetime — no mid-call mode switching in v1. |
+| **Invariant** | The entry point selects the sibling; the learner does not "pick a Course mid-call". Mode-switching (Pop Quiz → Revision Aid for the same learner) requires end-call + start-call. |
+| **Enforcement** | Existing FK; Story A3 (#1040) adds the post-join landing page that lets a multi-Playbook-cohort learner pick which sibling to start. Out-of-scope tightening (`Invite.playbookId` mandatory) deferred to a separate story per #1034 TL review. |
+| **Test** | E2E (per Story A3 scope when built) — same Caller enrolled in N siblings, click sibling A's "Start" card → `Call.playbookId == A`. |
+| **Memory doc** | `docs/flow-call-lifecycle.md`; #1040 Story body. |
+| **Audit counter** | n/a (existing FK is the surface). |
+| **Reinforced by** | #1034 (groundwork) + #1040 (learner UI). |
+
+### CC-D — Call → COMPOSE Curriculum resolution
+
+| Field | Value |
+|---|---|
+| **Producer** | Call start (`Call.playbookId` is the input). |
+| **Consumer** | Pipeline COMPOSE — `lib/curriculum/resolve-module.ts::resolveCurriculumIdForPlaybook(playbookId)` returns the shared Curriculum id. Used by `app/api/calls/[callId]/pipeline/route.ts:148`, `lib/prompt/composition/SectionDataLoader.ts:1128`, `lib/prompt/compose-content-section.ts:374` and `:564`. |
+| **Data shape** | `resolveCurriculumIdForPlaybook(playbookId) → curriculumId | null` — reads PlaybookCurriculum first (any role, primary before linked, oldest createdAt within role), falls back to the deprecated `Curriculum.playbookId` column only when no join row exists. |
+| **Invariant** | Variant Playbooks MUST resolve to the parent's shared Curriculum, not null. The pre-#1034 implementation queried the deprecated column directly and silently returned null for variants → pipeline skipped module-aware composition for every variant Call. Pinning this invariant is the TL hard-block resolution. |
+| **Enforcement** | The resolver itself + 5 hot-reader migrations (Task 3 of #1034). Each hot reader keeps the deprecated-column fallback path for transition rollback safety; the fallback is removed in #1038. |
+| **Test** | `tests/lib/curriculum/resolve-curriculum-for-playbook.test.ts` includes the explicit "REGRESSION (TL block #1): variant Playbook's linked row resolves to PARENT's Curriculum" case. Future: integration test that runs a variant Call through pipeline COMPOSE and asserts module-aware section renders. |
+| **Memory doc** | `docs/flow-prompt-composition.md` + `lib/curriculum/resolve-module.ts` header. |
+| **Audit counter** | Propose `variantCallsWithNullCurriculum` (target 0) once the variant flow is in production. |
+| **Reinforced by** | #1034 (Task 2 + Task 3). |
+
+### CC-E — AGGREGATE → cross-Playbook mastery scope (INTENTIONAL)
+
+| Field | Value |
+|---|---|
+| **Producer** | AGGREGATE-stage writes — `CallerAttribute.lo_mastery:{moduleSlug}:{loRef}` (#611 canonical slug form) and `CallerModuleProgress` rows. |
+| **Consumer** | COMPOSE on every sibling Playbook's next Call for the same Caller. Mastery flows naturally because: (a) `lo_mastery` keys are slug-keyed and the variant shares the parent's CurriculumModule slugs; (b) `CallerModuleProgress @@unique([callerId, moduleId])` shares one row across siblings because moduleId UUIDs ARE shared. |
+| **Data shape** | Existing — no schema change. The new fact is that the rows are now CROSS-PLAYBOOK scoped by *design* for a given Caller. |
+| **Invariant** | **Intentional cross-Playbook scope.** A Caller doing Pop Quiz → Revision Aid → Exam Assessment writes and reads the same mastery rows. Variants compose against the same EMA. This is the funnel mechanism and must not be "fixed" as a bug. |
+| **Enforcement** | Documented here. Future test (Story A test bank): triple-enroll a Caller, run a Call against sibling A, assert sibling B's pipeline reads the same `lo_mastery:M3:LO2.3` row. |
+| **Test** | Pending integration test for the triple-sibling funnel. Existing AGGREGATE unit tests (`tests/lib/pipeline/aggregate-*`) implicitly cover the write side; cross-sibling READ is the new assertion class. |
+| **Memory doc** | `docs/ENTITIES.md` (CallerAttribute + CallerModuleProgress); this row. |
+| **Audit counter** | TBD — `crossSiblingMasteryDivergence` (target 0) — non-trivial to compute, defer until needed. |
+| **Reinforced by** | #1034 (documentation only — the mechanism is pre-existing). |
+
+### CC-F — SIM playbook-curriculum precondition
+
+| Field | Value |
+|---|---|
+| **Producer** | `scripts/sim-drive-call.ts` (and any future sim runner). |
+| **Consumer** | Pipeline COMPOSE during the simulated Call. |
+| **Data shape** | `(playbookId, curriculumId)` linkage MUST exist before sim runs. Pre-flight: `await prisma.playbookCurriculum.findFirst({where:{playbookId}})` returns a row OR `Curriculum.playbookId === playbookId` (transition fallback). |
+| **Invariant** | A sim launched against a Playbook with no shared Curriculum MUST fail fast with a clear error, not proceed silently and produce a malformed Call. |
+| **Enforcement** | Pre-flight check in `sim-drive-call.ts` (added per #1034 Task 9 scope). Future: shared precondition helper in `lib/sim/preflight.ts` so other sim runners pick it up automatically. |
+| **Test** | `tests/scripts/sim-drive-call-preflight.test.ts` (new — pending Task 9): sim with un-linked Playbook exits non-zero; sim with primary or linked Curriculum proceeds. |
+| **Memory doc** | `scripts/sim-drive-call.ts` header + this row. |
+| **Audit counter** | n/a (sim is a CI/dev surface). |
+| **Reinforced by** | #1034 (Task 9 — pre/post-snapshot CHAIN tests). |
+
+---
+
 ## 4. DataContract registry
 
 The runtime DataContract registry (`lib/contracts/`) is the DB-backed source of truth for storage-key patterns. Contract files live in `apps/admin/docs-archive/bdd-specs/contracts/` and are seeded into `DataContract` rows on `db:seed`.
@@ -400,6 +493,7 @@ If a chain row above references "DataContract slug: implicit" and the contract i
 
 | Date | Change |
 |---|---|
+| 2026-06-04 | **Section 3d added — Course Variant product line (#1034).** Six new contracts (CC-A through CC-F) covering: PlaybookCurriculum join-table linkage; curriculum mutation fanout across siblings (`resolvePlaybookIdForCurriculum` signature changed from `string\|null` to `string[]`); Enrollment → Call.playbookId scoping (per-Course entry surfaces, no mid-call switching in v1 — Story A3 #1040 closes the learner-side UI); Call → COMPOSE Curriculum resolution (closes TL hard-block: pre-#1034 variants silently skipped module-aware composition because the resolver queried the deprecated `Curriculum.playbookId` column directly); AGGREGATE → cross-Playbook mastery scope (INTENTIONAL — slug-keyed `lo_mastery:*` and shared `CallerModuleProgress` rows are the funnel mechanism); SIM playbook-curriculum precondition (pre-flight in `sim-drive-call.ts`). Deprecated `Curriculum.playbookId` column stays for one release as a primary-owner pointer + transition fallback; dropped in #1038. Wizard write sites dual-write column + `PlaybookCurriculum{role:'primary'}` row in the same `prisma.$transaction` to prevent two-write divergence. Five preset config keys (`teachingProfile`, `welcomeMessage`, `maxCallDurationSeconds`, `modelTier`, `bloomLevelOverride`, `useFreshMastery`) on `Playbook.config` are forward-declared per the TL re-review — stored as JSON, no runtime effect today. Cost tiering (`modelTier`) and Bloom override ship in follow-up stories. Variant route NEVER writes `CurriculumModule` or `Curriculum` rows — the funnel depends on shared UUIDs (CC-A invariant pinned by `tests/lib/playbooks/create-variant.test.ts`). |
 | 2026-06-03 | **Link 3 sub-contract added — COMPOSE → LLM output invariants (#1008 / closes #1006).** Five output invariants enforced inside `executeComposition` before `persistComposedPrompt`: I-C1 module-lock honoured; I-C2 call-counter coherence; I-C3 no memory-less reminisce; I-C4 no generic-noun fallback in instructions (ESLint-enforced); I-C5 `estimatedProgress` heuristic is debug-only. Source: confirmed hallucination on caller `e1df05fa-9c85-4972-9bbe-b13e52784841` (Maya, IELTS Prep Lab) — `ComposedPrompt cd8e2995` simultaneously locked Part 2, asked the AI to spaced-retrieve Part 1, and supplied `key_memories: null`, so the model fabricated Part 2 progress specifics ("from one-minute panic to past 90 seconds") to maintain conversational coherence. Same anti-pattern class as #605 (categoryToTeachMethod fallback) and #608 (SYSTEM IDENTITY fallback) — silent code-side defaults masking missing data. **I-C1 + I-C2 land as `severity: "error"` from day 1** (binary invariants; Maya's vitest fixture is the reproducer). **I-C3 / I-C4 / I-C5 land as `"warn"`** and promote per-invariant to `"error"` after the matching audit counter reads 0 across dev/test/prod for ≥7 days. New ESLint rule `hf-compose/no-orphan-instruction-fallback` blocks the `${x?.name \|\| "previous concept"}` pattern class in `lib/prompt/composition/transforms/**` (rule-family pattern, sibling to `hf-curriculum/no-unscoped-slug-lookup`). **Co-landing spec-driven mutation hardcoding sweep:** replaces bare `masteryThreshold: 0.7` literals in `app/api/calls/[callId]/pipeline/route.ts` authored-module paths and `runLearningAssessmentFallback` with `DEFAULT_MASTERY_THRESHOLD` / `ContractRegistry.getThresholds('CURRICULUM_PROGRESS_V1')?.masteryComplete` (the registry call is already correctly used at line 397 of the same file then bypassed two functions later — exact same miss class as #605). Mock-engine `confidence: 0.7` → `guardrails.confidenceBounds.defaultConfidence`. `lib/pipeline/adapt-runner.ts::applyAdaptationAction`'s silent-fallback `targetValue ?? 0.5` writes get `// TODO(ai-guard):` markers and a child issue for the proper fix. Five new audit counters: `composeLockedModuleMismatch`, `composeCallCounterIncoherent`, `composeMemorylessReminisceCount`, `composeGenericNounFallbackCount`, `composeHeuristicProgressFallback` — all `kind: "invariant"`, target 0, baseline JSON updated in the same commit. Also fixed stale path in the TUNER → COMPOSE row (`lib/playbook/bump-timestamp.ts` → `lib/compose/bump-timestamp.ts`) — the file lives in `lib/compose/`, never `lib/playbook/`. |
 | 2026-05-27 | **Link L9 added — learner-facing module-picker reachability (#948).** Pins the silent-reachability invariant exposed by PR #947's `/x/sim` fix. Every learner-facing page that mounts a session on a Playbook MUST resolve `playbookId` via the canonical fallback (URL → single ACTIVE enrollment → most-recently enrolled ACTIVE → empty state). Shared helper at `lib/caller/resolve-active-playbook.ts` + API wrapper at `/api/callers/[id]/active-playbook` + arch-checker Check G (soft warn) + integration journey test on 4 caller shapes + 13-case vitest. Defends against a learner deep-linking into the sim view, missing the picker silently, and being unable to focus a session. |
 | 2026-05-27 | **Section 3c added — learner-surfacing contracts. Link L1: scheduler → learner (PRs #920 (#917 Slice 2) + #924 (#923 writer copy)).** First pipeline→learner contract boundary: scheduler `reason` field, written to `CallerAttribute` during COMPOSE, exposed via `GET /api/student/scheduler-decision` and rendered in SimProgressPanel. Five-layer enforcement (writer copy constants + build-time regression + route sanitizer + strict response shape + multi-curriculum/stale guards). Known gap #919 (multi-curriculum writer key shape) documented at read-time guard, pending writer-side fix. |


### PR DESCRIPTION
Closes #1034. Follow-ups #1035, #1038, #1040, #1041 are parked.

## Summary

- Adds `PlaybookCurriculum` join table — sibling Variant Playbooks share one Curriculum (and one `CurriculumModule` UUID set), which is what makes the funnel work: Pop Quiz finds a gap → Revision Aid teaches it → Exam Assessment scores against it, all reading and writing the same `lo_mastery:*` / `CallerModuleProgress` rows.
- New `POST /api/playbooks/[id]/variant` + `Create Variant` button on Course detail.
- Six chain contracts documented (CC-A through CC-F in `docs/CHAIN-CONTRACTS.md` §3d).
- Deprecated `Curriculum.playbookId` column stays for one release; full readers migration + drop is follow-up #1038.

## Architecture changes worth eyeballing

1. **Resolver flip** — `resolveCurriculumIdForPlaybook` now reads `PlaybookCurriculum` first and falls back to the deprecated column. Pre-PR this query returned `null` for variant Playbooks → pipeline silently skipped module-aware composition for every variant Call. TL hard-block #1 closed; regression test pinned at `tests/lib/curriculum/resolve-curriculum-for-playbook.test.ts`.
2. **Fanout** — `resolvePlaybookIdForCurriculum` + `…ForCurriculumModule` signature went from `string | null` → `string[]`. All 7 callers iterate and bump every sibling's `composeInputsUpdatedAt`. New helper `lib/compose/bump-curriculum-fanout.ts` is the canonical surface for future write sites.
3. **Wizard dual-write** — `apply-projection.ts::ensureCurriculum` + `sync-authored-modules-to-curriculum.ts` write both the deprecated column and a `PlaybookCurriculum{role:'primary'}` row in the SAME `prisma.\$transaction`. Two-write divergence is a real bug class — same-tx is the invariant.
4. **Variant route NEVER writes CurriculumModule** — the funnel literally depends on shared UUIDs. Snapshot test pins this (CC-A invariant).
5. **5 preset config keys forward-declared** — `teachingProfile`, `welcomeMessage`, `maxCallDurationSeconds`, `modelTier`, `bloomLevelOverride`, `useFreshMastery` are stored on `Playbook.config` but have no runtime effect today. Cost tiering + Bloom override ship in follow-up stories.

## Test plan

- [x] 32 unit tests pass on VM (resolver-curriculum-for-playbook + resolve-playbook-for-curriculum + bump-curriculum-fanout + create-variant)
- [x] 4 DB-backed integration tests pass on hf_sandbox (`course-variant-funnel.integration.test.ts`)
- [x] Migration `20260604_2046_1034_add_playbook_curriculum_join` applied cleanly on hf_sandbox
- [ ] Smoke test on dev/staging — see issue comment after merge

## Deploy

`/vm-cpp` for VM (Prisma migration). Then `/deploy` to dev for cloud QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)