### PR TITLE
fix(intake): ART50 ack UI + tighten chat prompt (no scratchpad, strict ageRange order)

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -73,9 +73,10 @@ How to capture:
 How to reply (in the same turn as the tool call, when applicable):
 - Be warm, concise, professional. No emoji. No filler.
 - One short sentence per reply.
+- Never describe your own tool-calling reasoning to the learner. Do not say things like "I need to capture X simultaneously" or "I'm mapping Y to band Z" — that is internal scratchpad, never user-facing. Write a normal natural reply, e.g. "Got it — what's your email?"
 - Ask in this STRICT order, one field at a time: firstName → lastName → ageRange → email. (Email is asked LAST because the enrolment commits as soon as all four required values are in.)
 - If a greeting or affirmation ("hi", "ok", "yes") arrives in place of a name, re-prompt for that name. Do not capture greetings.
-- ageRange is REQUIRED. Do not skip it. After capturing lastName, your next reply MUST ask for the learner's age range. If they decline, capture 'prefer-not-to-say' and then move to email. Do not ask for email before ageRange has a value.
+- ageRange is REQUIRED. After capturing lastName, your VERY NEXT reply MUST ask for the learner's age range — do NOT ask for email yet. The email question only comes AFTER ageRange has a value (or 'prefer-not-to-say'). If you find yourself about to ask for email and ageRange is still missing, stop and ask for ageRange instead.
 - When all four required fields (firstName, lastName, ageRange, email) are captured, confirm the enrolment is being submitted and that a confirmation email will follow.`;
 
 const AFFIRMATION_RE = /^(hi|hello|hey|yo|ok|okay|sure|yes|yeah|yep|y|n|no|nope|start)\b[!.,? ]*$/i;

--- a/apps/admin/components/intake/EnrollmentChat.tsx
+++ b/apps/admin/components/intake/EnrollmentChat.tsx
@@ -28,6 +28,7 @@ import {
 import { EnrollmentIntake, INTERNAL_FIELDS } from "@/lib/intake/specs/enrollment.intent";
 
 const ART13_REQUIREMENT_ID = "gdpr.art13.privacy-notice";
+const ART50_REQUIREMENT_ID = "eu-ai-act.art50.ai-interaction-disclosure";
 
 // Inline Article 13 notice — minimal DRAFT text. Production should
 // load + render the full mdx from lib/intake/copy/gdpr-art13-privacy.*
@@ -40,6 +41,17 @@ HumanFirst Foundation is the data controller. We collect your name and email so 
 We process this information for the purposes of adult-learner enrolment and AI-mediated tutoring. Sub-processor: Anthropic (EU). Retention: 7 years by default.
 
 You can contact our Data Protection Officer at dpo@humanfirstfoundation.com. You have the right to access, rectify, erase, restrict, port, and object to processing of your data, and to lodge a complaint with the ICO.`;
