### PR TITLE
fix(#1177): CallerDetailPage variant fan-out — calls/prompts include sibling Playbooks

### DIFF
--- a/apps/admin/app/api/playbooks/[playbookId]/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/route.ts
@@ -133,9 +133,30 @@ export async function GET(
         })
       : [];
 
+    // #1177 — variant Playbook sibling fan-out. Returns every Playbook
+    // sharing a Curriculum with this one (parent + linked variants),
+    // including this one. Used by UI surfaces that need to scope
+    // per-caller history (Calls, ComposedPrompts, etc.) across the whole
+    // variant family — e.g. CallerDetailPage's call-filter dropdown.
+    const ownCurricula = await prisma.playbookCurriculum.findMany({
+      where: { playbookId },
+      select: { curriculumId: true },
+    });
+    const curriculumIds = ownCurricula.map((r) => r.curriculumId);
+    const siblingRows = curriculumIds.length > 0
+      ? await prisma.playbookCurriculum.findMany({
+          where: { curriculumId: { in: curriculumIds } },
+          select: { playbookId: true },
+        })
+      : [];
+    const siblingPlaybookIds = Array.from(
+      new Set([playbookId, ...siblingRows.map((r) => r.playbookId)]),
+    );
+
     return NextResponse.json({
       ok: true,
       playbook: withSystemSpecs(playbook, resolvedSystemSpecs),
+      siblingPlaybookIds,
     });
   } catch (error: any) {
     console.error("Error fetching playbook:", error);

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -179,6 +179,11 @@ export default function CallerDetailPage() {
   type Enrollment = { id: string; playbookId: string; status: string; isDefault: boolean; enrolledAt: string; playbook: { id: string; name: string; status: string } };
   const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
   const [selectedPlaybookId, setSelectedPlaybookId] = useState<string>("all");
+  // #1177 — variant fan-out: when a variant Playbook is selected, the call
+  // filter must match the variant's sibling family (parent + linked variants
+  // sharing the Curriculum), not the variant alone. Populated by the
+  // /api/playbooks/[id] fetch below.
+  const [variantSiblingIds, setVariantSiblingIds] = useState<string[]>([]);
   // #253-follow-up: surface "Pick module" header button when the active
   // playbook has authored modules. Mirrors /x/sim/[callerId] wiring.
   const [modulesAuthored, setModulesAuthored] = useState<boolean>(false);
@@ -495,15 +500,27 @@ export default function CallerDetailPage() {
     return opts;
   }, [enrollments]);
 
+  // #1177 — variant fan-out: include calls/prompts from sibling Playbooks
+  // sharing the same Curriculum. Falls back to exact-match when sibling
+  // metadata hasn't loaded yet (the /api/playbooks/[id] fetch is async).
+  const callMatchSet = useMemo(() => {
+    if (selectedPlaybookId === "all") return null;
+    return new Set(
+      variantSiblingIds.length > 0 ? variantSiblingIds : [selectedPlaybookId],
+    );
+  }, [selectedPlaybookId, variantSiblingIds]);
+
   const filteredCalls = useMemo(() => {
-    if (!data?.calls || selectedPlaybookId === "all") return data?.calls || [];
-    return data.calls.filter((c) => c.playbookId === selectedPlaybookId);
-  }, [data?.calls, selectedPlaybookId]);
+    if (!data?.calls || !callMatchSet) return data?.calls || [];
+    return data.calls.filter((c) => c.playbookId && callMatchSet.has(c.playbookId));
+  }, [data?.calls, callMatchSet]);
 
   const filteredPrompts = useMemo(() => {
-    if (selectedPlaybookId === "all") return composedPrompts;
-    return composedPrompts.filter((p) => p.playbookId === selectedPlaybookId || !p.playbookId);
-  }, [composedPrompts, selectedPlaybookId]);
+    if (!callMatchSet) return composedPrompts;
+    return composedPrompts.filter(
+      (p) => !p.playbookId || callMatchSet.has(p.playbookId),
+    );
+  }, [composedPrompts, callMatchSet]);
 
   // #253-follow-up: load `modulesAuthored` from the active playbook's config
   // so the SimChat header shows the "Pick module" button when authored
@@ -511,6 +528,7 @@ export default function CallerDetailPage() {
   useEffect(() => {
     if (!selectedPlaybookId || selectedPlaybookId === "all") {
       setModulesAuthored(false);
+      setVariantSiblingIds([]);
       return;
     }
     let cancelled = false;
@@ -526,11 +544,21 @@ export default function CallerDetailPage() {
         } else {
           setAuthoredModules([]);
         }
+        // #1177 — variant fan-out: sibling Playbook IDs (parent + linked
+        // variants sharing a Curriculum). Used to widen the Calls/Prompts
+        // filter so a learner's history isn't hidden when a variant is
+        // selected instead of the parent.
+        if (Array.isArray(pbData.siblingPlaybookIds)) {
+          setVariantSiblingIds(pbData.siblingPlaybookIds as string[]);
+        } else {
+          setVariantSiblingIds([selectedPlaybookId]);
+        }
       })
       .catch(() => {
         if (!cancelled) {
           setModulesAuthored(false);
           setAuthoredModules([]);
+          setVariantSiblingIds([]);
         }
       });
     return () => {


### PR DESCRIPTION
## Bug

Operator screenshot: Levi Grant's Calls tab badge shows **"8"** but only "Bootstrap Prompt — Ready for Call 1" rendered. Cause: when a variant Playbook ("CIO/CTO Standard — Revision Aid") is selected, this client-side filter excludes calls on the parent Playbook (where the historical calls live):

```ts
data.calls.filter((c) => c.playbookId === selectedPlaybookId)
```

Per CC-A, variants share the **parent's Curriculum** — historical calls are tagged with the originating Playbook (often the parent). Variant's id never matches → all 8 calls disappear.

## Why it surfaced now

Pre-Slice-6 variant Playbooks were less navigable so this filter rarely fired on a variant context. #1212/#1216 made variants first-class — they now have their own URLs and load as `selectedPlaybookId`, exposing the pre-existing strict-equality bug.

## Fix

**`app/api/playbooks/[playbookId]/route.ts`** (GET) — returns new field `siblingPlaybookIds: string[]`: every Playbook sharing a Curriculum with this one (parent + linked variants + self). Two cheap PlaybookCurriculum queries.

**`components/callers/CallerDetailPage.tsx`** — new state `variantSiblingIds`, `callMatchSet` memo. `filteredCalls` and `filteredPrompts` consult the Set instead of strict equality. Graceful fallback: while sibling fetch in-flight, falls back to strict-equality (no regression).

## Regression proof

- Caller vitest: **69 / 69 passing**
- Zero new tsc errors (2 pre-existing `callerTargets` errors unchanged)
- Variant context now shows all calls across the variant family

## Note on duplicate commit

The same commit (`ae42ba03`) accidentally landed on `fix/922-vapi-call-stack-fixes` (concurrent-claude-session HEAD swap). This PR is the canonical standalone version. PR #1230 (voice work) can stay as-is; the duplicate is harmless after both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)