### PR TITLE
chore(kb): close the self-maintaining loop — CI gate + pre-commit auto-regen

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -140,4 +140,40 @@ apps/admin/docs-archive/bdd-specs/*)
   fi
 fi
 
+# 6) Auto-regen the KB Tier-2 generated facts when their inputs change.
+#    Schema edits → model-map; route edits → route-inventory; overrides
+#    edits → model-map. Adds the regenerated JSON to the same commit so
+#    the CI freshness gate (kb:check, .github/workflows/test.yml) passes
+#    without a follow-up commit. Non-blocking on failure. See docs/kb/README.md.
+if command -v npx >/dev/null 2>&1; then
+  schema_changed="0"
+  routes_changed="0"
+  while IFS= read -r f; do
+    case "$f" in
+      apps/admin/prisma/schema.prisma|docs/kb/model-map-overrides.json)
+        schema_changed="1" ;;
+      apps/admin/app/api/*route.ts)
+        routes_changed="1" ;;
+    esac
+  done <<< "${STAGED_FILES}"
+
+  if [[ "$schema_changed" == "1" ]]; then
+    echo "[pre-commit] Regenerating docs/kb/generated/model-map.json..."
+    if (cd apps/admin && npx tsx scripts/capture/model-map.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/model-map.json
+    else
+      echo "[pre-commit] ⚠ model-map regen failed (non-blocking). Run: cd apps/admin && npm run kb:model-map"
+    fi
+  fi
+
+  if [[ "$routes_changed" == "1" ]]; then
+    echo "[pre-commit] Regenerating docs/kb/generated/route-inventory.json..."
+    if (cd apps/admin && npx tsx scripts/capture/route-inventory.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/route-inventory.json
+    else
+      echo "[pre-commit] ⚠ route-inventory regen failed (non-blocking). Run: cd apps/admin && npm run kb:routes"
+    fi
+  fi
+fi
+
 exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,15 @@ jobs:
       - name: AI-CAPABILITIES.md drift guard
         run: npm run docs:ai-capabilities:check
 
+      # KB integrity. Blocking. Runs the meta-ratchet that holds every
+      # custom ESLint rule pointing back at its guard-registry anchor
+      # (check-guard-kb-links.ts), and the freshness check that fails
+      # if docs/kb/generated/*.json drifted from the schema/route walk
+      # (check-kb-fresh.sh, ignores the volatile generatedAt). See
+      # docs/kb/README.md. Same one-liner as `ctl check` step 8/8.
+      - name: KB integrity (guard back-links + generated-fact freshness)
+        run: npm run kb:check
+
   # Job 2: Unit Tests
   unit-tests:
     name: Unit Tests

--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -82,12 +82,20 @@ re-derived on every run.
 - **What is true & enforced?** → this KB (authoritative, curated).
 - **Query the facts** → `jq` over `docs/kb/generated/*.json`.
 
-## Drift discipline (wired)
+## Drift discipline (self-maintaining loop)
 
-Tier-2 JSON is committed; `npm run kb:check` (step **8/8** of `npm run ctl check`) re-runs
-the generators and fails if the committed facts are stale — ignoring the volatile
-`generatedAt` line (`git diff -I`). Same spirit as `check-fk-consistency` (step 5).
-The meta-ratchet `check-guard-kb-links.ts` holds ESLint→KB back-links at 10/10.
+The KB integrity gate fires at **three** points; together they make it self-maintaining:
+
+| When | What | Result |
+|---|---|---|
+| **Pre-commit** | `.githooks/pre-commit` § 6 auto-regenerates `model-map.json` if `schema.prisma` or `model-map-overrides.json` is staged, and `route-inventory.json` if any `app/api/**/route.ts` is staged. Regen'd JSON is `git add`-ed to the same commit. | Drift never reaches a commit in the common case. |
+| **Local** (manual) | `npm run kb:check` (also step **8/8** of `npm run ctl check`) runs the meta-ratchet (`check-guard-kb-links.ts`) + the freshness diff (`check-kb-fresh.sh`, ignores volatile `generatedAt` via `git diff -I`). | Dev confirms before push. |
+| **CI** | `.github/workflows/test.yml` runs `npm run kb:check` as a blocking step in the Lint & Type Check job. | Forgetting all the above still gets caught before merge. |
+
+Tier-2 JSON is committed so a fresh `git diff --exit-code -I '"generatedAt":'` is the
+actual check — same spirit as `check-fk-consistency` (CI step 5). The meta-ratchet
+holds ESLint→KB back-links at the floor (any rule that loses its `meta.docs.url`
+fails CI).
 
 ## The hardening program this feeds
 


### PR DESCRIPTION
## Why

`npm run kb:check` (meta-ratchet + generated-fact freshness) existed but only fired
locally via `ctl check` step 8/8. **CI didn't invoke it** and pre-commit didn't keep
generated facts in step. So the KB wasn't actually self-maintaining — it relied on
discipline.

## What

Closes the loop at **three** trigger points:

| When | What changed | Effect |
|---|---|---|
| **Pre-commit** | `.githooks/pre-commit` § 6 auto-regen | Edit `schema.prisma` → `model-map.json` regen'd + `git add`-ed in the same commit. Edit any `api/**/route.ts` → `route-inventory.json` regen'd. Non-blocking on failure. |
| **Local** | unchanged (`npm run kb:check`, `ctl check` step 8/8) | The dev's pre-push reassurance. |
| **CI** | `.github/workflows/test.yml` new step under Lint & Type Check | `npm run kb:check` runs as a **blocking** gate on every PR. Mirrors `check:fk` / `docs:ai-capabilities:check` / KNOWLEDGE-MAP ratchet patterns. |

## Net behaviour

- Common path: schema edit → pre-commit regen → CI passes silently.
- Forgotten regen: CI catches it before merge.
- Lost guard pointer: `check-guard-kb-links.ts` floor-0 ratchet fails CI.

## README

`docs/kb/README.md` "Drift discipline" section now describes the three trigger points
instead of just local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)