### PR TITLE
fix(hardening): drill clone async + poll; runbook IAM/App-Engine corrections

### DIFF
--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -64,14 +64,45 @@ if [[ -z "${DB_PASSWORD:-}" ]]; then
 fi
 
 # ---------------- clone -----------------
-log "cloning to PIT $PIT (expect ~10min on db-f1-micro)"
-if ! gcloud sql instances clone "$SOURCE_INSTANCE" "$DRILL_INSTANCE" \
-       --point-in-time="$PIT" \
-       --project="$PROJECT" \
-       --quiet 2>&1; then
-  fail 2 "clone failed — check PITR window, quota, or tier restrictions"
+# `gcloud sql instances clone` waits synchronously by default but caps its wait
+# at ~10 min — db-f1-micro routinely takes longer, leaving the operation running
+# server-side while the CLI bails with "taking longer than expected" and the
+# script falls through to `fail 2`. CLOUDSDK_CORE_OPERATION_TIMEOUT does NOT
+# apply to `gcloud sql`. Submit async, poll the operation explicitly with a
+# longer budget. (#1394 spike — observed 2026-06-09.)
+CLONE_POLL_MAX=60          # 60 × 30s = 30 min ceiling
+CLONE_POLL_INTERVAL=30
+
+log "cloning to PIT $PIT (async; poll up to $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min)"
+OP_ID=$(gcloud sql instances clone "$SOURCE_INSTANCE" "$DRILL_INSTANCE" \
+          --point-in-time="$PIT" --project="$PROJECT" --async \
+          --format='value(name)' 2>&1) || fail 2 "clone submit failed: $OP_ID"
+log "clone op submitted: $OP_ID"
+
+for i in $(seq 1 "$CLONE_POLL_MAX"); do
+  STATUS=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
+             --format='value(status)' 2>/dev/null || echo UNKNOWN)
+  case "$STATUS" in
+    DONE)
+      ERR=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
+              --format='value(error.errors[0].code,error.errors[0].message)' 2>/dev/null)
+      if [ -n "$ERR" ]; then
+        fail 2 "clone op failed: $ERR"
+      fi
+      ok "clone complete (op DONE in ~$((i * CLONE_POLL_INTERVAL))s)"
+      break
+      ;;
+    PENDING|RUNNING)
+      sleep "$CLONE_POLL_INTERVAL"
+      ;;
+    *)
+      fail 2 "unexpected clone op status: $STATUS"
+      ;;
+  esac
+done
+if [ "$STATUS" != "DONE" ]; then
+  fail 2 "clone op did not reach DONE within $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min — see gcloud sql operations describe $OP_ID"
 fi
-ok "clone complete"
 
 # ---------------- sanity SQL -------------
 CONN=$(gcloud sql instances describe "$DRILL_INSTANCE" --project="$PROJECT" --format='value(connectionName)')

--- a/docs/runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md
+++ b/docs/runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md
@@ -15,10 +15,20 @@ recipe if the script changes.
 - `gcloud auth login` as a user with `roles/cloudsql.admin`, `roles/run.admin`,
   `roles/iam.serviceAccountAdmin`, `roles/monitoring.alertPolicyEditor` on `hf-admin-prod`.
 - The DB superuser password stored in Secret Manager as `cloud-sql-drill-db-password`.
+- **App Engine app in `europe-west2`** — required by Cloud Scheduler (§4). One-time, free:
 
 ```bash
-# One-time: create the secret (skip if already present)
-echo -n "<paste DB password>" | gcloud secrets create cloud-sql-drill-db-password \
+gcloud app describe --project=hf-admin-prod >/dev/null 2>&1 \
+  || gcloud app create --region=europe-west2 --project=hf-admin-prod
+```
+
+```bash
+# One-time: create the secret (skip if already present). The easiest source
+# is the password embedded in the existing DATABASE_URL_SANDBOX secret —
+# extract it once and store as a derived secret:
+URL=$(gcloud secrets versions access latest --secret=DATABASE_URL_SANDBOX --project=hf-admin-prod)
+PASS=$(python3 -c "import sys; from urllib.parse import urlparse, unquote; print(unquote(urlparse(sys.argv[1]).password))" "$URL")
+printf '%s' "$PASS" | gcloud secrets create cloud-sql-drill-db-password \
   --data-file=- --project=hf-admin-prod --replication-policy=user-managed --locations=europe-west2
 ```
 
