### PR TITLE
fix(audit-g10): tutor-briefing validator + 140-row backfill (#1160)

### DIFF
--- a/apps/admin/lib/domain/course-setup.ts
+++ b/apps/admin/lib/domain/course-setup.ts
@@ -12,6 +12,7 @@ import { config } from "@/lib/config";
 import { logSystem } from "@/lib/logger";
 import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
 import { updateDomainConfig } from "@/lib/domain/update-domain-config";
+import { filterLearningOutcomes } from "@/lib/domain/validate-learning-outcome";
 import slugify from "slugify";
 import { scaffoldDomain } from "@/lib/domain/scaffold";
 import { loadPersonaFlowPhases, loadPersonaArchetype, loadPersonaWelcomeTemplate } from "@/lib/domain/quick-launch";
@@ -376,10 +377,24 @@ const stepExecutors: Record<string, (ctx: CourseSetupContext, step: CourseSetupS
         // Map learning outcomes → GoalTemplate entries so instantiatePlaybookGoals
         // creates real Goal rows on enrolment. Without this, enrolled learners have
         // no reward signal and the adapt loop runs dry.
+        //
+        // G10 / #1160 (audit 2026-06): validate each `learningOutcomes` entry
+        // against the tutor-briefing heuristic before it becomes a Goal row.
+        // Pre-G10, IELTS V1.0 accumulated 120 rows of tutor-instruction text
+        // ("Call 1 is a topic-led warm-up", "FC is the most visible criterion")
+        // because the wizard author dropped them into `learningOutcomes[]`. The
+        // validator rejects fragments that look like rules-of-engagement /
+        // rubric-references / tutor-actions and warn-logs each rejection so
+        // operators see exactly which entries were filtered out and why.
         let mergedGoals = (existingConfig.goals as Array<{ name?: string; [k: string]: any }> | undefined) || [];
         if (ctx.input.learningOutcomes?.length) {
+          const validated = filterLearningOutcomes(ctx.input.learningOutcomes, (entry, reason) => {
+            console.warn(
+              `[course-setup] G10 rejected learningOutcomes entry — looks like tutor briefing, not a learner outcome. reason="${reason}" entry=${JSON.stringify(entry.slice(0, 120))}`,
+            );
+          });
           const existingNames = new Set(mergedGoals.map((g) => g.name?.toLowerCase().trim()));
-          const newLOGoals = ctx.input.learningOutcomes
+          const newLOGoals = validated
             .filter((lo) => !existingNames.has(lo.toLowerCase().trim()))
             .map((lo) => ({
               type: "LEARN" as const,

--- a/apps/admin/lib/domain/validate-learning-outcome.ts
+++ b/apps/admin/lib/domain/validate-learning-outcome.ts
@@ -1,0 +1,107 @@
+/**
+ * Learning Outcome Validator (G10 / #1160)
+ *
+ * Defends `Goal.type = "LEARN"` rows from tutor-briefing pollution.
+ *
+ * Audit context: the IELTS V1.0 playbook (`eb6bc79e`) accumulated 280
+ * `Goal.type=LEARN` rows (audit 2026-06-06). 160 were legitimate
+ * `lo_rollup` outcomes mapped to `LearningObjective` (OUT-01..OUT-08).
+ * The other 120 were tutor-briefing directives — text the wizard
+ * author dropped into the `learningOutcomes[]` field that was meant
+ * for the COMPOSE prompt's `criticalRules` section, not as learner-
+ * facing Goal rows. Examples:
+ *
+ *   "Call 1 is a topic-led warm-up only with special rules that differ from subsequent calls"
+ *   "On Call 1 the tutor scores silently in the background"
+ *   "FC is the most visible criterion — poor fluency masks good vocabulary and grammar"
+ *   "The four criteria below must NOT be named, listed, or explained on Call 1"
+ *
+ * These polluted Goal rows (a) loaded `trackGoalProgress` with 360 noise
+ * rows per pipeline run on IELTS V1.0 callers, (b) corrupted the
+ * "what is this learner trying to achieve?" semantics that ADAPT and
+ * COMPOSE both depend on.
+ *
+ * This validator is heuristic-based — strings that look like tutor
+ * briefings rather than learner-intent statements get rejected at
+ * `course-setup.ts` ingest time. `validate(entry).ok === false` means
+ * the entry is dropped from `learningOutcomes[]` with a warn log
+ * carrying the rejection reason.
+ *
+ * Companion to existing issue #307 (which stops a different bleed path
+ * in the same surface — see TL #1160 review).
+ */
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Tutor-briefing red flags. Each pattern is a fragment of common
+ * tutor-instruction language that has no place in a learner-outcome
+ * statement. Order independent.
+ *
+ * Some patterns are intentionally narrow ("Call 1 is", "On Call 1")
+ * to avoid false positives on legitimate outcomes that reference
+ * calls (e.g. "Complete 5 practice calls on Part 2 within 4 weeks"
+ * passes — "Complete N calls" is a learner outcome).
+ */
+const TUTOR_BRIEFING_FRAGMENTS: ReadonlyArray<{ pattern: RegExp; reason: string }> = [
+  { pattern: /\bCall\s+\d+\s+is\b/i, reason: "rule-of-engagement statement ('Call N is …')" },
+  { pattern: /\bOn\s+Call\s+\d+\b/i, reason: "tutor-direction statement ('On Call N …')" },
+  { pattern: /\bfrom\s+Call\s+\d+\s+onwards\b/i, reason: "tutor-direction statement ('From Call N onwards …')" },
+  { pattern: /\bthe\s+tutor\s+(scores|coach(es|ing)?|grades|notes|silently)/i, reason: "tutor-action statement ('the tutor scores/coaches …')" },
+  { pattern: /\bthe\s+(four|three|five)\s+criteria\b/i, reason: "rubric-reference statement ('the four criteria …')" },
+  { pattern: /\bMUST\s+NOT\b/, reason: "prohibition statement ('MUST NOT …')" },
+  { pattern: /\bmust\s+not\s+be\s+(named|listed|explained|mentioned)\b/i, reason: "prohibition statement ('must not be named …')" },
+  { pattern: /\bis\s+the\s+most\s+visible\s+criterion\b/i, reason: "rubric-criterion statement ('… is the most visible criterion …')" },
+  { pattern: /\bpartially\s+independent\b.*\b(vocabulary|grammar|pronunciation|fluency)\b/i, reason: "rubric-relationship statement" },
+  { pattern: /\bin\s+the\s+background\b/i, reason: "behind-the-scenes-mechanic statement" },
+  { pattern: /\bthe\s+rubric\b/i, reason: "rubric-reference statement" },
+  { pattern: /\bsilently\s+(scor|grad|not|coach)/i, reason: "background-scoring statement" },
+];
+
+/**
+ * Minimum-length floor: a one- or two-word entry is unlikely to be a
+ * real learner outcome (real outcomes specify a measurable behaviour
+ * or competence). Allow 3+ tokens.
+ */
+const MIN_TOKENS = 3;
+
+export function validateLearningOutcomeEntry(raw: string): ValidationResult {
+  const entry = (raw ?? "").trim();
+  if (!entry) return { ok: false, reason: "empty string" };
+
+  const tokens = entry.split(/\s+/).filter(Boolean);
+  if (tokens.length < MIN_TOKENS) {
+    return { ok: false, reason: `too short (${tokens.length} tokens; min ${MIN_TOKENS})` };
+  }
+
+  for (const { pattern, reason } of TUTOR_BRIEFING_FRAGMENTS) {
+    if (pattern.test(entry)) {
+      return { ok: false, reason: `tutor-briefing fragment: ${reason}` };
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Bulk filter — returns only the entries that pass validation. Rejected
+ * entries are reported via the optional `onReject` callback so callers
+ * (e.g. course-setup.ts) can warn-log without surfacing duplicates.
+ */
+export function filterLearningOutcomes(
+  raw: ReadonlyArray<string>,
+  onReject?: (entry: string, reason: string) => void,
+): string[] {
+  const passed: string[] = [];
+  for (const entry of raw) {
+    const result = validateLearningOutcomeEntry(entry);
+    if (result.ok) {
+      passed.push(entry);
+    } else {
+      onReject?.(entry, result.reason);
+    }
+  }
+  return passed;
+}

--- a/apps/admin/scripts/backfill-archive-tutor-briefing-goals.ts
+++ b/apps/admin/scripts/backfill-archive-tutor-briefing-goals.ts
@@ -1,0 +1,97 @@
+/**
+ * G10 / #1160 — backfill ARCHIVE tutor-briefing Goal rows
+ *
+ * Walks every `Goal` row of `type=LEARN`, `progressStrategy=manual_only`,
+ * `ref IS NULL`, `sourceContentId IS NULL` (the shape the audit identified
+ * as the tutor-briefing leak). Runs the same validator
+ * (`validateLearningOutcomeEntry`) against `Goal.name`. Rows that the
+ * validator rejects get `status = 'ARCHIVED'`.
+ *
+ * Idempotent: re-running is a no-op once the row is ARCHIVED.
+ *
+ * `trackGoalProgress` (PIPELINE.md §7 sub-op 4) and `extractGoals` (sub-op 3)
+ * both filter on `status: { in: [ACTIVE, PAUSED] }` per TL #1160 review —
+ * archived rows are automatically excluded from pipeline reads.
+ *
+ * Usage:
+ *   npx tsx apps/admin/scripts/backfill-archive-tutor-briefing-goals.ts
+ *   npx tsx apps/admin/scripts/backfill-archive-tutor-briefing-goals.ts --dry-run
+ *
+ * @see docs/audit/pipeline-measure-adapt-2026-06.md §6 G10
+ * @see lib/domain/validate-learning-outcome.ts (shared validator)
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { validateLearningOutcomeEntry } from "../lib/domain/validate-learning-outcome";
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const prisma = new PrismaClient();
+
+  console.log(`=== G10 backfill ${dryRun ? "(DRY RUN)" : "(APPLY)"} ===\n`);
+
+  // Scope: LEARN goals shaped like the tutor-briefing leak.
+  const candidates = await prisma.goal.findMany({
+    where: {
+      type: "LEARN",
+      progressStrategy: "manual_only",
+      ref: null,
+      sourceContentId: null,
+      status: { in: ["ACTIVE", "PAUSED"] }, // skip already-archived
+    },
+    select: {
+      id: true,
+      name: true,
+      playbookId: true,
+      callerId: true,
+    },
+  });
+
+  console.log(`Candidates (manual_only + ref=null + sourceContentId=null + status∈{ACTIVE,PAUSED}): ${candidates.length}\n`);
+
+  const rejected: Array<{ id: string; name: string; reason: string; playbookId: string | null }> = [];
+  for (const g of candidates) {
+    const result = validateLearningOutcomeEntry(g.name);
+    if (!result.ok) {
+      rejected.push({ id: g.id, name: g.name, reason: result.reason, playbookId: g.playbookId });
+    }
+  }
+  console.log(`Validator-rejected (would archive): ${rejected.length}\n`);
+
+  // Group by playbook for a readable summary.
+  const byPlaybook = new Map<string, number>();
+  for (const r of rejected) {
+    const key = r.playbookId ?? "(no-playbook)";
+    byPlaybook.set(key, (byPlaybook.get(key) ?? 0) + 1);
+  }
+  console.log("Per-playbook breakdown:");
+  for (const [pb, count] of [...byPlaybook.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${pb.slice(0, 8)}  ${count} row(s)`);
+  }
+
+  console.log("\nFirst 10 rejections (id / reason / name[:80]):");
+  for (const r of rejected.slice(0, 10)) {
+    console.log(`  ${r.id.slice(0, 8)}  ${r.reason}  ${r.name.slice(0, 80)}`);
+  }
+
+  if (dryRun) {
+    console.log(`\nDRY RUN — no writes. Pass without --dry-run to ARCHIVE ${rejected.length} row(s).`);
+    await prisma.$disconnect();
+    return;
+  }
+
+  // Apply
+  let archived = 0;
+  for (const r of rejected) {
+    await prisma.goal.update({ where: { id: r.id }, data: { status: "ARCHIVED" } });
+    archived++;
+  }
+  console.log(`\n✓ Archived ${archived} tutor-briefing Goal rows.`);
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/admin/tests/lib/validate-learning-outcome.test.ts
+++ b/apps/admin/tests/lib/validate-learning-outcome.test.ts
@@ -1,0 +1,129 @@
+/**
+ * G10 / #1160 — validateLearningOutcomeEntry + filterLearningOutcomes
+ *
+ * Defends Goal-table semantics: tutor-briefing fragments (which the
+ * IELTS V1.0 wizard author dumped into `learningOutcomes[]`) MUST NOT
+ * become `Goal.type=LEARN` rows.
+ *
+ * AC defended:
+ *   - The 6 known IELTS V1.0 tutor-briefing fragments are all rejected
+ *   - Real IELTS learner outcomes (the 8 OUT-NN entries) all pass
+ *   - Short/empty entries are rejected
+ *   - `filterLearningOutcomes` calls onReject for each drop and returns
+ *     only validator-passing entries
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  validateLearningOutcomeEntry,
+  filterLearningOutcomes,
+} from "@/lib/domain/validate-learning-outcome";
+
+/**
+ * The 6 distinct tutor-briefing strings observed on IELTS V1.0 (audit
+ * 2026-06-06). Each replicated across 20 callers → 120 dirty rows.
+ */
+const TUTOR_BRIEFING_FIXTURES = [
+  "Call 1 is a topic-led warm-up only with special rules that differ from subsequent calls",
+  "From Call 2 onwards the tutor's coaching is explicitly criterion-referenced and each call ends with a concrete, criterion-specific gain the student can name",
+  "P is partially independent — a student can have excellent vocabulary but poor pronunciation, or vice versa",
+  "FC is the most visible criterion — poor fluency masks good vocabulary and grammar",
+  "The four criteria below must NOT be named, listed, or explained on Call 1",
+  "On Call 1 the tutor scores silently in the background",
+];
+
+/**
+ * The 8 legitimate `lo_rollup` outcomes from IELTS V1.0 (OUT-01..OUT-08).
+ * Each must pass the validator unchanged.
+ */
+const LEGITIMATE_OUTCOMES = [
+  "Speak naturally about familiar topics for 4–5 minutes without long pauses or repeated self-correction",
+  "Extend Part 1 answers with one supporting detail or example beyond the direct answer",
+  "Speak for 90 seconds on a Part 2 cue card without stalling on word-search",
+  "Cover all four cue-card bullets in a structured Part 2 monologue",
+  "Vary sentence structure across a Part 2 monologue (simple → complex → conditional or hypothetical)",
+  "Sustain abstract Part 3 discussion with hedging, paraphrase, and concession-then-reassertion moves",
+  "Compare across time, generalise, and speculate using conditional structures in Part 3",
+  "Maintain clear pronunciation with appropriate stress, rhythm, and intonation throughout the test",
+];
+
+describe("validateLearningOutcomeEntry", () => {
+  it.each(TUTOR_BRIEFING_FIXTURES)("rejects tutor-briefing fixture: %s", (entry) => {
+    const r = validateLearningOutcomeEntry(entry);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/.+/);
+  });
+
+  it.each(LEGITIMATE_OUTCOMES)("accepts legitimate IELTS V1.0 outcome: %s", (entry) => {
+    expect(validateLearningOutcomeEntry(entry)).toEqual({ ok: true });
+  });
+
+  it("rejects empty string", () => {
+    expect(validateLearningOutcomeEntry("")).toEqual({ ok: false, reason: "empty string" });
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(validateLearningOutcomeEntry("   ")).toEqual({ ok: false, reason: "empty string" });
+  });
+
+  it("rejects too-short entries (fewer than 3 tokens)", () => {
+    const r = validateLearningOutcomeEntry("Pass IELTS");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("too short");
+  });
+
+  it("accepts an entry exactly at the 3-token minimum", () => {
+    expect(validateLearningOutcomeEntry("Pass IELTS Speaking")).toEqual({ ok: true });
+  });
+
+  it("does NOT false-positive on outcomes that reference call count as a learner target", () => {
+    // "Complete 5 practice calls" is a learner outcome, not a rule-of-engagement.
+    expect(
+      validateLearningOutcomeEntry(
+        "Complete 5 practice calls on Part 2 within 4 weeks",
+      ),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("filterLearningOutcomes", () => {
+  it("filters a mixed list — keeps real outcomes, drops briefing", () => {
+    const mixed = [
+      ...TUTOR_BRIEFING_FIXTURES,
+      ...LEGITIMATE_OUTCOMES,
+    ];
+    const passed = filterLearningOutcomes(mixed);
+    expect(passed).toHaveLength(LEGITIMATE_OUTCOMES.length);
+    expect(passed).toEqual(LEGITIMATE_OUTCOMES);
+  });
+
+  it("calls onReject for each dropped entry with its rejection reason", () => {
+    const onReject = vi.fn();
+    filterLearningOutcomes(TUTOR_BRIEFING_FIXTURES, onReject);
+    expect(onReject).toHaveBeenCalledTimes(TUTOR_BRIEFING_FIXTURES.length);
+    for (const call of onReject.mock.calls) {
+      expect(call[0]).toEqual(expect.any(String)); // the entry
+      expect(call[1]).toEqual(expect.any(String)); // the reason
+      expect(call[1].length).toBeGreaterThan(5);
+    }
+  });
+
+  it("returns an empty array when given only tutor-briefing entries", () => {
+    expect(filterLearningOutcomes(TUTOR_BRIEFING_FIXTURES)).toEqual([]);
+  });
+
+  it("preserves order of legitimate outcomes", () => {
+    const passed = filterLearningOutcomes([
+      LEGITIMATE_OUTCOMES[2],
+      TUTOR_BRIEFING_FIXTURES[0],
+      LEGITIMATE_OUTCOMES[0],
+      TUTOR_BRIEFING_FIXTURES[3],
+      LEGITIMATE_OUTCOMES[5],
+    ]);
+    expect(passed).toEqual([
+      LEGITIMATE_OUTCOMES[2],
+      LEGITIMATE_OUTCOMES[0],
+      LEGITIMATE_OUTCOMES[5],
+    ]);
+  });
+});

--- a/docs/TEST-BANK.md
+++ b/docs/TEST-BANK.md
@@ -212,6 +212,22 @@ Mixing tags is fine. `describe("buildLoMasteryMap (#928 scoping helper)", ...)` 
 | **Owner area** | Adaptive Loop / Compose Stage |
 | **Related** | `docs/CHAIN-CONTRACTS.md` Link 3 sub-contract I-C1 · audit G6 entry · `#1006` Maya hallucination root cause · `lib/caller/resolve-active-playbook.ts::resolveActivePlaybookId` (sibling resolver used by voice/calls/start) |
 
+### 008 — Learning-outcome validator (G10 — tutor-briefing rejection)
+
+| Field | Value |
+|---|---|
+| **File** | `apps/admin/tests/lib/validate-learning-outcome.test.ts` |
+| **Subject** | `apps/admin/lib/domain/validate-learning-outcome.ts` (validator + bulk filter) |
+| **Defends** | Goal-table semantics — `Goal.type=LEARN` rows MUST be learner-outcome statements, not tutor-instruction text. |
+| **Issue / origin** | [#1160](https://github.com/WANDERCOLTD/HF/issues/1160) — IELTS V1.0 accumulated 120 `manual_only` Goal rows where the wizard author dumped tutor-briefing directives ("Call 1 is a topic-led warm-up", "FC is the most visible criterion") into the `learningOutcomes[]` field. Pre-fix `trackGoalProgress` iterated 360 noise rows per pipeline run. |
+| **Failure mode it pins** | A future edit weakens the heuristic and lets tutor-briefing fragments through (re-pollutes the Goal table). Or false-positives on legitimate outcomes that reference call counts ("Complete 5 practice calls …"). |
+| **What it proves** | (1) All 6 known IELTS V1.0 tutor-briefing fixtures REJECT. (2) All 8 legitimate `lo_rollup` outcomes ACCEPT. (3) Empty/short entries reject. (4) Entries that reference call counts as a learner target pass. (5) `filterLearningOutcomes` calls `onReject` once per drop with reason. (6) Order of legitimate outcomes is preserved. |
+| **How to run** | `cd apps/admin && npx vitest run tests/lib/validate-learning-outcome.test.ts` |
+| **When to re-run** | Edits to `validate-learning-outcome.ts` OR to `lib/domain/course-setup.ts:380` (the `learningOutcomes[]` filter). |
+| **Status** | ✅ green (23/23, 2026-06-06) |
+| **Owner area** | Adaptive Loop / Goal Semantics |
+| **Related** | `lib/domain/course-setup.ts:382` (filter call-site) · `scripts/backfill-archive-tutor-briefing-goals.ts` (one-shot cleanup) · `docs/PIPELINE.md §7` (`extractGoals` + `trackGoalProgress` ADAPT sub-ops) · audit G10 entry |
+
 ---
 
 ## Live-DB Demos


### PR DESCRIPTION
Closes #1160.

## Summary

Audit G10 stop-the-bleed for the Goal.type=LEARN tutor-briefing pollution observed on IELTS V1.0:

- New `lib/domain/validate-learning-outcome.ts` heuristic validator with 12 tutor-briefing pattern fragments.
- Patched `lib/domain/course-setup.ts:382` to route `learningOutcomes[]` through the validator with `console.warn` on rejection.
- New `scripts/backfill-archive-tutor-briefing-goals.ts` one-shot — applied to hf-dev (140 rows archived: 120 V1.0 + 20 ec4127a1).
- 23 vitest cases, all green. TEST-BANK entry 008.

## Test plan

- [x] Validator rejects all 6 known IELTS V1.0 tutor-briefing fixtures
- [x] Validator accepts all 8 legitimate OUT-NN outcomes
- [x] Edge cases (empty, too-short, call-count learner targets) handled
- [x] Backfill dry-run preview matches apply result (140 rows)
- [x] hf-dev archive applied; `trackGoalProgress` will skip archived rows on next pipeline run (status ∈ {ACTIVE, PAUSED} filter per TL review)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)