### PR TITLE
chore(vm-cpp): wire npm run tallyseal:migrate into the deploy heredoc

### DIFF
--- a/.claude/commands/vm-cpp.md
+++ b/.claude/commands/vm-cpp.md
@@ -78,6 +78,12 @@ gcloud compute ssh hf-dev --zone=europe-west2-a --tunnel-through-iap -- bash <<'
   echo "==> Regenerating Prisma client..."
   npx prisma generate
 
+  echo "==> Running tallyseal migrations..."
+  # Applies @tallyseal/prisma-adapter raw-SQL migrations (idempotent +
+  # checksum-pinned per ratchet #4). Runs AFTER `prisma generate` so the
+  # freshly-regenerated Prisma client is used by the runner. See #1045.
+  npm run tallyseal:migrate
+
   # ONLY if seed files changed — include this block:
   # echo "==> Seeding..."
   # npx tsx prisma/seed-full.ts


### PR DESCRIPTION
## Summary

Follows up #1045 which shipped the `npm run tallyseal:migrate` script. Adds the call to the canonical `/vm-cpp` heredoc between `prisma generate` and the dev-server restart, so the 5 @tallyseal/prisma-adapter migrations land automatically on every dev deploy instead of waiting on operator memory.

## Diff

```diff
   echo "==> Regenerating Prisma client..."
   npx prisma generate

+  echo "==> Running tallyseal migrations..."
+  # Applies @tallyseal/prisma-adapter raw-SQL migrations (idempotent +
+  # checksum-pinned per ratchet #4). Runs AFTER `prisma generate` so the
+  # freshly-regenerated Prisma client is used by the runner. See #1045.
+  npm run tallyseal:migrate
+
   # ONLY if seed files changed — include this block:
```

## Test plan
- [x] Diff is the canonical insertion point per the script's own dependency note (prisma client must be regenerated first).
- [ ] Next `/vm-cpp` run picks it up (no other functional change to the command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)