### PR TITLE
feat(#1225 Slice A): course-aware Cmd+K mode + /x/courses/[id]/chat page

### DIFF
--- a/apps/admin/app/api/chat/page-context.ts
+++ b/apps/admin/app/api/chat/page-context.ts
@@ -4,13 +4,29 @@
  * Lives next to route.ts and system-prompts.ts because both consume it:
  * route.ts parses the request body into the typed shape, system-prompts.ts
  * renders it into a short prompt preamble.
+ *
+ * #1225 — extended to carry a course snapshot when page === "course" so
+ * COURSE_MANAGE-mode chats see the live editable surface of the active
+ * course in the system prompt, not just the breadcrumb. Forbidden top-level
+ * keys (per AI_FORBIDDEN_FIELDS.playbook) are stripped at parse time as
+ * defence-in-depth — the page builder is also expected to omit them.
  */
+
+import { AI_FORBIDDEN_FIELDS } from "@/lib/chat/ai-forbidden-fields";
 
 export interface PageContextHint {
   page: string;
   params: {
     activeTab?: string;
     visibleSections?: string[];
+    /**
+     * #1225 — when page === "course", a snapshot of the active course's
+     * editable surface (name, slug, description, config.*, behaviorTargets,
+     * primary/linked curricula refs). Built server-side in the page
+     * component; rendered into the system prompt by buildPageContextBlock.
+     * Keys in AI_FORBIDDEN_FIELDS.playbook are stripped by the parser.
+     */
+    courseSnapshot?: Record<string, unknown>;
   };
 }
 
@@ -26,6 +42,7 @@ export function parsePageContext(raw: unknown): PageContextHint | undefined {
   const rawParams = (obj.params && typeof obj.params === "object" ? obj.params : {}) as {
     activeTab?: unknown;
     visibleSections?: unknown;
+    courseSnapshot?: unknown;
   };
   const params: PageContextHint["params"] = {};
   if (typeof rawParams.activeTab === "string" && rawParams.activeTab.length > 0) {
@@ -36,6 +53,18 @@ export function parsePageContext(raw: unknown): PageContextHint | undefined {
       (s: unknown): s is string => typeof s === "string" && s.length > 0,
     );
     if (sections.length > 0) params.visibleSections = sections;
+  }
+  // #1225 — accept courseSnapshot when page === "course"; strip any
+  // top-level key listed in AI_FORBIDDEN_FIELDS.playbook so a malformed
+  // client payload cannot inject forbidden state into the system prompt
+  // (e.g. status, publishedAt, deletedAt, domainId).
+  if (obj.page === "course" && rawParams.courseSnapshot && typeof rawParams.courseSnapshot === "object" && !Array.isArray(rawParams.courseSnapshot)) {
+    const forbidden = new Set(AI_FORBIDDEN_FIELDS.playbook ?? []);
+    const snapshot: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawParams.courseSnapshot as Record<string, unknown>)) {
+      if (!forbidden.has(key)) snapshot[key] = value;
+    }
+    if (Object.keys(snapshot).length > 0) params.courseSnapshot = snapshot;
   }
   return { page: obj.page, params };
 }
@@ -54,5 +83,19 @@ export function buildPageContextBlock(pageContext: PageContextHint | undefined):
     tabBits.push(`Active section: ${pageContext.params.visibleSections.join(", ")}`);
   }
   if (tabBits.length > 0) lines.push(tabBits.join(" | "));
-  return `\n\n## Page context (what the user is looking at)\n${lines.join("\n")}`;
+
+  // #1225 — when the operator is on a course page, append the course
+  // snapshot so the AI can propose informed deltas instead of asking
+  // "what is the current value?". Serialised as JSON inside a fenced
+  // block so the AI sees structure without parser ambiguity.
+  let snapshotBlock = "";
+  if (pageContext.page === "course" && pageContext.params.courseSnapshot) {
+    snapshotBlock =
+      "\n\n## Current course snapshot (live editable surface)\n" +
+      "```json\n" +
+      JSON.stringify(pageContext.params.courseSnapshot, null, 2) +
+      "\n```";
+  }
+
+  return `\n\n## Page context (what the user is looking at)\n${lines.join("\n")}${snapshotBlock}`;
 }

