### PR TITLE
refactor(wizard): #1544 stage 1 of 8 — extract create_course graph guard

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared helper for creating pedagogy ContentSource + ContentAssertion
+ * rows from course-reference data during `create_course`.
+ *
+ * Closes #1545 — the pre-#1547 monolith carried mirror-pair write blocks
+ * in the reuse-path and new-path branches; both shipped with three
+ * silently-dropped field references (`status` on ContentSource,
+ * `confidence` + `isActive` on ContentAssertion, none of which exist on
+ * the Prisma models) plus a missing required `slug`. Result: Prisma
+ * threw on every wizard-driven course; the outer try/catch logged
+ * "non-fatal" and the assertions never landed.
+ *
+ * The write shape mirrors the canonical route at
+ * `app/api/courses/[courseId]/course-reference/route.ts:145-177` so the
+ * two pedagogy-write surfaces stay in lockstep.
+ *
+ * Out of scope for #1545:
+ *   - `subjectSourceId` is NOT set here. Same pre-existing gap as
+ *     `app/api/content-sources/route.ts` and the course-pack ingest
+ *     path; tracked separately, not introduced by this fix.
+ *   - Backfill of historical wizard-created courses that never received
+ *     pedagogy assertions — a separate ops concern (see PR body for
+ *     the live count probe).
+ */
+
+import { createHash } from "node:crypto";
+import slugify from "slugify";
+
+import { prisma } from "@/lib/prisma";
+import { upsertPlaybookSource } from "@/lib/knowledge/domain-sources";
+import type { AssertionCreateData } from "@/lib/content-trust/course-ref-to-assertions";
+
+export interface PedagogyContext {
+  /** Display title used to derive the ContentSource slug + name. */
+  courseName: string;
+  /** The playbook scope for the PlaybookSource dual-write. */
+  playbookId: string;
+  /** Primary subject id for the SubjectSource linkage. */
+  subjectId: string;
+  /** Rendered markdown the assertions were extracted from. */
+  textSample: string;
+  /**
+   * Rows produced by `convertCourseRefToAssertions(refData)`. Each row
+   * is the partial `ContentAssertion` shape minus FK + provenance.
+   */
+  assertionRows: AssertionCreateData[];
+}
+
+export interface PedagogyResult {
+  sourceId: string;
+  assertionCount: number;
+}
+
+/**
+ * Creates the ContentSource + ContentAssertion rows for a course's
+ * course-reference pedagogy block. Idempotent at the SubjectSource +
+ * PlaybookSource join layer (uses upsert / create patterns matching the
+ * canonical route).
+ *
+ * Throws on Prisma validation failure — the caller's try/catch decides
+ * whether a failure is fatal to the wizard run. Pre-fix the outer
+ * try/catch swallowed Prisma rejects as "non-fatal"; post-fix the same
+ * try/catch surfaces any future drift as a real diagnostic.
+ */
+export async function createPedagogyAssertionsFromCourseRef(
+  ctx: PedagogyContext,
+): Promise<PedagogyResult> {
+  const { courseName, playbookId, subjectId, textSample, assertionRows } = ctx;
+
+  const contentHash = createHash("sha256")
+    .update(textSample)
+    .digest("hex");
+
+  // Slug shape mirrors `course-reference/route.ts:165` —
+  // `${slugify(playbook.name)}-ref-${Date.now()}` so reuse-path +
+  // new-path + canonical-route stay drift-resistant.
+  const sourceSlug = `${slugify(courseName, { lower: true, strict: true })}-ref-${Date.now()}`;
+
+  const refSource = await prisma.contentSource.create({
+    data: {
+      slug: sourceSlug,
+      name: `${courseName} — Course Reference`,
+      documentType: "COURSE_REFERENCE",
+      trustLevel: "EXPERT_CURATED",
+      textSample,
+      contentHash,
+      isActive: true,
+    },
+    select: { id: true },
+  });
+
+  await prisma.subjectSource.create({
+    data: { subjectId, sourceId: refSource.id },
+  });
+
+  await upsertPlaybookSource(playbookId, refSource.id, {
+    tags: ["course-reference"],
+  });
+
+  for (const row of assertionRows) {
+    await prisma.contentAssertion.create({
+      data: {
+        ...row,
+        sourceId: refSource.id,
+        // Course-reference assertions are teacher-authored — bias the
+        // LO-link confidence to 1.0 so the linker treats them as
+        // high-confidence anchors (per `reconcile-lo-linkage.ts`
+        // 1.0 == structured-ref match).
+        linkConfidence: 1.0,
+        depth: 0,
+      },
+    });
+  }
+
+  return { sourceId: refSource.id, assertionCount: assertionRows.length };
+}

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course.ts
@@ -474,27 +474,21 @@ try {
             };
             const assertionRows = convertCourseRefToAssertions(refData);
             if (assertionRows.length > 0) {
-              const refSource = await prisma.contentSource.create({
-                data: {
-                  name: `${courseName || "Course"} — Course Reference`,
-                  documentType: "COURSE_REFERENCE",
-                  textSample: renderCourseRefMarkdown(refData),
-                  status: "COMPLETED",
-                },
+              // #1545 — route through the shared pedagogy helper. Pre-fix
+              // this branch hand-rolled a write block that named three
+              // non-existent fields (`status` on ContentSource;
+              // `confidence` + `isActive` on ContentAssertion) plus
+              // missed the required `slug` — Prisma threw on every run
+              // and the outer try/catch logged "non-fatal".
+              const { createPedagogyAssertionsFromCourseRef } = await import("./_pedagogy-assertions");
+              const result = await createPedagogyAssertionsFromCourseRef({
+                courseName: courseName || "Course",
+                playbookId: existingPlaybookId,
+                subjectId: existingPbSubject.subjectId,
+                textSample: renderCourseRefMarkdown(refData),
+                assertionRows,
               });
-              await prisma.subjectSource.create({
-                data: { subjectId: existingPbSubject.subjectId, sourceId: refSource.id },
-              });
-              // Dual-write: PlaybookSource for pedagogy source
-              const { upsertPlaybookSource: upsertPedExisting } = await import("@/lib/knowledge/domain-sources");
-              await upsertPedExisting(existingPlaybookId, refSource.id, { tags: ["course-reference"] });
-
-              for (const row of assertionRows) {
-                await prisma.contentAssertion.create({
-                  data: { ...row, sourceId: refSource.id, confidence: 1.0, depth: 0, isActive: true },
-                });
-              }
-              console.log(`[wizard] Created ${assertionRows.length} pedagogy assertions for existing course`);
+              console.log(`[wizard] Created ${result.assertionCount} pedagogy assertions for existing course`);
             }
           } catch (err) {
             console.error("[wizard] Pedagogy assertion creation (existing) failed (non-fatal):", (err as Error).message);
@@ -1094,7 +1088,10 @@ try {
     // Skip onboarding: mark complete, mark surveys submitted, then compose
     if (skipOnboarding) {
       const { applySkipOnboarding } = await import("@/lib/enrollment/skip-onboarding");
-      await applySkipOnboarding(c.id, domainId);
+      // domainId is narrowed at L107 guard; the re-broadening from L104
+      // assignment loses through this deep nested closure. Non-null
+      // assertion is safe — control flow can't reach here without it.
+      await applySkipOnboarding(c.id, domainId!);
 
       const { autoComposeForCaller } = await import("@/lib/enrollment/auto-compose");
       autoComposeForCaller(c.id, playbookId).catch(err =>
@@ -1213,37 +1210,19 @@ try {
 
         const assertionRows = convertCourseRefToAssertions(refData);
         if (assertionRows.length > 0) {
-          // Create a ContentSource to hold the pedagogy assertions
-          const refSource = await prisma.contentSource.create({
-            data: {
-              name: `${courseName} — Course Reference`,
-              documentType: "COURSE_REFERENCE",
-              textSample: renderCourseRefMarkdown(refData),
-              status: "COMPLETED",
-            },
+          // #1545 — route through the shared pedagogy helper (mirror of
+          // the reuse-path block above). Pre-fix this branch carried the
+          // same three drifted field names and missed the required
+          // `slug` — Prisma threw on every wizard run.
+          const { createPedagogyAssertionsFromCourseRef } = await import("./_pedagogy-assertions");
+          const result = await createPedagogyAssertionsFromCourseRef({
+            courseName,
+            playbookId,
+            subjectId: subject.id,
+            textSample: renderCourseRefMarkdown(refData),
+            assertionRows,
           });
-
-          // Link source to primary subject
-          await prisma.subjectSource.create({
-            data: { subjectId: subject.id, sourceId: refSource.id },
-          });
-          // Dual-write: PlaybookSource for pedagogy source
-          const { upsertPlaybookSource: upsertPedNew } = await import("@/lib/knowledge/domain-sources");
-          await upsertPedNew(playbookId, refSource.id, { tags: ["course-reference"] });
-
-          // Create assertion rows
-          for (const row of assertionRows) {
-            await prisma.contentAssertion.create({
-              data: {
-                ...row,
-                sourceId: refSource.id,
-                confidence: 1.0,
-                depth: 0,
-                isActive: true,
-              },
-            });
-          }
-          console.log(`[wizard] Created ${assertionRows.length} pedagogy assertions from course reference data`);
+          console.log(`[wizard] Created ${result.assertionCount} pedagogy assertions from course reference data`);
         }
       } catch (err) {
         console.error("[wizard] Pedagogy assertion creation failed (non-fatal):", (err as Error).message);

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course.ts
@@ -10,29 +10,10 @@ export async function execute(
   userId: string,
   setupData?: Record<string, unknown>,
 ): Promise<WizardToolExec> {
-// ── Guard: graph must say "Can launch: YES" before creation ──
-const { evaluateGraph } = await import("@/lib/wizard/graph-evaluator");
-const graphCheck = evaluateGraph(setupData ?? {});
-if (!graphCheck.canLaunch) {
-  const labels = graphCheck.missingRequired.map((n) => n.label);
-  const keys = graphCheck.missingRequired.map((n) => n.key);
-  console.log(`[wizard-tools] create_course BLOCKED — missing required: ${labels.join(", ")}`);
-  // #317 follow-up: previously this returned a soft ack — the chat AI
-  // saw it as success and called mark_complete next, leaving the user
-  // on a fake "course created" card. Hard-fail so the AI must collect
-  // the missing fields and retry create_course.
-  return {
-    content: JSON.stringify({
-      ok: false,
-      error:
-        `Cannot create course yet — still missing required fields: ${labels.join(", ")}. ` +
-        `Collect these first, then call create_course again. Do NOT call mark_complete until create_course succeeds.`,
-      missingKeys: keys,
-      missingLabels: labels,
-    }),
-    is_error: true,
-  };
-}
+// ── Stage 1 — graph guard (extracted #1544) ──
+const { runGraphGuard } = await import("./create_course/_graph-guard");
+const graphGuard = await runGraphGuard(setupData);
+if (graphGuard.earlyReturn) return graphGuard.earlyReturn;
 // Server-side: full course creation with scaffolding (identity spec, playbook, system specs, publish, onboarding)
 try {
   const { prisma } = await import("@/lib/prisma");

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_graph-guard.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_graph-guard.ts
@@ -1,0 +1,55 @@
+/**
+ * Stage 1 of `create_course` — graph guard.
+ *
+ * Extracted from the monolithic `create_course.ts` per #1544. The graph
+ * evaluator is the very first hard-fail check: if `evaluateGraph` reports
+ * `canLaunch: false`, the tool returns an `is_error: true` payload with
+ * the missing field labels so the AI can collect them and retry. No DB
+ * writes occur on a failed guard.
+ *
+ * Behaviour-preserving: the return shape (content JSON + is_error: true)
+ * is verbatim identical to the pre-extract code at `create_course.ts:13-35`.
+ * The dispatcher tests at `tests/lib/chat/wizard-tool-executor-dispatcher.test.ts`
+ * pin this guard via the "create_course hard-fails when graph is incomplete"
+ * scenario — those tests must stay green after extraction.
+ */
+
+import type { WizardToolExec } from "../../_shared/types";
+
+export interface GraphGuardResult {
+  /** `null` means continue; a payload means early-return from the executor. */
+  earlyReturn: WizardToolExec | null;
+}
+
+export async function runGraphGuard(
+  setupData?: Record<string, unknown>,
+): Promise<GraphGuardResult> {
+  const { evaluateGraph } = await import("@/lib/wizard/graph-evaluator");
+  const graphCheck = evaluateGraph(setupData ?? {});
+  if (graphCheck.canLaunch) {
+    return { earlyReturn: null };
+  }
+
+  const labels = graphCheck.missingRequired.map((n) => n.label);
+  const keys = graphCheck.missingRequired.map((n) => n.key);
+  console.log(
+    `[wizard-tools] create_course BLOCKED — missing required: ${labels.join(", ")}`,
+  );
+  // #317 follow-up: previously this returned a soft ack — the chat AI
+  // saw it as success and called mark_complete next, leaving the user
+  // on a fake "course created" card. Hard-fail so the AI must collect
+  // the missing fields and retry create_course.
+  return {
+    earlyReturn: {
+      content: JSON.stringify({
+        ok: false,
+        error:
+          `Cannot create course yet — still missing required fields: ${labels.join(", ")}. ` +
+          `Collect these first, then call create_course again. Do NOT call mark_complete until create_course succeeds.`,
+        missingKeys: keys,
+        missingLabels: labels,
+      }),
+      is_error: true,
+    },
+  };
+}

--- a/apps/admin/tests/lib/chat/wizard-tool-executor/pedagogy-assertions.test.ts
+++ b/apps/admin/tests/lib/chat/wizard-tool-executor/pedagogy-assertions.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit + static-regression tests for the shared pedagogy helper (#1545).
+ *
+ * The helper centralises the ContentSource + ContentAssertion write
+ * shape that pre-#1547 lived inline in two mirror blocks of
+ * `wizard-tool-executor.ts` and now lives in two mirror blocks of
+ * `tools/create_course.ts`. The pre-fix blocks shipped with three
+ * silently-dropped field names (`status` on ContentSource;
+ * `confidence` + `isActive` on ContentAssertion) plus a missing required
+ * `slug`. Prisma threw on every write; the outer try/catch logged
+ * "non-fatal" — silent NO-OP for every wizard-driven course.
+ *
+ * Tests pin:
+ *   1. Helper invokes prisma with the canonical write shape (matches
+ *      `app/api/courses/[courseId]/course-reference/route.ts:166`).
+ *   2. Static-source grep against `create_course.ts` — the four drift
+ *      fields must NOT reappear in the file; `linkConfidence:` + `slug`
+ *      must be reachable through the helper import.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockContentSourceCreate = vi.fn();
+const mockSubjectSourceCreate = vi.fn();
+const mockContentAssertionCreate = vi.fn();
+const mockUpsertPlaybookSource = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    contentSource: { create: (...args: unknown[]) => mockContentSourceCreate(...args) },
+    subjectSource: { create: (...args: unknown[]) => mockSubjectSourceCreate(...args) },
+    contentAssertion: { create: (...args: unknown[]) => mockContentAssertionCreate(...args) },
+  },
+}));
+
+vi.mock("@/lib/knowledge/domain-sources", () => ({
+  upsertPlaybookSource: (...args: unknown[]) => mockUpsertPlaybookSource(...args),
+}));
+
+import { createPedagogyAssertionsFromCourseRef } from "@/lib/chat/wizard-tool-executor/tools/_pedagogy-assertions";
+import type { AssertionCreateData } from "@/lib/content-trust/course-ref-to-assertions";
+
+function row(overrides: Partial<AssertionCreateData> = {}): AssertionCreateData {
+  return {
+    assertion: "Teach this point",
+    category: "teaching_rule",
+    chapter: "Module 1",
+    section: null,
+    tags: ["pedagogy"],
+    orderIndex: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockContentSourceCreate.mockResolvedValue({ id: "src-1" });
+  mockSubjectSourceCreate.mockResolvedValue({});
+  mockContentAssertionCreate.mockResolvedValue({});
+  mockUpsertPlaybookSource.mockResolvedValue({});
+});
+
+describe("createPedagogyAssertionsFromCourseRef — canonical write shape (#1545)", () => {
+  it("writes ContentSource with slug + trustLevel + contentHash + isActive (mirror canonical route)", async () => {
+    await createPedagogyAssertionsFromCourseRef({
+      courseName: "Big Five OCEAN",
+      playbookId: "pb-1",
+      subjectId: "sub-1",
+      textSample: "# Course reference markdown",
+      assertionRows: [row()],
+    });
+
+    expect(mockContentSourceCreate).toHaveBeenCalledTimes(1);
+    const args = mockContentSourceCreate.mock.calls[0][0];
+    expect(args.data.slug).toMatch(/^big-five-ocean-ref-\d+$/);
+    expect(args.data.name).toBe("Big Five OCEAN — Course Reference");
+    expect(args.data.documentType).toBe("COURSE_REFERENCE");
+    expect(args.data.trustLevel).toBe("EXPERT_CURATED");
+    expect(args.data.textSample).toBe("# Course reference markdown");
+    expect(args.data.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(args.data.isActive).toBe(true);
+    expect(args.data.status).toBeUndefined();
+  });
+
+  it("links primary subject + dual-writes PlaybookSource", async () => {
+    await createPedagogyAssertionsFromCourseRef({
+      courseName: "Course",
+      playbookId: "pb-1",
+      subjectId: "sub-1",
+      textSample: "x",
+      assertionRows: [row()],
+    });
+
+    expect(mockSubjectSourceCreate).toHaveBeenCalledWith({
+      data: { subjectId: "sub-1", sourceId: "src-1" },
+    });
+    expect(mockUpsertPlaybookSource).toHaveBeenCalledWith("pb-1", "src-1", {
+      tags: ["course-reference"],
+    });
+  });
+
+  it("writes ContentAssertion rows with linkConfidence=1.0 + depth=0 (NOT confidence, NOT isActive)", async () => {
+    await createPedagogyAssertionsFromCourseRef({
+      courseName: "Course",
+      playbookId: "pb-1",
+      subjectId: "sub-1",
+      textSample: "x",
+      assertionRows: [row({ assertion: "First fact" }), row({ assertion: "Second fact" })],
+    });
+
+    expect(mockContentAssertionCreate).toHaveBeenCalledTimes(2);
+    const args0 = mockContentAssertionCreate.mock.calls[0][0];
+    expect(args0.data.sourceId).toBe("src-1");
+    expect(args0.data.linkConfidence).toBe(1.0);
+    expect(args0.data.depth).toBe(0);
+    expect(args0.data.assertion).toBe("First fact");
+    expect(args0.data.confidence).toBeUndefined();
+    expect(args0.data.isActive).toBeUndefined();
+  });
+
+  it("returns sourceId + assertionCount summary", async () => {
+    const result = await createPedagogyAssertionsFromCourseRef({
+      courseName: "Course",
+      playbookId: "pb-1",
+      subjectId: "sub-1",
+      textSample: "x",
+      assertionRows: [row(), row(), row()],
+    });
+    expect(result).toEqual({ sourceId: "src-1", assertionCount: 3 });
+  });
+
+  it("propagates Prisma errors instead of swallowing them (the outer try/catch chooses fatality)", async () => {
+    mockContentSourceCreate.mockRejectedValueOnce(new Error("unique constraint"));
+    await expect(
+      createPedagogyAssertionsFromCourseRef({
+        courseName: "Course",
+        playbookId: "pb-1",
+        subjectId: "sub-1",
+        textSample: "x",
+        assertionRows: [row()],
+      }),
+    ).rejects.toThrow(/unique constraint/);
+  });
+});
+
+describe("create_course.ts static regression — drift fields must not return (#1545)", () => {
+  it("create_course.ts no longer writes status / confidence / isActive on assertion creates", async () => {
+    // Sibling of the static-source check at
+    // `tests/lib/content-trust/playbook-source-isolation.test.ts:77-100`.
+    // The helper is the sanctioned source of write shape; if a future
+    // edit re-inlines a drifted field, this test fires.
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const file = path.resolve(
+      __dirname,
+      "../../../../lib/chat/wizard-tool-executor/tools/create_course.ts",
+    );
+    const src = await fs.readFile(file, "utf8");
+
+    // None of the four drift fields may appear inside a ContentSource or
+    // ContentAssertion `prisma.*.create({ data: { … } })` block. The
+    // wider file uses `isActive: true` elsewhere (Playbook etc.) so we
+    // anchor the check on context: the helper import + canonical write
+    // shape must be present.
+    expect(src).toContain('await import("./_pedagogy-assertions")');
+    expect(src).toContain("createPedagogyAssertionsFromCourseRef");
+    expect(src).not.toMatch(/contentSource\.create[\s\S]*?status:\s*"COMPLETED"/);
+    expect(src).not.toMatch(/contentAssertion\.create[\s\S]*?confidence:\s*1\.0/);
+  });
+});


### PR DESCRIPTION
## Summary

First commit of the 8-stage split tracked in #1544. Pure shape change, no behaviour change. Closes #1544's first AC item; the remaining 7 stages are mapped in the issue with realistic line ranges on the post-#1545 file.

**Note:** stacked on top of PR #1552 (#1545 fix). Merge #1552 first or use the GitHub stack-merge view; the diff against `main` includes both PRs.

## What moved

- `lib/chat/wizard-tool-executor/tools/create_course/_graph-guard.ts` (new, 55 LOC) — exports `runGraphGuard(setupData)` returning `{ earlyReturn: WizardToolExec | null }`. `null` means continue; a payload means caller returns it verbatim.
- `lib/chat/wizard-tool-executor/tools/create_course.ts` L13-35 replaced with a 3-line call site. Orchestrator drops from 1340 → 1321 LOC.

The pre-extract behaviour is preserved verbatim — same return shape (`is_error: true`, `missingKeys`, `missingLabels`), same console log line (`[wizard-tools] create_course BLOCKED`), same `#317 follow-up` comment.

## Verified by

```
$ npm test -- --run tests/lib/chat/wizard-tool-executor-dispatcher.test.ts tests/lib/chat/wizard-tool-executor
 Test Files  2 passed (2)
      Tests  17 passed (17)
```

Dispatcher test `tests/lib/chat/wizard-tool-executor-dispatcher.test.ts → "create_course: hard-fails when graph is incomplete"` is the canonical pin for this guard — green after extraction, byte-identical contract.

No new tsc errors (verified via `npx tsc --noEmit | grep -E "create_course|_graph-guard"` returning no matches).

## Sequencing — stages 2-8 still to extract

| # | Stage | Approx range | Notes |
|---|---|---|---|
| 2 | `resolveDomainOrError` | L28-96 | validUuid cascade + slug/name + `ensureInstitutionAndDomain` + final guard |
| 3 | `resolveSubjectOrError` | L55-116 | placeholder discipline guard + `subjectDiscipline` assignment |
| 4 | `reuseExistingCoursePath` | L114-498 | the big one — `draftPlaybookId` branch (~380 LOC); already calls `createPedagogyAssertionsFromCourseRef` from #1545 |
| 5 | `newCourseScaffoldPath` | L500-1015 | fresh-scaffold branch (~510 LOC); needs the new-path test pin (#1544 AC) |
| 6 | `applyBehaviorTargetsBlock` | inside L5 | not a separate stage at this file shape — folds into the new-path extract |
| 7 | `enrollAndCreateCaller` | L1017-1080 | `enrollCaller` + `randomFakeName` + skip-onboarding wiring |
| 8 | `generateLessonPlanAndReturn` | L1081-1321 | lesson plan + final response payload |

Stages 4 + 5 are the bulk of the LOC and the riskiest cuts (shared closed-over locals: `domainId`, `playbookId`, `subject`, `existingPlaybookId`, `caller`, `lessonPlanModel`). The BA brief calls for a shared `CreateCourseContext` interface threaded through each stage helper. Subsequent commits introduce the context shape one stage at a time so dispatcher tests can run between every commit.

## Out of scope (this PR)

- The new-path branch test pin (#1544 AC). Mock surface is still too wide at stage 1; the pin lands together with stage 5 (`_new-path.ts`).
- Stages 2-8 themselves. They each get their own PR with the dispatcher tests staying green between commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)