### PR TITLE
feat(ui): Sprint 1 SP1-C — tier-colors util + <TierCell> + <CascadeValue>

### DIFF
--- a/apps/admin/components/shared/CascadeValue.tsx
+++ b/apps/admin/components/shared/CascadeValue.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import type { Effective } from "@/lib/cascade/layer-types";
+import { LayerBadge } from "@/components/cascade/LayerBadge";
+
+import "./cascade-value.css";
+
+export interface CascadeValueProps<T = unknown> {
+  /** The cascade envelope from `/api/cascade/resolve` or `resolveEffective()`. */
+  envelope: Effective<T>;
+  /**
+   * The rendered display of the effective value. Consumers control the
+   * formatting — this wrapper just adds the cascade chip + inspector wiring.
+   * Examples: `"0.70"` for a numeric, `"Practitioner"` for a tier, JSX for
+   * a complex composite.
+   */
+  children: ReactNode;
+  /**
+   * Knob key for telemetry — passed to `<LayerBadge knobKey=...>` so the
+   * cascade-inspector-open event groups correctly in the admin telemetry
+   * view (#1484). Consumers SHOULD pass this; falling back to "unknown"
+   * loses the analytics signal.
+   */
+  knobKey?: string;
+  /**
+   * Optional aria-label for the value + chip pair.
+   */
+  ariaLabel?: string;
+  /**
+   * Hide the subtitle ("set on this Course" / "inherited from Domain")
+   * below the chip. Useful in dense rows (Cohort Heatmap legend, etc.)
+   * where the consumer renders its own caption.
+   */
+  hideSubtitle?: boolean;
+  /**
+   * Called when the operator clicks the cascade chip — typically opens
+   * `<CascadeInspectorTray>` which the consumer mounts with its own scope-chain
+   * context (the tray takes `(knobKey, knobLabel, scopeChain, onClose, …)`,
+   * which only the host page knows). When omitted, the chip is non-interactive
+   * but still renders the source-layer + subtitle.
+   */
+  onInspect?: () => void;
+  /**
+   * Render only the chip without the inline value display. Rarely useful — most
+   * consumers want the `{value} <chip>` pair. Pass `bare` only when composing
+   * the value display yourself.
+   */
+  bare?: boolean;
+}
+
+/**
+ * Inline composite that pairs an effective value with its cascade-honesty
+ * chip — the canonical render for any educator-facing knob that the
+ * cascade resolves across layers (Domain → Course → Segment → Caller → Call).
+ *
+ * Composition is intentionally thin: `{value} <LayerBadge envelope=...>`.
+ * Click semantics delegate to the host via `onInspect` — the consumer mounts
+ * `<CascadeInspectorTray>` because tray construction needs scope-chain context
+ * the host knows about (currentEditScope, scopeChain, onOverride callbacks).
+ *
+ * Standalone surfaces (`CascadeLensPanel`, `CascadeInspectorTray`) are KEPT
+ * — this primitive is for the INLINE case (e.g. a heatmap cell, a settings
+ * row, a Skills Framework tier descriptor) where rendering the full tray
+ * inline would be too heavy.
+ *
+ * Stream A SP1-C from the consolidated Skills Framework + CourseReDesign epic.
+ */
+export function CascadeValue<T>({
+  envelope,
+  children,
+  knobKey,
+  ariaLabel,
+  hideSubtitle,
+  onInspect,
+  bare,
+}: CascadeValueProps<T>) {
+  if (bare) {
+    return (
+      <LayerBadge
+        envelope={envelope}
+        knobKey={knobKey}
+        ariaLabel={ariaLabel}
+        hideSubtitle={hideSubtitle ?? true}
+        onInspect={onInspect}
+      />
+    );
+  }
+
+  return (
+    <span className="hf-cascade-value" aria-label={ariaLabel}>
+      <span className="hf-cascade-value-display">{children}</span>
+      <LayerBadge
+        envelope={envelope}
+        knobKey={knobKey}
+        ariaLabel={ariaLabel ?? "Inspect cascade chain"}
+        hideSubtitle={hideSubtitle ?? true}
+        onInspect={onInspect}
+      />
+    </span>
+  );
+}

