### PR TITLE
chore(guard): #944 — block schema.prisma changes without paired migration

### DIFF
--- a/.claude/agents/guard-checker.md
+++ b/.claude/agents/guard-checker.md
@@ -1,11 +1,11 @@
 ---
 name: guard-checker
-description: Runs all 14 CLAUDE.md plan guards against recently changed files. Use after implementation, before committing. Pass a file list, a GitHub issue number, or say "current changes".
+description: Runs all 15 CLAUDE.md plan guards against recently changed files. Use after implementation, before committing. Pass a file list, a GitHub issue number, or say "current changes".
 tools: Bash, Read, Glob, Grep
 model: haiku
 ---
 
-You are the HF Guard Checker. Run all 14 guards from CLAUDE.md against the specified files or changes.
+You are the HF Guard Checker. Run all 15 guards from CLAUDE.md against the specified files or changes.
 
 ## Step 1 — Get the files to check
 
@@ -87,6 +87,17 @@ Prompt files → eval files mapping:
 For each changed behavioural rule in the prompt, verify there is at least one test case covering it.
 Flag: prompt changes without eval coverage, new rules without assertions, removed rules still tested.
 
+### Guard 15 — Schema has paired migration (#944)
+If `apps/admin/prisma/schema.prisma` changed, the diff MUST also add a new file under `apps/admin/prisma/migrations/*/migration.sql`. `prisma migrate deploy` is a no-op for schema-only changes; without a migration file every env that pulls main 500s on the next code path that touches the new field.
+
+Run the structural check:
+```bash
+cd /Users/paulwander/projects/HF && scripts/check-schema-has-migration.sh
+```
+Exit 0 = pass (including the comment-only-edit case). Exit 1 = flag this guard with the script's stderr verbatim.
+
+The same script runs as a blocking step in `.github/workflows/test.yml` — surfacing it at guard-check time gives the operator a chance to fix before the PR opens.
+
 ## Step 3 — Report
 
 ```
@@ -110,6 +121,7 @@ Files checked: [list]
 | 12 | API docs | ✅ PASS / N/A / ⚠️ FLAG | |
 | 13 | Orphan cleanup | ✅ PASS / ⚠️ FLAG | |
 | 14 | Prompt eval coverage | ✅ PASS / N/A / ⚠️ FLAG | |
+| 15 | Schema has paired migration | ✅ PASS / N/A / ⚠️ FLAG | |
 
 **Result: CLEAN** (all pass) / **FLAGS: [N]** (list issues)
 ```

