### PR TITLE
fix(sim): full assistant text in live bubbles + fat red end-call button

### DIFF
--- a/apps/admin/app/x/sim/sim.css
+++ b/apps/admin/app/x/sim/sim.css
@@ -230,6 +230,36 @@
   background: var(--wa-green-darker);
 }
 
+/* #1371 — Fat red phone-down circle for ending a live voice call.
+   Same 72×72 footprint as the green start button so the lobby/active
+   transition swaps in place. Used for BOTH WebRTC [Talk Here] and
+   PSTN [Call me] live states — replaces the prior text-link "End
+   voice session" which operators reported as too small to find. */
+.wa-lobby-end-btn {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--status-error-text, #ef4444);
+  border: none;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--status-error-text, #ef4444) 45%, transparent);
+  transition: background 0.15s, transform 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.wa-lobby-end-btn:hover {
+  background: color-mix(in srgb, var(--status-error-text, #ef4444) 88%, black);
+}
+
+.wa-lobby-end-btn:active {
+  transform: scale(0.93);
+  background: color-mix(in srgb, var(--status-error-text, #ef4444) 75%, black);
+}
+
 /* Chat background with subtle pattern */
 .wa-chat-bg {
   background-color: var(--wa-bg);

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -1447,12 +1447,23 @@ export function SimChat({
               </p>
             )}
             {providerCall.status === 'active' && (
-              <button
-                onClick={() => { void providerCall.end(); }}
-                style={{ fontSize: 13, color: 'var(--status-error-text)', background: 'none', border: 'none', cursor: 'pointer' }}
-              >
-                End voice session
-              </button>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+                {/* #1371 — Fat red phone-down to end the live WebRTC
+                    session. Replaces a small text link operators
+                    couldn't find quickly. */}
+                <button
+                  className="wa-lobby-end-btn"
+                  onClick={() => { void providerCall.end(); }}
+                  aria-label="End voice session"
+                  title="End voice session"
+                >
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                    {/* phone handset rotated 135° = "hang up" */}
+                    <path transform="rotate(135 12 12)" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+                  </svg>
+                </button>
+                <span style={{ fontSize: 12, color: 'var(--wa-text-secondary)' }}>End voice session</span>
+              </div>
             )}
             {providerCall.status === 'error' && providerCall.errorMessage && (
               <p style={{ fontSize: 13, color: 'var(--status-error-text)', textAlign: 'center', margin: 0 }}>
@@ -1520,6 +1531,25 @@ export function SimChat({
               <p style={{ fontSize: 13, color: 'var(--status-success-text)', textAlign: 'center', margin: 0 }}>
                 Ringing {outboundDial.phoneMasked} — pick up your phone.
               </p>
+            )}
+            {/* #1371 — Fat red end-call for PSTN. Shown whenever the
+                dial is live (dialing OR ringing OR active on the phone).
+                Same affordance as the WebRTC end button — operators
+                shouldn't hunt for a hang-up. */}
+            {(outboundDial.status === 'dialing' || outboundDial.status === 'ringing') && (
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, marginTop: 12 }}>
+                <button
+                  className="wa-lobby-end-btn"
+                  onClick={() => { outboundDial.reset(); }}
+                  aria-label="End phone call"
+                  title="End phone call"
+                >
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                    <path transform="rotate(135 12 12)" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+                  </svg>
+                </button>
+                <span style={{ fontSize: 12, color: 'var(--wa-text-secondary)' }}>End phone call</span>
+              </div>
             )}
             {outboundDial.status === 'error' && outboundDial.errorMessage && (
               <p style={{ fontSize: 13, color: 'var(--status-error-text)', textAlign: 'center', margin: 0 }}>

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -545,6 +545,15 @@ export class VapiProvider implements VoiceProvider {
         message.messagesOpenAIFormatted ??
         message.conversation) as Array<Record<string, unknown>> | undefined;
       if (Array.isArray(msgs)) {
+        // #1371 — VAPI emits multi-message assistant turns (one message
+        // per sentence / TTS chunk). Pre-#1371 we picked ONLY the last
+        // message — REPLACE coalesce then showed only the last phrase
+        // live, while the full text only appeared post-call from
+        // Call.transcript. Fix: walk backwards from the tail, collect
+        // ALL consecutive same-role messages, join with spaces. Stops
+        // on the first role change (= previous speaker's turn).
+        const collected: string[] = [];
+        let pickedRole: string | null = null;
         for (let i = msgs.length - 1; i >= 0; i--) {
           const m = msgs[i];
           if (!m || typeof m !== "object") continue;
@@ -554,11 +563,19 @@ export class VapiProvider implements VoiceProvider {
             (m.content as string | undefined) ??
             (m.message as string | undefined) ??
             "";
-          if (typeof content === "string" && content.length > 0) {
-            rawText = content;
-            rawRole = role || rawRole;
+          if (typeof content !== "string" || content.length === 0) continue;
+          if (pickedRole === null) {
+            pickedRole = role;
+            collected.unshift(content);
+          } else if (role === pickedRole) {
+            collected.unshift(content);
+          } else {
             break;
           }
+        }
+        if (collected.length > 0 && pickedRole) {
+          rawText = collected.join(" ");
+          rawRole = pickedRole || rawRole;
         }
       }
     }


### PR DESCRIPTION
Two issues, one branch.

## 1. AI bubbles showed only the LAST phrase live
VAPI's conversation-update events split the assistant's TTS response into multiple consecutive messages (one per sentence/chunk). Parser picked only the latest → REPLACE coalesce overwrote the bubble each tick → only final phrase stuck. Full text appeared post-call only.

**Fix:** walk backwards collecting ALL consecutive same-role messages, join with spaces, stop on role change. Live bubble grows with cumulative text, matches post-call.

## 2. End-call affordance was hard to find
Small text link "End voice session" replaced with a fat 72×72 red phone-down circle. Same affordance for BOTH WebRTC active state AND PSTN dialing/ringing states. New `.wa-lobby-end-btn` CSS mirrors the green start button.

19/19 parse-transcript tests green (existing single-message tests unaffected — join is no-op for length-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)