### PR TITLE
feat(demo): 🎬 clapperboard icon + Preview primary/secondary flip + annotation-visibility toggle

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -27,7 +27,8 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { Eye, RefreshCw, FileSearch, AlertCircle, Edit3, X, Star, StickyNote, Trash2 } from "lucide-react";
+import { Eye, RefreshCw, FileSearch, AlertCircle, Edit3, X, Star, Clapperboard, Trash2 } from "lucide-react";
+import { useChatContext } from "@/contexts/ChatContext";
 import {
   SessionFlowEditor,
   type SessionFlowLens,
@@ -129,6 +130,7 @@ const SIDETRAY_TITLES: Record<SessionFlowLens, string> = {
 };
 
 export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement {
+  const { demoAnnotationsVisible } = useChatContext();
   const [mode, setMode] = useState<ViewMode>("educator");
   const [flow, setFlow] = useState<SessionFlowResp | null>(null);
   const [dryRun, setDryRun] = useState<DryRunResp | null>(null);
@@ -241,11 +243,17 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
   // R1 mitigation — warn when stored bubbleRefs don't match any current
   // bubble. The annotation isn't lost (it's still persisted) but the
   // sticky note silently detaches; the warning surfaces the divergence.
+  //
+  // Visibility honours the Demo-tab Eye/EyeOff toggle from ChatContext:
+  // when off, the map is empty so no sticky notes render and the
+  // bubble's "Add demo note" affordance stays available for editing
+  // (clicking it still opens the editor — operator can re-show after).
   const annotationsByRef = useMemo(() => {
     const map = new Map<string, DemoAnnotation>();
+    if (!demoAnnotationsVisible) return map;
     for (const a of demoScript.annotations) map.set(a.bubbleRef, a);
     return map;
-  }, [demoScript]);
+  }, [demoScript, demoAnnotationsVisible]);
 
   const transcriptRefs = useMemo(() => {
     const set = new Set<string>();
@@ -811,42 +819,46 @@ function BubbleRow({
       {bubble.caption && (
         <div className="hf-preview-bubble-caption">{bubble.caption}</div>
       )}
-      {/* #1493 — primary click opens the demo annotation editor.
-          The lens-edit affordance lives below the bubble as a separate row. */}
-      <button
-        type="button"
-        className={bubbleClasses}
-        title={annotateLabel}
-        aria-label={annotateLabel}
-        onClick={() => onOpenAnnotation(bubbleRef)}
-      >
-        <span className="hf-preview-bubble-text">{bubble.text}</span>
-        <span className="hf-preview-bubble-edit">
-          <StickyNote size={11} />
-          <span>{annotation ? "Edit demo note" : "Add demo note"}</span>
-        </span>
-      </button>
+      {/* Primary click = edit the lens (the educator's main job).
+          Secondary row below carries the demo-note affordance (presenter use). */}
+      {inSidetray ? (
+        <button
+          type="button"
+          className={bubbleClasses}
+          title={bubble.lensLabel}
+          aria-label={bubble.lensLabel}
+          onClick={() => onOpenSidetray(bubble.lens)}
+        >
+          <span className="hf-preview-bubble-text">{bubble.text}</span>
+          <span className="hf-preview-bubble-edit">
+            <Edit3 size={11} />
+            <span>{bubble.lensLabel}</span>
+          </span>
+        </button>
+      ) : (
+        <Link
+          href={`/x/courses/${courseId}?tab=design&design_view=${bubble.lens}`}
+          className={bubbleClasses}
+          title={bubble.lensLabel}
+          aria-label={bubble.lensLabel}
+        >
+          <span className="hf-preview-bubble-text">{bubble.text}</span>
+          <span className="hf-preview-bubble-edit">
+            <Edit3 size={11} />
+            <span>{bubble.lensLabel}</span>
+          </span>
+        </Link>
+      )}
       <div className="hf-preview-bubble-lens-actions">
-        {inSidetray ? (
-          <button
-            type="button"
-            className="hf-preview-bubble-lens-link"
-            onClick={() => onOpenSidetray(bubble.lens)}
-            title={bubble.lensLabel}
-          >
-            <Edit3 size={11} />
-            <span>{bubble.lensLabel}</span>
-          </button>
-        ) : (
-          <Link
-            href={`/x/courses/${courseId}?tab=design&design_view=${bubble.lens}`}
-            className="hf-preview-bubble-lens-link"
-            title={bubble.lensLabel}
-          >
-            <Edit3 size={11} />
-            <span>{bubble.lensLabel}</span>
-          </Link>
-        )}
+        <button
+          type="button"
+          className="hf-preview-bubble-lens-link"
+          onClick={() => onOpenAnnotation(bubbleRef)}
+          title={annotateLabel}
+        >
+          <Clapperboard size={11} />
+          <span>{annotation ? "Edit demo note" : "Add demo note"}</span>
+        </button>
       </div>
       {annotation && (
         <AnnotationStickyNote
@@ -1015,7 +1027,7 @@ function AnnotationEditSidetray({
       >
         <header className="hf-preview-annotation-sidetray-header">
           <h2>
-            <StickyNote size={14} aria-hidden />
+            <Clapperboard size={14} aria-hidden />
             <span>{existing ? "Edit demo annotation" : "Add demo annotation"}</span>
           </h2>
           <button

--- a/apps/admin/components/chat/ChatPanel.tsx
+++ b/apps/admin/components/chat/ChatPanel.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useSession } from "next-auth/react";
+import { Eye, EyeOff } from "lucide-react";
 import { useChatContext, MODE_CONFIG, getMergedBannerKey, type ChatMode, type TuningScope } from "@/contexts/ChatContext";
 import { useEntityContext, ENTITY_COLORS, EntityBreadcrumb } from "@/contexts/EntityContext";
 import { useEntityDetection } from "@/hooks/useEntityDetection";
@@ -423,7 +424,7 @@ function ChatInput() {
 }
 
 export function ChatPanel() {
-  const { isOpen, closePanel, mode, chatLayout, setChatLayout, messages, clearHistory } = useChatContext();
+  const { isOpen, closePanel, mode, chatLayout, setChatLayout, messages, clearHistory, demoAnnotationsVisible, setDemoAnnotationsVisible } = useChatContext();
   const { breadcrumbs } = useEntityContext();
   const { data: session } = useSession();
 
@@ -513,6 +514,25 @@ export function ChatPanel() {
             </div>
           </div>
           <div className="chat-header-actions">
+            {mode === "DEMO" && (
+              <button
+                onClick={() => setDemoAnnotationsVisible(!demoAnnotationsVisible)}
+                className="chat-header-btn chat-header-btn--annotations-toggle"
+                title={
+                  demoAnnotationsVisible
+                    ? "Hide demo annotations on the Preview lens"
+                    : "Show demo annotations on the Preview lens"
+                }
+                aria-label={
+                  demoAnnotationsVisible
+                    ? "Hide demo annotations"
+                    : "Show demo annotations"
+                }
+                aria-pressed={demoAnnotationsVisible}
+              >
+                {demoAnnotationsVisible ? <Eye size={14} /> : <EyeOff size={14} />}
+              </button>
+            )}
             <button
               onClick={handleClearClick}
               className="chat-header-btn chat-header-btn--clear"

--- a/apps/admin/components/chat/chat-panel.css
+++ b/apps/admin/components/chat/chat-panel.css
@@ -521,6 +521,11 @@
   font-size: 14px;
 }
 
+.chat-header-btn--annotations-toggle[aria-pressed="true"] {
+  color: var(--accent-primary);
+  border-color: color-mix(in srgb, var(--accent-primary) 40%, transparent);
+}
+
 .chat-header-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/apps/admin/contexts/ChatContext.tsx
+++ b/apps/admin/contexts/ChatContext.tsx
@@ -74,6 +74,14 @@ interface ChatState {
    */
   tuningScope: TuningScope | null;
   /**
+   * Whether demo annotations (operator presenter notes) render on the
+   * Course Design Preview lens. Toggled from the 🎬 Demo tab header in
+   * ChatPanel. Persisted in settings. Default ON so a fresh operator sees
+   * their notes; OFF hides every saved annotation + sticky note until
+   * flipped back. Does NOT delete anything — purely a visibility filter.
+   */
+  demoAnnotationsVisible: boolean;
+  /**
    * #727 v1 — when set, every Assistant-mode message includes this ticket's
    * UUID so the API can inject the ticket + comment thread into the system
    * prompt. Set by the Feedback view's "Discuss with AI" button. Not
@@ -95,6 +103,11 @@ interface ChatActions {
    * AI re-asks on the next turn (#911 — closes the stale-toggle hole).
    */
   setTuningScope: (scope: TuningScope | null) => void;
+  /**
+   * Show / hide demo annotations on the Preview lens. UI lives on the
+   * Demo tab header in ChatPanel; Preview reads via useChatContext.
+   */
+  setDemoAnnotationsVisible: (visible: boolean) => void;
   /**
    * Set / clear the active ticket the Assistant should be discussing.
    * Pass `null` to clear (e.g. when closing the ticket detail panel).
@@ -178,7 +191,7 @@ export const MODE_CONFIG: Record<ChatMode, { label: string; icon: string; color:
   // contracts (`fanoutScope:'none'`, `no-ai-fanout-all` ESLint).
   DEMO: {
     label: "Demo",
-    icon: "▶",
+    icon: "🎬",
     color: "var(--accent-primary)",
     description: "Remote control for live demos — narrow action palette (test voice, dry-run, apply preset)",
   },
@@ -351,8 +364,8 @@ function persistMessages(messages: Record<ChatMode, ChatMessage[]>, userId: stri
   }
 }
 
-function loadSettings(userId: string | undefined): { isOpen: boolean; mode: ChatMode; chatLayout: ChatLayout; tuningScope: TuningScope | null } {
-  const defaults = { isOpen: false, mode: "ASSISTANT" as ChatMode, chatLayout: "vertical" as ChatLayout, tuningScope: "PLAYBOOK" as TuningScope | null };
+function loadSettings(userId: string | undefined): { isOpen: boolean; mode: ChatMode; chatLayout: ChatLayout; tuningScope: TuningScope | null; demoAnnotationsVisible: boolean } {
+  const defaults = { isOpen: false, mode: "ASSISTANT" as ChatMode, chatLayout: "vertical" as ChatLayout, tuningScope: "PLAYBOOK" as TuningScope | null, demoAnnotationsVisible: true };
   if (typeof window === "undefined") return defaults;
   try {
     const stored = localStorage.getItem(getSettingsKey(userId));
@@ -370,16 +383,20 @@ function loadSettings(userId: string | undefined): { isOpen: boolean; mode: Chat
     // setting maps to ASSISTANT; anything unrecognised falls back the
     // same way (safer than stranding the user on a missing tab).
     const mode = normalizeChatMode(parsed.mode);
-    return { isOpen: false, mode, chatLayout: parsed.chatLayout || "vertical", tuningScope: scope };
+    const demoAnnotationsVisible =
+      typeof parsed.demoAnnotationsVisible === "boolean"
+        ? parsed.demoAnnotationsVisible
+        : true;
+    return { isOpen: false, mode, chatLayout: parsed.chatLayout || "vertical", tuningScope: scope, demoAnnotationsVisible };
   } catch {
     return defaults;
   }
 }
 
-function persistSettings(isOpen: boolean, mode: ChatMode, chatLayout: ChatLayout, tuningScope: TuningScope | null, userId: string | undefined): void {
+function persistSettings(isOpen: boolean, mode: ChatMode, chatLayout: ChatLayout, tuningScope: TuningScope | null, demoAnnotationsVisible: boolean, userId: string | undefined): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(getSettingsKey(userId), JSON.stringify({ isOpen, mode, chatLayout, tuningScope }));
+    localStorage.setItem(getSettingsKey(userId), JSON.stringify({ isOpen, mode, chatLayout, tuningScope, demoAnnotationsVisible }));
   } catch {
     // Ignore storage errors
   }
@@ -393,6 +410,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [mode, setModeState] = useState<ChatMode>("ASSISTANT");
   const [chatLayout, setChatLayoutState] = useState<ChatLayout>("vertical");
   const [tuningScope, setTuningScopeState] = useState<TuningScope | null>("PLAYBOOK");
+  const [demoAnnotationsVisible, setDemoAnnotationsVisibleState] = useState<boolean>(true);
   const [messages, setMessages] = useState<Record<ChatMode, ChatMessage[]>>(createEmptyMessages);
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingMessageId, setStreamingMessageId] = useState<string | null>(null);
@@ -433,6 +451,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       setModeState(settings.mode);
       setChatLayoutState(settings.chatLayout);
       setTuningScopeState(settings.tuningScope);
+      setDemoAnnotationsVisibleState(settings.demoAnnotationsVisible);
       setLastUserId(userId);
       setInitialized(true);
     }
@@ -448,9 +467,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   // Persist settings when they change
   useEffect(() => {
     if (initialized) {
-      persistSettings(isOpen, mode, chatLayout, tuningScope, userId);
+      persistSettings(isOpen, mode, chatLayout, tuningScope, demoAnnotationsVisible, userId);
     }
-  }, [isOpen, mode, chatLayout, tuningScope, initialized, userId]);
+  }, [isOpen, mode, chatLayout, tuningScope, demoAnnotationsVisible, initialized, userId]);
 
   // #911 — reset the tuning scope toggle whenever the *type* of the active
   // entity changes (caller → playbook, playbook → caller, either → none, or
@@ -527,6 +546,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
   const setTuningScope = useCallback((scope: TuningScope | null) => {
     setTuningScopeState(scope);
+  }, []);
+
+  const setDemoAnnotationsVisible = useCallback((visible: boolean) => {
+    setDemoAnnotationsVisibleState(visible);
   }, []);
 
   const setDiscussionTicket = useCallback((id: string | null, ticketNumber: number | null = null) => {
@@ -815,6 +838,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     mode,
     chatLayout,
     tuningScope,
+    demoAnnotationsVisible,
     discussionTicketId,
     discussionTicketNumber,
     messages,
@@ -828,6 +852,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     setMode,
     setChatLayout,
     setTuningScope,
+    setDemoAnnotationsVisible,
     setDiscussionTicket,
     sendMessage,
     addMessage,

--- a/docs/DEMO-MODE-GUIDE.md
+++ b/docs/DEMO-MODE-GUIDE.md
@@ -1,0 +1,145 @@
+# Demo Mode — operator guide
+
+> Two surfaces, one icon (🎬). Both live in the Course Design Console.
+> One drives a live demo; the other rehearses what to say while it runs.
+
+Demo Mode is **two separate features that happen to share a name**:
+
+| Surface | What it is | Where it lives | When to use |
+|---|---|---|---|
+| **Demo chat tab** (🎬 Demo) | A scoped 5-tool chat palette — your remote control during a live demo | Cmd+K → Assistant panel → **🎬 Demo** tab | While a prospect is watching, to tweak the course and see the change on the next call within ~30s |
+| **Demo annotations** (🎬 Add demo note) | Presenter sticky notes attached to specific bubbles in the Preview transcript | Course Design Console → **Preview** lens → click "🎬 Add demo note" under any bubble | Before the demo, to rehearse what you'll say at each moment of Call 1 |
+
+They are **independent**. You can use either without the other. The shared 🎬 clapperboard icon is the visual signal that something is "for the demo, not for the learner".
+
+---
+
+## Surface 1 — the Demo chat tab (🎬)
+
+### What it is
+
+When you open Cmd+K → the Assistant panel and switch to the **🎬 Demo** tab, the AI assistant flips into a "demo operator" stance:
+
+- **Narrow tool surface** — five tools only (listed below). No course-creation, no caller lookup, no spec editing. The route enforces this structurally via the `DEMO_TOOLS` filter in `app/api/chat/route.ts`.
+- **Scoped to demo callers** — writes only fan out to callers with `CallerPlaybook.policyMode='demo'` (the test-admin escape-hatch callers, never real learners).
+- **Two-sentence answers** — the prompt instructs the model to skip prose. Tool results carry the truth; you carry the intent.
+
+### The five tools
+
+| Tool | Min role | What it does | When to say it |
+|---|---|---|---|
+| `test_voice` | SUPER_TESTER+ | Plays a short TTS sample of the course's current voice config | "Let me hear how Aura Asteria sounds saying the welcome" |
+| `dry_run_prompt` | SUPER_TESTER+ | Composes the prompt that would fire on the next call, **without** persisting a Call or ComposedPrompt | "What would the prompt look like for the next call?" |
+| `apply_demo_preset` | OPERATOR+ | Sets the four "good demo defaults" in one batch (see below) | "Make this course demo-ready" |
+| `precompose_for_fresh_learner` | OPERATOR+ | Pre-warms a demo caller's prompt so the next live call starts instantly | "Get Bertie ready for the next demo call" |
+| `open_sim` | VIEWER+ | Returns a navigation hint → `/x/sim/<callerId>` | "Let's jump into the chat" |
+
+### The four "good demo defaults" (`apply_demo_preset`)
+
+| Knob | Set to | Why |
+|---|---|---|
+| `firstCallMode` | `teach_immediately` | Skip onboarding fluff — get to the teaching fast |
+| `welcome.aboutYou.enabled` | `false` | Skip the pre-call survey |
+| `welcome.aiIntroCall.enabled` | `false` | Skip the AI intro call |
+| `BEH-RESPONSE-LEN` | `0.2` | Short, punchy AI responses (good for a watching audience) |
+
+The preset writes course-level config inline (`updatePlaybookConfig` with `fanoutScope: 'none'`) then surfaces the batch in the **pending-changes tray** with `aiSuggested: true`. You can click **Recompose this learner** to rebuild a specific demo caller's prompt now, or dismiss — the next call from any learner picks up the change automatically.
+
+### The demo loop
+
+```
+tweak  →  precompose_for_fresh_learner  →  open_sim  →  call  →  see the change
+(apply_demo_preset
+ or dry_run_prompt)
+```
+
+Two sentences in, change visible on the next call. That's the whole point.
+
+### Rules of honesty (built into the prompt)
+
+1. The AI **never** claims it applied / changed / pre-composed anything unless the matching tool call returned `ok: true` in the same turn.
+2. The AI **never** fans out to production learners. Writes are bounded to the demo set.
+3. The AI **never** proposes tools outside the five above. If you ask for something else (e.g. "add a new module"), it points you at the Course Design Console.
+
+---
+
+## Surface 2 — Demo annotations (🎬 sticky notes on Preview bubbles)
+
+### What it is
+
+The Course Design Console's **Preview** lens shows Call 1 as a WhatsApp-style chat transcript — every line the AI will say, every survey card, every onboarding step, every divider, in order. Each bubble can carry a **demo annotation**: a presenter note for *you*, the operator, to read off while running the demo.
+
+Annotations are stored in `Playbook.config.demoScript.annotations[]`, keyed by `bubbleRef`. They are:
+
+- **Operator-only metadata.** Never reach the learner. Never appear in the composed prompt. Never affect scoring.
+- **Not a compose input.** `demoScript` is in the `NEVER-COMPOSE` set — editing notes does not invalidate any learner's prompt cache.
+
+### How to add / edit / delete a note
+
+| Action | Click |
+|---|---|
+| Edit the prompt for this bubble | **The bubble itself** (clicks open the lens editor — Edit Greeting, Edit Onboarding, etc.) |
+| Add a demo note | **🎬 Add demo note** link directly underneath the bubble |
+| Edit an existing note | **🎬 Edit demo note** link, or click the saved sticky note that appears below the bubble |
+| Delete | Sticky-note editor → Delete button |
+
+**Hierarchy:** the bubble is the primary click target because editing the prompt is the educator's main job. The 🎬 demo note is one click deeper because it's a presenter aid, not a course feature.
+
+### What you can put in a note
+
+The annotation editor (slide-in from the right) has three fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| **Presenter note** | textarea, ≤4000 chars | What you'll say while this bubble is on screen. Free text. |
+| **Mark as wow moment** | checkbox | Flips the saved sticky note to the gold-bordered ★ variant — a visual marker for the highlight of the demo |
+| **Dwell duration** | optional integer (seconds) | How long you plan to linger on this bubble. Currently informational only — drives no timer or auto-advance |
+
+### Why notes appear "prefilled" when you re-open them
+
+Re-opening an existing annotation pre-loads its saved values (`presenterNote`, `isWowMoment`, `durationSecOnStep`) into the editor. That's **not** a template — it's just the note you (or a colleague) saved earlier. The empty placeholder *"What to say while this bubble is on screen…"* disappears as soon as you start typing.
+
+The **bubble text itself** ("Hi, welcome to your AI Tutoring Experience.") is the **script the AI will actually say** to the learner — it's pulled from the course's welcome / onboarding / module config, not from the annotation. That's why every bubble has text in it before you've added any notes: the bubbles are showing the live prompt; the notes are your sidecar.
+
+### What "WOW moment" means
+
+Marking a note as a wow moment changes nothing functionally — it only changes the **visual** of the saved sticky note (gold border + ★ icon) so you can spot the highlight at a glance while skimming Preview. Use it for the one or two beats of Call 1 that you want a prospect to remember (the personalised callback, the voice quality, the recall question that "just knew"). It's a scanning aid, not a behaviour switch.
+
+### Hiding annotations when you're not running the demo
+
+Open Cmd+K → switch to the 🎬 **Demo** tab → click the **Eye** button in the chat panel header.
+
+- Eye **on** (default): every saved annotation + sticky note renders under its bubble.
+- Eye **off**: bubbles render clean, no presenter notes visible. The 🎬 "Add demo note" affordance is still clickable so you can keep editing — clicking it re-opens the editor.
+
+The toggle is per-user, persisted in localStorage; nothing is deleted. Use **off** when reviewing the course as a teacher (you want to see the learner's view, no presenter clutter). Use **on** when prepping for or running the demo (you want your script visible).
+
+---
+
+## Cmd+K cheat sheet
+
+| Goal | Keystrokes |
+|---|---|
+| Open the Assistant panel | `Cmd+K` |
+| Switch to Demo chat (🎬) | `Cmd+K` → click **🎬 Demo** tab |
+| Hide / show all demo annotations on Preview | `Cmd+K` → Demo tab → **Eye / EyeOff** button in panel header |
+| See the Call 1 transcript with annotations | Navigate to `/x/courses/<id>?tab=design` (Preview is the default lens) |
+| Add a presenter note to a specific bubble | Preview lens → 🎬 Add demo note under the bubble |
+| Apply the four good-demo defaults | Demo chat → "make this course demo-ready" (calls `apply_demo_preset`) |
+| Hear the voice | Demo chat → "play the welcome" (calls `test_voice`) |
+| Pre-warm a demo caller before showing the prospect | Demo chat → "get \<caller name\> ready" (calls `precompose_for_fresh_learner`) |
+
+---
+
+## Where this lives in the code
+
+| Surface | File |
+|---|---|
+| Demo chat system prompt + 5 tools | `apps/admin/lib/chat/demo-system-prompt.ts` |
+| Demo chat tool registry | `apps/admin/lib/chat/admin-tools.ts` (`DEMO_TOOLS` filter) |
+| Demo chat route branch | `apps/admin/app/api/chat/route.ts` |
+| Demo chat tab icon (🎬) | `apps/admin/contexts/ChatContext.tsx` (`MODE_CONFIG.DEMO`) |
+| Eye/EyeOff annotation-visibility toggle | `apps/admin/components/chat/ChatPanel.tsx` header + `ChatContext.demoAnnotationsVisible` |
+| Preview lens — bubble + annotation UI | `apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx` |
+| Annotation persistence (REST) | `apps/admin/app/api/courses/[courseId]/demo-script/route.ts` |
+| Annotation persistence (DB) | `Playbook.config.demoScript.annotations[]` (JSON column) |


### PR DESCRIPTION
## Summary

- **Primary/secondary flip on PreviewLens bubbles.** The bubble itself now opens the lens editor (Edit Greeting / Edit Onboarding / etc.) — the educator's main job gets the primary click. The 🎬 demo-note affordance moves to a secondary row below.
- **🎬 clapperboard icon everywhere.** Chat tab \`MODE_CONFIG.DEMO.icon\` (\`▶\` → \`🎬\`), the bubble's secondary "Add demo note" affordance, and the annotation editor header all now share the same glyph.
- **Eye/EyeOff visibility toggle.** A new per-user toggle in the Demo-tab chat-panel header hides every saved sticky note across the Preview lens. Persisted in localStorage with the other chat settings. Default ON.
- **Operator guide.** New \`docs/DEMO-MODE-GUIDE.md\` covering both demo surfaces (chat tab vs preview annotations), the 5-tool palette, the demo loop, prefill/WOW behaviour, and the new visibility toggle.

## Verified by

- \`tests/components/chat/ChatModeTabs.test.tsx\` — 8/8 pass (MODE_CONFIG structural shape preserved; only the icon string changed, no pinned label or key broke)
- \`tests/api/courses/demo-script.test.ts\` — 11/11 pass (annotation persistence unaffected — UI swap is pure click-handler + icon rewiring)
- \`tsc --noEmit\` clean on changed files; pre-push hook ran tsc + eslint on the 3 changed TS files → green
- Manual: \`Clapperboard\` confirmed exported by \`lucide-react\` package; no new dep
- Manual: \`grep\` confirmed no other call sites in the codebase pin \`StickyNote\` icon or \`▶\` glyph for the demo surface

## Test plan

- [ ] On hf-dev, open a course's Design tab → Preview lens. Confirm:
  - Clicking a bubble (e.g. the Greeting bubble) opens the lens sidetray (was previously: opened the demo annotation editor)
  - "🎬 Add demo note" link sits below the bubble; clicking it still opens the annotation editor
  - The annotation editor header shows 🎬
- [ ] Cmd+K → switch to Demo tab. Confirm tab icon is 🎬 (was ▶). Click the Eye button in the panel header — saved sticky notes hide on Preview. Click again → reappear.
- [ ] Refresh the page → toggle state persists (localStorage round-trip).

Closes the operator-confusion thread around \`docs/DEMO-MODE-GUIDE.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)