### PR TITLE
docs(glossary): canonical Skills/LOs/TPs/Mastery vocab + /x/help/glossary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,7 @@ These memory files are kept in sync with the codebase. Consult them first.
 | [memory/holographic.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/holographic.md) | 8 sections, state shape, permissions, Phase 2 pattern | Section added/changed, new Phase 2 component |
 | [memory/async-patterns.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/async-patterns.md) | useTaskPoll / useAsyncStep / WizardShell / spinner-vs-glow | New hook, polling pattern, wizard framework change |
 | [memory/extraction.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/extraction.md) | DocumentTypes, resolution chain, ContentAssertion shape, trust levels | New DocumentType, extraction category, new resolveExtractionConfig caller |
+| [`docs/glossary-skills-mastery.md`](./docs/glossary-skills-mastery.md) | Canonical vocab: Course/Source/Skill/LO/TP/Mastery. Educator label ↔ DB shape. Surfaced at `/x/help/glossary`. | New entity in the 7 layers; UI label change; new tier scheme; new mastery store |
 
 ### Hard-prereq contract docs (read before touching the surface)
 

--- a/apps/admin/app/x/help/glossary/help-glossary.css
+++ b/apps/admin/app/x/help/glossary/help-glossary.css
@@ -1,0 +1,123 @@
+.hf-help-glossary-body {
+  background: var(--surface-primary);
+  border-radius: 16px;
+  padding: 32px;
+  border: 1px solid var(--border-default);
+  margin-top: 16px;
+}
+
+.hf-help-glossary-body h1 {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-top: 32px;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.hf-help-glossary-body h1:first-child {
+  margin-top: 0;
+}
+
+.hf-help-glossary-body h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 28px;
+  margin-bottom: 12px;
+}
+
+.hf-help-glossary-body h3 {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 20px;
+  margin-bottom: 8px;
+}
+
+.hf-help-glossary-body p {
+  color: var(--text-primary);
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.hf-help-glossary-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 13px;
+}
+
+.hf-help-glossary-body th,
+.hf-help-glossary-body td {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-default);
+  vertical-align: top;
+}
+
+.hf-help-glossary-body th {
+  background: var(--surface-secondary);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.hf-help-glossary-body code {
+  background: var(--surface-secondary);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: 'SF Mono', Monaco, Consolas, monospace;
+  color: var(--text-primary);
+}
+
+.hf-help-glossary-body pre {
+  background: var(--surface-secondary);
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 16px 0;
+}
+
+.hf-help-glossary-body pre code {
+  background: transparent;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.hf-help-glossary-body blockquote {
+  border-left: 3px solid var(--accent-primary);
+  padding: 8px 16px;
+  margin: 16px 0;
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+  color: var(--text-primary);
+  font-style: normal;
+}
+
+.hf-help-glossary-body hr {
+  border: 0;
+  border-top: 1px solid var(--border-default);
+  margin: 32px 0;
+}
+
+.hf-help-glossary-body ul,
+.hf-help-glossary-body ol {
+  padding-left: 24px;
+  margin: 12px 0;
+}
+
+.hf-help-glossary-body li {
+  margin-bottom: 6px;
+  color: var(--text-primary);
+}
+
+.hf-help-glossary-body a {
+  color: var(--accent-primary);
+  text-decoration: none;
+}
+
+.hf-help-glossary-body a:hover {
+  text-decoration: underline;
+}

--- a/apps/admin/app/x/help/glossary/page.tsx
+++ b/apps/admin/app/x/help/glossary/page.tsx
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import "./help-glossary.css";
+
+/**
+ * Glossary — Courses, Skills, LOs, TPs, Mastery.
+ *
+ * Single source of truth for the educator + engineer vocabulary used across
+ * course design, skill measurement, and learner progress. Maintained as
+ * `docs/glossary-skills-mastery.md`; this page reads the markdown at request
+ * time so any commit to the doc is live immediately — no rebuild needed.
+ *
+ * Surfaced in the help bank at `/x/help/glossary` and indexed by Cmd+K via
+ * `lib/help/page-help.ts`.
+ *
+ * Auth: open to all signed-in roles (vocabulary, not data).
+ */
+
+export const dynamic = "force-dynamic";
+
+const GLOSSARY_PATH = "docs/glossary-skills-mastery.md";
+
+function loadGlossary(): { content: string; lastModified: string } {
+  const repoRoot = resolve(process.cwd(), "..", "..");
+  const fullPath = resolve(repoRoot, GLOSSARY_PATH);
+  const content = readFileSync(fullPath, "utf-8");
+  // Strip the front-matter callout block so the page header doesn't double up.
+  return { content, lastModified: new Date().toISOString().slice(0, 10) };
+}
+
+export default function HelpGlossaryPage() {
+  const { content } = loadGlossary();
+
+  return (
+    <div className="hf-page">
+      <header className="hf-page-header">
+        <h1 className="hf-page-title">Glossary — Skills, LOs, TPs, Mastery</h1>
+        <p className="hf-page-subtitle">
+          Canonical vocabulary across course design, skill measurement, and
+          learner progress. Maintained in{" "}
+          <code>{GLOSSARY_PATH}</code>; this page reflects whatever's on the
+          current branch.
+        </p>
+      </header>
+      <article className="hf-help-glossary-body">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </article>
+    </div>
+  );
+}

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -291,6 +291,17 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       { keys: "A", action: "callback", callbackId: "tab:ai-call", label: "Call tab (cAll)" },
     ],
   },
