### PR TITLE
feat(speech-assessment): #1118 voice scoring providers — CRUD + admin UI

### DIFF
--- a/apps/admin/app/api/speech-assessment-providers/[id]/route.ts
+++ b/apps/admin/app/api/speech-assessment-providers/[id]/route.ts
@@ -1,0 +1,271 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { maskCredentials } from "@/lib/voice/mask-credentials";
+import { invalidateSpeechAssessmentProviderCache } from "@/lib/speech-assessment/provider-factory";
+import { SPEECH_ASSESSMENT_ADAPTERS } from "@/lib/speech-assessment/adapter-registry";
+
+export const runtime = "nodejs";
+
+/**
+ * @api GET /api/speech-assessment-providers/[id]
+ * @visibility internal
+ * @scope speech-assessment-providers:read
+ * @auth session ADMIN
+ * @tags voice, scoring, admin
+ * @description Get a single speech assessment provider by id. Credentials
+ *   masked. Response also includes the adapter's `configSchema` +
+ *   `capabilities` (instantiated with empty creds purely to invoke its
+ *   pure introspection methods).
+ * @response 200 { ok: true, provider, configSchema, capabilities }
+ * @response 404 { ok: false, error: "not found" }
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth("ADMIN");
+  if (isAuthError(auth)) return auth.error;
+
+  const { id } = await params;
+  const row = await prisma.speechAssessmentProvider.findUnique({
+    where: { id },
+  });
+  if (!row) {
+    return NextResponse.json(
+      { ok: false, error: "not found" },
+      { status: 404 },
+    );
+  }
+
+  const AdapterCtor = SPEECH_ASSESSMENT_ADAPTERS[row.adapterKey];
+  let configSchema = null;
+  let capabilities = null;
+  if (AdapterCtor) {
+    const probe = new AdapterCtor({}, {});
+    configSchema = probe.getConfigSchema();
+    capabilities = probe.getCapabilities();
+  }
+
+  return NextResponse.json({
+    ok: true,
+    provider: {
+      ...row,
+      credentials: maskCredentials(row.credentials as Record<string, unknown>),
+    },
+    configSchema,
+    capabilities,
+  });
+}
+
+const patchSchema = z.object({
+  displayName: z.string().min(1).max(128).optional(),
+  adapterKey: z.string().min(1).optional(),
+  credentials: z.record(z.string(), z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+  isDefault: z.boolean().optional(),
+  enabled: z.boolean().optional(),
+});
+
+/**
+ * @api PATCH /api/speech-assessment-providers/[id]
+ * @visibility internal
+ * @scope speech-assessment-providers:write
+ * @auth session ADMIN
+ * @tags voice, scoring, admin
+ * @description Update a speech assessment provider. `slug` is immutable
+ *   (Call FK references could rot). `isDefault: true` unsets the flag on
+ *   every other row in the same transaction. Cache invalidated immediately
+ *   so credential rotations propagate without waiting for TTL.
+ *
+ *   Field validation: every field declared in the adapter's `configSchema`
+ *   is checked against the merged credentials+config. Required fields
+ *   cannot be empty, enum values must match `enumValues`, types must
+ *   match.
+ * @body { displayName?, adapterKey?, credentials?, config?, isDefault?, enabled? }
+ * @response 200 { ok: true, provider (credentials masked) }
+ * @response 400 { ok: false, error: string }
+ * @response 404 { ok: false, error: "not found" }
+ */
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth("ADMIN");
+  if (isAuthError(auth)) return auth.error;
+
+  const { id } = await params;
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: parsed.error.issues.map((i) => i.message).join("; ") },
+      { status: 400 },
+    );
+  }
+  const data = parsed.data;
+
+  if (data.adapterKey && !SPEECH_ASSESSMENT_ADAPTERS[data.adapterKey]) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `Unknown adapterKey: ${data.adapterKey}. Registered keys: ${Object.keys(SPEECH_ASSESSMENT_ADAPTERS).join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.speechAssessmentProvider.findUnique({
+    where: { id },
+  });
+  if (!existing) {
+    return NextResponse.json(
+      { ok: false, error: "not found" },
+      { status: 404 },
+    );
+  }
+
+  const adapterKey = data.adapterKey ?? existing.adapterKey;
+  const AdapterCtor = SPEECH_ASSESSMENT_ADAPTERS[adapterKey];
+  if (AdapterCtor) {
+    const probe = new AdapterCtor({}, {});
+    const schema = probe.getConfigSchema();
+    const merged: Record<string, unknown> = {
+      ...((existing.credentials ?? {}) as Record<string, unknown>),
+      ...((existing.config ?? {}) as Record<string, unknown>),
+      ...((data.credentials ?? {}) as Record<string, unknown>),
+      ...((data.config ?? {}) as Record<string, unknown>),
+    };
+    const fieldErrors: string[] = [];
+    for (const field of schema.fields) {
+      const v = merged[field.key];
+      if (
+        field.required &&
+        (v === undefined || v === null || v === "")
+      ) {
+        fieldErrors.push(`${field.key} is required`);
+        continue;
+      }
+      if (v === undefined || v === null || v === "") continue;
+      if (field.type === "number" && typeof v !== "number") {
+        fieldErrors.push(`${field.key} must be a number`);
+      } else if (field.type === "boolean" && typeof v !== "boolean") {
+        fieldErrors.push(`${field.key} must be a boolean`);
+      } else if (
+        field.type === "enum" &&
+        (typeof v !== "string" || !field.enumValues?.includes(v))
+      ) {
+        fieldErrors.push(
+          `${field.key} must be one of: ${(field.enumValues ?? []).join(", ")}`,
+        );
+      } else if (field.type === "string" && typeof v !== "string") {
+        fieldErrors.push(`${field.key} must be a string`);
+      }
+    }
+    if (fieldErrors.length > 0) {
+      return NextResponse.json(
+        { ok: false, error: fieldErrors.join("; ") },
+        { status: 400 },
+      );
+    }
+  }
+
+  const updated = await prisma.$transaction(async (tx) => {
+    if (data.isDefault === true) {
+      await tx.speechAssessmentProvider.updateMany({
+        where: { isDefault: true, NOT: { id } },
+        data: { isDefault: false },
+      });
+    }
+    return tx.speechAssessmentProvider.update({
+      where: { id },
+      data: {
+        ...(data.displayName !== undefined
+          ? { displayName: data.displayName }
+          : {}),
+        ...(data.adapterKey !== undefined
+          ? { adapterKey: data.adapterKey }
+          : {}),
+        ...(data.credentials !== undefined
+          ? { credentials: data.credentials as Prisma.InputJsonValue }
+          : {}),
+        ...(data.config !== undefined
+          ? { config: data.config as Prisma.InputJsonValue }
+          : {}),
+        ...(data.isDefault !== undefined
+          ? { isDefault: data.isDefault }
+          : {}),
+        ...(data.enabled !== undefined ? { enabled: data.enabled } : {}),
+      },
+    });
+  });
+
+  invalidateSpeechAssessmentProviderCache(updated.slug);
+
+  return NextResponse.json({
+    ok: true,
+    provider: {
+      ...updated,
+      credentials: maskCredentials(
+        updated.credentials as Record<string, unknown>,
+      ),
+    },
+  });
+}
+
+/**
+ * @api DELETE /api/speech-assessment-providers/[id]
+ * @visibility internal
+ * @scope speech-assessment-providers:write
+ * @auth session ADMIN
+ * @tags voice, scoring, admin
+ * @description Delete a speech assessment provider. Refuses if the row
+ *   has `isDefault: true` — flip another to default first.
+ * @response 200 { ok: true }
+ * @response 404 { ok: false, error: "not found" }
+ * @response 409 { ok: false, error: "cannot delete the default provider" }
+ */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth("ADMIN");
+  if (isAuthError(auth)) return auth.error;
+
+  const { id } = await params;
+  const row = await prisma.speechAssessmentProvider.findUnique({
+    where: { id },
+  });
+  if (!row) {
+    return NextResponse.json(
+      { ok: false, error: "not found" },
+      { status: 404 },
+    );
+  }
+  if (row.isDefault) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "cannot delete the default provider — set another as default first",
+      },
+      { status: 409 },
+    );
+  }
+
+  await prisma.speechAssessmentProvider.delete({ where: { id } });
+  invalidateSpeechAssessmentProviderCache(row.slug);
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/admin/app/api/speech-assessment-providers/[id]/test-connection/route.ts
+++ b/apps/admin/app/api/speech-assessment-providers/[id]/test-connection/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { getSpeechAssessmentProvider } from "@/lib/speech-assessment/provider-factory";
+
+export const runtime = "nodejs";
+
+/**
+ * @api POST /api/speech-assessment-providers/[id]/test-connection
+ * @visibility internal
+ * @scope speech-assessment-providers:test
+ * @auth session ADMIN
+ * @tags voice, scoring, admin
+ * @description Test that the adapter for a speech assessment provider is
+ *   loadable. Instantiates the adapter via the factory (forcing a
+ *   credential read + adapterKey whitelist check) and invokes
+ *   `getCapabilities()` — a pure introspection method that never calls
+ *   the vendor.
+ *
+ *   **No live scoring call is made.** Both SpeechAce and SpeechSuper
+ *   charge per-second of scored audio; a probe that hit the scoring
+ *   endpoint would cost on every click. The capabilities probe is free
+ *   and verifies the adapter loads + the credentials JSON deserialises
+ *   without throwing.
+ *
+ *   Never returns raw credential values in the response or error message.
+ * @response 200 { ok: true, ping: { reachable: boolean, capabilities?, detail } }
+ * @response 404 { ok: false, error: "not found" }
+ */
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth("ADMIN");
+  if (isAuthError(auth)) return auth.error;
+
+  const { id } = await params;
+  const row = await prisma.speechAssessmentProvider.findUnique({
+    where: { id },
+  });
+  if (!row) {
+    return NextResponse.json(
+      { ok: false, error: "not found" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const adapter = await getSpeechAssessmentProvider(row.slug);
+    const capabilities = adapter.getCapabilities();
+    return NextResponse.json({
+      ok: true,
+      ping: {
+        reachable: true,
+        capabilities,
+        detail:
+          "Adapter loaded and capabilities probe succeeded. No live vendor call was made (would incur per-second scoring cost).",
+      },
+    });
+  } catch (err) {
+    return NextResponse.json({
+      ok: true,
+      ping: {
+        reachable: false,
+        detail: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}

--- a/apps/admin/app/api/speech-assessment-providers/route.ts
+++ b/apps/admin/app/api/speech-assessment-providers/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { maskCredentials } from "@/lib/voice/mask-credentials";
+import { invalidateSpeechAssessmentProviderCache } from "@/lib/speech-assessment/provider-factory";
+import { SPEECH_ASSESSMENT_ADAPTERS } from "@/lib/speech-assessment/adapter-registry";
+
+export const runtime = "nodejs";
+
+/**
+ * @api GET /api/speech-assessment-providers
+ * @visibility internal
+ * @scope speech-assessment-providers:read
+ * @auth session ADMIN
+ * @tags voice, scoring, admin
+ * @description List all registered speech assessment providers (SpeechAce,
+ *   SpeechSuper). Credentials masked via `maskCredentials` — any key whose
+ *   name ends in `key`, `secret`, `token`, or `password` is replaced with
+ *   `***`. Raw secrets never leave the server.
+ * @response 200 { ok: true, providers: SpeechAssessmentProvider[] (credentials masked) }
+ */
+export async function GET() {
+  const auth = await requireAuth("ADMIN");
+  if (isAuthError(auth)) return auth.error;
+
+  const rows = await prisma.speechAssessmentProvider.findMany({
+    orderBy: [{ isDefault: "desc" }, { slug: "asc" }],
+  });
+  const providers = rows.map((row) => ({
+    ...row,
+    credentials: maskCredentials(row.credentials as Record<string, unknown>),
+  }));
+  return NextResponse.json({ ok: true, providers });
+}
+
+const createSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(
+      /^[a-z][a-z0-9-]*$/,
+      "slug must be lowercase letters/digits/hyphens, starting with a letter",
+    ),
+  displayName: z.string().min(1).max(128),
+  adapterKey: z.string().min(1),
+  credentials: z.record(z.string(), z.unknown()).optional().default({}),
+  config: z.record(z.string(), z.unknown()).optional().default({}),
+  isDefault: z.boolean().optional().default(false),
+  enabled: z.boolean().optional().default(true),
+});
+
+/**
+ * @api POST /api/speech-assessment-providers
+ * @visibility internal
+ * @scope speech-assessment-providers:write
+ * @auth session ADMIN
+ * @tags voice, scoring, admin
+ * @description Create a new speech assessment provider. `adapterKey` must
+ *   match an entry in `SPEECH_ASSESSMENT_ADAPTERS`. `isDefault: true`
+ *   unsets the flag on every other provider in the same transaction.
+ * @body { slug, displayName, adapterKey, credentials?, config?, isDefault?, enabled? }
+ * @response 201 { ok: true, provider: SpeechAssessmentProvider (credentials masked) }
+ * @response 400 { ok: false, error: string }
+ * @response 409 { ok: false, error: "slug already exists" }
+ */
+export async function POST(request: Request) {
+  const auth = await requireAuth("ADMIN");
+  if (isAuthError(auth)) return auth.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: parsed.error.issues.map((i) => i.message).join("; "),
+      },
+      { status: 400 },
+    );
+  }
+  const data = parsed.data;
+
+  if (!SPEECH_ASSESSMENT_ADAPTERS[data.adapterKey]) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `Unknown adapterKey: ${data.adapterKey}. Registered keys: ${Object.keys(SPEECH_ASSESSMENT_ADAPTERS).join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.speechAssessmentProvider.findUnique({
+    where: { slug: data.slug },
+  });
+  if (existing) {
+    return NextResponse.json(
+      { ok: false, error: "slug already exists" },
+      { status: 409 },
+    );
+  }
+
+  const row = await prisma.$transaction(async (tx) => {
+    if (data.isDefault) {
+      await tx.speechAssessmentProvider.updateMany({
+        where: { isDefault: true },
+        data: { isDefault: false },
+      });
+    }
+    return tx.speechAssessmentProvider.create({
+      data: {
+        slug: data.slug,
+        displayName: data.displayName,
+        adapterKey: data.adapterKey,
+        credentials: (data.credentials ?? {}) as Prisma.InputJsonValue,
+        config: (data.config ?? {}) as Prisma.InputJsonValue,
+        isDefault: data.isDefault,
+        enabled: data.enabled,
+      },
+    });
+  });
+
+  invalidateSpeechAssessmentProviderCache(row.slug);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      provider: {
+        ...row,
+        credentials: maskCredentials(row.credentials as Record<string, unknown>),
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/apps/admin/app/x/settings/SettingsClient.tsx
+++ b/apps/admin/app/x/settings/SettingsClient.tsx
@@ -28,6 +28,7 @@ import { PanelLayoutPanel } from "@/components/settings/PanelLayoutPanel";
 import { InstitutionTypesPanel } from "@/components/settings/InstitutionTypesPanel";
 import { ConstantsReferencePanel } from "@/components/settings/ConstantsReferencePanel";
 import { VoiceProvidersPanel } from "@/components/settings/VoiceProvidersPanel";
+import { VoiceScoringProvidersPanel } from "@/components/settings/VoiceScoringProvidersPanel";
 import { VoiceToolsPanel } from "@/components/settings/VoiceToolsPanel";
 
 // ── Build the unified panel registry ────────────────
@@ -38,6 +39,10 @@ function ChannelsPanelAdapter(_props: PanelProps) {
 
 function VoiceProvidersPanelAdapter(_props: PanelProps) {
   return <VoiceProvidersPanel />;
+}
+
+function VoiceScoringProvidersPanelAdapter(_props: PanelProps) {
+  return <VoiceScoringProvidersPanel />;
 }
 
 function VoiceToolsPanelAdapter(_props: PanelProps) {
@@ -63,6 +68,12 @@ const CUSTOM_PANELS: SettingsPanel[] = [
     "CRUD voice-call providers (VAPI etc.) — credentials, defaults, archive",
     "communications", VoiceProvidersPanelAdapter,
     ["voice", "provider", "vapi", "credentials", "api key", "webhook", "archive", "call"],
+  ),
+  registerCustomPanel(
+    "voice_scoring_providers", "Voice Scoring", "Activity",
+    "CRUD speech-assessment providers (SpeechAce, SpeechSuper) — credentials, defaults, archive",
+    "communications", VoiceScoringProvidersPanelAdapter,
+    ["speech", "scoring", "pronunciation", "ielts", "prosody", "speechace", "speechsuper", "fluency"],
   ),
   registerCustomPanel(
     "voice_tools", "Voice Tools", "Wrench",

--- a/apps/admin/app/x/settings/voice-scoring-providers/[id]/page.tsx
+++ b/apps/admin/app/x/settings/voice-scoring-providers/[id]/page.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+/**
+ * Voice Scoring Provider edit page (#1118).
+ *
+ * Renders three sections:
+ *   1. Top-level row metadata (displayName, enabled toggle)
+ *   2. Capabilities badges (adapter-declared)
+ *   3. Per-provider form (generated from `adapter.getConfigSchema()`)
+ *
+ * Sensitive fields render as password inputs and never pre-fill with the
+ * raw value — the GET endpoint masks them to `***` / `[not set]`. The
+ * `fieldPresence` helper surfaces which fields currently have a saved
+ * value so the operator can tell at a glance.
+ *
+ * Save behaviour matches the post-#1115 voice-providers pattern:
+ *   - Stay on the page after save
+ *   - Show a success banner naming which fields actually changed
+ *   - Sensitive blank-on-save = keep current value
+ *
+ * No cross-provider system settings section — VoiceScoringSystemSettings
+ * is explicitly out of scope for #1118 (no real cross-provider setting
+ * exists yet). When one does, this page acquires a section matching the
+ * voice-providers parallel.
+ *
+ * ADMIN-only via the API layer.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+
+interface ConfigField {
+  key: string;
+  label: string;
+  type: "string" | "number" | "boolean" | "enum";
+  help?: string;
+  enumValues?: string[];
+  default?: unknown;
+  sensitive?: boolean;
+  required?: boolean;
+}
+
+interface Capabilities {
+  ieltsSupported: boolean;
+  spontaneousSupported: boolean;
+  scriptedSupported: boolean;
+  acceptsRecordingUrl: boolean;
+  requiresFileUpload: boolean;
+  transcriptIncluded: boolean;
+  perWordDiagnostics: boolean;
+  prosodyFeatures: boolean;
+}
+
+interface SpeechAssessmentProviderRow {
+  id: string;
+  slug: string;
+  displayName: string;
+  adapterKey: string;
+  credentials: Record<string, unknown>;
+  config: Record<string, unknown>;
+  isDefault: boolean;
+  enabled: boolean;
+}
+
+/**
+ * Compute whether a config field currently has a saved value in the DB.
+ * Mirrors the voice-providers/[id]/page.tsx::fieldPresence helper (#1115).
+ *
+ * Sensitive fields: the GET response masks credentials to `***` (set) or
+ * `[not set]` (unset) — we read that signal directly.
+ *
+ * Non-sensitive fields: the actual value is returned in `row.config`.
+ * Empty string / undefined = unset.
+ */
+function fieldPresence(
+  f: ConfigField,
+  row: SpeechAssessmentProviderRow,
+): { set: boolean; label: string } {
+  if (f.sensitive) {
+    const v = (row.credentials as Record<string, unknown>)[f.key];
+    const isSet =
+      v === "***" ||
+      (typeof v === "string" && v !== "" && v !== "[not set]");
+    return {
+      set: isSet,
+      label: isSet ? " (currently set)" : " (currently unset)",
+    };
+  }
+  const v =
+    (row.config as Record<string, unknown>)[f.key] ??
+    (row.credentials as Record<string, unknown>)[f.key];
+  const isSet =
+    v !== undefined && v !== null && v !== "" && v !== "[not set]";
+  return {
+    set: isSet,
+    label: isSet ? " (currently set)" : " (currently unset)",
+  };
+}
+
+export default function VoiceScoringProviderEditPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const id = params?.id;
+
+  const [row, setRow] = useState<SpeechAssessmentProviderRow | null>(null);
+  const [configSchema, setConfigSchema] = useState<ConfigField[] | null>(null);
+  const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const [displayName, setDisplayName] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [fieldValues, setFieldValues] = useState<
+    Record<string, string | boolean>
+  >({});
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/speech-assessment-providers/${id}`);
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setRow(body.provider);
+      setConfigSchema(body.configSchema?.fields ?? null);
+      setCapabilities(body.capabilities ?? null);
+      setDisplayName(body.provider.displayName);
+      setEnabled(body.provider.enabled);
+
+      const seed: Record<string, string | boolean> = {};
+      for (const f of (body.configSchema?.fields ?? []) as ConfigField[]) {
+        if (f.sensitive) {
+          seed[f.key] = "";
+          continue;
+        }
+        const v =
+          (body.provider.config as Record<string, unknown>)[f.key] ??
+          (body.provider.credentials as Record<string, unknown>)[f.key];
+        if (f.type === "boolean") {
+          seed[f.key] = v === true;
+        } else {
+          seed[f.key] =
+            v === undefined || v === null ? "" : String(v);
+        }
+      }
+      setFieldValues(seed);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function saveProvider() {
+    if (!row || !configSchema) return;
+    setSaving(true);
+    setErr(null);
+    setSaveMessage(null);
+    try {
+      const credentials: Record<string, unknown> = { ...row.credentials };
+      const config: Record<string, unknown> = { ...row.config };
+      // Drop masked sentinels so we don't write "***" back to DB
+      for (const k of Object.keys(credentials)) {
+        if (
+          credentials[k] === "***" ||
+          credentials[k] === "[not set]"
+        ) {
+          delete credentials[k];
+        }
+      }
+
+      const changedFields: string[] = [];
+
+      for (const f of configSchema) {
+        const raw = fieldValues[f.key];
+        if (f.sensitive && raw === "") continue;
+        let value: unknown;
+        if (f.type === "number") {
+          if (raw === "" || raw === undefined) {
+            value = undefined;
+          } else {
+            const n = Number(raw);
+            if (!Number.isFinite(n)) {
+              throw new Error(`${f.label}: not a number`);
+            }
+            value = n;
+          }
+        } else if (f.type === "boolean") {
+          value = Boolean(raw);
+        } else {
+          value = raw === "" ? undefined : raw;
+        }
+        if (value === undefined) continue;
+        if (f.sensitive) {
+          changedFields.push(f.label);
+          credentials[f.key] = value;
+        } else {
+          const currentValue =
+            (row.config as Record<string, unknown>)[f.key] ??
+            (row.credentials as Record<string, unknown>)[f.key];
+          if (currentValue !== value) {
+            changedFields.push(f.label);
+          }
+          config[f.key] = value;
+        }
+      }
+
+      const patch: Record<string, unknown> = {
+        displayName,
+        enabled,
+        credentials,
+        config,
+      };
+      const res = await fetch(`/api/speech-assessment-providers/${id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok)
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+
+      await load();
+      if (changedFields.length === 0) {
+        setSaveMessage("Saved. No field values changed.");
+      } else {
+        setSaveMessage(`Saved. Updated: ${changedFields.join(", ")}.`);
+      }
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="hf-page">
+        <div className="hf-empty">
+          <span className="hf-spinner" aria-label="Loading" /> Loading
+          provider&hellip;
+        </div>
+      </main>
+    );
+  }
+  if (!row) {
+    return (
+      <main className="hf-page">
+        <div className="hf-banner hf-banner-error">
+          {err ?? "Provider not found"}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="hf-page">
+      <h1 className="hf-page-title">{row.displayName}</h1>
+      <p className="hf-page-subtitle">
+        slug: <code>{row.slug}</code> · adapter: <code>{row.adapterKey}</code>
+      </p>
+      <p className="hf-section-desc">
+        <Link href="/x/settings/voice-scoring-providers">
+          ← All scoring providers
+        </Link>
+      </p>
+
+      {err && (
+        <div className="hf-banner hf-banner-error" role="alert">
+          {err}
+        </div>
+      )}
+
+      {saveMessage && !err && (
+        <div className="hf-banner hf-banner-success" role="status">
+          {saveMessage}
+        </div>
+      )}
+
+      {/* Capabilities */}
+      {capabilities && (
+        <section className="hf-card">
+          <h2 className="hf-section-title">Supported features</h2>
+          <p className="hf-section-desc">
+            Declared by the <code>{row.adapterKey}</code> adapter via
+            <code> getCapabilities()</code>. Drives the PROSODY pipeline
+            stage&rsquo;s vendor selection.
+          </p>
+          <ul className="hf-kv">
+            <CapRow label="IELTS scoring" value={capabilities.ieltsSupported} />
+            <CapRow
+              label="Spontaneous speech"
+              value={capabilities.spontaneousSupported}
+            />
+            <CapRow
+              label="Scripted (read-aloud)"
+              value={capabilities.scriptedSupported}
+            />
+            <CapRow
+              label="Accepts recording URL"
+              value={capabilities.acceptsRecordingUrl}
+            />
+            <CapRow
+              label="Requires file upload"
+              value={capabilities.requiresFileUpload}
+            />
+            <CapRow
+              label="Transcript included"
+              value={capabilities.transcriptIncluded}
+            />
+            <CapRow
+              label="Per-word diagnostics"
+              value={capabilities.perWordDiagnostics}
+            />
+            <CapRow
+              label="Prosody features"
+              value={capabilities.prosodyFeatures}
+            />
+          </ul>
+        </section>
+      )}
+
+      {/* Row metadata */}
+      <section className="hf-card">
+        <h2 className="hf-section-title">Row settings</h2>
+        <label className="hf-label" htmlFor="displayName">
+          Display name
+        </label>
+        <input
+          id="displayName"
+          className="hf-input"
+          type="text"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+        />
+
+        <label className="hf-label" htmlFor="enabled">
+          <input
+            id="enabled"
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />{" "}
+          Enabled (factory will refuse to instantiate when off)
+        </label>
+      </section>
+
+      {/* Per-provider form */}
+      {configSchema && configSchema.length > 0 ? (
+        <section className="hf-card">
+          <h2 className="hf-section-title">Provider configuration</h2>
+          <p className="hf-section-desc">
+            Fields declared by the <code>{row.adapterKey}</code> adapter.
+            Sensitive fields are masked — leave blank to keep the current
+            value.
+          </p>
+          {configSchema.map((f) => {
+            const presence = fieldPresence(f, row);
+            return (
+              <div key={f.key}>
+                <label className="hf-label" htmlFor={`field-${f.key}`}>
+                  {f.label}{" "}
+                  {f.required ? <span aria-hidden>*</span> : null}
+                  <span
+                    className={
+                      presence.set
+                        ? "hf-presence-set"
+                        : "hf-presence-unset"
+                    }
+                  >
+                    {presence.label}
+                  </span>
+                </label>
+                {f.type === "enum" ? (
+                  <select
+                    id={`field-${f.key}`}
+                    className="hf-input"
+                    value={String(fieldValues[f.key] ?? "")}
+                    onChange={(e) =>
+                      setFieldValues({
+                        ...fieldValues,
+                        [f.key]: e.target.value,
+                      })
+                    }
+                  >
+                    <option value="">— select —</option>
+                    {(f.enumValues ?? []).map((v) => (
+                      <option key={v} value={v}>
+                        {v}
+                      </option>
+                    ))}
+                  </select>
+                ) : f.type === "boolean" ? (
+                  <input
+                    id={`field-${f.key}`}
+                    type="checkbox"
+                    checked={Boolean(fieldValues[f.key])}
+                    onChange={(e) =>
+                      setFieldValues({
+                        ...fieldValues,
+                        [f.key]: e.target.checked,
+                      })
+                    }
+                  />
+                ) : (
+                  <input
+                    id={`field-${f.key}`}
+                    className="hf-input"
+                    type={
+                      f.sensitive
+                        ? "password"
+                        : f.type === "number"
+                          ? "number"
+                          : "text"
+                    }
+                    autoComplete={
+                      f.sensitive ? "new-password" : undefined
+                    }
+                    placeholder={
+                      f.sensitive
+                        ? presence.set
+                          ? "leave blank to keep current"
+                          : "type new value"
+                        : ""
+                    }
+                    value={String(fieldValues[f.key] ?? "")}
+                    onChange={(e) =>
+                      setFieldValues({
+                        ...fieldValues,
+                        [f.key]: e.target.value,
+                      })
+                    }
+                  />
+                )}
+                {f.help && (
+                  <p className="hf-section-desc">{f.help}</p>
+                )}
+              </div>
+            );
+          })}
+        </section>
+      ) : (
+        <section className="hf-card">
+          <p className="hf-section-desc">
+            Adapter <code>{row.adapterKey}</code> declares no
+            provider-specific configuration.
+          </p>
+        </section>
+      )}
+
+      <div className="hf-card-footer">
+        <button
+          type="button"
+          className="hf-btn hf-btn-primary"
+          onClick={saveProvider}
+          disabled={saving}
+        >
+          {saving ? "Saving…" : "Save provider"}
+        </button>
+        <button
+          type="button"
+          className="hf-btn hf-btn-secondary"
+          onClick={() => router.push("/x/settings/voice-scoring-providers")}
+          disabled={saving}
+        >
+          Cancel
+        </button>
+      </div>
+    </main>
+  );
+}
+
+function CapRow({ label, value }: { label: string; value: boolean }) {
+  return (
+    <li className="hf-kv-row">
+      <span>{label}</span>
+      <span className={value ? "hf-badge hf-badge-success" : "hf-badge hf-badge-muted"}>
+        {value ? "Yes" : "No"}
+      </span>
+    </li>
+  );
+}

--- a/apps/admin/app/x/settings/voice-scoring-providers/new/page.tsx
+++ b/apps/admin/app/x/settings/voice-scoring-providers/new/page.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+/**
+ * Voice Scoring Provider create page (#1118).
+ *
+ * Minimal form to register a new SpeechAssessmentProvider row. slug is
+ * immutable after creation. Adapter key defaults to "speechace"; the
+ * other registered key is "speechsuper". Per-vendor field schema is
+ * rendered on the edit page (`/x/settings/voice-scoring-providers/[id]`).
+ *
+ * ADMIN-only via the API layer.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function VoiceScoringProviderNewPage() {
+  const router = useRouter();
+  const [slug, setSlug] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [adapterKey, setAdapterKey] = useState("speechace");
+  const [credentialsText, setCredentialsText] = useState("{}");
+  const [configText, setConfigText] = useState("{}");
+  const [isDefault, setIsDefault] = useState(false);
+  const [enabled, setEnabled] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function create() {
+    setErr(null);
+    setSaving(true);
+    try {
+      let credentials: Record<string, unknown> = {};
+      let config: Record<string, unknown> = {};
+      try {
+        credentials = JSON.parse(credentialsText);
+        if (
+          credentials === null ||
+          typeof credentials !== "object" ||
+          Array.isArray(credentials)
+        ) {
+          throw new Error("credentials must be a JSON object");
+        }
+      } catch (e) {
+        throw new Error(
+          `Invalid credentials JSON: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+      try {
+        config = JSON.parse(configText);
+        if (
+          config === null ||
+          typeof config !== "object" ||
+          Array.isArray(config)
+        ) {
+          throw new Error("config must be a JSON object");
+        }
+      } catch (e) {
+        throw new Error(
+          `Invalid config JSON: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+
+      const res = await fetch("/api/speech-assessment-providers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          slug,
+          displayName,
+          adapterKey,
+          credentials,
+          config,
+          isDefault,
+          enabled,
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok)
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      router.push("/x/settings/voice-scoring-providers");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <main className="hf-page">
+      <h1 className="hf-page-title">Add voice scoring provider</h1>
+      <p className="hf-page-subtitle">
+        Register a new speech-scoring vendor (SpeechAce or SpeechSuper). The
+        slug is permanent — pick carefully. Credentials are stored in the
+        database and masked in every API response.
+      </p>
+
+      {err ? (
+        <div className="hf-banner hf-banner-error" role="alert">
+          {err}
+        </div>
+      ) : null}
+
+      <section className="hf-card">
+        <label className="hf-label" htmlFor="slug">
+          Slug{" "}
+          <span className="hf-section-desc">
+            (permanent — lowercase letters, digits, hyphens; e.g.
+            &ldquo;speechace&rdquo;, &ldquo;speechsuper&rdquo;)
+          </span>
+        </label>
+        <input
+          id="slug"
+          className="hf-input"
+          type="text"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="speechace"
+        />
+
+        <label className="hf-label" htmlFor="displayName">
+          Display name
+        </label>
+        <input
+          id="displayName"
+          className="hf-input"
+          type="text"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="SpeechAce (v9)"
+        />
+
+        <label className="hf-label" htmlFor="adapterKey">
+          Adapter key{" "}
+          <span className="hf-section-desc">
+            (must match an entry in
+            lib/speech-assessment/adapter-registry.ts: speechace or speechsuper)
+          </span>
+        </label>
+        <input
+          id="adapterKey"
+          className="hf-input"
+          type="text"
+          value={adapterKey}
+          onChange={(e) => setAdapterKey(e.target.value)}
+        />
+
+        <label className="hf-label">
+          <input
+            type="checkbox"
+            checked={isDefault}
+            onChange={(e) => setIsDefault(e.target.checked)}
+          />{" "}
+          Set as default (will unset the current default in the same
+          transaction)
+        </label>
+        <label className="hf-label">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />{" "}
+          Enabled
+        </label>
+      </section>
+
+      <section className="hf-card">
+        <h2 className="hf-section-title">Credentials</h2>
+        <p className="hf-section-desc">
+          JSON object. Most operators leave this empty here and paste values on
+          the per-field edit page (where keys are typed inputs and sensitive
+          values are masked).
+        </p>
+        <textarea
+          className="hf-input"
+          rows={6}
+          value={credentialsText}
+          onChange={(e) => setCredentialsText(e.target.value)}
+        />
+      </section>
+
+      <section className="hf-card">
+        <h2 className="hf-section-title">Config (non-sensitive)</h2>
+        <p className="hf-section-desc">JSON object. dialect, userId, etc.</p>
+        <textarea
+          className="hf-input"
+          rows={4}
+          value={configText}
+          onChange={(e) => setConfigText(e.target.value)}
+        />
+      </section>
+
+      <div className="hf-card-footer">
+        <button
+          type="button"
+          className="hf-btn hf-btn-primary"
+          onClick={create}
+          disabled={saving}
+        >
+          {saving ? "Creating…" : "Create"}
+        </button>
+        <button
+          type="button"
+          className="hf-btn hf-btn-secondary"
+          onClick={() => router.push("/x/settings/voice-scoring-providers")}
+          disabled={saving}
+        >
+          Cancel
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/app/x/settings/voice-scoring-providers/page.tsx
+++ b/apps/admin/app/x/settings/voice-scoring-providers/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+/**
+ * Voice Scoring Providers admin page (#1118).
+ *
+ * Standalone route that wraps the shared VoiceScoringProvidersPanel with
+ * a page heading. The same panel renders inside
+ * /x/settings#voice_scoring_providers. ADMIN-only — the API enforces auth;
+ * this page just renders.
+ */
+
+import { VoiceScoringProvidersPanel } from "@/components/settings/VoiceScoringProvidersPanel";
+
+export default function VoiceScoringProvidersPage() {
+  return (
+    <main className="hf-page">
+      <VoiceScoringProvidersPanel showHeading />
+    </main>
+  );
+}

--- a/apps/admin/components/settings/VoiceScoringProvidersPanel.tsx
+++ b/apps/admin/components/settings/VoiceScoringProvidersPanel.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+/**
+ * Voice Scoring Providers CRUD body (#1118).
+ *
+ * Parallel to VoiceProvidersPanel — manages SpeechAssessmentProvider rows
+ * (SpeechAce, SpeechSuper). Credentials always masked — the API never
+ * returns raw values. Test-connection probe invokes the adapter's
+ * `getCapabilities()` and never makes a live vendor call (per-second
+ * cost). No telemetry tab yet — telemetry / PROSODY stage is the
+ * sister story (#1119).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+
+interface SpeechAssessmentProviderRow {
+  id: string;
+  slug: string;
+  displayName: string;
+  adapterKey: string;
+  credentials: Record<string, unknown>;
+  config: Record<string, unknown>;
+  isDefault: boolean;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PingResult {
+  reachable: boolean;
+  detail: string;
+}
+
+interface Props {
+  showHeading?: boolean;
+}
+
+export function VoiceScoringProvidersPanel({ showHeading = false }: Props = {}) {
+  const [rows, setRows] = useState<SpeechAssessmentProviderRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [pingResults, setPingResults] = useState<
+    Record<string, PingResult | "loading">
+  >({});
+  const [showArchived, setShowArchived] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await fetch("/api/speech-assessment-providers");
+      const body = await res.json();
+      if (!res.ok || !body.ok)
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      setRows(body.providers);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function testConnection(id: string) {
+    setPingResults((p) => ({ ...p, [id]: "loading" }));
+    try {
+      const res = await fetch(
+        `/api/speech-assessment-providers/${id}/test-connection`,
+        { method: "POST" },
+      );
+      const body = await res.json();
+      if (!body.ok) throw new Error(body.error ?? "test failed");
+      setPingResults((p) => ({ ...p, [id]: body.ping }));
+    } catch (e) {
+      setPingResults((p) => ({
+        ...p,
+        [id]: {
+          reachable: false,
+          detail: e instanceof Error ? e.message : String(e),
+        },
+      }));
+    }
+  }
+
+  async function setDefault(id: string) {
+    try {
+      const res = await fetch(`/api/speech-assessment-providers/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isDefault: true }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok)
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      await load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function deleteRow(id: string, displayName: string) {
+    if (
+      !confirm(
+        `Delete speech assessment provider "${displayName}"? This cannot be undone.`,
+      )
+    )
+      return;
+    try {
+      const res = await fetch(`/api/speech-assessment-providers/${id}`, {
+        method: "DELETE",
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok)
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      await load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function setEnabled(id: string, enabled: boolean, displayName: string) {
+    if (
+      !enabled &&
+      !confirm(
+        `Archive "${displayName}"? It will stop receiving scoring requests but can be restored from "Show archived".`,
+      )
+    )
+      return;
+    try {
+      const res = await fetch(`/api/speech-assessment-providers/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok)
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      await load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return (
+    <div>
+      {showHeading ? (
+        <>
+          <h1 className="hf-page-title">Voice scoring</h1>
+          <p className="hf-page-subtitle">
+            Manage the speech-scoring vendors (SpeechAce, SpeechSuper) that
+            score uploaded learner audio for IELTS bands and prosody features.
+            Credentials are stored in the database and never displayed in plain
+            text. Wired into the PROSODY pipeline stage (#1119).
+          </p>
+        </>
+      ) : (
+        <p className="hf-section-desc">
+          Manage speech-scoring vendors (SpeechAce, SpeechSuper). Credentials
+          masked. The default provider serves the PROSODY pipeline stage when
+          no per-playbook override exists.
+        </p>
+      )}
+
+      {err ? (
+        <div className="hf-banner hf-banner-error" role="alert">
+          {err}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="hf-empty">
+          <span className="hf-spinner" aria-label="Loading providers" /> Loading
+          providers&hellip;
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="hf-empty">
+          No scoring providers registered.{" "}
+          <Link href="/x/settings/voice-scoring-providers/new">Add one</Link> to
+          start.
+        </div>
+      ) : (
+        (() => {
+          const visible = showArchived ? rows : rows.filter((r) => r.enabled);
+          const archivedCount = rows.filter((r) => !r.enabled).length;
+          return (
+            <>
+              {archivedCount > 0 || rows.some((r) => !r.enabled) ? (
+                <div className="hf-card-footer hf-archive-toggle-row">
+                  <label className="hf-label hf-archive-toggle-label">
+                    <input
+                      type="checkbox"
+                      checked={showArchived}
+                      onChange={(e) => setShowArchived(e.target.checked)}
+                    />
+                    Show archived ({archivedCount})
+                  </label>
+                </div>
+              ) : null}
+              <ul className="hf-card-list">
+                {visible.map((row) => {
+                  const credKeys = Object.keys(row.credentials);
+                  const ping = pingResults[row.id];
+                  return (
+                    <li key={row.id} className="hf-card">
+                      <header className="hf-card-header">
+                        <div>
+                          <h2 className="hf-section-title">{row.displayName}</h2>
+                          <p className="hf-section-desc">
+                            slug: <code>{row.slug}</code> · adapter:{" "}
+                            <code>{row.adapterKey}</code>
+                          </p>
+                        </div>
+                        <div className="hf-badge-row">
+                          {row.isDefault ? (
+                            <span className="hf-badge hf-badge-info">
+                              Default
+                            </span>
+                          ) : null}
+                          {row.enabled ? (
+                            <span className="hf-badge hf-badge-success">
+                              Enabled
+                            </span>
+                          ) : (
+                            <span className="hf-badge hf-badge-muted">
+                              Disabled
+                            </span>
+                          )}
+                        </div>
+                      </header>
+
+                      {credKeys.length > 0 ? (
+                        <dl className="hf-kv">
+                          {credKeys.map((key) => (
+                            <div key={key} className="hf-kv-row">
+                              <dt>{key}</dt>
+                              <dd>{String(row.credentials[key])}</dd>
+                            </div>
+                          ))}
+                        </dl>
+                      ) : null}
+
+                      {ping ? (
+                        ping === "loading" ? (
+                          <p className="hf-section-desc">
+                            <span className="hf-spinner" aria-label="Testing" />{" "}
+                            Testing connection&hellip;
+                          </p>
+                        ) : (
+                          <p
+                            className={
+                              ping.reachable
+                                ? "hf-banner hf-banner-success"
+                                : "hf-banner hf-banner-error"
+                            }
+                          >
+                            {ping.detail}
+                          </p>
+                        )
+                      ) : null}
+
+                      <footer className="hf-card-footer">
+                        <button
+                          type="button"
+                          className="hf-btn hf-btn-secondary"
+                          onClick={() => testConnection(row.id)}
+                          disabled={ping === "loading"}
+                        >
+                          Test connection
+                        </button>
+                        <Link
+                          href={`/x/settings/voice-scoring-providers/${row.id}`}
+                          className="hf-btn hf-btn-secondary"
+                        >
+                          Edit
+                        </Link>
+                        {!row.isDefault && row.enabled ? (
+                          <button
+                            type="button"
+                            className="hf-btn hf-btn-secondary"
+                            onClick={() => setDefault(row.id)}
+                          >
+                            Set as default
+                          </button>
+                        ) : null}
+                        {!row.isDefault ? (
+                          row.enabled ? (
+                            <button
+                              type="button"
+                              className="hf-btn hf-btn-secondary"
+                              onClick={() =>
+                                setEnabled(row.id, false, row.displayName)
+                              }
+                            >
+                              Archive
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="hf-btn hf-btn-secondary"
+                              onClick={() =>
+                                setEnabled(row.id, true, row.displayName)
+                              }
+                            >
+                              Unarchive
+                            </button>
+                          )
+                        ) : null}
+                        {!row.isDefault ? (
+                          <button
+                            type="button"
+                            className="hf-btn hf-btn-destructive"
+                            onClick={() => deleteRow(row.id, row.displayName)}
+                          >
+                            Delete
+                          </button>
+                        ) : null}
+                      </footer>
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          );
+        })()
+      )}
+
+      <div className="hf-card-footer">
+        <Link
+          href="/x/settings/voice-scoring-providers/new"
+          className="hf-btn hf-btn-primary"
+        >
+          + Add scoring provider
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/lib/speech-assessment/adapter-registry.ts
+++ b/apps/admin/lib/speech-assessment/adapter-registry.ts
@@ -1,0 +1,40 @@
+/**
+ * Speech-assessment adapter registry (#1118).
+ *
+ * Parallel to `lib/voice/adapter-registry.ts` — maps an `adapterKey`
+ * string (stored on the `SpeechAssessmentProvider` DB row) to a class
+ * constructor implementing `SpeechAssessmentAdapter`. Adding a new
+ * scoring vendor means: (a) write the class under
+ * `lib/speech-assessment/providers/<slug>/`, (b) add one entry here.
+ * Everything else — credentials, config, enablement, default
+ * selection — is data in the `SpeechAssessmentProvider` table managed
+ * via /x/settings/voice-scoring-providers.
+ *
+ * TODO: extract at 3rd provider type — when a third provider category
+ * (e.g. STT-only, sentiment) lands, lift the registry + factory pattern
+ * into a generic `createProviderRegistry<T>()` helper. With two uses
+ * (VoiceProvider + SpeechAssessmentProvider) the duplication is honest.
+ */
+
+import { SpeechAceAdapter } from "./providers/speechace";
+import { SpeechSuperAdapter } from "./providers/speechsuper";
+import type { SpeechAssessmentAdapterConstructor } from "./types";
+
+/**
+ * `adapterKey` → constructor. Add a new line per new vendor adapter.
+ * The key stored on `SpeechAssessmentProvider.adapterKey` must match
+ * a key here, or the factory throws on instantiation.
+ */
+export const SPEECH_ASSESSMENT_ADAPTERS: Record<
+  string,
+  SpeechAssessmentAdapterConstructor
+> = {
+  speechace: SpeechAceAdapter as unknown as SpeechAssessmentAdapterConstructor,
+  speechsuper:
+    SpeechSuperAdapter as unknown as SpeechAssessmentAdapterConstructor,
+};
+
+/** Health-check / test enumeration of registered keys without instantiation. */
+export function listRegisteredSpeechAssessmentAdapterKeys(): string[] {
+  return Object.keys(SPEECH_ASSESSMENT_ADAPTERS);
+}

--- a/apps/admin/lib/speech-assessment/provider-factory.ts
+++ b/apps/admin/lib/speech-assessment/provider-factory.ts
@@ -1,0 +1,114 @@
+/**
+ * Speech-assessment provider factory (#1118). Parallel to
+ * `lib/voice/provider-factory.ts` — reads the
+ * `SpeechAssessmentProvider` DB row, looks up the matching adapter
+ * class in `SPEECH_ASSESSMENT_ADAPTERS`, instantiates with the row's
+ * credentials + config, caches per-slug for `CACHE_TTL_MS`.
+ *
+ * TODO: extract at 3rd provider type — the cache primitive +
+ * invalidate pattern is identical to the voice factory. Lifting to a
+ * `createProviderCache<T>()` helper after a third use earns its keep;
+ * with two uses it doesn't.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+import { SPEECH_ASSESSMENT_ADAPTERS } from "./adapter-registry";
+import type { SpeechAssessmentAdapter } from "./types";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  adapter: SpeechAssessmentAdapter;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Look up the `SpeechAssessmentAdapter` for a slug. Reads the
+ * `SpeechAssessmentProvider` DB row, instantiates the matching
+ * adapter class with the row's credentials + config, caches for
+ * `CACHE_TTL_MS`.
+ *
+ * @throws when the slug is unknown, disabled, or has an `adapterKey`
+ *   not registered in `SPEECH_ASSESSMENT_ADAPTERS`.
+ */
+export async function getSpeechAssessmentProvider(
+  slug: string,
+): Promise<SpeechAssessmentAdapter> {
+  const now = Date.now();
+  const cached = cache.get(slug);
+  if (cached && cached.expiresAt > now) {
+    return cached.adapter;
+  }
+
+  const row = await prisma.speechAssessmentProvider.findUnique({
+    where: { slug },
+  });
+  if (!row) {
+    throw new Error(`Unknown speech assessment provider slug: ${slug}`);
+  }
+  if (!row.enabled) {
+    throw new Error(`Speech assessment provider ${slug} is disabled`);
+  }
+
+  const Constructor = SPEECH_ASSESSMENT_ADAPTERS[row.adapterKey];
+  if (!Constructor) {
+    throw new Error(
+      `Unknown adapterKey: ${row.adapterKey} for slug ${slug} — add an entry to lib/speech-assessment/adapter-registry.ts`,
+    );
+  }
+
+  const credentials = (row.credentials as Record<string, unknown>) ?? {};
+  const config = (row.config as Record<string, unknown>) ?? {};
+  const adapter = new Constructor(credentials, config);
+
+  cache.set(slug, { adapter, expiresAt: now + CACHE_TTL_MS });
+  return adapter;
+}
+
+/**
+ * Evict cached adapter instance for a slug. Must be called after
+ * every mutation to a `SpeechAssessmentProvider` row (POST / PATCH /
+ * DELETE).
+ */
+export function invalidateSpeechAssessmentProviderCache(slug: string): void {
+  cache.delete(slug);
+}
+
+/** Evict the entire cache. Used by tests + after bulk operations. */
+export function clearSpeechAssessmentProviderCache(): void {
+  cache.clear();
+}
+
+/**
+ * Look up the default speech-assessment provider slug (the row with
+ * `isDefault = true`). Used by the PROSODY pipeline stage (#1119) when
+ * no per-playbook override exists.
+ *
+ * @throws when no row has `isDefault: true` AND `enabled: true`.
+ */
+export async function getDefaultSpeechAssessmentProviderSlug(): Promise<string> {
+  const row = await prisma.speechAssessmentProvider.findFirst({
+    where: { isDefault: true, enabled: true },
+    select: { slug: true },
+  });
+  if (!row) {
+    throw new Error(
+      "No default speech assessment provider configured — seed SpeechAssessmentProvider table or visit /x/settings/voice-scoring-providers",
+    );
+  }
+  return row.slug;
+}
+
+/** List registered slugs without instantiating. Used by admin UI + tests. */
+export async function listRegisteredSpeechAssessmentProviders(): Promise<
+  string[]
+> {
+  const rows = await prisma.speechAssessmentProvider.findMany({
+    select: { slug: true },
+    orderBy: { slug: "asc" },
+  });
+  return rows.map((r) => r.slug);
+}

--- a/apps/admin/lib/speech-assessment/providers/speechace/index.ts
+++ b/apps/admin/lib/speech-assessment/providers/speechace/index.ts
@@ -1,0 +1,222 @@
+/**
+ * SpeechAce v9 adapter (#1118).
+ *
+ * Wraps the SpeechAce "Score Task" / spontaneous-speech IELTS scoring
+ * endpoint. Auth is a single API key passed as the `?key=` query
+ * parameter (NOT a header). Audio is uploaded multipart as
+ * `user_audio_file`. IELTS scores live under
+ * `speech_score.ielts_score.{overall, pronunciation, fluency, grammar,
+ * vocab, coherence}` in the v9 response shape.
+ *
+ * Docs source of truth: https://api-docs.speechace.com (v9). Sample
+ * code: https://github.com/speechace/speechace-api-samples.
+ *
+ * Cost model: per-second of scored audio. Test-connection probe MUST
+ * NOT call this endpoint — it invokes `getCapabilities()` only. See
+ * `/api/speech-assessment-providers/[id]/test-connection`.
+ */
+
+import type { ProviderConfigSchema } from "@/lib/voice/types";
+import type {
+  NormalisedScoreResult,
+  ScoringMode,
+  SpeechAssessmentAdapter,
+  SpeechAssessmentCapabilities,
+} from "@/lib/speech-assessment/types";
+
+const SPEECHACE_ENDPOINT = "https://api.speechace.co/api/scoring/speech/v9/json";
+
+/** Dialect codes accepted by SpeechAce v9. */
+const ALLOWED_DIALECTS = [
+  "en-us",
+  "en-gb",
+  "fr-fr",
+  "fr-ca",
+  "es-es",
+  "es-mx",
+] as const;
+
+interface SpeechAceCredentials {
+  apiKey?: string;
+}
+
+interface SpeechAceConfig {
+  dialect?: string;
+  /** Optional billing-attribution user identifier passed on every call. */
+  userId?: string;
+  /** `default` | `strict` — strict mode penalises minor mispronunciations. */
+  pronunciationScoreMode?: string;
+}
+
+interface SpeechAceIeltsScore {
+  overall?: number;
+  pronunciation?: number;
+  fluency?: number;
+  grammar?: number;
+  vocab?: number;
+  coherence?: number;
+}
+
+interface SpeechAceResponse {
+  status?: string;
+  quota_remaining?: number;
+  speech_score?: {
+    ielts_score?: SpeechAceIeltsScore;
+    transcript?: string;
+    word_score_list?: unknown;
+  };
+}
+
+export class SpeechAceAdapter implements SpeechAssessmentAdapter {
+  readonly slug = "speechace";
+  private readonly apiKey: string | undefined;
+  private readonly dialect: string;
+  private readonly userId: string | undefined;
+  private readonly pronunciationScoreMode: string | undefined;
+
+  constructor(
+    credentials: Record<string, unknown>,
+    config: Record<string, unknown>,
+  ) {
+    const creds = credentials as SpeechAceCredentials;
+    const cfg = config as SpeechAceConfig;
+    this.apiKey = creds.apiKey;
+    this.dialect = cfg.dialect ?? "en-us";
+    this.userId = cfg.userId;
+    this.pronunciationScoreMode = cfg.pronunciationScoreMode;
+  }
+
+  getCapabilities(): SpeechAssessmentCapabilities {
+    return {
+      ieltsSupported: true,
+      spontaneousSupported: true,
+      scriptedSupported: false,
+      acceptsRecordingUrl: false,
+      requiresFileUpload: true,
+      transcriptIncluded: true,
+      perWordDiagnostics: true,
+      prosodyFeatures: false,
+    };
+  }
+
+  getConfigSchema(): ProviderConfigSchema {
+    return {
+      fields: [
+        {
+          key: "apiKey",
+          label: "SpeechAce API key",
+          type: "string",
+          help: 'Single API key issued by SpeechAce. Passed as the `?key=` query parameter on every scoring request. Get one at https://www.speechace.com — sign up gives ~120 minutes free credit for sandbox use.',
+          sensitive: true,
+          required: true,
+        },
+        {
+          key: "dialect",
+          label: "Dialect",
+          type: "enum",
+          enumValues: [...ALLOWED_DIALECTS],
+          default: "en-us",
+          help: "Spoken-language dialect SpeechAce will score against. `en-us` / `en-gb` for English IELTS. Adapter falls back to `en-us` when blank.",
+        },
+        {
+          key: "userId",
+          label: "User ID (billing attribution)",
+          type: "string",
+          help: "Optional anonymised identifier passed on every scoring call. SpeechAce uses it to break costs down by end-user in their dashboard. Safe to leave blank for sandbox.",
+        },
+        {
+          key: "pronunciationScoreMode",
+          label: "Pronunciation score mode",
+          type: "enum",
+          enumValues: ["default", "strict"],
+          default: "default",
+          help: "`default` is lenient — typical for IELTS. `strict` penalises minor phoneme errors — use for diagnostic / accent-training mode.",
+        },
+      ],
+    };
+  }
+
+  async scoreUploadedAudio(
+    buffer: Buffer,
+    mimeType: string,
+    mode: ScoringMode,
+  ): Promise<NormalisedScoreResult> {
+    if (!this.apiKey) {
+      throw new Error(
+        "SpeechAceAdapter: apiKey is not configured. Set credentials.apiKey on the SpeechAssessmentProvider row.",
+      );
+    }
+
+    const url = new URL(SPEECHACE_ENDPOINT);
+    url.searchParams.set("key", this.apiKey);
+    url.searchParams.set("dialect", this.dialect);
+    if (this.userId) {
+      url.searchParams.set("user_id", this.userId);
+    }
+
+    const form = new FormData();
+    form.set(
+      "user_audio_file",
+      new Blob([new Uint8Array(buffer)], { type: mimeType }),
+      filenameForMimeType(mimeType),
+    );
+    if (mode === "ielts") {
+      form.set("include_ielts_feedback", "1");
+    }
+    if (this.pronunciationScoreMode) {
+      form.set("pronunciation_score_mode", this.pronunciationScoreMode);
+    }
+
+    const res = await fetch(url.toString(), {
+      method: "POST",
+      body: form,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `SpeechAceAdapter: HTTP ${res.status} from scoring endpoint. Body: ${text.slice(0, 300)}`,
+      );
+    }
+
+    const body = (await res.json()) as SpeechAceResponse;
+
+    if (body.status && body.status !== "success") {
+      throw new Error(
+        `SpeechAceAdapter: vendor returned status="${body.status}" — scoring rejected.`,
+      );
+    }
+
+    const ielts = body.speech_score?.ielts_score;
+    return {
+      ielts: ielts
+        ? {
+            overall: ielts.overall ?? 0,
+            pronunciation: ielts.pronunciation ?? 0,
+            fluency: ielts.fluency ?? 0,
+            ...(ielts.grammar !== undefined ? { grammar: ielts.grammar } : {}),
+            ...(ielts.vocab !== undefined ? { vocabulary: ielts.vocab } : {}),
+            ...(ielts.coherence !== undefined
+              ? { coherence: ielts.coherence }
+              : {}),
+          }
+        : undefined,
+      transcript: body.speech_score?.transcript,
+      diagnostics: body.speech_score?.word_score_list,
+      raw: body,
+    };
+  }
+}
+
+/** Filename hint for the multipart upload. SpeechAce inspects the
+ *  filename extension to pick a decoder — `audio.bin` is rejected. */
+function filenameForMimeType(mimeType: string): string {
+  if (mimeType.includes("wav")) return "audio.wav";
+  if (mimeType.includes("mpeg") || mimeType.includes("mp3")) return "audio.mp3";
+  if (mimeType.includes("ogg")) return "audio.ogg";
+  if (mimeType.includes("webm")) return "audio.webm";
+  if (mimeType.includes("aiff")) return "audio.aiff";
+  if (mimeType.includes("m4a") || mimeType.includes("aac"))
+    return "audio.m4a";
+  return "audio.wav";
+}

--- a/apps/admin/lib/speech-assessment/providers/speechsuper/index.ts
+++ b/apps/admin/lib/speech-assessment/providers/speechsuper/index.ts
@@ -1,0 +1,277 @@
+/**
+ * SpeechSuper English Spontaneous Speech adapter (#1118).
+ *
+ * Wraps SpeechSuper's `speak.eval.pro` core (English unscripted IELTS
+ * scoring). Auth uses two SHA-1 signatures, both computed per call from
+ * a per-call epoch timestamp:
+ *   - connectSig = sha1(appKey + timestamp + secretKey)            (hex)
+ *   - startSig   = sha1(appKey + timestamp + userId + secretKey)   (hex)
+ *
+ * Both signatures + a JSON params blob are posted multipart alongside
+ * the audio file. The endpoint URL is path-suffixed with the coreType:
+ *   POST https://api.speechsuper.com/speak.eval.pro
+ *
+ * Docs source: https://docs.speechsuper.com. Reference implementation:
+ * https://github.com/speechsuper/SpeechSuper-API-Samples
+ * (http_samples/python_http_sample/sample.py).
+ *
+ * Audio constraints: 16-bit, 16kHz, mono. WAV format expected; adapter
+ * passes the buffer through verbatim — caller is responsible for any
+ * resampling. Test-connection MUST NOT call this endpoint (per-second
+ * cost).
+ */
+
+import * as crypto from "node:crypto";
+
+import type { ProviderConfigSchema } from "@/lib/voice/types";
+import type {
+  NormalisedScoreResult,
+  ScoringMode,
+  SpeechAssessmentAdapter,
+  SpeechAssessmentCapabilities,
+} from "@/lib/speech-assessment/types";
+
+const SPEECHSUPER_BASE_URL = "https://api.speechsuper.com/";
+const CORE_TYPE_SPONTANEOUS_IELTS = "speak.eval.pro";
+
+interface SpeechSuperCredentials {
+  appKey?: string;
+  secretKey?: string;
+}
+
+interface SpeechSuperConfig {
+  defaultUserId?: string;
+  /** `non_native` (default — IELTS candidates) or `native`. */
+  model?: string;
+  penalizeOfftopic?: boolean;
+}
+
+interface SpeechSuperIeltsBlock {
+  overall?: number;
+  pronunciation?: number;
+  fluency?: number;
+  grammar?: number;
+  vocabulary?: number;
+  coherence?: number;
+}
+
+interface SpeechSuperResponse {
+  errId?: number;
+  error?: string;
+  result?: {
+    ielts?: SpeechSuperIeltsBlock;
+    overall?: number;
+    pronunciation?: number;
+    fluency?: number;
+    grammar?: number;
+    vocabulary?: number;
+    transcription?: string;
+    words?: unknown;
+  };
+}
+
+export class SpeechSuperAdapter implements SpeechAssessmentAdapter {
+  readonly slug = "speechsuper";
+  private readonly appKey: string | undefined;
+  private readonly secretKey: string | undefined;
+  private readonly defaultUserId: string;
+  private readonly model: string;
+  private readonly penalizeOfftopic: boolean;
+
+  constructor(
+    credentials: Record<string, unknown>,
+    config: Record<string, unknown>,
+  ) {
+    const creds = credentials as SpeechSuperCredentials;
+    const cfg = config as SpeechSuperConfig;
+    this.appKey = creds.appKey;
+    this.secretKey = creds.secretKey;
+    this.defaultUserId = cfg.defaultUserId ?? "guest";
+    this.model = cfg.model ?? "non_native";
+    this.penalizeOfftopic = cfg.penalizeOfftopic ?? false;
+  }
+
+  getCapabilities(): SpeechAssessmentCapabilities {
+    return {
+      ieltsSupported: true,
+      spontaneousSupported: true,
+      scriptedSupported: false,
+      acceptsRecordingUrl: false,
+      requiresFileUpload: true,
+      transcriptIncluded: true,
+      perWordDiagnostics: true,
+      prosodyFeatures: true,
+    };
+  }
+
+  getConfigSchema(): ProviderConfigSchema {
+    return {
+      fields: [
+        {
+          key: "appKey",
+          label: "SpeechSuper app key",
+          type: "string",
+          help: "Application key issued by SpeechSuper (the public half of the credential pair). Combined with the secret key to form per-request HMAC-SHA1 signatures.",
+          sensitive: true,
+          required: true,
+        },
+        {
+          key: "secretKey",
+          label: "SpeechSuper secret key",
+          type: "string",
+          help: "Secret key paired with the app key. Used to sign every request — never sent to the vendor directly. Rotate via the SpeechSuper dashboard if leaked.",
+          sensitive: true,
+          required: true,
+        },
+        {
+          key: "defaultUserId",
+          label: "Default user ID (billing attribution)",
+          type: "string",
+          default: "guest",
+          help: "Anonymised identifier passed as the SpeechSuper `userId` field. Used by their dashboard to break down cost per end-user. Adapter falls back to `guest` when blank.",
+        },
+        {
+          key: "model",
+          label: "Scoring model",
+          type: "enum",
+          enumValues: ["non_native", "native"],
+          default: "non_native",
+          help: "`non_native` is the IELTS candidate default (more lenient on accent). `native` enforces native-speaker norms — use for advanced learners only.",
+        },
+        {
+          key: "penalizeOfftopic",
+          label: "Penalise off-topic answers",
+          type: "boolean",
+          default: false,
+          help: "When `true`, SpeechSuper deducts marks if the response strays from the prompt. Leave off unless you're feeding the prompt in via the question_prompt field — without context this just produces false negatives.",
+        },
+      ],
+    };
+  }
+
+  async scoreUploadedAudio(
+    buffer: Buffer,
+    mimeType: string,
+    mode: ScoringMode,
+  ): Promise<NormalisedScoreResult> {
+    if (!this.appKey || !this.secretKey) {
+      throw new Error(
+        "SpeechSuperAdapter: appKey and secretKey are not both configured. Set credentials.{appKey,secretKey} on the SpeechAssessmentProvider row.",
+      );
+    }
+
+    const coreType = CORE_TYPE_SPONTANEOUS_IELTS;
+    const url = `${SPEECHSUPER_BASE_URL}${coreType}`;
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const userId = this.defaultUserId;
+
+    const connectSig = crypto
+      .createHash("sha1")
+      .update(`${this.appKey}${timestamp}${this.secretKey}`)
+      .digest("hex");
+    const startSig = crypto
+      .createHash("sha1")
+      .update(`${this.appKey}${timestamp}${userId}${this.secretKey}`)
+      .digest("hex");
+
+    const audioType = audioTypeForMimeType(mimeType);
+
+    const params = {
+      connect: {
+        cmd: "connect",
+        param: {
+          sdk: { version: 16777472, source: 9, protocol: 2 },
+          app: { applicationId: this.appKey, sig: connectSig, timestamp },
+        },
+      },
+      start: {
+        cmd: "start",
+        param: {
+          app: {
+            userId,
+            applicationId: this.appKey,
+            timestamp,
+            sig: startSig,
+          },
+          audio: {
+            audioType,
+            channel: 1,
+            sampleBytes: 2,
+            sampleRate: 16000,
+          },
+          request: {
+            coreType,
+            tokenId: "tokenId",
+            ...(mode === "ielts" ? { test_type: "ielts" } : {}),
+            model: this.model,
+            penalize_offtopic: this.penalizeOfftopic ? 1 : 0,
+          },
+        },
+      },
+    };
+
+    const form = new FormData();
+    form.set("text", JSON.stringify(params));
+    form.set(
+      "audio",
+      new Blob([new Uint8Array(buffer)], { type: mimeType }),
+      `audio.${audioType}`,
+    );
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Request-Index": "0" },
+      body: form,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `SpeechSuperAdapter: HTTP ${res.status} from ${coreType}. Body: ${text.slice(0, 300)}`,
+      );
+    }
+
+    const body = (await res.json()) as SpeechSuperResponse;
+
+    if (body.errId !== undefined && body.errId !== 0) {
+      throw new Error(
+        `SpeechSuperAdapter: vendor returned errId=${body.errId} (${body.error ?? "unknown"})`,
+      );
+    }
+
+    const result = body.result;
+    const ieltsBlock = result?.ielts;
+    const overall = ieltsBlock?.overall ?? result?.overall;
+    const pronunciation =
+      ieltsBlock?.pronunciation ?? result?.pronunciation;
+    const fluency = ieltsBlock?.fluency ?? result?.fluency;
+    const grammar = ieltsBlock?.grammar ?? result?.grammar;
+    const vocabulary = ieltsBlock?.vocabulary ?? result?.vocabulary;
+    const coherence = ieltsBlock?.coherence;
+
+    return {
+      ielts:
+        overall !== undefined
+          ? {
+              overall,
+              pronunciation: pronunciation ?? 0,
+              fluency: fluency ?? 0,
+              ...(grammar !== undefined ? { grammar } : {}),
+              ...(vocabulary !== undefined ? { vocabulary } : {}),
+              ...(coherence !== undefined ? { coherence } : {}),
+            }
+          : undefined,
+      transcript: result?.transcription,
+      diagnostics: result?.words,
+      raw: body,
+    };
+  }
+}
+
+function audioTypeForMimeType(mimeType: string): string {
+  if (mimeType.includes("wav")) return "wav";
+  if (mimeType.includes("mp3") || mimeType.includes("mpeg")) return "mp3";
+  if (mimeType.includes("ogg")) return "ogg";
+  if (mimeType.includes("webm")) return "webm";
+  return "wav";
+}

--- a/apps/admin/lib/speech-assessment/types.ts
+++ b/apps/admin/lib/speech-assessment/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Speech-assessment provider abstraction (#1118).
+ *
+ * Parallel pattern to VoiceProvider but for SCORING vendors (SpeechAce,
+ * SpeechSuper) — vendors that take an uploaded audio buffer and return
+ * pronunciation / fluency / IELTS scores. Architecture rationale:
+ * docs-memory/project_voice_chain_contracts_boundary.md.
+ *
+ * The interface is upload-only: both known vendors require multipart
+ * file upload and neither offers a URL-fetch endpoint. The forthcoming
+ * PROSODY pipeline stage (#1119) will `fetch(Call.stereoRecordingUrl)`
+ * to obtain a Buffer, then call `scoreUploadedAudio`. A URL-fetch
+ * method can be added the day a real URL-fetch vendor is on the roadmap.
+ */
+
+import type { ProviderConfigSchema } from "@/lib/voice/types";
+
+export interface SpeechAssessmentCapabilities {
+  /** Vendor returns IELTS band scores (0.0–9.0). */
+  ieltsSupported: boolean;
+  /** Vendor scores unscripted / long-turn audio. */
+  spontaneousSupported: boolean;
+  /** Vendor scores read-aloud / prompted audio. */
+  scriptedSupported: boolean;
+  /** Vendor downloads the audio itself given a URL (none today). */
+  acceptsRecordingUrl: boolean;
+  /** Vendor requires HF to upload the audio bytes (both known vendors). */
+  requiresFileUpload: boolean;
+  /** Vendor returns a transcript alongside the scores. */
+  transcriptIncluded: boolean;
+  /** Vendor returns word-level pronunciation diagnostics. */
+  perWordDiagnostics: boolean;
+  /** Vendor surfaces pace / rhythm / stress prosody features. */
+  prosodyFeatures: boolean;
+}
+
+/**
+ * Vendor-agnostic score envelope emitted by every adapter. The PROSODY
+ * pipeline stage (#1119) consumes this shape — the raw vendor payload
+ * is kept in `raw` for forensic / audit but never read in shared code.
+ */
+export interface NormalisedScoreResult {
+  ielts?: {
+    /** Combined IELTS band 0.0–9.0. */
+    overall: number;
+    pronunciation: number;
+    fluency: number;
+    grammar?: number;
+    vocabulary?: number;
+    coherence?: number;
+  };
+  transcript?: string;
+  /** Vendor-specific word / phoneme detail (shape varies by vendor). */
+  diagnostics?: unknown;
+  /** Verbatim vendor response — never inspected in shared code. */
+  raw: unknown;
+}
+
+export type ScoringMode = "ielts" | "general";
+
+export interface SpeechAssessmentAdapter {
+  readonly slug: string;
+  getCapabilities(): SpeechAssessmentCapabilities;
+  getConfigSchema(): ProviderConfigSchema;
+
+  /**
+   * Score an uploaded audio buffer. REQUIRED on every adapter.
+   *
+   * Both known vendors (SpeechAce v9, SpeechSuper) require multipart
+   * file upload and neither offers a URL-fetch endpoint, so the
+   * interface is upload-only at this stage.
+   *
+   * - `buffer` — raw audio bytes. Adapter is responsible for any
+   *   re-encoding the vendor requires (e.g. SpeechSuper expects
+   *   16-bit / 16kHz / mono).
+   * - `mimeType` — `audio/wav` / `audio/mpeg` / `audio/ogg` etc. The
+   *   adapter maps this onto the vendor's expected `audioType`.
+   * - `mode` — `"ielts"` enables IELTS band rubric scoring; `"general"`
+   *   asks the vendor for generic prosody / pronunciation features.
+   *   Adapters that don't support a mode should throw a clear error.
+   *
+   * Returns a `NormalisedScoreResult`. Throws on vendor 4xx/5xx — the
+   * PROSODY stage catches and emits a `mode: "unavailable"` contract.
+   */
+  scoreUploadedAudio(
+    buffer: Buffer,
+    mimeType: string,
+    mode: ScoringMode,
+  ): Promise<NormalisedScoreResult>;
+}
+
+export interface SpeechAssessmentAdapterConstructor {
+  new (
+    credentials: Record<string, unknown>,
+    config: Record<string, unknown>,
+  ): SpeechAssessmentAdapter;
+}

--- a/apps/admin/prisma/migrations/20260605211608_speech_assessment_provider/migration.sql
+++ b/apps/admin/prisma/migrations/20260605211608_speech_assessment_provider/migration.sql
@@ -1,0 +1,29 @@
+-- #1118 — SpeechAssessmentProvider DB table. Parallel pattern to
+-- VoiceProvider (#1031). Multi-vendor scoring registry for SpeechAce +
+-- SpeechSuper. Adapter resolution via `adapterKey`; stable identifier
+-- via `slug` (immutable post-creation). Architecture note:
+-- docs-memory/project_voice_chain_contracts_boundary.md.
+--
+-- Seeded with two unconfigured rows (speechace, speechsuper; enabled:false,
+-- empty credentials) by prisma/seed-speech-assessment-providers.ts.
+
+-- CreateTable
+CREATE TABLE "SpeechAssessmentProvider" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "adapterKey" TEXT NOT NULL,
+    "credentials" JSONB NOT NULL DEFAULT '{}',
+    "config" JSONB NOT NULL DEFAULT '{}',
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SpeechAssessmentProvider_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SpeechAssessmentProvider_slug_key" ON "SpeechAssessmentProvider"("slug");
+CREATE INDEX "SpeechAssessmentProvider_slug_idx" ON "SpeechAssessmentProvider"("slug");
+CREATE INDEX "SpeechAssessmentProvider_isDefault_idx" ON "SpeechAssessmentProvider"("isDefault");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -4667,6 +4667,33 @@ model VoiceProvider {
   @@index([isDefault])
 }
 
+// SpeechAssessmentProvider — multi-vendor abstraction for SPEECH SCORING
+// vendors (SpeechAce, SpeechSuper). Parallel pattern to VoiceProvider —
+// different domain (scoring uploaded audio, not transporting voice calls)
+// so kept as a separate model rather than discriminating on a `kind` field.
+// Architecture rationale: docs-memory/project_voice_chain_contracts_boundary.md.
+//
+// Adapter resolution: lib/speech-assessment/provider-factory.ts uses
+// `adapterKey` to look up a registered adapter constructor in
+// lib/speech-assessment/adapter-registry.ts. `slug` is the stable
+// identifier callers reference (resolveSpeechAssessmentProviderForCaller);
+// it's immutable post-creation because Call FK references could rot.
+model SpeechAssessmentProvider {
+  id          String   @id @default(uuid())
+  slug        String   @unique
+  displayName String
+  adapterKey  String
+  credentials Json     @default("{}")
+  config      Json     @default("{}")
+  isDefault   Boolean  @default(false)
+  enabled     Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([slug])
+  @@index([isDefault])
+}
+
 // VoiceSystemSettings — cross-provider voice settings (AnyVoice #1044).
 //
 // Single-row settings document. Applies to every VoiceProvider — held

--- a/apps/admin/prisma/seed-speech-assessment-providers.ts
+++ b/apps/admin/prisma/seed-speech-assessment-providers.ts
@@ -1,0 +1,78 @@
+/**
+ * Seed the SpeechAssessmentProvider table (#1118).
+ *
+ * Idempotent: re-runs do NOT overwrite existing credentials. Both rows
+ * are created with `enabled: false` + empty credentials — an operator
+ * must go to /x/settings/voice-scoring-providers, paste vendor keys, and
+ * flip enabled to true before the PROSODY pipeline stage (#1119) can
+ * resolve them.
+ *
+ * Neither row is `isDefault: true` — the PROSODY stage is gated on a
+ * per-playbook config flag (Option A from the TL review), so no
+ * sandbox-wide default is needed.
+ *
+ * Usage (run on VM after migration):
+ *   npx tsx prisma/seed-speech-assessment-providers.ts
+ *
+ * Re-runs are safe; nothing is overwritten.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+interface SeedRow {
+  slug: string;
+  displayName: string;
+  adapterKey: string;
+}
+
+const ROWS: SeedRow[] = [
+  {
+    slug: "speechace",
+    displayName: "SpeechAce (v9)",
+    adapterKey: "speechace",
+  },
+  {
+    slug: "speechsuper",
+    displayName: "SpeechSuper (English Spontaneous)",
+    adapterKey: "speechsuper",
+  },
+];
+
+async function main() {
+  for (const row of ROWS) {
+    const existing = await prisma.speechAssessmentProvider.findUnique({
+      where: { slug: row.slug },
+    });
+    if (existing) {
+      console.log(
+        `[seed:speech-assessment] slug=${row.slug} already exists (id=${existing.id}) — leaving credentials unchanged.`,
+      );
+      continue;
+    }
+    const created = await prisma.speechAssessmentProvider.create({
+      data: {
+        slug: row.slug,
+        displayName: row.displayName,
+        adapterKey: row.adapterKey,
+        credentials: {},
+        config: {},
+        isDefault: false,
+        enabled: false,
+      },
+    });
+    console.log(
+      `[seed:speech-assessment] Created row slug=${row.slug} id=${created.id} (enabled=false; configure at /x/settings/voice-scoring-providers).`,
+    );
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("[seed:speech-assessment] FAILED:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/admin/tests/lib/speech-assessment/speechace.test.ts
+++ b/apps/admin/tests/lib/speech-assessment/speechace.test.ts
@@ -1,0 +1,144 @@
+/**
+ * SpeechAce adapter unit tests (#1118).
+ *
+ * Covers:
+ *   - getConfigSchema() + getCapabilities() return non-empty correctness
+ *   - scoreUploadedAudio normalises a fixture vendor response into the
+ *     NormalisedScoreResult shape with the correct IELTS field mapping
+ *   - scoreUploadedAudio throws when apiKey is missing
+ *   - scoreUploadedAudio throws on HTTP non-2xx
+ *
+ * Vendor docs source: https://api-docs.speechace.com (v9 endpoint).
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { SpeechAceAdapter } from "@/lib/speech-assessment/providers/speechace";
+
+describe("SpeechAceAdapter", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("declares non-empty getConfigSchema", () => {
+    const adapter = new SpeechAceAdapter({}, {});
+    const schema = adapter.getConfigSchema();
+    expect(schema.fields.length).toBeGreaterThan(0);
+    const keys = schema.fields.map((f) => f.key);
+    expect(keys).toContain("apiKey");
+    expect(keys).toContain("dialect");
+  });
+
+  it("marks apiKey as sensitive and required", () => {
+    const adapter = new SpeechAceAdapter({}, {});
+    const schema = adapter.getConfigSchema();
+    const apiKey = schema.fields.find((f) => f.key === "apiKey");
+    expect(apiKey?.sensitive).toBe(true);
+    expect(apiKey?.required).toBe(true);
+  });
+
+  it("declares IELTS + spontaneous + upload-only capabilities", () => {
+    const adapter = new SpeechAceAdapter({}, {});
+    const caps = adapter.getCapabilities();
+    expect(caps.ieltsSupported).toBe(true);
+    expect(caps.spontaneousSupported).toBe(true);
+    expect(caps.acceptsRecordingUrl).toBe(false);
+    expect(caps.requiresFileUpload).toBe(true);
+  });
+
+  it("scoreUploadedAudio normalises IELTS scores from speech_score.ielts_score", async () => {
+    const fixture = {
+      status: "success",
+      speech_score: {
+        ielts_score: {
+          overall: 7.5,
+          pronunciation: 8.0,
+          fluency: 7.0,
+          grammar: 7.5,
+          vocab: 7.0,
+          coherence: 8.0,
+        },
+        transcript: "I think the weather today is...",
+      },
+    };
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const adapter = new SpeechAceAdapter(
+      { apiKey: "test-key" },
+      { dialect: "en-gb" },
+    );
+    const buffer = Buffer.from([0x52, 0x49, 0x46, 0x46]);
+    const result = await adapter.scoreUploadedAudio(buffer, "audio/wav", "ielts");
+
+    expect(result.ielts).toEqual({
+      overall: 7.5,
+      pronunciation: 8.0,
+      fluency: 7.0,
+      grammar: 7.5,
+      vocabulary: 7.0,
+      coherence: 8.0,
+    });
+    expect(result.transcript).toBe("I think the weather today is...");
+    expect(result.raw).toEqual(fixture);
+  });
+
+  it("passes apiKey and dialect as query parameters", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ status: "success", speech_score: {} }), {
+        status: 200,
+      }),
+    );
+
+    const adapter = new SpeechAceAdapter(
+      { apiKey: "test-key-123" },
+      { dialect: "en-gb" },
+    );
+    await adapter.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts");
+
+    const calledUrl = fetchSpy.mock.calls[0]?.[0]?.toString() ?? "";
+    expect(calledUrl).toContain("key=test-key-123");
+    expect(calledUrl).toContain("dialect=en-gb");
+  });
+
+  it("throws when apiKey is missing", async () => {
+    const adapter = new SpeechAceAdapter({}, {});
+    await expect(
+      adapter.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts"),
+    ).rejects.toThrow(/apiKey is not configured/);
+  });
+
+  it("throws on HTTP non-2xx", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("unauthorised", { status: 401 }),
+    );
+
+    const adapter = new SpeechAceAdapter({ apiKey: "bad-key" }, {});
+    await expect(
+      adapter.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts"),
+    ).rejects.toThrow(/HTTP 401/);
+  });
+
+  it("throws when vendor returns a non-success status string", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ status: "audio_too_short" }), {
+        status: 200,
+      }),
+    );
+
+    const adapter = new SpeechAceAdapter({ apiKey: "test" }, {});
+    await expect(
+      adapter.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts"),
+    ).rejects.toThrow(/audio_too_short/);
+  });
+});

--- a/apps/admin/tests/lib/speech-assessment/speechsuper.test.ts
+++ b/apps/admin/tests/lib/speech-assessment/speechsuper.test.ts
@@ -1,0 +1,219 @@
+/**
+ * SpeechSuper adapter unit tests (#1118).
+ *
+ * Covers:
+ *   - getConfigSchema() declares both sensitive keys + spontaneous mode
+ *   - getCapabilities() declares IELTS + spontaneous + prosody
+ *   - scoreUploadedAudio computes the two SHA-1 signatures correctly
+ *   - scoreUploadedAudio normalises a fixture vendor response with IELTS
+ *     scores into NormalisedScoreResult
+ *   - scoreUploadedAudio throws when either credential is missing
+ *   - scoreUploadedAudio throws on vendor errId
+ *
+ * Vendor reference: github.com/speechsuper/SpeechSuper-API-Samples
+ * (http_samples/python_http_sample/sample.py) — confirmed signature
+ * computation: sha1(appKey + timestamp + secretKey).hexdigest() and
+ * sha1(appKey + timestamp + userId + secretKey).hexdigest().
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as crypto from "node:crypto";
+
+import { SpeechSuperAdapter } from "@/lib/speech-assessment/providers/speechsuper";
+
+describe("SpeechSuperAdapter", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("declares non-empty getConfigSchema with both sensitive keys", () => {
+    const adapter = new SpeechSuperAdapter({}, {});
+    const schema = adapter.getConfigSchema();
+    const keys = schema.fields.map((f) => f.key);
+    expect(keys).toContain("appKey");
+    expect(keys).toContain("secretKey");
+    const appKey = schema.fields.find((f) => f.key === "appKey");
+    const secretKey = schema.fields.find((f) => f.key === "secretKey");
+    expect(appKey?.sensitive).toBe(true);
+    expect(appKey?.required).toBe(true);
+    expect(secretKey?.sensitive).toBe(true);
+    expect(secretKey?.required).toBe(true);
+  });
+
+  it("declares IELTS + spontaneous + prosody capabilities", () => {
+    const adapter = new SpeechSuperAdapter({}, {});
+    const caps = adapter.getCapabilities();
+    expect(caps.ieltsSupported).toBe(true);
+    expect(caps.spontaneousSupported).toBe(true);
+    expect(caps.prosodyFeatures).toBe(true);
+    expect(caps.acceptsRecordingUrl).toBe(false);
+    expect(caps.requiresFileUpload).toBe(true);
+  });
+
+  it("computes SHA-1 signatures matching the SpeechSuper sample.py reference", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ errId: 0, result: { ielts: {} } }), {
+        status: 200,
+      }),
+    );
+
+    const fixedNow = 1717000000000; // 2024-05-29T18:26:40Z
+    vi.spyOn(Date, "now").mockReturnValue(fixedNow);
+
+    const appKey = "app-123";
+    const secretKey = "secret-abc";
+    const userId = "guest";
+    const timestamp = String(Math.floor(fixedNow / 1000));
+
+    const expectedConnectSig = crypto
+      .createHash("sha1")
+      .update(`${appKey}${timestamp}${secretKey}`)
+      .digest("hex");
+    const expectedStartSig = crypto
+      .createHash("sha1")
+      .update(`${appKey}${timestamp}${userId}${secretKey}`)
+      .digest("hex");
+
+    const adapter = new SpeechSuperAdapter(
+      { appKey, secretKey },
+      { defaultUserId: userId },
+    );
+    await adapter.scoreUploadedAudio(
+      Buffer.from([0x52, 0x49, 0x46, 0x46]),
+      "audio/wav",
+      "ielts",
+    );
+
+    const body = fetchSpy.mock.calls[0]?.[1]?.body as FormData;
+    const text = body.get("text");
+    expect(typeof text).toBe("string");
+    const params = JSON.parse(text as string);
+    expect(params.connect.param.app.sig).toBe(expectedConnectSig);
+    expect(params.start.param.app.sig).toBe(expectedStartSig);
+    expect(params.start.param.app.userId).toBe(userId);
+    expect(params.start.param.app.timestamp).toBe(timestamp);
+  });
+
+  it("posts to the speak.eval.pro endpoint with Request-Index header", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ errId: 0, result: { ielts: {} } }), {
+        status: 200,
+      }),
+    );
+
+    const adapter = new SpeechSuperAdapter(
+      { appKey: "a", secretKey: "s" },
+      {},
+    );
+    await adapter.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts");
+
+    const [url, init] = fetchSpy.mock.calls[0] ?? [];
+    expect(url).toContain("api.speechsuper.com/speak.eval.pro");
+    const headers = (init as RequestInit | undefined)?.headers as
+      | Record<string, string>
+      | undefined;
+    expect(headers?.["Request-Index"]).toBe("0");
+  });
+
+  it("normalises IELTS scores from result.ielts into NormalisedScoreResult", async () => {
+    const fixture = {
+      errId: 0,
+      result: {
+        ielts: {
+          overall: 6.5,
+          pronunciation: 7.0,
+          fluency: 6.0,
+          grammar: 6.5,
+          vocabulary: 6.5,
+          coherence: 7.0,
+        },
+        transcription: "Today I would like to talk about...",
+      },
+    };
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify(fixture), { status: 200 }),
+    );
+
+    const adapter = new SpeechSuperAdapter(
+      { appKey: "a", secretKey: "s" },
+      {},
+    );
+    const result = await adapter.scoreUploadedAudio(
+      Buffer.from([0]),
+      "audio/wav",
+      "ielts",
+    );
+
+    expect(result.ielts).toEqual({
+      overall: 6.5,
+      pronunciation: 7.0,
+      fluency: 6.0,
+      grammar: 6.5,
+      vocabulary: 6.5,
+      coherence: 7.0,
+    });
+    expect(result.transcript).toBe("Today I would like to talk about...");
+  });
+
+  it("falls back to top-level scores when result.ielts block is absent", async () => {
+    const fixture = {
+      errId: 0,
+      result: {
+        overall: 5.5,
+        pronunciation: 6.0,
+        fluency: 5.0,
+      },
+    };
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify(fixture), { status: 200 }),
+    );
+
+    const adapter = new SpeechSuperAdapter(
+      { appKey: "a", secretKey: "s" },
+      {},
+    );
+    const result = await adapter.scoreUploadedAudio(
+      Buffer.from([0]),
+      "audio/wav",
+      "ielts",
+    );
+    expect(result.ielts?.overall).toBe(5.5);
+    expect(result.ielts?.pronunciation).toBe(6.0);
+    expect(result.ielts?.fluency).toBe(5.0);
+  });
+
+  it("throws when appKey or secretKey is missing", async () => {
+    const noAppKey = new SpeechSuperAdapter({ secretKey: "s" }, {});
+    await expect(
+      noAppKey.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts"),
+    ).rejects.toThrow(/appKey and secretKey/);
+
+    const noSecretKey = new SpeechSuperAdapter({ appKey: "a" }, {});
+    await expect(
+      noSecretKey.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts"),
+    ).rejects.toThrow(/appKey and secretKey/);
+  });
+
+  it("throws when vendor returns non-zero errId", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({ errId: 16385, error: "audio too short" }),
+        { status: 200 },
+      ),
+    );
+
+    const adapter = new SpeechSuperAdapter(
+      { appKey: "a", secretKey: "s" },
+      {},
+    );
+    await expect(
+      adapter.scoreUploadedAudio(Buffer.from([0]), "audio/wav", "ielts"),
+    ).rejects.toThrow(/errId=16385/);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -14578,6 +14578,124 @@ Returns a hierarchical tree of the full taxonomy:
 
 ## Voice
 
+### `GET` /api/speech-assessment-providers
+
+List all registered speech assessment providers (SpeechAce,
+
+**Auth**: session ADMIN · **Scope**: `speech-assessment-providers:read`
+
+**Response** `200`
+```json
+{ ok: true, providers: SpeechAssessmentProvider[] (credentials masked) }
+```
+
+---
+
+### `POST` /api/speech-assessment-providers
+
+Create a new speech assessment provider. `adapterKey` must
+
+**Auth**: session ADMIN · **Scope**: `speech-assessment-providers:write`
+
+**Response** `201`
+```json
+{ ok: true, provider: SpeechAssessmentProvider (credentials masked) }
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `409`
+```json
+{ ok: false, error: "slug already exists" }
+```
+
+---
+
+### `DELETE` /api/speech-assessment-providers/[id]
+
+Delete a speech assessment provider. Refuses if the row
+
+**Auth**: session ADMIN · **Scope**: `speech-assessment-providers:write`
+
+**Response** `200`
+```json
+{ ok: true }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "not found" }
+```
+
+**Response** `409`
+```json
+{ ok: false, error: "cannot delete the default provider" }
+```
+
+---
+
+### `GET` /api/speech-assessment-providers/[id]
+
+Get a single speech assessment provider by id. Credentials
+
+**Auth**: session ADMIN · **Scope**: `speech-assessment-providers:read`
+
+**Response** `200`
+```json
+{ ok: true, provider, configSchema, capabilities }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "not found" }
+```
+
+---
+
+### `PATCH` /api/speech-assessment-providers/[id]
+
+Update a speech assessment provider. `slug` is immutable
+
+**Auth**: session ADMIN · **Scope**: `speech-assessment-providers:write`
+
+**Response** `200`
+```json
+{ ok: true, provider (credentials masked) }
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "not found" }
+```
+
+---
+
+### `POST` /api/speech-assessment-providers/[id]/test-connection
+
+Test that the adapter for a speech assessment provider is
+
+**Auth**: session ADMIN · **Scope**: `speech-assessment-providers:test`
+
+**Response** `200`
+```json
+{ ok: true, ping: { reachable: boolean, capabilities?, detail } }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "not found" }
+```
+
+---
+
 ### `GET` /api/voice-providers
 
 List all registered voice providers. Credentials are MASKED
@@ -15196,8 +15314,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 487 |
-| Files with annotations | 478 |
+| Route files found | 490 |
+| Files with annotations | 481 |
 | Files missing annotations | 9 |
 | Coverage | 98.2% |
 


### PR DESCRIPTION
## Summary

Closes the foundation half of the voice-scoring epic (#1118). Sister story #1119 (PROSODY pipeline wire-in) is unblocked by this PR.

Parallel pattern to `VoiceProvider`: separate Prisma model, separate adapter registry + factory, separate REST surface, separate admin UI. Architecture decision captured in [project_voice_chain_contracts_boundary.md](https://github.com/WANDERCOLTD/HF/blob/main/.claude/projects/-Users-paulwander-projects-HF/memory/project_voice_chain_contracts_boundary.md) — keep adapter layer as TypeScript code (not spec-driven); promote two distinct provider categories to two distinct tables.

## What ships

1. **Prisma model `SpeechAssessmentProvider`** — mirrors `VoiceProvider` columns exactly. Migration `20260605211608_speech_assessment_provider` is additive (no destructive change).
2. **TypeScript interface `SpeechAssessmentAdapter`** — `scoreUploadedAudio(buffer, mimeType, mode)` is **required** (both vendors require multipart upload). `scoreRecording` dropped per Tech Lead review.
3. **`SpeechAceAdapter`** — wraps `POST https://api.speechace.co/api/scoring/speech/v9/json?key=...&dialect=...`. IELTS path: `speech_score.ielts_score.{overall,pronunciation,fluency,grammar,vocab,coherence}`. Config: dialect enum (6 codes), userId, pronunciationScoreMode.
4. **`SpeechSuperAdapter`** — wraps `speak.eval.pro`. Two SHA-1 sigs computed exactly per the [reference Python sample](https://github.com/speechsuper/SpeechSuper-API-Samples/blob/main/http_samples/python_http_sample/sample.py). 16-bit / 16kHz / mono audio constraint documented.
5. **Adapter registry + factory** (`lib/speech-assessment/*`). TTL cache 5min; invalidate-on-write. `TODO: extract at 3rd provider type` comment per Tech Lead.
6. **6 REST routes** under `/api/speech-assessment-providers`. `test-connection` is `getCapabilities()`-only — zero vendor cost.
7. **Admin UI** at `/x/settings/voice-scoring-providers` with `fieldPresence` helper + presence badges (clone of #1115 pattern), stay-on-page + save-diff banner, capabilities section.
8. **Sidebar entry** "Voice Scoring" under communications.
9. **Seed** — both vendors as `enabled:false`, empty credentials. Operator pastes keys via admin UI.
10. **16 vitests** covering schema declarations, capabilities, request shape (query params, sigs, headers), response normalisation, missing-credential errors, vendor 4xx, vendor errId.

## Vendor field requirements (verified from docs)

| Vendor | Sensitive | Config |
|---|---|---|
| **SpeechAce** | `apiKey` | `dialect` (en-us/en-gb/fr-fr/fr-ca/es-es/es-mx), `userId`, `pronunciationScoreMode` |
| **SpeechSuper** | `appKey`, `secretKey` | `defaultUserId`, `model` (non_native/native), `penalizeOfftopic` |

## Verification

- [x] `npx tsc --noEmit` clean on changed files (pre-existing errors elsewhere unchanged)
- [x] `npx vitest run tests/lib/speech-assessment` — **16/16 passed**
- [ ] **Manual (post-merge):** `/vm-cpp` migrates + seeds; visit `/x/settings/voice-scoring-providers`; both rows visible; click into SpeechAce; presence badges read `(currently unset)`; save fields; badges flip to `(currently set)`; test-connection returns capability summary.

## Out of scope (sister story #1119)

- `PROSODY` pipeline stage
- `voice-prosody-features` DataContract
- `Call.voiceProsody` column
- Per-playbook `tierPresetId` → mode resolution

## Deploy

`/vm-cpp` (migration + seed). Migration is additive — no destructive operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)