### PR TITLE
feat(measurement): #1539 spec-driven batched measurement (close analysisSpecId NULL gap)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -70,6 +70,9 @@ import { loadGuardrails, type GuardrailsConfig } from "@/lib/pipeline/guardrails
 import { shouldRunCallerAnalysis } from "@/lib/pipeline/event-gate";
 import { getCourseStyle, type CourseStyle } from "@/lib/pipeline/course-style";
 import { getTranscriptLimit, getSystemSpecs, getSpecsByOutputType, getPlaybookSpecs, batchLoadParameters, resolveCallerTeachingProfile, filterByTeachingProfile } from "@/lib/pipeline/specs-loader";
+import { writeCallScore, MEASUREMENT_SENTINEL_SPEC_IDS } from "@/lib/measurement/write-call-score";
+import { buildParameterSpecMap, type ParameterWithSpec } from "@/lib/measurement/parameter-spec-map";
+import { buildBatchedMeasurePrompt } from "@/lib/measurement/build-batched-measure-prompt";
 import type { SpecConfig } from "@/lib/types/json-fields";
 
 /**
@@ -494,52 +497,11 @@ async function loadCurrentModuleContext(
   return null;
 }
 
-function buildBatchedCallerPrompt(
-  transcript: string,
-  measureParams: Array<{ parameterId: string; name: string; definition: string | null }>,
-  learnActions: Array<{ category: string; keyPrefix: string; keyHint: string; description: string }>,
-  transcriptLimit: number = 4000,
-  moduleContext?: { moduleId: string; moduleName: string; learningOutcomes: string[] } | null,
-  assessmentPromptInstructions?: string | null,
-): string {
-  const paramList = measureParams.map(p => `${p.parameterId}:${p.name}`).join("|");
-  const learnList = learnActions.map(a => {
-    const keys = a.keyHint || `${a.keyPrefix}item`;
-    return `- ${a.category}: ${a.description}. Use keys like: ${keys}`;
-  }).join("\n");
-
-  let learningSection = "";
-  let learningJsonHint = "";
-  if (moduleContext?.learningOutcomes?.length) {
-    // #403: emit the real LO refs (not positional placeholders) and ground the JSON
-    // example in the FIRST real ref. Previous "LO1:..." pattern + example baked into
-    // the prompt led the AI to return {"LO1": 0.6} regardless of curriculum content.
-    const loList = moduleContext.learningOutcomes.map((lo) => `- ${JSON.stringify(lo)}`).join("\n");
-    const exampleRef = moduleContext.learningOutcomes[0];
-    const exampleOutcomes = JSON.stringify({ [exampleRef]: 0.6 });
-    const instructions = assessmentPromptInstructions
-      || "Score caller's demonstrated understanding of each outcome 0-1 (0=no evidence, 0.5=partial, 1=full mastery).";
-    learningSection = `\n\nLEARNING OUTCOMES TO ASSESS (module "${moduleContext.moduleName}"):\n${loList}\n\nCRITICAL: Use the EXACT strings above as keys in "outcomes" — copy them verbatim. Do NOT invent placeholders like "LO1", "LO2".\n\n${instructions}`;
-    learningJsonHint = `,"learning":{"moduleId":"${moduleContext.moduleId}","outcomes":${exampleOutcomes},"overallMastery":0.7}`;
-  }
-
-  return `Analyze transcript. Score caller 0-1 on params, extract ALL personal facts.
-
-TRANSCRIPT (analyze this — read the ENTIRE transcript including the end):
-${transcript.slice(0, transcriptLimit)}
-
-PARAMS TO SCORE: ${paramList}
-
-FACTS TO EXTRACT (use the suggested keys, extract EVERY fact mentioned including names, pets, family, preferences):
-${learnList}${learningSection}
-
-For each param, also include EVIDENCE FIELDS:
-- "he" (hasLearnerEvidence): true if the LEARNER's own utterances contain scoreable evidence for this param. false if the score is inferred from the tutor's prose only.
-- "eq" (evidenceQuality): 0-1 confidence that the LEARNER produced enough material to score this param. 0 = nothing scoreable, 1 = abundant evidence.
-
-Return compact JSON:
-{"scores":{"PARAM-ID":{"s":0.75,"c":0.8,"he":true,"eq":0.7},...},"memories":[{"cat":"RELATIONSHIP","key":"family_pet","val":"dog called Fred","c":0.9,"e":"my dog is called Fred"},...]${learningJsonHint}}`;
-}
+// #1539 — `buildBatchedCallerPrompt` was extracted to
+// `lib/measurement/build-batched-measure-prompt.ts::buildBatchedMeasurePrompt`.
+// The old inline builder dropped each spec's `promptTemplate`; the new
+// builder interpolates it as a per-parameter rubric block. Do NOT
+// reintroduce a local copy here — the helper is the contract.
 
 /**
  * Build a BATCHED prompt for MEASURE specs
@@ -591,7 +553,7 @@ Return compact JSON:
 async function runPerSegmentScoring(
   call: { id: string; transcript: string | null; curriculumModuleId?: string | null },
   callerId: string,
-  measureParams: Array<{ parameterId: string; name: string; definition: string | null }>,
+  measureParams: ParameterWithSpec[],
   engine: AIEngine,
   transcriptLimit: number,
   log: PipelineLogger,
@@ -754,41 +716,27 @@ async function runPerSegmentScoring(
               ? Math.max(0, Math.min(1, scoreData.evidenceQuality))
               : null;
 
-        const existing = await prisma.callScore.findFirst({
-          where: { callId: call.id, parameterId, moduleId: segmentModuleId },
+        // #1539 — inherit the parent parameter's spec lineage. The
+        // per-segment scorer writes against the same AnalysisSpec that
+        // produced the bound-module score; the rubric chain stays
+        // intact even though the per-segment prompt is hardcoded
+        // IELTS (`buildPerSegmentMeasurePrompt`) rather than spec-driven.
+        const parentSpec = measureParams.find((p) => p.parameterId === parameterId);
+        const segmentResult = await writeCallScore({
+          callId: call.id,
+          callerId,
+          parameterId,
+          analysisSpecId: parentSpec?.analysisSpecId ?? MEASUREMENT_SENTINEL_SPEC_IDS.MOCK,
+          moduleId: segmentModuleId,
+          score,
+          confidence,
+          reasoning,
+          evidence: [`Segment: ${segment.slug}`],
+          scoredBy: `${engine}_segment_v1`,
+          hasLearnerEvidence,
+          evidenceQuality,
         });
-        if (existing) {
-          await prisma.callScore.update({
-            where: { id: existing.id },
-            data: {
-              score,
-              confidence,
-              reasoning,
-              evidence: [`Segment: ${segment.slug}`],
-              scoredBy: `${engine}_segment_v1`,
-              scoredAt: new Date(),
-              hasLearnerEvidence,
-              evidenceQuality,
-            },
-          });
-        } else {
-          await prisma.callScore.create({
-            data: {
-              callId: call.id,
-              callerId,
-              parameterId,
-              moduleId: segmentModuleId,
-              score,
-              confidence,
-              reasoning,
-              evidence: [`Segment: ${segment.slug}`],
-              scoredBy: `${engine}_segment_v1`,
-              hasLearnerEvidence,
-              evidenceQuality,
-            },
-          });
-          segmentScoresCreated++;
-        }
+        if (segmentResult.created) segmentScoresCreated++;
       }
     } catch (err: any) {
       log.warn("Per-part MEASURE failed for segment", {
@@ -906,19 +854,25 @@ async function runBatchedCallerAnalysis(
   //
   // When skipMeasure is true we still include "always" specs — only the
   // gated specs are zeroed out.
-  let paramMap: Map<string, { parameterId: string; name: string; definition: string | null }>;
+  // #1539 — preserve the parameter -> AnalysisSpec lineage so the prompt
+  // builder can inject the spec's `promptTemplate` rubric AND the write
+  // helper can stamp `CallScore.analysisSpecId`. Previously this path
+  // used `batchLoadParameters` which dropped the spec association.
+  let paramMap: Map<string, ParameterWithSpec>;
   if (skipMeasure) {
     const alwaysSpecs = measureSpecs.filter(
       (s) => (s.config as SpecConfig)?.scoringGate === "always",
     );
     paramMap = alwaysSpecs.length > 0
-      ? await batchLoadParameters(alwaysSpecs)
+      ? await buildParameterSpecMap(alwaysSpecs, { log: (m, meta) => log.info(m, meta) })
       : new Map();
     if (alwaysSpecs.length > 0) {
       log.info(`Event-gate: ${measureSpecs.length - alwaysSpecs.length} MEASURE specs gated, ${alwaysSpecs.length} always-on (${alwaysSpecs.map(s => s.slug).join(", ")})`);
     }
   } else {
-    paramMap = await batchLoadParameters(measureSpecs);
+    paramMap = await buildParameterSpecMap(measureSpecs, {
+      log: (m, meta) => log.info(m, meta),
+    });
   }
 
   // Collect LEARN actions
@@ -1037,45 +991,25 @@ async function runBatchedCallerAnalysis(
     const mockConfidence = mockGuardrails.confidenceBounds.defaultConfidence;
     for (const param of measureParams) {
       const score = 0.4 + Math.random() * 0.4;
-      // Check if score already exists for this call+parameter
-      const existing = await prisma.callScore.findFirst({
-        where: { callId: call.id, parameterId: param.parameterId },
+      // #1539 — mock engine inherits the spec lineage of the parameter
+      // it's scoring. Falls back to the MOCK sentinel only when the
+      // parameter has no resolved spec (should be impossible — the map
+      // omits parameters without a spec).
+      await writeCallScore({
+        callId: call.id,
+        callerId,
+        parameterId: param.parameterId,
+        analysisSpecId: param.analysisSpecId ?? MEASUREMENT_SENTINEL_SPEC_IDS.MOCK,
+        moduleId: call.curriculumModuleId ?? null,
+        score,
+        confidence: mockConfidence,
+        evidence: ["Mock batched scoring"],
+        scoredBy: "mock_batched_v1",
+        // #566 Step 1 — mock engine has no LLM reasoning; leave evidence
+        // fields null (legacy path semantics per schema comment).
+        hasLearnerEvidence: null,
+        evidenceQuality: null,
       });
-      if (existing) {
-        await prisma.callScore.update({
-          where: { id: existing.id },
-          data: {
-            score,
-            confidence: mockConfidence,
-            evidence: ["Mock batched scoring"],
-            scoredBy: "mock_batched_v1",
-            scoredAt: new Date(),
-            // #566 Step 1 — mock engine has no LLM reasoning; leave evidence
-            // fields null (legacy path semantics per schema comment).
-            hasLearnerEvidence: null,
-            evidenceQuality: null,
-          },
-        });
-      } else {
-        await prisma.callScore.create({
-          data: {
-            callId: call.id,
-            callerId,
-            parameterId: param.parameterId,
-            // #491 Slice 1.2 — attribute the score to the module this call covered.
-            // Null for non-attributed calls (legacy / no module pick); a partial
-            // unique index keeps one-score-per-(callId, parameterId) in that case.
-            ...(call.curriculumModuleId ? { moduleId: call.curriculumModuleId } : {}),
-            score,
-            confidence: mockConfidence,
-            evidence: ["Mock batched scoring"],
-            scoredBy: "mock_batched_v1",
-            // #566 Step 1 — null sentinels (see above).
-            hasLearnerEvidence: null,
-            evidenceQuality: null,
-          },
-        });
-      }
       scoresCreated++;
     }
     // Log mock usage for visibility in metering dashboard
@@ -1092,7 +1026,21 @@ async function runBatchedCallerAnalysis(
     const transcriptLimit = await getTranscriptLimit("pipeline.measure");
     const timeouts = await getAITimeoutSettings();
     const assessPromptInstructions = assessmentSpec ? (assessmentSpec.config as SpecConfig)?.promptInstructions : null;
-    const prompt = buildBatchedCallerPrompt(transcript, measureParams, learnActions, transcriptLimit, moduleContext, assessPromptInstructions);
+    // #1539 — switched from the inline `buildBatchedCallerPrompt` (which
+    // dropped each spec's `promptTemplate`) to the spec-aware builder.
+    // Each MEASURE parameter now gets its rubric block interpolated into
+    // the prompt body so the LLM scores against the IELTS band
+    // descriptors (or whichever rubric the spec carries) instead of its
+    // own internalised idea of the dimension.
+    const prompt = buildBatchedMeasurePrompt({
+      transcript,
+      measureParams,
+      learnActions,
+      transcriptLimit,
+      moduleContext,
+      assessmentPromptInstructions: assessPromptInstructions,
+      log: (m, meta) => log.warn(m, meta),
+    });
 
     // #UI-followup Gap 1 — load the playbook config ONCE up front so the
     // Boaz guard (per-parameter persistence skip below) can honour the
@@ -1230,42 +1178,28 @@ async function runBatchedCallerAnalysis(
             continue;
           }
 
-          // Check if score already exists for this call+parameter
-          const existing = await prisma.callScore.findFirst({
-            where: { callId: call.id, parameterId },
+          // #1539 — stamp the spec lineage. The batched prompt loaded
+          // this parameter via `buildParameterSpecMap`, which preserves
+          // the originating AnalysisSpec id; the writer reads it from
+          // paramMap. The fallback sentinel exists only as a structural
+          // backstop — it should never fire because paramMap omits
+          // parameters without a spec.
+          const sourceSpec = paramMap.get(parameterId);
+          await writeCallScore({
+            callId: call.id,
+            callerId,
+            parameterId,
+            analysisSpecId:
+              sourceSpec?.analysisSpecId ?? MEASUREMENT_SENTINEL_SPEC_IDS.MOCK,
+            moduleId: call.curriculumModuleId ?? null,
+            score,
+            confidence,
+            reasoning,
+            evidence: ["AI batched analysis"],
+            scoredBy: `${engine}_batched_v2`,
+            hasLearnerEvidence,
+            evidenceQuality,
           });
-          if (existing) {
-            await prisma.callScore.update({
-              where: { id: existing.id },
-              data: {
-                score,
-                confidence,
-                reasoning,
-                evidence: ["AI batched analysis"],
-                scoredBy: `${engine}_batched_v2`,
-                scoredAt: new Date(),
-                hasLearnerEvidence,
-                evidenceQuality,
-              },
-            });
-          } else {
-            await prisma.callScore.create({
-              data: {
-                callId: call.id,
-                callerId,
-                parameterId,
-                // #491 Slice 1.2 — module attribution (see note above).
-                ...(call.curriculumModuleId ? { moduleId: call.curriculumModuleId } : {}),
-                score,
-                confidence,
-                reasoning,
-                evidence: ["AI batched analysis"],
-                scoredBy: `${engine}_batched_v2`,
-                hasLearnerEvidence,
-                evidenceQuality,
-              },
-            });
-          }
           scoresCreated++;
         }
         // #566 Step 1 — shadow log of evidence-field coverage. Records what
@@ -2386,29 +2320,23 @@ async function computeAdapt(
       const deltaParam = await prisma.parameter.findUnique({ where: { parameterId: deltaParameterId } });
       if (deltaParam) {
         const deltaScore = (delta + 1) / 2; // Normalize -1..1 to 0..1
-        // Check if score already exists
-        const existing = await prisma.callScore.findFirst({
-          where: { callId, parameterId: deltaParameterId },
+        // #1539 — delta inherits the parent score's spec lineage when
+        // available (the parent CallScore now stamps analysisSpecId).
+        // Falls back to ADAPT-DELTA-V1 sentinel for first-run callers
+        // whose source score was written pre-#1539 (NULL spec id).
+        await writeCallScore({
+          callId,
+          callerId,
+          parameterId: deltaParameterId,
+          analysisSpecId:
+            currentScore.analysisSpecId ?? MEASUREMENT_SENTINEL_SPEC_IDS.ADAPT_DELTA,
+          // #491 Slice 1.2 — delta scores inherit the source call's module attribution.
+          moduleId: currentCall.curriculumModuleId ?? null,
+          score: deltaScore,
+          confidence: 0.9,
+          evidence: [`adapt:delta-from=${currentScore.id}`],
+          scoredBy: "adapt_v1",
         });
-        if (existing) {
-          await prisma.callScore.update({
-            where: { id: existing.id },
-            data: { score: deltaScore, scoredAt: new Date() },
-          });
-        } else {
-          await prisma.callScore.create({
-            data: {
-              callId,
-              callerId,
-              parameterId: deltaParameterId,
-              // #491 Slice 1.2 — delta scores inherit the source call's module attribution.
-              ...(currentCall.curriculumModuleId ? { moduleId: currentCall.curriculumModuleId } : {}),
-              score: deltaScore,
-              confidence: 0.9,
-              scoredBy: "adapt_v1",
-            },
-          });
-        }
         deltasComputed++;
       }
     }

--- a/apps/admin/eslint-rules/no-bare-call-score-write.mjs
+++ b/apps/admin/eslint-rules/no-bare-call-score-write.mjs
@@ -1,0 +1,116 @@
+/**
+ * #1539 — block bare `prisma.callScore.create | update | upsert` outside
+ * the explicit allow-list. Every `CallScore` row written from the
+ * production pipeline MUST carry `analysisSpecId` (the AnalysisSpec
+ * whose rubric produced the score). The chokepoint helper
+ * `writeCallScore` requires the column in its TypeScript signature AND
+ * asserts non-empty at runtime; this rule stops a future edit from
+ * smuggling a bare write past the helper.
+ *
+ * Pairs with `eslint-rules/no-bare-call-create.mjs` (#1333 / #1342).
+ *
+ * @see lib/measurement/write-call-score.ts
+ * @see docs/decisions/2026-06-12-spec-driven-batched-measurement.md
+ */
+
+const ALLOWED_PATH_SUFFIXES = [
+  // The canonical chokepoint — IS the helper.
+  "lib/measurement/write-call-score.ts",
+  // The drain script lands writes against historical NULL rows; it
+  // attributes by parameter -> active MEASURE spec or marks
+  // LEGACY_UNSPECCED_PRE_1539. Explicitly allow-listed.
+  "scripts/backfill-call-score-analysis-spec.ts",
+  // Demo / scoped reset routes hand-roll write shapes for fixture
+  // tear-down. They're not part of the production pipeline; if they
+  // start producing learner-visible scores, route them through the
+  // helper.
+  "app/api/admin/demo-reset-scoped/route.ts",
+  "app/api/x/seed-transcripts/route.ts",
+  // Manual ops endpoint — operators re-grade individual calls via
+  // ops/run-spec; routes through measureAgent + BehaviorMeasurement
+  // (not CallScore). The legacy callScore write site here is allow-
+  // listed pending the deeper ops-route refactor.
+  "app/api/calls/[callId]/ops/[opId]/route.ts",
+];
+
+const ALLOWED_PATH_CONTAINS = [
+  "prisma/seed-",
+  "prisma/_archived/seed-",
+  "/tests/",
+  "/__tests__/",
+  ".test.ts",
+  ".test.tsx",
+  ".spec.ts",
+  "/scripts/",
+  "/_archived/",
+  // Personality ops + verifier scripts touch CallScore as part of
+  // their analyse-then-write cycle but pre-date the helper. Either
+  // refactor them onto the helper OR keep them here when adopting.
+  "/lib/ops/",
+];
+
+function isAllowed(filename) {
+  if (!filename) return false;
+  const normalised = filename.replace(/\\/g, "/");
+  for (const suffix of ALLOWED_PATH_SUFFIXES) {
+    if (normalised.endsWith(suffix)) return true;
+  }
+  for (const substr of ALLOWED_PATH_CONTAINS) {
+    if (normalised.includes(substr)) return true;
+  }
+  return false;
+}
+
+function isCallScoreWrite(callee) {
+  if (
+    !callee ||
+    callee.type !== "MemberExpression" ||
+    !callee.property ||
+    callee.property.type !== "Identifier"
+  ) {
+    return false;
+  }
+  if (!["create", "update", "upsert"].includes(callee.property.name)) {
+    return false;
+  }
+  const inner = callee.object;
+  if (
+    !inner ||
+    inner.type !== "MemberExpression" ||
+    !inner.property ||
+    inner.property.type !== "Identifier" ||
+    inner.property.name !== "callScore"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow bare `prisma.callScore.{create,update,upsert}` outside the allow-list (#1539). Use `writeCallScore` from `@/lib/measurement/write-call-score` so every CallScore row stamps `analysisSpecId`.",
+      url: "https://github.com/WANDERCOLTD/HF/blob/main/docs/decisions/2026-06-12-spec-driven-batched-measurement.md",
+    },
+    schema: [],
+    messages: {
+      bareCallScoreWrite:
+        "Bare `prisma.callScore.{create,update,upsert}` outside the #1539 allow-list. Route through `writeCallScore` from `@/lib/measurement/write-call-score` so the `analysisSpecId` stamp is structural. If this is a deliberate bypass (drain script, archived migration, manual ops), add the path to the allow-list in `eslint-rules/no-bare-call-score-write.mjs` AND document why in the helper's call-site comment.",
+    },
+  },
+  create(context) {
+    const filename = context.getFilename ? context.getFilename() : context.filename;
+    if (isAllowed(filename)) return {};
+    return {
+      CallExpression(node) {
+        if (isCallScoreWrite(node.callee)) {
+          context.report({ node, messageId: "bareCallScoreWrite" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -15,6 +15,7 @@ import noVapiToolDefinitionsConst from "./eslint-rules/hf-voice/no-vapi-tool-def
 import noUndeclaredFieldRequire from "./eslint-rules/no-undeclared-field-require.mjs";
 import noModuleReadWithoutCourseStyleGuard from "./eslint-rules/no-module-read-without-course-style-guard.mjs";
 import noBareCallCreate from "./eslint-rules/no-bare-call-create.mjs";
+import noBareCallScoreWrite from "./eslint-rules/no-bare-call-score-write.mjs";
 import noOpsImportFromApi from "./eslint-rules/no-ops-import-from-api.mjs";
 import noSecretsInClient from "./eslint-rules/no-secrets-in-client.mjs";
 import noHardcodedSpecSlug from "./eslint-rules/no-hardcoded-spec-slug.mjs";
@@ -182,6 +183,16 @@ const eslintConfig = defineConfig([
           "no-bare-call-create": noBareCallCreate,
         },
       },
+      // #1539 — spec-lineage contract for CallScore writes. Every row
+      // MUST carry `analysisSpecId` (the AnalysisSpec whose rubric
+      // produced the score). Helper at `lib/measurement/write-call-score.ts`
+      // requires the column in its TypeScript signature; the rule blocks
+      // bare `prisma.callScore.{create,update,upsert}` from drift.
+      "hf-measurement": {
+        rules: {
+          "no-bare-call-score-write": noBareCallScoreWrite,
+        },
+      },
       "hf-ops": {
         rules: {
           "no-ops-import-from-api": noOpsImportFromApi,
@@ -242,6 +253,13 @@ const eslintConfig = defineConfig([
       // inline Call insert when needed) or add to the allow-list with a
       // documented bypass justification.
       "hf-call/no-bare-call-create": "error",
+      // #1539 — error severity from day 1. Allow-list covers every
+      // pre-existing legitimate write site (the chokepoint helper itself,
+      // the drain script, the demo-reset / seed-transcripts admin
+      // routes, and the manual ops re-grade route). Any new write site
+      // must either route through `writeCallScore` or add to the
+      // allow-list with documented bypass justification.
+      "hf-measurement/no-bare-call-score-write": "error",
 
       // #1395 / #1423 — Block app/api routes from importing the 5 lib/ops/*
       // files that instantiate their own PrismaClient (bypass the singleton).

--- a/apps/admin/lib/measurement/build-batched-measure-prompt.ts
+++ b/apps/admin/lib/measurement/build-batched-measure-prompt.ts
@@ -1,0 +1,126 @@
+/**
+ * Builds the batched MEASURE prompt for `runBatchedCallerAnalysis`.
+ *
+ * #1539 — replaces the inline `buildBatchedCallerPrompt` that used to
+ * live in `app/api/calls/[callId]/pipeline/route.ts`. The old builder
+ * sent only `parameterId:name` pairs to the LLM; it never injected the
+ * `AnalysisSpec.promptTemplate` rubric. The LLM scored `IELTS-FLUENCY`
+ * based on its own internalised idea of "fluency" instead of the IELTS
+ * band 1-9 descriptors stored in the spec.
+ *
+ * This builder interpolates each parameter's `promptTemplate` verbatim
+ * as a `RUBRIC[<parameterId>]:\n<template>` block. Parameters whose
+ * spec has `promptTemplate = null` (legacy / under-specced) fall back
+ * to the name+definition shape AND log an `[measure] unspecced
+ * parameter` warning, so the gap is visible in operator dashboards.
+ *
+ * The shape of the LLM's JSON response is unchanged — adding rubric
+ * blocks does not change the contract the response parser depends on.
+ */
+
+import type { ParameterWithSpec } from "./parameter-spec-map";
+
+export interface BuildBatchedMeasurePromptInput {
+  transcript: string;
+  measureParams: ParameterWithSpec[];
+  learnActions: Array<{
+    category: string;
+    keyPrefix: string;
+    keyHint: string;
+    description: string;
+  }>;
+  transcriptLimit?: number;
+  moduleContext?: {
+    moduleId: string;
+    moduleName: string;
+    learningOutcomes: string[];
+  } | null;
+  assessmentPromptInstructions?: string | null;
+  /** Logger for unspecced-parameter warnings. */
+  log?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+const DEFAULT_TRANSCRIPT_LIMIT = 4000;
+
+export function buildBatchedMeasurePrompt({
+  transcript,
+  measureParams,
+  learnActions,
+  transcriptLimit = DEFAULT_TRANSCRIPT_LIMIT,
+  moduleContext,
+  assessmentPromptInstructions,
+  log,
+}: BuildBatchedMeasurePromptInput): string {
+  const paramList = measureParams
+    .map((p) => `${p.parameterId}:${p.name}`)
+    .join("|");
+
+  const rubricBlocks: string[] = [];
+  const unspecced: Array<{ parameterId: string; specSlug: string }> = [];
+  for (const p of measureParams) {
+    if (p.promptTemplate && p.promptTemplate.trim().length > 0) {
+      rubricBlocks.push(
+        `RUBRIC[${p.parameterId}] (from spec ${p.specSlug}):\n${p.promptTemplate.trim()}`,
+      );
+    } else {
+      unspecced.push({ parameterId: p.parameterId, specSlug: p.specSlug });
+      const defLine = p.definition
+        ? ` Definition: ${p.definition.trim()}`
+        : "";
+      rubricBlocks.push(
+        `RUBRIC[${p.parameterId}] (from spec ${p.specSlug}, no promptTemplate set — fall back to definition):\n${p.name}.${defLine}`,
+      );
+    }
+  }
+
+  if (unspecced.length > 0 && log) {
+    log(
+      `[measure] ${unspecced.length} parameter(s) lack a promptTemplate; ` +
+        `fell back to name+definition. #1539 — populate the spec's ` +
+        `promptTemplate to ground the LLM.`,
+      { unspecced },
+    );
+  }
+
+  const learnList = learnActions
+    .map((a) => {
+      const keys = a.keyHint || `${a.keyPrefix}item`;
+      return `- ${a.category}: ${a.description}. Use keys like: ${keys}`;
+    })
+    .join("\n");
+
+  let learningSection = "";
+  let learningJsonHint = "";
+  if (moduleContext?.learningOutcomes?.length) {
+    const loList = moduleContext.learningOutcomes
+      .map((lo) => `- ${JSON.stringify(lo)}`)
+      .join("\n");
+    const exampleRef = moduleContext.learningOutcomes[0];
+    const exampleOutcomes = JSON.stringify({ [exampleRef]: 0.6 });
+    const instructions =
+      assessmentPromptInstructions ||
+      "Score caller's demonstrated understanding of each outcome 0-1 (0=no evidence, 0.5=partial, 1=full mastery).";
+    learningSection = `\n\nLEARNING OUTCOMES TO ASSESS (module "${moduleContext.moduleName}"):\n${loList}\n\nCRITICAL: Use the EXACT strings above as keys in "outcomes" — copy them verbatim. Do NOT invent placeholders like "LO1", "LO2".\n\n${instructions}`;
+    learningJsonHint = `,"learning":{"moduleId":"${moduleContext.moduleId}","outcomes":${exampleOutcomes},"overallMastery":0.7}`;
+  }
+
+  return `Analyze transcript. Score caller 0-1 on params, extract ALL personal facts.
+
+TRANSCRIPT (analyze this — read the ENTIRE transcript including the end):
+${transcript.slice(0, transcriptLimit)}
+
+PARAMS TO SCORE: ${paramList}
+
+SCORING RUBRICS (use the matching rubric for each parameter — DO NOT guess from the parameter name alone):
+${rubricBlocks.join("\n\n")}
+
+FACTS TO EXTRACT (use the suggested keys, extract EVERY fact mentioned including names, pets, family, preferences):
+${learnList}${learningSection}
+
+For each param, also include EVIDENCE FIELDS:
+- "he" (hasLearnerEvidence): true if the LEARNER's own utterances contain scoreable evidence for this param. false if the score is inferred from the tutor's prose only.
+- "eq" (evidenceQuality): 0-1 confidence that the LEARNER produced enough material to score this param. 0 = nothing scoreable, 1 = abundant evidence.
+
+Return compact JSON:
+{"scores":{"PARAM-ID":{"s":0.75,"c":0.8,"he":true,"eq":0.7},...},"memories":[{"cat":"RELATIONSHIP","key":"family_pet","val":"dog called Fred","c":0.9,"e":"my dog is called Fred"},...]${learningJsonHint}}`;
+}

--- a/apps/admin/lib/measurement/parameter-spec-map.ts
+++ b/apps/admin/lib/measurement/parameter-spec-map.ts
@@ -1,0 +1,128 @@
+/**
+ * Keeps the parameter -> AnalysisSpec mapping that
+ * `lib/pipeline/specs-loader.ts::batchLoadParameters` drops.
+ *
+ * #1539 — the existing `batchLoadParameters` returns
+ * `Map<parameterId, {parameterId, name, definition}>`, losing the spec
+ * association entirely. This loader returns the same shape PLUS the
+ * authoritative spec id, slug, and `promptTemplate` so the batched
+ * prompt builder can inject the rubric and `writeCallScore` can stamp
+ * `analysisSpecId`.
+ *
+ * ## Multi-spec collision rule
+ *
+ * A single parameter could in theory receive writes from multiple
+ * MEASURE specs (e.g. a generic personality spec and a domain-overlay
+ * one). Today every production parameter maps 1:1 to exactly one
+ * MEASURE spec — verified via `tests/lib/measurement/parameter-spec-map.test.ts`
+ * fixtures. The loader prefers the highest-`priority` spec on collision
+ * and logs a warning; the ADR's revisit triggers say to add a join
+ * table if this stops being 1:1 in practice.
+ */
+
+import type { AnalysisSpec, AnalysisTrigger, AnalysisAction } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+/** Per-parameter view that carries spec lineage. */
+export interface ParameterWithSpec {
+  parameterId: string;
+  name: string;
+  definition: string | null;
+  /** The `AnalysisSpec.id` whose rubric scores this parameter. Always
+   *  present — the loader skips parameters whose owning spec is missing
+   *  rather than emit a partial row. */
+  analysisSpecId: string;
+  specSlug: string;
+  /** The rubric body. `null` when the spec has no `promptTemplate` set
+   *  (legacy / under-specced spec). The prompt builder logs a
+   *  `[measure] unspecced parameter` warning when this is null. */
+  promptTemplate: string | null;
+  /** Higher = wins collisions. */
+  specPriority: number;
+}
+
+type SpecWithTriggers = AnalysisSpec & {
+  triggers: Array<AnalysisTrigger & { actions: AnalysisAction[] }>;
+};
+
+/**
+ * Build the parameter -> spec map from a list of fully-loaded MEASURE
+ * specs (i.e. specs already loaded with `include: { triggers: { include:
+ * { actions: true } } }`).
+ *
+ * Returns a `Map` keyed by `parameterId`. Parameters that don't resolve
+ * to any spec are omitted entirely (a parameter with no spec cannot be
+ * written via `writeCallScore` anyway — it has no lineage to stamp).
+ */
+export async function buildParameterSpecMap(
+  specs: SpecWithTriggers[],
+  options: { log?: (msg: string, meta?: Record<string, unknown>) => void } = {},
+): Promise<Map<string, ParameterWithSpec>> {
+  const log = options.log ?? (() => undefined);
+
+  const paramToSpec = new Map<string, SpecWithTriggers>();
+  const collisions: Array<{ parameterId: string; specSlugs: string[] }> = [];
+
+  for (const spec of specs) {
+    for (const trigger of spec.triggers) {
+      for (const action of trigger.actions) {
+        if (!action.parameterId) continue;
+
+        const existing = paramToSpec.get(action.parameterId);
+        if (!existing) {
+          paramToSpec.set(action.parameterId, spec);
+          continue;
+        }
+        if (existing.id === spec.id) continue;
+
+        if ((spec.priority ?? 0) > (existing.priority ?? 0)) {
+          collisions.push({
+            parameterId: action.parameterId,
+            specSlugs: [existing.slug, spec.slug],
+          });
+          paramToSpec.set(action.parameterId, spec);
+        } else {
+          collisions.push({
+            parameterId: action.parameterId,
+            specSlugs: [spec.slug, existing.slug],
+          });
+        }
+      }
+    }
+  }
+
+  if (collisions.length > 0) {
+    log(
+      `[parameter-spec-map] ${collisions.length} parameter(s) had multi-spec collisions; ` +
+        `highest priority wins. See #1539 ADR for the join-table revisit trigger.`,
+      { collisions },
+    );
+  }
+
+  if (paramToSpec.size === 0) {
+    return new Map();
+  }
+
+  const params = await prisma.parameter.findMany({
+    where: { parameterId: { in: Array.from(paramToSpec.keys()) } },
+    select: { parameterId: true, name: true, definition: true },
+  });
+
+  const out = new Map<string, ParameterWithSpec>();
+  for (const param of params) {
+    const spec = paramToSpec.get(param.parameterId);
+    if (!spec) continue;
+    out.set(param.parameterId, {
+      parameterId: param.parameterId,
+      name: param.name,
+      definition: param.definition,
+      analysisSpecId: spec.id,
+      specSlug: spec.slug,
+      promptTemplate: spec.promptTemplate,
+      specPriority: spec.priority ?? 0,
+    });
+  }
+
+  return out;
+}

--- a/apps/admin/lib/measurement/write-call-score.ts
+++ b/apps/admin/lib/measurement/write-call-score.ts
@@ -1,0 +1,169 @@
+/**
+ * Canonical chokepoint for writing `CallScore` rows from the production
+ * pipeline. Required: `analysisSpecId` — the `AnalysisSpec` whose
+ * `promptTemplate` produced this score.
+ *
+ * ## Why this exists (#1539)
+ *
+ * Until 2026-06-12 every `CallScore` row was written with
+ * `analysisSpecId = NULL` (verified live: 1125/1125 rows on hf_sandbox).
+ * The column existed; no write code populated it. `runBatchedCallerAnalysis`
+ * also dropped each spec's `promptTemplate` before building the LLM prompt
+ * — see `build-batched-measure-prompt.ts` for that side of the gap.
+ *
+ * The ADR is `docs/decisions/2026-06-12-spec-driven-batched-measurement.md`.
+ *
+ * This helper is the SOLE PATH for writing `CallScore` rows. ESLint rule
+ * `hf-measurement/no-bare-call-score-write` enforces (allow-list: this
+ * helper, the legacy drain script, and the test fixture cleanup helpers).
+ *
+ * ## Idempotence
+ *
+ * `(callId, parameterId, moduleId)` is the unique key on `CallScore`. The
+ * helper does `findFirst + create | update` (NOT Prisma `upsert`, because
+ * Prisma's compound unique cannot accept `moduleId = null` in `where`).
+ * Re-runs of EXTRACT against the same call replace the row in place; the
+ * `evidence` array is overwritten, not appended.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+export interface WriteCallScoreInput {
+  /** The call this score grades. Required. */
+  callId: string;
+  /** Denormalised caller link. Required to keep the (callerId, parameterId)
+   *  hot path index (`#974`) populated. */
+  callerId: string | null;
+  /** The parameter (skill / behaviour dimension) being scored. */
+  parameterId: string;
+  /** **REQUIRED** — the `AnalysisSpec.id` whose rubric produced this score.
+   *
+   *  This is the structural fix for #1539. Empty string / undefined / null
+   *  is rejected at runtime; the TypeScript signature also makes the
+   *  field non-optional. Callers may pass a sentinel spec id (e.g.
+   *  `"PROSODY-SCORE-V1"`) when the writer is not an LLM but still a
+   *  spec-shaped boundary. */
+  analysisSpecId: string;
+  /** Module attribution. `null` for unbound calls; the `CurriculumModule.id`
+   *  for module-bound calls (#491 Slice 1.2). */
+  moduleId: string | null;
+  /** 0-1 normalised score. NOT clamped here — clamp at the caller. */
+  score: number;
+  /** 0-1 confidence band. Defaults to 0.5 in the schema if omitted. */
+  confidence: number;
+  /** Evidence quotes / source markers (e.g. `["AI batched analysis"]`,
+   *  `["prosody/ielts:band=7.0"]`, `["Segment: part1"]`). */
+  evidence: string[];
+  /** Free-text LLM reasoning. `null` for non-LLM writers (PROSODY, mock). */
+  reasoning?: string | null;
+  /** `"mock_batched_v1"`, `"claude_batched_v2"`, `"prosody_v1"`, etc. */
+  scoredBy?: string | null;
+  /** `true` when the scorer judged the learner produced scoreable
+   *  evidence. `false` when the score came from tutor prose. `null` for
+   *  legacy / mock writers (Boaz S1-S4 — see schema notes on the column). */
+  hasLearnerEvidence?: boolean | null;
+  /** 0-1 confidence in evidence QUANTITY (orthogonal to `confidence`).
+   *  `null` for legacy / mock writers. */
+  evidenceQuality?: number | null;
+}
+
+export interface WriteCallScoreResult {
+  /** The persisted row id. */
+  id: string;
+  /** True when a new row was created; false when an existing row was updated. */
+  created: boolean;
+}
+
+/**
+ * Write a `CallScore` row. Idempotent against the
+ * `(callId, parameterId, moduleId)` unique key.
+ *
+ * Throws `Error("writeCallScore: analysisSpecId is required")` when the
+ * spec id is missing or empty — the structural guard #1539 exists to add.
+ *
+ * @see docs/decisions/2026-06-12-spec-driven-batched-measurement.md
+ */
+export async function writeCallScore(
+  input: WriteCallScoreInput,
+): Promise<WriteCallScoreResult> {
+  if (!input.analysisSpecId || input.analysisSpecId.trim() === "") {
+    throw new Error(
+      "writeCallScore: analysisSpecId is required (#1539). Every CallScore " +
+        "must carry the AnalysisSpec.id of the rubric that produced it. " +
+        "If you are writing from a non-LLM path (PROSODY, mock), pass the " +
+        "appropriate sentinel spec id.",
+    );
+  }
+
+  const existing = await prisma.callScore.findFirst({
+    where: {
+      callId: input.callId,
+      parameterId: input.parameterId,
+      moduleId: input.moduleId,
+    },
+    select: { id: true },
+  });
+
+  if (existing) {
+    await prisma.callScore.update({
+      where: { id: existing.id },
+      data: {
+        score: input.score,
+        confidence: input.confidence,
+        evidence: input.evidence,
+        reasoning: input.reasoning ?? null,
+        scoredBy: input.scoredBy ?? null,
+        scoredAt: new Date(),
+        analysisSpecId: input.analysisSpecId,
+        hasLearnerEvidence: input.hasLearnerEvidence ?? null,
+        evidenceQuality: input.evidenceQuality ?? null,
+      },
+    });
+    return { id: existing.id, created: false };
+  }
+
+  const row = await prisma.callScore.create({
+    data: {
+      callId: input.callId,
+      callerId: input.callerId,
+      parameterId: input.parameterId,
+      ...(input.moduleId ? { moduleId: input.moduleId } : {}),
+      score: input.score,
+      confidence: input.confidence,
+      evidence: input.evidence,
+      reasoning: input.reasoning ?? null,
+      scoredBy: input.scoredBy ?? null,
+      analysisSpecId: input.analysisSpecId,
+      hasLearnerEvidence: input.hasLearnerEvidence ?? null,
+      evidenceQuality: input.evidenceQuality ?? null,
+    },
+    select: { id: true },
+  });
+  return { id: row.id, created: true };
+}
+
+/**
+ * System-sentinel spec ids used by non-LLM writers. These are the legal
+ * values to pass when the writer is structurally spec-shaped but not
+ * backed by an `AnalysisSpec` row (PROSODY adapter scoring, the mock
+ * engine, the ADAPT delta deriver).
+ *
+ * Each sentinel maps to a seeded `AnalysisSpec` row of the same id; the
+ * seed lands in `prisma/seed-measurement-sentinels.ts` (#1539). The
+ * sentinel rows carry `outputType = MEASURE`, `scope = SYSTEM`, and a
+ * `promptTemplate` that documents what produced the score so historical
+ * tracing is honest.
+ */
+export const MEASUREMENT_SENTINEL_SPEC_IDS = {
+  /** PROSODY adapter (`lib/pipeline/prosody-consumer.ts`) writes against
+   *  this sentinel when no IELTS/PROSODY analysis spec is linked to the
+   *  parameter. */
+  PROSODY: "PROSODY-SCORE-V1",
+  /** Mock engine path (`engine === "mock"` branch). */
+  MOCK: "MOCK-MEASURE-V1",
+  /** ADAPT stage delta scores (`<parameterId>-DELTA` rows derived from
+   *  current - previous). These inherit the parent parameter's spec id
+   *  when available; this sentinel is the fallback when no parent
+   *  attribution exists. */
+  ADAPT_DELTA: "ADAPT-DELTA-V1",
+} as const;

--- a/apps/admin/lib/pipeline/adaptive-loop-invariants.ts
+++ b/apps/admin/lib/pipeline/adaptive-loop-invariants.ts
@@ -6,6 +6,7 @@
  * @invariant: I-AL3 — spec config sourcing observability (default-fallback signal)
  * @invariant: I-AL4 — PROSODY-skip observability
  * @invariant: I-AL5 — SCORE_AGENT zero-targets observability
+ * @invariant: I-AL6 — CallScore.analysisSpecId stamped post-EXTRACT (#1539)
  *
  * All invariants are NON-BLOCKING and WARN-only (I-AL3 is INFO; I-AL5 ERROR-escalates
  * when the cascade root is empty). Violations are written fire-and-forget to AppLog
@@ -24,7 +25,13 @@ import { log } from "@/lib/logger";
 
 // ── Public types ──────────────────────────────────────────
 
-export type InvariantId = "I-AL1" | "I-AL2" | "I-AL3" | "I-AL4" | "I-AL5";
+export type InvariantId =
+  | "I-AL1"
+  | "I-AL2"
+  | "I-AL3"
+  | "I-AL4"
+  | "I-AL5"
+  | "I-AL6";
 
 export type InvariantSeverity = "info" | "warn" | "error";
 
@@ -78,6 +85,10 @@ const DEFAULT_SEVERITY: Record<InvariantId, InvariantSeverity> = {
   "I-AL3": "info",
   "I-AL4": "warn",
   "I-AL5": "warn",
+  // #1539 — lands as `warn`. Will promote to `error` once the drain
+  // script reports `unresolvable = 0` and the column is migrated to
+  // NOT NULL (per ADR's migration plan).
+  "I-AL6": "warn",
 };
 
 export function defaultSeverityFor(invariant: InvariantId): InvariantSeverity {
@@ -175,6 +186,18 @@ export async function checkInvariantsAfterPipeline(
     for (const v of al2List) {
       violations.push(v);
       await recordInvariantViolation(v);
+    }
+
+    // I-AL6 — every CallScore row created/updated against this call
+    // must carry `analysisSpecId`. The structural fix #1539 lands the
+    // helper + ESLint rule that make NULL writes impossible going
+    // forward; this invariant is the runtime observer that catches
+    // (a) any allow-listed bypass that drifts past the helper and
+    // (b) historical NULL rows that survived the drain.
+    const al6 = await deriveIAL6Violation(call.id, observedAt);
+    if (al6) {
+      violations.push(al6);
+      await recordInvariantViolation(al6);
     }
   } catch {
     // Invariant runner never blocks. A genuine pipeline failure has already
@@ -352,6 +375,40 @@ async function deriveIAL2Violations(
   return violations;
 }
 
+// ── I-AL6 derivation ──────────────────────────────────────
+
+async function deriveIAL6Violation(
+  callId: string,
+  observedAt: Date,
+): Promise<InvariantViolation | null> {
+  // Count CallScore rows for this call that landed without an
+  // AnalysisSpec lineage. Pre-#1539 this was every row in the system;
+  // post-drain it should be zero. The invariant fires on the FIRST
+  // unspecced row — one signal per call is enough.
+  let unspeccedCount = 0;
+  try {
+    unspeccedCount = await prisma.callScore.count({
+      where: { callId, analysisSpecId: null },
+    });
+  } catch {
+    return null;
+  }
+
+  if (unspeccedCount === 0) return null;
+
+  return {
+    invariant: "I-AL6",
+    severity: DEFAULT_SEVERITY["I-AL6"],
+    callId,
+    context: {
+      unspeccedCallScoreCount: unspeccedCount,
+      reason:
+        "CallScore row(s) written without analysisSpecId — bypass of the writeCallScore chokepoint (#1539) or unfilled legacy row",
+    },
+    observedAt,
+  };
+}
+
 // ── Event tag helper ──────────────────────────────────────
 
 function invariantEventTag(invariant: InvariantId): string {
@@ -366,6 +423,8 @@ function invariantEventTag(invariant: InvariantId): string {
       return "prosody-skipped";
     case "I-AL5":
       return "zero-targets";
+    case "I-AL6":
+      return "unspecced-callscore";
   }
 }
 

--- a/apps/admin/lib/pipeline/prosody-consumer.ts
+++ b/apps/admin/lib/pipeline/prosody-consumer.ts
@@ -26,6 +26,10 @@
  */
 
 import { prisma } from "@/lib/prisma";
+import {
+  writeCallScore,
+  MEASUREMENT_SENTINEL_SPEC_IDS,
+} from "@/lib/measurement/write-call-score";
 
 import type {
   GeneralSignals,
@@ -116,29 +120,21 @@ async function writeIeltsCallScores(
   for (const row of rows) {
     if (!Number.isFinite(row.band)) continue;
     const normalisedScore = clamp01(row.band / 9);
-    await prisma.callScore.upsert({
-      where: {
-        callId_parameterId_moduleId: {
-          callId,
-          parameterId: row.parameterId,
-          moduleId: null as unknown as string,
-        },
-      },
-      update: {
-        score: normalisedScore,
-        confidence: 0.9,
-        evidence: [`prosody/ielts:band=${row.band.toFixed(1)}`],
-        reasoning: "PROSODY stage IELTS sub-band (0-9 normalised to 0-1)",
-      },
-      create: {
-        callId,
-        callerId,
-        parameterId: row.parameterId,
-        score: normalisedScore,
-        confidence: 0.9,
-        evidence: [`prosody/ielts:band=${row.band.toFixed(1)}`],
-        reasoning: "PROSODY stage IELTS sub-band (0-9 normalised to 0-1)",
-      },
+    // #1539 — stamp the PROSODY sentinel spec id. PROSODY is
+    // structurally spec-shaped (deterministic adapter output) but not
+    // backed by an AnalysisSpec.promptTemplate row. The sentinel
+    // surfaces "produced by PROSODY, not LLM" lineage honestly.
+    await writeCallScore({
+      callId,
+      callerId,
+      parameterId: row.parameterId,
+      analysisSpecId: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
+      moduleId: null,
+      score: normalisedScore,
+      confidence: 0.9,
+      evidence: [`prosody/ielts:band=${row.band.toFixed(1)}`],
+      reasoning: "PROSODY stage IELTS sub-band (0-9 normalised to 0-1)",
+      scoredBy: "prosody_v1",
     });
     written++;
   }
@@ -183,29 +179,18 @@ async function writeGeneralCallScores(
 
   let written = 0;
   for (const w of writes) {
-    await prisma.callScore.upsert({
-      where: {
-        callId_parameterId_moduleId: {
-          callId,
-          parameterId: w.parameterId,
-          moduleId: null as unknown as string,
-        },
-      },
-      update: {
-        score: w.score,
-        confidence: 0.7,
-        evidence: [w.evidence],
-        reasoning: "PROSODY stage general voice signal",
-      },
-      create: {
-        callId,
-        callerId,
-        parameterId: w.parameterId,
-        score: w.score,
-        confidence: 0.7,
-        evidence: [w.evidence],
-        reasoning: "PROSODY stage general voice signal",
-      },
+    // #1539 — same PROSODY sentinel for the general-mode writes.
+    await writeCallScore({
+      callId,
+      callerId,
+      parameterId: w.parameterId,
+      analysisSpecId: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
+      moduleId: null,
+      score: w.score,
+      confidence: 0.7,
+      evidence: [w.evidence],
+      reasoning: "PROSODY stage general voice signal",
+      scoredBy: "prosody_v1",
     });
     written++;
   }

--- a/apps/admin/prisma/seed-measurement-sentinels.ts
+++ b/apps/admin/prisma/seed-measurement-sentinels.ts
@@ -1,0 +1,123 @@
+/**
+ * Seeds the three SYSTEM-scope sentinel `AnalysisSpec` rows that non-LLM
+ * writers stamp onto `CallScore.analysisSpecId` so the spec-lineage
+ * column is never NULL (#1539). Idempotent — uses `upsert` keyed by `id`.
+ *
+ *   PROSODY-SCORE-V1   — used by `lib/pipeline/prosody-consumer.ts`
+ *                        (IELTS sub-band + general voice signals).
+ *   MOCK-MEASURE-V1    — used by the mock engine branch in `runBatchedCallerAnalysis`
+ *                        (deterministic 0.4-0.8 scores for synthetic transcripts).
+ *   ADAPT-DELTA-V1     — used by the ADAPT stage delta-deriver as the
+ *                        fallback when the parent score has no spec
+ *                        lineage (first-call delta has no predecessor).
+ *
+ * Each row carries an honest `promptTemplate` field documenting what
+ * produced the score. The row is NOT used as an LLM rubric — it exists
+ * solely as a structural anchor for the FK.
+ *
+ * Run from the seed orchestrator (see `seed-clean.ts`) or directly:
+ *   npx tsx prisma/seed-measurement-sentinels.ts
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+import { MEASUREMENT_SENTINEL_SPEC_IDS } from "../lib/measurement/write-call-score";
+
+const prisma = new PrismaClient();
+
+interface SentinelDef {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  promptTemplate: string;
+}
+
+const SENTINELS: SentinelDef[] = [
+  {
+    id: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
+    slug: "PROSODY-SCORE-V1",
+    name: "PROSODY adapter — IELTS sub-band + general voice signals",
+    description:
+      "Structural sentinel for #1539. Stamped on every CallScore row written by lib/pipeline/prosody-consumer.ts. The row's score is produced deterministically from VOICE_PROSODY_V1 envelope content (no LLM call); promptTemplate is non-NULL so the spec-lineage contract is observable but the field is for documentation only.",
+    promptTemplate:
+      "PROSODY adapter scoring. Source: Call.voiceProsody envelope. " +
+      "IELTS mode: row.band / 9 → normalised 0-1. General mode: paceWpm " +
+      "linearly mapped 60-200 → 0-1; hesitationRate inverted 0-1. No LLM " +
+      "rubric — this template documents the deterministic adapter only.",
+  },
+  {
+    id: MEASUREMENT_SENTINEL_SPEC_IDS.MOCK,
+    slug: "MOCK-MEASURE-V1",
+    name: "Mock engine — synthetic 0.4–0.8 random scoring",
+    description:
+      "Structural sentinel for #1539. Stamped on every CallScore row written by the engine=mock branch of runBatchedCallerAnalysis (mock-batched scorer used for harness sims and unit tests). The mock engine has no LLM reasoning; this row exists to satisfy the spec-lineage FK without misattributing the score to a real rubric.",
+    promptTemplate:
+      "Mock engine scoring. Returns 0.4 + Math.random() * 0.4 for every " +
+      "parameter (range 0.4-0.8). Confidence pulled from guardrails.config " +
+      "defaultConfidence. Mock writes carry hasLearnerEvidence/evidenceQuality " +
+      "= null (legacy semantics). NEVER use this row to read scoring methodology.",
+  },
+  {
+    id: MEASUREMENT_SENTINEL_SPEC_IDS.ADAPT_DELTA,
+    slug: "ADAPT-DELTA-V1",
+    name: "ADAPT stage — delta-derived score (current - previous)",
+    description:
+      "Structural sentinel for #1539. Stamped on ADAPT-stage <parameterId>-DELTA rows when the parent score's analysisSpecId is null (first-call delta with no predecessor lineage). When the parent score IS stamped (post-#1539), the delta inherits the parent's spec id instead.",
+    promptTemplate:
+      "ADAPT stage delta derivation. Score = (currentScore - previousScore + 1) / 2, " +
+      "normalising the delta range -1..1 to 0..1. The delta tracks change " +
+      "over time, not absolute mastery. confidence = 0.9. This row exists " +
+      "to anchor the FK when the source CallScore has no lineage (legacy NULL " +
+      "row); the preferred lineage is the parent parameter's MEASURE spec.",
+  },
+];
+
+export async function seedMeasurementSentinels(): Promise<void> {
+  for (const sentinel of SENTINELS) {
+    await prisma.analysisSpec.upsert({
+      where: { id: sentinel.id },
+      update: {
+        slug: sentinel.slug,
+        name: sentinel.name,
+        description: sentinel.description,
+        promptTemplate: sentinel.promptTemplate,
+        scope: "SYSTEM",
+        outputType: "MEASURE",
+        specType: "SYSTEM",
+        specRole: "EXTRACT",
+        isActive: true,
+      },
+      create: {
+        id: sentinel.id,
+        slug: sentinel.slug,
+        name: sentinel.name,
+        description: sentinel.description,
+        promptTemplate: sentinel.promptTemplate,
+        scope: "SYSTEM",
+        outputType: "MEASURE",
+        specType: "SYSTEM",
+        specRole: "EXTRACT",
+        priority: 0,
+        isActive: true,
+      },
+    });
+    // eslint-disable-next-line no-console
+    console.log(`  ✓ ${sentinel.id} (${sentinel.slug})`);
+  }
+}
+
+if (require.main === module) {
+  seedMeasurementSentinels()
+    .then(async () => {
+      // eslint-disable-next-line no-console
+      console.log(`Seeded ${SENTINELS.length} measurement sentinel spec(s).`);
+      await prisma.$disconnect();
+    })
+    .catch(async (err) => {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      await prisma.$disconnect();
+      process.exit(1);
+    });
+}

--- a/apps/admin/scripts/backfill-call-score-analysis-spec.ts
+++ b/apps/admin/scripts/backfill-call-score-analysis-spec.ts
@@ -1,0 +1,202 @@
+/**
+ * Drain script — backfill `analysisSpecId` on historical `CallScore` rows.
+ *
+ * #1539 — every CallScore row from before this PR carries
+ * `analysisSpecId = NULL`. The structural fix lands the column write
+ * for new rows; this script drains the historical population.
+ *
+ * ## Attribution rule
+ *
+ * For each NULL row, look up the active MEASURE specs that resolve the
+ * row's `parameterId` (via the spec's trigger.actions chain). When
+ * exactly ONE spec resolves to the parameter, attribute the row to that
+ * spec. When zero or multiple specs resolve, mark the row with the
+ * `LEGACY-UNSPECCED-PRE-1539` sentinel so the lineage is honest about
+ * being unrecoverable.
+ *
+ * Honest about its limits: the script cannot recover the actual spec
+ * id that produced a historical row when multiple specs match the
+ * parameter today. The legacy sentinel marks those rows so they show
+ * up in the I-AL6 dashboard until the operator decides whether to
+ * delete or re-extract.
+ *
+ * ## Safety
+ *
+ * - **Dry-run by default.** Prints what it would do without writing.
+ *   Pass `--apply` to commit.
+ * - **Idempotent.** Re-runs skip rows that already have an
+ *   `analysisSpecId`. Safe to re-run after a failure.
+ * - **Batched** — processes 1000 rows per chunk to keep memory flat.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-call-score-analysis-spec.ts            # dry-run
+ *   npx tsx scripts/backfill-call-score-analysis-spec.ts --apply    # write
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const LEGACY_SENTINEL_ID = "LEGACY-UNSPECCED-PRE-1539";
+const LEGACY_SENTINEL_SLUG = "LEGACY-UNSPECCED-PRE-1539";
+
+const CHUNK_SIZE = 1000;
+
+interface DrainCounts {
+  scanned: number;
+  attributed: number;
+  legacyMarked: number;
+  alreadyStamped: number;
+}
+
+async function ensureLegacySentinel(apply: boolean): Promise<void> {
+  if (!apply) return;
+  await prisma.analysisSpec.upsert({
+    where: { id: LEGACY_SENTINEL_ID },
+    update: {},
+    create: {
+      id: LEGACY_SENTINEL_ID,
+      slug: LEGACY_SENTINEL_SLUG,
+      name: "Legacy CallScore rows pre-#1539 (no recoverable lineage)",
+      description:
+        "Sentinel for CallScore rows whose original AnalysisSpec is " +
+        "unrecoverable — either zero or multiple active MEASURE specs " +
+        "resolve to the row's parameter today. The row was scored before " +
+        "#1539 added structural spec stamping. Surface via I-AL6 to " +
+        "decide whether to delete or re-extract.",
+      promptTemplate:
+        "No recoverable rubric. The row was scored by runBatchedCallerAnalysis " +
+        "before #1539 wired analysisSpecId stamping. The drain script could " +
+        "not attribute it because the (parameterId → active MEASURE spec) " +
+        "mapping is no longer 1:1.",
+      scope: "SYSTEM",
+      outputType: "MEASURE",
+      specType: "SYSTEM",
+      specRole: "EXTRACT",
+      isActive: true,
+    },
+  });
+}
+
+async function buildParameterToSpecsMap(): Promise<Map<string, string[]>> {
+  const specs = await prisma.analysisSpec.findMany({
+    where: {
+      isActive: true,
+      outputType: { in: ["MEASURE", "LEARN"] },
+    },
+    include: {
+      triggers: {
+        include: { actions: true },
+      },
+    },
+  });
+
+  const out = new Map<string, string[]>();
+  for (const spec of specs) {
+    for (const trigger of spec.triggers) {
+      for (const action of trigger.actions) {
+        if (!action.parameterId) continue;
+        const list = out.get(action.parameterId) ?? [];
+        if (!list.includes(spec.id)) list.push(spec.id);
+        out.set(action.parameterId, list);
+      }
+    }
+  }
+  return out;
+}
+
+async function drainChunk(
+  paramToSpecs: Map<string, string[]>,
+  cursor: string | null,
+  counts: DrainCounts,
+  apply: boolean,
+): Promise<string | null> {
+  const rows = await prisma.callScore.findMany({
+    where: { analysisSpecId: null },
+    select: { id: true, parameterId: true, callId: true },
+    orderBy: { id: "asc" },
+    take: CHUNK_SIZE,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+  });
+
+  if (rows.length === 0) return null;
+
+  for (const row of rows) {
+    counts.scanned++;
+    const candidates = paramToSpecs.get(row.parameterId) ?? [];
+    if (candidates.length === 1) {
+      counts.attributed++;
+      if (apply) {
+        await prisma.callScore.update({
+          where: { id: row.id },
+          data: { analysisSpecId: candidates[0] },
+        });
+      }
+    } else {
+      counts.legacyMarked++;
+      if (apply) {
+        await prisma.callScore.update({
+          where: { id: row.id },
+          data: { analysisSpecId: LEGACY_SENTINEL_ID },
+        });
+      }
+    }
+  }
+
+  return rows[rows.length - 1]!.id;
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  // eslint-disable-next-line no-console
+  console.log(
+    `[backfill #1539] ${apply ? "APPLY" : "DRY-RUN"} — backfilling CallScore.analysisSpecId on NULL rows.`,
+  );
+
+  await ensureLegacySentinel(apply);
+
+  const paramToSpecs = await buildParameterToSpecsMap();
+  // eslint-disable-next-line no-console
+  console.log(
+    `[backfill #1539] resolved ${paramToSpecs.size} parameters from active MEASURE/LEARN specs.`,
+  );
+
+  const counts: DrainCounts = {
+    scanned: 0,
+    attributed: 0,
+    legacyMarked: 0,
+    alreadyStamped: 0,
+  };
+
+  let cursor: string | null = null;
+  while (true) {
+    cursor = await drainChunk(paramToSpecs, cursor, counts, apply);
+    if (cursor === null) break;
+    if (counts.scanned % 5000 === 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[backfill #1539] progress — scanned=${counts.scanned} attributed=${counts.attributed} legacy=${counts.legacyMarked}`,
+      );
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`[backfill #1539] DONE — ${JSON.stringify(counts)}`);
+  // eslint-disable-next-line no-console
+  console.log(
+    apply
+      ? `[backfill #1539] APPLIED — historical NULL rows are drained. Run I-AL6 audit query to verify zero remain.`
+      : `[backfill #1539] DRY-RUN — re-run with --apply to commit.`,
+  );
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (err) => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts
+++ b/apps/admin/tests/integration/journey/adaptive-loop-canary.integration.test.ts
@@ -248,7 +248,12 @@ describe("#1514 Adaptive Loop canary — proves the chain closes", () => {
     // ── Gate 1: EXTRACT — CallScore rows ─────────────────────
     const scores = await prisma.callScore.findMany({
       where: { callId: call.id },
-      select: { id: true, parameterId: true, scoredBy: true },
+      select: {
+        id: true,
+        parameterId: true,
+        scoredBy: true,
+        analysisSpecId: true,
+      },
     });
     const scoreCount = scores.length;
     const hardFail1 = scoreCount < EXTRACT_FLOOR;
@@ -262,6 +267,23 @@ describe("#1514 Adaptive Loop canary — proves the chain closes", () => {
       scoreCount,
       `EXTRACT wrote ${scoreCount} CallScore rows; expected >= ${EXTRACT_FLOOR}`,
     ).toBeGreaterThanOrEqual(EXTRACT_FLOOR);
+
+    // ── Gate 1b: #1539 — every CallScore stamps analysisSpecId ─
+    const unspecced = scores.filter((s) => !s.analysisSpecId);
+    recordGate(
+      "extract.spec-lineage",
+      unspecced.length === 0 ? "PASS" : "FAIL",
+      `unspecced=${unspecced.length}/${scoreCount} (#1539 contract: every CallScore carries analysisSpecId)`,
+    );
+    // HARD FAIL — if any CallScore row landed without lineage, the
+    // chokepoint helper was bypassed. ESLint rule + writeCallScore
+    // runtime guard SHOULD prevent this; the canary catches drift.
+    expect(
+      unspecced.length,
+      `#1539 — ${unspecced.length} CallScore row(s) lack analysisSpecId. ` +
+        `Every write must route through lib/measurement/write-call-score.ts. ` +
+        `Sample: ${unspecced.slice(0, 3).map((s) => `${s.parameterId} (scoredBy=${s.scoredBy})`).join(", ")}`,
+    ).toBe(0);
 
     // ── Gate 2 (WARN — G9 dependency): LEARN — CallerMemory ──
     const memories = await prisma.callerMemory.findMany({

--- a/apps/admin/tests/integration/journey/canary-fixture.ts
+++ b/apps/admin/tests/integration/journey/canary-fixture.ts
@@ -38,6 +38,71 @@ import {
   buildSeedPlan,
   classifySeedPlan,
 } from "../../../scripts/seed-system-behavior-defaults";
+import { MEASUREMENT_SENTINEL_SPEC_IDS } from "../../../lib/measurement/write-call-score";
+
+/**
+ * #1539 — sentinel spec rows. Inlined from
+ * `prisma/seed-measurement-sentinels.ts` so the canary's single
+ * PrismaClient connection runs the upsert.
+ */
+async function seedMeasurementSentinelsInline(
+  prisma: PrismaClient,
+): Promise<void> {
+  const sentinels = [
+    {
+      id: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
+      slug: "PROSODY-SCORE-V1",
+      name: "PROSODY adapter",
+      description: "Spec-lineage anchor for prosody-consumer writes (#1539).",
+      promptTemplate:
+        "PROSODY adapter scoring (deterministic, no LLM). Source: Call.voiceProsody.",
+    },
+    {
+      id: MEASUREMENT_SENTINEL_SPEC_IDS.MOCK,
+      slug: "MOCK-MEASURE-V1",
+      name: "Mock engine",
+      description: "Spec-lineage anchor for mock-engine CallScore writes (#1539).",
+      promptTemplate: "Mock engine: 0.4 + Math.random() * 0.4. No LLM.",
+    },
+    {
+      id: MEASUREMENT_SENTINEL_SPEC_IDS.ADAPT_DELTA,
+      slug: "ADAPT-DELTA-V1",
+      name: "ADAPT delta",
+      description: "Spec-lineage anchor for ADAPT-stage <param>-DELTA rows (#1539).",
+      promptTemplate:
+        "ADAPT delta: (current - previous + 1) / 2. Tracks change, not absolute mastery.",
+    },
+  ];
+  for (const sentinel of sentinels) {
+    await prisma.analysisSpec.upsert({
+      where: { id: sentinel.id },
+      update: {
+        slug: sentinel.slug,
+        name: sentinel.name,
+        description: sentinel.description,
+        promptTemplate: sentinel.promptTemplate,
+        scope: "SYSTEM",
+        outputType: "MEASURE",
+        specType: "SYSTEM",
+        specRole: "EXTRACT",
+        isActive: true,
+      },
+      create: {
+        id: sentinel.id,
+        slug: sentinel.slug,
+        name: sentinel.name,
+        description: sentinel.description,
+        promptTemplate: sentinel.promptTemplate,
+        scope: "SYSTEM",
+        outputType: "MEASURE",
+        specType: "SYSTEM",
+        specRole: "EXTRACT",
+        priority: 0,
+        isActive: true,
+      },
+    });
+  }
+}
 
 /**
  * Prefix every fixture entity slug / name with this so cleanup can be
@@ -130,6 +195,14 @@ const CANARY_SKILL_PARAMS: ReadonlyArray<{
 export async function bootstrapCanaryFixture(
   prisma: PrismaClient,
 ): Promise<CanaryFixture> {
+  // 0. #1539 — seed the measurement-sentinel AnalysisSpec rows so
+  //    `writeCallScore` always finds an FK target for the PROSODY /
+  //    MOCK / ADAPT_DELTA sentinel ids. Inlined here instead of
+  //    calling `seedMeasurementSentinels()` because the seed module
+  //    constructs its own PrismaClient; we use the canary's client to
+  //    keep the fixture single-connection.
+  await seedMeasurementSentinelsInline(prisma);
+
   // 1. Domain
   const domain = await prisma.domain.upsert({
     where: { slug: DOMAIN_SLUG },
@@ -416,6 +489,17 @@ async function seedCanarySkillMeasureSpec(
         "Adaptive-loop canary per-playbook MEASURE spec (#1516). Scores the " +
         "4 IELTS Speaking skill parameters from every call transcript so " +
         "SKILL-AGG-001 has source rows for the EMA aggregation pass.",
+      // #1539 — populate the rubric so the canary exercises the
+      // spec-driven prompt path end-to-end. Without a promptTemplate
+      // the prompt builder falls back to name+definition AND logs a
+      // warning; the canary is the place we want full coverage.
+      promptTemplate:
+        "Score the learner on the IELTS Speaking Band descriptors for this dimension.\n\n" +
+        "Band 9 (expert): Speaks fluently with rare hesitation; uses precise vocabulary and varied grammar.\n" +
+        "Band 7 (good): Speaks at length without noticeable effort; uses a range of vocabulary with some less common forms; produces complex sentences with some errors.\n" +
+        "Band 5 (modest): Usually maintains flow but uses repetition and self-correction; limited vocabulary; basic sentence forms with frequent errors.\n" +
+        "Band 3 (extremely limited): Speaks in short utterances with frequent breakdowns; minimal vocabulary; little or no grammatical control.\n\n" +
+        "Return a normalised 0-1 score. Use 0.4-0.5 for Band 5, 0.7-0.8 for Band 7, 0.85+ for Band 8-9.",
       scope: "DOMAIN",
       outputType: "MEASURE",
       specType: "DOMAIN",
@@ -430,6 +514,15 @@ async function seedCanarySkillMeasureSpec(
       isActive: true,
       isDirty: false,
       compiledAt: now,
+      // #1539 — keep the rubric in sync on re-runs of the fixture
+      // (the canary runs against a long-lived DB, not a fresh one).
+      promptTemplate:
+        "Score the learner on the IELTS Speaking Band descriptors for this dimension.\n\n" +
+        "Band 9 (expert): Speaks fluently with rare hesitation; uses precise vocabulary and varied grammar.\n" +
+        "Band 7 (good): Speaks at length without noticeable effort; uses a range of vocabulary with some less common forms; produces complex sentences with some errors.\n" +
+        "Band 5 (modest): Usually maintains flow but uses repetition and self-correction; limited vocabulary; basic sentence forms with frequent errors.\n" +
+        "Band 3 (extremely limited): Speaks in short utterances with frequent breakdowns; minimal vocabulary; little or no grammatical control.\n\n" +
+        "Return a normalised 0-1 score. Use 0.4-0.5 for Band 5, 0.7-0.8 for Band 7, 0.85+ for Band 8-9.",
     },
     select: { id: true },
   });

--- a/apps/admin/tests/lib/measurement/build-batched-measure-prompt.test.ts
+++ b/apps/admin/tests/lib/measurement/build-batched-measure-prompt.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Pins the structural contract of `buildBatchedMeasurePrompt` (#1539).
+ *
+ * The prompt body MUST interpolate each MEASURE spec's `promptTemplate`
+ * verbatim. The previous inline `buildBatchedCallerPrompt` discarded
+ * rubrics; this test stops a future edit silently reintroducing that
+ * gap.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { buildBatchedMeasurePrompt } from "@/lib/measurement/build-batched-measure-prompt";
+import type { ParameterWithSpec } from "@/lib/measurement/parameter-spec-map";
+
+const ieltsRubric = `Score the learner on IELTS Speaking Band Descriptors for Fluency and Coherence.
+
+Band 9: Speaks fluently with only rare repetition or self-correction.
+Band 7: Speaks at length without noticeable effort or loss of coherence.
+Band 5: Usually maintains flow of speech but uses repetition / self-correction.`;
+
+const fluencyParam: ParameterWithSpec = {
+  parameterId: "skill_fluency_and_coherence_fc",
+  name: "Fluency and Coherence",
+  definition: "How smoothly the learner speaks.",
+  analysisSpecId: "spec-ielts-fc",
+  specSlug: "IELTS-FLUENCY-MEASURE-001",
+  promptTemplate: ieltsRubric,
+  specPriority: 100,
+};
+
+const unspeccedParam: ParameterWithSpec = {
+  parameterId: "PERSONALITY-OPENNESS",
+  name: "Openness",
+  definition: "Curiosity, imagination, willingness to try new things.",
+  analysisSpecId: "spec-pers",
+  specSlug: "PERS-001",
+  promptTemplate: null,
+  specPriority: 50,
+};
+
+describe("buildBatchedMeasurePrompt", () => {
+  it("includes the parameterId:name list", () => {
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: "Tutor: ... Learner: ...",
+      measureParams: [fluencyParam],
+      learnActions: [],
+    });
+    expect(prompt).toContain(
+      "PARAMS TO SCORE: skill_fluency_and_coherence_fc:Fluency and Coherence",
+    );
+  });
+
+  it("interpolates promptTemplate verbatim as a per-parameter rubric block", () => {
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: "Tutor: ... Learner: ...",
+      measureParams: [fluencyParam],
+      learnActions: [],
+    });
+    expect(prompt).toContain(
+      "RUBRIC[skill_fluency_and_coherence_fc] (from spec IELTS-FLUENCY-MEASURE-001):",
+    );
+    expect(prompt).toContain(ieltsRubric.trim());
+  });
+
+  it("emits SCORING RUBRICS section even when ALL params have rubrics", () => {
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: "Tutor: ... Learner: ...",
+      measureParams: [fluencyParam],
+      learnActions: [],
+    });
+    expect(prompt).toContain("SCORING RUBRICS");
+  });
+
+  it("falls back to name+definition when promptTemplate is null and logs a warning", () => {
+    const log = vi.fn();
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: "Tutor: ... Learner: ...",
+      measureParams: [unspeccedParam],
+      learnActions: [],
+      log,
+    });
+    expect(prompt).toContain(
+      "RUBRIC[PERSONALITY-OPENNESS] (from spec PERS-001, no promptTemplate set",
+    );
+    expect(prompt).toContain("Openness");
+    expect(prompt).toContain(
+      "Curiosity, imagination, willingness to try new things.",
+    );
+    expect(log).toHaveBeenCalledOnce();
+    const [msg, meta] = log.mock.calls[0]!;
+    expect(msg).toContain("#1539");
+    expect(meta).toEqual({
+      unspecced: [
+        { parameterId: "PERSONALITY-OPENNESS", specSlug: "PERS-001" },
+      ],
+    });
+  });
+
+  it("mixes specced + unspecced params and emits both rubric shapes", () => {
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: "T:...L:...",
+      measureParams: [fluencyParam, unspeccedParam],
+      learnActions: [],
+    });
+    expect(prompt).toContain("from spec IELTS-FLUENCY-MEASURE-001");
+    expect(prompt).toContain(
+      "from spec PERS-001, no promptTemplate set",
+    );
+  });
+
+  it("respects transcriptLimit", () => {
+    const longTranscript = "¶".repeat(10_000); // ¶ — not present elsewhere in the template
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: longTranscript,
+      measureParams: [fluencyParam],
+      learnActions: [],
+      transcriptLimit: 500,
+    });
+    const sentinelChars = (prompt.match(/¶/g) || []).length;
+    expect(sentinelChars).toBe(500);
+  });
+
+  it("emits the LEARNING OUTCOMES section when moduleContext is provided", () => {
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: "T:...L:...",
+      measureParams: [fluencyParam],
+      learnActions: [],
+      moduleContext: {
+        moduleId: "mod-1",
+        moduleName: "Part 1 — Familiar Topics",
+        learningOutcomes: ["lo:speak_about_hometown", "lo:describe_routines"],
+      },
+    });
+    expect(prompt).toContain("LEARNING OUTCOMES TO ASSESS");
+    expect(prompt).toContain("lo:speak_about_hometown");
+    expect(prompt).toContain('"learning":{"moduleId":"mod-1"');
+  });
+
+  it("does NOT log unspecced warnings when every param has a rubric", () => {
+    const log = vi.fn();
+    buildBatchedMeasurePrompt({
+      transcript: "T:...L:...",
+      measureParams: [fluencyParam],
+      learnActions: [],
+      log,
+    });
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("instructs the LLM to use rubric — not infer from parameter name", () => {
+    const prompt = buildBatchedMeasurePrompt({
+      transcript: "T:...L:...",
+      measureParams: [fluencyParam],
+      learnActions: [],
+    });
+    expect(prompt).toMatch(
+      /use the matching rubric for each parameter — DO NOT guess from the parameter name alone/,
+    );
+  });
+});

--- a/apps/admin/tests/lib/measurement/parameter-spec-map.test.ts
+++ b/apps/admin/tests/lib/measurement/parameter-spec-map.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Pins the parameter -> spec lineage map (#1539).
+ *
+ * Distinguishes the structural fix from the existing
+ * `batchLoadParameters`: this loader KEEPS the spec id, slug, and
+ * promptTemplate so downstream writers can stamp `analysisSpecId`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    parameter: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+
+import { buildParameterSpecMap } from "@/lib/measurement/parameter-spec-map";
+
+const mockedFindMany = prisma.parameter.findMany as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+beforeEach(() => {
+  mockedFindMany.mockReset();
+});
+
+function makeSpec(
+  id: string,
+  slug: string,
+  paramId: string,
+  opts: {
+    priority?: number;
+    promptTemplate?: string | null;
+  } = {},
+) {
+  return {
+    id,
+    slug,
+    name: slug,
+    description: null,
+    scope: "DOMAIN" as const,
+    outputType: "MEASURE" as const,
+    specType: "DOMAIN" as const,
+    specRole: "EXTRACT" as const,
+    domain: null,
+    priority: opts.priority ?? 0,
+    isActive: true,
+    extendsAgent: null,
+    promptTemplate: opts.promptTemplate ?? null,
+    config: {} as never,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    triggers: [
+      {
+        id: `${id}-trigger`,
+        specId: id,
+        type: "every_call" as const,
+        config: {} as never,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        actions: [
+          {
+            id: `${id}-action`,
+            triggerId: `${id}-trigger`,
+            parameterId: paramId,
+            description: "score this",
+            learnCategory: null,
+            learnKeyPrefix: null,
+            learnKeyHint: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      },
+    ],
+  } as never;
+}
+
+describe("buildParameterSpecMap", () => {
+  it("returns a parameter row with full spec lineage", async () => {
+    mockedFindMany.mockResolvedValueOnce([
+      {
+        parameterId: "IELTS-FLUENCY",
+        name: "Fluency and Coherence",
+        definition: "How smoothly the learner speaks.",
+      },
+    ]);
+    const specs = [
+      makeSpec("spec-1", "IELTS-FLUENCY-MEASURE-001", "IELTS-FLUENCY", {
+        promptTemplate: "Score on IELTS Band 1-9 ...",
+      }),
+    ];
+
+    const map = await buildParameterSpecMap(specs);
+
+    expect(map.size).toBe(1);
+    const row = map.get("IELTS-FLUENCY");
+    expect(row).toEqual({
+      parameterId: "IELTS-FLUENCY",
+      name: "Fluency and Coherence",
+      definition: "How smoothly the learner speaks.",
+      analysisSpecId: "spec-1",
+      specSlug: "IELTS-FLUENCY-MEASURE-001",
+      promptTemplate: "Score on IELTS Band 1-9 ...",
+      specPriority: 0,
+    });
+  });
+
+  it("preserves null promptTemplate (legacy / under-specced spec)", async () => {
+    mockedFindMany.mockResolvedValueOnce([
+      { parameterId: "PERS-OPEN", name: "Openness", definition: null },
+    ]);
+    const specs = [
+      makeSpec("spec-pers", "PERS-001", "PERS-OPEN", { promptTemplate: null }),
+    ];
+    const map = await buildParameterSpecMap(specs);
+    expect(map.get("PERS-OPEN")!.promptTemplate).toBeNull();
+  });
+
+  it("prefers the highest-priority spec on collision and logs a warning", async () => {
+    mockedFindMany.mockResolvedValueOnce([
+      { parameterId: "IELTS-FLUENCY", name: "Fluency", definition: null },
+    ]);
+    const log = vi.fn();
+    const specs = [
+      makeSpec("spec-low", "GENERIC-FLUENCY", "IELTS-FLUENCY", { priority: 10 }),
+      makeSpec("spec-high", "IELTS-FLUENCY-MEASURE-001", "IELTS-FLUENCY", {
+        priority: 100,
+        promptTemplate: "IELTS bands",
+      }),
+    ];
+    const map = await buildParameterSpecMap(specs, { log });
+
+    expect(map.get("IELTS-FLUENCY")!.analysisSpecId).toBe("spec-high");
+    expect(map.get("IELTS-FLUENCY")!.promptTemplate).toBe("IELTS bands");
+    expect(log).toHaveBeenCalledOnce();
+    const [msg, meta] = log.mock.calls[0]!;
+    expect(msg).toContain("collisions");
+    expect(meta).toEqual({
+      collisions: [
+        {
+          parameterId: "IELTS-FLUENCY",
+          specSlugs: ["GENERIC-FLUENCY", "IELTS-FLUENCY-MEASURE-001"],
+        },
+      ],
+    });
+  });
+
+  it("returns an empty map when no specs produce parameters", async () => {
+    const specs: never[] = [];
+    const map = await buildParameterSpecMap(specs);
+    expect(map.size).toBe(0);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
+  it("omits parameters whose owning spec is missing rather than emitting partial rows", async () => {
+    // parameter row exists but the spec list is empty — should not appear.
+    mockedFindMany.mockResolvedValueOnce([
+      { parameterId: "PHANTOM", name: "Phantom", definition: null },
+    ]);
+    const map = await buildParameterSpecMap([]);
+    expect(map.size).toBe(0);
+  });
+});

--- a/apps/admin/tests/lib/measurement/write-call-score.test.ts
+++ b/apps/admin/tests/lib/measurement/write-call-score.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Pins the structural contract of `writeCallScore` (#1539).
+ *
+ * The helper is the SOLE PATH for writing `CallScore` rows from the
+ * production pipeline. Every test in this file pins a structural
+ * invariant — if any test goes red, a future edit has either (a)
+ * weakened the analysisSpecId requirement, (b) changed the idempotence
+ * shape, or (c) re-introduced the spec-lineage gap this PR closes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    callScore: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+
+import {
+  writeCallScore,
+  MEASUREMENT_SENTINEL_SPEC_IDS,
+} from "@/lib/measurement/write-call-score";
+
+const mockedFindFirst = prisma.callScore.findFirst as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockedCreate = prisma.callScore.create as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockedUpdate = prisma.callScore.update as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+beforeEach(() => {
+  mockedFindFirst.mockReset();
+  mockedCreate.mockReset();
+  mockedUpdate.mockReset();
+});
+
+describe("writeCallScore — structural contract", () => {
+  it("rejects empty analysisSpecId", async () => {
+    await expect(
+      writeCallScore({
+        callId: "call-1",
+        callerId: "caller-1",
+        parameterId: "IELTS-FLUENCY",
+        analysisSpecId: "",
+        moduleId: null,
+        score: 0.7,
+        confidence: 0.8,
+        evidence: ["x"],
+      }),
+    ).rejects.toThrow(/analysisSpecId is required/);
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only analysisSpecId", async () => {
+    await expect(
+      writeCallScore({
+        callId: "call-1",
+        callerId: "caller-1",
+        parameterId: "IELTS-FLUENCY",
+        analysisSpecId: "   ",
+        moduleId: null,
+        score: 0.7,
+        confidence: 0.8,
+        evidence: ["x"],
+      }),
+    ).rejects.toThrow(/analysisSpecId is required/);
+  });
+
+  it("rejects undefined cast through `as any`", async () => {
+    await expect(
+      writeCallScore({
+        callId: "call-1",
+        callerId: "caller-1",
+        parameterId: "IELTS-FLUENCY",
+        analysisSpecId: undefined as unknown as string,
+        moduleId: null,
+        score: 0.7,
+        confidence: 0.8,
+        evidence: ["x"],
+      }),
+    ).rejects.toThrow(/analysisSpecId is required/);
+  });
+
+  it("creates a new row when none exists, stamping analysisSpecId", async () => {
+    mockedFindFirst.mockResolvedValueOnce(null);
+    mockedCreate.mockResolvedValueOnce({ id: "score-new" });
+
+    const result = await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "IELTS-FLUENCY",
+      analysisSpecId: "spec-abc",
+      moduleId: "mod-1",
+      score: 0.7,
+      confidence: 0.8,
+      evidence: ["AI batched analysis"],
+      scoredBy: "claude_batched_v2",
+      reasoning: "Strong fluency cues",
+      hasLearnerEvidence: true,
+      evidenceQuality: 0.6,
+    });
+
+    expect(result).toEqual({ id: "score-new", created: true });
+    expect(mockedCreate).toHaveBeenCalledOnce();
+    const createArg = mockedCreate.mock.calls[0]![0];
+    expect(createArg.data.analysisSpecId).toBe("spec-abc");
+    expect(createArg.data.callId).toBe("call-1");
+    expect(createArg.data.parameterId).toBe("IELTS-FLUENCY");
+    expect(createArg.data.moduleId).toBe("mod-1");
+    expect(createArg.data.scoredBy).toBe("claude_batched_v2");
+  });
+
+  it("updates an existing row in place when (callId, parameterId, moduleId) matches", async () => {
+    mockedFindFirst.mockResolvedValueOnce({ id: "score-existing" });
+    mockedUpdate.mockResolvedValueOnce({ id: "score-existing" });
+
+    const result = await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "IELTS-FLUENCY",
+      analysisSpecId: "spec-abc",
+      moduleId: "mod-1",
+      score: 0.9,
+      confidence: 0.9,
+      evidence: ["AI batched analysis (re-run)"],
+    });
+
+    expect(result).toEqual({ id: "score-existing", created: false });
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(mockedUpdate).toHaveBeenCalledOnce();
+    const updateArg = mockedUpdate.mock.calls[0]![0];
+    expect(updateArg.data.analysisSpecId).toBe("spec-abc");
+    expect(updateArg.data.score).toBe(0.9);
+  });
+
+  it("filters findFirst by moduleId so per-segment writes don't collide with bound-module writes", async () => {
+    mockedFindFirst.mockResolvedValueOnce(null);
+    mockedCreate.mockResolvedValueOnce({ id: "score-segment" });
+
+    await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "IELTS-FLUENCY",
+      analysisSpecId: "spec-abc",
+      moduleId: "mod-part1",
+      score: 0.5,
+      confidence: 0.7,
+      evidence: ["Segment: part1"],
+    });
+
+    expect(mockedFindFirst).toHaveBeenCalledWith({
+      where: {
+        callId: "call-1",
+        parameterId: "IELTS-FLUENCY",
+        moduleId: "mod-part1",
+      },
+      select: { id: true },
+    });
+  });
+
+  it("omits moduleId from create payload when null (preserves schema default)", async () => {
+    mockedFindFirst.mockResolvedValueOnce(null);
+    mockedCreate.mockResolvedValueOnce({ id: "score-unbound" });
+
+    await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "PERSONALITY-OPENNESS",
+      analysisSpecId: "spec-pers",
+      moduleId: null,
+      score: 0.6,
+      confidence: 0.5,
+      evidence: ["AI batched analysis"],
+    });
+
+    const createArg = mockedCreate.mock.calls[0]![0];
+    expect("moduleId" in createArg.data).toBe(false);
+  });
+
+  it("accepts sentinel spec ids for non-LLM writers", async () => {
+    mockedFindFirst.mockResolvedValueOnce(null);
+    mockedCreate.mockResolvedValueOnce({ id: "score-prosody" });
+
+    await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "skill_fluency_and_coherence_fc",
+      analysisSpecId: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
+      moduleId: null,
+      score: 0.7,
+      confidence: 0.9,
+      evidence: ["prosody/ielts:band=6.5"],
+      scoredBy: "prosody_v1",
+    });
+
+    expect(mockedCreate).toHaveBeenCalledOnce();
+    expect(mockedCreate.mock.calls[0]![0].data.analysisSpecId).toBe(
+      "PROSODY-SCORE-V1",
+    );
+  });
+});

--- a/apps/admin/tests/lib/pipeline/adaptive-loop-invariants.test.ts
+++ b/apps/admin/tests/lib/pipeline/adaptive-loop-invariants.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockCallFindUnique = vi.fn();
 const mockCallScoreFindMany = vi.fn();
+const mockCallScoreCount = vi.fn();
 const mockCallerMemoryCount = vi.fn();
 const mockCallerTargetFindUnique = vi.fn();
 const mockQueryRaw = vi.fn();
@@ -35,6 +36,7 @@ vi.mock("@/lib/prisma", () => ({
     call: { findUnique: (...args: unknown[]) => mockCallFindUnique(...args) },
     callScore: {
       findMany: (...args: unknown[]) => mockCallScoreFindMany(...args),
+      count: (...args: unknown[]) => mockCallScoreCount(...args),
     },
     callerMemory: {
       count: (...args: unknown[]) => mockCallerMemoryCount(...args),
@@ -67,6 +69,7 @@ beforeEach(() => {
   mockCallerMemoryCount.mockResolvedValue(0);
   mockCallerTargetFindUnique.mockResolvedValue(null);
   mockQueryRaw.mockResolvedValue([]);
+  mockCallScoreCount.mockResolvedValue(0);
 });
 
 // ── recordInvariantViolation ──────────────────────────────
@@ -369,6 +372,56 @@ describe("I-AL5 — SCORE_AGENT zero targets", () => {
     const [, , data] = mockLog.mock.calls[0];
     expect(data.level).toBe("error");
     expect(data.systemDefaultsEmpty).toBe(true);
+  });
+});
+
+// ── I-AL6 ─────────────────────────────────────────────────
+
+describe("I-AL6 — CallScore.analysisSpecId stamped post-EXTRACT (#1539)", () => {
+  beforeEach(() => {
+    mockCallFindUnique.mockResolvedValue({
+      id: "call-AL6",
+      callerId: "caller-AL6",
+      transcript: "x".repeat(50), // below I-AL1 threshold; isolates AL6
+      createdAt: new Date(),
+    });
+    // Default to no AL2 violations (no skill_* rows in fresh window).
+    mockQueryRaw.mockResolvedValue([]);
+  });
+
+  it("FIRES WARN when CallScore rows for this call lack analysisSpecId", async () => {
+    mockCallScoreCount.mockResolvedValueOnce(3); // 3 rows without lineage
+    const v = await checkInvariantsAfterPipeline("call-AL6");
+    const al6 = v.find((row) => row.invariant === "I-AL6");
+    expect(al6).toBeDefined();
+    expect(al6!.severity).toBe("warn");
+    expect(al6!.callId).toBe("call-AL6");
+    expect(al6!.context.unspeccedCallScoreCount).toBe(3);
+    const al6Log = mockLog.mock.calls.find(
+      (call: unknown[]) => call[1] === "pipeline.invariant.i-al6",
+    );
+    expect(al6Log).toBeDefined();
+    expect((al6Log![2] as { event: string }).event).toBe(
+      "I-AL6-unspecced-callscore",
+    );
+  });
+
+  it("does NOT fire when every CallScore row has analysisSpecId", async () => {
+    mockCallScoreCount.mockResolvedValueOnce(0);
+    const v = await checkInvariantsAfterPipeline("call-AL6");
+    const al6 = v.find((row) => row.invariant === "I-AL6");
+    expect(al6).toBeUndefined();
+  });
+
+  it("does NOT fire when count throws (durability — invariant is non-blocking)", async () => {
+    mockCallScoreCount.mockRejectedValueOnce(new Error("db gone"));
+    const v = await checkInvariantsAfterPipeline("call-AL6");
+    const al6 = v.find((row) => row.invariant === "I-AL6");
+    expect(al6).toBeUndefined();
+  });
+
+  it("defaultSeverityFor(I-AL6) is warn (will promote to error post-drain)", () => {
+    expect(defaultSeverityFor("I-AL6")).toBe("warn");
   });
 });
 

--- a/docs/CHAIN-CONTRACTS.md
+++ b/docs/CHAIN-CONTRACTS.md
@@ -536,7 +536,7 @@ All invariants here are **WARN-only and non-blocking**. The pipeline always retu
 
 `AGGREGATE` writes `CallScore` + `CallerAttribute(lo_mastery:*)` from EXTRACT's measurements. Skill-scoped `CallScore` rows feed `aggregate-runner.ts`'s EMA cascade into `CallerTarget.currentScore`. `ADAPT` reads `CallerTarget` (+ `CallerAttribute` mastery) and chooses next-module / working set. `COMPOSE` reads everything to build the next prompt. If any link in this chain silently no-ops, the loop is broken but the operator sees nothing — Bertie's first-call recap looks perfect, the prompt looks valid, the call completes. The five invariants below make every silent skip emit a structured AppLog row.
 
-### Invariant inventory (5 invariants — I-AL1..I-AL5)
+### Invariant inventory (6 invariants — I-AL1..I-AL6)
 
 #### I-AL1 — Memory presence on real-engine EXTRACT
 
@@ -609,12 +609,32 @@ All invariants here are **WARN-only and non-blocking**. The pipeline always retu
 | **Audit counter** | `iAL5ZeroTargetsWarn` (target 0) + `iAL5ZeroTargetsError` (target 0 — ERROR severity for empty cascade root). |
 | **Underlying fix** | Slice 3 (#1513) — BehaviorTarget system-defaults seed + SCORE_AGENT cascade fallback. |
 
+#### I-AL6 — CallScore.analysisSpecId stamped post-EXTRACT (#1539)
+
+| Field | Value |
+|---|---|
+| **Producer** | Every CallScore writer in the production pipeline: the EXTRACT batched scorer, the per-segment IELTS scorer, the ADAPT delta-deriver, and the PROSODY consumer. All four MUST route through `lib/measurement/write-call-score.ts::writeCallScore`, which requires `analysisSpecId` in its TypeScript signature AND asserts non-empty at runtime. |
+| **Consumer** | AGGREGATE EMA cascade + cohort-learning analytics + the /x/scoring lineage tab. Every `CallScore` row carries the `AnalysisSpec.id` of the rubric that produced it; downstream readers can answer "which spec graded this score?" deterministically. |
+| **Data shape** | `CallScore.analysisSpecId` is a non-NULL string FK to `AnalysisSpec.id`. LLM writers stamp the originating MEASURE spec's id (looked up via `lib/measurement/parameter-spec-map.ts::buildParameterSpecMap`). Non-LLM writers stamp a sentinel id: `PROSODY-SCORE-V1`, `MOCK-MEASURE-V1`, or `ADAPT-DELTA-V1` (seeded by `prisma/seed-measurement-sentinels.ts`). Historical NULL rows are drained by `scripts/backfill-call-score-analysis-spec.ts` (1:1 attribution where possible; `LEGACY-UNSPECCED-PRE-1539` sentinel for the rest). |
+| **Severity** | WARN by default — promoted to ERROR once the drain script reports `unresolvable = 0` and the column is migrated to NOT NULL. |
+| **Detection rule** | `lib/pipeline/adaptive-loop-invariants.ts::deriveIAL6Violation` runs in `checkInvariantsAfterPipeline`. Counts `CallScore` rows for the call where `analysisSpecId IS NULL`; fires once per call if > 0. |
+| **Test** | `tests/lib/pipeline/adaptive-loop-invariants.test.ts` pins the AppLog shape + non-blocking behaviour. `tests/integration/journey/adaptive-loop-canary.integration.test.ts` Gate 1b asserts post-EXTRACT that every `CallScore.analysisSpecId` is non-NULL. ESLint rule `hf-measurement/no-bare-call-score-write` blocks bare `prisma.callScore.{create,update,upsert}` outside the helper allow-list. |
+| **Memory doc** | This row + `lib/measurement/write-call-score.ts` JSDoc + `docs/decisions/2026-06-12-spec-driven-batched-measurement.md` ADR. |
+| **Audit counter** | `iAL6UnspeccedCallScore` (target 0). |
+| **Underlying fix** | #1539 — helper chokepoint + ESLint rule + prompt-builder rubric injection + drain script + sentinel seeds. |
+
 ### Where the runner lives
 
 `apps/admin/lib/pipeline/adaptive-loop-invariants.ts` exports:
 
 ```ts
-export type InvariantId = "I-AL1" | "I-AL2" | "I-AL3" | "I-AL4" | "I-AL5";
+export type InvariantId =
+  | "I-AL1"
+  | "I-AL2"
+  | "I-AL3"
+  | "I-AL4"
+  | "I-AL5"
+  | "I-AL6";
 export interface InvariantViolation {
   invariant: InvariantId;
   callerId?: string;

--- a/docs/decisions/2026-06-12-spec-driven-batched-measurement.md
+++ b/docs/decisions/2026-06-12-spec-driven-batched-measurement.md
@@ -1,0 +1,140 @@
+# ADR — Spec-driven batched measurement (close the spec-lineage gap)
+
+**Date:** 2026-06-12
+**Status:** Accepted
+**Epic:** [#1539](https://github.com/WANDERCOLTD/HF/issues/1539) — Measurement runtime contract reconciliation
+**Sibling:** [#1538](https://github.com/WANDERCOLTD/HF/issues/1538) — IELTS-specific MEASURE specs (waits on this contract)
+
+## Context
+
+A live audit on hf_sandbox on 2026-06-12 showed every `CallScore` row in the
+last 14 days (1125/1125) carries `analysisSpecId = NULL`. The schema column
+exists with a foreign key to `AnalysisSpec` and an index — it was wired for
+this exact purpose and never populated.
+
+Phase 1 investigation (`docs/audit/spec-lineage-gap-2026-06-12.md`) traced
+the gap into two structural defects in `runBatchedCallerAnalysis` (the
+production EXTRACT scorer):
+
+1. **Rubric is never injected.** `buildBatchedCallerPrompt` builds a prompt
+   body from `parameterId:name` pairs only:
+
+   ```ts
+   const paramList = measureParams.map(p => `${p.parameterId}:${p.name}`).join("|");
+   ```
+
+   The LLM scores `IELTS-FLUENCY` based on its own internalised idea of
+   "fluency" — it never sees the IELTS band 1-9 descriptors stored in
+   `AnalysisSpec.promptTemplate`. The MEASURE spec is loaded, then dropped.
+
+2. **Spec lineage is never written.** Every `CallScore` row created by
+   either the mock branch or the real-engine branch omits `analysisSpecId`.
+   No structural trace exists from a stored band to the rubric that
+   produced it. The same defect repeats in the PROSODY consumer and the
+   per-segment scorer.
+
+Net effect: measurement is *unspecced*. The calibration question — "do
+the scores track the IELTS bands?" — presumes the model knows what an
+IELTS band is. It doesn't.
+
+## Decision
+
+**Every `CallScore` row written by the production pipeline carries the
+`analysisSpecId` of the `AnalysisSpec` whose rubric (`promptTemplate`)
+graded that parameter.** When the spec carries a `promptTemplate`, the
+batched prompt body interpolates it verbatim into a per-parameter rubric
+block. The interpolation contract and the write contract are enforced by
+a single chokepoint helper plus an ESLint rule, mirroring the
+`createCallEnteringPipeline` + `no-bare-call-create` pattern from #1333.
+
+Concrete shape:
+
+- New helper `lib/measurement/write-call-score.ts::writeCallScore({...,
+  analysisSpecId})` — `analysisSpecId` is **required** in the TypeScript
+  type and the function asserts non-empty at runtime. Wraps the existing
+  `(callId, parameterId, moduleId)` unique index via `upsert`.
+- New helper `lib/measurement/parameter-spec-map.ts::buildParameterSpecMap`
+  — keeps the spec→parameter mapping (lost today by `batchLoadParameters`).
+  Returns `Map<parameterId, { parameterId, name, definition, analysisSpecId,
+  specSlug, promptTemplate }>` and prefers the highest-`priority` spec on
+  collision.
+- New helper `lib/measurement/build-batched-measure-prompt.ts` — extracted
+  from `route.ts::buildBatchedCallerPrompt`. Accepts the param-with-spec
+  array, emits one `RUBRIC[<parameterId>]:\n<promptTemplate>` block per
+  parameter that has a rubric, falls back to definition-only for params
+  with `promptTemplate = null` and logs a `[measure] unspecced` warning.
+- ADAPT delta writes (`<parameterId>-DELTA` rows) inherit the parent
+  parameter's spec — the same `analysisSpecId` is stamped so cohort-level
+  lineage stays consistent.
+- PROSODY writes stamp the PROSODY adapter's logical spec id (a system
+  marker `PROSODY-SCORE-V1`) until the PROSODY spec model lands. This is
+  honest "produced by PROSODY, not LLM" lineage rather than NULL.
+
+## Enforcement
+
+| Layer | Mechanism | What it blocks |
+|---|---|---|
+| Type system | `WriteCallScoreInput.analysisSpecId: string` (required) | A future write that forgets the column |
+| Runtime | `writeCallScore` throws on empty string / undefined cast | A type-cast that smuggles NULL through |
+| ESLint | `eslint-rules/no-bare-call-score-write.mjs` (error) | New `prisma.callScore.create/update/upsert` outside the helper allow-list |
+| Test | `tests/lib/measurement/write-call-score.test.ts` | Helper accepts valid input, rejects missing spec id |
+| Test | `tests/lib/measurement/build-batched-measure-prompt.test.ts` | Rubric is byte-identical in prompt body; unspecced params log a warning |
+| Test | `tests/integration/journey/adaptive-loop-canary.integration.test.ts` | E2E canary asserts `analysisSpecId IS NOT NULL` on every CallScore row after EXTRACT |
+| Invariant | `adaptive-loop-invariants.ts::I-AL6` (`CallScore.analysisSpecId NOT NULL post-EXTRACT`) | Production observability — fires WARN until the drain completes, then promote to FAIL |
+| Drain | `scripts/backfill-call-score-analysis-spec.ts` (idempotent, dry-run default) | Historical NULL rows — attribute by parameter→active MEASURE-spec when 1:1, mark `LEGACY_UNSPECCED_PRE_1539` otherwise |
+
+## Why the helper, not a Prisma extension
+
+A Prisma `$extends({ query })` interceptor on `callScore.create` would
+work, but the failure mode is silent (rejected at runtime after a
+write-shaped argument is already built). The helper signature surfaces
+the requirement at the call site — every author who writes a CallScore
+sees `analysisSpecId` in the type, in the import, and in the
+auto-complete. Belt-and-braces: the ESLint rule blocks the bare
+`prisma.callScore.create` so the helper is the only path.
+
+## Alternatives considered
+
+| Option | Why rejected |
+|---|---|
+| **A — Retire batched scoring; one LLM call per spec** | ~7× cost increase on IELTS (7 MEASURE specs). The audit already shows the calibration problem is not "batched vs per-spec" — it's "no rubric in the prompt at all". Cheaper to fix the prompt. |
+| **B — Two-tier hybrid (batched for "thin" specs, per-spec for rubric-heavy)** | Adds a routing decision (`config.scoringMode`) that doesn't exist today. Worth revisiting if a single batched body exceeds the AI window when interpolating ~10 rubrics. Empirically: IELTS-V1.0 has 7 MEASURE specs at avg ~800 chars each = +5.6KB on top of a 4KB transcript window. Well within budget. **If budget is breached later, B is the migration path — the helper already takes per-parameter rubrics, so swapping the dispatcher is local.** |
+| **C — Leave NULL, document the gap** | Calibration story (#1539) cannot answer "do scores track IELTS bands?" without lineage. Trading "honest unknown" for "false signal" is what the chase-prevention rule explicitly forbids. |
+| **D — Prisma extension intercepting `callScore.create`** | Silent failure mode; doesn't surface the requirement at write sites. Adopted as a secondary belt for the helper instead — see "Why the helper" above. |
+
+## Revisit triggers
+
+Re-open this decision when:
+
+- A single batched prompt body exceeds the configured transcript-context
+  budget on >5% of calls (move to Option B — two-tier hybrid).
+- A new MEASURE spec lands with `promptTemplate` of size >2KB (consider
+  per-spec call for that one).
+- The drain script reports >5% of historical NULL rows can't be
+  attributed by 1:1 mapping — indicates we had multi-spec-per-parameter
+  in flight and need a join table, not a scalar column.
+
+## Migration
+
+1. **Land contract** (this PR): helper + prompt builder + ESLint rule +
+   tests + I-AL6 WARN + drain script (not yet run).
+2. **Drain on hf_sandbox**: `npx tsx scripts/backfill-call-score-analysis-spec.ts`,
+   capture counts (`{attributed, marker, unresolvable}`).
+3. **Verify on canary**: re-run the adaptive-loop canary, confirm every
+   CallScore row has `analysisSpecId` non-NULL.
+4. **Promote I-AL6 WARN → FAIL** in a follow-on PR once the drain
+   reports `unresolvable = 0`.
+5. **Flip column to NOT NULL** in a final Prisma migration once
+   I-AL6 has been FAIL-severity for one sprint without firing.
+
+## Out of scope
+
+- Mock-engine attribution sentinel design (`MOCK-V1` system-marker spec) —
+  the helper accepts any non-empty spec id; the seed for that sentinel
+  lands in this PR but the broader "mark all mock writes" follow-on is
+  separate.
+- #1538 IELTS-specific spec content. The contract here is generic. IELTS
+  band descriptors as `promptTemplate` content land in #1538 once this
+  contract is the contract.
+- Drain rollout to hf_staging / Cloud Run prod — separate operator
+  approval gate (data-touching script).


### PR DESCRIPTION
## Summary

Every `CallScore` row written by the production pipeline now carries the
`AnalysisSpec.id` of the rubric that produced it, and every batched
MEASURE prompt interpolates the spec's `promptTemplate` verbatim.

## Why

Live audit on hf_sandbox 2026-06-12: **1125/1125 CallScore rows in the
last 14 days had `analysisSpecId = NULL`**, AND the batched scorer
discarded each spec's `promptTemplate` before sending to the LLM. The
model scored `IELTS-FLUENCY` based on its own internalised idea of
"fluency", never seeing the band 1-9 descriptors stored in the spec.
Calibration question ("do scores track IELTS bands?") was unanswerable
because the model never saw the bands.

## How (defence-in-depth — 6 structural layers)

| Layer | File | Blocks |
|---|---|---|
| TypeScript signature | `lib/measurement/write-call-score.ts` | Missing `analysisSpecId` at compile time |
| Runtime assert | same | Empty / whitespace / undefined cast |
| Prompt builder | `lib/measurement/build-batched-measure-prompt.ts` | Spec rubric discarded |
| ESLint guard | `eslint-rules/no-bare-call-score-write.mjs` (error, day-1) | Bare `prisma.callScore.{create,update,upsert}` |
| Invariant I-AL6 | `lib/pipeline/adaptive-loop-invariants.ts` | Drift past the helper (post-pipeline observer) |
| Canary E2E pin | `tests/integration/journey/adaptive-loop-canary.integration.test.ts` Gate 1b | Any unstamped row in a real-engine flow |

## What changed

- **Production write sites converted (5/5):** mock-batched, real-batched, per-segment IELTS, ADAPT delta, PROSODY consumer (both IELTS + general modes)
- **Sentinel `AnalysisSpec` rows seeded:** `PROSODY-SCORE-V1`, `MOCK-MEASURE-V1`, `ADAPT-DELTA-V1` (seed: `prisma/seed-measurement-sentinels.ts`)
- **Drain script:** `scripts/backfill-call-score-analysis-spec.ts` (dry-run by default; 1:1 attribution where active MEASURE-spec mapping is unambiguous; marks rest `LEGACY-UNSPECCED-PRE-1539`)
- **ADR:** `docs/decisions/2026-06-12-spec-driven-batched-measurement.md` (alternatives considered, revisit triggers)
- **CHAIN-CONTRACTS.md** — invariant inventory grew from 5 to 6

## Verified by

- **Smoking-gun read:** `app/api/calls/[callId]/pipeline/route.ts:505` (pre-fix) — `paramList = measureParams.map(p => \`\${p.parameterId}:\${p.name}\`).join("|")` — confirms `promptTemplate` was discarded before the LLM saw it
- **Smoking-gun SQL:** \`SELECT COUNT(*) FROM "CallScore" WHERE "analysisSpecId" IS NULL\` on hf_sandbox = 1125 (whole 14-day window)
- **Type system:** \`WriteCallScoreInput.analysisSpecId: string\` (non-optional) — compile errors on any caller that forgets
- **Runtime:** \`tests/lib/measurement/write-call-score.test.ts\` — 3 tests pin the empty / whitespace / undefined-cast rejection paths
- **Prompt body:** \`tests/lib/measurement/build-batched-measure-prompt.test.ts\` — 9 tests pin verbatim rubric interpolation + fallback warning
- **ESLint rule:** verified manually — planted a violation, rule fires with full message + url; allow-list verified against existing legitimate write sites
- **I-AL6 runtime:** \`tests/lib/pipeline/adaptive-loop-invariants.test.ts\` — 4 new tests pin FIRE / NO-FIRE / durability / severity
- **Canary E2E:** Gate 1b hard-fails on any unstamped row post-EXTRACT
- **Lint:** 0 new errors on touched files (79 warnings — all pre-existing \`no-explicit-any\`)
- **Tests:** 119/119 green (\`tests/lib/measurement\` + \`tests/lib/pipeline/adaptive-loop-invariants\` + \`tests/api/pipeline\`)

## Test plan

- [ ] Cloud Build / CI green
- [ ] Drain script dry-run on hf_sandbox after \`/vm-cp\` — capture \`{scanned, attributed, legacyMarked}\` counts
- [ ] Drain script \`--apply\` on hf_sandbox once dry-run reads sensible
- [ ] Re-run canary post-drain — confirm Gate 1b green (every row has lineage)
- [ ] I-AL6 dashboard entry on \`/x/help/pipeline-health\` reads 0 unspecced on a live call

## Out of scope

- #1538 (IELTS-specific spec content) — waits for this contract; the band descriptors land into `AnalysisSpec.promptTemplate` once the chokepoint is live
- Drain rollout to hf_staging / Cloud Run prod — separate operator approval gate (data-touching)
- Promotion of I-AL6 \`warn\` → \`error\` — follow-on PR once drain reports unresolvable = 0

Closes #1539