### PR TITLE
feat(identity): PIN-gated first call — continuity attestation slice 1

### DIFF
--- a/apps/admin/app/api/identity/challenge-status/route.ts
+++ b/apps/admin/app/api/identity/challenge-status/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  resolveCallerScopeForReading,
+  isScopeError,
+} from "@/lib/learner-scope";
+
+/**
+ * @api GET /api/identity/challenge-status
+ * @visibility public
+ * @auth session (STUDENT+)
+ * @description Whether the learner has an outstanding first-call PIN challenge
+ * to satisfy before the sim page should render the chat. Used by
+ * /x/sim/[callerId] to decide between FirstCallPinGate and SimChat. STUDENT
+ * sessions are locked to their own caller via resolveCallerScopeForReading.
+ * @query callerId string
+ * @response 200 { ok: true, needsPin: boolean, locked: boolean, recipient: string | null }
+ */
+export async function GET(req: Request) {
+  const authResult = await requireAuth("VIEWER");
+  if (isAuthError(authResult)) return authResult.error;
+
+  const url = new URL(req.url);
+  const requestedCallerId = url.searchParams.get("callerId");
+
+  const scope = await resolveCallerScopeForReading(
+    authResult.session,
+    requestedCallerId,
+  );
+  if (isScopeError(scope)) return scope.error;
+  const callerId = scope.scopedCallerId;
+  if (!callerId) {
+    return NextResponse.json(
+      { ok: true, needsPin: false, locked: false, recipient: null },
+    );
+  }
+
+  const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  const locked = await prisma.callerIdentityChallenge.findFirst({
+    where: {
+      callerId,
+      issuedAt: { gte: windowStart },
+      lockedAt: { not: null },
+    },
+    select: { id: true },
+  });
+
+  const active = await prisma.callerIdentityChallenge.findFirst({
+    where: { callerId, verifiedAt: null },
+    orderBy: { issuedAt: "desc" },
+    select: { recipient: true },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    needsPin: Boolean(active),
+    locked: Boolean(locked),
+    recipient: active?.recipient ?? null,
+  });
+}

