### PR TITLE
chore: unbreak CI after #1488 — bump lens count + tsc ratchet baseline

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 201,
+  "tsc_errors": 193,
   "lint_errors": 0,
   "lint_warnings": 4422,
   "quarantined_tests": 37,

--- a/apps/admin/tests/components/courses/course-design-console.test.tsx
+++ b/apps/admin/tests/components/courses/course-design-console.test.tsx
@@ -95,11 +95,11 @@ beforeEach(() => {
 });
 
 describe("CourseDesignConsole — nav", () => {
-  it("renders 12 lenses in the nav (5 Journey + 6 Behaviour + 1 Preview)", () => {
+  it("renders 13 lenses in the nav (5 Journey + 7 Behaviour + 1 Preview)", () => {
     mockSessionFlowFetch(makeResolvedResponse());
     const { container } = render(<CourseDesignConsole courseId="course-1" />);
     const items = container.querySelectorAll(".hf-console-shell-nav-item");
-    expect(items.length).toBe(12);
+    expect(items.length).toBe(13);
   });
 
   it("renders a 'soon' badge only on agentTunerNlp (1 — Slices 2+3 absorbed the rest)", () => {


### PR DESCRIPTION
## Summary

Two pre-existing CI failures on every open PR after #1488 merged, both fixed here:

1. **`tests/components/courses/course-design-console.test.tsx`** — #1488 added a 13th lens (Voice Flow) to \`CourseDesignConsole\` but didn't update its own \`expect(items.length).toBe(12)\` assertion. Every PR now fails the Unit Tests step with \`AssertionError: expected 13 to be 12\`.
2. **\`.ratchet.json\`** — same PR brought CI's tsc-error count down to 193 (from baseline 201), tripping the ratchet's "lock the win" gate. Every PR's Lint & Type Check step exits 1 with \`tsc_errors: 193 (-8 under baseline). Update .ratchet.json to lock the win.\`

## Changes

- \`tests/components/courses/course-design-console.test.tsx:98-102\` — bump expected nav-item count 12 → 13; rewrite the comment to reflect the new "5 Journey + 7 Behaviour + 1 Preview" split (Voice Flow lens lives in the Behaviour group per \`CourseDesignConsole.tsx:88-102\`).
- \`.ratchet.json\` — \`tsc_errors: 201 → 193\` to match CI's current count.

## Verified by

- \`npx vitest run tests/components/courses/course-design-console.test.tsx\` — 11/11 pass (previously 10/11 with the same 1 failure)
- Direct inspection of \`DESIGN_LENS_ORDER\` confirming 13 entries: preview + 5 Journey (intake/onboarding/stops/offboarding/welcome) + 7 Behaviour (call1Mode/firstCallTargets/tolerances/skillBanding/progressSignals/agentTunerNlp/voiceFlow)
- CI's last-run report \`tsc_errors: 193\` on every PR's Lint & Type Check step

Unblocks PR #1494 (cascade gate Course-layer fix for #1457) and every other PR currently behind these two checks.

## Test plan

- [x] Single failing test now passes (\`npx vitest run\`)
- [ ] CI Lint & Type Check passes (post-merge)
- [ ] CI Unit Tests passes (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)