### PR TITLE
fix(voice): stop falling back to LLM provider slug as voice provider (#1271)

### DIFF
--- a/apps/admin/lib/voice/load-voice-config.ts
+++ b/apps/admin/lib/voice/load-voice-config.ts
@@ -39,14 +39,29 @@ function extractVoiceBlob(blob: unknown): Record<string, unknown> | null {
 export async function loadResolvedVoiceConfig(args: LoadArgs): Promise<ResolvedVoiceConfig> {
   const vs = await getVoiceCallSettings();
   const sys = await getVoiceSystemSettings();
-  const enabledSlug = sys.defaultProviderSlug || vs.provider || "vapi";
+  // #1271 — `vs.provider` is the LLM provider (openai / anthropic /
+  // custom-llm), NOT the voice provider slug. Falling back to it caused
+  // `getVoiceProvider("custom-llm")` 500s on any system where
+  // `VoiceSystemSettings.defaultProviderSlug` is blank but a VAPI row
+  // exists. Pick a real voice provider: explicit setting → vapi default.
+  const explicit = sys.defaultProviderSlug?.trim();
+  const enabledSlug = explicit && explicit.length > 0 ? explicit : "vapi";
 
   const [vpRow, adapter, domainConfig, courseConfig] = await Promise.all([
     prisma.voiceProvider.findUnique({
       where: { slug: enabledSlug },
       select: { slug: true, config: true },
     }),
-    getVoiceProvider(enabledSlug),
+    getVoiceProvider(enabledSlug).catch((err) => {
+      // If the configured slug doesn't resolve (operator setting drift)
+      // surface a synthetic empty-schema adapter so the resolver still
+      // returns a valid cascade — the caller will see system defaults.
+      console.warn(`[voice-config] adapter resolve failed for slug=${enabledSlug}:`, err instanceof Error ? err.message : String(err));
+      return {
+        slug: enabledSlug,
+        getConfigSchema: () => ({ fields: [] }),
+      } as Awaited<ReturnType<typeof getVoiceProvider>>;
+    }),
     args.callerId ? loadDomainVoice(args.callerId) : Promise.resolve(null),
     args.playbookId ? loadPlaybookVoice(args.playbookId) : Promise.resolve(null),
   ]);


### PR DESCRIPTION
Second voice-config 500 surfaced after #1301 — different cause, same endpoint.

## Cause

\`loadResolvedVoiceConfig\` had: \`sys.defaultProviderSlug || vs.provider || "vapi"\`. But \`vs.provider\` is the LLM provider (openai / anthropic / **custom-llm**), NOT the voice adapter slug. On hf-dev where \`VoiceSystemSettings.defaultProviderSlug\` is blank, the fallback tried to resolve \`getVoiceProvider("custom-llm")\` which throws "Unknown voice provider slug" → HTTP 500.

## Fix

- \`enabledSlug = sys.defaultProviderSlug?.trim() || "vapi"\` — never reads from \`vs.provider\`.
- \`getVoiceProvider()\` failure downgrades to a synthetic empty-schema adapter so the cascade still returns system defaults instead of 500ing.

## Test plan

- [ ] Reload /x/courses/[id]?tab=settings → expand Voice → section renders rows (not "HTTP 500").
- [ ] Existing tests untouched — load helper still returns the resolver shape.

## Deploy

\`/vm-cp\` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)