### PR TITLE
feat(eslint): hf-voice rules block vapi* column refs + VAPI_TOOL_DEFINITIONS const (#1024)

### DIFF
--- a/.claude/agents/arch-checker.md
+++ b/.claude/agents/arch-checker.md
@@ -151,6 +151,40 @@ Flag (soft warning — promoted to error once #911 lands and the existing violat
 
 This check is the static sibling of audit counter `authoringBehTargetBypassCount` in `apps/admin/scripts/audit-epic-100.ts`. See `docs/CHAIN-CONTRACTS.md` Link 3a and ADR `docs/decisions/2026-05-26-tray-model-a-semantics.md` for the sibling tray-label-honesty invariant surfaced in the same debugging session.
 
+### Check VP1 — No `vapi`-prefixed Call columns (AnyVoice I-VP3)
+
+For any change touching `apps/admin/**/*.{ts,tsx}` outside `_archived/` and `prisma/migrations/`:
+
+```bash
+grep -rn "vapi\(DurationSeconds\|EndedReason\|CostUsd\|AnalysisSummary\|StructuredData\|SuccessEvaluation\)" apps/admin --include="*.ts" --include="*.tsx" | grep -v "_archived\|prisma/migrations"
+```
+
+Any hit is a violation. The 6 columns were renamed to `voice*` in #1020; the pre-rename names are forbidden in application code. Build-time enforced by `hf-voice/no-vapi-column-ref` ESLint rule (#1024). The arch-checker is the second-line guard for cases where the rule somehow slipped (e.g. an eslint-disable that should not have been added).
+
+Flag (error severity once the audit counter `vapiNamedColumnsOnCallModel` reads 0 — it should always be 0 post-#1020):
+
+- Any code-side reference to one of the 6 forbidden names outside the allowed paths
+- A new `// eslint-disable` line silencing `hf-voice/no-vapi-column-ref` without a documented rationale
+
+See `docs/CHAIN-CONTRACTS.md` Link 3 sub-contract "COMPOSE → VOICE PROVIDER (transport adapter)" I-VP3.
+
+### Check VP2 — No `VAPI_TOOL_DEFINITIONS` constant (AnyVoice I-VP2)
+
+For any change touching `apps/admin/**/*.{ts,tsx}` outside `_archived/`:
+
+```bash
+grep -rn "VAPI_TOOL_DEFINITIONS" apps/admin --include="*.ts" --include="*.tsx" | grep -v "_archived"
+```
+
+Any hit declaring the const is a violation. The tool list moved to the `TOOLS-001` AnalysisSpec in #1019; loaded at runtime via `lib/voice/load-tool-definitions.ts`. Build-time enforced by `hf-voice/no-vapi-tool-definitions-const` ESLint rule (#1024).
+
+Flag (error):
+
+- New `const VAPI_TOOL_DEFINITIONS = [...]` or `export const VAPI_TOOL_DEFINITIONS = [...]`
+- Re-importing from a place that re-declares it
+
+See `docs/CHAIN-CONTRACTS.md` Link 3 sub-contract I-VP2 and audit counter `vapiToolDefinitionsConstantPresent`.
+
 ---
 
 ## Step 3 — Memory Doc Freshness

--- a/apps/admin/eslint-rules/hf-voice/no-vapi-column-ref.mjs
+++ b/apps/admin/eslint-rules/hf-voice/no-vapi-column-ref.mjs
@@ -1,0 +1,102 @@
+/**
+ * AnyVoice #1024 — block reintroduction of the 6 specific `vapi`-prefixed
+ * Call columns renamed in #1020.
+ *
+ * The schema rename moved 6 columns from `Call.vapi*` to canonical
+ * `Call.voice*`. The audit counter `vapiNamedColumnsOnCallModel` (#1016)
+ * drives to 0 after that migration; this rule keeps it at 0 by failing
+ * CI on any reference to the OLD column names. Closes the I-VP3
+ * invariant in `docs/CHAIN-CONTRACTS.md` Link 3 sub-contract
+ * (COMPOSE → VOICE PROVIDER).
+ *
+ * Why an explicit allowlist of forbidden NAMES (not a regex prefix):
+ *
+ *   The original draft of this rule used `/^vapi[A-Z]/` which
+ *   correctly catches every renamed column — but ALSO catches
+ *   legitimate code-side identifiers like `vapiInbound` (the
+ *   URL-bound adapter ref in `app/api/vapi/*` routes), `vapiCall`
+ *   (the historical-import VAPI payload var), `vapiProvider`
+ *   (general references to the VapiProvider class). Those are
+ *   Category B residuals — VAPI-specific by nature, correct
+ *   in context. Narrowing to the exact 6 renamed COLUMNS removes
+ *   the false-positive class without weakening the guarantee:
+ *   any genuinely renamed column reference still fires; legitimate
+ *   non-column VAPI-prefixed identifiers don't.
+ *
+ *   When a future schema rename adds another `vapi*` column to
+ *   forbid (vanishingly unlikely post-#1020 since we don't add such
+ *   columns anymore), append it to `FORBIDDEN_COLUMN_NAMES`.
+ *
+ * Allowed paths:
+ *   - `_archived/**` — read-only legacy (already globally ignored)
+ *   - `prisma/migrations/**` — pre-rename migration files reference
+ *     the old names verbatim (DROP/RENAME SQL)
+ */
+
+const FORBIDDEN_COLUMN_NAMES = new Set([
+  "vapiDurationSeconds",
+  "vapiEndedReason",
+  "vapiCostUsd",
+  "vapiAnalysisSummary",
+  "vapiStructuredData",
+  "vapiSuccessEvaluation",
+]);
+
+const ALLOWED_PATH_FRAGMENTS = [
+  "/prisma/migrations/",
+  "/_archived/",
+];
+
+function isAllowedFile(filename) {
+  if (!filename) return false;
+  return ALLOWED_PATH_FRAGMENTS.some((frag) => filename.includes(frag));
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow the 6 pre-#1020 vapi-prefixed Call column names. Use voice* names. See docs/CHAIN-CONTRACTS.md I-VP3.",
+    },
+    schema: [],
+    messages: {
+      vapiColumn:
+        "`{{ name }}` is the pre-#1020 column name. Use `voice{{ suffix }}` instead. The schema rename closed I-VP3; this rule keeps it closed.",
+    },
+  },
+  create(context) {
+    const filename = context.getFilename?.() ?? context.filename ?? "";
+    if (isAllowedFile(filename)) return {};
+
+    function reportIfForbidden(node, name) {
+      if (!name || !FORBIDDEN_COLUMN_NAMES.has(name)) return;
+      // suffix = name without the "vapi" prefix, capitalised — used in
+      // the message to suggest the canonical replacement
+      const suffix = name.slice(4); // "vapi".length === 4
+      context.report({
+        node,
+        messageId: "vapiColumn",
+        data: { name, suffix },
+      });
+    }
+
+    return {
+      // Identifier visitor catches bare refs (`call.vapiDurationSeconds`)
+      // AND identifier-typed property keys (`{ vapiDurationSeconds: 0 }`)
+      // because object keys ARE Identifier nodes in the AST.
+      Identifier(node) {
+        reportIfForbidden(node, node.name);
+      },
+      // Property visitor only handles QUOTED keys (`{"vapiCostUsd": 0}`)
+      // since identifier-typed keys are already covered by the visitor
+      // above. Without this split, every literal property key would fire
+      // twice and the rule's test expectations get noisy.
+      Property(node) {
+        if (node.key?.type === "Literal" && typeof node.key.value === "string") {
+          reportIfForbidden(node.key, node.key.value);
+        }
+      },
+    };
+  },
+};

--- a/apps/admin/eslint-rules/hf-voice/no-vapi-tool-definitions-const.mjs
+++ b/apps/admin/eslint-rules/hf-voice/no-vapi-tool-definitions-const.mjs
@@ -1,0 +1,46 @@
+/**
+ * AnyVoice #1024 — block reintroduction of the `VAPI_TOOL_DEFINITIONS`
+ * TypeScript constant.
+ *
+ * #1019 moved the tool definitions into the `TOOLS-001` AnalysisSpec.
+ * Loading happens at runtime via `lib/voice/load-tool-definitions.ts`.
+ * The audit counter `vapiToolDefinitionsConstantPresent` (#1016) drives
+ * to 0 after the spec migration; this rule keeps it at 0 by failing CI
+ * on any future re-introduction of a hardcoded TS const. Closes the
+ * I-VP2 invariant in `docs/CHAIN-CONTRACTS.md` Link 3 sub-contract.
+ *
+ * What this rule flags:
+ *   - VariableDeclarator where `id.name === "VAPI_TOOL_DEFINITIONS"`
+ *     (covers `const VAPI_TOOL_DEFINITIONS = [...]` AND
+ *      `export const VAPI_TOOL_DEFINITIONS = [...]`)
+ *
+ * Allowed paths:
+ *   - `_archived/**` — already globally ignored
+ *
+ * The TOOLS-001 spec lives in `docs-archive/bdd-specs/`; that's a JSON
+ * file, not a TS const, so this rule doesn't catch it.
+ */
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow the `VAPI_TOOL_DEFINITIONS` TypeScript constant. Load tool definitions from TOOLS-001 spec via `lib/voice/load-tool-definitions.ts`. See #1019.",
+    },
+    schema: [],
+    messages: {
+      hardcodedConstant:
+        "`VAPI_TOOL_DEFINITIONS` is forbidden — tool definitions must be loaded from the TOOLS-001 AnalysisSpec via `loadToolDefinitions()` in `lib/voice/load-tool-definitions.ts` (#1019). Hardcoding the array reintroduces the I-VP2 violation that #1019 closed.",
+    },
+  },
+  create(context) {
+    return {
+      VariableDeclarator(node) {
+        if (node.id?.type === "Identifier" && node.id.name === "VAPI_TOOL_DEFINITIONS") {
+          context.report({ node: node.id, messageId: "hardcodedConstant" });
+        }
+      },
+    };
+  },
+};

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -8,6 +8,8 @@ import noDirectSpecConfigWrite from "./eslint-rules/no-direct-spec-config-write.
 import noAiFanoutAll from "./eslint-rules/no-ai-fanout-all.mjs";
 import noAiForbiddenFields from "./eslint-rules/no-ai-forbidden-fields.mjs";
 import noOrphanInstructionFallback from "./eslint-rules/no-orphan-instruction-fallback.mjs";
