### PR TITLE
docs(audit): market-test readiness assessment

### DIFF
--- a/apps/admin/tests/api/voice-config-routes.test.ts
+++ b/apps/admin/tests/api/voice-config-routes.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Voice-config route tests (#1271 Slices C + D promotion from manual).
+ *
+ * Covers /api/playbooks/[id]/voice-config + /api/domains/[id]/voice-config
+ * — GET (resolved cascade + schema fields) and PATCH (per-field write
+ * with LOCKED_KEYS / SECRET_KEYS / allowedKeys rejection).
+ *
+ * Tests target the route handlers directly with mocked Prisma + mocked
+ * voice loaders so the cascade resolver itself isn't exercised here —
+ * that's covered by config.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockPrisma = {
+  playbook: { findUnique: vi.fn() },
+  domain: { findUnique: vi.fn(), update: vi.fn() },
+  caller: { findFirst: vi.fn() },
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+const mockUpdatePlaybookConfig = vi.fn();
+vi.mock("@/lib/playbook/update-playbook-config", () => ({
+  updatePlaybookConfig: mockUpdatePlaybookConfig,
+}));
+
+const mockLoad = vi.fn();
+vi.mock("@/lib/voice/load-voice-config", () => ({
+  loadResolvedVoiceConfig: mockLoad,
+}));
+
+vi.mock("@/lib/voice/system-settings", () => ({
+  getVoiceSystemSettings: vi.fn(async () => ({
+    defaultProviderSlug: "vapi",
+    silenceTimeoutSeconds: 30,
+    maxDurationSeconds: 600,
+    voicemailDetectionEnabled: true,
+    endCallPhrases: ["goodbye"],
+    maxCostPerCallUsd: null,
+  })),
+}));
+
+vi.mock("@/lib/voice/provider-factory", () => ({
+  getVoiceProvider: vi.fn(async () => ({
+    slug: "vapi",
+    getConfigSchema: () => ({
+      fields: [
+        { key: "apiKey", label: "Key", type: "string", sensitive: true },
+        { key: "voiceId", label: "Voice ID", type: "string", sensitive: false },
+        { key: "transcriber", label: "STT", type: "enum", sensitive: false, enumValues: ["deepgram"] },
+      ],
+    }),
+  })),
+}));
+
+function buildRequest(url: string, opts: { method?: string; body?: unknown } = {}) {
+  return new Request(url, {
+    method: opts.method ?? "GET",
+    headers: { "Content-Type": "application/json" },
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+async function loadPlaybookRoute() {
+  return await import("../../app/api/playbooks/[playbookId]/voice-config/route");
+}
+async function loadDomainRoute() {
+  return await import("../../app/api/domains/[domainId]/voice-config/route");
+}
+
+describe("/api/playbooks/:playbookId/voice-config (#1271 Slice C)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoad.mockResolvedValue({
+      provider: { value: "vapi", source: "system" },
+      model: { value: null, source: "system" },
+      fields: {
+        autoPipeline: { value: true, source: "system" },
+        silenceTimeoutSeconds: { value: 30, source: "system" },
+        voiceId: { value: "rachel", source: "provider" },
+      },
+    });
+  });
+
+  describe("GET", () => {
+    it("returns the resolved cascade + allowed key set + this-layer overrides", async () => {
+      mockPrisma.playbook.findUnique.mockResolvedValue({
+        id: "pb-1",
+        name: "Sales 101",
+        domainId: "dom-1",
+        config: { voice: { autoPipeline: false } },
+      });
+      mockPrisma.caller.findFirst.mockResolvedValue({ id: "c-1" });
+
+      const { GET } = await loadPlaybookRoute();
+      const res = await GET(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config"),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.playbookId).toBe("pb-1");
+      expect(body.enabledProviderSlug).toBe("vapi");
+      expect(body.resolved.fields.autoPipeline.value).toBe(true);
+      expect(body.allowedKeys).toContain("voiceId");
+      expect(body.allowedKeys).toContain("autoPipeline");
+      expect(body.allowedKeys).not.toContain("apiKey"); // sensitive filtered
+      expect(body.allowedKeys).not.toContain("provider"); // locked
+      expect(body.courseOverrides).toEqual({ autoPipeline: false });
+    });
+
+    it("404 when playbook does not exist", async () => {
+      mockPrisma.playbook.findUnique.mockResolvedValue(null);
+      const { GET } = await loadPlaybookRoute();
+      const res = await GET(
+        buildRequest("http://x/api/playbooks/missing/voice-config"),
+        { params: Promise.resolve({ playbookId: "missing" }) },
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("resolves with callerId null when the playbook has no callers yet", async () => {
+      mockPrisma.playbook.findUnique.mockResolvedValue({
+        id: "pb-2",
+        name: "Empty",
+        domainId: "dom-1",
+        config: {},
+      });
+      mockPrisma.caller.findFirst.mockResolvedValue(null);
+
+      const { GET } = await loadPlaybookRoute();
+      const res = await GET(
+        buildRequest("http://x/api/playbooks/pb-2/voice-config"),
+        { params: Promise.resolve({ playbookId: "pb-2" }) },
+      );
+      expect(res.status).toBe(200);
+      expect(mockLoad).toHaveBeenCalledWith({ callerId: null, playbookId: "pb-2" });
+    });
+  });
+
+  describe("PATCH", () => {
+    beforeEach(() => {
+      mockPrisma.playbook.findUnique.mockResolvedValue({
+        id: "pb-1",
+        config: { voice: { autoPipeline: true } },
+      });
+    });
+
+    it("accepts a cascadeable key and writes via updatePlaybookConfig", async () => {
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "autoPipeline", value: false },
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      const body = await res.json();
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.applied).toBe("set");
+      expect(mockUpdatePlaybookConfig).toHaveBeenCalledWith("pb-1", {
+        voice: { autoPipeline: false },
+      });
+    });
+
+    it("accepts a per-VP schema field (voiceId)", async () => {
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "voiceId", value: "rachel-v2" },
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      expect(res.status).toBe(200);
+      expect(mockUpdatePlaybookConfig).toHaveBeenCalled();
+    });
+
+    it("REJECTS LOCKED_KEYS (provider)", async () => {
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "provider", value: "retell" },
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      expect(res.status).toBe(400);
+      expect(mockUpdatePlaybookConfig).not.toHaveBeenCalled();
+    });
+
+    it("REJECTS LOCKED_KEYS (model)", async () => {
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "model", value: "claude-x" },
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      expect(res.status).toBe(400);
+      expect(mockUpdatePlaybookConfig).not.toHaveBeenCalled();
+    });
+
+    it("REJECTS SECRET_KEYS (apiKey)", async () => {
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "apiKey", value: "sk-leak" },
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      expect(res.status).toBe(400);
+      expect(mockUpdatePlaybookConfig).not.toHaveBeenCalled();
+    });
+
+    it("REJECTS unknown key not in cascadeableKeys", async () => {
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "totallyMadeUpKey", value: "x" },
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("`value: null` clears the override (delete-key semantics)", async () => {
+      mockPrisma.playbook.findUnique.mockResolvedValue({
+        id: "pb-1",
+        config: { voice: { autoPipeline: false, voiceId: "rachel" } },
+      });
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "autoPipeline", value: null },
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      const body = await res.json();
+      expect(res.status).toBe(200);
+      expect(body.applied).toBe("cleared");
+      // voice object should NOT contain autoPipeline (cleared), still has voiceId.
+      expect(mockUpdatePlaybookConfig).toHaveBeenCalledWith("pb-1", {
+        voice: { voiceId: "rachel" },
+      });
+    });
+
+    it("400 when body is malformed", async () => {
+      const { PATCH } = await loadPlaybookRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/playbooks/pb-1/voice-config", {
+          method: "PATCH",
+          body: { key: "" }, // empty
+        }),
+        { params: Promise.resolve({ playbookId: "pb-1" }) },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+});
+
+describe("/api/domains/:domainId/voice-config (#1271 Slice D)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoad.mockResolvedValue({
+      provider: { value: "vapi", source: "system" },
+      model: { value: null, source: "system" },
+      fields: {
+        autoPipeline: { value: true, source: "system" },
+        voiceId: { value: "rachel", source: "provider" },
+      },
+    });
+  });
+
+  describe("GET", () => {
+    it("returns resolved cascade + domain overrides", async () => {
+      mockPrisma.domain.findUnique.mockResolvedValue({
+        id: "dom-1",
+        name: "Tutor",
+        slug: "tutor",
+        config: { voice: { autoPipeline: false }, somethingElse: "x" },
+      });
+      mockPrisma.caller.findFirst.mockResolvedValue({ id: "c-1" });
+
+      const { GET } = await loadDomainRoute();
+      const res = await GET(
+        buildRequest("http://x/api/domains/dom-1/voice-config"),
+        { params: Promise.resolve({ domainId: "dom-1" }) },
+      );
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.domainOverrides).toEqual({ autoPipeline: false });
+    });
+
+    it("resolves with playbookId null (domain layer, not playbook)", async () => {
+      mockPrisma.domain.findUnique.mockResolvedValue({
+        id: "dom-1",
+        name: "Tutor",
+        slug: "tutor",
+        config: {},
+      });
+      mockPrisma.caller.findFirst.mockResolvedValue({ id: "c-1" });
+
+      const { GET } = await loadDomainRoute();
+      await GET(
+        buildRequest("http://x/api/domains/dom-1/voice-config"),
+        { params: Promise.resolve({ domainId: "dom-1" }) },
+      );
+      expect(mockLoad).toHaveBeenCalledWith({ callerId: "c-1", playbookId: null });
+    });
+
+    it("404 when domain does not exist", async () => {
+      mockPrisma.domain.findUnique.mockResolvedValue(null);
+      const { GET } = await loadDomainRoute();
+      const res = await GET(
+        buildRequest("http://x/api/domains/missing/voice-config"),
+        { params: Promise.resolve({ domainId: "missing" }) },
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH", () => {
+    beforeEach(() => {
+      mockPrisma.domain.findUnique.mockResolvedValue({
+        id: "dom-1",
+        config: { voice: {}, somethingElse: "preserved" },
+      });
+      mockPrisma.domain.update.mockResolvedValue({});
+    });
+
+    it("accepts a cascadeable key and writes to Domain.config.voice", async () => {
+      const { PATCH } = await loadDomainRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/domains/dom-1/voice-config", {
+          method: "PATCH",
+          body: { key: "autoPipeline", value: false },
+        }),
+        { params: Promise.resolve({ domainId: "dom-1" }) },
+      );
+      expect(res.status).toBe(200);
+      expect(mockPrisma.domain.update).toHaveBeenCalledWith({
+        where: { id: "dom-1" },
+        data: { config: { somethingElse: "preserved", voice: { autoPipeline: false } } },
+      });
+    });
+
+    it("REJECTS LOCKED_KEYS (provider)", async () => {
+      const { PATCH } = await loadDomainRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/domains/dom-1/voice-config", {
+          method: "PATCH",
+          body: { key: "provider", value: "retell" },
+        }),
+        { params: Promise.resolve({ domainId: "dom-1" }) },
+      );
+      expect(res.status).toBe(400);
+      expect(mockPrisma.domain.update).not.toHaveBeenCalled();
+    });
+
+    it("REJECTS SECRET_KEYS (apiKey)", async () => {
+      const { PATCH } = await loadDomainRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/domains/dom-1/voice-config", {
+          method: "PATCH",
+          body: { key: "apiKey", value: "sk-leak" },
+        }),
+        { params: Promise.resolve({ domainId: "dom-1" }) },
+      );
+      expect(res.status).toBe(400);
+      expect(mockPrisma.domain.update).not.toHaveBeenCalled();
+    });
+
+    it("`value: null` clears the domain override but preserves other config keys", async () => {
+      mockPrisma.domain.findUnique.mockResolvedValue({
+        id: "dom-1",
+        config: { voice: { autoPipeline: false, voiceId: "rachel" }, communityKind: "K" },
+      });
+      const { PATCH } = await loadDomainRoute();
+      const res = await PATCH(
+        buildRequest("http://x/api/domains/dom-1/voice-config", {
+          method: "PATCH",
+          body: { key: "autoPipeline", value: null },
+        }),
+        { params: Promise.resolve({ domainId: "dom-1" }) },
+      );
+      expect(res.status).toBe(200);
+      expect(mockPrisma.domain.update).toHaveBeenCalledWith({
+        where: { id: "dom-1" },
+        data: {
+          config: {
+            communityKind: "K",
+            voice: { voiceId: "rachel" },
+          },
+        },
+      });
+    });
+  });
+});

