### PR TITLE
fix(sim): smoke 1+2 — end-call button below bubbles + Calls tab auto-scroll to latest

### DIFF
--- a/apps/admin/components/callers/caller-detail/CallsPromptsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/CallsPromptsTab.tsx
@@ -629,12 +629,25 @@ export function CallsPromptsTab({
 
   const latestId = entries[0]?.id ?? null;
 
-  // Auto-expand latest call on first render only (can be closed afterward)
+  // Auto-expand latest call on first render only (can be closed afterward).
+  // Smoke 2026-06-09 — also scroll the latest call into view so the user
+  // doesn't land on "looks empty, scroll up" after returning from /x/sim.
+  // The tab body sits inside the caller-detail-v2 scroll surface; an inert
+  // scrollIntoView on the latest call's card is the smallest fix.
   const didAutoExpand = useRef(false);
   useEffect(() => {
     if (!didAutoExpand.current && latestId && expandedCallId === null && externalExpanded === undefined) {
       didAutoExpand.current = true;
       setInternalExpanded(latestId);
+      // Defer to the next frame so the expanded card has rendered before we
+      // try to scroll to it. requestAnimationFrame is enough — the timeline
+      // builds synchronously from the already-loaded calls + prompts arrays.
+      if (typeof window !== "undefined") {
+        requestAnimationFrame(() => {
+          const el = document.getElementById(`cpt-call-${latestId}`);
+          if (el) el.scrollIntoView({ behavior: "auto", block: "start" });
+        });
+      }
     }
   }, [latestId]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -835,7 +848,7 @@ export function CallsPromptsTab({
         const latestResult = callResults.prompt || callResults.prep;
 
         return (
-          <div key={entry.id} className={`cpt-call ${isExpanded ? "cpt-call--expanded" : ""} ${isProcessing ? "cpt-call--processing" : ""}`}>
+          <div id={`cpt-call-${entry.id}`} key={entry.id} className={`cpt-call ${isExpanded ? "cpt-call--expanded" : ""} ${isProcessing ? "cpt-call--processing" : ""}`}>
             {/* Call header */}
             <div className="cpt-call-header">
               <button

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -1575,77 +1575,6 @@ export function SimChat({
           </div>
         )}
 
-        {/* #1379 — Voice-call status strip (hoisted out of the lobby block).
-            #1370 flipped callPhase to 'active' on voice-call start, which
-            hid the lobby — and with it, the Talk Here status text + the
-            fat red end-call button (both lived inside the lobby JSX).
-            Hoisting these here means they're visible whenever a voice
-            call is in any non-idle state, regardless of callPhase.
-            #1383 — also stays visible during 'wrapping' so the user sees
-            the "Ending your session..." feedback at the SAME location
-            they just clicked, instead of a silent transition. */}
-        {(providerCall.status === 'starting' ||
-          providerCall.status === 'connecting' ||
-          providerCall.status === 'active' ||
-          providerCall.status === 'error' ||
-          callPhase === 'wrapping') && (
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, padding: '16px 12px 8px' }}>
-            {providerCall.status === 'starting' && (
-              <p style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
-                Setting up your voice session&hellip;
-              </p>
-            )}
-            {providerCall.status === 'connecting' && (
-              <p style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
-                Connecting&hellip; (you&apos;ll be asked for microphone access)
-              </p>
-            )}
-            {providerCall.status === 'error' && providerCall.errorMessage && (
-              <p style={{ fontSize: 13, color: 'var(--status-error-text)', textAlign: 'center', margin: 0 }}>
-                {providerCall.errorMessage}
-              </p>
-            )}
-            {/* #1383 — Active call: red end button. */}
-            {(providerCall.status === 'starting' ||
-              providerCall.status === 'connecting' ||
-              providerCall.status === 'active') &&
-              callPhase !== 'wrapping' && (
-                <>
-                  <button
-                    className="wa-lobby-end-btn"
-                    onClick={() => { void providerCall.end(); }}
-                    aria-label="End voice session"
-                    title="End voice session"
-                  >
-                    <svg width="28" height="28" viewBox="0 0 24 24" fill="white" aria-hidden="true">
-                      <path transform="rotate(135 12 12)" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
-                    </svg>
-                  </button>
-                  <span style={{ fontSize: 12, color: 'var(--wa-text-secondary)' }}>End voice session</span>
-                </>
-              )}
-            {/* #1383 — Wrapping: replace the button with a spinner +
-                "Ending…" so the click feels acknowledged immediately at
-                the same screen location. Pre-fix the only feedback was a
-                small marker at the END of the message list — easy to
-                miss when the user's eye is still on the button. */}
-            {callPhase === 'wrapping' && (
-              <>
-                <div style={{
-                  width: 72, height: 72, borderRadius: '50%',
-                  background: 'color-mix(in srgb, var(--status-error-text, #ef4444) 30%, transparent)',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                }}>
-                  <div className="hf-spinner" style={{ width: 28, height: 28, borderWidth: 3, borderColor: 'rgba(255,255,255,0.5)', borderTopColor: 'white' }} />
-                </div>
-                <span style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
-                  Ending your session&hellip; saving the conversation.
-                </span>
-              </>
-            )}
-          </div>
-        )}
-
         {/* Active/wrapping/ended: session separator + live messages */}
         {(callPhase === 'active' || callPhase === 'wrapping' || callPhase === 'ended') && (
           <>
@@ -1692,6 +1621,68 @@ export function SimChat({
               <TypingIndicator />
             )}
           </>
+        )}
+
+        {/* #1379 / #1383 / smoke-1 — Voice-call status strip + fat red end
+            button. Positioned AFTER the live-message list so it flows
+            DOWN the screen UNDER the bubbles (smoke feedback 2026-06-09).
+            Gates are independent of the active/wrapping/ended outer block
+            so it still appears during 'starting' (sub-second pre-active
+            window) and during 'wrapping' (post-hangup feedback). */}
+        {(providerCall.status === 'starting' ||
+          providerCall.status === 'connecting' ||
+          providerCall.status === 'active' ||
+          providerCall.status === 'error' ||
+          callPhase === 'wrapping') && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, padding: '16px 12px 8px' }}>
+            {providerCall.status === 'starting' && (
+              <p style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
+                Setting up your voice session&hellip;
+              </p>
+            )}
+            {providerCall.status === 'connecting' && (
+              <p style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
+                Connecting&hellip; (you&apos;ll be asked for microphone access)
+              </p>
+            )}
+            {providerCall.status === 'error' && providerCall.errorMessage && (
+              <p style={{ fontSize: 13, color: 'var(--status-error-text)', textAlign: 'center', margin: 0 }}>
+                {providerCall.errorMessage}
+              </p>
+            )}
+            {(providerCall.status === 'starting' ||
+              providerCall.status === 'connecting' ||
+              providerCall.status === 'active') &&
+              callPhase !== 'wrapping' && (
+                <>
+                  <button
+                    className="wa-lobby-end-btn"
+                    onClick={() => { void providerCall.end(); }}
+                    aria-label="End voice session"
+                    title="End voice session"
+                  >
+                    <svg width="28" height="28" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                      <path transform="rotate(135 12 12)" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+                    </svg>
+                  </button>
+                  <span style={{ fontSize: 12, color: 'var(--wa-text-secondary)' }}>End voice session</span>
+                </>
+              )}
+            {callPhase === 'wrapping' && (
+              <>
+                <div style={{
+                  width: 72, height: 72, borderRadius: '50%',
+                  background: 'color-mix(in srgb, var(--status-error-text, #ef4444) 30%, transparent)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}>
+                  <div className="hf-spinner" style={{ width: 28, height: 28, borderWidth: 3, borderColor: 'rgba(255,255,255,0.5)', borderTopColor: 'white' }} />
+                </div>
+                <span style={{ fontSize: 13, color: 'var(--wa-text-secondary)', textAlign: 'center', margin: 0 }}>
+                  Ending your session&hellip; saving the conversation.
+                </span>
+              </>
+            )}
+          </div>
         )}
 
         {/* Post-call: new prompt notification (operator-only — breaks learner immersion) */}


### PR DESCRIPTION
## Summary

Two UI smoke regressions surfaced 2026-06-09 after the #1385 + #1391 merge.

1. **SimChat fat red end-call button stuck at top of chat panel.** During a live voice call, the hoisted (#1379) status strip + button sat ABOVE the message list. New bubbles streamed in below, making the button look glued to the header. Operator feedback: *"fat red button needs to flow down screen, under text bubbles."*

2. **CallsPromptsTab returning to the tab landed on empty space.** Auto-expand of the latest call existed already but didn't scroll the page; user had to scroll up to find it. Operator feedback: *"after call, go back into Call tab....dont see previous calls (scroll up to view?)."*

## Changes

| File | Change |
|---|---|
| `components/sim/SimChat.tsx` | Moved the voice-call status strip + fat red end-call button block from BEFORE the live-message list to AFTER it (after the typing indicator, before the post-call notification banner). Same gates; no behavioural change. |
| `components/callers/caller-detail/CallsPromptsTab.tsx` | Added DOM id `cpt-call-${entry.id}` to each call card. On auto-expand of latest call, `scrollIntoView({behavior:'auto', block:'start'})` runs on `requestAnimationFrame`. Inert; doesn't fight user-initiated scroll. |

## Test plan

- [x] `npx tsc --noEmit` — no new errors on touched files (one pre-existing lucide-react prop typing error at CallsPromptsTab.tsx:873 unrelated to this diff)
- [ ] Manual: open /x/sim/<id>, click [Talk Here], confirm red button sits BELOW bubbles
- [ ] Manual: end the call, switch to another tab, switch back to Calls tab, confirm latest call card is visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)