### PR TITLE
feat(hygiene): cleanup-agent-worktrees.sh + SessionStart nudge

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -145,6 +145,15 @@ fi
 if [ "$DIRTY" -gt 0 ]; then
   MSG="$MSG⚠️  $DIRTY uncommitted changes from last session. "
 fi
+
+# Agent-worktree zombie nudge — surfaces when accumulation gets noisy
+# without making an gh API call on every session start. Threshold of 6
+# allows for typical in-flight work + main; above that, the cleanup
+# script almost always has zombies to garbage-collect.
+ZOMBIE_COUNT=$(find "$REPO_ROOT/.claude/worktrees" -maxdepth 1 -type d -name 'agent-*' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$ZOMBIE_COUNT" -gt 6 ]; then
+  MSG="${MSG}🧟 $ZOMBIE_COUNT agent worktrees in .claude/worktrees/ — likely zombies from merged-PR agents. Run \`bash scripts/cleanup-agent-worktrees.sh --dry-run\` to see what's removable; drop \`--dry-run\` to GC. "
+fi
 if [ "$PEER_COUNT" -gt 1 ]; then
   MSG="${MSG}🚨 $PEER_COUNT concurrent claude processes detected. They share this working tree — peer 'git checkout' calls will swap HEAD under you. Treat any unexplained branch change as confirmation. See memory/feedback_concurrent_claude_processes.md for recovery. "
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,8 @@ If you discover work has started on `main`, stop and move it: `git checkout -b <
    - **PreToolUse `git-lock-enforcer.sh` (#849):** defence-in-depth for anything that slips past the first two — blocks destructive git from secondary sessions sharing a tree.
 
    When you spawn peer agents that touch code, use `isolation: "worktree"` on the `Agent` tool — the agent gets its own `git worktree add ../HF-feat-X feat/X-…` checkout, lock-keyed on `git rev-parse --show-toplevel`, so every worktree is its own PRIMARY slot.
+
+   **Agent-worktree GC:** The Agent tool's contract auto-deletes the worktree only if the agent made no changes. Productive agents leave their worktree behind; across many sessions these pile up under `.claude/worktrees/agent-*` (21 GB observed 2026-06-10, 14 of 17 zombies). Run `bash scripts/cleanup-agent-worktrees.sh --dry-run` after a PR-closing session to see what's GC-able; drop `--dry-run` to actually remove (script keeps `main`, OPEN PRs, and no-PR branches; only removes MERGED/CLOSED). The SessionStart hook nudges when the count exceeds 6.
 4. **Operator override (one-shot, per command):** export `HF_FORCE_GIT=1` before the blocked git command. Use only when you have confirmed the peer is finished or you accept the HEAD-swap risk.
 5. **Recovery when drift hits anyway:**
    - `git stash --include-untracked -m '<work-description>'`

--- a/docs/kb/guard-registry.md
+++ b/docs/kb/guard-registry.md
@@ -214,6 +214,7 @@ parallel rules will be needed if/when other tool-loading constants are migrated.
 | `check-doc-citations.ts` | Canonical-doc `file::symbol` citation drift | — | **meta** (KB integrity) |
 | `check-knowledge-map.ts` | `KNOWLEDGE-MAP.md` ratchet — repo translation layer stays in step | — | **meta** (KB integrity) |
 | `check-uplift-visual.ts` | Caller Insights visual regression | — | **meta** (test) |
+| `cleanup-agent-worktrees.sh` | GC of agent-spawned worktrees whose PR is MERGED or CLOSED. Operator script; nudge surfaced in SessionStart hook when count > 6. | — | **meta** (process hygiene) |
 
 ## Runtime guards & contracts
 

--- a/scripts/cleanup-agent-worktrees.sh
+++ b/scripts/cleanup-agent-worktrees.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# scripts/cleanup-agent-worktrees.sh
+#
+# Garbage-collect agent-spawned git worktrees whose PR is finished. The
+# Claude Code Agent tool spawns worktrees at .claude/worktrees/agent-<id>
+# (when invoked with `isolation: "worktree"`). Per its contract a worktree
+# is auto-deleted only if the agent made NO changes; otherwise it survives
+# and accumulates across sessions. This script collects the zombies.
+#
+# Logic per worktree:
+#   - branch = main      → keep (canonical)
+#   - branch has PR MERGED or CLOSED → remove worktree + delete branch
+#   - branch has PR OPEN → keep (in-flight)
+#   - branch has no PR   → warn but keep (manual decision)
+#
+# Run modes:
+#   --dry-run   Print what would be removed, do nothing.
+#   --quiet     Suppress per-worktree output; print only summary line.
+#   (default)   Verbose; prints each decision and final summary.
+#
+# Requires: gh CLI authenticated. No-op + warn if not available.
+#
+# Born from a 2026-06-10 broken-windows pass where 14 of 17 agent
+# worktrees were zombies, consuming 21 GB of disk. See guard-registry.md.
+set -euo pipefail
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[ -z "$REPO_ROOT" ] && { echo "[cleanup] not inside a git repo" >&2; exit 1; }
+cd "$REPO_ROOT"
+
+DRY_RUN=0
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --quiet)   QUIET=1 ;;
+    -h|--help)
+      sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[cleanup] ⚠ gh CLI not on PATH — cannot resolve PR state, exiting."
+  exit 0
+fi
+
+log() { [ "$QUIET" = "1" ] || echo "$@"; }
+
+REMOVED=0
+KEPT_INFLIGHT=0
+KEPT_NOPR=0
+KEPT_MAIN=0
+SKIPPED_NO_BRANCH=0
+
+# Parse `git worktree list --porcelain` for agent-* paths + their branch refs.
+while IFS=$'\t' read -r wt_path branch_ref; do
+  [ -z "$wt_path" ] && continue
+  short_wt=$(basename "$wt_path")
+  branch=$(printf '%s' "$branch_ref" | sed 's|refs/heads/||')
+
+  if [ -z "$branch" ]; then
+    SKIPPED_NO_BRANCH=$((SKIPPED_NO_BRANCH + 1))
+    log "  skip   $short_wt (no branch — detached HEAD?)"
+    continue
+  fi
+
+  if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    KEPT_MAIN=$((KEPT_MAIN + 1))
+    log "  keep   $short_wt ($branch — canonical)"
+    continue
+  fi
+
+  state=$(gh pr list --head "$branch" --state all --limit 1 --json state --jq '.[0].state' 2>/dev/null || true)
+  case "$state" in
+    MERGED|CLOSED)
+      if [ "$DRY_RUN" = "1" ]; then
+        log "  [dry] WOULD remove $short_wt ($branch — PR $state)"
+        REMOVED=$((REMOVED + 1))
+      else
+        log "  rm     $short_wt ($branch — PR $state)"
+        git worktree remove --force "$wt_path" 2>/dev/null || true
+        git branch -D "$branch" 2>/dev/null || true
+        REMOVED=$((REMOVED + 1))
+      fi ;;
+    OPEN)
+      KEPT_INFLIGHT=$((KEPT_INFLIGHT + 1))
+      log "  keep   $short_wt ($branch — PR OPEN, in-flight)" ;;
+    ""|null)
+      KEPT_NOPR=$((KEPT_NOPR + 1))
+      log "  keep   $short_wt ($branch — no PR found, manual decision)" ;;
+    *)
+      KEPT_NOPR=$((KEPT_NOPR + 1))
+      log "  keep   $short_wt ($branch — PR state '$state', leaving alone)" ;;
+  esac
+done < <(
+  git worktree list --porcelain | awk '
+    /^worktree / { wt = $2 }
+    /^branch /   { br = $2 }
+    /^$/         {
+      if (wt ~ /\/\.claude\/worktrees\/agent-/) { print wt "\t" br }
+      wt=""; br=""
+    }'
+)
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "[cleanup] DRY-RUN summary: would remove $REMOVED · in-flight $KEPT_INFLIGHT · no-PR $KEPT_NOPR · main $KEPT_MAIN"
+else
+  git worktree prune 2>/dev/null || true
+  echo "[cleanup] removed $REMOVED zombie worktree(s) · kept $KEPT_INFLIGHT in-flight · kept $KEPT_NOPR no-PR (manual) · kept $KEPT_MAIN main"
+fi


### PR DESCRIPTION
Process fix for the worktree accumulation observed today (17 worktrees, 21 GB, 14 zombies whose PRs had merged/closed weeks ago). The Agent tool's contract auto-deletes only when an agent made no changes — productive agents always leave their worktree behind.

## Changes

- `scripts/cleanup-agent-worktrees.sh` — operator script. Removes worktree + branch when PR is **MERGED** or **CLOSED**. Keeps `main`, OPEN PRs (in-flight), and no-PR branches (manual). Modes: default verbose, `--dry-run`, `--quiet`.
- `.claude/hooks/session-start.sh` — nudge when >6 `agent-*` worktrees exist. Cheap check, does NOT call `gh` (would couple session start to API latency).
- `docs/kb/guard-registry.md` — new row under CI check scripts.
- `CLAUDE.md` — three-line callout under worktree-discipline.

## Validation

Dry-run on the live tree correctly identifies 14 zombies (12 MERGED, 2 CLOSED), keeps the 1 OPEN PR worktree (#1420), keeps the 1 no-PR worktree, keeps the `main` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)