### PR TITLE
feat(wizard): consume launchBlockers — demote to DRAFT + chat surfaces them

### DIFF
--- a/apps/admin/evals/wizard/v5-launch-blockers.yaml
+++ b/apps/admin/evals/wizard/v5-launch-blockers.yaml
@@ -1,0 +1,139 @@
+description: "Wizard V5 — post-create launchBlockers gate (#3 mastery follow-up 2026-06-13)"
+
+# Run with: npx promptfoo eval -c evals/wizard/v5-launch-blockers.yaml --no-cache
+#
+# Tests the "Post-create publish gate (launchBlockers)" section of
+# v5-system-prompt.ts: when create_course's response carries non-empty
+# launchBlockers + playbookStatus: "DRAFT", the assistant MUST refuse the
+# "Ready to launch" affirmation, plainly tell the educator the course is in
+# DRAFT, list each blocker's message, and suggest the fix (typically: add
+# a `## Skills Framework` section to the course-ref doc).
+
+prompts:
+  - id: v5-launch-blockers-prompt
+    label: "V5 — launchBlockers post-create gate"
+    raw: |
+      You are the HumanFirst Studio setup assistant.
+
+      ## Post-create publish gate (launchBlockers)
+
+      `create_course`'s response includes two fields that gate the post-create message:
+      - `playbookStatus`: `"PUBLISHED"` (course is live and learners can use it) OR
+        `"DRAFT"` (course exists but is NOT live).
+      - `launchBlockers`: an array of `{code, message, sourceName?}` items. Non-empty
+        array ⇔ `playbookStatus === "DRAFT"`.
+
+      **When `launchBlockers` is non-empty:**
+      1. DO NOT say "Your course is ready" or "You can start testing" or anything
+         suggesting the course can take learners.
+      2. DO say plainly: "Your course was created as a **DRAFT** — I can't launch it
+         yet because:" then list each blocker's `message` as a bullet.
+      3. For `PROJECTION_NO_SKILLS_FRAMEWORK`: tell the educator to add a
+         `## Skills Framework` section to their course-ref doc with at least one
+         skill and re-upload.
+      4. For `NO_COURSE_REFERENCE_SOURCE`: tell them to upload a course-ref doc.
+      5. NEVER show "Ready to launch" / "Start testing" chips while blockers present.
+      6. The educator's next action is to fix the course-ref + re-run create_course.
+
+      **When `launchBlockers` is empty (the normal path):** behave as before —
+      short success message + action cards.
+
+      ---
+      Tool result from create_course: {{toolResult}}
+      The educator says: {{userMessage}}
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 1500
+
+tests:
+  # ── Test A — PROJECTION_NO_SKILLS_FRAMEWORK blocker ──
+
+  - description: "Test A — DRAFT + no-skills blocker → assistant tells educator to add Skills Framework"
+    vars:
+      toolResult: |
+        {
+          "ok": true,
+          "playbookId": "pb-abc",
+          "playbookStatus": "DRAFT",
+          "launchBlockers": [
+            {
+              "code": "PROJECTION_NO_SKILLS_FRAMEWORK",
+              "sourceName": "course-ref.md",
+              "message": "No parseable `## Skills Framework` -> `### SKILL-NN: Name` section found. Educator dashboard band/tier UI will be flat-zero until at least one skill is declared. Skills Framework is REQUIRED per a-sample-docs/course-reference-template.md."
+            }
+          ]
+        }
+      userMessage: "Great, what's next?"
+    assert:
+      - type: llm-rubric
+        value: |
+          Response mentions DRAFT explicitly. Response surfaces the
+          PROJECTION_NO_SKILLS_FRAMEWORK blocker in plain English
+          (mentions "Skills Framework" or "skills"). Response tells the
+          educator to add the Skills Framework section to the course-ref
+          and re-upload (or similar fix guidance). Response does NOT say
+          "Your course is ready" or "You can start testing" or "Ready to
+          launch". Response does NOT pretend the course is publishable.
+      - type: not-icontains
+        value: "course is ready"
+      - type: not-icontains
+        value: "start testing"
+      - type: not-icontains
+        value: "Ready to launch"
+      - type: icontains
+        value: "DRAFT"
+
+  # ── Test B — NO_COURSE_REFERENCE_SOURCE blocker ──
+
+  - description: "Test B — DRAFT + missing-course-ref blocker → assistant tells educator to upload course-ref"
+    vars:
+      toolResult: |
+        {
+          "ok": true,
+          "playbookId": "pb-def",
+          "playbookStatus": "DRAFT",
+          "launchBlockers": [
+            {
+              "code": "NO_COURSE_REFERENCE_SOURCE",
+              "message": "No COURSE_REFERENCE source linked. Upload at least one course-ref doc before launching."
+            }
+          ]
+        }
+      userMessage: "Done?"
+    assert:
+      - type: llm-rubric
+        value: |
+          Response mentions DRAFT and tells the educator to upload a
+          course-ref doc. Response does NOT say "Your course is ready" or
+          "You can start testing".
+      - type: icontains
+        value: "DRAFT"
+      - type: not-icontains
+        value: "course is ready"
+
+  # ── Test C — empty launchBlockers → normal success path ──
+
+  - description: "Test C — PUBLISHED with empty launchBlockers → normal short success message"
+    vars:
+      toolResult: |
+        {
+          "ok": true,
+          "playbookId": "pb-ghi",
+          "playbookStatus": "PUBLISHED",
+          "launchBlockers": [],
+          "callerId": "caller-1",
+          "callerName": "Test Learner"
+        }
+      userMessage: "Done?"
+    assert:
+      - type: llm-rubric
+        value: |
+          Response is short and acknowledges the course was created
+          successfully. Response does NOT mention DRAFT, blockers, or
+          Skills Framework problems.
+      - type: not-icontains
+        value: "DRAFT"
+      - type: not-icontains
+        value: "blocker"

