### PR TITLE
fix(config): typeof-window guard on evidenceFirstPlaybooks (unblock dev HMR after #1285)

### DIFF
--- a/apps/admin/lib/config.ts
+++ b/apps/admin/lib/config.ts
@@ -705,6 +705,19 @@ export const config = {
      */
     get evidenceFirstPlaybooks(): string[] {
       if (_evidenceFirstPlaybookCache !== null) return _evidenceFirstPlaybookCache;
+      // Server-only: a recent client-side import path (typed-config
+      // cascade in #1285) pulls `lib/config.ts` into the browser
+      // bundle. Without this guard, Next.js's client bundler tries to
+      // resolve `fs` and throws "Module not found: Can't resolve 'fs'"
+      // at compile time, breaking HMR on every sim/intake page.
+      // The getter is only meaningfully consulted server-side
+      // (pipeline + compose); on the client we short-circuit to an
+      // empty list — matches the fall-through value already used when
+      // the JSON file is absent.
+      if (typeof window !== "undefined") {
+        _evidenceFirstPlaybookCache = [];
+        return _evidenceFirstPlaybookCache;
+      }
       try {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const fs = require("fs") as typeof import("fs");


### PR DESCRIPTION
Hotfix for dev-mode breakage introduced when #1285's typed config cascade transitively pulled lib/config.ts into the client bundle. The existing require('fs') in evidenceFirstPlaybooks then threw 'Module not found' on every client compile, breaking HMR on all sim/intake pages. Surgical typeof-window guard short-circuits the client path to [] (matches existing 'file absent' fallback). Followup: factor server-only getters into lib/config-server.ts once #1285 stabilises.