### PR TITLE
feat(callers): #1448 — extract CallerVoiceSurface, unify sim + Call tab

### DIFF
--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -1,32 +1,29 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useResponsive } from '@/hooks/useResponsive';
 import { WhatsAppHeader } from '@/components/sim/WhatsAppHeader';
-import { SimChat } from '@/components/sim/SimChat';
-import { useJourneyChat } from '@/hooks/useJourneyChat';
+import { CallerVoiceSurface } from '@/components/callers/CallerVoiceSurface';
+import { FirstCallPinGate } from '@/components/identity/FirstCallPinGate';
 import { deriveParameterMap } from '@/lib/agent-tuner/derive';
 import type { AgentTunerPill } from '@/lib/agent-tuner/types';
-import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from '@/components/sim/ModulePickerBanners';
-import { SimStateBreadcrumb } from '@/components/sim/SimStateBreadcrumb';
-import { ModuleQuickSwitcher } from '@/components/sim/ModuleQuickSwitcher';
-import { QualificationContextStrip } from '@/components/sim/qualification/QualificationContextStrip';
-import { FirstCallPinGate } from '@/components/identity/FirstCallPinGate';
 
-interface PastCall {
-  transcript: string;
-  createdAt: string;
-}
-
-interface CallerInfo {
-  name: string;
-  role: string;
-  domain?: { name: string; slug: string } | null;
-  pastCalls: PastCall[];
-}
-
+/**
+ * /x/sim/[callerId] — standalone simulator page (#1448).
+ *
+ * Page-level responsibilities:
+ *   - URL param parsing (`?goal=`, `?tunerPills=`, `?forceFirstCall=`, `?as=`)
+ *   - WhatsAppHeader chrome
+ *   - FirstCallPinGate for STUDENT / preview-as-learner
+ *   - Mobile back-button routing
+ *
+ * Everything else (caller fetch, playbook fetch, journey integration,
+ * SimStateBreadcrumb, ModulePickerBanners, QualificationContextStrip,
+ * ModuleQuickSwitcher, SimChat mount) is owned by `<CallerVoiceSurface
+ * layout="standalone">` — shared with `/x/callers/<id>?tab=ai-call`.
+ */
 export default function SimConversationPage() {
   const router = useRouter();
   const { callerId } = useParams<{ callerId: string }>();
@@ -34,39 +31,16 @@ export default function SimConversationPage() {
   const { data: session, status: sessionStatus } = useSession();
   const { isDesktop } = useResponsive();
   const isStudent = session?.user?.role === 'STUDENT';
-  // Admin "preview as learner" — `?as=learner` flips the PIN gate on for an
-  // OPERATOR+ session so the auth surface can be demo'd without signing out.
-  // Server-side scope (resolveCallerScopeForReading) still treats the request
-  // as OPERATOR+ (passes the supplied callerId through), so the challenge
-  // status / verify-pin endpoints answer for the requested caller.
+  // Admin "preview as learner" — `?as=learner` flips the PIN gate on
+  // for an OPERATOR+ session so the auth surface can be demo'd without
+  // signing out.
   const previewAsLearner = searchParams.get('as') === 'learner';
   const gateAsStudent = isStudent || previewAsLearner;
+
   const sessionGoal = searchParams.get('goal') || undefined;
   const expectedDomainId = searchParams.get('domainId') || undefined;
-  // #948 — `playbookId` may be missing from the URL when a learner lands
-  // directly on /x/sim/[callerId]. Without it the playbook fetch below
-  // never fires, so `modulesAuthored` stays false and the module-picker
-  // banner never renders even for a caller enrolled on a course with an
-  // authored module catalogue. Resolve it from enrollments instead — same
-  // logic as `CallerDetailPage:386-398`: single active enrollment → that
-  // playbook; multiple → most-recently enrolled.
-  //
-  // URL wins (deep-link from elsewhere); enrollment-resolved fallback only
-  // applies when URL has nothing. Derived sync, so no setState-in-effect.
-  const urlPlaybookId = searchParams.get('playbookId') || undefined;
-  const [enrollmentPlaybookId, setEnrollmentPlaybookId] = useState<string | undefined>(undefined);
-  const playbookId = urlPlaybookId ?? enrollmentPlaybookId;
   const communityName = searchParams.get('communityName') || undefined;
   const forceFirstCall = searchParams.get('forceFirstCall') === 'true';
-  // #242 Slice 2 placeholder: surface the moduleId chosen in the picker.
-  // No real voice dial wiring yet — the banner just confirms the round-trip.
-  const urlRequestedModuleId = searchParams.get('requestedModuleId') || undefined;
-  // #1245 — per-Caller "last picked module" persistence. Populated from
-  // GET /api/callers/[callerId]; used to back-fill the picker state when
-  // the learner returns to /x/sim without a URL param so they don't
-  // have to re-pick every visit.
-  const [lastSelectedModuleId, setLastSelectedModuleId] = useState<string | undefined>(undefined);
-  const requestedModuleId = urlRequestedModuleId ?? lastSelectedModuleId;
 
   const targetOverrides = useMemo(() => {
     const raw = searchParams.get('tunerPills');
@@ -81,182 +55,18 @@ export default function SimConversationPage() {
     }
   }, [searchParams]);
 
-  const [caller, setCaller] = useState<CallerInfo | null>(null);
-  // #1101 — first-call PIN gate. Only STUDENT sessions are gated; OPERATOR+
-  // admin browsing of a learner's sim page is unaffected. 'loading' until the
-  // challenge-status fetch returns; 'verified' once the gate posts ok.
-  const [pinGateStatus, setPinGateStatus] = useState<
-    'loading' | 'needsPin' | 'verified'
-  >('loading');
+  // #1101 — PIN gate state machine (loading | needsPin | verified).
+  // Lives at the page level because the gate replaces the entire surface,
+  // not just the chat panel — so it sits above CallerVoiceSurface.
+  const [pinGateStatus, setPinGateStatus] = useState<'loading' | 'needsPin' | 'verified'>('loading');
   const [pinGateRecipient, setPinGateRecipient] = useState<string | null>(null);
-  const [playbookName, setPlaybookName] = useState<string | undefined>(undefined);
-  const [subjectDiscipline, setSubjectDiscipline] = useState<string | undefined>(undefined);
-  const [modulesAuthored, setModulesAuthored] = useState<boolean>(false);
-  // #274 Slice C: hold the authored module list so the picker-selection
-  // banner can display a human label instead of the raw id.
-  const [authoredModules, setAuthoredModules] = useState<Array<{ id: string; label?: string }>>([]);
-  const [error, setError] = useState<string | null>(null);
-  // #396: parent-owned "is a call live?" flag so the SimStateBreadcrumb pill
-  // reads "(Active)" while the user is mid-call instead of always "(Pre-call)".
-  const [isCallActive, setIsCallActive] = useState(false);
-
-  // Journey chat — unified WhatsApp-style survey/onboarding/teaching flow
-  // Only runs for LEARNER callers; waits for caller data before deciding.
-  const journey = useJourneyChat({ callerId, forceFirstCall, callerRole: caller?.role });
-
-  // #948 — auto-resolve playbookId from the caller's active enrollments
-  // when the URL didn't pass one explicitly. Delegates to the shared L9
-  // resolver via `/api/callers/[id]/active-playbook` so the pick rule lives
-  // in one place. See docs/CHAIN-CONTRACTS.md Link L9 + the helper at
-  // lib/caller/resolve-active-playbook.ts.
-  useEffect(() => {
-    if (urlPlaybookId) return; // URL already provided it — playbookId derives from it directly
-    let cancelled = false;
-    fetch(`/api/callers/${callerId}/active-playbook`)
-      .then((r) => r.json())
-      .then((result) => {
-        if (cancelled || !result?.ok) return;
-        if (result.playbookId) {
-          setEnrollmentPlaybookId(result.playbookId);
-        }
-      })
-      .catch(() => { /* non-fatal: page still renders, just without module picker */ });
-    return () => { cancelled = true; };
-  }, [callerId, urlPlaybookId]);
-
-  // #1245 — persist the picker round-trip. When the URL carries a
-  // `?requestedModuleId=` the learner just picked (or re-picked via
-  // "Switch module"), write it to `Caller.lastSelectedModuleId` so the
-  // next visit (no URL param) restores the choice. Fire-and-forget —
-  // a persistence failure must not break the sim. Skipped when the URL
-  // value matches what's already persisted (avoids the no-op POST on
-  // every render after the page hydrates).
-  useEffect(() => {
-    if (!urlRequestedModuleId) return;
-    if (urlRequestedModuleId === lastSelectedModuleId) return;
-    let cancelled = false;
-    fetch(`/api/callers/${callerId}/last-selected-module`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ moduleId: urlRequestedModuleId }),
-    })
-      .then((r) => r.json())
-      .then((result) => {
-        if (cancelled) return;
-        if (result?.ok) {
-          setLastSelectedModuleId(urlRequestedModuleId);
-        }
-      })
-      .catch(() => { /* non-fatal — sim still works from URL param */ });
-    return () => { cancelled = true; };
-  }, [callerId, urlRequestedModuleId, lastSelectedModuleId]);
+  // Hold the caller's first name for the PIN gate copy — fetched once,
+  // independent of CallerVoiceSurface's own caller fetch (which only
+  // mounts after the gate clears).
+  const [callerFirstName, setCallerFirstName] = useState<string | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
-
-    // #1247 — post-enrol /intake/done → /x/sim race. First fetch can
-    // surface "Caller not found" while the sidebar's separate fetch
-    // (which fires fractionally later) sees the newly-created caller.
-    // Hard refresh fixes it permanently. Defensive retry: on the first
-    // 403/404, wait 300ms and try once more with `cache: 'no-store'`.
-    // If the row really doesn't exist the second 404 surfaces the
-    // error as before; if it's the race, the second hit lands clean.
-    // Console breadcrumb so we can detect any recurring window in dev
-    // / staging logs.
-    async function fetchCallerOnce(noCache: boolean) {
-      return fetch(`/api/callers/${callerId}`, noCache ? { cache: 'no-store' } : undefined);
-    }
-
-    async function fetchCaller() {
-      try {
-        let res = await fetchCallerOnce(false);
-        if ((res.status === 403 || res.status === 404) && !cancelled) {
-          console.warn(
-            `[sim/page] caller fetch returned ${res.status} on first try (callerId=${callerId}) — retrying after 300ms (#1247 defensive retry)`,
-          );
-          await new Promise((r) => setTimeout(r, 300));
-          if (cancelled) return;
-          res = await fetchCallerOnce(true);
-        }
-        if (res.status === 401) {
-          if (!cancelled) {
-            router.push(`/login?callbackUrl=${encodeURIComponent(`/x/sim/${callerId}`)}`);
-          }
-          return;
-        }
-        const data = await res.json();
-        if (!res.ok || !data.ok) {
-          if (!cancelled) setError('Caller not found');
-          return;
-        }
-        if (!cancelled) {
-          const callerDomainId = data.caller.domain?.id || data.caller.domainId;
-          if (expectedDomainId && callerDomainId && expectedDomainId !== callerDomainId) {
-            setError('Caller is no longer in the expected institution. Please re-select from the wizard.');
-            return;
-          }
-          if (!callerDomainId) {
-            setError('Caller has no institution assigned. Please assign one before simulating.');
-            return;
-          }
-
-          const calls = (data.calls || [])
-            .filter((c: any) => c.transcript?.trim())
-            .map((c: any) => ({ transcript: c.transcript, createdAt: c.createdAt }))
-            .sort((a: PastCall, b: PastCall) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-          setCaller({
-            name: data.caller.name || 'Unknown',
-            role: data.caller.role || 'SIM',
-            domain: data.caller.domain,
-            pastCalls: calls,
-          });
-          // #1245 — restore the picker state from the persisted pick.
-          // No URL param? Use Caller.lastSelectedModuleId (set on the
-          // previous picker round-trip via POST below). When both are
-          // present the URL param wins (acts as an explicit override).
-          if (typeof data.caller.lastSelectedModuleId === 'string') {
-            setLastSelectedModuleId(data.caller.lastSelectedModuleId);
-          }
-
-          if (playbookId) {
-            fetch(`/api/playbooks/${playbookId}`)
-              .then(r => r.json())
-              .then(pbData => {
-                if (!cancelled && pbData.ok) {
-                  setPlaybookName(pbData.playbook?.name);
-                  const cfg = (pbData.playbook?.config as any) || {};
-                  if (cfg.subjectDiscipline) setSubjectDiscipline(cfg.subjectDiscipline);
-                  // Issue #242: gate the "Pick module" header button on authored modules.
-                  // Treat both `null` (never imported) and `false` (opted out) as off.
-                  setModulesAuthored(cfg.modulesAuthored === true);
-                  // #274 Slice C: capture authored modules so the banner can
-                  // resolve the picked module's label (not just the id).
-                  if (Array.isArray(cfg.modules)) {
-                    setAuthoredModules(cfg.modules);
-                  }
-                }
-              })
-              .catch(() => {});
-          }
-        }
-      } catch {
-        if (!cancelled) setError('Failed to load caller');
-      }
-    }
-
-    fetchCaller();
-    return () => { cancelled = true; };
-  }, [callerId, expectedDomainId, playbookId, router]);
-
-  // #1101 — fetch challenge status once we know the session role. Skip for
-  // OPERATOR+ so admin browsing of a learner's sim page is unaffected.
-  // HOTFIX: previously gated on `isStudent` while session was still loading,
-  // which set pinGateStatus='verified' eagerly. Now wait for the session to
-  // RESOLVE before deciding (status === 'loading' → stay in 'loading'); also
-  // fail CLOSED on non-JSON / non-ok responses (was: silently treat as
-  // verified, which masked auth middleware 307 redirects).
-  useEffect(() => {
-    if (sessionStatus === 'loading') return; // wait — don't pre-decide
+    if (sessionStatus === 'loading') return;
     if (!gateAsStudent) {
       setPinGateStatus('verified');
       return;
@@ -272,8 +82,6 @@ export default function SimConversationPage() {
       .then((data) => {
         if (cancelled) return;
         if (!data?.ok) {
-          // Server replied but not in the expected shape — gate fail-closed
-          // so we never silently let a real learner skip the PIN.
           setPinGateRecipient(null);
           setPinGateStatus('needsPin');
           return;
@@ -287,8 +95,6 @@ export default function SimConversationPage() {
       })
       .catch((err) => {
         if (cancelled) return;
-        // Network/redirect/parse failure — fail CLOSED. Better to show a PIN
-        // gate the learner can't bypass than silently let them past.
         console.warn('[pin-gate] challenge-status fetch failed:', err);
         setPinGateRecipient(null);
         setPinGateStatus('needsPin');
@@ -298,65 +104,26 @@ export default function SimConversationPage() {
     };
   }, [callerId, gateAsStudent, sessionStatus]);
 
-  const handleStudentCallEnd = useCallback(() => {
-    if (isStudent) {
-      setTimeout(() => router.push('/x/student'), 1500);
-    }
-    // Journey onCallEnd is now called directly inside SimChat
-  }, [router, isStudent]);
+  // Fetch caller's first name once for the PIN gate copy. Cheap; no error
+  // handling because the gate copy degrades gracefully without it.
+  useEffect(() => {
+    if (pinGateStatus !== 'needsPin') return;
+    if (callerFirstName) return;
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled || !data?.ok) return;
+        const name = data.caller?.name?.trim().split(/\s+/)[0] ?? null;
+        setCallerFirstName(name);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, pinGateStatus, callerFirstName]);
 
-  // #242 Slice 2: must live ABOVE the early returns or React's hook order
-  // changes between renders (Rules of Hooks violation).
-  // #1248 — module picker is now an inline modal on the sim page.
-  // Pre-fix, the rail's "Pick a module" button navigated to
-  // /x/student/[playbookId]/modules and back — heavy for a single
-  // decision ("pick Unit 04 vs Unit 09"). The dedicated picker page
-  // remains available as a deep link via the dialog's "See full
-  // picker →" escape (full prereqs, recommendation reasoning, etc.).
-  const [moduleSwitcherOpen, setModuleSwitcherOpen] = useState(false);
-  const handlePickModule = useCallback(() => {
-    if (!playbookId) return;
-    setModuleSwitcherOpen(true);
-  }, [playbookId]);
-
-  const handleModuleSwitcherPick = useCallback(
-    (moduleId: string) => {
-      // Replace `?requestedModuleId=` in the URL. The sim page already
-      // handles the param-driven recompose + #1245 persistence write.
-      const carryParams = new URLSearchParams(searchParams.toString());
-      carryParams.set('requestedModuleId', moduleId);
-      router.replace(`/x/sim/${callerId}?${carryParams.toString()}`);
-    },
-    [callerId, router, searchParams],
-  );
-
-  const fullPickerHref = useMemo(() => {
-    if (!playbookId) return undefined;
-    const sp = new URLSearchParams();
-    const carryParams = new URLSearchParams(searchParams.toString());
-    carryParams.delete('requestedModuleId');
-    sp.set('returnTo', `/x/sim/${callerId}${carryParams.toString() ? `?${carryParams.toString()}` : ''}`);
-    sp.set('callerId', callerId);
-    return `/x/student/${playbookId}/modules?${sp.toString()}`;
-  }, [callerId, playbookId, searchParams]);
-
-  // #357 NOTE: an earlier slice auto-routed to the picker on first entry
-  // when modulesAuthored=true. That created a trap — user couldn't get
-  // back to the sim without picking, even to test an undirected call.
-  // Reverted: the banner CTA below is the non-blocking entry instead.
-
-  if (error) {
-    return (
-      <>
-        <WhatsAppHeader title="Error" onBack={isDesktop ? undefined : () => router.push('/x/sim')} />
-        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-          <p style={{ color: 'var(--text-muted)', textAlign: 'center' }}>{error}</p>
-        </div>
-      </>
-    );
-  }
-
-  if (!caller || pinGateStatus === 'loading') {
+  if (pinGateStatus === 'loading') {
     return (
       <>
         <WhatsAppHeader title="Loading..." />
@@ -367,18 +134,14 @@ export default function SimConversationPage() {
       </>
     );
   }
-
-  // #1101 — gate first-call STUDENT sessions on PIN verification before the
-  // chat renders. OPERATOR+ skip this branch (pinGateStatus pre-set to verified).
   if (pinGateStatus === 'needsPin') {
-    const callerFirstName = caller.name?.trim().split(/\s+/)[0];
     return (
       <>
         <WhatsAppHeader title="Verify your code" />
         <FirstCallPinGate
           callerId={callerId}
           recipient={pinGateRecipient}
-          callerFirstName={callerFirstName}
+          callerFirstName={callerFirstName ?? undefined}
           onVerified={() => setPinGateStatus('verified')}
         />
       </>
@@ -386,58 +149,22 @@ export default function SimConversationPage() {
   }
 
   return (
-    <>
-      <SimStateBreadcrumb
-        pastCallCount={caller.pastCalls.length}
-        activeCall={isCallActive}
-        requestedModuleId={requestedModuleId ?? null}
-        modules={authoredModules}
-        onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
-      />
-      <ModuleQuickSwitcher
-        open={moduleSwitcherOpen}
-        onClose={() => setModuleSwitcherOpen(false)}
-        modules={authoredModules}
-        currentModuleId={requestedModuleId ?? null}
-        onPick={handleModuleSwitcherPick}
-        fullPickerHref={fullPickerHref}
-      />
-      {/* #1098 Slice C — Qualification context strip (renders only when the
-          learner's active Curriculum has a qualificationAnchor). */}
-      <QualificationContextStrip requestedModuleId={requestedModuleId ?? null} />
-      {requestedModuleId ? (
-        <ModulePickerSelectionBanner
-          moduleId={requestedModuleId}
-          modules={authoredModules}
-        />
-      ) : modulesAuthored && playbookId ? (
-        <ModulePickerInviteBanner
-          moduleCount={authoredModules.length}
-          onPick={handlePickModule}
-        />
-      ) : null}
-      <SimChat
-        callerId={callerId}
-        callerName={caller.name}
-        domainName={caller.domain?.name}
-        playbookId={playbookId}
-        playbookName={communityName ?? playbookName}
-        subjectDiscipline={subjectDiscipline}
-        pastCalls={caller.pastCalls}
-        mode="standalone"
-        sessionGoal={sessionGoal}
-        targetOverrides={targetOverrides}
-        forceFirstCall={forceFirstCall || undefined}
-        onBack={isDesktop ? undefined : () => router.push('/x/sim')}
-        onCallEnd={isStudent ? handleStudentCallEnd : undefined}
-        onCallStateChange={setIsCallActive}
-        requestedModuleId={requestedModuleId}
-        journey={journey}
-        onNameChange={(next) => setCaller((prev) => (prev ? { ...prev, name: next } : prev))}
-      />
-    </>
+    <CallerVoiceSurface
+      callerId={callerId}
+      layout="standalone"
+      sessionGoal={sessionGoal}
+      targetOverrides={targetOverrides}
+      forceFirstCall={forceFirstCall}
+      onBack={isDesktop ? undefined : () => router.push('/x/sim')}
+      onCallEnd={
+        isStudent
+          ? () => {
+              setTimeout(() => router.push('/x/student'), 1500);
+            }
+          : undefined
+      }
+      communityName={communityName}
+      expectedDomainId={expectedDomainId}
+    />
   );
 }
-
-// Banner components moved to components/sim/ModulePickerBanners.tsx (#357)
-// so the admin caller-detail surface can reuse them.

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -13,9 +13,7 @@ import { CallerDomainSection } from "@/components/callers/CallerDomainSection";
 import { VoiceProviderOverride } from "@/components/callers/VoiceProviderOverride";
 import { VoiceCostPanel } from "@/components/callers/VoiceCostPanel";
 import { CascadeLensPanel } from "@/components/callers/CascadeLensPanel";
-import { SimChat } from "@/components/sim/SimChat";
-import { ModulePickerSelectionBanner, ModulePickerInviteBanner } from "@/components/sim/ModulePickerBanners";
-import { SimStateBreadcrumb } from "@/components/sim/SimStateBreadcrumb";
+import { CallerVoiceSurface } from "@/components/callers/CallerVoiceSurface";
 import '@/app/x/sim/sim.css';
 import './caller-detail-page.css';
 import './caller-detail/lens.css';
@@ -156,10 +154,9 @@ export default function CallerDetailPage() {
     }
   };
   const [simChatMounted, setSimChatMounted] = useState(initialTab === "ai-call");
-  const [callSession, setCallSession] = useState(0);
-  // #396: parent-owned "is a call live?" flag so the SimStateBreadcrumb pill
-  // reads "(Active)" while the user is mid-call instead of always "(Pre-call)".
-  const [isCallActive, setIsCallActive] = useState(false);
+  // #1448 — callSession remount + isCallActive state moved INTO
+  // CallerVoiceSurface. The state machine for "is the call live" + "should
+  // SimChat unmount on New call" is now owned by the shared component.
   if (activeSection === "ai-call" && !simChatMounted) setSimChatMounted(true);
 
   // Dynamic parameter display configuration (fetched from database)
@@ -185,13 +182,9 @@ export default function CallerDetailPage() {
   // sharing the Curriculum), not the variant alone. Populated by the
   // /api/playbooks/[id] fetch below.
   const [variantSiblingIds, setVariantSiblingIds] = useState<string[]>([]);
-  // #253-follow-up: surface "Pick module" header button when the active
-  // playbook has authored modules. Mirrors /x/sim/[callerId] wiring.
-  const [modulesAuthored, setModulesAuthored] = useState<boolean>(false);
-  // #357: authored modules — needed so the selection banner can resolve a
-  // human label for the module id rather than show the raw id.
-  const [authoredModules, setAuthoredModules] = useState<Array<{ id: string; label?: string }>>([]);
-  const requestedModuleId = searchParams.get("requestedModuleId") || undefined;
+  // #1448 — modulesAuthored / authoredModules moved INTO CallerVoiceSurface.
+  // The playbook fetch below now only writes `variantSiblingIds` (used by
+  // the Calls/Prompts filter elsewhere in this page).
   const [progressVis, toggleProgressVis] = useSectionVisibility("caller-progress", {
     scores: true, behaviour: true, goals: true, exam: true,
   });
@@ -529,12 +522,13 @@ export default function CallerDetailPage() {
     );
   }, [composedPrompts, callMatchSet]);
 
-  // #253-follow-up: load `modulesAuthored` from the active playbook's config
-  // so the SimChat header shows the "Pick module" button when authored
-  // modules exist for this course. Mirrors /x/sim/[callerId] wiring.
+  // #1177 — variant fan-out: sibling Playbook IDs (parent + linked variants
+  // sharing a Curriculum). Used to widen the Calls/Prompts filter so a
+  // learner's history isn't hidden when a variant is selected instead of
+  // the parent. #1448: trimmed of the now-moved modulesAuthored /
+  // authoredModules state (those live in CallerVoiceSurface).
   useEffect(() => {
     if (!selectedPlaybookId || selectedPlaybookId === "all") {
-      setModulesAuthored(false);
       setVariantSiblingIds([]);
       return;
     }
@@ -543,18 +537,6 @@ export default function CallerDetailPage() {
       .then((r) => r.json())
       .then((pbData) => {
         if (cancelled || !pbData?.ok) return;
-        const cfg = (pbData.playbook?.config as Record<string, unknown> | null) ?? {};
-        setModulesAuthored(cfg.modulesAuthored === true);
-        // #357: also surface the authored module list for the banner label.
-        if (Array.isArray(cfg.modules)) {
-          setAuthoredModules(cfg.modules as Array<{ id: string; label?: string }>);
-        } else {
-          setAuthoredModules([]);
-        }
-        // #1177 — variant fan-out: sibling Playbook IDs (parent + linked
-        // variants sharing a Curriculum). Used to widen the Calls/Prompts
-        // filter so a learner's history isn't hidden when a variant is
-        // selected instead of the parent.
         if (Array.isArray(pbData.siblingPlaybookIds)) {
           setVariantSiblingIds(pbData.siblingPlaybookIds as string[]);
         } else {
@@ -562,35 +544,12 @@ export default function CallerDetailPage() {
         }
       })
       .catch(() => {
-        if (!cancelled) {
-          setModulesAuthored(false);
-          setAuthoredModules([]);
-          setVariantSiblingIds([]);
-        }
+        if (!cancelled) setVariantSiblingIds([]);
       });
     return () => {
       cancelled = true;
     };
   }, [selectedPlaybookId]);
-
-  const handlePickModule = useCallback(() => {
-    if (selectedPlaybookId === "all" || !selectedPlaybookId) return;
-    const sp = new URLSearchParams();
-    // #270: pass callerId so the picker (admin context) can include it on
-    // GET /api/student/module-progress — without it the route returns 400
-    // because requireStudentOrAdmin demands explicit caller selection for
-    // non-STUDENT users.
-    sp.set("callerId", callerId);
-    // Strip requestedModuleId from the carry-over so the banner doesn't
-    // double-fire when the learner returns from the picker.
-    const carryParams = new URLSearchParams(searchParams.toString());
-    carryParams.delete("requestedModuleId");
-    sp.set(
-      "returnTo",
-      `/x/callers/${callerId}${carryParams.toString() ? `?${carryParams.toString()}` : ""}`,
-    );
-    router.push(`/x/student/${selectedPlaybookId}/modules?${sp.toString()}`);
-  }, [callerId, router, searchParams, selectedPlaybookId]);
 
   // ── Processing detection + auto-poll ──────────────
   // A call is "processing" if it's recent (< 5 min) and hasn't been analyzed yet.
@@ -1493,57 +1452,23 @@ export default function CallerDetailPage() {
 
       {simChatMounted && (
         <div className={activeSection === "ai-call" ? undefined : "hf-hidden"}>
-          {/* #357: mirror the sim-view module-picker banners + state
-              breadcrumb so the admin caller-detail surface gives the same
-              signals as /x/sim/[id]. */}
-          <SimStateBreadcrumb
-            pastCallCount={(data?.calls ?? []).filter((c: { transcript?: string | null }) => c.transcript?.trim()).length}
-            activeCall={isCallActive}
-            requestedModuleId={requestedModuleId ?? null}
-            modules={authoredModules}
-            onPickModule={
-              modulesAuthored && selectedPlaybookId && selectedPlaybookId !== "all"
-                ? handlePickModule
-                : undefined
-            }
-          />
-          {requestedModuleId ? (
-            <ModulePickerSelectionBanner
-              moduleId={requestedModuleId}
-              modules={authoredModules}
-            />
-          ) : modulesAuthored && selectedPlaybookId && selectedPlaybookId !== "all" ? (
-            <ModulePickerInviteBanner
-              moduleCount={authoredModules.length}
-              onPick={handlePickModule}
-            />
-          ) : null}
-          <SimChat
-            key={callSession}
+          {/* #1448 — voice surface is now a single shared component
+              between sim page + this Call tab. Owns banners, breadcrumb,
+              QualificationContextStrip, ModuleQuickSwitcher, SimChat
+              + caller/playbook/journey loading. `onPostCallRefresh`
+              keeps CallerDetailPage's other tabs (Calls, Prompts) in
+              sync after each call. The pre-#1448 hand-rolled wiring
+              (SimStateBreadcrumb / module banners / SimChat with
+              `key={callSession}`) lived here verbatim with the
+              divergences documented in #1448 BA brief; all moved into
+              CallerVoiceSurface. */}
+          <CallerVoiceSurface
             callerId={callerId}
-            callerName={data.caller.name || "Caller"}
-            domainName={data.caller.domain?.name}
-            playbookId={selectedPlaybookId === "all" ? undefined : selectedPlaybookId}
-            mode="embedded"
-            /* #1447 / closing the prop-parity gap with /x/sim/[callerId] —
-               sim page derives pastCalls from data.calls identically (same
-               filter + map + sort as `app/x/sim/[callerId]/page.tsx:203-206`).
-               Pre-fix the embedded SimChat had no past-call context, so an
-               operator switching into the Call tab saw an empty timeline
-               under the "History" divider even when the caller had real
-               calls on record. The deeper surface-unification refactor
-               is tracked as #1448. */
-            pastCalls={(data.calls ?? [])
-              .filter((c: { transcript?: string | null }) => c.transcript?.trim())
-              .map((c: { transcript: string; createdAt: string }) => ({
-                transcript: c.transcript,
-                createdAt: c.createdAt,
-              }))
-              .sort(
-                (a: { createdAt: string }, b: { createdAt: string }) =>
-                  new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-              )}
-            onCallEnd={() => {
+            layout="embedded"
+            playbookIdOverride={
+              selectedPlaybookId === "all" ? undefined : selectedPlaybookId
+            }
+            onPostCallRefresh={() => {
               fetch(`/api/callers/${callerId}`)
                 .then((r) => r.json())
                 .then((result) => {
@@ -1556,9 +1481,6 @@ export default function CallerDetailPage() {
                 });
               fetchPrompts();
             }}
-            onNewCall={() => setCallSession(prev => prev + 1)}
-            onCallStateChange={setIsCallActive}
-            requestedModuleId={requestedModuleId}
           />
         </div>
       )}

--- a/apps/admin/components/callers/CallerVoiceSurface.tsx
+++ b/apps/admin/components/callers/CallerVoiceSurface.tsx
@@ -1,0 +1,400 @@
+/**
+ * CallerVoiceSurface (#1448) — single shared voice-surface component
+ * mounted by both `/x/sim/[callerId]` (standalone layout) and
+ * `/x/callers/[id]?tab=ai-call` (embedded layout).
+ *
+ * Pre-#1448 both pages hand-rolled the wrapper around `<SimChat>` with
+ * divergent prop sets — Sim page passed pastCalls / playbookName /
+ * subjectDiscipline / sessionGoal / targetOverrides / forceFirstCall /
+ * journey / onNameChange; CallerDetailPage's ai-call section passed
+ * none of those. The Call tab also forced a remount via `key={callSession}`
+ * on every "New call" click — load-bearing because SimChat's internal
+ * state (messages, callPhase, streaming) doesn't fully reset between
+ * calls without unmount (TL brief, #1448).
+ *
+ * This component owns: caller fetch, playbook fetch, active-playbook
+ * resolver, lastSelectedModuleId persistence, useJourneyChat,
+ * isCallActive state, SimStateBreadcrumb / ModulePickerBanners /
+ * QualificationContextStrip / ModuleQuickSwitcher / SimChat render,
+ * post-call refresh.
+ *
+ * Layout switch:
+ *   - `standalone` — full sim page chrome above us; we render the
+ *     SimStateBreadcrumb + banners + SimChat. PIN gate decision lives
+ *     in the sim page wrapper (it needs WhatsAppHeader chrome around
+ *     the gate). On-error / on-loading states render a chrome-less
+ *     spinner/message — caller wraps.
+ *   - `embedded` — inside the CallerDetailPage ai-call tab. Same render
+ *     tree; no PIN gate (admin context); accepts `onPostCallRefresh`
+ *     so the parent can re-fetch its own caller data + prompts on
+ *     call-end.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { SimChat } from "@/components/sim/SimChat";
+import { SimStateBreadcrumb } from "@/components/sim/SimStateBreadcrumb";
+import { ModuleQuickSwitcher } from "@/components/sim/ModuleQuickSwitcher";
+import {
+  ModulePickerSelectionBanner,
+  ModulePickerInviteBanner,
+} from "@/components/sim/ModulePickerBanners";
+import { QualificationContextStrip } from "@/components/sim/qualification/QualificationContextStrip";
+import { useJourneyChat } from "@/hooks/useJourneyChat";
+import { useResponsive } from "@/hooks/useResponsive";
+
+export interface PastCall {
+  transcript: string;
+  createdAt: string;
+}
+
+export interface CallerInfo {
+  name: string;
+  role: string;
+  domain?: { name?: string | null; slug?: string | null; id?: string | null } | null;
+  pastCalls: PastCall[];
+}
+
+export interface CallerVoiceSurfaceProps {
+  callerId: string;
+  layout: "standalone" | "embedded";
+  /** STANDALONE-only — passed through to SimChat. */
+  sessionGoal?: string;
+  /** STANDALONE-only — passed through to SimChat. */
+  targetOverrides?: Record<string, number>;
+  /** STANDALONE-only — passed through to SimChat. */
+  forceFirstCall?: boolean;
+  /** STANDALONE-only — passed through to SimChat. Routes back to /x/sim on mobile. */
+  onBack?: () => void;
+  /**
+   * STANDALONE-only — STUDENT-session post-call redirect. Sim page passes
+   * a 1.5s `router.push('/x/student')` for learners. Embedded callers
+   * (admin) leave this undefined.
+   */
+  onCallEnd?: () => void;
+  /**
+   * EMBEDDED — parent's hook to refetch its own caller data + prompts
+   * after the call ends, so the broader caller-detail view stays in sync.
+   * Called AFTER our internal post-call refresh; no return value matters.
+   */
+  onPostCallRefresh?: () => void;
+  /**
+   * Both layouts — community / cohort name override for SimChat header.
+   * Sim page reads this from the URL `?communityName=` param; embedded
+   * caller leaves it undefined and SimChat falls back to the playbook name.
+   */
+  communityName?: string;
+  /**
+   * EMBEDDED — when the embedding page has its own playbook scoping
+   * (CallerDetailPage's `selectedPlaybookId` dropdown), pass it here.
+   * Overrides our enrollment-resolver fallback. Standalone reads
+   * `?playbookId=` from the URL itself.
+   */
+  playbookIdOverride?: string;
+  /** Initial expected-domain assertion (sim page only). */
+  expectedDomainId?: string;
+  /** Standalone passes a notifier so the sidebar reflects renames. */
+  onNameChange?: (next: string) => void;
+}
+
+export function CallerVoiceSurface({
+  callerId,
+  layout,
+  sessionGoal,
+  targetOverrides,
+  forceFirstCall,
+  onBack,
+  onCallEnd,
+  onPostCallRefresh,
+  communityName,
+  playbookIdOverride,
+  expectedDomainId,
+  onNameChange,
+}: CallerVoiceSurfaceProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isDesktop } = useResponsive();
+
+  // URL → enrollment → override resolution for playbookId.
+  // EMBEDDED layout: parent dictates via `playbookIdOverride`; the URL
+  // param is ignored because the parent's dropdown is the source of
+  // truth. STANDALONE layout: `?playbookId=` first, then the active-
+  // enrollment resolver.
+  const urlPlaybookId = searchParams.get("playbookId") || undefined;
+  const [enrollmentPlaybookId, setEnrollmentPlaybookId] = useState<string | undefined>(undefined);
+  const playbookId =
+    layout === "embedded"
+      ? playbookIdOverride
+      : urlPlaybookId ?? enrollmentPlaybookId;
+
+  const urlRequestedModuleId = searchParams.get("requestedModuleId") || undefined;
+  const [lastSelectedModuleId, setLastSelectedModuleId] = useState<string | undefined>(undefined);
+  const requestedModuleId = urlRequestedModuleId ?? lastSelectedModuleId;
+
+  const [caller, setCaller] = useState<CallerInfo | null>(null);
+  const [playbookName, setPlaybookName] = useState<string | undefined>(undefined);
+  const [subjectDiscipline, setSubjectDiscipline] = useState<string | undefined>(undefined);
+  const [modulesAuthored, setModulesAuthored] = useState<boolean>(false);
+  const [authoredModules, setAuthoredModules] = useState<Array<{ id: string; label?: string }>>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isCallActive, setIsCallActive] = useState(false);
+
+  // Load-bearing remount key (#1448 TL brief): incremented when the
+  // operator clicks "New call" to ensure SimChat's internal state
+  // (messages array, callPhase, streaming) fully resets. Both layouts
+  // get this — Sim page previously didn't have it because navigation
+  // naturally unmounted, but mid-call → end → new call → mid-call on
+  // the SAME page session needs the same hygiene.
+  const [callSession, setCallSession] = useState(0);
+
+  // #948 — active-playbook resolver fallback (STANDALONE only).
+  useEffect(() => {
+    if (layout === "embedded") return;
+    if (urlPlaybookId) return;
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/active-playbook`)
+      .then((r) => r.json())
+      .then((result) => {
+        if (cancelled || !result?.ok) return;
+        if (result.playbookId) setEnrollmentPlaybookId(result.playbookId);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, urlPlaybookId, layout]);
+
+  // #1245 — persist picker round-trip (both layouts).
+  useEffect(() => {
+    if (!urlRequestedModuleId) return;
+    if (urlRequestedModuleId === lastSelectedModuleId) return;
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/last-selected-module`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ moduleId: urlRequestedModuleId }),
+    })
+      .then((r) => r.json())
+      .then((result) => {
+        if (cancelled) return;
+        if (result?.ok) setLastSelectedModuleId(urlRequestedModuleId);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, urlRequestedModuleId, lastSelectedModuleId]);
+
+  // Caller + past-calls + playbook metadata fetch.
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchCallerOnce(noCache: boolean) {
+      return fetch(`/api/callers/${callerId}`, noCache ? { cache: "no-store" } : undefined);
+    }
+    async function load() {
+      try {
+        let res = await fetchCallerOnce(false);
+        if ((res.status === 403 || res.status === 404) && !cancelled) {
+          // #1247 defensive retry — covers the post-enrol /intake/done → /x/sim race.
+          await new Promise((r) => setTimeout(r, 300));
+          if (cancelled) return;
+          res = await fetchCallerOnce(true);
+        }
+        if (res.status === 401) {
+          if (!cancelled) {
+            router.push(`/login?callbackUrl=${encodeURIComponent(`/x/sim/${callerId}`)}`);
+          }
+          return;
+        }
+        const data = await res.json();
+        if (!res.ok || !data.ok) {
+          if (!cancelled) setError("Caller not found");
+          return;
+        }
+        if (cancelled) return;
+
+        const callerDomainId = data.caller.domain?.id || data.caller.domainId;
+        if (layout === "standalone" && expectedDomainId && callerDomainId && expectedDomainId !== callerDomainId) {
+          setError("Caller is no longer in the expected institution. Please re-select from the wizard.");
+          return;
+        }
+        if (layout === "standalone" && !callerDomainId) {
+          setError("Caller has no institution assigned. Please assign one before simulating.");
+          return;
+        }
+
+        const calls = (data.calls || [])
+          .filter((c: { transcript?: string | null }) => c.transcript?.trim())
+          .map((c: { transcript: string; createdAt: string }) => ({
+            transcript: c.transcript,
+            createdAt: c.createdAt,
+          }))
+          .sort(
+            (a: PastCall, b: PastCall) =>
+              new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+          );
+        setCaller({
+          name: data.caller.name || "Unknown",
+          role: data.caller.role || "SIM",
+          domain: data.caller.domain,
+          pastCalls: calls,
+        });
+        if (typeof data.caller.lastSelectedModuleId === "string") {
+          setLastSelectedModuleId(data.caller.lastSelectedModuleId);
+        }
+
+        if (playbookId) {
+          fetch(`/api/playbooks/${playbookId}`)
+            .then((r) => r.json())
+            .then((pbData) => {
+              if (cancelled || !pbData.ok) return;
+              setPlaybookName(pbData.playbook?.name);
+              const cfg = (pbData.playbook?.config as Record<string, unknown>) || {};
+              if (typeof cfg.subjectDiscipline === "string") {
+                setSubjectDiscipline(cfg.subjectDiscipline);
+              }
+              setModulesAuthored(cfg.modulesAuthored === true);
+              if (Array.isArray(cfg.modules)) {
+                setAuthoredModules(cfg.modules as Array<{ id: string; label?: string }>);
+              }
+            })
+            .catch(() => {});
+        }
+      } catch {
+        if (!cancelled) setError("Failed to load caller");
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, expectedDomainId, layout, playbookId, router]);
+
+  // Journey chat — only meaningful for learner callers; the hook itself
+  // gates on callerRole internally. Hook is expensive (#1448 TL brief)
+  // so we still call it here (single mount point) and pass through.
+  const journey = useJourneyChat({
+    callerId,
+    forceFirstCall,
+    callerRole: caller?.role,
+  });
+
+  // #1248 — inline ModuleQuickSwitcher modal on both surfaces.
+  const [moduleSwitcherOpen, setModuleSwitcherOpen] = useState(false);
+  const handlePickModule = useCallback(() => {
+    if (!playbookId) return;
+    setModuleSwitcherOpen(true);
+  }, [playbookId]);
+
+  const handleModuleSwitcherPick = useCallback(
+    (moduleId: string) => {
+      const carryParams = new URLSearchParams(searchParams.toString());
+      carryParams.set("requestedModuleId", moduleId);
+      const path = layout === "standalone" ? `/x/sim/${callerId}` : window.location.pathname;
+      router.replace(`${path}?${carryParams.toString()}`);
+    },
+    [callerId, layout, router, searchParams],
+  );
+
+  const fullPickerHref = useMemo(() => {
+    if (!playbookId) return undefined;
+    const sp = new URLSearchParams();
+    const carryParams = new URLSearchParams(searchParams.toString());
+    carryParams.delete("requestedModuleId");
+    const returnTo =
+      layout === "standalone"
+        ? `/x/sim/${callerId}${carryParams.toString() ? `?${carryParams.toString()}` : ""}`
+        : window.location.pathname + (carryParams.toString() ? `?${carryParams.toString()}` : "");
+    sp.set("returnTo", returnTo);
+    sp.set("callerId", callerId);
+    return `/x/student/${playbookId}/modules?${sp.toString()}`;
+  }, [callerId, layout, playbookId, searchParams]);
+
+  const handleNameChange = useCallback(
+    (next: string) => {
+      setCaller((prev) => (prev ? { ...prev, name: next } : prev));
+      onNameChange?.(next);
+    },
+    [onNameChange],
+  );
+
+  const handleNewCall = useCallback(() => {
+    setCallSession((prev) => prev + 1);
+  }, []);
+
+  const handleCallEnd = useCallback(() => {
+    onCallEnd?.();
+    onPostCallRefresh?.();
+  }, [onCallEnd, onPostCallRefresh]);
+
+  if (error) {
+    return (
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 24 }}>
+        <p style={{ color: "var(--text-muted)", textAlign: "center" }}>{error}</p>
+      </div>
+    );
+  }
+  if (!caller) {
+    return (
+      <div className="wa-chat-bg" style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12 }}>
+        <div className="hf-spinner" style={{ width: 28, height: 28 }} />
+        <p style={{ color: "var(--text-muted)", fontSize: 14 }}>Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <SimStateBreadcrumb
+        pastCallCount={caller.pastCalls.length}
+        activeCall={isCallActive}
+        requestedModuleId={requestedModuleId ?? null}
+        modules={authoredModules}
+        onPickModule={modulesAuthored && playbookId ? handlePickModule : undefined}
+      />
+      <ModuleQuickSwitcher
+        open={moduleSwitcherOpen}
+        onClose={() => setModuleSwitcherOpen(false)}
+        modules={authoredModules}
+        currentModuleId={requestedModuleId ?? null}
+        onPick={handleModuleSwitcherPick}
+        fullPickerHref={fullPickerHref}
+      />
+      <QualificationContextStrip requestedModuleId={requestedModuleId ?? null} />
+      {requestedModuleId ? (
+        <ModulePickerSelectionBanner
+          moduleId={requestedModuleId}
+          modules={authoredModules}
+        />
+      ) : modulesAuthored && playbookId ? (
+        <ModulePickerInviteBanner
+          moduleCount={authoredModules.length}
+          onPick={handlePickModule}
+        />
+      ) : null}
+      <SimChat
+        key={callSession}
+        callerId={callerId}
+        callerName={caller.name}
+        domainName={caller.domain?.name ?? undefined}
+        playbookId={playbookId}
+        playbookName={communityName ?? playbookName}
+        subjectDiscipline={subjectDiscipline}
+        pastCalls={caller.pastCalls}
+        mode={layout}
+        sessionGoal={sessionGoal}
+        targetOverrides={targetOverrides}
+        forceFirstCall={forceFirstCall || undefined}
+        onBack={layout === "standalone" && !isDesktop ? onBack : undefined}
+        onCallEnd={handleCallEnd}
+        onCallStateChange={setIsCallActive}
+        onNewCall={handleNewCall}
+        requestedModuleId={requestedModuleId}
+        journey={journey}
+        onNameChange={handleNameChange}
+      />
+    </>
+  );
+}

--- a/apps/admin/tests/components/callers/CallerVoiceSurface.test.tsx
+++ b/apps/admin/tests/components/callers/CallerVoiceSurface.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Smoke tests for `<CallerVoiceSurface>` (#1448).
+ *
+ * Pins:
+ *   - Standalone layout: caller fetch + playbook fetch + SimChat mount
+ *     with full prop set (pastCalls, playbookName, subjectDiscipline,
+ *     journey)
+ *   - Embedded layout: respects `playbookIdOverride` (parent dictates);
+ *     onPostCallRefresh fired on handleCallEnd
+ *   - Caller-not-found error renders error message
+ *   - 401 → router.push to login
+ *   - PastCalls filter: only transcripts with content; sorted ASC
+ *
+ * Heavy mocking — the goal is to lock the prop-passing contract, not to
+ * exercise SimChat's internals (covered by existing SimChat tests).
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const mockRouterPush = vi.fn();
+const mockRouterReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush, replace: mockRouterReplace }),
+  useSearchParams: () => ({
+    get: (k: string) => null as string | null,
+    toString: () => "",
+  }),
+  useParams: () => ({ callerId: "caller-abc" }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
+vi.mock("@/hooks/useResponsive", () => ({
+  useResponsive: () => ({ isDesktop: true, isMobile: false }),
+}));
+
+vi.mock("@/hooks/useJourneyChat", () => ({
+  useJourneyChat: vi.fn(() => ({ items: [], phase: "idle" })),
+}));
+
+// Capture SimChat's props for assertion.
+let capturedSimChatProps: Record<string, unknown> | null = null;
+vi.mock("@/components/sim/SimChat", () => ({
+  SimChat: (props: Record<string, unknown>) => {
+    capturedSimChatProps = props;
+    return <div data-testid="sim-chat-mock" />;
+  },
+}));
+
+vi.mock("@/components/sim/SimStateBreadcrumb", () => ({
+  SimStateBreadcrumb: () => <div data-testid="sim-state-breadcrumb" />,
+}));
+
+vi.mock("@/components/sim/ModuleQuickSwitcher", () => ({
+  ModuleQuickSwitcher: () => <div data-testid="module-quick-switcher" />,
+}));
+
+vi.mock("@/components/sim/ModulePickerBanners", () => ({
+  ModulePickerSelectionBanner: () => <div data-testid="picker-selection" />,
+  ModulePickerInviteBanner: () => <div data-testid="picker-invite" />,
+}));
+
+vi.mock("@/components/sim/qualification/QualificationContextStrip", () => ({
+  QualificationContextStrip: () => <div data-testid="qual-strip" />,
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { CallerVoiceSurface } from "@/components/callers/CallerVoiceSurface";
+
+const CALLER_OK = {
+  ok: true,
+  caller: {
+    name: "Cyrus Horváth",
+    role: "LEARNER",
+    domain: { id: "dom1", name: "PAW Training Ltd" },
+    lastSelectedModuleId: undefined,
+  },
+  calls: [
+    { transcript: "AI: Hi\nUser: Hello", createdAt: "2026-06-01T10:00:00Z" },
+    { transcript: "", createdAt: "2026-06-02T10:00:00Z" }, // filtered out
+    { transcript: "AI: B\nUser: C", createdAt: "2026-06-03T10:00:00Z" },
+  ],
+};
+
+const PLAYBOOK_OK = {
+  ok: true,
+  playbook: {
+    name: "CIO/CTO Programme",
+    config: {
+      subjectDiscipline: "IT Operations",
+      modulesAuthored: true,
+      modules: [{ id: "mod1", label: "Module 1" }],
+    },
+  },
+  siblingPlaybookIds: ["pb-abc"],
+};
+
+beforeEach(() => {
+  capturedSimChatProps = null;
+  mockFetch.mockReset();
+  mockRouterPush.mockReset();
+  mockRouterReplace.mockReset();
+});
+
+function mockByUrl(
+  routes: Record<string, { status?: number; body: unknown }>,
+) {
+  mockFetch.mockImplementation((url: string) => {
+    let match: { status?: number; body: unknown } | undefined;
+    for (const [pattern, resp] of Object.entries(routes)) {
+      if (url.includes(pattern)) {
+        match = resp;
+        break;
+      }
+    }
+    if (!match) {
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        headers: { get: () => "application/json" },
+        json: async () => ({ ok: false, error: `no mock for ${url}` }),
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: (match.status ?? 200) < 400,
+      status: match.status ?? 200,
+      headers: { get: () => "application/json" },
+      json: async () => match.body,
+    } as Response);
+  });
+}
+
+function mockFetchSequence(...responses: Array<{ status?: number; body: unknown }>) {
+  let i = 0;
+  mockFetch.mockImplementation(() => {
+    const r = responses[i++] ?? responses[responses.length - 1];
+    return Promise.resolve({
+      ok: (r.status ?? 200) < 400,
+      status: r.status ?? 200,
+      headers: { get: () => "application/json" },
+      json: async () => r.body,
+    } as Response);
+  });
+}
+
+describe("CallerVoiceSurface (#1448)", () => {
+  it("standalone layout: passes full canonical prop set to SimChat", async () => {
+    mockByUrl({
+      "/active-playbook": { body: { ok: true, playbookId: "pb-resolved" } },
+      "/api/callers/caller-abc": { body: CALLER_OK },
+      "/api/playbooks/": { body: PLAYBOOK_OK },
+    });
+    render(
+      <CallerVoiceSurface
+        callerId="caller-abc"
+        layout="standalone"
+        forceFirstCall
+        sessionGoal="Test goal"
+        targetOverrides={{ accuracy: 0.85 }}
+      />,
+    );
+    await waitFor(() => expect(capturedSimChatProps).not.toBeNull());
+    const p = capturedSimChatProps!;
+    expect(p.callerId).toBe("caller-abc");
+    expect(p.callerName).toBe("Cyrus Horváth");
+    expect(p.mode).toBe("standalone");
+    expect(p.forceFirstCall).toBe(true);
+    expect(p.sessionGoal).toBe("Test goal");
+    expect(p.targetOverrides).toEqual({ accuracy: 0.85 });
+    // pastCalls filter: only non-empty transcripts, sorted ASC by createdAt
+    const past = p.pastCalls as Array<{ transcript: string; createdAt: string }>;
+    expect(past).toHaveLength(2);
+    expect(past[0].createdAt).toBe("2026-06-01T10:00:00Z");
+    expect(past[1].createdAt).toBe("2026-06-03T10:00:00Z");
+  });
+
+  it("embedded layout: respects playbookIdOverride (parent dictates)", async () => {
+    mockFetchSequence(
+      { body: CALLER_OK },
+      { body: PLAYBOOK_OK },
+    );
+    render(
+      <CallerVoiceSurface
+        callerId="caller-abc"
+        layout="embedded"
+        playbookIdOverride="pb-from-parent"
+      />,
+    );
+    await waitFor(() => expect(capturedSimChatProps).not.toBeNull());
+    expect(capturedSimChatProps!.playbookId).toBe("pb-from-parent");
+    expect(capturedSimChatProps!.mode).toBe("embedded");
+    // active-playbook resolver should NOT have fired (embedded uses override).
+    const calls = mockFetch.mock.calls.map((c) => c[0] as string);
+    expect(calls.some((u) => u.includes("/active-playbook"))).toBe(false);
+  });
+
+  it("renders 'Caller not found' on 404", async () => {
+    mockFetchSequence({ status: 404, body: { ok: false } }, { status: 404, body: { ok: false } });
+    render(<CallerVoiceSurface callerId="caller-abc" layout="standalone" />);
+    await waitFor(() => expect(screen.getByText(/Caller not found/i)).toBeTruthy());
+    expect(capturedSimChatProps).toBeNull();
+  });
+
+  it("401 → router.push to login", async () => {
+    mockFetchSequence({ status: 401, body: {} });
+    render(<CallerVoiceSurface callerId="caller-abc" layout="standalone" />);
+    await waitFor(() => expect(mockRouterPush).toHaveBeenCalled());
+    const arg = mockRouterPush.mock.calls[0][0] as string;
+    expect(arg).toMatch(/\/login/);
+    expect(arg).toMatch(/callbackUrl=/);
+  });
+
+  it("standalone: no expectedDomainId mismatch when domain matches", async () => {
+    mockByUrl({
+      "/active-playbook": { body: { ok: true, playbookId: "pb-resolved" } },
+      "/api/callers/caller-abc": { body: CALLER_OK },
+      "/api/playbooks/": { body: PLAYBOOK_OK },
+    });
+    render(
+      <CallerVoiceSurface
+        callerId="caller-abc"
+        layout="standalone"
+        expectedDomainId="dom1"
+      />,
+    );
+    await waitFor(() => expect(capturedSimChatProps).not.toBeNull());
+    // Should reach SimChat, not the error path.
+    expect(screen.queryByText(/no longer in the expected institution/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1448. Single shared voice-surface component mounted by both `/x/sim/[callerId]` (standalone) and `/x/callers/[id]?tab=ai-call` (embedded). Sim page 444 → 170 lines; Call tab section 70 → 18 lines. 5/5 vitests on prop-passing contract. Load-bearing remount mechanism preserved per TL brief. PIN gate + WhatsAppHeader stay in sim page wrapper (chrome). Follows the #1449 stopgap.