### PR TITLE
feat(skills): Cohort Heatmap lens (SP2-D) + lens switcher

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/skills-cohort-heatmap/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/skills-cohort-heatmap/route.ts
@@ -1,0 +1,227 @@
+/**
+ * @api GET /api/courses/[courseId]/skills-cohort-heatmap
+ *
+ * Per-skill × per-tier cohort distribution for the Skills Framework
+ * Inspector's Cohort Heatmap lens (SP2-D).
+ *
+ * Auth: OPERATOR+ (educator-scope — STUDENT never sees cohort aggregates).
+ *
+ * ## Why a single aggregation query
+ *
+ * Tech-Lead audit (Task #10) flagged the obvious N+1: with N learners x
+ * M skills x T tiers, a naive implementation hits Prisma `findFirst`
+ * for every cell — 100 learners x 4 skills x 4 tiers = 1600 round-trips
+ * and a timeout on any real cohort. This route mandates a SINGLE
+ * `groupBy` against `CallerTarget` filtered to:
+ *
+ *   - The playbook's enrolled callers (`CallerPlaybook`)
+ *   - The course's `skill_*` parameters (matched against
+ *     `resolveAllSkillsForPlaybook` output)
+ *
+ * The banding (currentScore → tier) happens in-process from the grouped
+ * rows — `scoreToTier` is a pure function, so we never re-query.
+ *
+ * ## Response shape
+ *
+ *   {
+ *     courseId: "…",
+ *     totalLearners: 47,
+ *     rows: [
+ *       {
+ *         skillRef: "SKILL-01",
+ *         parameterName: "Stakeholder anticipation",
+ *         tierScheme: ["foundation", "developing", "practitioner", "distinction"],
+ *         targetTier: "practitioner",
+ *         buckets: {
+ *           awaiting_evidence: 18,
+ *           foundation: 4,
+ *           developing: 8,
+ *           practitioner: 12,
+ *           distinction: 5,
+ *           above_target: 0
+ *         }
+ *       },
+ *       …
+ *     ]
+ *   }
+ */
+
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { resolveAllSkillsForPlaybook } from "@/lib/curriculum/resolve-skill";
+import { getSkillTierMapping, scoreToTier } from "@/lib/goals/track-progress";
+import { AWAITING_EVIDENCE, ABOVE_TARGET } from "@/lib/banding/tier-colors";
+
+export interface CohortHeatmapRow {
+  skillRef: string;
+  parameterId: string;
+  parameterName: string;
+  tierScheme: string[];
+  targetTier: string | null;
+  targetValue: number;
+  /** Map of tier name (or AWAITING_EVIDENCE / ABOVE_TARGET) → learner count. */
+  buckets: Record<string, number>;
+}
+
+export interface CohortHeatmapResponse {
+  courseId: string;
+  totalLearners: number;
+  rows: CohortHeatmapRow[];
+  empty: boolean;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ courseId: string }> },
+) {
+  const { courseId } = await params;
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    select: { id: true },
+  });
+  if (!playbook) {
+    return NextResponse.json({ error: "Course not found" }, { status: 404 });
+  }
+
+  // ── Skills for this playbook ────────────────────────────────────────────
+  const skills = await resolveAllSkillsForPlaybook(courseId);
+  if (skills.length === 0) {
+    const response: CohortHeatmapResponse = {
+      courseId,
+      totalLearners: 0,
+      rows: [],
+      empty: true,
+    };
+    return NextResponse.json(response);
+  }
+  const parameterIds = skills.map((s) => s.parameterId);
+
+  // ── Cohort scope: who's enrolled on this playbook ────────────────────────
+  const enrollments = await prisma.callerPlaybook.findMany({
+    where: { playbookId: courseId },
+    select: { callerId: true },
+  });
+  const callerIds = enrollments.map((e) => e.callerId);
+  const totalLearners = callerIds.length;
+
+  if (totalLearners === 0) {
+    // Pre-populate rows with all learners in the awaiting_evidence bucket so
+    // the empty-cohort case is visually obvious without a separate UI branch.
+    const response: CohortHeatmapResponse = {
+      courseId,
+      totalLearners: 0,
+      rows: skills.map((s) => ({
+        skillRef: s.skillRef,
+        parameterId: s.parameterId,
+        parameterName: s.parameterId,
+        tierScheme: [...s.tierScheme],
+        targetTier: null,
+        targetValue: s.targetValue,
+        buckets: { [AWAITING_EVIDENCE]: 0 },
+      })),
+      empty: false,
+    };
+    return NextResponse.json(response);
+  }
+
+  // ── SINGLE aggregation query (Task #10 — avoid N+1) ─────────────────────
+  // One findMany returns every (callerId, parameterId, currentScore) tuple
+  // for the cohort × skill matrix. Banding + bucket counts happen in-process.
+  const rows = await prisma.callerTarget.findMany({
+    where: {
+      callerId: { in: callerIds },
+      parameterId: { in: parameterIds },
+    },
+    select: {
+      callerId: true,
+      parameterId: true,
+      currentScore: true,
+      callsUsed: true,
+    },
+  });
+
+  // Parameter display names + targetValues (for the ABOVE_TARGET buckets).
+  const parameters = await prisma.parameter.findMany({
+    where: { parameterId: { in: parameterIds } },
+    select: { parameterId: true, name: true },
+  });
+  const nameByParam = new Map(parameters.map((p) => [p.parameterId, p.name]));
+
+  // Tier mapping — same source the BandChip uses on the Caller Detail surfaces.
+  const tierMapping = await getSkillTierMapping(courseId);
+
+  // ── Banding ─────────────────────────────────────────────────────────────
+  // For each skill, walk its tierScheme and bucket every learner.
+  const rowsByParam = new Map<string, typeof rows>();
+  for (const r of rows) {
+    if (!rowsByParam.has(r.parameterId)) rowsByParam.set(r.parameterId, []);
+    rowsByParam.get(r.parameterId)!.push(r);
+  }
+
+  const heatmapRows: CohortHeatmapRow[] = skills.map((s) => {
+    const scheme = [...s.tierScheme];
+    const buckets: Record<string, number> = { [AWAITING_EVIDENCE]: 0 };
+    for (const tier of scheme) buckets[tier] = 0;
+    buckets[ABOVE_TARGET] = 0;
+
+    const skillRows = rowsByParam.get(s.parameterId) ?? [];
+    const measuredCallerIds = new Set<string>();
+
+    for (const r of skillRows) {
+      if (r.currentScore == null || (r.callsUsed ?? 0) === 0) continue;
+      measuredCallerIds.add(r.callerId);
+
+      // ABOVE_TARGET wins when score exceeds the educator's target.
+      if (r.currentScore > s.targetValue) {
+        buckets[ABOVE_TARGET]++;
+        continue;
+      }
+
+      // Bucket by tier name returned from scoreToTier — fall back to lowest
+      // scheme entry when the mapping returns something the scheme doesn't
+      // know (e.g. CEFR vs 4-tier mismatch).
+      const { tier: tierName } = scoreToTier(r.currentScore, tierMapping);
+      const normalized = tierName.toLowerCase();
+      if (buckets[normalized] !== undefined) {
+        buckets[normalized]++;
+      } else {
+        // Unknown tier from mapping — bucket into the closest scheme entry.
+        buckets[scheme[0] ?? AWAITING_EVIDENCE]++;
+      }
+    }
+
+    // Everyone not in `measuredCallerIds` is awaiting evidence.
+    buckets[AWAITING_EVIDENCE] = callerIds.length - measuredCallerIds.size;
+
+    // Target tier — proportional mapping of the (0–1) targetValue onto the
+    // scheme. Matches the Framework Map's `tierForTargetValue` helper.
+    const idx = Math.min(
+      Math.max(Math.floor(s.targetValue * scheme.length), 0),
+      scheme.length - 1,
+    );
+    const targetTier = scheme[idx] ?? null;
+
+    return {
+      skillRef: s.skillRef,
+      parameterId: s.parameterId,
+      parameterName: nameByParam.get(s.parameterId) ?? s.parameterId,
+      tierScheme: scheme,
+      targetTier,
+      targetValue: s.targetValue,
+      buckets,
+    };
+  });
+
+  const response: CohortHeatmapResponse = {
+    courseId,
+    totalLearners,
+    rows: heatmapRows,
+    empty: false,
+  };
+  return NextResponse.json(response);
+}

