### PR TITLE
chore(hooks): pre-push gate is ratchet-aware (no more HF_SKIP_PREPUSH=1 false positives)

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -7,10 +7,11 @@
 # Four hooks land in .git/hooks/:
 #   pre-commit   — blocks direct commits on main, regenerates API docs,
 #                  fast qmd index update. Slow qmd embed moved out (post-commit).
-#   pre-push     — runs tsc + eslint, FILTERED to only the .ts/.tsx files
-#                  in the commits being pushed (vs upstream). Catches errors
-#                  YOU introduced without fighting the codebase's 200+
-#                  pre-existing tsc errors or mac/linux platform drift.
+#   pre-push     — runs tsc (whole project) + eslint (changed files only).
+#                  Compares tsc error count against .ratchet.json baseline —
+#                  passes if count <= baseline so pre-existing errors in
+#                  touched files don't block routine pushes. Lint errors in
+#                  changed files are always a hard fail (baseline is 0).
 #                  Escape hatch: HF_SKIP_PREPUSH=1 git push ...
 #   post-commit  — runs qmd embed synchronously so the index is consistent
 #                  before the next command starts. ~30s blocking.
@@ -103,10 +104,20 @@ cat > "$HOOK_DIR/pre-push" << 'HOOK'
 # HF pre-push hook (installed by scripts/install-hooks.sh)
 #
 # Why: catch tsc + lint errors YOU introduced before they hit the 5-10 min
-# CI loop. We filter to only `.ts`/`.tsx` files touched in the commits being
-# pushed — so the hook doesn't fight the codebase's 200+ pre-existing
-# tsc errors (schema-rot, see test.yml comments), and doesn't suffer the
-# mac vs linux platform drift that breaks raw `npm run ratchet:check`.
+# CI loop. We filter changed .ts/.tsx files to decide whether to run at all
+# (fast path — no TS changes = skip). When TS changes are present we run
+# tsc on the whole project and compare the TOTAL error count against the
+# .ratchet.json baseline rather than doing a binary pass/fail on changed
+# files. This mirrors what CI's Ratchet check does and avoids false positives
+# when pre-existing errors live in files you legitimately touched.
+#
+# Gate logic:
+#   total tsc errors  >  .ratchet.json baseline  →  FAIL  (you added errors)
+#   total tsc errors  <=  .ratchet.json baseline  →  PASS  (no regression)
+#   .ratchet.json missing                         →  WARN + binary fallback
+#
+# Lint: errors gate on changed files only (lint_errors baseline is 0 so any
+# new error is a regression). Warnings are not gated (too noisy).
 #
 # Pre-push (not pre-commit) so small commits stay fast.
 #
@@ -120,7 +131,7 @@ cat >/dev/null
 
 # Escape hatch.
 if [ "${HF_SKIP_PREPUSH:-0}" = "1" ]; then
-  echo "[pre-push] ⚠ HF_SKIP_PREPUSH=1 — skipping checks. Don't make this a habit."
+  echo "[pre-push] HF_SKIP_PREPUSH=1 — skipping checks. Don't make this a habit."
   exit 0
 fi
 
@@ -142,42 +153,97 @@ fi
 
 cd apps/admin || exit 0
 REL=$(echo "$CHANGED" | sed 's|^apps/admin/||')
+CHANGED_COUNT=$(echo "$REL" | wc -l | tr -d ' ')
 
-# 1) tsc — whole project (type errors cascade), then filter output to your files.
-echo "[pre-push] Running tsc (filtered to $(echo "$REL" | wc -l | tr -d ' ') changed file(s))..."
+# ── 1) tsc — ratchet-aware ──────────────────────────────────────────────────
+echo "[pre-push] Running tsc ($CHANGED_COUNT changed file(s) in push)..."
 TSC_OUT=$(mktemp)
 trap 'rm -f "$TSC_OUT"' EXIT
 npx tsc --noEmit >"$TSC_OUT" 2>&1 || true
 
-# Build a regex of changed file paths; anchor to start of line and require
-# the opening `(` that tsc puts before line:col.
-PATTERN=$(echo "$REL" | sed 's|\.|\\.|g' | paste -sd'|' -)
-NEW_TSC=$(grep -E "^($PATTERN)\(" "$TSC_OUT" || true)
+TSC_ERRORS=$(grep -cE "error TS[0-9]+:" "$TSC_OUT" || true)
 
