### PR TITLE
fix(tests): unblock 22 mock-gap test failures from main

### DIFF
--- a/apps/admin/tests/api/callers-calls-module-resolver.test.ts
+++ b/apps/admin/tests/api/callers-calls-module-resolver.test.ts
@@ -20,6 +20,10 @@ const mockPrisma = vi.hoisted(() => ({
   },
   curriculum: { findFirst: vi.fn() },
   curriculumModule: { findFirst: vi.fn() },
+  // Added 2026-06-04: resolveCurriculumIdForPlaybook from #1034 reads
+  // PlaybookCurriculum to map playbookId → curriculumId. Without this
+  // mock the test 500s on "Cannot read properties of undefined".
+  playbookCurriculum: { findFirst: vi.fn() },
 }));
 
 const mockRequireAuth = vi.hoisted(() => vi.fn());

--- a/apps/admin/tests/api/import-modules-fallback.test.ts
+++ b/apps/admin/tests/api/import-modules-fallback.test.ts
@@ -36,6 +36,14 @@ const { mockPrisma, mockRequireAuth, mockIsAuthError } = vi.hoisted(() => ({
     learningObjective: {
       findMany: vi.fn(),
     },
+    // Added 2026-06-04: peer #1034 added prisma.playbookCurriculum
+    // calls in lib/curriculum/resolve-module.ts +
+    // lib/curriculum/resolve-playbook-for-curriculum.ts. Without this
+    // mock the route 500s on "Cannot read properties of undefined".
+    playbookCurriculum: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
   },
   mockRequireAuth: vi.fn(),
   mockIsAuthError: vi.fn(),

--- a/apps/admin/tests/api/import-modules-recommendation.test.ts
+++ b/apps/admin/tests/api/import-modules-recommendation.test.ts
@@ -52,6 +52,13 @@ const {
     callerModuleProgress: {
       findMany: vi.fn(),
     },
+    // Added 2026-06-04: peer #1034 added prisma.playbookCurriculum
+    // calls in lib/curriculum/resolve-*. Without this mock the route
+    // 500s on "Cannot read properties of undefined".
+    playbookCurriculum: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
   },
   mockRequireAuth: vi.fn(),
   mockIsAuthError: vi.fn(),

--- a/apps/admin/tests/api/import-modules-status-badges.test.ts
+++ b/apps/admin/tests/api/import-modules-status-badges.test.ts
@@ -41,6 +41,13 @@ const { mockPrisma, mockRequireAuth, mockIsAuthError } = vi.hoisted(() => ({
     callerModuleProgress: {
       findMany: vi.fn(),
     },
+    // Added 2026-06-04: peer #1034 added prisma.playbookCurriculum
+    // calls in lib/curriculum/resolve-*. Without this mock the route
+    // 500s on "Cannot read properties of undefined".
+    playbookCurriculum: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
   },
   mockRequireAuth: vi.fn(),
   mockIsAuthError: vi.fn(),

--- a/apps/admin/tests/api/import-modules.test.ts
+++ b/apps/admin/tests/api/import-modules.test.ts
@@ -39,6 +39,13 @@ const {
     curriculumModule: {
       findMany: vi.fn(),
     },
+    // Added 2026-06-04: peer #1034 added prisma.playbookCurriculum
+    // calls in lib/curriculum/resolve-*. Without this mock the
+    // empty-state path 500s on "Cannot read properties of undefined".
+    playbookCurriculum: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
     // #245: import-modules POST now wraps the playbook update + module sync
     // in a transaction. The mock invokes the callback with a tx that proxies
     // playbook.update so existing assertions still see the call.

--- a/apps/admin/tests/api/vapi-assistant-request.test.ts
+++ b/apps/admin/tests/api/vapi-assistant-request.test.ts
@@ -21,16 +21,46 @@ vi.mock("@/lib/system-settings", () => ({
 
 // ── Mock prisma ────────────────────────────────────
 const mockCallerFindFirst = vi.fn();
+const mockCallerFindUnique = vi.fn();
 const mockComposedPromptFindFirst = vi.fn();
+// AnyVoice #1027 — assistant-request route now calls
+// resolveVoiceProviderForCaller(callerId), which reads
+// prisma.caller.findUnique({ select: { voiceProvider, cohortGroupId } }).
+// Default returns null voiceProvider so the cascade falls through to
+// SYSTEM default via getDefaultVoiceProviderSlug (mocked below).
+const mockVoiceProviderFindFirst = vi.fn();
+const mockVoiceProviderFindUnique = vi.fn();
 
 vi.mock("@/lib/prisma", () => {
   const _p = {
   prisma: {
-    caller: { findFirst: (...args: any[]) => mockCallerFindFirst(...args) },
+    caller: {
+      findFirst: (...args: any[]) => mockCallerFindFirst(...args),
+      findUnique: (...args: any[]) => mockCallerFindUnique(...args),
+    },
     composedPrompt: { findFirst: (...args: any[]) => mockComposedPromptFindFirst(...args) },
+    voiceProvider: {
+      findFirst: (...args: any[]) => mockVoiceProviderFindFirst(...args),
+      findUnique: (...args: any[]) => mockVoiceProviderFindUnique(...args),
+    },
   },
 };
   return { ..._p, db: (tx?: unknown) => tx ?? _p.prisma };
+});
+
+// AnyVoice #1031 — factory reads VoiceProvider from DB. Mock the
+// adapter directly so the cost-of-instantiation + VAPI-spec coupling
+// stay out of these wire-format tests.
+vi.mock("@/lib/voice/provider-factory", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/voice/provider-factory")>();
+  return {
+    ...actual,
+    getVoiceProvider: vi.fn(async () => {
+      const { VapiProvider } = await import("@/lib/voice/providers/vapi");
+      return new VapiProvider({ webhookSecret: "" }, {});
+    }),
+    getDefaultVoiceProviderSlug: vi.fn(async () => "vapi"),
+  };
 });
 
 // ── Mock config ────────────────────────────────────
@@ -41,7 +71,18 @@ vi.mock("@/lib/config", () => ({
       openai: { model: "gpt-4o" },
       claude: { model: "claude-sonnet-4-5-20250929" },
     },
+    // AnyVoice #1019 — loadToolDefinitions reads config.specs.voiceTools.
+    specs: {
+      voiceTools: "TOOLS-001",
+    },
   },
+}));
+
+// AnyVoice #1019 — loadToolDefinitions otherwise tries to read the
+// AnalysisSpec from prisma; short-circuit with empty tools array so
+// these wire-format tests stay focused on assistant-config shape.
+vi.mock("@/lib/voice/load-tool-definitions", () => ({
+  loadToolDefinitions: vi.fn().mockResolvedValue([]),
 }));
 
 // ── Mock fallback-settings (prevents config.ai.claude crash) ──
@@ -190,6 +231,13 @@ describe("POST /api/vapi/assistant-request", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetVoiceCallSettings.mockResolvedValue({ ...defaultSettings });
+    // AnyVoice #1027 — default: caller has no override, cascade falls
+    // through to SYSTEM default ("vapi"). Per-test can override
+    // mockCallerFindUnique to return a different voiceProvider.
+    mockCallerFindUnique.mockResolvedValue({
+      voiceProvider: null,
+      cohortGroupId: null,
+    });
   });
 
   it("uses provider and model from VoiceCallSettings", async () => {
@@ -246,6 +294,16 @@ describe("POST /api/vapi/assistant-request", () => {
   });
 
   it("filters out disabled tools", async () => {
+    // AnyVoice #1019 — tool defs come from TOOLS-001 spec.
+    // Re-mock loadToolDefinitions for this test so it returns all 10
+    // tools; the route's per-tool enablement filter then drops the
+    // three flipped to false below.
+    const { loadToolDefinitions } = await import("@/lib/voice/load-tool-definitions");
+    const toolsSpec = await import("../../docs-archive/bdd-specs/TOOLS-001-voice-tool-definitions.spec.json");
+    (loadToolDefinitions as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      (toolsSpec as any).default.config.tools,
+    );
+
     mockGetVoiceCallSettings.mockResolvedValue({
       ...defaultSettings,
       toolLookupTeachingPoint: false,

--- a/apps/admin/tests/api/vapi-knowledge.test.ts
+++ b/apps/admin/tests/api/vapi-knowledge.test.ts
@@ -9,6 +9,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mock VAPI auth ─────────────────────────────────
+// AnyVoice #1031 — knowledge route reads getVoiceProvider("vapi")
+// which DB-loads VoiceProvider. Short-circuit via factory mock so
+// this wire-format test stays focused on RAG response shape, not
+// the provider table.
+vi.mock("@/lib/voice/provider-factory", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/voice/provider-factory")>();
+  return {
+    ...actual,
+    getVoiceProvider: vi.fn(async () => {
+      const { VapiProvider } = await import("@/lib/voice/providers/vapi");
+      return new VapiProvider({ webhookSecret: "" }, {});
+    }),
+  };
+});
+
 vi.mock("@/lib/voice/providers/vapi/auth", () => ({
   verifyVapiRequest: vi.fn().mockReturnValue(null), // Auth passes
 }));

--- a/apps/admin/tests/lib/admin-tools-coverage-gaps.test.ts
+++ b/apps/admin/tests/lib/admin-tools-coverage-gaps.test.ts
@@ -16,6 +16,14 @@ const mockPrisma = {
   caller: { update: vi.fn() },
   goal: { findUnique: vi.fn(), update: vi.fn() },
   callerAttribute: { findFirst: vi.fn(), update: vi.fn() },
+  // Added 2026-06-04: peer #1034's bump-curriculum-fanout helper +
+  // resolve-* read prisma.playbookCurriculum. Without this the
+  // update_curriculum_module tool 500s in this test. findMany returns
+  // [] so the fanout helper's `.length` access doesn't NPE.
+  playbookCurriculum: {
+    findFirst: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
 };
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 

--- a/apps/admin/tests/lib/admin-tools-read-parity.test.ts
+++ b/apps/admin/tests/lib/admin-tools-read-parity.test.ts
@@ -21,6 +21,17 @@ const mockPrisma = {
   curriculumModule: { findMany: vi.fn() },
   goal: { findMany: vi.fn() },
   learningObjective: { findUnique: vi.fn(), update: vi.fn() },
+  // Added 2026-06-04: peer #1034's resolveCurriculumIdForPlaybook + the
+  // bump-curriculum-fanout helper read prisma.playbookCurriculum. Without
+  // this the read-parity tests for update_curriculum_module +
+  // list_curriculum_modules + update_curriculum_metadata +
+  // update_learning_objective throw. findMany returns [] so the fanout
+  // helper's `.length` access doesn't NPE — tests that need rows back
+  // override per-test via `playbookCurriculum.findMany.mockResolvedValueOnce`.
+  playbookCurriculum: {
+    findFirst: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
 };
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 

--- a/apps/admin/tests/lib/composition/section-data-loader.test.ts
+++ b/apps/admin/tests/lib/composition/section-data-loader.test.ts
@@ -24,6 +24,11 @@ vi.mock("@/lib/prisma", () => {
     playbookSource: { findMany: vi.fn() },
     behaviorTarget: { findMany: vi.fn() },
     contentAssertion: { findMany: vi.fn() },
+    // Added 2026-06-04: SectionDataLoader subjectSources loader reads
+    // prisma.playbookCurriculum.findFirst (peer #1034). Without this
+    // mock the tutorOnly-hint test 500s. Returns null → loader falls
+    // through to its existing curriculum-by-name path.
+    playbookCurriculum: { findFirst: vi.fn() },
   };
   return { prisma: mock, db: () => mock };
 });

--- a/apps/admin/tests/setup.ts
+++ b/apps/admin/tests/setup.ts
@@ -255,6 +255,25 @@ vi.mock('@prisma/client', () => {
       create: vi.fn(),
       update: vi.fn(),
     },
+    // Added 2026-06-04 — peer #1034 introduced runtime calls to
+    // prisma.playbookCurriculum (the join table between Playbook and
+    // Curriculum) from lib/curriculum/resolve-module.ts and
+    // lib/curriculum/resolve-playbook-for-curriculum.ts. Without this
+    // mock, every test that exercises module-slug resolution throws
+    // "Cannot read properties of undefined (reading 'findFirst')".
+    // Confirmed empirically — 3 test files (callers-calls-module-
+    // resolver, import-modules-fallback, import-modules-recommendation,
+    // import-modules-status-badges) failed in CI on the post-#1065
+    // main run; same failure on a fresh checkout of main without any
+    // AnyVoice code.
+    playbookCurriculum: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
     userTask: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
@@ -263,16 +282,65 @@ vi.mock('@prisma/client', () => {
       update: vi.fn(),
     },
     $disconnect: vi.fn(),
-    $transaction: vi.fn().mockImplementation((fn: any) => {
-      if (typeof fn === 'function') return fn(mockPrismaClient);
-      return Promise.all(fn);
-    }),
+    // $transaction assigned after proxiedClient is constructed so the
+    // transaction's tx argument is the proxied (auto-stub) client too.
+    $transaction: undefined as unknown as ReturnType<typeof vi.fn>,
   };
 
-  // Create a mock class
-  const MockPrismaClient = function(this: any) {
-    Object.assign(this, mockPrismaClient);
+  // Self-healing Proxy fallback — return an auto-stub for any model
+  // access that wasn't explicitly defined above. This stops the
+  // recurring "Cannot read properties of undefined (reading 'findX')"
+  // failures every time the runtime adds a new model query (peer's
+  // #1034 hit 4 test files this way; #1031's VoiceProvider model
+  // would have hit similar paths without the explicit mock added in
+  // that PR's tests).
+  //
+  // The auto-stub exposes every method the Prisma client surface uses
+  // (findMany / findUnique / findFirst / create / createMany /
+  // update / updateMany / delete / deleteMany / upsert / count /
+  // aggregate / groupBy). Each is a fresh vi.fn() per access — tests
+  // that need specific behaviour for a model continue to either set
+  // up the explicit mock above OR call `prisma.<model>.<fn>.mockResolvedValue(...)`
+  // inside the test (the auto-stub is a real vi.fn()).
+  //
+  // Cached per-property so two reads of the same model return the
+  // same stub (so test setup via `prisma.foo.findMany.mockResolvedValue(x)`
+  // is visible at the call site).
+  const autoStubCache = new Map<string, Record<string, ReturnType<typeof vi.fn>>>();
+  const PRISMA_MODEL_METHODS = [
+    "findMany", "findUnique", "findFirst", "findUniqueOrThrow", "findFirstOrThrow",
+    "create", "createMany", "update", "updateMany", "delete", "deleteMany",
+    "upsert", "count", "aggregate", "groupBy",
+  ];
+  const makeAutoStub = () => {
+    const stub: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const m of PRISMA_MODEL_METHODS) stub[m] = vi.fn();
+    return stub;
   };
+  const proxiedClient = new Proxy(mockPrismaClient, {
+    get(target, prop: string | symbol) {
+      if (prop in target) return (target as Record<string | symbol, unknown>)[prop];
+      if (typeof prop !== "string") return undefined;
+      // Skip vitest-internal probes + Symbol-shaped probes
+      if (prop.startsWith("$") || prop.startsWith("_") || prop === "then") return undefined;
+      if (!autoStubCache.has(prop)) autoStubCache.set(prop, makeAutoStub());
+      return autoStubCache.get(prop);
+    },
+  });
+
+  // Wire $transaction to pass the proxied client so callbacks see
+  // the same auto-stub fallback for any unmocked models.
+  mockPrismaClient.$transaction = vi.fn().mockImplementation((fn: any) => {
+    if (typeof fn === 'function') return fn(proxiedClient);
+    return Promise.all(fn);
+  });
+
+  // Create a mock class — instances are themselves Proxies over the
+  // shared mockPrismaClient (so explicit + auto-stub mocks behave
+  // identically across `new PrismaClient()` and the singleton import).
+  const MockPrismaClient = function(this: any) {
+    return proxiedClient;
+  } as unknown as { new (): typeof proxiedClient };
 
   return {
     PrismaClient: MockPrismaClient,


### PR DESCRIPTION
## Summary

Tests using hand-rolled \`vi.hoisted({mockPrisma: ...})\` were missing mocks for models that recent upstream work made the runtime read:

- **`prisma.playbookCurriculum`** — peer #1034 wired this into `resolve-module.ts` / `resolve-playbook-for-curriculum.ts` / `bump-curriculum-fanout.ts`. 8 test files broke.
- **`prisma.caller.findUnique`** + **`prisma.voiceProvider.*`** — AnyVoice #1027 / #1031 made the assistant-request + knowledge routes call these. 2 test files broke.

Failures showed as TypeError "Cannot read properties of undefined (reading 'findFirst' | 'findMany' | 'findUnique')".

## Changes

10 test files: add missing `playbookCurriculum` / `voiceProvider` mock entries. For tests where the runtime calls `findMany().length`, the mock returns `[]` by default so the fanout helper doesn't NPE.

`tests/setup.ts`: Proxy fallback on the **global** mockPrismaClient. Missing-model accesses return an auto-stubbed `vi.fn()` instead of throwing. Defence-in-depth — hand-rolled mocks still need explicit entries (that's the contract; this is the safety net).

## Test plan

Before: `22 failed | 4355 passed`
After: `0 failed | 4377 passed`

## Deploy

\`/vm-cp\` — test-only changes, no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)