### PR TITLE
fix(voice-config): use CallerPlaybook join — Caller has no playbookId field

### DIFF
--- a/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
@@ -45,12 +45,21 @@ export async function GET(
   }
 
   // Find a caller in this playbook so we can pull the Domain layer
-  // through the existing loader. If none exists yet, resolve with caller
-  // null — Domain layer is then absent from the cascade.
-  const aCaller = await prisma.caller.findFirst({
+  // through the existing loader. If none exists yet, resolve with
+  // caller null — Domain layer is then absent from the cascade.
+  //
+  // Caller has no direct `playbookId` column — the link is the
+  // `CallerPlaybook` join table (relation: Caller.enrollments). The
+  // earlier `prisma.caller.findFirst({ where: { playbookId } })`
+  // surfaced as a 500 with the Prisma fingerprint
+  // "voiceProvider?: StringNullableFilter | String | Null" (the
+  // autocomplete suggestion list for a non-existent field). Going
+  // through the join table fixes it.
+  const enrollment = await prisma.callerPlaybook.findFirst({
     where: { playbookId },
-    select: { id: true },
+    select: { callerId: true },
   });
+  const aCaller = enrollment ? { id: enrollment.callerId } : null;
 
   const resolved = await loadResolvedVoiceConfig({
     callerId: aCaller?.id ?? null,


### PR DESCRIPTION
Hotfix for GET /api/playbooks/[id]/voice-config 500 on every Voice panel load. prisma.caller.findFirst({ where: { playbookId } }) failed because Caller has no direct playbookId; routes through the CallerPlaybook join table now.