### PR TITLE
feat(cascade): mastery-policy family — skillTierMapping + skillScoringEmaHalfLifeDays

### DIFF
--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -28,6 +28,7 @@ import { resolveSessionFlowKnob } from "./resolvers/session-flow";
 import { resolveWelcomeMessage } from "./resolvers/welcome-message";
 import { resolveVoiceConfigKnob } from "./resolvers/voice-config";
 import { resolveIdentitySpec } from "./resolvers/identity-spec";
+import { resolveMasteryPolicyKnob } from "./resolvers/mastery-policy";
 
 /**
  * Scope IDs the cascade can resolve against. SYSTEM is implicit (no id);
@@ -100,6 +101,17 @@ const FAMILIES: readonly KnobFamily[] = [
     name: "identity-spec",
     match: (k) => k === "identitySpecId",
     resolve: (scope) => resolveIdentitySpec(scope),
+  },
+  {
+    // Sprint 1 SP1-D (2026-06-13) — only the 2 mastery knobs that
+    // genuinely cascade across Domain → Playbook. The other three
+    // (`useFreshMastery`, `maxMasteryTier`, `scoringMode`) are intrinsic
+    // to the course/variant and stay Playbook-only — the Rubric
+    // Calibration lens renders them with a variant-preset pill instead
+    // of a cascade chip.
+    name: "mastery-policy",
+    match: (k) => k === "skillTierMapping" || k === "skillScoringEmaHalfLifeDays",
+    resolve: (scope, knobKey) => resolveMasteryPolicyKnob(scope, knobKey),
   },
 ];
 

--- a/apps/admin/lib/cascade/resolvers/mastery-policy.ts
+++ b/apps/admin/lib/cascade/resolvers/mastery-policy.ts
@@ -1,0 +1,157 @@
+/**
+ * Mastery-policy cascade resolver — covers the two genuinely cascade-eligible
+ * mastery knobs (Sprint 1 SP1-D, post-investigation 2026-06-13):
+ *
+ *   - `skillTierMapping` — full tier-threshold + tierBands override
+ *     (IELTS-style 9-band vs CEFR vs custom). Institution may want a
+ *     domain-wide default so individual courses inherit a single rubric
+ *     style across the institution.
+ *
+ *   - `skillScoringEmaHalfLifeDays` — mastery responsiveness in days
+ *     (default 14). Short-demo institutions may want 4d at the Domain
+ *     level; year-long programmes may want 30d. Per-course override stays
+ *     available.
+ *
+ * These two knobs are READ today from `Playbook.config` only — by
+ * `lib/banding/presets.ts`, `lib/pipeline/aggregate-runner.ts:204-206`,
+ * `lib/goals/track-progress.ts::getSkillTierMapping`. The cascade layer
+ * adds Domain → Playbook resolution + provenance for the educator UI
+ * (Rubric Calibration lens in SP3-A). The underlying readers can stay
+ * Playbook-only until SP3-A is ready to wire them through this resolver.
+ *
+ * The other three mastery knobs are NOT cascade-eligible by design:
+ *   - `useFreshMastery` — variant-preset intrinsic ("Exam Assessment" identity)
+ *   - `maxMasteryTier` — variant-preset intrinsic ("Pop Quiz" cap)
+ *   - `scoringMode` — Playbook-only for now; no institutional precedent
+ *
+ * The Rubric Calibration lens (SP3-A) renders these three with a small
+ * variant-preset pill instead of a cascade chip.
+ *
+ * `Domain.config` is already a `Json?` field — no schema migration. The
+ * institution operator writes the override via the existing Domain
+ * settings surface (or via the future Cmd+K NLP lane).
+ *
+ * Sister of:
+ *   - `welcome-message.ts` — same Domain-column-vs-Playbook-blob pattern
+ *   - `voice-config.ts`    — thin adapter over a domain-specific resolver
+ */
+
+// TODO(cascade-provenance): there is no per-key authorship metadata for
+// `Playbook.config.*` or `Domain.config.*`. Adding `configUpdatedBy` /
+// `configUpdatedAt` columns to both tables would let us surface real
+// "Set by Paul on 2026-05-22" provenance. Until then the tray renders
+// "Set by (unknown)" for these knobs. Tracked in the same TODO as
+// `welcome-message.ts`.
+
+import { prisma } from "@/lib/prisma";
+
+import type { Effective, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+const SUPPORTED_KEYS = ["skillTierMapping", "skillScoringEmaHalfLifeDays"] as const;
+type MasteryPolicyKey = (typeof SUPPORTED_KEYS)[number];
+
+function isMasteryPolicyKey(k: string): k is MasteryPolicyKey {
+  return (SUPPORTED_KEYS as readonly string[]).includes(k);
+}
+
+/**
+ * Resolver entry called from `FAMILIES` in `effective-value.ts`. Reads
+ * Playbook.config + Domain.config and returns the cascade envelope in
+ * SYSTEM→CALL order (Domain before Playbook).
+ *
+ * Throws when:
+ *   - `scope.playbookId` missing (every mastery knob is per-course)
+ *   - the playbook row isn't found
+ *   - the knob key isn't one of the SUPPORTED_KEYS (defence-in-depth;
+ *     `pickResolver` in `effective-value.ts` should never dispatch here
+ *     for other keys, but better to fail loudly than return stale data)
+ */
+export async function resolveMasteryPolicyKnob(
+  scope: ScopeChain,
+  knobKey: string,
+): Promise<Effective<unknown>> {
+  if (!isMasteryPolicyKey(knobKey)) {
+    throw new Error(
+      `resolveMasteryPolicyKnob: unsupported knob "${knobKey}". ` +
+        `Supported: ${SUPPORTED_KEYS.join(", ")}.`,
+    );
+  }
+  if (!scope.playbookId) {
+    throw new Error(
+      `resolveMasteryPolicyKnob requires \`playbookId\` in scopeChain (got: ${JSON.stringify(
+        scope,
+      )})`,
+    );
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: scope.playbookId },
+    select: {
+      id: true,
+      name: true,
+      config: true,
+      domainId: true,
+    },
+  });
+  if (!playbook) {
+    throw new Error(`Playbook not found: ${scope.playbookId}`);
+  }
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: playbook.domainId },
+    select: { id: true, name: true, config: true },
+  });
+
+  const pbConfig = (playbook.config ?? {}) as Record<string, unknown>;
+  const domainConfig = (domain?.config ?? {}) as Record<string, unknown>;
+
+  // Build `layers` in SYSTEM→CALL order — DOMAIN before PLAYBOOK — so
+  // the inspector tray can iterate top-to-bottom without re-sorting.
+  const layers: LayerHit<unknown>[] = [];
+
+  const domainValue = domainConfig[knobKey];
+  if (domainValue !== undefined && domainValue !== null) {
+    layers.push({
+      layer: "DOMAIN",
+      scopeId: domain!.id,
+      scopeLabel: domain!.name,
+      value: domainValue,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
+
+  const playbookValue = pbConfig[knobKey];
+  if (playbookValue !== undefined && playbookValue !== null) {
+    layers.push({
+      layer: "PLAYBOOK",
+      scopeId: playbook.id,
+      scopeLabel: playbook.name,
+      value: playbookValue,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
+
+  // Deepest (innermost) layer wins — the last entry in SYSTEM→CALL order.
+  const winner = layers.length > 0 ? layers[layers.length - 1] : null;
+
+  if (!winner) {
+    return {
+      value: null,
+      source: "SYSTEM",
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
+
+  return {
+    value: winner.value,
+    source: winner.layer,
+    layers,
+    isInherited: winner.layer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/tests/lib/cascade/mastery-policy-resolver.test.ts
+++ b/apps/admin/tests/lib/cascade/mastery-policy-resolver.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for `lib/cascade/resolvers/mastery-policy.ts`.
+ *
+ * Mirrors `welcome-message.test.ts` shape and pins:
+ *   1. PLAYBOOK wins over DOMAIN when both layers carry the knob
+ *   2. DOMAIN-only resolution flags `isInherited: true`
+ *   3. Empty resolution returns `source: "SYSTEM"` with empty layers
+ *   4. Layers are emitted in SYSTEM → CALL order (Domain before Playbook)
+ *   5. Throws on missing playbookId
+ *   6. Throws on unsupported knobKey (defence-in-depth)
+ *   7. Throws when the playbook row isn't found
+ *   8. Covers both supported keys (`skillTierMapping`, `skillScoringEmaHalfLifeDays`)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: { findUnique: vi.fn() },
+    domain: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+import { resolveMasteryPolicyKnob } from "@/lib/cascade/resolvers/mastery-policy";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveMasteryPolicyKnob — basic gates", () => {
+  it("throws on unsupported knob key", async () => {
+    await expect(
+      resolveMasteryPolicyKnob({ playbookId: "pb-1" }, "useFreshMastery"),
+    ).rejects.toThrow(/unsupported knob "useFreshMastery"/i);
+  });
+
+  it("throws on missing playbookId", async () => {
+    await expect(
+      resolveMasteryPolicyKnob({ playbookId: "" }, "skillScoringEmaHalfLifeDays"),
+    ).rejects.toThrow(/playbookId/i);
+  });
+
+  it("throws when playbook not found", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      resolveMasteryPolicyKnob({ playbookId: "pb-missing" }, "skillTierMapping"),
+    ).rejects.toThrow(/Playbook not found/);
+  });
+});
+
+describe("resolveMasteryPolicyKnob — skillScoringEmaHalfLifeDays", () => {
+  it("returns SYSTEM source when neither layer carries the knob", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "CTO Revision Aid",
+      config: {},
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: {},
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "skillScoringEmaHalfLifeDays",
+    );
+    expect(result.value).toBeNull();
+    expect(result.source).toBe("SYSTEM");
+    expect(result.layers).toEqual([]);
+    expect(result.isInherited).toBe(false);
+    expect(result.recommendedLayerForEdit).toBe("PLAYBOOK");
+  });
+
+  it("PLAYBOOK wins over DOMAIN when both layers carry the knob", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "CTO Revision Aid",
+      config: { skillScoringEmaHalfLifeDays: 7 },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: { skillScoringEmaHalfLifeDays: 30 },
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "skillScoringEmaHalfLifeDays",
+    );
+    expect(result.value).toBe(7); // PLAYBOOK overrides DOMAIN
+    expect(result.source).toBe("PLAYBOOK");
+    expect(result.layers).toHaveLength(2);
+    // Order: SYSTEM → CALL means DOMAIN before PLAYBOOK
+    expect(result.layers[0].layer).toBe("DOMAIN");
+    expect(result.layers[1].layer).toBe("PLAYBOOK");
+    expect(result.isInherited).toBe(false);
+  });
+
+  it("DOMAIN-only resolution flags isInherited: true", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "CTO Revision Aid",
+      config: {}, // no playbook override
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: { skillScoringEmaHalfLifeDays: 4 }, // Domain default for short-demo institution
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "skillScoringEmaHalfLifeDays",
+    );
+    expect(result.value).toBe(4);
+    expect(result.source).toBe("DOMAIN");
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].layer).toBe("DOMAIN");
+    expect(result.isInherited).toBe(true);
+  });
+});
+
+describe("resolveMasteryPolicyKnob — skillTierMapping", () => {
+  it("supports complex object values (full tier-mapping override)", async () => {
+    const cefrMapping = {
+      thresholds: {
+        approachingEmerging: 0.2,
+        emerging: 0.4,
+        developing: 0.6,
+        secure: 1.0,
+      },
+      tierBands: {
+        approachingEmerging: 1,
+        emerging: 2,
+        developing: 4,
+        secure: 6,
+      },
+    };
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "IELTS Speaking",
+      config: {},
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "CEFR Language School",
+      config: { skillTierMapping: cefrMapping },
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "skillTierMapping",
+    );
+    expect(result.value).toEqual(cefrMapping);
+    expect(result.source).toBe("DOMAIN");
+    expect(result.isInherited).toBe(true);
+  });
+
+  it("treats null value as 'no override' (not as an explicit null layer)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "CTO Revision Aid",
+      config: { skillTierMapping: null },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: {},
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "skillTierMapping",
+    );
+    expect(result.source).toBe("SYSTEM");
+    expect(result.layers).toEqual([]);
+  });
+});
+
+describe("resolveMasteryPolicyKnob — provenance TODO", () => {
+  it("returns setAt: null + setBy: null until config authorship metadata lands", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "CTO Revision Aid",
+      config: { skillScoringEmaHalfLifeDays: 14 },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme",
+      config: {},
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "skillScoringEmaHalfLifeDays",
+    );
+    expect(result.layers[0].setAt).toBeNull();
+    expect(result.layers[0].setBy).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Sixth cascade family. Sprint 1 SP1-D. Of the 5 mastery-policy knobs, registers only the 2 genuinely Domain-overridable ones; the other 3 are intrinsic to variant presets and stay Playbook-only (Rubric Calibration lens will render them with a variant-preset pill).

Investigation rationale + table in commit body. PLAYBOOK wins on collision; layers emitted in SYSTEM→CALL order; `Domain.config` already `Json?` so no schema migration.

## Verified by

- 9/9 vitests in `apps/admin/tests/lib/cascade/mastery-policy-resolver.test.ts` mirror the welcome-message-resolver shape: unsupported-knob throw, missing-playbookId throw, playbook-not-found throw, SYSTEM-when-empty, PLAYBOOK-over-DOMAIN, DOMAIN-only-inherited, layer ordering, complex object values, explicit-null-as-no-override, provenance-null-until-todo
- tsc clean on `apps/admin/lib/cascade/resolvers/mastery-policy.ts` + `apps/admin/lib/cascade/effective-value.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)