### PR TITLE
feat(skills): SP5-C "Why" — RewardScore.targetUpdatesApplied timeline

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
@@ -66,17 +66,22 @@ export interface AdaptationOverride {
   updatedAt: string | null;
 }
 
-/** Why the engine adapted — `RewardScore` evidence + `Goal.progressMetrics`
- *  structured progress. SP5-C fills this. */
+/** Why the engine adapted — one entry per `targetUpdatesApplied` row
+ *  inside `RewardScore` (the REWARD stage writes this per call). The
+ *  rationale text is whatever the REWARD-stage writer logged on the
+ *  update; the direction is derived from `newTarget - oldTarget`. */
 export interface AdaptationReason {
   callId: string;
   at: string;
-  /** Free-text explanation written by the REWARD stage. */
+  /** Free-text rationale captured by the REWARD-stage writer. */
   rationale: string;
-  /** Direction the engine pushed: UP / DOWN / HOLD. */
+  /** Direction the engine pushed the target. */
   direction: "up" | "down" | "hold";
   parameterId: string | null;
   parameterName: string | null;
+  /** Numeric delta `newTarget - oldTarget`. Null when either side is
+   *  missing from the JSON. */
+  delta: number | null;
 }
 
 /** What the next call's adaptation will be — `goalAdaptationGuidance`
@@ -236,14 +241,107 @@ export async function GET(
     });
   }
 
+  // ── SP5-C "Why" ─────────────────────────────────────────────────────────
+  // Walk the most recent N calls with RewardScore.targetUpdatesApplied
+  // populated; each update row produces one AdaptationReason entry.
+  // Bounded fetch keeps the read O(N callers × constant) — no per-row N+1.
+  const recentRewards = await prisma.rewardScore.findMany({
+    where: {
+      call: { callerId, playbookId },
+      NOT: { targetUpdatesApplied: { equals: null as never } },
+    },
+    select: {
+      callId: true,
+      scoredAt: true,
+      targetUpdatesApplied: true,
+    },
+    orderBy: { scoredAt: "desc" },
+    take: REWARD_LOOKBACK,
+  });
+
+  const reasonParamIds = new Set<string>();
+  for (const r of recentRewards) {
+    const updates = parseTargetUpdates(r.targetUpdatesApplied);
+    for (const u of updates) {
+      if (u.parameterId) reasonParamIds.add(u.parameterId);
+    }
+  }
+  const reasonParamNames = reasonParamIds.size
+    ? await prisma.parameter.findMany({
+        where: { parameterId: { in: [...reasonParamIds] } },
+        select: { parameterId: true, name: true },
+      })
+    : [];
+  const reasonNameByParam = new Map(
+    reasonParamNames.map((p) => [p.parameterId, p.name]),
+  );
+
+  const why: AdaptationReason[] = [];
+  for (const r of recentRewards) {
+    const updates = parseTargetUpdates(r.targetUpdatesApplied);
+    for (const u of updates) {
+      const delta =
+        typeof u.oldTarget === "number" && typeof u.newTarget === "number"
+          ? u.newTarget - u.oldTarget
+          : null;
+      const direction: "up" | "down" | "hold" =
+        delta == null || Math.abs(delta) < 0.005
+          ? "hold"
+          : delta > 0
+            ? "up"
+            : "down";
+      why.push({
+        callId: r.callId,
+        at: r.scoredAt.toISOString(),
+        rationale: u.reason ?? "(no rationale logged)",
+        direction,
+        parameterId: u.parameterId,
+        parameterName: u.parameterId
+          ? reasonNameByParam.get(u.parameterId) ?? u.parameterId
+          : null,
+        delta,
+      });
+    }
+  }
+  const whyTrimmed = why.slice(0, REWARD_REASONS_MAX);
+
   return NextResponse.json({
     callerId,
     callerName: caller.name,
     playbookId,
     playbookName: enrolment.playbook?.name ?? null,
     whatWasAdapted,
-    why: [],
+    why: whyTrimmed,
     nextAdaptation: null,
-    empty: whatWasAdapted.length === 0,
+    empty: whatWasAdapted.length === 0 && whyTrimmed.length === 0,
   } satisfies AdaptationsResponse);
+}
+
+/** Most-recent N RewardScore rows scanned for `targetUpdatesApplied`. */
+const REWARD_LOOKBACK = 12;
+/** Max reason entries returned to the UI (some calls have multiple updates). */
+const REWARD_REASONS_MAX = 30;
+
+interface TargetUpdate {
+  parameterId: string | null;
+  oldTarget: number | null;
+  newTarget: number | null;
+  reason: string | null;
+}
+
+function parseTargetUpdates(value: unknown): TargetUpdate[] {
+  if (!Array.isArray(value)) return [];
+  const out: TargetUpdate[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    out.push({
+      parameterId:
+        typeof e.parameterId === "string" ? e.parameterId : null,
+      oldTarget: typeof e.oldTarget === "number" ? e.oldTarget : null,
+      newTarget: typeof e.newTarget === "number" ? e.newTarget : null,
+      reason: typeof e.reason === "string" ? e.reason : null,
+    });
+  }
+  return out;
 }

