### PR TITLE
fix(student-api): #1167 — primary/recent orderBy on multi-enrollment findFirst (5 routes)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
@@ -61,8 +61,12 @@ export async function GET(
   // Resolve teaching profile + playbook context: caller → enrollment →
   // playbook → subject. We pull the playbook id + name as well so the
   // module-mastery branch (below) can render the course name.
+  // #1167 — prefer primary (isDefault) then most recently enrolled when a
+  // learner has multiple ACTIVE enrollments. Without orderBy the trajectory
+  // would show data from a non-deterministic course.
   const enrollment = await prisma.callerPlaybook.findFirst({
     where: { callerId, status: "ACTIVE" },
+    orderBy: [{ isDefault: "desc" }, { enrolledAt: "desc" }],
     select: {
       playbookId: true,
       playbook: {

--- a/apps/admin/app/api/callers/[callerId]/session-flow-progress/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/session-flow-progress/route.ts
@@ -60,8 +60,12 @@ export async function GET(
   try {
     const { callerId } = await params;
 
+    // #1167 — prefer primary (isDefault) then most recently enrolled when a
+    // learner has multiple ACTIVE enrollments. Without orderBy the session-
+    // flow progress could show data from a non-deterministic course.
     const enrollment = await prisma.callerPlaybook.findFirst({
       where: { callerId, status: "ACTIVE" },
+      orderBy: [{ isDefault: "desc" }, { enrolledAt: "desc" }],
       select: {
         playbook: {
           select: {

--- a/apps/admin/app/api/student/assessment-questions/route.ts
+++ b/apps/admin/app/api/student/assessment-questions/route.ts
@@ -45,8 +45,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   // Resolve enrollment + teaching profile for post-test comprehension detection
   if (type === "post_test") {
+    // #1167 — pick the learner's PRIMARY enrollment when they have multiple
+    // ACTIVE Playbooks. Without orderBy, Prisma returns whichever row hits
+    // the natural index first — for Emma Richardson (enrolled in CIO/CTO
+    // Standard as default + Psychology as legacy), this was Psychology,
+    // routing the post-test through the wrong course's content.
     const enrollment = await prisma.callerPlaybook.findFirst({
       where: { callerId, status: "ACTIVE" },
+      orderBy: [{ isDefault: "desc" }, { enrolledAt: "desc" }],
       select: {
         playbookId: true,
         playbook: {
@@ -81,9 +87,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, ...result });
   }
 
-  // pre_test — resolve enrolled playbook and curriculum
+  // pre_test — resolve enrolled playbook and curriculum.
+  // #1167 — see the post_test comment above. Same isDefault / enrolledAt
+  // ordering must be applied here so the pre-test routes through the
+  // learner's primary enrollment when they have multiple active courses.
   const enrollment = await prisma.callerPlaybook.findFirst({
     where: { callerId, status: "ACTIVE" },
+    orderBy: [{ isDefault: "desc" }, { enrolledAt: "desc" }],
     include: {
       playbook: {
         select: {

--- a/apps/admin/app/api/student/journey-position/route.ts
+++ b/apps/admin/app/api/student/journey-position/route.ts
@@ -58,6 +58,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const [enrollment, onboardingSession] = await Promise.all([
       prisma.callerPlaybook.findFirst({
         where: { callerId, status: "ACTIVE" },
+        // #1167 — prefer primary (isDefault) then most recently enrolled
+        // for learners with multiple ACTIVE enrollments. Without orderBy
+        // Prisma's findFirst was non-deterministic.
+        orderBy: [{ isDefault: "desc" }, { enrolledAt: "desc" }],
         include: {
           playbook: {
             select: {

--- a/apps/admin/app/api/student/survey-config/route.ts
+++ b/apps/admin/app/api/student/survey-config/route.ts
@@ -35,8 +35,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const auth = await requireStudentOrAdmin(request);
     if (isStudentAuthError(auth)) return auth.error;
 
+    // #1167 — prefer primary (isDefault) then most recently enrolled when a
+    // learner has multiple ACTIVE enrollments. Without orderBy, Prisma's
+    // findFirst returned a non-deterministic row.
     const enrollment = await prisma.callerPlaybook.findFirst({
       where: { callerId: auth.callerId, status: "ACTIVE" },
+      orderBy: [{ isDefault: "desc" }, { enrolledAt: "desc" }],
       select: {
         playbook: {
           select: {


### PR DESCRIPTION
Live audit on 2026-06-06 found 5 student-facing routes were calling `prisma.callerPlaybook.findFirst({ where: { callerId, status: ACTIVE } })` without an `orderBy`. For learners with multiple ACTIVE enrollments, Prisma's row-pick is non-deterministic. Emma Richardson (Standard primary + Psychology legacy) was getting routed through Psychology for pre-test, survey config, journey position, etc.

The fix is one canonical orderBy line per site, matching the working pattern already in `/api/student/qualification-progress` (from #1098):

```ts
orderBy: [{ isDefault: "desc" }, { enrolledAt: "desc" }]
```

5 files, 6 query sites patched. Routes that filter by `enrollmentId` (activate, retake) are intentionally unchanged — uniquely identified, ordering moot.

This is the live blocker behind #1167's empty pre-test for Emma; with the orderBy in place plus the prior #1167 PR's filter + backfill, her pre-test should now return the Standard's 250 MCQs.