### PR TITLE
fix(curriculum): #1117 — write-site LO ref guard + courses route to DRAFT (Option A+B)

### DIFF
--- a/apps/admin/app/api/courses/route.ts
+++ b/apps/admin/app/api/courses/route.ts
@@ -200,13 +200,26 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Create the playbook
+    // #1117 — create as DRAFT, not PUBLISHED.
+    //
+    // The previous PUBLISHED-on-create behaviour bypassed the publish-time
+    // LO-ref guard (rule 7 of `publish/route.ts`) entirely: the Playbook
+    // shipped straight to PUBLISHED, and any LOs added later via the
+    // curricula/[id]/modules routes never re-triggered validation. By the
+    // time the operator noticed the dashboard sitting at "Not yet
+    // assessed", the placeholder refs had silently entered the catalog.
+    //
+    // Callers must now follow create with POST /api/playbooks/{id}/publish,
+    // which runs the full validation chain including the LO-ref
+    // placeholder + cross-module-duplicate gate. The write-site guards
+    // (assertValidLoRefBatch at every LearningObjective writer) catch any
+    // bad ref before it lands in the catalog at all.
     const playbook = await prisma.playbook.create({
       data: {
         name: courseName,
         domainId,
         groupId: groupId || undefined,
-        status: 'PUBLISHED',
+        status: 'DRAFT',
         description: learningOutcomes?.join('\n') || '',
       },
       include: {

--- a/apps/admin/app/api/curricula/[curriculumId]/modules/[moduleId]/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/modules/[moduleId]/route.ts
@@ -22,6 +22,10 @@ import { prisma } from "@/lib/prisma";
 import { isValidLoPair, sanitiseLORef } from "@/lib/content-trust/validate-lo-linkage";
 import { reconcileAssertionLOs } from "@/lib/content-trust/reconcile-lo-linkage";
 import {
+  assertValidLoRefBatch,
+  InvalidLoRefError,
+} from "@/lib/curriculum/validate-lo-refs";
+import {
   AUDIENCE_AWARE_LO_SELECT,
   filterLOsForAudience,
   parseAudience,
@@ -157,6 +161,16 @@ export async function PATCH(req: NextRequest, { params }: Params) {
       });
 
       if (learningObjectives !== undefined) {
+        // #1117 — reject placeholder refs + intra-batch duplicates before any
+        // DB write. Anchor-agnostic (CERTIFIED + UNCERTIFIED courses).
+        const moduleSlugRow = await tx.curriculumModule.findUnique({
+          where: { id: moduleId },
+          select: { slug: true },
+        });
+        assertValidLoRefBatch(
+          learningObjectives.map((lo) => sanitiseLORef(lo.ref) ?? lo.ref),
+          moduleSlugRow?.slug ?? undefined,
+        );
         // #317 — upsert-by-ref instead of deleteMany+create. The author UI edits
         // `description` only; classifier-owned columns (originalText,
         // learnerVisible, performanceStatement, systemRole, humanOverriddenAt)
@@ -231,6 +245,14 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 
     return NextResponse.json({ ok: true, module: result });
   } catch (error: any) {
+    // #1117 — surface InvalidLoRefError as a 400 with the canonical fix
+    // suggestion (operator-actionable instead of opaque 500).
+    if (error instanceof InvalidLoRefError) {
+      return NextResponse.json(
+        { error: error.message, code: "INVALID_LO_REF", ref: error.ref },
+        { status: 400 },
+      );
+    }
     console.error("[curricula/:id/modules/:id] PATCH error:", error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/apps/admin/app/api/curricula/[curriculumId]/modules/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/modules/route.ts
@@ -22,6 +22,10 @@ import { prisma } from "@/lib/prisma";
 import { parseLoLine } from "@/lib/content-trust/validate-lo-linkage";
 import { reconcileAssertionLOs } from "@/lib/content-trust/reconcile-lo-linkage";
 import {
+  assertValidLoRefBatch,
+  InvalidLoRefError,
+} from "@/lib/curriculum/validate-lo-refs";
+import {
   AUDIENCE_AWARE_LO_SELECT,
   filterLOsForAudience,
   parseAudience,
@@ -200,6 +204,9 @@ export async function POST(req: NextRequest, { params }: Params) {
             await tx.learningObjective.deleteMany({ where: { id: { in: removedIds } } });
           }
 
+          // #1117 — reject placeholder refs + intra-batch duplicates before
+          // any DB write. Anchor-agnostic (CERTIFIED + UNCERTIFIED courses).
+          assertValidLoRefBatch(parsed.map((lo) => lo.ref), upserted.slug);
           for (const lo of parsed) {
             await tx.learningObjective.upsert({
               where: { moduleId_ref: { moduleId: upserted.id, ref: lo.ref } },
@@ -249,6 +256,15 @@ export async function POST(req: NextRequest, { params }: Params) {
 
     return NextResponse.json({ ok: true, modules, count: result.length }, { status: 201 });
   } catch (error: any) {
+    // #1117 — surface the LO-ref guard's reason as a 400 with the canonical
+    // fix suggestion, so operators get an actionable error instead of an
+    // opaque 500.
+    if (error instanceof InvalidLoRefError) {
+      return NextResponse.json(
+        { error: error.message, code: "INVALID_LO_REF", ref: error.ref },
+        { status: 400 },
+      );
+    }
     console.error("[curricula/:id/modules] POST error:", error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/apps/admin/lib/curriculum/sync-modules.ts
+++ b/apps/admin/lib/curriculum/sync-modules.ts
@@ -17,6 +17,7 @@ import { reconcileAssertionLOs, type ReconcileResult } from "@/lib/content-trust
 import { sanitizeModuleTitle } from "@/lib/content-trust/sanitize-module";
 import type { AssertionTag } from "@/lib/content-trust/extract-curriculum";
 import { reclassifyLearningObjectives, type ReclassifyLosResult } from "@/lib/curriculum/reclassify-los";
+import { assertValidLoRefBatch } from "@/lib/curriculum/validate-lo-refs";
 
 export type SyncModulesMode = "merge" | "replace";
 
@@ -243,6 +244,9 @@ export async function syncModulesToDB(
           await tx.learningObjective.deleteMany({ where: { id: { in: removedIds } } });
         }
 
+        // #1117 — reject placeholder refs + intra-batch duplicates before any
+        // DB write. Anchor-agnostic (CERTIFIED + UNCERTIFIED courses).
+        assertValidLoRefBatch(parsed.map((lo) => lo.ref), upserted.slug);
         for (const lo of parsed) {
           await tx.learningObjective.upsert({
             where: { moduleId_ref: { moduleId: upserted.id, ref: lo.ref } },

--- a/apps/admin/lib/curriculum/validate-lo-refs.ts
+++ b/apps/admin/lib/curriculum/validate-lo-refs.ts
@@ -1,0 +1,90 @@
+/**
+ * AI-to-DB / Operator-to-DB guard — LO ref shape (#1117).
+ *
+ * Sits at every LearningObjective write site (wizard projection, authored
+ * sync, curriculum sync, direct module API). Rejects ref shapes that would
+ * silently break per-LO mastery scoring downstream:
+ *
+ *   1. **Placeholder pattern `/^LO\d+$/`** — `validateLoScores` rejects these
+ *      at the write boundary so no `lo_mastery:*` writes ever land. The
+ *      qualification dashboard then sits at "Not yet assessed" forever.
+ *      Reject at WRITE time so the operator gets a clear error instead of a
+ *      silent zero-data symptom.
+ *
+ *   2. **Duplicates within a batch** — the readiness rollup dedupes by
+ *      `loRef` across sibling Curricula, so cross-module ref collisions
+ *      silently merge unrelated LOs.
+ *
+ * Applies equally to CERTIFIED Curricula (with `qualificationAnchor`) and
+ * UNCERTIFIED Curricula (without). The guard only cares about ref shape +
+ * uniqueness, not certification state. Real regulated refs (e.g. SIAS
+ * "STD-04-01", IELTS "OUT-01", SIAS apprenticeship "R04-LO2-AC2.3") pass.
+ *
+ * See also:
+ *   - `lib/curriculum/track-progress.ts::validateLoScores` — write-boundary
+ *     guard for AI-returned LO refs (the LAST defence layer).
+ *   - `app/api/playbooks/[playbookId]/publish/route.ts` rule 7 — publish-
+ *     time gate; catches anything that slips through these write-site checks.
+ */
+
+const PLACEHOLDER = /^LO\d+$/;
+
+export class InvalidLoRefError extends Error {
+  readonly ref: string;
+  readonly reason: string;
+  constructor(ref: string, reason: string) {
+    super(`Invalid LO ref "${ref}" — ${reason}`);
+    this.name = "InvalidLoRefError";
+    this.ref = ref;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Throw if a single ref is unfit for the DB. `moduleSlug` is optional; when
+ * provided, the error message suggests the canonical fix (`{moduleSlug}-LO{n}`).
+ */
+export function assertValidLoRef(ref: unknown, moduleSlug?: string): void {
+  if (typeof ref !== "string" || ref.length === 0) {
+    throw new InvalidLoRefError(
+      String(ref ?? ""),
+      "ref must be a non-empty string",
+    );
+  }
+  if (PLACEHOLDER.test(ref)) {
+    const suggestion = moduleSlug ? `"${moduleSlug}-${ref}"` : `"{moduleSlug}-${ref}"`;
+    throw new InvalidLoRefError(
+      ref,
+      `matches placeholder pattern /^LO\\d+$/. The AI ignores these and per-LO mastery is silently dropped at the write boundary (#1117 validateLoScores). Use a module-scoped form like ${suggestion} instead.`,
+    );
+  }
+}
+
+/**
+ * Throw if any ref in `refs` is unfit OR if the batch contains duplicates.
+ * Batch-level uniqueness check is per-module (callers already scope the batch
+ * to a single Module). Cross-module uniqueness within a Curriculum is enforced
+ * at publish time (see publish/route.ts rule 7).
+ */
+export function assertValidLoRefBatch(
+  refs: readonly unknown[],
+  moduleSlug?: string,
+): void {
+  const seen = new Set<string>();
+  for (const ref of refs) {
+    assertValidLoRef(ref, moduleSlug);
+    const r = ref as string;
+    if (seen.has(r)) {
+      throw new InvalidLoRefError(
+        r,
+        `duplicate within this module's LO batch — refs must be unique within a Module (publish-time gate also enforces uniqueness across modules within a Curriculum).`,
+      );
+    }
+    seen.add(r);
+  }
+}
+
+/** Pure check (no throw) — for callers that want a fall-through instead. */
+export function isValidLoRef(ref: unknown): boolean {
+  return typeof ref === "string" && ref.length > 0 && !PLACEHOLDER.test(ref);
+}

--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -47,6 +47,7 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import { assertValidLoRefBatch } from "@/lib/curriculum/validate-lo-refs";
 import type {
   GoalTemplate,
   PlaybookConfig,
@@ -460,7 +461,7 @@ async function diffCurriculumModules(
 
     // Sync LearningObjective rows for this module. Key: (moduleId, ref).
     // Issue #365.
-    const loDiff = await diffLearningObjectives(tx, moduleId, m.learningObjectives);
+    const loDiff = await diffLearningObjectives(tx, moduleId, m.learningObjectives, m.slug);
     loCreated += loDiff.created;
     loUpdated += loDiff.updated;
     loRemoved += loDiff.removed;
@@ -491,7 +492,12 @@ async function diffLearningObjectives(
   tx: Tx,
   moduleId: string,
   desired: ProjectedLearningObjective[],
+  moduleSlug?: string,
 ): Promise<LearningObjectiveDiff> {
+  // #1117 — reject placeholder refs + duplicates before any DB write.
+  // Applies to both CERTIFIED and UNCERTIFIED courses (anchor-agnostic).
+  assertValidLoRefBatch(desired.map((lo) => lo.ref), moduleSlug);
+
   const existing = await tx.learningObjective.findMany({
     where: { moduleId },
     select: { id: true, ref: true, description: true, sortOrder: true },

--- a/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
+++ b/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
@@ -28,6 +28,7 @@
 import type { Prisma, PrismaClient } from "@prisma/client";
 import type { AuthoredModule } from "@/lib/types/json-fields";
 import { detectMockShapeCovers } from "./detect-mock-shape-modules";
+import { assertValidLoRefBatch } from "@/lib/curriculum/validate-lo-refs";
 
 // #317 — LO audience classification is NOT run from this helper because it
 // receives an open transaction (`tx`) and the classifier runs its own
@@ -166,6 +167,9 @@ export async function syncAuthoredModulesToCurriculum(
     // exists for downstream tagging but lacks a friendly description —
     // the extractor's garbage-guard will warn).
     if (Array.isArray(m.outcomesPrimary) && m.outcomesPrimary.length > 0) {
+      // #1117 — reject placeholder refs + intra-batch duplicates before any
+      // DB write. Anchor-agnostic (CERTIFIED + UNCERTIFIED courses).
+      assertValidLoRefBatch(m.outcomesPrimary, m.slug);
       for (const [loIdx, ref] of m.outcomesPrimary.entries()) {
         const description = outcomes?.[ref] ?? ref;
         await tx.learningObjective.upsert({

--- a/apps/admin/tests/lib/validate-lo-refs.test.ts
+++ b/apps/admin/tests/lib/validate-lo-refs.test.ts
@@ -1,0 +1,135 @@
+/**
+ * #1117 — shared LO ref guard. Tested in isolation; the helper is
+ * deliberately pure (no DB calls) so write-site call-graph tests stay
+ * lightweight.
+ *
+ * Anchor-agnostic: CERTIFIED and UNCERTIFIED Curricula apply the same gate.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  assertValidLoRef,
+  assertValidLoRefBatch,
+  isValidLoRef,
+  InvalidLoRefError,
+} from "@/lib/curriculum/validate-lo-refs";
+
+describe("validate-lo-refs — #1117 shared guard", () => {
+  describe("assertValidLoRef — single", () => {
+    it("accepts module-scoped form {moduleSlug}-LO{N}", () => {
+      expect(() => assertValidLoRef("standard-unit-04-LO1", "standard-unit-04")).not.toThrow();
+      expect(() => assertValidLoRef("MOD-1-LO5")).not.toThrow();
+    });
+
+    it("accepts regulated body refs (IELTS OUT-NN, SIAS STD-{unit}-{lo}, AC*, R*-LO*)", () => {
+      expect(() => assertValidLoRef("OUT-01")).not.toThrow();
+      expect(() => assertValidLoRef("STD-04-01")).not.toThrow();
+      expect(() => assertValidLoRef("AC1.2")).not.toThrow();
+      expect(() => assertValidLoRef("R04-LO2")).not.toThrow();
+      expect(() => assertValidLoRef("PSY-MEM-1")).not.toThrow();
+    });
+
+    it("rejects placeholder LO\\d+ pattern with operator-actionable suggestion", () => {
+      let err: unknown;
+      try {
+        assertValidLoRef("LO1", "standard-unit-04");
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(InvalidLoRefError);
+      expect((err as InvalidLoRefError).ref).toBe("LO1");
+      expect((err as InvalidLoRefError).message).toContain("standard-unit-04-LO1");
+      expect((err as InvalidLoRefError).message).toContain("/^LO\\d+$/");
+    });
+
+    it("rejects non-string / empty values", () => {
+      expect(() => assertValidLoRef("")).toThrow(InvalidLoRefError);
+      expect(() => assertValidLoRef(null)).toThrow(InvalidLoRefError);
+      expect(() => assertValidLoRef(undefined)).toThrow(InvalidLoRefError);
+      expect(() => assertValidLoRef(42)).toThrow(InvalidLoRefError);
+    });
+
+    it("suggests the canonical form generically when no moduleSlug is supplied", () => {
+      let err: unknown;
+      try {
+        assertValidLoRef("LO3");
+      } catch (e) {
+        err = e;
+      }
+      expect((err as InvalidLoRefError).message).toContain("{moduleSlug}-LO3");
+    });
+  });
+
+  describe("assertValidLoRefBatch — many", () => {
+    it("accepts a valid batch", () => {
+      expect(() =>
+        assertValidLoRefBatch(["STD-04-01", "STD-04-02", "STD-04-03"], "standard-unit-04"),
+      ).not.toThrow();
+    });
+
+    it("rejects any single placeholder ref in the batch (first failure wins)", () => {
+      let err: unknown;
+      try {
+        assertValidLoRefBatch(["STD-04-01", "LO2", "STD-04-03"], "standard-unit-04");
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(InvalidLoRefError);
+      expect((err as InvalidLoRefError).ref).toBe("LO2");
+    });
+
+    it("rejects duplicate refs within a batch (intra-module collision)", () => {
+      let err: unknown;
+      try {
+        assertValidLoRefBatch(["STD-04-01", "STD-04-02", "STD-04-01"], "standard-unit-04");
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(InvalidLoRefError);
+      expect((err as InvalidLoRefError).ref).toBe("STD-04-01");
+      expect((err as InvalidLoRefError).reason).toContain("duplicate");
+    });
+
+    it("empty batch is a no-op (legacy back-compat for empty learningObjectives)", () => {
+      expect(() => assertValidLoRefBatch([], "any-slug")).not.toThrow();
+    });
+  });
+
+  describe("isValidLoRef — pure boolean", () => {
+    it("mirrors the throwing API for callers that want a fall-through", () => {
+      expect(isValidLoRef("OUT-01")).toBe(true);
+      expect(isValidLoRef("LO1")).toBe(false);
+      expect(isValidLoRef("")).toBe(false);
+      expect(isValidLoRef(null)).toBe(false);
+      expect(isValidLoRef(undefined)).toBe(false);
+    });
+  });
+
+  describe("CERTIFIED vs UNCERTIFIED — anchor-agnostic", () => {
+    // The guard does NOT discriminate by qualificationAnchor. CERTIFIED
+    // courses (CIO/CTO Standard with anchor sias-cio-cto-v6) and
+    // UNCERTIFIED courses (Big Five, Psychology, IELTS Speaking) both
+    // pass when refs are well-formed and both fail equally when refs
+    // are placeholders. The check is on ref SHAPE, not certification
+    // state. This test pins the contract.
+    it("CERTIFIED Standard's refs pass the same gate as UNCERTIFIED Big Five's refs", () => {
+      // Certified (anchored Curriculum on sandbox):
+      expect(() =>
+        assertValidLoRefBatch(["STD-04-01", "STD-04-02", "STD-09-01"]),
+      ).not.toThrow();
+      // Uncertified (no anchor):
+      expect(() =>
+        assertValidLoRefBatch(["OUT-01", "OUT-02", "OUT-03"]),
+      ).not.toThrow();
+    });
+
+    it("CERTIFIED course with placeholder refs fails the gate (same as uncertified)", () => {
+      expect(() =>
+        assertValidLoRefBatch(["LO1", "LO2", "LO3"], "standard-unit-04"),
+      ).toThrow(InvalidLoRefError);
+      expect(() =>
+        assertValidLoRefBatch(["LO1", "LO2", "LO3"], "big-five-foundations"),
+      ).toThrow(InvalidLoRefError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the create-route bypass the user flagged. Two changes, both anchor-agnostic:

**A (1-line fix)** — `app/api/courses/route.ts` now creates the Playbook as `DRAFT`, not `PUBLISHED`. Callers must follow with `POST /api/playbooks/{id}/publish`, which runs the LO-ref guard from PR #1134 (rule 7). Matches the `POST /api/playbooks` pattern.

**B (defence-in-depth)** — new shared helper `lib/curriculum/validate-lo-refs.ts` wired into all 5 LO write sites so bad refs can't be persisted regardless of which path created the course or whether the operator ever re-publishes:

| Write site | What it ingests |
|---|---|
| `lib/wizard/apply-projection.ts::diffLearningObjectives` | Wizard-projected LO catalog from course-reference docs |
| `lib/wizard/sync-authored-modules-to-curriculum.ts` | Authored `outcomesPrimary` from wizard config |
| `lib/curriculum/sync-modules.ts` | Parsed LO blob from spec sync |
| `app/api/curricula/[curriculumId]/modules/route.ts` POST | Direct module-create API |
| `app/api/curricula/[curriculumId]/modules/[moduleId]/route.ts` PATCH | Direct module-edit API |

Two API routes additionally catch `InvalidLoRefError` and surface a 400 with `code: "INVALID_LO_REF"` + the canonical fix suggestion so admin UIs render an actionable error rather than an opaque 500.

## CERTIFIED vs UNCERTIFIED coverage

The guard is anchor-agnostic — both classes apply the same rule:

| Course | Anchor | Refs today | Passes new guard? |
|---|---|---|---|
| CIO/CTO Standard (3 variants) | ✓ `sias-cio-cto-v6` (CERTIFIED) | `STD-{unit}-{lo}` | ✓ |
| IELTS Speaking (3 variants) | — (UNCERTIFIED) | `OUT-01..27` | ✓ |
| Big Five (OCEAN) | — (UNCERTIFIED) | `OUT-NN` | ✓ |
| Psychology | — (UNCERTIFIED) | `PSY-MEM-N` | ✓ |
| Persuasion Literacy | — (UNCERTIFIED) | `OUT-NN` | ✓ |
| Hypothetical placeholder course | (either) | `LO1, LO2, …` | ✗ rejected at write time with `STD-04-LO1` suggestion |

## Final defence chain (5 layers, all in)

```
1. AI Prompt registry          — instructs AI to emit {moduleSlug}-LO{N}
2. Backfill parser             — normalises legacy placeholders + slug fallback
3. WRITE-SITE guard (this PR)  — assertValidLoRefBatch at all 5 writers
4. Publish gate (rule 7)       — hard-rejects placeholders + duplicates at ship time
5. Write-boundary guard        — validateLoScores rejects bad refs at the lo_mastery:* upsert
```

## Test plan

- [x] 12 new vitests in `validate-lo-refs.test.ts` (single + batch + boolean form, CERTIFIED/UNCERTIFIED parity)
- [x] Pre-existing `apply-projection.test.ts` failures (3) confirmed unrelated — same 3 fail on main with `tx.playbookCurriculum.upsert is not a function` mock gap from the #1034 variant pattern
- [ ] Manual smoke: `POST /api/courses` → Playbook lands as DRAFT (not PUBLISHED)
- [ ] Manual smoke: `POST /api/curricula/{id}/modules` with `LO1` refs → 400 with `INVALID_LO_REF` code and operator-actionable error message

Companion to PR #1134 (publish-time gate) + the operator runbook in PR #chore/1117-deploy-runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)