--- a/apps/admin/lib/chat/v5-system-prompt.ts
+++ b/apps/admin/lib/chat/v5-system-prompt.ts
@@ -596,6 +596,31 @@ You do NOT need domainId — the system resolves it from the institution name au
 Never reason about missing domainId. Just call the tool.
 After success, keep your text SHORT — the UI shows action cards.
 
+### Post-create publish gate (launchBlockers)
+
+\`create_course\`'s response includes two fields that gate the post-create message:
+- \`playbookStatus\`: \`"PUBLISHED"\` (course is live and learners can use it) OR
+  \`"DRAFT"\` (course exists but is NOT live).
+- \`launchBlockers\`: an array of \`{code, message, sourceName?}\` items. Non-empty
+  array ⇔ \`playbookStatus === "DRAFT"\`.
+
+**When \`launchBlockers\` is non-empty:**
+1. DO NOT say "Your course is ready" or "You can start testing" or anything
+   suggesting the course can take learners.
+2. DO say plainly: "Your course was created as a **DRAFT** — I can't launch it
+   yet because:" then list each blocker's \`message\` as a bullet.
+3. For \`PROJECTION_NO_SKILLS_FRAMEWORK\`: tell the educator to add a
+   \`## Skills Framework\` section to their course-ref doc with at least one
+   skill (heading form \`### SKILL-01: Name\` OR table form
+   \`| SKILL-01 | **Name** — desc | tier1 | tier2 | tier3 |\`) and re-upload.
+4. For \`NO_COURSE_REFERENCE_SOURCE\`: tell them to upload a course-ref doc.
+5. NEVER show "Ready to launch" / "Start testing" chips while blockers present.
+6. The educator's next action is to fix the course-ref + re-run create_course
+   (which is idempotent and will re-publish once blockers clear).
+
+**When \`launchBlockers\` is empty (the normal path):** behave as before —
+short success message + action cards.
+
 ## Amendment handling
 
 Users can click items on the "Building Your Course" panel to review settings.

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course.ts
@@ -66,7 +66,7 @@ try {
   if (!newPathResult.ok) {
     return execute(input, userId, newPathResult.recurse.setupData);
   }
-  const { playbookId, subjectId: subjectIdFromScaffold, subjectIdsToLink, resolvedWelcome, mediaLookup } = newPathResult.state;
+  const { playbookId, subjectId: subjectIdFromScaffold, subjectIdsToLink, resolvedWelcome, mediaLookup, launchBlockers } = newPathResult.state;
   // Stages 7+8 use `subject` (the Prisma row shape). Re-fetch to preserve
   // type compatibility — orchestrator-level cost is one extra DB read,
   // which the next stage extracts away.
@@ -90,6 +90,7 @@ try {
     resolvedWelcome,
     mediaLookup,
     enrollState,
+    launchBlockers,
   });
 } catch (err) {
   // #338 followup — log the error server-side so failed create_course

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts
@@ -22,6 +22,7 @@
 import type { WizardToolExec } from "../../_shared/types";
 import type { ResolvedCreateCourseContext } from "./_context";
 import type { EnrollState } from "./_enroll";
+import type { LaunchBlocker } from "./_new-path";
 
 export interface LessonPlanArgs {
   ctx: ResolvedCreateCourseContext;
@@ -31,12 +32,20 @@ export interface LessonPlanArgs {
   resolvedWelcome: string | null;
   mediaLookup: Map<string, { fileName: string; title: string | null }>;
   enrollState: EnrollState;
+  /**
+   * Launch blockers from projection (#3 — 2026-06-13). Surfaced in the
+   * tool response under `launchBlockers`. When non-empty, the chat
+   * assistant MUST refuse the "Ready to launch" affirmation and tell
+   * the educator what to fix (typically: the uploaded course-ref has
+   * no parseable Skills Framework).
+   */
+  launchBlockers: LaunchBlocker[];
 }
 
 export async function generateLessonPlanAndReturn(
   args: LessonPlanArgs,
 ): Promise<WizardToolExec> {
-  const { ctx, playbookId, subject, subjectIdsToLink, resolvedWelcome, mediaLookup, enrollState } = args;
+  const { ctx, playbookId, subject, subjectIdsToLink, resolvedWelcome, mediaLookup, enrollState, launchBlockers } = args;
   const { input, setupData, domainId, subjectDiscipline, courseName, interactionPattern, packSubjectIds } = ctx;
   const { caller, callerName, demoCaller, demoName, cohort, joinToken } = enrollState;
   const { prisma } = await import("@/lib/prisma");
@@ -174,11 +183,22 @@ export async function generateLessonPlanAndReturn(
     distinct: ["sourceId"],
   });
 
+  // (#3 2026-06-13) Publish-time launch blockers. When non-empty the
+  // playbook has been demoted back to DRAFT inside _new-path.ts and the
+  // course is NOT available to learners. The chat assistant reads this
+  // field and tells the educator what to fix.
+  //
+  // `playbookStatus` is computed deterministically here so the chat does
+  // not need a second DB lookup to render "DRAFT — fix course-ref first"
+  // vs "PUBLISHED — ready to test" banners.
+  const playbookStatus = launchBlockers.length > 0 ? "DRAFT" : "PUBLISHED";
+
   return {
     content: JSON.stringify({
       ok: true,
       domainId,
       playbookId,
+      playbookStatus,
       subjectId: subject.id,
       callerId: caller.id,
       callerName,
@@ -191,6 +211,9 @@ export async function generateLessonPlanAndReturn(
         subjectNames: linkedSubjects.map((ls) => ls.subject.name),
         documentCount: linkedSources.length,
       },
+      // (#3) Empty array when the course is publishable; non-empty when
+      // the educator needs to fix the course-ref before learners can use it.
+      launchBlockers,
     }),
   };
 }

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts
@@ -21,6 +21,21 @@ import { applyStudentExperienceConfig } from "../../_shared/apply-student-experi
 import type { ResolvedCreateCourseContext } from "./_context";
 import { buildNewConfigUpdate } from "./_new-config-merge";
 
+/**
+ * Publish-time launch blocker (#3 — 2026-06-13). Emitted by
+ * `runProjectionForPlaybook` and forwarded through the create_course
+ * tool response so the wizard chat assistant can surface them to the
+ * educator. When non-empty the Playbook is demoted back to DRAFT
+ * inside `newCourseScaffoldPath` and the chat's "Ready to launch" cue
+ * is replaced by a course-ref-fix nudge.
+ */
+export interface LaunchBlocker {
+  code: string;
+  sourceContentId?: string;
+  sourceName?: string;
+  message: string;
+}
+
 export interface NewPathState {
   playbookId: string;
   subjectId: string;
@@ -29,6 +44,8 @@ export interface NewPathState {
   mediaLookup: Map<string, { fileName: string; title: string | null }>;
   /** Resolved onboarding flow phases (after media attachment, if any). */
   finalFlowPhases: { phases: Array<Record<string, unknown>> } | null;
+  /** Launch blockers from projection — see {@link LaunchBlocker}. */
+  launchBlockers: LaunchBlocker[];
 }
 
 export type NewPathResult =
@@ -285,9 +302,29 @@ export async function newCourseScaffoldPath(
 
   // 7d. COURSE_REFERENCE projection (#338) — derive CurriculumModule,
   //     BehaviorTargets, Parameters, Goal templates. Race-safe + best-effort.
+  //
+  // The projection result's `launchBlockers` is the publish-time gate (#3
+  // 2026-06-13). When non-empty the playbook is demoted back to DRAFT —
+  // `scaffoldDomain` already published it in the same call chain, before
+  // we knew whether the course-ref had a parseable Skills Framework. The
+  // blockers are forwarded to the educator via the tool response so the
+  // chat assistant can surface them in plain language.
+  let launchBlockers: Array<{ code: string; sourceContentId?: string; sourceName?: string; message: string }> = [];
   try {
     const { runProjectionForPlaybook } = await import("@/lib/wizard/run-projection-for-playbook");
-    await runProjectionForPlaybook(playbookId);
+    const projectionResult = await runProjectionForPlaybook(playbookId);
+    launchBlockers = projectionResult.launchBlockers ?? [];
+    if (launchBlockers.length > 0) {
+      // Demote to DRAFT — keep the course visible to the educator for fixes
+      // but refuse to expose it to learners until the blockers clear.
+      await prisma.playbook.update({
+        where: { id: playbookId },
+        data: { status: "DRAFT", publishedAt: null },
+      });
+      console.warn(
+        `[projection] create_course: demoting playbook=${playbookId} to DRAFT — ${launchBlockers.length} launch blocker(s): ${launchBlockers.map((b) => b.code).join(", ")}`,
+      );
+    }
   } catch (err) {
     console.error(
       `[projection] create_course: projection failed for playbook=${playbookId} — course still created. Error:`,
@@ -395,6 +432,7 @@ export async function newCourseScaffoldPath(
       resolvedWelcome,
       mediaLookup,
       finalFlowPhases,
+      launchBlockers,
     },
   };
 }

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts
@@ -169,9 +169,24 @@ export async function reuseExistingCoursePath(
   // branch (step 7d below). Re-applying the projection on an
   // already-set-up playbook is idempotent, so this is safe even
   // when the user is just tweaking config on an existing course.
+  //
+  // (#3 2026-06-13) launchBlockers gate — same semantics as _new-path.ts.
+  // When non-empty the playbook is demoted back to DRAFT and the chat
+  // surfaces them to the educator via the response payload.
+  let reuseLaunchBlockers: Array<{ code: string; sourceContentId?: string; sourceName?: string; message: string }> = [];
   try {
     const { runProjectionForPlaybook } = await import("@/lib/wizard/run-projection-for-playbook");
-    await runProjectionForPlaybook(existingPlaybookId);
+    const projectionResult = await runProjectionForPlaybook(existingPlaybookId);
+    reuseLaunchBlockers = projectionResult.launchBlockers ?? [];
+    if (reuseLaunchBlockers.length > 0) {
+      await prisma.playbook.update({
+        where: { id: existingPlaybookId },
+        data: { status: "DRAFT", publishedAt: null },
+      });
+      console.warn(
+        `[projection] create_course (existing path): demoting playbook=${existingPlaybookId} to DRAFT — ${reuseLaunchBlockers.length} launch blocker(s): ${reuseLaunchBlockers.map((b) => b.code).join(", ")}`,
+      );
+    }
   } catch (err) {
     console.error(
       `[projection] create_course (existing path): projection failed for playbook=${existingPlaybookId} — config update still applied. Error:`,
@@ -200,8 +215,10 @@ export async function reuseExistingCoursePath(
         content: JSON.stringify({
           ok: true,
           playbookId: existingPlaybookId,
+          playbookStatus: reuseLaunchBlockers.length > 0 ? "DRAFT" : "PUBLISHED",
           callerId: existingCallerId,
           existingCourse: true,
+          launchBlockers: reuseLaunchBlockers,
         }),
       },
     };
@@ -384,9 +401,11 @@ export async function reuseExistingCoursePath(
       content: JSON.stringify({
         ok: true,
         playbookId: existingPlaybookId,
+        playbookStatus: reuseLaunchBlockers.length > 0 ? "DRAFT" : "PUBLISHED",
         callerId: caller.id,
         callerName,
         existingCourse: true,
+        launchBlockers: reuseLaunchBlockers,
       }),
     },
   };


### PR DESCRIPTION
## Summary

PR #1564 introduced `runProjectionForPlaybook`'s `launchBlockers` field. Nothing read it. This PR wires the wizard's `create_course` tool to:

1. **Demote to DRAFT** when blockers present (was: auto-published by `scaffoldDomain` immediately, so educators got a "Course ready!" message + a flat-zero dashboard)
2. **Surface blockers in the chat** via the tool response's new `playbookStatus` + `launchBlockers` fields
3. **System prompt** instructs the assistant to refuse "Ready to launch / Start testing" framing while blockers present + tell the educator what to fix

## Market test courses audit — all 6 pass

Confirmed each market-test course-ref declares a parseable Skills Framework:

| Course | `## Skills Framework` | Skills | Format | Outcomes |
|---|---|---|---|---|
| IELTS Speaking | ✓ | 4 | heading 3-tier | 8 |
| Big Five | ✓ | 3 | heading 3-tier | 16 |
| Seducing Strangers | ✓ | 3 | heading 3-tier | 16 |
| CTO Revision Aid | ✓ | 10 | **table 4-tier** | 26 |
| CTO Pop Quiz | ✓ | 10 | **table 4-tier** | 10 |
| CTO Exam Assessment | ✓ | 10 | **table 4-tier** | 10 |

