### PR TITLE
feat(voice): #1441 — path-segment auth for VAPI custom-LLM proxy (production-ready HMAC)

### DIFF
--- a/apps/admin/app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts
+++ b/apps/admin/app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts
@@ -1,0 +1,127 @@
+/**
+ * VAPI custom-llm proxy — path-segment auth surface (#1441).
+ *
+ * VAPI's custom-llm client APPENDS `/chat/completions` to whatever URL
+ * the assistant config provides. Both `model.secret` (rejected by
+ * schema) and `?secret=…` (mangled into the appended suffix) failed
+ * (#922). The path-segment scheme survives intact:
+ *
+ *   assistant.model.url = "<host>/api/voice/vapi/llm-proxy/auth/<HEX>"
+ *   VAPI appends "/chat/completions"
+ *   ─────────────────────────────────────────────────────────────────
+ *   final POST → "<host>/api/voice/vapi/llm-proxy/auth/<HEX>/chat/completions"
+ *
+ * Next.js matches the `[secret]` dynamic segment, hands it as
+ * `params.secret`. We hex-validate (defence against `..` traversal),
+ * timing-safe-compare against `credentials.webhookSecret`, then call
+ * the shared body handler.
+ *
+ * Format gate: only `[A-Fa-f0-9]` accepted in the path param. Any other
+ * character class returns 400 BEFORE the timing-safe compare runs —
+ * this stops path-traversal probes (`..`, slashes) and reserves the URL
+ * shape for the hex secrets the operator actually generates via
+ * `openssl rand -hex 32`.
+ */
+
+import { NextResponse } from "next/server";
+import { log } from "@/lib/logger";
+import { runVapiChatCompletion } from "@/lib/voice/llm-proxy/run-vapi-chat-completion";
+import { verifyVapiSecretFromPath } from "@/lib/voice/llm-proxy/verify-vapi-secret";
+
+export const runtime = "nodejs";
+
+const VAPI_SLUG = "vapi";
+
+const HEX_ONLY = /^[A-Fa-f0-9]+$/;
+/** Defensive lower + upper bounds. `openssl rand -hex 32` → 64 chars.
+ *  A short token (e.g. 16 chars hex = 64 bits of entropy) is weak but
+ *  not invalid; reject below 8 chars and above 256. */
+const MIN_SECRET_LEN = 8;
+const MAX_SECRET_LEN = 256;
+
+/**
+ * @api POST /api/voice/llm-proxy/auth/[secret]/chat/completions
+ * @visibility public
+ * @scope voice:llm-proxy:chat-completions
+ * @auth path-segment shared-secret
+ * @tags voice, anyvoice, custom-llm, path-segment-auth
+ * @description VAPI custom-llm proxy with auth via URL path segment.
+ *   Companion to `/api/voice/llm-proxy/chat/completions` (header auth /
+ *   pass-through). Both share the same body handler.
+ *
+ * @response 200 — same shape as the header-auth route
+ * @response 400 — invalid secret format in path (non-hex / too short / too long)
+ * @response 401 — path secret doesn't match stored webhookSecret
+ * @response 500 — Anthropic upstream error
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ secret: string }> },
+): Promise<Response> {
+  const { secret } = await params;
+  const callIdHeader = request.headers.get("x-vapi-call-id") ?? null;
+  log("api", "voice.llm_proxy.arrive", {
+    level: "info",
+    callId: callIdHeader,
+    userAgent: request.headers.get("user-agent") ?? null,
+    authSurface: "path-segment",
+    secretLen: secret?.length ?? 0,
+  });
+
+  if (!secret || typeof secret !== "string") {
+    log("system", "voice.llm_proxy.path.empty", {
+      level: "error",
+      callId: callIdHeader,
+    });
+    return NextResponse.json(
+      { error: { message: "Empty path secret", type: "invalid_request_error" } },
+      { status: 400 },
+    );
+  }
+  if (secret.length < MIN_SECRET_LEN || secret.length > MAX_SECRET_LEN) {
+    log("system", "voice.llm_proxy.path.bad_length", {
+      level: "error",
+      callId: callIdHeader,
+      secretLen: secret.length,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          message: `Path secret length out of bounds (${MIN_SECRET_LEN}–${MAX_SECRET_LEN})`,
+          type: "invalid_request_error",
+        },
+      },
+      { status: 400 },
+    );
+  }
+  if (!HEX_ONLY.test(secret)) {
+    log("system", "voice.llm_proxy.path.non_hex", {
+      level: "error",
+      callId: callIdHeader,
+      secretLen: secret.length,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          message: "Path secret must be hexadecimal characters only",
+          type: "invalid_request_error",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const auth = await verifyVapiSecretFromPath(secret, VAPI_SLUG);
+  if (!auth.ok) {
+    log("system", "voice.llm_proxy.auth_failed", {
+      level: "error",
+      callId: callIdHeader,
+      authSurface: "path-segment",
+    });
+    return auth.response ?? NextResponse.json(
+      { error: { message: "Auth failed", type: "auth_error" } },
+      { status: 401 },
+    );
+  }
+  return runVapiChatCompletion(request);
+}

--- a/apps/admin/app/api/voice/llm-proxy/chat/completions/route.ts
+++ b/apps/admin/app/api/voice/llm-proxy/chat/completions/route.ts
@@ -1,431 +1,72 @@
 /**
  * VAPI custom-llm proxy — OpenAI-compatible chat completions (#1176).
  *
- * VAPI POSTs here once per turn during a voice call when the voice
- * provider's `model.provider` is `custom-llm` and `model.url` points at
- * this route. We translate the OpenAI request to Anthropic, forward via
- * HF's metered AI wrapper, capture real token usage from the Anthropic
- * stream's `message_delta` event, and stream the response back in
- * OpenAI SSE format.
+ * **Header-auth surface.** VAPI POSTs here once per turn during a voice
+ * call when the `voiceProvider.config.voiceProvider === "custom-llm"`
+ * and `assistant.model.url === "<host>/api/voice/vapi/llm-proxy"`.
  *
  * Auth: `x-vapi-secret` header verified via timing-safe compare against
- * the VAPI VoiceProvider's `credentials.webhookSecret`.
+ * the VAPI VoiceProvider's `credentials.webhookSecret`. Pass-through
+ * when the secret is empty (local-dev convention). When the operator
+ * sets a webhookSecret, VAPI must include the matching header — but
+ * VAPI's custom-llm client offers no first-class way to send custom
+ * headers OR a non-mangled query param.
  *
- * Telemetry: every call logs both `logVoiceEvent` (voice op latency +
- * outcome) AND `logAIUsage` (per-token cost into the AI dashboard).
- * Voice cost shows up in `/x/settings/ai-costs` as `engine: "claude"`
- * with `sourceOp: "voice_llm_proxy"`.
+ * **For a configured secret, use the path-segment route instead:**
+ * `app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts`.
  *
- * Failure modes:
- *   - 401 → bad / missing secret
- *   - 400 → un-parseable request body
- *   - 500 → Anthropic upstream error (returned as OpenAI-format error)
+ * Auth pass-through here lets a dev VAPI assistant point at the
+ * plain `/llm-proxy` URL during smoke testing without setup overhead.
  *
- * None of these throw — they all return clean responses VAPI can read.
+ * Body handling, translation, and telemetry live in
+ * `lib/voice/llm-proxy/run-vapi-chat-completion.ts` so both auth
+ * surfaces share them.
  */
 
 import { NextResponse } from "next/server";
