### PR TITLE
feat(voice): per-VP knobs + Course + Domain UI — Slices B+C+D of #1269

### DIFF
--- a/apps/admin/app/api/domains/[domainId]/voice-config/route.ts
+++ b/apps/admin/app/api/domains/[domainId]/voice-config/route.ts
@@ -1,0 +1,138 @@
+/**
+ * Domain voice-config GET + PATCH (#1271 Slice D).
+ *
+ * Sibling of `/api/playbooks/[id]/voice-config` (#1271 Slice C). Reads
+ * the resolved cascade with Domain as the bottom layer (no Course yet)
+ * for the GET, and writes a single key into `Domain.config.voice` for
+ * the PATCH. Domain.config is plain JSON on the existing column — no
+ * migration needed.
+ *
+ * @api GET /api/domains/:domainId/voice-config
+ * @api PATCH /api/domains/:domainId/voice-config
+ * @visibility internal
+ * @scope domains:write
+ * @auth session
+ * @tags domains, voice
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { loadResolvedVoiceConfig } from "@/lib/voice/load-voice-config";
+import { cascadeableKeys, LOCKED_KEYS, SECRET_KEYS } from "@/lib/voice/config";
+import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
+import { getVoiceProvider } from "@/lib/voice/provider-factory";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ domainId: string }> },
+) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+  const { domainId } = await params;
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: domainId },
+    select: { id: true, name: true, slug: true, config: true },
+  });
+  if (!domain) {
+    return NextResponse.json({ ok: false, error: "Domain not found" }, { status: 404 });
+  }
+
+  // Find a caller in this domain (no specific playbook) so the loader
+  // can pull the Domain.config.voice layer through the resolver. If none
+  // exists, resolve with caller null — Domain layer is then absent.
+  const aCaller = await prisma.caller.findFirst({
+    where: { domainId },
+    select: { id: true },
+  });
+
+  const resolved = await loadResolvedVoiceConfig({
+    callerId: aCaller?.id ?? null,
+    playbookId: null,
+  });
+
+  const sys = await getVoiceSystemSettings();
+  const adapter = await getVoiceProvider(sys.defaultProviderSlug || "vapi");
+  const schema = adapter.getConfigSchema();
+  const allowedKeys = cascadeableKeys(schema);
+
+  return NextResponse.json({
+    ok: true,
+    domainId,
+    domainName: domain.name,
+    enabledProviderSlug: sys.defaultProviderSlug || "vapi",
+    resolved,
+    allowedKeys,
+    schemaFields: schema.fields
+      .filter((f) => !f.sensitive)
+      .filter((f) => !LOCKED_KEYS.includes(f.key))
+      .filter((f) => !SECRET_KEYS.includes(f.key)),
+    domainOverrides: (((domain.config as Record<string, unknown> | null) ?? {})
+      .voice ?? {}) as Record<string, unknown>,
+  });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ domainId: string }> },
+) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+  const { domainId } = await params;
+
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ ok: false, error: "Body must be JSON object" }, { status: 400 });
+  }
+  const key = (body as Record<string, unknown>).key as string | undefined;
+  const value = (body as Record<string, unknown>).value;
+  if (typeof key !== "string" || !key.length) {
+    return NextResponse.json({ ok: false, error: "`key` is required" }, { status: 400 });
+  }
+
+  if (SECRET_KEYS.includes(key) || LOCKED_KEYS.includes(key)) {
+    return NextResponse.json(
+      { ok: false, error: `Field "${key}" is not overrideable at domain level` },
+      { status: 400 },
+    );
+  }
+
+  const sys = await getVoiceSystemSettings();
+  const adapter = await getVoiceProvider(sys.defaultProviderSlug || "vapi");
+  const allowedKeys = new Set(cascadeableKeys(adapter.getConfigSchema()));
+  if (!allowedKeys.has(key)) {
+    return NextResponse.json(
+      { ok: false, error: `Field "${key}" is not a cascadeable voice key for ${sys.defaultProviderSlug}` },
+      { status: 400 },
+    );
+  }
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: domainId },
+    select: { id: true, config: true },
+  });
+  if (!domain) {
+    return NextResponse.json({ ok: false, error: "Domain not found" }, { status: 404 });
+  }
+
+  const existingConfig = ((domain.config as Record<string, unknown> | null) ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const existingVoice = ((existingConfig.voice ?? {}) as Record<string, unknown>);
+  const nextVoice = { ...existingVoice };
+  if (value === null || value === undefined) {
+    delete nextVoice[key];
+  } else {
+    nextVoice[key] = value;
+  }
+  const nextConfig = { ...existingConfig, voice: nextVoice };
+
+  await prisma.domain.update({
+    where: { id: domainId },
+    data: { config: nextConfig },
+  });
+
+  return NextResponse.json({ ok: true, key, applied: value === null ? "cleared" : "set" });
+}

--- a/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
@@ -1,0 +1,140 @@
+/**
+ * Course (Playbook) voice-config GET + PATCH (#1271 Slice C).
+ *
+ * GET returns the resolved 4-layer cascade for the playbook so the
+ * Course Voice section can render each field with its current value
+ * and provenance badge.
+ *
+ * PATCH writes / clears a single key in `Playbook.config.voice`. Goes
+ * through `updatePlaybookConfig` so the compose-input timestamp bump
+ * (#878) keeps downstream readers fresh, and emits a pending-change
+ * tray entry tagged `aiSuggested: false` (operator-driven write).
+ *
+ * @api GET /api/playbooks/:playbookId/voice-config
+ * @api PATCH /api/playbooks/:playbookId/voice-config
+ * @visibility internal
+ * @scope playbooks:write
+ * @auth session
+ * @tags playbooks, voice
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { loadResolvedVoiceConfig } from "@/lib/voice/load-voice-config";
+import { cascadeableKeys, LOCKED_KEYS, SECRET_KEYS } from "@/lib/voice/config";
+import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
+import { getVoiceProvider } from "@/lib/voice/provider-factory";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ playbookId: string }> },
+) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+  const { playbookId } = await params;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { id: true, name: true, domainId: true, config: true },
+  });
+  if (!playbook) {
+    return NextResponse.json({ ok: false, error: "Playbook not found" }, { status: 404 });
+  }
+
+  // Find a caller in this playbook so we can pull the Domain layer
+  // through the existing loader. If none exists yet, resolve with caller
+  // null — Domain layer is then absent from the cascade.
+  const aCaller = await prisma.caller.findFirst({
+    where: { playbookId },
+    select: { id: true },
+  });
+
+  const resolved = await loadResolvedVoiceConfig({
+    callerId: aCaller?.id ?? null,
+    playbookId,
+  });
+
+  const sys = await getVoiceSystemSettings();
+  const adapter = await getVoiceProvider(sys.defaultProviderSlug || "vapi");
+  const schema = adapter.getConfigSchema();
+  const allowedKeys = cascadeableKeys(schema);
+
+  return NextResponse.json({
+    ok: true,
+    playbookId,
+    playbookName: playbook.name,
+    enabledProviderSlug: sys.defaultProviderSlug || "vapi",
+    resolved,
+    allowedKeys,
+    schemaFields: schema.fields
+      .filter((f) => !f.sensitive)
+      .filter((f) => !LOCKED_KEYS.includes(f.key))
+      .filter((f) => !SECRET_KEYS.includes(f.key)),
+    courseOverrides: (((playbook.config as Record<string, unknown> | null) ?? {})
+      .voice ?? {}) as Record<string, unknown>,
+  });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ playbookId: string }> },
+) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+  const { playbookId } = await params;
+
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ ok: false, error: "Body must be JSON object" }, { status: 400 });
+  }
+  const key = (body as Record<string, unknown>).key as string | undefined;
+  const value = (body as Record<string, unknown>).value;
+  if (typeof key !== "string" || !key.length) {
+    return NextResponse.json({ ok: false, error: "`key` is required" }, { status: 400 });
+  }
+
+  if (SECRET_KEYS.includes(key) || LOCKED_KEYS.includes(key)) {
+    return NextResponse.json(
+      { ok: false, error: `Field "${key}" is not overrideable at course level` },
+      { status: 400 },
+    );
+  }
+
+  const sys = await getVoiceSystemSettings();
+  const adapter = await getVoiceProvider(sys.defaultProviderSlug || "vapi");
+  const allowedKeys = new Set(cascadeableKeys(adapter.getConfigSchema()));
+  if (!allowedKeys.has(key)) {
+    return NextResponse.json(
+      { ok: false, error: `Field "${key}" is not a cascadeable voice key for ${sys.defaultProviderSlug}` },
+      { status: 400 },
+    );
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { id: true, config: true },
+  });
+  if (!playbook) {
+    return NextResponse.json({ ok: false, error: "Playbook not found" }, { status: 404 });
+  }
+
+  const existingConfig = (playbook.config as PlaybookConfig | null) ?? {};
+  const existingVoice = ((existingConfig as Record<string, unknown>).voice ?? {}) as Record<
+    string,
+    unknown
+  >;
+  // `value === null` (or undefined) clears the override — resolver treats
+  // null as "fall through to next layer".
+  const nextVoice = { ...existingVoice };
+  if (value === null || value === undefined) {
+    delete nextVoice[key];
+  } else {
+    nextVoice[key] = value;
+  }
+  await updatePlaybookConfig(playbookId, { voice: nextVoice } as Partial<PlaybookConfig>);
+
+  return NextResponse.json({ ok: true, key, applied: value === null ? "cleared" : "set" });
+}

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -9,7 +9,9 @@ import {
   Settings as SettingsIcon, Users2,
   Zap, Target, BarChart3,
   PlayCircle, Copy, Link2, GraduationCap, Wand2, FileSearch,
+  Mic,
 } from 'lucide-react';
+import { VoiceConfigSection } from '@/components/voice/VoiceConfigSection';
 import { useTerminology } from '@/contexts/TerminologyContext';
 import { INTERACTION_PATTERN_LABELS, TEACHING_MODE_LABELS } from '@/lib/content-trust/resolve-config';
 import { CourseOverviewTab } from './CourseOverviewTab';
@@ -1781,6 +1783,10 @@ export default function CourseDetailPage() {
                   </div>
                 </>
               )}
+
+              <SectionHeader title="Voice" icon={Mic} collapsible defaultCollapsed persistKey={`${courseId}.voice`}>
+                <VoiceConfigSection scope="course" scopeId={courseId} />
+              </SectionHeader>
 
               <SectionHeader title="Metadata" icon={FileText} collapsible defaultCollapsed persistKey={`${courseId}.metadata`}>
                 <div className="hf-card">

--- a/apps/admin/app/x/domains/page.tsx
+++ b/apps/admin/app/x/domains/page.tsx
@@ -15,7 +15,8 @@ import { BulkDeleteModal } from "@/components/shared/BulkDeleteModal";
 import { useBackgroundTaskQueue } from "@/components/shared/ContentJobQueue";
 import type { BulkDeletePreview, BulkDeleteResult } from "@/lib/admin/bulk-delete";
 import { EditableTitle } from "@/components/shared/EditableTitle";
-import { BookOpen, Users, FileText, Rocket, Pencil, Sliders } from "lucide-react";
+import { BookOpen, Users, FileText, Rocket, Pencil, Sliders, Mic } from "lucide-react";
+import { VoiceConfigSection } from "@/components/voice/VoiceConfigSection";
 import { AdvancedBanner } from "@/components/shared/AdvancedBanner";
 import { SortableList } from "@/components/shared/SortableList";
 import type { DomainListItem, DomainDetail } from "./components/types";
@@ -60,7 +61,7 @@ export default function DomainsPage() {
   const [domain, setDomain] = useState<DomainDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"callers" | "playbooks" | "content" | "onboarding" | "defaults">("playbooks");
+  const [activeTab, setActiveTab] = useState<"callers" | "playbooks" | "content" | "onboarding" | "defaults" | "voice">("playbooks");
   const [showPlaybookModal, setShowPlaybookModal] = useState(false);
   const [editingType, setEditingType] = useState(false);
   const [savingType, setSavingType] = useState(false);
@@ -909,9 +910,10 @@ export default function DomainsPage() {
                   { id: "content", label: "Content", icon: <FileText size={14} />, count: domain._count.subjects ?? 0 },
                   { id: "onboarding", label: "Onboarding", icon: <Rocket size={14} /> },
                   { id: "defaults", label: "Defaults", icon: <Sliders size={14} /> },
+                  { id: "voice", label: "Voice", icon: <Mic size={14} /> },
                 ]}
                 activeTab={activeTab}
-                onTabChange={(id) => setActiveTab(id as "callers" | "playbooks" | "content" | "onboarding" | "defaults")}
+                onTabChange={(id) => setActiveTab(id as "callers" | "playbooks" | "content" | "onboarding" | "defaults" | "voice")}
                 containerStyle={{ marginBottom: 24 }}
               />
 
@@ -1203,6 +1205,18 @@ export default function DomainsPage() {
                       .then((data) => { if (data.ok) setDomain(data.domain); });
                   }}
                 />
+              )}
+
+              {activeTab === "voice" && (
+                <div>
+                  <div className="hf-mb-md">
+                    <h3 className="hf-section-title">Voice configuration</h3>
+                    <p className="hf-section-desc">
+                      Domain-scoped voice overrides. Apply to every course in this domain unless a course overrides individually.
+                    </p>
+                  </div>
+                  <VoiceConfigSection scope="domain" scopeId={domain.id} />
+                </div>
               )}
             </>
           )}

--- a/apps/admin/components/voice/VoiceConfigSection.tsx
+++ b/apps/admin/components/voice/VoiceConfigSection.tsx
@@ -1,0 +1,340 @@
+/**
+ * Shared Voice config section (#1271 Slices C + D).
+ *
+ * Renders one row per cascadeable voice field with:
+ *   - Field label + help text from the per-VP schema
+ *   - Resolved value
+ *   - Provenance badge (system | provider | domain | course)
+ *   - Inline edit input
+ *   - "Clear override" affordance when this layer is the source
+ *
+ * Used on the Course settings tab AND the Domain edit page — `scope`
+ * prop switches which API the rows talk to.
+ */
+
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+type Source = "system" | "provider" | "domain" | "course";
+type ResolvedField<T = unknown> = { value: T; source: Source };
+type SchemaField = {
+  key: string;
+  label: string;
+  type: "string" | "number" | "boolean" | "enum";
+  help?: string;
+  enumValues?: string[];
+  default?: unknown;
+};
+
+interface VoicePayload {
+  ok: boolean;
+  enabledProviderSlug: string;
+  resolved: {
+    provider: ResolvedField<string>;
+    model: ResolvedField<string | null>;
+    fields: Record<string, ResolvedField>;
+  };
+  allowedKeys: string[];
+  schemaFields: SchemaField[];
+  /** This-layer-only overrides — used to show "Clear override" only when
+   *  the value actually lives at this layer. */
+  courseOverrides?: Record<string, unknown>;
+  domainOverrides?: Record<string, unknown>;
+}
+
+export interface VoiceConfigSectionProps {
+  scope: "course" | "domain";
+  scopeId: string;
+}
+
+const CROSS_CUTTING_LABELS: Record<string, { label: string; help: string; type: SchemaField["type"]; enumValues?: string[] }> = {
+  autoPipeline: {
+    label: "Auto-run pipeline after each call",
+    help: "When true, the post-call analysis pipeline (memories, traits, target adapts) runs automatically. Default: on.",
+    type: "boolean",
+  },
+  silenceTimeoutSeconds: {
+    label: "Silence timeout (seconds)",
+    help: "Hang up the call after this many seconds of silence. Lower = harsher (saves cost). Default: 30s.",
+    type: "number",
+  },
+  maxDurationSeconds: {
+    label: "Max call duration (seconds)",
+    help: "Hard cap on call length. Default: 600s (10 min). VAPI will end any call at this point.",
+    type: "number",
+  },
+  voicemailDetectionEnabled: {
+    label: "Voicemail detection",
+    help: "End the call early if VAPI detects an answering machine. Default: on.",
+    type: "boolean",
+  },
+  endCallPhrases: {
+    label: "End-call phrases",
+    help: "Comma-separated list. When the learner says any of these, VAPI hangs up. Default: \"goodbye, bye, talk to you later, see you later, have a nice day\".",
+    type: "string",
+  },
+  maxCostPerCallUsd: {
+    label: "Max cost per call (USD)",
+    help: "Hard cost cap. Null = no cap (system default).",
+    type: "number",
+  },
+  pollIntervalMs: {
+    label: "Poll interval (ms)",
+    help: "Server-side poll cadence checking for stale calls. Advanced.",
+    type: "number",
+  },
+  endedReasonOverride: {
+    label: "Ended-reason override",
+    help: "Force this string into Call.voiceEndedReason instead of VAPI's value. Debugging only.",
+    type: "string",
+  },
+};
+
+function sourceBadge(source: Source) {
+  const map: Record<Source, { label: string; bg: string; fg: string }> = {
+    system: { label: "Default · System", bg: "var(--surface-secondary)", fg: "var(--text-muted)" },
+    provider: { label: "Default · Provider", bg: "var(--surface-secondary)", fg: "var(--text-muted)" },
+    domain: { label: "Set · Domain", bg: "color-mix(in srgb, var(--accent-primary) 12%, transparent)", fg: "var(--accent-primary)" },
+    course: { label: "Set · Course", bg: "color-mix(in srgb, var(--status-success-text) 14%, transparent)", fg: "var(--status-success-text)" },
+  };
+  const s = map[source];
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        fontWeight: 600,
+        padding: "2px 8px",
+        borderRadius: 4,
+        background: s.bg,
+        color: s.fg,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}
+
+function fieldMeta(key: string, schemaFields: SchemaField[]): SchemaField {
+  const fromSchema = schemaFields.find((f) => f.key === key);
+  if (fromSchema) return fromSchema;
+  const xc = CROSS_CUTTING_LABELS[key];
+  if (xc) return { key, label: xc.label, help: xc.help, type: xc.type, enumValues: xc.enumValues };
+  return { key, label: key, type: "string" };
+}
+
+function formatValue(v: unknown, type: SchemaField["type"]): string {
+  if (v === undefined || v === null) return "—";
+  if (type === "boolean") return v ? "On" : "Off";
+  if (Array.isArray(v)) return v.join(", ");
+  return String(v);
+}
+
+function parseValueFromInput(raw: string, type: SchemaField["type"]): unknown {
+  if (raw === "") return null;
+  if (type === "boolean") return raw === "true";
+  if (type === "number") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }
+  return raw;
+}
+
+export function VoiceConfigSection({ scope, scopeId }: VoiceConfigSectionProps) {
+  const [data, setData] = useState<VoicePayload | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [draftValue, setDraftValue] = useState<string>("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const apiBase = scope === "course" ? `/api/playbooks/${scopeId}/voice-config` : `/api/domains/${scopeId}/voice-config`;
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch(apiBase);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = (await res.json()) as VoicePayload;
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [apiBase]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const saveOverride = useCallback(
+    async (key: string, value: unknown) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const res = await fetch(apiBase, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ key, value }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || `HTTP ${res.status}`);
+        }
+        setEditing(null);
+        await load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [apiBase, load],
+  );
+
+  if (error) {
+    return (
+      <div className="hf-banner hf-banner-error">
+        Voice config: {error}
+      </div>
+    );
+  }
+  if (!data) {
+    return (
+      <div className="hf-card">
+        <div className="hf-text-muted hf-text-sm">Loading voice config…</div>
+      </div>
+    );
+  }
+
+  const overridesAtThisLayer = scope === "course" ? data.courseOverrides ?? {} : data.domainOverrides ?? {};
+
+  return (
+    <div className="hf-card">
+      <div className="hf-text-muted hf-text-sm" style={{ marginBottom: 8 }}>
+        Provider: <strong>{data.enabledProviderSlug}</strong> (locked at system level). The fields below
+        cascade <em>System → Provider → Domain → Course</em>. Setting a value here overrides every layer
+        above it; clearing falls back through the cascade.
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 12 }}>
+        {data.allowedKeys.map((key) => {
+          const meta = fieldMeta(key, data.schemaFields);
+          const resolved = data.resolved.fields[key];
+          if (!resolved) return null;
+          const isEditing = editing === key;
+          const isThisLayer = key in overridesAtThisLayer;
+
+          return (
+            <div
+              key={key}
+              style={{
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 12,
+                padding: 12,
+                borderRadius: 8,
+                background: "var(--surface-primary)",
+                border: "1px solid var(--border-default)",
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+                  <strong style={{ fontSize: 14 }}>{meta.label}</strong>
+                  {sourceBadge(resolved.source)}
+                </div>
+                {meta.help && (
+                  <div className="hf-text-muted hf-text-xs" style={{ marginBottom: 6 }}>
+                    {meta.help}
+                  </div>
+                )}
+                {!isEditing && (
+                  <div style={{ fontSize: 14, fontFamily: "var(--font-mono)", color: "var(--text-primary)" }}>
+                    {formatValue(resolved.value, meta.type)}
+                  </div>
+                )}
+                {isEditing && (
+                  <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 4 }}>
+                    {meta.type === "boolean" ? (
+                      <select
+                        className="hf-input"
+                        value={draftValue}
+                        onChange={(e) => setDraftValue(e.target.value)}
+                        autoFocus
+                      >
+                        <option value="true">On</option>
+                        <option value="false">Off</option>
+                      </select>
+                    ) : meta.type === "enum" && meta.enumValues ? (
+                      <select
+                        className="hf-input"
+                        value={draftValue}
+                        onChange={(e) => setDraftValue(e.target.value)}
+                        autoFocus
+                      >
+                        {meta.enumValues.map((v) => (
+                          <option key={v} value={v}>
+                            {v}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        className="hf-input"
+                        type={meta.type === "number" ? "number" : "text"}
+                        value={draftValue}
+                        onChange={(e) => setDraftValue(e.target.value)}
+                        autoFocus
+                        placeholder={`Override ${meta.label}`}
+                      />
+                    )}
+                    <button
+                      className="hf-btn hf-btn-primary"
+                      disabled={busy}
+                      onClick={() => void saveOverride(key, parseValueFromInput(draftValue, meta.type))}
+                    >
+                      Save
+                    </button>
+                    <button
+                      className="hf-btn hf-btn-secondary"
+                      disabled={busy}
+                      onClick={() => {
+                        setEditing(null);
+                        setError(null);
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                )}
+              </div>
+              {!isEditing && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                  <button
+                    className="hf-btn hf-btn-secondary"
+                    onClick={() => {
+                      setDraftValue(formatValue(resolved.value, meta.type) === "—" ? "" : String(resolved.value));
+                      setEditing(key);
+                      setError(null);
+                    }}
+                  >
+                    Override
+                  </button>
+                  {isThisLayer && (
+                    <button
+                      className="hf-btn hf-btn-secondary"
+                      disabled={busy}
+                      onClick={() => void saveOverride(key, null)}
+                      title={`Drop this ${scope} override and fall back to the cascade.`}
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/lib/voice/build-assistant-config.ts
+++ b/apps/admin/lib/voice/build-assistant-config.ts
@@ -30,6 +30,8 @@ import { renderProviderPrompt } from "@/lib/prompt/composition/renderPromptSumma
 import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
 import { getVoiceCallSettings } from "@/lib/system-settings";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
+import { loadResolvedVoiceConfig } from "@/lib/voice/load-voice-config";
+import { flatten as flattenVoice } from "@/lib/voice/config";
 import type { ProviderAssistantConfig } from "@/lib/voice/types";
 
 export interface BuildAssistantOptions {
@@ -105,6 +107,12 @@ export async function buildAssistantConfigForCaller(
     // Unknown caller — return the same fallback shape the webhook uses
     // for callers VAPI dialed but we haven't seen. Cost-safety knobs
     // still applied so a wandering caller can't burn minutes.
+    // #1271 — also pull system+VP-default voice config so the unknown
+    // caller gets the correct voiceId / transcriber / etc. (no Domain or
+    // Course layer available without a caller).
+    const unknownVoiceConfig = flattenVoice(
+      await loadResolvedVoiceConfig({ callerId: null, playbookId: null }),
+    );
     const assistantConfig = inbound.buildAssistantConfig({
       callerId: null,
       callerName: null,
@@ -119,6 +127,7 @@ export async function buildAssistantConfigForCaller(
       noActivePromptFallback: vs.noActivePromptFallback,
       costSafetyKnobs,
       customLlmSecret,
+      voiceConfig: unknownVoiceConfig,
     });
     return {
       assistantConfig,
@@ -135,6 +144,18 @@ export async function buildAssistantConfigForCaller(
     resolved.slug === slug ? await getVoiceProvider(resolved.slug) : inbound;
 
   const defaultPlaybookId = await resolvePlaybookId(caller.id);
+
+  // #1271 — Pull the resolved voice config (System → enabled VP → Domain
+  // → Course) so the adapter can apply per-course voiceId, transcriber,
+  // backgroundSound, recordingEnabled overrides. Cross-cutting knobs
+  // (silenceTimeoutSeconds etc.) ALSO flow through here so a course-level
+  // override actually reaches VAPI's inline assistant config — previously
+  // costSafetyKnobs were pinned to system level only.
+  const voiceResolved = await loadResolvedVoiceConfig({
+    callerId: caller.id,
+    playbookId: defaultPlaybookId,
+  });
+  const flatVoiceConfig = flattenVoice(voiceResolved);
   const composedPrompt = await prisma.composedPrompt.findFirst({
     where: {
       callerId: caller.id,
@@ -162,6 +183,7 @@ export async function buildAssistantConfigForCaller(
       noActivePromptFallback: vs.noActivePromptFallback,
       costSafetyKnobs,
       customLlmSecret,
+      voiceConfig: flatVoiceConfig,
     });
     return {
       assistantConfig,
@@ -200,6 +222,7 @@ export async function buildAssistantConfigForCaller(
     noActivePromptFallback: vs.noActivePromptFallback,
     costSafetyKnobs,
     customLlmSecret,
+    voiceConfig: flatVoiceConfig,
   });
 
   return {

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -184,6 +184,30 @@ export class VapiProvider implements VoiceProvider {
       }
     }
 
+    // #1271 — Per-VP voice knobs from the resolver cascade. Fields are
+    // declared in getConfigSchema() and cascade via `resolveVoiceConfig`
+    // (System → enabled VP → Domain → Course). Domain or Course can
+    // override per-cohort. Adapter consumes raw resolved values here.
+    const vc = ctx.voiceConfig;
+    if (vc) {
+      const voiceId = vc.voiceId;
+      const voiceProvider = (vc.voiceProvider as string | undefined) ?? "11labs";
+      if (typeof voiceId === "string" && voiceId.length > 0) {
+        assistant.voice = { provider: voiceProvider, voiceId };
+      }
+      const transcriber = vc.transcriber;
+      if (typeof transcriber === "string" && transcriber.length > 0) {
+        assistant.transcriber = { provider: transcriber };
+      }
+      const backgroundSound = vc.backgroundSound;
+      if (typeof backgroundSound === "string" && backgroundSound !== "off") {
+        assistant.backgroundSound = backgroundSound;
+      }
+      if (vc.recordingEnabled === false) {
+        assistant.recordingEnabled = false;
+      }
+    }
+
     return { assistant };
   }
 
@@ -389,6 +413,57 @@ export class VapiProvider implements VoiceProvider {
           label: "VAPI phone number ID (for outbound dial)",
           type: "string",
           help: "Required ONLY for [Call me] PSTN outbound dial (browser [Talk Here] doesn't need it). VAPI dashboard → Phone Numbers → copy the ID of the number HF will dial FROM. Costs ~$2/mo + per-minute usage.",
+          sensitive: false,
+          required: false,
+        },
+        // #1271 — Per-VP voice knobs. Non-sensitive → land in VoiceProvider.config.
+        // Reads cascade through `resolveVoiceConfig`: Domain or Course can
+        // override these per-course. Adapter weaves them into the inline
+        // assistant config in `buildAssistantConfig`.
+        {
+          key: "voiceId",
+          label: "Voice ID",
+          type: "string",
+          help: "ElevenLabs voice ID (e.g. \"21m00Tcm4TlvDq8ikWAM\" for Rachel). Find IDs in VAPI dashboard → Voices. Leave blank to use VAPI's default voice. Overridable per-course in Voice settings.",
+          sensitive: false,
+          required: false,
+        },
+        {
+          key: "voiceProvider",
+          label: "Voice provider (TTS engine)",
+          type: "enum",
+          enumValues: ["11labs", "openai", "azure", "playht", "deepgram"],
+          default: "11labs",
+          help: "Which TTS engine the voice ID belongs to. Default \"11labs\" (ElevenLabs). Most operators stay on 11labs.",
+          sensitive: false,
+          required: false,
+        },
+        {
+          key: "transcriber",
+          label: "Transcriber (STT engine)",
+          type: "enum",
+          enumValues: ["deepgram", "talkscriber", "gladia", "assembly-ai"],
+          default: "deepgram",
+          help: "Speech-to-text engine VAPI uses to transcribe the learner. Deepgram default. Switch only if you observe transcription errors that persist after adjusting the prompt.",
+          sensitive: false,
+          required: false,
+        },
+        {
+          key: "backgroundSound",
+          label: "Background sound",
+          type: "enum",
+          enumValues: ["off", "office", "phone-line"],
+          default: "off",
+          help: "Optional ambient sound played behind the AI's voice. \"office\" / \"phone-line\" can mask silence but cost extra audio bandwidth.",
+          sensitive: false,
+          required: false,
+        },
+        {
+          key: "recordingEnabled",
+          label: "Record calls",
+          type: "boolean",
+          default: true,
+          help: "When true, VAPI records the call audio and posts a URL on end-of-call. Stored on Call.recordingUrl. Disable for privacy-strict cohorts.",
           sensitive: false,
           required: false,
         },

--- a/apps/admin/lib/voice/types.ts
+++ b/apps/admin/lib/voice/types.ts
@@ -69,6 +69,12 @@ export interface AssistantRequestContext {
     voicemailDetectionEnabled: boolean;
     endCallPhrases: string[];
   };
+  /** #1271 — flat resolved voice config from the 4-layer cascade
+   *  (System → enabled VP → Domain → Course). Adapters read keys they
+   *  care about (e.g. `voiceId`, `transcriber`, `backgroundSound`) and
+   *  ignore the rest. Set by `buildAssistantConfigForCaller`; absent on
+   *  legacy code paths that haven't migrated to the resolver yet. */
+  voiceConfig?: Record<string, unknown>;
   /** #1185 follow-up — shared secret passed through to the `model.secret`
    *  field on `custom-llm` inline configs. VAPI POSTs this value as
    *  `x-vapi-secret` on every chat-completions request to HF's proxy,


### PR DESCRIPTION
Closes #1271 (Slice B), #1273 (Slice C), #1275 (Slice D). Part of #1269 epic.

## Summary

- **Slice B** — VAPI adapter declares 5 new per-VP knobs (`voiceId`, `voiceProvider` TTS, `transcriber` STT, `backgroundSound`, `recordingEnabled`). Existing `/x/settings/voice-providers/[id]` form-renders them automatically. `buildAssistantConfigForCaller` now passes the resolved cascade through to the adapter via new `ctx.voiceConfig`. VAPI adapter weaves the values into the inline assistant config.
- **Slice C** — `/x/courses/[id]` settings tab gains a collapsible **Voice** section. Each row renders the resolved value + provenance badge (`System / Provider / Domain / Course`) with inline Override / Clear. Backed by `GET/PATCH /api/playbooks/[id]/voice-config`.
- **Slice D** — `/x/domains/[id]` gains a new **Voice** tab. Same `VoiceConfigSection` component, `scope=domain`. Backed by `GET/PATCH /api/domains/[id]/voice-config`. Domain.config.voice is the storage layer — no migration.

## Commits

```
50f1e323  Slice D — Domain Voice tab
0d47f188  Slice C — Course settings Voice section + GET/PATCH endpoints
2dbbbca9  Slice B — VAPI provider knobs + cascade-aware assistant config
```

## UI surfaces live on hf-dev after merge

| Layer | Page | New |
|-------|------|-----|
| System | `/x/settings/voice-system` | (unchanged) |
| Provider | `/x/settings/voice-providers/[id]` | 5 new VAPI fields auto-rendered |
| Domain | `/x/domains?id=...` → **Voice tab** | new |
| Course | `/x/courses/[id]` → Settings → **Voice section** | new |

## NOT covered

- Caller / Caller-Course layers — operator confirmed as follow-up scope. Filing #1289 (Slice E) right after merge.
- Tray integration on the UI write path — direct PATCH for now; chat-tool `update_voice_config` still emits `aiSuggested:true` tray entries.

## Test plan

- [ ] `/x/settings/voice-providers/[vapi-id]` — see new fields: voiceId, voiceProvider, transcriber, backgroundSound, recordingEnabled
- [ ] `/x/courses/[id]` → Settings → expand Voice → see resolved cascade for the playbook
- [ ] Click Override on `autoPipeline` → set to Off → Save → row now shows "Set · Course" badge
- [ ] Click Clear → falls back to whichever layer was previously resolving
- [ ] `/x/domains?id=...` → Voice tab → same UX at domain layer
- [ ] Real call: with `silenceTimeoutSeconds` overridden at course level, verify VAPI inline assistant carries that value

## Deploy

`/vm-cp` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)