### PR TITLE
fix: #1202/#1203/#1204 — orphan-Curriculum create-routes (transactional dual-write)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/regenerate-curriculum/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/regenerate-curriculum/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { extractCurriculumFromAssertions } from "@/lib/content-trust/extract-curriculum";
 import { syncModulesToDB } from "@/lib/curriculum/sync-modules";
+import { ensurePrimaryPlaybookLink } from "@/lib/curriculum/ensure-primary-playbook-link";
 import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
 import type { LegacyCurriculumModuleJSON } from "@/lib/types/json-fields";
 
@@ -134,16 +135,20 @@ export async function POST(
       select: { id: true, deliveryConfig: true },
     });
 
-    const curriculumRecord = existingCurr ?? await prisma.curriculum.create({
-      data: {
-        slug: `${courseId}-content`,
-        subjectId: primarySubject.id,
-        playbookId: courseId,
-        name: disciplineName,
-        description: `Auto-generated curriculum for ${playbook.name}`,
-        deliveryConfig: {},
-      },
-      select: { id: true, deliveryConfig: true },
+    const curriculumRecord = existingCurr ?? await prisma.$transaction(async (tx) => {
+      const created = await tx.curriculum.create({
+        data: {
+          slug: `${courseId}-content`,
+          subjectId: primarySubject.id,
+          playbookId: courseId,
+          name: disciplineName,
+          description: `Auto-generated curriculum for ${playbook.name}`,
+          deliveryConfig: {},
+        },
+        select: { id: true, deliveryConfig: true },
+      });
+      await ensurePrimaryPlaybookLink(tx, courseId, created.id);
+      return created;
     });
 
     // 4. Snapshot module slugs before regen so we can detect orphan risk

--- a/apps/admin/app/api/curricula/route.ts
+++ b/apps/admin/app/api/curricula/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { ensurePrimaryPlaybookLink } from "@/lib/curriculum/ensure-primary-playbook-link";
 
 /**
  * @api GET /api/curricula
@@ -102,14 +103,20 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const curriculum = await prisma.curriculum.create({
-      data: {
-        slug,
-        name: name.trim(),
-        subjectId: subjectId || null,
-        playbookId,
-      },
-      select: { id: true, slug: true, name: true, subjectId: true, playbookId: true },
+    const curriculum = await prisma.$transaction(async (tx) => {
+      const created = await tx.curriculum.create({
+        data: {
+          slug,
+          name: name.trim(),
+          subjectId: subjectId || null,
+          playbookId,
+        },
+        select: { id: true, slug: true, name: true, subjectId: true, playbookId: true },
+      });
+      if (playbookId) {
+        await ensurePrimaryPlaybookLink(tx, playbookId, created.id);
+      }
+      return created;
     });
 
     return NextResponse.json({ ok: true, curriculum });

--- a/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
+++ b/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { startCurriculumGeneration } from "@/lib/jobs/curriculum-runner";
 import { syncModulesToDB } from "@/lib/curriculum/sync-modules";
+import { ensurePrimaryPlaybookLink } from "@/lib/curriculum/ensure-primary-playbook-link";
 import {
   deriveQualificationAnchor,
   isAnchorSafe,
@@ -302,37 +303,46 @@ export async function POST(req: NextRequest, { params }: Params) {
         ? await prisma.curriculum.findUniqueOrThrow({
             where: { id: siblingLink.curriculumId },
           })
-        : await prisma.curriculum.upsert({
-            where: { slug },
-            create: {
-              slug,
-              name: result.name,
-              description: result.description,
-              subjectId,
-              playbookId: resolvedPlaybookId,
-              primarySourceId,
-              trustLevel: subject.defaultTrustLevel,
-              qualificationBody: subject.qualificationBody,
-              qualificationNumber: subject.qualificationRef,
-              qualificationLevel: subject.qualificationLevel,
-              // #1081 Slice 2B.2 — stamp the derived anchor so subsequent
-              // siblings in the same domain find it. Null when no
-              // qualification metadata or anchor was unsafe.
-              qualificationAnchor: derivedAnchor && isAnchorSafe(derivedAnchor) ? derivedAnchor : null,
-              notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
-              coreArgument: Prisma.JsonNull,
-              deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
-              version: "1.0",
-            },
-            update: {
-              name: result.name,
-              description: result.description,
-              primarySourceId,
-              trustLevel: subject.defaultTrustLevel,
-              notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
-              deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
-              updatedAt: new Date(),
-            },
+        : await prisma.$transaction(async (tx) => {
+            const upserted = await tx.curriculum.upsert({
+              where: { slug },
+              create: {
+                slug,
+                name: result.name,
+                description: result.description,
+                subjectId,
+                playbookId: resolvedPlaybookId,
+                primarySourceId,
+                trustLevel: subject.defaultTrustLevel,
+                qualificationBody: subject.qualificationBody,
+                qualificationNumber: subject.qualificationRef,
+                qualificationLevel: subject.qualificationLevel,
+                // #1081 Slice 2B.2 — stamp the derived anchor so subsequent
+                // siblings in the same domain find it. Null when no
+                // qualification metadata or anchor was unsafe.
+                qualificationAnchor: derivedAnchor && isAnchorSafe(derivedAnchor) ? derivedAnchor : null,
+                notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
+                coreArgument: Prisma.JsonNull,
+                deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
+                version: "1.0",
+              },
+              update: {
+                name: result.name,
+                description: result.description,
+                primarySourceId,
+                trustLevel: subject.defaultTrustLevel,
+                notableInfo: { modules: result.modules } as unknown as Prisma.InputJsonValue,
+                deliveryConfig: result.deliveryConfig as unknown as Prisma.InputJsonValue,
+                updatedAt: new Date(),
+              },
+            });
+            // #1204 — fresh-mint AND update paths both ensure a primary join row
+            // exists. Idempotent: if the row already exists (with any role) it's
+            // left alone; if missing, created with role='primary'.
+            if (resolvedPlaybookId) {
+              await ensurePrimaryPlaybookLink(tx, resolvedPlaybookId, upserted.id);
+            }
+            return upserted;
           });
 
       // If we linked to a sibling, also ensure the primary PlaybookCurriculum

--- a/apps/admin/lib/curriculum/ensure-primary-playbook-link.ts
+++ b/apps/admin/lib/curriculum/ensure-primary-playbook-link.ts
@@ -1,0 +1,50 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+type TxOrClient =
+  | PrismaClient
+  | Omit<PrismaClient, "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends">
+  | Prisma.TransactionClient;
+
+/**
+ * Idempotently ensure a `PlaybookCurriculum(role:'primary')` join row exists for
+ * the given (playbookId, curriculumId) pair. The canonical write-side guard for
+ * the Playbook ↔ Curriculum duality — see
+ * [`docs/CONTRACTS-PLAYBOOK-CURRICULUM.md`](../../../../../docs/CONTRACTS-PLAYBOOK-CURRICULUM.md) §3.
+ *
+ * Use inside the same `$transaction` as a `Curriculum.create` / `upsert` to
+ * prevent the orphan-Curriculum bug class (#1184, #1202, #1203, #1204).
+ *
+ * Behaviour:
+ * - No existing row → creates with role='primary'.
+ * - Existing row with any role → leaves it (variants must not be promoted to
+ *   primary by accident; if a true ownership change is needed, do it
+ *   explicitly).
+ *
+ * This helper does NOT enforce that the call is inside a transaction at the
+ * type level — callers must wrap it themselves. The proposed ESLint rule
+ * `hf-curriculum/no-orphan-curriculum-create` will catch lexical misuse.
+ */
+export async function ensurePrimaryPlaybookLink(
+  tx: TxOrClient,
+  playbookId: string,
+  curriculumId: string,
+): Promise<void> {
+  if (!playbookId || !curriculumId) {
+    throw new Error(
+      `ensurePrimaryPlaybookLink: both playbookId and curriculumId required ` +
+        `(got playbookId=${JSON.stringify(playbookId)}, curriculumId=${JSON.stringify(curriculumId)}).`,
+    );
+  }
+
+  await tx.playbookCurriculum.upsert({
+    where: {
+      playbookId_curriculumId: { playbookId, curriculumId },
+    },
+    create: {
+      playbookId,
+      curriculumId,
+      role: "primary",
+    },
+    update: {},
+  });
+}

--- a/apps/admin/tests/lib/curriculum/ensure-primary-playbook-link.test.ts
+++ b/apps/admin/tests/lib/curriculum/ensure-primary-playbook-link.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ensurePrimaryPlaybookLink } from "@/lib/curriculum/ensure-primary-playbook-link";
+
+describe("ensurePrimaryPlaybookLink", () => {
+  let tx: { playbookCurriculum: { upsert: ReturnType<typeof vi.fn> } };
+
+  beforeEach(() => {
+    tx = {
+      playbookCurriculum: {
+        upsert: vi.fn().mockResolvedValue({}),
+      },
+    };
+  });
+
+  it("upserts with create=primary, update={} for canonical idempotent write", async () => {
+    await ensurePrimaryPlaybookLink(
+      tx as never,
+      "pb-1",
+      "curr-1",
+    );
+
+    expect(tx.playbookCurriculum.upsert).toHaveBeenCalledTimes(1);
+    expect(tx.playbookCurriculum.upsert).toHaveBeenCalledWith({
+      where: {
+        playbookId_curriculumId: { playbookId: "pb-1", curriculumId: "curr-1" },
+      },
+      create: { playbookId: "pb-1", curriculumId: "curr-1", role: "primary" },
+      update: {},
+    });
+  });
+
+  it("does NOT clobber an existing row's role (update is {})", async () => {
+    // If a row already exists as role='linked' (variant), the upsert update={}
+    // means we leave it alone. This is the load-bearing invariant for CC-A.
+    await ensurePrimaryPlaybookLink(tx as never, "pb-1", "curr-1");
+    const call = tx.playbookCurriculum.upsert.mock.calls[0][0];
+    expect(call.update).toEqual({});
+  });
+
+  it("throws when playbookId is empty", async () => {
+    await expect(
+      ensurePrimaryPlaybookLink(tx as never, "", "curr-1"),
+    ).rejects.toThrow(/playbookId and curriculumId required/);
+    expect(tx.playbookCurriculum.upsert).not.toHaveBeenCalled();
+  });
+
+  it("throws when curriculumId is empty", async () => {
+    await expect(
+      ensurePrimaryPlaybookLink(tx as never, "pb-1", ""),
+    ).rejects.toThrow(/playbookId and curriculumId required/);
+    expect(tx.playbookCurriculum.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -7138,58 +7138,6 @@ Get teaching points (assertions) for a domain through the subject→source chain
 
 ---
 
-### `POST` /api/domains/quick-launch
-
-Runs the Quick Launch flow: upload content → create domain → scaffold tutor → ready.
-
-**Auth**: OPERATOR
-
-**Response** `200`
-```json
-text/event-stream — progress events then final result
-```
-
----
-
-### `POST` /api/domains/quick-launch/analyze
-
-Community Quick Launch setup.
-
-**Auth**: OPERATOR
-
-**Response** `202`
-```json
-{ ok, domainId, domainSlug, domainName, subjectId, identityConfig, taskId }
-```
-
----
-
-### `POST` /api/domains/quick-launch/commit
-
-Runs the commit phase of Quick Launch (Steps 5-7):
-
-**Auth**: OPERATOR
-
-**Response** `200`
-```json
-text/event-stream — progress events then final QuickLaunchResult
-```
-
----
-
-### `POST` /api/domains/suggest-name
-
-AI-generates field suggestions (name, persona, goals) from a free-text brief.
-
-**Auth**: OPERATOR
-
-**Response** `200`
-```json
-{ ok, name, slug, persona?, goals? }
-```
-
----
-
 ## Educator
 
 ### `POST` /api/calls/[callId]/interject
@@ -15592,8 +15540,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 498 |
-| Files with annotations | 489 |
+| Route files found | 494 |
+| Files with annotations | 485 |
 | Files missing annotations | 9 |
 | Coverage | 98.2% |
 


### PR DESCRIPTION
## Summary

Three routes wrote \`Curriculum\` without the canonical \`PlaybookCurriculum(role:'primary')\` join row, recreating the same orphan-Curriculum bug class as #1184 on every call. Fixed with a shared helper that encodes the canonical pattern documented in \`docs/CONTRACTS-PLAYBOOK-CURRICULUM.md\` §3.

## Changes

### New helper
\`lib/curriculum/ensure-primary-playbook-link.ts\` — idempotent upsert that:
- creates \`PlaybookCurriculum(role:'primary')\` when no row exists
- leaves existing rows alone (variants must NOT be promoted to primary by accident)
- throws on empty \`playbookId\` or \`curriculumId\`
- must be called inside a \`\$transaction\` with the Curriculum write

### Route fixes
| Issue | Route | Change |
|---|---|---|
| #1202 | \`POST /api/curricula\` | Wraps \`Curriculum.create\` + helper in \`\$transaction\` |
| #1203 | \`POST /api/courses/[id]/regenerate-curriculum\` | Wraps the fresh-mint branch in \`\$transaction\` + helper (existingCurr reuse path unchanged) |
| #1204 | \`POST /api/subjects/[id]/curriculum\` | Wraps upsert + helper in \`\$transaction\`. The helper's idempotent contract means the update branch transparently repairs pre-existing missing join rows. Sibling-link path was already correct. |

## Regression proof

Local vitest:
\`\`\`
Baseline (main 27a9eecb):  463/465 files | 5791 tests passing | 4 failing
This fix:                  464/466 files | 5795 tests passing | 4 failing
Δ: +1 file, +4 passing (the new helper tests). SAME 4 baseline failures.
\`\`\`

The 4 baseline failures (\`tests/api/calls-create.test.ts\` × 3 + \`tests/api/callers-calls-module-resolver.test.ts\` × 1) are pre-existing on main and unrelated to this PR.

tsc: zero new errors on touched files (verified by diff against main).

## Risk

Low. Each route gains a single \`\$transaction\` wrapper around an existing single-table write + one additional upsert. The helper is idempotent, so re-running any of these routes against existing data is safe. No schema changes, no migrations.

The only behaviour change is that runs which would previously have produced an orphan now produce a complete row set — strictly safer than before.

## Closes
- #1202 \`/api/curricula\` orphan-bug
- #1203 regenerate-curriculum orphan-bug
- #1204 subjects/curriculum fresh-mint orphan-bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)