### PR TITLE
fix(course-design): #1418 Preview honest about onboarding source

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -33,6 +33,7 @@ import {
   type SessionFlowLens,
 } from "@/components/session-flow/SessionFlowEditor";
 import "./preview-lens.css";
+import { emptyOnboardingBubble } from "./empty-onboarding-bubble";
 
 interface PreviewLensProps {
   courseId: string;
@@ -51,6 +52,16 @@ interface SessionFlowResp {
     welcomeMessage: string | null;
     offboarding: { phases: Array<{ phase: string }>; triggerAfterCalls?: number };
     stops: Array<{ id: string; kind: string; trigger?: { type: string; threshold?: number; count?: number } }>;
+    /** Provenance — which layer of the cascade supplied each section's
+     *  value. Used by the empty-state copy below (#1418) to distinguish
+     *  "explicitly disabled" from "never configured / using INIT-001". */
+    source?: {
+      intake?: "new-shape" | "legacy-welcome" | "defaults";
+      onboarding?: "new-shape" | "playbook-legacy" | "domain" | "init001";
+      stops?: "new-shape" | "synthesized-from-legacy";
+      offboarding?: "new-shape" | "playbook-legacy" | "defaults";
+      welcomeMessage?: "playbook" | "domain" | "generic";
+    };
   };
   courseName?: string;
   error?: string;
@@ -392,10 +403,16 @@ function buildTranscript(flow: SessionFlowResp | null): PreviewItem[] {
       });
     }
   } else {
+    // #1418 — distinguish "explicitly disabled" from "never configured".
+    // Pre-fix both states landed here with the same INIT-001 fallback
+    // copy; the resolver's `source` carries the distinction.
+    const bubble = emptyOnboardingBubble(sf.source?.onboarding);
     items.push({
-      kind: "bubble", side: "bot", lens: "onboarding", lensLabel: "Add Onboarding phases", ghost: true,
-      caption: "No onboarding phases configured",
-      text: "(falls back to INIT-001 default phases)",
+      kind: "bubble", side: "bot", lens: "onboarding",
+      lensLabel: bubble.lensLabel,
+      ghost: true,
+      caption: bubble.caption,
+      text: bubble.text,
     });
   }
 

--- a/apps/admin/app/x/courses/[courseId]/_components/empty-onboarding-bubble.ts
+++ b/apps/admin/app/x/courses/[courseId]/_components/empty-onboarding-bubble.ts
@@ -1,0 +1,54 @@
+/**
+ * Empty-onboarding bubble copy decision (#1418).
+ *
+ * When the resolved session-flow has zero onboarding phases, the Preview
+ * lens needs to distinguish "educator explicitly opted out" from "never
+ * configured — INIT-001 is genuinely the runtime path". The pre-#1418
+ * code surfaced the same `(falls back to INIT-001 default phases)` copy
+ * for both states, which misled educators into re-editing settings they
+ * had intentionally cleared.
+ *
+ * The resolver at `lib/session-flow/resolver.ts::resolveOnboarding`
+ * exposes the distinction via its `source` field — this helper maps
+ * that field to the right educator-facing copy.
+ *
+ * Extracted into a pure module so it can be unit-tested without the
+ * surrounding Course Design Console scaffolding.
+ */
+
+export type OnboardingSource =
+  | "new-shape"
+  | "playbook-legacy"
+  | "domain"
+  | "init001"
+  | undefined;
+
+export interface EmptyOnboardingBubble {
+  caption: string;
+  text: string;
+  lensLabel: string;
+}
+
+export function emptyOnboardingBubble(
+  source: OnboardingSource,
+): EmptyOnboardingBubble {
+  if (source === "new-shape" || source === "playbook-legacy") {
+    return {
+      caption: "Onboarding explicitly disabled",
+      text: "(call 1 goes straight to teaching — no onboarding phases will run)",
+      lensLabel: "Edit Onboarding",
+    };
+  }
+  if (source === "domain") {
+    return {
+      caption: "Using Domain default onboarding",
+      text: "(edit at the domain level to add phases — this course has no override)",
+      lensLabel: "Add Onboarding phases",
+    };
+  }
+  return {
+    caption: "No onboarding phases configured",
+    text: "(falls back to INIT-001 default phases)",
+    lensLabel: "Add Onboarding phases",
+  };
+}

