### PR TITLE
fix(voice): kill duplicate bubbles — skip conversation-update + REPLACE coalesce

### DIFF
--- a/apps/admin/app/api/voice/calls/start/route.ts
+++ b/apps/admin/app/api/voice/calls/start/route.ts
@@ -238,6 +238,19 @@ export async function POST(request: Request) {
       callIdForRuntime: placeholderCall.id,
     });
 
+    // #1361 — Inject HF placeholder id into assistant.metadata so the
+    // provider echoes it on every webhook (transcript_update, status,
+    // end-of-call). Without this, the WebRTC path has no way for the
+    // webhook handler to map provider call-id → our placeholder Call row,
+    // and the SimChat SSE subscription receives no transcript-partial
+    // events. PSTN doesn't need this — outbound-dial captures the VAPI
+    // call.id synchronously from the POST /call response — but passing
+    // metadata on both paths is harmless and uniform.
+    const assistantConfigWithMeta = injectAssistantMetadata(
+      built.assistantConfig,
+      { hfCallId: placeholderCall.id },
+    );
+
     const response = NextResponse.json({
       ok: true,
       callId: placeholderCall.id,
@@ -251,7 +264,7 @@ export async function POST(request: Request) {
         // Inline assistant config — Web SDK consumes this directly.
         // PSTN dial-in uses the assistant-request webhook instead;
         // both paths share the same builder so behaviour is identical.
-        assistantConfig: built.assistantConfig,
+        assistantConfig: assistantConfigWithMeta,
       },
       expiresAt,
     });
@@ -269,4 +282,35 @@ export async function POST(request: Request) {
       { status: 500 },
     );
   }
