### PR TITLE
fix(projection): persist per-skill tierScheme + tier descriptors on Parameter.config

### DIFF
--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -110,11 +110,21 @@ async function upsertParameters(
   let created = 0;
 
   for (const p of parameters) {
-    // #500 PR-2 — persist bandThresholds on Parameter.config when present so
-    // the MEASURE spec runtime (PR-5) can hydrate per-band scoring anchors.
-    const config = p.bandThresholds && Object.keys(p.bandThresholds).length > 0
-      ? { bandThresholds: p.bandThresholds }
-      : undefined;
+    // #500 PR-2 — persist bandThresholds on Parameter.config when present.
+    // Sprint 2 SP2-B+ (2026-06-13) — also persist tierScheme + tiers so the
+    // Skills Framework Inspector lens reads the rubric directly from
+    // Parameter.config without a ContentAssertion-text fallback.
+    const configEntries: Record<string, unknown> = {};
+    if (p.bandThresholds && Object.keys(p.bandThresholds).length > 0) {
+      configEntries.bandThresholds = p.bandThresholds;
+    }
+    if (p.tierScheme && p.tierScheme.length > 0) {
+      configEntries.tierScheme = [...p.tierScheme];
+    }
+    if (p.tiers && Object.keys(p.tiers).length > 0) {
+      configEntries.tiers = p.tiers;
+    }
+    const config = Object.keys(configEntries).length > 0 ? configEntries : undefined;
 
     const existing = await tx.parameter.findUnique({
       where: { parameterId: p.name },
@@ -123,11 +133,14 @@ async function upsertParameters(
 
     if (existing) {
       map.set(p.name, existing.parameterId);
-      // Keep config in sync if the doc gained or changed bandThresholds.
+      // Keep config in sync if the doc gained or changed any of the merged keys.
+      // Merge rather than replace so prior `bandThresholds` from the rubric pass
+      // aren't blown away when the main projection runs without them.
       if (config) {
+        const merged = { ...((existing.config as Record<string, unknown>) ?? {}), ...config };
         await tx.parameter.update({
           where: { parameterId: p.name },
-          data: { config: config as any },
+          data: { config: merged as any },
         });
       }
       continue;

--- a/apps/admin/lib/wizard/project-course-reference.ts
+++ b/apps/admin/lib/wizard/project-course-reference.ts
@@ -149,6 +149,21 @@ export interface ProjectedParameter {
    * absent for skills with only tier descriptors (Emerging/Developing/Secure).
    */
   bandThresholds?: Record<number, string>;
+  /**
+   * Per-skill tier scheme (Sprint 2 SP2-B+ 2026-06-13). The parser detects
+   * this per-skill (see `KNOWN_TIER_SCHEMES`) and the applier persists it
+   * to `Parameter.config.tierScheme`. The runtime resolver
+   * `resolveSkillByLogicalId` reads it from there and falls back to the
+   * 3-tier default when absent.
+   */
+  tierScheme?: readonly string[];
+  /**
+   * Per-tier descriptor text (Sprint 2 SP2-B+ 2026-06-13). Map of tier name
+   * → descriptor prose from the course-ref doc. Written to
+   * `Parameter.config.tiers` so the Skills Framework Inspector lens can
+   * render the structural rubric without a second ContentAssertion read.
+   */
+  tiers?: Record<string, string>;
 }
 
 /**
@@ -699,6 +714,11 @@ function mapSkillsToAchieveAndTargets(skills: ParsedSkill[]): {
       // #500 PR-2 — pass band thresholds through; applier writes them into
       // Parameter.config.bandThresholds. Only present for graded-rubric skills.
       bandThresholds: skill.bandThresholds,
+      // Sprint 2 SP2-B+ — persist per-skill tierScheme + tier descriptors so
+      // the Skills Framework Inspector lens can render the rubric without a
+      // ContentAssertion-text fallback.
+      tierScheme: skill.tierScheme,
+      tiers: Object.keys(skill.tiers).length > 0 ? skill.tiers : undefined,
     });
 
     achieveGoals.push({


### PR DESCRIPTION
## Summary

Live state on hf_sandbox post-PR #1572 backfill showed all 10 CTO skills returning 3-tier default + empty `tiers: {}`. Root cause: `applyProjection::upsertParameters` only wrote `bandThresholds` from the parser. Per-skill `tierScheme` + tier descriptors hit the floor.

Fix: `ProjectedParameter` gains `tierScheme` + `tiers` fields; `mapSkillsToAchieveAndTargets` populates them; `upsertParameters` merges them into `Parameter.config` (merge not replace, so band-pass writes don't blow away main-pass writes or vice versa).

## Verified by

- Tested via `npx vitest run lib/wizard/__tests__/project-course-reference.test.ts` — 36/36 pass (existing parser tests unaffected; additive config keys only)
- Operator step after deploy: re-run `apps/admin/scripts/backfill-cto-projection.ts` on hf_sandbox; then `curl /api/courses/<cto-id>/skills-framework` should return `tierScheme: ["foundation", "developing", "practitioner", "distinction"]` for the CTO playbooks
- No schema changes; additive Json fields on `Parameter.config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)