### PR TITLE
fix(migration): #1198 follow-up — remove broken Call.curriculumId clause

### DIFF
--- a/apps/admin/prisma/migrations/20260606134121_cleanup_orphan_seed_curricula/migration.sql
+++ b/apps/admin/prisma/migrations/20260606134121_cleanup_orphan_seed_curricula/migration.sql
@@ -9,8 +9,12 @@
 --
 -- The NOT EXISTS guards make this idempotent and refuse to drop any curriculum
 -- that has been retroactively attached to content or a playbook.
+--
+-- Note: there is no Call→Curriculum direct FK. Calls reference Curriculum
+-- transitively via Call.curriculumModuleId → CurriculumModule.curriculumId
+-- (landmine §8.5 in docs/CONTRACTS-PLAYBOOK-CURRICULUM.md). The first NOT EXISTS
+-- on CurriculumModule already guarantees no Call can reach this Curriculum.
 DELETE FROM "Curriculum"
 WHERE slug IN ('wnf-content-001', 'qm-content-001', 'curr-fs-l2-001')
   AND NOT EXISTS (SELECT 1 FROM "CurriculumModule" WHERE "curriculumId" = "Curriculum"."id")
-  AND NOT EXISTS (SELECT 1 FROM "PlaybookCurriculum" WHERE "curriculumId" = "Curriculum"."id")
-  AND NOT EXISTS (SELECT 1 FROM "Call" WHERE "curriculumId" = "Curriculum"."id");
+  AND NOT EXISTS (SELECT 1 FROM "PlaybookCurriculum" WHERE "curriculumId" = "Curriculum"."id");


### PR DESCRIPTION
## Summary
- The `cleanup_orphan_seed_curricula` migration shipped in #1198 referenced `Call.curriculumId`, a column that does not exist (landmine §8.5 in `docs/CONTRACTS-PLAYBOOK-CURRICULUM.md` — Call→Curriculum is transitive via `Call.curriculumModuleId → CurriculumModule.curriculumId`).
- `prisma migrate deploy` was failing with `column curriculumId does not exist`, blocking dev server start on hf-dev (`npm run dev` wraps `prisma migrate deploy && next dev`).
- 1-clause removal: the third NOT EXISTS is redundant — the first NOT EXISTS on `CurriculumModule` already guarantees no Call can reach this Curriculum transitively.

## Why this is safe
- The migration never succeeded anywhere — the missing-column error fires at planner time, before any DELETE runs. No data is at risk.
- Environments mid-flight may need `prisma migrate resolve --rolled-back 20260606134121_cleanup_orphan_seed_curricula` before the corrected version re-applies.

## Test plan
- [x] tsc clean (SQL-only change, no app code touched)
- [ ] On hf-dev: `prisma migrate deploy` succeeds and the 3 orphan rows are dropped
- [ ] On hf-dev: dev server starts cleanly (no migration error on boot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)