### PR TITLE
fix: #1192 migration — drop bogus Call.curriculumId clause (recovers hf-dev from P3009)

### DIFF
--- a/apps/admin/prisma/migrations/20260606134121_cleanup_orphan_seed_curricula/migration.sql
+++ b/apps/admin/prisma/migrations/20260606134121_cleanup_orphan_seed_curricula/migration.sql
@@ -5,12 +5,12 @@
 -- docs-archive/bdd-specs/. The DB rows have:
 --   - 0 CurriculumModule children
 --   - 0 PlaybookCurriculum links
---   - 0 referencing Calls
+--   - 0 referencing Calls (Calls reference CurriculumModule via curriculumModuleId,
+--     not Curriculum directly — so the CurriculumModule guard below covers this case)
 --
 -- The NOT EXISTS guards make this idempotent and refuse to drop any curriculum
 -- that has been retroactively attached to content or a playbook.
 DELETE FROM "Curriculum"
 WHERE slug IN ('wnf-content-001', 'qm-content-001', 'curr-fs-l2-001')
   AND NOT EXISTS (SELECT 1 FROM "CurriculumModule" WHERE "curriculumId" = "Curriculum"."id")
-  AND NOT EXISTS (SELECT 1 FROM "PlaybookCurriculum" WHERE "curriculumId" = "Curriculum"."id")
-  AND NOT EXISTS (SELECT 1 FROM "Call" WHERE "curriculumId" = "Curriculum"."id");
+  AND NOT EXISTS (SELECT 1 FROM "PlaybookCurriculum" WHERE "curriculumId" = "Curriculum"."id");


### PR DESCRIPTION
## Summary

The \`20260606134121_cleanup_orphan_seed_curricula\` migration shipped in PR #1198 referenced \`\"Call\".\"curriculumId\"\` — a column that **does not exist** on the Call model. The Call→Curriculum relation is via \`Call.curriculumModuleId\` (Calls point at a CurriculumModule, not at a Curriculum directly).

This caused the migration to fail with **P3009** on hf-dev when the user merged PR #1198 at 14:03:50Z.

## Fix

Drop the bogus \`NOT EXISTS Call\` clause. The other guards (\`CurriculumModule\` + \`PlaybookCurriculum\`) already cover the "referencing Call" case transitively: **no module ⇒ no call can reference module ⇒ safe to delete**.

## Recovery (each environment with the failed migration)

\`\`\`bash
# 1. Mark the failed migration as rolled back (it never committed any rows)
npx prisma migrate resolve --rolled-back "20260606134121_cleanup_orphan_seed_curricula"

# 2. Pull this fix
git pull origin main

# 3. Re-apply
npx prisma migrate deploy
\`\`\`

Safe because the buggy migration never successfully applied anywhere.

## Why this slipped through

The PR #1198 test plan said *"Migrations apply cleanly on hf-dev (/vm-cpp after merge)"* — the migration was never executed against hf-dev before merge. Locally I never ran \`prisma migrate dev\` because I don't run a local DB; I rely on hf-dev for migration testing. **Process lesson:** any new migration must be applied on hf-dev *before* the PR is opened, not after.

## Closes
- Recovers hf-dev from P3009 introduced by PR #1198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)