@@ -32,9 +42,18 @@ gcloud iam service-accounts create "$SA" \
 
 SA_EMAIL="${SA}@hf-admin-prod.iam.gserviceaccount.com"
 
-# Only the rights the drill actually needs
+# Least-privilege custom role. Verified 2026-06-09 against the actual operations the
+# drill performs: clone, describe, delete. PITR clone also needs backupRuns.{get,list}.
+# `roles/cloudsql.editor` is INSUFFICIENT — it lacks instances.clone and instances.delete
+# despite the role name. `roles/cloudsql.admin` works but is too broad.
+gcloud iam roles create restoreDrillMinimal --project=hf-admin-prod \
+  --title="Restore Drill (minimal)" \
+  --description="Clone + delete drill instances; describe hf-db. No stop/restart/modify." \
+  --permissions="cloudsql.instances.clone,cloudsql.instances.create,cloudsql.instances.delete,cloudsql.instances.get,cloudsql.instances.list,cloudsql.backupRuns.get,cloudsql.backupRuns.list" \
+  --stage=GA
+
 for ROLE in \
-  roles/cloudsql.editor \
+  projects/hf-admin-prod/roles/restoreDrillMinimal \
   roles/cloudsql.client \
   roles/logging.logWriter \
   roles/secretmanager.secretAccessor; do
@@ -83,7 +102,7 @@ gcloud run jobs create cloud-sql-restore-drill \
   --region=europe-west2 \
   --service-account="${SA_EMAIL}" \
   --max-retries=0 \
-  --task-timeout=30m \
+  --task-timeout=60m \
   --memory=512Mi \
   --set-env-vars=PROJECT=hf-admin-prod,SOURCE_INSTANCE=hf-db,DRILL_DB=hf_sandbox,DB_USER=postgres,DB_PASSWORD_SECRET=cloud-sql-drill-db-password \
   --project=hf-admin-prod
@@ -95,7 +114,8 @@ gcloud run jobs execute cloud-sql-restore-drill --region=europe-west2 --wait --p
 ## 4. Cloud Scheduler (monthly, 1st @ 03:00 UTC)
 
 ```bash
-SCHED_SA=cloud-sql-restore-drill-scheduler
+SCHED_SA=drill-scheduler  # GCP SA IDs cap at 30 chars; long names like
+                          # cloud-sql-restore-drill-scheduler are rejected.
 gcloud iam service-accounts create "$SCHED_SA" \
   --display-name="Cloud SQL restore drill — scheduler" \
   --project=hf-admin-prod


### PR DESCRIPTION
Follow-up to #1394 / PR #1400. Observed twice during today's deploy: the drill exits with `clone failed` while the Cloud SQL clone is still happily progressing server-side. Cause: `gcloud sql instances clone` caps its internal wait at ~10 min, but db-f1-micro routinely takes 15+ min. `CLOUDSDK_CORE_OPERATION_TIMEOUT` does NOT apply to `gcloud sql` (verified empirically — set to 1800, zero effect).

## Script fix

Switch to `--async` + explicit operation poll. 30-minute ceiling (60 × 30s). Distinct fail messages for submit-failure vs poll-timeout vs op-error.

## Runbook corrections (5 gaps surfaced during deploy)

| Gap | Was | Now |
|---|---|---|
| Insufficient role | `roles/cloudsql.editor` (lacks `instances.clone`+`delete`!) | Custom `restoreDrillMinimal` with the exact 7 perms used |
| Missing prereq | — | `gcloud app create --region=europe-west2` (Cloud Scheduler needs it) |
| Scheduler SA name | `cloud-sql-restore-drill-scheduler` (33 chars — GCP rejects) | `drill-scheduler` |
| Task timeout | `30m` | `60m` |
| Password secret source | "paste DB password" | extract from `DATABASE_URL_SANDBOX` (one-liner) |

## What this PR does NOT do

- Does not re-deploy the running Cloud Run Job (operator step — rebuild image, `gcloud run jobs update`)
- Does not fix the `backup_count` alert-policy metric name (separate follow-up)
- Does not start on #1411 (staging refresh) — that builds on this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)