### PR TITLE
feat(intake): V2 auth-first enrolment path (#1141 Story 2)

### DIFF
--- a/apps/admin/app/api/intake/bootstrap/route.ts
+++ b/apps/admin/app/api/intake/bootstrap/route.ts
@@ -35,6 +35,13 @@ const BodySchema = z.object({
   chatSessionId: z.string().min(1).max(120),
   specKey: z.literal("EnrollmentIntake"),
   classroomToken: z.string().min(1).max(120).optional(),
+  // V2 path support: when set, these field values are pre-populated on the
+  // intent at bootstrap time so the spec-driven chat (#1130) skips asking
+  // for them. Used by /intake/v2 where email is captured BEFORE the chat
+  // starts (auth-first flow). Only string-valued fields are accepted —
+  // sufficient for the current spec fields (firstName, lastName, email,
+  // ageRange, phone, etc.); booleans/numbers can be added later.
+  prefilledValues: z.record(z.string(), z.string()).optional(),
 });
 
 const INTAKE_KEY = "EnrollmentIntake" as IntentKey;
@@ -165,6 +172,17 @@ export async function POST(req: NextRequest) {
       dataSubjectIds: [subjectId],
     });
     welcomeMessage = `Welcome — you're enrolling in "${classroomName}". I'll need four things: your first name, last name, age range, and email. What's your first name?`;
+  }
+
+  // V2 path: pre-populate captured fields so the spec-driven chat skips
+  // them. The chat AI sees the snapshot at first turn and asks only for
+  // fields that are still missing per the spec's readiness gate.
+  if (body.prefilledValues) {
+    for (const [key, value] of Object.entries(body.prefilledValues)) {
+      if (typeof value === "string" && value.trim().length > 0) {
+        setValue(session, key, value);
+      }
+    }
   }
 
   appendMessage(session, "system", welcomeMessage);

