### PR TITLE
fix(compose): #1530 ComposedPrompt.inputs.key_memories empty despite CallerMemory writes — surface from llmPrompt._quickStart

### DIFF
--- a/apps/admin/lib/prompt/composition/persist.ts
+++ b/apps/admin/lib/prompt/composition/persist.ts
@@ -88,6 +88,33 @@ export async function persistComposedPrompt(
       }
     : undefined;
 
+  // #1514 Gate 4 / #1530 — surface the deduplicated `key_memories` list
+  // that the quickstart transform already computed (and that lives at
+  // `llmPrompt._quickStart.key_memories`) into `inputs.key_memories`
+  // alongside the sibling `memoriesCount` field. The canary at
+  // tests/integration/journey/adaptive-loop-canary.integration.test.ts
+  // reads `ComposedPrompt.inputs.key_memories` as the external
+  // observability surface for "did the tutor actually receive the key
+  // memory facts?". Pre-fix the value was never persisted under
+  // `inputs.*` — it only existed at `llmPrompt._quickStart.key_memories`,
+  // so the canary's Gate 4 tripped WARN even when CallerMemory writes
+  // were healthy (proven by #1515).
+  //
+  // Value semantics:
+  //   - non-empty string[]  → quickstart found memories and surfaced them
+  //   - []                  → no memories to surface (zero-memory caller, or
+  //                            quickstart returned null for any other reason)
+  // Never `undefined`/`null` — the canary uses `Array.isArray(...) ? x : []`
+  // and the dashboard widgets can rely on the field being defined.
+  //
+  // Purely additive — no existing reader of `inputs.*` consumes this name
+  // (sweep in docs/audit/compose-key-memories-empty-root-cause.md).
+  const quickStartFromPrompt = (llmPrompt as Record<string, unknown> | undefined)?._quickStart;
+  const keyMemoriesFromQuickStart = (quickStartFromPrompt as { key_memories?: unknown } | undefined)?.key_memories;
+  const keyMemories: string[] = Array.isArray(keyMemoriesFromQuickStart)
+    ? (keyMemoriesFromQuickStart.filter((m): m is string => typeof m === "string"))
+    : [];
+
   // A2 — the create-new-active + supersede-old-active pair MUST be atomic.
   // Pre-fix, two concurrent recomposes could both finish their create()
   // before either reached updateMany(), leaving two `status:"active"` rows
