### PR TITLE
Proposed BDD specs: engine QA loops for config & prompt fidelity

### DIFF
--- a/bdd/proposed/README.md
+++ b/bdd/proposed/README.md
@@ -1,0 +1,22 @@
+# Proposed BDD specs — engine QA loops (for discussion)
+
+These feature files describe **proposed** quality-assurance behaviour for the engine. They document QA loops that **do not exist today**. The step definitions are intentionally not implemented, and the files live **outside `bdd/features/`** so CI (`npm run bdd`, which globs `bdd/features/**`) does not execute them.
+
+They came out of a gap analysis of the IELTS Speaking **assessment** flow, which surfaced two engine-level gaps. In both cases the engine has solid *structural/mechanical* validation, but no *semantic* check that the output reflects what was intended or what was measured. The consistent pattern is **"propose → validate structure → write"**, with no fidelity gate.
+
+## Gap 1 — Course-configuration fidelity (`qa-loops/course_config_fidelity_qa.feature`)
+
+When a course configuration is generated from a creator's intent (a course-reference), the only gate before publish is structural (item counts, duplicate IDs, ordering, active specs, placeholder shape — `apps/admin/app/api/playbooks/[playbookId]/publish/route.ts`). The projection itself is a pure parser (`apps/admin/lib/wizard/project-course-reference.ts`, "No AI, no side effects"). Nothing checks that every intended parameter/goal is represented, that goals are coherent with the criteria, or that the configuration matches the source — and nothing flags drift, omission, or hallucination.
+
+## Gap 2 — Prompt-composition fidelity (`qa-loops/prompt_composition_fidelity_qa.feature`)
+
+The bootstrap prompt ("prompt 0") and each post-session prompt ("prompt n+1") are composed deterministically, templating in the config and the session's measurements and trusting them. Mechanical invariants run (`apps/admin/lib/prompt/composition/compose-invariants.ts`) and SUPERVISE clamps numeric targets (`docs/PIPELINE.md` notes SUPERVISE does **not** do drift detection), but nothing checks that prompt 0 reflects the configuration, or that prompt n+1 reflects the configuration **and** the session's measurements. The one AI prompt critic (`apps/admin/app/api/callers/[callerId]/eval-prompt/route.ts`) is operator-triggered, config- and measurement-blind, and its result is stored but never used to gate anything — `ComposedPrompt` is written `status: "active"` immediately.
+
+## Why these might be closeable with existing machinery
+
+- The "**propose → guard → write**" pattern already exists throughout; a fidelity guard would slot into the same shape.
+- A **confidence < 0.8 → review-queue** mechanism already exists for LO classification (`apps/admin/lib/content-trust/validate-lo-classification.ts`) — an analogous gate could route low-fidelity config/prompts to review.
+- An AI prompt critic already exists (`eval-prompt`); the gap is that it is out-of-loop and config-blind, not that it is missing.
+- A **projection-vs-snapshot drift cron** is already noted as a Phase-2 design item (`docs/decisions/2026-06-02-v6-wizard-on-crawcusspec.md`).
+
+These files are a starting point for a decision on whether to add these loops and how.

--- a/bdd/proposed/qa-loops/course_config_fidelity_qa.feature
+++ b/bdd/proposed/qa-loops/course_config_fidelity_qa.feature
@@ -1,0 +1,42 @@
+# PROPOSED — documents a current gap in the engine. Steps are NOT implemented.
+# Kept outside bdd/features/ so CI (npm run bdd) does not execute it.
+#
+# Today: a course configuration is generated from a creator's intent (course-reference)
+# by a deterministic, no-AI projection (apps/admin/lib/wizard/project-course-reference.ts).
+# The only gate before publish is STRUCTURAL — item counts, duplicate IDs, ordering,
+# active specs, placeholder shape (apps/admin/app/api/playbooks/[playbookId]/publish/route.ts;
+# validationPassed = errors.length === 0). There is NO semantic check that the generated
+# configuration faithfully reflects the creator's intent.
+#
+# This feature describes the intended QA loop, for discussion.
+
+Feature: QA of generated course configuration against creator intent
+
+  As the engine
+  I want to verify a generated course configuration against the creator's intent
+  So that a course never goes live with silently missing or incoherent parameters, goals, or criteria
+
+  Background:
+    Given a course creator has provided their intent as a course-reference
+    And the system has generated a course configuration from that intent
+
+  Scenario: Every intended parameter is represented in the configuration
+    When the configuration is checked against the course-reference
+    Then every parameter named in the intent has a matching parameter in the configuration
+    And any intended parameter missing from the configuration is reported as a fidelity error
+
+  Scenario: Goals are coherent with the parameters and criteria
+    When the configuration is checked for coherence
+    Then every goal references parameters or criteria that exist in the configuration
+    And a goal that targets a missing or undefined criterion is reported as a fidelity error
+
+  Scenario: The configuration is compared back to its source for completeness
+    When the configuration is compared against the course-reference
+    Then sections present in the source but absent from the configuration are reported
+    And content present in the configuration but absent from the source is flagged as a possible hallucination
+
+  Scenario: A low-fidelity configuration is routed to review rather than published silently
+    Given the fidelity check finds one or more issues
+    When the creator attempts to publish the configuration
+    Then publishing is blocked, or the configuration is routed to a review queue
+    And the specific fidelity issues are shown to the reviewer

