### PR TITLE
feat(skills): SP5-A Adaptations tab shell on Caller Detail (beta)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
@@ -1,0 +1,154 @@
+/**
+ * @api GET /api/callers/[callerId]/adaptations
+ *
+ * Sprint 5 SP5-A — Adaptations tab shell endpoint. Sister of
+ * `/api/callers/[callerId]/attainment` (the per-learner mastery view);
+ * Adaptations surfaces what the engine CHANGED for this learner, why
+ * those changes were warranted, and what the next call's adaptation
+ * will be.
+ *
+ * SP5-A scope: the SHELL — single-load wrapper that branches into
+ * three sections, all returned as empty placeholders. Real data lands
+ * in:
+ *
+ *   - SP5-B "What was adapted" — `CallerTarget` overrides vs PLAYBOOK
+ *     default (cascade chips on each override).
+ *   - SP5-C "Why" — `RewardScore` rows + `Goal.progressMetrics.progress`
+ *     evidence (tier, band, callId, at).
+ *   - SP5-D "Next call's adaptation" — `goalAdaptationGuidance`
+ *     LOW/MID/HIGH preview.
+ *
+ * Auth: **OPERATOR+ only.** Locked per master epic #1577 — Adaptations
+ * is operator-private; STUDENT can read their OWN attainment but NEVER
+ * the change-log. `requireAuth("OPERATOR")` is the structural gate; no
+ * path-param scope is needed because STUDENT can't reach this method.
+ *
+ * Single-load: the response carries the three section envelopes
+ * needed for first paint. Real-data sections that grow large will
+ * lazy-fetch per section in SP5-B/C/D, mirroring the Attainment
+ * pattern (SP4-C's `/lo-mastery` lazy fetch on module-row click).
+ */
+
+/* eslint-disable hf-security/no-unscoped-caller-id-route --
+ * OPERATOR+ only per master epic #1577 (Adaptations is operator-private,
+ * STUDENT may only read their own Attainment). `requireAuth("OPERATOR")`
+ * structurally refuses STUDENT/VIEWER at the auth gate, so the
+ * studentAllowedToReadCaller path-param guard is moot for this surface.
+ */
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+
+/** What changed for this learner vs the playbook default. SP5-B fills
+ *  this with `CallerTarget` rows joined to `Parameter` so the UI can
+ *  render the override + the cascade chip (system / playbook / caller). */
+export interface AdaptationOverride {
+  parameterId: string;
+  parameterName: string;
+  defaultValue: number;
+  overrideValue: number;
+  confidence: number | null;
+  callsApplied: number;
+  /** ISO timestamp of the most recent override write. */
+  updatedAt: string;
+}
+
+/** Why the engine adapted — `RewardScore` evidence + `Goal.progressMetrics`
+ *  structured progress. SP5-C fills this. */
+export interface AdaptationReason {
+  callId: string;
+  at: string;
+  /** Free-text explanation written by the REWARD stage. */
+  rationale: string;
+  /** Direction the engine pushed: UP / DOWN / HOLD. */
+  direction: "up" | "down" | "hold";
+  parameterId: string | null;
+  parameterName: string | null;
+}
+
+/** What the next call's adaptation will be — `goalAdaptationGuidance`
+ *  with LOW / MID / HIGH bands. SP5-D fills this. */
+export interface NextAdaptationGuidance {
+  band: "low" | "mid" | "high";
+  summary: string;
+  affectedParameterIds: string[];
+}
+
+export interface AdaptationsResponse {
+  callerId: string;
+  callerName: string | null;
+  playbookId: string | null;
+  playbookName: string | null;
+  whatWasAdapted: AdaptationOverride[];
+  why: AdaptationReason[];
+  nextAdaptation: NextAdaptationGuidance | null;
+  /** True when no enrolment + no overrides + no rewards exist. The UI
+   *  branches on this for the empty-state copy. */
+  empty: boolean;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ callerId: string }> },
+) {
+  const { callerId } = await params;
+
+  // OPERATOR+ gate. No `studentAllowedToReadCaller` — STUDENT is below
+  // OPERATOR and is refused at this line, so per-caller path-param
+  // scope is moot.
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { id: true, name: true },
+  });
+  if (!caller) {
+    return NextResponse.json({ error: "Caller not found" }, { status: 404 });
+  }
+
+  // Most-recent enrolment is the playbook scope — same convention as
+  // attainment + skills-evidence routes.
+  const enrolment = await prisma.callerPlaybook.findFirst({
+    where: { callerId },
+    select: {
+      playbookId: true,
+      playbook: { select: { id: true, name: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (!enrolment) {
+    return NextResponse.json({
+      callerId,
+      callerName: caller.name,
+      playbookId: null,
+      playbookName: null,
+      whatWasAdapted: [],
+      why: [],
+      nextAdaptation: null,
+      empty: true,
+    } satisfies AdaptationsResponse);
+  }
+
+  // SP5-A is the shell — real data writers (SP5-B/C/D) will replace
+  // these placeholders. We still walk one cheap query (CallerTarget
+  // count) so the UI can render an accurate "no adaptations yet"
+  // empty-state rather than misleadingly claiming the section is
+  // ready-but-empty.
+  const overrideCount = await prisma.callerTarget.count({
+    where: { callerId },
+  });
+
+  return NextResponse.json({
+    callerId,
+    callerName: caller.name,
+    playbookId: enrolment.playbookId,
+    playbookName: enrolment.playbook?.name ?? null,
+    whatWasAdapted: [],
+    why: [],
+    nextAdaptation: null,
+    empty: overrideCount === 0,
+  } satisfies AdaptationsResponse);
+}

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -37,6 +37,7 @@ import { UpliftTab } from "./caller-detail/UpliftTab";
 import { UpliftV2Tab } from "./caller-detail/caller-detail-v2/UpliftV2Tab";
 import { ProgressV2Tab } from "./caller-detail/caller-detail-v2/ProgressV2Tab";
 import { AttainmentTab } from "./caller-detail/AttainmentTab";
+import { AdaptationsTab } from "./caller-detail/AdaptationsTab";
 import { V1BetaBanner } from "./caller-detail/caller-detail-v2/V1BetaBanner";
 import { OverviewV2Tab } from "./caller-detail/caller-detail-v2/OverviewV2Tab";
 
@@ -90,7 +91,7 @@ export default function CallerDetailPage() {
   // Tabs that may render but DO NOT appear in the tab bar (legacy / hidden).
   // The validTabs list keeps render branches reachable via ?tab=<id>; the
   // tab bar itself is built from the VISIBLE_TABS subset below.
-  const validTabs: SectionId[] = ["overview", "overview-v2", "uplift", "uplift-v2", "calls-prompts", "tune", "how", "what", "progress-v2", "artifacts", "ai-call", "session-flow", "attainment"];
+  const validTabs: SectionId[] = ["overview", "overview-v2", "uplift", "uplift-v2", "calls-prompts", "tune", "how", "what", "progress-v2", "artifacts", "ai-call", "session-flow", "attainment", "adaptations"];
   const VISIBLE_TABS = new Set<SectionId>([
     "overview-v2",
     "calls-prompts",
@@ -704,6 +705,7 @@ export default function CallerDetailPage() {
       // mastery + goal progress). Will replace Progress (v2) once SP4-E
       // tags the legacy surface WILL_RETIRE.
       { id: "attainment", label: <TabWithHelp tabId="attainment">Attainment</TabWithHelp>, icon: <TrendingUp size={13} />, group: "shared" },
+      { id: "adaptations", label: <TabWithHelp tabId="adaptations">Adaptations</TabWithHelp>, icon: <SlidersHorizontal size={13} />, group: "shared" },
       { id: "uplift-v2", label: <TabWithHelp tabId="uplift-v2">Uplift</TabWithHelp>, icon: <TrendingUp size={13} />, group: "shared" },
       { id: "session-flow", label: <TabWithHelp tabId="session-flow">Session Flow</TabWithHelp>, icon: <SlidersHorizontal size={13} />, group: "shared" },
       { id: "how", label: <TabWithHelp tabId="how">Profile</TabWithHelp>, icon: <User size={13} />, count: (data.counts.memories || 0) + (data.counts.observations || 0), group: "caller" },
@@ -1256,6 +1258,13 @@ export default function CallerDetailPage() {
       {/* Sprint 4 SP4-A — Attainment beta tab. Unified per-learner view. */}
       {activeSection === "attainment" && (
         <AttainmentTab callerId={callerId} />
+      )}
+
+      {/* Sprint 5 SP5-A — Adaptations beta tab. OPERATOR+ only; the
+          component renders a "locked" message for STUDENT/VIEWER and
+          the API route refuses non-OPERATOR sessions. */}
+      {activeSection === "adaptations" && (
+        <AdaptationsTab callerId={callerId} />
       )}
 
       {activeSection === "calls-prompts" && (

--- a/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import { SlidersHorizontal, AlertTriangle, Info, Lock } from "lucide-react";
+
+import { ROLE_LEVEL } from "@/lib/roles";
+import type { UserRole } from "@prisma/client";
+
+import "./adaptations-tab.css";
+
+/**
+ * Caller Detail → Adaptations tab (SP5-A shell).
+ *
+ * Sister of `AttainmentTab` (SP4-A) — Attainment shows "where this
+ * learner IS"; Adaptations shows "what the engine CHANGED for this
+ * learner, why, and what's next". Replaces fragmented coverage in
+ * `AdaptationLens` + the Tune-tab adaptation sections (those land in
+ * SP5-E's `WILL_RETIRE` audit once the S5 registry ships).
+ *
+ * SP5-A SHELL — three section placeholders rendered with educator-
+ * meaningful "coming next" copy so the operator can SEE the layout
+ * before SP5-B/C/D fill the boxes:
+ *
+ *   - SP5-B "What was adapted" — `CallerTarget` overrides vs PLAYBOOK
+ *     default + cascade chips
+ *   - SP5-C "Why" — `RewardScore` + `Goal.progressMetrics` evidence
+ *   - SP5-D "Next call's adaptation" — `goalAdaptationGuidance`
+ *     LOW/MID/HIGH preview
+ *
+ * **OPERATOR+ only.** STUDENT/VIEWER → "Operator-only view" message
+ * (mirrors `CascadeLensPanel.tsx`'s pattern). The API route also
+ * refuses (`requireAuth("OPERATOR")`) so client-side hiding is the
+ * cosmetic layer, not the security boundary.
+ */
+
+interface AdaptationOverride {
+  parameterId: string;
+  parameterName: string;
+  defaultValue: number;
+  overrideValue: number;
+  confidence: number | null;
+  callsApplied: number;
+  updatedAt: string;
+}
+
+interface AdaptationReason {
+  callId: string;
+  at: string;
+  rationale: string;
+  direction: "up" | "down" | "hold";
+  parameterId: string | null;
+  parameterName: string | null;
+}
+
+interface NextAdaptationGuidance {
+  band: "low" | "mid" | "high";
+  summary: string;
+  affectedParameterIds: string[];
+}
+
+interface AdaptationsResponse {
+  callerId: string;
+  callerName: string | null;
+  playbookId: string | null;
+  playbookName: string | null;
+  whatWasAdapted: AdaptationOverride[];
+  why: AdaptationReason[];
+  nextAdaptation: NextAdaptationGuidance | null;
+  empty: boolean;
+}
+
+interface Props {
+  callerId: string;
+}
+
+export function AdaptationsTab({ callerId }: Props) {
+  const { data: session } = useSession();
+  const userLevel = useMemo(() => {
+    const role = session?.user?.role as UserRole | undefined;
+    if (!role) return 0;
+    return ROLE_LEVEL[role] ?? 0;
+  }, [session?.user?.role]);
+  const operatorOrBetter = userLevel >= ROLE_LEVEL.OPERATOR;
+
+  const [data, setData] = useState<AdaptationsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!operatorOrBetter) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/callers/${callerId}/adaptations`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `${res.status} ${res.statusText}`);
+        }
+        return res.json();
+      })
+      .then((payload: AdaptationsResponse) => {
+        if (!cancelled) setData(payload);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId, operatorOrBetter]);
+
+  if (!operatorOrBetter) {
+    return (
+      <div className="hf-adaptations-locked" role="status">
+        <Lock size={18} aria-hidden />
+        <div>
+          <strong>Operator-only view.</strong>
+          <p>
+            Adaptations show what the engine changed for this learner.
+            Sign in as an operator to see the change log.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="hf-adaptations-loading" role="status" aria-live="polite">
+        Loading adaptations…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="hf-adaptations-error hf-banner-error" role="alert">
+        <AlertTriangle size={16} />
+        <div>
+          <strong>Could not load Adaptations.</strong>
+          <div>{error}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  if (!data.playbookId) {
+    return (
+      <div className="hf-adaptations-empty">
+        <Info size={20} aria-hidden />
+        <div>
+          <strong>No course enrolment found.</strong>
+          <p>
+            This learner isn&apos;t enrolled on a course yet. Once they
+            start a course and complete a call, the engine&apos;s
+            adaptations show here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hf-adaptations-tab">
+      <header className="hf-adaptations-header">
+        <h2 className="hf-section-title">
+          <SlidersHorizontal size={18} aria-hidden /> Adaptations
+        </h2>
+        <p className="hf-section-desc">
+          What the engine changed for{" "}
+          {data.callerName ? <strong>{data.callerName}</strong> : "this learner"}
+          {data.playbookName ? (
+            <>
+              {" "}on <strong>{data.playbookName}</strong>
+            </>
+          ) : null}
+          {" "}— and why.
+        </p>
+      </header>
+
+      <WhatWasAdaptedSection overrides={data.whatWasAdapted} empty={data.empty} />
+      <WhySection reasons={data.why} empty={data.empty} />
+      <NextAdaptationSection guidance={data.nextAdaptation} empty={data.empty} />
+    </div>
+  );
+}
+
+// ── Section 1: What was adapted (SP5-B will fill) ───────────────────────────
+
+function WhatWasAdaptedSection({
+  overrides,
+  empty,
+}: {
+  overrides: AdaptationOverride[];
+  empty: boolean;
+}) {
+  return (
+    <section className="hf-adaptations-section">
+      <h3 className="hf-adaptations-section-title">What was adapted</h3>
+      <p className="hf-adaptations-section-desc">
+        Per-parameter overrides this learner has earned through their calls.
+        Each row shows the playbook default, the override value, and which
+        cascade layer is currently in effect.
+      </p>
+      {overrides.length === 0 ? (
+        <p className="hf-adaptations-empty-text">
+          {empty
+            ? "No adaptations yet — the engine starts with the playbook's defaults and adapts after the first scoring call."
+            : "Coming in SP5-B: CallerTarget overrides with cascade chips."}
+        </p>
+      ) : (
+        <p className="hf-adaptations-placeholder">
+          {overrides.length} override
+          {overrides.length === 1 ? "" : "s"} captured · full table lands in SP5-B.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ── Section 2: Why (SP5-C will fill) ────────────────────────────────────────
+
+function WhySection({
+  reasons,
+  empty,
+}: {
+  reasons: AdaptationReason[];
+  empty: boolean;
+}) {
+  return (
+    <section className="hf-adaptations-section">
+      <h3 className="hf-adaptations-section-title">Why</h3>
+      <p className="hf-adaptations-section-desc">
+        Reasoning the REWARD stage logged when it pushed a parameter up,
+        down, or held it steady. Pulls from <code>RewardScore</code> + the
+        structured <code>Goal.progressMetrics.progress</code> evidence so
+        you can trace any change back to the call that triggered it.
+      </p>
+      {reasons.length === 0 ? (
+        <p className="hf-adaptations-empty-text">
+          {empty
+            ? "No adaptation reasoning logged yet — appears after the first scoring call."
+            : "Coming in SP5-C: timeline of REWARD-stage rationale with cite-back to source calls."}
+        </p>
+      ) : (
+        <p className="hf-adaptations-placeholder">
+          {reasons.length} reason{reasons.length === 1 ? "" : "s"} captured ·
+          full timeline lands in SP5-C.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ── Section 3: Next call's adaptation (SP5-D will fill) ─────────────────────
+
+function NextAdaptationSection({
+  guidance,
+  empty,
+}: {
+  guidance: NextAdaptationGuidance | null;
+  empty: boolean;
+}) {
+  return (
+    <section className="hf-adaptations-section">
+      <h3 className="hf-adaptations-section-title">Next call</h3>
+      <p className="hf-adaptations-section-desc">
+        What the engine will adapt on the next scoring call — preview of the{" "}
+        <code>goalAdaptationGuidance</code> LOW / MID / HIGH band the ADAPT
+        stage will apply when the learner next picks up the phone.
+      </p>
+      {guidance === null ? (
+        <p className="hf-adaptations-empty-text">
+          {empty
+            ? "Nothing queued yet — the engine plans the next adaptation once it has at least one scoring call to work from."
+            : "Coming in SP5-D: live preview of the next call's planned adaptation with affected parameters."}
+        </p>
+      ) : (
+        <p className="hf-adaptations-placeholder">
+          Next adaptation: <strong>{guidance.band.toUpperCase()}</strong> ·
+          {guidance.affectedParameterIds.length} parameter
+          {guidance.affectedParameterIds.length === 1 ? "" : "s"} affected ·
+          full preview lands in SP5-D.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/adaptations-tab.css
+++ b/apps/admin/components/callers/caller-detail/adaptations-tab.css
@@ -1,0 +1,122 @@
+/* Caller Detail → Adaptations tab (SP5-A shell).
+ * Mirrors `attainment-tab.css` layout primitives so the two beta tabs
+ * read as siblings. Tokens only — no hardcoded hex (HF design system
+ * zero-tolerance).
+ */
+
+.hf-adaptations-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hf-adaptations-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ── Loading / error / locked / empty states ──────────────────────────── */
+
+.hf-adaptations-loading {
+  padding: 24px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.hf-adaptations-error,
+.hf-adaptations-empty,
+.hf-adaptations-locked {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.hf-adaptations-locked {
+  background: color-mix(in srgb, var(--text-muted) 8%, transparent);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+}
+
+.hf-adaptations-locked strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.hf-adaptations-locked p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hf-adaptations-empty {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.hf-adaptations-empty strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.hf-adaptations-empty p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hf-adaptations-error strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+/* ── Section primitives ──────────────────────────────────────────────── */
+
+.hf-adaptations-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 16px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+}
+
+.hf-adaptations-section-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.hf-adaptations-section-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0 0 6px 0;
+  line-height: 1.45;
+}
+
+.hf-adaptations-section-desc code {
+  font-size: 11px;
+  background: var(--surface-secondary);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+.hf-adaptations-empty-text {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 0;
+  padding: 8px 0;
+}
+
+.hf-adaptations-placeholder {
+  font-size: 12px;
+  color: var(--text-primary);
+  margin: 0;
+  padding: 8px 0;
+}

--- a/apps/admin/components/callers/caller-detail/types.ts
+++ b/apps/admin/components/callers/caller-detail/types.ts
@@ -262,7 +262,7 @@ export type CallerData = {
   };
 };
 
-export type SectionId = "overview" | "overview-v2" | "uplift" | "uplift-v2" | "calls-prompts" | "tune" | "how" | "what" | "progress-v2" | "artifacts" | "ai-call" | "session-flow" | "attainment";
+export type SectionId = "overview" | "overview-v2" | "uplift" | "uplift-v2" | "calls-prompts" | "tune" | "how" | "what" | "progress-v2" | "artifacts" | "ai-call" | "session-flow" | "attainment" | "adaptations";
 
 // ---------------------------------------------------------------------------
 // Uplift tab types — computed from existing models, no new DB tables

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -265,6 +265,12 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
         whenToUse: "When you want a single coherent answer to 'where is this learner right now?' across all four mastery stores. STUDENT-visible for own data.",
       },
       {
+        id: "adaptations",
+        label: "Adaptations",
+        about: "Per-learner change log — what the engine adapted (CallerTarget overrides vs playbook default), why (REWARD-stage rationale + Goal evidence trail), and what the next call's adaptation will be (goalAdaptationGuidance LOW/MID/HIGH preview). OPERATOR+ only — the change log is operator-private, not learner-facing.",
+        whenToUse: "When you want to audit what the engine has done for this learner since enrolment, or preview what it will adapt next call.",
+      },
+      {
         id: "uplift-v2",
         label: "Uplift",
         about: "Learner proof report — Hero rings, How we adapted (EQ), Skill chart + radar, Module heatmap, Goals achieved, Score trends, Topics covered, Engagement. Printable.",

--- a/apps/admin/tests/api/callers/adaptations-route.test.ts
+++ b/apps/admin/tests/api/callers/adaptations-route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for `GET /api/callers/[callerId]/adaptations` — Sprint 5 SP5-A
+ * shell. Pins:
+ *
+ *   1. OPERATOR+ only — STUDENT/VIEWER refused at the auth gate.
+ *   2. 404 when caller missing.
+ *   3. Empty enrolment response when caller has no playbook.
+ *   4. Empty shell when caller is enrolled but has zero CallerTarget
+ *      overrides (empty=true so the UI can render the right copy).
+ *   5. empty=false when ≥1 override exists (SP5-B will fill the array).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    caller: { findUnique: vi.fn() },
+    callerPlaybook: { findFirst: vi.fn() },
+    callerTarget: { count: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// Default mock — OPERATOR session passes. Per-test overrides simulate
+// STUDENT/VIEWER refusal at the auth gate.
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: (v: unknown) =>
+    typeof v === "object" && v !== null && "error" in v,
+}));
+
+const PARAMS = { params: Promise.resolve({ callerId: "c1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/callers/[callerId]/adaptations/route");
+}
+
+describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 for STUDENT (refused at requireAuth OPERATOR gate)", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      error: new Response("forbidden", { status: 403 }),
+    } as never);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when caller missing", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue(null);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns shell with empty=true and null playbook when caller has no enrolment", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.playbookId).toBeNull();
+    expect(body.playbookName).toBeNull();
+    expect(body.empty).toBe(true);
+    expect(body.whatWasAdapted).toEqual([]);
+    expect(body.why).toEqual([]);
+    expect(body.nextAdaptation).toBeNull();
+  });
+
+  it("returns shell with empty=true when enrolled but zero overrides", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    mockPrisma.callerTarget.count.mockResolvedValue(0);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.playbookId).toBe("pb1");
+    expect(body.playbookName).toBe("IELTS Speaking");
+    expect(body.empty).toBe(true);
+  });
+
+  it("returns shell with empty=false when ≥1 override exists", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    mockPrisma.callerTarget.count.mockResolvedValue(3);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.empty).toBe(false);
+    // SP5-A shell — sections are still empty arrays. SP5-B fills them.
+    expect(body.whatWasAdapted).toEqual([]);
+    expect(body.why).toEqual([]);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9875,6 +9875,12 @@ Evaluate a composed prompt against the quality rubric.
 
 ---
 
+### `GET` /api/callers/[callerId]/adaptations
+
+**Auth**: Session
+
+---
+
 ### `GET` /api/callers/[callerId]/attainment
 
 **Auth**: Session
@@ -16056,8 +16062,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 521 |
-| Files with annotations | 509 |
+| Route files found | 522 |
+| Files with annotations | 510 |
 | Files missing annotations | 12 |
 | Coverage | 97.7% |
 


### PR DESCRIPTION
## Summary

Sprint 5 SP5-A — first slice of the **Adaptations** lens on Caller
Detail. Sister of Sprint 4's Attainment tab (#1580 + SP4-C/D/F).

| Tab | Question it answers |
|---|---|
| **Attainment** (SP4) | Where is this learner RIGHT NOW? |
| **Adaptations** (SP5) | What did the engine CHANGE for them, why, and what's next? |

**OPERATOR+ only.** Locked per master epic #1577 — STUDENT may read their own Attainment but NEVER the change-log. `requireAuth("OPERATOR")` is the structural gate; the component renders an *"Operator-only view"* lock screen for STUDENT/VIEWER (mirrors `CascadeLensPanel.tsx`'s pattern). Belt-and-braces.

## What ships

**New route: `GET /api/callers/[callerId]/adaptations`**

- OPERATOR+ guard at `requireAuth`; no `studentAllowedToReadCaller` needed because STUDENT can't reach the handler (file-top `eslint-disable hf-security/no-unscoped-caller-id-route` carries the OPERATOR-only rationale required by the rule).
- SP5-A is the **shell** — three section envelopes returned as empty placeholders:
  - `whatWasAdapted: []` → filled by SP5-B (`CallerTarget` overrides + cascade chips)
  - `why: []` → filled by SP5-C (`RewardScore` + `Goal.progressMetrics` evidence)
  - `nextAdaptation: null` → filled by SP5-D (`goalAdaptationGuidance` LOW/MID/HIGH preview)
- Walks one cheap query (`CallerTarget` count) so the `empty=true` flag is **accurate** — UI can honestly render *"no adaptations yet"* vs *"section ready-but-empty"* copy.

**UI: `AdaptationsTab.tsx` + `adaptations-tab.css`**

- Three placeholder sections with educator-meaningful *"coming next"* copy so the operator **sees** the layout before SP5-B/C/D fill the boxes (avoids the "blank tab, nothing happening" perception).
- `useSession` + `ROLE_LEVEL` guard returns the Operator-only message for STUDENT/VIEWER **before** any fetch fires.
- Tokens only — no hardcoded hex. Layout primitives mirror `attainment-tab.css` so the two beta tabs read as siblings.

**Wired into `CallerDetailPage`:**

- `SectionId` union extended with `"adaptations"`
- `validTabs` array updated
- Tab entry added after `"attainment"` with `SlidersHorizontal` icon
- Render branch keyed on `activeSection === "adaptations"`
- `lib/help/page-help.ts` entry between attainment and uplift-v2

## Cascade / Chain / Guards

- ✅ `requireAuth("OPERATOR")` — STUDENT structurally refused at the gate.
- ✅ No `CallerModuleProgress` reads — no `getCourseStyle` guard needed (rule `hf-pipeline/no-module-read-without-course-style-guard` not triggered).
- ✅ No new schema, no Chain boundary crossed — pure read endpoint.
- ✅ Inline `eslint-disable` for `hf-security/no-unscoped-caller-id-route` carries the OPERATOR-only rationale required by the rule (#977 IDOR contract — OPERATOR-only routes are explicitly allow-listed).
- ✅ Old tabs (`AdaptationLens`, Tune-tab adaptation sections) untouched — retire via SP5-E once S5 registry ships.

## Verified by

`npx vitest run tests/api/callers/adaptations-route.test.ts tests/api/callers/lo-mastery-route.test.ts tests/api/callers/attainment-route.test.ts tests/components/callers/attainment-tab-deeplink.test.tsx` → **25/25 pass**.

Five new SP5-A cases pin:
1. `403` for STUDENT (refused at `requireAuth` OPERATOR gate).
2. `404` when caller missing.
3. Empty enrolment shell with `playbookId=null` + `empty=true`.
4. Zero-override enrolled caller → `empty=true`.
5. ≥1 override → `empty=false` (sections still empty arrays — SP5-B fills them).

Pre-push hook (`tsc --noEmit` + ESLint on changed files) green.

## Test plan

- [ ] /vm-cp → `/x/callers/<id>?tab=adaptations` → renders tab as OPERATOR.
- [ ] Same URL as STUDENT session → "Operator-only view" lock screen (no fetch fires).
- [ ] Caller with no enrolment → "No course enrolment found" empty state.
- [ ] Caller with no calls → "No adaptations yet — the engine starts with the playbook's defaults" empty-state copy.
- [ ] Caller with ≥1 `CallerTarget` override → all three sections render with placeholder counts pointing to SP5-B/C/D.

## Sprint 5 progress

| Story | Status |
|---|---|
| **SP5-A** Adaptations tab shell | ✅ this PR |
| SP5-B "What was adapted" section | queued |
| SP5-C "Why" section | queued |
| SP5-D "Next call's adaptation" | queued |
| SP5-E `WILL_RETIRE` tag on `AdaptationLens` + Tune adaptation sections | blocked on S5 registry |
| SP5-F Epic closeout (verify all 10 renderers + retire audit + docs) | depends on S5 |

Closes part of #1577 (master epic — Sprint 5 SP5-A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)