### PR TITLE
fix(roster): row click always navigates to caller detail (regression)

### DIFF
--- a/apps/admin/components/callers/roster/RosterRow.tsx
+++ b/apps/admin/components/callers/roster/RosterRow.tsx
@@ -171,7 +171,10 @@ export function RosterRow({
   return (
     <div
       className={rowClass}
-      onClick={() => inCallId && onObserve ? onObserve(inCallId) : onNavigate(caller.id)}
+      // Row click ALWAYS opens caller detail. Observe is the dedicated
+      // button in the actions cell — clicking the row used to jump to
+      // observe whenever a caller was in-call, which surprised users.
+      onClick={() => onNavigate(caller.id)}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => { if (e.key === "Enter") onNavigate(caller.id); }}


### PR DESCRIPTION
## Summary

Roster row was branching into \`onObserve\` when an in-call existed — clicking the row of a caller currently on a call jumped to the observe surface instead of opening their detail page. Every other admin list opens detail on row click; this restores the convention.

The Observe button in the actions cell (rendered only when \`inCallId\` exists) stays the dedicated observe trigger. Already wired with \`stopPropagation\` so it doesn't also fire the row click.

One-line fix.

## Test plan

- [ ] Search "Ryan" — confirm the row shows the "Observe" button (In Call state)
- [ ] Click anywhere ON the row → lands on \`/x/callers/<id>\` detail page
- [ ] Click the Observe button → opens the observe surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)