### PR TITLE
fix(tests): drop invalid playbookId from Caller create (#1081 follow-up)

### DIFF
--- a/apps/admin/tests/integration/journey/exam-assessment-isolation.integration.test.ts
+++ b/apps/admin/tests/integration/journey/exam-assessment-isolation.integration.test.ts
@@ -98,7 +98,6 @@ beforeAll(async () => {
     data: {
       name: `${PFX} caller`,
       domainId,
-      playbookId,
     },
     select: { id: true },
   });


### PR DESCRIPTION
Follow-up to #1084. Agent-authored integration test seeded a Caller with a non-existent playbookId field; removed. Test seed now runs cleanly on VM.

Refs #1081 (AC11).