### PR TITLE
chore(tests): fix 3 pre-existing identity-test failures

### DIFF
--- a/apps/admin/tests/api/identity-resend-pin.test.ts
+++ b/apps/admin/tests/api/identity-resend-pin.test.ts
@@ -78,12 +78,19 @@ describe("POST /api/identity/resend-pin", () => {
     const body = await res.json();
 
     expect(body).toEqual({ ok: true });
-    expect(mockIssueFirstCallPin).toHaveBeenCalledWith({
-      callerId: "caller-own",
-      email: "learner@example.com",
-      firstName: "Test",
-      isResend: true,
-    });
+    // #1120 added `originUrl` to issueFirstCallPin so resend-issued emails
+    // land on the same env the learner is on. Match by subset rather than
+    // by exact-equality so this assertion survives future param additions
+    // (e.g. when SMS rollout adds a channel hint).
+    expect(mockIssueFirstCallPin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callerId: "caller-own",
+        email: "learner@example.com",
+        firstName: "Test",
+        isResend: true,
+        originUrl: expect.any(String),
+      }),
+    );
   });
 
   it("cap query filters resendCount > 0 (excludes initial issuance)", async () => {

--- a/apps/admin/tests/scripts/unlock-identity-challenge.test.ts
+++ b/apps/admin/tests/scripts/unlock-identity-challenge.test.ts
@@ -69,22 +69,27 @@ describe("scripts/unlock-identity-challenge", () => {
 
   it("exits non-zero when no callerId is supplied", async () => {
     process.argv = ["node", "script"];
+    // The script's main() catches its own errors and calls process.exit(1).
+    // The catch chain swallows our exitSpy throw, so the import() resolves —
+    // we assert on the exit-spy call count, not on rejection.
+    await import("@/scripts/unlock-identity-challenge");
+    await new Promise((r) => setImmediate(r));
 
-    await expect(import("@/scripts/unlock-identity-challenge")).rejects.toThrow(
-      /process.exit\(1\)/,
-    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining("Usage:"),
     );
+    expect(mockPrisma.callerIdentityChallenge.updateMany).not.toHaveBeenCalled();
   });
 
   it("exits non-zero when caller does not exist", async () => {
     process.argv = ["node", "script", "missing"];
     mockPrisma.caller.findUnique.mockResolvedValue(null);
 
-    await expect(import("@/scripts/unlock-identity-challenge")).rejects.toThrow(
-      /process.exit\(1\)/,
-    );
+    await import("@/scripts/unlock-identity-challenge");
+    await new Promise((r) => setImmediate(r));
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
     expect(mockPrisma.callerIdentityChallenge.updateMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Three flaky tests went green on origin/main but were red end-to-end. Surfaced when running the Story 3 regression suite. 1 stale exact-match assertion + 2 tests asserting on rejection of an import that never rejects. Full details in commit body.