### PR TITLE
chore(courseredesign): land parked-epic + handoff docs

### DIFF
--- a/docs/draft-issues/followon-designer-renderers-v2.md
+++ b/docs/draft-issues/followon-designer-renderers-v2.md
@@ -1,0 +1,91 @@
+# DRAFT EPIC: Designer Renderers v2 + Snapshot Tab
+
+> **Status:** parked until structural foundation epic ships Story S4 (Designer shell + empty `PREVIEW_RENDERERS` registry).
+> **Activation:** file as GitHub epic the day S4 merges.
+> **Draft author:** 2026-06-13 session "CourseReDesign"; corrections folded in after TL re-review.
+
+## TL;DR
+
+~18 small UI stories. Most read an existing transform output from `ComposedPrompt.inputs.composition` and render it via the `registerPreviewRenderer<S>()` API from S4. A 4-story subset (Group A.5) creates new composer sections first because the source composer doesn't emit them today.
+
+## Why this exists
+
+The structural foundation epic (S1–S5) ships:
+- **S1**: the discriminated `ComposeSection` union (14 members) + `kind: "config" | "runtime"` discriminator + key→section + loader→section maps
+- **S2**: section-grain staleness hashes
+- **S3**: section-scoped incremental regen
+- **S4**: tri-pane Designer shell + **empty** `PREVIEW_RENDERERS` registry
+- **S5**: caller-detail `?v=3` beta route + `WILL_RETIRE` audit registry
+
+…but ships zero new visible renderers. PreviewLens continues to hand-wire its 8 existing sections inline. The educator sees no improvement.
+
+This epic flips the switch. It migrates the 8 hand-wired sections into the registry, adds the 10 renderers for sections the composer already emits, adds 2 stories per item for the 2 items where the composer doesn't yet emit the section, and adds the Snapshot tab content for caller-detail v3.
+
+## Scope — ~18 stories at ~½–1 day each
+
+### Group A — Missing renderers for sections the composer ALREADY emits (10)
+
+Each reads `ComposedPrompt.inputs.composition` via the S4 registry. No new loaders, no pipeline changes.
+
+| # | Section (registry key) | Renderer surfaces | Data source |
+|---|---|---|---|
+| 1 | `firstCallMode` (kind: config) | "This Call 1 runs as Baseline Assessment" chip | `Playbook.config.firstCallMode` |
+| 2 | `modePolicy` (kind: config) | demo-policy / useFreshMastery / maxMasteryTier / evidence-first banner | `Playbook.config` |
+| 3 | `loMastery` | per-LO mastery chips inside a module bubble | `lo_mastery:{moduleId}:{loRef}` CallerAttribute keys |
+| 4 | `instructions` sub-render (goalAdaptation) | per-goal LOW/MID/HIGH guidance sticky | `instructions.session_guidance` (already merged by `goalAdaptationGuidance()`) |
+| 5 | `instructions` sub-render (goal evidence) | "You grew on LO3 — your DR/BC framing is much sharper" | `Goal.progressMetrics.progress.{evidence, tier, band, callId, at}` |
+| 6 | `behaviorTargets` sub-render (skillBands) | skill band + EMA delta + callsUsed card | `CallerTarget.currentScore` + banding presets |
+| 7 | `personality` | personality snippet for Big-Five courses | `CallerPersonalityProfile` + `personalityDecayHalfLifeDays` |
+| 8 | `contentTrust` | "Tax facts expire in 12 days" amber chip | `subjectSources` loader + `transforms/trust.ts::checkFreshness` `FreshnessWarning` |
+| 9 | `carryOverActions` | "From last call: complete worksheet X" bubble | `CallAction` (HOMEWORK / SEND_MEDIA / TASK) |
+| 10 | `priorCallFeedback` | recap-depth indicator + admin warning on dry-run trace (per Q8 ruling — NOT a Preview chip) | `recapSynthesisCache` + `PRIOR_CALL_RECAP_RICH_DEPTH_ENABLED` env |
+
+### Group A.5 — New composer sections (loader + transform + seed-sync prerequisite) (4)
+
+These items from the original Q1 audit have **no backing composer section today**. The Q1 audit gap is deeper than "missing renderer" — the composer doesn't emit them at all. A renderer slice cannot ship until each gets a loader + transform + COMP-001 seed-sync update first.
+
+| # | New section | Prerequisite story | Renderer story |
+|---|---|---|---|
+| 11 | `conversationArtifacts` (loader + transform + seed-sync) | `SectionDataLoader.ts::registerLoader("conversationArtifacts", …)` + `transforms/artifacts.ts` + new `outputKey: "conversationArtifacts"` in `getDefaultSections()` + COMP-001 spec JSON update + add `"conversationArtifacts"` to `ComposeSection` union + section map entries + loader map entry | Quote-worthy lines rendered as a bubble in Preview |
+| 12 | `memoryDeltas` (loader + transform + seed-sync) | New loader computing `{ added: CallerMemory[], updated: CallerMemory[] }` between most-recent call and prior call + transform + new section + COMP-001 spec update + same union/map updates | "New facts learned this call" sticky-note in Preview |
+
+**Each item = 2 stories** (loader+transform = 1, renderer = 1). Total Group A.5 = 4 stories.
+
+### Group B — Registry migration + infrastructure (2)
+
+| # | Story |
+|---|---|
+| 13 | Migrate the 8 hand-wired PreviewLens sections into the registry — behaviour-preserving; deletes inline rendering code in `PreviewLens.tsx`; tests assert byte-identical output |
+| 14 | Renderer testing harness + Storybook fixtures for the registry |
+
+### Group C — Snapshot tab content for caller-detail v3 (4+)
+
+| # | Story |
+|---|---|
+| 15 | Snapshot landing tab — composes existing data: trajectory sparklines + "who we think they are" with interpretations + adapt panel + LO heatmap + last-call decisions block. Drills into existing tabs (Modules, Profile, Adaptation, Calls). |
+| 16 | Per-LO heatmap drill from Modules — reads `lo_mastery:*` directly |
+| 17 | DISC/COACH/COMP per-learner sub-skill cards — new `/api/callers/[id]/sub-skills` route |
+| 18 | "Why this call?" panel — reads `scheduler:last_decision` + workingSet from compose trace |
+| 19+ | Render `Parameter.interpretationHigh/Low` everywhere personality + traits render — schema fields already exist; never rendered |
+
+## Out of scope (explicit non-goals)
+
+- The 9 sprinkles (D1–D9 from master plan) — they're separate small wins
+- Dead-key cleanup (5 orphans) — separate 3-phase deprecate-observe-delete workstream
+- Migration of the 14 existing CourseDesignConsole lenses into the Inspector slot — third epic, after Renderers v2 ships
+- IELTS-specific UI — separate course-level concern
+- New loaders / pipeline stages / schema changes are out of scope EXCEPT in Group A.5 where loader+transform+seed-sync is the explicit deliverable for `conversationArtifacts` and `memoryDeltas`
+
+## Activation checklist
+
+- [ ] Structural foundation epic Story S4 merged (`PREVIEW_RENDERERS` registry exported)
+- [ ] BA agent run to groom this draft into a real epic with sized child issues
+- [ ] Tech Lead review for any data-source assumptions that drifted between draft and ship date
+- [ ] File epic; reference this draft as the source-of-truth
+
+## References
+
+- Source session: 2026-06-13 "CourseReDesign"
+- Master plan: 4 workstreams (A Designer, B dead keys, C caller-detail v3, D sprinkles)
+- Structural foundation BA epic: 5 stories, 5 remaining TL questions (Q1, Q2, Q3, Q5 pending; Q4/Q6/Q7/Q8 RULED), current as of 2026-06-13
+- Q1 audit baseline: PreviewLens covered 8 of 30 controls; TL re-review reshaped 19→14 sections + flagged 2 items needing new composer sections

