### PR TITLE
feat(help): #1483 Layer 3 Slice 2 — @operator-surface tag + generator + page section

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/calls/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/calls/route.ts
@@ -11,6 +11,8 @@ import { isSessionModelV2Enabled } from "@/lib/voice/session-flag";
 import { createSession } from "@/lib/voice/create-session";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/callers/:callerId/calls
  * @visibility internal
  * @scope callers:read

--- a/apps/admin/app/api/callers/[callerId]/cascade/voice/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/cascade/voice/route.ts
@@ -5,6 +5,8 @@ import { explainVoiceCascade } from "@/lib/cascade/voice-explain";
 export const runtime = "nodejs";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/callers/[callerId]/cascade/voice
  * @visibility internal
  * @scope cascade:read

--- a/apps/admin/app/api/callers/[callerId]/last-selected-module/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/last-selected-module/route.ts
@@ -1,4 +1,6 @@
 /**
+ * @operator-surface yes
+ *
  * POST /api/callers/[callerId]/last-selected-module
  *
  * Persist a Caller's most-recent module pick so the sim landing can

--- a/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts
@@ -1,4 +1,6 @@
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/callers/:callerId/learning-trajectory
  * @visibility public
  * @scope callers:read

--- a/apps/admin/app/api/courses/[courseId]/cascade/welcome-message/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/cascade/welcome-message/route.ts
@@ -6,6 +6,8 @@ import { resolveWelcomeMessage } from "@/lib/cascade/resolvers/welcome-message";
 export const runtime = "nodejs";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/courses/[courseId]/cascade/welcome-message
  * @visibility internal
  * @scope cascade:read

--- a/apps/admin/app/api/courses/[courseId]/course-reference/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/course-reference/route.ts
@@ -7,6 +7,8 @@ import { requireAuth, isAuthError } from "@/lib/permissions";
 import { bumpPlaybookComposeTimestamp } from "@/lib/compose/bump-timestamp";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/courses/:courseId/course-reference
  * @visibility public
  * @scope courses:read

--- a/apps/admin/app/api/courses/[courseId]/dry-run-prompt/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/dry-run-prompt/route.ts
@@ -1,3 +1,10 @@
+/**
+ * @operator-surface yes
+ *
+ * @description Compose a dry-run prompt for a course — used during demos
+ * to preview what the next call's system prompt would look like without
+ * actually placing a call.
+ */
 import { NextRequest, NextResponse } from "next/server";
 import { executeComposition, loadComposeConfig } from "@/lib/prompt/composition";
 import { renderPromptSummary } from "@/lib/prompt/composition/renderPromptSummary";

--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -1,4 +1,6 @@
 /**
+ * @operator-surface yes
+ *
  * POST /api/courses/[courseId]/import-modules
  *
  * Parses a Course Reference markdown body for an author-declared Module

--- a/apps/admin/app/api/courses/[courseId]/regenerate-curriculum/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/regenerate-curriculum/route.ts
@@ -1,3 +1,10 @@
+/**
+ * @operator-surface yes
+ *
+ * The "regenerate this course's curriculum" button on Course Design — used
+ * during demos to recover from a garbled or stale Curriculum without
+ * deleting the course. See per-function JSDoc below for full contract.
+ */
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";

--- a/apps/admin/app/api/courses/[courseId]/session-flow/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/session-flow/route.ts
@@ -1,4 +1,6 @@
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/courses/[courseId]/session-flow
  * @visibility internal
  * @scope course:read

--- a/apps/admin/app/api/curricula/route.ts
+++ b/apps/admin/app/api/curricula/route.ts
@@ -4,6 +4,8 @@ import { requireAuth, isAuthError } from "@/lib/permissions";
 import { ensurePrimaryPlaybookLink } from "@/lib/curriculum/ensure-primary-playbook-link";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/curricula
  * @visibility internal
  * @scope curricula:read

--- a/apps/admin/app/api/goals/route.ts
+++ b/apps/admin/app/api/goals/route.ts
@@ -5,6 +5,8 @@ import { resolveCallerScopeForReading, isScopeError } from "@/lib/learner-scope"
 import { GoalType } from "@prisma/client";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/goals
  * @visibility public
  * @scope goals:read

