### PR TITLE
fix(sidebar): register UserPlus + KeyRound icons; switch V2 to ShieldCheck

### DIFF
--- a/apps/admin/lib/sidebar/icons.ts
+++ b/apps/admin/lib/sidebar/icons.ts
@@ -63,6 +63,8 @@ import {
   ScrollText,
   GitCompareArrows,
   FileCode,
+  UserPlus,
+  KeyRound,
   type LucideIcon,
 } from "lucide-react";
 
@@ -131,4 +133,6 @@ export const ICON_MAP: Record<string, LucideIcon> = {
   ScrollText,
   GitCompareArrows,
   FileCode,
+  UserPlus,
+  KeyRound,
 };


### PR DESCRIPTION
Enrol V1 + V2 items had no icon rendering because UserPlus / KeyRound weren't in ICON_MAP. Registered both. V2 switches from KeyRound to ShieldCheck (already in map) for the 'auth-stamp' character — shield + checkmark.