--- a/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
@@ -52,6 +52,7 @@ interface AdaptationReason {
   direction: "up" | "down" | "hold";
   parameterId: string | null;
   parameterName: string | null;
+  delta: number | null;
 }
 
 interface NextAdaptationGuidance {
@@ -308,7 +309,7 @@ function sourceScopeLabel(scope: "SYSTEM" | "PLAYBOOK" | "CALLER"): string {
   }
 }
 
-// ── Section 2: Why (SP5-C will fill) ────────────────────────────────────────
+// ── Section 2: Why (SP5-C) ──────────────────────────────────────────────────
 
 function WhySection({
   reasons,
@@ -321,25 +322,70 @@ function WhySection({
     <section className="hf-adaptations-section">
       <h3 className="hf-adaptations-section-title">Why</h3>
       <p className="hf-adaptations-section-desc">
-        Reasoning the REWARD stage logged when it pushed a parameter up,
-        down, or held it steady. Pulls from <code>RewardScore</code> + the
-        structured <code>Goal.progressMetrics.progress</code> evidence so
-        you can trace any change back to the call that triggered it.
+        Timeline of REWARD-stage adaptations — what the engine pushed up,
+        down, or held, with the rationale the writer logged. Each entry
+        links back to the call that triggered it (callId shown).
       </p>
       {reasons.length === 0 ? (
         <p className="hf-adaptations-empty-text">
           {empty
             ? "No adaptation reasoning logged yet — appears after the first scoring call."
-            : "Coming in SP5-C: timeline of REWARD-stage rationale with cite-back to source calls."}
+            : "No target updates have been logged in the most recent calls."}
         </p>
       ) : (
-        <p className="hf-adaptations-placeholder">
-          {reasons.length} reason{reasons.length === 1 ? "" : "s"} captured ·
-          full timeline lands in SP5-C.
-        </p>
+        <ul className="hf-adaptations-reason-rows">
+          {reasons.map((r, i) => (
+            <ReasonRow key={`${r.callId}-${i}`} reason={r} />
+          ))}
+        </ul>
       )}
     </section>
   );
+}
+
+function ReasonRow({ reason }: { reason: AdaptationReason }) {
+  const arrow =
+    reason.direction === "up" ? "↑" : reason.direction === "down" ? "↓" : "→";
+  const deltaLabel =
+    reason.delta != null
+      ? `${reason.delta > 0 ? "+" : ""}${(reason.delta * 100).toFixed(0)} pts`
+      : "";
+  const when = formatReasonDate(reason.at);
+  return (
+    <li className="hf-adaptations-reason-row">
+      <div className="hf-adaptations-reason-head">
+        <span
+          className={`hf-adaptations-reason-arrow hf-adaptations-reason-arrow-${reason.direction}`}
+          aria-label={`Direction ${reason.direction}`}
+        >
+          {arrow}
+        </span>
+        <span className="hf-adaptations-reason-param">
+          {reason.parameterName ?? "(no parameter)"}
+        </span>
+        <span className="hf-adaptations-reason-delta">{deltaLabel}</span>
+        <span className="hf-adaptations-reason-when">{when}</span>
+      </div>
+      <p className="hf-adaptations-reason-text">{reason.rationale}</p>
+      <div className="hf-adaptations-reason-callid">
+        Call {reason.callId.slice(0, 8)}…
+      </div>
+    </li>
+  );
+}
+
+function formatReasonDate(iso: string): string {
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return iso;
+  const diffMs = Date.now() - then.getTime();
+  const day = 24 * 60 * 60 * 1000;
+  const days = Math.floor(diffMs / day);
+  if (days < 0) return then.toLocaleDateString();
+  if (days === 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.round(days / 7)}w ago`;
+  return then.toLocaleDateString();
 }
 
 // ── Section 3: Next call's adaptation (SP5-D will fill) ─────────────────────

--- a/apps/admin/components/callers/caller-detail/adaptations-tab.css
+++ b/apps/admin/components/callers/caller-detail/adaptations-tab.css
@@ -252,3 +252,87 @@
   color: var(--text-muted);
   padding-top: 2px;
 }
+
+/* ── SP5-C: reason rows ──────────────────────────────────────────────── */
+
+.hf-adaptations-reason-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hf-adaptations-reason-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border-left: 3px solid var(--border-default);
+  border-radius: 0 4px 4px 0;
+  background: color-mix(in srgb, var(--surface-secondary) 50%, transparent);
+}
+
+.hf-adaptations-reason-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+
+.hf-adaptations-reason-arrow {
+  font-size: 14px;
+  font-weight: 700;
+  width: 16px;
+  text-align: center;
+}
+
+.hf-adaptations-reason-arrow-up {
+  color: var(--status-success-text);
+}
+
+.hf-adaptations-reason-arrow-down {
+  color: var(--status-error-text);
+}
+
+.hf-adaptations-reason-arrow-hold {
+  color: var(--text-muted);
+}
+
+.hf-adaptations-reason-param {
+  font-weight: 500;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 120px;
+}
+
+.hf-adaptations-reason-delta {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 50px;
+  text-align: right;
+}
+
+.hf-adaptations-reason-when {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.hf-adaptations-reason-text {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-primary);
+  line-height: 1.45;
+  padding-left: 24px;
+}
+
+.hf-adaptations-reason-callid {
+  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  color: var(--text-muted);
+  padding-left: 24px;
+}

--- a/apps/admin/tests/api/callers/adaptations-route.test.ts
+++ b/apps/admin/tests/api/callers/adaptations-route.test.ts
@@ -19,6 +19,7 @@ const { mockPrisma } = vi.hoisted(() => ({
     callerTarget: { count: vi.fn(), findMany: vi.fn() },
     parameter: { findMany: vi.fn() },
     behaviorTarget: { findMany: vi.fn() },
+    rewardScore: { findMany: vi.fn() as ReturnType<typeof vi.fn> },
   },
 }));
 
@@ -48,6 +49,8 @@ async function loadRoute() {
 describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no RewardScore rows. Individual SP5-C tests override.
+    mockPrisma.rewardScore.findMany.mockResolvedValue([]);
   });
 
   it("returns 403 for STUDENT (refused at requireAuth OPERATOR gate)", async () => {
@@ -150,6 +153,120 @@ describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
       callsApplied: 0,
     });
     expect(body.empty).toBe(false);
+  });
+
+  it("SP5-C: derives why-entries from RewardScore.targetUpdatesApplied with direction + delta", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    mockPrisma.rewardScore.findMany.mockResolvedValueOnce([
+      {
+        callId: "call-99",
+        scoredAt: new Date("2026-06-12T10:00:00Z"),
+        targetUpdatesApplied: [
+          {
+            parameterId: "BEH_QUESTION_RATE",
+            oldTarget: 0.5,
+            newTarget: 0.7,
+            reason: "Assessment near threshold — raise questioning",
+          },
+          {
+            parameterId: "BEH_PRAISE_RATE",
+            oldTarget: 0.5,
+            newTarget: 0.5,
+            reason: "No change warranted this call",
+          },
+        ],
+      },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "BEH_QUESTION_RATE", name: "Question rate" },
+      { parameterId: "BEH_PRAISE_RATE", name: "Praise rate" },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.why).toHaveLength(2);
+    const up = body.why.find((r: { direction: string }) => r.direction === "up");
+    const hold = body.why.find((r: { direction: string }) => r.direction === "hold");
+    expect(up).toMatchObject({
+      parameterName: "Question rate",
+      direction: "up",
+      callId: "call-99",
+    });
+    expect(up.delta).toBeCloseTo(0.2, 5);
+    expect(hold).toMatchObject({
+      parameterName: "Praise rate",
+      direction: "hold",
+    });
+    expect(hold.delta).toBeCloseTo(0, 5);
+    expect(body.empty).toBe(false);
+  });
+
+  it("SP5-C: down direction when newTarget < oldTarget", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    mockPrisma.rewardScore.findMany.mockResolvedValueOnce([
+      {
+        callId: "call-7",
+        scoredAt: new Date("2026-06-10T10:00:00Z"),
+        targetUpdatesApplied: [
+          {
+            parameterId: "BEH_INTERRUPTIONS",
+            oldTarget: 0.4,
+            newTarget: 0.2,
+            reason: "Too many interruptions — soften",
+          },
+        ],
+      },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "BEH_INTERRUPTIONS", name: "Interruptions" },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.why[0].direction).toBe("down");
+    expect(body.why[0].delta).toBeCloseTo(-0.2, 5);
+  });
+
+  it("SP5-C: tolerates malformed targetUpdatesApplied entries", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    mockPrisma.rewardScore.findMany.mockResolvedValueOnce([
+      {
+        callId: "call-1",
+        scoredAt: new Date("2026-06-10T10:00:00Z"),
+        targetUpdatesApplied: [
+          null,
+          { parameterId: 42 }, // non-string parameterId
+          { reason: "missing both targets" },
+          { parameterId: "OK", oldTarget: 0.3, newTarget: 0.5, reason: "valid" },
+        ],
+      },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "OK", name: "OK param" },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.why).toHaveLength(3); // null skipped; non-object skipped; others kept
+    const valid = body.why.find((r: { parameterId: string }) => r.parameterId === "OK");
+    expect(valid?.direction).toBe("up");
+    const missingBoth = body.why.find(
+      (r: { rationale: string }) => r.rationale === "missing both targets",
+    );
+    expect(missingBoth?.direction).toBe("hold");
+    expect(missingBoth?.delta).toBeNull();
   });
 
   it("SP5-B: CALLER-scope override carries confidence + callsApplied from CallerTarget", async () => {


### PR DESCRIPTION
Sprint 5 SP5-C — fills the Why section.

## Verified by
`npx vitest run tests/api/callers/adaptations-route.test.ts` → **9/9 pass**.

## What ships
- Route walks most recent 12 RewardScore rows (callerId + playbookId scoped) where targetUpdatesApplied populated. Bounded fetch + bulk Parameter.name lookup.
- Direction derived from newTarget - oldTarget (up/down/hold with 0.5pp threshold).
- Defensive JSON parser tolerates null entries, non-string parameterId, missing oldTarget/newTarget.
- UI <ReasonRow> with ↑/↓/→ arrow, delta pill, relative when ("3d ago"), rationale block, source callId footer.
- empty=true now requires BOTH whatWasAdapted AND why to be empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)