### PR TITLE
feat(transcripts): chat-bubble layout across Call + Tune tabs; SimChat AI: prefix fix

### DIFF
--- a/apps/admin/components/callers/caller-detail/calls-prompts-tab.css
+++ b/apps/admin/components/callers/caller-detail/calls-prompts-tab.css
@@ -363,16 +363,29 @@
   gap: 10px;
 }
 
+/* Chat-bubble layout — Learner right-aligned (accent), AI left-aligned
+   (neutral). Mirrors the SimChat WhatsApp pattern so the same transcript
+   reads the same way in every surface. */
 .cpt-msg {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  max-width: 78%;
+}
+.cpt-msg--user {
+  align-self: flex-end;
+  align-items: flex-end;
+}
+.cpt-msg--assistant {
+  align-self: flex-start;
+  align-items: flex-start;
 }
 .cpt-msg-role {
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
+  padding: 0 4px;
 }
 .cpt-msg-role--user {
   color: var(--accent-primary);
@@ -387,13 +400,15 @@
   white-space: pre-wrap;
   word-break: break-word;
   padding: 8px 12px;
-  border-radius: 8px;
+  border-radius: 12px;
 }
 .cpt-msg--user .cpt-msg-content {
-  background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+  background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+  border-top-right-radius: 4px;
 }
 .cpt-msg--assistant .cpt-msg-content {
   background: var(--surface-secondary);
+  border-top-left-radius: 4px;
 }
 
 /* ── Extraction ──────────────────────────────────── */

--- a/apps/admin/components/callers/caller-detail/prompts-section.css
+++ b/apps/admin/components/callers/caller-detail/prompts-section.css
@@ -822,38 +822,59 @@
 .ptr-transcript-empty {
   padding: 10px 14px;
 }
+/* Chat-bubble layout — Learner right-aligned (accent), AI left-aligned
+   (neutral). Mirrors SimChat + Call-tab transcript so the same conversation
+   reads the same way in every surface. */
 .ptr-transcript-inline {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px 14px 14px 14px;
-  background: var(--surface-secondary);
+  gap: 10px;
+  padding: 12px 16px 16px 16px;
+  background: var(--surface-primary);
   border-radius: 0 0 6px 6px;
   margin-top: -6px; /* tuck under the header */
   border-left: 4px solid color-mix(in srgb, var(--accent-primary) 70%, #000);
 }
 .ptr-transcript-msg {
-  display: grid;
-  grid-template-columns: 70px 1fr;
-  gap: 8px;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 78%;
   font-size: 13px;
   line-height: 1.5;
 }
-.ptr-transcript-msg--assistant .ptr-transcript-text {
-  color: var(--text-primary);
+.ptr-transcript-msg--user {
+  align-self: flex-end;
+  align-items: flex-end;
 }
-.ptr-transcript-msg--user .ptr-transcript-text {
-  color: var(--text-primary);
-  font-weight: 500;
+.ptr-transcript-msg--assistant {
+  align-self: flex-start;
+  align-items: flex-start;
 }
 .ptr-transcript-role {
   font-size: 10px;
   letter-spacing: 0.05em;
+  padding: 0 4px;
+}
+.ptr-transcript-msg--user .ptr-transcript-role {
+  color: var(--accent-primary);
+}
+.ptr-transcript-msg--assistant .ptr-transcript-role {
+  color: var(--status-success-text);
 }
 .ptr-transcript-text {
   white-space: pre-wrap;
   word-break: break-word;
+  padding: 8px 12px;
+  border-radius: 12px;
+}
+.ptr-transcript-msg--user .ptr-transcript-text {
+  background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+  border-top-right-radius: 4px;
+}
+.ptr-transcript-msg--assistant .ptr-transcript-text {
+  background: var(--surface-secondary);
+  border-top-left-radius: 4px;
 }
 .ptr-transcript-raw {
   padding: 10px 14px;

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -97,10 +97,16 @@ function parseTranscript(transcript: string): { role: 'user' | 'assistant'; cont
   const messages: { role: 'user' | 'assistant'; content: string }[] = [];
   const lines = transcript.split('\n');
   let current: { role: 'user' | 'assistant'; content: string } | null = null;
+  // VAPI transcripts use "AI: ", sim transcripts use "Assistant: ". Both map
+  // to the assistant role. #1236 fix applied here too — without "AI: " VAPI
+  // transcripts collapse into a single learner block when viewed through Sim.
   for (const line of lines) {
     if (line.startsWith('User: ')) {
       if (current) messages.push(current);
       current = { role: 'user', content: line.slice(6) };
+    } else if (line.startsWith('AI: ')) {
+      if (current) messages.push(current);
+      current = { role: 'assistant', content: line.slice(4) };
     } else if (line.startsWith('Assistant: ')) {
       if (current) messages.push(current);
       current = { role: 'assistant', content: line.slice(11) };


### PR DESCRIPTION
## Changes

### 1. Chat-bubble layout (Call tab + Tune tab transcripts)
Learner right-aligned with accent tint, AI left-aligned with neutral surface, max-width 78%. Matches the SimChat WhatsApp pattern so the same conversation reads the same way in every surface.

| Surface | Before | After |
|---|---|---|
| Call tab transcript (`cpt-msg`) | Stacked rows, same width/colour | Right-aligned Learner / left-aligned AI bubbles |
| Tune tab inline transcript (`ptr-transcript-msg`, #1237) | Grid label+text | Same chat-bubble pattern |
| SimChat (`wa-bubble`) | Already WhatsApp-style | Unchanged |

### 2. SimChat parser — recognise `AI: ` prefix
Same fix as #1236 in CallsPromptsTab. Without it, VAPI transcripts opened in Sim collapse into a single Learner block.

## Regression proof
- vitest (components/callers + components/sim): **69 / 69 passing**
- tsc: zero new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)