### PR TITLE
feat(course-design): #1478 Voice Flow lens — dynamic flowchart of call voice settings

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
@@ -40,6 +40,7 @@ import {
   Sliders,
   Compass,
   Eye,
+  Workflow,
 } from "lucide-react";
 import {
   ConsoleShell,
@@ -55,6 +56,8 @@ import { FeltProgressSettings } from "@/components/course-design/FeltProgressSet
 import { TolerancesSettings } from "@/components/course-design/TolerancesSettings";
 import { BandingPicker } from "@/components/shared/BandingPicker";
 import { PreviewLens } from "./PreviewLens";
+import { VoiceFlowLens } from "./VoiceFlowLens";
+import "./voice-flow-lens.css";
 import { StalePromptPillForCourse } from "@/components/callers/caller-detail/StalePromptPillForCourse";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 
@@ -70,7 +73,8 @@ type DesignLensId =
   | "tolerances"
   | "skillBanding"
   | "progressSignals"
-  | "agentTunerNlp";
+  | "agentTunerNlp"
+  | "voiceFlow";
 
 /** Preview moved to the top of the nav (2026-06-07) — it's now the
  *  canonical landing surface: educator sees the full call walkthrough,
@@ -88,6 +92,7 @@ const DESIGN_LENS_ORDER: DesignLensId[] = [
   "skillBanding",
   "progressSignals",
   "agentTunerNlp",
+  "voiceFlow",
 ];
 
 interface LensProps {
@@ -145,6 +150,11 @@ const PreviewLensWrap: React.FC<LensProps> = ({ courseId }) => (
   <PreviewLens courseId={courseId} />
 );
 PreviewLensWrap.displayName = "PreviewLensWrap";
+
+const VoiceFlowLensWrap: React.FC<LensProps> = ({ courseId }) => (
+  <VoiceFlowLens courseId={courseId} />
+);
+VoiceFlowLensWrap.displayName = "VoiceFlowLensWrap";
 
 const DESIGN_LENSES: Record<DesignLensId, ConsoleLensDef<LensProps>> = {
   // #1316 — Number the JOURNEY lenses ① ② ③ ④ ⑤ so the operator sees the
@@ -235,6 +245,13 @@ const DESIGN_LENSES: Record<DesignLensId, ConsoleLensDef<LensProps>> = {
     iconNode: <Eye size={ICON_SIZE} />,
     blurb: "Educator view + Engineer view of what Call 1 will look like.",
     Component: PreviewLensWrap,
+  },
+  voiceFlow: {
+    id: "voiceFlow",
+    label: "Voice Flow",
+    iconNode: <Workflow size={ICON_SIZE} />,
+    blurb: "Flowchart of cascade-bound voice settings — provider, voice, transcriber, during-the-call behaviours.",
+    Component: VoiceFlowLensWrap,
   },
 };
 

--- a/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
@@ -98,6 +98,11 @@ const DESIGN_LENS_ORDER: DesignLensId[] = [
 interface LensProps {
   courseId: string;
   playbookConfig?: PlaybookConfig | Record<string, unknown> | null;
+  /** Called by lenses after a successful cascade write that may have
+   *  marked demo callers stale (e.g. Voice Flow lens edits voice
+   *  config). Bumps `staleRefreshTick` so `StalePromptPillForCourse`
+   *  re-fetches without a page reload (#1478 Amendment A). */
+  onComposeInputChange?: () => void;
 }
 
 const ICON_SIZE = 14;
@@ -151,8 +156,8 @@ const PreviewLensWrap: React.FC<LensProps> = ({ courseId }) => (
 );
 PreviewLensWrap.displayName = "PreviewLensWrap";
 
-const VoiceFlowLensWrap: React.FC<LensProps> = ({ courseId }) => (
-  <VoiceFlowLens courseId={courseId} />
+const VoiceFlowLensWrap: React.FC<LensProps> = ({ courseId, onComposeInputChange }) => (
+  <VoiceFlowLens courseId={courseId} onComposeInputChange={onComposeInputChange} />
 );
 VoiceFlowLensWrap.displayName = "VoiceFlowLensWrap";
 
@@ -282,12 +287,20 @@ export function CourseDesignConsole({
     consoleId: "course-design",
   });
 
+  // #1478 Amendment A — when a lens reports a compose-input change
+  // (e.g. Voice Flow lens saves voice config), bump this tick so the
+  // header staleness banner re-fetches without a page reload.
+  const [staleRefreshTick, setStaleRefreshTick] = React.useState(0);
+  const onComposeInputChange = React.useCallback(() => {
+    setStaleRefreshTick((n) => n + 1);
+  }, []);
+
   return (
     <>
       <ConsoleShell<DesignLensId, LensProps>
         lensOrder={DESIGN_LENS_ORDER}
         lenses={DESIGN_LENSES}
-        lensProps={{ courseId, playbookConfig }}
+        lensProps={{ courseId, playbookConfig, onComposeInputChange }}
         activeLensId={view}
         onLensChange={setView}
         ariaNavLabel="Course design lenses"
@@ -295,7 +308,12 @@ export function CourseDesignConsole({
         comingSoonHelpText={COMING_SOON_HELP}
         // #1429 — staleness aggregate above the lens nav. Self-hides
         // when no demo callers on this course have a stale prompt.
-        headerBanner={<StalePromptPillForCourse courseId={courseId} />}
+        headerBanner={
+          <StalePromptPillForCourse
+            courseId={courseId}
+            refreshKey={staleRefreshTick}
+          />
+        }
       />
     </>
   );

--- a/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
@@ -56,7 +56,13 @@ import { FeltProgressSettings } from "@/components/course-design/FeltProgressSet
 import { TolerancesSettings } from "@/components/course-design/TolerancesSettings";
 import { BandingPicker } from "@/components/shared/BandingPicker";
 import { PreviewLens } from "./PreviewLens";
-import { VoiceFlowLens } from "./VoiceFlowLens";
+// Voice Flow lens is the heaviest of the 13 — it imports HFDrawer
+// (Radix Dialog), FieldRow + VoiceSampleButton (with blob playback),
+// and useSession. Lazy-loaded to keep it out of the Design tab's
+// initial bundle (#1478 non-functional AC).
+const VoiceFlowLensLazy = React.lazy(() =>
+  import("./VoiceFlowLens").then((m) => ({ default: m.VoiceFlowLens })),
+);
 import "./voice-flow-lens.css";
 import { StalePromptPillForCourse } from "@/components/callers/caller-detail/StalePromptPillForCourse";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
@@ -157,7 +163,18 @@ const PreviewLensWrap: React.FC<LensProps> = ({ courseId }) => (
 PreviewLensWrap.displayName = "PreviewLensWrap";
 
 const VoiceFlowLensWrap: React.FC<LensProps> = ({ courseId, onComposeInputChange }) => (
-  <VoiceFlowLens courseId={courseId} onComposeInputChange={onComposeInputChange} />
+  <React.Suspense
+    fallback={
+      <div className="hf-card">
+        <div className="hf-text-muted hf-text-sm">Loading voice flow…</div>
+      </div>
+    }
+  >
+    <VoiceFlowLensLazy
+      courseId={courseId}
+      onComposeInputChange={onComposeInputChange}
+    />
+  </React.Suspense>
 );
 VoiceFlowLensWrap.displayName = "VoiceFlowLensWrap";
 

--- a/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
@@ -23,14 +23,17 @@
 
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { useSession } from "next-auth/react";
 import { Pencil, Phone, BarChart3 } from "lucide-react";
 import {
   sourceBadge,
   fieldMeta,
+  FieldRow,
   type ResolvedField,
   type SchemaField,
 } from "@/components/voice/VoiceConfigSection";
+import { HFDrawer } from "@/components/shared/HFDrawer";
 
 /* ── Hardcoded exclusion ─────────────────────────────────
    `fillerInjectionEnabled` is declared in the VAPI provider schema at
@@ -186,12 +189,36 @@ interface VoiceFlowLensProps {
   /** Course id from the Console — equal to the Playbook id used by
    *  the cascade routes. Identity asserted at fetch boundary. */
   courseId: string;
+  /** Called after a successful save / reset so the Course Design
+   *  Console's staleness banner can re-fetch (#1478 Amendment A). */
+  onComposeInputChange?: () => void;
 }
 
-export function VoiceFlowLens({ courseId }: VoiceFlowLensProps): React.ReactElement {
+/* Roles that may PATCH /api/playbooks/[id]/voice-config (the route
+   enforces OPERATOR at route.ts:97). Mirrored client-side so the ✏️
+   button is visibly disabled for under-privileged sessions instead of
+   firing a silent 403 (#1478 Amendment C). */
+const OPERATOR_ROLES: ReadonlySet<string> = new Set([
+  "OPERATOR",
+  "EDUCATOR",
+  "ADMIN",
+  "SUPERADMIN",
+]);
+
+export function VoiceFlowLens({
+  courseId,
+  onComposeInputChange,
+}: VoiceFlowLensProps): React.ReactElement {
   const [data, setData] = useState<VoicePayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [drawerKey, setDrawerKey] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState<string | null>(null);
+
+  const session = useSession();
+  const role = (session.data?.user as { role?: string } | undefined)?.role ?? "";
+  const canEdit = useMemo(() => OPERATOR_ROLES.has(role), [role]);
 
   // `courseId` is the Playbook id at the route level — same identity
   // the Tolerances lens uses (CourseDesignConsole.tsx:127).
@@ -217,6 +244,43 @@ export function VoiceFlowLens({ courseId }: VoiceFlowLensProps): React.ReactElem
   useEffect(() => {
     void load();
   }, [load]);
+
+  const persist = useCallback(
+    async (key: string, value: unknown): Promise<void> => {
+      if (!canEdit) return;
+      setBusyKey(key);
+      setError(null);
+      try {
+        const res = await fetch(`/api/playbooks/${playbookId}/voice-config`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ key, value }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || `HTTP ${res.status}`);
+        }
+        await load();
+        setSavedFlash(key);
+        setTimeout(() => {
+          setSavedFlash((cur) => (cur === key ? null : cur));
+        }, 1500);
+        // #1478 Amendment A — tell the console the cascade changed so
+        // the staleness banner can re-fetch.
+        onComposeInputChange?.();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [canEdit, playbookId, load, onComposeInputChange],
+  );
+
+  const reset = useCallback(
+    (key: string): Promise<void> => persist(key, null),
+    [persist],
+  );
 
   if (loading && !data) {
     return <VoiceFlowSkeleton />;
@@ -314,6 +378,9 @@ export function VoiceFlowLens({ courseId }: VoiceFlowLensProps): React.ReactElem
                         row={row}
                         resolved={data.resolved.fields[row.key]!}
                         schemaFields={data.schemaFields}
+                        canEdit={canEdit}
+                        justSaved={savedFlash === row.key}
+                        onEdit={() => setDrawerKey(row.key)}
                       />
                     ))}
                   </div>
@@ -333,7 +400,78 @@ export function VoiceFlowLens({ courseId }: VoiceFlowLensProps): React.ReactElem
           );
         })}
       </ol>
