### PR TITLE
fix(chat): broaden DEMO tools with reads + fix 'Save & apply' mislabel

### DIFF
--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -74,6 +74,12 @@ const COURSE_MANAGE_TOOLS = ADMIN_TOOLS.filter((t) => COURSE_MANAGE_TOOL_NAMES.h
 // Same filtering pattern as COURSE_MANAGE so the meta-tests
 // (forbidden-fields, RBAC, pending-change) apply automatically.
 const DEMO_TOOL_NAMES = new Set([
+  // Read tools — so the AI can answer "what's the current welcomeMessage?"
+  // and "what's BEH-RESPONSE-LEN set to?" without telling the operator to
+  // leave DEMO mode. Both OPERATOR+ read-only; no AI-to-DB write risk.
+  "get_playbook_config",
+  "list_behavior_targets",
+  // Write/probe tools
   "test_voice",
   "dry_run_prompt",
   "apply_demo_preset",

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -44,8 +44,12 @@ const MAX_RESULT_LENGTH = 3000;
  * recompose via isPromptStale picks them up on next caller touchpoint).
  * The "proposed" wording is about RECOMPOSE, not WRITE.
  */
+// The actual tray buttons are "Recompose this learner" / "Recompose entire
+// cohort" (and "Got it — dismiss" when both are disabled, per #1502).
+// Earlier copy said "Save & apply" which has no matching button label —
+// confused operators in live demo (2026-06-11).
 const TRAY_PROPOSED_SUFFIX =
-  "Proposed — review in the pending changes tray (bottom-right) and click **Save & apply** to recompose.";
+  "Proposed — review in the pending changes tray (bottom-right). The config is already saved; click **Recompose this learner** to rebuild their prompt now, or dismiss the tray (the next call from any learner will pick up the change automatically).";
 
 // Minimum role required per tool (matches REST API auth levels)
 const TOOL_MIN_ROLE: Record<string, UserRole> = {

--- a/apps/admin/lib/chat/admin-tools.ts
+++ b/apps/admin/lib/chat/admin-tools.ts
@@ -932,7 +932,7 @@ export const ADMIN_TOOLS: AITool[] = [
   {
     name: "apply_demo_preset",
     description:
-      "Set the four 'good demo defaults' on a course in one batch: `firstCallMode='teach_immediately'`, `welcome.aboutYou.enabled=false`, `welcome.aiIntroCall.enabled=false`, `welcomeMessage` (optional), and behaviour target `BEH-RESPONSE-LEN=0.2` (short, punchy responses). Every write goes through the pending-changes tray with `aiSuggested: true` and `fanoutScope: 'none'` — the operator clicks Save & apply to confirm. You DO NOT bypass the tray. Use when the operator says 'apply the demo preset' or similar.",
+      "Set the four 'good demo defaults' on a course in one batch: `firstCallMode='teach_immediately'`, `welcome.aboutYou.enabled=false`, `welcome.aiIntroCall.enabled=false`, `welcomeMessage` (optional), and behaviour target `BEH-RESPONSE-LEN=0.2` (short, punchy responses). The config writes happen INLINE via updatePlaybookConfig with `fanoutScope: 'none'` — the config is saved by the time you respond. The pending-changes tray surfaces the change with `aiSuggested: true`; the operator can click 'Recompose this learner' to rebuild a specific learner's prompt now, or dismiss the tray (the next call from any learner will pick up the change automatically). You DO NOT bypass the tray. Use when the operator says 'apply the demo preset' or similar.",
     input_schema: {
       type: "object",
       properties: {

--- a/apps/admin/lib/chat/demo-system-prompt.ts
+++ b/apps/admin/lib/chat/demo-system-prompt.ts
@@ -68,7 +68,7 @@ You have exactly FIVE tools. Do not propose any other action. If the operator as
    - \`welcomeMessage\` (set if the operator provides one)
    - \`BEH-RESPONSE-LEN = 0.2\` (short, punchy responses)
 
-   All four writes go through the pending-changes tray with \`aiSuggested: true\`. The operator reviews and clicks **Save & apply** to confirm — that is the human gate. You DO NOT bypass the tray.
+   The config writes happen INLINE via \`updatePlaybookConfig\` with \`fanoutScope: 'none'\`, then the pending-changes tray surfaces the batch with \`aiSuggested: true\`. The operator can click **Recompose this learner** to rebuild a specific learner's prompt now, or dismiss the tray (next call from any learner will pick up the change automatically). You DO NOT bypass the tray.
 
 4. **\`precompose_for_fresh_learner\`** (OPERATOR+) — pre-warm a demo caller's prompt so the next live call starts instantly. Wraps the canonical enrollment compose helper; you DO NOT create Call rows or compose prompts yourself.
 
@@ -77,7 +77,7 @@ You have exactly FIVE tools. Do not propose any other action. If the operator as
 ## Rules of honesty (non-negotiable)
 
 1. NEVER claim you applied, changed, or pre-composed anything unless the matching tool call returned \`ok: true\` in the same turn. No "Applied", no "Done", no success language without a tool result.
-2. NEVER fan out to production learners. Your writes apply to the demo set only — \`apply_demo_preset\` writes course-level config that affects every enrollment, but the recompose fan-out is bounded to demo callers via \`fanoutScope: 'none'\` plus the tray's "Save & apply" human gate.
+2. NEVER fan out to production learners. Your writes apply to the demo set only — \`apply_demo_preset\` writes course-level config that affects every enrollment, but the recompose fan-out is bounded to demo callers via \`fanoutScope: 'none'\` plus the tray's "Recompose this learner" human gate.
 3. NEVER propose tools outside the five above. Say "I can't do that from DEMO mode — try the Course Design Console" or similar.
 4. If the operator asks for a tweak that DOESN'T map to a tool (e.g. "add a new module"), say so and point at the Course Design Console at \`/x/courses/<id>?tab=design\`.
 


### PR DESCRIPTION
Two fixes caught from live operator session:

1. **DEMO toolset too narrow** — AI couldn't read current welcomeMessage/BEH targets, told operator to leave DEMO mode. Adds get_playbook_config + list_behavior_targets (both OPERATOR+ read-only).

2. **'Save & apply' button doesn't exist** — AI kept telling operator to click it. Actual tray labels are 'Recompose this learner' / 'Recompose entire cohort' / 'Got it — dismiss' (#1502). Fixed in 4 places (tool description, handler suffix, demo-system-prompt §2 + §3).

202/202 chat vitests pass. Deploy: /vm-cp.