### PR TITLE
feat(pipeline): #1514 adaptive-loop canary E2E — proves the chain closes (WARN-only)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,87 @@
+name: Adaptive Loop canary
+
+# Story #1514 — Slice 4 of epic #1510. Nightly real-engine canary that
+# drives one call through the full pipeline (EXTRACT → LEARN → AGGREGATE
+# → COMPOSE) and asserts the chain closes. WARN-only by default — hard
+# fails only on EXTRACT-empty and COMPOSE invariant errors. Results land
+# in AppLog (subject: pipeline.canary.run) and surface on
+# /x/help/pipeline-health.
+#
+# Schedule: 03:00 UTC nightly. The cron uses UTC; pick a window away
+# from the main test workflow to avoid contention.
+#
+# Required secrets:
+#   - ANTHROPIC_API_KEY    real-engine LLM (canary self-skips without it)
+#   - INTERNAL_API_SECRET  service-to-service header for the pipeline
+#                          route (the same secret prod uses)
+#   - DATABASE_URL         points at the env we're canarying against
+#                          (hf_sandbox by default; flip to hf_staging
+#                          for a tighter gate later)
+#   - TEST_API_URL         the Cloud Run dev/staging URL the canary
+#                          POSTs into
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      target_env:
+        description: "Target environment to canary"
+        type: choice
+        default: "dev"
+        options:
+          - dev
+          - staging
+
+env:
+  NODE_VERSION: "20"
+
+jobs:
+  canary:
+    name: Adaptive Loop canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: apps/admin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: apps/admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Run canary (warn-only, against ${{ inputs.target_env || 'dev' }})
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
+          # DATABASE_URL points at the same DB the target Cloud Run
+          # service binds (hf_sandbox for DEV; hf_staging for STAGING).
+          # See `docs/CLOUD-DEPLOYMENT.md` for the secret mapping.
+          DATABASE_URL: ${{ secrets.DATABASE_URL_CANARY }}
+          TEST_API_URL: ${{ secrets.CANARY_API_URL }}
+          # Default to WARN-only for the first 2 weeks of observation
+          # per the epic plan. Flip to "false" via workflow_dispatch
+          # input once G9 / G2 / G3 dependency stories land.
+          HF_CANARY_WARN_ONLY: "true"
+        run: npm run test:canary
+
+      - name: Upload vitest output as artefact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-vitest-output
+          path: apps/admin/test-results/**
+          retention-days: 14
+          if-no-files-found: ignore

--- a/apps/admin/app/x/help/pipeline-health/page.tsx
+++ b/apps/admin/app/x/help/pipeline-health/page.tsx
@@ -114,6 +114,35 @@ function formatPayload(payload: unknown): string {
   }
 }
 
+/**
+ * Latest `pipeline.canary.run` row — written by the #1514 canary E2E
+ * after each run (nightly via `.github/workflows/canary.yml`, or
+ * ad-hoc via `npm run test:canary`). Renders the gate-by-gate verdict
+ * so an operator can confirm at a glance "did the loop close last
+ * night?" without digging through AppLog.
+ */
+async function loadLatestCanaryRun(): Promise<{
+  createdAt: Date;
+  level: string | null;
+  message: string | null;
+  metadata: unknown;
+} | null> {
+  try {
+    return await prisma.appLog.findFirst({
+      where: { stage: "pipeline.canary.run" },
+      orderBy: { createdAt: "desc" },
+      select: {
+        createdAt: true,
+        level: true,
+        message: true,
+        metadata: true,
+      },
+    });
+  } catch {
+    return null;
+  }
+}
+
 export default async function PipelineHealthPage() {
   const session = await auth();
   if (!session) redirect("/login");
@@ -122,6 +151,22 @@ export default async function PipelineHealthPage() {
 
   const rows = await loadAggregate();
   const seen = new Set(rows.map((r) => r.invariantId));
+  const latestCanary = await loadLatestCanaryRun();
+  const canaryMeta =
+    (latestCanary?.metadata as
+      | {
+          passed?: number;
+          failed?: number;
+          warns?: number;
+          gateResults?: Array<{
+            gate: string;
+            outcome: string;
+            detail: string;
+          }>;
+          warnOnly?: boolean;
+        }
+      | null
+      | undefined) ?? null;
 
   return (
     <main className="hf-page">
@@ -179,6 +224,61 @@ export default async function PipelineHealthPage() {
               ))}
             </tbody>
           </table>
+        )}
+      </section>
+
+      <section className="hf-card">
+        <h2 className="hf-section-title">Latest canary run</h2>
+        <p className="hf-section-desc">
+          The Adaptive Loop canary E2E (story <code>#1514</code>) drives a
+          real-engine call through EXTRACT → LEARN → AGGREGATE → COMPOSE and
+          asserts the chain closes. Hard FAILs block deploy; WARNs surface
+          the dependency stories (G9 / #1515 and G2 / #1516). Schedule:
+          nightly via <code>.github/workflows/canary.yml</code>; ad-hoc via{" "}
+          <code>npm run test:canary</code>.
+        </p>
+        {!latestCanary ? (
+          <div className="hf-empty">
+            <p>No canary run recorded yet.</p>
+            <p className="hf-text-xs hf-text-muted">
+              Run <code>npm run test:canary</code> with{" "}
+              <code>ANTHROPIC_API_KEY</code> set, or wait for the nightly
+              workflow to land its first result.
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="hf-text-xs hf-text-muted">
+              {latestCanary.createdAt.toISOString()} ·{" "}
+              <code>{latestCanary.level ?? "info"}</code> ·{" "}
+              {latestCanary.message ?? "(no summary)"}
+              {canaryMeta?.warnOnly ? " · warn-only mode" : ""}
+            </p>
+            {canaryMeta?.gateResults && canaryMeta.gateResults.length > 0 && (
+              <table className="hf-help-demos-table">
+                <thead>
+                  <tr>
+                    <th>Gate</th>
+                    <th>Outcome</th>
+                    <th>Detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {canaryMeta.gateResults.map((g) => (
+                    <tr key={g.gate}>
+                      <td>
+                        <code>{g.gate}</code>
+                      </td>
+                      <td>
+                        <code>{g.outcome}</code>
+                      </td>
+                      <td className="hf-text-xs">{g.detail}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </>
         )}
       </section>
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -46,6 +46,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:canary": "vitest run --config vitest.integration.config.ts tests/integration/journey/adaptive-loop-canary.integration.test.ts",
     "test:e2e": "NODE_ENV=test playwright test",
     "test:e2e:ui": "NODE_ENV=test playwright test --ui",
     "test:e2e:debug": "NODE_ENV=test playwright test --debug",

--- a/apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts
+++ b/apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Adaptive Loop Canary — #1514 Slice 4 of epic #1510.
+ *
+ * THE PROOF GATE. Drives a real-engine call through the full pipeline and
+ * asserts the chain closes:
+ *
+ *   EXTRACT → MEMORIES (LEARN) → AGGREGATE → CallerTarget → COMPOSE
+ *
+ * **Gate classification:**
+ *
+ * | Assertion | Gate | Action on failure |
+ * | --- | --- | --- |
+ * | EXTRACT: `CallScore.length >= 10` | hard FAIL | blocks deploy |
+ * | LEARN: `CallerMemory.length > 0` (G9) | WARN (env-gated) | surfaces #1515 |
+ * | AGGREGATE: `skill_* CallerTarget.currentScore > 0` (G2) | WARN | surfaces #1516 |
+ * | COMPOSE: `key_memories` non-null | WARN | downstream of G9 |
+ * | COMPOSE: `invariantErrors` empty | hard FAIL | I-C invariants tripped |
+ *
+ * Hard FAILs use vanilla `expect()`. WARN-gated assertions use
+ * `expect.soft()` so the test process exits 0 with the gap surfaced in
+ * the AppLog dashboard row (`pipeline.canary.run`). Flip
+ * `HF_CANARY_WARN_ONLY=false` to promote the WARN gates to hard fails
+ * (planned after the 2-week observation window per the epic plan).
+ *
+ * **Constraints honoured (per #1514 brief):**
+ *
+ *  - PURE READ + ASSERT — never modifies pipeline runner or invariant
+ *    module.
+ *  - I-AL3 is informational only — known broken until #1519 ships; the
+ *    canary observes via the AppLog count but never blocks on it.
+ *  - Fixture cleanup is non-negotiable — `cleanupCanaryFixture` runs in
+ *    `afterAll` regardless of test outcome.
+ *
+ * **Run modes:**
+ *
+ *  - Local (against `npm run dev`):
+ *      `TEST_API_URL=http://localhost:3000 ANTHROPIC_API_KEY=… \
+ *       npm run test:canary`
+ *  - hf-dev VM (preferred): SSH to the VM, then run the same command.
+ *  - Without `ANTHROPIC_API_KEY`: the test SKIPS cleanly with a
+ *    friendly message. The CI workflow only schedules the run on
+ *    branches with the secret available.
+ *
+ * Companion: `tests/integration/journey/canary-fixture.integration.test.ts`
+ * pins the fixture itself.
+ *
+ * @see docs/CHAIN-CONTRACTS.md §6 — invariant contracts
+ * @see scripts/seed-system-behavior-defaults.ts — SYSTEM cascade root
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PrismaClient } from "@prisma/client";
+
+import {
+  bootstrapCanaryFixture,
+  cleanupCanaryFixture,
+  CANARY_TRANSCRIPT,
+  type CanaryFixture,
+} from "./canary-fixture";
+
+const prisma = new PrismaClient();
+
+const API_BASE_URL = process.env.TEST_API_URL || "http://localhost:3000";
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
+
+const WARN_ONLY = process.env.HF_CANARY_WARN_ONLY !== "false"; // default true
+
+const EXTRACT_FLOOR = 10; // canonical lower bound; not 50+ to leave room
+                          // for spec evolution
+
+let fixture: CanaryFixture | null = null;
+let canRun = false;
+
+interface CanaryGateRecord {
+  gate: string;
+  outcome: "PASS" | "WARN" | "FAIL" | "SKIP";
+  detail: string;
+}
+
+const gateResults: CanaryGateRecord[] = [];
+
+function recordGate(
+  gate: string,
+  outcome: CanaryGateRecord["outcome"],
+  detail: string,
+): void {
+  gateResults.push({ gate, outcome, detail });
+}
+
+beforeAll(async () => {
+  if (!ANTHROPIC_API_KEY) {
+    console.warn(
+      "[canary] ANTHROPIC_API_KEY not set — skipping real-engine canary. " +
+        "The fixture self-tests still run; this case requires a live LLM.",
+    );
+    return;
+  }
+
+  // Probe the server before touching the DB.
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) {
+      console.warn(
+        `[canary] ${API_BASE_URL}/api/health returned ${res.status} — skipping. ` +
+          "Start the server with `npm run dev` (or set TEST_API_URL to a live env).",
+      );
+      return;
+    }
+  } catch (err) {
+    console.warn(
+      `[canary] ${API_BASE_URL} unreachable (${(err as Error).message}) — skipping.`,
+    );
+    return;
+  }
+
+  if (!INTERNAL_API_SECRET) {
+    console.warn(
+      "[canary] INTERNAL_API_SECRET not set — pipeline route requires it for " +
+        "the service-to-service path. Skipping.",
+    );
+    return;
+  }
+
+  await cleanupCanaryFixture(prisma);
+  fixture = await bootstrapCanaryFixture(prisma);
+  canRun = true;
+});
+
+afterAll(async () => {
+  // Cleanup is non-negotiable per the #1514 brief — runs regardless of
+  // test outcome.
+  try {
+    if (fixture) {
+      await cleanupCanaryFixture(prisma);
+    }
+  } finally {
+    // Write one AppLog row summarising the run so the
+    // /x/help/pipeline-health "Latest canary run" panel can render it.
+    if (canRun) {
+      const passed = gateResults.filter((g) => g.outcome === "PASS").length;
+      const failed = gateResults.filter((g) => g.outcome === "FAIL").length;
+      const warns = gateResults.filter((g) => g.outcome === "WARN").length;
+      try {
+        // Prisma's `Json` input type doesn't admit a wider Record<string,
+        // unknown>; cast the structured payload through a generic
+        // marshal step before handing it to the create() call.
+        const metadataPayload = JSON.parse(
+          JSON.stringify({
+            passed,
+            failed,
+            warns,
+            gateResults,
+            warnOnly: WARN_ONLY,
+            apiBaseUrl: API_BASE_URL,
+            observedAt: new Date().toISOString(),
+          }),
+        );
+        await prisma.appLog.create({
+          data: {
+            type: "system",
+            stage: "pipeline.canary.run",
+            level: failed > 0 ? "error" : warns > 0 ? "warn" : "info",
+            message: `Adaptive Loop canary — passed=${passed} failed=${failed} warns=${warns}`,
+            metadata: metadataPayload,
+          },
+        });
+      } catch (err) {
+        console.warn(
+          `[canary] Could not write AppLog summary: ${(err as Error).message}`,
+        );
+      }
+    }
+    await prisma.$disconnect();
+  }
+});
+
+describe("#1514 Adaptive Loop canary — proves the chain closes", () => {
+  it("real-engine call: EXTRACT → MEMORIES → AGGREGATE → CallerTarget → COMPOSE", async () => {
+    if (!canRun || !fixture) {
+      recordGate(
+        "preflight",
+        "SKIP",
+        "ANTHROPIC_API_KEY / server / INTERNAL_API_SECRET prerequisites not met",
+      );
+      console.warn("[canary] preflight failed — see beforeAll output");
+      return;
+    }
+
+    // ARRANGE — create the Call row directly. We mirror the shape the
+    // production `createCallEnteringPipeline` builder writes (#1333 chain
+    // contract Link 3): callerId + playbookId + curriculumModuleId all
+    // populated. Skipping the builder lets the canary test stay PURE READ
+    // on pipeline code while still producing the FK triple the pipeline
+    // expects.
+    const call = await prisma.call.create({
+      data: {
+        source: "canary-1514",
+        externalId: `canary-1514-${Date.now()}`,
+        callerId: fixture.callerId,
+        playbookId: fixture.playbookId,
+        curriculumModuleId: fixture.moduleId,
+        transcript: CANARY_TRANSCRIPT,
+      },
+    });
+
+    const callStartedAt = call.createdAt;
+
+    // ACT — trigger the pipeline via the same service-to-service path
+    // the VAPI webhook uses. Mode "prompt" runs all stages including
+    // COMPOSE, which is the gate the canary cares about most.
+    const pipelineRes = await fetch(
+      `${API_BASE_URL}/api/calls/${call.id}/pipeline`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-internal-secret": INTERNAL_API_SECRET,
+        },
+        body: JSON.stringify({
+          callerId: fixture.callerId,
+          mode: "prompt",
+          engine: "claude",
+          force: true,
+        }),
+        // The pipeline is allowed to take a while (real LLM + multi-stage).
+        signal: AbortSignal.timeout(180_000),
+      },
+    );
+
+    const pipelineBody = await pipelineRes.json().catch(() => ({}));
+
+    // The pipeline route returns 200 even for partial failures — it
+    // surfaces them in `summary.composeFailed`. So we don't fail on a
+    // non-200 unconditionally; we attach it to the FAIL detail.
+    const pipelineOk = pipelineRes.ok;
+    recordGate(
+      "pipeline.http",
+      pipelineOk ? "PASS" : "FAIL",
+      `status=${pipelineRes.status} ok=${pipelineOk} composeFailed=${pipelineBody?.data?.composeFailed ?? "n/a"}`,
+    );
+
+    // ASSERT — read the post-state. Even a failed COMPOSE leaves
+    // EXTRACT/AGGREGATE rows behind in the happy paths we want to verify.
+
+    // ── Gate 1: EXTRACT — CallScore rows ─────────────────────
+    const scores = await prisma.callScore.findMany({
+      where: { callId: call.id },
+      select: { id: true, parameterId: true, scoredBy: true },
+    });
+    const scoreCount = scores.length;
+    const hardFail1 = scoreCount < EXTRACT_FLOOR;
+    recordGate(
+      "extract.scores",
+      hardFail1 ? "FAIL" : "PASS",
+      `CallScore count=${scoreCount} floor=${EXTRACT_FLOOR}`,
+    );
+    // HARD FAIL — pipeline is broken if EXTRACT didn't write anything.
+    expect(
+      scoreCount,
+      `EXTRACT wrote ${scoreCount} CallScore rows; expected >= ${EXTRACT_FLOOR}`,
+    ).toBeGreaterThanOrEqual(EXTRACT_FLOOR);
+
+    // ── Gate 2 (WARN — G9 dependency): LEARN — CallerMemory ──
+    const memories = await prisma.callerMemory.findMany({
+      where: {
+        callerId: fixture.callerId,
+        createdAt: { gte: callStartedAt },
+      },
+      select: { id: true, key: true, category: true },
+    });
+    const memoryCount = memories.length;
+    const memoriesOk = memoryCount > 0;
+    recordGate(
+      "learn.memories",
+      memoriesOk ? "PASS" : "WARN",
+      `CallerMemory count=${memoryCount}; > 0 expected. Tied to #1515.`,
+    );
+    if (WARN_ONLY) {
+      expect
+        .soft(
+          memoryCount,
+          `LEARN produced ${memoryCount} CallerMemory rows; expected > 0. Surfaces G9 / #1515.`,
+        )
+        .toBeGreaterThan(0);
+    } else {
+      expect(memoryCount).toBeGreaterThan(0);
+    }
+
+    // ── Gate 3 (WARN — G2 dependency): AGGREGATE — CallerTarget ──
+    const skillTargets = await prisma.callerTarget.findMany({
+      where: {
+        callerId: fixture.callerId,
+        parameterId: { startsWith: "skill_" },
+        currentScore: { not: null },
+      },
+      select: { id: true, parameterId: true, currentScore: true },
+    });
+    const skillTargetCount = skillTargets.length;
+    const targetsOk = skillTargetCount > 0;
+    recordGate(
+      "aggregate.skillTargets",
+      targetsOk ? "PASS" : "WARN",
+      `CallerTarget(skill_*, currentScore!=null) count=${skillTargetCount}; > 0 expected. Tied to #1516.`,
+    );
+    if (WARN_ONLY) {
+      expect
+        .soft(
+          skillTargetCount,
+          `AGGREGATE produced ${skillTargetCount} skill_* CallerTarget rows; expected > 0. Surfaces G2 / #1516.`,
+        )
+        .toBeGreaterThan(0);
+    } else {
+      expect(skillTargetCount).toBeGreaterThan(0);
+    }
+
+    // ── Gate 4 (WARN — downstream of G9): COMPOSE — key_memories ──
+    const composed = await prisma.composedPrompt.findFirst({
+      where: { callerId: fixture.callerId, status: "active" },
+      orderBy: { composedAt: "desc" },
+      select: { id: true, inputs: true },
+    });
+    const composedExists = !!composed;
+    const inputs = (composed?.inputs as Record<string, unknown> | null) ?? {};
+    const keyMemories = inputs.key_memories;
+    const keyMemoriesArray = Array.isArray(keyMemories) ? keyMemories : [];
+    const composeKeyMemoriesOk = composedExists && keyMemoriesArray.length > 0;
+    recordGate(
+      "compose.keyMemories",
+      composeKeyMemoriesOk ? "PASS" : "WARN",
+      `ComposedPrompt=${composedExists ? "present" : "missing"}; key_memories len=${keyMemoriesArray.length}`,
+    );
+    if (WARN_ONLY) {
+      expect
+        .soft(
+          composedExists,
+          "COMPOSE produced no active ComposedPrompt for the canary caller.",
+        )
+        .toBe(true);
+      expect
+        .soft(
+          keyMemoriesArray.length,
+          `ComposedPrompt.inputs.key_memories is empty (len=${keyMemoriesArray.length}). Downstream of G9.`,
+        )
+        .toBeGreaterThan(0);
+    } else {
+      expect(composedExists).toBe(true);
+      expect(keyMemoriesArray.length).toBeGreaterThan(0);
+    }
+
+    // ── Gate 5: COMPOSE invariant errors (HARD FAIL) ─────────
+    const invariantErrors =
+      (inputs.invariantErrors as unknown[] | undefined) ?? [];
+    recordGate(
+      "compose.invariantErrors",
+      invariantErrors.length === 0 ? "PASS" : "FAIL",
+      `invariantErrors count=${invariantErrors.length}`,
+    );
+    expect(
+      invariantErrors,
+      `COMPOSE tripped invariant errors: ${JSON.stringify(invariantErrors)}`,
+    ).toEqual([]);
+
+    // ── Observability: count I-AL3 emits since the canary's call started ──
+    // This is informational only — I-AL3 is known-broken until #1519
+    // ships (the ContractRegistry.get typo). We log the count to the
+    // AppLog summary row so trend-watchers can see it drop after #1519.
+    const ial3Count = await prisma.appLog.count({
+      where: {
+        stage: "pipeline.invariant.i-al3",
+        createdAt: { gte: callStartedAt },
+      },
+    });
+    recordGate(
+      "observe.iAL3",
+      "PASS",
+      `I-AL3 emits since call start: ${ial3Count}. Known-broken until #1519.`,
+    );
+  });
+
+  it("mock-engine call: EXTRACT writes scores but NOT memories (by design)", async () => {
+    if (!canRun || !fixture) {
+      console.warn("[canary] preflight failed — skipping mock-engine case");
+      return;
+    }
+
+    // Pin the route.ts:1029-1031 mock-engine carve-out: I-AL1 must NOT
+    // fire for a mock call, even though the transcript is long enough to
+    // pass the 200-char threshold. The CallScore.scoredBy marker
+    // `mock_batched_v1` is what the invariant classifier reads.
+    const mockCall = await prisma.call.create({
+      data: {
+        source: "canary-1514-mock",
+        externalId: `canary-1514-mock-${Date.now()}`,
+        callerId: fixture.callerId,
+        playbookId: fixture.playbookId,
+        curriculumModuleId: fixture.moduleId,
+        transcript: CANARY_TRANSCRIPT,
+      },
+    });
+
+    const startedAt = mockCall.createdAt;
+
+    const res = await fetch(
+      `${API_BASE_URL}/api/calls/${mockCall.id}/pipeline`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-internal-secret": INTERNAL_API_SECRET,
+        },
+        body: JSON.stringify({
+          callerId: fixture.callerId,
+          mode: "prep",
+          engine: "mock",
+          force: true,
+        }),
+        signal: AbortSignal.timeout(60_000),
+      },
+    );
+
+    // Even mock can return non-200 if upstream stages fail for unrelated
+    // reasons. We tolerate that for this case — what matters is the
+    // mock-engine carve-out marker.
+    const mockOk = res.ok;
+    const mockScores = await prisma.callScore.findMany({
+      where: { callId: mockCall.id },
+      select: { scoredBy: true, parameterId: true },
+    });
+    const mockMarked = mockScores.filter((s) =>
+      (s.scoredBy ?? "").startsWith("mock_"),
+    );
+
+    // Mock-engine writes scores with the `mock_batched_v1` marker —
+    // verified at route.ts:1051 / 1072.
+    recordGate(
+      "mock.scoredByMarker",
+      mockMarked.length > 0 ? "PASS" : "WARN",
+      `mock_batched_v1 scoredBy rows=${mockMarked.length} / total=${mockScores.length} httpOk=${mockOk}`,
+    );
+
+    if (mockMarked.length === 0) {
+      console.warn(
+        "[canary] mock-engine wrote zero mock_-prefixed CallScore rows. " +
+          "This is unusual but not a chain failure; the carve-out cannot be " +
+          "asserted without the marker.",
+      );
+      return;
+    }
+
+    // CONTRACT: mock engine MUST NOT write CallerMemory rows.
+    // I-AL1 is suppressed by the classifier when only mock_ rows are
+    // present, so this assertion is the canary's structural pin of the
+    // route.ts:1029-1031 design.
+    const mockMemories = await prisma.callerMemory.count({
+      where: {
+        callerId: fixture.callerId,
+        createdAt: { gte: startedAt },
+      },
+    });
+
+    recordGate(
+      "mock.zeroMemories",
+      mockMemories === 0 ? "PASS" : "FAIL",
+      `mock-engine memory writes=${mockMemories}; expected exactly 0`,
+    );
+    expect(
+      mockMemories,
+      `Mock engine wrote ${mockMemories} CallerMemory rows; expected 0 (route.ts:1029-1031 carve-out broken).`,
+    ).toBe(0);
+  });
+});

--- a/apps/admin/tests/integration/journey/canary-fixture.integration.test.ts
+++ b/apps/admin/tests/integration/journey/canary-fixture.integration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Canary fixture self-tests — #1514 Slice 4 of epic #1510.
+ *
+ * Pins the contract of `bootstrapCanaryFixture` + `cleanupCanaryFixture`
+ * so the proof gate (`adaptive-loop-canary.integration.test.ts`) never
+ * relies on a fixture that silently no-ops or leaks rows between runs.
+ *
+ * Strictly DB-only — no pipeline, no HTTP, no AI. The fixture itself is
+ * the unit under test.
+ *
+ * Run via:
+ *   cd apps/admin && npm run test:integration -- tests/integration/journey/canary-fixture
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PrismaClient } from "@prisma/client";
+
+import {
+  bootstrapCanaryFixture,
+  cleanupCanaryFixture,
+  CANARY_PREFIX,
+  CANARY_TRANSCRIPT,
+} from "./canary-fixture";
+
+const prisma = new PrismaClient();
+
+beforeAll(async () => {
+  // Ensure a clean slate so the first test's "fresh bootstrap" case is
+  // genuinely fresh.
+  await cleanupCanaryFixture(prisma);
+});
+
+afterAll(async () => {
+  await cleanupCanaryFixture(prisma);
+  await prisma.$disconnect();
+});
+
+describe("#1514 canary fixture — self-tests", () => {
+  it("creates the expected Domain / Subject / Playbook / Curriculum / Module / Caller / CallerPlaybook chain", async () => {
+    const fx = await bootstrapCanaryFixture(prisma);
+
+    expect(fx.domainId).toBeTruthy();
+    expect(fx.subjectId).toBeTruthy();
+    expect(fx.curriculumId).toBeTruthy();
+    expect(fx.moduleId).toBeTruthy();
+    expect(fx.playbookId).toBeTruthy();
+    expect(fx.callerId).toBeTruthy();
+
+    // Playbook is PUBLISHED + tier preset set (so PROSODY's no-tierPreset
+    // skip reason cannot fire on the canary path).
+    const pb = await prisma.playbook.findUnique({
+      where: { id: fx.playbookId },
+      select: { status: true, config: true, domainId: true },
+    });
+    expect(pb?.status).toBe("PUBLISHED");
+    expect(pb?.domainId).toBe(fx.domainId);
+    expect(
+      (pb?.config as Record<string, unknown> | null)?.tierPresetId,
+    ).toBe("ielts-speaking");
+
+    // Curriculum is linked to the playbook via the canonical primary join.
+    const link = await prisma.playbookCurriculum.findUnique({
+      where: {
+        playbookId_curriculumId: {
+          playbookId: fx.playbookId,
+          curriculumId: fx.curriculumId,
+        },
+      },
+      select: { role: true },
+    });
+    expect(link?.role).toBe("primary");
+
+    // Module belongs to the curriculum.
+    const mod = await prisma.curriculumModule.findUnique({
+      where: { id: fx.moduleId },
+      select: { curriculumId: true, slug: true },
+    });
+    expect(mod?.curriculumId).toBe(fx.curriculumId);
+    expect(mod?.slug).toContain(CANARY_PREFIX);
+
+    // Caller is enrolled in the playbook as ACTIVE + default.
+    const enroll = await prisma.callerPlaybook.findUnique({
+      where: {
+        callerId_playbookId: {
+          callerId: fx.callerId,
+          playbookId: fx.playbookId,
+        },
+      },
+      select: { status: true, isDefault: true },
+    });
+    expect(enroll?.status).toBe("ACTIVE");
+    expect(enroll?.isDefault).toBe(true);
+  });
+
+  it("cleanupCanaryFixture removes every fixture row except shared SYSTEM defaults", async () => {
+    await bootstrapCanaryFixture(prisma);
+    await cleanupCanaryFixture(prisma);
+
+    // Caller / Playbook / Curriculum / Subject / Domain are all gone.
+    const caller = await prisma.caller.findUnique({
+      where: { externalId: `${CANARY_PREFIX}-caller` },
+    });
+    expect(caller).toBeNull();
+
+    const playbook = await prisma.playbook.findFirst({
+      where: { name: `${CANARY_PREFIX}-playbook` },
+    });
+    expect(playbook).toBeNull();
+
+    const curriculum = await prisma.curriculum.findUnique({
+      where: { slug: `${CANARY_PREFIX}-curriculum` },
+    });
+    expect(curriculum).toBeNull();
+
+    const subject = await prisma.subject.findUnique({
+      where: { slug: `${CANARY_PREFIX}-subject` },
+    });
+    expect(subject).toBeNull();
+
+    const domain = await prisma.domain.findUnique({
+      where: { slug: `${CANARY_PREFIX}-domain` },
+    });
+    expect(domain).toBeNull();
+  });
+
+  it("bootstrap is idempotent — re-running yields the same IDs", async () => {
+    const first = await bootstrapCanaryFixture(prisma);
+    const second = await bootstrapCanaryFixture(prisma);
+
+    expect(second.domainId).toBe(first.domainId);
+    expect(second.subjectId).toBe(first.subjectId);
+    expect(second.curriculumId).toBe(first.curriculumId);
+    expect(second.moduleId).toBe(first.moduleId);
+    expect(second.playbookId).toBe(first.playbookId);
+    expect(second.callerId).toBe(first.callerId);
+
+    // No duplicate CallerPlaybook rows.
+    const enrollments = await prisma.callerPlaybook.findMany({
+      where: { callerId: first.callerId, playbookId: first.playbookId },
+    });
+    expect(enrollments).toHaveLength(1);
+  });
+
+  it("SYSTEM BehaviorTarget seeding is idempotent (re-bootstrap does not duplicate rows)", async () => {
+    await bootstrapCanaryFixture(prisma);
+    const before = await prisma.behaviorTarget.count({
+      where: { scope: "SYSTEM", playbookId: null },
+    });
+
+    await bootstrapCanaryFixture(prisma);
+    const after = await prisma.behaviorTarget.count({
+      where: { scope: "SYSTEM", playbookId: null },
+    });
+
+    expect(after).toBe(before);
+
+    // And the count is >= what the production seed plan would produce
+    // for rows whose underlying Parameter exists. The fixture does NOT
+    // guarantee every plan entry — that's the seed script's job — but it
+    // does guarantee no row is dropped on a re-run.
+    expect(before).toBeGreaterThanOrEqual(0);
+  });
+
+  it("CANARY_TRANSCRIPT is at least 1KB and contains the assertable memory hook", async () => {
+    expect(CANARY_TRANSCRIPT.length).toBeGreaterThanOrEqual(1024);
+    // The exact "My name is X" pattern that gives a real-engine extractor
+    // a clean memory hook.
+    expect(CANARY_TRANSCRIPT).toMatch(/My name is \w+/);
+    // And a workplace hook that any reasonable extractor will catch.
+    expect(CANARY_TRANSCRIPT).toMatch(/I work at/);
+  });
+});

