### PR TITLE
feat(skills): SP5-B "What was adapted" — CallerTarget overrides + cascade chips

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
@@ -39,19 +39,31 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { getEffectiveBehaviorTargetsForCaller } from "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller";
 
-/** What changed for this learner vs the playbook default. SP5-B fills
- *  this with `CallerTarget` rows joined to `Parameter` so the UI can
- *  render the override + the cascade chip (system / playbook / caller). */
+/** What changed for this learner vs the playbook default. Each row is one
+ *  cascade-resolved BEHAVIOR parameter; the UI renders the source-scope
+ *  chip (SYSTEM / PLAYBOOK / CALLER) so the educator can see which layer
+ *  is currently in effect. SYSTEM-only rows are omitted (those aren't
+ *  "adaptations" — they're the unchanged baseline). */
 export interface AdaptationOverride {
   parameterId: string;
   parameterName: string;
+  /** SYSTEM-scope value (or 0.5 default if no SYSTEM row exists). */
   defaultValue: number;
+  /** Cascade-resolved effective value (the winning layer's value). */
   overrideValue: number;
+  /** Which cascade layer is currently winning. */
+  sourceScope: "SYSTEM" | "PLAYBOOK" | "CALLER";
+  /** AI confidence on the CallerTarget override (CALLER-scope only;
+   *  null when the winner is PLAYBOOK or SYSTEM). */
   confidence: number | null;
+  /** How many scoring calls fed into the CallerTarget rollup
+   *  (CALLER-scope only; 0 when the winner is PLAYBOOK or SYSTEM). */
   callsApplied: number;
-  /** ISO timestamp of the most recent override write. */
-  updatedAt: string;
+  /** ISO timestamp of the most recent override write to the winning
+   *  layer; null when no override exists (pure SYSTEM baseline). */
+  updatedAt: string | null;
 }
 
 /** Why the engine adapted — `RewardScore` evidence + `Goal.progressMetrics`
@@ -132,23 +144,106 @@ export async function GET(
     } satisfies AdaptationsResponse);
   }
 
-  // SP5-A is the shell — real data writers (SP5-B/C/D) will replace
-  // these placeholders. We still walk one cheap query (CallerTarget
-  // count) so the UI can render an accurate "no adaptations yet"
-  // empty-state rather than misleadingly claiming the section is
-  // ready-but-empty.
-  const overrideCount = await prisma.callerTarget.count({
-    where: { callerId },
-  });
+  const playbookId = enrolment.playbookId;
+
+  // ── SP5-B "What was adapted" ─────────────────────────────────────────────
+  // Cascade-resolved per-parameter values via the canonical resolver
+  // (`getEffectiveBehaviorTargetsForCaller`) so we never drift from the
+  // values the COMPOSE stage uses. The resolver returns one entry per
+  // parameter touched by ANY layer; we filter to entries where a
+  // non-SYSTEM layer is winning — SYSTEM-only rows are the unchanged
+  // baseline, not an "adaptation".
+  const effectiveTargets = await getEffectiveBehaviorTargetsForCaller(
+    playbookId,
+    callerId,
+  );
+  const adaptedEntries = effectiveTargets.filter(
+    (e) => e.sourceScope !== "SYSTEM",
+  );
+
+  let whatWasAdapted: AdaptationOverride[] = [];
+  if (adaptedEntries.length > 0) {
+    const parameterIds = adaptedEntries.map((e) => e.parameterId);
+    const parameters = await prisma.parameter.findMany({
+      where: { parameterId: { in: parameterIds } },
+      select: { parameterId: true, name: true },
+    });
+    const nameByParam = new Map(
+      parameters.map((p) => [p.parameterId, p.name]),
+    );
+
+    // Pull CallerTarget rows for CALLER-scope winners — gives us the
+    // AI-computed confidence + callsUsed + updatedAt that the cascade
+    // resolver doesn't carry. PLAYBOOK winners get a separate
+    // BehaviorTarget read for updatedAt.
+    const callerScopeIds = adaptedEntries
+      .filter((e) => e.sourceScope === "CALLER")
+      .map((e) => e.parameterId);
+    const callerTargets = callerScopeIds.length
+      ? await prisma.callerTarget.findMany({
+          where: { callerId, parameterId: { in: callerScopeIds } },
+          select: {
+            parameterId: true,
+            confidence: true,
+            callsUsed: true,
+            updatedAt: true,
+          },
+        })
+      : [];
+    const callerTargetByParam = new Map(
+      callerTargets.map((t) => [t.parameterId, t]),
+    );
+
+    const playbookScopeIds = adaptedEntries
+      .filter((e) => e.sourceScope === "PLAYBOOK")
+      .map((e) => e.parameterId);
+    const playbookTargets = playbookScopeIds.length
+      ? await prisma.behaviorTarget.findMany({
+          where: {
+            scope: "PLAYBOOK",
+            playbookId,
+            parameterId: { in: playbookScopeIds },
+            effectiveUntil: null,
+          },
+          select: { parameterId: true, updatedAt: true },
+        })
+      : [];
+    const playbookTargetByParam = new Map(
+      playbookTargets.map((t) => [t.parameterId, t]),
+    );
+
+    whatWasAdapted = adaptedEntries.map((e) => {
+      const callerRow = callerTargetByParam.get(e.parameterId);
+      const playbookRow = playbookTargetByParam.get(e.parameterId);
+      const updatedAt =
+        e.sourceScope === "CALLER"
+          ? callerRow?.updatedAt.toISOString() ?? null
+          : e.sourceScope === "PLAYBOOK"
+            ? playbookRow?.updatedAt.toISOString() ?? null
+            : null;
+      return {
+        parameterId: e.parameterId,
+        parameterName: nameByParam.get(e.parameterId) ?? e.parameterId,
+        defaultValue: e.systemValue ?? 0.5,
+        overrideValue: e.effectiveValue,
+        sourceScope: e.sourceScope,
+        confidence:
+          e.sourceScope === "CALLER" ? callerRow?.confidence ?? null : null,
+        callsApplied:
+          e.sourceScope === "CALLER" ? callerRow?.callsUsed ?? 0 : 0,
+        updatedAt,
+      };
+    });
+  }
 
   return NextResponse.json({
     callerId,
     callerName: caller.name,
-    playbookId: enrolment.playbookId,
+    playbookId,
     playbookName: enrolment.playbook?.name ?? null,
-    whatWasAdapted: [],
+    whatWasAdapted,
     why: [],
     nextAdaptation: null,
-    empty: overrideCount === 0,
+    empty: whatWasAdapted.length === 0,
   } satisfies AdaptationsResponse);
 }

--- a/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
@@ -39,9 +39,10 @@ interface AdaptationOverride {
   parameterName: string;
   defaultValue: number;
   overrideValue: number;
+  sourceScope: "SYSTEM" | "PLAYBOOK" | "CALLER";
   confidence: number | null;
   callsApplied: number;
-  updatedAt: string;
+  updatedAt: string | null;
 }
 
 interface AdaptationReason {
@@ -195,7 +196,7 @@ export function AdaptationsTab({ callerId }: Props) {
   );
 }
 
-// ── Section 1: What was adapted (SP5-B will fill) ───────────────────────────
+// ── Section 1: What was adapted (SP5-B) ─────────────────────────────────────
 
 function WhatWasAdaptedSection({
   overrides,
@@ -208,24 +209,103 @@ function WhatWasAdaptedSection({
     <section className="hf-adaptations-section">
       <h3 className="hf-adaptations-section-title">What was adapted</h3>
       <p className="hf-adaptations-section-desc">
-        Per-parameter overrides this learner has earned through their calls.
-        Each row shows the playbook default, the override value, and which
-        cascade layer is currently in effect.
+        Per-parameter overrides this learner has earned. Each row shows the
+        system default, the current effective value, and the cascade chip
+        for the layer winning right now (CALLER overrides PLAYBOOK overrides
+        SYSTEM). SYSTEM-only rows (unchanged baseline) are hidden.
       </p>
       {overrides.length === 0 ? (
         <p className="hf-adaptations-empty-text">
           {empty
             ? "No adaptations yet — the engine starts with the playbook's defaults and adapts after the first scoring call."
-            : "Coming in SP5-B: CallerTarget overrides with cascade chips."}
+            : "No per-parameter overrides recorded yet on top of the playbook + system baseline."}
         </p>
       ) : (
-        <p className="hf-adaptations-placeholder">
-          {overrides.length} override
-          {overrides.length === 1 ? "" : "s"} captured · full table lands in SP5-B.
-        </p>
+        <ul className="hf-adaptations-override-rows">
+          {overrides.map((o) => (
+            <OverrideRow key={o.parameterId} override={o} />
+          ))}
+        </ul>
       )}
     </section>
   );
+}
+
+function OverrideRow({ override }: { override: AdaptationOverride }) {
+  const defaultPct = Math.round(override.defaultValue * 100);
+  const overridePct = Math.round(override.overrideValue * 100);
+  const delta = override.overrideValue - override.defaultValue;
+  const direction = delta > 0.02 ? "up" : delta < -0.02 ? "down" : "flat";
+  const deltaLabel =
+    direction === "flat"
+      ? "≈ default"
+      : `${delta > 0 ? "+" : ""}${(delta * 100).toFixed(0)} pts`;
+  return (
+    <li className="hf-adaptations-override-row">
+      <div className="hf-adaptations-override-head">
+        <span className="hf-adaptations-override-name">
+          {override.parameterName}
+        </span>
+        <span
+          className={`hf-adaptations-cascade-chip hf-adaptations-cascade-chip-${override.sourceScope.toLowerCase()}`}
+        >
+          {sourceScopeLabel(override.sourceScope)}
+        </span>
+        <span
+          className={`hf-adaptations-override-delta hf-adaptations-override-delta-${direction}`}
+        >
+          {deltaLabel}
+        </span>
+      </div>
+      <div className="hf-adaptations-override-bars">
+        <div className="hf-adaptations-override-bar-row">
+          <span className="hf-adaptations-override-bar-label">Default</span>
+          <span className="hf-adaptations-override-bar">
+            <span
+              className="hf-adaptations-override-bar-fill hf-adaptations-override-bar-fill-default"
+              style={{ width: `${defaultPct}%` }}
+            />
+          </span>
+          <span className="hf-adaptations-override-bar-pct">{defaultPct}%</span>
+        </div>
+        <div className="hf-adaptations-override-bar-row">
+          <span className="hf-adaptations-override-bar-label">Now</span>
+          <span className="hf-adaptations-override-bar">
+            <span
+              className="hf-adaptations-override-bar-fill hf-adaptations-override-bar-fill-now"
+              style={{ width: `${overridePct}%` }}
+            />
+          </span>
+          <span className="hf-adaptations-override-bar-pct">{overridePct}%</span>
+        </div>
+      </div>
+      {override.sourceScope === "CALLER" ? (
+        <div className="hf-adaptations-override-meta">
+          {override.callsApplied > 0
+            ? `${override.callsApplied} call${override.callsApplied === 1 ? "" : "s"} of evidence`
+            : "Evidence pending"}
+          {override.confidence != null
+            ? ` · ${Math.round(override.confidence * 100)}% confidence`
+            : ""}
+        </div>
+      ) : override.sourceScope === "PLAYBOOK" ? (
+        <div className="hf-adaptations-override-meta">
+          Playbook-scope default (no caller-specific adaptation yet)
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function sourceScopeLabel(scope: "SYSTEM" | "PLAYBOOK" | "CALLER"): string {
+  switch (scope) {
+    case "SYSTEM":
+      return "System";
+    case "PLAYBOOK":
+      return "Playbook";
+    case "CALLER":
+      return "Caller";
+  }
 }
 
 // ── Section 2: Why (SP5-C will fill) ────────────────────────────────────────

--- a/apps/admin/components/callers/caller-detail/adaptations-tab.css
+++ b/apps/admin/components/callers/caller-detail/adaptations-tab.css
@@ -120,3 +120,135 @@
   margin: 0;
   padding: 8px 0;
 }
+
+/* ── SP5-B: override rows ────────────────────────────────────────────── */
+
+.hf-adaptations-override-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hf-adaptations-override-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--surface-primary);
+}
+
+.hf-adaptations-override-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.hf-adaptations-override-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 140px;
+}
+
+.hf-adaptations-cascade-chip {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+.hf-adaptations-cascade-chip-system {
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+  border: 1px solid var(--border-default);
+}
+
+.hf-adaptations-cascade-chip-playbook {
+  background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+  color: var(--accent-primary);
+}
+
+.hf-adaptations-cascade-chip-caller {
+  background: color-mix(in srgb, var(--status-success-text) 14%, transparent);
+  color: var(--status-success-text);
+}
+
+.hf-adaptations-override-delta {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+.hf-adaptations-override-delta-up {
+  color: var(--status-success-text);
+}
+
+.hf-adaptations-override-delta-down {
+  color: var(--status-error-text);
+}
+
+.hf-adaptations-override-delta-flat {
+  color: var(--text-muted);
+}
+
+.hf-adaptations-override-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hf-adaptations-override-bar-row {
+  display: grid;
+  grid-template-columns: 60px 1fr 40px;
+  gap: 8px;
+  align-items: center;
+  font-size: 11px;
+}
+
+.hf-adaptations-override-bar-label {
+  color: var(--text-muted);
+}
+
+.hf-adaptations-override-bar {
+  display: block;
+  height: 6px;
+  background: var(--surface-secondary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.hf-adaptations-override-bar-fill {
+  display: block;
+  height: 100%;
+}
+
+.hf-adaptations-override-bar-fill-default {
+  background: var(--text-muted);
+  opacity: 0.5;
+}
+
+.hf-adaptations-override-bar-fill-now {
+  background: var(--status-success-text);
+}
+
+.hf-adaptations-override-bar-pct {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: right;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+.hf-adaptations-override-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  padding-top: 2px;
+}

--- a/apps/admin/tests/api/callers/adaptations-route.test.ts
+++ b/apps/admin/tests/api/callers/adaptations-route.test.ts
@@ -16,11 +16,17 @@ const { mockPrisma } = vi.hoisted(() => ({
   mockPrisma: {
     caller: { findUnique: vi.fn() },
     callerPlaybook: { findFirst: vi.fn() },
-    callerTarget: { count: vi.fn() },
+    callerTarget: { count: vi.fn(), findMany: vi.fn() },
+    parameter: { findMany: vi.fn() },
+    behaviorTarget: { findMany: vi.fn() },
   },
 }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock(
+  "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller",
+  () => ({ getEffectiveBehaviorTargetsForCaller: vi.fn(async () => []) }),
+);
 
 // Default mock — OPERATOR session passes. Per-test overrides simulate
 // STUDENT/VIEWER refusal at the auth gate.
@@ -82,7 +88,6 @@ describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
       playbookId: "pb1",
       playbook: { id: "pb1", name: "IELTS Speaking" },
     });
-    mockPrisma.callerTarget.count.mockResolvedValue(0);
     const { GET } = await loadRoute();
     const res = await GET(new Request("http://x"), PARAMS);
     const body = await res.json();
@@ -90,21 +95,105 @@ describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
     expect(body.playbookId).toBe("pb1");
     expect(body.playbookName).toBe("IELTS Speaking");
     expect(body.empty).toBe(true);
+    expect(body.whatWasAdapted).toEqual([]);
   });
 
-  it("returns shell with empty=false when ≥1 override exists", async () => {
+  it("SP5-B: filters SYSTEM-only entries from whatWasAdapted (those are unchanged baseline)", async () => {
     mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
     mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
       playbookId: "pb1",
       playbook: { id: "pb1", name: "IELTS Speaking" },
     });
-    mockPrisma.callerTarget.count.mockResolvedValue(3);
+    const effective = await import(
+      "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller"
+    );
+    vi.mocked(effective.getEffectiveBehaviorTargetsForCaller).mockResolvedValueOnce([
+      {
+        parameterId: "BEH_QUESTION_RATE",
+        effectiveValue: 0.6,
+        sourceScope: "SYSTEM",
+        systemValue: 0.6,
+        playbookValue: null,
+        callerValue: null,
+      },
+      {
+        parameterId: "BEH_PRAISE_RATE",
+        effectiveValue: 0.4,
+        sourceScope: "PLAYBOOK",
+        systemValue: 0.5,
+        playbookValue: 0.4,
+        callerValue: null,
+      },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "BEH_PRAISE_RATE", name: "Praise rate" },
+    ]);
+    mockPrisma.callerTarget.findMany.mockResolvedValue([]);
+    mockPrisma.behaviorTarget.findMany.mockResolvedValue([
+      {
+        parameterId: "BEH_PRAISE_RATE",
+        updatedAt: new Date("2026-06-10T10:00:00Z"),
+      },
+    ]);
     const { GET } = await loadRoute();
     const res = await GET(new Request("http://x"), PARAMS);
     const body = await res.json();
+    // SYSTEM-only row dropped; PLAYBOOK survived.
+    expect(body.whatWasAdapted).toHaveLength(1);
+    expect(body.whatWasAdapted[0]).toMatchObject({
+      parameterId: "BEH_PRAISE_RATE",
+      parameterName: "Praise rate",
+      defaultValue: 0.5,
+      overrideValue: 0.4,
+      sourceScope: "PLAYBOOK",
+      confidence: null,
+      callsApplied: 0,
+    });
     expect(body.empty).toBe(false);
-    // SP5-A shell — sections are still empty arrays. SP5-B fills them.
-    expect(body.whatWasAdapted).toEqual([]);
-    expect(body.why).toEqual([]);
+  });
+
+  it("SP5-B: CALLER-scope override carries confidence + callsApplied from CallerTarget", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    const effective = await import(
+      "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller"
+    );
+    vi.mocked(effective.getEffectiveBehaviorTargetsForCaller).mockResolvedValueOnce([
+      {
+        parameterId: "skill_fluency",
+        effectiveValue: 0.78,
+        sourceScope: "CALLER",
+        systemValue: 0.5,
+        playbookValue: null,
+        callerValue: 0.78,
+      },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "skill_fluency", name: "Fluency" },
+    ]);
+    mockPrisma.callerTarget.findMany.mockResolvedValue([
+      {
+        parameterId: "skill_fluency",
+        confidence: 0.85,
+        callsUsed: 4,
+        updatedAt: new Date("2026-06-12T09:00:00Z"),
+      },
+    ]);
+    mockPrisma.behaviorTarget.findMany.mockResolvedValue([]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.whatWasAdapted[0]).toMatchObject({
+      parameterId: "skill_fluency",
+      sourceScope: "CALLER",
+      confidence: 0.85,
+      callsApplied: 4,
+      overrideValue: 0.78,
+      defaultValue: 0.5,
+    });
+    expect(body.whatWasAdapted[0].updatedAt).toBe("2026-06-12T09:00:00.000Z");
   });
 });


### PR DESCRIPTION
Sprint 5 SP5-B — fills the first section of the SP5-A shell.

## Verified by
`npx vitest run tests/api/callers/adaptations-route.test.ts` → **6/6 pass**.

## What ships
- Route now calls `getEffectiveBehaviorTargetsForCaller` (canonical cascade resolver used by COMPOSE — no drift between UI and the values the AI uses).
- Filters SYSTEM-only entries (those are unchanged baseline, not adaptations).
- Bulk-fetches Parameter.name + (CALLER-scope only) CallerTarget.{confidence,callsUsed,updatedAt}.
- New `<OverrideRow>` with cascade chip (System/Playbook/Caller, distinct colors), delta pill (+/- pts vs default), two stacked bars (Default vs Now), and per-scope footer copy.

## Cascade / Chain / Guards
- ✅ Canonical resolver — UI shows the same values COMPOSE uses
- ✅ Multi-identity MAX preserved (resolver-side, #1098 Link 3)
- ✅ No schema change, no Chain crossing

Closes part of #1577 — Sprint 5 SP5-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)