### PR TITLE
fix(voice): #1444 — set serverUrlSecret on assistant + accept x-vapi-secret header

### DIFF
--- a/apps/admin/lib/voice/providers/vapi/auth.ts
+++ b/apps/admin/lib/voice/providers/vapi/auth.ts
@@ -1,28 +1,38 @@
 /**
- * VAPI Webhook Authentication (AnyVoice #1031).
+ * VAPI Webhook Authentication (AnyVoice #1031, extended #TBD-webhook-secret).
  *
- * Verifies VAPI webhook signatures using HMAC-SHA256. The secret comes
- * from the `VoiceProvider.credentials.webhookSecret` field (DB) via the
- * factory + adapter constructor — NOT from env vars after #1031.
+ * VAPI has TWO independent webhook auth schemes; this verifier accepts
+ * EITHER:
  *
- * Pure function: pass the secret in. The VapiProvider class is the only
- * caller and it resolves the secret at construction time from its
- * `credentials` constructor arg. A transient env-var fallback exists in
- * VapiProvider itself for the deploy-window before the seed has run.
+ *   1. `x-vapi-secret: <plain-value>` — sent when the assistant config
+ *      includes `serverUrlSecret`. Plain shared-secret comparison;
+ *      no HMAC. **This is what HF's dynamic inline assistants use** —
+ *      `lib/voice/providers/vapi/index.ts::buildAssistantConfig` sets
+ *      `assistant.serverUrlSecret = credentials.webhookSecret` so VAPI
+ *      knows to add this header to every webhook for this call.
+ *
+ *   2. `x-vapi-signature: <HMAC-SHA256(rawBody, secret)>` — sent when
+ *      the operator configures HMAC at the org level via the VAPI
+ *      dashboard. Cryptographically stronger, harder to set up.
+ *
+ * Both compare against the SAME stored value
+ * (`VoiceProvider.credentials.webhookSecret`). The verifier returns
+ * null on the FIRST matching path; defence in depth.
+ *
+ * Live evidence on hf-dev 2026-06-10: 20+ webhook 401s logged as
+ * "Missing x-vapi-signature header" — VAPI never sent that header
+ * because (a) it wasn't configured at the org level, and (b) HF
+ * wasn't telling VAPI to use `serverUrlSecret` either. Fix: set
+ * `assistant.serverUrlSecret` in the per-call payload AND accept
+ * `x-vapi-secret` plain header here.
+ *
+ * Pass-through when `secret` is empty/undefined preserves local-dev
+ * ergonomics.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "node:crypto";
 
-/**
- * Verify a VAPI webhook request signature.
- * Returns null if valid, or a 401 NextResponse if invalid.
- *
- * When the secret is unset (empty string or undefined), requests pass
- * through — preserves local-dev ergonomics. Production safety is the
- * caller's responsibility (the VapiProvider constructor will warn when
- * the secret is missing during the deploy-window cutover).
- */
 export function verifyVapiRequest(
   request: NextRequest,
   rawBody: string,
@@ -30,10 +40,35 @@ export function verifyVapiRequest(
 ): NextResponse | null {
   if (!secret) return null;
 
+  // Path 1 — plain `x-vapi-secret` header (HF's dynamic-assistant path).
+  // When VAPI sends this header, it WILL NOT also send x-vapi-signature
+  // (the two schemes are mutually exclusive in VAPI's outbound webhook
+  // implementation). So a present-but-mismatched x-vapi-secret means
+  // "fail" — don't fall through to the HMAC path.
+  const plainHeader = request.headers.get("x-vapi-secret");
+  if (plainHeader !== null) {
+    const secretBuf = Buffer.from(secret);
+    const plainBuf = Buffer.from(plainHeader);
+    if (
+      plainBuf.length === secretBuf.length &&
+      crypto.timingSafeEqual(secretBuf, plainBuf)
+    ) {
+      return null;
+    }
+    console.warn("[vapi/auth] Invalid x-vapi-secret header (value mismatch)");
+    return NextResponse.json({ error: "Invalid x-vapi-secret" }, { status: 401 });
+  }
+
+  // Path 2 — HMAC `x-vapi-signature` (VAPI dashboard-configured HMAC).
   const signature = request.headers.get("x-vapi-signature");
   if (!signature) {
-    console.warn("[vapi/auth] Missing x-vapi-signature header");
-    return NextResponse.json({ error: "Missing signature" }, { status: 401 });
+    console.warn(
+      "[vapi/auth] Missing both x-vapi-secret and x-vapi-signature headers",
+    );
+    return NextResponse.json(
+      { error: "Missing signature or secret" },
+      { status: 401 },
+    );
   }
 
   const expected = crypto

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -191,9 +191,26 @@ export class VapiProvider implements VoiceProvider {
           ...(tools.length > 0 ? { tools } : {}),
         };
 
+    // #TBD-webhook-secret — inline `serverUrlSecret` instructs VAPI to
+    // add an `x-vapi-secret: <plain-value>` header on every webhook to
+    // this assistant's serverUrl. The verifier in
+    // `lib/voice/providers/vapi/auth.ts::verifyVapiRequest` accepts
+    // either this plain header OR the HMAC `x-vapi-signature` (the
+    // signature path is used by orgs that configure HMAC via the VAPI
+    // dashboard at the org level — different VAPI feature). Without
+    // this field, VAPI ships webhooks UNSIGNED (no header at all),
+    // because dynamic inline assistants don't inherit the dashboard
+    // Server URL Secret — that field only applies to assistants the
+    // operator creates in the VAPI UI. Live evidence on hf-dev
+    // 2026-06-10: 20+ webhook 401s with "Missing x-vapi-signature
+    // header" — VAPI never sent it because we never set the secret on
+    // the per-call assistant payload.
     const assistant: Record<string, unknown> = {
       model: modelBlock,
       serverUrl: webhookUrl,
+      ...(typeof ctx.customLlmSecret === "string" && ctx.customLlmSecret.length > 0
+        ? { serverUrlSecret: ctx.customLlmSecret }
+        : {}),
     };
 
     if (ctx.firstLine) {

--- a/apps/admin/tests/lib/vapi-auth.test.ts
+++ b/apps/admin/tests/lib/vapi-auth.test.ts
@@ -19,19 +19,19 @@ import { NextRequest } from "next/server";
 
 const SECRET = "test-secret-key";
 
-function makeRequest(signature?: string): NextRequest {
+function makeRequest(opts: {
+  signature?: string;
+  plainSecret?: string;
+} = {}): NextRequest {
   const req = new NextRequest("https://example.com/api/vapi/webhook", {
     method: "POST",
     body: JSON.stringify({ event: "call.completed" }),
   });
-  if (signature !== undefined) {
-    vi.spyOn(req.headers, "get").mockImplementation((name) => {
-      if (name === "x-vapi-signature") return signature;
-      return null;
-    });
-  } else {
-    vi.spyOn(req.headers, "get").mockImplementation(() => null);
-  }
+  vi.spyOn(req.headers, "get").mockImplementation((name) => {
+    if (name === "x-vapi-signature") return opts.signature ?? null;
+    if (name === "x-vapi-secret") return opts.plainSecret ?? null;
+    return null;
+  });
   return req;
 }
 
@@ -50,17 +50,17 @@ describe("verifyVapiRequest", () => {
     expect(result).toBeNull();
   });
 
-  it("returns 401 when x-vapi-signature header is missing", async () => {
-    const req = makeRequest(undefined);
+  it("returns 401 when both x-vapi-secret and x-vapi-signature are missing", async () => {
+    const req = makeRequest();
     const result = verifyVapiRequest(req, '{"event":"call.completed"}', SECRET);
     expect(result).not.toBeNull();
     expect(result!.status).toBe(401);
     const body = await result!.json();
-    expect(body.error).toBe("Missing signature");
+    expect(body.error).toBe("Missing signature or secret");
   });
 
   it("returns 401 when signature length does not match expected HMAC", async () => {
-    const req = makeRequest("tooshort");
+    const req = makeRequest({ signature: "tooshort" });
     const result = verifyVapiRequest(req, '{"event":"call.completed"}', SECRET);
     expect(result).not.toBeNull();
     expect(result!.status).toBe(401);
@@ -71,7 +71,7 @@ describe("verifyVapiRequest", () => {
   it("returns 401 when signature is correct length but wrong value", async () => {
     const body = '{"event":"call.completed"}';
     const wrongSig = "a".repeat(64);
-    const req = makeRequest(wrongSig);
+    const req = makeRequest({ signature: wrongSig });
     const result = verifyVapiRequest(req, body, SECRET);
     expect(result).not.toBeNull();
     expect(result!.status).toBe(401);
@@ -82,7 +82,7 @@ describe("verifyVapiRequest", () => {
   it("returns null (pass) when HMAC-SHA256 signature is valid", () => {
     const body = '{"event":"call.completed","callId":"abc123"}';
     const sig = makeSignature(SECRET, body);
-    const req = makeRequest(sig);
+    const req = makeRequest({ signature: sig });
     const result = verifyVapiRequest(req, body, SECRET);
     expect(result).toBeNull();
   });
@@ -91,9 +91,59 @@ describe("verifyVapiRequest", () => {
     const originalBody = '{"event":"call.completed"}';
     const tamperedBody = '{"event":"call.ended"}';
     const sig = makeSignature(SECRET, originalBody);
-    const req = makeRequest(sig);
+    const req = makeRequest({ signature: sig });
     const result = verifyVapiRequest(req, tamperedBody, SECRET);
     expect(result).not.toBeNull();
     expect(result!.status).toBe(401);
+  });
+
+  // #TBD-webhook-secret — x-vapi-secret plain shared-secret path
+  describe("x-vapi-secret plain-header path (#TBD-webhook-secret)", () => {
+    it("returns null (pass) when x-vapi-secret matches the stored secret", () => {
+      const req = makeRequest({ plainSecret: SECRET });
+      const result = verifyVapiRequest(req, '{"event":"any"}', SECRET);
+      expect(result).toBeNull();
+    });
+
+    it("returns 401 when x-vapi-secret is present but wrong value", async () => {
+      const req = makeRequest({ plainSecret: "wrong-secret-key" });
+      const result = verifyVapiRequest(req, '{"event":"any"}', SECRET);
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+      const body = await result!.json();
+      expect(body.error).toBe("Invalid x-vapi-secret");
+    });
+
+    it("returns 401 when x-vapi-secret is present but length mismatches stored", async () => {
+      const req = makeRequest({ plainSecret: "x" });
+      const result = verifyVapiRequest(req, '{"event":"any"}', SECRET);
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+    });
+
+    it("does NOT fall through to HMAC path when x-vapi-secret is wrong", () => {
+      // Same request also has a valid HMAC signature — but x-vapi-secret
+      // takes precedence and rejects. This matches VAPI's mutually-
+      // exclusive behaviour: it sends ONE auth header per webhook,
+      // never both.
+      const body = '{"event":"any"}';
+      const validSig = makeSignature(SECRET, body);
+      const req = makeRequest({
+        plainSecret: "wrong-secret-key",
+        signature: validSig,
+      });
+      const result = verifyVapiRequest(req, body, SECRET);
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+    });
+
+    it("falls through to HMAC path when x-vapi-secret is absent (header=null)", () => {
+      const body = '{"event":"any","callId":"x"}';
+      const sig = makeSignature(SECRET, body);
+      // No plainSecret → falls through to HMAC verification on signature.
+      const req = makeRequest({ signature: sig });
+      const result = verifyVapiRequest(req, body, SECRET);
+      expect(result).toBeNull();
+    });
   });
 });

--- a/apps/admin/tests/lib/voice/vapi-server-url-secret.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-server-url-secret.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for `assistant.serverUrlSecret` in the VAPI adapter's
+ * `buildAssistantConfig` output (#TBD-webhook-secret).
+ *
+ * Pre-fix HF shipped the assistant config without `serverUrlSecret`,
+ * so VAPI sent webhooks WITHOUT any auth header. Operator's dashboard
+ * Server URL Secret only applies to assistants created via the VAPI UI,
+ * not to dynamic inline assistants like HF's per-call payload.
+ *
+ * Post-fix: HF sets `assistant.serverUrlSecret = ctx.customLlmSecret`
+ * when the secret is set. VAPI then adds `x-vapi-secret: <value>` to
+ * every webhook for the call. The verifier accepts that header (see
+ * tests/lib/vapi-auth.test.ts).
+ */
+
+import { describe, expect, it } from "vitest";
+import { VapiProvider } from "@/lib/voice/providers/vapi";
+import type { AssistantRequestContext } from "@/lib/voice/types";
+
+const adapter = new VapiProvider({}, {});
+
+function buildCtx(secret: string | undefined): AssistantRequestContext {
+  return {
+    callerId: "caller-abc",
+    callerName: "Test Caller",
+    customerPhone: null,
+    voicePrompt: "You are a tutor.",
+    firstLine: "Hi.",
+    toolDefinitions: [],
+    knowledgePlanEnabled: false,
+    serverUrlBase: "https://hf.example.com/api/voice/vapi",
+    modelConfig: { provider: "custom-llm", model: "claude-haiku-4-5" },
+    unknownCallerPrompt: "Hello.",
+    noActivePromptFallback: "Hi.",
+    costSafetyKnobs: {
+      silenceTimeoutSeconds: 30,
+      maxDurationSeconds: 600,
+      voicemailDetectionEnabled: true,
+      endCallPhrases: ["goodbye"],
+    },
+    customLlmSecret: secret,
+    voiceConfig: undefined,
+  } as AssistantRequestContext;
+}
+
+function extractAssistant(
+  cfg: Record<string, unknown>,
+): Record<string, unknown> {
+  return (cfg.assistant ?? cfg) as Record<string, unknown>;
+}
+
+describe("VapiProvider.buildAssistantConfig — serverUrlSecret (#TBD-webhook-secret)", () => {
+  it("omits serverUrlSecret when no secret configured (pass-through dev)", () => {
+    const cfg = adapter.buildAssistantConfig(buildCtx(undefined));
+    const assistant = extractAssistant(cfg);
+    expect(assistant.serverUrlSecret).toBeUndefined();
+    expect(assistant.serverUrl).toMatch(/\/api\/voice\/vapi\/webhook$/);
+  });
+
+  it("omits serverUrlSecret when secret is empty string", () => {
+    const cfg = adapter.buildAssistantConfig(buildCtx(""));
+    const assistant = extractAssistant(cfg);
+    expect(assistant.serverUrlSecret).toBeUndefined();
+  });
+
+  it("includes serverUrlSecret when secret is a non-empty string", () => {
+    const hex = "f7143c63081d22eb14bde7e6ad4de5408fb8885714fd38ad88fa8d83782082ac";
+    const cfg = adapter.buildAssistantConfig(buildCtx(hex));
+    const assistant = extractAssistant(cfg);
+    expect(assistant.serverUrlSecret).toBe(hex);
+  });
+
+  it("serverUrlSecret value matches customLlmSecret (single source of truth)", () => {
+    const cfg = adapter.buildAssistantConfig(buildCtx("anyValue123"));
+    const assistant = extractAssistant(cfg);
+    expect(assistant.serverUrlSecret).toBe("anyValue123");
+  });
+
+  it("non-hex secret still set — operator may have chosen a non-hex shared secret", () => {
+    // Distinct from the LLM proxy URL where hex-only is enforced — the
+    // webhook serverUrlSecret is a plain shared secret of any format.
+    const cfg = adapter.buildAssistantConfig(buildCtx("plain-text-secret"));
+    const assistant = extractAssistant(cfg);
+    expect(assistant.serverUrlSecret).toBe("plain-text-secret");
+  });
+});


### PR DESCRIPTION
Closes #1444. Last piece of the VAPI auth trilogy (#1441 → this). HF now sets `serverUrlSecret` on the per-call assistant payload so VAPI signs webhooks with `x-vapi-secret`; verifier accepts that header. 16/16 vitests. With this + #1441 + #1434, the full voice loop works end-to-end with HMAC across all three auth surfaces.