### PR TITLE
fix(sim): hoist voice-call status + end-call button out of lobby block

### DIFF
--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -1566,6 +1566,52 @@ export function SimChat({
           </div>
         )}
 
+        {/* #1379 — Voice-call status strip (hoisted out of the lobby block).
+            #1370 flipped callPhase to 'active' on voice-call start, which
+            hid the lobby — and with it, the Talk Here status text + the
+            fat red end-call button (both lived inside the lobby JSX).
+            Hoisting these here means they're visible whenever a voice
+            call is in any non-idle state, regardless of callPhase. */}
+        {(providerCall.status === 'starting' ||
+          providerCall.status === 'connecting' ||
+          providerCall.status === 'active' ||
+          providerCall.status === 'error') && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, padding: '16px 12px 8px' }}>
+            {providerCall.status === 'starting' && (
+              <p style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
+                Setting up your voice session&hellip;
+              </p>
+            )}
+            {providerCall.status === 'connecting' && (
+              <p style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
+                Connecting&hellip; (you&apos;ll be asked for microphone access)
+              </p>
+            )}
+            {providerCall.status === 'error' && providerCall.errorMessage && (
+              <p style={{ fontSize: 13, color: 'var(--status-error-text)', textAlign: 'center', margin: 0 }}>
+                {providerCall.errorMessage}
+              </p>
+            )}
+            {(providerCall.status === 'starting' ||
+              providerCall.status === 'connecting' ||
+              providerCall.status === 'active') && (
+              <>
+                <button
+                  className="wa-lobby-end-btn"
+                  onClick={() => { void providerCall.end(); }}
+                  aria-label="End voice session"
+                  title="End voice session"
+                >
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                    <path transform="rotate(135 12 12)" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+                  </svg>
+                </button>
+                <span style={{ fontSize: 12, color: 'var(--wa-text-secondary)' }}>End voice session</span>
+              </>
+            )}
+          </div>
+        )}
+
         {/* Active/wrapping/ended: session separator + live messages */}
         {(callPhase === 'active' || callPhase === 'wrapping' || callPhase === 'ended') && (
           <>


### PR DESCRIPTION
#1370 regression. Lobby JSX (gated on `callPhase === 'lobby'`) contained the Talk Here status indicator + fat red end-call button. When my callPhase-flip useEffect promoted state to 'active' on `providerCall.status === 'starting'`, the lobby hid — taking the user's only call affordance with it.

Live evidence in screenshots: text-input + empty message area + no call indicator + no way to hang up.

Hoist the voice-call status strip into a sibling block gated on `providerCall.status` being non-idle (independent of callPhase). Status messages (Setting up… / Connecting… / error) + red end-call button now show throughout the call lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)