-
-import Anthropic from "@anthropic-ai/sdk";
-
-import { config } from "@/lib/config";
 import { log } from "@/lib/logger";
-import { logAIUsage } from "@/lib/metering/usage-logger";
-import { logVoiceEvent, startVoiceSpan } from "@/lib/voice/telemetry";
-
-import {
-  translateOpenAIRequestToAnthropic,
-  type OpenAIChatCompletionRequest,
-} from "@/lib/voice/llm-proxy/translate-request";
-import {
-  emptyCapturedUsage,
-  translateAnthropicToOpenAISSE,
-  type AnthropicStreamEvent,
-} from "@/lib/voice/llm-proxy/translate-stream";
+import { runVapiChatCompletion } from "@/lib/voice/llm-proxy/run-vapi-chat-completion";
 import { verifyVapiSecret } from "@/lib/voice/llm-proxy/verify-vapi-secret";
 
 export const runtime = "nodejs";
 
-/** Slug of the VAPI VoiceProvider whose `webhookSecret` authenticates
- *  inbound requests. Kept as a constant — there's exactly one VAPI
- *  provider per HF install today. Multiple-provider routing is a
- *  separate story. */
 const VAPI_SLUG = "vapi";
-
-let anthropicClient: Anthropic | null = null;
-function getAnthropicClient(): Anthropic {
-  if (!anthropicClient) {
-    const apiKey = config.ai.claude.apiKey ?? process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
-      throw new Error("Anthropic API key not configured (config.ai.claude.apiKey)");
-    }
-    anthropicClient = new Anthropic({ apiKey });
-  }
-  return anthropicClient;
-}
 
 /**
  * @api POST /api/voice/llm-proxy/chat/completions
- * @visibility public-via-vapi-secret
- * @auth x-vapi-secret header
- * @tags voice, llm, proxy, vapi
- * @description OpenAI-compatible chat-completions endpoint. VAPI's
- *   `custom-llm` provider calls this once per voice-turn. HF translates
- *   the request to Anthropic, forwards via the metered wrapper, and
- *   streams the response back in OpenAI SSE format. Real Anthropic token
- *   counts (including cache_read / cache_creation) are captured from
- *   the `message_delta` event and logged to AI metering.
- * @body { model, messages, stream?, temperature?, max_tokens?, tools?, ... }
- * @response 200 (streamed) — OpenAI chat-completion SSE chunks
- * @response 200 (non-streamed) — `{ id, choices: [{message,finish_reason}], usage }`
+ * @visibility public
+ * @scope voice:llm-proxy:chat-completions
+ * @auth shared-secret (`x-vapi-secret` header) — pass-through when empty
+ * @tags voice, anyvoice, custom-llm
+ * @description VAPI custom-llm chat completions, OpenAI-compatible
+ *   request shape, Anthropic upstream. See file docblock.
+ *
+ * @response 200 (streamed) — SSE OpenAI deltas (`text/event-stream`)
+ * @response 200 (non-streamed) — `{ id, choices, usage }`
  * @response 400 — un-parseable request body
  * @response 401 — bad / missing `x-vapi-secret`
  * @response 500 — Anthropic upstream error (OpenAI-format error body)
  */
