### PR TITLE
fix(pipeline): #1516 CallerTarget.currentScore NULL for skill_* — canary playbook had no MEASURE spec

### DIFF
--- a/apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts
+++ b/apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts
@@ -178,7 +178,7 @@ afterAll(async () => {
 });
 
 describe("#1514 Adaptive Loop canary — proves the chain closes", () => {
-  it("real-engine call: EXTRACT → MEMORIES → AGGREGATE → CallerTarget → COMPOSE", async () => {
+  it("real-engine call: EXTRACT → MEMORIES → AGGREGATE → CallerTarget → COMPOSE", { timeout: 180_000 }, async () => {
     if (!canRun || !fixture) {
       recordGate(
         "preflight",

--- a/apps/admin/tests/integration/journey/canary-fixture.integration.test.ts
+++ b/apps/admin/tests/integration/journey/canary-fixture.integration.test.ts
@@ -169,4 +169,141 @@ describe("#1514 canary fixture — self-tests", () => {
     // And a workplace hook that any reasonable extractor will catch.
     expect(CANARY_TRANSCRIPT).toMatch(/I work at/);
   });
+
+  // ── #1516 — per-playbook skill-measure spec seeding ──────────────────
+  describe("#1516 G2 — skill-measure spec wiring", () => {
+    it("seeds the skill-measure-<canary> AnalysisSpec with 4 MEASURE actions targeting skill_* parameters", async () => {
+      const fx = await bootstrapCanaryFixture(prisma);
+
+      const spec = await prisma.analysisSpec.findUnique({
+        where: { slug: `skill-measure-${CANARY_PREFIX}` },
+        select: {
+          id: true,
+          outputType: true,
+          specType: true,
+          isActive: true,
+          isDirty: true,
+          triggers: {
+            select: {
+              id: true,
+              actions: {
+                select: { parameterId: true, weight: true },
+              },
+            },
+          },
+        },
+      });
+
+      expect(spec).not.toBeNull();
+      expect(spec!.outputType).toBe("MEASURE");
+      expect(spec!.specType).toBe("DOMAIN");
+      expect(spec!.isActive).toBe(true);
+      // spec-loader at `lib/pipeline/specs-loader.ts` filters on
+      // `isDirty: false`. If this assertion ever flips, the spec stops
+      // loading and the canary's G2 gate regresses silently.
+      expect(spec!.isDirty).toBe(false);
+
+      // Exactly 1 trigger, 4 actions — one per canonical IELTS skill.
+      expect(spec!.triggers).toHaveLength(1);
+      const actionParams = spec!.triggers[0]!.actions
+        .map((a) => a.parameterId)
+        .sort();
+      expect(actionParams).toEqual(
+        [
+          "skill_fluency_and_coherence_fc",
+          "skill_grammatical_range_and_accuracy_gra",
+          "skill_lexical_resource_lr",
+          "skill_pronunciation_p",
+        ].sort(),
+      );
+
+      // PlaybookItem link is present + enabled — without it the spec-loader's
+      // playbook-scope filter excludes the spec from the canary playbook's
+      // EXTRACT pass even though the spec exists.
+      const link = await prisma.playbookItem.findFirst({
+        where: { playbookId: fx.playbookId, specId: spec!.id },
+        select: { isEnabled: true, itemType: true },
+      });
+      expect(link).not.toBeNull();
+      expect(link!.isEnabled).toBe(true);
+      expect(link!.itemType).toBe("SPEC");
+    });
+
+    it("seeds 4 PLAYBOOK-scope BehaviorTarget rows for skill_* params (closes the AGGREGATE → CallerTarget cascade root)", async () => {
+      const fx = await bootstrapCanaryFixture(prisma);
+
+      const targets = await prisma.behaviorTarget.findMany({
+        where: {
+          scope: "PLAYBOOK",
+          playbookId: fx.playbookId,
+          parameterId: { startsWith: "skill_" },
+        },
+        select: { parameterId: true, targetValue: true, source: true },
+      });
+
+      expect(targets).toHaveLength(4);
+      // All 4 skill parameters present.
+      expect(targets.map((t) => t.parameterId).sort()).toEqual(
+        [
+          "skill_fluency_and_coherence_fc",
+          "skill_grammatical_range_and_accuracy_gra",
+          "skill_lexical_resource_lr",
+          "skill_pronunciation_p",
+        ].sort(),
+      );
+      // targetValue defaults to 1.0 (Secure) — the canonical "where you
+      // want to be" for IELTS skill aggregation.
+      for (const t of targets) {
+        expect(t.targetValue).toBe(1.0);
+        expect(t.source).toBe("SEED");
+      }
+    });
+
+    it("skill-measure spec seeding is idempotent (re-bootstrap does not duplicate actions or targets)", async () => {
+      const fx = await bootstrapCanaryFixture(prisma);
+
+      // Re-bootstrap.
+      await bootstrapCanaryFixture(prisma);
+
+      const triggers = await prisma.analysisTrigger.count({
+        where: { spec: { slug: `skill-measure-${CANARY_PREFIX}` } },
+      });
+      const actions = await prisma.analysisAction.count({
+        where: { trigger: { spec: { slug: `skill-measure-${CANARY_PREFIX}` } } },
+      });
+      const targets = await prisma.behaviorTarget.count({
+        where: { scope: "PLAYBOOK", playbookId: fx.playbookId },
+      });
+      const links = await prisma.playbookItem.count({
+        where: {
+          playbookId: fx.playbookId,
+          spec: { slug: `skill-measure-${CANARY_PREFIX}` },
+        },
+      });
+
+      expect(triggers).toBe(1);
+      expect(actions).toBe(4);
+      expect(targets).toBe(4);
+      expect(links).toBe(1);
+    });
+
+    it("cleanup removes the skill-measure spec, its PlaybookItem link, and the PLAYBOOK-scope BehaviorTargets", async () => {
+      const fx = await bootstrapCanaryFixture(prisma);
+      await cleanupCanaryFixture(prisma);
+
+      const spec = await prisma.analysisSpec.findUnique({
+        where: { slug: `skill-measure-${CANARY_PREFIX}` },
+      });
+      expect(spec).toBeNull();
+
+      // BehaviorTargets PLAYBOOK-scoped to the canary playbook are gone.
+      // (Use the captured playbookId — the playbook row itself is also gone
+      // post-cleanup, but the FK ordering means BehaviorTargets are dropped
+      // first.)
+      const targets = await prisma.behaviorTarget.count({
+        where: { scope: "PLAYBOOK", playbookId: fx.playbookId },
+      });
+      expect(targets).toBe(0);
+    });
+  });
 });

--- a/apps/admin/tests/integration/journey/canary-fixture.ts
+++ b/apps/admin/tests/integration/journey/canary-fixture.ts
@@ -62,6 +62,68 @@ const MODULE_SLUG = `${CANARY_PREFIX}-module`;
 const CALLER_EXTERNAL_ID = `${CANARY_PREFIX}-caller`;
 
 /**
+ * Slug for the per-playbook MEASURE spec that writes `skill_*` CallScores
+ * during EXTRACT. Mirrors the production naming pattern from
+ * `apps/admin/lib/wizard/apply-projection.ts::upsertMeasureSpec` (line 644):
+ * `skill-measure-<playbookId-prefix-8>`. We use the CANARY_PREFIX instead of
+ * the playbook UUID prefix so the slug stays stable across DB resets.
+ */
+const SKILL_MEASURE_SPEC_SLUG = `skill-measure-${CANARY_PREFIX}`;
+
+/**
+ * Canonical IELTS Speaking skill parameter IDs the canary fixture seeds.
+ * These are the SAME parameterIds production IELTS playbooks use
+ * (`skill_fluency_and_coherence_fc`, etc.) so SKILL-AGG-001's
+ * `startsWith: "skill_"` pattern matches and the CallerTarget rows the
+ * canary's G2 gate inspects line up with how real callers' rows are keyed.
+ * Upsert semantics — if a production seed already created these rows, the
+ * fixture leaves them alone.
+ */
+const CANARY_SKILL_PARAMS: ReadonlyArray<{
+  parameterId: string;
+  name: string;
+  description: string;
+  /**
+   * What the MEASURE trigger should look at in the transcript. Drives the
+   * `description` on AnalysisAction so a real-engine EXTRACT pass has
+   * something concrete to score against.
+   */
+  triggerHint: string;
+}> = [
+  {
+    parameterId: "skill_fluency_and_coherence_fc",
+    name: "Fluency & Coherence",
+    description: "IELTS Speaking — Fluency & Coherence (FC)",
+    triggerHint:
+      "Score how smoothly the learner speaks, the logical flow of their ideas, " +
+      "and use of cohesive devices on a 0-1 scale.",
+  },
+  {
+    parameterId: "skill_lexical_resource_lr",
+    name: "Lexical Resource",
+    description: "IELTS Speaking — Lexical Resource (LR)",
+    triggerHint:
+      "Score the range and precision of the learner's vocabulary, including " +
+      "topic-specific terms and paraphrasing on a 0-1 scale.",
+  },
+  {
+    parameterId: "skill_grammatical_range_and_accuracy_gra",
+    name: "Grammatical Range & Accuracy",
+    description: "IELTS Speaking — Grammatical Range & Accuracy (GRA)",
+    triggerHint:
+      "Score the range of grammatical structures and their accuracy on a 0-1 scale.",
+  },
+  {
+    parameterId: "skill_pronunciation_p",
+    name: "Pronunciation",
+    description: "IELTS Speaking — Pronunciation (P)",
+    triggerHint:
+      "Score pronunciation features the transcript explicitly cites on a 0-1 scale. " +
+      "Use evidence from coach feedback turns when available.",
+  },
+];
+
+/**
  * Create / re-attach the canary's data graph. Returns the IDs the canary
  * test threads through its assertions.
  */
@@ -188,6 +250,9 @@ export async function bootstrapCanaryFixture(
         title: "Canary Module — Part 1: Familiar Topics",
         sortOrder: 0,
         keyTerms: ["work", "study", "hometown", "hobbies"],
+        // NOT NULL on String[] — empty array means self-contained module.
+        // (PR #1525 fix; restored here for #1516 — system reminder dropped it.)
+        coversModules: [],
       },
     });
   }
@@ -229,6 +294,15 @@ export async function bootstrapCanaryFixture(
   //    verdict reflects the production cascade root. Idempotent: rows
   //    already present are left alone (the script's contract).
   await seedSystemBehaviorDefaultsViaScript(prisma);
+
+  // 7. Per-playbook skill-measure spec + PLAYBOOK-scope BehaviorTarget seeding
+  //    (#1516). The canary playbook's EXTRACT stage needs a MEASURE spec that
+  //    writes `skill_*` CallScores; without it, SKILL-AGG-001 finds zero source
+  //    rows and the G2 gate fails. Production playbooks get this spec from
+  //    `apply-projection.ts::upsertMeasureSpec` after a course-reference
+  //    projection — the canary bootstrap mirrors that surface area without
+  //    requiring a full wizard run.
+  await seedCanarySkillMeasureSpec(prisma, playbook.id);
 
   return {
     domainId: domain.id,
@@ -281,13 +355,177 @@ async function seedSystemBehaviorDefaultsViaScript(
 }
 
 /**
+ * #1516 — Seed the per-playbook `skill-measure-<canary-prefix>` MEASURE spec
+ * + matching PLAYBOOK-scope BehaviorTarget rows that the canary's pipeline
+ * run needs to write `skill_*` CallScore rows during EXTRACT.
+ *
+ * Without this, SKILL-AGG-001 (`outputType=AGGREGATE, method=ema_to_caller_target,
+ * sourceParameterPattern="skill_*"`) finds zero source rows for the canary
+ * caller, leaves `CallerTarget(skill_*).currentScore` NULL, and the G2 gate
+ * at `adaptive-loop-canary.integration.test.ts:292-317` fails.
+ *
+ * Production playbooks get this spec from
+ * `apps/admin/lib/wizard/apply-projection.ts::upsertMeasureSpec` after a
+ * course-reference projection. The canary bootstrap mirrors the **shape** of
+ * that output — Parameter rows + AnalysisSpec + AnalysisTrigger +
+ * AnalysisAction + PlaybookItem link + PLAYBOOK-scope BehaviorTarget rows —
+ * without requiring the full wizard pipeline. The slug pattern matches
+ * production (`skill-measure-<prefix>`) so a follow-on real-engine projection
+ * pass over the canary playbook would safely upsert into the same row.
+ *
+ * Idempotent — every write uses upsert / findFirst+create semantics. Safe to
+ * re-run.
+ */
+async function seedCanarySkillMeasureSpec(
+  prisma: PrismaClient,
+  playbookId: string,
+): Promise<void> {
+  // 1. Upsert canonical skill Parameter rows (shared with production IELTS
+  //    seed — same parameterIds, idempotent on collision).
+  for (const skill of CANARY_SKILL_PARAMS) {
+    await prisma.parameter.upsert({
+      where: { parameterId: skill.parameterId },
+      create: {
+        parameterId: skill.parameterId,
+        name: skill.name,
+        definition: skill.description,
+        sectionId: "skill",
+        domainGroup: "skill",
+        scaleType: "0-1",
+        directionality: "positive",
+        computedBy: `canary-1514-fixture`,
+        parameterType: "BEHAVIOR",
+        isAdjustable: true,
+      },
+      update: {
+        // Don't overwrite production rows — leave name/definition/config
+        // alone on upsert collision. The empty update is intentional.
+      },
+    });
+  }
+
+  // 2. Upsert the MEASURE spec itself. Mirror the production shape from
+  //    `apply-projection.ts::upsertMeasureSpec` (line 648).
+  const now = new Date();
+  const spec = await prisma.analysisSpec.upsert({
+    where: { slug: SKILL_MEASURE_SPEC_SLUG },
+    create: {
+      slug: SKILL_MEASURE_SPEC_SLUG,
+      name: "Canary 1514 — Skill Measure",
+      description:
+        "Adaptive-loop canary per-playbook MEASURE spec (#1516). Scores the " +
+        "4 IELTS Speaking skill parameters from every call transcript so " +
+        "SKILL-AGG-001 has source rows for the EMA aggregation pass.",
+      scope: "DOMAIN",
+      outputType: "MEASURE",
+      specType: "DOMAIN",
+      specRole: "MEASURE",
+      domain: DOMAIN_SLUG,
+      priority: 10,
+      isActive: true,
+      isDirty: false,
+      compiledAt: now,
+    },
+    update: {
+      isActive: true,
+      isDirty: false,
+      compiledAt: now,
+    },
+    select: { id: true },
+  });
+
+  // 3. Replace triggers + actions wholesale (cheap — 1 trigger, 4 actions).
+  //    Same pattern as the production upsert.
+  await prisma.analysisTrigger.deleteMany({ where: { specId: spec.id } });
+  await prisma.analysisTrigger.create({
+    data: {
+      specId: spec.id,
+      name: "Score IELTS speaking skills",
+      given:
+        "the call transcript captures a speaking-practice interaction with at " +
+        "least one learner utterance",
+      when: "the EXTRACT stage runs over the transcript",
+      then: "each IELTS skill parameter is scored on a 0-1 scale with evidence cites",
+      sortOrder: 0,
+      notes: `canary-1514 skill measure (#1516)`,
+      actions: {
+        create: CANARY_SKILL_PARAMS.map((skill, idx) => ({
+          description: skill.triggerHint,
+          parameterId: skill.parameterId,
+          weight: 1.0,
+          sortOrder: idx,
+        })),
+      },
+    },
+  });
+
+  // 4. Link the spec to the canary playbook via PlaybookItem so the
+  //    spec-loader's playbook-scope filter includes it. No composite unique
+  //    on (playbookId, specId), so emulate upsert with findFirst.
+  const existingLink = await prisma.playbookItem.findFirst({
+    where: { playbookId, specId: spec.id },
+    select: { id: true, isEnabled: true },
+  });
+  if (existingLink) {
+    if (!existingLink.isEnabled) {
+      await prisma.playbookItem.update({
+        where: { id: existingLink.id },
+        data: { isEnabled: true },
+      });
+    }
+  } else {
+    await prisma.playbookItem.create({
+      data: {
+        playbookId,
+        specId: spec.id,
+        itemType: "SPEC",
+        isEnabled: true,
+        groupId: "SKILL_MEASURE",
+        groupLabel: "Per-skill scoring (#1516 canary)",
+        sortOrder: 100,
+      },
+    });
+  }
+
+  // 5. Seed PLAYBOOK-scope BehaviorTarget rows for the 4 skill parameters
+  //    so the AGGREGATE-side `CallerTarget.upsert` finds a non-default
+  //    targetValue when it lands. Without these the cascade falls through
+  //    to SKILL-AGG-001's hardcoded `targetValue: 1.0` (the runner's
+  //    `create` default at `aggregate-runner.ts:274`).
+  for (const skill of CANARY_SKILL_PARAMS) {
+    const existing = await prisma.behaviorTarget.findFirst({
+      where: {
+        parameterId: skill.parameterId,
+        scope: "PLAYBOOK",
+        playbookId,
+      },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await prisma.behaviorTarget.create({
+      data: {
+        parameterId: skill.parameterId,
+        scope: "PLAYBOOK",
+        playbookId,
+        targetValue: 1.0,
+        source: "SEED",
+        confidence: 0.5,
+      },
+    });
+  }
+}
+
+/**
  * Remove every row authored by `bootstrapCanaryFixture` for this
  * `CANARY_PREFIX`. Symmetric — running this then re-bootstrapping is
  * the expected reset path between tests.
  *
  * Order matters because of FK constraints. SYSTEM BehaviorTarget rows
  * are intentionally NOT removed — they're shared cascade roots that
- * `scripts/seed-system-behavior-defaults.ts` owns.
+ * `scripts/seed-system-behavior-defaults.ts` owns. Likewise the canonical
+ * skill `Parameter` rows are LEFT IN PLACE — they're shared with production
+ * IELTS playbooks via `apply-projection.ts::ensureParameters`, so deleting
+ * them would break unrelated callers.
  */
 export async function cleanupCanaryFixture(
   prisma: PrismaClient,
@@ -310,7 +548,32 @@ export async function cleanupCanaryFixture(
     await prisma.callerModuleProgress.deleteMany({
       where: { callerId: caller.id },
     });
+    // #1525 — Call has soft FKs from PersonalityObservation,
+    // BehaviorMeasurement, and CallTarget. Drop them before the Call rows.
+    await prisma.personalityObservation
+      .deleteMany({ where: { callerId: caller.id } })
+      .catch(() => {});
+    await prisma.behaviorMeasurement
+      .deleteMany({ where: { call: { callerId: caller.id } } })
+      .catch(() => {});
+    await prisma.callTarget
+      .deleteMany({ where: { call: { callerId: caller.id } } })
+      .catch(() => {});
     await prisma.call.deleteMany({ where: { callerId: caller.id } });
+    // #1516 — `CallerPersonalityProfile` (legacy FK name
+    // `UserPersonalityProfile_callerId_fkey`) and `CallerPersonality` are
+    // hard FKs on Caller; without an explicit delete the silent
+    // `.catch(() => {})` below leaks the caller row across runs (the
+    // "cleanup removes every fixture row" self-test asserts against a
+    // leftover Caller). Wrap each in `.catch` so the delete is best-effort
+    // — production DBs without these rows for the canary still complete
+    // cleanly.
+    await prisma.callerPersonalityProfile
+      .deleteMany({ where: { callerId: caller.id } })
+      .catch(() => {});
+    await prisma.callerPersonality
+      .deleteMany({ where: { callerId: caller.id } })
+      .catch(() => {});
     await prisma.caller.delete({ where: { id: caller.id } }).catch(() => {});
   }
 
@@ -318,6 +581,19 @@ export async function cleanupCanaryFixture(
     where: { name: PLAYBOOK_NAME },
   });
   if (playbook) {
+    // #1516 — Drop the per-playbook skill-measure spec + its links + targets.
+    //   Order: PlaybookItem → BehaviorTarget(PLAYBOOK) → AnalysisSpec (which
+    //   cascades to AnalysisTrigger → AnalysisAction via onDelete:Cascade).
+    await prisma.playbookItem.deleteMany({
+      where: { playbookId: playbook.id },
+    });
+    await prisma.behaviorTarget.deleteMany({
+      where: { scope: "PLAYBOOK", playbookId: playbook.id },
+    });
+    await prisma.analysisSpec
+      .delete({ where: { slug: SKILL_MEASURE_SPEC_SLUG } })
+      .catch(() => {});
+
     await prisma.playbookSubject.deleteMany({
       where: { playbookId: playbook.id },
     });

--- a/docs/audit/g2-callertarget-null-root-cause.md
+++ b/docs/audit/g2-callertarget-null-root-cause.md
@@ -1,0 +1,220 @@
+# G2 — CallerTarget.currentScore NULL for skill_* parameters
+
+**Issue:** [#1516](https://github.com/WANDERCOLTD/HF/issues/1516)
+**Surfaced by:** [#1525](https://github.com/WANDERCOLTD/HF/pull/1525) — adaptive-loop canary live verdict (G2 gate `aggregate.skill_*` failed in WARN mode)
+**Investigator:** fix/1516-callertarget-null-currentscore
+**Date:** 2026-06-11
+
+## TL;DR — the chain is NOT broken; the canary fixture is
+
+The AGGREGATE → CallerTarget write path works correctly for real (non-canary) callers on `hf_sandbox`. The canary fixture's playbook is missing the per-playbook `skill-measure-<playbookPrefix>` MEASURE spec, so EXTRACT never writes `skill_*` CallScore rows for the canary caller, so AGGREGATE (`SKILL-AGG-001`) reads zero source rows and writes zero CallerTarget rows.
+
+The canary's G2 gate at [`adaptive-loop-canary.integration.test.ts:292-317`](../../apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts) is asserting on a precondition that the canary fixture itself never establishes.
+
+## Evidence
+
+### 1. AGGREGATE specs are correctly seeded
+
+```text
+=== Active AGGREGATE specs on hf_sandbox ===
+{ slug: 'spec-learn-prof-001', ruleMethods: ['threshold_mapping' x 5] }
+{ slug: 'spec-coach-agg-001',  ruleMethods: ['threshold_mapping' x 5] }
+{ slug: 'spec-disc-agg-001',   ruleMethods: ['threshold_mapping' x 5] }
+{ slug: 'spec-comp-agg-001',   ruleMethods: ['threshold_mapping' x 7] }
+{ slug: 'spec-skill-agg-001',  ruleMethods: ['ema_to_caller_target'] }  ← SKILL-AGG-001
+```
+
+`SKILL-AGG-001` is seeded with the correct rule. Spec config at
+`apps/admin/docs-archive/bdd-specs/SKILL-AGG-001-skill-ema-aggregation.spec.json:36-44`:
+
+```json
+{
+  "sourceParameter": "skill_*",
+  "sourceParameterPattern": "skill_*",
+  "method": "ema_to_caller_target",
+  "emaHalfLifeDays": 14,
+  "minCallsToFull": 4
+}
+```
+
+### 2. The runner path is wired and exercised
+
+`apps/admin/app/api/calls/[callId]/pipeline/route.ts::stageExecutors.AGGREGATE` calls
+`runAggregateSpecs(ctx.callerId)`. That function picks up SKILL-AGG-001 because it
+filters on `outputType: 'AGGREGATE', isActive: true`. SKILL-AGG-001 satisfies both.
+
+The runner then enters `runAggregation` → `accumulateSkillScores` which queries
+`CallScore.findMany({ where: { callerId, parameterId: { startsWith: 'skill_' }, NOT: { hasLearnerEvidence: false } } })`.
+
+### 3. The canary caller has zero CallScore rows of any parameterId
+
+```text
+=== Distinct CallScore.parameterId for canary caller (externalId=canary-1514-caller) ===
+(empty — cleanup ran after PR #1525's live run)
+```
+
+The canary fixture's `cleanupCanaryFixture` (`canary-fixture.ts:293-355`) wipes
+CallScore + CallerTarget for the canary caller. So we cannot inspect the post-run
+state directly. But we can inspect the post-run state for OTHER callers who share
+the same pipeline path.
+
+### 4. Real callers DO get `CallerTarget.currentScore` populated
+
+`callerId=c05d5267-471c-4a10-9288-4ff416fb7cb6` on the IELTS playbook
+(`playbookId=eb6bc79e-3168-49e5-90a0-d732a37fe294`):
+
+```text
+=== CallScore evidence breakdown ===
+{ skill_scores: 10, evidence_true: 10, evidence_false: 0, evidence_null: 0 }
+
+=== CallerTarget(skill_*) ===
+{ parameterId: 'skill_grammatical_range_and_accuracy_gra', currentScore: 0.538, callsUsed: 3 }
+{ parameterId: 'skill_pronunciation_p',                    currentScore: 0.500, callsUsed: 1 }
+{ parameterId: 'skill_fluency_and_coherence_fc',           currentScore: <populated> }
+{ parameterId: 'skill_lexical_resource_lr',                currentScore: <populated> }
+```
+
+**The runner WORKS for real callers.** When `skill_*` CallScore rows exist, the
+EMA cascade lands them in `CallerTarget.currentScore` correctly.
+
+### 5. The differentiator: per-playbook MEASURE spec attachment
+
+```text
+=== AnalysisSpec slugs containing 'skill' ===
+{ slug: 'skill-measure-ec4127a1', outputType: 'MEASURE', specType: 'DOMAIN' }
+{ slug: 'skill-measure-eb6bc79e', outputType: 'MEASURE', specType: 'DOMAIN' }  ← IELTS playbook
+{ slug: 'skill-measure-41d4dcfa', outputType: 'MEASURE', specType: 'DOMAIN' }
+{ slug: 'skill-measure-2d63715e', outputType: 'MEASURE', specType: 'DOMAIN' }
+{ slug: 'skill-measure-eebf437a', outputType: 'MEASURE', specType: 'DOMAIN' }
+{ slug: 'spec-skill-agg-001',     outputType: 'AGGREGATE', specType: 'SYSTEM' }
+```
+
+Every IELTS-style playbook has its own `skill-measure-<playbookPrefix>` spec. These
+are created by `apps/admin/lib/wizard/apply-projection.ts::upsertMeasureSpec`
+(line 618) **when a course-reference projection is run on the playbook**. The spec
+writes `skill_*` CallScore rows during EXTRACT.
+
+The canary playbook (`Canary 1514 Playbook`) has **no** such spec because the
+canary fixture bootstrap (`canary-fixture.ts::bootstrapCanaryFixture`) seeds the
+playbook directly without going through the wizard projection. Result: the canary
+EXTRACT has nothing to write `skill_*` CallScores from; AGGREGATE finds zero source
+rows; CallerTarget(skill_*).currentScore stays NULL.
+
+## Distinguishing the four candidates
+
+| Candidate | Verdict |
+|---|---|
+| AGGREGATE doesn't run at all | ❌ False — `runAggregateSpecs` is wired into `stageExecutors.AGGREGATE` and the entry/exit log lines exist at `aggregate-runner.ts:392-394, 434-436` |
+| AGGREGATE runs but no rules | ❌ False — `SKILL-AGG-001` is seeded with `method: ema_to_caller_target` |
+| AGGREGATE runs with rules but writes fail silently | ❌ False — real callers like `c05d5267` have populated `currentScore` |
+| AGGREGATE runs but `skill_*` source rows don't exist | ✅ **TRUE for canary** — canary playbook has no `skill-measure-<canary>` MEASURE spec |
+
+## Relationship to #1519 (ContractRegistry.get typo)
+
+The `.get()` typo at `aggregate-runner.ts:184` is real but **not** the root cause
+of #1516. It causes a silent throw inside the try/catch at lines 173-196, which
+falls through to `SKILL_DEFAULTS = { emaHalfLifeDays: 14, minCallsToFull: 4 }`.
+Critically, **these defaults are IDENTICAL to the contract values** in
+`SKILL_MEASURE_V1.contract.json`. So the typo causes I-AL3 ("defaults fired") to
+emit when it doesn't have to, but the EMA math runs with the same constants the
+contract would have supplied.
+
+Fixing the typo is correct (it eliminates a spurious I-AL3 emit) but it does not
+populate `CallerTarget.currentScore` for the canary. **#1519's scope is the typo;
+#1516's scope is the canary fixture seeding gap.** They are independent.
+
+This PR does NOT touch the typo — keep that change in #1519's own PR with its own
+behavioural risk review (the contract STARTS being consulted instead of being
+silently bypassed, which is a behavioural change even when the values match).
+
+## Fix shape
+
+Extend `bootstrapCanaryFixture` in `apps/admin/tests/integration/journey/canary-fixture.ts`
+to seed a minimal per-playbook MEASURE spec for the canary's playbook AND the
+matching `BehaviorTarget` rows that the AGGREGATE-side `CallerTarget.upsert` uses
+as the parameter set.
+
+Specifically:
+1. Create 4 skill `Parameter` rows (`skill_fluency_and_coherence_fc`,
+   `skill_lexical_resource_lr`, `skill_grammatical_range_and_accuracy_gra`,
+   `skill_pronunciation_p`) — these are the canonical IELTS Speaking parameters
+   the rubric writes.
+2. Create a `skill-measure-canary-1514` `AnalysisSpec` with `outputType=MEASURE,
+   scope=DOMAIN, specRole=MEASURE` whose triggers + actions reference those
+   parameters with `weight: 1.0` and `parameterId` set.
+3. Link it to the canary playbook via `PlaybookItem` (`itemType=SPEC,
+   isEnabled=true, groupId=SKILL_MEASURE`).
+4. Seed `BehaviorTarget` rows scoped to the canary playbook with the 4 skill
+   parameterIds and `targetValue=1.0` so AGGREGATE's `CallerTarget.upsert`
+   `create.targetValue` default matches the cascade root.
+5. Add `cleanupCanaryFixture` teardown for these rows (PlaybookItem +
+   AnalysisTrigger + AnalysisAction + AnalysisSpec + BehaviorTarget +
+   Parameter).
+
+After this seeding, a real-engine claude pass over `CANARY_TRANSCRIPT` should:
+- write `skill_*` CallScores in EXTRACT (the canary transcript has explicit
+  fluency, vocabulary, and grammar exemplars) — gate G2 source rows present
+- run `accumulateSkillScores` and EMA-blend those scores into
+  `CallerTarget.currentScore` — gate G2 PASS
+
+## Verification — DONE (post-fix evidence)
+
+Live canary runs on hf-dev VM, source `AppLog.stage='pipeline.canary.run'`:
+
+| Run | Verdict | Detail |
+|---|---|---|
+| 2026-06-12T11:52:28Z (BEFORE, on `main`) | G2=WARN | `CallerTarget(skill_*, currentScore!=null) count=0; > 0 expected` |
+| 2026-06-12T11:07:45Z (BEFORE, on `main`) | G2=WARN | `count=0` |
+| 2026-06-12T12:11:26Z (AFTER, on `fix/1516`) | G2=PASS | `count=3` |
+| 2026-06-12T12:12:39Z (AFTER) | G2=PASS | `count=3` |
+| 2026-06-12T12:13:44Z (AFTER) | G2=PASS | `count=3` |
+| 2026-06-12T12:14:34Z (AFTER) | G2=PASS | `count=3` |
+
+4 stable PASSes across consecutive runs with `engine=claude`. `extract.scores`
+remained at `count=18..19` across runs. Three distinct skill parameters
+(out of 4 seeded) landed CallerTarget rows; the 4th (pronunciation) has no
+text-only signal so claude legitimately skipped it.
+
+Other gates after fix:
+- `extract.scores >= 10` PASS (unchanged)
+- `learn.memories > 0` PASS — already passing on the v2 canary (G9/#1515 was disproven; see PR #1527 audit doc)
+- `compose.keyMemories > 0` still WARN — downstream `key_memories` plumbing has its own gap (not in scope here)
+- `compose.invariantErrors empty` PASS (unchanged)
+
+## How to re-verify
+
+```bash
+gcloud compute ssh hf-dev --zone=europe-west2-a --command='cd ~/HF/apps/admin && \
+  set -a && source .env.local && set +a && \
+  npm run test:integration -- tests/integration/journey/adaptive-loop-canary.integration.test.ts'
+```
+
+Then inspect `AppLog` for the G2 verdict:
+
+```sql
+SELECT metadata->'gateResults'
+FROM "AppLog"
+WHERE stage = 'pipeline.canary.run'
+ORDER BY "createdAt" DESC LIMIT 1;
+```
+
+## Risk + rollback
+
+- **Risk:** zero for production code paths. Fixture-only change. Rollback = revert
+  the PR; the canary returns to its current WARN-on-G2 state.
+- **Risk:** Parameter table is shared across the DB; the canary's 4 skill
+  parameter slugs collide with the production IELTS slugs. **Mitigation:** the
+  canary fixture uses `upsert` semantics (`skill_fluency_and_coherence_fc` etc.
+  are stable and shared with production IELTS — using the same parameterIds is
+  actually correct because SKILL-AGG-001 matches `startsWith: 'skill_'`
+  irrespective of which playbook produced the score).
+- **Note:** The `behaviorTarget` rows are scoped to the canary playbook (not
+  SYSTEM), so they don't leak into the cascade root for other playbooks.
+
+## What this PR is NOT
+
+- NOT fixing the EMA math (works correctly per evidence section 4)
+- NOT fixing CallScore writing (works correctly per evidence section 4)
+- NOT fixing the `.get()` typo (that's #1519's scope; values are identical
+  anyway so no behavioural diff in defaults)
+- NOT touching the invariant runner from Slice 1 (#1517)

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-12T10:34:59.953Z",
+  "generatedAt": "2026-06-12T12:17:05.868Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
   "fileCount": 1670,

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-12T10:35:00.468Z",
+  "generatedAt": "2026-06-12T12:17:06.714Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-12T10:34:58.302Z",
+  "generatedAt": "2026-06-12T12:17:03.228Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-12T10:35:01.017Z",
+  "generatedAt": "2026-06-12T12:17:07.689Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-12T10:34:59.038Z",
+  "generatedAt": "2026-06-12T12:17:04.547Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Root cause

The adaptive-loop canary fixture seeded a Domain/Subject/Playbook/Curriculum/Module/Caller chain but **no per-playbook MEASURE spec**. Production IELTS playbooks get their `skill-measure-<playbookPrefix>` spec from [`apply-projection.ts::upsertMeasureSpec` (line 644)](apps/admin/lib/wizard/apply-projection.ts) after a course-reference projection — the canary bootstrap skipped that surface.

Result: when the canary runs EXTRACT, no spec emits `skill_*` CallScore rows. Downstream `SKILL-AGG-001` (`outputType=AGGREGATE`, `method=ema_to_caller_target`, `sourceParameterPattern="skill_*"`) queries `CallScore.findMany({ where: { parameterId: { startsWith: "skill_" } } })` and finds 0 rows for the canary caller, leaves `CallerTarget(skill_*).currentScore` NULL, and the G2 gate at [`adaptive-loop-canary.integration.test.ts:292-317`](apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts) flags it.

**The chain itself is healthy.** Real callers like `c05d5267-471c-4a10-9288-4ff416fb7cb6` on the IELTS playbook (`eb6bc79e-…`) have populated `currentScore` values today (0.5, 0.538, …). This was a canary fixture coverage gap, not a pipeline bug.

## Fix shape

Fixture-only — zero production-code risk.

- `bootstrapCanaryFixture` adds step 7 `seedCanarySkillMeasureSpec` which upserts:
  - 4 canonical IELTS skill `Parameter` rows (shared with production seed via idempotent upsert)
  - the `skill-measure-canary-1514` `AnalysisSpec` with `outputType=MEASURE, scope=DOMAIN, specType=DOMAIN, isActive=true, isDirty=false`
  - 1 `AnalysisTrigger` + 4 `AnalysisAction` rows linking each skill parameter
  - `PlaybookItem(SPEC, isEnabled=true, groupId=SKILL_MEASURE)` linking spec to canary playbook
  - 4 `BehaviorTarget(scope=PLAYBOOK, targetValue=1.0, source=SEED)` rows for the cascade root
- `cleanupCanaryFixture` drops the new rows in FK order before the Playbook delete, AND adds defensive `CallerPersonalityProfile` / `CallerPersonality` / `PersonalityObservation` / `BehaviorMeasurement` / `CallTarget` teardown that PR #1525's cleanup missed.
- 4 new vitests pin the seed.

Mirrors the production shape from `apply-projection.ts::upsertMeasureSpec` so a follow-on real projection over the canary playbook would safely upsert into the same row.

## Before / after — live canary on hf-dev VM

Source: `SELECT metadata FROM "AppLog" WHERE stage='pipeline.canary.run' ORDER BY "createdAt" DESC`

| Run                                       | G2 verdict | Detail                                              |
|-------------------------------------------|------------|-----------------------------------------------------|
| 2026-06-12T11:52:28Z (**BEFORE**, `main`) | **WARN**   | `CallerTarget(skill_*, currentScore!=null) count=0` |
| 2026-06-12T11:07:45Z (**BEFORE**, `main`) | **WARN**   | `count=0`                                           |
| 2026-06-12T12:11:26Z (**AFTER**)          | **PASS**   | `count=3`                                           |
| 2026-06-12T12:12:39Z (AFTER)              | PASS       | `count=3`                                           |
| 2026-06-12T12:13:44Z (AFTER)              | PASS       | `count=3`                                           |
| 2026-06-12T12:14:34Z (AFTER)              | PASS       | `count=3`                                           |

4 consecutive PASSes with `engine=claude` over the 1KB `CANARY_TRANSCRIPT`. 3 of 4 seeded skill parameters get populated (pronunciation has no text-only signal so claude legitimately skips it).

Full gate summary on AFTER run @ 12:14:34Z (`passed=8, failed=0, warns=1`):
- `pipeline.http`: PASS (status=200)
- `extract.scores`: PASS (count=18, floor=10)
- `learn.memories`: PASS (count=19)
- `aggregate.skillTargets`: **PASS (count=3) ← #1516 closed**
- `compose.keyMemories`: WARN — `key_memories len=0` (downstream of separate `key_memories` plumbing gap, not in scope here)
- `compose.invariantErrors`: PASS (count=0)
- `observe.iAL3`: PASS (count=0 — known-broken until #1519)
- `mock.scoredByMarker`: PASS
- `mock.zeroMemories`: PASS

## Relationship to #1519

#1519 is the `ContractRegistry.get` typo at `aggregate-runner.ts:184`. **Independent** — fixing the typo would NOT have populated `CallerTarget` for the canary because the `SKILL_MEASURE_V1.config` values (`emaHalfLifeDays: 14, minCallsToFull: 4`) are byte-equal to `SKILL_DEFAULTS`. The typo only causes a spurious I-AL3 emit, not the NULL CallerTarget. This PR leaves the typo for #1519 to resolve in its own behavioural-risk review (the contract STARTS being consulted when fixed).

## Verified by

- 9/9 vitests in `tests/integration/journey/canary-fixture.integration.test.ts` PASS on hf_sandbox (incl. 4 new G2 tests + the previously-failing cleanup self-test now passing)
- 7/7 existing vitests in `tests/lib/pipeline/aggregate-runner-i-al3.test.ts` PASS (no behavioural change)
- Live canary on hf-dev: 4 consecutive G2=PASS runs (table above)
- `npx tsc --noEmit` clean on changed files
- `npx eslint` clean on changed files
- `npm run kb:fresh` PASS

## Risk + rollback

- **Risk:** zero for production code paths — fixture/test surface only.
- **Rollback:** revert this PR; the canary G2 gate returns to WARN-only state.

## Refs

- Audit doc: `docs/audit/g2-callertarget-null-root-cause.md`
- #1525 (canary live verdict that surfaced this)
- #1517 (Slice 1 invariant runner — not touched)
- #1519 (`.get()` typo — independent)

Closes #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)