### PR TITLE
feat(course-design): wire LayerBadge + InspectorTray into FirstSessionSettings

### DIFF
--- a/apps/admin/components/course-design/FirstSessionSettings.tsx
+++ b/apps/admin/components/course-design/FirstSessionSettings.tsx
@@ -26,6 +26,9 @@
 
 import { useEffect, useState } from "react";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { LayerBadge } from "@/components/cascade/LayerBadge";
+import { CascadeInspectorTray } from "@/components/cascade/CascadeInspectorTray";
+import type { Effective } from "@/lib/cascade/layer-types";
 
 interface Call1OverrideSample {
   id: string;
@@ -157,6 +160,13 @@ export function FirstSessionSettings({
   // from `GET /api/courses/[courseId]/design`. Fetched on mount so the
   // panel reflects what compose sees, not just what this panel writes.
   const [behaviorRows, setBehaviorRows] = useState<BehaviorTargetRow[]>([]);
+
+  // #1454 wire-up — knob currently open in the CascadeInspectorTray.
+  // The chip on each row sets this; closing the tray clears it.
+  const [inspecting, setInspecting] = useState<{
+    parameterId: string;
+    label: string;
+  } | null>(null);
   useEffect(() => {
     let alive = true;
     fetch(`/api/courses/${courseId}/design`)
@@ -216,6 +226,36 @@ export function FirstSessionSettings({
   }, [courseId]);
 
   const signpost = readSignpostState(cfg);
+
+  /**
+   * #1454 — Synthesize a chip-ready Effective<number> envelope from a
+   * row we already know is PLAYBOOK-scope. The chip only needs the
+   * winning layer; clicking opens the inspector tray which fetches the
+   * full chain (SYSTEM + DOMAIN + PLAYBOOK + ...) from
+   * `GET /api/cascade/resolve`.
+   */
+  function envelopeFor(
+    parameterId: string,
+    value: number,
+    setAt: string | null,
+  ): Effective<number> {
+    return {
+      value,
+      source: "PLAYBOOK",
+      layers: [
+        {
+          layer: "PLAYBOOK",
+          scopeId: courseId,
+          scopeLabel: "this Course",
+          value,
+          setAt: setAt ? new Date(setAt) : null,
+          setBy: null,
+        },
+      ],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
 
   function addOverride() {
     // Pick the first parameter not already present, or fall back to first option.
@@ -358,6 +398,20 @@ export function FirstSessionSettings({
                   >
                     {row.value.toFixed(2)}
                   </span>
+                  <LayerBadge
+                    envelope={envelopeFor(
+                      row.parameterId,
+                      row.value,
+                      row.updatedAt,
+                    )}
+                    hideSubtitle
+                    onInspect={() =>
+                      setInspecting({
+                        parameterId: row.parameterId,
+                        label: param?.label ?? row.parameterId,
+                      })
+                    }
+                  />
                   <span className="hf-category-label" data-tone="info">
                     Managed via AgentTuner
                   </span>
@@ -406,6 +460,19 @@ export function FirstSessionSettings({
                   className="hf-input"
                 />
                 <span className="hf-text-xs hf-text-muted">{row.value.toFixed(2)}</span>
+                <LayerBadge
+                  envelope={envelopeFor(row.parameterId, row.value, null)}
+                  hideSubtitle
+                  onInspect={() => {
+                    const param = COMMON_BEHAVIOR_PARAMS.find(
+                      (p) => p.id === row.parameterId,
+                    );
+                    setInspecting({
+                      parameterId: row.parameterId,
+                      label: param?.label ?? row.parameterId,
+                    });
+                  }}
+                />
                 <button
                   type="button"
                   className="hf-btn hf-btn-sm hf-btn-destructive"
@@ -492,6 +559,16 @@ export function FirstSessionSettings({
         {success && <span className="hf-text-xs hf-text-success">Saved.</span>}
         {error && <span className="hf-text-xs hf-text-error">{error}</span>}
       </div>
+
+      {inspecting ? (
+        <CascadeInspectorTray
+          knobKey={inspecting.parameterId}
+          knobLabel={inspecting.label}
+          scopeChain={{ playbookId: courseId }}
+          currentEditScope="PLAYBOOK"
+          onClose={() => setInspecting(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/admin/tests/components/course-design/FirstSessionSettings-behaviorTarget.test.tsx
+++ b/apps/admin/tests/components/course-design/FirstSessionSettings-behaviorTarget.test.tsx
@@ -150,4 +150,110 @@ describe("FirstSessionSettings — #1417 BehaviorTarget row visibility", () => {
     const sliders = document.querySelectorAll('input[type="range"]');
     expect(sliders.length).toBe(1); // firstSessionTargets row only; behaviorTarget is read-only
   });
+
+  it("LayerBadge renders next to every row (wire-up of Slice 3 components)", async () => {
+    mockDesignResponse({
+      ok: true,
+      rows: [
+        {
+          parameterId: "BEH-RESPONSE-LEN",
+          value: 0.2,
+          origin: "behaviorTarget",
+          source: "MANUAL",
+          updatedAt: "2026-06-09T00:00:00.000Z",
+        },
+      ],
+      firstCallMode: null,
+    });
+
+    render(
+      <FirstSessionSettings
+        courseId="c1"
+        playbookConfig={{
+          firstSessionTargets: { "BEH-WARMTH": { value: 0.7 } },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Managed via AgentTuner")).toBeTruthy();
+    });
+    // One [PB] chip per row — behaviorTarget row + firstSessionTargets row.
+    const chips = document.querySelectorAll('.hf-cascade-badge--pb');
+    expect(chips.length).toBe(2);
+  });
+
+  it("clicking the LayerBadge opens the CascadeInspectorTray", async () => {
+    mockDesignResponse({
+      ok: true,
+      rows: [
+        {
+          parameterId: "BEH-RESPONSE-LEN",
+          value: 0.2,
+          origin: "behaviorTarget",
+          source: "MANUAL",
+          updatedAt: "2026-06-09T00:00:00.000Z",
+        },
+      ],
+      firstCallMode: null,
+    });
+    // Tray opens then fetches the cascade — first fetch wins, rest fall back.
+    let trayFetches = 0;
+    fetchMock.mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/api/cascade/resolve")) {
+        trayFetches++;
+        return Promise.resolve(
+          jsonRes({
+            value: 0.2,
+            source: "PLAYBOOK",
+            layers: [
+              {
+                layer: "PLAYBOOK",
+                scopeId: "c1",
+                scopeLabel: "Test Course",
+                value: 0.2,
+                setAt: null,
+                setBy: null,
+              },
+            ],
+            isInherited: false,
+            recommendedLayerForEdit: "PLAYBOOK",
+          }),
+        );
+      }
+      if (typeof url === "string" && url.includes("/call1-override-preview")) {
+        return Promise.resolve(jsonRes({ ok: true, count: 0, samples: [], rangeFormCount: 0 }));
+      }
+      return Promise.resolve(
+        jsonRes({
+          ok: true,
+          rows: [
+            {
+              parameterId: "BEH-RESPONSE-LEN",
+              value: 0.2,
+              origin: "behaviorTarget",
+              source: "MANUAL",
+              updatedAt: "2026-06-09T00:00:00.000Z",
+            },
+          ],
+          firstCallMode: null,
+        }),
+      );
+    });
+
+    const { fireEvent } = await import("@testing-library/react");
+    render(<FirstSessionSettings courseId="c1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Managed via AgentTuner")).toBeTruthy();
+    });
+
+    const chip = document.querySelector('.hf-cascade-badge--pb');
+    expect(chip).toBeTruthy();
+    fireEvent.click(chip!);
+
+    await waitFor(() => {
+      expect(trayFetches).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes the gap from Epic #1442 Slice 3 (PR #1464): the cascade-honesty components shipped but no panel mounted them. The First-call AI behaviour targets panel is the first consumer.

## What lands

Each row — both the read-only \`BehaviorTarget(scope=PLAYBOOK)\` rows revealed by #1466 AND the editable \`firstSessionTargets\` rows — now shows a \`[PB]\` chip after the value. The chip is non-blocking (\`hideSubtitle\`); clicking opens the slide-in \`<CascadeInspectorTray>\` which fetches \`GET /api/cascade/resolve?knobKey=<parameterId>&playbookId=<courseId>\` and renders the full SYSTEM→CALL chain with the winner marked.

## Implementation

- **\`envelopeFor(parameterId, value, setAt)\`** helper synthesizes an \`Effective<number>\` from the row state we already have. The chip just needs the winning layer (we know it's PLAYBOOK); the inspector fetches the rest on click. Avoids one-fetch-per-row on mount.
- **\`inspecting\` state** holds the open knob + label; closing the tray clears it.
- **InspectorTray mounts conditionally** at the end of the component tree so the slide-in overlay sits above the panel content.

## Tests

6/6 green (4 original + 2 new):
- \`LayerBadge renders next to every row\` — verifies 2 \`.hf-cascade-badge--pb\` chips (one per row type)
- \`clicking the LayerBadge opens the CascadeInspectorTray\` — verifies the chip-click triggers a fetch to \`/api/cascade/resolve\`

## What's NOT in this PR

- \`<ScopePicker>\` wire-up — the inspector tray's "Override for a specific caller…" CTA is rendered but unwired (next story)
- LayerBadge on the Welcome-message editor / Onboarding phase editor / voice config editor (separate consumer stories)
- Cmd+K scope-prefix syntax (Sprint 3 of Epic #1442)

## Deploy

\`/vm-cp\` — no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)