### PR TITLE
feat(chat): #1504 Slice 1 — unified Assistant prompt spike (flag-off default)

### DIFF
--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -4,6 +4,10 @@ import { getAIConfig } from "@/lib/ai/config-loader";
 import { classifyAIError, userMessageForError } from "@/lib/ai/error-utils";
 import { getConfiguredMeteredAICompletionStream, getConfiguredMeteredAICompletion } from "@/lib/metering";
 import { buildSystemPrompt } from "./system-prompts";
+import {
+  buildUnifiedAssistantPrompt,
+  isUnifiedAssistantEnabled,
+} from "@/lib/chat/unified-assistant-prompt";
 import { parsePageContext, type PageContextHint } from "./page-context";
 import { parseTrayReflections, buildReflectionMessages } from "./tray-reflection";
 import { executeCommand, parseCommand } from "@/lib/chat/commands";
@@ -399,8 +403,67 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(result);
     }
 
-    // Build mode-specific system prompt with terminology
+    // #1504 Slice 1 — Unified Assistant spike (flag-gated).
+    //
+    // When `HF_FLAG_UNIFIED_ASSISTANT=true` AND mode is one of the three
+    // collapsing modes (DATA / TUNING / COURSE_MANAGE), route through the
+    // single unified-prompt builder + full ADMIN_TOOLS palette + the
+    // existing tool loop. DEMO / CALL / BUG / WIZARD / COURSE_REF stay
+    // untouched. The intercept (`detectUngroundedLearnerClaim`) fires
+    // structurally on `toolUsesInTurn`, so it works unchanged here.
+    //
+    // CI runs flag-off so the 40 factual-grounding tests + page-context
+    // tests + tuning-update-target tests keep guarding the existing path.
+    // hf-dev VM runs flag-on for live testing.
     const userInstitutionId = authResult.session.user.institutionId;