+
+      <VoiceFlowEditDrawer
+        drawerKey={drawerKey}
+        data={data}
+        busyKey={busyKey}
+        savedFlash={savedFlash}
+        onClose={() => setDrawerKey(null)}
+        onSave={persist}
+        onReset={reset}
+      />
     </div>
+  );
+}
+
+interface VoiceFlowEditDrawerProps {
+  drawerKey: string | null;
+  data: VoicePayload;
+  busyKey: string | null;
+  savedFlash: string | null;
+  onClose: () => void;
+  onSave: (key: string, value: unknown) => Promise<void>;
+  onReset: (key: string) => Promise<void>;
+}
+
+function VoiceFlowEditDrawer({
+  drawerKey,
+  data,
+  busyKey,
+  savedFlash,
+  onClose,
+  onSave,
+  onReset,
+}: VoiceFlowEditDrawerProps): React.ReactElement {
+  const key = drawerKey ?? "";
+  const resolved = key ? data.resolved.fields[key] : undefined;
+  const meta = key ? fieldMeta(key, data.schemaFields) : null;
+  const courseOverrides = data.courseOverrides ?? {};
+  const isThisLayer = key !== "" && Object.prototype.hasOwnProperty.call(courseOverrides, key);
+  const open = drawerKey !== null && resolved !== undefined && meta !== null;
+
+  return (
+    <HFDrawer
+      open={open}
+      onClose={onClose}
+      title={meta?.label ?? "Edit cascade key"}
+      description="Edit one cascade-bound voice setting. Save persists at the course layer; Reset clears the override and falls back through System → Provider → Domain → Course."
+      width={520}
+    >
+      {open && resolved && meta && (
+        <div className="hf-voice-flow-drawer-body">
+          <FieldRow
+            meta={meta}
+            resolved={resolved}
+            scope="course"
+            isThisLayer={isThisLayer}
+            busyKey={busyKey}
+            savedFlash={savedFlash}
+            onSave={async (k, v) => {
+              await onSave(k, v);
+            }}
+            onReset={async (k) => {
+              await onReset(k);
+            }}
+            voiceCatalog={undefined}
+            currentVoiceProvider={
+              (data.resolved.fields.voiceProvider?.value as string | undefined) ?? null
+            }
+            enabledProviderId={data.enabledProviderId ?? null}
+          />
+        </div>
+      )}
+    </HFDrawer>
   );
 }
 
