### PR TITLE
fix(#1177): show null-playbookId calls under any caller filter (Levi 10/0 → 10/10)

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -512,7 +512,13 @@ export default function CallerDetailPage() {
 
   const filteredCalls = useMemo(() => {
     if (!data?.calls || !callMatchSet) return data?.calls || [];
-    return data.calls.filter((c) => c.playbookId && callMatchSet.has(c.playbookId));
+    // Null-playbookId calls predate the per-call stamping feature; show them
+    // under every filter (the alternative — hiding them — leaves callers like
+    // Levi Grant with a "10 calls" badge and zero rows). Matches the same
+    // tolerance the filteredPrompts memo below already applies.
+    return data.calls.filter(
+      (c) => !c.playbookId || callMatchSet.has(c.playbookId),
+    );
   }, [data?.calls, callMatchSet]);
 
   const filteredPrompts = useMemo(() => {


### PR DESCRIPTION
## Bug

Levi Grant's Calls tab showed badge **"10"** but only the Bootstrap Prompt row. After my #1232 variant-fan-out fix, the badge still showed 10 — but the list was still empty.

## Root cause (deeper than #1232)

DB query: `SELECT pb.name, COUNT(call.id) FROM Call WHERE callerId = levi GROUP BY pb.name;`
```
 name | cnt
------+-----
      |  10
```

**All 10 of Levi's calls have `Call.playbookId = NULL`** — they predate the per-call playbook-stamping feature. Both the pre-#1232 strict-equality filter AND #1232's variant-aware Set filter exclude null-playbookId calls.

The badge counts `data.counts.calls` (raw row count from server). The list filters by playbookId match. Divergence → "10 calls" badge, zero rows visible.

## Fix

`filteredCalls` now treats null-playbookId calls as "any course":

```diff
- return data.calls.filter((c) => c.playbookId && callMatchSet.has(c.playbookId));
+ return data.calls.filter(
+   (c) => !c.playbookId || callMatchSet.has(c.playbookId),
+ );
```

Matches the tolerance `filteredPrompts` already has (line 522).

## Trade-off

- **PRO:** Legacy callers' history visible. Badge = list count.
- **CON:** When a caller has calls across multiple courses + some null-playbookId calls, the nulls appear under every course filter. Acceptable until null-playbookId becomes impossible at call-create time (separate backfill task).

## Regression proof
- Caller vitest: **69 / 69 passing**
- Zero tsc errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)