### PR TITLE
feat(voice): cost telemetry — VOICE UsageCategory + caller/cohort/system aggregator (#1028)

### DIFF
--- a/apps/admin/app/api/voice/costs/route.ts
+++ b/apps/admin/app/api/voice/costs/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  getVoiceCostForCaller,
+  getVoiceCostForCohort,
+  getVoiceCostForPlaybook,
+  getVoiceCostByProviderSystemWide,
+} from "@/lib/voice/cost-aggregator";
+
+export const runtime = "nodejs";
+
+const SCOPES = ["caller", "cohort", "playbook", "system"] as const;
+type Scope = (typeof SCOPES)[number];
+
+/**
+ * @api GET /api/voice/costs
+ * @visibility internal
+ * @scope voice:costs:read
+ * @auth session (OPERATOR for scoped; ADMIN for system-wide)
+ * @tags voice, costs, metering
+ * @description Returns voice-call cost rollups for a chosen scope. Reads
+ *   from Call.voiceCostUsd (denorm snapshot written by the webhook
+ *   normaliser). Currency: USD. Default lookback: 30 days; pass `since`
+ *   as an ISO timestamp to override.
+ * @queryParam scope "caller" | "cohort" | "playbook" | "system" (required)
+ * @queryParam id    The matching id for caller/cohort/playbook scope (required for non-system)
+ * @queryParam since ISO timestamp (optional; default = 30 days ago)
+ * @response 200 { ok: true, summary: VoiceCostSummary }
+ * @response 400 { ok: false, error: "scope required" | "id required" }
+ * @response 403 { ok: false, error: "system scope requires ADMIN" }
+ */
+export async function GET(request: Request) {
+  // Most scopes admit OPERATOR; system requires ADMIN — start permissive,
+  // tighten when scope === "system".
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const { searchParams } = new URL(request.url);
+  const rawScope = searchParams.get("scope");
+  const id = searchParams.get("id");
+  const sinceRaw = searchParams.get("since");
+
+  if (!rawScope || !SCOPES.includes(rawScope as Scope)) {
+    return NextResponse.json(
+      { ok: false, error: `scope must be one of ${SCOPES.join(", ")}` },
+      { status: 400 },
+    );
+  }
+  const scope = rawScope as Scope;
+
+  if (scope !== "system" && !id) {
+    return NextResponse.json(
+      { ok: false, error: `id is required for scope=${scope}` },
+      { status: 400 },
+    );
+  }
+
+  if (scope === "system" && auth.session.user.role !== "ADMIN" && auth.session.user.role !== "SUPERADMIN") {
+    return NextResponse.json(
+      { ok: false, error: "system scope requires ADMIN" },
+      { status: 403 },
+    );
+  }
+
+  const since = sinceRaw ? new Date(sinceRaw) : undefined;
+  if (sinceRaw && since && isNaN(since.getTime())) {
+    return NextResponse.json({ ok: false, error: "since must be an ISO timestamp" }, { status: 400 });
+  }
+
+  let summary;
+  switch (scope) {
+    case "caller":
+      summary = await getVoiceCostForCaller(id as string, since);
+      break;
+    case "cohort":
+      summary = await getVoiceCostForCohort(id as string, since);
+      break;
+    case "playbook":
+      summary = await getVoiceCostForPlaybook(id as string, since);
+      break;
+    case "system":
+      summary = await getVoiceCostByProviderSystemWide(since);
+      break;
+  }
+
+  return NextResponse.json({ ok: true, summary });
+}