@@ -110,6 +137,7 @@ export async function persistComposedPrompt(
         inputs: {
           callerContext,
           memoriesCount: loadedData.memories.length,
+          key_memories: keyMemories,
           personalityAvailable: !!loadedData.personality,
           recentCallsCount: loadedData.recentCalls.length,
           behaviorTargetsCount: metadata.mergedTargetCount,

--- a/apps/admin/tests/lib/prompt/composition/persist-key-memories.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/persist-key-memories.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for `persistComposedPrompt` — `inputs.key_memories` surfacing.
+ *
+ * Root cause we're guarding against: pre-fix, the `key_memories` list
+ * computed by `transforms/quickstart.ts` lived ONLY at
+ * `llmPrompt._quickStart.key_memories`. The adaptive-loop canary
+ * (#1514 Gate 4) reads `ComposedPrompt.inputs.key_memories` as the
+ * external observability surface — that field was never written, so
+ * Gate 4 tripped WARN even when CallerMemory writes were healthy.
+ *
+ * Fix: `persist.ts` now mirrors the already-computed list from
+ * `llmPrompt._quickStart.key_memories` into `inputs.key_memories` as a
+ * `string[]` (empty array, never null/undefined). The forensics blob
+ * shape is otherwise unchanged.
+ *
+ * These tests pin:
+ *   1. Populated case — `inputs.key_memories` matches the quickstart list.
+ *   2. Empty / missing case — `inputs.key_memories` is `[]`, never null.
+ *   3. Sibling `memoriesCount` still written (no regression of existing
+ *      forensics shape).
+ *   4. `llmPrompt` column still receives the full composition (no
+ *      duplication that loses the structured `_quickStart`).
+ *
+ * Linked: docs/audit/compose-key-memories-empty-root-cause.md
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CompositionResult } from "@/lib/prompt/composition/types";
+
+const mocks = vi.hoisted(() => ({
+  composedPromptCreate: vi.fn(),
+  composedPromptUpdateMany: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => {
+  const tx = {
+    composedPrompt: {
+      create: mocks.composedPromptCreate,
+      updateMany: mocks.composedPromptUpdateMany,
+    },
+  };
+  return {
+    prisma: {
+      $transaction: vi.fn(async (cb: (innerTx: unknown) => Promise<unknown>) => cb(tx)),
+    },
+    db: (client: unknown) => client,
+    type: {},
+  };
+});
+
+import { persistComposedPrompt } from "@/lib/prompt/composition/persist";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The route only reads back what `create` returned; we don't need a
+  // realistic id, just enough fields to pass the `as PersistedPrompt` cast.
+  mocks.composedPromptCreate.mockImplementation(async ({ data }) => ({
+    id: "cp_test_123",
+    callerId: data.callerId,
+    prompt: data.prompt,
+    llmPrompt: data.llmPrompt,
+    status: data.status,
+    composedAt: new Date(),
+  }));
+  mocks.composedPromptUpdateMany.mockResolvedValue({ count: 0 });
+});
+
+/** Build a minimal `CompositionResult` with whatever quickstart shape we want. */
+function makeComposition(quickStart: Record<string, unknown> | undefined): CompositionResult {
+  return {
+    llmPrompt: {
+      _version: "2.0",
+      _format: "LLM_STRUCTURED",
+      ...(quickStart !== undefined ? { _quickStart: quickStart } : {}),
+    },
+    callerContext: "## Caller Information\n- Name: Test",
+    sections: {},
+    loadedData: {
+      caller: { id: "caller_x", name: "Test" },
+      memories: [
+        { category: "FACT", key: "name", value: "Test", confidence: 0.9 },
+        { category: "FACT", key: "city", value: "London", confidence: 0.8 },
+      ],
+      personality: null,
+      recentCalls: [],
+      playbooks: [{ name: "Test Course" }],
+    } as unknown as CompositionResult["loadedData"],
+    resolvedSpecs: {
+      identitySpec: { name: "TUT-001", config: {} },
+      voiceSpec: null,
+    } as unknown as CompositionResult["resolvedSpecs"],
+    metadata: {
+      sectionsActivated: ["caller_info", "memories", "quick_start"],
+      sectionsSkipped: [],
+      activationReasons: {},
+      loadTimeMs: 100,
+      transformTimeMs: 200,
+      mergedTargetCount: 3,
+    },
+  };
+}
+
+describe("persistComposedPrompt → inputs.key_memories surfacing", () => {
+  it("Gate 4 (#1514): mirrors llmPrompt._quickStart.key_memories into inputs.key_memories", async () => {
+    const composition = makeComposition({
+      key_memories: ["name: Test", "city: London", "interest: cooking"],
+      this_caller: "Test (call #1)",
+    });
+
+    await persistComposedPrompt(composition, "rendered markdown", {
+      callerId: "caller_x",
+      playbookId: "pb_test",
+    });
+
+    expect(mocks.composedPromptCreate).toHaveBeenCalledTimes(1);
+    const data = mocks.composedPromptCreate.mock.calls[0][0].data;
+    expect(data.inputs.key_memories).toEqual([
+      "name: Test",
+      "city: London",
+      "interest: cooking",
+    ]);
+    // Sibling forensics field unchanged.
+    expect(data.inputs.memoriesCount).toBe(2);
+  });
+
+  it("returns [] when _quickStart is missing entirely (omitted section)", async () => {
+    const composition = makeComposition(undefined);
+
+    await persistComposedPrompt(composition, "rendered markdown", {
+      callerId: "caller_x",
+    });
+
+    const data = mocks.composedPromptCreate.mock.calls[0][0].data;
+    expect(data.inputs.key_memories).toEqual([]);
+    expect(Array.isArray(data.inputs.key_memories)).toBe(true);
+  });
+
+  it("returns [] when key_memories is null (quickstart returned null because no memories)", async () => {
+    const composition = makeComposition({
+      key_memories: null,
+      this_caller: "Test (call #1)",
+    });
+
+    await persistComposedPrompt(composition, "rendered markdown", {
+      callerId: "caller_x",
+    });
+
+    const data = mocks.composedPromptCreate.mock.calls[0][0].data;
+    expect(data.inputs.key_memories).toEqual([]);
+  });
+
+  it("returns [] when key_memories is missing from _quickStart (non-array)", async () => {
+    const composition = makeComposition({
+      this_caller: "Test (call #1)",
+      // No key_memories field at all
+    });
+
+    await persistComposedPrompt(composition, "rendered markdown", {
+      callerId: "caller_x",
+    });
+
+    const data = mocks.composedPromptCreate.mock.calls[0][0].data;
+    expect(data.inputs.key_memories).toEqual([]);
+  });
+
+  it("filters non-string entries defensively (the shape comes from a transform)", async () => {
+    const composition = makeComposition({
+      // Defensive — quickstart should always return string[], but guard
+      // against future drift / partial outputs.
+      key_memories: ["name: Test", 42, null, "city: London", undefined],
+    });
+
+    await persistComposedPrompt(composition, "rendered markdown", {
+      callerId: "caller_x",
+    });
+
+    const data = mocks.composedPromptCreate.mock.calls[0][0].data;
+    expect(data.inputs.key_memories).toEqual(["name: Test", "city: London"]);
+  });
+
+  it("does NOT duplicate _quickStart into llmPrompt — full structure preserved", async () => {
+    const quickStart = {
+      key_memories: ["name: Test"],
+      this_caller: "Test (call #1)",
+    };
+    const composition = makeComposition(quickStart);
+
+    await persistComposedPrompt(composition, "rendered markdown", {
+      callerId: "caller_x",
+    });
+
+    const data = mocks.composedPromptCreate.mock.calls[0][0].data;
+    // llmPrompt column still contains the full structure
+    expect(data.llmPrompt._quickStart).toEqual(quickStart);
+    // inputs.key_memories is the mirror
+    expect(data.inputs.key_memories).toEqual(["name: Test"]);
+  });
+
+  it("preserves all existing forensics-shape inputs fields (no regression)", async () => {
+    const composition = makeComposition({
+      key_memories: ["a: b"],
+    });
+
+    await persistComposedPrompt(composition, "rendered markdown", {
+      callerId: "caller_x",
+      playbookId: "pb_x",
+      composeSpecSlug: "spec-comp-001",
+      specConfig: { foo: "bar" },
+    });
+
+    const data = mocks.composedPromptCreate.mock.calls[0][0].data;
+    expect(data.inputs).toEqual(
+      expect.objectContaining({
+        callerContext: expect.any(String),
+        memoriesCount: 2,
+        key_memories: ["a: b"],
+        personalityAvailable: false,
+        recentCallsCount: 0,
+        behaviorTargetsCount: 3,
+        playbooksUsed: ["Test Course"],
+        playbooksCount: 1,
+        identitySpec: "TUT-001",
+        contentSpec: null,
+        specUsed: "spec-comp-001",
+        specConfig: { foo: "bar" },
+        composition: expect.objectContaining({
+          sectionsActivated: ["caller_info", "memories", "quick_start"],
+          sectionsSkipped: [],
+          loadTimeMs: 100,
+          transformTimeMs: 200,
+        }),
+      }),
+    );
+  });
+});

--- a/docs/audit/compose-key-memories-empty-root-cause.md
+++ b/docs/audit/compose-key-memories-empty-root-cause.md
@@ -1,0 +1,153 @@
+# Canary Gate 4 — `ComposedPrompt.inputs.key_memories` is empty — root cause
+
+**Date:** 2026-06-11
+**Branch:** `fix/canary-compose-key-memories`
+**Tied to:** #1514 (canary) + #1515 (G9 memories) + this fix
+
+## TL;DR
+
+The canary's Gate 4 (`ComposedPrompt.inputs.key_memories` non-null) is failing
+because `inputs.key_memories` is **never written** by `persistComposedPrompt`.
+The computed key-memory list lives at `llmPrompt._quickStart.key_memories`
+(written by `transforms/quickstart.ts:444-470`), and `inputs` is a separate
+forensics blob designed before the canary existed. Failure mode (D) from the
+brief — "the `key_memories` field has been renamed but the canary asserts on
+the old name" — except in this case it was never persisted to `inputs` in the
+first place.
+
+Memories themselves are loading fine (the G9 doc confirmed 17-18 CallerMemory
+rows per canary run; the memories loader at `SectionDataLoader.ts:553` filters
+by `supersededById: null` + `expiresAt` and reads them correctly; the memories
+transform deduplicates and ranks them; the quickstart transform pulls the top 4
+into `_quickStart.key_memories`). The break is one layer downstream of all
+that, in the persistence step that flattens the composition result into the
+`ComposedPrompt.inputs` JSON column.
+
+## Data flow trace
+
+```
+CallerMemory rows (DB)
+  └── SectionDataLoader.ts::registerLoader("memories")   ←── 17-18 rows here
+        └── memories transform "deduplicateAndGroupMemories"
+              └── context.sections.memories._deduplicated
+                    └── transforms/quickstart.ts::computeQuickStart()
+                          └── _quickStart.key_memories: [...]     ←── populated
+                                └── llmPrompt._quickStart.key_memories  ←── written to ComposedPrompt.llmPrompt
+                                                                            ✗ NOT written to ComposedPrompt.inputs
+```
+
+The canary then reads `composed.inputs.key_memories` (test file line 327) and
+finds `undefined`, so `keyMemoriesArray.length === 0` and the WARN gate trips.
+
+## Evidence
+
+### 1. The transform IS populating `key_memories`
+
+`apps/admin/lib/prompt/composition/transforms/quickstart.ts:444-470` reads
+`sections.memories._deduplicated` and returns a `key_memories` string array
+(capped at 4). On the canary's transcript (17-18 CallerMemory rows) this
+returns a non-empty list — proven by the G9 doc and by the memories transform
+producing `totalCount > 0` (which is the data the canary already passes through
+Gate 2 via `LEARN — CallerMemory count > 0`).
+
+### 2. `inputs` is a forensics blob, not a reflection of `llmPrompt`
+
+`apps/admin/lib/prompt/composition/persist.ts:110-128` builds `inputs` as:
+
+```ts
+inputs: {
+  callerContext,            // assembled markdown (separate column-shaped string)
+  memoriesCount,            // ← the count IS here (Gate 4 sibling)
+  personalityAvailable,
+  recentCallsCount,
+  behaviorTargetsCount,
+  playbooksUsed,
+  playbooksCount,
+  identitySpec,
+  contentSpec,
+  specUsed,
+  specConfig,
+  composition: { sectionsActivated, sectionsSkipped, loadTimeMs, transformTimeMs },
+}
+```
+
+No `key_memories`. The `llmPrompt` column (also written, but as a separate
+column, not under `inputs`) is the canonical shape the voice path reads from.
+
+### 3. Existing `inputs.*` readers all consume forensics-shaped fields
+
+Confirmed via grep across the repo. Every other reader of
+`ComposedPrompt.inputs.*` is reading a forensics field
+(`memoriesCount`, `composition.sectionsActivated`, `callerContext`,
+`behaviorTargetsCount`), not a per-section payload. So adding `key_memories`
+under `inputs` is purely additive — no existing reader changes shape.
+
+The complete reader list:
+
+| File | Read |
+| --- | --- |
+| `app/api/pipeline/runs/route.ts` | `inputs.composition`, `inputs.memoriesCount` |
+| `app/api/callers/[callerId]/eval-prompt/route.ts` | `inputs.memoriesCount`, `inputs.composition.sectionsActivated/Skipped` |
+| `components/callers/caller-detail/CallsTab.tsx` | `inputs.memoriesCount`, `inputs.callerContext` |
+| `components/callers/caller-detail/PromptsSection.tsx` | `inputs.memoriesCount` |
+| `tests/integration/journey/adaptive-loop-canary.integration.test.ts` | `inputs.key_memories` ← **the only reader of this field** |
+
+## Why this isn't the same class as #1515 G9
+
+The G9 doc (`docs/audit/g9-callermemory-zero-writes-root-cause.md`) established
+that CallerMemory writes were healthy. This canary gate was the next assertion
+in the chain — but it's reading from the wrong path. Both findings stack:
+
+1. `CallerMemory` rows exist (G9 disproved zero-writes premise) — confirmed.
+2. The memories transform reads them and emits `_deduplicated` — confirmed
+   (Gate 2 passes).
+3. The quickstart transform pulls them into `_quickStart.key_memories` — works.
+4. **`persist.ts` does not surface `key_memories` to `inputs`** — the gap.
+
+So Gate 4 is "downstream of G9" only in the sense that an empty memory set
+would also produce an empty `key_memories`. But on a healthy memory write
+path, Gate 4 still fails — because `inputs.key_memories` is structurally
+absent.
+
+## Fix shape
+
+In `apps/admin/lib/prompt/composition/persist.ts`, read
+`composition.llmPrompt?._quickStart?.key_memories` (already computed by the
+composition pipeline) and surface it as `inputs.key_memories: string[] | null`.
+
+- Pure additive change — no existing reader of `inputs.*` cares.
+- No new transform — uses the already-computed list.
+- Default is `[]` (empty array, not null) when no memories were surfaced, so
+  the canary's `Array.isArray(...) ? x : []` guard at line 328 is honest.
+- Mirrors the `memoriesCount` pattern that's already there — the count is the
+  cardinality, `key_memories` is the actual list.
+
+## Why not change the canary instead?
+
+Two reasons:
+
+1. The canary's intent is to observe the chain externally — looking at
+   `ComposedPrompt.inputs` is the right architectural surface (the DB row, not
+   a deep field of the assembled prompt). Asking the canary to drill into
+   `llmPrompt._quickStart.key_memories` makes it brittle to internal layout
+   changes.
+2. The `inputs` blob is already partially observability-shaped (`memoriesCount`,
+   `recentCallsCount`, `behaviorTargetsCount`). Adding `key_memories` is
+   consistent — it answers "what did the tutor actually learn this caller's
+   key facts as?" alongside "how many did it have to choose from?".
+
+## Verification plan
+
+1. Vitest pinning that `persistComposedPrompt` writes `inputs.key_memories`
+   as an array when `llmPrompt._quickStart.key_memories` is populated, and
+   writes `[]` when absent.
+2. Re-run the canary on hf-dev VM. Gate 4 (`compose.keyMemories`) should
+   flip from WARN to PASS.
+
+## Constraints honoured
+
+- DO NOT touch the invariant runner ✓
+- DO NOT touch AGGREGATE / EXTRACT runners ✓
+- DO NOT change the compose-invariant runner ✓
+- DO add a vitest that pins the fix ✓
+- `npm run lint`, `npx tsc --noEmit`, `npm run kb:fresh` all green ✓


### PR DESCRIPTION
## Summary

The adaptive-loop canary's Gate 4 (`ComposedPrompt.inputs.key_memories` non-null) tripped WARN on live runs even when CallerMemory writes were healthy (proven by #1515). Root cause: the canary reads `inputs.key_memories` as its external observability surface, but `persistComposedPrompt` never wrote that field. The computed list lived only at `llmPrompt._quickStart.key_memories`.

Failure mode classified (D) per the brief: \"the `key_memories` field has been renamed but the canary asserts on the old name\" — except it was never under `inputs.*` to begin with. The `inputs` blob in `persist.ts` was a forensics dashboard shape (memoriesCount, sectionsActivated, …) that was designed before the canary existed.

**Fix shape:** mirror the already-computed `_quickStart.key_memories` into `inputs.key_memories` as `string[]` (empty array, never null/undefined). Defensive filter against non-string entries. Purely additive — no existing reader of `inputs.*` consumes this name (reader sweep in the audit doc).

## Root cause

`apps/admin/lib/prompt/composition/transforms/quickstart.ts:444-470` already produces the top-4 deduplicated key-memory list. It writes into `llmPrompt._quickStart.key_memories` (the LLM-facing column). The persistence step at `apps/admin/lib/prompt/composition/persist.ts:110-128` then assembles the `inputs` JSON column as:

\`\`\`ts
inputs: {
  callerContext, memoriesCount, personalityAvailable, recentCallsCount,
  behaviorTargetsCount, playbooksUsed, playbooksCount, identitySpec,
  contentSpec, specUsed, specConfig, composition: { ... }
}
\`\`\`

— no `key_memories` field. The canary at `tests/integration/journey/adaptive-loop-canary.integration.test.ts:327` reads `composed.inputs.key_memories` and finds `undefined`, so the array-length check trips WARN regardless of memory population.

Full data-flow trace + reader sweep in `docs/audit/compose-key-memories-empty-root-cause.md`.

## Why surface to `inputs` (not change the canary)?

1. The canary's intent is to observe externally — `ComposedPrompt.inputs` is the right shape (one DB column, not a deep JSON path inside `llmPrompt`). Making the canary drill into `llmPrompt._quickStart.key_memories` makes it brittle to internal layout changes.
2. `inputs` is already partially observability-shaped (`memoriesCount`, `recentCallsCount`, `behaviorTargetsCount`). Adding `key_memories` is consistent — \"how many were there?\" is already there; \"what were they?\" rounds out the pair.

## Before / after

**Before** (canary on hf_sandbox post-#1529 merge):
\`\`\`
✓ extract.scores          PASS   CallScore count=50+
✓ learn.memories          PASS   CallerMemory count=17-18
✓ aggregate.skillTargets  PASS
⚠ compose.keyMemories     WARN   key_memories len=0   ← this PR
✓ compose.invariantErrors PASS
\`\`\`

**After** (proven via the new vitest fixtures):
- when quickstart produces `key_memories: [\"name: Test\", \"city: London\", \"interest: cooking\"]` → `inputs.key_memories` is `[\"name: Test\", \"city: London\", \"interest: cooking\"]`
- when `_quickStart` is omitted → `inputs.key_memories` is `[]` (never null/undefined)
- when `_quickStart.key_memories` is null → `inputs.key_memories` is `[]`
- when entries are non-strings → filtered out defensively

## Test plan

- [x] 7/7 vitests pass in `tests/lib/prompt/composition/persist-key-memories.test.ts`
- [x] 167/167 composition tests pass — no regression
- [x] `npx tsc --noEmit` clean on persist.ts + the new test (3 pre-existing `any` warnings unchanged)
- [x] `npm run kb:fresh` green
- [ ] Re-run canary on hf-dev VM to confirm Gate 4 flips WARN → PASS (operator step — VM run gated on `ANTHROPIC_API_KEY` + `INTERNAL_API_SECRET`)

## Verified by

- **Vitest:** `tests/lib/prompt/composition/persist-key-memories.test.ts` — 7 tests covering populated mirror, omitted/null/missing → `[]`, non-string filter, llmPrompt structure preservation, and full forensics-shape preservation.
- **SQL-shape reasoning:** the `ComposedPrompt.inputs` reader sweep in `docs/audit/compose-key-memories-empty-root-cause.md` confirms no existing consumer reads `inputs.key_memories` — change is purely additive on the persistence side.
- **Code citation:** `quickstart.ts:444-470` computes `key_memories`; `persist.ts:110-128` (pre-fix) omits it; canary at `adaptive-loop-canary.integration.test.ts:327` reads `inputs.key_memories`. The mismatch is the bug.

## Constraints honoured

- DO NOT touch the invariant runner ✓
- DO NOT touch AGGREGATE / EXTRACT runners ✓
- DO NOT change the compose-invariant runner ✓
- DO add a vitest that pins the fix ✓
- `npm run lint`, `npx tsc --noEmit`, `npm run kb:fresh` all green ✓

Closes #1530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)