--- a/apps/admin/tests/components/course-design/empty-onboarding-bubble.test.ts
+++ b/apps/admin/tests/components/course-design/empty-onboarding-bubble.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the empty-onboarding bubble copy decision (#1418).
+ *
+ * Pre-fix: every empty-phases path landed on the INIT-001 fallback copy.
+ * Post-fix: the resolver `source` distinguishes explicitly-disabled from
+ * never-configured from domain-default cases.
+ */
+
+import { describe, it, expect } from "vitest";
+import { emptyOnboardingBubble } from "@/app/x/courses/[courseId]/_components/empty-onboarding-bubble";
+
+describe("emptyOnboardingBubble", () => {
+  it("source 'new-shape' → educator explicitly disabled onboarding", () => {
+    const b = emptyOnboardingBubble("new-shape");
+    expect(b.caption).toBe("Onboarding explicitly disabled");
+    expect(b.text).toMatch(/straight to teaching/);
+    expect(b.lensLabel).toBe("Edit Onboarding");
+  });
+
+  it("source 'playbook-legacy' → same as new-shape (both are educator-owned)", () => {
+    const b = emptyOnboardingBubble("playbook-legacy");
+    expect(b.caption).toBe("Onboarding explicitly disabled");
+    expect(b.text).toMatch(/straight to teaching/);
+  });
+
+  it("source 'domain' → domain default applies, edit at domain", () => {
+    const b = emptyOnboardingBubble("domain");
+    expect(b.caption).toBe("Using Domain default onboarding");
+    expect(b.text).toMatch(/domain level/);
+    expect(b.lensLabel).toBe("Add Onboarding phases");
+  });
+
+  it("source 'init001' → INIT-001 fallback is GENUINELY active (existing copy preserved)", () => {
+    const b = emptyOnboardingBubble("init001");
+    expect(b.caption).toBe("No onboarding phases configured");
+    expect(b.text).toBe("(falls back to INIT-001 default phases)");
+    expect(b.lensLabel).toBe("Add Onboarding phases");
+  });
+
+  it("source undefined (absent from API response) → falls back to INIT-001 copy", () => {
+    const b = emptyOnboardingBubble(undefined);
+    expect(b.caption).toBe("No onboarding phases configured");
+    expect(b.text).toBe("(falls back to INIT-001 default phases)");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1418. Preview lens onboarding bubble now distinguishes \"educator explicitly disabled\" from \"never configured / INIT-001 fallback\" from \"using Domain default\" — three real states that previously all rendered as the misleading \"falls back to INIT-001 default phases\" copy.

The fix routes through the resolver's existing \`source\` field (no backend change needed) via a new pure helper \`emptyOnboardingBubble(source)\` extracted into its own module for tractable unit testing.

## Three states post-fix

| Resolver \`source\` | \`phases.length\` | Copy shown |
|---|---|---|
| \`new-shape\` / \`playbook-legacy\` | 0 | \"Onboarding explicitly disabled — call 1 goes straight to teaching\" |
| \`domain\` | 0 | \"Using Domain default onboarding — edit at the domain level\" |
| \`init001\` / \`defaults\` / undefined | 0 | \"No onboarding phases configured — (falls back to INIT-001 default phases)\" (existing copy, now shown only when warranted) |
| any | > 0 | Unchanged phase bubbles |

## Files

| File | Change |
|---|---|
| \`app/x/courses/[courseId]/_components/PreviewLens.tsx\` | Extend local \`SessionFlowResp\` type with \`source\` field; call new helper from the else-branch |
| \`app/x/courses/[courseId]/_components/empty-onboarding-bubble.ts\` | New — pure helper, testable |
| \`tests/components/course-design/empty-onboarding-bubble.test.ts\` | 5 vitests: every distinct source value + undefined |

## Test plan

- [x] \`npx tsc --noEmit\` — no new errors on changed files
- [x] \`npx vitest run tests/components/course-design/empty-onboarding-bubble.test.ts\` — 5/5 green
- [ ] After deploy: visit \`/x/courses/<id>?tab=design\` on a course with \`sessionFlow.onboarding = {phases:[]}\` — bubble should now read \"Onboarding explicitly disabled\"

## Deploy

\`/vm-cp\` — no migration, pure client-type extension + display fix.

## Refs

- Closes #1418
- Theme: Course Design Console truthfulness (siblings: #1417, #1403, #1405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)