### PR TITLE
fix(wizard-v6): drop evt- prefix from event id (tallyseal_event.id is UUID)

### DIFF
--- a/apps/admin/lib/wizard-v6/record-field-answered.ts
+++ b/apps/admin/lib/wizard-v6/record-field-answered.ts
@@ -162,7 +162,7 @@ export async function recordFieldAnswered(
     .digest("hex") as ContentHash;
 
   const event: Event = {
-    id: `evt-${randomUUID()}` as EventId,
+    id: randomUUID() as EventId,
     tenantId: tenant.id,
     intentId,
     kind: "FieldAnswered" as EventKind,


### PR DESCRIPTION
## Summary

The V6 playground's `Send event` was failing with Postgres `22P02 invalid input syntax for type uuid: evt-<uuid>`. `record-field-answered.ts:165` constructed event IDs as `evt-${randomUUID()}` but `tallyseal_event.id` is `UUID PRIMARY KEY`.

## Fix

One line: drop the `evt-` prefix.

```diff
-id: `evt-${randomUUID()}` as EventId,
+id: randomUUID() as EventId,
```

`EventId` is `Brand<string, 'EventId'>` — opaque at the type level, so bare UUID compiles cleanly and matches the column type.

## Related

`lib/intake/session-store.ts:145` has the same `evt-` prefix pattern but writes to in-memory session-store (PrismaEventStore wiring is Phase 1.5). Doesn't hit Postgres validation today; revisit when intake migrates.

## Test plan

- [x] Lint clean
- [ ] Smoke `/x/wizard-v6/playground` — `Send event` writes successfully (operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)