### PR TITLE
fix(#1076): fold modulesAuthored=true into CIO/CTO Slice A script

### DIFF
--- a/apps/admin/scripts/fix-cio-cto-playbooks.ts
+++ b/apps/admin/scripts/fix-cio-cto-playbooks.ts
@@ -246,7 +246,12 @@ async function writeGoalTemplates(playbookId: string, templates: ReturnType<type
   });
   const cfg = (playbook?.config as Record<string, unknown> | null) ?? {};
   const variantTemplates = templates.map((t) => ({ ...t, isAssessmentTarget: isExamAssessment }));
-  const nextConfig = { ...cfg, goals: variantTemplates };
+  // `modulesAuthored: true` drives the ProgressionModePill in the course header to
+  // render "Learner picks" instead of the orange "Mode not set" warning. All three
+  // CIO/CTO courses use the five SIAS Units as their authored modules, with the
+  // learner choosing which Unit to work on each session (see each course-ref's
+  // "Default mode: learner-picks" line).
+  const nextConfig = { ...cfg, goals: variantTemplates, modulesAuthored: true };
   await prisma.playbook.update({ where: { id: playbookId }, data: { config: nextConfig } });
   return variantTemplates.length;
 }


### PR DESCRIPTION
Follow-up to #1102 (merged). The live DB on hf_sandbox is already patched via a one-off; this PR folds the same change into the canonical Slice A script so any future re-run sets the field correctly without manual follow-up.

## Why

`ProgressionModePill` at `app/x/courses/[courseId]/page.tsx:1997` reads `Playbook.config.modulesAuthored`:
- `true` → green "Learner picks" pill
- `false` → "AI-led" pill
- `null` / `undefined` → orange "**Mode not set**" warning

The original Slice A script preserved each playbook's existing config verbatim and added only `goals[]`. `modulesAuthored` was already missing from the config when these three playbooks were created, so the orange warning showed up in the UI on first inspection.

All three CIO/CTO courses use the five SIAS Units as their authored modules with the learner choosing which Unit to work on each session — see each course-ref's "Default mode: learner-picks" line — so `true` is the correct value.

## Verification

Live state on sandbox already patched (verified visually in the admin UI). Re-running `fix-cio-cto-playbooks.ts` after this PR merges will be a no-op on sandbox (idempotent skip) but will set the field correctly on any fresh environment.

## Test plan

- [x] Verified live: orange "Mode not set" badge flipped to "Learner picks" after the one-off patch
- [ ] Re-run the script against sandbox post-merge — expect idempotent no-op