### PR TITLE
feat: Settings sidebar link + Archive on voice providers

### DIFF
--- a/apps/admin/app/x/settings/voice-providers/page.tsx
+++ b/apps/admin/app/x/settings/voice-providers/page.tsx
@@ -39,6 +39,7 @@ export default function VoiceProvidersPage() {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [pingResults, setPingResults] = useState<Record<string, PingResult | "loading">>({});
+  const [showArchived, setShowArchived] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -101,6 +102,22 @@ export default function VoiceProvidersPage() {
     }
   }
 
+  async function setEnabled(id: string, enabled: boolean, displayName: string) {
+    if (!enabled && !confirm(`Archive "${displayName}"? It will stop serving calls but can be restored from "Show archived".`)) return;
+    try {
+      const res = await fetch(`/api/voice-providers/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      await load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
   return (
     <main className="hf-page">
       <h1 className="hf-page-title">Voice providers</h1>
@@ -125,8 +142,25 @@ export default function VoiceProvidersPage() {
           No providers registered. <Link href="/x/settings/voice-providers/new">Add one</Link> to start.
         </div>
       ) : (
-        <ul className="hf-card-list">
-          {rows.map((row) => {
+        (() => {
+          const visible = showArchived ? rows : rows.filter((r) => r.enabled);
+          const archivedCount = rows.filter((r) => !r.enabled).length;
+          return (
+            <>
+              {archivedCount > 0 ? (
+                <div className="hf-card-footer" style={{ justifyContent: "flex-end", marginBottom: 12 }}>
+                  <label className="hf-label" style={{ display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer" }}>
+                    <input
+                      type="checkbox"
+                      checked={showArchived}
+                      onChange={(e) => setShowArchived(e.target.checked)}
+                    />
+                    Show archived ({archivedCount})
+                  </label>
+                </div>
+              ) : null}
+              <ul className="hf-card-list">
+                {visible.map((row) => {
             const credKeys = Object.keys(row.credentials);
             const ping = pingResults[row.id];
             return (
@@ -187,7 +221,7 @@ export default function VoiceProvidersPage() {
                   <Link href={`/x/settings/voice-providers/${row.id}`} className="hf-btn hf-btn-secondary">
                     Edit
                   </Link>
-                  {!row.isDefault ? (
+                  {!row.isDefault && row.enabled ? (
                     <button
                       type="button"
                       className="hf-btn hf-btn-secondary"
@@ -195,6 +229,25 @@ export default function VoiceProvidersPage() {
                     >
                       Set as default
                     </button>
+                  ) : null}
+                  {!row.isDefault ? (
+                    row.enabled ? (
+                      <button
+                        type="button"
+                        className="hf-btn hf-btn-secondary"
+                        onClick={() => setEnabled(row.id, false, row.displayName)}
+                      >
+                        Archive
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="hf-btn hf-btn-secondary"
+                        onClick={() => setEnabled(row.id, true, row.displayName)}
+                      >
+                        Unarchive
+                      </button>
+                    )
                   ) : null}
                   {!row.isDefault ? (
                     <button
@@ -208,8 +261,11 @@ export default function VoiceProvidersPage() {
                 </footer>
               </li>
             );
-          })}
-        </ul>
+                })}
+              </ul>
+            </>
+          );
+        })()
       )}
 
       <div className="hf-card-footer">

--- a/apps/admin/lib/sidebar/sidebar-manifest.json
+++ b/apps/admin/lib/sidebar/sidebar-manifest.json
@@ -10,5 +10,12 @@
       { "id": "demo-feedback", "href": "/x/feedback", "label": "Feedback", "icon": "MessageSquarePlus" },
       { "id": "demo-cohorts", "href": "/x/cohorts", "label": "Cohorts", "icon": "School" }
     ]
+  },
+  {
+    "id": "admin-bottom",
+    "requiredRole": "ADMIN",
+    "items": [
+      { "id": "admin-settings", "href": "/x/settings", "label": "Settings", "icon": "Settings", "shortcutHint": "⌘," }
+    ]
   }
 ]

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary
- Adds **Settings** link to the bottom of the primary sidebar (ADMIN-gated)
- Adds **Archive** / **Unarchive** buttons to `/x/settings/voice-providers` — flips the existing `enabled` flag via the PATCH endpoint
- Adds a **Show archived** toggle so disabled rows aren't lost from the UI

## Why
After AnyVoice (#1015/#1031) shipped, admins had no nav path to discover `/x/settings` or the new `/x/settings/voice-providers` page. Also, the only destructive action was hard-delete — `enabled: false` already gates the provider in `provider-factory.ts`, so Archive is a soft equivalent that keeps call-history attribution intact.

## Test plan
- [ ] Log in as ADMIN — Settings appears at bottom of sidebar
- [ ] Log in as OPERATOR — Settings is hidden (requiredRole gate)
- [ ] Click Settings → lands on `/x/settings`
- [ ] Navigate to Voice Providers (`/x/settings/voice-providers`)
- [ ] Click Archive on the non-default provider — confirm modal, row hides, badge flips to Disabled when shown
- [ ] Toggle "Show archived" — the row reappears, with Unarchive button
- [ ] Click Unarchive — row returns to active list

🤖 Generated with [Claude Code](https://claude.com/claude-code)