--- a/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Award, AlertTriangle, Info } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Award, AlertTriangle, Info, Grid3X3, Users } from "lucide-react";
 
 import {
   ABOVE_TARGET,
@@ -11,6 +11,30 @@ import {
 import { tierLabel } from "@/lib/banding/tier-colors";
 
 import "./course-skills-tab.css";
+
+type LensId = "framework-map" | "cohort-heatmap";
+
+interface LensSpec {
+  id: LensId;
+  label: string;
+  icon: React.ReactNode;
+  blurb: string;
+}
+
+const LENSES: LensSpec[] = [
+  {
+    id: "framework-map",
+    label: "Framework Map",
+    icon: <Grid3X3 size={14} />,
+    blurb: "The structural rubric — Skills × Tiers grid.",
+  },
+  {
+    id: "cohort-heatmap",
+    label: "Cohort Heatmap",
+    icon: <Users size={14} />,
+    blurb: "Where the cohort sits — per-skill × per-tier learner count.",
+  },
+];
 
 /**
  * Course Detail → Skills Framework tab (`?tab=skills&v=3`).
@@ -56,6 +80,7 @@ export function CourseSkillsTab({ courseId }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expandedSkillRef, setExpandedSkillRef] = useState<string | null>(null);
+  const [activeLens, setActiveLens] = useState<LensId>("framework-map");
 
   useEffect(() => {
     let cancelled = false;
@@ -113,8 +138,8 @@ export function CourseSkillsTab({ courseId }: Props) {
         </h2>
         <p className="hf-section-desc">
           The structural rubric this course measures learners against.
-          Each row is a Skill; each cell is a Tier in that skill's scheme.
-          The educator's target tier carries a ★ marker.
+          Each row is a Skill; each cell is a Tier in that skill&apos;s scheme.
+          The educator&apos;s target tier carries a ★ marker.
         </p>
         {data.playbookStatus === "DRAFT" ? (
           <div className="hf-skills-draft-watermark" aria-label="Course is in draft mode">
@@ -123,9 +148,11 @@ export function CourseSkillsTab({ courseId }: Props) {
         ) : null}
       </header>
 
+      <LensSwitcher active={activeLens} onChange={setActiveLens} />
+
       {data.empty ? (
         <EmptyState />
-      ) : (
+      ) : activeLens === "framework-map" ? (
         <FrameworkMapLens
           skills={data.skills}
           expandedSkillRef={expandedSkillRef}
@@ -133,9 +160,45 @@ export function CourseSkillsTab({ courseId }: Props) {
             setExpandedSkillRef((prev) => (prev === skillRef ? null : skillRef))
           }
         />
+      ) : (
+        <CohortHeatmapLens courseId={courseId} />
       )}
 
       <Legend />
+    </div>
+  );
+}
+
+// ── Lens switcher ───────────────────────────────────────────────────────────
+
+function LensSwitcher({
+  active,
+  onChange,
+}: {
+  active: LensId;
+  onChange: (id: LensId) => void;
+}) {
+  const activeSpec = LENSES.find((l) => l.id === active);
+  return (
+    <div className="hf-skills-lens-switcher" role="tablist" aria-label="Skills Framework lens">
+      {LENSES.map((lens) => (
+        <button
+          key={lens.id}
+          type="button"
+          role="tab"
+          aria-selected={active === lens.id}
+          className={`hf-skills-lens-tab ${
+            active === lens.id ? "hf-skills-lens-tab--active" : ""
+          }`}
+          onClick={() => onChange(lens.id)}
+        >
+          {lens.icon}
+          <span>{lens.label}</span>
+        </button>
+      ))}
+      {activeSpec ? (
+        <span className="hf-skills-lens-blurb">{activeSpec.blurb}</span>
+      ) : null}
     </div>
   );
 }
@@ -246,6 +309,156 @@ function FrameworkMapLens({
           </div>
         );
       })}
+    </div>
+  );
+}
+
+// ── Cohort Heatmap lens (SP2-D) ─────────────────────────────────────────────
+
+interface CohortHeatmapRow {
+  skillRef: string;
+  parameterId: string;
+  parameterName: string;
+  tierScheme: string[];
+  targetTier: string | null;
+  targetValue: number;
+  buckets: Record<string, number>;
+}
+
+interface CohortHeatmapResponse {
+  courseId: string;
+  totalLearners: number;
+  rows: CohortHeatmapRow[];
+  empty: boolean;
+}
+
+function CohortHeatmapLens({ courseId }: { courseId: string }) {
+  const [data, setData] = useState<CohortHeatmapResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/courses/${courseId}/skills-cohort-heatmap`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `${res.status} ${res.statusText}`);
+        }
+        return res.json();
+      })
+      .then((payload: CohortHeatmapResponse) => {
+        if (!cancelled) setData(payload);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  if (loading) {
+    return (
+      <div className="hf-skills-loading" role="status" aria-live="polite">
+        Loading cohort heatmap…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="hf-skills-error hf-banner-error" role="alert">
+        <AlertTriangle size={16} />
+        <div>
+          <strong>Could not load the Cohort Heatmap.</strong>
+          <div>{error}</div>
+        </div>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  if (data.empty) {
+    return <EmptyState />;
+  }
+
+  if (data.totalLearners === 0) {
+    return (
+      <div className="hf-skills-empty">
+        <Info size={20} aria-hidden />
+        <div>
+          <strong>No learners enrolled on this course yet.</strong>
+          <p>
+            Once learners enrol, this lens shows their distribution across
+            each skill&apos;s tiers — cold→hot, same colours as the
+            Framework Map and the per-learner Attainment view.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hf-skills-cohort">
+      <div className="hf-skills-cohort-meta">
+        Cohort: <strong>{data.totalLearners}</strong> learners enrolled
+      </div>
+      {data.rows.map((row) => (
+        <CohortHeatmapRowView
+          key={row.skillRef}
+          row={row}
+          totalLearners={data.totalLearners}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CohortHeatmapRowView({
+  row,
+  totalLearners,
+}: {
+  row: CohortHeatmapRow;
+  totalLearners: number;
+}) {
+  // Ordered render: AWAITING, scheme[0..n], ABOVE_TARGET
+  const orderedTiers = useMemo(() => {
+    const out: string[] = [AWAITING_EVIDENCE, ...row.tierScheme, ABOVE_TARGET];
+    return out;
+  }, [row.tierScheme]);
+
+  return (
+    <div className="hf-cohort-row">
+      <div className="hf-cohort-row-meta">
+        <span className="hf-skill-row-ref">{row.skillRef}</span>
+        <span className="hf-skill-row-name">{row.parameterName}</span>
+        <span className="hf-skill-row-target">
+          Target:{" "}
+          {row.targetTier ? tierLabel(row.targetTier) : "—"} · {(row.targetValue * 10).toFixed(1)}
+        </span>
+      </div>
+      <div className="hf-cohort-row-cells">
+        {orderedTiers.map((tier) => {
+          const count = row.buckets[tier] ?? 0;
+          const pct = totalLearners > 0 ? Math.round((count / totalLearners) * 100) : 0;
+          return (
+            <TierCell
+              key={`${row.skillRef}-${tier}`}
+              tier={tier}
+              target={tier === row.targetTier}
+              caption={`${count} · ${pct}%`}
+              size="default"
+            >
+              {count}
+            </TierCell>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/course-skills-tab.css
+++ b/apps/admin/app/x/courses/[courseId]/course-skills-tab.css
@@ -220,3 +220,92 @@
   color: var(--text-muted);
   font-size: 11px;
 }
+
+/* ── Lens switcher ───────────────────────────────────────────────────────── */
+
+.hf-skills-lens-switcher {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--border-default);
+  flex-wrap: wrap;
+}
+
+.hf-skills-lens-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 80ms ease-out, color 80ms ease-out;
+}
+
+.hf-skills-lens-tab:hover {
+  background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+  color: var(--text-primary);
+}
+
+.hf-skills-lens-tab--active {
+  background: var(--surface-primary);
+  color: var(--accent-primary);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 8%, transparent);
+}
+
+.hf-skills-lens-blurb {
+  margin-left: 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
+/* ── Cohort Heatmap lens ─────────────────────────────────────────────────── */
+
+.hf-skills-cohort {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hf-skills-cohort-meta {
+  font-size: 13px;
+  color: var(--text-muted);
+  padding: 4px 0;
+}
+
+.hf-skills-cohort-meta strong {
+  color: var(--text-primary);
+}
+
+.hf-cohort-row {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+}
+
+.hf-cohort-row-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hf-cohort-row-cells {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-start;
+}

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -10094,6 +10094,12 @@ Partial update of Playbook.config — accepts a sessionFlow
 
 ---
 
+### `GET` /api/courses/[courseId]/skills-cohort-heatmap
+
+**Auth**: Session
+
+---
+
 ### `GET` /api/courses/[courseId]/skills-framework
 
 **Auth**: Session
@@ -16014,8 +16020,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 514 |
-| Files with annotations | 502 |
+| Route files found | 515 |
+| Files with annotations | 503 |
 | Files missing annotations | 12 |
 | Coverage | 97.7% |
 


### PR DESCRIPTION
## Summary

Sprint 2 SP2-D — second lens on the Skills Framework tab. Per-skill × per-tier learner-count heatmap. Same cold→hot colour + glyph scheme as Framework Map.

## Highlights

- **New route** `GET /api/courses/[courseId]/skills-cohort-heatmap` — OPERATOR+ only. **Single aggregation query** per Task #10's mandate: one `CallerTarget.findMany` filtered to the playbook's enrolled callers × skill_* parameters, banded in-process via `scoreToTier`. No N+1.
- **`<LensSwitcher>`** — radio-style tabs at the top of the Skills tab. Framework Map default, Cohort Heatmap second. More lenses drop in via the `LENSES` array.
- **`<CohortHeatmapLens>` + `<CohortHeatmapRowView>`** — each row is one skill; cells ordered AWAITING → tierScheme[0..n] → ABOVE_TARGET. Each cell shows `count · pct%`. Target tier carries ★.
- **Empty-state branches** — zero learners → friendly copy; zero skills → reuses Framework Map's EmptyState.

## Verified by

- **tsc clean** on `apps/admin/app/api/courses/[courseId]/skills-cohort-heatmap/route.ts` + `apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx` + companion CSS
- **Sprint 1 + projection vitests pass** unchanged: 36 in `apps/admin/lib/wizard/__tests__/project-course-reference.test.ts` + 51 across `tier-colors.test.ts` / `TierCell.test.tsx` / `resolve-skill.test.ts` / `mastery-policy-resolver.test.ts`
- Live smoke pending in browser — `dev.humanfirstfoundation.com/x/courses/<cto-id>?tab=skills` → click "Cohort Heatmap" lens

## Test plan

- [x] tsc clean
- [ ] Visual smoke — lens switcher renders + Cohort Heatmap loads on CTO Revision Aid (has the 10 4-tier rubric live post PR #1573 + backfill)
- [ ] Cohort with real CallerTarget data (Cyrus Horváth on hf_sandbox has the only populated test data per earlier audits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)