--- a/apps/admin/app/api/identity/challenge-skip/route.ts
+++ b/apps/admin/app/api/identity/challenge-skip/route.ts
@@ -10,6 +10,8 @@ const bodySchema = z
   .strict();
 
 /**
+ * @operator-surface yes
+ *
  * @api POST /api/identity/challenge-skip
  * @visibility internal (OPERATOR+)
  * @auth session (OPERATOR / ADMIN / SUPERADMIN)

--- a/apps/admin/app/api/intake/v2/admin-test-enrol/route.ts
+++ b/apps/admin/app/api/intake/v2/admin-test-enrol/route.ts
@@ -12,6 +12,8 @@ const bodySchema = z
   .strict();
 
 /**
+ * @operator-surface yes
+ *
  * @api POST /api/intake/v2/admin-test-enrol
  * @visibility internal (OPERATOR+)
  * @auth session (OPERATOR / EDUCATOR / ADMIN / SUPERADMIN)

--- a/apps/admin/app/api/playbooks/[playbookId]/subjects/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/subjects/route.ts
@@ -4,6 +4,8 @@ import { requireAuth, isAuthError } from "@/lib/permissions";
 import { bumpPlaybookComposeTimestamp } from "@/lib/compose/bump-timestamp";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/playbooks/:playbookId/subjects
  * @visibility internal
  * @scope playbooks:read

--- a/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
+++ b/apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts
@@ -1,4 +1,6 @@
 /**
+ * @operator-surface yes
+ *
  * Course (Playbook) voice-config GET + PATCH (#1271 Slice C).
  *
  * GET returns the resolved 4-layer cascade for the playbook so the

--- a/apps/admin/app/api/recompose/apply/route.ts
+++ b/apps/admin/app/api/recompose/apply/route.ts
@@ -1,4 +1,6 @@
 /**
+ * @operator-surface yes
+ *
  * Apply pending changes from the PendingChangesTray (epic #854 / Story #857).
  *
  * The tray accumulates compose-affecting settings edits across surfaces.

--- a/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
+++ b/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
@@ -1,3 +1,9 @@
+/**
+ * @operator-surface yes
+ *
+ * @description Generate or fetch a Subject's Curriculum — the "build a
+ * course from this Subject" path operators kick off during demo setup.
+ */
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";

--- a/apps/admin/app/api/voice-providers/[id]/sample/route.ts
+++ b/apps/admin/app/api/voice-providers/[id]/sample/route.ts
@@ -9,6 +9,8 @@ import { checkRateLimit, getClientIP } from "@/lib/rate-limit";
 export const runtime = "nodejs";
 
 /**
+ * @operator-surface yes
+ *
  * #1421 Slice B — voice sample button server route.
  *
  * Hard limits to protect cost + abuse:

--- a/apps/admin/app/api/voice/[slug]/catalog/route.ts
+++ b/apps/admin/app/api/voice/[slug]/catalog/route.ts
@@ -5,6 +5,8 @@ import { getVoiceProvider } from "@/lib/voice/provider-factory";
 export const runtime = "nodejs";
 
 /**
+ * @operator-surface yes
+ *
  * @api GET /api/voice/[slug]/catalog
  * @visibility internal
  * @scope voice:catalog:read

--- a/apps/admin/app/api/voice/calls/outbound-dial/route.ts
+++ b/apps/admin/app/api/voice/calls/outbound-dial/route.ts
@@ -1,3 +1,10 @@
+/**
+ * @operator-surface yes
+ *
+ * @description Place an outbound PSTN call to a caller via VAPI — the
+ * "Call now" button operators trigger during a live demo to dial a
+ * learner directly.
+ */
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";

--- a/apps/admin/app/x/help/demos/help-demos.css
+++ b/apps/admin/app/x/help/demos/help-demos.css
@@ -67,3 +67,9 @@
 .hf-help-demos-family-name {
   font-family: ui-monospace, monospace;
 }
+
+/* Operator-surfaces table (Slice 2, #1483) — slight spacing between
+   stacked method badges in the Method column. */
+.hf-help-demos-table tbody td .hf-category-label + .hf-category-label {
+  margin-left: 4px;
+}

--- a/apps/admin/app/x/help/demos/page.tsx
+++ b/apps/admin/app/x/help/demos/page.tsx
@@ -7,13 +7,14 @@ import { redirect } from "next/navigation";
 import "./help-demos.css";
 
 /**
- * Demo Knob Reference — Epic #1442 Layer 3 Slice 1 (#1482).
+ * Demo Knob Reference — Epic #1442 Layer 3 Slice 1 (#1482) + Slice 2 (#1483).
  *
- * Operator-facing schema-driven catalogue of cascade-resolvable knobs.
- * Reads `docs/kb/generated/demo-knobs.json` at request time (a tiny
- * file, ~3KB) so the page is automatically current when CI regenerates
- * the JSON. Subsequent slices add live cascade-effective-value reads
- * per course, role-filtering, and Cmd+K shortcuts.
+ * Operator-facing schema-driven catalogue of cascade-resolvable knobs
+ * (Slice 1) plus the curated list of API surfaces operators touch during
+ * demo prep / debugging (Slice 2). Both sections read generated JSON at
+ * request time so the page is automatically current when CI regenerates.
+ * Subsequent slices add live cascade-effective-value reads per course,
+ * role-filtering, and Cmd+K shortcuts.
  *
  * Auth: OPERATOR+ only. STUDENT / VIEWER bounce back to /x.
  */
@@ -34,12 +35,46 @@ type DemoKnobsManifest = {
   knobs: KnobRow[];
 };
 
