### PR TITLE
chore(kb): ratify high-stakes model-map globals (8/109)

### DIFF
--- a/apps/admin/scripts/capture/model-map.ts
+++ b/apps/admin/scripts/capture/model-map.ts
@@ -14,7 +14,7 @@
  * Run:  npx tsx scripts/capture/model-map.ts        (from apps/admin)
  * CI:   re-run and `git diff --exit-code` the JSON to catch schema drift.
  */
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -22,6 +22,7 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "../../../..");
 const SCHEMA_PATH = resolve(REPO_ROOT, "apps/admin/prisma/schema.prisma");
 const OUT_PATH = resolve(REPO_ROOT, "docs/kb/generated/model-map.json");
+const OVERRIDES_PATH = resolve(REPO_ROOT, "docs/kb/model-map-overrides.json");
 
 const PRISMA_SCALARS = new Set([
   "String", "Int", "Boolean", "DateTime", "Float", "Decimal", "BigInt", "Bytes", "Json",
@@ -132,6 +133,33 @@ function parseModel(name: string, body: string, scalarTypes: Set<string>): Model
   };
 }
 
+type Override = {
+  proposedClass?: ModelInfo["proposedClass"];
+  notes?: string;
+  confidence?: ModelInfo["confidence"];
+};
+
+function loadOverrides(): Record<string, Override> {
+  if (!existsSync(OVERRIDES_PATH)) return {};
+  const j = JSON.parse(readFileSync(OVERRIDES_PATH, "utf8"));
+  return (j.overrides ?? {}) as Record<string, Override>;
+}
+
+function applyOverrides(models: ModelInfo[]): number {
+  const overrides = loadOverrides();
+  let n = 0;
+  for (const m of models) {
+    const o = overrides[m.name];
+    if (!o) continue;
+    if (o.proposedClass) m.proposedClass = o.proposedClass;
+    if (o.confidence) m.confidence = o.confidence;
+    if (o.notes) m.notes = o.notes;
+    m.reviewed = true;
+    n++;
+  }
+  return n;
+}
+
 function main() {
   const src = readFileSync(SCHEMA_PATH, "utf8");
   const scalarTypes = new Set([...PRISMA_SCALARS, ...collectEnums(src)]);
@@ -144,13 +172,16 @@ function main() {
   }
   models.sort((a, b) => a.name.localeCompare(b.name));
 
+  const ratifiedCount = applyOverrides(models);
+
   const summary = models.reduce(
     (acc, mdl) => {
       acc[mdl.proposedClass]++;
       if (mdl.hasTenantHint) acc.alreadyTenantAware++;
+      if (mdl.reviewed) acc.ratified++;
       return acc;
     },
-    { "tenant-scoped": 0, global: 0, join: 0, alreadyTenantAware: 0 } as Record<string, number>,
+    { "tenant-scoped": 0, global: 0, join: 0, alreadyTenantAware: 0, ratified: 0 } as Record<string, number>,
   );
 
   const out = {
@@ -158,8 +189,9 @@ function main() {
     generatedAt: new Date().toISOString(),
     generator: "scripts/capture/model-map.ts",
     schemaPath: "apps/admin/prisma/schema.prisma",
-    note: "Tier-2 generated KB. proposedClass is a HEURISTIC; ratify each row (set reviewed:true) to make this the authoritative tenant-scoping map. Do not hand-edit — re-run the generator.",
+    note: "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",
     modelCount: models.length,
+    ratifiedCount,
     summary,
     models,
   };
@@ -171,6 +203,7 @@ function main() {
   console.log(
     `[model-map] proposed: ${summary["tenant-scoped"]} tenant-scoped · ${summary.global} global · ${summary.join} join · ${summary.alreadyTenantAware} already tenant-aware`,
   );
+  console.log(`[model-map] ratified: ${ratifiedCount}/${models.length} (via model-map-overrides.json)`);
 }
 
 main();

--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -33,7 +33,7 @@ already exists, scattered across mechanisms that were never designed as one syst
 
 | # | Part | Format | Lives in | Status |
 |---|---|---|---|---|
-| 1 | Structural facts (model map, routes, coupling) | generated JSON | `docs/kb/generated/` | 🟡 model-map + routes done; coupling TODO |
+| 1 | Structural facts (model map, routes, coupling) | generated JSON | `docs/kb/generated/` | 🟡 model-map + routes done; 8/109 ratified (the high-stakes globals); coupling TODO |
 | 2 | Guard / contract registry | markdown (CHAIN-style) | `docs/kb/guard-registry.md` | 🟢 10/10 ESLint rules wired |
 | 2b | Guards *process* (the ritual) | markdown | `docs/kb/guards-process.md` | 🟢 first cut |
 | 3 | Narrative invariants / history | markdown | `docs/kb/invariants.md` | 🟡 seeded |
@@ -55,10 +55,27 @@ already exists, scattered across mechanisms that were never designed as one syst
 
 ```bash
 cd apps/admin
-npm run kb:model-map     # → docs/kb/generated/model-map.json   (105 models classified)
+npm run kb:model-map     # → docs/kb/generated/model-map.json   (109 models classified)
 npm run kb:routes        # → docs/kb/generated/route-inventory.json (501 routes)
 npm run kb:check         # meta-ratchet (guard back-links) + generated-fact freshness
 ```
+
+### Ratifying a model classification
+
+The model map's `proposedClass` is a heuristic; ratify a row by adding an entry to
+[`model-map-overrides.json`](./model-map-overrides.json) (NOT the generated JSON):
+
+```json
+{
+  "overrides": {
+    "ModelName": { "proposedClass": "tenant-scoped", "confidence": "medium", "notes": "why" }
+  }
+}
+```
+
+Re-run `npm run kb:model-map`; the generator applies overrides and sets `reviewed:true`
+on each ratified row. The overrides file is the *human* tier; the generated JSON is
+re-derived on every run.
 
 - **Find something** → `qmd search` (semantic recall over the whole corpus).
   qmd is **not** retired — it's how this KB gets built (search → curate → register).

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,15 +1,17 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-09T08:30:14.496Z",
+  "generatedAt": "2026-06-09T10:29:17.601Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
-  "note": "Tier-2 generated KB. proposedClass is a HEURISTIC; ratify each row (set reviewed:true) to make this the authoritative tenant-scoping map. Do not hand-edit — re-run the generator.",
-  "modelCount": 105,
+  "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",
+  "modelCount": 109,
+  "ratifiedCount": 8,
   "summary": {
-    "tenant-scoped": 89,
-    "global": 8,
+    "tenant-scoped": 97,
+    "global": 4,
     "join": 8,
-    "alreadyTenantAware": 1
+    "alreadyTenantAware": 1,
+    "ratified": 8
   },
   "models": [
     {
@@ -157,9 +159,9 @@
       ],
       "hasTenantHint": false,
       "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Call-point AI config (provider, model, temperature, timeouts). Platform-global; identical for all tenants on a single deployment. Verified — no FK to per-tenant entities."
     },
     {
       "name": "AIModel",
@@ -383,10 +385,10 @@
         "@@map"
       ],
       "hasTenantHint": false,
-      "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Has `scope` field (SYSTEM | DOMAIN | CALLER). SYSTEM rows are platform-global, DOMAIN/CALLER rows are tenant-scoped via FK chain. As a single table it carries tenant data — requires tenantId. Heuristic wrongly matched /Spec/ → global."
     },
     {
       "name": "AnalysisTrigger",
@@ -522,6 +524,30 @@
         "@@index",
         "@@index"
       ],
+      "hasTenantHint": false,
+      "proposedClass": "tenant-scoped",
+      "confidence": "low",
+      "reviewed": false,
+      "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
+    },
+    {
+      "name": "AuthSession",
+      "fieldCount": 5,
+      "relationCount": 1,
+      "meaningfulScalarCount": 2,
+      "scalarFields": [
+        "id",
+        "sessionToken",
+        "userId",
+        "expires"
+      ],
+      "relations": [
+        {
+          "field": "user",
+          "target": "User"
+        }
+      ],
+      "blockAttrs": [],
       "hasTenantHint": false,
       "proposedClass": "tenant-scoped",
       "confidence": "low",
@@ -710,8 +736,8 @@
     },
     {
       "name": "Call",
-      "fieldCount": 44,
-      "relationCount": 18,
+      "fieldCount": 46,
+      "relationCount": 19,
       "meaningfulScalarCount": 17,
       "scalarFields": [
         "id",
@@ -720,6 +746,7 @@
         "transcript",
         "createdAt",
         "callerId",
+        "sessionId",
         "playbookId",
         "curriculumModuleId",
         "requestedModuleId",
@@ -745,6 +772,10 @@
         {
           "field": "caller",
           "target": "Caller"
+        },
+        {
+          "field": "session",
+          "target": "Session"
         },
         {
           "field": "playbook",
@@ -890,8 +921,8 @@
     },
     {
       "name": "Caller",
-      "fieldCount": 46,
-      "relationCount": 28,
+      "fieldCount": 47,
+      "relationCount": 29,
       "meaningfulScalarCount": 9,
       "scalarFields": [
         "id",
@@ -1025,6 +1056,10 @@
         {
           "field": "lastSelectedModule",
           "target": "CurriculumModule"
+        },
+        {
+          "field": "sessions",
+          "target": "Session"
         }
       ],
       "blockAttrs": [
@@ -1449,6 +1484,27 @@
       "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
     },
     {
+      "name": "CallerSequenceCounter",
+      "fieldCount": 4,
+      "relationCount": 0,
+      "meaningfulScalarCount": 2,
+      "scalarFields": [
+        "callerId",
+        "kind",
+        "nextSeq",
+        "updatedAt"
+      ],
+      "relations": [],
+      "blockAttrs": [
+        "@@id"
+      ],
+      "hasTenantHint": false,
+      "proposedClass": "tenant-scoped",
+      "confidence": "low",
+      "reviewed": false,
+      "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
+    },
+    {
       "name": "CallerTarget",
       "fieldCount": 14,
       "relationCount": 2,
@@ -1645,10 +1701,10 @@
         "@@index"
       ],
       "hasTenantHint": false,
-      "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Has `domainId` FK — already scoped per Domain. Multi-tenancy: domain → tenant gives the scoping chain. Heuristic matched /Config$/ → global."
     },
     {
       "name": "CohortGroup",
@@ -1753,8 +1809,8 @@
     },
     {
       "name": "ComposedPrompt",
-      "fieldCount": 20,
-      "relationCount": 4,
+      "fieldCount": 24,
+      "relationCount": 7,
       "meaningfulScalarCount": 11,
       "scalarFields": [
         "id",
@@ -1764,6 +1820,7 @@
         "llmPrompt",
         "triggerType",
         "triggerCallId",
+        "triggerSessionId",
         "inputs",
         "model",
         "status",
@@ -1784,8 +1841,20 @@
           "target": "Call"
         },
         {
+          "field": "triggerSession",
+          "target": "Session"
+        },
+        {
           "field": "usedForCalls",
           "target": "Call"
+        },
+        {
+          "field": "sessionsUsedBy",
+          "target": "Session"
+        },
+        {
+          "field": "sessionsProducedBy",
+          "target": "Session"
         },
         {
           "field": "caller",
@@ -1793,6 +1862,7 @@
         }
       ],
       "blockAttrs": [
+        "@@index",
         "@@index",
         "@@index",
         "@@index",
@@ -2276,8 +2346,8 @@
     },
     {
       "name": "CurriculumModule",
-      "fieldCount": 24,
-      "relationCount": 7,
+      "fieldCount": 25,
+      "relationCount": 8,
       "meaningfulScalarCount": 12,
       "scalarFields": [
         "id",
@@ -2322,6 +2392,10 @@
         {
           "field": "lastSelectedByCallers",
           "target": "Caller"
+        },
+        {
+          "field": "sessions",
+          "target": "Session"
         },
         {
           "field": "sourceContent",
@@ -2469,6 +2543,36 @@
         {
           "field": "processedFile",
           "target": "ProcessedFile"
+        }
+      ],
+      "blockAttrs": [
+        "@@index",
+        "@@index",
+        "@@index"
+      ],
+      "hasTenantHint": false,
+      "proposedClass": "tenant-scoped",
+      "confidence": "low",
+      "reviewed": false,
+      "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
+    },
+    {
+      "name": "FailureLog",
+      "fieldCount": 7,
+      "relationCount": 1,
+      "meaningfulScalarCount": 4,
+      "scalarFields": [
+        "id",
+        "sessionId",
+        "kind",
+        "attemptNumber",
+        "errorPayload",
+        "occurredAt"
+      ],
+      "relations": [
+        {
+          "field": "session",
+          "target": "Session"
         }
       ],
       "blockAttrs": [
@@ -2665,6 +2769,33 @@
       "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
     },
     {
+      "name": "IntakeEvent",
+      "fieldCount": 8,
+      "relationCount": 0,
+      "meaningfulScalarCount": 5,
+      "scalarFields": [
+        "id",
+        "intentId",
+        "version",
+        "kind",
+        "prevHash",
+        "contentHash",
+        "payload",
+        "createdAt"
+      ],
+      "relations": [],
+      "blockAttrs": [
+        "@@unique",
+        "@@index",
+        "@@map"
+      ],
+      "hasTenantHint": false,
+      "proposedClass": "tenant-scoped",
+      "confidence": "low",
+      "reviewed": false,
+      "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
+    },
+    {
       "name": "IntakeSpec",
       "fieldCount": 14,
       "relationCount": 2,
@@ -2700,9 +2831,9 @@
       ],
       "hasTenantHint": false,
       "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Tallyseal-shaped spec registry (key + version + body). Authored by admins, consumed by enrollment chat. No per-tenant data."
     },
     {
       "name": "Invite",
@@ -3398,10 +3529,10 @@
         "@@index"
       ],
       "hasTenantHint": false,
-      "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Records of a pipeline execution with `callerId` and `callId` FKs. Each row is per-call tenant data, not platform config. Heuristic wrongly matched /^Pipeline/ → global."
     },
     {
       "name": "PipelineStep",
@@ -3445,15 +3576,15 @@
         "@@index"
       ],
       "hasTenantHint": false,
-      "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Child of PipelineRun via `runId`; tenancy inherited through `run.callerId`. Heuristic wrongly matched /^Pipeline/ → global."
     },
     {
       "name": "Playbook",
-      "fieldCount": 37,
-      "relationCount": 16,
+      "fieldCount": 38,
+      "relationCount": 17,
       "meaningfulScalarCount": 15,
       "scalarFields": [
         "id",
@@ -3542,6 +3673,10 @@
         {
           "field": "wizardSessions",
           "target": "WizardSession"
+        },
+        {
+          "field": "sessions",
+          "target": "Session"
         }
       ],
       "blockAttrs": [
@@ -4042,9 +4177,9 @@
       ],
       "hasTenantHint": false,
       "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Catalog of prompt templates referenced by PlaybookItem. The template content is shared across tenants; per-playbook usage carries tenancy via Playbook."
     },
     {
       "name": "RewardScore",
@@ -4139,22 +4274,72 @@
     },
     {
       "name": "Session",
-      "fieldCount": 5,
-      "relationCount": 1,
-      "meaningfulScalarCount": 2,
+      "fieldCount": 27,
+      "relationCount": 8,
+      "meaningfulScalarCount": 11,
       "scalarFields": [
         "id",
-        "sessionToken",
-        "userId",
-        "expires"
+        "callerId",
+        "playbookId",
+        "kind",
+        "sequenceNumber",
+        "learnerFacingNumber",
+        "requestedModuleId",
+        "curriculumModuleId",
+        "voiceProvider",
+        "intentId",
+        "voiceConfigSnapshot",
+        "startedAt",
+        "endedAt",
+        "status",
+        "countsTowardLearnerNumber",
+        "countsTowardPipelineNumber",
+        "skipStages",
+        "usedPromptId",
+        "producedComposedPromptId"
       ],
       "relations": [
         {
-          "field": "user",
-          "target": "User"
+          "field": "caller",
+          "target": "Caller"
+        },
+        {
+          "field": "playbook",
+          "target": "Playbook"
+        },
+        {
+          "field": "curriculumModule",
+          "target": "CurriculumModule"
+        },
+        {
+          "field": "usedPrompt",
+          "target": "ComposedPrompt"
+        },
+        {
+          "field": "producedComposedPrompt",
+          "target": "ComposedPrompt"
+        },
+        {
+          "field": "call",
+          "target": "Call"
+        },
+        {
+          "field": "triggeredComposedPrompts",
+          "target": "ComposedPrompt"
+        },
+        {
+          "field": "failureLogs",
+          "target": "FailureLog"
         }
       ],
-      "blockAttrs": [],
+      "blockAttrs": [
+        "@@unique",
+        "@@index",
+        "@@index",
+        "@@index",
+        "@@index",
+        "@@index"
+      ],
       "hasTenantHint": false,
       "proposedClass": "tenant-scoped",
       "confidence": "low",
@@ -4376,9 +4561,9 @@
       ],
       "hasTenantHint": false,
       "proposedClass": "global",
-      "confidence": "low",
-      "reviewed": false,
-      "notes": "Name matches a platform/config pattern — verify it holds no per-tenant data."
+      "confidence": "medium",
+      "reviewed": true,
+      "notes": "Key/value system settings — by definition platform-global."
     },
     {
       "name": "Tag",
@@ -4620,8 +4805,8 @@
           "target": "Account"
         },
         {
-          "field": "sessions",
-          "target": "Session"
+          "field": "authSessions",
+          "target": "AuthSession"
         },
         {
           "field": "sentMessages",

--- a/docs/kb/model-map-overrides.json
+++ b/docs/kb/model-map-overrides.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "model-map-overrides/v1",
+  "note": "Human-ratified classifications applied AFTER the heuristic in scripts/capture/model-map.ts. Any model named here gets reviewed:true in the generated map. Edit this file to ratify a model; never hand-edit docs/kb/generated/model-map.json.",
+  "lastReviewedAt": "2026-06-09",
+  "overrides": {
+    "AnalysisSpec": {
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "notes": "Has `scope` field (SYSTEM | DOMAIN | CALLER). SYSTEM rows are platform-global, DOMAIN/CALLER rows are tenant-scoped via FK chain. As a single table it carries tenant data — requires tenantId. Heuristic wrongly matched /Spec/ → global."
+    },
+    "ChannelConfig": {
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "notes": "Has `domainId` FK — already scoped per Domain. Multi-tenancy: domain → tenant gives the scoping chain. Heuristic matched /Config$/ → global."
+    },
+    "PipelineRun": {
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "notes": "Records of a pipeline execution with `callerId` and `callId` FKs. Each row is per-call tenant data, not platform config. Heuristic wrongly matched /^Pipeline/ → global."
+    },
+    "PipelineStep": {
+      "proposedClass": "tenant-scoped",
+      "confidence": "medium",
+      "notes": "Child of PipelineRun via `runId`; tenancy inherited through `run.callerId`. Heuristic wrongly matched /^Pipeline/ → global."
+    },
+    "AIConfig": {
+      "proposedClass": "global",
+      "confidence": "medium",
+      "notes": "Call-point AI config (provider, model, temperature, timeouts). Platform-global; identical for all tenants on a single deployment. Verified — no FK to per-tenant entities."
+    },
+    "IntakeSpec": {
+      "proposedClass": "global",
+      "confidence": "medium",
+      "notes": "Tallyseal-shaped spec registry (key + version + body). Authored by admins, consumed by enrollment chat. No per-tenant data."
+    },
+    "PromptTemplate": {
+      "proposedClass": "global",
+      "confidence": "medium",
+      "notes": "Catalog of prompt templates referenced by PlaybookItem. The template content is shared across tenants; per-playbook usage carries tenancy via Playbook."
+    },
+    "SystemSetting": {
+      "proposedClass": "global",
+      "confidence": "medium",
+      "notes": "Key/value system settings — by definition platform-global."
+    }
+  }
+}