-export async function POST(request: Request) {
-  const startMs = Date.now();
-  const endSpan = startVoiceSpan({
-    slug: VAPI_SLUG,
-    operation: "voice_llm_proxy",
-  });
-
+export async function POST(request: Request): Promise<Response> {
   const callIdHeader = request.headers.get("x-vapi-call-id") ?? null;
   log("api", "voice.llm_proxy.arrive", {
     level: "info",
     callId: callIdHeader,
     userAgent: request.headers.get("user-agent") ?? null,
     hasSecretHeader: request.headers.get("x-vapi-secret") !== null,
-    message: "VAPI custom-llm POST landed",
+    authSurface: "header",
   });
-
   const auth = await verifyVapiSecret(request, VAPI_SLUG);
   if (!auth.ok) {
-    log("system", "voice.llm_proxy.auth_failed", { level: "error", callId: callIdHeader });
-    endSpan({ errorMessage: "Auth failed" });
-    return auth.response!;
-  }
-
-  let body: OpenAIChatCompletionRequest;
-  try {
-    body = (await request.json()) as OpenAIChatCompletionRequest;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log("system", "voice.llm_proxy.bad_json", {
+    log("system", "voice.llm_proxy.auth_failed", {
       level: "error",
       callId: callIdHeader,
-      message: msg,
+      authSurface: "header",
     });
-    endSpan({ errorMessage: `Invalid JSON body: ${msg}` });
-    return NextResponse.json(
-      { error: { message: `Invalid JSON: ${msg}`, type: "invalid_request_error" } },
-      { status: 400 },
+    return auth.response ?? NextResponse.json(
+      { error: { message: "Auth failed", type: "auth_error" } },
+      { status: 401 },
     );
   }
-
-  const systemCharCount = (() => {
-    const sys = (body as Record<string, unknown>).messages as
-      | Array<{ role?: string; content?: unknown }>
-      | undefined;
-    if (!Array.isArray(sys)) return 0;
-    const sysMsg = sys.find((m) => m?.role === "system");
-    return typeof sysMsg?.content === "string" ? sysMsg.content.length : 0;
-  })();
-  log("api", "voice.llm_proxy.body_parsed", {
-    level: "info",
-    callId: callIdHeader,
-    model: (body as Record<string, unknown>).model ?? null,
-    messageCount: Array.isArray((body as Record<string, unknown>).messages)
-      ? ((body as Record<string, unknown>).messages as unknown[]).length
-      : 0,
-    systemCharCount,
-    toolCount: Array.isArray((body as Record<string, unknown>).tools)
-      ? ((body as Record<string, unknown>).tools as unknown[]).length
-      : 0,
-    stream: Boolean((body as Record<string, unknown>).stream),
-  });
-
-  let translated;
-  try {
-    translated = translateOpenAIRequestToAnthropic(body);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log("system", "voice.llm_proxy.translate_failed", {
-      level: "error",
-      callId: callIdHeader,
-      message: msg,
-    });
-    endSpan({ errorMessage: `Translation failed: ${msg}` });
-    return NextResponse.json(
-      { error: { message: msg, type: "invalid_request_error" } },
-      { status: 400 },
-    );
-  }
-
-  // Extract VAPI metadata when present — passed as a custom header per
-  // VAPI's custom-llm contract. Used for telemetry tagging.
-  const callId = callIdHeader;
-  log("api", "voice.llm_proxy.translated", {
-    level: "info",
-    callId,
-    anthropicModel: translated.model,
-    anthropicMessageCount: translated.messages.length,
-    hasSystem: translated.system !== undefined,
-    hasTools: Boolean(translated.tools?.length),
-    maxTokens: translated.max_tokens,
-  });
-
-  // Build the Anthropic create params.
-  const anthropicParams: Record<string, unknown> = {
-    model: translated.model,
-    max_tokens: translated.max_tokens,
-    temperature: translated.temperature,
-    messages: translated.messages,
-  };
-  if (translated.system !== undefined) {
-    anthropicParams.system = translated.system;
-  }
-  if (translated.tools) {
-    anthropicParams.tools = translated.tools;
-  }
-
-  const client = getAnthropicClient();
-  const completionId = `chatcmpl-${cryptoRandomId()}`;
-
-  // Streaming path — the only one VAPI actually uses for low-latency
-  // voice. Non-streaming exists for parity / testing only.
-  if (translated.stream) {
-    let stream;
-    try {
-      log("api", "voice.llm_proxy.stream_open", {
-        level: "info",
-        callId,
-        completionId,
-        model: translated.model,
-      });
-      stream = client.messages.stream(
-        anthropicParams as unknown as Anthropic.MessageStreamParams,
-      );
-    } catch (err) {
-      log("system", "voice.llm_proxy.stream_open_failed", {
-        level: "error",
-        callId,
-        completionId,
-        model: translated.model,
-        message: err instanceof Error ? err.message : String(err),
-      });
-      return handleAnthropicError(err, completionId, translated.model, endSpan, callId);
-    }
-
-    const usage = emptyCapturedUsage();
-    const sse = translateAnthropicToOpenAISSE(
-      stream as unknown as AsyncIterable<AnthropicStreamEvent>,
-      {
-        completionId,
-        model: translated.model,
-        usage,
-      },
-    );
-
-    // Wrap the SSE stream so we can fire `logAIUsage` and end the span
-    // AFTER the stream has fully drained. We tee the stream so the
-    // response gets the bytes AND we observe completion.
-    const [forResponse, forObserver] = sse.tee();
-    void observeStreamEnd(forObserver, () => {
-      const durationMs = Date.now() - startMs;
-      if (usage.captured) {
-        void logAIUsage({
-          engine: "claude",
-          model: translated.model,
-          inputTokens: usage.inputTokens,
-          outputTokens: usage.outputTokens,
-          callId: callId ?? undefined,
-          sourceOp: "voice_llm_proxy",
-          metadata: {
-            cacheReadTokens: usage.cacheReadInputTokens,
-            cacheCreationTokens: usage.cacheCreationInputTokens,
-            voiceProviderSlug: VAPI_SLUG,
-            durationMs,
-          },
-        });
-      }
-      logVoiceEvent({
-        slug: VAPI_SLUG,
-        operation: "voice_llm_proxy",
-        durationMs,
-        callId,
-        metadata: {
-          model: translated.model,
-          usageCaptured: usage.captured,
-          inputTokens: usage.inputTokens,
-          outputTokens: usage.outputTokens,
-          cacheReadTokens: usage.cacheReadInputTokens,
-          cacheCreationTokens: usage.cacheCreationInputTokens,
-        },
-      });
-      log("api", "voice.llm_proxy.stream_done", {
-        level: "info",
-        callId,
-        completionId,
-        durationMs,
-        model: translated.model,
-        usageCaptured: usage.captured,
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
-        cacheReadTokens: usage.cacheReadInputTokens,
-        cacheCreationTokens: usage.cacheCreationInputTokens,
-      });
-      endSpan({});
-    });
-
-    return new Response(forResponse, {
-      status: 200,
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache, no-transform",
-        Connection: "keep-alive",
-      },
-    });
-  }
-
-  // Non-streaming path.
-  try {
-    const message = await client.messages.create(
-      anthropicParams as unknown as Anthropic.MessageCreateParamsNonStreaming,
-    );
-    const durationMs = Date.now() - startMs;
-    void logAIUsage({
-      engine: "claude",
-      model: translated.model,
-      inputTokens: message.usage?.input_tokens ?? 0,
-      outputTokens: message.usage?.output_tokens ?? 0,
-      callId: callId ?? undefined,
-      sourceOp: "voice_llm_proxy",
-      metadata: {
-        cacheReadTokens: message.usage?.cache_read_input_tokens ?? 0,
-        cacheCreationTokens: message.usage?.cache_creation_input_tokens ?? 0,
-        voiceProviderSlug: VAPI_SLUG,
-        durationMs,
-      },
-    });
-    logVoiceEvent({
-      slug: VAPI_SLUG,
-      operation: "voice_llm_proxy",
-      durationMs,
-      callId,
-      metadata: {
-        model: translated.model,
-        stream: false,
-      },
-    });
-    endSpan({});
-
-    // Pack the Anthropic response into an OpenAI chat-completion shape.
-    const text = message.content
-      .filter((c): c is Anthropic.TextBlock => c.type === "text")
-      .map((c) => c.text)
-      .join("");
-    return NextResponse.json({
-      id: completionId,
-      object: "chat.completion",
-      created: Math.floor(Date.now() / 1000),
-      model: translated.model,
-      choices: [
-        {
-          index: 0,
-          message: { role: "assistant", content: text },
-          finish_reason: mapStopReason(message.stop_reason),
-        },
-      ],
-      usage: {
-        prompt_tokens: message.usage?.input_tokens ?? 0,
-        completion_tokens: message.usage?.output_tokens ?? 0,
-        total_tokens:
-          (message.usage?.input_tokens ?? 0) + (message.usage?.output_tokens ?? 0),
-      },
-    });
-  } catch (err) {
-    return handleAnthropicError(err, completionId, translated.model, endSpan, callId);
-  }
-}
-
-function handleAnthropicError(
-  err: unknown,
-  completionId: string,
-  model: string,
-  endSpan: (input: { errorMessage?: string }) => void,
-  callId: string | null,
-): Response {
-  const msg = err instanceof Error ? err.message : String(err);
-  const stack = err instanceof Error ? err.stack ?? null : null;
-  const errStatus = (err as { status?: number })?.status ?? null;
-  console.error("[voice/llm-proxy] Anthropic upstream error:", msg);
-  log("system", "voice.llm_proxy.anthropic_error", {
-    level: "error",
-    callId,
-    completionId,
-    model,
-    upstreamStatus: errStatus,
-    message: msg,
-    stack,
-  });
-  endSpan({ errorMessage: msg });
-  logVoiceEvent({
-    slug: VAPI_SLUG,
-    operation: "voice_llm_proxy",
-    durationMs: 0,
-    metadata: { model, errorPath: "anthropic_upstream", upstreamStatus: errStatus },
-    errorMessage: msg,
-  });
-  return NextResponse.json(
-    {
-      id: completionId,
-      error: {
-        message: `Anthropic upstream error: ${msg}`,
-        type: "upstream_error",
-      },
-    },
-    { status: 500 },
-  );
-}
-
-function mapStopReason(
-  reason: Anthropic.Message["stop_reason"],
-): "stop" | "length" | "tool_calls" {
-  switch (reason) {
-    case "end_turn":
-      return "stop";
-    case "max_tokens":
-      return "length";
-    case "tool_use":
-      return "tool_calls";
-    case "stop_sequence":
-      return "stop";
-    default:
-      return "stop";
-  }
-}
-
-async function observeStreamEnd(
-  stream: ReadableStream<Uint8Array>,
-  onEnd: () => void,
-): Promise<void> {
-  const reader = stream.getReader();
-  try {
-    // Drain to EOF — we only care about completion, not the bytes.
-    while (true) {
-      const { done } = await reader.read();
-      if (done) break;
-    }
-  } catch {
-    // Swallow — the response stream's own error path is what matters.
-  } finally {
-    onEnd();
-    reader.releaseLock();
-  }
-}
-
-function cryptoRandomId(): string {
-  // Short, URL-safe random id. Anthropic IDs are longer; OpenAI's are
-  // ~24 chars. This satisfies the format VAPI expects.
-  return Math.random().toString(36).slice(2, 14);
+  return runVapiChatCompletion(request);
 }

--- a/apps/admin/lib/voice/llm-proxy/run-vapi-chat-completion.ts
+++ b/apps/admin/lib/voice/llm-proxy/run-vapi-chat-completion.ts
@@ -1,0 +1,367 @@
+/**
+ * Shared body handler for VAPI custom-LLM POSTs (#1441 — extracted from
+ * the route file so two auth surfaces can call it).
+ *
+ *   - Header / query auth surface: `/api/voice/llm-proxy/chat/completions`
+ *   - Path-segment auth surface:   `/api/voice/llm-proxy/auth/[secret]/chat/completions`
+ *
+ * Each route does its own auth then calls `runVapiChatCompletion` with
+ * the already-authenticated Request. NO auth here.
+ *
+ * This module owns everything from "parse the OpenAI request" through
+ * "stream back the SSE response", including translation to Anthropic
+ * and `logAIUsage` / `logVoiceEvent` telemetry. Pre-fix this logic was
+ * 240 lines inside a single 431-line route file; splitting auth
+ * surfaces was untenable until extraction.
+ */
+
+import { NextResponse } from "next/server";
+
+import Anthropic from "@anthropic-ai/sdk";
+
+import { config } from "@/lib/config";
+import { log } from "@/lib/logger";
+import { logAIUsage } from "@/lib/metering/usage-logger";
+import { logVoiceEvent, startVoiceSpan } from "@/lib/voice/telemetry";
+
+import {
+  translateOpenAIRequestToAnthropic,
+  type OpenAIChatCompletionRequest,
+} from "./translate-request";
+import {
+  emptyCapturedUsage,
+  translateAnthropicToOpenAISSE,
+  type AnthropicStreamEvent,
+} from "./translate-stream";
+
+/** Slug of the VAPI VoiceProvider whose telemetry tag is used. */
+const VAPI_SLUG = "vapi";
+
+let anthropicClient: Anthropic | null = null;
+function getAnthropicClient(): Anthropic {
+  if (!anthropicClient) {
+    const apiKey = config.ai.claude.apiKey ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error("Anthropic API key not configured (config.ai.claude.apiKey)");
+    }
+    anthropicClient = new Anthropic({ apiKey });
+  }
+  return anthropicClient;
+}
+
+export async function runVapiChatCompletion(request: Request): Promise<Response> {
+  const startMs = Date.now();
+  const endSpan = startVoiceSpan({
+    slug: VAPI_SLUG,
+    operation: "voice_llm_proxy",
+  });
+  const callIdHeader = request.headers.get("x-vapi-call-id") ?? null;
+
+  let body: OpenAIChatCompletionRequest;
+  try {
+    body = (await request.json()) as OpenAIChatCompletionRequest;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log("system", "voice.llm_proxy.bad_json", {
+      level: "error",
+      callId: callIdHeader,
+      message: msg,
+    });
+    endSpan({ errorMessage: `Invalid JSON body: ${msg}` });
+    return NextResponse.json(
+      { error: { message: `Invalid JSON: ${msg}`, type: "invalid_request_error" } },
+      { status: 400 },
+    );
+  }
+
+  const systemCharCount = (() => {
+    const sys = (body as Record<string, unknown>).messages as
+      | Array<{ role?: string; content?: unknown }>
+      | undefined;
+    if (!Array.isArray(sys)) return 0;
+    const sysMsg = sys.find((m) => m?.role === "system");
+    return typeof sysMsg?.content === "string" ? sysMsg.content.length : 0;
+  })();
+  log("api", "voice.llm_proxy.body_parsed", {
+    level: "info",
+    callId: callIdHeader,
+    model: (body as Record<string, unknown>).model ?? null,
+    messageCount: Array.isArray((body as Record<string, unknown>).messages)
+      ? ((body as Record<string, unknown>).messages as unknown[]).length
+      : 0,
+    systemCharCount,
+    toolCount: Array.isArray((body as Record<string, unknown>).tools)
+      ? ((body as Record<string, unknown>).tools as unknown[]).length
+      : 0,
+    stream: Boolean((body as Record<string, unknown>).stream),
+  });
+
+  let translated;
+  try {
+    translated = translateOpenAIRequestToAnthropic(body);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log("system", "voice.llm_proxy.translate_failed", {
+      level: "error",
+      callId: callIdHeader,
+      message: msg,
+    });
+    endSpan({ errorMessage: `Translation failed: ${msg}` });
+    return NextResponse.json(
+      { error: { message: msg, type: "invalid_request_error" } },
+      { status: 400 },
+    );
+  }
+
+  const callId = callIdHeader;
+  log("api", "voice.llm_proxy.translated", {
+    level: "info",
+    callId,
+    anthropicModel: translated.model,
+    anthropicMessageCount: translated.messages.length,
+    hasSystem: translated.system !== undefined,
+    hasTools: Boolean(translated.tools?.length),
+    maxTokens: translated.max_tokens,
+  });
+
+  const anthropicParams: Record<string, unknown> = {
+    model: translated.model,
+    max_tokens: translated.max_tokens,
+    temperature: translated.temperature,
+    messages: translated.messages,
+  };
+  if (translated.system !== undefined) {
+    anthropicParams.system = translated.system;
+  }
+  if (translated.tools) {
+    anthropicParams.tools = translated.tools;
+  }
+
+  const client = getAnthropicClient();
+  const completionId = `chatcmpl-${cryptoRandomId()}`;
+
+  if (translated.stream) {
+    let stream;
+    try {
+      log("api", "voice.llm_proxy.stream_open", {
+        level: "info",
+        callId,
+        completionId,
+        model: translated.model,
+      });
+      stream = client.messages.stream(
+        anthropicParams as unknown as Anthropic.MessageStreamParams,
+      );
+    } catch (err) {
+      log("system", "voice.llm_proxy.stream_open_failed", {
+        level: "error",
+        callId,
+        completionId,
+        model: translated.model,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return handleAnthropicError(err, completionId, translated.model, endSpan, callId);
+    }
+
+    const usage = emptyCapturedUsage();
+    const sse = translateAnthropicToOpenAISSE(
+      stream as unknown as AsyncIterable<AnthropicStreamEvent>,
+      {
+        completionId,
+        model: translated.model,
+        usage,
+      },
+    );
+
+    const [forResponse, forObserver] = sse.tee();
+    void observeStreamEnd(forObserver, () => {
+      const durationMs = Date.now() - startMs;
+      if (usage.captured) {
+        void logAIUsage({
+          engine: "claude",
+          model: translated.model,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          callId: callId ?? undefined,
+          sourceOp: "voice_llm_proxy",
+          metadata: {
+            cacheReadTokens: usage.cacheReadInputTokens,
+            cacheCreationTokens: usage.cacheCreationInputTokens,
+            voiceProviderSlug: VAPI_SLUG,
+            durationMs,
+          },
+        });
+      }
+      logVoiceEvent({
+        slug: VAPI_SLUG,
+        operation: "voice_llm_proxy",
+        durationMs,
+        callId,
+        metadata: {
+          model: translated.model,
+          usageCaptured: usage.captured,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          cacheReadTokens: usage.cacheReadInputTokens,
+          cacheCreationTokens: usage.cacheCreationInputTokens,
+        },
+      });
+      log("api", "voice.llm_proxy.stream_done", {
+        level: "info",
+        callId,
+        completionId,
+        durationMs,
+        model: translated.model,
+        usageCaptured: usage.captured,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cacheReadTokens: usage.cacheReadInputTokens,
+        cacheCreationTokens: usage.cacheCreationInputTokens,
+      });
+      endSpan({});
+    });
+
+    return new Response(forResponse, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  try {
+    const message = await client.messages.create(
+      anthropicParams as unknown as Anthropic.MessageCreateParamsNonStreaming,
+    );
+    const durationMs = Date.now() - startMs;
+    void logAIUsage({
+      engine: "claude",
+      model: translated.model,
+      inputTokens: message.usage?.input_tokens ?? 0,
+      outputTokens: message.usage?.output_tokens ?? 0,
+      callId: callId ?? undefined,
+      sourceOp: "voice_llm_proxy",
+      metadata: {
+        cacheReadTokens: message.usage?.cache_read_input_tokens ?? 0,
+        cacheCreationTokens: message.usage?.cache_creation_input_tokens ?? 0,
+        voiceProviderSlug: VAPI_SLUG,
+        durationMs,
+      },
+    });
+    logVoiceEvent({
+      slug: VAPI_SLUG,
+      operation: "voice_llm_proxy",
+      durationMs,
+      callId,
+      metadata: { model: translated.model, stream: false },
+    });
+    endSpan({});
+
+    const text = message.content
+      .filter((c): c is Anthropic.TextBlock => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    return NextResponse.json({
+      id: completionId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: translated.model,
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: text },
+          finish_reason: mapStopReason(message.stop_reason),
+        },
+      ],
+      usage: {
+        prompt_tokens: message.usage?.input_tokens ?? 0,
+        completion_tokens: message.usage?.output_tokens ?? 0,
+        total_tokens:
+          (message.usage?.input_tokens ?? 0) + (message.usage?.output_tokens ?? 0),
+      },
+    });
+  } catch (err) {
+    return handleAnthropicError(err, completionId, translated.model, endSpan, callId);
+  }
+}
+
+function handleAnthropicError(
+  err: unknown,
+  completionId: string,
+  model: string,
+  endSpan: (input: { errorMessage?: string }) => void,
+  callId: string | null,
+): Response {
+  const msg = err instanceof Error ? err.message : String(err);
+  const stack = err instanceof Error ? err.stack ?? null : null;
+  const errStatus = (err as { status?: number })?.status ?? null;
+  console.error("[voice/llm-proxy] Anthropic upstream error:", msg);
+  log("system", "voice.llm_proxy.anthropic_error", {
+    level: "error",
+    callId,
+    completionId,
+    model,
+    upstreamStatus: errStatus,
+    message: msg,
+    stack,
+  });
+  endSpan({ errorMessage: msg });
+  logVoiceEvent({
+    slug: VAPI_SLUG,
+    operation: "voice_llm_proxy",
+    durationMs: 0,
+    metadata: { model, errorPath: "anthropic_upstream", upstreamStatus: errStatus },
+    errorMessage: msg,
+  });
+  return NextResponse.json(
+    {
+      id: completionId,
+      error: {
+        message: `Anthropic upstream error: ${msg}`,
+        type: "upstream_error",
+      },
+    },
+    { status: 500 },
+  );
+}
+
+function mapStopReason(
+  reason: Anthropic.Message["stop_reason"],
+): "stop" | "length" | "tool_calls" {
+  switch (reason) {
+    case "end_turn":
+      return "stop";
+    case "max_tokens":
+      return "length";
+    case "tool_use":
+      return "tool_calls";
+    case "stop_sequence":
+      return "stop";
+    default:
+      return "stop";
+  }
+}
+
+async function observeStreamEnd(
+  stream: ReadableStream<Uint8Array>,
+  onEnd: () => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+  } catch {
+    // Swallow — the response stream's own error path is what matters.
+  } finally {
+    onEnd();
+    reader.releaseLock();
+  }
+}
+
+function cryptoRandomId(): string {
+  return Math.random().toString(36).slice(2, 14);
+}

--- a/apps/admin/lib/voice/llm-proxy/verify-vapi-secret.ts
+++ b/apps/admin/lib/voice/llm-proxy/verify-vapi-secret.ts
@@ -37,6 +37,103 @@ export interface SecretVerifyResult {
 }
 
 /**
+ * #1441 — Verify a secret already extracted from a URL path segment
+ * against the slug's stored webhookSecret. Used by
+ * `/api/voice/llm-proxy/auth/[secret]/chat/completions` — the only
+ * auth surface that survives VAPI's URL-concatenation mangling
+ * (see `lib/voice/providers/vapi/index.ts` #922 comments).
+ *
+ * Unlike `verifyVapiSecret` which pass-throughs when no secret is
+ * configured (local-dev convention on the header surface), this
+ * variant ALWAYS rejects when `webhookSecret` is empty — the operator
+ * chose path-segment auth, so the secret has to be present.
+ */
+export async function verifyVapiSecretFromPath(
+  presented: string,
+  slug: string,
+): Promise<SecretVerifyResult> {
+  const providerRow = await prisma.voiceProvider.findUnique({
+    where: { slug },
+    select: { slug: true, credentials: true },
+  });
+  if (!providerRow) {
+    log("system", "voice.llm_proxy.secret.unknown_slug", {
+      level: "error",
+      slug,
+      headerPresent: false,
+      headerLen: presented.length,
+    });
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: { message: `Unknown voice provider slug: ${slug}`, type: "auth_error" } },
+        { status: 401 },
+      ),
+    };
+  }
+  const creds = (providerRow.credentials as Record<string, unknown>) ?? {};
+  const expectedRaw = typeof creds.webhookSecret === "string" ? creds.webhookSecret : "";
+  if (!expectedRaw) {
+    log("system", "voice.llm_proxy.secret.path.no_expected", {
+      level: "error",
+      slug,
+      presentedLen: presented.length,
+      message:
+        "Path-segment auth requires a configured webhookSecret. Either set it or use the /chat/completions pass-through surface.",
+    });
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: {
+            message:
+              "Path-segment auth requires a configured webhookSecret on the VAPI VoiceProvider row.",
+            type: "auth_error",
+          },
+        },
+        { status: 401 },
+      ),
+    };
+  }
+  if (!presented) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: { message: "Empty secret path param", type: "auth_error" } },
+        { status: 401 },
+      ),
+    };
+  }
+  const expectedBuf = Buffer.from(expectedRaw);
+  const presentedBuf = Buffer.from(presented);
+  if (
+    presentedBuf.length === expectedBuf.length &&
+    crypto.timingSafeEqual(expectedBuf, presentedBuf)
+  ) {
+    log("system", "voice.llm_proxy.secret.ok", {
+      level: "info",
+      slug,
+      expectedLen: expectedBuf.length,
+      source: "path",
+    });
+    return { ok: true, providerSlug: providerRow.slug };
+  }
+  log("system", "voice.llm_proxy.secret.path.no_match", {
+    level: "error",
+    slug,
+    expectedLen: expectedBuf.length,
+    presentedLen: presentedBuf.length,
+  });
+  return {
+    ok: false,
+    response: NextResponse.json(
+      { error: { message: "Invalid secret", type: "auth_error" } },
+      { status: 401 },
+    ),
+  };
+}
+
+/**
  * Verify the request's `x-vapi-secret` header against the slug's
  * stored webhookSecret. Pass-through when no secret is configured.
  */

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -154,11 +154,28 @@ export class VapiProvider implements VoiceProvider {
     //   2. `?secret=...` query — VAPI naively concatenates
     //      "/chat/completions" onto the END, mangling the value.
     //   3. Pass-through auth (empty webhookSecret) — works in dev.
-    //      Prod will need a path-segment scheme.
-    const customLlmProxyUrl = ctx.serverUrlBase
+    //   4. **Path-segment auth (#TBD-pathseg)** — survives VAPI's
+    //      "/chat/completions" append cleanly. When `ctx.customLlmSecret`
+    //      is set AND hex-shaped, URL becomes ".../llm-proxy/auth/<HEX>";
+    //      VAPI's append produces ".../llm-proxy/auth/<HEX>/chat/completions"
+    //      → hits `app/api/voice/llm-proxy/auth/[secret]/chat/completions`
+    //      which path-validates + timing-safe-compares against
+    //      `credentials.webhookSecret`. Non-hex / wrong-length secrets
+    //      fall back to the header surface — pass-through if empty,
+    //      401 otherwise (the operator should see a clear error in the
+    //      VM log + diag dump rather than ship a mangled URL).
+    const llmProxyBase = ctx.serverUrlBase
       .replace(new RegExp(`/${this.slug}$`), "")
       .concat("/llm-proxy");
-    void ctx.customLlmSecret; // intentionally unused — see comment above
+    const secret = ctx.customLlmSecret;
+    const useHexPathSegment =
+      typeof secret === "string" &&
+      secret.length >= 8 &&
+      secret.length <= 256 &&
+      /^[A-Fa-f0-9]+$/.test(secret);
+    const customLlmProxyUrl = useHexPathSegment
+      ? `${llmProxyBase}/auth/${secret}`
+      : llmProxyBase;
     const modelBlock: Record<string, unknown> = isCustomLlm
       ? {
           provider: "custom-llm",

--- a/apps/admin/tests/api/voice-llm-proxy-path-segment.test.ts
+++ b/apps/admin/tests/api/voice-llm-proxy-path-segment.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the path-segment auth surface on the VAPI custom-LLM proxy
+ * (#TBD-pathseg). Pins:
+ *
+ *   - Non-hex path → 400 (defence against `..` traversal)
+ *   - Short / long path → 400 (bounds)
+ *   - Hex path but no webhookSecret on row → 401
+ *   - Hex path mismatching webhookSecret → 401
+ *   - Hex path matching webhookSecret → handler reached (200 from mocked run)
+ *
+ * Body-handler logic itself is tested separately by the existing
+ * `tests/api/voice-llm-proxy.test.ts` (which uses the header surface).
+ * This file only exercises the path-segment route's auth layer +
+ * format-validation guard.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockFindUnique = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    voiceProvider: { findUnique: mockFindUnique },
+  },
+}));
+
+const mockRunVapiChatCompletion = vi.fn(
+  async () =>
+    new Response("body-handler-ok", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    }),
+);
+vi.mock("@/lib/voice/llm-proxy/run-vapi-chat-completion", () => ({
+  runVapiChatCompletion: mockRunVapiChatCompletion,
+}));
+
+vi.mock("@/lib/voice/telemetry", () => ({
+  startVoiceSpan: vi.fn(() => () => undefined),
+  logVoiceEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: vi.fn(),
+}));
+
+const EXPECTED_HEX = "f7143c63081d22eb14bde7e6ad4de5408fb8885714fd38ad88fa8d83782082ac"; // 64-char
+
+beforeEach(() => {
+  mockFindUnique.mockReset();
+  mockRunVapiChatCompletion.mockClear();
+});
+
+function postRequest(): Request {
+  return new Request("http://test/api/voice/llm-proxy/auth/X/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "claude-haiku-4-5", messages: [], stream: false }),
+  });
+}
+
+async function callRoute(secret: string) {
+  const mod = await import(
+    "@/app/api/voice/llm-proxy/auth/[secret]/chat/completions/route"
+  );
+  return mod.POST(postRequest(), {
+    params: Promise.resolve({ secret }),
+  });
+}
+
+describe("POST /api/voice/llm-proxy/auth/[secret]/chat/completions (#TBD-pathseg)", () => {
+  it("400 — empty secret param", async () => {
+    const res = await callRoute("");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/Empty path secret/);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("400 — too short (below 8 chars)", async () => {
+    const res = await callRoute("ab12cd");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/length out of bounds/);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("400 — too long (above 256 chars)", async () => {
+    const tooLong = "a".repeat(257);
+    const res = await callRoute(tooLong);
+    expect(res.status).toBe(400);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("400 — non-hex characters (path-traversal defence)", async () => {
+    const res = await callRoute("../../../etc/passwd");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/hexadecimal/);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("400 — slash in secret (path-traversal defence)", async () => {
+    const res = await callRoute("abc/def");
+    expect(res.status).toBe(400);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("401 — no VoiceProvider row for the slug", async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+    const res = await callRoute(EXPECTED_HEX);
+    expect(res.status).toBe(401);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("401 — webhookSecret is empty on the row (path-segment requires it)", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      slug: "vapi",
+      credentials: {},
+    });
+    const res = await callRoute(EXPECTED_HEX);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/requires a configured webhookSecret/);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("401 — path secret doesn't match stored webhookSecret", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      slug: "vapi",
+      credentials: { webhookSecret: "deadbeefcafebabe1234567890abcdef" },
+    });
+    const res = await callRoute(EXPECTED_HEX);
+    expect(res.status).toBe(401);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("401 — length mismatches stored webhookSecret (defends timing-safe-equal)", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      slug: "vapi",
+      credentials: { webhookSecret: "shortabcd" },
+    });
+    const res = await callRoute(EXPECTED_HEX);
+    expect(res.status).toBe(401);
+    expect(mockRunVapiChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("200 — hex path secret matches stored webhookSecret → calls body handler", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      slug: "vapi",
+      credentials: { webhookSecret: EXPECTED_HEX },
+    });
+    const res = await callRoute(EXPECTED_HEX);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("body-handler-ok");
+    expect(mockRunVapiChatCompletion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin/tests/lib/voice/vapi-custom-llm-url.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-custom-llm-url.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for VAPI adapter's customLlmProxyUrl construction (#TBD-pathseg).
+ *
+ * Pins the URL shape we send to VAPI in the assistant config:
+ *   - empty/non-hex secret → bare ".../llm-proxy" (pass-through surface)
+ *   - hex secret in [8..256] → ".../llm-proxy/auth/<HEX>" (path-segment)
+ *
+ * VAPI's custom-LLM client appends "/chat/completions" to whatever URL
+ * we hand it. The route layer handles the resulting paths.
+ */
+
+import { describe, expect, it } from "vitest";
+import { VapiProvider } from "@/lib/voice/providers/vapi";
+import type { AssistantRequestContext } from "@/lib/voice/types";
+
+const adapter = new VapiProvider({}, {});
+
+function buildCtx(
+  customLlmSecret: string | undefined,
+): AssistantRequestContext {
+  return {
+    callerId: "caller-abc",
+    callerName: "Test Caller",
+    customerPhone: null,
+    voicePrompt: "You are a tutor.",
+    firstLine: "Hi.",
+    toolDefinitions: [],
+    knowledgePlanEnabled: false,
+    serverUrlBase: "https://hf.example.com/api/voice/vapi",
+    modelConfig: { provider: "custom-llm", model: "claude-haiku-4-5" },
+    unknownCallerPrompt: "Hello.",
+    noActivePromptFallback: "Hi.",
+    costSafetyKnobs: {
+      silenceTimeoutSeconds: 30,
+      maxDurationSeconds: 600,
+      voicemailDetectionEnabled: true,
+      endCallPhrases: ["goodbye"],
+    },
+    customLlmSecret,
+    voiceConfig: undefined,
+  } as AssistantRequestContext;
+}
+
+function extractModelUrl(assistantConfig: Record<string, unknown>): string {
+  const inner = (assistantConfig.assistant ?? assistantConfig) as Record<string, unknown>;
+  const model = inner.model as Record<string, unknown>;
+  return String(model.url ?? "");
+}
+
+describe("VapiProvider.buildAssistantConfig — customLlmProxyUrl shape", () => {
+  it("empty secret → bare ./llm-proxy (header-auth pass-through surface)", () => {
+    const cfg = adapter.buildAssistantConfig(buildCtx(undefined));
+    expect(extractModelUrl(cfg)).toBe(
+      "https://hf.example.com/api/voice/llm-proxy",
+    );
+  });
+
+  it("hex secret (64 chars) → /llm-proxy/auth/<HEX>", () => {
+    const hex64 = "f7143c63081d22eb14bde7e6ad4de5408fb8885714fd38ad88fa8d83782082ac";
+    const cfg = adapter.buildAssistantConfig(buildCtx(hex64));
+    expect(extractModelUrl(cfg)).toBe(
+      `https://hf.example.com/api/voice/llm-proxy/auth/${hex64}`,
+    );
+  });
+
+  it("hex secret (16 chars) → still path-segment", () => {
+    const hex16 = "deadbeefcafebabe";
+    const cfg = adapter.buildAssistantConfig(buildCtx(hex16));
+    expect(extractModelUrl(cfg)).toBe(
+      `https://hf.example.com/api/voice/llm-proxy/auth/${hex16}`,
+    );
+  });
+
+  it("hex secret (7 chars) → too short, falls back to bare", () => {
+    const tooShort = "abc1234";
+    const cfg = adapter.buildAssistantConfig(buildCtx(tooShort));
+    expect(extractModelUrl(cfg)).toBe(
+      "https://hf.example.com/api/voice/llm-proxy",
+    );
+  });
+
+  it("non-hex secret → falls back to bare (no risk of mangled URL)", () => {
+    const nonHex = "this-is-not-hex!";
+    const cfg = adapter.buildAssistantConfig(buildCtx(nonHex));
+    expect(extractModelUrl(cfg)).toBe(
+      "https://hf.example.com/api/voice/llm-proxy",
+    );
+  });
+
+  it("secret with whitespace → falls back to bare", () => {
+    const withSpace = "abc def 123 4567";
+    const cfg = adapter.buildAssistantConfig(buildCtx(withSpace));
+    expect(extractModelUrl(cfg)).toBe(
+      "https://hf.example.com/api/voice/llm-proxy",
+    );
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -15425,20 +15425,48 @@ Health snapshot for a voice provider (AnyVoice #1080).
 
 ---
 
-### `POST` /api/voice/llm-proxy/chat/completions
+### `POST` /api/voice/llm-proxy/auth/[secret]/chat/completions
 
-OpenAI-compatible chat-completions endpoint. VAPI's
+VAPI custom-llm proxy with auth via URL path segment.
 
-**Auth**: x-vapi-secret header
+**Auth**: path-segment shared-secret · **Scope**: `voice:llm-proxy:chat-completions`
 
 **Response** `200`
 ```json
-(streamed) — OpenAI chat-completion SSE chunks
+— same shape as the header-auth route
+```
+
+**Response** `400`
+```json
+— invalid secret format in path (non-hex / too short / too long)
+```
+
+**Response** `401`
+```json
+— path secret doesn't match stored webhookSecret
+```
+
+**Response** `500`
+```json
+— Anthropic upstream error
+```
+
+---
+
+### `POST` /api/voice/llm-proxy/chat/completions
+
+VAPI custom-llm chat completions, OpenAI-compatible
+
+**Auth**: shared-secret (`x-vapi-secret` header) — pass-through when empty · **Scope**: `voice:llm-proxy:chat-completions`
+
+**Response** `200`
+```json
+(streamed) — SSE OpenAI deltas (`text/event-stream`)
 ```
 
 **Response** `200`
 ```json
-(non-streamed) — `{ id, choices: [{message,finish_reason}], usage }`
+(non-streamed) — `{ id, choices, usage }`
 ```
 
 **Response** `400`
@@ -15809,8 +15837,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 505 |
-| Files with annotations | 495 |
+| Route files found | 506 |
+| Files with annotations | 496 |
 | Files missing annotations | 10 |
 | Coverage | 98.0% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -4964,6 +4964,67 @@ Shared voice provider webhook endpoint (AnyVoice #1079).
 
 ---
 
+### `POST` /api/v1/voice/llm-proxy/auth/[secret]/chat/completions
+
+VAPI custom-llm proxy with auth via URL path segment.
+
+**Auth**: path-segment shared-secret · **Scope**: `voice:llm-proxy:chat-completions`
+
+**Response** `200`
+```json
+— same shape as the header-auth route
+```
+
+**Response** `400`
+```json
+— invalid secret format in path (non-hex / too short / too long)
+```
+
+**Response** `401`
+```json
+— path secret doesn't match stored webhookSecret
+```
+
+**Response** `500`
+```json
+— Anthropic upstream error
+```
+
+---
+
+### `POST` /api/v1/voice/llm-proxy/chat/completions
+
+VAPI custom-llm chat completions, OpenAI-compatible
+
+**Auth**: shared-secret (`x-vapi-secret` header) — pass-through when empty · **Scope**: `voice:llm-proxy:chat-completions`
+
+**Response** `200`
+```json
+(streamed) — SSE OpenAI deltas (`text/event-stream`)
+```
+
+**Response** `200`
+```json
+(non-streamed) — `{ id, choices, usage }`
+```
+
+**Response** `400`
+```json
+— un-parseable request body
+```
+
+**Response** `401`
+```json
+— bad / missing `x-vapi-secret`
+```
+
+**Response** `500`
+```json
+— Anthropic upstream error (OpenAI-format error body)
+```
+
+---
+
 ## Voice Integration
 
 HF integrates with popular voice platforms to analyse live conversations


### PR DESCRIPTION
## Summary

VAPI's custom-LLM client mangles every available auth surface (`model.secret`, `?secret=`, custom headers). Net effect: the existing header-auth route only worked in pass-through mode (empty `webhookSecret`). Operator on hf-dev set a 64-char HMAC for production-grade webhook verification → every voice call died at the LLM hop with `pipeline-error-custom-llm-401-unauthorized`.

This PR ships the path-segment auth scheme that survives VAPI's URL-append behaviour:

```
assistant.model.url = "<host>/api/voice/vapi/llm-proxy/auth/<HEX>"
VAPI appends "/chat/completions"
final POST → "<host>/.../llm-proxy/auth/<HEX>/chat/completions"
```

Next.js dynamic segment `[secret]` → hex validation → timing-safe-compare → shared body handler.

## Architecture

| Surface | URL form | Auth | Use case |
|---|---|---|---|
| Header (existing) | `/api/voice/vapi/llm-proxy` | `x-vapi-secret` header, pass-through when empty | Local dev / dev VAPI assistant pointing at the plain URL |
| **Path-segment (new)** | `/api/voice/vapi/llm-proxy/auth/<HEX>` | URL path param, hex-validated + timing-safe | Production — operator sets `webhookSecret`, HF builds the URL automatically |

Both surfaces share `lib/voice/llm-proxy/run-vapi-chat-completion.ts` so body handling / Anthropic translation / telemetry stays single-sourced.

## Selection logic (transparent to the operator)

`VapiProvider.buildAssistantConfig` inspects `ctx.customLlmSecret`:

| Secret state | URL form chosen |
|---|---|
| empty / undefined | `/llm-proxy` (header pass-through — dev) |
| non-hex / shorter than 8 / longer than 256 | `/llm-proxy` (fallback — non-hex can't go in the URL path safely) |
| valid hex `[A-Fa-f0-9]{8..256}` | `/llm-proxy/auth/<HEX>` (production-secured) |

## Live evidence

3 calls failed pre-fix on hf-dev (operator generated 64-char hex, saved to both HF + VAPI dashboard):

| externalId | started | duration | cost | endedReason |
|---|---|---|---|---|
| `019eb14b…` | 11:29:44 | 9s | $0.013 | pipeline-error-custom-llm-401-unauthorized |
| `019eb158…` | 11:43:51 | 6s | $0.055 | same |
| `019eb15e…` | 11:49:58 | 8s | $0.056 | same |

Operator workaround (clear `webhookSecret` via #1434 `clearCredentials`) restored pass-through. This PR is the proper fix.

## Test plan

- [x] `npx vitest run` on 2 new test files — **16/16 pass**
  - `voice-llm-proxy-path-segment.test.ts` (10): empty/short/long/non-hex/slash → 400; no row/no secret/mismatch/length-mismatch → 401; hex match → 200
  - `vapi-custom-llm-url.test.ts` (6): empty/non-hex/too-short → bare URL; valid hex → path-segment URL
- [x] `npx tsc --noEmit` — 0 new errors
- [x] `npx eslint` — 0 errors
- [ ] Manual smoke (post-merge): paste 64-char hex into HF + VAPI dashboard, make test call, expect call to complete with transcript + duration populated

## Operator runbook (post-merge)

1. `openssl rand -hex 32` → paste into HF `/x/settings/voice-providers/<id>` "Webhook secret (HMAC)" field → Save
2. Paste the SAME value into VAPI dashboard → Server URL Secret field → Save
3. Make a test call. HF will build the path-segment URL automatically. Webhook HMAC + LLM proxy auth both verify properly.

Closes #1441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)