--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -23,6 +23,37 @@ import { extractPendingChangeFromToolResult, type PendingChangePayload } from "@
 // Playbook.config — no per-learner variant).
 const TUNING_TOOL_NAMES = new Set(["update_behavior_target", "update_playbook_config"]);
 const TUNING_TOOLS = ADMIN_TOOLS.filter((t) => TUNING_TOOL_NAMES.has(t.name));
+
+// #1225 — COURSE_MANAGE mode: operator is looking at a specific course (Playbook);
+// system prompt carries a full snapshot of that course's editable surface; the
+// AI sees only course-relevant tools (not domain, system, or cross-tenant ones).
+// Subset of ADMIN_TOOLS so the existing forbidden-fields + pending-change
+// meta-tests apply automatically — no parallel allowlist to maintain.
+// Tools added by #1225 Slice B (swap_primary_curriculum, attach_linked_curriculum,
+// detach_linked_curriculum, update_intake_spec_draft, get_voice_config,
+// update_voice_config) will be appended to this set when they ship.
+const COURSE_MANAGE_TOOL_NAMES = new Set([
+  // Writers — course config + curriculum + LO + lesson plan
+  "update_playbook_config",
+  "update_playbook_meta",
+  "update_behavior_target",
+  "update_curriculum_module",
+  "update_curriculum_metadata",
+  "update_learning_objective",
+  "update_assertion_lo_link",
+  "add_curriculum_module",
+  "replace_lesson_plan",
+  "recompose_caller_prompt",
+  // Readers — current course state + per-learner queries operators often run
+  // while looking at a course (e.g. "how is Brynn doing on module 3?")
+  "get_playbook_config",
+  "list_behavior_targets",
+  "list_curriculum_modules",
+  "get_caller_detail",
+  "list_goals_for_caller",
+  "list_caller_memories",
+]);
+const COURSE_MANAGE_TOOLS = ADMIN_TOOLS.filter((t) => COURSE_MANAGE_TOOL_NAMES.has(t.name));
 import { CHAT_TOOLS, executeToolCall, buildContentCatalog } from "./tools";
 import { executeWizardTool } from "@/lib/chat/wizard-tool-executor";
 import { buildV5SystemPrompt } from "@/lib/chat/v5-system-prompt";