### PR DESCRIPTION
## Why

The model map's `proposedClass` is a heuristic. The **`global`** category is the
highest-stakes call — a tenant-scoped model mis-classified as global would leak
across tenants in Phase 2. Reviewing the 8 heuristic globals against the schema:

| Model | Heuristic | Ratified | Why |
|---|---|---|---|
| `AnalysisSpec` | global | **tenant-scoped** | Has `scope` field (SYSTEM/DOMAIN/CALLER). DOMAIN/CALLER rows are per-tenant. |
| `ChannelConfig` | global | **tenant-scoped** | Has `domainId` FK — already domain-scoped. |
| `PipelineRun` | global | **tenant-scoped** | Has `callerId`/`callId` — pipeline execution records. |
| `PipelineStep` | global | **tenant-scoped** | Child of PipelineRun via `runId`. |
| `AIConfig` | global | global ✓ | Call-point AI config (provider/model/temperature). No tenant FK. |
| `IntakeSpec` | global | global ✓ | Tallyseal spec registry (key + version + body). |
| `PromptTemplate` | global | global ✓ | Shared catalog referenced by PlaybookItem. |
| `SystemSetting` | global | global ✓ | Key/value, by definition platform-global. |

**4 corrections** that would have been silent tenancy leaks at Phase 2.

## What

Adds the ratification mechanism *and* the first 8 ratifications:

- **`docs/kb/model-map-overrides.json`** — the human tier (edit this, never the generated JSON).
- **`scripts/capture/model-map.ts`** — loads overrides after the heuristic, applies
  them, sets `reviewed:true` on each, tracks `ratifiedCount` in the summary.
- **`docs/kb/generated/model-map.json`** — regenerated with `8/109` ratified.
- **`docs/kb/README.md`** — documents the ratification workflow.

Generator stays the single source of truth: re-running preserves ratifications
because they come from the overrides file.

## Net counts

`97 tenant-scoped · 4 global · 8 join · 1 already-tenant-aware · 8/109 ratified`

## Follow-ups (not in this PR)

- Ratify the 97 `tenant-scoped` defaults by classifying each one's *tenant parent*
  (e.g., CurriculumModule → Curriculum → Playbook → tenant).
- Ratify the 8 `join` calls (verify each is truly a link table, not an entity).
- Walk the 1 `tenant-aware` (User) — the `Account` relation hit was an OAuth
  false-positive; the multi-tenant question is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)