+}
+
+/**
+ * Inject `metadata` onto the assistant object inside a provider-shaped
+ * assistant config (#1361). Adapters return `{ assistant: {...} }` (VAPI
+ * shape) — write the metadata on the inner object so VAPI echoes it back
+ * on every webhook (transcript / status-update / end-of-call). When the
+ * adapter doesn't wrap (`{...}` directly), merge at the root. Pure;
+ * doesn't mutate the input.
+ */
+function injectAssistantMetadata(
+  assistantConfig: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+): Record<string, unknown> {
+  const inner = (assistantConfig as { assistant?: Record<string, unknown> })
+    .assistant;
+  if (inner && typeof inner === "object") {
+    const existing = (inner.metadata as Record<string, unknown> | undefined) ?? {};
+    return {
+      ...assistantConfig,
+      assistant: {
+        ...inner,
+        metadata: { ...existing, ...metadata },
+      },
+    };
+  }
+  const existing = (assistantConfig.metadata as Record<string, unknown> | undefined) ?? {};
+  return {
+    ...assistantConfig,
+    metadata: { ...existing, ...metadata },
+  };
 }

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -231,9 +231,13 @@ export function SimChat({
         const id = `voice-${event.timestampMs}-${event.role}`;
         const isLearner = event.role === 'learner';
         setMessages((prev) => {
-          // Coalesce: if the last message is the same role from a
-          // recent transcript-partial, append. Keeps the chat from
-          // exploding with one bubble per word.
+          // #1364 — Coalesce same-role chunks by REPLACE, not APPEND.
+          // VAPI's `transcript` events carry the latest Deepgram interim
+          // result for the current speaker turn — each chunk is the FULL
+          // transcript-so-far, not a delta to concatenate. APPEND
+          // produced duplication like "hello hello there hello there how
+          // are you". REPLACE shows a single growing bubble per turn.
+          // Pre-existing bug, masked until #1361 made the bubbles appear.
           const last = prev[prev.length - 1];
           if (
             last &&
@@ -241,7 +245,11 @@ export function SimChat({
             ((isLearner && last.role === 'user') ||
               (!isLearner && last.role === 'assistant'))
           ) {
-            const updated = { ...last, content: `${last.content} ${event.text}`.trim() };
+            // Drop no-op events (same text as the bubble already shows).
+            if (last.content === event.text) {
+              return prev;
+            }
+            const updated = { ...last, content: event.text };
             return [...prev.slice(0, -1), updated];
           }
           return [

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -561,7 +561,30 @@ export class VapiProvider implements VoiceProvider {
         ? "assistant"
         : "learner";
 
-    return { externalCallId, role, text: rawText };
+    // #1361 — Pull HF placeholder id out of `assistant.metadata.hfCallId`
+    // (set at WebRTC call-start). VAPI echoes assistant metadata in webhook
+    // payloads under a few different nest paths depending on event type;
+    // try the most common ones in order, fall back to null.
+    const assistant = (message.assistant ?? root.assistant) as
+      | Record<string, unknown>
+      | undefined;
+    const assistantOverrides = (call?.assistantOverrides ??
+      message.assistantOverrides) as Record<string, unknown> | undefined;
+    const callMeta = call?.metadata as Record<string, unknown> | undefined;
+    const messageMeta = message.metadata as Record<string, unknown> | undefined;
+
+    const hfCallIdCandidate =
+      (assistant?.metadata as Record<string, unknown> | undefined)?.hfCallId ??
+      (assistantOverrides?.metadata as Record<string, unknown> | undefined)?.hfCallId ??
+      callMeta?.hfCallId ??
+      messageMeta?.hfCallId ??
+      null;
+    const hfCallId =
+      typeof hfCallIdCandidate === "string" && hfCallIdCandidate.length > 0
+        ? hfCallIdCandidate
+        : null;
+
+    return { externalCallId, role, text: rawText, hfCallId };
   }
 
   /**

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -506,7 +506,15 @@ export class VapiProvider implements VoiceProvider {
     const root = body as Record<string, unknown>;
     const message = (root.message ?? root) as Record<string, unknown>;
     const type = (message.type ?? root.type) as string | undefined;
-    if (type !== "transcript" && type !== "conversation-update") return null;
+    // #1364 — parse `transcript` events only. VAPI fires both `transcript`
+    // (per-chunk Deepgram interim_results) AND `conversation-update`
+    // (full-history snapshot ~1Hz). Pre-#1364 we parsed both, broadcasting
+    // the latest message twice — once as a transcript chunk, once via the
+    // conversation-update history-walk — and SimChat showed duplicate
+    // bubbles. transcript chunks are sufficient for incremental streaming;
+    // conversation-update is a catch-up snapshot that the chat surface
+    // doesn't need when it's been subscribed from call start.
+    if (type !== "transcript") return null;
 
     const call = (message.call ?? root.call) as
       | Record<string, unknown>

--- a/apps/admin/lib/voice/route-handlers.ts
+++ b/apps/admin/lib/voice/route-handlers.ts
@@ -368,11 +368,41 @@ async function processTranscriptUpdate(
   parsed: ParsedTranscriptUpdate,
   slug: string,
 ): Promise<void> {
-  const callRow = await prisma.call.findFirst({
-    where: { externalId: parsed.externalCallId, source: slug },
-    select: { id: true, callerId: true },
-  });
+  // #1361 — Prefer hfCallId lookup (WebRTC path round-trips our placeholder
+  // id via assistant.metadata.hfCallId). Fall back to externalId for PSTN
+  // and any legacy rows. Same single indexed findFirst — no perf cost.
+  let callRow: { id: string; callerId: string | null; externalId: string | null } | null = null;
+  if (parsed.hfCallId) {
+    callRow = await prisma.call.findFirst({
+      where: { id: parsed.hfCallId, source: slug },
+      select: { id: true, callerId: true, externalId: true },
+    });
+  }
+  if (!callRow) {
+    callRow = await prisma.call.findFirst({
+      where: { externalId: parsed.externalCallId, source: slug },
+      select: { id: true, callerId: true, externalId: true },
+    });
+  }
   if (!callRow) return;
+
+  // Self-heal: when matched via hfCallId AND the externalId is empty
+  // (WebRTC placeholder pre-first-webhook), stamp VAPI's externalId
+  // onto the row so subsequent code paths (cost-cap trickle, end-of-call
+  // merge, /x/logs lookups) can still use externalId as before.
+  if (!callRow.externalId && parsed.externalCallId) {
+    prisma.call
+      .update({
+        where: { id: callRow.id },
+        data: { externalId: parsed.externalCallId },
+      })
+      .catch((err) => {
+        console.warn(
+          `[voice/transcript-update] externalId backfill failed for callId=${callRow!.id}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+  }
 
   await broadcastToCall({
     type: "transcript-partial",
@@ -388,7 +418,11 @@ async function processTranscriptUpdate(
     durationMs: 0,
     callId: callRow.id,
     callerId: callRow.callerId,
-    metadata: { role: parsed.role, chars: parsed.text.length },
+    metadata: {
+      role: parsed.role,
+      chars: parsed.text.length,
+      matchedBy: parsed.hfCallId && callRow.id === parsed.hfCallId ? "hfCallId" : "externalId",
+    },
   });
 }
 

--- a/apps/admin/lib/voice/types.ts
+++ b/apps/admin/lib/voice/types.ts
@@ -193,6 +193,19 @@ export interface ParsedTranscriptUpdate {
   externalCallId: string;
   role: "learner" | "assistant";
   text: string;
+  /** Optional HF placeholder Call id, surfaced via `assistant.metadata.hfCallId`
+   *  in the inline assistant config (#1361). The WebRTC [Talk Here] path
+   *  creates a placeholder Call row BEFORE the provider assigns its own id,
+   *  so the synchronous "capture VAPI id from POST /call response" trick the
+   *  PSTN path uses is unavailable. Instead we round-trip our placeholder id
+   *  through the provider's metadata field; the webhook then resolves to the
+   *  correct row by this id (preferred) or by `externalCallId` (legacy /
+   *  PSTN fallback).
+   *
+   *  Absent when (a) the adapter doesn't echo metadata, (b) the inline
+   *  config didn't include it, or (c) the inbound payload is a PSTN call
+   *  where the placeholder was created with externalId already populated. */
+  hfCallId?: string | null;
 }
 
 /** Single tool call normalised from a provider's batched callback. */

--- a/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
@@ -89,68 +89,36 @@ describe("VapiProvider.parseTranscriptUpdate — `transcript` event (chunk)", ()
   });
 });
 
-describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#922 fix)", () => {
+describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#1364 skip)", () => {
+  // #1364 — Parser intentionally returns null for conversation-update.
+  // VAPI fires both `transcript` (per-chunk Deepgram interim_results)
+  // AND `conversation-update` (full-history snapshot ~1Hz). Parsing
+  // both produced duplicate bubbles in SimChat (each turn broadcast
+  // twice — once as a chunk, once via the history-walk). Transcript
+  // chunks are sufficient for incremental streaming; the history
+  // snapshot is a catch-up channel the chat surface doesn't need.
   const p = new VapiProvider({}, {});
 
-  it("extracts the most recent non-system turn from `messages` array", () => {
-    // Pre-#922: route handler read `message.transcript` only and so
-    // dropped every conversation-update event silently. The fix walks
-    // the messages array bottom-up to find the latest non-system/
-    // non-tool turn.
+  it("returns null for conversation-update with messages array (was the #922 history-walk path)", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_history" },
         messages: [
-          { role: "system", content: "You are a tutor." },
           { role: "user", content: "what is past tense?" },
           { role: "assistant", content: "past tense describes actions that have already happened" },
         ],
       },
     };
-    expect(p.parseTranscriptUpdate(body)).toEqual({
-      externalCallId: "vapi_call_history",
-      role: "assistant",
-      text: "past tense describes actions that have already happened",
-      hfCallId: null,
-    });
+    expect(p.parseTranscriptUpdate(body)).toBeNull();
   });
 
-  it("skips `system` and `tool` roles when walking the history", () => {
-    const body = {
-      message: {
-        type: "conversation-update",
-        call: { id: "vapi_call_skip" },
-        messages: [
-          { role: "user", content: "what time is it" },
-          { role: "tool", content: '{"time":"15:42"}' },
-          { role: "system", content: "(internal)" },
-        ],
-      },
-    };
-    // After filtering system + tool, the most-recent non-skipped is `user`.
-    expect(p.parseTranscriptUpdate(body)?.role).toBe("learner");
-  });
-
-  it("accepts the alternate `messagesOpenAIFormatted` key VAPI sometimes uses", () => {
+  it("returns null for conversation-update with messagesOpenAIFormatted", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_alt" },
-        messagesOpenAIFormatted: [
-          { role: "user", content: "hi" },
-        ],
-      },
-    };
-    expect(p.parseTranscriptUpdate(body)?.text).toBe("hi");
-  });
-
-  it("returns null when no non-system content found", () => {
-    const body = {
-      message: {
-        type: "conversation-update",
-        call: { id: "vapi_call_only_system" },
-        messages: [{ role: "system", content: "..." }],
+        messagesOpenAIFormatted: [{ role: "user", content: "hi" }],
       },
     };
     expect(p.parseTranscriptUpdate(body)).toBeNull();

--- a/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
@@ -40,6 +40,7 @@ describe("VapiProvider.parseTranscriptUpdate — `transcript` event (chunk)", ()
       externalCallId: "vapi_call_abc",
       role: "learner",
       text: "hello can you hear me",
+      hfCallId: null,
     });
   });
 
