### PR TITLE
feat(course-design): #1442 Layer 4 — Preview annotations + sticky-note editor

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,7 +1,7 @@
 {
   "tsc_errors": 193,
   "lint_errors": 0,
-  "lint_warnings": 4425,
+  "lint_warnings": 4426,
   "quarantined_tests": 37,
   "same_issue_fix_chain_max": 10,
   "memory_md_bytes": 29073

--- a/apps/admin/app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts
@@ -1,0 +1,85 @@
+/**
+ * @operator-surface yes
+ *
+ * DELETE /api/courses/[courseId]/demo-script/[bubbleRef]
+ *
+ * Removes a single annotation from `Playbook.config.demoScript.annotations[]`
+ * by its `bubbleRef`. Used by the Preview annotation editor sidetray when
+ * the operator clicks "Remove annotation" (#1493).
+ *
+ * 404 is reserved for the playbook missing entirely; deleting an annotation
+ * that doesn't exist is a no-op 200 (idempotent — matches how the
+ * sidetray's UI behaves when the user double-clicks delete).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import { bumpPlaybookComposeTimestamp } from "@/lib/compose/bump-timestamp";
+import type { PlaybookConfig, DemoScript } from "@/lib/types/json-fields";
+
+/**
+ * @api DELETE /api/courses/[courseId]/demo-script/[bubbleRef]
+ * @visibility internal
+ * @scope course:write
+ * @auth session (OPERATOR+)
+ * @description Remove a single annotation by `bubbleRef` (URL-encoded).
+ *   Idempotent — missing annotations return 200 with `removed: false`.
+ *   Bumps `composeInputsUpdatedAt` regardless (operator-touch signal).
+ * @response 200 { ok: true, removed: boolean, count: number }
+ * @response 404 { ok: false, error: "Course not found" }
+ */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ courseId: string; bubbleRef: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  try {
+    const { courseId, bubbleRef: bubbleRefRaw } = await params;
+    const bubbleRef = decodeURIComponent(bubbleRefRaw);
+
+    let removed = false;
+    let total = 0;
+
+    try {
+      await updatePlaybookConfig(
+        courseId,
+        (existing: PlaybookConfig) => {
+          const existingScript: DemoScript =
+            existing.demoScript ?? { annotations: [] };
+          const before = existingScript.annotations.length;
+          const annotations = existingScript.annotations.filter(
+            (a) => a.bubbleRef !== bubbleRef,
+          );
+          removed = annotations.length < before;
+          total = annotations.length;
+          return {
+            ...existing,
+            demoScript: { annotations },
+          };
+        },
+        { reason: "demo-script DELETE" },
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes("not found")) {
+        return NextResponse.json(
+          { ok: false, error: "Course not found" },
+          { status: 404 },
+        );
+      }
+      throw err;
+    }
+
+    await bumpPlaybookComposeTimestamp(courseId);
+
+    return NextResponse.json({ ok: true, removed, count: total });
+  } catch (err) {
+    console.error("[courses/[courseId]/demo-script DELETE]", err);
+    return NextResponse.json(
+      { ok: false, error: (err as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/api/courses/[courseId]/demo-script/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/demo-script/route.ts
@@ -1,0 +1,196 @@
+/**
+ * @operator-surface yes
+ *
+ * POST /api/courses/[courseId]/demo-script
+ *
+ * Upserts a single Preview-lens sticky-note annotation into
+ * `Playbook.config.demoScript.annotations[]`, keyed by `bubbleRef`. Used
+ * by the Preview annotation editor sidetray (#1493, Epic #1442 Layer 4).
+ *
+ * The route is intentionally separate from the existing
+ * `PUT /api/courses/[courseId]/session-flow` — that handler is already
+ * juggling `sessionFlow / lessonPlanMode / welcomeMessage / nps` and a
+ * `demoScript` payload has no relationship to any of them (TL question R2
+ * in #1493). Dedicated routes also let `arch-checker` keep the
+ * operator-surface boundary tight.
+ *
+ * **Composition isolation (R3 in #1493).** `demoScript` is `NEVER-COMPOSE` —
+ * the JSDoc on `PlaybookConfig.demoScript` says so, the test in
+ * `tests/api/courses/demo-script.test.ts` asserts the structural grep
+ * against `lib/prompt/composition/` returns zero hits. If a future
+ * composer needs to surface presenter notes, add a NEW field — do not
+ * teach composition to read `demoScript`.
+ *
+ * Save bumps `composeInputsUpdatedAt` via the standard
+ * `bumpPlaybookComposeTimestamp` helper. This is structurally harmless
+ * because `demoScript` is NOT a compose-affecting key
+ * (`composeAffectingChanged` returns false), and the Preview "is the
+ * compose surface stale?" banner reads the same timestamp — so the
+ * banner correctly stays put while a presenter scribbles annotations.
+ *
+ * In other words: the bump tells the UI "the operator touched the
+ * course" without telling the composer "regenerate the prompt".
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import { bumpPlaybookComposeTimestamp } from "@/lib/compose/bump-timestamp";
+import type {
+  PlaybookConfig,
+  DemoAnnotation,
+  DemoScript,
+} from "@/lib/types/json-fields";
+
+const BodySchema = z.object({
+  bubbleRef: z.string().min(1, "bubbleRef is required").max(300),
+  presenterNote: z.string().max(4000),
+  isWowMoment: z.boolean(),
+  durationSecOnStep: z.number().int().positive().max(3600).optional(),
+});
+
+type Body = z.infer<typeof BodySchema>;
+
+/**
+ * @api GET /api/courses/[courseId]/demo-script
+ * @visibility internal
+ * @scope course:read
+ * @auth session (OPERATOR+)
+ * @description Returns the operator-only demo script for a course. This
+ *   is NEVER returned by composition — it lives alongside the Preview
+ *   lens and is read only by the Preview annotation editor.
+ * @response 200 { ok: true, demoScript: DemoScript }
+ * @response 404 { ok: false, error: "Course not found" }
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  try {
+    const { courseId } = await params;
+    const row = await prisma.playbook.findUnique({
+      where: { id: courseId },
+      select: { config: true },
+    });
+    if (!row) {
+      return NextResponse.json(
+        { ok: false, error: "Course not found" },
+        { status: 404 },
+      );
+    }
+    const cfg = (row.config ?? {}) as PlaybookConfig;
+    const demoScript: DemoScript = cfg.demoScript ?? { annotations: [] };
+    return NextResponse.json({ ok: true, demoScript });
+  } catch (err) {
+    console.error("[courses/[courseId]/demo-script GET]", err);
+    return NextResponse.json(
+      { ok: false, error: (err as Error).message },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * @api POST /api/courses/[courseId]/demo-script
+ * @visibility internal
+ * @scope course:write
+ * @auth session (OPERATOR+)
+ * @description Upsert a single Preview-lens annotation by `bubbleRef`.
+ *   If an annotation with the same `bubbleRef` exists, its fields are
+ *   replaced; otherwise a new entry is appended to
+ *   `config.demoScript.annotations[]`. Bumps `composeInputsUpdatedAt`
+ *   (operator-touch signal — does NOT invalidate composer cache).
+ * @request { bubbleRef: string, presenterNote: string, isWowMoment: boolean, durationSecOnStep?: number }
+ * @response 200 { ok: true, annotation: DemoAnnotation, count: number }
+ * @response 400 { ok: false, error: "Invalid body", details?: unknown }
+ * @response 404 { ok: false, error: "Course not found" }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  try {
+    const { courseId } = await params;
+    const json = (await req.json()) as unknown;
+    const parsed = BodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: "Invalid body", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const body: Body = parsed.data;
+
+    let upsertedAnnotation: DemoAnnotation | null = null;
+    let total = 0;
+
+    try {
+      await updatePlaybookConfig(
+        courseId,
+        (existing: PlaybookConfig) => {
+          const existingScript: DemoScript =
+            existing.demoScript ?? { annotations: [] };
+          const annotations = [...existingScript.annotations];
+          const next: DemoAnnotation = {
+            bubbleRef: body.bubbleRef,
+            presenterNote: body.presenterNote,
+            isWowMoment: body.isWowMoment,
+            ...(body.durationSecOnStep !== undefined
+              ? { durationSecOnStep: body.durationSecOnStep }
+              : {}),
+          };
+          const idx = annotations.findIndex(
+            (a) => a.bubbleRef === body.bubbleRef,
+          );
+          if (idx === -1) {
+            annotations.push(next);
+          } else {
+            annotations[idx] = next;
+          }
+          upsertedAnnotation = next;
+          total = annotations.length;
+          return {
+            ...existing,
+            demoScript: { annotations },
+          };
+        },
+        { reason: "demo-script POST" },
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes("not found")) {
+        return NextResponse.json(
+          { ok: false, error: "Course not found" },
+          { status: 404 },
+        );
+      }
+      throw err;
+    }
+
+    // `demoScript` is NOT in COMPOSE_AFFECTING_PLAYBOOK_CONFIG_KEYS, so the
+    // central helper above will NOT have bumped the timestamp. Bump it
+    // explicitly so the Preview lens flips its "operator made changes"
+    // indicator. The bump is structurally harmless to the composer (no
+    // affecting-key changed → COMPOSE re-reads same inputs → same prompt).
+    await bumpPlaybookComposeTimestamp(courseId);
+
+    return NextResponse.json({
+      ok: true,
+      annotation: upsertedAnnotation,
+      count: total,
+    });
+  } catch (err) {
+    console.error("[courses/[courseId]/demo-script POST]", err);
+    return NextResponse.json(
+      { ok: false, error: (err as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -27,7 +27,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { Eye, RefreshCw, FileSearch, AlertCircle, Edit3, X } from "lucide-react";
+import { Eye, RefreshCw, FileSearch, AlertCircle, Edit3, X, Star, StickyNote, Trash2 } from "lucide-react";
 import {
   SessionFlowEditor,
   type SessionFlowLens,
@@ -40,6 +40,7 @@ import { CascadeInspectorTray } from "@/components/cascade/CascadeInspectorTray"
 import { getArchetypeLabel } from "@/lib/domain/generate-identity";
 import type { Effective, Layer } from "@/lib/cascade/layer-types";
 import { substituteGreetingTokens } from "@/lib/prompt/composition/defaults/substitute-greeting-tokens";
+import type { DemoAnnotation, DemoScript } from "@/lib/types/json-fields";
 
 interface PreviewLensProps {
   courseId: string;
@@ -135,19 +136,28 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
   const [error, setError] = useState<string | null>(null);
   const [lastComposedAt, setLastComposedAt] = useState<number | null>(null);
   const [sidetrayLens, setSidetrayLens] = useState<SessionFlowLens | null>(null);
+  // #1493 — Preview annotations. `demoScript` is operator-only metadata,
+  // NEVER forwarded to prompt composition. Loaded alongside session-flow
+  // on first paint; opens the annotation editor sidetray on bubble click.
+  const [demoScript, setDemoScript] = useState<DemoScript>({ annotations: [] });
+  const [annotationEdit, setAnnotationEdit] = useState<{
+    bubbleRef: string;
+    existing: DemoAnnotation | null;
+  } | null>(null);
   const composedOnceRef = useRef(false);
 
   const compose = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const [flowRes, dryRes] = await Promise.all([
+      const [flowRes, dryRes, demoRes] = await Promise.all([
         fetch(`/api/courses/${courseId}/session-flow`),
         fetch(`/api/courses/${courseId}/dry-run-prompt`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ callSequence: 1 }),
         }),
+        fetch(`/api/courses/${courseId}/demo-script`),
       ]);
       const flowJson = (await flowRes.json()) as SessionFlowResp;
       const dryJson = (await dryRes.json()) as DryRunResp;
@@ -156,6 +166,16 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
       setFlow(flowJson);
       setDryRun(dryJson);
       setLastComposedAt(Date.now());
+      // Best-effort — annotations are operator decoration, never block paint.
+      if (demoRes.ok) {
+        const demoJson = (await demoRes.json()) as {
+          ok: boolean;
+          demoScript?: DemoScript;
+        };
+        if (demoJson.ok && demoJson.demoScript) {
+          setDemoScript(demoJson.demoScript);
+        }
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -180,7 +200,70 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
     void compose();
   }, [compose]);
 
+  const openAnnotation = useCallback(
+    (bubbleRef: string) => {
+      const existing =
+        demoScript.annotations.find((a) => a.bubbleRef === bubbleRef) ?? null;
+      setAnnotationEdit({ bubbleRef, existing });
+    },
+    [demoScript],
+  );
+
+  const closeAnnotation = useCallback(() => {
+    setAnnotationEdit(null);
+  }, []);
+
+  const onAnnotationSaved = useCallback(
+    (next: DemoAnnotation) => {
+      setDemoScript((prev) => {
+        const existing = prev.annotations.findIndex(
+          (a) => a.bubbleRef === next.bubbleRef,
+        );
+        const annotations = [...prev.annotations];
+        if (existing === -1) annotations.push(next);
+        else annotations[existing] = next;
+        return { annotations };
+      });
+      setAnnotationEdit(null);
+    },
+    [],
+  );
+
+  const onAnnotationDeleted = useCallback((bubbleRef: string) => {
+    setDemoScript((prev) => ({
+      annotations: prev.annotations.filter((a) => a.bubbleRef !== bubbleRef),
+    }));
+    setAnnotationEdit(null);
+  }, []);
+
   const transcript = useMemo(() => buildTranscript(flow), [flow]);
+
+  // R1 mitigation — warn when stored bubbleRefs don't match any current
+  // bubble. The annotation isn't lost (it's still persisted) but the
+  // sticky note silently detaches; the warning surfaces the divergence.
+  const annotationsByRef = useMemo(() => {
+    const map = new Map<string, DemoAnnotation>();
+    for (const a of demoScript.annotations) map.set(a.bubbleRef, a);
+    return map;
+  }, [demoScript]);
+
+  const transcriptRefs = useMemo(() => {
+    const set = new Set<string>();
+    let bubbleIdx = 0;
+    for (const item of transcript) {
+      if (item.kind === "bubble") {
+        set.add(derivePreviewBubbleRef(item, bubbleIdx));
+        bubbleIdx += 1;
+      }
+    }
+    return set;
+  }, [transcript]);
+
+  const detachedRefs = useMemo(() => {
+    return demoScript.annotations
+      .filter((a) => !transcriptRefs.has(a.bubbleRef))
+      .map((a) => a.bubbleRef);
+  }, [demoScript, transcriptRefs]);
 
   return (
     <div className="hf-preview-lens">
@@ -238,10 +321,31 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
         </div>
       )}
 
+      {!loading && flow && mode === "educator" && detachedRefs.length > 0 && (
+        <div
+          className="hf-banner hf-banner-warning"
+          data-testid="hf-preview-annotation-detached-warning"
+        >
+          <AlertCircle size={14} />
+          <span>
+            {detachedRefs.length} demo annotation
+            {detachedRefs.length === 1 ? "" : "s"} no longer matches any bubble
+            (session-flow likely reordered). They are still saved but won&apos;t
+            render until you re-attach or delete them.
+          </span>
+        </div>
+      )}
+
       {!loading && flow && mode === "educator" && (
         <>
           <IdentityHeader meta={dryRun?.metadata} courseId={courseId} />
-          <EducatorView transcript={transcript} courseId={courseId} onOpenSidetray={openSidetray} />
+          <EducatorView
+            transcript={transcript}
+            courseId={courseId}
+            onOpenSidetray={openSidetray}
+            annotationsByRef={annotationsByRef}
+            onOpenAnnotation={openAnnotation}
+          />
         </>
       )}
 
@@ -254,6 +358,17 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
           courseId={courseId}
           lens={sidetrayLens}
           onClose={closeSidetray}
+        />
+      )}
+
+      {annotationEdit && (
+        <AnnotationEditSidetray
+          courseId={courseId}
+          bubbleRef={annotationEdit.bubbleRef}
+          existing={annotationEdit.existing}
+          onClose={closeAnnotation}
+          onSaved={onAnnotationSaved}
+          onDeleted={onAnnotationDeleted}
         />
       )}
     </div>
@@ -297,6 +412,29 @@ type PreviewItem =
   | ({ kind: "bubble" } & PreviewBubble)
   | PreviewDivider
   | PreviewStopNote;
+
+/**
+ * Strategy A from #1493 R1 — derive a stable per-bubble ref from
+ * `lens + caption + side + positional-index`. Cheap; reorders detach the
+ * annotation (we warn at load time when a stored bubbleRef does not match
+ * any current bubble).
+ *
+ * Exported so vitests can pin determinism. The slug treatment lowercases
+ * + ASCII-collapses non-alphanumeric runs into single `-` so a caption
+ * tweak like "Goals question" → "Goals question " does NOT detach the
+ * annotation. Truncated to 60 chars to keep DB keys readable.
+ */
+export function derivePreviewBubbleRef(
+  item: { kind: "bubble" } & PreviewBubble,
+  positionalIndex: number,
+): string {
+  const slugCaption = (item.caption ?? item.text ?? "no-caption")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+  return `${item.lens}__${item.side}__${slugCaption}__${positionalIndex}`;
+}
 
 function buildTranscript(flow: SessionFlowResp | null): PreviewItem[] {
   if (!flow?.sessionFlow) return [];
@@ -525,14 +663,30 @@ function buildTranscript(flow: SessionFlowResp | null): PreviewItem[] {
 // ── Views ──────────────────────────────────────────────────────
 
 function EducatorView({
-  transcript, courseId, onOpenSidetray,
+  transcript, courseId, onOpenSidetray, annotationsByRef, onOpenAnnotation,
 }: {
   transcript: PreviewItem[];
   courseId: string;
   onOpenSidetray: (lensId: string) => void;
+  annotationsByRef: Map<string, DemoAnnotation>;
+  onOpenAnnotation: (bubbleRef: string) => void;
 }): React.ReactElement {
   if (transcript.length === 0) {
     return <p className="hf-text-muted">Nothing configured yet — see Engineer view for raw compose state.</p>;
+  }
+  // Sticky-note refs are stamped over BUBBLE items only — positional
+  // index is the running count of bubbles seen so far, not the transcript
+  // map index (which includes dividers + stop-notes). Pre-compute the
+  // mapping so the render loop is reassignment-free.
+  const bubblePositionByMapIndex = new Map<number, number>();
+  {
+    let bubbleIdx = -1;
+    transcript.forEach((item, i) => {
+      if (item.kind === "bubble") {
+        bubbleIdx += 1;
+        bubblePositionByMapIndex.set(i, bubbleIdx);
+      }
+    });
   }
   return (
     <div className="hf-preview-chat">
@@ -608,12 +762,17 @@ function EducatorView({
             </Link>
           );
         }
+        const positionalIndex = bubblePositionByMapIndex.get(i) ?? 0;
+        const bubbleRef = derivePreviewBubbleRef(item, positionalIndex);
         return (
           <BubbleRow
             key={i}
             bubble={item}
             courseId={courseId}
             onOpenSidetray={onOpenSidetray}
+            bubbleRef={bubbleRef}
+            annotation={annotationsByRef.get(bubbleRef) ?? null}
+            onOpenAnnotation={onOpenAnnotation}
           />
         );
       })}
@@ -622,11 +781,14 @@ function EducatorView({
 }
 
 function BubbleRow({
-  bubble, courseId, onOpenSidetray,
+  bubble, courseId, onOpenSidetray, bubbleRef, annotation, onOpenAnnotation,
 }: {
   bubble: { kind: "bubble" } & PreviewBubble;
   courseId: string;
   onOpenSidetray: (lensId: string) => void;
+  bubbleRef: string;
+  annotation: DemoAnnotation | null;
+  onOpenAnnotation: (bubbleRef: string) => void;
 }): React.ReactElement {
   const wrapClasses = [
     "hf-preview-bubble-row",
@@ -640,41 +802,317 @@ function BubbleRow({
   ].filter(Boolean).join(" ");
 
   const inSidetray = SIDETRAY_LENS_MAP[bubble.lens];
-
-  const body = (
-    <>
-      <span className="hf-preview-bubble-text">{bubble.text}</span>
-      <span className="hf-preview-bubble-edit">
-        <Edit3 size={11} />
-        <span>{bubble.lensLabel}</span>
-      </span>
-    </>
-  );
+  const annotateLabel = annotation
+    ? "Edit demo annotation"
+    : "Add demo annotation";
 
   return (
-    <div className={wrapClasses}>
+    <div className={wrapClasses} data-bubble-ref={bubbleRef}>
       {bubble.caption && (
         <div className="hf-preview-bubble-caption">{bubble.caption}</div>
       )}
-      {inSidetray ? (
-        <button
-          type="button"
-          className={bubbleClasses}
-          title={bubble.lensLabel}
-          onClick={() => onOpenSidetray(bubble.lens)}
-        >
-          {body}
-        </button>
-      ) : (
-        <Link
-          href={`/x/courses/${courseId}?tab=design&design_view=${bubble.lens}`}
-          className={bubbleClasses}
-          title={bubble.lensLabel}
-        >
-          {body}
-        </Link>
+      {/* #1493 — primary click opens the demo annotation editor.
+          The lens-edit affordance lives below the bubble as a separate row. */}
+      <button
+        type="button"
+        className={bubbleClasses}
+        title={annotateLabel}
+        aria-label={annotateLabel}
+        onClick={() => onOpenAnnotation(bubbleRef)}
+      >
+        <span className="hf-preview-bubble-text">{bubble.text}</span>
+        <span className="hf-preview-bubble-edit">
+          <StickyNote size={11} />
+          <span>{annotation ? "Edit demo note" : "Add demo note"}</span>
+        </span>
+      </button>
+      <div className="hf-preview-bubble-lens-actions">
+        {inSidetray ? (
+          <button
+            type="button"
+            className="hf-preview-bubble-lens-link"
+            onClick={() => onOpenSidetray(bubble.lens)}
+            title={bubble.lensLabel}
+          >
+            <Edit3 size={11} />
+            <span>{bubble.lensLabel}</span>
+          </button>
+        ) : (
+          <Link
+            href={`/x/courses/${courseId}?tab=design&design_view=${bubble.lens}`}
+            className="hf-preview-bubble-lens-link"
+            title={bubble.lensLabel}
+          >
+            <Edit3 size={11} />
+            <span>{bubble.lensLabel}</span>
+          </Link>
+        )}
+      </div>
+      {annotation && (
+        <AnnotationStickyNote
+          annotation={annotation}
+          onClick={() => onOpenAnnotation(bubbleRef)}
+        />
       )}
     </div>
+  );
+}
+
+/**
+ * Rendered alongside a Preview bubble when an annotation exists. Click
+ * re-opens the annotation editor sidetray pre-filled with current values.
+ * `isWowMoment: true` flips the gold-border + star variant.
+ */
+function AnnotationStickyNote({
+  annotation, onClick,
+}: {
+  annotation: DemoAnnotation;
+  onClick: () => void;
+}): React.ReactElement {
+  const cls = [
+    "hf-preview-sticky-note",
+    annotation.isWowMoment ? "hf-preview-sticky-note--wow-moment" : "",
+  ].filter(Boolean).join(" ");
+  return (
+    <button
+      type="button"
+      className={cls}
+      onClick={onClick}
+      title={
+        annotation.isWowMoment
+          ? "Wow moment — edit demo annotation"
+          : "Edit demo annotation"
+      }
+      data-testid={
+        annotation.isWowMoment
+          ? "hf-preview-sticky-note--wow"
+          : "hf-preview-sticky-note"
+      }
+    >
+      {annotation.isWowMoment && (
+        <Star
+          size={12}
+          className="hf-preview-sticky-note-star"
+          fill="var(--login-gold)"
+        />
+      )}
+      <span className="hf-preview-sticky-note-text">
+        {annotation.presenterNote || (
+          <span className="hf-text-muted">(empty note)</span>
+        )}
+      </span>
+      {annotation.durationSecOnStep !== undefined && (
+        <span className="hf-preview-sticky-note-duration">
+          {annotation.durationSecOnStep}s
+        </span>
+      )}
+    </button>
+  );
+}
+
+/**
+ * Slide-in annotation editor opened from a Preview bubble click (#1493).
+ * Distinct from `PreviewEditSidetray` above — that one mounts a
+ * `SessionFlowEditor` to tune lens configuration; this one only mutates
+ * `Playbook.config.demoScript.annotations[]` and never touches compose
+ * inputs.
+ */
+function AnnotationEditSidetray({
+  courseId, bubbleRef, existing, onClose, onSaved, onDeleted,
+}: {
+  courseId: string;
+  bubbleRef: string;
+  existing: DemoAnnotation | null;
+  onClose: () => void;
+  onSaved: (next: DemoAnnotation) => void;
+  onDeleted: (bubbleRef: string) => void;
+}): React.ReactElement {
+  const [presenterNote, setPresenterNote] = useState(existing?.presenterNote ?? "");
+  const [isWowMoment, setIsWowMoment] = useState(existing?.isWowMoment ?? false);
+  const [duration, setDuration] = useState<string>(
+    existing?.durationSecOnStep !== undefined
+      ? String(existing.durationSecOnStep)
+      : "",
+  );
+  const [busy, setBusy] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const save = useCallback(async () => {
+    setBusy(true);
+    setSaveError(null);
+    try {
+      const parsedDuration = duration.trim() === ""
+        ? undefined
+        : Number.parseInt(duration, 10);
+      if (parsedDuration !== undefined && (!Number.isFinite(parsedDuration) || parsedDuration <= 0)) {
+        throw new Error("Duration must be a positive whole number of seconds.");
+      }
+      const res = await fetch(`/api/courses/${courseId}/demo-script`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bubbleRef,
+          presenterNote,
+          isWowMoment,
+          ...(parsedDuration !== undefined
+            ? { durationSecOnStep: parsedDuration }
+            : {}),
+        }),
+      });
+      const json = (await res.json()) as {
+        ok: boolean;
+        annotation?: DemoAnnotation;
+        error?: string;
+      };
+      if (!json.ok || !json.annotation) {
+        throw new Error(json.error || "Failed to save annotation");
+      }
+      onSaved(json.annotation);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, [bubbleRef, courseId, duration, isWowMoment, onSaved, presenterNote]);
+
+  const remove = useCallback(async () => {
+    setBusy(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(
+        `/api/courses/${courseId}/demo-script/${encodeURIComponent(bubbleRef)}`,
+        { method: "DELETE" },
+      );
+      const json = (await res.json()) as { ok: boolean; error?: string };
+      if (!json.ok) throw new Error(json.error || "Failed to delete annotation");
+      onDeleted(bubbleRef);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, [bubbleRef, courseId, onDeleted]);
+
+  return (
+    <>
+      <div
+        className="hf-preview-annotation-sidetray-backdrop"
+        onClick={onClose}
+      />
+      <aside
+        className="hf-preview-annotation-sidetray"
+        role="dialog"
+        aria-label="Demo annotation editor"
+        data-testid="hf-preview-annotation-sidetray"
+      >
+        <header className="hf-preview-annotation-sidetray-header">
+          <h2>
+            <StickyNote size={14} aria-hidden />
+            <span>{existing ? "Edit demo annotation" : "Add demo annotation"}</span>
+          </h2>
+          <button
+            type="button"
+            className="hf-preview-sidetray-close"
+            onClick={onClose}
+            title="Close (Esc)"
+          >
+            <X size={16} />
+          </button>
+        </header>
+        <div className="hf-preview-annotation-sidetray-body">
+          <p className="hf-text-muted hf-preview-annotation-help">
+            Demo annotations are operator-only metadata. They never reach the
+            learner, never appear in the composed prompt, and never affect
+            scoring.
+          </p>
+
+          <label className="hf-label" htmlFor="hf-preview-annotation-note">
+            Presenter note
+          </label>
+          <textarea
+            id="hf-preview-annotation-note"
+            className="hf-input"
+            rows={5}
+            value={presenterNote}
+            onChange={(e) => setPresenterNote(e.target.value)}
+            placeholder="What to say while this bubble is on screen…"
+            data-testid="hf-preview-annotation-note-input"
+          />
+
+          <label className="hf-preview-annotation-toggle">
+            <input
+              type="checkbox"
+              checked={isWowMoment}
+              onChange={(e) => setIsWowMoment(e.target.checked)}
+              data-testid="hf-preview-annotation-wow-toggle"
+            />
+            <Star size={14} aria-hidden />
+            <span>Mark as wow moment (highlights this step)</span>
+          </label>
+
+          <label className="hf-label" htmlFor="hf-preview-annotation-duration">
+            Dwell duration (seconds, optional)
+          </label>
+          <input
+            id="hf-preview-annotation-duration"
+            type="number"
+            inputMode="numeric"
+            min={1}
+            className="hf-input hf-preview-annotation-duration"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            placeholder="e.g. 30"
+            data-testid="hf-preview-annotation-duration-input"
+          />
+
+          {saveError && (
+            <div className="hf-banner hf-banner-error">
+              <AlertCircle size={14} />
+              <span>{saveError}</span>
+            </div>
+          )}
+        </div>
+        <footer className="hf-preview-annotation-sidetray-footer">
+          {existing && (
+            <button
+              type="button"
+              className="hf-btn hf-btn-destructive"
+              onClick={remove}
+              disabled={busy}
+              data-testid="hf-preview-annotation-delete"
+            >
+              <Trash2 size={14} />
+              <span>Delete</span>
+            </button>
+          )}
+          <button
+            type="button"
+            className="hf-btn"
+            onClick={onClose}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="hf-btn hf-btn-primary"
+            onClick={save}
+            disabled={busy}
+            data-testid="hf-preview-annotation-save"
+          >
+            {busy ? "Saving…" : "Save annotation"}
+          </button>
+        </footer>
+      </aside>
+    </>
   );
 }
 

--- a/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
@@ -402,3 +402,173 @@
   max-height: 400px;
   overflow: auto;
 }
+
+/* ── Demo annotations (#1493, Epic #1442 Layer 4) ──────────────────
+   Sticky-note overlay rendered next to a Preview bubble when an
+   annotation exists in `Playbook.config.demoScript.annotations[]`.
+   `isWowMoment: true` flips the gold-border + star variant. All
+   styling is design-token only — no hardcoded hex. */
+
+.hf-preview-bubble-lens-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.hf-preview-bubble-row--user .hf-preview-bubble-lens-actions {
+  justify-content: flex-start;
+}
+
+.hf-preview-bubble-lens-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-decoration: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.hf-preview-bubble-lens-link:hover {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.hf-preview-sticky-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--login-gold) 12%, var(--surface-primary));
+  border: 1px solid color-mix(in srgb, var(--login-gold) 40%, var(--border-default));
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  max-width: 80%;
+}
+
+.hf-preview-sticky-note:hover {
+  background: color-mix(in srgb, var(--login-gold) 18%, var(--surface-primary));
+}
+
+.hf-preview-sticky-note--wow-moment {
+  border: 2px solid var(--login-gold);
+  background: color-mix(in srgb, var(--login-gold) 18%, var(--surface-primary));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--login-gold) 25%, transparent);
+}
+
+.hf-preview-sticky-note-star {
+  flex-shrink: 0;
+  color: var(--login-gold);
+}
+
+.hf-preview-sticky-note-text {
+  flex: 1;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.hf-preview-sticky-note-duration {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-family: ui-monospace, monospace;
+  color: var(--text-muted);
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--surface-secondary);
+}
+
+/* ── Annotation editor sidetray ────────────────────────────────────
+   Namespaced separately from `.hf-preview-sidetray*` so the two
+   slide-in panes never overlap visual responsibilities. The
+   session-flow sidetray edits lens config; this one edits demo
+   metadata only. */
+
+.hf-preview-annotation-sidetray-backdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, #000 35%, transparent);
+  z-index: 210;
+}
+
+.hf-preview-annotation-sidetray {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 480px;
+  max-width: 100vw;
+  background: var(--surface-primary);
+  border-left: 1px solid var(--border-default);
+  box-shadow: -8px 0 20px color-mix(in srgb, #000 12%, transparent);
+  z-index: 211;
+  display: flex;
+  flex-direction: column;
+  animation: hf-preview-sidetray-slide 0.18s ease-out;
+}
+
+.hf-preview-annotation-sidetray-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.hf-preview-annotation-sidetray-header h2 {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.hf-preview-annotation-sidetray-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hf-preview-annotation-help {
+  font-size: 12px;
+  margin: 0 0 4px 0;
+}
+
+.hf-preview-annotation-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.hf-preview-annotation-duration {
+  max-width: 140px;
+}
+
+.hf-preview-annotation-sidetray-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border-default);
+}
+
+.hf-preview-annotation-sidetray-footer .hf-btn-destructive {
+  margin-right: auto;
+}

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -730,7 +730,59 @@ export interface PlaybookConfig {
   outcomes?: Record<string, string>;
   pickerLayout?: PickerLayout;
   validationWarnings?: ValidationWarning[];
+  /**
+   * NEVER-COMPOSE — operator-only demo script (#1493, Epic #1442 Layer 4).
+   *
+   * Presenter notes + "wow moment" markers attached to specific Preview
+   * lens bubbles. Set exclusively via the Preview annotation editor at
+   * `/x/courses/[courseId]?tab=design&design_view=preview` — there is no
+   * wizard path, AI tool, or runtime read.
+   *
+   * **This field MUST NOT be forwarded to prompt assembly.** Verified by a
+   * structural grep against `lib/prompt/composition/` in the route test
+   * (`tests/api/courses/demo-script.test.ts`). If a future composer wants
+   * to surface demo metadata to the learner, add a NEW field; do not
+   * teach composition to read `demoScript`.
+   *
+   * @see app/x/courses/[courseId]/_components/PreviewLens.tsx
+   * @see app/api/courses/[courseId]/demo-script/route.ts
+   */
+  demoScript?: DemoScript;
   [key: string]: any;
+}
+
+/**
+ * NEVER-COMPOSE — single sticky-note annotation on a Preview bubble (#1493).
+ *
+ * `bubbleRef` is the deterministic key derived from
+ * `lens + caption + side + positional-index` by
+ * `derivePreviewBubbleRef()` in `PreviewLens.tsx`. Strategy A from #1493 R1:
+ * cheaper than stamping an explicit id; fragile if session-flow config
+ * changes reorder bubbles — the Preview lens warns on load when a stored
+ * `bubbleRef` does not match any current bubble.
+ */
+export interface DemoAnnotation {
+  /** Deterministic key from `derivePreviewBubbleRef()`. */
+  bubbleRef: string;
+  /** Free-form note shown next to the bubble while presenting. */
+  presenterNote: string;
+  /** When true, the sticky note renders with a gold border + star icon. */
+  isWowMoment: boolean;
+  /** Optional pacing hint — seconds to dwell on this step. */
+  durationSecOnStep?: number;
+}
+
+/**
+ * NEVER-COMPOSE — operator-only demo script container (#1493).
+ *
+ * Stored on `PlaybookConfig.demoScript`. Persists across reloads via
+ * `POST /api/courses/[courseId]/demo-script` (upsert by bubbleRef) and
+ * `DELETE /api/courses/[courseId]/demo-script/[bubbleRef]` (remove).
+ *
+ * **Do not read this in any composer.**
+ */
+export interface DemoScript {
+  annotations: DemoAnnotation[];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/admin/tests/api/courses/demo-script.test.ts
+++ b/apps/admin/tests/api/courses/demo-script.test.ts
@@ -100,8 +100,8 @@ describe("POST /api/courses/[courseId]/demo-script — #1493", () => {
     // The transformer must have produced a NEVER-COMPOSE structure.
     expect(nextConfig).not.toBeNull();
     expect(
-      (nextConfig as { demoScript: { annotations: unknown[] } }).demoScript
-        .annotations,
+      (nextConfig as unknown as { demoScript: { annotations: unknown[] } })
+        .demoScript.annotations,
     ).toHaveLength(1);
     // composeInputsUpdatedAt bumped as the operator-touch signal.
     expect(bumpPlaybookComposeTimestampMock).toHaveBeenCalledWith("c1");

--- a/apps/admin/tests/api/courses/demo-script.test.ts
+++ b/apps/admin/tests/api/courses/demo-script.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for the Preview-lens annotation routes (#1493, Epic #1442 Layer 4).
+ *
+ *   - GET    /api/courses/[courseId]/demo-script
+ *   - POST   /api/courses/[courseId]/demo-script
+ *   - DELETE /api/courses/[courseId]/demo-script/[bubbleRef]
+ *
+ * Plus the composition-leak guard (R3 in #1493) — a structural assertion
+ * that no transform under `lib/prompt/composition/` reads `demoScript`.
+ * The whole point of the NEVER-COMPOSE tag is that no composer ever picks
+ * up an operator's presenter notes; if a future change forgets and adds
+ * one, this test fails before the regression ships.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const requireAuth = vi.fn();
+const isAuthError = vi.fn();
+const updatePlaybookConfigMock = vi.fn();
+const bumpPlaybookComposeTimestampMock = vi.fn();
+
+const prismaMock = {
+  playbook: { findUnique: vi.fn() },
+};
+
+vi.mock("@/lib/permissions", () => ({ requireAuth, isAuthError }));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/playbook/update-playbook-config", () => ({
+  updatePlaybookConfig: (...args: unknown[]) =>
+    updatePlaybookConfigMock(...args),
+}));
+vi.mock("@/lib/compose/bump-timestamp", () => ({
+  bumpPlaybookComposeTimestamp: (...args: unknown[]) =>
+    bumpPlaybookComposeTimestampMock(...args),
+}));
+
+const PARAMS = { params: Promise.resolve({ courseId: "c1" }) };
+const BUBBLE_PARAMS = {
+  params: Promise.resolve({
+    courseId: "c1",
+    bubbleRef: "intake__bot__goals-question__0",
+  }),
+};
+
+function makeRequest(
+  method: string,
+  body?: unknown,
+): import("next/server").NextRequest {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "Content-Type": "application/json" };
+  }
+  return new Request(
+    "http://localhost:3000/api/courses/c1/demo-script",
+    init,
+  ) as unknown as import("next/server").NextRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isAuthError.mockReturnValue(false);
+  requireAuth.mockResolvedValue({ session: { user: { id: "u1" } } });
+});
+
+describe("POST /api/courses/[courseId]/demo-script — #1493", () => {
+  it("appends a new annotation when no entry exists for the bubbleRef", async () => {
+    // updatePlaybookConfig invokes the transformer with the current config
+    // — simulate an empty `demoScript` and capture the new shape.
+    let nextConfig: Record<string, unknown> | null = null;
+    updatePlaybookConfigMock.mockImplementation(async (_id, transformer) => {
+      nextConfig = transformer({});
+      return { playbook: { id: "c1" }, composeAffectingChanged: false, timestampBumped: false, fanoutScope: "none" };
+    });
+
+    const { POST } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        bubbleRef: "intake__bot__goals-question__0",
+        presenterNote: "Pause here — let the audience guess what comes next.",
+        isWowMoment: true,
+        durationSecOnStep: 30,
+      }),
+      PARAMS,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.count).toBe(1);
+    expect(body.annotation).toMatchObject({
+      bubbleRef: "intake__bot__goals-question__0",
+      presenterNote: expect.stringContaining("Pause here"),
+      isWowMoment: true,
+      durationSecOnStep: 30,
+    });
+    // The transformer must have produced a NEVER-COMPOSE structure.
+    expect(nextConfig).not.toBeNull();
+    expect(
+      (nextConfig as { demoScript: { annotations: unknown[] } }).demoScript
+        .annotations,
+    ).toHaveLength(1);
+    // composeInputsUpdatedAt bumped as the operator-touch signal.
+    expect(bumpPlaybookComposeTimestampMock).toHaveBeenCalledWith("c1");
+  });
+
+  it("UPDATES rather than duplicates when bubbleRef already exists", async () => {
+    let nextConfig: { demoScript: { annotations: Array<{ bubbleRef: string; presenterNote: string; isWowMoment: boolean }> } } | null = null;
+    updatePlaybookConfigMock.mockImplementation(async (_id, transformer) => {
+      nextConfig = transformer({
+        demoScript: {
+          annotations: [
+            {
+              bubbleRef: "intake__bot__goals-question__0",
+              presenterNote: "Old note.",
+              isWowMoment: false,
+            },
+          ],
+        },
+      });
+      return { playbook: { id: "c1" }, composeAffectingChanged: false, timestampBumped: false, fanoutScope: "none" };
+    });
+
+    const { POST } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        bubbleRef: "intake__bot__goals-question__0",
+        presenterNote: "New note.",
+        isWowMoment: true,
+      }),
+      PARAMS,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(1); // still 1 — replaced not appended
+    expect(nextConfig).not.toBeNull();
+    expect(nextConfig!.demoScript.annotations).toHaveLength(1);
+    expect(nextConfig!.demoScript.annotations[0].presenterNote).toBe("New note.");
+    expect(nextConfig!.demoScript.annotations[0].isWowMoment).toBe(true);
+  });
+
+  it("returns 400 on invalid body shape", async () => {
+    const { POST } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await POST(
+      // missing presenterNote + isWowMoment
+      makeRequest("POST", { bubbleRef: "ref-1" }),
+      PARAMS,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/Invalid body/i);
+    // No write should have happened.
+    expect(updatePlaybookConfigMock).not.toHaveBeenCalled();
+    expect(bumpPlaybookComposeTimestampMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the course is missing", async () => {
+    updatePlaybookConfigMock.mockRejectedValueOnce(
+      new Error("updatePlaybookConfig: playbook c1 not found"),
+    );
+    const { POST } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        bubbleRef: "intake__bot__goals-question__0",
+        presenterNote: "note",
+        isWowMoment: false,
+      }),
+      PARAMS,
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/Course not found/i);
+    expect(bumpPlaybookComposeTimestampMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks non-OPERATOR sessions via requireAuth", async () => {
+    const forbidden = new Response("Forbidden", { status: 403 });
+    requireAuth.mockResolvedValueOnce({ error: forbidden });
+    isAuthError.mockReturnValueOnce(true);
+    const { POST } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        bubbleRef: "ref-1",
+        presenterNote: "n",
+        isWowMoment: false,
+      }),
+      PARAMS,
+    );
+    expect(res.status).toBe(403);
+    expect(updatePlaybookConfigMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/courses/[courseId]/demo-script — #1493", () => {
+  it("returns the persisted demoScript when present", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      config: {
+        demoScript: {
+          annotations: [
+            {
+              bubbleRef: "intake__bot__goals-question__0",
+              presenterNote: "note",
+              isWowMoment: true,
+            },
+          ],
+        },
+      },
+    });
+    const { GET } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await GET(makeRequest("GET"), PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.demoScript.annotations).toHaveLength(1);
+  });
+
+  it("returns an empty demoScript when none is set", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({ config: {} });
+    const { GET } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await GET(makeRequest("GET"), PARAMS);
+    const body = await res.json();
+    expect(body.demoScript).toEqual({ annotations: [] });
+  });
+
+  it("returns 404 when the playbook does not exist", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce(null);
+    const { GET } = await import(
+      "@/app/api/courses/[courseId]/demo-script/route"
+    );
+    const res = await GET(makeRequest("GET"), PARAMS);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/courses/[courseId]/demo-script/[bubbleRef] — #1493", () => {
+  it("removes the matching annotation and reports removed: true", async () => {
+    let nextConfig: { demoScript: { annotations: unknown[] } } | null = null;
+    updatePlaybookConfigMock.mockImplementation(async (_id, transformer) => {
+      nextConfig = transformer({
+        demoScript: {
+          annotations: [
+            {
+              bubbleRef: "intake__bot__goals-question__0",
+              presenterNote: "x",
+              isWowMoment: false,
+            },
+            {
+              bubbleRef: "welcome__bot__welcome-message__0",
+              presenterNote: "y",
+              isWowMoment: false,
+            },
+          ],
+        },
+      });
+      return { playbook: { id: "c1" }, composeAffectingChanged: false, timestampBumped: false, fanoutScope: "none" };
+    });
+
+    const { DELETE } = await import(
+      "@/app/api/courses/[courseId]/demo-script/[bubbleRef]/route"
+    );
+    const res = await DELETE(
+      makeRequest("DELETE"),
+      BUBBLE_PARAMS,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.removed).toBe(true);
+    expect(body.count).toBe(1);
+    expect(nextConfig!.demoScript.annotations).toHaveLength(1);
+    expect(bumpPlaybookComposeTimestampMock).toHaveBeenCalledWith("c1");
+  });
+
+  it("is idempotent — returns removed: false when bubbleRef is missing", async () => {
+    updatePlaybookConfigMock.mockImplementation(async (_id, transformer) => {
+      transformer({ demoScript: { annotations: [] } });
+      return { playbook: { id: "c1" }, composeAffectingChanged: false, timestampBumped: false, fanoutScope: "none" };
+    });
+    const { DELETE } = await import(
+      "@/app/api/courses/[courseId]/demo-script/[bubbleRef]/route"
+    );
+    const res = await DELETE(makeRequest("DELETE"), BUBBLE_PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.removed).toBe(false);
+    expect(body.count).toBe(0);
+    // Idempotent — bump still fires so the UI staleness signal remains
+    // consistent (operator-touch happened).
+    expect(bumpPlaybookComposeTimestampMock).toHaveBeenCalledWith("c1");
+  });
+});
+
+describe("Composition-leak guard (#1493 R3) — `demoScript` is NEVER-COMPOSE", () => {
+  /**
+   * Structural assertion: no source file under
+   * `apps/admin/lib/prompt/composition/` may read `demoScript`. The type
+   * `DemoScript` is allowed only because composition has no business
+   * importing the type either — the test reads raw text to catch both.
+   */
+  it("no file under lib/prompt/composition/ references demoScript / DemoScript / DemoAnnotation", () => {
+    const ROOT = join(
+      process.cwd(),
+      "lib",
+      "prompt",
+      "composition",
+    );
+    const offenders: Array<{ file: string; matches: string[] }> = [];
+    const banned = ["demoScript", "DemoScript", "DemoAnnotation"];
+
+    function walk(dir: string): void {
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const p = join(dir, entry);
+        let s;
+        try {
+          s = statSync(p);
+        } catch {
+          continue;
+        }
+        if (s.isDirectory()) {
+          walk(p);
+          continue;
+        }
+        if (!/\.(ts|tsx|js|mjs|cjs|json)$/.test(entry)) continue;
+        const text = readFileSync(p, "utf8");
+        const matches = banned.filter((b) => text.includes(b));
+        if (matches.length > 0) offenders.push({ file: p, matches });
+      }
+    }
+
+    walk(ROOT);
+
+    expect(
+      offenders,
+      `Composition surface must not read or import demo-script types. Offenders:\n${offenders
+        .map((o) => `  ${o.file} (matched: ${o.matches.join(", ")})`)
+        .join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/admin/tests/components/course-design/preview-bubble-ref.test.ts
+++ b/apps/admin/tests/components/course-design/preview-bubble-ref.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Pins the `derivePreviewBubbleRef` strategy from #1493 R1 (Strategy A).
+ *
+ * The ref is the deterministic key that ties a sticky-note annotation to a
+ * specific Preview bubble — its stability across re-renders is the whole
+ * reason annotations don't silently detach when the session-flow re-fetches.
+ *
+ * If a future change reorders bubbles within a lens, the ref WILL shift —
+ * that is the documented R1 trade-off, mitigated by the "detached" warning
+ * banner rendered by PreviewLens.tsx when stored refs don't match any
+ * current bubble.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { derivePreviewBubbleRef } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+
+describe("derivePreviewBubbleRef (#1493 R1 strategy A)", () => {
+  it("produces a stable ref from lens + side + caption + index", () => {
+    const ref = derivePreviewBubbleRef(
+      {
+        kind: "bubble",
+        side: "bot",
+        lens: "intake",
+        lensLabel: "Edit Goals",
+        caption: "Goals question",
+        text: "What would you most like to get out of this course?",
+      },
+      0,
+    );
+    expect(ref).toBe("intake__bot__goals-question__0");
+  });
+
+  it("uses the bubble text when no caption is set", () => {
+    const ref = derivePreviewBubbleRef(
+      {
+        kind: "bubble",
+        side: "user",
+        lens: "intake",
+        lensLabel: "Edit Goals",
+        text: "(learner's response will go here)",
+      },
+      1,
+    );
+    // The default text contains parens + apostrophes — they collapse to
+    // hyphens so the key stays URL-safe and DB-friendly.
+    expect(ref).toContain("intake__user__");
+    expect(ref).toMatch(/__1$/);
+    expect(ref).not.toMatch(/[()'!]/);
+  });
+
+  it("collapses whitespace + casing so caption tweaks don't detach the annotation", () => {
+    const a = derivePreviewBubbleRef(
+      {
+        kind: "bubble",
+        side: "bot",
+        lens: "welcome",
+        lensLabel: "Edit Welcome",
+        caption: "Welcome message",
+        text: "Hi!",
+      },
+      3,
+    );
+    const b = derivePreviewBubbleRef(
+      {
+        kind: "bubble",
+        side: "bot",
+        lens: "welcome",
+        lensLabel: "Edit Welcome",
+        caption: "  WELCOME    Message  ",
+        text: "Hi!",
+      },
+      3,
+    );
+    expect(a).toBe(b);
+  });
+
+  it("includes the positional index so two bubbles with the same caption stay distinct", () => {
+    const item = {
+      kind: "bubble" as const,
+      side: "bot" as const,
+      lens: "onboarding",
+      lensLabel: "Edit Onboarding",
+      caption: "Phase 1 of 3 — Warm-up",
+      text: "Let's start.",
+    };
+    expect(derivePreviewBubbleRef(item, 0)).not.toBe(
+      derivePreviewBubbleRef(item, 1),
+    );
+  });
+
+  it("clamps captions to 60 chars so DB keys stay readable", () => {
+    const ref = derivePreviewBubbleRef(
+      {
+        kind: "bubble",
+        side: "bot",
+        lens: "intake",
+        lensLabel: "Edit",
+        caption: "a".repeat(200),
+        text: "x",
+      },
+      0,
+    );
+    // Format: `${lens}__${side}__${slug}__${idx}` — slug capped to 60.
+    const parts = ref.split("__");
+    expect(parts).toHaveLength(4);
+    expect(parts[2].length).toBeLessThanOrEqual(60);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9959,6 +9959,65 @@ List all classrooms (cohort groups) assigned to a course (playbook).
 
 ---
 
+### `GET` /api/courses/[courseId]/demo-script
+
+Returns the operator-only demo script for a course. This
+
+**Auth**: session (OPERATOR+) · **Scope**: `course:read`
+
+**Response** `200`
+```json
+{ ok: true, demoScript: DemoScript }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+---
+
+### `POST` /api/courses/[courseId]/demo-script
+
+Upsert a single Preview-lens annotation by `bubbleRef`.
+
+**Auth**: session (OPERATOR+) · **Scope**: `course:write`
+
+**Response** `200`
+```json
+{ ok: true, annotation: DemoAnnotation, count: number }
+```
+
+**Response** `400`
+```json
+{ ok: false, error: "Invalid body", details?: unknown }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+---
+
+### `DELETE` /api/courses/[courseId]/demo-script/[bubbleRef]
+
+Remove a single annotation by `bubbleRef` (URL-encoded).
+
+**Auth**: session (OPERATOR+) · **Scope**: `course:write`
+
+**Response** `200`
+```json
+{ ok: true, removed: boolean, count: number }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+---
+
 ### `GET` /api/courses/[courseId]/import-modules
 
 Read the current modules catalogue for a course. Prefers
@@ -15949,8 +16008,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 509 |
-| Files with annotations | 499 |
+| Route files found | 511 |
+| Files with annotations | 501 |
 | Files missing annotations | 10 |
 | Coverage | 98.0% |
 

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-11T15:11:53.955Z",
+  "generatedAt": "2026-06-11T15:32:58.628Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1661,
-  "edgeCount": 3819,
+  "fileCount": 1664,
+  "edgeCount": 3825,
   "skippedEdges": 1,
   "edges": [
     {
@@ -7877,6 +7877,10 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
+      "to": "components/course-design/ModuleVisibilitySettings.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "to": "components/course-design/TolerancesSettings.tsx"
     },
     {
@@ -7941,6 +7945,10 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "components/course-design/ModuleVisibilitySettings.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "to": "components/session-flow/SessionFlowEditor.tsx"
     },
     {
@@ -7950,6 +7958,10 @@
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "to": "lib/domain/generate-identity.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "lib/prompt/composition/defaults/substitute-greeting-tokens.ts"
     },
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
@@ -13609,6 +13621,10 @@
     },
     {
       "from": "lib/prompt/composition/transforms/pedagogy.ts",
+      "to": "lib/prompt/composition/transforms/module-visibility-gate.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/pedagogy.ts",
       "to": "lib/prompt/composition/transforms/quickstart.ts"
     },
     {
@@ -13713,11 +13729,19 @@
     },
     {
       "from": "lib/prompt/composition/transforms/quickstart.ts",
+      "to": "lib/prompt/composition/defaults/substitute-greeting-tokens.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/quickstart.ts",
       "to": "lib/prompt/composition/TransformRegistry.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/quickstart.ts",
       "to": "lib/prompt/composition/transforms/audience.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/quickstart.ts",
+      "to": "lib/prompt/composition/transforms/module-visibility-gate.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/quickstart.ts",
@@ -18403,7 +18427,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "inDegree": 1,
-      "outDegree": 11
+      "outDegree": 12
     },
     {
       "path": "app/x/courses/[courseId]/_components/ImportModulesDialog.tsx",
@@ -18428,7 +18452,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "inDegree": 1,
-      "outDegree": 8
+      "outDegree": 10
     },
     {
       "path": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
@@ -19573,6 +19597,11 @@
     {
       "path": "components/course-design/FirstSessionSettings.tsx",
       "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/course-design/ModuleVisibilitySettings.tsx",
+      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -22171,6 +22200,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/prompt/composition/defaults/substitute-greeting-tokens.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
       "path": "lib/prompt/composition/index.ts",
       "inDegree": 10,
       "outDegree": 0
@@ -22271,6 +22305,11 @@
       "outDegree": 3
     },
     {
+      "path": "lib/prompt/composition/transforms/module-visibility-gate.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
       "path": "lib/prompt/composition/transforms/modules.ts",
       "inDegree": 4,
       "outDegree": 8
@@ -22288,7 +22327,7 @@
     {
       "path": "lib/prompt/composition/transforms/pedagogy.ts",
       "inDegree": 1,
-      "outDegree": 6
+      "outDegree": 7
     },
     {
       "path": "lib/prompt/composition/transforms/personality.ts",
@@ -22318,7 +22357,7 @@
     {
       "path": "lib/prompt/composition/transforms/quickstart.ts",
       "inDegree": 2,
-      "outDegree": 10
+      "outDegree": 12
     },
     {
       "path": "lib/prompt/composition/transforms/retrieval-practice.ts",

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-11T15:23:48.738Z",
+  "generatedAt": "2026-06-11T15:11:53.955Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1662,
-  "edgeCount": 3815,
+  "fileCount": 1661,
+  "edgeCount": 3819,
   "skippedEdges": 1,
   "edges": [
     {
@@ -2566,6 +2566,42 @@
     {
       "from": "app/api/courses/[courseId]/curriculum-scorecard/route.ts",
       "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts",
+      "to": "lib/compose/bump-timestamp.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/route.ts",
+      "to": "lib/compose/bump-timestamp.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/route.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/demo-script/route.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "app/api/courses/[courseId]/design/route.ts",
@@ -7841,10 +7877,6 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
-      "to": "components/course-design/ModuleVisibilitySettings.tsx"
-    },
-    {
-      "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "to": "components/course-design/TolerancesSettings.tsx"
     },
     {
@@ -7909,10 +7941,6 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
-      "to": "components/course-design/ModuleVisibilitySettings.tsx"
-    },
-    {
-      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "to": "components/session-flow/SessionFlowEditor.tsx"
     },
     {
@@ -7925,7 +7953,7 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
-      "to": "lib/prompt/composition/defaults/substitute-greeting-tokens.ts"
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
@@ -13581,10 +13609,6 @@
     },
     {
       "from": "lib/prompt/composition/transforms/pedagogy.ts",
-      "to": "lib/prompt/composition/transforms/module-visibility-gate.ts"
-    },
-    {
-      "from": "lib/prompt/composition/transforms/pedagogy.ts",
       "to": "lib/prompt/composition/transforms/quickstart.ts"
     },
     {
@@ -13689,19 +13713,11 @@
     },
     {
       "from": "lib/prompt/composition/transforms/quickstart.ts",
-      "to": "lib/prompt/composition/defaults/substitute-greeting-tokens.ts"
-    },
-    {
-      "from": "lib/prompt/composition/transforms/quickstart.ts",
       "to": "lib/prompt/composition/TransformRegistry.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/quickstart.ts",
       "to": "lib/prompt/composition/transforms/audience.ts"
-    },
-    {
-      "from": "lib/prompt/composition/transforms/quickstart.ts",
-      "to": "lib/prompt/composition/transforms/module-visibility-gate.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/quickstart.ts",
@@ -16160,6 +16176,16 @@
       "outDegree": 2
     },
     {
+      "path": "app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts",
+      "inDegree": 0,
+      "outDegree": 4
+    },
+    {
+      "path": "app/api/courses/[courseId]/demo-script/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
       "path": "app/api/courses/[courseId]/design/route.ts",
       "inDegree": 0,
       "outDegree": 4
@@ -18377,7 +18403,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "inDegree": 1,
-      "outDegree": 12
+      "outDegree": 11
     },
     {
       "path": "app/x/courses/[courseId]/_components/ImportModulesDialog.tsx",
@@ -18402,7 +18428,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "inDegree": 1,
-      "outDegree": 9
+      "outDegree": 8
     },
     {
       "path": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
@@ -19547,11 +19573,6 @@
     {
       "path": "components/course-design/FirstSessionSettings.tsx",
       "inDegree": 1,
-      "outDegree": 0
-    },
-    {
-      "path": "components/course-design/ModuleVisibilitySettings.tsx",
-      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -20811,7 +20832,7 @@
     },
     {
       "path": "lib/compose/bump-timestamp.ts",
-      "inDegree": 16,
+      "inDegree": 18,
       "outDegree": 1
     },
     {
@@ -21971,7 +21992,7 @@
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 439,
+      "inDegree": 441,
       "outDegree": 3
     },
     {
@@ -22081,7 +22102,7 @@
     },
     {
       "path": "lib/playbook/update-playbook-config.ts",
-      "inDegree": 17,
+      "inDegree": 19,
       "outDegree": 5
     },
     {
@@ -22091,7 +22112,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 614,
+      "inDegree": 615,
       "outDegree": 0
     },
     {
@@ -22147,11 +22168,6 @@
     {
       "path": "lib/prompt/composition/defaults/first-call-openings.ts",
       "inDegree": 1,
-      "outDegree": 0
-    },
-    {
-      "path": "lib/prompt/composition/defaults/substitute-greeting-tokens.ts",
-      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -22255,11 +22271,6 @@
       "outDegree": 3
     },
     {
-      "path": "lib/prompt/composition/transforms/module-visibility-gate.ts",
-      "inDegree": 2,
-      "outDegree": 0
-    },
-    {
       "path": "lib/prompt/composition/transforms/modules.ts",
       "inDegree": 4,
       "outDegree": 8
@@ -22277,7 +22288,7 @@
     {
       "path": "lib/prompt/composition/transforms/pedagogy.ts",
       "inDegree": 1,
-      "outDegree": 7
+      "outDegree": 6
     },
     {
       "path": "lib/prompt/composition/transforms/personality.ts",
@@ -22307,7 +22318,7 @@
     {
       "path": "lib/prompt/composition/transforms/quickstart.ts",
       "inDegree": 2,
-      "outDegree": 12
+      "outDegree": 10
     },
     {
       "path": "lib/prompt/composition/transforms/retrieval-practice.ts",
@@ -22626,7 +22637,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 103,
+      "inDegree": 106,
       "outDegree": 0
     },
     {
@@ -23583,17 +23594,17 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 614,
+      "inDegree": 615,
       "outDegree": 0
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 439,
+      "inDegree": 441,
       "outDegree": 3
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 103,
+      "inDegree": 106,
       "outDegree": 0
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-11T15:23:49.460Z",
+  "generatedAt": "2026-06-11T15:11:54.845Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-11T15:11:54.845Z",
+  "generatedAt": "2026-06-11T15:33:00.190Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-11T15:23:47.235Z",
+  "generatedAt": "2026-06-11T15:11:50.841Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-11T15:11:50.841Z",
+  "generatedAt": "2026-06-11T15:32:54.047Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-11T15:23:50.192Z",
+  "generatedAt": "2026-06-11T15:11:55.802Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [
@@ -78,6 +78,31 @@
         "OPERATOR"
       ],
       "description": "Returns the most recent COURSE_REFERENCE markdown document",
+      "category": "courses"
+    },
+    {
+      "route": "/api/courses/[courseId]/demo-script",
+      "file": "apps/admin/app/api/courses/[courseId]/demo-script/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Returns the operator-only demo script for a course. This",
+      "category": "courses"
+    },
+    {
+      "route": "/api/courses/[courseId]/demo-script/[bubbleRef]",
+      "file": "apps/admin/app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts",
+      "methods": [
+        "DELETE"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "description": "Remove a single annotation by `bubbleRef` (URL-encoded).",
       "category": "courses"
     },
     {

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-11T15:11:55.802Z",
+  "generatedAt": "2026-06-11T15:33:02.023Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-11T15:11:51.909Z",
+  "generatedAt": "2026-06-11T15:32:56.049Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,16 +1,16 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-11T15:23:47.892Z",
+  "generatedAt": "2026-06-11T15:11:51.909Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
-    "routeCount": 509,
+    "routeCount": 511,
     "byAuthLevel": {
       "VIEWER": 112,
       "ADMIN": 81,
       "SUPERADMIN": 9,
       "VIEWER+ADMIN": 5,
-      "OPERATOR": 139,
+      "OPERATOR": 141,
       "OPERATOR+VIEWER": 8,
       "VIEWER+OPERATOR": 56,
       "auth-gate(non-role)": 54,
@@ -3529,6 +3529,47 @@
         "usesScopeHelper": false,
         "handlesInternalSecret": false,
         "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/demo-script/[bubbleRef]",
+      "file": "apps/admin/app/api/courses/[courseId]/demo-script/[bubbleRef]/route.ts",
+      "methods": [
+        "DELETE"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/demo-script",
+      "file": "apps/admin/app/api/courses/[courseId]/demo-script/route.ts",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
         "possiblyUnscoped": false,
         "noAuthGate": false
       },


### PR DESCRIPTION
## Summary

- Educator-facing Preview annotation editor (sticky-notes + "wow moment" markers) opened by clicking any Call-1 bubble in the Course Design Console → Preview lens.
- Adds `DemoAnnotation` / `DemoScript` to `PlaybookConfig`, both tagged `NEVER-COMPOSE` so composition can never read them; a structural-grep vitest pins the boundary.
- Three new OPERATOR+ routes: `GET / POST /api/courses/[courseId]/demo-script` and `DELETE .../[bubbleRef]`. Bumps `composeInputsUpdatedAt` so the Preview's "operator made changes" indicator flips, but `demoScript` is NOT a compose-affecting key, so cached prompts are untouched.

## Slice scope (#1493 Epic #1442 Layer 4)

- `DemoAnnotation { bubbleRef, presenterNote, isWowMoment, durationSecOnStep? }` on `PlaybookConfig.demoScript: DemoScript`
- `derivePreviewBubbleRef(item, idx)` — Strategy A from #1493 R1 (`lens + side + slug(caption) + index`). Cheap, fragile-to-reorder, mitigated by a warn banner when stored refs no longer match the current transcript.
- `<AnnotationStickyNote>` renders next to bubbles; `isWowMoment: true` flips gold border (`var(--login-gold)`) + star.
- `<AnnotationEditSidetray>` namespaced `hf-preview-annotation-*` so it never collides with the existing `hf-preview-sidetray-*` lens editor.
- Click-on-bubble flow: empty editor when no annotation, pre-filled editor when one exists.
- New dedicated routes — not bolted onto `session-flow PUT` (TL question R2).
- No DB migration (JSON blob field only).

## Composition-leak verification (R3)

`tests/api/courses/demo-script.test.ts` walks every file under `apps/admin/lib/prompt/composition/` and asserts none of them reference `demoScript`, `DemoScript`, or `DemoAnnotation`. The test fails the build if a future composer change picks them up.

## Verified by

- vitest: \`tests/api/courses/demo-script.test.ts\` (11 tests — upsert vs replace, 400/404, RBAC, idempotent delete, composition-leak structural grep)
- vitest: \`tests/components/course-design/preview-bubble-ref.test.ts\` (5 tests pinning \`derivePreviewBubbleRef\` determinism + collision shape)
- vitest regression: \`tests/components/course-design/\` (27/27 pass — no break to existing PreviewLens identity + first-session-settings tests)
- vitest regression: \`tests/api/courses/\` (23/23 pass)
- tsc: \`npx tsc --noEmit\` — 0 errors on changed files (\`PreviewLens.tsx\`, \`json-fields.ts\`, both \`demo-script/route.ts\`)
- lint: \`npm run lint\` — 0 errors; sole warning is pre-existing \`PlaybookConfig\` catch-all index signature
- kb:fresh: regenerated after route additions; route-inventory + operator-surfaces + coupling-graph picked up the two new operator surfaces
- structural grep: \`grep -rn 'demoScript' apps/admin/lib/prompt/composition/\` → 0 hits

## Test plan

- [ ] Open \`/x/courses/<id>?tab=design&design_view=preview\` on hf-dev VM
- [ ] Click any bubble → annotation editor sidetray opens empty
- [ ] Type a presenter note, toggle "wow moment", save → sticky note renders inline with gold border + star, sidetray closes, no page reload
- [ ] Click the same bubble → editor reopens pre-filled
- [ ] Toggle off wow moment, save → sticky note loses gold variant
- [ ] Delete annotation → sticky note vanishes
- [ ] Reload page → annotations persist
- [ ] Click "Edit Goals" pill below a bubble → original lens-edit sidetray still opens (no regression to #1268)
- [ ] As STUDENT, hit \`POST /api/courses/<id>/demo-script\` → 403
- [ ] After save, hit \`/api/courses/<id>/session-flow\` GET → \`composeInputsUpdatedAt\` advanced; existing cached \`ComposedPrompt\` rows untouched

## Deploy

\`/vm-cp\` — no migration; JSON blob field only.

Closes #1493.