### PR TITLE
feat(course-design): polish JOURNEY group — labels + provenance + numbers (#1316)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
@@ -146,39 +146,45 @@ const PreviewLensWrap: React.FC<LensProps> = ({ courseId }) => (
 PreviewLensWrap.displayName = "PreviewLensWrap";
 
 const DESIGN_LENSES: Record<DesignLensId, ConsoleLensDef<LensProps>> = {
+  // #1316 — Number the JOURNEY lenses ① ② ③ ④ ⑤ so the operator sees the
+  // learner-journey sequence at a glance from the LH-nav. Labels-only
+  // change; lens order in DESIGN_LENS_ORDER already encodes the sequence.
   intake: {
     id: "intake",
-    label: "Intake",
+    label: "① Intake",
     iconNode: <GraduationCap size={ICON_SIZE} />,
     blurb: "Goals question, About You, Knowledge Check, AI Intro Call — what Call 1 asks the learner.",
     Component: makeJourneyLens("intake"),
   },
   onboarding: {
     id: "onboarding",
-    label: "Onboarding",
+    label: "② Onboarding",
     iconNode: <Sparkles size={ICON_SIZE} />,
     blurb: "First-call structural template — phases, durations, goals.",
     Component: makeJourneyLens("onboarding"),
   },
   stops: {
     id: "stops",
-    label: "Session Stops",
+    label: "③ Session Stops",
     iconNode: <ClipboardCheck size={ICON_SIZE} />,
     blurb: "Pre-test / mid-test / post-test / NPS — the gated moments around teaching.",
     Component: makeJourneyLens("stops"),
   },
   offboarding: {
     id: "offboarding",
-    label: "Offboarding",
+    label: "④ Offboarding",
     iconNode: <ThumbsUp size={ICON_SIZE} />,
     blurb: "End-of-course wrap-up phases.",
     Component: makeJourneyLens("offboarding"),
   },
+  // #1316 — Renamed "Welcome message" → "Course opening line" to
+  // disambiguate from the Domain-level Domain.onboardingWelcome which
+  // operators were also seeing labelled as "Welcome message".
   welcome: {
     id: "welcome",
-    label: "Welcome message",
+    label: "⑤ Course opening line",
     iconNode: <MessageSquare size={ICON_SIZE} />,
-    blurb: "First-line greeting the learner hears on call 1.",
+    blurb: "First-line greeting the learner hears on call 1. Overrides the Domain greeting.",
     Component: makeJourneyLens("welcome"),
   },
   call1Mode: {

--- a/apps/admin/app/x/domains/components/OnboardingTab.tsx
+++ b/apps/admin/app/x/domains/components/OnboardingTab.tsx
@@ -408,18 +408,21 @@ export function OnboardingTabContent({
                     <div className="ob-tab-layout">
                     <div className="ob-tab-edit-col">
                     <div className="hf-card hf-p-20" style={{ borderRadius: 8 }}>
-                      {/* Welcome Message */}
+                      {/* #1316 — Renamed "Welcome Message" → "Domain greeting"
+                          to disambiguate from the Course-level "Course opening
+                          line" (Playbook.welcomeMessage) which overrides this
+                          when set. */}
                       <div className="hf-mb-lg" style={{ marginBottom: 20 }}>
-                        <FieldHint label="Welcome Message" hint={WIZARD_HINTS["onboard.welcomeMessage"]} labelClass="hf-text-md hf-text-bold hf-mb-sm" />
+                        <FieldHint label="Domain greeting" hint={WIZARD_HINTS["onboard.welcomeMessage"]} labelClass="hf-text-md hf-text-bold hf-mb-sm" />
                         <textarea
                           className="hf-textarea"
                           value={onboardingForm.welcomeMessage}
                           onChange={(e) => setOnboardingForm({ ...onboardingForm, welcomeMessage: e.target.value })}
-                          placeholder="Enter the welcome message for first-time callers..."
+                          placeholder="Enter the greeting for first-time callers in this domain..."
                           style={{ minHeight: 120 }}
                         />
                         <div className="hf-hint">
-                          This message is shown to new callers on their first call
+                          Used as the first-call greeting for callers in this domain. Course-level &quot;Course opening line&quot; overrides this when set.
                         </div>
                       </div>
 
@@ -935,11 +938,11 @@ export function OnboardingTabContent({
                       </div>
                     </div>
 
-                    {/* Welcome Message */}
+                    {/* #1316 — "Welcome Message" → "Domain greeting" */}
                     <div className="hf-list-row" style={{ padding: "12px 16px" }}>
                       <span style={{ fontSize: 16, flexShrink: 0 }}>{"\uD83D\uDCAC"}</span>
                       <div style={{ flex: 1, minWidth: 0 }}>
-                        <div className="hf-text-sm hf-text-bold">Welcome Message</div>
+                        <div className="hf-text-sm hf-text-bold">Domain greeting</div>
                         {domain.onboardingWelcome ? (
                           <div className="hf-text-xs hf-text-muted" style={{
                             overflow: "hidden",
@@ -952,7 +955,7 @@ export function OnboardingTabContent({
                           <div className="hf-text-xs hf-text-muted">
                             Not configured &mdash;{" "}
                             <button className="hf-link-inline" onClick={() => setEditingOnboarding(true)}>
-                              add a welcome message
+                              add a domain greeting
                             </button>
                           </div>
                         )}

--- a/apps/admin/components/session-flow/SessionFlowEditor.tsx
+++ b/apps/admin/components/session-flow/SessionFlowEditor.tsx
@@ -281,8 +281,19 @@ export function SessionFlowEditor({ courseId, activeSection }: SessionFlowEditor
     {
       id: "welcome-message",
       icon: <MessageSquare size={16} />,
-      label: "Welcome message",
-      summary: sessionFlow.welcomeMessage ? truncate(sessionFlow.welcomeMessage, 60) : "Generic fallback",
+      // #1316 — Renamed to "Course opening line" to disambiguate from
+      // the Domain-level Domain.onboardingWelcome (also surfaced as
+      // "Welcome message" on the Domain editor). Source badge is now
+      // inline in the summary so the operator sees at a glance whether
+      // the value comes from Course / Domain / generic without expanding
+      // the row details. Matches the onboarding row pattern at :276.
+      label: "Course opening line",
+      summary: (() => {
+        const text = sessionFlow.welcomeMessage
+          ? truncate(sessionFlow.welcomeMessage, 60)
+          : "Generic fallback";
+        return `${text} · source: ${sourceLabel(sessionFlow.source.welcomeMessage)}`;
+      })(),
       status: sessionFlow.welcomeMessage ? "enabled" : "default",
       details: welcomeMessageDetails(sessionFlow),
       editable: true,


### PR DESCRIPTION
Closes #1316. Replaces the original 5-slice expansion of #1309 after TL reframe — the timeline already exists; this is the actual operator-clarity work.

## Summary

1. **Welcome label collision fix**
   - Course Design lens: `Welcome message` → **`Course opening line`**
   - Domain editor (edit + read-only views): `Welcome Message` → **`Domain greeting`**
2. **Welcome row provenance inline** — `SessionFlowEditor` welcome row now shows `source: Domain` (or Course / generic) in the summary, matching the onboarding row pattern.
3. **Numbered JOURNEY markers** — ①–⑤ prefixes on intake / onboarding / stops / offboarding / welcome labels in the LH-nav.

## Smoke

- [ ] `/x/courses/[id]?tab=design` → LH-nav shows ① Intake · ② Onboarding · ③ Session Stops · ④ Offboarding · ⑤ Course opening line.
- [ ] Welcome row in the editor body shows `… · source: Domain` (or Course / generic) inline in the summary.
- [ ] `/x/domains?id=…` → Onboarding tab → field is now labelled "Domain greeting"; hint copy mentions the Course override.

## Deploy

`/vm-cp` — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)