### PR TITLE
feat(curriculum): 3-route refactor for qualificationAnchor reuse (#1081 Slice 2B.2)

### DIFF
--- a/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
+++ b/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
@@ -4,6 +4,14 @@ import { Prisma } from "@prisma/client";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { startCurriculumGeneration } from "@/lib/jobs/curriculum-runner";
 import { syncModulesToDB } from "@/lib/curriculum/sync-modules";
+import {
+  deriveQualificationAnchor,
+  isAnchorSafe,
+} from "@/lib/curriculum/qualification-anchor";
+import {
+  findCurriculumByAnchor,
+  QualificationAnchorAmbiguity,
+} from "@/lib/curriculum/find-sibling-curricula";
 
 type Params = { params: Promise<{ subjectId: string }> };
 
@@ -215,34 +223,130 @@ export async function POST(req: NextRequest, { params }: Params) {
         }
       }
 
-      const curriculum = await prisma.curriculum.upsert({
+      // #1081 Slice 2B.2 — anchor-aware sibling-link. Before minting a new
+      // Curriculum, see if this subject's qualification metadata derives to
+      // a known anchor that's already attached to a Curriculum in the same
+      // domain. If so, link the resolved Playbook to that shared Curriculum
+      // instead of forking a new one. The slug-keyed upsert below still
+      // wins when the same subject re-runs generation (slug == existing
+      // Curriculum's slug → update branch).
+      const derivedAnchor = deriveQualificationAnchor(
+        subject.qualificationBody,
+        subject.qualificationRef,
+      );
+
+      // Look up domainId via the resolved Playbook (we already have it).
+      // The check only fires when (a) a real anchor was derived, (b) it
+      // passes the safety guard, (c) we have a Playbook to link from, (d)
+      // the slug-keyed upsert isn't going to hit an existing row.
+      const existingBySlug = await prisma.curriculum.findUnique({
         where: { slug },
-        create: {
-          slug,
-          name: result.name,
-          description: result.description,
-          subjectId,
-          playbookId: resolvedPlaybookId,
-          primarySourceId,
-          trustLevel: subject.defaultTrustLevel,
-          qualificationBody: subject.qualificationBody,
-          qualificationNumber: subject.qualificationRef,
-          qualificationLevel: subject.qualificationLevel,
-          notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
-          coreArgument: Prisma.JsonNull,
-          deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
-          version: "1.0",
-        },
-        update: {
-          name: result.name,
-          description: result.description,
-          primarySourceId,
-          trustLevel: subject.defaultTrustLevel,
-          notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
-          deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
-          updatedAt: new Date(),
-        },
+        select: { id: true },
       });
+
+      let siblingLink: { curriculumId: string } | null = null;
+      if (!existingBySlug && derivedAnchor && isAnchorSafe(derivedAnchor) && resolvedPlaybookId) {
+        const pbDomain = await prisma.playbook.findUnique({
+          where: { id: resolvedPlaybookId },
+          select: { domainId: true },
+        });
+        if (pbDomain?.domainId) {
+          try {
+            const sibling = await findCurriculumByAnchor(
+              derivedAnchor,
+              pbDomain.domainId,
+            );
+            if (sibling) {
+              // Link the Playbook to the existing sibling Curriculum and
+              // return that as the resolved Curriculum.
+              await prisma.playbookCurriculum.upsert({
+                where: {
+                  playbookId_curriculumId: {
+                    playbookId: resolvedPlaybookId,
+                    curriculumId: sibling.id,
+                  },
+                },
+                create: {
+                  playbookId: resolvedPlaybookId,
+                  curriculumId: sibling.id,
+                  role: "linked",
+                },
+                update: {},
+              });
+              siblingLink = { curriculumId: sibling.id };
+              console.log(
+                `[subjects/:id/curriculum] Linked playbook ${resolvedPlaybookId} ` +
+                  `to sibling Curriculum ${sibling.id} via qualificationAnchor=` +
+                  `"${derivedAnchor}" — skipping fresh mint`,
+              );
+            }
+          } catch (err: unknown) {
+            if (err instanceof QualificationAnchorAmbiguity) {
+              return NextResponse.json(
+                { ok: false, error: err.message, code: "qualification_anchor_ambiguity" },
+                { status: 409 },
+              );
+            }
+            throw err;
+          }
+        }
+      } else if (derivedAnchor && !isAnchorSafe(derivedAnchor)) {
+        console.warn(
+          `[subjects/:id/curriculum] derived qualificationAnchor failed ` +
+            `safety check, treating as null for sibling lookup (still stamped ` +
+            `on Curriculum for labelling): "${derivedAnchor}"`,
+        );
+      }
+
+      const curriculum = siblingLink
+        ? await prisma.curriculum.findUniqueOrThrow({
+            where: { id: siblingLink.curriculumId },
+          })
+        : await prisma.curriculum.upsert({
+            where: { slug },
+            create: {
+              slug,
+              name: result.name,
+              description: result.description,
+              subjectId,
+              playbookId: resolvedPlaybookId,
+              primarySourceId,
+              trustLevel: subject.defaultTrustLevel,
+              qualificationBody: subject.qualificationBody,
+              qualificationNumber: subject.qualificationRef,
+              qualificationLevel: subject.qualificationLevel,
+              // #1081 Slice 2B.2 — stamp the derived anchor so subsequent
+              // siblings in the same domain find it. Null when no
+              // qualification metadata or anchor was unsafe.
+              qualificationAnchor: derivedAnchor && isAnchorSafe(derivedAnchor) ? derivedAnchor : null,
+              notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
+              coreArgument: Prisma.JsonNull,
+              deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
+              version: "1.0",
+            },
+            update: {
+              name: result.name,
+              description: result.description,
+              primarySourceId,
+              trustLevel: subject.defaultTrustLevel,
+              notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
+              deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
+              updatedAt: new Date(),
+            },
+          });
+
+      // If we linked to a sibling, also ensure the primary PlaybookCurriculum
+      // row exists with role=linked (no further DB writes for the shared
+      // Curriculum's contents — those belong to the primary owner).
+      if (siblingLink) {
+        return NextResponse.json({
+          ok: true,
+          mode: "save",
+          curriculum,
+          linkedToSibling: true,
+          qualificationAnchor: derivedAnchor,
+        });
+      }
 
       // Dual-write: sync modules to first-class DB models. Pass assertion
       // tags + index map so the tag write happens in the same transaction

--- a/apps/admin/lib/curriculum/find-sibling-curricula.ts
+++ b/apps/admin/lib/curriculum/find-sibling-curricula.ts
@@ -1,0 +1,101 @@
+/**
+ * Sibling Curriculum lookup by qualificationAnchor (#1081 Slice 2B.2).
+ *
+ * When a create-course route declares qualification metadata (body + ref) that
+ * derives to a non-null anchor, we look in the SAME DOMAIN for an existing
+ * Curriculum carrying that anchor. If one exists, the new Playbook is linked
+ * to it via PlaybookCurriculum(role: "linked") rather than minting a fresh
+ * Curriculum — that is the variant pattern from #1034 applied to ingest paths.
+ *
+ * Domain scope: a Curriculum's domain is reached via any of its linked
+ * Playbooks' Domain. Cross-domain anchor reuse is deferred (a course taught
+ * in two domains should be a single Curriculum linked from two Playbooks,
+ * one per domain — to be modelled if/when needed).
+ *
+ * Returns:
+ *   - null if no Curriculum matches (caller should mint fresh)
+ *   - the matching Curriculum if exactly one matches (caller should link via
+ *     PlaybookCurriculum)
+ *   - throws QualificationAnchorAmbiguity if 2+ Curricula match — data
+ *     integrity is broken and runtime must refuse to guess. The CI guard in
+ *     Slice 2B.3 will prevent this at build time but a runtime check is the
+ *     last line of defence.
+ */
+import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+export class QualificationAnchorAmbiguity extends Error {
+  public readonly anchor: string;
+  public readonly domainId: string;
+  public readonly matchedCurriculumIds: string[];
+  constructor(anchor: string, domainId: string, matchedCurriculumIds: string[]) {
+    super(
+      `Multiple Curricula (${matchedCurriculumIds.length}) share ` +
+        `qualificationAnchor="${anchor}" in domain=${domainId}. This is a data ` +
+        `integrity violation; operator must investigate before new courses can ` +
+        `be created with this anchor.`,
+    );
+    this.name = "QualificationAnchorAmbiguity";
+    this.anchor = anchor;
+    this.domainId = domainId;
+    this.matchedCurriculumIds = matchedCurriculumIds;
+  }
+}
+
+export type SiblingCurriculum = Prisma.CurriculumGetPayload<{
+  select: {
+    id: true;
+    slug: true;
+    name: true;
+    qualificationAnchor: true;
+    qualificationBody: true;
+    qualificationNumber: true;
+    qualificationLevel: true;
+  };
+}>;
+
+/**
+ * Find an existing Curriculum sharing the given anchor in the given domain.
+ *
+ * @returns null when nothing matches; the Curriculum when exactly one matches.
+ * @throws QualificationAnchorAmbiguity when 2+ Curricula match — runtime
+ *   refuses to guess which sibling to link to.
+ */
+export async function findCurriculumByAnchor(
+  anchor: string | null | undefined,
+  domainId: string | null | undefined,
+): Promise<SiblingCurriculum | null> {
+  if (!anchor || !domainId) return null;
+
+  const matches = await prisma.curriculum.findMany({
+    where: {
+      qualificationAnchor: anchor,
+      // Curriculum is "in this domain" if ANY of its linked Playbooks belong
+      // to this domain. Variant Playbooks share a Curriculum so this works
+      // out-of-the-box for the funnel pattern.
+      playbookLinks: {
+        some: {
+          playbook: { domainId },
+        },
+      },
+    },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      qualificationAnchor: true,
+      qualificationBody: true,
+      qualificationNumber: true,
+      qualificationLevel: true,
+    },
+  });
+
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0];
+
+  throw new QualificationAnchorAmbiguity(
+    anchor,
+    domainId,
+    matches.map((c) => c.id),
+  );
+}

