### PR TITLE
fix(voice): #1185 follow-up — emit model.secret on custom-llm inline config

### DIFF
--- a/apps/admin/lib/voice/build-assistant-config.ts
+++ b/apps/admin/lib/voice/build-assistant-config.ts
@@ -73,6 +73,23 @@ export async function buildAssistantConfigForCaller(
   const serverUrlBase = `${config.app.url}/api/voice/${slug}`;
   const enabledTools = await loadToolDefinitions();
 
+  // #1185 follow-up — pull the webhookSecret out of the VoiceProvider
+  // credentials JSON so we can pass it to the custom-llm `model.secret`
+  // field. VAPI uses this exact value as `x-vapi-secret` on the chat-
+  // completions POST, and the proxy timing-safe-compares against the
+  // SAME row's webhookSecret. One credential, two purposes (webhook
+  // HMAC + custom-llm shared secret).
+  const providerRow = await prisma.voiceProvider.findUnique({
+    where: { slug },
+    select: { credentials: true },
+  });
+  const providerCreds = (providerRow?.credentials ?? {}) as Record<string, unknown>;
+  const customLlmSecret =
+    typeof providerCreds.webhookSecret === "string" &&
+    providerCreds.webhookSecret.length > 0
+      ? providerCreds.webhookSecret
+      : undefined;
+
   const costSafetyKnobs = {
     silenceTimeoutSeconds: sys.silenceTimeoutSeconds,
     maxDurationSeconds: sys.maxDurationSeconds,
@@ -101,6 +118,7 @@ export async function buildAssistantConfigForCaller(
       unknownCallerPrompt: vs.unknownCallerPrompt,
       noActivePromptFallback: vs.noActivePromptFallback,
       costSafetyKnobs,
+      customLlmSecret,
     });
     return {
       assistantConfig,
@@ -143,6 +161,7 @@ export async function buildAssistantConfigForCaller(
       unknownCallerPrompt: vs.unknownCallerPrompt,
       noActivePromptFallback: vs.noActivePromptFallback,
       costSafetyKnobs,
+      customLlmSecret,
     });
     return {
       assistantConfig,

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -127,6 +127,13 @@ export class VapiProvider implements VoiceProvider {
       ? {
           provider: "custom-llm",
           url: customLlmProxyUrl,
+          // VAPI sends this value as `x-vapi-secret` on every chat-
+          // completions POST to the proxy. The proxy timing-safe-compares
+          // against the SAME VoiceProvider's credentials.webhookSecret.
+          // One credential, two purposes (webhook HMAC + custom-llm
+          // auth). Omit when undefined — proxy passes through in
+          // pass-through mode on local dev.
+          ...(ctx.customLlmSecret ? { secret: ctx.customLlmSecret } : {}),
           model: ctx.modelConfig.model,
           messages: [{ role: "system", content: ctx.voicePrompt }],
           ...(tools.length > 0 ? { tools } : {}),

--- a/apps/admin/lib/voice/types.ts
+++ b/apps/admin/lib/voice/types.ts
@@ -69,6 +69,14 @@ export interface AssistantRequestContext {
     voicemailDetectionEnabled: boolean;
     endCallPhrases: string[];
   };
+  /** #1185 follow-up — shared secret passed through to the `model.secret`
+   *  field on `custom-llm` inline configs. VAPI POSTs this value as
+   *  `x-vapi-secret` on every chat-completions request to HF's proxy,
+   *  which timing-safe-compares against the same VoiceProvider's
+   *  `credentials.webhookSecret`. When undefined, the custom-llm config
+   *  omits `model.secret` and VAPI sends no header — fine only when the
+   *  proxy is in pass-through mode (no secret configured on the provider). */
+  customLlmSecret?: string;
 }
 
 /** Provider tool shape — OpenAI function-call format (the lingua franca). */


### PR DESCRIPTION
## Summary

Three-line follow-up to #1185. The proxy and verifier shipped, but the inline assistant config didn't include `model.secret` — so VAPI sent no `x-vapi-secret` header. With a webhookSecret configured on the VoiceProvider row (live state on hf-dev), every voice call would 401.

## Fix

| Layer | Change |
|---|---|
| `lib/voice/types.ts::AssistantRequestContext` | New optional `customLlmSecret?: string` field |
| `lib/voice/build-assistant-config.ts` | Reads `VoiceProvider.credentials.webhookSecret` and threads it into every adapter call |
| `lib/voice/providers/vapi/index.ts::buildAssistantConfig` | Emits `model.secret` on the `custom-llm` branch when `ctx.customLlmSecret` is set |

## One credential, two purposes

- VAPI **signs webhooks** with HMAC over body using `credentials.webhookSecret`
- VAPI **POSTs LLM turns** sending the same value as `x-vapi-secret` header
- HF verifies both against the same row

## Verification

- [x] `npx tsc --noEmit` clean
- [x] Vitests from #1185 unchanged (verifier tests still pass)
- [ ] **Manual (post-merge):** outbound dial → VAPI sends `x-vapi-secret` → proxy verifies → 200, streamed response

## Deploy

`/vm-cp` — no migration, code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)