The CTO 4-tier table form was unlocked by PR #1564's parser extension.

## Verified by

- **Live SQL on hf_sandbox** after PR #1564 backfill: 30 BehaviorTargets minted across 3 CTO playbooks (10 cross-cutting skills each)
- **Audit grep** on each market-test course-ref: `grep -c "^## Skills Framework"` returns 1 for all 6 files; SKILL row counts above match course-ref source-of-truth
- **Unit tests** `apps/admin/lib/wizard/__tests__/project-course-reference.test.ts` (36 cases) + `apps/admin/lib/wizard/__tests__/run-projection-for-playbook.test.ts` (14 cases) + `apps/admin/tests/lib/goals-track-progress.test.ts` (60 + 15 skipped) + `apps/admin/tests/lib/goals-compound-ref-resolver.test.ts` (10) + `apps/admin/tests/lib/goals-strategy-registry-aliases.test.ts` (7) — all 112 pass
- **TypeScript** `npx tsc --noEmit` clean on all touched files (pre-existing errors in unrelated files only)
- **New eval** `apps/admin/evals/wizard/v5-launch-blockers.yaml` with 3 promptfoo test cases (PROJECTION_NO_SKILLS_FRAMEWORK / NO_COURSE_REFERENCE_SOURCE / normal path) — run via `npx promptfoo eval -c evals/wizard/v5-launch-blockers.yaml --no-cache`

## Test plan

- [x] Unit + tsc green
- [x] Market-test course audit (all 6 produce parseable Skills Framework)
- [ ] Run promptfoo eval `npx promptfoo eval -c apps/admin/evals/wizard/v5-launch-blockers.yaml --no-cache`
- [ ] Smoke on hf-dev: upload a course-ref WITHOUT a Skills Framework section, click "Ready to create" → chat should say "DRAFT — add Skills Framework"
- [ ] Smoke on hf-dev: upload a valid course-ref → chat says success + dashboard works

## What's NOT in this PR

- **One-off learner re-instantiation** — Cyrus / Ulric have no SKILL-* Goal rows because they were enrolled BEFORE the projection ran. The user said to skip this. New enrollments get them automatically via `instantiatePlaybookGoals`.
- **Pre-create dry-run** — currently the gate fires DURING create_course (course is created in DRAFT). A nicer UX would dry-run projection BEFORE create_course and block the call entirely. Deferred — the post-create demote-to-DRAFT is the publish-time gate the user asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)