### PR TITLE
chore(voice): Category C VAPI hygiene sweep — comments, JSDoc, SIM prompts (#1029)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -198,7 +198,7 @@ async function loadCurrentModuleContext(
   // ── #284 Path 0b: authored-module fallback ──
   // Authored-module playbooks (modulesAuthored=true) store the canonical
   // module catalogue in `Playbook.config.modules[]`. When the caller has no
-  // `requestedModuleId` (every VAPI background call) we never used to look
+  // `requestedModuleId` (every inbound voice-provider background call) we never used to look
   // here — Path 1's CONTENT-spec lookup misses, Path 2's curriculum.notableInfo
   // is empty, and the function returned null. Result: `learningAssessment`
   // never fires and `CallerModuleProgress` never gets written. That's the
@@ -3768,7 +3768,7 @@ export async function POST(
   const log = createLogger();
 
   try {
-    // Allow internal service-to-service calls (VAPI webhook → pipeline)
+    // Allow internal service-to-service calls (voice webhook → pipeline)
     const internalSecret = request.headers.get("x-internal-secret");
     const isInternalCall = internalSecret && internalSecret === appConfig.security.internalApiSecret;
 

--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -306,7 +306,7 @@ export async function POST(request: NextRequest) {
       return await handleDataModeWithTools(messages, callPoint, engine, selectedEngine, mode, message, entityContext, conversationHistory, userRole, userId);
     }
 
-    // CALL mode: per-turn knowledge retrieval (matches what VAPI does live)
+    // CALL mode: per-turn knowledge retrieval (matches what the voice provider does live)
     if (mode === "CALL") {
       const callerEntity = entityContext.find((e) => e.type === "caller");
 
@@ -1160,7 +1160,7 @@ async function handleWizardModeWithTools(
 
 /**
  * Per-turn knowledge retrieval for sim calls.
- * Mirrors what VAPI gets via /api/vapi/knowledge on every conversation turn.
+ * Mirrors what the voice provider gets via /api/vapi/knowledge on every conversation turn.
  * Returns a formatted text block to append to the system prompt, or null.
  */
 async function retrieveSimKnowledge(
@@ -1172,7 +1172,7 @@ async function retrieveSimKnowledge(
     // Load retrieval settings (30s cache)
     const ks = await getKnowledgeRetrievalSettings();
 
-    // Build query from last N user messages (same as VAPI endpoint)
+    // Build query from last N user messages (same as voice knowledge endpoint)
     const recentUserMessages = conversationHistory
       .filter((m) => m.role === "user")
       .slice(-(ks.queryMessageCount - 1))

--- a/apps/admin/app/api/chat/system-prompts.ts
+++ b/apps/admin/app/api/chat/system-prompts.ts
@@ -240,7 +240,7 @@ You have tools to **query and modify** the database:
 - **add_content_assertions** — Add teaching points to a source (AI generates from knowledge)
 - **link_subject_to_domain** — Connect a subject to a domain
 - **generate_curriculum** — Trigger AI curriculum generation from assertions
-- **system_ini_check** — Run a full system initialization check (SUPERADMIN only). Returns pass/fail/warn for 10 checks covering env vars, database, specs, domains, contracts, admin users, parameters, AI services, VAPI, and storage.
+- **system_ini_check** — Run a full system initialization check (SUPERADMIN only). Returns pass/fail/warn for 10 checks covering env vars, database, specs, domains, contracts, admin users, parameters, AI services, voice provider, and storage.
 
 Use tools proactively. If the user asks about a spec or domain, look it up yourself.
 
@@ -1024,7 +1024,7 @@ async function getDomainContext(domainId: string): Promise<string | null> {
 /**
  * Build CALL mode prompt using the actual composed prompt for the caller.
  *
- * Uses renderProviderPrompt() for the same voice-optimized format that VAPI receives,
+ * Uses renderProviderPrompt() for the same voice-optimized format the voice provider receives,
  * giving a realistic simulation of the actual call experience.
  */
 async function buildCallSimPrompt(entityContext: EntityBreadcrumb[], terms?: TermMap, termBlock?: string): Promise<SystemPromptResult> {
@@ -1035,7 +1035,7 @@ async function buildCallSimPrompt(entityContext: EntityBreadcrumb[], terms?: Ter
     : "";
 
   if (!callerEntity) {
-    return { prompt: `You are simulating a VAPI voice AI call.
+    return { prompt: `You are simulating a voice AI call.
 
 No caller is currently selected. Please navigate to a caller to enable personalized simulation.
 
@@ -1053,7 +1053,7 @@ For now, respond as a friendly, helpful voice AI assistant. Keep responses short
     if (composedPrompt?.llmPrompt) {
       const voicePrompt = renderProviderPrompt(composedPrompt.llmPrompt as any);
       return {
-        prompt: `You are simulating a VAPI voice AI call. This is the EXACT prompt the voice AI receives.
+        prompt: `You are simulating a voice AI call. This is the EXACT prompt the voice AI receives.
 Keep responses SHORT (1-3 sentences) — this is voice, not text.
 ${goalPrefix}${voicePrompt}${termBlock || ""}`,
         llmPrompt: composedPrompt.llmPrompt,
@@ -1077,7 +1077,7 @@ ${goalPrefix}${voicePrompt}${termBlock || ""}`,
     });
 
     const parts = [
-      `You are simulating a VAPI voice AI call with ${caller?.name || "a caller"}.
+      `You are simulating a voice AI call with ${caller?.name || "a caller"}.
 
 No composed prompt found — run "Compose Prompt" for this caller first for the full experience.
 
@@ -1096,7 +1096,7 @@ No composed prompt found — run "Compose Prompt" for this caller first for the 
 
     return { prompt: parts.join("\n") + (termBlock || "") };
   } catch {
-    return { prompt: `You are simulating a VAPI voice AI call with caller ${callerEntity.label}.
+    return { prompt: `You are simulating a voice AI call with caller ${callerEntity.label}.
 
 Keep responses short (1-3 sentences) and conversational.
 Be helpful, warm, and natural.${termBlock || ""}` };

--- a/apps/admin/app/api/monitor/activity/route.ts
+++ b/apps/admin/app/api/monitor/activity/route.ts
@@ -39,7 +39,7 @@ export async function GET() {
       openTickets,
       aiStats,
     ] = await Promise.all([
-      // Live = endedAt null + started recently (proxy; no real VAPI session feed)
+      // Live = endedAt null + started recently (proxy; no real voice session feed)
       prisma.call.count({
         where: { endedAt: null, createdAt: { gte: fiveMinAgo } },
       }),

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -49,7 +49,7 @@ export default function SimConversationPage() {
   const communityName = searchParams.get('communityName') || undefined;
   const forceFirstCall = searchParams.get('forceFirstCall') === 'true';
   // #242 Slice 2 placeholder: surface the moduleId chosen in the picker.
-  // No real VAPI dial wiring yet — the banner just confirms the round-trip.
+  // No real voice dial wiring yet — the banner just confirms the round-trip.
   const requestedModuleId = searchParams.get('requestedModuleId') || undefined;
 
   const targetOverrides = useMemo(() => {

--- a/apps/admin/app/x/student/[courseId]/modules/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/modules/page.tsx
@@ -197,13 +197,13 @@ function PickerContent() {
       //      pickup #274 + tutor lockedModule narrative #266) — when returnTo points at
       //      /x/sim/[id] the picker rewrites the URL with ?requestedModuleId and SimChat
       //      forwards it on call init.
-      //   ⏳ VAPI / real voice dial path: NOT YET wired. The picker still bounces back to
+      //   ⏳ voice dial path: NOT YET wired. The picker still bounces back to
       //      a SIM session for voice scenarios; voice FOH integration would consume the
       //      same /api/student/module-status data and pass requestedModuleId to the dial.
       //      Tracked under #242 Slice 3 (in-chat picker — voice). Do not remove this
       //      comment until Slice 3 lands.
       console.info(
-        "[picker] selected moduleId=%s for course=%s — SIM path active, VAPI dial deferred to #242 Slice 3",
+        "[picker] selected moduleId=%s for course=%s — SIM path active, voice dial deferred to #242 Slice 3",
         moduleId,
         courseId,
       );
@@ -312,7 +312,7 @@ function PickerContent() {
                 aria-live="polite"
                 className="hf-banner learner-picker-page__banner"
               >
-                <strong>Placeholder:</strong> VAPI call would start now —
+                <strong>Placeholder:</strong> Voice call would start now —
                 returning to the simulator with the selected module.
               </div>
             )}

--- a/apps/admin/lib/chat/admin-tools.ts
+++ b/apps/admin/lib/chat/admin-tools.ts
@@ -617,7 +617,7 @@ export const ADMIN_TOOLS: AITool[] = [
   {
     name: "system_ini_check",
     description:
-      "Run a full system initialization check. Verifies environment variables, database connectivity, canonical specs, domains, contracts, admin users, parameters, AI services, VAPI integration, and storage. SUPERADMIN only. Returns pass/fail/warn for each check with remediation advice. Use when the user asks about system health, setup status, or readiness.",
+      "Run a full system initialization check. Verifies environment variables, database connectivity, canonical specs, domains, contracts, admin users, parameters, AI services, voice provider integration, and storage. SUPERADMIN only. Returns pass/fail/warn for each check with remediation advice. Use when the user asks about system health, setup status, or readiness.",
     input_schema: {
       type: "object",
       properties: {},

--- a/apps/admin/lib/knowledge/assertions.ts
+++ b/apps/admin/lib/knowledge/assertions.ts
@@ -1,5 +1,5 @@
 /**
- * Shared assertion search functions — used by both VAPI knowledge endpoint
+ * Shared assertion search functions — used by both voice knowledge endpoint
  * and sim call per-turn retrieval.
  *
  * Supports hybrid search (pgvector cosine similarity + keyword fallback).
@@ -381,7 +381,7 @@ export type QuestionResult = {
 
 /**
  * Search ContentQuestions by keyword matching.
- * Used by VAPI knowledge endpoint when learner asks for practice/assessment.
+ * Used by voice knowledge endpoint when learner asks for practice/assessment.
  * @param sourceIds — when provided, only return questions from these content sources (domain scoping)
  */
 export async function searchQuestions(
@@ -431,7 +431,7 @@ export async function searchQuestions(
 }
 
 /**
- * Format a question for AI consumption (VAPI knowledge result).
+ * Format a question for AI consumption (voice knowledge result).
  */
 export function formatQuestion(q: QuestionResult): string {
   const parts = [`[QUESTION: ${q.questionType}]`];
@@ -455,7 +455,7 @@ export type VocabularyResult = {
 
 /**
  * Search ContentVocabulary by keyword matching.
- * Used by VAPI knowledge endpoint when learner asks "what does X mean?"
+ * Used by voice knowledge endpoint when learner asks "what does X mean?"
  * @param sourceIds — when provided, only return vocabulary from these content sources (domain scoping)
  */
 export async function searchVocabulary(
@@ -508,7 +508,7 @@ export async function searchVocabulary(
 }
 
 /**
- * Format a vocabulary item for AI consumption (VAPI knowledge result).
+ * Format a vocabulary item for AI consumption (voice knowledge result).
  */
 export function formatVocabulary(v: VocabularyResult): string {
   const pos = v.partOfSpeech ? ` (${v.partOfSpeech})` : "";

--- a/apps/admin/lib/knowledge/domain-sources.ts
+++ b/apps/admin/lib/knowledge/domain-sources.ts
@@ -6,7 +6,7 @@
  * Domain-wide:  Domain → SubjectDomain → Subject → SubjectSource → ContentSource
  * Course-scoped: Playbook → PlaybookSubject → Subject → SubjectSource → ContentSource
  *
- * Used by VAPI knowledge endpoint, call sim, prompt composition, and
+ * Used by voice knowledge endpoint, call sim, prompt composition, and
  * content-breakdown API to scope content retrieval.
  *
  * Playbook-scoped functions fall back to domain-wide when no
@@ -372,7 +372,7 @@ export async function getSubjectsForPlaybook(playbookId: string, domainId: strin
  * Get teaching source IDs for a domain, EXCLUDING teacher-only documents.
  * Uses isStudentVisibleDefault() to filter — only READING_PASSAGE, WORKSHEET,
  * COMPREHENSION, and EXAMPLE documents are included.
- * Used by VAPI knowledge retrieval to prevent teacher materials from
+ * Used by voice knowledge retrieval to prevent teacher materials from
  * being served as student content during calls.
  */
 export async function getTeachingSourceIdsForDomain(domainId: string): Promise<string[]> {
@@ -392,7 +392,7 @@ export async function getTeachingSourceIdsForDomain(domainId: string): Promise<s
  * Get teaching source IDs for a playbook, EXCLUDING teacher-only documents.
  * Uses isStudentVisibleDefault() to filter — only READING_PASSAGE, WORKSHEET,
  * COMPREHENSION, and EXAMPLE documents are included.
- * Used by VAPI knowledge retrieval to prevent teacher materials from
+ * Used by voice knowledge retrieval to prevent teacher materials from
  * being served as student content during calls.
  */
 export async function getTeachingSourceIdsForPlaybook(playbookId: string): Promise<string[]> {

--- a/apps/admin/lib/pipeline/evidence-prefilter.ts
+++ b/apps/admin/lib/pipeline/evidence-prefilter.ts
@@ -106,7 +106,7 @@ export function getEvidenceKeywords(param: PrefilterParameter): {
 /**
  * Splits a transcript into the User-side text only. Pattern matches the
  * "User: ..." / "Assistant: ..." line shape produced by every Call writer
- * (sim-drive-call.ts, VAPI webhook, manual ingestion).
+ * (sim-drive-call.ts, voice webhook, manual ingestion).
  */
 export function extractLearnerText(transcript: string | null | undefined): string {
   if (!transcript) return "";

--- a/apps/admin/lib/prompt/composition/transforms/voice.ts
+++ b/apps/admin/lib/prompt/composition/transforms/voice.ts
@@ -8,7 +8,7 @@ import type { AssembledContext } from "../types";
 import type { SpecConfig } from "@/lib/types/json-fields";
 
 /**
- * Compute voice-specific guidance for VAPI/voice AI.
+ * Compute voice-specific guidance for voice AI.
  * Uses voiceSpec config when available, falls back to defaults.
  */
 registerTransform("computeVoiceGuidance", (

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -349,7 +349,7 @@ export interface CurriculumMetadata {
 }
 
 export interface SharedComputedState {
-  /** Delivery channel — 'text' for sim chat, 'voice' for VAPI/phone */
+  /** Delivery channel — 'text' for sim chat, 'voice' for phone (any voice provider) */
   channel: 'text' | 'voice';
   modules: ModuleData[];
   isFirstCall: boolean;

--- a/apps/admin/lib/system-settings.ts
+++ b/apps/admin/lib/system-settings.ts
@@ -1061,7 +1061,7 @@ export const SETTINGS_REGISTRY: SettingGroup[] = [
     id: "knowledge",
     label: "Knowledge Retrieval",
     icon: "Search",
-    description: "Per-turn RAG retrieval for VAPI and sim calls (vector + keyword hybrid)",
+    description: "Per-turn RAG retrieval for voice and sim calls (vector + keyword hybrid)",
     settings: [
       { key: "knowledge.query_message_count", label: "Query message count", description: "Number of recent user messages used as search context", type: "int", default: 3, min: 1, max: 10 },
       { key: "knowledge.top_results", label: "Top results", description: "Max results returned per retrieval turn", type: "int", default: 10, min: 1, max: 30 },


### PR DESCRIPTION
## Summary
Final epic story. Drops Category C VAPI references (comments, JSDocs, TODO markers, SIM-mode system prompts the AI reads at runtime).

## Critical runtime edits
- `app/api/chat/system-prompts.ts` — 5 SIM prompts: "VAPI voice AI call" → "voice AI call"; system_ini_check tool description rephrased
- `lib/chat/admin-tools.ts` — system_ini_check tool description rephrased

## Comment hygiene
- knowledge/assertions.ts, knowledge/domain-sources.ts, pipeline/evidence-prefilter.ts, compose transforms, system-settings, monitor/activity, chat/route, pipeline route, sim/student pages — all VAPI mentions → voice provider

## Kept (legitimately VAPI)
- transcripts/raw-files JSDoc "VAPI exports" (historical file format)
- scripts/fix-orphaned-calls "assuming VAPI format" (describes legacy data)
- seed-metering operation/engine "vapi" (slug values, not vocabulary)

## Test plan
- [x] Post-sweep audit: ~250 VAPI refs remain, all Category B legitimate (env vars, adapter dir, /api/vapi routes, slug values, historical importer)
- [x] Zero behavioural change — pure rebranding, no new prompt evals needed

## Deploy
`/vm-cp`

Closes #1029
**Closes the AnyVoice epic #1015** — all 14 stories shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)