### PR TITLE
fix: batch-2 backfill migration — drop bogus updatedAt column

### DIFF
--- a/apps/admin/prisma/migrations/20260606152557_backfill_primary_playbookcurriculum/migration.sql
+++ b/apps/admin/prisma/migrations/20260606152557_backfill_primary_playbookcurriculum/migration.sql
@@ -13,8 +13,9 @@
 --   - issues #1202/#1203/#1204 (orphan-create routes fixed)
 --   - docs/CONTRACTS-PLAYBOOK-CURRICULUM.md §3 (canonical pattern)
 --   - lib/curriculum/ensure-primary-playbook-link.ts (the helper)
-INSERT INTO "PlaybookCurriculum" (id, "playbookId", "curriculumId", role, "createdAt", "updatedAt")
-SELECT gen_random_uuid(), c."playbookId", c.id, 'primary'::"PlaybookCurriculumRole", NOW(), NOW()
+-- PlaybookCurriculum has no updatedAt column (only createdAt with @default(now())).
+INSERT INTO "PlaybookCurriculum" (id, "playbookId", "curriculumId", role, "createdAt")
+SELECT gen_random_uuid(), c."playbookId", c.id, 'primary'::"PlaybookCurriculumRole", NOW()
 FROM "Curriculum" c
 WHERE c."playbookId" IS NOT NULL
   AND EXISTS (SELECT 1 FROM "Playbook" p WHERE p.id = c."playbookId")


### PR DESCRIPTION
PlaybookCurriculum schema has no `updatedAt` column (only `createdAt @default(now())`). The 20260606152557 backfill INSERT referenced it and errored on `hf-dev migrate deploy` (P3009 / E42703). One-line SQL fix.

Process lesson reinforced (same as #1210): any new migration MUST be applied on hf-dev before the PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)