--- a/apps/admin/tests/integration/journey/canary-fixture.ts
+++ b/apps/admin/tests/integration/journey/canary-fixture.ts
@@ -1,0 +1,375 @@
+/**
+ * Adaptive Loop Canary Fixture — #1514 Slice 4 of epic #1510.
+ *
+ * Bootstraps the minimal data graph needed to drive a real-engine call
+ * through the full pipeline (EXTRACT → MEMORIES → AGGREGATE → COMPOSE) and
+ * assert the chain closes:
+ *
+ *   Domain → Subject → Playbook (PUBLISHED, IELTS-tier preset)
+ *           → Curriculum (primary) → CurriculumModule
+ *           → Caller (enrolled via CallerPlaybook)
+ *           → SYSTEM-scope BehaviorTarget rows seeded
+ *
+ * The fixture is PURE READ + WRITE on Prisma — it does NOT touch the
+ * pipeline runner, the invariant module, or any HTTP endpoint. The canary
+ * test owns the pipeline-trigger side; the fixture owns shape only.
+ *
+ * **Idempotent** — re-runs find existing rows and leave them alone.
+ *
+ * **Cleanup** — the symmetric `cleanupCanaryFixture()` removes every row
+ * the fixture authors. The two functions share the `CANARY_PREFIX` so
+ * external rows are never touched.
+ *
+ * Used by:
+ *   - `adaptive-loop-canary.integration.test.ts` — the proof gate
+ *   - `canary-fixture.integration.test.ts` — pins the fixture itself
+ *
+ * @see docs/CHAIN-CONTRACTS.md §6 — Adaptive Loop invariants the canary
+ *      observes (I-AL1 / I-AL2 / I-AL3 / I-AL4 / I-AL5).
+ * @see scripts/seed-system-behavior-defaults.ts — the production source
+ *      for SYSTEM BehaviorTarget seeding. The fixture mirrors its plan
+ *      but seeds against an isolated Parameter set so the canary's
+ *      WARN/INFO/ERROR verdicts are scoped to fixture data.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+import {
+  buildSeedPlan,
+  classifySeedPlan,
+} from "../../../scripts/seed-system-behavior-defaults";
+
+/**
+ * Prefix every fixture entity slug / name with this so cleanup can be
+ * exhaustive without nuking pre-existing rows.
+ */
+export const CANARY_PREFIX = "canary-1514";
+
+export interface CanaryFixture {
+  domainId: string;
+  subjectId: string;
+  curriculumId: string;
+  moduleId: string;
+  playbookId: string;
+  callerId: string;
+}
+
+const PLAYBOOK_NAME = `${CANARY_PREFIX}-playbook`;
+const DOMAIN_SLUG = `${CANARY_PREFIX}-domain`;
+const SUBJECT_SLUG = `${CANARY_PREFIX}-subject`;
+const CURRICULUM_SLUG = `${CANARY_PREFIX}-curriculum`;
+const MODULE_SLUG = `${CANARY_PREFIX}-module`;
+const CALLER_EXTERNAL_ID = `${CANARY_PREFIX}-caller`;
+
+/**
+ * Create / re-attach the canary's data graph. Returns the IDs the canary
+ * test threads through its assertions.
+ */
+export async function bootstrapCanaryFixture(
+  prisma: PrismaClient,
+): Promise<CanaryFixture> {
+  // 1. Domain
+  const domain = await prisma.domain.upsert({
+    where: { slug: DOMAIN_SLUG },
+    create: {
+      slug: DOMAIN_SLUG,
+      name: "Canary 1514 Domain",
+      description:
+        "Adaptive-loop canary domain — owned by tests/integration/journey/canary-fixture.ts.",
+      isActive: true,
+    },
+    update: { isActive: true },
+  });
+
+  // 2. Subject
+  const subject = await prisma.subject.upsert({
+    where: { slug: SUBJECT_SLUG },
+    create: {
+      slug: SUBJECT_SLUG,
+      name: "Canary 1514 Subject (IELTS Speaking)",
+    },
+    update: {},
+  });
+
+  await prisma.subjectDomain.upsert({
+    where: {
+      subjectId_domainId: { subjectId: subject.id, domainId: domain.id },
+    },
+    create: { subjectId: subject.id, domainId: domain.id },
+    update: {},
+  });
+
+  // 3. Playbook — PUBLISHED + tierPresetId set so PROSODY won't WARN
+  //    on the no-tierPreset reason. We don't actually want PROSODY to
+  //    run successfully (no stereo recording in a fake test call), but
+  //    we DO want the canary to observe whether the chain forward of
+  //    PROSODY closes.
+  //
+  //    `config` is set only on the first `create` (the test path is
+  //    a fresh-bootstrap). The update branch goes through
+  //    `updatePlaybookConfig` from #826 to satisfy the canonical
+  //    write-side guard `hf-playbook/no-direct-config-write` —
+  //    educator-facing config writes must bump `composeInputsUpdatedAt`.
+  let playbook = await prisma.playbook.findFirst({
+    where: { domainId: domain.id, name: PLAYBOOK_NAME },
+  });
+
+  if (!playbook) {
+    playbook = await prisma.playbook.create({
+      data: {
+        name: PLAYBOOK_NAME,
+        description: "Adaptive-loop canary playbook (#1514).",
+        domainId: domain.id,
+        status: "PUBLISHED",
+        publishedAt: new Date(),
+        config: {
+          tierPresetId: "ielts-speaking",
+        },
+      },
+    });
+  } else if (
+    !(playbook.config as Record<string, unknown> | null)?.tierPresetId
+  ) {
+    const { updatePlaybookConfig } = await import(
+      "../../../lib/playbook/update-playbook-config"
+    );
+    const result = await updatePlaybookConfig(
+      playbook.id,
+      (current) => ({ ...current, tierPresetId: "ielts-speaking" }),
+      { reason: "canary-1514 fixture bootstrap", skipTimestamp: true },
+    );
+    playbook = result.playbook;
+  }
+
+  await prisma.playbookSubject.upsert({
+    where: {
+      playbookId_subjectId: {
+        playbookId: playbook.id,
+        subjectId: subject.id,
+      },
+    },
+    create: { playbookId: playbook.id, subjectId: subject.id },
+    update: {},
+  });
+
+  // 4. Curriculum (primary) + 1 Module
+  const curriculum = await prisma.curriculum.upsert({
+    where: { slug: CURRICULUM_SLUG },
+    create: {
+      slug: CURRICULUM_SLUG,
+      name: "Canary 1514 Curriculum",
+    },
+    update: {},
+  });
+
+  await prisma.playbookCurriculum.upsert({
+    where: {
+      playbookId_curriculumId: {
+        playbookId: playbook.id,
+        curriculumId: curriculum.id,
+      },
+    },
+    create: {
+      playbookId: playbook.id,
+      curriculumId: curriculum.id,
+      role: "primary",
+    },
+    update: { role: "primary" },
+  });
+
+  let curriculumModule = await prisma.curriculumModule.findFirst({
+    where: { curriculumId: curriculum.id, slug: MODULE_SLUG },
+  });
+  if (!curriculumModule) {
+    curriculumModule = await prisma.curriculumModule.create({
+      data: {
+        curriculumId: curriculum.id,
+        slug: MODULE_SLUG,
+        title: "Canary Module — Part 1: Familiar Topics",
+        sortOrder: 0,
+        keyTerms: ["work", "study", "hometown", "hobbies"],
+      },
+    });
+  }
+
+  // 5. Caller (enrolled via CallerPlaybook)
+  const caller = await prisma.caller.upsert({
+    where: { externalId: CALLER_EXTERNAL_ID },
+    create: {
+      externalId: CALLER_EXTERNAL_ID,
+      name: "Canary Maya Tester",
+      phone: "+1-555-CAN-1514",
+      domainId: domain.id,
+    },
+    update: { domainId: domain.id },
+  });
+
+  await prisma.callerPlaybook.upsert({
+    where: {
+      callerId_playbookId: {
+        callerId: caller.id,
+        playbookId: playbook.id,
+      },
+    },
+    create: {
+      callerId: caller.id,
+      playbookId: playbook.id,
+      status: "ACTIVE",
+      enrolledBy: CANARY_PREFIX,
+      isDefault: true,
+    },
+    update: {
+      status: "ACTIVE",
+      isDefault: true,
+    },
+  });
+
+  // 6. SYSTEM-scope BehaviorTarget seeding — mirrors
+  //    scripts/seed-system-behavior-defaults.ts so the canary's I-AL5
+  //    verdict reflects the production cascade root. Idempotent: rows
+  //    already present are left alone (the script's contract).
+  await seedSystemBehaviorDefaultsViaScript(prisma);
+
+  return {
+    domainId: domain.id,
+    subjectId: subject.id,
+    curriculumId: curriculum.id,
+    moduleId: curriculumModule.id,
+    playbookId: playbook.id,
+    callerId: caller.id,
+  };
+}
+
+/**
+ * Seed the SYSTEM-scope `BehaviorTarget` rows using the production
+ * script's pure planner / classifier helpers. This avoids re-implementing
+ * the LISTED_KNOBS filter and guarantees the canary's view of the
+ * cascade root matches what `npx tsx scripts/seed-system-behavior-defaults.ts`
+ * would write on a real environment.
+ *
+ * Idempotent — `classifySeedPlan` skips rows already present, and the
+ * `create` path here re-checks under a single statement to absorb any
+ * race against a concurrent operator run.
+ */
+async function seedSystemBehaviorDefaultsViaScript(
+  prisma: PrismaClient,
+): Promise<void> {
+  const plan = buildSeedPlan();
+  const report = await classifySeedPlan(plan);
+
+  for (const entry of report.toCreate) {
+    const existing = await prisma.behaviorTarget.findFirst({
+      where: {
+        parameterId: entry.parameterId,
+        scope: "SYSTEM",
+        playbookId: null,
+      },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await prisma.behaviorTarget.create({
+      data: {
+        parameterId: entry.parameterId,
+        scope: "SYSTEM",
+        playbookId: null,
+        targetValue: entry.targetValue,
+        source: "SEED",
+        confidence: 0.5,
+      },
+    });
+  }
+}
+
+/**
+ * Remove every row authored by `bootstrapCanaryFixture` for this
+ * `CANARY_PREFIX`. Symmetric — running this then re-bootstrapping is
+ * the expected reset path between tests.
+ *
+ * Order matters because of FK constraints. SYSTEM BehaviorTarget rows
+ * are intentionally NOT removed — they're shared cascade roots that
+ * `scripts/seed-system-behavior-defaults.ts` owns.
+ */
+export async function cleanupCanaryFixture(
+  prisma: PrismaClient,
+): Promise<void> {
+  const caller = await prisma.caller.findUnique({
+    where: { externalId: CALLER_EXTERNAL_ID },
+  });
+  if (caller) {
+    await prisma.callerPlaybook.deleteMany({ where: { callerId: caller.id } });
+    await prisma.composedPrompt.deleteMany({ where: { callerId: caller.id } });
+    await prisma.callerMemory.deleteMany({ where: { callerId: caller.id } });
+    await prisma.callerMemorySummary.deleteMany({
+      where: { callerId: caller.id },
+    });
+    await prisma.callScore.deleteMany({ where: { callerId: caller.id } });
+    await prisma.callerTarget.deleteMany({ where: { callerId: caller.id } });
+    await prisma.callerAttribute.deleteMany({
+      where: { callerId: caller.id },
+    });
+    await prisma.callerModuleProgress.deleteMany({
+      where: { callerId: caller.id },
+    });
+    await prisma.call.deleteMany({ where: { callerId: caller.id } });
+    await prisma.caller.delete({ where: { id: caller.id } }).catch(() => {});
+  }
+
+  const playbook = await prisma.playbook.findFirst({
+    where: { name: PLAYBOOK_NAME },
+  });
+  if (playbook) {
+    await prisma.playbookSubject.deleteMany({
+      where: { playbookId: playbook.id },
+    });
+    await prisma.playbookCurriculum.deleteMany({
+      where: { playbookId: playbook.id },
+    });
+    await prisma.playbook.delete({ where: { id: playbook.id } }).catch(() => {});
+  }
+
+  const curriculum = await prisma.curriculum.findUnique({
+    where: { slug: CURRICULUM_SLUG },
+  });
+  if (curriculum) {
+    await prisma.curriculumModule.deleteMany({
+      where: { curriculumId: curriculum.id },
+    });
+    await prisma.curriculum.delete({ where: { id: curriculum.id } }).catch(() => {});
+  }
+
+  const subject = await prisma.subject.findUnique({
+    where: { slug: SUBJECT_SLUG },
+  });
+  if (subject) {
+    await prisma.subjectDomain.deleteMany({
+      where: { subjectId: subject.id },
+    });
+    await prisma.subject.delete({ where: { id: subject.id } }).catch(() => {});
+  }
+
+  await prisma.domain.deleteMany({ where: { slug: DOMAIN_SLUG } });
+}
+
+/**
+ * Canary transcript — long enough (≥ 1KB, well above I-AL1's 200-char
+ * threshold) and with explicit memory hooks ("My name is Maya", workplace,
+ * hobby) so a real-engine EXTRACT has unambiguous content to attribute
+ * memories to.
+ *
+ * Exported so the canary test reads ONE canonical transcript.
+ */
+export const CANARY_TRANSCRIPT = [
+  "AI: Hello! Welcome to your IELTS Speaking practice. Could we start by you telling me a little about yourself?",
+  "Student: Hi! My name is Maya. I work at a small architecture firm in Madrid as a junior architect.",
+  "AI: That's great, Maya. How long have you been working there?",
+  "Student: About two years now. Before that I was studying architecture at the Universidad Politécnica de Madrid.",
+  "AI: Wonderful. Let's talk about hometowns — can you describe where you grew up?",
+  "Student: I grew up in a small coastal town in northern Spain called Llanes. It's famous for its beaches and the asturian cider tradition.",
+  "AI: Lovely. What did you enjoy most about growing up there?",
+  "Student: I loved how close everything was to the sea. My family would go fishing on weekends — my dad taught me how to read the tides.",
+  "AI: That sounds wonderful. Now let's move to a slightly more abstract topic — what's a hobby that keeps you balanced outside of work?",
+  "Student: I started rock climbing about a year ago. There's a great indoor gym near my apartment and I go three times a week. It really helps with stress.",
+  "AI: Excellent. Do you have any long-term goals for your climbing?",
+  "Student: I'd like to do a multi-pitch outdoor route in the Picos de Europa next summer. It's something I've been training for.",
+  "AI: Thank you, Maya. Those were some great responses. Your fluency was strong and you used some nice descriptive vocabulary.",
+].join("\n");


### PR DESCRIPTION
## Summary

Slice 4 of epic #1510 — **THE PROOF GATE**. Drives one real-engine call
through the full pipeline (EXTRACT → MEMORIES → AGGREGATE → COMPOSE) and
asserts the chain closes.

WARN-only for the first 2 weeks per the epic plan. Hard FAILs only on
EXTRACT-empty and COMPOSE invariant errors; everything else degrades to
`expect.soft()` so the process exits 0 with the gap surfaced in
`AppLog(stage="pipeline.canary.run")` and rendered on
`/x/help/pipeline-health`. Flip `HF_CANARY_WARN_ONLY=false` after #1515
+ #1516 land to promote the WARN gates.

| Gate | Outcome | Action on failure |
|---|---|---|
| `extract.scores >= 10` | hard FAIL | blocks deploy |
| `learn.memories > 0` (G9 / #1515) | WARN (env-gated) | logs + dashboard |
| `aggregate.skillTargets > 0` (G2 / #1516) | WARN | logs + dashboard |
| `compose.keyMemories` non-null | WARN (downstream of G9) | logs |
| `compose.invariantErrors` empty | hard FAIL | I-C tripped |

I-AL3 is informational only — observed via AppLog count but never blocks.
Known-broken until #1519 (`ContractRegistry.get` typo) ships; the canary
will watch the count drop to zero after that fix lands.

## What ships

- `apps/admin/tests/integration/journey/canary-fixture.ts` — bootstrap
  / cleanup helpers. Mirrors the production
  `scripts/seed-system-behavior-defaults.ts` plan via its exported
  `buildSeedPlan` + `classifySeedPlan` helpers so the canary's view of
  the SYSTEM cascade root matches reality. Routes `Playbook.config`
  updates through `updatePlaybookConfig` (the canonical #826 helper) so
  the `hf-playbook/no-direct-config-write` lint rule stays clean.
  Idempotent + symmetric.
- `apps/admin/tests/integration/journey/canary-fixture.integration.test.ts`
  — 5 cases pinning the fixture itself (creates, cleans, idempotent
  bootstrap, idempotent SYSTEM seeding, transcript ≥ 1KB).
- `apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts`
  — the canary. Two cases:
  1. **Real-engine call** — drives all 5 gates above end-to-end via
     `POST /api/calls/{id}/pipeline` with `x-internal-secret`. Self-skips
     cleanly if `ANTHROPIC_API_KEY` / server / `INTERNAL_API_SECRET` not
     present (prerequisite check in `beforeAll`).
  2. **Mock-engine carve-out** — pins `route.ts:1029-1031`: mock writes
     scores but NOT memories. I-AL1 must not fire when CallScore.scoredBy
     is `mock_batched_v1`.
- `apps/admin/package.json` — new `npm run test:canary` script
  (wraps `vitest run --config vitest.integration.config.ts <path>`).
- `.github/workflows/canary.yml` — nightly schedule (03:00 UTC) +
  workflow_dispatch. Secrets needed before first run:
  `ANTHROPIC_API_KEY`, `INTERNAL_API_SECRET`, `DATABASE_URL_CANARY`,
  `CANARY_API_URL`.
- `apps/admin/app/x/help/pipeline-health/page.tsx` — new
  **"Latest canary run"** panel reading
  `AppLog(stage="pipeline.canary.run")`. Renders the gate-by-gate verdict
  so an operator can confirm at a glance whether last night's run closed
  the chain.

## Out of scope (per the slice plan in the brief)

- Modifying any pipeline runner code or the invariant module — PURE READ
  + ASSERT.
- I-AL3 hard fail — known broken until #1519 ships.
- Adding stereo-recording support to canary calls (PROSODY will WARN
  with `no-stereoUrl` on the canary call; expected).
- Operator setup of CI secrets (`DATABASE_URL_CANARY`, `CANARY_API_URL`) —
  required before the first nightly run.

## Verified by

- `npx tsc --noEmit` on changed files — **zero** errors after
  `npm ci` (the dev-machine baseline was poisoned by missing
  `node_modules`; reinstalled to confirm a clean baseline).
- `npx eslint <4 changed files>` — **zero** warnings, zero errors.
  Caught one legitimate violation during the first lint pass
  (`hf-playbook/no-direct-config-write`) — fixed by routing through
  `updatePlaybookConfig` per the rule's canonical helper.
- `npm run kb:fresh` — green; no module-map / coupling-graph drift
  from the new files (the canary only imports the seed-script helpers
  and the runtime `lib/playbook/update-playbook-config`).
- `npx vitest run --config vitest.integration.config.ts
  tests/integration/journey/canary-fixture.integration.test.ts` —
  compiles + loads + reaches the Prisma client. Fails on
  `DATABASE_URL not set` in this edit-only environment (per
  `CLAUDE.local.md`), which is the expected behaviour — the journey
  setup intentionally runs in DB-mode only. **The fixture tests
  themselves will run green on hf-dev VM.**
- The canary itself: **NOT yet run end-to-end on this branch** —
  the prerequisite is a live server with `ANTHROPIC_API_KEY` +
  `INTERNAL_API_SECRET`. **Unable to verify here, will verify on
  hf-dev VM in the PR-comment follow-up.** The canary writes its
  verdict to AppLog regardless of PASS/WARN/FAIL so the first run's
  result lands on `/x/help/pipeline-health` automatically.

## Headline

**Loop closes / Loop fails on N gates — verdict pending first live run
on hf-dev VM.** This is the honest "I built the gate; the gate hasn't
seen the live data yet" status. The two prerequisites — a configured
canary user (`ANTHROPIC_API_KEY` env on the VM) and the secret
configuration in GitHub Actions — are operator steps documented in the
workflow file's comment block.

Closes #1514. Part of #1510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)