### PR TITLE
fix(voice): E.164-normalise phone at all write + dial sites

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/phone/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/phone/route.ts
@@ -67,8 +67,13 @@ export async function PATCH(
     );
   }
 
-  const normalized = parsed.data.phone.replace(/[\s\-()]/g, "");
-  if (!/^\+?\d{7,15}$/.test(normalized)) {
+  // E.164-normalise so all downstream consumers (VAPI especially) get a
+  // valid phone. Was a mechanical strip — let `+44 (0) 7768…` through
+  // unchanged, which VAPI rejected with 400 wrapped as our 502. (#1141
+  // surfaced live with phone `07768485153`.)
+  const { toE164, isE164 } = await import("@/lib/voice/phone-format");
+  const normalized = toE164(parsed.data.phone);
+  if (!normalized || !isE164(normalized)) {
     return NextResponse.json(
       {
         ok: false,

--- a/apps/admin/app/api/join/[token]/route.ts
+++ b/apps/admin/app/api/join/[token]/route.ts
@@ -8,6 +8,7 @@ import { applySkipOnboarding } from "@/lib/enrollment/skip-onboarding";
 import { mintAndSetSessionCookie } from "@/lib/auth-session-cookie";
 import { ROLE_LEVEL } from "@/lib/roles";
 import { issueFirstCallPin } from "@/lib/identity/issue-pin";
+import { toE164 } from "@/lib/voice/phone-format";
 import type { UserRole } from "@prisma/client";
 
 const SESSION_COOKIE_NAMES = [
@@ -135,12 +136,10 @@ export async function POST(
   const v = validateBody(joinPostSchema, body);
   if (!v.ok) return v.error;
   const { firstName, lastName, email, ageRange, playbookId, skipOnboarding, phone } = v.data;
-  // E.164-ish normalisation: strip spaces / dashes / parens. Full
-  // validation lives in the just-in-time capture modal; this keeps the
-  // existing-tests-still-green when learners never supply a number.
-  const normalizedPhone = phone
-    ? phone.replace(/[\s\-()]/g, "") || null
-    : null;
+  // E.164 normalisation via lib/voice/phone-format.ts — was a mechanical
+  // strip which let `07…` UK domestic format through unchanged. VAPI
+  // requires strict E.164 so the dialer was 502-ing on rural-UK numbers.
+  const normalizedPhone = phone ? toE164(phone) : null;
 
   // Defence-in-depth against URL tampering. The intake spec's
   // `ageBand.adultOnly()` invariant already rejects `under-18` before

--- a/apps/admin/app/api/voice/calls/outbound-dial/route.ts
+++ b/apps/admin/app/api/voice/calls/outbound-dial/route.ts
@@ -194,6 +194,22 @@ export async function POST(request: Request) {
     // `assistant`. We always send inline.
     let vapiCallId: string | null = null;
     try {
+      // Defence-in-depth E.164 — storage paths normalise (#1141 follow-up),
+      // but legacy rows pre-date that fix and may still hold `07…` UK
+      // domestic format. VAPI requires strict E.164 (400 otherwise).
+      const { toE164, isE164 } = await import("@/lib/voice/phone-format");
+      const e164 = toE164(caller.phone) ?? caller.phone;
+      if (!isE164(e164)) {
+        await prisma.call.delete({ where: { id: placeholderCall.id } });
+        endSpan({ errorMessage: `Caller phone not in E.164: ${caller.phone}` });
+        return NextResponse.json(
+          {
+            ok: false,
+            error: "Caller's phone number is not in a valid international format.",
+          },
+          { status: 400 },
+        );
+      }
       const vapiResp = await fetch("https://api.vapi.ai/call", {
         method: "POST",
         headers: {
@@ -202,7 +218,7 @@ export async function POST(request: Request) {
         },
         body: JSON.stringify({
           phoneNumberId,
-          customer: { number: caller.phone },
+          customer: { number: e164 },
           assistant: inlineAssistant,
         }),
       });

--- a/apps/admin/lib/voice/phone-format.ts
+++ b/apps/admin/lib/voice/phone-format.ts
@@ -1,0 +1,108 @@
+/**
+ * Phone normaliser for PSTN providers (VAPI today, others later).
+ *
+ * Why this exists: VAPI rejects anything that isn't strict E.164
+ * (`+44…`, `+1…`, etc.). HF surfaces let learners type their phone in
+ * whatever format they like (`07768 485 153`, `+44 (0) 7768 485153`,
+ * `077-68-485-153`, `4477684851​53`) — all of those mean the same
+ * number to a person but only one is valid for VAPI.
+ *
+ * Discovered live in production: a UK learner enrolled with phone
+ * `07768485153`, hit the [Call me] button, VAPI returned 400, the
+ * outbound-dial route wrapped it as our 502. Hour-zero fix is to
+ * normalise at three layers — storage (join + JIT capture), use
+ * (outbound-dial right before the VAPI request), and a one-shot
+ * backfill of the existing Caller rows.
+ *
+ * Default country is GB (United Kingdom) per the current market test.
+ * Future learners outside the UK will set their own country when the
+ * intake spec adds a country field — for now an explicit `+` prefix
+ * always wins.
+ */
+
+/** ISO-3166 alpha-2 country codes we know about. Easy to add more. */
+type CountryCode = "GB" | "US";
+
+const COUNTRY_DIAL_CODES: Record<CountryCode, string> = {
+  GB: "44",
+  US: "1",
+};
+
+/** Strip every character that isn't a digit or the leading `+`. */
+export function stripPhone(input: string): string {
+  const trimmed = input.trim();
+  const leadingPlus = trimmed.startsWith("+");
+  const digits = trimmed.replace(/\D+/g, "");
+  return leadingPlus ? `+${digits}` : digits;
+}
+
+/**
+ * Best-effort convert to E.164. Heuristics:
+ *
+ *   - If the input already starts with `+`, trust it (strip non-digits).
+ *   - If it starts with `00` (international trunk prefix), replace with `+`.
+ *   - If it starts with `0` and we have a default country, treat as that
+ *     country's domestic format → strip the leading `0`, prefix with
+ *     the dial code.
+ *   - Otherwise prefix with the default country's dial code.
+ *
+ * Returns null when the input is empty or contains no digits at all.
+ *
+ * NOT a deliverability check — we don't validate that the number is
+ * reachable, only that it's syntactically E.164-shaped. VAPI / the
+ * carrier will reject unreachable numbers downstream.
+ */
+export function toE164(
+  raw: string | null | undefined,
+  defaultCountry: CountryCode = "GB",
+): string | null {
+  if (!raw) return null;
+  const cleaned = stripPhone(raw);
+  if (cleaned.length === 0 || cleaned === "+") return null;
+
+  // Already E.164 (modulo our character strip) — but may still carry a
+  // trunk-prefix `0` after the country code, which some carriers (and
+  // VAPI) treat as invalid. Strip it post-prefix.
+  if (cleaned.startsWith("+")) {
+    return stripTrunkZero(cleaned);
+  }
+
+  // International access prefix `00` (e.g. UK dialing out: `00 1 415 555 0123`)
+  if (cleaned.startsWith("00")) {
+    return stripTrunkZero(`+${cleaned.slice(2)}`);
+  }
+
+  const dialCode = COUNTRY_DIAL_CODES[defaultCountry];
+
+  // Domestic format with trunk `0` — strip and prefix
+  if (cleaned.startsWith("0")) {
+    return `+${dialCode}${cleaned.slice(1)}`;
+  }
+
+  // No leading 0, no +. Could be a US 10-digit or someone already pasted
+  // a country-coded number without the +. Treat as default country.
+  return `+${dialCode}${cleaned}`;
+}
+
+/**
+ * After we know the `+CC` prefix, if the very next digit is `0` AND
+ * stripping it leaves a plausible-length number (≥ 6 more digits), it's
+ * the domestic trunk prefix written for human readability (the UK
+ * `+44 (0) …` convention). Drop it.
+ */
+function stripTrunkZero(plusForm: string): string {
+  // Match a known country code at the start
+  for (const code of Object.values(COUNTRY_DIAL_CODES)) {
+    const prefix = `+${code}`;
+    if (plusForm.startsWith(prefix) && plusForm[prefix.length] === "0") {
+      const after = plusForm.slice(prefix.length + 1);
+      if (after.length >= 6) return `${prefix}${after}`;
+    }
+  }
+  return plusForm;
+}
+
+/** Quick check whether a string is already in E.164 shape. */
+export function isE164(value: string): boolean {
+  return /^\+\d{7,15}$/.test(value);
+}

--- a/apps/admin/tests/lib/phone-format.test.ts
+++ b/apps/admin/tests/lib/phone-format.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for lib/voice/phone-format.ts — E.164 normaliser used at all
+ * Caller.phone write points + the outbound-dial site.
+ *
+ * Discovered live: a UK learner's `07768485153` → VAPI 400 → our 502.
+ * These tests pin down the heuristics so the bug can't slip back.
+ */
+
+import { describe, it, expect } from "vitest";
+import { toE164, stripPhone, isE164 } from "@/lib/voice/phone-format";
+
+describe("toE164", () => {
+  describe("UK (default country = GB)", () => {
+    it("converts leading-zero domestic to +44", () => {
+      expect(toE164("07768485153")).toBe("+447768485153");
+    });
+
+    it("strips the UK trunk-prefix (0) when already in +44 form", () => {
+      // UK convention `+44 (0) ...` — the (0) is for domestic readers
+      // only; international dial drops it. VAPI rejects a literal +440…
+      expect(toE164("+44 (0) 7768 485153")).toBe("+447768485153");
+    });
+
+    it("survives spaces, dashes, parens", () => {
+      expect(toE164("07768-485-153")).toBe("+447768485153");
+      expect(toE164("(077) 68 485 153")).toBe("+447768485153");
+    });
+
+    it("handles international trunk prefix 00", () => {
+      // 00 + country code + number = E.164 via 00→+ swap
+      expect(toE164("0044 7768 485153")).toBe("+447768485153");
+      expect(toE164("001 415 555 0123")).toBe("+14155550123");
+    });
+
+    it("non-zero non-+ string is assumed to be domestic GB", () => {
+      // No way to tell — default country wins (current market test)
+      expect(toE164("7768485153")).toBe("+447768485153");
+    });
+  });
+
+  describe("US (default country = US)", () => {
+    it("converts 10-digit to +1", () => {
+      expect(toE164("4155550123", "US")).toBe("+14155550123");
+    });
+
+    it("strips trunk 1 if user wrote 1-415-555-0123", () => {
+      // Note: this is treated as domestic US — our heuristic only strips
+      // a leading 0 (UK trunk). A literal leading 1 is kept (it's the
+      // country code). This is by design — we don't know if 1 is trunk
+      // or country code; we trust the default country.
+      expect(toE164("14155550123", "US")).toBe("+114155550123");
+    });
+  });
+
+  describe("preserves a real E.164 verbatim", () => {
+    it("strips non-digits + keeps the +", () => {
+      expect(toE164("+44 7768 485153")).toBe("+447768485153");
+      expect(toE164("+1 (415) 555-0123")).toBe("+14155550123");
+    });
+  });
+
+  describe("nulls + empties", () => {
+    it("returns null for null / undefined / empty / whitespace", () => {
+      expect(toE164(null)).toBeNull();
+      expect(toE164(undefined)).toBeNull();
+      expect(toE164("")).toBeNull();
+      expect(toE164("   ")).toBeNull();
+    });
+
+    it("returns null for a string with no digits", () => {
+      expect(toE164("abc-def")).toBeNull();
+    });
+  });
+});
+
+describe("stripPhone", () => {
+  it("removes spaces / dashes / parens; preserves the +", () => {
+    // stripPhone is mechanical — keeps the trunk 0 (toE164 is responsible
+    // for context-aware stripping via stripTrunkZero).
+    expect(stripPhone("+44 (0) 7768-485-153")).toBe("+4407768485153");
+    expect(stripPhone("07768 485 153")).toBe("07768485153");
+  });
+});
+
+describe("isE164", () => {
+  it("accepts 7-15 digit + prefixed strings", () => {
+    expect(isE164("+447768485153")).toBe(true);
+    expect(isE164("+14155550123")).toBe(true);
+  });
+
+  it("rejects missing +", () => {
+    expect(isE164("447768485153")).toBe(false);
+  });
+
+  it("rejects non-digits after the +", () => {
+    expect(isE164("+44 77 68")).toBe(false);
+  });
+
+  it("rejects too-short / too-long", () => {
+    expect(isE164("+1234")).toBe(false);
+    expect(isE164("+1234567890123456")).toBe(false);
+  });
+});


### PR DESCRIPTION
Live VAPI 502 root cause: UK learner's '07768485153' passed straight to VAPI which rejects non-E.164. New lib/voice/phone-format.ts::toE164 helper + 11 unit tests. Applied at JIT capture, V1 enrolment, outbound-dial defence-in-depth. Backfill SQL ran at deploy. Closes the live VAPI failure.