### PR TITLE
Make Claude hooks portable across machines

### DIFF
--- a/.claude/hooks/branch-drift-detector.sh
+++ b/.claude/hooks/branch-drift-detector.sh
@@ -11,7 +11,10 @@
 # Exit 0 always — do not block tool execution. Over-blocking is worse than
 # letting through a false positive.
 
-cd /Users/paulwander/projects/HF 2>/dev/null || exit 0
+# Portable repo root + per-machine Claude memory key.
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+PROJ_DASH=$(printf '%s' "$REPO_ROOT" | sed 's#/#-#g')
+cd "$REPO_ROOT" 2>/dev/null || exit 0
 
 SNAPSHOT="/tmp/claude-head-snapshot-HF"
 
@@ -50,7 +53,7 @@ echo "   If the LAST tool call you ran in THIS session was an intentional"
 echo "   git checkout / reset / pull --rebase / stash pop / branch -f, this"
 echo "   warning is a false positive — ignore."
 echo ""
-echo "   Recovery playbook: ~/.claude/projects/-Users-paulwander-projects-HF"
+echo "   Recovery playbook: ~/.claude/projects/$PROJ_DASH"
 echo "   /memory/feedback_concurrent_claude_processes.md"
 
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -114,10 +114,17 @@ else
   fi
 fi
 
-cd /Users/paulwander/projects/HF || exit 0
+# Portable repo root: Claude Code sets $CLAUDE_PROJECT_DIR to the project
+# root on any machine; fall back to the git toplevel for manual runs.
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+cd "$REPO_ROOT" || exit 0
+
+# Per-machine Claude memory dir: derive the dashed project key from the
+# repo root (e.g. /Users/x/HF -> -Users-x-HF) so this resolves on any host.
+PROJ_DASH=$(printf '%s' "$REPO_ROOT" | sed 's#/#-#g')
 
 # Check memory-sync staleness
-MEMORY_SYNC_LOG="$HOME/.claude/projects/-Users-paulwander-projects-HF/memory/MEMORY.md"
+MEMORY_SYNC_LOG="$HOME/.claude/projects/$PROJ_DASH/memory/MEMORY.md"
 LAST_SYNC=$(git log -1 --format="%ar" -- "$MEMORY_SYNC_LOG" 2>/dev/null || echo "unknown")
 
 # Check for uncommitted changes

--- a/.claude/hooks/sprint-context.sh
+++ b/.claude/hooks/sprint-context.sh
@@ -3,9 +3,12 @@
 # Runs before Claude responds to each message
 # Output is injected as a system reminder visible to Claude
 
-REPO_ROOT="/Users/paulwander/projects/HF"
+# Portable repo root + per-machine Claude memory key ($CLAUDE_PROJECT_DIR
+# resolves on any host; dashed key derived from it for the memory dir).
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 REPO="paw2paw/HF"
-AGENT_STATE="$HOME/.claude/projects/-Users-paulwander-projects-HF/memory/agent-state.json"
+PROJ_DASH=$(printf '%s' "$REPO_ROOT" | sed 's#/#-#g')
+AGENT_STATE="$HOME/.claude/projects/$PROJ_DASH/memory/agent-state.json"
 
 # Get current sprint issues (top 3 open)
 SPRINT_ISSUES=$(gh issue list \
@@ -91,7 +94,7 @@ except:
 fi
 
 # Get latest fix chain warning from retro (if any)
-RETRO_WARNING=$(cat "$HOME/.claude/projects/-Users-paulwander-projects-HF/memory/retro-latest.md" 2>/dev/null | \
+RETRO_WARNING=$(cat "$HOME/.claude/projects/$PROJ_DASH/memory/retro-latest.md" 2>/dev/null | \
   grep "REPEAT\|Fix chain" | head -3 | sed 's/^/  /')
 
 # Only output if we have something useful

--- a/.claude/hooks/stop-reminder.sh
+++ b/.claude/hooks/stop-reminder.sh
@@ -2,7 +2,9 @@
 # Stop hook — remind about deploy command after code changes
 # Receives JSON on stdin with session context
 
-cd /Users/paulwander/projects/HF || exit 0
+# Portable repo root: $CLAUDE_PROJECT_DIR resolves on any machine.
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+cd "$REPO_ROOT" || exit 0
 
 # Check if there are uncommitted changes (code was written)
 DIRTY=$(git status --porcelain 2>/dev/null | grep -c '^ M\|^??\|^A ')

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/paulwander/projects/HF/.claude/hooks/session-start.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
           }
         ]
       }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/paulwander/projects/HF/.claude/hooks/sprint-context.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/sprint-context.sh"
           }
         ]
       }
@@ -41,12 +41,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/paulwander/projects/HF/.claude/hooks/branch-drift-detector.sh",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/branch-drift-detector.sh",
             "timeout": 3
           },
           {
             "type": "command",
-            "command": "/Users/paulwander/projects/HF/.claude/hooks/git-lock-enforcer.sh",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/git-lock-enforcer.sh",
             "timeout": 3
           }
         ]
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/paulwander/projects/HF/.claude/hooks/flow-map-reminder.sh",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/flow-map-reminder.sh",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/paulwander/projects/HF/.claude/hooks/stop-reminder.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/stop-reminder.sh"
           }
         ]
       }


### PR DESCRIPTION
## Problem

All six `.claude` hooks are hardcoded to `/Users/paulwander/projects/HF` — in both the `settings.json` launcher commands **and** the internal `cd`/memory paths of the scripts.

On any collaborator's checkout (e.g. `~/HF`):
- the launcher path points at a file that doesn't exist → **the hook never starts**;
- the internal `cd /Users/paulwander/projects/HF` fails → **the script no-ops**.

Net effect: the concurrent-session guards (`git-lock-enforcer`, `branch-drift-detector`) and session context provide **zero protection off your machine**. I hit this live today — a second session pushed a branch + opened a PR with nothing guarding the shared tree.

## Fix

Use `$CLAUDE_PROJECT_DIR` (Claude Code sets it to the repo root on every machine; git-toplevel fallback for manual runs) for:
- all six launcher commands in `settings.json`;
- the internal repo root in `session-start`, `sprint-context`, `branch-drift-detector`, `stop-reminder`.

Per-machine Claude memory dir key is derived from the repo root (`/Users/x/HF` → `-Users-x-HF`).

**Behaviour is identical on your machine** — `$CLAUDE_PROJECT_DIR` resolves to `/Users/paulwander/projects/HF` there. It just *also* works for the rest of us.

`git-lock-enforcer.sh` and `flow-map-reminder.sh` had no internal hardcoded paths — only their launcher lines changed.

## Verification (on a second machine)
- All 5 edited scripts pass `bash -n`; `settings.json` valid JSON.
- `session-start` claims the lock + writes the correct HEAD snapshot.
- `git-lock-enforcer` runs; allows non-git / read-only / `HF_FORCE_GIT=1`.
- `branch-drift-detector` + `stop-reminder` execute (exit 0).

## Note
The `~/.zshrc` `claude` wrapper (worktree auto-create) is keyed to `~/projects/HF` and lives outside the repo, so it's untouched here — collaborators with a different layout would need their own wrapper. Flagging in case you want a repo-level equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)