### PR TITLE
fix(hardening): drill — private-IP proxy + VPC connector for Cloud Run Job

### DIFF
--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -93,7 +93,27 @@ log "starting auth proxy on :$PROXY_PORT  conn=$CONN"
 "$PROXY_BIN" "$CONN" --port "$PROXY_PORT" >/tmp/restore-drill-proxy.log 2>&1 &
 PROXY_PID=$!
 trap '[[ -n "${PROXY_PID:-}" ]] && kill "$PROXY_PID" 2>/dev/null || true' EXIT
-sleep 6  # let the proxy come up
+# Wait for the proxy + cloned DB to actually accept connections, not just
+# "be running." On a cold Cloud Run container against a freshly-cloned
+# db-f1-micro, the Cloud SQL backend itself can need 10-20s to accept
+# connections after the proxy starts. A naive `sleep 6` produced
+# "server closed the connection unexpectedly" mid-handshake (#1394, observed
+# 2026-06-09 — final exit(3) bug after PR #1415).
+log "waiting for proxy + cloned DB to accept connections (max 60s)"
+PROXY_READY=0
+for try in $(seq 1 12); do
+  if PGPASSWORD="$DB_PASSWORD" psql -h localhost -p "$PROXY_PORT" \
+       -U "$DB_USER" -d postgres -c 'SELECT 1' >/dev/null 2>&1; then
+    PROXY_READY=1
+    ok "proxy + DB ready after ~$((try * 5))s"
+    break
+  fi
+  sleep 5
+done
+if [[ "$PROXY_READY" != "1" ]]; then
+  cat /tmp/restore-drill-proxy.log 2>/dev/null | tail -5
+  fail 3 "proxy + DB did not accept connections within 60s"
+fi
 
 cleanup_clone() {
   log "deleting drill instance $DRILL_INSTANCE"

--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -64,45 +64,28 @@ if [[ -z "${DB_PASSWORD:-}" ]]; then
 fi
 
 # ---------------- clone -----------------
-# `gcloud sql instances clone` waits synchronously by default but caps its wait
-# at ~10 min — db-f1-micro routinely takes longer, leaving the operation running
-# server-side while the CLI bails with "taking longer than expected" and the
-# script falls through to `fail 2`. CLOUDSDK_CORE_OPERATION_TIMEOUT does NOT
-# apply to `gcloud sql`. Submit async, poll the operation explicitly with a
-# longer budget. (#1394 spike — observed 2026-06-09.)
-CLONE_POLL_MAX=60          # 60 × 30s = 30 min ceiling
-CLONE_POLL_INTERVAL=30
+# `gcloud sql instances clone` waits synchronously but caps at ~10 min, while
+# db-f1-micro clones routinely take 30+ min. CLOUDSDK_CORE_OPERATION_TIMEOUT
+# does NOT apply to `gcloud sql`. Solution: submit --async, then use the
+# purpose-built `gcloud sql operations wait` which has a `--timeout` knob and
+# clean exit-code semantics (0 = success, non-zero = error). 60-minute ceiling
+# is well above observed clone times.
+# (#1394 spike + #1412 follow-up — the prior --format='value(error.errors[0]...)'
+# parse returned a tab when fields were empty, which `[ -n "$ERR" ]` saw as
+# non-empty and triggered a false failure. operations wait avoids the parsing
+# trap entirely.)
+CLONE_TIMEOUT=3600
 
-log "cloning to PIT $PIT (async; poll up to $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min)"
+log "cloning to PIT $PIT (async; will wait up to $((CLONE_TIMEOUT / 60))min for op)"
 OP_ID=$(gcloud sql instances clone "$SOURCE_INSTANCE" "$DRILL_INSTANCE" \
           --point-in-time="$PIT" --project="$PROJECT" --async \
           --format='value(name)' 2>&1) || fail 2 "clone submit failed: $OP_ID"
 log "clone op submitted: $OP_ID"
 
-for i in $(seq 1 "$CLONE_POLL_MAX"); do
-  STATUS=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
-             --format='value(status)' 2>/dev/null || echo UNKNOWN)
-  case "$STATUS" in
-    DONE)
-      ERR=$(gcloud sql operations describe "$OP_ID" --project="$PROJECT" \
-              --format='value(error.errors[0].code,error.errors[0].message)' 2>/dev/null)
-      if [ -n "$ERR" ]; then
-        fail 2 "clone op failed: $ERR"
-      fi
-      ok "clone complete (op DONE in ~$((i * CLONE_POLL_INTERVAL))s)"
-      break
-      ;;
-    PENDING|RUNNING)
-      sleep "$CLONE_POLL_INTERVAL"
-      ;;
-    *)
-      fail 2 "unexpected clone op status: $STATUS"
-      ;;
-  esac
-done
-if [ "$STATUS" != "DONE" ]; then
-  fail 2 "clone op did not reach DONE within $((CLONE_POLL_MAX * CLONE_POLL_INTERVAL / 60))min — see gcloud sql operations describe $OP_ID"
+if ! gcloud sql operations wait "$OP_ID" --project="$PROJECT" --timeout="$CLONE_TIMEOUT" 2>&1; then
+  fail 2 "clone op failed or exceeded ${CLONE_TIMEOUT}s — gcloud sql operations describe $OP_ID --project=$PROJECT"
 fi
