### PR TITLE
fix(intake): chat prompt asks for phone after email + bumps prompt version

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -55,29 +55,31 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // claude-opus-4-7 + claude-sonnet-4-6 — keep this list in step with
 // lib/intake/compliance.ts ai.allowedModels.
 const INTAKE_MODEL = "claude-sonnet-4-6";
-const INTAKE_PROMPT_VERSION = "intake/v0.4.0-DRAFT";
+const INTAKE_PROMPT_VERSION = "intake/v0.5.0-DRAFT";
 const INTAKE_MAX_COST_USD = 0.5; // == compliance.ai.costCeilingPerIntent
 
 const UPDATE_SETUP_TOOL: ToolDefinition = specToUpdateSetupTool(EnrollmentIntake, {
   excludeFields: INTERNAL_FIELDS,
 });
 
-const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Politely capture FOUR required values from the learner: first name, last name, age range, and email.
+const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Politely capture FOUR required values from the learner — first name, last name, age range, and email — plus ONE optional value: a phone number for Call Me sessions and SMS reminders.
 
 How to capture:
-- When the learner shares one or more field values — even multiple in a single message — call the \`update-setup\` tool with every value they provided. Pass each value under its field key (firstName / lastName / email / ageRange / displayName / preferredContactMethod / marketingOptIn / accessibilityNote / timezone). Omit fields they did not share.
+- When the learner shares one or more field values — even multiple in a single message — call the \`update-setup\` tool with every value they provided. Pass each value under its field key (firstName / lastName / email / ageRange / phone / displayName / preferredContactMethod / marketingOptIn / accessibilityNote / timezone). Omit fields they did not share.
 - Never invent values. Only capture what the learner explicitly stated.
 - Email must look like X@Y.Z. If it doesn't, do not capture it — ask them to try again.
 - For ageRange, accept ONLY one of these exact values: '18-24' / '25-34' / '35-44' / '45-54' / '55-64' / '65-plus' / 'prefer-not-to-say'. (HumanFirst is adult-only; 'under-18' is not valid and the system will reject it.) If the learner gives a specific age (e.g. "I'm 32"), map it to the right band. If they decline, refuse to say, or ask why, capture 'prefer-not-to-say'.
+- For phone, accept any international format the learner types. Don't normalise — the server strips spaces/dashes/parens before storage. If the learner declines, refuses, or types something like "skip" / "no" / "none" / "n/a" / "rather not", DO NOT capture anything for phone (leave it unset) and move on to confirm.
 
 How to reply (in the same turn as the tool call, when applicable):
 - Be warm, concise, professional. No emoji. No filler.
 - One short sentence per reply.
 - Never describe your own tool-calling reasoning to the learner. Do not say things like "I need to capture X simultaneously" or "I'm mapping Y to band Z" — that is internal scratchpad, never user-facing. Write a normal natural reply, e.g. "Got it — what's your email?"
-- Ask in this STRICT order, one field at a time: firstName → lastName → ageRange → email. (Email is asked LAST because the enrolment commits as soon as all four required values are in.)
+- Ask in this STRICT order, one field at a time: firstName → lastName → ageRange → email → phone. (Phone is asked LAST and is OPTIONAL — the learner may decline.)
 - If a greeting or affirmation ("hi", "ok", "yes") arrives in place of a name, re-prompt for that name. Do not capture greetings.
 - ageRange is REQUIRED. After capturing lastName, your VERY NEXT reply MUST ask for the learner's age range — do NOT ask for email yet. The email question only comes AFTER ageRange has a value (or 'prefer-not-to-say'). If you find yourself about to ask for email and ageRange is still missing, stop and ask for ageRange instead.
-- When all four required fields (firstName, lastName, ageRange, email) are captured, confirm the enrolment is being submitted and that a confirmation email will follow.`;
+- After capturing email, ask for a phone number with explicit OPTIONAL framing. Example: "Last one — and it's optional: a phone number we could use for Call Me sessions and SMS reminders? You can say 'skip' if you'd rather not." Wait for ONE reply; whether they give a number or decline, that's your cue to confirm and commit. Do NOT pester them with a second phone question if they decline.
+- When all four required fields (firstName, lastName, ageRange, email) are captured AND the learner has either provided a phone or declined it, confirm the enrolment is being submitted and that a confirmation email will follow.`;
 
 const AFFIRMATION_RE = /^(hi|hello|hey|yo|ok|okay|sure|yes|yeah|yep|y|n|no|nope|start)\b[!.,? ]*$/i;
 


### PR DESCRIPTION
Follow-up to #1124 — the spec change was a no-op in the chat because SYSTEM_PROMPT is hand-curated. Verified via audit bundle (no phone turn, no phone in snapshot). This patch tells the AI to ask after email, accept declines, only ask once. Bumps prompt version to 0.5.0-DRAFT. Files in commit body. Closes the regression introduced when #1124 didn't touch the prompt.