### PR TITLE
feat(sim): #1098 Slice C — SIM qualification context strip + post-call summary

### DIFF
--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -11,6 +11,7 @@ import { deriveParameterMap } from '@/lib/agent-tuner/derive';
 import type { AgentTunerPill } from '@/lib/agent-tuner/types';
 import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from '@/components/sim/ModulePickerBanners';
 import { SimStateBreadcrumb } from '@/components/sim/SimStateBreadcrumb';
+import { QualificationContextStrip } from '@/components/sim/qualification/QualificationContextStrip';
 
 interface PastCall {
   transcript: string;
@@ -229,6 +230,9 @@ export default function SimConversationPage() {
         modules={authoredModules}
         onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
       />
+      {/* #1098 Slice C — Qualification context strip (renders only when the
+          learner's active Curriculum has a qualificationAnchor). */}
+      <QualificationContextStrip requestedModuleId={requestedModuleId ?? null} />
       {requestedModuleId ? (
         <ModulePickerSelectionBanner
           moduleId={requestedModuleId}

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -22,6 +22,7 @@ import { ChatSurveyInput } from './ChatSurveyInput';
 import { SimAdminPanel } from './SimAdminPanel';
 import { SimProgressPanel } from './SimProgressPanel';
 import { PostCallProgressCard } from './PostCallProgressCard';
+import { QualificationSessionSummary } from './qualification/QualificationContextStrip';
 import { useStudentProgress } from '@/hooks/useStudentProgress';
 import { useJourneyPosition } from '@/hooks/useJourneyPosition';
 import type { ChatItem, UseJourneyChatResult } from '@/hooks/useJourneyChat';
@@ -1357,6 +1358,12 @@ export function SimChat({
         {callPhase === 'ended' && (
           <PostCallProgressCard callerId={callerId} />
         )}
+
+        {/* #1098 Slice C — Qualification readiness recap after the call settles.
+            Renders only when the learner's active Curriculum has a qualificationAnchor;
+            silent otherwise. Refetches inside so the AGGREGATE rollup for the
+            just-ended call is reflected. */}
+        {callPhase === 'ended' && <QualificationSessionSummary />}
 
         {/* Post-call content — artifacts & actions from pipeline */}
         {(artifacts.length > 0 || actions.length > 0) && (

--- a/apps/admin/components/sim/qualification/QualificationContextStrip.tsx
+++ b/apps/admin/components/sim/qualification/QualificationContextStrip.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { useQualificationProgress } from "@/hooks/useQualificationProgress";
+import type { MasteryTier } from "@/lib/curriculum/mastery-tiers";
+import "./sim-qualification.css";
+
+/**
+ * Pre-call qualification context strip — #1098 Slice C.
+ *
+ * Renders a single-line context band above the SIM chat when the active
+ * Curriculum has a qualificationAnchor. Shows the unit + tier + focus LO
+ * so the learner walks into the call knowing what this session is for.
+ *
+ * If `requestedModuleId` matches a unit slug in the catalog, that unit becomes
+ * the focus; otherwise we surface the qualification's `weakestUnitSlug`.
+ * Silent when there's no qualification (non-anchored Curriculum or learner not
+ * yet enrolled) — no real-estate waste.
+ *
+ * Real-estate discipline (audit risk #2): keeps to ONE line of meaningful
+ * content + an unobtrusive border. The full dashboard at /x/student/progress
+ * carries the heavy lifting.
+ */
+
+const TIER_LABELS: Record<MasteryTier, string> = {
+  FOUNDATION: "Foundation",
+  DEVELOPING: "Developing",
+  PRACTITIONER: "Practitioner",
+  DISTINCTION: "Distinction",
+};
+
+interface Props {
+  /** From the URL `?requestedModuleId=` param, when present. */
+  requestedModuleId?: string | null;
+}
+
+export function QualificationContextStrip({ requestedModuleId }: Props): React.ReactElement | null {
+  const { data } = useQualificationProgress();
+  if (!data?.qualification) return null;
+
+  const focusUnitSlug =
+    (requestedModuleId && data.units.find((u) => u.moduleSlug === requestedModuleId)?.moduleSlug) ||
+    data.qualification.weakestUnitSlug ||
+    data.units[0]?.moduleSlug ||
+    null;
+
+  const focusUnit = focusUnitSlug
+    ? data.units.find((u) => u.moduleSlug === focusUnitSlug) ?? null
+    : null;
+
+  // Without a focus unit there's nothing useful to say; stay silent.
+  if (!focusUnit) return null;
+
+  const unitTierLabel = focusUnit.tier ? TIER_LABELS[focusUnit.tier] : "Not yet assessed";
+  const focusLoRef = focusUnit.weakestLoRef;
+
+  return (
+    <div
+      className="hf-sim-qual-strip"
+      role="status"
+      aria-label="Qualification context for this session"
+    >
+      <span className="hf-sim-qual-strip-line1">
+        <span className="hf-sim-qual-strip-anchor">{data.qualification.displayName}</span>
+        <span className="hf-sim-qual-strip-dot">·</span>
+        <span className="hf-sim-qual-strip-unit">{focusUnit.displayName}</span>
+      </span>
+      <span className="hf-sim-qual-strip-line2">
+        <span>You&apos;re at </span>
+        <span className="hf-sim-qual-strip-tier">{unitTierLabel}</span>
+        {focusLoRef && (
+          <>
+            <span className="hf-sim-qual-strip-dot">·</span>
+            <span>Focus: </span>
+            <code className="hf-sim-qual-strip-loref">{focusLoRef}</code>
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Post-call qualification readiness summary — renders next to
+ * `PostCallProgressCard` in `SimChat.tsx` when `callPhase === 'ended'`.
+ *
+ * Re-fetches qualification progress (via the hook's `refetch`) on mount, so
+ * the AGGREGATE rollup written for the just-ended call is reflected here. No
+ * before/after delta — the dashboard carries the running totals, and a
+ * before/after probe would require dragging in a snapshot mechanism for
+ * marginal UX value. Slice D may add the delta if user testing demands it.
+ */
+export function QualificationSessionSummary(): React.ReactElement | null {
+  const { data, refetch, loading } = useQualificationProgress();
+  const [didRefetch, setDidRefetch] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!didRefetch) {
+      refetch();
+      setDidRefetch(true);
+    }
+  }, [didRefetch, refetch]);
+
+  if (loading && !data) return null;
+  if (!data?.qualification) return null;
+
+  const focusUnitSlug = data.qualification.weakestUnitSlug ?? data.units[0]?.moduleSlug ?? null;
+  const focusUnit = focusUnitSlug
+    ? data.units.find((u) => u.moduleSlug === focusUnitSlug) ?? null
+    : null;
+
+  const qualTierLabel = data.qualification.tier ? TIER_LABELS[data.qualification.tier] : null;
+
+  return (
+    <section className="hf-sim-qual-summary" aria-label="Qualification readiness after this session">
+      <header className="hf-sim-qual-summary-head">
+        <h3 className="hf-sim-qual-summary-title">Qualification readiness</h3>
+      </header>
+      <p className="hf-sim-qual-summary-line">
+        <span className="hf-sim-qual-summary-anchor">{data.qualification.displayName}</span>
+        {qualTierLabel && (
+          <>
+            <span className="hf-sim-qual-strip-dot">·</span>
+            <span className="hf-sim-qual-summary-tier">{qualTierLabel}</span>
+          </>
+        )}
+        <span className="hf-sim-qual-strip-dot">·</span>
+        <span>
+          {data.qualification.losAtTierOrAbove} of {data.qualification.losTotal} Learning Outcomes
+        </span>
+      </p>
+
+      {focusUnit && (
+        <p className="hf-sim-qual-summary-unitline">
+          <span className="hf-sim-qual-summary-unit">{focusUnit.displayName}</span>
+          {focusUnit.tier && (
+            <>
+              <span className="hf-sim-qual-strip-dot">·</span>
+              <span className="hf-sim-qual-summary-unittier">
+                {TIER_LABELS[focusUnit.tier]} on {focusUnit.losCovered}/{focusUnit.losTotal} LOs
+              </span>
+            </>
+          )}
+          {focusUnit.weakestLoRef && (
+            <>
+              <span className="hf-sim-qual-strip-dot">·</span>
+              <span>Focus next: </span>
+              <code className="hf-sim-qual-strip-loref">{focusUnit.weakestLoRef}</code>
+            </>
+          )}
+        </p>
+      )}
+
+      <Link href="/x/student/progress" className="hf-sim-qual-summary-link">
+        View full progress →
+      </Link>
+    </section>
+  );
+}

--- a/apps/admin/components/sim/qualification/sim-qualification.css
+++ b/apps/admin/components/sim/qualification/sim-qualification.css
@@ -1,0 +1,132 @@
+/* SIM qualification surfaces — #1098 Slice C.
+ *
+ * Both pre- and post-call live inside the SIM frame, so styles share
+ * tokens with the rest of the SimChat surface. No hard-coded colors;
+ * uses the global CSS custom properties with safe fallbacks.
+ */
+
+/* ─── Pre-call context strip ─────────────────────────────────────────── */
+
+.hf-sim-qual-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 14px;
+  background: color-mix(in srgb, var(--accent-primary, #6366f1) 6%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent-primary, #6366f1) 25%, transparent);
+  font-size: 12px;
+  color: var(--text-secondary, #374151);
+}
+.hf-sim-qual-strip-line1 {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.hf-sim-qual-strip-line2 {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-muted, #6b7280);
+}
+.hf-sim-qual-strip-anchor {
+  font-weight: 600;
+  color: var(--text-primary, #111827);
+}
+.hf-sim-qual-strip-unit {
+  color: var(--text-primary, #111827);
+}
+.hf-sim-qual-strip-tier {
+  font-weight: 600;
+  color: var(--accent-primary, #6366f1);
+}
+.hf-sim-qual-strip-dot {
+  color: var(--text-muted, #9ca3af);
+}
+.hf-sim-qual-strip-loref {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  background: color-mix(in srgb, var(--text-primary, #111827) 8%, transparent);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+/* ─── Post-call session summary ──────────────────────────────────────── */
+
+.hf-sim-qual-summary {
+  margin: 12px 8px;
+  padding: 14px 16px;
+  background: var(--surface-primary, var(--card-bg, #ffffff));
+  border: 1px solid var(--border-primary, var(--card-border, #e5e7eb));
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.hf-sim-qual-summary-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.hf-sim-qual-summary-title {
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-primary, #111827);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.hf-sim-qual-summary-line {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary, #374151);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.hf-sim-qual-summary-anchor {
+  font-weight: 600;
+  color: var(--text-primary, #111827);
+}
+.hf-sim-qual-summary-tier {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  background: color-mix(in srgb, var(--accent-primary, #6366f1) 12%, transparent);
+  color: var(--accent-primary, #6366f1);
+}
+.hf-sim-qual-summary-unitline {
+  margin: 4px 0 0;
+  padding: 8px 10px;
+  background: var(--surface-secondary, #f9fafb);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-secondary, #374151);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.hf-sim-qual-summary-unit {
+  font-weight: 600;
+  color: var(--text-primary, #111827);
+}
+.hf-sim-qual-summary-unittier {
+  color: var(--text-secondary, #374151);
+}
+.hf-sim-qual-summary-link {
+  align-self: flex-end;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-primary, #6366f1);
+  text-decoration: none;
+  margin-top: 4px;
+}
+.hf-sim-qual-summary-link:hover {
+  text-decoration: underline;
+}

--- a/apps/admin/tests/components/QualificationContextStrip.test.tsx
+++ b/apps/admin/tests/components/QualificationContextStrip.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * QualificationContextStrip + QualificationSessionSummary — #1098 Slice C.
+ *
+ * Both reuse `useQualificationProgress`. We mock the hook so the components'
+ * render logic can be unit-tested without faking fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import type { QualificationProgressData } from "@/hooks/useQualificationProgress";
+
+const mockHook = vi.fn();
+vi.mock("@/hooks/useQualificationProgress", () => ({
+  useQualificationProgress: () => mockHook(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function makeFixture(overrides?: Partial<QualificationProgressData>): QualificationProgressData {
+  return {
+    qualification: {
+      anchor: "sias-cio-cto-v6",
+      displayName: "The CIO/CTO Standard",
+      qualificationBody: null,
+      qualificationNumber: null,
+      qualificationLevel: null,
+      tier: "DEVELOPING",
+      unitsCovered: 1,
+      unitsTotal: 2,
+      weakestUnitSlug: "standard-unit-09",
+      losAtTierOrAbove: 4,
+      losTotal: 12,
+    },
+    units: [
+      {
+        moduleSlug: "standard-unit-04",
+        displayName: "IT Operations",
+        tier: "PRACTITIONER",
+        losCovered: 7,
+        losTotal: 7,
+        weakestLoRef: null,
+        learningObjectives: [],
+      },
+      {
+        moduleSlug: "standard-unit-09",
+        displayName: "Enterprise Architecture",
+        tier: "DEVELOPING",
+        losCovered: 1,
+        losTotal: 7,
+        weakestLoRef: "OUT-09-05",
+        learningObjectives: [],
+      },
+    ],
+    skills: [],
+    recentActivity: [],
+    nextBestStep: null,
+    ...overrides,
+  };
+}
+
+describe("QualificationContextStrip — #1098 Slice C", () => {
+  let QualificationContextStrip: typeof import("@/components/sim/qualification/QualificationContextStrip").QualificationContextStrip;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/components/sim/qualification/QualificationContextStrip");
+    QualificationContextStrip = mod.QualificationContextStrip;
+  });
+
+  it("returns null when hook data is missing", () => {
+    mockHook.mockReturnValue({ data: null, loading: false, error: null, refetch: vi.fn() });
+    const { container } = render(<QualificationContextStrip />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when qualification is null (non-anchored Curriculum)", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture({ qualification: null }),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { container } = render(<QualificationContextStrip />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("surfaces the requested moduleId's unit when matched in catalog", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture(),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { getByText, container } = render(
+      <QualificationContextStrip requestedModuleId="standard-unit-04" />,
+    );
+    expect(getByText("IT Operations")).toBeDefined();
+    expect(getByText("Practitioner")).toBeDefined();
+    // No focus LO surfaced because Unit 04 has weakestLoRef=null.
+    expect(container.textContent).not.toContain("Focus:");
+  });
+
+  it("falls back to qualification.weakestUnitSlug when no requestedModuleId match", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture(),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { getByText, container } = render(<QualificationContextStrip />);
+    expect(getByText("Enterprise Architecture")).toBeDefined();
+    expect(getByText("Developing")).toBeDefined();
+    // Focus LO surfaced from the weakest unit.
+    expect(container.textContent).toContain("Focus:");
+    expect(getByText("OUT-09-05")).toBeDefined();
+  });
+
+  it("shows 'Not yet assessed' when the focus unit has no tier", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture({
+        units: [
+          {
+            moduleSlug: "u1",
+            displayName: "Unit 1",
+            tier: null,
+            losCovered: 0,
+            losTotal: 3,
+            weakestLoRef: null,
+            learningObjectives: [],
+          },
+        ],
+        qualification: {
+          ...makeFixture().qualification!,
+          weakestUnitSlug: "u1",
+        },
+      }),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { getByText } = render(<QualificationContextStrip />);
+    expect(getByText("Not yet assessed")).toBeDefined();
+  });
+
+  it("returns null when no focus unit can be derived (degenerate catalog)", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture({
+        qualification: { ...makeFixture().qualification!, weakestUnitSlug: null },
+        units: [],
+      }),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { container } = render(<QualificationContextStrip />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("QualificationSessionSummary — #1098 Slice C", () => {
+  let QualificationSessionSummary: typeof import("@/components/sim/qualification/QualificationContextStrip").QualificationSessionSummary;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/components/sim/qualification/QualificationContextStrip");
+    QualificationSessionSummary = mod.QualificationSessionSummary;
+  });
+
+  it("returns null when loading and no data yet (no flash of empty card)", () => {
+    mockHook.mockReturnValue({ data: null, loading: true, error: null, refetch: vi.fn() });
+    const { container } = render(<QualificationSessionSummary />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when qualification is null", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture({ qualification: null }),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { container } = render(<QualificationSessionSummary />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("refetches on first mount so AGGREGATE rollup is reflected", () => {
+    const refetch = vi.fn();
+    mockHook.mockReturnValue({
+      data: makeFixture(),
+      loading: false,
+      error: null,
+      refetch,
+    });
+    render(<QualificationSessionSummary />);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders qualification anchor + tier + LO totals + focus unit", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture(),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { getByText, container } = render(<QualificationSessionSummary />);
+    expect(getByText("The CIO/CTO Standard")).toBeDefined();
+    expect(getByText("Developing")).toBeDefined();
+    expect(getByText("4 of 12 Learning Outcomes")).toBeDefined();
+    expect(getByText("Enterprise Architecture")).toBeDefined();
+    expect(getByText("Developing on 1/7 LOs")).toBeDefined();
+    expect(getByText("OUT-09-05")).toBeDefined();
+    // Link to the full dashboard.
+    const link = container.querySelector('a[href="/x/student/progress"]');
+    expect(link).not.toBeNull();
+  });
+
+  it("omits the focus-unit line when no focus unit can be derived", () => {
+    mockHook.mockReturnValue({
+      data: makeFixture({
+        qualification: { ...makeFixture().qualification!, weakestUnitSlug: null },
+        units: [],
+      }),
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { queryByText } = render(<QualificationSessionSummary />);
+    // No unit name should appear when units list is empty AND weakestUnitSlug is null.
+    expect(queryByText("Enterprise Architecture")).toBeNull();
+    expect(queryByText("IT Operations")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Slice C of #1098 — wraps the SIM chat with qualification context. Two minimal components, both reuse the `useQualificationProgress` hook from Slice B + the same `qualification:null` guard so non-anchored Curricula see zero UI change.

**`QualificationContextStrip`** — pre-call, between `SimStateBreadcrumb` and the ModulePicker banners. Surfaces the session's focus Unit (matched to `?requestedModuleId=` when present, else `qualification.weakestUnitSlug`) + tier + focus LO ref. Stays silent for non-anchored Curricula and when no focus unit can be derived. Single-line content per the audit's real-estate-war mitigation.

**`QualificationSessionSummary`** — post-call. Refetches on mount so the AGGREGATE rollup written for the just-ended call is reflected. Shows qualification anchor + tier + LO totals + the focus unit's per-unit tier + Focus-next LO ref. Links to the full dashboard.

No before/after delta — the dashboard carries running totals and a diff probe would need a session-snapshot mechanism for marginal UX value. Deferred to Slice D if user testing demands it.

**Integrations**
- `app/x/sim/[callerId]/page.tsx` — mounts `QualificationContextStrip` between `SimStateBreadcrumb` and `ModulePickerSelectionBanner`
- `components/sim/SimChat.tsx` — renders `QualificationSessionSummary` alongside `PostCallProgressCard` inside the existing `callPhase === 'ended'` block

## Test plan

- [x] 11 component tests (hook-data-missing, qualification-null, requestedModuleId match, weakest-unit fallback, not-yet-assessed tier, degenerate catalog, refetch on mount, link to dashboard, omit-focus-line)
- [ ] Manual smoke on VM: CIO/CTO learner opens `/x/sim/[callerId]` → pre-call strip visible above chat
- [ ] Manual smoke on VM: learner completes a SIM call → post-call summary card appears alongside PostCallProgressCard
- [ ] Non-regression: learners on non-anchored courses see no strip / no summary
- [ ] Real estate check on mobile <380px width — strip is single-pair of lines, doesn't push chat below the fold

Closes #1098 (Slices A + B + C; full story now shipped pending optional Slice D polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)