--- a/.claude/agents/migration-checker.md
+++ b/.claude/agents/migration-checker.md
@@ -26,6 +26,18 @@ And check for any pending migration files:
 ls -lt apps/admin/prisma/migrations/ | head -5
 ```
 
+### Step 1b — Paired-migration guard (#944)
+
+Before reviewing the schema diff in detail, run the structural guard:
+
+```bash
+cd /Users/paulwander/projects/HF && scripts/check-schema-has-migration.sh
+```
+
+If exit code is 1, the schema has substantive changes but no new `apps/admin/prisma/migrations/*/migration.sql` file is staged. Surface the script's output verbatim and instruct the operator to run `cd apps/admin && npx prisma migrate dev --name <descriptive_slug>` before proceeding. Do not continue with destructive-op review until this gate passes — there's no point reviewing a migration that doesn't exist as a file.
+
+Comment-only changes (JSDoc tweaks) pass this guard automatically.
+
 ## Step 2 — Check for destructive operations
 
 Scan the schema diff for each risk pattern:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         working-directory: apps/admin
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # #944 guard needs base ref reachable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,6 +30,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # #944 — block schema.prisma changes without a paired migration file.
+      # Prevents the #931 / #1210 / #915 class of incident where schema-only
+      # PRs land on main and every env that pulls starts 500ing with `P2022
+      # column does not exist`. Runs BEFORE lint/tsc so the operator sees
+      # the migration ask immediately, not buried under typecheck noise.
+      - name: Block schema changes without paired migration (#944)
+        working-directory: .
+        run: scripts/check-schema-has-migration.sh
 
       - name: Run ESLint
         run: npm run lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ When the user says anything matching these patterns, **STOP and run the BA + Tec
 
 - [ ] All acceptance criteria checked off
 - [ ] `qa-engineer` agent run (vitest + promptfoo evals if applicable)
-- [ ] `guard-checker` agent run (all 14 guards)
+- [ ] `guard-checker` agent run (all 15 guards)
 - [ ] `standards-checker` agent run — READY TO MERGE verdict
 - [ ] `/check` passes (tsc + lint + tests)
 - [ ] Issue closed on GitHub
@@ -313,7 +313,7 @@ Run `plan-reviewer` agent before presenting a plan for approval. It checks phase
 
 Run `guard-checker` agent:
 - **Pre-plan:** guards 1-6, 10-11 (architectural — catch mistakes early)
-- **Post-plan / pre-commit:** all 14 guards
+- **Post-plan / pre-commit:** all 15 guards
 
 Guard definitions in `.claude/agents/guard-checker.md`. Always end a completed story with a guard report.
 

--- a/scripts/check-schema-has-migration.sh
+++ b/scripts/check-schema-has-migration.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# #944 — Block schema.prisma changes without a paired migration file.
+#
+# Substantive changes to apps/admin/prisma/schema.prisma MUST be accompanied
+# by at least one new apps/admin/prisma/migrations/*/migration.sql file in
+# the same diff. Without one, `prisma migrate deploy` is a no-op and every
+# environment that pulls main breaks with `P2022 column does not exist`.
+#
+# This script is run from:
+#   - .github/workflows/test.yml (hard gate at PR time)
+#   - .claude/agents/migration-checker.md (advisory at author time)
+#   - .claude/agents/guard-checker.md (advisory pre-commit)
+#
+# Usage:
+#   scripts/check-schema-has-migration.sh [BASE_REF]
+#
+#   BASE_REF defaults to `origin/main` (local use) or the CI base ref when
+#   running under GitHub Actions.
+#
+# Exit codes:
+#   0 — clean (no schema change, comment-only change, or schema + migration)
+#   1 — substantive schema change without a paired migration file
+#   2 — script error (couldn't find git, no base ref, etc.)
+#
+# False-positive prevention: comment-only edits to schema.prisma (lines that
+# are entirely blank, `//`, or `///` JSDoc comments after stripping leading
+# `+`/`-`) are ignored. The check looks for at least one substantive token
+# change before requiring a migration.
+
+set -u
+
+SCHEMA_FILE="apps/admin/prisma/schema.prisma"
+MIGRATIONS_GLOB='^apps/admin/prisma/migrations/[^/]+/migration\.sql$'
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "[check-schema-has-migration] git not available — skipping" >&2
+  exit 2
+fi
+
+# Resolve base ref.
+BASE="${1:-}"
+if [ -z "$BASE" ]; then
+  if [ -n "${GITHUB_BASE_REF:-}" ]; then
+    BASE="origin/${GITHUB_BASE_REF}"
+  else
+    BASE="origin/main"
+  fi
+fi
+
+# Make sure the base ref is reachable. In CI the checkout action sometimes
+# only fetches the head; fall back to fetching the base if needed.
+if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+  git fetch origin "${BASE#origin/}" --depth=50 >/dev/null 2>&1 || true
+fi
+
+if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+  echo "[check-schema-has-migration] cannot resolve base ref '$BASE' — skipping" >&2
+  exit 0
+fi
+
+MERGE_BASE=$(git merge-base "$BASE" HEAD 2>/dev/null || echo "$BASE")
+
+# Did schema.prisma change at all in this range?
+if ! git diff --quiet "$MERGE_BASE...HEAD" -- "$SCHEMA_FILE"; then
+  SCHEMA_CHANGED=1
+else
+  SCHEMA_CHANGED=0
+fi
+
+if [ "$SCHEMA_CHANGED" -eq 0 ]; then
+  exit 0
+fi
+
+# Strip:
+#   - diff hunk headers (`@@`, `+++`, `---`)
+#   - blank lines on either side
+#   - comment lines (`//` or `///`, possibly indented)
+# Keep only substantive added/removed lines.
+SUBSTANTIVE=$(
+  git diff "$MERGE_BASE...HEAD" -- "$SCHEMA_FILE" \
+    | grep -E '^[+-]' \
+    | grep -Ev '^(\+\+\+|---)' \
+    | grep -Ev '^[+-]\s*$' \
+    | grep -Ev '^[+-]\s*//' \
+    || true
+)
+
+if [ -z "$SUBSTANTIVE" ]; then
+  echo "[check-schema-has-migration] schema.prisma has comment-only changes — OK"
+  exit 0
+fi
+
+# Substantive change present. Look for a NEW migration file added in the
+# same range. We only care about Added (status A) files — modifying an
+# existing migration file is suspicious (history rewrite) and should be
+# justified case-by-case, not relied on as the migration for a new change.
+NEW_MIGRATIONS=$(
+  git diff --name-only --diff-filter=A "$MERGE_BASE...HEAD" \
+    | grep -E "$MIGRATIONS_GLOB" \
+    || true
+)
+
+if [ -n "$NEW_MIGRATIONS" ]; then
+  echo "[check-schema-has-migration] schema.prisma changed + new migration found:"
+  echo "$NEW_MIGRATIONS" | sed 's/^/  - /'
+  exit 0
+fi
+
+cat >&2 <<EOF
+❌ [check-schema-has-migration] #944 guard failed.
+
+apps/admin/prisma/schema.prisma was modified (substantively) in this branch,
+but no new apps/admin/prisma/migrations/*/migration.sql file was added.
+
+\`prisma migrate deploy\` is a no-op for schema-only changes — every
+environment that pulls main will start 500ing with \`P2022 column does
+not exist\` until someone notices.
+
+Fix locally:
+  cd apps/admin
+  npx prisma migrate dev --name <descriptive_slug>
+  git add prisma/migrations/<the-new-dir>
+  git commit --amend --no-edit  # or a new commit
+
+Then push again. If the schema change is genuinely safe without a
+migration (e.g. you regenerated the file but it produced no SQL),
+re-run \`prisma migrate dev\` to confirm — Prisma will create an
+empty .sql file you can commit, which satisfies this guard.
+
+Substantive changes detected:
+EOF
+
+echo "$SUBSTANTIVE" | head -20 | sed 's/^/  /' >&2
+
+exit 1


### PR DESCRIPTION
## Summary
Prevents the #931 / #915 / #1210 class of incident where schema-only PRs land on main and every env that pulls breaks with \`P2022 column does not exist\`. Closes #944.

## Implementation (Option A + C from the issue)

- **`scripts/check-schema-has-migration.sh`** — single source of truth. Diffs \`origin/main...HEAD\`, filters out comment-only edits (\`//\`, \`///\`), fails if substantive schema changes exist without a newly-added \`apps/admin/prisma/migrations/*/migration.sql\` file.
- **CI hard gate** — \`.github/workflows/test.yml\` runs the script BEFORE lint/tsc. \`fetch-depth: 0\` added so the base ref resolves.
- **\`migration-checker\` agent** — Step 1b "Paired-migration guard" runs the script first. Stops review if no migration file.
- **\`guard-checker\` agent** — new Guard 15. Table + report updated. CLAUDE.md "all 14 guards" → "all 15 guards".

## Self-test (all four cases pass)

| Case | Expected | Result |
|---|---|---|
| Schema change, no migration | exit 1 | ✅ exit 1 |
| Schema change + new migration | exit 0 | ✅ exit 0 |
| Comment-only edit | exit 0 | ✅ exit 0 + "comment-only" note |
| No schema change at all | exit 0 | ✅ exit 0 |

## False-negative note

The guard only fires on schema-only changes WITHOUT a new migration file. Modifying an EXISTING migration file (the rare-and-suspicious case) still passes — that case is a deliberate human judgement call and the migration-checker agent is where it gets surfaced for review.

## Test plan
- [x] Self-tested locally (4 cases)
- [x] yaml structure verified
- [ ] CI confirms the step runs (will show in this PR's checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)