### PR TITLE
chore(guard): ESLint rule + CLAUDE.md discipline — no hardcoded greetings

### DIFF
--- a/.claude/rules/pipeline-and-prompt.md
+++ b/.claude/rules/pipeline-and-prompt.md
@@ -71,3 +71,20 @@ Use `config.specs.*` — never hardcode spec slug strings like `"pipeline-001"`.
 ## AI Calls
 
 All AI calls go through metered wrappers (`getConfiguredMeteredAICompletion`). ESLint enforces this. Never pass explicit maxTokens/temperature — use cascade.
+
+## ⚠️ MANDATORY — Search before editing `lib/prompt/composition/transforms/` or `lib/voice/build-assistant-config.ts`
+
+#1367 / #1384 live incident: a 2-line "fix" inside `quickstart.ts::first_line()` returned a hardcoded greeting template (`Hi ${name}! Let's get into "${module}".`) — intercepting BEFORE the existing configurable layers (identity-spec opening, phase-derived opening, fallback templates) could fire. The greeting became un-customisable from Course Design. Root cause: nobody checked whether the architecture already covered this case.
+
+**Before touching any file under `lib/prompt/composition/transforms/` or `lib/voice/build-assistant-config.ts` you MUST:**
+
+1. **Search existing config surface.** Run at minimum:
+   - `qmd search "<concept>"` — e.g. `welcome`, `firstCall`, `greeting`, `opening`
+   - Read the relevant interface in `lib/types/json-fields.ts` (`PlaybookConfig`, `WelcomeConfig`, `FirstCallConfig`)
+   - Read the existing branches in the transform you're about to edit — many have a cascade that already reads from configurable sources
+2. **Write findings in the PR description.** Two lines minimum: "I searched X, found Y, decided to Z because A."
+3. **If the right answer is a new config field** — add it to `PlaybookConfig` first, wire the cascade read, THEN the transform. The transform should NEVER hold a literal AI utterance that isn't sourced from config or from an explicit system-default template under `lib/prompt/composition/defaults/`.
+
+**Mechanically enforced** by `hf-compose/no-hardcoded-greeting-in-composition` (severity `error`). A literal `Hi`, `Hello`, `Welcome`, `Hey`, `Good morning|afternoon|evening` string returned from one of these files will fail the lint. Move it to `lib/prompt/composition/defaults/` (the allow-listed system-default home) or read from `playbook.config.welcome.*` / `firstCall.*`.
+
+**Why this matters:** the AI's literal utterances are tutor-behavior contracts. Educators tune them via Course Design. Code constants make those knobs invisible — the educator changes nothing in the UI because the value is baked in the bundle.

