### PR TITLE
feat(compose): #1195 first-call opening robustness — phase-derived openings + returning-user guard

### DIFF
--- a/apps/admin/lib/prompt/composition/defaults/first-call-openings.ts
+++ b/apps/admin/lib/prompt/composition/defaults/first-call-openings.ts
@@ -1,0 +1,164 @@
+/**
+ * First-call opening template defaults (#1195).
+ *
+ * The `quickstart.ts::first_line` transform synthesises the literal
+ * opening line the AI speaks on `isFirstCall === true`. The cascade
+ * is documented at `transforms/quickstart.ts` and walks the same
+ * onboarding-phases sources as `pedagogy.ts::computeSessionPedagogy`
+ * (PR #1195 follow-up to the #1196 source-attribution work).
+ *
+ * Phase 0's `goals[]` are EDUCATOR INSTRUCTIONS ("Greet the caller
+ * warmly"), NOT sentence fragments to copy verbatim. This module
+ * provides:
+ *
+ *   1. `classifyFirstPhaseIntent` — classifies the FIRST goal in
+ *      phase 0 by intent (greet / introduce / set-expectations /
+ *      discover / understand-goals / assess-knowledge).
+ *   2. `renderFirstCallOpening` — emits a fixed template per intent,
+ *      seeded with the caller name + subjectRef. ≤2 sentences, ≤140
+ *      chars per template.
+ *   3. `RETURNING_USER_HEURISTIC_PATTERNS` — regex set for the
+ *      `welcomeMessage` rewrite path (when no phases are configured
+ *      but the educator-authored welcomeMessage assumes a returning
+ *      user — the textual "Welcome back" trap from the live incident).
+ *   4. `rewriteReturningUserPhrasing` — applies a first-call-
+ *      appropriate replacement using subjectRef.
+ *
+ * Per PROMPT-COMPOSITION.md §9 L10, behavioural default strings live
+ * here, NOT inline in `transforms/`. Add new templates to this file
+ * when course-setup grows new intent buckets.
+ *
+ * Pure functions. Deterministic templating. No LLM calls.
+ */
+
+export type FirstPhaseIntent =
+  | "greet"
+  | "introduce"
+  | "set-expectations"
+  | "discover"
+  | "understand-goals"
+  | "assess-knowledge"
+  | "unclassified";
+
+/** Case-insensitive intent classification from the FIRST goal string
+ *  in onboarding phase 0. Picks the first pattern that matches; falls
+ *  through to `"unclassified"` so the caller can decide whether to
+ *  emit a fully-generic opening or skip the phase-derived path. */
+export function classifyFirstPhaseIntent(
+  firstGoal: string | undefined | null,
+): FirstPhaseIntent {
+  if (!firstGoal) return "unclassified";
+  const normalized = firstGoal.toLowerCase();
+  if (/\bgreet|\bsay hello|\bwelcome\b/.test(normalized)) return "greet";
+  if (/\bintroduce (yourself|the )|\bmeet the\b/.test(normalized))
+    return "introduce";
+  if (/\bset expectation|\bsession frame|\bexplain what|\bwhat to expect/.test(normalized))
+    return "set-expectations";
+  if (/\bdiscover|\bunderstand (their|the) background|\blearn about (the|their)/.test(normalized))
+    return "discover";
+  if (/\bunderstand (their|the) goals?|\blearn (their|the) goals?|\bmotivation/.test(normalized))
+    return "understand-goals";
+  if (/\bknowledge level|\bassess(ment)?\b|\bcheck understanding|\bprior knowledge/.test(normalized))
+    return "assess-knowledge";
+  return "unclassified";
+}
+
+export interface FirstCallOpeningInput {
+  intent: FirstPhaseIntent;
+  /** Caller's display name, when known. */
+  callerName: string | null | undefined;
+  /** Subject discipline (e.g. "The CIO/CTO Standard"). */
+  subjectRef: string | null | undefined;
+  /** Module title when available, for orientation when intent is
+   *  greet / introduce. */
+  moduleTitle?: string | null;
+}
+
+/** Render the first_line for a first call. Returns a 1–2 sentence
+ *  opening seeded by intent, name, and subject. Length cap ~140 chars
+ *  (per the AC) so the AI doesn't read a paragraph. */
+export function renderFirstCallOpening(input: FirstCallOpeningInput): string {
+  const namePart = input.callerName ? `, ${input.callerName}` : "";
+  const subjectPart = input.subjectRef
+    ? ` on ${input.subjectRef}`
+    : "";
+  const subjectStandalone = input.subjectRef ?? "today's session";
+  const modulePart = input.moduleTitle
+    ? ` We'll be looking at ${input.moduleTitle} today.`
+    : "";
+
+  switch (input.intent) {
+    case "greet":
+      return cap(
+        `Hi${namePart}! Good to meet you${subjectPart}.${modulePart}`.trim(),
+      );
+    case "introduce":
+      return cap(
+        `Hi${namePart}! I'm your tutor for ${subjectStandalone}.${modulePart}`.trim(),
+      );
+    case "set-expectations":
+      return cap(
+        `Hi${namePart}! Glad you're here. Let me set the frame for how we'll work together on ${subjectStandalone}.`,
+      );
+    case "discover":
+      return cap(
+        `Hi${namePart}! Before we dive in, I'd love to hear a little about you and what brings you to ${subjectStandalone}.`,
+      );
+    case "understand-goals":
+      return cap(
+        `Hi${namePart}! Let's start with what you're hoping to get from working on ${subjectStandalone}.`,
+      );
+    case "assess-knowledge":
+      return cap(
+        `Hi${namePart}! To pitch this right, can I ask what you already know about ${subjectStandalone}?`,
+      );
+    case "unclassified":
+    default:
+      return cap(
+        `Hi${namePart}! Good to have you here. Let's ease into ${subjectStandalone}.`,
+      );
+  }
+}
+
+/** Returning-user phrasing patterns. Narrow — must NOT fire on benign
+ *  first-call welcomes like "Welcome! Glad you're here." */
+export const RETURNING_USER_HEURISTIC_PATTERNS: readonly RegExp[] = [
+  /welcome\s+back/i,
+  /let'?s revise/i,
+  /pick up where we left off/i,
+  /last (time|session)/i,
+  /you'?ve covered/i,
+];
+
+/** True when the message contains returning-user phrasing AND would
+ *  confuse a brand-new caller. */
+export function hasReturningUserPhrasing(msg: string): boolean {
+  return RETURNING_USER_HEURISTIC_PATTERNS.some((rx) => rx.test(msg));
+}
+
+/** Replace a returning-user-assumed welcomeMessage with a first-call-
+ *  appropriate opening. Conservative — only fires when
+ *  `hasReturningUserPhrasing` returns true (caller's responsibility
+ *  to gate on isFirstCall). */
+export function rewriteReturningUserPhrasing(input: {
+  callerName: string | null | undefined;
+  subjectRef: string | null | undefined;
+}): string {
+  const namePart = input.callerName ? `, ${input.callerName}` : "";
+  const subjectStandalone = input.subjectRef ?? "today's session";
+  return cap(
+    `Hi${namePart}! Good to have you here. Let's ease into ${subjectStandalone}.`,
+  );
+}
+
+function cap(s: string, max = 160): string {
+  if (s.length <= max) return s;
+  // Trim to last sentence boundary before max.
+  const truncated = s.slice(0, max);
+  const lastDot = Math.max(
+    truncated.lastIndexOf("."),
+    truncated.lastIndexOf("!"),
+    truncated.lastIndexOf("?"),
+  );
+  return lastDot > 0 ? truncated.slice(0, lastDot + 1) : truncated;
+}

