### PR TITLE
feat(curriculum): qualificationAnchor field + derive helper (#1081 Slice 2B.1)

### DIFF
--- a/apps/admin/lib/curriculum/qualification-anchor.ts
+++ b/apps/admin/lib/curriculum/qualification-anchor.ts
@@ -1,0 +1,54 @@
+/**
+ * Qualification anchor — labelling/grouping field for Curricula teaching the same
+ * regulated qualification. NOT a mastery-sharing mechanism (see #1081 — sharing
+ * comes from PlaybookCurriculum role=linked, one shared Curriculum).
+ *
+ * The anchor is derived deterministically from declared frontmatter / wizard input
+ * so the same qualification always lands on the same anchor across re-ingests.
+ */
+
+/**
+ * Known-qualifications override table. Lookup is case-insensitive on the
+ * (body, ref) pair; first match wins. Add canonical anchors here as new
+ * regulated qualifications are onboarded.
+ */
+const KNOWN_QUALIFICATIONS: ReadonlyArray<readonly [body: string, ref: string, anchor: string]> = [
+  ["Ofqual", "SIAS / The CIO/CTO Standard V6.0", "sias-cio-cto-v6"],
+  ["SIAS", "The CIO/CTO Standard V6.0", "sias-cio-cto-v6"],
+  // Add new known qualifications above this line.
+];
+
+/**
+ * Derive the canonical qualificationAnchor for a (body, ref) pair.
+ * Returns null if both inputs are null/empty (caller decides whether to leave
+ * the Curriculum's anchor null or to derive from other inputs).
+ */
+export function deriveQualificationAnchor(
+  body: string | null | undefined,
+  ref: string | null | undefined,
+): string | null {
+  const b = (body ?? "").trim();
+  const r = (ref ?? "").trim();
+  if (!b && !r) return null;
+
+  // 1. Known-qualifications override (case-insensitive lookup on body + ref).
+  for (const [knownBody, knownRef, anchor] of KNOWN_QUALIFICATIONS) {
+    if (b.toLowerCase() === knownBody.toLowerCase() && r.toLowerCase() === knownRef.toLowerCase()) {
+      return anchor;
+    }
+  }
+
+  // 2. Fallback: slugify body + ref, joined.
+  const combined = [b, r].filter(Boolean).join(" ");
+  return slugify(combined);
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip diacritics (combining marks)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .substring(0, 80);
+}

--- a/apps/admin/prisma/migrations/20260605_1458_1081_add_curriculum_qualification_anchor/migration.sql
+++ b/apps/admin/prisma/migrations/20260605_1458_1081_add_curriculum_qualification_anchor/migration.sql
@@ -1,0 +1,14 @@
+-- #1081 Slice 2B.1: add qualificationAnchor labelling field on Curriculum.
+-- NOT a mastery-sharing mechanism (sharing comes from PlaybookCurriculum
+-- role=linked, one shared Curriculum). This field labels sibling Curricula
+-- so the upcoming CI guard (Slice 2B.3) can detect slug/ref set divergence
+-- within an anchor family, and admin rollups can group by qualification.
+--
+-- See lib/curriculum/qualification-anchor.ts for the derive helper and
+-- scripts/backfill-curriculum-anchors.ts for the one-shot operator backfill.
+
+-- AlterTable
+ALTER TABLE "Curriculum" ADD COLUMN "qualificationAnchor" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Curriculum_qualificationAnchor_idx" ON "Curriculum"("qualificationAnchor");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -2388,6 +2388,12 @@ model Curriculum {
   qualificationBody   String? // "CII", "Highfield", "Ofqual"
   qualificationNumber String? // "603/4937/2" or "R04"
   qualificationLevel  String? // "Level 2", "Diploma", "Certificate"
+  // qualificationAnchor — labelling/grouping field (NOT a visibility gate or mastery
+  // sharing mechanism). Groups Curricula teaching the same regulated qualification
+  // for CI guards (slug/ref set divergence detection) and admin rollups. Mastery
+  // sharing itself comes from the PlaybookCurriculum(role: linked) variant pattern
+  // — one Curriculum, multiple Playbooks — not from this field. See #1081.
+  qualificationAnchor String?
   validFrom           DateTime? // When this curriculum version becomes active
   validUntil          DateTime? // When this curriculum version expires
 
@@ -2418,6 +2424,7 @@ model Curriculum {
   @@index([validUntil])
   @@index([subjectId])
   @@index([playbookId])
+  @@index([qualificationAnchor])
 }
 
 // =============================================================================

--- a/apps/admin/scripts/backfill-curriculum-anchors.ts
+++ b/apps/admin/scripts/backfill-curriculum-anchors.ts
@@ -1,0 +1,110 @@
+/**
+ * Backfill — #1081 Slice 2B.1: label the existing CIO/CTO Curriculum with
+ * `qualificationAnchor = "sias-cio-cto-v6"`.
+ *
+ * This is the one-shot backfill that goes with the schema change. It targets
+ * a single, known Curriculum (the shared `the-standard-v1` Curriculum used by
+ * all three CIO/CTO Playbooks — Revision Aid / Pop Quiz / Exam Assessment) and
+ * sets its `qualificationAnchor`. Mastery sharing already works via the
+ * PlaybookCurriculum(role: linked) variant pattern — this field is purely a
+ * labelling/grouping marker for CI guards (Slice 2B.3) and admin rollups.
+ *
+ * Safety properties:
+ *   - Dry-run by default. Pass --apply to commit.
+ *   - Idempotent: re-running with the anchor already set is a no-op.
+ *   - Refuses to overwrite an unexpected non-null anchor (operator investigates).
+ *   - Wraps the write + assertion in a single $transaction.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-curriculum-anchors.ts            # dry-run (default)
+ *   npx tsx scripts/backfill-curriculum-anchors.ts --apply    # commit
+ *
+ * Exit codes:
+ *   0 — clean (skipped or applied)
+ *   1 — unexpected error
+ *   2 — aborted (anchor set to an unexpected value)
+ */
+
+import { prisma } from "../lib/prisma";
+
+const TARGET_CURRICULUM_ID = "0ccb2874-f2d5-4431-96d0-0c0faf342636";
+const TARGET_ANCHOR = "sias-cio-cto-v6";
+
+async function main(): Promise<number> {
+  const apply = process.argv.includes("--apply");
+  const mode = apply ? "APPLY" : "DRY-RUN";
+
+  let updated = 0;
+  let skipped = 0;
+  let aborted = 0;
+
+  const current = await prisma.curriculum.findUnique({
+    where: { id: TARGET_CURRICULUM_ID },
+    select: { id: true, slug: true, qualificationAnchor: true },
+  });
+
+  if (!current) {
+    console.error(
+      `[backfill-anchors] ERROR — target Curriculum ${TARGET_CURRICULUM_ID} not found`,
+    );
+    return 1;
+  }
+
+  console.log(
+    `[backfill-anchors] target id=${current.id} slug=${current.slug} current=${
+      current.qualificationAnchor ?? "null"
+    } proposed=${TARGET_ANCHOR}`,
+  );
+
+  if (current.qualificationAnchor === TARGET_ANCHOR) {
+    console.log(`[backfill-anchors] anchor already set to "${TARGET_ANCHOR}" — no-op`);
+    skipped = 1;
+  } else if (current.qualificationAnchor && current.qualificationAnchor !== TARGET_ANCHOR) {
+    console.error(
+      `[backfill-anchors] ABORT — anchor already set to unexpected value "${current.qualificationAnchor}" (expected null or "${TARGET_ANCHOR}"). Operator must investigate before re-running.`,
+    );
+    aborted = 1;
+  } else if (apply) {
+    // Transactional write + post-update assertion.
+    await prisma.$transaction(async (tx) => {
+      const result = await tx.curriculum.update({
+        where: { id: TARGET_CURRICULUM_ID },
+        data: { qualificationAnchor: TARGET_ANCHOR },
+        select: { id: true, qualificationAnchor: true },
+      });
+      if (result.id !== TARGET_CURRICULUM_ID) {
+        throw new Error(
+          `[backfill-anchors] assertion failed — updated row id "${result.id}" !== target "${TARGET_CURRICULUM_ID}"`,
+        );
+      }
+      if (result.qualificationAnchor !== TARGET_ANCHOR) {
+        throw new Error(
+          `[backfill-anchors] assertion failed — post-update anchor "${result.qualificationAnchor}" !== expected "${TARGET_ANCHOR}"`,
+        );
+      }
+    });
+    console.log(`[backfill-anchors] APPLIED — set anchor to "${TARGET_ANCHOR}"`);
+    updated = 1;
+  } else {
+    console.log(
+      `[backfill-anchors] would set anchor to "${TARGET_ANCHOR}" (dry-run — pass --apply to commit)`,
+    );
+  }
+
+  console.log(
+    `[backfill-anchors] mode=${mode}  target=1  updated=${updated}  skipped=${skipped}  aborted=${aborted}`,
+  );
+
+  return aborted > 0 ? 2 : 0;
+}
+
+main()
+  .then(async (code) => {
+    await prisma.$disconnect();
+    process.exit(code);
+  })
+  .catch(async (err) => {
+    console.error("[backfill-anchors] unexpected error:", err);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/admin/tests/unit/curriculum/qualification-anchor.test.ts
+++ b/apps/admin/tests/unit/curriculum/qualification-anchor.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #1081 Slice 2B.1 — deriveQualificationAnchor() unit tests.
+ *
+ * The helper labels Curricula teaching the same regulated qualification with
+ * a stable anchor string. NOT a mastery-sharing mechanism (sharing comes from
+ * PlaybookCurriculum role=linked).
+ *
+ * Cases:
+ *   1. Override match (canonical case)
+ *   2. Override match (case-insensitive)
+ *   3. Override match (alternative body — "SIAS" instead of "Ofqual")
+ *   4. Fallback slugify (no override)
+ *   5. Fallback diacritic strip
+ *   6. Null/empty inputs → null
+ *   7. Whitespace-only inputs → null
+ *   8. One null, one valid — derive from ref alone
+ *   9. Slugify length cap (<= 80 chars)
+ */
+
+import { describe, it, expect } from "vitest";
+import { deriveQualificationAnchor } from "@/lib/curriculum/qualification-anchor";
+
+describe("deriveQualificationAnchor", () => {
+  it("returns canonical anchor for known-qualification override match (Ofqual case)", () => {
+    expect(deriveQualificationAnchor("Ofqual", "SIAS / The CIO/CTO Standard V6.0")).toBe(
+      "sias-cio-cto-v6",
+    );
+  });
+
+  it("override lookup is case-insensitive", () => {
+    expect(deriveQualificationAnchor("ofqual", "sias / the cio/cto standard v6.0")).toBe(
+      "sias-cio-cto-v6",
+    );
+  });
+
+  it("matches alternative known body 'SIAS' with the same ref", () => {
+    expect(deriveQualificationAnchor("SIAS", "The CIO/CTO Standard V6.0")).toBe("sias-cio-cto-v6");
+  });
+
+  it("falls back to slugify(body + ref) when no override matches", () => {
+    expect(deriveQualificationAnchor("Ofqual", "NMC English Language Requirement V2")).toBe(
+      "ofqual-nmc-english-language-requirement-v2",
+    );
+  });
+
+  it("strips diacritics in slugify fallback", () => {
+    expect(deriveQualificationAnchor(null, "Café Français Standard")).toBe(
+      "cafe-francais-standard",
+    );
+  });
+
+  it("returns null for null/empty inputs", () => {
+    expect(deriveQualificationAnchor(null, null)).toBeNull();
+    expect(deriveQualificationAnchor("", "")).toBeNull();
+    expect(deriveQualificationAnchor("", null)).toBeNull();
+    expect(deriveQualificationAnchor(undefined, undefined)).toBeNull();
+  });
+
+  it("returns null when both inputs are whitespace-only", () => {
+    expect(deriveQualificationAnchor("   ", "  ")).toBeNull();
+  });
+
+  it("derives from ref alone when body is null", () => {
+    expect(deriveQualificationAnchor(null, "Some Standard V1")).toBe("some-standard-v1");
+  });
+
+  it("caps slugified output at 80 chars", () => {
+    const huge = "x".repeat(200);
+    const result = deriveQualificationAnchor(null, huge);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(80);
+  });
+});


### PR DESCRIPTION
Foundation slice. Adds labelling field to Curriculum + pure derive helper + one-shot backfill. Zero behaviour change.

Builds on Slice 1 (#1084, #1086 merged) and Slice 2A (#1089, #1090, #1091 merged).

Slice 2B.2 (route refactor) and 2B.3 (CI guard + docs) will build on this.

Test plan:
- [x] Unit: deriveQualificationAnchor — 9 cases (override, fallback, null/empty, diacritic, length)
- [ ] Migration applies cleanly on hf_sandbox (operator: /vm-cpp)
- [ ] Backfill --dry-run shows expected diff (operator)
- [ ] Backfill --apply sets sias-cio-cto-v6 on Curriculum 0ccb2874... (operator)

Refs #1081.