### PR TITLE
feat(identity): admin escape hatch — OPERATOR+ can skip the PIN gate

### DIFF
--- a/apps/admin/app/api/identity/challenge-skip/route.ts
+++ b/apps/admin/app/api/identity/challenge-skip/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+
+const bodySchema = z
+  .object({
+    callerId: z.string().min(1),
+  })
+  .strict();
+
+/**
+ * @api POST /api/identity/challenge-skip
+ * @visibility internal (OPERATOR+)
+ * @auth session (OPERATOR / ADMIN / SUPERADMIN)
+ * @description Admin escape hatch: mark a caller's most-recent
+ * unverified `CallerIdentityChallenge` as verified WITHOUT requiring
+ * the 6-digit PIN. The intended use is admins testing or supporting a
+ * learner on the first-call sign-in screen — same end state as a
+ * correct PIN entry (challenge.verifiedAt set, FirstCallPinGate
+ * onVerified path runs, the rest of the flow continues).
+ *
+ * Strictly OPERATOR+. `requireAuth("OPERATOR")` admits OPERATOR,
+ * EDUCATOR (same level), ADMIN, and SUPERADMIN; refuses STUDENT,
+ * VIEWER, TESTER, DEMO with 401.
+ *
+ * Lockout: an active 24h lockout does NOT block the skip (the
+ * skip's whole point is to bypass auth friction). The audit row
+ * does record the unlock, however.
+ *
+ * Audit: emits a `[identity/skip]` console.warn with the admin's
+ * userId, the target callerId, and a timestamp so the action is
+ * visible in dev/staging/prod logs. A formal AuditLog entry could
+ * be added once we have a shared audit-event table — out of scope.
+ *
+ * @response 200 { ok: true, challengeId: string }
+ * @response 200 { ok: false, noActiveChallenge: true } — no unverified challenge to skip; admin should request a fresh resend first
+ * @response 400 { ok: false, error: string }
+ * @response 401 — caller not authenticated or not OPERATOR+
+ */
+export async function POST(req: Request) {
+  const authResult = await requireAuth("OPERATOR");
+  if (isAuthError(authResult)) return authResult.error;
+
+  const body = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+  const { callerId } = parsed.data;
+
+  const challenge = await prisma.callerIdentityChallenge.findFirst({
+    where: { callerId, verifiedAt: null },
+    orderBy: { issuedAt: "desc" },
+    select: { id: true },
+  });
+  if (!challenge) {
+    return NextResponse.json({ ok: false, noActiveChallenge: true });
+  }
+
+  await prisma.callerIdentityChallenge.update({
+    where: { id: challenge.id },
+    data: { verifiedAt: new Date() },
+  });
+
+  console.warn(
+    `[identity/skip] OPERATOR+ session marked challenge ${challenge.id} verified — admin=${authResult.session.user.id} (${authResult.session.user.role}) caller=${callerId} at ${new Date().toISOString()}`,
+  );
+
+  return NextResponse.json({ ok: true, challengeId: challenge.id });
+}

