### PR TITLE
feat(#1268): Preview shows real chat bubbles + per-bubble deep-links to source lenses

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -1,30 +1,27 @@
 "use client";
 
 /**
- * Preview lens — Slice 3 of epic #1263.
+ * Preview lens — Slice 3 of epic #1263 (chat-bubble revision).
  *
- * Lazy-mounted via `<ConsoleShell>` — the dry-run compose only fires
- * when an educator selects the Preview lens, not on Design-tab open.
+ * Renders an Educator view + Engineer view of what the learner will
+ * experience on Call 1. The Educator view now uses WhatsApp-style chat
+ * bubbles (matching the SimChat + ChatSurvey UI the learner actually
+ * sees) — one transcript that walks pre-call survey questions first,
+ * then a "Call 1 begins" divider, then the AI's opening + first
+ * teaching turn. Each bubble is a clickable deep-link to the lens that
+ * controls it.
  *
- * Two view modes:
- *   - Educator (default): config-driven summary of what the learner will
- *     experience on call 1. Reads `sessionFlow.*` directly, renders one
- *     line per active stage + ghosted lines for stages that won't fire.
- *     Each ghost has a deep-link to the lens that would enable it.
- *   - Engineer: section-by-section from POST /dry-run-prompt — uses
- *     `metadata.sectionsActivated` + `sectionsSkipped` + `activationReasons`.
+ * Lazy compose — the `<ConsoleShell>` only mounts this component when
+ * the Preview lens is active, so `useEffect` on mount fires the
+ * dry-run-prompt POST exactly once on first visit. StrictMode guard
+ * via `useRef` prevents double-fire.
  *
- * Staleness — leans on `Playbook.composeInputsUpdatedAt` (#878). A "stale"
- * badge appears when the compose-affecting timestamp on the resolved
- * playbook is newer than the timestamp captured at the last compose.
- * `[Regenerate]` re-fetches and re-anchors.
- *
- * Closes #1268 (Slice 3). Refs epic #1263.
+ * Closes #1268. Refs epic #1263.
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { Eye, RefreshCw, FileSearch, AlertCircle } from "lucide-react";
+import { Eye, RefreshCw, FileSearch, AlertCircle, Edit3 } from "lucide-react";
 import "./preview-lens.css";
 
 interface PreviewLensProps {
@@ -43,8 +40,9 @@ interface SessionFlowResp {
     onboarding: { phases: Array<{ phase: string; duration?: string; goals?: string[] }> };
     welcomeMessage: string | null;
     offboarding: { phases: Array<{ phase: string }>; triggerAfterCalls?: number };
-    stops: Array<{ id: string; kind: string }>;
+    stops: Array<{ id: string; kind: string; trigger?: { type: string; threshold?: number; count?: number } }>;
   };
+  courseName?: string;
   error?: string;
 }
 
@@ -102,17 +100,13 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
     }
   }, [courseId]);
 
-  // Lazy compose: this component is only mounted when the lens is active
-  // (`<ConsoleShell>` renders `def.Component` only for the active lens), so
-  // a single useEffect on mount achieves the "don't fire until viewed"
-  // contract. Guard against double-fire from StrictMode.
   useEffect(() => {
     if (composedOnceRef.current) return;
     composedOnceRef.current = true;
     void compose();
   }, [compose]);
 
-  const educatorRows = useMemo(() => buildEducatorRows(flow, courseId), [flow, courseId]);
+  const transcript = useMemo(() => buildTranscript(flow), [flow]);
 
   return (
     <div className="hf-preview-lens">
@@ -152,7 +146,7 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
       {lastComposedAt && (
         <p className="hf-preview-lens-meta">
           Last composed {new Date(lastComposedAt).toLocaleTimeString()}.
-          Re-run after any setup change to see the latest.
+          Click any bubble to jump to the lens that controls it.
         </p>
       )}
 
@@ -170,7 +164,7 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
       )}
 
       {!loading && flow && mode === "educator" && (
-        <EducatorView rows={educatorRows} courseId={courseId} />
+        <EducatorView transcript={transcript} courseId={courseId} />
       )}
 
       {!loading && dryRun && mode === "engineer" && (
@@ -180,117 +174,260 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
   );
 }
 
-interface EducatorRow {
-  kind: "active" | "ghost";
-  icon: "👋" | "❓" | "💡" | "🎯" | "📝" | "🎓" | "🏁";
-  title: string;
-  detail: string;
-  fixLens?: string;
-  fixLabel?: string;
+// ── Transcript model ───────────────────────────────────────────
+
+type Side = "bot" | "user";
+
+interface PreviewBubble {
+  side: Side;
+  /** True when this bubble represents config that's missing/disabled — rendered ghosted. */
+  ghost?: boolean;
+  /** Visible bubble copy. */
+  text: string;
+  /** Optional caption above bubble (e.g., "Goals question"). */
+  caption?: string;
+  /** Lens id to deep-link to when the bubble is clicked. */
+  lens: string;
+  /** Educator-facing label for the deep-link affordance. */
+  lensLabel: string;
 }
 
