### PR TITLE
feat(assessment): #1067 — deterministic MCQ option shuffle (no "always A" leak)

### DIFF
--- a/apps/admin/app/api/student/assessment-questions/route.ts
+++ b/apps/admin/app/api/student/assessment-questions/route.ts
@@ -69,7 +69,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // Post-test: comprehension → direct query; others → mirror pre-test
     if (isComprehension && enrollment?.playbookId) {
-      const result = await buildComprehensionPostTest(enrollment.playbookId);
+      // #1067 — pass callerId as the shuffle seed.
+      const result = await buildComprehensionPostTest(enrollment.playbookId, {
+        callerSeed: callerId,
+      });
       return NextResponse.json({ ok: true, ...result });
     }
 
@@ -105,9 +108,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     enrollment?.playbook?.config,
   );
 
-  // Try curriculum-scoped first, then fall back to playbook-wide search
+  // Try curriculum-scoped first, then fall back to playbook-wide search.
+  // #1067 — pass callerId as the shuffle seed so option order is
+  // deterministic per (caller, question).
   if (curriculumId) {
-    const result = await buildPreTest(curriculumId, { lockedOutcomeRefs });
+    const result = await buildPreTest(curriculumId, {
+      lockedOutcomeRefs,
+      callerSeed: callerId,
+    });
     if (!result.skipped) {
       return NextResponse.json({ ok: true, ...result });
     }
@@ -115,7 +123,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   // Playbook-wide fallback — searches all subjects' content sources
   if (enrollment?.playbookId) {
-    const result = await buildPreTestForPlaybook(enrollment.playbookId, { lockedOutcomeRefs });
+    const result = await buildPreTestForPlaybook(enrollment.playbookId, {
+      lockedOutcomeRefs,
+      callerSeed: callerId,
+    });
     return NextResponse.json({ ok: true, ...result });
   }
 

--- a/apps/admin/lib/assessment/pre-test-builder.ts
+++ b/apps/admin/lib/assessment/pre-test-builder.ts
@@ -8,6 +8,11 @@ import { prisma } from "@/lib/prisma";
 import { config } from "@/lib/config";
 import { ContractRegistry } from "@/lib/contracts/registry";
 import type { SurveyStepConfig } from "@/lib/types/json-fields";
+import {
+  seedFromStrings,
+  shuffleOptions,
+  relabelByPosition,
+} from "@/lib/assessment/shuffle-options";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -315,27 +320,59 @@ async function fetchComprehensionQuestions(
 // Convert ContentQuestion → SurveyStepConfig
 // ---------------------------------------------------------------------------
 
-function toSurveyStep(q: ContentQuestionRow): SurveyStepConfig | null {
+function toSurveyStep(
+  q: ContentQuestionRow,
+  callerSeed: string = "",
+): SurveyStepConfig | null {
   const rawOptions = q.options as McqOption[] | null;
   if (!rawOptions || !Array.isArray(rawOptions) || rawOptions.length < 2) return null;
 
-  // Find the correct answer — either from the isCorrect flag or correctAnswer field
-  let correctValue: string | undefined;
-  const options = rawOptions.map((opt) => {
-    const value = opt.label; // "A", "B", "C", "D"
-    if (opt.isCorrect) correctValue = value;
-    return { value, label: `${opt.label}. ${opt.text}` };
-  });
-
-  // Fallback: match correctAnswer field against option labels
-  if (!correctValue && q.correctAnswer) {
+  // #1067 — locate the correct answer BEFORE shuffle. Either from the
+  // `isCorrect` flag (preferred — XAMS import) or from `correctAnswer`
+  // (legacy text match). We carry the "is the correct option" identity
+  // through the shuffle on each option's `isCorrect` flag and on
+  // `originalText`/`originalLabel` so we can recompute the new label
+  // post-shuffle.
+  let preCorrectLabel: string | undefined;
+  let preCorrectText: string | undefined;
+  for (const opt of rawOptions) {
+    if (opt.isCorrect) {
+      preCorrectLabel = opt.label;
+      preCorrectText = opt.text;
+      break;
+    }
+  }
+  if (!preCorrectLabel && q.correctAnswer) {
     const match = rawOptions.find(
       (opt) => opt.label === q.correctAnswer || opt.text === q.correctAnswer,
     );
-    if (match) correctValue = match.label;
+    if (match) {
+      preCorrectLabel = match.label;
+      preCorrectText = match.text;
+    }
   }
+  if (!preCorrectLabel || !preCorrectText) return null;
 
-  if (!correctValue) return null;
+  // #1067 — deterministic shuffle, then relabel by post-shuffle position so
+  // the renderer can present "A. … | B. … | C. …" with the correct answer
+  // landing in a different slot across learners.
+  const seed = seedFromStrings(callerSeed, q.id);
+  const shuffled = relabelByPosition(shuffleOptions(rawOptions, seed));
+
+  let correctValue: string | undefined;
+  const options = shuffled.map((opt) => {
+    // After relabel, opt.label is the NEW position label (A/B/C/D in
+    // shuffled order). `isCorrect` travels through, so the correct
+    // option's new label becomes correctValue.
+    if (opt.isCorrect) correctValue = opt.label;
+    return { value: opt.label, label: `${opt.label}. ${opt.text}` };
+  });
+
+  if (!correctValue) {
+    // Belt-and-braces fall-through: re-locate by text match after shuffle.
+    const match = shuffled.find((opt) => opt.text === preCorrectText);
+    correctValue = match?.label ?? preCorrectLabel;
+  }
 
   return {
     id: q.id,
@@ -369,6 +406,17 @@ export interface BuildPreTestOptions {
    * a server-side warning so the pre-test is never silently skipped.
    */
   lockedOutcomeRefs?: string[];
+  /**
+   * #1067 — seed for the deterministic per-question option shuffle. Typically
+   * the caller's `Caller.id`; combined with each question's id to produce a
+   * stable permutation per (caller, question). Different learners see
+   * different label positions for the same question → cohort-wide
+   * ~25/25/25/25 distribution across A/B/C/D. Same learner sees the same
+   * permutation on retry/refresh. Falls back to "" when missing, which
+   * still produces a stable per-question shuffle (all learners see the
+   * same one) — better than no shuffle, worse than per-learner.
+   */
+  callerSeed?: string;
 }
 
 /**
@@ -443,7 +491,12 @@ async function buildFromSourceIds(
     : fillUp(filledFromLocked, allQuestions, assessmentCfg.questionCount);
 
   // Convert to SurveyStepConfig
-  const steps = selected.map(toSurveyStep).filter((s): s is SurveyStepConfig => s !== null);
+  // #1067 — thread the caller seed through so the shuffle is stable per
+  // (caller, question) and the same learner sees the same labels on retry.
+  const callerSeed = opts?.callerSeed ?? "";
+  const steps = selected
+    .map((q) => toSurveyStep(q, callerSeed))
+    .filter((s): s is SurveyStepConfig => s !== null);
 
   if (steps.length === 0) {
     return { questions: [], questionIds: [], skipped: true, skipReason: "no_valid_mcq" };
@@ -496,7 +549,12 @@ export async function buildPostTest(callerId: string): Promise<PreTestResult> {
   const byId = new Map(questions.map((q) => [q.id, q]));
   const ordered = questionIds.map((id) => byId.get(id)).filter((q): q is ContentQuestionRow => !!q);
 
-  const steps = ordered.map(toSurveyStep).filter((s): s is SurveyStepConfig => s !== null);
+  // #1067 — post-test reuses pre-test question IDs; shuffle with the same
+  // (callerId, questionId) seed so the same learner sees the same option
+  // labels on the post-test as they did on the pre-test.
+  const steps = ordered
+    .map((q) => toSurveyStep(q, callerId))
+    .filter((s): s is SurveyStepConfig => s !== null);
 
   return {
     questions: steps,
@@ -511,7 +569,10 @@ export async function buildPostTest(callerId: string): Promise<PreTestResult> {
  * Does NOT depend on pre-test question IDs — comprehension courses skip pre-tests.
  * Selects questions spread across comprehension skillRefs (SKILL-01 through SKILL-06).
  */
-export async function buildComprehensionPostTest(playbookId: string): Promise<PreTestResult> {
+export async function buildComprehensionPostTest(
+  playbookId: string,
+  opts?: { callerSeed?: string },
+): Promise<PreTestResult> {
   const sourceIds = await getSourceIdsForPlaybook(playbookId);
   if (sourceIds.length === 0) {
     return { questions: [], questionIds: [], skipped: true, skipReason: "no_content_source" };
@@ -526,7 +587,11 @@ export async function buildComprehensionPostTest(playbookId: string): Promise<Pr
   const primary = selectBySkillSpread(allQuestions, assessmentCfg.questionCount);
   const selected = fillUp(primary, allQuestions, assessmentCfg.questionCount);
 
-  const steps = selected.map(toSurveyStep).filter((s): s is SurveyStepConfig => s !== null);
+  // #1067 — thread the caller seed for per-(caller, question) shuffle.
+  const callerSeed = opts?.callerSeed ?? "";
+  const steps = selected
+    .map((q) => toSurveyStep(q, callerSeed))
+    .filter((s): s is SurveyStepConfig => s !== null);
 
   if (steps.length === 0) {
     return { questions: [], questionIds: [], skipped: true, skipReason: "no_valid_mcq" };

--- a/apps/admin/lib/assessment/shuffle-options.ts
+++ b/apps/admin/lib/assessment/shuffle-options.ts
@@ -1,0 +1,104 @@
+/**
+ * Deterministic MCQ option shuffle — #1067.
+ *
+ * XAMS XLSX export convention stores the correct answer as the first option
+ * ("Answer 1") for every question; the source platform shuffles at delivery
+ * time. HFF used to render options in storage order, leaking the correct
+ * answer as "always A" (verified on hf_sandbox 2026-06-04: 250/250 MCQs
+ * across 5 question banks had `correctAnswer` at label A).
+ *
+ * Shuffle at presentation time (prompt assembly + UI rendering). The shuffle
+ * is deterministic per `seed` so retries reproduce the same order — i.e. a
+ * learner who refreshes the page or replays a survey sees the same labels in
+ * the same positions for the same question. Different learners get
+ * different shuffles → cohort-wide ~25/25/25/25 distribution across the four
+ * label positions.
+ *
+ * Implementation:
+ *   - `seedFromStrings(...parts)` — stable 32-bit hash for a seed
+ *   - `shuffleOptions(options, seed)` — Fisher-Yates driven by mulberry32 PRNG
+ *
+ * The mulberry32 PRNG is a 32-bit non-cryptographic generator with good
+ * uniformity for small N — exactly the use case here (typically 4 options).
+ */
+
+/**
+ * Stable 32-bit unsigned int hash over a concatenation of strings. Used to
+ * seed mulberry32. Not cryptographic; just needs to be deterministic and
+ * spread well across inputs. djb2 variant.
+ */
+export function seedFromStrings(...parts: readonly string[]): number {
+  const joined = parts.join("|");
+  let h = 5381;
+  for (let i = 0; i < joined.length; i++) {
+    h = (h * 33) ^ joined.charCodeAt(i);
+    h >>>= 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * mulberry32 — a fast 32-bit PRNG.
+ *
+ * Returns a function that emits floats in [0, 1). The state is captured in
+ * the closure; calling the same factory with the same seed reproduces the
+ * exact same sequence.
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6D2B79F5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Fisher-Yates shuffle, driven by a deterministic seed.
+ *
+ * Returns a new array; the input is not mutated. The shape of each option
+ * (text, label, isCorrect, …) is preserved verbatim — the `isCorrect` flag
+ * travels with each option through the shuffle so downstream consumers
+ * (UI label renderer, AI evaluator) can still locate the correct answer
+ * by reading `option.isCorrect`.
+ *
+ * @param options array of option objects (typically `{ label, text, isCorrect }`)
+ * @param seed    32-bit unsigned integer (use `seedFromStrings(...)` to derive)
+ * @returns shuffled copy of `options`
+ */
+export function shuffleOptions<T>(options: readonly T[], seed: number): T[] {
+  const out = [...options];
+  const rng = mulberry32(seed);
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/**
+ * Relabel a shuffled options array so position 0 is "A", 1 is "B", etc.
+ *
+ * Used by UI surfaces (e.g. pre-test survey) that present labels back to the
+ * learner. After this call, the option in slot N carries `label = letterAt(N)`
+ * and its original `isCorrect` flag, so:
+ *   - the renderer shows "A. {text-of-correct} | B. … | …" when the correct
+ *     answer happens to land in slot 0 after shuffle, or
+ *   - "A. … | B. {text-of-correct} | …" when it lands in slot 1, etc.
+ *
+ * Callers that compute `correctAnswer` from `isCorrect` get the new label
+ * automatically — there's no separate "correct position" to thread.
+ */
+export function relabelByPosition<T extends { label?: string }>(
+  options: readonly T[],
+): T[] {
+  return options.map((opt, idx) => ({ ...opt, label: letterAt(idx) }));
+}
+
+function letterAt(i: number): string {
+  // A, B, C, …, Z, AA, AB, … (only first 26 in practice; MCQs are rarely > 5).
+  if (i < 26) return String.fromCharCode(65 + i);
+  return letterAt(Math.floor(i / 26) - 1) + letterAt(i % 26);
+}

--- a/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
+++ b/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
@@ -20,6 +20,7 @@ import { buildLoMasteryMap } from "../lo-mastery-map";
 import type { AssembledContext, CompositionSectionDef } from "../types";
 import { computeInformationNeed, deriveQuestionCount } from "@/lib/assessment/information-need";
 import { selectRetrievalQuestions, type RetrievalQuestion } from "@/lib/assessment/retrieval-question-selector";
+import { seedFromStrings, shuffleOptions } from "@/lib/assessment/shuffle-options";
 import { prisma } from "@/lib/prisma";
 import { findCurriculumInfo } from "./modules";
 
@@ -157,7 +158,17 @@ registerTransform(
     }
 
     // ── Format prompt section ──
-    const formattedQuestions = questions.map((q, i) => formatQuestion(q, i + 1)).join("\n\n");
+    // #1067 — shuffle MCQ options at presentation time, deterministic per
+    // (callerId, questionId). The XAMS import convention places the correct
+    // answer at storage label A; without shuffle the AI tutor lists options
+    // in storage order and the student learns "A is always correct". Seed
+    // includes callerId so different learners get different shuffles
+    // (cohort-wide ~25/25/25/25 distribution) while same-learner retries
+    // reproduce the same labels for the same question.
+    const shuffleSeedCaller = loadedData.caller?.id ?? "";
+    const formattedQuestions = questions
+      .map((q, i) => formatQuestion(q, i + 1, shuffleSeedCaller))
+      .join("\n\n");
 
     console.log(
       `[retrieval-practice] ${mode} mode: injected ${questions.length} questions ` +
@@ -176,7 +187,11 @@ registerTransform(
   },
 );
 
-function formatQuestion(q: RetrievalQuestion, num: number): string {
+function formatQuestion(
+  q: RetrievalQuestion,
+  num: number,
+  callerSeed: string = "",
+): string {
   const parts = [`Q${num}: ${q.questionText}`];
 
   if (q.correctAnswer) {
@@ -190,7 +205,16 @@ function formatQuestion(q: RetrievalQuestion, num: number): string {
       const opts = Array.isArray(q.options)
         ? q.options
         : Object.values(q.options);
-      const optTexts = opts.map((o: any) => o.text ?? o.label ?? String(o));
+      // #1067 — deterministic shuffle per (callerId, questionId). callerSeed
+      // is "" for system calls without an enrolment; in that case shuffle
+      // still runs but is keyed only on questionId, which means each
+      // question still gets a stable permutation distinct from storage
+      // order. The AI tutor + voice reader pick this up via the printed
+      // text order; `correctAnswer` (stored as text) still resolves
+      // regardless of position.
+      const seed = seedFromStrings(callerSeed, q.id);
+      const shuffled = shuffleOptions(opts, seed);
+      const optTexts = shuffled.map((o: any) => o.text ?? o.label ?? String(o));
       parts.push(`    Options: ${optTexts.join(" | ")}`);
     } catch {
       // Options format unrecognised — skip

--- a/apps/admin/tests/lib/assessment/shuffle-options.test.ts
+++ b/apps/admin/tests/lib/assessment/shuffle-options.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #1067 — deterministic MCQ option shuffle.
+ *
+ * Pinned contracts:
+ *   - Same seed → same permutation (retry stability)
+ *   - Different seeds → different permutations (cohort spread)
+ *   - `isCorrect` flag travels through the shuffle on each option
+ *   - Across 100 questions for one caller, correct answer lands in
+ *     A/B/C/D positions at ~25% each (the AC headline number)
+ *   - relabelByPosition assigns A/B/C/D to the shuffled positions so
+ *     the survey renderer presents labels in display order
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  seedFromStrings,
+  shuffleOptions,
+  relabelByPosition,
+} from "@/lib/assessment/shuffle-options";
+
+type Opt = { label: string; text: string; isCorrect?: boolean };
+
+const baseFour: Opt[] = [
+  { label: "A", text: "1347", isCorrect: true },
+  { label: "B", text: "1234" },
+  { label: "C", text: "1265" },
+  { label: "D", text: "1450" },
+];
+
+describe("shuffle-options — #1067 deterministic shuffle", () => {
+  it("same seed produces the same permutation (retry stable)", () => {
+    const seed = seedFromStrings("caller-1", "question-42");
+    const a = shuffleOptions(baseFour, seed);
+    const b = shuffleOptions(baseFour, seed);
+    expect(a.map((o) => o.text)).toEqual(b.map((o) => o.text));
+  });
+
+  it("different seeds usually produce different permutations", () => {
+    const seedA = seedFromStrings("caller-1", "question-42");
+    const seedB = seedFromStrings("caller-2", "question-42");
+    const a = shuffleOptions(baseFour, seedA);
+    const b = shuffleOptions(baseFour, seedB);
+    // Not strictly guaranteed mathematically but the chance of collision
+    // on 4! = 24 permutations is < 5%. mulberry32 spreads well across
+    // close seeds — verified locally.
+    expect(a.map((o) => o.text)).not.toEqual(b.map((o) => o.text));
+  });
+
+  it("isCorrect flag travels through the shuffle on the same option", () => {
+    const seed = seedFromStrings("caller-x", "q-1");
+    const shuffled = shuffleOptions(baseFour, seed);
+    // The "1347" option is the correct one in the input; it must still
+    // carry isCorrect=true after shuffle.
+    const found = shuffled.find((o) => o.text === "1347");
+    expect(found).toBeDefined();
+    expect(found?.isCorrect).toBe(true);
+    // And no other option falsely picks it up.
+    const wrongTagged = shuffled.filter((o) => o.text !== "1347" && o.isCorrect);
+    expect(wrongTagged).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const seed = seedFromStrings("caller-1", "question-42");
+    const before = baseFour.map((o) => o.text);
+    shuffleOptions(baseFour, seed);
+    expect(baseFour.map((o) => o.text)).toEqual(before);
+  });
+
+  it("AC distribution — across 100 questions for one caller, correct answer is ~25/25/25/25 across labels", () => {
+    // Simulate the XAMS shape: 100 questions, all with correct = storage label A.
+    const counts: Record<string, number> = { A: 0, B: 0, C: 0, D: 0 };
+    for (let i = 0; i < 100; i++) {
+      const seed = seedFromStrings("caller-x", `q-${i.toString().padStart(3, "0")}`);
+      const shuffled = relabelByPosition(shuffleOptions(baseFour, seed));
+      const correct = shuffled.find((o) => o.isCorrect);
+      if (correct?.label) counts[correct.label] = (counts[correct.label] ?? 0) + 1;
+    }
+    // Allow generous slack (10..40) — 100 trials over 4 buckets has
+    // wide variance; the AC's "approximately 25%" wording covers this.
+    expect(counts.A).toBeGreaterThan(10);
+    expect(counts.A).toBeLessThan(40);
+    expect(counts.B).toBeGreaterThan(10);
+    expect(counts.B).toBeLessThan(40);
+    expect(counts.C).toBeGreaterThan(10);
+    expect(counts.C).toBeLessThan(40);
+    expect(counts.D).toBeGreaterThan(10);
+    expect(counts.D).toBeLessThan(40);
+    expect(counts.A + counts.B + counts.C + counts.D).toBe(100);
+    // And critically: NONE of the buckets has all 100 (the symptom the
+    // story exists to fix — "always A" leak).
+    expect(Math.max(counts.A, counts.B, counts.C, counts.D)).toBeLessThan(100);
+  });
+
+  it("AC: stable per (caller, question) — repeat call gives same labels", () => {
+    const seedPre = seedFromStrings("caller-x", "q-001");
+    const seedPost = seedFromStrings("caller-x", "q-001"); // same key
+    const pre = relabelByPosition(shuffleOptions(baseFour, seedPre));
+    const post = relabelByPosition(shuffleOptions(baseFour, seedPost));
+    // Same label → same text across the two calls (post-test mirrors pre-test).
+    for (let i = 0; i < pre.length; i++) {
+      expect(pre[i].label).toBe(post[i].label);
+      expect(pre[i].text).toBe(post[i].text);
+    }
+  });
+
+  it("relabelByPosition rewrites label to position letter", () => {
+    const seed = seedFromStrings("caller-x", "q-1");
+    const shuffled = relabelByPosition(shuffleOptions(baseFour, seed));
+    expect(shuffled.map((o) => o.label)).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("handles 2-option questions (true/false)", () => {
+    const tf: Opt[] = [
+      { label: "A", text: "True", isCorrect: true },
+      { label: "B", text: "False" },
+    ];
+    const a = relabelByPosition(shuffleOptions(tf, seedFromStrings("c", "tf-1")));
+    expect(a.map((o) => o.label)).toEqual(["A", "B"]);
+    // Correct option's new label is consistent with its position.
+    const correct = a.find((o) => o.isCorrect);
+    expect(correct).toBeDefined();
+    expect(["A", "B"]).toContain(correct?.label);
+  });
+
+  it("seedFromStrings is stable across calls for same input", () => {
+    expect(seedFromStrings("a", "b")).toBe(seedFromStrings("a", "b"));
+    expect(seedFromStrings("a", "b")).not.toBe(seedFromStrings("a", "c"));
+  });
+
+  it("empty-input is a no-op", () => {
+    expect(shuffleOptions([], 1234)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Shuffle MCQ options at presentation time so the XAMS "Answer 1 always correct" storage convention stops leaking to learners as "always A". Deterministic per `(callerSeed, questionId)` so pre-test ↔ post-test labels stay stable for the same learner, while different learners get different shuffles for cohort-wide ~25/25/25/25 distribution.

## Approach

| Piece | Where |
|---|---|
| New shared helper: `seedFromStrings`, `shuffleOptions`, `relabelByPosition` | `lib/assessment/shuffle-options.ts` |
| AI tutor prompt path | `lib/prompt/composition/transforms/retrieval-practice.ts::formatQuestion` |
| UI survey path | `lib/assessment/pre-test-builder.ts::toSurveyStep` |
| Caller seed threading | `buildPreTest` / `buildPreTestForPlaybook` / `buildPostTest` / `buildComprehensionPostTest` |
| Route wiring | `/api/student/assessment-questions` passes `callerId` as `callerSeed` on all 4 paths |

**Algorithm:** djb2 over `(callerSeed + questionId)` → 32-bit seed → mulberry32 PRNG → Fisher-Yates shuffle. Survey path additionally relabels A/B/C/D by post-shuffle position.

## AC checklist

- [x] Shuffle at presentation time (prompt + UI), deterministic per (caller, question)
- [x] `isCorrect` flag travels with each option through the shuffle
- [x] Tutor's answer-evaluation compares against shuffled-position label (`correctValue` recomputed from post-shuffle `isCorrect`)
- [x] Vitest: "across 100 questions presented to caller X, correct-answer label distribution is approximately 25%/25%/25%/25%"
- [x] No DB migration

## Test plan

- [x] 10 vitests pass (10/10) — retry stability, cohort spread, isCorrect travel, no mutation, distribution AC, pre/post stability, relabel, TRUE_FALSE, seed determinism, empty-input
- [x] tsc clean on touched files
- [ ] Manual smoke on VM: `/x/student/survey/pre` as a CIO/CTO learner with XAMS-style MCQs → expect labels scattered (not always A on correct)

## Effort

~2h actual (vs 1-2d story estimate). Deploy: `/vm-cp` (no migration).

Closes #1067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)