### PR TITLE
chore(wizard-refactor): scaffolding — ESLint rule broadened + dispatcher tests pinned

### DIFF
--- a/apps/admin/eslint-rules/no-ai-fanout-all.mjs
+++ b/apps/admin/eslint-rules/no-ai-fanout-all.mjs
@@ -31,11 +31,16 @@ const WATCHED_HELPER_NAMES = new Set([
  *
  * If a new AI tool surface lands (e.g. a new chat route, a new palette
  * command bundle), add its path here. The list is the contract.
+ *
+ * Fragments are directory-or-file-prefix substrings so the rule survives
+ * a monolith → per-tool-file split: `lib/chat/wizard-tool-executor`
+ * matches both `…/wizard-tool-executor.ts` AND
+ * `…/wizard-tool-executor/tools/create_course.ts` after the split lands.
  */
 const AI_TOOL_PATH_FRAGMENTS = [
-  "lib/chat/wizard-tool-executor.ts",
-  "lib/chat/conversational-wizard-tools.ts",
-  "lib/chat/admin-tool-handlers.ts",
+  "lib/chat/wizard-tool-executor",
+  "lib/chat/conversational-wizard-tools",
+  "lib/chat/admin-tool-handlers",
   "app/api/chat/route.ts",
 ];
 

--- a/apps/admin/tests/eslint-rules/no-ai-fanout-all.test.ts
+++ b/apps/admin/tests/eslint-rules/no-ai-fanout-all.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for `eslint-rules/no-ai-fanout-all.mjs` (#854 / #878).
+ *
+ * Pins:
+ *   - rule fires inside each of the 4 guarded AI-tool surfaces
+ *   - rule survives the wizard-tool-executor monolith → per-tool-file split
+ *     (matches both `lib/chat/wizard-tool-executor.ts` AND
+ *     `lib/chat/wizard-tool-executor/tools/create_course.ts`)
+ *   - rule does NOT fire in unrelated files (human-driven API routes,
+ *     UI components) — those are allowed to pass `fanoutScope: 'all'`
+ *   - rule fires on all 3 watched helpers (updatePlaybookConfig,
+ *     updateDomainConfig, updateAnalysisSpecConfig)
+ *   - rule allows the safe scopes (`'caller'`, `'none'`)
+ *   - known false-negative caveat: pre-assembled options var is NOT
+ *     flagged (documented limitation, mirrored from sibling
+ *     no-direct-*-config-write rules)
+ */
+
+import { RuleTester } from "eslint";
+import rule from "../../eslint-rules/no-ai-fanout-all.mjs";
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+// Synthetic paths matching each guarded path fragment.
+const WIZARD_MONOLITH = "/repo/lib/chat/wizard-tool-executor.ts";
+const WIZARD_PER_TOOL =
+  "/repo/lib/chat/wizard-tool-executor/tools/create_course.ts";
+const WIZARD_INDEX = "/repo/lib/chat/wizard-tool-executor/index.ts";
+const CONVERSATIONAL_TOOLS = "/repo/lib/chat/conversational-wizard-tools.ts";
+const ADMIN_HANDLERS_MONOLITH = "/repo/lib/chat/admin-tool-handlers.ts";
+const ADMIN_HANDLERS_PER_ENTITY =
+  "/repo/lib/chat/admin-tool-handlers/playbook.ts";
+const CHAT_ROUTE = "/repo/app/api/chat/route.ts";
+
+// Unrelated paths — rule must NOT fire here.
+const HUMAN_API_ROUTE = "/repo/app/api/playbooks/[id]/config/route.ts";
+const UI_COMPONENT = "/repo/components/RecomposeButton.tsx";
+
+const callAll = (helper: string) =>
+  `${helper}("pb-1", { x: 1 }, { fanoutScope: 'all' });`;
+const callCaller = (helper: string) =>
+  `${helper}("pb-1", { x: 1 }, { fanoutScope: 'caller' });`;
+const callNone = (helper: string) =>
+  `${helper}("pb-1", { x: 1 }, { fanoutScope: 'none' });`;
+
+tester.run("no-ai-fanout-all", rule as never, {
+  valid: [
+    // ────────────────────────────────────────────────────────────────────
+    // Allowed scopes inside guarded paths
+    // ────────────────────────────────────────────────────────────────────
+    { filename: WIZARD_MONOLITH, code: callCaller("updatePlaybookConfig") },
+    { filename: WIZARD_MONOLITH, code: callNone("updatePlaybookConfig") },
+    { filename: ADMIN_HANDLERS_MONOLITH, code: callCaller("updateDomainConfig") },
+    { filename: CHAT_ROUTE, code: callNone("updateAnalysisSpecConfig") },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Rule does NOT fire outside guarded paths — humans may fan out
+    // ────────────────────────────────────────────────────────────────────
+    { filename: HUMAN_API_ROUTE, code: callAll("updatePlaybookConfig") },
+    { filename: UI_COMPONENT, code: callAll("updateDomainConfig") },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Documented false-negative — pre-assembled options var is NOT flagged.
+    // Pinned so future-us doesn't accidentally "fix" it without the AST
+    // work the sibling rules also share.
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: WIZARD_MONOLITH,
+      code: `
+        const opts = { fanoutScope: 'all' };
+        updatePlaybookConfig("pb-1", { x: 1 }, opts);
+      `,
+    },
+
+    // Non-watched helper calls — rule ignores them.
+    {
+      filename: WIZARD_MONOLITH,
+      code: "someOtherHelper('pb-1', { x: 1 }, { fanoutScope: 'all' });",
+    },
+  ],
+  invalid: [
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #1 — wizard monolith (pre-refactor shape)
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: WIZARD_MONOLITH,
+      code: callAll("updatePlaybookConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+    {
+      filename: WIZARD_MONOLITH,
+      code: callAll("updateDomainConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+    {
+      filename: WIZARD_MONOLITH,
+      code: callAll("updateAnalysisSpecConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #1 — wizard POST-REFACTOR shape (the load-bearing case
+    // for this PR). Per-tool file + index file under the directory must
+    // BOTH still trip the rule.
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: WIZARD_PER_TOOL,
+      code: callAll("updatePlaybookConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+    {
+      filename: WIZARD_INDEX,
+      code: callAll("updateDomainConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #2 — conversational-wizard-tools (sibling AI surface)
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: CONVERSATIONAL_TOOLS,
+      code: callAll("updatePlaybookConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #3 — admin-tool-handlers (also queued for refactor;
+    // pin both monolith + future per-entity-file shapes)
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: ADMIN_HANDLERS_MONOLITH,
+      code: callAll("updatePlaybookConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+    {
+      filename: ADMIN_HANDLERS_PER_ENTITY,
+      code: callAll("updatePlaybookConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+
+    // ────────────────────────────────────────────────────────────────────
+    // Guard scope #4 — chat route
+    // ────────────────────────────────────────────────────────────────────
+    {
+      filename: CHAT_ROUTE,
+      code: callAll("updateAnalysisSpecConfig"),
+      errors: [{ messageId: "aiFanoutAll" }],
+    },
+  ],
+});

--- a/apps/admin/tests/lib/chat/wizard-tool-executor-dispatcher.test.ts
+++ b/apps/admin/tests/lib/chat/wizard-tool-executor-dispatcher.test.ts
@@ -400,10 +400,10 @@ describe("executeWizardTool / create_course (reuse path — #607 invariant)", ()
       "subj-1",
     );
     // Critical: updatePlaybookConfig fired with reason carrying reuse-path label.
-    expect(mockUpdatePlaybookConfig).toHaveBeenCalled();
-    const call = mockUpdatePlaybookConfig.mock.calls[0];
-    expect(call[0]).toBe(draftPbId);
-    const opts = call[2] as { reason: string };
-    expect(opts.reason).toMatch(/existing path/);
+    expect(mockUpdatePlaybookConfig).toHaveBeenCalledWith(
+      draftPbId,
+      expect.any(Function),
+      expect.objectContaining({ reason: expect.stringContaining("existing path") }),
+    );
   });
 });

--- a/apps/admin/tests/lib/chat/wizard-tool-executor-dispatcher.test.ts
+++ b/apps/admin/tests/lib/chat/wizard-tool-executor-dispatcher.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Golden tests for `executeWizardTool` — the dispatcher contract.
+ *
+ * Purpose
+ * -------
+ * Pre-flight for the wizard-tool-executor monolith → per-tool-file split
+ * (Phase 1 of docs/audit/HANDOFF-large-file-refactor.md). The split moves
+ * each `case` body into its own file under
+ * `lib/chat/wizard-tool-executor/tools/<name>.ts`. These tests pin the
+ * dispatcher behaviour at the entrypoint (`executeWizardTool(toolName,
+ * input, userId, setupData?)`) BEFORE the move, so the per-tool extraction
+ * is behaviour-preserving by construction — any drift fails here.
+ *
+ * What's covered (Tech Lead minimum-5, this branch)
+ * -------------------------------------------------
+ *   1. `mark_complete`         — terminal lifecycle guards + success shape
+ *   2. `create_institution`    — already-exists short-circuit
+ *   3. `update_setup`          — progressionMode rejection contract (#398)
+ *   4. `create_course` (graph) — pre-launch hard-fail when canLaunch=false
+ *   5. `create_course` (reuse) — `unlinkNonPrimaryPlaybookSubjects` fires
+ *                                on the existing-playbook reuse path
+ *                                (ai-to-db-guard.md row 8 / #607)
+ *
+ * What's NOT covered (intentional)
+ * --------------------------------
+ *   - Full happy-path snapshots of every branch in update_setup /
+ *     create_course (the executor has ~370 + ~1360 lines of branch code;
+ *     covering exhaustively would inflate the test bed to thousands of
+ *     LOC for a refactor that should land in days). The refactor PR can
+ *     add per-tool tests as each case is extracted.
+ *   - `create_institution` create-new transaction body — the test pins
+ *     the happy guard path only. The transaction is well-isolated and
+ *     its own integration test exists at the prisma level.
+ *
+ * Mock strategy
+ * -------------
+ * The executor uses dynamic imports (`await import("@/lib/…")`) so each
+ * test mocks only the modules its case body actually loads. `vi.mock`
+ * hoists, so per-test mock returns are set via `mockResolvedValueOnce`
+ * inside `beforeEach`. Shared `mockPrisma` at the top of the file.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Shared prisma mock — every case touches some subset of these models ──
+const mockPrisma = {
+  playbook: { findUnique: vi.fn(), update: vi.fn() },
+  domain: { findUnique: vi.fn(), findFirst: vi.fn() },
+  institution: { findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn() },
+  institutionType: { findFirst: vi.fn() },
+  subject: { findUnique: vi.fn() },
+  user: { update: vi.fn() },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// Default $transaction passthrough: feed the same mockPrisma to the
+// callback so create_institution's create+create+update chain runs.
+beforeEach(() => {
+  for (const model of Object.values(mockPrisma)) {
+    if (typeof model === "object" && model) {
+      for (const fn of Object.values(model)) {
+        if (typeof fn === "function" && "mockReset" in fn) (fn as ReturnType<typeof vi.fn>).mockReset();
+      }
+    }
+  }
+  mockPrisma.$transaction.mockReset();
+  mockPrisma.$transaction.mockImplementation(async (cb: (tx: typeof mockPrisma) => unknown) => cb(mockPrisma));
+});
+
+// ─── Dynamic-import targets used across cases ────────────────────────────
+
+const mockUpdatePlaybookConfig = vi.fn(async () => undefined);
+vi.mock("@/lib/playbook/update-playbook-config", () => ({
+  updatePlaybookConfig: mockUpdatePlaybookConfig,
+}));
+
+const mockUpdateDomainConfig = vi.fn(async () => undefined);
+vi.mock("@/lib/domain/update-domain-config", () => ({
+  updateDomainConfig: mockUpdateDomainConfig,
+}));
+
+const mockValidateSetupFields = vi.fn();
+vi.mock("@/lib/wizard/validate-setup-fields", () => ({
+  validateSetupFields: mockValidateSetupFields,
+}));
+
+const mockEvaluateGraph = vi.fn();
+vi.mock("@/lib/wizard/graph-evaluator", () => ({
+  evaluateGraph: mockEvaluateGraph,
+}));
+
+const mockUnlinkNonPrimaryPlaybookSubjects = vi.fn(async () => ({
+  removed: 0,
+  displaced: [] as { subjectName: string }[],
+}));
+const mockRemovePlaceholderPlaybookSubjects = vi.fn(async () => undefined);
+const mockIsPlaceholderSubjectName = vi.fn((s: string) => s.toLowerCase() === "course");
+vi.mock("@/lib/knowledge/cleanup-placeholder-subjects", () => ({
+  unlinkNonPrimaryPlaybookSubjects: mockUnlinkNonPrimaryPlaybookSubjects,
+  removePlaceholderPlaybookSubjects: mockRemovePlaceholderPlaybookSubjects,
+  isPlaceholderSubjectName: mockIsPlaceholderSubjectName,
+}));
+
+// slugify is dynamically imported; vitest's auto-mock would clobber it.
+// Provide a thin real impl since several cases depend on its output for
+// transaction params. slugify ships its own default export.
+vi.mock("slugify", () => ({
+  default: (s: string, opts?: { lower?: boolean; strict?: boolean }) => {
+    let out = s.replace(/[^A-Za-z0-9\s-]/g, "").replace(/\s+/g, "-");
+    if (opts?.lower) out = out.toLowerCase();
+    return out;
+  },
+}));
+
+// ─── Helper: import executor freshly per-test so mocks above are in scope ─
+async function loadExecutor() {
+  const mod = await import("@/lib/chat/wizard-tool-executor");
+  return mod.executeWizardTool;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// 1. mark_complete
+// ════════════════════════════════════════════════════════════════════════
+
+describe("executeWizardTool / mark_complete", () => {
+  it("BLOCKS with is_error when setupData has no draftPlaybookId", async () => {
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool("mark_complete", {}, "user-1", {});
+    expect(result.is_error).toBe(true);
+    const body = JSON.parse(result.content);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/no course has been created/i);
+    // Critical: prisma never touched without a playbook id.
+    expect(mockPrisma.playbook.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("BLOCKS with is_error when the playbook id doesn't resolve in DB", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce(null);
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "mark_complete",
+      {},
+      "user-1",
+      { draftPlaybookId: "pb-missing" },
+    );
+    expect(result.is_error).toBe(true);
+    const body = JSON.parse(result.content);
+    expect(body.error).toMatch(/doesn't exist in the database/i);
+  });
+
+  it("BLOCKS with is_error when the playbook has no curriculum modules", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "Course Alpha",
+      playbookCurricula: [
+        { curriculum: { id: "cur-1", _count: { modules: 0 } } },
+      ],
+    });
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "mark_complete",
+      {},
+      "user-1",
+      { draftPlaybookId: "pb-1" },
+    );
+    expect(result.is_error).toBe(true);
+    expect(JSON.parse(result.content).error).toMatch(/no curriculum modules yet/i);
+  });
+
+  it("returns 'Setup complete' when playbook + curriculum + modules exist", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "Course Alpha",
+      playbookCurricula: [
+        { curriculum: { id: "cur-1", _count: { modules: 5 } } },
+      ],
+    });
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "mark_complete",
+      {},
+      "user-1",
+      { draftPlaybookId: "pb-1" },
+    );
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toMatch(/Setup complete/i);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// 2. create_institution
+// ════════════════════════════════════════════════════════════════════════
+
+describe("executeWizardTool / create_institution", () => {
+  it("short-circuits when setupData carries valid existing UUIDs", async () => {
+    // cuid shape: leading 'c' + 24 alphanumeric chars. validUuid accepts /^c[a-z0-9]{24,}$/i.
+    const cuid = "ckabcdefghijklmnopqrstuvw";
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "create_institution",
+      { name: "Test Org" },
+      "user-1",
+      {
+        existingDomainId: cuid,
+        existingInstitutionId: cuid,
+      },
+    );
+    expect(result.is_error).toBeUndefined();
+    const body = JSON.parse(result.content);
+    expect(body.ok).toBe(true);
+    expect(body.alreadyExisted).toBe(true);
+    expect(body.institutionId).toBe(cuid);
+    expect(body.domainId).toBe(cuid);
+    // No write attempted on the short-circuit branch.
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns alreadyExisted when resolveInstitutionByName finds a match", async () => {
+    // resolveInstitutionByName queries `prisma.institution.findFirst` then
+    // reads institution.domains[0] for domainId + subjects/playbooks merge.
+    mockPrisma.institution.findFirst.mockResolvedValueOnce({
+      id: "inst-1",
+      name: "Test Org",
+      type: { slug: "school" },
+      domains: [
+        {
+          id: "dom-1",
+          kind: "INSTITUTION",
+          subjects: [],
+          playbooks: [],
+        },
+      ],
+    });
+
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "create_institution",
+      { name: "Test Org" },
+      "user-1",
+      {},
+    );
+    const body = JSON.parse(result.content);
+    expect(body.ok).toBe(true);
+    expect(body.alreadyExisted).toBe(true);
+    expect(body.institutionId).toBe("inst-1");
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// 3. update_setup — progressionMode rejection contract (#398)
+// ════════════════════════════════════════════════════════════════════════
+
+describe("executeWizardTool / update_setup", () => {
+  it("REJECTS progressionMode when not already set in setupData (#398)", async () => {
+    mockValidateSetupFields.mockReturnValueOnce({
+      validated: { progressionMode: "ai-led", interactionPattern: "voice-first" },
+      corrections: [],
+      errors: [],
+    });
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "update_setup",
+      { fields: { progressionMode: "ai-led", interactionPattern: "voice-first" } },
+      "user-1",
+      {}, // progressionMode NOT already set
+    );
+    // The valid sibling (interactionPattern) still saves — content threads
+    // the rejection note. progressionMode does NOT appear in the saved set.
+    expect(result.content).toMatch(/progressionMode NOT saved/i);
+    expect(result.content).toMatch(/dataKey:"progressionMode"/);
+  });
+
+  it("ALLOWS progressionMode write when already set in setupData (idempotent re-affirm)", async () => {
+    mockValidateSetupFields.mockReturnValueOnce({
+      validated: { progressionMode: "ai-led" },
+      corrections: [],
+      errors: [],
+    });
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "update_setup",
+      { fields: { progressionMode: "ai-led" } },
+      "user-1",
+      { progressionMode: "ai-led" }, // already set — rewrite allowed
+    );
+    expect(result.content).not.toMatch(/progressionMode NOT saved/i);
+  });
+
+  it("auto-corrects bad field names via validateSetupFields", async () => {
+    mockValidateSetupFields.mockReturnValueOnce({
+      validated: { progressionMode: "ai-led" },
+      corrections: [{ from: "moduleProgression", to: "progressionMode", reason: "alias" }],
+      errors: [],
+    });
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "update_setup",
+      { fields: { moduleProgression: "ai-led" } },
+      "user-1",
+      { progressionMode: "ai-led" }, // already set so the corrected key isn't re-rejected
+    );
+    // validateSetupFields was invoked with the raw fields
+    expect(mockValidateSetupFields).toHaveBeenCalledWith({ moduleProgression: "ai-led" });
+    expect(result.is_error).toBeUndefined();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// 4. create_course — pre-launch graph guard
+// ════════════════════════════════════════════════════════════════════════
+
+describe("executeWizardTool / create_course (graph guard)", () => {
+  it("HARD-FAILS with is_error when evaluateGraph.canLaunch is false", async () => {
+    mockEvaluateGraph.mockReturnValueOnce({
+      canLaunch: false,
+      missingRequired: [
+        { key: "courseName", label: "Course name" },
+        { key: "subjectDiscipline", label: "Subject discipline" },
+      ],
+    });
+    const executeWizardTool = await loadExecutor();
+    const result = await executeWizardTool(
+      "create_course",
+      {},
+      "user-1",
+      {},
+    );
+    expect(result.is_error).toBe(true);
+    const body = JSON.parse(result.content);
+    expect(body.ok).toBe(false);
+    expect(body.missingKeys).toEqual(["courseName", "subjectDiscipline"]);
+    expect(body.missingLabels).toEqual(["Course name", "Subject discipline"]);
+    // Critical: did NOT touch prisma — early hard fail.
+    expect(mockPrisma.playbook.findUnique).not.toHaveBeenCalled();
+    expect(mockUpdatePlaybookConfig).not.toHaveBeenCalled();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// 5. create_course — reuse path #607 unlink guard (ai-to-db-guard row 8)
+// ════════════════════════════════════════════════════════════════════════
+
+describe("executeWizardTool / create_course (reuse path — #607 invariant)", () => {
+  it("calls unlinkNonPrimaryPlaybookSubjects when course-scoped Subject exists on reuse", async () => {
+    // Graph green-lit.
+    mockEvaluateGraph.mockReturnValueOnce({ canLaunch: true, missingRequired: [] });
+
+    // setupData carries a valid draftPlaybookId (cuid shape — leading c + 24 alphanumeric).
+    const draftPbId = "ckpb1abcdefghijklmnopqrstu";
+    const existingDomainId = "ckdomabcdefghijklmnopqrstu";
+    const courseName = "Reused Course";
+    const subjectDiscipline = "Geometry";
+
+    // playbook.findUnique #1 — name lookup for the "rename mismatch" guard.
+    // Same name → reuse-path proceeds.
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({ name: courseName });
+    // playbook.findUnique #2 — the reuse branch's existingPb fetch.
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: draftPbId,
+      domainId: existingDomainId,
+      config: {},
+    });
+    // domain.findUnique — slug for expectedSubjectSlug
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({ slug: "test-domain" });
+    // subject.findUnique — course-scoped Subject DOES exist → unlink fires.
+    mockPrisma.subject.findUnique.mockResolvedValueOnce({ id: "subj-1" });
+
+    // Unlink returns 1 displaced.
+    mockUnlinkNonPrimaryPlaybookSubjects.mockResolvedValueOnce({
+      removed: 1,
+      displaced: [{ subjectName: "Stale Subject" }],
+    });
+
+    const executeWizardTool = await loadExecutor();
+    // Suppress noisy console.log under the reuse-path success branch.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await executeWizardTool(
+        "create_course",
+        { courseName, subjectDiscipline },
+        "user-1",
+        {
+          draftPlaybookId: draftPbId,
+          existingDomainId,
+        },
+      );
+    } catch {
+      // The full reuse path continues into enrollment / lesson-plan paths
+      // we haven't mocked — a downstream throw is expected. The assertions
+      // below are about the #607 guard, which fires BEFORE any throw.
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    // Critical: #607 unlink fired with the resolved Subject id.
+    expect(mockUnlinkNonPrimaryPlaybookSubjects).toHaveBeenCalledWith(
+      draftPbId,
+      "subj-1",
+    );
+    // Critical: updatePlaybookConfig fired with reason carrying reuse-path label.
+    expect(mockUpdatePlaybookConfig).toHaveBeenCalled();
+    const call = mockUpdatePlaybookConfig.mock.calls[0];
+    expect(call[0]).toBe(draftPbId);
+    const opts = call[2] as { reason: string };
+    expect(opts.reason).toMatch(/existing path/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of [docs/audit/HANDOFF-large-file-refactor.md](https://github.com/WANDERCOLTD/HF/blob/main/docs/audit/HANDOFF-large-file-refactor.md) — pre-flight scaffolding for the upcoming `lib/chat/wizard-tool-executor.ts` monolith → per-tool-file split. Two tightly-coupled commits, deliberately on one PR because both belong to the same "before we move anything, lock the safety net" step.

**Why this is the right shape now:** Tech Lead reviewed the wizard executor against current state and flagged two structural risks that MUST be addressed before any case body moves. Both are addressed here.

## What's in this PR

### Commit 1 — `chore(eslint): broaden no-ai-fanout-all path match for wizard refactor`

`eslint-rules/no-ai-fanout-all.mjs` hardcodes the literal path `"lib/chat/wizard-tool-executor.ts"` in `AI_TOOL_PATH_FRAGMENTS`. After the split, the 9 calls to `updatePlaybookConfig` / `updateDomainConfig` spread across `lib/chat/wizard-tool-executor/tools/*.ts` would silently fall outside the substring match — the `fanoutScope: 'all'` guard (epic #854 safety property: cohort fan-out is human-only) would go dark.

Fix: change the 3 wizard/handler fragments from `*.ts` literals to directory prefixes so the substring match catches BOTH the monolith AND post-refactor shapes.

- `"lib/chat/wizard-tool-executor"` (covers `.ts` + future `/tools/*.ts`)
- `"lib/chat/conversational-wizard-tools"` (parity)
- `"lib/chat/admin-tool-handlers"` (handlers refactor is queued next)
- `"app/api/chat/route.ts"` (single-file, unchanged)

Verified zero collateral via a `find` sweep — only the 3 current monolith files match the broadened fragments today.

New test `tests/eslint-rules/no-ai-fanout-all.test.ts` (17 assertions) pins both shapes — monolith and per-tool-file — and the negative case that human-driven API routes / UI components stay unguarded.

### Commit 2 — `chore(test): pin executeWizardTool dispatcher behaviour before refactor`

New `tests/lib/chat/wizard-tool-executor-dispatcher.test.ts` (11 assertions) pins the dispatcher contract at the entrypoint (`executeWizardTool(toolName, input, userId, setupData?)`) so the per-tool extraction PR can be reviewed as "did the tests stay green" rather than "did I miss a branch".

Covers the Tech Lead minimum-5 scenarios:

| Case | Pinned behaviour |
|---|---|
| `mark_complete` | blocks on missing draftPlaybookId / missing playbook / zero modules; returns "Setup complete" happy-path |
| `create_institution` | short-circuits when setupData carries valid UUIDs; returns alreadyExisted on name-resolve match |
| `update_setup` | rejects `progressionMode` write when not already-set (#398); allows re-affirm; auto-corrects bad field names |
| `create_course` (graph) | hard-fails with `is_error` when `evaluateGraph.canLaunch` is false |
| `create_course` (reuse path) | calls `unlinkNonPrimaryPlaybookSubjects` when course-scoped Subject exists (ai-to-db-guard.md row 8 / #607 invariant) |

### Commit 3 — `chore(test): tsc-clean mock.calls assertion in dispatcher test`

Drive-by — replace indexed `mock.calls[0]` access (which vitest infers as a zero-arity tuple, tripping TS2493) with `toHaveBeenCalledWith` + `expect.objectContaining`. Same assertion semantics, no inference fight.

## What's NOT in this PR (intentional)

- The actual file split. That lands in the follow-on PR; this PR makes that PR mechanical (ESLint rule + tests both green = behaviour-preserving by construction).
- Exhaustive coverage of every branch in `update_setup` (~370 lines) and `create_course` (~1360 lines). Per-tool tests get added as each case is extracted in the refactor PR.

## Verified by

- `npx vitest run tests/eslint-rules/no-ai-fanout-all.test.ts tests/lib/chat/wizard-tool-executor-dispatcher.test.ts` — 28/28 green
- `npx tsc --noEmit` — no errors on the new files (pre-push hook confirmed)
- `find` sweep on the broadened fragments — only the 3 current monolith files match

## Test plan

- [ ] CI: tsc + lint + vitest all green
- [ ] CI: the new ESLint rule test (`no-ai-fanout-all.test.ts`) green
- [ ] CI: the new dispatcher test (`wizard-tool-executor-dispatcher.test.ts`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)