### PR TITLE
fix(compose): #1385 rollback — drop hardcoded greetings + promote guard to error

### DIFF
--- a/apps/admin/eslint-rules/no-hardcoded-greeting-in-composition.mjs
+++ b/apps/admin/eslint-rules/no-hardcoded-greeting-in-composition.mjs
@@ -32,12 +32,12 @@
  *     that path holds the explicit system-default templates; greetings
  *     LIVE there by design
  *
- * Severity: lands at `warn` because the four known offences need a
- * companion rollback PR (#1384 follow-up) that touches the prompt-
- * composition path — and per `.claude/rules/pipeline-and-prompt.md`
- * that path requires BA+TL grooming. The rollback PR promotes this
- * rule to `error` in the same commit that removes the last offence,
- * so the "halt — not accumulate" intent holds end-to-end.
+ * Severity: `error`. Promoted in #1385 in the same commit that removed
+ * the last offence — the "halt, do not accumulate" intent holds end-to-
+ * end. The six known offences (quickstart.ts:549,566 +
+ * build-assistant-config.ts:121,177 + route-handlers.ts:1204,1250) were
+ * all dropped or rehomed under `lib/prompt/composition/defaults/
+ * fallback-first-lines.ts` in the same PR.
  *
  * Companion: `.claude/rules/pipeline-and-prompt.md` documents the
  * "search for existing config before editing prompt-composition
@@ -47,6 +47,7 @@
 const GUARDED_PATH_FRAGMENTS = [
   "lib/prompt/composition/transforms/",
   "lib/voice/build-assistant-config.ts",
+  "lib/voice/route-handlers.ts",
 ];
 
 /** Paths where literal greeting strings ARE the contract — system-default

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -187,15 +187,15 @@ const eslintConfig = defineConfig([
       // once `composeGenericNounFallbackCount` reads 0 in dev/test/prod for
       // ≥7 days (per the chain-contract severity-escalation path).
       "hf-compose/no-orphan-instruction-fallback": "warn",
-      // #1384 — hardcoded greeting guard. Lands at `warn` because the
-      // four known offences (quickstart.ts:549,566 + build-assistant-
-      // config.ts:121,177) still need their rollback PR — which itself
-      // needs BA+TL grooming per `.claude/rules/pipeline-and-prompt.md`
-      // "search before editing prompt-composition transforms". The
-      // rollback PR PROMOTES this to `error` in the same commit that
-      // removes the last offence. Pre-existing failure pattern: see
-      // `no-orphan-instruction-fallback` companion comment.
-      "hf-compose/no-hardcoded-greeting-in-composition": "warn",
+      // #1384 / #1385 — hardcoded greeting guard. Promoted to `error`
+      // in the same PR that removed the six known offences
+      // (quickstart.ts:549,566 + build-assistant-config.ts:121,177 +
+      // route-handlers.ts:1204,1250 — all rehomed under
+      // `lib/prompt/composition/defaults/fallback-first-lines.ts`).
+      // Any new literal greeting in `lib/prompt/composition/transforms/`,
+      // `lib/voice/build-assistant-config.ts`, or `lib/voice/route-
+      // handlers.ts` now fails CI.
+      "hf-compose/no-hardcoded-greeting-in-composition": "error",
       "hf-voice/no-vapi-column-ref": "error",
       "hf-voice/no-vapi-tool-definitions-const": "error",
       "hf-wizard-v6/no-undeclared-field-require": "error",

--- a/apps/admin/lib/prompt/composition/defaults/fallback-first-lines.ts
+++ b/apps/admin/lib/prompt/composition/defaults/fallback-first-lines.ts
@@ -1,0 +1,46 @@
+/**
+ * Voice assistant first-line fallback defaults (#1385).
+ *
+ * The voice adapter builders (`lib/voice/build-assistant-config.ts`,
+ * `lib/voice/route-handlers.ts`) need a literal `first_line` to hand to
+ * VAPI/Retell when the configurable cascade can't supply one — either
+ * because the caller is unknown (no per-caller cascade reachable) OR
+ * because no `ComposedPrompt` exists for the resolved playbook yet
+ * (the "no active prompt" fallback path).
+ *
+ * Per `.claude/rules/pipeline-and-prompt.md` MANDATORY rule, behavioural
+ * greeting literals do NOT live inline in voice/composition code — they
+ * live HERE (`lib/prompt/composition/defaults/`), the allow-listed
+ * system-default template home that the `hf-compose/no-hardcoded-greeting-
+ * in-composition` ESLint rule explicitly greenlights. The rule blocks
+ * any greeting literal returned from a transform or assistant-config
+ * builder, forcing it through this module instead.
+ *
+ * These are NOT educator-tunable in the current cascade. They are the
+ * floor — when every configurable layer is silent, the voice call still
+ * gets a coherent opening rather than an empty `assistant.firstMessage`
+ * (VAPI dead-airs for ~5s when firstMessage is null). Promotion to a
+ * config-cascade source (PlaybookConfig.welcome.unknownCaller,
+ * VoiceCallSettings.unknownCallerFirstLine, etc.) is tracked separately.
+ *
+ * Pure functions. Deterministic. No LLM calls. No DB reads.
+ */
+
+/** Unknown-caller fallback — used when VAPI dials a phone we haven't
+ *  seen before, so no caller / playbook / domain cascade is available.
+ *  Asks for the name; the user's response is captured into the next
+ *  pipeline run and persisted on `Caller.name`. */
+export const UNKNOWN_CALLER_FIRST_LINE =
+  "Hello! I don't think we've spoken before. What's your name?";
+
+/** "No active prompt" fallback — used when a known caller is reached
+ *  but no `ComposedPrompt` exists for the resolved playbook yet (typical
+ *  for a freshly enrolled caller, before the first call has run through
+ *  the COMPOSE pipeline stage). Personalised with the caller's name
+ *  when available; falls back to a generic greeting otherwise. */
+export function noActivePromptFirstLine(
+  callerName: string | null | undefined,
+): string {
+  const namePart = callerName ? ` ${callerName}` : "";
+  return `Hi${namePart}! Good to hear from you.`;
+}

--- a/apps/admin/lib/prompt/composition/transforms/quickstart.ts
+++ b/apps/admin/lib/prompt/composition/transforms/quickstart.ts
@@ -86,7 +86,7 @@ registerTransform("computeQuickStart", (
   context: AssembledContext,
 ) => {
   const { sharedState, loadedData, resolvedSpecs, sections } = context;
-  const { modules, isFirstCall, completedModules, moduleToReview, nextModule, thresholds, callNumber, schedulerDecision, schedulerPolicy, moduleAttemptCounts, hasAttemptData, lockedModule } = sharedState;
+  const { modules, isFirstCall, completedModules, moduleToReview, nextModule, thresholds, callNumber, schedulerDecision, schedulerPolicy, moduleAttemptCounts, lockedModule } = sharedState;
   const caller = loadedData.caller;
   const learnerGoals = loadedData.goals;
   const identitySpec = resolvedSpecs.identitySpec;
@@ -534,37 +534,22 @@ registerTransform("computeQuickStart", (
       // touching unrelated callers in this file.
       const injectSubject = sanitiseWelcome;
 
-      // 0a. #274 Slice B / #1367: locked-module opening — highest priority.
-      // The learner has explicitly picked a module via the Module Picker.
-      // Return a LITERAL greeting (VAPI speaks `first_line` verbatim as
-      // assistant.firstMessage). The system-prompt body already carries
-      // "lockedModule.name" and the "don't ask what they want to work on"
-      // intent — the AI doesn't need a meta-instruction inside the line
-      // it's literally going to say out loud.
-      // Pre-#1367 this returned the directive text starting with "The
-      // learner has picked..." which VAPI dutifully spoke aloud as the
-      // greeting — surfaced live 2026-06-08 on /x/sim Peter Parker call.
-      if (lockedModule) {
-        const namePart = caller?.name ? ` ${caller.name}` : "";
-        return `Hi${namePart}! Let's get into "${lockedModule.name}".`;
-      }
-
-      // 0b. #266 Slice 1 / #1367: module-progress opening for authored
-      // courses with attempt history. Same bug class as 0a — was returning
-      // an AI directive instead of a literal opening. The directive ("open
-      // by referencing progress") belongs in the system prompt body, not
-      // in the literal-spoken greeting. Keep first_line short and warm;
-      // let TUT-001 persona + the Module-progress prompt section drive
-      // the actual referencing.
-      if (
-        !isFirstCall &&
-        pbConfig.modulesAuthored === true &&
-        hasAttemptData === true &&
-        modules.length > 0
-      ) {
-        const namePart = caller?.name ? ` ${caller.name}` : "";
-        return `Welcome back${namePart}!`;
-      }
+      // #1385 — rollback of #1367. Locked-module and module-progress
+      // branches previously short-circuited with hardcoded literal
+      // greetings ("Hi ${name}! Let's get into ${module}.", "Welcome
+      // back ${name}!"). Those literals intercepted BEFORE the
+      // configurable cascade (identity spec, phase-derived #1195,
+      // course-scoped welcome, generic fallback) could fire, making the
+      // greeting un-customisable from Course Design and breaking the
+      // "Configuration over Code" contract.
+      //
+      // After rollback: the cascade below handles every case. The
+      // system-prompt body still carries `lockedModule.name` and the
+      // "don't ask what they want to work on" intent — that's the right
+      // home for those directives, not the literal-spoken greeting.
+      // Mechanically enforced by `hf-compose/no-hardcoded-greeting-in-
+      // composition` (severity `error`). See `.claude/rules/pipeline-
+      // and-prompt.md` MANDATORY rule.
 
       // 1. Identity spec instruction (highest priority — persona spec)
       const identityOpening = (identitySpec?.config as SpecConfig)?.sessionStructure?.opening?.instruction;

--- a/apps/admin/lib/voice/build-assistant-config.ts
+++ b/apps/admin/lib/voice/build-assistant-config.ts
@@ -32,6 +32,10 @@ import { getVoiceCallSettings } from "@/lib/system-settings";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
 import { loadResolvedVoiceConfig } from "@/lib/voice/load-voice-config";
 import { flatten as flattenVoice } from "@/lib/voice/config";
+import {
+  UNKNOWN_CALLER_FIRST_LINE,
+  noActivePromptFirstLine,
+} from "@/lib/prompt/composition/defaults/fallback-first-lines";
 import type { ProviderAssistantConfig } from "@/lib/voice/types";
 
 export interface BuildAssistantOptions {
@@ -118,7 +122,7 @@ export async function buildAssistantConfigForCaller(
       callerName: null,
       customerPhone: null,
       voicePrompt: vs.unknownCallerPrompt,
-      firstLine: "Hello! I don't think we've spoken before. What's your name?",
+      firstLine: UNKNOWN_CALLER_FIRST_LINE,
       toolDefinitions: [],
       knowledgePlanEnabled: false,
       serverUrlBase,
@@ -174,7 +178,7 @@ export async function buildAssistantConfigForCaller(
       callerName: caller.name,
       customerPhone: caller.phone,
       voicePrompt: fallbackPrompt,
-      firstLine: `Hi${caller.name ? ` ${caller.name}` : ""}! Good to hear from you.`,
+      firstLine: noActivePromptFirstLine(caller.name),
       toolDefinitions: [],
       knowledgePlanEnabled: false,
       serverUrlBase,

--- a/apps/admin/lib/voice/route-handlers.ts
+++ b/apps/admin/lib/voice/route-handlers.ts
@@ -62,6 +62,10 @@ import { isSessionModelV2Enabled } from "@/lib/voice/session-flag";
 import { createSession } from "@/lib/voice/create-session";
 import { endSession } from "@/lib/voice/end-session";
 import { broadcastToCall } from "@/lib/voice/sse-registry";
+import {
+  UNKNOWN_CALLER_FIRST_LINE,
+  noActivePromptFirstLine,
+} from "@/lib/prompt/composition/defaults/fallback-first-lines";
 import { log } from "@/lib/logger";
 
 // `getVoiceSystemSettings` is imported for the existing cost-cap
@@ -1308,7 +1312,7 @@ export async function handleVoiceAssistantRequestPost(
           callerName: null,
           customerPhone: normalizedPhone,
           voicePrompt: vs.unknownCallerPrompt,
-          firstLine: "Hello! I don't think we've spoken before. What's your name?",
+          firstLine: UNKNOWN_CALLER_FIRST_LINE,
           toolDefinitions: [],
           knowledgePlanEnabled: false,
           serverUrlBase,
@@ -1354,7 +1358,7 @@ export async function handleVoiceAssistantRequestPost(
           callerName: caller.name,
           customerPhone: normalizedPhone,
           voicePrompt: `${vs.noActivePromptFallback} The caller is ${callerLabel}.`,
-          firstLine: `Hi${caller.name ? ` ${caller.name}` : ""}! Good to hear from you.`,
+          firstLine: noActivePromptFirstLine(caller.name),
           toolDefinitions: [],
           knowledgePlanEnabled: false,
           serverUrlBase,

--- a/apps/admin/tests/eslint-rules/no-hardcoded-greeting-in-composition.test.ts
+++ b/apps/admin/tests/eslint-rules/no-hardcoded-greeting-in-composition.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for `eslint-rules/no-hardcoded-greeting-in-composition.mjs`
+ * (#1384 / #1385). Pins:
+ *   - rule fires on literal + template greeting in guarded paths
+ *   - rule covers all three guarded path fragments (transforms/,
+ *     build-assistant-config.ts, route-handlers.ts)
+ *   - rule does NOT fire under `lib/prompt/composition/defaults/`
+ *     (the allow-listed system-default template home)
+ *   - rule does NOT fire on identifier-referenced greeting (i.e. the
+ *     post-rollback shape where literals are imported from defaults/)
+ *   - rule covers all six ASSIGNMENT_TARGETS (first_line, firstLine,
+ *     firstMessage, voicePrompt, openingLine, greeting)
+ *   - rule fires in Property positions (object-literal config payloads)
+ *     in addition to VariableDeclarator / AssignmentExpression /
+ *     ReturnStatement
+ *
+ * Uses ESLint's RuleTester with synthetic file paths matching the
+ * guarded + allow-listed path fragments so the rule's `isGuardedFile`
+ * helper picks them up.
+ */
+
+import { RuleTester } from "eslint";
+import rule from "../../eslint-rules/no-hardcoded-greeting-in-composition.mjs";
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+// Synthetic paths under each guarded + allow-listed fragment.
+const GUARDED_TRANSFORM = "/repo/lib/prompt/composition/transforms/quickstart.ts";
+const GUARDED_BUILDER = "/repo/lib/voice/build-assistant-config.ts";
+const GUARDED_ROUTE_HANDLER = "/repo/lib/voice/route-handlers.ts";
+const ALLOWED_DEFAULTS =
+  "/repo/lib/prompt/composition/defaults/fallback-first-lines.ts";
+const UNGUARDED_OTHER = "/repo/lib/voice/some-other-file.ts";
+
+tester.run("no-hardcoded-greeting-in-composition", rule as never, {
+  valid: [
+    // Identifier reference (the post-rollback shape — literal lives in
+    // defaults/, imported by name) — pass through in guarded paths.
+    {
+      filename: GUARDED_BUILDER,
+      code: `
+        import { UNKNOWN_CALLER_FIRST_LINE } from "@/lib/prompt/composition/defaults/fallback-first-lines";
+        const x = { firstLine: UNKNOWN_CALLER_FIRST_LINE };
+      `,
+    },
+    // Function-call reference (interpolated helper from defaults/).
+    {
+      filename: GUARDED_BUILDER,
+      code: `
+        import { noActivePromptFirstLine } from "@/lib/prompt/composition/defaults/fallback-first-lines";
+        const x = { firstLine: noActivePromptFirstLine("Peter") };
+      `,
+    },
+    // Non-greeting literal in guarded path — pass through.
+    {
+      filename: GUARDED_TRANSFORM,
+      code: `const firstLine = "We're going to be working on this together.";`,
+    },
+    // Greeting literal under defaults/ (allow-listed home) — pass through.
+    {
+      filename: ALLOWED_DEFAULTS,
+      code: `export const UNKNOWN_CALLER_FIRST_LINE = "Hello! What's your name?";`,
+    },
+    // Greeting literal in an UNGUARDED path — pass through.
+    // (The rule only fires inside `GUARDED_PATH_FRAGMENTS`.)
+    {
+      filename: UNGUARDED_OTHER,
+      code: `const firstLine = "Hi there! Good to hear from you.";`,
+    },
+    // Non-greeting object property in a guarded path — pass through.
+    {
+      filename: GUARDED_BUILDER,
+      code: `const x = { voicePrompt: "You are a tutor. Stay on topic." };`,
+    },
+  ],
+  invalid: [
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #1 — transforms/
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: GUARDED_TRANSFORM,
+      code: 'function f() { return "Hi there! Let\'s get into it."; }',
+      errors: [{ messageId: "hardcoded" }],
+    },
+    {
+      filename: GUARDED_TRANSFORM,
+      code: "function f(name) { return `Welcome back ${name}!`; }",
+      errors: [{ messageId: "hardcoded" }],
+    },
+    {
+      filename: GUARDED_TRANSFORM,
+      code: 'function f() { return "Good morning! What\'s on your mind?"; }',
+      errors: [{ messageId: "hardcoded" }],
+    },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #2 — build-assistant-config.ts
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: GUARDED_BUILDER,
+      code: 'const x = { firstLine: "Hello! What is your name?" };',
+      errors: [{ messageId: "hardcoded" }],
+    },
+    {
+      filename: GUARDED_BUILDER,
+      code: "const x = { first_line: `Hi ${name}!` };",
+      errors: [{ messageId: "hardcoded" }],
+    },
+    {
+      filename: GUARDED_BUILDER,
+      code: 'const firstMessage = "Hey there! Good to meet you.";',
+      errors: [{ messageId: "hardcoded" }],
+    },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #3 — route-handlers.ts (TL-added in #1385)
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: GUARDED_ROUTE_HANDLER,
+      code: 'const x = { firstLine: "Hello, friend! Welcome aboard." };',
+      errors: [{ messageId: "hardcoded" }],
+    },
+    {
+      filename: GUARDED_ROUTE_HANDLER,
+      code: "const x = { firstLine: `Welcome back ${user.name}!` };",
+      errors: [{ messageId: "hardcoded" }],
+    },
+
+    // ────────────────────────────────────────────────────────────────────
+    // All ASSIGNMENT_TARGETS keys — Property + VariableDeclarator paths
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: GUARDED_BUILDER,
+      code: 'const x = { openingLine: "Hi there." };',
+      errors: [{ messageId: "hardcoded" }],
+    },
+    {
+      filename: GUARDED_BUILDER,
+      code: 'const x = { greeting: "Hello, learner." };',
+      errors: [{ messageId: "hardcoded" }],
+    },
+    {
+      filename: GUARDED_BUILDER,
+      code: 'const voicePrompt = "Welcome! Let\'s begin.";',
+      errors: [{ messageId: "hardcoded" }],
+    },
+  ],
+});

--- a/apps/admin/tests/lib/prompt/composition/fallback-first-lines.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/fallback-first-lines.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for `lib/prompt/composition/defaults/fallback-first-lines.ts`
+ * (#1385). Pins the contract that the rehomed voice-fallback literals
+ * stay byte-equal to what shipped pre-rollback — so VAPI behaviour is
+ * net-zero — and that the `noActivePromptFirstLine` interpolation
+ * handles name presence/absence the same way the inline templates did.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  UNKNOWN_CALLER_FIRST_LINE,
+  noActivePromptFirstLine,
+} from "@/lib/prompt/composition/defaults/fallback-first-lines";
+
+describe("UNKNOWN_CALLER_FIRST_LINE", () => {
+  it("is the byte-equal string the inline literals used pre-rollback", () => {
+    expect(UNKNOWN_CALLER_FIRST_LINE).toBe(
+      "Hello! I don't think we've spoken before. What's your name?",
+    );
+  });
+
+  it("is a non-empty string (VAPI dead-airs on empty firstMessage)", () => {
+    expect(UNKNOWN_CALLER_FIRST_LINE.length).toBeGreaterThan(0);
+  });
+});
+
+describe("noActivePromptFirstLine", () => {
+  it("emits the name-bearing greeting when a name is supplied", () => {
+    expect(noActivePromptFirstLine("Peter")).toBe(
+      "Hi Peter! Good to hear from you.",
+    );
+  });
+
+  it("emits the no-name greeting when name is null", () => {
+    expect(noActivePromptFirstLine(null)).toBe("Hi! Good to hear from you.");
+  });
+
+  it("emits the no-name greeting when name is undefined", () => {
+    expect(noActivePromptFirstLine(undefined)).toBe(
+      "Hi! Good to hear from you.",
+    );
+  });
+
+  it("emits the no-name greeting when name is an empty string", () => {
+    expect(noActivePromptFirstLine("")).toBe("Hi! Good to hear from you.");
+  });
+
+  it("preserves the name with whitespace+punctuation pattern the original used", () => {
+    // The pre-rollback template was:
+    //   `Hi${caller.name ? ` ${caller.name}` : ""}! Good to hear from you.`
+    // Net-zero check: single space before the name, exclamation immediately
+    // after, full sentence terminator at the end.
+    const out = noActivePromptFirstLine("Bertie Tallstaff");
+    expect(out).toBe("Hi Bertie Tallstaff! Good to hear from you.");
+    expect(out.startsWith("Hi ")).toBe(true);
+    expect(out.endsWith(".")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Drops 6 hardcoded learner-facing greeting literals that intercepted BEFORE the configurable cascade (Configuration over Code violation).
- Rehomes voice-fallback literals (unknown caller, no active prompt) under `lib/prompt/composition/defaults/fallback-first-lines.ts` — the allow-listed system-default template home.
- Adds `lib/voice/route-handlers.ts` to the guard scope (TL caught two extra offences out of original #1384 scope).
- Promotes `hf-compose/no-hardcoded-greeting-in-composition` from warn → error. "Halt, don't accumulate" — any new literal now fails CI.

## What changed

| Offence | Before | After |
|---------|--------|-------|
| `quickstart.ts:549` (locked-module) | `\`Hi \${name}! Let's get into "\${module}".\`` | branch dropped — cascade handles |
| `quickstart.ts:566` (returning) | `\`Welcome back \${name}!\`` | branch dropped — cascade handles |
| `build-assistant-config.ts:121` | inline literal | imports `UNKNOWN_CALLER_FIRST_LINE` |
| `build-assistant-config.ts:177` | inline template | imports `noActivePromptFirstLine()` |
| `route-handlers.ts:1204` | inline literal | imports `UNKNOWN_CALLER_FIRST_LINE` |
| `route-handlers.ts:1250` | inline template | imports `noActivePromptFirstLine()` |
| eslint rule | `warn` | `error` |
| guard scope | 2 paths | 3 paths (+ route-handlers.ts) |

## Why

Live incident 2026-06-08 on /x/sim Peter Parker call: the #1367 "fix" hardcoded `\`Hi Peter Parker! Let's get into "..."\`` in `quickstart.ts::first_line()`, which intercepted the educator's onboardingFlowPhases phase-0 cascade (#1195) and made the greeting un-tunable from Course Design.

Root cause: the configurable cascade already exists. Nobody searched for it before editing the transform. Two architectural rules broken in one 2-line PR:
- "Configuration over Code" (CLAUDE.md)
- chain-contracts.md Link 3 sub-contract "COMPOSE → LLM" (output invariants)

This PR + the discipline rule landed in `37d2515f` (`.claude/rules/pipeline-and-prompt.md` "Search before editing") close the gap end-to-end.

## Test plan

- [x] `npx tsc --noEmit` — clean on changed files
- [x] `npx eslint lib/voice/route-handlers.ts lib/voice/build-assistant-config.ts lib/prompt/composition/transforms/quickstart.ts lib/prompt/composition/defaults/fallback-first-lines.ts` — 0 errors
- [x] `npx eslint --print-config lib/voice/route-handlers.ts | grep no-hardcoded-greeting` confirms severity `2` (error)
- [ ] Manual smoke on /x/sim — Peter Parker first call now uses phase-derived opening from playbook's `onboardingFlowPhases` (visible in compose-prompt route's first-line trace)

Closes #1385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)