### PR TITLE
feat(voice): typed config cascade — Slice A of #1269 (#1270)

### DIFF
--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -26,6 +26,9 @@ import { updateDraft, findById as findIntakeSpecById } from "@/lib/intake/spec-s
 import { projectBodyFromEditable } from "@/lib/intake/crawcus-serde";
 import { parse as parseSpecSource, SpecParseError } from "@tallyseal/spec-emitter";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { cascadeableKeys, LOCKED_KEYS, SECRET_KEYS } from "@/lib/voice/config";
+import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
+import { getVoiceProvider } from "@/lib/voice/provider-factory";
 
 const MAX_RESULT_LENGTH = 3000;
 
@@ -2414,20 +2417,27 @@ async function handleUpdateVoiceConfig(input: Record<string, any>) {
   });
   if (!playbook) return { error: `Playbook ${playbookId} not found.` };
 
-  // Whitelist allowed keys + strip any attempt at writing a secret.
-  // #1241 — `autoPipeline` controls whether the post-call analysis pipeline
-  // runs automatically when a call ends. Cascade: Playbook.config.voice
-  // overrides SystemSetting `voice.auto_pipeline` (default true).
-  const ALLOWED = new Set(["provider", "model", "endedReasonOverride", "pollIntervalMs", "maxCostPerCallUsd", "autoPipeline"]);
+  // #1270 supersedes #1241 — ALLOWED set is now driven by the resolver's
+  // `cascadeableKeys` against the system-enabled VoiceProvider's
+  // `getConfigSchema()`. New fields auto-allow when the adapter schema
+  // gains them (Slice B will add voiceId, transcriber, etc.). `provider`
+  // and `model` are LOCKED at system level per the spike — explicitly
+  // dropped here, mirroring the resolver contract. autoPipeline (added
+  // by #1241) survives as a cross-cutting field via the resolver.
+  const sys = await getVoiceSystemSettings();
+  const enabledSlug = sys.defaultProviderSlug || "vapi";
+  const adapter = await getVoiceProvider(enabledSlug);
+  const allowedKeys = new Set(cascadeableKeys(adapter.getConfigSchema()));
   const sanitised: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(settings)) {
-    if (k === "modelSecret" || k === "secret" || k === "apiKey") continue;
-    if (ALLOWED.has(k)) sanitised[k] = v;
+    if (SECRET_KEYS.includes(k)) continue;
+    if (LOCKED_KEYS.includes(k)) continue;
+    if (allowedKeys.has(k)) sanitised[k] = v;
   }
   if (Object.keys(sanitised).length === 0) {
     return {
       error:
-        "No allowed voice settings provided. Allowed keys: provider, model, endedReasonOverride, pollIntervalMs, maxCostPerCallUsd, autoPipeline. Note: modelSecret is operator-only and not chat-editable.",
+        `No allowed voice settings provided. Allowed keys (for ${enabledSlug}): ${Array.from(allowedKeys).join(", ")}. Note: provider/model are system-locked; modelSecret is operator-only.`,
     };
   }
 

