### PR TITLE
fix(pipeline): #1117 — loadCurrentModuleContext Path 2.5 (first-class CurriculumModule rows)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -362,6 +362,73 @@ async function loadCurrentModuleContext(
     }
   }
 
+  // Path 2.5 (#1117) — first-class CurriculumModule fallback.
+  //
+  // Modern courses (#1034 PlaybookCurriculum + first-class CurriculumModule
+  // rows + first-class LearningObjective rows) don't necessarily cache the
+  // catalog in Playbook.config.modules[] or Curriculum.notableInfo.modules[].
+  // The CIO/CTO Standard family hit this gap: modulesAuthored=true but the
+  // modules[] cache was never populated, so Paths 0b / 1 / 2 all returned null
+  // and per-LO scoring never fired. Read directly from CurriculumModule +
+  // LearningObjective when the JSON caches are absent or empty. This is the
+  // universal fallback that unblocks every Curriculum-anchored course.
+  if (resolvedPlaybookId) {
+    const pbcLink = await prisma.playbookCurriculum.findFirst({
+      where: { playbookId: resolvedPlaybookId },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: { curriculumId: true, curriculum: { select: { slug: true } } },
+    });
+    if (pbcLink?.curriculumId && pbcLink.curriculum?.slug) {
+      const moduleRows = await prisma.curriculumModule.findMany({
+        where: { curriculumId: pbcLink.curriculumId, isActive: true },
+        orderBy: { sortOrder: "asc" },
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          masteryThreshold: true,
+          learningObjectives: {
+            where: { learnerVisible: true },
+            orderBy: { sortOrder: "asc" },
+            select: { ref: true },
+          },
+        },
+      });
+      if (moduleRows.length > 0) {
+        const defaultThreshold =
+          (await ContractRegistry.getThresholds("CURRICULUM_PROGRESS_V1"))
+            ?.masteryComplete ?? 0.7;
+        const progress = await getCurriculumProgress(callerId, pbcLink.curriculum.slug);
+        const masteryByModuleKey = new Map(
+          Object.entries(progress.modulesMastery || {}) as [string, number][],
+        );
+        // Pick the first module whose mastery is below the threshold; falls
+        // back to the first authored module when all are above threshold.
+        const next =
+          moduleRows.find((m) => {
+            const masteryKey = m.slug || m.id;
+            const mastery = masteryByModuleKey.get(masteryKey) ?? 0;
+            return mastery < (m.masteryThreshold ?? defaultThreshold);
+          }) ?? moduleRows[0];
+        const refs = next.learningObjectives.map((lo) => lo.ref);
+        log.info("#1117 Path 2.5 — module context from first-class CurriculumModule rows", {
+          curriculumSlug: pbcLink.curriculum.slug,
+          moduleSlug: next.slug,
+          loCount: refs.length,
+          availableModules: moduleRows.length,
+        });
+        return {
+          specSlug: pbcLink.curriculum.slug,
+          moduleId: next.slug || next.id,
+          moduleName: next.title || next.slug || next.id,
+          learningOutcomes: refs,
+          masteryThreshold: next.masteryThreshold ?? defaultThreshold,
+          allModuleIds: moduleRows.map((m) => m.slug || m.id),
+        };
+      }
+    }
+  }
+
   // Path 3: Domain-wide Subject curriculum fallback (legacy)
   const caller = await prisma.caller.findUnique({
     where: { id: callerId },


### PR DESCRIPTION
## Summary

Follow-on to #1123. Live-fire test against Emma's Standard call surfaced that `loadCurrentModuleContext`'s three existing paths (0b, 1, 2) all read JSON caches (`Playbook.config.modules[]`, spec `config.modules[]`, `Curriculum.notableInfo.modules[]`). None read first-class `CurriculumModule + LearningObjective` rows.

The CIO/CTO Standard family hits this exactly: `modulesAuthored=true` but `modules[]` cache empty → all 3 paths return null → universal LO scoring never opens.

Path 2.5 reads first-class rows when JSON caches fail. Slots between Path 2 and the legacy Subject fallback so existing IELTS/authored-cache paths still win.

## Test plan

- [ ] Trigger pipeline `force=true` on Emma's existing Revision Aid call → confirm `lo_mastery:*` rows now land in CallerAttribute
- [ ] Confirm `unit_readiness:*` + `qualification_readiness:*` rollups follow
- [ ] Non-regression: IELTS Playbook still resolves via Path 0b (authored cache) — Path 2.5 only runs as fallback

Part of #1117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)