### PR TITLE
fix: clear main red — outbound-dial tests + admin-tools-parity + lint drift

### DIFF
--- a/apps/admin/app/api/admin/access-control/sidebar-visibility/route.ts
+++ b/apps/admin/app/api/admin/access-control/sidebar-visibility/route.ts
@@ -5,8 +5,6 @@ import sidebarManifest from "@/lib/sidebar/sidebar-manifest.json";
 
 const SETTING_KEY = "sidebar.visibility_rules";
 
-type VisibilityState = "visible" | "hidden_default" | "blocked";
-
 type SidebarVisibilityRules = {
   sections: Record<
     string,

--- a/apps/admin/app/api/admin/institution-types/route.ts
+++ b/apps/admin/app/api/admin/institution-types/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { TERM_KEYS } from "@/lib/terminology/types";
-import { invalidateTerminologyCache } from "@/lib/terminology";
 
 /**
  * @api GET /api/admin/institution-types

--- a/apps/admin/app/api/admin/masquerade/route.ts
+++ b/apps/admin/app/api/admin/masquerade/route.ts
@@ -7,7 +7,6 @@ import {
   MASQUERADE_COOKIE,
   MASQUERADE_MAX_AGE,
   getMasqueradeState,
-  canMasquerade,
   isRoleEscalation,
   type MasqueradeState,
 } from "@/lib/masquerade";

--- a/apps/admin/app/api/agents/run/route.ts
+++ b/apps/admin/app/api/agents/run/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { AgentRunStatus as DbAgentRunStatus } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { resolveAgentPaths } from '@/lib/agent-paths';
 import { requireAuth, isAuthError } from '@/lib/permissions';

--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -16,7 +16,6 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { MemoryCategory } from "@prisma/client";
 import { AIEngine, isEngineAvailable } from "@/lib/ai/client";
 import { classifyAIError, userMessageForError } from "@/lib/ai/error-utils";
 import { getConfiguredMeteredAICompletion, logMockAIUsage } from "@/lib/metering";
@@ -3110,10 +3109,8 @@ async function updateTpMasteryAfterCall(
     if (pbCurr) {
       // #1008 (Finding C) — AI-returned masteryThreshold is authoritative when present;
       // fall back to CURRICULUM_PROGRESS_V1 contract, hard literal only if registry empty.
-      const threshold =
-        learningAssessment.masteryThreshold ||
-        (await ContractRegistry.getThresholds('CURRICULUM_PROGRESS_V1'))?.masteryComplete ||
-        0.7;
+      // NOTE: threshold itself is not consumed by this branch (per-LO scores are
+      // persisted raw); the comparison happens at LO read time via the same cascade.
       const assessedLoRefs = Object.keys(learningAssessment.outcomes);
       const loRows = await prisma.learningObjective.findMany({
         where: {

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -29,6 +29,7 @@ import type { PlaybookConfig } from "@/lib/types/json-fields";
 import { cascadeableKeys, LOCKED_KEYS, SECRET_KEYS } from "@/lib/voice/config";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
 import { getVoiceProvider } from "@/lib/voice/provider-factory";
+import { explainVoiceCascade } from "@/lib/cascade/voice-explain";
 
 const MAX_RESULT_LENGTH = 3000;
 
@@ -99,6 +100,8 @@ const TOOL_MIN_ROLE: Record<string, UserRole> = {
   update_intake_spec_draft: "OPERATOR",
   get_voice_config: "OPERATOR",
   update_voice_config: "OPERATOR",
+  // #1348 Cascade Lens v1 — read-only voice provenance explainer
+  explain_voice_cascade: "OPERATOR",
 };
 
 /** Names of every roadmap-stub tool — kept centralised so the
@@ -270,6 +273,10 @@ export async function executeAdminTool(
         break;
       case "update_voice_config":
         result = await handleUpdateVoiceConfig(input);
+        break;
+      // #1348 Cascade Lens v1 — read-only
+      case "explain_voice_cascade":
+        result = await handleExplainVoiceCascade(input);
         break;
       default:
         if (NOT_YET_AVAILABLE_TOOLS.has(name)) {
@@ -2478,5 +2485,24 @@ async function handleUpdateVoiceConfig(input: Record<string, any>) {
     compose_inputs_bumped: true,
     message: `Updated voice config (${changedKeys.join(", ")}) on "${playbook.name}". ${TRAY_PROPOSED_SUFFIX}`,
     pendingChange,
+  };
+}
+
+/**
+ * #1348 Cascade Lens v1 — read-only voice cascade explainer for Cmd+K.
+ *
+ * Returns the full VoiceCascadeExplanation shape (callerId, playbookId,
+ * courseId, providerId, resolvedAt, fields[]) so the AI can narrate which
+ * layer (system / provider / domain / course) won for every cascadeable
+ * field. No DB writes; no pendingChange.
+ */
+async function handleExplainVoiceCascade(input: Record<string, any>) {
+  const callerId = typeof input.callerId === "string" ? input.callerId : "";
+  if (!callerId) return { error: "callerId is required" };
+
+  const explanation = await explainVoiceCascade(callerId);
+  return {
+    ok: true,
+    explanation,
   };
 }

--- a/apps/admin/tests/api/outbound-dial-1345.test.ts
+++ b/apps/admin/tests/api/outbound-dial-1345.test.ts
@@ -6,8 +6,10 @@
  *
  *   1. Happy path — externalId stamps normally, placeholder kept,
  *      200 returned. (Regression guard.)
- *   2. Stamp exception — Prisma throws on the update; route deletes the
- *      placeholder explicitly, logs structured context, returns 502.
+ *   2. Stamp exception — Prisma throws on the update; route records a
+ *      FailureLog against the placeholder (per #1340 the placeholder is
+ *      now preserved, not deleted, so the Tune tab can render a FAILED
+ *      card), logs structured context, returns 502.
  */
 
 import { describe, expect, it, vi, beforeEach, afterAll } from "vitest";
@@ -42,6 +44,8 @@ const stores = vi.hoisted(() => ({
   failStampUpdate: { value: false },
   // Track delete calls so we can assert the cleanup path.
   deleteCalls: [] as string[],
+  // Track recordCallFailure calls so we can assert the #1340 preserve-+-FailureLog path.
+  failureCalls: [] as Array<{ callId: string; kind: string; errorPayload: Record<string, unknown> }>,
   // Track log calls for the structured-context assertion.
   logCalls: [] as Array<{ event: string; payload: Record<string, unknown> }>,
 }));
@@ -132,6 +136,53 @@ vi.mock("@/lib/voice/build-assistant-config", () => ({
   }),
 }));
 
