### PR TITLE
feat(docs): include VAPI tools in AI-CAPABILITIES generator (#1026)

### DIFF
--- a/apps/admin/scripts/generate-ai-capabilities.ts
+++ b/apps/admin/scripts/generate-ai-capabilities.ts
@@ -30,6 +30,10 @@ import * as path from "path";
 import { ADMIN_TOOLS } from "../lib/chat/admin-tools";
 import { CONVERSATIONAL_TOOLS } from "../lib/chat/conversational-wizard-tools";
 import { COURSE_REF_TOOLS } from "../lib/chat/course-ref-tools";
+// AnyVoice #1026 — surface the voice (VAPI) tool definitions as a 4th
+// registry so the CI gate covers them. TODO(#1019): point this scraper at
+// the TOOLS-001 spec once VAPI_TOOL_DEFINITIONS is migrated to spec-driven.
+import { VAPI_TOOL_DEFINITIONS } from "../app/api/vapi/tools/route";
 
 const ROOT = path.resolve(__dirname, "../../..");
 const DOC_PATH = path.resolve(ROOT, "docs/AI-CAPABILITIES.md");
@@ -68,6 +72,23 @@ const REGISTRIES: RegistrySpec[] = [
     schemaFile: "apps/admin/lib/chat/course-ref-tools.ts",
     tools: COURSE_REF_TOOLS,
     handlerFile: path.resolve(ROOT, "apps/admin/lib/chat/course-ref-tool-handlers.ts"),
+  },
+  {
+    // AnyVoice #1026. VAPI_TOOL_DEFINITIONS uses the OpenAI tool-call
+    // shape (`{ type, function: { name, description, parameters } }`);
+    // the other three registries use the Anthropic-style flat shape.
+    // Adapt to the internal RegistrySpec shape so the same renderer
+    // covers all four surfaces. Auth is webhook-secret (see
+    // verifyVapiRequest in app/api/vapi/tools/route.ts), not session
+    // role — TOOL_MIN_ROLE will be empty and the doc shows "(route-level)".
+    surface: "Voice (VAPI custom tools)",
+    schemaFile: "apps/admin/app/api/vapi/tools/route.ts",
+    tools: VAPI_TOOL_DEFINITIONS.map((t) => ({
+      name: t.function.name,
+      description: t.function.description,
+      input_schema: t.function.parameters,
+    })),
+    handlerFile: path.resolve(ROOT, "apps/admin/app/api/vapi/tools/route.ts"),
   },
 ];
 

--- a/docs/AI-CAPABILITIES.md
+++ b/docs/AI-CAPABILITIES.md
@@ -4,9 +4,9 @@
 
 This mirrors what the AI sees at every chat turn across all three AI surfaces. "Live" tools execute real handlers. "Roadmap stubs" return a friendly refusal that points the user at the UI surface to use today.
 
-> Last generated: 2026-05-26T16:25:17.737Z
-> Surfaces: 3
-> Total tools: 48 (42 live, 6 roadmap stubs)
+> Last generated: 2026-06-04T15:47:40.485Z
+> Surfaces: 4
+> Total tools: 58 (52 live, 6 roadmap stubs)
 
 ## Contract
 
@@ -103,6 +103,27 @@ Source: `apps/admin/lib/chat/course-ref-tools.ts`
 | `show_ref_preview` | (route-level) | `sections` | — | Update the preview panel to show the current state of one or more sections. |
 | `show_suggestions` | (route-level) | `question`, `suggestions` | — | Show clickable quick-reply chips above the chat input. |
 | `update_ref` | (route-level) | `section`, `data` | — | Save or update a section of the course reference document. |
+
+## Voice (VAPI custom tools)
+
+Source: `apps/admin/app/api/vapi/tools/route.ts`
+
+10 live, 0 stubs.
+
+### Live tools
+
+| Tool | Min role | Required | Optional | Summary |
+|------|----------|----------|----------|---------|
+| `check_mastery` | (route-level) | `module` | — | Check if the caller has mastered a specific module or concept. |
+| `get_next_module` | (route-level) | — | — | Find out what the next module or topic is in the caller's curriculum. |
+| `get_practice_question` | (route-level) | `topic` | — | Get a practice question or scenario for the current topic. |
+| `log_activity_result` | (route-level) | `activity_id`, `outcome` | `topic`, `notes` | Log the result of an interactive activity (pop quiz, MCQ, scenario, teach-back, etc. |
+| `lookup_teaching_point` | (route-level) | `topic` | `limit` | Look up specific teaching content or facts about a topic. |
+| `lookup_vocabulary` | (route-level) | `term` | — | Look up the definition of a word or term from the course materials. |
+| `record_observation` | (route-level) | `key`, `value` | `category` | Record an important observation about the caller during the conversation. |
+| `request_artifact` | (route-level) | `type`, `title`, `content` | `reason` | Request that a study artifact be sent to the caller after the call. |
+| `send_text_to_caller` | (route-level) | `message` | `purpose` | Send a text message (SMS) to the caller. |
+| `share_content` | (route-level) | `media_id` | `caption` | Share a visual aid (image, diagram, PDF) with the caller. |
 
 ## Promoting a stub
 


### PR DESCRIPTION
## Summary
AnyVoice epic #1015 — extends `scripts/generate-ai-capabilities.ts` to scrape `VAPI_TOOL_DEFINITIONS` as a 4th registry so the CI drift gate covers voice tools too.

Pre-#1019 the 10 voice tools were invisible to `docs/AI-CAPABILITIES.md` — 3-of-4 surfaces covered. This adds the 4th. The generator's TOOLS-001 redirect happens in #1019; this PR keeps the constant covered until that lands.

## Changes
- New 4th `RegistrySpec` entry in `scripts/generate-ai-capabilities.ts`
- Adapter maps OpenAI tool-call shape (`{type, function: {...}}`) to internal flat shape
- `docs/AI-CAPABILITIES.md` regenerated — now 4 surfaces, 58 tools, 6 stubs
- Min role displays "(route-level)" — accurate (VAPI tools webhook-auth'd)

## Test plan
- [x] `npm run docs:ai-capabilities` rewrites doc
- [x] `npm run docs:ai-capabilities:check` passes
- [x] Drift gate verified — STALE on description edit, OK after revert

## Deploy
`/vm-cp`

Closes #1026
Part of #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)