### PR TITLE
fix(intake): normalize captured email to lowercase

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -127,6 +127,16 @@ export async function POST(req: NextRequest) {
     assistantReply = stubResult.reply;
   }
 
+  // Normalize email to lowercase. The spec validates format but does
+  // not transform; the AI / stub paths capture whatever case the
+  // learner typed. Aligns with /api/join/[token]'s `emailSchema`
+  // which `.toLowerCase()`s at zod validation, so downstream
+  // routes don't see case-divergent shapes for the same address.
+  if (typeof session.values.email === "string") {
+    const lower = session.values.email.toLowerCase();
+    if (lower !== session.values.email) session.values.email = lower;
+  }
+
   // Fallback narration. Claude commonly returns a tool call with no
   // accompanying text after `update-setup` fires; an empty assistant
   // reply makes the chat look stuck even though the fields were


### PR DESCRIPTION
Adds a 4-line server-authoritative `.toLowerCase()` on `session.values.email` after `applyToolCalls` returns. Aligns the intake capture path with /api/join/[token]'s zod `emailSchema` which already lowercases at validation. Idempotent.

Bundle 5c89b486… caught the inconsistency: snapshot had `email: 'James@bond.com'` (capital J preserved by AI path) but /api/join's path would have normalized it. This closes the divergence so the same address has the same shape everywhere.

No new tests — small enough that the existing chat-route coverage hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)