### PR TITLE
chore(process): #1534 verify-before-fix covers conditional story activation

### DIFF
--- a/.claude/rules/verify-before-fix.md
+++ b/.claude/rules/verify-before-fix.md
@@ -32,6 +32,28 @@ Most acutely: composed-prompt regressions ("the recap renders garbage"),
 caller-state bugs ("Bertie's voice is wrong"), pipeline silent-skip bugs,
 and anything described as "sometimes happens".
 
+### Conditional story activation is also a fix trigger
+
+Conditional story activation — opening a story because a canary FAILed, an
+audit probe returned a finding, or an automated check flipped red — is a fix
+trigger and must satisfy the same evidence bar as a fix PR. The activation
+PR body MUST include a `## Verified by` section with a live citation (SQL
+query result, log subject line, curl probe, or DB row count) — not only a
+test output. A test output may reflect a timeout, fixture gap, mocking
+artifact, or environment skew, any of which are indistinguishable from a
+real failure at the issue-filing step.
+
+This is the lesson of #1515: PR #1525 declared G9 (CallerMemory zero-writes)
+a real failure based on a canary run under a 10s timeout — the pipeline
+never completed, so `learn.memories = 0` was a fixture artifact, not live
+data. Story #1515 was activated and required two follow-on docs-audit PRs
+(#1527 + #1528) to close by disproving the premise on live SQL that took
+under a minute to run.
+
+The rule: if you are about to file or activate a story from an automated
+verdict, run the live probe FIRST. If the probe contradicts the test output,
+close the activation with the evidence; do not open the story.
+
 ## Required Evidence Forms
 
 | Evidence type | When to use | Example |
@@ -61,8 +83,9 @@ const result = await prisma.composedPrompt.findFirst({
 | Location | Mechanism | What it prevents |
 |---|---|---|
 | `scripts/gh-pr-create.sh` | Wraps `gh pr create`; rejects PRs whose body lacks a `## Verified by` section with concrete evidence | Shipping a fix-story without a citation (the #1406 fingerprint) |
-| `docs/kb/guard-registry.md#guard-verify-before-fix` | Catalogue entry | Discoverability — every guard points back at its row |
+| `docs/kb/guard-registry.md#guard-verify-before-fix` | Catalogue entry — covers both fix PRs and conditional story activation | Discoverability — every guard points back at its row |
 | `memory/feedback_verify_before_fix_misread_2026_06_09.md` | Operator memory | The original incident + the rule it produced |
+| Convention (no code gate today) | Conditional story activation PR body MUST carry `## Verified by` with a live citation — see #1515 / #1525 / #1527 / #1528 chain | Opening a story from a timed-out canary or fixture-broken probe (the #1515 fingerprint) |
 
 ## When NOT to apply
 

--- a/docs/kb/guard-registry.md
+++ b/docs/kb/guard-registry.md
@@ -294,15 +294,27 @@ re-introduces 25/34 removed lines, 73%). **Survives hardening:** AP-1 is a
 methodology fitness function — architecture-independent.
 
 <a id="guard-verify-before-fix"></a>
-**`gh-pr-create.sh`** · class **meta** · born 2026-06-11 ·
+**`gh-pr-create.sh`** · class **meta** · born 2026-06-11 (#1406) · extended 2026-06-12 (#1534) ·
 [script source](../../scripts/gh-pr-create.sh) ·
+rule → [.claude/rules/verify-before-fix.md](../../.claude/rules/verify-before-fix.md) ·
 memory → [feedback_verify_before_fix_misread_2026_06_09.md](../../../.claude/projects/-Users-paulwander-projects-HF/memory/feedback_verify_before_fix_misread_2026_06_09.md)
 
 Wraps `gh pr create`; requires a `## Verified by` section in the PR body
 containing at least one concrete evidence form (SQL query result, vitest
 name, Playwright trace path, or log subject line). Enforces the #1406 lesson
-(don't trust screenshot OCR — cite an underlying check). **Survives
-hardening:** AP-4 is a methodology fitness function — architecture-independent.
+(don't trust screenshot OCR — cite an underlying check).
+
+**Extended scope (#1534, 2026-06-12):** the rule covers BOTH fix PRs AND
+conditional story activation. A story opened because a canary FAILed, an
+audit probe returned a finding, or an automated check flipped red is a fix
+trigger — the activation PR body MUST carry a live citation (SQL query,
+log subject, curl probe), not only a test output. Test outputs may reflect
+timeouts, fixture gaps, or mocking artifacts (the #1515 / #1525 / #1527 /
+#1528 chain — G9 CallerMemory zero-writes was a 10s-timeout fixture
+artifact, not a real failure; live SQL closed the activation in under a
+minute). The script gate covers PR body content; the activation-side
+discipline is convention-only today. **Survives hardening:** AP-4 is a
+methodology fitness function — architecture-independent.
 
 <a id="guard-fix-refactor-inversion"></a>
 **`check-fix-refactor-inversion.ts`** · class **meta** · born 2026-06-11 ·


### PR DESCRIPTION
## Summary

- Closes #1534. Ships **Fix B** from the 2026-06-12 7-day fix-chain root-cause: extend `verify-before-fix` to cover conditional story activation, not only fix PRs.
- Docs-only — `.claude/rules/verify-before-fix.md` gains a "Conditional story activation is also a fix trigger" sub-section + one row in the Existing Enforcement table; `docs/kb/guard-registry.md#guard-verify-before-fix` updates to note the extended scope and the live #1515 fingerprint.
- **Fix A** (chat-mode registry refactor for the DEMO cluster) parked as #1535 for BA + TL grooming — chat surface too hot to land alongside the in-flight canary epic closeout (#1511-#1516).

## Root-Cause Triage (#1534)

| Origin | Commits | Cause |
|--------|---------|-------|
| A — DEMO chat mode | #1500, #1501, #1502, #1503 | Implicit ChatMode contract; ~6 edit sites; no registry, no coverage test. **Parked as #1535.** |
| B — G9 premise disproven | #1515, #1525, #1527, #1528 | `verify-before-fix.md` covered fix PRs but not conditional story activation. **Closed by this PR.** |
| C — isolated | #1494, #1500 | One-offs (missing arg, Next.js folder routing). No pattern. |

The "7-day fix chain" was three distinct lines of work that happened to cluster, not a single regression.

## Verified by

- **Live SQL (the canonical evidence that closed #1515)** — `SELECT … FROM "UserMemory" WHERE "extractedBy" = 'claude_batched_v2' ORDER BY "createdAt" DESC LIMIT 25` returned 25 rows in the last 48h on hf_sandbox, disproving the canary's `learn.memories = 0` verdict in under a minute. Full evidence in `docs/audit/g9-callermemory-zero-writes-root-cause.md`. This PR formalises that the same live-citation discipline applies to the story-opening step, not only the story-closing step.
- **Spec activation probe** — `SELECT slug, "outputType", scope, "isActive", "isDirty" FROM "BddFeature" WHERE "outputType" IN ('LEARN','MEASURE')` confirms 4 SYSTEM-scope LEARN specs were active when the canary "FAILed" — the failure was the 10s timeout, not a missing spec.
- **Issue artifacts** — `gh api repos/WANDERCOLTD/HF/issues/1534` and `gh api repos/WANDERCOLTD/HF/issues/1535` resolve to the two stories filed today; both close back to this root-cause analysis.
- **Scope of the change** — `git diff --stat` reports 2 files, +39/-4 lines, no code touched. `pre-push` reported "No .ts/.tsx changes in apps/admin — skipping checks." No CI surface affected.
- **Log subject context** — `[pipeline.canary.run]` is the AppLog subject whose timed-out outputs produced the false-FAIL verdict; future activations from this subject must now carry live SQL citations per the extended rule.

## Test plan

- [x] `git diff --stat` confirms docs-only scope (`.claude/rules/verify-before-fix.md` + `docs/kb/guard-registry.md`)
- [x] `pre-commit` ran cleanly (qmd reindex picked up the 4 changed files; no embedding work needed)
- [x] `pre-push` skipped TS checks correctly (no `.ts/.tsx` changes)
- [ ] First real use of the rule (next conditional story activation) will validate the convention holds without a code gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