-if [ -n "$NEW_TSC" ]; then
+# Read baseline from .ratchet.json (two levels up from apps/admin).
+RATCHET_FILE="$REPO_ROOT/.ratchet.json"
+if [ -f "$RATCHET_FILE" ] && command -v node >/dev/null 2>&1; then
+  BASELINE_TSC=$(node -e '
+    try {
+      const j = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+      if (typeof j.tsc_errors === "number") { process.stdout.write(String(j.tsc_errors)); }
+    } catch {}
+  ' "$RATCHET_FILE")
+else
+  BASELINE_TSC=""
+fi
+
+if [ -z "$BASELINE_TSC" ]; then
+  # No baseline — fall back to old behaviour: any tsc error in changed files blocks.
+  echo "[pre-push] Warning: .ratchet.json not found or unreadable — using file-filtered fallback."
+  PATTERN=$(echo "$REL" | sed 's|\.|\\.|g' | paste -sd'|' -)
+  NEW_TSC=$(grep -E "^($PATTERN)\(" "$TSC_OUT" || true)
+  if [ -n "$NEW_TSC" ]; then
+    echo ""
+    echo "  [pre-push] tsc errors in files you're pushing:"
+    echo ""
+    echo "$NEW_TSC" | head -30 | sed 's/^/    /'
+    echo ""
+    echo "  Fix these or set up .ratchet.json (npm run ratchet:init) for ratchet-aware checks."
+    echo "  Override (emergencies only): HF_SKIP_PREPUSH=1 git push ..."
+    echo ""
+    exit 1
+  fi
+  echo "[pre-push] tsc: no errors in changed files (fallback mode)."
+elif [ "$TSC_ERRORS" -gt "$BASELINE_TSC" ]; then
+  DELTA=$((TSC_ERRORS - BASELINE_TSC))
   echo ""
-  echo "  [pre-push] ✗ tsc errors in files you're pushing:"
+  echo "  [pre-push] tsc errors increased: $TSC_ERRORS (baseline $BASELINE_TSC, +$DELTA new)"
   echo ""
-  echo "$NEW_TSC" | head -30 | sed 's/^/    /'
-  echo ""
-  echo "  Fix these before pushing. (Pre-existing errors in unchanged files are not shown.)"
+  echo "  Your push introduced $DELTA new tsc error(s). Fix them before pushing."
+  echo "  Run:  cd apps/admin && npx tsc --noEmit 2>&1 | grep 'error TS'"
   echo "  Override (emergencies only): HF_SKIP_PREPUSH=1 git push ..."
   echo ""
   exit 1
+else
+  if [ "$TSC_ERRORS" -lt "$BASELINE_TSC" ]; then
+    DELTA=$((BASELINE_TSC - TSC_ERRORS))
+    echo "[pre-push] tsc: $TSC_ERRORS errors (baseline $BASELINE_TSC, -$DELTA). Run 'npm run ratchet:lock' to lock the improvement."
+  else
+    echo "[pre-push] tsc: $TSC_ERRORS errors (== baseline $BASELINE_TSC)."
+  fi
 fi
 
-# 2) lint on changed files only.
+# ── 2) lint — errors gate on changed files (warnings not gated) ─────────────
 echo "[pre-push] Running eslint on changed files..."
+LINT_OUT=$(mktemp)
+trap 'rm -f "$TSC_OUT" "$LINT_OUT"' EXIT
 # shellcheck disable=SC2086
-if ! npx eslint $REL; then
+npx eslint --format json $REL >"$LINT_OUT" 2>/dev/null || true
+
+LINT_ERRORS=0
+if [ -s "$LINT_OUT" ] && command -v node >/dev/null 2>&1; then
+  LINT_ERRORS=$(node -e '
+    try {
+      const j = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+      process.stdout.write(String(j.reduce((s, f) => s + (f.errorCount || 0), 0)));
+    } catch { process.stdout.write("0"); }
+  ' "$LINT_OUT")
+fi
+
+if [ "${LINT_ERRORS:-0}" -gt 0 ]; then
   echo ""
-  echo "  [pre-push] ✗ lint errors in files you're pushing."
+  echo "  [pre-push] $LINT_ERRORS lint error(s) in files you're pushing."
+  # Re-run in human-readable format for the developer.
+  # shellcheck disable=SC2086
+  npx eslint $REL 2>/dev/null || true
+  echo ""
+  echo "  Fix these before pushing."
   echo "  Override (emergencies only): HF_SKIP_PREPUSH=1 git push ..."
   echo ""
   exit 1
 fi
 
-echo "[pre-push] ✓ Your changed files pass tsc + lint."
+echo "[pre-push] lint: no errors in changed files."
+echo "[pre-push] Push checks passed."
 exit 0
 HOOK
 chmod +x "$HOOK_DIR/pre-push"


### PR DESCRIPTION
## Summary

- Pre-push hook previously used binary pass/fail on tsc errors filtered to changed files — any pre-existing error in a touched file blocked the push
- On macOS, tsc reports ~217 errors vs the Linux baseline of 201, so every routine push hit the gate
- Operators were using `HF_SKIP_PREPUSH=1` on ~6 pushes during the #1338 Session epic wave that should have passed cleanly

## What changed (`scripts/install-hooks.sh`)

**Before:** run `tsc --noEmit`, filter output to lines matching changed files, `exit 1` if any match found

**After:** run `tsc --noEmit`, count total `error TS` lines, compare against `.ratchet.json baseline`:
- `total_errors <= baseline` → PASS (no regression, even if changed files have pre-existing errors)
- `total_errors > baseline` → FAIL with clear delta message (+N new errors)
- `.ratchet.json` missing → WARN + old file-filtered fallback (backwards compat)

Lint: errors in changed files remain a hard fail (lint_errors baseline is 0). Warnings not gated.

`HF_SKIP_PREPUSH=1` preserved as emergency escape hatch but should no longer be needed for routine pushes.

## Test plan

- [ ] Push with only non-TS changes → hook fast-exits "No .ts/.tsx changes" (verified in this PR's own push)
- [ ] Push with a TS change that touches a file with pre-existing tsc errors → hook passes if total count <= 201
- [ ] Push that introduces a new tsc error → hook fails with `+1 new` message
- [ ] `HF_SKIP_PREPUSH=1 git push` → still skips with warning message
- [ ] Remove `.ratchet.json` and push → falls back to old file-filtered behaviour with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)