+
+  // ── Help bank ────────────────────────────────────────────────────────
+  {
+    match: "/x/help/glossary",
+    title: "Glossary — Skills, LOs, TPs, Mastery",
+    about:
+      "Canonical vocabulary across course design, skill measurement, and learner progress. Open this when you're unsure whether a label means Skill vs LO vs Mastery vs Skill Score — every term maps to its DB shape and example. Maintained in `docs/glossary-skills-mastery.md`; this page reflects the current branch.",
+    chords: [
+      { keys: "C", action: "navigate", href: "/x/courses", label: "Back to Courses" },
+    ],
+  },
 ];
 
 /**

--- a/docs/glossary-skills-mastery.md
+++ b/docs/glossary-skills-mastery.md
@@ -1,0 +1,207 @@
+# Glossary — Courses, Skills, LOs, TPs, Mastery
+
+> **Source of truth** for the vocabulary used across course design, skill
+> measurement, and learner progress. Maintained as the system evolves.
+> Surfaced in the help bank at `/x/help/glossary` and indexed by Cmd+K.
+>
+> **Last updated:** 2026-06-13
+
+When in doubt about a term, look here first. Every entry maps an
+educator-facing label to its DB shape so designers + engineers don't drift.
+
+---
+
+## 1. Course-level (what the educator owns)
+
+| DB entity | UI label | Plain English | Example |
+|---|---|---|---|
+| `Domain` | **Institution** | The school / org / company that owns the course | "PAW Campus" |
+| `Playbook` | **Course** | One sellable / runnable course inside an institution | "CTO Standard — Revision Aid" |
+| `Subject` | **Subject** (topic area) | Discipline label; a course teaches one or more subjects | "IT Leadership" |
+| `CohortGroup` | **Class** / **Cohort** | The classroom of learners taking the course | "Sept 2026 intake" |
+
+---
+
+## 2. Sources (what the educator uploads)
+
+| DB entity | UI label | Plain English | Example |
+|---|---|---|---|
+| `ContentSource` | **Source** / **Document** | An uploaded file (PDF, MD, URL) | `cio-cto-standard-revision-aid.course-ref.md` |
+| `PlaybookSource` | (join row, no UI label) | "This Course uses this Source" | — |
+| `documentType: COURSE_REFERENCE_CANONICAL` | **Course Reference** | The MAIN config doc — declares Skills, LOs, modules, teaching rules | The `*.course-ref.md` spine |
+| `documentType: COURSE_REFERENCE_ASSESSOR_RUBRIC` | **Rubric Doc** | The separate per-band rubric (IELTS-style 9-band descriptors) | `assessor-rubric.md` |
+| `documentType: COURSE_REFERENCE_TUTOR_BRIEFING` | **Tutor Briefing** | Facts the tutor needs but never quizzes on | `tutor-briefing.md` |
+| `documentType: QUESTION_BANK` | **Question Bank** | Practice prompts the tutor draws from | `ielts-part1-questions.md` |
+| `documentType: TEXTBOOK` | **Textbook** | Reference material extracted as content | `openstax-psych-ch11.md` |
+
+---
+
+## 3. The Skills Framework (the rubric the projection builds)
+
+Lives inside the Course Reference's `## Skills Framework` section.
+Parsed by `parseSkillsFramework()` in `apps/admin/lib/wizard/project-course-reference.ts`.
+
+| DB entity / shape | UI label | Plain English | Example |
+|---|---|---|---|
+| `ParsedSkill` (parser output) | **Skill** | One measurable competency the course teaches | "Stakeholder anticipation" |
+| `ParsedSkill.ref` | **Skill ref** | Stable ID (`SKILL-01`...) | `SKILL-01` |
+| `ParsedSkill.tierScheme` | **Tier scheme** | Ordered names of the levels this course uses | `[foundation, developing, practitioner, distinction]` |
+| `ParsedSkill.tiers[name]` | **Tier descriptor** | What "Developing" looks like for this skill | "Translates one risk per call" |
+| `ParsedSkill.targetBand` | **Target band** | The tier / band the educator wants learners to reach | `0.70` = Band 7 / Practitioner |
+| `ParsedSkill.bandThresholds[n]` | **Band descriptor** | Per-band text (IELTS 9-band style, optional) | "Band 7: Speaks at length without effort" |
+
+**Projection writes these to DB:**
+
+| DB entity | UI label | Plain English |
+|---|---|---|
+| `Parameter` (`parameterId: skill_*`) | **Skill Parameter** | The measurable dimension the AI tutor scores against |
+| `BehaviorTarget` (PLAYBOOK scope, `skillRef`) | **Skill Target** | "On this course, target value for SKILL-01 is 0.70" |
+| `Parameter.config.bandThresholds` | **Band rubric** | Per-band descriptor text written by the rubric-pass |
+| `AnalysisSpec` (`skill-measure-<id>`) | **Skill Scoring Spec** | The prompt the AI uses to score this skill per call |
+
+---
+
+## 4. The Curriculum (the WHAT — content structure)
+
+| DB entity | UI label | Plain English | Example |
+|---|---|---|---|
+| `Curriculum` | **Curriculum** | The full content map of the course | "The Standard V6.0" |
+| `CurriculumModule` | **Module** (a.k.a. Unit / Part) | One teachable chunk | "Unit 04: IT Operations" |
+| `LearningObjective` (LO) | **Learning Objective** (a.k.a. Outcome) | One specific thing the learner should be able to do | "STD-04-01: Articulate cost-effectiveness vs performance" |
+| `LearningObjective.ref` | **LO ref** | Stable ID | `STD-04-01` |
+| `LearningObjective.description` | **LO statement** | The "the learner can…" sentence | "The learner can describe…" |
+
+**OUT-NN outcomes** (from `## Outcomes` section of course-ref) are
+written as `LearningObjective` rows too — same table, tagged by source.
+
+---
+
+## 5. TPs — Teaching Principles (the HOW — tutor instructions)
+
+The wizard `setupData.teachingPrinciples` AND the course-ref's `## Teaching
+Approach` section. Stored as `ContentAssertion` rows categorised by intent.
+
+| DB entity (category) | UI label | Plain English | Example |
+|---|---|---|---|
+| `ContentAssertion(teaching_rule)` | **Teaching Rule** | Instruction to the tutor about HOW to teach | "Never answer for the learner — wait for them to attempt first" |
+| `ContentAssertion(scaffolding_technique)` | **Scaffolding** | Move the tutor uses when the learner struggles | "Offer the next-tier prompt as a question, not an answer" |
+| `ContentAssertion(edge_case)` | **Edge Case** | What to do when X happens | "If the learner gives up, validate then offer scaffolding" |
+| `ContentAssertion(skill_framework)` | (raw skill text) | Source text behind a Skill — provenance only | — |
+| `ContentAssertion(assessment_approach)` | **Assessment Rule** | How the tutor judges progress | "Score per-LO per-dimension at session close" |
+| `ContentAssertion(communication_rule)` | **Communication Rule** | Tone, register, voice rules | "Comfortable with silence — don't fill it" |
+| `ContentAssertion(session_flow)` | **Session Flow** | The order of phases in a session | "Open → diagnose → teach → re-ask → close" |
+
+> **Spoken shorthand "TPs"** maps to `teaching_rule + scaffolding_technique + edge_case`
+> combined — all the HOW-TO-TEACH text. Rendered together in `CourseHowTab.tsx` as
+> the "How" tab categories.
+
+---
+
+## 6. Per-learner state (what we measure — TWO parallel systems)
+
+| DB entity | UI label | What it measures | Aggregation | Example |
+|---|---|---|---|---|
+| `CallerTarget.currentScore` (`skill_*` param) | **Learner Skill Score** | Continuous EMA across all calls for ONE skill | EMA, 14d half-life (config) | `0.62` → Band 6 / Practitioner |
+| `CallerAttribute lo_mastery:slug:loRef` | **Learner LO Mastery** | Per-LO best-ever-seen score | Monotonic `Math.max` ratchet | `0.70` |
+| `CallerModuleProgress.mastery` | **Learner Module Mastery** | Per-module rolled-up mastery | `computeModuleMastery()` EMA | `0.45` → IN_PROGRESS |
+| `CallerModuleProgress.loScoresJson[ref].mastery` | (internal) Per-LO running avg | Arithmetic mean across calls | Lags the ratchet on purpose | `0.11` |
+| `Call.scratchMastery` | **Mock Exam Mastery** | Per-call only, NOT cumulative (Exam Assessment) | Reset each call | varies |
+| `CallerPersonalityProfile.parameterValues` | **Learner Personality Profile** | Big5 / VARK trait scores | EMA, 30d half-life | `B5-O=0.58` |
+| `Goal.progress` | **Goal Progress** | 0.0–1.0 progress toward a goal | Strategy-dispatched (lo_rollup / skill_ema / etc.) | `0.70` |
+| `Goal.progressMetrics.progress` | (internal) Evidence trail | `{evidence, tier, band, callId, at}` | — | — |
+
+---
+
+## 7. Per-call evidence (the raw signal)
+
+| DB entity | UI label | What it captures |
+|---|---|---|
+| `CallScore` | **Call Score** (per-parameter measurement) | One score per Parameter per call, with `confidence` + `evidence` |
+| `BehaviorMeasurement` | **Behavior Measurement** | Actual agent behavior vs. target |
+| `PersonalityObservation` | **Personality Observation** | Snapshot of trait scores from one call |
+| `RewardScore` | **Reward Score** | Overall call quality (`behaviorScore` × `goalProgressScore`) |
+| `ConversationArtifact` | **Quote-worthy line** | Lines from the transcript flagged for sharing |
+| `CallAction` | **Action Item** | Homework / next-call task |
+
+---
+
+## The chain — one diagram
+
+```
+Institution (Domain)
+   └── Course (Playbook)
+         ├── Subject(s)              ← topic area
+         ├── Source(s)                ← uploaded docs
+         │     │  COURSE_REFERENCE → projection extracts:
+         │     │
+         │     ├──► Skills Framework
+         │     │      ├── Skill (SKILL-01..N) ← ParsedSkill / Parameter
+         │     │      │     ├── Tier × N (descriptors)
+         │     │      │     ├── Band rubric (per-band text)
+         │     │      │     └── Skill Target (per-course)
+         │     │      └── (AI Scoring Spec — MEASURE)
+         │     │
+         │     ├──► Curriculum
+         │     │      └── Module(s)
+         │     │            └── Learning Objective(s) (LO)
+         │     │
+         │     └──► Teaching Principles (TPs)
+         │            ├── Teaching Rules
+         │            ├── Scaffolding moves
+         │            ├── Edge cases
+         │            ├── Session flow
+         │            └── Communication rules
+         │
+         └── Learners (Callers)
+                ├── Skill Score per Skill (EMA, banded)
+                ├── LO Mastery per LO (ratchet)
+                ├── Module Mastery per Module (rolled up)
+                ├── Goal Progress per Goal
+                └── Personality Profile (trait EMA)
+                       │
+                       └── one CALL at a time
+                             ├── Call Scores (per Parameter)
+                             ├── Behavior Measurements
+                             ├── Personality Observation
+                             ├── Reward Score
+                             ├── Action Items
+                             └── Quote-worthy lines
+```
+
+---
+
+## Three confusions worth naming explicitly
+
+1. **"Skill" vs "Learning Objective"** — Skill is broad and cross-cutting
+   (e.g. "Risk articulation" spans every Unit). LO is a specific can-do
+   statement inside ONE module (e.g. "STD-04-01: Articulate cost-effectiveness
+   vs performance"). One Skill spans many LOs across modules.
+
+2. **"Mastery" vs "Skill Score"** — Mastery is the LO ratchet (best-ever-seen
+   score, monotonic). Skill Score is the EMA across all calls (decays, can fall).
+   They DIVERGE by design — Mastery says "you proved you can"; Skill Score says
+   "you can right now". Both are correct; both surface separately.
+
+3. **"Tier" vs "Band"** — Tier is the NAME (Developing). Band is the NUMBER (5.5).
+   For 4-tier CTO they map 1:1. For IELTS the 9 bands compress to 3 tiers via
+   `scoreToTier()`. The educator usually thinks in tiers; the learner-facing
+   chip shows the band number.
+
+---
+
+## Maintenance rules
+
+- Update this file whenever a new entity is introduced that belongs to any
+  of the 7 layers above, OR whenever a label changes on the educator UI.
+- The `/x/help/glossary` route reads this file at request time — no rebuild
+  required after updates.
+- Cmd+K search indexes this file via the help bank.
+- Tested by `tests/lib/glossary-freshness.test.ts` (planned) which fails if
+  any entity referenced in `entities.md` is missing from this glossary.
+
+## See also
+
+- [docs/ENTITIES.md](./ENTITIES.md) — full schema entity boundary rules
+- [memory/entities.md](../.claude/projects/-Users-paulwander-projects-HF/memory/entities.md) — schema hierarchy + canonical files
+- [docs/CONTENT-PIPELINE.md](./CONTENT-PIPELINE.md) — projection from course-ref to DB
+- [a-sample-docs/course-reference-template.md](../a-sample-docs/course-reference-template.md) — the template educators fill in


### PR DESCRIPTION
## Summary

Adds a canonical vocabulary doc + a help-bank page that surfaces it. Closes the "is this a Skill or an LO? is this Mastery or Skill Score?" confusion that's been latent since the projection epic shipped.

**5 files:**
1. `docs/glossary-skills-mastery.md` — the doc (7 layers + 3 explicit confusion call-outs + maintenance rules)
2. `apps/admin/app/x/help/glossary/page.tsx` — renders the markdown via react-markdown (mirrors `/x/help/demos` pattern of `readFileSync` at request time)
3. `apps/admin/app/x/help/glossary/help-glossary.css` — design-token-only styling
4. `apps/admin/lib/help/page-help.ts` — registry entry so help overlay + chord engine + DATA-mode AI assistant index it
5. `CLAUDE.md` — reference-docs table adds the glossary as hard-prereq

## Test plan

- [x] tsc clean on touched files
- [ ] Smoke `/x/help/glossary` route renders markdown correctly
- [ ] Smoke Cmd+K palette finds "Glossary" once that wires up (currently a TODO in FlashSidebar.tsx:293)

Docs-only / new-route — no production-data risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)