### PR TITLE
feat(intake-spec): #1140 Phase 2c — body re-derive + PUBLISHED-source backfill

### DIFF
--- a/apps/admin/app/x/intake/specs/[id]/page.tsx
+++ b/apps/admin/app/x/intake/specs/[id]/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { loadRow, createSpecStoreAdapter } from "@/lib/intake/spec-store-adapter";
 import { updateDraft } from "@/lib/intake/spec-store";
+import { projectBodyFromEditable } from "@/lib/intake/crawcus-serde";
+import { parse, SpecParseError } from "@tallyseal/spec-emitter";
 import type {
   SaveSpecCallback,
   DeploySpecCallback,
@@ -49,7 +51,6 @@ export default async function IntakeSpecDetailPage({
   const currentRole = auth.session.user.role ?? null;
   const canEdit = row.status === "DRAFT";
   const canDeploy = row.status === "DRAFT";
-  const rowBody = row.body;
 
   // ────────────────────────────────────────────────────────────────
   // Server actions — invoked by EditorShell via its save / deploy
@@ -58,13 +59,27 @@ export default async function IntakeSpecDetailPage({
 
   const saveSpecAction: SaveSpecCallback = async (input) => {
     "use server";
+    // #1140 Phase 2c — re-derive the body JSON cache from the new
+    // source on every save so list-page fieldCount stays in sync.
+    // Parse failures surface as a SaveSpecResult.fail so the editor
+    // can show them inline rather than throwing past the boundary.
+    let body;
     try {
-      // Phase 2b persists source verbatim; the body JSON cache stays
-      // as last-seen (re-derivation lands Phase 2c via a parse+project
-      // pass server-side per save).
+      const editable = parse(input.source);
+      body = projectBodyFromEditable(editable);
+    } catch (err) {
+      const detail =
+        err instanceof SpecParseError
+          ? `Spec source did not parse: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : "Unknown parse error";
+      return { kind: "fail", detail };
+    }
+    try {
       await updateDraft({
         id,
-        body: rowBody,
+        body,
         source: input.source,
       });
       return { kind: "ok" };

--- a/apps/admin/lib/intake/crawcus-serde.ts
+++ b/apps/admin/lib/intake/crawcus-serde.ts
@@ -25,7 +25,13 @@
 // Type source: @tallyseal/crawcus-spec@0.11.0 dist/index.d.ts:2012.
 
 import type { CrawcusSpec } from "@tallyseal/crawcus-spec";
+import type { EditableSpec } from "@tallyseal/spec-emitter";
 import type { Prisma } from "@prisma/client";
+
+// SpecLiteralValue is not exported from @tallyseal/spec-emitter; access
+// via indexed access on EditableSpec.key (which is typed as the same
+// discriminated union).
+type SpecLiteralValue = EditableSpec["key"];
 
 /**
  * Deserialise a stored IntakeSpec body into a CrawcusSpec for editor
@@ -65,4 +71,54 @@ export function serialiseSpec(spec: CrawcusSpec): Prisma.JsonValue {
   // only the JSON descriptors. This protects the DB from accidentally
   // attempting to persist a non-serialisable value.
   return JSON.parse(JSON.stringify(spec)) as Prisma.JsonValue;
+}
+
+/**
+ * #1140 Phase 2c — project an EditableSpec (parsed from source by
+ * @tallyseal/spec-emitter) to the IntakeSpec.body JSON cache shape.
+ *
+ * The body shape is the list-page read surface: `fieldCount` reads
+ * `Object.keys(body.fields).length` in spec-store.ts::toSummary.
+ * EditableSpec carries `fields: readonly EditableField[]` (array
+ * with `.name`); body carries `fields: Record<name, descriptor>`.
+ * This helper bridges the two so saveSpecAction can re-derive the
+ * cache on every save, keeping fieldCount + status / projection /
+ * key / version coherent with the saved source.
+ *
+ * Contract details the editor doesn't structurally model (opaque
+ * suffix, contracts, extraSpecProperties) are NOT projected into
+ * the cache — the body is a read-cache for surface metadata, not
+ * a hydrated runtime spec. The canonical source-of-truth remains
+ * the `source` column.
+ */
+export function projectBodyFromEditable(
+  spec: EditableSpec,
+): Prisma.JsonValue {
+  const fields: Record<string, Prisma.JsonValue> = {};
+  for (const f of spec.fields) {
+    const descriptor: Record<string, Prisma.JsonValue> = {
+      type: f.base,
+      required: f.required,
+    };
+    if (f.enumOptions !== undefined) {
+      descriptor.enumSource = f.enumOptions.source;
+    }
+    fields[f.name] = descriptor;
+  }
+  return {
+    key: literalToString(spec.key),
+    version: spec.version,
+    projection: literalToString(spec.projection),
+    fields,
+    contracts: { invariants: [] },
+    readiness: {
+      kind: spec.readiness.kind === "template" ? "all-required" : "opaque",
+    },
+  };
+}
+
+function literalToString(value: SpecLiteralValue): string {
+  if (value.kind === "string") return value.value;
+  if (value.kind === "identifier") return value.name;
+  return value.source;
 }

--- a/apps/admin/scripts/seed-intake-specs.ts
+++ b/apps/admin/scripts/seed-intake-specs.ts
@@ -108,10 +108,25 @@ async function main() {
       });
       if (existing) {
         if (existing.status === "PUBLISHED") {
-          // DB trigger refuses body/source mutation on PUBLISHED;
-          // application layer respects that here.
+          // #1140 Phase 2c — PUBLISHED-source backfill.
+          // The intake_spec_published_immutable_trigger blocks
+          // body/key/version/status mutations on PUBLISHED rows but
+          // intentionally NOT `source` (the column post-dated the
+          // trigger — see migration 20260606131540_1194_intake_spec_source).
+          // So an old PUBLISHED row with source = NULL is correctable
+          // by a source-only update. Body stays frozen.
+          if (existing.source === null) {
+            await prisma.intakeSpec.update({
+              where: { id: existing.id },
+              data: { source: seed.source },
+            });
+            console.log(
+              `[seed] ${seed.key}@${seed.version} — backfilled source on PUBLISHED row.`,
+            );
+            continue;
+          }
           console.log(
-            `[seed] ${seed.key}@${seed.version} — already PUBLISHED, skipping (immutable).`,
+            `[seed] ${seed.key}@${seed.version} — already PUBLISHED with source on record, skipping (immutable).`,
           );
           continue;
         }

--- a/apps/admin/tests/lib/intake/crawcus-serde.test.ts
+++ b/apps/admin/tests/lib/intake/crawcus-serde.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #1140 Phase 2c — projectBodyFromEditable contract tests.
+ *
+ * Verifies that an EditableSpec parsed from canonical seed source
+ * (CreateRecipe / CreateCourse) projects to a body cache shape that
+ * preserves the surface metadata spec-store.ts::toSummary depends on
+ * (fields-as-Record so Object.keys(body.fields).length works, plus
+ * key/version/projection identity).
+ *
+ * Round-trip check: take seed source, parse via @tallyseal/spec-emitter,
+ * project, assert the result has the right shape AND the right
+ * fieldCount that the list page will read.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "@tallyseal/spec-emitter";
+import { projectBodyFromEditable } from "@/lib/intake/crawcus-serde";
+
+const CREATE_RECIPE_SOURCE = `import { defineCrawcusSpec, field } from '@tallyseal/core';
+
+export const CreateRecipe = defineCrawcusSpec({
+  key: "CreateRecipe",
+  projection: "Recipe",
+  version: 1,
+  fields: {
+    recipeName: field.string().required(),
+    servings: field.integer().required(),
+    cuisine: field.string().optional(),
+    difficulty: field.enum(["easy", "medium", "hard"]).required(),
+  },
+  readiness: ({ has }) => has("recipeName", "servings", "difficulty"),
+});
+`;
+
+const CREATE_COURSE_SOURCE = `import { defineCrawcusSpec, field } from '@tallyseal/core';
+
+export const CreateCourse = defineCrawcusSpec({
+  key: "CreateCourse",
+  projection: "Course",
+  version: 1,
+  fields: {
+    placeholder: field.string().optional(),
+  },
+  readiness: ({ has }) => has("placeholder"),
+});
+`;
+
+describe("projectBodyFromEditable", () => {
+  it("projects CreateRecipe source to a body with all 4 fields", () => {
+    const editable = parse(CREATE_RECIPE_SOURCE);
+    const body = projectBodyFromEditable(editable) as Record<string, unknown>;
+
+    expect(body.key).toBe("CreateRecipe");
+    expect(body.projection).toBe("Recipe");
+    expect(body.version).toBe(1);
+
+    const fields = body.fields as Record<string, unknown>;
+    // The exact contract spec-store.ts::toSummary depends on:
+    // Object.keys(body.fields).length === fieldCount.
+    expect(Object.keys(fields).sort()).toEqual([
+      "cuisine",
+      "difficulty",
+      "recipeName",
+      "servings",
+    ]);
+
+    const recipeName = fields.recipeName as Record<string, unknown>;
+    expect(recipeName.type).toBe("string");
+    expect(recipeName.required).toBe(true);
+
+    const cuisine = fields.cuisine as Record<string, unknown>;
+    expect(cuisine.type).toBe("string");
+    expect(cuisine.required).toBe(false);
+
+    const difficulty = fields.difficulty as Record<string, unknown>;
+    expect(difficulty.type).toBe("enum");
+    expect(difficulty.required).toBe(true);
+  });
+
+  it("projects CreateCourse source to a body with the single placeholder field", () => {
+    const editable = parse(CREATE_COURSE_SOURCE);
+    const body = projectBodyFromEditable(editable) as Record<string, unknown>;
+
+    expect(body.key).toBe("CreateCourse");
+    expect(body.version).toBe(1);
+
+    const fields = body.fields as Record<string, unknown>;
+    expect(Object.keys(fields)).toEqual(["placeholder"]);
+
+    const placeholder = fields.placeholder as Record<string, unknown>;
+    expect(placeholder.type).toBe("string");
+    expect(placeholder.required).toBe(false);
+  });
+
+  it("preserves the contracts/readiness skeleton expected by the body cache", () => {
+    const editable = parse(CREATE_RECIPE_SOURCE);
+    const body = projectBodyFromEditable(editable) as Record<string, unknown>;
+
+    expect(body.contracts).toEqual({ invariants: [] });
+    expect(body.readiness).toEqual({ kind: "all-required" });
+  });
+
+  it("survives the editor-save round-trip: parse → project → fieldCount matches added field", () => {
+    // Simulate the editor adding a new field by editing the source
+    // before saving. saveSpecAction then parses + projects on the
+    // server; this test mirrors that path.
+    const editedSource = CREATE_COURSE_SOURCE.replace(
+      "placeholder: field.string().optional(),",
+      "placeholder: field.string().optional(),\n    title: field.string().required(),",
+    );
+    const editable = parse(editedSource);
+    const body = projectBodyFromEditable(editable) as Record<string, unknown>;
+    const fields = body.fields as Record<string, unknown>;
+
+    expect(Object.keys(fields).sort()).toEqual(["placeholder", "title"]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Body re-derivation on save** — `page.tsx::saveSpecAction` now parses the saved source server-side via `@tallyseal/spec-emitter`, projects to the body JSON cache shape via the new `projectBodyFromEditable` helper, writes both atomically. Pre-fix the body stayed stale → list-page `fieldCount` lied after every field add/remove. Parse failures surface as a typed `{ kind: "fail", detail }` so the editor can show them inline.
- **PUBLISHED-source backfill** — `scripts/seed-intake-specs.ts` previously skipped PUBLISHED rows entirely, leaving `CreateRecipe@1.0.0` stuck with `source = NULL` and rendering the "re-seed needed" banner. The `intake_spec_published_immutable_trigger` blocks `body`/`key`/`version`/`status` mutations on PUBLISHED but intentionally NOT `source` (the column post-dated the trigger — #1194). Seed now does a source-only update when `existing.source === null`; body stays frozen.
- **`projectBodyFromEditable` helper** (`lib/intake/crawcus-serde.ts`) — bridges `EditableSpec.fields[]` (array) → body cache `fields: Record<name, descriptor>` so `spec-store.ts::toSummary` reads the right count. Only surface metadata projected; canonical source-of-truth remains the `source` column.

Closes part of #1140 (Phase 2c).

## Test plan

- [ ] On hf-dev: open `dev.humanfirstfoundation.com/x/intake/specs/[CreateCourse@0.1.0]`
- [ ] Edit a field name in the editor, click Save
- [ ] Verify save succeeds (no fail banner)
- [ ] Back to list page, verify `fieldCount` reflects new field count
- [ ] Re-run `npx tsx scripts/seed-intake-specs.ts` on VM
- [ ] Open `CreateRecipe@1.0.0` — banner should be gone; editor renders

## Notes

- `SpecLiteralValue` is not in `@tallyseal/spec-emitter@0.0.1` public exports; accessed via indexed-access on `EditableSpec["key"]`. When `admin-editor@0.1.1` lands (tallyseal merged `02f0d33e`, next vendor batch), Section B cleanup folds this into a named import.
- Ready for `/vm-cp` (no schema, no deps).
- 2 pre-existing tsc clusters on main (per handoff §Cautions) unchanged — none in Phase 2c files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)