### PR TITLE
fix(hardening): drill clone via gcloud sql operations wait (PR #1412 follow-up)

### DIFF
--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -64,45 +64,28 @@ if [[ -z "${DB_PASSWORD:-}" ]]; then
 fi
 
 # ---------------- clone -----------------
-# `gcloud sql instances clone` waits synchronously by default but caps its wait
-# at ~10 min — db-f1-micro routinely takes longer, leaving the operation running
-# server-side while the CLI bails with "taking longer than expected" and the
-# script falls through to `fail 2`. CLOUDSDK_CORE_OPERATION_TIMEOUT does NOT
-# apply to `gcloud sql`. Submit async, poll the operation explicitly with a
-# longer budget. (#1394 spike — observed 2026-06-09.)
-CLONE_POLL_MAX=60          # 60 × 30s = 30 min ceiling
-CLONE_POLL_INTERVAL=30
+# `gcloud sql instances clone` waits synchronously but caps at ~10 min, while
+# db-f1-micro clones routinely take 30+ min. CLOUDSDK_CORE_OPERATION_TIMEOUT
+# does NOT apply to `gcloud sql`. Solution: submit --async, then use the
+# purpose-built `gcloud sql operations wait` which has a `--timeout` knob and
+# clean exit-code semantics (0 = success, non-zero = error). 60-minute ceiling
+# is well above observed clone times.
+# (#1394 spike + #1412 follow-up — the prior --format='value(error.errors[0]...)'
+# parse returned a tab when fields were empty, which `[ -n "$ERR" ]` saw as
+# non-empty and triggered a false failure. operations wait avoids the parsing
+# trap entirely.)
+CLONE_TIMEOUT=3600
 
-log "cloning to PIT $PIT (async; poll up to $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min)"
+log "cloning to PIT $PIT (async; will wait up to $((CLONE_TIMEOUT / 60))min for op)"
 OP_ID=$(gcloud sql instances clone "$SOURCE_INSTANCE" "$DRILL_INSTANCE" \
           --point-in-time="$PIT" --project="$PROJECT" --async \
           --format='value(name)' 2>&1) || fail 2 "clone submit failed: $OP_ID"
 log "clone op submitted: $OP_ID"
 
-for i in $(seq 1 "$CLONE_POLL_MAX"); do
-  STATUS=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
-             --format='value(status)' 2>/dev/null || echo UNKNOWN)
-  case "$STATUS" in
-    DONE)
-      ERR=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
-              --format='value(error.errors[0].code,error.errors[0].message)' 2>/dev/null)
-      if [ -n "$ERR" ]; then
-        fail 2 "clone op failed: $ERR"
-      fi
-      ok "clone complete (op DONE in ~$((i * CLONE_POLL_INTERVAL))s)"
-      break
-      ;;
-    PENDING|RUNNING)
-      sleep "$CLONE_POLL_INTERVAL"
-      ;;
-    *)
-      fail 2 "unexpected clone op status: $STATUS"
-      ;;
-  esac
-done
-if [ "$STATUS" != "DONE" ]; then
-  fail 2 "clone op did not reach DONE within $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min — see gcloud sql operations describe $OP_ID"
+if ! gcloud sql operations wait "$OP_ID" --project="$PROJECT" --timeout="$CLONE_TIMEOUT" 2>&1; then
+  fail 2 "clone op failed or exceeded ${CLONE_TIMEOUT}s — gcloud sql operations describe $OP_ID --project=$PROJECT"
 fi
+ok "clone complete"
 
 # ---------------- sanity SQL -------------
 CONN=$(gcloud sql instances describe "$DRILL_INSTANCE" --project="$PROJECT" --format='value(connectionName)')


### PR DESCRIPTION
Follow-up to PR #1412. Two bugs surfaced on the next deploy attempt:

1. **30-min poll budget too tight** — db-f1-micro clone observed 30m34s; loop exited 34s short of completion.
2. **Empty-error parse bug** — `--format='value(error.errors[0].code,error.errors[0].message)'` returns a tab character when no errors exist; `[ -n "$ERR" ]` reads it as non-empty; the script falsely fails with "clone op failed: <tab>" even though the clone succeeded.

## Fix

Delegate to `gcloud sql operations wait` (purpose-built):
- polls server-side with a knob-able `--timeout`
- returns 0 on success, non-zero on failure
- no parsing required

Budget bumped 30min → 60min for headroom.

Net: -33 / +16 lines. Removes the entire custom poll loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)