### PR TITLE
fix(cascade): hide LayerBadge on non-cascade knobs (skill_* rows)

### DIFF
--- a/apps/admin/components/course-design/FirstSessionSettings.tsx
+++ b/apps/admin/components/course-design/FirstSessionSettings.tsx
@@ -29,6 +29,7 @@ import type { PlaybookConfig } from "@/lib/types/json-fields";
 import { LayerBadge } from "@/components/cascade/LayerBadge";
 import { CascadeInspectorTray } from "@/components/cascade/CascadeInspectorTray";
 import type { Effective } from "@/lib/cascade/layer-types";
+import { isResolvableKnob } from "@/lib/cascade/effective-value";
 
 interface Call1OverrideSample {
   id: string;
@@ -398,20 +399,22 @@ export function FirstSessionSettings({
                   >
                     {row.value.toFixed(2)}
                   </span>
-                  <LayerBadge
-                    envelope={envelopeFor(
-                      row.parameterId,
-                      row.value,
-                      row.updatedAt,
-                    )}
-                    hideSubtitle
-                    onInspect={() =>
-                      setInspecting({
-                        parameterId: row.parameterId,
-                        label: param?.label ?? row.parameterId,
-                      })
-                    }
-                  />
+                  {isResolvableKnob(row.parameterId) ? (
+                    <LayerBadge
+                      envelope={envelopeFor(
+                        row.parameterId,
+                        row.value,
+                        row.updatedAt,
+                      )}
+                      hideSubtitle
+                      onInspect={() =>
+                        setInspecting({
+                          parameterId: row.parameterId,
+                          label: param?.label ?? row.parameterId,
+                        })
+                      }
+                    />
+                  ) : null}
                   <span className="hf-category-label" data-tone="info">
                     Managed via AgentTuner
                   </span>
@@ -460,19 +463,21 @@ export function FirstSessionSettings({
                   className="hf-input"
                 />
                 <span className="hf-text-xs hf-text-muted">{row.value.toFixed(2)}</span>
-                <LayerBadge
-                  envelope={envelopeFor(row.parameterId, row.value, null)}
-                  hideSubtitle
-                  onInspect={() => {
-                    const param = COMMON_BEHAVIOR_PARAMS.find(
-                      (p) => p.id === row.parameterId,
-                    );
-                    setInspecting({
-                      parameterId: row.parameterId,
-                      label: param?.label ?? row.parameterId,
-                    });
-                  }}
-                />
+                {isResolvableKnob(row.parameterId) ? (
+                  <LayerBadge
+                    envelope={envelopeFor(row.parameterId, row.value, null)}
+                    hideSubtitle
+                    onInspect={() => {
+                      const param = COMMON_BEHAVIOR_PARAMS.find(
+                        (p) => p.id === row.parameterId,
+                      );
+                      setInspecting({
+                        parameterId: row.parameterId,
+                        label: param?.label ?? row.parameterId,
+                      });
+                    }}
+                  />
+                ) : null}
                 <button
                   type="button"
                   className="hf-btn hf-btn-sm hf-btn-destructive"

--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -114,6 +114,17 @@ function pickResolver(knobKey: string): AnyResolver {
   );
 }
 
+/**
+ * True when `knobKey` matches a registered cascade family. UI consumers
+ * use this to gate `<LayerBadge>` rendering — rows for parameters that
+ * aren't cascade-resolvable (e.g., `skill_*` capture fields) should not
+ * surface the badge / kebab affordance, because clicking them would
+ * surface "Unknown cascade knob key" instead of useful provenance.
+ */
+export function isResolvableKnob(knobKey: string): boolean {
+  return FAMILIES.some((fam) => fam.match(knobKey));
+}
+
 // ── Cache ──────────────────────────────────────────────────────────────
 
 const CACHE_TTL_MS = 30_000;

--- a/apps/admin/tests/lib/cascade/effective-value.test.ts
+++ b/apps/admin/tests/lib/cascade/effective-value.test.ts
@@ -200,3 +200,35 @@ describe("isLayerHit", () => {
     expect(isLayerHit(envelope, "DOMAIN")).toBe(false);
   });
 });
+
+describe("isResolvableKnob", () => {
+  it("BEH-* keys are resolvable (behavior-target family)", async () => {
+    const { isResolvableKnob } = await import("@/lib/cascade/effective-value");
+    expect(isResolvableKnob("BEH-RESPONSE-LEN")).toBe(true);
+    expect(isResolvableKnob("BEH-CONVERSATIONAL-TONE")).toBe(true);
+    expect(isResolvableKnob("BEH-WARMTH")).toBe(true);
+  });
+
+  it("known single-key families resolve", async () => {
+    const { isResolvableKnob } = await import("@/lib/cascade/effective-value");
+    expect(isResolvableKnob("welcomeMessage")).toBe(true);
+    expect(isResolvableKnob("identitySpecId")).toBe(true);
+    expect(isResolvableKnob("voiceProvider")).toBe(true);
+    expect(isResolvableKnob("voiceId")).toBe(true);
+    expect(isResolvableKnob("model")).toBe(true);
+    expect(isResolvableKnob("language")).toBe(true);
+    expect(isResolvableKnob("onboarding")).toBe(true);
+    expect(isResolvableKnob("intake")).toBe(true);
+    expect(isResolvableKnob("stops")).toBe(true);
+    expect(isResolvableKnob("offboarding")).toBe(true);
+  });
+
+  it("returns false for skill_* and other non-cascade parameter ids", async () => {
+    const { isResolvableKnob } = await import("@/lib/cascade/effective-value");
+    expect(isResolvableKnob("skill_self_locate")).toBe(false);
+    expect(isResolvableKnob("skill_catch_the_misconception")).toBe(false);
+    expect(isResolvableKnob("skill_name_the_trade")).toBe(false);
+    expect(isResolvableKnob("")).toBe(false);
+    expect(isResolvableKnob("random_unknown_key")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Live-reported by the operator after #1473 made the kebab affordance discoverable: clicking the badge on a `skill_*` row in **First Session Settings → First-call AI behaviour targets** opened the cascade inspector tray showing:

> Could not load cascade — Unknown cascade knob key: \"skill_self_locate\". Known families: behavior-target, welcome-message, session-flow, voice-config, identity-spec

## Root cause

`FirstSessionSettings` renders a `<LayerBadge>` per editable row regardless of whether the row's `parameterId` matches a registered cascade family. `skill_*` parameters live in playbook config but aren't cascade-resolvable — there's no Domain or System layer to walk.

The badge was wired in #1467 (paw2paw). #1469's kebab affordance made the broken click discoverable rather than the badge itself being new.

## Fix

- New `isResolvableKnob(knobKey)` exported from `lib/cascade/effective-value.ts` — reads the same `FAMILIES` dispatch table that `pickResolver` uses (single source of truth, so adding a new family auto-extends the gate)
- `FirstSessionSettings` gates both `LayerBadge` call sites on it — skill_* rows render without a badge, honest about what cascades

## Verified by

- `tests/lib/cascade/effective-value.test.ts` — 3 new tests on `isResolvableKnob` (BEH-* matches, 10 single-key families match, skill_* + empty + unknown all reject); 11 prior tests pass unchanged
- `tests/components/course-design/FirstSessionSettings-behaviorTarget.test.tsx` — 6 existing tests pass unchanged

```
Test Files  2 passed (2)
     Tests  20 passed (20)
```

## Acceptance criteria

- [x] Clicking any `[PB]` on a `skill_*` row no longer surfaces a cascade error
- [x] BEH-* rows still get the badge + tray as before
- [x] When a new cascade family is registered (e.g. follow-on Layer 2 work), the gate auto-extends — no consumer change required
- [x] No regression to existing First Session Settings behaviour

## Deploy

`/vm-cp` (no schema, no migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)