### PR TITLE
fix(test): voice-config-routes mock — add voiceProvider.findUnique (#1428 follow-up)

### DIFF
--- a/apps/admin/tests/api/voice-config-routes.test.ts
+++ b/apps/admin/tests/api/voice-config-routes.test.ts
@@ -17,6 +17,14 @@ const mockPrisma = {
   domain: { findUnique: vi.fn(), update: vi.fn() },
   caller: { findFirst: vi.fn() },
   callerPlaybook: { findFirst: vi.fn() },
+  // #1421 follow-up — routes now look up the VoiceProvider row by slug
+  // to surface its id in the response (drives the VoiceSampleButton's
+  // POST target). Always returns a stable test id so the route's
+  // `enabledProviderId` field is non-null; tests that don't assert on
+  // it stay unaffected.
+  voiceProvider: {
+    findUnique: vi.fn(async () => ({ id: "vp-test-id" })),
+  },
 };
 
 vi.mock("@/lib/prisma", () => ({


### PR DESCRIPTION
Test regression from PR #1428. The new `prisma.voiceProvider.findUnique` call (surfaces `enabledProviderId` for the sample button) wasn't in the test's mockPrisma. 4/18 → 18/18 passing after this one-line mock addition.