@@ -111,6 +112,7 @@ describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#9
       externalCallId: "vapi_call_history",
       role: "assistant",
       text: "past tense describes actions that have already happened",
+      hfCallId: null,
     });
   });
 
@@ -168,6 +170,76 @@ describe("VapiProvider.getCapabilities — orchestrationMode (#1337)", () => {
     expect(caps.hasKnowledgeCallback).toBe(true);
     expect(caps.toolCallsOverWebSocket).toBe(false);
     expect(caps.supportsRequestEndCall).toBe(true);
+  });
+});
+
+describe("VapiProvider.parseTranscriptUpdate — hfCallId extraction (#1361)", () => {
+  const p = new VapiProvider({}, {});
+
+  it("extracts hfCallId from assistant.metadata (canonical WebRTC path)", () => {
+    const body = {
+      message: {
+        type: "transcript",
+        transcript: "hi",
+        role: "user",
+        call: { id: "vapi_call_xyz" },
+        assistant: { metadata: { hfCallId: "hf_placeholder_123" } },
+      },
+    };
+    const out = p.parseTranscriptUpdate(body);
+    expect(out?.hfCallId).toBe("hf_placeholder_123");
+  });
+
+  it("extracts hfCallId from call.metadata (alternate VAPI nest)", () => {
+    const body = {
+      message: {
+        type: "transcript",
+        transcript: "hi",
+        role: "user",
+        call: { id: "vapi_call_xyz", metadata: { hfCallId: "hf_alt_456" } },
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.hfCallId).toBe("hf_alt_456");
+  });
+
+  it("extracts hfCallId from call.assistantOverrides.metadata (override nest)", () => {
+    const body = {
+      message: {
+        type: "transcript",
+        transcript: "hi",
+        role: "user",
+        call: {
+          id: "vapi_call_xyz",
+          assistantOverrides: { metadata: { hfCallId: "hf_override_789" } },
+        },
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.hfCallId).toBe("hf_override_789");
+  });
+
+  it("returns hfCallId: null when no metadata anywhere (PSTN / legacy)", () => {
+    const body = {
+      message: {
+        type: "transcript",
+        transcript: "hi",
+        role: "user",
+        call: { id: "vapi_call_xyz" },
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.hfCallId).toBeNull();
+  });
+
+  it("ignores empty-string hfCallId (treated as missing)", () => {
+    const body = {
+      message: {
+        type: "transcript",
+        transcript: "hi",
+        role: "user",
+        call: { id: "vapi_call_xyz" },
+        assistant: { metadata: { hfCallId: "" } },
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.hfCallId).toBeNull();
   });
 });
 


### PR DESCRIPTION
After #1363 made WebRTC transcript bubbles appear, the user immediately saw them duplicated. Two bugs that cancelled out before are now visible:

## 1. Parser broadcast both `transcript` AND `conversation-update` events
VAPI fires both — `transcript` is per-chunk Deepgram interim_results (full transcript-so-far per chunk), `conversation-update` is a full-history snapshot ~1Hz. Walking the messages array picked the LATEST turn — same content as the concurrent transcript event. Broadcast twice.

**Fix:** parser returns null for conversation-update. Transcript chunks are sufficient for incremental streaming.

## 2. SimChat coalescer APPENDED chunks
Each transcript event is the FULL interim, not a delta. APPEND produced "hello hello there hello there how are you". 

**Fix:** REPLACE-semantics — one bubble per speaker turn, growing in real time. Plus skip-setState shortcut when chunk equals existing content (no flicker).

## Tests
4 conversation-update tests rewritten to assert null returns. 159/159 voice tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)