--- a/apps/admin/app/x/settings/voice-costs/page.tsx
+++ b/apps/admin/app/x/settings/voice-costs/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/**
+ * System-wide voice spend admin page (AnyVoice #1028).
+ *
+ * ADMIN-only. Reads GET /api/voice/costs?scope=system. Shows the
+ * rolling 30-day spend grouped by provider — provider | calls | total
+ * | avg cost/call. Currency: USD. No edits.
+ *
+ * For per-caller / per-cohort / per-playbook drill-down, the educator
+ * uses the inline VoiceCostPanel on the respective entity's detail
+ * page; this surface is the only system-wide one.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+interface VoiceCostByProvider {
+  provider: string;
+  totalUsd: number;
+  callCount: number;
+}
+
+interface VoiceCostSummary {
+  totalUsd: number;
+  byProvider: VoiceCostByProvider[];
+  callCount: number;
+  since: string | null;
+}
+
+function formatUsd(n: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n);
+}
+
+export default function VoiceCostsAdminPage() {
+  const [summary, setSummary] = useState<VoiceCostSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await fetch("/api/voice/costs?scope=system");
+      const body = await res.json();
+      if (!res.ok || !body.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setSummary(body.summary);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <main className="hf-page">
+      <h1 className="hf-page-title">Voice spend</h1>
+      <p className="hf-page-subtitle">
+        Rolling 30-day total across all callers, grouped by voice provider. Values in USD.
+        Drill-down to per-caller or per-cohort spend lives on the corresponding entity&rsquo;s detail
+        page.
+      </p>
+
+      {err ? (
+        <div className="hf-banner hf-banner-error" role="alert">
+          {err}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="hf-empty">
+          <span className="hf-spinner" aria-label="Loading" /> Loading&hellip;
+        </div>
+      ) : !summary ? null : summary.callCount === 0 ? (
+        <div className="hf-empty">No voice calls with recorded cost in the last 30 days.</div>
+      ) : (
+        <section className="hf-card">
+          <h2 className="hf-section-title">By provider</h2>
+          <table className="hf-table">
+            <thead>
+              <tr>
+                <th>Provider</th>
+                <th style={{ textAlign: "right" }}>Calls</th>
+                <th style={{ textAlign: "right" }}>Total</th>
+                <th style={{ textAlign: "right" }}>Avg / call</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.byProvider.map((row) => (
+                <tr key={row.provider}>
+                  <td>
+                    <strong>{row.provider}</strong>
+                  </td>
+                  <td style={{ textAlign: "right" }}>{row.callCount}</td>
+                  <td style={{ textAlign: "right" }}>{formatUsd(row.totalUsd)}</td>
+                  <td style={{ textAlign: "right" }}>
+                    {row.callCount === 0 ? "—" : formatUsd(row.totalUsd / row.callCount)}
+                  </td>
+                </tr>
+              ))}
+              <tr>
+                <td>
+                  <strong>Total</strong>
+                </td>
+                <td style={{ textAlign: "right" }}>
+                  <strong>{summary.callCount}</strong>
+                </td>
+                <td style={{ textAlign: "right" }}>
+                  <strong>{formatUsd(summary.totalUsd)}</strong>
+                </td>
+                <td style={{ textAlign: "right" }}>
+                  {summary.callCount === 0
+                    ? "—"
+                    : formatUsd(summary.totalUsd / summary.callCount)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -11,6 +11,7 @@ import { FancySelect, type FancySelectOption } from "@/components/shared/FancySe
 import { SectionSelector, useSectionVisibility } from "@/components/shared/SectionSelector";
 import { CallerDomainSection } from "@/components/callers/CallerDomainSection";
 import { VoiceProviderOverride } from "@/components/callers/VoiceProviderOverride";
+import { VoiceCostPanel } from "@/components/callers/VoiceCostPanel";
 import { SimChat } from "@/components/sim/SimChat";
 import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from "@/components/sim/ModulePickerBanners";
 import { SimStateBreadcrumb } from "@/components/sim/SimStateBreadcrumb";
@@ -1158,6 +1159,11 @@ export default function CallerDetailPage() {
           {/* Per-caller voice provider override (AnyVoice #1027). */}
           {showDomainSection && data.caller.id ? (
             <VoiceProviderOverride callerId={data.caller.id} />
+          ) : null}
+
+          {/* Per-caller voice spend summary (AnyVoice #1028). */}
+          {showDomainSection && data.caller.id ? (
+            <VoiceCostPanel callerId={data.caller.id} />
           ) : null}
 
           {insights ? (

--- a/apps/admin/components/callers/VoiceCostPanel.tsx
+++ b/apps/admin/components/callers/VoiceCostPanel.tsx
@@ -1,0 +1,106 @@
+/**
+ * Per-caller voice spend panel (AnyVoice #1028).
+ *
+ * Inline card on the caller detail page. Shows the rolling 30-day
+ * voice cost grouped by provider. Pure read surface — no edits;
+ * cost rates are managed via the metering layer.
+ *
+ * Calls GET /api/voice/costs?scope=caller&id=<callerId>.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+interface VoiceCostByProvider {
+  provider: string;
+  totalUsd: number;
+  callCount: number;
+}
+
+interface VoiceCostSummary {
+  totalUsd: number;
+  byProvider: VoiceCostByProvider[];
+  callCount: number;
+  since: string | null;
+}
+
+function formatUsd(n: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n);
+}
+
+export function VoiceCostPanel({ callerId }: { callerId: string }) {
+  const [summary, setSummary] = useState<VoiceCostSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/voice/costs?scope=caller&id=${encodeURIComponent(callerId)}`);
+      const body = await res.json();
+      if (!res.ok || !body.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setSummary(body.summary);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [callerId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <section className="hf-card">
+        <h3 className="hf-section-title">Voice spend (last 30 days)</h3>
+        <div className="hf-empty">
+          <span className="hf-spinner" aria-label="Loading" /> Loading&hellip;
+        </div>
+      </section>
+    );
+  }
+  if (!summary) {
+    return (
+      <section className="hf-card">
+        <h3 className="hf-section-title">Voice spend (last 30 days)</h3>
+        <div className="hf-banner hf-banner-error">{err ?? "Failed to load"}</div>
+      </section>
+    );
+  }
+
+  if (summary.callCount === 0) {
+    return (
+      <section className="hf-card">
+        <h3 className="hf-section-title">Voice spend (last 30 days)</h3>
+        <p className="hf-section-desc">No voice calls with recorded cost in the last 30 days.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="hf-card">
+      <h3 className="hf-section-title">Voice spend (last 30 days)</h3>
+      <p className="hf-section-desc">
+        <strong>{formatUsd(summary.totalUsd)}</strong> across {summary.callCount} call
+        {summary.callCount === 1 ? "" : "s"}.
+      </p>
+      {summary.byProvider.length > 0 ? (
+        <ul className="hf-kv">
+          {summary.byProvider.map((row) => (
+            <li key={row.provider} className="hf-kv-row">
+              <span>
+                <strong>{row.provider}</strong> &mdash; {row.callCount} call
+                {row.callCount === 1 ? "" : "s"}
+              </span>
+              <span>{formatUsd(row.totalUsd)}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/admin/lib/metering/cost-config.ts
+++ b/apps/admin/lib/metering/cost-config.ts
@@ -141,6 +141,26 @@ export const DEFAULT_COST_RATES: Record<
     unitType: "count",
     description: "VAPI API call",
   },
+
+  // =========================
+  // VOICE CALL COSTS (per minute)
+  // =========================
+  // AnyVoice #1028 — voice providers bill by minutes, not per-call
+  // counts. Keep these under VOICE, NOT EXTERNAL — mixing per-call and
+  // per-minute under the same category corrupts rollups in
+  // lib/metering/rollup.ts. Per-direction (inbound vs outbound) so the
+  // cost model can express asymmetric billing (some providers charge
+  // more for outbound dialled calls).
+  "VOICE:vapi:inbound": {
+    costPerUnit: 0.05,
+    unitType: "minutes",
+    description: "VAPI inbound voice minutes (PSTN-in / web → VAPI)",
+  },
+  "VOICE:vapi:outbound": {
+    costPerUnit: 0.07,
+    unitType: "minutes",
+    description: "VAPI outbound voice minutes (VAPI → PSTN-out)",
+  },
 };
 
 // Cache for DB rates (5 minute TTL)
@@ -256,6 +276,14 @@ export function calculateCost(
     case "mb":
       // quantity is in bytes, convert to MB
       normalizedQty = quantity / (1024 * 1024);
+      break;
+    case "minutes":
+      // Voice (#1028) — quantity arrives in seconds (VAPI's
+      // durationSeconds), convert to minutes for per-minute billing.
+      normalizedQty = quantity / 60;
+      break;
+    case "seconds":
+      // Voice (#1028) — pass through for providers that bill per-second.
       break;
     default:
       // "count", "ms", etc. - use as-is

--- a/apps/admin/lib/voice/cost-aggregator.ts
+++ b/apps/admin/lib/voice/cost-aggregator.ts
@@ -1,0 +1,133 @@
+/**
+ * Voice cost aggregator (AnyVoice #1028).
+ *
+ * Reads denormalised per-call cost snapshots from `Call.voiceCostUsd`
+ * (populated by the webhook normaliser in #1021) and rolls them up by
+ * caller / cohort / playbook / provider for the educator and admin UIs.
+ *
+ * Why denorm snapshot, not metering ledger:
+ *   - VAPI reports final cost at end-of-call; that's a single row write.
+ *   - Per-minute metering (UsageLog category VOICE, added in this PR's
+ *     cost-config.ts) is the path for FUTURE adapters that want to log
+ *     incremental minutes. For VAPI today, the end-of-call snapshot is
+ *     authoritative — no point double-bookkeeping.
+ *   - The Call row is already the join target for caller / cohort /
+ *     playbook scopes, so the rollup query is a simple groupBy.
+ *
+ * Null handling: `voiceCostUsd` is nullable (calls that failed before
+ * billing, SIM calls, pre-#1020 historical rows). Aggregations treat
+ * null as 0 — the SQL `SUM(... )` already does this; the aggregator
+ * also filters with `voiceCostUsd: { not: null }` so a row with zero
+ * recorded cost doesn't inflate the call-count denominator on
+ * "avg cost per call" calculations.
+ *
+ * Currency: VAPI reports USD. UI labels as USD; no implicit conversion.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+export interface VoiceCostByProvider {
+  /** VoiceProvider.slug — same value stored on Call.voiceProvider */
+  provider: string;
+  /** Sum of voiceCostUsd across matching calls. */
+  totalUsd: number;
+  /** Count of calls that contributed (non-null cost rows only). */
+  callCount: number;
+}
+
+export interface VoiceCostSummary {
+  /** Combined total across all providers in scope. */
+  totalUsd: number;
+  /** Per-provider breakdown. */
+  byProvider: VoiceCostByProvider[];
+  /** Number of calls with a recorded cost. Excludes SIM / null-cost rows. */
+  callCount: number;
+  /** ISO timestamp of the earliest call in the window (for "since X" labels). */
+  since: string | null;
+}
+
+/** Default lookback window for educator UI panels. 30 days. */
+export const DEFAULT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+function windowStart(since?: Date): Date {
+  return since ?? new Date(Date.now() - DEFAULT_WINDOW_MS);
+}
+
+async function summarise(
+  where: Record<string, unknown>,
+  since: Date,
+): Promise<VoiceCostSummary> {
+  const grouped = await prisma.call.groupBy({
+    by: ["voiceProvider"],
+    where: {
+      ...where,
+      voiceCostUsd: { not: null },
+      createdAt: { gte: since },
+    },
+    _sum: { voiceCostUsd: true },
+    _count: { _all: true },
+  });
+
+  const byProvider: VoiceCostByProvider[] = grouped.map((g) => ({
+    provider: g.voiceProvider,
+    totalUsd: g._sum.voiceCostUsd ?? 0,
+    callCount: g._count._all,
+  }));
+
+  const totalUsd = byProvider.reduce((acc, r) => acc + r.totalUsd, 0);
+  const callCount = byProvider.reduce((acc, r) => acc + r.callCount, 0);
+
+  return {
+    totalUsd,
+    byProvider,
+    callCount,
+    since: since.toISOString(),
+  };
+}
+
+/** Voice cost for a single learner across the window. */
+export async function getVoiceCostForCaller(
+  callerId: string,
+  since?: Date,
+): Promise<VoiceCostSummary> {
+  return summarise({ callerId }, windowStart(since));
+}
+
+/** Voice cost for every learner in a cohort. Uses the multi-cohort
+ *  membership join table (CallerCohortMembership) — falls back to the
+ *  legacy Caller.cohortGroupId direct relation when membership rows
+ *  don't cover all members (transition period from single → multi). */
+export async function getVoiceCostForCohort(
+  cohortId: string,
+  since?: Date,
+): Promise<VoiceCostSummary> {
+  const memberRows = await prisma.caller.findMany({
+    where: {
+      OR: [
+        { cohortGroupId: cohortId },
+        { cohortMemberships: { some: { cohortGroupId: cohortId } } },
+      ],
+    },
+    select: { id: true },
+  });
+  const callerIds = memberRows.map((c) => c.id);
+  if (callerIds.length === 0) {
+    return { totalUsd: 0, byProvider: [], callCount: 0, since: windowStart(since).toISOString() };
+  }
+  return summarise({ callerId: { in: callerIds } }, windowStart(since));
+}
+
+/** Voice cost for every call on a playbook (course). */
+export async function getVoiceCostForPlaybook(
+  playbookId: string,
+  since?: Date,
+): Promise<VoiceCostSummary> {
+  return summarise({ playbookId }, windowStart(since));
+}
+
+/** System-wide voice cost grouped by provider. ADMIN-only. */
+export async function getVoiceCostByProviderSystemWide(
+  since?: Date,
+): Promise<VoiceCostSummary> {
+  return summarise({}, windowStart(since));
+}

--- a/apps/admin/prisma/migrations/20260604_1050_1028_add_voice_usage_category/migration.sql
+++ b/apps/admin/prisma/migrations/20260604_1050_1028_add_voice_usage_category/migration.sql
@@ -1,0 +1,9 @@
+-- AnyVoice #1028: add VOICE to UsageCategory enum so voice-call ledger
+-- writes (per-minute billing) don't have to be force-fit under EXTERNAL
+-- (which is per-call count). DEFAULT_COST_RATES gets matching VOICE:vapi
+-- entries in the same PR; calculateCost gains "minutes" + "seconds" arms.
+--
+-- ALTER TYPE ADD VALUE on Postgres is metadata-only on recent versions,
+-- safe under load. Does not require concurrent operations.
+
+ALTER TYPE "UsageCategory" ADD VALUE IF NOT EXISTS 'VOICE';

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -3269,6 +3269,12 @@ enum UsageCategory {
   COMPUTE // CPU-intensive operations (pipeline runs, analysis)
   STORAGE // File storage operations
   EXTERNAL // Third-party API calls (webhooks, external services)
+  // AnyVoice #1028 — voice call usage (per-minute billing). Distinct
+  // from EXTERNAL because providers bill by minutes/seconds, not per-
+  // call counts. calculateCost has a "minutes"/"seconds" arm for this
+  // category. Do NOT log voice calls under EXTERNAL:vapi — that rate is
+  // per-call count, would corrupt minute-based rollups.
+  VOICE
 }
 
 enum RollupPeriod {

--- a/apps/admin/tests/lib/metering/voice-cost-rate.test.ts
+++ b/apps/admin/tests/lib/metering/voice-cost-rate.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for the VOICE UsageCategory rate + minutes/seconds calculation
+ * (AnyVoice #1028).
+ *
+ * Locks the contract TL flagged in the #1015 epic re-review: VAPI bills
+ * per-minute; do NOT extend EXTERNAL:vapi (per-call count semantics)
+ * because mixing the two corrupts rollups in lib/metering/rollup.ts.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: { usageCostRate: { findFirst: vi.fn().mockResolvedValue(null) } },
+}));
+
+import { DEFAULT_COST_RATES, calculateCost, getCostRate } from "@/lib/metering/cost-config";
+
+describe("VOICE UsageCategory (#1028)", () => {
+  it("DEFAULT_COST_RATES has VOICE:vapi:inbound and outbound entries", () => {
+    expect(DEFAULT_COST_RATES["VOICE:vapi:inbound"]).toBeDefined();
+    expect(DEFAULT_COST_RATES["VOICE:vapi:inbound"].unitType).toBe("minutes");
+    expect(DEFAULT_COST_RATES["VOICE:vapi:outbound"]).toBeDefined();
+    expect(DEFAULT_COST_RATES["VOICE:vapi:outbound"].unitType).toBe("minutes");
+  });
+
+  it("EXTERNAL:vapi remains per-call count — voice rates do not regress its semantics", () => {
+    // Negative-space assertion. TL flag: do NOT extend EXTERNAL:vapi.
+    expect(DEFAULT_COST_RATES["EXTERNAL:vapi"].unitType).toBe("count");
+  });
+
+  it('calculateCost("minutes") converts seconds → minutes before rate multiplication', () => {
+    // 180 seconds × $0.05/minute = $0.15
+    expect(calculateCost(180, 0.05, "minutes")).toBeCloseTo(0.15, 6);
+    // 90 seconds × $0.05/minute = $0.075
+    expect(calculateCost(90, 0.05, "minutes")).toBeCloseTo(0.075, 6);
+  });
+
+  it('calculateCost("seconds") passes quantity through (per-second billing)', () => {
+    // 30 seconds × $0.001/second = $0.03
+    expect(calculateCost(30, 0.001, "seconds")).toBeCloseTo(0.03, 6);
+  });
+
+  it("getCostRate falls back to the DEFAULT_COST_RATES entry when DB has no override", async () => {
+    const rate = await getCostRate("VOICE", "vapi:inbound");
+    expect(rate.costPerUnit).toBe(DEFAULT_COST_RATES["VOICE:vapi:inbound"].costPerUnit);
+    expect(rate.unitType).toBe("minutes");
+  });
+});

