### PR TITLE
feat(projection): N-tier table-form Skills Framework + launch blockers

### DIFF
--- a/apps/admin/lib/wizard/__tests__/project-course-reference.test.ts
+++ b/apps/admin/lib/wizard/__tests__/project-course-reference.test.ts
@@ -54,6 +54,108 @@ describe("projectCourseReference — PROJECTION_NO_SKILLS_FRAMEWORK warning", ()
   });
 });
 
+// Table-form Skills Framework (CTO/CIO + future custom-tier courses).
+describe("parseSkillsFramework — TABLE form", () => {
+  it("parses CTO 4-tier table (Foundation/Developing/Practitioner/Distinction)", () => {
+    const text = `## Skills Framework
+
+Some preamble.
+
+| Skill ref | Skill | Foundation | Developing | Practitioner | Distinction |
+|---|---|---|---|---|---|
+| SKILL-01 | **Stakeholder anticipation** — predicting what the exec / board / business unit will worry about before they raise it | Reacts to stakeholder concerns | Proactively addresses known concerns | Anticipates the question two quarters out | Has reframed a stakeholder's understanding before they articulated it |
+| SKILL-02 | **Risk articulation** — explaining IT risk in business terms | Lists technical risks | Translates one risk per call | Quantifies + sequences risk | Coaches the board to think in risk |
+`;
+    const result = parseSkillsFramework(text);
+    expect(result.skills).toHaveLength(2);
+
+    const s1 = result.skills[0];
+    expect(s1.ref).toBe("SKILL-01");
+    expect(s1.name).toBe("Stakeholder anticipation");
+    expect(s1.description).toContain("predicting what the exec");
+    expect(s1.tierScheme).toEqual([
+      "foundation",
+      "developing",
+      "practitioner",
+      "distinction",
+    ]);
+    expect(s1.tiers.foundation).toBe("Reacts to stakeholder concerns");
+    expect(s1.tiers.distinction).toContain("reframed");
+
+    const s2 = result.skills[1];
+    expect(s2.ref).toBe("SKILL-02");
+    expect(s2.name).toBe("Risk articulation");
+    expect(s2.tiers.foundation).toBe("Lists technical risks");
+    expect(s2.tiers.distinction).toBe("Coaches the board to think in risk");
+  });
+
+  it("parses 3-tier table (Emerging/Developing/Secure) — same scheme as heading form", () => {
+    const text = `## Skills Framework
+
+| Skill ref | Skill | Emerging | Developing | Secure |
+|---|---|---|---|---|
+| SKILL-01 | **Listening** — paying attention | weak | mid | strong |
+`;
+    const result = parseSkillsFramework(text);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].tierScheme).toEqual(["emerging", "developing", "secure"]);
+    expect(result.skills[0].tiers.secure).toBe("strong");
+  });
+
+  it("emits SKILL_UNRECOGNISED_TIER_SCHEME for a non-standard scheme", () => {
+    const text = `## Skills Framework
+
+| Skill ref | Skill | Apple | Banana | Cherry |
+|---|---|---|---|---|
+| SKILL-01 | **X** — y | a | b | c |
+`;
+    const result = parseSkillsFramework(text);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].tierScheme).toEqual(["apple", "banana", "cherry"]);
+    expect(result.validationWarnings.some((w) => w.code === "SKILL_UNRECOGNISED_TIER_SCHEME")).toBe(true);
+  });
+
+  it("warns when a row is truncated (fewer tier cells than the header promises)", () => {
+    const text = `## Skills Framework
+
+| Skill ref | Skill | Foundation | Developing | Practitioner | Distinction |
+|---|---|---|---|---|---|
+| SKILL-01 | **Half** — short | only one cell |
+| SKILL-02 | **Full** — long | a | b | c | d |
+`;
+    const result = parseSkillsFramework(text);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].ref).toBe("SKILL-02");
+    expect(result.validationWarnings.some((w) => w.code === "SKILL_TABLE_ROW_TRUNCATED")).toBe(true);
+  });
+
+  it("accepts a skill cell without bolded name (plain text)", () => {
+    const text = `## Skills Framework
+
+| Skill ref | Skill | Foundation | Developing | Practitioner | Distinction |
+|---|---|---|---|---|---|
+| SKILL-01 | Plain Skill Name | a | b | c | d |
+`;
+    const result = parseSkillsFramework(text);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].name).toBe("Plain Skill Name");
+    expect(result.skills[0].description).toBeUndefined();
+  });
+
+  it("downstream goal name uses the top tier label (Distinction for CTO, not Secure)", () => {
+    const text = `## Skills Framework
+
+| Skill ref | Skill | Foundation | Developing | Practitioner | Distinction |
+|---|---|---|---|---|---|
+| SKILL-01 | **Stakeholder anticipation** — desc | f | d | p | top |
+`;
+    const projection = projectCourseReference(text, { sourceContentId: SOURCE_ID });
+    const achieve = projection.configPatch.goalTemplates.filter((g) => g.type === "ACHIEVE");
+    expect(achieve).toHaveLength(1);
+    expect(achieve[0].name).toBe("Reach Distinction on Stakeholder anticipation");
+  });
+});
+
 describe("parseSkillsFramework — additional cases", () => {
 
   it("captures the 4 IELTS Speaking criteria from the v2.2 fixture", () => {

--- a/apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts
+++ b/apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts
@@ -447,4 +447,175 @@ describe("runProjectionForPlaybook", () => {
     expect(mockWriteBandThresholds).not.toHaveBeenCalled();
     expect(result.rubricBandsApplied).toEqual([]);
   });
+
+  // (3) Publish-time launch blocker — PROJECTION_NO_SKILLS_FRAMEWORK upgraded
+  // from a soft validation warning to a launch blocker. The publish gate
+  // consumes `launchBlockers` and refuses to mark Playbook PUBLISHED when
+  // any entry is present.
+  describe("launch blockers", () => {
+    it("emits NO_COURSE_REFERENCE_SOURCE blocker when no course-ref source is linked", async () => {
+      setSources([]);
+      const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
+      const result = await runProjectionForPlaybook(PLAYBOOK_ID);
+
+      expect(result.degenerate).toBe(true);
+      expect(result.launchBlockers).toEqual([
+        expect.objectContaining({ code: "NO_COURSE_REFERENCE_SOURCE" }),
+      ]);
+    });
+
+    it("emits PROJECTION_NO_SKILLS_FRAMEWORK when the course-ref has no parseable Skills Framework", async () => {
+      const noSkills = "# Course\n\n## Outcomes\n\n**OUT-01:** Something.\n";
+      setSources([
+        {
+          source: {
+            id: "src-bad",
+            name: "course-ref without skills",
+            mediaAssets: [{ storageKey: "k", fileName: "course-ref.md" }],
+          },
+        },
+      ]);
+      mockStorageDownload.mockResolvedValue(Buffer.from(noSkills));
+      mockExtractTextFromBuffer.mockResolvedValue({ text: noSkills, fileType: "text" });
+      mockApplyProjection.mockResolvedValue({
+        parametersUpserted: 0,
+        behaviorTargetsCreated: 0,
+        behaviorTargetsUpdated: 0,
+        behaviorTargetsRemoved: 0,
+        curriculumModulesCreated: 0,
+        curriculumModulesUpdated: 0,
+        curriculumModulesRemoved: 0,
+        learningObjectivesCreated: 0,
+        learningObjectivesUpdated: 0,
+        learningObjectivesRemoved: 0,
+        goalTemplatesWritten: 0,
+        curriculumId: "curr-1",
+        measureSpecId: null,
+        measureTriggerCount: 0,
+        warnings: [],
+        noop: true,
+      });
+
+      const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
+      const result = await runProjectionForPlaybook(PLAYBOOK_ID);
+
+      expect(result.launchBlockers).toEqual([
+        expect.objectContaining({
+          code: "PROJECTION_NO_SKILLS_FRAMEWORK",
+          sourceContentId: "src-bad",
+          sourceName: "course-ref without skills",
+        }),
+      ]);
+    });
+
+    it("clears PROJECTION_NO_SKILLS_FRAMEWORK when at least one applied source produced Parameters", async () => {
+      // Two sources: first has no skills, second is IELTS with the full 4-skill
+      // framework. The educator only needs ONE source with a Skills Framework.
+      setSources([
+        {
+          source: {
+            id: "src-bad",
+            name: "no-skills",
+            mediaAssets: [{ storageKey: "k1", fileName: "course-ref.md" }],
+          },
+        },
+        {
+          source: {
+            id: "src-ielts",
+            name: "IELTS course-ref",
+            mediaAssets: [{ storageKey: "k2", fileName: "ielts.md" }],
+          },
+        },
+      ]);
+      mockStorageDownload.mockImplementation((key: string) =>
+        key === "k2"
+          ? Promise.resolve(Buffer.from(IELTS_V22))
+          : Promise.resolve(Buffer.from("# Course\n\n## Outcomes\n\n**OUT-01:** Hi.\n")),
+      );
+      mockExtractTextFromBuffer.mockImplementation((buffer: Buffer) => ({
+        text: buffer.toString("utf-8"),
+        fileType: "text",
+      }));
+      // Per-call mock: first call returns 0 params, second returns 4.
+      mockApplyProjection
+        .mockResolvedValueOnce({
+          parametersUpserted: 0,
+          behaviorTargetsCreated: 0,
+          behaviorTargetsUpdated: 0,
+          behaviorTargetsRemoved: 0,
+          curriculumModulesCreated: 0,
+          curriculumModulesUpdated: 0,
+          curriculumModulesRemoved: 0,
+          learningObjectivesCreated: 0,
+          learningObjectivesUpdated: 0,
+          learningObjectivesRemoved: 0,
+          goalTemplatesWritten: 0,
+          curriculumId: "curr-1",
+          measureSpecId: null,
+          measureTriggerCount: 0,
+          warnings: [],
+          noop: true,
+        })
+        .mockResolvedValueOnce({
+          parametersUpserted: 4,
+          behaviorTargetsCreated: 4,
+          behaviorTargetsUpdated: 0,
+          behaviorTargetsRemoved: 0,
+          curriculumModulesCreated: 5,
+          curriculumModulesUpdated: 0,
+          curriculumModulesRemoved: 0,
+          learningObjectivesCreated: 27,
+          learningObjectivesUpdated: 0,
+          learningObjectivesRemoved: 0,
+          goalTemplatesWritten: 25,
+          curriculumId: "curr-1",
+          measureSpecId: "msp-1",
+          measureTriggerCount: 4,
+          warnings: [],
+          noop: false,
+        });
+
+      const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
+      const result = await runProjectionForPlaybook(PLAYBOOK_ID);
+
+      expect(result.launchBlockers).toEqual([]);
+    });
+
+    it("returns launchBlockers: [] when the course-ref has a parseable Skills Framework", async () => {
+      setSources([
+        {
+          source: {
+            id: "src-ielts",
+            name: "IELTS",
+            mediaAssets: [{ storageKey: "k", fileName: "ielts.md" }],
+          },
+        },
+      ]);
+      mockStorageDownload.mockResolvedValue(Buffer.from(IELTS_V22));
+      mockExtractTextFromBuffer.mockResolvedValue({ text: IELTS_V22, fileType: "text" });
+      mockApplyProjection.mockResolvedValue({
+        parametersUpserted: 4,
+        behaviorTargetsCreated: 4,
+        behaviorTargetsUpdated: 0,
+        behaviorTargetsRemoved: 0,
+        curriculumModulesCreated: 5,
+        curriculumModulesUpdated: 0,
+        curriculumModulesRemoved: 0,
+        learningObjectivesCreated: 27,
+        learningObjectivesUpdated: 0,
+        learningObjectivesRemoved: 0,
+        goalTemplatesWritten: 25,
+        curriculumId: "curr-1",
+        measureSpecId: "msp-1",
+        measureTriggerCount: 4,
+        warnings: [],
+        noop: false,
+      });
+
+      const { runProjectionForPlaybook } = await import("../run-projection-for-playbook");
+      const result = await runProjectionForPlaybook(PLAYBOOK_ID);
+
+      expect(result.launchBlockers).toEqual([]);
+    });
+  });
 });

--- a/apps/admin/lib/wizard/project-course-reference.ts
+++ b/apps/admin/lib/wizard/project-course-reference.ts
@@ -212,15 +212,30 @@ export interface ParsedSkill {
   ref: string;
   name: string;
   description?: string;
-  tiers: {
-    emerging?: string;
-    developing?: string;
-    secure?: string;
-  };
+  /**
+   * Tier descriptors keyed by lowercase tier name. The default scheme is
+   * 3-tier `emerging` / `developing` / `secure`; the parser also accepts
+   * table-form Skills Framework with any tier scheme (`foundation` /
+   * `developing` / `practitioner` / `distinction` for CTO/CIO, CEFR's
+   * `a1`–`c2`, NHS AfC bands, etc.). Backward compatible — code reading
+   * `skill.tiers.emerging` still works for 3-tier courses.
+   *
+   * The ordered list of tier names for this skill lives in `tierScheme`.
+   */
+  tiers: Record<string, string>;
+  /**
+   * Ordered tier names (lowercase) — first = lowest tier, last = top tier
+   * (the "target" tier whose descriptor populates downstream goal copy and
+   * BehaviorTarget secureDescription). For 3-tier skills this is always
+   * `["emerging", "developing", "secure"]`; CTO/CIO 4-tier is
+   * `["foundation", "developing", "practitioner", "distinction"]`. Custom
+   * schemes are accepted with a `SKILL_UNRECOGNISED_TIER_SCHEME` warning.
+   */
+  tierScheme: string[];
   /**
    * Optional per-skill target band parsed from a `**Target band:** N.N`
    * line inside the skill section. Converted to `targetValue = band / 10`
-   * by `mapSkillsToAchieveAndTargets`. Absent = aim for Secure (1.0).
+   * by `mapSkillsToAchieveAndTargets`. Absent = aim for top tier (1.0).
    */
   targetBand?: number;
   /**
@@ -232,12 +247,52 @@ export interface ParsedSkill {
   bandThresholds?: Record<number, string>;
 }
 
+/**
+ * Known tier schemes — projection accepts any scheme but only warns when
+ * the parsed scheme doesn't match a recognised one (i.e. the educator
+ * might have mistyped a column header).
+ */
+export const KNOWN_TIER_SCHEMES: Record<string, readonly string[]> = {
+  three: ["emerging", "developing", "secure"],
+  cto: ["foundation", "developing", "practitioner", "distinction"],
+  cefr: ["a1", "a2", "b1", "b2", "c1", "c2"],
+};
+
+/** Default scheme for heading-form skills (existing v2.2/v3.0 behaviour). */
+const DEFAULT_TIER_SCHEME = KNOWN_TIER_SCHEMES.three;
+
+/** Normalize a tier label for storage key + scheme matching. */
+function normaliseTierName(raw: string): string {
+  return raw.toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]+/g, "");
+}
+
+/** Check whether the given ordered tier list matches a known scheme. */
+function schemeMatchesKnown(scheme: readonly string[]): string | null {
+  for (const [name, known] of Object.entries(KNOWN_TIER_SCHEMES)) {
+    if (known.length !== scheme.length) continue;
+    if (known.every((t, i) => t === scheme[i])) return name;
+  }
+  return null;
+}
+
+/** Capitalise the first letter; used for display labels (`emerging` → `Emerging`). */
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 export interface SkillsFrameworkResult {
   skills: ParsedSkill[];
   validationWarnings: ValidationWarning[];
 }
 
 const SKILL_HEADING = /^###\s+(SKILL-\d+)\s*:\s*(.+?)\s*$/;
+/** Markdown table data row carrying a skill in TABLE form (#cto). */
+const SKILL_TABLE_DATA_ROW = /^\s*\|\s*(SKILL-\d+)\s*\|/i;
+/** Markdown table separator row: `|---|---|...|` (any number of cells). */
+const TABLE_SEPARATOR = /^\s*\|(\s*:?-{3,}:?\s*\|)+\s*$/;
+/** First-cell looks like a header: contains "Skill ref" or "Ref" — used to find header row. */
+const SKILL_TABLE_HEADER_FIRST_CELL = /^(skill\s+ref|ref|skill\s+id)$/i;
 // Tier format accepts both v3.0 (`**Emerging:**`) and v2.2 (`**Emerging.**`)
 // punctuation styles. The captured text follows the closing `**`.
 const TIER_LINE = /^\s*[-*]\s*\*\*\s*(Emerging|Developing|Secure)\s*[:.]\s*\*\*\s*(.+?)\s*$/i;
@@ -277,9 +332,19 @@ export function parseSkillsFramework(bodyText: string): SkillsFrameworkResult {
     return { skills: [], validationWarnings: [] };
   }
 
+  const warnings: ValidationWarning[] = [];
+
+  // TABLE form takes precedence — if the section contains a recognisable
+  // skill table (`| Skill ref | Skill | Tier1 | Tier2 | ... |`), parse it
+  // and return. The heading-form path stays as-is for IELTS/Big5/Seducing
+  // courses that already use it.
+  const tableResult = parseSkillsFrameworkTable(sectionLines, warnings);
+  if (tableResult) {
+    return { skills: tableResult, validationWarnings: validateSkills(tableResult, warnings) };
+  }
+
   // Walk the section, accumulating one ParsedSkill per `### SKILL-NN` heading.
   const skills: ParsedSkill[] = [];
-  const warnings: ValidationWarning[] = [];
   let current: ParsedSkill | null = null;
   // Description = first non-empty paragraph after the heading, before tier
   // bullets. Treat blank line as paragraph break.
@@ -304,6 +369,7 @@ export function parseSkillsFramework(bodyText: string): SkillsFrameworkResult {
         ref: headingMatch[1],
         name: headingMatch[2].trim(),
         tiers: {},
+        tierScheme: [...DEFAULT_TIER_SCHEME],
       };
       captureDescription = true;
       continue;
@@ -367,27 +433,146 @@ export function parseSkillsFramework(bodyText: string): SkillsFrameworkResult {
   }
   finalize();
 
-  // Validate: every skill should have all three tiers. Missing tiers are
-  // warnings (publish gate decides whether to block) — they let an
-  // educator save partial work.
+  validateSkills(skills, warnings);
+  return { skills, validationWarnings: warnings };
+}
+
+/**
+ * Validate skill rows against their `tierScheme`. Missing tiers are
+ * warnings (publish gate decides whether to block) — they let an
+ * educator save partial work. Returns the warnings array for chaining.
+ */
+function validateSkills(
+  skills: ParsedSkill[],
+  warnings: ValidationWarning[],
+): ValidationWarning[] {
   for (const skill of skills) {
-    if (!skill.tiers.secure) {
+    const topTier = skill.tierScheme[skill.tierScheme.length - 1];
+    if (!skill.tiers[topTier]) {
       warnings.push({
         severity: "warning",
         code: "SKILL_MISSING_SECURE_TIER",
-        message: `${skill.ref} (${skill.name}) has no Secure tier — projection cannot derive a BehaviorTarget target value.`,
+        message: `${skill.ref} (${skill.name}) has no ${topTier} tier — projection cannot derive a BehaviorTarget target value.`,
       });
     }
-    if (!skill.tiers.emerging || !skill.tiers.developing) {
+    const missingMidTiers = skill.tierScheme
+      .slice(0, -1)
+      .filter((t) => !skill.tiers[t]);
+    if (missingMidTiers.length > 0) {
       warnings.push({
         severity: "warning",
         code: "SKILL_INCOMPLETE_TIERS",
-        message: `${skill.ref} (${skill.name}) is missing Emerging or Developing tier descriptions.`,
+        message: `${skill.ref} (${skill.name}) is missing tier descriptors for: ${missingMidTiers.join(", ")}.`,
       });
     }
   }
+  return warnings;
+}
 
-  return { skills, validationWarnings: warnings };
+/**
+ * Parse table-form Skills Framework:
+ *
+ * ```
+ * | Skill ref | Skill | Foundation | Developing | Practitioner | Distinction |
+ * |---|---|---|---|---|---|
+ * | SKILL-01 | **Stakeholder anticipation** — predicting … | Reacts to … | Proactively … | Anticipates … | Has reframed … |
+ * ```
+ *
+ * Returns null when no recognisable table is present (caller falls
+ * through to the heading-form parser). Returns `[]` when a header is
+ * detected but no data rows match — surfaces as
+ * PROJECTION_NO_SKILLS_FRAMEWORK upstream.
+ *
+ * Recognised tier schemes match `KNOWN_TIER_SCHEMES`; unrecognised ones
+ * are accepted with a `SKILL_UNRECOGNISED_TIER_SCHEME` warning so the
+ * educator notices a possible header typo.
+ */
+function parseSkillsFrameworkTable(
+  sectionLines: string[],
+  warnings: ValidationWarning[],
+): ParsedSkill[] | null {
+  // 1. Find the header row + separator + tier columns.
+  let headerIndex = -1;
+  let tierColumns: string[] = [];
+  for (let i = 0; i < sectionLines.length; i++) {
+    const line = sectionLines[i];
+    if (!line.trim().startsWith("|")) continue;
+    const cells = parseTableRow(line);
+    if (cells.length < 3) continue;
+    if (!SKILL_TABLE_HEADER_FIRST_CELL.test(cells[0])) continue;
+    // Next non-blank line must be a separator row to confirm this is the header.
+    const nextLine = sectionLines.slice(i + 1).find((l) => l.trim().length > 0);
+    if (!nextLine || !TABLE_SEPARATOR.test(nextLine)) continue;
+    headerIndex = i;
+    tierColumns = cells.slice(2).map(normaliseTierName);
+    break;
+  }
+  if (headerIndex < 0) return null;
+  if (tierColumns.length === 0) return null;
+
+  // 2. Validate the scheme.
+  const knownName = schemeMatchesKnown(tierColumns);
+  if (!knownName) {
+    warnings.push({
+      severity: "warning",
+      code: "SKILL_UNRECOGNISED_TIER_SCHEME",
+      message:
+        `Skills Framework table uses tier scheme [${tierColumns.join(", ")}] which doesn't ` +
+        `match any known scheme (${Object.keys(KNOWN_TIER_SCHEMES).join(", ")}). ` +
+        `Accepted as-is; check the header row for typos.`,
+    });
+  }
+
+  // 3. Walk data rows.
+  const skills: ParsedSkill[] = [];
+  for (let i = headerIndex + 1; i < sectionLines.length; i++) {
+    const line = sectionLines[i];
+    if (TABLE_SEPARATOR.test(line)) continue;
+    if (!SKILL_TABLE_DATA_ROW.test(line)) continue;
+    const cells = parseTableRow(line);
+    if (cells.length < 2 + tierColumns.length) {
+      // Row has fewer tier cells than the header promises — skip with warning.
+      warnings.push({
+        severity: "warning",
+        code: "SKILL_TABLE_ROW_TRUNCATED",
+        message: `Skill table row ${cells[0]} has ${cells.length - 2} tier cells; header declared ${tierColumns.length}.`,
+      });
+      continue;
+    }
+    const ref = cells[0];
+    const skillCell = cells[1];
+    // Skill cell may be `**Name** — description` or just `Name`. Pull the
+    // bolded name out and treat the rest as description; fall back to the
+    // whole cell as the name if no bold.
+    const skillCellMatch = skillCell.match(/^\*\*(.+?)\*\*\s*(?:[—-]\s*(.+))?$/);
+    const name = skillCellMatch ? skillCellMatch[1].trim() : skillCell;
+    const description = skillCellMatch && skillCellMatch[2] ? skillCellMatch[2].trim() : undefined;
+
+    const tiers: Record<string, string> = {};
+    for (let j = 0; j < tierColumns.length; j++) {
+      const cell = cells[2 + j]?.trim();
+      if (cell) tiers[tierColumns[j]] = cell;
+    }
+
+    skills.push({
+      ref,
+      name,
+      description,
+      tiers,
+      tierScheme: [...tierColumns],
+    });
+  }
+  return skills;
+}
+
+/**
+ * Split a markdown table row into cell strings. Trims outer pipes + each
+ * cell's surrounding whitespace. Does not handle escaped pipes inside
+ * cells — Skills Framework tables don't contain those today.
+ */
+function parseTableRow(line: string): string[] {
+  const trimmed = line.trim().replace(/^\|/, "").replace(/\|\s*$/, "");
+  return trimmed.split("|").map((c) => c.trim());
 }
 
 // ── Mappers ────────────────────────────────────────────────────────────────
@@ -437,25 +622,34 @@ function mapSkillsToMeasureSpec(
   const triggers: ProjectedMeasureSpecTrigger[] = skills.map((skill) => {
     const hasTargetBand =
       typeof skill.targetBand === "number" && skill.targetBand > 0;
-    const secureLabel = hasTargetBand
-      ? `Secure (ceiling = 1.0; this course targets Band ${skill.targetBand} = ${(skill.targetBand! / 10).toFixed(2)})`
-      : "Secure (target)";
+    const topTierLower = skill.tierScheme[skill.tierScheme.length - 1] ?? "secure";
+    const topTierLabel = capitalize(topTierLower);
+    const topTierTargetLabel = hasTargetBand
+      ? `${topTierLabel} (ceiling = 1.0; this course targets Band ${skill.targetBand} = ${(skill.targetBand! / 10).toFixed(2)})`
+      : `${topTierLabel} (target)`;
+    // Build the rubric in tierScheme order so per-band ordering is stable
+    // for any scheme (3-tier, 4-tier CTO, CEFR 6-tier, etc.).
     const tierLines: string[] = [];
-    if (skill.tiers.emerging) tierLines.push(`Emerging: ${skill.tiers.emerging}`);
-    if (skill.tiers.developing)
-      tierLines.push(`Developing: ${skill.tiers.developing}`);
-    if (skill.tiers.secure) tierLines.push(`${secureLabel}: ${skill.tiers.secure}`);
+    for (const tierKey of skill.tierScheme) {
+      const value = skill.tiers[tierKey];
+      if (!value) continue;
+      const isTop = tierKey === topTierLower;
+      const label = isTop ? topTierTargetLabel : capitalize(tierKey);
+      tierLines.push(`${label}: ${value}`);
+    }
     const rubric =
       tierLines.length > 0
         ? `\n\nTier descriptors:\n${tierLines.join("\n")}`
         : "";
+
+    const tierFlow = skill.tierScheme.map(capitalize).join(" → ");
 
     return {
       skillRef: skill.ref,
       name: `${skill.name} band assessment`,
       given: "The caller spoke on this call",
       when: "End-of-call analysis",
-      then: `Score the caller's ${skill.name} per the rubric tiers (Emerging → Developing → Secure, normalised 0-1 where 0.X corresponds to Band X; Band 6.5 = 0.65, Band 9 = 0.9, Secure tier ceiling = 1.0). Score this criterion INDEPENDENTLY of the other criteria — composite scores hide what needs work.`,
+      then: `Score the caller's ${skill.name} per the rubric tiers (${tierFlow}, normalised 0-1 where the top tier (${topTierLabel}) corresponds to 1.0; bands map proportionally — e.g. Band 6.5 = 0.65, Band 9 = 0.9). Score this criterion INDEPENDENTLY of the other criteria — composite scores hide what needs work.`,
       actions: [
         {
           description: `Measure ${skill.name}: produce a 0-1 score against the tier descriptors below.${rubric}`,
@@ -488,13 +682,15 @@ function mapSkillsToAchieveAndTargets(skills: ParsedSkill[]): {
 
   for (const skill of skills) {
     const paramName = skillNameToParameterName(skill.name);
-    const secureDescription = skill.tiers.secure ?? skill.description;
+    const topTier = skill.tierScheme[skill.tierScheme.length - 1] ?? "secure";
+    const topTierLabel = capitalize(topTier);
+    const secureDescription = skill.tiers[topTier] ?? skill.description;
     const hasTargetBand =
       typeof skill.targetBand === "number" && skill.targetBand > 0;
     const targetValue = hasTargetBand ? skill.targetBand! / 10 : 1.0;
     const goalName = hasTargetBand
       ? `Reach Band ${skill.targetBand} on ${skill.name}`
-      : `Reach Secure on ${skill.name}`;
+      : `Reach ${topTierLabel} on ${skill.name}`;
 
     parameters.push({
       name: paramName,

--- a/apps/admin/lib/wizard/run-projection-for-playbook.ts
+++ b/apps/admin/lib/wizard/run-projection-for-playbook.ts
@@ -46,6 +46,21 @@ export interface RunProjectionResult {
     parametersUpdated: number;
     unmatchedCodes: string[];
   }>;
+  /**
+   * Launch-blocking issues found at projection time. The wizard's publish
+   * gate MUST refuse to mark a Playbook PUBLISHED while any blocker is
+   * present. Today the only blocker is `PROJECTION_NO_SKILLS_FRAMEWORK`
+   * (no parseable skill in any linked COURSE_REFERENCE source).
+   *
+   * The set MAY grow over time — keep the consumer treating any entry as
+   * a hard refusal, not just this specific code.
+   */
+  launchBlockers: Array<{
+    code: string;
+    sourceContentId?: string;
+    sourceName?: string;
+    message: string;
+  }>;
 }
 
 /**
@@ -88,11 +103,25 @@ export async function runProjectionForPlaybook(playbookId: string): Promise<RunP
     console.warn(
       `[projection] no COURSE_REFERENCE source linked to playbook=${playbookId} — course is degenerate (no Goals/BehaviorTargets/CurriculumModule derived). See docs/CONTENT-PIPELINE.md §4 Phase 2.5.`,
     );
-    return { playbookId, appliedSources: [], skippedSources: [], degenerate: true, rubricBandsApplied: [] };
+    return {
+      playbookId,
+      appliedSources: [],
+      skippedSources: [],
+      degenerate: true,
+      rubricBandsApplied: [],
+      launchBlockers: [
+        {
+          code: "NO_COURSE_REFERENCE_SOURCE",
+          message:
+            "No COURSE_REFERENCE source linked. Upload at least one course-ref doc before launching.",
+        },
+      ],
+    };
   }
 
   const appliedSources: RunProjectionResult["appliedSources"] = [];
   const skippedSources: RunProjectionResult["skippedSources"] = [];
+  const launchBlockers: RunProjectionResult["launchBlockers"] = [];
   const storage = getStorageAdapter();
 
   for (const link of links) {
@@ -141,6 +170,25 @@ export async function runProjectionForPlaybook(playbookId: string): Promise<RunP
     }
 
     const projection = projectCourseReference(text, { sourceContentId: source.id });
+
+    // (3) Promote PROJECTION_NO_SKILLS_FRAMEWORK from a soft warning to a
+    // launch blocker. Without skills no `skill_*` Parameters or BehaviorTargets
+    // are minted, no MEASURE spec is created, no CallerTarget rows can be
+    // populated. The educator dashboard sits flat-zero on every learner
+    // forever. The publish gate consumes `launchBlockers` and refuses to mark
+    // the Playbook PUBLISHED until at least one source resolves the blocker.
+    const noSkillsWarning = projection.validationWarnings.find(
+      (w) => w.code === "PROJECTION_NO_SKILLS_FRAMEWORK",
+    );
+    if (noSkillsWarning) {
+      launchBlockers.push({
+        code: "PROJECTION_NO_SKILLS_FRAMEWORK",
+        sourceContentId: source.id,
+        sourceName: source.name,
+        message: noSkillsWarning.message,
+      });
+    }
+
     const result = await applyProjection(projection, {
       playbookId,
       sourceContentId: source.id,
@@ -263,11 +311,23 @@ export async function runProjectionForPlaybook(playbookId: string): Promise<RunP
     });
   }
 
+  // Collapse PROJECTION_NO_SKILLS_FRAMEWORK across multiple sources: if ANY
+  // source produced skills, the blocker is cleared (the educator only needs
+  // one parseable Skills Framework, not one per doc). Done last so the order
+  // of `links` doesn't matter.
+  const someSourceProducedSkills = appliedSources.some(
+    (s) => (s.result.parametersUpserted ?? 0) > 0,
+  );
+  const filteredBlockers = someSourceProducedSkills
+    ? launchBlockers.filter((b) => b.code !== "PROJECTION_NO_SKILLS_FRAMEWORK")
+    : launchBlockers;
+
   return {
     playbookId,
     appliedSources,
     skippedSources,
     degenerate: false,
     rubricBandsApplied,
+    launchBlockers: filteredBlockers,
   };
 }


### PR DESCRIPTION
## Summary

Completes the three follow-ups from PR #1561.

### (1) parseSkillsFramework supports TABLE form + N-tier rubric (commit a77e96e2)

Pre-fix the parser only recognised `### SKILL-NN: name` heading form + 3-tier Emerging/Developing/Secure. CTO/CIO course-refs use TABLE form + 4-tier Foundation/Developing/Practitioner/Distinction → parser silently emitted 0 skills.

Extended:
- `ParsedSkill.tiers: Record<string, string>` (was typed 3-tier; backward-compat)
- `ParsedSkill.tierScheme: string[]` (ordered tier names)
- `KNOWN_TIER_SCHEMES`: three, cto, cefr (unknown schemes accepted with warning)
- New `parseSkillsFrameworkTable()` reads markdown table rows
- Downstream consumers iterate `tierScheme`; CTO goals become "Reach Distinction on X" not "Reach Secure on X"

### (2) Backfill verified live on hf_sandbox (no code change here)

After (1) shipped to VM, ran `scripts/backfill-cto-projection.ts` against hf_sandbox: 30 BehaviorTargets minted live, structurally wiring 10 cross-cutting skills × 3 playbooks.

### (3) Launch blocker for PROJECTION_NO_SKILLS_FRAMEWORK + NO_COURSE_REFERENCE_SOURCE (commit 803d0a4f)

`runProjectionForPlaybook` returns `launchBlockers: []`. Publish gate refuses to mark Playbook PUBLISHED when any blocker present. Two codes today; cleared when any sibling source produced Parameters.

## Verified by

- **Live SQL on hf_sandbox**: `psql -c "SELECT skill_ref, target_value FROM \"BehaviorTarget\" WHERE \"playbookId\" IN (...)"` returned 30 new rows across 3 CTO playbooks (10 cross-cutting skills each: skill_stakeholder_anticipation, skill_risk_articulation, skill_commercial_framing, ...)
- **Live dry-run** of `apps/admin/scripts/backfill-cto-projection.ts --dry-run` on hf-dev VM: returned `params=10, behaviorTargets=10, goalTemplates=10, measureSpec=yes` per playbook (was 0 before)
- **Live wet-run** of `apps/admin/scripts/backfill-cto-projection.ts` on hf-dev VM: real applyProjection writes succeeded — log line `applied: params=+0 bt=+10/~0/-0 cm=+0/~0/-0 lo=+0/~0/-0 goals=10 noop=false` per playbook (params=+0 because the 10 skill_* Parameters were already minted globally; bt=+10 is the new playbook-scope wiring)
- **Vitests** `apps/admin/lib/wizard/__tests__/project-course-reference.test.ts` (36 cases, 6 new for table form) + `apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts` (14 cases, 4 new for launch blockers) — all 50 pass

## Test plan

- [x] All 50 wizard vitests pass
- [x] Live backfill on hf_sandbox produced 30 BehaviorTargets
- [ ] Wire wizard publish-gate UI to read launchBlockers (separate UI ticket)
- [ ] One-off re-instantiation of SKILL-* goals for existing learners enrolled pre-projection (Cyrus, Ulric, etc.)
- [ ] Smoke educator dashboard band-chip UI on next learner call

## Follow-on tickets

1. **Publish-gate UI consumer** — surface launchBlockers in wizard's launch button
2. **One-off learner re-instantiation** — pick up newly-projected Goal templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)