### PR TITLE
fix(voice-providers): PATCH merges credentials instead of replacing — credential-wipe (#1433)

### DIFF
--- a/apps/admin/app/api/voice-providers/[id]/route.ts
+++ b/apps/admin/app/api/voice-providers/[id]/route.ts
@@ -56,8 +56,19 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
 const patchSchema = z.object({
   displayName: z.string().min(1).max(128).optional(),
   adapterKey: z.string().min(1).optional(),
+  /** #1433 — merge semantics (NOT replace). Keys present in the patch
+   *  body are set / overwritten. Keys absent from the patch body are
+   *  PRESERVED on the existing row. To explicitly clear a key, list it
+   *  in `clearCredentials`. */
   credentials: z.record(z.string(), z.unknown()).optional(),
+  /** Same merge semantics as credentials. */
   config: z.record(z.string(), z.unknown()).optional(),
+  /** Explicit clear list — these keys are deleted from `credentials`
+   *  AFTER the merge above. Defends against the wipe class fixed in
+   *  #1433: a UI bug or stale form can no longer silently empty the
+   *  credentials JSON by shipping `credentials: {}`. */
+  clearCredentials: z.array(z.string()).optional(),
+  clearConfig: z.array(z.string()).optional(),
   isDefault: z.boolean().optional(),
   enabled: z.boolean().optional(),
 });
@@ -160,6 +171,37 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     }
   }
 
