### PR TITLE
fix(tests): align update_curriculum_metadata pendingChange test with #1034

### DIFF
--- a/apps/admin/tests/lib/admin-tools-pending-change.test.ts
+++ b/apps/admin/tests/lib/admin-tools-pending-change.test.ts
@@ -219,11 +219,13 @@ describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () =
     });
   });
 
-  it("update_curriculum_metadata emits pendingChange with playbookId from curriculum", async () => {
+  it("update_curriculum_metadata emits pendingChange with the representative sibling Playbook (#1034)", async () => {
+    // #1034 — handler now resolves sibling Playbooks via resolvePlaybookIdForCurriculum
+    // instead of reading the deprecated Curriculum.playbookId column directly.
+    // pendingChange.scopeId is the representative (first = primary by ordering).
     mockPrisma.curriculum.findUnique.mockResolvedValue({
       id: "cur-1",
       name: "Old",
-      playbookId: "pb-9",
     });
     mockPrisma.curriculum.update.mockResolvedValue({
       id: "cur-1",
@@ -233,6 +235,11 @@ describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () =
       sourceYear: null,
       authors: [],
     });
+    const { resolvePlaybookIdForCurriculum } = await import(
+      "@/lib/curriculum/resolve-playbook-for-curriculum"
+    );
+    (resolvePlaybookIdForCurriculum as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(["pb-9", "pb-variant-1", "pb-variant-2"]);
     const raw = await executeAdminTool(
       "update_curriculum_metadata",
       { curriculum_id: "cur-1", name: "New" },


### PR DESCRIPTION
Post-merge fix for the broken test that landed in #1046. The
\`update_curriculum_metadata pendingChange\` test was asserting the
pre-#1034 semantic (scopeId from \`Curriculum.playbookId\` directly);
post-#1034 the handler resolves via \`resolvePlaybookIdForCurriculum\`
and uses the representative sibling as scopeId.

Updated the test mocks + assertion accordingly. Test now passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)