### PR TITLE
fix(course-design): #1417 First-call panel reveals BehaviorTarget rows

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/design/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/design/route.ts
@@ -27,7 +27,105 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import { prisma } from "@/lib/prisma";
 import type { WelcomeConfig, NpsConfig, PlaybookConfig } from "@/lib/types/json-fields";
+
+/**
+ * @api GET /api/courses/[courseId]/design
+ * @visibility internal
+ * @scope course:read
+ * @auth session (OPERATOR+)
+ * @tags course, design, first-session-targets
+ * @description Returns the merged "first-call behaviour targets" payload
+ *   that the FirstSessionSettings panel renders. Merges TWO sources at
+ *   PLAYBOOK scope — `Playbook.config.firstSessionTargets` (educator-
+ *   owned via this panel's Save) AND `BehaviorTarget(scope=PLAYBOOK)`
+ *   rows (written by AgentTuner / Cmd+K). Each merged row carries an
+ *   `origin` so the panel can render `behaviorTarget` rows read-only
+ *   (#1417). Identical `parameterId` in both sources produces TWO rows
+ *   (no silent dedup) so the educator can resolve the conflict.
+ * @response 200 { ok: true, rows: Array<{ parameterId, value, origin: "firstSessionTargets" | "behaviorTarget" }>, firstCallMode? }
+ * @response 404 { ok: false, error: "Course not found" }
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  try {
+    const { courseId } = await params;
+
+    const playbook = await prisma.playbook.findUnique({
+      where: { id: courseId },
+      select: { id: true, config: true },
+    });
+    if (!playbook) {
+      return NextResponse.json(
+        { ok: false, error: "Course not found" },
+        { status: 404 },
+      );
+    }
+
+    const cfg = (playbook.config ?? {}) as PlaybookConfig;
+    const fst = cfg.firstSessionTargets ?? {};
+
+    const behaviorRows = await prisma.behaviorTarget.findMany({
+      where: {
+        playbookId: courseId,
+        scope: "PLAYBOOK",
+        effectiveUntil: null,
+      },
+      select: {
+        parameterId: true,
+        targetValue: true,
+        source: true,
+        updatedAt: true,
+      },
+      orderBy: { parameterId: "asc" },
+    });
+
+    type MergedRow = {
+      parameterId: string;
+      value: number;
+      origin: "firstSessionTargets" | "behaviorTarget";
+      source?: string;
+      updatedAt?: string;
+    };
+
+    const rows: MergedRow[] = [];
+    for (const [parameterId, v] of Object.entries(fst)) {
+      rows.push({
+        parameterId,
+        value: typeof v.value === "number" ? v.value : 0,
+        origin: "firstSessionTargets",
+      });
+    }
+    for (const r of behaviorRows) {
+      rows.push({
+        parameterId: r.parameterId,
+        value: r.targetValue,
+        origin: "behaviorTarget",
+        source: r.source,
+        updatedAt: r.updatedAt.toISOString(),
+      });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      rows,
+      firstCallMode: cfg.firstCallMode ?? null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[api/courses/:courseId/design GET] error", err);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 },
+    );
+  }
+}
 
 export async function PUT(
   req: NextRequest,

--- a/apps/admin/components/course-design/FirstSessionSettings.tsx
+++ b/apps/admin/components/course-design/FirstSessionSettings.tsx
@@ -64,6 +64,21 @@ interface TargetOverrideRow {
   value: number;
 }
 
+/**
+ * Read-only row sourced from `BehaviorTarget(scope=PLAYBOOK)` (#1417).
+ * These rows are visible in this panel but are NOT editable here — the
+ * canonical write surface is the AgentTuner / Cmd+K. We surface them so
+ * educators don't see "No overrides set" when targets are live; pre-fix
+ * three live rows on the OCEAN course were invisible because the panel
+ * only read `playbook.config.firstSessionTargets`.
+ */
+interface BehaviorTargetRow {
+  parameterId: string;
+  value: number;
+  source: string | null;
+  updatedAt: string | null;
+}
+
 const FIRST_CALL_MODE_OPTIONS: Array<{
   value: FirstCallMode;
   label: string;
@@ -137,6 +152,46 @@ export function FirstSessionSettings({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+
+  // #1417 — read-only BehaviorTarget(scope=PLAYBOOK) rows merged in
+  // from `GET /api/courses/[courseId]/design`. Fetched on mount so the
+  // panel reflects what compose sees, not just what this panel writes.
+  const [behaviorRows, setBehaviorRows] = useState<BehaviorTargetRow[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetch(`/api/courses/${courseId}/design`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json: {
+        ok?: boolean;
+        rows?: Array<{
+          parameterId: string;
+          value: number;
+          origin: "firstSessionTargets" | "behaviorTarget";
+          source?: string;
+          updatedAt?: string;
+        }>;
+      } | null) => {
+        if (!alive || !json?.ok || !json.rows) return;
+        // We only need the behaviorTarget-origin rows; firstSessionTargets
+        // come from `playbookConfig` prop already.
+        setBehaviorRows(
+          json.rows
+            .filter((r) => r.origin === "behaviorTarget")
+            .map((r) => ({
+              parameterId: r.parameterId,
+              value: r.value,
+              source: r.source ?? null,
+              updatedAt: r.updatedAt ?? null,
+            })),
+        );
+      })
+      .catch(() => {
+        /* read-only merged display is non-critical — silently no-op */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [courseId]);
 
   // #798 — course-ref Layer-0 override preview. Read-only fetch on mount.
   const [courseRefPreview, setCourseRefPreview] = useState<Call1OverridePreview | null>(null);
@@ -274,11 +329,54 @@ export function FirstSessionSettings({
           exists. Falls back to domain defaults when not set.
         </div>
 
-        {rows.length === 0 ? (
+        {/* #1417 — read-only BehaviorTarget(scope=PLAYBOOK) rows. Edit
+            from the AgentTuner / Cmd+K; not editable here. */}
+        {behaviorRows.length > 0 ? (
+          <div className="hf-flex-col hf-gap-xs hf-mb-sm">
+            {behaviorRows.map((row) => {
+              const param = COMMON_BEHAVIOR_PARAMS.find(
+                (p) => p.id === row.parameterId,
+              );
+              const conflicts = rows.some(
+                (r) => r.parameterId === row.parameterId,
+              );
+              return (
+                <div
+                  key={`bt-${row.parameterId}`}
+                  className="hf-flex hf-gap-sm hf-items-center"
+                  data-origin="behaviorTarget"
+                  title={conflicts
+                    ? `Conflict: ${row.parameterId} is also in firstSessionTargets. BehaviorTarget rows win at compose time — remove the duplicate firstSessionTargets entry to clear the conflict.`
+                    : `Managed via AgentTuner — edit from the Tuning tab. Source: ${row.source ?? "MANUAL"}.`}
+                >
+                  <span className="hf-input hf-text-xs hf-text-muted" style={{ minWidth: 0 }}>
+                    {param?.label ?? row.parameterId} ({row.parameterId})
+                  </span>
+                  <span
+                    className="hf-input hf-text-xs hf-text-muted hf-text-center"
+                    aria-label={`Current value ${row.value.toFixed(2)} (read-only)`}
+                  >
+                    {row.value.toFixed(2)}
+                  </span>
+                  <span className="hf-category-label" data-tone="info">
+                    Managed via AgentTuner
+                  </span>
+                  {conflicts ? (
+                    <span className="hf-category-label" data-tone="warning">
+                      Conflict with editable row
+                    </span>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+
+        {rows.length === 0 && behaviorRows.length === 0 ? (
           <div className="hf-empty hf-text-xs hf-text-muted hf-mb-sm">
             No overrides set — domain defaults apply.
           </div>
-        ) : (
+        ) : rows.length === 0 ? null : (
           <div className="hf-flex-col hf-gap-sm hf-mb-sm">
             {rows.map((row, i) => (
               <div

--- a/apps/admin/tests/app/api/courses-design-get.test.ts
+++ b/apps/admin/tests/app/api/courses-design-get.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the new GET /api/courses/[courseId]/design (#1417).
+ *
+ * Pre-fix the FirstSessionSettings panel only knew about
+ * `playbook.config.firstSessionTargets` — `BehaviorTarget(scope=PLAYBOOK)`
+ * rows were invisible. This GET merges both sources with an `origin`
+ * field so the panel can show what compose actually sees.
+ *
+ * Covers:
+ *   - 200 with merged rows (both sources populated)
+ *   - 200 with only firstSessionTargets
+ *   - 200 with only BehaviorTarget rows
+ *   - 200 with empty rows when neither populated
+ *   - 200 returns DUPLICATE entries (no silent dedup) for the conflict
+ *     case (same parameterId in both sources)
+ *   - 404 when playbook not found
+ *   - requireAuth gated
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const requireAuth = vi.fn();
+const isAuthError = vi.fn();
+
+const prismaMock = {
+  playbook: { findUnique: vi.fn() },
+  behaviorTarget: { findMany: vi.fn() },
+};
+
+vi.mock("@/lib/permissions", () => ({ requireAuth, isAuthError }));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/playbook/update-playbook-config", () => ({
+  updatePlaybookConfig: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isAuthError.mockReturnValue(false);
+  requireAuth.mockResolvedValue({ session: { user: { id: "u1" } } });
+});
+
+function makeRequest(): import("next/server").NextRequest {
+  return new Request("http://localhost:3000/api/courses/c1/design") as unknown as
+    import("next/server").NextRequest;
+}
+
+const PARAMS = { params: Promise.resolve({ courseId: "c1" }) };
+
+describe("GET /api/courses/[courseId]/design — #1417", () => {
+  it("returns merged rows when both sources populated", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "c1",
+      config: {
+        firstSessionTargets: { "BEH-WARMTH": { value: 0.7 } },
+        firstCallMode: "teach_immediately",
+      },
+    });
+    prismaMock.behaviorTarget.findMany.mockResolvedValueOnce([
+      {
+        parameterId: "BEH-CHALLENGE-LEVEL",
+        targetValue: 0.4,
+        source: "MANUAL",
+        updatedAt: new Date("2026-05-22T00:00:00Z"),
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/courses/[courseId]/design/route");
+    const res = await GET(makeRequest(), PARAMS);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.firstCallMode).toBe("teach_immediately");
+    expect(body.rows).toHaveLength(2);
+    expect(body.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          parameterId: "BEH-WARMTH",
+          origin: "firstSessionTargets",
+        }),
+        expect.objectContaining({
+          parameterId: "BEH-CHALLENGE-LEVEL",
+          origin: "behaviorTarget",
+          source: "MANUAL",
+        }),
+      ]),
+    );
+  });
+
+  it("returns only firstSessionTargets rows when no BehaviorTarget exists", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "c1",
+      config: { firstSessionTargets: { "BEH-WARMTH": { value: 0.7 } } },
+    });
+    prismaMock.behaviorTarget.findMany.mockResolvedValueOnce([]);
+
+    const { GET } = await import("@/app/api/courses/[courseId]/design/route");
+    const res = await GET(makeRequest(), PARAMS);
+
+    const body = await res.json();
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].origin).toBe("firstSessionTargets");
+  });
+
+  it("returns only behaviorTarget rows when firstSessionTargets is empty (the pre-fix invisible state)", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "c1",
+      config: {},
+    });
+    prismaMock.behaviorTarget.findMany.mockResolvedValueOnce([
+      {
+        parameterId: "BEH-RESPONSE-LEN",
+        targetValue: 0.2,
+        source: "MANUAL",
+        updatedAt: new Date("2026-06-09T00:00:00Z"),
+      },
+      {
+        parameterId: "BEH-TURN-LENGTH",
+        targetValue: 0.2,
+        source: "MANUAL",
+        updatedAt: new Date("2026-06-09T00:00:00Z"),
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/courses/[courseId]/design/route");
+    const res = await GET(makeRequest(), PARAMS);
+    const body = await res.json();
+
+    expect(body.rows).toHaveLength(2);
+    body.rows.forEach((r: { origin: string }) =>
+      expect(r.origin).toBe("behaviorTarget"),
+    );
+  });
+
+  it("returns DUPLICATE entries (no silent dedup) when same parameterId in both sources", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "c1",
+      config: { firstSessionTargets: { "BEH-WARMTH": { value: 0.7 } } },
+    });
+    prismaMock.behaviorTarget.findMany.mockResolvedValueOnce([
+      {
+        parameterId: "BEH-WARMTH",
+        targetValue: 0.4,
+        source: "MANUAL",
+        updatedAt: new Date("2026-05-22T00:00:00Z"),
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/courses/[courseId]/design/route");
+    const res = await GET(makeRequest(), PARAMS);
+    const body = await res.json();
+
+    expect(body.rows).toHaveLength(2);
+    const origins = body.rows.map(
+      (r: { parameterId: string; origin: string }) => r.origin,
+    );
+    expect(origins).toContain("firstSessionTargets");
+    expect(origins).toContain("behaviorTarget");
+  });
+
+  it("returns empty rows when neither source has entries", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({ id: "c1", config: {} });
+    prismaMock.behaviorTarget.findMany.mockResolvedValueOnce([]);
+
+    const { GET } = await import("@/app/api/courses/[courseId]/design/route");
+    const res = await GET(makeRequest(), PARAMS);
+    const body = await res.json();
+    expect(body.rows).toEqual([]);
+  });
+
+  it("returns 404 when playbook not found", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce(null);
+
+    const { GET } = await import("@/app/api/courses/[courseId]/design/route");
+    const res = await GET(makeRequest(), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 from requireAuth when not authorised", async () => {
+    isAuthError.mockReturnValueOnce(true);
+    requireAuth.mockResolvedValueOnce({
+      error: new Response("forbidden", { status: 403 }),
+    });
+    const { GET } = await import("@/app/api/courses/[courseId]/design/route");
+    const res = await GET(makeRequest(), PARAMS);
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/admin/tests/components/course-design/FirstSessionSettings-behaviorTarget.test.tsx
+++ b/apps/admin/tests/components/course-design/FirstSessionSettings-behaviorTarget.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for FirstSessionSettings rendering BehaviorTarget(scope=PLAYBOOK)
+ * rows surfaced via the new GET /api/courses/[courseId]/design (#1417).
+ *
+ * Covers:
+ *   - read-only behaviorTarget row appears with "Managed via AgentTuner"
+ *     badge
+ *   - "No overrides set" empty state appears ONLY when both sources empty
+ *   - editable firstSessionTargets path unchanged when behaviorTarget rows
+ *     are present (no regression on the existing editor)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor, screen } from "@testing-library/react";
+import { FirstSessionSettings } from "@/components/course-design/FirstSessionSettings";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  // FirstSessionSettings issues TWO mount fetches: the existing
+  // `call1-override-preview` (#798) AND the new `/design` GET (#1417).
+  // Tests below override the `/design` response per-case; this fallback
+  // catches the preview call and any other request.
+  fetchMock.mockImplementation((url: string) => {
+    if (typeof url === "string" && url.includes("/call1-override-preview")) {
+      return Promise.resolve(jsonRes({ ok: true, count: 0, samples: [], rangeFormCount: 0 }));
+    }
+    return Promise.resolve(jsonRes({ ok: true, rows: [] }));
+  });
+});
+
+function mockDesignResponse(body: unknown) {
+  fetchMock.mockImplementation((url: string) => {
+    if (typeof url === "string" && url.includes("/call1-override-preview")) {
+      return Promise.resolve(jsonRes({ ok: true, count: 0, samples: [], rangeFormCount: 0 }));
+    }
+    if (typeof url === "string" && url.includes("/design")) {
+      return Promise.resolve(jsonRes(body));
+    }
+    return Promise.resolve(jsonRes({ ok: true }));
+  });
+}
+
+describe("FirstSessionSettings — #1417 BehaviorTarget row visibility", () => {
+  it("renders read-only behaviorTarget row with Managed badge", async () => {
+    mockDesignResponse({
+      ok: true,
+      rows: [
+        {
+          parameterId: "BEH-RESPONSE-LEN",
+          value: 0.2,
+          origin: "behaviorTarget",
+          source: "MANUAL",
+          updatedAt: "2026-06-09T00:00:00.000Z",
+        },
+      ],
+      firstCallMode: null,
+    });
+
+    render(<FirstSessionSettings courseId="c1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Managed via AgentTuner")).toBeTruthy();
+    });
+    expect(screen.getByText(/BEH-RESPONSE-LEN/)).toBeTruthy();
+    expect(
+      screen.queryByText("No overrides set — domain defaults apply."),
+    ).toBeNull();
+  });
+
+  it("shows 'No overrides set' only when BOTH sources are empty", async () => {
+    mockDesignResponse({ ok: true, rows: [], firstCallMode: null });
+
+    render(<FirstSessionSettings courseId="c1" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No overrides set — domain defaults apply."),
+      ).toBeTruthy();
+    });
+  });
+
+  it("flags conflict when same parameterId exists in both sources", async () => {
+    mockDesignResponse({
+      ok: true,
+      rows: [
+        {
+          parameterId: "BEH-WARMTH",
+          value: 0.4,
+          origin: "behaviorTarget",
+          source: "MANUAL",
+          updatedAt: "2026-05-22T00:00:00.000Z",
+        },
+      ],
+      firstCallMode: null,
+    });
+
+    render(
+      <FirstSessionSettings
+        courseId="c1"
+        playbookConfig={{
+          firstSessionTargets: { "BEH-WARMTH": { value: 0.7 } },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Managed via AgentTuner")).toBeTruthy();
+    });
+    expect(screen.getByText("Conflict with editable row")).toBeTruthy();
+  });
+
+  it("editable firstSessionTargets rows remain editable when behaviorTarget rows are also present", async () => {
+    mockDesignResponse({
+      ok: true,
+      rows: [
+        {
+          parameterId: "BEH-RESPONSE-LEN",
+          value: 0.2,
+          origin: "behaviorTarget",
+          source: "MANUAL",
+          updatedAt: "2026-06-09T00:00:00.000Z",
+        },
+      ],
+      firstCallMode: null,
+    });
+
+    render(
+      <FirstSessionSettings
+        courseId="c1"
+        playbookConfig={{
+          firstSessionTargets: { "BEH-WARMTH": { value: 0.7 } },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Managed via AgentTuner")).toBeTruthy();
+    });
+    // The editable repeater renders a `<input type="range">` per row.
+    const sliders = document.querySelectorAll('input[type="range"]');
+    expect(sliders.length).toBe(1); // firstSessionTargets row only; behaviorTarget is read-only
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -5343,6 +5343,24 @@ Read-only preview of `ContentAssertion` rows scoped to this
 
 ---
 
+### `GET` /api/courses/[courseId]/design
+
+Returns the merged "first-call behaviour targets" payload
+
+**Auth**: session (OPERATOR+) · **Scope**: `course:read`
+
+**Response** `200`
+```json
+{ ok: true, rows: Array<{ parameterId, value, origin: "firstSessionTargets" | "behaviorTarget" }>, firstCallMode? }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+---
+
 ### `PUT` /api/courses/[courseId]/design
 
 Save student experience design config. Writes to


### PR DESCRIPTION
## Summary

Closes #1417. First-call AI behaviour-targets panel now reveals \`BehaviorTarget(scope=PLAYBOOK)\` rows alongside the editable \`firstSessionTargets\` config — pre-fix, three live BehaviorTarget rows on the OCEAN course were invisible to the educator, who saw \"No overrides set — domain defaults apply.\"

Stacked on #1464 (Slice 3 — cascade components). Does not consume the cascade primitive directly (the groomed manual-merge approach is more efficient for this panel than per-knob \`resolveEffective\` calls); the LayerBadge component is the natural next iteration once consumer feedback validates the read-only-row pattern.

## Three pieces

### 1. New \`GET /api/courses/[courseId]/design\`

\`requireAuth(\"OPERATOR\")\`. Merges \`Playbook.config.firstSessionTargets\` + \`BehaviorTarget(scope=PLAYBOOK)\` rows into one \`rows[]\` payload, each tagged with \`origin\`:

\`\`\`json
{
  \"ok\": true,
  \"firstCallMode\": \"teach_immediately\",
  \"rows\": [
    { \"parameterId\": \"BEH-WARMTH\", \"value\": 0.7, \"origin\": \"firstSessionTargets\" },
    { \"parameterId\": \"BEH-RESPONSE-LEN\", \"value\": 0.2, \"origin\": \"behaviorTarget\", \"source\": \"MANUAL\", \"updatedAt\": \"2026-06-09T00:00:00.000Z\" }
  ]
}
\`\`\`

Same \`parameterId\` in both sources → TWO rows (no silent dedup), so the educator can resolve the conflict.

### 2. \`FirstSessionSettings\` useEffect on mount

Mirrors the existing \`call1-override-preview\` fetch pattern. Pulls the merged rows; keeps only the \`behaviorTarget\`-origin ones (firstSessionTargets already come from the parent's \`playbookConfig\` prop). Non-critical — silently no-ops on error.

### 3. Render BehaviorTarget rows above the editable repeater

Each row renders read-only:
- Parameter label + value (no slider)
- \"Managed via AgentTuner\" badge (\`hf-category-label data-tone=\"info\"\`)
- \"Conflict with editable row\" badge (\`data-tone=\"warning\"\`) when same \`parameterId\` exists in both sources
- \`title\` tooltip explaining the precedence + how to clear the conflict

Empty state (\"No overrides set — domain defaults apply\") appears ONLY when BOTH sources are empty.

## What did NOT change

- Write path is unchanged — Save still POSTs only \`firstSessionTargets\`. AgentTuner / Cmd+K remain the canonical write surface for BehaviorTarget rows.
- \`mergeTargets\` precedence logic is untouched.
- No migration, no compose-path change.

## Test plan

- [x] \`npx tsc --noEmit\` — clean for changed files
- [x] \`npx vitest run\` — 11/11 green (7 GET-route, 4 component RTL covering all paths from the AC table)
- [ ] After deploy, visit \`/x/courses/eebf437a-…?tab=design\` → First-call panel should now show the 3 OCEAN \`BehaviorTarget\` rows from the 2026-06-09 tuning session, each badged \"Managed via AgentTuner\"

## Deploy

\`/vm-cp\` — pure read-side fix, no migration.

## Refs

- Closes #1417
- Theme: Course Design Console truthfulness (siblings: #1418, #1403, #1405)
- Stacked on: #1464 (Slice 3 cascade components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)