### PR TITLE
chore(tests): repair 17 inherited test failures from #1533/#1547/#1549 fallout

### DIFF
--- a/apps/admin/eslint-rules/no-bare-call-score-write.mjs
+++ b/apps/admin/eslint-rules/no-bare-call-score-write.mjs
@@ -92,7 +92,7 @@ const rule = {
     docs: {
       description:
         "Disallow bare `prisma.callScore.{create,update,upsert}` outside the allow-list (#1539). Use `writeCallScore` from `@/lib/measurement/write-call-score` so every CallScore row stamps `analysisSpecId`.",
-      url: "https://github.com/WANDERCOLTD/HF/blob/main/docs/decisions/2026-06-12-spec-driven-batched-measurement.md",
+      url: "https://github.com/WANDERCOLTD/HF/blob/main/docs/kb/guard-registry.md#guard-no-bare-call-score-write",
     },
     schema: [],
     messages: {

--- a/apps/admin/lib/chat/scope-infer.ts
+++ b/apps/admin/lib/chat/scope-infer.ts
@@ -20,8 +20,6 @@
  * rather than this helper inventing a default.
  */
 
-export type InferredLayer = "PLAYBOOK" | "CALLER" | "DOMAIN";
-
 export type ScopeInferResult =
   | { ok: true; layer: "PLAYBOOK"; scopeIds: { playbookId: string } }
   | { ok: true; layer: "CALLER"; scopeIds: { callerId: string } }

--- a/apps/admin/tests/api/callers-status.test.ts
+++ b/apps/admin/tests/api/callers-status.test.ts
@@ -16,8 +16,17 @@ const { mockPrisma } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+// #1533 added studentAllowedToReadCaller(session, callerId) at the top of
+// the route — the mock must therefore return a `session` shape with
+// `user.role` so the STUDENT-scope branch has something to read. OPERATOR
+// passes through regardless of `learnerCallerId`.
 vi.mock("@/lib/access-control", () => ({
-  requireEntityAccess: vi.fn().mockResolvedValue({ userId: "u1" }),
+  requireEntityAccess: vi.fn().mockResolvedValue({
+    session: {
+      user: { id: "u1", role: "OPERATOR", learnerCallerId: null },
+    },
+    scope: "ALL",
+  }),
   isEntityAuthError: vi.fn().mockReturnValue(false),
 }));
 

--- a/apps/admin/tests/api/last-selected-module.test.ts
+++ b/apps/admin/tests/api/last-selected-module.test.ts
@@ -39,11 +39,27 @@ vi.mock("@/lib/permissions", () => ({
     Boolean(v && typeof v === "object" && "error" in (v as Record<string, unknown>)),
 }));
 
-function makeSession(role: string, userId = "user-1") {
+function makeSession(
+  role: string,
+  userId = "user-1",
+  // #1533 added `studentAllowedToReadCaller(session, callerId)` as the
+  // first gate in this route — when `role === "STUDENT"`, the session
+  // must carry `user.learnerCallerId` matching the URL `callerId` or the
+  // route 403s before reaching the prisma path. Tests using STUDENT pass
+  // `learnerCallerId` to control the IDOR gate; OPERATOR+ bypass it.
+  learnerCallerId: string | null = null,
+) {
   return {
     session: {
       expires: new Date(Date.now() + 86400000).toISOString(),
-      user: { id: userId, email: "u@example.com", name: "U", image: null, role },
+      user: {
+        id: userId,
+        email: "u@example.com",
+        name: "U",
+        image: null,
+        role,
+        learnerCallerId,
+      },
     },
   };
 }
@@ -69,7 +85,11 @@ describe("POST /api/callers/[callerId]/last-selected-module", () => {
 
   describe("STUDENT scope (own-only)", () => {
     it("writes when callerId matches the session's own LEARNER caller", async () => {
-      mockRequireAuth.mockResolvedValue(makeSession("STUDENT"));
+      // #1533 — session must carry learnerCallerId matching the URL
+      // caller for the IDOR gate to pass through to the inline check.
+      mockRequireAuth.mockResolvedValue(
+        makeSession("STUDENT", "user-1", "own-caller"),
+      );
       mockCallerFindFirst.mockResolvedValue({ id: "own-caller" });
       mockModuleFindUnique.mockResolvedValue({ id: "mod-1" });
       mockCallerUpdate.mockResolvedValue({ id: "own-caller", lastSelectedModuleId: "mod-1" });
@@ -87,13 +107,20 @@ describe("POST /api/callers/[callerId]/last-selected-module", () => {
     });
 
     it("refuses 403 when callerId is a different caller (foreign-write leak)", async () => {
-      mockRequireAuth.mockResolvedValue(makeSession("STUDENT"));
+      // #1533 — IDOR gate (studentAllowedToReadCaller) intercepts foreign
+      // callerId BEFORE the inline check, returning "caller scope
+      // mismatch" rather than the inline "STUDENT cannot write" message.
+      // Both code paths share the security property (the write is
+      // blocked); accept either error message.
+      mockRequireAuth.mockResolvedValue(
+        makeSession("STUDENT", "user-1", "own-caller"),
+      );
       mockCallerFindFirst.mockResolvedValue({ id: "own-caller" });
 
       const { status, json } = await callPost("victim-caller", { moduleId: "mod-1" });
 
       expect(status).toBe(403);
-      expect(json.error).toMatch(/STUDENT cannot write/);
+      expect(json.error).toMatch(/STUDENT cannot write|caller scope mismatch/);
       expect(mockCallerUpdate).not.toHaveBeenCalled();
     });
 

--- a/apps/admin/tests/components/IntakeDoneClient.test.tsx
+++ b/apps/admin/tests/components/IntakeDoneClient.test.tsx
@@ -36,8 +36,11 @@ global.fetch = mockFetch as unknown as typeof fetch;
 import { IntakeDoneClient } from "@/components/intake/IntakeDoneClient";
 
 function mockSessionFetch(snapshotValues: Record<string, unknown>) {
+  // #1549 changed the URL from `/api/intake/session/<intentId>` to
+  // bare `/api/intake/session` (cookie-authenticated). Match either
+  // form so this mock works across the cookie cutover.
   mockFetch.mockImplementation(async (url: string) => {
-    if (url.startsWith("/api/intake/session/")) {
+    if (url === "/api/intake/session" || url.startsWith("/api/intake/session/")) {
       return {
         ok: true,
         json: async () => ({

--- a/apps/admin/tests/components/courses/course-design-console.test.tsx
+++ b/apps/admin/tests/components/courses/course-design-console.test.tsx
@@ -33,6 +33,20 @@ vi.mock("next/navigation", () => {
   };
 });
 
+// #1531 — PreviewLens consumes `useChatContext()` to read the
+// `demoAnnotationsVisible` toggle. Tests render PreviewLens directly
+// (lazy compose) without a `<ChatProvider>`, so stub the hook to a
+// minimal shape — `demoAnnotationsVisible: true` matches the default.
+vi.mock("@/contexts/ChatContext", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    "@/contexts/ChatContext",
+  );
+  return {
+    ...actual,
+    useChatContext: () => ({ demoAnnotationsVisible: true }),
+  };
+});
+
 // Synthetic resolved Session Flow response — represents a *post-migration*
 // course (sessionFlow.intake set, welcome legacy can be absent).
 function makeResolvedResponse(opts: {

--- a/apps/admin/tests/eslint-rules/no-bare-call-score-write.test.ts
+++ b/apps/admin/tests/eslint-rules/no-bare-call-score-write.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from "vitest";
+import rule from "../../eslint-rules/no-bare-call-score-write.mjs";
+import { smokeRule } from "./_helpers.js";
+
+describe("no-bare-call-score-write", () => {
+  it("has the structural pieces (meta.docs.url to KB, messages, create)", () => {
+    smokeRule("no-bare-call-score-write", rule as never);
+  });
+});

--- a/apps/admin/tests/lib/aggregate-evidence-filter.test.ts
+++ b/apps/admin/tests/lib/aggregate-evidence-filter.test.ts
@@ -31,9 +31,11 @@ vi.mock("@/lib/prisma", () => ({
     },
 }));
 
-// contracts / profile writes are not under test here
+// contracts / profile writes are not under test here. #1533 HF-A
+// renamed `ContractRegistry.get` → `getContract`; mock the canonical
+// method so the contract read returns null cleanly.
 vi.mock("@/lib/contracts/registry", () => ({
-  ContractRegistry: { get: vi.fn().mockResolvedValue(null) },
+  ContractRegistry: { getContract: vi.fn().mockResolvedValue(null) },
 }));
 vi.mock("@/lib/learner/profile", () => ({
   updateLearnerProfile: vi.fn().mockResolvedValue(undefined),

--- a/apps/admin/tests/lib/content-trust/playbook-source-isolation.test.ts
+++ b/apps/admin/tests/lib/content-trust/playbook-source-isolation.test.ts
@@ -53,7 +53,8 @@ describe("PlaybookSource isolation guards", () => {
       expect(targetsWithScope).toHaveLength(1);
 
       // Without playbookId → fan-out (legacy, only for backward compat)
-      const targetsWithoutScope = null ? [null] : allPlaybooks;
+      const noPlaybookId: string | null = null;
+      const targetsWithoutScope = noPlaybookId ? [noPlaybookId] : allPlaybooks;
       expect(targetsWithoutScope).toHaveLength(3);
     });
 
@@ -69,7 +70,7 @@ describe("PlaybookSource isolation guards", () => {
       const shouldSync = !uploadSourceIds?.length;
       expect(shouldSync).toBe(false);
 
-      const noSourceIds: string[] | undefined = undefined;
+      const noSourceIds = undefined as string[] | undefined;
       const shouldSyncLegacy = !noSourceIds?.length;
       expect(shouldSyncLegacy).toBe(true);
     });
@@ -81,11 +82,15 @@ describe("PlaybookSource isolation guards", () => {
       // upsertPlaybookSource. Without this, the projection (#338) sees no
       // COURSE_REFERENCE and the course is "degenerate".
       //
-      // Static check that the existing-path in wizard-tool-executor.ts
-      // contains the same upsertPlaybookSource loop the new-path has.
+      // Static check that the existing-path of create_course (split
+      // out of `wizard-tool-executor.ts` by #1547) contains the same
+      // upsertPlaybookSource loop the new-path has.
       const fs = await import("fs/promises");
       const path = await import("path");
-      const file = path.resolve(__dirname, "../../../lib/chat/wizard-tool-executor.ts");
+      const file = path.resolve(
+        __dirname,
+        "../../../lib/chat/wizard-tool-executor/tools/create_course.ts",
+      );
       const src = await fs.readFile(file, "utf8");
 
       // The fix block in the existing-path uses existingPlaybookId as the

--- a/apps/admin/tests/lib/pipeline/aggregate-runner-i-al3.test.ts
+++ b/apps/admin/tests/lib/pipeline/aggregate-runner-i-al3.test.ts
@@ -32,10 +32,14 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
+// #1533 HF-A audit renamed `ContractRegistry.get` → `getContract`; the
+// runtime in `aggregate-runner.ts:184` calls `.getContract`. Mock the
+// canonical method or the contract read silently fails → defaults
+// always win → I-AL3 emit fires when the test expects it not to.
 const mockContractGet = vi.fn();
 vi.mock("@/lib/contracts/registry", () => ({
   ContractRegistry: {
-    get: (...args: unknown[]) => mockContractGet(...args),
+    getContract: (...args: unknown[]) => mockContractGet(...args),
   },
 }));
 

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-12T13:23:25.405Z",
+  "generatedAt": "2026-06-12T17:02:55.059Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1676,
-  "edgeCount": 3880,
+  "fileCount": 1710,
+  "edgeCount": 3946,
   "skippedEdges": 1,
   "edges": [
     {
@@ -1373,6 +1373,18 @@
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/measurement/build-batched-measure-prompt.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/measurement/parameter-spec-map.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/measurement/write-call-score.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/metering/index.ts"
     },
     {
@@ -1597,7 +1609,35 @@
     },
     {
       "from": "app/api/chat/route.ts",
+      "to": "lib/chat/hf-tool-meta.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
       "to": "lib/chat/pending-change-payload.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "lib/chat/scope-hint-message.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "lib/chat/scope-infer.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "lib/chat/scope-prefix-parser.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "lib/chat/scope-resolvers/caller-by-name.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "lib/chat/scope-resolvers/domain-by-name.ts"
+    },
+    {
+      "from": "app/api/chat/route.ts",
+      "to": "lib/chat/scope-resolvers/playbook-by-name.ts"
     },
     {
       "from": "app/api/chat/route.ts",
@@ -4120,20 +4160,28 @@
       "to": "lib/permissions.ts"
     },
     {
-      "from": "app/api/intake/audit-bundle/[intentId]/route.ts",
+      "from": "app/api/intake/audit-bundle/download/route.ts",
       "to": "lib/intake/audit-bundle.ts"
     },
     {
-      "from": "app/api/intake/audit-bundle/[intentId]/route.ts",
+      "from": "app/api/intake/audit-bundle/download/route.ts",
+      "to": "lib/intake/intake-session-cookie.ts"
+    },
+    {
+      "from": "app/api/intake/audit-bundle/download/route.ts",
       "to": "lib/intake/tallyseal/index.ts"
     },
     {
-      "from": "app/api/intake/audit-bundle/[intentId]/route.ts",
+      "from": "app/api/intake/audit-bundle/download/route.ts",
       "to": "lib/rate-limit.ts"
     },
     {
       "from": "app/api/intake/audit-bundle/route.ts",
       "to": "lib/intake/audit-bundle.ts"
+    },
+    {
+      "from": "app/api/intake/audit-bundle/route.ts",
+      "to": "lib/intake/intake-session-cookie.ts"
     },
     {
       "from": "app/api/intake/audit-bundle/route.ts",
@@ -4161,6 +4209,10 @@
     },
     {
       "from": "app/api/intake/bootstrap/route.ts",
+      "to": "lib/intake/intake-session-cookie.ts"
+    },
+    {
+      "from": "app/api/intake/bootstrap/route.ts",
       "to": "lib/intake/session-store.ts"
     },
     {
@@ -4174,6 +4226,10 @@
     {
       "from": "app/api/intake/chat/route.ts",
       "to": "lib/intake/hf-adapter/ai.ts"
+    },
+    {
+      "from": "app/api/intake/chat/route.ts",
+      "to": "lib/intake/intake-session-cookie.ts"
     },
     {
       "from": "app/api/intake/chat/route.ts",
@@ -4197,6 +4253,10 @@
     },
     {
       "from": "app/api/intake/disclosure-acknowledge/route.ts",
+      "to": "lib/intake/intake-session-cookie.ts"
+    },
+    {
+      "from": "app/api/intake/disclosure-acknowledge/route.ts",
       "to": "lib/intake/session-store.ts"
     },
     {
@@ -4209,6 +4269,10 @@
     },
     {
       "from": "app/api/intake/disclosure-signal/route.ts",
+      "to": "lib/intake/intake-session-cookie.ts"
+    },
+    {
+      "from": "app/api/intake/disclosure-signal/route.ts",
       "to": "lib/intake/session-store.ts"
     },
     {
@@ -4216,15 +4280,19 @@
       "to": "lib/intake/tallyseal/index.ts"
     },
     {
-      "from": "app/api/intake/session/[intentId]/route.ts",
+      "from": "app/api/intake/session/route.ts",
+      "to": "lib/intake/intake-session-cookie.ts"
+    },
+    {
+      "from": "app/api/intake/session/route.ts",
       "to": "lib/intake/session-store.ts"
     },
     {
-      "from": "app/api/intake/session/[intentId]/route.ts",
+      "from": "app/api/intake/session/route.ts",
       "to": "lib/intake/tallyseal/index.ts"
     },
     {
-      "from": "app/api/intake/session/[intentId]/route.ts",
+      "from": "app/api/intake/session/route.ts",
       "to": "lib/rate-limit.ts"
     },
     {
@@ -11120,8 +11188,28 @@
       "to": "lib/ai/client.ts"
     },
     {
+      "from": "lib/chat/hf-tool-meta.ts",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
       "from": "lib/chat/page-feature-catalogue.ts",
       "to": "lib/help/page-help.ts"
+    },
+    {
+      "from": "lib/chat/scope-hint-message.ts",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
+      "from": "lib/chat/scope-resolvers/caller-by-name.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/chat/scope-resolvers/domain-by-name.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/chat/scope-resolvers/playbook-by-name.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "lib/chat/ticket-context.ts",
@@ -11216,12 +11304,172 @@
       "to": "lib/types/json-fields.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor.ts",
+      "from": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/welcome-phases.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/resolvers/infer-type-from-name.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/resolvers/institution-by-name.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_community.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_institution.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/mark_complete.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/show_options.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/show_suggestions.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/show_upload.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/suggest_welcome_message.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/update_course_config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/index.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/update_setup.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/resolvers/subject-by-name.ts",
+      "to": "lib/chat/wizard-tool-executor/resolvers/course-by-name.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_community.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_community.ts",
       "to": "lib/domain/update-domain-config.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor.ts",
+      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "to": "lib/domain/update-domain-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
       "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_institution.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_institution.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_institution.ts",
+      "to": "lib/chat/wizard-tool-executor/resolvers/institution-by-name.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/mark_complete.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/show_options.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/show_suggestions.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/show_upload.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/show_upload.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/suggest_welcome_message.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_course_config.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_course_config.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_course_config.ts",
+      "to": "lib/domain/update-domain-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_course_config.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_setup.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_setup.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_setup.ts",
+      "to": "lib/chat/wizard-tool-executor/resolvers/course-by-name.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_setup.ts",
+      "to": "lib/chat/wizard-tool-executor/resolvers/institution-by-name.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/update_setup.ts",
+      "to": "lib/chat/wizard-tool-executor/resolvers/subject-by-name.ts"
     },
     {
       "from": "lib/cohort-access.ts",
@@ -12880,6 +13128,18 @@
       "to": "lib/roles.ts"
     },
     {
+      "from": "lib/measurement/build-batched-measure-prompt.ts",
+      "to": "lib/measurement/parameter-spec-map.ts"
+    },
+    {
+      "from": "lib/measurement/parameter-spec-map.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/measurement/write-call-score.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "lib/messaging/adapters/email-resend.ts",
       "to": "lib/messaging/types.ts"
     },
@@ -13178,6 +13438,10 @@
     {
       "from": "lib/pipeline/guardrails.ts",
       "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/pipeline/prosody-consumer.ts",
+      "to": "lib/measurement/write-call-score.ts"
     },
     {
       "from": "lib/pipeline/prosody-consumer.ts",
@@ -16037,7 +16301,7 @@
     {
       "path": "app/api/calls/[callId]/pipeline/route.ts",
       "inDegree": 0,
-      "outDegree": 48
+      "outDegree": 51
     },
     {
       "path": "app/api/calls/[callId]/route.ts",
@@ -16077,7 +16341,7 @@
     {
       "path": "app/api/chat/route.ts",
       "inDegree": 0,
-      "outDegree": 31
+      "outDegree": 38
     },
     {
       "path": "app/api/chat/system-prompts.ts",
@@ -17002,37 +17266,47 @@
     {
       "path": "app/api/intake/audit-bundle/[intentId]/route.ts",
       "inDegree": 0,
-      "outDegree": 3
+      "outDegree": 0
     },
     {
-      "path": "app/api/intake/audit-bundle/route.ts",
+      "path": "app/api/intake/audit-bundle/download/route.ts",
       "inDegree": 0,
       "outDegree": 4
     },
     {
-      "path": "app/api/intake/bootstrap/route.ts",
-      "inDegree": 0,
-      "outDegree": 6
-    },
-    {
-      "path": "app/api/intake/chat/route.ts",
+      "path": "app/api/intake/audit-bundle/route.ts",
       "inDegree": 0,
       "outDegree": 5
     },
     {
+      "path": "app/api/intake/bootstrap/route.ts",
+      "inDegree": 0,
+      "outDegree": 7
+    },
+    {
+      "path": "app/api/intake/chat/route.ts",
+      "inDegree": 0,
+      "outDegree": 6
+    },
+    {
       "path": "app/api/intake/disclosure-acknowledge/route.ts",
       "inDegree": 0,
-      "outDegree": 3
+      "outDegree": 4
     },
     {
       "path": "app/api/intake/disclosure-signal/route.ts",
       "inDegree": 0,
-      "outDegree": 3
+      "outDegree": 4
     },
     {
       "path": "app/api/intake/session/[intentId]/route.ts",
       "inDegree": 0,
-      "outDegree": 3
+      "outDegree": 0
+    },
+    {
+      "path": "app/api/intake/session/route.ts",
+      "inDegree": 0,
+      "outDegree": 4
     },
     {
       "path": "app/api/intake/v2/admin-test-enrol/route.ts",
@@ -20886,7 +21160,7 @@
     },
     {
       "path": "lib/cascade/layer-types.ts",
-      "inDegree": 8,
+      "inDegree": 10,
       "outDegree": 0
     },
     {
@@ -21020,6 +21294,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/chat/hf-tool-meta.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
       "path": "lib/chat/page-feature-catalogue.ts",
       "inDegree": 2,
       "outDegree": 1
@@ -21033,6 +21312,36 @@
       "path": "lib/chat/pending-change-payload.ts",
       "inDegree": 2,
       "outDegree": 0
+    },
+    {
+      "path": "lib/chat/scope-hint-message.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/scope-infer.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/scope-prefix-parser.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/scope-resolvers/caller-by-name.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/scope-resolvers/domain-by-name.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/scope-resolvers/playbook-by-name.ts",
+      "inDegree": 1,
+      "outDegree": 1
     },
     {
       "path": "lib/chat/ticket-context.ts",
@@ -21062,7 +21371,107 @@
     {
       "path": "lib/chat/wizard-tool-executor.ts",
       "inDegree": 3,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts",
+      "inDegree": 3,
       "outDegree": 2
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/_shared/types.ts",
+      "inDegree": 11,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/_shared/welcome-phases.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/index.ts",
+      "inDegree": 0,
+      "outDegree": 12
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/resolvers/course-by-name.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/resolvers/infer-type-from-name.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/resolvers/institution-by-name.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/resolvers/subject-by-name.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_community.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "inDegree": 1,
+      "outDegree": 6
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_institution.ts",
+      "inDegree": 1,
+      "outDegree": 3
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/mark_complete.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/show_options.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/show_suggestions.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/show_upload.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/suggest_welcome_message.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/update_course_config.ts",
+      "inDegree": 1,
+      "outDegree": 4
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/update_setup.ts",
+      "inDegree": 1,
+      "outDegree": 5
     },
     {
       "path": "lib/cohort-access.ts",
@@ -21636,7 +22045,7 @@
     },
     {
       "path": "lib/domain/update-domain-config.ts",
-      "inDegree": 5,
+      "inDegree": 7,
       "outDegree": 3
     },
     {
@@ -21925,6 +22334,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/intake/intake-session-cookie.ts",
+      "inDegree": 7,
+      "outDegree": 0
+    },
+    {
       "path": "lib/intake/prisma-event-store.ts",
       "inDegree": 1,
       "outDegree": 2
@@ -22135,6 +22549,21 @@
       "outDegree": 1
     },
     {
+      "path": "lib/measurement/build-batched-measure-prompt.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/measurement/parameter-spec-map.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/measurement/write-call-score.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
       "path": "lib/messaging/adapters/email-resend.ts",
       "inDegree": 1,
       "outDegree": 1
@@ -22322,7 +22751,7 @@
     {
       "path": "lib/pipeline/prosody-consumer.ts",
       "inDegree": 1,
-      "outDegree": 2
+      "outDegree": 3
     },
     {
       "path": "lib/pipeline/prosody-runner.ts",
@@ -22371,7 +22800,7 @@
     },
     {
       "path": "lib/playbook/update-playbook-config.ts",
-      "inDegree": 19,
+      "inDegree": 20,
       "outDegree": 5
     },
     {
@@ -22381,7 +22810,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 619,
+      "inDegree": 624,
       "outDegree": 0
     },
     {
@@ -23390,6 +23819,11 @@
       "outDegree": 1
     },
     {
+      "path": "scripts/backfill-call-score-analysis-spec.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
       "path": "scripts/backfill-call-sequence.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -23913,7 +24347,7 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 619,
+      "inDegree": 624,
       "outDegree": 0
     },
     {
@@ -23944,7 +24378,7 @@
     {
       "path": "app/api/calls/[callId]/pipeline/route.ts",
       "inDegree": 0,
-      "outDegree": 48
+      "outDegree": 51
     },
     {
       "path": "app/x/courses/[courseId]/page.tsx",
@@ -23967,6 +24401,11 @@
       "outDegree": 6
     },
     {
+      "path": "app/api/chat/route.ts",
+      "inDegree": 0,
+      "outDegree": 38
+    },
+    {
       "path": "lib/prompt/composition/CompositionExecutor.ts",
       "inDegree": 1,
       "outDegree": 36
@@ -23975,11 +24414,6 @@
       "path": "lib/voice/route-handlers.ts",
       "inDegree": 5,
       "outDegree": 27
-    },
-    {
-      "path": "app/api/chat/route.ts",
-      "inDegree": 0,
-      "outDegree": 31
     },
     {
       "path": "lib/prompt/composition/TransformRegistry.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-12T13:23:26.005Z",
+  "generatedAt": "2026-06-12T17:02:55.431Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-12T13:23:23.039Z",
+  "generatedAt": "2026-06-12T17:02:54.055Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-12T13:23:26.427Z",
+  "generatedAt": "2026-06-12T17:02:55.838Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,10 +1,10 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-12T13:23:23.991Z",
+  "generatedAt": "2026-06-12T17:02:54.510Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
-    "routeCount": 511,
+    "routeCount": 513,
     "byAuthLevel": {
       "VIEWER": 113,
       "ADMIN": 81,
@@ -15,7 +15,7 @@
       "VIEWER+OPERATOR": 67,
       "auth-gate(non-role)": 53,
       "VIEWER+OPERATOR+ADMIN": 4,
-      "<none>": 29,
+      "<none>": 31,
       "VIEWER+STUDENT": 1,
       "OPERATOR+ADMIN": 4,
       "TESTER": 1,
@@ -24,7 +24,7 @@
       "ADMIN+OPERATOR": 1,
       "VIEWER+TESTER": 3
     },
-    "noAuthGate": 28,
+    "noAuthGate": 30,
     "possiblyUnscoped": 109,
     "internalSecret": 8
   },
@@ -5896,6 +5896,24 @@
       "reviewed": false
     },
     {
+      "route": "/api/intake/audit-bundle/download",
+      "file": "apps/admin/app/api/intake/audit-bundle/download/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [],
+      "hasAuthGate": false,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": true
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/intake/audit-bundle",
       "file": "apps/admin/app/api/intake/audit-bundle/route.ts",
       "methods": [
@@ -5988,6 +6006,24 @@
     {
       "route": "/api/intake/session/[intentId]",
       "file": "apps/admin/app/api/intake/session/[intentId]/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [],
+      "hasAuthGate": false,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": true
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/intake/session",
+      "file": "apps/admin/app/api/intake/session/route.ts",
       "methods": [
         "GET"
       ],

--- a/docs/kb/guard-registry.md
+++ b/docs/kb/guard-registry.md
@@ -60,6 +60,7 @@ The meta-ratchet (`check-guard-kb-links.ts`) holds this at 12/12.
 | [`no-orphan-instruction-fallback`](#guard-no-orphan-instruction-fallback) | Generic-noun fallbacks for missing module/LO names in prompt transforms (mechanism: [CHAIN-CONTRACTS](../CHAIN-CONTRACTS.md) I-C4) | #1006/#1008 | **a** |
 | [`no-undeclared-field-require`](#guard-no-undeclared-field-require) | `has(...)` refs to field keys not declared in the enclosing spec `define` | #1078 | **a** |
 | [`no-bare-call-create`](#guard-no-bare-call-create) | Bare `prisma.call.create` / `prisma.session.create` outside allow-list; must use `createCallEnteringPipeline` / `createSession` | #1333/#1342 | **a** |
+| [`no-bare-call-score-write`](#guard-no-bare-call-score-write) | Bare `prisma.callScore.{create,update,upsert}` outside allow-list; must use `writeCallScore` so every row stamps `analysisSpecId` | #1539 | **a** |
 | [`no-hardcoded-greeting-in-composition`](#guard-no-hardcoded-greeting-in-composition) | Literal greeting strings in prompt-composition transforms / voice assistant-config builders | #1384 | **a** |
 | [`no-unscoped-slug-lookup`](#guard-no-unscoped-slug-lookup) | Unscoped slug/ref lookups on per-parent-unique entities (`CurriculumModule`, LO) | #407/#411 | **b** |
 | [`no-deprecated-curricula-relation`](#guard-no-deprecated-curricula-relation) | Reads of the `@deprecated Playbook.curricula` relation; use `playbookCurricula` | #1205 | **b** |
@@ -176,6 +177,20 @@ The allow-list in `no-bare-call-create.mjs` must be updated when adding a delibe
 bypass (harness, seed, batch import) — making the bypass intentional and documented.
 **Survives hardening:** FK-completeness and atomic counter assignment are write-path
 invariants independent of architecture; the builder pattern carries forward.
+
+<a id="guard-no-bare-call-score-write"></a>
+**`no-bare-call-score-write`** · class **(a) invariant** · born #1539 ·
+[rule source](../../apps/admin/eslint-rules/no-bare-call-score-write.mjs)
+
+Every `CallScore` row written from the production pipeline MUST carry `analysisSpecId`
+(the AnalysisSpec whose rubric produced the score). The chokepoint helper `writeCallScore`
+requires the column in its TypeScript signature AND asserts non-empty at runtime; this
+rule stops a future edit from smuggling a bare `prisma.callScore.{create,update,upsert}`
+past the helper. Pairs structurally with `no-bare-call-create` — same builder-pattern
+discipline, applied to the measurement write path. Allow-list updates accompany any
+deliberate bypass (drain scripts, demo reset, manual ops) so the bypass stays
+documented. **Survives hardening:** spec-driven measurement is an architectural
+property of the pipeline; the builder pattern carries forward.
 
 <a id="guard-no-hardcoded-greeting-in-composition"></a>
 **`no-hardcoded-greeting-in-composition`** · class **(a) invariant** · born #1384 ·


### PR DESCRIPTION
## Summary

Five test files (and one ESLint rule's KB hygiene) broke when production code changed without updating their fixtures. All failures present on \`main\` since the parent PRs landed; **zero behaviour change** in this PR — only test-mock + KB-link plumbing.

| Source PR | Surface that drifted | Tests fixed |
|---|---|---|
| #1533 (HF-A/HF-M audit) | `studentAllowedToReadCaller` added to routes; `ContractRegistry.get` → `getContract` rename | 9 |
| #1547 (wizard-refactor split) | `tools/create_course.ts` moved | 1 |
| #1531 (clapperboard) | `PreviewLens` consumes `useChatContext` | 4 |
| #1549 (intake cookie) | `/api/intake/session/<id>` → bare `/api/intake/session` | 3 |
| #1539 (spec-driven measurement) | `no-bare-call-score-write.mjs` had no KB-registry link or sibling test | (KB hygiene) |

Total: **17 vitest failures repaired, 2 KB-ratchet gates flipped green, 1 knip dead-code item cleaned.**

## What changed

**Test-mock shape fixes (no behaviour change):**

- `tests/api/callers-status.test.ts` — mock of `requireEntityAccess` now returns `{ session: { user: { id, role, learnerCallerId } }, scope }` so `studentAllowedToReadCaller` has a session to read
- `tests/api/last-selected-module.test.ts` — `makeSession` accepts `learnerCallerId`; foreign-caller test accepts either IDOR-gate or inline-check error
- `tests/components/courses/course-design-console.test.tsx` — mock `@/contexts/ChatContext` returning the minimal `demoAnnotationsVisible` shape
- `tests/lib/content-trust/playbook-source-isolation.test.ts` — static-source path points at \`wizard-tool-executor/tools/create_course.ts\` (post-split); also cleared 2 pre-existing tsc errors in same file flagged by pre-push
- `tests/lib/pipeline/aggregate-runner-i-al3.test.ts` + `tests/lib/aggregate-evidence-filter.test.ts` — both mocks use canonical \`ContractRegistry.getContract\` instead of \`.get\`
- `tests/components/IntakeDoneClient.test.tsx` — fetch mock matches both old (\`/api/intake/session/<id>\`) and new (\`/api/intake/session\`) URL shapes across the cookie cutover

**KB hygiene (\`kb:check\` ratchet):**

- Added \`<a id="guard-no-bare-call-score-write">\` section + table row to \`docs/kb/guard-registry.md\`
- Flipped \`no-bare-call-score-write.mjs::meta.docs.url\` from the ADR to the guard-registry anchor
- Added \`tests/eslint-rules/no-bare-call-score-write.test.ts\` (smoke pattern mirroring \`no-bare-call-create\`)
- Regenerated \`docs/kb/generated/*.json\` (model-map, route-inventory, coupling-graph, demo-knobs, operator-surfaces) — recovers the KB-regen step dropped on PR #1548's rebase

**Dead-code (knip ratchet):**

- \`lib/chat/scope-infer.ts::InferredLayer\` removed (internal-only type, not consumed outside the file)

## What this PR does NOT touch

- Production behaviour. Every change is test fixture, KB doc, or generated KB facts.
- The +11 lint warnings inherited from #1547 (separate ratchet-update PR).

## Verified by

**Full vitest suite — all green:**

```
$ npm test -- --run
 Test Files  619 passed (619)
      Tests  7111 passed | 18 skipped (7129)
```

**Pre-fix on \`main\` HEAD \`61cb955c\`:**

```
 Test Files  5 failed | 614 passed (619)
      Tests  17 failed | 7094 passed | 18 skipped (7129)
```

**Net: 17 inherited failures repaired; zero new failures introduced.**

**KB ratchet:**

- \`kb-guard-links\`: was \`18/19 rules KB-linked\` → now \`19/19\`
- \`eslint-rule-tests\`: was \`20/21 rules have sibling tests\` → now \`21/21\`
- \`kb-fresh\`: was stale (5 files diff) → now clean

**Pre-push tsc check:** `[pre-push] ✓ Your changed files pass tsc + lint.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)