### PR TITLE
fix(#1101): PIN email URL from request origin + gate fail-closed on session race

### DIFF
--- a/apps/admin/app/api/identity/resend-pin/route.ts
+++ b/apps/admin/app/api/identity/resend-pin/route.ts
@@ -101,11 +101,14 @@ export async function POST(req: Request) {
   }
 
   const firstName = caller.name?.trim().split(/\s+/)[0];
+  // originUrl from the resend request so the new PIN email's button URL
+  // matches where the learner is sitting (same hotfix as the join route).
   await issueFirstCallPin({
     callerId,
     email: caller.email,
     firstName,
     isResend: true,
+    originUrl: new URL(req.url).origin,
   });
 
   return NextResponse.json({ ok: true });

--- a/apps/admin/app/api/join/[token]/route.ts
+++ b/apps/admin/app/api/join/[token]/route.ts
@@ -296,10 +296,14 @@ export async function POST(
 
     // Issue first-call PIN (#1101). Best-effort — SMTP failure won't roll
     // back the Caller; the learner can request a resend on the sim page.
+    // originUrl ensures the email's button URL matches the env the learner
+    // enrolled in (localhost vs Cloud Run dev vs prod) — hotfix for the
+    // localhost-enrolment → dev.humanfirstfoundation.com link mismatch.
     await issueFirstCallPin({
       callerId: newCaller.id,
       email: email.trim().toLowerCase(),
       firstName: firstName.trim(),
+      originUrl: request.nextUrl.origin,
     });
 
     const existingResponse = NextResponse.json({
@@ -388,10 +392,13 @@ export async function POST(
 
   // Issue first-call PIN (#1101). Outside the transaction by design — SMTP
   // failure must not roll back the user+caller create. TL review note.
+  // originUrl from the actual request so localhost enrollees get a localhost
+  // link, dev.humanfirstfoundation.com enrollees get a dev link, etc.
   await issueFirstCallPin({
     callerId: result.newCallerId,
     email: email.trim().toLowerCase(),
     firstName: firstName.trim(),
+    originUrl: request.nextUrl.origin,
   });
 
   const response = NextResponse.json({

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -30,7 +30,7 @@ export default function SimConversationPage() {
   const router = useRouter();
   const { callerId } = useParams<{ callerId: string }>();
   const searchParams = useSearchParams();
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const { isDesktop } = useResponsive();
   const isStudent = session?.user?.role === 'STUDENT';
   const sessionGoal = searchParams.get('goal') || undefined;
@@ -181,16 +181,34 @@ export default function SimConversationPage() {
 
   // #1101 — fetch challenge status once we know the session role. Skip for
   // OPERATOR+ so admin browsing of a learner's sim page is unaffected.
+  // HOTFIX: previously gated on `isStudent` while session was still loading,
+  // which set pinGateStatus='verified' eagerly. Now wait for the session to
+  // RESOLVE before deciding (status === 'loading' → stay in 'loading'); also
+  // fail CLOSED on non-JSON / non-ok responses (was: silently treat as
+  // verified, which masked auth middleware 307 redirects).
   useEffect(() => {
+    if (sessionStatus === 'loading') return; // wait — don't pre-decide
     if (!isStudent) {
       setPinGateStatus('verified');
       return;
     }
     let cancelled = false;
     fetch(`/api/identity/challenge-status?callerId=${encodeURIComponent(callerId)}`)
-      .then((r) => r.json())
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`status ${r.status}`);
+        const ct = r.headers.get('content-type') ?? '';
+        if (!ct.includes('application/json')) throw new Error(`non-JSON: ${ct}`);
+        return r.json();
+      })
       .then((data) => {
-        if (cancelled || !data?.ok) return;
+        if (cancelled) return;
+        if (!data?.ok) {
+          // Server replied but not in the expected shape — gate fail-closed
+          // so we never silently let a real learner skip the PIN.
+          setPinGateRecipient(null);
+          setPinGateStatus('needsPin');
+          return;
+        }
         if (data.needsPin) {
           setPinGateRecipient(data.recipient ?? null);
           setPinGateStatus('needsPin');
@@ -198,13 +216,18 @@ export default function SimConversationPage() {
           setPinGateStatus('verified');
         }
       })
-      .catch(() => {
-        if (!cancelled) setPinGateStatus('verified');
+      .catch((err) => {
+        if (cancelled) return;
+        // Network/redirect/parse failure — fail CLOSED. Better to show a PIN
+        // gate the learner can't bypass than silently let them past.
+        console.warn('[pin-gate] challenge-status fetch failed:', err);
+        setPinGateRecipient(null);
+        setPinGateStatus('needsPin');
       });
     return () => {
       cancelled = true;
     };
-  }, [callerId, isStudent]);
+  }, [callerId, isStudent, sessionStatus]);
 
   const handleStudentCallEnd = useCallback(() => {
     if (isStudent) {

--- a/apps/admin/lib/identity/issue-pin.ts
+++ b/apps/admin/lib/identity/issue-pin.ts
@@ -8,6 +8,14 @@ interface IssuePinParams {
   email: string;
   firstName?: string;
   isResend?: boolean;
+  /**
+   * Base URL (scheme + host + port) the learner is currently on — the email's
+   * "Enter your code" button is built from this so the link lands on the same
+   * environment they enrolled in. Callers (the join route + resend route)
+   * derive this from `request.nextUrl.origin`. Falls back to
+   * `config.app.url` when not supplied (server-to-server callers).
+   */
+  originUrl?: string;
 }
 
 /**
@@ -25,6 +33,7 @@ export async function issueFirstCallPin({
   email,
   firstName,
   isResend = false,
+  originUrl,
 }: IssuePinParams): Promise<{ challengeId: string }> {
   const pin = generatePin();
   const pinHash = await hashPin(pin);
@@ -47,7 +56,12 @@ export async function issueFirstCallPin({
     select: { id: true },
   });
 
-  const callerSimUrl = `${config.app.url}/x/sim/${callerId}`;
+  // Use the request's origin when supplied so the email link lands on the
+  // same environment the learner enrolled in (localhost vs Cloud Run dev vs
+  // prod). #1101 hotfix: previously hardcoded to config.app.url which sent
+  // localhost enrollees to dev.humanfirstfoundation.com with no session.
+  const baseUrl = originUrl ?? config.app.url;
+  const callerSimUrl = `${baseUrl}/x/sim/${callerId}`;
 
   try {
     await sendIdentityPinEmail({


### PR DESCRIPTION
## Summary

Two hotfixes for bugs found while smoke-testing #1101 end-to-end:

1. **Email link points to wrong env** — `issueFirstCallPin` now takes `originUrl` (`request.nextUrl.origin`), so a learner enrolling on localhost gets a localhost link, not `dev.humanfirstfoundation.com`. Falls back to `config.app.url` for server-to-server callers.
2. **Gate skipped during session-loading race** — the page set `pinGateStatus = 'verified'` while `useSession()` was still loading, and the subsequent fetch silently failed on 307-to-login HTML responses. Now waits for `sessionStatus !== 'loading'` and fails CLOSED (gates) on non-JSON or `!r.ok` responses.

Bugs intentionally NOT fixed here (separate issues):
- Join form prefers `session.user.email` over URL `?email=` param (Admin auto-fill overrides intake snapshot)
- Tallyseal projection → HF join handoff is URL string-cat with no integrity check

## Test plan
- [x] Vitest still green on existing identity tests
- [ ] Live smoke: enroll fresh learner on localhost via SSH tunnel → email link should be `http://localhost:3000/x/sim/[id]` → opening it (same browser session) should show the PIN gate, not the chat
- [ ] Live smoke: same flow on `dev.humanfirstfoundation.com` → email link should be that domain

Refs #1101