--- a/apps/admin/eslint-rules/no-hardcoded-greeting-in-composition.mjs
+++ b/apps/admin/eslint-rules/no-hardcoded-greeting-in-composition.mjs
@@ -1,0 +1,161 @@
+/**
+ * #1384 — Block hardcoded learner-facing greetings in prompt-composition
+ * transforms and voice assistant-config builders.
+ *
+ * Live incident 2026-06-09: #1367's "fix" returned literal greeting
+ * templates (`Hi ${name}! Let's get into "${module}".`,
+ * `Welcome back ${name}!`) from inside `quickstart.ts::first_line()`
+ * branches. Those literals intercepted BEFORE the configurable layers
+ * (identity-spec opening, phase-derived opening, fallback templates)
+ * fired — making the AI's greeting un-customisable from Course Design
+ * and from the cascade. Two architectural rules were broken in one
+ * 2-line PR:
+ *
+ *   - CLAUDE.md "Configuration over Code" (greeting style is a
+ *     course-tunable behaviour, not a code constant)
+ *   - chain-contracts.md Link 3 sub-contract "COMPOSE → LLM" (output
+ *     invariants — literal AI utterances must reference a configurable
+ *     source OR be explicitly marked as a system-default fallback)
+ *
+ * This rule fires when a Literal or TemplateLiteral starting with a
+ * greeting word (`Hi`, `Hello`, `Hey`, `Welcome`, `Good morning/
+ * afternoon/evening`) appears inside a transforms or voice
+ * assistant-config file, in a position that will be returned to the AI
+ * as a literal utterance (`first_line`, `firstLine`, `firstMessage`,
+ * `voicePrompt`, or a direct ReturnStatement).
+ *
+ * Greenlit:
+ *   - String literals inside JSDoc / comments (parser doesn't visit)
+ *   - Greeting strings imported from a config / template module
+ *     (the regex doesn't fire on identifiers)
+ *   - Greeting strings under `lib/prompt/composition/defaults/` —
+ *     that path holds the explicit system-default templates; greetings
+ *     LIVE there by design
+ *
+ * Severity: lands at `warn` because the four known offences need a
+ * companion rollback PR (#1384 follow-up) that touches the prompt-
+ * composition path — and per `.claude/rules/pipeline-and-prompt.md`
+ * that path requires BA+TL grooming. The rollback PR promotes this
+ * rule to `error` in the same commit that removes the last offence,
+ * so the "halt — not accumulate" intent holds end-to-end.
+ *
+ * Companion: `.claude/rules/pipeline-and-prompt.md` documents the
+ * "search for existing config before editing prompt-composition
+ * transforms" discipline that the rule enforces mechanically.
+ */
+
+const GUARDED_PATH_FRAGMENTS = [
+  "lib/prompt/composition/transforms/",
+  "lib/voice/build-assistant-config.ts",
+];
+
+/** Paths where literal greeting strings ARE the contract — system-default
+ *  template libraries that the configurable layers read FROM. */
+const ALLOWLIST_PATH_FRAGMENTS = [
+  "lib/prompt/composition/defaults/",
+];
+
+// Greeting word at the start, followed by whitespace / punctuation / end.
+// End-of-string matters for template literals: the head before the first
+// `${...}` interpolation can be JUST the greeting word (e.g. `Hi${name}!`
+// has head `"Hi"`). Pre-fix this missed the locked-module case from #1367.
+const GREETING_REGEX =
+  /^\s*(hi|hello|hey|welcome|good\s+(morning|afternoon|evening))(\s|[,!.?]|$)/i;
+
+const ASSIGNMENT_TARGETS = new Set([
+  "first_line",
+  "firstLine",
+  "firstMessage",
+  "voicePrompt",
+  "openingLine",
+  "greeting",
+]);
+
+function isGuardedFile(filename) {
+  if (!filename) return false;
+  if (ALLOWLIST_PATH_FRAGMENTS.some((p) => filename.includes(p))) return false;
+  return GUARDED_PATH_FRAGMENTS.some((p) => filename.includes(p));
+}
+
+function isGreetingLiteral(node) {
+  if (!node) return false;
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return GREETING_REGEX.test(node.value);
+  }
+  if (node.type === "TemplateLiteral" && node.quasis.length > 0) {
+    const head = node.quasis[0].value.cooked ?? node.quasis[0].value.raw ?? "";
+    return GREETING_REGEX.test(head);
+  }
+  return false;
+}
+
+const messages = {
+  hardcoded:
+    "Hardcoded learner-facing greeting in a prompt-composition / assistant-config file. " +
+    "Greeting style is course-tunable behaviour — read from `playbook.config.welcome.*` or " +
+    "`firstCall.*`, or move the template into `lib/prompt/composition/defaults/`. " +
+    "See `.claude/rules/pipeline-and-prompt.md` + #1384.",
+};
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Block hardcoded learner-facing greetings in prompt-composition transforms and voice assistant-config builders. See #1384.",
+    },
+    schema: [],
+    messages,
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.();
+    if (!isGuardedFile(filename)) return {};
+
+    function report(node) {
+      context.report({ node, messageId: "hardcoded" });
+    }
+
+    return {
+      ReturnStatement(node) {
+        if (node.argument && isGreetingLiteral(node.argument)) {
+          report(node.argument);
+        }
+      },
+      VariableDeclarator(node) {
+        if (
+          node.id?.type === "Identifier" &&
+          ASSIGNMENT_TARGETS.has(node.id.name) &&
+          node.init &&
+          isGreetingLiteral(node.init)
+        ) {
+          report(node.init);
+        }
+      },
+      AssignmentExpression(node) {
+        if (
+          node.left?.type === "Identifier" &&
+          ASSIGNMENT_TARGETS.has(node.left.name) &&
+          isGreetingLiteral(node.right)
+        ) {
+          report(node.right);
+        }
+      },
+      Property(node) {
+        // Catches object literals like `{ firstLine: "Hi ..." }` and
+        // `{ first_line: \`Welcome ...\` }` that get passed into adapter
+        // builders. Both shorthand-key and named.
+        const key = node.key;
+        const keyName =
+          key?.type === "Identifier"
+            ? key.name
+            : key?.type === "Literal" && typeof key.value === "string"
+              ? key.value
+              : null;
+        if (!keyName || !ASSIGNMENT_TARGETS.has(keyName)) return;
+        if (isGreetingLiteral(node.value)) {
+          report(node.value);
+        }
+      },
+    };
+  },
+};

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -9,6 +9,7 @@ import noDirectSpecConfigWrite from "./eslint-rules/no-direct-spec-config-write.
 import noAiFanoutAll from "./eslint-rules/no-ai-fanout-all.mjs";
 import noAiForbiddenFields from "./eslint-rules/no-ai-forbidden-fields.mjs";
 import noOrphanInstructionFallback from "./eslint-rules/no-orphan-instruction-fallback.mjs";
