### PR TITLE
feat(voice-ui): direct-edit voice config — kill the Override step (#1271)

### DIFF
--- a/apps/admin/components/voice/VoiceConfigSection.tsx
+++ b/apps/admin/components/voice/VoiceConfigSection.tsx
@@ -1,12 +1,11 @@
 /**
  * Shared Voice config section (#1271 Slices C + D).
  *
- * Renders one row per cascadeable voice field with:
- *   - Field label + help text from the per-VP schema
- *   - Resolved value
- *   - Provenance badge (system | provider | domain | course)
- *   - Inline edit input
- *   - "Clear override" affordance when this layer is the source
+ * Renders one row per cascadeable voice field. Each field is always
+ * directly editable — no "Override" intermediate step. Edits autosave
+ * on change (toggles + selects) or blur with debounce (text + number).
+ * A reset-to-inherited control appears only when THIS layer is the
+ * source of the resolved value.
  *
  * Used on the Course settings tab AND the Domain edit page — `scope`
  * prop switches which API the rows talk to.
@@ -14,7 +13,7 @@
 
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 
 type Source = "system" | "provider" | "domain" | "course";
 type ResolvedField<T = unknown> = { value: T; source: Source };
@@ -37,8 +36,6 @@ interface VoicePayload {
   };
   allowedKeys: string[];
   schemaFields: SchemaField[];
-  /** This-layer-only overrides — used to show "Clear override" only when
-   *  the value actually lives at this layer. */
   courseOverrides?: Record<string, unknown>;
   domainOverrides?: Record<string, unknown>;
 }
