### PR TITLE
fix(transcript): recognise VAPI 'AI:' prefix — Learner/AI rows split correctly

### DIFF
--- a/apps/admin/components/callers/caller-detail/CallsPromptsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/CallsPromptsTab.tsx
@@ -138,10 +138,17 @@ function parseTranscript(transcript: string): { role: "user" | "assistant"; cont
   const messages: { role: "user" | "assistant"; content: string }[] = [];
   const lines = transcript.split("\n");
   let current: { role: "user" | "assistant"; content: string } | null = null;
+  // VAPI emits "AI: …" / "User: …" prefixes. Some legacy/sim transcripts
+  // use "Assistant: …". Match all three — without "AI:" the AI turns get
+  // silently appended to the previous user turn, collapsing the whole
+  // transcript into a single Learner block (the bug screenshot).
   for (const line of lines) {
     if (line.startsWith("User: ")) {
       if (current) messages.push(current);
       current = { role: "user", content: line.slice(6) };
+    } else if (line.startsWith("AI: ")) {
+      if (current) messages.push(current);
+      current = { role: "assistant", content: line.slice(4) };
     } else if (line.startsWith("Assistant: ")) {
       if (current) messages.push(current);
       current = { role: "assistant", content: line.slice(11) };


### PR DESCRIPTION
## Bug

Operator screenshot: Kai Foster's Call 2 transcript showed 6 turns ALL labelled LEARNER, even though content alternates ("Hi" / "Good to meet you, Kai…" / "I'm currently a full time CEO…" / "Right. So that's a really interesting transition…").

## Root cause

`CallsPromptsTab.parseTranscript()` only matched `User: ` and `Assistant: ` prefixes. VAPI uses `AI: ` for agent turns. `AI: …` lines fell through to the catch-all branch (`else if (current) current.content += line`) and got appended to the previous user message — collapsing the whole transcript into one Learner block.

Confirmed in DB: Kai's transcripts contain `AI: ` / `User: ` alternating, never `Assistant: `.

## Fix

Add `AI: ` branch (`line.slice(4)`) alongside the existing `Assistant: ` branch. Kept `Assistant: ` for legacy/sim compatibility.

## Regression proof
- Caller vitest: **69 / 69 passing**
- Zero tsc errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)