### PR TITLE
perf+fix(audit-A): Track A — caps, transaction, cron endpoint, partial index

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/route.ts
@@ -159,11 +159,13 @@ export async function GET(
         },
       }),
 
-      // Calls with analysis status
+      // Calls with analysis status. A1 — cap reduced 50 → 25; the audit
+      // measured ~250KB of transcripts on detail-page load for active
+      // learners and the UI's Recent Calls card only renders ~10 anyway.
       prisma.call.findMany({
         where: { callerId: callerId },
         orderBy: { createdAt: "desc" },
-        take: 50,
+        take: 25,
         select: {
           id: true,
           source: true,
@@ -265,9 +267,13 @@ export async function GET(
       // Includes currentScore (skill EMA — #417) + Parameter.config so the
       // caller-detail UI can render BandChip + band-descriptor drawers
       // without extra queries (#564 / #575).
+      // A1 — was uncapped; cap to the 200 most recently updated targets so a
+      // long-running learner doesn't drag the detail page proportional to
+      // their lifetime parameter count.
       prisma.callerTarget.findMany({
         where: { callerId: callerId },
         orderBy: { updatedAt: "desc" },
+        take: 200,
         select: {
           id: true,
           parameterId: true,
@@ -473,16 +479,20 @@ export async function GET(
       memoryCountsByCall.map((m) => [m.callId, m._count.id])
     );
 
-    // Get prompt status per call (which calls triggered a prompt)
-    const promptsByCall = await prisma.composedPrompt.findMany({
-      where: {
-        callerId: callerId,
-        triggerCallId: { not: null },
-      },
-      select: {
-        triggerCallId: true,
-      },
-    });
+    // Get prompt status per call (which calls triggered a prompt). A1 —
+    // was uncapped over the caller's lifetime; restrict to the calls we're
+    // actually returning so the work is bounded by `take` on the calls query
+    // above. Eliminates a tail-call scan on long-running learners.
+    const promptsByCall = calls.length > 0
+      ? await prisma.composedPrompt.findMany({
+          where: {
+            triggerCallId: { in: calls.map((c) => c.id) },
+          },
+          select: {
+            triggerCallId: true,
+          },
+        })
+      : [];
     const promptedCallIds = new Set(promptsByCall.map((p) => p.triggerCallId));
 
     // Transform calls to include analysis status

--- a/apps/admin/app/api/cron/cleanup-usage-events/route.ts
+++ b/apps/admin/app/api/cron/cleanup-usage-events/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+
+import { config } from "@/lib/config";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { cleanupOldUsageData } from "@/lib/metering/rollup";
+
+export const runtime = "nodejs";
+
+/**
+ * @api POST /api/cron/cleanup-usage-events
+ * @visibility internal
+ * @auth session ADMIN OR x-internal-secret (dual path)
+ * @tags cron, metering
+ * @description A7 / audit-fix Track A — nightly cleanup of stale UsageEvent
+ *   rows (default 30d retention) and hourly rollups (default 90d). The
+ *   underlying `cleanupOldUsageData` function existed in
+ *   `lib/metering/rollup.ts` but was never invoked from anywhere; per
+ *   the data-explosion audit, UsageEvent projects to ~30M rows / ~12 GB
+ *   at 10K learners × 12 months unless pruned.
+ *
+ *   **Triggering:** Cloud Scheduler → POST here once daily at 03:00 UTC
+ *   with header `x-internal-secret: $INTERNAL_API_SECRET`. See
+ *   `docs/audit/track-a-deployment-handoff.md` for the gcloud commands.
+ *
+ *   **Auth:** dual-path — either an ADMIN session cookie (manual
+ *   operator run for ad-hoc cleanup) OR an `x-internal-secret` header
+ *   matching `process.env.INTERNAL_API_SECRET`. Mirrors the existing
+ *   `voice/poll-stale-calls/route.ts` pattern.
+ * @body eventRetentionDays number - optional override for raw event TTL (default 30)
+ * @body hourlyRetentionDays number - optional override for hourly rollup TTL (default 90)
+ * @response 200 { ok: true, summary: { eventsDeleted, hourlyRollupsDeleted } }
+ * @response 401 { error: "Unauthorized" }
+ */
+export async function POST(request: Request) {
+  const internalSecret = request.headers.get("x-internal-secret");
+  const expectedSecret = config.security.internalApiSecret;
+  if (!(internalSecret && expectedSecret && internalSecret === expectedSecret)) {
+    const auth = await requireAuth("ADMIN");
+    if (isAuthError(auth)) return auth.error;
+  }
+
+  let body: { eventRetentionDays?: number; hourlyRetentionDays?: number } = {};
+  try {
+    body = (await request.json().catch(() => ({}))) as typeof body;
+  } catch {
+    // No body → defaults apply.
+  }
+
+  const summary = await cleanupOldUsageData({
+    eventRetentionDays: body.eventRetentionDays,
+    hourlyRetentionDays: body.hourlyRetentionDays,
+    verbose: false,
+  });
+
+  return NextResponse.json({ ok: true, summary });
+}

--- a/apps/admin/lib/prompt/composition/persist.ts
+++ b/apps/admin/lib/prompt/composition/persist.ts
@@ -5,7 +5,7 @@
  * Shared by both the compose-prompt API route and the pipeline COMPOSE stage.
  */
 
-import { db, type TxClient } from "@/lib/prisma";
+import { db, prisma, type TxClient } from "@/lib/prisma";
 import type { CompositionResult } from "./types";
 
 export interface PersistOptions {
@@ -68,8 +68,6 @@ export async function persistComposedPrompt(
     };
   }
 
-  const p = db(tx);
-
   // #599 Slice 1 — populate the recap cache column when the loader produced
   // a synthesized recap. The loader writes the AI call + audit row; persist
   // just stores the cached text alongside the new prompt row so subsequent
@@ -83,52 +81,66 @@ export async function persistComposedPrompt(
       }
     : undefined;
 
-  const composedPrompt = await p.composedPrompt.create({
-    data: {
-      callerId,
-      playbookId: playbookId || null,
-      prompt: promptSummary,
-      llmPrompt,
-      triggerType,
-      triggerCallId: triggerCallId || null,
-      model: "deterministic",
-      status: "active",
-      ...(recapSynthesisCache ? { recapSynthesisCache } : {}),
-      inputs: {
-        callerContext,
-        memoriesCount: loadedData.memories.length,
-        personalityAvailable: !!loadedData.personality,
-        recentCallsCount: loadedData.recentCalls.length,
-        behaviorTargetsCount: metadata.mergedTargetCount,
-        playbooksUsed: loadedData.playbooks.map((p: any) => p.name),
-        playbooksCount: loadedData.playbooks.length,
-        identitySpec: resolvedSpecs.identitySpec?.name || null,
-        contentSpec: null, // Removed in ADR-002
-        specUsed: composeSpecSlug || "(defaults)",
-        specConfig: specConfig || {},
-        composition: {
-          sectionsActivated: metadata.sectionsActivated,
-          sectionsSkipped: metadata.sectionsSkipped,
-          loadTimeMs: metadata.loadTimeMs,
-          transformTimeMs: metadata.transformTimeMs,
+  // A2 — the create-new-active + supersede-old-active pair MUST be atomic.
+  // Pre-fix, two concurrent recomposes could both finish their create()
+  // before either reached updateMany(), leaving two `status:"active"` rows
+  // for the same (callerId, playbookId). The downstream reader at
+  // /api/callers/[id]/active-playbook then picks one non-deterministically.
+  // When the caller already supplied a tx (rare: pipeline COMPOSE stage
+  // wraps a bigger commit), reuse it; otherwise open a fresh one.
+  const persist = async (client: TxClient): Promise<PersistedPrompt> => {
+    const composedPrompt = await client.composedPrompt.create({
+      data: {
+        callerId,
+        playbookId: playbookId || null,
+        prompt: promptSummary,
+        llmPrompt,
+        triggerType,
+        triggerCallId: triggerCallId || null,
+        model: "deterministic",
+        status: "active",
+        ...(recapSynthesisCache ? { recapSynthesisCache } : {}),
+        inputs: {
+          callerContext,
+          memoriesCount: loadedData.memories.length,
+          personalityAvailable: !!loadedData.personality,
+          recentCallsCount: loadedData.recentCalls.length,
+          behaviorTargetsCount: metadata.mergedTargetCount,
+          playbooksUsed: loadedData.playbooks.map((p: any) => p.name),
+          playbooksCount: loadedData.playbooks.length,
+          identitySpec: resolvedSpecs.identitySpec?.name || null,
+          contentSpec: null, // Removed in ADR-002
+          specUsed: composeSpecSlug || "(defaults)",
+          specConfig: specConfig || {},
+          composition: {
+            sectionsActivated: metadata.sectionsActivated,
+            sectionsSkipped: metadata.sectionsSkipped,
+            loadTimeMs: metadata.loadTimeMs,
+            transformTimeMs: metadata.transformTimeMs,
+          },
         },
       },
-    },
-  });
+    });
 
-  // Supersede previous active prompts for this caller, scoped to same playbook.
-  // A caller can have one active prompt per playbook (course) simultaneously.
-  await p.composedPrompt.updateMany({
-    where: {
-      callerId,
-      id: { not: composedPrompt.id },
-      status: "active",
-      ...(playbookId ? { playbookId } : { playbookId: null }),
-    },
-    data: {
-      status: "superseded",
-    },
-  });
+    // Supersede previous active prompts for this caller, scoped to same playbook.
+    // A caller can have one active prompt per playbook (course) simultaneously.
+    await client.composedPrompt.updateMany({
+      where: {
+        callerId,
+        id: { not: composedPrompt.id },
+        status: "active",
+        ...(playbookId ? { playbookId } : { playbookId: null }),
+      },
+      data: {
+        status: "superseded",
+      },
+    });
 
-  return composedPrompt as PersistedPrompt;
+    return composedPrompt as PersistedPrompt;
+  };
+
+  if (tx) {
+    return persist(db(tx));
+  }
+  return prisma.$transaction(async (innerTx) => persist(innerTx as TxClient));
 }

--- a/apps/admin/prisma/migrations/20260607114630_a8_caller_attribute_active_index/migration.sql
+++ b/apps/admin/prisma/migrations/20260607114630_a8_caller_attribute_active_index/migration.sql
@@ -1,0 +1,16 @@
+-- A8 / audit-fix Track A: partial index on the hot read path for the
+-- CallerAttribute append-only table. The table is append-with-tombstones
+-- (validUntil = NULL marks the live row, non-NULL marks superseded), and
+-- every adaptive-loop read filters validUntil IS NULL. As tombstone rows
+-- accumulate (one per ADAPT mutation per caller per key), the existing
+-- B-tree on (callerId, key) reads more tombstones than live rows for
+-- long-running learners. Partial index lets Postgres jump straight to
+-- the live tip.
+--
+-- IF NOT EXISTS so reruns and existing-env replays no-op. Not built
+-- CONCURRENTLY because Prisma wraps migrations in a transaction and
+-- CONCURRENTLY can't run inside one — same pattern as
+-- 20260606190000_1225_playbook_curriculum_one_primary.
+CREATE INDEX IF NOT EXISTS "CallerAttribute_active_idx"
+  ON "CallerAttribute" ("callerId", "key")
+  WHERE "validUntil" IS NULL;

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -44,6 +44,7 @@
   - [Course](#course)
   - [Course Pack](#course-pack)
   - [Courses](#courses)
+  - [Cron](#cron)
   - [Curricula](#curricula)
   - [Curriculum](#curriculum)
   - [Dashboard](#dashboard)
@@ -5961,6 +5962,31 @@ AI-suggests the best TeachingMode for a given course name.
 **Response** `200`
 ```json
 { ok, mode, confidence }
+```
+
+---
+
+## Cron
+
+### `POST` /api/cron/cleanup-usage-events
+
+A7 / audit-fix Track A — nightly cleanup of stale UsageEvent
+
+**Auth**: session ADMIN OR x-internal-secret (dual path)
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| eventRetentionDays | body | number | No | optional override for raw event TTL (default 30) |
+| hourlyRetentionDays | body | number | No | optional override for hourly rollup TTL (default 90) |
+
+**Response** `200`
+```json
+{ ok: true, summary: { eventsDeleted, hourlyRollupsDeleted } }
+```
+
+**Response** `401`
+```json
+{ error: "Unauthorized" }
 ```
 
 ---
@@ -15540,8 +15566,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 495 |
-| Files with annotations | 485 |
+| Route files found | 496 |
+| Files with annotations | 486 |
 | Files missing annotations | 10 |
 | Coverage | 98.0% |
 

--- a/docs/audit/b0-domain-migration-investigation.md
+++ b/docs/audit/b0-domain-migration-investigation.md
@@ -1,0 +1,128 @@
+# B0 — Domain table migration debt: investigation findings
+
+Status: investigation only. No implementation.
+
+Context: `.github/workflows/test.yml` line 188 currently runs `npx prisma migrate deploy` with `continue-on-error: true`. The flag exists because migration `20260213_expand_user_roles` adds a FK from `User.assignedDomainId` to `Domain.id`, but `Domain` has no `CREATE TABLE` migration anywhere — it was originally created by `prisma db push` on long-running envs. On a fresh CI DB the FK fails because Domain doesn't exist, which cascades into every subsequent migration not running. The PR-level pain is real: integration tests then run against a partial schema. Removing the flag is the goal of B0.
+
+## How many migrations touch Domain?
+
+8 migrations reference `Domain` or `DomainKind`. All are ALTER / ADD COLUMN / ADD CONSTRAINT — **none CREATE the table**. Chronological order, with what each does:
+
+| Migration | Operation |
+|---|---|
+| `20260213_expand_user_roles` | FK `User.assignedDomainId → Domain.id` (where the cascade fails on fresh DB) |
+| `20260214_add_caller_roles_and_cohorts` | FK `CohortGroup.domainId → Domain.id` |
+| `20260215_add_media_delivery` | FK `ChannelConfig.domainId → Domain.id` |
+| `20260220_add_institution_type_table` | `CREATE TYPE "DomainKind"` (enum) + `InstitutionType.defaultDomainKind` column |
+| `20260222_add_domain_kind_column` | `ALTER TABLE "Domain" ADD COLUMN "kind"` |
+| `20260225_community_config` | `ALTER TABLE "Domain" ADD COLUMN "config"` |
+| `20260302_add_lesson_plan_defaults` | `ALTER TABLE "Domain" ADD COLUMN "lessonPlanDefaults"` |
+| `20260525_825_compose_inputs_updated_at` | `ALTER TABLE "Domain" ADD COLUMN "composeInputsUpdatedAt"` |
+
+## What Domain looked like at 2026-02-13 (the FK reference point)
+
+By back-subtracting the four later `ADD COLUMN` migrations from the current schema, Domain at the moment `20260213_expand_user_roles` runs needs to have:
+
+```
+id                          TEXT PRIMARY KEY
+slug                        TEXT UNIQUE NOT NULL
+name                        TEXT NOT NULL
+description                 TEXT NULL
+isDefault                   BOOLEAN NOT NULL DEFAULT false
+isActive                    BOOLEAN NOT NULL DEFAULT true
+onboardingWelcome           TEXT NULL
+onboardingIdentitySpecId    TEXT NULL                   -- ⚠ FK target may not exist yet (see below)
+onboardingFlowPhases        JSONB NULL
+onboardingDefaultTargets    JSONB NULL
+institutionId               TEXT NULL                   -- ⚠ FK target does not exist yet (see below)
+createdAt                   TIMESTAMP NOT NULL DEFAULT NOW()
+updatedAt                   TIMESTAMP NOT NULL
+```
+
+Indexes that subsequent code/schema assumes exist by then: `slug`, `isDefault`, `isActive`, `onboardingIdentitySpecId`, `institutionId`. (The `kind` index comes later with the column.)
+
+## FK ordering landmines
+
+Two of Domain's fields point at tables whose own `CREATE TABLE` is later than 20260213:
+
+| Domain field | Target | First CREATE TABLE migration |
+|---|---|---|
+| `onboardingIdentitySpecId` | `AnalysisSpec.id` | **no CREATE TABLE anywhere** — also `db push`'d, same class of debt |
+| `institutionId` | `Institution.id` | `20260215_add_institution_branding` (2 days after) |
+
+Neither FK exists in the current schema as enforced — both fields are declared as plain `String?` in `prisma/schema.prisma` and the `@relation` is the only thing that knows about them. Prisma will only emit the FK constraint when generating a migration that adds it; no such migration was ever generated. So **the backfill just needs the columns, not the FK constraints**. Existing envs (where Domain was `db push`'d) don't have those FKs either, which is consistent.
+
+## Recommended fix shape (not implementing yet)
+
+One new migration named `20260212_backfill_create_domain` (sorts immediately before `20260213_expand_user_roles`). All SQL idempotent via `IF NOT EXISTS`:
+
+```sql
+-- 20260212_backfill_create_domain/migration.sql
+CREATE TABLE IF NOT EXISTS "Domain" (
+  "id"                       TEXT NOT NULL,
+  "slug"                     TEXT NOT NULL,
+  "name"                     TEXT NOT NULL,
+  "description"              TEXT,
+  "isDefault"                BOOLEAN NOT NULL DEFAULT false,
+  "isActive"                 BOOLEAN NOT NULL DEFAULT true,
+  "onboardingWelcome"        TEXT,
+  "onboardingIdentitySpecId" TEXT,
+  "onboardingFlowPhases"     JSONB,
+  "onboardingDefaultTargets" JSONB,
+  "institutionId"            TEXT,
+  "createdAt"                TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"                TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "Domain_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "Domain_slug_key"               ON "Domain"("slug");
+CREATE INDEX        IF NOT EXISTS "Domain_isDefault_idx"          ON "Domain"("isDefault");
+CREATE INDEX        IF NOT EXISTS "Domain_isActive_idx"           ON "Domain"("isActive");
+CREATE INDEX        IF NOT EXISTS "Domain_onboardingIdentitySpecId_idx" ON "Domain"("onboardingIdentitySpecId");
+CREATE INDEX        IF NOT EXISTS "Domain_institutionId_idx"      ON "Domain"("institutionId");
+```
+
+### Why this is safe on existing envs
+
+- `_prisma_migrations` table on hf_sandbox / hf_dev / hf_staging / pilot / prod does NOT have `20260212_backfill_create_domain`. `prisma migrate deploy` will try to apply it.
+- Domain already exists (was `db push`'d). `CREATE TABLE IF NOT EXISTS` is a no-op, and so are all the `CREATE INDEX IF NOT EXISTS` lines.
+- `_prisma_migrations` gains a row recording the migration as applied. Future `migrate deploy` runs are idempotent.
+
+### Why this works on CI (the fresh-DB case)
+
+- `prisma migrate deploy` applies migrations in directory-name lex order.
+- `20260212_backfill_create_domain` runs first, creates Domain.
+- `20260213_expand_user_roles` runs next, the `User.assignedDomainId → Domain.id` FK resolves.
+- Every subsequent migration that ALTERs Domain finds the table waiting.
+
+### Why we do NOT need to touch the FKs to Institution / AnalysisSpec
+
+The current schema doesn't declare those FKs as physical constraints — Prisma never generated them, so they're not in any migration. The backfill just creates the columns. If a future PR wants the FKs, that's a separate migration after Institution exists.
+
+## After the backfill lands
+
+Remove `continue-on-error: true` from `.github/workflows/test.yml` line 188 (the `Run Prisma migrations` step). Also consider the same for line 192 (`Seed specs`) — seeds will only succeed if migrate succeeds, so the flag is redundant once migrate is real. Leave line 196 (`Run integration tests`) alone for now — the existing test debt that produces those failures is outside B0 scope.
+
+## Risk summary
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Existing env disagrees with `IF NOT EXISTS` (column drift between db-push'd state and the backfill SQL) | Low | Run `prisma db pull` against hf_sandbox before drafting the SQL, diff against the recommended shape above, adjust if drift exists |
+| `_prisma_migrations` ordering check rejects the early-dated migration | Low | Prisma applies missing-from-DB migrations without strict order verification; sequence guarantees only matter for fresh applies, where this works |
+| Future `prisma migrate diff` confused by the inserted history | Low | The schema doesn't change — just adds a migration that brings history in line with what `prisma db push` did. Schema and migrations align after this lands. |
+| Side effect on `prisma migrate dev` workflows | Low | `migrate dev` re-applies all from scratch — backfill creates Domain cleanly. |
+| AnalysisSpec missing CREATE TABLE migration (same debt class) | Medium | **Not in B0 scope** — B0 is specifically about unblocking `migrate deploy` for CI. AnalysisSpec is referenced by Domain.onboardingIdentitySpecId as a column-only, no FK constraint. CI doesn't fail on AnalysisSpec today. Track as separate debt. |
+
+## Verification plan (before merging the eventual fix)
+
+1. Run `prisma db pull` against hf_sandbox, diff Domain shape against the recommended SQL, reconcile.
+2. On a fresh local Postgres: `prisma migrate deploy` from scratch — confirm exit 0, confirm schema matches `prisma db pull` output.
+3. On a clone of hf_sandbox: `prisma migrate deploy` — confirm idempotent (no errors, `_prisma_migrations` gains exactly one row).
+4. CI: remove `continue-on-error: true` from `Run Prisma migrations` step in `.github/workflows/test.yml`. Confirm subsequent CI runs go green on migrate.
+5. Smoke: confirm integration tests still run (they were continue-on-error too, but seed had to succeed).
+
+## Estimated cost
+
+- 1 new migration file, ~30 lines of SQL
+- 1 line removed from test.yml
+- Verification = run prisma db pull + diff + clone-and-test (~1h)
+- Total: ~2h, low blast radius

--- a/docs/audit/track-a-deployment-handoff.md
+++ b/docs/audit/track-a-deployment-handoff.md
@@ -1,0 +1,87 @@
+# Audit-fix Track A — operator handoff
+
+Status: code lands via PR. Two items below require **gcloud / Cloud Console action** to fully ship — they are not in the merge.
+
+## Shipped in the PR (no operator action needed)
+
+| # | Change | Files |
+|---|---|---|
+| A1 | Caller-detail route capped: `calls` 50 → 25; new `take: 200` on uncapped `callerTarget`; `composedPrompt` lookup scoped to the returned-call window | `app/api/callers/[callerId]/route.ts` |
+| A2 | ComposedPrompt demote-then-create wrapped in `$transaction` so two concurrent recomposes can't both stamp `status: "active"` | `lib/prompt/composition/persist.ts` |
+| A7 | New `POST /api/cron/cleanup-usage-events` endpoint wires the existing-but-unused `cleanupOldUsageData()` to a HTTP trigger (dual auth: ADMIN session OR `x-internal-secret`) | `app/api/cron/cleanup-usage-events/route.ts` |
+| A8 | Partial index `CallerAttribute_active_idx ON (callerId, key) WHERE validUntil IS NULL` | `prisma/migrations/20260607114630_a8_caller_attribute_active_index/migration.sql` |
+| B0 (investigation) | Findings doc for the Domain migration backfill — not yet implemented | `docs/audit/b0-domain-migration-investigation.md` |
+
+## Operator actions still needed
+
+### A3 — `DATABASE_URL` connection pool parameters
+
+The audit's concurrency stress test predicted the Cloud SQL pool dies at ~30 concurrent calls because Prisma defaults to one connection per Node instance, then multiplies by N Cloud Run instances, and Cloud SQL caps total connections. Adding `?connection_limit=5&pool_timeout=20` to `DATABASE_URL` makes the pool behaviour explicit and survivable.
+
+**For each env**, append the params to the existing `DATABASE_URL` secret value. Append, do not replace — the existing user / password / host / db is correct, you're just adding query params.
+
+```bash
+# DEV — hf-admin-dev → hf_sandbox
+gcloud secrets versions access latest --secret=DATABASE_URL_DEV   # read current
+# Then create a new version with the params appended:
+# postgresql://<user>:<pw>@<host>:5432/hf_sandbox?schema=public&connection_limit=5&pool_timeout=20
+echo -n 'postgresql://<paste-current>?schema=public&connection_limit=5&pool_timeout=20' \
+  | gcloud secrets versions add DATABASE_URL_DEV --data-file=-
+
+# Repeat for hf-admin-test (hf_staging) and hf-admin (hf_prod):
+#   gcloud secrets versions add DATABASE_URL_TEST --data-file=- < ...
+#   gcloud secrets versions add DATABASE_URL_PROD --data-file=- < ...
+```
+
+Cloud Run picks up secret changes on next deploy. Force a deploy with `gcloud run services update-traffic <service> --to-latest --region europe-west2` if needed.
+
+### A7 — Cloud Scheduler job for the cleanup endpoint
+
+The endpoint exists after this PR merges. Schedule it once daily at 03:00 UTC against each environment that should keep its UsageEvent volume in check:
+
+```bash
+# Replace <ENV-URL> with dev.humanfirstfoundation.com / test.humanfirstfoundation.com /
+# lab.humanfirstfoundation.com per the env.
+# Replace <SECRET> with `gcloud secrets versions access latest --secret=INTERNAL_API_SECRET`.
+
+gcloud scheduler jobs create http hf-cleanup-usage-events-dev \
+  --location=europe-west2 \
+  --schedule='0 3 * * *' \
+  --time-zone='UTC' \
+  --uri='https://dev.humanfirstfoundation.com/api/cron/cleanup-usage-events' \
+  --http-method=POST \
+  --headers="x-internal-secret=<SECRET>,Content-Type=application/json" \
+  --message-body='{}' \
+  --attempt-deadline='5m' \
+  --max-retry-attempts=2
+```
+
+Verify with a manual trigger:
+
+```bash
+gcloud scheduler jobs run hf-cleanup-usage-events-dev --location=europe-west2
+gcloud scheduler jobs describe hf-cleanup-usage-events-dev --location=europe-west2
+```
+
+The endpoint returns `{ ok: true, summary: { eventsDeleted, hourlyRollupsDeleted } }` — surfaced in Cloud Scheduler's job logs and `/api/metering/events` shortly after.
+
+## Verification after operator action
+
+| Action | Verify |
+|---|---|
+| A3 in dev | New `DATABASE_URL` version is `enabled`; `hf-admin-dev` deploy succeeds; concurrent-call sim (`scripts/sim-drive-call.ts` × 30) no longer trips `P1001 connection pool timeout` |
+| A3 in test/prod | Same checks, plus monitor Cloud SQL connection count for ~1 day post-deploy |
+| A7 in dev | After first scheduled run: `SELECT COUNT(*) FROM "UsageEvent" WHERE "createdAt" < NOW() - INTERVAL '30 days'` returns 0; the response body's `eventsDeleted` matches the prior count |
+| A7 in test/prod | Same; if 30d feels too aggressive, pass `eventRetentionDays` in the body via Cloud Scheduler `--message-body` |
+
+## Rollback
+
+| Action | Rollback |
+|---|---|
+| A3 | Revert `DATABASE_URL` to its previous version: `gcloud secrets versions disable <new-version> --secret=DATABASE_URL_DEV` |
+| A7 | `gcloud scheduler jobs delete hf-cleanup-usage-events-dev --location=europe-west2`. The endpoint code stays — no schema or behaviour change to undo. |
+
+## Owner / paging
+
+- **A3**: hf-platform on-call. Cloud SQL connection issues page on the existing `cloudsql.connections` alert.
+- **A7**: no paging — failure is benign (just no cleanup that day). Monitor weekly via the Cloud Scheduler job dashboard.


### PR DESCRIPTION
## Summary

Audit-fix Track A in 5 commits. Each addresses a specific finding from the parallel audits earlier in the session; A4 stays parked (multi-day prompt-builder refactor) and A5 already shipped via #1240.

| # | Title | Change | Files |
|---|---|---|---|
| A1 | Cap caller-detail route payloads | `calls` 50→25, `callerTarget` newly capped at 200, `composedPrompt` scoped to returned-call window | `app/api/callers/[callerId]/route.ts` |
| A2 | ComposedPrompt create+supersede atomic | Wrap the two writes in `$transaction` — kills the "two `status:active` rows" race for concurrent recomposes | `lib/prompt/composition/persist.ts` |
| A7 | HTTP trigger for `cleanupOldUsageData()` | New `POST /api/cron/cleanup-usage-events`, dual-auth (ADMIN session OR `x-internal-secret`) | `app/api/cron/cleanup-usage-events/route.ts` |
| A8 | Partial index on `CallerAttribute` live tip | `CREATE INDEX IF NOT EXISTS … WHERE validUntil IS NULL` | `prisma/migrations/20260607114630_a8_caller_attribute_active_index/` |
| docs | Operator handoff + B0 investigation | A3 (DATABASE_URL pool params) and A7 Cloud Scheduler wiring need gcloud action — documented for ops; B0 (Domain migration backfill) investigation findings parked for a future implementation PR | `docs/audit/track-a-deployment-handoff.md`, `docs/audit/b0-domain-migration-investigation.md` |

## Test plan

- [x] `tests/lib/learner-scope.test.ts` + `tests/lib/middleware-student-scope.test.ts` — 34/34 green (smoke that A2's transaction wrapping didn't break adjacent persistence code paths the auth surface uses)
- [x] `npx tsc --noEmit` on the 3 modified TS files — 0 new errors (the 4 pre-existing errors in `callers/[callerId]/route.ts` at lines 581/583/663/665 are unchanged shifted line numbers of the same pre-existing errors at 568/570/650/652)
- [ ] CI must include the new `npx prisma generate` step from #1242 — already on main
- [ ] On dev VM: `npx prisma migrate deploy` applies A8 cleanly (it's idempotent — IF NOT EXISTS)
- [ ] Manual: `curl -X POST -H 'x-internal-secret: $SECRET' http://localhost:3000/api/cron/cleanup-usage-events` returns `{ok: true, summary: {...}}`

## Operator follow-ups (NOT in this PR)

See `docs/audit/track-a-deployment-handoff.md`:
1. **A3** — append `?connection_limit=5&pool_timeout=20` to `DATABASE_URL` for hf-admin-dev / hf-admin-test / hf-admin.
2. **A7** — Cloud Scheduler job per env hitting the new endpoint daily at 03:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)