### PR TITLE
fix(voice): add /api/voice to middleware auth allowlist

### DIFF
--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -9,7 +9,7 @@ import { getRequiredRole, hasRequiredRole } from "@/lib/page-roles";
 
 const publicRoutes = ["/login", "/login/verify", "/login/error", "/invite", "/join", "/intake"];
 // Routes that handle their own auth (webhooks, external APIs)
-const apiTokenRoutes = ["/api/auth", "/api/vapi", "/api/webhook", "/api/invite", "/api/join", "/api/health", "/api/ready", "/api/system/readiness", "/api/system/db-target", "/api/intake", "/api/tallyseal-bridge"];
+const apiTokenRoutes = ["/api/auth", "/api/vapi", "/api/voice", "/api/webhook", "/api/invite", "/api/join", "/api/health", "/api/ready", "/api/system/readiness", "/api/system/db-target", "/api/intake", "/api/tallyseal-bridge"];
 
 // Internal API secret for server-to-server calls (bypasses session check)
 // No fallback — if unset, internal-secret bypass is disabled (fail-closed)


### PR DESCRIPTION
## Summary

- One-line allowlist addition so `/api/voice/<slug>/*` routes (canonical AnyVoice webhooks) bypass the session-auth middleware
- Routes still verify themselves via per-provider HMAC (`verifyVapiRequest` for VAPI)

## Why

AnyVoice migration left `/api/vapi/*` allowlisted but added new canonical paths at `/api/voice/<slug>/*` without updating the allowlist. The legacy `/api/vapi/webhook` 307-redirects to `/api/voice/vapi/webhook`, which then hit the middleware and bounced to `/login`. VAPI webhooks would silently fail.

## Repro (pre-fix)

```bash
curl -i -X POST https://<ngrok>/api/voice/vapi/webhook -H "Content-Type: application/json" -d '{}'
# HTTP/1.1 307 Temporary Redirect
# Location: /login?callbackUrl=/api/voice/vapi/webhook
```

## After

```bash
# Handler reaches verifyVapiRequest → 401 (no signature) or 200 (valid)
```

## Test plan

- [x] Local ngrok smoke against hf-dev VM after `/vm-cp` shows `POST /api/voice/vapi/webhook` reaches the route handler (HMAC check, not auth bounce)
- [ ] VAPI dashboard "Test Webhook" to the ngrok URL returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)