### PR TITLE
feat(cascade): #1454 Slice 2 — write router + API route + caller tray scope

### DIFF
--- a/apps/admin/app/api/cascade/resolve/route.ts
+++ b/apps/admin/app/api/cascade/resolve/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  resolveEffective,
+  type ScopeChain,
+} from "@/lib/cascade/effective-value";
+
+export const runtime = "nodejs";
+
+/**
+ * @api GET /api/cascade/resolve
+ * @visibility internal
+ * @scope cascade:resolve:read
+ * @auth session (OPERATOR)
+ * @tags cascade, inspector, epic-1442
+ * @description Resolves the effective value of a cascade-eligible knob
+ *   against the provided scope chain. Powers `<CascadeInspectorTray>`
+ *   and the upcoming Cmd+K cascade tools. Read-only — see
+ *   `lib/cascade/set-at-layer.ts` for the write counterpart.
+ * @queryParam knobKey   e.g. "BEH-WARMTH" / "welcomeMessage" / "voiceId" (required)
+ * @queryParam playbookId  scope chain id (optional)
+ * @queryParam callerId    scope chain id (optional)
+ * @queryParam domainId    scope chain id (optional)
+ * @response 200 Effective<unknown> envelope: { value, source, layers, isInherited, recommendedLayerForEdit }
+ * @response 400 { ok: false, error: "Unknown knob key …" | "Missing required scope …" }
+ * @response 403 (returned by requireAuth)
+ */
+export async function GET(request: Request) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const { searchParams } = new URL(request.url);
+  const knobKey = searchParams.get("knobKey");
+  if (!knobKey) {
+    return NextResponse.json(
+      { ok: false, error: "knobKey is required" },
+      { status: 400 },
+    );
+  }
+
+  const scopeChain: ScopeChain = {};
+  const playbookId = searchParams.get("playbookId");
+  const callerId = searchParams.get("callerId");
+  const domainId = searchParams.get("domainId");
+  if (playbookId) scopeChain.playbookId = playbookId;
+  if (callerId) scopeChain.callerId = callerId;
+  if (domainId) scopeChain.domainId = domainId;
+
+  try {
+    const envelope = await resolveEffective({ knobKey, scopeChain });
+    return NextResponse.json(envelope);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Distinguish unknown knob keys from missing-scope params from
+    // unexpected internal errors — gives the client a useful 400 vs 500.
+    if (/Unknown cascade knob key/.test(message)) {
+      return NextResponse.json({ ok: false, error: message }, { status: 400 });
+    }
+    if (/requires\s+`?\w+`?\s+in\s+scopeChain/.test(message)) {
+      return NextResponse.json({ ok: false, error: message }, { status: 400 });
+    }
+    if (/not found/.test(message)) {
+      return NextResponse.json({ ok: false, error: message }, { status: 404 });
+    }
+    console.error("[api/cascade/resolve] internal error", err);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/api/recompose/apply/route.ts
+++ b/apps/admin/app/api/recompose/apply/route.ts
@@ -43,7 +43,11 @@ const trayEntrySchema = z
     scopeLabel: z.string(),
     beforeValue: z.string(),
     afterValue: z.string(),
-    scope: z.enum(["playbook", "domain", "system"]),
+    // "caller" added with Epic #1442 Slice 2 (#1454) — ScopePicker writes
+    // at caller scope route through the tray collector to preserve the
+    // audit trail. The CALLER write itself bumps composeInputsUpdatedAt
+    // inside writeCallerBehaviorTarget, so no extra fanout needed here.
+    scope: z.enum(["playbook", "domain", "system", "caller"]),
     scopeId: z.string().nullable(),
     aiSuggested: z.boolean(),
     fanoutScope: z.enum(["none", "caller", "all"]),

--- a/apps/admin/hooks/use-pending-changes-tray.tsx
+++ b/apps/admin/hooks/use-pending-changes-tray.tsx
@@ -34,7 +34,9 @@ import {
 const STORAGE_KEY = "hf-pending-tray-v1";
 const PERSIST_DEBOUNCE_MS = 3_000;
 
-export type TrayEntryScope = "playbook" | "domain" | "system";
+// "caller" added for ScopePicker (Epic #1442 Layer 2) — preserves audit
+// trail for caller-scope cascade overrides. Slice 2 of #1454.
+export type TrayEntryScope = "playbook" | "domain" | "system" | "caller";
 export type FanoutScope = "none" | "caller" | "all";
 
 export interface TrayEntry {
@@ -234,7 +236,9 @@ export function PendingChangesTrayProvider({
         return;
       }
       const scope: TrayEntryScope =
-        p.scope === "domain" || p.scope === "system" ? p.scope : "playbook";
+        p.scope === "domain" || p.scope === "system" || p.scope === "caller"
+          ? p.scope
+          : "playbook";
       const fanoutScope: FanoutScope =
         p.fanoutScope === "caller" || p.fanoutScope === "none"
           ? p.fanoutScope

--- a/apps/admin/lib/agent-tuner/write-target.ts
+++ b/apps/admin/lib/agent-tuner/write-target.ts
@@ -17,6 +17,7 @@ import {
   bumpCallerComposeTimestamp,
   bumpPlaybookComposeTimestamp,
 } from "@/lib/compose/bump-timestamp";
+import { invalidateKnob } from "@/lib/cascade/effective-value";
 
 export type WriteTargetResult =
   | { ok: true; action: "created" | "updated" | "removed" | "noop"; parameterId: string; value: number | null }
@@ -83,6 +84,8 @@ export async function writeBehaviorTarget(
     // #830 — out-of-band PLAYBOOK-scope target removal: mark every
     // caller in this playbook stale on next call.
     await bumpPlaybookComposeTimestamp(playbookId);
+    // #1454 Slice 2 — drop cascade-cache for this BEH-* knob.
+    invalidateKnob(parameterId);
     return { ok: true, action: "removed", parameterId, value: null };
   }
 
@@ -98,6 +101,8 @@ export async function writeBehaviorTarget(
       },
     });
     await bumpPlaybookComposeTimestamp(playbookId);
+    // #1454 Slice 2 — drop cascade-cache for this BEH-* knob.
+    invalidateKnob(parameterId);
     return { ok: true, action: "updated", parameterId, value: clamped };
   }
 
@@ -112,6 +117,8 @@ export async function writeBehaviorTarget(
     },
   });
   await bumpPlaybookComposeTimestamp(playbookId);