+ok "clone complete"
 
 # ---------------- sanity SQL -------------
 CONN=$(gcloud sql instances describe "$DRILL_INSTANCE" --project="$PROJECT" --format='value(connectionName)')

--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -90,7 +90,12 @@ ok "clone complete"
 # ---------------- sanity SQL -------------
 CONN=$(gcloud sql instances describe "$DRILL_INSTANCE" --project="$PROJECT" --format='value(connectionName)')
 log "starting auth proxy on :$PROXY_PORT  conn=$CONN"
-"$PROXY_BIN" "$CONN" --port "$PROXY_PORT" >/tmp/restore-drill-proxy.log 2>&1 &
+# --private-ip: hf-db is a private-IP instance; clones inherit. Public IP is
+# off (verified `gcloud sql instances describe hf-db` 2026-06-09). Without
+# this flag the proxy errors "instance does not have IP of type 'PUBLIC'".
+# The Cloud Run Job must also have a VPC connector with egress to reach the
+# private IP — see RB-1394-DEPLOY.md § 3.
+"$PROXY_BIN" "$CONN" --port "$PROXY_PORT" --private-ip >/tmp/restore-drill-proxy.log 2>&1 &
 PROXY_PID=$!
 trap '[[ -n "${PROXY_PID:-}" ]] && kill "$PROXY_PID" 2>/dev/null || true' EXIT
 # Wait for the proxy + cloned DB to actually accept connections, not just

--- a/docs/runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md
+++ b/docs/runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md
@@ -98,14 +98,21 @@ gcloud builds submit /tmp/build \
 
 ```bash
 gcloud run jobs create cloud-sql-restore-drill \
-  --image=europe-west2-docker.pkg.dev/hf-admin-prod/hf/cloud-sql-restore-drill:latest \
+  --image=europe-west2-docker.pkg.dev/hf-admin-prod/hf-docker/cloud-sql-restore-drill:latest \
   --region=europe-west2 \
   --service-account="${SA_EMAIL}" \
   --max-retries=0 \
   --task-timeout=60m \
   --memory=512Mi \
+  --vpc-connector=hf-connector \
+  --vpc-egress=private-ranges-only \
   --set-env-vars=PROJECT=hf-admin-prod,SOURCE_INSTANCE=hf-db,DRILL_DB=hf_sandbox,DB_USER=postgres,DB_PASSWORD_SECRET=cloud-sql-drill-db-password \
   --project=hf-admin-prod
+
+# VPC connector: hf-db is a private-IP-only instance; the drill clone inherits.
+# Cloud Run's default egress can't reach private IPs in the project VPC. The
+# existing `hf-connector` (used by hf-admin-dev) routes private-range traffic
+# into the VPC, letting the drill's Cloud SQL Auth Proxy connect via private IP.
 
 # Manual test (do this once before scheduling)
 gcloud run jobs execute cloud-sql-restore-drill --region=europe-west2 --wait --project=hf-admin-prod


### PR DESCRIPTION
Final fix on #1394. The drill clone succeeds, the auth proxy starts, but the readiness probe fails with:
`failed to connect to instance: Config error: instance does not have IP of type 'PUBLIC'`.

hf-db is **private-IP only** (verified `gcloud sql instances describe`); clones inherit. Two changes:

- **Script** `apps/admin/scripts/cloud-sql-restore-drill.sh` — add `--private-ip` to the auth proxy invocation.
- **Runbook** `RB-1394-RESTORE-DRILL-DEPLOY.md` § 3 — add `--vpc-connector=hf-connector --vpc-egress=private-ranges-only` to the Cloud Run Job create command (same path `hf-admin-dev` already uses) + fix image-path typo (`hf-docker` not `hf`).

This closes the final gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)