### PR TITLE
fix(hygiene): cleanup-agent-worktrees — unlock before remove

### DIFF
--- a/scripts/cleanup-agent-worktrees.sh
+++ b/scripts/cleanup-agent-worktrees.sh
@@ -79,6 +79,11 @@ while IFS=$'\t' read -r wt_path branch_ref; do
         REMOVED=$((REMOVED + 1))
       else
         log "  rm     $short_wt ($branch — PR $state)"
+        # `git worktree remove --force` does NOT bypass the `locked` flag;
+        # unlock first (no-op on unlocked worktrees) then remove. Observed
+        # 2026-06-10: without the unlock, `--force` silently leaves locked
+        # worktrees in place even though the script logs "rm".
+        git worktree unlock "$wt_path" 2>/dev/null || true
         git worktree remove --force "$wt_path" 2>/dev/null || true
         git branch -D "$branch" 2>/dev/null || true
         REMOVED=$((REMOVED + 1))


### PR DESCRIPTION
Follow-up to #1436. The cleanup script logged `rm` 14 times but the worktrees survived because `git worktree remove --force` does NOT bypass the `locked` flag (the Agent tool sets it on every isolated worktree). Add `git worktree unlock` before the `remove --force` — no-op on unlocked worktrees, fixes the silent failure on locked ones.