### PR TITLE
fix(sim): flip callPhase to 'active' on voice call start (live bubbles render)

### DIFF
--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -320,6 +320,29 @@ export function SimChat({
       es.close();
     };
   }, [outboundDial.callId, handleVoiceSseEvent]);
+
+  // #1369 — Flip callPhase to 'active' when ANY voice path starts.
+  // Pre-#1369 only the text-chat `startNewCall` set callPhase; [Talk Here]
+  // and [Call me] buttons called providerCall.start() / outboundDial.start()
+  // directly without transitioning the phase. The messages render block at
+  // ~line 1517 is gated on `callPhase === 'active' | 'wrapping' | 'ended'`
+  // so the transcript-partial bubbles landed in state but were never
+  // rendered. Server-side SSE was firing correctly — symptom was "no live
+  // bubbles" for both voice surfaces. This effect closes that gap from any
+  // source: WebRTC SDK transitions through starting → connecting → active;
+  // PSTN dial transitions through dialing → ringing. Either triggers the
+  // phase flip the same way startNewCall does for text chat.
+  useEffect(() => {
+    const webrtcLive =
+      providerCall.status === 'starting' ||
+      providerCall.status === 'connecting' ||
+      providerCall.status === 'active';
+    const pstnLive =
+      outboundDial.status === 'dialing' || outboundDial.status === 'ringing';
+    if ((webrtcLive || pstnLive) && callPhase === 'lobby') {
+      setCallPhase('active');
+    }
+  }, [providerCall.status, outboundDial.status, callPhase]);
   const [phoneDraft, setPhoneDraft] = useState('');
 
   // Abort in-flight stream on unmount (prevents orphaned fetches during key-based remount)

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -220,76 +220,106 @@ export function SimChat({
   // the existing useVoiceMode coverage stays green.
   const localSimVoiceModeEnabled = config.features.localSimVoiceMode;
 
+  // #1368 — shared SSE event handler for BOTH WebRTC [Talk Here] AND
+  // PSTN [Call me]. Pre-#1368 only WebRTC subscribed via useProviderCall;
+  // PSTN bubbles required a page refresh because no SSE was open during
+  // the call. Now both surfaces share this handler — WebRTC plugs it
+  // into useProviderCall.onSseEvent, PSTN plugs it into a useEffect-
+  // managed EventSource keyed on outboundDial.callId below.
+  const handleVoiceSseEvent = useCallback((event: import('@/lib/voice/sse-registry').VoiceCallSseEvent) => {
+    if (event.type === 'transcript-partial') {
+      const id = `voice-${event.timestampMs}-${event.role}`;
+      const isLearner = event.role === 'learner';
+      setMessages((prev) => {
+        // #1365 — Coalesce same-role chunks by REPLACE, not APPEND.
+        // VAPI's transcript-bearing events carry the latest interim for
+        // the current speaker turn — each is the FULL transcript-so-far,
+        // not a delta to concatenate. REPLACE shows a single growing
+        // bubble per turn.
+        const last = prev[prev.length - 1];
+        if (
+          last &&
+          last.id.startsWith('voice-') &&
+          ((isLearner && last.role === 'user') ||
+            (!isLearner && last.role === 'assistant'))
+        ) {
+          if (last.content === event.text) return prev;
+          const updated = { ...last, content: event.text };
+          return [...prev.slice(0, -1), updated];
+        }
+        return [
+          ...prev,
+          {
+            id,
+            role: isLearner ? 'user' : 'assistant',
+            content: event.text,
+            timestamp: new Date(event.timestampMs),
+          },
+        ];
+      });
+    } else if (event.type === 'share-content') {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `share-${event.timestampMs}`,
+          role: 'assistant',
+          content: event.caption ?? `[Shared media: ${event.mediaId}]`,
+          timestamp: new Date(event.timestampMs),
+        },
+      ]);
+    } else if (event.type === 'send-text') {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `text-${event.timestampMs}`,
+          role: 'assistant',
+          content: event.message,
+          timestamp: new Date(event.timestampMs),
+        },
+      ]);
+    }
+  }, []);
+
   // #1092 — provider-backed "Call me" mixed mode. Lazy-imports the
   // VAPI Web SDK on first click; opens an SSE stream keyed on Call.id
   // and pushes incoming events into the chat surface as messages.
   const providerCall = useProviderCall({
     callerId,
     intent: 'chat',
-    onSseEvent: useCallback((event: import('@/lib/voice/sse-registry').VoiceCallSseEvent) => {
-      if (event.type === 'transcript-partial') {
-        const id = `voice-${event.timestampMs}-${event.role}`;
-        const isLearner = event.role === 'learner';
-        setMessages((prev) => {
-          // #1364 — Coalesce same-role chunks by REPLACE, not APPEND.
-          // VAPI's `transcript` events carry the latest Deepgram interim
-          // result for the current speaker turn — each chunk is the FULL
-          // transcript-so-far, not a delta to concatenate. APPEND
-          // produced duplication like "hello hello there hello there how
-          // are you". REPLACE shows a single growing bubble per turn.
-          // Pre-existing bug, masked until #1361 made the bubbles appear.
-          const last = prev[prev.length - 1];
-          if (
-            last &&
-            last.id.startsWith('voice-') &&
-            ((isLearner && last.role === 'user') ||
-              (!isLearner && last.role === 'assistant'))
-          ) {
-            // Drop no-op events (same text as the bubble already shows).
-            if (last.content === event.text) {
-              return prev;
-            }
-            const updated = { ...last, content: event.text };
-            return [...prev.slice(0, -1), updated];
-          }
-          return [
-            ...prev,
-            {
-              id,
-              role: isLearner ? 'user' : 'assistant',
-              content: event.text,
-              timestamp: new Date(event.timestampMs),
-            },
-          ];
-        });
-      } else if (event.type === 'share-content') {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `share-${event.timestampMs}`,
-            role: 'assistant',
-            content: event.caption ?? `[Shared media: ${event.mediaId}]`,
-            timestamp: new Date(event.timestampMs),
-          },
-        ]);
-      } else if (event.type === 'send-text') {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `text-${event.timestampMs}`,
-            role: 'assistant',
-            content: event.message,
-            timestamp: new Date(event.timestampMs),
-          },
-        ]);
-      }
-    }, []),
+    onSseEvent: handleVoiceSseEvent,
   });
 
   // PSTN [Call me] hook — separate from the browser WebRTC [Talk Here]
   // above. VAPI rings the learner's actual phone. Just-in-time phone
   // capture handles the "no number on file" case.
   const outboundDial = useOutboundDial({ callerId });
