### PR TITLE
feat(skills): SP5-D "Next call" — preview goalAdaptationGuidance brackets

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
@@ -84,12 +84,22 @@ export interface AdaptationReason {
   delta: number | null;
 }
 
-/** What the next call's adaptation will be — `goalAdaptationGuidance`
- *  with LOW / MID / HIGH bands. SP5-D fills this. */
-export interface NextAdaptationGuidance {
+/** What the next call's adaptation will be — one preview entry per
+ *  top-3 active goal, derived from `goalAdaptationGuidance` in
+ *  `lib/prompt/composition/transforms/instructions.ts`. The same band
+ *  thresholds (LOW <30% / MID <70% / HIGH ≥70%) the AI will see when
+ *  the next call's prompt is composed. */
+export interface NextAdaptationGuidanceEntry {
+  goalId: string;
+  goalName: string;
+  goalType: string;
+  /** 0–1 current progress on the goal. */
+  progress: number;
+  /** Derived from `progress` against the LOW/MID/HIGH thresholds. */
   band: "low" | "mid" | "high";
-  summary: string;
-  affectedParameterIds: string[];
+  /** The exact textual guidance that will land in the next prompt. */
+  guidance: string;
+  isAssessmentTarget: boolean;
 }
 
 export interface AdaptationsResponse {
@@ -99,7 +109,7 @@ export interface AdaptationsResponse {
   playbookName: string | null;
   whatWasAdapted: AdaptationOverride[];
   why: AdaptationReason[];
-  nextAdaptation: NextAdaptationGuidance | null;
+  nextAdaptation: NextAdaptationGuidanceEntry[];
   /** True when no enrolment + no overrides + no rewards exist. The UI
    *  branches on this for the empty-state copy. */
   empty: boolean;
@@ -305,6 +315,42 @@ export async function GET(
   }
   const whyTrimmed = why.slice(0, REWARD_REASONS_MAX);
 
+  // ── SP5-D "Next call's adaptation" ──────────────────────────────────────
+  // Preview the same bracket-derived guidance the AI will see when the next
+  // prompt is composed (replicates the LOW/MID/HIGH logic in
+  // `lib/prompt/composition/transforms/instructions.ts::goalAdaptationGuidance`
+  // — small table, low drift risk; ESM import would couple this read route
+  // to the composition layer for a one-time copy of 6 UX strings).
+  const topGoals = await prisma.goal.findMany({
+    where: { callerId, playbookId, status: { in: ["ACTIVE", "PAUSED"] } },
+    select: {
+      id: true,
+      name: true,
+      type: true,
+      progress: true,
+      isAssessmentTarget: true,
+    },
+    orderBy: [{ priority: "desc" }, { name: "asc" }],
+    take: 3,
+  });
+
+  const nextAdaptation: NextAdaptationGuidanceEntry[] = topGoals.map((g) => {
+    const band: "low" | "mid" | "high" =
+      g.progress < 0.3 ? "low" : g.progress < 0.7 ? "mid" : "high";
+    const bracketIndex = band === "low" ? 0 : band === "mid" ? 1 : 2;
+    const guidance =
+      (GOAL_ADAPTATION[g.type] ?? GOAL_ADAPTATION.LEARN)[bracketIndex];
+    return {
+      goalId: g.id,
+      goalName: g.name,
+      goalType: g.type,
+      progress: g.progress,
+      band,
+      guidance,
+      isAssessmentTarget: g.isAssessmentTarget,
+    };
+  });
+
   return NextResponse.json({
     callerId,
     callerName: caller.name,
@@ -312,10 +358,57 @@ export async function GET(
     playbookName: enrolment.playbook?.name ?? null,
     whatWasAdapted,
     why: whyTrimmed,
-    nextAdaptation: null,
-    empty: whatWasAdapted.length === 0 && whyTrimmed.length === 0,
+    nextAdaptation,
+    empty:
+      whatWasAdapted.length === 0 &&
+      whyTrimmed.length === 0 &&
+      nextAdaptation.length === 0,
   } satisfies AdaptationsResponse);
 }
+
+/**
+ * Mirror of `GOAL_ADAPTATION` in
+ * `lib/prompt/composition/transforms/instructions.ts`. **Canonical
+ * source is the composition transform** — that is the one the AI
+ * actually sees. This route renders a preview using the same table so
+ * the educator sees what the AI WILL see on the next call's prompt.
+ *
+ * If the canonical table changes, update this mirror in the same PR
+ * (search both paths). The drift surface is tiny (6 rows of UX copy)
+ * so a structural import is overkill.
+ */
+const GOAL_ADAPTATION: Record<string, [low: string, mid: string, high: string]> = {
+  LEARN: [
+    "Introduce concepts gently, check understanding frequently",
+    "Build on prior foundations, connect to what they already know",
+    "Challenge with application, prepare for mastery",
+  ],
+  ACHIEVE: [
+    "Clarify what success looks like, break into steps",
+    "Track milestones, celebrate progress",
+    "Focus on final steps, anticipate obstacles",
+  ],
+  CHANGE: [
+    "Explore motivation, validate feelings",
+    "Practice new behaviours, reflect on changes",
+    "Reinforce new habits, plan sustainability",
+  ],
+  CONNECT: [
+    "Build trust, find common ground",
+    "Deepen relationship, share openly",
+    "Maintain connection, mutual exchange",
+  ],
+  SUPPORT: [
+    "Listen actively, understand needs",
+    "Provide targeted support, check coping",
+    "Evaluate effectiveness, plan independence",
+  ],
+  CREATE: [
+    "Brainstorm freely, no judgment",
+    "Iterate and refine, give constructive feedback",
+    "Polish and finish, celebrate creation",
+  ],
+};
 
 /** Most-recent N RewardScore rows scanned for `targetUpdatesApplied`. */
 const REWARD_LOOKBACK = 12;

--- a/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
@@ -55,10 +55,14 @@ interface AdaptationReason {
   delta: number | null;
 }
 
-interface NextAdaptationGuidance {
+interface NextAdaptationGuidanceEntry {
+  goalId: string;
+  goalName: string;
+  goalType: string;
+  progress: number;
   band: "low" | "mid" | "high";
-  summary: string;
-  affectedParameterIds: string[];
+  guidance: string;
+  isAssessmentTarget: boolean;
 }
 
 interface AdaptationsResponse {
@@ -68,7 +72,7 @@ interface AdaptationsResponse {
   playbookName: string | null;
   whatWasAdapted: AdaptationOverride[];
   why: AdaptationReason[];
-  nextAdaptation: NextAdaptationGuidance | null;
+  nextAdaptation: NextAdaptationGuidanceEntry[];
   empty: boolean;
 }
 
@@ -388,37 +392,60 @@ function formatReasonDate(iso: string): string {
   return then.toLocaleDateString();
 }
 
-// ── Section 3: Next call's adaptation (SP5-D will fill) ─────────────────────
+// ── Section 3: Next call's adaptation (SP5-D) ───────────────────────────────
 
 function NextAdaptationSection({
   guidance,
   empty,
 }: {
-  guidance: NextAdaptationGuidance | null;
+  guidance: NextAdaptationGuidanceEntry[];
   empty: boolean;
 }) {
   return (
     <section className="hf-adaptations-section">
       <h3 className="hf-adaptations-section-title">Next call</h3>
       <p className="hf-adaptations-section-desc">
-        What the engine will adapt on the next scoring call — preview of the{" "}
-        <code>goalAdaptationGuidance</code> LOW / MID / HIGH band the ADAPT
-        stage will apply when the learner next picks up the phone.
+        Preview of the guidance the AI will receive when composing this
+        learner&apos;s next prompt. One entry per top-3 active goal, banded
+        by current progress: LOW (&lt;30%) · MID (&lt;70%) · HIGH (≥70%).
       </p>
-      {guidance === null ? (
+      {guidance.length === 0 ? (
         <p className="hf-adaptations-empty-text">
           {empty
-            ? "Nothing queued yet — the engine plans the next adaptation once it has at least one scoring call to work from."
-            : "Coming in SP5-D: live preview of the next call's planned adaptation with affected parameters."}
+            ? "Nothing queued yet — the engine plans the next adaptation once at least one active goal is set."
+            : "No active goals — set or import a goal for this learner to see the next-call preview."}
         </p>
       ) : (
-        <p className="hf-adaptations-placeholder">
-          Next adaptation: <strong>{guidance.band.toUpperCase()}</strong> ·
-          {guidance.affectedParameterIds.length} parameter
-          {guidance.affectedParameterIds.length === 1 ? "" : "s"} affected ·
-          full preview lands in SP5-D.
-        </p>
+        <ul className="hf-adaptations-next-rows">
+          {guidance.map((g) => (
+            <NextRow key={g.goalId} entry={g} />
+          ))}
+        </ul>
       )}
     </section>
+  );
+}
+
+function NextRow({ entry }: { entry: NextAdaptationGuidanceEntry }) {
+  const pct = Math.round(entry.progress * 100);
+  return (
+    <li className="hf-adaptations-next-row">
+      <div className="hf-adaptations-next-head">
+        <span
+          className={`hf-adaptations-next-band hf-adaptations-next-band-${entry.band}`}
+        >
+          {entry.band.toUpperCase()}
+        </span>
+        <span className="hf-adaptations-next-type">{entry.goalType}</span>
+        <span className="hf-adaptations-next-name">{entry.goalName}</span>
+        <span className="hf-adaptations-next-pct">{pct}%</span>
+        {entry.isAssessmentTarget ? (
+          <span className="hf-adaptations-next-assessment">
+            assessment target
+          </span>
+        ) : null}
+      </div>
+      <p className="hf-adaptations-next-guidance">{entry.guidance}.</p>
+    </li>
   );
 }

--- a/apps/admin/components/callers/caller-detail/adaptations-tab.css
+++ b/apps/admin/components/callers/caller-detail/adaptations-tab.css
@@ -336,3 +336,95 @@
   color: var(--text-muted);
   padding-left: 24px;
 }
+
+/* ── SP5-D: next-call preview rows ───────────────────────────────────── */
+
+.hf-adaptations-next-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hf-adaptations-next-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+}
+
+.hf-adaptations-next-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+.hf-adaptations-next-band {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 2px 8px;
+  border-radius: 10px;
+  min-width: 44px;
+  text-align: center;
+}
+
+.hf-adaptations-next-band-low {
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-muted);
+  border: 1px solid var(--border-default);
+}
+
+.hf-adaptations-next-band-mid {
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  color: var(--accent-primary);
+}
+
+.hf-adaptations-next-band-high {
+  background: color-mix(in srgb, var(--status-success-text) 14%, transparent);
+  color: var(--status-success-text);
+}
+
+.hf-adaptations-next-type {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.hf-adaptations-next-name {
+  font-weight: 500;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 100px;
+}
+
+.hf-adaptations-next-pct {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.hf-adaptations-next-assessment {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.hf-adaptations-next-guidance {
+  margin: 0;
+  padding-left: 56px;
+  font-size: 12px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}

--- a/apps/admin/tests/api/callers/adaptations-route.test.ts
+++ b/apps/admin/tests/api/callers/adaptations-route.test.ts
@@ -20,6 +20,7 @@ const { mockPrisma } = vi.hoisted(() => ({
     parameter: { findMany: vi.fn() },
     behaviorTarget: { findMany: vi.fn() },
     rewardScore: { findMany: vi.fn() as ReturnType<typeof vi.fn> },
+    goal: { findMany: vi.fn() as ReturnType<typeof vi.fn> },
   },
 }));
 
@@ -49,8 +50,10 @@ async function loadRoute() {
 describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: no RewardScore rows. Individual SP5-C tests override.
+    // Defaults: no RewardScore rows, no Goal rows. Individual SP5-C/D
+    // tests override.
     mockPrisma.rewardScore.findMany.mockResolvedValue([]);
+    mockPrisma.goal.findMany.mockResolvedValue([]);
   });
 
   it("returns 403 for STUDENT (refused at requireAuth OPERATOR gate)", async () => {
@@ -267,6 +270,81 @@ describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
     );
     expect(missingBoth?.direction).toBe("hold");
     expect(missingBoth?.delta).toBeNull();
+  });
+
+  it("SP5-D: bands top-3 goals as LOW/MID/HIGH from progress", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        name: "Foundations",
+        type: "LEARN",
+        progress: 0.1,
+        isAssessmentTarget: false,
+      },
+      {
+        id: "g2",
+        name: "Mid track",
+        type: "ACHIEVE",
+        progress: 0.55,
+        isAssessmentTarget: true,
+      },
+      {
+        id: "g3",
+        name: "Almost there",
+        type: "LEARN",
+        progress: 0.9,
+        isAssessmentTarget: false,
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.nextAdaptation).toHaveLength(3);
+    const low = body.nextAdaptation.find(
+      (e: { goalId: string }) => e.goalId === "g1",
+    );
+    const mid = body.nextAdaptation.find(
+      (e: { goalId: string }) => e.goalId === "g2",
+    );
+    const high = body.nextAdaptation.find(
+      (e: { goalId: string }) => e.goalId === "g3",
+    );
+    expect(low.band).toBe("low");
+    expect(low.guidance).toMatch(/Introduce concepts gently/);
+    expect(mid.band).toBe("mid");
+    expect(mid.guidance).toMatch(/Track milestones/);
+    expect(mid.isAssessmentTarget).toBe(true);
+    expect(high.band).toBe("high");
+    expect(high.guidance).toMatch(/Challenge with application/);
+    expect(body.empty).toBe(false);
+  });
+
+  it("SP5-D: unknown goal type falls back to LEARN guidance", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "IELTS Speaking" },
+    });
+    mockPrisma.goal.findMany.mockResolvedValue([
+      {
+        id: "g1",
+        name: "Unknown-type goal",
+        type: "FOOBAR",
+        progress: 0.5,
+        isAssessmentTarget: false,
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.nextAdaptation[0].guidance).toMatch(
+      /Build on prior foundations/,
+    );
   });
 
   it("SP5-B: CALLER-scope override carries confidence + callsApplied from CallerTarget", async () => {


### PR DESCRIPTION
Sprint 5 SP5-D — fills the final section. The Adaptations tab is now structurally complete.

## Verified by
`npx vitest run tests/api/callers/adaptations-route.test.ts` → **11/11 pass**.

## What ships
- Top-3 active goals banded LOW/MID/HIGH from progress (<30/<70/≥70).
- Mirrored GOAL_ADAPTATION table from `instructions.ts` (6 types × 3 brackets = 18 guidance strings) with docstring pointer to the canonical source.
- Unknown goal types fall back to LEARN (matches canonical behaviour).
- UI <NextRow> with cold→hot band pill, type chip, progress %, assessment-target tag, guidance block.

## Adaptations tab status after this PR
✅ SP5-A shell · ✅ SP5-B What was adapted · ✅ SP5-C Why · ✅ **SP5-D Next call**
Remaining: SP5-E (WILL_RETIRE — blocked on S5) · SP5-F (epic closeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)