+import noHardcodedGreetingInComposition from "./eslint-rules/no-hardcoded-greeting-in-composition.mjs";
 import noVapiColumnRef from "./eslint-rules/hf-voice/no-vapi-column-ref.mjs";
 import noVapiToolDefinitionsConst from "./eslint-rules/hf-voice/no-vapi-tool-definitions-const.mjs";
 import noUndeclaredFieldRequire from "./eslint-rules/no-undeclared-field-require.mjs";
@@ -116,6 +117,11 @@ const eslintConfig = defineConfig([
       "hf-compose": {
         rules: {
           "no-orphan-instruction-fallback": noOrphanInstructionFallback,
+          // #1384 — block hardcoded learner-facing greetings in
+          // prompt-composition transforms + voice assistant-config
+          // builders. The greeting is course-tunable behaviour, not a
+          // code constant. Companion: `.claude/rules/pipeline-and-prompt.md`.
+          "no-hardcoded-greeting-in-composition": noHardcodedGreetingInComposition,
         },
       },
       // AnyVoice #1024 — block reintroduction of pre-rename vapi*
@@ -178,6 +184,15 @@ const eslintConfig = defineConfig([
       // once `composeGenericNounFallbackCount` reads 0 in dev/test/prod for
       // ≥7 days (per the chain-contract severity-escalation path).
       "hf-compose/no-orphan-instruction-fallback": "warn",
+      // #1384 — hardcoded greeting guard. Lands at `warn` because the
+      // four known offences (quickstart.ts:549,566 + build-assistant-
+      // config.ts:121,177) still need their rollback PR — which itself
+      // needs BA+TL grooming per `.claude/rules/pipeline-and-prompt.md`
+      // "search before editing prompt-composition transforms". The
+      // rollback PR PROMOTES this to `error` in the same commit that
+      // removes the last offence. Pre-existing failure pattern: see
+      // `no-orphan-instruction-fallback` companion comment.
+      "hf-compose/no-hardcoded-greeting-in-composition": "warn",
       "hf-voice/no-vapi-column-ref": "error",
       "hf-voice/no-vapi-tool-definitions-const": "error",
       "hf-wizard-v6/no-undeclared-field-require": "error",


### PR DESCRIPTION
Closes the failure pattern from #1367. Two-layer guard:

1. **ESLint rule** `hf-compose/no-hardcoded-greeting-in-composition` — scopes to `lib/prompt/composition/transforms/` + `lib/voice/build-assistant-config.ts` (allow-lists `lib/prompt/composition/defaults/`). Detects literal greeting strings (Hi/Hello/Hey/Welcome/Good morning|afternoon|evening) in return / firstLine / firstMessage / voicePrompt positions. Severity `warn` initially — promotes to `error` in the rollback PR that removes the 4 known offences.

2. **CLAUDE.md discipline** in `.claude/rules/pipeline-and-prompt.md` — MANDATORY "search before editing prompt-composition transforms" rule: qmd-search for existing config surface, read PlaybookConfig / WelcomeConfig / FirstCallConfig, write findings in PR description before code.

Verified rule catches all 4 existing offences:
- `quickstart.ts:549` (locked-module greeting, #1367)
- `quickstart.ts:566` (returning-learner greeting, #1367)  
- `build-assistant-config.ts:121` (pre-existing fallback)
- `build-assistant-config.ts:177` (pre-existing fallback)

Rollback PR (filed separately) removes those offences AND promotes severity to error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)