@@ -46,7 +77,7 @@ import {
 
 export const runtime = "nodejs";
 
-type ChatMode = "DATA" | "CALL" | "BUG" | "WIZARD" | "COURSE_REF" | "TUNING";
+type ChatMode = "DATA" | "CALL" | "BUG" | "WIZARD" | "COURSE_REF" | "TUNING" | "COURSE_MANAGE";
 
 interface EntityBreadcrumb {
   type: string;
@@ -306,6 +337,19 @@ export async function POST(request: NextRequest) {
       return await handleDataModeWithTools(messages, callPoint, engine, selectedEngine, mode, message, entityContext, conversationHistory, userRole, userId);
     }
 
+    // #1225 — COURSE_MANAGE mode: same tool loop as DATA, but the AI sees only
+    // course-relevant tools (COURSE_MANAGE_TOOLS) and the system prompt carries
+    // a full snapshot of the active course (via pageContext.params.courseSnapshot,
+    // injected by page-context.ts::buildPageContextBlock).
+    if (mode === "COURSE_MANAGE") {
+      const userId = authResult.session.user.id;
+      return await handleDataModeWithTools(
+        messages, callPoint, engine, selectedEngine, mode, message,
+        entityContext, conversationHistory, userRole, userId,
+        COURSE_MANAGE_TOOLS,
+      );
+    }
+
     // CALL mode: per-turn knowledge retrieval (matches what the voice provider does live)
     if (mode === "CALL") {
       const callerEntity = entityContext.find((e) => e.type === "caller");
@@ -409,6 +453,10 @@ async function handleDataModeWithTools(
   conversationHistory: { role: string; content: string }[],
   userRole: string,
   userId: string,
+  // #1225 — tool surface defaults to the full ADMIN_TOOLS for DATA mode;
+  // COURSE_MANAGE passes COURSE_MANAGE_TOOLS to narrow the AI's surface to
+  // course-relevant mutators only.
+  tools: typeof ADMIN_TOOLS = ADMIN_TOOLS,
 ): Promise<Response> {
   const loopMessages: AIMessage[] = [...messages];
   let toolCallCount = 0;
@@ -425,7 +473,7 @@ async function handleDataModeWithTools(
         callPoint,
         engineOverride: engine,
         messages: loopMessages,
-        tools: ADMIN_TOOLS,
+        tools,
       },
       { sourceOp: `${callPoint}.tools` }
     );

--- a/apps/admin/app/api/chat/system-prompts.ts
+++ b/apps/admin/app/api/chat/system-prompts.ts
@@ -12,7 +12,7 @@ import { buildPageFeatureCatalogue } from "@/lib/chat/page-feature-catalogue";
 
 export type { PageContextHint };
 
-type ChatMode = "DATA" | "CALL" | "BUG" | "TUNING";
+type ChatMode = "DATA" | "CALL" | "BUG" | "TUNING" | "COURSE_MANAGE";
 
 interface EntityBreadcrumb {
   type: string;
@@ -126,6 +126,7 @@ export async function buildSystemPrompt(
   const runtimeBlock = buildRuntimeContextBlock(userRole, options?.pageHintRoute);
 
   switch (mode) {
+    case "COURSE_MANAGE":
     case "DATA": {
       // DATA mode shares the TUNING catalogue + truthfulness rules so the
       // model can call update_behavior_target from the Assistant tab — but

--- a/apps/admin/app/x/courses/[courseId]/chat/ChatLauncher.tsx
+++ b/apps/admin/app/x/courses/[courseId]/chat/ChatLauncher.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import { useChatContext } from "@/contexts/ChatContext";
+import { useEntityContext } from "@/contexts/EntityContext";
+import { useGlobalAssistant } from "@/contexts/AssistantContext";
+import type { CourseSnapshot } from "./page";
+
+/**
+ * #1225 — bridges the server-rendered course snapshot into the global
+ * Cmd+K assistant.
+ *
+ * On mount:
+ *   1. Set ChatContext mode = "COURSE_MANAGE" — the server dispatcher
+ *      narrows tools to COURSE_MANAGE_TOOLS and the system prompt
+ *      switch-case routes through the DATA-mode template (page-context
+ *      builder picks up the snapshot).
+ *   2. Set EntityContext.pageContext = { page: "course", params: {
+ *      courseSnapshot } } — every /api/chat POST from this page carries
+ *      the snapshot.
+ *   3. Push a course entity breadcrumb so the assistant has the
+ *      conventional `entityContext` channel too.
+ *   4. Open the assistant on mount so the operator doesn't have to hit
+ *      Cmd+K — they came here to chat.
+ *
+ * On unmount: leave mode/pageContext alone — the user is navigating away,
+ * and Cmd+K elsewhere will reset to DATA via the existing route-change
+ * effects in EntityContext.
+ */
+interface ChatLauncherProps {
+  readonly courseId: string;
+  readonly courseName: string;
+  readonly snapshot: CourseSnapshot;
+}
+
+export function ChatLauncher({ courseId, courseName, snapshot }: ChatLauncherProps) {
+  const { setMode, mode } = useChatContext();
+  const { setPageContext, pushEntity } = useEntityContext();
+  const assistant = useGlobalAssistant();
+
+  useEffect(() => {
+    if (mode !== "COURSE_MANAGE") {
+      setMode("COURSE_MANAGE");
+    }
+    setPageContext("course", { courseSnapshot: snapshot });
+    pushEntity({
+      type: "playbook",
+      id: courseId,
+      label: courseName,
+      data: { snapshotKeys: Object.keys(snapshot.config) },
+    });
+    if (!assistant.isOpen) {
+      assistant.open();
+    }
+    // Run once on mount — snapshot is server-rendered and stable for
+    // this page render. router.refresh() after a tray apply re-renders
+    // the server component which re-mounts this with a fresh snapshot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}

--- a/apps/admin/app/x/courses/[courseId]/chat/ValuesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/chat/ValuesPanel.tsx
@@ -1,0 +1,127 @@
+import type { CourseSnapshot } from "./page";
+
+/**
+ * #1225 — RHS read-only render of the course's editable surface.
+ *
+ * Server component: receives the snapshot built by page.tsx, renders it
+ * as a typed list. After a successful chat apply, the page's
+ * router.refresh() re-runs page.tsx, which rebuilds the snapshot from
+ * the DB and re-renders this panel with new values.
+ *
+ * Intentionally minimal in v1 — no diff highlight (Phase 2 / #1223).
+ */
+interface ValuesPanelProps {
+  readonly snapshot: CourseSnapshot;
+}
+
+export function ValuesPanel({ snapshot }: ValuesPanelProps) {
+  const configEntries = Object.entries(snapshot.config);
+
+  return (
+    <div className="course-chat-values">
+      <section className="course-chat-values-section">
+        <h3 className="course-chat-values-section-title">Identity</h3>
+        <dl className="course-chat-values-dl">
+          <dt>Name</dt>
+          <dd>{snapshot.name}</dd>
+          <dt>Description</dt>
+          <dd>{snapshot.description ?? <em>—</em>}</dd>
+          <dt>Learners enrolled</dt>
+          <dd>{snapshot.learnerCount}</dd>
+        </dl>
+      </section>
+
+      <section className="course-chat-values-section">
+        <h3 className="course-chat-values-section-title">Curricula</h3>
+        <dl className="course-chat-values-dl">
+          <dt>Primary</dt>
+          <dd>
+            {snapshot.curricula.primary ? (
+              snapshot.curricula.primary.name
+            ) : (
+              <em>— (no primary set)</em>
+            )}
+          </dd>
+          <dt>Linked variants</dt>
+          <dd>
+            {snapshot.curricula.linked.length === 0 ? (
+              <em>none</em>
+            ) : (
+              <ul className="course-chat-values-list">
+                {snapshot.curricula.linked.map((c) => (
+                  <li key={c.id}>{c.name}</li>
+                ))}
+              </ul>
+            )}
+          </dd>
+        </dl>
+      </section>
+
+      <section className="course-chat-values-section">
+        <h3 className="course-chat-values-section-title">
+          Config ({configEntries.length})
+        </h3>
+        {configEntries.length === 0 ? (
+          <p className="course-chat-values-empty">No config keys set.</p>
+        ) : (
+          <dl className="course-chat-values-dl">
+            {configEntries.map(([key, value]) => (
+              <FragmentEntry key={key} k={key} v={value} />
+            ))}
+          </dl>
+        )}
+      </section>
+
+      <section className="course-chat-values-section">
+        <h3 className="course-chat-values-section-title">
+          Behaviour targets ({snapshot.behaviorTargets.length})
+        </h3>
+        {snapshot.behaviorTargets.length === 0 ? (
+          <p className="course-chat-values-empty">No behaviour targets set.</p>
+        ) : (
+          <table className="course-chat-values-table">
+            <thead>
+              <tr>
+                <th>Parameter</th>
+                <th>Scope</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {snapshot.behaviorTargets.map((bt) => (
+                <tr key={`${bt.parameterId}:${bt.scope}`}>
+                  <td>
+                    <code>{bt.parameterId}</code>
+                  </td>
+                  <td>{bt.scope}</td>
+                  <td>{bt.targetValue}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function FragmentEntry({ k, v }: { k: string; v: unknown }) {
+  let rendered: React.ReactNode;
+  if (v === null || v === undefined) {
+    rendered = <em>—</em>;
+  } else if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+    rendered = String(v);
+  } else {
+    rendered = (
+      <pre className="course-chat-values-json">{JSON.stringify(v, null, 2)}</pre>
+    );
+  }
+  return (
+    <>
+      <dt>
+        <code>{k}</code>
+      </dt>
+      <dd>{rendered}</dd>
+    </>
+  );
+}

--- a/apps/admin/app/x/courses/[courseId]/chat/course-chat.css
+++ b/apps/admin/app/x/courses/[courseId]/chat/course-chat.css
@@ -1,0 +1,128 @@
+/* #1225 — course-chat page styles. Uses HF design tokens. */
+
+.course-chat-shell {
+  padding-bottom: var(--space-6);
+}
+
+.course-chat-breadcrumb {
+  margin-bottom: var(--space-3);
+}
+
+.course-chat-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 980px) {
+  .course-chat-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.course-chat-pane {
+  background: var(--surface-1);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+}
+
+.course-chat-pane-header {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-default);
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.course-chat-pane-hint {
+  padding: var(--space-4);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.course-chat-pane-hint kbd {
+  background: var(--surface-2);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.course-chat-values {
+  padding: var(--space-4);
+  overflow-y: auto;
+}
+
+.course-chat-values-section {
+  margin-bottom: var(--space-5);
+}
+
+.course-chat-values-section-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-2);
+}
+
+.course-chat-values-dl {
+  display: grid;
+  grid-template-columns: minmax(120px, 32%) minmax(0, 1fr);
+  gap: var(--space-2) var(--space-3);
+  margin: 0;
+}
+
+.course-chat-values-dl dt {
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.course-chat-values-dl dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.course-chat-values-list {
+  margin: 0;
+  padding-left: var(--space-4);
+}
+
+.course-chat-values-empty {
+  color: var(--text-tertiary);
+  font-style: italic;
+  font-size: var(--text-sm);
+}
+
+.course-chat-values-json {
+  background: var(--surface-2);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  font-size: var(--text-xs);
+  overflow-x: auto;
+  margin: 0;
+}
+
+.course-chat-values-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.course-chat-values-table th,
+.course-chat-values-table td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.course-chat-values-table th {
+  font-weight: 600;
+  color: var(--text-secondary);
+}

--- a/apps/admin/app/x/courses/[courseId]/chat/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/chat/page.tsx
@@ -1,0 +1,165 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { AI_FORBIDDEN_FIELDS } from "@/lib/chat/ai-forbidden-fields";
+import { ChatLauncher } from "./ChatLauncher";
+import { ValuesPanel } from "./ValuesPanel";
+import "./course-chat.css";
+
+/**
+ * @page /x/courses/[courseId]/chat
+ *
+ * #1225 — course-aware Cmd+K surface. Two-pane:
+ *   LHS = the global ChatPanel (Cmd+K), forced into COURSE_MANAGE mode on
+ *         mount so the route.ts dispatcher narrows tools to
+ *         COURSE_MANAGE_TOOLS and the system prompt carries the snapshot.
+ *   RHS = ValuesPanel — a read-only render of the course's editable
+ *         surface, refreshed via router.refresh() after a tray apply.
+ *
+ * The snapshot is built server-side here from Playbook + PlaybookConfig
+ * + recent BehaviorTargets, then handed to ChatLauncher which writes it
+ * into EntityContext.pageContext.params.courseSnapshot. From there it
+ * rides on every /api/chat POST and the server's page-context.ts
+ * renders it into the prompt.
+ *
+ * Forbidden-field defence is layered: this page strips
+ * AI_FORBIDDEN_FIELDS.playbook from the snapshot before handing it down;
+ * parsePageContext on the server strips again on receipt; existing
+ * admin-tools-no-forbidden-fields meta-test catches any tool schema
+ * exposure.
+ *
+ * Auth: OPERATOR or above.
+ */
+export const dynamic = "force-dynamic";
+
+interface CourseSnapshot {
+  courseId: string;
+  name: string;
+  description: string | null;
+  config: Record<string, unknown>;
+  behaviorTargets: Array<{
+    parameterId: string;
+    scope: string;
+    targetValue: number;
+    updatedAt: string;
+  }>;
+  curricula: {
+    primary: { id: string; name: string } | null;
+    linked: Array<{ id: string; name: string }>;
+  };
+  learnerCount: number;
+}
+
+export default async function CourseChatPage({
+  params,
+}: {
+  params: Promise<{ courseId: string }>;
+}) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) {
+    redirect(`/login?callbackUrl=/x/courses/${(await params).courseId}/chat`);
+  }
+
+  const { courseId } = await params;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    include: {
+      behaviorTargets: {
+        select: {
+          parameterId: true,
+          scope: true,
+          targetValue: true,
+          updatedAt: true,
+        },
+        take: 50,
+        orderBy: { updatedAt: "desc" },
+      },
+      playbookCurricula: {
+        select: {
+          role: true,
+          curriculum: { select: { id: true, name: true } },
+        },
+      },
+      _count: { select: { enrollments: true } },
+    },
+  });
+
+  if (!playbook) notFound();
+
+  // Build the snapshot — keep it tight, only what the AI needs to propose
+  // informed deltas. Strip any top-level key in the forbidden set as a
+  // defensive belt; the server-side parsePageContext does the same on
+  // receipt.
+  const forbidden = new Set(AI_FORBIDDEN_FIELDS.playbook ?? []);
+  const rawConfig = (playbook.config as Record<string, unknown> | null) ?? {};
+  const safeConfig: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rawConfig)) {
+    if (!forbidden.has(k)) safeConfig[k] = v;
+  }
+
+  const primary = playbook.playbookCurricula.find((pc) => pc.role === "primary");
+  const linked = playbook.playbookCurricula.filter((pc) => pc.role === "linked");
+
+  const snapshot: CourseSnapshot = {
+    courseId: playbook.id,
+    name: playbook.name,
+    description: playbook.description ?? null,
+    config: safeConfig,
+    behaviorTargets: playbook.behaviorTargets.map((bt) => ({
+      parameterId: bt.parameterId,
+      scope: bt.scope,
+      targetValue: bt.targetValue,
+      updatedAt: bt.updatedAt.toISOString(),
+    })),
+    curricula: {
+      primary: primary ? primary.curriculum : null,
+      linked: linked.map((pc) => pc.curriculum),
+    },
+    learnerCount: playbook._count.enrollments,
+  };
+
+  return (
+    <main className="hf-page-shell course-chat-shell">
+      <nav aria-label="Breadcrumb" className="course-chat-breadcrumb">
+        <Link href={`/x/courses/${courseId}`} className="hf-btn hf-btn-secondary">
+          ← Back to course
+        </Link>
+      </nav>
+
+      <h1 className="hf-page-title">
+        Chat with <code>{playbook.name}</code>
+      </h1>
+      <p className="hf-page-subtitle">
+        The Cmd+K assistant on this page only sees tools that mutate this
+        course. Anything you propose lands in the pending-changes tray for
+        your review.
+      </p>
+
+      <ChatLauncher
+        courseId={courseId}
+        courseName={playbook.name}
+        snapshot={snapshot}
+      />
+
+      <section className="course-chat-grid">
+        <div className="course-chat-pane course-chat-pane--chat">
+          <div className="course-chat-pane-header">Chat</div>
+          <div className="course-chat-pane-hint">
+            Open the global assistant (<kbd>⌘K</kbd> or <kbd>Ctrl+K</kbd>) to
+            chat. The mode is forced to <code>COURSE_MANAGE</code> for this
+            page.
+          </div>
+        </div>
+
+        <div className="course-chat-pane course-chat-pane--values">
+          <div className="course-chat-pane-header">Current values</div>
+          <ValuesPanel snapshot={snapshot} />
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export type { CourseSnapshot };

--- a/apps/admin/contexts/ChatContext.tsx
+++ b/apps/admin/contexts/ChatContext.tsx
@@ -5,7 +5,7 @@ import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { EntityBreadcrumb, useEntityContext } from "./EntityContext";
 
-export type ChatMode = "DATA" | "TUNING";
+export type ChatMode = "DATA" | "TUNING" | "COURSE_MANAGE";
 export type ChatLayout = "vertical" | "horizontal" | "popout";
 export type TuningScope = "LEARNER" | "PLAYBOOK";
 
@@ -112,6 +112,16 @@ export const MODE_CONFIG: Record<ChatMode, { label: string; icon: string; color:
     color: "var(--accent-primary)",
     description: "Tune behaviour parameters for one learner or the whole course",
   },
+  // #1225 — Course-management mode. Mounted by /x/courses/[id]/chat; the
+  // ChatPanel renders identically to DATA mode but the route.ts dispatcher
+  // narrows the tool surface to COURSE_MANAGE_TOOLS and the system prompt
+  // carries the active course's full editable snapshot.
+  COURSE_MANAGE: {
+    label: "Course",
+    icon: "◎",
+    color: "var(--accent-primary)",
+    description: "Chat-driven editor for the active course — talks to course-relevant tools only",
+  },
 };
 
 function generateId(): string {
@@ -122,6 +132,7 @@ function createEmptyMessages(): Record<ChatMode, ChatMessage[]> {
   return {
     DATA: [],
     TUNING: [],
+    COURSE_MANAGE: [],
   };
 }
 
@@ -453,8 +464,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               isCommand: true,
               ...((mode === "DATA" || mode === "TUNING") && tuningScope ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
-              ...(pathname && (mode === "DATA" || mode === "TUNING") ? { pageHint: { route: pathname } } : {}),
-              ...(mode === "DATA" && entityContext.pageContext?.page
+              ...(pathname && (mode === "DATA" || mode === "TUNING" || mode === "COURSE_MANAGE") ? { pageHint: { route: pathname } } : {}),
+              ...((mode === "DATA" || mode === "COURSE_MANAGE") && entityContext.pageContext?.page
                 ? { pageContext: entityContext.pageContext }
                 : {}),
             }),
@@ -516,8 +527,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               conversationHistory: history,
               ...((mode === "DATA" || mode === "TUNING") && tuningScope ? { tuningScope } : {}),
               ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
-              ...(pathname && (mode === "DATA" || mode === "TUNING") ? { pageHint: { route: pathname } } : {}),
-              ...(mode === "DATA" && entityContext.pageContext?.page
+              ...(pathname && (mode === "DATA" || mode === "TUNING" || mode === "COURSE_MANAGE") ? { pageHint: { route: pathname } } : {}),
+              ...((mode === "DATA" || mode === "COURSE_MANAGE") && entityContext.pageContext?.page
                 ? { pageContext: entityContext.pageContext }
                 : {}),
               ...(trayReflections.length > 0 ? { trayReflections } : {}),

--- a/apps/admin/contexts/EntityContext.tsx
+++ b/apps/admin/contexts/EntityContext.tsx
@@ -17,7 +17,11 @@ export interface EntityBreadcrumb {
 
 interface PageContext {
   page: string;
-  params: Record<string, string>;
+  // #1225 — widened from Record<string, string> to allow structured
+  // payloads like courseSnapshot (Record<string, unknown>) when the
+  // operator is on /x/courses/[id]/chat. The server-side
+  // parsePageContext defensively shapes anything it sees.
+  params: Record<string, unknown>;
 }
 
 interface EntityContextState {
@@ -31,7 +35,7 @@ interface EntityContextActions {
   popEntity: () => void;
   clearToEntity: (entityId: string) => void;
   replaceEntity: (entity: EntityBreadcrumb) => void;
-  setPageContext: (page: string, params: Record<string, string>) => void;
+  setPageContext: (page: string, params: Record<string, unknown>) => void;
   reset: () => void;
 }
 
@@ -177,7 +181,7 @@ export function EntityProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
-  const setPageContext = useCallback((page: string, params: Record<string, string>) => {
+  const setPageContext = useCallback((page: string, params: Record<string, unknown>) => {
     setPageContextState({ page, params });
   }, []);
 


### PR DESCRIPTION
## Summary

- New `COURSE_MANAGE` chat mode on top of existing Cmd+K plumbing — narrows the AI's tool surface to course-relevant mutators only (16 of the 33 `ADMIN_TOOLS`) and injects a live course snapshot into the system prompt
- New thin page `/x/courses/[courseId]/chat` — server-component, server-rendered snapshot, split-pane (LHS Cmd+K assistant in COURSE_MANAGE mode, RHS read-only values panel)
- V5 wizard untouched. No new Prisma models. No new endpoints. No tray bypass.

Slice A of #1225. Slice B (new tools for last-7-days surfaces) and Slice C (extend existing meta-tests + 2 structural gaps) follow.

## Test plan

- [ ] On hf-dev: navigate to a course detail page → open `/x/courses/[id]/chat`
- [ ] Verify split-pane renders; RHS shows identity / curricula / config / behaviour targets
- [ ] Cmd+K opens; mode badge shows "Course"
- [ ] Type "what's this course's interaction pattern?" — AI reads snapshot, answers without calling a tool
- [ ] Type "change interaction pattern to coaching" — AI calls `update_playbook_config`, lands in #878 tray with `aiSuggested: true`
- [ ] Approve tray; RHS refreshes via `router.refresh()`, shows new value
- [ ] Try to call a tool not in `COURSE_MANAGE_TOOL_NAMES` (e.g. `update_caller`) — AI declines (tool isn't in the schema it received)

## Notes

- Reuses 100% of existing safety machinery: `ai-forbidden-fields.ts` meta-test (96 tests pass), `admin-tools-pending-change.test.ts` cascade contract, #878 tray's 5-layer guard, `scripts/check-fk-consistency.ts`
- `lib/chat/wizard-tool-executor.ts` line count unchanged
- Ready for `/vm-cp` (no schema, no deps)
- Pre-existing tsc clusters on main unchanged — none in Slice A files

🤖 Generated with [Claude Code](https://claude.com/claude-code)