+import noVapiColumnRef from "./eslint-rules/hf-voice/no-vapi-column-ref.mjs";
+import noVapiToolDefinitionsConst from "./eslint-rules/hf-voice/no-vapi-tool-definitions-const.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -107,6 +109,18 @@ const eslintConfig = defineConfig([
           "no-orphan-instruction-fallback": noOrphanInstructionFallback,
         },
       },
+      // AnyVoice #1024 — block reintroduction of pre-rename vapi*
+      // column refs and the removed VAPI_TOOL_DEFINITIONS TS const.
+      // Both audit counters (vapiNamedColumnsOnCallModel,
+      // vapiToolDefinitionsConstantPresent) read 0 after #1019/#1020;
+      // these rules keep them at 0. See chain-contracts.md Link 3
+      // sub-contract I-VP2 + I-VP3.
+      "hf-voice": {
+        rules: {
+          "no-vapi-column-ref": noVapiColumnRef,
+          "no-vapi-tool-definitions-const": noVapiToolDefinitionsConst,
+        },
+      },
     },
     rules: {
       "hf-curriculum/no-unscoped-slug-lookup": "error",
@@ -119,6 +133,8 @@ const eslintConfig = defineConfig([
       // once `composeGenericNounFallbackCount` reads 0 in dev/test/prod for
       // ≥7 days (per the chain-contract severity-escalation path).
       "hf-compose/no-orphan-instruction-fallback": "warn",
+      "hf-voice/no-vapi-column-ref": "error",
+      "hf-voice/no-vapi-tool-definitions-const": "error",
     },
   },
   // Enforce config+metering for ALL AI calls (no raw client usage)

--- a/apps/admin/tests/eslint-rules/no-vapi-column-ref.test.ts
+++ b/apps/admin/tests/eslint-rules/no-vapi-column-ref.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for eslint-rules/hf-voice/no-vapi-column-ref.mjs (AnyVoice #1024).
+ *
+ * Pins the rule contract: exactly the 6 forbidden Call column names
+ * fire; legitimate VAPI-prefixed identifiers (vapiInbound, vapiCall,
+ * vapiProvider — Category B residuals) do NOT. Path allowlist for
+ * migrations + _archived honoured.
+ */
+
+import { RuleTester } from "eslint";
+import rule from "../../eslint-rules/hf-voice/no-vapi-column-ref.mjs";
+
+// RuleTester.run drives the test runner's describe/it directly — must
+// live at module top level, not nested inside vitest's describe/it.
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+// Cast: the .mjs rule object's shape is correct at runtime, but TS's
+// ESLint RuleDefinition type is stricter than the .mjs export inference.
+tester.run("no-vapi-column-ref", rule as never, {
+      valid: [
+        // Canonical post-#1020 column names — pass through
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `
+            const data = {
+              voiceDurationSeconds: 90,
+              voiceEndedReason: "customer-ended-call",
+              voiceCostUsd: 0.05,
+              voiceAnalysisSummary: "ok",
+              voiceStructuredData: {},
+              voiceSuccessEvaluation: "true",
+            };
+            prisma.call.create({ data });
+          `,
+        },
+        // Category B legitimate identifiers — vapi*-named but NOT
+        // renamed-column names. Must NOT fire.
+        {
+          filename: "/repo/apps/admin/app/api/vapi/tools/route.ts",
+          code: `
+            const vapiInbound = await getVoiceProvider("vapi");
+            const vapiProvider = vapiInbound;
+            const vapiCall = { id: "abc" };
+          `,
+        },
+        // Migration files reference the old names verbatim — allowed
+        // by path exclusion.
+        {
+          filename: "/repo/apps/admin/prisma/migrations/20260604_xxx/migration.sql.ts",
+          code: `
+            const sql = \`ALTER TABLE "Call" RENAME COLUMN "vapiDurationSeconds" TO "voiceDurationSeconds";\`;
+          `,
+        },
+        // Archived legacy code — allowed by path exclusion.
+        {
+          filename: "/repo/apps/admin/prisma/_archived/seed-mabel.ts",
+          code: `prisma.call.create({ data: { vapiCostUsd: 0.05 } });`,
+        },
+      ],
+      invalid: [
+        // Each of the 6 forbidden names — one case per to pin the set.
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `prisma.call.create({ data: { vapiDurationSeconds: 90 } });`,
+          errors: [{ messageId: "vapiColumn" }],
+        },
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `prisma.call.create({ data: { vapiEndedReason: "x" } });`,
+          errors: [{ messageId: "vapiColumn" }],
+        },
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `prisma.call.create({ data: { vapiCostUsd: 0.05 } });`,
+          errors: [{ messageId: "vapiColumn" }],
+        },
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `prisma.call.create({ data: { vapiAnalysisSummary: "x" } });`,
+          errors: [{ messageId: "vapiColumn" }],
+        },
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `prisma.call.create({ data: { vapiStructuredData: {} } });`,
+          errors: [{ messageId: "vapiColumn" }],
+        },
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `prisma.call.create({ data: { vapiSuccessEvaluation: "true" } });`,
+          errors: [{ messageId: "vapiColumn" }],
+        },
+        // Bare identifier reference — also forbidden
+        {
+          filename: "/repo/apps/admin/app/api/vapi/webhook/route.ts",
+          code: `const x = call.vapiDurationSeconds;`,
+          errors: [{ messageId: "vapiColumn" }],
+        },
+      ],
+});