--- a/apps/admin/app/api/intake/v2/start/route.ts
+++ b/apps/admin/app/api/intake/v2/start/route.ts
@@ -1,0 +1,241 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { checkRateLimit, getClientIP } from "@/lib/rate-limit";
+import { mintAndSetSessionCookie } from "@/lib/auth-session-cookie";
+import { issueFirstCallPin } from "@/lib/identity/issue-pin";
+import { enrollCallerInCohortPlaybooks } from "@/lib/enrollment";
+
+export const runtime = "nodejs";
+
+const bodySchema = z.object({
+  classroomToken: z.string().min(1).max(120),
+  /** Free-form contact field — auto-detected as email (contains @) or
+   *  phone (else). Phone-based is rejected for now since SMS is stubbed
+   *  (#1133); a clear error surfaces from this route. */
+  contact: z.string().min(1).max(256),
+});
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * @api POST /api/intake/v2/start
+ * @visibility public
+ * @auth none
+ * @description V2 auth-first enrolment kickoff (#1141 Story 2). Takes a
+ *   cohort token + a single contact field, creates a stub User + Caller
+ *   for the cohort, issues a first-call PIN via the messaging-provider
+ *   resolver (#1141 Story 3 — today: email-resend; tomorrow: SMS), and
+ *   returns { callerId } so the client can navigate to the gate +
+ *   chat-to-complete flow.
+ *
+ *   For now phone is detected but REJECTED with a clear "use email"
+ *   message — SMS adapter stubbed (#1133). When SMS lands this route
+ *   accepts both.
+ *
+ *   Existing users (matching email): the user signed up before. Allowed
+ *   per epic spec — we attach them to the cohort if they aren't already
+ *   in it, issue a fresh PIN to their on-file email. PIN gate flow then
+ *   proves they own the inbox, chat-to-complete fills in any missing
+ *   profile fields.
+ *
+ * @body { classroomToken, contact }
+ * @response 201 { ok: true, callerId, channel: 'email', gatePath: '/intake/v2/<token>/<callerId>' }
+ * @response 400 { ok: false, error } — phone supplied, invalid email, expired token
+ * @response 404 { ok: false, error: "Invalid or expired classroom token" }
+ */
+export async function POST(request: Request) {
+  const rl = checkRateLimit(getClientIP(request as never), "intake-v2-start");
+  if (!rl.ok) return rl.error;
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await request.json());
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid body" },
+      { status: 400 },
+    );
+  }
+
+  const trimmedContact = body.contact.trim();
+  const isEmail = trimmedContact.includes("@");
+  if (!isEmail) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "Phone-based sign-in is coming soon. For now please enter an email address.",
+        kind: "phone-not-supported",
+      },
+      { status: 400 },
+    );
+  }
+  if (!EMAIL_RE.test(trimmedContact)) {
+    return NextResponse.json(
+      { ok: false, error: "That doesn't look like a valid email address." },
+      { status: 400 },
+    );
+  }
+  const email = trimmedContact.toLowerCase();
+
+  // Resolve the cohort + verify the token is active.
+  const cohort = await prisma.cohortGroup.findUnique({
+    where: { joinToken: body.classroomToken },
+    select: {
+      id: true,
+      isActive: true,
+      joinTokenExp: true,
+      domainId: true,
+      institutionId: true,
+    },
+  });
+  if (!cohort || !cohort.isActive) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid or expired classroom token" },
+      { status: 404 },
+    );
+  }
+  if (cohort.joinTokenExp && new Date(cohort.joinTokenExp) < new Date()) {
+    return NextResponse.json(
+      { ok: false, error: "This classroom link has expired" },
+      { status: 410 },
+    );
+  }
+
+  // Existing-user path: attach to cohort if not already.
+  const existingUser = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, name: true, displayName: true },
+  });
+
+  let callerId: string;
+  let userId: string;
+
+  const requestUrl = new URL(request.url);
+  const originUrl = `${requestUrl.protocol}//${requestUrl.host}`;
+
+  if (existingUser) {
+    userId = existingUser.id;
+
+    // Already a member of this cohort? Find or create the Caller.
+    const existingMembership = await prisma.callerCohortMembership.findFirst({
+      where: { cohortGroupId: cohort.id, caller: { userId: existingUser.id } },
+      select: { callerId: true },
+    });
+    const directCaller = !existingMembership
+      ? await prisma.caller.findFirst({
+          where: { userId: existingUser.id, cohortGroupId: cohort.id },
+          select: { id: true },
+        })
+      : null;
+    callerId = existingMembership?.callerId ?? directCaller?.id ?? "";
+
+    if (!callerId) {
+      // Existing user, new cohort — create the Caller, mirror /join path 2.
+      const newCaller = await prisma.caller.create({
+        data: {
+          name: existingUser.name ?? email,
+          email,
+          role: "LEARNER",
+          userId: existingUser.id,
+          domainId: cohort.domainId,
+          cohortGroupId: cohort.id,
+          externalId: `intake-v2-${existingUser.id}-${cohort.id}`,
+        },
+        select: { id: true },
+      });
+      callerId = newCaller.id;
+      await prisma.callerCohortMembership.create({
+        data: { callerId, cohortGroupId: cohort.id },
+      });
+      if (cohort.domainId) {
+        await enrollCallerInCohortPlaybooks(
+          callerId,
+          cohort.id,
+          cohort.domainId,
+          "intake-v2",
+        );
+      }
+    }
+  } else {
+    // New user: create both User + Caller atomically. Name + displayName
+    // are placeholders (the email's local-part). Real values arrive via
+    // the chat-to-complete step + the /join PATCH that the chat's
+    // commit-redirect triggers.
+    const placeholderName = email.split("@")[0] || "Learner";
+    const result = await prisma.$transaction(async (tx) => {
+      const user = await tx.user.create({
+        data: {
+          email,
+          name: placeholderName,
+          displayName: placeholderName,
+          role: "STUDENT",
+          emailVerified: new Date(),
+          isActive: true,
+          assignedDomainId: cohort.domainId,
+          institutionId: cohort.institutionId,
+        },
+      });
+      const caller = await tx.caller.create({
+        data: {
+          name: placeholderName,
+          email,
+          role: "LEARNER",
+          userId: user.id,
+          domainId: cohort.domainId,
+          cohortGroupId: cohort.id,
+          externalId: `intake-v2-${user.id}`,
+        },
+      });
+      await tx.callerCohortMembership.create({
+        data: { callerId: caller.id, cohortGroupId: cohort.id },
+      });
+      return { userId: user.id, callerId: caller.id };
+    });
+    userId = result.userId;
+    callerId = result.callerId;
+    if (cohort.domainId) {
+      await enrollCallerInCohortPlaybooks(
+        callerId,
+        cohort.id,
+        cohort.domainId,
+        "intake-v2",
+      );
+    }
+  }
+
+  // Issue PIN via the resolver (#1141 — today: email; tomorrow: caller's
+  // preferredContactMethod). Best-effort — SMTP failure logs but doesn't
+  // break the flow; learner hits Resend in the gate.
+  await issueFirstCallPin({
+    callerId,
+    email,
+    firstName: existingUser?.displayName ?? existingUser?.name ?? undefined,
+    originUrl,
+  });
+
+  // Mint a session cookie so the gate's verify-pin call has an auth
+  // context (#1101 STUDENT-scope guard). Without this, the verify
+  // would 401 + redirect to /login — fatal UX for an anon learner.
+  const userRow = await prisma.user.findUnique({ where: { id: userId } });
+  const response = NextResponse.json(
+    {
+      ok: true,
+      callerId,
+      channel: "email",
+      gatePath: `/intake/v2/${body.classroomToken}/${callerId}`,
+    },
+    { status: 201 },
+  );
+  try {
+    if (userRow) {
+      await mintAndSetSessionCookie(response, userRow);
+    }
+  } catch {
+    // Auth secret missing — non-fatal here, but the gate will likely
+    // 401. The downstream error message is clearer than a 500 from
+    // this route.
+  }
+  return response;
+}

