### PR TITLE
fix(tray): surface 'config saved' reassurance when both recompose buttons disabled

### DIFF
--- a/apps/admin/components/shared/PendingChangesTray.tsx
+++ b/apps/admin/components/shared/PendingChangesTray.tsx
@@ -330,6 +330,42 @@ export function PendingChangesTray(): React.ReactElement | null {
             </p>
           )}
 
+          {/* Dead-end-state reassurance (#1442 Layer 4 follow-on).
+             When both recompose buttons are disabled, the operator could
+             think nothing applied. In fact the underlying config write
+             already happened inline (e.g. apply_demo_preset called
+             updatePlaybookConfig directly) — the tray's recompose buttons
+             only proactively rebuild prompts for *existing* learners. The
+             next call from any learner picks up the new config via the
+             stale-check. Surface that explicitly. */}
+          {hasAiSuggested && learnerButtonDisabled && cohortButtonDisabled && (
+            <div
+              className="hf-pending-tray-config-saved"
+              data-testid="hf-pending-tray-config-saved"
+            >
+              <p>
+                ✓ Course config is already saved. The next call from any
+                learner will use the new settings.
+              </p>
+              {!callerInContext && (
+                <p className="hf-pending-tray-config-saved-cta">
+                  To rebuild a specific learner&apos;s prompt now, open them
+                  in <code>/x/sim/&lt;callerId&gt;</code> or
+                  <code>/x/callers/&lt;callerId&gt;</code> and click
+                  &ldquo;Recompose this learner&rdquo;.
+                </p>
+              )}
+              <button
+                type="button"
+                className="hf-pending-tray-config-saved-dismiss"
+                onClick={() => clear()}
+                disabled={applying}
+              >
+                Got it — dismiss
+              </button>
+            </div>
+          )}
+
           {applyError && (
             <p className="hf-pending-tray-ai-warning" role="alert">
               ⚠ {applyError}

--- a/apps/admin/components/shared/pending-changes-tray.css
+++ b/apps/admin/components/shared/pending-changes-tray.css
@@ -182,6 +182,51 @@
   border-radius: 4px;
 }
 
+/* Config-saved reassurance — shown when both recompose buttons are
+   disabled and the operator would otherwise see a dead-end (#1442 L4 polish). */
+.hf-pending-tray-config-saved {
+  margin: 8px 14px;
+  padding: 10px 12px;
+  background: color-mix(in srgb, var(--accent-primary) 6%, var(--surface-primary));
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 25%, var(--border-default));
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.hf-pending-tray-config-saved p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+.hf-pending-tray-config-saved-cta {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.5;
+}
+.hf-pending-tray-config-saved-cta code {
+  background: var(--surface-secondary);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+  font-size: 10.5px;
+}
+.hf-pending-tray-config-saved-dismiss {
+  align-self: flex-end;
+  padding: 4px 10px;
+  font-size: 11.5px;
+  font-weight: 500;
+  background: var(--accent-primary);
+  color: var(--accent-primary-text, var(--surface-primary));
+  border: 1px solid var(--accent-primary);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.hf-pending-tray-config-saved-dismiss:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .hf-pending-tray-actions {
   display: flex;
   justify-content: flex-end;

--- a/apps/admin/tests/components/shared/PendingChangesTray.test.tsx
+++ b/apps/admin/tests/components/shared/PendingChangesTray.test.tsx
@@ -235,6 +235,40 @@ describe("PendingChangesTray", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows config-saved reassurance when both recompose buttons are disabled (#1442 L4)", async () => {
+    const { findByTestId, findByRole, queryByTestId } = render(
+      <TestHarness
+        setupEntries={(push) => push(nonFanoutEntry({ aiSuggested: true }))}
+      />,
+    );
+    await waitForPreview();
+    // Reassurance block should render — caller is null AND aiSuggested.
+    const block = await findByTestId("hf-pending-tray-config-saved");
+    expect(block).toBeInTheDocument();
+    expect(block.textContent).toMatch(/Course config is already saved/i);
+    expect(block.textContent).toMatch(/next call/i);
+    // CTA pointing to /x/sim/<callerId> rendered when no caller in context.
+    expect(block.textContent).toMatch(/\/x\/sim\/<callerId>/);
+    // Dismiss button is rendered and enabled.
+    const dismiss = await findByRole("button", { name: /Got it/i });
+    expect(dismiss).toBeInTheDocument();
+    expect((dismiss as HTMLButtonElement).disabled).toBe(false);
+    // Reassurance should NOT render when there is a caller in context
+    // (the learner button isn't disabled) — sanity proof of the gate.
+    void queryByTestId; // suppress "unused" if upgraded later
+  });
+
+  it("does NOT show config-saved reassurance when caller-in-context (learner button enabled)", async () => {
+    const { queryByTestId } = render(
+      <TestHarness
+        setupCaller={{ id: "c-1", name: "Mary Smith" }}
+        setupEntries={(push) => push(nonFanoutEntry({ aiSuggested: true }))}
+      />,
+    );
+    await waitForPreview();
+    expect(queryByTestId("hf-pending-tray-config-saved")).toBeNull();
+  });
+
   it("'Recompose entire cohort' is enabled when all entries are non-AI and cohort > 0", async () => {
     const { findByRole } = render(
       <TestHarness


### PR DESCRIPTION
Demo-prep dead-end: AI fires apply_demo_preset from Course page → tray shows change but BOTH recompose buttons disabled. Config IS saved already (apply_demo_preset writes via updatePlaybookConfig inline), but operator sees no apply path.

Adds an explicit affordance for that state with reassurance copy + dismiss button. Pure UX layer — no API/schema change.

12/12 vitests. Deploy: /vm-cp