--- a/apps/admin/tests/eslint-rules/no-vapi-tool-definitions-const.test.ts
+++ b/apps/admin/tests/eslint-rules/no-vapi-tool-definitions-const.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for eslint-rules/hf-voice/no-vapi-tool-definitions-const.mjs
+ * (AnyVoice #1024). Pins: VAPI_TOOL_DEFINITIONS const declaration fires;
+ * other identifier patterns including the canonical replacement
+ * (loadToolDefinitions) do NOT.
+ */
+
+import { RuleTester } from "eslint";
+import rule from "../../eslint-rules/hf-voice/no-vapi-tool-definitions-const.mjs";
+
+// See sibling no-vapi-column-ref.test.ts for why RuleTester.run sits at
+// module top level and why the rule object is cast.
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+tester.run("no-vapi-tool-definitions-const", rule as never, {
+      valid: [
+        // Canonical replacement — pass through
+        {
+          code: `
+            import { loadToolDefinitions } from "@/lib/voice/load-tool-definitions";
+            const tools = await loadToolDefinitions();
+          `,
+        },
+        // Differently-named constants — pass through (rule is exact-name)
+        {
+          code: `const VOICE_TOOL_DEFINITIONS = [];`,
+        },
+        {
+          code: `const MY_CUSTOM_TOOLS = [];`,
+        },
+        // Importing the symbol (not declaring it) — pass through. The
+        // rule blocks the DECLARATION; an import would fail at runtime
+        // anyway since the symbol no longer exists.
+        {
+          code: `import { someUnrelated } from "./other";`,
+        },
+      ],
+      invalid: [
+        // Bare const declaration
+        {
+          code: `const VAPI_TOOL_DEFINITIONS = [];`,
+          errors: [{ messageId: "hardcodedConstant" }],
+        },
+        // Exported const declaration
+        {
+          code: `export const VAPI_TOOL_DEFINITIONS = [{ type: "function" }];`,
+          errors: [{ messageId: "hardcodedConstant" }],
+        },
+        // `let` is also forbidden — same name, same intent
+        {
+          code: `let VAPI_TOOL_DEFINITIONS = [];`,
+          errors: [{ messageId: "hardcodedConstant" }],
+        },
+      ],
+});


### PR DESCRIPTION
## Summary
Build-time enforcement of I-VP2 + I-VP3 invariants. Two ESLint rules + arch-checker doc updates. Both audit counters now have a build-time guard.

## Changes
- `eslint-rules/hf-voice/no-vapi-column-ref.mjs` — exact allowlist of 6 forbidden column names (avoids Category B false positives on vapiInbound/vapiCall/vapiProvider)
- `eslint-rules/hf-voice/no-vapi-tool-definitions-const.mjs` — flags const declaration
- Both registered at `error` severity in eslint.config.mjs
- `.claude/agents/arch-checker.md` — Check VP1 + VP2 added
- 18 rule test cases pass; 0 violations on cleaned codebase

## Deploy
`/vm-cp`

Merge-time follow-ups (sibling-branch coordination):
- `audit-epic-100.ts` (#1016) — promote counter comments from "drives target 0" to "enforced by hf-voice/no-vapi-*"
- baseline JSON — both counters → count=0 status=pass

Closes #1024 · Part of #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)