### PR TITLE
fix(hardening): drill readiness DB + no-ops-import-from-api ESLint rule

### DIFF
--- a/apps/admin/eslint-rules/no-ops-import-from-api.mjs
+++ b/apps/admin/eslint-rules/no-ops-import-from-api.mjs
@@ -1,0 +1,84 @@
+/**
+ * #1395 / #1423 — Block imports of the 5 `lib/ops/*` files that instantiate
+ * their own `new PrismaClient()` from any `app/api/**` route, with one
+ * exception for the dedicated ops endpoint.
+ *
+ * Why this matters:
+ *   The five files below each create a *separate* PrismaClient instance,
+ *   bypassing the shared singleton in `lib/prisma.ts`. The Tech Lead surfaced
+ *   this in #1395 (RLS log-only) as the Phase-2 enforcement blocker: any
+ *   per-request `$extends` hook on the singleton will not fire for these
+ *   paths, so tenant-context-injection and Phase-2 enforcement will be
+ *   silently understated. The fix is to unify these onto the singleton, but
+ *   in the meantime new code must not deepen the problem.
+ *
+ *   The coupling-graph (#1423) made the cost visible: `lib/prisma.ts` is
+ *   imported by 600 files; each new ops-style bypass is a hidden 601st
+ *   surface that won't honour any future Prisma extension.
+ *
+ * Why path-restricted:
+ *   `app/api/ops/route.ts` IS the ops endpoint — invoking these by design.
+ *   Carving it out makes the rule pass on today's main while still blocking
+ *   *new* routes from sneaking imports in.
+ */
+
+const BYPASS_FILES = new Set([
+  "compose-next-prompt",
+  "compute-reward",
+  "knowledge-ingest",
+  "transcripts-process",
+  "update-targets",
+]);
+
+// Paths allowed to import bypass files (the only legitimate ops surface).
+const ALLOWED_SOURCE_FRAGMENTS = [
+  "/app/api/ops/route.ts",
+];
+
+const importRe = /^(?:@\/lib\/ops|(?:\.\.\/)+(?:.*\/)?lib\/ops)\/(?<file>[a-z0-9-]+?)(?:\.(?:ts|tsx|js|mjs))?$/;
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow API routes from importing the 5 lib/ops/* files that instantiate their own PrismaClient (bypass the singleton). See #1395 / #1423.",
+      // KB pointer — why this guard exists + survives-hardening class.
+      url: "https://github.com/WANDERCOLTD/HF/blob/main/docs/kb/guard-registry.md#guard-no-ops-import-from-api",
+    },
+    schema: [],
+    messages: {
+      opsImportFromApi:
+        "API routes must not import `{{file}}` from `lib/ops/` — this file instantiates its own PrismaClient and bypasses the singleton. Tenant-context injection (#1395 RLS) will not fire. Refactor lib/ops/{{file}} to use the shared `prisma` singleton from `@/lib/prisma`, OR move the orchestration into `app/api/ops/route.ts` (the only carved-out surface).",
+    },
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename?.() || "";
+    // Only fire inside app/api/** (any route handler).
+    if (!filename.includes("/app/api/")) return {};
+    // Carve out the legitimate ops surface.
+    if (ALLOWED_SOURCE_FRAGMENTS.some((frag) => filename.endsWith(frag) || filename.includes(frag))) return {};
+
+    function check(node, specifier) {
+      const m = importRe.exec(specifier);
+      if (!m) return;
+      const file = m.groups?.file ?? "";
+      if (BYPASS_FILES.has(file)) {
+        context.report({ node, messageId: "opsImportFromApi", data: { file } });
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (typeof node.source.value === "string") check(node, node.source.value);
+      },
+      // Dynamic `import('@/lib/ops/...')`
+      ImportExpression(node) {
+        if (node.source.type === "Literal" && typeof node.source.value === "string") {
+          check(node, node.source.value);
+        }
+      },
+    };
+  },
+};

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -15,6 +15,7 @@ import noVapiToolDefinitionsConst from "./eslint-rules/hf-voice/no-vapi-tool-def
 import noUndeclaredFieldRequire from "./eslint-rules/no-undeclared-field-require.mjs";
 import noModuleReadWithoutCourseStyleGuard from "./eslint-rules/no-module-read-without-course-style-guard.mjs";
 import noBareCallCreate from "./eslint-rules/no-bare-call-create.mjs";
+import noOpsImportFromApi from "./eslint-rules/no-ops-import-from-api.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -177,6 +178,11 @@ const eslintConfig = defineConfig([
           "no-bare-call-create": noBareCallCreate,
         },
       },
+      "hf-ops": {
+        rules: {
+          "no-ops-import-from-api": noOpsImportFromApi,
+        },
+      },
     },
     rules: {
       "hf-curriculum/no-unscoped-slug-lookup": "error",
@@ -214,6 +220,11 @@ const eslintConfig = defineConfig([
       // inline Call insert when needed) or add to the allow-list with a
       // documented bypass justification.
       "hf-call/no-bare-call-create": "error",
+
+      // #1395 / #1423 — Block app/api routes from importing the 5 lib/ops/*
+      // files that instantiate their own PrismaClient (bypass the singleton).
+      // Carves out app/api/ops/route.ts (the legitimate ops surface).
+      "hf-ops/no-ops-import-from-api": "error",
     },
   },
   // Enforce config+metering for ALL AI calls (no raw client usage)

--- a/apps/admin/scripts/cloud-sql-restore-drill.sh
+++ b/apps/admin/scripts/cloud-sql-restore-drill.sh
@@ -107,8 +107,15 @@ trap '[[ -n "${PROXY_PID:-}" ]] && kill "$PROXY_PID" 2>/dev/null || true' EXIT
 log "waiting for proxy + cloned DB to accept connections (max 60s)"
 PROXY_READY=0
 for try in $(seq 1 12); do
+  # Probe against $DRILL_DB, not the hardcoded `postgres` maintenance DB.
+  # The drill SA's password (extracted from DATABASE_URL_SANDBOX) belongs
+  # to `hf_user`, which has access to `hf_sandbox` and `hf_staging` but NOT
+  # to the `postgres` maintenance DB. Hardcoding `postgres` here produced
+  # auth failures during the 2026-06-09 #1394 deploy: proxy connected
+  # ("Accepted connection") but Postgres rejected the user, psql disconnected,
+  # readiness loop timed out. Use the DB we're actually going to query.
   if PGPASSWORD="$DB_PASSWORD" psql -h localhost -p "$PROXY_PORT" \
-       -U "$DB_USER" -d postgres -c 'SELECT 1' >/dev/null 2>&1; then
+       -U "$DB_USER" -d "$DRILL_DB" -c 'SELECT 1' >/dev/null 2>&1; then
     PROXY_READY=1
     ok "proxy + DB ready after ~$((try * 5))s"
     break

--- a/docs/runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md
+++ b/docs/runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md
@@ -106,7 +106,10 @@ gcloud run jobs create cloud-sql-restore-drill \
   --memory=512Mi \
   --vpc-connector=hf-connector \
   --vpc-egress=private-ranges-only \
-  --set-env-vars=PROJECT=hf-admin-prod,SOURCE_INSTANCE=hf-db,DRILL_DB=hf_sandbox,DB_USER=postgres,DB_PASSWORD_SECRET=cloud-sql-drill-db-password \
+  --set-env-vars=PROJECT=hf-admin-prod,SOURCE_INSTANCE=hf-db,DRILL_DB=hf_sandbox,DB_USER=hf_user,DB_PASSWORD_SECRET=cloud-sql-drill-db-password \
+  # DB_USER=hf_user matches the password we extracted from DATABASE_URL_SANDBOX.
+  # `postgres` (the maintenance superuser) is NOT in that secret. Using postgres
+  # here produced auth-fail at the readiness probe (#1394 deploy, 2026-06-09).
   --project=hf-admin-prod
 
 # VPC connector: hf-db is a private-IP-only instance; the drill clone inherits.

--- a/tests/eslint-rules/no-ops-import-from-api.test.ts
+++ b/tests/eslint-rules/no-ops-import-from-api.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from "vitest";
+import rule from "../../apps/admin/eslint-rules/no-ops-import-from-api.mjs";
+import { smokeRule } from "./_helpers.js";
+
+describe("no-ops-import-from-api", () => {
+  it("has the structural pieces (meta.docs.url to KB, messages, create)", () => {
+    smokeRule("no-ops-import-from-api", rule as never);
+  });
+});


### PR DESCRIPTION
Bundles two parked items.

## Drill fix-5
Readiness probe now queries `$DRILL_DB` instead of hardcoded `postgres`. The drill SA's password is from `DATABASE_URL_SANDBOX` (user `hf_user`), which has access to `hf_sandbox`/`hf_staging` but not the maintenance `postgres` DB. RB-1394-DEPLOY.md updated; live Cloud Run Job env will be updated in the next deploy step.

## no-ops-import-from-api (deferred from #1423)
Blocks `app/api/**` from importing the 5 `lib/ops/*` files that instantiate their own PrismaClient (the #1395 Phase-2 enforcement blocker). Carves out `app/api/ops/route.ts` (legitimate ops surface). Meta-ratchets stay at floor 0: 13/13 KB-linked, 15/15 with sibling tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)