### PR TITLE
feat(schema): rename Call.vapi* to canonical voice* + voiceProviderRaw (#1020)

### DIFF
--- a/apps/admin/app/api/vapi/webhook/route.ts
+++ b/apps/admin/app/api/vapi/webhook/route.ts
@@ -23,11 +23,11 @@ export const runtime = "nodejs";
  *
  *   Events handled:
  *   - end-of-call-report: Create Call record from the normalised event;
- *     persists recordingUrl, stereoRecordingUrl, vapiDurationSeconds,
- *     vapiEndedReason, vapiCostUsd, and the analysis.{summary,
- *     structuredData, successEvaluation} block when present.
- *     The schema rename (#1020) will retire the vapi*-prefixed columns
- *     in favour of canonical voice* fields.
+ *     persists recordingUrl, stereoRecordingUrl, voiceDurationSeconds,
+ *     voiceEndedReason, voiceCostUsd, and the analysis.{summary,
+ *     structuredData, successEvaluation} block when present (now
+ *     stored in voiceAnalysisSummary / voiceStructuredData /
+ *     voiceSuccessEvaluation columns post-#1020).
  *   - status-update: Log call status changes
  *
  *   Ref: https://docs.vapi.ai/server-url/events
@@ -134,18 +134,20 @@ async function handleEndOfCallReport(event: {
   // Resolve default playbook for course-scoped calls
   const playbookId = callerId ? await resolvePlaybookId(callerId) : null;
 
-  // Translate canonical capture keys to the current schema column names.
-  // After #1020 this block becomes a direct spread (`...capture`) because
-  // capture keys and column names will align.
+  // Map canonical capture keys to the current schema column names.
+  // Post-#1020 the column names are voice*-prefixed; the mapping is
+  // mostly a 1:1 prefix swap but kept explicit so the writer is
+  // grep-able and future provider adapters know exactly what shape
+  // the Call row expects.
   const persistableCapture: Record<string, unknown> = {};
   if (capture.recordingUrl !== undefined) persistableCapture.recordingUrl = capture.recordingUrl;
   if (capture.stereoRecordingUrl !== undefined) persistableCapture.stereoRecordingUrl = capture.stereoRecordingUrl;
-  if (capture.durationSeconds !== undefined) persistableCapture.vapiDurationSeconds = capture.durationSeconds;
-  if (capture.endedReason !== undefined) persistableCapture.vapiEndedReason = capture.endedReason;
-  if (capture.costUsd !== undefined) persistableCapture.vapiCostUsd = capture.costUsd;
-  if (capture.analysisSummary !== undefined) persistableCapture.vapiAnalysisSummary = capture.analysisSummary;
-  if (capture.structuredData !== undefined) persistableCapture.vapiStructuredData = capture.structuredData as Prisma.InputJsonValue;
-  if (capture.successEvaluation !== undefined) persistableCapture.vapiSuccessEvaluation = capture.successEvaluation;
+  if (capture.durationSeconds !== undefined) persistableCapture.voiceDurationSeconds = capture.durationSeconds;
+  if (capture.endedReason !== undefined) persistableCapture.voiceEndedReason = capture.endedReason;
+  if (capture.costUsd !== undefined) persistableCapture.voiceCostUsd = capture.costUsd;
+  if (capture.analysisSummary !== undefined) persistableCapture.voiceAnalysisSummary = capture.analysisSummary;
+  if (capture.structuredData !== undefined) persistableCapture.voiceStructuredData = capture.structuredData as Prisma.InputJsonValue;
+  if (capture.successEvaluation !== undefined) persistableCapture.voiceSuccessEvaluation = capture.successEvaluation;
 
   // Stamp callSequence (1, 2, 3...) so the prompt timeline can label this
   // call as "Call N". Without it, the UI shows "—" or jumps. Only meaningful
@@ -232,23 +234,25 @@ async function triggerPipeline(callId: string, callerId: string) {
 }
 
 /**
- * Re-export for backward compatibility — the existing test
- * `tests/lib/vapi-extract-capture.test.ts` imports this name. The canonical
- * extractor lives at `lib/voice/providers/vapi::extractVapiCapture` and
- * returns provider-neutral key names; this shim translates those back to
- * the current Call-column names (the schema rename #1020 retires the
- * shim along with the columns).
+ * Re-export for backward compatibility — the existing test at
+ * `tests/lib/vapi-extract-capture.test.ts` imports this name. The
+ * canonical extractor lives at `lib/voice/providers/vapi::extractVapiCapture`
+ * and returns provider-neutral key names; this shim translates those to
+ * the post-#1020 Call-column names (`voice*`-prefixed). The shim now
+ * exists purely to keep the test surface stable — once the test imports
+ * directly from the canonical extractor + asserts canonical keys, this
+ * re-export goes away.
  */
 export function extractVapiCapture(message: unknown): Record<string, unknown> {
   const c = extractCanonicalCapture(message);
   const out: Record<string, unknown> = {};
   if (c.recordingUrl !== undefined) out.recordingUrl = c.recordingUrl;
   if (c.stereoRecordingUrl !== undefined) out.stereoRecordingUrl = c.stereoRecordingUrl;
-  if (c.durationSeconds !== undefined) out.vapiDurationSeconds = c.durationSeconds;
-  if (c.endedReason !== undefined) out.vapiEndedReason = c.endedReason;
-  if (c.costUsd !== undefined) out.vapiCostUsd = c.costUsd;
-  if (c.analysisSummary !== undefined) out.vapiAnalysisSummary = c.analysisSummary;
-  if (c.structuredData !== undefined) out.vapiStructuredData = c.structuredData;
-  if (c.successEvaluation !== undefined) out.vapiSuccessEvaluation = c.successEvaluation;
+  if (c.durationSeconds !== undefined) out.voiceDurationSeconds = c.durationSeconds;
+  if (c.endedReason !== undefined) out.voiceEndedReason = c.endedReason;
+  if (c.costUsd !== undefined) out.voiceCostUsd = c.costUsd;
+  if (c.analysisSummary !== undefined) out.voiceAnalysisSummary = c.analysisSummary;
+  if (c.structuredData !== undefined) out.voiceStructuredData = c.structuredData;
+  if (c.successEvaluation !== undefined) out.voiceSuccessEvaluation = c.successEvaluation;
   return out;
 }

--- a/apps/admin/prisma/migrations/20260604_1040_1020_rename_vapi_to_voice/migration.sql
+++ b/apps/admin/prisma/migrations/20260604_1040_1020_rename_vapi_to_voice/migration.sql
@@ -1,0 +1,23 @@
+-- AnyVoice #1020: rename vapi*-prefixed Call columns to canonical voice*
+-- + add voiceProviderRaw Json for provider-specific extras.
+--
+-- Closes the I-VP3 invariant in CHAIN-CONTRACTS.md Link 3 sub-contract:
+-- canonical Call columns MUST NOT carry provider-specific vocabulary.
+-- The columns themselves stay typed (duration / cost / endedReason /
+-- analysisSummary / structuredData / successEvaluation) — only the
+-- prefix changes. Extras blob is the new escape hatch for genuinely
+-- provider-shaped fields that don't fit a canonical column.
+--
+-- ALTER ... RENAME COLUMN is metadata-only on Postgres — no row rewrite,
+-- no lock-escalation, safe under load. Migration-checker validated.
+-- Existing test fixture (vapi-end-of-call-report.json) is unchanged
+-- because it stores the VAPI payload shape, not the DB column names.
+
+ALTER TABLE "Call" RENAME COLUMN "vapiDurationSeconds"   TO "voiceDurationSeconds";
+ALTER TABLE "Call" RENAME COLUMN "vapiEndedReason"       TO "voiceEndedReason";
+ALTER TABLE "Call" RENAME COLUMN "vapiCostUsd"           TO "voiceCostUsd";
+ALTER TABLE "Call" RENAME COLUMN "vapiAnalysisSummary"   TO "voiceAnalysisSummary";
+ALTER TABLE "Call" RENAME COLUMN "vapiStructuredData"    TO "voiceStructuredData";
+ALTER TABLE "Call" RENAME COLUMN "vapiSuccessEvaluation" TO "voiceSuccessEvaluation";
+
+ALTER TABLE "Call" ADD COLUMN "voiceProviderRaw" JSONB;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -1464,20 +1464,35 @@ model Call {
   // referencing the VoiceProvider table.)
   voiceProvider String @default("vapi")
 
-  // VAPI end-of-call payload capture (Phase 0 of plan-voice-analysis.md). Captured
-  // verbatim from VAPI's `end-of-call-report` message body — see
-  // https://docs.vapi.ai/server-url/events. All nullable so SIM, manual, and
-  // legacy paths continue to create Call rows with these fields unset.
-  // No consumer reads them today; AssemblyAI / voice-analysis pipeline (deferred)
-  // will be the first reader.
+  // Voice end-of-call capture — canonical, provider-neutral columns
+  // populated by the adapter's normaliseEndOfCallEvent (#1017 / #1020).
+  // Canonical typed columns for fields every voice provider has an
+  // analogue for (duration, cost, ended-reason, analysis summary,
+  // success evaluation). Provider-specific extras land in
+  // voiceProviderRaw Json so the typed surface stays portable.
+  //
+  // recordingUrl / stereoRecordingUrl predate the rename and were
+  // already neutral, so they keep their names.
+  //
+  // Renamed from vapi*-prefixed columns in #1020. Pre-rename the names
+  // leaked VAPI vocabulary into a model meant to span every provider —
+  // direct violation of the I-VP3 invariant in CHAIN-CONTRACTS.md Link
+  // 3 sub-contract (COMPOSE → VOICE PROVIDER).
   recordingUrl          String?
   stereoRecordingUrl    String?
-  vapiDurationSeconds   Float?
-  vapiEndedReason       String?
-  vapiCostUsd           Float?
-  vapiAnalysisSummary   String? @db.Text
-  vapiStructuredData    Json?
-  vapiSuccessEvaluation String?
+  voiceDurationSeconds  Float?
+  voiceEndedReason      String?
+  voiceCostUsd          Float?
+  voiceAnalysisSummary  String? @db.Text
+  voiceStructuredData   Json?
+  voiceSuccessEvaluation String?
+  /// Provider-specific extras the adapter wants to stash that don't
+  /// fit a canonical column. Anything in here is opaque to HF —
+  /// only the provider that wrote it knows the shape. Do NOT query
+  /// or index fields inside this blob in shared code; if a field
+  /// is read by anything other than its provider's own adapter,
+  /// promote it to a canonical column.
+  voiceProviderRaw      Json?
 
   @@index([source])
   @@index([externalId])

--- a/apps/admin/tests/lib/vapi-extract-capture.test.ts
+++ b/apps/admin/tests/lib/vapi-extract-capture.test.ts
@@ -22,16 +22,16 @@ describe("extractVapiCapture", () => {
     expect(result).toEqual({
       recordingUrl: "https://storage.vapi.ai/recordings/abc-123-mono.mp3",
       stereoRecordingUrl: "https://storage.vapi.ai/recordings/abc-123-stereo.wav",
-      vapiDurationSeconds: 187.4,
-      vapiEndedReason: "customer-ended-call",
-      vapiCostUsd: 0.0734,
-      vapiAnalysisSummary: expect.stringContaining("IELTS speaking practice"),
-      vapiStructuredData: {
+      voiceDurationSeconds: 187.4,
+      voiceEndedReason: "customer-ended-call",
+      voiceCostUsd: 0.0734,
+      voiceAnalysisSummary: expect.stringContaining("IELTS speaking practice"),
+      voiceStructuredData: {
         topic: "IELTS speaking",
         callType: "intake",
         fluencyIndicative: 6.5,
       },
-      vapiSuccessEvaluation: "true",
+      voiceSuccessEvaluation: "true",
     });
   });
 
@@ -61,25 +61,25 @@ describe("extractVapiCapture", () => {
   });
 
   it("omits durationSeconds when NaN / Infinity / non-number", () => {
-    expect(extractVapiCapture({ durationSeconds: "100" }).vapiDurationSeconds).toBeUndefined();
-    expect(extractVapiCapture({ durationSeconds: NaN }).vapiDurationSeconds).toBeUndefined();
-    expect(extractVapiCapture({ durationSeconds: Infinity }).vapiDurationSeconds).toBeUndefined();
-    expect(extractVapiCapture({ durationSeconds: 12.5 }).vapiDurationSeconds).toBe(12.5);
+    expect(extractVapiCapture({ durationSeconds: "100" }).voiceDurationSeconds).toBeUndefined();
+    expect(extractVapiCapture({ durationSeconds: NaN }).voiceDurationSeconds).toBeUndefined();
+    expect(extractVapiCapture({ durationSeconds: Infinity }).voiceDurationSeconds).toBeUndefined();
+    expect(extractVapiCapture({ durationSeconds: 12.5 }).voiceDurationSeconds).toBe(12.5);
   });
 
   it("reads cost as a number directly", () => {
-    expect(extractVapiCapture({ cost: 0.05 }).vapiCostUsd).toBe(0.05);
+    expect(extractVapiCapture({ cost: 0.05 }).voiceCostUsd).toBe(0.05);
   });
 
   it("reads cost.total when cost is an object", () => {
-    expect(extractVapiCapture({ cost: { total: 0.12, llm: 0.08 } }).vapiCostUsd).toBe(0.12);
+    expect(extractVapiCapture({ cost: { total: 0.12, llm: 0.08 } }).voiceCostUsd).toBe(0.12);
   });
 
   it("omits cost when neither shape provides a finite number", () => {
-    expect(extractVapiCapture({ cost: "0.10" }).vapiCostUsd).toBeUndefined();
-    expect(extractVapiCapture({ cost: { total: "0.10" } }).vapiCostUsd).toBeUndefined();
-    expect(extractVapiCapture({ cost: { other: 0.10 } }).vapiCostUsd).toBeUndefined();
-    expect(extractVapiCapture({ cost: NaN }).vapiCostUsd).toBeUndefined();
+    expect(extractVapiCapture({ cost: "0.10" }).voiceCostUsd).toBeUndefined();
+    expect(extractVapiCapture({ cost: { total: "0.10" } }).voiceCostUsd).toBeUndefined();
+    expect(extractVapiCapture({ cost: { other: 0.10 } }).voiceCostUsd).toBeUndefined();
+    expect(extractVapiCapture({ cost: NaN }).voiceCostUsd).toBeUndefined();
   });
 
   it("omits analysis fields when analysis is missing or wrong shape", () => {
@@ -89,13 +89,13 @@ describe("extractVapiCapture", () => {
   });
 
   it("omits summary when not a string", () => {
-    expect(extractVapiCapture({ analysis: { summary: 42 } }).vapiAnalysisSummary).toBeUndefined();
-    expect(extractVapiCapture({ analysis: { summary: null } }).vapiAnalysisSummary).toBeUndefined();
+    expect(extractVapiCapture({ analysis: { summary: 42 } }).voiceAnalysisSummary).toBeUndefined();
+    expect(extractVapiCapture({ analysis: { summary: null } }).voiceAnalysisSummary).toBeUndefined();
   });
 
   it("omits structuredData when it's an array (must be an object record)", () => {
     expect(
-      extractVapiCapture({ analysis: { structuredData: [1, 2, 3] } }).vapiStructuredData,
+      extractVapiCapture({ analysis: { structuredData: [1, 2, 3] } }).voiceStructuredData,
     ).toBeUndefined();
   });
 
@@ -103,26 +103,26 @@ describe("extractVapiCapture", () => {
     const result = extractVapiCapture({
       analysis: { structuredData: { topic: "x", n: 1 } },
     });
-    expect(result.vapiStructuredData).toEqual({ topic: "x", n: 1 });
+    expect(result.voiceStructuredData).toEqual({ topic: "x", n: 1 });
   });
 
   it("coerces successEvaluation booleans to strings", () => {
-    expect(extractVapiCapture({ analysis: { successEvaluation: true } }).vapiSuccessEvaluation).toBe("true");
-    expect(extractVapiCapture({ analysis: { successEvaluation: false } }).vapiSuccessEvaluation).toBe("false");
+    expect(extractVapiCapture({ analysis: { successEvaluation: true } }).voiceSuccessEvaluation).toBe("true");
+    expect(extractVapiCapture({ analysis: { successEvaluation: false } }).voiceSuccessEvaluation).toBe("false");
   });
 
   it("coerces successEvaluation numbers to strings", () => {
-    expect(extractVapiCapture({ analysis: { successEvaluation: 0.75 } }).vapiSuccessEvaluation).toBe("0.75");
-    expect(extractVapiCapture({ analysis: { successEvaluation: 1 } }).vapiSuccessEvaluation).toBe("1");
+    expect(extractVapiCapture({ analysis: { successEvaluation: 0.75 } }).voiceSuccessEvaluation).toBe("0.75");
+    expect(extractVapiCapture({ analysis: { successEvaluation: 1 } }).voiceSuccessEvaluation).toBe("1");
   });
 
   it("preserves successEvaluation string verbatim (e.g. rubric labels)", () => {
-    expect(extractVapiCapture({ analysis: { successEvaluation: "PASS" } }).vapiSuccessEvaluation).toBe("PASS");
+    expect(extractVapiCapture({ analysis: { successEvaluation: "PASS" } }).voiceSuccessEvaluation).toBe("PASS");
   });
 
   it("omits successEvaluation for unknown shapes (object, array, null)", () => {
-    expect(extractVapiCapture({ analysis: { successEvaluation: { rubric: "x" } } }).vapiSuccessEvaluation).toBeUndefined();
-    expect(extractVapiCapture({ analysis: { successEvaluation: null } }).vapiSuccessEvaluation).toBeUndefined();
+    expect(extractVapiCapture({ analysis: { successEvaluation: { rubric: "x" } } }).voiceSuccessEvaluation).toBeUndefined();
+    expect(extractVapiCapture({ analysis: { successEvaluation: null } }).voiceSuccessEvaluation).toBeUndefined();
   });
 
   it("does not throw on a payload with unrelated extra keys", () => {


### PR DESCRIPTION
## Summary
Closes I-VP3 invariant — canonical Call columns must not carry VAPI-specific vocabulary. 6 columns renamed; voiceProviderRaw Json added for extras.

## Changes
- vapiDurationSeconds/EndedReason/CostUsd/AnalysisSummary/StructuredData/SuccessEvaluation → voice*
- Added voiceProviderRaw Json (typed columns kept canonical; extras blob only)
- Webhook writer + back-compat shim updated
- 63 touched tests pass

## Test plan
- [x] migration-checker: SAFE (metadata-only RENAME on Postgres 16)
- [x] Migration sorted as 20260604_1040_* (after 1025/1031 in lex order)

## Deploy
`/vm-cpp`

Closes #1020 · Part of #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)