### PR TITLE
docs(adr): #1334 ADR — add empirical baseline + reality-check on $/min

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -149,7 +149,7 @@ type SessionTabData = {
 
 import { SectionHeader } from './SectionHeader';
 
-const VALID_TABS = ['intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'settings',
+const VALID_TABS = ['intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'voice', 'settings',
   // Legacy tab IDs — redirected in handleTabChange
   'overview', 'journey', 'genome', 'audience', 'session-flow',
 ];
@@ -406,6 +406,10 @@ export default function CourseDetailPage() {
     { id: 'learners', label: <TabWithHelp tabId="learners">Learners</TabWithHelp>, icon: <Users2 size={14} /> },
     { id: 'proof', label: <TabWithHelp tabId="proof">Proof Points</TabWithHelp>, icon: <BarChart3 size={14} /> },
     { id: 'goals', label: <TabWithHelp tabId="goals">Goals</TabWithHelp>, icon: <Target size={14} /> },
+    // #1273 — Voice extracted from Settings tab to a first-class tab.
+    // OPERATOR-only (matches the in-Settings location's gate). Sits before
+    // Settings to keep the tuning surfaces (Goals + Voice) adjacent.
+    ...(isOperator ? [{ id: 'voice', label: <TabWithHelp tabId="voice">Voice</TabWithHelp>, icon: <Mic size={14} /> }] : []),
     ...(isOperator ? [{ id: 'settings', label: <TabWithHelp tabId="settings">Settings</TabWithHelp>, icon: <SettingsIcon size={14} /> }] : []),
   ], [totalSources, isOperator]);
 
@@ -1712,6 +1716,18 @@ export default function CourseDetailPage() {
       {/* ═══════════════════════════════════════════════ */}
       {/* SETTINGS TAB                                   */}
       {/* ═══════════════════════════════════════════════ */}
+      {activeTab === 'voice' && (
+        <div className="hf-mt-lg">
+          {isOperator ? (
+            <VoiceConfigSection scope="course" scopeId={courseId} />
+          ) : (
+            <div className="hf-banner hf-banner-info">
+              You do not have permission to manage course voice settings.
+            </div>
+          )}
+        </div>
+      )}
+
       {activeTab === 'settings' && (
         <div className="hf-mt-lg">
           {isOperator ? (
@@ -1847,9 +1863,8 @@ export default function CourseDetailPage() {
                 </>
               )}
 
-              <SectionHeader title="Voice" icon={Mic} collapsible defaultCollapsed persistKey={`${courseId}.voice`}>
-                <VoiceConfigSection scope="course" scopeId={courseId} />
-              </SectionHeader>
+              {/* #1273 — Voice extracted to its own tab. Find it at
+                  /x/courses/<id>?tab=voice. */}
 
               <SectionHeader title="Metadata" icon={FileText} collapsible defaultCollapsed persistKey={`${courseId}.metadata`}>
                 <div className="hf-card">

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -185,6 +185,13 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
         whenToUse: "When you want to retune what the AI is trying to achieve with each caller.",
       },
       {
+        id: "voice",
+        label: "Voice",
+        about: "TTS engine, voice ID, transcriber, silence timeout, max duration, and other per-course voice overrides. Cascades from System → Provider → Domain → Course.",
+        whenToUse: "When you want a different voice for this course, or you need to tighten cost caps, silence timeouts, or recording behaviour for a specific cohort.",
+        requiresOperator: true,
+      },
+      {
         id: "settings",
         label: "Settings",
         about: "Scheduling, AI model selection, soft-delete, and other course-level configuration.",
@@ -199,6 +206,7 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       { keys: "E", action: "callback", callbackId: "tab:learners", label: "Learners tab (Enrolled)" },
       { keys: "P", action: "callback", callbackId: "tab:proof", label: "Proof Points tab" },
       { keys: "O", action: "callback", callbackId: "tab:goals", label: "Goals tab (gOals — G is reserved as a chord prefix)" },
+      { keys: "V", action: "callback", callbackId: "tab:voice", label: "Voice tab", requiresOperator: true },
       { keys: "T", action: "callback", callbackId: "tab:settings", label: "Settings tab", requiresOperator: true },
     ],
   },

--- a/docs/decisions/2026-06-08-pilot-cheaper-tts.md
+++ b/docs/decisions/2026-06-08-pilot-cheaper-tts.md
@@ -151,6 +151,33 @@ The runbook section below stays in this ADR — if quality complaints land, run 
 - Reviewer: Tech Lead agent confirmed the cascade plumbing is fully wired and the swap is single-config-flip reversible ([review comment](https://github.com/WANDERCOLTD/HF/issues/1334#issuecomment-4650299662)).
 - Date: 2026-06-08.
 
+### Baseline data (captured post-merge, pre-migration effect)
+
+Pulled from `hf_sandbox.Call.voiceCostUsd / voiceDurationSeconds` via `/tmp/vm-cost-baseline.sh` immediately after the migration ran on the VM but before any post-migration calls had completed. So this is the **pre-migration** baseline — every call here used the prior default (VAPI's underlying ElevenLabs).
+
+Last 30 days, 21 calls with cost data, 8 of those ≥ 30 seconds:
+
+| Metric | $/min |
+|---|---|
+| Mean (n=8) | **$0.0933** |
+| Median | $0.0905 |
+| Min | $0.0828 |
+| Max | $0.1137 |
+
+**Reality check on the original $0.18/min estimate.** This ADR opened by quoting "~$0.18/min" as the ElevenLabs price point and "~12× cheaper" as the framing. The measured bundled cost is **$0.093/min** — about half what the ADR estimated. VAPI is presumably using ElevenLabs Turbo (~$0.05/min) and/or volume pricing, not Multilingual Standard. The TTS-only line in the bundle is therefore closer to $0.05/min, not $0.18/min.
+
+**Updated projection** (TTS-only swap, holding STT + LLM constant at their bundled rates):
+- Old TTS contribution: ~$0.05/min (ElevenLabs Turbo via VAPI)
+- New TTS contribution: ~$0.015/min (Deepgram Aura via VAPI)
+- Per-min saving: ~$0.035/min
+- New projected total: **~$0.058/min** vs **$0.093/min** baseline = **~37% reduction**, not 90%.
+
+Real saving will be in the next 5–10 post-migration calls. Re-run `/tmp/vm-cost-baseline.sh` then to confirm.
+
+### Open follow-on: UsageEvent.costCents not populated for VOICE
+
+While capturing the baseline, found that `UsageEvent` has 1,334 rows in the last 30 days with `category = "VOICE"` and **all rows have `costCents = 0`**. The cost data lives on `Call.voiceCostUsd` (canonical post-#1020 column) and that's the only authoritative source today. `processStatusUpdate` in `lib/voice/route-handlers.ts:262` writes `costCents` per status-update event but those writes aren't materialising in the table. Worth a focused look if we want per-component (TTS / STT / LLM) cost breakdowns rather than per-call totals. Not blocking — Call.voiceCostUsd works for #1334 measurement.
+
 ## Risks + footguns
 
 - **Voice ID provider-mismatch:** setting `voiceProvider: "deepgram"` with an ElevenLabs voice ID (or vice versa) results in a silent failure inside VAPI's TTS layer — calls connect, no audio, learner hears nothing. Today there's no form-level validation. Mitigation: copy the voice ID exactly from this ADR; double-check both fields are saved together. Follow-on: file a form-validation issue if the pilot trips this footgun.


### PR DESCRIPTION
Pulls the actual pre-migration baseline from `hf_sandbox.Call.voiceCostUsd` and grounds the ADR in real numbers instead of the original /bin/zsh.18/min estimate. Updated projection: ~37% reduction (not 90%). Also captures an open follow-on: `UsageEvent.costCents` is 0 for all VOICE-category rows — per-call cost lives on `Call.voiceCostUsd` only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)