### PR TITLE
feat(#1177-S6b/#1038): drop Curriculum.playbookId column — Epic #1177 complete

### DIFF
--- a/apps/admin/__tests__/lib/curriculum/resolve-module.test.ts
+++ b/apps/admin/__tests__/lib/curriculum/resolve-module.test.ts
@@ -118,23 +118,25 @@ describe("resolveModuleByLogicalId", () => {
 });
 
 describe("resolveCurriculumIdForPlaybook", () => {
+  const mockedPlaybookCurriculumFindFirst = prisma.playbookCurriculum.findFirst as ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
-    mockedCurriculumFindFirst.mockReset();
+    mockedPlaybookCurriculumFindFirst.mockReset().mockResolvedValue(null);
   });
 
-  it("returns the curriculum id when one is attached", async () => {
-    mockedCurriculumFindFirst.mockResolvedValue({ id: "curr-1" });
+  it("returns the curriculum id from the canonical PlaybookCurriculum join", async () => {
+    mockedPlaybookCurriculumFindFirst.mockResolvedValue({ curriculumId: "curr-1" });
     const result = await resolveCurriculumIdForPlaybook("pb-1");
     expect(result).toBe("curr-1");
-    expect(mockedCurriculumFindFirst).toHaveBeenCalledWith({
+    expect(mockedPlaybookCurriculumFindFirst).toHaveBeenCalledWith({
       where: { playbookId: "pb-1" },
-      orderBy: { createdAt: "asc" },
-      select: { id: true },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: { curriculumId: true },
     });
   });
 
   it("returns null when the playbook has no curriculum", async () => {
-    mockedCurriculumFindFirst.mockResolvedValue(null);
+    mockedPlaybookCurriculumFindFirst.mockResolvedValue(null);
     const result = await resolveCurriculumIdForPlaybook("pb-empty");
     expect(result).toBeNull();
   });
@@ -143,6 +145,6 @@ describe("resolveCurriculumIdForPlaybook", () => {
     expect(await resolveCurriculumIdForPlaybook(null)).toBeNull();
     expect(await resolveCurriculumIdForPlaybook(undefined)).toBeNull();
     expect(await resolveCurriculumIdForPlaybook("")).toBeNull();
-    expect(mockedCurriculumFindFirst).not.toHaveBeenCalled();
+    expect(mockedPlaybookCurriculumFindFirst).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/lib/curriculum/resolve-module.ts
+++ b/apps/admin/lib/curriculum/resolve-module.ts
@@ -140,27 +140,15 @@ export async function resolveCurriculumIdForPlaybook(
 ): Promise<string | null> {
   if (!playbookId) return null;
 
-  // #1034 — Prefer PlaybookCurriculum (join table). A variant Playbook has a
-  // `linked` row pointing at the parent's Curriculum; reading the deprecated
-  // Curriculum.playbookId column would silently miss it and the pipeline
-  // would skip module-aware composition for every variant Call.
-  // Order: primary before linked, then oldest first — matches the
-  // pre-#1034 convention of "the oldest Curriculum for this Playbook."
+  // #1034 / #1177 Slice 6 — single-path canonical resolution via
+  // PlaybookCurriculum. The legacy Curriculum.playbookId fallback was
+  // removed with the column drop in #1038 — backfill ensures every
+  // Curriculum has a join row.
+  // Order: primary before linked, then oldest first.
   const join = await prisma.playbookCurriculum.findFirst({
     where: { playbookId },
     orderBy: [{ role: "asc" }, { createdAt: "asc" }],
     select: { curriculumId: true },
   });
-  if (join) return join.curriculumId;
-
-  // Fallback: deprecated Curriculum.playbookId column. Rollback safety
-  // during the #1034 → #1038 transition window — covers the narrow case
-  // where a Curriculum write site hasn't yet been updated to dual-write.
-  // Dropped in #1038.
-  const row = await prisma.curriculum.findFirst({
-    where: { playbookId },
-    orderBy: { createdAt: "asc" },
-    select: { id: true },
-  });
-  return row?.id ?? null;
+  return join?.curriculumId ?? null;
 }

--- a/apps/admin/prisma/migrations/20260606170000_drop_curriculum_playbookid/migration.sql
+++ b/apps/admin/prisma/migrations/20260606170000_drop_curriculum_playbookid/migration.sql
@@ -1,0 +1,23 @@
+-- #1177 Slice 6 / #1038 — drop the deprecated Curriculum.playbookId column.
+--
+-- Ownership of a Curriculum by a Playbook is now expressed exclusively
+-- through `PlaybookCurriculum` (role: 'primary' | 'linked'). The
+-- 20260606152557 backfill ensured every historical Curriculum has a
+-- canonical primary join row; all read sites have been migrated to use
+-- it (Slices 1-5); all write sites have stopped setting the column in
+-- this same PR.
+--
+-- Drops in order:
+--   1. The FK constraint (Curriculum_playbookId_fkey)
+--   2. The @@index([playbookId]) we declared in the Prisma model
+--   3. The column itself
+--
+-- All operations are idempotent via IF EXISTS so re-application is a no-op.
+
+ALTER TABLE "Curriculum"
+  DROP CONSTRAINT IF EXISTS "Curriculum_playbookId_fkey";
+
+DROP INDEX IF EXISTS "Curriculum_playbookId_idx";
+
+ALTER TABLE "Curriculum"
+  DROP COLUMN IF EXISTS "playbookId";

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -2429,15 +2429,9 @@ model Curriculum {
   validFrom                DateTime? // When this curriculum version becomes active
   validUntil               DateTime? // When this curriculum version expires
 
-  // Subject linkage (legacy — being replaced by playbookId)
+  // Subject linkage
   subjectId String?
   subject   Subject? @relation(fields: [subjectId], references: [id], onDelete: SetNull)
-
-  /// @deprecated #1034 — kept as primary-owner pointer during PlaybookCurriculum
-  /// rollout. Readers MUST prefer PlaybookCurriculum (any role) and only fall
-  /// back to this column if the join table returns nothing. Dropped in #1038.
-  playbookId String?
-  playbook   Playbook? @relation("PlaybookCurricula", fields: [playbookId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -2445,16 +2439,15 @@ model Curriculum {
   // First-class modules (replaces JSON notableInfo.modules)
   modules CurriculumModule[]
 
-  // #1034 — many-to-many link to Playbooks (primary owner + linked siblings).
-  // Source-of-truth for the variant Course product line. Replaces direct
-  // Curriculum.playbookId read on the hot Call path.
+  // #1034 / #1177 Slice 6 — canonical many-to-many link to Playbooks
+  // (primary owner + linked variant siblings). Single source of truth for
+  // Curriculum ownership after Curriculum.playbookId was dropped in #1038.
   playbookLinks PlaybookCurriculum[]
 
   @@index([sourceSpecId])
   @@index([trustLevel])
   @@index([validUntil])
   @@index([subjectId])
-  @@index([playbookId])
   @@index([qualificationAnchor])
 }
 

--- a/apps/admin/scripts/check-fk-consistency.ts
+++ b/apps/admin/scripts/check-fk-consistency.ts
@@ -34,21 +34,23 @@ async function runChecks(): Promise<CheckResult[]> {
   // Query 1 — cross-playbook CallerModuleProgress.
   // Detects a CallerModuleProgress row pointing at a module whose curriculum
   // belongs to a different playbook than the caller's active enrolment.
+  // #1177 Slice 6 — `cur."playbookId"` was dropped; the curriculum's owning
+  // playbook now lives on PlaybookCurriculum(role='primary').
   const cmpLeaks = await prisma.$queryRaw<
     Array<{ id: string; callerId: string; moduleId: string; cur_playbookId: string | null; cp_playbookId: string | null }>
   >`
     SELECT cmp."id", cmp."callerId", cmp."moduleId",
-           cur."playbookId" AS cur_playbookId, cp."playbookId" AS cp_playbookId
+           pbc."playbookId" AS cur_playbookId, cp."playbookId" AS cp_playbookId
     FROM "CallerModuleProgress" cmp
     JOIN "CurriculumModule" cm ON cm.id = cmp."moduleId"
-    JOIN "Curriculum" cur ON cur.id = cm."curriculumId"
+    LEFT JOIN "PlaybookCurriculum" pbc ON pbc."curriculumId" = cm."curriculumId" AND pbc.role = 'primary'
     LEFT JOIN "CallerPlaybook" cp ON cp."callerId" = cmp."callerId" AND cp.status = 'ACTIVE'
-    WHERE cur."playbookId" IS DISTINCT FROM cp."playbookId"
+    WHERE pbc."playbookId" IS DISTINCT FROM cp."playbookId"
   `;
   results.push({
     name: "cross-playbook-caller-module-progress",
     description:
-      "CallerModuleProgress.moduleId points at a CurriculumModule whose curriculum.playbookId differs from the caller's active CallerPlaybook.playbookId.",
+      "CallerModuleProgress.moduleId points at a CurriculumModule whose owning playbook (via PlaybookCurriculum primary) differs from the caller's active CallerPlaybook.playbookId.",
     rows: cmpLeaks.map((r) => ({
       id: r.id,
       detail: {
@@ -61,16 +63,17 @@ async function runChecks(): Promise<CheckResult[]> {
   });
 
   // Query 2 — cross-playbook Call.curriculumModuleId.
+  // Same rewrite as Query 1.
   const callLeaks = await prisma.$queryRaw<
     Array<{ id: string; callerId: string; curriculumModuleId: string; cur_playbookId: string; cp_playbookId: string }>
   >`
     SELECT c."id", c."callerId", c."curriculumModuleId",
-           cur."playbookId" AS cur_playbookId, cp."playbookId" AS cp_playbookId
+           pbc."playbookId" AS cur_playbookId, cp."playbookId" AS cp_playbookId
     FROM "Call" c
     JOIN "CurriculumModule" cm ON cm.id = c."curriculumModuleId"
-    JOIN "Curriculum" cur ON cur.id = cm."curriculumId"
+    LEFT JOIN "PlaybookCurriculum" pbc ON pbc."curriculumId" = cm."curriculumId" AND pbc.role = 'primary'
     JOIN "CallerPlaybook" cp ON cp."callerId" = c."callerId" AND cp.status = 'ACTIVE'
-    WHERE cur."playbookId" IS DISTINCT FROM cp."playbookId"
+    WHERE pbc."playbookId" IS DISTINCT FROM cp."playbookId"
   `;
   results.push({
     name: "cross-playbook-call-curriculum-module-id",

--- a/apps/admin/tests/api/callers-calls-module-resolver.test.ts
+++ b/apps/admin/tests/api/callers-calls-module-resolver.test.ts
@@ -78,7 +78,9 @@ describe("POST /api/callers/[callerId]/calls — module slug resolver (#491 Slic
   });
 
   it("resolves a slug to CurriculumModule.id and writes both fields", async () => {
-    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: CURRICULUM });
+    // #1177 Slice 6 — resolveCurriculumIdForPlaybook reads PlaybookCurriculum
+    // (canonical-only after the column drop).
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue({ curriculumId: CURRICULUM });
     mockPrisma.curriculumModule.findFirst.mockResolvedValue({ id: MOCK_MOD_ID });
 
     const res = await POST(makeReq({ requestedModuleId: "mock" }), { params });
@@ -97,7 +99,7 @@ describe("POST /api/callers/[callerId]/calls — module slug resolver (#491 Slic
   });
 
   it("returns 400 when curriculum doesn't exist for the playbook", async () => {
-    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue(null);
 
     const res = await POST(makeReq({ requestedModuleId: "mock" }), { params });
     const body = await res.json();
@@ -108,7 +110,7 @@ describe("POST /api/callers/[callerId]/calls — module slug resolver (#491 Slic
   });
 
   it("returns 400 when the slug doesn't resolve to a module in this curriculum", async () => {
-    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: CURRICULUM });
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue({ curriculumId: CURRICULUM });
     mockPrisma.curriculumModule.findFirst.mockResolvedValue(null);
 
     const res = await POST(makeReq({ requestedModuleId: "typo-slug" }), { params });

--- a/apps/admin/tests/api/import-modules-fallback.test.ts
+++ b/apps/admin/tests/api/import-modules-fallback.test.ts
@@ -169,8 +169,10 @@ describe("GET /api/courses/[courseId]/import-modules — generated fallback (#49
       id: "playbook-1",
       config: { lessonPlanMode: "continuous" },
     });
-    // resolveCurriculumIdForPlaybook → curriculum.findFirst
-    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-1" });
+    // #1177 Slice 6 — resolveCurriculumIdForPlaybook reads the canonical
+    // PlaybookCurriculum join (the deprecated Curriculum.playbookId fallback
+    // was removed with the column drop).
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue({ curriculumId: "curr-1" });
     // Two CurriculumModule rows scoped to the resolved curriculum.
     mockPrisma.curriculumModule.findMany.mockResolvedValue([
       {
@@ -228,8 +230,8 @@ describe("GET /api/courses/[courseId]/import-modules — generated fallback (#49
     expect(body.modulesAuthored).toBeNull();
     expect(body.moduleSource).toBeNull();
 
-    // Fallback path was actually used.
-    expect(mockPrisma.curriculum.findFirst).toHaveBeenCalledOnce();
+    // #1177 Slice 6 — fallback now reads canonical PlaybookCurriculum join.
+    expect(mockPrisma.playbookCurriculum.findFirst).toHaveBeenCalledOnce();
     expect(mockPrisma.curriculumModule.findMany).toHaveBeenCalledOnce();
     const findManyArgs = mockPrisma.curriculumModule.findMany.mock.calls[0][0];
     expect(findManyArgs.where).toMatchObject({
@@ -248,7 +250,7 @@ describe("GET /api/courses/[courseId]/import-modules — empty curriculum (#495 
       id: "playbook-1",
       config: {},
     });
-    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-1" });
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue({ curriculumId: "curr-1" });
     mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
 
     const res = await GET(makeGetReq(), { params });
@@ -267,7 +269,7 @@ describe("GET /api/courses/[courseId]/import-modules — empty curriculum (#495 
       config: {},
     });
     // No curriculum attached at all.
-    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue(null);
 
     const res = await GET(makeGetReq(), { params });
     expect(res.status).toBe(200);

--- a/apps/admin/tests/api/import-modules-recommendation.test.ts
+++ b/apps/admin/tests/api/import-modules-recommendation.test.ts
@@ -167,9 +167,10 @@ beforeEach(() => {
   mockIsAuthError.mockReturnValue(false);
   mockPrisma.contentQuestion.groupBy.mockResolvedValue([]);
   mockPrisma.learningObjective.findMany.mockResolvedValue([]);
+  // #1177 Slice 6 — resolveCurriculumIdForPlaybook reads canonical join.
   // Default curriculum resolution returns a real id so recommendNextModule
   // gets invoked. Individual cases override as needed.
-  mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-1" });
+  mockPrisma.playbookCurriculum.findFirst.mockResolvedValue({ curriculumId: "curr-1" });
   mockPrisma.curriculumModule.findMany.mockResolvedValue([]);
   mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
 });

--- a/apps/admin/tests/lib/admin-tools-read-parity.test.ts
+++ b/apps/admin/tests/lib/admin-tools-read-parity.test.ts
@@ -184,7 +184,8 @@ describe("Cmd+K read-parity tools (#852 follow-up)", () => {
 
   describe("list_curriculum_modules", () => {
     it("resolves curriculum from playbook_id", async () => {
-      mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "curr-1" });
+      // #1177 Slice 6 — canonical PlaybookCurriculum join (no deprecated FK).
+      mockPrisma.playbookCurriculum.findFirst.mockResolvedValueOnce({ curriculumId: "curr-1" });
       mockPrisma.curriculumModule.findMany.mockResolvedValue([
         {
           id: "m-1",
@@ -212,7 +213,7 @@ describe("Cmd+K read-parity tools (#852 follow-up)", () => {
     });
 
     it("returns note when playbook has no curriculum yet", async () => {
-      mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+      mockPrisma.playbookCurriculum.findFirst.mockResolvedValueOnce(null);
       const raw = await executeAdminTool(
         "list_curriculum_modules",
         { playbook_id: "pb-1" },

--- a/apps/admin/tests/lib/curriculum/resolve-curriculum-for-playbook.test.ts
+++ b/apps/admin/tests/lib/curriculum/resolve-curriculum-for-playbook.test.ts
@@ -52,17 +52,12 @@ describe("resolveCurriculumIdForPlaybook — #1034", () => {
     });
   });
 
-  it("falls back to deprecated Curriculum.playbookId only when no join row exists", async () => {
-    mockPrisma.playbookCurriculum.findFirst.mockResolvedValue(null);
-    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "c-legacy" });
-    await expect(
-      mod.resolveCurriculumIdForPlaybook("pb-legacy"),
-    ).resolves.toBe("c-legacy");
-  });
+  // #1177 Slice 6 — the deprecated-column fallback was removed with the
+  // Curriculum.playbookId column drop in #1038. Single-path resolution now.
+  // Backfill ensures every Curriculum has a join row.
 
-  it("returns null when neither join nor deprecated column matches", async () => {
+  it("returns null when no join row exists", async () => {
     mockPrisma.playbookCurriculum.findFirst.mockResolvedValue(null);
-    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
     await expect(
       mod.resolveCurriculumIdForPlaybook("pb-orphan"),
     ).resolves.toBeNull();
@@ -73,6 +68,5 @@ describe("resolveCurriculumIdForPlaybook — #1034", () => {
     await expect(mod.resolveCurriculumIdForPlaybook(undefined)).resolves.toBeNull();
     await expect(mod.resolveCurriculumIdForPlaybook("")).resolves.toBeNull();
     expect(mockPrisma.playbookCurriculum.findFirst).not.toHaveBeenCalled();
-    expect(mockPrisma.curriculum.findFirst).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes Epic #1177 and #1038. Drops the deprecated `Curriculum.playbookId` column from schema + database. Ownership of a Curriculum by a Playbook is now exclusively expressed through `PlaybookCurriculum` (role: 'primary' | 'linked'). Single source of truth.

## Pre-applied on hf-dev ✅

Per the process lesson from #1210 + #1220, the migration was applied + verified on hf-dev BEFORE this PR opened. Results:
- Migration applied cleanly (`20260606170000_drop_curriculum_playbookid`)
- Column `Curriculum.playbookId` confirmed gone
- Index `Curriculum_playbookId_idx` confirmed gone
- 7 curricula remain, 7/7 have primary join (100% coverage)
- FK consistency probe: ALL GREEN (6/6 checks pass)

## What changed

### Schema (`prisma/schema.prisma`)
- Removed `Curriculum.playbookId` field + `Curriculum.playbook` relation
- Removed `@@index([playbookId])` on Curriculum
- Removed deprecated `Playbook.curricula` direct relation

### Code
- `lib/curriculum/resolve-module.ts` — `resolveCurriculumIdForPlaybook` now single-path (canonical PlaybookCurriculum join only; legacy fallback dropped)
- `scripts/check-fk-consistency.ts` — 2 cross-playbook queries rewritten to LEFT JOIN `PlaybookCurriculum(role='primary')` since `cur."playbookId"` is gone

### Migration (`20260606170000_drop_curriculum_playbookid`)
```sql
ALTER TABLE "Curriculum" DROP CONSTRAINT IF EXISTS "Curriculum_playbookId_fkey";
DROP INDEX IF EXISTS "Curriculum_playbookId_idx";
ALTER TABLE "Curriculum" DROP COLUMN IF EXISTS "playbookId";
```
All idempotent via `IF EXISTS`.

### Test mocks (9 tests across 6 files)
Same pattern as batch 4: tests that mocked `curriculum.findFirst` for the resolver fallback now mock `playbookCurriculum.findFirst`. The explicit fallback test was deleted.

## Regression proof

| State | Files | Passing | Failing |
|---|---|---|---|
| Pre-Slice-6b main | 465/467 | 5797 | 4 (baseline) |
| **This PR** | **465/467** | **5796** | **4 (SAME baseline)** |

-1 passing test = the deleted fallback unit test. Zero new failures.

tsc: 17 "new" errors are line-shifted pre-existing baseline errors (verified by diff vs main).

## Closes
- #1038 — Drop `Curriculum.playbookId` column
- **Epic #1177 — Curriculum → Playbook collapse** (the structural problem is fully resolved)

## What's left

Only the contract-driven `track-progress.ts` `curriculum:{specSlug}:lo_mastery:*` → `playbook:{playbookId}:lo_mastery:*` rekey remains as separate "focused Slice 3 ticket" work — deliberately scoped out because it touches a different system (the CURRICULUM_PROGRESS_V1 contract pattern, ~20 call sites) and the variant-bleed mitigation already exists via `useFreshMastery` config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)