### PR TITLE
fix(voice): course voice-config caller lookup via CallerPlaybook (#1271)

### DIFF
--- a/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
@@ -45,24 +45,17 @@ export async function GET(
   }
 
   // Find a caller in this playbook so we can pull the Domain layer
-  // through the existing loader. If none exists yet, resolve with
-  // caller null — Domain layer is then absent from the cascade.
-  //
-  // Caller has no direct `playbookId` column — the link is the
-  // `CallerPlaybook` join table (relation: Caller.enrollments). The
-  // earlier `prisma.caller.findFirst({ where: { playbookId } })`
-  // surfaced as a 500 with the Prisma fingerprint
-  // "voiceProvider?: StringNullableFilter | String | Null" (the
-  // autocomplete suggestion list for a non-existent field). Going
-  // through the join table fixes it.
+  // through the existing loader. Caller has no `playbookId` column —
+  // the link is the `CallerPlaybook` join. The earlier
+  // `prisma.caller.findFirst({where:{playbookId}})` surfaced as a 500
+  // with a PrismaClientValidationError. Going through the join fixes it.
   const enrollment = await prisma.callerPlaybook.findFirst({
     where: { playbookId },
     select: { callerId: true },
   });
-  const aCaller = enrollment ? { id: enrollment.callerId } : null;
 
   const resolved = await loadResolvedVoiceConfig({
-    callerId: aCaller?.id ?? null,
+    callerId: enrollment?.callerId ?? null,
     playbookId,
   });
 

--- a/apps/admin/tests/api/voice-config-routes.test.ts
+++ b/apps/admin/tests/api/voice-config-routes.test.ts
@@ -16,6 +16,7 @@ const mockPrisma = {
   playbook: { findUnique: vi.fn() },
   domain: { findUnique: vi.fn(), update: vi.fn() },
   caller: { findFirst: vi.fn() },
+  callerPlaybook: { findFirst: vi.fn() },
 };
 
 vi.mock("@/lib/prisma", () => ({
@@ -93,7 +94,7 @@ describe("/api/playbooks/:playbookId/voice-config (#1271 Slice C)", () => {
         domainId: "dom-1",
         config: { voice: { autoPipeline: false } },
       });
-      mockPrisma.caller.findFirst.mockResolvedValue({ id: "c-1" });
+      mockPrisma.callerPlaybook.findFirst.mockResolvedValue({ callerId: "c-1" });
 
       const { GET } = await loadPlaybookRoute();
       const res = await GET(
@@ -129,7 +130,7 @@ describe("/api/playbooks/:playbookId/voice-config (#1271 Slice C)", () => {
         domainId: "dom-1",
         config: {},
       });
-      mockPrisma.caller.findFirst.mockResolvedValue(null);
+      mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
 
       const { GET } = await loadPlaybookRoute();
       const res = await GET(


### PR DESCRIPTION
Found via live smoke on hf-dev: the new Course Settings → Voice section rendered "Voice config: HTTP 500".

## Cause

\`/api/playbooks/[id]/voice-config\` GET handler called \`prisma.caller.findFirst({where:{playbookId}})\`, but \`Caller\` has no \`playbookId\` column. Caller↔Playbook is via the \`CallerPlaybook\` join.

## Fix

Switched to \`prisma.callerPlaybook.findFirst({where:{playbookId}})\` and use its \`callerId\`. Domain-route counterpart was already correct (Caller does have \`domainId\`).

## Test plan

- [x] Walking-set tests updated to mock \`callerPlaybook.findFirst\`. 18/18 still pass on the route handler test file.
- [ ] Smoke after merge: load /x/courses/[id] → Settings → Voice → section renders rows (not HTTP 500).

## Deploy

\`/vm-cp\` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)