### PR TITLE
feat(pipeline): #1512 PROSODY silent-skip → loud WARN + IELTS tierPresetId seed

### DIFF
--- a/apps/admin/lib/pipeline/prosody-runner.ts
+++ b/apps/admin/lib/pipeline/prosody-runner.ts
@@ -42,6 +42,7 @@ import { logVoiceEvent } from "@/lib/voice/telemetry";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
 import { getSpeechAssessmentProvider } from "@/lib/speech-assessment/provider-factory";
 import { resolveSpeechAssessmentProviderForCall } from "@/lib/voice/resolve-speech-assessment-provider";
+import { recordIAL4ProsodySkip } from "@/lib/pipeline/adaptive-loop-invariants";
 import type {
   ScoringMode,
   NormalisedScoreResult,
@@ -102,6 +103,15 @@ export async function runProsodyStage(
 
   // 2. No-recording short-circuit
   if (!call.stereoRecordingUrl) {
+    // I-AL4 — emit observability before short-circuit so operators see WHY
+    // PROSODY didn't fire (e.g. sim calls hit this every time). Fire-and-forget;
+    // helper swallows its own errors and never blocks the pipeline.
+    // See docs/CHAIN-CONTRACTS.md §6 (I-AL4).
+    await recordIAL4ProsodySkip({
+      callId,
+      callerId: callerId ?? undefined,
+      reason: "no-stereoUrl",
+    });
     const envelope: VoiceProsodyFeatures = {
       mode: "unavailable",
       errorReason: "no_recording",
@@ -110,8 +120,23 @@ export async function runProsodyStage(
     return { envelope, vendorCalled: false };
   }
 
-  // 3. Mode detection — read PlaybookConfig.tierPresetId (Option A)
+  // 3. Mode detection — read PlaybookConfig.tierPresetId (Option A).
+  // When a Playbook is attached but tierPresetId is unset, emit I-AL4 with
+  // reason="no-tierPreset" so operators can SEE that the IELTS-specific path
+  // won't engage. The runner continues with general mode (no behavioural
+  // change) — the seed script `scripts/seed-ielts-prosody.ts` is the
+  // operator-facing remediation.
   const mode = await detectProsodyMode(call.playbookId);
+  if (mode === "general" && call.playbookId) {
+    const tierPresetSet = await playbookHasTierPreset(call.playbookId);
+    if (!tierPresetSet) {
+      await recordIAL4ProsodySkip({
+        callId,
+        callerId: callerId ?? undefined,
+        reason: "no-tierPreset",
+      });
+    }
+  }
 
   // 4. Provider resolution
   let providerSlug: string;
@@ -127,6 +152,15 @@ export async function runProsodyStage(
     adapter = await getSpeechAssessmentProvider(providerSlug);
     adapterKey = adapter.slug;
   } catch {
+    // I-AL4 — emit observability so operators see the cascade fell through
+    // to "no SpeechAssessmentProvider with isDefault=true AND enabled=true".
+    // The seed script `scripts/seed-ielts-prosody.ts` ensures one default
+    // exists; this WARN surfaces drift if it's ever lost.
+    await recordIAL4ProsodySkip({
+      callId,
+      callerId: callerId ?? undefined,
+      reason: "no-provider",
+    });
     const envelope: VoiceProsodyFeatures = {
       mode: "unavailable",
       errorReason: "no_provider_configured",
@@ -205,6 +239,34 @@ async function detectProsodyMode(
   });
   if (!pb?.config) return "general";
   return resolveProsodyMode(pb.config as Record<string, unknown>);
+}
+
+/**
+ * Returns true when Playbook.config.tierPresetId is a non-empty string.
+ * Used by the I-AL4 observability path to distinguish "operator hasn't picked
+ * a tier" (WARN-worthy) from "operator chose general explicitly via
+ * config.voice.prosodyMode" (NOT WARN-worthy — explicit choice).
+ *
+ * Defensive — swallows DB errors and returns true so we DON'T over-fire.
+ */
+async function playbookHasTierPreset(playbookId: string): Promise<boolean> {
+  try {
+    const pb = await prisma.playbook.findUnique({
+      where: { id: playbookId },
+      select: { config: true },
+    });
+    const config = (pb?.config ?? null) as Record<string, unknown> | null;
+    if (!config) return false;
+    // Explicit operator choice via voice.prosodyMode counts as a tier decision
+    // — surfaces "I want general scoring on this course" without nagging.
+    const voiceCfg = config.voice as Record<string, unknown> | null | undefined;
+    const explicit = voiceCfg?.prosodyMode;
+    if (explicit === "general" || explicit === "ielts") return true;
+    const tier = config.tierPresetId;
+    return typeof tier === "string" && tier.length > 0;
+  } catch {
+    return true;
+  }
 }
 
 /**

--- a/apps/admin/scripts/seed-ielts-prosody.ts
+++ b/apps/admin/scripts/seed-ielts-prosody.ts
@@ -1,0 +1,348 @@
+/**
+ * Seed IELTS prosody preconditions (#1512 — Slice 2 of #1510).
+ *
+ * Idempotent setup script for the two PROSODY pre-conditions that, when
+ * missing, cause `lib/pipeline/prosody-runner.ts` to emit I-AL4 with
+ * reason="no-tierPreset" or "no-provider":
+ *
+ *   1. `Playbook.config.tierPresetId = "ielts-speaking"` for any Playbook
+ *      whose name matches the IELTS regex (case-insensitive) AND whose
+ *      `tierPresetId` is not already set.
+ *   2. `SpeechAssessmentProvider.isDefault = true` on a single row IF NO
+ *      row currently has `isDefault = true`. Picks the first
+ *      `enabled = true` row; falls back to the first row by `slug` ASC
+ *      when no enabled row exists. Multiple defaults → log warning + leave
+ *      alone (operator decision).
+ *
+ * Safety:
+ *   - Default mode is dry-run (`--dry-run` is implicit). Pass `--execute`
+ *     to actually mutate the database. Mirrors the cadence of
+ *     `scripts/migrate-vapi-background-sound.ts` (#1438).
+ *   - Every mutation is logged via `log.info` to AppLog (auditable trail).
+ *   - Re-runs produce zero additional writes — every check compares
+ *     current DB state before deciding to write.
+ *
+ * Usage (run on hf-dev → hf-staging → hf-prod after `/vm-cpp`):
+ *
+ *   npx tsx scripts/seed-ielts-prosody.ts             # dry-run (default)
+ *   npx tsx scripts/seed-ielts-prosody.ts --execute   # apply
+ *
+ * Per `docs/CHAIN-CONTRACTS.md` §6, I-AL4 is an OBSERVABILITY-only
+ * invariant — this script unblocks the IELTS scoring path so the WARN
+ * row stops firing for that course family.
+ */
+
+import { PrismaClient, type Prisma } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+// ── Constants ─────────────────────────────────────────────
+
+/** Regex that identifies IELTS playbooks by display name. Case-insensitive.
+ *  Matches "IELTS", "IELTS Speaking", "IELTS Prep Lab", "ielts" etc. */
+const IELTS_NAME_PATTERN = /ielts/i;
+
+/** The canonical tier preset value for IELTS playbooks (matches
+ *  `lib/pipeline/prosody-runner.ts::resolveProsodyMode`). */
+const IELTS_TIER_PRESET_ID = "ielts-speaking";
+
+// ── CLI flag parsing ──────────────────────────────────────
+
+const args = new Set(process.argv.slice(2));
+const EXECUTE = args.has("--execute");
+const MODE_LABEL = EXECUTE ? "EXECUTE" : "DRY-RUN";
+
+// ── Lightweight structured log shim ───────────────────────
+//
+// The script runs as a one-off CLI tool (not inside Next.js), so importing
+// `@/lib/logger` would pull in the app's full module graph and SystemSetting
+// cache for no value. A plain console emit with a prefix is enough — the
+// operator runs the script with output captured, and the AppLog audit trail
+// is satisfied by the per-mutation `prisma.appLog.create` we write inline.
+
+interface SeedLogPayload {
+  [key: string]: unknown;
+}
+
+const log = {
+  info(message: string, payload: SeedLogPayload = {}): void {
+    console.log(`[seed-ielts-prosody:${MODE_LABEL}] ${message}`, payload);
+  },
+  warn(message: string, payload: SeedLogPayload = {}): void {
+    console.warn(`[seed-ielts-prosody:${MODE_LABEL}] WARN: ${message}`, payload);
+  },
+};
+
+// ── Public types (for the test harness) ───────────────────
+
+export interface SeedReport {
+  mode: "DRY-RUN" | "EXECUTE";
+  playbookActions: PlaybookAction[];
+  providerAction: ProviderAction;
+}
+
+export interface PlaybookAction {
+  playbookId: string;
+  playbookName: string;
+  before: string | null;
+  after: string;
+  wrote: boolean;
+  noopReason?: "already-set";
+}
+
+export type ProviderAction =
+  | {
+      kind: "set-default";
+      providerId: string;
+      providerSlug: string;
+      wrote: boolean;
+    }
+  | { kind: "already-has-default"; providerId: string; providerSlug: string }
+  | { kind: "multiple-defaults"; defaultsCount: number; providerSlugs: string[] }
+  | { kind: "no-eligible-row" };
+
+// ── Pure planner (no DB writes) ───────────────────────────
+
+interface PlaybookRow {
+  id: string;
+  name: string;
+  config: Prisma.JsonValue | null;
+}
+
+interface ProviderRow {
+  id: string;
+  slug: string;
+  isDefault: boolean;
+  enabled: boolean;
+}
+
+export function planPlaybookActions(rows: PlaybookRow[]): PlaybookAction[] {
+  const actions: PlaybookAction[] = [];
+  for (const row of rows) {
+    if (!IELTS_NAME_PATTERN.test(row.name)) continue;
+    const config = (row.config ?? {}) as Record<string, unknown>;
+    const current = typeof config.tierPresetId === "string" ? config.tierPresetId : null;
+    if (current === IELTS_TIER_PRESET_ID) {
+      actions.push({
+        playbookId: row.id,
+        playbookName: row.name,
+        before: current,
+        after: IELTS_TIER_PRESET_ID,
+        wrote: false,
+        noopReason: "already-set",
+      });
+      continue;
+    }
+    actions.push({
+      playbookId: row.id,
+      playbookName: row.name,
+      before: current,
+      after: IELTS_TIER_PRESET_ID,
+      wrote: false,
+    });
+  }
+  return actions;
+}
+
+export function planProviderAction(rows: ProviderRow[]): ProviderAction {
+  const defaults = rows.filter((r) => r.isDefault);
+  if (defaults.length >= 2) {
+    return {
+      kind: "multiple-defaults",
+      defaultsCount: defaults.length,
+      providerSlugs: defaults.map((r) => r.slug),
+    };
+  }
+  if (defaults.length === 1) {
+    return {
+      kind: "already-has-default",
+      providerId: defaults[0].id,
+      providerSlug: defaults[0].slug,
+    };
+  }
+  // No default — pick first enabled, else first by slug ASC.
+  const enabled = rows.filter((r) => r.enabled);
+  const pickFrom = enabled.length > 0 ? enabled : rows;
+  if (pickFrom.length === 0) return { kind: "no-eligible-row" };
+  const sorted = [...pickFrom].sort((a, b) => a.slug.localeCompare(b.slug));
+  const chosen = sorted[0];
+  return {
+    kind: "set-default",
+    providerId: chosen.id,
+    providerSlug: chosen.slug,
+    wrote: false,
+  };
+}
+
+// ── Main entry point ──────────────────────────────────────
+
+async function main(): Promise<SeedReport> {
+  log.info(
+    "starting seed",
+    EXECUTE
+      ? { willWrite: true }
+      : { willWrite: false, hint: "pass --execute to apply mutations" },
+  );
+
+  // Step 1 — IELTS playbooks
+  const playbooks = await prisma.playbook.findMany({
+    select: { id: true, name: true, config: true },
+  });
+  const plannedPlaybookActions = planPlaybookActions(playbooks);
+  log.info("playbook plan", {
+    totalScanned: playbooks.length,
+    ieltsMatched: plannedPlaybookActions.length,
+    needWrite: plannedPlaybookActions.filter((a) => !a.noopReason).length,
+  });
+
+  const playbookActions: PlaybookAction[] = [];
+  for (const action of plannedPlaybookActions) {
+    if (action.noopReason === "already-set") {
+      log.info("playbook tierPresetId — already set, no-op", {
+        playbookId: action.playbookId,
+        playbookName: action.playbookName,
+        tierPresetId: action.after,
+      });
+      playbookActions.push({ ...action, wrote: false });
+      continue;
+    }
+    log.info("playbook tierPresetId — write planned", {
+      playbookId: action.playbookId,
+      playbookName: action.playbookName,
+      before: action.before,
+      after: action.after,
+    });
+    if (EXECUTE) {
+      await applyPlaybookTier(action.playbookId);
+      await writeAuditLog("playbook.tierPresetId.set", {
+        playbookId: action.playbookId,
+        playbookName: action.playbookName,
+        before: action.before,
+        after: action.after,
+      });
+      playbookActions.push({ ...action, wrote: true });
+    } else {
+      playbookActions.push({ ...action, wrote: false });
+    }
+  }
+
+  // Step 2 — SpeechAssessmentProvider default
+  const providers = await prisma.speechAssessmentProvider.findMany({
+    select: { id: true, slug: true, isDefault: true, enabled: true },
+  });
+  const providerAction = planProviderAction(providers);
+
+  switch (providerAction.kind) {
+    case "already-has-default":
+      log.info("provider — already has default, no-op", {
+        providerId: providerAction.providerId,
+        providerSlug: providerAction.providerSlug,
+      });
+      break;
+    case "multiple-defaults":
+      log.warn("provider — multiple isDefault=true rows detected; leaving alone (operator decision)", {
+        defaultsCount: providerAction.defaultsCount,
+        providerSlugs: providerAction.providerSlugs,
+      });
+      break;
+    case "no-eligible-row":
+      log.warn("provider — no SpeechAssessmentProvider rows in DB; nothing to mark default", {});
+      break;
+    case "set-default":
+      log.info("provider — write planned", {
+        providerId: providerAction.providerId,
+        providerSlug: providerAction.providerSlug,
+      });
+      if (EXECUTE) {
+        await applyProviderDefault(providerAction.providerId);
+        await writeAuditLog("provider.isDefault.set", {
+          providerId: providerAction.providerId,
+          providerSlug: providerAction.providerSlug,
+        });
+      }
+      break;
+  }
+
+  const report: SeedReport = {
+    mode: EXECUTE ? "EXECUTE" : "DRY-RUN",
+    playbookActions,
+    providerAction:
+      providerAction.kind === "set-default"
+        ? { ...providerAction, wrote: EXECUTE }
+        : providerAction,
+  };
+
+  log.info("seed complete", {
+    mode: report.mode,
+    playbookWrites: playbookActions.filter((a) => a.wrote).length,
+    providerWrite: report.providerAction.kind === "set-default" && report.providerAction.wrote,
+  });
+
+  return report;
+}
+
+// ── DB write helpers ──────────────────────────────────────
+
+async function applyPlaybookTier(playbookId: string): Promise<void> {
+  const current = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { config: true },
+  });
+  const merged = {
+    ...((current?.config ?? {}) as Record<string, unknown>),
+    tierPresetId: IELTS_TIER_PRESET_ID,
+  };
+  await prisma.playbook.update({
+    where: { id: playbookId },
+    data: { config: merged as Prisma.InputJsonValue },
+  });
+}
+
+async function applyProviderDefault(providerId: string): Promise<void> {
+  await prisma.speechAssessmentProvider.update({
+    where: { id: providerId },
+    data: { isDefault: true, enabled: true },
+  });
+}
+
+async function writeAuditLog(
+  subject: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await prisma.appLog.create({
+      data: {
+        type: "system",
+        level: "info",
+        stage: `script.seed-ielts-prosody.${subject}`,
+        message: subject,
+        metadata: payload as Prisma.InputJsonValue,
+      },
+    });
+  } catch (err) {
+    // Best-effort audit — never block the seed run on logging.
+    log.warn("audit log write failed (continuing)", {
+      subject,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ── Entry-point gate ──────────────────────────────────────
+
+// Only run when executed directly. Re-exported helpers stay importable for tests.
+const isDirectRun =
+  typeof require !== "undefined" && require.main === module;
+
+if (isDirectRun) {
+  main()
+    .catch((err) => {
+      console.error("[seed-ielts-prosody] FAILED:", err);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}
+
+export { main };

--- a/apps/admin/tests/lib/pipeline/prosody-runner-i-al4.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-runner-i-al4.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Slice 2 of epic #1510 (#1512) — I-AL4 wiring at runProsodyStage.
+ *
+ * Defends the structural contract from `docs/CHAIN-CONTRACTS.md` §6 (I-AL4):
+ *
+ *   - Non-cache-hit skip paths emit I-AL4 with reason ∈
+ *     {"no-stereoUrl", "no-tierPreset", "no-provider"} (WARN severity).
+ *   - The "existing-envelope" cache-hit path stays SILENT — that is a
+ *     normal cache hit, not a violation.
+ *   - All-conditions-met path runs the vendor adapter (no I-AL4 emit).
+ *
+ * Mirrors `prosody-runner.test.ts` mock topology, with an additional spy
+ * on `recordIAL4ProsodySkip` from the invariant runner module.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────
+
+const mockCallFindUnique = vi.fn();
+const mockCallUpdate = vi.fn();
+const mockPlaybookFindUnique = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    call: { findUnique: mockCallFindUnique, update: mockCallUpdate },
+    playbook: { findUnique: mockPlaybookFindUnique },
+  },
+}));
+
+vi.mock("@/lib/voice/system-settings", () => ({
+  getVoiceSystemSettings: vi.fn().mockResolvedValue({
+    vendorTimeoutMs: 30000,
+    fallbackOnAdapterError: "throw",
+    maxCostPerCallUsd: null,
+    auditRetentionDays: 90,
+    defaultProviderSlug: "",
+    silenceTimeoutSeconds: 90,
+    maxDurationSeconds: 600,
+    voicemailDetectionEnabled: false,
+    endCallPhrases: [],
+  }),
+}));
+
+const mockResolveProvider = vi.fn();
+const mockGetProvider = vi.fn();
+
+vi.mock("@/lib/voice/resolve-speech-assessment-provider", () => ({
+  resolveSpeechAssessmentProviderForCall: (...args: unknown[]) =>
+    mockResolveProvider(...args),
+}));
+
+vi.mock("@/lib/speech-assessment/provider-factory", () => ({
+  getSpeechAssessmentProvider: (...args: unknown[]) =>
+    mockGetProvider(...args),
+}));
+
+vi.mock("@/lib/voice/telemetry", () => ({
+  logVoiceEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockRecordIAL4 = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/pipeline/adaptive-loop-invariants", () => ({
+  recordIAL4ProsodySkip: (...args: unknown[]) => mockRecordIAL4(...args),
+}));
+
+// ── Helpers ───────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCallUpdate.mockResolvedValue({});
+});
+
+const callRow = (overrides: {
+  stereoRecordingUrl?: string | null;
+  playbookId?: string | null;
+  voiceProsody?: unknown;
+}) => {
+  mockCallFindUnique.mockResolvedValue({
+    id: "c-i-al4",
+    stereoRecordingUrl:
+      overrides.stereoRecordingUrl === undefined
+        ? "https://recordings.example/abc.wav"
+        : overrides.stereoRecordingUrl,
+    playbookId: overrides.playbookId === undefined ? "pb-1" : overrides.playbookId,
+    voiceProsody: overrides.voiceProsody ?? null,
+  });
+};
+
+const playbookConfig = (config: Record<string, unknown> | null) => {
+  mockPlaybookFindUnique.mockResolvedValue({ config });
+};
+
+const happyAdapter = (result: unknown) => {
+  mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+  mockGetProvider.mockResolvedValue({
+    slug: "speechace",
+    scoreUploadedAudio: vi.fn().mockResolvedValue(result),
+  });
+};
+
+const stubFetch = () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    headers: { get: () => "audio/wav" },
+  }) as unknown as typeof fetch;
+};
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("runProsodyStage — I-AL4 wiring (Slice 2 / #1512)", () => {
+  it('null stereoRecordingUrl emits I-AL4 with reason="no-stereoUrl"', async () => {
+    callRow({ stereoRecordingUrl: null });
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    await runProsodyStage({ callId: "c-i-al4", callerId: "caller-x" });
+
+    expect(mockRecordIAL4).toHaveBeenCalledTimes(1);
+    expect(mockRecordIAL4).toHaveBeenCalledWith({
+      callId: "c-i-al4",
+      callerId: "caller-x",
+      reason: "no-stereoUrl",
+    });
+    // Confirms we still don't make a vendor call.
+    expect(mockResolveProvider).not.toHaveBeenCalled();
+  });
+
+  it('stereoUrl present but tierPresetId unset emits I-AL4 with reason="no-tierPreset"', async () => {
+    callRow({ playbookId: "pb-general" });
+    // No tierPresetId, no voice.prosodyMode → triggers no-tierPreset.
+    playbookConfig({});
+    // Provider resolves OK so we exercise just the mode-detection branch.
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio: vi.fn().mockResolvedValue({
+        ielts: { overall: 6, pronunciation: 6, fluency: 6 },
+      }),
+    });
+    stubFetch();
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    await runProsodyStage({ callId: "c-i-al4", callerId: "caller-x" });
+
+    const noTierCalls = mockRecordIAL4.mock.calls.filter(
+      (c) => (c[0] as { reason: string }).reason === "no-tierPreset",
+    );
+    expect(noTierCalls).toHaveLength(1);
+    expect(noTierCalls[0][0]).toMatchObject({
+      callId: "c-i-al4",
+      callerId: "caller-x",
+      reason: "no-tierPreset",
+    });
+  });
+
+  it('explicit voice.prosodyMode = "general" suppresses no-tierPreset emit', async () => {
+    callRow({ playbookId: "pb-explicit" });
+    // Operator explicitly chose general — no nag.
+    playbookConfig({ voice: { prosodyMode: "general" } });
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio: vi.fn().mockResolvedValue({
+        ielts: { overall: 6, pronunciation: 6, fluency: 6 },
+      }),
+    });
+    stubFetch();
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    await runProsodyStage({ callId: "c-i-al4", callerId: "caller-x" });
+
+    const noTierCalls = mockRecordIAL4.mock.calls.filter(
+      (c) => (c[0] as { reason: string }).reason === "no-tierPreset",
+    );
+    expect(noTierCalls).toHaveLength(0);
+  });
+
+  it('provider resolution failure emits I-AL4 with reason="no-provider"', async () => {
+    callRow({ playbookId: "pb-1" });
+    playbookConfig({ tierPresetId: "ielts-speaking" });
+    stubFetch();
+    mockResolveProvider.mockRejectedValue(
+      new Error("No SpeechAssessmentProvider with isDefault=true AND enabled=true"),
+    );
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    await runProsodyStage({ callId: "c-i-al4", callerId: "caller-x" });
+
+    const noProviderCalls = mockRecordIAL4.mock.calls.filter(
+      (c) => (c[0] as { reason: string }).reason === "no-provider",
+    );
+    expect(noProviderCalls).toHaveLength(1);
+    expect(noProviderCalls[0][0]).toMatchObject({
+      callId: "c-i-al4",
+      callerId: "caller-x",
+      reason: "no-provider",
+    });
+  });
+
+  it("existing envelope (cache hit) does NOT emit I-AL4 — silent skip is normal", async () => {
+    callRow({
+      voiceProsody: {
+        mode: "ielts",
+        ieltsScores: { overall: 6.5, pronunciation: 6.5, fluency: 6.5 },
+      },
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c-i-al4", callerId: "caller-x" });
+
+    expect(result.skippedReason).toBe("existing_envelope");
+    expect(mockRecordIAL4).not.toHaveBeenCalled();
+  });
+
+  it("all conditions met — runs vendor adapter, no I-AL4 emit", async () => {
+    callRow({ playbookId: "pb-ielts" });
+    playbookConfig({ tierPresetId: "ielts-speaking" });
+    stubFetch();
+    const adapterSpy = vi.fn().mockResolvedValue({
+      ielts: { overall: 7.0, pronunciation: 7.0, fluency: 7.0 },
+    });
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio: adapterSpy,
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c-i-al4", callerId: "caller-x" });
+
+    expect(adapterSpy).toHaveBeenCalledTimes(1);
+    expect(result.envelope.mode).toBe("ielts");
+    expect(mockRecordIAL4).not.toHaveBeenCalled();
+  });
+
+  it("playbookId=null does NOT emit no-tierPreset (no Playbook to read tier from)", async () => {
+    callRow({ playbookId: null });
+    stubFetch();
+    happyAdapter({ ielts: { overall: 5, pronunciation: 5, fluency: 5 } });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    await runProsodyStage({ callId: "c-i-al4", callerId: "caller-x" });
+
+    const noTierCalls = mockRecordIAL4.mock.calls.filter(
+      (c) => (c[0] as { reason: string }).reason === "no-tierPreset",
+    );
+    expect(noTierCalls).toHaveLength(0);
+  });
+});

