### PR TITLE
fix: batch-2 caller-delete migration — explicit DELETE from 7 RESTRICT FK tables

### DIFF
--- a/apps/admin/prisma/migrations/20260606152558_purge_pipeline_legacy_lo_keys_and_bleed_caller/migration.sql
+++ b/apps/admin/prisma/migrations/20260606152558_purge_pipeline_legacy_lo_keys_and_bleed_caller/migration.sql
@@ -28,6 +28,18 @@
 DELETE FROM "CallerAttribute"
 WHERE key LIKE 'curriculum:%:lo:%';
 
--- (b) Purge the bleed-evidence caller (cascades to all child rows).
-DELETE FROM "Caller"
-WHERE id = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+-- (b) Purge the bleed-evidence caller. The Caller model has 23 FK referrers;
+-- 11 cascade automatically, 5 SET NULL, but 7 are RESTRICT and would block
+-- the DELETE. Delete from each RESTRICT table first. All operations are
+-- idempotent against the absence of the target row.
+DELETE FROM "ComposedPrompt"          WHERE "callerId" = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+DELETE FROM "PersonalityObservation"  WHERE "callerId" = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+DELETE FROM "UserMemory"              WHERE "callerId" = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+DELETE FROM "UserMemorySummary"       WHERE "callerId" = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+DELETE FROM "UserPersonality"         WHERE "callerId" = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+DELETE FROM "UserPersonalityProfile"  WHERE "callerId" = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+-- CohortGroup references Caller via ownerId. If this caller owns cohorts,
+-- the cohort goes too (acceptable per the "callers are disposable" decision).
+DELETE FROM "CohortGroup"             WHERE "ownerId" = '4413a1f8-c91f-4577-b801-1e7e7e98697a';
+
+DELETE FROM "Caller" WHERE id = '4413a1f8-c91f-4577-b801-1e7e7e98697a';


### PR DESCRIPTION
Caller has 23 FK referrers; 7 RESTRICT-mode tables must be cleared before the Caller DELETE. Adds explicit DELETE statements ahead of the Caller delete. All idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)