### PR TITLE
fix(course-design): #1478 follow-on — Voice Flow lens smoke fixes (Pickup copy + VAPI chip + voiceId dropdown)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/VoiceFlowLens.tsx
@@ -58,6 +58,13 @@ interface VoicePayload {
   courseOverrides?: Record<string, unknown>;
 }
 
+interface VoiceCatalogEntry {
+  voiceProvider: string;
+  voiceId: string;
+  label: string;
+  description?: string;
+}
+
 interface NodeRowDef {
   /** Cascade key this row reads from. */
   key: string;
@@ -89,8 +96,7 @@ const NODES: NodeDef[] = [
   {
     id: "pickup",
     marker: <Phone size={18} aria-hidden="true" />,
-    title: "Pickup",
-    subtitle: "The learner answers the call.",
+    title: "Call starts",
     rows: [],
   },
   {
@@ -215,6 +221,10 @@ export function VoiceFlowLens({
   const [drawerKey, setDrawerKey] = useState<string | null>(null);
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState<string | null>(null);
+  // Vendor-validated voice catalog for the voiceId drawer dropdown
+  // (#1421 Slice A pattern, mirrored from VoiceConfigSection.tsx:417–444).
+  // Empty array = custom-ID hatch (e.g. ElevenLabs account-specific IDs).
+  const [voiceCatalog, setVoiceCatalog] = useState<VoiceCatalogEntry[] | null>(null);
 
   const session = useSession();
   const role = (session.data?.user as { role?: string } | undefined)?.role ?? "";
@@ -244,6 +254,37 @@ export function VoiceFlowLens({
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Re-fetch the catalog whenever the orchestrator slug + resolved
+  // voiceProvider change. Mirrors VoiceConfigSection.tsx:417–444.
+  const orchestratorSlug = data?.enabledProviderSlug;
+  const resolvedVoiceProvider =
+    (data?.resolved.fields.voiceProvider?.value as string | undefined) ?? null;
+  useEffect(() => {
+    if (!orchestratorSlug || !resolvedVoiceProvider) {
+      setVoiceCatalog(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/voice/${encodeURIComponent(orchestratorSlug)}/catalog?voiceProvider=${encodeURIComponent(resolvedVoiceProvider)}`,
+        );
+        if (!res.ok) {
+          if (!cancelled) setVoiceCatalog([]);
+          return;
+        }
+        const json = (await res.json()) as { ok: boolean; voices: VoiceCatalogEntry[] };
+        if (!cancelled) setVoiceCatalog(json.voices ?? []);
+      } catch {
+        if (!cancelled) setVoiceCatalog([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orchestratorSlug, resolvedVoiceProvider]);
 
   const persist = useCallback(
     async (key: string, value: unknown): Promise<void> => {
@@ -313,6 +354,12 @@ export function VoiceFlowLens({
   return (
     <div className="hf-voice-flow">
       <header className="hf-voice-flow-intro">
+        <div className="hf-voice-flow-intro-platform">
+          <span className="hf-voice-flow-platform-label">Voice platform</span>
+          <span className="hf-voice-flow-platform-chip">
+            {data.enabledProviderSlug.toUpperCase()}
+          </span>
+        </div>
         <div className="hf-text-muted hf-text-sm">
           Settings inherit from the system default unless overridden here.
           Edit any field to set a course-specific value. Clear it (↺ Reset)
@@ -407,6 +454,7 @@ export function VoiceFlowLens({
         data={data}
         busyKey={busyKey}
         savedFlash={savedFlash}
+        voiceCatalog={voiceCatalog}
         onClose={() => setDrawerKey(null)}
         onSave={persist}
         onReset={reset}
@@ -420,6 +468,9 @@ interface VoiceFlowEditDrawerProps {
   data: VoicePayload;
   busyKey: string | null;
   savedFlash: string | null;
+  /** Vendor-validated voice list for the voiceId dropdown. null until
+   *  fetched; empty array = custom-ID hatch (use free-text input). */
+  voiceCatalog: VoiceCatalogEntry[] | null;
   onClose: () => void;
   onSave: (key: string, value: unknown) => Promise<void>;
   onReset: (key: string) => Promise<void>;
@@ -430,6 +481,7 @@ function VoiceFlowEditDrawer({
   data,
   busyKey,
   savedFlash,
+  voiceCatalog,
   onClose,
   onSave,
   onReset,
@@ -464,7 +516,7 @@ function VoiceFlowEditDrawer({
             onReset={async (k) => {
               await onReset(k);
             }}
-            voiceCatalog={undefined}
+            voiceCatalog={key === "voiceId" ? voiceCatalog : undefined}
             currentVoiceProvider={
               (data.resolved.fields.voiceProvider?.value as string | undefined) ?? null
             }

--- a/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/voice-flow-lens.css
@@ -19,6 +19,33 @@
   background: color-mix(in srgb, var(--accent-primary) 4%, var(--surface-primary));
   border: 1px solid var(--border-default);
   border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+}
+
+.hf-voice-flow-intro-platform {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+}
+
+.hf-voice-flow-platform-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hf-voice-flow-platform-chip {
+  font-size: 12px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  color: var(--accent-primary);
+  letter-spacing: 0.04em;
 }
 
 /* ── Node list ────────────────────────────────────────── */

--- a/apps/admin/tests/components/VoiceFlowLens.test.tsx
+++ b/apps/admin/tests/components/VoiceFlowLens.test.tsx
@@ -132,11 +132,11 @@ describe("VoiceFlowLens — Slice 1 read-only diagram", () => {
 
     render(<VoiceFlowLens courseId={COURSE_ID} />);
 
-    await waitFor(() => expect(screen.getByText("Pickup")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Call starts")).toBeInTheDocument());
 
     const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
     expect(headings).toEqual([
-      "Pickup",
+      "Call starts",
       "Voice Provider",
       "Selected Voice",
       "Transcriber",
@@ -243,7 +243,13 @@ describe("VoiceFlowLens — Slice 1 read-only diagram", () => {
     });
 
     await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The lens makes TWO classes of fetches: the cascade GET on the
+    // playbook route, and (once data lands) the voice catalog on the
+    // /api/voice/[slug]/catalog route. Count only the voice-config calls.
+    const voiceConfigCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("/voice-config"),
+    );
+    expect(voiceConfigCalls.length).toBe(2);
   });
 
   it("wraps the node list in an ordered list with the call-lifecycle aria-label", async () => {
@@ -369,12 +375,19 @@ describe("VoiceFlowLens — Slice 2 edit drawer + Amendment A + Amendment C", ()
     });
 
     await waitFor(() => {
-      // Three calls: initial GET + PATCH + re-fetch
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      // Three voice-config calls: initial GET + PATCH + re-fetch. The
+      // catalog GET (/api/voice/[slug]/catalog) fires once when data
+      // first lands; ignore it.
+      const voiceConfigCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("/voice-config"),
+      );
+      expect(voiceConfigCalls.length).toBe(3);
     });
 
-    // PATCH call body
-    const patchCall = fetchMock.mock.calls[1]!;
+    // PATCH is the only voice-config call with a body.
+    const patchCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "PATCH",
+    )!;
     expect(patchCall[0]).toBe(`/api/playbooks/${COURSE_ID}/voice-config`);
     expect(patchCall[1]).toMatchObject({
       method: "PATCH",
@@ -420,10 +433,15 @@ describe("VoiceFlowLens — Slice 2 edit drawer + Amendment A + Amendment C", ()
     });
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const voiceConfigCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("/voice-config"),
+      );
+      expect(voiceConfigCalls.length).toBe(3);
     });
 
-    const patchCall = fetchMock.mock.calls[1]!;
+    const patchCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as { method?: string } | undefined)?.method === "PATCH",
+    )!;
     const patchBody = JSON.parse((patchCall[1] as { body: string }).body);
     expect(patchBody).toEqual({ key: "voiceId", value: null });
   });


### PR DESCRIPTION
## Summary

Three smoke-test findings from running #1488 on a live course.

| # | Finding | Fix |
|---|---------|-----|
| 1 | "Pickup → The learner answers the call" is wrong (learners can start calls too) | Renamed to "Call starts", subtitle dropped |
| 2 | VAPI (the orchestrator) wasn't visible anywhere — earlier ux-reviewer stripped it from the intro as jargon, but operators actually need that signal | Restored as a labelled chip in the intro: `VOICE PLATFORM` `VAPI` |
| 3 | Voice ID drawer rendered a free-text input — `<FieldRow>` supports a vendor-validated dropdown but only when handed a non-null `voiceCatalog`, and the lens was passing `undefined` | Lens now fetches `/api/voice/[slug]/catalog?voiceProvider=...` when data lands (mirrors `VoiceConfigSection.tsx:417-444`) and threads it through the drawer for the `voiceId` field |

Closes the smoke-pass loop for #1478.

## Test plan

- [x] `npx vitest run tests/components/VoiceFlowLens.test.tsx` → 13/13 green
- [x] `npx tsc --noEmit` → 0 errors in story files
- [ ] Manual on hf-dev: lens shows the `VAPI` chip in the intro
- [ ] Manual: Voice ID ✏️ opens a `<select>` populated from the catalog
- [ ] Manual: Pickup node now reads "Call starts" with no misleading subtitle

## Verified by

- 13 vitests (test count assertions now filter for `/voice-config` URLs so the new catalog fetch doesn't inflate them)
- tsc + eslint clean on story files

🤖 Generated with [Claude Code](https://claude.com/claude-code)