### PR TITLE
chore: clear +1 lint warning drift on main (unblocks #1371)

### DIFF
--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -2496,7 +2496,7 @@ async function handleUpdateVoiceConfig(input: Record<string, any>) {
  * layer (system / provider / domain / course) won for every cascadeable
  * field. No DB writes; no pendingChange.
  */
-async function handleExplainVoiceCascade(input: Record<string, any>) {
+async function handleExplainVoiceCascade(input: Record<string, unknown>) {
   const callerId = typeof input.callerId === "string" ? input.callerId : "";
   if (!callerId) return { error: "callerId is required" };
 


### PR DESCRIPTION
## Summary

A +1 lint warning drift accumulated on main from the cascade-lens PR (#1354, commit `daf29501`). This blocked PR #1371 (test-fix for voice-config-routes) from merging green, which in turn blocks #1350, #1351, #1353.

## The fix

One file changed: `apps/admin/lib/chat/admin-tool-handlers.ts` line 2499.

Rule: `@typescript-eslint/no-explicit-any`

`handleExplainVoiceCascade` was added by the cascade-lens PR with `input: Record<string, any>`, matching the file's historic pattern but adding net +1 to the warning count. The handler only reads `input.callerId` via a `typeof` guard, so `Record<string, unknown>` is structurally identical.

Fix: `Record<string, any>` → `Record<string, unknown>`

## Test plan

- [x] `./scripts/check-ratchet.sh` shows all four metrics ✅ on this branch (`lint_warnings: 4423 == baseline`)
- [x] Pre-push hook: tsc + lint pass on the changed file
- [x] No `eslint-disable` suppressions or `as any` casts added

🤖 Generated with [Claude Code](https://claude.com/claude-code)