### PR TITLE
fix(voice): restore conversation-update parsing — sole live transcript source

### DIFF
--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -506,15 +506,16 @@ export class VapiProvider implements VoiceProvider {
     const root = body as Record<string, unknown>;
     const message = (root.message ?? root) as Record<string, unknown>;
     const type = (message.type ?? root.type) as string | undefined;
-    // #1364 — parse `transcript` events only. VAPI fires both `transcript`
-    // (per-chunk Deepgram interim_results) AND `conversation-update`
-    // (full-history snapshot ~1Hz). Pre-#1364 we parsed both, broadcasting
-    // the latest message twice — once as a transcript chunk, once via the
-    // conversation-update history-walk — and SimChat showed duplicate
-    // bubbles. transcript chunks are sufficient for incremental streaming;
-    // conversation-update is a catch-up snapshot that the chat surface
-    // doesn't need when it's been subscribed from call start.
-    if (type !== "transcript") return null;
+    // #1366 — parse BOTH `transcript` AND `conversation-update`. Live data
+    // showed VAPI's custom-llm setup fires ONLY `conversation-update`
+    // (no `transcript` events at all on the wire for this call shape).
+    // The #1364 "skip conversation-update" attempt killed all live
+    // broadcasts. Dedup now lives ENTIRELY on the client (#1365 REPLACE-
+    // not-APPEND coalesce) — REPLACE handles both event types correctly
+    // because each event carries the FULL latest turn (transcript = full
+    // Deepgram interim, conversation-update = full latest message via
+    // history-walk).
+    if (type !== "transcript" && type !== "conversation-update") return null;
 
     const call = (message.call ?? root.call) as
       | Record<string, unknown>

--- a/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
@@ -89,36 +89,66 @@ describe("VapiProvider.parseTranscriptUpdate — `transcript` event (chunk)", ()
   });
 });
 
-describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#1364 skip)", () => {
-  // #1364 — Parser intentionally returns null for conversation-update.
-  // VAPI fires both `transcript` (per-chunk Deepgram interim_results)
-  // AND `conversation-update` (full-history snapshot ~1Hz). Parsing
-  // both produced duplicate bubbles in SimChat (each turn broadcast
-  // twice — once as a chunk, once via the history-walk). Transcript
-  // chunks are sufficient for incremental streaming; the history
-  // snapshot is a catch-up channel the chat surface doesn't need.
+describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#922 + #1366 restore)", () => {
+  // #1366 — Re-enabled after live data showed VAPI's custom-llm setup
+  // fires conversation-update ONLY (no `transcript` events). The
+  // history-walk path picks the latest non-system turn. Dedup against
+  // transcript events lives client-side via REPLACE-not-APPEND coalesce
+  // (#1365) — REPLACE handles same-text repeats from either source.
   const p = new VapiProvider({}, {});
 
-  it("returns null for conversation-update with messages array (was the #922 history-walk path)", () => {
+  it("extracts the most recent non-system turn from `messages` array (#922)", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_history" },
         messages: [
+          { role: "system", content: "You are a tutor." },
           { role: "user", content: "what is past tense?" },
           { role: "assistant", content: "past tense describes actions that have already happened" },
         ],
       },
     };
-    expect(p.parseTranscriptUpdate(body)).toBeNull();
+    expect(p.parseTranscriptUpdate(body)).toEqual({
+      externalCallId: "vapi_call_history",
+      role: "assistant",
+      text: "past tense describes actions that have already happened",
+      hfCallId: null,
+    });
   });
 
-  it("returns null for conversation-update with messagesOpenAIFormatted", () => {
+  it("skips `system` and `tool` roles when walking the history", () => {
+    const body = {
+      message: {
+        type: "conversation-update",
+        call: { id: "vapi_call_skip" },
+        messages: [
+          { role: "user", content: "what time is it" },
+          { role: "tool", content: '{"time":"15:42"}' },
+          { role: "system", content: "(internal)" },
+        ],
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.role).toBe("learner");
+  });
+
+  it("accepts the alternate `messagesOpenAIFormatted` key VAPI sometimes uses", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_alt" },
         messagesOpenAIFormatted: [{ role: "user", content: "hi" }],
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.text).toBe("hi");
+  });
+
+  it("returns null when no non-system content found", () => {
+    const body = {
+      message: {
+        type: "conversation-update",
+        call: { id: "vapi_call_only_system" },
+        messages: [{ role: "system", content: "..." }],
       },
     };
     expect(p.parseTranscriptUpdate(body)).toBeNull();


### PR DESCRIPTION
#1364 hypothesis was wrong. Live data from /x/sim WebRTC call shows VAPI's custom-llm setup fires `conversation-update` ONLY — zero `transcript` events on the wire. AppLog evidence: 4× `voice.webhook.ignored | messageType: conversation-update`, zero `voice.webhook.transcript_update`.

The #1364 skip killed all live broadcasts. Restoring conversation-update parsing.

Dedup against transcript repeats now lives ENTIRELY client-side via the REPLACE-not-APPEND coalescer (#1365) — REPLACE handles same-text repeats from either event type because each conversation-update walks the messages array and picks the LATEST turn.

19/19 parse-transcript tests, 161+ across voice suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)