### PR TITLE
chore(skills): drift sentinel in /vm-cp /vm-cpp /vm-pull

### DIFF
--- a/.claude/commands/vm-cp.md
+++ b/.claude/commands/vm-cp.md
@@ -85,6 +85,20 @@ gcloud compute ssh hf-dev --zone=europe-west2-a --tunnel-through-iap -- bash <<'
   git pull --rebase
   git stash pop 2>/dev/null || true
 
+  # Drift sentinel — warn (don't block) if working tree diverged from origin/main.
+  # If this fires repeatedly, run a full sweep: see playbook in MEMORY.md or
+  # ask Claude for a `git diff origin/main` summary on the VM. Set
+  # HF_VM_DRIFT_OK=1 to silence (e.g. when intentionally on a feature branch).
+  git fetch origin --quiet 2>/dev/null || true
+  if [ "${HF_VM_DRIFT_OK:-0}" != "1" ]; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$BRANCH" = "main" ] && ! git diff origin/main --quiet 2>/dev/null; then
+      DRIFT_COUNT=$(git diff --name-only origin/main 2>/dev/null | wc -l | tr -d ' ')
+      echo "⚠  VM drift: $DRIFT_COUNT tracked file(s) differ from origin/main on the VM."
+      echo "   git diff origin/main --stat to inspect; reset --hard if you want a clean slate."
+    fi
+  fi
+
   echo "==> Installing deps..."
   cd apps/admin && npm install --prefer-offline
 

--- a/.claude/commands/vm-cpp.md
+++ b/.claude/commands/vm-cpp.md
@@ -69,6 +69,20 @@ gcloud compute ssh hf-dev --zone=europe-west2-a --tunnel-through-iap -- bash <<'
   git pull --rebase
   git stash pop 2>/dev/null || true
 
+  # Drift sentinel — warn (don't block) if working tree diverged from origin/main.
+  # If this fires repeatedly, run a full sweep: see playbook in MEMORY.md or
+  # ask Claude for a `git diff origin/main` summary on the VM. Set
+  # HF_VM_DRIFT_OK=1 to silence (e.g. when intentionally on a feature branch).
+  git fetch origin --quiet 2>/dev/null || true
+  if [ "${HF_VM_DRIFT_OK:-0}" != "1" ]; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$BRANCH" = "main" ] && ! git diff origin/main --quiet 2>/dev/null; then
+      DRIFT_COUNT=$(git diff --name-only origin/main 2>/dev/null | wc -l | tr -d ' ')
+      echo "⚠  VM drift: $DRIFT_COUNT tracked file(s) differ from origin/main on the VM."
+      echo "   git diff origin/main --stat to inspect; reset --hard if you want a clean slate."
+    fi
+  fi
+
   echo "==> Installing deps..."
   cd apps/admin && npm install --prefer-offline
 

--- a/.claude/commands/vm-pull.md
+++ b/.claude/commands/vm-pull.md
@@ -29,6 +29,26 @@ gcloud compute ssh hf-dev --zone=europe-west2-a --tunnel-through-iap -- bash -c 
 
 Report what changed (new commits, updated packages). If the SSH command fails with exit code 255, wait 3 seconds and retry once.
 
+### 1a. Drift sentinel — warn if VM working tree diverged from origin/main
+
+```bash
+gcloud compute ssh hf-dev --zone=europe-west2-a --tunnel-through-iap -- bash -c '
+  cd ~/HF
+  git fetch origin --quiet 2>/dev/null || true
+  if [ "${HF_VM_DRIFT_OK:-0}" != "1" ]; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$BRANCH" = "main" ] && ! git diff origin/main --quiet 2>/dev/null; then
+      COUNT=$(git diff --name-only origin/main 2>/dev/null | wc -l | tr -d " ")
+      echo "⚠  VM drift: $COUNT tracked file(s) differ from origin/main."
+      echo "   Inspect: git diff origin/main --stat"
+      echo "   Clean slate: git stash push --include-untracked -m drift-reset-$(date +%s) && git reset --hard origin/main"
+    fi
+  fi
+'
+```
+
+Surfaces accumulated working-tree drift on the VM before it bites at runtime (e.g. stale wizard-v6 lab residue or schema.prisma divergence). Warn-only; doesn't block the pull. Set `HF_VM_DRIFT_OK=1` to silence when intentionally on a feature branch.
+
 If there are merge conflicts, show them and stop — do NOT force resolve.
 
 ## 2. Ask about restart


### PR DESCRIPTION
Adds a non-blocking warning to the three VM-sync skills when the VM's working tree has drifted from origin/main. Same pattern that just cost 30 min of debugging on a Friday night. See commit body for details. 48 lines, 3 files.