--- a/apps/admin/app/api/join/[token]/route.ts
+++ b/apps/admin/app/api/join/[token]/route.ts
@@ -224,6 +224,57 @@ export async function POST(
     const returningCallerId = existingMembership?.callerId ?? existingCallerDirect?.id;
 
     if (returningCallerId) {
+      // V2 (auth-first) finish: if the existing Caller has a placeholder
+      // name (from /api/intake/v2/start) and the body supplies the real
+      // values from the chat-to-complete step, backfill them now. Only
+      // touch fields we can confidently set; do not OVERWRITE an existing
+      // non-placeholder name. (#1141 Story 2.)
+      const fullName = `${firstName.trim()} ${lastName.trim()}`;
+      const existingCaller = await prisma.caller.findUnique({
+        where: { id: returningCallerId },
+        select: { name: true, phone: true },
+      });
+      const looksPlaceholder =
+        !existingCaller?.name ||
+        existingCaller.name === existingUser.name ||
+        existingCaller.name === existingUser.email?.split("@")[0] ||
+        existingCaller.name.toLowerCase() === "learner";
+      const updates: Record<string, string> = {};
+      if (looksPlaceholder && firstName.trim() && lastName.trim()) {
+        updates.name = fullName;
+      }
+      if (!existingCaller?.phone && normalizedPhone) {
+        updates.phone = normalizedPhone;
+      }
+      if (Object.keys(updates).length > 0) {
+        await prisma.caller.update({
+          where: { id: returningCallerId },
+          data: updates,
+        });
+      }
+      // ageRange always upserts (idempotent) so an updated declaration
+      // overwrites the prior one — same as paths 2 + 3.
+      if (ageRange) {
+        await prisma.callerAttribute.upsert({
+          where: {
+            callerId_key_scope: {
+              callerId: returningCallerId,
+              key: "intake.ageRange",
+              scope: "GLOBAL",
+            },
+          },
+          create: {
+            callerId: returningCallerId,
+            key: "intake.ageRange",
+            scope: "GLOBAL",
+            valueType: "STRING",
+            stringValue: ageRange,
+            sourceSpecSlug: "EnrollmentIntake",
+          },
+          update: { stringValue: ageRange },
+        });
+      }
+
       // Returning learner — sign them in and redirect to their journey
       const returningResponse = NextResponse.json({
         ok: true,

--- a/apps/admin/app/intake/v2/[token]/EnrolV2EntryClient.tsx
+++ b/apps/admin/app/intake/v2/[token]/EnrolV2EntryClient.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Mail, Phone, AlertCircle, Loader2 } from "lucide-react";
+
+interface Props {
+  token: string;
+  cohortName: string;
+  domainName: string;
+  institutionName: string | null;
+}
+
+export function EnrolV2EntryClient({
+  token,
+  cohortName,
+  domainName,
+  institutionName,
+}: Props) {
+  const router = useRouter();
+  const [contact, setContact] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-detection — presence of '@' wins. Below the input we surface
+  // a one-line hint so the learner knows what we'll do with their input.
+  const detected = useMemo<"email" | "phone" | "unknown">(() => {
+    if (contact.trim().length === 0) return "unknown";
+    if (contact.includes("@")) return "email";
+    if (/^[+\d\s()-]+$/.test(contact)) return "phone";
+    return "unknown";
+  }, [contact]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/intake/v2/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          classroomToken: token,
+          contact: contact.trim(),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      // Navigate to the gate + chat-to-complete URL. The route uses the
+      // same token + the new callerId so a refresh after PIN entry stays
+      // on the same surface.
+      router.push(data.gatePath);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Sign-in failed");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+        background: "var(--bg-default, #fafafa)",
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: 440,
+          background: "var(--bg-surface, #fff)",
+          borderRadius: 12,
+          padding: 32,
+          boxShadow: "0 4px 12px rgba(0,0,0,0.05)",
+        }}
+      >
+        <div style={{ textAlign: "center", marginBottom: 24 }}>
+          {institutionName && (
+            <p
+              style={{
+                margin: 0,
+                fontSize: 13,
+                color: "var(--text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: 0.5,
+                marginBottom: 8,
+              }}
+            >
+              {institutionName}
+            </p>
+          )}
+          <h1
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              margin: "0 0 6px",
+              color: "var(--text-primary)",
+            }}
+          >
+            Join {cohortName}
+          </h1>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 14,
+              color: "var(--text-muted)",
+              lineHeight: 1.4,
+            }}
+          >
+            {domainName} · sign in to begin
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <label
+            htmlFor="contact-input"
+            style={{
+              display: "block",
+              fontSize: 13,
+              fontWeight: 500,
+              marginBottom: 6,
+            }}
+          >
+            Your email
+          </label>
+          <input
+            id="contact-input"
+            type="text"
+            inputMode="email"
+            autoComplete="email"
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+            disabled={submitting}
+            required
+            placeholder="you@example.com"
+            style={{
+              width: "100%",
+              padding: "12px 14px",
+              fontSize: 16,
+              border: "1px solid var(--border-default, #d4d4d8)",
+              borderRadius: 8,
+              boxSizing: "border-box",
+              marginBottom: 6,
+            }}
+          />
+          {detected !== "unknown" && (
+            <p
+              style={{
+                margin: "0 0 12px",
+                fontSize: 12,
+                color: "var(--text-muted)",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              {detected === "email" ? (
+                <>
+                  <Mail size={12} /> We'll email you a 6-digit code.
+                </>
+              ) : (
+                <>
+                  <Phone size={12} /> Phone sign-in is coming soon — please use email for now.
+                </>
+              )}
+            </p>
+          )}
+
+          {error && (
+            <div
+              style={{
+                margin: "12px 0",
+                padding: 10,
+                fontSize: 13,
+                color: "var(--text-danger, #b91c1c)",
+                background: "var(--bg-danger-subtle, #fef2f2)",
+                border: "1px solid var(--border-danger, #fecaca)",
+                borderRadius: 6,
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              <AlertCircle size={14} /> {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting || detected === "phone" || contact.trim().length === 0}
+            className="hf-btn-primary"
+            style={{
+              width: "100%",
+              padding: "12px 16px",
+              fontSize: 15,
+              marginTop: 8,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+            }}
+          >
+            {submitting ? (
+              <>
+                <Loader2 size={14} className="hf-spinner" /> Sending code…
+              </>
+            ) : (
+              "Send my code"
+            )}
+          </button>
+
+          <p
+            style={{
+              marginTop: 18,
+              fontSize: 12,
+              color: "var(--text-muted)",
+              textAlign: "center",
+              lineHeight: 1.4,
+            }}
+          >
+            By continuing you agree to receive a sign-in code by email and
+            to the privacy notice you'll see on the next screen.
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/intake/v2/[token]/[callerId]/EnrolV2FinishClient.tsx
+++ b/apps/admin/app/intake/v2/[token]/[callerId]/EnrolV2FinishClient.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { FirstCallPinGate } from "@/components/identity/FirstCallPinGate";
+import { EnrollmentChat } from "@/components/intake/EnrollmentChat";
+
+interface Props {
+  token: string;
+  callerId: string;
+  email: string;
+  cohortName: string;
+  domainName: string;
+}
+
+type Stage =
+  | { kind: "loading" }
+  | { kind: "gate"; recipient: string | null }
+  | { kind: "chat" }
+  | { kind: "no-active-challenge" };
+
+/**
+ * V2 finish flow client (#1141 Story 2). Renders the FirstCallPinGate
+ * if there's an unverified challenge for this caller; once verified,
+ * renders EnrollmentChat with the email pre-populated so the AI only
+ * asks for the missing fields (name, age, disclosures).
+ *
+ * When the chat commits the projection, the chat itself navigates the
+ * window to /intake/done?intentId=...&token=... per the existing flow.
+ * From there the "Continue to course" button goes to /join/[token] which
+ * detects the existing caller in this cohort and redirects to /x/sim.
+ */
+export function EnrolV2FinishClient({
+  token,
+  callerId,
+  email,
+  cohortName,
+  domainName,
+}: Props) {
+  const router = useRouter();
+  const { status: sessionStatus } = useSession();
+  const [stage, setStage] = useState<Stage>({ kind: "loading" });
+
+  useEffect(() => {
+    if (sessionStatus === "loading") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/identity/challenge-status?callerId=${encodeURIComponent(callerId)}`,
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const ct = res.headers.get("content-type") ?? "";
+        if (!ct.includes("application/json")) throw new Error("non-JSON");
+        const data = await res.json();
+        if (cancelled) return;
+        if (!data?.ok) {
+          setStage({ kind: "no-active-challenge" });
+          return;
+        }
+        if (data.needsPin) {
+          setStage({ kind: "gate", recipient: data.recipient ?? null });
+        } else {
+          setStage({ kind: "chat" });
+        }
+      } catch {
+        if (!cancelled) setStage({ kind: "no-active-challenge" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, sessionStatus]);
+
+  if (stage.kind === "loading") {
+    return (
+      <div style={loadingStyle}>
+        <div className="hf-spinner" style={{ width: 28, height: 28 }} />
+        <p style={{ color: "var(--text-muted)", fontSize: 14 }}>Loading…</p>
+      </div>
+    );
+  }
+
+  if (stage.kind === "no-active-challenge") {
+    return (
+      <div style={loadingStyle}>
+        <p style={{ color: "var(--text-muted)", fontSize: 14 }}>
+          We couldn't find a sign-in code for this enrolment. Start over —
+        </p>
+        <button
+          type="button"
+          className="hf-btn-primary"
+          onClick={() => router.push(`/intake/v2/${token}`)}
+          style={{ marginTop: 12 }}
+        >
+          Start sign-in again
+        </button>
+      </div>
+    );
+  }
+
+  if (stage.kind === "gate") {
+    return (
+      <>
+        <header style={headerStyle}>
+          <h1 style={{ fontSize: 18, fontWeight: 600, margin: "0 0 4px" }}>
+            {cohortName}
+          </h1>
+          <p style={{ fontSize: 13, color: "var(--text-muted)", margin: 0 }}>
+            {domainName}
+          </p>
+        </header>
+        <FirstCallPinGate
+          callerId={callerId}
+          recipient={stage.recipient ?? email}
+          callerFirstName={undefined}
+          onVerified={() => setStage({ kind: "chat" })}
+        />
+      </>
+    );
+  }
+
+  // Verified — hand off to the spec-driven chat with email prefilled.
+  return (
+    <EnrollmentChat
+      classroomToken={token}
+      prefilledValues={{ email }}
+    />
+  );
+}
+
+const loadingStyle: React.CSSProperties = {
+  minHeight: "60vh",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 12,
+};
+
+const headerStyle: React.CSSProperties = {
+  padding: "16px 24px",
+  borderBottom: "1px solid var(--border-default, #e4e4e7)",
+  background: "var(--bg-surface, #fff)",
+};

--- a/apps/admin/app/intake/v2/[token]/[callerId]/page.tsx
+++ b/apps/admin/app/intake/v2/[token]/[callerId]/page.tsx
@@ -1,0 +1,52 @@
+import { notFound, redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { EnrolV2FinishClient } from "./EnrolV2FinishClient";
+
+/**
+ * @page /intake/v2/[token]/[callerId]
+ * V2 post-start surface: PIN gate first, then chat-to-complete profile.
+ * Hit via redirect from POST /api/intake/v2/start. Story 2 of #1141.
+ *
+ * The page validates token + callerId match the cohort + that the Caller
+ * actually belongs to it (defence against URL tampering — someone
+ * pasting another caller's UUID), then hands off to the client.
+ *
+ * If the Caller's chat completion has already happened (verifiedAt set
+ * AND profile fields populated) we send them straight to /x/sim.
+ */
+export default async function IntakeV2FinishPage({
+  params,
+}: {
+  params: Promise<{ token: string; callerId: string }>;
+}) {
+  const { token, callerId } = await params;
+
+  const [cohort, caller] = await Promise.all([
+    prisma.cohortGroup.findUnique({
+      where: { joinToken: token },
+      select: {
+        id: true,
+        isActive: true,
+        name: true,
+        domain: { select: { name: true } },
+      },
+    }),
+    prisma.caller.findUnique({
+      where: { id: callerId },
+      select: { id: true, email: true, name: true, cohortGroupId: true },
+    }),
+  ]);
+
+  if (!cohort || !cohort.isActive) notFound();
+  if (!caller || caller.cohortGroupId !== cohort.id) notFound();
+
+  return (
+    <EnrolV2FinishClient
+      token={token}
+      callerId={caller.id}
+      email={caller.email ?? ""}
+      cohortName={cohort.name}
+      domainName={cohort.domain.name}
+    />
+  );
+}

--- a/apps/admin/app/intake/v2/[token]/page.tsx
+++ b/apps/admin/app/intake/v2/[token]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { EnrolV2EntryClient } from "./EnrolV2EntryClient";
+
+/**
+ * @page /intake/v2/[token]
+ * V2 auth-first enrolment entry — single field (email or phone with
+ * auto-detection). Pre-PIN, pre-disclosure-chat, pre-everything.
+ * Story 2 of the #1141 epic.
+ */
+export default async function IntakeV2EntryPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const cohort = await prisma.cohortGroup.findUnique({
+    where: { joinToken: token },
+    select: {
+      isActive: true,
+      joinTokenExp: true,
+      name: true,
+      domain: { select: { name: true } },
+      institution: { select: { name: true } },
+    },
+  });
+
+  if (!cohort || !cohort.isActive) notFound();
+  const expired =
+    cohort.joinTokenExp && new Date(cohort.joinTokenExp) < new Date();
+  if (expired) notFound();
+
+  return (
+    <EnrolV2EntryClient
+      token={token}
+      cohortName={cohort.name}
+      domainName={cohort.domain.name}
+      institutionName={cohort.institution?.name ?? null}
+    />
+  );
+}

--- a/apps/admin/components/intake/EnrollmentChat.tsx
+++ b/apps/admin/components/intake/EnrollmentChat.tsx
@@ -94,9 +94,21 @@ export interface EnrollmentChatProps {
    * platform-level demo with no classroom binding.
    */
   readonly classroomToken?: string;
+
+  /**
+   * V2 (auth-first) only: field values already captured BEFORE the chat
+   * started — typically `email` from /intake/v2/[token]. Passed through
+   * to /api/intake/bootstrap which writes them into the intent at start
+   * time. The spec-driven prompt (#1130) sees them as set and the AI
+   * skips asking. (#1141 Story 2.)
+   */
+  readonly prefilledValues?: Record<string, string>;
 }
 
-export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
+export function EnrollmentChat({
+  classroomToken,
+  prefilledValues,
+}: EnrollmentChatProps = {}) {
   const [boot, setBoot] = useState<BootstrapState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
@@ -127,6 +139,7 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
             chatSessionId,
             specKey: "EnrollmentIntake",
             classroomToken,
+            prefilledValues,
           }),
         });
         if (!res.ok) {
@@ -151,6 +164,10 @@ export function EnrollmentChat({ classroomToken }: EnrollmentChatProps = {}) {
     return () => {
       cancelled = true;
     };
+    // prefilledValues is intentionally NOT in deps — we don't want a
+    // re-bootstrap if the parent re-renders with the same data (would
+    // create a second intent). Mount-time-only is correct.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [classroomToken]);
 
   useEffect(() => {

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -10183,6 +10183,29 @@ Extract metadata (name, logo, colors) from a website URL
 
 ---
 
+### `POST` /api/intake/v2/start
+
+V2 auth-first enrolment kickoff (#1141 Story 2). Takes a
+
+**Auth**: None
+
+**Response** `201`
+```json
+{ ok: true, callerId, channel: 'email', gatePath: '/intake/v2/<token>/<callerId>' }
+```
+
+**Response** `400`
+```json
+{ ok: false, error } — phone supplied, invalid email, expired token
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Invalid or expired classroom token" }
+```
+
+---
+
 ### `GET` /api/join/[token]
 
 Verify a classroom/community join token. Returns group info if valid.
@@ -15518,8 +15541,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 495 |
-| Files with annotations | 486 |
+| Route files found | 496 |
+| Files with annotations | 487 |
 | Files missing annotations | 9 |
 | Coverage | 98.2% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -3411,6 +3411,29 @@ Verify a learner's first-call PIN. STUDENT sessions are locked
 
 ---
 
+### `POST` /api/v1/intake/v2/start
+
+V2 auth-first enrolment kickoff (#1141 Story 2). Takes a
+
+**Auth**: None
+
+**Response** `201`
+```json
+{ ok: true, callerId, channel: 'email', gatePath: '/intake/v2/<token>/<callerId>' }
+```
+
+**Response** `400`
+```json
+{ ok: false, error } — phone supplied, invalid email, expired token
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Invalid or expired classroom token" }
+```
+
+---
+
 ### `GET` /api/v1/join/[token]
 
 Verify a classroom/community join token. Returns group info if valid.


### PR DESCRIPTION
Story 2 of the auth-first epic. 5 new files + 3 modified. Uses #1141 Story 3 MessagingProvider resolver natively + #1101 PIN gate as-is + #1130 spec-driven chat with new prefilledValues prop. SMS rejected with clean UX message (Story 3 stub). /join path 1 backfills placeholder Caller fields after V2 commit. Closes #1141 epic.