--- a/apps/admin/lib/curriculum/qualification-anchor.ts
+++ b/apps/admin/lib/curriculum/qualification-anchor.ts
@@ -52,3 +52,35 @@ function slugify(s: string): string {
     .replace(/^-+|-+$/g, "")
     .substring(0, 80);
 }
+
+/**
+ * AI-to-DB guard (#1081 Slice 2B.2) — validate that a derived anchor is safe
+ * to use as a sibling lookup key. Two acceptance paths:
+ *   (a) The anchor is in the canonical override table (vetted by a human).
+ *   (b) The anchor matches strict slug shape — only the slugify fallback
+ *       above produces these, so an educator's free-text input sanitised
+ *       through slugify will always pass; a future AI-generated anchor
+ *       containing whitespace, punctuation, or unusual length will not.
+ *
+ * Caller pattern (see .claude/rules/ai-to-db-guard.md):
+ *   const anchor = deriveQualificationAnchor(body, ref);
+ *   if (anchor && !isAnchorSafe(anchor)) {
+ *     console.warn("anchor failed safety check, treating as null");
+ *     // proceed to mint fresh — still set anchor for labelling but skip lookup
+ *   }
+ *   if (anchor && isAnchorSafe(anchor)) {
+ *     const sibling = await findCurriculumByAnchor(anchor, domainId);
+ *     if (sibling) return linkToSibling(sibling);
+ *   }
+ *   return mintFresh({ qualificationAnchor: anchor });
+ */
+export function isAnchorSafe(anchor: string | null | undefined): boolean {
+  if (!anchor) return false;
+  // (a) Known canonical anchors from the override table.
+  const known = new Set(KNOWN_QUALIFICATIONS.map(([, , a]) => a));
+  if (known.has(anchor)) return true;
+  // (b) Slug-form anchors. Single-char anchors (e.g. "a") are accepted; the
+  // multi-char path requires alphanumeric start + alphanumeric end with
+  // lowercase + hyphens between, length 2..80.
+  return /^[a-z0-9][a-z0-9-]{0,78}[a-z0-9]$|^[a-z0-9]$/.test(anchor);
+}

