### PR TITLE
docs(voice): #1178 follow-up — crontab grep .env.local not .env

### DIFF
--- a/docs/CLOUD-DEPLOYMENT.md
+++ b/docs/CLOUD-DEPLOYMENT.md
@@ -645,7 +645,13 @@ The scheduled job runs every minute; HF's poll itself is idempotent and race-saf
 
 ### Sandbox VM — crontab alternative
 
-`hf-dev` has no Cloud Scheduler. Use the VM's crontab:
+`hf-dev` has no Cloud Scheduler. Use the VM's crontab.
+
+**Important env-file note:** the VM runs both `.env` AND `.env.local`,
+and per Next.js precedence **`.env.local` wins on conflicting keys**.
+`INTERNAL_API_SECRET` is set in BOTH files with DIFFERENT values — the
+runtime uses `.env.local`. Cron commands MUST grep `.env.local`, not
+`.env`, or the call returns 401 silently.
 
 ```bash
 # SSH into VM, edit crontab
@@ -654,8 +660,20 @@ crontab -e
 
 # Add this line (every minute):
 * * * * * curl -sS -X POST http://localhost:3000/api/voice/poll-stale-calls \
-  -H "x-internal-secret: $(grep '^INTERNAL_API_SECRET=' /home/paul_thewanders_com/HF/apps/admin/.env | cut -d= -f2)" \
+  -H "x-internal-secret: $(grep '^INTERNAL_API_SECRET=' /home/paul_thewanders_com/HF/apps/admin/.env.local | cut -d= -f2)" \
   -H "Content-Type: application/json" -d '{}' >> /tmp/voice-poll.log 2>&1
+```
+
+**Verifying the right secret:** if your manual smoke against the route
+returns `{"error":"Unauthorized"}`, double-check which file is being
+read. Both files have the key; only `.env.local` matches the runtime:
+
+```bash
+# Wrong (returns the unused .env value)
+grep '^INTERNAL_API_SECRET=' ~/HF/apps/admin/.env | cut -d= -f2
+
+# Right (returns the value Next.js actually loaded)
+grep '^INTERNAL_API_SECRET=' ~/HF/apps/admin/.env.local | cut -d= -f2
 ```
 
 ### Manual invocation (operator debug)


### PR DESCRIPTION
## Summary

Two-line docs fix to `CLOUD-DEPLOYMENT.md` — the voice-poll crontab was reading `INTERNAL_API_SECRET` from `.env`, but Next.js loads `.env.local` on top with **different** values. Following the runbook verbatim returns 401 silently.

Found during the #1189 smoke: recovery batch returned `Unauthorized` despite a properly formatted header. Tracing showed `.env.local` had a different key.

## Fix

- Crontab snippet now greps `.env.local`
- Added a side-by-side verification block showing both grep commands so the next operator catches it instantly

## Verification

- [x] Smoke poll on hf-dev using `.env.local` value returned `{ok:true, stale:5, recovered:5, ...}` — the original recovery worked once the correct file was queried
- No code change; doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)