### PR TITLE
fix(hardening): drill — wait for proxy + cloned DB to actually accept connections

### DIFF
--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -93,7 +93,27 @@ log "starting auth proxy on :$PROXY_PORT  conn=$CONN"
 "$PROXY_BIN" "$CONN" --port "$PROXY_PORT" >/tmp/restore-drill-proxy.log 2>&1 &
 PROXY_PID=$!
 trap '[[ -n "${PROXY_PID:-}" ]] && kill "$PROXY_PID" 2>/dev/null || true' EXIT
-sleep 6  # let the proxy come up
+# Wait for the proxy + cloned DB to actually accept connections, not just
+# "be running." On a cold Cloud Run container against a freshly-cloned
+# db-f1-micro, the Cloud SQL backend itself can need 10-20s to accept
+# connections after the proxy starts. A naive `sleep 6` produced
+# "server closed the connection unexpectedly" mid-handshake (#1394, observed
+# 2026-06-09 — final exit(3) bug after PR #1415).
+log "waiting for proxy + cloned DB to accept connections (max 60s)"
+PROXY_READY=0
+for try in $(seq 1 12); do
+  if PGPASSWORD="$DB_PASSWORD" psql -h localhost -p "$PROXY_PORT" \
+       -U "$DB_USER" -d postgres -c 'SELECT 1' >/dev/null 2>&1; then
+    PROXY_READY=1
+    ok "proxy + DB ready after ~$((try * 5))s"
+    break
+  fi
+  sleep 5
+done
+if [[ "$PROXY_READY" != "1" ]]; then
+  cat /tmp/restore-drill-proxy.log 2>/dev/null | tail -5
+  fail 3 "proxy + DB did not accept connections within 60s"
+fi
 
 cleanup_clone() {
   log "deleting drill instance $DRILL_INSTANCE"

--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -64,45 +64,28 @@ if [[ -z "${DB_PASSWORD:-}" ]]; then
 fi
 
 # ---------------- clone -----------------
-# `gcloud sql instances clone` waits synchronously by default but caps its wait
-# at ~10 min — db-f1-micro routinely takes longer, leaving the operation running
-# server-side while the CLI bails with "taking longer than expected" and the
-# script falls through to `fail 2`. CLOUDSDK_CORE_OPERATION_TIMEOUT does NOT
-# apply to `gcloud sql`. Submit async, poll the operation explicitly with a
-# longer budget. (#1394 spike — observed 2026-06-09.)
-CLONE_POLL_MAX=60          # 60 × 30s = 30 min ceiling
-CLONE_POLL_INTERVAL=30
+# `gcloud sql instances clone` waits synchronously but caps at ~10 min, while
+# db-f1-micro clones routinely take 30+ min. CLOUDSDK_CORE_OPERATION_TIMEOUT
+# does NOT apply to `gcloud sql`. Solution: submit --async, then use the
+# purpose-built `gcloud sql operations wait` which has a `--timeout` knob and
+# clean exit-code semantics (0 = success, non-zero = error). 60-minute ceiling
+# is well above observed clone times.
+# (#1394 spike + #1412 follow-up — the prior --format='value(error.errors[0]...)'
+# parse returned a tab when fields were empty, which `[ -n "$ERR" ]` saw as
+# non-empty and triggered a false failure. operations wait avoids the parsing
+# trap entirely.)
+CLONE_TIMEOUT=3600
 
-log "cloning to PIT $PIT (async; poll up to $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min)"
+log "cloning to PIT $PIT (async; will wait up to $((CLONE_TIMEOUT / 60))min for op)"
 OP_ID=$(gcloud sql instances clone "$SOURCE_INSTANCE" "$DRILL_INSTANCE" \
           --point-in-time="$PIT" --project="$PROJECT" --async \
           --format='value(name)' 2>&1) || fail 2 "clone submit failed: $OP_ID"
 log "clone op submitted: $OP_ID"
 
-for i in $(seq 1 "$CLONE_POLL_MAX"); do
-  STATUS=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
-             --format='value(status)' 2>/dev/null || echo UNKNOWN)
-  case "$STATUS" in
-    DONE)
-      ERR=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
-              --format='value(error.errors[0].code,error.errors[0].message)' 2>/dev/null)
-      if [ -n "$ERR" ]; then
-        fail 2 "clone op failed: $ERR"
-      fi
-      ok "clone complete (op DONE in ~$((i * CLONE_POLL_INTERVAL))s)"
-      break
-      ;;
-    PENDING|RUNNING)
-      sleep "$CLONE_POLL_INTERVAL"
-      ;;
-    *)
-      fail 2 "unexpected clone op status: $STATUS"
-      ;;
-  esac
-done
-if [ "$STATUS" != "DONE" ]; then
-  fail 2 "clone op did not reach DONE within $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min — see gcloud sql operations describe $OP_ID"
+if ! gcloud sql operations wait "$OP_ID" --project="$PROJECT" --timeout="$CLONE_TIMEOUT" 2>&1; then
+  fail 2 "clone op failed or exceeded ${CLONE_TIMEOUT}s — gcloud sql operations describe $OP_ID --project=$PROJECT"
 fi
+ok "clone complete"
 
 # ---------------- sanity SQL -------------
 CONN=$(gcloud sql instances describe "$DRILL_INSTANCE" --project="$PROJECT" --format='value(connectionName)')


### PR DESCRIPTION
Closes the last gap on #1394. After PR #1415 (operations wait) the drill cleared clone + wait + cleanup, but a final exit(3) fired in sanity: psql got 'server closed the connection unexpectedly' mid-handshake. On a cold Cloud Run container against a freshly-cloned db-f1-micro, the Cloud SQL backend itself can need 10-20s to accept connections after the proxy starts; the prior `sleep 6` was too tight.

Replace the sleep with an active probe (psql 'SELECT 1' against the postgres DB), retry every 5s up to 60s. Fail 3 with the proxy log tail if the DB never accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)