### PR TITLE
feat(voice): #1391 pipe requestedModuleId from URL → SimChat → call-start

### DIFF
--- a/apps/admin/app/api/voice/calls/start/route.ts
+++ b/apps/admin/app/api/voice/calls/start/route.ts
@@ -27,6 +27,13 @@ const bodySchema = z
      *  per-session override is NOT persisted on Caller — that's
      *  what the per-caller setting is for. */
     overrideProviderSlug: z.string().min(1).max(64).optional(),
+    /** #1391 — module slug the learner picked (via `?requestedModuleId=`
+     *  in the sim URL or `Caller.lastSelectedModuleId`). Forwarded to
+     *  `createCallEnteringPipeline` so the placeholder Call carries the
+     *  picked module from creation. Without this the WebRTC path
+     *  dropped the param at the SimChat boundary and the call entered
+     *  the pipeline with `requestedModuleId = null`. */
+    requestedModuleId: z.string().min(1).max(128).optional(),
   })
   .strict();
 
@@ -53,6 +60,7 @@ const bodySchema = z
  *   callerId: string,
  *   intent?: "chat" | "audio-only",
  *   overrideProviderSlug?: string,
+ *   requestedModuleId?: string,
  * }
  * @response 200 {
  *   ok: true,
@@ -162,6 +170,13 @@ export async function POST(request: Request) {
       callerId: caller.id,
       source: providerSlug,
       voiceProvider: providerSlug,
+      // #1391 — explicit module hint beats the
+      // `Caller.lastSelectedModuleId` fallback inside the builder, so a
+      // mid-session URL change picks up the new module on the very next
+      // [Talk Here] click rather than the previous pick.
+      ...(parsed.data.requestedModuleId
+        ? { requestedModuleId: parsed.data.requestedModuleId }
+        : {}),
     });
     const placeholderCall = entry.call;
     if (entry.playbookId && entry.requestedModuleId) {

--- a/apps/admin/app/api/voice/calls/start/route.ts
+++ b/apps/admin/app/api/voice/calls/start/route.ts
@@ -15,7 +15,7 @@ import { createCallEnteringPipeline } from "@/lib/voice/create-call-entering-pip
 
 export const runtime = "nodejs";
 
-const bodySchema = z
+export const bodySchema = z
   .object({
     callerId: z.string().min(1),
     /** Intent hint — populates `runtime.hasChatRail` optimistically at

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -283,10 +283,17 @@ export function SimChat({
   // #1092 — provider-backed "Call me" mixed mode. Lazy-imports the
   // VAPI Web SDK on first click; opens an SSE stream keyed on Call.id
   // and pushes incoming events into the chat surface as messages.
+  //
+  // #1391 — forward `requestedModuleId` to the call-start route so the
+  // placeholder Call carries the learner's picked module from the very
+  // first event. Without this, the URL param was dropped at the
+  // SimChat → useProviderCall boundary and the call entered the
+  // pipeline with `requestedModuleId = null`, defeating the picker.
   const providerCall = useProviderCall({
     callerId,
     intent: 'chat',
     onSseEvent: handleVoiceSseEvent,
+    requestedModuleId: requestedModuleId ?? undefined,
   });
 
   // PSTN [Call me] hook — separate from the browser WebRTC [Talk Here]

--- a/apps/admin/components/sim/useProviderCall.ts
+++ b/apps/admin/components/sim/useProviderCall.ts
@@ -97,6 +97,15 @@ interface UseProviderCallOptions {
   callerId: string;
   intent?: "chat" | "audio-only";
   overrideProviderSlug?: string;
+  /**
+   * #1391 — module slug the learner picked (via URL `?requestedModuleId=`
+   * or `Caller.lastSelectedModuleId`). Forwarded to /api/voice/calls/start
+   * so `createCallEnteringPipeline` attributes the placeholder Call with
+   * `requestedModuleId` + `curriculumModuleId` at creation time, before
+   * any pipeline event fires. Without this the URL param was dropped at
+   * the hook boundary.
+   */
+  requestedModuleId?: string;
   onSseEvent?: (event: VoiceCallSseEvent) => void;
 }
 
@@ -216,6 +225,9 @@ export function useProviderCall(
           ...(options.overrideProviderSlug
             ? { overrideProviderSlug: options.overrideProviderSlug }
             : {}),
+          ...(options.requestedModuleId
+            ? { requestedModuleId: options.requestedModuleId }
+            : {}),
         }),
       });
       const body = (await res.json()) as ProviderCallStartResponse;
@@ -302,7 +314,7 @@ export function useProviderCall(
       setStatus("error");
       await teardown();
     }