--- a/docs/draft-issues/handoff-skills-framework-heatmap.md
+++ b/docs/draft-issues/handoff-skills-framework-heatmap.md
@@ -1,0 +1,126 @@
+# Handoff — Skills Framework × Mastery Heatmap UI
+
+> **From:** CourseReDesign epic session (#1555 / S1 just merged via PR #1563, commit `fe841b6d`)
+> **To:** the parallel session that landed #1564 (N-tier Skills Framework) / #1565 (launchBlockers consume) / #1566 (eval looseners)
+> **Date:** 2026-06-13
+> **Purpose:** Lock in the visual-and-data contract between your structural Skills Framework work and the upcoming mastery-heatmap renderer in the CourseReDesign follow-on epic. Read once, no action needed today — picks up when you've finished the framework round.
+
+## What I'm flagging
+
+Your N-tier Skills Framework (#1564) is the structural backbone we want to render in the educator-facing **mastery heatmap** UI that's queued for the CourseReDesign follow-on epic ("Designer Renderers v2 + Snapshot Tab"). The educator's mental model — and the request we got from the operator — is:
+
+> *"Show me a Skill, let me drill into Tier, drill into LO, drill into per-learner trajectory — same visual idiom at every level."*
+
+That maps 1:1 onto your hierarchy:
+
+```
+Course (#1555 epic context)
+  └─ Skill            (your SKILL-NN headings, N-tier)
+       └─ Tier         (Emerging / Developing / Secure today; N-tier-table-form per #1564)
+            └─ LO       (descriptor / behaviour per tier)
+                 └─ Per-learner mastery state  (CallerAttribute `lo_mastery:{moduleId}:{loRef}`)
+```
+
+The renderer wants four data invariants from your work; if any change as you keep iterating, please ping me and I'll re-scope. Detail below.
+
+## Three views, one component — Course Details / Cohort / Single Learner
+
+Same heatmap primitive (9-cell sparkline strip + tooltip + drill) renders in **three lenses**, each with different cell semantics:
+
+| Lens | Where | What a cell means | Hierarchy expansion |
+|---|---|---|---|
+| **Course Details** | `/x/courses/[id]` (educator's structural view) | "Does this LO exist in the curriculum / what's its tier band / how taught" — structural, no learner data yet | Skill ▸ Tier ▸ LO. Used to *design* the framework. |
+| **Cohort View** | `/x/courses/[id]/learners` (or follow-on Snapshot tab equivalent) | "% of cohort that have mastered this LO" or "mean mastery score" across the cohort over time | Skill row aggregates all tiers; tier row aggregates all LOs; LO row shows cohort distribution sparkline |
+| **Single Learner** | `/x/callers/[id]?v=3` (Snapshot tab, follow-on epic) | "This learner's mastery score, call-by-call" — time × call number | Same hierarchy, but cells are per-call mastery readings for one learner |
+
+The component is the **same**; the three lenses differ in (a) data source, (b) cell color/value scale, (c) tooltip copy. We keep the visual idiom identical so educators recognise the pattern immediately when they move from "designing my course" → "watching my cohort" → "auditing one learner".
+
+## The visual idiom (so you can sanity-check it against #1564's shape)
+
+Same 9-cell sparkline-style heatmap strip at every layer, lazy-unfolded:
+
+```
+SKILL-03 · Lexical Resource                                ⌃ collapse
+   cohort:  ▂▃▃▄▄▅▅▅▅   48% mastered
+   ┌─ Tiers ─────────────────────────────────────────────────────────┐
+   │  Emerging      ▇▇▇▇▇▇▇▇▇  94% (16 of 17 learners ≥ Emerging)    │
+   │  Developing    ▃▄▄▅▅▆▆▆▇  68% (11 of 17)        ⌄ expand        │
+   │  Secure        ▁▁▂▂▂▃▃▃▃  31% (5 of 17)         ⌄ expand        │
+   │     ┌─ Developing LOs (drill open) ────────────────────────┐   │
+   │     │  LO-03A "use synonyms for common topics"  ▇▆▆▆▆▅▅▅▅ │   │
+   │     │  LO-03B "paraphrase when stuck"           ▃▃▄▄▄▅▅▅▆ │   │
+   │     │  LO-03C "less reliance on common words"   ▁▁▂▂▂▃▃▃▃ │   │
+   │     │  → click LO row → per-learner heatmap                │   │
+   │     └──────────────────────────────────────────────────────┘   │
+   └────────────────────────────────────────────────────────────────┘
+```
+
+The 9-cell strip displays whatever axis is most useful at that lens × layer:
+
+| Lens | Skill row | Tier row | LO row | Cell semantics |
+|---|---|---|---|---|
+| **Course Details** | static colour (designed) | static colour | static colour | tier-band colour from the framework spec — no learner data; the strip is symbolic |
+| **Cohort** | time × % of cohort at-or-above tier | time × % of cohort that have mastered any LO in this tier | time × % of cohort that have mastered this LO | mastery diffusion across the cohort |
+| **Single Learner** | aggregate trajectory across skill | aggregate across tier | call-by-call mastery on this LO | personal progression |
+
+Tooltip copy adapts per lens. Click affordances stay identical (expand / collapse / drill into next level).
+
+## 4 invariants we'll consume — please don't break these silently
+
+1. **Skill identifier is stable + addressable.** The renderer needs `SKILL-01`-style stable IDs that survive course edits. Today these come out of `parseSkillsFramework` in `apps/admin/lib/wizard/project-course-reference.ts`. If you ever switch to UUIDs / DB-rowids, give us a logical-id resolver helper (mirror of `lib/curriculum/resolve-module.ts`).
+2. **Tier ordering is preserved.** Emerging → Developing → Secure is the canonical bottom-to-top order. The N-tier-table-form change in #1564 widens this past 3 — fine — but please publish the canonical order somewhere we can import (an `as const` array would be enough). The heatmap renders rows in that order.
+3. **LOs roll up to a single tier per skill.** An LO belongs to one Tier of one Skill — not multiple. If that ever loosens (e.g. an LO crosses tiers), we need a roll-up rule before the renderer can compute "% of learners ≥ this tier". A short JSDoc on whichever function emits the LO→Tier link is enough.
+4. **Mastery state stays on `CallerAttribute lo_mastery:{moduleId}:{loRef}`.** The recent canonical-key migration is on the goals-progress side; the renderer reads from `lo_mastery:*` directly. If projection ever proposes moving mastery state elsewhere, please loop me in — it's load-bearing for the heatmap drill and would also affect S1's `PIPELINE_STATE_SECTION_LOADERS` (`loMastery → ["callerAttributes"]`).
+
+## What we'll contribute back (so you know the shape)
+
+The renderer + its three lenses sit in the **follow-on epic** — `docs/draft-issues/followon-designer-renderers-v2.md`, **Group A → `loMastery` renderer**, plus the Snapshot tab "LO mastery (heatmap)" block, plus a new Cohort view block. The roll-up arithmetic is ours; we'll consume your hierarchy. Slice estimates (revised for three lenses):
+
+| Slice | Effort | Lens | Status |
+|---|---|---|---|
+| Heatmap component primitive (the 9-cell strip + tooltip + drill) — Storybook-first, lens-agnostic | S (3h) | (all) | queued in follow-on epic |
+| **Course Details lens** — Skills + Tiers + LOs structural view; no learner data | S (3h) | Course Details | queued |
+| **Cohort lens** — Skill row aggregating cohort %; tier + LO drills | M (5h) | Cohort | queued |
+| **Single Learner lens** — Snapshot block, per-call trajectory | S (3h) | Single Learner | queued; also part of Snapshot tab work |
+| Tier unfold (shared across lenses) | S (3h) | (all) | queued |
+| LO unfold + drill (shared) | M (6h) | (all) | queued |
+
+Not blocked on you — but if your Skills Framework iteration changes any of the 4 invariants above, please ping so I can re-scope before grooming.
+
+## Where it interlocks with the CourseReDesign foundation (just-shipped #1556)
+
+S1 (#1556 / merged commit `fe841b6d`) introduced a `ComposeSection` taxonomy. The `loMastery` section (`PIPELINE_STATE_SECTION_LOADERS["loMastery"] = ["callerAttributes"]`) is the slot the renderer will plug into. Three downstream stories from the foundation queue gate the renderer:
+
+| Story | Why it gates the heatmap |
+|---|---|
+| **#1557 S2** field staleness | Lets the educator see when their LO list is stale vs the latest learner mastery state — banner-level signal in the heatmap header |
+| **#1558 S3** section-scoped regen | "Regenerate just this skill's LO mastery section" — actionable from the heatmap |
+| **#1559 S4** Designer shell + `PREVIEW_RENDERERS` registry | The renderer registers under `loMastery` here once S4 ships |
+
+You don't need to touch any of these — they're queued for me. Just FYI so you know the path.
+
+## Quick consistency check you can run on your side
+
+If you want a 30-second test that #1564's parser still aligns with the renderer's expectations: run `parseSkillsFramework` against `a-sample-docs/course-reference-template.md`'s `## Skills Framework` block and confirm the result shape carries (a) stable skill IDs, (b) tier-ordered descriptors, (c) clear LO → Tier attribution. If any of those three are degraded or planned to change, drop a note in this file under "Drift detected" and I'll re-shape the renderer brief.
+
+## Open questions I'd like your ruling on (when you're back)
+
+1. **N-tier — is the order operator-defined or fixed?** If a course can declare `Beginner → Intermediate → Advanced` instead of `Emerging → Developing → Secure`, the renderer needs to read the tier names from the parser output, not from a hardcoded literal. Confirm where the canonical list lives post-#1564.
+2. **Empty tier rows — render or hide?** When a tier has 0 LOs (early-edit state) the renderer can either show "(no descriptors yet)" or hide the row. Educator-preference call — what's your inclination from the projection side?
+3. **Launch blockers + heatmap interaction.** #1565 demotes courses to DRAFT when launchBlockers fire. Should the heatmap render at all on DRAFT courses, or show a "Course not yet published" placeholder? I'd lean "render but with a `DRAFT` watermark badge" — same UX as the Course Design Console Preview lens treats DRAFT mode.
+
+## TL;DR for the next session that opens this file
+
+- Your Skills Framework hierarchy from #1564 is the data scaffold; the educator-facing **mastery heatmap** consumes it across **three lenses** — Course Details, Cohort, Single Learner — using one shared primitive.
+- 4 invariants we depend on — don't break silently (stable skill IDs, tier order, LO→Tier 1:1, mastery on `CallerAttribute lo_mastery:*`).
+- Renderer lives in the CourseReDesign follow-on epic; not blocked on you; ping me if any of the 4 invariants shift.
+- 3 open questions worth your ruling: N-tier ordering source, empty-tier handling, DRAFT-mode rendering.
+
+## References
+
+- This handoff: `docs/draft-issues/handoff-skills-framework-heatmap.md`
+- Follow-on epic scope: `docs/draft-issues/followon-designer-renderers-v2.md` (Group A `loMastery` renderer + Snapshot tab heatmap block)
+- Foundation epic just shipped: #1555 epic, #1556 S1 (commit `fe841b6d`)
+- Your work: #1564 N-tier Skills Framework, #1565 launchBlockers consume, #1566 eval looseners
+- Course-ref Skills Framework spec lives in `a-sample-docs/course-reference-template.md` lines 252+ ("## Skills Framework")
+- Parser implementation: `apps/admin/lib/wizard/project-course-reference.ts::parseSkillsFramework`


### PR DESCRIPTION
## Summary

Two CourseReDesign session artifacts landed on main so the parallel Skills Framework session (and future-me) can grep them rather than relying on session memory.

Part of #1555

## What ships

- **`docs/draft-issues/followon-designer-renderers-v2.md`** — parked follow-on epic scope (~18 stories). Activates the day S4 (#1559) merges. Group A.5 explicitly enumerates the 2 items (`conversationArtifacts`, `memoryDeltas`) that need new composer sections (loader + transform + COMP-001 seed-sync) BEFORE a renderer slice can ship — the Q1 audit gap was deeper than "missing renderer" for those two.

- **`docs/draft-issues/handoff-skills-framework-heatmap.md`** — handoff for whoever picks up the parallel Skills Framework session that landed #1564 / #1565 / #1566. Documents the **3-lens heatmap UI** (Course Details / Cohort / Single Learner) that consumes the N-tier hierarchy, the 4 invariants we depend on, and 3 open questions for that session to rule on (N-tier ordering source, empty-tier handling, DRAFT-mode rendering).

## Pure docs

No code change. No schema change. No deploy needed.

## Test plan

- [x] `ls docs/draft-issues/` — both files present
- [x] Self-contained — each doc reads cold without conversation context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