+type SurfaceCategory =
+  | "courses"
+  | "callers"
+  | "voice"
+  | "playbooks"
+  | "settings"
+  | "other";
+
+type OperatorSurface = {
+  route: string;
+  file: string;
+  methods: string[];
+  authLevels: string[];
+  description: string;
+  category: SurfaceCategory;
+};
+
+type OperatorSurfacesManifest = {
+  $schema: string;
+  generatedAt: string;
+  surfaces: OperatorSurface[];
+};
+
 function loadKnobs(): DemoKnobsManifest {
   // The generated JSON lives at repo root; this page lives in apps/admin.
   // Resolve from `process.cwd()` (apps/admin) up to the repo root.
   const path = resolve(process.cwd(), "..", "..", "docs/kb/generated/demo-knobs.json");
   const raw = readFileSync(path, "utf8");
   return JSON.parse(raw) as DemoKnobsManifest;
+}
+
+function loadSurfaces(): OperatorSurfacesManifest {
+  const path = resolve(
+    process.cwd(),
+    "..",
+    "..",
+    "docs/kb/generated/operator-surfaces.json",
+  );
+  const raw = readFileSync(path, "utf8");
+  return JSON.parse(raw) as OperatorSurfacesManifest;
 }
 
 const OPERATOR_PLUS = new Set(["OPERATOR", "ADMIN", "SUPERADMIN"]);
@@ -54,6 +89,9 @@ export default async function HelpDemosPage() {
   const demoKnobs = manifest.knobs.filter((k) => k.demoKnob);
   const otherKnobs = manifest.knobs.filter((k) => !k.demoKnob);
   const familyGroups = groupByFamily(otherKnobs);
+
+  const surfaces = loadSurfaces();
+  const surfaceGroups = groupByCategory(surfaces.surfaces);
 
   return (
     <main className="hf-help-demos">
@@ -98,6 +136,42 @@ export default async function HelpDemosPage() {
             <KnobTable rows={rows} />
           </details>
         ))}
+      </section>
+
+      <section className="hf-card hf-help-demos-section">
+        <h2 className="hf-section-title">
+          Surfaces operators touch ({surfaces.surfaces.length})
+        </h2>
+        <p className="hf-section-desc">
+          The API routes you&apos;ll hit in the admin UI during demo prep or
+          debugging. Curated, not exhaustive — annotate more routes with{" "}
+          <code>@operator-surface yes</code> as the demo workflow widens.
+          Grouped by URL prefix.
+        </p>
+        <p className="hf-text-xs hf-text-muted">
+          Generated from <code>scripts/capture/operator-surfaces.ts</code> on{" "}
+          {new Date(surfaces.generatedAt).toISOString().slice(0, 10)}.
+        </p>
+        {SURFACE_CATEGORY_ORDER.filter((cat) => surfaceGroups[cat]?.length).map(
+          (category) => {
+            const rows = surfaceGroups[category] ?? [];
+            return (
+              <details
+                key={category}
+                className="hf-help-demos-family"
+                open
+              >
+                <summary>
+                  <span className="hf-help-demos-family-name">{category}</span>{" "}
+                  <span className="hf-text-xs hf-text-muted">
+                    ({rows.length})
+                  </span>
+                </summary>
+                <SurfaceTable rows={rows} />
+              </details>
+            );
+          },
+        )}
       </section>
     </main>
   );
@@ -158,4 +232,68 @@ function groupByFamily(knobs: KnobRow[]): Record<string, KnobRow[]> {
     (out[knob.family] ??= []).push(knob);
   }
   return out;
