### PR TITLE
chore(kb): route-inventory recognises all 8 HF auth gates (80 → 27)

### DIFF
--- a/apps/admin/scripts/capture/route-inventory.ts
+++ b/apps/admin/scripts/capture/route-inventory.ts
@@ -49,7 +49,19 @@ function main() {
     );
 
     const authLevels = [...src.matchAll(/requireAuth\(\s*["'`](\w+)["'`]/g)].map((m) => m[1]);
-    const hasRequireAuth = /requireAuth\s*\(/.test(src);
+    // HF auth gates fan out beyond requireAuth — each helper enforces a role/scope.
+    // Discovered via `grep -hoE 'require[A-Z]\w+\(' apps/admin/app/api/**/route.ts`.
+    const AUTH_GATES = [
+      "requireAuth",
+      "requireEntityAccess",
+      "requireEducator",
+      "requireEducatorOrAdmin",
+      "requireEducatorCohortOwnership",
+      "requireEducatorStudentAccess",
+      "requireCohortOwnership",
+      "requireStudentOrAdmin",
+    ];
+    const hasAuthGate = AUTH_GATES.some((g) => new RegExp(`\\b${g}\\s*\\(`).test(src));
     const handlesInternalSecret = /x-internal-secret|INTERNAL_API_SECRET/.test(src);
     const acceptsCallerIdParam = /callerId/.test(src);
     const usesScopeHelper = /resolveCallerScopeForReading|resolvePlaybookId|learner-scope/.test(src);
@@ -62,7 +74,7 @@ function main() {
       handlesInternalSecret,
       rawPrisma,
       possiblyUnscoped: acceptsCallerIdParam && !usesScopeHelper,
-      noAuthGate: !hasRequireAuth && !handlesInternalSecret,
+      noAuthGate: !hasAuthGate && !handlesInternalSecret,
     };
 
     return {
@@ -70,7 +82,7 @@ function main() {
       file: relative(REPO_ROOT, file),
       methods: methods.length ? methods : ["<none-detected>"],
       authLevels: [...new Set(authLevels)],
-      hasRequireAuth,
+      hasAuthGate,
       tenantSignals,
       reviewed: false,
     };
@@ -84,7 +96,7 @@ function main() {
     internalSecret: 0,
   };
   for (const r of routes) {
-    const key = r.authLevels.length ? r.authLevels.join("+") : r.hasRequireAuth ? "requireAuth(?)" : "<none>";
+    const key = r.authLevels.length ? r.authLevels.join("+") : r.hasAuthGate ? "auth-gate(non-role)" : "<none>";
     summary.byAuthLevel[key] = (summary.byAuthLevel[key] ?? 0) + 1;
     if (r.tenantSignals.noAuthGate) summary.noAuthGate++;
     if (r.tenantSignals.possiblyUnscoped) summary.possiblyUnscoped++;

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-09T08:30:15.820Z",
+  "generatedAt": "2026-06-09T10:37:33.750Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
@@ -13,18 +13,18 @@
       "OPERATOR": 133,
       "OPERATOR+VIEWER": 8,
       "VIEWER+OPERATOR": 56,
-      "<none>": 81,
+      "auth-gate(non-role)": 54,
       "VIEWER+OPERATOR+ADMIN": 3,
+      "<none>": 28,
       "OPERATOR+ADMIN": 5,
       "VIEWER+STUDENT": 1,
-      "requireAuth(?)": 1,
       "TESTER": 1,
       "EDUCATOR": 1,
       "SUPERADMIN+ADMIN": 1,
       "ADMIN+OPERATOR": 1,
       "VIEWER+TESTER": 3
     },
-    "noAuthGate": 80,
+    "noAuthGate": 27,
     "possiblyUnscoped": 130,
     "internalSecret": 7
   },
@@ -39,7 +39,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -60,7 +60,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -81,7 +81,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -101,7 +101,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -121,7 +121,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -142,7 +142,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -162,7 +162,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -182,7 +182,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -202,7 +202,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -223,7 +223,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -243,7 +243,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -263,7 +263,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -283,7 +283,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -303,7 +303,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -324,7 +324,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -346,7 +346,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -366,7 +366,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -386,7 +386,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -409,7 +409,7 @@
         "VIEWER",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -430,7 +430,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -451,7 +451,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -471,7 +471,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -491,7 +491,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -511,7 +511,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -531,7 +531,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -552,7 +552,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -574,7 +574,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -594,7 +594,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -614,7 +614,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -636,7 +636,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -659,7 +659,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -679,7 +679,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -701,7 +701,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -723,7 +723,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -743,7 +743,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -761,14 +761,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -781,14 +781,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -803,7 +803,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -823,7 +823,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -845,7 +845,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -866,7 +866,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -886,7 +886,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -906,7 +906,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -926,7 +926,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -946,7 +946,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -966,7 +966,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -986,7 +986,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1006,7 +1006,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1026,7 +1026,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1051,7 +1051,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1073,7 +1073,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1095,7 +1095,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1115,7 +1115,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1135,7 +1135,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": true,
@@ -1153,7 +1153,7 @@
         "<none-detected>"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1171,7 +1171,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -1191,7 +1191,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1213,7 +1213,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1235,7 +1235,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1255,7 +1255,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1277,7 +1277,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1297,7 +1297,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1317,7 +1317,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1338,7 +1338,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1360,7 +1360,7 @@
         "VIEWER",
         "STUDENT"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -1380,7 +1380,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1398,14 +1398,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -1420,7 +1420,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1440,7 +1440,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1461,7 +1461,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1483,7 +1483,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1503,7 +1503,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1525,7 +1525,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1543,14 +1543,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -1563,7 +1563,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1583,7 +1583,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1603,7 +1603,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1623,7 +1623,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1643,7 +1643,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1663,7 +1663,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1683,7 +1683,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -1703,7 +1703,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1723,7 +1723,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1743,14 +1743,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -1763,7 +1763,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1783,7 +1783,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1803,7 +1803,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1821,14 +1821,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -1841,7 +1841,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1861,7 +1861,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1881,7 +1881,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1901,7 +1901,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1919,14 +1919,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -1939,7 +1939,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1959,7 +1959,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1979,7 +1979,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -1998,14 +1998,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2018,7 +2018,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -2036,14 +2036,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2057,7 +2057,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2077,7 +2077,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -2097,7 +2097,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -2118,7 +2118,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -2138,7 +2138,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2158,7 +2158,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -2178,7 +2178,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2196,7 +2196,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -2214,14 +2214,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2232,14 +2232,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2251,14 +2251,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2271,14 +2271,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2290,14 +2290,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2308,14 +2308,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": false,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2327,14 +2327,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2345,14 +2345,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": false,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2365,14 +2365,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2383,14 +2383,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2402,14 +2402,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -2422,7 +2422,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2442,7 +2442,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -2462,7 +2462,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -2484,7 +2484,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2505,7 +2505,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2526,7 +2526,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2547,7 +2547,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -2567,7 +2567,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2587,7 +2587,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2607,7 +2607,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2627,7 +2627,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2647,7 +2647,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -2667,7 +2667,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2687,7 +2687,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2707,7 +2707,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2729,7 +2729,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2749,7 +2749,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2769,7 +2769,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2789,7 +2789,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2809,7 +2809,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2830,7 +2830,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2850,7 +2850,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2870,7 +2870,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2890,7 +2890,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2912,7 +2912,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2932,7 +2932,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2954,7 +2954,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2974,7 +2974,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -2998,7 +2998,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3018,7 +3018,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3038,7 +3038,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3058,7 +3058,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3080,7 +3080,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3100,7 +3100,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3122,7 +3122,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3140,14 +3140,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": false,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -3160,7 +3160,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3181,7 +3181,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3201,7 +3201,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3221,7 +3221,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3241,7 +3241,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3261,7 +3261,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3281,7 +3281,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3301,7 +3301,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3321,7 +3321,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3341,7 +3341,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3361,7 +3361,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3381,7 +3381,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -3401,7 +3401,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3421,7 +3421,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3441,7 +3441,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3463,7 +3463,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3483,7 +3483,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3503,7 +3503,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3523,7 +3523,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3543,7 +3543,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -3563,7 +3563,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3585,7 +3585,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -3605,7 +3605,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3625,7 +3625,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3645,7 +3645,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -3665,7 +3665,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3687,7 +3687,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3707,7 +3707,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -3727,7 +3727,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3747,7 +3747,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3767,7 +3767,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -3787,7 +3787,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3807,7 +3807,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3827,7 +3827,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3847,7 +3847,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3868,7 +3868,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3888,7 +3888,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -3908,7 +3908,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3928,7 +3928,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3948,7 +3948,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3970,7 +3970,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -3990,7 +3990,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4011,7 +4011,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4031,7 +4031,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4051,7 +4051,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4071,7 +4071,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4091,7 +4091,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4111,7 +4111,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4131,7 +4131,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4151,7 +4151,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4174,7 +4174,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": true,
@@ -4197,7 +4197,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": true,
@@ -4220,7 +4220,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": true,
@@ -4240,7 +4240,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4260,7 +4260,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4280,7 +4280,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4300,7 +4300,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4320,7 +4320,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4342,7 +4342,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4362,7 +4362,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4382,7 +4382,7 @@
       "authLevels": [
         "TESTER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4402,7 +4402,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4422,7 +4422,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4442,7 +4442,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4462,7 +4462,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4482,7 +4482,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4502,7 +4502,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4522,7 +4522,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4542,7 +4542,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4562,7 +4562,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4582,7 +4582,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4604,7 +4604,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4624,7 +4624,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4644,7 +4644,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4666,7 +4666,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4688,7 +4688,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4708,7 +4708,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4728,7 +4728,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4749,7 +4749,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4772,7 +4772,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4792,7 +4792,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4812,7 +4812,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4832,7 +4832,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4852,7 +4852,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4873,7 +4873,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4895,7 +4895,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -4915,7 +4915,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4933,14 +4933,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -4953,7 +4953,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -4972,14 +4972,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -4990,14 +4990,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5010,7 +5010,7 @@
       "authLevels": [
         "EDUCATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5028,14 +5028,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5046,14 +5046,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5066,14 +5066,14 @@
         "DELETE"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5087,7 +5087,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5107,7 +5107,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5127,7 +5127,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5147,7 +5147,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5165,14 +5165,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5183,14 +5183,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5203,7 +5203,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5221,14 +5221,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5239,14 +5239,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5257,14 +5257,14 @@
         "PATCH"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -5278,7 +5278,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5298,7 +5298,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5318,7 +5318,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5338,7 +5338,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5361,7 +5361,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5383,7 +5383,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -5401,7 +5401,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5421,7 +5421,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5441,7 +5441,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -5461,7 +5461,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -5481,7 +5481,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -5503,7 +5503,7 @@
         "VIEWER",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5523,7 +5523,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5545,7 +5545,7 @@
         "VIEWER",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5565,7 +5565,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5585,7 +5585,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5605,7 +5605,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5628,7 +5628,7 @@
         "SUPERADMIN",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5648,7 +5648,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5668,7 +5668,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5690,7 +5690,7 @@
         "ADMIN",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5710,7 +5710,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5730,7 +5730,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5748,7 +5748,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5766,7 +5766,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5784,7 +5784,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5802,7 +5802,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5820,7 +5820,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5838,7 +5838,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5856,7 +5856,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5876,7 +5876,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5894,7 +5894,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5912,7 +5912,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -5930,7 +5930,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5950,7 +5950,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5972,7 +5972,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -5991,7 +5991,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -6011,7 +6011,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6033,7 +6033,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6053,7 +6053,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6073,7 +6073,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6093,7 +6093,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6113,7 +6113,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6133,7 +6133,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6156,7 +6156,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6176,7 +6176,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6196,7 +6196,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6216,7 +6216,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6236,7 +6236,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6259,7 +6259,7 @@
         "VIEWER",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6277,7 +6277,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6301,7 +6301,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6321,7 +6321,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6343,7 +6343,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -6366,7 +6366,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6388,7 +6388,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6408,7 +6408,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6430,7 +6430,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6451,7 +6451,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6473,7 +6473,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6495,7 +6495,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -6517,7 +6517,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6537,7 +6537,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -6557,7 +6557,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6577,7 +6577,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -6597,7 +6597,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6619,7 +6619,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6639,7 +6639,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6659,7 +6659,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6682,7 +6682,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6706,7 +6706,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6728,7 +6728,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6750,7 +6750,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -6774,7 +6774,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6796,7 +6796,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6820,7 +6820,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6843,7 +6843,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6864,7 +6864,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6884,7 +6884,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6904,7 +6904,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6926,7 +6926,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6946,7 +6946,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6966,7 +6966,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -6986,7 +6986,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -7006,7 +7006,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7026,7 +7026,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7049,7 +7049,7 @@
         "OPERATOR",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7071,7 +7071,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7091,7 +7091,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7112,7 +7112,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7132,7 +7132,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7152,7 +7152,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7172,7 +7172,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -7192,7 +7192,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7212,7 +7212,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7232,7 +7232,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7252,7 +7252,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7272,7 +7272,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -7292,7 +7292,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7315,7 +7315,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7335,7 +7335,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7357,7 +7357,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7379,7 +7379,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7399,7 +7399,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7419,7 +7419,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7439,7 +7439,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7459,7 +7459,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7480,7 +7480,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -7500,7 +7500,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7522,7 +7522,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7542,7 +7542,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -7565,7 +7565,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7587,7 +7587,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7610,7 +7610,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7632,7 +7632,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7654,7 +7654,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7676,7 +7676,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -7698,7 +7698,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -7716,7 +7716,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7736,7 +7736,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -7756,7 +7756,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7778,7 +7778,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7801,7 +7801,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7821,7 +7821,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7841,7 +7841,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7861,7 +7861,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -7881,7 +7881,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7901,7 +7901,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7921,7 +7921,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7942,7 +7942,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7963,7 +7963,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -7986,7 +7986,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8006,7 +8006,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8026,7 +8026,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8046,7 +8046,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8066,7 +8066,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8088,7 +8088,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8108,7 +8108,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8128,7 +8128,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8148,7 +8148,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8170,7 +8170,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8190,7 +8190,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8211,7 +8211,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8231,7 +8231,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -8249,14 +8249,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8267,14 +8267,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8285,14 +8285,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8303,14 +8303,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8321,14 +8321,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8339,14 +8339,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8357,14 +8357,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8375,14 +8375,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8393,14 +8393,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8411,14 +8411,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8429,14 +8429,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8447,14 +8447,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8465,14 +8465,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8483,14 +8483,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8501,14 +8501,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8519,14 +8519,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8537,14 +8537,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8557,7 +8557,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -8575,14 +8575,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8593,14 +8593,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8612,14 +8612,14 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8630,14 +8630,14 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
-        "noAuthGate": true
+        "noAuthGate": false
       },
       "reviewed": false
     },
@@ -8650,7 +8650,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8670,7 +8670,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8690,7 +8690,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8713,7 +8713,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8736,7 +8736,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8759,7 +8759,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8782,7 +8782,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8806,7 +8806,7 @@
         "VIEWER",
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8826,7 +8826,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8848,7 +8848,7 @@
         "VIEWER",
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8868,7 +8868,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8890,7 +8890,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8908,7 +8908,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8928,7 +8928,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8946,7 +8946,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -8964,7 +8964,7 @@
         "GET"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -8984,7 +8984,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9009,7 +9009,7 @@
         "OPERATOR",
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9029,7 +9029,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9049,7 +9049,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9069,7 +9069,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9089,7 +9089,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9109,7 +9109,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9129,7 +9129,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9149,7 +9149,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9169,7 +9169,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9189,7 +9189,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9209,7 +9209,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9229,7 +9229,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9251,7 +9251,7 @@
         "VIEWER",
         "TESTER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9274,7 +9274,7 @@
         "VIEWER",
         "TESTER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9296,7 +9296,7 @@
         "VIEWER",
         "TESTER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9316,7 +9316,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9336,7 +9336,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -9356,7 +9356,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9376,7 +9376,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9396,7 +9396,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9416,7 +9416,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9436,7 +9436,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9456,7 +9456,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9476,7 +9476,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9496,7 +9496,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9514,7 +9514,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9532,7 +9532,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9550,7 +9550,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -9568,7 +9568,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9590,7 +9590,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9610,7 +9610,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9631,7 +9631,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9652,7 +9652,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9673,7 +9673,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9691,7 +9691,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9709,7 +9709,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9727,7 +9727,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9745,7 +9745,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9765,7 +9765,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -9785,7 +9785,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -9805,7 +9805,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": true,
@@ -9825,7 +9825,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9845,7 +9845,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9863,7 +9863,7 @@
         "POST"
       ],
       "authLevels": [],
-      "hasRequireAuth": false,
+      "hasAuthGate": false,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9883,7 +9883,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9903,7 +9903,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -9923,7 +9923,7 @@
       "authLevels": [
         "VIEWER"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9943,7 +9943,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9963,7 +9963,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -9983,7 +9983,7 @@
       "authLevels": [
         "SUPERADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -10003,7 +10003,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -10023,7 +10023,7 @@
       "authLevels": [
         "OPERATOR"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -10043,7 +10043,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -10064,7 +10064,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -10084,7 +10084,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -10104,7 +10104,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -10124,7 +10124,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
@@ -10144,7 +10144,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
         "usesScopeHelper": false,
@@ -10165,7 +10165,7 @@
       "authLevels": [
         "ADMIN"
       ],
-      "hasRequireAuth": true,
+      "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,


### PR DESCRIPTION
## TL;DR

The route-inventory generator only detected `requireAuth(...)`, missing 7 other
auth-gate helpers. **53 of 80 `noAuthGate` routes were false positives.** Fixing
the heuristic drops the count to 27, **all of which are legitimately unauthenticated**
(NextAuth, health checks, anonymous intake, token-protected join, VAPI webhooks).

**Net finding (per current evidence): no real auth gaps in HF.**

## What

`scripts/capture/route-inventory.ts` now recognises every auth-gate helper in
actual use:

| Helper | Uses |
|---|---:|
| `requireAuth` | 605 |
| `requireEntityAccess` | 35 |
| `requireEducator` | 25 |
| `requireStudentOrAdmin` | 22 |
| `requireCohortOwnership` | 16 |
| `requireEducatorCohortOwnership` | 9 |
| `requireEducatorStudentAccess` | 6 |
| `requireEducatorOrAdmin` | 1 |

Discovered with `grep -hoE 'require[A-Z]\w+\(' apps/admin/app/api/**/route.ts | sort | uniq -c`.

## Why it matters

`docs/decisions/2026-06-09-tenancy-isolation-model.md` cited the inflated 80
count as the Phase-2 Phase-1-style audit surface. After this fix, the real
surface is **27 expected-public routes** — confirms HF's auth posture is solid.

The **130 `possiblyUnscoped`** count (callerId + no scope helper) is **unchanged**
— that's still the real Phase 2 tenant-scoping worklist.

## The remaining 27 (all legitimately unauthenticated)

| Cluster | Count | Why |
|---|---:|---|
| NextAuth + login | 2 | Must be public for sign-in |
| Health / readiness probes | 3 | Load-balancer probes |
| Anonymous enrollment intake | 7 | Pre-account by design |
| Invite / join token flows | 4 | Token-protected, not session |
| VAPI webhooks + LLM proxy | 11 | Signature-verified |

🤖 Generated with [Claude Code](https://claude.com/claude-code)