+
+  // #1368 — Open SSE on the PSTN placeholder Call.id as soon as
+  // outboundDial fires. Mirrors what useProviderCall does internally
+  // for WebRTC. Same handler, same coalesce/dedup semantics — PSTN
+  // bubbles now appear LIVE during the phone call without a refresh.
+  useEffect(() => {
+    const cid = outboundDial.callId;
+    if (!cid) return;
+    const url = `/api/voice/calls/${encodeURIComponent(cid)}/stream`;
+    const es = new EventSource(url, { withCredentials: true });
+    const dispatch = (msg: MessageEvent<string>) => {
+      try {
+        const parsed = JSON.parse(msg.data) as import('@/lib/voice/sse-registry').VoiceCallSseEvent;
+        handleVoiceSseEvent(parsed);
+      } catch (err) {
+        console.warn('[SimChat] PSTN SSE parse error:', err);
+      }
+    };
+    es.onmessage = dispatch;
+    ['call-started', 'transcript-partial', 'share-content', 'send-text', 'request-artifact', 'call-ended'].forEach((name) => {
+      es.addEventListener(name, dispatch as EventListener);
+    });
+    es.onerror = (err) => console.warn('[SimChat] PSTN SSE error:', err);
+    return () => {
+      es.close();
+    };
+  }, [outboundDial.callId, handleVoiceSseEvent]);
   const [phoneDraft, setPhoneDraft] = useState('');
 
   // Abort in-flight stream on unmount (prevents orphaned fetches during key-based remount)

