### PR TITLE
fix(assessment): #1167 — data-routing chain, robust for all courses

### DIFF
--- a/apps/admin/lib/assessment/pre-test-builder.ts
+++ b/apps/admin/lib/assessment/pre-test-builder.ts
@@ -130,8 +130,19 @@ async function fetchQuestions(
       sourceId: { in: sourceIds },
       // Filter to requested types, excluding TUTOR_QUESTION (never student-facing)
       questionType: { in: questionTypes.filter((t) => t !== "TUTOR_QUESTION") as any },
-      // Exclude POST_TEST-only and TUTOR_ONLY questions from student pre-tests
-      assessmentUse: { notIn: ["POST_TEST", "TUTOR_ONLY"] },
+      // #1167 — exclude POST_TEST-only and TUTOR_ONLY questions from student
+      // pre-tests AND keep NULL rows (legacy / not-yet-categorised imports).
+      // Prisma's `notIn` follows SQL three-valued logic, so NULL is filtered
+      // out — silently dropping every uncategorised question. The live
+      // CIO/CTO Standard incident: all 250 XAMS-imported MCQs had
+      // assessmentUse=NULL → pre-test returned `no_questions`. The OR shape
+      // here explicitly admits NULL ("we don't know which side this is for,
+      // so allow both") which is consistent with the import-time default
+      // (see lib/content-trust/save-questions.ts).
+      OR: [
+        { assessmentUse: null },
+        { assessmentUse: { notIn: ["POST_TEST", "TUTOR_ONLY"] } },
+      ],
     },
     select: {
       id: true,

--- a/apps/admin/lib/assessment/retrieval-question-selector.ts
+++ b/apps/admin/lib/assessment/retrieval-question-selector.ts
@@ -18,6 +18,7 @@
  */
 
 import { prisma } from "@/lib/prisma";
+import { getSourceIdsForPlaybook } from "@/lib/knowledge/domain-sources";
 
 /** Bloom levels in taxonomy order for >= comparison */
 const BLOOM_ORDER: string[] = [
@@ -48,8 +49,28 @@ export interface RetrievalQuestion {
 }
 
 export interface SelectRetrievalOpts {
-  /** Curriculum ID — filters to sources linked to this curriculum */
+  /**
+   * Curriculum ID — kept for back-compat / logging only. The actual source
+   * resolution now goes through `playbookId` via
+   * `getSourceIdsForPlaybook` to walk the modern PlaybookSource attachment
+   * chain. The legacy `source: { curricula: { some: { id } } }` filter only
+   * matched sources where `Curriculum.primarySourceId = ContentSource.id`
+   * (the `@relation("CurriculumPrimarySource")` back-relation), which silently
+   * returned zero questions for every course that attached its Question
+   * Banks via PlaybookSource — i.e. all of the CIO/CTO Standard variants
+   * + any other modern course. See #1167.
+   */
   curriculumId: string;
+  /**
+   * #1167 — Playbook ID for the canonical source resolution. When provided,
+   * sources are resolved via `getSourceIdsForPlaybook(playbookId)` which
+   * walks `PlaybookSource` first, then the legacy 4-hop
+   * `PlaybookSubject → Subject → SubjectSource` chain. When omitted (legacy
+   * callers), the function falls back to the broken curricula-relation
+   * filter so existing behaviour is preserved — but new callers should
+   * always pass `playbookId`.
+   */
+  playbookId?: string | null;
   /** LO refs from the current working set (e.g., ["LO1", "LO2"]) */
   outcomeRefs: string[];
   /** How many questions to select */
@@ -71,7 +92,7 @@ export interface SelectRetrievalOpts {
 export async function selectRetrievalQuestions(
   opts: SelectRetrievalOpts,
 ): Promise<RetrievalQuestion[]> {
-  const { curriculumId, outcomeRefs, count, bloomFloor, recentQuestionIds, channel } = opts;
+  const { curriculumId, playbookId, outcomeRefs, count, bloomFloor, recentQuestionIds, channel } = opts;
 
   if (count <= 0) return [];
 
@@ -80,9 +101,29 @@ export async function selectRetrievalQuestions(
     ? BLOOM_ORDER.slice(bloomFloorIdx)
     : BLOOM_ORDER; // Unknown floor → allow all
 
+  // #1167 — source filter resolution.
+  //
+  // PREFERRED (when `playbookId` is provided): resolve sources via
+  // `getSourceIdsForPlaybook(playbookId)`. That helper walks
+  // `PlaybookSource` first, then the legacy 4-hop fallback. Every modern
+  // course (CIO/CTO Standard variants, IELTS, Big Five, Psychology,
+  // Persuasion) attaches its Question Banks via PlaybookSource — the
+  // path the helper covers.
+  //
+  // FALLBACK (when `playbookId` is missing): keep the legacy
+  // `source: { curricula: { some: { id: curriculumId } } }` filter so
+  // existing call sites that haven't been updated yet don't regress to
+  // empty pools. The legacy filter only matches sources where
+  // `Curriculum.primarySourceId = ContentSource.id` — a small subset of
+  // courses in practice — but it's better than nothing for any caller
+  // that genuinely has no playbookId in scope.
+  const sourceFilter = playbookId
+    ? { sourceId: { in: await getSourceIdsForPlaybook(playbookId) } }
+    : { source: { curricula: { some: { id: curriculumId } } } };
+
   // Base filter: eligible assessment use + bloom floor + not recently used
   const baseWhere = {
-    source: { curricula: { some: { id: curriculumId } } },
+    ...sourceFilter,
     assessmentUse: { in: RETRIEVAL_ELIGIBLE_USES as any },
     bloomLevel: { in: eligibleBlooms as any },
     ...(recentQuestionIds.length > 0 ? { id: { notIn: recentQuestionIds } } : {}),

--- a/apps/admin/lib/content-trust/save-questions.ts
+++ b/apps/admin/lib/content-trust/save-questions.ts
@@ -131,7 +131,17 @@ export async function saveQuestions(
   // gradable answer key; PRE_TEST / POST_TEST / BOTH / FORMATIVE all imply
   // a scored item. The only coherent values for TUTOR_QUESTION are null or
   // TUTOR_ONLY. Anything else is auto-corrected to TUTOR_ONLY and logged.
+  //
+  // #1167 — additionally default null assessmentUse to "BOTH" for ALL
+  // non-TUTOR question types. Live incident: XAMS XLSX import surfaced
+  // 250 CIO/CTO Standard MCQs with assessmentUse=NULL → silently
+  // dropped from every pre-test (`notIn` excludes NULL). The pre-test
+  // filter at lib/assessment/pre-test-builder.ts now explicitly admits
+  // NULL too (defence in depth), but the cleaner long-term state is
+  // for the import path to populate a sensible default. "BOTH" matches
+  // the IELTS V1.0 convention already in production.
   let assessmentUseCoerced = 0;
+  let assessmentUseDefaulted = 0;
   await prisma.contentQuestion.createMany({
     data: toCreate.map((q, i) => {
       const rawAssessmentUse = declaredAssessmentUse ?? q.assessmentUse ?? null;
@@ -143,6 +153,15 @@ export async function saveQuestions(
       ) {
         resolvedAssessmentUse = "TUTOR_ONLY";
         assessmentUseCoerced++;
+      }
+      // #1167 — final default. Skip for TUTOR_QUESTION (which legitimately
+      // wants null / TUTOR_ONLY semantics handled above).
+      if (
+        resolvedAssessmentUse === null &&
+        q.questionType !== "TUTOR_QUESTION"
+      ) {
+        resolvedAssessmentUse = "BOTH";
+        assessmentUseDefaulted++;
       }
       return {
         sourceId,
@@ -180,6 +199,11 @@ export async function saveQuestions(
   if (assessmentUseCoerced > 0) {
     console.warn(
       `[save-questions] source ${sourceId}: coerced ${assessmentUseCoerced} TUTOR_QUESTION row(s) from incompatible assessmentUse to TUTOR_ONLY (#385 Slice 3a guard)`,
+    );
+  }
+  if (assessmentUseDefaulted > 0) {
+    console.info(
+      `[save-questions] source ${sourceId}: defaulted ${assessmentUseDefaulted} row(s) with null assessmentUse to BOTH (#1167)`,
     );
   }
 

--- a/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
+++ b/apps/admin/lib/prompt/composition/transforms/retrieval-practice.ts
@@ -113,8 +113,14 @@ registerTransform(
     }
 
     // ── Select questions ──
+    // #1167 — pass the active Playbook's id so the selector uses the modern
+    // PlaybookSource attachment chain (via getSourceIdsForPlaybook) instead
+    // of the broken `source: { curricula: { some: { id } } }` filter that
+    // only matched sources where Curriculum.primarySourceId = source.id.
+    const activePlaybookId = loadedData.playbooks?.[0]?.id ?? null;
     const questions = await selectRetrievalQuestions({
       curriculumId: curriculumInfo.id,
+      playbookId: activePlaybookId,
       outcomeRefs,
       count: questionCount,
       bloomFloor,

--- a/apps/admin/scripts/migrate-content-question-assessment-use.sql
+++ b/apps/admin/scripts/migrate-content-question-assessment-use.sql
@@ -1,0 +1,41 @@
+-- #1167 — backfill ContentQuestion.assessmentUse from NULL → 'BOTH'.
+--
+-- Operator-applied SQL. Idempotent. Matches the import-time default that
+-- save-questions.ts now applies for new rows. Pre-2026-06-06 imports landed
+-- with NULL assessmentUse because XAMS XLSX export doesn't carry the field;
+-- the pre-test filter `notIn ['POST_TEST','TUTOR_ONLY']` followed Prisma SQL
+-- three-valued logic and silently excluded every NULL row.
+--
+-- Apply on each environment AFTER deploying the #1167 code changes:
+--   * sandbox (hf_sandbox) — confirmed 250 rows on CIO/CTO Standard as of 2026-06-06
+--   * staging (hf_staging) — TBD
+--   * prod    (hf_prod)    — TBD
+--
+-- Safety:
+--   * TUTOR_QUESTION rows are deliberately left alone (their NULL or
+--     TUTOR_ONLY semantics are intentional — see save-questions.ts).
+--   * Idempotent: a re-run after the code default applies will be a no-op
+--     (no rows with NULL assessmentUse remain).
+
+BEGIN;
+
+WITH affected AS (
+  SELECT id
+  FROM "ContentQuestion"
+  WHERE "assessmentUse" IS NULL
+    AND "questionType" <> 'TUTOR_QUESTION'
+)
+UPDATE "ContentQuestion" cq
+SET "assessmentUse" = 'BOTH'
+FROM affected
+WHERE cq.id = affected.id;
+
+-- Report what changed
+SELECT
+  COUNT(*) FILTER (WHERE "assessmentUse" IS NULL) AS still_null,
+  COUNT(*) FILTER (WHERE "assessmentUse" = 'BOTH') AS now_both,
+  COUNT(*) AS total
+FROM "ContentQuestion"
+WHERE "questionType" <> 'TUTOR_QUESTION';
+
+COMMIT;

--- a/apps/admin/tests/lib/assessment/pre-test-filter-null-assessment-use.test.ts
+++ b/apps/admin/tests/lib/assessment/pre-test-filter-null-assessment-use.test.ts
@@ -1,0 +1,84 @@
+/**
+ * #1167 — pre-test filter must include NULL assessmentUse rows.
+ *
+ * Live incident (2026-06-06): 250 CIO/CTO Standard MCQs landed with
+ * `assessmentUse: NULL` because XAMS XLSX import doesn't carry the field.
+ * The original Prisma filter `assessmentUse: { notIn: ['POST_TEST',
+ * 'TUTOR_ONLY'] }` followed SQL three-valued logic and silently excluded
+ * every NULL row → pre-test returned `no_questions`.
+ *
+ * Fix at `lib/assessment/pre-test-builder.ts::fetchQuestions`: replace with
+ *   OR: [ { assessmentUse: null }, { assessmentUse: { notIn: [...] } } ]
+ *
+ * This test pins the WHERE shape so a future refactor can't quietly
+ * regress the NULL admission.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  callerPlaybook: { findFirst: vi.fn() },
+  contentQuestion: { findMany: vi.fn() },
+  curriculum: { findUnique: vi.fn() },
+  contentSource: { findMany: vi.fn() },
+  playbookSource: { findMany: vi.fn() },
+  playbookSubject: { findMany: vi.fn() },
+  subjectSource: { findMany: vi.fn() },
+  domain: { findUnique: vi.fn() },
+  callerAttribute: { findUnique: vi.fn() },
+  callerModuleProgress: { findMany: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/contracts/registry", () => ({
+  ContractRegistry: { getEnum: vi.fn().mockResolvedValue(null) },
+}));
+vi.mock("@/lib/config", () => ({
+  config: { specs: {} },
+}));
+vi.mock("@/lib/knowledge/domain-sources", () => ({
+  getSourceIdsForPlaybook: vi.fn().mockResolvedValue(["src-1"]),
+}));
+
+describe("pre-test fetchQuestions — #1167 NULL assessmentUse admission", () => {
+  let buildPreTest: typeof import("@/lib/assessment/pre-test-builder").buildPreTest;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockPrisma.contentSource.findMany.mockResolvedValue([{ id: "src-1" }]);
+    mockPrisma.playbookSource.findMany.mockResolvedValue([{ sourceId: "src-1" }]);
+    mockPrisma.contentQuestion.findMany.mockResolvedValue([]);
+    mockPrisma.curriculum.findUnique.mockResolvedValue({
+      id: "cur-1",
+      primarySourceId: "src-1",
+      playbookId: "pb-1",
+      subjectId: null,
+    });
+    const mod = await import("@/lib/assessment/pre-test-builder");
+    buildPreTest = mod.buildPreTest;
+  });
+
+  it("emits a WHERE that admits NULL assessmentUse via OR (not the old notIn-only shape)", async () => {
+    await buildPreTest("cur-1");
+
+    // Find the fetchQuestions Prisma call — distinguished by the
+    // `assessmentUse` OR/notIn shape on the where clause.
+    const fetchCall = mockPrisma.contentQuestion.findMany.mock.calls.find(
+      (call) => {
+        const where = call?.[0]?.where ?? {};
+        return Array.isArray(where.OR);
+      },
+    );
+    expect(fetchCall, "expected fetchQuestions to issue a Prisma findMany with an OR clause").toBeDefined();
+    const where = fetchCall![0].where;
+
+    // Pin the exact shape: OR of (null, notIn excluding POST_TEST + TUTOR_ONLY).
+    expect(where.OR).toContainEqual({ assessmentUse: null });
+    expect(where.OR).toContainEqual({
+      assessmentUse: { notIn: ["POST_TEST", "TUTOR_ONLY"] },
+    });
+
+    // The OLD shape MUST NOT be present at the top level — that's the bug we
+    // just fixed.
+    expect(where.assessmentUse).toBeUndefined();
+  });
+});

--- a/apps/admin/tests/lib/assessment/retrieval-selector-source-resolution.test.ts
+++ b/apps/admin/tests/lib/assessment/retrieval-selector-source-resolution.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #1167 — retrieval-question-selector source resolution.
+ *
+ * The legacy filter `source: { curricula: { some: { id: curriculumId } } }`
+ * only matched ContentSources where `Curriculum.primarySourceId = source.id`
+ * (the `@relation("CurriculumPrimarySource")` back-relation). For every
+ * modern course that attaches Question Banks via `PlaybookSource` — i.e.
+ * CIO/CTO Standard variants + every product family on the market test —
+ * that filter silently returned zero questions.
+ *
+ * Fix: when the caller passes `playbookId`, resolve sources via
+ * `getSourceIdsForPlaybook` (the canonical helper that walks
+ * `PlaybookSource → ContentSource`). Fall back to the legacy filter only
+ * when `playbookId` is missing (back-compat for callers not yet updated).
+ *
+ * These vitests pin the contract without spinning up the DB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPrisma = {
+  contentQuestion: { findMany: vi.fn() },
+};
+const mockGetSourceIdsForPlaybook = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/knowledge/domain-sources", () => ({
+  getSourceIdsForPlaybook: (...args: unknown[]) => mockGetSourceIdsForPlaybook(...args),
+}));
+
+describe("selectRetrievalQuestions — #1167 source resolution", () => {
+  let selectRetrievalQuestions: typeof import("@/lib/assessment/retrieval-question-selector").selectRetrievalQuestions;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/lib/assessment/retrieval-question-selector");
+    selectRetrievalQuestions = mod.selectRetrievalQuestions;
+  });
+
+  it("uses getSourceIdsForPlaybook when playbookId is provided", async () => {
+    mockGetSourceIdsForPlaybook.mockResolvedValue(["src-a", "src-b", "src-c"]);
+    mockPrisma.contentQuestion.findMany.mockResolvedValue([]);
+
+    await selectRetrievalQuestions({
+      curriculumId: "cur-1",
+      playbookId: "pb-revision-aid",
+      outcomeRefs: [],
+      count: 5,
+      bloomFloor: "REMEMBER",
+      recentQuestionIds: [],
+      channel: "text",
+    });
+
+    expect(mockGetSourceIdsForPlaybook).toHaveBeenCalledWith("pb-revision-aid");
+    // Verify the actual Prisma WHERE used the source-id filter (not the
+    // broken curricula relation filter).
+    const where = mockPrisma.contentQuestion.findMany.mock.calls.at(-1)?.[0].where;
+    expect(where.sourceId).toEqual({ in: ["src-a", "src-b", "src-c"] });
+    expect(where.source).toBeUndefined();
+  });
+
+  it("falls back to legacy curricula relation filter when playbookId is null", async () => {
+    mockPrisma.contentQuestion.findMany.mockResolvedValue([]);
+
+    await selectRetrievalQuestions({
+      curriculumId: "cur-1",
+      playbookId: null,
+      outcomeRefs: [],
+      count: 5,
+      bloomFloor: "REMEMBER",
+      recentQuestionIds: [],
+      channel: "text",
+    });
+
+    expect(mockGetSourceIdsForPlaybook).not.toHaveBeenCalled();
+    const where = mockPrisma.contentQuestion.findMany.mock.calls.at(-1)?.[0].where;
+    expect(where.source).toEqual({ curricula: { some: { id: "cur-1" } } });
+    expect(where.sourceId).toBeUndefined();
+  });
+
+  it("falls back to legacy filter when playbookId is undefined (legacy callers)", async () => {
+    mockPrisma.contentQuestion.findMany.mockResolvedValue([]);
+
+    await selectRetrievalQuestions({
+      curriculumId: "cur-1",
+      outcomeRefs: [],
+      count: 5,
+      bloomFloor: "REMEMBER",
+      recentQuestionIds: [],
+      channel: "text",
+    });
+
+    expect(mockGetSourceIdsForPlaybook).not.toHaveBeenCalled();
+    const where = mockPrisma.contentQuestion.findMany.mock.calls.at(-1)?.[0].where;
+    expect(where.source).toEqual({ curricula: { some: { id: "cur-1" } } });
+  });
+
+  it("count=0 short-circuits — no source lookup, no DB hit", async () => {
+    const result = await selectRetrievalQuestions({
+      curriculumId: "cur-1",
+      playbookId: "pb-1",
+      outcomeRefs: [],
+      count: 0,
+      bloomFloor: "REMEMBER",
+      recentQuestionIds: [],
+      channel: "text",
+    });
+
+    expect(result).toEqual([]);
+    expect(mockGetSourceIdsForPlaybook).not.toHaveBeenCalled();
+    expect(mockPrisma.contentQuestion.findMany).not.toHaveBeenCalled();
+  });
+
+  it("threads recentQuestionIds + channel filters into the WHERE alongside the new source filter", async () => {
+    mockGetSourceIdsForPlaybook.mockResolvedValue(["src-x"]);
+    mockPrisma.contentQuestion.findMany.mockResolvedValue([]);
+
+    await selectRetrievalQuestions({
+      curriculumId: "cur-1",
+      playbookId: "pb-x",
+      outcomeRefs: [],
+      count: 3,
+      bloomFloor: "REMEMBER",
+      recentQuestionIds: ["q-old-1", "q-old-2"],
+      channel: "voice",
+    });
+
+    const where = mockPrisma.contentQuestion.findMany.mock.calls.at(-1)?.[0].where;
+    expect(where.sourceId).toEqual({ in: ["src-x"] });
+    expect(where.id).toEqual({ notIn: ["q-old-1", "q-old-2"] });
+    expect(where.questionType).toBeDefined(); // voice channel adds VISUAL_ONLY exclusion
+  });
+});


### PR DESCRIPTION
## Summary

Three real bugs surfaced during yesterday's #1067 smoke test (Emma Richardson on the CIO/CTO Standard — Revision Aid hit `/api/student/assessment-questions` and got `{ ok: true, questions: [], skipped: true }` despite the Playbook having 250 MCQs).

| # | Site | Bug | Fix |
|---|---|---|---|
| **1** | `lib/assessment/pre-test-builder.ts::fetchQuestions` | Prisma `notIn: ['POST_TEST','TUTOR_ONLY']` silently excludes NULL rows (SQL 3VL). All 250 XAMS-imported Standard MCQs had `assessmentUse: NULL`. | `OR: [{ assessmentUse: null }, { assessmentUse: { notIn: [...] } }]` |
| **2** | `lib/content-trust/save-questions.ts` (defence in depth) | Future imports that don't set `assessmentUse` get NULL again. | Default null → `'BOTH'` at write time for non-TUTOR rows. Matches IELTS V1.0's production convention. |
| **3** | `lib/assessment/retrieval-question-selector.ts` (in-call MCQ injection) | Filter `source: { curricula: { some: { id: curriculumId } } }` only matches sources where `Curriculum.primarySourceId = source.id` (the `@relation("CurriculumPrimarySource")` back-relation). Every PlaybookSource-attached course returns zero questions silently. | Add `playbookId?` to `SelectRetrievalOpts`. Use `getSourceIdsForPlaybook(playbookId)` when provided; legacy fallback when not. Caller `retrieval-practice.ts` threads `loadedData.playbooks[0]?.id`. |
| **4** | `scripts/migrate-content-question-assessment-use.sql` | Existing NULL data on prod / staging. | Idempotent backfill SQL — operator runs per environment. |

## Robustness across the 4 market-test product families

| Course | Pre-test path (fix 1+2) | In-call retrieval (fix 3) |
|---|---|---|
| CIO/CTO Standard (3 variants) | ✓ via NULL admission | ✓ via PlaybookSource lookup |
| IELTS Speaking (3 variants) | ✓ already worked (`BOTH`); no regression | ✓ |
| Big Five (OCEAN) | ✓ | ✓ |
| Psychology | ✓ | ✓ |
| Persuasion Literacy | ✓ | ✓ |

## Robustness for NEW courses

| Creation route | Why this PR covers it |
|---|---|
| V5 wizard (`wizard-tool-executor.ts::create_course`) | Writes PlaybookSource → covered by fix 3 |
| V6 wizard | Same expected path |
| `POST /api/courses` | Writes PlaybookSource after course-setup flow → covered |
| Domain auto-enroll / quick-launch | Same PlaybookSource path |
| Save-questions guard (fix 2) | Any future XAMS-style import that leaves `assessmentUse` blank lands as `BOTH` automatically |

## Test plan

- [x] 6 new vitest cases pass (5 source-resolution + 1 NULL admission shape)
- [ ] Operator runs `scripts/migrate-content-question-assessment-use.sql` on sandbox / staging / prod
- [ ] Manual smoke: `GET /api/student/assessment-questions?type=pre_test&callerId=<emma>` returns ≥ 1 MCQ
- [ ] Manual smoke: in-call retrieval-practice injects MCQs on a CIO/CTO Standard session

Closes (most of) #1167. Chain-walk doc update deferred per TL scope-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)