### PR TITLE
feat(cascade): #1472 — identity-spec rendering shows archetype source

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/dry-run-prompt/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/dry-run-prompt/route.ts
@@ -3,6 +3,7 @@ import { executeComposition, loadComposeConfig } from "@/lib/prompt/composition"
 import { renderPromptSummary } from "@/lib/prompt/composition/renderPromptSummary";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
+import { resolveIdentitySpec } from "@/lib/cascade/resolvers/identity-spec";
 
 export const runtime = "nodejs";
 
@@ -118,6 +119,27 @@ export async function POST(
     const composition = await executeComposition(callerId, sections, fullSpecConfig, "dry-run");
     const { loadedData, resolvedSpecs, metadata } = composition;
 
+    // #1472 — surface the identity-spec cascade source so Preview lens can
+    // render a LayerBadge ("Persona: tutor from System default"). Read-only
+    // resolution off the same primitive `/api/cascade/resolve` uses; falls
+    // back to null on resolver throw so dry-run continues working.
+    let identitySpecSource: "SYSTEM" | "DOMAIN" | "PLAYBOOK" | null = null;
+    try {
+      const idEnv = await resolveIdentitySpec({ playbookId: courseId });
+      if (
+        idEnv.source === "SYSTEM" ||
+        idEnv.source === "DOMAIN" ||
+        idEnv.source === "PLAYBOOK"
+      ) {
+        identitySpecSource = idEnv.source;
+      }
+    } catch (err) {
+      console.warn(
+        `[dry-run-prompt] identity-spec cascade lookup failed for course=${courseId}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
     const promptSummary = renderPromptSummary(composition.llmPrompt);
 
     console.log(
@@ -143,6 +165,12 @@ export async function POST(
         loadTimeMs: metadata.loadTimeMs,
         transformTimeMs: metadata.transformTimeMs,
         identitySpec: resolvedSpecs.identitySpec?.name ?? null,
+        // #1472 — additive fields; existing consumers reading `identitySpec`
+        // are unaffected. `identitySpecExtendsAgent` is the base archetype
+        // slug ("TUT-001" / "COACH-001"); Preview lens maps it to a label
+        // via `getArchetypeLabel()`.
+        identitySpecSource,
+        identitySpecExtendsAgent: resolvedSpecs.identitySpec?.extendsAgent ?? null,
         playbooksUsed: loadedData.playbooks.map((p: any) => p.name),
         memoriesCount: loadedData.memories.length,
         behaviorTargetsCount: metadata.mergedTargetCount,

--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -34,6 +34,10 @@ import {
 } from "@/components/session-flow/SessionFlowEditor";
 import "./preview-lens.css";
 import { emptyOnboardingBubble } from "./empty-onboarding-bubble";
+import { LayerBadge } from "@/components/cascade/LayerBadge";
+import { CascadeInspectorTray } from "@/components/cascade/CascadeInspectorTray";
+import { getArchetypeLabel } from "@/lib/domain/generate-identity";
+import type { Effective, Layer } from "@/lib/cascade/layer-types";
 
 interface PreviewLensProps {
   courseId: string;
@@ -77,6 +81,10 @@ interface DryRunResp {
     loadTimeMs: number;
     transformTimeMs: number;
     identitySpec: string | null;
+    /** #1472 — which cascade layer sourced the identity-spec (SYSTEM/DOMAIN/PLAYBOOK). */
+    identitySpecSource?: "SYSTEM" | "DOMAIN" | "PLAYBOOK" | null;
+    /** #1472 — base archetype slug ("TUT-001"); map to a label via `getArchetypeLabel`. */
+    identitySpecExtendsAgent?: string | null;
     playbooksUsed: string[];
     memoriesCount: number;
     behaviorTargetsCount: number;
@@ -217,7 +225,10 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
       )}
 
       {!loading && flow && mode === "educator" && (
-        <EducatorView transcript={transcript} courseId={courseId} onOpenSidetray={openSidetray} />
+        <>
+          <IdentityHeader meta={dryRun?.metadata} courseId={courseId} />
+          <EducatorView transcript={transcript} courseId={courseId} onOpenSidetray={openSidetray} />
+        </>
       )}
 
       {!loading && dryRun && mode === "engineer" && (
@@ -660,12 +671,17 @@ function PreviewEditSidetray({
 function EngineerView({ data }: { data: DryRunResp }): React.ReactElement {
   const meta = data.metadata;
   if (!meta) return <p className="hf-text-muted">No metadata returned.</p>;
+  // #1472 — append the cascade source layer so the Engineer view exposes
+  // provenance without expanding into a separate badge surface.
+  const identityWithSource = meta.identitySpec
+    ? `${meta.identitySpec}${meta.identitySpecSource ? ` (${meta.identitySpecSource})` : ""}`
+    : "—";
   return (
     <div className="hf-preview-lens-engineer">
       <div className="hf-preview-lens-engineer-stats">
         <Stat label="Activated" value={meta.sectionsActivated.length} />
         <Stat label="Skipped" value={meta.sectionsSkipped.length} />
-        <Stat label="Identity" value={meta.identitySpec ?? "—"} />
+        <Stat label="Identity" value={identityWithSource} />
         <Stat label="Memories" value={meta.memoriesCount} />
         <Stat label="Targets" value={meta.behaviorTargetsCount} />
       </div>
@@ -721,6 +737,140 @@ function Stat({ label, value }: { label: string; value: string | number }): Reac
     <div className="hf-preview-lens-stat">
       <div className="hf-preview-lens-stat-value">{value}</div>
       <div className="hf-preview-lens-stat-label">{label}</div>
+    </div>
+  );
+}
+
+// ── Identity header (#1472) ─────────────────────────────────────────────
+// Cascade-honest persona row shown above the Educator transcript. Reads
+// `identitySpec` (name) + `identitySpecSource` + `identitySpecExtendsAgent`
+// from the dry-run metadata, synthesizes an `Effective<string>` envelope
+// so `<LayerBadge>` can render the source layer, and opens
+// `<CascadeInspectorTray>` on inspect.
+
+/**
+ * Synthesizes a single-layer envelope for the identity cascade so the
+ * badge renders honestly without re-querying `/api/cascade/resolve` on
+ * mount. The tray fetches the full 6-layer chain itself when opened.
+ */
+export function identitySpecEnvelope(
+  source: Layer | null | undefined,
+  name: string | null,
+): Effective<string | null> {
+  if (!source || !name) {
+    return {
+      value: null,
+      source: "SYSTEM",
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
+  return {
+    value: name,
+    source,
+    layers: [
+      {
+        layer: source,
+        scopeId: null,
+        scopeLabel: scopeLabelForLayer(source),
+        value: name,
+        setAt: null,
+        setBy: null,
+      },
+    ],
+    isInherited: source !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}
+
+function scopeLabelForLayer(layer: Layer): string {
+  switch (layer) {
+    case "PLAYBOOK":
+      return "Course";
+    case "DOMAIN":
+      return "Domain";
+    case "SYSTEM":
+      return "System default";
+    case "CALLER":
+      return "Caller";
+    case "SEGMENT":
+      return "Segment";
+    case "CALL":
+      return "Call";
+  }
+}
+
+export function identityCaption(
+  source: "SYSTEM" | "DOMAIN" | "PLAYBOOK" | null | undefined,
+  archetypeSlug: string | null | undefined,
+): string {
+  const label = getArchetypeLabel(archetypeSlug);
+  if (!source) return `Persona: ${label}`;
+  const layer = source === "PLAYBOOK"
+    ? "Course"
+    : source === "DOMAIN"
+      ? "Domain"
+      : "System default";
+  const base = `Persona: ${label} from ${layer}`;
+  if (source === "SYSTEM") return `${base} (no override at Course/Domain)`;
+  return base;
+}
+
+function IdentityHeader({
+  meta,
+  courseId,
+}: {
+  meta: DryRunResp["metadata"];
+  courseId: string;
+}): React.ReactElement | null {
+  const [inspecting, setInspecting] = useState(false);
+  if (!meta) return null;
+
+  const envelope = identitySpecEnvelope(
+    meta.identitySpecSource ?? null,
+    meta.identitySpec,
+  );
+  const caption = identityCaption(meta.identitySpecSource ?? null, meta.identitySpecExtendsAgent);
+
+  // Ghosted fallback row when there's no identity at all.
+  if (!meta.identitySpec) {
+    return (
+      <div
+        className="hf-preview-lens-identity"
+        data-testid="hf-preview-identity-empty"
+      >
+        <span className="hf-text-muted">No persona configured — system default will be used.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="hf-preview-lens-identity"
+      data-testid="hf-preview-identity-row"
+    >
+      <LayerBadge
+        envelope={envelope}
+        hideSubtitle
+        onInspect={() => setInspecting(true)}
+        ariaLabel={`Identity spec source: ${meta.identitySpecSource ?? "unknown"}`}
+      />
+      <span
+        className="hf-preview-lens-identity-caption"
+        data-testid="hf-preview-identity-caption"
+      >
+        {caption}
+      </span>
+      {inspecting ? (
+        <CascadeInspectorTray
+          knobKey="identitySpecId"
+          knobLabel="Identity spec"
+          scopeChain={{ playbookId: courseId }}
+          currentEditScope="PLAYBOOK"
+          onClose={() => setInspecting(false)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
@@ -312,6 +312,22 @@
   background: var(--surface-secondary);
 }
 
+/* Identity header (#1472) — cascade-honest persona row above transcript. */
+.hf-preview-lens-identity {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  background: var(--surface-secondary);
+}
+.hf-preview-lens-identity-caption {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
 .hf-preview-lens-stat-value {
   font-size: 16px;
   font-weight: 700;

--- a/apps/admin/lib/domain/generate-identity.ts
+++ b/apps/admin/lib/domain/generate-identity.ts
@@ -141,6 +141,17 @@ const DEFAULT_DESCRIPTOR = {
 - General conversational patterns`,
 };
 
+/**
+ * Public archetype-slug → display label mapping. Used by Preview lens and
+ * other surfaces that need to render "tutor"/"coach"/"companion" instead
+ * of raw spec slugs ("TUT-001"). Falls back to `"agent"` when the slug
+ * is unknown.
+ */
+export function getArchetypeLabel(archetypeSlug: string | null | undefined): string {
+  if (!archetypeSlug) return DEFAULT_DESCRIPTOR.label;
+  return ARCHETYPE_DESCRIPTORS[archetypeSlug]?.label ?? DEFAULT_DESCRIPTOR.label;
+}
+
 async function buildIdentitySystemPrompt(archetypeSlug?: string): Promise<string> {
   const desc = (archetypeSlug && ARCHETYPE_DESCRIPTORS[archetypeSlug]) || DEFAULT_DESCRIPTOR;
   const template = await getPromptTemplate("identity-generation");

--- a/apps/admin/tests/components/course-design/preview-identity-header.test.tsx
+++ b/apps/admin/tests/components/course-design/preview-identity-header.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Identity-spec cascade rendering helpers (#1472).
+ *
+ * Pins the {source, archetype} → caption + envelope shape rules used by
+ * `<IdentityHeader>` inside PreviewLens.tsx. Component-level mount tests
+ * for PreviewLens would require a much bigger harness (session-flow
+ * fetch + sidetray + dry-run polling); these helpers are pure and fully
+ * isolatable.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  identitySpecEnvelope,
+  identityCaption,
+} from "@/app/x/courses/[courseId]/_components/PreviewLens";
+
+describe("identitySpecEnvelope", () => {
+  it("returns SYSTEM/empty envelope when source is null", () => {
+    const env = identitySpecEnvelope(null, "Tutor Spec");
+    expect(env.source).toBe("SYSTEM");
+    expect(env.layers).toHaveLength(0);
+    expect(env.value).toBeNull();
+  });
+
+  it("returns SYSTEM/empty envelope when name is null", () => {
+    const env = identitySpecEnvelope("PLAYBOOK", null);
+    expect(env.source).toBe("SYSTEM");
+    expect(env.layers).toHaveLength(0);
+  });
+
+  it("returns PLAYBOOK envelope (not inherited) for source=PLAYBOOK", () => {
+    const env = identitySpecEnvelope("PLAYBOOK", "Identity Spec");
+    expect(env.source).toBe("PLAYBOOK");
+    expect(env.value).toBe("Identity Spec");
+    expect(env.isInherited).toBe(false);
+    expect(env.layers[0].scopeLabel).toBe("Course");
+  });
+
+  it("returns DOMAIN envelope (inherited) for source=DOMAIN", () => {
+    const env = identitySpecEnvelope("DOMAIN", "FoodSafety Identity");
+    expect(env.source).toBe("DOMAIN");
+    expect(env.isInherited).toBe(true);
+    expect(env.layers[0].scopeLabel).toBe("Domain");
+  });
+
+  it("returns SYSTEM envelope (inherited) for source=SYSTEM", () => {
+    const env = identitySpecEnvelope("SYSTEM", "Default Tutor");
+    expect(env.source).toBe("SYSTEM");
+    expect(env.isInherited).toBe(true);
+    expect(env.layers[0].scopeLabel).toBe("System default");
+  });
+});
+
+describe("identityCaption", () => {
+  it("PLAYBOOK source → 'Persona: <label> from Course'", () => {
+    expect(identityCaption("PLAYBOOK", "TUT-001")).toBe(
+      "Persona: tutor from Course",
+    );
+  });
+
+  it("DOMAIN source → 'Persona: <label> from Domain'", () => {
+    expect(identityCaption("DOMAIN", "COACH-001")).toBe(
+      "Persona: coach from Domain",
+    );
+  });
+
+  it("SYSTEM source includes '(no override at Course/Domain)' note", () => {
+    expect(identityCaption("SYSTEM", "TUT-001")).toBe(
+      "Persona: tutor from System default (no override at Course/Domain)",
+    );
+  });
+
+  it("Unknown archetype slug falls back to 'agent'", () => {
+    expect(identityCaption("PLAYBOOK", "UNKNOWN-999")).toBe(
+      "Persona: agent from Course",
+    );
+  });
+
+  it("Null archetype slug falls back to 'agent'", () => {
+    expect(identityCaption("DOMAIN", null)).toBe(
+      "Persona: agent from Domain",
+    );
+  });
+
+  it("No source → 'Persona: <label>' without layer suffix", () => {
+    expect(identityCaption(null, "TUT-001")).toBe("Persona: tutor");
+  });
+});

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-11T11:48:42.798Z",
+  "generatedAt": "2026-06-11T12:01:47.338Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1643,
-  "edgeCount": 3786,
+  "fileCount": 1645,
+  "edgeCount": 3791,
   "skippedEdges": 1,
   "edges": [
     {
@@ -2602,6 +2602,10 @@
     {
       "from": "app/api/courses/[courseId]/distribution-advisory/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/dry-run-prompt/route.ts",
+      "to": "lib/cascade/resolvers/identity-spec.ts"
     },
     {
       "from": "app/api/courses/[courseId]/dry-run-prompt/route.ts",
@@ -7869,7 +7873,23 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "components/cascade/CascadeInspectorTray.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "components/cascade/LayerBadge.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "to": "components/session-flow/SessionFlowEditor.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "lib/domain/generate-identity.ts"
     },
     {
       "from": "app/x/courses/[courseId]/chat/ChatLauncher.tsx",
@@ -16056,7 +16076,7 @@
     {
       "path": "app/api/courses/[courseId]/dry-run-prompt/route.ts",
       "inDegree": 0,
-      "outDegree": 4
+      "outDegree": 5
     },
     {
       "path": "app/api/courses/[courseId]/genome/route.ts",
@@ -18281,7 +18301,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "inDegree": 1,
-      "outDegree": 3
+      "outDegree": 7
     },
     {
       "path": "app/x/courses/[courseId]/_components/authored-modules-panel.css",
@@ -19369,6 +19389,16 @@
       "outDegree": 0
     },
     {
+      "path": "components/cascade/CascadeInspectorTray.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/cascade/LayerBadge.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/cockpit/AIEngineSettingsCard.tsx",
       "inDegree": 1,
       "outDegree": 0
@@ -20435,7 +20465,7 @@
     },
     {
       "path": "lib/cascade/layer-types.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 0
     },
     {
@@ -20445,7 +20475,7 @@
     },
     {
       "path": "lib/cascade/resolvers/identity-spec.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 4
     },
     {
@@ -21145,7 +21175,7 @@
     },
     {
       "path": "lib/domain/generate-identity.ts",
-      "inDegree": 0,
+      "inDegree": 1,
       "outDegree": 5
     },
     {

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-11T11:48:41.648Z",
+  "generatedAt": "2026-06-11T12:01:46.432Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-11T11:48:42.134Z",
+  "generatedAt": "2026-06-11T12:01:46.809Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

- PreviewLens Educator view gets a new `IdentityHeader` above the transcript: `[SYS|DOM|PB]` badge + caption `"Persona: tutor from System default"` + click → `CascadeInspectorTray`
- PreviewLens Engineer view's `Identity` stat now reads `"<spec name> (SYS|DOM|PB)"`
- `dry-run-prompt` route gains additive `identitySpecSource` + `identitySpecExtendsAgent` metadata fields — existing `identitySpec` name string is unchanged
- New exported `getArchetypeLabel(slug)` helper in `lib/domain/generate-identity.ts` for slug → display label

> **Stacked on #1474 → #1473.** Once those merge, this rebases cleanly onto main.

## Honest about TODO(playbook-identity-cascade)

The resolver's PLAYBOOK layer returns `null` today (column doesn't exist; PlaybookItem walk deferred). So the badge shows `[DOM]` or `[SYS]` — never fabricates `[PB]`. That's correct cascade-honesty behaviour, not a bug. Follow-on tracked in resolver comments.

## Verified by

- `tests/components/course-design/preview-identity-header.test.tsx` — 11 tests (envelope shape × caption rules × known/unknown archetype slug)
- `tests/components/cascade/*` + `tests/components/course-design/*` + `tests/components/session-flow/*` — all 50 prior pass unchanged
- pre-push tsc + eslint on changed files: ✓

```
Test Files  7 passed (7)
     Tests  61 passed (61)
```

## Acceptance criteria checklist

- [x] `POST /api/courses/[courseId]/dry-run-prompt` metadata includes `identitySpecSource` + `identitySpecExtendsAgent` (additive)
- [x] PreviewLens Educator renders identity row with `<LayerBadge>` chip showing winning layer
- [x] Caption: `"Persona: <archetype label> from <layer label>"`
- [x] SYSTEM source caption appends `"(no override at Course/Domain)"`
- [x] Badge click opens `<CascadeInspectorTray knobKey="identitySpecId" />` (kebab pattern from #1469 stacked above)
- [x] Engineer view `Identity` stat appends `(SYS|DOM|PB)`
- [x] No regression to existing PreviewLens bubble rendering
- [x] No regression to dry-run `identitySpec` name string consumers (Engineer view + tests)
- [x] 4+ vitests pass (Course / Domain / System / null spec; we shipped 11)
- [x] `TODO(playbook-identity-cascade)` honoured — no fake `[PB]` hit ever fabricated

## Out of scope

- Resolving `TODO(playbook-identity-cascade)` (PlaybookItem IDENTITY walk) — separate follow-up
- Write-path / `ScopePicker` integration to override at Domain — Layer 2 polish follow-on
- Settings tab identity-spec field — no dedicated field exists today

## Deploy

`/vm-cp` (no schema, no migration)

Closes #1472
Refs Epic #1442 (Layer 2), #1471, #1469

🤖 Generated with [Claude Code](https://claude.com/claude-code)