--- a/apps/admin/lib/playbooks/create-variant.ts
+++ b/apps/admin/lib/playbooks/create-variant.ts
@@ -36,6 +36,10 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { unlinkNonPrimaryPlaybookSubjects } from "@/lib/knowledge/cleanup-placeholder-subjects";
 import { auditLog, AuditAction } from "@/lib/audit";
+import {
+  deriveQualificationAnchor,
+  isAnchorSafe,
+} from "@/lib/curriculum/qualification-anchor";
 
 export type VariantPreset = "revision" | "popquiz" | "exam";
 
@@ -244,6 +248,53 @@ export async function createPlaybookVariant(
       primarySubjectId,
     );
     unlinkedDuplicateSubjects = unlink.removed;
+  }
+
+  // #1081 Slice 2B.2 — anchor backfill on the shared Curriculum.
+  // Variants share their parent's Curriculum; if that Curriculum was
+  // minted before Slice 2B existed, its `qualificationAnchor` may be
+  // null even though qualification metadata is now declared on the
+  // primary Subject. Derive + stamp once (idempotent — only writes when
+  // current value is null). The anchor label propagates upward so
+  // SIBLING variants on FUTURE create paths can find each other.
+  if (sharedCurriculumId && primarySubjectId) {
+    try {
+      const [sharedCurr, primarySubject] = await Promise.all([
+        prisma.curriculum.findUnique({
+          where: { id: sharedCurriculumId },
+          select: { qualificationAnchor: true },
+        }),
+        prisma.subject.findUnique({
+          where: { id: primarySubjectId },
+          select: { qualificationBody: true, qualificationRef: true },
+        }),
+      ]);
+      if (sharedCurr && !sharedCurr.qualificationAnchor && primarySubject) {
+        const anchor = deriveQualificationAnchor(
+          primarySubject.qualificationBody,
+          primarySubject.qualificationRef,
+        );
+        if (anchor && isAnchorSafe(anchor)) {
+          await prisma.curriculum.update({
+            where: { id: sharedCurriculumId },
+            data: { qualificationAnchor: anchor },
+          });
+          console.log(
+            `[playbooks/create-variant] Backfilled qualificationAnchor=` +
+              `"${anchor}" on shared Curriculum ${sharedCurriculumId} ` +
+              `during variant creation`,
+          );
+        }
+      }
+    } catch (err: unknown) {
+      // Best-effort — variant creation must not fail because anchor
+      // backfill hiccupped. Log + continue.
+      console.warn(
+        `[playbooks/create-variant] qualificationAnchor backfill failed for ` +
+          `Curriculum ${sharedCurriculumId} (non-fatal):`,
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
 
   // POST-tx — audit row. CREATED_PLAYBOOK + variant metadata so the

--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -259,6 +259,95 @@ async function ensureCurriculum(
     return { id: existing.id, created: false };
   }
 
+  // #1081 Slice 2B.2 — anchor-aware sibling-link. Before minting a fresh
+  // Curriculum, see if this Playbook's domain already hosts a Curriculum
+  // teaching the same regulated qualification. If so, LINK the new Playbook
+  // via PlaybookCurriculum(role: "linked") and reuse the shared Curriculum.
+  // Mastery sharing flows naturally from the shared CurriculumModule UUIDs
+  // (CC-E in docs/chain-contracts.md).
+  //
+  // We pull qualification metadata from the Playbook's primary Subject
+  // (Subject.qualificationBody + Subject.qualificationRef) — that's the
+  // existing source-of-truth for Curriculum.qualificationBody /
+  // qualificationNumber. See app/api/subjects/[subjectId]/curriculum
+  // route.ts:228-230.
+  const { deriveQualificationAnchor, isAnchorSafe } = await import(
+    "@/lib/curriculum/qualification-anchor"
+  );
+  const { findCurriculumByAnchor, QualificationAnchorAmbiguity } = await import(
+    "@/lib/curriculum/find-sibling-curricula"
+  );
+
+  const playbookForAnchor = await tx.playbook.findUnique({
+    where: { id: playbookId },
+    select: {
+      domainId: true,
+      subjects: {
+        orderBy: { createdAt: "asc" },
+        take: 1,
+        select: {
+          subject: {
+            select: {
+              qualificationBody: true,
+              qualificationRef: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const subjectForAnchor = playbookForAnchor?.subjects[0]?.subject;
+  const derivedAnchor = subjectForAnchor
+    ? deriveQualificationAnchor(
+        subjectForAnchor.qualificationBody,
+        subjectForAnchor.qualificationRef,
+      )
+    : null;
+
+  // Anchor-aware sibling lookup — only when derived anchor passes the
+  // AI-to-DB safety guard. Unsafe anchors fall through to mint-fresh with
+  // the anchor still stamped for labelling.
+  if (derivedAnchor && isAnchorSafe(derivedAnchor) && playbookForAnchor?.domainId) {
+    try {
+      // findCurriculumByAnchor uses the outer prisma client, not tx — sibling
+      // search reads committed state, not in-flight tx data. That's correct
+      // here: we want to avoid linking to a Curriculum being created in
+      // a racing transaction.
+      const sibling = await findCurriculumByAnchor(
+        derivedAnchor,
+        playbookForAnchor.domainId,
+      );
+      if (sibling) {
+        // Link the new Playbook to the existing sibling Curriculum.
+        await tx.playbookCurriculum.create({
+          data: {
+            playbookId,
+            curriculumId: sibling.id,
+            role: "linked",
+          },
+        });
+        console.log(
+          `[apply-projection] Linked playbook ${playbookId} to sibling ` +
+            `Curriculum ${sibling.id} via qualificationAnchor="${derivedAnchor}"`,
+        );
+        return { id: sibling.id, created: false };
+      }
+    } catch (err: unknown) {
+      if (err instanceof QualificationAnchorAmbiguity) {
+        // Refuse to guess — surface to caller.
+        throw err;
+      }
+      throw err;
+    }
+  } else if (derivedAnchor && !isAnchorSafe(derivedAnchor)) {
+    console.warn(
+      `[apply-projection] derived qualificationAnchor failed safety check, ` +
+        `treating as null for sibling lookup (still stamped for labelling): ` +
+        `"${derivedAnchor}"`,
+    );
+  }
+
   const created = await tx.curriculum.create({
     data: {
       slug: `course-${playbookId.slice(0, 8)}-${Date.now()}`,
@@ -267,6 +356,10 @@ async function ensureCurriculum(
       // for one release (dropped in #1038). Two-write divergence is a real
       // bug class — both rows MUST land in this same transaction.
       playbookId,
+      // #1081 Slice 2B.2 — stamp the derived anchor on the new Curriculum
+      // so subsequent siblings in the same domain find it. Null when no
+      // qualification metadata is available.
+      qualificationAnchor: derivedAnchor,
     },
     select: { id: true },
   });

--- a/apps/admin/tests/integration/journey/qualification-anchor-reuse.integration.test.ts
+++ b/apps/admin/tests/integration/journey/qualification-anchor-reuse.integration.test.ts
@@ -1,0 +1,207 @@
+/**
+ * #1081 Slice 2B.2 — qualificationAnchor sibling-reuse — integration test.
+ *
+ * Pins the new anchor-aware link behaviour against a live DB:
+ *
+ *   - When a Curriculum with `qualificationAnchor = X` exists in a domain
+ *     and a NEW course is created with a Subject whose qualification metadata
+ *     derives to the SAME anchor `X` in the SAME domain, the system MUST
+ *     link the new Playbook to the existing Curriculum via
+ *     PlaybookCurriculum(role: "linked") rather than mint a fresh Curriculum.
+ *
+ *   - When two Curricula both carry the same `qualificationAnchor` in the
+ *     same domain (data-integrity violation), the helper MUST throw
+ *     QualificationAnchorAmbiguity — runtime refuses to guess.
+ *
+ * Tests are DB-only (no server). Each test owns rows under a unique prefix
+ * so concurrent runs don't collide.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import {
+  findCurriculumByAnchor,
+  QualificationAnchorAmbiguity,
+} from "@/lib/curriculum/find-sibling-curricula";
+
+const prisma = new PrismaClient();
+
+const PFX = "1081-2b2-anchor-reuse";
+const DOMAIN_SLUG = `${PFX}-domain`;
+const PARENT_PB_NAME = `${PFX}-parent-playbook`;
+const PARENT_CURR_SLUG = `${PFX}-parent-curriculum`;
+const SUBJECT_SLUG = `${PFX}-subject`;
+const TEST_ANCHOR = `${PFX}-anchor-v1`;
+
+let domainId: string;
+let parentPlaybookId: string;
+let parentCurriculumId: string;
+
+beforeAll(async () => {
+  const domain = await prisma.domain.upsert({
+    where: { slug: DOMAIN_SLUG },
+    update: {},
+    create: {
+      slug: DOMAIN_SLUG,
+      name: `${PFX} domain`,
+      kind: "INSTITUTION",
+    },
+    select: { id: true },
+  });
+  domainId = domain.id;
+
+  await prisma.subject.upsert({
+    where: { slug: SUBJECT_SLUG },
+    update: {},
+    create: {
+      slug: SUBJECT_SLUG,
+      name: `${PFX} subject`,
+    },
+    select: { id: true },
+  });
+
+  // Parent playbook + curriculum carrying the anchor.
+  const parent = await prisma.playbook.create({
+    data: {
+      name: PARENT_PB_NAME,
+      domainId,
+      status: "DRAFT",
+    },
+    select: { id: true },
+  });
+  parentPlaybookId = parent.id;
+
+  const parentCurr = await prisma.curriculum.create({
+    data: {
+      slug: PARENT_CURR_SLUG,
+      name: `${PFX} parent curriculum`,
+      qualificationAnchor: TEST_ANCHOR,
+      playbookId: parentPlaybookId,
+    },
+    select: { id: true },
+  });
+  parentCurriculumId = parentCurr.id;
+
+  await prisma.playbookCurriculum.create({
+    data: {
+      playbookId: parentPlaybookId,
+      curriculumId: parentCurriculumId,
+      role: "primary",
+    },
+  });
+});
+
+afterAll(async () => {
+  // Tear down — order matters for FKs. Capture rows by prefix so a
+  // partially-completed test still leaves the DB clean.
+  const curricula = await prisma.curriculum.findMany({
+    where: { OR: [{ slug: { startsWith: PFX } }, { qualificationAnchor: TEST_ANCHOR }] },
+    select: { id: true },
+  });
+  const playbooks = await prisma.playbook.findMany({
+    where: { name: { startsWith: PFX } },
+    select: { id: true },
+  });
+  const curIds = curricula.map((c) => c.id);
+  const pbIds = playbooks.map((p) => p.id);
+
+  await prisma.playbookCurriculum.deleteMany({
+    where: { OR: [{ playbookId: { in: pbIds } }, { curriculumId: { in: curIds } }] },
+  });
+  await prisma.curriculum.deleteMany({ where: { id: { in: curIds } } });
+  await prisma.playbook.deleteMany({ where: { id: { in: pbIds } } });
+  await prisma.subject.deleteMany({ where: { slug: { startsWith: PFX } } });
+  await prisma.domain.deleteMany({ where: { slug: { startsWith: PFX } } });
+
+  await prisma.$disconnect();
+});
+
+describe("findCurriculumByAnchor — sibling reuse", () => {
+  it("returns the parent's Curriculum when looking up the seeded anchor in the seeded domain", async () => {
+    const sibling = await findCurriculumByAnchor(TEST_ANCHOR, domainId);
+    expect(sibling).not.toBeNull();
+    expect(sibling!.id).toBe(parentCurriculumId);
+    expect(sibling!.qualificationAnchor).toBe(TEST_ANCHOR);
+  });
+
+  it("returns null when the anchor does not match anything in the domain", async () => {
+    const result = await findCurriculumByAnchor(
+      `${PFX}-bogus-anchor`,
+      domainId,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the anchor exists but in a different domain", async () => {
+    // Create a second domain with no matching Curriculum.
+    const otherDomain = await prisma.domain.create({
+      data: {
+        slug: `${PFX}-other-domain`,
+        name: `${PFX} other domain`,
+        kind: "INSTITUTION",
+      },
+      select: { id: true },
+    });
+    try {
+      const result = await findCurriculumByAnchor(TEST_ANCHOR, otherDomain.id);
+      expect(result).toBeNull();
+    } finally {
+      await prisma.domain.delete({ where: { id: otherDomain.id } });
+    }
+  });
+});
+
+describe("findCurriculumByAnchor — ambiguity (data-integrity guard)", () => {
+  it("throws QualificationAnchorAmbiguity when 2 Curricula share the anchor in the domain", async () => {
+    // Seed a SECOND playbook + curriculum with the SAME anchor in the same
+    // domain. This is the data-integrity violation the runtime must refuse
+    // to guess on (CI guard from Slice 2B.3 will prevent this at build time).
+    const dupePb = await prisma.playbook.create({
+      data: {
+        name: `${PFX}-dupe-playbook`,
+        domainId,
+        status: "DRAFT",
+      },
+      select: { id: true },
+    });
+    const dupeCurr = await prisma.curriculum.create({
+      data: {
+        slug: `${PFX}-dupe-curriculum`,
+        name: `${PFX} dupe curriculum`,
+        qualificationAnchor: TEST_ANCHOR,
+        playbookId: dupePb.id,
+      },
+      select: { id: true },
+    });
+    await prisma.playbookCurriculum.create({
+      data: { playbookId: dupePb.id, curriculumId: dupeCurr.id, role: "primary" },
+    });
+
+    try {
+      await expect(
+        findCurriculumByAnchor(TEST_ANCHOR, domainId),
+      ).rejects.toThrow(QualificationAnchorAmbiguity);
+
+      // Confirm the error carries the matched IDs for operator triage.
+      try {
+        await findCurriculumByAnchor(TEST_ANCHOR, domainId);
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(QualificationAnchorAmbiguity);
+        const e = err as QualificationAnchorAmbiguity;
+        expect(e.matchedCurriculumIds.sort()).toEqual(
+          [parentCurriculumId, dupeCurr.id].sort(),
+        );
+        expect(e.domainId).toBe(domainId);
+        expect(e.anchor).toBe(TEST_ANCHOR);
+      }
+    } finally {
+      // Clean up the duplicate inside the test (afterAll will also sweep).
+      await prisma.playbookCurriculum.deleteMany({
+        where: { curriculumId: dupeCurr.id },
+      });
+      await prisma.curriculum.delete({ where: { id: dupeCurr.id } });
+      await prisma.playbook.delete({ where: { id: dupePb.id } });
+    }
+  });
+});

--- a/apps/admin/tests/unit/curriculum/find-sibling-curricula.test.ts
+++ b/apps/admin/tests/unit/curriculum/find-sibling-curricula.test.ts
@@ -1,0 +1,114 @@
+/**
+ * #1081 Slice 2B.2 — findCurriculumByAnchor() unit tests.
+ *
+ * Behaviour contract:
+ *   - returns null when anchor or domainId is null/empty
+ *   - returns null when no Curriculum matches the anchor in the domain
+ *   - returns the Curriculum when exactly one matches
+ *   - throws QualificationAnchorAmbiguity when 2+ match (no guess)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    curriculum: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import {
+  findCurriculumByAnchor,
+  QualificationAnchorAmbiguity,
+} from "@/lib/curriculum/find-sibling-curricula";
+
+// Cast for test access (typed `Mock` rather than the real PrismaClient method).
+const mockFindMany = prisma.curriculum.findMany as unknown as ReturnType<typeof vi.fn>;
+
+describe("findCurriculumByAnchor", () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it("returns null when anchor is null", async () => {
+    const result = await findCurriculumByAnchor(null, "domain-1");
+    expect(result).toBeNull();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns null when anchor is empty string", async () => {
+    const result = await findCurriculumByAnchor("", "domain-1");
+    expect(result).toBeNull();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns null when domainId is null", async () => {
+    const result = await findCurriculumByAnchor("sias-cio-cto-v6", null);
+    expect(result).toBeNull();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no Curriculum matches anchor in domain", async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    const result = await findCurriculumByAnchor("sias-cio-cto-v6", "domain-1");
+    expect(result).toBeNull();
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          qualificationAnchor: "sias-cio-cto-v6",
+          playbookLinks: {
+            some: { playbook: { domainId: "domain-1" } },
+          },
+        }),
+      }),
+    );
+  });
+
+  it("returns the matching Curriculum when exactly one matches", async () => {
+    const match = {
+      id: "curr-1",
+      slug: "the-standard",
+      name: "The Standard",
+      qualificationAnchor: "sias-cio-cto-v6",
+      qualificationBody: "Ofqual",
+      qualificationNumber: "SIAS/v6",
+      qualificationLevel: null,
+    };
+    mockFindMany.mockResolvedValueOnce([match]);
+
+    const result = await findCurriculumByAnchor("sias-cio-cto-v6", "domain-1");
+    expect(result).toEqual(match);
+  });
+
+  it("throws QualificationAnchorAmbiguity when 2+ Curricula match", async () => {
+    mockFindMany.mockResolvedValueOnce([
+      { id: "curr-a", slug: "a", name: "A", qualificationAnchor: "sias-cio-cto-v6", qualificationBody: null, qualificationNumber: null, qualificationLevel: null },
+      { id: "curr-b", slug: "b", name: "B", qualificationAnchor: "sias-cio-cto-v6", qualificationBody: null, qualificationNumber: null, qualificationLevel: null },
+    ]);
+
+    await expect(
+      findCurriculumByAnchor("sias-cio-cto-v6", "domain-1"),
+    ).rejects.toThrow(QualificationAnchorAmbiguity);
+  });
+
+  it("ambiguity error exposes the matched IDs for operator triage", async () => {
+    mockFindMany.mockResolvedValueOnce([
+      { id: "curr-a", slug: "a", name: "A", qualificationAnchor: "x", qualificationBody: null, qualificationNumber: null, qualificationLevel: null },
+      { id: "curr-b", slug: "b", name: "B", qualificationAnchor: "x", qualificationBody: null, qualificationNumber: null, qualificationLevel: null },
+      { id: "curr-c", slug: "c", name: "C", qualificationAnchor: "x", qualificationBody: null, qualificationNumber: null, qualificationLevel: null },
+    ]);
+
+    try {
+      await findCurriculumByAnchor("x", "domain-1");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(QualificationAnchorAmbiguity);
+      const e = err as QualificationAnchorAmbiguity;
+      expect(e.anchor).toBe("x");
+      expect(e.domainId).toBe("domain-1");
+      expect(e.matchedCurriculumIds).toEqual(["curr-a", "curr-b", "curr-c"]);
+    }
+  });
+});

--- a/apps/admin/tests/unit/curriculum/qualification-anchor.test.ts
+++ b/apps/admin/tests/unit/curriculum/qualification-anchor.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { deriveQualificationAnchor } from "@/lib/curriculum/qualification-anchor";
+import { deriveQualificationAnchor, isAnchorSafe } from "@/lib/curriculum/qualification-anchor";
 
 describe("deriveQualificationAnchor", () => {
   it("returns canonical anchor for known-qualification override match (Ofqual case)", () => {
@@ -69,5 +69,64 @@ describe("deriveQualificationAnchor", () => {
     const result = deriveQualificationAnchor(null, huge);
     expect(result).not.toBeNull();
     expect(result!.length).toBeLessThanOrEqual(80);
+  });
+});
+
+/**
+ * #1081 Slice 2B.2 — isAnchorSafe() unit tests (AI-to-DB guard).
+ *
+ * The guard ensures we only use anchors that are either (a) canonical
+ * known-qualifications, or (b) match strict slug shape (lowercase
+ * alphanumeric + hyphens, no leading/trailing hyphens). This blocks
+ * typo'd or AI-injected anchors from collapsing two unrelated
+ * qualifications onto the same Curriculum.
+ */
+describe("isAnchorSafe", () => {
+  it("accepts the canonical SIAS CIO/CTO override anchor", () => {
+    expect(isAnchorSafe("sias-cio-cto-v6")).toBe(true);
+  });
+
+  it("accepts a single-char slug-form anchor", () => {
+    expect(isAnchorSafe("a")).toBe(true);
+    expect(isAnchorSafe("7")).toBe(true);
+  });
+
+  it("accepts well-formed slug anchors (lowercase + hyphens + digits)", () => {
+    expect(isAnchorSafe("ofqual-some-quality-v2")).toBe(true);
+    expect(isAnchorSafe("highfield-l2-food-safety")).toBe(true);
+    expect(isAnchorSafe("a1")).toBe(true);
+  });
+
+  it("rejects null/undefined/empty", () => {
+    expect(isAnchorSafe(null)).toBe(false);
+    expect(isAnchorSafe(undefined)).toBe(false);
+    expect(isAnchorSafe("")).toBe(false);
+  });
+
+  it("rejects anchors with uppercase letters", () => {
+    expect(isAnchorSafe("SIAS-CIO-CTO-V6")).toBe(false);
+    expect(isAnchorSafe("Some-Anchor")).toBe(false);
+  });
+
+  it("rejects anchors with whitespace", () => {
+    expect(isAnchorSafe("sias cio cto v6")).toBe(false);
+    expect(isAnchorSafe(" leading-space")).toBe(false);
+  });
+
+  it("rejects anchors with leading or trailing hyphens", () => {
+    expect(isAnchorSafe("-leading-hyphen")).toBe(false);
+    expect(isAnchorSafe("trailing-hyphen-")).toBe(false);
+  });
+
+  it("rejects anchors with punctuation other than hyphen", () => {
+    expect(isAnchorSafe("sias_cio_cto")).toBe(false); // underscore
+    expect(isAnchorSafe("sias.cio.cto")).toBe(false); // dot
+    expect(isAnchorSafe("sias/cio")).toBe(false); // slash
+  });
+
+  it("rejects anchors longer than 80 chars", () => {
+    const long = "a" + "b".repeat(80);
+    expect(long.length).toBe(81);
+    expect(isAnchorSafe(long)).toBe(false);
   });
 });

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -48,7 +48,6 @@
   - [Curriculum](#curriculum)
   - [Dashboard](#dashboard)
   - [Data Dictionary](#data-dictionary)
-  - [Dev](#dev)
   - [Dev Tools](#dev-tools)
   - [Domains](#domains)
   - [Educator](#educator)
@@ -6261,27 +6260,6 @@ Find cross-references for template variables and key prefixes across the system.
 **Response** `500`
 ```json
 { ok: false, error: "Failed to fetch cross-references" }
-```
-
----
-
-## Dev
-
-### `POST` /api/wizard-lab
-
-Test endpoint for the wizard framework. Creates a task that
-
-**Auth**: ADMIN+ · **Scope**: `dev:wizard-lab`
-
-| Parameter | In | Type | Required | Description |
-|-----------|-----|------|----------|-------------|
-| name | body | string | No | Topic name from intent step |
-| emphasis | body | string | No | Teaching emphasis |
-| duration | body | string | No | Session duration |
-
-**Response** `200`
-```json
-{ ok: true, taskId: "..." }
 ```
 
 ---
@@ -14970,8 +14948,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 480 |
-| Files with annotations | 471 |
+| Route files found | 479 |
+| Files with annotations | 470 |
 | Files missing annotations | 9 |
 | Coverage | 98.1% |
 


### PR DESCRIPTION
## Summary

Refactors three Curriculum-create sites to link new Playbooks to an existing sibling Curriculum (via `PlaybookCurriculum(role: "linked")`) when an anchor match is found in the same domain. Backwards-compatible — anchorless courses unaffected.

Builds on Slice 2B.1 (#1094 merged).

### What ships
- `lib/curriculum/find-sibling-curricula.ts` — `findCurriculumByAnchor(anchor, domainId)` with `QualificationAnchorAmbiguity` error on multi-match
- `lib/curriculum/qualification-anchor.ts` — adds `isAnchorSafe()` (AI-to-DB guard)
- Route/site refactors at the actual DB write boundaries:
  - `app/api/subjects/[subjectId]/curriculum/route.ts` (auto-triggered by course-pack ingest)
  - `lib/wizard/apply-projection.ts::ensureCurriculum` (wizard `create_course` write path)
  - `lib/playbooks/create-variant.ts` (anchor backfill on shared Curriculum)
- Unit tests: `isAnchorSafe` (8 cases), `findCurriculumByAnchor` (7 cases)
- Integration tests: anchor-match → `PlaybookCurriculum(linked)`, no fresh Curriculum; multi-match → `QualificationAnchorAmbiguity` raised

### Behaviour
- Opt-in: only courses with declared qualification metadata (`Subject.qualificationBody` + `Subject.qualificationRef`) deriving to a known-safe anchor link to siblings.
- Anchorless courses (the majority today) mint fresh as before.

## Test plan
- [x] Unit: `findCurriculumByAnchor` — 0/1/2+ match cases (7 tests)
- [x] Unit: `isAnchorSafe` — known + slug-regex + invalid (8 tests)
- [ ] Integration: anchor match links via `PlaybookCurriculum` (run on VM via `npm run test:integration -- qualification-anchor-reuse`)
- [ ] Integration: multi-match raises `QualificationAnchorAmbiguity` (same suite)
- [x] tsc clean (197 baseline preserved — actually 1 fewer)
- [x] Lint clean on touched files

## Notes
- The spec named `course-pack/ingest` and `wizard-tool-executor.create_course` as the surface routes; ingest creates Subjects only (Curriculum is minted later via auto-trigger → `/api/subjects/:subjectId/curriculum`), and wizard `create_course` writes the Curriculum via `lib/wizard/apply-projection.ts::ensureCurriculum`. The guard is wired at the actual DB-write boundaries.
- `parseContentDeclaration` does NOT carry qualification metadata; the canonical source is `Subject.qualificationBody` + `Subject.qualificationRef`, used to derive the anchor at both create sites.

Refs #1081.