### PR TITLE
fix(callers): #1459 — restore sessionId + voice fields on /api/callers/[id] wire

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/route.ts
@@ -9,6 +9,7 @@ import type { CallerRole } from "@prisma/client";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 import { getSkillTierMapping } from "@/lib/goals/track-progress";
 import { bumpCallerComposeTimestamp } from "@/lib/compose/bump-timestamp";
+import { serializeCallForCallerDetail } from "@/lib/callers/serialize-call-for-detail";
 
 /**
  * @api GET /api/callers/:callerId
@@ -510,30 +511,18 @@ export async function GET(
         .map((c) => c.id),
     );
 
-    // Transform calls to include analysis status
-    const callsWithStatus = calls.map((call) => ({
-      id: call.id,
-      source: call.source,
-      externalId: call.externalId,
-      transcript: call.transcript,
-      createdAt: call.createdAt,
-      // #1344 Slice 4 — `callSequence` column is gone. Emit the parent
-      // Session's learner-facing number for back-compat with the
-      // existing UI shape; null when the Call pre-dates Slice 3 (no
-      // Session parent).
-      callSequence: call.session?.learnerFacingNumber ?? null,
-      playbookId: call.playbookId || null,
-      // Analysis status flags
-      hasScores: call._count.scores > 0,
-      hasMemories: (memoryCountMap.get(call.id) || 0) > 0,
-      hasBehaviorMeasurements: call._count.behaviorMeasurements > 0,
-      hasRewardScore: !!call.rewardScore,
-      // Prompt status
-      hasPrompt: promptedCallIds.has(call.id),
-      // Module context
-      curriculumModuleId: call.curriculumModuleId || null,
-      curriculumModule: call.curriculumModule || null,
-    }));
+    // Transform calls to include analysis status (#1459 — extracted to
+    // `lib/callers/serialize-call-for-detail.ts` so the wire contract
+    // is pinned by a unit test instead of requiring a 30-mock route
+    // integration test). Adds back `sessionId` + voice end-state fields
+    // that the old inline transform stripped from the response.
+    const callsWithStatus = calls.map((call) =>
+      serializeCallForCallerDetail(
+        call,
+        memoryCountMap.get(call.id) || 0,
+        promptedCallIds.has(call.id),
+      ),
+    );
 
     // Extract available slug variable names from playbook templates
     const availableSlugNames = new Set<string>();

--- a/apps/admin/lib/callers/serialize-call-for-detail.ts
+++ b/apps/admin/lib/callers/serialize-call-for-detail.ts
@@ -1,0 +1,88 @@
+/**
+ * Wire-shape transform for `GET /api/callers/[callerId]` `calls[]`.
+ *
+ * Extracted from the route handler so the wire contract can be pinned
+ * by a unit test without mocking the route's ~30 Prisma calls.
+ *
+ * #1459 — pre-fix the inline transform stripped `sessionId`, `endedAt`,
+ * `requestedModuleId`, and the three voice end-state fields even though
+ * Prisma selected them, the route used `sessionId` internally for
+ * `promptedCallIds`, and the UI `Call` type marked them as required.
+ * That broke `CallsPromptsTab.buildTimeline` — every call rendered
+ * "previous call has no composition" because `callBySessionId` was
+ * empty.
+ */
+
+export type CallerDetailCallInput = {
+  id: string;
+  source: string;
+  externalId: string | null;
+  transcript: string;
+  createdAt: Date;
+  endedAt: Date | null;
+  sessionId: string | null;
+  session: { sequenceNumber: number; learnerFacingNumber: number | null } | null;
+  playbookId: string | null;
+  requestedModuleId: string | null;
+  voiceEndedReason: string | null;
+  voiceDurationSeconds: number | null;
+  voiceCostUsd: number | null;
+  curriculumModuleId: string | null;
+  curriculumModule:
+    | { id: string; slug: string; title: string; coversModules: unknown }
+    | null;
+  _count: { scores: number; behaviorMeasurements: number };
+  rewardScore: { id: string } | null;
+};
+
+export type CallerDetailCallWire = {
+  id: string;
+  source: string;
+  externalId: string | null;
+  transcript: string;
+  createdAt: Date;
+  endedAt: Date | null;
+  sessionId: string | null;
+  callSequence: number | null;
+  playbookId: string | null;
+  requestedModuleId: string | null;
+  hasScores: boolean;
+  hasMemories: boolean;
+  hasBehaviorMeasurements: boolean;
+  hasRewardScore: boolean;
+  hasPrompt: boolean;
+  curriculumModuleId: string | null;
+  curriculumModule: CallerDetailCallInput["curriculumModule"];
+  voiceEndedReason: string | null;
+  voiceDurationSeconds: number | null;
+  voiceCostUsd: number | null;
+};
+
+export function serializeCallForCallerDetail(
+  call: CallerDetailCallInput,
+  memoryCount: number,
+  hasPrompt: boolean,
+): CallerDetailCallWire {
+  return {
+    id: call.id,
+    source: call.source,
+    externalId: call.externalId,
+    transcript: call.transcript,
+    createdAt: call.createdAt,
+    endedAt: call.endedAt,
+    sessionId: call.sessionId,
+    callSequence: call.session?.learnerFacingNumber ?? null,
+    playbookId: call.playbookId || null,
+    requestedModuleId: call.requestedModuleId || null,
+    hasScores: call._count.scores > 0,
+    hasMemories: memoryCount > 0,
+    hasBehaviorMeasurements: call._count.behaviorMeasurements > 0,
+    hasRewardScore: !!call.rewardScore,
+    hasPrompt,
+    curriculumModuleId: call.curriculumModuleId || null,
+    curriculumModule: call.curriculumModule || null,
+    voiceEndedReason: call.voiceEndedReason ?? null,
+    voiceDurationSeconds: call.voiceDurationSeconds ?? null,
+    voiceCostUsd: call.voiceCostUsd ?? null,
+  };
+}