--- a/apps/admin/components/shared/TierCell.tsx
+++ b/apps/admin/components/shared/TierCell.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+
+import {
+  ABOVE_TARGET,
+  AWAITING_EVIDENCE,
+  tierBackground,
+  tierColor,
+  tierGlyph,
+  tierLabel,
+  type TierName,
+} from "@/lib/banding/tier-colors";
+
+import "./tier-cell.css";
+
+export interface TierCellProps {
+  /**
+   * Lowercase tier name from `ParsedSkill.tierScheme`. May also be one of
+   * the two special states `AWAITING_EVIDENCE` / `ABOVE_TARGET` exported
+   * from `lib/banding/tier-colors.ts`.
+   */
+  tier: TierName;
+  /**
+   * Optional cell content — defaults to the glyph alone. Cohort heatmap cells
+   * usually pass a count (e.g. `12`); per-learner cells pass `★` when the
+   * learner is at-or-above the target tier.
+   */
+  children?: ReactNode;
+  /**
+   * Optional secondary label rendered below the glyph. Cohort heatmap uses
+   * this for `n of N` lines; per-learner cells use it for the band number.
+   */
+  caption?: string;
+  /**
+   * When `target: true`, draws the educator's target tier marker. Pure
+   * decoration — does not change the colour/glyph mapping.
+   */
+  target?: boolean;
+  /** Optional explicit tooltip text. Defaults to the `tierLabel`. */
+  title?: string;
+  /** `compact` shrinks padding for dense heatmap rows. */
+  size?: "default" | "compact";
+  /** Optional click handler — opens a drill. Click-eligible cells get a hover state via CSS. */
+  onClick?: () => void;
+  /** Inline-style escape hatch. Avoid; use `size` / `caption` where possible. */
+  style?: CSSProperties;
+}
+
+/**
+ * Single heatmap cell rendering tier visual + optional content.
+ *
+ * One primitive shared across:
+ *
+ *   - Course Detail → Skills Framework → Cohort Heatmap lens (cell = `n learners`)
+ *   - Course Detail → Skills Framework → Framework Map lens (cell = `★` on target tier)
+ *   - Caller Detail → Attainment → Skill Bands section (cell = `band #` per skill)
+ *   - Cohort views that want a consistent tier visual (replaces inline `BAND_COLORS`
+ *     map at `CohortLearningAggregate.tsx:22-28`)
+ *
+ * Tier name → colour mapping comes from `lib/banding/tier-colors.ts` — single
+ * source so educators see the SAME treatment across surfaces. See that file
+ * for the design conventions.
+ *
+ * Always renders a glyph + label combo (not colour alone) — colourblind-safe.
+ */
+export function TierCell({
+  tier,
+  children,
+  caption,
+  target,
+  title,
+  size = "default",
+  onClick,
+  style,
+}: TierCellProps) {
+  const ariaTitle = title ?? tierLabel(tier);
+  const isInteractive = Boolean(onClick);
+
+  const cellStyle: CSSProperties = {
+    background: tierBackground(tier),
+    color: tierColor(tier),
+    ...style,
+  };
+
+  const content = children ?? tierGlyph(tier);
+
+  if (isInteractive) {
+    return (
+      <button
+        type="button"
+        className={`hf-tier-cell hf-tier-cell--${size} hf-tier-cell--interactive`}
+        style={cellStyle}
+        onClick={onClick}
+        title={ariaTitle}
+        aria-label={ariaTitle}
+        data-tier={tier}
+        data-target={target ? "true" : undefined}
+      >
+        <span className="hf-tier-cell-content" aria-hidden={typeof content !== "string"}>
+          {content}
+        </span>
+        {target ? <span className="hf-tier-cell-target" aria-label="Target tier">★</span> : null}
+        {caption ? <span className="hf-tier-cell-caption">{caption}</span> : null}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      className={`hf-tier-cell hf-tier-cell--${size}`}
+      style={cellStyle}
+      title={ariaTitle}
+      data-tier={tier}
+      data-target={target ? "true" : undefined}
+    >
+      <span className="hf-tier-cell-content" aria-hidden={typeof content !== "string"}>
+        {content}
+      </span>
+      {target ? <span className="hf-tier-cell-target" aria-label="Target tier">★</span> : null}
+      {caption ? <span className="hf-tier-cell-caption">{caption}</span> : null}
+    </span>
+  );
+}
+
+/** Re-export the special states for convenient one-stop import at consumer sites. */
+export { AWAITING_EVIDENCE, ABOVE_TARGET };

--- a/apps/admin/components/shared/cascade-value.css
+++ b/apps/admin/components/shared/cascade-value.css
@@ -1,0 +1,11 @@
+.hf-cascade-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  vertical-align: middle;
+}
+
+.hf-cascade-value-display {
+  font-weight: 600;
+  color: var(--text-primary);
+}

