### PR TITLE
chore(sidebar): Enrol V2 sidebar entry + V2 URL column on enrol-links

### DIFF
--- a/apps/admin/lib/sidebar/sidebar-manifest.json
+++ b/apps/admin/lib/sidebar/sidebar-manifest.json
@@ -15,7 +15,8 @@
     "id": "operator-bottom",
     "requiredRole": "OPERATOR",
     "items": [
-      { "id": "operator-enrol-v1", "href": "/x/enrol-links", "label": "Enrol V1", "icon": "UserPlus" }
+      { "id": "operator-enrol-v1", "href": "/x/enrol-links", "label": "Enrol V1", "icon": "UserPlus" },
+      { "id": "operator-enrol-v2", "href": "/x/enrol-links", "label": "Enrol V2", "icon": "KeyRound" }
     ]
   },
   {


### PR DESCRIPTION
Sibling to Enrol V1 sidebar item. Same /x/enrol-links page now shows both V1 (chat-first) and V2 (auth-first) URLs per cohort with separate Copy/Open buttons.