### PR TITLE
feat(skills): SP4-D goal evidence trail polish on Attainment tab

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/attainment/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/attainment/route.ts
@@ -55,6 +55,28 @@ export interface AttainmentSkillBand {
   exceedsTarget: boolean;
 }
 
+export interface AttainmentGoalTrail {
+  /** Up to N most-recent evidence excerpts (transcript fragments captured
+   *  at extraction time). */
+  excerpts: string[];
+  /** Total number of evidence entries on this goal (may exceed `excerpts.length`). */
+  totalCount: number;
+  /** When the goal was first extracted. */
+  firstNoticedAt: string | null;
+  /** When the goal was most recently mentioned. */
+  lastMentionedAt: string | null;
+  /** Source call where the goal was first extracted. */
+  sourceCallId: string | null;
+  /** Most recent call where the goal was mentioned. */
+  lastMentionedCallId: string | null;
+  /** How many times this goal has been mentioned across calls. */
+  mentionCount: number;
+  /** EXPLICIT (caller said it directly) vs INFERRED (AI deduced). */
+  extractionMethod: string | null;
+  /** AI confidence at extraction time (0–1). */
+  confidence: number | null;
+}
+
 export interface AttainmentGoal {
   id: string;
   ref: string | null;
@@ -66,14 +88,12 @@ export interface AttainmentGoal {
    *  assessment_readiness / connect_warmth_avg / manual_only. Shown on
    *  the UI so the educator knows "this goal is driven by per-skill EMA". */
   strategy: string | null;
-  /** Structured evidence from `Goal.progressMetrics.progress` (last update). */
-  lastEvidence: {
-    evidence: string | null;
-    tier: string | null;
-    band: number | null;
-    callId: string | null;
-    at: string | null;
-  } | null;
+  /** Evidence trail synthesised from `Goal.progressMetrics`. `null` when
+   *  no metrics row exists (e.g. manually-created goal with no extraction
+   *  history). The trail uses the shape written by `extract-goals.ts`:
+   *  `{evidence: string[], extractionMethod, confidence, sourceCallId,
+   *  extractedAt, lastMentionedAt, lastMentionedCallId, mentionCount}`. */
+  trail: AttainmentGoalTrail | null;
 }
 
 export interface AttainmentModuleProgress {
@@ -103,6 +123,88 @@ export interface AttainmentResponse {
   modules: AttainmentModuleProgress[];
   goals: AttainmentGoal[];
   empty: boolean;
+}
+
+/** Max number of evidence excerpts surfaced in the trail. Older entries
+ *  are truncated; `totalCount` reports the full length. */
+const GOAL_TRAIL_MAX_EXCERPTS = 4;
+
+/**
+ * Synthesise an `AttainmentGoalTrail` from the JSON in `Goal.progressMetrics`.
+ *
+ * The shape that ships today is written by `lib/goals/extract-goals.ts`:
+ *
+ *   {
+ *     extractionMethod: "EXPLICIT" | "INFERRED",
+ *     confidence: 0..1,
+ *     evidence: string[],
+ *     sourceCallId: "call-…",
+ *     extractedAt: ISO date,
+ *     // — appended on subsequent mentions —
+ *     lastMentionedCallId: "call-…",
+ *     lastMentionedAt: ISO date,
+ *     mentionCount: number,
+ *   }
+ *
+ * Returns null when the metrics are absent / unparseable, so the UI can
+ * branch cleanly on "no evidence yet".
+ */
+function buildGoalTrail(
+  metrics: unknown,
+): AttainmentGoalTrail | null {
+  if (!metrics || typeof metrics !== "object") return null;
+  const m = metrics as Record<string, unknown>;
+  const rawEvidence = Array.isArray(m.evidence)
+    ? (m.evidence.filter((e) => typeof e === "string") as string[])
+    : [];
+  const sourceCallId =
+    typeof m.sourceCallId === "string" ? m.sourceCallId : null;
+  const lastMentionedCallId =
+    typeof m.lastMentionedCallId === "string" ? m.lastMentionedCallId : null;
+  const firstNoticedAt =
+    typeof m.extractedAt === "string" ? m.extractedAt : null;
+  const lastMentionedAt =
+    typeof m.lastMentionedAt === "string"
+      ? m.lastMentionedAt
+      : firstNoticedAt;
+  const mentionCount =
+    typeof m.mentionCount === "number"
+      ? m.mentionCount
+      : rawEvidence.length || 0;
+  const extractionMethod =
+    typeof m.extractionMethod === "string" ? m.extractionMethod : null;
+  const confidence =
+    typeof m.confidence === "number" ? m.confidence : null;
+
+  // Surface zero excerpts → null trail unless we have at least one signal
+  // (a callId or timestamp) so the UI can still render "Mentioned once,
+  // no excerpt captured".
+  if (
+    rawEvidence.length === 0 &&
+    !sourceCallId &&
+    !lastMentionedCallId &&
+    !firstNoticedAt
+  ) {
+    return null;
+  }
+
+  // Newest-first; the writer appends in chronological order so we reverse.
+  const excerptsNewestFirst = [...rawEvidence].reverse().slice(
+    0,
+    GOAL_TRAIL_MAX_EXCERPTS,
+  );
+
+  return {
+    excerpts: excerptsNewestFirst,
+    totalCount: rawEvidence.length,
+    firstNoticedAt,
+    lastMentionedAt,
+    sourceCallId,
+    lastMentionedCallId,
+    mentionCount,
+    extractionMethod,
+    confidence,
+  };
 }
 
 export async function GET(
@@ -271,29 +373,16 @@ export async function GET(
     orderBy: [{ priority: "desc" }, { name: "asc" }],
   });
 
-  const goals: AttainmentGoal[] = goalRows.map((g) => {
-    const metrics = (g.progressMetrics as Record<string, unknown> | null) ?? {};
-    const progress = (metrics.progress ?? null) as Record<string, unknown> | null;
-    const lastEvidence = progress
-      ? {
-          evidence: typeof progress.evidence === "string" ? progress.evidence : null,
-          tier: typeof progress.tier === "string" ? progress.tier : null,
-          band: typeof progress.band === "number" ? progress.band : null,
-          callId: typeof progress.callId === "string" ? progress.callId : null,
-          at: typeof progress.at === "string" ? progress.at : null,
-        }
-      : null;
-    return {
-      id: g.id,
-      ref: g.ref,
-      name: g.name,
-      type: g.type,
-      status: g.status,
-      progress: g.progress,
-      strategy: g.progressStrategy,
-      lastEvidence,
-    };
-  });
+  const goals: AttainmentGoal[] = goalRows.map((g) => ({
+    id: g.id,
+    ref: g.ref,
+    name: g.name,
+    type: g.type,
+    status: g.status,
+    progress: g.progress,
+    strategy: g.progressStrategy,
+    trail: buildGoalTrail(g.progressMetrics),
+  }));
 
   return NextResponse.json({
     callerId,

--- a/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
@@ -62,6 +62,18 @@ interface ModuleProgress {
   freshMasteryActive: boolean;
 }
 
+interface AttainmentGoalTrail {
+  excerpts: string[];
+  totalCount: number;
+  firstNoticedAt: string | null;
+  lastMentionedAt: string | null;
+  sourceCallId: string | null;
+  lastMentionedCallId: string | null;
+  mentionCount: number;
+  extractionMethod: string | null;
+  confidence: number | null;
+}
+
 interface AttainmentGoal {
   id: string;
   ref: string | null;
@@ -70,13 +82,7 @@ interface AttainmentGoal {
   status: string;
   progress: number;
   strategy: string | null;
-  lastEvidence: {
-    evidence: string | null;
-    tier: string | null;
-    band: number | null;
-    callId: string | null;
-    at: string | null;
-  } | null;
+  trail: AttainmentGoalTrail | null;
 }
 
 interface AttainmentResponse {
@@ -150,6 +156,7 @@ export function AttainmentTab({ callerId }: Props) {
   const [loBreakdown, setLoBreakdown] = useState<Record<string, LoMasteryResponse>>({});
   const [loLoading, setLoLoading] = useState<string | null>(null);
   const [loError, setLoError] = useState<Record<string, string>>({});
+  const [expandedGoalId, setExpandedGoalId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -299,7 +306,13 @@ export function AttainmentTab({ callerId }: Props) {
         onToggleModule={handleToggleModule}
       />
 
-      <GoalsSection goals={data.goals} />
+      <GoalsSection
+        goals={data.goals}
+        expandedGoalId={expandedGoalId}
+        onToggleGoal={(id) =>
+          setExpandedGoalId((current) => (current === id ? null : id))
+        }
+      />
     </div>
   );
 }
@@ -657,13 +670,22 @@ function loStatusLabel(status: LoMasteryStatus): string {
 
 // ── Goals section (SP4-D will deepen this) ──────────────────────────────────
 
-function GoalsSection({ goals }: { goals: AttainmentGoal[] }) {
+function GoalsSection({
+  goals,
+  expandedGoalId,
+  onToggleGoal,
+}: {
+  goals: AttainmentGoal[];
+  expandedGoalId: string | null;
+  onToggleGoal: (goalId: string) => void;
+}) {
   if (goals.length === 0) {
     return (
       <section className="hf-attainment-section">
         <h3 className="hf-attainment-section-title">Goal progress</h3>
         <p className="hf-attainment-empty-text">
-          No goals instantiated for this learner yet.
+          No goals instantiated for this learner yet — the first few calls
+          haven&apos;t surfaced anything specific to chase.
         </p>
       </section>
     );
@@ -672,35 +694,72 @@ function GoalsSection({ goals }: { goals: AttainmentGoal[] }) {
     <section className="hf-attainment-section">
       <h3 className="hf-attainment-section-title">Goal progress</h3>
       <p className="hf-attainment-section-desc">
-        Per-goal progress with the strategy driving it.
+        Per-goal progress with the strategy driving it. Click a goal to see
+        the evidence trail — what the learner said and when.
       </p>
       <div className="hf-attainment-goal-rows">
         {goals.slice(0, 12).map((g) => {
           const pct = Math.round(g.progress * 100);
+          const expanded = expandedGoalId === g.id;
+          const hasTrail = g.trail != null && (
+            g.trail.excerpts.length > 0 ||
+            g.trail.mentionCount > 0 ||
+            g.trail.firstNoticedAt != null
+          );
           return (
             <div key={g.id} className="hf-attainment-goal-row">
-              <div className="hf-attainment-goal-meta">
+              <button
+                type="button"
+                className="hf-attainment-goal-header"
+                onClick={() => onToggleGoal(g.id)}
+                aria-expanded={expanded}
+                aria-controls={`hf-attainment-goal-body-${g.id}`}
+                disabled={!hasTrail}
+              >
+                <span
+                  className="hf-attainment-goal-chevron"
+                  aria-hidden="true"
+                >
+                  {hasTrail ? (
+                    expanded ? (
+                      <ChevronDown size={12} />
+                    ) : (
+                      <ChevronRight size={12} />
+                    )
+                  ) : (
+                    <span className="hf-attainment-goal-chevron-spacer" />
+                  )}
+                </span>
                 <span className="hf-attainment-goal-type">{g.type}</span>
                 <span className="hf-attainment-goal-name">{g.name}</span>
                 {g.strategy ? (
                   <span className="hf-attainment-goal-strategy">
-                    {tierLabelForStrategy(g.strategy)}
+                    via {strategyLabel(g.strategy)}
                   </span>
                 ) : null}
-              </div>
-              <div className="hf-attainment-goal-bar">
+                <span className="hf-attainment-goal-bar">
+                  <span
+                    className="hf-attainment-goal-bar-fill"
+                    style={{ width: `${pct}%` }}
+                  />
+                </span>
+                <span className="hf-attainment-goal-pct">{pct}%</span>
+              </button>
+              {hasTrail && g.trail ? (
+                <div className="hf-attainment-goal-summary">
+                  {goalSummaryLine(g.trail)}
+                </div>
+              ) : (
+                <div className="hf-attainment-goal-summary hf-attainment-goal-summary-empty">
+                  No transcript evidence captured for this goal yet.
+                </div>
+              )}
+              {expanded && g.trail ? (
                 <div
-                  className="hf-attainment-goal-bar-fill"
-                  style={{ width: `${pct}%` }}
-                />
-              </div>
-              <div className="hf-attainment-goal-pct">{pct}%</div>
-              {g.lastEvidence?.evidence ? (
-                <div className="hf-attainment-goal-evidence">
-                  <strong>Last:</strong> {g.lastEvidence.evidence}
-                  {g.lastEvidence.tier
-                    ? ` (${tierLabel(g.lastEvidence.tier.toLowerCase())})`
-                    : ""}
+                  id={`hf-attainment-goal-body-${g.id}`}
+                  className="hf-attainment-goal-body"
+                >
+                  <GoalTrailDetail trail={g.trail} />
                 </div>
               ) : null}
             </div>
@@ -716,7 +775,91 @@ function GoalsSection({ goals }: { goals: AttainmentGoal[] }) {
   );
 }
 
-function tierLabelForStrategy(strategy: string): string {
+function GoalTrailDetail({ trail }: { trail: AttainmentGoalTrail }) {
+  return (
+    <div className="hf-attainment-trail">
+      <div className="hf-attainment-trail-meta">
+        {trail.extractionMethod ? (
+          <span className="hf-attainment-trail-pill">
+            {trail.extractionMethod === "EXPLICIT"
+              ? "Said directly"
+              : trail.extractionMethod === "INFERRED"
+                ? "Inferred"
+                : trail.extractionMethod}
+          </span>
+        ) : null}
+        {trail.confidence != null ? (
+          <span className="hf-attainment-trail-pill hf-attainment-trail-pill-muted">
+            {Math.round(trail.confidence * 100)}% confidence
+          </span>
+        ) : null}
+        {trail.mentionCount > 0 ? (
+          <span className="hf-attainment-trail-pill hf-attainment-trail-pill-muted">
+            Mentioned {trail.mentionCount}×
+          </span>
+        ) : null}
+      </div>
+      {trail.excerpts.length > 0 ? (
+        <ul className="hf-attainment-trail-excerpts">
+          {trail.excerpts.map((excerpt, i) => (
+            <li key={i}>&ldquo;{excerpt}&rdquo;</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="hf-attainment-trail-empty">
+          No transcript excerpt captured at extraction time.
+        </p>
+      )}
+      {trail.totalCount > trail.excerpts.length ? (
+        <p className="hf-attainment-trail-more">
+          + {trail.totalCount - trail.excerpts.length} older mention
+          {trail.totalCount - trail.excerpts.length === 1 ? "" : "s"}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** Educator-friendly one-liner summarising the trail. */
+function goalSummaryLine(trail: AttainmentGoalTrail): string {
+  const parts: string[] = [];
+  if (trail.firstNoticedAt) {
+    parts.push(`First noticed ${formatRelativeDate(trail.firstNoticedAt)}`);
+  }
+  if (
+    trail.lastMentionedAt &&
+    trail.lastMentionedAt !== trail.firstNoticedAt
+  ) {
+    parts.push(`last mentioned ${formatRelativeDate(trail.lastMentionedAt)}`);
+  }
+  if (trail.mentionCount > 1) {
+    parts.push(`across ${trail.mentionCount} calls`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : "Captured once";
+}
+
+/** Crude relative-date formatter — "today" / "yesterday" / "N days ago"
+ *  / "N weeks ago" / explicit date for older. Educators read these in
+ *  pre-call prep so absolute dates beyond a month carry more weight. */
+function formatRelativeDate(iso: string): string {
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return iso;
+  const now = Date.now();
+  const diffMs = now - then.getTime();
+  const day = 24 * 60 * 60 * 1000;
+  const days = Math.floor(diffMs / day);
+  if (days < 0) return then.toLocaleDateString();
+  if (days === 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days} days ago`;
+  if (days < 30) {
+    const weeks = Math.round(days / 7);
+    return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+  }
+  return then.toLocaleDateString();
+}
+
+function strategyLabel(strategy: string): string {
   switch (strategy.toLowerCase()) {
     case "lo_rollup":
       return "LO rollup";

--- a/apps/admin/components/callers/caller-detail/attainment-tab.css
+++ b/apps/admin/components/callers/caller-detail/attainment-tab.css
@@ -403,22 +403,18 @@
   font-style: italic;
 }
 
-/* ── Goal rows ───────────────────────────────────────────────────────────── */
+/* ── Goal rows + trail (SP4-D) ───────────────────────────────────────────── */
 
 .hf-attainment-goal-rows {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   margin-top: 6px;
 }
 
 .hf-attainment-goal-row {
-  display: grid;
-  grid-template-columns: 1fr 220px 60px;
-  grid-template-rows: auto auto;
-  gap: 6px 12px;
-  align-items: center;
-  padding: 6px 4px;
+  display: flex;
+  flex-direction: column;
   border-bottom: 1px dashed var(--border-default);
 }
 
@@ -426,39 +422,74 @@
   border-bottom: 0;
 }
 
-.hf-attainment-goal-meta {
-  display: flex;
-  gap: 8px;
+.hf-attainment-goal-header {
+  display: grid;
+  grid-template-columns: 14px 56px 1fr auto 200px 50px;
+  gap: 10px;
   align-items: center;
-  grid-column: 1;
-  grid-row: 1;
+  width: 100%;
+  padding: 6px 4px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.hf-attainment-goal-header:hover:not(:disabled) {
+  background: var(--surface-secondary);
+}
+
+.hf-attainment-goal-header:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
+.hf-attainment-goal-header:disabled {
+  cursor: default;
+}
+
+.hf-attainment-goal-chevron {
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hf-attainment-goal-chevron-spacer {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
 }
 
 .hf-attainment-goal-type {
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.05em;
   color: var(--accent-primary);
   background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
   padding: 1px 6px;
   border-radius: 4px;
+  text-align: center;
 }
 
 .hf-attainment-goal-name {
   font-size: 13px;
   font-weight: 500;
   color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hf-attainment-goal-strategy {
   font-size: 10px;
   color: var(--text-muted);
   font-style: italic;
+  white-space: nowrap;
 }
 
 .hf-attainment-goal-bar {
-  grid-column: 2;
-  grid-row: 1;
+  display: block;
   height: 6px;
   background: var(--surface-secondary);
   border-radius: 3px;
@@ -466,24 +497,92 @@
 }
 
 .hf-attainment-goal-bar-fill {
+  display: block;
   height: 100%;
   background: var(--status-success-text);
 }
 
 .hf-attainment-goal-pct {
-  grid-column: 3;
-  grid-row: 1;
   font-size: 12px;
   color: var(--text-muted);
   text-align: right;
 }
 
-.hf-attainment-goal-evidence {
-  grid-column: 1 / -1;
-  grid-row: 2;
+.hf-attainment-goal-summary {
   font-size: 11px;
   color: var(--text-muted);
-  padding-left: 8px;
+  padding: 0 4px 6px 28px;
+}
+
+.hf-attainment-goal-summary-empty {
+  font-style: italic;
+}
+
+.hf-attainment-goal-body {
+  padding: 4px 4px 12px 28px;
+  background: color-mix(in srgb, var(--surface-secondary) 50%, transparent);
+}
+
+.hf-attainment-trail {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 12px;
+}
+
+.hf-attainment-trail-meta {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 10px;
+}
+
+.hf-attainment-trail-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  color: var(--accent-primary);
+  font-weight: 500;
+}
+
+.hf-attainment-trail-pill-muted {
+  background: var(--surface-primary);
+  color: var(--text-muted);
+  border: 1px solid var(--border-default);
+}
+
+.hf-attainment-trail-excerpts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.hf-attainment-trail-excerpts li {
+  padding: 4px 8px;
+  background: var(--surface-primary);
+  border-left: 2px solid var(--accent-primary);
+  border-radius: 0 4px 4px 0;
+}
+
+.hf-attainment-trail-empty {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+.hf-attainment-trail-more {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 0;
 }
 
 .hf-attainment-goal-more {

--- a/apps/admin/tests/api/callers/attainment-route.test.ts
+++ b/apps/admin/tests/api/callers/attainment-route.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for `GET /api/callers/[callerId]/attainment` — SP4-D goal trail
+ * polish. Validates the `buildGoalTrail` synthesis against the real
+ * `progressMetrics` shape written by `lib/goals/extract-goals.ts`.
+ *
+ * Sister of `tests/api/callers/lo-mastery-route.test.ts` (SP4-C).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    caller: { findUnique: vi.fn() },
+    callerPlaybook: { findFirst: vi.fn() },
+    callerTarget: { findMany: vi.fn() },
+    callerModuleProgress: { findMany: vi.fn() },
+    parameter: { findMany: vi.fn() },
+    goal: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: () => true,
+  callerScopeMismatchResponse: () => new Response(null, { status: 403 }),
+}));
+vi.mock("@/lib/curriculum/resolve-skill", () => ({
+  resolveAllSkillsForPlaybook: vi.fn(async () => []),
+}));
+vi.mock("@/lib/curriculum/playbook-mastery-config", () => ({
+  isUseFreshMastery: vi.fn(async () => false),
+}));
+vi.mock("@/lib/goals/track-progress", () => ({
+  getSkillTierMapping: vi.fn(async () => ({ tiers: [] })),
+  scoreToTier: () => ({ tier: "DEVELOPING", band: 2 }),
+}));
+vi.mock("@/lib/pipeline/course-style", () => ({
+  // CONTINUOUS by default → modules section is empty (the route's #1252
+  // guard branches out). Tests can override per-case via mockReturnValue.
+  getCourseStyle: vi.fn(() => "continuous"),
+}));
+
+const PARAMS = { params: Promise.resolve({ callerId: "c1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/callers/[callerId]/attainment/route");
+}
+
+function happy() {
+  mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+  mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+    playbookId: "pb1",
+    playbook: { id: "pb1", name: "IELTS Speaking", config: {} },
+  });
+  mockPrisma.callerTarget.findMany.mockResolvedValue([]);
+  mockPrisma.parameter.findMany.mockResolvedValue([]);
+  mockPrisma.callerModuleProgress.findMany.mockResolvedValue([]);
+}
+
+describe("GET /api/callers/[callerId]/attainment — goal trail (SP4-D)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("trail is null when goal has no progressMetrics", async () => {
+    happy();
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        ref: null,
+        name: "Improve fluency",
+        type: "LEARN",
+        status: "ACTIVE",
+        progress: 0.3,
+        progressStrategy: "lo_rollup",
+        progressMetrics: null,
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.goals[0].trail).toBeNull();
+  });
+
+  it("trail surfaces evidence + extraction context for a real extract-goals shape", async () => {
+    happy();
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        ref: null,
+        name: "Improve fluency",
+        type: "LEARN",
+        status: "ACTIVE",
+        progress: 0.4,
+        progressStrategy: "skill_ema",
+        progressMetrics: {
+          extractionMethod: "EXPLICIT",
+          confidence: 0.82,
+          evidence: [
+            "I want to stop stalling on word-search",
+            "Need to get faster at part 2 monologue",
+          ],
+          sourceCallId: "call-a",
+          extractedAt: "2026-06-05T10:00:00Z",
+          lastMentionedCallId: "call-b",
+          lastMentionedAt: "2026-06-10T11:00:00Z",
+          mentionCount: 2,
+        },
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    const t = body.goals[0].trail;
+    expect(t).not.toBeNull();
+    expect(t.extractionMethod).toBe("EXPLICIT");
+    expect(t.confidence).toBe(0.82);
+    expect(t.sourceCallId).toBe("call-a");
+    expect(t.lastMentionedCallId).toBe("call-b");
+    expect(t.firstNoticedAt).toBe("2026-06-05T10:00:00Z");
+    expect(t.lastMentionedAt).toBe("2026-06-10T11:00:00Z");
+    expect(t.mentionCount).toBe(2);
+    expect(t.totalCount).toBe(2);
+    // Newest-first ordering — writer appends chronologically.
+    expect(t.excerpts[0]).toBe("Need to get faster at part 2 monologue");
+    expect(t.excerpts[1]).toBe("I want to stop stalling on word-search");
+  });
+
+  it("truncates excerpts to the first 4 entries, preserving totalCount", async () => {
+    happy();
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        ref: null,
+        name: "Goal",
+        type: "LEARN",
+        status: "ACTIVE",
+        progress: 0,
+        progressStrategy: null,
+        progressMetrics: {
+          evidence: ["e1", "e2", "e3", "e4", "e5", "e6"],
+          mentionCount: 6,
+          extractedAt: "2026-06-01T10:00:00Z",
+        },
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    const t = body.goals[0].trail;
+    expect(t.excerpts).toHaveLength(4);
+    expect(t.totalCount).toBe(6);
+    // Newest-first → e6 first.
+    expect(t.excerpts[0]).toBe("e6");
+  });
+
+  it("handles legacy goals with no evidence array but a source call (single-mention bootstrap)", async () => {
+    happy();
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        ref: null,
+        name: "Goal",
+        type: "LEARN",
+        status: "ACTIVE",
+        progress: 0,
+        progressStrategy: null,
+        progressMetrics: {
+          extractionMethod: "INFERRED",
+          confidence: 0.6,
+          sourceCallId: "call-a",
+          extractedAt: "2026-06-05T10:00:00Z",
+        },
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    const t = body.goals[0].trail;
+    expect(t).not.toBeNull();
+    expect(t.excerpts).toEqual([]);
+    expect(t.totalCount).toBe(0);
+    expect(t.extractionMethod).toBe("INFERRED");
+    expect(t.sourceCallId).toBe("call-a");
+  });
+
+  it("ignores non-string evidence entries (defensive against future writer drift)", async () => {
+    happy();
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        ref: null,
+        name: "Goal",
+        type: "LEARN",
+        status: "ACTIVE",
+        progress: 0,
+        progressStrategy: null,
+        progressMetrics: {
+          evidence: ["valid", 42, null, { foo: "bar" }, "also-valid"],
+          extractedAt: "2026-06-05T10:00:00Z",
+        },
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    const t = body.goals[0].trail;
+    expect(t.excerpts).toEqual(["also-valid", "valid"]);
+    expect(t.totalCount).toBe(2);
+  });
+
+  it("falls back to extractedAt for lastMentionedAt when missing (single-mention)", async () => {
+    happy();
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        ref: null,
+        name: "Goal",
+        type: "LEARN",
+        status: "ACTIVE",
+        progress: 0,
+        progressStrategy: null,
+        progressMetrics: {
+          evidence: ["only"],
+          extractedAt: "2026-06-05T10:00:00Z",
+          sourceCallId: "call-a",
+        },
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    const t = body.goals[0].trail;
+    expect(t.lastMentionedAt).toBe("2026-06-05T10:00:00Z");
+    expect(t.firstNoticedAt).toBe("2026-06-05T10:00:00Z");
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -16050,8 +16050,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 519 |
-| Files with annotations | 507 |
+| Route files found | 520 |
+| Files with annotations | 508 |
 | Files missing annotations | 12 |
 | Coverage | 97.7% |
 

--- a/docs/decisions/2026-06-13-kms-envelope-encryption-prereq.md
+++ b/docs/decisions/2026-06-13-kms-envelope-encryption-prereq.md
@@ -1,0 +1,204 @@
+# ADR: KMS envelope encryption — prereq substrate for app-layer column encryption
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Deciders:** Paul W
+
+## Context
+
+Today HF has no application-layer encryption. PII columns (`Caller.{email,name,phone}`,
+`User.{email,phone}`, `Call.transcript`, `CallMessage.content`, `VoiceProvider.credentials`)
+live in plaintext. The only protection is Cloud SQL transparent at-rest, which is keyed
+by Google's managed KMS and defends against the *disk-theft* threat model — not against
+leaked backup snapshots, DB-admin compromise, or insider read access.
+
+The pre-existing TODO at `lib/voice/provider-factory.ts:24-25` calls for AES-256-GCM
+on `VoiceProvider.credentials` (tracked as R1 in #1031, non-blocking post-market-test
+follow-up). Reuse-finder ran 2026-06-13 and confirmed:
+
+- **Zero AES-GCM / column-cipher usage** in the codebase. HMAC-SHA256 only (webhook
+  signatures at `lib/voice/providers/{vapi,retell}/auth.ts`, media token signing at
+  `app/api/media/[id]/public/route.ts:47`, content hashing at `lib/storage/utils.ts`).
+- **Zero KMS / Secret Manager wrappers** — no `@google-cloud/kms` or
+  `@google-cloud/secret-manager` dependency.
+- The existing env-secret pattern at `lib/config.ts:101-117`
+  (`config.security.internalApiSecret`) is the closest precedent for key injection
+  but is single-value, no rotation, no envelope.
+
+Without a key-management substrate, any app-layer encryption is theatre — a leaked
+process env or a leaked `.env.local` reveals the master key alongside the ciphertext,
+and the attacker has both. **KMS is a prereq, not a story line-item.**
+
+This ADR captures the substrate. The encryption *scope* (which fields, in which order)
+is a separate decision (2026-06-13-pii-encryption-scope.md).
+
+## Options considered
+
+1. **No KMS — env-var DEK with manual rotation runbook.** Cheapest. Defended only
+   against leaked DB backup snapshot taken without the env. Useless if env + DB are
+   exfiltrated together (the realistic incident shape for a Cloud Run breach).
+   **Rejected.**
+2. **GCP KMS envelope encryption.** Master key in KMS (`hf-pii-kek-<env>`), per-row
+   data encryption key (DEK) generated at app layer, DEK wrapped by KMS, wrapped DEK
+   stored alongside ciphertext in the row. Standard pattern; matches Google's own
+   guidance.
+3. **GCP KMS direct encrypt (no envelope).** Every encrypt/decrypt is a KMS API
+   round-trip. Latency: ~30ms × every read of every PII row. Rejected — destroys
+   list-view performance.
+4. **GCP Secret Manager.** Wrong tool — Secret Manager stores secrets but doesn't
+   provide a cipher API. Could be used to hold the wrapping key, but that just
+   reinvents KMS poorly. **Rejected.**
+5. **HashiCorp Vault.** Adds a sidecar dependency. We have no Vault deployment;
+   spinning one up for one use case is disproportionate. **Rejected.**
+6. **AWS KMS / Azure Key Vault.** We're on GCP. **Rejected.**
+
+## Decision
+
+**Adopt Option 2 — GCP KMS envelope encryption.**
+
+### Substrate
+
+- One **KEK (Key Encryption Key)** per environment in GCP KMS:
+  `projects/hf-<env>/locations/europe-west2/keyRings/hf-pii/cryptoKeys/hf-pii-kek`.
+- Per-row **DEK (Data Encryption Key)** generated app-side via
+  `crypto.randomBytes(32)` (AES-256). DEK is used to AES-256-GCM encrypt the
+  plaintext column.
+- DEK is wrapped by the KEK via `kmsClient.encrypt(kekName, dek)` and the wrapped
+  blob stored alongside the ciphertext (typically in a sibling column or a
+  `Bytes` column with a length prefix).
+- Decrypt path: read wrapped DEK + ciphertext, call `kmsClient.decrypt(kekName,
+  wrappedDek)` → DEK, then AES-256-GCM decrypt locally. KMS round-trip is one per
+  *row read*, not per byte. List views can amortise via parallel KMS calls.
+
+### Storage shape
+
+For a single encrypted column `X`, the row carries:
+
+| Column | Type | Contents |
+|---|---|---|
+| `X_ciphertext` | `Bytes` | AES-256-GCM(plaintext, DEK, IV) ‖ GCM tag |
+| `X_iv` | `Bytes` | 12-byte random IV (per-row) |
+| `X_wrappedDek` | `Bytes` | KMS-wrapped DEK |
+| `X_kekVersion` | `Int` | KMS key version at encrypt-time (for rotation tracking) |
+
+Overhead per row: 16B GCM tag + 12B IV + ~120B wrapped DEK + 4B version = **~152B
+fixed** + plaintext size. Negligible storage cost.
+
+### Key rotation
+
+GCP KMS supports automatic key rotation. We enable:
+- Rotation period: **90 days** (matches API-key rotation cadence).
+- On rotation, KMS generates a new primary version; existing wrapped DEKs continue
+  to decrypt against their original version (KMS keeps prior versions enabled).
+- A background re-wrap job (out of scope here, future story) walks rows with
+  `X_kekVersion < currentVersion` and re-wraps DEKs against the new primary. This
+  is the "cryptoshred-old-key" eventual cleanup.
+
+### Helpers
+
+New `lib/crypto/envelope.ts`:
+
+- `encryptColumn(plaintext: string): Promise<EncryptedColumn>` — generates DEK,
+  encrypts, wraps DEK against the current KEK, returns the four-field tuple.
+- `decryptColumn(blob: EncryptedColumn): Promise<string>` — unwraps DEK against
+  the appropriate KEK version, decrypts.
+- `encryptColumnBatch(plaintexts: string[])` / `decryptColumnBatch(blobs[])` —
+  amortise KMS round-trips for list views via `Promise.all`.
+
+The helper interface intentionally hides the DEK lifecycle. Call sites see a
+plaintext-in / blob-out interface and never touch the KEK directly.
+
+### Env vars / config
+
+Add to `lib/config.ts::config.security`:
+
+- `kmsKekName: string` — required in production, optional in dev with a
+  **plaintext-passthrough fallback** that returns the input unchanged and stamps
+  the row with `X_kekVersion = 0` (a sentinel meaning "not encrypted, dev only").
+- The dev fallback is what makes tests pass without a real KMS; it must
+  **fail-closed in production** (config validation rejects empty `kmsKekName`
+  when `NEXT_PUBLIC_APP_ENV=PROD`).
+
+### Local dev / tests
+
+Tests never hit real KMS. The plaintext-passthrough fallback is the test mode.
+This is the deliberate "encryption in tests is theatre — verify the pipeline
+shape, not the cipher" trade-off. **The fallback MUST NOT compile into the
+production bundle when `NEXT_PUBLIC_APP_ENV=PROD`** — enforce via a build-time
+guard that aborts if both `NEXT_PUBLIC_APP_ENV=PROD` and `kmsKekName` is empty.
+
+A small integration test runs against an actual KMS keyring on hf-dev (one
+KEK, one decrypt round-trip) — proves the pipeline end-to-end, doesn't gate the
+unit suite.
+
+### IAM
+
+- Cloud Run service account gets `roles/cloudkms.cryptoKeyEncrypterDecrypter` on
+  the KEK only. No admin permissions.
+- KMS admin roles held by Paul + ops (not the runtime SA).
+- Audit log: GCP automatically logs every encrypt/decrypt against the KEK. We
+  retain this as the auditor surface — "X decrypts of Caller PII at time T from
+  service S" is queryable in Cloud Logging.
+
+## Consequences
+
+### Positive
+
+- App-layer column encryption becomes a tractable next step. Any field can be
+  added to the encrypted set with `encryptColumn` / `decryptColumn` wrapping —
+  no per-field cipher boilerplate.
+- KMS audit log is auditor-grade and free.
+- Cryptoshred-on-rotation is a real capability (re-wrap job).
+- Defends against the realistic threat: leaked backup + leaked env. Attacker
+  needs the live KMS KEK to decrypt; KMS is not in the backup or the env.
+
+### Negative
+
+- Adds `@google-cloud/kms` dep tree (~500KB transitive).
+- One KMS round-trip per row read on cold cache. List views need batching to
+  stay under 100ms.
+- GCP KMS is not free: ~$0.06 per 10K operations. At market-test scale
+  (~50 learners × 5 reads/day × 10 PII fields = 2,500 ops/day) this is
+  **~$0.45/year**. At pilot scale (10K learners) it climbs to ~$1.80/year.
+  Always cheap.
+- Dev experience: developers must remember the plaintext-passthrough fallback
+  exists in dev; calling `.toLowerCase()` on what they think is `email` will
+  still work, but tests that grep DB directly for "alice@example.com" must
+  decrypt first.
+- Rollback path: complex. Once a column is encrypted in prod, rolling back
+  means decrypting every row before disabling encryption — a forward-only
+  decision.
+
+### Open follow-ons
+
+- **DEK caching** — short-lived in-memory cache (60s TTL) of unwrapped DEKs to
+  cut KMS round-trips on hot rows. Not part of v1; add if KMS cost ever bites.
+- **Re-wrap on rotation** worker. Schedule via Cloud Scheduler once a column is
+  encrypted in prod and the 90-day rotation completes.
+- **Per-tenant KEK** (multi-tenancy future) — different KEK per
+  Institution/Domain. Out of scope today; the column carries `X_kekName` if we
+  ever need this.
+
+## Implementation order
+
+This ADR is a prereq, not a story. The actual story sequence is:
+
+1. **Land KMS infrastructure** — terraform/gcloud the KEKs in DEV / STAGING /
+   PROD KMS keyrings; add SA bindings; add config env vars. ~1d.
+2. **Land `lib/crypto/envelope.ts`** — encrypt/decrypt helpers, fallback,
+   integration test. ~1d.
+3. **Apply to first column** — `VoiceProvider.credentials` (smallest, lowest
+   blast radius, already TODO'd). Migration + backfill + decrypt-on-read in
+   `provider-factory.ts`. ~1d.
+4. **Then** the broader scope decision in
+   `2026-06-13-pii-encryption-scope.md` rolls in.
+
+**Total prereq budget: ~3d.** Story-tracked separately once approved.
+
+## References
+
+- [GCP KMS envelope encryption guidance](https://cloud.google.com/kms/docs/envelope-encryption)
+- `lib/voice/provider-factory.ts:24-25` — original TODO
+- #1031 — voice provider rationalisation epic (where R1 lives)
+- Sibling ADR: `2026-06-13-pii-encryption-scope.md` (which fields, what order)
+- Reuse-finder report 2026-06-13 (in conversation)

--- a/docs/decisions/2026-06-13-pii-encryption-scope.md
+++ b/docs/decisions/2026-06-13-pii-encryption-scope.md
@@ -1,0 +1,174 @@
+# ADR: PII encryption scope — what we encrypt and in what order
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Deciders:** Paul W
+
+## Context
+
+Sibling decision to `2026-06-13-kms-envelope-encryption-prereq.md`. That ADR
+establishes the KMS + envelope-encryption substrate; this ADR decides *which
+columns* go through it and *in which order*.
+
+The candidate columns, from the reuse-finder pass 2026-06-13:
+
+| Column | Sensitivity | Write sites | Read sites that filter/search |
+|---|---|---|---|
+| `VoiceProvider.credentials` (JSON) | **High** — live API keys + webhook secrets | 3 (seed + 2 migrations) | 0 (slug-keyed lookup) |
+| `Call.transcript` | **High** — conversational PII inside the text | ~70 | 0 directly; many *read* it but none `WHERE transcript LIKE …` |
+| `CallMessage.content` | **High** — same shape | 8 | 0 |
+| `Caller.email` | **Medium** — PII identifier | 39 routes + 32 seed | **4 legacy seed-only**; modern code does not filter by email |
+| `Caller.phone` | **Medium** — PII identifier | (same) | **2 legacy seed-only**; modern code does not filter by phone |
+| `Caller.name` | **Low-medium** — display name | (same) | 0 direct `LIKE` filters |
+| `User.email` | **Medium** — auth identifier | 31 | **NextAuth depends on `findUnique({where:{email}})`** |
+| `User.phone` | **Medium** | (same) | 0 |
+
+The original cost analysis (in conversation 2026-06-13) priced full PII
+encryption at "expensive + breaks search + needs KMS + low marginal benefit
+vs Cloud SQL at-rest for current threat model." The reuse-finder then
+**inverted one of those assumptions**: modern code rarely filters by email
+or phone. Search regression cost is much smaller than feared. But **NextAuth
+on `User.email` is a hard blocker** for `User` field encryption — the entire
+credentials login flow keys off it.
+
+The threat we are defending against is **leaked DB backup or live snapshot
+clone reaching an attacker who does not also have live KMS access**. Cloud
+SQL transparent at-rest handles disk theft but not snapshot exfiltration to
+a 3rd-party storage bucket.
+
+## Options considered
+
+1. **Full PII encryption** — Caller + User + transcripts + credentials.
+   ~6 weeks engineering. Forces redesign of NextAuth User.email lookup
+   (hash-and-lookup pattern) and the GDPR export flow. Highest defensive
+   posture; worst time-to-value.
+2. **Credentials only (R1 / #1031)** — just `VoiceProvider.credentials`.
+   ~1d after KMS substrate lands. Defends the realistic, highest-impact
+   threat (leaked DB → 3rd-party billing fraud via stolen API keys). Doesn't
+   touch any auditor-visible PII story.
+3. **Credentials + transcripts** — the high-sensitivity content tier.
+   Covers conversational PII (which is most of what an external auditor will
+   ask about) without touching identifier columns. ~5d after KMS substrate.
+   No search regression. No NextAuth blocker.
+4. **Credentials + transcripts + Caller PII** — option 3 plus
+   `Caller.{email,name,phone}`. ~10d total. Search regression is small
+   (legacy seed sites only) but introduces a hash-shadow column pattern for
+   the legacy filters and the `findUnique` on Caller.email if it exists.
+   Touches `User` only at the edges.
+5. **Defer indefinitely** — the do-nothing option. Cost: zero today, but
+   the threat is real and the post-market-test pickup cost grows linearly
+   with rows.
+
+## Decision
+
+**Adopt Option 3 — Credentials + transcripts.** Phased rollout:
+
+### Phase 1 (immediate, on KMS substrate landing)
+
+**`VoiceProvider.credentials`** — closes R1 / #1031 TODO.
+
+- Column shape per the KMS ADR (`credentials_ciphertext`, `_iv`, `_wrappedDek`,
+  `_kekVersion`). The existing `credentials Json` field is renamed
+  `credentials_legacy_plaintext` for migration window, then dropped after backfill.
+- Read site: `lib/voice/provider-factory.ts::getVoiceProvider` — calls
+  `decryptColumn` before passing to the adapter. The 5-minute cache means KMS
+  round-trip is amortised across many calls.
+- Write site: admin UI `/x/settings/voice-providers/[id]` calls
+  `encryptColumn` before `prisma.voiceProvider.update`.
+- Backfill: idempotent migration script reads every row, encrypts plaintext,
+  writes the encrypted tuple, leaves `_legacy_plaintext` populated until the
+  follow-up drop migration.
+- Effort: ~1d.
+
+### Phase 2 (after Phase 1 ships)
+
+**`Call.transcript` + `CallMessage.content`.**
+
+- Same column-tuple shape on both. Existing column becomes the ciphertext
+  field; the redacted/raw decision from `C3` (separate story) determines
+  what plaintext we feed into encrypt.
+- **Order with C3:** C3 (redaction) lands FIRST. Phase 2 encryption then
+  encrypts both `transcriptRaw` and `transcript`. Inverting the order means
+  Phase 2 encrypts the raw transcript, then C3 has to decrypt-redact-re-encrypt
+  on every existing row.
+- Pipeline read sites (`priorCallFeedback.ts`, `adaptive-loop-invariants.ts`,
+  pipeline runners) all gain a `decryptColumn` call. Batch decrypt where
+  list views fetch many rows.
+- Admin transcript views (`/x/calls/[id]`, Course Design Preview) gain
+  the same decrypt step.
+- AppLog / verbose voice diag: per C3 read-path rules these always read the
+  redacted column, which is still encrypted at rest but cheap to decrypt
+  because it's already PII-scrubbed.
+- Effort: ~3d after Phase 1, **plus** the dependency on C3 landing first.
+
+### Out of scope (deferred or rejected)
+
+| Item | Reason |
+|---|---|
+| `Caller.{email,name,phone}` encryption | NextAuth depends on `User.email` `findUnique` and the auth flow's design (#1133 SMS adapter epic) is in flux. Encrypting Caller PII without Encrypting User PII leaves a gap. Defer until the auth flow stabilises and we have a defensible end-to-end story. |
+| `User.{email,phone}` encryption | NextAuth credentials provider keys off `User.email`. Encrypting it requires a hash-shadow column and a NextAuth adapter rewrite. Disproportionate cost — better to defer until we move to passkeys / OIDC where the email isn't on the auth hot path. |
+| `CallerMemory.{key,value}` encryption | These are AI-derived structured facts, often quoting PII. Encrypting them solves a smaller surface than encrypting transcript (the transcript is the source). Wait until transcript encryption proves the pattern. |
+| `CallerAttribute.value` encryption | Same as CallerMemory. |
+| `IntakeEvent.payload` encryption | This is the auditor chain. Encryption would impede the auditor surface. Better to keep `intake_event` accessible in plaintext and rely on database access controls + retention to protect it. (Open follow-on: row-level access policies — separate decision.) |
+| `Caller.externalId` encryption | Opaque token already; defeats the threat. |
+| Indexed-search on encrypted columns (HMAC-hash sibling) | Not needed yet — modern code doesn't filter by email/phone. Add when a future feature requires it. |
+| Re-encryption with new KEK version after rotation | Cron job, separate story. Phase 1 + Phase 2 just stamp `_kekVersion`; the re-wrap worker comes later. |
+
+## Consequences
+
+### Positive
+
+- The realistic threat is closed quickly (Phase 1 — ~1d after KMS substrate).
+- Conversational PII (the biggest auditor narrative item) gets encrypted in
+  Phase 2 without breaking auth or search.
+- No NextAuth rewrite required.
+- Caller / User PII deferral is a real cost saving on the test-fixture burden
+  (Caller is constructed in 100+ test fixtures; not having to thread
+  encryption helpers through all of them is meaningful engineering hours).
+
+### Negative
+
+- **The Caller / User identifier columns remain in plaintext.** A leaked
+  backup still reveals who-is-who at the identifier level. The defence
+  applies only to the *content tier*. Document this honestly in the
+  auditor-facing security page — don't claim full PII encryption.
+- C3 (transcript redaction) is now a hard prereq of Phase 2. If C3 slips,
+  Phase 2 slips.
+- The "credentials are encrypted" Phase 1 win is small in surface area but
+  defends a real-money threat (stolen API keys → 3rd-party billing fraud);
+  it doesn't move the GDPR / auditor needle much.
+
+### Reversibility
+
+- Phase 1 (credentials): forward-only. Rolling back means decrypting every
+  row before disabling. Cost: small (~10s of rows in prod).
+- Phase 2 (transcripts): forward-only. Rolling back at scale is expensive
+  (decrypt all calls). Mitigation: a feature flag `HF_PII_ENCRYPT_ENABLED`
+  during the rollout window so we can disable new-write encryption while
+  leaving existing rows encrypted-and-readable.
+
+### Open follow-ons
+
+- **Auth flow stabilisation** (#1133) — when SMS-first / passkey design
+  lands, revisit Caller + User PII encryption.
+- **Row-level access policies** for `intake_event` — if database-admin
+  threat model tightens, restrict who can `SELECT` from the chain.
+- **DEK cache + KMS cost analysis** — review actual KMS spend at Phase 2 +
+  30d. Re-enable batching/caching if cost rises faster than expected.
+
+## Implementation order
+
+1. **KMS substrate** — per sibling ADR. ~3d.
+2. **Phase 1 — credentials encryption** — ~1d after substrate.
+3. **C3 — transcript redaction** — separate story, separate ADR if needed.
+4. **Phase 2 — transcript encryption** — ~3d after C3.
+
+**Total: ~7d of focused engineering across two stories, sequenced behind KMS.**
+
+## References
+
+- Sibling ADR: `2026-06-13-kms-envelope-encryption-prereq.md`
+- `lib/voice/provider-factory.ts:24-25` — original TODO
+- #1031 — R1 follow-on
+- C3 story (transcript redaction) — TL ruling 2026-06-13
+- Reuse-finder report 2026-06-13 (in conversation) — write/read site counts


### PR DESCRIPTION
## Summary

Sprint 4 SP4-D — surfaces the educator-meaningful goal evidence trail
that SP4-A's `lastEvidence` reader missed. The shipped read assumed a
`Goal.progressMetrics.progress.{evidence,tier,band,callId,at}`
sub-object that **no writer in the codebase ever produces** —
`lib/goals/extract-goals.ts` writes the flat shape `{evidence: string[],
extractionMethod, confidence, sourceCallId, extractedAt,
lastMentionedCallId, lastMentionedAt, mentionCount}`. Result on live data:
every real goal's `lastEvidence` came back `null` and the section
showed only %s — none of the educator-meaningful "what did they actually
say?" context.

## Verified by

Live evidence on hf_sandbox before this PR — SP4-A's `lastEvidence`
section was empty for every real goal because `progressMetrics.progress`
was never populated. Confirmed by reading `lib/goals/extract-goals.ts`
lines 311–360 (only writer) — the only sub-keys ever written are
`evidence: string[]`, `extractionMethod`, `confidence`, `sourceCallId`,
`extractedAt`, `lastMentionedCallId`, `lastMentionedAt`, `mentionCount`.

Tests: `npx vitest run tests/api/callers/attainment-route.test.ts
tests/api/callers/lo-mastery-route.test.ts` → 16/16 pass. Pre-push hook
green.

## What ships

**Route `app/api/callers/[callerId]/attainment/route.ts`**

- Replaces `AttainmentGoal.lastEvidence` (broken shape) with
  `AttainmentGoal.trail: AttainmentGoalTrail | null` (real shape).
- New `buildGoalTrail(metrics)` pure synthesis fn — no new query, no
  schema change.
- Defensive against non-string entries in the `evidence` array (filters
  silently rather than throwing).
- Returns `null` trail when there's nothing to show; falls back to
  `extractedAt` for `lastMentionedAt` on single-mention goals.
- Excerpts truncated to 4 newest-first; `totalCount` preserves the full
  length so the UI can show "+ N older mentions".

**UI `AttainmentTab.tsx`**

- Goal rows become buttons with chevron; disabled when no trail.
- One-line summary always visible: *"First noticed 3 days ago · last
  mentioned today · across 3 calls"* via `formatRelativeDate`.
- Expand → trail panel with `extractionMethod` pill ("Said directly" /
  "Inferred") + confidence + mention count + excerpt list styled as
  transcript quote-blocks (left accent border) + "+ N older mentions"
  when truncated.
- Empty trail row shows *"No transcript evidence captured for this goal
  yet"* — educator-meaningful instead of going silent.

## Cascade / Chain / Guards

- ✅ `getCourseStyle` guard preserved on `CallerModuleProgress` read (#1252 / #1259) — unchanged from SP4-A.
- ✅ Path-param scope (`studentAllowedToReadCaller`) unchanged.
- ✅ Trail logic is pure JSON synthesis — no new query, no schema change, no Chain boundary crossed.

## Test plan

- [ ] /vm-cp → reload `/x/callers/<callerId>?tab=attainment` → Goal rows now show summary line beneath each row.
- [ ] Goals with `extract-goals.ts`-written metrics → chevron enabled → expand → trail with excerpts.
- [ ] Manually-created goal (no `progressMetrics`) → chevron disabled → "No transcript evidence captured for this goal yet".
- [ ] Single-mention goal → "First noticed 5 days ago · across 1 call" (no `last mentioned` redundancy).
- [ ] Multi-mention goal (≥2 calls) → "First noticed X · last mentioned Y · across N calls".

## Out of scope (Sprint 4 follow-ons)

- SP4-E `WILL_RETIRE` tagging on old tabs — needs S5 registry
- SP4-F Cohort Heatmap → Attainment deep-link

Closes part of #1577 (master epic — Sprint 4 SP4-D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)