### PR TITLE
fix(intake): deterministic reply when AI tool-call returns no text

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -127,6 +127,16 @@ export async function POST(req: NextRequest) {
     assistantReply = stubResult.reply;
   }
 
+  // Fallback narration. Claude commonly returns a tool call with no
+  // accompanying text after `update-setup` fires; an empty assistant
+  // reply makes the chat look stuck even though the fields were
+  // captured. If we have no text but a required field is still
+  // missing, ask for it deterministically. Idempotent — if the reply
+  // already has content, this is a no-op.
+  if (!assistantReply || assistantReply.trim() === "") {
+    assistantReply = nextQuestionFor(session.values);
+  }
+
   appendEvent(session, {
     kind: "CapturedTurn",
     payload: { role: "assistant", content: assistantReply },
@@ -193,6 +203,29 @@ function isReady(values: Record<string, unknown>): boolean {
     return v !== undefined && v !== null && v !== "";
   };
   return has("firstName") && has("lastName") && has("email") && has("ageRange");
+}
+
+/**
+ * Deterministic next-question fallback. Mirrors the field ordering in
+ * `isReady()`. Returns "" when readiness is already satisfied — the
+ * commit path will redirect and the chat doesn't need to say anything.
+ *
+ * Used when the AI call returns a tool call with no accompanying text
+ * (a common shape Claude produces after `update-setup` fires). Keeps
+ * the chat visibly flowing instead of showing a blank assistant turn.
+ */
+function nextQuestionFor(values: Record<string, unknown>): string {
+  const has = (k: string): boolean => {
+    const v = values[k];
+    return v !== undefined && v !== null && v !== "";
+  };
+  if (!has("firstName")) return "What's your first name?";
+  if (!has("lastName")) return "Thanks. What's your last name?";
+  if (!has("email")) return "Got it. What's your email?";
+  if (!has("ageRange")) {
+    return "Last one — which age band fits? Options: 18-24, 25-34, 35-44, 45-54, 55-64, 65-plus, or prefer-not-to-say. (Under-18 enrolment isn't supported via this flow.)";
+  }
+  return "";
 }
 
 // ── AI call — passes the `update-setup` tool ───────────────────────


### PR DESCRIPTION
## Summary

After PR #999 swapped the regex extractor for the spec-driven `update-setup` tool, Claude commonly returns the tool call with no accompanying text — `assistantReply = ""`. The chat UI shows nothing back even though `update-setup` correctly captured the fields, so the conversation looks stuck.

Closes the smoke MEMORY flagged as pending after Items 12+13 ("Peter Jones, peter@example.com → expect 3 fields atomically").

## Fix

When `assistantReply` is empty after the AI call, ask deterministically for the next missing field via `nextQuestionFor(values)`. Field ordering mirrors `isReady()`:

```
firstName → lastName → email → ageRange (with adult-only nudge) → "" (commit path takes over)
```

Idempotent — if Claude DID narrate, leaves the text alone.

## Live verification (hf-dev)

```
=== Turn 1 ===
user:   "James Bond james@bond.com"
server: values = { firstName: "James", lastName: "Bond", email: "james@bond.com" }
        assistant: "Last one — which age band fits? Options: 18-24, 25-34, …"

=== Turn 2 ===
user:   "25-34"
server: values += { ageRange: "25-34" }  → isReady() true
        redirectUrl: /intake/done?intentId=…
        assistant: ""  (correct — commit path takes over)
```

## Test plan
- [x] Live repro on hf-dev shows pre-fix empty assistant message, post-fix readable prompt
- [x] Two-turn flow completes with redirect to /intake/done
- [x] No tsc errors on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)