+  // #1454 Slice 2 — drop cascade-cache for this BEH-* knob.
+  invalidateKnob(parameterId);
   return { ok: true, action: "created", parameterId, value: clamped };
 }
 
@@ -197,6 +204,8 @@ export async function writeCallerBehaviorTarget(
       // so the staleness check picks it up on next call. Noop deletions
       // don't change anything and don't need a bump.
       await bumpCallerComposeTimestamp(callerId);
+      // #1454 Slice 2 — drop cascade-cache for this BEH-* knob.
+      invalidateKnob(parameterId);
     }
     return {
       ok: true,
@@ -244,6 +253,9 @@ export async function writeCallerBehaviorTarget(
   // #830 — successful upsert across the caller's identities: stamp the
   // caller so the staleness check picks this up on next call.
   await bumpCallerComposeTimestamp(callerId);
+
+  // #1454 Slice 2 — drop cascade-cache for this BEH-* knob.
+  invalidateKnob(parameterId);
 
   return {
     ok: true,

--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -167,15 +167,15 @@ function cacheSet(
 
 /**
  * Drop every cache entry for the given `knobKey` (across all scope
- * chains). Called from `setKnobAtLayer` (Slice 2) after a successful
- * write so the next read returns the fresh winner.
+ * chains). Called from:
+ *   - `setKnobAtLayer` after every successful write (cascade write path)
+ *   - `writeBehaviorTarget` / `writeCallerBehaviorTarget` (BEH-* writes
+ *     from non-cascade paths — sidebar PATCH, chat tool, etc.)
  *
- * TODO(slice-2-invalidation-coverage): existing mutators
- * (`updatePlaybookConfig`, `updateDomainConfig`, direct `BehaviorTarget`
- * writes via `/api/playbooks/[id]/behavior-targets`) do NOT call
- * `invalidateKnob` today — same-session reads can race a same-session
- * write within the 30s window. Slice 2 wires `invalidateKnob` into the
- * shared write helpers so non-cascade write paths also self-invalidate.
+ * `updatePlaybookConfig` and `updateDomainConfig` call `invalidateAll`
+ * instead because diffing the JSON blob to identify changed knob keys
+ * would have to enumerate every cascade family — coarse invalidation
+ * is cheaper and equally correct (next reads rebuild lazily).
  */
 export function invalidateKnob(knobKey: string): void {
   const prefix = `${knobKey}|`;

--- a/apps/admin/lib/cascade/set-at-layer.ts
+++ b/apps/admin/lib/cascade/set-at-layer.ts
@@ -1,0 +1,305 @@
+/**
+ * Cascade-write router (Epic #1442 Layer 2 — see
+ * `docs/decisions/2026-06-10-cascade-honesty-ux.md` §3.3).
+ *
+ * Single chokepoint for cascade-scope writes — `<ScopePicker>` and the
+ * upcoming Cmd+K scope-prefix tools both call through here. The router
+ * dispatches by `(layer, knobKey)` to the canonical write helper for that
+ * combination; it NEVER calls `prisma.*` directly and is NOT permitted in
+ * the allowlist of `hf-playbook/no-direct-playbook-config-write` or
+ * `hf-domain/no-direct-onboarding-write`.
+ *
+ * Routes per ADR §3.3:
+ *   PLAYBOOK  → `updatePlaybookConfig` (welcomeMessage / voice / session-flow)
+ *               or `writeBehaviorTarget` (BEH-* parameters)
+ *   DOMAIN    → `updateDomainConfig` (welcomeMessage = onboardingWelcome,
+ *               identitySpecId = onboardingIdentitySpecId)
+ *   CALLER    → `writeCallerBehaviorTarget` (BEH-* only) + the bump helper
+ *               is called transitively inside that function
+ *   SEGMENT / CALL → throws (Sprint 2 deferred; ADR §4 OUT)
+ *   SYSTEM    → throws (ADMIN-only, future sprint)
+ *
+ * After a successful write the router calls `invalidateKnob(knobKey)` so
+ * any cached `Effective<T>` for that knob across all scope chains is
+ * dropped — the next `resolveEffective` re-reads.
+ *
+ * No auto-creation of intermediate scope rows (ADR §6 non-goal — the
+ * SharePoint "Limited Access" anti-pattern). The router writes exactly
+ * one row at exactly the requested layer.
+ *
+ * Sprint 3 TODO: when Cmd+K domain writes ship, add `lib/cascade/
+ * set-at-layer.ts` to `AI_TOOL_PATH_FRAGMENTS` in
+ * `eslint-rules/no-ai-fanout-all.mjs`.
+ */
+
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import { updateDomainConfig } from "@/lib/domain/update-domain-config";
+import {
+  writeBehaviorTarget,
+  writeCallerBehaviorTarget,
+} from "@/lib/agent-tuner/write-target";
+
+import type { Layer } from "./layer-types";
+import { invalidateKnob } from "./effective-value";
+
+export interface SetKnobScopeIds {
+  playbookId?: string;
+  domainId?: string;
+  callerId?: string;
+}
+
+export interface SetKnobArgs {
+  knobKey: string;
+  layer: Layer;
+  scopeIds: SetKnobScopeIds;
+  value: unknown;
+  /** Optional diagnostic label propagated to bump-log lines + audit rows. */
+  reason?: string;
+}
+
+export type SetKnobResult =
+  | { ok: true; layer: Layer; knobKey: string }
+  | { ok: false; layer: Layer; knobKey: string; reason: string };
+
+// ── Knob family detection ──────────────────────────────────────────────
+
+function isBehaviorParameter(knobKey: string): boolean {
+  return knobKey.startsWith("BEH-");
+}
+
+function isWelcomeMessage(knobKey: string): boolean {
+  return knobKey === "welcomeMessage";
+}
+
+function isIdentitySpecId(knobKey: string): boolean {
+  return knobKey === "identitySpecId";
+}
+
+const VOICE_KEYS = new Set([
+  "voiceProvider",
+  "voiceId",
+  "model",
+  "modelTemp",
+  "modelTopP",
+  "language",
+]);
+
+const SESSION_FLOW_KEYS = new Set([
+  "onboarding",
+  "intake",
+  "stops",
+  "offboarding",
+]);
+
+// ── PLAYBOOK dispatch ──────────────────────────────────────────────────
+
+async function setAtPlaybook(args: SetKnobArgs): Promise<void> {
+  const { knobKey, scopeIds, value, reason } = args;
+  if (!scopeIds.playbookId) {
+    throw new Error(
+      `setKnobAtLayer: PLAYBOOK scope requires \`scopeIds.playbookId\``,
+    );
+  }
+
+  if (isBehaviorParameter(knobKey)) {
+    if (typeof value !== "number" && value !== null) {
+      throw new Error(
+        `setKnobAtLayer: BEH-* knob "${knobKey}" requires number | null value (got ${typeof value})`,
+      );
+    }
+    const r = await writeBehaviorTarget(
+      scopeIds.playbookId,
+      knobKey,
+      value as number | null,
+      { source: "MANUAL" },
+    );
+    if (!r.ok) {
+      throw new Error(
+        `setKnobAtLayer: PLAYBOOK BEH write failed for "${knobKey}" — ${r.reason}`,
+      );
+    }
+    return;
+  }
+
+  if (isWelcomeMessage(knobKey)) {
+    if (value !== null && typeof value !== "string") {
+      throw new Error(
+        `setKnobAtLayer: welcomeMessage requires string | null value`,
+      );
+    }
+    await updatePlaybookConfig(
+      scopeIds.playbookId,
+      (cfg) => {
+        if (value === null) {
+          const next = { ...cfg };
+          delete (next as Record<string, unknown>).welcomeMessage;
+          return next;
+        }
+        return { ...cfg, welcomeMessage: value as string };
+      },
+      { reason: reason ?? "set-at-layer:welcomeMessage" },
+    );
+    return;
+  }
+
+  if (VOICE_KEYS.has(knobKey)) {
+    await updatePlaybookConfig(
+      scopeIds.playbookId,
+      (cfg) => {
+        const voice = {
+          ...((cfg as Record<string, unknown>).voice as Record<string, unknown> ?? {}),
+        };
+        if (value === null) {
+          delete voice[knobKey];
+        } else {
+          voice[knobKey] = value;
+        }
+        return { ...cfg, voice } as typeof cfg;
+      },
+      { reason: reason ?? `set-at-layer:voice:${knobKey}` },
+    );
+    return;
+  }
+
+  if (SESSION_FLOW_KEYS.has(knobKey)) {
+    await updatePlaybookConfig(
+      scopeIds.playbookId,
+      (cfg) => {
+        const sf = {
+          ...((cfg as Record<string, unknown>).sessionFlow as Record<string, unknown> ?? {}),
+        };
+        if (value === null) {
+          delete sf[knobKey];
+        } else {
+          sf[knobKey] = value;
+        }
+        return { ...cfg, sessionFlow: sf } as typeof cfg;
+      },
+      { reason: reason ?? `set-at-layer:sessionFlow:${knobKey}` },
+    );
+    return;
+  }
+
+  throw new Error(
+    `setKnobAtLayer: unsupported PLAYBOOK-scope knob "${knobKey}" — write path not implemented`,
+  );
+}
+
+// ── DOMAIN dispatch ────────────────────────────────────────────────────
+
+async function setAtDomain(args: SetKnobArgs): Promise<void> {
+  const { knobKey, scopeIds, value, reason } = args;
+  if (!scopeIds.domainId) {
+    throw new Error(
+      `setKnobAtLayer: DOMAIN scope requires \`scopeIds.domainId\``,
+    );
+  }
+
+  if (isWelcomeMessage(knobKey)) {
+    if (value !== null && typeof value !== "string") {
+      throw new Error(
+        `setKnobAtLayer: DOMAIN welcomeMessage requires string | null value`,
+      );
+    }
+    await updateDomainConfig(
+      scopeIds.domainId,
+      (cur) => ({ ...cur, onboardingWelcome: value as string | null }),
+      { reason: reason ?? "set-at-layer:domain.onboardingWelcome" },
+    );
+    return;
+  }
+
+  if (isIdentitySpecId(knobKey)) {
+    if (value !== null && typeof value !== "string") {
+      throw new Error(
+        `setKnobAtLayer: DOMAIN identitySpecId requires string | null value`,
+      );
+    }
+    await updateDomainConfig(
+      scopeIds.domainId,
+      (cur) => ({ ...cur, onboardingIdentitySpecId: value as string | null }),
+      { reason: reason ?? "set-at-layer:domain.onboardingIdentitySpecId" },
+    );
+    return;
+  }
+
+  throw new Error(
+    `setKnobAtLayer: unsupported DOMAIN-scope knob "${knobKey}" — write path not implemented`,
+  );
+}
+
+// ── CALLER dispatch ────────────────────────────────────────────────────
+
+async function setAtCaller(args: SetKnobArgs): Promise<void> {
+  const { knobKey, scopeIds, value } = args;
+  if (!scopeIds.callerId) {
+    throw new Error(
+      `setKnobAtLayer: CALLER scope requires \`scopeIds.callerId\``,
+    );
+  }
+
+  if (!isBehaviorParameter(knobKey)) {
+    throw new Error(
+      `setKnobAtLayer: CALLER scope today supports BEH-* parameters only (got "${knobKey}")`,
+    );
+  }
+  if (typeof value !== "number" && value !== null) {
+    throw new Error(
+      `setKnobAtLayer: BEH-* knob "${knobKey}" requires number | null value`,
+    );
+  }
+  const r = await writeCallerBehaviorTarget(
+    scopeIds.callerId,
+    knobKey,
+    value as number | null,
+    { source: "MANUAL" },
+  );
+  if (!r.ok) {
+    throw new Error(
+      `setKnobAtLayer: CALLER BEH write failed for "${knobKey}" — ${r.reason}`,
+    );
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Write a cascade-scope knob value at the requested layer. Always
+ * delegates to the canonical write helper for the combination; never
+ * calls `prisma.*` directly. Drops the cache for `knobKey` after a
+ * successful write.
+ *
+ * @example
+ * await setKnobAtLayer({
+ *   knobKey: "BEH-WARMTH",
+ *   layer: "CALLER",
+ *   scopeIds: { callerId: "smoke-test-…" },
+ *   value: 0.8,
+ *   reason: "scope-picker:smoke-test",
+ * });
+ */
+export async function setKnobAtLayer(args: SetKnobArgs): Promise<SetKnobResult> {
+  switch (args.layer) {
+    case "PLAYBOOK":
+      await setAtPlaybook(args);
+      break;
+    case "DOMAIN":
+      await setAtDomain(args);
+      break;
+    case "CALLER":
+      await setAtCaller(args);
+      break;
+    case "SEGMENT":
+    case "CALL":
+      throw new Error(
+        `setKnobAtLayer: ${args.layer} scope writes not implemented in Sprint 1 — Epic #1442 Sprint 2`,
+      );
+    case "SYSTEM":
+      throw new Error(
+        `setKnobAtLayer: SYSTEM scope writes are ADMIN-only and not implemented in Sprint 1`,
+      );
+  }
+
+  invalidateKnob(args.knobKey);
+  return { ok: true, layer: args.layer, knobKey: args.knobKey };
+}

--- a/apps/admin/lib/domain/update-domain-config.ts
+++ b/apps/admin/lib/domain/update-domain-config.ts
@@ -28,11 +28,12 @@
  */
 
 import { prisma } from "@/lib/prisma";
-import type { Domain } from "@prisma/client";
+import type { Domain, Prisma } from "@prisma/client";
 import {
   composeAffectingDomainChanged,
   COMPOSE_AFFECTING_DOMAIN_FIELDS,
 } from "@/lib/compose/affecting-keys-domain";
+import { invalidateAll } from "@/lib/cascade/effective-value";
 
 /** Subset of Domain that this helper is allowed to mutate. */
 export type DomainUpdatable = Partial<Pick<
@@ -100,12 +101,16 @@ export async function updateDomainConfig(
   );
   const shouldBumpTimestamp = composeAffected && !options.skipTimestamp;
 
+  // Cast to satisfy Prisma's stricter `JsonValue` → `InputJsonValue` typing
+  // on the JSON columns (`onboardingFlowPhases`, `onboardingDefaultTargets`).
+  // The transformer-supplied values are already validated by upstream zod
+  // schemas at the route level.
   const domain = await prisma.domain.update({
     where: { id: domainId },
     data: {
       ...nextFields,
       ...(shouldBumpTimestamp && { composeInputsUpdatedAt: new Date() }),
-    },
+    } as Prisma.DomainUpdateInput,
   });
 
   if (shouldBumpTimestamp) {
@@ -113,6 +118,11 @@ export async function updateDomainConfig(
       `[updateDomainConfig] composeInputsUpdatedAt bumped for ${domainId}${options.reason ? ` (reason: ${options.reason})` : ""}`,
     );
   }
+
+  // #1454 Slice 2 — drop every cascade-cache entry so the next
+  // `resolveEffective` re-reads fresh. See `update-playbook-config.ts`
+  // for the same wiring rationale.
+  invalidateAll();
 
   return {
     domain,

--- a/apps/admin/lib/playbook/update-playbook-config.ts
+++ b/apps/admin/lib/playbook/update-playbook-config.ts
@@ -42,6 +42,7 @@ import {
   COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS,
 } from "@/lib/compose/affecting-keys";
 import { triggerEagerRepromptForDemoCallers } from "@/lib/compose/eager-reprompt-on-bump";
+import { invalidateAll } from "@/lib/cascade/effective-value";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 
 export interface UpdatePlaybookConfigOptions {
@@ -157,6 +158,13 @@ export async function updatePlaybookConfig(
     // the helper filters on `policyMode='demo'`.
     void triggerEagerRepromptForDemoCallers(playbookId);
   }
+
+  // #1454 Slice 2 — drop every cascade-cache entry so the next
+  // `resolveEffective` re-reads fresh. Coarse invalidation: cheaper than
+  // diffing the JSON blob to identify exactly which knob keys changed,
+  // and the cache rebuilds lazily on demand. Safe even when this writer
+  // is called from a non-cascade code path (e.g. wizard, AI tray).
+  invalidateAll();
 
   return {
     playbook,

--- a/apps/admin/tests/app/api/cascade-resolve.test.ts
+++ b/apps/admin/tests/app/api/cascade-resolve.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for GET /api/cascade/resolve (Slice 2 of #1454 / Epic #1442).
+ *
+ * Covers:
+ *   - requireAuth("OPERATOR") — VIEWER returns 403
+ *   - knobKey required (400)
+ *   - unknown knobKey returns 400
+ *   - missing required scope returns 400
+ *   - Playbook not found returns 404
+ *   - happy path returns the Effective<T> envelope
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const requireAuth = vi.fn();
+const isAuthError = vi.fn();
+const resolveEffective = vi.fn();
+
+vi.mock("@/lib/permissions", () => ({ requireAuth, isAuthError }));
+vi.mock("@/lib/cascade/effective-value", () => ({
+  resolveEffective,
+  invalidateKnob: vi.fn(),
+  invalidateAll: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isAuthError.mockReturnValue(false);
+  requireAuth.mockResolvedValue({ session: { user: { id: "u1" } } });
+});
+
+function makeRequest(qs: string): Request {
+  return new Request(`http://localhost:3000/api/cascade/resolve?${qs}`);
+}
+
+describe("GET /api/cascade/resolve", () => {
+  it("returns 403 when requireAuth refuses", async () => {
+    isAuthError.mockReturnValueOnce(true);
+    requireAuth.mockResolvedValueOnce({
+      error: new Response("forbidden", { status: 403 }),
+    });
+    const { GET } = await import("@/app/api/cascade/resolve/route");
+    const res = await GET(makeRequest("knobKey=BEH-WARMTH&playbookId=pb1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when knobKey missing", async () => {
+    const { GET } = await import("@/app/api/cascade/resolve/route");
+    const res = await GET(makeRequest("playbookId=pb1"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/knobKey/);
+  });
+
+  it("returns 400 on unknown knobKey", async () => {
+    resolveEffective.mockRejectedValueOnce(
+      new Error('Unknown cascade knob key: "totally-fake"'),
+    );
+    const { GET } = await import("@/app/api/cascade/resolve/route");
+    const res = await GET(
+      makeRequest("knobKey=totally-fake&playbookId=pb1"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when a required scope id is missing", async () => {
+    resolveEffective.mockRejectedValueOnce(
+      new Error("resolveWelcomeMessage requires `playbookId` in scopeChain (got: {})"),
+    );
+    const { GET } = await import("@/app/api/cascade/resolve/route");
+    const res = await GET(makeRequest("knobKey=welcomeMessage"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when underlying entity not found", async () => {
+    resolveEffective.mockRejectedValueOnce(
+      new Error("Playbook not found: pb1"),
+    );
+    const { GET } = await import("@/app/api/cascade/resolve/route");
+    const res = await GET(makeRequest("knobKey=welcomeMessage&playbookId=pb1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with the Effective<T> envelope on success", async () => {
+    const envelope = {
+      value: 0.6,
+      source: "DOMAIN",
+      layers: [
+        {
+          layer: "SYSTEM",
+          scopeId: null,
+          scopeLabel: "System default",
+          value: 0.5,
+          setAt: null,
+          setBy: null,
+        },
+        {
+          layer: "DOMAIN",
+          scopeId: "dom1",
+          scopeLabel: "Education",
+          value: 0.6,
+          setAt: "2026-05-22T00:00:00.000Z",
+          setBy: null,
+        },
+      ],
+      isInherited: true,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+    resolveEffective.mockResolvedValueOnce(envelope);
+    const { GET } = await import("@/app/api/cascade/resolve/route");
+    const res = await GET(
+      makeRequest("knobKey=BEH-WARMTH&playbookId=pb1&callerId=c1"),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(envelope);
+  });
+
+  it("threads playbookId/callerId/domainId into scopeChain", async () => {
+    resolveEffective.mockResolvedValueOnce({
+      value: null,
+      source: "SYSTEM",
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    });
+    const { GET } = await import("@/app/api/cascade/resolve/route");
+    await GET(
+      makeRequest(
+        "knobKey=welcomeMessage&playbookId=pb1&callerId=c1&domainId=dom1",
+      ),
+    );
+    expect(resolveEffective).toHaveBeenCalledWith({
+      knobKey: "welcomeMessage",
+      scopeChain: { playbookId: "pb1", callerId: "c1", domainId: "dom1" },
+    });
+  });
+});

--- a/apps/admin/tests/hooks/use-pending-changes-tray-caller-scope.test.ts
+++ b/apps/admin/tests/hooks/use-pending-changes-tray-caller-scope.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression test for TrayEntryScope "caller" enum addition (Slice 2 of
+ * #1454). Ensures the reducer wiring at line ~240 of
+ * `hooks/use-pending-changes-tray.tsx` accepts "caller" without falling
+ * through to the "playbook" default.
+ *
+ * Verified via the union-type source-import. The full reducer behaviour
+ * is exercised by integration tests in `tests/lib/admin-tools-*.test.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe('TrayEntryScope includes "caller"', () => {
+  it('use-pending-changes-tray.tsx exports a "caller" union member', () => {
+    const filePath = join(
+      __dirname,
+      "..",
+      "..",
+      "hooks",
+      "use-pending-changes-tray.tsx",
+    );
+    const src = readFileSync(filePath, "utf-8");
+    expect(src).toMatch(
+      /export type TrayEntryScope\s*=\s*"playbook"\s*\|\s*"domain"\s*\|\s*"system"\s*\|\s*"caller"/,
+    );
+  });
+
+  it("reducer dispatch admits 'caller' without falling through to 'playbook' default", () => {
+    const filePath = join(
+      __dirname,
+      "..",
+      "..",
+      "hooks",
+      "use-pending-changes-tray.tsx",
+    );
+    const src = readFileSync(filePath, "utf-8");
+    // The reducer at line ~240 picks scope from the incoming event payload.
+    // After Slice 2, the explicit allow-list must include "caller" alongside
+    // "domain" and "system" to avoid defaulting to "playbook".
+    expect(src).toMatch(
+      /p\.scope === "domain" \|\| p\.scope === "system" \|\| p\.scope === "caller"/,
+    );
+  });
+
+  it("recompose/apply route zod schema includes caller", () => {
+    const filePath = join(
+      __dirname,
+      "..",
+      "..",
+      "app",
+      "api",
+      "recompose",
+      "apply",
+      "route.ts",
+    );
+    const src = readFileSync(filePath, "utf-8");
+    expect(src).toMatch(
+      /z\.enum\(\["playbook", "domain", "system", "caller"\]\)/,
+    );
+  });
+});

--- a/apps/admin/tests/lib/cascade/set-at-layer.test.ts
+++ b/apps/admin/tests/lib/cascade/set-at-layer.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the cascade write router (Slice 2 of #1454 / Epic #1442).
+ *
+ * Covers:
+ *   - No direct `prisma.*` import (source-import assertion)
+ *   - PLAYBOOK BEH-* → writeBehaviorTarget
+ *   - PLAYBOOK welcomeMessage → updatePlaybookConfig
+ *   - PLAYBOOK voice key → updatePlaybookConfig (writes config.voice.<key>)
+ *   - PLAYBOOK session-flow key → updatePlaybookConfig (writes config.sessionFlow.<key>)
+ *   - DOMAIN welcomeMessage → updateDomainConfig (onboardingWelcome column)
+ *   - DOMAIN identitySpecId → updateDomainConfig (onboardingIdentitySpecId column)
+ *   - CALLER BEH-* → writeCallerBehaviorTarget
+ *   - SEGMENT / CALL / SYSTEM throw with a descriptive Sprint-2 message
+ *   - No auto-creation of intermediate scope rows (writes go to exactly the requested layer)
+ *   - invalidateKnob called after successful write
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const updatePlaybookConfig = vi.fn();
+const updateDomainConfig = vi.fn();
+const writeBehaviorTarget = vi.fn();
+const writeCallerBehaviorTarget = vi.fn();
+const invalidateKnob = vi.fn();
+
+vi.mock("@/lib/playbook/update-playbook-config", () => ({
+  updatePlaybookConfig,
+}));
+vi.mock("@/lib/domain/update-domain-config", () => ({
+  updateDomainConfig,
+}));
+vi.mock("@/lib/agent-tuner/write-target", () => ({
+  writeBehaviorTarget,
+  writeCallerBehaviorTarget,
+}));
+vi.mock("@/lib/cascade/effective-value", () => ({
+  invalidateKnob,
+  // Other exports the router doesn't touch but the module loader might.
+  resolveEffective: vi.fn(),
+  invalidateAll: vi.fn(),
+  isLayerHit: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  writeBehaviorTarget.mockResolvedValue({ ok: true });
+  writeCallerBehaviorTarget.mockResolvedValue({ ok: true });
+  updatePlaybookConfig.mockResolvedValue({});
+  updateDomainConfig.mockResolvedValue({});
+});
+
+describe("set-at-layer — no direct prisma access", () => {
+  it("source file does NOT import @/lib/prisma", () => {
+    const src = readFileSync(
+      join(__dirname, "..", "..", "..", "lib", "cascade", "set-at-layer.ts"),
+      "utf-8",
+    );
+    const code = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:\/])\/\/.*$/gm, "$1");
+    expect(code).not.toMatch(/from\s+["']@\/lib\/prisma["']/);
+  });
+});
+
+describe("setKnobAtLayer — PLAYBOOK dispatch", () => {
+  it("routes BEH-* to writeBehaviorTarget", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "BEH-WARMTH",
+      layer: "PLAYBOOK",
+      scopeIds: { playbookId: "pb1" },
+      value: 0.6,
+    });
+    expect(writeBehaviorTarget).toHaveBeenCalledWith(
+      "pb1",
+      "BEH-WARMTH",
+      0.6,
+      expect.objectContaining({ source: "MANUAL" }),
+    );
+    expect(updatePlaybookConfig).not.toHaveBeenCalled();
+  });
+
+  it("routes welcomeMessage to updatePlaybookConfig", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "welcomeMessage",
+      layer: "PLAYBOOK",
+      scopeIds: { playbookId: "pb1" },
+      value: "Hi from OCEAN",
+    });
+    expect(updatePlaybookConfig).toHaveBeenCalledOnce();
+    const [pbId, transformer] = updatePlaybookConfig.mock.calls[0];
+    expect(pbId).toBe("pb1");
+    const result = transformer({});
+    expect(result.welcomeMessage).toBe("Hi from OCEAN");
+  });
+
+  it("routes voice key to updatePlaybookConfig and writes under config.voice", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "voiceId",
+      layer: "PLAYBOOK",
+      scopeIds: { playbookId: "pb1" },
+      value: "asteria",
+    });
+    expect(updatePlaybookConfig).toHaveBeenCalledOnce();
+    const [, transformer] = updatePlaybookConfig.mock.calls[0];
+    const result = transformer({});
+    expect(result.voice).toEqual({ voiceId: "asteria" });
+  });
+
+  it("routes session-flow key under config.sessionFlow", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "onboarding",
+      layer: "PLAYBOOK",
+      scopeIds: { playbookId: "pb1" },
+      value: { phases: [] },
+    });
+    expect(updatePlaybookConfig).toHaveBeenCalledOnce();
+    const [, transformer] = updatePlaybookConfig.mock.calls[0];
+    const result = transformer({});
+    expect(result.sessionFlow).toEqual({ onboarding: { phases: [] } });
+  });
+
+  it("throws when playbookId missing", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await expect(
+      setKnobAtLayer({
+        knobKey: "BEH-WARMTH",
+        layer: "PLAYBOOK",
+        scopeIds: {},
+        value: 0.6,
+      }),
+    ).rejects.toThrow(/playbookId/);
+  });
+
+  it("throws on unsupported PLAYBOOK knob", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await expect(
+      setKnobAtLayer({
+        knobKey: "identitySpecId",
+        layer: "PLAYBOOK",
+        scopeIds: { playbookId: "pb1" },
+        value: "spec-x",
+      }),
+    ).rejects.toThrow(/not implemented/);
+  });
+});
+
+describe("setKnobAtLayer — DOMAIN dispatch", () => {
+  it("routes welcomeMessage to updateDomainConfig as onboardingWelcome", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "welcomeMessage",
+      layer: "DOMAIN",
+      scopeIds: { domainId: "dom1" },
+      value: "Welcome from Education",
+    });
+    expect(updateDomainConfig).toHaveBeenCalledOnce();
+    const [, transformer] = updateDomainConfig.mock.calls[0];
+    const result = transformer({});
+    expect(result.onboardingWelcome).toBe("Welcome from Education");
+  });
+
+  it("routes identitySpecId to updateDomainConfig as onboardingIdentitySpecId", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "identitySpecId",
+      layer: "DOMAIN",
+      scopeIds: { domainId: "dom1" },
+      value: "spec-tut-001",
+    });
+    const [, transformer] = updateDomainConfig.mock.calls[0];
+    const result = transformer({});
+    expect(result.onboardingIdentitySpecId).toBe("spec-tut-001");
+  });
+});
+
+describe("setKnobAtLayer — CALLER dispatch", () => {
+  it("routes BEH-* to writeCallerBehaviorTarget", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "BEH-WARMTH",
+      layer: "CALLER",
+      scopeIds: { callerId: "c1" },
+      value: 0.8,
+    });
+    expect(writeCallerBehaviorTarget).toHaveBeenCalledWith(
+      "c1",
+      "BEH-WARMTH",
+      0.8,
+      expect.objectContaining({ source: "MANUAL" }),
+    );
+  });
+
+  it("refuses non-BEH knob at CALLER scope", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await expect(
+      setKnobAtLayer({
+        knobKey: "welcomeMessage",
+        layer: "CALLER",
+        scopeIds: { callerId: "c1" },
+        value: "hi",
+      }),
+    ).rejects.toThrow(/BEH-\*/);
+  });
+});
+
+describe("setKnobAtLayer — deferred / forbidden layers throw", () => {
+  it("SEGMENT throws Sprint-2 message", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await expect(
+      setKnobAtLayer({
+        knobKey: "BEH-WARMTH",
+        layer: "SEGMENT",
+        scopeIds: {},
+        value: 0.5,
+      }),
+    ).rejects.toThrow(/Sprint 2/);
+  });
+
+  it("CALL throws Sprint-2 message", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await expect(
+      setKnobAtLayer({
+        knobKey: "BEH-WARMTH",
+        layer: "CALL",
+        scopeIds: {},
+        value: 0.5,
+      }),
+    ).rejects.toThrow(/Sprint 2/);
+  });
+
+  it("SYSTEM throws ADMIN-only message", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await expect(
+      setKnobAtLayer({
+        knobKey: "BEH-WARMTH",
+        layer: "SYSTEM",
+        scopeIds: {},
+        value: 0.5,
+      }),
+    ).rejects.toThrow(/ADMIN-only/);
+  });
+});
+
+describe("setKnobAtLayer — cache invalidation", () => {
+  it("calls invalidateKnob with the same knobKey after a successful write", async () => {
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await setKnobAtLayer({
+      knobKey: "BEH-WARMTH",
+      layer: "PLAYBOOK",
+      scopeIds: { playbookId: "pb1" },
+      value: 0.6,
+    });
+    expect(invalidateKnob).toHaveBeenCalledWith("BEH-WARMTH");
+  });
+
+  it("does NOT invalidate when the underlying write throws", async () => {
+    writeBehaviorTarget.mockResolvedValueOnce({
+      ok: false,
+      reason: "parameter_not_adjustable",
+    });
+    const { setKnobAtLayer } = await import("@/lib/cascade/set-at-layer");
+    await expect(
+      setKnobAtLayer({
+        knobKey: "BEH-XYZ",
+        layer: "PLAYBOOK",
+        scopeIds: { playbookId: "pb1" },
+        value: 0.6,
+      }),
+    ).rejects.toThrow();
+    expect(invalidateKnob).not.toHaveBeenCalled();
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -32,6 +32,7 @@
   - [Caller](#caller)
   - [Callers](#callers)
   - [Calls](#calls)
+  - [Cascade](#cascade)
   - [Chat](#chat)
   - [Classrooms](#classrooms)
   - [Cohorts](#cohorts)
@@ -3526,6 +3527,31 @@ List call scores across all calls, ordered by most recent. Includes parameter de
 **Response** `500`
 ```json
 { ok: false, error: "Failed to fetch call scores" }
+```
+
+---
+
+## Cascade
+
+### `GET` /api/cascade/resolve
+
+Resolves the effective value of a cascade-eligible knob
+
+**Auth**: session (OPERATOR) · **Scope**: `cascade:resolve:read`
+
+**Response** `200`
+```json
+Effective<unknown> envelope: { value, source, layers, isInherited, recommendedLayerForEdit }
+```
+
+**Response** `400`
+```json
+{ ok: false, error: "Unknown knob key …" | "Missing required scope …" }
+```
+
+**Response** `403`
+```json
+(returned by requireAuth)
 ```
 
 ---
@@ -15837,8 +15863,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 506 |
-| Files with annotations | 496 |
+| Route files found | 507 |
+| Files with annotations | 497 |
 | Files missing annotations | 10 |
 | Coverage | 98.0% |
 


### PR DESCRIPTION
## Summary

Slice 2 of [story #1454](https://github.com/WANDERCOLTD/HF/issues/1454) (Epic #1442 Layer 2 — cascade-honesty UX). Builds on **Slice 1 (PR #1462)** to make the cascade primitive write-capable and reachable from a UI / curl. **Stacked on #1462** — recommend merging in order; this PR's diff shows only the Slice 2 changes once Slice 1 lands.

## Three pieces

### 1. `lib/cascade/set-at-layer.ts` — write router

Dispatches by \`(layer, knobKey)\` to the canonical write helper for the combination. **Never calls \`prisma.*\` directly** (verified by source-import test):

| Layer | knob family | Routes to |
|---|---|---|
| PLAYBOOK | \`BEH-*\` | \`writeBehaviorTarget\` |
| PLAYBOOK | \`welcomeMessage\` | \`updatePlaybookConfig\` (config.welcomeMessage) |
| PLAYBOOK | \`voiceProvider\`/\`voiceId\`/\`model\`/etc. | \`updatePlaybookConfig\` (config.voice.\<key\>) |
| PLAYBOOK | \`onboarding\`/\`intake\`/\`stops\`/\`offboarding\` | \`updatePlaybookConfig\` (config.sessionFlow.\<key\>) |
| DOMAIN | \`welcomeMessage\` | \`updateDomainConfig\` (\`onboardingWelcome\` column) |
| DOMAIN | \`identitySpecId\` | \`updateDomainConfig\` (\`onboardingIdentitySpecId\` column) |
| CALLER | \`BEH-*\` | \`writeCallerBehaviorTarget\` |
| SEGMENT / CALL | any | throws \"not implemented in Sprint 1 — Sprint 2\" |
| SYSTEM | any | throws \"ADMIN-only, not implemented in Sprint 1\" |

After every successful write: \`invalidateKnob(knobKey)\`. No auto-creation of intermediate scope rows (ADR §6 non-goal — SharePoint Limited Access anti-pattern).

### 2. \`GET /api/cascade/resolve\` — inspector payload route

\`requireAuth(\"OPERATOR\")\`. Query params: \`knobKey\` (required) + \`playbookId\`/\`callerId\`/\`domainId\` (optional). Returns the \`Effective\<T\>\` envelope as JSON.

\`\`\`bash
curl -s 'https://dev.humanfirstfoundation.com/api/cascade/resolve?knobKey=BEH-WARMTH&playbookId=eebf437a-...&callerId=a3ffcf41-...' \\
  -b cookies.txt
\`\`\`

Returns:
\`\`\`json
{
  \"knobKey\": \"BEH-WARMTH\",
  \"value\": 0.6,
  \"source\": \"DOMAIN\",
  \"layers\": [
    { \"layer\": \"SYSTEM\", \"scopeId\": null, \"scopeLabel\": \"System default\", \"value\": 0.5, \"setAt\": null, \"setBy\": null },
    { \"layer\": \"DOMAIN\", \"scopeId\": \"edu-001\", \"scopeLabel\": \"Education\", \"value\": 0.6, \"setAt\": \"2026-05-22T00:00:00Z\", \"setBy\": null }
  ],
  \"isInherited\": true,
  \"recommendedLayerForEdit\": \"PLAYBOOK\"
}
\`\`\`

Error responses: 400 (unknown knob / missing required scope), 404 (entity not found), 500 (unexpected). 403 from \`requireAuth\` for VIEWER.

### 3. \`TrayEntryScope \"caller\"\` addition + plumbing

- \`hooks/use-pending-changes-tray.tsx\` — union now includes \`\"caller\"\`. Reducer explicit allow-list extended (no fallthrough to \`\"playbook\"\` default).
- \`app/api/recompose/apply/route.ts\` — zod schema enum now includes \`\"caller\"\`. CALLER-scope tray entries don't need a recompose fanout because \`writeCallerBehaviorTarget\` already calls \`bumpCallerComposeTimestamp\` internally.

## Cache-invalidation coverage (closes Slice 1 forward-flag)

Slice 1's TODO at \`effective-value.ts:173\` flagged that existing mutators didn't self-invalidate the cascade cache. Closed in this PR:

- \`updatePlaybookConfig\` / \`updateDomainConfig\` → \`invalidateAll()\` (coarse — cheaper than diffing the JSON blob)
- \`writeBehaviorTarget\` / \`writeCallerBehaviorTarget\` → fine-grained \`invalidateKnob(parameterId)\`

Same-session read-after-write race window across all non-cascade write paths is now closed.

## Test plan

- [x] \`npx tsc --noEmit\` — clean for changed files (pre-existing unrelated TS error in \`update-domain-config.ts:106\` fixed as part of this PR — \`Prisma.DomainUpdateInput\` cast for JSON columns)
- [x] \`npx eslint\` — 0 errors (1 pre-existing warning at \`use-pending-changes-tray.tsx:186\` unchanged)
- [x] \`npx vitest run\` — 69/69 green (43 Slice 1 + 26 new: 16 set-at-layer, 7 cascade-resolve route, 3 tray-scope regression)
- [ ] Once deployed, smoke against a demo caller on hf_sandbox:
  \`\`\`bash
  curl -s 'https://dev.humanfirstfoundation.com/api/cascade/resolve?knobKey=BEH-WARMTH&playbookId=eebf437a-62c7-4389-9d87-081a1557ba3b&callerId=a3ffcf41-f95b-4105-bafd-a7467a40d7d8' -b cookies.txt | jq
  \`\`\`

## What's still NOT in (Slice 3)

- \`<LayerBadge>\` chip + inline subtitle
- \`<CascadeInspectorTray>\` slide-in tray
- \`<ScopePicker>\` write affordance
- Wire into the Course Design Console (First-call settings panel + Preview lens)

## Refs

- Story: #1454
- Epic: #1442
- ADR: #1450
- Slice 1: #1462 (depends on — merge first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)