### PR TITLE
fix(voice): wrap voice-config writes in PlaybookConfigTransformer

### DIFF
--- a/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
@@ -136,7 +136,10 @@ export async function PATCH(
   } else {
     nextVoice[key] = value;
   }
-  await updatePlaybookConfig(playbookId, { voice: nextVoice } as Partial<PlaybookConfig>);
+  await updatePlaybookConfig(playbookId, (current) => ({
+    ...current,
+    voice: nextVoice,
+  }));
 
   return NextResponse.json({ ok: true, key, applied: value === null ? "cleared" : "set" });
 }

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -2455,7 +2455,10 @@ async function handleUpdateVoiceConfig(input: Record<string, any>) {
     ...sanitised,
   };
 
-  await updatePlaybookConfig(playbookId, { voice: mergedVoice } as Partial<PlaybookConfig>);
+  await updatePlaybookConfig(playbookId, (current) => ({
+    ...current,
+    voice: mergedVoice,
+  }));
 
   const changedKeys = Object.keys(sanitised);
   const pendingChange = buildPendingChangePayload({


### PR DESCRIPTION
## Summary

Production-blocking bug fix. Two call sites passed `{ voice: nextVoice } as Partial<PlaybookConfig>` to `updatePlaybookConfig`, which expects a `(current: PlaybookConfig) => PlaybookConfig` transformer function. The `as` cast suppressed the TypeScript error; runtime threw `TypeError: transformer is not a function` on every voice-config save.

Both sites now pass a transformer that spreads `current` and sets `voice`:

```ts
await updatePlaybookConfig(playbookId, (current) => ({
  ...current,
  voice: nextVoice,
}));
```

## Live evidence (hf-dev sandbox)

```
TypeError: transformer is not a function
    at updatePlaybookConfig (lib/playbook/update-playbook-config.ts:130:22)
    at async PATCH (app/api/playbooks/[playbookId]/voice-config/route.ts:139:3)
```

PATCH `/api/playbooks/eebf437a-62c7-4389-9d87-081a1557ba3b/voice-config` returned HTTP 500 every time before this fix.

## Files touched

- `apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts:139`
- `apps/admin/lib/chat/admin-tool-handlers.ts:2458` (the `update_voice_config` admin tool added in #1234)

## CI impact

Closes the +1 tsc ratchet currently red on every PR. The CI tsc error `lib/chat/admin-tool-handlers.ts(2458,42): error TS2345: Argument of type 'Partial<PlaybookConfig>' is not assignable to parameter of type 'PlaybookConfigTransformer'.` greens up immediately.

## Test plan

- [ ] CI tsc passes (was the +1 ratchet on main)
- [ ] After merge + `/vm-cp`: PATCH /api/playbooks/<id>/voice-config returns 200 instead of 500
- [ ] Operator can save voice settings on `/x/settings/voice-providers/<id>` without server error