### PR TITLE
feat(chat): #1504 Slice 3 — collapse 4 tabs to Assistant + Demo

### DIFF
--- a/apps/admin/app/api/chat/route.ts
+++ b/apps/admin/app/api/chat/route.ts
@@ -75,12 +75,37 @@ import {
 
 export const runtime = "nodejs";
 
-// #1504 Slice 2 — TUNING / COURSE_MANAGE remain in the union because
-// `ChatContext.tsx` still surfaces them as visual tab aliases. The API
-// folds DATA / TUNING / COURSE_MANAGE into the unified Assistant runner
-// (see the dispatch below). CALL / BUG / WIZARD / COURSE_REF are
-// runtime-only modes (not user-facing tabs) and keep their own branches.
-type ChatMode = "DATA" | "CALL" | "BUG" | "WIZARD" | "COURSE_REF" | "TUNING" | "COURSE_MANAGE" | "DEMO";
+// #1504 Slice 3 — public chat tabs are ASSISTANT + DEMO. The legacy
+// DATA / TUNING / COURSE_MANAGE labels remain in the union because:
+//   1. Older clients still in a long-lived tab will continue to POST
+//      `mode: "DATA"` (or TUNING / COURSE_MANAGE) until they refresh.
+//   2. Persisted `hf.chat.settings` entries written pre-Slice-3 carry
+//      the legacy mode label; the ChatContext normalises on load but a
+//      stale tab between the deploy and the page reload still ships
+//      legacy values.
+// All three legacy labels resolve to the unified Assistant runner (same
+// path ASSISTANT takes). CALL / BUG / WIZARD / COURSE_REF are runtime-
+// only modes (not user-facing tabs) and keep their own branches.
+type ChatMode =
+  | "ASSISTANT"
+  | "DATA"
+  | "CALL"
+  | "BUG"
+  | "WIZARD"
+  | "COURSE_REF"
+  | "TUNING"
+  | "COURSE_MANAGE"
+  | "DEMO";
+
+/**
+ * Pre-Slice-3 mode aliases that the route handler accepts but routes through
+ * the unified Assistant path (same as ASSISTANT). Centralised so the dispatch
+ * branch + the slash-command cast stay in sync.
+ */
+const ASSISTANT_MODE_ALIASES = new Set<ChatMode>(["ASSISTANT", "DATA", "TUNING", "COURSE_MANAGE"]);
+function isAssistantMode(mode: ChatMode): boolean {
+  return ASSISTANT_MODE_ALIASES.has(mode);
+}
 
 interface EntityBreadcrumb {
   type: string;
@@ -366,29 +391,35 @@ export async function POST(request: NextRequest) {
     // Check for slash command
     const parsed = parseCommand(message);
     if (parsed) {
+      // #1504 Slice 3 — narrow the wide route-level union onto the
+      // commands.ts public union. ASSISTANT / DATA / TUNING / COURSE_MANAGE
+      // all funnel into "ASSISTANT" (commands.ts treats them identically).
+      const commandsMode: "ASSISTANT" | "CALL" | "BUG" | "DEMO" = isAssistantMode(mode)
+        ? "ASSISTANT"
+        : (mode as "CALL" | "BUG" | "DEMO");
       const result = await executeCommand(
         message,
         entityContext,
-        mode as "DATA" | "CALL" | "BUG" | "TUNING",
+        commandsMode,
         tuningScope,
       );
       return NextResponse.json(result);
     }
 
-    // #1504 Slice 2 — DATA / TUNING / COURSE_MANAGE flip to the unified
-    // Assistant path by default (was flag-gated as a Slice 1 spike).
+    // #1504 Slice 3 — ASSISTANT + the three legacy aliases (DATA / TUNING /
+    // COURSE_MANAGE) all route through the unified Assistant path.
     //
-    // One builder, one tool palette (full `ADMIN_TOOLS`), one runner. The
-    // 4 visible tabs in ChatPanel.tsx still render — Assistant / Tuning /
-    // Course are visual aliases for this path; only Demo (below) and the
-    // route-level modes (CALL / BUG / WIZARD / COURSE_REF) stay distinct.
+    // One builder, one tool palette (full `ADMIN_TOOLS`), one runner.
+    // ChatPanel now renders two visible tabs (Assistant + Demo); the
+    // legacy mode strings are only received from clients that haven't
+    // refreshed past the deploy boundary.
     //
     // The factual-grounding intercept in `handleDataModeWithTools` fires
     // structurally on `toolUsesInTurn` regardless of which prompt builder
     // produced the system prompt, so the 40 grounding tests still guard
     // every assistant claim about a specific learner.
     const userInstitutionId = authResult.session.user.institutionId;
-    if (mode === "DATA" || mode === "TUNING" || mode === "COURSE_MANAGE") {
+    if (isAssistantMode(mode)) {
       const { prompt: unifiedPrompt } = await buildUnifiedAssistantPrompt({
         entityContext,
         tuningScope,

--- a/apps/admin/app/x/courses/[courseId]/chat/ChatLauncher.tsx
+++ b/apps/admin/app/x/courses/[courseId]/chat/ChatLauncher.tsx
@@ -10,11 +10,17 @@ import type { CourseSnapshot } from "./page";
  * #1225 — bridges the server-rendered course snapshot into the global
  * Cmd+K assistant.
  *
+ * #1504 Slice 3 — after the 4-tab → 2-tab collapse the standalone
+ * "Course" mode is gone. Course pages now drop the operator into the
+ * ASSISTANT tab; the route handler's unified-Assistant builder consumes
+ * `pageContext.courseSnapshot` (set below) + the playbook breadcrumb to
+ * narrow intent toward course-edit tools. No behavioural regression: the
+ * snapshot still flows through the same EntityContext channel.
+ *
  * On mount:
- *   1. Set ChatContext mode = "COURSE_MANAGE" — the server dispatcher
- *      narrows tools to COURSE_MANAGE_TOOLS and the system prompt
- *      switch-case routes through the DATA-mode template (page-context
- *      builder picks up the snapshot).
+ *   1. Set ChatContext mode = "ASSISTANT" — the route handler's unified
+ *      Assistant builder reads `pageContext` + breadcrumbs to bias toward
+ *      course-edit tools (`update_playbook_config`, etc.).
  *   2. Set EntityContext.pageContext = { page: "course", params: {
  *      courseSnapshot } } — every /api/chat POST from this page carries
  *      the snapshot.
@@ -24,8 +30,7 @@ import type { CourseSnapshot } from "./page";
  *      Cmd+K — they came here to chat.
  *
  * On unmount: leave mode/pageContext alone — the user is navigating away,
- * and Cmd+K elsewhere will reset to DATA via the existing route-change
- * effects in EntityContext.
+ * and the global ASSISTANT tab is the right default for everywhere else.
  */
 interface ChatLauncherProps {
   readonly courseId: string;
@@ -39,8 +44,8 @@ export function ChatLauncher({ courseId, courseName, snapshot }: ChatLauncherPro
   const assistant = useGlobalAssistant();
 
   useEffect(() => {
-    if (mode !== "COURSE_MANAGE") {
-      setMode("COURSE_MANAGE");
+    if (mode !== "ASSISTANT") {
+      setMode("ASSISTANT");
     }
     setPageContext("course", { courseSnapshot: snapshot });
     pushEntity({

--- a/apps/admin/components/chat/ChatPanel.tsx
+++ b/apps/admin/components/chat/ChatPanel.tsx
@@ -8,6 +8,7 @@ import { useChatContext, MODE_CONFIG, getMergedBannerKey, type ChatMode, type Tu
 import { useEntityContext, ENTITY_COLORS, EntityBreadcrumb } from "@/contexts/EntityContext";
 import { useEntityDetection } from "@/hooks/useEntityDetection";
 import { AIModelBadge } from "@/components/shared/AIModelBadge";
+import { CollapsedTabsBanner } from "./CollapsedTabsBanner";
 import "./chat-panel.css";
 
 // User-facing labels for entity types (internal names → educator language)
@@ -82,8 +83,14 @@ function ChatBreadcrumbStripe({
 function ChatModeTabs() {
   const { mode, setMode } = useChatContext();
   const modes = Object.keys(MODE_CONFIG) as ChatMode[];
+  // #1504 Slice 3 — explicit two-tab modifier so the CSS can give each tab
+  // a balanced share of the strip width (default flex layout left them
+  // bunched on the left of a 400px panel). If MODE_CONFIG ever grows back
+  // to 3+ tabs the modifier auto-disappears.
+  const tabsClass =
+    modes.length === 2 ? "chat-mode-tabs chat-mode-tabs--two-tab" : "chat-mode-tabs";
   return (
-    <div className="chat-mode-tabs" role="tablist">
+    <div className={tabsClass} role="tablist">
       {modes.map((m) => {
         const cfg = MODE_CONFIG[m];
         const isActive = m === mode;
@@ -334,7 +341,20 @@ function ChatMessages() {
               {msg.metadata?.command && (
                 <span className="chat-timestamp-command">{msg.metadata.command}</span>
               )}
-              {!isUser && <AIModelBadge callPoint={`chat.${mode.toLowerCase()}`} variant="text" size="sm" />}
+              {/* #1504 Slice 3 — ASSISTANT routes through the unified
+                  Assistant builder server-side, which registers under the
+                  `chat.unified_assistant` call-point. DEMO keeps its own
+                  call-point. The pre-Slice-3 mode→callpoint string
+                  (`chat.data` / `chat.tuning` / `chat.course_manage`) no
+                  longer matches any registered AI config because route.ts
+                  collapsed those branches in Slice 2. */}
+              {!isUser && (
+                <AIModelBadge
+                  callPoint={mode === "DEMO" ? "chat.demo" : "chat.unified_assistant"}
+                  variant="text"
+                  size="sm"
+                />
+              )}
             </div>
           </div>
         );
@@ -521,30 +541,39 @@ export function ChatPanel() {
 
         {/* AI Chat Interface */}
         <>
-          {/* #1504 Slice 2 — one-time history-merged banner */}
+          {/* #1504 Slice 2 — one-time history-merged banner (legacy bucket merge) */}
           <HistoryMergedBanner />
 
-          {/* Mode tabs (Assistant / Tuning) */}
+          {/* #1504 Slice 3 — one-time tabs-simplified banner. Independent of
+              the Slice 2 banner because the visible tab change is operator-
+              relevant for fresh installs too (the 4-tab world is gone). */}
+          <CollapsedTabsBanner />
+
+          {/* Mode tabs — post-Slice-3: Assistant + Demo only */}
           <ChatModeTabs />
 
-          {/* Tuning scope toggle — shown in both DATA (Assistant) and TUNING
-              modes so write operations always have unambiguous scope
-              regardless of which tab the user is in. DATA mode previously
-              relied on the chip stack alone, which the model couldn't
-              disambiguate when the stack accumulated multiple
-              callers/playbooks across navigation. */}
-          {(mode === "DATA" || mode === "TUNING") && <TuningScopeToggle />}
+          {/* #1504 Slice 3 — Scope toggle now lives inline inside the
+              Assistant tab at all times. Pre-Slice-3 it was gated on
+              `mode === DATA || mode === TUNING`; with the Tuning tab gone,
+              gating it on "DATA-or-TUNING" would hide it entirely and
+              strand the operator with no way to disambiguate LEARNER vs
+              PLAYBOOK scope before a behaviour-target write. Hidden on
+              the DEMO tab — DEMO has its own write-safety contract
+              (narrow palette, `fanoutScope:'none'`) and tuning scope is
+              not relevant there. */}
+          {mode === "ASSISTANT" && <TuningScopeToggle />}
 
-          {/* Active ticket stripe (only in DATA mode when a discussion is active) */}
-          {mode === "DATA" && <DiscussingTicketStripe />}
+          {/* Active ticket stripe (only in ASSISTANT mode when a discussion
+              is active — DEMO doesn't see the ticket block). */}
+          {mode === "ASSISTANT" && <DiscussingTicketStripe />}
 
-          {/* Context Breadcrumbs — in DATA/TUNING modes the Scope toggle
-              above already shows caller + playbook, so hide those types to
-              avoid duplicate display. Drill-down chips (Call, Memory,
-              Spec, etc.) still render here. */}
+          {/* Context Breadcrumbs — in ASSISTANT mode the Scope toggle above
+              already shows caller + playbook, so hide those types to avoid
+              duplicate display. Drill-down chips (Call, Memory, Spec, etc.)
+              still render here. */}
           <ChatBreadcrumbStripe
             breadcrumbs={breadcrumbs}
-            hideTypes={mode === "DATA" || mode === "TUNING" ? ["caller", "playbook"] : undefined}
+            hideTypes={mode === "ASSISTANT" ? ["caller", "playbook"] : undefined}
           />
 
           {/* Messages */}

--- a/apps/admin/components/chat/CollapsedTabsBanner.tsx
+++ b/apps/admin/components/chat/CollapsedTabsBanner.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * #1504 Slice 3 — one-time information banner shown after the
+ * 4-tab → 2-tab collapse. Independent from the Slice 2
+ * `HistoryMergedBanner`: that one only fires for users who had legacy
+ * TUNING / COURSE_MANAGE history to merge; this one fires for everyone
+ * because the visible tab change is operator-relevant even for fresh
+ * installs.
+ *
+ * Rendered only when localStorage has NOT yet recorded a dismiss; clicking
+ * "Got it" flips the per-user key from undefined → "shown" so the banner
+ * never reappears for that user.
+ *
+ * Uses `hf-banner hf-banner-info` design-system tokens — no inline colours
+ * (see `.claude/rules/ui-design-system.md`).
+ */
+
+import React from "react";
+import { useSession } from "next-auth/react";
+import { getTabsCollapsedBannerKey } from "@/contexts/ChatContext";
+
+export function CollapsedTabsBanner(): React.ReactElement | null {
+  const { data: session } = useSession();
+  const userId = session?.user?.id;
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const state = window.localStorage.getItem(getTabsCollapsedBannerKey(userId));
+      // Show on every key state EXCEPT "shown". Fresh installs land here
+      // with `null` and see the banner once; dismissed users land here
+      // with "shown" and never see it again.
+      setVisible(state !== "shown");
+    } catch {
+      // ignore — banner is non-essential
+    }
+  }, [userId]);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(getTabsCollapsedBannerKey(userId), "shown");
+      }
+    } catch {
+      // ignore
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div className="hf-banner hf-banner-info chat-tabs-banner" role="status">
+      <span>
+        Chat tabs simplified: Tuning and Course are now part of Assistant. Open
+        a learner or course to scope your edits.
+      </span>
+      <button
+        type="button"
+        className="chat-tabs-banner-dismiss"
+        onClick={dismiss}
+        aria-label="Dismiss tab simplification notice"
+      >
+        Got it
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/components/chat/chat-panel.css
+++ b/apps/admin/components/chat/chat-panel.css
@@ -702,3 +702,45 @@
   border-color: var(--accent-primary);
   background: var(--accent-primary);
 }
+
+/* #1504 Slice 3 — tab-consolidation one-time banner.
+   Re-uses the global hf-banner + hf-banner-info tokens; this block only
+   tightens spacing for the chat panel's compact header area. Same shape as
+   the Slice 2 merge banner — kept as a sibling rule for clarity. */
+.chat-tabs-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 8px 12px 0;
+  padding: 8px 12px;
+  font-size: 12px;
+  border-radius: 8px;
+}
+
+.chat-tabs-banner-dismiss {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 30%, transparent);
+  border-radius: 10px;
+  background: var(--surface-primary);
+  color: var(--accent-primary);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.chat-tabs-banner-dismiss:hover {
+  color: var(--accent-primary-text);
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+}
+
+/* #1504 Slice 3 — two-tab layout adjustments. With only Assistant + Demo
+   tabs rendering, give each tab a touch more breathing room so the strip
+   doesn't look sparse at the typical 400px panel width. */
+.chat-mode-tabs--two-tab .chat-mode-tab {
+  flex: 1 1 0;
+  justify-content: center;
+}

--- a/apps/admin/contexts/ChatContext.tsx
+++ b/apps/admin/contexts/ChatContext.tsx
@@ -5,9 +5,33 @@ import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { EntityBreadcrumb, useEntityContext } from "./EntityContext";
 
-export type ChatMode = "DATA" | "TUNING" | "COURSE_MANAGE" | "DEMO";
+/**
+ * #1504 Slice 3 — public ChatMode narrowed to the two tabs the operator
+ * actually sees in the chat panel. Internal route-level execution modes
+ * (CALL / BUG / WIZARD / COURSE_REF) are NOT in this union — they're
+ * dispatched by route.ts based on entry point, not picked by a tab.
+ *
+ * Legacy persisted-history aliases:
+ *   - "DATA"          → maps to ASSISTANT
+ *   - "TUNING"        → already merged into DATA by the Slice 2 migration
+ *   - "COURSE_MANAGE" → already merged into DATA by the Slice 2 migration
+ *
+ * The migration in `loadPersistedMessages` collapsed any TUNING /
+ * COURSE_MANAGE arrays into the DATA bucket. Slice 3 then aliases the DATA
+ * bucket → ASSISTANT on load, so the on-disk shape stays compatible with
+ * the pre-Slice-3 storage written by older clients but the in-memory shape
+ * is the new two-tab world.
+ */
+export type ChatMode = "ASSISTANT" | "DEMO";
 export type ChatLayout = "vertical" | "horizontal" | "popout";
 export type TuningScope = "LEARNER" | "PLAYBOOK";
+
+/**
+ * Legacy mode values that may appear in localStorage from pre-Slice-3
+ * persisted writes. Exported so the route handler + commands layer can
+ * accept both shapes during the transition window.
+ */
+export type LegacyChatMode = "DATA" | "TUNING" | "COURSE_MANAGE";
 
 export interface ChatMessage {
   id: string;
@@ -41,13 +65,20 @@ interface ChatState {
    * active entity's *type* changes (caller ↔ playbook ↔ neither) so a stale
    * PLAYBOOK toggle from a previous course page never leaks onto a caller
    * page and causes the AI to mis-attribute writes.
+   *
+   * #1504 Slice 3 — after the tab consolidation this toggle lives INSIDE
+   * Assistant at all times (was previously only rendered when mode was
+   * DATA or TUNING). It's the only way an operator can disambiguate
+   * LEARNER vs PLAYBOOK scope for behaviour-target writes once the
+   * Tuning tab is gone.
    */
   tuningScope: TuningScope | null;
   /**
-   * #727 v1 — when set, every DATA-mode message includes this ticket's UUID
-   * so the API can inject the ticket + comment thread into the system prompt.
-   * Set by the Feedback view's "Discuss with AI" button. Not persisted —
-   * lives only as long as the user is actively discussing the ticket.
+   * #727 v1 — when set, every Assistant-mode message includes this ticket's
+   * UUID so the API can inject the ticket + comment thread into the system
+   * prompt. Set by the Feedback view's "Discuss with AI" button. Not
+   * persisted — lives only as long as the user is actively discussing the
+   * ticket.
    */
   discussionTicketId: string | null;
   discussionTicketNumber: number | null;
@@ -94,6 +125,12 @@ const MIGRATION_FLAG_KEY_PREFIX = "hf.chat.history-migrated.v1504";
 // (set by the migration; ChatPanel renders the banner) | "shown" (user has
 // dismissed; never shows again for this user).
 const MERGED_BANNER_KEY_PREFIX = "hf.chat.history-merged-banner.v1504";
+// #1504 Slice 3 — per-user marker for the "tabs simplified" one-time banner.
+// Always shown once on first load after the consolidation, regardless of
+// whether the user had legacy history (the change is operator-visible even
+// for fresh installs because the 4-tab world is gone). Values: undefined
+// (not yet seen) | "shown" (dismissed; never re-appears).
+const TABS_COLLAPSED_BANNER_KEY_PREFIX = "hf.chat.tabs-collapsed-banner.v1504s3";
 // Rolling trim, not an expiry. No TTL on chat history — persists until the
 // user clears it explicitly (Clear button in header or /clear command).
 // Matches Slack / ChatGPT / Linear conventions; localStorage cap (~5MB) is
@@ -116,33 +153,29 @@ export function getMergedBannerKey(userId: string | undefined): string {
   return userId ? `${MERGED_BANNER_KEY_PREFIX}.${userId}` : MERGED_BANNER_KEY_PREFIX;
 }
 
-// Mode display configuration
+export function getTabsCollapsedBannerKey(userId: string | undefined): string {
+  return userId
+    ? `${TABS_COLLAPSED_BANNER_KEY_PREFIX}.${userId}`
+    : TABS_COLLAPSED_BANNER_KEY_PREFIX;
+}
+
+// Mode display configuration. After Slice 3 only two visible tabs.
 export const MODE_CONFIG: Record<ChatMode, { label: string; icon: string; color: string; description: string }> = {
-  DATA: {
+  // #1504 Slice 3 — subsumes legacy DATA + TUNING + COURSE_MANAGE. The
+  // unified-assistant builder routes intent based on entity context + the
+  // sticky `tuningScope` toggle below the tabs. Backend prompts handled at
+  // app/api/chat/route.ts via `buildUnifiedAssistantPrompt`.
+  ASSISTANT: {
     label: "Assistant",
     icon: "✦",
     color: "var(--accent-primary)",
-    description: "Context-aware assistant with tools and parameter knowledge",
-  },
-  TUNING: {
-    label: "Tuning",
-    icon: "⚙",
-    color: "var(--accent-primary)",
-    description: "Tune behaviour parameters for one learner or the whole course",
-  },
-  // #1225 — Course-management mode. Mounted by /x/courses/[id]/chat; the
-  // ChatPanel renders identically to DATA mode but the route.ts dispatcher
-  // narrows the tool surface to COURSE_MANAGE_TOOLS and the system prompt
-  // carries the active course's full editable snapshot.
-  COURSE_MANAGE: {
-    label: "Course",
-    icon: "◎",
-    color: "var(--accent-primary)",
-    description: "Chat-driven editor for the active course — talks to course-relevant tools only",
+    description: "Context-aware assistant — tunes, edits, queries. Use the Scope toggle to target Learner or Course.",
   },
   // #1485 (Layer 3 Slice 4) — DEMO mode: scoped 5-tool palette for operators
-  // driving a live demo. Wired in app/api/chat/route.ts:354 (DEMO branch +
-  // DEMO_TOOLS filter + buildDemoSystemPrompt).
+  // driving a live demo. Wired in app/api/chat/route.ts:330 (DEMO branch +
+  // DEMO_TOOLS filter + buildDemoSystemPrompt). Structurally distinct from
+  // ASSISTANT — narrow palette, different conversational stance, safety
+  // contracts (`fanoutScope:'none'`, `no-ai-fanout-all` ESLint).
   DEMO: {
     label: "Demo",
     icon: "▶",
@@ -157,30 +190,40 @@ function generateId(): string {
 
 function createEmptyMessages(): Record<ChatMode, ChatMessage[]> {
   return {
-    DATA: [],
-    TUNING: [],
-    COURSE_MANAGE: [],
+    ASSISTANT: [],
     DEMO: [],
   };
+}
+
+/**
+ * #1504 Slice 3 — public for routes / handlers that still emit legacy
+ * mode strings. Maps the wide pre-Slice-3 union onto the narrowed two-tab
+ * union. ASSISTANT round-trips identity.
+ */
+export function normalizeChatMode(input: string | undefined | null): ChatMode {
+  if (input === "DEMO") return "DEMO";
+  if (input === "ASSISTANT") return "ASSISTANT";
+  // Pre-Slice-3 persisted aliases — all funnel into ASSISTANT because the
+  // unified builder owns those intents post-Slice 2.
+  if (input === "DATA" || input === "TUNING" || input === "COURSE_MANAGE") return "ASSISTANT";
+  // Anything unrecognised — including CALL / BUG / WIZARD / COURSE_REF
+  // which never land here from the panel — falls back to ASSISTANT so a
+  // mis-typed setting can't strand the user on a nonexistent tab.
+  return "ASSISTANT";
 }
 
 /**
  * #1504 Slice 2 — exported for unit tests so the migration shape can be
  * pinned without going through the full ChatProvider hydration cycle.
  *
- * Collapses any legacy per-mode `TUNING` / `COURSE_MANAGE` history arrays
- * into the canonical `DATA` stream (which is the runtime default mode that
- * the unified Assistant API path uses for all three collapsed tabs).
+ * #1504 Slice 3 — extended to alias legacy DATA / TUNING / COURSE_MANAGE
+ * persisted keys onto the new ASSISTANT bucket. The Slice 2 migration
+ * collapsed TUNING + COURSE_MANAGE → DATA; Slice 3 then reads DATA out as
+ * ASSISTANT (and merges any straggler TUNING / COURSE_MANAGE entries from
+ * pre-Slice-2 clients that wrote AFTER this user's last load).
  *
- * Idempotency: writes a sentinel into `localStorage` under
- * `getMigrationFlagKey(userId)` on the first successful merge. Subsequent
- * loads see the sentinel + return the persisted shape unchanged.
- *
- * Banner: when the merge actually moves at least one message from a
- * collapsed bucket into DATA, sets `getMergedBannerKey(userId)` to
- * `"pending"` so the ChatPanel can render a one-time info banner. If no
- * legacy messages exist (fresh install / empty buckets), no banner is
- * triggered — there's nothing to notify the user about.
+ * Idempotency: the v1504 sentinel from Slice 2 still gates the legacy
+ * bucket re-merge; the Slice 3 alias-read is pure and always runs.
  *
  * Corrupt JSON / unparseable storage → returns empty state (graceful
  * fallback; never throws). Pre-existing CALL-key migration kept.
@@ -209,8 +252,9 @@ export function loadPersistedMessages(userId: string | undefined): Record<ChatMo
       return createEmptyMessages();
     }
     // Convert timestamp strings back to Date objects (defensive on every key
-    // we know about, not just the canonical modes).
-    const knownKeys = ["DATA", "TUNING", "COURSE_MANAGE", "DEMO"] as const;
+    // we know about — both the canonical two-tab modes and the legacy ones
+    // we still alias-read for backward compatibility).
+    const knownKeys = ["ASSISTANT", "DATA", "TUNING", "COURSE_MANAGE", "DEMO"] as const;
     for (const key of knownKeys) {
       const bucket = parsed[key];
       if (Array.isArray(bucket)) {
@@ -223,50 +267,53 @@ export function loadPersistedMessages(userId: string | undefined): Record<ChatMo
 
     const alreadyMigrated = localStorage.getItem(getMigrationFlagKey(userId)) === "1";
 
-    // Ensure all canonical modes exist (handle migration from old storage with CALL).
+    // #1504 Slice 3 — build the new two-tab in-memory shape. ASSISTANT
+    // absorbs the post-Slice-2 DATA bucket plus any straggler legacy
+    // buckets that might have been written by a client that bypassed the
+    // Slice 2 migration (e.g. an offline tab opened before Slice 2 shipped
+    // and saved after).
     const result = createEmptyMessages();
-    for (const mode of Object.keys(result) as ChatMode[]) {
-      if (Array.isArray(parsed[mode])) {
-        result[mode] = parsed[mode];
-      }
+
+    const retagToAssistant = (m: ChatMessage): ChatMessage => ({ ...m, mode: "ASSISTANT" });
+
+    const assistantBucket = Array.isArray(parsed.ASSISTANT) ? (parsed.ASSISTANT as ChatMessage[]) : [];
+    const dataBucket = Array.isArray(parsed.DATA) ? (parsed.DATA as ChatMessage[]) : [];
+    const tuningBucket = Array.isArray(parsed.TUNING) ? (parsed.TUNING as ChatMessage[]) : [];
+    const courseManageBucket = Array.isArray(parsed.COURSE_MANAGE)
+      ? (parsed.COURSE_MANAGE as ChatMessage[])
+      : [];
+
+    // Merge by timestamp so a chronological scroll-back stays coherent
+    // even when legacy clients interleaved writes across two buckets.
+    const mergedAssistant = [
+      ...assistantBucket.map(retagToAssistant),
+      ...dataBucket.map(retagToAssistant),
+      ...tuningBucket.map(retagToAssistant),
+      ...courseManageBucket.map(retagToAssistant),
+    ].sort((a, b) => {
+      const ta = a.timestamp instanceof Date ? a.timestamp.getTime() : 0;
+      const tb = b.timestamp instanceof Date ? b.timestamp.getTime() : 0;
+      return ta - tb;
+    });
+    result.ASSISTANT = mergedAssistant.slice(-MAX_MESSAGES_PER_MODE);
+
+    if (Array.isArray(parsed.DEMO)) {
+      result.DEMO = parsed.DEMO as ChatMessage[];
     }
 
-    // #1504 Slice 2 — one-time collapse. Old shape persisted TUNING +
-    // COURSE_MANAGE as separate arrays; the unified Assistant API path now
-    // talks through DATA. We merge by timestamp so the educator sees one
-    // chronological stream, then mark the user as migrated.
+    // #1504 Slice 2 — one-time banner trigger for users whose legacy
+    // TUNING / COURSE_MANAGE buckets contained at least one message. Slice
+    // 3 inherits this banner unchanged because the user-visible message
+    // ("Chat history merged across modes") still describes what happened.
     if (!alreadyMigrated) {
-      const legacyTuning = Array.isArray(parsed.TUNING) ? (parsed.TUNING as ChatMessage[]) : [];
-      const legacyCourseManage = Array.isArray(parsed.COURSE_MANAGE)
-        ? (parsed.COURSE_MANAGE as ChatMessage[])
-        : [];
-      const hadLegacy = legacyTuning.length + legacyCourseManage.length > 0;
-
+      const hadLegacy = tuningBucket.length + courseManageBucket.length > 0;
       if (hadLegacy) {
-        // Re-tag the message mode so re-renders + future writes treat them
-        // as DATA-stream entries (avoids state mismatch when the reducer
-        // later filters by `message.mode`).
-        const retag = (m: ChatMessage): ChatMessage => ({ ...m, mode: "DATA" });
-        const merged = [
-          ...result.DATA.map(retag),
-          ...legacyTuning.map(retag),
-          ...legacyCourseManage.map(retag),
-        ].sort((a, b) => {
-          const ta = a.timestamp instanceof Date ? a.timestamp.getTime() : 0;
-          const tb = b.timestamp instanceof Date ? b.timestamp.getTime() : 0;
-          return ta - tb;
-        });
-        result.DATA = merged.slice(-MAX_MESSAGES_PER_MODE);
-        result.TUNING = [];
-        result.COURSE_MANAGE = [];
-
         try {
           localStorage.setItem(getMergedBannerKey(userId), "pending");
         } catch {
           // ignore — banner is a nice-to-have, not load-bearing
         }
       }
-
       try {
         localStorage.setItem(getMigrationFlagKey(userId), "1");
       } catch {
@@ -305,7 +352,7 @@ function persistMessages(messages: Record<ChatMode, ChatMessage[]>, userId: stri
 }
 
 function loadSettings(userId: string | undefined): { isOpen: boolean; mode: ChatMode; chatLayout: ChatLayout; tuningScope: TuningScope | null } {
-  const defaults = { isOpen: false, mode: "DATA" as ChatMode, chatLayout: "vertical" as ChatLayout, tuningScope: "PLAYBOOK" as TuningScope | null };
+  const defaults = { isOpen: false, mode: "ASSISTANT" as ChatMode, chatLayout: "vertical" as ChatLayout, tuningScope: "PLAYBOOK" as TuningScope | null };
   if (typeof window === "undefined") return defaults;
   try {
     const stored = localStorage.getItem(getSettingsKey(userId));
@@ -318,7 +365,12 @@ function loadSettings(userId: string | undefined): { isOpen: boolean; mode: Chat
         : parsed.tuningScope === null
           ? null
           : "PLAYBOOK";
-    return { isOpen: false, mode: "DATA", chatLayout: parsed.chatLayout || "vertical", tuningScope: scope };
+    // #1504 Slice 3 — narrow persisted `mode` onto the two-tab union via
+    // the canonical normaliser. Any legacy DATA / TUNING / COURSE_MANAGE
+    // setting maps to ASSISTANT; anything unrecognised falls back the
+    // same way (safer than stranding the user on a missing tab).
+    const mode = normalizeChatMode(parsed.mode);
+    return { isOpen: false, mode, chatLayout: parsed.chatLayout || "vertical", tuningScope: scope };
   } catch {
     return defaults;
   }
@@ -338,7 +390,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const userId = session?.user?.id;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [mode, setModeState] = useState<ChatMode>("DATA");
+  const [mode, setModeState] = useState<ChatMode>("ASSISTANT");
   const [chatLayout, setChatLayoutState] = useState<ChatLayout>("vertical");
   const [tuningScope, setTuningScopeState] = useState<TuningScope | null>("PLAYBOOK");
   const [messages, setMessages] = useState<Record<ChatMode, ChatMessage[]>>(createEmptyMessages);
@@ -480,9 +532,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const setDiscussionTicket = useCallback((id: string | null, ticketNumber: number | null = null) => {
     setDiscussionTicketIdState(id);
     setDiscussionTicketNumberState(id ? ticketNumber : null);
-    // Force DATA mode when starting a ticket discussion — TUNING wouldn't see
-    // the ticket block (it's only injected on the DATA-mode prompt branch).
-    if (id) setModeState("DATA");
+    // Force ASSISTANT mode when starting a ticket discussion — DEMO doesn't
+    // see the ticket block (it's only injected on the unified Assistant
+    // prompt branch).
+    if (id) setModeState("ASSISTANT");
   }, []);
 
   const addMessage = useCallback((message: Omit<ChatMessage, "id" | "timestamp">): string => {
@@ -588,12 +641,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               mode,
               entityContext: entityContext.breadcrumbs,
               isCommand: true,
-              ...((mode === "DATA" || mode === "TUNING") && tuningScope ? { tuningScope } : {}),
-              ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
-              ...(pathname && (mode === "DATA" || mode === "TUNING" || mode === "COURSE_MANAGE" || mode === "DEMO") ? { pageHint: { route: pathname } } : {}),
-              ...((mode === "DATA" || mode === "COURSE_MANAGE" || mode === "DEMO") && entityContext.pageContext?.page
-                ? { pageContext: entityContext.pageContext }
-                : {}),
+              ...(mode === "ASSISTANT" && tuningScope ? { tuningScope } : {}),
+              ...(mode === "ASSISTANT" && discussionTicketId ? { discussionTicketId } : {}),
+              ...(pathname ? { pageHint: { route: pathname } } : {}),
+              ...(entityContext.pageContext?.page ? { pageContext: entityContext.pageContext } : {}),
             }),
           });
 
@@ -603,7 +654,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
             metadata: { command: content.trim(), commandResult: data, isStreaming: false },
           });
           if (data?.action === "execute" && data?.data?.clearHistory) {
-            const targetMode = data.data.clearHistory as ChatMode;
+            const targetMode = normalizeChatMode(data.data.clearHistory);
             setMessages((prev) => ({ ...prev, [targetMode]: [] }));
           }
         } catch (err) {
@@ -651,12 +702,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
               mode,
               entityContext: entityContext.breadcrumbs,
               conversationHistory: history,
-              ...((mode === "DATA" || mode === "TUNING") && tuningScope ? { tuningScope } : {}),
-              ...(mode === "DATA" && discussionTicketId ? { discussionTicketId } : {}),
-              ...(pathname && (mode === "DATA" || mode === "TUNING" || mode === "COURSE_MANAGE" || mode === "DEMO") ? { pageHint: { route: pathname } } : {}),
-              ...((mode === "DATA" || mode === "COURSE_MANAGE" || mode === "DEMO") && entityContext.pageContext?.page
-                ? { pageContext: entityContext.pageContext }
-                : {}),
+              ...(mode === "ASSISTANT" && tuningScope ? { tuningScope } : {}),
+              ...(mode === "ASSISTANT" && discussionTicketId ? { discussionTicketId } : {}),
+              ...(pathname ? { pageHint: { route: pathname } } : {}),
+              ...(entityContext.pageContext?.page ? { pageContext: entityContext.pageContext } : {}),
               ...(trayReflections.length > 0 ? { trayReflections } : {}),
             }),
             signal: abortControllerRef.current.signal,

--- a/apps/admin/lib/chat/commands.ts
+++ b/apps/admin/lib/chat/commands.ts
@@ -1,12 +1,13 @@
 import { prisma } from "@/lib/prisma";
 import { MemoryCategory } from "@prisma/client";
 
-// #1504 Slice 2 — DATA / TUNING / COURSE_MANAGE still appear as visible UI
-// tabs in `ChatContext.tsx` so the union keeps them. The API folds those
-// three into the unified Assistant runner; CALL and BUG are runtime-only
-// modes (not user-facing tabs) but stay in the union because the
-// command pipeline can still receive them via the route's mode cast.
-type ChatMode = "DATA" | "CALL" | "BUG" | "TUNING" | "COURSE_MANAGE" | "DEMO";
+// #1504 Slice 3 — public chat tabs are now ASSISTANT + DEMO only. CALL +
+// BUG remain in the union because they're still dispatched through this
+// command pipeline by route-level entry points (voice sim, bug reporter) —
+// they are never picked by a UI tab. Pre-Slice-3 aliases (DATA / TUNING /
+// COURSE_MANAGE) are normalised to ASSISTANT by the route handler before
+// reaching this layer, so they don't appear here.
+type ChatMode = "ASSISTANT" | "CALL" | "BUG" | "DEMO";
 
 interface EntityBreadcrumb {
   type: string;
@@ -107,7 +108,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["?", "commands"],
     description: "Show available commands",
     usage: "/help [command]",
-    modes: ["DATA", "CALL", "TUNING", "COURSE_MANAGE", "DEMO"],
+    modes: ["ASSISTANT", "CALL", "DEMO"],
     execute: async (args, ctx) => {
       const specificCommand = args[0];
       if (specificCommand) {
@@ -140,7 +141,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["ctx"],
     description: "Show current entity context",
     usage: "/context",
-    modes: ["DATA", "CALL", "TUNING"],
+    modes: ["ASSISTANT", "CALL"],
     execute: async (args, ctx) => {
       if (ctx.entityContext.length === 0) {
         return {
@@ -169,7 +170,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["reset"],
     description: "Clear chat history for current mode",
     usage: "/clear",
-    modes: ["DATA", "CALL", "TUNING"],
+    modes: ["ASSISTANT", "CALL"],
     execute: async (args, ctx) => {
       return {
         ok: true,
@@ -185,7 +186,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["mem"],
     description: "Show memories for current caller",
     usage: "/memories [category]",
-    modes: ["DATA", "CALL"],
+    modes: ["ASSISTANT", "CALL"],
     execute: async (args, ctx) => {
       const callerEntity = ctx.entityContext.find((e) => e.type === "caller");
       if (!callerEntity) {
@@ -256,7 +257,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["prompt", "compose"],
     description: "Show or build the composed prompt for current caller",
     usage: "/buildprompt",
-    modes: ["DATA", "CALL"],
+    modes: ["ASSISTANT", "CALL"],
     execute: async (args, ctx) => {
       const callerEntity = ctx.entityContext.find((e) => e.type === "caller");
       if (!callerEntity) {
@@ -304,7 +305,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: [],
     description: "Show information about the current caller",
     usage: "/caller",
-    modes: ["DATA", "CALL"],
+    modes: ["ASSISTANT", "CALL"],
     execute: async (args, ctx) => {
       const callerEntity = ctx.entityContext.find((e) => e.type === "caller");
       if (!callerEntity) {
@@ -365,16 +366,18 @@ const COMMANDS: ChatCommand[] = [
     aliases: [],
     description: "Show current tuning scope (LEARNER or PLAYBOOK)",
     usage: "/scope",
-    modes: ["TUNING"],
+    modes: ["ASSISTANT"],
     execute: async (_args, ctx) => {
       const scope = ctx.tuningScope ?? "PLAYBOOK";
       const explainer =
         scope === "LEARNER"
           ? "Changes apply to the selected learner only."
           : "Changes apply to the whole course.";
+      // #1504 Slice 3 — the scope toggle now lives inline inside the
+      // Assistant tab (no separate Tuning tab post-consolidation).
       return {
         ok: true,
-        message: `**Scope: ${scope}**\n\n${explainer}\n\nFlip with the toggle at the top of the Tuning tab.`,
+        message: `**Scope: ${scope}**\n\n${explainer}\n\nFlip with the Scope toggle just above the message list in the Assistant tab.`,
         action: "display",
       };
     },
@@ -385,7 +388,7 @@ const COMMANDS: ChatCommand[] = [
     aliases: ["parameters"],
     description: "List tunable parameters for current context",
     usage: "/params",
-    modes: ["TUNING"],
+    modes: ["ASSISTANT"],
     execute: async (_args, ctx) => {
       const scope = ctx.tuningScope ?? "PLAYBOOK";
       const lines = [

--- a/apps/admin/lib/validation/schemas.ts
+++ b/apps/admin/lib/validation/schemas.ts
@@ -108,7 +108,22 @@ const entityBreadcrumbSchema = z.object({
 /** POST /api/chat */
 export const chatRequestSchema = z.object({
   message: z.string().min(1, "Message is required").max(50_000),
-  mode: z.enum(["DATA", "CALL", "BUG", "WIZARD", "COURSE_REF"]),
+  // #1504 Slice 3 — ASSISTANT is the canonical user-tab mode (collapses
+  // legacy DATA / TUNING / COURSE_MANAGE). Legacy values stay accepted in
+  // the enum because clients that haven't refreshed past the deploy may
+  // still POST them; route.ts normalises any of {DATA, TUNING,
+  // COURSE_MANAGE} → unified Assistant path.
+  mode: z.enum([
+    "ASSISTANT",
+    "DATA",
+    "TUNING",
+    "COURSE_MANAGE",
+    "CALL",
+    "BUG",
+    "WIZARD",
+    "COURSE_REF",
+    "DEMO",
+  ]),
   entityContext: z.array(entityBreadcrumbSchema).default([]),
   conversationHistory: z.array(z.object({
     role: z.string(),

--- a/apps/admin/tests/components/chat/ChatModeTabs.test.tsx
+++ b/apps/admin/tests/components/chat/ChatModeTabs.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * #1504 Slice 3 — ChatModeTabs renders the two-tab world.
+ *
+ * Pre-Slice-3 the strip rendered 4 tabs (Assistant / Tuning / Course /
+ * Demo). After the consolidation it MUST render exactly 2 (Assistant +
+ * Demo) — Tuning and Course are gone as standalone tabs; their intents
+ * funnel into Assistant via the breadcrumb + Scope toggle.
+ *
+ * Pin the structural shape here so any future regression that re-adds a
+ * legacy tab breaks loudly instead of silently re-introducing the 4-tab
+ * confusion. The legacy ChatPanel.tsx::ChatModeTabs was simple enough
+ * that we cover it via a small render-test against the public Provider
+ * surface (mocks next-auth so no real session is needed).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: {
+      user: { id: "u-test", email: "t@x", name: "T", role: "OPERATOR", image: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/x/test",
+}));
+
+vi.mock("@/components/shared/AIModelBadge", () => ({
+  AIModelBadge: () => null,
+}));
+
+vi.mock("@/hooks/useEntityDetection", () => ({
+  useEntityDetection: () => undefined,
+}));
+
+import { ChatProvider, MODE_CONFIG } from "@/contexts/ChatContext";
+import { EntityProvider } from "@/contexts/EntityContext";
+import { ChatPanel } from "@/components/chat/ChatPanel";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <EntityProvider>
+      <ChatProvider>{children}</ChatProvider>
+    </EntityProvider>
+  );
+}
+
+beforeEach(() => {
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("MODE_CONFIG — post-Slice-3 structural shape", () => {
+  it("exposes exactly two visible tabs: ASSISTANT and DEMO", () => {
+    const keys = Object.keys(MODE_CONFIG).sort();
+    expect(keys).toEqual(["ASSISTANT", "DEMO"]);
+  });
+
+  it("uses operator-readable labels for the two surviving tabs", () => {
+    expect(MODE_CONFIG.ASSISTANT.label).toBe("Assistant");
+    expect(MODE_CONFIG.DEMO.label).toBe("Demo");
+  });
+
+  it("does NOT include legacy DATA / TUNING / COURSE_MANAGE keys", () => {
+    const cfg = MODE_CONFIG as unknown as Record<string, unknown>;
+    expect(cfg.DATA).toBeUndefined();
+    expect(cfg.TUNING).toBeUndefined();
+    expect(cfg.COURSE_MANAGE).toBeUndefined();
+  });
+});
+
+describe("ChatPanel — ChatModeTabs renders exactly two tabs", () => {
+  it("renders the Assistant tab and the Demo tab — no Tuning, no Course", () => {
+    render(
+      <Wrapper>
+        <ChatPanel />
+      </Wrapper>,
+    );
+    // Force the panel open via the provider's openPanel — without a click
+    // it stays closed and the tabs don't mount. The simplest way is to
+    // render and then look for the tab strip even when collapsed; the
+    // tablist always renders inside the panel root regardless of the
+    // open state because the strip is part of the persistent layout.
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+    const labels = tabs.map((t) => t.textContent ?? "");
+    expect(labels.some((l) => l.includes("Assistant"))).toBe(true);
+    expect(labels.some((l) => l.includes("Demo"))).toBe(true);
+    expect(labels.some((l) => l.includes("Tuning"))).toBe(false);
+    expect(labels.some((l) => l.includes("Course"))).toBe(false);
+  });
+
+  it("marks Assistant as the active tab on first render (default mode = ASSISTANT)", () => {
+    render(
+      <Wrapper>
+        <ChatPanel />
+      </Wrapper>,
+    );
+    const tabs = screen.getAllByRole("tab");
+    const assistantTab = tabs.find((t) => (t.textContent ?? "").includes("Assistant"));
+    const demoTab = tabs.find((t) => (t.textContent ?? "").includes("Demo"));
+    expect(assistantTab?.getAttribute("aria-selected")).toBe("true");
+    expect(demoTab?.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("switches active tab on click", () => {
+    render(
+      <Wrapper>
+        <ChatPanel />
+      </Wrapper>,
+    );
+    const tabs = screen.getAllByRole("tab");
+    const demoTab = tabs.find((t) => (t.textContent ?? "").includes("Demo"));
+    expect(demoTab).toBeDefined();
+    fireEvent.click(demoTab!);
+
+    // Re-read after the click — aria-selected should have flipped.
+    const tabsAfter = screen.getAllByRole("tab");
+    const assistantAfter = tabsAfter.find((t) => (t.textContent ?? "").includes("Assistant"));
+    const demoAfter = tabsAfter.find((t) => (t.textContent ?? "").includes("Demo"));
+    expect(assistantAfter?.getAttribute("aria-selected")).toBe("false");
+    expect(demoAfter?.getAttribute("aria-selected")).toBe("true");
+  });
+});
+
+describe("ChatPanel — TuningScopeToggle visibility", () => {
+  it("renders the Scope toggle while on the Assistant tab", () => {
+    render(
+      <Wrapper>
+        <ChatPanel />
+      </Wrapper>,
+    );
+    // The toggle wrapper carries role=radiogroup aria-label="Tuning scope".
+    const toggle = screen.queryByRole("radiogroup", { name: /tuning scope/i });
+    expect(toggle).not.toBeNull();
+  });
+
+  it("hides the Scope toggle on the Demo tab (DEMO has its own narrow palette)", () => {
+    render(
+      <Wrapper>
+        <ChatPanel />
+      </Wrapper>,
+    );
+    const tabs = screen.getAllByRole("tab");
+    const demoTab = tabs.find((t) => (t.textContent ?? "").includes("Demo"));
+    fireEvent.click(demoTab!);
+
+    const toggle = screen.queryByRole("radiogroup", { name: /tuning scope/i });
+    expect(toggle).toBeNull();
+  });
+});

--- a/apps/admin/tests/components/chat/CollapsedTabsBanner.test.tsx
+++ b/apps/admin/tests/components/chat/CollapsedTabsBanner.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * #1504 Slice 3 — CollapsedTabsBanner shows once per user.
+ *
+ * The banner:
+ *   - renders by default on first load (state = null in localStorage)
+ *   - hides after the user clicks "Got it" (state flips to "shown")
+ *   - stays hidden on subsequent mounts (idempotent across page reloads)
+ *   - is independent of the Slice 2 "history merged" banner (different
+ *     storage key, different copy)
+ *
+ * Uses next-auth's mocked session so the user-scoped storage key
+ * (`hf.chat.tabs-collapsed-banner.v1504s3.<userId>`) resolves to a stable
+ * value per test.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: {
+      user: { id: "u_test_banner", email: "t@x", name: "T", role: "OPERATOR", image: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    },
+    status: "authenticated",
+  }),
+}));
+
+import { CollapsedTabsBanner } from "@/components/chat/CollapsedTabsBanner";
+import { getTabsCollapsedBannerKey } from "@/contexts/ChatContext";
+
+const STORAGE_KEY = getTabsCollapsedBannerKey("u_test_banner");
+
+beforeEach(() => {
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("CollapsedTabsBanner — first-time visibility", () => {
+  it("renders on first mount when localStorage has no record", () => {
+    render(<CollapsedTabsBanner />);
+    expect(
+      screen.queryByText(/Chat tabs simplified/i),
+    ).not.toBeNull();
+  });
+
+  it("renders the dismiss button labelled 'Got it'", () => {
+    render(<CollapsedTabsBanner />);
+    expect(screen.queryByRole("button", { name: /dismiss tab simplification notice/i })).not.toBeNull();
+  });
+
+  it("uses the design-system info-banner class (no inline colours)", () => {
+    const { container } = render(<CollapsedTabsBanner />);
+    const banner = container.querySelector(".hf-banner");
+    expect(banner).not.toBeNull();
+    expect(banner?.className).toContain("hf-banner-info");
+    expect(banner?.className).toContain("chat-tabs-banner");
+  });
+});
+
+describe("CollapsedTabsBanner — dismiss + persistence", () => {
+  it("hides after the dismiss button is clicked", () => {
+    render(<CollapsedTabsBanner />);
+    const dismissBtn = screen.getByRole("button", { name: /dismiss tab simplification notice/i });
+    fireEvent.click(dismissBtn);
+    expect(screen.queryByText(/Chat tabs simplified/i)).toBeNull();
+  });
+
+  it("writes 'shown' to the user-scoped localStorage key after dismiss", () => {
+    render(<CollapsedTabsBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /dismiss tab simplification notice/i }));
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("shown");
+  });
+
+  it("stays hidden on a subsequent mount when localStorage already says 'shown'", () => {
+    window.localStorage.setItem(STORAGE_KEY, "shown");
+    render(<CollapsedTabsBanner />);
+    expect(screen.queryByText(/Chat tabs simplified/i)).toBeNull();
+  });
+});
+
+describe("CollapsedTabsBanner — storage key contract", () => {
+  it("scopes the key by userId so two operators sharing a machine don't collide", () => {
+    const userAKey = getTabsCollapsedBannerKey("alice");
+    const userBKey = getTabsCollapsedBannerKey("bob");
+    expect(userAKey).not.toBe(userBKey);
+    expect(userAKey).toBe("hf.chat.tabs-collapsed-banner.v1504s3.alice");
+    expect(userBKey).toBe("hf.chat.tabs-collapsed-banner.v1504s3.bob");
+  });
+
+  it("falls back to the bare prefix when userId is undefined (unauthenticated mount)", () => {
+    expect(getTabsCollapsedBannerKey(undefined)).toBe(
+      "hf.chat.tabs-collapsed-banner.v1504s3",
+    );
+  });
+
+  it("uses a DIFFERENT key from the Slice 2 history-merged banner", async () => {
+    const tabsKey = getTabsCollapsedBannerKey("alice");
+    const { getMergedBannerKey } = await import("@/contexts/ChatContext");
+    const mergedKey = getMergedBannerKey("alice");
+    expect(tabsKey).not.toBe(mergedKey);
+  });
+});

--- a/apps/admin/tests/contexts/ChatContext-history-migration.test.tsx
+++ b/apps/admin/tests/contexts/ChatContext-history-migration.test.tsx
@@ -1,15 +1,18 @@
 /**
- * #1504 Slice 2 — ChatContext history migration.
+ * #1504 Slice 2 — ChatContext history migration (legacy bucket collapse).
+ * #1504 Slice 3 — extended to assert the legacy buckets now read as
+ *                  `ASSISTANT` after the public ChatMode union narrows.
  *
- * `loadPersistedMessages` collapses legacy `TUNING` + `COURSE_MANAGE` arrays
- * into a single `DATA` stream once per user. The migration must be:
+ * `loadPersistedMessages` collapses any legacy `DATA` / `TUNING` /
+ * `COURSE_MANAGE` arrays into a single `ASSISTANT` stream once per user.
+ * The migration must be:
  *   - **idempotent** — a second call after the first must return the same
  *     shape (no re-merge, no doubled messages, no banner re-fire).
  *   - **chronological** — merged messages are sorted by timestamp so the
- *     educator sees a coherent thread, not three concatenated buckets.
+ *     educator sees a coherent thread, not multiple concatenated buckets.
  *   - **mode-rewriting** — each merged message has its `mode` field
- *     rewritten to "DATA" so future renders / persists treat it as part
- *     of the canonical stream.
+ *     rewritten to "ASSISTANT" so future renders / persists treat it as
+ *     part of the canonical stream.
  *   - **safe on corrupt input** — JSON parse failure returns the empty
  *     state and marks the user as migrated so we don't retry forever.
  *
@@ -22,6 +25,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   loadPersistedMessages,
   getMergedBannerKey,
+  normalizeChatMode,
   type ChatMessage,
 } from "@/contexts/ChatContext";
 
@@ -33,9 +37,14 @@ const STORAGE_KEY = `hf.chat.history.${USER_ID}`;
 const MIGRATION_FLAG_KEY = `hf.chat.history-migrated.v1504.${USER_ID}`;
 const MERGED_BANNER_KEY = `hf.chat.history-merged-banner.v1504.${USER_ID}`;
 
+// Legacy modes still appear on persisted messages written pre-Slice-3, so
+// the test fixture builder accepts the wide union; we cast on the way in
+// (`ChatMessage` post-Slice-3 only accepts `ASSISTANT` or `DEMO`).
+type AnyPersistedMode = "ASSISTANT" | "DATA" | "TUNING" | "COURSE_MANAGE" | "DEMO";
+
 function msg(
   id: string,
-  mode: "DATA" | "TUNING" | "COURSE_MANAGE" | "DEMO",
+  mode: AnyPersistedMode,
   content: string,
   timestamp: string,
 ): ChatMessage {
@@ -44,7 +53,10 @@ function msg(
     role: "user",
     content,
     timestamp: new Date(timestamp),
-    mode,
+    // The on-disk shape carries the legacy string; the loader re-tags it
+    // to ASSISTANT in-memory. Cast through `unknown` so TypeScript doesn't
+    // complain about the legacy string entering a narrowed union.
+    mode: mode as unknown as ChatMessage["mode"],
   };
 }
 
@@ -62,9 +74,7 @@ describe("loadPersistedMessages — fresh install (no legacy keys)", () => {
   it("returns the empty state and marks the user as migrated", () => {
     const result = loadPersistedMessages(USER_ID);
 
-    expect(result.DATA).toEqual([]);
-    expect(result.TUNING).toEqual([]);
-    expect(result.COURSE_MANAGE).toEqual([]);
+    expect(result.ASSISTANT).toEqual([]);
     expect(result.DEMO).toEqual([]);
 
     // Migration sentinel set even on the no-op path so we never re-scan.
@@ -75,7 +85,7 @@ describe("loadPersistedMessages — fresh install (no legacy keys)", () => {
 });
 
 describe("loadPersistedMessages — legacy buckets present (the migration path)", () => {
-  it("merges TUNING + COURSE_MANAGE into DATA in timestamp order", () => {
+  it("merges DATA + TUNING + COURSE_MANAGE into ASSISTANT in timestamp order", () => {
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -87,23 +97,22 @@ describe("loadPersistedMessages — legacy buckets present (the migration path)"
 
     const result = loadPersistedMessages(USER_ID);
 
-    expect(result.DATA.map((m) => m.id)).toEqual(["t1", "d1", "c1"]);
-    expect(result.TUNING).toEqual([]);
-    expect(result.COURSE_MANAGE).toEqual([]);
+    expect(result.ASSISTANT.map((m) => m.id)).toEqual(["t1", "d1", "c1"]);
 
-    // Every merged message tagged as DATA so downstream filters by
+    // Every merged message tagged as ASSISTANT so downstream filters by
     // `message.mode` see the canonical stream.
-    for (const m of result.DATA) {
-      expect(m.mode).toBe("DATA");
+    for (const m of result.ASSISTANT) {
+      expect(m.mode).toBe("ASSISTANT");
     }
 
-    // Banner flagged "pending" so ChatPanel shows the one-time notice.
+    // Banner flagged "pending" so ChatPanel shows the one-time notice
+    // (banner only fires when legacy TUNING / COURSE_MANAGE had content).
     expect(window.localStorage.getItem(MERGED_BANNER_KEY)).toBe("pending");
     // Migration sentinel set so subsequent loads skip the merge.
     expect(window.localStorage.getItem(MIGRATION_FLAG_KEY)).toBe("1");
   });
 
-  it("preserves DEMO history (DEMO is NOT folded in)", () => {
+  it("preserves DEMO history (DEMO is NOT folded into ASSISTANT)", () => {
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -116,9 +125,45 @@ describe("loadPersistedMessages — legacy buckets present (the migration path)"
 
     const result = loadPersistedMessages(USER_ID);
 
-    expect(result.DATA.map((m) => m.id)).toEqual(["t1"]);
+    expect(result.ASSISTANT.map((m) => m.id)).toEqual(["t1"]);
     expect(result.DEMO.map((m) => m.id)).toEqual(["dm1"]);
     expect(result.DEMO[0].mode).toBe("DEMO");
+  });
+
+  it("does NOT trigger the merge banner when only DATA was present (Slice 2 already moved those messages)", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        DATA: [msg("d1", "DATA", "data", "2026-06-09T10:00:00Z")],
+        TUNING: [],
+        COURSE_MANAGE: [],
+      }),
+    );
+
+    const result = loadPersistedMessages(USER_ID);
+
+    // DATA → ASSISTANT alias-read still happens, but the user-visible
+    // "history merged" notice only fires when the operator can detect a
+    // change. Pre-Slice-2 the user only had DATA; they wouldn't see a
+    // merge happening because nothing was reshuffled.
+    expect(result.ASSISTANT.map((m) => m.id)).toEqual(["d1"]);
+    expect(window.localStorage.getItem(MERGED_BANNER_KEY)).toBeNull();
+  });
+
+  it("reads a post-Slice-3 client's ASSISTANT bucket directly (no DATA fallback needed)", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        ASSISTANT: [
+          msg("a1", "ASSISTANT", "assistant q1", "2026-06-10T10:00:00Z"),
+          msg("a2", "ASSISTANT", "assistant q2", "2026-06-10T11:00:00Z"),
+        ],
+        DEMO: [],
+      }),
+    );
+
+    const result = loadPersistedMessages(USER_ID);
+    expect(result.ASSISTANT.map((m) => m.id)).toEqual(["a1", "a2"]);
   });
 });
 
@@ -134,16 +179,14 @@ describe("loadPersistedMessages — idempotent (the second call must be a no-op)
     );
 
     const first = loadPersistedMessages(USER_ID);
-    expect(first.DATA).toHaveLength(2);
+    expect(first.ASSISTANT).toHaveLength(2);
 
     // Simulate the ChatProvider persisting the merged shape back to storage
     // (the real `persistMessages` writes the new shape on the next effect).
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        DATA: first.DATA,
-        TUNING: [],
-        COURSE_MANAGE: [],
+        ASSISTANT: first.ASSISTANT,
         DEMO: [],
       }),
     );
@@ -151,31 +194,23 @@ describe("loadPersistedMessages — idempotent (the second call must be a no-op)
     const second = loadPersistedMessages(USER_ID);
 
     // Same length, same ids, in the same order. NOT doubled.
-    expect(second.DATA).toHaveLength(2);
-    expect(second.DATA.map((m) => m.id)).toEqual(first.DATA.map((m) => m.id));
+    expect(second.ASSISTANT).toHaveLength(2);
+    expect(second.ASSISTANT.map((m) => m.id)).toEqual(first.ASSISTANT.map((m) => m.id));
 
     // Banner stays at whatever the first call set; the second call does NOT
     // overwrite it because the migration sentinel short-circuits the merge.
     expect(window.localStorage.getItem(MERGED_BANNER_KEY)).toBe("pending");
   });
 
-  it("does not re-merge even if a future bug repopulates TUNING after the first run", () => {
-    // First run does the migration.
-    window.localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        DATA: [],
-        TUNING: [msg("t1", "TUNING", "tuning", "2026-06-08T09:00:00Z")],
-        COURSE_MANAGE: [],
-      }),
-    );
-    loadPersistedMessages(USER_ID);
-
-    // Sentinel now set. Manually re-add a TUNING message (simulating a
-    // pre-fix client that hadn't shipped Slice 2 yet writing back via the
-    // same key). The next load must NOT merge it again — the user has
-    // already seen the merge banner; surprising them with a second one
-    // would erode trust.
+  it("a leaked legacy TUNING bucket from an unmigrated client still alias-reads into ASSISTANT", () => {
+    // Slice 3 broadens the safety net: the post-Slice-2 idempotency check
+    // would have left a leaked TUNING bucket sitting in its own slot. In
+    // Slice 3 the in-memory shape no longer has a TUNING slot at all, so
+    // the alias-read pulls those entries into ASSISTANT every load. The
+    // banner sentinel is what guarantees idempotency from the *user's*
+    // perspective — they only see "history merged" once.
+    window.localStorage.setItem(MIGRATION_FLAG_KEY, "1");
+    window.localStorage.setItem(MERGED_BANNER_KEY, "shown");
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -186,11 +221,9 @@ describe("loadPersistedMessages — idempotent (the second call must be a no-op)
     );
 
     const result = loadPersistedMessages(USER_ID);
-    // TUNING stays in its own bucket (no merge); the educator can see
-    // the leak in localStorage if they look. We can clean it up in Slice 3
-    // when the UI tabs collapse and the bucket is structurally unreachable.
-    expect(result.DATA.map((m) => m.id)).toEqual(["d1"]);
-    expect(result.TUNING.map((m) => m.id)).toEqual(["t2"]);
+    expect(result.ASSISTANT.map((m) => m.id)).toEqual(["d1", "t2"]);
+    // Banner state unchanged — user already dismissed it.
+    expect(window.localStorage.getItem(MERGED_BANNER_KEY)).toBe("shown");
   });
 });
 
@@ -200,16 +233,14 @@ describe("loadPersistedMessages — already-migrated shape (no legacy buckets)",
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        DATA: [msg("d1", "DATA", "data", "2026-06-09T10:00:00Z")],
-        TUNING: [],
-        COURSE_MANAGE: [],
+        ASSISTANT: [msg("a1", "ASSISTANT", "assistant", "2026-06-09T10:00:00Z")],
         DEMO: [msg("dm1", "DEMO", "demo", "2026-06-09T10:30:00Z")],
       }),
     );
 
     const result = loadPersistedMessages(USER_ID);
 
-    expect(result.DATA.map((m) => m.id)).toEqual(["d1"]);
+    expect(result.ASSISTANT.map((m) => m.id)).toEqual(["a1"]);
     expect(result.DEMO.map((m) => m.id)).toEqual(["dm1"]);
     // No banner triggered — already migrated.
     expect(window.localStorage.getItem(MERGED_BANNER_KEY)).toBeNull();
@@ -222,9 +253,7 @@ describe("loadPersistedMessages — corrupt input (graceful fallback)", () => {
 
     const result = loadPersistedMessages(USER_ID);
 
-    expect(result.DATA).toEqual([]);
-    expect(result.TUNING).toEqual([]);
-    expect(result.COURSE_MANAGE).toEqual([]);
+    expect(result.ASSISTANT).toEqual([]);
     expect(result.DEMO).toEqual([]);
 
     // Mark migrated so we don't retry parsing the same corrupt blob.
@@ -238,7 +267,7 @@ describe("loadPersistedMessages — corrupt input (graceful fallback)", () => {
 
     const result = loadPersistedMessages(USER_ID);
 
-    expect(result.DATA).toEqual([]);
+    expect(result.ASSISTANT).toEqual([]);
     // The migration sentinel is still set so we don't retry parsing this
     // valid-JSON-but-wrong-shape blob on every page load.
     expect(window.localStorage.getItem(MIGRATION_FLAG_KEY)).toBe("1");
@@ -256,5 +285,25 @@ describe("getMergedBannerKey — exported for ChatPanel reads", () => {
     expect(getMergedBannerKey(undefined)).toBe(
       "hf.chat.history-merged-banner.v1504",
     );
+  });
+});
+
+describe("normalizeChatMode — public API maps legacy mode strings → ASSISTANT", () => {
+  it("round-trips ASSISTANT and DEMO unchanged", () => {
+    expect(normalizeChatMode("ASSISTANT")).toBe("ASSISTANT");
+    expect(normalizeChatMode("DEMO")).toBe("DEMO");
+  });
+
+  it("collapses every legacy alias to ASSISTANT", () => {
+    expect(normalizeChatMode("DATA")).toBe("ASSISTANT");
+    expect(normalizeChatMode("TUNING")).toBe("ASSISTANT");
+    expect(normalizeChatMode("COURSE_MANAGE")).toBe("ASSISTANT");
+  });
+
+  it("falls back to ASSISTANT on unknown / missing values (safer than stranding the user)", () => {
+    expect(normalizeChatMode("UNKNOWN")).toBe("ASSISTANT");
+    expect(normalizeChatMode(undefined)).toBe("ASSISTANT");
+    expect(normalizeChatMode(null)).toBe("ASSISTANT");
+    expect(normalizeChatMode("")).toBe("ASSISTANT");
   });
 });

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-11T22:29:28.214Z",
+  "generatedAt": "2026-06-11T23:14:03.723Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
   "fileCount": 1665,

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-11T22:29:28.754Z",
+  "generatedAt": "2026-06-11T23:14:04.135Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-11T22:29:26.642Z",
+  "generatedAt": "2026-06-11T23:14:02.498Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-11T22:29:29.422Z",
+  "generatedAt": "2026-06-11T23:14:04.590Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-11T22:29:27.312Z",
+  "generatedAt": "2026-06-11T23:14:03.065Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Final slice of epic #1504. The chat panel now renders exactly 2 visible tabs (Assistant + Demo) instead of the legacy 4 (Assistant / Tuning / Course / Demo). Tuning + Course intents funnel into Assistant via the unified-prompt builder shipped in Slice 1 + made default in Slice 2; the LEARNER vs PLAYBOOK scope toggle now lives inline inside Assistant at all times so write operations have unambiguous scope regardless of which breadcrumb the operator is on.

DEMO stays structurally distinct (narrow 5-tool palette, `buildDemoSystemPrompt()`, `fanoutScope:'none'`, `no-ai-fanout-all` ESLint rule) — collapsing it would re-expose `update_behavior_target` in a demo context, which the safety story explicitly prevents (epic risk 2).

## What changed

### Public chat-mode shape
- `contexts/ChatContext.tsx::ChatMode` narrowed: `"DATA" | "TUNING" | "COURSE_MANAGE" | "DEMO"` → `"ASSISTANT" | "DEMO"`.
- `MODE_CONFIG` collapsed to two entries: ASSISTANT (subsumes DATA/TUNING/COURSE_MANAGE) + DEMO.
- `createEmptyMessages()` returns `{ ASSISTANT: [], DEMO: [] }`.
- New `normalizeChatMode(input)` helper centralises the legacy-string → ASSISTANT alias so the route handler, settings loader, and slash-command flush queue all map identically.
- `loadPersistedMessages` extended to alias legacy DATA / TUNING / COURSE_MANAGE persisted buckets onto ASSISTANT in-memory + sort by timestamp so a Slice-2 → Slice-3 jump never doubles messages.

### UI shape
- `components/chat/ChatPanel.tsx::ChatModeTabs` renders exactly 2 tabs; CSS modifier \`chat-mode-tabs--two-tab\` gives them balanced width.
- \`TuningScopeToggle\` always visible in ASSISTANT mode (previously gated on \`mode === "DATA" || mode === "TUNING"\`, which would hide it entirely after the collapse).
- \`DiscussingTicketStripe\` + \`ChatBreadcrumbStripe\` re-gated on \`mode === "ASSISTANT"\` (was \`mode === "DATA"\`).
- \`AIModelBadge\` callPoint switched from \`chat.\${mode.toLowerCase()}\` to \`chat.unified_assistant\` / \`chat.demo\` — the legacy \`chat.data\` / \`chat.tuning\` / \`chat.course_manage\` AI configs are no longer registered server-side after Slice 2.

### New banner
- \`components/chat/CollapsedTabsBanner.tsx\` — one-time info banner ("Chat tabs simplified: Tuning and Course are now part of Assistant. Open a learner or course to scope your edits.") using \`hf-banner hf-banner-info\` design-system tokens. Uses localStorage key \`hf.chat.tabs-collapsed-banner.v1504s3.<userId>\`; flips to \`"shown"\` on dismiss; independent of the Slice 2 history-merged banner.
- \`chat-panel.css\` adds \`.chat-tabs-banner\` + \`.chat-tabs-banner-dismiss\` + \`.chat-mode-tabs--two-tab\` rules (design-token only, no hex).

### Route + validation
- \`app/api/chat/route.ts\` ChatMode union widened to include \`ASSISTANT\` alongside the legacy aliases. New \`isAssistantMode()\` helper centralises the dispatch branch. Slash-command cast narrows to the public union via the helper.
- \`lib/validation/schemas.ts::chatRequestSchema\` mode enum extended to accept \`ASSISTANT\` + \`DEMO\` + the legacy strings (kept for rolling-deploy compat — old clients in long-lived tabs still POST \`mode: "DATA"\`).

### Course-page entry point
- \`app/x/courses/[courseId]/chat/ChatLauncher.tsx\` sets mode to \`ASSISTANT\` (was \`COURSE_MANAGE\`). The breadcrumb + pageContext snapshot still drive course-edit tool selection via the unified-prompt's intent-routing block.

### commands.ts
- \`ChatMode\` union narrowed to \`"ASSISTANT" | "CALL" | "BUG" | "DEMO"\` (TUNING + COURSE_MANAGE dropped; CALL + BUG remain because they're still route-level dispatch targets, not tabs).
- \`/scope\` + \`/params\` commands re-gated to ASSISTANT.
- \`/scope\` copy updated to point at the inline Scope toggle (no more "Tuning tab").

## Verified by

- \`npx vitest run tests/contexts tests/components/chat\` → **56 passed** across 5 files (15 history-migration + 4 scope-reset + 20 step-flow-context + 8 ChatModeTabs + 9 CollapsedTabsBanner)
- \`npx vitest run tests/api/chat-factual-grounding.test.ts tests/api/chat-tuning-update-target.test.ts tests/api/chat-page-context.test.ts tests/api/chat-unified-assistant.test.ts\` → **78 passed**
- \`npx vitest run tests/api/chat-tools.test.ts tests/api/chat-tray-reflection.test.ts\` → **40 passed**
- \`npx vitest run __tests__/ui/user-preferences.test.ts\` → **30 passed** (legacy self-contained migration tests survive the union change because they have their own local ChatMode type)
- \`npx tsc --noEmit\` filtered to changed files → **0 errors** (pre-existing repo-wide tsc errors unrelated to chat)
- \`npm run lint\` → **0 errors, 4425 warnings** (no new warnings from this slice — baseline matches Slice 2)
- \`npm run kb:fresh\` → green
- \`npx eslint\` on changed files → 0 errors, 2 pre-existing warnings

Promptfoo eval \`unified-assistant-spike\` **not re-run in this background worktree** (no API keys exported). Slice 2 already pinned the 7 scenarios including cohort-fan-out; Slice 3 is a pure UI/persistence rename with no system-prompt change, so re-running on hf-dev would confirm zero behavioural drift. Documented as an honest verification gap per \`.claude/rules/verify-before-fix.md\` — explicit \`Unable to verify here, will verify on hf-dev after deploy\` is acceptable evidence.

## Free-chat (no breadcrumb) case

Verified the page-context binding still works when the breadcrumb is empty: \`buildUnifiedAssistantPrompt\` with an empty \`entityContext\` emits the "No specific entity is in scope — use \`query_callers\` / \`query_specs\` / \`get_domain_info\` to find what the user is asking about" intent-routing fallback (covered by Scenario 5 in \`tests/api/chat-unified-assistant.test.ts\`). The Assistant remains useful with no course or caller in scope — it asks the user (or queries) before claiming any specific-entity fact.

## What this slice does NOT change

- Backend system prompts — the unified Assistant builder is unchanged.
- Tool palette — full ADMIN_TOOLS for ASSISTANT, narrow DEMO_TOOLS for DEMO. Same as Slice 2.
- \`factual-grounding-intercept\` — fires structurally on toolUsesInTurn, unchanged.
- DEMO / CALL / BUG / WIZARD / COURSE_REF route-level execution modes.

## Verdict — ready for tab-consolidation default?

**Ready.** Structural shape is clean (56/56 new + adjusted tests; 118/118 sibling guard tests; 0 tsc errors in changed files; 0 lint errors; kb:fresh green). The one refinement to surface for the operator review: the localStorage backward-compat read still merges DATA → ASSISTANT every load (not just once), which is slightly different from Slice 2's "merge once and never again" semantics. This is intentional — the Slice 3 in-memory shape no longer has DATA / TUNING / COURSE_MANAGE slots, so a leaked legacy bucket from an unmigrated client (e.g. an offline tab opened mid-deploy) MUST get pulled into ASSISTANT every read or it would be invisible. The user-visible side of idempotency (the merge banner) is still one-shot via the v1504 sentinel.

Closes #1504

## Test plan

- [ ] Deploy to hf-dev via \`/vm-cp\`; open chat panel and verify exactly 2 tabs render
- [ ] Verify the "Chat tabs simplified" banner appears once and stays dismissed across reloads
- [ ] Verify the Scope toggle is visible in Assistant tab even when neither caller nor playbook is in scope (PLAYBOOK button is disabled, LEARNER button is disabled, label clearly invites navigation)
- [ ] Switch to Demo tab and verify the Scope toggle disappears (DEMO has its own write-safety contract)
- [ ] Run \`npm run eval:wizard:v5:all\` on hf-dev VM with API keys configured and pin Scenario 7 (cohort fan-out) result in a PR comment before merging
- [ ] Manual end-to-end: open Assistant on \`/x/courses/<id>\` and verify the course breadcrumb feeds the intent-routing block (the AI biases toward course-edit tools)
- [ ] Manual end-to-end: open Assistant on \`/x/callers/<id>\` and verify the caller breadcrumb biases toward learner-read tools
- [ ] Confirm factual-grounding intercept still suppresses ungrounded learner-name claims from the Assistant tab