--- a/apps/admin/app/api/identity/resend-pin/route.ts
+++ b/apps/admin/app/api/identity/resend-pin/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  resolveCallerScopeForReading,
+  isScopeError,
+} from "@/lib/learner-scope";
+import { config } from "@/lib/config";
+import { issueFirstCallPin } from "@/lib/identity/issue-pin";
+
+const bodySchema = z.object({ callerId: z.string().min(1) }).strict();
+
+/**
+ * @api POST /api/identity/resend-pin
+ * @visibility public
+ * @auth session (STUDENT+)
+ * @description Re-issue a first-call PIN to the caller's on-file email. Caps
+ * at IDENTITY_PIN_MAX_RESENDS (default 3) in any 24h window — the cap query
+ * filters resendCount > 0 so the initial enrolment issuance does not count.
+ * Cooldown of IDENTITY_PIN_RESEND_COOLDOWN_SECONDS (default 60) between
+ * resends. Resending does NOT clear lockout — the learner can hold a fresh
+ * PIN, but cannot verify until 24h elapses or an admin unlocks.
+ * @response 200 { ok: true } — fresh PIN sent
+ * @response 200 { ok: false, resendCapReached: true } — 3 resends already today
+ * @response 200 { ok: false, cooldownSecondsRemaining: number } — within 60s window
+ * @response 200 { ok: false, noActiveCaller: true } — caller has no email on file
+ * @response 400 { ok: false, error: string } — invalid body
+ */
+export async function POST(req: Request) {
+  const authResult = await requireAuth("VIEWER");
+  if (isAuthError(authResult)) return authResult.error;
+
+  const body = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const scope = await resolveCallerScopeForReading(
+    authResult.session,
+    parsed.data.callerId,
+  );
+  if (isScopeError(scope)) return scope.error;
+  const callerId = scope.scopedCallerId;
+  if (!callerId) {
+    return NextResponse.json(
+      { ok: false, error: "Caller scope not resolved" },
+      { status: 400 },
+    );
+  }
+
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { email: true, name: true },
+  });
+  if (!caller || !caller.email) {
+    return NextResponse.json({ ok: false, noActiveCaller: true });
+  }
+
+  const pinConfig = config.security.identityPin;
+  const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  // Cap query: count ONLY resend-issued challenges in last 24h. The initial
+  // enrolment issuance has resendCount = 0 and is excluded by the filter.
+  // (TL review: without this filter the learner would get 2 resends, not 3.)
+  const resendsUsed = await prisma.callerIdentityChallenge.count({
+    where: {
+      callerId,
+      issuedAt: { gte: windowStart },
+      resendCount: { gt: 0 },
+    },
+  });
+  if (resendsUsed >= pinConfig.maxResendsPer24h) {
+    return NextResponse.json({ ok: false, resendCapReached: true });
+  }
+
+  // Cooldown — defence-in-depth alongside the client-side button countdown.
+  const cooldownStart = new Date(
+    Date.now() - pinConfig.resendCooldownSeconds * 1000,
+  );
+  const lastResend = await prisma.callerIdentityChallenge.findFirst({
+    where: {
+      callerId,
+      issuedAt: { gte: cooldownStart },
+      resendCount: { gt: 0 },
+    },
+    orderBy: { issuedAt: "desc" },
+    select: { issuedAt: true },
+  });
+  if (lastResend) {
+    const elapsed = (Date.now() - lastResend.issuedAt.getTime()) / 1000;
+    const remaining = Math.ceil(pinConfig.resendCooldownSeconds - elapsed);
+    return NextResponse.json({
+      ok: false,
+      cooldownSecondsRemaining: Math.max(1, remaining),
+    });
+  }
+
+  const firstName = caller.name?.trim().split(/\s+/)[0];
+  await issueFirstCallPin({
+    callerId,
+    email: caller.email,
+    firstName,
+    isResend: true,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/admin/app/api/identity/verify-pin/route.ts
+++ b/apps/admin/app/api/identity/verify-pin/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  resolveCallerScopeForReading,
+  isScopeError,
+} from "@/lib/learner-scope";
+import { config } from "@/lib/config";
+import { verifyPinHash } from "@/lib/identity/pin";
+
+const bodySchema = z
+  .object({
+    callerId: z.string().min(1),
+    pin: z.string().length(6).regex(/^\d{6}$/),
+  })
+  .strict();
+
+/**
+ * @api POST /api/identity/verify-pin
+ * @visibility public
+ * @auth session (STUDENT+)
+ * @description Verify a learner's first-call PIN. STUDENT sessions are locked
+ * to their own caller via resolveCallerScopeForReading — body callerId is
+ * ignored for STUDENTs. Lockout aggregates failed attempts across the caller's
+ * challenges in the last 24h.
+ * @response 200 { ok: true } — PIN correct, challenge marked verified
+ * @response 200 { ok: false, expired: true } — PIN matched but past TTL; does NOT count toward lockout
+ * @response 200 { ok: false, locked: true } — caller is in 24h lockout window
+ * @response 200 { ok: false, attemptsRemaining: number } — wrong PIN
+ * @response 200 { ok: false, noActiveChallenge: true } — no challenge to verify (request resend)
+ * @response 400 { ok: false, error: string } — invalid body
+ */
+export async function POST(req: Request) {
+  const authResult = await requireAuth("VIEWER");
+  if (isAuthError(authResult)) return authResult.error;
+
+  const body = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const scope = await resolveCallerScopeForReading(
+    authResult.session,
+    parsed.data.callerId,
+  );
+  if (isScopeError(scope)) return scope.error;
+  const callerId = scope.scopedCallerId;
+  if (!callerId) {
+    return NextResponse.json(
+      { ok: false, error: "Caller scope not resolved" },
+      { status: 400 },
+    );
+  }
+
+  const pinConfig = config.security.identityPin;
+  const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  // Lockout check — any challenge in the last 24h with a lockedAt timestamp
+  // means the caller is locked regardless of which challenge they're trying.
+  const locked = await prisma.callerIdentityChallenge.findFirst({
+    where: {
+      callerId,
+      issuedAt: { gte: windowStart },
+      lockedAt: { not: null },
+    },
+    select: { id: true },
+  });
+  if (locked) {
+    return NextResponse.json({ ok: false, locked: true });
+  }
+
+  // Most recent unverified challenge — older ones are moot (resends invalidate
+  // by superseding; we always verify against the latest).
+  const challenge = await prisma.callerIdentityChallenge.findFirst({
+    where: { callerId, verifiedAt: null },
+    orderBy: { issuedAt: "desc" },
+    select: {
+      id: true,
+      pinHash: true,
+      expiresAt: true,
+      attemptCount: true,
+    },
+  });
+  if (!challenge) {
+    return NextResponse.json({ ok: false, noActiveChallenge: true });
+  }
+
+  // Hash compare is constant-time (bcryptjs ~111ms for both match and miss),
+  // so the expired/wrong branch below does not leak via timing. TL review.
+  const matches = await verifyPinHash(parsed.data.pin, challenge.pinHash);
+
+  if (matches) {
+    if (challenge.expiresAt.getTime() < Date.now()) {
+      // Right PIN but expired — distinct response, does NOT increment attemptCount.
+      return NextResponse.json({ ok: false, expired: true });
+    }
+    await prisma.callerIdentityChallenge.update({
+      where: { id: challenge.id },
+      data: { verifiedAt: new Date() },
+    });
+    return NextResponse.json({ ok: true });
+  }
+
+  // Wrong PIN — increment attempt counter; aggregate across last 24h.
+  await prisma.callerIdentityChallenge.update({
+    where: { id: challenge.id },
+    data: { attemptCount: { increment: 1 } },
+  });
+
+  const totalAttempts = await prisma.callerIdentityChallenge.aggregate({
+    where: { callerId, issuedAt: { gte: windowStart } },
+    _sum: { attemptCount: true },
+  });
+  const usedAttempts = totalAttempts._sum.attemptCount ?? 0;
+
+  if (usedAttempts >= pinConfig.maxAttempts) {
+    await prisma.callerIdentityChallenge.update({
+      where: { id: challenge.id },
+      data: { lockedAt: new Date() },
+    });
+    return NextResponse.json({ ok: false, locked: true });
+  }
+
+  return NextResponse.json({
+    ok: false,
+    attemptsRemaining: Math.max(0, pinConfig.maxAttempts - usedAttempts),
+  });
+}

--- a/apps/admin/app/api/join/[token]/route.ts
+++ b/apps/admin/app/api/join/[token]/route.ts
@@ -7,6 +7,7 @@ import { enrollCaller, enrollCallerInCohortPlaybooks } from "@/lib/enrollment";
 import { applySkipOnboarding } from "@/lib/enrollment/skip-onboarding";
 import { mintAndSetSessionCookie } from "@/lib/auth-session-cookie";
 import { ROLE_LEVEL } from "@/lib/roles";
+import { issueFirstCallPin } from "@/lib/identity/issue-pin";
 import type { UserRole } from "@prisma/client";
 
 const SESSION_COOKIE_NAMES = [
@@ -293,6 +294,14 @@ export async function POST(
       await applySkipOnboarding(newCaller.id, cohort.domainId);
     }
 
+    // Issue first-call PIN (#1101). Best-effort — SMTP failure won't roll
+    // back the Caller; the learner can request a resend on the sim page.
+    await issueFirstCallPin({
+      callerId: newCaller.id,
+      email: email.trim().toLowerCase(),
+      firstName: firstName.trim(),
+    });
+
     const existingResponse = NextResponse.json({
       ok: true,
       message: "Joined classroom",
@@ -376,6 +385,14 @@ export async function POST(
   if (skipOnboarding && cohort.domainId) {
     await applySkipOnboarding(result.newCallerId, cohort.domainId);
   }
+
+  // Issue first-call PIN (#1101). Outside the transaction by design — SMTP
+  // failure must not roll back the user+caller create. TL review note.
+  await issueFirstCallPin({
+    callerId: result.newCallerId,
+    email: email.trim().toLowerCase(),
+    firstName: firstName.trim(),
+  });
 
   const response = NextResponse.json({
     ok: true,

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -12,6 +12,7 @@ import type { AgentTunerPill } from '@/lib/agent-tuner/types';
 import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from '@/components/sim/ModulePickerBanners';
 import { SimStateBreadcrumb } from '@/components/sim/SimStateBreadcrumb';
 import { QualificationContextStrip } from '@/components/sim/qualification/QualificationContextStrip';
+import { FirstCallPinGate } from '@/components/identity/FirstCallPinGate';
 
 interface PastCall {
   transcript: string;
@@ -67,6 +68,13 @@ export default function SimConversationPage() {
   }, [searchParams]);
 
   const [caller, setCaller] = useState<CallerInfo | null>(null);
+  // #1101 — first-call PIN gate. Only STUDENT sessions are gated; OPERATOR+
+  // admin browsing of a learner's sim page is unaffected. 'loading' until the
+  // challenge-status fetch returns; 'verified' once the gate posts ok.
+  const [pinGateStatus, setPinGateStatus] = useState<
+    'loading' | 'needsPin' | 'verified'
+  >('loading');
+  const [pinGateRecipient, setPinGateRecipient] = useState<string | null>(null);
   const [playbookName, setPlaybookName] = useState<string | undefined>(undefined);
   const [subjectDiscipline, setSubjectDiscipline] = useState<string | undefined>(undefined);
   const [modulesAuthored, setModulesAuthored] = useState<boolean>(false);
@@ -171,6 +179,33 @@ export default function SimConversationPage() {
     return () => { cancelled = true; };
   }, [callerId, expectedDomainId, playbookId, router]);
 
+  // #1101 — fetch challenge status once we know the session role. Skip for
+  // OPERATOR+ so admin browsing of a learner's sim page is unaffected.
+  useEffect(() => {
+    if (!isStudent) {
+      setPinGateStatus('verified');
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/identity/challenge-status?callerId=${encodeURIComponent(callerId)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled || !data?.ok) return;
+        if (data.needsPin) {
+          setPinGateRecipient(data.recipient ?? null);
+          setPinGateStatus('needsPin');
+        } else {
+          setPinGateStatus('verified');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setPinGateStatus('verified');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, isStudent]);
+
   const handleStudentCallEnd = useCallback(() => {
     if (isStudent) {
       setTimeout(() => router.push('/x/student'), 1500);
@@ -209,7 +244,7 @@ export default function SimConversationPage() {
     );
   }
 
-  if (!caller) {
+  if (!caller || pinGateStatus === 'loading') {
     return (
       <>
         <WhatsAppHeader title="Loading..." />
@@ -217,6 +252,23 @@ export default function SimConversationPage() {
           <div className="hf-spinner" style={{ width: 28, height: 28 }} />
           <p style={{ color: 'var(--text-muted)', fontSize: 14 }}>Loading...</p>
         </div>
+      </>
+    );
+  }
+
+  // #1101 — gate first-call STUDENT sessions on PIN verification before the
+  // chat renders. OPERATOR+ skip this branch (pinGateStatus pre-set to verified).
+  if (pinGateStatus === 'needsPin') {
+    const callerFirstName = caller.name?.trim().split(/\s+/)[0];
+    return (
+      <>
+        <WhatsAppHeader title="Verify your code" />
+        <FirstCallPinGate
+          callerId={callerId}
+          recipient={pinGateRecipient}
+          callerFirstName={callerFirstName}
+          onVerified={() => setPinGateStatus('verified')}
+        />
       </>
     );
   }

--- a/apps/admin/components/identity/FirstCallPinGate.tsx
+++ b/apps/admin/components/identity/FirstCallPinGate.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface FirstCallPinGateProps {
+  callerId: string;
+  recipient: string | null;
+  callerFirstName?: string;
+  onVerified: () => void;
+}
+
+type VerifyStatus =
+  | { kind: 'idle' }
+  | { kind: 'verifying' }
+  | { kind: 'error'; message: string };
+
+type ResendStatus =
+  | { kind: 'idle' }
+  | { kind: 'sending' }
+  | { kind: 'cooldown'; secondsRemaining: number }
+  | { kind: 'capReached' };
+
+const COOLDOWN_SECONDS = 60;
+const SUCCESS_COPY_FADE_MS = 5000;
+
+function maskRecipient(value: string | null): string {
+  if (!value) return 'the email we have on file';
+  const at = value.indexOf('@');
+  if (at < 2) return value;
+  const local = value.slice(0, at);
+  const domain = value.slice(at);
+  const masked = local[0] + '*'.repeat(Math.max(1, local.length - 2)) + local.slice(-1);
+  return masked + domain;
+}
+
+export function FirstCallPinGate({
+  callerId,
+  recipient,
+  callerFirstName,
+  onVerified,
+}: FirstCallPinGateProps) {
+  const [pin, setPin] = useState('');
+  const [verifyStatus, setVerifyStatus] = useState<VerifyStatus>({ kind: 'idle' });
+  const [resendStatus, setResendStatus] = useState<ResendStatus>({ kind: 'idle' });
+  const [successCopyVisible, setSuccessCopyVisible] = useState(false);
+  const [isLocked, setIsLocked] = useState(false);
+  const cooldownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const successFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current) clearInterval(cooldownTimerRef.current);
+      if (successFadeRef.current) clearTimeout(successFadeRef.current);
+    };
+  }, []);
+
+  function startCooldown(seconds: number) {
+    setResendStatus({ kind: 'cooldown', secondsRemaining: seconds });
+    if (cooldownTimerRef.current) clearInterval(cooldownTimerRef.current);
+    cooldownTimerRef.current = setInterval(() => {
+      setResendStatus((prev) => {
+        if (prev.kind !== 'cooldown') return prev;
+        const next = prev.secondsRemaining - 1;
+        if (next <= 0) {
+          if (cooldownTimerRef.current) clearInterval(cooldownTimerRef.current);
+          return { kind: 'idle' };
+        }
+        return { kind: 'cooldown', secondsRemaining: next };
+      });
+    }, 1000);
+  }
+
+  function showSuccessCopy() {
+    setSuccessCopyVisible(true);
+    if (successFadeRef.current) clearTimeout(successFadeRef.current);
+    successFadeRef.current = setTimeout(() => {
+      setSuccessCopyVisible(false);
+    }, SUCCESS_COPY_FADE_MS);
+  }
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault();
+    if (verifyStatus.kind === 'verifying' || isLocked) return;
+    if (!/^\d{6}$/.test(pin)) {
+      setVerifyStatus({ kind: 'error', message: 'Enter the 6-digit code from your email.' });
+      return;
+    }
+    setVerifyStatus({ kind: 'verifying' });
+    try {
+      const res = await fetch('/api/identity/verify-pin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ callerId, pin }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        onVerified();
+        return;
+      }
+      if (data.locked) {
+        setIsLocked(true);
+        setVerifyStatus({
+          kind: 'error',
+          message:
+            'Your code entry is locked for 24 hours. Requesting a new code won’t unlock it — please contact your teacher.',
+        });
+        return;
+      }
+      if (data.expired) {
+        setVerifyStatus({
+          kind: 'error',
+          message: 'This code has expired. Click Resend below for a fresh one.',
+        });
+        return;
+      }
+      if (data.noActiveChallenge) {
+        setVerifyStatus({
+          kind: 'error',
+          message: 'No code is waiting for you. Click Resend to get a new one.',
+        });
+        return;
+      }
+      const remaining = typeof data.attemptsRemaining === 'number'
+        ? data.attemptsRemaining
+        : null;
+      setVerifyStatus({
+        kind: 'error',
+        message:
+          remaining !== null
+            ? `That code didn’t match. ${remaining} ${remaining === 1 ? 'try' : 'tries'} left.`
+            : 'That code didn’t match.',
+      });
+    } catch {
+      setVerifyStatus({
+        kind: 'error',
+        message: 'Couldn’t reach the server. Try again in a moment.',
+      });
+    }
+  }
+
+  async function handleResend() {
+    if (resendStatus.kind !== 'idle') return;
+    setResendStatus({ kind: 'sending' });
+    try {
+      const res = await fetch('/api/identity/resend-pin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ callerId }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        showSuccessCopy();
+        startCooldown(COOLDOWN_SECONDS);
+        setVerifyStatus({ kind: 'idle' });
+        setPin('');
+        return;
+      }
+      if (data.resendCapReached) {
+        setResendStatus({ kind: 'capReached' });
+        return;
+      }
+      if (typeof data.cooldownSecondsRemaining === 'number') {
+        startCooldown(data.cooldownSecondsRemaining);
+        return;
+      }
+      setResendStatus({ kind: 'idle' });
+    } catch {
+      setResendStatus({ kind: 'idle' });
+    }
+  }
+
+  const verifying = verifyStatus.kind === 'verifying';
+  const resendDisabled = resendStatus.kind !== 'idle' || isLocked;
+  const resendLabel = (() => {
+    switch (resendStatus.kind) {
+      case 'sending':
+        return 'Sending…';
+      case 'cooldown':
+        return `Resend in ${resendStatus.secondsRemaining}s`;
+      case 'capReached':
+        return 'Resend unavailable';
+      default:
+        return 'Resend code';
+    }
+  })();
+
+  return (
+    <div
+      className="wa-chat-bg"
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 380,
+          background: 'var(--bg-surface, #fff)',
+          border: '1px solid var(--border-default, #e4e4e7)',
+          borderRadius: 12,
+          padding: 24,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
+        }}
+      >
+        <h1 style={{ fontSize: 20, fontWeight: 600, margin: '0 0 8px' }}>
+          {callerFirstName ? `Welcome, ${callerFirstName}` : 'Enter your sign-in code'}
+        </h1>
+        <p style={{ fontSize: 14, color: 'var(--text-muted)', margin: '0 0 20px' }}>
+          {`We sent a 6-digit code to ${maskRecipient(recipient)}. Enter it to start your first call.`}
+        </p>
+
+        <form onSubmit={handleVerify} noValidate>
+          <label
+            htmlFor="pin-input"
+            style={{ display: 'block', fontSize: 13, fontWeight: 500, marginBottom: 6 }}
+          >
+            6-digit code
+          </label>
+          <input
+            id="pin-input"
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={6}
+            value={pin}
+            onChange={(e) => setPin(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            disabled={verifying || isLocked}
+            style={{
+              width: '100%',
+              padding: '12px 14px',
+              fontSize: 22,
+              letterSpacing: 8,
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+              textAlign: 'center',
+              border: '1px solid var(--border-default, #d4d4d8)',
+              borderRadius: 8,
+              marginBottom: 16,
+              boxSizing: 'border-box',
+            }}
+          />
+
+          <button
+            type="submit"
+            disabled={verifying || isLocked || pin.length !== 6}
+            className="hf-btn-primary"
+            style={{ width: '100%', padding: '12px 16px', fontSize: 15 }}
+          >
+            {verifying ? 'Verifying…' : 'Verify code'}
+          </button>
+        </form>
+
+        {verifyStatus.kind === 'error' && (
+          <p
+            style={{
+              marginTop: 12,
+              fontSize: 13,
+              color: 'var(--text-danger, #b91c1c)',
+              lineHeight: 1.4,
+            }}
+          >
+            {verifyStatus.message}
+          </p>
+        )}
+
+        <div
+          style={{
+            marginTop: 20,
+            paddingTop: 16,
+            borderTop: '1px solid var(--border-default, #e4e4e7)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            minHeight: 32,
+          }}
+        >
+          <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>
+            {successCopyVisible
+              ? 'New code sent — check your email'
+              : resendStatus.kind === 'capReached'
+                ? 'We’ve sent the code 3 times today. If you didn’t receive it, the email on file may be wrong — contact your teacher.'
+                : 'Didn’t get the email?'}
+          </span>
+          <button
+            type="button"
+            onClick={handleResend}
+            disabled={resendDisabled}
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              fontSize: 13,
+              color: resendDisabled
+                ? 'var(--text-muted, #71717a)'
+                : 'var(--text-link, #2563eb)',
+              cursor: resendDisabled ? 'default' : 'pointer',
+              fontWeight: 500,
+            }}
+          >
+            {resendLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/lib/config.ts
+++ b/apps/admin/lib/config.ts
@@ -120,6 +120,28 @@ export const config = {
       const origins = process.env.CORS_ALLOWED_ORIGINS;
       return origins ? origins.split(",").map((o) => o.trim()).filter(Boolean) : [];
     },
+    /**
+     * Identity PIN settings (#1101 — first-call continuity attestation).
+     * All env-overridable so test environments can shorten TTLs.
+     */
+    identityPin: {
+      /** PIN TTL in hours (default 24) — after this, verify returns expired:true. */
+      get ttlHours(): number {
+        return optionalInt("IDENTITY_PIN_TTL_HOURS", 24);
+      },
+      /** Max wrong attempts in 24h before lockout (default 5). */
+      get maxAttempts(): number {
+        return optionalInt("IDENTITY_PIN_MAX_ATTEMPTS", 5);
+      },
+      /** Max resends in 24h, not counting the initial issuance (default 3). */
+      get maxResendsPer24h(): number {
+        return optionalInt("IDENTITY_PIN_MAX_RESENDS", 3);
+      },
+      /** Minimum seconds between resend requests (default 60). */
+      get resendCooldownSeconds(): number {
+        return optionalInt("IDENTITY_PIN_RESEND_COOLDOWN_SECONDS", 60);
+      },
+    },
   },
 
   // ---------------------------------------------------------------------------

--- a/apps/admin/lib/email.ts
+++ b/apps/admin/lib/email.ts
@@ -133,6 +133,67 @@ export async function sendInviteEmail({
   });
 }
 
+// ── Identity PIN email (#1101 — first-call continuity attestation) ──────
+
+interface SendIdentityPinEmailParams {
+  to: string;
+  firstName?: string;
+  pin: string;
+  callerSimUrl: string;
+  isResend?: boolean;
+}
+
+/**
+ * Email the learner their first-call PIN. Reuses the shared transporter and
+ * renderEmailHtml. PIN is rendered as a prominent code block in the body and
+ * also surfaced in the subject-line-adjacent space; the button takes the
+ * learner to /x/sim/[callerId] where they enter it.
+ *
+ * Subject differs on resend so a learner's inbox makes the new code obvious
+ * when there are multiple in a thread.
+ */
+export async function sendIdentityPinEmail({
+  to,
+  firstName,
+  pin,
+  callerSimUrl,
+  isResend = false,
+}: SendIdentityPinEmailParams) {
+  const fromAddress = process.env.EMAIL_FROM || EMAIL_FROM_DEFAULT;
+  const greeting = firstName ? `Hi ${firstName},` : "Hi there,";
+  const heading = isResend ? "Your new sign-in code" : "Your sign-in code";
+  const subject = isResend
+    ? `Your new sign-in code: ${pin}`
+    : `Your sign-in code: ${pin}`;
+
+  const pinDisplay = `<div style="font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 32px; letter-spacing: 8px; font-weight: 700; text-align: center; padding: 24px; margin: 16px 0; background: #f4f4f5; border-radius: 8px; color: #18181b;">${pin}</div>`;
+
+  const bodyHtml = [
+    `<p style="font-size: 16px; margin: 0 0 16px;">${greeting}</p>`,
+    `<p style="font-size: 16px; margin: 0 0 16px;">Enter this code on the page below to start your first call. It expires in 24 hours.</p>`,
+    pinDisplay,
+    `<p style="font-size: 14px; color: #71717a; margin: 16px 0 0;">If you didn't request this code, you can safely ignore this email.</p>`,
+  ].join("\n");
+
+  const html = renderEmailHtml({
+    heading,
+    bodyHtml,
+    buttonText: "Enter your code",
+    buttonUrl: callerSimUrl,
+    footer: "This code lets us confirm it's really you on your first call.",
+  });
+
+  const text = `${greeting}\n\nYour sign-in code is: ${pin}\n\nIt expires in 24 hours. Enter it here: ${callerSimUrl}\n\nIf you didn't request this code, you can safely ignore this email.`;
+
+  await transporter.sendMail({
+    from: fromAddress,
+    to,
+    subject,
+    text,
+    html,
+  });
+}
+
 // ── Password reset email ────────────────────────────────────
 
 interface SendPasswordResetEmailParams {

--- a/apps/admin/lib/identity/issue-pin.ts
+++ b/apps/admin/lib/identity/issue-pin.ts
@@ -1,0 +1,70 @@
+import { prisma } from "@/lib/prisma";
+import { config } from "@/lib/config";
+import { sendIdentityPinEmail } from "@/lib/email";
+import { generatePin, hashPin } from "./pin";
+
+interface IssuePinParams {
+  callerId: string;
+  email: string;
+  firstName?: string;
+  isResend?: boolean;
+}
+
+/**
+ * Issue a fresh first-call PIN for a caller. Creates a CallerIdentityChallenge
+ * row, then best-effort emails the PIN. Email failure is logged but does NOT
+ * throw — callers (the join route) must not roll back Caller creation if SMTP
+ * is down. (#1101 TL review.)
+ *
+ * When `isResend` is true, increments `resendCount` on the new challenge row
+ * and uses the resend subject-line variant in the email. The cap query at
+ * /api/identity/resend-pin uses `resendCount > 0` to ignore initial issuance.
+ */
+export async function issueFirstCallPin({
+  callerId,
+  email,
+  firstName,
+  isResend = false,
+}: IssuePinParams): Promise<{ challengeId: string }> {
+  const pin = generatePin();
+  const pinHash = await hashPin(pin);
+
+  const ttlMs = config.security.identityPin.ttlHours * 60 * 60 * 1000;
+  const issuedAt = new Date();
+  const expiresAt = new Date(issuedAt.getTime() + ttlMs);
+
+  const challenge = await prisma.callerIdentityChallenge.create({
+    data: {
+      callerId,
+      pinHash,
+      channel: "email",
+      recipient: email,
+      issuedAt,
+      expiresAt,
+      resendCount: isResend ? 1 : 0,
+      lastResentAt: isResend ? issuedAt : null,
+    },
+    select: { id: true },
+  });
+
+  const callerSimUrl = `${config.app.url}/x/sim/${callerId}`;
+
+  try {
+    await sendIdentityPinEmail({
+      to: email,
+      firstName,
+      pin,
+      callerSimUrl,
+      isResend,
+    });
+  } catch (err) {
+    // Best-effort: SMTP failure must not break enrolment. Log and move on;
+    // the learner can request a resend if they don't receive the email.
+    console.error(
+      `[identity-pin] failed to send PIN email for caller ${callerId}`,
+      err,
+    );
+  }
+
+  return { challengeId: challenge.id };
+}

--- a/apps/admin/lib/identity/pin.ts
+++ b/apps/admin/lib/identity/pin.ts
@@ -1,0 +1,27 @@
+import { randomInt } from "node:crypto";
+import bcrypt from "bcryptjs";
+
+const PIN_LENGTH = 6;
+const BCRYPT_ROUNDS = 10;
+
+/**
+ * Generate a 6-digit numeric PIN using a CSPRNG.
+ * Range: 000000–999999, zero-padded. Never returns a value shorter than 6 chars.
+ */
+export function generatePin(): string {
+  return String(randomInt(0, 1_000_000)).padStart(PIN_LENGTH, "0");
+}
+
+/** Hash a PIN for storage. Matches the auth module's bcryptjs choice. */
+export async function hashPin(pin: string): Promise<string> {
+  return bcrypt.hash(pin, BCRYPT_ROUNDS);
+}
+
+/**
+ * Verify a candidate PIN against a stored hash. Constant-time via bcrypt.compare
+ * so timing does not leak whether the PIN was correct (relied upon by the
+ * expired-PIN flow at /api/identity/verify-pin).
+ */
+export async function verifyPinHash(pin: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(pin, hash);
+}

--- a/apps/admin/prisma/migrations/20260605162259_caller_identity_challenge/migration.sql
+++ b/apps/admin/prisma/migrations/20260605162259_caller_identity_challenge/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+CREATE TABLE "CallerIdentityChallenge" (
+    "id" TEXT NOT NULL,
+    "callerId" TEXT NOT NULL,
+    "pinHash" TEXT NOT NULL,
+    "channel" TEXT NOT NULL DEFAULT 'email',
+    "recipient" TEXT NOT NULL,
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "verifiedAt" TIMESTAMP(3),
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "lockedAt" TIMESTAMP(3),
+    "resendCount" INTEGER NOT NULL DEFAULT 0,
+    "lastResentAt" TIMESTAMP(3),
+
+    CONSTRAINT "CallerIdentityChallenge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CallerIdentityChallenge_callerId_issuedAt_idx" ON "CallerIdentityChallenge"("callerId", "issuedAt");
+
+-- CreateIndex
+CREATE INDEX "CallerIdentityChallenge_callerId_verifiedAt_idx" ON "CallerIdentityChallenge"("callerId", "verifiedAt");
+
+-- AddForeignKey
+ALTER TABLE "CallerIdentityChallenge" ADD CONSTRAINT "CallerIdentityChallenge_callerId_fkey" FOREIGN KEY ("callerId") REFERENCES "Caller"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- #1101 — Backfill existing LEARNER Callers as verified so they don't hit the
+-- PIN gate on their next sim visit. Each Caller gets a single pre-verified
+-- challenge row with verifiedAt = NOW(). pinHash is a marker that cannot
+-- match a real bcrypt result, so verify-pin would never accept it; expiresAt
+-- is NOW() so it's also already expired. These rows exist solely to satisfy
+-- the challenge-status query's `verifiedAt IS NULL` check — they're seen as
+-- "already verified" and the gate stays closed for legacy callers.
+INSERT INTO "CallerIdentityChallenge" (
+    "id", "callerId", "pinHash", "channel", "recipient",
+    "issuedAt", "expiresAt", "verifiedAt", "attemptCount", "resendCount"
+)
+SELECT
+    gen_random_uuid()::text,
+    c."id",
+    'backfill-not-a-bcrypt-hash',
+    'email',
+    COALESCE(c."email", ''),
+    NOW(),
+    NOW(),
+    NOW(),
+    0,
+    0
+FROM "Caller" c
+WHERE c."role" = 'LEARNER';

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -907,6 +907,9 @@ model Caller {
   // CallerIdentities (phone numbers, etc.) linked to this caller
   callerIdentities CallerIdentity[]
 
+  // First-call PIN identity challenges (#1101 — continuity attestation)
+  identityChallenges CallerIdentityChallenge[]
+
   // AI-composed prompts for this caller
   composedPrompts ComposedPrompt[]
 
@@ -3223,6 +3226,47 @@ model CallerIdentity {
   @@index([callerId])
   @@index([externalId])
   @@index([segmentId])
+}
+
+// =========================
+// CALLER IDENTITY CHALLENGE (#1101 — continuity attestation, slice 1)
+// =========================
+// One row per PIN challenge issued to a learner. Created at enrolment
+// (initial issuance, resendCount = 0). Resends increment resendCount and
+// invalidate prior unverified challenges for the same caller. Verification
+// stamps verifiedAt; lockout stamps lockedAt after 5 failed attempts in a
+// 24h window. See .claude/rules/ai-to-db-guard.md and issue #1101.
+model CallerIdentityChallenge {
+  id       String @id @default(uuid())
+  callerId String
+  caller   Caller @relation(fields: [callerId], references: [id], onDelete: Cascade)
+
+  // PIN material — hashed (bcrypt). Plaintext never stored.
+  pinHash String
+
+  // Delivery channel — "email" today; "sms" stubbed for slice 2.
+  channel   String   @default("email")
+  recipient String // email address or phone number used at issuance
+
+  // Issuance + lifecycle timestamps
+  issuedAt  DateTime  @default(now())
+  expiresAt DateTime // issuedAt + 24h (configurable via lib/config.ts)
+
+  // Verification
+  verifiedAt DateTime? // null = unverified
+
+  // Failed-attempt tracking — 5 in any 24h window triggers lockout
+  attemptCount Int       @default(0)
+  lockedAt     DateTime? // admin unlock clears both lockedAt AND attemptCount
+
+  // Resend audit — initial issuance has resendCount = 0; each resend
+  // increments and updates lastResentAt. Cap query at /api/identity/resend-pin
+  // counts rows with resendCount > 0 in the last 24h (max 3).
+  resendCount  Int       @default(0)
+  lastResentAt DateTime?
+
+  @@index([callerId, issuedAt])
+  @@index([callerId, verifiedAt])
 }
 
 // =========================

--- a/apps/admin/scripts/unlock-identity-challenge.ts
+++ b/apps/admin/scripts/unlock-identity-challenge.ts
@@ -1,0 +1,63 @@
+/**
+ * Admin unlock for a learner locked out of the first-call PIN gate (#1101).
+ *
+ * Usage:
+ *   npx tsx scripts/unlock-identity-challenge.ts <callerId>
+ *
+ * Clears BOTH `lockedAt` AND `attemptCount` on every CallerIdentityChallenge
+ * row issued in the last 24h for the caller. Clearing only lockedAt would
+ * leave attemptCount at the cap, so the next wrong attempt would re-lock
+ * immediately (TL review fix).
+ *
+ * Use this when a learner contacted their teacher to say they're locked out
+ * of their first call. The next PIN they receive (via /api/identity/resend-pin
+ * or a fresh enrolment) will be verifiable from a clean state.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+async function main() {
+  const callerId = process.argv[2];
+  if (!callerId) {
+    console.error("Usage: tsx scripts/unlock-identity-challenge.ts <callerId>");
+    process.exit(1);
+  }
+
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { id: true, name: true, email: true },
+  });
+  if (!caller) {
+    console.error(`No Caller found with id ${callerId}`);
+    process.exit(1);
+  }
+
+  const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  const result = await prisma.callerIdentityChallenge.updateMany({
+    where: {
+      callerId,
+      issuedAt: { gte: windowStart },
+    },
+    data: {
+      lockedAt: null,
+      attemptCount: 0,
+    },
+  });
+
+  console.log(
+    `Unlocked ${result.count} challenge row(s) in the last 24h for caller ${caller.name ?? callerId} (${caller.email ?? "no email"}).`,
+  );
+  console.log(
+    "The learner can now re-enter their last PIN, or request a fresh one from the gate.",
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/admin/tests/api/identity-resend-pin.test.ts
+++ b/apps/admin/tests/api/identity-resend-pin.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for POST /api/identity/resend-pin (#1101).
+ *
+ * Covers:
+ *   - Success path (within cap, no cooldown) → ok: true
+ *   - Resend cap reached → { resendCapReached: true }
+ *     ★ critical: count query MUST filter resendCount > 0 so initial
+ *       enrolment issuance doesn't eat a slot (TL review fix)
+ *   - Cooldown active → { cooldownSecondsRemaining: number }
+ *   - No active caller / no email on file → { noActiveCaller: true }
+ *   - STUDENT-scope: foreign callerId is locked to own caller
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  caller: { findUnique: vi.fn() },
+  callerIdentityChallenge: {
+    count: vi.fn(),
+    findFirst: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
+
+const mockRequireAuth = vi.fn();
+const mockIsAuthError = vi.fn();
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...a: unknown[]) => mockRequireAuth(...a),
+  isAuthError: (...a: unknown[]) => mockIsAuthError(...a),
+}));
+
+const mockResolveScope = vi.fn();
+const mockIsScopeError = vi.fn();
+vi.mock("@/lib/learner-scope", () => ({
+  resolveCallerScopeForReading: (...a: unknown[]) => mockResolveScope(...a),
+  isScopeError: (...a: unknown[]) => mockIsScopeError(...a),
+}));
+
+const mockIssueFirstCallPin = vi.fn();
+vi.mock("@/lib/identity/issue-pin", () => ({
+  issueFirstCallPin: (...a: unknown[]) => mockIssueFirstCallPin(...a),
+}));
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/identity/resend-pin", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/identity/resend-pin", () => {
+  let POST: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "u-1", email: "l@example.com", role: "STUDENT" } },
+    });
+    mockIsAuthError.mockReturnValue(false);
+    mockResolveScope.mockResolvedValue({ scopedCallerId: "caller-own" });
+    mockIsScopeError.mockReturnValue(false);
+    mockPrisma.caller.findUnique.mockResolvedValue({
+      email: "learner@example.com",
+      name: "Test Learner",
+    });
+    mockIssueFirstCallPin.mockResolvedValue({ challengeId: "ch-new" });
+    const mod = await import("@/app/api/identity/resend-pin/route");
+    POST = mod.POST;
+  });
+
+  it("issues a resend when under cap and outside cooldown", async () => {
+    mockPrisma.callerIdentityChallenge.count.mockResolvedValue(1);
+    mockPrisma.callerIdentityChallenge.findFirst.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ callerId: "caller-own" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: true });
+    expect(mockIssueFirstCallPin).toHaveBeenCalledWith({
+      callerId: "caller-own",
+      email: "learner@example.com",
+      firstName: "Test",
+      isResend: true,
+    });
+  });
+
+  it("cap query filters resendCount > 0 (excludes initial issuance)", async () => {
+    mockPrisma.callerIdentityChallenge.count.mockResolvedValue(0);
+    mockPrisma.callerIdentityChallenge.findFirst.mockResolvedValue(null);
+
+    await POST(makeRequest({ callerId: "caller-own" }));
+
+    const countCall = mockPrisma.callerIdentityChallenge.count.mock.calls[0][0];
+    expect(countCall.where.resendCount).toEqual({ gt: 0 });
+    expect(countCall.where.callerId).toBe("caller-own");
+    expect(countCall.where.issuedAt.gte).toBeInstanceOf(Date);
+  });
+
+  it("returns resendCapReached when 3 resends already used in 24h", async () => {
+    mockPrisma.callerIdentityChallenge.count.mockResolvedValue(3);
+
+    const res = await POST(makeRequest({ callerId: "caller-own" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: false, resendCapReached: true });
+    expect(mockIssueFirstCallPin).not.toHaveBeenCalled();
+  });
+
+  it("returns cooldownSecondsRemaining when a recent resend is within the cooldown window", async () => {
+    mockPrisma.callerIdentityChallenge.count.mockResolvedValue(1);
+    mockPrisma.callerIdentityChallenge.findFirst.mockResolvedValue({
+      issuedAt: new Date(Date.now() - 20_000), // 20s ago
+    });
+
+    const res = await POST(makeRequest({ callerId: "caller-own" }));
+    const body = await res.json();
+
+    expect(body.ok).toBe(false);
+    expect(body.cooldownSecondsRemaining).toBeGreaterThan(0);
+    expect(body.cooldownSecondsRemaining).toBeLessThanOrEqual(60);
+    expect(mockIssueFirstCallPin).not.toHaveBeenCalled();
+  });
+
+  it("returns noActiveCaller when caller has no email on file", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ email: null, name: "X" });
+
+    const res = await POST(makeRequest({ callerId: "caller-own" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: false, noActiveCaller: true });
+    expect(mockIssueFirstCallPin).not.toHaveBeenCalled();
+  });
+
+  it("STUDENT-scope: foreign callerId in body is replaced by own caller before any DB read", async () => {
+    mockResolveScope.mockResolvedValue({ scopedCallerId: "caller-own" });
+    mockPrisma.callerIdentityChallenge.count.mockResolvedValue(0);
+    mockPrisma.callerIdentityChallenge.findFirst.mockResolvedValue(null);
+
+    await POST(makeRequest({ callerId: "caller-VICTIM" }));
+
+    expect(mockPrisma.caller.findUnique).toHaveBeenCalledWith({
+      where: { id: "caller-own" },
+      select: expect.any(Object),
+    });
+    if (mockIssueFirstCallPin.mock.calls.length > 0) {
+      expect(mockIssueFirstCallPin.mock.calls[0][0].callerId).toBe("caller-own");
+    }
+  });
+
+  it("returns 400 when body is malformed", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/admin/tests/api/identity-verify-pin.test.ts
+++ b/apps/admin/tests/api/identity-verify-pin.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for POST /api/identity/verify-pin (#1101).
+ *
+ * Covers:
+ *   - Success path (match + valid)
+ *   - Match + expired → { expired: true } and attemptCount NOT incremented
+ *   - Wrong PIN → attemptsRemaining decremented; ≥ maxAttempts → locked
+ *   - Pre-existing lockout in 24h window short-circuits before hash check
+ *   - No active challenge → { noActiveChallenge: true }
+ *   - STUDENT-scope: body callerId is ignored; resolves to own caller
+ *   - Body validation: 400 on missing/short PIN
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+const mockPrisma = {
+  callerIdentityChallenge: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    aggregate: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma, db: (tx?: unknown) => tx ?? mockPrisma }));
+
+const mockRequireAuth = vi.fn();
+const mockIsAuthError = vi.fn();
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...a: unknown[]) => mockRequireAuth(...a),
+  isAuthError: (...a: unknown[]) => mockIsAuthError(...a),
+}));
+
+const mockResolveScope = vi.fn();
+const mockIsScopeError = vi.fn();
+vi.mock("@/lib/learner-scope", () => ({
+  resolveCallerScopeForReading: (...a: unknown[]) => mockResolveScope(...a),
+  isScopeError: (...a: unknown[]) => mockIsScopeError(...a),
+}));
+
+const mockVerifyPinHash = vi.fn();
+vi.mock("@/lib/identity/pin", () => ({
+  verifyPinHash: (...a: unknown[]) => mockVerifyPinHash(...a),
+}));
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/identity/verify-pin", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function activeChallenge(overrides: Partial<{
+  id: string;
+  pinHash: string;
+  expiresAt: Date;
+  attemptCount: number;
+}> = {}) {
+  return {
+    id: "challenge-1",
+    pinHash: "bcrypt-hash",
+    expiresAt: new Date(Date.now() + 3600_000),
+    attemptCount: 0,
+    ...overrides,
+  };
+}
+
+describe("POST /api/identity/verify-pin", () => {
+  let POST: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({
+      session: { user: { id: "u-1", email: "l@example.com", role: "STUDENT" } },
+    });
+    mockIsAuthError.mockReturnValue(false);
+    mockResolveScope.mockResolvedValue({ scopedCallerId: "caller-own" });
+    mockIsScopeError.mockReturnValue(false);
+    const mod = await import("@/app/api/identity/verify-pin/route");
+    POST = mod.POST;
+  });
+
+  it("returns ok: true when the PIN matches and challenge is not expired", async () => {
+    mockPrisma.callerIdentityChallenge.findFirst
+      .mockResolvedValueOnce(null) // lockout probe
+      .mockResolvedValueOnce(activeChallenge()); // active challenge fetch
+    mockVerifyPinHash.mockResolvedValue(true);
+    mockPrisma.callerIdentityChallenge.update.mockResolvedValue({});
+
+    const res = await POST(makeRequest({ callerId: "caller-own", pin: "123456" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: true });
+    expect(mockPrisma.callerIdentityChallenge.update).toHaveBeenCalledWith({
+      where: { id: "challenge-1" },
+      data: { verifiedAt: expect.any(Date) },
+    });
+  });
+
+  it("returns { expired: true } without incrementing attemptCount when PIN matches an expired challenge", async () => {
+    mockPrisma.callerIdentityChallenge.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        activeChallenge({ expiresAt: new Date(Date.now() - 1000) }),
+      );
+    mockVerifyPinHash.mockResolvedValue(true);
+
+    const res = await POST(makeRequest({ callerId: "caller-own", pin: "123456" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: false, expired: true });
+    expect(mockPrisma.callerIdentityChallenge.update).not.toHaveBeenCalled();
+  });
+
+  it("decrements attemptsRemaining on wrong PIN", async () => {
+    mockPrisma.callerIdentityChallenge.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(activeChallenge({ attemptCount: 1 }));
+    mockVerifyPinHash.mockResolvedValue(false);
+    mockPrisma.callerIdentityChallenge.update.mockResolvedValue({});
+    mockPrisma.callerIdentityChallenge.aggregate.mockResolvedValue({
+      _sum: { attemptCount: 2 },
+    });
+
+    const res = await POST(makeRequest({ callerId: "caller-own", pin: "000000" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: false, attemptsRemaining: 3 });
+    // first update is attemptCount++; lockedAt update only fires at threshold
+    expect(mockPrisma.callerIdentityChallenge.update).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.callerIdentityChallenge.update).toHaveBeenCalledWith({
+      where: { id: "challenge-1" },
+      data: { attemptCount: { increment: 1 } },
+    });
+  });
+
+  it("locks the caller when 24h aggregate attempts reaches maxAttempts", async () => {
+    mockPrisma.callerIdentityChallenge.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(activeChallenge({ attemptCount: 4 }));
+    mockVerifyPinHash.mockResolvedValue(false);
+    mockPrisma.callerIdentityChallenge.update.mockResolvedValue({});
+    mockPrisma.callerIdentityChallenge.aggregate.mockResolvedValue({
+      _sum: { attemptCount: 5 },
+    });
+
+    const res = await POST(makeRequest({ callerId: "caller-own", pin: "000000" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: false, locked: true });
+    // both updates: attemptCount++ and lockedAt=NOW
+    expect(mockPrisma.callerIdentityChallenge.update).toHaveBeenCalledTimes(2);
+    const setLockCall = mockPrisma.callerIdentityChallenge.update.mock.calls[1][0];
+    expect(setLockCall.data.lockedAt).toBeInstanceOf(Date);
+  });
+
+  it("short-circuits to locked when a 24h-window challenge is already lockedAt", async () => {
+    mockPrisma.callerIdentityChallenge.findFirst.mockResolvedValueOnce({
+      id: "locked-row",
+    });
+
+    const res = await POST(makeRequest({ callerId: "caller-own", pin: "123456" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: false, locked: true });
+    expect(mockVerifyPinHash).not.toHaveBeenCalled();
+    expect(mockPrisma.callerIdentityChallenge.update).not.toHaveBeenCalled();
+  });
+
+  it("returns noActiveChallenge when caller has no unverified challenge", async () => {
+    mockPrisma.callerIdentityChallenge.findFirst
+      .mockResolvedValueOnce(null) // lockout probe
+      .mockResolvedValueOnce(null); // active challenge fetch
+
+    const res = await POST(makeRequest({ callerId: "caller-own", pin: "123456" }));
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: false, noActiveChallenge: true });
+  });
+
+  it("STUDENT-scope: a foreign callerId in the body is replaced by the session's own caller", async () => {
+    mockResolveScope.mockResolvedValue({ scopedCallerId: "caller-own" });
+    mockPrisma.callerIdentityChallenge.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(activeChallenge());
+    mockVerifyPinHash.mockResolvedValue(true);
+    mockPrisma.callerIdentityChallenge.update.mockResolvedValue({});
+
+    await POST(makeRequest({ callerId: "caller-VICTIM", pin: "123456" }));
+
+    // every prisma query must use the resolved own-caller id, never the body one
+    const findFirstCalls = mockPrisma.callerIdentityChallenge.findFirst.mock.calls;
+    for (const call of findFirstCalls) {
+      expect(call[0].where.callerId).toBe("caller-own");
+    }
+  });
+
+  it("returns scope-error response when resolveCallerScopeForReading errors", async () => {
+    const errorResponse = NextResponse.json(
+      { ok: false, error: "No learner profile found" },
+      { status: 403 },
+    );
+    mockResolveScope.mockResolvedValue({ error: errorResponse });
+    mockIsScopeError.mockReturnValue(true);
+
+    const res = await POST(makeRequest({ callerId: "caller-1", pin: "123456" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when body is missing or malformed", async () => {
+    const res1 = await POST(makeRequest({ callerId: "caller-own" })); // no pin
+    expect(res1.status).toBe(400);
+    const res2 = await POST(makeRequest({ callerId: "caller-own", pin: "abc" }));
+    expect(res2.status).toBe(400);
+    const res3 = await POST(makeRequest({ callerId: "caller-own", pin: "12345" }));
+    expect(res3.status).toBe(400);
+  });
+});

--- a/apps/admin/tests/lib/identity-pin.test.ts
+++ b/apps/admin/tests/lib/identity-pin.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for lib/identity/pin.ts — PIN generation + hash/verify primitives
+ * used by the first-call PIN gate (#1101).
+ *
+ * Properties under test:
+ *   - generatePin yields a 6-digit zero-padded string
+ *   - distinct calls yield distinct values (probabilistic — CSPRNG sanity)
+ *   - hashPin output is not the plaintext and is stable enough to verify
+ *   - verifyPinHash is constant-time-shaped (bcrypt) — match/miss both
+ *     return a boolean, never throw
+ */
+
+import { describe, it, expect } from "vitest";
+import { generatePin, hashPin, verifyPinHash } from "@/lib/identity/pin";
+
+describe("lib/identity/pin", () => {
+  describe("generatePin", () => {
+    it("returns a 6-character string of digits", () => {
+      for (let i = 0; i < 50; i++) {
+        const pin = generatePin();
+        expect(pin).toHaveLength(6);
+        expect(pin).toMatch(/^\d{6}$/);
+      }
+    });
+
+    it("zero-pads values below 100000", () => {
+      // Sample many; eventually one will start with a 0 if randomInt's range
+      // is correct (000000-999999). This is a sanity check that we cover the
+      // whole range — not a strict guarantee.
+      const samples = Array.from({ length: 200 }, () => generatePin());
+      const hasZeroPrefix = samples.some((s) => s[0] === "0");
+      // ~20% of 200 samples should start with 0; if none, padding is broken.
+      expect(hasZeroPrefix).toBe(true);
+    });
+
+    it("yields distinct values across calls (CSPRNG sanity)", () => {
+      const samples = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        samples.add(generatePin());
+      }
+      // 50 draws from 1M space — collisions essentially impossible (<0.2%)
+      expect(samples.size).toBeGreaterThanOrEqual(49);
+    });
+  });
+
+  describe("hashPin + verifyPinHash", () => {
+    it("hash is not the plaintext PIN", async () => {
+      const pin = "482931";
+      const hash = await hashPin(pin);
+      expect(hash).not.toBe(pin);
+      expect(hash).not.toContain(pin);
+      expect(hash.length).toBeGreaterThan(40); // bcrypt hashes are 60 chars
+    });
+
+    it("verifyPinHash returns true for the correct PIN", async () => {
+      const pin = "123456";
+      const hash = await hashPin(pin);
+      await expect(verifyPinHash(pin, hash)).resolves.toBe(true);
+    });
+
+    it("verifyPinHash returns false for a wrong PIN", async () => {
+      const hash = await hashPin("123456");
+      await expect(verifyPinHash("000000", hash)).resolves.toBe(false);
+      await expect(verifyPinHash("123457", hash)).resolves.toBe(false);
+    });
+
+    it("two hashes of the same PIN differ (per-hash salt)", async () => {
+      const pin = "999999";
+      const a = await hashPin(pin);
+      const b = await hashPin(pin);
+      expect(a).not.toBe(b);
+      // both still verify
+      await expect(verifyPinHash(pin, a)).resolves.toBe(true);
+      await expect(verifyPinHash(pin, b)).resolves.toBe(true);
+    });
+  });
+});

--- a/apps/admin/tests/scripts/unlock-identity-challenge.test.ts
+++ b/apps/admin/tests/scripts/unlock-identity-challenge.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for scripts/unlock-identity-challenge.ts (#1101).
+ *
+ * The TL review flagged: admin unlock must clear BOTH `lockedAt` AND
+ * `attemptCount`. Clearing only lockedAt leaves attemptCount at the cap,
+ * so the next wrong attempt re-locks immediately.
+ *
+ * This test verifies that property at the updateMany call site by importing
+ * the script's main logic with mocked Prisma + argv.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockPrisma = {
+  caller: { findUnique: vi.fn() },
+  callerIdentityChallenge: { updateMany: vi.fn() },
+  $disconnect: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+describe("scripts/unlock-identity-challenge", () => {
+  let originalArgv: string[];
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    originalArgv = process.argv;
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it("clears BOTH lockedAt AND attemptCount on the 24h-window rows", async () => {
+    process.argv = ["node", "script", "caller-1"];
+    mockPrisma.caller.findUnique.mockResolvedValue({
+      id: "caller-1",
+      name: "Test Learner",
+      email: "l@example.com",
+    });
+    mockPrisma.callerIdentityChallenge.updateMany.mockResolvedValue({ count: 2 });
+
+    await import("@/scripts/unlock-identity-challenge");
+    // Allow main() microtasks to flush
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockPrisma.callerIdentityChallenge.updateMany).toHaveBeenCalledTimes(1);
+    const call = mockPrisma.callerIdentityChallenge.updateMany.mock.calls[0][0];
+    expect(call.where.callerId).toBe("caller-1");
+    expect(call.where.issuedAt.gte).toBeInstanceOf(Date);
+    // ★ critical: BOTH fields cleared, not just lockedAt
+    expect(call.data).toEqual({ lockedAt: null, attemptCount: 0 });
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unlocked 2 challenge row(s)"),
+    );
+  });
+
+  it("exits non-zero when no callerId is supplied", async () => {
+    process.argv = ["node", "script"];
+
+    await expect(import("@/scripts/unlock-identity-challenge")).rejects.toThrow(
+      /process.exit\(1\)/,
+    );
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Usage:"),
+    );
+  });
+
+  it("exits non-zero when caller does not exist", async () => {
+    process.argv = ["node", "script", "missing"];
+    mockPrisma.caller.findUnique.mockResolvedValue(null);
+
+    await expect(import("@/scripts/unlock-identity-challenge")).rejects.toThrow(
+      /process.exit\(1\)/,
+    );
+    expect(mockPrisma.callerIdentityChallenge.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9862,6 +9862,23 @@ Unlink a subject from this domain (deletes SubjectDomain join row)
 
 ---
 
+### `GET` /api/identity/challenge-status
+
+Whether the learner has an outstanding first-call PIN challenge
+
+**Auth**: session (STUDENT+)
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | query | string | No |  |
+
+**Response** `200`
+```json
+{ ok: true, needsPin: boolean, locked: boolean, recipient: string | null }
+```
+
+---
+
 ### `POST` /api/identity/resend-pin
 
 Re-issue a first-call PIN to the caller's on-file email. Caps
@@ -15080,8 +15097,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 483 |
-| Files with annotations | 474 |
+| Route files found | 484 |
+| Files with annotations | 475 |
 | Files missing annotations | 9 |
 | Coverage | 98.1% |
 

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9862,6 +9862,77 @@ Unlink a subject from this domain (deletes SubjectDomain join row)
 
 ---
 
+### `POST` /api/identity/resend-pin
+
+Re-issue a first-call PIN to the caller's on-file email. Caps
+
+**Auth**: session (STUDENT+)
+
+**Response** `200`
+```json
+{ ok: true } — fresh PIN sent
+```
+
+**Response** `200`
+```json
+{ ok: false, resendCapReached: true } — 3 resends already today
+```
+
+**Response** `200`
+```json
+{ ok: false, cooldownSecondsRemaining: number } — within 60s window
+```
+
+**Response** `200`
+```json
+{ ok: false, noActiveCaller: true } — caller has no email on file
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string } — invalid body
+```
+
+---
+
+### `POST` /api/identity/verify-pin
+
+Verify a learner's first-call PIN. STUDENT sessions are locked
+
+**Auth**: session (STUDENT+)
+
+**Response** `200`
+```json
+{ ok: true } — PIN correct, challenge marked verified
+```
+
+**Response** `200`
+```json
+{ ok: false, expired: true } — PIN matched but past TTL; does NOT count toward lockout
+```
+
+**Response** `200`
+```json
+{ ok: false, locked: true } — caller is in 24h lockout window
+```
+
+**Response** `200`
+```json
+{ ok: false, attemptsRemaining: number } — wrong PIN
+```
+
+**Response** `200`
+```json
+{ ok: false, noActiveChallenge: true } — no challenge to verify (request resend)
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string } — invalid body
+```
+
+---
+
 ### `GET` /api/institution/branding
 
 Get branding for the current user's institution.
@@ -13021,29 +13092,6 @@ Mark onboarding as complete for a caller.
 
 ---
 
-### `GET` /api/student/qualification-progress
-
-Returns the learner's progress against their active qualification —
-
-**Auth**: Session · **Scope**: `progress:read`
-
-**Response** `200`
-```json
-{ ok: true, qualification: Qualification | null, units: Unit[],
-```
-
-**Response** `401`
-```json
-{ ok: false, error: "Unauthorized" }
-```
-
-**Response** `404`
-```json
-{ ok: false, error: "no active enrollment" }
-```
-
----
-
 ### `GET` /api/student/survey-config
 
 **Auth**: STUDENT | OPERATOR+ (with callerId param)
@@ -15032,8 +15080,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 482 |
-| Files with annotations | 473 |
+| Route files found | 483 |
+| Files with annotations | 474 |
 | Files missing annotations | 9 |
 | Coverage | 98.1% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -3323,6 +3323,77 @@ Returns the most recent COURSE_REFERENCE markdown document
 
 ---
 
+### `POST` /api/v1/identity/resend-pin
+
+Re-issue a first-call PIN to the caller's on-file email. Caps
+
+**Auth**: session (STUDENT+)
+
+**Response** `200`
+```json
+{ ok: true } — fresh PIN sent
+```
+
+**Response** `200`
+```json
+{ ok: false, resendCapReached: true } — 3 resends already today
+```
+
+**Response** `200`
+```json
+{ ok: false, cooldownSecondsRemaining: number } — within 60s window
+```
+
+**Response** `200`
+```json
+{ ok: false, noActiveCaller: true } — caller has no email on file
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string } — invalid body
+```
+
+---
+
+### `POST` /api/v1/identity/verify-pin
+
+Verify a learner's first-call PIN. STUDENT sessions are locked
+
+**Auth**: session (STUDENT+)
+
+**Response** `200`
+```json
+{ ok: true } — PIN correct, challenge marked verified
+```
+
+**Response** `200`
+```json
+{ ok: false, expired: true } — PIN matched but past TTL; does NOT count toward lockout
+```
+
+**Response** `200`
+```json
+{ ok: false, locked: true } — caller is in 24h lockout window
+```
+
+**Response** `200`
+```json
+{ ok: false, attemptsRemaining: number } — wrong PIN
+```
+
+**Response** `200`
+```json
+{ ok: false, noActiveChallenge: true } — no challenge to verify (request resend)
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string } — invalid body
+```
+
+---
+
 ### `GET` /api/v1/join/[token]
 
 Verify a classroom/community join token. Returns group info if valid.

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -3323,6 +3323,23 @@ Returns the most recent COURSE_REFERENCE markdown document
 
 ---
 
+### `GET` /api/v1/identity/challenge-status
+
+Whether the learner has an outstanding first-call PIN challenge
+
+**Auth**: session (STUDENT+)
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | query | string | No |  |
+
+**Response** `200`
+```json
+{ ok: true, needsPin: boolean, locked: boolean, recipient: string | null }
+```
+
+---
+
 ### `POST` /api/v1/identity/resend-pin
 
 Re-issue a first-call PIN to the caller's on-file email. Caps


### PR DESCRIPTION
## Summary
- New `CallerIdentityChallenge` table — one row per PIN issuance; `resendCount` distinguishes initial from resend (TL fix)
- `/api/identity/verify-pin` + `/api/identity/resend-pin` + `/api/identity/challenge-status` — STUDENT-scope guarded (locks to own caller, can't probe foreign callerIds)
- `FirstCallPinGate` component — three-state Resend button (idle → in-flight → 60s cooldown), inline success copy, distinct messages for expired / locked / cap-reached
- PIN issued at `/api/join/[token]` AFTER Caller create, OUTSIDE the `$transaction` so SMTP failure doesn't roll back enrolment
- Lockout aggregates failed attempts across the caller's 24h window — resend doesn't reset the counter
- Admin unlock CLI (`scripts/unlock-identity-challenge.ts`) clears BOTH `lockedAt` AND `attemptCount` (regression-tested)
- Migration generated via the workaround in #1112; backfilled 57 existing LEARNERs as pre-verified so they don't get gated retroactively
- Tests: PIN util + verify-pin (8 branches) + resend-pin (cap query filter, cooldown, STUDENT-scope) + unlock script (both-fields-cleared)

## Out of scope (later slices)
- Voiceprint capture from VAPI recordings
- IDENTITY signal in EXTRACT → SUPERVISE
- TallySeal biometric disclosure
- SMS channel (stubbed `NotImplementedError`)
- Anti-spoof / clone detection
- Calls 2+ identity matching

## Test plan
- [x] Migration applied to hf_sandbox via the #1112 workaround
- [x] Backfill: 57 verified rows = 57 LEARNER callers
- [x] Vitest coverage in place
- [ ] Smoke-test the gate end-to-end on hf-dev (new learner via /join/[token] → email PIN → gate → verify → chat)
- [ ] QA + guard-checker + standards-checker agents per CLAUDE.md DoD

Closes #1101