### PR TITLE
fix(#1341): backfill uses ROW_NUMBER for sequenceNumber (not COALESCE)

### DIFF
--- a/apps/admin/prisma/migrations/20260608165135_1341_session_schema/migration.sql
+++ b/apps/admin/prisma/migrations/20260608165135_1341_session_schema/migration.sql
@@ -146,11 +146,13 @@ CREATE INDEX "ComposedPrompt_triggerSessionId_idx"
 
 -- =================================================================
 -- Step 6a — Backfill: one Session row per Call row.
--- Sequence assignment uses COALESCE(callSequence, ROW_NUMBER OVER ...).
--- Tie-break (per kind) on createdAt ASC, id ASC for determinism. The
--- ROW_NUMBER fallback only fires when callSequence is NULL on the
--- legacy Call row (which is the historical happy path, plus the few
--- ghost rows the epic was named after).
+-- Sequence assignment uses ROW_NUMBER unconditionally — the legacy
+-- `Call.callSequence` is NOT unique per (callerId, source) (sim test
+-- loops reset it to 1 repeatedly), so COALESCE(callSequence, …) would
+-- violate `Session_callerId_kind_sequenceNumber_key`. The original
+-- callSequence value is preserved in `learnerFacingNumber`, which has
+-- no unique constraint and may carry duplicates / NULLs.
+-- Tie-break (per kind) on createdAt ASC, id ASC for determinism.
 -- =================================================================
 
 WITH ranked AS (
@@ -169,18 +171,15 @@ WITH ranked AS (
       WHEN 'sim'  THEN 'SIM_CALL'::"SessionKind"
       ELSE             'VOICE_CALL'::"SessionKind"
     END AS kind,
-    COALESCE(
-      c."callSequence",
-      ROW_NUMBER() OVER (
-        PARTITION BY c."callerId",
-          CASE c.source
-            WHEN 'vapi' THEN 'VOICE_CALL'
-            WHEN 'sim'  THEN 'SIM_CALL'
-            ELSE             'VOICE_CALL'
-          END
-        ORDER BY c."createdAt", c.id
-      )::int
-    ) AS seq
+    ROW_NUMBER() OVER (
+      PARTITION BY c."callerId",
+        CASE c.source
+          WHEN 'vapi' THEN 'VOICE_CALL'
+          WHEN 'sim'  THEN 'SIM_CALL'
+          ELSE             'VOICE_CALL'
+        END
+      ORDER BY c."createdAt", c.id
+    )::int AS seq
   FROM "Call" c
   WHERE c."callerId" IS NOT NULL
     AND NOT EXISTS (
@@ -227,28 +226,55 @@ FROM ranked r;
 
 -- =================================================================
 -- Step 6b — Wire Call.sessionId to the newly-created Session row.
--- Join key: (callerId, startedAt = createdAt, sequenceNumber = COALESCE).
--- The sequenceNumber tie-breaker disambiguates Calls that share the same
--- createdAt timestamp for the same caller (ghost-row duplicates).
+-- Join key: (callerId, startedAt = createdAt) — paired by row-number
+-- to handle Calls that share the same createdAt timestamp for the same
+-- caller (ghost-row duplicates). We can no longer use sequenceNumber
+-- as a join key because Step 6a now always re-numbers via ROW_NUMBER
+-- (the old COALESCE assumed callSequence was unique per kind, which
+-- doesn't hold — sim test loops produce many callSequence=1 rows).
 -- =================================================================
 
+WITH unmatched AS (
+  SELECT
+    c.id AS call_id,
+    c."callerId",
+    c."createdAt",
+    ROW_NUMBER() OVER (
+      PARTITION BY c."callerId", c."createdAt"
+      ORDER BY c.id
+    ) AS rn
+  FROM "Call" c
+  WHERE c."sessionId" IS NULL AND c."callerId" IS NOT NULL
+),
+candidates AS (
+  SELECT
+    s.id AS session_id,
+    s."callerId",
+    s."startedAt",
+    ROW_NUMBER() OVER (
+      PARTITION BY s."callerId", s."startedAt"
+      ORDER BY s."sequenceNumber"
+    ) AS rn
+  FROM "Session" s
+  WHERE NOT EXISTS (SELECT 1 FROM "Call" c WHERE c."sessionId" = s.id)
+)
 UPDATE "Call" c
-SET "sessionId" = s.id
-FROM "Session" s
-WHERE c."sessionId" IS NULL
-  AND s."callerId" = c."callerId"
-  AND s."startedAt" = c."createdAt"
-  AND s."sequenceNumber" = COALESCE(
-        c."callSequence",
-        s."sequenceNumber" -- when both NULL, the ROW_NUMBER fallback
-                            -- in step 6a wrote the same value into both
-                            -- columns via the CTE
-      );
+SET "sessionId" = pick.session_id
+FROM (
+  SELECT u.call_id, x.session_id
+  FROM unmatched u
+  JOIN candidates x
+    ON x."callerId" = u."callerId"
+   AND x."startedAt" = u."createdAt"
+   AND x.rn = u.rn
+) pick
+WHERE c.id = pick.call_id;
 
 -- Last-resort fallback: any Call row whose sessionId is still NULL is
--- linked to its caller's earliest UNLINKED Session (sequenceNumber ASC).
--- This handles the corner-case where two ghost Calls share the same
--- (callerId, createdAt) and only one matched in the prior UPDATE.
+-- linked to its caller's earliest UNLINKED Session by sequenceNumber.
+-- Defends against any (callerId, createdAt) where row-counts mismatch
+-- between unmatched and candidates (shouldn't happen post-fix; kept
+-- for paranoia).
 WITH unmatched AS (
   SELECT c.id AS call_id, c."callerId", c."createdAt"
   FROM "Call" c


### PR DESCRIPTION
## Summary

Slice 0 (#1341) migration backfill failed on hf_sandbox due to a unique-constraint violation in the Session.sequenceNumber assignment.

## Root cause

`COALESCE(callSequence, ROW_NUMBER)` returns the same value when multiple Calls share `callSequence=1`, violating `@@unique([callerId, kind, sequenceNumber])`. Real distribution on sandbox: 4 callers each have 4 sim Calls with `callSequence=1`.

## Fix

- **Step 6a**: always use `ROW_NUMBER() OVER (PARTITION BY callerId, kind ORDER BY createdAt, id)` for `sequenceNumber`. Preserve original `callSequence` in `learnerFacingNumber` (no unique constraint there — duplicates and NULLs allowed).
- **Step 6b**: rewrite the `Call.sessionId` wire-up to pair `(callerId, startedAt)` matches by row-number, since the post-fix `sequenceNumber` no longer equals the legacy `callSequence` and can't be used as a join key. The existing last-resort fallback (lines 273+) stays as belt-and-braces.

## Verified locally

Ran the migration against a Postgres scaffold seeded with the exact failure pattern (4 sim Calls, all `callSequence=1`, same caller) plus a happy-path control (sequential `callSequence`, one NULL):

- Failure scenario: 9 Sessions written, all 9 Calls wired, zero duplicate `(callerId, kind, sequenceNumber)` triplets, `CallerSequenceCounter.nextSeq = MAX + 1` per pair.
- Happy path: sequential 1..4, `learnerFacingNumber` preserved (NULL for the legacy NULL row).

## Test plan

- [x] Migration SQL parses cleanly (Postgres 18 local)
- [x] Repro scenario (4 sim Calls, callSequence=1) succeeds with unique-constraint intact
- [x] Happy-path scenario (sequential callSequence + 1 NULL) preserves data
- [ ] After merge: `prisma migrate resolve --rolled-back` clears failed state on hf_sandbox
- [ ] After merge: `prisma migrate deploy` applies clean
- [ ] Session row count = Call row count on hf_sandbox