### PR TITLE
chore: post-#1198 follow-up — KNOWLEDGE-MAP + dead tour step (returns suite to baseline)

### DIFF
--- a/KNOWLEDGE-MAP.md
+++ b/KNOWLEDGE-MAP.md
@@ -48,7 +48,7 @@ Plain reading: a student has a call, the call becomes a transcript, the transcri
 | When a human says... | They probably mean (HF concept) | Type |
 |---|---|---|
 | "the course," "the lesson," "the curriculum" | **Playbook** (a collection of Specs for a domain) and/or **Domain** (Tutor, Companion, Coach) | Runtime data |
-| "the teaching material," "the content" | **CONTENT** specs (e.g. `WNF-CONTENT-001`), Content Trust levels | Runtime data |
+| "the teaching material," "the content" | **CONTENT** specs (one per Curriculum body), Content Trust levels | Runtime data |
 | "how it measures the student," "the assessment" | **Parameters** (e.g. Big Five, VARK) measured by **EXTRACT** specs | Runtime data |
 | "how it decides what to say next," "the AI's reply" | **COMPOSE** stage + **SYNTHESISE** specs producing the Next Prompt | Engine + data |
 | "the rules," "the guardrails," "what it must not do" | **CONSTRAIN** specs (e.g. `GUARD-001`) | Runtime data |
@@ -83,7 +83,7 @@ Type key: *Runtime data* = edit in the database via UI/CLI to change a live envi
 | `SYNTHESISE` | Combine and transform data | `COMP-001`, `REW-001`, `ADAPT-*` |
 | `CONSTRAIN` | Bounds and guards | `GUARD-001` |
 | `IDENTITY` | Agent personas | `TUT-001`, `COACH-001` |
-| `CONTENT` | Curriculum material | `WNF-CONTENT-001` |
+| `CONTENT` | Curriculum material | one spec per Curriculum body, created at seed time |
 | `VOICE` | Voice guidance | `VOICE-001` |
 
 A useful note for teachers: in the UI, teachers never see Playbooks, Specs, or Roles directly. The UI is organised by educator intent, and the system auto-scaffolds the underlying specs. So the "course" a teacher edits in the UI maps down to Playbooks and specs underneath.

--- a/apps/admin/lib/tours/tour-definitions.ts
+++ b/apps/admin/lib/tours/tour-definitions.ts
@@ -277,12 +277,6 @@ export const TOUR_DEFINITIONS: TourDefinition[] = [
         placement: "center",
       },
       {
-        id: "demo-ql",
-        title: "Community",
-        description: "Create a community and start conversations with an AI companion.",
-        manifestItem: "quick-launch",
-      },
-      {
         id: "demo-demos",
         title: "Demos",
         description: "Explore demo scenarios to see different conversation styles and teaching approaches.",


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #1198. Two regressions surfaced after #1198 landed:

### 1. KNOWLEDGE-MAP.md ratchet — \`WNF-CONTENT-001\` slug references
\`KNOWLEDGE-MAP.md:51\` and \`:86\` cited \`WNF-CONTENT-001\` as the canonical example of a \`SpecRole.CONTENT\` spec. PR #1198's \`cleanup_orphan_seed_curricula\` migration deleted that slug from the seed-spec set, so \`scripts/check-knowledge-map.ts --ci\` started failing.

**Fix:** replace specific slug with category-level language. CONTENT specs are created per-curriculum at seed time; pointing at any one slug as canonical was always brittle.

### 2. tour-definitions \`demo-ql\` step — dead \`quick-launch\` manifestItem
PR #1191 (folded into #1198) removed \`quick-launch\` from the sidebar manifest. The TESTER tour's \`demo-ql\` step still referenced \`manifestItem: \"quick-launch\"\`, breaking \`tests/lib/tour-manifest-binding.test.ts\` ('every tour manifestItem resolves to a valid manifest entry').

**Fix:** drop the dead step. Tour goes directly from welcome → demos.

## Test impact

| State | Test Files | Tests | Δ from baseline |
|---|---|---|---|
| Baseline (pre-#1198, \`6abe6bf2\`) | 2 failed | 4 failed | — |
| Post-#1198 (\`ec5ccf4f\`) | 5 failed | 9 failed | **+4 regressions** |
| Post this PR | 2 failed | 4 failed | **0 net regressions** |

Verified locally on the two affected test files:
\`\`\`
Test Files  2 passed (2)
Tests       7 passed (7)
\`\`\`

## Closes
- #1206 (dead \`demo-ql\` tour step)
- KNOWLEDGE-MAP issue is implicit follow-up to #1198 (not separately filed — caught + fixed in same audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)