### PR TITLE
feat(intake): capture phone number during enrolment (optional)

### DIFF
--- a/apps/admin/app/join/[token]/page.tsx
+++ b/apps/admin/app/join/[token]/page.tsx
@@ -110,6 +110,7 @@ export default function JoinPage() {
           lastName,
           email,
           ...(searchParams.get("ageRange") ? { ageRange: searchParams.get("ageRange") } : {}),
+          ...(searchParams.get("phone")?.trim() ? { phone: searchParams.get("phone") } : {}),
           ...(searchParams.get("course") ? { playbookId: searchParams.get("course") } : {}),
           ...(searchParams.get("skipOnboarding") === "true" ? { skipOnboarding: true } : {}),
         }),

--- a/apps/admin/components/intake/IntakeDoneClient.tsx
+++ b/apps/admin/components/intake/IntakeDoneClient.tsx
@@ -24,6 +24,7 @@ const VALUES_DISPLAY: ReadonlyArray<readonly [string, string]> = [
   ["firstName", "First name"],
   ["lastName", "Last name"],
   ["email", "Email"],
+  ["phone", "Phone"],
   ["displayName", "Display name"],
   ["timezone", "Timezone"],
   ["preferredContactMethod", "Preferred contact"],
@@ -127,6 +128,7 @@ function buildContinueUrl(token: string, values: Readonly<Record<string, unknown
   const lastName = values.lastName;
   const email = values.email;
   const ageRange = values.ageRange;
+  const phone = values.phone;
   if (typeof firstName === "string") params.set("firstName", firstName);
   if (typeof lastName === "string") params.set("lastName", lastName);
   if (typeof email === "string") params.set("email", email);
@@ -135,6 +137,13 @@ function buildContinueUrl(token: string, values: Readonly<Record<string, unknown
   // `ageBand.adultOnly()` at intake, so this should never be present
   // as that value, but the route handler defends against URL tampering.
   if (typeof ageRange === "string") params.set("ageRange", ageRange);
+  // phone — optional in the intake spec. When supplied, the join route
+  // normalises (strip spaces / dashes / parens) and writes Caller.phone,
+  // which unblocks Call Me sessions without the mid-call JIT capture
+  // and is a prerequisite for the SMS slice of #1101.
+  if (typeof phone === "string" && phone.trim().length > 0) {
+    params.set("phone", phone.trim());
+  }
   const qs = params.toString();
   return `/join/${encodeURIComponent(token)}${qs ? `?${qs}` : ""}`;
 }

--- a/apps/admin/lib/intake/specs/enrollment.intent.ts
+++ b/apps/admin/lib/intake/specs/enrollment.intent.ts
@@ -60,6 +60,13 @@ export const INTERNAL_FIELDS = [
 // validation happens server-side via deliverability check (deferred).
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// E.164-ish phone pattern — optional `+`, 7–15 digits. The join route
+// already strips spaces/dashes/parens via the same normalisation as
+// `/api/join/[token]:140-143`, so the pattern here is the post-strip
+// shape. Permissive on purpose; deliverability check is deferred to
+// the SMS provider when slice B of #1101 lands.
+const PHONE_PATTERN = /^\+?\d{7,15}$/;
+
 // ── Spec ───────────────────────────────────────────────────────────
 export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
   key: INTAKE_KEY,
@@ -88,6 +95,20 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
       .label({ en: "Email" })
       .askHint({ en: "What email should we use for this enrolment?" })
       .validates((v) => typeof v === "string" && EMAIL_PATTERN.test(v)),
+
+    // Optional but actively asked — phone enables Call Me sessions (PSTN
+    // outbound dial from the sim) without the mid-call JIT capture, and
+    // is a prerequisite for the SMS channel of #1101 (first-call PIN by
+    // SMS, currently stubbed). Skipping is fine — Call Me falls back to
+    // the JIT prompt and PIN still delivers by email.
+    phone: field
+      .string()
+      .optional()
+      .label({ en: "Phone number" })
+      .askHint({
+        en: "What's a good phone number for Call Me sessions? Optional — leave blank if you don't want SMS or phone calls.",
+      })
+      .validates((v) => typeof v !== "string" || PHONE_PATTERN.test(v.replace(/[\s\-()]/g, ""))),
 
     // ── Optional — one per distinct shape ─────────────────────────
     displayName: field
@@ -202,6 +223,19 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
         predicate: ({ value }) => {
           const e = value<string>("email");
           return e === undefined || EMAIL_PATTERN.test(e);
+        },
+      }),
+
+      // 4a. phone format invariant — when phone is supplied, it must
+      //     normalise to a 7–15-digit E.164-ish shape. Same audit chain
+      //     as email; absent phone is permitted (field is optional).
+      defineContract({
+        id: "enrollment.phone.format-valid",
+        description: { en: "Phone field, when supplied, must match basic E.164 pattern after stripping separators." },
+        predicate: ({ value }) => {
+          const p = value<string>("phone");
+          if (p === undefined || p === "") return true;
+          return PHONE_PATTERN.test(p.replace(/[\s\-()]/g, ""));
         },
       }),
 


### PR DESCRIPTION
Adds optional phone field to the Tallyseal intake chat. Propagates Caller.phone → unblocks Call Me without JIT capture + prerequisite for #1101 SMS slice. 3 files, 44 lines. Same audit-chain coverage as email (compliance metadata already declared on spec). See commit body for details.