--- a/apps/admin/lib/chat/admin-tools.ts
+++ b/apps/admin/lib/chat/admin-tools.ts
@@ -828,22 +828,25 @@ export const ADMIN_TOOLS: AITool[] = [
   {
     name: "update_voice_config",
     description:
-      "Adjust voice configuration for a Playbook by merging into Playbook.config.voice. Allowed keys: provider (string), model (string), endedReasonOverride (string|null), pollIntervalMs (integer), maxCostPerCallUsd (number), autoPipeline (boolean — when true the post-call analysis pipeline runs automatically when the call ends; default true via SystemSetting). The model.secret field is DELIBERATELY not accepted — secret rotation is an operator-only flow. Bumps Playbook.composeInputsUpdatedAt.",
+      "Adjust voice configuration for a Playbook by merging into Playbook.config.voice. The ALLOWED key set is driven by the system-enabled VoiceProvider's getConfigSchema() PLUS cross-cutting HF keys (autoPipeline, silenceTimeoutSeconds, maxDurationSeconds, voicemailDetectionEnabled, endCallPhrases, maxCostPerCallUsd, pollIntervalMs, endedReasonOverride). #1270 — `provider` and `model` are LOCKED at system level and are NOT accepted (system picks the enabled VP; model is pinned per VP); `modelSecret` / `secret` / `apiKey` are DELIBERATELY not accepted — secret rotation is an operator-only flow. Bumps Playbook.composeInputsUpdatedAt.",
     input_schema: {
       type: "object",
       properties: {
         playbook_id: { type: "string" },
         settings: {
           type: "object",
-          description: "Voice settings to merge into config.voice (allowed keys above).",
+          description: "Voice settings to merge into config.voice. Validated against the resolver's cascadeable key set at handler time.",
           properties: {
-            provider: { type: "string" },
-            model: { type: "string" },
+            autoPipeline: { type: "boolean" },
             endedReasonOverride: { type: ["string", "null"] },
             pollIntervalMs: { type: "integer" },
             maxCostPerCallUsd: { type: "number" },
-            autoPipeline: { type: "boolean" },
+            silenceTimeoutSeconds: { type: "integer" },
+            maxDurationSeconds: { type: "integer" },
+            voicemailDetectionEnabled: { type: "boolean" },
+            endCallPhrases: { type: "array", items: { type: "string" } },
           },
+          additionalProperties: true,
         },
         reason: { type: "string" },
       },

--- a/apps/admin/lib/voice/config.ts
+++ b/apps/admin/lib/voice/config.ts
@@ -1,0 +1,214 @@
+/**
+ * Voice configuration cascade resolver (#1269 / #1270 Slice A).
+ *
+ * Four-layer cascade — System → enabled VoiceProvider → Domain → Course —
+ * with provenance tracking on every field. Pure function: every input is
+ * passed in, no DB calls, fully unit-testable. Callers (adapter wiring at
+ * `buildAssistantConfigForCaller`, end-of-call gates at `persistEndOfCall`)
+ * are responsible for the Prisma reads.
+ *
+ * The available override SURFACE flips with the system-enabled VoiceProvider:
+ * each adapter's `getConfigSchema()` declares its editable per-VP fields.
+ * Cross-cutting HF concepts (autoPipeline, silenceTimeoutSeconds, etc.)
+ * are orthogonal to the per-VP schema and cascade across providers.
+ *
+ * Two fields are **locked at system level** and explicitly excluded from
+ * Domain / Course overrides: `provider` (the enabled slug) and `model`.
+ * This is the spike decision recorded on #1270 — overriding the model
+ * provider at course level could silently bypass the HF custom-llm
+ * metering proxy. Locked here, in the chat tool ALLOWED set, and in the
+ * UI override surface.
+ */
+
+import type { ProviderConfigSchema } from "./types";
+
+/** Which layer supplied a resolved value. */
+export type VoiceConfigSource = "system" | "provider" | "domain" | "course";
+
+/** A single resolved field carries both value and provenance so callers
+ *  can render "comes from System / Provider / Domain / Course" without
+ *  re-running the cascade. */
+export interface ResolvedField<T = unknown> {
+  value: T;
+  source: VoiceConfigSource;
+}
+
+export interface ResolvedVoiceConfig {
+  /** Locked at system level — never overrideable at Domain or Course. */
+  provider: ResolvedField<string>;
+  /** Locked at system level — see header for rationale. */
+  model: ResolvedField<string | null>;
+  /** Every other cascadeable field, keyed by storage key. */
+  fields: Record<string, ResolvedField<unknown>>;
+}
+
+/** Cross-cutting HF fields that cascade across every voice provider. The
+ *  source-of-truth for default values is the System layer; per-provider
+ *  schemas don't redeclare these. Order doesn't matter — Set lookup. */
+const CROSS_CUTTING_KEYS = [
+  "autoPipeline",
+  "silenceTimeoutSeconds",
+  "maxDurationSeconds",
+  "voicemailDetectionEnabled",
+  "endCallPhrases",
+  "maxCostPerCallUsd",
+  "pollIntervalMs",
+  "endedReasonOverride",
+] as const;
+
+/** Keys that MUST NOT appear in Domain or Course override surfaces. The
+ *  Zod schema for the AI-writable surface and the admin tool ALLOWED set
+ *  both filter against this list. */
+export const LOCKED_KEYS: readonly string[] = ["provider", "model"];
+
+/** Keys that MUST NEVER be exposed to any reader — defence-in-depth on
+ *  top of the credentials/config split. */
+export const SECRET_KEYS: readonly string[] = ["modelSecret", "secret", "apiKey", "webhookSecret"];
+
+export interface ResolveVoiceConfigArgs {
+  /** Shape mirroring `VoiceSystemSettings` + the `voice.auto_pipeline`
+   *  SystemSetting. Callers normalise their reads into this object so the
+   *  resolver stays portable across the two storage locations. */
+  systemSettings: {
+    defaultProviderSlug: string;
+    autoPipeline: boolean;
+    silenceTimeoutSeconds: number;
+    maxDurationSeconds: number;
+    voicemailDetectionEnabled: boolean;
+    endCallPhrases: readonly string[];
+    maxCostPerCallUsd: number | null;
+    /** Optional — VoiceSystemSettings doesn't currently expose this; the
+     *  field is here so resolver tests can override the cascade default. */
+    pollIntervalMs?: number;
+  };
+  /** The VoiceProvider row + its declared schema. The schema is fetched
+   *  from `adapter.getConfigSchema()` at the call site. */
+  enabledProvider: {
+    slug: string;
+    /** Plain JSON from `VoiceProvider.config`. Per-VP defaults like
+     *  `voiceId`, `transcriber`, etc. land here once Slice B writes them
+     *  via `/x/settings/voice-providers/[id]`. */
+    config: Record<string, unknown>;
+    schema: ProviderConfigSchema;
+    /** Optional pinned model from `VoiceProvider.config.model` or the
+     *  adapter's own default. Locked here, not overrideable. */
+    model?: string | null;
+  };
+  /** `Domain.config.voice` blob — null if the domain hasn't set any
+   *  overrides yet. The resolver only reads keys that survive the
+   *  per-VP and cross-cutting whitelist. */
+  domainConfig?: Record<string, unknown> | null;
+  /** `Playbook.config.voice` blob — null when the course hasn't set any
+   *  overrides yet. Course wins over Domain wins over Provider wins over
+   *  System. */
+  courseConfig?: Record<string, unknown> | null;
+}
+
+/** Returns the set of cascadeable keys for the enabled VP. = cross-cutting
+ *  HF fields + per-VP schema fields, minus locked + sensitive + secret. */
+export function cascadeableKeys(schema: ProviderConfigSchema): string[] {
+  const perVp = schema.fields
+    .filter((f) => !f.sensitive)
+    .filter((f) => !LOCKED_KEYS.includes(f.key))
+    .filter((f) => !SECRET_KEYS.includes(f.key))
+    .map((f) => f.key);
+  return Array.from(new Set([...CROSS_CUTTING_KEYS, ...perVp]));
+}
+
+/** Look a key up in a raw config blob, returning undefined when absent
+ *  AND when the stored value is explicitly null (treat null as "cleared,
+ *  fall back to next layer" — supports the Clear-override UX). */
+function readKey(
+  blob: Record<string, unknown> | null | undefined,
+  key: string,
+): { found: boolean; value: unknown } {
+  if (!blob || !(key in blob)) return { found: false, value: undefined };
+  const v = blob[key];
+  if (v === undefined || v === null) return { found: false, value: undefined };
+  return { found: true, value: v };
+}
+
+/** Returns the resolved system-default for a cross-cutting key. */
+function systemDefaultFor(
+  key: string,
+  systemSettings: ResolveVoiceConfigArgs["systemSettings"],
+): unknown {
+  switch (key) {
+    case "autoPipeline":
+      return systemSettings.autoPipeline;
+    case "silenceTimeoutSeconds":
+      return systemSettings.silenceTimeoutSeconds;
+    case "maxDurationSeconds":
+      return systemSettings.maxDurationSeconds;
+    case "voicemailDetectionEnabled":
+      return systemSettings.voicemailDetectionEnabled;
+    case "endCallPhrases":
+      return systemSettings.endCallPhrases;
+    case "maxCostPerCallUsd":
+      return systemSettings.maxCostPerCallUsd;
+    case "pollIntervalMs":
+      return systemSettings.pollIntervalMs;
+    default:
+      return undefined;
+  }
+}
+
+export function resolveVoiceConfig(args: ResolveVoiceConfigArgs): ResolvedVoiceConfig {
+  const { systemSettings, enabledProvider, domainConfig, courseConfig } = args;
+
+  const provider: ResolvedField<string> = {
+    value: enabledProvider.slug,
+    source: "system",
+  };
+
+  const model: ResolvedField<string | null> = enabledProvider.model
+    ? { value: enabledProvider.model, source: "provider" }
+    : { value: null, source: "system" };
+
+  const fields: Record<string, ResolvedField<unknown>> = {};
+  const keys = cascadeableKeys(enabledProvider.schema);
+
+  for (const key of keys) {
+    const fromCourse = readKey(courseConfig, key);
+    if (fromCourse.found) {
+      fields[key] = { value: fromCourse.value, source: "course" };
+      continue;
+    }
+    const fromDomain = readKey(domainConfig, key);
+    if (fromDomain.found) {
+      fields[key] = { value: fromDomain.value, source: "domain" };
+      continue;
+    }
+    const fromProvider = readKey(enabledProvider.config, key);
+    if (fromProvider.found) {
+      fields[key] = { value: fromProvider.value, source: "provider" };
+      continue;
+    }
+    const sysVal = systemDefaultFor(key, systemSettings);
+    if (sysVal !== undefined) {
+      fields[key] = { value: sysVal, source: "system" };
+      continue;
+    }
+    // Last resort — schema-declared default for a per-VP field.
+    const schemaField = enabledProvider.schema.fields.find((f) => f.key === key);
+    if (schemaField?.default !== undefined) {
+      fields[key] = { value: schemaField.default, source: "provider" };
+    }
+    // Else: no value at any layer — omit the key. Callers tolerant via
+    // optional access.
+  }
+
+  return { provider, model, fields };
+}
+
+/** Convenience accessor — returns the raw value, dropping provenance. */
+export function flatten(resolved: ResolvedVoiceConfig): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    provider: resolved.provider.value,
+    model: resolved.model.value,
+  };
+  for (const [k, v] of Object.entries(resolved.fields)) {
+    out[k] = v.value;
+  }
+  return out;
+}

--- a/apps/admin/lib/voice/load-voice-config.ts
+++ b/apps/admin/lib/voice/load-voice-config.ts
@@ -1,0 +1,100 @@
+/**
+ * Voice config loader (#1269 / #1270 Slice A).
+ *
+ * Bridges the pure `resolveVoiceConfig` cascade with Prisma reads. Two
+ * entry points to keep call sites tidy:
+ *
+ *   `loadResolvedVoiceConfig({ callerId?, playbookId? })` — resolves the
+ *   full 4-layer cascade for an end-of-call gate or assistant-config
+ *   build. Caller / playbook nullable so unknown-caller paths get a
+ *   sane (system-default) shape.
+ *
+ *   `loadCascadeInputs({...})` — exposes the raw inputs so existing
+ *   callers that already fetched the VP row don't double-read. Falls
+ *   back to fetching anything not supplied.
+ *
+ * Call frequency: one call per end-of-call event (route-handlers
+ * autoPipeline gate) and per assistant-config build. Both are infrequent
+ * enough to absorb 3-4 small Prisma reads without batching concerns.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { getVoiceCallSettings, type VoiceCallSettings } from "@/lib/system-settings";
+import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
+import { getVoiceProvider } from "@/lib/voice/provider-factory";
+import { resolveVoiceConfig, type ResolvedVoiceConfig } from "@/lib/voice/config";
+
+interface LoadArgs {
+  callerId?: string | null;
+  playbookId?: string | null;
+}
+
+function extractVoiceBlob(blob: unknown): Record<string, unknown> | null {
+  if (!blob || typeof blob !== "object" || Array.isArray(blob)) return null;
+  const voice = (blob as Record<string, unknown>).voice;
+  if (!voice || typeof voice !== "object" || Array.isArray(voice)) return null;
+  return voice as Record<string, unknown>;
+}
+
+export async function loadResolvedVoiceConfig(args: LoadArgs): Promise<ResolvedVoiceConfig> {
+  const vs = await getVoiceCallSettings();
+  const sys = await getVoiceSystemSettings();
+  const enabledSlug = sys.defaultProviderSlug || vs.provider || "vapi";
+
+  const [vpRow, adapter, domainConfig, courseConfig] = await Promise.all([
+    prisma.voiceProvider.findUnique({
+      where: { slug: enabledSlug },
+      select: { slug: true, config: true },
+    }),
+    getVoiceProvider(enabledSlug),
+    args.callerId ? loadDomainVoice(args.callerId) : Promise.resolve(null),
+    args.playbookId ? loadPlaybookVoice(args.playbookId) : Promise.resolve(null),
+  ]);
+
+  return resolveVoiceConfig({
+    systemSettings: normaliseSystemSettings(vs, sys, enabledSlug),
+    enabledProvider: {
+      slug: enabledSlug,
+      config: (vpRow?.config as Record<string, unknown>) ?? {},
+      schema: adapter.getConfigSchema(),
+      model: vs.model ?? null,
+    },
+    domainConfig,
+    courseConfig,
+  });
+}
+
+async function loadDomainVoice(callerId: string): Promise<Record<string, unknown> | null> {
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { domain: { select: { config: true } } },
+  });
+  return extractVoiceBlob(caller?.domain?.config);
+}
+
+async function loadPlaybookVoice(playbookId: string): Promise<Record<string, unknown> | null> {
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { config: true },
+  });
+  return extractVoiceBlob(playbook?.config);
+}
+
+/** Maps the two existing system-level settings rows into the shape
+ *  `resolveVoiceConfig` expects. Single source of truth for the system
+ *  layer so every loader produces the same shape. */
+function normaliseSystemSettings(
+  vs: VoiceCallSettings,
+  sys: { silenceTimeoutSeconds: number; maxDurationSeconds: number; voicemailDetectionEnabled: boolean; endCallPhrases: string[]; maxCostPerCallUsd: number | null },
+  enabledSlug: string,
+) {
+  return {
+    defaultProviderSlug: enabledSlug,
+    autoPipeline: vs.autoPipeline,
+    silenceTimeoutSeconds: sys.silenceTimeoutSeconds,
+    maxDurationSeconds: sys.maxDurationSeconds,
+    voicemailDetectionEnabled: sys.voicemailDetectionEnabled,
+    endCallPhrases: sys.endCallPhrases,
+    maxCostPerCallUsd: sys.maxCostPerCallUsd ?? null,
+  };
+}

--- a/apps/admin/lib/voice/route-handlers.ts
+++ b/apps/admin/lib/voice/route-handlers.ts
@@ -56,6 +56,7 @@ import type {
 } from "@/lib/voice/types";
 import { startVoiceSpan, logVoiceEvent } from "@/lib/voice/telemetry";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
+import { loadResolvedVoiceConfig } from "@/lib/voice/load-voice-config";
 import { broadcastToCall } from "@/lib/voice/sse-registry";
 import { log } from "@/lib/logger";
 
@@ -751,26 +752,16 @@ export async function persistEndOfCall(
   // Pipeline gating per #1079: skip on bare "basic" — analysis will
   // arrive later and fire the pipeline against the merged row.
   //
-  // #1241 — Cascade: Playbook.config.voice.autoPipeline (per-Playbook
-  // override) → SystemSetting `voice.auto_pipeline` (instance default).
-  // Cmd+K writes the override via `update_voice_config`; the SystemSetting
-  // remains the global fallback (default true).
-  if (eventKind !== "basic") {
-    const vs = await getVoiceCallSettings();
-    let autoPipeline = vs.autoPipeline;
-    if (playbookId) {
-      const playbook = await prisma.playbook.findUnique({
-        where: { id: playbookId },
-        select: { config: true },
-      });
-      const voice = (playbook?.config as Record<string, unknown> | null)?.voice as
-        | Record<string, unknown>
-        | undefined;
-      if (voice && typeof voice.autoPipeline === "boolean") {
-        autoPipeline = voice.autoPipeline;
-      }
-    }
-    if (autoPipeline && callerId) {
+  // #1270 supersedes #1241 — autoPipeline now resolves through the
+  // 4-layer cascade: System → enabled VoiceProvider → Domain → Course.
+  // Course-level override (Playbook.config.voice.autoPipeline) wins;
+  // falls through to domain / VP / system. See lib/voice/config.ts.
+  // Pre-#1270 the gate hand-rolled a 2-layer system+playbook check;
+  // resolveVoiceConfig generalises that without losing behaviour.
+  if (eventKind !== "basic" && callerId) {
+    const resolved = await loadResolvedVoiceConfig({ callerId, playbookId });
+    const autoPipeline = resolved.fields.autoPipeline?.value === true;
+    if (autoPipeline) {
       triggerPipeline(newCall.id, callerId).catch((err) => {
         console.error(
           `[voice/${slug}/${sourceTag}] Pipeline trigger failed for call ${newCall.id}:`,

--- a/apps/admin/tests/lib/admin-tools-pending-change.test.ts
+++ b/apps/admin/tests/lib/admin-tools-pending-change.test.ts
@@ -58,6 +58,31 @@ vi.mock("@/lib/curriculum/resolve-playbook-for-curriculum", () => ({
   resolvePlaybookIdsForContentSource: vi.fn(async () => ["pb-1", "pb-2"]),
 }));
 
+// #1270 — `handleUpdateVoiceConfig` now reads the system-enabled VP and
+// its `getConfigSchema()` to drive the ALLOWED set. Stub both so the
+// happy path passes without needing a real VoiceProvider row + adapter.
+vi.mock("@/lib/voice/system-settings", () => ({
+  getVoiceSystemSettings: vi.fn(async () => ({
+    defaultProviderSlug: "vapi",
+    silenceTimeoutSeconds: 30,
+    maxDurationSeconds: 600,
+    voicemailDetectionEnabled: true,
+    endCallPhrases: ["goodbye"],
+    maxCostPerCallUsd: null,
+  })),
+}));
+vi.mock("@/lib/voice/provider-factory", () => ({
+  getVoiceProvider: vi.fn(async () => ({
+    slug: "vapi",
+    getConfigSchema: () => ({
+      fields: [
+        { key: "apiKey", label: "x", type: "string", sensitive: true },
+        { key: "voiceId", label: "Voice ID", type: "string", sensitive: false },
+      ],
+    }),
+  })),
+}));
+
 // BehaviorTarget writer (used by update_behavior_target handler)
 vi.mock("@/lib/agent-tuner/write-target", () => ({
   writeBehaviorTarget: vi.fn(async () => ({
@@ -354,46 +379,18 @@ describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () =
     });
   });
 
-  it("update_voice_config emits pendingChange against config.voice.* key", async () => {
+  it("update_voice_config emits pendingChange against config.voice.* key (#1270 cross-cutting key)", async () => {
+    // #1270 — `model` is now LOCKED at system level. Test uses
+    // `autoPipeline` (cross-cutting) which is always cascadeable.
     mockPrisma.playbook.findUnique.mockResolvedValue({
       id: "pb-1",
       name: "Sales 101",
-      config: { voice: { provider: "vapi", model: "claude-old" } },
-    });
-    const raw = await executeAdminTool(
-      "update_voice_config",
-      {
-        playbook_id: "pb-1",
-        settings: { model: "claude-opus-4-7" },
-        reason: "model bump",
-      },
-      "OPERATOR",
-    );
-    const result = JSON.parse(raw);
-    expect(result.ok).toBe(true);
-    expect(result.compose_inputs_bumped).toBe(true);
-    expect(result.pendingChange).toMatchObject({
-      key: "voice.model",
-      scope: "playbook",
-      scopeId: "pb-1",
-      beforeValue: "claude-old",
-      afterValue: "claude-opus-4-7",
-    });
-  });
-
-  // #1241 Slice 3 — autoPipeline must pass the ALLOWED whitelist and emit
-  // a pendingChange against `voice.autoPipeline`. Catches the regression
-  // where the key gets dropped from either the schema or the runtime set.
-  it("update_voice_config accepts autoPipeline (#1241)", async () => {
-    mockPrisma.playbook.findUnique.mockResolvedValue({
-      id: "pb-2",
-      name: "IELTS Speaking",
       config: { voice: { autoPipeline: true } },
     });
     const raw = await executeAdminTool(
       "update_voice_config",
       {
-        playbook_id: "pb-2",
+        playbook_id: "pb-1",
         settings: { autoPipeline: false },
         reason: "manual review for this play",
       },
@@ -401,17 +398,92 @@ describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () =
     );
     const result = JSON.parse(raw);
     expect(result.ok).toBe(true);
-    expect(result.updated_keys).toContain("autoPipeline");
-    // `buildPendingChangePayload.stringifyValue` coerces booleans + numbers
-    // to strings (tray UI renders one uniform diff). Caught by the
-    // auto-test on the VM after #1241 Slice 3 landed.
+    expect(result.compose_inputs_bumped).toBe(true);
     expect(result.pendingChange).toMatchObject({
       key: "voice.autoPipeline",
       scope: "playbook",
-      scopeId: "pb-2",
-      beforeValue: "true",
-      afterValue: "false",
+      scopeId: "pb-1",
+      beforeValue: true,
+      afterValue: false,
     });
+  });
+
+  it("update_voice_config REJECTS provider override (#1270 LOCKED_KEYS)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "Sales 101",
+      config: {},
+    });
+    const raw = await executeAdminTool(
+      "update_voice_config",
+      {
+        playbook_id: "pb-1",
+        settings: { provider: "retell" },
+        reason: "switch provider per course",
+      },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    // No fields survived sanitisation → handler returns error.
+    expect(result.error).toMatch(/No allowed voice settings/);
+  });
+
+  it("update_voice_config REJECTS model override (#1270 LOCKED_KEYS)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "Sales 101",
+      config: {},
+    });
+    const raw = await executeAdminTool(
+      "update_voice_config",
+      {
+        playbook_id: "pb-1",
+        settings: { model: "claude-opus-4-7" },
+        reason: "per-course model",
+      },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.error).toMatch(/No allowed voice settings/);
+  });
+
+  it("update_voice_config ACCEPTS per-VP schema field (voiceId on vapi)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "Sales 101",
+      config: {},
+    });
+    const raw = await executeAdminTool(
+      "update_voice_config",
+      {
+        playbook_id: "pb-1",
+        settings: { voiceId: "elevenlabs-rachel" },
+        reason: "course-specific voice",
+      },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.ok).toBe(true);
+    expect(result.updated_keys).toContain("voiceId");
+  });
+
+  it("update_voice_config REJECTS sensitive schema field (apiKey)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "pb-1",
+      name: "Sales 101",
+      config: {},
+    });
+    const raw = await executeAdminTool(
+      "update_voice_config",
+      {
+        playbook_id: "pb-1",
+        settings: { apiKey: "sk-leaked-via-chat" },
+        reason: "trying it",
+      },
+      "OPERATOR",
+    );
+    const result = JSON.parse(raw);
+    expect(result.error).toMatch(/No allowed voice settings/);
   });
 
   // Note: update_intake_spec_draft does NOT bump Playbook compose stamp

--- a/apps/admin/tests/lib/admin-tools-pending-change.test.ts
+++ b/apps/admin/tests/lib/admin-tools-pending-change.test.ts
@@ -399,12 +399,14 @@ describe("Admin tool handlers — pendingChange emission (#873 follow-up)", () =
     const result = JSON.parse(raw);
     expect(result.ok).toBe(true);
     expect(result.compose_inputs_bumped).toBe(true);
+    // `buildPendingChangePayload.stringifyValue` coerces primitives to
+    // strings (tray serialises everything as string for the diff UI).
     expect(result.pendingChange).toMatchObject({
       key: "voice.autoPipeline",
       scope: "playbook",
       scopeId: "pb-1",
-      beforeValue: true,
-      afterValue: false,
+      beforeValue: "true",
+      afterValue: "false",
     });
   });
 

--- a/apps/admin/tests/lib/voice/config.test.ts
+++ b/apps/admin/tests/lib/voice/config.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Voice config cascade resolver tests — #1269 / #1270 Slice A.
+ *
+ * Locks in the precedence contract (course > domain > provider > system),
+ * the locked-keys invariant (provider/model not overrideable), the
+ * secret-field exclusion, and the per-VP schema-driven cascadeable set.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveVoiceConfig,
+  cascadeableKeys,
+  flatten,
+  LOCKED_KEYS,
+  SECRET_KEYS,
+} from "@/lib/voice/config";
+import type { ProviderConfigSchema } from "@/lib/voice/types";
+
+const systemSettings = {
+  defaultProviderSlug: "vapi",
+  autoPipeline: true,
+  silenceTimeoutSeconds: 30,
+  maxDurationSeconds: 600,
+  voicemailDetectionEnabled: true,
+  endCallPhrases: ["goodbye", "bye"],
+  maxCostPerCallUsd: null as number | null,
+} as const;
+
+const vapiSchemaWithVoiceId: ProviderConfigSchema = {
+  fields: [
+    { key: "apiKey", label: "API Key", type: "string", sensitive: true },
+    { key: "voiceId", label: "Voice ID", type: "string", sensitive: false, default: "default-voice" },
+    { key: "transcriber", label: "Transcriber", type: "enum", enumValues: ["deepgram", "whisper"], sensitive: false },
+  ],
+};
+
+const enabledProvider = (overrides: Partial<{ config: Record<string, unknown>; model: string | null; schema: ProviderConfigSchema }> = {}) => ({
+  slug: "vapi",
+  config: overrides.config ?? {},
+  schema: overrides.schema ?? vapiSchemaWithVoiceId,
+  model: overrides.model,
+});
+
+describe("resolveVoiceConfig — basic cascade precedence", () => {
+  it("falls through to system default when no layer overrides", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider(),
+    });
+    expect(r.fields.autoPipeline.value).toBe(true);
+    expect(r.fields.autoPipeline.source).toBe("system");
+    expect(r.fields.silenceTimeoutSeconds.value).toBe(30);
+    expect(r.fields.silenceTimeoutSeconds.source).toBe("system");
+  });
+
+  it("provider config wins over system for cross-cutting fields", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider({ config: { silenceTimeoutSeconds: 45 } }),
+    });
+    expect(r.fields.silenceTimeoutSeconds.value).toBe(45);
+    expect(r.fields.silenceTimeoutSeconds.source).toBe("provider");
+  });
+
+  it("domain wins over provider", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider({ config: { silenceTimeoutSeconds: 45 } }),
+      domainConfig: { silenceTimeoutSeconds: 60 },
+    });
+    expect(r.fields.silenceTimeoutSeconds.value).toBe(60);
+    expect(r.fields.silenceTimeoutSeconds.source).toBe("domain");
+  });
+
+  it("course wins over everything", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider({ config: { silenceTimeoutSeconds: 45 } }),
+      domainConfig: { silenceTimeoutSeconds: 60 },
+      courseConfig: { silenceTimeoutSeconds: 90 },
+    });
+    expect(r.fields.silenceTimeoutSeconds.value).toBe(90);
+    expect(r.fields.silenceTimeoutSeconds.source).toBe("course");
+  });
+});
+
+describe("resolveVoiceConfig — null clears the override and falls through", () => {
+  it("course key set to null falls back to domain", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider(),
+      domainConfig: { autoPipeline: false },
+      courseConfig: { autoPipeline: null },
+    });
+    expect(r.fields.autoPipeline.value).toBe(false);
+    expect(r.fields.autoPipeline.source).toBe("domain");
+  });
+
+  it("domain key set to null falls back to provider", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider({ config: { autoPipeline: false } }),
+      domainConfig: { autoPipeline: null },
+    });
+    expect(r.fields.autoPipeline.value).toBe(false);
+    expect(r.fields.autoPipeline.source).toBe("provider");
+  });
+});
+
+describe("resolveVoiceConfig — per-VP schema fields", () => {
+  it("non-sensitive schema field cascades from course", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider(),
+      courseConfig: { voiceId: "custom-voice-1" },
+    });
+    expect(r.fields.voiceId.value).toBe("custom-voice-1");
+    expect(r.fields.voiceId.source).toBe("course");
+  });
+
+  it("schema field falls back to schema default when no layer provides", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider(),
+    });
+    expect(r.fields.voiceId.value).toBe("default-voice");
+    expect(r.fields.voiceId.source).toBe("provider");
+  });
+
+  it("sensitive schema fields are NOT cascadeable", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider({ config: { apiKey: "leaked-key" } }),
+      courseConfig: { apiKey: "another-leak" },
+    });
+    expect(r.fields.apiKey).toBeUndefined();
+  });
+});
+
+describe("resolveVoiceConfig — locked keys at system level", () => {
+  it("provider always equals enabled VP slug — domain/course can't override", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider(),
+      domainConfig: { provider: "retell" },
+      courseConfig: { provider: "openai-realtime" },
+    });
+    expect(r.provider.value).toBe("vapi");
+    expect(r.provider.source).toBe("system");
+    expect(r.fields.provider).toBeUndefined();
+  });
+
+  it("model is sourced from VP.config.model, never from course/domain", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider({ model: "claude-opus-4-7" }),
+      domainConfig: { model: "gpt-4o" },
+      courseConfig: { model: "claude-haiku-4-5" },
+    });
+    expect(r.model.value).toBe("claude-opus-4-7");
+    expect(r.model.source).toBe("provider");
+    expect(r.fields.model).toBeUndefined();
+  });
+
+  it("model is null when VP doesn't pin one — adapter falls back to its own default", () => {
+    const r = resolveVoiceConfig({ systemSettings, enabledProvider: enabledProvider() });
+    expect(r.model.value).toBeNull();
+    expect(r.model.source).toBe("system");
+  });
+
+  it("LOCKED_KEYS contract", () => {
+    expect(LOCKED_KEYS).toEqual(["provider", "model"]);
+  });
+});
+
+describe("cascadeableKeys", () => {
+  it("includes per-VP non-sensitive + cross-cutting; excludes sensitive + locked + secret", () => {
+    const keys = cascadeableKeys(vapiSchemaWithVoiceId);
+    expect(keys).toContain("voiceId");
+    expect(keys).toContain("transcriber");
+    expect(keys).toContain("autoPipeline");
+    expect(keys).toContain("silenceTimeoutSeconds");
+    expect(keys).not.toContain("apiKey"); // sensitive
+    expect(keys).not.toContain("provider"); // locked
+    expect(keys).not.toContain("model"); // locked
+  });
+
+  it("SECRET_KEYS contract enforced", () => {
+    const malicious: ProviderConfigSchema = {
+      fields: [
+        { key: "modelSecret", label: "x", type: "string" },
+        { key: "secret", label: "x", type: "string" },
+        { key: "apiKey", label: "x", type: "string" },
+        { key: "webhookSecret", label: "x", type: "string" },
+      ],
+    };
+    const keys = cascadeableKeys(malicious);
+    for (const k of SECRET_KEYS) {
+      expect(keys).not.toContain(k);
+    }
+  });
+});
+
+describe("flatten", () => {
+  it("returns plain object with provider/model/fields merged", () => {
+    const r = resolveVoiceConfig({
+      systemSettings,
+      enabledProvider: enabledProvider({ model: "claude-opus-4-7", config: { voiceId: "v1" } }),
+      courseConfig: { autoPipeline: false },
+    });
+    const flat = flatten(r);
+    expect(flat.provider).toBe("vapi");
+    expect(flat.model).toBe("claude-opus-4-7");
+    expect(flat.voiceId).toBe("v1");
+    expect(flat.autoPipeline).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1270. Part of #1269.

## Summary

- Pure `resolveVoiceConfig(...)` — 4-layer cascade (System → enabled VoiceProvider → Domain → Course) with per-field provenance tracking
- `provider` and `model` LOCKED at system level per the spike decision (no per-course override → no custom-llm proxy bypass)
- `SECRET_KEYS` contract excludes `modelSecret` / `secret` / `apiKey` / `webhookSecret` defence-in-depth on top of `ai-forbidden-fields.ts`
- `update_voice_config` admin tool ALLOWED set is now schema-driven via `cascadeableKeys(adapter.getConfigSchema())` — new fields auto-allow when Slice B adds voiceId / transcriber / backgroundSound etc.
- Server-side autoPipeline gate (`persistEndOfCall`) wired to the resolver, replacing the pre-existing 1-layer SystemSetting read and the post-#1241 2-layer hand-roll
- 16 vitests on the resolver + 4 new walking-set cases (provider REJECTED, model REJECTED, voiceId ACCEPTED, apiKey REJECTED)

## Commits

```
94ca5dc6  test fix: pendingChange values stringified
71ca1e0b  Schema-driven ALLOWED set + LOCKED_KEYS contract
ae90cc34  Wire autoPipeline gate to resolveVoiceConfig
f09b3e64  4-layer cascade resolver + locked-keys contract
```

## Breaking change

Operators who set `provider` or `model` per-course via Cmd+K now get a rejection with the new allowed-key list. Per the spike decision on #1270.

## Test plan

- [x] vitest — 16/16 voice/config.test.ts + 17/17 admin-tools-pending-change.test.ts (verified on hf-dev)
- [ ] Smoke after merge: Cmd+K on a course — set `voice.autoPipeline: false` → pending change → approve → next call's webhook skips the pipeline

## Deploy

`/vm-cp` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)