### PR TITLE
chore(ratchet): reconcile .ratchet.json after #1547 — lock 3 wins + accept +11 lint-warning floor

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,10 +1,10 @@
 {
-  "tsc_errors": 196,
+  "tsc_errors": 190,
   "lint_errors": 0,
-  "lint_warnings": 4425,
-  "quarantined_tests": 37,
+  "lint_warnings": 4436,
+  "quarantined_tests": 36,
   "knip_unused": 162,
-  "same_issue_fix_chain_max": 10,
+  "same_issue_fix_chain_max": 6,
   "memory_md_bytes": 29422,
   "npm_audit_high_crit": 6
 }


### PR DESCRIPTION
## Summary

Single-purpose chore PR: reconcile `.ratchet.json` with current measurements so the ratchet gate flips green and three accumulated wins are locked as the new floor.

| Metric | Was | Now | Delta | Why |
|---|---|---|---|---|
| `tsc_errors` | 196 | 190 | **-6** | Win |
| `lint_warnings` | 4425 | 4436 | **+11** | Inherited debt from #1547 |
| `quarantined_tests` | 37 | 36 | **-1** | Win |
| `same_issue_fix_chain_max` | 10 | 6 | **-4** | Win |

## Verified by

Local `scripts/check-ratchet.sh` against commit `80b98b4a` (this branch's tip):

```
[ratchet:check] tsc_errors: 190 (== baseline)
[ratchet:check] lint_errors: 0 (== baseline)
[ratchet:check] lint_warnings: 4436 (== baseline)
[ratchet:check] quarantined_tests: 36 (== baseline)
[ratchet:check] same_issue_fix_chain_max: 6 (== baseline)
[ratchet:check] memory_md_bytes: 29422 (== baseline)
```

Pre-update CI evidence — same failure reproduced across three runs, confirming the +11 is structural floor-shift from #1547 and not a transient measurement glitch. Independently observable via:

```
gh api repos/WANDERCOLTD/HF/actions/runs/27428400792/jobs | jq '.jobs[] | select(.name == "Lint & Type Check")'
gh api repos/WANDERCOLTD/HF/actions/runs/27426571468/jobs | jq '.jobs[] | select(.name == "Lint & Type Check")'
```

Both runs reported `lint_warnings: 4436 (+11 over baseline 4425)` plus three "Update .ratchet.json to lock the win" informational notes for `tsc_errors`, `quarantined_tests`, and `same_issue_fix_chain_max`.

## Why bump rather than fix

Operator directive: "+11 lint warnings inherited from #1547 — those need a separate ratchet-update PR with a clean .ratchet.json baseline bump, not test-fixture work".

The +11 are inherited from the per-tool module split. `apps/admin/lib/chat/wizard-tool-executor/tools/create_course.ts` carries pre-existing `any`-types and unused-var warnings that the move preserved verbatim. Cleaning them up properly is naturally bundled with #1544 (the re-split along 8 stages) — that refactor touches the same lines.

## Out of scope

- `knip_unused` (162 == baseline), `npm_audit_high_crit` (ops-driven), `memory_md_bytes` (== baseline).
- Actually fixing the +11 lint warnings — deferred to #1544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)