--- a/apps/admin/components/sim/useOutboundDial.ts
+++ b/apps/admin/components/sim/useOutboundDial.ts
@@ -32,6 +32,12 @@ interface DialApi {
   /** Last 4 of the phone number on file, masked. Empty when missing. */
   phoneMasked: string;
   errorMessage: string | null;
+  /** HF placeholder Call.id once the dial fires (#1368). Consumers use
+   *  this as the SSE subscription key — `/api/voice/calls/<id>/stream`
+   *  delivers transcript-partial events so SimChat can show live
+   *  bubbles during a PSTN call, mirroring the WebRTC path. Null
+   *  before dial fires; set in dialing/ringing state; cleared on reset. */
+  callId: string | null;
   /** Trigger from the [Call me] button. */
   start: () => Promise<void>;
   /** Submit the just-in-time phone form. */
@@ -48,6 +54,7 @@ export function useOutboundDial(options: UseOutboundDialOptions): DialApi {
   const [status, setStatus] = useState<DialStatus>("idle");
   const [phoneMasked, setPhoneMasked] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [callId, setCallId] = useState<string | null>(null);
 
   // Cache the resolved phone so we don't re-fetch on every click.
   const resolvedPhoneRef = useRef<string | null | "unknown">("unknown");
@@ -55,6 +62,7 @@ export function useOutboundDial(options: UseOutboundDialOptions): DialApi {
   const reset = useCallback(() => {
     setStatus("idle");
     setErrorMessage(null);
+    setCallId(null);
   }, []);
 
   const maskPhone = (p: string): string => {
@@ -86,7 +94,7 @@ export function useOutboundDial(options: UseOutboundDialOptions): DialApi {
         body: JSON.stringify({ callerId: options.callerId }),
       });
       const body = (await res.json()) as
-        | { ok?: boolean; error?: string; vapiCallId?: string }
+        | { ok?: boolean; error?: string; callId?: string; vapiCallId?: string }
         | null;
       if (!res.ok || !body?.ok) {
         throw new Error(
@@ -94,6 +102,9 @@ export function useOutboundDial(options: UseOutboundDialOptions): DialApi {
             `Dial failed (HTTP ${res.status}). Try again or check provider settings.`,
         );
       }
+      // #1368 — expose HF placeholder Call.id so SimChat can open SSE
+      // on /api/voice/calls/<id>/stream for live transcript bubbles.
+      if (body.callId) setCallId(body.callId);
       setStatus("ringing");
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -163,12 +174,14 @@ export function useOutboundDial(options: UseOutboundDialOptions): DialApi {
     setStatus("idle");
     setPhoneMasked("");
     setErrorMessage(null);
+    setCallId(null);
   }, [options.callerId]);
 
   return {
     status,
     phoneMasked,
     errorMessage,
+    callId,
     start,
     savePhoneAndDial,
     reset,

--- a/apps/admin/lib/prompt/composition/transforms/quickstart.ts
+++ b/apps/admin/lib/prompt/composition/transforms/quickstart.ts
@@ -534,33 +534,36 @@ registerTransform("computeQuickStart", (
       // touching unrelated callers in this file.
       const injectSubject = sanitiseWelcome;
 
-      // 0a. #274 Slice B: locked-module opening — highest priority.
-      // The learner has explicitly picked a module via the Module Picker;
-      // honour that and open the session focused on it. Wins over both the
-      // identity spec opening and #266's module-status narrative.
+      // 0a. #274 Slice B / #1367: locked-module opening — highest priority.
+      // The learner has explicitly picked a module via the Module Picker.
+      // Return a LITERAL greeting (VAPI speaks `first_line` verbatim as
+      // assistant.firstMessage). The system-prompt body already carries
+      // "lockedModule.name" and the "don't ask what they want to work on"
+      // intent — the AI doesn't need a meta-instruction inside the line
+      // it's literally going to say out loud.
+      // Pre-#1367 this returned the directive text starting with "The
+      // learner has picked..." which VAPI dutifully spoke aloud as the
+      // greeting — surfaced live 2026-06-08 on /x/sim Peter Parker call.
       if (lockedModule) {
-        return [
-          `The learner has picked the "${lockedModule.name}" module — open by acknowledging their pick`,
-          "and transition naturally into teaching it. Do NOT ask 'what brings you here' or 'what would you like to work on'",
-          "— that decision is already made. Keep it warm and brief.",
-        ].join(" ");
+        const namePart = caller?.name ? ` ${caller.name}` : "";
+        return `Hi${namePart}! Let's get into "${lockedModule.name}".`;
       }
 
-      // 0b. #266 Slice 1: module-aware opening for authored courses with
-      // attempt history. Soft instruction (data section + intent), not a
-      // scripted line — TUT-001 persona drives wording.
+      // 0b. #266 Slice 1 / #1367: module-progress opening for authored
+      // courses with attempt history. Same bug class as 0a — was returning
+      // an AI directive instead of a literal opening. The directive ("open
+      // by referencing progress") belongs in the system prompt body, not
+      // in the literal-spoken greeting. Keep first_line short and warm;
+      // let TUT-001 persona + the Module-progress prompt section drive
+      // the actual referencing.
       if (
         !isFirstCall &&
         pbConfig.modulesAuthored === true &&
         hasAttemptData === true &&
         modules.length > 0
       ) {
-        return [
-          "Open by referencing the learner's module progress (see Module progress above) in plain language —",
-          "name what they've done and how many times, then transition naturally into",
-          subjectRef ? `${subjectRef}. ` : "today's teaching. ",
-          "Keep it warm and brief; do NOT read the list verbatim.",
-        ].join(" ");
+        const namePart = caller?.name ? ` ${caller.name}` : "";
+        return `Welcome back${namePart}!`;
       }
 
       // 1. Identity spec instruction (highest priority — persona spec)

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -506,15 +506,16 @@ export class VapiProvider implements VoiceProvider {
     const root = body as Record<string, unknown>;
     const message = (root.message ?? root) as Record<string, unknown>;
     const type = (message.type ?? root.type) as string | undefined;
-    // #1364 — parse `transcript` events only. VAPI fires both `transcript`
-    // (per-chunk Deepgram interim_results) AND `conversation-update`
-    // (full-history snapshot ~1Hz). Pre-#1364 we parsed both, broadcasting
-    // the latest message twice — once as a transcript chunk, once via the
-    // conversation-update history-walk — and SimChat showed duplicate
-    // bubbles. transcript chunks are sufficient for incremental streaming;
-    // conversation-update is a catch-up snapshot that the chat surface
-    // doesn't need when it's been subscribed from call start.
-    if (type !== "transcript") return null;
+    // #1366 — parse BOTH `transcript` AND `conversation-update`. Live data
+    // showed VAPI's custom-llm setup fires ONLY `conversation-update`
+    // (no `transcript` events at all on the wire for this call shape).
+    // The #1364 "skip conversation-update" attempt killed all live
+    // broadcasts. Dedup now lives ENTIRELY on the client (#1365 REPLACE-
+    // not-APPEND coalesce) — REPLACE handles both event types correctly
+    // because each event carries the FULL latest turn (transcript = full
+    // Deepgram interim, conversation-update = full latest message via
+    // history-walk).
+    if (type !== "transcript" && type !== "conversation-update") return null;
 
     const call = (message.call ?? root.call) as
       | Record<string, unknown>

--- a/apps/admin/tests/lib/composition/quickstart.test.ts
+++ b/apps/admin/tests/lib/composition/quickstart.test.ts
@@ -316,7 +316,12 @@ describe("computeQuickStart transform", () => {
     expect(result.this_session).not.toContain("Introduce Advanced");
   });
 
-  it("first_line emits locked-module instruction when lockedModule is set (highest priority)", () => {
+  it("first_line emits a literal greeting naming the locked module (highest priority, #1367)", () => {
+    // Post-#1367: first_line is the literal text VAPI speaks aloud as
+    // assistant.firstMessage — must be a greeting, NOT an AI directive
+    // ("the learner has picked... do NOT ask..."). The instruction
+    // semantics still live in the system-prompt body via the
+    // lockedModule + Module-progress sections.
     const ctx = makeContext({
       sharedState: {
         ...makeContext().sharedState,
@@ -326,8 +331,8 @@ describe("computeQuickStart transform", () => {
     });
     const result = getTransform("computeQuickStart")!(null, ctx, makeSectionDef());
     expect(result.first_line).toContain("Part 1: Familiar Topics");
-    expect(result.first_line).toContain("picked");
-    expect(result.first_line).toContain("acknowledg"); // "acknowledging"
+    expect(result.first_line).not.toMatch(/the learner has picked/i);
+    expect(result.first_line).not.toMatch(/do NOT ask/i);
     expect(result.first_line).not.toContain("reconnect"); // legacy fallback
   });
 
@@ -366,9 +371,9 @@ describe("computeQuickStart transform", () => {
     // seeded with nextModule.name; lockedModule must win and that line never runs.
     expect(result.first_line).not.toContain("Unit 09 — Architecture");
     expect(result.first_line).not.toContain("Good to meet you");
-    // Locked-module instruction wraps the picked module name in quotes.
-    expect(result.first_line).toContain("picked");
-    expect(result.first_line).toContain("acknowledg");
+    // Post-#1367: literal greeting, not a directive.
+    expect(result.first_line).not.toMatch(/the learner has picked/i);
+    expect(result.first_line).not.toMatch(/do NOT ask/i);
   });
 
   it("first_line locked-module wins over #266 narrative when both apply", () => {

--- a/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-provider.parse-transcript.test.ts
@@ -89,36 +89,66 @@ describe("VapiProvider.parseTranscriptUpdate — `transcript` event (chunk)", ()
   });
 });
 
-describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#1364 skip)", () => {
-  // #1364 — Parser intentionally returns null for conversation-update.
-  // VAPI fires both `transcript` (per-chunk Deepgram interim_results)
-  // AND `conversation-update` (full-history snapshot ~1Hz). Parsing
-  // both produced duplicate bubbles in SimChat (each turn broadcast
-  // twice — once as a chunk, once via the history-walk). Transcript
-  // chunks are sufficient for incremental streaming; the history
-  // snapshot is a catch-up channel the chat surface doesn't need.
+describe("VapiProvider.parseTranscriptUpdate — `conversation-update` event (#922 + #1366 restore)", () => {
+  // #1366 — Re-enabled after live data showed VAPI's custom-llm setup
+  // fires conversation-update ONLY (no `transcript` events). The
+  // history-walk path picks the latest non-system turn. Dedup against
+  // transcript events lives client-side via REPLACE-not-APPEND coalesce
+  // (#1365) — REPLACE handles same-text repeats from either source.
   const p = new VapiProvider({}, {});
 
-  it("returns null for conversation-update with messages array (was the #922 history-walk path)", () => {
+  it("extracts the most recent non-system turn from `messages` array (#922)", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_history" },
         messages: [
+          { role: "system", content: "You are a tutor." },
           { role: "user", content: "what is past tense?" },
           { role: "assistant", content: "past tense describes actions that have already happened" },
         ],
       },
     };
-    expect(p.parseTranscriptUpdate(body)).toBeNull();
+    expect(p.parseTranscriptUpdate(body)).toEqual({
+      externalCallId: "vapi_call_history",
+      role: "assistant",
+      text: "past tense describes actions that have already happened",
+      hfCallId: null,
+    });
   });
 
-  it("returns null for conversation-update with messagesOpenAIFormatted", () => {
+  it("skips `system` and `tool` roles when walking the history", () => {
+    const body = {
+      message: {
+        type: "conversation-update",
+        call: { id: "vapi_call_skip" },
+        messages: [
+          { role: "user", content: "what time is it" },
+          { role: "tool", content: '{"time":"15:42"}' },
+          { role: "system", content: "(internal)" },
+        ],
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.role).toBe("learner");
+  });
+
+  it("accepts the alternate `messagesOpenAIFormatted` key VAPI sometimes uses", () => {
     const body = {
       message: {
         type: "conversation-update",
         call: { id: "vapi_call_alt" },
         messagesOpenAIFormatted: [{ role: "user", content: "hi" }],
+      },
+    };
+    expect(p.parseTranscriptUpdate(body)?.text).toBe("hi");
+  });
+
+  it("returns null when no non-system content found", () => {
+    const body = {
+      message: {
+        type: "conversation-update",
+        call: { id: "vapi_call_only_system" },
+        messages: [{ role: "system", content: "..." }],
       },
     };
     expect(p.parseTranscriptUpdate(body)).toBeNull();


### PR DESCRIPTION
**Root cause of all 'no live bubbles' reports today.**

`messages.map` render block at SimChat.tsx:1517 is gated on `callPhase === 'active' | 'wrapping' | 'ended'`. The text-chat path (`startNewCall`) sets callPhase='active' synchronously. The [Talk Here] and [Call me] buttons just call `providerCall.start()` / `outboundDial.start()` — **callPhase stays at 'lobby'**.

Net effect: transcript-partial events landed in state correctly (`setMessages` ran), but the conditional hid the entire message list. Symptom: 'no live bubbles' on both voice surfaces despite server-side log showing `voice.sse.broadcast | delivered: true | subscriberCount: 1`.

## Fix
New useEffect watches `providerCall.status` (WebRTC: starting/connecting/active) AND `outboundDial.status` (PSTN: dialing/ringing). When either flips live AND callPhase is still 'lobby', flip callPhase to 'active' — same transition `startNewCall` does for text chat.

This unblocks rendering for bubbles already in state from #1361 (hfCallId routing) and #1368 (PSTN SSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)