### PR TITLE
fix(qualification): rules-of-hooks in QualificationCard.tsx (unblock CI ratchet)

### DIFF
--- a/apps/admin/components/student/qualification/QualificationCard.tsx
+++ b/apps/admin/components/student/qualification/QualificationCard.tsx
@@ -49,17 +49,19 @@ export function QualificationCard({
   onStartCall,
 }: QualificationCardProps): React.ReactElement | null {
   const { qualification, units, skills, nextBestStep } = data;
-  if (!qualification) return null;
 
-  const initialExpanded = qualification.weakestUnitSlug ?? units[0]?.moduleSlug ?? null;
+  const initialExpanded = qualification?.weakestUnitSlug ?? units[0]?.moduleSlug ?? null;
   const [expandedUnit, setExpandedUnit] = useState<string | null>(initialExpanded);
 
   const fraction = useMemo(() => {
-    if (qualification.losTotal === 0) return null;
+    if (!qualification || qualification.losTotal === 0) return null;
     return qualification.losAtTierOrAbove / qualification.losTotal;
-  }, [qualification.losAtTierOrAbove, qualification.losTotal]);
+  }, [qualification]);
 
   const sortedSkills = useMemo(() => sortByTierDesc(skills), [skills]);
+
+  if (!qualification) return null;
+
   const isColdStart = qualification.tier == null;
 
   return (


### PR DESCRIPTION
Fixes 3 react-hooks/rules-of-hooks errors in `QualificationCard.tsx` that have been failing the **Lint & Type Check** ratchet gate on every PR since #1109/#1110 landed.

```
QualificationCard.tsx:
  55:43  error  React Hook "useState" is called conditionally...
  57:20  error  React Hook "useMemo" is called conditionally...
  62:24  error  React Hook "useMemo" is called conditionally...
```

## Fix

Moved hooks above the `if (!qualification) return null` early return. `useMemo` body guards against `qualification === null` defensively. Zero behavior change for the rendering path (`return null` still fires before any UI).

## Result

```
✅ lint_errors: 0 (== baseline)
```

Other ratchet items (+3 tsc, +8 lint_warnings) are out of scope here — different files, different recent PRs. This PR unblocks the **hard error** gate so any in-flight PR (notably V6 #1085) can re-merge main and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)