--- a/apps/admin/components/identity/FirstCallPinGate.tsx
+++ b/apps/admin/components/identity/FirstCallPinGate.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { useSession } from 'next-auth/react';
 
 interface FirstCallPinGateProps {
   callerId: string;
@@ -8,6 +9,16 @@ interface FirstCallPinGateProps {
   callerFirstName?: string;
   onVerified: () => void;
 }
+
+// OPERATOR+ levels for the admin escape hatch. SUPER_TESTER and TESTER
+// stay below the cut so they still go through the real PIN flow when
+// testing the auth UX itself.
+const ADMIN_SKIP_ROLES = new Set([
+  'OPERATOR',
+  'EDUCATOR',
+  'ADMIN',
+  'SUPERADMIN',
+]);
 
 type VerifyStatus =
   | { kind: 'idle' }
@@ -44,8 +55,21 @@ export function FirstCallPinGate({
   const [resendStatus, setResendStatus] = useState<ResendStatus>({ kind: 'idle' });
   const [successCopyVisible, setSuccessCopyVisible] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
+  const [adminSkipPending, setAdminSkipPending] = useState(false);
+  const [adminSkipError, setAdminSkipError] = useState<string | null>(null);
   const cooldownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const successFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Admin escape hatch: OPERATOR+ session sees a secondary action that
+  // marks the challenge verified without entering a PIN. Same end state
+  // as a correct PIN (onVerified fires, parent transitions to next
+  // step). STUDENT sessions never see this affordance — `role` is null
+  // when the user isn't signed in (e.g. the genuine first-call flow on
+  // a brand-new caller), so the check is also a privacy gate.
+  const { data: session } = useSession();
+  const sessionRole = session?.user?.role ?? null;
+  const showAdminSkip =
+    typeof sessionRole === 'string' && ADMIN_SKIP_ROLES.has(sessionRole);
 
   useEffect(() => {
     return () => {
@@ -135,6 +159,41 @@ export function FirstCallPinGate({
         kind: 'error',
         message: 'Couldn’t reach the server. Try again in a moment.',
       });
+    }
+  }
+
+  async function handleAdminSkip() {
+    if (adminSkipPending) return;
+    setAdminSkipPending(true);
+    setAdminSkipError(null);
+    try {
+      const res = await fetch('/api/identity/challenge-skip', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ callerId }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data?.ok) {
+        onVerified();
+        return;
+      }
+      if (data?.noActiveChallenge) {
+        setAdminSkipError(
+          'No active challenge to skip — hit "Resend code" first, then try again.',
+        );
+        return;
+      }
+      if (res.status === 401) {
+        setAdminSkipError(
+          'Your session can\'t skip the PIN (OPERATOR+ only). Sign in as an admin first.',
+        );
+        return;
+      }
+      setAdminSkipError(`Couldn't skip (${res.status}). Try again.`);
+    } catch {
+      setAdminSkipError('Network error — try again.');
+    } finally {
+      setAdminSkipPending(false);
     }
   }
 
@@ -304,6 +363,43 @@ export function FirstCallPinGate({
             {resendLabel}
           </button>
         </div>
+
+        {showAdminSkip ? (
+          <div
+            style={{
+              marginTop: 16,
+              paddingTop: 12,
+              borderTop: '1px dashed var(--border-default, #e4e4e7)',
+            }}
+            data-testid="first-call-pin-gate-admin-skip-block"
+          >
+            <button
+              type="button"
+              onClick={handleAdminSkip}
+              disabled={adminSkipPending}
+              data-testid="first-call-pin-gate-admin-skip"
+              className="hf-btn hf-btn-secondary"
+              style={{ width: '100%', padding: '8px 12px', fontSize: 13 }}
+            >
+              {adminSkipPending
+                ? 'Skipping PIN…'
+                : `Admin: skip PIN (you're signed in as ${sessionRole})`}
+            </button>
+            {adminSkipError ? (
+              <p
+                style={{
+                  marginTop: 8,
+                  fontSize: 12,
+                  color: 'var(--text-danger, #b91c1c)',
+                  lineHeight: 1.4,
+                }}
+                role="alert"
+              >
+                {adminSkipError}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/admin/tests/api/identity-challenge-skip.test.ts
+++ b/apps/admin/tests/api/identity-challenge-skip.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for POST /api/identity/challenge-skip — admin escape hatch
+ * that marks a caller's most-recent unverified
+ * CallerIdentityChallenge as verified without requiring the PIN.
+ *
+ * Security properties covered:
+ *   - STUDENT / VIEWER refused 401 (requireAuth("OPERATOR") gate)
+ *   - OPERATOR / EDUCATOR / ADMIN / SUPERADMIN allowed
+ *   - Body validation (missing/invalid callerId → 400)
+ *   - No active challenge → 200 { noActiveChallenge: true } (admin
+ *     should request a resend first)
+ *   - Audit breadcrumb fires (console.warn) so the action is
+ *     traceable in logs
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.unmock("@/lib/permissions");
+
+const mockChallengeFindFirst = vi.fn();
+const mockChallengeUpdate = vi.fn();
+const mockRequireAuth = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    callerIdentityChallenge: {
+      findFirst: (...args: unknown[]) => mockChallengeFindFirst(...args),
+      update: (...args: unknown[]) => mockChallengeUpdate(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+  isAuthError: (v: unknown): v is { error: unknown } =>
+    Boolean(v && typeof v === "object" && "error" in (v as Record<string, unknown>)),
+}));
+
+function makeAuth(role: string, userId = "user-1") {
+  return {
+    session: {
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      user: { id: userId, email: "u@example.com", name: "U", image: null, role },
+    },
+  };
+}
+
+function makeAuthError(status: number) {
+  return {
+    error: new Response(JSON.stringify({ error: "Unauthorized" }), { status }),
+  };
+}
+
+async function callPost(body: unknown) {
+  const mod = await import("@/app/api/identity/challenge-skip/route");
+  const req = new Request("http://test/api/identity/challenge-skip", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const res = await mod.POST(req);
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/identity/challenge-skip", () => {
+  describe("RBAC — OPERATOR+ only", () => {
+    for (const role of ["OPERATOR", "EDUCATOR", "ADMIN", "SUPERADMIN"] as const) {
+      it(`allows ${role} session to skip the challenge`, async () => {
+        mockRequireAuth.mockResolvedValue(makeAuth(role));
+        mockChallengeFindFirst.mockResolvedValue({ id: "chal-1" });
+        mockChallengeUpdate.mockResolvedValue({ id: "chal-1" });
+
+        const { status, json } = await callPost({ callerId: "c-1" });
+
+        expect(status).toBe(200);
+        expect(json).toEqual({ ok: true, challengeId: "chal-1" });
+        expect(mockChallengeUpdate).toHaveBeenCalledWith({
+          where: { id: "chal-1" },
+          data: { verifiedAt: expect.any(Date) },
+        });
+      });
+    }
+
+    it("refuses STUDENT session — requireAuth returns auth error", async () => {
+      mockRequireAuth.mockResolvedValue(makeAuthError(401));
+      const { status } = await callPost({ callerId: "c-1" });
+      expect(status).toBe(401);
+      expect(mockChallengeFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Body validation", () => {
+    it("400 when callerId is missing", async () => {
+      mockRequireAuth.mockResolvedValue(makeAuth("OPERATOR"));
+      const { status, json } = await callPost({});
+      expect(status).toBe(400);
+      expect(json.error).toMatch(/invalid/i);
+    });
+
+    it("400 when callerId is empty string", async () => {
+      mockRequireAuth.mockResolvedValue(makeAuth("OPERATOR"));
+      const { status } = await callPost({ callerId: "" });
+      expect(status).toBe(400);
+    });
+
+    it("400 on unknown extra fields (zod strict)", async () => {
+      mockRequireAuth.mockResolvedValue(makeAuth("OPERATOR"));
+      const { status } = await callPost({ callerId: "c-1", pin: "123456" });
+      expect(status).toBe(400);
+    });
+  });
+
+  describe("No active challenge", () => {
+    it("returns noActiveChallenge:true when there's no unverified challenge", async () => {
+      mockRequireAuth.mockResolvedValue(makeAuth("ADMIN"));
+      mockChallengeFindFirst.mockResolvedValue(null);
+
+      const { status, json } = await callPost({ callerId: "c-1" });
+
+      expect(status).toBe(200);
+      expect(json).toEqual({ ok: false, noActiveChallenge: true });
+      expect(mockChallengeUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Audit", () => {
+    it("emits a [identity/skip] console.warn breadcrumb on success", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockRequireAuth.mockResolvedValue(makeAuth("OPERATOR", "admin-42"));
+      mockChallengeFindFirst.mockResolvedValue({ id: "chal-1" });
+      mockChallengeUpdate.mockResolvedValue({ id: "chal-1" });
+
+      await callPost({ callerId: "victim-1" });
+
+      const call = warn.mock.calls.find(([msg]) =>
+        typeof msg === "string" && msg.includes("[identity/skip]"),
+      );
+      expect(call).toBeDefined();
+      expect(String(call?.[0])).toContain("admin-42");
+      expect(String(call?.[0])).toContain("OPERATOR");
+      expect(String(call?.[0])).toContain("victim-1");
+      warn.mockRestore();
+    });
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9911,6 +9911,34 @@ Unlink a subject from this domain (deletes SubjectDomain join row)
 
 ---
 
+### `POST` /api/identity/challenge-skip
+
+Admin escape hatch: mark a caller's most-recent
+
+**Auth**: session (OPERATOR / ADMIN / SUPERADMIN)
+
+**Response** `200`
+```json
+{ ok: true, challengeId: string }
+```
+
+**Response** `200`
+```json
+{ ok: false, noActiveChallenge: true } — no unverified challenge to skip; admin should request a fresh resend first
+```
+
+**Response** `400`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `401`
+```json
+— caller not authenticated or not OPERATOR+
+```
+
+---
+
 ### `GET` /api/identity/challenge-status
 
 Whether the learner has an outstanding first-call PIN challenge
@@ -15568,8 +15596,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 496 |
-| Files with annotations | 486 |
+| Route files found | 497 |
+| Files with annotations | 487 |
 | Files missing annotations | 10 |
 | Coverage | 98.0% |
 


### PR DESCRIPTION
OPERATOR+ sessions see a 'Admin: skip PIN' button on FirstCallPinGate. Click → server-side POST marks the most-recent unverified CallerIdentityChallenge as verified → onVerified() runs → parent transitions exactly as if a correct PIN had been entered. STUDENT/VIEWER sessions never see the affordance. 10 vitests cover RBAC (4 OPERATOR+ roles pass, STUDENT-equivalent refused), body validation, no-active-challenge path, and the audit breadcrumb. Use case: admins testing/supporting a learner without needing the PIN email.