### PR TITLE
feat(voice): tool router + SIM exercises tool surface (#1023)

### DIFF
--- a/apps/admin/app/api/vapi/tools/route.ts
+++ b/apps/admin/app/api/vapi/tools/route.ts
@@ -119,7 +119,7 @@ export async function POST(request: NextRequest) {
  * Look up teaching content by topic keyword.
  * Course-scoped: only returns content from the caller's enrolled course/domain.
  */
-async function handleLookupTeachingPoint(
+export async function handleLookupTeachingPoint(
   args: { topic: string; limit?: number },
   callerId: string | null,
 ) {
@@ -176,7 +176,7 @@ async function handleLookupTeachingPoint(
  * remains opt-in via LEGACY_MASTERY_FALLBACK_ENABLED (default off) — see
  * apps/admin/docs/mastery-store-migration.md.
  */
-async function handleCheckMastery(
+export async function handleCheckMastery(
   args: { module: string },
   callerId: string | null,
 ) {
@@ -276,7 +276,7 @@ async function handleCheckMastery(
 /**
  * Record an observation about the caller in real-time.
  */
-async function handleRecordObservation(
+export async function handleRecordObservation(
   args: { key: string; value: string; category?: string },
   callerId: string | null,
 ) {
@@ -308,7 +308,7 @@ async function handleRecordObservation(
  * Searches ContentQuestion first (real extracted questions with answers),
  * falls back to assertion-based suggestion if none found.
  */
-async function handleGetPracticeQuestion(
+export async function handleGetPracticeQuestion(
   args: { topic: string },
   callerId: string | null,
 ) {
@@ -388,7 +388,7 @@ async function handleGetPracticeQuestion(
 /**
  * Get the next module the caller should study.
  */
-async function handleGetNextModule(
+export async function handleGetNextModule(
   args: Record<string, any>,
   callerId: string | null,
 ) {
@@ -430,7 +430,7 @@ async function handleGetNextModule(
  * Log the result of an interactive activity (pop quiz, MCQ, scenario, etc.).
  * Creates a CallerMemory and optionally updates CallerAttribute for tracking.
  */
-async function handleLogActivityResult(
+export async function handleLogActivityResult(
   args: {
     activity_id: string;
     outcome: "correct" | "incorrect" | "partial" | "completed" | "skipped";
@@ -502,7 +502,7 @@ async function handleLogActivityResult(
  *
  * Switching provider = change the setting. Zero code changes.
  */
-async function handleSendTextToCaller(
+export async function handleSendTextToCaller(
   args: { message: string; purpose?: string },
   callerId: string | null,
   customerPhone: string | null,
@@ -612,7 +612,7 @@ async function sendViaTwilio(
  * Request an artifact be created for the caller after the call ends.
  * Creates a CallAction that the pipeline picks up during EXTRACT.
  */
-async function handleRequestArtifact(
+export async function handleRequestArtifact(
   args: { type: string; title: string; content: string; reason?: string },
   callerId: string | null,
 ) {
@@ -670,7 +670,7 @@ async function handleRequestArtifact(
  * The AI's voice prompt lists available visual aids with media IDs.
  * This tool lets the AI push any of those to the caller mid-conversation.
  */
-async function handleShareContent(
+export async function handleShareContent(
   args: { media_id: string; caption?: string; context?: string },
   callerId: string | null,
   customerPhone: string | null,
@@ -828,7 +828,7 @@ async function handleShareContent(
  * Searches ContentVocabulary — extracted terms with definitions,
  * part of speech, and source context.
  */
-async function handleLookupVocabulary(
+export async function handleLookupVocabulary(
   args: { term: string },
   callerId: string | null,
 ) {

--- a/apps/admin/lib/voice/tool-router.ts
+++ b/apps/admin/lib/voice/tool-router.ts
@@ -1,0 +1,117 @@
+/**
+ * Voice tool router (AnyVoice #1023).
+ *
+ * Provider-agnostic dispatcher: maps a canonical NormalisedToolCall to
+ * the matching handler in app/api/vapi/tools/route.ts (which exports the
+ * 10 handle* functions). SIM uses this to exercise the tool surface
+ * end-to-end so a regression in any tool definition or handler is
+ * caught before it reaches a live voice call.
+ *
+ * Closes the I-VP5 outbound-half gap flagged by the TL during the
+ * #1015 epic review: the inbound side (tool-callback shape parsing)
+ * landed with #1017's NormalisedToolCallBatch; this router gives the
+ * outbound side (handler dispatch) a provider-agnostic entry point.
+ *
+ * The handlers themselves are already provider-agnostic — they take
+ * typed args + a callerId, not a VAPI-shaped request body. The only
+ * VAPI-specific concern (parsing toolCallList) lives in
+ * VapiProvider.normaliseToolCallList; by the time we get here, the
+ * tool call is canonical.
+ */
+
+import type { NormalisedToolCall } from "./types";
+import {
+  handleLookupTeachingPoint,
+  handleCheckMastery,
+  handleRecordObservation,
+  handleGetPracticeQuestion,
+  handleGetNextModule,
+  handleLogActivityResult,
+  handleSendTextToCaller,
+  handleRequestArtifact,
+  handleShareContent,
+  handleLookupVocabulary,
+} from "@/app/api/vapi/tools/route";
+
+export interface ToolRouterContext {
+  callerId: string | null;
+  /** Customer phone — required for outbound reach-ins
+   *  (send_text_to_caller, share_content) when a live channel is in
+   *  play. SIM passes null; the handler falls back to inline rendering. */
+  customerPhone: string | null;
+}
+
+export interface ToolRouterResult {
+  /** Stringified result to feed back to the LLM as a tool-result message. */
+  content: string;
+  /** Raw handler return value — useful for assertions / observability. */
+  raw: unknown;
+}
+
+/**
+ * Dispatch a normalised tool call to the matching handler. Returns a
+ * stringified result the LLM can consume in its next turn.
+ *
+ * Unknown tool name → returns a standardised diagnostic string; never
+ * throws. Voice call must continue even if a tool fails — surface the
+ * error to the LLM and let the conversation handle it.
+ */
+export async function routeToolCall(
+  tool: NormalisedToolCall,
+  ctx: ToolRouterContext,
+): Promise<ToolRouterResult> {
+  const args = tool.args as any;
+  const { callerId, customerPhone } = ctx;
+
+  try {
+    let raw: unknown;
+    switch (tool.funcName) {
+      case "lookup_teaching_point":
+        raw = await handleLookupTeachingPoint(args, callerId);
+        break;
+      case "check_mastery":
+        raw = await handleCheckMastery(args, callerId);
+        break;
+      case "record_observation":
+        raw = await handleRecordObservation(args, callerId);
+        break;
+      case "get_practice_question":
+        raw = await handleGetPracticeQuestion(args, callerId);
+        break;
+      case "get_next_module":
+        raw = await handleGetNextModule(args, callerId);
+        break;
+      case "log_activity_result":
+        raw = await handleLogActivityResult(args, callerId);
+        break;
+      case "send_text_to_caller":
+        // Outbound reach-in — uses customerPhone when present, falls
+        // back to SIM inline rendering otherwise.
+        raw = await handleSendTextToCaller(args, callerId, customerPhone);
+        break;
+      case "request_artifact":
+        raw = await handleRequestArtifact(args, callerId);
+        break;
+      case "share_content":
+        // Outbound reach-in — same SIM/live branching as send_text.
+        raw = await handleShareContent(args, callerId, customerPhone);
+        break;
+      case "lookup_vocabulary":
+        raw = await handleLookupVocabulary(args, callerId);
+        break;
+      default:
+        return {
+          content: JSON.stringify({ error: `Unknown tool: ${tool.funcName}` }),
+          raw: { error: `Unknown tool: ${tool.funcName}` },
+        };
+    }
+    return { content: JSON.stringify(raw), raw };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[voice/tool-router] ${tool.funcName} threw:`, message);
+    return {
+      content: JSON.stringify({ error: `Tool ${tool.funcName} failed: ${message}` }),
+      raw: { error: message },
+    };
+  }
+}

--- a/apps/admin/scripts/sim-drive-call.ts
+++ b/apps/admin/scripts/sim-drive-call.ts
@@ -49,6 +49,8 @@ import {
   resolveCurriculumIdForPlaybook,
   resolveModuleByLogicalId,
 } from "@/lib/curriculum/resolve-module";
+import { loadToolDefinitions } from "@/lib/voice/load-tool-definitions";
+import { routeToolCall } from "@/lib/voice/tool-router";
 
 interface Args {
   callerId: string;
@@ -256,7 +258,16 @@ End the conversation naturally when the tutor signals the session is winding dow
     await prisma.callMessage.create({ data: { callId: call.id, role: "user", content: userMsg } });
     history.push({ role: "user", content: userMsg });
 
-    // Tutor reply
+    // Tutor reply — passes TOOLS-001 definitions so the AI can invoke
+    // tools mid-turn (AnyVoice #1023). Adapts our OpenAI-shape tool
+    // definitions to AITool (Anthropic flat shape) for the wrapper.
+    const toolDefs = await loadToolDefinitions();
+    const aiTools = toolDefs.map((t) => ({
+      name: t.function.name,
+      description: t.function.description,
+      input_schema: t.function.parameters,
+    }));
+
     const aiMessages = [
       { role: "system" as const, content: promptText },
       ...history.map((h) => ({ role: h.role, content: h.content })),
@@ -266,6 +277,7 @@ End the conversation naturally when the tutor signals the session is winding dow
         callPoint: "test-harness.system",
         messages: aiMessages,
         maxRetries: 1,
+        ...(aiTools.length > 0 ? { tools: aiTools } : {}),
       },
       { sourceOp: "sim-drive", callerId, callId: call.id }
     );
@@ -273,6 +285,29 @@ End the conversation naturally when the tutor signals the session is winding dow
     console.log(`Tutor → ${tutorReply.slice(0, 200)}${tutorReply.length > 200 ? "..." : ""}`);
     await prisma.callMessage.create({ data: { callId: call.id, role: "assistant", content: tutorReply } });
     history.push({ role: "assistant", content: tutorReply });
+
+    // If the AI invoked any tools, route them through the canonical
+    // dispatcher (no VAPI wire-format involved) and log the results.
+    // SIM doesn't feed results back as further messages today — the
+    // test value is proving the tool surface is alive end-to-end.
+    if (result.toolUses && result.toolUses.length > 0) {
+      for (const tu of result.toolUses) {
+        const toolResult = await routeToolCall(
+          { toolCallId: tu.id, funcName: tu.name, args: tu.input },
+          { callerId, customerPhone: null },
+        );
+        console.log(
+          `  ↳ tool ${tu.name}: ${toolResult.content.slice(0, 200)}${toolResult.content.length > 200 ? "..." : ""}`,
+        );
+        await prisma.callMessage.create({
+          data: {
+            callId: call.id,
+            role: "assistant",
+            content: `[tool ${tu.name}] ${toolResult.content.slice(0, 500)}`,
+          },
+        });
+      }
+    }
   }
 
   // 4. Update Call with full transcript text

--- a/apps/admin/tests/lib/voice/tool-router.test.ts
+++ b/apps/admin/tests/lib/voice/tool-router.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for lib/voice/tool-router.ts (AnyVoice #1023).
+ *
+ * The TL #1015 review fixed the I-VP5 scope at "3/10 tools through the
+ * adapter — INCLUDING 1 outbound reach-in". This file pins:
+ *   - lookup_teaching_point (inbound — content lookup)
+ *   - check_mastery (inbound — caller-scoped read)
+ *   - send_text_to_caller (outbound reach-in — the TL-required one)
+ *
+ * Plus: unknown tool returns the standardised diagnostic (no throw),
+ * handler-throw is caught and surfaced as a tool-result error string
+ * so the voice call keeps moving.
+ *
+ * Handlers are mocked at module level — these tests verify the
+ * router's dispatch + error handling, not the handler internals
+ * (those have their own integration tests on the VAPI tools route).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock is hoisted to the top of the file; mock factories can't see
+// closure variables defined below. vi.hoisted hoists the variable
+// definition alongside the mock so we can both stub and assert on the
+// same handler set.
+const handlers = vi.hoisted(() => ({
+  handleLookupTeachingPoint: vi.fn(),
+  handleCheckMastery: vi.fn(),
+  handleRecordObservation: vi.fn(),
+  handleGetPracticeQuestion: vi.fn(),
+  handleGetNextModule: vi.fn(),
+  handleLogActivityResult: vi.fn(),
+  handleSendTextToCaller: vi.fn(),
+  handleRequestArtifact: vi.fn(),
+  handleShareContent: vi.fn(),
+  handleLookupVocabulary: vi.fn(),
+}));
+
+vi.mock("@/app/api/vapi/tools/route", () => handlers);
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+import { routeToolCall } from "@/lib/voice/tool-router";
+import type { NormalisedToolCall } from "@/lib/voice/types";
+
+describe("routeToolCall (#1023)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches lookup_teaching_point with args + callerId (inbound)", async () => {
+    handlers.handleLookupTeachingPoint.mockResolvedValue({
+      found: true,
+      count: 1,
+      points: [{ content: "Part 2 is a 2-minute long-turn task." }],
+    });
+
+    const result = await routeToolCall(
+      { toolCallId: "tc-1", funcName: "lookup_teaching_point", args: { topic: "Part 2", limit: 3 } },
+      { callerId: "caller-1", customerPhone: null },
+    );
+
+    expect(handlers.handleLookupTeachingPoint).toHaveBeenCalledWith(
+      { topic: "Part 2", limit: 3 },
+      "caller-1",
+    );
+    expect(JSON.parse(result.content).found).toBe(true);
+    expect(result.raw).toMatchObject({ count: 1 });
+  });
+
+  it("dispatches check_mastery and returns the mastery summary (inbound)", async () => {
+    handlers.handleCheckMastery.mockResolvedValue({
+      mastered: false,
+      score: 0.42,
+      module: "Part 2",
+      message: "Caller is still learning \"Part 2\" (score: 42%)",
+    });
+
+    const result = await routeToolCall(
+      { toolCallId: "tc-2", funcName: "check_mastery", args: { module: "Part 2" } },
+      { callerId: "caller-1", customerPhone: null },
+    );
+
+    expect(handlers.handleCheckMastery).toHaveBeenCalledWith({ module: "Part 2" }, "caller-1");
+    expect(JSON.parse(result.content).mastered).toBe(false);
+  });
+
+  it("dispatches send_text_to_caller and propagates customerPhone (OUTBOUND reach-in — TL-required)", async () => {
+    handlers.handleSendTextToCaller.mockResolvedValue({
+      sent: true,
+      channel: "sms",
+      message: "Sent",
+    });
+
+    const result = await routeToolCall(
+      {
+        toolCallId: "tc-3",
+        funcName: "send_text_to_caller",
+        args: { message: "Practice these 5 connectives tonight", purpose: "practice" },
+      },
+      { callerId: "caller-1", customerPhone: "+447700900123" },
+    );
+
+    // Outbound handlers MUST receive customerPhone so the channel
+    // dispatcher can route SMS / WhatsApp. The TL flagged that the
+    // current code branched on `!!externalId` for this dispatch —
+    // this test pins that the router forwards customerPhone instead.
+    expect(handlers.handleSendTextToCaller).toHaveBeenCalledWith(
+      { message: "Practice these 5 connectives tonight", purpose: "practice" },
+      "caller-1",
+      "+447700900123",
+    );
+    expect(JSON.parse(result.content).sent).toBe(true);
+  });
+
+  it("send_text_to_caller passes customerPhone=null when SIM is on the wire", async () => {
+    // SIM context: no customer phone. Handler should fall back to
+    // inline rendering (CallMessage row + SimChat displays it).
+    handlers.handleSendTextToCaller.mockResolvedValue({ sent: true, channel: "sim" });
+
+    await routeToolCall(
+      {
+        toolCallId: "tc-4",
+        funcName: "send_text_to_caller",
+        args: { message: "hi" },
+      },
+      { callerId: "caller-1", customerPhone: null },
+    );
+
+    expect(handlers.handleSendTextToCaller).toHaveBeenCalledWith(
+      { message: "hi" },
+      "caller-1",
+      null,
+    );
+  });
+
+  it("returns a standardised error string for an unknown tool — never throws", async () => {
+    const result = await routeToolCall(
+      { toolCallId: "tc-x", funcName: "nonexistent_tool", args: {} },
+      { callerId: "caller-1", customerPhone: null },
+    );
+
+    expect(JSON.parse(result.content).error).toMatch(/Unknown tool: nonexistent_tool/);
+  });
+
+  it("catches handler throws and surfaces them as a tool-result error string", async () => {
+    handlers.handleCheckMastery.mockRejectedValue(new Error("temporary DB blip"));
+
+    const result = await routeToolCall(
+      { toolCallId: "tc-fail", funcName: "check_mastery", args: { module: "x" } },
+      { callerId: "caller-1", customerPhone: null },
+    );
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toMatch(/Tool check_mastery failed/);
+    expect(parsed.error).toMatch(/temporary DB blip/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes I-VP5 outbound-half gap (TL #1015 review). SIM no longer a lower-bound check — tool calls dispatched through provider-agnostic router.

## Changes
- 10 handle* functions exported from `app/api/vapi/tools/route.ts`
- `lib/voice/tool-router.ts` — routeToolCall dispatcher; unknown tool returns diagnostic; handler-throw caught + surfaced as tool-result string
- SIM loads TOOLS-001 tools, routes AI toolUses through router, logs results
- 6-case test (≥3 tools incl. send_text_to_caller outbound reach-in — TL-required)

## Deploy
`/vm-cp`

Closes #1023 · Part of #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)