### PR TITLE
fix(sidebar): swap V2 icon to ShieldCheck (auth-stamp)

### DIFF
--- a/apps/admin/lib/sidebar/sidebar-manifest.json
+++ b/apps/admin/lib/sidebar/sidebar-manifest.json
@@ -16,7 +16,7 @@
     "requiredRole": "OPERATOR",
     "items": [
       { "id": "operator-enrol-v1", "href": "/x/enrol-links", "label": "Enrol V1", "icon": "UserPlus" },
-      { "id": "operator-enrol-v2", "href": "/x/enrol-links", "label": "Enrol V2", "icon": "KeyRound" }
+      { "id": "operator-enrol-v2", "href": "/x/enrol-links", "label": "Enrol V2", "icon": "ShieldCheck" }
     ]
   },
   {


### PR DESCRIPTION
One-line follow-up to #1179. The manifest swap I intended for that PR didn't make it in. V2 now uses ShieldCheck as the auth-stamp icon.