### PR TITLE
feat(voice): #1478 follow-on — enum dropdowns carry HF capability hints

### DIFF
--- a/apps/admin/components/voice/VoiceConfigSection.tsx
+++ b/apps/admin/components/voice/VoiceConfigSection.tsx
@@ -24,6 +24,10 @@ export type SchemaField = {
   type: "string" | "number" | "boolean" | "enum";
   help?: string;
   enumValues?: string[];
+  /** Display label per enum value — falls back to the raw value when
+   *  absent. Decorates the dropdown options without altering the
+   *  submitted value. */
+  enumLabels?: Record<string, string>;
   default?: unknown;
 };
 
@@ -266,7 +270,7 @@ export function FieldRow({
         >
           {meta.enumValues.map((v) => (
             <option key={v} value={v}>
-              {v}
+              {meta.enumLabels?.[v] ?? v}
             </option>
           ))}
         </select>

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -547,6 +547,20 @@ export class VapiProvider implements VoiceProvider {
           label: "Voice provider (TTS engine)",
           type: "enum",
           enumValues: ["11labs", "openai", "azure", "playht", "deepgram"],
+          // #1478 — capability hints so educators see HF-side asymmetry
+          // up front. Deepgram + OpenAI have vendor-validated voice
+          // catalogs (#1421 Slice A); 11labs/azure/playht fall back to
+          // free-text "custom ID" entry. Only Deepgram supports the
+          // exact ▶ Test voice preview (others use OpenAI TTS fallback
+          // labelled "Preview ≠ live voice"). Submitted enum value is
+          // unchanged — only the rendered label is decorated.
+          enumLabels: {
+            "deepgram": "deepgram (recommended — Aura catalog + exact preview)",
+            "openai": "openai (catalog available)",
+            "11labs": "11labs (no catalog — paste a custom voice ID)",
+            "azure": "azure (no catalog — paste a custom voice ID)",
+            "playht": "playht (no catalog — paste a custom voice ID)",
+          },
           default: "deepgram",
           help: "Which TTS engine the voice ID belongs to. Default \"deepgram\" (Aura — ~$0.015/min, conversational-AI tuned, same datacentre as default STT for lowest latency). Use \"11labs\" for premium voice quality at ~12× the cost. \"openai\" is a viable middle ground. \"azure\"/\"playht\" require extra API-key linkage in the VAPI dashboard. See ADR docs/decisions/2026-06-08-pilot-cheaper-tts.md.",
           sensitive: false,
@@ -557,6 +571,12 @@ export class VapiProvider implements VoiceProvider {
           label: "Transcriber (STT engine)",
           type: "enum",
           enumValues: ["deepgram", "talkscriber", "gladia", "assembly-ai"],
+          // #1478 — all four are first-class through VAPI (auth is
+          // VAPI-side); no HF asymmetry. The hint just signposts the
+          // safe default so educators don't pick at random.
+          enumLabels: {
+            "deepgram": "deepgram (default — recommended)",
+          },
           default: "deepgram",
           help: "Speech-to-text engine VAPI uses to transcribe the learner. Deepgram default. Switch only if you observe transcription errors that persist after adjusting the prompt.",
           sensitive: false,

--- a/apps/admin/lib/voice/types.ts
+++ b/apps/admin/lib/voice/types.ts
@@ -272,6 +272,12 @@ export interface ProviderConfigField {
   help?: string;
   /** Allowed values for type === "enum". */
   enumValues?: string[];
+  /** Display label per enum value — falls back to the raw value when
+   *  absent. Used to communicate HF-side capability hints (e.g. which
+   *  TTS engines have a vendor-validated voice catalog vs. fall back
+   *  to free-text). The submitted value is always the raw enum value;
+   *  only the rendered label is decorated. */
+  enumLabels?: Record<string, string>;
   /** Pre-fill when creating a new provider row. */
   default?: unknown;
   /** Mask + route to credentials. */

--- a/apps/admin/tests/components/VoiceFlowLens.test.tsx
+++ b/apps/admin/tests/components/VoiceFlowLens.test.tsx
@@ -445,4 +445,50 @@ describe("VoiceFlowLens — Slice 2 edit drawer + Amendment A + Amendment C", ()
     const patchBody = JSON.parse((patchCall[1] as { body: string }).body);
     expect(patchBody).toEqual({ key: "voiceId", value: null });
   });
+
+  it("enum dropdown decorates options via enumLabels but keeps the raw value as the submitted enum", async () => {
+    const payload = makeVapiPayload();
+    // Decorate the voiceProvider schema field — the VAPI adapter ships
+    // this in production (#1478 enum-hints). Only "deepgram" gets a
+    // label here so we can also assert the fallback (the raw enum)
+    // path in the same test.
+    payload.schemaFields = payload.schemaFields.map((f) =>
+      f.key === "voiceProvider"
+        ? {
+            ...f,
+            enumValues: ["deepgram", "openai", "azure"],
+            enumLabels: {
+              deepgram: "deepgram (recommended)",
+            },
+          }
+        : f,
+    );
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VoiceFlowLens courseId={COURSE_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Voice Provider")).toBeInTheDocument());
+
+    const editEngine = screen.getByRole("button", { name: "Edit Voice engine" });
+    await act(async () => {
+      fireEvent.click(editEngine);
+    });
+
+    // Decorated label.
+    const deepgramOption = await screen.findByRole("option", {
+      name: /deepgram \(recommended\)/i,
+    });
+    expect(deepgramOption).toHaveAttribute("value", "deepgram");
+
+    // Undecorated values still render the raw enum as their own label.
+    const openaiOption = screen.getByRole("option", { name: "openai" });
+    expect(openaiOption).toHaveAttribute("value", "openai");
+    const azureOption = screen.getByRole("option", { name: "azure" });
+    expect(azureOption).toHaveAttribute("value", "azure");
+  });
 });


### PR DESCRIPTION
## Summary

Smoke testing the Voice Flow lens (#1488 + #1491) surfaced a real UX gap: the `voiceProvider` and `transcriber` dropdowns show raw enum slugs with no signal as to which choices are first-class vs. degraded experience. Operators rightly asked "are these all actually usable?"

Fix: a new optional `enumLabels: Record<string, string>` on `ProviderConfigField` (and the mirrored `SchemaField` in `VoiceConfigSection`). Decorates the visible `<option>` text while keeping the submitted enum `value` raw — cascade write path unchanged, existing data stays valid.

## After (lens + Voice tab both pick it up)

```
Voice provider (TTS engine)
  ✓ deepgram (recommended — Aura catalog + exact preview)
    openai (catalog available)
    11labs (no catalog — paste a custom voice ID)
    azure (no catalog — paste a custom voice ID)
    playht (no catalog — paste a custom voice ID)

Transcriber (STT engine)
  ✓ deepgram (default — recommended)
    talkscriber
    gladia
    assembly-ai
```

## Why each label

| Provider | Hint | Why |
|---|---|---|
| **deepgram (TTS)** | Recommended | 12-voice catalog + exact preview via HF's `deepgramApiKey` (#1421 Slice B) |
| **openai (TTS)** | Catalog available | 6-voice catalog, OpenAI-TTS fallback preview labelled "≠ live voice" |
| **11labs / azure / playht (TTS)** | No catalog — paste a custom voice ID | Empty catalog ("custom-ID hatch"); no HF-side preview |
| **deepgram (STT)** | Default — recommended | VAPI's standard, lowest latency in our experience |
| **other STTs** | _unlabelled_ | All four route through VAPI with no HF asymmetry; just signpost the default |

## Files

- `lib/voice/types.ts` — new `enumLabels?: Record<string, string>` on `ProviderConfigField`
- `lib/voice/providers/vapi/index.ts` — adds `enumLabels` to the `voiceProvider` + `transcriber` schema entries
- `components/voice/VoiceConfigSection.tsx` — extended local `SchemaField` type; `FieldRow` enum renders `enumLabels[v] ?? v`. Both the lens drawer AND the Voice tab pick it up.
- `tests/components/VoiceFlowLens.test.tsx` — 1 new vitest pinning that the dropdown decorates labels while preserving raw enum as the submitted value

## Test plan

- [x] 14/14 vitests green
- [x] tsc clean
- [ ] Manual: open Voice Flow lens → ✏️ on Voice Provider → all 5 options carry the right hint
- [ ] Manual: ✏️ on Engine (transcriber) → only deepgram is hinted
- [ ] Manual: existing Voice tab on `/x/courses/...?tab=settings` also picks up the labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)