+
+// Inline EU AI Act Art 50 notice — same DRAFT-vs-production caveat as
+// ART13_NOTICE_BODY above. Surfaced so the learner can scroll-signal
+// against the body that was hashed at delivery time.
+const ART50_NOTICE_BODY = `AI Interaction Disclosure (DRAFT)
+
+You're interacting with an AI assistant powered by Anthropic Claude. EU AI Act Article 50 requires us to tell you when an AI system is in use.
+
+The assistant captures the values you provide and submits them to a human-reviewed enrolment pipeline. It does NOT make enrolment decisions about you and it cannot grant or deny your access on its own.
+
+You can request a human handover at any time by typing "human please" in the chat, or by emailing dpo@humanfirstfoundation.com.`;
 
 interface ChatMessage {
   readonly role: "user" | "assistant" | "system";
@@ -242,6 +254,40 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
             // Optimistic refresh — re-fetch the snapshot via the next
             // chat turn or by re-bootstrapping the events. Cheapest:
             // refetch session events directly.
+            void fetch(`/api/intake/session/${encodeURIComponent(boot.intentId)}`)
+              .then((r) => r.json())
+              .then((data) => {
+                setBoot((b) => (b ? { ...b, events: rehydrateEvents(data.events) } : b));
+              })
+              .catch(() => {});
+          }}
+        />
+        {/* EU AI Act Art 50 — parallel surface to ART13 so the audit
+            bundle carries delivery + acknowledgement for BOTH notices.
+            Same TallysealBanner scroll-signal contract + same
+            DisclosureNoticeCard acknowledge contract. */}
+        <TallysealBanner
+          events={[...boot.events]}
+          requirementId={ART50_REQUIREMENT_ID as never}
+          noticeText={ART50_NOTICE_BODY}
+          onReadSignal={(signal) => {
+            void fetch("/api/intake/disclosure-signal", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                intentId: boot.intentId,
+                signal,
+              }),
+            }).catch(() => {});
+          }}
+        />
+        <DisclosureNoticeCard
+          intentId={boot.intentId}
+          chatSessionId={boot.chatSessionId}
+          requirementId={ART50_REQUIREMENT_ID}
+          body={ART50_NOTICE_BODY}
+          acknowledged={hasAcknowledgement(boot.events, ART50_REQUIREMENT_ID)}
+          onAcknowledged={() => {
             void fetch(`/api/intake/session/${encodeURIComponent(boot.intentId)}`)
               .then((r) => r.json())
               .then((data) => {


### PR DESCRIPTION
## Summary

Two small fixes surfaced by today's live intake runs at `/intake/enrollment-crawcus`.

### 1. ART50 acknowledgement UI (bundle symmetry)

Before this PR `EnrollmentChat.tsx` rendered a `TallysealBanner` + `DisclosureNoticeCard` for **art13 only**. Bootstrap fired `DisclosureDelivered` events for *both* art13 and art50 but the learner had no way to acknowledge art50, so bundles came out lopsided:

```
2 × DisclosureDelivered    (art13 + art50)
1 × DisclosureAcknowledged (art13 only)
```

After this PR the art50 surface mirrors art13: same scroll-signal contract, same acknowledge contract. Audit bundles now carry **2 deliveries + 2 acks**.

### 2. System prompt — no scratchpad + strict ageRange order

Live evidence from bundle `a2a717ae…-2`:

**Scratchpad leak** (commit turn):
> *"I need to capture the age range '25-34' (mapped from '30') and the email 'james@bond.com' simultaneously since they were provided in consecutive messages and the age range wasn't captured yet."*

That's Claude narrating its own internal reasoning to the learner. New rule added: *"Never describe your own tool-calling reasoning to the learner. Do not say things like 'I need to capture X simultaneously' or 'I'm mapping Y to band Z' — that is internal scratchpad, never user-facing."*

**Ordering violation** (turn 4):
After capturing `lastName: "Notie"`, Claude jumped to *"Got it. What's your email?"* — skipping ageRange. Self-corrected at turn 6 only when the user supplied email out-of-order. Strengthened: *"the VERY NEXT reply after lastName MUST ask for the learner's age range — do NOT ask for email yet … If you find yourself about to ask for email and ageRange is still missing, stop and ask for ageRange instead."*

## Files

| File | Change |
|---|---|
| `apps/admin/components/intake/EnrollmentChat.tsx` | Add `ART50_REQUIREMENT_ID` + `ART50_NOTICE_BODY` + parallel `TallysealBanner` + `DisclosureNoticeCard` surfaces |
| `apps/admin/app/api/intake/chat/route.ts` | Two new system-prompt lines: no-scratchpad rule + tighter ordering enforcement |

## Test plan

- [x] tsc clean on changed files (verified locally before push)
- [ ] Browser smoke at `localhost:3000/intake/enrollment-crawcus` — verify both notices have ack buttons, both populate `tallyseal_disclosure.acknowledged_at` post-click
- [ ] Replay "James Bond james@bond.com" + "25-34" + "james@bond.com" — verify no scratchpad leak in any assistant turn
- [ ] Audit bundle download shows 2× DisclosureAcknowledged events

🤖 Generated with [Claude Code](https://claude.com/claude-code)