-function buildEducatorRows(flow: SessionFlowResp | null, _courseId: string): EducatorRow[] {
+interface PreviewDivider {
+  kind: "divider";
+  label: string;
+}
+
+interface PreviewStopNote {
+  kind: "stop-note";
+  text: string;
+  lens: string;
+}
+
+type PreviewItem =
+  | ({ kind: "bubble" } & PreviewBubble)
+  | PreviewDivider
+  | PreviewStopNote;
+
+function buildTranscript(flow: SessionFlowResp | null): PreviewItem[] {
   if (!flow?.sessionFlow) return [];
   const sf = flow.sessionFlow;
-  const rows: EducatorRow[] = [];
+  const items: PreviewItem[] = [];
 
-  // Welcome opener
+  // ── Pre-call survey (intake questions) ──
+  // If any intake toggle is on, those run BEFORE call 1 (or in the first
+  // discovery phase, depending on delivery). Render them as a survey-style
+  // pre-call chat.
+  const anyIntake =
+    sf.intake.goals.enabled
+    || sf.intake.aboutYou.enabled
+    || (sf.intake.knowledgeCheck.enabled && (sf.intake.knowledgeCheck.deliveryMode ?? "mcq") === "mcq");
+
+  if (anyIntake) {
+    items.push({ kind: "divider", label: "Pre-call survey" });
+
+    if (sf.intake.goals.enabled) {
+      items.push({
+        kind: "bubble", side: "bot", lens: "intake", lensLabel: "Edit Goals",
+        caption: "Goals question",
+        text: "What would you most like to get out of this course?",
+      });
+      items.push({
+        kind: "bubble", side: "user", lens: "intake", lensLabel: "Edit Goals", ghost: true,
+        text: "(learner's response will go here)",
+      });
+    } else {
+      items.push({
+        kind: "bubble", side: "bot", lens: "intake", lensLabel: "Enable Goals", ghost: true,
+        caption: "Goals question — OFF",
+        text: "(no goals question — learner will not be asked about course goals)",
+      });
+    }
+
+    if (sf.intake.aboutYou.enabled) {
+      items.push({
+        kind: "bubble", side: "bot", lens: "intake", lensLabel: "Edit About You",
+        caption: "About You",
+        text: "On a scale of 1–5, how confident do you feel about this topic?",
+      });
+      items.push({
+        kind: "bubble", side: "user", lens: "intake", lensLabel: "Edit About You", ghost: true,
+        text: "(confidence rating + optional motivation text)",
+      });
+    } else {
+      items.push({
+        kind: "bubble", side: "bot", lens: "intake", lensLabel: "Enable About You", ghost: true,
+        caption: "About You — OFF",
+        text: "(no confidence + motivation prompt)",
+      });
+    }
+
+    if (sf.intake.knowledgeCheck.enabled) {
+      const mode = sf.intake.knowledgeCheck.deliveryMode || "mcq";
+      if (mode === "mcq") {
+        items.push({
+          kind: "bubble", side: "bot", lens: "intake", lensLabel: "Edit Knowledge Check",
+          caption: "Knowledge Check — MCQ batch (5 questions)",
+          text: "Question 1 of 5: …",
+        });
+        items.push({
+          kind: "bubble", side: "user", lens: "intake", lensLabel: "Edit Knowledge Check", ghost: true,
+          text: "(learner answers each MCQ)",
+        });
+      }
+      // Socratic mode delivers inside the call's discovery phase, so it shows
+      // in the call section below, not here.
+    }
+  }
+
+  // ── Call 1 begins ──
+  items.push({ kind: "divider", label: "Call 1 begins" });
+
+  // Welcome / first-line greeting
   if (sf.welcomeMessage) {
-    rows.push({
-      kind: "active",
-      icon: "👋",
-      title: "Welcome",
-      detail: sf.welcomeMessage,
+    items.push({
+      kind: "bubble", side: "bot", lens: "welcome", lensLabel: "Edit Welcome",
+      caption: "Welcome message",
+      text: sf.welcomeMessage,
     });
   } else {
-    rows.push({
-      kind: "ghost",
-      icon: "👋",
-      title: "Welcome",
-      detail: "Falls back to a generic greeting. Add a course-specific welcome to set the tone.",
-      fixLens: "welcome",
-      fixLabel: "Edit Welcome",
+    items.push({
+      kind: "bubble", side: "bot", lens: "welcome", lensLabel: "Edit Welcome", ghost: true,
+      caption: "Welcome message — using generic fallback",
+      text: "(domain-level or generic greeting — set a course-specific welcome to personalise the opener)",
     });
   }
 
-  // Intake — discovery questions
-  if (sf.intake.goals.enabled) {
-    rows.push({ kind: "active", icon: "🎯", title: "Goals question", detail: "Asks what the learner wants to get out of the course." });
-  } else {
-    rows.push({ kind: "ghost", icon: "🎯", title: "Goals question", detail: "Disabled. Toggle ON to capture the learner's goals.", fixLens: "intake", fixLabel: "Edit Intake" });
-  }
-
-  if (sf.intake.aboutYou.enabled) {
-    rows.push({ kind: "active", icon: "❓", title: "About You", detail: "Confidence + motivation prompts." });
-  } else {
-    rows.push({ kind: "ghost", icon: "❓", title: "About You", detail: "Disabled.", fixLens: "intake", fixLabel: "Edit Intake" });
-  }
-
-  if (sf.intake.knowledgeCheck.enabled) {
-    const mode = sf.intake.knowledgeCheck.deliveryMode || "mcq";
-    rows.push({
-      kind: "active",
-      icon: "💡",
-      title: "Knowledge Check",
-      detail: mode === "socratic" ? "Socratic probe during the discovery phase." : "5-question MCQ batch after call 1.",
-    });
-  } else {
-    rows.push({ kind: "ghost", icon: "💡", title: "Knowledge Check", detail: "Disabled.", fixLens: "intake", fixLabel: "Edit Intake" });
-  }
-
-  // Onboarding phases
+  // Onboarding phases / discovery
   if (sf.onboarding.phases.length > 0) {
-    rows.push({
-      kind: "active",
-      icon: "📝",
-      title: "Onboarding phases",
-      detail: `${sf.onboarding.phases.length} phase${sf.onboarding.phases.length === 1 ? "" : "s"} — ${sf.onboarding.phases.map(p => p.phase).join(" → ")}`,
+    const firstPhase = sf.onboarding.phases[0];
+    items.push({
+      kind: "bubble", side: "bot", lens: "onboarding", lensLabel: "Edit Onboarding",
+      caption: `Phase 1 of ${sf.onboarding.phases.length} — ${firstPhase.phase}`,
+      text: firstPhase.goals?.[0] || `(first onboarding phase: ${firstPhase.phase})`,
     });
+    if (sf.onboarding.phases.length > 1) {
+      items.push({
+        kind: "bubble", side: "bot", lens: "onboarding", lensLabel: "Edit Onboarding",
+        caption: `Then phases: ${sf.onboarding.phases.slice(1).map(p => p.phase).join(" → ")}`,
+        text: "(walks through the remaining phases before the first teaching segment)",
+      });
+    }
   } else {
-    rows.push({
-      kind: "ghost",
-      icon: "📝",
-      title: "Onboarding phases",
-      detail: "No phases configured — first-call flow falls back to INIT-001.",
-      fixLens: "onboarding",
-      fixLabel: "Edit Onboarding",
+    items.push({
+      kind: "bubble", side: "bot", lens: "onboarding", lensLabel: "Add Onboarding phases", ghost: true,
+      caption: "No onboarding phases configured",
+      text: "(falls back to INIT-001 default phases)",
     });
   }
 
-  // First teaching content (synthetic — composition would resolve)
-  rows.push({
-    kind: "active",
-    icon: "🎓",
-    title: "First module",
-    detail: "Loads from the Curriculum's first module. See the Engineer view for the composed prompt.",
+  // Socratic knowledge check probe — fires during discovery if enabled
+  if (sf.intake.knowledgeCheck.enabled && (sf.intake.knowledgeCheck.deliveryMode ?? "mcq") === "socratic") {
+    items.push({
+      kind: "bubble", side: "bot", lens: "intake", lensLabel: "Edit Knowledge Check",
+      caption: "Knowledge Check — Socratic probe (in-call)",
+      text: "What do you already know about this topic?",
+    });
+    items.push({
+      kind: "bubble", side: "user", lens: "intake", lensLabel: "Edit Knowledge Check", ghost: true,
+      text: "(open answer — AI probes deeper)",
+    });
+  }
+
+  // First teaching turn — link to Preview's own Engineer view
+  items.push({
+    kind: "bubble", side: "bot", lens: "preview", lensLabel: "See full prompt (Engineer)",
+    caption: "First teaching turn",
+    text: "(the first module's opening — see the Engineer view for the composed prompt)",
   });
 
-  return rows;
+  // ── Stops / NPS that fire downstream ──
+  const npsStop = sf.stops.find(s => s.kind === "nps");
+  if (npsStop?.trigger) {
+    const t = npsStop.trigger;
+    let trigger = "";
+    if (t.type === "mastery_reached" && t.threshold) {
+      trigger = `mastery ≥ ${Math.round(t.threshold * 100)}%`;
+    } else if (t.type === "session_count" && t.count) {
+      trigger = `after ${t.count} sessions`;
+    } else {
+      trigger = t.type;
+    }
+    items.push({ kind: "stop-note", text: `NPS survey fires when ${trigger}.`, lens: "stops" });
+  }
+
+  return items;
 }
 
-function EducatorView({ rows, courseId }: { rows: EducatorRow[]; courseId: string }): React.ReactElement {
+// ── Views ──────────────────────────────────────────────────────
+
+function EducatorView({ transcript, courseId }: { transcript: PreviewItem[]; courseId: string }): React.ReactElement {
+  if (transcript.length === 0) {
+    return <p className="hf-text-muted">Nothing configured yet — see Engineer view for raw compose state.</p>;
+  }
   return (
-    <div className="hf-preview-lens-educator">
-      {rows.map((r, i) => (
-        <div
-          key={i}
-          className={`hf-preview-lens-row ${r.kind === "ghost" ? "hf-preview-lens-row--ghost" : ""}`}
-        >
-          <span className="hf-preview-lens-row-icon">{r.icon}</span>
-          <div className="hf-preview-lens-row-body">
-            <div className="hf-preview-lens-row-title">{r.title}</div>
-            <div className="hf-preview-lens-row-detail">{r.detail}</div>
-          </div>
-          {r.fixLens && (
+    <div className="hf-preview-chat">
+      {transcript.map((item, i) => {
+        if (item.kind === "divider") {
+          return (
+            <div key={i} className="hf-preview-divider" aria-label={item.label}>
+              <span>{item.label}</span>
+            </div>
+          );
+        }
+        if (item.kind === "stop-note") {
+          return (
             <Link
-              href={`/x/courses/${courseId}?tab=design&design_view=${r.fixLens}`}
-              className="hf-preview-lens-row-fix"
+              key={i}
+              href={`/x/courses/${courseId}?tab=design&design_view=${item.lens}`}
+              className="hf-preview-stop-note"
             >
-              {r.fixLabel || "Fix"} →
+              <AlertCircle size={12} />
+              <span>{item.text}</span>
+              <span className="hf-preview-stop-note-edit">Edit Stops →</span>
             </Link>
-          )}
-        </div>
-      ))}
+          );
+        }
+        return (
+          <BubbleRow
+            key={i}
+            bubble={item}
+            courseId={courseId}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function BubbleRow({
+  bubble, courseId,
+}: {
+  bubble: { kind: "bubble" } & PreviewBubble;
+  courseId: string;
+}): React.ReactElement {
+  const href = `/x/courses/${courseId}?tab=design&design_view=${bubble.lens}`;
+  const wrapClasses = [
+    "hf-preview-bubble-row",
+    bubble.side === "user" ? "hf-preview-bubble-row--user" : "hf-preview-bubble-row--bot",
+    bubble.ghost ? "hf-preview-bubble-row--ghost" : "",
+  ].filter(Boolean).join(" ");
+  const bubbleClasses = [
+    "hf-preview-bubble",
+    bubble.side === "user" ? "hf-preview-bubble--user" : "hf-preview-bubble--bot",
+    bubble.ghost ? "hf-preview-bubble--ghost" : "",
+  ].filter(Boolean).join(" ");
+  return (
+    <div className={wrapClasses}>
+      {bubble.caption && (
+        <div className="hf-preview-bubble-caption">{bubble.caption}</div>
+      )}
+      <Link href={href} className={bubbleClasses} title={bubble.lensLabel}>
+        <span className="hf-preview-bubble-text">{bubble.text}</span>
+        <span className="hf-preview-bubble-edit">
+          <Edit3 size={11} />
+          <span>{bubble.lensLabel}</span>
+        </span>
+      </Link>
     </div>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
@@ -1,4 +1,8 @@
-/* ── Preview lens (#1268) ── */
+/* ── Preview lens (#1268, chat-bubble revision) ──
+   The Educator view uses WhatsApp-theme tokens from wa-theme.css so the
+   preview visually matches what the learner sees in SimChat + ChatSurvey.
+   wa-theme.css is loaded by sim.css + chat-survey.css globally; we just
+   reference its CSS variables here. */
 
 .hf-preview-lens {
   display: flex;
@@ -44,67 +48,148 @@
   padding: 12px 0;
 }
 
-/* Educator view */
-.hf-preview-lens-educator {
+/* ── Chat transcript (Educator view) ── */
+.hf-preview-chat {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 12px;
+  background: var(--wa-bg, #ECE5DD);
+  min-height: 320px;
 }
 
-.hf-preview-lens-row {
+.hf-preview-divider {
   display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 10px 12px;
-  border: 1px solid var(--border-default);
-  border-radius: 10px;
-  background: var(--surface-primary);
+  align-items: center;
+  justify-content: center;
+  margin: 8px 0;
+  gap: 8px;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--wa-text-muted, #8696A0);
 }
 
-.hf-preview-lens-row--ghost {
-  opacity: 0.6;
-  background: var(--surface-secondary);
-  border-style: dashed;
-}
-
-.hf-preview-lens-row-icon {
-  font-size: 18px;
-  line-height: 1;
-}
-
-.hf-preview-lens-row-body {
+.hf-preview-divider::before,
+.hf-preview-divider::after {
+  content: "";
   flex: 1;
-  min-width: 0;
+  height: 1px;
+  background: var(--wa-divider, #E9EDEF);
 }
 
-.hf-preview-lens-row-title {
+.hf-preview-divider span {
+  background: color-mix(in srgb, var(--wa-surface-secondary, #F0F2F5) 90%, transparent);
+  padding: 4px 12px;
+  border-radius: 12px;
+}
+
+.hf-preview-bubble-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 75%;
+}
+
+.hf-preview-bubble-row--user {
+  align-self: flex-end;
+  align-items: flex-end;
+}
+
+.hf-preview-bubble-row--bot {
+  align-self: flex-start;
+  align-items: flex-start;
+}
+
+.hf-preview-bubble-caption {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--wa-text-muted, #8696A0);
+  padding: 0 4px;
+}
+
+.hf-preview-bubble {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 10px;
   font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
+  line-height: 1.4;
+  color: var(--wa-text-primary, #111B21);
+  text-decoration: none;
+  transition: filter 0.12s ease, transform 0.12s ease;
+  box-shadow: 0 1px 1px var(--wa-shadow, rgba(0, 0, 0, 0.1));
+  cursor: pointer;
 }
 
-.hf-preview-lens-row-detail {
-  font-size: 12px;
-  color: var(--text-secondary);
-  margin-top: 2px;
+.hf-preview-bubble--bot {
+  background: var(--wa-bubble-in, #FFFFFF);
+  border-bottom-left-radius: 4px;
 }
 
-.hf-preview-lens-row-fix {
+.hf-preview-bubble--user {
+  background: var(--wa-bubble-out, #DCF8C6);
+  border-bottom-right-radius: 4px;
+}
+
+.hf-preview-bubble--ghost {
+  opacity: 0.55;
+  font-style: italic;
+}
+
+.hf-preview-bubble:hover {
+  filter: brightness(0.97);
+  transform: translateY(-1px);
+}
+
+.hf-preview-bubble-text {
+  display: block;
+}
+
+.hf-preview-bubble-edit {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 12px;
-  color: var(--accent-primary);
-  text-decoration: none;
+  font-size: 10px;
   font-weight: 600;
-  white-space: nowrap;
+  color: var(--accent-primary);
+  opacity: 0;
+  transition: opacity 0.12s ease;
 }
 
-.hf-preview-lens-row-fix:hover {
-  text-decoration: underline;
+.hf-preview-bubble:hover .hf-preview-bubble-edit,
+.hf-preview-bubble:focus-visible .hf-preview-bubble-edit {
+  opacity: 1;
 }
 
-/* Engineer view */
+.hf-preview-stop-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--accent-primary) 40%, transparent);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--text-primary);
+  text-decoration: none;
+  align-self: center;
+}
+
+.hf-preview-stop-note-edit {
+  margin-left: auto;
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--accent-primary);
+}
+
+/* ── Engineer view ── */
 .hf-preview-lens-engineer {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Replaces the row-list Educator view with a real WhatsApp-style chat transcript that matches what the learner sees in SimChat + ChatSurvey. The transcript walks Call 1 end-to-end and every bubble is a clickable deep-link to the lens that controls it.

### Transcript flow

\`\`\`
─── Pre-call survey ───   (only if any intake toggle is on)
Bot: Goals question
User: (placeholder)
Bot: About You
User: (placeholder)
Bot: Knowledge Check MCQ  (if KC + delivery=mcq)

─── Call 1 begins ───
Bot: Welcome message
Bot: Phase 1 — <name>
Bot: Then phases: ...
Bot: KC Socratic probe    (if KC + delivery=socratic)
Bot: First teaching turn

[ NPS fires when mastery ≥ 80% — Edit Stops → ]
\`\`\`

### Per-bubble deep-links

Every bubble links to \`?tab=design&design_view=<lens>\` — click a Goals bubble, land on Intake lens. Click the Welcome bubble, land on Welcome lens. NPS sticky note → Stops lens. On hover, an "Edit X" affordance appears under the bubble.

### Ghosted bubbles for missing config

Disabled toggles render as italic + faded with a label like "Goals question — OFF" and copy "(no goals question — learner will not be asked...)". Still clickable so educators can toggle on.

### Styling

Reuses \`wa-*\` CSS variables from \`app/styles/wa-theme.css\` (loaded globally). Bot bubbles \`var(--wa-bubble-in)\`, user bubbles \`var(--wa-bubble-out)\`, background \`var(--wa-bg)\`. Light + dark mode inherited.

## Test plan

- [x] 11/11 in \`course-design-console.test.tsx\` green
- [ ] Manual: visit \`?tab=design&design_view=preview\` — transcript renders with bubbles, hover any bubble to see "Edit X" affordance, click "About You" bubble → lands on Intake lens
- [ ] Manual: toggle Knowledge Check OFF in Intake lens → return to Preview → KC bubble now ghosted with "OFF" caption
- [ ] Manual: change welcome message → return to Preview, hit Regenerate → bubble updates

Closes #1268. Refs epic #1263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)