--- a/apps/admin/tests/lib/callers/serialize-call-for-detail.test.ts
+++ b/apps/admin/tests/lib/callers/serialize-call-for-detail.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression pin for #1459 — the wire shape returned by
+ * `GET /api/callers/[callerId]` `calls[]` must include `sessionId` and
+ * the four `voice*` end-state fields. Pre-fix the inline transform
+ * stripped them and the calls-prompts tab rendered "previous call has
+ * no composition" for every populated call (`buildTimeline` joins via
+ * `Call.sessionId → ComposedPrompt.triggerSessionId`).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  serializeCallForCallerDetail,
+  type CallerDetailCallInput,
+} from "@/lib/callers/serialize-call-for-detail";
+
+function callRow(
+  overrides: Partial<CallerDetailCallInput> = {},
+): CallerDetailCallInput {
+  return {
+    id: "call-1",
+    source: "vapi",
+    externalId: "ext-1",
+    transcript: "User: hi\nAI: hello",
+    createdAt: new Date("2026-06-10T16:22:24.621Z"),
+    endedAt: new Date("2026-06-10T16:24:00.000Z"),
+    sessionId: "sess-abc",
+    session: { sequenceNumber: 7, learnerFacingNumber: 7 },
+    playbookId: "pb-1",
+    requestedModuleId: "mod-1",
+    voiceEndedReason: "customer-ended-call",
+    voiceDurationSeconds: 96.5,
+    voiceCostUsd: 0.21,
+    curriculumModuleId: "cm-1",
+    curriculumModule: {
+      id: "cm-1",
+      slug: "unit-04",
+      title: "IT Operations",
+      coversModules: null,
+    },
+    _count: { scores: 3, behaviorMeasurements: 12 },
+    rewardScore: { id: "rs-1" },
+    ...overrides,
+  };
+}
+
+describe("serializeCallForCallerDetail (#1459)", () => {
+  it("includes sessionId on the wire (root cause of #1459)", () => {
+    const row = callRow({ sessionId: "sess-xyz" });
+    const wire = serializeCallForCallerDetail(row, 0, false);
+    expect(wire.sessionId).toBe("sess-xyz");
+  });
+
+  it("passes through all four voice end-state fields", () => {
+    const row = callRow({
+      voiceEndedReason: "assistant-ended-call",
+      voiceDurationSeconds: 42.5,
+      voiceCostUsd: 0.0992,
+    });
+    const wire = serializeCallForCallerDetail(row, 0, false);
+    expect(wire.voiceEndedReason).toBe("assistant-ended-call");
+    expect(wire.voiceDurationSeconds).toBe(42.5);
+    expect(wire.voiceCostUsd).toBe(0.0992);
+  });
+
+  it("preserves null voice fields without coercion", () => {
+    const row = callRow({
+      voiceEndedReason: null,
+      voiceDurationSeconds: null,
+      voiceCostUsd: null,
+    });
+    const wire = serializeCallForCallerDetail(row, 0, false);
+    expect(wire.voiceEndedReason).toBeNull();
+    expect(wire.voiceDurationSeconds).toBeNull();
+    expect(wire.voiceCostUsd).toBeNull();
+  });
+
+  it("emits callSequence from parent Session.learnerFacingNumber", () => {
+    const row = callRow({
+      session: { sequenceNumber: 7, learnerFacingNumber: 4 },
+    });
+    const wire = serializeCallForCallerDetail(row, 0, false);
+    expect(wire.callSequence).toBe(4);
+  });
+
+  it("emits null callSequence for pre-Slice-3 Calls (no Session parent)", () => {
+    const row = callRow({ session: null });
+    const wire = serializeCallForCallerDetail(row, 0, false);
+    expect(wire.callSequence).toBeNull();
+  });
+
+  it("coerces empty playbookId / requestedModuleId to null (existing contract)", () => {
+    const row = callRow({
+      playbookId: "" as unknown as string,
+      requestedModuleId: "" as unknown as string,
+    });
+    const wire = serializeCallForCallerDetail(row, 0, false);
+    expect(wire.playbookId).toBeNull();
+    expect(wire.requestedModuleId).toBeNull();
+  });
+
+  it("derives analysis flags from _count and explicit args", () => {
+    const row = callRow({
+      _count: { scores: 0, behaviorMeasurements: 5 },
+      rewardScore: null,
+    });
+    const wire = serializeCallForCallerDetail(row, 3, true);
+    expect(wire.hasScores).toBe(false);
+    expect(wire.hasMemories).toBe(true);
+    expect(wire.hasBehaviorMeasurements).toBe(true);
+    expect(wire.hasRewardScore).toBe(false);
+    expect(wire.hasPrompt).toBe(true);
+  });
+
+  it("hasMemories=false when memory count is zero", () => {
+    const row = callRow();
+    const wire = serializeCallForCallerDetail(row, 0, false);
+    expect(wire.hasMemories).toBe(false);
+  });
+
+  it("wire shape pin — exact field set (catches future drift)", () => {
+    const row = callRow();
+    const wire = serializeCallForCallerDetail(row, 1, true);
+    expect(Object.keys(wire).sort()).toEqual(
+      [
+        "callSequence",
+        "createdAt",
+        "curriculumModule",
+        "curriculumModuleId",
+        "endedAt",
+        "externalId",
+        "hasBehaviorMeasurements",
+        "hasMemories",
+        "hasPrompt",
+        "hasRewardScore",
+        "hasScores",
+        "id",
+        "playbookId",
+        "requestedModuleId",
+        "sessionId",
+        "source",
+        "transcript",
+        "voiceCostUsd",
+        "voiceDurationSeconds",
+        "voiceEndedReason",
+      ].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The inline transform in `GET /api/callers/[id]` stripped `sessionId`, `endedAt`, `requestedModuleId`, and the three `voice*` end-state fields from the response. Prisma selected them; the UI type required them.
- Symptom: every entry on the Calls & Prompts tab rendered "No input prompt — previous call has no composition" — including calls where COMPOSE had successfully produced a `ComposedPrompt`. The timeline joins via `Call.sessionId → ComposedPrompt.triggerSessionId`; with `sessionId` missing on the wire, `callBySessionId` stayed empty.
- Fix: extract the transform to `serializeCallForCallerDetail` so the wire shape is pinned by a unit test (no ~30-mock route integration test required). Added `endedAt` / `sessionId` / `requestedModuleId` / `voiceEndedReason` / `voiceDurationSeconds` / `voiceCostUsd` back into the response.

## Root-cause notes

The original incident report at session-end (the post-summary text under #1459) hypothesised the end-of-call webhook never landed. That was wrong. Live state on hf_sandbox confirms:

- `AppLog` has the full `voice.webhook.arrive` → `voice.webhook.body` → `voice.webhook.end_of_call` chain.
- Caller `fe879e24` has 8 vapi calls AND 9 `ComposedPrompt` rows with matching `triggerSessionId` values.
- All Call rows are populated (`trLen`, `cost`, `reason`, `dur` all set).

The pipeline was working end-to-end. The UI bug was an API serialiser dropping the FK that the UI's timeline grouping joined on.

## Test plan

- [x] `npx vitest run tests/lib/callers/serialize-call-for-detail.test.ts` — 9/9 pass
- [x] `npx tsc --noEmit` — no new errors on the touched files (pre-existing errors in `route.ts` skill-goal grouping are out of scope)
- [ ] Smoke on hf-dev after `/vm-cp`: open `/x/callers/fe879e24-17e6-443d-a046-95b6baedab2b?tab=calls-prompts` and confirm Call 7 shows its Input Prompt
- [ ] Confirm voice end-state chips render duration / cost where present (#1178 surface unblocked)

Closes #1459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)