@@ -341,19 +479,28 @@ interface VoiceFlowRowProps {
   row: NodeRowDef;
   resolved: ResolvedField;
   schemaFields: SchemaField[];
+  canEdit: boolean;
+  justSaved: boolean;
+  onEdit: () => void;
 }
 
 function VoiceFlowRow({
   row,
   resolved,
   schemaFields,
+  canEdit,
+  justSaved,
+  onEdit,
 }: VoiceFlowRowProps): React.ReactElement {
   const meta = fieldMeta(row.key, schemaFields);
   const label = row.labelOverride ?? meta.label;
   const value = formatValue(resolved.value, meta.type);
 
   return (
-    <div className="hf-voice-flow-row">
+    <div
+      className={`hf-voice-flow-row${justSaved ? " hf-glow-active" : ""}`}
+      data-key={row.key}
+    >
       <div className="hf-voice-flow-row-label">
         <span className="hf-voice-flow-row-name">{label}</span>
         {row.subtitle && (
@@ -369,8 +516,9 @@ function VoiceFlowRow({
           type="button"
           className="hf-btn hf-btn-secondary hf-voice-flow-edit"
           aria-label={`Edit ${label}`}
-          title="Edit drawer — Slice 2"
-          disabled
+          title={canEdit ? "Edit this setting" : "Operator access required"}
+          disabled={!canEdit}
+          onClick={onEdit}
         >
           <Pencil size={12} aria-hidden="true" />
         </button>

--- a/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
@@ -115,7 +115,6 @@ const NODES: NodeDef[] = [
       {
         key: "voiceId",
         labelOverride: "Voice ID",
-        subtitle: "Sample with ▶ Test voice in the edit drawer.",
       },
     ],
   },
@@ -123,7 +122,8 @@ const NODES: NodeDef[] = [
     id: "transcriber",
     marker: "③",
     title: "Transcriber",
-    subtitle: "What converts the learner's speech into text the LLM sees.",
+    subtitle:
+      "Converts the learner's spoken words into text so the tutor can understand them.",
     rows: [
       {
         key: "transcriber",
@@ -153,7 +153,7 @@ const NODES: NodeDef[] = [
       {
         key: "voicemailDetectionEnabled",
         labelOverride: "Voicemail detection",
-        subtitle: "End the call early if VAPI detects an answering machine.",
+        subtitle: "End the call early if an answering machine is detected.",
       },
       {
         key: "maxCostPerCallUsd",
@@ -289,7 +289,10 @@ export function VoiceFlowLens({
   if (error) {
     return (
       <div className="hf-banner hf-banner-error">
-        <strong>Voice config:</strong> {error}{" "}
+        <strong>We couldn&rsquo;t load the voice settings for this course.</strong>
+        <span className="hf-text-muted hf-text-xs hf-voice-flow-error-detail">
+          {" "}({error})
+        </span>{" "}
         <button
           type="button"
           className="hf-btn hf-btn-secondary hf-voice-flow-retry"
@@ -311,11 +314,9 @@ export function VoiceFlowLens({
     <div className="hf-voice-flow">
       <header className="hf-voice-flow-intro">
         <div className="hf-text-muted hf-text-sm">
-          Provider: <strong>{data.enabledProviderSlug}</strong> (locked at
-          system level). Cascade is{" "}
-          <em>System → Provider → Domain → Course</em>. Edit a field to set
-          it at this layer; clear it (↺ Reset) to fall back through the
-          cascade.
+          Settings inherit from the system default unless overridden here.
+          Edit any field to set a course-specific value. Clear it (↺ Reset)
+          to go back to the inherited default.
         </div>
       </header>
 
@@ -516,7 +517,11 @@ function VoiceFlowRow({
           type="button"
           className="hf-btn hf-btn-secondary hf-voice-flow-edit"
           aria-label={`Edit ${label}`}
-          title={canEdit ? "Edit this setting" : "Operator access required"}
+          title={
+            canEdit
+              ? "Edit this setting"
+              : "Only admins can edit this — contact your administrator."
+          }
           disabled={!canEdit}
           onClick={onEdit}
         >

--- a/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
@@ -1,0 +1,437 @@
+/**
+ * Voice Flow lens (#1478) — 13th lens on the Course Design Console.
+ *
+ * Renders a vertical flowchart of how a voice call will work for this
+ * course, with cascade-bound voice settings shown as numbered nodes.
+ * Each editable row carries an origin pill (System / Provider / Domain /
+ * Course) sourced from the existing 4-layer voice cascade.
+ *
+ * Slice 1: read-only diagram. ✏️ buttons are present but no-op.
+ * Slice 2 wires HFDrawer + the exported <FieldRow> for the edit
+ * round-trip via PATCH /api/playbooks/[id]/voice-config.
+ *
+ * Reads the cascade via the existing
+ *   GET /api/playbooks/[playbookId]/voice-config
+ * (same wrapper VoiceConfigSection uses). Does NOT call
+ * loadResolvedVoiceConfig directly — that's server-only.
+ *
+ * The lens consumes `courseId` but the URL+route are keyed by
+ * `playbookId`. `playbookId === courseId` in this codebase (Tolerances
+ * lens at CourseDesignConsole.tsx:127 uses the same identity); the
+ * identity is asserted at the fetch boundary below.
+ */
+
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Pencil, Phone, BarChart3 } from "lucide-react";
+import {
+  sourceBadge,
+  fieldMeta,
+  type ResolvedField,
+  type SchemaField,
+} from "@/components/voice/VoiceConfigSection";
+
+/* ── Hardcoded exclusion ─────────────────────────────────
+   `fillerInjectionEnabled` is declared in the VAPI provider schema at
+   lib/voice/providers/vapi/index.ts:614 but explicitly no-op'd at line
+   307 because VAPI rejects it with HTTP 400 (incident #1382, 2026-06-09).
+   Editing it does NOT reach live calls. Rendering it as editable would
+   mislead educators, so the lens excludes it silently — no "coming
+   soon" copy, no placeholder. */
+const EXCLUDED_KEYS: ReadonlySet<string> = new Set(["fillerInjectionEnabled"]);
+
+interface VoicePayload {
+  ok: boolean;
+  enabledProviderSlug: string;
+  enabledProviderId?: string | null;
+  resolved: {
+    provider: ResolvedField<string>;
+    model: ResolvedField<string | null>;
+    fields: Record<string, ResolvedField>;
+  };
+  allowedKeys: string[];
+  schemaFields: SchemaField[];
+  courseOverrides?: Record<string, unknown>;
+}
+
+interface NodeRowDef {
+  /** Cascade key this row reads from. */
+  key: string;
+  /** Override the schema-resolved label (for re-narration). */
+  labelOverride?: string;
+  /** Subtitle copy below the label. */
+  subtitle?: string;
+}
+
+interface NodeDef {
+  /** DOM id stem — used for aria-labelledby. */
+  id: string;
+  /** Visual marker rendered in the gutter (number, icon, or emoji). */
+  marker: React.ReactNode;
+  /** Node title rendered in the header strip. */
+  title: string;
+  /** Optional helper copy under the title. */
+  subtitle?: string;
+  /** Cascade-bound rows rendered inside this node, in order. When
+   *  empty, the node renders as a label-only step (Pickup / Post-call). */
+  rows: NodeRowDef[];
+  /** When provided, this node is hidden if `enabledProviderSlug !==
+   *  requireProvider`. The "During the call" + transcriber-endpointing
+   *  rows are VAPI-specific. */
+  requireProvider?: string;
+}
+
+const NODES: NodeDef[] = [
+  {
+    id: "pickup",
+    marker: <Phone size={18} aria-hidden="true" />,
+    title: "Pickup",
+    subtitle: "The learner answers the call.",
+    rows: [],
+  },
+  {
+    id: "voiceProvider",
+    marker: "①",
+    title: "Voice Provider",
+    subtitle: "TTS engine your tutor speaks through.",
+    rows: [
+      {
+        key: "voiceProvider",
+        labelOverride: "Voice engine",
+        subtitle: "Deepgram, OpenAI, ElevenLabs, …",
+      },
+    ],
+  },
+  {
+    id: "selectedVoice",
+    marker: "②",
+    title: "Selected Voice",
+    subtitle: "The specific voice the tutor uses.",
+    rows: [
+      {
+        key: "voiceId",
+        labelOverride: "Voice ID",
+        subtitle: "Sample with ▶ Test voice in the edit drawer.",
+      },
+    ],
+  },
+  {
+    id: "transcriber",
+    marker: "③",
+    title: "Transcriber",
+    subtitle: "What converts the learner's speech into text the LLM sees.",
+    rows: [
+      {
+        key: "transcriber",
+        labelOverride: "Engine",
+      },
+      {
+        key: "transcriberEndpointingMs",
+        labelOverride: "Endpointing (ms)",
+        subtitle: "How long of a silence counts as 'end of turn'.",
+      },
+    ],
+    requireProvider: "vapi",
+  },
+  {
+    id: "duringCall",
+    marker: "④",
+    title: "During the call",
+    subtitle:
+      "Live behaviours that change how the call sounds and stops.",
+    rows: [
+      {
+        key: "transcriptStreamEnabled",
+        labelOverride: "Live transcript stream",
+        subtitle:
+          "Show the learner the running transcript while they speak.",
+      },
+      {
+        key: "voicemailDetectionEnabled",
+        labelOverride: "Voicemail detection",
+        subtitle: "End the call early if VAPI detects an answering machine.",
+      },
+      {
+        key: "maxCostPerCallUsd",
+        labelOverride: "Cost cap (USD / call)",
+        subtitle: "Hard ceiling on cost. Empty = no cap.",
+      },
+    ],
+  },
+  {
+    id: "endOfCall",
+    marker: "⑤",
+    title: "End of call",
+    subtitle: "What runs after the learner hangs up.",
+    rows: [
+      {
+        key: "autoPipeline",
+        labelOverride: "Auto-run pipeline",
+        subtitle:
+          "Run the post-call analysis pipeline (memories, traits, target adapts) automatically.",
+      },
+    ],
+  },
+  {
+    id: "postCall",
+    marker: <BarChart3 size={18} aria-hidden="true" />,
+    title: "Post-call summary",
+    subtitle: "Educator dashboards + learner trajectory update.",
+    rows: [],
+  },
+];
+
+interface VoiceFlowLensProps {
+  /** Course id from the Console — equal to the Playbook id used by
+   *  the cascade routes. Identity asserted at fetch boundary. */
+  courseId: string;
+}
+
+export function VoiceFlowLens({ courseId }: VoiceFlowLensProps): React.ReactElement {
+  const [data, setData] = useState<VoicePayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // `courseId` is the Playbook id at the route level — same identity
+  // the Tolerances lens uses (CourseDesignConsole.tsx:127).
+  const playbookId = courseId;
+
+  const load = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/playbooks/${playbookId}/voice-config`);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const json = (await res.json()) as VoicePayload;
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [playbookId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading && !data) {
+    return <VoiceFlowSkeleton />;
+  }
+
+  if (error) {
+    return (
+      <div className="hf-banner hf-banner-error">
+        <strong>Voice config:</strong> {error}{" "}
+        <button
+          type="button"
+          className="hf-btn hf-btn-secondary hf-voice-flow-retry"
+          onClick={() => void load()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <VoiceFlowSkeleton />;
+  }
+
+  const isVapi = data.enabledProviderSlug === "vapi";
+
+  return (
+    <div className="hf-voice-flow">
+      <header className="hf-voice-flow-intro">
+        <div className="hf-text-muted hf-text-sm">
+          Provider: <strong>{data.enabledProviderSlug}</strong> (locked at
+          system level). Cascade is{" "}
+          <em>System → Provider → Domain → Course</em>. Edit a field to set
+          it at this layer; clear it (↺ Reset) to fall back through the
+          cascade.
+        </div>
+      </header>
+
+      <ol
+        className="hf-voice-flow-nodes"
+        aria-label="Call lifecycle voice configuration"
+      >
+        {NODES.map((node, idx) => {
+          const isHidden = Boolean(
+            node.requireProvider && node.requireProvider !== data.enabledProviderSlug,
+          );
+
+          if (isHidden) {
+            return (
+              <VoiceFlowNonVapiPlaceholder
+                key={node.id}
+                node={node}
+                provider={data.enabledProviderSlug}
+                isLast={idx === NODES.length - 1}
+              />
+            );
+          }
+
+          // Filter out excluded + unknown rows.
+          const visibleRows = node.rows.filter(
+            (row) =>
+              !EXCLUDED_KEYS.has(row.key) &&
+              data.resolved.fields[row.key] !== undefined,
+          );
+
+          return (
+            <li
+              key={node.id}
+              className="hf-voice-flow-node"
+              aria-labelledby={`hf-voice-flow-${node.id}-title`}
+            >
+              <div className="hf-voice-flow-marker" aria-hidden="true">
+                {node.marker}
+              </div>
+              <div className="hf-voice-flow-body">
+                <div className="hf-voice-flow-node-head">
+                  <h3
+                    id={`hf-voice-flow-${node.id}-title`}
+                    className="hf-voice-flow-node-title"
+                  >
+                    {node.title}
+                  </h3>
+                  {node.subtitle && (
+                    <p className="hf-voice-flow-node-subtitle">
+                      {node.subtitle}
+                    </p>
+                  )}
+                </div>
+
+                {visibleRows.length > 0 && (
+                  <div className="hf-voice-flow-rows">
+                    {visibleRows.map((row) => (
+                      <VoiceFlowRow
+                        key={row.key}
+                        row={row}
+                        resolved={data.resolved.fields[row.key]!}
+                        schemaFields={data.schemaFields}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {isVapi && node.id === "duringCall" && visibleRows.length === 0 && (
+                  <div className="hf-voice-flow-empty hf-text-muted hf-text-sm">
+                    No cascade-bound during-call fields surfaced for this
+                    provider.
+                  </div>
+                )}
+              </div>
+              {idx < NODES.length - 1 && (
+                <span className="hf-voice-flow-connector" aria-hidden="true" />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+interface VoiceFlowRowProps {
+  row: NodeRowDef;
+  resolved: ResolvedField;
+  schemaFields: SchemaField[];
+}
+
+function VoiceFlowRow({
+  row,
+  resolved,
+  schemaFields,
+}: VoiceFlowRowProps): React.ReactElement {
+  const meta = fieldMeta(row.key, schemaFields);
+  const label = row.labelOverride ?? meta.label;
+  const value = formatValue(resolved.value, meta.type);
+
+  return (
+    <div className="hf-voice-flow-row">
+      <div className="hf-voice-flow-row-label">
+        <span className="hf-voice-flow-row-name">{label}</span>
+        {row.subtitle && (
+          <span className="hf-voice-flow-row-help hf-text-muted hf-text-xs">
+            {row.subtitle}
+          </span>
+        )}
+      </div>
+      <div className="hf-voice-flow-row-value">
+        <span className="hf-voice-flow-row-value-text">{value}</span>
+        {sourceBadge(resolved.source, "course")}
+        <button
+          type="button"
+          className="hf-btn hf-btn-secondary hf-voice-flow-edit"
+          aria-label={`Edit ${label}`}
+          title="Edit drawer — Slice 2"
+          disabled
+        >
+          <Pencil size={12} aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface VoiceFlowNonVapiPlaceholderProps {
+  node: NodeDef;
+  provider: string;
+  isLast: boolean;
+}
+
+function VoiceFlowNonVapiPlaceholder({
+  node,
+  provider,
+  isLast,
+}: VoiceFlowNonVapiPlaceholderProps): React.ReactElement {
+  return (
+    <li
+      className="hf-voice-flow-node hf-voice-flow-node-disabled"
+      aria-labelledby={`hf-voice-flow-${node.id}-title`}
+    >
+      <div className="hf-voice-flow-marker" aria-hidden="true">
+        {node.marker}
+      </div>
+      <div className="hf-voice-flow-body">
+        <div className="hf-voice-flow-node-head">
+          <h3
+            id={`hf-voice-flow-${node.id}-title`}
+            className="hf-voice-flow-node-title"
+          >
+            {node.title}
+          </h3>
+        </div>
+        <div className="hf-voice-flow-placeholder hf-text-muted hf-text-sm">
+          ⊘ Not configurable for <strong>{provider}</strong> — see provider
+          settings → Voice tab
+        </div>
+      </div>
+      {!isLast && (
+        <span className="hf-voice-flow-connector" aria-hidden="true" />
+      )}
+    </li>
+  );
+}
+
+function VoiceFlowSkeleton(): React.ReactElement {
+  return (
+    <div className="hf-voice-flow hf-voice-flow-skeleton" aria-busy="true">
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <div key={i} className="hf-voice-flow-skeleton-row" />
+      ))}
+    </div>
+  );
+}
+
+function formatValue(value: unknown, type: SchemaField["type"]): string {
+  if (value === null || value === undefined || value === "") return "—";
+  if (type === "boolean") return value ? "On" : "Off";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value);
+}

--- a/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
@@ -224,12 +224,25 @@
   100% { background-position: -200% 0; }
 }
 
-/* ── Save flash (used in Slice 2) ─────────────────────── */
+/* ── Save flash (Slice 2) ─────────────────────────────── */
 
 .hf-voice-flow-row.hf-glow-active {
   outline: 2px solid color-mix(in srgb, var(--status-success-text) 60%, transparent);
   outline-offset: 1px;
-  transition: outline-color 1s ease-out;
+  animation: hf-voice-flow-glow-fade 1.6s ease-out;
+}
+
+@keyframes hf-voice-flow-glow-fade {
+  0% { outline-color: color-mix(in srgb, var(--status-success-text) 60%, transparent); }
+  100% { outline-color: transparent; }
+}
+
+/* ── Drawer body (Slice 2) ────────────────────────────── */
+
+.hf-voice-flow-drawer-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md, 12px);
 }
 
 /* ── Mobile ───────────────────────────────────────────── */

--- a/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
@@ -1,0 +1,268 @@
+/**
+ * Voice Flow lens styles (#1478).
+ *
+ * Vertical 6-node flowchart of cascade-bound voice settings. Uses HF
+ * design tokens — no hardcoded hex, no inline style for static visuals.
+ * Mobile: nodes stack full-width; connector arrows shrink; HFDrawer (in
+ * Slice 2) handles the bottom-up slide on its own.
+ */
+
+.hf-voice-flow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg, 16px);
+  padding: var(--space-lg, 16px) 0;
+}
+
+.hf-voice-flow-intro {
+  padding: var(--space-md, 12px) var(--space-lg, 16px);
+  background: color-mix(in srgb, var(--accent-primary) 4%, var(--surface-primary));
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+}
+
+/* ── Node list ────────────────────────────────────────── */
+
+.hf-voice-flow-nodes {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.hf-voice-flow-node {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: var(--space-md, 12px);
+  position: relative;
+  padding: var(--space-md, 12px) 0;
+}
+
+.hf-voice-flow-node-disabled .hf-voice-flow-body {
+  opacity: 0.7;
+}
+
+/* ── Marker (number / icon) ───────────────────────────── */
+
+.hf-voice-flow-marker {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--surface-secondary);
+  color: var(--text-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  border: 1px solid var(--border-default);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+/* ── Body ─────────────────────────────────────────────── */
+
+.hf-voice-flow-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+}
+
+.hf-voice-flow-node-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hf-voice-flow-node-title {
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--text-default);
+}
+
+.hf-voice-flow-node-subtitle {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── Rows ─────────────────────────────────────────────── */
+
+.hf-voice-flow-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+  padding: var(--space-sm, 8px) 0;
+}
+
+.hf-voice-flow-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-md, 12px);
+  padding: var(--space-md, 12px);
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  align-items: center;
+}
+
+.hf-voice-flow-row-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.hf-voice-flow-row-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-default);
+}
+
+.hf-voice-flow-row-help {
+  line-height: 1.4;
+}
+
+.hf-voice-flow-row-value {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.hf-voice-flow-row-value-text {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-default);
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+  max-width: 220px;
+  text-align: right;
+}
+
+/* ── Edit button ──────────────────────────────────────── */
+
+.hf-voice-flow-edit {
+  padding: 4px 8px;
+  font-size: 12px;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hf-voice-flow-edit[disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* ── Placeholders & empty ─────────────────────────────── */
+
+.hf-voice-flow-placeholder {
+  padding: var(--space-md, 12px);
+  background: var(--surface-secondary);
+  border: 1px dashed var(--border-default);
+  border-radius: 8px;
+  line-height: 1.4;
+}
+
+.hf-voice-flow-empty {
+  padding: var(--space-sm, 8px) 0;
+}
+
+/* ── Connector ────────────────────────────────────────── */
+
+.hf-voice-flow-connector {
+  position: absolute;
+  left: 23px;
+  top: calc(36px + var(--space-md, 12px) + 2px);
+  width: 2px;
+  height: calc(100% - 36px - var(--space-md, 12px) - 2px);
+  background: linear-gradient(
+    to bottom,
+    var(--border-default) 0%,
+    var(--border-default) 70%,
+    color-mix(in srgb, var(--border-default) 30%, transparent) 100%
+  );
+  z-index: 0;
+}
+
+/* ── Retry button ─────────────────────────────────────── */
+
+.hf-voice-flow-retry {
+  margin-left: var(--space-sm, 8px);
+  font-size: 12px;
+  padding: 4px 10px;
+}
+
+/* ── Skeleton ─────────────────────────────────────────── */
+
+.hf-voice-flow-skeleton {
+  gap: var(--space-md, 12px);
+}
+
+.hf-voice-flow-skeleton-row {
+  height: 72px;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    var(--surface-secondary) 0%,
+    color-mix(in srgb, var(--surface-secondary) 50%, var(--surface-primary)) 50%,
+    var(--surface-secondary) 100%
+  );
+  background-size: 200% 100%;
+  animation: hf-voice-flow-shimmer 1.4s linear infinite;
+}
+
+@keyframes hf-voice-flow-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── Save flash (used in Slice 2) ─────────────────────── */
+
+.hf-voice-flow-row.hf-glow-active {
+  outline: 2px solid color-mix(in srgb, var(--status-success-text) 60%, transparent);
+  outline-offset: 1px;
+  transition: outline-color 1s ease-out;
+}
+
+/* ── Mobile ───────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .hf-voice-flow-node {
+    grid-template-columns: 32px 1fr;
+    gap: var(--space-sm, 8px);
+  }
+
+  .hf-voice-flow-marker {
+    width: 28px;
+    height: 28px;
+    font-size: 14px;
+  }
+
+  .hf-voice-flow-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-sm, 8px);
+  }
+
+  .hf-voice-flow-row-value {
+    justify-content: flex-start;
+  }
+
+  .hf-voice-flow-row-value-text {
+    max-width: 100%;
+    text-align: left;
+  }
+
+  .hf-voice-flow-connector {
+    left: 17px;
+    top: calc(28px + var(--space-sm, 8px) + 2px);
+    height: calc(100% - 28px - var(--space-sm, 8px) - 2px);
+  }
+}

--- a/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
@@ -200,6 +200,10 @@
   padding: 4px 10px;
 }
 
+.hf-voice-flow-error-detail {
+  font-style: italic;
+}
+
 /* ── Skeleton ─────────────────────────────────────────── */
 
 .hf-voice-flow-skeleton {

--- a/apps/admin/components/callers/caller-detail/StalePromptPillForCourse.tsx
+++ b/apps/admin/components/callers/caller-detail/StalePromptPillForCourse.tsx
@@ -37,6 +37,11 @@ interface AggregateResponse {
 
 interface StalePromptPillForCourseProps {
   courseId: string;
+  /** Bump to trigger a forced cache-bypassing re-fetch. Used by the
+   *  Voice Flow lens (#1478 Amendment A) to refresh the banner after
+   *  an educator edits a cascade key — the banner otherwise only fetches
+   *  on mount or after the local Reprompt-all fan-out. */
+  refreshKey?: number;
 }
 
 function relativeTime(iso: string | null): string {
@@ -52,6 +57,7 @@ function relativeTime(iso: string | null): string {
 
 export function StalePromptPillForCourse({
   courseId,
+  refreshKey = 0,
 }: StalePromptPillForCourseProps) {
   const [data, setData] = useState<AggregateResponse | null>(null);
   const [reprompting, setReprompting] = useState(false);
@@ -79,13 +85,16 @@ export function StalePromptPillForCourse({
     mountedRef.current = true;
     // Defer the fetch to the next microtask so we don't call setState
     // synchronously inside the effect body (react-hooks/set-state-in-effect).
+    // When `refreshKey` bumps (e.g. after the Voice Flow lens saves), force
+    // a cache-bypassing re-fetch so the banner doesn't show a stale snapshot.
+    const bypassCache = refreshKey > 0;
     queueMicrotask(() => {
-      if (mountedRef.current) void fetchAggregate(false);
+      if (mountedRef.current) void fetchAggregate(bypassCache);
     });
     return () => {
       mountedRef.current = false;
     };
-  }, [fetchAggregate]);
+  }, [fetchAggregate, refreshKey]);
 
   const onRepromptAll = useCallback(async () => {
     const callers = data?.staleCallers ?? [];

--- a/apps/admin/components/voice/VoiceConfigSection.tsx
+++ b/apps/admin/components/voice/VoiceConfigSection.tsx
@@ -16,9 +16,9 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { VoiceSampleButton } from "./VoiceSampleButton";
 
-type Source = "system" | "provider" | "domain" | "course";
-type ResolvedField<T = unknown> = { value: T; source: Source };
-type SchemaField = {
+export type Source = "system" | "provider" | "domain" | "course";
+export type ResolvedField<T = unknown> = { value: T; source: Source };
+export type SchemaField = {
   key: string;
   label: string;
   type: "string" | "number" | "boolean" | "enum";
@@ -105,7 +105,7 @@ const FIELD_GROUPS: { title: string; keys: string[] }[] = [
   { title: "Advanced", keys: ["pollIntervalMs", "publicKey", "phoneNumberId"] },
 ];
 
-function sourceBadge(source: Source, scope: "course" | "domain") {
+export function sourceBadge(source: Source, scope: "course" | "domain") {
   const isThis =
     (scope === "course" && source === "course") || (scope === "domain" && source === "domain");
   const map: Record<Source, { label: string; bg: string; fg: string }> = {
@@ -133,7 +133,7 @@ function sourceBadge(source: Source, scope: "course" | "domain") {
   );
 }
 
-function fieldMeta(key: string, schemaFields: SchemaField[]): SchemaField {
+export function fieldMeta(key: string, schemaFields: SchemaField[]): SchemaField {
   const fromSchema = schemaFields.find((f) => f.key === key);
   if (fromSchema) return fromSchema;
   const xc = CROSS_CUTTING_LABELS[key];

--- a/apps/admin/components/voice/VoiceConfigSection.tsx
+++ b/apps/admin/components/voice/VoiceConfigSection.tsx
@@ -158,7 +158,7 @@ function parseValueFromInput(raw: string, type: SchemaField["type"]): unknown {
   return raw;
 }
 
-interface RowProps {
+export interface RowProps {
   meta: SchemaField;
   resolved: ResolvedField;
   scope: "course" | "domain";
@@ -179,7 +179,7 @@ interface RowProps {
   enabledProviderId?: string | null;
 }
 
-function FieldRow({
+export function FieldRow({
   meta,
   resolved,
   scope,

--- a/apps/admin/tests/components/VoiceFlowLens.test.tsx
+++ b/apps/admin/tests/components/VoiceFlowLens.test.tsx
@@ -1,7 +1,7 @@
 /**
- * VoiceFlowLens — Slice 1 read-only diagram coverage (#1478).
+ * VoiceFlowLens — Slice 1 + 2 coverage (#1478).
  *
- * Pins:
+ * Slice 1 pins (read-only diagram):
  *   - 6 nodes render in the confirmed top-to-bottom order
  *   - fillerInjectionEnabled is NEVER rendered (Amendment B regression)
  *   - VAPI-only nodes hidden + replaced by the muted placeholder when
@@ -9,6 +9,12 @@
  *   - Origin pill copy reflects the cascade source
  *   - Loading skeleton → diagram transition fires after fetch resolves
  *   - Error banner renders + Retry button re-fetches
+ *
+ * Slice 2 pins (edit drawer + Amendment A + Amendment C):
+ *   - ✏️ click opens the HFDrawer with the field's editor
+ *   - Save → PATCH {key, value} → re-fetch → onComposeInputChange()
+ *   - Reset → PATCH {key, value: null}
+ *   - Non-OPERATOR session sees ✏️ disabled (Amendment C)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -16,6 +22,17 @@ import { render, screen, act, waitFor, fireEvent } from "@testing-library/react"
 import { VoiceFlowLens } from "@/app/x/courses/[courseId]/_components/VoiceFlowLens";
 
 const COURSE_ID = "pb_test_123";
+
+// next-auth/react useSession mock — defaults to OPERATOR. Per-test
+// override via `mockUseSession.mockReturnValue(...)`.
+const mockUseSession = vi.fn(() => ({
+  data: { user: { role: "OPERATOR" } },
+  status: "authenticated",
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
 
 function makeVapiPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -95,6 +112,10 @@ function makeNonVapiPayload() {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  mockUseSession.mockReturnValue({
+    data: { user: { role: "OPERATOR" } },
+    status: "authenticated",
+  });
 });
 
 afterEach(() => {
@@ -223,7 +244,28 @@ describe("VoiceFlowLens — Slice 1 read-only diagram", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("renders edit buttons that are disabled in Slice 1 (drawer wired in Slice 2)", async () => {
+  it("wraps the node list in an ordered list with the call-lifecycle aria-label", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
+
+    const list = screen.getByRole("list", { name: /call lifecycle voice configuration/i });
+    expect(list.tagName).toBe("OL");
+  });
+});
+
+describe("VoiceFlowLens — Slice 2 edit drawer + Amendment A + Amendment C", () => {
+  it("Amendment C: ✏️ buttons are DISABLED for a non-OPERATOR session", async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { role: "VIEWER" } },
+      status: "authenticated",
+    });
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => makeVapiPayload(),
@@ -241,7 +283,7 @@ describe("VoiceFlowLens — Slice 1 read-only diagram", () => {
     });
   });
 
-  it("wraps the node list in an ordered list with the call-lifecycle aria-label", async () => {
+  it("Amendment C: ✏️ buttons are ENABLED for an OPERATOR session", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => makeVapiPayload(),
@@ -252,7 +294,135 @@ describe("VoiceFlowLens — Slice 1 read-only diagram", () => {
 
     await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
 
-    const list = screen.getByRole("list", { name: /call lifecycle voice configuration/i });
-    expect(list.tagName).toBe("OL");
+    const editButtons = screen.getAllByRole("button", { name: /^Edit / });
+    expect(editButtons.length).toBeGreaterThan(0);
+    editButtons.forEach((btn) => {
+      expect(btn).not.toBeDisabled();
+    });
+  });
+
+  it("clicking ✏️ opens an HFDrawer with the field's editor", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
+
+    const editVoiceId = screen.getByRole("button", { name: "Edit Voice ID" });
+    await act(async () => {
+      fireEvent.click(editVoiceId);
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    // Drawer title surfaces the field label via HFDrawer's <Dialog.Title>.
+    expect(dialog.textContent).toMatch(/Voice id/i);
+  });
+
+  it("Save → PATCH {key, value} → re-fetch → onComposeInputChange (Amendment A)", async () => {
+    const fetchMock = vi
+      .fn()
+      // initial GET
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeVapiPayload(),
+      })
+      // PATCH
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, key: "maxCostPerCallUsd", applied: "set" }),
+      })
+      // re-fetch after save
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeVapiPayload(),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onComposeInputChange = vi.fn();
+    render(
+      <VoiceFlowLens
+        courseId={COURSE_ID}
+        onComposeInputChange={onComposeInputChange}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("During the call")).toBeInTheDocument());
+
+    const editCost = screen.getByRole("button", { name: "Edit Cost cap (USD / call)" });
+    await act(async () => {
+      fireEvent.click(editCost);
+    });
+
+    // The drawer renders the exported FieldRow which uses a debounced
+    // text input. Triggering blur with a new value commits.
+    const input = screen.getByPlaceholderText(/falls back to cascade/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "0.75" } });
+      fireEvent.blur(input);
+    });
+
+    await waitFor(() => {
+      // Three calls: initial GET + PATCH + re-fetch
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    // PATCH call body
+    const patchCall = fetchMock.mock.calls[1]!;
+    expect(patchCall[0]).toBe(`/api/playbooks/${COURSE_ID}/voice-config`);
+    expect(patchCall[1]).toMatchObject({
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+    });
+    const patchBody = JSON.parse((patchCall[1] as { body: string }).body);
+    expect(patchBody).toEqual({ key: "maxCostPerCallUsd", value: 0.75 });
+
+    // Amendment A — staleness re-fetch callback fired
+    await waitFor(() => expect(onComposeInputChange).toHaveBeenCalled());
+  });
+
+  it("Reset sends {key, value: null} to clear the override", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeVapiPayload(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, key: "voiceId", applied: "cleared" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeVapiPayload(),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Selected Voice")).toBeInTheDocument());
+
+    // voiceId is in courseOverrides so Reset is visible inside the drawer.
+    const editVoiceId = screen.getByRole("button", { name: "Edit Voice ID" });
+    await act(async () => {
+      fireEvent.click(editVoiceId);
+    });
+
+    const resetBtn = await screen.findByRole("button", { name: /reset/i });
+    await act(async () => {
+      fireEvent.click(resetBtn);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    const patchCall = fetchMock.mock.calls[1]!;
+    const patchBody = JSON.parse((patchCall[1] as { body: string }).body);
+    expect(patchBody).toEqual({ key: "voiceId", value: null });
   });
 });

--- a/apps/admin/tests/components/VoiceFlowLens.test.tsx
+++ b/apps/admin/tests/components/VoiceFlowLens.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * VoiceFlowLens — Slice 1 read-only diagram coverage (#1478).
+ *
+ * Pins:
+ *   - 6 nodes render in the confirmed top-to-bottom order
+ *   - fillerInjectionEnabled is NEVER rendered (Amendment B regression)
+ *   - VAPI-only nodes hidden + replaced by the muted placeholder when
+ *     enabledProviderSlug !== "vapi"
+ *   - Origin pill copy reflects the cascade source
+ *   - Loading skeleton → diagram transition fires after fetch resolves
+ *   - Error banner renders + Retry button re-fetches
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor, fireEvent } from "@testing-library/react";
+import { VoiceFlowLens } from "@/app/x/courses/[courseId]/_components/VoiceFlowLens";
+
+const COURSE_ID = "pb_test_123";
+
+function makeVapiPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    playbookId: COURSE_ID,
+    playbookName: "Test Course",
+    enabledProviderSlug: "vapi",
+    enabledProviderId: "vp_vapi_1",
+    resolved: {
+      provider: { value: "vapi", source: "system" },
+      model: { value: "gpt-4o-mini", source: "system" },
+      fields: {
+        voiceProvider: { value: "deepgram", source: "system" },
+        voiceId: { value: "aura-asteria-en", source: "course" },
+        transcriber: { value: "deepgram", source: "provider" },
+        transcriberEndpointingMs: { value: 200, source: "system" },
+        transcriptStreamEnabled: { value: true, source: "domain" },
+        voicemailDetectionEnabled: { value: false, source: "system" },
+        maxCostPerCallUsd: { value: 0.5, source: "course" },
+        autoPipeline: { value: true, source: "system" },
+        // Ghost field included in the cascade — lens must filter it out.
+        fillerInjectionEnabled: { value: true, source: "system" },
+      },
+    },
+    allowedKeys: [
+      "voiceProvider",
+      "voiceId",
+      "transcriber",
+      "transcriberEndpointingMs",
+      "transcriptStreamEnabled",
+      "fillerInjectionEnabled",
+      "voicemailDetectionEnabled",
+      "maxCostPerCallUsd",
+      "autoPipeline",
+    ],
+    schemaFields: [
+      { key: "voiceProvider", label: "Voice provider", type: "enum", enumValues: ["deepgram", "openai"] },
+      { key: "voiceId", label: "Voice id", type: "string" },
+      { key: "transcriber", label: "Transcriber", type: "enum", enumValues: ["deepgram", "assembly-ai"] },
+      { key: "transcriberEndpointingMs", label: "Transcriber endpointing (ms)", type: "number" },
+      { key: "transcriptStreamEnabled", label: "Transcript stream", type: "boolean" },
+      { key: "fillerInjectionEnabled", label: "Filler injection", type: "boolean" },
+      { key: "voicemailDetectionEnabled", label: "Voicemail detection", type: "boolean" },
+      { key: "maxCostPerCallUsd", label: "Max cost per call (USD)", type: "number" },
+      { key: "autoPipeline", label: "Auto-run pipeline after each call", type: "boolean" },
+    ],
+    courseOverrides: { voiceId: "aura-asteria-en", maxCostPerCallUsd: 0.5 },
+    ...overrides,
+  };
+}
+
+function makeNonVapiPayload() {
+  return makeVapiPayload({
+    enabledProviderSlug: "elevenlabs",
+    enabledProviderId: "vp_eleven_1",
+    resolved: {
+      provider: { value: "elevenlabs", source: "system" },
+      model: { value: null, source: "system" },
+      fields: {
+        voiceProvider: { value: "elevenlabs", source: "system" },
+        voiceId: { value: "rachel", source: "course" },
+        // Non-VAPI providers don't expose transcriber-* / transcriptStreamEnabled
+        voicemailDetectionEnabled: { value: false, source: "system" },
+        maxCostPerCallUsd: { value: 0.5, source: "system" },
+        autoPipeline: { value: true, source: "system" },
+      },
+    },
+    allowedKeys: [
+      "voiceProvider",
+      "voiceId",
+      "voicemailDetectionEnabled",
+      "maxCostPerCallUsd",
+      "autoPipeline",
+    ],
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("VoiceFlowLens — Slice 1 read-only diagram", () => {
+  it("renders all 6 cascade-bound nodes in confirmed top-to-bottom order on a VAPI course", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Pickup")).toBeInTheDocument());
+
+    const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
+    expect(headings).toEqual([
+      "Pickup",
+      "Voice Provider",
+      "Selected Voice",
+      "Transcriber",
+      "During the call",
+      "End of call",
+      "Post-call summary",
+    ]);
+  });
+
+  it("requests the cascade with the courseId mapped onto the playbookId URL segment", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(`/api/playbooks/${COURSE_ID}/voice-config`);
+  });
+
+  it("NEVER renders fillerInjectionEnabled (Amendment B — hardcoded exclusion of the VAPI ghost field)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("During the call")).toBeInTheDocument());
+
+    expect(screen.queryByText(/Filler injection/i)).toBeNull();
+    expect(screen.queryByText(/filler/i)).toBeNull();
+  });
+
+  it("renders the muted placeholder for the Transcriber node when enabledProviderSlug is not vapi", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeNonVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Transcriber")).toBeInTheDocument());
+
+    const placeholder = screen.getByText(/Not configurable for/i);
+    expect(placeholder).toBeInTheDocument();
+    expect(placeholder.textContent).toContain("elevenlabs");
+  });
+
+  it("renders an origin pill describing the cascade source for each row", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
+
+    expect(screen.getAllByText("Set at Course").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/System default|Provider default|Set at Domain/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the loading skeleton before the fetch resolves", async () => {
+    let resolveFetch: ((v: unknown) => void) | null = null;
+    const pending = new Promise((res) => {
+      resolveFetch = res;
+    });
+    const fetchMock = vi.fn().mockReturnValue(pending);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    expect(container.querySelector(".hf-voice-flow-skeleton")).not.toBeNull();
+
+    // Cleanup
+    await act(async () => {
+      resolveFetch?.({ ok: true, json: async () => makeVapiPayload() });
+      await pending.catch(() => {});
+    });
+  });
+
+  it("renders an error banner with a Retry button when the fetch fails, and retry re-fetches", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, json: async () => makeVapiPayload() });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText(/Voice config:/i)).toBeInTheDocument());
+
+    const retry = screen.getByRole("button", { name: /retry/i });
+    await act(async () => {
+      fireEvent.click(retry);
+    });
+
+    await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders edit buttons that are disabled in Slice 1 (drawer wired in Slice 2)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
+
+    const editButtons = screen.getAllByRole("button", { name: /^Edit / });
+    expect(editButtons.length).toBeGreaterThan(0);
+    editButtons.forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it("wraps the node list in an ordered list with the call-lifecycle aria-label", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeVapiPayload(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
+
+    const list = screen.getByRole("list", { name: /call lifecycle voice configuration/i });
+    expect(list.tagName).toBe("OL");
+  });
+});

--- a/apps/admin/tests/components/VoiceFlowLens.test.tsx
+++ b/apps/admin/tests/components/VoiceFlowLens.test.tsx
@@ -233,7 +233,9 @@ describe("VoiceFlowLens — Slice 1 read-only diagram", () => {
 
     render(<VoiceFlowLens courseId={COURSE_ID} />);
 
-    await waitFor(() => expect(screen.getByText(/Voice config:/i)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/We couldn.t load the voice settings/i)).toBeInTheDocument(),
+    );
 
     const retry = screen.getByRole("button", { name: /retry/i });
     await act(async () => {


### PR DESCRIPTION
## Summary

13th lens on the Course Design Console — `/x/courses/[id]?tab=design&design_view=voiceFlow`. Vertical 6-node flowchart of how a voice call will work for the course, with cascade-bound rows that show resolved value + origin pill (System / Provider / Domain / Course) + ✏️ edit drawer.

```
📞 Pickup
    │
① Voice Provider          [provider]      [origin pill]  ✏️
    │
② Selected Voice          [voiceId]       [origin pill]  ✏️
    │
③ Transcriber             [engine + ms]   [origin pill]  ✏️
    │
④ During the call  ┌──────────────────────────────────┐
                   │ ●━ Live transcript    [on/off]   ✏️ │
                   │ ●━ Voicemail det.     [on/off]   ✏️ │
                   │ ●━ Cost cap           $N/call    ✏️ │
                   └──────────────────────────────────┘
    │
⑤ End of call             [autoPipeline]  [origin pill]  ✏️
    │
📈 Post-call summary
```

Closes #1478.

## What it does

- **Reuses 100% of the existing cascade** — `loadResolvedVoiceConfig` for reads (via the existing `GET /api/playbooks/[id]/voice-config`); `PATCH /api/playbooks/[id]/voice-config` for writes (existing LOCKED_KEYS / allowedKeys / `composeInputsUpdatedAt` bump). Zero new resolution logic, zero new routes, zero schema changes.
- **Inline edit via `<HFDrawer>`** hosting the exported `<FieldRow>` from `VoiceConfigSection.tsx`.
- **`<VoiceSampleButton>`** drops into the Selected Voice drawer (▶ Test voice).
- **Per-provider conditional** — VAPI-only rows collapse to `⊘ Not configurable for {provider}` on non-VAPI courses.

## TL Amendments delivered

| # | Amendment | How it lands |
|---|-----------|-------|
| **A** | Staleness re-fetch after save | `StalePromptPillForCourse` gains a `refreshKey` prop. Console bumps `staleRefreshTick` via `onComposeInputChange` callback threaded through `LensProps`; pill re-fetches with `?nocache=1`. Pre-fix the banner only fetched on mount, so voice edits silently failed to nudge reprompt. |
| **B** | `fillerInjectionEnabled` hardcoded-excluded | Schema-declared at `vapi/index.ts:614` but no-op'd in adapter at `:307` (VAPI HTTP 400, incident #1382). Rendering it would mislead educators. Excluded silently — no "coming soon" copy. |
| **C** | OPERATOR+ defensive client gate | Lens calls `useSession()`; ✏️ disabled for VIEWER/STUDENT with task-centric tooltip. The PATCH route already enforced OPERATOR at `route.ts:97`; this mirrors it client-side so a non-OPERATOR session navigating directly to `?design_view=voiceFlow` sees disabled buttons instead of a silent 403. |

## Reviewer scorecard

| Agent | Verdict |
|---|---|
| `ui-reviewer` | **PASS** — design tokens, hf-* classes, mobile responsive, glow used only for save feedback |
| `ux-reviewer` | 5 findings, 4 applied (educator microcopy + error copy + tooltip), 1 deferred (link in non-VAPI placeholder) |
| `standards-checker` | **READY TO MERGE** — 6/6 PASS |
| `qa-engineer` | Initially BLOCKED on `React.lazy` AC, resolved in Slice 3 polish |
| `guard-checker` | **CLEAN — 15/15 guards satisfied** |

## Slices

- `52dbe5d6` — Slice 1: lens shell + read-only diagram (8 vitests)
- `e510fc69` — Slice 2: edit drawer + Amendments A/B/C + 5 more vitests
- `83bafc9d` — Slice 3: polish + `React.lazy` + educator microcopy

## Test plan

- [x] `npx vitest run tests/components/VoiceFlowLens.test.tsx` → 13/13 green
- [x] `npx tsc --noEmit` → 0 errors in story files
- [x] `npx eslint <story files>` → 0 errors
- [ ] Manual: lens renders on `dev.humanfirstfoundation.com/x/courses/<id>?tab=design&design_view=voiceFlow`
- [ ] Manual: Save round-trip — PATCH returns 200, origin pill flips System → Course
- [ ] Manual: Reset round-trip — `{key, value: null}` sent, pill reverts
- [ ] Manual: Non-VAPI provider course shows the muted placeholder text
- [ ] Manual: `fillerInjectionEnabled` confirmed absent from rendered DOM (Amendment B)
- [ ] Manual: Staleness pill updates after save without page reload (Amendment A)
- [ ] Manual: VIEWER session sees ✏️ disabled (Amendment C)

## Verified by

- 13 vitests in `tests/components/VoiceFlowLens.test.tsx`:
  - Node order (8 tests covering 6 nodes + ✏️ disabled + ✏️ enabled for OPERATOR)
  - Cascade GET URL contract → `/api/playbooks/{courseId}/voice-config`
  - Amendment B regression (`fillerInjectionEnabled` never rendered)
  - Per-provider conditional (non-VAPI placeholder)
  - Origin pill copy per cascade source
  - Loading skeleton → diagram transition
  - Error banner + Retry re-fetches
  - Amendment A — Save → PATCH {key, value} → re-fetch → `onComposeInputChange` fired
  - Amendment C — ✏️ disabled for VIEWER, enabled for OPERATOR
  - Reset → PATCH {key, value: null}
  - `<ol aria-label="Call lifecycle voice configuration">` a11y
- `guard-checker` 15/15 PASS
- `standards-checker` 6/6 PASS
- `ui-reviewer` PASS
- `ux-reviewer` 4/5 advisory applied

Deploy command: `/vm-cp` (no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)