### PR TITLE
feat(#1266): Course Design Console — Journey lenses (Slice 1 of #1263)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SessionFlowEditor } from '@/components/session-flow/SessionFlowEditor';
+import { CourseDesignConsole } from './_components/CourseDesignConsole';
 import { CourseSetupTracker } from '@/components/shared/CourseSetupTracker';
 import { BandingPicker } from '@/components/shared/BandingPicker';
 import { CollapsibleCard } from '@/components/shared/CollapsibleCard';
@@ -123,19 +123,15 @@ export function CourseDesignTab({
         </>
       )}
 
-      {/* ── Session Flow (canonical editor — absorbed from retired tab) ──
-          The Session Flow tab was retired in favour of one canonical editor
-          on the Design tab. SessionFlowEditor owns its own data fetching
-          (GET /api/courses/:id/session-flow) and persistence, so we mount it
-          directly — no prop plumbing, no duplicate state. */}
-      <CollapsibleCard
-        title="Session Flow"
-        hint="Before / during / after phases, intake, NPS, welcome"
-        defaultOpen
-        className="hf-mb-lg"
-      >
-        <SessionFlowEditor courseId={courseId} />
-      </CollapsibleCard>
+      {/* ── Course Design Console (#1263 / Slice 1 #1266) ──
+          Replaces the Session Flow CollapsibleCard with a lens-shell that
+          surfaces Intake / Onboarding / Stops / Offboarding / Welcome
+          journey lenses, plus 6 Behaviour lenses (Slice 2 — soon) and a
+          Preview lens (Slice 3 — soon). Reads + writes still go through
+          SessionFlowEditor → GET/PUT /api/courses/:id/session-flow. */}
+      <div className="hf-mb-lg">
+        <CourseDesignConsole courseId={courseId} />
+      </div>
 
       {/* ── Progress Signals controls (#784 S6 Section 1 — #779 + #780 namespaces;
           internally still the "Felt Progress" epic) ── */}

--- a/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+/**
+ * Course Design Console — Slice 1 of epic #1263.
+ *
+ * Mounts the shared `<ConsoleShell>` (Slice 0) on the Course Design tab
+ * with 12 lenses across three groups:
+ *
+ *   JOURNEY     (5, live in this slice)
+ *     intake, onboarding, stops, offboarding, welcome
+ *   BEHAVIOUR   (6, soon — Slice 2 absorbs them)
+ *     call1Mode, firstCallTargets, tolerances, skillBanding, progressSignals, agentTunerNlp
+ *   PREVIEW     (1, soon — Slice 3)
+ *     preview
+ *
+ * `soon` lenses surface in the nav so educators see the full surface from
+ * day one; clicking shows the shared "Coming soon" body with the blurb.
+ *
+ * URL state uses `?design_view=<id>` (distinct from Progress v2's `?view=`).
+ *
+ * Reads/writes: each lens mounts `<SessionFlowEditor activeSection="…">`
+ * which already routes through `resolveSessionFlow` (dual-read fallback)
+ * and `PUT /api/courses/:id/session-flow`. No parallel paths.
+ *
+ * Closes #1266.
+ */
+
+import React from "react";
+import {
+  GraduationCap,
+  Sparkles,
+  ClipboardCheck,
+  ThumbsUp,
+  MessageSquare,
+  Settings2,
+  Target,
+  Gauge,
+  Award,
+  Sliders,
+  Compass,
+  Eye,
+} from "lucide-react";
+import {
+  ConsoleShell,
+  useConsoleView,
+  type ConsoleLensDef,
+} from "@/components/shared/console-shell";
+import {
+  SessionFlowEditor,
+  type SessionFlowLens,
+} from "@/components/session-flow/SessionFlowEditor";
+
+type DesignLensId =
+  // Journey (live)
+  | "intake"
+  | "onboarding"
+  | "stops"
+  | "offboarding"
+  | "welcome"
+  // Behaviour (soon — Slice 2)
+  | "call1Mode"
+  | "firstCallTargets"
+  | "tolerances"
+  | "skillBanding"
+  | "progressSignals"
+  | "agentTunerNlp"
+  // Preview (soon — Slice 3)
+  | "preview";
+
+const DESIGN_LENS_ORDER: DesignLensId[] = [
+  "intake",
+  "onboarding",
+  "stops",
+  "offboarding",
+  "welcome",
+  "call1Mode",
+  "firstCallTargets",
+  "tolerances",
+  "skillBanding",
+  "progressSignals",
+  "agentTunerNlp",
+  "preview",
+];
+
+interface LensProps {
+  courseId: string;
+}
+
+const ICON_SIZE = 14;
+
+/** Journey-lens body — `<SessionFlowEditor>` scoped to one section. */
+function makeJourneyLens(section: SessionFlowLens): React.ComponentType<LensProps> {
+  const Lens: React.FC<LensProps> = ({ courseId }) => (
+    <SessionFlowEditor courseId={courseId} activeSection={section} />
+  );
+  Lens.displayName = `JourneyLens(${section})`;
+  return Lens;
+}
+
+const DESIGN_LENSES: Record<DesignLensId, ConsoleLensDef<LensProps>> = {
+  // ── Journey ─────────────────────────────────────────────
+  intake: {
+    id: "intake",
+    label: "Intake",
+    iconNode: <GraduationCap size={ICON_SIZE} />,
+    blurb: "Goals question, About You, Knowledge Check, AI Intro Call — what Call 1 asks the learner.",
+    Component: makeJourneyLens("intake"),
+  },
+  onboarding: {
+    id: "onboarding",
+    label: "Onboarding",
+    iconNode: <Sparkles size={ICON_SIZE} />,
+    blurb: "First-call structural template — phases, durations, goals.",
+    Component: makeJourneyLens("onboarding"),
+  },
+  stops: {
+    id: "stops",
+    label: "Session Stops",
+    iconNode: <ClipboardCheck size={ICON_SIZE} />,
+    blurb: "Pre-test / mid-test / post-test / NPS — the gated moments around teaching.",
+    Component: makeJourneyLens("stops"),
+  },
+  offboarding: {
+    id: "offboarding",
+    label: "Offboarding",
+    iconNode: <ThumbsUp size={ICON_SIZE} />,
+    blurb: "End-of-course wrap-up phases.",
+    Component: makeJourneyLens("offboarding"),
+  },
+  welcome: {
+    id: "welcome",
+    label: "Welcome message",
+    iconNode: <MessageSquare size={ICON_SIZE} />,
+    blurb: "First-line greeting the learner hears on call 1.",
+    Component: makeJourneyLens("welcome"),
+  },
+  // ── Behaviour (Slice 2 — soon) ──────────────────────────
+  call1Mode: {
+    id: "call1Mode",
+    label: "Call 1 Mode",
+    iconNode: <Settings2 size={ICON_SIZE} />,
+    blurb: "Onboarding / Teach Immediately / Baseline Assessment — what shape Call 1 takes.",
+  },
+  firstCallTargets: {
+    id: "firstCallTargets",
+    label: "First-call Targets",
+    iconNode: <Target size={ICON_SIZE} />,
+    blurb: "Per-course BEHAVIOR target overrides applied only to Call 1.",
+  },
+  tolerances: {
+    id: "tolerances",
+    label: "Tolerances",
+    iconNode: <Gauge size={ICON_SIZE} />,
+    blurb: "Course-default mastery threshold, retrieval cadence, memory decay.",
+  },
+  skillBanding: {
+    id: "skillBanding",
+    label: "Skill Banding",
+    iconNode: <Award size={ICON_SIZE} />,
+    blurb: "Per-course tier mapping override.",
+  },
+  progressSignals: {
+    id: "progressSignals",
+    label: "Progress Signals",
+    iconNode: <Sliders size={ICON_SIZE} />,
+    blurb: "Mid-call acknowledgement + structured offboarding summary.",
+  },
+  agentTunerNlp: {
+    id: "agentTunerNlp",
+    label: "Agent Tuner (NLP)",
+    iconNode: <Compass size={ICON_SIZE} />,
+    blurb: "Natural-language tuning of agent identity. Follow-on after Slice 2 ships.",
+  },
+  // ── Preview (Slice 3 — soon) ────────────────────────────
+  preview: {
+    id: "preview",
+    label: "Preview",
+    iconNode: <Eye size={ICON_SIZE} />,
+    blurb: "See the chat-bubble flow + composed prompt the learner would experience on Call 1, with deep-links to fix gaps.",
+  },
+};
+
+const DEFAULT_LENS: DesignLensId = "intake";
+
+function isDesignLensId(value: string | null | undefined): value is DesignLensId {
+  if (!value) return false;
+  return (DESIGN_LENS_ORDER as string[]).includes(value);
+}
+
+const COMING_SOON_HELP = (
+  <>
+    Use the cards below the console until this lens ships. Live progress on
+    epic <code>#1263</code>.
+  </>
+);
+
+export interface CourseDesignConsoleProps {
+  courseId: string;
+}
+
+export function CourseDesignConsole({
+  courseId,
+}: CourseDesignConsoleProps): React.ReactElement {
+  const { view, setView } = useConsoleView<DesignLensId>({
+    isValidId: isDesignLensId,
+    defaultId: DEFAULT_LENS,
+    paramName: "design_view",
+    consoleId: "course-design",
+  });
+
+  return (
+    <ConsoleShell<DesignLensId, LensProps>
+      lensOrder={DESIGN_LENS_ORDER}
+      lenses={DESIGN_LENSES}
+      lensProps={{ courseId }}
+      activeLensId={view}
+      onLensChange={setView}
+      ariaNavLabel="Course design lenses"
+      idPrefix="hf-course-design"
+      comingSoonHelpText={COMING_SOON_HELP}
+    />
+  );
+}

--- a/apps/admin/components/session-flow/SessionFlowEditor.tsx
+++ b/apps/admin/components/session-flow/SessionFlowEditor.tsx
@@ -87,13 +87,55 @@ interface RowSpec {
 
 type DrawerKind = null | "mode" | "kc-delivery" | "nps" | "welcome-msg" | "onboarding-phases" | "offboarding-phases";
 
+/**
+ * Lens scoping (Slice 1 of #1263 / story #1266).
+ *
+ * When `activeSection` is set, SessionFlowEditor renders ONLY the rows
+ * that belong to the named journey lens — the BEFORE / DURING / AFTER
+ * section headers and the editor's own header are hidden because
+ * `<ConsoleShell>` already provides surrounding context. When undefined
+ * (legacy callers), the full BEFORE/DURING/AFTER timeline renders.
+ */
+export type SessionFlowLens =
+  | "intake"
+  | "onboarding"
+  | "stops"
+  | "offboarding"
+  | "welcome";
+
+const ROW_TO_LENS: Record<string, SessionFlowLens> = {
+  goals: "intake",
+  "about-you": "intake",
+  "knowledge-check": "intake",
+  "ai-intro-call": "intake",
+  onboarding: "onboarding",
+  sessions: "stops",
+  "pre-test": "stops",
+  "mid-test": "stops",
+  "post-test": "stops",
+  nps: "stops",
+  offboarding: "offboarding",
+  "welcome-message": "welcome",
+};
+
+function rowsForLens(rows: RowSpec[], lens: SessionFlowLens | undefined): RowSpec[] {
+  if (!lens) return rows;
+  return rows.filter((r) => ROW_TO_LENS[r.id] === lens);
+}
+
 export type SessionFlowEditorProps = {
   courseId: string;
+  /**
+   * When set, only render rows belonging to the named lens. Used by
+   * `<CourseDesignConsole>` to surface one journey stage per panel.
+   * When omitted, the full BEFORE/DURING/AFTER timeline renders.
+   */
+  activeSection?: SessionFlowLens;
 };
 
 // ── Component ──────────────────────────────────────────────
 
-export function SessionFlowEditor({ courseId }: SessionFlowEditorProps) {
+export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditorProps) {
   const [data, setData] = useState<ApiResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -382,23 +424,57 @@ export function SessionFlowEditor({ courseId }: SessionFlowEditorProps) {
 
   const toggleRow = (id: string) => setExpandedId(prev => (prev === id ? null : id));
 
+  const beforeRows = rowsForLens(before, activeSection);
+  const duringRows = rowsForLens(during, activeSection);
+  const afterRows = rowsForLens(after, activeSection);
+  const isLensMode = activeSection !== undefined;
+
   return (
     <>
       <div className="sft">
-        <header className="sft-header">
-          <div className="sft-header-title">
-            <Settings2 size={16} />
-            <span>Session Flow</span>
-          </div>
-          <div className="sft-header-meta">
-            <span className="sft-pill">Mode: {mode}</span>
-            {teachingMode && <span className="sft-pill">Type: {teachingMode}</span>}
-          </div>
-        </header>
+        {!isLensMode && (
+          <header className="sft-header">
+            <div className="sft-header-title">
+              <Settings2 size={16} />
+              <span>Session Flow</span>
+            </div>
+            <div className="sft-header-meta">
+              <span className="sft-pill">Mode: {mode}</span>
+              {teachingMode && <span className="sft-pill">Type: {teachingMode}</span>}
+            </div>
+          </header>
+        )}
 
-        <Section title="BEFORE" rows={before} expandedId={expandedId} onToggle={toggleRow} onEdit={handleEdit} savingToggle={savingToggle} />
-        <Section title="DURING" rows={during} expandedId={expandedId} onToggle={toggleRow} onEdit={handleEdit} savingToggle={savingToggle} />
-        <Section title="AFTER" rows={after} expandedId={expandedId} onToggle={toggleRow} onEdit={handleEdit} savingToggle={savingToggle} />
+        {beforeRows.length > 0 && (
+          <Section
+            title={isLensMode ? null : "BEFORE"}
+            rows={beforeRows}
+            expandedId={expandedId}
+            onToggle={toggleRow}
+            onEdit={handleEdit}
+            savingToggle={savingToggle}
+          />
+        )}
+        {duringRows.length > 0 && (
+          <Section
+            title={isLensMode ? null : "DURING"}
+            rows={duringRows}
+            expandedId={expandedId}
+            onToggle={toggleRow}
+            onEdit={handleEdit}
+            savingToggle={savingToggle}
+          />
+        )}
+        {afterRows.length > 0 && (
+          <Section
+            title={isLensMode ? null : "AFTER"}
+            rows={afterRows}
+            expandedId={expandedId}
+            onToggle={toggleRow}
+            onEdit={handleEdit}
+            savingToggle={savingToggle}
+          />
+        )}
       </div>
 
       {drawer === "mode" && (
@@ -500,7 +576,7 @@ function PhaseListDrawer({
 function Section({
   title, rows, expandedId, onToggle, onEdit, savingToggle,
 }: {
-  title: string;
+  title: string | null;
   rows: RowSpec[];
   expandedId: string | null;
   onToggle: (id: string) => void;
@@ -509,7 +585,7 @@ function Section({
 }) {
   return (
     <div className="sft-section">
-      <h3 className="sft-section-title">{title}</h3>
+      {title !== null && <h3 className="sft-section-title">{title}</h3>}
       <ul className="sft-rows">
         {rows.map(row => (
           <Row

--- a/apps/admin/tests/components/courses/course-design-console.test.tsx
+++ b/apps/admin/tests/components/courses/course-design-console.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Slice 1 of epic #1263 — Course Design Console smoke tests.
+ *
+ * Covers:
+ *  - Console renders 12 lenses in the nav (5 Journey + 6 Behaviour + 1 Preview)
+ *  - Default lens on first paint is `intake`
+ *  - URL param is `?design_view=` not `?view=`
+ *  - Each Journey lens scope-filters SessionFlowEditor to the correct rows
+ *  - Dual-read fallback: a pre-migration course (welcome.* set, sessionFlow.intake
+ *    empty) still renders non-blank intake toggles — covered upstream by
+ *    `resolveSessionFlow` because the resolver maps `welcome.*` → `intake.*`
+ *    when the new shape is absent, and SessionFlowEditor consumes the resolved
+ *    response shape verbatim. This test asserts the wiring is intact.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, within } from "@testing-library/react";
+
+import { CourseDesignConsole } from "@/app/x/courses/[courseId]/_components/CourseDesignConsole";
+
+const replaceSpy = vi.fn();
+let currentDesignView: string | null = null;
+
+vi.mock("next/navigation", () => {
+  return {
+    useRouter: () => ({ replace: replaceSpy }),
+    useSearchParams: () => ({
+      get: (key: string) => (key === "design_view" ? currentDesignView : null),
+      toString: () =>
+        currentDesignView ? `design_view=${currentDesignView}` : "",
+    }),
+  };
+});
+
+// Synthetic resolved Session Flow response — represents a *post-migration*
+// course (sessionFlow.intake set, welcome legacy can be absent).
+function makeResolvedResponse(opts: {
+  intakeEnabled?: Partial<{
+    goals: boolean;
+    aboutYou: boolean;
+    knowledgeCheck: boolean;
+    aiIntroCall: boolean;
+  }>;
+  intakeShape?: "new" | "legacy-only";
+} = {}) {
+  const enabled = {
+    goals: opts.intakeEnabled?.goals ?? true,
+    aboutYou: opts.intakeEnabled?.aboutYou ?? true,
+    knowledgeCheck: opts.intakeEnabled?.knowledgeCheck ?? true,
+    aiIntroCall: opts.intakeEnabled?.aiIntroCall ?? false,
+  };
+  return {
+    ok: true,
+    sessionFlow: {
+      intake: {
+        goals: { enabled: enabled.goals },
+        aboutYou: { enabled: enabled.aboutYou },
+        knowledgeCheck: { enabled: enabled.knowledgeCheck, deliveryMode: "mcq" },
+        aiIntroCall: { enabled: enabled.aiIntroCall },
+      },
+      onboarding: { phases: [{ phase: "init-welcome", duration: "1 min", goals: ["Greet"] }] },
+      stops: [],
+      offboarding: { triggerAfterCalls: 0, phases: [] },
+      welcomeMessage: null,
+      source: {
+        intake: opts.intakeShape === "legacy-only" ? "legacy-welcome" : "new-shape",
+        onboarding: "playbook-legacy",
+        stops: "synthesized-from-legacy",
+        offboarding: "defaults",
+        welcomeMessage: "generic",
+      },
+    },
+    mode: "structured",
+    teachingMode: null,
+    sessionCount: 4,
+    courseName: "Fixture",
+    domainId: null,
+    domainName: null,
+  };
+}
+
+function mockSessionFlowFetch(response: ReturnType<typeof makeResolvedResponse>) {
+  const fetchSpy = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(response),
+  });
+  (global as { fetch: typeof fetch }).fetch = fetchSpy as unknown as typeof fetch;
+  return fetchSpy;
+}
+
+beforeEach(() => {
+  replaceSpy.mockReset();
+  currentDesignView = null;
+});
+
+describe("CourseDesignConsole — nav", () => {
+  it("renders 12 lenses in the nav (5 Journey + 6 Behaviour + 1 Preview)", () => {
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { container } = render(<CourseDesignConsole courseId="course-1" />);
+    const items = container.querySelectorAll(".hf-console-shell-nav-item");
+    expect(items.length).toBe(12);
+  });
+
+  it("renders a 'soon' badge on every non-Journey lens (7 = 6 Behaviour + 1 Preview)", () => {
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { container } = render(<CourseDesignConsole courseId="course-1" />);
+    const soon = container.querySelectorAll(".hf-console-shell-nav-soon");
+    expect(soon.length).toBe(7);
+  });
+
+  it("defaults to Intake when ?design_view= is absent", () => {
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { container } = render(<CourseDesignConsole courseId="course-1" />);
+    const active = container.querySelector(".hf-console-shell-nav-item--active");
+    expect(active?.textContent).toContain("Intake");
+  });
+
+  it("activates the lens pointed to by ?design_view=onboarding", () => {
+    currentDesignView = "onboarding";
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { container } = render(<CourseDesignConsole courseId="course-1" />);
+    const active = container.querySelector(".hf-console-shell-nav-item--active");
+    expect(active?.textContent).toContain("Onboarding");
+  });
+});
+
+describe("CourseDesignConsole — lens-scoped SessionFlowEditor", () => {
+  it("Intake lens renders the four intake rows when sessionFlow.intake is populated (new shape)", async () => {
+    currentDesignView = "intake";
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { findByText } = render(<CourseDesignConsole courseId="course-1" />);
+    // SessionFlowEditor is async (fetch + setData) — findByText awaits resolution.
+    await findByText("Goals question");
+    await findByText("About You");
+    await findByText("Knowledge Check");
+    await findByText("AI Intro Call");
+  });
+
+  it("Intake lens renders non-blank for a pre-migration course (welcome.* set, sessionFlow.intake empty)", async () => {
+    // The resolver collapses `welcome.*` into `sessionFlow.intake.*` shape via
+    // the `legacy-welcome` source path. The GET route returns the *resolved*
+    // shape, so the editor sees a populated intake object regardless of which
+    // legacy field the data lived in. This test asserts the dual-read wiring
+    // remains intact by feeding a `source.intake = "legacy-welcome"` payload.
+    currentDesignView = "intake";
+    mockSessionFlowFetch(
+      makeResolvedResponse({
+        intakeShape: "legacy-only",
+        intakeEnabled: { goals: true, aboutYou: false, knowledgeCheck: true, aiIntroCall: false },
+      }),
+    );
+    const { findByText, queryByText } = render(<CourseDesignConsole courseId="course-1" />);
+    // All four intake rows should render — none silently dropped because of
+    // the missing new shape.
+    await findByText("Goals question");
+    expect(queryByText("About You")).not.toBeNull();
+    expect(queryByText("Knowledge Check")).not.toBeNull();
+    expect(queryByText("AI Intro Call")).not.toBeNull();
+  });
+
+  it("Welcome lens renders only the Welcome message row", async () => {
+    currentDesignView = "welcome";
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { findByRole, queryByText } = render(<CourseDesignConsole courseId="course-1" />);
+    const panel = (await findByRole("tabpanel")) as HTMLElement;
+    await within(panel).findByText("Welcome message");
+    // Intake rows must NOT appear in the Welcome lens panel
+    expect(queryByText("Goals question")).toBeNull();
+    expect(queryByText("About You")).toBeNull();
+  });
+
+  it("Onboarding lens renders only the Onboarding row", async () => {
+    currentDesignView = "onboarding";
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { findByRole, queryByText } = render(<CourseDesignConsole courseId="course-1" />);
+    const panel = (await findByRole("tabpanel")) as HTMLElement;
+    await within(panel).findByText("Onboarding");
+    expect(queryByText("Goals question")).toBeNull();
+    // Welcome message row not present in this lens
+    expect(within(panel).queryByText("Welcome message")).toBeNull();
+  });
+
+  it("Offboarding lens renders only the Offboarding row", async () => {
+    currentDesignView = "offboarding";
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { findByRole, queryByText } = render(<CourseDesignConsole courseId="course-1" />);
+    const panel = (await findByRole("tabpanel")) as HTMLElement;
+    await within(panel).findByText("Offboarding");
+    expect(queryByText("Goals question")).toBeNull();
+  });
+});
+
+describe("CourseDesignConsole — soon lens behaviour", () => {
+  it("Behaviour lens shows the Coming soon body when clicked", async () => {
+    currentDesignView = "call1Mode";
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { findByRole } = render(<CourseDesignConsole courseId="course-1" />);
+    const panel = (await findByRole("tabpanel")) as HTMLElement;
+    await within(panel).findByText("Coming soon");
+    await within(panel).findByRole("heading", { name: "Call 1 Mode" });
+  });
+
+  it("Preview lens shows the Coming soon body when clicked", async () => {
+    currentDesignView = "preview";
+    mockSessionFlowFetch(makeResolvedResponse());
+    const { findByRole } = render(<CourseDesignConsole courseId="course-1" />);
+    const panel = (await findByRole("tabpanel")) as HTMLElement;
+    await within(panel).findByText("Coming soon");
+    await within(panel).findByRole("heading", { name: "Preview" });
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of epic #1263. Replaces the Session Flow CollapsibleCard on the Course Design tab with a 12-lens console mounted on the shared `<ConsoleShell>` from Slice 0 (#1280).

## Lens layout

**Journey (live):** Intake / Onboarding / Stops / Offboarding / Welcome message
**Behaviour (soon — Slice 2):** Call 1 Mode / First-call Targets / Tolerances / Skill Banding / Progress Signals / Agent Tuner (NLP)
**Preview (soon — Slice 3):** Preview

Each Journey lens mounts `<SessionFlowEditor activeSection=\"…\">` scoped to the right rows. URL param: `?design_view=<id>` (distinct from Progress v2's `?view=` so the two shells can coexist on a future page).

## TL flags honoured

- **Dual-read fallback:** all reads route through `GET /api/courses/:id/session-flow` which calls `resolveSessionFlow` — that already maps `welcome.*` → `sessionFlow.intake.*` for pre-migration courses. A vitest covers the wiring by feeding `source.intake = \"legacy-welcome\"` and asserting all four intake rows render.
- **No parallel write paths:** every save routes through `PUT /api/courses/:id/session-flow` which mirrors `sessionFlow.*` ↔ legacy fields (the mirror landed in #1279).
- **`resolveSessionFlow` is the only read path** — no direct `Playbook.config.sessionFlow.*` access.

## Test plan

- [x] Vitest: 11 cases in `tests/components/courses/course-design-console.test.tsx` — all pass
- [x] Type-check: no new tsc errors caused by this change (pre-existing failures in `CourseDesignTab.tsx`, `CourseOverviewTab.tsx`, `page.tsx`, `courses/page.tsx` unrelated)
- [x] Lint: clean on touched files
- [ ] Manual: visit `/x/courses/<id>?tab=design` on hf_dev → console renders with Intake as default lens; nav highlights active lens; deep-link `?design_view=stops` lands on Session Stops; `soon` lenses show Coming-soon body
- [ ] Manual: legacy SessionFlowEditor consumers (e.g. SessionFlowProgress on caller page) unaffected — full BEFORE/DURING/AFTER timeline still renders when `activeSection` is omitted

## What's still in CourseDesignTab as CollapsibleCards

Progress Signals, Call 1 / First Session, Tolerances, Skill Banding — Slice 2 absorbs them.

## Out of scope

- Behaviour lenses content (#1267 — Slice 2)
- Preview lens (#1268 — Slice 3)
- AgentTuner NLP scope (#1276 — follow-on)
- Mobile <768px icon-only nav — out of scope per epic

Closes #1266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)