### PR TITLE
chore: docs + script for shadow-DB migration workaround

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -34,6 +34,7 @@
     "prisma:seed": "npx prisma db seed",
     "prisma:studio": "npx prisma studio",
     "tallyseal:migrate": "tsx scripts/apply-tallyseal-migrations.ts",
+    "migrate:gen": "bash scripts/generate-migration.sh",
     "registry:generate": "tsx scripts/generate-registry.ts",
     "registry:validate": "tsx scripts/validate-registry.ts",
     "generate:constants": "tsx scripts/generate-constants-manifest.ts",

--- a/apps/admin/scripts/generate-migration.sh
+++ b/apps/admin/scripts/generate-migration.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# generate-migration.sh — create a Prisma migration without going through
+# the broken shadow-DB rebuild. Runs `prisma migrate diff --from-url`
+# against the live DB pointed at by $DATABASE_URL, lets you eyeball the
+# SQL before applying, then registers the migration as applied.
+#
+# WHY THIS EXISTS: see docs/MIGRATIONS.md. The repo's pre-formal-migrations
+# tables (Caller, Domain, etc.) were never CREATE TABLE'd in any migration,
+# so `prisma migrate dev` always fails at the shadow-DB replay step.
+#
+# USAGE (run on hf-dev VM, where Postgres is reachable):
+#   cd ~/HF/apps/admin
+#   ./scripts/generate-migration.sh <migration_name>
+#
+# Example:
+#   ./scripts/generate-migration.sh caller_identity_challenge
+#
+# Always read the generated SQL before confirming — the diff includes any
+# drift between the live DB and schema.prisma (DROP TABLE tallyseal_*,
+# unrelated ALTER COLUMN, etc.), not just your intended change.
+
+set -e
+
+NAME="${1:-}"
+if [ -z "$NAME" ]; then
+  echo "Usage: $0 <migration_name>" >&2
+  echo "Example: $0 caller_identity_challenge" >&2
+  exit 1
+fi
+
+# Validate name: lowercase, digits, underscores only — matches Prisma's convention.
+if ! printf '%s' "$NAME" | grep -Eq '^[a-z0-9_]+$'; then
+  echo "Migration name must be lowercase letters / digits / underscores only." >&2
+  echo "Got: $NAME" >&2
+  exit 1
+fi
+
+# Must run from apps/admin (where prisma/ lives).
+if [ ! -f prisma/schema.prisma ]; then
+  echo "Run this from apps/admin/ (no prisma/schema.prisma found in cwd)." >&2
+  exit 1
+fi
+
+# Source .env so DATABASE_URL is available.
+if [ ! -f .env ]; then
+  echo "No .env in cwd — DATABASE_URL needed for --from-url." >&2
+  exit 1
+fi
+set -a
+. .env
+set +a
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL not set after sourcing .env." >&2
+  exit 1
+fi
+
+TS=$(date -u +%Y%m%d%H%M%S)
+FULL_NAME="${TS}_${NAME}"
+DIR="prisma/migrations/${FULL_NAME}"
+
+mkdir -p "$DIR"
+
+echo "==> Generating SQL diff (live DB → schema.prisma)..."
+npx prisma migrate diff \
+  --from-url "$DATABASE_URL" \
+  --to-schema-datamodel prisma/schema.prisma \
+  --script > "$DIR/migration.sql"
+
+if [ ! -s "$DIR/migration.sql" ]; then
+  echo ""
+  echo "Generated SQL is empty — schema is already in sync with the DB." >&2
+  echo "Removing empty migration directory: $DIR" >&2
+  rm -rf "$DIR"
+  exit 1
+fi
+
+echo ""
+echo "================================================================"
+echo "Generated migration SQL — review before applying:"
+echo "================================================================"
+cat "$DIR/migration.sql"
+echo "================================================================"
+echo ""
+echo "Path: $DIR/migration.sql"
+echo ""
+echo "★ Check for unrelated drift (DROP TABLE tallyseal_*, unwanted ALTERs)."
+echo "  If the diff is wrong, edit $DIR/migration.sql before continuing."
+echo ""
+read -p "Apply this SQL to the DB now? [y/N] " -n 1 -r ANSWER
+echo ""
+if [[ ! "$ANSWER" =~ ^[Yy]$ ]]; then
+  echo "Aborted. Migration file kept at $DIR/migration.sql — edit + re-run apply manually:"
+  echo "  npx prisma db execute --file $DIR/migration.sql --schema prisma/schema.prisma"
+  echo "  npx prisma migrate resolve --applied $FULL_NAME"
+  exit 0
+fi
+
+echo ""
+echo "==> Applying SQL via prisma db execute..."
+npx prisma db execute \
+  --file "$DIR/migration.sql" \
+  --schema prisma/schema.prisma
+
+echo ""
+echo "==> Registering migration as applied in _prisma_migrations..."
+npx prisma migrate resolve --applied "$FULL_NAME"
+
+echo ""
+echo "==> Regenerating Prisma client..."
+npx prisma generate
+
+echo ""
+echo "================================================================"
+echo "Done. Next steps:"
+echo "  git add apps/admin/prisma/migrations/$FULL_NAME"
+echo "  git commit -m 'feat(<area>): <description> (#NNNN)'"
+echo "  git push"
+echo "================================================================"

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,70 @@
+# Schema Migrations — Working Around the Shadow DB Bug
+
+> **TL;DR:** `npx prisma migrate dev` is broken in this repo. Use `apps/admin/scripts/generate-migration.sh` instead. Real envs (dev/staging/pilot/prod) are unaffected — `migrate deploy` works normally there.
+
+## The bug, briefly
+
+The first ~6 weeks of HF development (Dec 2025 → mid-Feb 2026) used `prisma db push` rather than formal migrations. Ten tables were created in that period — `Caller`, `ContentAssertion`, `ContentSource`, `ConversationArtifact`, `Curriculum`, `Domain`, `Playbook`, `PlaybookGroup`, `Subject`, `SubjectSource` — and their `CREATE TABLE` statements were never captured in `prisma/migrations/`.
+
+When `prisma migrate dev` runs, it spins up a fresh empty **shadow database** and replays every migration from scratch to validate the new one. Replay fails at the first migration that references one of those ten tables in an FK constraint — historically `20260213_expand_user_roles` (`User.assignedDomainId → Domain.id`) — with:
+
+```
+Error: P3006
+Migration `20260213_expand_user_roles` failed to apply cleanly to the shadow database.
+Error code: P1014
+The underlying table for model `Domain` does not exist.
+```
+
+Real envs don't hit this because the ten tables already exist there (from the original `db push`). The replay only runs in shadow.
+
+## The workaround — what to use instead
+
+`apps/admin/scripts/generate-migration.sh` wraps `prisma migrate diff --from-url` to bypass the shadow DB entirely. It diffs the **live database** against your updated `schema.prisma` and writes the SQL straight into a migration directory, then applies it directly.
+
+### Usage
+
+```bash
+# 1. Edit apps/admin/prisma/schema.prisma — add your new model / column / index.
+# 2. On the hf-dev VM (where Postgres is reachable):
+cd ~/HF/apps/admin
+./scripts/generate-migration.sh my_new_thing
+
+# That's it. The script:
+#   - Generates apps/admin/prisma/migrations/<timestamp>_my_new_thing/migration.sql
+#   - Applies it to whatever DB DATABASE_URL points at
+#   - Registers it as applied in _prisma_migrations
+#   - Regenerates the Prisma client
+#   - You then git add / commit / push the migration directory
+```
+
+### Why on the VM (not local)?
+
+Prisma needs a live Postgres connection to read the current DB state. The hf-dev VM has Postgres reachable on the wireguard network; local Macs typically don't.
+
+### Pitfalls of `migrate diff --from-url`
+
+Because the script compares the **live DB** to your **new schema**, the diff includes any **drift** between them — things that someone changed in the DB outside the migration history. Examples seen in the wild:
+
+- `ALTER TABLE "CurriculumModule" ALTER COLUMN "coversModules" DROP DEFAULT` — a default that the schema doesn't declare but the DB had
+- `DROP TABLE "tallyseal_*"` — the tallyseal-prisma-adapter tables, which are managed by raw-SQL migrations outside Prisma
+
+**Always read the generated `migration.sql` before letting the script apply it.** The script prints the SQL to stdout and pauses for confirmation. If the diff includes anything beyond your intended change, either:
+
+1. **Hand-edit the SQL** to remove the unrelated drift — keep only your change.
+2. **Manage drift first** — fix the schema or DB, then re-generate.
+
+For #1101's `CallerIdentityChallenge` we hand-edited the SQL to drop tallyseal/CurriculumModule drift. See the migration file at `apps/admin/prisma/migrations/20260605162259_caller_identity_challenge/` for an example of a clean, hand-curated migration written this way.
+
+## When `prisma migrate dev` will work again
+
+When the latent issue is fixed — see GitHub issue **#1108** for the cross-env surgery (scaffold migration + `migrate resolve --applied` across dev / staging / pilot / prod). Until then, the workflow above is canonical.
+
+## Deploy path is unchanged
+
+`prisma migrate deploy` (what runs in real envs) **works normally**. It applies any migration directories not yet recorded in `_prisma_migrations`, in order. No shadow DB involved. So commits made via this workflow ship to staging/pilot/prod via the existing `/deploy` flow without any special handling.
+
+## See also
+
+- `apps/admin/scripts/generate-migration.sh` — the wrapper script
+- `apps/admin/scripts/apply-tallyseal-migrations.ts` — separate raw-SQL migration runner for tallyseal tables (must run after `prisma generate`)
+- `.claude/skills/vm-cpp.md` — the VM deploy flow, which calls `prisma migrate deploy`


### PR DESCRIPTION
## Summary
- `docs/MIGRATIONS.md` documents the latent `prisma migrate dev` shadow-DB failure (10 pre-formal-migration tables never CREATE TABLE'd) and the workaround
- `apps/admin/scripts/generate-migration.sh` wraps `prisma migrate diff --from-url` — generates SQL, prints for review, prompts before applying, registers via `migrate resolve --applied`
- `npm run migrate:gen <name>` for discoverability
- Tactical fix only; strategic surgery tracked in #1108

## Test plan
- [x] Workflow used in anger to ship #1101's CallerIdentityChallenge migration
- [ ] Reviewer eyeballs docs/MIGRATIONS.md