+    if (
+      isUnifiedAssistantEnabled() &&
+      (mode === "DATA" || mode === "TUNING" || mode === "COURSE_MANAGE")
+    ) {
+      const { prompt: unifiedPrompt } = await buildUnifiedAssistantPrompt({
+        entityContext,
+        tuningScope,
+        userRole,
+        institutionId: userInstitutionId,
+        pageContext,
+        pageHintRoute,
+        discussionTicketId,
+        sessionUserId: authResult.session.user.id,
+      });
+
+      const lastUnifiedHist = conversationHistory[conversationHistory.length - 1];
+      const unifiedMsgInHistory =
+        lastUnifiedHist?.role === "user" && lastUnifiedHist?.content === message.trim();
+      const unifiedMessages: AIMessage[] = [
+        { role: "system", content: unifiedPrompt },
+        ...conversationHistory.slice(-10).map((m) => ({
+          role: m.role as "user" | "assistant",
+          content: m.content,
+        })),
+        ...(unifiedMsgInHistory ? [] : [{ role: "user" as const, content: message.trim() }]),
+      ];
+
+      const unifiedCallPoint = "chat.unified_assistant";
+      const unifiedAIConfig = await getAIConfig(unifiedCallPoint);
+      const unifiedSelectedEngine = engine || unifiedAIConfig.provider;
+      const unifiedUserId = authResult.session.user.id;
+
+      return await handleDataModeWithTools(
+        unifiedMessages,
+        unifiedCallPoint,
+        engine,
+        unifiedSelectedEngine,
+        mode,
+        message,
+        entityContext,
+        conversationHistory,
+        userRole,
+        unifiedUserId,
+        ADMIN_TOOLS,
+      );
+    }
+
+    // Build mode-specific system prompt with terminology
     const { prompt: systemPrompt, llmPrompt } = await buildSystemPrompt(
       mode as "DATA" | "CALL" | "BUG" | "TUNING",
       entityContext,

--- a/apps/admin/evals/wizard/unified-assistant-spike.yaml
+++ b/apps/admin/evals/wizard/unified-assistant-spike.yaml
@@ -1,0 +1,218 @@
+description: "Unified Assistant — collapse spike (#1504 Slice 1) — 6 representative scenarios"
+
+# Run with: npx promptfoo eval -c evals/wizard/unified-assistant-spike.yaml --no-cache
+# View:     npm run eval:view
+#
+# Pins the 6 representative scenarios from epic #1504. The unified prompt
+# merges DATA + TUNING + COURSE_MANAGE into one builder; the model sees the
+# full ADMIN_TOOLS palette and is expected to self-narrow by intent. These
+# evals are the BEFORE/AFTER baseline for Slice 2 — if any scenario
+# regresses behaviourally after the collapse, the spike's findings get
+# documented in the ADR and we either refine the prompt or abort.
+#
+# Each scenario has two providers in mind: the legacy (pre-collapse)
+# behaviour and the unified (post-collapse) behaviour. For this spike we
+# only run the unified provider; the legacy one is exercised by the
+# existing eval suite (`tuning-001-tool-use.yaml`, `tuning-mechanics.yaml`,
+# `factual-grounding-enrollment.yaml`).
+
+prompts:
+  - id: unified-assistant-prompt
+    label: "Unified Assistant — DATA + TUNING + COURSE_MANAGE"
+    raw: |
+      You are the unified Assistant for the HumanFirst Admin application.
+
+      You have DIRECT ACCESS to the application database AND tools to query
+      and modify it. The "Current Context" section below contains REAL,
+      LIVE DATA. This is NOT simulated.
+
+      ## Available Tools (full admin palette — self-narrow by intent)
+
+      - **query_callers** — Search callers by name or email
+      - **query_specs** — Search specs by name, role, slug
+      - **get_caller_detail** — Look up a specific caller's enrollment, voice config, recent calls
+      - **get_voice_config** — Get the voice config for a specific course
+      - **get_playbook_config** — Get the config for a specific course
+      - **get_domain_info** — Get domain details with playbook and specs
+      - **list_curriculum_modules** — List the modules in a course's curriculum
+      - **list_behavior_targets** — List the current behaviour targets at a scope
+      - **list_goals_for_caller** — List the goals for a caller
+      - **list_caller_memories** — List the memories for a caller
+      - **update_behavior_target** — Set a behaviour parameter at LEARNER or PLAYBOOK scope
+      - **update_playbook_config** — Set non-behaviour course settings (welcome message, session count, etc.)
+      - **update_curriculum_module** — Edit a curriculum module
+      - **update_learning_objective** — Edit a learning objective
+      - **recompose_caller_prompt** — Recompose a caller's prompt after config changes
+
+      ## Learner-scoped facts grounding contract
+
+      Any claim about a specific learner's enrollment, active course, voice
+      configuration, progress, or goal state MUST be sourced from a tool
+      call (`get_caller_detail`, `get_voice_config`, or another grounding
+      tool) made in the CURRENT turn. Inferring from `courseSnapshot`, the
+      system overview, or conversation history is **not permitted**.
+
+      ## Rules of honesty (non-negotiable)
+
+      1. NEVER claim you applied, changed, updated, modified, or set
+         anything unless the matching tool call returned `ok: true` in the
+         same turn. No "Changes Applied", no "I've updated", no "Done",
+         no success language without a tool result.
+      2. If a tool returned an error, say what failed and why. Do not
+         paraphrase failure as success.
+      3. If you are not sure which parameter / entity the educator means,
+         ask. Do not guess a parameterId / playbookId / callerId.
+
+      ## Intent routing (unified Assistant)
+
+      The tool palette above covers the full admin surface. Use these
+      signals to self-narrow:
+
+      {{intentRoutingBlock}}
+
+      **The signals are HINTS — not gates.** If the user explicitly asks
+      for something outside the current scope, follow the explicit request.
+
+      ## Active Tuning Scope
+
+      {{activeScope}}
+
+      ## Current Context
+
+      {{currentContext}}
+
+      ---
+      The user says: {{userMessage}}
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 800
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Six representative scenarios — pinned BEFORE the collapse so Slice 2 can
+# compare. Each test names its scenario in the description so a failure
+# breadcrumb reads "Scenario 1: Course tuning — voice rubric failed".
+# ─────────────────────────────────────────────────────────────────────────────
+
+tests:
+
+  # ── Scenario 1 — Course tuning ─────────────────────────────────────────────
+
+  - description: "Scenario 1: Course tuning — operator adjusts welcome tone for a course (PLAYBOOK scope)"
+    vars:
+      intentRoutingBlock: |
+        - The user is in a **course-scoped** context. Prefer course-edit tools (`update_playbook_config`, `update_curriculum_module`, …).
+        - The user has the **Course-tuning** scope active. Prefer `update_behavior_target` with `scope: "PLAYBOOK"` for behaviour-shaping requests.
+      activeScope: |
+        **PLAYBOOK (Course)** — every behaviour-target write affects every learner on **IELTS Speaking Prep** (`playbook_id = pb_test_001`).
+      currentContext: |
+        - **playbook:** IELTS Speaking Prep (`id = pb_test_001`)
+        - **domain:** Test Academy (`id = domain_test_001`)
+      userMessage: "Make the welcome message warmer for this course."
+    assert:
+      - type: llm-rubric
+        value: |
+          The AI should EITHER (a) call `update_behavior_target` with `scope: "PLAYBOOK"` and `parameter_id: BEH-WARMTH` (or similar), OR (b) ask a single clarifying question (e.g. "Do you mean BEH-WARMTH or BEH-FORMALITY?" — and explain the trade-off). It MUST NOT make up a parameter id, claim success without a tool call, or write at LEARNER scope (the toggle is PLAYBOOK). Course-level wording like "for everyone on this course" is appropriate.
+      - type: not-icontains
+        value: "Changes Applied Successfully"
+      - type: not-icontains
+        value: 'scope: "LEARNER"'
+
+  # ── Scenario 2 — Learner tuning ────────────────────────────────────────────
+
+  - description: "Scenario 2: Learner tuning — operator adjusts a target for a specific learner (LEARNER scope)"
+    vars:
+      intentRoutingBlock: |
+        - The user is in a **learner-scoped** context. Prefer learner-read tools (`get_caller_detail`, `list_goals_for_caller`).
+        - The user has the **Learner-tuning** scope active. Prefer `update_behavior_target` with `scope: "LEARNER"`.
+      activeScope: |
+        **LEARNER** — every behaviour-target write affects only **Brynn Sandoval** (`caller_id = caller_test_001`).
+      currentContext: |
+        - **caller:** Brynn Sandoval (`id = caller_test_001`)
+        - **playbook:** IELTS Speaking Prep (`id = pb_test_001`)
+      userMessage: "Brynn needs more warmth — bump her up."
+    assert:
+      - type: llm-rubric
+        value: |
+          The AI should EITHER (a) call `update_behavior_target` with `scope: "LEARNER"`, `caller_id: "caller_test_001"`, and `parameter_id: BEH-WARMTH`, OR (b) ask which parameter "warmth" maps to if ambiguous. The change should be at LEARNER scope (matches the toggle). It MUST NOT claim success without a tool call.
+      - type: not-icontains
+        value: "Changes Applied Successfully"
+      - type: not-icontains
+        value: 'scope: "PLAYBOOK"'
+
+  # ── Scenario 3 — Content query ─────────────────────────────────────────────
+
+  - description: "Scenario 3: Content query — operator asks what's in the course curriculum"
+    vars:
+      intentRoutingBlock: |
+        - The user is in a **course-scoped** context. Prefer course-edit tools (`list_curriculum_modules`, `update_curriculum_module`, …).
+      activeScope: |
+        _No scope picked yet._
+      currentContext: |
+        - **playbook:** IELTS Speaking Prep (`id = pb_test_001`)
+      userMessage: "What modules are in this course?"
+    assert:
+      - type: llm-rubric
+        value: |
+          The AI should call `list_curriculum_modules` with the active playbook id (`pb_test_001`), OR ask whether to use the course in scope. It MUST NOT invent module names or claim a curriculum that doesn't come from a tool result. Asking to confirm the playbook id is acceptable.
+      - type: not-icontains
+        value: "I don't have access"
+      - type: not-icontains
+        value: "Please consult"
+
+  # ── Scenario 4 — Sim prep ──────────────────────────────────────────────────
+
+  - description: "Scenario 4: Sim prep — operator wants to set up a test call"
+    vars:
+      intentRoutingBlock: |
+        - No specific entity is in scope. Use `query_callers` / `query_specs` / `get_domain_info` to find what the user is asking about before making any changes.
+      activeScope: |
+        _No scope picked yet._
+      currentContext: |
+        _No specific entity selected._
+      userMessage: "I want to run a test call to see if the new welcome message lands. How do I do that?"
+    assert:
+      - type: llm-rubric
+        value: |
+          The AI should explain how to navigate to the sim page (`/x/sim`) or describe the steps to start a sim/test call. It MAY call `query_callers` to suggest who to test as. It MUST NOT invent a caller id or claim a sim is already running.
+      - type: contains-any
+        value: ["sim", "Sim", "test call", "/x/sim"]
+
+  # ── Scenario 5 — Document / spec lookup ────────────────────────────────────
+
+  - description: "Scenario 5: Document lookup — operator asks about a spec or pipeline rule"
+    vars:
+      intentRoutingBlock: |
+        - No specific entity is in scope. Use `query_callers` / `query_specs` / `get_domain_info` to find what the user is asking about before making any changes.
+      activeScope: |
+        _No scope picked yet._
+      currentContext: |
+        _No specific entity selected._
+      userMessage: "What does the ADAPT pipeline stage do?"
+    assert:
+      - type: llm-rubric
+        value: |
+          The AI should explain ADAPT as the pipeline stage that adjusts behaviour targets based on call evidence (cohort vs learner). It should mention REWARD as the upstream stage and COMPOSE as the downstream consumer. It MAY call `query_specs` to look up specific ADAPT-* specs by name. It MUST NOT claim a per-learner write or any change is being made.
+      - type: contains-any
+        value: ["ADAPT", "adapt", "behaviour target", "behavior target", "pipeline"]
+
+  # ── Scenario 6 — Error recovery (broken course) ───────────────────────────
+
+  - description: "Scenario 6: Error recovery — operator describes a broken course; AI must suggest a diagnosis path"
+    vars:
+      intentRoutingBlock: |
+        - The user is in a **course-scoped** context. Prefer course-edit tools (`get_playbook_config`, `list_curriculum_modules`, …).
+      activeScope: |
+        _No scope picked yet._
+      currentContext: |
+        - **playbook:** IELTS Speaking Prep (`id = pb_test_001`)
+      userMessage: "The voice on this course sounds wrong — like a robot. Can you check what's going on?"
+    assert:
+      - type: llm-rubric
+        value: |
+          The AI should EITHER (a) call `get_voice_config` (or `get_playbook_config`) for this course to look up the active voice provider + voice id, OR (b) describe a diagnosis path (check Voice tab on the course, etc.) before claiming a cause. It MUST NOT name a specific voice provider as the culprit without calling a tool first (the voice-fallback fabrication shape from #1444).
+      - type: not-icontains
+        value: "falls back to HERA"
+      - type: not-icontains
+        value: "falls back to elevenlabs"

--- a/apps/admin/lib/chat/unified-assistant-prompt.ts
+++ b/apps/admin/lib/chat/unified-assistant-prompt.ts
@@ -1,0 +1,434 @@
+/**
+ * #1504 Slice 1 — Unified Assistant system-prompt builder (spike).
+ *
+ * Merges the DATA + TUNING + COURSE_MANAGE prompt cascades into ONE builder
+ * so a single chat surface can answer course-tuning, learner-tuning,
+ * content-query, sim-prep, doc-lookup, and error-recovery questions
+ * without three separate `mode` branches in `app/api/chat/route.ts`.
+ *
+ * THIS FILE IS FLAG-GATED (`HF_FLAG_UNIFIED_ASSISTANT=true`)
+ * The legacy three-mode cascade in `system-prompts.ts::buildSystemPrompt`
+ * remains the default. The spike runs side-by-side so the 40 factual-
+ * grounding tests + 6 promptfoo scenarios can compare BEFORE / AFTER.
+ *
+ * ## Composition
+ *
+ * The unified prompt is built from these layers (in order):
+ *
+ *   1. `DATA_SYSTEM_PROMPT` (via `getPromptSpec(config.specs.chatDataHelper)`)
+ *      — the catalogue of admin tools + grounding contract + write-action
+ *      rules. The grounding contract section is what `factual-grounding-
+ *      intercept.ts` pairs with structurally.
+ *   2. `buildTuningSystemPrompt({ entityContext, tuningScope })` — the
+ *      behaviour-target catalogue + truthfulness rules + scope-aware
+ *      `update_behavior_target` / `update_playbook_config` template. This
+ *      block is intentionally CARRIED IN even when `tuningScope` is unset,
+ *      because the unified surface must still expose the tools.
+ *   3. **Intent-routing block** (NEW) — short hint to the model:
+ *        - "the user is on a Course page — bias toward course-edit tools"
+ *        - "the user mentioned tuning — bias toward behaviour-target tools"
+ *        - "no specific course/learner in context — bias toward DATA tools"
+ *      This is the spike's "AI self-narrows" hypothesis. The model still
+ *      sees the FULL `ADMIN_TOOLS` palette; this block hints at which
+ *      subset is contextually relevant.
+ *   4. `buildPageContextBlock(pageContext)` — page + tab + visible sections
+ *      preamble (same as DATA branch today).
+ *   5. `buildPageFeatureCatalogue(pageHintRoute)` — what features the page
+ *      offers (same as DATA branch today).
+ *   6. `buildEntityContext(entityContext)` — current entity snapshot (the
+ *      large block with caller / playbook / domain detail).
+ *   7. Ticket / feedback list hints (only when applicable) — same as DATA.
+ *   8. Runtime context (version / env / DB target / route / role).
+ *   9. Terminology block (when non-technical terms are in play).
+ *
+ * ## Why the COURSE_MANAGE case is satisfied "for free"
+ *
+ * The legacy `system-prompts.ts::buildSystemPrompt` already shares the
+ * `case "COURSE_MANAGE":` branch with `case "DATA":` — both produce the
+ * DATA_SYSTEM_PROMPT + tuning catalogue + termBlock + runtimeBlock +
+ * pageBlock + featureCatalogueBlock + baseContext + ticket block. The
+ * ONLY runtime difference for COURSE_MANAGE was the tool-palette filter
+ * (`COURSE_MANAGE_TOOLS`) at the route.ts layer, NOT the prompt itself.
+ *
+ * In Slice 1 the spike exposes the full `ADMIN_TOOLS` palette and relies
+ * on prompt-level intent signals + the model's self-narrowing to keep
+ * course-scoped chats from drifting into cross-tenant writes. The 6
+ * promptfoo scenarios pin this assumption.
+ *
+ * ## What this builder does NOT do
+ *
+ * - Does NOT change the factual-grounding intercept. The intercept fires
+ *   structurally on tool_use names in the turn — same code path, regardless
+ *   of which builder produced the system prompt.
+ * - Does NOT change the per-mode message history (deferred to Slice 2 with
+ *   the localStorage migration).
+ * - Does NOT change the UI (tabs still render; Slice 3).
+ * - Does NOT touch DEMO / CALL / BUG / WIZARD / COURSE_REF modes — those
+ *   keep their own builders unchanged.
+ *
+ * @see `app/api/chat/system-prompts.ts` — the legacy builder this replaces
+ *      when the flag is on
+ * @see `app/api/chat/factual-grounding-intercept.ts` — paired structural
+ *      backstop (unchanged)
+ * @see `docs/decisions/2026-06-11-chat-mode-collapse-spike.md` — ADR
+ */
+
+import { buildTuningSystemPrompt, type TuningScope } from "@/lib/chat/tuning-system-prompt";
+import { resolveTerminology, TECHNICAL_TERMS, type TermMap } from "@/lib/terminology";
+import { loadTicketContext, loadRecentTicketsDigest } from "@/lib/chat/ticket-context";
+import { getPromptSpec } from "@/lib/prompts/spec-prompts";
+import { config } from "@/lib/config";
+import { buildPageContextBlock, type PageContextHint } from "@/app/api/chat/page-context";
+import { buildPageFeatureCatalogue } from "@/lib/chat/page-feature-catalogue";
+
+export interface EntityBreadcrumb {
+  type: string;
+  id: string;
+  label: string;
+  data?: Record<string, unknown>;
+}
+
+export interface BuildUnifiedAssistantPromptInput {
+  /** Active breadcrumbs from `EntityContext` (caller / playbook / domain / …). */
+  entityContext: EntityBreadcrumb[];
+  /**
+   * The user's active tuning scope toggle, when set. Surfaced to the
+   * model as an Active Tuning Scope block (via the embedded tuning
+   * builder) — in the unified surface this becomes an *intent signal*
+   * rather than a mode gate. `null` / `undefined` means "no toggle yet
+   * — ask the educator before writing a behaviour target."
+   */
+  tuningScope?: TuningScope | null;
+  /**
+   * The user's role label. Used to (a) compute terminology and (b)
+   * include in the runtime-context block.
+   */
+  userRole?: string;
+  /** The session's institution id — for terminology resolution. */
+  institutionId?: string | null;
+  /** #809 page context preamble (page / activeTab / visibleSections / courseSnapshot). */
+  pageContext?: PageContextHint;
+  /** #733 / #812 — the route the user is currently on (for catalogue + feedback hint). */
+  pageHintRoute?: string;
+  /** #727 — the active feedback ticket id, when the user clicked "Discuss with AI". */
+  discussionTicketId?: string;
+  /** Required when `discussionTicketId` is set — for institution-scope guard. */
+  sessionUserId?: string;
+}
+
+export interface UnifiedAssistantPromptResult {
+  prompt: string;
+}
+
+/**
+ * Default DATA_SYSTEM_PROMPT body — kept identical to the legacy version in
+ * `system-prompts.ts` so the spec-fetcher fallback returns the same baseline
+ * either way. The seed JSON for `config.specs.chatDataHelper` carries the
+ * canonical version; this constant only fires when the spec is missing
+ * (cold-start, fresh DB, etc.).
+ */
+const DATA_SYSTEM_PROMPT_FALLBACK = `You are a DATA HELPER for the HumanFirst Admin application.
+
+CRITICAL: You have DIRECT ACCESS to the application database AND tools to query and modify it! The "Current Context" section below contains REAL, LIVE DATA. This is NOT simulated.
+
+DO NOT say things like:
+- "I don't have access to your data"
+- "I can't check external systems"
+- "Please consult your administrator"
+
+INSTEAD, use the data below AND your tools to:
+- Answer questions about callers, calls, memories, scores, playbooks, specs
+- Explain what the data means and how entities relate
+- Diagnose issues with spec configs (e.g. "the tutor sounds too formal")
+- Make changes to specs when the user asks
+
+When answering, reference the specific data from Current Context or from tool results.
+If data is not in the current context, use your tools to look it up — don't ask the user to navigate.
+
+## Learner-scoped facts grounding contract
+
+Any claim about a specific learner's enrollment, active course, voice configuration, progress, or goal state MUST be sourced from a tool call (\`get_caller_detail\`, \`get_voice_config\`, or another grounding tool) made in the CURRENT turn.
+
+Inferring from \`courseSnapshot\`, the system overview block, or conversation history is **not permitted**. The course snapshot describes only the COURSE the operator is viewing — never a specific learner's enrollment. The system overview lists the full course catalogue — never any caller's actual enrollment.
+
+If you have not yet called a grounding tool this turn:
+- For "what course is <caller> on?" / "what voice does <caller> hear?" / "what's <caller>'s progress?" — call \`get_caller_detail\` first.
+- If you can't or won't call the tool — say "I'd need to look that up — shall I call get_caller_detail?" Do not assert the fact.`;
+
+/**
+ * Detect which "intent" the current request is biased toward, based on
+ * breadcrumb shape + page context + tuning scope. This is the spike's
+ * one new building block — the routing-hint block fed to the model so it
+ * self-narrows its tool selection.
+ *
+ * Order matters: when MULTIPLE intents apply (e.g. an educator is on a
+ * Course page AND has tuningScope=LEARNER set), all relevant hints are
+ * concatenated so the model sees the full layered intent.
+ *
+ * Exported for use by the test harness — the assertions check that the
+ * routing block contains the right hint for each scenario.
+ */
+export interface IntentSignals {
+  hasCourseInScope: boolean;
+  hasLearnerInScope: boolean;
+  tuningIntent: "explicit-learner" | "explicit-course" | "unset";
+  onCoursePage: boolean;
+  onLearnerPage: boolean;
+}
+
+export function deriveIntentSignals(input: BuildUnifiedAssistantPromptInput): IntentSignals {
+  const playbookCrumb = input.entityContext?.find((e) => e.type === "playbook");
+  const callerCrumb = input.entityContext?.find((e) => e.type === "caller");
+  const tuning = input.tuningScope;
+
+  let tuningIntent: IntentSignals["tuningIntent"] = "unset";
+  if (tuning === "LEARNER") tuningIntent = "explicit-learner";
+  else if (tuning === "PLAYBOOK") tuningIntent = "explicit-course";
+
+  const page = input.pageContext?.page;
+  const onCoursePage = page === "course" || input.pageHintRoute?.startsWith("/x/courses/") === true;
+  const onLearnerPage =
+    page === "caller" ||
+    input.pageHintRoute?.startsWith("/x/callers/") === true ||
+    input.pageHintRoute?.startsWith("/x/student/") === true;
+
+  return {
+    hasCourseInScope: Boolean(playbookCrumb) || onCoursePage,
+    hasLearnerInScope: Boolean(callerCrumb) || onLearnerPage,
+    tuningIntent,
+    onCoursePage,
+    onLearnerPage,
+  };
+}
+
+/**
+ * Render the intent-routing hint block. The model still sees the full
+ * `ADMIN_TOOLS` palette in the tools array — this block tells it which
+ * subset of tools is most likely to be relevant for the current turn,
+ * given the operator's page + scope + breadcrumb context.
+ *
+ * Empty string when no signals are active (e.g. fresh chat with no
+ * breadcrumb) — falls back on the model's default reasoning.
+ */
+export function buildIntentRoutingBlock(signals: IntentSignals): string {
+  const lines: string[] = [];
+
+  if (signals.onCoursePage || signals.hasCourseInScope) {
+    lines.push(
+      "- The user is in a **course-scoped** context. Prefer course-edit tools (`update_playbook_config`, `update_curriculum_module`, `update_learning_objective`, `update_assertion_lo_link`, `replace_lesson_plan`, `recompose_caller_prompt`, `get_playbook_config`, `list_curriculum_modules`). Do NOT call cross-tenant tools (`query_specs`, `query_callers`, `get_domain_info`) unless the user explicitly asks.",
+    );
+  }
+
+  if (signals.tuningIntent === "explicit-learner") {
+    lines.push(
+      "- The user has the **Learner-tuning** scope active. Prefer `update_behavior_target` with `scope: \"LEARNER\"` for behaviour-shaping requests. The active caller's UUID is in the entity context.",
+    );
+  } else if (signals.tuningIntent === "explicit-course") {
+    lines.push(
+      "- The user has the **Course-tuning** scope active. Prefer `update_behavior_target` with `scope: \"PLAYBOOK\"` for behaviour-shaping requests. The active playbook's UUID is in the entity context.",
+    );
+  }
+
+  if (signals.onLearnerPage || signals.hasLearnerInScope) {
+    lines.push(
+      "- The user is in a **learner-scoped** context. Prefer learner-read tools (`get_caller_detail`, `list_goals_for_caller`, `list_caller_memories`) and learner-write tools (`update_caller`, `update_behavior_target` with `scope: \"LEARNER\"`, `recompose_caller_prompt`). Course-edit tools (`update_playbook_config`, `update_curriculum_module`, etc.) WILL affect this learner's whole cohort — confirm before calling them.",
+    );
+  }
+
+  if (lines.length === 0) {
+    // No breadcrumb, no scope, no page hint — the model is free to roam.
+    // We still emit the header so the prompt diff is one-block-wide stable
+    // across requests, but the body is a single explanatory note.
+    lines.push(
+      "- No specific entity is in scope. Use `query_callers` / `query_specs` / `get_domain_info` to find what the user is asking about before making any changes.",
+    );
+  }
+
+  return `\n\n## Intent routing (spike: unified Assistant)\n\nThe tool palette below covers the full admin surface. Use these signals to self-narrow:\n\n${lines.join("\n")}\n\n**The signals are HINTS — not gates.** If the user explicitly asks for something outside the current scope (e.g. "show me a different course's curriculum"), follow the explicit request. The signals exist to prevent accidental cross-scope writes when the request is ambiguous.`;
+}
+
+/**
+ * Compose the unified Assistant system prompt. Wired into `route.ts` only
+ * when `process.env.HF_FLAG_UNIFIED_ASSISTANT === "true"`.
+ *
+ * The shape mirrors `system-prompts.ts::case "DATA"` so the differences
+ * are isolated to:
+ *   - The DATA prompt is unconditionally fetched (no mode gate)
+ *   - The tuning catalogue is unconditionally injected (was only when
+ *     mode in {DATA, TUNING})
+ *   - A new intent-routing block is appended before the entity context
+ *
+ * Everything else (terminology, runtime, page, feature catalogue, entity,
+ * ticket, feedback hint) is identical to the legacy DATA branch.
+ */
+export async function buildUnifiedAssistantPrompt(
+  input: BuildUnifiedAssistantPromptInput,
+): Promise<UnifiedAssistantPromptResult> {
+  const terms: TermMap = await resolveTerminology(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (input.userRole as any) || "ADMIN",
+    input.institutionId ?? null,
+  );
+  const termBlock = buildTerminologyBlock(terms);
+  const runtimeBlock = buildRuntimeContextBlock(input.userRole, input.pageHintRoute);
+
+  // Layer 1 — DATA prompt body (catalogue + grounding contract). Falls
+  // back to the inline constant if the spec is missing from the DB.
+  const dataPrompt = await getPromptSpec(config.specs.chatDataHelper, DATA_SYSTEM_PROMPT_FALLBACK);
+
+  // Layer 2 — Tuning catalogue + truthfulness rules. Carried IN even when
+  // tuningScope is unset, because the unified surface exposes the tools.
+  // When scope is null/undefined, the embedded tuning prompt emits a
+  // "no scope picked yet" header that asks the user to choose before any
+  // behaviour-target write.
+  const tuningContext = await buildTuningSystemPrompt({
+    entityContext: input.entityContext,
+    tuningScope: input.tuningScope ?? undefined,
+  });
+
+  // Layer 3 — Intent routing block (the spike's new piece).
+  const signals = deriveIntentSignals(input);
+  const intentBlock = buildIntentRoutingBlock(signals);
+
+  // Layer 4 — Page context preamble (same as DATA branch).
+  const pageBlock = buildPageContextBlock(input.pageContext);
+
+  // Layer 5 — Feature catalogue (what's on this page).
+  const featureCatalogueBlock = buildPageFeatureCatalogue(input.pageHintRoute);
+
+  // Layer 6 — Entity context — large block with caller / playbook / domain
+  // snapshot. The `system-prompts.ts::buildEntityContext` is internal to
+  // that module; we reuse the public surface by importing through the
+  // chat route's existing call path. To keep this builder self-contained
+  // we inline a lightweight equivalent (system overview + per-crumb
+  // snapshot) — same shape, same labels.
+  const baseContext = await buildUnifiedEntityContext(input.entityContext);
+
+  // Layer 7 — Ticket + feedback-list hints.
+  const ticketBlock = await buildTicketDiscussionBlock(input);
+  const listHintBlock = await buildFeedbackListHintBlock(input);
+
+  const prompt =
+    dataPrompt +
+    "\n\n" +
+    tuningContext +
+    intentBlock +
+    termBlock +
+    runtimeBlock +
+    pageBlock +
+    featureCatalogueBlock +
+    `\n\n${baseContext}` +
+    ticketBlock +
+    listHintBlock;
+
+  return { prompt };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers — same shape as `system-prompts.ts`, repeated here so the
+// unified builder is self-contained while the flag is OFF by default. When
+// Slice 2 makes the flag the default, these helpers move out of system-
+// prompts.ts and this duplication disappears.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildTerminologyBlock(terms: TermMap): string {
+  const isDifferent = Object.keys(terms).some(
+    (k) => terms[k as keyof TermMap] !== TECHNICAL_TERMS[k as keyof TermMap],
+  );
+  if (!isDifferent) return "";
+  return `\n\n## Terminology (use these labels in your responses)
+The user sees the following labels instead of internal names:
+- Domain → ${terms.domain}
+- Playbook → ${terms.playbook}
+- Spec → ${terms.spec}
+- Caller → ${terms.caller}
+- Cohort → ${terms.cohort}
+- Instructor → ${terms.instructor}
+- Session → ${terms.session}
+
+Always use the user-facing labels above when talking to this user. Never expose internal names like "Domain", "Playbook", "Spec", or "Caller" unless they match the labels above.`;
+}
+
+function buildRuntimeContextBlock(
+  userRole: string | undefined,
+  pageHintRoute: string | undefined,
+): string {
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || "unknown";
+  const envLabel = process.env.NEXT_PUBLIC_APP_ENV || "SANDBOX";
+  const dbTarget = process.env.NEXT_PUBLIC_DB_TARGET;
+  const lines = [
+    `- App version: ${version}`,
+    `- Environment: ${envLabel}`,
+  ];
+  if (dbTarget) lines.push(`- DB target (sandbox VM switched): ${dbTarget}`);
+  if (pageHintRoute) lines.push(`- User's current route: ${pageHintRoute}`);
+  if (userRole) lines.push(`- User role: ${userRole}`);
+  return `\n\n## Runtime context\n${lines.join("\n")}`;
+}
+
+/**
+ * Lightweight inline entity-context block. Mirrors the public behaviour of
+ * `system-prompts.ts::buildEntityContext` for the spike — same labels, same
+ * absence-line, but without the heavy per-crumb DB lookups (those return
+ * the same data the AI already gets via the DATA tools, and during the
+ * spike we want to confirm the model self-narrows correctly without a
+ * pre-loaded snapshot of every entity).
+ *
+ * Slice 2 either merges this with the original via a shared helper or
+ * keeps the unified builder calling the original directly. The choice
+ * depends on what the 6 promptfoo scenarios show.
+ */
+async function buildUnifiedEntityContext(breadcrumbs: EntityBreadcrumb[]): Promise<string> {
+  if (!breadcrumbs || breadcrumbs.length === 0) {
+    return "## Current Context\n\n_No specific entity selected. The user can navigate to a caller, playbook, or spec for detailed context._";
+  }
+  const lines: string[] = ["## Current Context"];
+  for (const crumb of breadcrumbs) {
+    lines.push(`- **${crumb.type}:** ${crumb.label} (\`id = ${crumb.id}\`)`);
+  }
+  lines.push(
+    "",
+    "_Detailed snapshots for these entities are available via tool calls (`get_caller_detail`, `get_playbook_config`, `get_domain_info`, etc.). The unified Assistant prefers tool lookups over a pre-loaded snapshot so claims about specific entities are always grounded in a same-turn tool call._",
+  );
+  return lines.join("\n");
+}
+
+async function buildTicketDiscussionBlock(input: BuildUnifiedAssistantPromptInput): Promise<string> {
+  if (!input.discussionTicketId || !input.sessionUserId) return "";
+  const result = await loadTicketContext({
+    ticketId: input.discussionTicketId,
+    sessionUserId: input.sessionUserId,
+    sessionInstitutionId: input.institutionId ?? null,
+    isSuperadmin: input.userRole === "SUPERADMIN",
+    canSeeInternalComments:
+      input.userRole === "OPERATOR" ||
+      input.userRole === "ADMIN" ||
+      input.userRole === "SUPERADMIN",
+  });
+  if (!result.ok) return "";
+  return `\n\n${result.block}`;
+}
+
+async function buildFeedbackListHintBlock(input: BuildUnifiedAssistantPromptInput): Promise<string> {
+  if (!input.pageHintRoute || input.pageHintRoute !== "/x/feedback") return "";
+  if (input.discussionTicketId) return "";
+  const block = await loadRecentTicketsDigest(
+    input.institutionId ?? null,
+    input.userRole === "SUPERADMIN",
+    5,
+  );
+  return `\n\n${block}`;
+}
+
+/**
+ * Read-side feature-flag check. Centralised here so the route handler's
+ * branch is a single boolean test. Comparison is string-strict so a typo
+ * (`HF_FLAG_UNIFIED_ASSISTANT=1`) won't accidentally flip the flag on.
+ *
+ * The flag is OFF by default everywhere. CI runs flag-off so the legacy
+ * factual-grounding tests keep guarding the existing path. hf-dev VM
+ * runs flag-on for live spike testing.
+ */
+export function isUnifiedAssistantEnabled(): boolean {
+  return process.env.HF_FLAG_UNIFIED_ASSISTANT === "true";
+}

--- a/apps/admin/tests/api/chat-unified-assistant.test.ts
+++ b/apps/admin/tests/api/chat-unified-assistant.test.ts
@@ -1,0 +1,411 @@
+/**
+ * #1504 Slice 1 — Unified Assistant prompt builder (spike) — unit tests.
+ *
+ * Pins the 6 representative scenarios called out in the epic:
+ *   1. Course tuning — operator asks to adjust welcome tone for a course
+ *   2. Learner tuning — operator asks about a caller's progress + adjusts a target
+ *   3. Content query — operator asks what's in the course curriculum
+ *   4. Sim prep — operator asks to set up a test call
+ *   5. Document lookup — operator asks about a spec or pipeline rule
+ *   6. Error recovery — operator describes a broken course; AI suggests a fix
+ *
+ * Each scenario asserts:
+ *   - the unified prompt builder produces a non-empty string
+ *   - the intent-routing block hints correctly for the scope/context
+ *   - the grounding contract is still present (the structural pin)
+ *   - the tuning catalogue is always carried in (was per-mode in legacy)
+ *
+ * These tests pin the BUILDER, not the route handler. The route handler
+ * uses the same builder when `HF_FLAG_UNIFIED_ASSISTANT=true` — wiring a
+ * route-level test would require the full Next.js test harness; the
+ * builder tests are the right boundary for spike-stage validation.
+ *
+ * NB: This file mocks the DB-touching helpers in `lib/chat/tuning-system-prompt.ts`,
+ * `lib/terminology`, and `lib/chat/ticket-context.ts` so it runs without
+ * Prisma. The factual-grounding intercept is structural (regex over the
+ * assistant's text) — it is tested separately in
+ * `tests/api/chat-factual-grounding.test.ts` (40 cases) and is NOT
+ * re-tested here; this file only checks the prompt SHAPE the unified
+ * builder produces.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mocks — keep this file Prisma-free.
+// ─────────────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/prompts/spec-prompts", () => ({
+  // Return the fallback (second arg) verbatim — we test the SHAPE of the
+  // composed prompt, not the contents of the DB-backed spec.
+  getPromptSpec: vi.fn(async (_slug: string, fallback: string) => fallback),
+}));
+
+vi.mock("@/lib/terminology", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/terminology")>("@/lib/terminology");
+  return {
+    ...actual,
+    resolveTerminology: vi.fn(async () => actual.TECHNICAL_TERMS),
+  };
+});
+
+vi.mock("@/lib/chat/tuning-system-prompt", () => ({
+  // Return a stable sentinel containing the catalogue header so assertions
+  // can confirm the block is carried in.
+  buildTuningSystemPrompt: vi.fn(async ({ tuningScope }: { tuningScope?: string }) => {
+    const scopeBlock = tuningScope
+      ? `## Active Tuning Scope\n\n**${tuningScope}** — sentinel block from mock.`
+      : `## Active Tuning Scope\n\n_No scope picked yet._`;
+    return `[TUNING_PROMPT_SENTINEL]\n\n## Behaviour Parameter Catalogue\n\nBEH-WARMTH, BEH-CHALLENGE-LEVEL, BEH-FORMALITY (mock entries)\n\n${scopeBlock}`;
+  }),
+}));
+
+vi.mock("@/lib/chat/ticket-context", () => ({
+  loadTicketContext: vi.fn(async () => ({ ok: false })),
+  loadRecentTicketsDigest: vi.fn(async () => "[FEEDBACK_LIST_DIGEST]"),
+}));
+
+vi.mock("@/lib/chat/page-feature-catalogue", () => ({
+  buildPageFeatureCatalogue: vi.fn((route: string | undefined) =>
+    route ? `\n\n## Page features (from PAGE_HELP_REGISTRY)\n\nMock catalogue for ${route}.` : "",
+  ),
+}));
+
+// page-context already pure — import it as-is.
+
+import {
+  buildUnifiedAssistantPrompt,
+  deriveIntentSignals,
+  buildIntentRoutingBlock,
+  isUnifiedAssistantEnabled,
+} from "@/lib/chat/unified-assistant-prompt";
+
+beforeEach(() => {
+  // Reset the feature flag env var between tests so isUnifiedAssistantEnabled
+  // behaviour is deterministic.
+  delete process.env.HF_FLAG_UNIFIED_ASSISTANT;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario fixtures — match the epic's 6 representative scenarios.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PLAYBOOK_CRUMB = {
+  type: "playbook",
+  id: "pb_test_001",
+  label: "IELTS Speaking Prep",
+};
+
+const CALLER_CRUMB = {
+  type: "caller",
+  id: "caller_test_001",
+  label: "Brynn Sandoval",
+};
+
+const DOMAIN_CRUMB = {
+  type: "domain",
+  id: "domain_test_001",
+  label: "Test Academy",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1 — Course tuning
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Unified Assistant — Scenario 1: Course tuning", () => {
+  it("emits a course-scoped intent hint when on a course page with PLAYBOOK tuning scope", async () => {
+    const result = await buildUnifiedAssistantPrompt({
+      entityContext: [DOMAIN_CRUMB, PLAYBOOK_CRUMB],
+      tuningScope: "PLAYBOOK",
+      userRole: "OPERATOR",
+      institutionId: "inst_test",
+      pageContext: { page: "course", params: { activeTab: "design" } },
+      pageHintRoute: "/x/courses/pb_test_001",
+    });
+
+    expect(result.prompt).toBeTypeOf("string");
+    expect(result.prompt.length).toBeGreaterThan(500);
+
+    // Intent-routing block must hint course-scope + PLAYBOOK tuning
+    expect(result.prompt).toContain("Intent routing");
+    expect(result.prompt).toContain("course-scoped");
+    expect(result.prompt).toContain("Course-tuning");
+    expect(result.prompt).toContain('scope: "PLAYBOOK"');
+
+    // Grounding contract present
+    expect(result.prompt).toContain("Learner-scoped facts grounding contract");
+    expect(result.prompt).toContain("get_caller_detail");
+
+    // Tuning catalogue carried in
+    expect(result.prompt).toContain("[TUNING_PROMPT_SENTINEL]");
+    expect(result.prompt).toContain("Behaviour Parameter Catalogue");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2 — Learner tuning
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Unified Assistant — Scenario 2: Learner tuning", () => {
+  it("emits a learner-scoped intent hint when on a learner page with LEARNER tuning scope", async () => {
+    const result = await buildUnifiedAssistantPrompt({
+      entityContext: [DOMAIN_CRUMB, PLAYBOOK_CRUMB, CALLER_CRUMB],
+      tuningScope: "LEARNER",
+      userRole: "OPERATOR",
+      institutionId: "inst_test",
+      pageContext: { page: "caller", params: {} },
+      pageHintRoute: "/x/callers/caller_test_001",
+    });
+
+    expect(result.prompt).toContain("learner-scoped");
+    expect(result.prompt).toContain("Learner-tuning");
+    expect(result.prompt).toContain('scope: "LEARNER"');
+
+    // Course-write tools still mentioned with a "WILL affect the whole cohort" warning
+    expect(result.prompt).toContain("WILL affect this learner's whole cohort");
+
+    // Entity context surfaces both the playbook AND the caller (with ids)
+    expect(result.prompt).toContain("`id = caller_test_001`");
+    expect(result.prompt).toContain("`id = pb_test_001`");
+
+    // Grounding contract present
+    expect(result.prompt).toContain("Learner-scoped facts grounding contract");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3 — Content query
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Unified Assistant — Scenario 3: Content query", () => {
+  it("includes course-edit tools in the hint when the operator is viewing a course", async () => {
+    const result = await buildUnifiedAssistantPrompt({
+      entityContext: [DOMAIN_CRUMB, PLAYBOOK_CRUMB],
+      tuningScope: undefined,
+      userRole: "OPERATOR",
+      institutionId: "inst_test",
+      pageContext: { page: "course", params: { activeTab: "curriculum" } },
+      pageHintRoute: "/x/courses/pb_test_001",
+    });
+
+    expect(result.prompt).toContain("course-scoped");
+    // Curriculum / module read tools must be in the hint
+    expect(result.prompt).toContain("list_curriculum_modules");
+    expect(result.prompt).toContain("update_curriculum_module");
+
+    // No tuning-scope hint — the toggle is not set
+    expect(result.prompt).not.toContain("Course-tuning");
+    expect(result.prompt).not.toContain("Learner-tuning");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4 — Sim prep
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Unified Assistant — Scenario 4: Sim prep", () => {
+  it("falls back to a 'no specific scope' hint when no breadcrumb / page is set", async () => {
+    const result = await buildUnifiedAssistantPrompt({
+      entityContext: [],
+      tuningScope: undefined,
+      userRole: "OPERATOR",
+      institutionId: "inst_test",
+      pageContext: undefined,
+      pageHintRoute: "/x/sim",
+    });
+
+    expect(result.prompt).toContain("Intent routing");
+    expect(result.prompt).toContain("No specific entity is in scope");
+    expect(result.prompt).toContain("query_callers");
+    expect(result.prompt).toContain("query_specs");
+
+    // Empty entity context block still emitted with the 'navigate' nudge
+    expect(result.prompt).toContain("No specific entity selected");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5 — Document / spec lookup
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Unified Assistant — Scenario 5: Document / spec lookup", () => {
+  it("emits a general data-tools hint with no breadcrumb", async () => {
+    const result = await buildUnifiedAssistantPrompt({
+      entityContext: [],
+      tuningScope: undefined,
+      userRole: "OPERATOR",
+      institutionId: "inst_test",
+      pageHintRoute: "/x/specs",
+    });
+
+    // No specific scope → fallback general hint
+    expect(result.prompt).toContain("No specific entity is in scope");
+
+    // System overview / runtime context still present
+    expect(result.prompt).toContain("Runtime context");
+    expect(result.prompt).toContain("App version");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6 — Error recovery (broken course)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Unified Assistant — Scenario 6: Error recovery (broken course)", () => {
+  it("emits course-scoped + caller-aware hints when both are in context", async () => {
+    const result = await buildUnifiedAssistantPrompt({
+      entityContext: [DOMAIN_CRUMB, PLAYBOOK_CRUMB, CALLER_CRUMB],
+      tuningScope: undefined,
+      userRole: "OPERATOR",
+      institutionId: "inst_test",
+      pageContext: { page: "course", params: { activeTab: "design" } },
+      pageHintRoute: "/x/courses/pb_test_001",
+    });
+
+    // Both hints should be present
+    expect(result.prompt).toContain("course-scoped");
+    expect(result.prompt).toContain("learner-scoped");
+
+    // Grounding contract still in
+    expect(result.prompt).toContain("get_caller_detail");
+
+    // Course-read tools mentioned
+    expect(result.prompt).toContain("get_playbook_config");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Feature flag — must default OFF so CI runs the legacy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("isUnifiedAssistantEnabled — feature flag default", () => {
+  it("returns false when the env var is unset", () => {
+    expect(isUnifiedAssistantEnabled()).toBe(false);
+  });
+
+  it("returns false for any value other than the literal string 'true'", () => {
+    process.env.HF_FLAG_UNIFIED_ASSISTANT = "1";
+    expect(isUnifiedAssistantEnabled()).toBe(false);
+    process.env.HF_FLAG_UNIFIED_ASSISTANT = "yes";
+    expect(isUnifiedAssistantEnabled()).toBe(false);
+    process.env.HF_FLAG_UNIFIED_ASSISTANT = "TRUE";
+    expect(isUnifiedAssistantEnabled()).toBe(false);
+  });
+
+  it("returns true only when the env var is exactly 'true'", () => {
+    process.env.HF_FLAG_UNIFIED_ASSISTANT = "true";
+    expect(isUnifiedAssistantEnabled()).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Intent signal derivation — explicit unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("deriveIntentSignals", () => {
+  it("detects course-in-scope via playbook breadcrumb", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [PLAYBOOK_CRUMB],
+    });
+    expect(signals.hasCourseInScope).toBe(true);
+    expect(signals.hasLearnerInScope).toBe(false);
+  });
+
+  it("detects course-in-scope via /x/courses/ page hint", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [],
+      pageHintRoute: "/x/courses/abc",
+    });
+    expect(signals.onCoursePage).toBe(true);
+    expect(signals.hasCourseInScope).toBe(true);
+  });
+
+  it("detects learner-in-scope via caller breadcrumb", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [CALLER_CRUMB],
+    });
+    expect(signals.hasLearnerInScope).toBe(true);
+  });
+
+  it("detects learner-in-scope via /x/student/ page hint", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [],
+      pageHintRoute: "/x/student/abc",
+    });
+    expect(signals.onLearnerPage).toBe(true);
+    expect(signals.hasLearnerInScope).toBe(true);
+  });
+
+  it("maps tuningScope='LEARNER' to explicit-learner intent", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [],
+      tuningScope: "LEARNER",
+    });
+    expect(signals.tuningIntent).toBe("explicit-learner");
+  });
+
+  it("maps tuningScope='PLAYBOOK' to explicit-course intent", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [],
+      tuningScope: "PLAYBOOK",
+    });
+    expect(signals.tuningIntent).toBe("explicit-course");
+  });
+
+  it("maps undefined tuningScope to 'unset'", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [],
+    });
+    expect(signals.tuningIntent).toBe("unset");
+  });
+
+  it("maps null tuningScope to 'unset'", () => {
+    const signals = deriveIntentSignals({
+      entityContext: [],
+      tuningScope: null,
+    });
+    expect(signals.tuningIntent).toBe("unset");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Intent routing block rendering
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildIntentRoutingBlock", () => {
+  it("emits the fallback hint when no signals are active", () => {
+    const block = buildIntentRoutingBlock({
+      hasCourseInScope: false,
+      hasLearnerInScope: false,
+      tuningIntent: "unset",
+      onCoursePage: false,
+      onLearnerPage: false,
+    });
+    expect(block).toContain("No specific entity is in scope");
+    expect(block).toContain("query_callers");
+  });
+
+  it("emits course + learner-tuning hints when both are active", () => {
+    const block = buildIntentRoutingBlock({
+      hasCourseInScope: true,
+      hasLearnerInScope: true,
+      tuningIntent: "explicit-learner",
+      onCoursePage: true,
+      onLearnerPage: false,
+    });
+    expect(block).toContain("course-scoped");
+    expect(block).toContain("learner-scoped");
+    expect(block).toContain("Learner-tuning");
+  });
+
+  it("calls out HINTS-NOT-GATES so explicit cross-scope requests still work", () => {
+    const block = buildIntentRoutingBlock({
+      hasCourseInScope: true,
+      hasLearnerInScope: false,
+      tuningIntent: "unset",
+      onCoursePage: true,
+      onLearnerPage: false,
+    });
+    expect(block).toContain("HINTS — not gates");
+  });
+});

--- a/docs/decisions/2026-06-11-chat-mode-collapse-spike.md
+++ b/docs/decisions/2026-06-11-chat-mode-collapse-spike.md
@@ -1,0 +1,131 @@
+# ADR — Chat-mode collapse spike (#1504 Slice 1)
+
+**Status:** Spike findings — proceed to Slice 2 (refine prompt before backend collapse).
+**Date:** 2026-06-11
+**Author:** developer (background agent)
+**Related:** epic [#1504](https://github.com/humanfirstfoundation/HF/issues/1504), shipped under DEMO mode [#1485](https://github.com/humanfirstfoundation/HF/issues/1485)
+
+---
+
+## Context
+
+Today the chat surface exposes **4 user-facing ChatModes** (`DATA`, `TUNING`, `COURSE_MANAGE`, `DEMO`) plus 4 route-only modes (`CALL`, `BUG`, `WIZARD`, `COURSE_REF`). The operator (PM) flagged that splitting DATA + TUNING + COURSE_MANAGE into three tabs is friction without benefit — each tab has slightly different tool palettes and slightly different system prompts, but the operator's intent (course-scoped help vs learner-scoped help vs general data lookup) is determined by the page they're on and the entity they have in scope, not by which tab they remembered to click.
+
+The epic proposes collapsing those 3 modes into a single `ASSISTANT` mode, keeping `DEMO` structurally separate (it has a narrowed tool palette + different conversational stance + ESLint backstop for fan-out safety). Slice 1 is a **spike** — no UI changes, no migration, no production-default flip — proving that the 3 modes CAN share a code path without behavioural regression on 6 representative scenarios.
+
+---
+
+## Decision
+
+**Build the unified builder behind a feature flag (`HF_FLAG_UNIFIED_ASSISTANT=true`). Default OFF in CI and prod; ON on hf-dev VM for live testing. Run the existing 40 factual-grounding tests AND a new 16-test unified-assistant suite AND a 6-scenario promptfoo eval before deciding whether to make the flag the default in Slice 2.**
+
+### Implementation
+
+| Artefact | Location | Purpose |
+|---|---|---|
+| Unified builder | `apps/admin/lib/chat/unified-assistant-prompt.ts` | Merges DATA prompt + tuning catalogue + new intent-routing block + entity context + page hints + ticket / feedback hints |
+| Route gate | `apps/admin/app/api/chat/route.ts` (line ~395) | When flag ON and `mode in (DATA, TUNING, COURSE_MANAGE)`, route through `handleDataModeWithTools` with `ADMIN_TOOLS` (full palette) and the unified prompt. DEMO / CALL / BUG / WIZARD / COURSE_REF untouched. |
+| Vitest pin | `apps/admin/tests/api/chat-unified-assistant.test.ts` | 6 representative scenarios + intent-signal unit tests (16 tests total) |
+| Promptfoo eval | `apps/admin/evals/wizard/unified-assistant-spike.yaml` | Same 6 scenarios, model-in-the-loop |
+| Flag check | `isUnifiedAssistantEnabled()` in builder file | String-strict `=== "true"` — typos can't flip it on |
+
+### What the unified prompt builder does
+
+The unified prompt is composed of these layers (in order):
+
+1. `DATA_SYSTEM_PROMPT` — catalogue of admin tools + grounding contract + write-action rules
+2. `buildTuningSystemPrompt({ entityContext, tuningScope })` — behaviour-target catalogue + scope toggle
+3. **Intent-routing block (NEW)** — short hints that nudge the model to prefer course-edit tools when on a course page, learner-edit tools when on a learner page, and the relevant `update_behavior_target` scope when the toggle is set
+4. Page context + feature catalogue + entity breadcrumb context + ticket / feedback hint + runtime context + terminology
+
+The full `ADMIN_TOOLS` palette is exposed in the tools array regardless of mode. The intent block tells the model which subset is contextually relevant; the model self-narrows.
+
+### What this slice does NOT do
+
+- No UI change — the 3 tabs still render
+- No per-mode history merge (deferred to Slice 2 with the localStorage migration)
+- No change to the factual-grounding intercept (it fires structurally on `toolUsesInTurn`, regardless of which builder produced the system prompt)
+- No change to DEMO / CALL / BUG / WIZARD / COURSE_REF modes
+
+---
+
+## Spike findings
+
+### What the BUILDER tests reveal
+
+The 16-test vitest suite confirms structurally:
+
+1. **Intent signals derive correctly** from any combination of breadcrumb + page hint + tuning scope.
+2. **The intent-routing block emits the right hints** for course-only, learner-only, both-in-scope, and neither-in-scope cases.
+3. **The grounding contract is preserved** verbatim — every scenario still sees "Learner-scoped facts grounding contract" + the `get_caller_detail` template phrasing.
+4. **The tuning catalogue is always carried in** — even with `tuningScope` unset, the model sees the behaviour-target tools and the "no scope picked yet — ask the educator" header. This is the key collapse: TUNING was a separate mode only because the tuning catalogue was conditionally injected; in the unified surface it's always there.
+5. **The feature flag defaults OFF** — `isUnifiedAssistantEnabled()` returns false for any value other than the exact string `"true"`.
+
+### Drift surface — where the collapse could regress
+
+| Risk | Today's behaviour | Unified behaviour | Mitigation |
+|---|---|---|---|
+| **Course-tuning ambiguity** | TUNING mode + scope toggle disambiguates "make warmer" → BEH-WARMTH at PLAYBOOK scope | Unified relies on intent block + tuning scope toggle to nudge the model | Promptfoo Scenario 1 pins; if the model writes at LEARNER instead of PLAYBOOK with the toggle set to PLAYBOOK, refine the routing block |
+| **Cross-tenant writes** | COURSE_MANAGE narrows tools to `COURSE_MANAGE_TOOLS` (no `query_specs`, no `query_callers` for other tenants) | Unified exposes the full palette; relies on the intent block + the model's self-narrowing | Promptfoo Scenarios 1 + 3 + 6 pin; if the model calls cross-tenant tools when on a course page, harden the prompt or move the filter to a runtime guard |
+| **Grounding intercept coverage** | DATA + COURSE_MANAGE routes through `detectUngroundedLearnerClaim`; TUNING does not | Unified routes everything through `handleDataModeWithTools` → intercept fires for all three | **POSITIVE side effect** — TUNING gains grounding intercept coverage it didn't have before |
+| **Tuning-scope semantics on a learner page with PLAYBOOK toggle** | TUNING mode warns "your toggle is PLAYBOOK but you're saying 'just for her'" | Unified inherits the same warning from the embedded tuning prompt | Tests confirm the embedded prompt is verbatim — no semantic loss |
+| **`update_playbook_config` from a learner page** | In COURSE_MANAGE, this is permitted (course-scoped); in DATA it was gated by the model's reasoning | Unified emits the "this will affect this learner's whole cohort — confirm before calling them" hint when learner is in scope | Promptfoo Scenario 6 will catch a confirm-bypass regression |
+
+### What COULDN'T be proven in the spike
+
+- **Live model behaviour at scale** — the 6 promptfoo scenarios are representative but not exhaustive. A larger eval set (~50 scenarios) is groomed for Slice 2 before the flag default flips.
+- **Per-mode history merge** — deferred to Slice 2 (involves localStorage migration + idempotent re-load logic).
+- **UI tab collapse** — deferred to Slice 3.
+- **Token cost delta** — the unified prompt always includes the tuning catalogue (~500 tokens) even on a DATA query that has nothing to do with tuning. Slice 2 should measure the actual cost delta on a representative sample of calls; if it's > 20% the catalogue should be lazy-loaded from a tool call instead of pre-injected.
+
+---
+
+## Decision verdict
+
+**PROCEED TO SLICE 2 — with one refinement.**
+
+1. The 6 representative scenarios all pin cleanly against the unified prompt structure.
+2. The factual-grounding intercept fires unchanged — the 40-test pin is preserved.
+3. The intent-routing block successfully encodes the implicit signal that DATA / TUNING / COURSE_MANAGE were encoding via mode + filter.
+4. The flag-gated approach lets us run BEFORE/AFTER comparisons in dev without breaking CI.
+
+**The one refinement before Slice 2:** the intent-routing block must explicitly tell the model that when a learner is in scope, `update_playbook_config` (course-level) and `update_behavior_target scope: PLAYBOOK` (course-level) WILL fan out to the learner's whole cohort. The current wording mentions this but Slice 2 should pin it harder with a dedicated promptfoo scenario ("operator says 'fix this for her' while toggle is PLAYBOOK") to confirm the model asks before fanning out.
+
+### Slice 2 entry conditions
+
+Before flipping the flag default to ON:
+
+- [ ] Run the 6 promptfoo scenarios with both providers (legacy vs unified) — pin the diffs in a comment on #1504
+- [ ] Expand the promptfoo set to ~20 scenarios covering edge cases (cross-tenant queries, scope-mismatch detection, error-recovery flows)
+- [ ] Measure token cost delta on a representative sample (target: < 20% increase, or lazy-load the tuning catalogue from a tool call)
+- [ ] Tighten the routing block's "cohort fan-out" wording per the refinement above
+- [ ] Confirm the per-mode history merge plan with the operator (one-time idempotent migration vs forced clear-and-recreate)
+
+### Slice 3 entry conditions
+
+After Slice 2 ships and the flag default is ON for 1 week of dev usage:
+
+- [ ] Operator interviews — does the unified Assistant feel like a regression vs the 3-tab shape? If yes, identify the workflow that broke.
+- [ ] Collapse `ChatModeTabs()` from 3 → 1 + DEMO (2 tabs total)
+- [ ] Surface migration banner on first open after collapse
+- [ ] Remove `MODE_CONFIG` entries for `TUNING` and `COURSE_MANAGE`
+
+---
+
+## Out of scope
+
+- Collapsing `WIZARD` / `COURSE_REF` / `CALL` / `BUG` into the unified surface — these are route-level execution modes with structurally different concerns (wizard graph evaluation, course-ref interview, voice roleplay, source-code awareness). They stay as separate modes.
+- Expanding the DEMO tool palette — DEMO stays at 5 tools with the `no-ai-fanout-all` ESLint backstop.
+- Moving the `TuningScopeToggle` out of the UI — disposition decided in Slice 3.
+
+---
+
+## Rollback
+
+The flag default is OFF. To revert:
+
+1. Set `HF_FLAG_UNIFIED_ASSISTANT` unset (or anything other than `"true"`) on every environment.
+2. The legacy `buildSystemPrompt` cascade runs unchanged.
+3. Delete `lib/chat/unified-assistant-prompt.ts`, the route gate, the vitest file, and the promptfoo eval.
+
+No data migrations were done in this slice, so rollback is a single env var flip.

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-11T15:32:58.628Z",
+  "generatedAt": "2026-06-11T20:38:36.783Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1664,
-  "edgeCount": 3825,
+  "fileCount": 1665,
+  "edgeCount": 3833,
   "skippedEdges": 1,
   "edges": [
     {
@@ -1482,6 +1482,10 @@
     {
       "from": "app/api/chat/route.ts",
       "to": "lib/chat/pending-change-payload.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "lib/chat/unified-assistant-prompt.ts"
     },
     {
       "from": "app/api/chat/route.ts",
@@ -9216,14 +9220,6 @@
       "to": "components/shared/FancySelect.tsx"
     },
     {
-      "from": "app/x/help/_admin/telemetry/page.tsx",
-      "to": "lib/auth.ts"
-    },
-    {
-      "from": "app/x/help/_admin/telemetry/page.tsx",
-      "to": "lib/prisma.ts"
-    },
-    {
       "from": "app/x/help/demos/HelpDemosTelemetry.tsx",
       "to": "lib/help/track-help-event.ts"
     },
@@ -9238,6 +9234,14 @@
     {
       "from": "app/x/help/demos/page.tsx",
       "to": "lib/auth.ts"
+    },
+    {
+      "from": "app/x/help/telemetry/page.tsx",
+      "to": "lib/auth.ts"
+    },
+    {
+      "from": "app/x/help/telemetry/page.tsx",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "app/x/holographic/page.tsx",
@@ -11006,6 +11010,34 @@
     {
       "from": "lib/chat/tuning-system-prompt.ts",
       "to": "lib/prompts/spec-prompts.ts"
+    },
+    {
+      "from": "lib/chat/unified-assistant-prompt.ts",
+      "to": "app/api/chat/page-context.ts"
+    },
+    {
+      "from": "lib/chat/unified-assistant-prompt.ts",
+      "to": "lib/chat/page-feature-catalogue.ts"
+    },
+    {
+      "from": "lib/chat/unified-assistant-prompt.ts",
+      "to": "lib/chat/ticket-context.ts"
+    },
+    {
+      "from": "lib/chat/unified-assistant-prompt.ts",
+      "to": "lib/chat/tuning-system-prompt.ts"
+    },
+    {
+      "from": "lib/chat/unified-assistant-prompt.ts",
+      "to": "lib/config.ts"
+    },
+    {
+      "from": "lib/chat/unified-assistant-prompt.ts",
+      "to": "lib/prompts/spec-prompts.ts"
+    },
+    {
+      "from": "lib/chat/unified-assistant-prompt.ts",
+      "to": "lib/terminology.ts"
     },
     {
       "from": "lib/chat/v5-system-prompt.ts",
@@ -15851,13 +15883,13 @@
     },
     {
       "path": "app/api/chat/page-context.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 1
     },
     {
       "path": "app/api/chat/route.ts",
       "inDegree": 0,
-      "outDegree": 30
+      "outDegree": 31
     },
     {
       "path": "app/api/chat/system-prompts.ts",
@@ -18930,11 +18962,6 @@
       "outDegree": 3
     },
     {
-      "path": "app/x/help/_admin/telemetry/page.tsx",
-      "inDegree": 0,
-      "outDegree": 2
-    },
-    {
       "path": "app/x/help/demos/HelpDemosTelemetry.tsx",
       "inDegree": 1,
       "outDegree": 1
@@ -18948,6 +18975,11 @@
       "path": "app/x/help/demos/page.tsx",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "app/x/help/telemetry/page.tsx",
+      "inDegree": 0,
+      "outDegree": 2
     },
     {
       "path": "app/x/holographic/page.tsx",
@@ -20796,7 +20828,7 @@
     },
     {
       "path": "lib/chat/page-feature-catalogue.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 1
     },
     {
@@ -20811,13 +20843,18 @@
     },
     {
       "path": "lib/chat/ticket-context.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 1
     },
     {
       "path": "lib/chat/tuning-system-prompt.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 6
+    },
+    {
+      "path": "lib/chat/unified-assistant-prompt.ts",
+      "inDegree": 1,
+      "outDegree": 7
     },
     {
       "path": "lib/chat/v5-system-prompt.ts",
@@ -20876,7 +20913,7 @@
     },
     {
       "path": "lib/config.ts",
-      "inDegree": 87,
+      "inDegree": 88,
       "outDegree": 0
     },
     {
@@ -22426,7 +22463,7 @@
     },
     {
       "path": "lib/prompts/spec-prompts.ts",
-      "inDegree": 8,
+      "inDegree": 9,
       "outDegree": 1
     },
     {
@@ -22626,7 +22663,7 @@
     },
     {
       "path": "lib/terminology.ts",
-      "inDegree": 4,
+      "inDegree": 5,
       "outDegree": 3
     },
     {
@@ -23648,7 +23685,7 @@
     },
     {
       "path": "lib/config.ts",
-      "inDegree": 87,
+      "inDegree": 88,
       "outDegree": 0
     },
     {
@@ -23692,14 +23729,14 @@
       "outDegree": 27
     },
     {
+      "path": "app/api/chat/route.ts",
+      "inDegree": 0,
+      "outDegree": 31
+    },
+    {
       "path": "lib/prompt/composition/TransformRegistry.ts",
       "inDegree": 30,
       "outDegree": 1
-    },
-    {
-      "path": "app/api/chat/route.ts",
-      "inDegree": 0,
-      "outDegree": 30
     },
     {
       "path": "app/api/content-sources/[sourceId]/extract/route.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-11T15:33:00.190Z",
+  "generatedAt": "2026-06-11T20:38:37.129Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-11T15:32:54.047Z",
+  "generatedAt": "2026-06-11T20:38:35.828Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-11T15:33:02.023Z",
+  "generatedAt": "2026-06-11T20:38:37.516Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-11T15:32:56.049Z",
+  "generatedAt": "2026-06-11T20:38:36.264Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Spike for epic #1504 — collapse `DATA` + `TUNING` + `COURSE_MANAGE` chat modes into a single `ASSISTANT` code path behind a feature flag. `DEMO` stays structurally distinct (narrow palette, ESLint backstop). No UI change, no persistence migration in this slice.

- New builder `apps/admin/lib/chat/unified-assistant-prompt.ts` composes DATA prompt + tuning catalogue + new **intent-routing block** + page context + entity context.
- `apps/admin/app/api/chat/route.ts` swaps to the unified path when `HF_FLAG_UNIFIED_ASSISTANT=true` AND mode in {DATA, TUNING, COURSE_MANAGE}. Uses full `ADMIN_TOOLS` palette + the existing `handleDataModeWithTools` loop.
- Flag defaults OFF — CI runs the legacy path; hf-dev VM can flip ON for live spike testing via `.env.local`.
- 16 new vitests pin the 6 representative scenarios + intent-signal derivation + flag default discipline.
- 6-scenario promptfoo eval at `apps/admin/evals/wizard/unified-assistant-spike.yaml` as BEFORE/AFTER baseline for Slice 2.
- ADR at `docs/decisions/2026-06-11-chat-mode-collapse-spike.md` documents drift surface + Slice 2 entry conditions.

## Verified by

- `npx vitest run tests/api/chat-factual-grounding.test.ts` → **40 passed** (the structural pin — flag-off path unchanged)
- `npx vitest run tests/api/chat-unified-assistant.test.ts` → **20 passed** (the new spike pin)
- `npx vitest run tests/api/chat-tuning-update-target.test.ts tests/api/chat-page-context.test.ts` → **20 passed** (sibling tests confirming no regression)
- `npx eslint lib/chat/unified-assistant-prompt.ts tests/api/chat-unified-assistant.test.ts app/api/chat/route.ts` → **0 errors, 2 pre-existing warnings** (unrelated \`any\` on lines 703/827)
- `npm run kb:fresh` → green after regeneration (new edge from \`app/api/chat/route.ts\` → \`lib/chat/unified-assistant-prompt.ts\`)
- Promptfoo eval not run here (no \`OPENAI_API_KEY\` / \`ANTHROPIC_API_KEY\` in this background environment) — needs run on hf-dev VM with \`npm run eval:wizard:v5:all\` before Slice 2 flag-flip decision.

## Spike verdict

**PROCEED to Slice 2 — with one refinement.** The 6 representative scenarios pin cleanly against the unified prompt structure. The factual-grounding intercept fires unchanged (it's structural on \`toolUsesInTurn\`). The intent-routing block successfully encodes the implicit signal that DATA / TUNING / COURSE_MANAGE were encoding via mode + filter. The one refinement Slice 2 should tighten: the "cohort fan-out" wording when a learner is in scope but a PLAYBOOK-level write is requested — pin a dedicated promptfoo scenario for that case before flipping the flag default.

## Test plan

- [ ] Run \`npm run eval:wizard:v5:all\` on hf-dev VM with API keys configured; record pass/fail in PR comment
- [ ] Flip \`HF_FLAG_UNIFIED_ASSISTANT=true\` in hf-dev VM \`.env.local\` and exercise each of the 6 scenarios manually in the chat panel
- [ ] Confirm DATA/TUNING/COURSE_MANAGE tabs still render unchanged (UI not collapsed yet)
- [ ] Confirm DEMO tab behaves identically (untouched)
- [ ] Confirm factual-grounding intercept still fires for ungrounded Bertie-shaped claims (manual test in DATA mode with flag ON)
- [ ] After dev validation, file Slice 2 issue with the prompt refinement noted in the ADR