### PR TITLE
feat(courses): extract Voice from Settings to its own tab

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -149,7 +149,7 @@ type SessionTabData = {
 
 import { SectionHeader } from './SectionHeader';
 
-const VALID_TABS = ['intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'settings',
+const VALID_TABS = ['intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'voice', 'settings',
   // Legacy tab IDs — redirected in handleTabChange
   'overview', 'journey', 'genome', 'audience', 'session-flow',
 ];
@@ -406,6 +406,10 @@ export default function CourseDetailPage() {
     { id: 'learners', label: <TabWithHelp tabId="learners">Learners</TabWithHelp>, icon: <Users2 size={14} /> },
     { id: 'proof', label: <TabWithHelp tabId="proof">Proof Points</TabWithHelp>, icon: <BarChart3 size={14} /> },
     { id: 'goals', label: <TabWithHelp tabId="goals">Goals</TabWithHelp>, icon: <Target size={14} /> },
+    // #1273 — Voice extracted from Settings tab to a first-class tab.
+    // OPERATOR-only (matches the in-Settings location's gate). Sits before
+    // Settings to keep the tuning surfaces (Goals + Voice) adjacent.
+    ...(isOperator ? [{ id: 'voice', label: <TabWithHelp tabId="voice">Voice</TabWithHelp>, icon: <Mic size={14} /> }] : []),
     ...(isOperator ? [{ id: 'settings', label: <TabWithHelp tabId="settings">Settings</TabWithHelp>, icon: <SettingsIcon size={14} /> }] : []),
   ], [totalSources, isOperator]);
 
@@ -1712,6 +1716,18 @@ export default function CourseDetailPage() {
       {/* ═══════════════════════════════════════════════ */}
       {/* SETTINGS TAB                                   */}
       {/* ═══════════════════════════════════════════════ */}
+      {activeTab === 'voice' && (
+        <div className="hf-mt-lg">
+          {isOperator ? (
+            <VoiceConfigSection scope="course" scopeId={courseId} />
+          ) : (
+            <div className="hf-banner hf-banner-info">
+              You do not have permission to manage course voice settings.
+            </div>
+          )}
+        </div>
+      )}
+
       {activeTab === 'settings' && (
         <div className="hf-mt-lg">
           {isOperator ? (
@@ -1847,9 +1863,8 @@ export default function CourseDetailPage() {
                 </>
               )}
 
-              <SectionHeader title="Voice" icon={Mic} collapsible defaultCollapsed persistKey={`${courseId}.voice`}>
-                <VoiceConfigSection scope="course" scopeId={courseId} />
-              </SectionHeader>
+              {/* #1273 — Voice extracted to its own tab. Find it at
+                  /x/courses/<id>?tab=voice. */}
 
               <SectionHeader title="Metadata" icon={FileText} collapsible defaultCollapsed persistKey={`${courseId}.metadata`}>
                 <div className="hf-card">

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -185,6 +185,13 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
         whenToUse: "When you want to retune what the AI is trying to achieve with each caller.",
       },
       {
+        id: "voice",
+        label: "Voice",
+        about: "TTS engine, voice ID, transcriber, silence timeout, max duration, and other per-course voice overrides. Cascades from System → Provider → Domain → Course.",
+        whenToUse: "When you want a different voice for this course, or you need to tighten cost caps, silence timeouts, or recording behaviour for a specific cohort.",
+        requiresOperator: true,
+      },
+      {
         id: "settings",
         label: "Settings",
         about: "Scheduling, AI model selection, soft-delete, and other course-level configuration.",
@@ -199,6 +206,7 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       { keys: "E", action: "callback", callbackId: "tab:learners", label: "Learners tab (Enrolled)" },
       { keys: "P", action: "callback", callbackId: "tab:proof", label: "Proof Points tab" },
       { keys: "O", action: "callback", callbackId: "tab:goals", label: "Goals tab (gOals — G is reserved as a chord prefix)" },
+      { keys: "V", action: "callback", callbackId: "tab:voice", label: "Voice tab", requiresOperator: true },
       { keys: "T", action: "callback", callbackId: "tab:settings", label: "Settings tab", requiresOperator: true },
     ],
   },


### PR DESCRIPTION
Closes #1273.

## Summary
- Voice was buried in the course Settings tab as a collapsed section (shipped under #1271 Slices C+D). With #1334 making voice a high-leverage cost lever and #1335 about to cascade it further, promotion to a first-class tab raises discoverability without changing any of the write path.
- Pure UI refactor — same \`VoiceConfigSection\` component (\`scope=\"course\"\`), same PATCH route, same autosave + provenance + reset-to-inherited behaviour.
- OPERATOR-only (matches the in-Settings location's gate).
- Sits between Goals and Settings so the two tuning surfaces are adjacent.

## Changes
- \`app/x/courses/[courseId]/page.tsx\` — \`VALID_TABS\` gains \`'voice'\`; new tab entry in the \`tabs\` useMemo with \`<Mic />\` icon; new \`activeTab === 'voice'\` render block; removed the in-Settings Voice SectionHeader.
- \`lib/help/page-help.ts\` — tab-help entry (about + whenToUse) + \`V\` chord registration consistent with \`T\` = Settings.

## No-touch
- No schema, no migration.
- No API changes — \`VoiceConfigSection\` already talks to its own PATCH endpoints.
- Settings tab still contains Status / Course Configuration / Teaching Identity / Metadata.

## Test plan
- [ ] \`/x/courses/<id>?tab=voice\` mounts the existing Voice config UI (OPERATOR session only).
- [ ] STUDENT/VIEWER session: \"Voice\" tab does not appear in the tab list.
- [ ] Setting an override on the new tab still persists to \`Playbook.config.voice\` (same write path as Settings location did).
- [ ] Settings tab no longer shows Voice section.
- [ ] Linear back/forward + deep link \`?tab=voice\` work.
- [ ] \`V\` chord switches to Voice tab (chord callback registration TBD — currently declarative-only in \`page-help.ts\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)