--- a/apps/admin/tests/lib/voice/cost-aggregator.test.ts
+++ b/apps/admin/tests/lib/voice/cost-aggregator.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for lib/voice/cost-aggregator.ts (AnyVoice #1028).
+ *
+ * Locks the aggregation contract the educator UI panel and the admin
+ * system-wide page depend on:
+ *   - Sum across calls with non-null voiceCostUsd
+ *   - Null cost rows excluded (SIM calls, billing failures)
+ *   - Per-provider grouping
+ *   - 30-day default window
+ *   - Zero-call result returns 0 / empty array, not throw
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    call: { groupBy: vi.fn() },
+    caller: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import {
+  getVoiceCostForCaller,
+  getVoiceCostForCohort,
+  getVoiceCostForPlaybook,
+  getVoiceCostByProviderSystemWide,
+} from "@/lib/voice/cost-aggregator";
+
+describe("voice cost aggregator (#1028)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sums voiceCostUsd across a caller's calls and groups by provider", async () => {
+    (prisma.call.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { voiceProvider: "vapi", _sum: { voiceCostUsd: 0.15 }, _count: { _all: 3 } },
+    ]);
+
+    const result = await getVoiceCostForCaller("caller-1");
+
+    expect(result.totalUsd).toBeCloseTo(0.15, 6);
+    expect(result.callCount).toBe(3);
+    expect(result.byProvider).toEqual([
+      { provider: "vapi", totalUsd: 0.15, callCount: 3 },
+    ]);
+    // groupBy must filter null voiceCostUsd — assert in the call args
+    const callArgs = (prisma.call.groupBy as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.where.voiceCostUsd).toEqual({ not: null });
+  });
+
+  it("returns zero-summary when the caller has no recorded-cost calls", async () => {
+    (prisma.call.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await getVoiceCostForCaller("caller-noop");
+
+    expect(result.totalUsd).toBe(0);
+    expect(result.callCount).toBe(0);
+    expect(result.byProvider).toEqual([]);
+    expect(result.since).toBeTruthy();
+  });
+
+  it("rolls up across multiple providers in the same scope", async () => {
+    (prisma.call.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { voiceProvider: "vapi", _sum: { voiceCostUsd: 0.12 }, _count: { _all: 2 } },
+      { voiceProvider: "retell", _sum: { voiceCostUsd: 0.08 }, _count: { _all: 1 } },
+    ]);
+
+    const result = await getVoiceCostByProviderSystemWide();
+
+    expect(result.totalUsd).toBeCloseTo(0.2, 6);
+    expect(result.callCount).toBe(3);
+    expect(result.byProvider).toHaveLength(2);
+  });
+
+  it("cohort aggregation expands members via both legacy + multi-cohort paths", async () => {
+    (prisma.caller.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "caller-a" },
+      { id: "caller-b" },
+    ]);
+    (prisma.call.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { voiceProvider: "vapi", _sum: { voiceCostUsd: 0.3 }, _count: { _all: 5 } },
+    ]);
+
+    const result = await getVoiceCostForCohort("cohort-1");
+
+    // Members lookup was issued with both relations
+    const memberArgs = (prisma.caller.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(memberArgs.where.OR).toEqual([
+      { cohortGroupId: "cohort-1" },
+      { cohortMemberships: { some: { cohortGroupId: "cohort-1" } } },
+    ]);
+    // groupBy scoped to the resolved member ids
+    const callArgs = (prisma.call.groupBy as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.where.callerId).toEqual({ in: ["caller-a", "caller-b"] });
+    expect(result.totalUsd).toBeCloseTo(0.3, 6);
+  });
+
+  it("cohort with zero members returns zero-summary without querying calls", async () => {
+    (prisma.caller.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await getVoiceCostForCohort("empty-cohort");
+
+    expect(result.totalUsd).toBe(0);
+    expect(result.callCount).toBe(0);
+    expect(prisma.call.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("playbook scope passes the playbookId straight to the groupBy filter", async () => {
+    (prisma.call.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { voiceProvider: "vapi", _sum: { voiceCostUsd: 0.5 }, _count: { _all: 10 } },
+    ]);
+
+    await getVoiceCostForPlaybook("playbook-7");
+
+    const callArgs = (prisma.call.groupBy as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.where.playbookId).toBe("playbook-7");
+  });
+
+  it("honours an explicit `since` Date, otherwise uses the 30-day default", async () => {
+    (prisma.call.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const customSince = new Date("2026-01-01T00:00:00Z");
+
+    await getVoiceCostForCaller("caller-x", customSince);
+    const args1 = (prisma.call.groupBy as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(args1.where.createdAt).toEqual({ gte: customSince });
+
+    await getVoiceCostForCaller("caller-y");
+    const args2 = (prisma.call.groupBy as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    const defaultSince = args2.where.createdAt.gte;
+    // Default is "now - 30 days" — verify roughly 30 days ago (allow 1 min skew)
+    const diffMs = Date.now() - defaultSince.getTime();
+    expect(diffMs).toBeGreaterThanOrEqual(30 * 24 * 60 * 60 * 1000 - 60_000);
+    expect(diffMs).toBeLessThanOrEqual(30 * 24 * 60 * 60 * 1000 + 60_000);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -14535,6 +14535,29 @@ Test the connection for a voice provider. Instantiates
 
 ---
 
+### `GET` /api/voice/costs
+
+Returns voice-call cost rollups for a chosen scope. Reads
+
+**Auth**: session (OPERATOR for scoped; ADMIN for system-wide) · **Scope**: `voice:costs:read`
+
+**Response** `200`
+```json
+{ ok: true, summary: VoiceCostSummary }
+```
+
+**Response** `400`
+```json
+{ ok: false, error: "scope required" | "id required" }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: "system scope requires ADMIN" }
+```
+
+---
+
 ## Wizard
 
 ### `POST` /api/teach-wizard/launch
@@ -14723,8 +14746,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 469 |
-| Files with annotations | 461 |
+| Route files found | 470 |
+| Files with annotations | 462 |
 | Files missing annotations | 8 |
 | Coverage | 98.3% |
 


### PR DESCRIPTION
## Summary
Per-caller / cohort / playbook / system-wide voice cost rollups. New VOICE UsageCategory with per-minute semantics (TL flag: do NOT extend EXTERNAL:vapi — per-call count would corrupt minute-based rollups).

## Changes
- `UsageCategory.VOICE` enum value
- `DEFAULT_COST_RATES["VOICE:vapi:inbound"]` ($0.05/min) + outbound ($0.07/min)
- `calculateCost` gains "minutes" + "seconds" arms
- `lib/voice/cost-aggregator.ts` — 4 aggregations, null-filter, 30-day default window
- `GET /api/voice/costs?scope=&id=&since=`
- `VoiceCostPanel` inline card on caller detail (USD)
- `/x/settings/voice-costs/` system-wide table
- 12 new tests

## Test plan
- [x] migration-checker: SAFE (ADD VALUE IF NOT EXISTS metadata-only)
- [x] All 12 tests green

## Deploy
`/vm-cpp` (enum-add migration)

Closes #1028 · Part of #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)