--- a/bdd/proposed/qa-loops/prompt_composition_fidelity_qa.feature
+++ b/bdd/proposed/qa-loops/prompt_composition_fidelity_qa.feature
@@ -1,0 +1,49 @@
+# PROPOSED — documents a current gap in the engine. Steps are NOT implemented.
+# Kept outside bdd/features/ so CI (npm run bdd) does not execute it.
+#
+# Today: the bootstrap prompt ("prompt 0") and each post-session prompt ("prompt n+1")
+# are composed deterministically (model: "deterministic"), templating in the course
+# configuration and the session's measurements and trusting them. Mechanical invariants
+# run (module-lock, call-counter coherence — apps/admin/lib/prompt/composition/compose-invariants.ts)
+# and the SUPERVISE stage clamps numeric targets (docs/PIPELINE.md states SUPERVISE does
+# NOT do drift detection). Nothing checks that prompt 0 reflects the configuration, or that
+# prompt n+1 reflects the configuration AND the session's measurements.
+# The one AI prompt critic (apps/admin/app/api/callers/[callerId]/eval-prompt/route.ts) is
+# operator-triggered, config- and measurement-blind, and its result is stored but never used
+# to gate anything — ComposedPrompt is written status="active" immediately.
+#
+# This feature describes the intended QA loop, for discussion.
+
+Feature: QA of composed prompts against configuration and measurements
+
+  As the engine
+  I want to verify each composed prompt against the configuration and the latest measurements
+  So that a prompt that drifts from the course design or ignores the measured results never drives the next call
+
+  Background:
+    Given a published course configuration exists
+
+  Scenario: The bootstrap prompt is checked against the course configuration before it becomes active
+    Given the system composes the bootstrap prompt for a new learner
+    When the bootstrap prompt has been composed
+    Then the prompt is checked for fidelity against the course configuration
+    And a prompt that omits or contradicts the configuration is blocked or flagged before it becomes active
+
+  Scenario: The next prompt is checked against the course configuration
+    Given a learner has completed a session
+    When the system composes the next prompt
+    Then the prompt is checked for fidelity against the course configuration
+    And a prompt that drifts from the configuration is blocked or flagged before it becomes active
+
+  Scenario: The next prompt is checked against the session's measurements
+    Given a learner has completed a session
+    And the session produced measurements and analysis
+    When the system composes the next prompt
+    Then the prompt is checked for consistency with those measurements
+    And a prompt that ignores or contradicts the measured results is blocked or flagged before it becomes active
+
+  Scenario: The prompt-quality check runs in the loop and gates the prompt status
+    Given a prompt has been composed
+    When the prompt-quality check runs as part of composition
+    Then its result determines whether the prompt becomes active
+    And a prompt that fails the check does not silently go live


### PR DESCRIPTION
## What this is

Two engine-level QA gaps, written up as **proposed BDD stories** for discussion. They surfaced while doing a gap analysis of the IELTS Speaking **assessment** flow, but they are general to the engine, not IELTS-specific.

In both places the engine has solid **structural/mechanical** validation, but **no semantic check** that the output reflects what was intended or what was measured. The consistent pattern is *"propose → validate structure → write"*, with no fidelity gate.

**No engine code changes.** This PR only adds Gherkin under `bdd/proposed/` (deliberately **outside `bdd/features/`**, so `npm run bdd` / CI does not execute it) plus a README with evidence references.

## Gap 1 — Course-configuration fidelity

A course configuration is generated from a creator's intent (course-reference) by a deterministic, no-AI projection (`apps/admin/lib/wizard/project-course-reference.ts`). The only gate before publish is structural — item counts, duplicate IDs, ordering, active specs, placeholder shape (`apps/admin/app/api/playbooks/[playbookId]/publish/route.ts`, `validationPassed = errors.length === 0`). Nothing checks that every intended parameter/goal is represented, that goals are coherent with the criteria, or that the config matches the source — and nothing flags drift/omission/hallucination.

→ `bdd/proposed/qa-loops/course_config_fidelity_qa.feature`

## Gap 2 — Prompt-composition fidelity

The bootstrap prompt ("prompt 0") and each post-session prompt ("prompt n+1") are composed deterministically, templating in the config and the session's measurements and trusting them. Mechanical invariants run (`apps/admin/lib/prompt/composition/compose-invariants.ts`) and SUPERVISE clamps numeric targets (`docs/PIPELINE.md` notes SUPERVISE does **not** do drift detection). Nothing checks that prompt 0 reflects the configuration, or that prompt n+1 reflects the configuration **and** the session's measurements. The one AI prompt critic (`apps/admin/app/api/callers/[callerId]/eval-prompt/route.ts`) is operator-triggered, config- and measurement-blind, and its result is stored but never used to gate anything — `ComposedPrompt` is written `status: "active"` immediately.

→ `bdd/proposed/qa-loops/prompt_composition_fidelity_qa.feature`

## Possibly closeable with existing machinery

- The "propose → guard → write" pattern already exists; a fidelity guard fits the same shape.
- A `confidence < 0.8 → review-queue` mechanism already exists for LO classification (`apps/admin/lib/content-trust/validate-lo-classification.ts`).
- The `eval-prompt` critic already exists — the gap is that it is out-of-loop and config-blind, not that it is missing.
- A projection-vs-snapshot drift cron is already noted as a Phase-2 item (`docs/decisions/2026-06-02-v6-wizard-on-crawcusspec.md`).

## Ask

@paw2paw — assigned to you for a read. Two questions: (1) do these gaps match your understanding of the engine, and (2) are they worth closing for the assessment/scoring use case? The feature files are a starting point, not a finished spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
