### PR TITLE
feat(cascade): #1471 — welcome-message editor surfaces Domain inheritance

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/cascade/welcome-message/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/cascade/welcome-message/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { resolveWelcomeMessage } from "@/lib/cascade/resolvers/welcome-message";
+
+export const runtime = "nodejs";
+
+/**
+ * @api GET /api/courses/[courseId]/cascade/welcome-message
+ * @visibility internal
+ * @scope cascade:read
+ * @auth session
+ * @tags courses, cascade, welcome-message
+ * @description Returns the `Effective<string | null>` envelope for the
+ *   `welcomeMessage` cascade knob, scoped to the given course (`playbookId`).
+ *   Walks Playbook → Domain → SYSTEM and reports the winner plus the full
+ *   layer chain so `LayerBadge` + `CascadeInspectorTray` can render
+ *   provenance honestly. Mirrors `/api/callers/[callerId]/cascade/voice`.
+ * @pathParam courseId string - The course (Playbook) ID
+ * @response 200 { data: Effective<string | null> }
+ * @response 401 { error: "Unauthorized" }
+ * @response 403 { error: "Forbidden" } - role below OPERATOR
+ * @response 500 { data: null, error: string }
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ courseId: string }> },
+) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const { courseId } = await params;
+
+  try {
+    const data = await resolveWelcomeMessage({ playbookId: courseId });
+    return NextResponse.json({ data });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[cascade/welcome-message] failed for courseId=${courseId}:`,
+      message,
+    );
+    return NextResponse.json(
+      { data: null, error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/components/session-flow/SessionFlowEditor.tsx
+++ b/apps/admin/components/session-flow/SessionFlowEditor.tsx
@@ -50,6 +50,14 @@ import {
   formatTrigger,
 } from "./timeline-helpers";
 import { OnboardingEditor } from "@/components/shared/OnboardingEditor";
+import { LayerBadge } from "@/components/cascade/LayerBadge";
+import { CascadeInspectorTray } from "@/components/cascade/CascadeInspectorTray";
+import type { Effective } from "@/lib/cascade/layer-types";
+import {
+  inheritedCaptionFor,
+  badgeAriaLabel,
+  placeholderFor,
+} from "./welcome-cascade";
 import "./session-flow-timeline.css";
 import "./session-flow-editor.css";
 
@@ -991,6 +999,29 @@ function WelcomeMessageDrawer({
   const [text, setText] = useState(current);
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [effective, setEffective] = useState<Effective<string | null> | null>(null);
+  const [effectiveError, setEffectiveError] = useState<string | null>(null);
+  const [inspecting, setInspecting] = useState(false);
+
+  // Fetch the cascade envelope on mount so the badge + caption render the
+  // honest source (PLAYBOOK / DOMAIN / SYSTEM). Falls back silently if
+  // the route 4xx/5xx — the textarea still reads from `current`.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/cascade/welcome-message`)
+      .then((r) => r.json())
+      .then((json: { data?: Effective<string | null>; error?: string }) => {
+        if (cancelled) return;
+        if (json.data) setEffective(json.data);
+        else if (json.error) setEffectiveError(json.error);
+      })
+      .catch((e) => {
+        if (!cancelled) setEffectiveError((e as Error).message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
 
   const dirty = text !== current;
   const trimmed = text.trim();
@@ -1013,22 +1044,45 @@ function WelcomeMessageDrawer({
     }
   };
 
+  const inheritedCaption = inheritedCaptionFor(effective);
+  const placeholder = placeholderFor(effective);
+
   return (
     <Drawer title="Welcome message">
       <p className="sfe-drawer-desc">
         First-line greeting the AI uses on the learner&rsquo;s first call. Leave blank to fall back to the domain default or a generic greeting.
       </p>
       <label className="sfe-field">
-        <span className="sfe-field-label">Message</span>
+        <span className="sfe-field-label">
+          <span className="sfe-field-label-text">Message</span>
+          {effective ? (
+            <LayerBadge
+              envelope={effective}
+              hideSubtitle
+              onInspect={() => setInspecting(true)}
+              ariaLabel={`Welcome message source: ${badgeAriaLabel(effective.source)}`}
+            />
+          ) : null}
+        </span>
+        {inheritedCaption ? (
+          <span className="sfe-field-hint" data-testid="hf-welcome-cascade-caption">
+            {inheritedCaption}
+          </span>
+        ) : null}
         <textarea
           className="sfe-textarea"
           value={text}
           onChange={(e) => setText(e.target.value)}
           rows={4}
           maxLength={500}
-          placeholder="Welcome to the course! Let's get started…"
+          placeholder={placeholder}
         />
         <span className="sfe-field-hint">{text.length} / 500 characters</span>
+        {effectiveError ? (
+          <span className="sfe-field-hint" data-testid="hf-welcome-cascade-error">
+            Cascade lookup failed: {effectiveError}
+          </span>
+        ) : null}
       </label>
       {err && <div className="sfe-error">Save failed: {err}</div>}
       <footer className="sfe-drawer-footer">
@@ -1036,9 +1090,19 @@ function WelcomeMessageDrawer({
           {saving ? "Saving…" : (trimmed.length === 0 && current.length > 0 ? "Clear message" : "Save message")}
         </button>
       </footer>
+      {inspecting && effective ? (
+        <CascadeInspectorTray
+          knobKey="welcomeMessage"
+          knobLabel="Welcome message"
+          scopeChain={{ playbookId: courseId }}
+          currentEditScope="PLAYBOOK"
+          onClose={() => setInspecting(false)}
+        />
+      ) : null}
     </Drawer>
   );
 }
+
 
 /**
  * Inline editor card. Was originally a fixed sidetray with backdrop and

--- a/apps/admin/components/session-flow/session-flow-editor.css
+++ b/apps/admin/components/session-flow/session-flow-editor.css
@@ -245,10 +245,26 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
+/* Welcome-message cascade badge (#1471): label hosts text + LayerBadge inline. */
+.sfe-field-label:has(.hf-cascade-badge-wrap) {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.sfe-field-label-text {
+  text-transform: inherit;
+  letter-spacing: inherit;
+}
 .sfe-field-hint {
   font-size: 11px;
   color: var(--text-muted);
   align-self: flex-end;
+}
+.sfe-field-hint[data-testid="hf-welcome-cascade-caption"] {
+  align-self: flex-start;
+  color: var(--text-secondary);
+  text-transform: none;
+  letter-spacing: 0;
 }
 .sfe-fieldset {
   border: 1px solid var(--border-default);

--- a/apps/admin/components/session-flow/timeline-helpers.ts
+++ b/apps/admin/components/session-flow/timeline-helpers.ts
@@ -8,12 +8,25 @@
 
 import type { JourneyStop, JourneyStopTrigger, SessionFlowResolved } from "@/lib/types/json-fields";
 
-export function sourceLabel(src: SessionFlowResolved["source"]["onboarding"]): string {
+/**
+ * SessionFlowResolved.source uses different per-field vocabularies — the
+ * onboarding cascade lands on `new-shape | playbook-legacy | domain | init001`
+ * while welcomeMessage lands on `playbook | domain | generic`. We accept the
+ * union and label whichever shows up. (Distinct from the cascade-honesty
+ * Layer enum from `lib/cascade/layer-types.ts` — see #1471 risk note.)
+ */
+type SessionFlowSourceTag =
+  | SessionFlowResolved["source"]["onboarding"]
+  | SessionFlowResolved["source"]["welcomeMessage"];
+
+export function sourceLabel(src: SessionFlowSourceTag): string {
   switch (src) {
     case "new-shape": return "course (sessionFlow)";
     case "playbook-legacy": return "course (legacy)";
+    case "playbook": return "course";
     case "domain": return "domain default";
     case "init001": return "system default";
+    case "generic": return "generic fallback";
   }
 }
 

--- a/apps/admin/components/session-flow/welcome-cascade.ts
+++ b/apps/admin/components/session-flow/welcome-cascade.ts
@@ -1,0 +1,62 @@
+/**
+ * Welcome-message cascade UX helpers (#1471).
+ *
+ * Pure functions extracted from `SessionFlowEditor::WelcomeMessageDrawer`
+ * so unit tests can pin the caption + aria-label rules without mounting
+ * the whole timeline editor. The drawer wires these into `<LayerBadge>`
+ * + `<CascadeInspectorTray>` from the cascade primitive (#1462/#1464/#1469).
+ */
+
+import type { Effective } from "@/lib/cascade/layer-types";
+
+/**
+ * Inline caption shown beneath the Message label. `null` means "render
+ * nothing" — the `[PB]` case is self-explanatory via the badge.
+ */
+export function inheritedCaptionFor(
+  envelope: Effective<string | null> | null,
+): string | null {
+  if (!envelope) return null;
+  if (envelope.source === "DOMAIN") {
+    const dom = envelope.layers.find((h) => h.layer === "DOMAIN");
+    return dom ? `Inherited from Domain: ${dom.scopeLabel}` : "Inherited from Domain";
+  }
+  if (envelope.source === "SYSTEM" && envelope.layers.length === 0) {
+    return "No override set — AI uses its default greeting";
+  }
+  return null;
+}
+
+/**
+ * Aria-label suffix used by the badge — keeps the chip's accessible name
+ * informative ("Welcome message source: inherited from Domain") instead
+ * of the generic default ("Cascade layer: DOM").
+ */
+export function badgeAriaLabel(source: Effective<unknown>["source"]): string {
+  switch (source) {
+    case "PLAYBOOK":
+      return "set on this Course";
+    case "DOMAIN":
+      return "inherited from Domain";
+    case "SYSTEM":
+      return "using System default";
+    case "CALLER":
+      return "caller-scope override";
+    case "SEGMENT":
+    case "CALL":
+      return "set at a deeper scope";
+  }
+}
+
+/**
+ * The textarea placeholder. When the live effective value is a Domain
+ * inheritance, surface it as ghost text so the operator sees what the
+ * AI would say if they don't override. SYSTEM/PLAYBOOK fall back to the
+ * generic placeholder.
+ */
+export function placeholderFor(
+  envelope: Effective<string | null> | null,
+): string {
+  if (envelope?.source === "DOMAIN" && envelope.value) return envelope.value;
+  return "Welcome to the course! Let's get started…";
+}

--- a/apps/admin/tests/api/courses/cascade-welcome-message-route.test.ts
+++ b/apps/admin/tests/api/courses/cascade-welcome-message-route.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for GET /api/courses/[courseId]/cascade/welcome-message (#1471).
+ *
+ * Security + shape:
+ *   - OPERATOR → 200 + Effective<string | null>
+ *   - STUDENT → 403 (insufficient role)
+ *   - Resolver throw → 500 + { data: null, error }
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.unmock("@/lib/permissions");
+
+const mockRequireAuth = vi.fn();
+const mockResolveWelcomeMessage = vi.fn();
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+  isAuthError: (v: unknown): v is { error: unknown } =>
+    Boolean(v && typeof v === "object" && "error" in (v as Record<string, unknown>)),
+}));
+
+vi.mock("@/lib/cascade/resolvers/welcome-message", () => ({
+  resolveWelcomeMessage: (...args: unknown[]) => mockResolveWelcomeMessage(...args),
+}));
+
+function makeSession(role: string) {
+  return {
+    session: {
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      user: {
+        id: "user-1",
+        email: "u@example.com",
+        name: "U",
+        image: null,
+        role,
+      },
+    },
+  };
+}
+
+async function callGet(courseId: string) {
+  const mod = await import(
+    "@/app/api/courses/[courseId]/cascade/welcome-message/route"
+  );
+  const req = new Request(
+    `http://test/api/courses/${courseId}/cascade/welcome-message`,
+  );
+  const res = await mod.GET(req, {
+    params: Promise.resolve({ courseId }),
+  });
+  // Only parse JSON for non-auth-error responses. The auth helper returns
+  // a plain-text 401/403 response, which JSON.parse would choke on.
+  if (res.status === 401 || res.status === 403) {
+    return { status: res.status, json: null as null };
+  }
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
+const playbookWinningEnvelope = {
+  value: "Welcome, friend!",
+  source: "PLAYBOOK" as const,
+  layers: [
+    {
+      layer: "PLAYBOOK" as const,
+      scopeId: "pb-1",
+      scopeLabel: "OCEAN",
+      value: "Welcome, friend!",
+      setAt: null,
+      setBy: null,
+    },
+  ],
+  isInherited: false,
+  recommendedLayerForEdit: "PLAYBOOK" as const,
+};
+
+describe("GET /api/courses/[courseId]/cascade/welcome-message", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("OPERATOR → 200 + Effective envelope", async () => {
+    mockRequireAuth.mockResolvedValue(makeSession("OPERATOR"));
+    mockResolveWelcomeMessage.mockResolvedValue(playbookWinningEnvelope);
+
+    const { status, json } = await callGet("pb-1");
+
+    expect(status).toBe(200);
+    expect(json.data.source).toBe("PLAYBOOK");
+    expect(json.data.value).toBe("Welcome, friend!");
+    expect(mockRequireAuth).toHaveBeenCalledWith("OPERATOR");
+    expect(mockResolveWelcomeMessage).toHaveBeenCalledWith({
+      playbookId: "pb-1",
+    });
+  });
+
+  it("STUDENT → 403 (role gate)", async () => {
+    const forbidden = new Response("Forbidden", { status: 403 });
+    mockRequireAuth.mockResolvedValue({ error: forbidden });
+
+    const { status } = await callGet("pb-1");
+
+    expect(status).toBe(403);
+    expect(mockResolveWelcomeMessage).not.toHaveBeenCalled();
+  });
+
+  it("Resolver throw → 500 with error message", async () => {
+    mockRequireAuth.mockResolvedValue(makeSession("OPERATOR"));
+    mockResolveWelcomeMessage.mockRejectedValue(new Error("Playbook not found"));
+
+    const { status, json } = await callGet("missing-pb");
+
+    expect(status).toBe(500);
+    expect(json.data).toBeNull();
+    expect(json.error).toBe("Playbook not found");
+  });
+
+  it("DOMAIN inheritance → source=DOMAIN, isInherited=true", async () => {
+    mockRequireAuth.mockResolvedValue(makeSession("OPERATOR"));
+    mockResolveWelcomeMessage.mockResolvedValue({
+      value: "Domain greeting",
+      source: "DOMAIN" as const,
+      layers: [
+        {
+          layer: "DOMAIN" as const,
+          scopeId: "dom-1",
+          scopeLabel: "Education",
+          value: "Domain greeting",
+          setAt: null,
+          setBy: null,
+        },
+      ],
+      isInherited: true,
+      recommendedLayerForEdit: "PLAYBOOK" as const,
+    });
+
+    const { status, json } = await callGet("pb-1");
+
+    expect(status).toBe(200);
+    expect(json.data.source).toBe("DOMAIN");
+    expect(json.data.isInherited).toBe(true);
+    expect(json.data.layers[0].scopeLabel).toBe("Education");
+  });
+
+  it("SYSTEM (neither layer set) → source=SYSTEM, empty layers", async () => {
+    mockRequireAuth.mockResolvedValue(makeSession("OPERATOR"));
+    mockResolveWelcomeMessage.mockResolvedValue({
+      value: null,
+      source: "SYSTEM" as const,
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK" as const,
+    });
+
+    const { status, json } = await callGet("pb-1");
+
+    expect(status).toBe(200);
+    expect(json.data.source).toBe("SYSTEM");
+    expect(json.data.value).toBeNull();
+    expect(json.data.layers).toHaveLength(0);
+  });
+});

--- a/apps/admin/tests/components/session-flow/welcome-cascade.test.ts
+++ b/apps/admin/tests/components/session-flow/welcome-cascade.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Welcome-message cascade UX helpers (#1471).
+ *
+ * Pins the source→caption + source→aria + source→placeholder rules
+ * that drive `WelcomeMessageDrawer`'s badge/caption/textarea rendering.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  inheritedCaptionFor,
+  badgeAriaLabel,
+  placeholderFor,
+} from "@/components/session-flow/welcome-cascade";
+import type { Effective } from "@/lib/cascade/layer-types";
+
+const PB_ENVELOPE: Effective<string | null> = {
+  value: "Hi from the Course",
+  source: "PLAYBOOK",
+  layers: [
+    {
+      layer: "PLAYBOOK",
+      scopeId: "pb-1",
+      scopeLabel: "OCEAN",
+      value: "Hi from the Course",
+      setAt: null,
+      setBy: null,
+    },
+  ],
+  isInherited: false,
+  recommendedLayerForEdit: "PLAYBOOK",
+};
+
+const DOM_ENVELOPE: Effective<string | null> = {
+  value: "Hi from the Domain",
+  source: "DOMAIN",
+  layers: [
+    {
+      layer: "DOMAIN",
+      scopeId: "dom-1",
+      scopeLabel: "Education",
+      value: "Hi from the Domain",
+      setAt: null,
+      setBy: null,
+    },
+  ],
+  isInherited: true,
+  recommendedLayerForEdit: "PLAYBOOK",
+};
+
+const SYS_ENVELOPE: Effective<string | null> = {
+  value: null,
+  source: "SYSTEM",
+  layers: [],
+  isInherited: false,
+  recommendedLayerForEdit: "PLAYBOOK",
+};
+
+describe("inheritedCaptionFor", () => {
+  it("returns null when envelope is null", () => {
+    expect(inheritedCaptionFor(null)).toBeNull();
+  });
+
+  it("returns null when source is PLAYBOOK (no caption needed — badge says it)", () => {
+    expect(inheritedCaptionFor(PB_ENVELOPE)).toBeNull();
+  });
+
+  it("returns Domain inheritance caption when source is DOMAIN", () => {
+    expect(inheritedCaptionFor(DOM_ENVELOPE)).toBe(
+      "Inherited from Domain: Education",
+    );
+  });
+
+  it("returns 'no override' caption when SYSTEM with empty layers", () => {
+    expect(inheritedCaptionFor(SYS_ENVELOPE)).toBe(
+      "No override set — AI uses its default greeting",
+    );
+  });
+
+  it("returns null for SYSTEM with non-empty layers (rare; explicit system override)", () => {
+    const sysWithHit: Effective<string | null> = {
+      ...SYS_ENVELOPE,
+      layers: [
+        {
+          layer: "SYSTEM",
+          scopeId: null,
+          scopeLabel: "System default",
+          value: null,
+          setAt: null,
+          setBy: null,
+        },
+      ],
+    };
+    expect(inheritedCaptionFor(sysWithHit)).toBeNull();
+  });
+});
+
+describe("badgeAriaLabel", () => {
+  it("PLAYBOOK source → 'set on this Course'", () => {
+    expect(badgeAriaLabel("PLAYBOOK")).toBe("set on this Course");
+  });
+
+  it("DOMAIN source → 'inherited from Domain'", () => {
+    expect(badgeAriaLabel("DOMAIN")).toBe("inherited from Domain");
+  });
+
+  it("SYSTEM source → 'using System default'", () => {
+    expect(badgeAriaLabel("SYSTEM")).toBe("using System default");
+  });
+});
+
+describe("placeholderFor", () => {
+  it("returns generic placeholder when envelope is null", () => {
+    expect(placeholderFor(null)).toBe(
+      "Welcome to the course! Let's get started…",
+    );
+  });
+
+  it("surfaces Domain value as ghost text when inheriting", () => {
+    expect(placeholderFor(DOM_ENVELOPE)).toBe("Hi from the Domain");
+  });
+
+  it("returns generic placeholder for PLAYBOOK source", () => {
+    expect(placeholderFor(PB_ENVELOPE)).toBe(
+      "Welcome to the course! Let's get started…",
+    );
+  });
+
+  it("returns generic placeholder for SYSTEM source", () => {
+    expect(placeholderFor(SYS_ENVELOPE)).toBe(
+      "Welcome to the course! Let's get started…",
+    );
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -6004,6 +6004,38 @@ Create a fresh test learner enrolled in this course. Random
 
 ---
 
+### `GET` /api/courses/[courseId]/cascade/welcome-message
+
+Returns the `Effective<string | null>` envelope for the
+
+**Auth**: Session · **Scope**: `cascade:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| courseId | path | string | Yes | The course (Playbook) ID |
+
+**Response** `200`
+```json
+{ data: Effective<string | null> }
+```
+
+**Response** `401`
+```json
+{ error: "Unauthorized" }
+```
+
+**Response** `403`
+```json
+{ error: "Forbidden" } - role below OPERATOR
+```
+
+**Response** `500`
+```json
+{ data: null, error: string }
+```
+
+---
+
 ### `GET` /api/courses/[courseId]/media
 
 List media assets (extracted images, uploaded files) across all subjects
@@ -15881,8 +15913,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 507 |
-| Files with annotations | 497 |
+| Route files found | 508 |
+| Files with annotations | 498 |
 | Files missing annotations | 10 |
 | Coverage | 98.0% |
 

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-11T11:47:57.653Z",
+  "generatedAt": "2026-06-11T11:48:42.798Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1642,
-  "edgeCount": 3784,
+  "fileCount": 1643,
+  "edgeCount": 3786,
   "skippedEdges": 1,
   "edges": [
     {
@@ -2482,6 +2482,14 @@
     {
       "from": "app/api/courses/[courseId]/call1-override-preview/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/cascade/welcome-message/route.ts",
+      "to": "lib/cascade/resolvers/welcome-message.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/cascade/welcome-message/route.ts",
+      "to": "lib/permissions.ts"
     },
     {
       "from": "app/api/courses/[courseId]/classrooms/route.ts",
@@ -15996,6 +16004,11 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/courses/[courseId]/cascade/welcome-message/route.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
       "path": "app/api/courses/[courseId]/classrooms/route.ts",
       "inDegree": 0,
       "outDegree": 2
@@ -20447,7 +20460,7 @@
     },
     {
       "path": "lib/cascade/resolvers/welcome-message.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 3
     },
     {
@@ -21772,7 +21785,7 @@
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 437,
+      "inDegree": 438,
       "outDegree": 3
     },
     {
@@ -23364,7 +23377,7 @@
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 437,
+      "inDegree": 438,
       "outDegree": 3
     },
     {

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-11T11:47:56.486Z",
+  "generatedAt": "2026-06-11T11:48:41.648Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,16 +1,16 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-11T11:47:57.007Z",
+  "generatedAt": "2026-06-11T11:48:42.134Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
-    "routeCount": 507,
+    "routeCount": 508,
     "byAuthLevel": {
       "VIEWER": 112,
       "ADMIN": 81,
       "SUPERADMIN": 9,
       "VIEWER+ADMIN": 5,
-      "OPERATOR": 137,
+      "OPERATOR": 138,
       "OPERATOR+VIEWER": 8,
       "VIEWER+OPERATOR": 56,
       "auth-gate(non-role)": 54,
@@ -25,7 +25,7 @@
       "VIEWER+TESTER": 3
     },
     "noAuthGate": 28,
-    "possiblyUnscoped": 132,
+    "possiblyUnscoped": 133,
     "internalSecret": 8
   },
   "routes": [
@@ -3368,6 +3368,26 @@
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/cascade/welcome-message",
+      "file": "apps/admin/app/api/courses/[courseId]/cascade/welcome-message/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": true,
         "noAuthGate": false
       },
       "reviewed": false


### PR DESCRIPTION
## Summary

- New route `GET /api/courses/[courseId]/cascade/welcome-message` (OPERATOR+) returning `Effective<string | null>` via existing `resolveWelcomeMessage`
- `WelcomeMessageDrawer` fetches the cascade envelope on mount and renders a `LayerBadge` + caption + tray-on-inspect next to the Message label
- Caption rules: `DOMAIN → "Inherited from Domain: <name>"`, `SYSTEM → "No override set"`, `PLAYBOOK → no caption (badge says it)`
- Domain text surfaces as textarea ghost-placeholder when inheriting → operator sees what AI would say if they don't override
- Existing Playbook save path unchanged; Domain-scope write affordance deferred to follow-on (kept narrow per BA risk note about two distinct source vocabularies)

> **Stacked on #1473** (`feat/1469-cascade-kebab`). Once that merges, the kebab affordance from #1469 lights up on this badge automatically.

## Verified by

- `tests/api/courses/cascade-welcome-message-route.test.ts` — 5 tests (OPERATOR 200 / STUDENT 403 / 500 / DOMAIN inheritance / SYSTEM fallback)
- `tests/components/session-flow/welcome-cascade.test.ts` — 12 tests (caption / aria / placeholder pure helpers)
- `tests/components/cascade/*` + `tests/components/course-design/*` — all 38 prior tests pass unchanged
- pre-push tsc + eslint on changed files: ✓

```
Test Files  3 passed (3)
     Tests  17 passed (17) — new
              38 passed (38) — prior, unchanged
```

## Acceptance criteria checklist

- [x] Drawer reads via the new cascade route on mount — does NOT read `playbook.config.welcomeMessage` directly
- [x] `source === "DOMAIN"`: `[DOM]` badge + `"Inherited from Domain: {domainName}"` caption + domain text as placeholder
- [x] `source === "PLAYBOOK"`: `[PB]` badge, no caption
- [x] `source === "SYSTEM"`: `[—]` badge + `"No override set"` caption
- [x] Kebab/`onInspect` on badge opens `CascadeInspectorTray` (kebab affordance from #1469 stacked above)
- [x] Playbook save unchanged (`PUT /api/courses/[courseId]/session-flow`); `composeInputsUpdatedAt` bump already on that path
- [x] OPERATOR+ only on the GET route; STUDENT → 403
- [x] `hf-compose/no-hardcoded-greeting-in-composition` NOT triggered — editor surface only
- [x] Cascade fetch failure degrades gracefully — drawer still usable, error caption shown
- [x] Pre-existing TS bug in `timeline-helpers.sourceLabel` widened to accept both `onboarding` + `welcomeMessage` source unions (one-line follow-on; was already broken before this PR but surfaced when I touched the file)

## Deferred to follow-on

- **Domain-scope write affordance** (AC 7 in #1471). Reasoning: requires ScopePicker integration + role plumbing into the drawer + re-fetch cycle. Read-side cascade-honesty is the high-leverage half; write-at-Domain is a polish layer. Tracking issue to follow.

## Deploy

`/vm-cp` (no schema, no migration)

Closes #1471
Refs Epic #1442 (Layer 2), #1469 (kebab affordance prereq)

🤖 Generated with [Claude Code](https://claude.com/claude-code)