### PR TITLE
polish(student): #1098 Slice D — ux-reviewer + ui-reviewer fixes

### DIFF
--- a/apps/admin/app/x/student/progress/page.tsx
+++ b/apps/admin/app/x/student/progress/page.tsx
@@ -212,10 +212,28 @@ function StudentProgressContent() {
 
       {/* #1098 Slice B — Qualification dashboard. Renders only when the learner's
           active Curriculum has a qualificationAnchor (the card returns null
-          otherwise so non-qualification learners see the existing page unchanged). */}
-      {qualification.data?.qualification && (
+          otherwise so non-qualification learners see the existing page unchanged).
+          Slice D — explicit error+retry surface so the card doesn't silently
+          disappear on hook failure (ux-reviewer #1). */}
+      {qualification.error ? (
+        <div
+          role="alert"
+          className="hf-qualification-error"
+        >
+          <p className="hf-qualification-error-message">
+            Couldn&apos;t load your qualification progress.
+          </p>
+          <button
+            type="button"
+            onClick={() => qualification.refetch()}
+            className="hf-qualification-error-retry"
+          >
+            Try again
+          </button>
+        </div>
+      ) : qualification.data?.qualification ? (
         <QualificationCard data={qualification.data} />
-      )}
+      ) : null}
 
       {/* Stats */}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-8">

--- a/apps/admin/components/callers/caller-detail/caller-detail-v2/lenses/QualificationLens.tsx
+++ b/apps/admin/components/callers/caller-detail/caller-detail-v2/lenses/QualificationLens.tsx
@@ -58,8 +58,13 @@ export function QualificationLens({ callerId }: Props): React.ReactElement {
 
   if (loading) {
     return (
-      <div className="hf-progress-v2-lens hf-progress-v2-lens--loading" role="status">
-        Loading qualification progress…
+      <div
+        className="hf-progress-v2-lens hf-progress-v2-lens--loading"
+        role="status"
+        aria-live="polite"
+      >
+        <div className="hf-spinner" aria-hidden="true" />
+        <span>Loading qualification progress…</span>
       </div>
     );
   }

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -1354,16 +1354,20 @@ export function SimChat({
           </div>
         )}
 
+        {/* #1098 Slice C — Qualification readiness recap after the call settles.
+            Slice D — moved ABOVE PostCallProgressCard per ux-reviewer #3: the
+            qualification summary directly answers "how did that session move the
+            needle on my certification?", which is the higher-signal item at the
+            attention peak post-call. The generic progress card sits below as
+            secondary context. Renders only when the learner's active Curriculum
+            has a qualificationAnchor; silent otherwise. Refetches inside so the
+            AGGREGATE rollup for the just-ended call is reflected. */}
+        {callPhase === 'ended' && <QualificationSessionSummary />}
+
         {/* Post-call learning progress card */}
         {callPhase === 'ended' && (
           <PostCallProgressCard callerId={callerId} />
         )}
-
-        {/* #1098 Slice C — Qualification readiness recap after the call settles.
-            Renders only when the learner's active Curriculum has a qualificationAnchor;
-            silent otherwise. Refetches inside so the AGGREGATE rollup for the
-            just-ended call is reflected. */}
-        {callPhase === 'ended' && <QualificationSessionSummary />}
 
         {/* Post-call content — artifacts & actions from pipeline */}
         {(artifacts.length > 0 || actions.length > 0) && (

--- a/apps/admin/components/student/qualification/QualificationCard.tsx
+++ b/apps/admin/components/student/qualification/QualificationCard.tsx
@@ -71,7 +71,11 @@ export function QualificationCard({
       />
 
       {!hideNextBestStep && nextBestStep && (
-        <NextBestStepCTA next={nextBestStep} onStartCall={onStartCall} />
+        <NextBestStepCTA
+          next={nextBestStep}
+          units={units}
+          onStartCall={onStartCall}
+        />
       )}
 
       {isColdStart && (
@@ -129,7 +133,7 @@ function QualificationHeader({
         )}
         <p className="hf-qualification-readiness">
           {isColdStart ? (
-            <span className="hf-qualification-readiness--cold">Not yet assessed</span>
+            <span className="hf-qualification-readiness--cold">Ready to start</span>
           ) : (
             <>
               <span className="hf-qualification-tier-pill">{tierLabel}</span>
@@ -157,22 +161,32 @@ function QualificationHeader({
 
 function NextBestStepCTA({
   next,
+  units,
   onStartCall,
 }: {
   next: NonNullable<QualificationProgressData["nextBestStep"]>;
+  units: readonly QualificationProgressUnit[];
   onStartCall?: (next: NonNullable<QualificationProgressData["nextBestStep"]>) => void;
 }): React.ReactElement {
   const href = `/x/sim?requestedModuleId=${encodeURIComponent(next.moduleSlug)}`;
+  // Resolve the unit's display name + the focus LO's plain-language name from
+  // the catalog so the CTA never surfaces a raw slug or ref to the learner.
+  const unit = units.find((u) => u.moduleSlug === next.moduleSlug) ?? null;
+  const unitDisplay = unit?.displayName ?? next.moduleSlug;
+  const focusLo = next.loRef
+    ? unit?.learningObjectives.find((lo) => lo.ref === next.loRef) ?? null
+    : null;
+  const focusLoDisplay = focusLo?.displayName ?? next.loRef;
   return (
     <div className="hf-qualification-cta" role="region" aria-label="Next best step">
       <div className="hf-qualification-cta-body">
         <p className="hf-qualification-cta-headline">
-          ▶ {next.courseType} on {next.moduleSlug}
+          ▶ {next.courseType} on {unitDisplay}
         </p>
         <p className="hf-qualification-cta-reason">{next.reason}</p>
-        {next.loRef && (
+        {focusLoDisplay && (
           <p className="hf-qualification-cta-focus">
-            Focus: <code>{next.loRef}</code>
+            Focus: <span className="hf-qualification-cta-focus-name">{focusLoDisplay}</span>
           </p>
         )}
       </div>
@@ -182,11 +196,11 @@ function NextBestStepCTA({
           className="hf-qualification-cta-button"
           onClick={() => onStartCall(next)}
         >
-          Start call →
+          Practise this unit →
         </button>
       ) : (
         <Link href={href} className="hf-qualification-cta-button">
-          Start call →
+          Practise this unit →
         </Link>
       )}
     </div>

--- a/apps/admin/components/student/qualification/qualification-card.css
+++ b/apps/admin/components/student/qualification/qualification-card.css
@@ -88,6 +88,37 @@
   color: var(--text-secondary, #374151);
 }
 
+/* Error / retry surface — Slice D */
+.hf-qualification-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  margin: 16px 0;
+  background: color-mix(in srgb, var(--status-error-text, #b91c1c) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--status-error-text, #b91c1c) 30%, transparent);
+  border-radius: 8px;
+}
+.hf-qualification-error-message {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-primary, #111827);
+}
+.hf-qualification-error-retry {
+  padding: 8px 14px;
+  background: var(--surface-primary, #ffffff);
+  border: 1px solid var(--border-primary, #e5e7eb);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary, #111827);
+  cursor: pointer;
+}
+.hf-qualification-error-retry:hover {
+  border-color: var(--accent-primary, #6366f1);
+}
+
 /* -- Next Best Step CTA -------------------------------------------------- */
 
 .hf-qualification-cta {
@@ -120,12 +151,9 @@
   color: var(--text-muted, #6b7280);
   margin: 4px 0 0;
 }
-.hf-qualification-cta-focus code {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  background: color-mix(in srgb, var(--text-primary, #111827) 8%, transparent);
-  padding: 1px 4px;
-  border-radius: 3px;
-  font-size: 11px;
+.hf-qualification-cta-focus-name {
+  font-weight: 600;
+  color: var(--text-primary, #111827);
 }
 .hf-qualification-cta-button {
   flex-shrink: 0;

--- a/apps/admin/tests/components/QualificationCard.test.tsx
+++ b/apps/admin/tests/components/QualificationCard.test.tsx
@@ -132,10 +132,14 @@ describe("QualificationCard — #1098 Slice B", () => {
   });
 
   it("expands the weakest Unit by default + highlights weakest LO", () => {
-    const { container, getByText } = render(<QualificationCard data={makeFixture()} />);
-    // standard-unit-09 is weakest → its LO list rendered.
-    expect(getByText("Define enterprise model")).toBeDefined();
-    expect(getByText("Map business capabilities")).toBeDefined();
+    const { container } = render(<QualificationCard data={makeFixture()} />);
+    // standard-unit-09 is weakest → its LO list rendered. Scope to the LO
+    // list region because Slice D's CTA now also surfaces the LO display
+    // name "Map business capabilities" in the focus line.
+    const loList = container.querySelector(".hf-qualification-lo-list");
+    expect(loList).not.toBeNull();
+    expect(loList!.textContent).toContain("Define enterprise model");
+    expect(loList!.textContent).toContain("Map business capabilities");
     // Weakest LO row carries the weakest modifier class.
     const weakestRow = container.querySelector(".hf-qualification-lo-row--weakest");
     expect(weakestRow).not.toBeNull();

--- a/apps/admin/tests/components/QualificationCard.test.tsx
+++ b/apps/admin/tests/components/QualificationCard.test.tsx
@@ -114,7 +114,9 @@ describe("QualificationCard — #1098 Slice B", () => {
       },
     });
     const { getByText } = render(<QualificationCard data={data} />);
-    expect(getByText("Not yet assessed")).toBeDefined();
+    // Slice D — softened from "Not yet assessed" to "Ready to start" in the
+    // header per ux-reviewer advisory B. Cold-start banner text unchanged.
+    expect(getByText("Ready to start")).toBeDefined();
     expect(getByText(/Take your first call/)).toBeDefined();
   });
 
@@ -161,26 +163,34 @@ describe("QualificationCard — #1098 Slice B", () => {
     ]);
   });
 
-  it("renders Next Best Step CTA by default with reason + focus LO", () => {
-    const { getByText, getByRole, container } = render(
+  it("Slice D — CTA renders Unit DISPLAY NAME (not slug) + LO DISPLAY NAME (not ref)", () => {
+    // ux-reviewer #2: the CTA must never expose a raw slug or ref. The
+    // CTA pulls Unit + LO display names from the units catalog.
+    const { getByText, getByRole, container, queryByText } = render(
       <QualificationCard data={makeFixture()} />,
     );
-    expect(getByText(/Revision Aid on standard-unit-09/)).toBeDefined();
-    expect(getByText("weakest LO in your weakest Unit")).toBeDefined();
-    // OUT-09-02 also appears in the LO list (it's the weakest LO of the
-    // expanded unit) — scope to the CTA region.
+    // Unit display name: "Enterprise and Business Architecture", NOT "standard-unit-09"
+    expect(getByText(/Revision Aid on Enterprise and Business Architecture/)).toBeDefined();
+    // CTA region carries the LO display name ("Map business capabilities" from fixture).
     const ctaRegion = container.querySelector('[aria-label="Next best step"]');
     expect(ctaRegion).not.toBeNull();
-    expect(ctaRegion!.textContent).toContain("OUT-09-02");
-    const cta = getByRole("link", { name: /Start call/ });
+    expect(ctaRegion!.textContent).toContain("Map business capabilities");
+    // The raw slug must NOT appear in the CTA region.
+    expect(ctaRegion!.textContent).not.toContain("standard-unit-09");
+    // Reason still rendered.
+    expect(getByText("weakest LO in your weakest Unit")).toBeDefined();
+    // Slice D — CTA button copy changed from "Start call →" to "Practise this unit →".
+    const cta = getByRole("link", { name: /Practise this unit/ });
     expect(cta.getAttribute("href")).toContain("standard-unit-09");
+    // No raw ref text inside <code> any more.
+    expect(queryByText("OUT-09-02", { selector: "code" })).toBeNull();
   });
 
   it("hides Next Best Step CTA when hideNextBestStep is true (educator lens mode)", () => {
     const { queryByText } = render(
       <QualificationCard data={makeFixture()} hideNextBestStep />,
     );
-    expect(queryByText("Start call →")).toBeNull();
+    expect(queryByText("Practise this unit →")).toBeNull();
     expect(queryByText("weakest LO in your weakest Unit")).toBeNull();
   });
 
@@ -189,7 +199,7 @@ describe("QualificationCard — #1098 Slice B", () => {
     const { getByRole } = render(
       <QualificationCard data={makeFixture()} onStartCall={handler} />,
     );
-    fireEvent.click(getByRole("button", { name: /Start call/ }));
+    fireEvent.click(getByRole("button", { name: /Practise this unit/ }));
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(makeFixture().nextBestStep);
   });


### PR DESCRIPTION
## Summary

Polish pass over Slices B + C in response to the ui-reviewer + ux-reviewer agent reports.

**Critical (UX)**
- **#1** — `/x/student/progress` now renders an error + Try-again surface when the qualification hook fails. Previously the card silently returned null on hook error; the educator lens already had this pattern, replicated to the learner page.
- **#2** — Next Best Step CTA never exposes a raw `moduleSlug` or `loRef`. Now resolves Unit `displayName` from `units` and the LO `displayName` from the unit's `learningObjectives`. Drops the `<code>` wrap on the LO ref in favour of a plain bold span.

**Advisory (high value)**
- **#3 (ordering)** — `QualificationSessionSummary` moved ABOVE `PostCallProgressCard` in SimChat. The qualification answer ("how did this session move my certification?") is the higher-signal item at the post-call attention peak.
- **B (microcopy)** — Header cold-start label softened from "Not yet assessed" → "Ready to start". The cold-start banner paragraph stays.
- **E (microcopy)** — CTA button: "Start call →" → "Practise this unit →". Specific + frames action as purposeful practice.

**UI consistency**
- `QualificationLens` loading state uses `hf-spinner` + `aria-live="polite"` instead of plain text.

## Test plan

- [x] 22 component tests (test for new CTA display-name resolution, cold-start string, button copy, weakest-LO scoped to LO list region)
- [ ] Manual smoke: trigger an API failure (`/api/student/qualification-progress` returns 500) → error/retry surface renders
- [ ] Manual smoke: open `/x/student/progress` as CIO/CTO learner → CTA reads "Revision Aid on Enterprise and Business Architecture", focus shows LO name (not "OUT-09-05")
- [ ] Manual smoke: complete a SIM call → `QualificationSessionSummary` renders ABOVE `PostCallProgressCard`

Closes #1098 fully — Slices A + B + C + D shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)