--- a/apps/admin/components/shared/tier-cell.css
+++ b/apps/admin/components/shared/tier-cell.css
@@ -1,0 +1,65 @@
+.hf-tier-cell {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  padding: 4px 8px;
+  min-width: 44px;
+  text-align: center;
+  position: relative;
+  line-height: 1.2;
+  user-select: none;
+}
+
+.hf-tier-cell--compact {
+  padding: 2px 6px;
+  min-width: 32px;
+  font-size: 11px;
+}
+
+.hf-tier-cell--default {
+  padding: 6px 10px;
+  min-width: 56px;
+  font-size: 13px;
+}
+
+.hf-tier-cell-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.hf-tier-cell-caption {
+  font-size: 10px;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.hf-tier-cell-target {
+  position: absolute;
+  top: -8px;
+  right: -4px;
+  font-size: 12px;
+  color: var(--status-success-text);
+}
+
+.hf-tier-cell--interactive {
+  cursor: pointer;
+  transition: transform 80ms ease-out, border-color 80ms ease-out;
+  background-clip: padding-box;
+  font-family: inherit;
+}
+
+.hf-tier-cell--interactive:hover {
+  transform: scale(1.02);
+  border-color: currentColor;
+}
+
+.hf-tier-cell--interactive:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}

--- a/apps/admin/lib/banding/tier-colors.ts
+++ b/apps/admin/lib/banding/tier-colors.ts
@@ -1,0 +1,163 @@
+/**
+ * Tier colour + glyph + label conventions for the Skills Framework + Attainment surfaces.
+ *
+ * Single source of truth so educators see the SAME visual treatment for a
+ * tier name regardless of whether they're looking at:
+ *
+ *   - Course Detail → Skills Framework → Cohort Heatmap (per-tier learner count)
+ *   - Caller Detail → Attainment → Skill Bands section (per-learner current tier)
+ *   - Caller Detail → ProgressTab BandChip (per-learner band, legacy)
+ *   - CohortLearningAggregate (legacy 3-tier inline map at lines 22-28)
+ *
+ * Replacing the legacy inline `BAND_COLORS` map in `CohortLearningAggregate`
+ * with this central utility is on the Sprint 4 migration list.
+ *
+ * Design conventions (verified 2026-06-13):
+ *
+ *   - **Cold → hot, left-to-right.** Lower tiers sit at the cold end (no_evidence
+ *     = grey muted), higher tiers approach hot green at the top.
+ *   - **Awaiting evidence is its own visual** — distinct from "low tier".
+ *     The educator must be able to tell "we don't know yet" from "they're at the
+ *     bottom tier" at a glance.
+ *   - **Colour is never the only signal.** Each tier has a glyph (▢●◐◑◉) and a
+ *     spelled-out label. Colourblind-safe by construction; tooltips spell the name.
+ *   - **Use CSS tokens only** — never hardcoded hex. Matches `ui-design-system.md`.
+ *
+ * Tier schemes supported (matches `KNOWN_TIER_SCHEMES` in
+ * `lib/wizard/project-course-reference.ts`):
+ *
+ *   - 3-tier: `emerging`, `developing`, `secure`
+ *   - 4-tier (CTO): `foundation`, `developing`, `practitioner`, `distinction`
+ *   - 6-tier (CEFR): `a1` `a2` `b1` `b2` `c1` `c2`
+ *   - Unknown tier names fall back to muted grey + the `?` glyph (the
+ *     `parseSkillsFramework` parser already warns `SKILL_UNRECOGNISED_TIER_SCHEME`
+ *     before we render — this is a defence-in-depth fallback).
+ *
+ * Plus two special states outside any tier scheme:
+ *
+ *   - `awaiting_evidence` — measurement hasn't happened yet (`CallerTarget.currentScore` NULL)
+ *   - `above_target` — exceeded the educator's target tier (rare; small `↑` chip + brighter green)
+ */
+
+/** Lowercase tier name, the canonical form used in `tierScheme` arrays. */
+export type TierName = string;
+
+/**
+ * Special states outside the tier scheme. Use these literals when calling
+ * `tierColor()` etc. to render the "awaiting" + "above target" cells.
+ */
+export const AWAITING_EVIDENCE = "awaiting_evidence" as const;
+export const ABOVE_TARGET = "above_target" as const;
+
+/** Glyph per tier name. Returns "?" for unknown tiers (defence-in-depth). */
+export function tierGlyph(tierName: TierName): string {
+  switch (tierName) {
+    case AWAITING_EVIDENCE:
+      return "▢";
+    case "emerging":
+    case "foundation":
+    case "a1":
+      return "●"; // cold end of the scale
+    case "developing":
+    case "a2":
+    case "b1":
+      return "◐";
+    case "secure":
+    case "practitioner":
+    case "b2":
+    case "c1":
+      return "◑";
+    case "distinction":
+    case "c2":
+      return "◉"; // hot end of the scale
+    case ABOVE_TARGET:
+      return "↑";
+    default:
+      return "?";
+  }
+}
+
+/**
+ * CSS colour token for the given tier name. Always a CSS var or `color-mix()`
+ * expression — never a hardcoded hex. Consumers spread this onto
+ * `style={{ color: ... }}` or `style={{ background: ... }}` directly.
+ *
+ * Cold → hot mapping intentionally avoids red at the bottom (educator-facing
+ * surfaces — red carries "wrong/error" semantics that's wrong for "lowest tier"):
+ *
+ *   awaiting_evidence  → muted grey
+ *   3-tier:  emerging → muted teal · developing → amber · secure → green
+ *   4-tier:  foundation → muted teal · developing → muted amber ·
+ *            practitioner → amber · distinction → green
+ *   CEFR:    A1→A2→B1 ramp teal · B2 amber · C1 → C2 green
+ *   above_target → brighter green (mix of success + accent)
+ */
+export function tierColor(tierName: TierName): string {
+  switch (tierName) {
+    case AWAITING_EVIDENCE:
+      return "var(--text-muted)";
+    // ── 3-tier (Emerging / Developing / Secure)
+    case "emerging":
+      return "color-mix(in srgb, var(--accent-primary) 45%, transparent)";
+    case "developing":
+      return "var(--status-warning-text)";
+    case "secure":
+      return "var(--status-success-text)";
+    // ── 4-tier CTO (Foundation / Developing / Practitioner / Distinction)
+    case "foundation":
+      return "color-mix(in srgb, var(--accent-primary) 35%, transparent)";
+    case "practitioner":
+      return "color-mix(in srgb, var(--status-success-text) 60%, var(--status-warning-text))";
+    case "distinction":
+      return "var(--status-success-text)";
+    // ── CEFR 6-tier (A1 A2 B1 B2 C1 C2)
+    case "a1":
+      return "color-mix(in srgb, var(--accent-primary) 30%, transparent)";
+    case "a2":
+      return "color-mix(in srgb, var(--accent-primary) 50%, transparent)";
+    case "b1":
+      return "var(--accent-primary)";
+    case "b2":
+      return "var(--status-warning-text)";
+    case "c1":
+      return "color-mix(in srgb, var(--status-success-text) 60%, var(--status-warning-text))";
+    case "c2":
+      return "var(--status-success-text)";
+    // ── Special: above the educator's target tier
+    case ABOVE_TARGET:
+      return "color-mix(in srgb, var(--status-success-text) 85%, var(--accent-primary))";
+    default:
+      // Unknown tier — defence-in-depth fallback. The parser should have
+      // emitted SKILL_UNRECOGNISED_TIER_SCHEME upstream.
+      return "var(--text-muted)";
+  }
+}
+
+/**
+ * Title-case display label for a tier name. "emerging" → "Emerging".
+ * Used by tooltips + the inline label next to the glyph.
+ */
+export function tierLabel(tierName: TierName): string {
+  switch (tierName) {
+    case AWAITING_EVIDENCE:
+      return "Awaiting evidence";
+    case ABOVE_TARGET:
+      return "Above target";
+    default:
+      if (!tierName) return "Unknown";
+      // CEFR codes stay uppercase.
+      if (/^[abc][12]$/.test(tierName)) return tierName.toUpperCase();
+      return tierName.charAt(0).toUpperCase() + tierName.slice(1);
+  }
+}
+
+/**
+ * Background colour for a heatmap cell — a softer version of `tierColor()`
+ * so foreground glyph + label stay legible. Wraps with `color-mix()` to
+ * 12% alpha against transparent, matching the existing `CohortLearningAggregate`
+ * pattern at line 108.
+ */
+export function tierBackground(tierName: TierName): string {
+  const base = tierColor(tierName);
+  return `color-mix(in srgb, ${base} 12%, transparent)`;
+}

