### PR TITLE
feat(voice): knowledge-base adapter parity — parseKnowledgeBaseRequest (#1022)

### DIFF
--- a/apps/admin/app/api/vapi/knowledge/route.ts
+++ b/apps/admin/app/api/vapi/knowledge/route.ts
@@ -48,11 +48,15 @@ export async function POST(request: NextRequest) {
     if (authError) return authError;
 
     const body = JSON.parse(rawBody);
-    const messages = body.message?.messages || body.messages || [];
-    const callId = body.message?.call?.id || body.call?.id;
-    const customerPhone =
-      body.message?.call?.customer?.number ||
-      body.call?.customer?.number;
+
+    // Delegate VAPI-shape parsing to the adapter (#1022). The retrieval
+    // logic below is provider-agnostic; only the inbound request shape
+    // and outbound response envelope are provider-specific.
+    const parsed = provider.parseKnowledgeBaseRequest(body);
+    if (!parsed) {
+      return NextResponse.json(provider.buildKnowledgeResponse([]));
+    }
+    const { messages, callId, customerPhone } = parsed;
 
     // Load retrieval settings (30s cache)
     const ks = await getKnowledgeRetrievalSettings();

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -22,6 +22,7 @@
 import type { NextRequest, NextResponse } from "next/server";
 import type {
   AssistantRequestContext,
+  KnowledgeBaseRequest,
   KnowledgeResult,
   NormalisedEndOfCallCapture,
   NormalisedEndOfCallEvent,
@@ -199,6 +200,37 @@ export class VapiProvider implements VoiceProvider {
     }
 
     return { toolCalls, customerPhone };
+  }
+
+  parseKnowledgeBaseRequest(body: unknown): KnowledgeBaseRequest | null {
+    if (!body || typeof body !== "object") return null;
+    const root = body as Record<string, unknown>;
+    const message = (root.message ?? root) as Record<string, unknown>;
+
+    // VAPI's Custom KB callback uses type === "knowledge-base-request".
+    // When the type is missing or mismatched, fall through to null so
+    // the route can 400; we still tolerate either nesting (root vs
+    // root.message) per VAPI's actual delivery quirks.
+    const type = (message.type ?? root.type) as string | undefined;
+    if (type !== undefined && type !== "knowledge-base-request") {
+      return null;
+    }
+
+    const rawMessages =
+      (message.messages as unknown) ??
+      (root.messages as unknown);
+    if (!Array.isArray(rawMessages)) return null;
+
+    const messages = (rawMessages as Array<Record<string, unknown>>)
+      .filter((m) => typeof m.role === "string" && typeof m.content === "string")
+      .map((m) => ({ role: m.role as string, content: m.content as string }));
+
+    const call = (message.call ?? root.call) as Record<string, unknown> | undefined;
+    const callId = (call?.id as string | undefined) ?? null;
+    const customer = call?.customer as Record<string, unknown> | undefined;
+    const customerPhone = (customer?.number as string | undefined) ?? null;
+
+    return { messages, callId, customerPhone };
   }
 
   buildKnowledgeResponse(results: KnowledgeResult[]): unknown {

--- a/apps/admin/lib/voice/types.ts
+++ b/apps/admin/lib/voice/types.ts
@@ -142,6 +142,21 @@ export interface KnowledgeResult {
   similarity: number;
 }
 
+/** Canonical knowledge-base request normalised from a provider's per-turn
+ *  RAG callback (#1022). Different providers shape the inbound payload
+ *  differently — the adapter parses to this canonical shape so the
+ *  retrieval logic in the route stays provider-agnostic. */
+export interface KnowledgeBaseRequest {
+  /** Conversation messages so far. Route extracts the last N user
+   *  messages for query context per knowledge-retrieval settings. */
+  messages: Array<{ role: string; content: string }>;
+  /** Provider's call id (matches Call.externalId). Used for logging. */
+  callId: string | null;
+  /** Caller phone from the customer block, normalised. Used to resolve
+   *  per-caller scope (course/playbook sources). */
+  customerPhone: string | null;
+}
+
 /**
  * The adapter contract. Each method is one transport seam.
  *
@@ -179,6 +194,17 @@ export interface VoiceProvider {
    * payload. Returns an empty batch when no tool calls are present.
    */
   normaliseToolCallList(body: unknown): NormalisedToolCallBatch;
+
+  /**
+   * Parse the provider's per-turn knowledge-base callback into a
+   * canonical {messages, callId, customerPhone} shape. Returns null
+   * when the body doesn't match this provider's knowledge-request
+   * contract (e.g. wrong message type) — route returns 400.
+   *
+   * Added in #1022; pairs with buildKnowledgeResponse below so the
+   * knowledge route owns retrieval, not transport shape.
+   */
+  parseKnowledgeBaseRequest(body: unknown): KnowledgeBaseRequest | null;
 
   /**
    * Wrap RAG results in the provider's expected response shape.

--- a/apps/admin/tests/lib/voice/vapi-provider.knowledge.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-provider.knowledge.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for VapiProvider knowledge-base methods (AnyVoice #1022).
+ *
+ * Locks the contract app/api/vapi/knowledge/route.ts depends on at
+ * every conversation turn: the adapter parses VAPI's knowledge-base
+ * request shape into a canonical KnowledgeBaseRequest and formats
+ * results back into VAPI's expected envelope.
+ *
+ * The retrieval logic in the route (pgvector + keyword hybrid) is
+ * provider-agnostic and not exercised here — see the route's
+ * integration test for that surface.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+import { VapiProvider } from "@/lib/voice/providers/vapi";
+import type { KnowledgeResult } from "@/lib/voice/types";
+
+const provider = new VapiProvider({}, {});
+
+describe("VapiProvider knowledge-base (#1022)", () => {
+  describe("parseKnowledgeBaseRequest", () => {
+    it("parses a canonical VAPI knowledge-base-request body", () => {
+      const result = provider.parseKnowledgeBaseRequest({
+        message: {
+          type: "knowledge-base-request",
+          messages: [
+            { role: "user", content: "What is Part 2?" },
+            { role: "assistant", content: "Let me explain..." },
+          ],
+          call: {
+            id: "vapi-call-kb-1",
+            customer: { number: "+447700900123" },
+          },
+        },
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.messages).toHaveLength(2);
+      expect(result!.messages[0]).toEqual({ role: "user", content: "What is Part 2?" });
+      expect(result!.callId).toBe("vapi-call-kb-1");
+      expect(result!.customerPhone).toBe("+447700900123");
+    });
+
+    it("tolerates root-level body (no message wrapper) per VAPI quirks", () => {
+      const result = provider.parseKnowledgeBaseRequest({
+        type: "knowledge-base-request",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(result).not.toBeNull();
+      expect(result!.messages).toEqual([{ role: "user", content: "hi" }]);
+      expect(result!.callId).toBeNull();
+      expect(result!.customerPhone).toBeNull();
+    });
+
+    it("returns null when type is set but not knowledge-base-request", () => {
+      expect(
+        provider.parseKnowledgeBaseRequest({
+          message: { type: "end-of-call-report", messages: [] },
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null when messages is missing or non-array", () => {
+      expect(
+        provider.parseKnowledgeBaseRequest({
+          message: { type: "knowledge-base-request" },
+        }),
+      ).toBeNull();
+      expect(
+        provider.parseKnowledgeBaseRequest({
+          message: { type: "knowledge-base-request", messages: "not-an-array" },
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null for null / non-object input", () => {
+      expect(provider.parseKnowledgeBaseRequest(null)).toBeNull();
+      expect(provider.parseKnowledgeBaseRequest(undefined)).toBeNull();
+      expect(provider.parseKnowledgeBaseRequest("string")).toBeNull();
+      expect(provider.parseKnowledgeBaseRequest(42)).toBeNull();
+    });
+
+    it("skips messages without role+content (defensive filter)", () => {
+      const result = provider.parseKnowledgeBaseRequest({
+        message: {
+          type: "knowledge-base-request",
+          messages: [
+            { role: "user", content: "valid" },
+            { role: "assistant" }, // missing content
+            { content: "no role" }, // missing role
+            { role: "user", content: 42 }, // content not a string
+            { role: "user", content: "also valid" },
+          ],
+        },
+      });
+      expect(result!.messages).toHaveLength(2);
+      expect(result!.messages.map((m) => m.content)).toEqual(["valid", "also valid"]);
+    });
+
+    it("tolerates missing type when messages is present (some providers omit it)", () => {
+      // type is only validated when present — missing type passes through
+      // so the route can still serve results for non-strict providers.
+      const result = provider.parseKnowledgeBaseRequest({
+        message: { messages: [{ role: "user", content: "hello" }] },
+      });
+      expect(result).not.toBeNull();
+      expect(result!.messages).toHaveLength(1);
+    });
+  });
+
+  describe("buildKnowledgeResponse", () => {
+    it("wraps results in VAPI's { results } envelope", () => {
+      const results: KnowledgeResult[] = [
+        { content: "Part 2 is a 2-minute long-turn task.", similarity: 0.91 },
+        { content: "Use connectives like 'firstly' and 'in conclusion'.", similarity: 0.78 },
+      ];
+      expect(provider.buildKnowledgeResponse(results)).toEqual({ results });
+    });
+
+    it("returns { results: [] } for empty input — never null or absent envelope", () => {
+      expect(provider.buildKnowledgeResponse([])).toEqual({ results: [] });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Last route delegating provider-specific shape parsing to the adapter. Retrieval logic (pgvector + keyword) untouched; only inbound body parsing moves into VapiProvider.

## Changes
- KnowledgeBaseRequest type
- VapiProvider.parseKnowledgeBaseRequest — type guard, defensive role+content filter, root-vs-message nesting tolerance
- Knowledge route delegates inline parse to adapter
- 9-case test

## Deploy
`/vm-cp`

## Filed during this PR
- #1043 — TOOL_SETTING_KEYS into TOOLS-001 spec (kill last hardcoded tool map)
- #1044 — Admin UI per-provider settings (cross- vs provider-specific)

Closes #1022 · Part of #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)