### PR TITLE
chore: remove dead get-started-v4 redirect stub

### DIFF
--- a/apps/admin/app/x/get-started-v4/page.tsx
+++ b/apps/admin/app/x/get-started-v4/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function GetStartedV4Page() {
-  redirect("/x/get-started-v5");
-}


### PR DESCRIPTION
Single-file delete. 5-line redirect-only page with zero inbound references. V5 and V6 wizard paths unaffected.

Refs #1081 Slice 2A.