+  // #1433 — merge credentials + config field-by-field instead of replace.
+  // Pre-fix: shipping `credentials: {}` blew away the entire credentials
+  // JSON (webhookSecret + apiKey + every other sensitive field). Now:
+  // - Keys present in patch body → set/overwrite
+  // - Keys absent → preserve existing value
+  // - Keys listed in `clearCredentials` → delete after merge
+  const existingCredentials = (existing.credentials ?? {}) as Record<string, unknown>;
+  const existingConfig = (existing.config ?? {}) as Record<string, unknown>;
+  const nextCredentials: Record<string, unknown> = {
+    ...existingCredentials,
+    ...(data.credentials ?? {}),
+  };
+  for (const k of data.clearCredentials ?? []) {
+    delete nextCredentials[k];
+  }
+  const nextConfig: Record<string, unknown> = {
+    ...existingConfig,
+    ...(data.config ?? {}),
+  };
+  for (const k of data.clearConfig ?? []) {
+    delete nextConfig[k];
+  }
+  // Only write to the JSON columns when there's actually something to
+  // write (avoid no-op updates that nudge updatedAt).
+  const credentialsChanged =
+    (data.credentials && Object.keys(data.credentials).length > 0) ||
+    (data.clearCredentials && data.clearCredentials.length > 0);
+  const configChanged =
+    (data.config && Object.keys(data.config).length > 0) ||
+    (data.clearConfig && data.clearConfig.length > 0);
+
   const updated = await prisma.$transaction(async (tx) => {
     if (data.isDefault === true) {
       await tx.voiceProvider.updateMany({
@@ -172,10 +214,10 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       data: {
         ...(data.displayName !== undefined ? { displayName: data.displayName } : {}),
         ...(data.adapterKey !== undefined ? { adapterKey: data.adapterKey } : {}),
-        ...(data.credentials !== undefined
-          ? { credentials: data.credentials as Prisma.InputJsonValue }
+        ...(credentialsChanged
+          ? { credentials: nextCredentials as Prisma.InputJsonValue }
           : {}),
-        ...(data.config !== undefined ? { config: data.config as Prisma.InputJsonValue } : {}),
+        ...(configChanged ? { config: nextConfig as Prisma.InputJsonValue } : {}),
         ...(data.isDefault !== undefined ? { isDefault: data.isDefault } : {}),
         ...(data.enabled !== undefined ? { enabled: data.enabled } : {}),
       },

--- a/apps/admin/app/x/settings/voice-providers/[id]/page.tsx
+++ b/apps/admin/app/x/settings/voice-providers/[id]/page.tsx
@@ -213,22 +213,18 @@ export default function VoiceProviderEditPage() {
     setErr(null);
     setSaveMessage(null);
     try {
-      const credentials: Record<string, unknown> = {
-        ...row.credentials,
-      };
-      const config: Record<string, unknown> = { ...row.config };
-      // Drop masked sentinels so we don't write "***" back to DB
-      for (const k of Object.keys(credentials)) {
-        if (credentials[k] === "***" || credentials[k] === "[not set]") {
-          delete credentials[k];
-        }
-      }
-
+      // #1433 — patch contains ONLY keys the operator changed.
+      // Pre-fix the UI spread `row.credentials` (masked `***`), deleted
+      // sentinels, and sent `{}` — which the PATCH route treated as a
+      // full replace, wiping every sensitive field. Route is now
+      // merge-safe AND the UI sends a minimal patch (defence in depth).
+      const credentials: Record<string, unknown> = {};
+      const config: Record<string, unknown> = {};
       const changedFields: string[] = [];
 
       for (const f of configSchema) {
         const raw = fieldValues[f.key];
-        // Sensitive empty string = keep current value
+        // Sensitive empty string = keep current value (omit from patch).
         if (f.sensitive && raw === "") continue;
         let value: unknown;
         if (f.type === "number") {
@@ -258,17 +254,19 @@ export default function VoiceProviderEditPage() {
             (row.credentials as Record<string, unknown>)[f.key];
           if (currentValue !== value) {
             changedFields.push(f.label);
+            config[f.key] = value;
           }
-          config[f.key] = value;
         }
       }
 
       const patch: Record<string, unknown> = {
         displayName,
         enabled,
-        credentials,
-        config,
       };
+      // #1433 — only include the JSON columns when at least one field
+      // changed. Merge-safe route preserves untouched keys.
+      if (Object.keys(credentials).length > 0) patch.credentials = credentials;
+      if (Object.keys(config).length > 0) patch.config = config;
       const res = await fetch(`/api/voice-providers/${id}`, {
         method: "PATCH",
         headers: { "content-type": "application/json" },

--- a/apps/admin/tests/api/voice-providers-patch-merge.test.ts
+++ b/apps/admin/tests/api/voice-providers-patch-merge.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for `PATCH /api/voice-providers/[id]` merge semantics (#1433).
+ *
+ * Pre-fix, the route did `credentials: data.credentials as InputJsonValue`
+ * — a full replace. Shipping `credentials: {}` wiped every sensitive
+ * field (webhookSecret / apiKey / etc.). Live evidence on hf-dev 2026-06-10
+ * showed the bug class blowing away every credential on every save where
+ * the operator left sensitive fields blank.
+ *
+ * Post-fix, the route merges field-by-field. This file pins the contract:
+ *
+ *   1. Empty `credentials: {}` → existing credentials PRESERVED
+ *   2. Partial `credentials: {newKey: val}` → existing keys preserved + new key set
+ *   3. Overlapping `credentials: {existingKey: newVal}` → existing key overwritten,
+ *      OTHER existing keys still preserved
+ *   4. `clearCredentials: ["key"]` → explicitly delete that key, others preserved
+ *   5. Same semantics for `config` + `clearConfig`
+ *   6. Omitting both `credentials` and `clearCredentials` → no write at all,
+ *      no spurious updatedAt nudge
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockUpdate = vi.fn();
+const mockUpdateMany = vi.fn(async () => ({}));
+const mockFindUnique = vi.fn();
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => unknown) =>
+  fn({
+    voiceProvider: { update: mockUpdate, updateMany: mockUpdateMany },
+  }),
+);
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    voiceProvider: { findUnique: mockFindUnique },
+    $transaction: mockTransaction,
+  },
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({ session: { user: { role: "ADMIN" } } })),
+  isAuthError: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/voice/provider-factory", () => ({
+  invalidateVoiceProviderCache: vi.fn(),
+}));
+
+vi.mock("@/lib/voice/mask-credentials", () => ({
+  maskCredentials: vi.fn((c: Record<string, unknown>) => c),
+}));
+
+// Empty adapter registry so the field validation loop short-circuits.
+vi.mock("@/lib/voice/adapter-registry", () => ({
+  VOICE_ADAPTERS: {},
+}));
+
+function buildPatchRequest(body: unknown) {
+  return new Request("http://test/api/voice-providers/test-id", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as Request;
+}
+
+async function callPatch(body: unknown) {
+  const { PATCH } = await import("@/app/api/voice-providers/[id]/route");
+  return PATCH(buildPatchRequest(body), {
+    params: Promise.resolve({ id: "test-id" }),
+  });
+}
+
+const EXISTING_CREDENTIALS = {
+  apiKey: "EXISTING_VAPI_KEY",
+  webhookSecret: "EXISTING_WEBHOOK_SECRET",
+  deepgramApiKey: "EXISTING_DEEPGRAM_KEY",
+};
+const EXISTING_CONFIG = {
+  voiceId: "asteria",
+  publicKey: "pk_existing",
+  transcriber: "deepgram",
+};
+
+beforeEach(() => {
+  mockUpdate.mockReset();
+  mockTransaction.mockClear();
+  mockFindUnique.mockReset();
+  mockUpdate.mockImplementation(async ({ data }: { data: unknown }) => ({
+    id: "test-id",
+    slug: "vapi",
+    ...((data ?? {}) as Record<string, unknown>),
+    credentials: ((data as Record<string, unknown>).credentials ?? EXISTING_CREDENTIALS) as unknown,
+  }));
+  mockFindUnique.mockResolvedValue({
+    id: "test-id",
+    slug: "vapi",
+    adapterKey: "vapi",
+    credentials: EXISTING_CREDENTIALS,
+    config: EXISTING_CONFIG,
+    isDefault: false,
+    enabled: true,
+  });
+});
+
+describe("PATCH /api/voice-providers/[id] — merge semantics (#1433)", () => {
+  it("empty credentials: {} → existing credentials PRESERVED (no write)", async () => {
+    const res = await callPatch({ credentials: {}, enabled: true });
+    expect(res.status).toBe(200);
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    // No `credentials` field in the update payload at all → existing row untouched.
+    expect(updateCall?.data?.credentials).toBeUndefined();
+  });
+
+  it("partial new key → existing keys preserved + new key set", async () => {
+    await callPatch({
+      credentials: { deepgramApiKey: "NEW_DEEPGRAM" },
+    });
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    expect(updateCall.data.credentials).toEqual({
+      apiKey: "EXISTING_VAPI_KEY", // preserved
+      webhookSecret: "EXISTING_WEBHOOK_SECRET", // preserved
+      deepgramApiKey: "NEW_DEEPGRAM", // set
+    });
+  });
+
+  it("overlapping key → that key overwritten, OTHER existing keys preserved", async () => {
+    await callPatch({
+      credentials: { webhookSecret: "ROTATED_SECRET" },
+    });
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    expect(updateCall.data.credentials).toEqual({
+      apiKey: "EXISTING_VAPI_KEY", // preserved
+      webhookSecret: "ROTATED_SECRET", // overwritten
+      deepgramApiKey: "EXISTING_DEEPGRAM_KEY", // preserved
+    });
+  });
+
+  it("clearCredentials: ['key'] → that key deleted, others preserved", async () => {
+    await callPatch({
+      clearCredentials: ["deepgramApiKey"],
+    });
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    expect(updateCall.data.credentials).toEqual({
+      apiKey: "EXISTING_VAPI_KEY",
+      webhookSecret: "EXISTING_WEBHOOK_SECRET",
+      // deepgramApiKey deleted
+    });
+  });
+
+  it("config merge semantics mirror credentials", async () => {
+    await callPatch({
+      config: { voiceId: "luna" },
+    });
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    expect(updateCall.data.config).toEqual({
+      voiceId: "luna", // overwritten
+      publicKey: "pk_existing", // preserved
+      transcriber: "deepgram", // preserved
+    });
+  });
+
+  it("omitting credentials AND clearCredentials → no credentials write at all", async () => {
+    await callPatch({ displayName: "Renamed" });
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    expect(updateCall.data.credentials).toBeUndefined();
+    expect(updateCall.data.displayName).toBe("Renamed");
+  });
+
+  it("REGRESSION pin: empty credentials: {} no longer wipes the row", async () => {
+    // This is the EXACT bug class from #1433. The UI's pre-fix save
+    // shipped `credentials: {}` which used to fully replace. We assert
+    // the existing keys still exist in the update payload.
+    await callPatch({ credentials: {}, config: {} });
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    // Either: no write to credentials (preferred — nothing changed),
+    // OR a write that includes ALL three original keys (acceptable).
+    if (updateCall.data.credentials !== undefined) {
+      expect(updateCall.data.credentials).toMatchObject(EXISTING_CREDENTIALS);
+    }
+  });
+
+  it("clear + set in same patch: clear key A, set key B, preserve key C", async () => {
+    await callPatch({
+      credentials: { deepgramApiKey: "ROTATED_DG" },
+      clearCredentials: ["apiKey"],
+    });
+    const updateCall = mockUpdate.mock.calls[0]?.[0];
+    expect(updateCall.data.credentials).toEqual({
+      // apiKey: CLEARED
+      webhookSecret: "EXISTING_WEBHOOK_SECRET",
+      deepgramApiKey: "ROTATED_DG",
+    });
+  });
+});


### PR DESCRIPTION
Closes #1433. Two-layer defence: route-level merge (structural) + UI minimal-patch (hygiene). 8/8 vitests; regression pin includes the exact bug class from hf-dev.