--- a/apps/admin/tests/components/TierCell.test.tsx
+++ b/apps/admin/tests/components/TierCell.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for `<TierCell>` — the shared tier visual primitive.
+ *
+ * Pins:
+ *   1. Renders the right glyph + colour + label for each tier name
+ *   2. `target` prop draws the ★ marker
+ *   3. `onClick` makes the cell interactive (button) with hover state
+ *   4. Awaiting-evidence vs above-target are visually distinct
+ *   5. Caption renders below the glyph for cohort-cell use
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TierCell, AWAITING_EVIDENCE, ABOVE_TARGET } from "@/components/shared/TierCell";
+
+describe("<TierCell>", () => {
+  it("renders the glyph for a known tier when no children supplied", () => {
+    const { container } = render(<TierCell tier="developing" />);
+    // ◐ is the developing glyph
+    expect(container.textContent).toContain("◐");
+  });
+
+  it("respects children over the default glyph", () => {
+    render(<TierCell tier="secure">12</TierCell>);
+    expect(screen.getByText("12")).toBeDefined();
+  });
+
+  it("uses tier name in data-tier attribute for CSS targeting", () => {
+    const { container } = render(<TierCell tier="practitioner" />);
+    expect(container.querySelector('[data-tier="practitioner"]')).toBeTruthy();
+  });
+
+  it("title attribute defaults to the tier display label", () => {
+    const { container } = render(<TierCell tier="distinction" />);
+    const el = container.querySelector('[data-tier="distinction"]');
+    expect(el?.getAttribute("title")).toBe("Distinction");
+  });
+
+  it("AWAITING_EVIDENCE renders the empty-square glyph + correct title", () => {
+    const { container } = render(<TierCell tier={AWAITING_EVIDENCE} />);
+    expect(container.textContent).toContain("▢");
+    const el = container.querySelector(`[data-tier="${AWAITING_EVIDENCE}"]`);
+    expect(el?.getAttribute("title")).toBe("Awaiting evidence");
+  });
+
+  it("ABOVE_TARGET renders the upward-arrow glyph", () => {
+    const { container } = render(<TierCell tier={ABOVE_TARGET} />);
+    expect(container.textContent).toContain("↑");
+  });
+
+  it("target prop draws the ★ marker", () => {
+    const { container } = render(<TierCell tier="practitioner" target />);
+    expect(container.querySelector('[data-target="true"]')).toBeTruthy();
+    expect(container.textContent).toContain("★");
+  });
+
+  it("target=false omits the ★ marker", () => {
+    const { container } = render(<TierCell tier="practitioner" />);
+    expect(container.querySelector('[data-target="true"]')).toBeFalsy();
+    expect(container.textContent).not.toContain("★");
+  });
+
+  it("onClick makes the cell a button + fires the handler", () => {
+    const onClick = vi.fn();
+    const { container } = render(<TierCell tier="developing" onClick={onClick} />);
+    const btn = container.querySelector("button");
+    expect(btn).toBeTruthy();
+    expect(btn?.classList.contains("hf-tier-cell--interactive")).toBe(true);
+    fireEvent.click(btn!);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("without onClick renders a non-interactive span (not a button)", () => {
+    const { container } = render(<TierCell tier="developing" />);
+    expect(container.querySelector("button")).toBeFalsy();
+    expect(container.querySelector("span.hf-tier-cell")).toBeTruthy();
+  });
+
+  it("caption appears below the glyph", () => {
+    render(<TierCell tier="secure" caption="11 of 17" />);
+    expect(screen.getByText("11 of 17")).toBeDefined();
+  });
+
+  it("compact size class applies", () => {
+    const { container } = render(<TierCell tier="secure" size="compact" />);
+    expect(container.querySelector(".hf-tier-cell--compact")).toBeTruthy();
+  });
+});

--- a/apps/admin/tests/lib/tier-colors.test.ts
+++ b/apps/admin/tests/lib/tier-colors.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for `lib/banding/tier-colors.ts` — the shared tier→colour/glyph/label
+ * convention consumed by `<TierCell>`, `<BandChip>`, `CohortLearningAggregate`
+ * (after migration), and the upcoming Sprint 2/3/4 lenses.
+ *
+ * Pins three load-bearing properties:
+ *
+ *   1. Every recognised tier name returns a CSS-token expression (no hex)
+ *   2. Unknown tier names fall back to the muted "?" defence-in-depth pair
+ *   3. Special states (AWAITING_EVIDENCE, ABOVE_TARGET) have distinct visuals
+ *      from any actual tier — educator must be able to distinguish "we don't
+ *      know yet" from "bottom tier"
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ABOVE_TARGET,
+  AWAITING_EVIDENCE,
+  tierBackground,
+  tierColor,
+  tierGlyph,
+  tierLabel,
+} from "@/lib/banding/tier-colors";
+
+describe("tierColor — returns CSS tokens for every recognised tier", () => {
+  const RECOGNISED_TIERS = [
+    // 3-tier
+    "emerging",
+    "developing",
+    "secure",
+    // CTO 4-tier
+    "foundation",
+    "practitioner",
+    "distinction",
+    // CEFR 6-tier
+    "a1",
+    "a2",
+    "b1",
+    "b2",
+    "c1",
+    "c2",
+    // Special states
+    AWAITING_EVIDENCE,
+    ABOVE_TARGET,
+  ];
+
+  it.each(RECOGNISED_TIERS)(
+    "%s returns a CSS-token expression (no hardcoded hex)",
+    (tier) => {
+      const color = tierColor(tier);
+      expect(color).toMatch(/^(var\(--|color-mix\()/);
+      expect(color).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+    },
+  );
+
+  it("unknown tier falls back to muted text token", () => {
+    expect(tierColor("totally-unknown")).toBe("var(--text-muted)");
+  });
+
+  it("awaiting_evidence is distinct from any actual tier colour", () => {
+    const awaiting = tierColor(AWAITING_EVIDENCE);
+    expect(awaiting).toBe("var(--text-muted)");
+    // No other named tier maps to plain muted — they're either var(--accent-*) or
+    // var(--status-*) or a color-mix expression.
+    expect(tierColor("emerging")).not.toBe(awaiting);
+    expect(tierColor("foundation")).not.toBe(awaiting);
+  });
+
+  it("above_target uses a brighter green than 'distinction' (visually celebratory)", () => {
+    const above = tierColor(ABOVE_TARGET);
+    expect(above).toMatch(/color-mix.+success-text/);
+    expect(above).not.toBe(tierColor("distinction"));
+  });
+});
+
+describe("tierGlyph — colourblind-safe shape per tier", () => {
+  it("awaiting_evidence renders the empty-square glyph", () => {
+    expect(tierGlyph(AWAITING_EVIDENCE)).toBe("▢");
+  });
+
+  it("above_target renders the upward-arrow glyph", () => {
+    expect(tierGlyph(ABOVE_TARGET)).toBe("↑");
+  });
+
+  it("each known tier maps to a non-empty glyph", () => {
+    const tiers = [
+      "emerging",
+      "developing",
+      "secure",
+      "foundation",
+      "practitioner",
+      "distinction",
+      "a1",
+      "a2",
+      "b1",
+      "b2",
+      "c1",
+      "c2",
+    ];
+    for (const t of tiers) {
+      const g = tierGlyph(t);
+      expect(g).toBeTruthy();
+      expect(g.length).toBeGreaterThan(0);
+      expect(g).not.toBe("?");
+    }
+  });
+
+  it("unknown tier falls back to '?' (defence-in-depth)", () => {
+    expect(tierGlyph("totally-unknown")).toBe("?");
+  });
+});
+
+describe("tierLabel — display label", () => {
+  it("title-cases 3-tier names", () => {
+    expect(tierLabel("emerging")).toBe("Emerging");
+    expect(tierLabel("developing")).toBe("Developing");
+    expect(tierLabel("secure")).toBe("Secure");
+  });
+
+  it("title-cases 4-tier CTO names", () => {
+    expect(tierLabel("foundation")).toBe("Foundation");
+    expect(tierLabel("distinction")).toBe("Distinction");
+  });
+
+  it("CEFR codes stay uppercase", () => {
+    expect(tierLabel("a1")).toBe("A1");
+    expect(tierLabel("b2")).toBe("B2");
+    expect(tierLabel("c2")).toBe("C2");
+  });
+
+  it("special states have explicit labels", () => {
+    expect(tierLabel(AWAITING_EVIDENCE)).toBe("Awaiting evidence");
+    expect(tierLabel(ABOVE_TARGET)).toBe("Above target");
+  });
+
+  it("empty / nullish tier falls back to 'Unknown'", () => {
+    expect(tierLabel("")).toBe("Unknown");
+  });
+});
+
+describe("tierBackground — wraps tierColor with color-mix() at 12% alpha", () => {
+  it("returns a color-mix() expression with 12% alpha against transparent", () => {
+    expect(tierBackground("secure")).toContain("color-mix(in srgb");
+    expect(tierBackground("secure")).toContain("12%");
+    expect(tierBackground("secure")).toContain("transparent");
+  });
+
+  it("never contains hardcoded hex", () => {
+    for (const t of ["emerging", "developing", "secure", "foundation", "practitioner", "distinction"]) {
+      expect(tierBackground(t)).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Three foundation primitives Sprint 2-5 will consume. Drops in alongside the existing cascade infrastructure (`LayerBadge` / `CascadeInspectorTray`) without replacing the heavy standalone tray; this is the **inline case** (heatmap cells, settings rows, Skills Framework descriptors).

| File | What | Consumed by |
|---|---|---|
| `apps/admin/lib/banding/tier-colors.ts` | Tier → colour / glyph / label single source. 3/4/CEFR-tier supported. Two special states `AWAITING_EVIDENCE` + `ABOVE_TARGET`. Cold→hot direction. CSS tokens only — no hex. | TierCell, BandChip (future migration), CohortLearningAggregate (Sprint 4 migration) |
| `apps/admin/components/shared/TierCell.tsx` | Heatmap cell primitive. Glyph + colour + caption + optional `★` target marker. Interactive when `onClick` supplied. | Cohort Heatmap lens (SP2-D), Framework Map lens (SP2-B), Attainment Skill Bands section (SP4-B) |
| `apps/admin/components/shared/CascadeValue.tsx` | Inline value + cascade chip. Composes `LayerBadge` with `{value}`. Delegates tray opening to host (`onInspect` callback) because the tray needs scope-chain context the host knows. | Every educator-facing knob in Rubric Calibration, Mastery vs Skill, Attainment, Adaptations |

## Design conventions locked

- Cold → hot direction (no red at bottom — educator surfaces shouldn't flag low tiers as "errors")
- Awaiting-evidence is its OWN visual, distinct from "lowest tier" — the educator must distinguish "we don't know yet" from "they're at the bottom"
- Glyph + label combo on every cell (colourblind-safe by construction)
- CSS tokens only (`var(--…)` / `color-mix()`), no hardcoded hex (`ui-design-system.md` rule)

## Verified by

- **51/51 vitests pass**: 28 in `apps/admin/tests/lib/tier-colors.test.ts` (every known tier returns CSS tokens, no hex; unknown falls back to muted; awaiting/above are visually distinct; tierLabel handles CEFR uppercase) + 12 in `apps/admin/tests/components/TierCell.test.tsx` (glyph rendering, target ★ marker, interactive vs non-interactive, awaiting/above visuals, caption, size classes) + 11 prior from #1569 for resolveSkillByLogicalId
- **tsc clean** on `apps/admin/lib/banding/tier-colors.ts`, `apps/admin/components/shared/TierCell.tsx`, `apps/admin/components/shared/CascadeValue.tsx`
- Manual smoke pending — render `<TierCell tier="practitioner" target caption="★" />` in a Storybook fixture (Sprint 2 work)

## Test plan

- [x] vitest 51/51
- [x] tsc clean
- [ ] Storybook fixtures for both primitives (Sprint 2 SP2-E)
- [ ] Migrate `CohortLearningAggregate.tsx:22-28` inline BAND_COLORS to use `tierColor()` (Sprint 4 SP4-F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)