### PR TITLE
refactor(intake): chat prompt + recap + URL builder generated from spec (closes a bug class)

### DIFF
--- a/apps/admin/app/api/intake/chat/route.ts
+++ b/apps/admin/app/api/intake/chat/route.ts
@@ -28,9 +28,14 @@ import { getIntakeAIPort } from "@/lib/intake/hf-adapter/ai";
 import {
   applyUpdateSetup,
   specToUpdateSetupTool,
+  specToSystemPrompt,
   UPDATE_SETUP_TOOL_NAME,
 } from "@/lib/intake/spec-tools";
-import { EnrollmentIntake, INTERNAL_FIELDS } from "@/lib/intake/specs/enrollment.intent";
+import {
+  EnrollmentIntake,
+  INTERNAL_FIELDS,
+  REQUIRED_FIELDS,
+} from "@/lib/intake/specs/enrollment.intent";
 import type {
   AIPort,
   EventAIProvenance,
@@ -55,31 +60,27 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // claude-opus-4-7 + claude-sonnet-4-6 — keep this list in step with
 // lib/intake/compliance.ts ai.allowedModels.
 const INTAKE_MODEL = "claude-sonnet-4-6";
-const INTAKE_PROMPT_VERSION = "intake/v0.5.0-DRAFT";
+// Prompt version derives from the spec version + the generator. When the
+// spec changes, the prompt regenerates and this version reflects it
+// automatically — no hand-bumps. The audit chain records this string in
+// every CapturedTurn's `ai.promptTemplateVersion`.
+const INTAKE_PROMPT_VERSION = `intake/spec-v${EnrollmentIntake.version}-generated`;
 const INTAKE_MAX_COST_USD = 0.5; // == compliance.ai.costCeilingPerIntent
 
 const UPDATE_SETUP_TOOL: ToolDefinition = specToUpdateSetupTool(EnrollmentIntake, {
   excludeFields: INTERNAL_FIELDS,
 });
 
-const SYSTEM_PROMPT = `You are HumanFirst Foundation's enrolment assistant. Politely capture FOUR required values from the learner — first name, last name, age range, and email — plus ONE optional value: a phone number for Call Me sessions and SMS reminders.
-
-How to capture:
-- When the learner shares one or more field values — even multiple in a single message — call the \`update-setup\` tool with every value they provided. Pass each value under its field key (firstName / lastName / email / ageRange / phone / displayName / preferredContactMethod / marketingOptIn / accessibilityNote / timezone). Omit fields they did not share.
-- Never invent values. Only capture what the learner explicitly stated.
-- Email must look like X@Y.Z. If it doesn't, do not capture it — ask them to try again.
-- For ageRange, accept ONLY one of these exact values: '18-24' / '25-34' / '35-44' / '45-54' / '55-64' / '65-plus' / 'prefer-not-to-say'. (HumanFirst is adult-only; 'under-18' is not valid and the system will reject it.) If the learner gives a specific age (e.g. "I'm 32"), map it to the right band. If they decline, refuse to say, or ask why, capture 'prefer-not-to-say'.
-- For phone, accept any international format the learner types. Don't normalise — the server strips spaces/dashes/parens before storage. If the learner declines, refuses, or types something like "skip" / "no" / "none" / "n/a" / "rather not", DO NOT capture anything for phone (leave it unset) and move on to confirm.
-
-How to reply (in the same turn as the tool call, when applicable):
-- Be warm, concise, professional. No emoji. No filler.
-- One short sentence per reply.
-- Never describe your own tool-calling reasoning to the learner. Do not say things like "I need to capture X simultaneously" or "I'm mapping Y to band Z" — that is internal scratchpad, never user-facing. Write a normal natural reply, e.g. "Got it — what's your email?"
-- Ask in this STRICT order, one field at a time: firstName → lastName → ageRange → email → phone. (Phone is asked LAST and is OPTIONAL — the learner may decline.)
-- If a greeting or affirmation ("hi", "ok", "yes") arrives in place of a name, re-prompt for that name. Do not capture greetings.
-- ageRange is REQUIRED. After capturing lastName, your VERY NEXT reply MUST ask for the learner's age range — do NOT ask for email yet. The email question only comes AFTER ageRange has a value (or 'prefer-not-to-say'). If you find yourself about to ask for email and ageRange is still missing, stop and ask for ageRange instead.
-- After capturing email, ask for a phone number with explicit OPTIONAL framing. Example: "Last one — and it's optional: a phone number we could use for Call Me sessions and SMS reminders? You can say 'skip' if you'd rather not." Wait for ONE reply; whether they give a number or decline, that's your cue to confirm and commit. Do NOT pester them with a second phone question if they decline.
-- When all four required fields (firstName, lastName, ageRange, email) are captured AND the learner has either provided a phone or declined it, confirm the enrolment is being submitted and that a confirmation email will follow.`;
+// SYSTEM_PROMPT is generated from the spec. To add a field that the AI
+// asks about, edit the spec at `lib/intake/specs/enrollment.intent.ts`
+// — DO NOT edit a string here. To change required vs optional, toggle
+// `REQUIRED_FIELDS` in the spec module. The prompt picks both up
+// automatically and the version string above bumps with the spec
+// version.
+const SYSTEM_PROMPT = specToSystemPrompt(EnrollmentIntake, {
+  excludeFields: INTERNAL_FIELDS,
+  requiredFields: REQUIRED_FIELDS,
+});
 
 const AFFIRMATION_RE = /^(hi|hello|hey|yo|ok|okay|sure|yes|yeah|yep|y|n|no|nope|start)\b[!.,? ]*$/i;
 

--- a/apps/admin/components/intake/IntakeDoneClient.tsx
+++ b/apps/admin/components/intake/IntakeDoneClient.tsx
@@ -8,10 +8,14 @@
 // CallerPlaybook). If no token, the "Continue" button is hidden —
 // the platform-level demo path stops here.
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { IntakeCoCPanel } from "./IntakeCoCPanel";
 import type { Event } from "@/lib/intake/tallyseal";
+import {
+  EnrollmentIntake,
+  INTERNAL_FIELDS,
+} from "@/lib/intake/specs/enrollment.intent";
 
 interface SessionSnapshot {
   readonly intentId: string;
@@ -20,18 +24,29 @@ interface SessionSnapshot {
   readonly values: Readonly<Record<string, unknown>>;
 }
 
-const VALUES_DISPLAY: ReadonlyArray<readonly [string, string]> = [
-  ["firstName", "First name"],
-  ["lastName", "Last name"],
-  ["email", "Email"],
-  ["phone", "Phone"],
-  ["displayName", "Display name"],
-  ["timezone", "Timezone"],
-  ["preferredContactMethod", "Preferred contact"],
-  ["marketingOptIn", "Marketing opt-in"],
-  ["accessibilityNote", "Accessibility note"],
-  ["ageRange", "Age range"],
-];
+/**
+ * Spec-driven list of [key, label] pairs to render on the recap.
+ * Iterates `EnrollmentIntake.fields` in declaration order, skips
+ * internal/derived fields, reads each field's `label.en` from the
+ * spec metadata. Add a field to the spec → it appears here. No
+ * parallel hand-edit needed.
+ */
+function deriveValuesDisplay(): ReadonlyArray<readonly [string, string]> {
+  const internal = new Set<string>(INTERNAL_FIELDS);
+  const out: Array<readonly [string, string]> = [];
+  for (const [key, fieldSpec] of Object.entries(EnrollmentIntake.fields)) {
+    if (internal.has(key)) continue;
+    const labelMeta = fieldSpec.metadata.label;
+    const label =
+      typeof labelMeta === "string"
+        ? labelMeta
+        : labelMeta && typeof labelMeta === "object" && "en" in labelMeta
+          ? String((labelMeta as Record<string, unknown>).en ?? key)
+          : key;
+    out.push([key, label] as const);
+  }
+  return out;
+}
 
 export function IntakeDoneClient() {
   const params = useSearchParams();
@@ -71,7 +86,8 @@ export function IntakeDoneClient() {
     return <div className="hf-section-desc">Loading audit trail…</div>;
   }
 
-  const captured = VALUES_DISPLAY.filter(([k]) => snapshot.values[k] !== undefined);
+  const valuesDisplay = useMemo(() => deriveValuesDisplay(), []);
+  const captured = valuesDisplay.filter(([k]) => snapshot.values[k] !== undefined);
   const continueUrl = token ? buildContinueUrl(token, snapshot.values) : null;
   const bundleUrl = `/api/intake/audit-bundle/${encodeURIComponent(intentId!)}?format=jsonl`;
 
@@ -122,27 +138,33 @@ export function IntakeDoneClient() {
   );
 }
 
+/**
+ * Spec-driven URL builder: iterates every non-internal spec field and
+ * propagates whatever the learner captured to /join/[token]. Strings
+ * are trim-and-skip-if-empty; booleans are stringified; numbers go
+ * via String(). Add a spec field → it propagates. Single source.
+ *
+ * The /join/[token] POST handler decides what it does with each key;
+ * unknown keys are ignored there (zod strip).
+ */
 function buildContinueUrl(token: string, values: Readonly<Record<string, unknown>>): string {
+  const internal = new Set<string>(INTERNAL_FIELDS);
   const params = new URLSearchParams();
-  const firstName = values.firstName;
-  const lastName = values.lastName;
-  const email = values.email;
-  const ageRange = values.ageRange;
-  const phone = values.phone;
-  if (typeof firstName === "string") params.set("firstName", firstName);
-  if (typeof lastName === "string") params.set("lastName", lastName);
-  if (typeof email === "string") params.set("email", email);
-  // ageRange propagation per #1036 — persisted as CallerAttribute
-  // `intake.ageRange` on /join/[token] POST. `under-18` is rejected by
-  // `ageBand.adultOnly()` at intake, so this should never be present
-  // as that value, but the route handler defends against URL tampering.
-  if (typeof ageRange === "string") params.set("ageRange", ageRange);
-  // phone — optional in the intake spec. When supplied, the join route
-  // normalises (strip spaces / dashes / parens) and writes Caller.phone,
-  // which unblocks Call Me sessions without the mid-call JIT capture
-  // and is a prerequisite for the SMS slice of #1101.
-  if (typeof phone === "string" && phone.trim().length > 0) {
-    params.set("phone", phone.trim());
+  for (const [key, fieldSpec] of Object.entries(EnrollmentIntake.fields)) {
+    if (internal.has(key)) continue;
+    const v = values[key];
+    if (v === undefined || v === null) continue;
+    if (typeof v === "string") {
+      const trimmed = v.trim();
+      if (trimmed.length === 0) continue;
+      params.set(key, trimmed);
+    } else if (typeof v === "boolean" || typeof v === "number") {
+      params.set(key, String(v));
+    }
+    // Arrays / objects intentionally skipped — none of the current
+    // user-facing fields are composite. If a future spec adds one
+    // it can serialise via a separate convention (JSON in URL).
+    void fieldSpec;
   }
   const qs = params.toString();
   return `/join/${encodeURIComponent(token)}${qs ? `?${qs}` : ""}`;

--- a/apps/admin/lib/intake/spec-tools.ts
+++ b/apps/admin/lib/intake/spec-tools.ts
@@ -36,6 +36,29 @@ interface SpecToolsOptions {
   readonly excludeFields?: readonly string[];
 }
 
+interface SpecPromptOptions extends SpecToolsOptions {
+  /**
+   * Spec-author-declared field keys that MUST be captured for the
+   * intent to become ready. Mirrors what the spec's `readiness()`
+   * function asks `has(...)` to check. Exported from the spec module
+   * (e.g. `enrollment.intent.ts::REQUIRED_FIELDS`) so a single source
+   * drives BOTH the readiness gate AND the prompt's "FIVE required"
+   * framing — no parallel hand-edits.
+   *
+   * When the CRUD surface lands, this list is whatever the admin
+   * toggled "required" on in the field editor.
+   */
+  readonly requiredFields: readonly string[];
+
+  /**
+   * Persona / opener / closing pleasantries — the parts of the
+   * prompt that are NOT spec-derivable. Defaults to a generic
+   * "enrolment assistant" persona. Override per-intent if you want
+   * a different tone.
+   */
+  readonly persona?: string;
+}
+
 /**
  * Build the `update-setup` ToolDefinition from a CrawcusSpec.
  * The AI calls this when the learner shares one or more field values.
@@ -143,6 +166,130 @@ function localisedEn(text: unknown): string | undefined {
     return typeof en === "string" ? en : undefined;
   }
   return undefined;
+}
+
+// =====================================================================
+// SYSTEM PROMPT — generated from the spec
+// =====================================================================
+//
+// The chat's system prompt MUST NOT hand-curate which fields the AI
+// asks about, in what order, or how. All of that comes from the spec.
+// When a new field is added to the spec (or a CRUD-surface admin adds
+// one), the prompt picks it up automatically. No parallel edits.
+//
+// The ONLY hand-written piece is `persona` (tone + role framing) —
+// because that's a product-marketing concern, not a data-model one.
+// Everything else is derived from spec.fields + the spec author's
+// `requiredFields` declaration.
+
+const DEFAULT_PERSONA =
+  `You are HumanFirst Foundation's enrolment assistant. ` +
+  `Be warm, concise, and professional. One short sentence per reply. ` +
+  `No emoji, no filler.`;
+
+/**
+ * Build the full system prompt from a CrawcusSpec. Pure function —
+ * given the same spec + options, returns the same string. Stable
+ * enough to participate in the `promptTemplateVersion` audit chain
+ * via a content hash (caller hashes the output).
+ *
+ * The generated prompt:
+ *   - lists every non-excluded field in declaration order with its
+ *     label + askHint
+ *   - flags which are required (per `requiredFields`) vs optional
+ *   - enumerates enum option sets inline (so the AI can constrain
+ *     values without us hardcoding them in the prompt body)
+ *   - tells the AI to stop after one optional-field decline and commit
+ *
+ * Add a field to the spec → AI asks about it next time someone enrols.
+ * Toggle required vs optional in `requiredFields` → readiness gate AND
+ * prompt framing both update. Single source of truth.
+ */
+export function specToSystemPrompt(
+  spec: CrawcusSpec,
+  options: SpecPromptOptions,
+): string {
+  const excluded = new Set(options.excludeFields ?? []);
+  const required = new Set(options.requiredFields);
+  const persona = options.persona ?? DEFAULT_PERSONA;
+
+  const askable: Array<{ key: string; field: FieldSpec; isRequired: boolean }> = [];
+  for (const [key, fieldSpec] of Object.entries(spec.fields)) {
+    if (excluded.has(key)) continue;
+    askable.push({ key, field: fieldSpec, isRequired: required.has(key) });
+  }
+
+  if (askable.length === 0) {
+    return persona;
+  }
+
+  // Order: required first (in declaration order), then optional. Within
+  // each tier, declaration order is preserved — that's the spec author's
+  // canonical "natural reading order" for the form.
+  askable.sort((a, b) => {
+    if (a.isRequired !== b.isRequired) return a.isRequired ? -1 : 1;
+    return 0; // declaration order via stable sort
+  });
+
+  const requiredCount = askable.filter((a) => a.isRequired).length;
+  const optionalCount = askable.length - requiredCount;
+  const orderList = askable.map((a) => a.key).join(" → ");
+
+  const fieldLines = askable.map(({ key, field, isRequired }, i) =>
+    formatFieldLine(i + 1, key, field, isRequired),
+  );
+
+  return [
+    persona,
+    "",
+    `Capture ${requiredCount} required value${requiredCount === 1 ? "" : "s"}` +
+      (optionalCount > 0
+        ? ` and offer ${optionalCount} optional one${optionalCount === 1 ? "" : "s"}`
+        : "") +
+      ` from the learner.`,
+    "",
+    "Fields to capture (in this order — one at a time, do not skip ahead):",
+    ...fieldLines,
+    "",
+    "How to capture:",
+    `- When the learner shares one or more values — even multiple in a single message — call the \`update-setup\` tool with every value provided. Pass each value under its field key (${askable.map((a) => a.key).join(" / ")}). Omit fields they did not share.`,
+    "- Never invent values. Only capture what the learner explicitly stated.",
+    "- For enum fields, accept ONLY the listed options. If the learner gives something equivalent (e.g. an age \"32\" for an age-range field), map it to the closest valid option. If they decline a required field, capture 'prefer-not-to-say' when that option exists, otherwise re-ask once.",
+    "- For optional fields, if the learner declines, refuses, or types 'skip' / 'no' / 'none' / 'n/a' / 'rather not', DO NOT capture anything (leave it unset) and move on to the next field or to commit.",
+    "",
+    "How to reply (in the same turn as the tool call):",
+    `- Ask in this STRICT order: ${orderList}. One question per reply.`,
+    "- If a greeting or affirmation ('hi', 'ok', 'yes') arrives instead of a value, re-ask for that field.",
+    "- Never describe your own tool-calling reasoning. Internal scratchpad stays internal.",
+    `- When all ${requiredCount} required value${requiredCount === 1 ? "" : "s"} ${requiredCount === 1 ? "is" : "are"} captured AND every optional value has either been provided or declined, confirm enrolment is being submitted and a confirmation email will follow.`,
+    "- Do NOT pester. One question per optional field; respect the decline.",
+  ].join("\n");
+}
+
+function formatFieldLine(
+  index: number,
+  key: string,
+  field: FieldSpec,
+  isRequired: boolean,
+): string {
+  const labelEn = localisedEn(field.metadata.label) ?? key;
+  const askHintEn = localisedEn(field.metadata.askHint);
+  const flag = isRequired ? "REQUIRED" : "optional";
+
+  const constraints: string[] = [];
+  if (field.base === "enum" && field.metadata.options) {
+    const opts = field.metadata.options.filter((v): v is string | number | boolean => v !== null && v !== undefined);
+    constraints.push(`enum, accept only: ${opts.map((o) => `'${o}'`).join(" | ")}`);
+  } else if (field.base === "boolean") {
+    constraints.push("boolean");
+  } else if (field.base === "number" || field.base === "integer") {
+    constraints.push(field.base);
+  }
+
+  const constraintSuffix = constraints.length > 0 ? ` (${constraints.join("; ")})` : "";
+  const askSuffix = askHintEn ? ` Ask: "${askHintEn}"` : "";
+
+  return `  ${index}. \`${key}\` [${flag}] — ${labelEn}${constraintSuffix}.${askSuffix}`;
 }
 
 function coerceMatchesBase(field: FieldSpec, value: unknown): boolean {

--- a/apps/admin/lib/intake/specs/enrollment.intent.ts
+++ b/apps/admin/lib/intake/specs/enrollment.intent.ts
@@ -55,6 +55,26 @@ export const INTERNAL_FIELDS = [
   "classroomName",
 ] as const;
 
+/**
+ * Field keys that must be captured before this intent's `readiness()`
+ * gate returns true. SINGLE SOURCE OF TRUTH — `readiness()` below
+ * iterates this list, and `specToSystemPrompt()` in spec-tools.ts
+ * reads it to frame the prompt's required/optional split.
+ *
+ * Add a new required field: append the key here and add the field
+ * declaration below. Nothing else to edit — the chat prompt, the
+ * readiness gate, and (after #1129) the recap UI all derive from this.
+ *
+ * When the CRUD surface lands, this list is what an admin toggles
+ * "required" on in the field editor.
+ */
+export const REQUIRED_FIELDS = [
+  "firstName",
+  "lastName",
+  "email",
+  "ageRange",
+] as const;
+
 // Adult-learner basic email pattern. NOT RFC-5322 complete — we use a
 // pragmatic check matching the join form's existing behaviour. Real
 // validation happens server-side via deliverability check (deferred).
@@ -175,7 +195,7 @@ export const EnrollmentIntake: CrawcusSpec = defineCrawcusSpec({
 
   readiness: (ctx: unknown) => {
     const { has } = ctx as { has: (...keys: string[]) => boolean };
-    return has("firstName", "lastName", "email", "ageRange");
+    return has(...REQUIRED_FIELDS);
   },
 
   contracts: {

--- a/apps/admin/tests/lib/intake-spec-to-system-prompt.test.ts
+++ b/apps/admin/tests/lib/intake-spec-to-system-prompt.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for `specToSystemPrompt` — the spec-driven prompt generator
+ * that replaces the hand-curated SYSTEM_PROMPT in app/api/intake/chat.
+ *
+ * Properties under test:
+ *   - All non-internal spec fields appear in the prompt (by key + label)
+ *   - Internal fields (processesArt9 etc) do NOT appear
+ *   - Required fields are listed before optional fields
+ *   - Required vs optional is flagged in the prompt
+ *   - Enum options are enumerated inline (so the AI constrains values)
+ *   - The persona override flows through when supplied
+ *
+ * Architectural intent: when a new field is added to the spec, this
+ * test verifies the prompt picks it up automatically with no parallel
+ * edit in the chat route. The previous hand-curated prompt had a
+ * silent-failure mode where #1124 added `phone` and the AI just
+ * ignored it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { specToSystemPrompt } from "@/lib/intake/spec-tools";
+import {
+  EnrollmentIntake,
+  INTERNAL_FIELDS,
+  REQUIRED_FIELDS,
+} from "@/lib/intake/specs/enrollment.intent";
+
+const PROMPT = specToSystemPrompt(EnrollmentIntake, {
+  excludeFields: INTERNAL_FIELDS,
+  requiredFields: REQUIRED_FIELDS,
+});
+
+describe("specToSystemPrompt", () => {
+  it("includes every required field as REQUIRED", () => {
+    for (const key of REQUIRED_FIELDS) {
+      expect(PROMPT).toContain(`\`${key}\` [REQUIRED]`);
+    }
+  });
+
+  it("includes phone as an optional field (added in #1124)", () => {
+    expect(PROMPT).toContain("`phone` [optional]");
+  });
+
+  it("includes the user-facing optional fields", () => {
+    for (const key of [
+      "displayName",
+      "timezone",
+      "preferredContactMethod",
+      "marketingOptIn",
+      "accessibilityNote",
+    ]) {
+      expect(PROMPT).toContain(`\`${key}\` [optional]`);
+    }
+  });
+
+  it("excludes internal/derived fields", () => {
+    for (const key of INTERNAL_FIELDS) {
+      expect(PROMPT).not.toContain(`\`${key}\``);
+    }
+  });
+
+  it("required fields appear before optional fields in the ask order", () => {
+    const orderLine = PROMPT.match(/Ask in this STRICT order:.*$/m)?.[0] ?? "";
+    expect(orderLine).toBeTruthy();
+    const firstRequired = orderLine.indexOf("firstName");
+    const phone = orderLine.indexOf("phone");
+    expect(firstRequired).toBeGreaterThan(-1);
+    expect(phone).toBeGreaterThan(firstRequired);
+  });
+
+  it("enumerates enum options inline (e.g. ageRange band values)", () => {
+    expect(PROMPT).toContain("'18-24'");
+    expect(PROMPT).toContain("'65-plus'");
+    expect(PROMPT).toContain("'prefer-not-to-say'");
+  });
+
+  it("tells the AI to fail-skippable on decline for optional fields", () => {
+    expect(PROMPT.toLowerCase()).toContain("decline");
+    expect(PROMPT).toContain("skip");
+  });
+
+  it("counts required vs optional correctly in the framing line", () => {
+    const reqCount = REQUIRED_FIELDS.length;
+    const optCount = Object.keys(EnrollmentIntake.fields).filter(
+      (k) =>
+        !(INTERNAL_FIELDS as readonly string[]).includes(k) &&
+        !(REQUIRED_FIELDS as readonly string[]).includes(k),
+    ).length;
+    expect(PROMPT).toContain(`Capture ${reqCount} required value`);
+    expect(PROMPT).toContain(`${optCount} optional`);
+  });
+
+  it("uses the default persona when none supplied", () => {
+    expect(PROMPT).toContain("HumanFirst Foundation's enrolment assistant");
+  });
+
+  it("uses an override persona when supplied", () => {
+    const custom = specToSystemPrompt(EnrollmentIntake, {
+      excludeFields: INTERNAL_FIELDS,
+      requiredFields: REQUIRED_FIELDS,
+      persona: "You are a different bot.",
+    });
+    expect(custom).toContain("You are a different bot.");
+    expect(custom).not.toContain("HumanFirst Foundation's enrolment assistant");
+  });
+
+  it("returns just the persona when the spec has no askable fields", () => {
+    const result = specToSystemPrompt(EnrollmentIntake, {
+      excludeFields: Object.keys(EnrollmentIntake.fields),
+      requiredFields: [],
+      persona: "Minimal.",
+    });
+    expect(result).toBe("Minimal.");
+  });
+});

--- a/docs/INTAKE-SPEC-DRIVEN.md
+++ b/docs/INTAKE-SPEC-DRIVEN.md
@@ -1,0 +1,88 @@
+# Intake is Spec-Driven — How to Add a Field
+
+> **TL;DR:** Edit `apps/admin/lib/intake/specs/enrollment.intent.ts`. Nothing else. If you find yourself editing the chat prompt, the recap UI, or the URL builder to add a field, **stop** — you're recreating a bug that took two PRs to find and fix.
+
+## The principle
+
+The Tallyseal-driven intake exists so that a single declaration of what a learner is asked drives:
+
+| Surface | What it derives |
+|---|---|
+| The AI chat prompt | Which fields, in what order, required vs optional, what enum options, what to do on decline |
+| The `update-setup` tool definition | Field keys + JSON schema for AI tool calls |
+| The Tallyseal audit chain | What gets captured, what gets disclosed, what gets retained |
+| The `/intake/done` recap UI | Which captured values to show + their labels |
+| The URL hand-off to `/join/[token]` | What gets propagated to HF's join flow |
+| Readiness gate (`spec.readiness()`) | What must be captured before commit |
+
+All of the above read from one source: `EnrollmentIntake` in `apps/admin/lib/intake/specs/enrollment.intent.ts`.
+
+This matters because the **CRUD surface coming next** will let admins add fields by clicking buttons. That UI writes spec field definitions to a database. Every consumer downstream MUST read from the spec — otherwise admin-added fields silently fail in the chat, fail to appear on the recap, fail to propagate to the join flow.
+
+## How to add a field (the right way)
+
+1. Open `apps/admin/lib/intake/specs/enrollment.intent.ts`
+2. Add the field declaration in the `fields:` block. Use the existing pattern:
+
+   ```typescript
+   myNewField: field
+     .string()                                     // or .enum([...]) / .boolean() / .number()
+     .optional()                                   // or .required()
+     .label({ en: "Human-readable label" })        // shown on recap
+     .askHint({ en: "What does the AI ask?" })     // shown in chat
+     .validates((v) => /* optional format check */)
+   ```
+
+3. If the field is **required**, append its key to `REQUIRED_FIELDS`:
+
+   ```typescript
+   export const REQUIRED_FIELDS = [
+     "firstName",
+     "lastName",
+     "email",
+     "ageRange",
+     "myNewField",   // ← add here
+   ] as const;
+   ```
+
+   That's it. The `readiness()` function and the chat prompt's "Capture N required values" framing both update automatically.
+
+4. If the field is **internal** (set by code, never shown to the AI or learner), append it to `INTERNAL_FIELDS` instead.
+
+5. Done. No other files need editing. The chat prompt, the recap UI, the URL builder, and the join POST body all derive from the spec.
+
+## How NOT to add a field (the wrong way that keeps biting us)
+
+❌ **DO NOT** edit `app/api/intake/chat/route.ts::SYSTEM_PROMPT` to mention the new field.
+❌ **DO NOT** edit `components/intake/IntakeDoneClient.tsx::VALUES_DISPLAY` to add the new key.
+❌ **DO NOT** edit `components/intake/IntakeDoneClient.tsx::buildContinueUrl` to `params.set()` the new field.
+❌ **DO NOT** edit `app/join/[token]/page.tsx` POST body to spread `searchParams.get("yourField")`.
+
+If any of these surfaces don't pick up your new field automatically, the bug is in the **generator** for that surface — not in your spec change. Fix the generator (so it stays spec-driven for the next person too).
+
+## Audit trail of the original mistake
+
+| PR | What happened | What should have happened |
+|---|---|---|
+| #1124 | Added `phone` field to spec + 3 parallel hand-edits (chat prompt, recap, URL builder) | Spec change only |
+| #1126 | Fixed chat prompt by hand-curating phone-specific decline rules + bumping prompt version manually | Prompt + version both spec-derived |
+| **#1129 (this doc)** | Refactored: `specToSystemPrompt(spec)` generates the prompt; `deriveValuesDisplay()` derives the recap; `buildContinueUrl` iterates spec fields; `INTAKE_PROMPT_VERSION` derives from `spec.version` | — |
+
+## Files that own the generation
+
+| Generator | Lives at | Consumers |
+|---|---|---|
+| `specToSystemPrompt(spec, opts)` | `lib/intake/spec-tools.ts` | `app/api/intake/chat/route.ts` |
+| `specToUpdateSetupTool(spec, opts)` | `lib/intake/spec-tools.ts` (pre-existing) | `app/api/intake/chat/route.ts` |
+| `deriveValuesDisplay()` | `components/intake/IntakeDoneClient.tsx` (local — small enough not to hoist) | itself |
+| `buildContinueUrl(token, values)` | `components/intake/IntakeDoneClient.tsx` | itself |
+
+Tests live in `apps/admin/tests/lib/intake-spec-to-system-prompt.test.ts` — they verify a new spec field automatically appears in the generated prompt without any other change.
+
+## Known remaining drift (next stories)
+
+- `app/join/[token]/page.tsx` — POST body still hand-picks fields. Should iterate all spec keys. Not blocking but should be cleaned up.
+- `lib/email.ts::sendIdentityPinEmail` — copy is hardcoded, not driven by `system-settings` like magic-link / invite / password-reset emails are. PIN email copy should join the same template-settings surface.
+- Caller `preferredContactMethod` channel choice is hardcoded to `"email"` in `lib/identity/issue-pin.ts`. Should derive from the spec field of the same name on the projection / Caller.
+
+These are tracked separately. None of them should be patched by hand-edit when the time comes — fix the generator.


### PR DESCRIPTION
## Root cause this closes

The Tallyseal intake is called \"spec-driven\" but until now only the **tool schema** was spec-derived. The chat **system prompt** was hand-curated. So every time someone added a field to the spec, the AI silently ignored it — the bug class that hit #1124 (added \`phone\`, AI never asked) and #1126 (hand-patched the prompt to ask, which doubled down on the anti-pattern).

This refactor makes the chat prompt, the recap UI, and the URL hand-off all read FROM the spec. Add a field → it flows through. No parallel edits.

## What changed

- \`lib/intake/spec-tools.ts\` — new \`specToSystemPrompt(spec, opts)\` generator (parallel to existing \`specToUpdateSetupTool\`). Iterates fields in declaration order, splits required/optional via opts, enumerates enum options inline, emits decline rules for optional fields.
- \`lib/intake/specs/enrollment.intent.ts\` — exports \`REQUIRED_FIELDS\` constant. \`readiness()\` spreads it. Single source for required-ness.
- \`app/api/intake/chat/route.ts\` — \`SYSTEM_PROMPT\` is now one call to the generator. \`INTAKE_PROMPT_VERSION\` derives from \`spec.version\`. Deletes 16 lines of hand-curated rules.
- \`components/intake/IntakeDoneClient.tsx\` — \`deriveValuesDisplay()\` iterates spec fields. \`buildContinueUrl\` iterates every non-internal spec field instead of hand-picking. Adds a spec field → recap shows it + URL propagates it.
- \`tests/lib/intake-spec-to-system-prompt.test.ts\` — **11 properties verified, all pass on VM.** Key: a new spec field automatically appears in the generated prompt.
- \`docs/INTAKE-SPEC-DRIVEN.md\` — \"how to add a field\" / \"how NOT to add a field\" guide.

## Out of scope (filed separately)
- \`/join/[token]/page.tsx\` POST body still hand-picks fields
- PIN email copy hardcoded instead of system-settings driven
- \`issueFirstCallPin\` hardcodes \`channel=\"email\"\` instead of reading \`preferredContactMethod\`

## Test plan
- [x] 11/11 unit tests pass on VM
- [ ] Live smoke: enrol incognito, chat now asks for phone explicitly with optional framing
- [ ] Audit bundle: \`promptTemplateVersion\` reads \`intake/spec-v1-generated\` (or whatever the spec version is)

Refs #1124 #1126