--- a/apps/admin/lib/prompt/composition/transforms/quickstart.ts
+++ b/apps/admin/lib/prompt/composition/transforms/quickstart.ts
@@ -15,6 +15,12 @@ import { getAudienceOption } from "./audience";
 import { SURVEY_SCOPES, PRE_SURVEY_KEYS } from "@/lib/learner/survey-keys";
 import { config } from "@/lib/config";
 import { resolveSessionFlow } from "@/lib/session-flow/resolver";
+import {
+  classifyFirstPhaseIntent,
+  hasReturningUserPhrasing,
+  renderFirstCallOpening,
+  rewriteReturningUserPhrasing,
+} from "@/lib/prompt/composition/defaults/first-call-openings";
 
 /** Keys whose presence (scope PRE) signals the learner already submitted onboarding data */
 const PRE_LOADED_KEYS: readonly string[] = [
@@ -560,6 +566,47 @@ registerTransform("computeQuickStart", (
       // 1. Identity spec instruction (highest priority — persona spec)
       const identityOpening = (identitySpec?.config as SpecConfig)?.sessionStructure?.opening?.instruction;
       if (identityOpening) return injectSubject(identityOpening);
+
+      // 1b. #1195 — Phase-derived first-call opening. When isFirstCall and
+      // onboarding phases are configured at any layer of the cascade
+      // (playbook, domain, or INIT-001), synthesise the opening from
+      // phase 0's first goal classified by intent. This honours the
+      // educator's course-setup configuration without inventing facts.
+      //
+      // Walks the SAME cascade as `pedagogy.ts::computeSessionPedagogy`
+      // (and the resolver, when SESSION_FLOW_RESOLVER_ENABLED). Critical:
+      // pre-#1195 first_line did NOT read the phases at all — operators
+      // configured phases for SESSION FLOW but the literal opening was
+      // disconnected. Now they're wired.
+      if (isFirstCall) {
+        let phases: { phases?: Array<{ goals?: string[]; phase?: string }> } | undefined;
+        if (config.features.sessionFlowResolverEnabled) {
+          phases = resolveSessionFlow({
+            playbook,
+            domain: callerDomain,
+            onboardingSpec: loadedData.onboardingSpec,
+          }).onboarding;
+        } else {
+          // Mirror `pedagogy.ts:245-249` cascade exactly.
+          const playbookPhases = (pbConfig.onboardingFlowPhases as { phases?: Array<{ goals?: string[]; phase?: string }> } | undefined);
+          const domainPhases = (callerDomain?.onboardingFlowPhases as { phases?: Array<{ goals?: string[]; phase?: string }> } | undefined);
+          const initPhases = ((loadedData.onboardingSpec?.config as { firstCallFlow?: { phases?: Array<{ goals?: string[]; phase?: string }> } } | null | undefined)?.firstCallFlow);
+          phases = playbookPhases ?? domainPhases ?? initPhases ?? undefined;
+        }
+        const firstPhaseGoal = phases?.phases?.[0]?.goals?.[0];
+        if (firstPhaseGoal) {
+          const intent = classifyFirstPhaseIntent(firstPhaseGoal);
+          if (intent !== "unclassified") {
+            return renderFirstCallOpening({
+              intent,
+              callerName: caller?.name ?? null,
+              subjectRef,
+              moduleTitle: nextModule?.title ?? null,
+            });
+          }
+        }
+      }
+
       // 2. Course-scoped welcome (playbook.config) > Domain welcome (institution default).
       // When SESSION_FLOW_RESOLVER_ENABLED, delegate to resolveSessionFlow().
       // Both paths must produce byte-equal output (epic #221, story #217).
@@ -574,7 +621,28 @@ registerTransform("computeQuickStart", (
         } else {
           welcomeMsg = pbConfig.welcomeMessage ?? callerDomain?.onboardingWelcome ?? null;
         }
-        if (welcomeMsg) return injectSubject(welcomeMsg);
+        if (welcomeMsg) {
+          // #1195 — Returning-user phrasing guard. The CIO/CTO incident
+          // saw a brand-new caller hear "Welcome back. Let's revise what
+          // you've covered." because the educator's welcomeMessage assumed
+          // a returning user. Rewrite when narrow phrasing patterns match;
+          // log so educators can find and fix the source playbook config.
+          if (hasReturningUserPhrasing(welcomeMsg)) {
+            console.log(
+              "[first-line/rewrite] welcomeMessage rewritten — returning-user phrasing on first call",
+              {
+                playbookId: playbook?.id ?? null,
+                playbookName: playbook?.name ?? null,
+                original: welcomeMsg,
+              },
+            );
+            return rewriteReturningUserPhrasing({
+              callerName: caller?.name ?? null,
+              subjectRef,
+            });
+          }
+          return injectSubject(welcomeMsg);
+        }
       }
       // 3. Generic fallback
       if (isFirstCall) {

--- a/apps/admin/tests/lib/prompt/composition/first-call-openings.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/first-call-openings.test.ts
@@ -1,0 +1,205 @@
+/**
+ * first-call-openings template defaults tests (#1195).
+ *
+ * 8 vitests covering the AC matrix. These exercise the PURE helpers
+ * directly — the quickstart.ts integration is covered by manual smoke
+ * + the existing composition test suite that runs the full transform.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyFirstPhaseIntent,
+  hasReturningUserPhrasing,
+  renderFirstCallOpening,
+  rewriteReturningUserPhrasing,
+  RETURNING_USER_HEURISTIC_PATTERNS,
+} from "@/lib/prompt/composition/defaults/first-call-openings";
+
+describe("classifyFirstPhaseIntent", () => {
+  it("classifies 'Greet the caller warmly' → greet", () => {
+    expect(classifyFirstPhaseIntent("Greet the caller warmly")).toBe("greet");
+  });
+
+  it("classifies 'Introduce yourself and your role' → introduce", () => {
+    expect(classifyFirstPhaseIntent("Introduce yourself and your role")).toBe(
+      "introduce",
+    );
+  });
+
+  it("classifies 'Set expectations for the session' → set-expectations", () => {
+    expect(classifyFirstPhaseIntent("Set expectations for the session")).toBe(
+      "set-expectations",
+    );
+  });
+
+  it("classifies 'Learn about the caller's background' → discover", () => {
+    expect(
+      classifyFirstPhaseIntent("Learn about the caller's background"),
+    ).toBe("discover");
+  });
+
+  it("classifies 'Understand their goals and motivations' → understand-goals", () => {
+    expect(
+      classifyFirstPhaseIntent("Understand their goals and motivations"),
+    ).toBe("understand-goals");
+  });
+
+  it("classifies 'Assess existing knowledge level' → assess-knowledge", () => {
+    expect(classifyFirstPhaseIntent("Assess existing knowledge level")).toBe(
+      "assess-knowledge",
+    );
+  });
+
+  it("falls through to unclassified on unfamiliar phrasing", () => {
+    expect(classifyFirstPhaseIntent("Sing the alphabet backwards")).toBe(
+      "unclassified",
+    );
+  });
+
+  it("handles empty / undefined gracefully", () => {
+    expect(classifyFirstPhaseIntent(undefined)).toBe("unclassified");
+    expect(classifyFirstPhaseIntent(null)).toBe("unclassified");
+    expect(classifyFirstPhaseIntent("")).toBe("unclassified");
+  });
+});
+
+describe("renderFirstCallOpening", () => {
+  it("produces a warm greet opening with name + subject", () => {
+    const out = renderFirstCallOpening({
+      intent: "greet",
+      callerName: "Pop",
+      subjectRef: "The CIO/CTO Standard",
+    });
+    expect(out).toMatch(/Hi, Pop!/);
+    expect(out).toMatch(/CIO\/CTO/);
+    // Sanity: never contains the "Welcome back" trap
+    expect(out).not.toMatch(/welcome\s+back/i);
+    expect(out).not.toMatch(/let'?s revise/i);
+  });
+
+  it("handles unknown caller name gracefully", () => {
+    const out = renderFirstCallOpening({
+      intent: "greet",
+      callerName: null,
+      subjectRef: "IELTS",
+    });
+    expect(out).not.toContain("null");
+    expect(out).not.toContain(", !");
+    expect(out).toMatch(/IELTS/);
+  });
+
+  it("set-expectations opening mentions session frame", () => {
+    const out = renderFirstCallOpening({
+      intent: "set-expectations",
+      callerName: "Sam",
+      subjectRef: "GCSE Biology",
+    });
+    expect(out).toMatch(/Sam/);
+    expect(out).toMatch(/frame|set/i);
+  });
+
+  it("each intent stays within length budget (≤160 chars)", () => {
+    const intents = [
+      "greet",
+      "introduce",
+      "set-expectations",
+      "discover",
+      "understand-goals",
+      "assess-knowledge",
+      "unclassified",
+    ] as const;
+    for (const intent of intents) {
+      const out = renderFirstCallOpening({
+        intent,
+        callerName: "Caller With A Long Name",
+        subjectRef: "A Very Long Subject Discipline Name",
+      });
+      expect(out.length).toBeLessThanOrEqual(160);
+    }
+  });
+});
+
+describe("hasReturningUserPhrasing", () => {
+  it("catches all 5 documented patterns", () => {
+    expect(hasReturningUserPhrasing("Welcome back. Let's revise what you've covered.")).toBe(true);
+    expect(hasReturningUserPhrasing("Welcome back")).toBe(true);
+    expect(hasReturningUserPhrasing("Let's revise the basics")).toBe(true);
+    expect(hasReturningUserPhrasing("Let me know if you want to pick up where we left off")).toBe(true);
+    expect(hasReturningUserPhrasing("Last time we worked on X")).toBe(true);
+    expect(hasReturningUserPhrasing("you've covered the fundamentals")).toBe(true);
+  });
+
+  it("does NOT catch the benign 'Welcome! Glad you're here.' (TL guard)", () => {
+    expect(hasReturningUserPhrasing("Welcome! Glad you're here.")).toBe(false);
+    expect(hasReturningUserPhrasing("Welcome to the course")).toBe(false);
+    expect(hasReturningUserPhrasing("Welcome aboard!")).toBe(false);
+  });
+
+  it("does NOT catch 'first revision session' (the word 'revise' must be adjacent to 'let's')", () => {
+    // The pattern is /let'?s revise/i — requires the let's prefix
+    expect(hasReturningUserPhrasing("This is a revision session.")).toBe(false);
+  });
+
+  it("exposes the pattern set for future audit", () => {
+    expect(RETURNING_USER_HEURISTIC_PATTERNS.length).toBe(5);
+    for (const rx of RETURNING_USER_HEURISTIC_PATTERNS) {
+      expect(rx).toBeInstanceOf(RegExp);
+    }
+  });
+});
+
+describe("rewriteReturningUserPhrasing", () => {
+  it("emits a first-call-appropriate opening seeded with name + subject", () => {
+    const out = rewriteReturningUserPhrasing({
+      callerName: "Pop",
+      subjectRef: "The CIO/CTO Standard",
+    });
+    expect(out).toMatch(/Pop/);
+    expect(out).toMatch(/CIO\/CTO/);
+    expect(out).not.toMatch(/welcome\s+back/i);
+    expect(out).not.toMatch(/let'?s revise/i);
+    expect(out).not.toMatch(/you'?ve covered/i);
+  });
+
+  it("falls back gracefully when subjectRef is null", () => {
+    const out = rewriteReturningUserPhrasing({
+      callerName: "Sam",
+      subjectRef: null,
+    });
+    expect(out).toMatch(/Sam/);
+    expect(out).not.toMatch(/null/);
+  });
+});
+
+describe("integration matrix — AC 1-8 condensed", () => {
+  it("AC1: phases configured → synthesised opening (not the welcomeMessage)", () => {
+    // Simulates the cascade outcome: phase 0 goal classified, then rendered.
+    const goal = "Greet the caller warmly";
+    const intent = classifyFirstPhaseIntent(goal);
+    const out = renderFirstCallOpening({
+      intent,
+      callerName: "Pop",
+      subjectRef: "The CIO/CTO Standard",
+    });
+    expect(intent).toBe("greet");
+    expect(out).toMatch(/Pop/);
+    expect(out).not.toMatch(/welcome\s+back/i);
+  });
+
+  it("AC2: no phases + 'Welcome back' welcomeMessage → rewritten", () => {
+    const original = "Welcome back. Let's revise what you've covered.";
+    expect(hasReturningUserPhrasing(original)).toBe(true);
+    const rewritten = rewriteReturningUserPhrasing({
+      callerName: "Pop",
+      subjectRef: "The CIO/CTO Standard",
+    });
+    expect(rewritten).not.toBe(original);
+    expect(rewritten).toMatch(/Pop/);
+  });
+
+  it("AC8: benign 'Welcome! Glad you're here.' is NOT rewritten (false-positive guard)", () => {
+    const benign = "Welcome! Glad you're here.";
+    expect(hasReturningUserPhrasing(benign)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1195. Two fixes to the literal `first_line` the AI speaks on first calls, both surfaced by the CIO/CTO incident (caller "pop" on call #1 heard "Welcome back. Let's revise what you've covered.").

| Fix | What | Why |
|---|---|---|
| **Phase-derived opening** (new layer) | Reads onboarding phase 0 from the same cascade `pedagogy.ts` uses, classifies the first goal by intent, renders a templated opening | Phases were already driving the SESSION FLOW prompt section but the literal `first_line` never read them — operators configured intent in course setup but the AI didn't honour it |
| **Returning-user phrasing guard** | When phases aren't configured AND `welcomeMessage` contains narrow returning-user phrasing on a first call, rewrites to a first-call-appropriate opening | The CIO/CTO playbook's `welcomeMessage` literally says "Welcome back" — fine for repeat calls, confusing on call #1 |

## TL findings addressed

| BLOCKER / required AC | How |
|---|---|
| Domain cascade walk | New layer mirrors `pedagogy.ts:245-249`: pbConfig.onboardingFlowPhases → resolveSessionFlow().onboarding (when flag enabled) → domain.onboardingFlowPhases → INIT-001 spec |
| Goal verbatim ban | Goals are NEVER embedded; `classifyFirstPhaseIntent` maps to an intent enum, `renderFirstCallOpening` emits a fixed template per intent |
| Defaults file path | `lib/prompt/composition/defaults/first-call-openings.ts` (per PROMPT-COMPOSITION.md §9 L10) |
| Resolver `.onboarding.phases` destructure | Added inside the new layer when `sessionFlowResolverEnabled` |
| Benign-welcome guard | "Welcome! Glad you're here." NOT rewritten (vitest 14) |
| `console.log` with playbook ID | Replaces `console.warn` for Cloud Logging searchability |

## Cascade tier order (unchanged except new layer)

```
1.   lockedModule                       ← module pick
2.   !isFirstCall + modulesAuthored     ← module-progress reference
3.   identitySpec opening                ← persona spec
3.5. #1195 phase-derived opening (NEW)   ← course-setup intent honoured
4.   welcomeMessage / onboardingWelcome  ← with returning-user rewrite
5.   Generic fallback
```

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/lib/prompt/composition/first-call-openings` → **21/21 passed**
  - 8 intent classifications (covering all goals from the real CIO/CTO + Big Five OCEAN onboarding panels)
  - 4 `renderFirstCallOpening` (length budget, null-name safety, intent-specific content)
  - 4 `hasReturningUserPhrasing` (CIO/CTO incident + benign-welcome guard + false-positive guard)
  - 2 `rewriteReturningUserPhrasing` (rewrites cleanly + null subjectRef)
  - 3 integration matrix (AC1 phase synthesis, AC2 rewrite path, AC8 benign NOT rewritten)
- [ ] **Manual (post-merge):** re-trigger pipeline COMPOSE on the CIO/CTO caller "pop"; `_quickStart.first_line` no longer contains "Welcome back" / "let's revise" / "you've covered" / "pick up where"

## Sister story

#1196 (onboarding source attribution, shipped at #1197 / `6abe6bf2`) corrected the cascade source labels this PR walks. Build order respected.

## Deploy

`/vm-cp` — no migration, code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)