-  }, [openSse, options.callerId, options.intent, options.overrideProviderSlug, teardown]);
+  }, [openSse, options.callerId, options.intent, options.overrideProviderSlug, options.requestedModuleId, teardown]);
 
   useEffect(() => {
     return () => {

--- a/apps/admin/tests/api/voice-calls-start-body-schema.test.ts
+++ b/apps/admin/tests/api/voice-calls-start-body-schema.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for `POST /api/voice/calls/start` body schema (#1391).
+ *
+ * Pins the schema-level contract for the WebRTC picker pipe-through:
+ *
+ *   - `requestedModuleId` is optional (not required for legacy callers)
+ *   - when present, it's a 1–128-char string forwarded to
+ *     `createCallEnteringPipeline` (`callerId,requestedModuleId` cascade)
+ *   - bad shapes are rejected:
+ *       - empty string  (min(1))
+ *       - >128 chars    (max(128))
+ *       - non-string    (z.string())
+ *   - strict() rejects unknown fields, so an accidental misspelling
+ *     (`moduleId` etc.) doesn't silently pass through
+ *
+ * This is the unit gate — the route's behavioural test (the builder
+ * actually receives the field) is covered by manual smoke until a
+ * route-level integration suite lands.
+ */
+
+import { describe, expect, it } from "vitest";
+import { bodySchema } from "@/app/api/voice/calls/start/route";
+
+describe("POST /api/voice/calls/start — body schema (#1391)", () => {
+  it("accepts a body without requestedModuleId (back-compat)", () => {
+    const r = bodySchema.safeParse({ callerId: "abc" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.requestedModuleId).toBeUndefined();
+    }
+  });
+
+  it("accepts a body with requestedModuleId as a slug", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      requestedModuleId: "part-1-familiar-topics",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.requestedModuleId).toBe("part-1-familiar-topics");
+    }
+  });
+
+  it("accepts a body with requestedModuleId as a UUID-shaped id", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      requestedModuleId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an empty-string requestedModuleId (min length 1)", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      requestedModuleId: "",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a requestedModuleId >128 chars", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      requestedModuleId: "x".repeat(129),
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a non-string requestedModuleId", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      requestedModuleId: 42 as unknown as string,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("strict() blocks `moduleId` misspelling (catches future typos)", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      moduleId: "part-1-familiar-topics",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("strict() blocks `requested_module_id` snake_case (wrong casing)", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      requested_module_id: "part-1-familiar-topics",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("requestedModuleId combines with intent + overrideProviderSlug", () => {
+    const r = bodySchema.safeParse({
+      callerId: "abc",
+      intent: "chat",
+      overrideProviderSlug: "vapi",
+      requestedModuleId: "module-2",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data).toMatchObject({
+        callerId: "abc",
+        intent: "chat",
+        overrideProviderSlug: "vapi",
+        requestedModuleId: "module-2",
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- The sim URL accepts `?requestedModuleId=` and `page.tsx` resolves it correctly, but SimChat dropped it at the `useProviderCall` boundary. Result: WebRTC `[Talk Here]` calls entered the pipeline with `requestedModuleId = null`, defeating the Module Picker.
- The builder `createCallEnteringPipeline` already accepts `requestedModuleId` (#1333). Only the wire / hook surface was missing. This PR adds the three plumbing edits.

## What changed

| Layer | Before | After |
|-------|--------|-------|
| `app/api/voice/calls/start/route.ts` `bodySchema` | no field | `requestedModuleId?: string` (1–128 chars) |
| `app/api/voice/calls/start/route.ts` builder call | no arg | spreads `requestedModuleId` when present |
| `components/sim/useProviderCall.ts` options | no field | `requestedModuleId?: string` |
| `components/sim/useProviderCall.ts` POST body | no field | spreads `requestedModuleId` when present + adds to deps array |
| `components/sim/SimChat.tsx` hook call | dropped prop | passes `requestedModuleId ?? undefined` |

## Why

Confirmed live as one of the three known issues blocking the operator's next test pass. The Module Picker visibly worked (URL changes, breadcrumb updates) but the call entered the pipeline with no module attribution because the URL param never crossed the WebRTC `[Talk Here]` boundary — only the PSTN dial-in path carried it through `outboundDial` correctly.

The explicit-arg cascade in `createCallEnteringPipeline` (explicit arg → `Caller.lastSelectedModuleId` → null) now resolves correctly because the URL choice reaches the explicit-arg slot. Without this fix the builder always fell through to G6 default-module resolution, ignoring the picker.

## Stacking note

This branch is currently stacked on PR #1390 (the #1385 rollback) because the local lock-enforcer blocked switching to main from this concurrent claude session. Diff renders correctly against `main` after #1390 merges; rebase is a no-op.

## Test plan

- [x] `npx tsc --noEmit` — clean on changed files
- [x] `npx eslint app/api/voice/calls/start/route.ts components/sim/useProviderCall.ts components/sim/SimChat.tsx` — 0 errors
- [ ] Manual smoke on /x/sim with `?requestedModuleId=<slug>` — click [Talk Here]; verify `Call.requestedModuleId` populated in the DB matches the URL slug (pipeline trace shows the picked module name in the first-line opening when the cascade reaches the locked-module branch in the system prompt body, not the literal greeting)

Closes #1391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)