@@ -51,32 +48,32 @@ export interface VoiceConfigSectionProps {
 const CROSS_CUTTING_LABELS: Record<string, { label: string; help: string; type: SchemaField["type"]; enumValues?: string[] }> = {
   autoPipeline: {
     label: "Auto-run pipeline after each call",
-    help: "When true, the post-call analysis pipeline (memories, traits, target adapts) runs automatically. Default: on.",
+    help: "Run the post-call analysis pipeline (memories, traits, target adapts) automatically.",
     type: "boolean",
   },
   silenceTimeoutSeconds: {
     label: "Silence timeout (seconds)",
-    help: "Hang up the call after this many seconds of silence. Lower = harsher (saves cost). Default: 30s.",
+    help: "Hang up after this many seconds of silence. Lower = cheaper but harsher.",
     type: "number",
   },
   maxDurationSeconds: {
     label: "Max call duration (seconds)",
-    help: "Hard cap on call length. Default: 600s (10 min). VAPI will end any call at this point.",
+    help: "Hard cap on call length. VAPI will end any call at this point.",
     type: "number",
   },
   voicemailDetectionEnabled: {
     label: "Voicemail detection",
-    help: "End the call early if VAPI detects an answering machine. Default: on.",
+    help: "End the call early if VAPI detects an answering machine.",
     type: "boolean",
   },
   endCallPhrases: {
     label: "End-call phrases",
-    help: "Comma-separated list. When the learner says any of these, VAPI hangs up. Default: \"goodbye, bye, talk to you later, see you later, have a nice day\".",
+    help: "Comma-separated. When the learner says any of these, VAPI hangs up.",
     type: "string",
   },
   maxCostPerCallUsd: {
     label: "Max cost per call (USD)",
-    help: "Hard cost cap. Null = no cap (system default).",
+    help: "Hard cost cap. Empty = no cap (system default).",
     type: "number",
   },
   pollIntervalMs: {
@@ -86,17 +83,26 @@ const CROSS_CUTTING_LABELS: Record<string, { label: string; help: string; type: 
   },
   endedReasonOverride: {
     label: "Ended-reason override",
-    help: "Force this string into Call.voiceEndedReason instead of VAPI's value. Debugging only.",
+    help: "Force this string into Call.voiceEndedReason. Debugging only.",
     type: "string",
   },
 };
 
-function sourceBadge(source: Source) {
+const FIELD_GROUPS: { title: string; keys: string[] }[] = [
+  { title: "Behaviour", keys: ["autoPipeline", "endedReasonOverride"] },
+  { title: "Voice & transcription", keys: ["voiceId", "voiceProvider", "transcriber", "backgroundSound", "recordingEnabled"] },
+  { title: "Cost safety", keys: ["silenceTimeoutSeconds", "maxDurationSeconds", "voicemailDetectionEnabled", "endCallPhrases", "maxCostPerCallUsd"] },
+  { title: "Advanced", keys: ["pollIntervalMs", "publicKey", "phoneNumberId"] },
+];
+
+function sourceBadge(source: Source, scope: "course" | "domain") {
+  const isThis =
+    (scope === "course" && source === "course") || (scope === "domain" && source === "domain");
   const map: Record<Source, { label: string; bg: string; fg: string }> = {
-    system: { label: "Default · System", bg: "var(--surface-secondary)", fg: "var(--text-muted)" },
-    provider: { label: "Default · Provider", bg: "var(--surface-secondary)", fg: "var(--text-muted)" },
-    domain: { label: "Set · Domain", bg: "color-mix(in srgb, var(--accent-primary) 12%, transparent)", fg: "var(--accent-primary)" },
-    course: { label: "Set · Course", bg: "color-mix(in srgb, var(--status-success-text) 14%, transparent)", fg: "var(--status-success-text)" },
+    system: { label: "System default", bg: "var(--surface-secondary)", fg: "var(--text-muted)" },
+    provider: { label: "Provider default", bg: "var(--surface-secondary)", fg: "var(--text-muted)" },
+    domain: { label: "Set at Domain", bg: "color-mix(in srgb, var(--accent-primary) 12%, transparent)", fg: "var(--accent-primary)" },
+    course: { label: "Set at Course", bg: "color-mix(in srgb, var(--status-success-text) 14%, transparent)", fg: "var(--status-success-text)" },
   };
   const s = map[source];
   return (
@@ -109,6 +115,7 @@ function sourceBadge(source: Source) {
         background: s.bg,
         color: s.fg,
         whiteSpace: "nowrap",
+        outline: isThis ? `1px solid ${s.fg}` : "none",
       }}
     >
       {s.label}
@@ -124,11 +131,11 @@ function fieldMeta(key: string, schemaFields: SchemaField[]): SchemaField {
   return { key, label: key, type: "string" };
 }
 
-function formatValue(v: unknown, type: SchemaField["type"]): string {
-  if (v === undefined || v === null) return "—";
-  if (type === "boolean") return v ? "On" : "Off";
-  if (Array.isArray(v)) return v.join(", ");
-  return String(v);
+function inputValueFor(value: unknown, type: SchemaField["type"]): string {
+  if (value === undefined || value === null) return "";
+  if (type === "boolean") return value ? "true" : "false";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value);
 }
 
 function parseValueFromInput(raw: string, type: SchemaField["type"]): unknown {
@@ -141,11 +148,163 @@ function parseValueFromInput(raw: string, type: SchemaField["type"]): unknown {
   return raw;
 }
 
+interface RowProps {
+  meta: SchemaField;
+  resolved: ResolvedField;
+  scope: "course" | "domain";
+  isThisLayer: boolean;
+  busyKey: string | null;
+  savedFlash: string | null;
+  onSave: (key: string, value: unknown) => Promise<void> | void;
+  onReset: (key: string) => Promise<void> | void;
+}
+
+function FieldRow({ meta, resolved, scope, isThisLayer, busyKey, savedFlash, onSave, onReset }: RowProps) {
+  const [draft, setDraft] = useState(inputValueFor(resolved.value, meta.type));
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync draft from resolved whenever the upstream value changes (e.g. after a clear).
+  useEffect(() => {
+    setDraft(inputValueFor(resolved.value, meta.type));
+  }, [resolved.value, meta.type]);
+
+  const commit = useCallback(
+    (raw: string) => {
+      const parsed = parseValueFromInput(raw, meta.type);
+      void onSave(meta.key, parsed);
+    },
+    [meta.key, meta.type, onSave],
+  );
+
+  const onTextChange = (val: string) => {
+    setDraft(val);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => commit(val), 600);
+  };
+
+  const onTextBlur = () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    if (inputValueFor(resolved.value, meta.type) !== draft) commit(draft);
+  };
+
+  const isBusy = busyKey === meta.key;
+  const justSaved = savedFlash === meta.key;
+
+  const renderInput = () => {
+    if (meta.type === "boolean") {
+      return (
+        <label
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            cursor: isBusy ? "wait" : "pointer",
+            userSelect: "none",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={draft === "true"}
+            disabled={isBusy}
+            onChange={(e) => {
+              const next = e.target.checked ? "true" : "false";
+              setDraft(next);
+              commit(next);
+            }}
+            style={{ width: 16, height: 16, accentColor: "var(--accent-primary)" }}
+          />
+          <span style={{ fontSize: 14 }}>{draft === "true" ? "On" : "Off"}</span>
+        </label>
+      );
+    }
+    if (meta.type === "enum" && meta.enumValues) {
+      return (
+        <select
+          className="hf-input"
+          value={draft}
+          disabled={isBusy}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            commit(e.target.value);
+          }}
+          style={{ minWidth: 180 }}
+        >
+          {meta.enumValues.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+      );
+    }
+    return (
+      <input
+        className="hf-input"
+        type={meta.type === "number" ? "number" : "text"}
+        value={draft}
+        disabled={isBusy}
+        onChange={(e) => onTextChange(e.target.value)}
+        onBlur={onTextBlur}
+        placeholder="(falls back to cascade)"
+        style={{ minWidth: 220 }}
+      />
+    );
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) auto",
+        gap: 16,
+        padding: 12,
+        borderRadius: 8,
+        background: isThisLayer
+          ? "color-mix(in srgb, var(--status-success-text) 4%, var(--surface-primary))"
+          : "var(--surface-primary)",
+        border: "1px solid var(--border-default)",
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 2, flexWrap: "wrap" }}>
+          <strong style={{ fontSize: 14 }}>{meta.label}</strong>
+          {sourceBadge(resolved.source, scope)}
+          {justSaved && (
+            <span style={{ fontSize: 11, color: "var(--status-success-text)", fontWeight: 600 }}>✓ saved</span>
+          )}
+        </div>
+        {meta.help && (
+          <div className="hf-text-muted hf-text-xs" style={{ marginBottom: 6 }}>
+            {meta.help}
+          </div>
+        )}
+        <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          {renderInput()}
+          {isThisLayer && (
+            <button
+              type="button"
+              className="hf-btn hf-btn-secondary"
+              disabled={isBusy}
+              onClick={() => void onReset(meta.key)}
+              title="Drop this override and fall back to the inherited value."
+              style={{ fontSize: 12, padding: "4px 10px" }}
+            >
+              ↺ Reset
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function VoiceConfigSection({ scope, scopeId }: VoiceConfigSectionProps) {
   const [data, setData] = useState<VoicePayload | null>(null);
-  const [editing, setEditing] = useState<string | null>(null);
-  const [draftValue, setDraftValue] = useState<string>("");
-  const [busy, setBusy] = useState(false);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const apiBase = scope === "course" ? `/api/playbooks/${scopeId}/voice-config` : `/api/domains/${scopeId}/voice-config`;
@@ -166,9 +325,9 @@ export function VoiceConfigSection({ scope, scopeId }: VoiceConfigSectionProps) 
     void load();
   }, [load]);
 
-  const saveOverride = useCallback(
+  const persist = useCallback(
     async (key: string, value: unknown) => {
-      setBusy(true);
+      setBusyKey(key);
       setError(null);
       try {
         const res = await fetch(apiBase, {
@@ -180,16 +339,21 @@ export function VoiceConfigSection({ scope, scopeId }: VoiceConfigSectionProps) 
           const err = await res.json().catch(() => ({}));
           throw new Error(err.error || `HTTP ${res.status}`);
         }
-        setEditing(null);
         await load();
+        setSavedFlash(key);
+        setTimeout(() => {
+          setSavedFlash((cur) => (cur === key ? null : cur));
+        }, 1500);
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       } finally {
-        setBusy(false);
+        setBusyKey(null);
       }
     },
     [apiBase, load],
   );
+
+  const reset = useCallback((key: string) => persist(key, null), [persist]);
 
   if (error) {
     return (
@@ -208,133 +372,59 @@ export function VoiceConfigSection({ scope, scopeId }: VoiceConfigSectionProps) 
 
   const overridesAtThisLayer = scope === "course" ? data.courseOverrides ?? {} : data.domainOverrides ?? {};
 
+  // Order keys via FIELD_GROUPS; any keys not in a group go in "Other".
+  const grouped: { title: string; keys: string[] }[] = FIELD_GROUPS.map((g) => ({
+    title: g.title,
+    keys: g.keys.filter((k) => data.allowedKeys.includes(k)),
+  })).filter((g) => g.keys.length > 0);
+  const groupedKeys = new Set(grouped.flatMap((g) => g.keys));
+  const otherKeys = data.allowedKeys.filter((k) => !groupedKeys.has(k));
+  if (otherKeys.length > 0) grouped.push({ title: "Other", keys: otherKeys });
+
   return (
     <div className="hf-card">
       <div className="hf-text-muted hf-text-sm" style={{ marginBottom: 8 }}>
-        Provider: <strong>{data.enabledProviderSlug}</strong> (locked at system level). The fields below
-        cascade <em>System → Provider → Domain → Course</em>. Setting a value here overrides every layer
-        above it; clearing falls back through the cascade.
+        Provider: <strong>{data.enabledProviderSlug}</strong> (locked at system level). Cascade
+        is <em>System → Provider → Domain → Course</em>. Edit a field to set it at this layer;
+        clear it (↺ Reset) to fall back through the cascade.
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 12 }}>
-        {data.allowedKeys.map((key) => {
-          const meta = fieldMeta(key, data.schemaFields);
-          const resolved = data.resolved.fields[key];
-          if (!resolved) return null;
-          const isEditing = editing === key;
-          const isThisLayer = key in overridesAtThisLayer;
-
-          return (
-            <div
-              key={key}
-              style={{
-                display: "flex",
-                alignItems: "flex-start",
-                gap: 12,
-                padding: 12,
-                borderRadius: 8,
-                background: "var(--surface-primary)",
-                border: "1px solid var(--border-default)",
-              }}
-            >
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
-                  <strong style={{ fontSize: 14 }}>{meta.label}</strong>
-                  {sourceBadge(resolved.source)}
-                </div>
-                {meta.help && (
-                  <div className="hf-text-muted hf-text-xs" style={{ marginBottom: 6 }}>
-                    {meta.help}
-                  </div>
-                )}
-                {!isEditing && (
-                  <div style={{ fontSize: 14, fontFamily: "var(--font-mono)", color: "var(--text-primary)" }}>
-                    {formatValue(resolved.value, meta.type)}
-                  </div>
-                )}
-                {isEditing && (
-                  <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 4 }}>
-                    {meta.type === "boolean" ? (
-                      <select
-                        className="hf-input"
-                        value={draftValue}
-                        onChange={(e) => setDraftValue(e.target.value)}
-                        autoFocus
-                      >
-                        <option value="true">On</option>
-                        <option value="false">Off</option>
-                      </select>
-                    ) : meta.type === "enum" && meta.enumValues ? (
-                      <select
-                        className="hf-input"
-                        value={draftValue}
-                        onChange={(e) => setDraftValue(e.target.value)}
-                        autoFocus
-                      >
-                        {meta.enumValues.map((v) => (
-                          <option key={v} value={v}>
-                            {v}
-                          </option>
-                        ))}
-                      </select>
-                    ) : (
-                      <input
-                        className="hf-input"
-                        type={meta.type === "number" ? "number" : "text"}
-                        value={draftValue}
-                        onChange={(e) => setDraftValue(e.target.value)}
-                        autoFocus
-                        placeholder={`Override ${meta.label}`}
-                      />
-                    )}
-                    <button
-                      className="hf-btn hf-btn-primary"
-                      disabled={busy}
-                      onClick={() => void saveOverride(key, parseValueFromInput(draftValue, meta.type))}
-                    >
-                      Save
-                    </button>
-                    <button
-                      className="hf-btn hf-btn-secondary"
-                      disabled={busy}
-                      onClick={() => {
-                        setEditing(null);
-                        setError(null);
-                      }}
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                )}
-              </div>
-              {!isEditing && (
-                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                  <button
-                    className="hf-btn hf-btn-secondary"
-                    onClick={() => {
-                      setDraftValue(formatValue(resolved.value, meta.type) === "—" ? "" : String(resolved.value));
-                      setEditing(key);
-                      setError(null);
-                    }}
-                  >
-                    Override
-                  </button>
-                  {isThisLayer && (
-                    <button
-                      className="hf-btn hf-btn-secondary"
-                      disabled={busy}
-                      onClick={() => void saveOverride(key, null)}
-                      title={`Drop this ${scope} override and fall back to the cascade.`}
-                    >
-                      Clear
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {grouped.map((group) => (
+        <div key={group.title} style={{ marginTop: 16 }}>
+          <div
+            className="hf-text-muted"
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              marginBottom: 6,
+            }}
+          >
+            {group.title}
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {group.keys.map((key) => {
+              const meta = fieldMeta(key, data.schemaFields);
+              const resolved = data.resolved.fields[key];
+              if (!resolved) return null;
+              return (
+                <FieldRow
+                  key={key}
+                  meta={meta}
+                  resolved={resolved}
+                  scope={scope}
+                  isThisLayer={key in overridesAtThisLayer}
+                  busyKey={busyKey}
+                  savedFlash={savedFlash}
+                  onSave={persist}
+                  onReset={reset}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Followup to live smoke on #1291. Replaces the click-Override-then-Save UX with always-editable inline inputs.

## Before
- 2 clicks per change: \`Override\` → edit → \`Save\`.
- Long flat list of 12+ fields, no grouping.

## After
- 1 interaction per change:
  - **boolean** → toggle the checkbox
  - **enum** → pick from select
  - **text / number** → type + blur (600ms debounce so typing doesn't fire a PATCH per keystroke)
- \`↺ Reset\` appears only when this layer holds the override.
- Rows grouped under sub-headers: Behaviour · Voice & transcription · Cost safety · Advanced.
- This-layer rows get a faint green tint; provenance badge has an outline when the source is this layer.
- ✓ saved flash next to the badge for 1.5s after each successful PATCH.

## What's NOT changed
- API contract (\`PATCH /api/playbooks/[id]/voice-config\` etc.) — unchanged.
- Cascade resolver / locked keys — unchanged.

## Smoke

- [ ] /x/courses/[id] → Settings → Voice — see grouped sections + inline inputs.
- [ ] Toggle \`Auto-run pipeline\` → instant ✓ saved + badge flips to "Set at Course".
- [ ] Edit \`Silence timeout\` → type 45 → tab out → ✓ saved.
- [ ] Click ↺ Reset on the autopipeline row → falls back to system default; row tint clears.
- [ ] Same flow on /x/domains?id=… → Voice tab.

## Deploy

\`/vm-cp\` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)