+// Route now uses createCallEnteringPipeline to mint the placeholder. The
+// helper has many DB-side dependencies (active-playbook lookup, module
+// cascade, FK writes) — short-circuit by writing through the existing
+// callStore mock so the rest of the assertions don't need to change.
+vi.mock("@/lib/voice/create-call-entering-pipeline", () => ({
+  createCallEnteringPipeline: vi.fn(
+    async (args: { callerId: string; source: string; voiceProvider: string }) => {
+      const id = `call-${stores.callStore.size + 1}`;
+      const row: MockCall = {
+        id,
+        callerId: args.callerId,
+        source: args.source,
+        voiceProvider: args.voiceProvider,
+        transcript: "",
+        externalId: null,
+      };
+      stores.callStore.set(id, row);
+      return {
+        call: { id },
+        playbookId: null,
+        requestedModuleId: null,
+        curriculumModuleId: null,
+      };
+    },
+  ),
+}));
+
+// Route uses recordCallFailure (post-#1340) instead of prisma.call.delete
+// to preserve the placeholder + write a FailureLog. Mock so the test can
+// assert the FailureLog payload without standing up the Session helpers.
+vi.mock("@/lib/voice/record-call-failure", () => ({
+  recordCallFailure: vi.fn(
+    async (args: {
+      callId: string;
+      kind: string;
+      errorPayload: Record<string, unknown>;
+    }) => {
+      stores.failureCalls.push(args);
+      return {
+        sessionId: null,
+        sessionCreated: false,
+        failureLogCreated: true,
+      };
+    },
+  ),
+}));
+
 vi.mock("@/lib/voice/telemetry", () => ({
   startVoiceSpan: vi.fn().mockReturnValue(() => undefined),
   logVoiceEvent: vi.fn(),
@@ -158,6 +209,7 @@ beforeEach(() => {
   stores.callerStore.clear();
   stores.providerStore.clear();
   stores.deleteCalls.length = 0;
+  stores.failureCalls.length = 0;
   stores.logCalls.length = 0;
   stores.failStampUpdate.value = false;
   // Re-stub global fetch (don't clear vi mocks, just rewire fetch).
@@ -217,7 +269,7 @@ describe("#1345 Part B — outbound-dial externalId-stamp safety", () => {
     expect(stores.deleteCalls).toHaveLength(0);
   });
 
-  it("stamp exception: placeholder explicitly deleted, 502 returned, structured error logged", async () => {
+  it("stamp exception: placeholder preserved + FailureLog written, 502 returned, structured error logged", async () => {
     seedHappyState();
     stores.failStampUpdate.value = true;
     const { POST } = await loadRoute();
@@ -229,9 +281,19 @@ describe("#1345 Part B — outbound-dial externalId-stamp safety", () => {
     expect(body.ok).toBe(false);
     expect(body.error).toContain("externalId");
     expect(body.error).toContain("simulated prisma exception");
-    // Placeholder explicitly cleaned up — no ghost row left.
-    expect(stores.deleteCalls).toHaveLength(1);
-    expect(stores.callStore.size).toBe(0);
+    // #1340 — placeholder is preserved (NOT deleted) so the Tune tab can
+    // render the FAILED card. Forensic detail lives in the FailureLog.
+    expect(stores.deleteCalls).toHaveLength(0);
+    expect(stores.callStore.size).toBe(1);
+    expect(stores.failureCalls).toHaveLength(1);
+    const failure = stores.failureCalls[0];
+    expect(failure.kind).toBe("OUTBOUND_DIAL_FAILED");
+    expect(failure.errorPayload.stage).toBe("externalid_stamp");
+    expect(failure.errorPayload.providerSlug).toBe("vapi");
+    expect(failure.errorPayload.vapiCallId).toBe("vapi-call-xyz");
+    expect(failure.errorPayload.errorMessage).toContain(
+      "simulated prisma exception",
+    );
     // Structured error logged with captured context.
     const stampLog = stores.logCalls.find(
       (l) => l.event === "voice.outbound_dial.externalid_stamp_failed",

--- a/apps/admin/tests/lib/voice/end-session.test.ts
+++ b/apps/admin/tests/lib/voice/end-session.test.ts
@@ -233,7 +233,7 @@ describe("endSession", () => {
     // is wired into a fire-and-forget Promise, so we just need to ensure
     // endSession itself returns normally even when the underlying network call
     // would have rejected.
-    global.fetch = vi.fn().mockRejectedValue(new Error("network down")) as any;
+    global.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof global.fetch;
     mockPrisma.call.findFirst.mockResolvedValueOnce({ id: "call-1" });
 
     const { endSession } = await import("@/lib/voice/end-session");
@@ -249,7 +249,7 @@ describe("endSession", () => {
 
   it("triggerPipelineAsync=false skips fetch entirely", async () => {
     const fetchMock = vi.fn();
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as unknown as typeof global.fetch;
 
     const { endSession } = await import("@/lib/voice/end-session");
     await endSession("session-1", {


### PR DESCRIPTION
## Summary

Main CI has been red since the #1338 Session epic merge wave. Failures were misread as workflow noise but they were real. This PR clears 4 failing tests + restores the lint ratchet baseline.

## What was wrong

### 4 failing unit tests

| Test | Cause | Fix |
|---|---|---|
| `tests/api/outbound-dial-1345.test.ts > happy path` | Route migrated to `createCallEnteringPipeline` + `recordCallFailure` (#1340 Slice 1); test still mocked pre-Slice 1 `prisma.call.delete` shape. Got 500 from outer catch because `createCallEnteringPipeline` ran for real. | Mock both helpers; assert preserve-+-FailureLog cleanup path. |
| `tests/api/outbound-dial-1345.test.ts > stamp exception` | Same as above. | Assert FailureLog payload (kind, stage, vapiCallId, errorMessage) instead of `prisma.call.delete` call. |
| `tests/lib/admin-tools-read-parity.test.ts > OPERATOR explain_voice_cascade` | #1376 (voice latency package) dropped the import, TOOL_MIN_ROLE entry, dispatch case, AND `handleExplainVoiceCascade` function in a merge collision — but left the tool in `admin-tools.ts`. Handler dispatch returned 'Unknown tool'. | Restored all four pieces (no behaviour change vs the original #1354 land). |
| `tests/lib/admin-tools-read-parity.test.ts > STUDENT refused` | Same as above. | Same fix. |

### Lint drift

Main was at `lint_warnings: 4427 (+5 over baseline 4422)`. Plus my `handleExplainVoiceCascade` restore added 1 more (matched the existing `Record<string, any>` pattern). Cleared 6 warnings + 2 from #1342 Slice 3 (rebased in mid-PR).

| File | Line | Rule | Fix |
|---|---|---|---|
| `app/api/calls/[callId]/pipeline/route.ts` | 19 | no-unused-vars | Removed unused `MemoryCategory` import (`mapToMemoryCategory` from `lib/pipeline/memory` is what's actually used). |
| `app/api/calls/[callId]/pipeline/route.ts` | 3112 | no-unused-vars | Removed unused `threshold` const in playbook-curriculum LO-score persistence block (per-LO scores stored raw; threshold isn't applied here). |
| `app/api/admin/access-control/sidebar-visibility/route.ts` | 8 | no-unused-vars | Removed unused `VisibilityState` type alias. |
| `app/api/admin/institution-types/route.ts` | 5 | no-unused-vars | Removed unused `invalidateTerminologyCache` import. |
| `app/api/admin/masquerade/route.ts` | 10 | no-unused-vars | Removed unused `canMasquerade` import. |
| `app/api/agents/run/route.ts` | 5 | no-unused-vars | Removed unused `DbAgentRunStatus` import. |
| `tests/lib/voice/end-session.test.ts` | 236, 252 | no-explicit-any | Replaced `as any` casts on `global.fetch` with `as unknown as typeof global.fetch`. |

## Verification

- `scripts/check-ratchet.sh`: `lint_warnings: 4422 (== baseline)`, `lint_errors: 0`, `quarantined_tests: 37 (== baseline)`. (`tsc_errors: 218` locally vs baseline 201 is documented macOS/Linux drift — CI on Linux reports 201, matching baseline.)
- All 18 target tests pass (`tests/api/outbound-dial-1345.test.ts` + `tests/lib/admin-tools-read-parity.test.ts`).
- Broader sanity: `tests/lib/admin-tools.test.ts` + `tests/lib/admin-tools-pending-change.test.ts` (57 tests) still green.
- `tests/lib/voice/end-session.test.ts` (10 tests) still green after the `unknown` cast change.

## Test plan

- [ ] CI passes on push (ratchet check, unit tests, integration)
- [ ] No new flakes on the rebased-in #1342 Slice 3 surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)