### PR TITLE
chore(#1266): kill sidetray + move Course-at-a-Glance to Content + hero rework

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseDesignTab.tsx
@@ -7,11 +7,6 @@ import { CollapsibleCard } from '@/components/shared/CollapsibleCard';
 import { FeltProgressSettings } from '@/components/course-design/FeltProgressSettings';
 import { FirstSessionSettings } from '@/components/course-design/FirstSessionSettings';
 import { TolerancesSettings } from '@/components/course-design/TolerancesSettings';
-import { CourseSummaryCard } from './CourseSummaryCard';
-import { archetypeLabel } from '@/lib/course/group-specs';
-import { INTERACTION_PATTERN_LABELS, type InteractionPattern } from '@/lib/content-trust/resolve-config';
-import { getTeachingProfile } from '@/lib/content-trust/teaching-profiles';
-import { getAudienceOption } from '@/lib/prompt/composition/transforms/audience';
 import type { PlaybookConfig } from '@/lib/types/json-fields';
 import type { SetupStatusInput } from '@/hooks/useCourseSetupStatus';
 
@@ -70,58 +65,17 @@ export function CourseDesignTab({
   onSimCall, instructionTotal, categoryCounts, contentMethods, onNavigate,
   onReadinessChange,
 }: CourseDesignTabProps): React.ReactElement {
-  // Session-flow state (intake, NPS, welcome message, onboarding/offboarding
-  // phases, mode, etc.) is owned end-to-end by <SessionFlowEditor>, which
-  // fetches /api/courses/:id/session-flow on mount and persists via PUT.
-  // No mirroring here — one canonical surface.
-
-  // Overview-derived data (from absorbed CourseOverviewTab)
+  // Session-flow state is owned end-to-end by `<CourseDesignConsole>` →
+  // `<SessionFlowEditor>`, which fetches /api/courses/:id/session-flow on
+  // mount and persists via PUT. No mirroring here — one canonical surface.
   const pbConfig = (playbookConfig || {}) as PlaybookConfig;
-  const goals = pbConfig.goals || [];
-  const audienceId = pbConfig.audience || '';
-  const audienceOption = audienceId ? getAudienceOption(audienceId) : null;
-  const firstProfile = (subjects || []).find(s => s.teachingProfile)?.teachingProfile;
-  const profile = firstProfile ? getTeachingProfile(firstProfile) : null;
-  const patternLabel = profile
-    ? (INTERACTION_PATTERN_LABELS[profile.interactionPattern as InteractionPattern]?.label ?? profile.interactionPattern)
-    : null;
-  const totalTPs = (subjects || []).reduce((sum, s) => sum + s.assertionCount, 0);
-  const totalSources = (() => {
-    const seen = new Set<string>();
-    for (const s of (subjects || [])) for (const src of (s.sources ?? [])) seen.add(src.id);
-    return seen.size || (subjects || []).reduce((sum, s) => sum + s.sourceCount, 0);
-  })();
 
   return (
     <div className="hf-mt-lg">
-      {/* ── Summary (absorbed from Overview) ──
-          Collapsed by default — see CourseSummaryCard. `persistKey` lets each
-          course remember its own preference. */}
-      {detail && (
-        <>
-          <CourseSummaryCard
-            interactionPattern={patternLabel}
-            teachingMode={profile?.teachingMode ?? null}
-            audienceLabel={audienceOption?.label ?? null}
-            audienceAges={audienceOption?.ages ?? null}
-            subjectCount={(subjects || []).length}
-            totalTPs={totalTPs}
-            totalSources={totalSources}
-            instructionTotal={instructionTotal || 0}
-            categoryCounts={categoryCounts}
-            contentMethods={contentMethods}
-            goals={goals.map(g => ({ type: g.type, name: g.name }))}
-            personaName={persona?.name ?? null}
-            personaArchetype={persona?.extendsAgent ? archetypeLabel(persona.extendsAgent) : null}
-            sessionPlan={sessionPlan ?? null}
-            publishedAt={detail.publishedAt ?? null}
-            version={String(detail.version ?? '1')}
-            subjectNames={(subjects || []).map(s => s.name)}
-            onNavigate={onNavigate || (() => {})}
-            persistKey={courseId}
-          />
-        </>
-      )}
+      {/* COURSE AT A GLANCE was retired from the Design tab in #1266 cleanup.
+          The same widget now lives at the top of the Content tab
+          (`CourseIntelligenceTab.tsx`) where the data it summarises actually
+          comes from. The Design tab focuses on the journey lenses below. */}
 
       {/* ── Course Design Console (#1263 / Slice 1 #1266) ──
           Replaces the Session Flow CollapsibleCard with a lens-shell that

--- a/apps/admin/app/x/courses/[courseId]/course-detail.css
+++ b/apps/admin/app/x/courses/[courseId]/course-detail.css
@@ -1,5 +1,40 @@
 /* ── Course Detail Page ── cd-* prefix ── */
 
+/* ── Hero (#1266 cleanup) ──
+   3 stacked rows: title, pills, action toolbar. Title is h2 sized so the
+   long "X — Revision Aid" titles don't wrap to 3 lines and shift layout.
+   Pills wrap inside their own row. Action toolbar is right-aligned and
+   can wrap below 920px so the buttons keep their full padding instead of
+   compressing into icons. */
+.cd-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.cd-hero-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.cd-hero-title-row > * {
+  min-width: 0;
+}
+.cd-hero-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.cd-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 /* Fill bar (capacity indicator) */
 .cd-fill-bar {
   width: 60px;

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -17,6 +17,10 @@ import { INTERACTION_PATTERN_LABELS, TEACHING_MODE_LABELS } from '@/lib/content-
 import { CourseOverviewTab } from './CourseOverviewTab';
 import { OnboardingEditor } from '@/components/shared/OnboardingEditor';
 import { CourseIntelligenceTab } from './CourseIntelligenceTab';
+import { CourseSummaryCard } from './CourseSummaryCard';
+import { getTeachingProfile } from '@/lib/content-trust/teaching-profiles';
+import { getAudienceOption } from '@/lib/prompt/composition/transforms/audience';
+import type { InteractionPattern } from '@/lib/content-trust/resolve-config';
 import { CourseWhoTab } from './CourseWhoTab';
 import { CourseGoalsTab } from './CourseGoalsTab';
 import { CourseDesignTab } from './CourseDesignTab';
@@ -37,6 +41,7 @@ import { getPageHelp } from '@/lib/help/page-help';
 import { type TPItem, type SessionOption } from '@/components/shared/SessionTPList';
 import {
   groupSpecs,
+  archetypeLabel,
   type PlaybookItem,
   type SystemSpec,
   type SpecDetail,
@@ -1123,50 +1128,54 @@ export default function CourseDetailPage() {
   // ── Render ───────────────────────────────────────────
   return (
     <div className="hf-page-container hf-page-scroll hf-page-left">
-      {/* ── Hero (always visible above tabs) ───────────── */}
-      <div className="hf-flex hf-flex-between hf-items-start hf-mb-lg">
-        <div>
-          <div className="hf-flex hf-gap-md hf-items-center hf-mb-sm">
-            <EditableTitle
-              value={detail.name}
-              as="h1"
-              onSave={async (newName) => {
-                const res = await fetch(`/api/playbooks/${detail.id}`, {
-                  method: 'PATCH',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ name: newName }),
-                });
-                const data = await res.json();
-                if (!data.ok) throw new Error(data.error);
-                setDetail((prev) => prev ? { ...prev, name: newName } : prev);
-              }}
-            />
-            <StatusBadge status={statusMap[detail.status.toLowerCase()] || 'draft'} />
-            {setupReadiness && (
-              <span className={`cd-readiness-pip ${setupReadiness.allComplete ? 'cd-readiness-pip--ready' : 'cd-readiness-pip--progress'}`}
-                title={setupReadiness.allComplete ? 'Ready to teach' : `Setup: ${setupReadiness.completedCount} of 6`}
-              >
-                {setupReadiness.allComplete ? 'Ready' : `${setupReadiness.completedCount}/6`}
-              </span>
-            )}
-            <ProgressionModePill
-              modulesAuthored={(detail.config as Record<string, unknown> | null | undefined)?.modulesAuthored as boolean | null | undefined}
-              onClickWhenUnset={() => router.push(`/x/courses/${detail.id}?tab=curriculum`)}
-            />
-            <CurriculumSourcePill
-              mode={activeCurriculumMode}
-              onClick={() => router.push(`/x/courses/${detail.id}?tab=curriculum`)}
-            />
-          </div>
-          <div className="hf-flex hf-gap-sm hf-items-center">
-            <DomainPill label={detail.domain.name} href={`/x/domains?id=${detail.domain.id}`} size="compact" />
-            {(detail as any).group && (
-              <span className="hf-pill hf-pill-neutral">{(detail as any).group.name}</span>
-            )}
-            <span className="hf-text-xs hf-text-placeholder">v{detail.version}</span>
-          </div>
+      {/* ── Hero (always visible above tabs) ─────────────
+          Restructured #1266 cleanup: title is h2 (was h1) so the long
+          "X — Revision Aid" style titles stop wrapping to 3 lines; badges
+          live on their own row directly under the title so the layout
+          stays stable regardless of title length; action toolbar sits on
+          its own bottom row, right-aligned, so it doesn't fight the
+          title for horizontal space. */}
+      <div className="hf-mb-lg cd-hero">
+        <div className="cd-hero-title-row">
+          <EditableTitle
+            value={detail.name}
+            as="h2"
+            onSave={async (newName) => {
+              const res = await fetch(`/api/playbooks/${detail.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: newName }),
+              });
+              const data = await res.json();
+              if (!data.ok) throw new Error(data.error);
+              setDetail((prev) => prev ? { ...prev, name: newName } : prev);
+            }}
+          />
         </div>
-        <div className="hf-flex hf-gap-sm">
+        <div className="cd-hero-pills">
+          <StatusBadge status={statusMap[detail.status.toLowerCase()] || 'draft'} />
+          {setupReadiness && (
+            <span className={`cd-readiness-pip ${setupReadiness.allComplete ? 'cd-readiness-pip--ready' : 'cd-readiness-pip--progress'}`}
+              title={setupReadiness.allComplete ? 'Ready to teach' : `Setup: ${setupReadiness.completedCount} of 6`}
+            >
+              {setupReadiness.allComplete ? 'Ready' : `${setupReadiness.completedCount}/6`}
+            </span>
+          )}
+          <ProgressionModePill
+            modulesAuthored={(detail.config as Record<string, unknown> | null | undefined)?.modulesAuthored as boolean | null | undefined}
+            onClickWhenUnset={() => router.push(`/x/courses/${detail.id}?tab=curriculum`)}
+          />
+          <CurriculumSourcePill
+            mode={activeCurriculumMode}
+            onClick={() => router.push(`/x/courses/${detail.id}?tab=curriculum`)}
+          />
+          <DomainPill label={detail.domain.name} href={`/x/domains?id=${detail.domain.id}`} size="compact" />
+          {(detail as any).group && (
+            <span className="hf-pill hf-pill-neutral">{(detail as any).group.name}</span>
+          )}
+          <span className="hf-text-xs hf-text-placeholder">v{detail.version}</span>
+        </div>
+        <div className="cd-hero-actions">
           {isOperator && (
             <button
               className="hf-btn hf-btn-destructive hf-nowrap"
@@ -1573,28 +1582,71 @@ export default function CourseDetailPage() {
       {/* ═══════════════════════════════════════════════ */}
       {/* CONTENT INTELLIGENCE TAB                       */}
       {/* ═══════════════════════════════════════════════ */}
-      {activeTab === 'intelligence' && (
-        <CourseIntelligenceTab
-          courseId={courseId!}
-          detail={detail}
-          subjects={subjects}
-          courseSources={courseSources}
-          courseTeachingProfile={courseTeachingProfile}
-          contentMethods={contentMethods}
-          contentTotal={contentTotal}
-          instructionCount={instructionTotal}
-          unassignedContentCount={unassignedContentCount}
-          categoryCounts={categoryCounts}
-          categoryItems={categoryItems}
-          isOperator={isOperator}
-          onContentRefresh={(methods, total, instrCount, unassignedContent) => {
-            setContentMethods(methods);
-            setContentTotal(total);
-            if (instrCount !== undefined) setInstructionTotal(instrCount);
-            if (unassignedContent !== undefined) setUnassignedContentCount(unassignedContent);
-          }}
-        />
-      )}
+      {activeTab === 'intelligence' && (() => {
+        // COURSE AT A GLANCE moved from the Design tab in #1266 cleanup.
+        // Derivation lives here (page.tsx) because page.tsx already has
+        // every input — no prop drilling into either CourseIntelligenceTab
+        // or the retired CourseDesignTab summary block.
+        const pbConfig = (detail?.config ?? {}) as PlaybookConfig;
+        const audienceId = (pbConfig.audience as string | undefined) || '';
+        const audienceOption = audienceId ? getAudienceOption(audienceId) : null;
+        const firstProfile = subjects.find(s => s.teachingProfile)?.teachingProfile;
+        const profile = firstProfile ? getTeachingProfile(firstProfile) : null;
+        const patternLabel = profile
+          ? (INTERACTION_PATTERN_LABELS[profile.interactionPattern as InteractionPattern]?.label ?? profile.interactionPattern)
+          : null;
+        const goalsList = (pbConfig.goals as Array<{ type: string; name: string }> | undefined) || [];
+        const sessionPlanForSummary = sessions?.plan
+          ? { estimatedSessions: sessions.plan.estimatedSessions, totalDurationMins: totalSessionDuration }
+          : null;
+        return (
+          <>
+            {detail && (
+              <CourseSummaryCard
+                interactionPattern={patternLabel}
+                teachingMode={profile?.teachingMode ?? null}
+                audienceLabel={audienceOption?.label ?? null}
+                audienceAges={audienceOption?.ages ?? null}
+                subjectCount={subjects.length}
+                totalTPs={totalTPs}
+                totalSources={totalSources}
+                instructionTotal={instructionTotal || 0}
+                categoryCounts={categoryCounts}
+                contentMethods={contentMethods.map(m => ({ teachMethod: m.teachMethod, count: m.count }))}
+                goals={goalsList.map(g => ({ type: g.type, name: g.name }))}
+                personaName={persona?.name ?? null}
+                personaArchetype={persona?.extendsAgent ? archetypeLabel(persona.extendsAgent) : null}
+                sessionPlan={sessionPlanForSummary}
+                publishedAt={detail.publishedAt ?? null}
+                version={String(detail.version ?? '1')}
+                subjectNames={subjects.map(s => s.name)}
+                onNavigate={handleTabChange}
+                persistKey={courseId!}
+              />
+            )}
+            <CourseIntelligenceTab
+              courseId={courseId!}
+              detail={detail}
+              subjects={subjects}
+              courseSources={courseSources}
+              courseTeachingProfile={courseTeachingProfile}
+              contentMethods={contentMethods}
+              contentTotal={contentTotal}
+              instructionCount={instructionTotal}
+              unassignedContentCount={unassignedContentCount}
+              categoryCounts={categoryCounts}
+              categoryItems={categoryItems}
+              isOperator={isOperator}
+              onContentRefresh={(methods, total, instrCount, unassignedContent) => {
+                setContentMethods(methods);
+                setContentTotal(total);
+                if (instrCount !== undefined) setInstructionTotal(instrCount);
+                if (unassignedContent !== undefined) setUnassignedContentCount(unassignedContent);
+              }}
+            />
+          </>
+        );
+      })()}
 
       {/* ═══════════════════════════════════════════════ */}
       {/* LEARNERS TAB                                   */}

--- a/apps/admin/components/session-flow/SessionFlowEditor.tsx
+++ b/apps/admin/components/session-flow/SessionFlowEditor.tsx
@@ -31,8 +31,6 @@ import {
   ChevronRight,
   Target,
   HelpCircle,
-  Pencil,
-  X,
   AlertTriangle,
 } from "lucide-react";
 import type {
@@ -84,8 +82,6 @@ interface RowSpec {
     onChange: (next: boolean) => void;
   };
 }
-
-type DrawerKind = null | "mode" | "kc-delivery" | "nps" | "welcome-msg" | "onboarding-phases" | "offboarding-phases";
 
 /**
  * Lens scoping (Slice 1 of #1263 / story #1266).
@@ -140,7 +136,6 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [drawer, setDrawer] = useState<DrawerKind>(null);
   const [savingToggle, setSavingToggle] = useState<string | null>(null);
 
   const refetch = useCallback(() => {
@@ -165,7 +160,6 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
 
   const onUpdated = (next: ApiResponse) => {
     setData(next);
-    setDrawer(null);
   };
 
   /**
@@ -415,15 +409,6 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
     },
   ];
 
-  const handleEdit = (rowId: string) => {
-    if (rowId === "sessions") setDrawer("mode");
-    else if (rowId === "knowledge-check") setDrawer("kc-delivery");
-    else if (rowId === "nps") setDrawer("nps");
-    else if (rowId === "welcome-message") setDrawer("welcome-msg");
-    else if (rowId === "onboarding") setDrawer("onboarding-phases");
-    else if (rowId === "offboarding") setDrawer("offboarding-phases");
-  };
-
   const toggleRow = (id: string) => setExpandedId(prev => (prev === id ? null : id));
 
   const beforeRows = rowsForLens(before, activeSection);
@@ -453,9 +438,7 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
             rows={beforeRows}
             expandedId={expandedId}
             onToggle={toggleRow}
-            onEdit={handleEdit}
             savingToggle={savingToggle}
-            hideEdit={isLensMode}
           />
         )}
         {duringRows.length > 0 && (
@@ -464,9 +447,7 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
             rows={duringRows}
             expandedId={expandedId}
             onToggle={toggleRow}
-            onEdit={handleEdit}
             savingToggle={savingToggle}
-            hideEdit={isLensMode}
           />
         )}
         {afterRows.length > 0 && (
@@ -475,9 +456,7 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
             rows={afterRows}
             expandedId={expandedId}
             onToggle={toggleRow}
-            onEdit={handleEdit}
             savingToggle={savingToggle}
-            hideEdit={isLensMode}
           />
         )}
 
@@ -487,118 +466,52 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
             lens mode — educators see + edit in one place. */}
         {isLensMode && activeSection === "intake" && sessionFlow.intake.knowledgeCheck.enabled && (
           <KcDeliveryDrawer
-            inline
             courseId={courseId}
             sessionFlow={sessionFlow}
-            onClose={() => {}}
             onSaved={onUpdated}
           />
         )}
         {isLensMode && activeSection === "onboarding" && data.domainId && (
           <PhaseListDrawer
-            inline
             title="Onboarding flow phases"
             courseId={courseId}
             domainId={data.domainId}
             domainName={data.domainName}
             mode="onboarding"
-            onClose={() => refetch()}
           />
         )}
         {isLensMode && activeSection === "stops" && (
           <>
             <ModeDrawer
-              inline
               courseId={courseId}
               currentMode={mode}
               sessionCount={sessionCount}
-              onClose={() => {}}
               onSaved={onUpdated}
             />
             <NpsDrawer
-              inline
               courseId={courseId}
               sessionFlow={sessionFlow}
-              onClose={() => {}}
               onSaved={onUpdated}
             />
           </>
         )}
         {isLensMode && activeSection === "offboarding" && data.domainId && (
           <PhaseListDrawer
-            inline
             title="Offboarding flow phases"
             courseId={courseId}
             domainId={data.domainId}
             domainName={data.domainName}
             mode="offboarding"
-            onClose={() => refetch()}
           />
         )}
         {isLensMode && activeSection === "welcome" && (
           <WelcomeMessageDrawer
-            inline
             courseId={courseId}
             current={sessionFlow.welcomeMessage ?? ""}
-            onClose={() => {}}
             onSaved={onUpdated}
           />
         )}
       </div>
-
-      {drawer === "mode" && (
-        <ModeDrawer
-          courseId={courseId}
-          currentMode={mode}
-          sessionCount={sessionCount}
-          onClose={() => setDrawer(null)}
-          onSaved={onUpdated}
-        />
-      )}
-      {drawer === "kc-delivery" && (
-        <KcDeliveryDrawer
-          courseId={courseId}
-          sessionFlow={sessionFlow}
-          onClose={() => setDrawer(null)}
-          onSaved={onUpdated}
-        />
-      )}
-      {drawer === "nps" && (
-        <NpsDrawer
-          courseId={courseId}
-          sessionFlow={sessionFlow}
-          onClose={() => setDrawer(null)}
-          onSaved={onUpdated}
-        />
-      )}
-      {drawer === "welcome-msg" && (
-        <WelcomeMessageDrawer
-          courseId={courseId}
-          current={sessionFlow.welcomeMessage ?? ""}
-          onClose={() => setDrawer(null)}
-          onSaved={onUpdated}
-        />
-      )}
-      {drawer === "onboarding-phases" && data.domainId && (
-        <PhaseListDrawer
-          title="Onboarding flow phases"
-          courseId={courseId}
-          domainId={data.domainId}
-          domainName={data.domainName}
-          mode="onboarding"
-          onClose={() => { setDrawer(null); refetch(); }}
-        />
-      )}
-      {drawer === "offboarding-phases" && data.domainId && (
-        <PhaseListDrawer
-          title="Offboarding flow phases"
-          courseId={courseId}
-          domainId={data.domainId}
-          domainName={data.domainName}
-          mode="offboarding"
-          onClose={() => { setDrawer(null); refetch(); }}
-        />
-      )}
     </>
   );
 }
@@ -606,21 +519,19 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
 // ── Phase list drawer (#225 part 4) ──────────────────────────────────────────
 
 function PhaseListDrawer({
-  title, courseId, domainId, domainName, mode, onClose, inline,
+  title, courseId, domainId, domainName, mode,
 }: {
   title: string;
   courseId: string;
   domainId: string;
   domainName: string | null;
   mode: "onboarding" | "offboarding";
-  onClose: () => void;
-  inline?: boolean;
 }) {
   return (
-    <Drawer title={title} onClose={onClose} inline={inline}>
+    <Drawer title={title}>
       <p className="sfe-drawer-desc">
         Drag phases to reorder. Click a phase to edit its goals, duration, content, and survey steps.
-        Changes save automatically{inline ? "." : " — close when done."}
+        Changes save automatically.
       </p>
       <div className="sfe-phase-host">
         <OnboardingEditor
@@ -632,13 +543,6 @@ function PhaseListDrawer({
           mode={mode}
         />
       </div>
-      {!inline && (
-        <footer className="sfe-drawer-footer">
-          <button type="button" className="sfe-btn-primary" onClick={onClose}>
-            Done
-          </button>
-        </footer>
-      )}
     </Drawer>
   );
 }
@@ -646,15 +550,13 @@ function PhaseListDrawer({
 // ── Sub-components ──────────────────────────────────────────────
 
 function Section({
-  title, rows, expandedId, onToggle, onEdit, savingToggle, hideEdit,
+  title, rows, expandedId, onToggle, savingToggle,
 }: {
   title: string | null;
   rows: RowSpec[];
   expandedId: string | null;
   onToggle: (id: string) => void;
-  onEdit: (id: string) => void;
   savingToggle: string | null;
-  hideEdit?: boolean;
 }) {
   return (
     <div className="sft-section">
@@ -666,9 +568,7 @@ function Section({
             row={row}
             expanded={expandedId === row.id}
             onToggle={() => onToggle(row.id)}
-            onEdit={() => onEdit(row.id)}
             saving={savingToggle === row.id}
-            hideEdit={hideEdit}
           />
         ))}
       </ul>
@@ -677,14 +577,12 @@ function Section({
 }
 
 function Row({
-  row, expanded, onToggle, onEdit, saving, hideEdit,
+  row, expanded, onToggle, saving,
 }: {
   row: RowSpec;
   expanded: boolean;
   onToggle: () => void;
-  onEdit: () => void;
   saving: boolean;
-  hideEdit?: boolean;
 }) {
   const expandable = !!row.details && row.details.length > 0;
   const classes = [
@@ -695,22 +593,15 @@ function Row({
   ].filter(Boolean).join(" ");
 
   // The status column shows either the Apple toggle or the static badge.
-  // The action column shows the Edit button, an expand chevron, or empty.
+  // The action column shows an expand chevron when the row is expandable.
+  // The per-row [Edit ▸] button was retired with the sidetray (#1266) —
+  // every editable field lives in an inline form below the rows.
   const statusControl = row.toggle ? (
     <Toggle on={row.toggle.on} onChange={row.toggle.onChange} saving={saving} ariaLabel={row.label} />
   ) : (
     <span className={`sft-row-badge sft-row-badge--${row.status}`}>{statusLabel(row.status)}</span>
   );
-  const actionControl = row.editable && !hideEdit ? (
-    <button
-      className="sfe-edit-btn"
-      type="button"
-      onClick={(e) => { e.stopPropagation(); onEdit(); }}
-      title="Edit"
-    >
-      <Pencil size={12} /> <span>Edit</span>
-    </button>
-  ) : (
+  const actionControl = (
     <span className="sft-row-chevron">
       {expandable ? <ChevronRight size={14} /> : <span style={{ width: 14, display: "inline-block" }} />}
     </span>
@@ -784,14 +675,12 @@ function Toggle({
 // ── Mode picker drawer ──────────────────────────────────────────────
 
 function ModeDrawer({
-  courseId, currentMode, sessionCount, onClose, onSaved, inline,
+  courseId, currentMode, sessionCount, onSaved,
 }: {
   courseId: string;
   currentMode: "continuous" | "structured";
   sessionCount: number | null;
-  onClose: () => void;
   onSaved: (next: ApiResponse) => void;
-  inline?: boolean;
 }) {
   const [picked, setPicked] = useState<"continuous" | "structured">(currentMode);
   const [saving, setSaving] = useState(false);
@@ -822,7 +711,7 @@ function ModeDrawer({
   };
 
   return (
-    <Drawer title="Course mode" onClose={onClose} inline={inline}>
+    <Drawer title="Course mode">
       <p className="sfe-drawer-desc">
         Pick how this course paces sessions. Changing this on a live course
         affects how learners progress.
@@ -861,11 +750,6 @@ function ModeDrawer({
       {err && <div className="sfe-error">Save failed: {err}</div>}
 
       <footer className="sfe-drawer-footer">
-        {!inline && (
-          <button type="button" className="sfe-btn-secondary" onClick={onClose} disabled={saving}>
-            Cancel
-          </button>
-        )}
         <button
           type="button"
           className="sfe-btn-primary"
@@ -904,13 +788,11 @@ function ModeOption({
 // ── KC delivery mode drawer ──────────────────────────────────────────────
 
 function KcDeliveryDrawer({
-  courseId, sessionFlow, onClose, onSaved, inline,
+  courseId, sessionFlow, onSaved,
 }: {
   courseId: string;
   sessionFlow: SessionFlowResolved;
-  onClose: () => void;
   onSaved: (next: ApiResponse) => void;
-  inline?: boolean;
 }) {
   const current = sessionFlow.intake.knowledgeCheck.deliveryMode ?? "mcq";
   const [picked, setPicked] = useState<"mcq" | "socratic">(current);
@@ -947,7 +829,7 @@ function KcDeliveryDrawer({
   };
 
   return (
-    <Drawer title="Knowledge Check delivery" onClose={onClose} inline={inline}>
+    <Drawer title="Knowledge Check delivery">
       <p className="sfe-drawer-desc">
         Choose how the educator probes prior knowledge in the first call. One mode only — no double-quizzing.
       </p>
@@ -971,7 +853,6 @@ function KcDeliveryDrawer({
       </div>
       {err && <div className="sfe-error">Save failed: {err}</div>}
       <footer className="sfe-drawer-footer">
-        {!inline && <button type="button" className="sfe-btn-secondary" onClick={onClose} disabled={saving}>Cancel</button>}
         <button type="button" className="sfe-btn-primary" onClick={save} disabled={!dirty || saving}>
           {saving ? "Saving…" : "Save delivery mode"}
         </button>
@@ -983,13 +864,11 @@ function KcDeliveryDrawer({
 // ── NPS drawer ──────────────────────────────────────────────
 
 function NpsDrawer({
-  courseId, sessionFlow, onClose, onSaved, inline,
+  courseId, sessionFlow, onSaved,
 }: {
   courseId: string;
   sessionFlow: SessionFlowResolved;
-  onClose: () => void;
   onSaved: (next: ApiResponse) => void;
-  inline?: boolean;
 }) {
   const stop = sessionFlow.stops.find(s => s.kind === "nps");
   const initialEnabled = !!stop;
@@ -1033,7 +912,7 @@ function NpsDrawer({
   };
 
   return (
-    <Drawer title="NPS satisfaction survey" onClose={onClose} inline={inline}>
+    <Drawer title="NPS satisfaction survey">
       <p className="sfe-drawer-desc">
         Pick when the post-course NPS survey fires. Mastery triggers respect the learner&rsquo;s actual progress; session count triggers fire on a fixed call number.
       </p>
@@ -1081,7 +960,6 @@ function NpsDrawer({
 
       {err && <div className="sfe-error">Save failed: {err}</div>}
       <footer className="sfe-drawer-footer">
-        {!inline && <button type="button" className="sfe-btn-secondary" onClick={onClose} disabled={saving}>Cancel</button>}
         <button type="button" className="sfe-btn-primary" onClick={save} disabled={!dirty || saving}>
           {saving ? "Saving…" : "Save NPS"}
         </button>
@@ -1093,13 +971,11 @@ function NpsDrawer({
 // ── Welcome message drawer ──────────────────────────────────────────────
 
 function WelcomeMessageDrawer({
-  courseId, current, onClose, onSaved, inline,
+  courseId, current, onSaved,
 }: {
   courseId: string;
   current: string;
-  onClose: () => void;
   onSaved: (next: ApiResponse) => void;
-  inline?: boolean;
 }) {
   const [text, setText] = useState(current);
   const [saving, setSaving] = useState(false);
@@ -1127,7 +1003,7 @@ function WelcomeMessageDrawer({
   };
 
   return (
-    <Drawer title="Welcome message" onClose={onClose} inline={inline}>
+    <Drawer title="Welcome message">
       <p className="sfe-drawer-desc">
         First-line greeting the AI uses on the learner&rsquo;s first call. Leave blank to fall back to the domain default or a generic greeting.
       </p>
@@ -1145,7 +1021,6 @@ function WelcomeMessageDrawer({
       </label>
       {err && <div className="sfe-error">Save failed: {err}</div>}
       <footer className="sfe-drawer-footer">
-        {!inline && <button type="button" className="sfe-btn-secondary" onClick={onClose} disabled={saving}>Cancel</button>}
         <button type="button" className="sfe-btn-primary" onClick={save} disabled={!dirty || saving}>
           {saving ? "Saving…" : (trimmed.length === 0 && current.length > 0 ? "Clear message" : "Save message")}
         </button>
@@ -1154,43 +1029,26 @@ function WelcomeMessageDrawer({
   );
 }
 
+/**
+ * Inline editor card. Was originally a fixed sidetray with backdrop and
+ * close X; the sidetray was retired (#1266 cleanup) in favour of always-
+ * inline forms inside `<CourseDesignConsole>` lens panels. The component
+ * is kept as a small composable wrapper so each XxxDrawer doesn't have
+ * to duplicate the header + body chrome.
+ */
 function Drawer({
-  title, onClose, children, inline,
+  title, children,
 }: {
   title: string;
-  onClose: () => void;
   children: React.ReactNode;
-  /**
-   * When true, render as an inline card (no backdrop, no fixed positioning,
-   * no header close button) so the form lives directly inside a lens panel.
-   * The Course Design Console (#1266) uses this so educators see + edit in
-   * one place instead of opening a sidetray.
-   */
-  inline?: boolean;
 }) {
-  if (inline) {
-    return (
-      <section className="sfe-drawer sfe-drawer--inline" aria-label={title}>
-        <header className="sfe-drawer-header">
-          <h2 className="sfe-drawer-title">{title}</h2>
-        </header>
-        <div className="sfe-drawer-body">{children}</div>
-      </section>
-    );
-  }
   return (
-    <>
-      <div className="sfe-backdrop" onClick={onClose} />
-      <aside className="sfe-drawer" role="dialog" aria-label={title}>
-        <header className="sfe-drawer-header">
-          <h2 className="sfe-drawer-title">{title}</h2>
-          <button type="button" className="sfe-icon-btn" onClick={onClose} title="Close">
-            <X size={16} />
-          </button>
-        </header>
-        <div className="sfe-drawer-body">{children}</div>
-      </aside>
-    </>
+    <section className="sfe-drawer sfe-drawer--inline" aria-label={title}>
+      <header className="sfe-drawer-header">
+        <h2 className="sfe-drawer-title">{title}</h2>
+      </header>
+      <div className="sfe-drawer-body">{children}</div>
+    </section>
   );
 }
 

--- a/apps/admin/components/session-flow/session-flow-editor.css
+++ b/apps/admin/components/session-flow/session-flow-editor.css
@@ -80,61 +80,26 @@
   background: color-mix(in srgb, var(--accent-primary) 6%, var(--surface-primary));
 }
 
-/* Drawer */
-.sfe-backdrop {
-  position: fixed;
-  inset: 0;
-  background: color-mix(in srgb, #000 35%, transparent);
-  z-index: 100;
-}
-.sfe-drawer {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 480px;
-  max-width: 100vw;
-  background: var(--surface-primary);
-  border-left: 1px solid var(--border-default);
-  box-shadow: -4px 0 16px color-mix(in srgb, #000 8%, transparent);
-  z-index: 101;
+/* ── Inline editor card (#1266 — sidetray retired) ──
+   Was originally a fixed sidetray with backdrop. Every drawer now lives
+   inline inside a lens panel, so the modal-only styles (backdrop, fixed
+   positioning, sliding shadow) are gone. The remaining .sfe-drawer
+   styles are just card chrome — border, radius, header + body padding.
+   `.sfe-drawer--inline` is retained as a no-op alias for any consumer
+   that still passes the className. */
+.sfe-drawer,
+.sfe-drawer--inline {
   display: flex;
   flex-direction: column;
-}
-
-/* Phase-list drawer wraps the full OnboardingEditor — needs wider canvas. */
-.sfe-drawer:has(.sfe-phase-host) {
-  width: 720px;
+  width: 100%;
+  max-width: none;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  margin-top: 16px;
 }
 .sfe-phase-host {
   margin-bottom: 12px;
-}
-
-/* ── Inline drawer (lens mode, #1266) ──
-   Rendered directly inside a lens panel — no backdrop, no fixed
-   positioning, no close X. Sits as a bordered card below the rows
-   so educators see + edit in one place. Wider canvas for the phase
-   list still applies. */
-.sfe-drawer--inline {
-  position: static;
-  width: 100%;
-  max-width: none;
-  border: 1px solid var(--border-default);
-  border-left: 1px solid var(--border-default);
-  border-radius: 12px;
-  box-shadow: none;
-  margin-top: 16px;
-  z-index: auto;
-}
-.sfe-drawer--inline.sfe-drawer:has(.sfe-phase-host) {
-  width: 100%;
-}
-.sfe-drawer--inline .sfe-drawer-header {
-  padding: 12px 16px;
-}
-.sfe-drawer--inline .sfe-drawer-body {
-  padding: 16px;
-  overflow: visible;
 }
 
 .sfe-drawer-header {


### PR DESCRIPTION
## Summary

Three follow-ups against the Slice 1 ship after live design review:

1. **Sidetray completely removed.** Previously \`inline\` mode kept the modal \`<Drawer>\` wrapper around each form and toggled chrome off. That's gone — \`Drawer\` is a plain bordered card, no backdrop, no fixed positioning, no header X close. The 5 form components drop their \`inline\` prop and Cancel button. \`SessionFlowEditor\` drops \`drawer\`/\`setDrawer\`/\`DrawerKind\`/\`handleEdit\` and the Edit row button entirely.
2. **COURSE AT A GLANCE moved.** Out of Design tab → top of Content tab. Same widget, page.tsx already has every input so no prop drilling. CourseDesignTab simplified (lost ~30 lines of derivation it no longer needs).
3. **Hero restructured.** Title h1 (28px) → h2 (20px). Three stacked rows: title / pills / action toolbar. Title no longer wraps to 3 lines; layout stable regardless of title length. New \`.cd-hero-*\` CSS classes.

## Test plan

- [x] 11/11 in \`tests/components/courses/course-design-console.test.tsx\` green
- [ ] Visit \`/x/courses/<id>?tab=design&design_view=onboarding\` — phase editor inline, no [Edit] button, no sidetray modal possible
- [ ] Visit \`/x/courses/<id>?tab=design&design_view=stops\` — Mode picker + NPS form inline together
- [ ] Visit \`/x/courses/<id>?tab=intelligence\` — COURSE AT A GLANCE card appears at top
- [ ] Visit \`/x/courses/<id>?tab=design\` — COURSE AT A GLANCE GONE from Design tab
- [ ] Resize window with a very long course title — header doesn't wrap, action buttons stay aligned

Refs #1266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)