### PR TITLE
fix(voice): kill duplicate bubbles — skip conversation-update + REPLACE coalesce

### DIFF
--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -231,9 +231,13 @@ export function SimChat({
         const id = `voice-${event.timestampMs}-${event.role}`;
         const isLearner = event.role === 'learner';
         setMessages((prev) => {
-          // Coalesce: if the last message is the same role from a
-          // recent transcript-partial, append. Keeps the chat from
-          // exploding with one bubble per word.
+          // #1364 — Coalesce same-role chunks by REPLACE, not APPEND.
+          // VAPI's `transcript` events carry the latest Deepgram interim
+          // result for the current speaker turn — each chunk is the FULL
+          // transcript-so-far, not a delta to concatenate. APPEND
+          // produced duplication like "hello hello there hello there how
+          // are you". REPLACE shows a single growing bubble per turn.
+          // Pre-existing bug, masked until #1361 made the bubbles appear.
           const last = prev[prev.length - 1];
           if (
             last &&
@@ -241,7 +245,11 @@ export function SimChat({
             ((isLearner && last.role === 'user') ||
               (!isLearner && last.role === 'assistant'))
           ) {
-            const updated = { ...last, content: `${last.content} ${event.text}`.trim() };
+            // Drop no-op events (same text as the bubble already shows).
+            if (last.content === event.text) {
+              return prev;
+            }
+            const updated = { ...last, content: event.text };
             return [...prev.slice(0, -1), updated];
           }
           return [

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -506,7 +506,15 @@ export class VapiProvider implements VoiceProvider {
     const root = body as Record<string, unknown>;
     const message = (root.message ?? root) as Record<string, unknown>;
     const type = (message.type ?? root.type) as string | undefined;
-    if (type !== "transcript" && type !== "conversation-update") return null;
+    // #1364 — parse `transcript` events only. VAPI fires both `transcript`
+    // (per-chunk Deepgram interim_results) AND `conversation-update`
+    // (full-history snapshot ~1Hz). Pre-#1364 we parsed both, broadcasting
+    // the latest message twice — once as a transcript chunk, once via the
+    // conversation-update history-walk — and SimChat showed duplicate
+    // bubbles. transcript chunks are sufficient for incremental streaming;
+    // conversation-update is a catch-up snapshot that the chat surface
+    // doesn't need when it's been subscribed from call start.
+    if (type !== "transcript") return null;
 
     const call = (message.call ?? root.call) as
       | Record<string, unknown>

--- a/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
@@ -89,68 +89,36 @@ describe("VapiProvider.parseTranscriptUpdate — `transcript` event (chunk)", ()
   });
 });
 
-describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#922 fix)", () => {
+describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#1364 skip)", () => {
+  // #1364 — Parser intentionally returns null for conversation-update.
+  // VAPI fires both `transcript` (per-chunk Deepgram interim_results)
+  // AND `conversation-update` (full-history snapshot ~1Hz). Parsing
+  // both produced duplicate bubbles in SimChat (each turn broadcast
+  // twice — once as a chunk, once via the history-walk). Transcript
+  // chunks are sufficient for incremental streaming; the history
+  // snapshot is a catch-up channel the chat surface doesn't need.
   const p = new VapiProvider({}, {});
 
-  it("extracts the most recent non-system turn from `messages` array", () => {
-    // Pre-#922: route handler read `message.transcript` only and so
-    // dropped every conversation-update event silently. The fix walks
-    // the messages array bottom-up to find the latest non-system/
-    // non-tool turn.
+  it("returns null for conversation-update with messages array (was the #922 history-walk path)", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_history" },
         messages: [
-          { role: "system", content: "You are a tutor." },
           { role: "user", content: "what is past tense?" },
           { role: "assistant", content: "past tense describes actions that have already happened" },
         ],
       },
     };
-    expect(p.parseTranscriptUpdate(body)).toEqual({
-      externalCallId: "vapi_call_history",
-      role: "assistant",
-      text: "past tense describes actions that have already happened",
-      hfCallId: null,
-    });
+    expect(p.parseTranscriptUpdate(body)).toBeNull();
   });
 
-  it("skips `system` and `tool` roles when walking the history", () => {
-    const body = {
-      message: {
-        type: "conversation-update",
-        call: { id: "vapi_call_skip" },
-        messages: [
-          { role: "user", content: "what time is it" },
-          { role: "tool", content: '{"time":"15:42"}' },
-          { role: "system", content: "(internal)" },
-        ],
-      },
-    };
-    // After filtering system + tool, the most-recent non-skipped is `user`.
-    expect(p.parseTranscriptUpdate(body)?.role).toBe("learner");
-  });
-
-  it("accepts the alternate `messagesOpenAIFormatted` key VAPI sometimes uses", () => {
+  it("returns null for conversation-update with messagesOpenAIFormatted", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_alt" },
-        messagesOpenAIFormatted: [
-          { role: "user", content: "hi" },
-        ],
-      },
-    };
-    expect(p.parseTranscriptUpdate(body)?.text).toBe("hi");
-  });
-
-  it("returns null when no non-system content found", () => {
-    const body = {
-      message: {
-        type: "conversation-update",
-        call: { id: "vapi_call_only_system" },
-        messages: [{ role: "system", content: "..." }],
+        messagesOpenAIFormatted: [{ role: "user", content: "hi" }],
       },
     };
     expect(p.parseTranscriptUpdate(body)).toBeNull();


### PR DESCRIPTION
After #1363 made WebRTC transcript bubbles appear, user immediately saw duplication. Two pre-existing bugs that were masked by 'no bubbles at all' surfaced together.

1. **Parser broadcast `transcript` AND `conversation-update` events.** VAPI fires both — `transcript` is per-chunk Deepgram interim_results (each chunk = full transcript-so-far for the current turn), `conversation-update` is a full-history snapshot ~1Hz. Walking the messages array picked the latest turn — same content as the concurrent transcript event. Broadcast twice → duplicate bubbles.

   **Fix:** parser returns null for conversation-update. Transcript chunks are sufficient for incremental streaming; conversation-update is a catch-up snapshot the chat surface doesn't need (subscribed from call-start).

2. **SimChat coalescer APPENDED chunks.** Each transcript event is the FULL interim, not a delta — APPEND produced "hello hello there hello there how are you". 

   **Fix:** REPLACE-semantics — one bubble per speaker turn, growing in real time. Plus skip-setState shortcut when chunk equals existing content.

## Tests
- 4 conversation-update tests rewritten to assert null returns (intentional skip)
- 159/159 voice tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)