--- a/docs/audit/MARKET-TEST-READINESS-20260607.md
+++ b/docs/audit/MARKET-TEST-READINESS-20260607.md
@@ -1,0 +1,67 @@
+# Market-Test Readiness Assessment (2026-06-07)
+
+## TL;DR — Not ready as-is. Three operator-action items must land first.
+
+| Block | Why it bites during market test | Owner |
+|---|---|---|
+| **A3** — DATABASE_URL `?connection_limit=5&pool_timeout=20` per env | Cloud SQL pool starves around ~30 concurrent calls. First peak hour will surface `P1001 connection pool timeout` and 5xx cascade. | platform-on-call |
+| **B3** — Cloud Run `--concurrency=20 --max-instances=10 --min-instances=1` on `hf-admin-*` | Without caps, traffic spike auto-scales instances faster than Cloud SQL can absorb. Also bounds runaway Anthropic spend during burst. | platform-on-call |
+| **A7 wiring** — Cloud Scheduler job hitting `/api/cron/cleanup-usage-events` daily | UsageEvent grows ~30M rows/year/10K learners. Without pruning, the metering dashboard slows then breaks within weeks; partial-index B11 work falls on top. | platform-on-call |
+
+Code for all three exists (A3 = env change, B3 = gcloud flag, A7 endpoint shipped in #1277). Exact gcloud commands are in `docs/audit/track-a-deployment-handoff.md`. Estimated ~30 minutes of operator time total.
+
+## Ready to ship as-is
+
+Audit findings that this session closed in code:
+
+- **STUDENT scope** (#1240) — all 25 audited caller-data leaks blocked at edge + per-route. Verified live on sandbox: 14/14 scope tests pass.
+- **Caller-detail page perf** (#1277/A1) — payload capped to 25 calls + 200 targets; composedPrompt scoped to returned window. ~250KB drop per active-learner page load.
+- **ComposedPrompt race** (#1277/A2) — create-then-supersede now atomic. "Two active rows" race eliminated.
+- **CallerAttribute hot path** (#1277/A8) — partial index on `(callerId, key) WHERE validUntil IS NULL`. Live tip reads no longer scan tombstones.
+- **UsageEvent prune endpoint** (#1277/A7) — `POST /api/cron/cleanup-usage-events` exists, dual-auth (ADMIN session OR x-internal-secret). Needs Cloud Scheduler wiring (A7-wiring above).
+- **Caller.phone unique** (#1289/B5) — partial unique index prevents duplicate learners from retried VAPI webhooks. 11 sandbox dupes nulled.
+- **CI safety net** (#1242 + #1272 + #1289/B8) — Prisma generate before tsc, ratchet relock, 10 stale unit tests unblocked, FK consistency check now runs on every PR.
+- **Domain migration backfill** (#1281/B0 part 1) — fresh-DB migrations stop tripping on Domain. Still informational due to wider db-push debt.
+
+## Should ship before market test (high-risk, code change needed)
+
+| # | Story | Effort | Why it matters at market test |
+|---|---|---|---|
+| **C5** | Voice-path composed-prompt first-line eval (#1207 regression net) | 1d | #1207 fixed a real regression where every call opened with "Welcome back. Let's revise…". Without an eval, the next analogous regression goes silently into market-test users. Highest single-user-experience risk. |
+| **B11** | Cron pruners for AppLog (90d), CallMessage (180d), PipelineStep (90d) | 1d | AppLog projects to ~36M rows / ~35GB at 10K learners × 12 months. Mirrors A7 pattern — three HTTP endpoints + Scheduler jobs. Without these, table sizes will become a 90-day problem. |
+| **B6** | ESLint rule `hf-auth/no-unscoped-caller-param` | 3h | Regression catcher for A5/B7. Five engineers shipping in parallel during market test = high chance a new route forgets the scope check. ESLint kills it at PR time. |
+| **B4** | Postgres advisory lock on CallerAttribute lo-mastery upsert | 3h | Concurrency audit Rank 2: classic read-modify-write race on `lo_mastery:` keys. Two calls landing within the same second for the same learner can clobber each other's mastery delta. Bite probability scales with peak concurrency. |
+
+## Can wait until post-market-test (volume optimization)
+
+These pay off at scale but don't break during a market test:
+
+| Bucket | Items |
+|---|---|
+| AI cost (eventually $19k/yr saving) | C1–C4: pipeline.measure rubric eval → pipeline.score_agent eval → cross-model harness → demote Sonnet to Haiku. C4 alone is the saving; C1–C3 are the gates. |
+| Pipeline prompt cache | A4 — multi-day prompt-builder refactor. 40–60% pipeline cost savings but high implementation risk. Only worth it when AI spend is actually material. |
+| Data — long arc | C9 (move Call.transcript to GCS blob), C10 (CallerAttribute tombstone compaction). Both meaningful at scale, neither urgent. |
+| CI strict gates | B0-followup (~80-table db-push backfill), B10 (make migrate non-optional in deploy-release), B9 (cross-env _prisma_migrations diff). Quality-of-life, not market-test blockers. |
+| Audit observability | B12 (cache-tier rows in cost-config.ts), B13 (cache_hit_ratio dashboard) — improves cost-visibility but no current incident. |
+| Other | B1 (split caller-detail god-endpoint), B2 (paginate /courses/[id]/learners). UI perf improvements; A1 covers the immediate hot-path. |
+
+## Recommended sprint to clear market-test blockers
+
+| Day | Work |
+|---|---|
+| Day 1 AM | Operator: A3 (DATABASE_URL params) + B3 (Cloud Run flags). 30 min combined. Verify with a 30-concurrent-call sim. |
+| Day 1 PM | Operator: A7 wiring (Cloud Scheduler job). 15 min. Verify by manual trigger. |
+| Day 2 | Engineer: B11 (three cron pruners + three Scheduler jobs). 1 day. |
+| Day 3 | Engineer: C5 (voice-opening eval). 1 day. |
+| Day 4 AM | Engineer: B6 (ESLint rule). 3h. |
+| Day 4 PM | Engineer: B4 (advisory lock). 3h. |
+| Day 5 | Run a 50-concurrent-call sandbox sim. Verify no `P1001`, no duplicate Caller rows, no doubled lo_mastery deltas, no AppLog runaway. Smoke-test STUDENT routes for 403/200 boundaries. Greenlight. |
+
+After Day 5, market test can open with confidence the audit-cited failure modes are blocked. Track-C optimization happens after first real users provide baseline metrics.
+
+## What this assessment is NOT
+
+- Not a security review beyond the STUDENT scope class. RBAC for OPERATOR/EDUCATOR/ADMIN is well-tested via the existing `route-auth-coverage.test.ts`; no new findings from this audit.
+- Not a UX/UI readiness assessment. The audit focused on backend correctness, cost, and concurrency.
+- Not a stress test. The sandbox sim on Day 5 is the closest we get without real users.
+- Not legal/compliance — separate to the GDPR/AUP work tracked under #1244.

--- a/docs/audit/SESSION-CLOSEOUT-20260607.md
+++ b/docs/audit/SESSION-CLOSEOUT-20260607.md
@@ -37,6 +37,10 @@ B1 (caller-detail tab-loaded slices), B2 (paginate `/courses/[id]/learners`), B3
 ### Track C remainder (eval + capability)
 C1–C3 (`pipeline.measure` / `pipeline.score_agent` rubric evals + cross-model harness) are the critical gate for **C4 (Sonnet → Haiku demotion, ~$19k/yr saving at 1k calls/day)**. C5–C10 follow. No dependency between C1–C2 → can start immediately.
 
+## Market-test readiness
+
+Separate assessment in `docs/audit/MARKET-TEST-READINESS-20260607.md`. **Headline: not ready as-is.** Three operator-action items (A3, B3, A7 wiring) must land before opening to >20 concurrent users. After that, a 4-day engineering sprint on C5 / B11 / B6 / B4 clears the remaining audit-cited risks for market test. Code lands; gcloud + Scheduler do the rest.
+
 ## Recommended first move next session
 
 B5 + B8 shipped late in this session. The remaining quick wins from Track B:


### PR DESCRIPTION
## Summary

`docs/audit/MARKET-TEST-READINESS-20260607.md` answers the strategic question: **can we open to market test as-is?**

**Headline: no.** Three operator-action items (A3 DATABASE_URL pool params, B3 Cloud Run caps, A7 Cloud Scheduler wiring) must land before opening to >20 concurrent users. After that, a 4-day engineering sprint on C5 + B11 + B6 + B4 clears the remaining audit-cited risks.

The doc breaks down:
- **Ready as-is** — what the session shipped
- **Operator-action blockers** — exact gcloud-only items, ~30 min total
- **Should-ship blockers** — C5, B11, B6, B4 (1d / 1d / 3h / 3h)
- **Can wait** — Track C optimization, A4 prompt cache, B0-followup, B1/B2 UI perf
- **Recommended 5-day sprint plan** ending in a 50-concurrent-call sandbox sim

Also updates `docs/audit/SESSION-CLOSEOUT-20260607.md` to link to the new doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)