### PR TITLE
feat(cascade): #1454 Slice 1 — lib/cascade/ primitive + 5 resolvers

### DIFF
--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -169,6 +169,13 @@ function cacheSet(
  * Drop every cache entry for the given `knobKey` (across all scope
  * chains). Called from `setKnobAtLayer` (Slice 2) after a successful
  * write so the next read returns the fresh winner.
+ *
+ * TODO(slice-2-invalidation-coverage): existing mutators
+ * (`updatePlaybookConfig`, `updateDomainConfig`, direct `BehaviorTarget`
+ * writes via `/api/playbooks/[id]/behavior-targets`) do NOT call
+ * `invalidateKnob` today — same-session reads can race a same-session
+ * write within the 30s window. Slice 2 wires `invalidateKnob` into the
+ * shared write helpers so non-cascade write paths also self-invalidate.
  */
 export function invalidateKnob(knobKey: string): void {
   const prefix = `${knobKey}|`;

--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -1,0 +1,220 @@
+/**
+ * Cascade-honesty primitive (Epic #1442 Layer 2 — see
+ * `docs/decisions/2026-06-10-cascade-honesty-ux.md`).
+ *
+ * `resolveEffective` is the single read entry-point for the cascade UX —
+ * `<LayerBadge>`, `<CascadeInspectorTray>`, and `GET /api/cascade/resolve`
+ * all route through here. It dispatches by knob key to the correct
+ * per-family resolver, all of which WRAP existing cascade helpers
+ * (`getEffectiveBehaviorTargetsForCaller`, `resolveSessionFlow`,
+ * `voice-explain`, etc.) rather than duplicating their layer reads.
+ *
+ * Why no `hf-cascade/no-bare-resolve` ESLint rule: composition transforms
+ * call the underlying helpers directly at >20 sites today and that is
+ * legitimate — they want the winner, not the chain. A blanket rule would
+ * generate false positives. The audience for `resolveEffective` is UI +
+ * the cascade-resolve API route only.
+ *
+ * Per-page-load cache: a 30s TTL Map keyed on `(knobKey, scopeChain)`.
+ * Mirrors the staleness pattern at `lib/compose/staleness.ts`. Invalidates
+ * on any `setKnobAtLayer` call for the same `knobKey` so an operator who
+ * writes an override sees the new effective value on the next read,
+ * unaffected by the otherwise-30s window.
+ */
+
+import type { Effective, Layer } from "./layer-types";
+import { resolveBehaviorTarget } from "./resolvers/behavior-target";
+import { resolveSessionFlowKnob } from "./resolvers/session-flow";
+import { resolveWelcomeMessage } from "./resolvers/welcome-message";
+import { resolveVoiceConfigKnob } from "./resolvers/voice-config";
+import { resolveIdentitySpec } from "./resolvers/identity-spec";
+
+/**
+ * Scope IDs the cascade can resolve against. SYSTEM is implicit (no id);
+ * other layers require the id when present in the chain. Resolvers pick
+ * the fields they need; missing-but-required fields produce a thrown
+ * `Error` (cascade can't resolve without them) — callers (route handler,
+ * components) decide whether to 400 or render a placeholder.
+ */
+export interface ScopeChain {
+  domainId?: string;
+  playbookId?: string;
+  segmentId?: string;
+  callerId?: string;
+  callId?: string;
+}
+
+export interface ResolveArgs {
+  knobKey: string;
+  scopeChain: ScopeChain;
+}
+
+type AnyResolver = (scope: ScopeChain, knobKey: string) => Promise<Effective<unknown>>;
+
+interface KnobFamily {
+  /** Brief diagnostic name surfaced in error messages and cache stats. */
+  name: string;
+  match: (knobKey: string) => boolean;
+  resolve: AnyResolver;
+}
+
+/**
+ * Knob → resolver dispatch table. Each entry is `{ match, resolve }`.
+ * First match wins — order matters when patterns could overlap (none do
+ * today; behavior-target's `BEH-*` prefix and the explicit knob lists
+ * below are disjoint).
+ *
+ * Adding a new cascade family: implement the resolver under
+ * `lib/cascade/resolvers/`, then add one entry here. No ESLint rule
+ * change required.
+ */
+const FAMILIES: readonly KnobFamily[] = [
+  {
+    name: "behavior-target",
+    match: (k) => k.startsWith("BEH-"),
+    resolve: (scope, knobKey) => resolveBehaviorTarget(scope, knobKey),
+  },
+  {
+    name: "welcome-message",
+    match: (k) => k === "welcomeMessage",
+    resolve: (scope) => resolveWelcomeMessage(scope),
+  },
+  {
+    name: "session-flow",
+    match: (k) =>
+      k === "onboarding" || k === "intake" || k === "stops" || k === "offboarding",
+    resolve: (scope, knobKey) => resolveSessionFlowKnob(scope, knobKey),
+  },
+  {
+    name: "voice-config",
+    match: (k) =>
+      k === "voiceProvider" ||
+      k === "voiceId" ||
+      k === "model" ||
+      k === "modelTemp" ||
+      k === "modelTopP" ||
+      k === "language",
+    resolve: (scope, knobKey) => resolveVoiceConfigKnob(scope, knobKey),
+  },
+  {
+    name: "identity-spec",
+    match: (k) => k === "identitySpecId",
+    resolve: (scope) => resolveIdentitySpec(scope),
+  },
+];
+
+function pickResolver(knobKey: string): AnyResolver {
+  for (const fam of FAMILIES) {
+    if (fam.match(knobKey)) return fam.resolve;
+  }
+  throw new Error(
+    `Unknown cascade knob key: "${knobKey}". Known families: ${FAMILIES.map(
+      (f) => f.name,
+    ).join(", ")}`,
+  );
+}
+
+// ── Cache ──────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+  value: Effective<unknown>;
+  expiresAt: number;
+}
+
+/** Module-level cache — per-page-load on the client, per-process on the
+ *  server. The 30s TTL matches `lib/compose/staleness.ts` so operators
+ *  who write a config see the new effective value immediately (via
+ *  invalidation) but in steady-state reads don't hit Prisma 20× per
+ *  panel render. */
+const cache = new Map<string, CacheEntry>();
+
+function cacheKey(knobKey: string, scope: ScopeChain): string {
+  // Stable JSON: object keys serialised in insertion order would be
+  // fragile, so pull the well-known scope ids in fixed order.
+  return [
+    knobKey,
+    scope.domainId ?? "",
+    scope.playbookId ?? "",
+    scope.segmentId ?? "",
+    scope.callerId ?? "",
+    scope.callId ?? "",
+  ].join("|");
+}
+
+function cacheGet(knobKey: string, scope: ScopeChain): Effective<unknown> | null {
+  const key = cacheKey(knobKey, scope);
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function cacheSet(
+  knobKey: string,
+  scope: ScopeChain,
+  value: Effective<unknown>,
+): void {
+  cache.set(cacheKey(knobKey, scope), {
+    value,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+}
+
+/**
+ * Drop every cache entry for the given `knobKey` (across all scope
+ * chains). Called from `setKnobAtLayer` (Slice 2) after a successful
+ * write so the next read returns the fresh winner.
+ */
+export function invalidateKnob(knobKey: string): void {
+  const prefix = `${knobKey}|`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}
+
+/**
+ * Drop the entire cache. Used by tests and on rare cataclysmic events
+ * (e.g., a system-setting blob rebuild) where every cached effective
+ * value may have changed.
+ */
+export function invalidateAll(): void {
+  cache.clear();
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve the effective value of a cascade-eligible knob for the given
+ * scope chain. Returns the winner + every contributing layer + provenance
+ * metadata. Caches for 30s; cache invalidates on `invalidateKnob`.
+ *
+ * @example
+ * const r = await resolveEffective<number>({
+ *   knobKey: "BEH-WARMTH",
+ *   scopeChain: { playbookId: "OCEAN-…", callerId: "smoke-test-…" },
+ * });
+ * // r.value === 0.6, r.source === "DOMAIN", r.layers === [{layer:"SYSTEM",...},{layer:"DOMAIN",...}]
+ */
+export async function resolveEffective<T>(
+  args: ResolveArgs,
+): Promise<Effective<T>> {
+  const cached = cacheGet(args.knobKey, args.scopeChain);
+  if (cached) return cached as Effective<T>;
+
+  const resolve = pickResolver(args.knobKey);
+  const result = (await resolve(args.scopeChain, args.knobKey)) as Effective<T>;
+  cacheSet(args.knobKey, args.scopeChain, result);
+  return result;
+}
+
+/** Pure helper exposed for the `<CascadeInspectorTray>` component when it
+ *  already has an `Effective<T>` envelope in hand and just needs the
+ *  "is this scope a winner?" check for CTA label flipping. */
+export function isLayerHit(envelope: Effective<unknown>, layer: Layer): boolean {
+  return envelope.layers.some((h) => h.layer === layer);
+}

--- a/apps/admin/lib/cascade/layer-types.ts
+++ b/apps/admin/lib/cascade/layer-types.ts
@@ -1,0 +1,92 @@
+/**
+ * Cascade-honesty display-layer types (Epic #1442 Layer 2 — see
+ * `docs/decisions/2026-06-10-cascade-honesty-ux.md`).
+ *
+ * **Display-layer type only.** For DB writes that need a Prisma enum,
+ * use `BehaviorTargetScope` from `@prisma/client` (values:
+ * `SYSTEM | PLAYBOOK | SEGMENT | CALLER`). The two vocabularies overlap
+ * but are structurally distinct — `Layer` is a 6-token UI string union
+ * used by `resolveEffective` / `<LayerBadge>` / `<CascadeInspectorTray>` /
+ * `<ScopePicker>` for chain provenance; `BehaviorTargetScope` is the
+ * Prisma-generated enum used at the DB write boundary.
+ */
+
+/**
+ * Ordered from outermost (least specific) to innermost (most specific).
+ * The cascade resolves the innermost set value as the winner.
+ *
+ * - `SYSTEM`  — global default (SystemSetting, INIT-001 spec defaults)
+ * - `DOMAIN`  — Domain-level override (e.g., Education vs Finance)
+ * - `PLAYBOOK` — course-level override (Playbook.config.* or
+ *   BehaviorTarget.scope=PLAYBOOK)
+ * - `SEGMENT` — cohort-level override (reserved; not wired in Sprint 1)
+ * - `CALLER`  — per-learner override (CallerIdentity-fanned BehaviorTarget
+ *   rows; Caller.config.*)
+ * - `CALL`    — per-call override (reserved; not wired in Sprint 1)
+ */
+export type Layer =
+  | "SYSTEM"
+  | "DOMAIN"
+  | "PLAYBOOK"
+  | "SEGMENT"
+  | "CALLER"
+  | "CALL";
+
+/**
+ * Canonical SYSTEM→CALL ordering. Exported for resolvers that need to sort
+ * raw layer hits before returning.
+ */
+export const LAYER_ORDER: readonly Layer[] = [
+  "SYSTEM",
+  "DOMAIN",
+  "PLAYBOOK",
+  "SEGMENT",
+  "CALLER",
+  "CALL",
+] as const;
+
+/**
+ * One layer's contribution to a cascade lookup. A resolver returns an
+ * array of these (only layers that have a value set) so the UI can render
+ * the full chain in the inspector tray, identify the winner, and surface
+ * provenance metadata.
+ *
+ * - `setAt`/`setBy` are best-effort. When the underlying DB row has no
+ *   authorship metadata (e.g., `Playbook.config` blob has no
+ *   `configUpdatedBy` column), resolvers MUST return `null` rather than
+ *   inventing a value from the current session.
+ */
+export interface LayerHit<T = unknown> {
+  layer: Layer;
+  /** Null for SYSTEM-level hits (no row id). */
+  scopeId: string | null;
+  /** Human label rendered in the inspector tray (e.g., "OCEAN (Big Five)",
+   *  "Education domain", "System default"). */
+  scopeLabel: string;
+  value: T;
+  /** Null when the underlying row has no `updatedAt` (or none reachable). */
+  setAt: Date | null;
+  /** Null when the underlying row has no `setBy` userId column. The tray
+   *  renders "Set by (unknown)" in that case. */
+  setBy: string | null;
+}
+
+/**
+ * Return shape of `resolveEffective` and every per-knob resolver. The UI
+ * reads `value` for display and `layers` for the chain inspector.
+ *
+ * - `source` is the winning `Layer` (always present in `layers`).
+ * - `isInherited` is true when `source` sits above the operator's current
+ *   editing scope — the badge renders as e.g. `[DOM]` on a Playbook page
+ *   to signal "inherited from above".
+ * - `recommendedLayerForEdit` is the scope-picker default — usually the
+ *   operator's current page scope (e.g., PLAYBOOK when viewing a course),
+ *   never a deeper scope unless the operator explicitly opts in.
+ */
+export interface Effective<T> {
+  value: T;
+  source: Layer;
+  layers: LayerHit<T>[];
+  isInherited: boolean;
+  recommendedLayerForEdit: Layer;
+}

--- a/apps/admin/lib/cascade/resolvers/behavior-target.ts
+++ b/apps/admin/lib/cascade/resolvers/behavior-target.ts
@@ -1,0 +1,166 @@
+/**
+ * Behavior-target cascade resolver (Epic #1442 Layer 2).
+ *
+ * Wraps `getEffectiveBehaviorTargetsForCaller` (the canonical cascade
+ * authority for `BEH-*` parameters — see `lib/tolerance/…`) to get the
+ * winner + per-layer values, then does targeted `updatedAt` reads for the
+ * layers that contributed a value so the inspector tray can render real
+ * `setAt` timestamps.
+ *
+ * Does NOT import `mergeTargets` from `lib/prompt/composition/transforms/
+ * quickstart.ts` — `mergeTargets` runs at COMPOSE stage and combines
+ * pre-resolved targets for the LLM context. It is NOT a cascade resolver,
+ * it is a composition step. Cascade resolution happens upstream at
+ * `getEffectiveBehaviorTargetsForCaller`.
+ *
+ * `setBy`: `BehaviorTarget` has no `setBy` userId column today — resolver
+ * returns `null` for every layer. Tray renders "Set by (unknown)".
+ * See TODO(cascade-provenance) below.
+ *
+ * SEGMENT layer: returns no hit in Sprint 1 (Sprint 2 wires it).
+ */
+
+// TODO(cascade-provenance): add `setBy String?` userId column to
+// `BehaviorTarget` to surface real authorship in the tray. Tracked as a
+// follow-up under Epic #1442. Migration plus tray copy update would land
+// in the same story.
+
+import { prisma } from "@/lib/prisma";
+import { getEffectiveBehaviorTargetsForCaller } from "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller";
+import { resolveCallerIdentityIds } from "@/lib/agent-tuner/write-target";
+
+import type { Effective, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+export async function resolveBehaviorTarget(
+  scope: ScopeChain,
+  knobKey: string,
+): Promise<Effective<number | null>> {
+  if (!scope.playbookId) {
+    throw new Error(
+      `resolveBehaviorTarget requires \`playbookId\` in scopeChain (got: ${JSON.stringify(
+        scope,
+      )})`,
+    );
+  }
+
+  // 1. Run the canonical cascade for the (playbook, caller) pair. This
+  //    returns one entry per parameter — find the one matching knobKey.
+  const all = await getEffectiveBehaviorTargetsForCaller(
+    scope.playbookId,
+    scope.callerId ?? "",
+  );
+  const row = all.find((e) => e.parameterId === knobKey);
+
+  // 2. If the cascade has no entry for this parameter at all, return an
+  //    "all-default" envelope. The compose path also defaults to 0.5; we
+  //    surface that explicitly so the badge renders `[—]` with the right
+  //    fallback value visible.
+  if (!row) {
+    return {
+      value: null,
+      source: "SYSTEM",
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
+
+  // 3. Get the row-level `updatedAt` for each layer that has a value, so
+  //    the inspector can show "Set on 2026-05-22". Three small queries —
+  //    cached for 30s by `resolveEffective`.
+  const layers: LayerHit<number | null>[] = [];
+
+  if (row.systemValue !== null) {
+    const sys = await prisma.behaviorTarget.findFirst({
+      where: { scope: "SYSTEM", parameterId: knobKey, effectiveUntil: null },
+      select: { updatedAt: true },
+      orderBy: { updatedAt: "desc" },
+    });
+    layers.push({
+      layer: "SYSTEM",
+      scopeId: null,
+      scopeLabel: "System default",
+      value: row.systemValue,
+      setAt: sys?.updatedAt ?? null,
+      setBy: null, // TODO(cascade-provenance)
+    });
+  }
+
+  if (row.playbookValue !== null) {
+    const [pb, pbRow] = await Promise.all([
+      prisma.playbook.findUnique({
+        where: { id: scope.playbookId },
+        select: { name: true },
+      }),
+      prisma.behaviorTarget.findFirst({
+        where: {
+          scope: "PLAYBOOK",
+          playbookId: scope.playbookId,
+          parameterId: knobKey,
+          effectiveUntil: null,
+        },
+        select: { updatedAt: true },
+        orderBy: { updatedAt: "desc" },
+      }),
+    ]);
+    layers.push({
+      layer: "PLAYBOOK",
+      scopeId: scope.playbookId,
+      scopeLabel: pb?.name ?? "this Playbook",
+      value: row.playbookValue,
+      setAt: pbRow?.updatedAt ?? null,
+      setBy: null, // TODO(cascade-provenance)
+    });
+  }
+
+  if (row.callerValue !== null && scope.callerId) {
+    // Fan out to the caller's identity rows so we pick the same
+    // `updatedAt` as the row that contributed `callerValue` (the cascade
+    // takes MAX across identities — same tie-break).
+    const ids = await resolveCallerIdentityIds(scope.callerId);
+    const identityIds = ids.ok ? ids.identityIds : [];
+    const callerRow = identityIds.length
+      ? await prisma.behaviorTarget.findFirst({
+          where: {
+            scope: "CALLER",
+            callerIdentityId: { in: identityIds },
+            parameterId: knobKey,
+            effectiveUntil: null,
+            targetValue: row.callerValue,
+          },
+          select: { updatedAt: true },
+          orderBy: { updatedAt: "desc" },
+        })
+      : null;
+
+    const callerLabel = await prisma.caller.findUnique({
+      where: { id: scope.callerId },
+      select: { name: true },
+    });
+
+    layers.push({
+      layer: "CALLER",
+      scopeId: scope.callerId,
+      scopeLabel: callerLabel?.name ?? "this caller",
+      value: row.callerValue,
+      setAt: callerRow?.updatedAt ?? null,
+      setBy: null, // TODO(cascade-provenance)
+    });
+  }
+
+  const sourceLayer =
+    row.sourceScope === "CALLER"
+      ? "CALLER"
+      : row.sourceScope === "PLAYBOOK"
+        ? "PLAYBOOK"
+        : "SYSTEM";
+
+  return {
+    value: row.effectiveValue,
+    source: sourceLayer,
+    layers,
+    isInherited: sourceLayer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/lib/cascade/resolvers/identity-spec.ts
+++ b/apps/admin/lib/cascade/resolvers/identity-spec.ts
@@ -87,13 +87,16 @@ export async function resolveIdentitySpec(
         })
       : null;
 
+  // SYSTEM→CALL order per `LAYER_ORDER` in `layer-types.ts`. The
+  // inspector tray iterates this array top-to-bottom; the deepest
+  // (innermost) layer with a non-null value wins the cascade.
   const layers: LayerHit<string | null>[] = [
     {
-      layer: "PLAYBOOK",
-      scopeId: playbook.id,
-      scopeLabel: playbook.name,
-      value: null, // TODO(playbook-identity-cascade): walk PlaybookItem IDENTITY rows
-      setAt: null,
+      layer: "SYSTEM",
+      scopeId: null,
+      scopeLabel: "System default",
+      value: defaultSpec?.id ?? defaultSlug ?? null,
+      setAt: defaultSpec?.updatedAt ?? null,
       setBy: null, // TODO(cascade-provenance)
     },
     {
@@ -105,11 +108,11 @@ export async function resolveIdentitySpec(
       setBy: null, // TODO(cascade-provenance)
     },
     {
-      layer: "SYSTEM",
-      scopeId: null,
-      scopeLabel: "System default",
-      value: defaultSpec?.id ?? defaultSlug ?? null,
-      setAt: defaultSpec?.updatedAt ?? null,
+      layer: "PLAYBOOK",
+      scopeId: playbook.id,
+      scopeLabel: playbook.name,
+      value: null, // TODO(playbook-identity-cascade): walk PlaybookItem IDENTITY rows
+      setAt: null,
       setBy: null, // TODO(cascade-provenance)
     },
   ];

--- a/apps/admin/lib/cascade/resolvers/identity-spec.ts
+++ b/apps/admin/lib/cascade/resolvers/identity-spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Identity-spec cascade resolver (Epic #1442 Layer 2).
+ *
+ * Does NOT call `transforms/identity.ts::resolveSpecs` — that function
+ * walks `PlaybookItem` rows + system specs and returns WINNER ONLY; it
+ * has no concept of `LayerHit[]`. This resolver reconstructs the chain
+ * from raw DB rows so the inspector tray can render every applicable
+ * layer (Playbook / Domain / System default) with its own value.
+ *
+ * Sprint 1 scope: returns `LayerHit` entries for **PLAYBOOK / DOMAIN /
+ * SYSTEM**. The PLAYBOOK hit's value is currently `null` (no
+ * Playbook-level identity-spec column today — overrides live in
+ * `PlaybookItem` rows with `IDENTITY` SpecRole, and walking those is
+ * deferred until the first UI consumer needs it). The hit is still
+ * returned so the inspector tray can render "PLAYBOOK — not set" rather
+ * than implying the cascade doesn't reach Playbook at all.
+ *
+ * `setAt`: returned from `AnalysisSpec.updatedAt` when the resolved spec
+ * id maps to a real row. `null` for the PLAYBOOK hit (no row to read)
+ * and for the SYSTEM hit when the default archetype slug doesn't resolve
+ * to a row.
+ *
+ * `setBy`: `null` everywhere — no spec-ownership audit column exists.
+ */
+
+// TODO(cascade-provenance): no per-spec authorship metadata. The
+// `AnalysisSpec` table has a generic `updatedAt`; surfacing `setBy`
+// would require a new column. Tracked as a follow-up.
+//
+// TODO(playbook-identity-cascade): the PLAYBOOK layer should walk
+// `PlaybookItem` rows for an `IDENTITY` SpecRole row before returning
+// `null`. Deferred to follow-up; current behaviour matches the story
+// AC ("Playbook with no identity override has PLAYBOOK hit with
+// value: null"). Tracked under Epic #1442 Sprint 2 candidates.
+
+import { prisma } from "@/lib/prisma";
+import { config } from "@/lib/config";
+
+import type { Effective, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+export async function resolveIdentitySpec(
+  scope: ScopeChain,
+): Promise<Effective<string | null>> {
+  if (!scope.playbookId) {
+    throw new Error(
+      `resolveIdentitySpec requires \`playbookId\` in scopeChain (got: ${JSON.stringify(
+        scope,
+      )})`,
+    );
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: scope.playbookId },
+    select: { id: true, name: true, domainId: true },
+  });
+  if (!playbook) {
+    throw new Error(`Playbook not found: ${scope.playbookId}`);
+  }
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: playbook.domainId },
+    select: {
+      id: true,
+      name: true,
+      onboardingIdentitySpecId: true,
+    },
+  });
+
+  // SYSTEM default — config-driven (env-overridable). Resolve the slug
+  // to an actual spec id when one exists; otherwise the SYSTEM hit
+  // carries the slug as its value (better than null — the tray can
+  // show what the slug WOULD have resolved to).
+  const defaultSlug = config.specs.defaultArchetype;
+  const defaultSpec = defaultSlug
+    ? await prisma.analysisSpec.findFirst({
+        where: { slug: defaultSlug },
+        select: { id: true, updatedAt: true },
+      })
+    : null;
+
+  const domainSpec =
+    domain?.onboardingIdentitySpecId
+      ? await prisma.analysisSpec.findUnique({
+          where: { id: domain.onboardingIdentitySpecId },
+          select: { id: true, updatedAt: true },
+        })
+      : null;
+
+  const layers: LayerHit<string | null>[] = [
+    {
+      layer: "PLAYBOOK",
+      scopeId: playbook.id,
+      scopeLabel: playbook.name,
+      value: null, // TODO(playbook-identity-cascade): walk PlaybookItem IDENTITY rows
+      setAt: null,
+      setBy: null, // TODO(cascade-provenance)
+    },
+    {
+      layer: "DOMAIN",
+      scopeId: domain?.id ?? null,
+      scopeLabel: domain?.name ?? "Domain",
+      value: domain?.onboardingIdentitySpecId ?? null,
+      setAt: domainSpec?.updatedAt ?? null,
+      setBy: null, // TODO(cascade-provenance)
+    },
+    {
+      layer: "SYSTEM",
+      scopeId: null,
+      scopeLabel: "System default",
+      value: defaultSpec?.id ?? defaultSlug ?? null,
+      setAt: defaultSpec?.updatedAt ?? null,
+      setBy: null, // TODO(cascade-provenance)
+    },
+  ];
+
+  // Cascade pick — deepest non-null wins.
+  const winner =
+    layers.find((h) => h.layer === "PLAYBOOK" && h.value !== null) ??
+    layers.find((h) => h.layer === "DOMAIN" && h.value !== null) ??
+    layers.find((h) => h.layer === "SYSTEM" && h.value !== null);
+
+  if (!winner) {
+    return {
+      value: null,
+      source: "SYSTEM",
+      layers,
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
+
+  return {
+    value: winner.value,
+    source: winner.layer,
+    layers,
+    isInherited: winner.layer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/lib/cascade/resolvers/session-flow.ts
+++ b/apps/admin/lib/cascade/resolvers/session-flow.ts
@@ -1,0 +1,169 @@
+/**
+ * Session-flow cascade resolver (Epic #1442 Layer 2).
+ *
+ * Wraps `resolveSessionFlow` (`lib/session-flow/resolver.ts`) and maps
+ * its per-section `source` string onto the 6-layer `Layer` taxonomy.
+ *
+ * Handles four knob keys: `onboarding | intake | stops | offboarding`.
+ * `welcomeMessage` has its own resolver (sibling file) because its
+ * source-string vocabulary is independent (`playbook | domain | generic`)
+ * and the inspector tray wants the welcome-message-specific multi-layer
+ * chain that this resolver doesn't compute.
+ *
+ * Sprint 1 returns a single `LayerHit` for the winning layer only —
+ * the underlying `resolveSessionFlow` does not expose the per-section
+ * values from non-winning layers. Sprint 2 would expand this to walk
+ * each raw layer independently for the full chain if needed; for now
+ * the badge + winner-layer hit are sufficient for the #1418 fix and
+ * the inspector tray gracefully degrades on the missing layers.
+ *
+ * `setAt` / `setBy`: `null` for every layer. `resolveSessionFlow` does
+ * not return timestamps and `Playbook.updatedAt` is too coarse — it
+ * advances on every Playbook edit. See TODO(cascade-provenance).
+ */
+
+// TODO(cascade-provenance): see welcome-message.ts — no per-key authorship
+// for session-flow knobs. Multi-layer chain expansion deferred to Sprint 2.
+
+import { prisma } from "@/lib/prisma";
+import {
+  resolveSessionFlow,
+  type ResolveSessionFlowInput,
+} from "@/lib/session-flow/resolver";
+import type { PlaybookConfig, SessionFlowResolved } from "@/lib/types/json-fields";
+
+import type { Effective, Layer, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+type SessionFlowKnob = "onboarding" | "intake" | "stops" | "offboarding";
+
+type AnySource =
+  | SessionFlowResolved["source"]["intake"]
+  | SessionFlowResolved["source"]["onboarding"]
+  | SessionFlowResolved["source"]["stops"]
+  | SessionFlowResolved["source"]["offboarding"];
+
+/**
+ * Source-string → `Layer` table. Explicit; no fallthrough. Exported for
+ * test coverage of every distinct source string `resolveSessionFlow` can
+ * emit (7 strings as of 2026-06-10).
+ */
+export function mapSessionFlowSource(source: AnySource): Layer {
+  switch (source) {
+    case "domain":
+      return "DOMAIN";
+    case "new-shape":
+    case "playbook-legacy":
+    case "legacy-welcome":
+    case "synthesized-from-legacy":
+      return "PLAYBOOK";
+    case "init001":
+    case "defaults":
+      return "SYSTEM";
+  }
+}
+
+function isKnown(knobKey: string): knobKey is SessionFlowKnob {
+  return (
+    knobKey === "onboarding" ||
+    knobKey === "intake" ||
+    knobKey === "stops" ||
+    knobKey === "offboarding"
+  );
+}
+
+export async function resolveSessionFlowKnob(
+  scope: ScopeChain,
+  knobKey: string,
+): Promise<Effective<unknown>> {
+  if (!isKnown(knobKey)) {
+    throw new Error(
+      `resolveSessionFlowKnob does not handle "${knobKey}". Use a different family resolver.`,
+    );
+  }
+  if (!scope.playbookId) {
+    throw new Error(
+      `resolveSessionFlowKnob requires \`playbookId\` in scopeChain (got: ${JSON.stringify(
+        scope,
+      )})`,
+    );
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: scope.playbookId },
+    select: {
+      id: true,
+      name: true,
+      config: true,
+      domainId: true,
+    },
+  });
+  if (!playbook) {
+    throw new Error(`Playbook not found: ${scope.playbookId}`);
+  }
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: playbook.domainId },
+    select: {
+      id: true,
+      name: true,
+      onboardingWelcome: true,
+      onboardingFlowPhases: true,
+    },
+  });
+
+  const input: ResolveSessionFlowInput = {
+    playbook: {
+      name: playbook.name,
+      config: (playbook.config ?? {}) as PlaybookConfig,
+    },
+    domain: domain
+      ? ({
+          name: domain.name,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          onboardingFlowPhases: domain.onboardingFlowPhases as any,
+          onboardingWelcome: domain.onboardingWelcome,
+        } as ResolveSessionFlowInput["domain"])
+      : null,
+    onboardingSpec: null,
+  };
+
+  const flow = resolveSessionFlow(input);
+
+  const value = flow[knobKey];
+  const sourceStr = flow.source[knobKey];
+  const winnerLayer = mapSessionFlowSource(sourceStr);
+
+  const winnerLabel =
+    winnerLayer === "DOMAIN"
+      ? (domain?.name ?? "Domain")
+      : winnerLayer === "PLAYBOOK"
+        ? playbook.name
+        : "System default";
+
+  const winnerScopeId =
+    winnerLayer === "DOMAIN"
+      ? (domain?.id ?? null)
+      : winnerLayer === "PLAYBOOK"
+        ? playbook.id
+        : null;
+
+  const layers: LayerHit<unknown>[] = [
+    {
+      layer: winnerLayer,
+      scopeId: winnerScopeId,
+      scopeLabel: winnerLabel,
+      value,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    },
+  ];
+
+  return {
+    value,
+    source: winnerLayer,
+    layers,
+    isInherited: winnerLayer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/lib/cascade/resolvers/voice-config.ts
+++ b/apps/admin/lib/cascade/resolvers/voice-config.ts
@@ -1,0 +1,114 @@
+/**
+ * Voice-config cascade resolver (Epic #1442 Layer 2).
+ *
+ * Thin adapter over the existing `explainVoiceCascade` in
+ * `lib/cascade/voice-explain.ts` (shipped with #1348). We do NOT
+ * re-implement the layer reads — two read paths reconstructing the same
+ * chain would drift on the next voice schema change. This file maps the
+ * voice-cascade's 4-tier chain (`system | provider | domain | course`)
+ * into the 6-layer `LayerHit<T>` shape used by `<LayerBadge>` and
+ * `<CascadeInspectorTray>`.
+ *
+ * Mapping:
+ *   - `system`   → `Layer.SYSTEM`   (scopeLabel: "System default")
+ *   - `provider` → `Layer.SYSTEM`   (scopeLabel: "Voice provider config")
+ *   - `domain`   → `Layer.DOMAIN`
+ *   - `course`   → `Layer.PLAYBOOK`
+ *
+ * Two `SYSTEM` rows is intentional — the provider config is a global
+ * singleton (VoiceProvider row) and the cascade-honesty taxonomy doesn't
+ * have a "PROVIDER" tier. The `scopeLabel` carries the distinction for
+ * the UI. (If a future epic needs to split these, we add `PROVIDER` to
+ * the `Layer` union and adjust here — but Sprint 1 does not.)
+ *
+ * `setAt` / `setBy`: returned `null`. `VoiceProvider.config`,
+ * `Playbook.config.voice`, and `Domain.config.voice` are all JSON blobs
+ * with no per-key authorship metadata. See TODO(cascade-provenance) in
+ * `welcome-message.ts` for the schema gap.
+ */
+
+// TODO(cascade-provenance): see welcome-message.ts — same blob authorship gap.
+
+import { explainVoiceCascade } from "../voice-explain";
+import type { Effective, Layer, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+/**
+ * Map the voice-cascade's 4-tier source label onto the 6-layer cascade
+ * vocabulary. Exported for tests.
+ */
+export function mapVoiceLayer(
+  voiceLayer: "system" | "provider" | "domain" | "course",
+): Layer {
+  switch (voiceLayer) {
+    case "system":
+    case "provider":
+      return "SYSTEM";
+    case "domain":
+      return "DOMAIN";
+    case "course":
+      return "PLAYBOOK";
+  }
+}
+
+function voiceLayerLabel(
+  voiceLayer: "system" | "provider" | "domain" | "course",
+): string {
+  switch (voiceLayer) {
+    case "system":
+      return "System default";
+    case "provider":
+      return "Voice provider config";
+    case "domain":
+      return "Domain";
+    case "course":
+      return "Playbook";
+  }
+}
+
+export async function resolveVoiceConfigKnob(
+  scope: ScopeChain,
+  knobKey: string,
+): Promise<Effective<unknown>> {
+  if (!scope.callerId) {
+    throw new Error(
+      `resolveVoiceConfigKnob requires \`callerId\` in scopeChain — the voice cascade is caller-rooted (resolves the active CallerPlaybook's voice config). Got: ${JSON.stringify(
+        scope,
+      )}`,
+    );
+  }
+
+  const explanation = await explainVoiceCascade(scope.callerId);
+  const field = explanation.fields.find((f) => f.key === knobKey);
+
+  if (!field) {
+    throw new Error(
+      `Unknown voice-config knob key: "${knobKey}". Known keys: ${explanation.fields
+        .map((f) => f.key)
+        .join(", ")}`,
+    );
+  }
+
+  const layers: LayerHit<unknown>[] = [];
+  for (const entry of field.chain) {
+    if (!entry.present) continue;
+    layers.push({
+      layer: mapVoiceLayer(entry.layer),
+      scopeId: null, // voice-explain does not expose per-layer ids
+      scopeLabel: voiceLayerLabel(entry.layer),
+      value: entry.value,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
+
+  const sourceLayer = mapVoiceLayer(field.winningSource);
+
+  return {
+    value: field.resolvedValue,
+    source: sourceLayer,
+    layers,
+    isInherited: sourceLayer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/lib/cascade/resolvers/welcome-message.ts
+++ b/apps/admin/lib/cascade/resolvers/welcome-message.ts
@@ -59,7 +59,21 @@ export async function resolveWelcomeMessage(
     select: { id: true, name: true, onboardingWelcome: true },
   });
 
+  // Build `layers` in SYSTEM→CALL order (per `LAYER_ORDER` in
+  // `layer-types.ts`) — DOMAIN before PLAYBOOK — so the inspector tray
+  // can iterate top-to-bottom without re-sorting.
   const layers: LayerHit<string | null>[] = [];
+
+  if (domain?.onboardingWelcome) {
+    layers.push({
+      layer: "DOMAIN",
+      scopeId: domain.id,
+      scopeLabel: domain.name,
+      value: domain.onboardingWelcome,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
 
   const pbConfig = (playbook.config ?? {}) as { welcomeMessage?: string | null };
   const pbMsg = pbConfig.welcomeMessage ?? null;
@@ -74,18 +88,8 @@ export async function resolveWelcomeMessage(
     });
   }
 
-  if (domain?.onboardingWelcome) {
-    layers.push({
-      layer: "DOMAIN",
-      scopeId: domain.id,
-      scopeLabel: domain.name,
-      value: domain.onboardingWelcome,
-      setAt: null, // TODO(cascade-provenance)
-      setBy: null,
-    });
-  }
-
-  const winner = layers[0] ?? null;
+  // Deepest (innermost) layer wins — the last entry in SYSTEM→CALL order.
+  const winner = layers.length > 0 ? layers[layers.length - 1] : null;
 
   if (!winner) {
     return {

--- a/apps/admin/lib/cascade/resolvers/welcome-message.ts
+++ b/apps/admin/lib/cascade/resolvers/welcome-message.ts
@@ -1,0 +1,107 @@
+/**
+ * Welcome-message cascade resolver (Epic #1442 Layer 2).
+ *
+ * Reads the same two layers `resolveWelcomeMessage` in
+ * `lib/session-flow/resolver.ts` reads (Playbook config.welcomeMessage,
+ * then Domain.onboardingWelcome) but returns BOTH layer hits when present
+ * — not just the winner — so the inspector can render the full chain.
+ *
+ * `resolveWelcomeMessage` in resolver.ts is module-private (not exported),
+ * so this file walks the two underlying rows directly. Behaviour matches
+ * the resolver exactly: pb wins over domain, generic null when neither.
+ *
+ * `setAt` / `setBy`: returned `null` for both layers.
+ *   - `Playbook.config` is a JSON blob with no per-key authorship metadata.
+ *   - `Domain.onboardingWelcome` is a column but the surrounding Domain
+ *     row's `updatedAt` is too coarse — it advances on any Domain edit.
+ *   See TODO(cascade-provenance) below.
+ */
+
+// TODO(cascade-provenance): There is no per-key authorship metadata for
+// `Playbook.config.welcomeMessage` or `Domain.onboardingWelcome`. Adding
+// `configUpdatedBy` / `configUpdatedAt` columns to Playbook + Domain
+// would let us surface real "Set by Paul on 2026-05-22" provenance. Track
+// as a separate story before the inspector tray ships; until then the
+// tray renders "Set by (unknown)" for these knobs.
+
+import { prisma } from "@/lib/prisma";
+
+import type { Effective, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+export async function resolveWelcomeMessage(
+  scope: ScopeChain,
+): Promise<Effective<string | null>> {
+  if (!scope.playbookId) {
+    throw new Error(
+      `resolveWelcomeMessage requires \`playbookId\` in scopeChain (got: ${JSON.stringify(
+        scope,
+      )})`,
+    );
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: scope.playbookId },
+    select: {
+      id: true,
+      name: true,
+      config: true,
+      domainId: true,
+    },
+  });
+
+  if (!playbook) {
+    throw new Error(`Playbook not found: ${scope.playbookId}`);
+  }
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: playbook.domainId },
+    select: { id: true, name: true, onboardingWelcome: true },
+  });
+
+  const layers: LayerHit<string | null>[] = [];
+
+  const pbConfig = (playbook.config ?? {}) as { welcomeMessage?: string | null };
+  const pbMsg = pbConfig.welcomeMessage ?? null;
+  if (pbMsg) {
+    layers.push({
+      layer: "PLAYBOOK",
+      scopeId: playbook.id,
+      scopeLabel: playbook.name,
+      value: pbMsg,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
+
+  if (domain?.onboardingWelcome) {
+    layers.push({
+      layer: "DOMAIN",
+      scopeId: domain.id,
+      scopeLabel: domain.name,
+      value: domain.onboardingWelcome,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
+
+  const winner = layers[0] ?? null;
+
+  if (!winner) {
+    return {
+      value: null,
+      source: "SYSTEM",
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
+
+  return {
+    value: winner.value,
+    source: winner.layer,
+    layers,
+    isInherited: winner.layer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/tests/lib/cascade/effective-value.test.ts
+++ b/apps/admin/tests/lib/cascade/effective-value.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the cascade primitive resolveEffective + cache helpers.
+ * (Epic #1442 Layer 2 / story #1454.)
+ *
+ * Covers:
+ *   - dispatch by knob key family (BEH-*, welcomeMessage, session-flow,
+ *     voice-config, identity-spec)
+ *   - unknown knob key throws with helpful message
+ *   - cache hit within 30s (resolver fn called once)
+ *   - invalidateKnob clears entries for that key
+ *   - invalidateAll wipes everything
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const resolveBehaviorTarget = vi.fn();
+const resolveSessionFlowKnob = vi.fn();
+const resolveWelcomeMessage = vi.fn();
+const resolveVoiceConfigKnob = vi.fn();
+const resolveIdentitySpec = vi.fn();
+
+vi.mock("@/lib/cascade/resolvers/behavior-target", () => ({
+  resolveBehaviorTarget,
+}));
+vi.mock("@/lib/cascade/resolvers/session-flow", () => ({
+  resolveSessionFlowKnob,
+}));
+vi.mock("@/lib/cascade/resolvers/welcome-message", () => ({
+  resolveWelcomeMessage,
+}));
+vi.mock("@/lib/cascade/resolvers/voice-config", () => ({
+  resolveVoiceConfigKnob,
+}));
+vi.mock("@/lib/cascade/resolvers/identity-spec", () => ({
+  resolveIdentitySpec,
+}));
+
+const FAKE_ENVELOPE = {
+  value: 0.6,
+  source: "DOMAIN" as const,
+  layers: [],
+  isInherited: true,
+  recommendedLayerForEdit: "PLAYBOOK" as const,
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const { invalidateAll } = await import("@/lib/cascade/effective-value");
+  invalidateAll();
+  resolveBehaviorTarget.mockResolvedValue(FAKE_ENVELOPE);
+  resolveSessionFlowKnob.mockResolvedValue(FAKE_ENVELOPE);
+  resolveWelcomeMessage.mockResolvedValue(FAKE_ENVELOPE);
+  resolveVoiceConfigKnob.mockResolvedValue(FAKE_ENVELOPE);
+  resolveIdentitySpec.mockResolvedValue(FAKE_ENVELOPE);
+});
+
+describe("resolveEffective dispatch", () => {
+  it("routes BEH-* to behavior-target resolver", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    await resolveEffective({
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb1" },
+    });
+    expect(resolveBehaviorTarget).toHaveBeenCalledOnce();
+    expect(resolveSessionFlowKnob).not.toHaveBeenCalled();
+  });
+
+  it("routes welcomeMessage to welcome-message resolver", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    await resolveEffective({
+      knobKey: "welcomeMessage",
+      scopeChain: { playbookId: "pb1" },
+    });
+    expect(resolveWelcomeMessage).toHaveBeenCalledOnce();
+  });
+
+  it("routes session-flow sub-keys to session-flow resolver", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    for (const k of ["onboarding", "intake", "stops", "offboarding"]) {
+      await resolveEffective({
+        knobKey: k,
+        scopeChain: { playbookId: "pb1" },
+      });
+    }
+    expect(resolveSessionFlowKnob).toHaveBeenCalledTimes(4);
+  });
+
+  it("routes voice keys to voice-config resolver", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    for (const k of ["voiceProvider", "voiceId", "model", "modelTemp"]) {
+      await resolveEffective({
+        knobKey: k,
+        scopeChain: { callerId: "c1" },
+      });
+    }
+    expect(resolveVoiceConfigKnob).toHaveBeenCalledTimes(4);
+  });
+
+  it("routes identitySpecId to identity-spec resolver", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    await resolveEffective({
+      knobKey: "identitySpecId",
+      scopeChain: { playbookId: "pb1" },
+    });
+    expect(resolveIdentitySpec).toHaveBeenCalledOnce();
+  });
+
+  it("throws on unknown knob key", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    await expect(
+      resolveEffective({
+        knobKey: "totally-made-up",
+        scopeChain: { playbookId: "pb1" },
+      }),
+    ).rejects.toThrow(/Unknown cascade knob key/);
+  });
+});
+
+describe("resolveEffective cache", () => {
+  it("returns cached value on second call within 30s (resolver fn called once)", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    const args = {
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb1", callerId: "c1" },
+    };
+    await resolveEffective(args);
+    await resolveEffective(args);
+    expect(resolveBehaviorTarget).toHaveBeenCalledOnce();
+  });
+
+  it("treats different scopeChains as separate cache keys", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    await resolveEffective({
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb1" },
+    });
+    await resolveEffective({
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb2" },
+    });
+    expect(resolveBehaviorTarget).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidateKnob clears entries for that knob only", async () => {
+    const { resolveEffective, invalidateKnob } = await import(
+      "@/lib/cascade/effective-value"
+    );
+    await resolveEffective({
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb1" },
+    });
+    await resolveEffective({
+      knobKey: "BEH-CONCISION",
+      scopeChain: { playbookId: "pb1" },
+    });
+    invalidateKnob("BEH-WARMTH");
+    await resolveEffective({
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb1" },
+    });
+    // BEH-WARMTH: 2 calls (cached, invalidated, re-fetched).
+    // BEH-CONCISION: 1 call (cached, still fresh).
+    expect(resolveBehaviorTarget).toHaveBeenCalledTimes(3);
+  });
+
+  it("invalidateAll wipes every cache entry", async () => {
+    const { resolveEffective, invalidateAll } = await import(
+      "@/lib/cascade/effective-value"
+    );
+    await resolveEffective({
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb1" },
+    });
+    invalidateAll();
+    await resolveEffective({
+      knobKey: "BEH-WARMTH",
+      scopeChain: { playbookId: "pb1" },
+    });
+    expect(resolveBehaviorTarget).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("isLayerHit", () => {
+  it("returns true when a layer appears in the envelope", async () => {
+    const { isLayerHit } = await import("@/lib/cascade/effective-value");
+    const envelope = {
+      ...FAKE_ENVELOPE,
+      layers: [
+        {
+          layer: "PLAYBOOK" as const,
+          scopeId: "pb1",
+          scopeLabel: "OCEAN",
+          value: 0.6,
+          setAt: null,
+          setBy: null,
+        },
+      ],
+    };
+    expect(isLayerHit(envelope, "PLAYBOOK")).toBe(true);
+    expect(isLayerHit(envelope, "DOMAIN")).toBe(false);
+  });
+});

--- a/apps/admin/tests/lib/cascade/resolvers/behavior-target.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/behavior-target.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for behavior-target resolver.
+ * (Epic #1442 Layer 2 / story #1454.)
+ *
+ * Covers:
+ *   - calls getEffectiveBehaviorTargetsForCaller (not mergeTargets)
+ *   - returns LayerHit[] populated for SYSTEM / PLAYBOOK / CALLER when
+ *     each has a value
+ *   - setAt populated from BehaviorTarget.updatedAt; setBy null
+ *   - all-default (no row) returns empty layers
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const prismaMock = {
+  behaviorTarget: { findFirst: vi.fn() },
+  playbook: { findUnique: vi.fn() },
+  caller: { findUnique: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const getEffectiveBehaviorTargetsForCaller = vi.fn();
+vi.mock("@/lib/tolerance/getEffectiveBehaviorTargetsForCaller", () => ({
+  getEffectiveBehaviorTargetsForCaller,
+}));
+
+const resolveCallerIdentityIds = vi.fn();
+vi.mock("@/lib/agent-tuner/write-target", () => ({
+  resolveCallerIdentityIds,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveBehaviorTarget — wraps the bulk cascade helper", () => {
+  it("does NOT import mergeTargets (which is a COMPOSE-stage helper)", () => {
+    const filePath = join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "..",
+      "lib",
+      "cascade",
+      "resolvers",
+      "behavior-target.ts",
+    );
+    const src = readFileSync(filePath, "utf-8");
+    // Strip line + block comments so the assertions only see code.
+    const code = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:\/])\/\/.*$/gm, "$1");
+    expect(code).not.toMatch(/\bmergeTargets\b/);
+    expect(code).not.toMatch(/transforms\/quickstart/);
+  });
+
+  it("returns three LayerHits when SYSTEM + PLAYBOOK + CALLER all have values", async () => {
+    getEffectiveBehaviorTargetsForCaller.mockResolvedValueOnce([
+      {
+        parameterId: "BEH-WARMTH",
+        effectiveValue: 0.8,
+        sourceScope: "CALLER",
+        systemValue: 0.5,
+        playbookValue: 0.6,
+        callerValue: 0.8,
+      },
+    ]);
+    prismaMock.behaviorTarget.findFirst.mockResolvedValue({
+      updatedAt: new Date("2026-05-01T00:00:00Z"),
+    });
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({ name: "OCEAN" });
+    prismaMock.caller.findUnique.mockResolvedValueOnce({ name: "Smoke Test" });
+    resolveCallerIdentityIds.mockResolvedValueOnce({
+      ok: true,
+      identityIds: ["id1"],
+    });
+
+    const { resolveBehaviorTarget } = await import(
+      "@/lib/cascade/resolvers/behavior-target"
+    );
+    const r = await resolveBehaviorTarget(
+      { playbookId: "pb1", callerId: "c1" },
+      "BEH-WARMTH",
+    );
+
+    expect(r.value).toBe(0.8);
+    expect(r.source).toBe("CALLER");
+    expect(r.layers.map((h) => h.layer)).toEqual([
+      "SYSTEM",
+      "PLAYBOOK",
+      "CALLER",
+    ]);
+  });
+
+  it("returns empty layers when bulk helper has no entry for this knob", async () => {
+    getEffectiveBehaviorTargetsForCaller.mockResolvedValueOnce([]);
+
+    const { resolveBehaviorTarget } = await import(
+      "@/lib/cascade/resolvers/behavior-target"
+    );
+    const r = await resolveBehaviorTarget(
+      { playbookId: "pb1" },
+      "BEH-WARMTH",
+    );
+
+    expect(r.value).toBeNull();
+    expect(r.layers).toEqual([]);
+    expect(r.source).toBe("SYSTEM");
+  });
+
+  it("setAt populated from BehaviorTarget.updatedAt; setBy null", async () => {
+    const setAt = new Date("2026-05-22T00:00:00Z");
+    getEffectiveBehaviorTargetsForCaller.mockResolvedValueOnce([
+      {
+        parameterId: "BEH-WARMTH",
+        effectiveValue: 0.6,
+        sourceScope: "PLAYBOOK",
+        systemValue: null,
+        playbookValue: 0.6,
+        callerValue: null,
+      },
+    ]);
+    prismaMock.behaviorTarget.findFirst.mockResolvedValueOnce({
+      updatedAt: setAt,
+    });
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({ name: "OCEAN" });
+
+    const { resolveBehaviorTarget } = await import(
+      "@/lib/cascade/resolvers/behavior-target"
+    );
+    const r = await resolveBehaviorTarget({ playbookId: "pb1" }, "BEH-WARMTH");
+
+    expect(r.layers[0].setAt).toEqual(setAt);
+    expect(r.layers[0].setBy).toBeNull();
+  });
+
+  it("throws when playbookId missing", async () => {
+    const { resolveBehaviorTarget } = await import(
+      "@/lib/cascade/resolvers/behavior-target"
+    );
+    await expect(
+      resolveBehaviorTarget({}, "BEH-WARMTH"),
+    ).rejects.toThrow(/playbookId/);
+  });
+});

--- a/apps/admin/tests/lib/cascade/resolvers/identity-spec.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/identity-spec.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for identity-spec resolver.
+ * (Epic #1442 Layer 2 / story #1454.)
+ *
+ * Covers:
+ *   - does NOT call transforms/identity.ts::resolveSpecs
+ *   - reconstructs LayerHit chain from raw DB rows (PLAYBOOK / DOMAIN / SYSTEM)
+ *   - setAt populated from AnalysisSpec.updatedAt when spec resolves
+ *   - PLAYBOOK hit has value:null until PlaybookItem walk lands (Sprint 2)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const prismaMock = {
+  playbook: { findUnique: vi.fn() },
+  domain: { findUnique: vi.fn() },
+  analysisSpec: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("identity-spec resolver — does not call resolveSpecs", () => {
+  it("does NOT import transforms/identity.ts::resolveSpecs", () => {
+    const filePath = join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "..",
+      "lib",
+      "cascade",
+      "resolvers",
+      "identity-spec.ts",
+    );
+    const src = readFileSync(filePath, "utf-8");
+    // Strip line + block comments so the assertions only see code.
+    const code = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:\/])\/\/.*$/gm, "$1");
+    expect(code).not.toMatch(/\bresolveSpecs\b/);
+    expect(code).not.toMatch(/transforms\/identity/);
+  });
+});
+
+describe("resolveIdentitySpec", () => {
+  it("returns three LayerHits (PLAYBOOK + DOMAIN + SYSTEM) and picks Domain as winner when Playbook is null", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingIdentitySpecId: "spec-edu-001",
+    });
+    prismaMock.analysisSpec.findUnique.mockResolvedValueOnce({
+      id: "spec-edu-001",
+      updatedAt: new Date("2026-05-01T00:00:00Z"),
+    });
+    prismaMock.analysisSpec.findFirst.mockResolvedValueOnce({
+      id: "spec-tut-001",
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const { resolveIdentitySpec } = await import(
+      "@/lib/cascade/resolvers/identity-spec"
+    );
+    const r = await resolveIdentitySpec({ playbookId: "pb1" });
+
+    expect(r.layers.map((h) => h.layer)).toEqual([
+      "PLAYBOOK",
+      "DOMAIN",
+      "SYSTEM",
+    ]);
+    // PLAYBOOK hit value is null until the PlaybookItem walk lands.
+    expect(r.layers[0].value).toBeNull();
+    // DOMAIN wins because PLAYBOOK is null and DOMAIN has the override.
+    expect(r.value).toBe("spec-edu-001");
+    expect(r.source).toBe("DOMAIN");
+    expect(r.isInherited).toBe(true);
+  });
+
+  it("setAt populated from AnalysisSpec.updatedAt for DOMAIN + SYSTEM hits", async () => {
+    const domainSpecAt = new Date("2026-04-04T00:00:00Z");
+    const sysSpecAt = new Date("2025-12-01T00:00:00Z");
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingIdentitySpecId: "spec-edu-001",
+    });
+    prismaMock.analysisSpec.findUnique.mockResolvedValueOnce({
+      id: "spec-edu-001",
+      updatedAt: domainSpecAt,
+    });
+    prismaMock.analysisSpec.findFirst.mockResolvedValueOnce({
+      id: "spec-tut-001",
+      updatedAt: sysSpecAt,
+    });
+
+    const { resolveIdentitySpec } = await import(
+      "@/lib/cascade/resolvers/identity-spec"
+    );
+    const r = await resolveIdentitySpec({ playbookId: "pb1" });
+
+    const playbookHit = r.layers.find((h) => h.layer === "PLAYBOOK")!;
+    const domainHit = r.layers.find((h) => h.layer === "DOMAIN")!;
+    const systemHit = r.layers.find((h) => h.layer === "SYSTEM")!;
+    expect(playbookHit.setAt).toBeNull();
+    expect(domainHit.setAt).toEqual(domainSpecAt);
+    expect(systemHit.setAt).toEqual(sysSpecAt);
+    expect(playbookHit.setBy).toBeNull();
+    expect(domainHit.setBy).toBeNull();
+    expect(systemHit.setBy).toBeNull();
+  });
+
+  it("throws when playbookId missing", async () => {
+    const { resolveIdentitySpec } = await import(
+      "@/lib/cascade/resolvers/identity-spec"
+    );
+    await expect(resolveIdentitySpec({})).rejects.toThrow(/playbookId/);
+  });
+});

--- a/apps/admin/tests/lib/cascade/resolvers/identity-spec.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/identity-spec.test.ts
@@ -77,12 +77,13 @@ describe("resolveIdentitySpec", () => {
     const r = await resolveIdentitySpec({ playbookId: "pb1" });
 
     expect(r.layers.map((h) => h.layer)).toEqual([
-      "PLAYBOOK",
-      "DOMAIN",
       "SYSTEM",
+      "DOMAIN",
+      "PLAYBOOK",
     ]);
     // PLAYBOOK hit value is null until the PlaybookItem walk lands.
-    expect(r.layers[0].value).toBeNull();
+    const playbookHit = r.layers.find((h) => h.layer === "PLAYBOOK")!;
+    expect(playbookHit.value).toBeNull();
     // DOMAIN wins because PLAYBOOK is null and DOMAIN has the override.
     expect(r.value).toBe("spec-edu-001");
     expect(r.source).toBe("DOMAIN");

--- a/apps/admin/tests/lib/cascade/resolvers/session-flow.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/session-flow.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for session-flow resolver.
+ * (Epic #1442 Layer 2 / story #1454.)
+ *
+ * AC focus: every distinct source string from resolveSessionFlow.source
+ * maps to the correct Layer via the explicit table (no fallthrough).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { mapSessionFlowSource } from "@/lib/cascade/resolvers/session-flow";
+
+describe("mapSessionFlowSource", () => {
+  it("maps 'domain' to DOMAIN", () => {
+    expect(mapSessionFlowSource("domain")).toBe("DOMAIN");
+  });
+
+  it("maps PLAYBOOK-tier source strings to PLAYBOOK", () => {
+    expect(mapSessionFlowSource("new-shape")).toBe("PLAYBOOK");
+    expect(mapSessionFlowSource("playbook-legacy")).toBe("PLAYBOOK");
+    expect(mapSessionFlowSource("legacy-welcome")).toBe("PLAYBOOK");
+    expect(mapSessionFlowSource("synthesized-from-legacy")).toBe("PLAYBOOK");
+  });
+
+  it("maps SYSTEM-tier source strings to SYSTEM", () => {
+    expect(mapSessionFlowSource("init001")).toBe("SYSTEM");
+    expect(mapSessionFlowSource("defaults")).toBe("SYSTEM");
+  });
+});

--- a/apps/admin/tests/lib/cascade/resolvers/session-flow.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/session-flow.test.ts
@@ -2,28 +2,121 @@
  * Tests for session-flow resolver.
  * (Epic #1442 Layer 2 / story #1454.)
  *
- * AC focus: every distinct source string from resolveSessionFlow.source
- * maps to the correct Layer via the explicit table (no fallthrough).
+ * Covers:
+ *   - every distinct source string from resolveSessionFlow.source maps
+ *     to the correct Layer via the explicit table (no fallthrough)
+ *   - resolveSessionFlowKnob async path produces a valid Effective<T>
+ *     envelope with a single LayerHit (winner)
+ *   - throws on unknown knob key and on missing playbookId
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { mapSessionFlowSource } from "@/lib/cascade/resolvers/session-flow";
+const prismaMock = {
+  playbook: { findUnique: vi.fn() },
+  domain: { findUnique: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("mapSessionFlowSource", () => {
-  it("maps 'domain' to DOMAIN", () => {
+  it("maps 'domain' to DOMAIN", async () => {
+    const { mapSessionFlowSource } = await import(
+      "@/lib/cascade/resolvers/session-flow"
+    );
     expect(mapSessionFlowSource("domain")).toBe("DOMAIN");
   });
 
-  it("maps PLAYBOOK-tier source strings to PLAYBOOK", () => {
+  it("maps PLAYBOOK-tier source strings to PLAYBOOK", async () => {
+    const { mapSessionFlowSource } = await import(
+      "@/lib/cascade/resolvers/session-flow"
+    );
     expect(mapSessionFlowSource("new-shape")).toBe("PLAYBOOK");
     expect(mapSessionFlowSource("playbook-legacy")).toBe("PLAYBOOK");
     expect(mapSessionFlowSource("legacy-welcome")).toBe("PLAYBOOK");
     expect(mapSessionFlowSource("synthesized-from-legacy")).toBe("PLAYBOOK");
   });
 
-  it("maps SYSTEM-tier source strings to SYSTEM", () => {
+  it("maps SYSTEM-tier source strings to SYSTEM", async () => {
+    const { mapSessionFlowSource } = await import(
+      "@/lib/cascade/resolvers/session-flow"
+    );
     expect(mapSessionFlowSource("init001")).toBe("SYSTEM");
     expect(mapSessionFlowSource("defaults")).toBe("SYSTEM");
+  });
+});
+
+describe("resolveSessionFlowKnob — async integration", () => {
+  it("returns a single-LayerHit envelope for the winning layer", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      // `sessionFlow.onboarding` present → resolveSessionFlow source = "new-shape" → PLAYBOOK.
+      config: { sessionFlow: { onboarding: { phases: [] } } },
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingWelcome: null,
+      onboardingFlowPhases: null,
+    });
+
+    const { resolveSessionFlowKnob } = await import(
+      "@/lib/cascade/resolvers/session-flow"
+    );
+    const r = await resolveSessionFlowKnob({ playbookId: "pb1" }, "onboarding");
+
+    expect(r.source).toBe("PLAYBOOK");
+    expect(r.isInherited).toBe(false);
+    expect(r.layers).toHaveLength(1);
+    expect(r.layers[0].layer).toBe("PLAYBOOK");
+    expect(r.layers[0].setAt).toBeNull();
+    expect(r.layers[0].setBy).toBeNull();
+  });
+
+  it("falls through to DOMAIN-source when only Domain has an override", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: {},
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingWelcome: null,
+      onboardingFlowPhases: { phases: [] },
+    });
+
+    const { resolveSessionFlowKnob } = await import(
+      "@/lib/cascade/resolvers/session-flow"
+    );
+    const r = await resolveSessionFlowKnob({ playbookId: "pb1" }, "onboarding");
+
+    expect(r.source).toBe("DOMAIN");
+    expect(r.isInherited).toBe(true);
+    expect(r.layers[0].layer).toBe("DOMAIN");
+  });
+
+  it("throws on unknown knob key", async () => {
+    const { resolveSessionFlowKnob } = await import(
+      "@/lib/cascade/resolvers/session-flow"
+    );
+    await expect(
+      resolveSessionFlowKnob({ playbookId: "pb1" }, "voiceProvider"),
+    ).rejects.toThrow(/does not handle/);
+  });
+
+  it("throws when playbookId missing", async () => {
+    const { resolveSessionFlowKnob } = await import(
+      "@/lib/cascade/resolvers/session-flow"
+    );
+    await expect(
+      resolveSessionFlowKnob({}, "onboarding"),
+    ).rejects.toThrow(/playbookId/);
   });
 });

--- a/apps/admin/tests/lib/cascade/resolvers/voice-config.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/voice-config.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for voice-config resolver.
+ * (Epic #1442 Layer 2 / story #1454.)
+ *
+ * AC focus: thin re-export over voice-explain.ts — no duplication of raw
+ * blob reads. Plus the pure voice-layer mapper.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { mapVoiceLayer } from "@/lib/cascade/resolvers/voice-config";
+
+describe("mapVoiceLayer", () => {
+  it("collapses system + provider onto SYSTEM (no PROVIDER tier in cascade-honesty)", () => {
+    expect(mapVoiceLayer("system")).toBe("SYSTEM");
+    expect(mapVoiceLayer("provider")).toBe("SYSTEM");
+  });
+
+  it("maps domain to DOMAIN", () => {
+    expect(mapVoiceLayer("domain")).toBe("DOMAIN");
+  });
+
+  it("maps course to PLAYBOOK", () => {
+    expect(mapVoiceLayer("course")).toBe("PLAYBOOK");
+  });
+});
+
+describe("voice-config resolver — no duplication", () => {
+  it("imports from voice-explain (no parallel raw-blob read path)", () => {
+    const filePath = join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "..",
+      "lib",
+      "cascade",
+      "resolvers",
+      "voice-config.ts",
+    );
+    const src = readFileSync(filePath, "utf-8");
+    expect(src).toMatch(/from\s+["']\.\.\/voice-explain["']/);
+    // Defence-in-depth: no prisma import — all DB reads belong to voice-explain.
+    expect(src).not.toMatch(/from\s+["']@\/lib\/prisma["']/);
+  });
+});

--- a/apps/admin/tests/lib/cascade/resolvers/welcome-message.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/welcome-message.test.ts
@@ -42,8 +42,10 @@ describe("resolveWelcomeMessage", () => {
     const r = await resolveWelcomeMessage({ playbookId: "pb1" });
 
     expect(r.layers).toHaveLength(2);
-    expect(r.layers[0].layer).toBe("PLAYBOOK");
-    expect(r.layers[1].layer).toBe("DOMAIN");
+    // SYSTEM→CALL order: DOMAIN first, then PLAYBOOK.
+    expect(r.layers[0].layer).toBe("DOMAIN");
+    expect(r.layers[1].layer).toBe("PLAYBOOK");
+    // PLAYBOOK wins (deepest layer).
     expect(r.value).toBe("Welcome to OCEAN");
     expect(r.source).toBe("PLAYBOOK");
     expect(r.isInherited).toBe(false);

--- a/apps/admin/tests/lib/cascade/resolvers/welcome-message.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/welcome-message.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for welcome-message resolver.
+ * (Epic #1442 Layer 2 / story #1454.)
+ *
+ * Covers AC:
+ *   - Two LayerHit entries when both Playbook.config.welcomeMessage and
+ *     Domain.onboardingWelcome are set
+ *   - One when only one is set
+ *   - value: null with empty layers when neither
+ *   - setAt and setBy null with TODO comment
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = {
+  playbook: { findUnique: vi.fn() },
+  domain: { findUnique: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveWelcomeMessage", () => {
+  it("returns two LayerHits when both Playbook and Domain set", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: { welcomeMessage: "Welcome to OCEAN" },
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingWelcome: "Welcome from Education",
+    });
+
+    const { resolveWelcomeMessage } = await import(
+      "@/lib/cascade/resolvers/welcome-message"
+    );
+    const r = await resolveWelcomeMessage({ playbookId: "pb1" });
+
+    expect(r.layers).toHaveLength(2);
+    expect(r.layers[0].layer).toBe("PLAYBOOK");
+    expect(r.layers[1].layer).toBe("DOMAIN");
+    expect(r.value).toBe("Welcome to OCEAN");
+    expect(r.source).toBe("PLAYBOOK");
+    expect(r.isInherited).toBe(false);
+  });
+
+  it("returns one DOMAIN hit when only Domain is set", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: {},
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingWelcome: "From the domain",
+    });
+
+    const { resolveWelcomeMessage } = await import(
+      "@/lib/cascade/resolvers/welcome-message"
+    );
+    const r = await resolveWelcomeMessage({ playbookId: "pb1" });
+
+    expect(r.layers).toHaveLength(1);
+    expect(r.layers[0].layer).toBe("DOMAIN");
+    expect(r.value).toBe("From the domain");
+    expect(r.source).toBe("DOMAIN");
+    expect(r.isInherited).toBe(true);
+  });
+
+  it("returns value:null with empty layers when neither set", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: {},
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingWelcome: null,
+    });
+
+    const { resolveWelcomeMessage } = await import(
+      "@/lib/cascade/resolvers/welcome-message"
+    );
+    const r = await resolveWelcomeMessage({ playbookId: "pb1" });
+
+    expect(r.layers).toHaveLength(0);
+    expect(r.value).toBeNull();
+    expect(r.source).toBe("SYSTEM");
+    expect(r.isInherited).toBe(false);
+  });
+
+  it("returns setAt and setBy null for every hit (provenance TODO)", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: { welcomeMessage: "Hi" },
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      onboardingWelcome: "Domain hi",
+    });
+
+    const { resolveWelcomeMessage } = await import(
+      "@/lib/cascade/resolvers/welcome-message"
+    );
+    const r = await resolveWelcomeMessage({ playbookId: "pb1" });
+
+    for (const hit of r.layers) {
+      expect(hit.setAt).toBeNull();
+      expect(hit.setBy).toBeNull();
+    }
+  });
+
+  it("throws when playbookId missing from scope", async () => {
+    const { resolveWelcomeMessage } = await import(
+      "@/lib/cascade/resolvers/welcome-message"
+    );
+    await expect(resolveWelcomeMessage({})).rejects.toThrow(/playbookId/);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation slice of [story #1454](https://github.com/WANDERCOLTD/HF/issues/1454) (Epic #1442 Layer 2 — cascade-honesty UX). Ships the `resolveEffective` primitive + 5 per-family resolvers + their tests. **No UI, no write router, no API route yet** — those land in Slice 2 + 3.

The design contract is [ADR PR #1450](https://github.com/WANDERCOLTD/HF/pull/1450) (also on `docs/decisions/2026-06-10-cascade-honesty-ux.md`).

## What's in

| File | Wraps | Notes |
|---|---|---|
| `lib/cascade/layer-types.ts` | — | `Layer` union, `LayerHit<T>`, `Effective<T>` |
| `lib/cascade/effective-value.ts` | — | `resolveEffective` dispatch by knob key + 30s per-page-load cache + `invalidateKnob` / `invalidateAll` |
| `lib/cascade/resolvers/behavior-target.ts` | `lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts` | Handles `BEH-*` keys. **Does NOT import `mergeTargets`** (that's COMPOSE-stage) |
| `lib/cascade/resolvers/session-flow.ts` | `lib/session-flow/resolver.ts::resolveSessionFlow` | Handles `onboarding / intake / stops / offboarding`. Explicit 7-string source→Layer mapping (`mapSessionFlowSource`) |
| `lib/cascade/resolvers/welcome-message.ts` | Direct Playbook+Domain read | Multi-layer chain; `welcomeMessage` knob |
| `lib/cascade/resolvers/voice-config.ts` | `lib/cascade/voice-explain.ts` (already shipped #1348) | Thin adapter — no parallel raw-blob reads |
| `lib/cascade/resolvers/identity-spec.ts` | Direct Playbook + Domain + DEFAULT_ARCHETYPE_SLUG read | **Does NOT call `resolveSpecs`** (winner-only). PlaybookItem walk deferred to follow-up |

## Provenance (`setBy` / `setAt`)

Per the BA's schema-grounded ACs:

- **`setAt`** populated where the underlying row has it: `BehaviorTarget.updatedAt`, `AnalysisSpec.updatedAt`. `null` elsewhere with `// TODO(cascade-provenance)`.
- **`setBy`** is `null` on every `LayerHit` today. No userId column exists on `BehaviorTarget`, `Playbook.config`, `Domain.config`, `AnalysisSpec`. Inspector tray will render "Set by (unknown)" until a follow-up migration ships the columns.

## Tests

```
Test Files  7 passed (7)
     Tests  39 passed (39)
```

- 32 new vitests across 6 files
- 7 existing `voice-explain` tests still green (regression check on the wrapped helper)
- Source-import assertions verify `mergeTargets` is not in `behavior-target.ts`, `resolveSpecs` is not in `identity-spec.ts`, `voice-explain` IS imported by `voice-config.ts`

## What's NOT in (next slices)

- **Slice 2** — `lib/cascade/set-at-layer.ts` write router (dispatches to `updatePlaybookConfig` / `updateDomainConfig` / `writeCallerBehaviorTarget`), `GET /api/cascade/resolve` route, `TrayEntryScope` "caller" enum addition
- **Slice 3** — `<LayerBadge>`, `<CascadeInspectorTray>`, `<ScopePicker>` components
- **First consumers** — #1417 (FirstSessionSettings) + #1418 (PreviewLens INIT-001 fallback) — separate stories, ride on top of the primitive

## Test plan

- [x] `npx tsc --noEmit` clean for the cascade files
- [x] `npx eslint lib/cascade/ tests/lib/cascade/` 0 errors
- [x] `npx vitest run tests/lib/cascade/` — 39/39 green
- [ ] Smoke against demo callers on hf_sandbox once Slice 2 lands the API route

## Refs

- Story: #1454
- Epic: #1442
- Design contract: PR #1450 (DECIDED, TL revisions baked in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)