+}
+
+const SURFACE_CATEGORY_ORDER: SurfaceCategory[] = [
+  "courses",
+  "callers",
+  "voice",
+  "playbooks",
+  "settings",
+  "other",
+];
+
+function groupByCategory(
+  surfaces: OperatorSurface[],
+): Partial<Record<SurfaceCategory, OperatorSurface[]>> {
+  const out: Partial<Record<SurfaceCategory, OperatorSurface[]>> = {};
+  for (const surface of surfaces) {
+    (out[surface.category] ??= []).push(surface);
+  }
+  return out;
+}
+
+function SurfaceTable({ rows }: { rows: OperatorSurface[] }) {
+  if (rows.length === 0) {
+    return (
+      <p className="hf-text-xs hf-text-muted">No surfaces in this group.</p>
+    );
+  }
+  return (
+    <table className="hf-help-demos-table">
+      <thead>
+        <tr>
+          <th>Method</th>
+          <th>Route</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.route}>
+            <td>
+              {row.methods.map((method) => (
+                <span
+                  key={method}
+                  className="hf-category-label"
+                  data-tone="info"
+                >
+                  {method}
+                </span>
+              ))}
+            </td>
+            <td>
+              <code>{row.route}</code>
+              {row.authLevels.length > 0 ? (
+                <div className="hf-text-xs hf-text-muted">
+                  auth: {row.authLevels.join(" / ")}
+                </div>
+              ) : null}
+            </td>
+            <td>{row.description || <span className="hf-text-muted">—</span>}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -59,6 +59,7 @@
     "kb:routes": "tsx scripts/capture/route-inventory.ts",
     "kb:coupling": "tsx scripts/capture/coupling-graph.ts",
     "kb:demo-knobs": "tsx scripts/capture/demo-knobs.ts",
+    "kb:operator-surfaces": "tsx scripts/capture/operator-surfaces.ts",
     "kb:guard-links": "tsx scripts/capture/check-guard-kb-links.ts",
     "kb:rule-tests": "tsx scripts/capture/check-eslint-rule-tests.ts",
     "kb:fresh": "bash scripts/capture/check-kb-fresh.sh",

--- a/apps/admin/scripts/capture/check-kb-fresh.sh
+++ b/apps/admin/scripts/capture/check-kb-fresh.sh
@@ -9,13 +9,14 @@ npx tsx scripts/capture/model-map.ts >/dev/null
 npx tsx scripts/capture/route-inventory.ts >/dev/null
 npx tsx scripts/capture/coupling-graph.ts >/dev/null
 npx tsx scripts/capture/demo-knobs.ts >/dev/null
+npx tsx scripts/capture/operator-surfaces.ts >/dev/null
 
 cd ../..                     # -> repo root (git compares the generated/ tree)
 if git diff --exit-code -I '"generatedAt":' -- docs/kb/generated/ >/dev/null; then
   echo "✔ KB generated facts fresh."
 else
   echo "✖ KB generated facts are STALE — regenerate and commit:"
-  echo "    cd apps/admin && npm run kb:model-map && npm run kb:routes && npm run kb:coupling && npm run kb:demo-knobs"
+  echo "    cd apps/admin && npm run kb:model-map && npm run kb:routes && npm run kb:coupling && npm run kb:demo-knobs && npm run kb:operator-surfaces"
   git --no-pager diff --stat -- docs/kb/generated/
   exit 1
 fi

--- a/apps/admin/scripts/capture/operator-surfaces.ts
+++ b/apps/admin/scripts/capture/operator-surfaces.ts
@@ -1,0 +1,194 @@
+/**
+ * operator-surfaces.ts — Tier-2 KB generator for Epic #1442 Layer 3 Slice 2 (#1483).
+ *
+ * Emits `docs/kb/generated/operator-surfaces.json` — the operator-facing
+ * catalogue of the ~20 API routes operators actually touch when preparing
+ * or debugging a demo. Inclusion is opt-in via a JSDoc tag:
+ *
+ *   /**
+ *    * @operator-surface yes
+ *    *
+ *    * @api POST /api/courses/:courseId/regenerate-curriculum
+ *    * @description Regenerates a course's curriculum…
+ *    *​/
+ *   export async function POST(…)
+ *
+ * Unannotated routes are silently omitted. The ratchet is: operators (or
+ * Slice 4 + later) add more annotations over time. The page at
+ * `app/x/help/demos/page.tsx` reads the JSON at request time and groups by
+ * URL prefix (`courses`, `callers`, `voice`, `playbooks`, `settings`, `other`).
+ *
+ * Cross-references `route-inventory.ts::routePath()` semantics for path
+ * normalisation (same `app/api/**\/route.ts` → `/api/...` mapping, dynamic
+ * `[param]` segments preserved verbatim).
+ *
+ * Pattern: regex-walk JSDoc — mirrors `scripts/generate-constants-manifest.ts`
+ * and `scripts/capture/demo-knobs.ts`. Does NOT use `ts.createProgram` —
+ * keeping it dependency-free is part of the contract for running under
+ * `npx tsx` in CI / pre-commit.
+ *
+ * Run:  npx tsx scripts/capture/operator-surfaces.ts        (from apps/admin)
+ * CI:   re-run and `git diff --exit-code -I '"generatedAt":'` to catch drift.
+ */
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "../../../..");
+const API_ROOT = resolve(REPO_ROOT, "apps/admin/app/api");
+const OUT_PATH = resolve(REPO_ROOT, "docs/kb/generated/operator-surfaces.json");
+
+const HTTP_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+const OPERATOR_SURFACE_TAG = /@operator-surface\s+yes\b/;
+const API_SUMMARY_RE = /@api\s+(?:(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+)?(.+?)\s*$/m;
+const DESCRIPTION_RE = /@description\s+([^\n*][^\n]*)/;
+
+/** Category derived from the URL prefix — keeps the page table groupable. */
+type Category =
+  | "courses"
+  | "callers"
+  | "voice"
+  | "playbooks"
+  | "settings"
+  | "other";
+
+interface OperatorSurface {
+  route: string;
+  file: string;
+  methods: string[];
+  authLevels: string[];
+  description: string;
+  category: Category;
+}
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) walk(full, acc);
+    else if (name === "route.ts") acc.push(full);
+  }
+  return acc;
+}
+
+/**
+ * Normalises a `route.ts` absolute path to its `/api/...` URL form.
+ *
+ * Mirrors `route-inventory.ts::routePath` deliberately — DO NOT hand-roll
+ * a second normaliser. If the inventory generator's rules change (new
+ * segment conventions, route groups, etc.), update both in lockstep.
+ */
+function routePath(file: string): string {
+  const rel = relative(API_ROOT, dirname(file));
+  return "/api" + (rel ? "/" + rel.split(sep).join("/") : "");
+}
+
+function categoryFor(route: string): Category {
+  if (route.startsWith("/api/courses/")) return "courses";
+  if (route.startsWith("/api/callers")) return "callers";
+  if (route.startsWith("/api/voice") || route.startsWith("/api/voice-providers"))
+    return "voice";
+  if (route.startsWith("/api/playbooks") || route.startsWith("/api/subjects") ||
+      route.startsWith("/api/curricula"))
+    return "playbooks";
+  if (
+    route.startsWith("/api/settings") ||
+    route.startsWith("/api/recompose") ||
+    route.startsWith("/api/goals")
+  )
+    return "settings";
+  return "other";
+}
+
+function extractMethods(src: string): string[] {
+  return HTTP_METHODS.filter(
+    (m) =>
+      new RegExp(`export\\s+(async\\s+)?function\\s+${m}\\b`).test(src) ||
+      new RegExp(`export\\s+const\\s+${m}\\b`).test(src),
+  );
+}
+
+function extractAuthLevels(src: string): string[] {
+  const hits = [...src.matchAll(/requireAuth\(\s*["'`](\w+)["'`]/g)].map(
+    (m) => m[1],
+  );
+  return [...new Set(hits)];
+}
+
+/**
+ * Pulls the first `@description` line out of any JSDoc block. Falls back to
+ * the `@api` summary text when no description tag is present. Returns empty
+ * string when neither is present — the page renders the empty state.
+ */
+function extractDescription(src: string): string {
+  const desc = DESCRIPTION_RE.exec(src);
+  if (desc) return desc[1].trim().replace(/\s+\*?\s*$/, "");
+  const api = API_SUMMARY_RE.exec(src);
+  if (api) return api[2].trim();
+  return "";
+}
+
+function main(): void {
+  const files = walk(API_ROOT).sort();
+  const surfaces: OperatorSurface[] = [];
+
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+    if (!OPERATOR_SURFACE_TAG.test(src)) continue;
+
+    const route = routePath(file);
+    const methods = extractMethods(src);
+    const authLevels = extractAuthLevels(src);
+    const description = extractDescription(src);
+
+    surfaces.push({
+      route,
+      file: relative(REPO_ROOT, file),
+      methods: methods.length ? methods : ["<none-detected>"],
+      authLevels,
+      description,
+      category: categoryFor(route),
+    });
+  }
+
+  // Stable sort by route for deterministic diffs.
+  surfaces.sort((a, b) => a.route.localeCompare(b.route));
+
+  const out = {
+    $schema: "operator-surfaces/v1",
+    generatedAt: new Date().toISOString(),
+    generator: "scripts/capture/operator-surfaces.ts",
+    note: "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
+    surfaces,
+  };
+
+  mkdirSync(dirname(OUT_PATH), { recursive: true });
+  writeFileSync(OUT_PATH, JSON.stringify(out, null, 2) + "\n");
+
+  const byCategory = surfaces.reduce<Record<string, number>>((acc, s) => {
+    acc[s.category] = (acc[s.category] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  console.log(
+    `[operator-surfaces] ${surfaces.length} surfaces → ${OUT_PATH}`,
+  );
+  console.log(`[operator-surfaces] by category:`, byCategory);
+}
+
+main();

--- a/apps/admin/tests/scripts/operator-surfaces-generator.test.ts
+++ b/apps/admin/tests/scripts/operator-surfaces-generator.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Pins the operator-surfaces.json generator output shape and the
+ * @operator-surface JSDoc tag detection contract.
+ *
+ * Three classes of test:
+ *   1. End-to-end against the committed JSON — schema shape, ≥20 surfaces,
+ *      sorted-by-route invariant.
+ *   2. Unit-style: re-run the regex against synthetic strings to pin the
+ *      tag-detection convention (must be `@operator-surface yes` exactly).
+ *   3. Negative: a route without the tag is omitted from the live output.
+ */
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+const OUT_PATH = resolve(
+  __dirname,
+  "../../../../docs/kb/generated/operator-surfaces.json",
+);
+
+type SurfaceCategory =
+  | "courses"
+  | "callers"
+  | "voice"
+  | "playbooks"
+  | "settings"
+  | "other";
+
+interface OperatorSurface {
+  route: string;
+  file: string;
+  methods: string[];
+  authLevels: string[];
+  description: string;
+  category: SurfaceCategory;
+}
+
+interface SurfacesManifest {
+  $schema: string;
+  generatedAt: string;
+  generator: string;
+  note: string;
+  surfaces: OperatorSurface[];
+}
+
+function readManifest(): SurfacesManifest {
+  expect(
+    existsSync(OUT_PATH),
+    `${OUT_PATH} missing — run \`npm run kb:operator-surfaces\``,
+  ).toBe(true);
+  return JSON.parse(readFileSync(OUT_PATH, "utf8")) as SurfacesManifest;
+}
+
+describe("operator-surfaces.json generator output", () => {
+  it("top-level shape matches the operator-surfaces/v1 schema", () => {
+    const m = readManifest();
+    expect(m.$schema).toBe("operator-surfaces/v1");
+    expect(new Date(m.generatedAt).toString()).not.toBe("Invalid Date");
+    expect(m.generator).toContain("operator-surfaces.ts");
+    expect(Array.isArray(m.surfaces)).toBe(true);
+  });
+
+  it("at least 20 routes are annotated (story AC floor)", () => {
+    const m = readManifest();
+    expect(m.surfaces.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("every surface row carries the full shape (no missing fields)", () => {
+    const m = readManifest();
+    for (const s of m.surfaces) {
+      expect(typeof s.route).toBe("string");
+      expect(s.route.startsWith("/api/")).toBe(true);
+      expect(typeof s.file).toBe("string");
+      expect(s.file.endsWith("/route.ts")).toBe(true);
+      expect(Array.isArray(s.methods)).toBe(true);
+      expect(s.methods.length).toBeGreaterThan(0);
+      expect(Array.isArray(s.authLevels)).toBe(true);
+      expect(typeof s.description).toBe("string");
+      expect([
+        "courses",
+        "callers",
+        "voice",
+        "playbooks",
+        "settings",
+        "other",
+      ]).toContain(s.category);
+    }
+  });
+
+  it("surfaces are sorted by route path", () => {
+    const m = readManifest();
+    const routes = m.surfaces.map((s) => s.route);
+    const sorted = [...routes].sort((a, b) => a.localeCompare(b));
+    expect(routes).toEqual(sorted);
+  });
+
+  it("the seed-list anchors are present (regression bait)", () => {
+    const m = readManifest();
+    const routes = new Set(m.surfaces.map((s) => s.route));
+    expect(routes.has("/api/courses/[courseId]/regenerate-curriculum")).toBe(
+      true,
+    );
+    expect(routes.has("/api/voice-providers/[id]/sample")).toBe(true);
+    expect(routes.has("/api/callers/[callerId]/cascade/voice")).toBe(true);
+  });
+});
+
+describe("@operator-surface tag detection invariants", () => {
+  // The generator uses this exact regex. The tests document the convention
+  // and lock the spelling — operators reading the JSDoc need a single
+  // authoritative form.
+  const TAG_RE = /@operator-surface\s+yes\b/;
+
+  it("matches the canonical spelling", () => {
+    expect(TAG_RE.test("* @operator-surface yes")).toBe(true);
+    expect(TAG_RE.test(" *  @operator-surface  yes")).toBe(true);
+    expect(TAG_RE.test("@operator-surface yes\n")).toBe(true);
+  });
+
+  it("rejects close variants (operators must use the exact form)", () => {
+    expect(TAG_RE.test("@operatorSurface yes")).toBe(false);
+    expect(TAG_RE.test("@operator-surface: yes")).toBe(false);
+    expect(TAG_RE.test("@operator-surface no")).toBe(false);
+    expect(TAG_RE.test("@operator-surface")).toBe(false);
+    // No standalone-token word boundary: "yesterday" must NOT match
+    expect(TAG_RE.test("@operator-surface yesterday")).toBe(false);
+  });
+});
+
+/**
+ * Parses a synthetic route.ts string the same way the generator does.
+ * Mirrors the regex shapes in `scripts/capture/operator-surfaces.ts` so we
+ * can pin the per-route parse without spinning up the full file walker.
+ */
+function parseRouteSource(src: string): {
+  tagged: boolean;
+  methods: string[];
+  authLevels: string[];
+  description: string;
+} {
+  const tagged = /@operator-surface\s+yes\b/.test(src);
+  const HTTP = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+  const methods = HTTP.filter(
+    (m) =>
+      new RegExp(`export\\s+(async\\s+)?function\\s+${m}\\b`).test(src) ||
+      new RegExp(`export\\s+const\\s+${m}\\b`).test(src),
+  );
+  const authLevels = [
+    ...new Set(
+      [...src.matchAll(/requireAuth\(\s*["'`](\w+)["'`]/g)].map((m) => m[1]),
+    ),
+  ];
+  const descMatch = /@description\s+([^\n*][^\n]*)/.exec(src);
+  const apiMatch = /@api\s+(?:GET|POST|PUT|PATCH|DELETE)\s+(.+?)\s*$/m.exec(src);
+  const description = descMatch
+    ? descMatch[1].trim()
+    : apiMatch
+      ? apiMatch[1].trim()
+      : "";
+  return { tagged, methods, authLevels, description };
+}
+
+describe("generator per-route parsing (unit-level)", () => {
+  it("parses a route with @operator-surface yes + @description into a surface entry", () => {
+    const src = `
+      /**
+       * @operator-surface yes
+       *
+       * @api POST /api/courses/:courseId/regenerate-curriculum
+       * @description Regenerate the curriculum for a course
+       */
+      export async function POST() {
+        const auth = await requireAuth("OPERATOR");
+      }
+    `;
+    const parsed = parseRouteSource(src);
+    expect(parsed.tagged).toBe(true);
+    expect(parsed.methods).toEqual(["POST"]);
+    expect(parsed.authLevels).toEqual(["OPERATOR"]);
+    expect(parsed.description).toBe("Regenerate the curriculum for a course");
+  });
+
+  it("omits a route without the @operator-surface tag (zero false positives)", () => {
+    const src = `
+      /**
+       * @api GET /api/foo
+       * @description This route is NOT tagged
+       */
+      export async function GET() {
+        const auth = await requireAuth("VIEWER");
+      }
+    `;
+    const parsed = parseRouteSource(src);
+    expect(parsed.tagged).toBe(false);
+  });
+
+  it("falls back to @api summary when @description is absent", () => {
+    const src = `
+      /**
+       * @operator-surface yes
+       *
+       * @api GET /api/voice/[slug]/catalog
+       */
+      export const GET = async () => {
+        const auth = await requireAuth("OPERATOR");
+      };
+    `;
+    const parsed = parseRouteSource(src);
+    expect(parsed.tagged).toBe(true);
+    expect(parsed.methods).toEqual(["GET"]);
+    // @api summary is the fallback (route summary line)
+    expect(parsed.description).toContain("/api/voice/[slug]/catalog");
+  });
+});
+
+describe("end-to-end: generator omits unannotated routes (negative pin)", () => {
+  it("a known untagged route is not present in the output", () => {
+    // /api/health is a high-traffic public route never tagged as
+    // operator-surface — it should NEVER appear in the output even though
+    // its file exists in app/api/health/route.ts.
+    const m = readManifest();
+    const routes = new Set(m.surfaces.map((s) => s.route));
+    expect(routes.has("/api/health")).toBe(false);
+    expect(routes.has("/api/ready")).toBe(false);
+  });
+});
+
+describe("integration with the walker (mini fixture)", () => {
+  it("a fresh temp directory tree only emits surfaces whose route.ts carries the tag", () => {
+    // Mirror the walker's algorithm against a tiny temp tree to prove the
+    // inclusion gate is the tag, not the file's existence.
+    const dir = mkdtempSync(join(tmpdir(), "op-surfaces-test-"));
+    const tagged = join(dir, "tagged");
+    const plain = join(dir, "plain");
+    mkdirSync(tagged, { recursive: true });
+    mkdirSync(plain, { recursive: true });
+    writeFileSync(
+      join(tagged, "route.ts"),
+      "/** @operator-surface yes */\nexport async function GET(){}",
+    );
+    writeFileSync(
+      join(plain, "route.ts"),
+      "/** not tagged */\nexport async function GET(){}",
+    );
+
+    const found: string[] = [];
+    const TAG = /@operator-surface\s+yes\b/;
+    const walk = (d: string): void => {
+      for (const name of readdirSync(d)) {
+        const full = join(d, name);
+        if (statSync(full).isDirectory()) walk(full);
+        else if (name === "route.ts" && TAG.test(readFileSync(full, "utf8")))
+          found.push(full);
+      }
+    };
+    walk(dir);
+    expect(found.length).toBe(1);
+    expect(found[0]).toContain("/tagged/");
+  });
+});

--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -59,8 +59,9 @@ npm run kb:model-map     # → docs/kb/generated/model-map.json   (109 models cl
 npm run kb:routes        # → docs/kb/generated/route-inventory.json (501 routes)
 npm run kb:coupling      # → docs/kb/generated/coupling-graph.json (~1600 files, ~3700 edges)
 npm run kb:demo-knobs    # → docs/kb/generated/demo-knobs.json (cascade-knob catalogue for /x/help/demos)
+npm run kb:operator-surfaces  # → docs/kb/generated/operator-surfaces.json (@operator-surface routes for /x/help/demos)
 npm run kb:rule-tests    # meta-ratchet: every custom ESLint rule has a sibling test
-npm run kb:check         # all four generators + meta-ratchets + generated-fact freshness
+npm run kb:check         # all five generators + meta-ratchets + generated-fact freshness
 ```
 
 ### Ratifying a model classification

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,9 +1,9 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-11T13:49:48.665Z",
+  "generatedAt": "2026-06-11T14:13:05.537Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1650,
+  "fileCount": 1651,
   "edgeCount": 3798,
   "skippedEdges": 1,
   "edges": [
@@ -23088,6 +23088,11 @@
     },
     {
       "path": "scripts/capture/model-map.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
+      "path": "scripts/capture/operator-surfaces.ts",
       "inDegree": 0,
       "outDegree": 0
     },

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,0 +1,277 @@
+{
+  "$schema": "operator-surfaces/v1",
+  "generatedAt": "2026-06-11T14:12:09.179Z",
+  "generator": "scripts/capture/operator-surfaces.ts",
+  "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
+  "surfaces": [
+    {
+      "route": "/api/callers/[callerId]/calls",
+      "file": "apps/admin/app/api/callers/[callerId]/calls/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER",
+        "STUDENT"
+      ],
+      "description": "Get the most recent active sim call for a caller (endedAt is null, source is sim, within last 2 hours).",
+      "category": "callers"
+    },
+    {
+      "route": "/api/callers/[callerId]/cascade/voice",
+      "file": "apps/admin/app/api/callers/[callerId]/cascade/voice/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Returns the full voice-config cascade explanation for one",
+      "category": "callers"
+    },
+    {
+      "route": "/api/callers/[callerId]/last-selected-module",
+      "file": "apps/admin/app/api/callers/[callerId]/last-selected-module/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "description": "* @method POST",
+      "category": "callers"
+    },
+    {
+      "route": "/api/callers/[callerId]/learning-trajectory",
+      "file": "apps/admin/app/api/callers/[callerId]/learning-trajectory/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "description": "Returns learning trajectory for a caller. The shape adapts to",
+      "category": "callers"
+    },
+    {
+      "route": "/api/courses/[courseId]/cascade/welcome-message",
+      "file": "apps/admin/app/api/courses/[courseId]/cascade/welcome-message/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Returns the `Effective<string | null>` envelope for the",
+      "category": "courses"
+    },
+    {
+      "route": "/api/courses/[courseId]/course-reference",
+      "file": "apps/admin/app/api/courses/[courseId]/course-reference/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER",
+        "OPERATOR"
+      ],
+      "description": "Returns the most recent COURSE_REFERENCE markdown document",
+      "category": "courses"
+    },
+    {
+      "route": "/api/courses/[courseId]/dry-run-prompt",
+      "file": "apps/admin/app/api/courses/[courseId]/dry-run-prompt/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Compose a dry-run prompt for a course — used during demos",
+      "category": "courses"
+    },
+    {
+      "route": "/api/courses/[courseId]/import-modules",
+      "file": "apps/admin/app/api/courses/[courseId]/import-modules/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER",
+        "OPERATOR"
+      ],
+      "description": "Read the current modules catalogue for a course. Prefers",
+      "category": "courses"
+    },
+    {
+      "route": "/api/courses/[courseId]/regenerate-curriculum",
+      "file": "apps/admin/app/api/courses/[courseId]/regenerate-curriculum/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Regenerates the curriculum structure (modules + learning objectives)",
+      "category": "courses"
+    },
+    {
+      "route": "/api/courses/[courseId]/session-flow",
+      "file": "apps/admin/app/api/courses/[courseId]/session-flow/route.ts",
+      "methods": [
+        "GET",
+        "PUT"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Returns the resolved Session Flow shape for a course — the",
+      "category": "courses"
+    },
+    {
+      "route": "/api/curricula",
+      "file": "apps/admin/app/api/curricula/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER",
+        "OPERATOR"
+      ],
+      "description": "List curricula, optionally filtered by subjectId.",
+      "category": "playbooks"
+    },
+    {
+      "route": "/api/goals",
+      "file": "apps/admin/app/api/goals/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER",
+        "OPERATOR"
+      ],
+      "description": "Fetch all goals across all callers with filtering options. Includes related caller, playbook, and content spec data. Returns aggregate counts grouped by status and type.",
+      "category": "settings"
+    },
+    {
+      "route": "/api/identity/challenge-skip",
+      "file": "apps/admin/app/api/identity/challenge-skip/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Admin escape hatch: mark a caller's most-recent",
+      "category": "other"
+    },
+    {
+      "route": "/api/intake/v2/admin-test-enrol",
+      "file": "apps/admin/app/api/intake/v2/admin-test-enrol/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Admin escape hatch on the V2 intake entry screen",
+      "category": "other"
+    },
+    {
+      "route": "/api/playbooks/[playbookId]/subjects",
+      "file": "apps/admin/app/api/playbooks/[playbookId]/subjects/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER",
+        "OPERATOR"
+      ],
+      "description": "Get subjects linked to a playbook via PlaybookSubject.",
+      "category": "playbooks"
+    },
+    {
+      "route": "/api/playbooks/[playbookId]/voice-config",
+      "file": "apps/admin/app/api/playbooks/[playbookId]/voice-config/route.ts",
+      "methods": [
+        "GET",
+        "PATCH"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "/api/playbooks/:playbookId/voice-config",
+      "category": "playbooks"
+    },
+    {
+      "route": "/api/recompose/apply",
+      "file": "apps/admin/app/api/recompose/apply/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Acts on the toggle decisions from the PendingChangesTray's",
+      "category": "settings"
+    },
+    {
+      "route": "/api/subjects/[subjectId]/curriculum",
+      "file": "apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts",
+      "methods": [
+        "GET",
+        "POST",
+        "PATCH"
+      ],
+      "authLevels": [
+        "VIEWER",
+        "OPERATOR"
+      ],
+      "description": "Generate or fetch a Subject's Curriculum — the \"build a",
+      "category": "playbooks"
+    },
+    {
+      "route": "/api/voice-providers/[id]/sample",
+      "file": "apps/admin/app/api/voice-providers/[id]/sample/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Generate a short TTS audio clip for the voice sample",
+      "category": "voice"
+    },
+    {
+      "route": "/api/voice/[slug]/catalog",
+      "file": "apps/admin/app/api/voice/[slug]/catalog/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Returns the catalog of legal voiceIds per TTS engine routed",
+      "category": "voice"
+    },
+    {
+      "route": "/api/voice/calls/outbound-dial",
+      "file": "apps/admin/app/api/voice/calls/outbound-dial/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "description": "Place an outbound PSTN call to a caller via VAPI — the",
+      "category": "voice"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- New JSDoc tag `@operator-surface yes` annotated on 21 routes operators touch directly
- New generator `apps/admin/scripts/capture/operator-surfaces.ts` → `docs/kb/generated/operator-surfaces.json`
- Generator uses regex-walk pattern (mirrors `scripts/generate-constants-manifest.ts`), reusing `route-inventory.ts::routePath()` for path normalisation
- `/x/help/demos` page extended with new "Operator-touchable routes" section grouped by URL-prefix category
- `check-kb-fresh.sh` + `package.json` + KB error message updated together

> **Stacked on #1486** (`feat/1482-demo-knobs`). Once Slice 1 merges, this rebases cleanly onto main.

## Verified by

- `tests/scripts/operator-surfaces-generator.test.ts` — 12 tests
- `tests/scripts/demo-knobs-generator.test.ts` — 4 tests (unchanged, still green)
- `npm run kb:fresh` → ✔

## Deploy

`/vm-cp` (no schema)

Closes #1483
Refs Epic #1442 Layer 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)