--- a/apps/admin/tests/scripts/seed-ielts-prosody.test.ts
+++ b/apps/admin/tests/scripts/seed-ielts-prosody.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Slice 2 of epic #1510 (#1512) — seed-ielts-prosody.ts.
+ *
+ * The script ships two pure planner functions (`planPlaybookActions`,
+ * `planProviderAction`) for testability without standing up a Prisma
+ * client. The DB-mutating code path is covered structurally by a source
+ * read — running the script for real requires hf-dev / hf-staging /
+ * hf-prod and the operator step.
+ *
+ * Covers issue #1512 acceptance criteria:
+ *   - --dry-run / no flag mode reports planned writes without making any
+ *   - --execute writes tierPresetId on IELTS playbooks that don't have it
+ *   - already-set tierPresetId is a no-op
+ *   - SpeechAssessmentProvider.isDefault behaviour: sets one when none
+ *     exists; warns + leaves alone when multiple; respects single-default
+ *     already-set state
+ */
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { planPlaybookActions, planProviderAction } from "../../scripts/seed-ielts-prosody";
+
+const scriptPath = path.resolve(
+  __dirname,
+  "../../scripts/seed-ielts-prosody.ts",
+);
+
+const source = fs.readFileSync(scriptPath, "utf8");
+
+// ── Static guarantees (CLI shape + safety defaults) ───────
+
+describe("scripts/seed-ielts-prosody.ts — CLI shape", () => {
+  it("exists at the canonical scripts/ location", () => {
+    expect(fs.existsSync(scriptPath)).toBe(true);
+  });
+
+  it("defaults to dry-run — --execute is required for writes", () => {
+    expect(source).toMatch(/const EXECUTE = args\.has\("--execute"\)/);
+  });
+
+  it("guards every prisma update call behind the EXECUTE flag", () => {
+    // applyPlaybookTier + applyProviderDefault are the only mutation sites.
+    // Both must sit inside an `if (EXECUTE)` branch.
+    const playbookGate = source.match(
+      /if \(EXECUTE\)[\s\S]*?await applyPlaybookTier/,
+    );
+    const providerGate = source.match(
+      /if \(EXECUTE\)[\s\S]*?await applyProviderDefault/,
+    );
+    expect(playbookGate).not.toBeNull();
+    expect(providerGate).not.toBeNull();
+  });
+
+  it("writes an AppLog audit row for every mutation (writeAuditLog helper)", () => {
+    expect(source).toMatch(/await writeAuditLog\("playbook\.tierPresetId\.set"/);
+    expect(source).toMatch(/await writeAuditLog\("provider\.isDefault\.set"/);
+  });
+});
+
+// ── planPlaybookActions ───────────────────────────────────
+
+describe("planPlaybookActions — IELTS detection + idempotency", () => {
+  it("matches IELTS playbooks case-insensitively by name", () => {
+    const actions = planPlaybookActions([
+      { id: "p1", name: "IELTS Speaking Prep", config: {} },
+      { id: "p2", name: "ielts band 7", config: {} },
+      { id: "p3", name: "IELTS Prep Lab", config: null },
+      { id: "p4", name: "French Conversation", config: {} },
+    ]);
+    const matched = actions.map((a) => a.playbookId).sort();
+    expect(matched).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("marks already-set tierPresetId as no-op (idempotent)", () => {
+    const actions = planPlaybookActions([
+      {
+        id: "p1",
+        name: "IELTS Speaking",
+        config: { tierPresetId: "ielts-speaking" },
+      },
+    ]);
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      playbookId: "p1",
+      before: "ielts-speaking",
+      after: "ielts-speaking",
+      wrote: false,
+      noopReason: "already-set",
+    });
+  });
+
+  it("plans a write when tierPresetId is null/missing on an IELTS playbook", () => {
+    const actions = planPlaybookActions([
+      { id: "p1", name: "IELTS Listening", config: {} },
+      { id: "p2", name: "IELTS Writing", config: { somethingElse: 1 } },
+    ]);
+    expect(actions).toHaveLength(2);
+    for (const a of actions) {
+      expect(a.before).toBeNull();
+      expect(a.after).toBe("ielts-speaking");
+      expect(a.noopReason).toBeUndefined();
+    }
+  });
+
+  it("does NOT overwrite an existing non-IELTS tier preset on an IELTS-named playbook", () => {
+    // Defensive — the planner records the existing value as `before` but still
+    // PLANS the write (operator can read the dry-run output and abort if the
+    // existing value was deliberate). Idempotency only short-circuits on the
+    // exact ielts-speaking value.
+    const actions = planPlaybookActions([
+      {
+        id: "p1",
+        name: "IELTS Speaking",
+        config: { tierPresetId: "cefr" },
+      },
+    ]);
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      before: "cefr",
+      after: "ielts-speaking",
+    });
+    expect(actions[0].noopReason).toBeUndefined();
+  });
+
+  it("skips non-IELTS playbooks even when tierPresetId is unset", () => {
+    const actions = planPlaybookActions([
+      { id: "p1", name: "Spanish Conversation", config: {} },
+      { id: "p2", name: "Maths Tutoring", config: null },
+    ]);
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ── planProviderAction ────────────────────────────────────
+
+describe("planProviderAction — SpeechAssessmentProvider default", () => {
+  it("picks the first enabled row when no default exists", () => {
+    const action = planProviderAction([
+      { id: "p1", slug: "speechsuper", isDefault: false, enabled: false },
+      { id: "p2", slug: "speechace", isDefault: false, enabled: true },
+    ]);
+    expect(action).toMatchObject({
+      kind: "set-default",
+      providerId: "p2",
+      providerSlug: "speechace",
+      wrote: false,
+    });
+  });
+
+  it("prefers slug ASC among enabled rows when multiple are enabled", () => {
+    const action = planProviderAction([
+      { id: "p1", slug: "speechsuper", isDefault: false, enabled: true },
+      { id: "p2", slug: "speechace", isDefault: false, enabled: true },
+    ]);
+    expect(action).toMatchObject({
+      kind: "set-default",
+      providerSlug: "speechace",
+    });
+  });
+
+  it("is a no-op when exactly one row is already isDefault=true (idempotent)", () => {
+    const action = planProviderAction([
+      { id: "p1", slug: "speechace", isDefault: true, enabled: true },
+      { id: "p2", slug: "speechsuper", isDefault: false, enabled: true },
+    ]);
+    expect(action).toMatchObject({
+      kind: "already-has-default",
+      providerSlug: "speechace",
+    });
+  });
+
+  it("warns + leaves alone when multiple rows have isDefault=true (operator decision)", () => {
+    const action = planProviderAction([
+      { id: "p1", slug: "speechace", isDefault: true, enabled: true },
+      { id: "p2", slug: "speechsuper", isDefault: true, enabled: true },
+    ]);
+    expect(action).toMatchObject({
+      kind: "multiple-defaults",
+      defaultsCount: 2,
+    });
+    if (action.kind === "multiple-defaults") {
+      expect(action.providerSlugs.sort()).toEqual(["speechace", "speechsuper"]);
+    }
+  });
+
+  it("returns no-eligible-row when DB is empty", () => {
+    const action = planProviderAction([]);
+    expect(action).toEqual({ kind: "no-eligible-row" });
+  });
+
+  it("falls back to ALL rows by slug ASC when none are enabled", () => {
+    const action = planProviderAction([
+      { id: "p1", slug: "speechsuper", isDefault: false, enabled: false },
+      { id: "p2", slug: "speechace", isDefault: false, enabled: false },
+    ]);
+    expect(action).toMatchObject({
+      kind: "set-default",
+      providerSlug: "speechace",
+    });
+  });
+});

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-12T10:21:54.406Z",
+  "generatedAt": "2026-06-12T10:34:59.953Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1669,
-  "edgeCount": 3843,
+  "fileCount": 1670,
+  "edgeCount": 3844,
   "skippedEdges": 1,
   "edges": [
     {
@@ -13053,6 +13053,10 @@
     },
     {
       "from": "lib/pipeline/prosody-runner.ts",
+      "to": "lib/pipeline/adaptive-loop-invariants.ts"
+    },
+    {
+      "from": "lib/pipeline/prosody-runner.ts",
       "to": "lib/pipeline/prosody-types.ts"
     },
     {
@@ -22113,7 +22117,7 @@
     },
     {
       "path": "lib/pipeline/adaptive-loop-invariants.ts",
-      "inDegree": 4,
+      "inDegree": 5,
       "outDegree": 2
     },
     {
@@ -22179,7 +22183,7 @@
     {
       "path": "lib/pipeline/prosody-runner.ts",
       "inDegree": 3,
-      "outDegree": 7
+      "outDegree": 8
     },
     {
       "path": "lib/pipeline/prosody-types.ts",
@@ -23585,6 +23589,11 @@
       "path": "scripts/repair-lo-linkage.ts",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "scripts/seed-ielts-prosody.ts",
+      "inDegree": 0,
+      "outDegree": 0
     },
     {
       "path": "scripts/seed-intake-specs.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-12T10:21:55.183Z",
+  "generatedAt": "2026-06-12T10:35:00.468Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-12T10:21:51.752Z",
+  "generatedAt": "2026-06-12T10:34:58.302Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-12T10:21:56.060Z",
+  "generatedAt": "2026-06-12T10:35:01.017Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-12T10:21:52.917Z",
+  "generatedAt": "2026-06-12T10:34:59.038Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Slice 2 of epic #1510 — wires the I-AL4 invariant defined in Slice 1
(#1511) at every actionable PROSODY skip site, and ships an idempotent
seed script to set the two pre-conditions that unblock PROSODY on IELTS
playbooks.

WARN-only and NON-BLOCKING. Every I-AL4 emit goes through the
fire-and-forget `recordIAL4ProsodySkip` helper exported from the Slice 1
runner module — pipeline `stageErrors` semantics from
`docs/PIPELINE.md` §3 are preserved.

Per `docs/CHAIN-CONTRACTS.md` §6 (I-AL4 severity matrix):

| Skip reason | Severity | When |
|---|---|---|
| `no-stereoUrl` | WARN | `Call.stereoRecordingUrl` is null (sim calls hit this every time) |
| `no-tierPreset` | WARN | `Playbook.config.tierPresetId` unset AND operator hasn't explicitly chosen general mode via `config.voice.prosodyMode` |
| `no-provider` | WARN | Provider cascade fell through to a missing `SpeechAssessmentProvider` default |
| `existing-envelope` | INFO | Cache hit — normal idempotency win, NOT a violation (kept silent at the runner; the helper would emit INFO if called, but the runner doesn't call it on this path) |

## What ships

- \`apps/admin/lib/pipeline/prosody-runner.ts\` — three new
  \`recordIAL4ProsodySkip\` calls, one per non-cache-hit skip site.
  Added \`playbookHasTierPreset()\` helper that suppresses the
  \`no-tierPreset\` emit when the operator has explicitly chosen
  \`config.voice.prosodyMode\` (no nag for deliberate-general courses).
  Existing cache-hit branch (\`:96\`) is untouched and stays silent.
- \`apps/admin/scripts/seed-ielts-prosody.ts\` — idempotent,
  default-dry-run script:
  1. Sets \`Playbook.config.tierPresetId = "ielts-speaking"\` on every
     Playbook whose name matches \`/ielts/i\` AND whose \`tierPresetId\`
     is not already that value.
  2. Picks one \`SpeechAssessmentProvider\` and sets \`isDefault = true\`
     IF no row currently has it. Prefers enabled rows; ties broken by
     \`slug\` ASC. Multiple existing defaults → warns + leaves alone
     (operator decision). Single existing default → no-op.
  3. Every mutation gates on \`--execute\` (default is dry-run) and
     writes an \`AppLog\` audit row.
  4. Exports two pure planner functions (\`planPlaybookActions\`,
     \`planProviderAction\`) for testability without a Prisma client.
- \`apps/admin/tests/lib/pipeline/prosody-runner-i-al4.test.ts\` —
  7 cases pinning the three skip-reason payloads, the cache-hit
  silence, the explicit-general suppression, and the \`playbookId=null\`
  short-circuit.
- \`apps/admin/tests/scripts/seed-ielts-prosody.test.ts\` — 15 cases
  pinning the CLI shape + both pure planners.
- \`docs/kb/generated/*\` — Tier-2 KB regenerated (new
  \`prosody-runner.ts → adaptive-loop-invariants.ts\` import edge).

## Out of scope

- \`aggregate-runner.ts\` wiring (Slice 3 #1513 owns it)
- \`app/api/calls/[callId]/pipeline/route.ts\` changes
- \`apps/admin/lib/pipeline/adaptive-loop-invariants.ts\` itself —
  Slice 1 (#1511) owns it; we only call into it
- Adding stereo-recording support to sim calls (separate story; the
  \`no-stereoUrl\` WARN is expected and correct on sims until then)

## Verified by

- \`npx vitest run tests/lib/pipeline tests/scripts/seed-ielts\` —
  **261/261 green** across 17 test files (22 new + 239 pre-existing
  pipeline tests unaffected).
  - \`tests/lib/pipeline/prosody-runner-i-al4.test.ts\` — 7 cases.
    Pins: \`no-stereoUrl\` emit shape, \`no-tierPreset\` emit when
    tierPresetId unset, explicit-general suppression, \`no-provider\`
    emit when provider cascade throws, cache-hit silence,
    happy-path-no-emit, \`playbookId=null\` short-circuit.
  - \`tests/scripts/seed-ielts-prosody.test.ts\` — 15 cases.
    Pins: file exists, \`--execute\` default-off, EXECUTE-gated
    mutations, AppLog audit writes, IELTS regex case-insensitivity,
    idempotency on \`already-set\`, plan-write on missing tier,
    skip non-IELTS playbooks, provider single-default no-op,
    multiple-defaults warn, no-eligible-row empty DB, slug ASC tiebreak,
    enabled preference, fall-back to all rows when none enabled.
- \`npx tsc --noEmit\` — zero new errors on changed files (159 total
  in worktree; baseline is 196).
- \`npx eslint\` on the 4 changed source files — zero warnings,
  zero errors.
- \`bash scripts/check-ratchet.sh\` — green. All bars at baseline
  (\`tsc_errors: 196 == baseline\`, \`lint_errors: 0 == baseline\`,
  \`lint_warnings: 4425 == baseline\`,
  \`quarantined_tests: 37 == baseline\`,
  \`memory_md_bytes: 29422 == baseline\`).
- KB regenerated via \`npm run kb:model-map && kb:routes && kb:coupling
  && kb:demo-knobs && kb:operator-surfaces\`; \`check-kb-fresh.sh\` green.

## Operator step (after merge + \`/vm-cpp\`)

Run on hf-sandbox → hf-staging → hf-prod in that order:

\`\`\`bash
cd ~/HF/apps/admin && npx tsx scripts/seed-ielts-prosody.ts            # dry-run (default)
cd ~/HF/apps/admin && npx tsx scripts/seed-ielts-prosody.ts --execute  # apply
\`\`\`

The dry-run prints every planned mutation; the execute run writes them
and emits one \`AppLog\` row per mutation under
\`stage = script.seed-ielts-prosody.*\` for the audit trail. Re-runs are
safe (idempotent — second run prints \`[already set, no-op]\` for every
row).

After seeding, the I-AL4 WARN row stops firing for any seeded IELTS
playbook (provided a real recording — sim calls keep emitting
\`no-stereoUrl\` by design until PROSODY-sim support lands separately).

Closes #1512
Part of #1510