### PR TITLE
feat(voice): wire telemetry + voice-tools nav links (follow-up to #1082)

### DIFF
--- a/apps/admin/app/x/settings/voice-providers/[id]/page.tsx
+++ b/apps/admin/app/x/settings/voice-providers/[id]/page.tsx
@@ -17,6 +17,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
 
 interface ConfigField {
   key: string;
@@ -237,6 +238,17 @@ export default function VoiceProviderEditPage() {
       <p className="hf-page-subtitle">
         slug: <code>{row.slug}</code> · adapter: <code>{row.adapterKey}</code>
         {row.isDefault ? " · default" : ""}
+      </p>
+
+      {/* Quick nav — telemetry per provider, tools system-wide */}
+      <p className="hf-section-desc">
+        <Link href={`/x/settings/voice-providers/${row.id}/telemetry`}>
+          View telemetry &rarr;
+        </Link>
+        {" · "}
+        <Link href="/x/settings/voice-tools">Voice tools (system-wide)</Link>
+        {" · "}
+        <Link href="/x/settings/voice-providers">All providers</Link>
       </p>
 
       {err && (

--- a/apps/admin/app/x/settings/voice-providers/[id]/telemetry/page.tsx
+++ b/apps/admin/app/x/settings/voice-providers/[id]/telemetry/page.tsx
@@ -73,6 +73,13 @@ export default function VoiceProviderTelemetryPage() {
       <h1 className="hf-page-title">
         Voice telemetry — {providerSlug || "provider"}
       </h1>
+      <p className="hf-section-desc">
+        <Link href={`/x/settings/voice-providers/${id}`}>
+          &larr; Back to provider
+        </Link>
+        {" · "}
+        <Link href="/x/settings/voice-providers">All providers</Link>
+      </p>
       <p className="hf-page-subtitle">
         {drillCallId ? (
           <>

--- a/apps/admin/components/settings/VoiceProvidersPanel.tsx
+++ b/apps/admin/components/settings/VoiceProvidersPanel.tsx
@@ -231,6 +231,9 @@ export function VoiceProvidersPanel({ showHeading = false }: Props = {}) {
                         <Link href={`/x/settings/voice-providers/${row.id}`} className="hf-btn hf-btn-secondary">
                           Edit
                         </Link>
+                        <Link href={`/x/settings/voice-providers/${row.id}/telemetry`} className="hf-btn hf-btn-secondary">
+                          Telemetry
+                        </Link>
                         {!row.isDefault && row.enabled ? (
                           <button
                             type="button"


### PR DESCRIPTION
## Summary

Pure-JSX nav fix discovered the moment after #1082 merged: the new telemetry page and the system-wide voice-tools panel had no clickable surface to reach them.

- **Voice Providers list panel** (`VoiceProvidersPanel.tsx`) — new "Telemetry" link per row next to "Edit"
- **Voice Provider edit page** (`/x/settings/voice-providers/[id]`) — header now shows three quick-nav links: *View telemetry → · Voice tools · All providers*
- **Telemetry page** (`/x/settings/voice-providers/[id]/telemetry`) — new "← Back to provider · All providers" header links

No API changes, no migration. Ready for `/vm-cp`.

## Test plan

- [ ] After `/vm-cp` — visit `/x/settings/voice-providers` and confirm each row shows Edit + Telemetry + (default actions)
- [ ] Click a provider row's Edit — confirm header shows the three quick-nav links
- [ ] Click "View telemetry →" — lands on the per-provider telemetry page with a working "← Back to provider" link
- [ ] On the telemetry page, click a callId to drill in — confirm the existing `[← back to all events]` still works alongside the new header links

🤖 Generated with [Claude Code](https://claude.com/claude-code)