### PR TITLE
test: fix voice-config-routes test mocks for PlaybookConfigTransformer (#1359 follow-up)

### DIFF
--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -2477,4 +2477,3 @@ async function handleUpdateVoiceConfig(input: Record<string, any>) {
     pendingChange,
   };
 }
-

--- a/apps/admin/tests/api/voice-config-routes.test.ts
+++ b/apps/admin/tests/api/voice-config-routes.test.ts
@@ -163,7 +163,15 @@ describe("/api/playbooks/:playbookId/voice-config (#1271 Slice C)", () => {
       expect(res.status).toBe(200);
       expect(body.ok).toBe(true);
       expect(body.applied).toBe("set");
-      expect(mockUpdatePlaybookConfig).toHaveBeenCalledWith("pb-1", {
+      // Post-#1359: route now calls updatePlaybookConfig(playbookId, transformer).
+      // Assert on the playbookId arg + invoke the transformer to verify it
+      // produces the expected config (preserves siblings, sets voice override).
+      expect(mockUpdatePlaybookConfig).toHaveBeenCalledTimes(1);
+      const [calledPlaybookId, transformer] = mockUpdatePlaybookConfig.mock.calls[0];
+      expect(calledPlaybookId).toBe("pb-1");
+      expect(typeof transformer).toBe("function");
+      expect(transformer({ someOther: "kept" })).toEqual({
+        someOther: "kept",
         voice: { autoPipeline: false },
       });
     });
@@ -248,8 +256,15 @@ describe("/api/playbooks/:playbookId/voice-config (#1271 Slice C)", () => {
       const body = await res.json();
       expect(res.status).toBe(200);
       expect(body.applied).toBe("cleared");
-      // voice object should NOT contain autoPipeline (cleared), still has voiceId.
-      expect(mockUpdatePlaybookConfig).toHaveBeenCalledWith("pb-1", {
+      // Post-#1359: route now calls updatePlaybookConfig(playbookId, transformer).
+      // Invoke the transformer to confirm the resulting voice object does NOT
+      // contain autoPipeline (cleared), still has voiceId.
+      expect(mockUpdatePlaybookConfig).toHaveBeenCalledTimes(1);
+      const [calledPlaybookId, transformer] = mockUpdatePlaybookConfig.mock.calls[0];
+      expect(calledPlaybookId).toBe("pb-1");
+      expect(typeof transformer).toBe("function");
+      expect(transformer({ someOther: "kept" })).toEqual({
+        someOther: "kept",
         voice: { voiceId: "rachel" },
       });
     });


### PR DESCRIPTION
## Summary

PR #1359 (`fix(voice): wrap voice-config writes in PlaybookConfigTransformer`) changed how `/api/playbooks/[playbookId]/voice-config` PATCH writes config — it now goes through `PlaybookConfigTransformer`. The unit tests at `tests/api/voice-config-routes.test.ts` were not updated and still mock the old signature, causing CI failures across all downstream PRs that run the unit-test job.

## Test intent preserved

- "accepts a cascadeable key and writes via updatePlaybookConfig" — still verifies cascadeable writes go through the proper config-update path
- "value: null clears the override" — still verifies the delete-key semantics

Only the mock surface + assertions changed to match the new code path.

## Blocked PRs that this unblocks

- #1350 (createCallEnteringPipeline builder)
- #1351 (Slice 0 Session schema)
- #1353 (ghost-row dedup)

## Test plan

- [x] Both target tests pass locally
- [x] Sibling tests in the same file unchanged + still pass
- [x] Ratchet still passes