### PR TITLE
feat(#1177-S5): migrate 7 curriculum.playbookId readers + drop resolver fallback

### DIFF
--- a/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/media-map/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/media-map/route.ts
@@ -41,20 +41,26 @@ export async function GET(
 
     const { curriculumId } = await params;
 
-    // Load curriculum + subject linkage
+    // Load curriculum + subject linkage. #1205 — primary playbookId via the
+    // canonical PlaybookCurriculum join (variant-aware).
     const curriculum = await prisma.curriculum.findUnique({
       where: { id: curriculumId },
       select: {
         id: true,
         deliveryConfig: true,
         subjectId: true,
-        playbookId: true,
+        playbookLinks: {
+          where: { role: "primary" },
+          take: 1,
+          select: { playbookId: true },
+        },
       },
     });
 
     if (!curriculum) {
       return NextResponse.json({ ok: false, error: "Curriculum not found" }, { status: 404 });
     }
+    const primaryPlaybookId = curriculum.playbookLinks[0]?.playbookId ?? null;
 
     const dc = (curriculum.deliveryConfig as Record<string, any>) || {};
     const lessonPlan = dc.lessonPlan;
@@ -133,7 +139,7 @@ export async function GET(
 
       // Priority 2: backfill via learningOutcomeRefs → assertions → AssertionMedia
       if (sessionImages.length === 0 && Array.isArray(entry.learningOutcomeRefs) && entry.learningOutcomeRefs.length > 0) {
-        const backfilled = await resolveMediaFromLORefs(entry.learningOutcomeRefs, curriculum.subjectId, curriculum.playbookId);
+        const backfilled = await resolveMediaFromLORefs(entry.learningOutcomeRefs, curriculum.subjectId, primaryPlaybookId);
         for (const ref of backfilled) {
           if (!assignedMediaIds.has(ref.mediaId)) {
             sessionImages.push(ref);

--- a/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
@@ -279,7 +279,8 @@ async function runBackgroundLessonPlanGeneration(
   includeAssessments: string,
 ) {
   try {
-    // Load curriculum with modules
+    // Load curriculum with modules + canonical primary playbookId (via join).
+    // #1205 — replaces direct curriculum.playbookId select (variant-aware).
     const curriculum = await prisma.curriculum.findUnique({
       where: { id: curriculumId },
       select: {
@@ -288,10 +289,15 @@ async function runBackgroundLessonPlanGeneration(
         description: true,
         notableInfo: true,
         subjectId: true,
-        playbookId: true,
         deliveryConfig: true,
+        playbookLinks: {
+          where: { role: "primary" },
+          take: 1,
+          select: { playbookId: true },
+        },
       },
     });
+    const primaryPlaybookId = curriculum?.playbookLinks[0]?.playbookId ?? null;
 
     if (!curriculum) {
       await updateTaskProgress(taskId, {
@@ -359,12 +365,12 @@ async function runBackgroundLessonPlanGeneration(
 
     // Count assertions per module topic
     const assertionCounts: Record<string, number> = {};
-    if (curriculum.playbookId || curriculum.subjectId) {
+    if (primaryPlaybookId || curriculum.subjectId) {
       // Resolve source IDs for assertion scoping
       let scopeSourceIds: string[] | undefined;
-      if (curriculum.playbookId) {
+      if (primaryPlaybookId) {
         const { getSourceIdsForPlaybook: getSrcIds } = await import("@/lib/knowledge/domain-sources");
-        scopeSourceIds = await getSrcIds(curriculum.playbookId);
+        scopeSourceIds = await getSrcIds(primaryPlaybookId);
       }
 
       const assertions = await prisma.contentAssertion.groupBy({
@@ -622,14 +628,13 @@ async function resolveSourceIdsForGeneration(
   curriculumId: string,
   subjectId: string | null,
 ): Promise<string[]> {
-  // Tier 1: Direct curriculum.playbookId → PlaybookSource
-  const curriculum = await prisma.curriculum.findUnique({
-    where: { id: curriculumId },
-    select: { playbookId: true },
-  });
-  if (curriculum?.playbookId) {
+  // Tier 1: canonical PlaybookCurriculum primary join → PlaybookSource.
+  // #1205 — replaces direct curriculum.playbookId read (variant-aware).
+  const { resolvePlaybookIdForCurriculum } = await import("@/lib/curriculum/resolve-playbook-for-curriculum");
+  const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+  if (playbookIds.length > 0) {
     const { getSourceIdsForPlaybook } = await import("@/lib/knowledge/domain-sources");
-    const ids = await getSourceIdsForPlaybook(curriculum.playbookId);
+    const ids = await getSourceIdsForPlaybook(playbookIds[0]);
     if (ids.length > 0) return ids;
   }
 
@@ -683,26 +688,37 @@ export async function POST(
     let emphasis: string = body.emphasis || "";
     let includeAssessments: string = body.includeAssessments || "";
 
-    // Verify curriculum exists
+    // Verify curriculum exists. #1205 — canonical primary playbookId via join.
     const curriculum = await prisma.curriculum.findUnique({
       where: { id: curriculumId },
-      select: { id: true, notableInfo: true, deliveryConfig: true, subjectId: true, playbookId: true },
+      select: {
+        id: true,
+        notableInfo: true,
+        deliveryConfig: true,
+        subjectId: true,
+        playbookLinks: {
+          where: { role: "primary" },
+          take: 1,
+          select: { playbookId: true },
+        },
+      },
     });
 
     if (!curriculum) {
       return NextResponse.json({ ok: false, error: "Curriculum not found" }, { status: 404 });
     }
+    const primaryPlaybookId = curriculum.playbookLinks[0]?.playbookId ?? null;
 
     // If no explicit params in body, fall back to playbook config
     // (the "Regenerate Plan" button may send {} — read saved educator preferences)
     let totalSessionTarget: number | null = body.totalSessionTarget || null;
     let durationMins: number | null = body.durationMins || null;
-    if ((!totalSessionTarget || !durationMins || !emphasis || !includeAssessments) && (curriculum.playbookId || curriculum.subjectId)) {
+    if ((!totalSessionTarget || !durationMins || !emphasis || !includeAssessments) && (primaryPlaybookId || curriculum.subjectId)) {
       // Prefer direct playbook lookup, fall back to subject chain
       let config: Record<string, any> = {};
-      if (curriculum.playbookId) {
+      if (primaryPlaybookId) {
         const pb = await prisma.playbook.findUnique({
-          where: { id: curriculum.playbookId },
+          where: { id: primaryPlaybookId },
           select: { config: true },
         });
         config = (pb?.config as Record<string, any>) || {};

--- a/apps/admin/lib/content-trust/reconcile-lo-linkage.ts
+++ b/apps/admin/lib/content-trust/reconcile-lo-linkage.ts
@@ -198,11 +198,15 @@ export async function reconcileAssertionLOs(
 
   if (loArray.length === 0) return empty;
 
-  // Resolve source IDs: prefer PlaybookSource (via curriculum.playbookId), fall back to SubjectSource
+  // Resolve source IDs: prefer PlaybookSource (via canonical PlaybookCurriculum
+  // primary join — variant-aware), fall back to SubjectSource. #1205 migration.
   let sourceIds: string[] = [];
-  if (curriculum.playbookId) {
+  const { resolvePlaybookIdForCurriculum } = await import("@/lib/curriculum/resolve-playbook-for-curriculum");
+  const playbookIds = await resolvePlaybookIdForCurriculum(curriculumId);
+  if (playbookIds.length > 0) {
     const { getSourceIdsForPlaybook } = await import("@/lib/knowledge/domain-sources");
-    sourceIds = await getSourceIdsForPlaybook(curriculum.playbookId);
+    // Primary playbook owns the canonical content scope; use the first.
+    sourceIds = await getSourceIdsForPlaybook(playbookIds[0]);
   }
   if (sourceIds.length === 0 && curriculum.subjectId) {
     const subjectSources = await prisma.subjectSource.findMany({

--- a/apps/admin/lib/curriculum/resolve-playbook-for-curriculum.ts
+++ b/apps/admin/lib/curriculum/resolve-playbook-for-curriculum.ts
@@ -33,8 +33,10 @@ import { prisma } from "@/lib/prisma";
 
 /**
  * Returns every `Playbook.id` linked to this Curriculum via `PlaybookCurriculum`
- * (siblings sharing the Curriculum). Falls back to the deprecated
- * `Curriculum.playbookId` column if no join rows exist (transition safety).
+ * (siblings sharing the Curriculum). Single source of truth — the legacy
+ * `Curriculum.playbookId` fallback was removed in batch 4 (#1177 Slice 5)
+ * after the 20260606152557 backfill migration ensured every Curriculum has
+ * a canonical primary join row on hf-dev (FK probe: 0 orphans).
  *
  * Signature changed from `string | null` to `string[]` in #1034 so a
  * single Curriculum mutation can bump compose staleness on all siblings.
@@ -49,14 +51,7 @@ export async function resolvePlaybookIdForCurriculum(
     where: { curriculumId },
     select: { playbookId: true },
   });
-  if (joins.length > 0) return joins.map((j) => j.playbookId);
-
-  // Fallback: deprecated Curriculum.playbookId column. Dropped in #1038.
-  const row = await prisma.curriculum.findUnique({
-    where: { id: curriculumId },
-    select: { playbookId: true },
-  });
-  return row?.playbookId ? [row.playbookId] : [];
+  return joins.map((j) => j.playbookId);
 }
 
 /**

--- a/apps/admin/lib/goals/track-progress.ts
+++ b/apps/admin/lib/goals/track-progress.ts
@@ -274,10 +274,16 @@ export async function deriveLearnGoalProgressFromRef(
 } | null> {
   if (!goal.ref || !goal.playbookId) return null;
 
+  // #1205 — canonical playbookId scoping via PlaybookCurriculum primary join
+  // (variant-aware). Replaces direct curriculum.playbookId filter.
   const los = await prisma.learningObjective.findMany({
     where: {
       ref: goal.ref,
-      module: { curriculum: { playbookId: goal.playbookId } },
+      module: {
+        curriculum: {
+          playbookLinks: { some: { playbookId: goal.playbookId, role: "primary" } },
+        },
+      },
     },
     select: { moduleId: true },
   });

--- a/apps/admin/tests/lib/admin-tools-coverage-gaps.test.ts
+++ b/apps/admin/tests/lib/admin-tools-coverage-gaps.test.ts
@@ -113,7 +113,8 @@ describe("Cmd+K coverage-gap fixes", () => {
         estimatedDurationMinutes: null,
         masteryThreshold: null,
       });
-      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: "pb-1" });
+      // #1205 batch 4 — bump-fanout via canonical join (no curriculum.playbookId).
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValueOnce([{ playbookId: "pb-1" }]);
 
       const raw = await executeAdminTool(
         "update_curriculum_module",

--- a/apps/admin/tests/lib/admin-tools-read-parity.test.ts
+++ b/apps/admin/tests/lib/admin-tools-read-parity.test.ts
@@ -289,7 +289,8 @@ describe("Cmd+K read-parity tools (#852 follow-up)", () => {
         learnerVisible: true,
         masteryThreshold: null,
       });
-      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: "pb-1" });
+      // #1205 batch 4 — bump-fanout via canonical join (no curriculum.playbookId).
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValueOnce([{ playbookId: "pb-1" }]);
 
       const raw = await executeAdminTool(
         "update_learning_objective",
@@ -324,7 +325,6 @@ describe("Cmd+K read-parity tools (#852 follow-up)", () => {
       mockPrisma.curriculum.findUnique.mockResolvedValue({
         id: "curr-1",
         name: "Old",
-        playbookId: "pb-1",
       });
       mockPrisma.curriculum.update.mockResolvedValue({
         id: "curr-1",
@@ -334,6 +334,9 @@ describe("Cmd+K read-parity tools (#852 follow-up)", () => {
         sourceYear: null,
         authors: [],
       });
+      // #1205 batch 4 — bump-fanout resolves owning playbooks via the
+      // canonical PlaybookCurriculum join (no Curriculum.playbookId fallback).
+      mockPrisma.playbookCurriculum.findMany.mockResolvedValueOnce([{ playbookId: "pb-1" }]);
 
       const raw = await executeAdminTool(
         "update_curriculum_metadata",

--- a/apps/admin/tests/lib/curriculum/resolve-playbook-for-curriculum.test.ts
+++ b/apps/admin/tests/lib/curriculum/resolve-playbook-for-curriculum.test.ts
@@ -37,30 +37,19 @@ describe("resolvePlaybookForCurriculum — #834 / #1034", () => {
       expect(mockPrisma.curriculum.findUnique).not.toHaveBeenCalled();
     });
 
-    it("falls back to deprecated Curriculum.playbookId column when no join rows", async () => {
-      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
-      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: "pb-legacy" });
-      await expect(
-        mod.resolvePlaybookIdForCurriculum("c1"),
-      ).resolves.toEqual(["pb-legacy"]);
-    });
+    // #1205 / batch 4 — the deprecated `Curriculum.playbookId` fallback was
+    // removed; backfill (20260606152557) ensures 100% join-row coverage.
+    // The "falls back to deprecated column" test was deleted with the code
+    // path. Single source of truth = the join.
 
-    it("returns empty array when no join row and no deprecated column value", async () => {
+    it("returns empty array when no join rows exist", async () => {
       mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
-      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: null });
       await expect(mod.resolvePlaybookIdForCurriculum("c1")).resolves.toEqual([]);
-    });
-
-    it("returns empty array when curriculum not found", async () => {
-      mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
-      mockPrisma.curriculum.findUnique.mockResolvedValue(null);
-      await expect(mod.resolvePlaybookIdForCurriculum("missing")).resolves.toEqual([]);
     });
 
     it("returns empty array on empty input without touching the DB", async () => {
       await expect(mod.resolvePlaybookIdForCurriculum("")).resolves.toEqual([]);
       expect(mockPrisma.playbookCurriculum.findMany).not.toHaveBeenCalled();
-      expect(mockPrisma.curriculum.findUnique).not.toHaveBeenCalled();
     });
   });
 
@@ -76,13 +65,13 @@ describe("resolvePlaybookForCurriculum — #834 / #1034", () => {
       ).resolves.toEqual(["pb-primary", "pb-linked"]);
     });
 
-    it("falls through to the deprecated column when join is empty", async () => {
+    // #1205 / batch 4 — deprecated-column fallback removed (see comment above).
+    it("returns empty array when module's curriculum has no join rows", async () => {
       mockPrisma.curriculumModule.findUnique.mockResolvedValue({ curriculumId: "c-shared" });
       mockPrisma.playbookCurriculum.findMany.mockResolvedValue([]);
-      mockPrisma.curriculum.findUnique.mockResolvedValue({ playbookId: "pb-legacy" });
       await expect(
         mod.resolvePlaybookIdForCurriculumModule("m1"),
-      ).resolves.toEqual(["pb-legacy"]);
+      ).resolves.toEqual([]);
     });
 
     it("returns empty array when module not found", async () => {


### PR DESCRIPTION
## Summary

Closes the last live dependencies on the deprecated `Curriculum.playbookId` column from production READ paths. After this PR, the only remaining production reads are intentional write-path uses during the #1038 deprecation window — Slice 6 (the schema drop) is unblocked.

Two commits, one concern each:
1. Drop deprecated-column fallback in `resolvePlaybookIdForCurriculum` (resolver becomes single-path).
2. Migrate 7 direct `curriculum.playbookId` readers to canonical join + update 3 admin-tool test mocks.

## Reader migrations (7 sites)

| File | Was | Now |
|---|---|---|
| `lib/content-trust/reconcile-lo-linkage.ts` | direct read | `resolvePlaybookIdForCurriculum()[0]` |
| `app/api/curricula/[id]/lesson-plan/route.ts` (×3) | direct select | `playbookLinks: { where: { role: 'primary' }, take: 1 }` |
| `app/api/curricula/[id]/lesson-plan/media-map/route.ts` | same | same |
| `lib/goals/track-progress.ts` | Prisma filter `{ curriculum: { playbookId } }` | `{ curriculum: { playbookLinks: { some: { playbookId, role: 'primary' } } } }` |

## Resolver fallback dropped
`resolvePlaybookIdForCurriculum` was the LAST canonical-path consumer of `Curriculum.playbookId`. Single-path now (join table only). Backfill migration (#1218) made the fallback unreachable.

## Regression proof
```
Pre-batch-4 main:        464/466 files | 5795 passing | 4 failing
This PR (post test fix): 465/467 files | 5797 passing | 4 failing ← SAME BASELINE
```
Zero new tsc errors. Lint clean.

## What's left for #1038 (column drop)
Write-path uses in `apply-projection.ts` and `sync-authored-modules-to-curriculum.ts` intentionally keep `Curriculum.playbookId` during the deprecation window. Slice 6 (the actual schema drop) will remove these in the same PR.

## Closes
Closes part of Epic #1177 Slice 5. Slice 6 (schema drop) unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)