### PR TITLE
chore(grounding): #1458 make #1444 grounding contract durable

### DIFF
--- a/.claude/agents/arch-checker.md
+++ b/.claude/agents/arch-checker.md
@@ -1,11 +1,11 @@
 ---
 name: arch-checker
-description: Validates changed files against HF architectural contracts — SpecRole taxonomy, entity hierarchy, holographic section contracts, adaptive loop integrity, and memory doc freshness. Run after implementation, before committing. Pass a file list, a GitHub issue number, or say "current changes".
+description: Validates changed files against HF architectural contracts — SpecRole taxonomy, entity hierarchy, holographic section contracts, adaptive loop integrity, AI-read grounding contract, and memory doc freshness. Run after implementation, before committing. Pass a file list, a GitHub issue number, or say "current changes".
 tools: Bash, Read, Glob, Grep
 model: haiku
 ---
 
-You are the HF Architecture Checker. Validate changed files against the four core architectural contracts of this codebase.
+You are the HF Architecture Checker. Validate changed files against the core architectural contracts of this codebase: SpecRole taxonomy, entity hierarchy, holographic section contracts, adaptive loop integrity, tolerance placement, authoring-cascade read parity, AnyVoice column / tool naming, and the AI-read grounding contract for new `@ai-call` annotations (#1444 / #1458).
 
 ## Step 1 — Get the files
 
@@ -185,6 +185,30 @@ Flag (error):
 
 See `docs/CHAIN-CONTRACTS.md` Link 3 sub-contract I-VP2 and audit counter `vapiToolDefinitionsConstantPresent`.
 
+### Check G — AI-read grounding contract (#1444 / #1458)
+
+When changed files include a NEW `@ai-call` annotation:
+
+```bash
+git diff HEAD -- 'apps/admin/**/*.ts' 'apps/admin/**/*.tsx' | grep -E "^\+.*@ai-call"
+```
+
+For each new `@ai-call` site:
+
+- The annotation must be classified by risk class (A–F per `.claude/rules/ai-read-grounding.md`).
+- For Class A / B / D, the corresponding guard checklist in `ai-read-grounding.md` must be satisfied OR a `// TODO(ai-read-guard):` comment must be present at the call site with rationale.
+- Verify the system prompt for the surface includes a grounding contract section (model is told to tool-call before asserting facts about a specific entity).
+- For Class A: a vitest pinning the intercept exists (mirror of `tests/api/chat-factual-grounding.test.ts`) AND a promptfoo eval pins the model behaviour on a representative fingerprint.
+
+Flag (warn — promoted to error once #1447 audit closes):
+
+- New `@ai-call` site with no risk-class comment and no `// TODO(ai-read-guard):` escape hatch
+- Class A surface whose response path lacks a `detectUngroundedLearnerClaim` / equivalent intercept
+- New chat-shaped route returning natural-language text about specific entities, with no grounding tool wired into its tool surface
+- System prompt for a Class A / B / D surface that lacks an explicit "tool-call before asserting facts" rule
+
+Reference: `.claude/rules/ai-read-grounding.md`, `app/api/chat/factual-grounding-intercept.ts`, `tests/api/chat-factual-grounding.test.ts` (40 vitests pinning the 6 intercept patterns).
+
 ---
 
 ## Step 3 — Memory Doc Freshness
@@ -219,6 +243,7 @@ Files checked: [list]
 | D | Adaptive Loop | ✅ PASS / ⚠️ FLAG / N/A | |
 | E | Tolerance Placement | ✅ PASS / ⚠️ FLAG / N/A | |
 | F | Authoring Cascade Read Parity | ✅ PASS / ⚠️ FLAG / N/A | |
+| G | AI-Read Grounding (#1444 / #1458) | ✅ PASS / ⚠️ FLAG / N/A | |
 | — | Memory Doc Freshness | ✅ PASS / ⚠️ FLAG / N/A | |
 
 **Result: CLEAN** / **FLAGS: [N]**

--- a/.claude/rules/ai-read-grounding.md
+++ b/.claude/rules/ai-read-grounding.md
@@ -1,0 +1,95 @@
+# AI-Read Grounding Pattern
+
+> AI proposes a factual claim → grounding tool MUST be called → only then state the fact.
+>
+> Sibling to [`ai-to-db-guard.md`](./ai-to-db-guard.md): that file holds the WRITE-side validate-before-execute pattern; this one holds the READ-side verify-before-claim pattern. #1444 shipped the contract; #1458 made it durable; #1447 audits the remaining AI surfaces.
+
+## Rule: Never let AI assert facts about specific entities without a tool-call grounding in the same turn
+
+When AI returns natural-language text that names a specific entity (a caller, course, voice, goal, etc.) and asserts something about it, **always** require a grounding tool call in the same turn — the model demonstrably looked up the data, not inferred it from page-context or a system overview.
+
+```
+AI proposes claim → Grounding tool called → Only then assert
+```
+
+## When This Applies
+
+Any code path where:
+1. AI returns natural-language text (chat reply, assistant response, narration)
+2. That text mentions a specific entity by name (caller name, course title, voice id, etc.)
+3. The text asserts an attribute / state / relationship about the entity (enrollment, voice config, progress, goal completion, parameter scores)
+
+Most acutely: DATA / COURSE_MANAGE / BUG mode in `app/api/chat/route.ts` and the sibling `assistant.*` route at `app/api/ai/assistant/route.ts`. Pipeline analysis routes and content-trust extraction routes share the risk class but aren't intercepted yet (#1447 epic).
+
+## Required Checks
+
+| AI claims | Guard must check |
+|-----------|------------------|
+| Caller's course / enrollment | `get_caller_detail` tool-called in same turn |
+| Caller's voice config | `get_caller_detail` or `get_voice_config` tool-called |
+| Caller's progress / mastery / completion | `get_caller_detail` tool-called |
+| Caller's goal achievement | `get_caller_detail` tool-called |
+| Caller's parameter scores | `get_caller_detail` tool-called |
+| File paths cited (BUG mode) | `fs.existsSync` check on the path |
+
+The set of grounding tools is intentionally tight — every entry is a tool that returns caller-specific data the model can legitimately quote. Add to `GROUNDING_TOOL_NAMES` in `factual-grounding-intercept.ts` only when a new tool returns directly-quotable learner-scoped state.
+
+## Pattern: Verify-then-claim
+
+```typescript
+// BAD: AI text → direct emit
+const reply = await callModel({ system, messages });
+return new Response(reply.text);
+
+// GOOD: AI text → verify grounding → emit (or replace)
+const reply = await callModel({ system, messages });
+const intercept = detectUngroundedLearnerClaim({
+  assistantText: reply.text,
+  toolUsesInTurn: reply.toolUses,
+});
+if (intercept.blocked) {
+  log(`[grounding] ${intercept.reason}`);
+  return new Response(intercept.replacementText);
+}
+return new Response(reply.text);
+```
+
+For BUG mode add the sibling `detectFabricatedFilePaths` check against the same response.
+
+## Existing Guards
+
+| Location | Guard | What it prevents |
+|----------|-------|------------------|
+| `app/api/chat/factual-grounding-intercept.ts` | `detectUngroundedLearnerClaim` (6 patterns: voice / enrollment / goal-completion / progress / score + caller-name-token gate) + `detectFabricatedFilePaths` (fs.existsSync against `apps/admin/<path>:<line>?` citations) | DATA / COURSE_MANAGE / BUG / assistant.* asserting learner-scoped facts (enrollment, voice fallback, progress %, goal achievement, parameter scores) or BUG-mode file citations that don't exist on disk. Pinned by `tests/api/chat-factual-grounding.test.ts` (40/40). |
+| `lib/chat/page-context.ts` + `lib/chat/system-prompts.ts` | Snapshot blocks self-label as "the COURSE the operator is viewing — NOT any caller's enrollment"; `getSystemOverview()` carries the same disclaimer | Model inferring a specific learner's state from a course-scoped snapshot or the catalogue overview (the 2026-06-10 Bertie fingerprint). |
+| `lib/chat/system-prompts.ts::DATA_SYSTEM_PROMPT` | "Learner-scoped facts grounding contract" section — model is told it MUST call a grounding tool before asserting any learner-scoped claim, with the `get_caller_detail` / `get_voice_config` template phrasing baked in | Prompt-level signpost; the intercept (above) is the structural backstop. |
+
+## Known Gaps (tech debt)
+
+- **Streaming branches across all modes** — the intercept only runs in the non-streaming tool-loop branch. Streaming requires buffering the chunk stream before emitting, which the BUG branch already does (small responses) but the CALL streaming branches still don't. (#1447 epic, Slice A.)
+- **`assistant.*` route streaming** — same shape as the chat-route streaming gap. The non-streaming branch is wired; the streaming branch is not.
+- **Pipeline analysis routes** — `runSpecDrivenPipeline` paths (EXTRACT, AGGREGATE, REWARD, ADAPT, SUPERVISE) emit AI-derived data into `Call.analysis*` and `CallerAttribute`. No structural grounding contract today; the `@ai-call` source-span audit (#1447 Slice B) is the prereq.
+- **Content-trust extraction routes** — `lib/content-trust/extract-*` paths produce ContentAssertions from PDF/MD source. They WRITE through `validateManifest()` (ai-to-db-guard side) but the natural-language narration in their responses isn't intercepted. Same shape as the pipeline gap.
+- **Other Class A routes not yet audited** — #1447 audit will enumerate. When a new chat-shaped route lands, classify it before merge (see checklist below).
+
+## Escalation
+
+If you're writing a new AI-read surface and can't add structural grounding, add a `// TODO(ai-read-guard):` comment explaining why and what the risk is. These are tracked by `broken-windows` agent and surface in `arch-checker` reports.
+
+## When adding a new `@ai-call` annotation
+
+Author checklist — must be satisfied before merge (or a TODO comment must explain why each unsatisfied item is acceptable):
+
+1. **Classify the surface by risk** — pick one of A / B / C / D / E / F:
+   - **A** — READ chat (DATA / COURSE_MANAGE / BUG / assistant.*) returning natural-language text that may mention a specific entity
+   - **B** — Transcript analysis (pipeline EXTRACT / AGGREGATE / REWARD / ADAPT / SUPERVISE) producing AI-derived structured data
+   - **C** — Generation draft (curriculum / lesson plan / module rebuild)
+   - **D** — Source extraction (content-trust ContentAssertion writes from PDF/MD)
+   - **E** — Roleplay (voice provider, learner-facing call narration)
+   - **F** — Classification (group-type whitelisting, parameter routing)
+2. **For Class A / B / D:** confirm a grounding contract exists in the system prompt for the surface — model is explicitly told it MUST call a grounding tool before asserting facts about a specific entity.
+3. **For Class A:** confirm a post-response intercept catches the relevant claim shape — extend `detectUngroundedLearnerClaim` patterns if needed, or document why the existing patterns cover this surface.
+4. **For Class A:** add a vitest that pins the intercept (mirrors `tests/api/chat-factual-grounding.test.ts`) AND a promptfoo eval (under `evals/`) that pins the model behaviour on a representative fingerprint.
+5. **Document the surface** in this file's "Existing Guards" table OR add a `// TODO(ai-read-guard):` comment at the call site with rationale.
+
+`arch-checker` (see `.claude/agents/arch-checker.md` Check G) enforces 1–5 against changed files containing a NEW `@ai-call` annotation. The build doesn't fail without it — the agent flags it for human review at PR time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,12 @@ See `.claude/rules/rbac.md` + `.claude/rules/api-conventions.md` (auto-loaded fo
 
 ---
 
+## AI Guards (read-side + write-side)
+
+See `.claude/rules/ai-to-db-guard.md` (validate-then-write — AI output driving DB mutations) + `.claude/rules/ai-read-grounding.md` (verify-then-claim — AI text asserting facts about specific entities; #1444 contract + `factual-grounding-intercept.ts`).
+
+---
+
 ## Seed Data & Docker
 
 Spec JSONs in `docs-archive/bdd-specs/` are seed data only. After seeding, DB owns the data.

--- a/apps/admin/lib/chat/admin-tools.ts
+++ b/apps/admin/lib/chat/admin-tools.ts
@@ -856,7 +856,7 @@ export const ADMIN_TOOLS: AITool[] = [
   {
     name: "get_voice_config",
     description:
-      "Read the voice configuration for a Playbook — provider, model, end-state behaviour, polling. Does NOT expose model.secret (operator-only material, surfaced via settings page only).",
+      "Read the voice configuration for a Playbook — provider, model, voiceId, end-state behaviour, polling. `voiceId` is the TTS voice catalogue id (e.g. \"aura-asteria-en\", \"arcas\") — what the LEARNER HEARS. Do NOT confuse it with `model` (the LLM behind the voice agent, e.g. \"claude-haiku-4-5\"), which has no effect on the heard voice. Does NOT expose model.secret (operator-only material, surfaced via settings page only).",
     input_schema: {
       type: "object",
       properties: {
@@ -882,7 +882,7 @@ export const ADMIN_TOOLS: AITool[] = [
   {
     name: "update_voice_config",
     description:
-      "Adjust voice configuration for a Playbook by merging into Playbook.config.voice. The ALLOWED key set is driven by the system-enabled VoiceProvider's getConfigSchema() PLUS cross-cutting HF keys (autoPipeline, silenceTimeoutSeconds, maxDurationSeconds, voicemailDetectionEnabled, endCallPhrases, maxCostPerCallUsd, pollIntervalMs, endedReasonOverride) AND `prosodyMode` (`\"ielts\" | \"general\" | \"auto\"`) which controls how the voice provider scores the call audio — IELTS mode writes the 4-band CallScores (Fluency & Coherence, Pronunciation, Lexical Resource, Grammatical Range & Accuracy); General mode writes CONV_PACE and pace_indicators only; `auto` falls back to the legacy tierPresetId heuristic. #1270 — `provider` and `model` are LOCKED at system level and are NOT accepted (system picks the enabled VP; model is pinned per VP); `modelSecret` / `secret` / `apiKey` are DELIBERATELY not accepted — secret rotation is an operator-only flow. Bumps Playbook.composeInputsUpdatedAt.",
+      "Adjust voice configuration for a Playbook by merging into Playbook.config.voice. The ALLOWED key set is driven by the system-enabled VoiceProvider's getConfigSchema() PLUS cross-cutting HF keys (autoPipeline, silenceTimeoutSeconds, maxDurationSeconds, voicemailDetectionEnabled, endCallPhrases, maxCostPerCallUsd, pollIntervalMs, endedReasonOverride) AND `prosodyMode` (`\"ielts\" | \"general\" | \"auto\"`) which controls how the voice provider scores the call audio — IELTS mode writes the 4-band CallScores (Fluency & Coherence, Pronunciation, Lexical Resource, Grammatical Range & Accuracy); General mode writes CONV_PACE and pace_indicators only; `auto` falls back to the legacy tierPresetId heuristic. #1270 — `provider` and `model` are LOCKED at system level and are NOT accepted (system picks the enabled VP; `model` is the LLM behind the voice agent and is pinned per VP; it is NOT the TTS voice the learner hears — that is `voiceId`); `modelSecret` / `secret` / `apiKey` are DELIBERATELY not accepted — secret rotation is an operator-only flow. Bumps Playbook.composeInputsUpdatedAt.",
     input_schema: {
       type: "object",
       properties: {

--- a/docs/AI-CAPABILITIES.md
+++ b/docs/AI-CAPABILITIES.md
@@ -4,7 +4,7 @@
 
 This mirrors what the AI sees at every chat turn across all three AI surfaces. "Live" tools execute real handlers. "Roadmap stubs" return a friendly refusal that points the user at the UI surface to use today.
 
-> Last generated: 2026-06-10T11:35:09.335Z
+> Last generated: 2026-06-10T16:44:38.808Z
 > Surfaces: 4
 > Total tools: 67 (61 live, 6 roadmap stubs)
 
@@ -40,7 +40,7 @@ Source: `apps/admin/lib/chat/admin-tools.ts`
 | `get_domain_info` | OPERATOR | — | `domain_id`, `domain_name` | Get detailed info about a domain: description, playbook, specs in the playbook, caller count, and identity/content spec configs. |
 | `get_playbook_config` | OPERATOR | `playbook_id` | — | Read the full Playbook (course) config + top-level metadata. |
 | `get_spec_config` | OPERATOR | `spec_id` | — | Get the full config JSON for a specific spec by ID. |
-| `get_voice_config` | OPERATOR | `playbook_id` | — | Read the voice configuration for a Playbook — provider, model, end-state behaviour, polling. |
+| `get_voice_config` | OPERATOR | `playbook_id` | — | Read the voice configuration for a Playbook — provider, model, voiceId, end-state behaviour, polling. |
 | `link_subject_to_domain` | OPERATOR | `subject_id`, `domain_id` | — | Link a subject to a domain so callers in that domain can access this curriculum. |
 | `list_behavior_targets` | OPERATOR | — | `playbook_id`, `caller_id` | List active BehaviorTargets. |
 | `list_curriculum_modules` | OPERATOR | — | `curriculum_id`, `playbook_id` | List CurriculumModule rows. |

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-10T17:00:22.973Z",
+  "generatedAt": "2026-06-10T17:09:09.904Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1630,
-  "edgeCount": 3745,
+  "fileCount": 1631,
+  "edgeCount": 3746,
   "skippedEdges": 1,
   "edges": [
     {
@@ -930,6 +930,10 @@
     {
       "from": "app/api/callers/[callerId]/route.ts",
       "to": "lib/audit.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/route.ts",
+      "to": "lib/callers/serialize-call-for-detail.ts"
     },
     {
       "from": "app/api/callers/[callerId]/route.ts",
@@ -15407,7 +15411,7 @@
     {
       "path": "app/api/callers/[callerId]/route.ts",
       "inDegree": 0,
-      "outDegree": 9
+      "outDegree": 10
     },
     {
       "path": "app/api/callers/[callerId]/session-flow-progress/route.ts",
@@ -20238,6 +20242,11 @@
       "path": "lib/caller/resolve-active-playbook.ts",
       "inDegree": 2,
       "outDegree": 1
+    },
+    {
+      "path": "lib/callers/serialize-call-for-detail.ts",
+      "inDegree": 1,
+      "outDegree": 0
     },
     {
       "path": "lib/cascade/voice-explain.ts",

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-10T11:02:03.414Z",
+  "generatedAt": "2026-06-10T17:00:22.973Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
   "fileCount": 1630,
-  "edgeCount": 3738,
+  "edgeCount": 3745,
   "skippedEdges": 1,
   "edges": [
     {
@@ -406,6 +406,10 @@
     {
       "from": "app/api/ai-models/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/ai/assistant/route.ts",
+      "to": "app/api/chat/factual-grounding-intercept.ts"
     },
     {
       "from": "app/api/ai/assistant/route.ts",
@@ -1398,6 +1402,10 @@
     {
       "from": "app/api/chat/page-context.ts",
       "to": "lib/chat/ai-forbidden-fields.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "app/api/chat/factual-grounding-intercept.ts"
     },
     {
       "from": "app/api/chat/route.ts",
@@ -6365,6 +6373,10 @@
     },
     {
       "from": "app/api/voice/calls/outbound-dial/route.ts",
+      "to": "lib/voice/diag.ts"
+    },
+    {
+      "from": "app/api/voice/calls/outbound-dial/route.ts",
       "to": "lib/voice/record-call-failure.ts"
     },
     {
@@ -6397,6 +6409,10 @@
     },
     {
       "from": "app/api/voice/calls/start/route.ts",
+      "to": "lib/voice/diag.ts"
+    },
+    {
+      "from": "app/api/voice/calls/start/route.ts",
       "to": "lib/voice/resolve-voice-provider.ts"
     },
     {
@@ -6424,8 +6440,16 @@
       "to": "lib/prisma.ts"
     },
     {
-      "from": "app/api/voice/llm-proxy/chat/completions/route.ts",
-      "to": "lib/config.ts"
+      "from": "app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts",
+      "to": "lib/voice/llm-proxy/run-vapi-chat-completion.ts"
+    },
+    {
+      "from": "app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts",
+      "to": "lib/voice/llm-proxy/verify-vapi-secret.ts"
     },
     {
       "from": "app/api/voice/llm-proxy/chat/completions/route.ts",
@@ -6433,23 +6457,11 @@
     },
     {
       "from": "app/api/voice/llm-proxy/chat/completions/route.ts",
-      "to": "lib/metering/usage-logger.ts"
-    },
-    {
-      "from": "app/api/voice/llm-proxy/chat/completions/route.ts",
-      "to": "lib/voice/llm-proxy/translate-request.ts"
-    },
-    {
-      "from": "app/api/voice/llm-proxy/chat/completions/route.ts",
-      "to": "lib/voice/llm-proxy/translate-stream.ts"
+      "to": "lib/voice/llm-proxy/run-vapi-chat-completion.ts"
     },
     {
       "from": "app/api/voice/llm-proxy/chat/completions/route.ts",
       "to": "lib/voice/llm-proxy/verify-vapi-secret.ts"
-    },
-    {
-      "from": "app/api/voice/llm-proxy/chat/completions/route.ts",
-      "to": "lib/voice/telemetry.ts"
     },
     {
       "from": "app/api/voice/poll-stale-calls/route.ts",
@@ -9609,35 +9621,15 @@
     },
     {
       "from": "app/x/sim/[callerId]/page.tsx",
+      "to": "components/callers/CallerVoiceSurface.tsx"
+    },
+    {
+      "from": "app/x/sim/[callerId]/page.tsx",
       "to": "components/identity/FirstCallPinGate.tsx"
     },
     {
       "from": "app/x/sim/[callerId]/page.tsx",
-      "to": "components/sim/ModulePickerBanners.tsx"
-    },
-    {
-      "from": "app/x/sim/[callerId]/page.tsx",
-      "to": "components/sim/ModuleQuickSwitcher.tsx"
-    },
-    {
-      "from": "app/x/sim/[callerId]/page.tsx",
-      "to": "components/sim/qualification/QualificationContextStrip.tsx"
-    },
-    {
-      "from": "app/x/sim/[callerId]/page.tsx",
-      "to": "components/sim/SimChat.tsx"
-    },
-    {
-      "from": "app/x/sim/[callerId]/page.tsx",
-      "to": "components/sim/SimStateBreadcrumb.tsx"
-    },
-    {
-      "from": "app/x/sim/[callerId]/page.tsx",
       "to": "components/sim/WhatsAppHeader.tsx"
-    },
-    {
-      "from": "app/x/sim/[callerId]/page.tsx",
-      "to": "hooks/useJourneyChat.ts"
     },
     {
       "from": "app/x/sim/[callerId]/page.tsx",
@@ -14020,6 +14012,10 @@
       "to": "lib/voice/session-rules.ts"
     },
     {
+      "from": "lib/voice/diag.ts",
+      "to": "lib/logger.ts"
+    },
+    {
       "from": "lib/voice/end-session.ts",
       "to": "lib/config.ts"
     },
@@ -14030,6 +14026,30 @@
     {
       "from": "lib/voice/end-session.ts",
       "to": "lib/voice/session-rules.ts"
+    },
+    {
+      "from": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+      "to": "lib/config.ts"
+    },
+    {
+      "from": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+      "to": "lib/metering/usage-logger.ts"
+    },
+    {
+      "from": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+      "to": "lib/voice/llm-proxy/translate-request.ts"
+    },
+    {
+      "from": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+      "to": "lib/voice/llm-proxy/translate-stream.ts"
+    },
+    {
+      "from": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+      "to": "lib/voice/telemetry.ts"
     },
     {
       "from": "lib/voice/llm-proxy/verify-vapi-secret.ts",
@@ -14102,6 +14122,10 @@
     {
       "from": "lib/voice/providers/retell/index.ts",
       "to": "lib/voice/types.ts"
+    },
+    {
+      "from": "lib/voice/providers/vapi/index.ts",
+      "to": "lib/logger.ts"
     },
     {
       "from": "lib/voice/providers/vapi/index.ts",
@@ -14198,6 +14222,10 @@
     {
       "from": "lib/voice/route-handlers.ts",
       "to": "lib/voice/create-session.ts"
+    },
+    {
+      "from": "lib/voice/route-handlers.ts",
+      "to": "lib/voice/diag.ts"
     },
     {
       "from": "lib/voice/route-handlers.ts",
@@ -15169,7 +15197,7 @@
     {
       "path": "app/api/ai/assistant/route.ts",
       "inDegree": 0,
-      "outDegree": 7
+      "outDegree": 8
     },
     {
       "path": "app/api/ai/assistant/search/route.ts",
@@ -15492,6 +15520,11 @@
       "outDegree": 1
     },
     {
+      "path": "app/api/chat/factual-grounding-intercept.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
       "path": "app/api/chat/page-context.ts",
       "inDegree": 2,
       "outDegree": 1
@@ -15499,7 +15532,7 @@
     {
       "path": "app/api/chat/route.ts",
       "inDegree": 0,
-      "outDegree": 29
+      "outDegree": 30
     },
     {
       "path": "app/api/chat/system-prompts.ts",
@@ -17409,12 +17442,12 @@
     {
       "path": "app/api/voice/calls/outbound-dial/route.ts",
       "inDegree": 0,
-      "outDegree": 9
+      "outDegree": 10
     },
     {
       "path": "app/api/voice/calls/start/route.ts",
       "inDegree": 0,
-      "outDegree": 7
+      "outDegree": 8
     },
     {
       "path": "app/api/voice/costs/route.ts",
@@ -17427,9 +17460,14 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "app/api/voice/llm-proxy/chat/completions/route.ts",
       "inDegree": 0,
-      "outDegree": 7
+      "outDegree": 3
     },
     {
       "path": "app/api/voice/poll-stale-calls/route.ts",
@@ -18854,7 +18892,7 @@
     {
       "path": "app/x/sim/[callerId]/page.tsx",
       "inDegree": 0,
-      "outDegree": 11
+      "outDegree": 6
     },
     {
       "path": "app/x/sim/feedback/page.tsx",
@@ -19133,6 +19171,11 @@
     },
     {
       "path": "components/callers/CallerDetailPage.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/callers/CallerVoiceSurface.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -19697,37 +19740,12 @@
       "outDegree": 0
     },
     {
-      "path": "components/sim/ModulePickerBanners.tsx",
-      "inDegree": 1,
-      "outDegree": 0
-    },
-    {
-      "path": "components/sim/ModuleQuickSwitcher.tsx",
-      "inDegree": 1,
-      "outDegree": 0
-    },
-    {
-      "path": "components/sim/SimChat.tsx",
-      "inDegree": 1,
-      "outDegree": 0
-    },
-    {
       "path": "components/sim/SimNavBar.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
     {
-      "path": "components/sim/SimStateBreadcrumb.tsx",
-      "inDegree": 1,
-      "outDegree": 0
-    },
-    {
       "path": "components/sim/WhatsAppHeader.tsx",
-      "inDegree": 1,
-      "outDegree": 0
-    },
-    {
-      "path": "components/sim/qualification/QualificationContextStrip.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -19899,11 +19917,6 @@
     {
       "path": "hooks/useCourseSetupStatus.ts",
       "inDegree": 2,
-      "outDegree": 0
-    },
-    {
-      "path": "hooks/useJourneyChat.ts",
-      "inDegree": 1,
       "outDegree": 0
     },
     {
@@ -21418,7 +21431,7 @@
     },
     {
       "path": "lib/logger.ts",
-      "inDegree": 18,
+      "inDegree": 22,
       "outDegree": 3
     },
     {
@@ -22237,6 +22250,11 @@
       "outDegree": 7
     },
     {
+      "path": "lib/voice/diag.ts",
+      "inDegree": 3,
+      "outDegree": 1
+    },
+    {
       "path": "lib/voice/end-session.ts",
       "inDegree": 1,
       "outDegree": 3
@@ -22252,6 +22270,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+      "inDegree": 2,
+      "outDegree": 6
+    },
+    {
       "path": "lib/voice/llm-proxy/translate-request.ts",
       "inDegree": 1,
       "outDegree": 0
@@ -22263,7 +22286,7 @@
     },
     {
       "path": "lib/voice/llm-proxy/verify-vapi-secret.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 2
     },
     {
@@ -22309,7 +22332,7 @@
     {
       "path": "lib/voice/providers/vapi/index.ts",
       "inDegree": 2,
-      "outDegree": 2
+      "outDegree": 3
     },
     {
       "path": "lib/voice/reconcile-missing-bootstrap.ts",
@@ -22344,7 +22367,7 @@
     {
       "path": "lib/voice/route-handlers.ts",
       "inDegree": 5,
-      "outDegree": 25
+      "outDegree": 26
     },
     {
       "path": "lib/voice/runtime-features.ts",
@@ -22897,6 +22920,11 @@
       "outDegree": 0
     },
     {
+      "path": "scripts/migrate-vapi-background-sound.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
       "path": "scripts/migrate-vapi-tts-default.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -23176,12 +23204,12 @@
     {
       "path": "lib/voice/route-handlers.ts",
       "inDegree": 5,
-      "outDegree": 25
+      "outDegree": 26
     },
     {
       "path": "app/api/chat/route.ts",
       "inDegree": 0,
-      "outDegree": 29
+      "outDegree": 30
     },
     {
       "path": "app/api/content-sources/[sourceId]/extract/route.ts",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-10T17:00:21.092Z",
+  "generatedAt": "2026-06-10T17:09:08.552Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-10T11:02:01.664Z",
+  "generatedAt": "2026-06-10T17:00:21.092Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-10T17:00:22.091Z",
+  "generatedAt": "2026-06-10T17:09:09.144Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,10 +1,10 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-10T11:02:02.428Z",
+  "generatedAt": "2026-06-10T17:00:22.091Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
-    "routeCount": 505,
+    "routeCount": 506,
     "byAuthLevel": {
       "VIEWER": 112,
       "ADMIN": 81,
@@ -15,7 +15,7 @@
       "VIEWER+OPERATOR": 56,
       "auth-gate(non-role)": 54,
       "VIEWER+OPERATOR+ADMIN": 3,
-      "<none>": 28,
+      "<none>": 29,
       "OPERATOR+ADMIN": 5,
       "VIEWER+STUDENT": 1,
       "TESTER": 1,
@@ -24,7 +24,7 @@
       "ADMIN+OPERATOR": 1,
       "VIEWER+TESTER": 3
     },
-    "noAuthGate": 27,
+    "noAuthGate": 28,
     "possiblyUnscoped": 131,
     "internalSecret": 8
   },
@@ -889,7 +889,7 @@
       "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": false,
-        "usesScopeHelper": false,
+        "usesScopeHelper": true,
         "handlesInternalSecret": false,
         "rawPrisma": false,
         "possiblyUnscoped": false,
@@ -9913,6 +9913,24 @@
         "rawPrisma": true,
         "possiblyUnscoped": false,
         "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/voice/llm-proxy/auth/[secret]/chat/completions",
+      "file": "apps/admin/app/api/voice/llm-proxy/auth/[secret]/chat/completions/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [],
+      "hasAuthGate": false,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": true
       },
       "reviewed": false
     },


### PR DESCRIPTION
## Summary

- voice tool descriptions now distinguish voiceId from LLM model (smoke quibble)
- new `.claude/rules/ai-read-grounding.md` mirrors `ai-to-db-guard.md` for the READ side
- `arch-checker` agent enforces the new rule on `@ai-call` changes
- memory file expanded with copy-paste 4-layer template

Closes #1458. Follow-on epic: #1447.

## Why

#1444 shipped the contract in code. This PR makes it durable — future authors get a signpost (rule file), an agent enforces it on PRs (arch-checker), and the memory file gives a copy-paste template so the pattern can be applied to new AI surfaces without re-deriving it.

## Test plan

- [x] `npx vitest run tests/api/chat-factual-grounding.test.ts` — 40/40 still green
- [x] `npx tsc --noEmit` clean on touched files
- [x] `npm run lint` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)