### PR TITLE
chore(retire): SP4-E + SP5-E — WILL_RETIRE tags + audit docs

### DIFF
--- a/apps/admin/components/callers/caller-detail/ProgressTab.tsx
+++ b/apps/admin/components/callers/caller-detail/ProgressTab.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+// WILL_RETIRE — covered by Attainment (SP4-A/C/D): see docs/retirement-audit/attainment-sp4e.md
+
 import { useState, useEffect, useCallback, useRef } from "react";
 import { BookOpen, CheckSquare, Layers, Target, Check, X } from "lucide-react";
 import { VerticalSlider, SliderGroup } from "@/components/shared/VerticalSlider";
@@ -1367,8 +1369,8 @@ export function TopLevelAgentBehaviorSection({ callerId, calls: propCalls, calle
     setLoading(true);
     try {
       // Use calls from props if available, otherwise fetch
-      let calls = propCalls;
-      if (!calls) {
+      let calls: NonNullable<typeof propCalls> = propCalls ?? [];
+      if (calls.length === 0 && !propCalls) {
         const res = await fetch(`/api/callers/${callerId}`);
         const data = await res.json();
         if (data.ok) {

--- a/apps/admin/components/callers/caller-detail/caller-detail-v2/lenses/AdaptationLens.tsx
+++ b/apps/admin/components/callers/caller-detail/caller-detail-v2/lenses/AdaptationLens.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+// WILL_RETIRE — covered by Adaptations (SP5-A/B/C/D): see docs/retirement-audit/adaptations-sp5e.md
+
 import React from "react";
 import { AdaptationSection } from "../sections/AdaptationSection";
 

--- a/apps/admin/components/callers/caller-detail/cards/MockResultCard.tsx
+++ b/apps/admin/components/callers/caller-detail/cards/MockResultCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+// WILL_RETIRE — covered by Attainment (SP4-A/C/D): see docs/retirement-audit/attainment-sp4e.md
+
 /**
  * MockResultCard — surfaces Mock exam results on the Caller overview.
  *

--- a/apps/admin/components/callers/caller-detail/cards/SkillBandStripCard.tsx
+++ b/apps/admin/components/callers/caller-detail/cards/SkillBandStripCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+// WILL_RETIRE — covered by Attainment (SP4-A/C/D): see docs/retirement-audit/attainment-sp4e.md
+
 /**
  * SkillBandStripCard — Overview hero strip showing per-skill bands.
  *

--- a/docs/retirement-audit/adaptations-sp5e.md
+++ b/docs/retirement-audit/adaptations-sp5e.md
@@ -1,0 +1,65 @@
+# Adaptations tab — SP5-E retirement audit
+
+> Tracks the surfaces that the SP5-A/B/C/D Adaptations tab replaces.
+> Sister of `attainment-sp4e.md`. Part of master epic #1577 → SP5-E.
+>
+> The Adaptations tab is already live on `main` (PRs #1589 / #1590 /
+> #1591 / #1592) and not gated behind `?v=3`. Retirement begins when
+> coverage parity is verified.
+
+## Legacy surfaces scheduled for retirement
+
+Each component below has a `// WILL_RETIRE — covered by Adaptations
+(SP5-A/B/C/D): see docs/retirement-audit/adaptations-sp5e.md` comment
+at the top of its module file. When a row is ticked, the retirement
+PR removes both the comment AND the component.
+
+- [ ] `components/callers/caller-detail/caller-detail-v2/lenses/AdaptationLens.tsx`
+  — current per-learner adaptation lens inside the Progress v2 console.
+  The new Adaptations tab subsumes its content with: (a) cascade chips
+  on per-parameter overrides (SP5-B), (b) timeline of REWARD-stage
+  rationale (SP5-C), (c) next-call preview (SP5-D). The lens has no
+  unique capability the tab doesn't carry.
+
+- [ ] `Tune` tab adaptation section(s) — the Tune tab currently
+  surfaces "engine adjustments to date" inline among its tuning
+  controls. The Adaptations tab is the single place for this; Tune
+  retains pure tuning controls only.
+  - File audit pending — Tune is a large surface and the adaptation
+    section is fused with tuning UI; the retirement PR for this row
+    must be careful to isolate display-only adaptation rendering from
+    the editable tuning controls.
+
+## Retirement preconditions
+
+A row may only be ticked when:
+
+1. The Adaptations tab's corresponding section is rendering correctly on
+   hf_sandbox for: (a) a caller with no CallerTarget overrides, (b) a
+   caller with PLAYBOOK-scope overrides, (c) a caller with CALLER-scope
+   overrides + RewardScore history, AND
+2. The "Why" timeline (SP5-C) has been verified to surface at least one
+   live RewardScore.targetUpdatesApplied entry per call attempted in
+   the test cohort, AND
+3. The "Next call" preview (SP5-D) matches what the AI actually receives
+   when the next prompt is composed (spot-check against a freshly
+   composed prompt in `/x/callers/<id>?tab=calls-prompts`), AND
+4. Two-sprint observation window passed without regression report.
+
+## Out of scope
+
+- `tune` tab itself — Tune is NOT scheduled for retirement; only the
+  adaptation **display** within it. Tune retains all writable tuning
+  controls.
+- Cascade chip details — the Adaptations tab surfaces System / Playbook
+  / Caller scope as a chip; the deeper `CascadeInspectorTray` opened
+  from the chip belongs to the cascade-lens family, not this audit.
+
+## Process
+
+Same as `attainment-sp4e.md`.
+
+## Backstop
+
+If a retirement PR is reverted, restore both the `WILL_RETIRE` comment
+AND this audit-doc row's unchecked state in the revert PR.

--- a/docs/retirement-audit/attainment-sp4e.md
+++ b/docs/retirement-audit/attainment-sp4e.md
@@ -1,0 +1,70 @@
+# Attainment tab — SP4-E retirement audit
+
+> Tracks the 3 legacy surfaces that the SP4-A/C/D Attainment tab
+> replaces. Sister of `caller-detail-v3.md` (broader Snapshot v3
+> retirement) — this audit is **narrower** and **independent**: the
+> Attainment tab is already live on `main` (PRs #1580 / #1586 / #1587 /
+> #1588) and not gated behind `?v=3`, so retirement can begin as soon as
+> coverage is verified.
+>
+> Part of master epic #1577 → SP4-E.
+
+## Legacy surfaces scheduled for retirement
+
+Each component below has a `// WILL_RETIRE — covered by Attainment
+(SP4-A/C/D): see docs/retirement-audit/attainment-sp4e.md` comment at
+the top of its module file. When a row is ticked, the next PR removes
+both the comment AND the component (and any unused parent that mounted
+only it).
+
+- [ ] `components/callers/caller-detail/ProgressTab.tsx` — legacy
+  progress view rendered before Progress (v2). Already hidden on the
+  default tab bar via `VISIBLE_TABS`; kept for `?tab=what` fall-through.
+- [ ] `components/callers/caller-detail/cards/SkillBandStripCard.tsx` —
+  per-skill bar strip mounted inside Progress v2's Overview lens.
+  Replaced by Attainment's `SkillBandsSection` with the click-to-expand
+  evidence trail (which Strip doesn't have).
+- [ ] `components/callers/caller-detail/cards/MockResultCard.tsx` —
+  mock-exam result card mounted inside Progress v2 + Uplift. The
+  Attainment tab branches on `useFreshMastery` for the same data with
+  the same colour scheme (cold→hot palette consistent with the rest of
+  the tab); this card duplicates that view.
+
+## Retirement preconditions
+
+A row may only be ticked when:
+
+1. The Attainment tab's corresponding section is rendering correctly on
+   hf_sandbox **for both structured and CONTINUOUS playbooks**, AND
+2. A two-sprint observation window has passed without an operator
+   regression report on Slack `#hf-dev` or via the in-app feedback path,
+   AND
+3. (For `SkillBandStripCard` + `MockResultCard`) the parent component
+   that mounts them has been audited — if it's the only consumer, it
+   too retires; if shared, only the mount-site is removed.
+
+## Out of scope for this retirement
+
+- `progress-v2` console as a whole — that retirement is tracked under
+  `caller-detail-v3.md` (Snapshot v3 absorbs it). SP4-E only retires
+  the three components listed above; the rest of Progress v2 stays
+  until Snapshot v3 ships.
+- Goal section duplication — the AttainmentTab's `GoalsSection`
+  (SP4-D) duplicates Progress v2's goal view, but Progress v2's goal
+  view also surfaces non-Attainment-shape data (e.g. raw confidence
+  intervals) used by the operator-tuning Tune tab. Retire only after
+  Tune tab no longer reads from there.
+
+## Process
+
+1. Confirm acceptance criteria above for the row.
+2. Open a retirement PR per component that: ticks the box here,
+   removes the `WILL_RETIRE` comment, deletes the component file,
+   removes any imports + mount sites.
+3. Bake on hf-dev for ≥1 day; on staging for ≥3 days; then deploy to
+   prod.
+
+## Backstop
+
+If a retirement PR is reverted, restore both the `WILL_RETIRE` comment
+AND this audit-doc row's unchecked state in the revert PR.


### PR DESCRIPTION
Sprint 4 SP4-E + Sprint 5 SP5-E (under #1577). Both unblocked by S5 (#1594). Filed together — same mechanic, separate timelines.

## What ships
- `docs/retirement-audit/attainment-sp4e.md` — 3-row audit (ProgressTab / SkillBandStripCard / MockResultCard).
- `docs/retirement-audit/adaptations-sp5e.md` — 2-row audit (AdaptationLens / Tune-tab adaptation sections — second row notes the display-vs-tuning isolation caveat).
- 4× `// WILL_RETIRE — covered by …` file-top comments pointing at the respective audit doc.
- Drive-by tsc fix on `ProgressTab.tsx` (`let calls` → narrowed; the hook surfaced the pre-existing error once the file entered the change-set).

## Acceptance
- ✅ Comment-only behaviour change
- ✅ Audit docs follow S5 template structure
- ✅ NOT removing components — per-row preconditions in each audit (2-sprint observation window, no regression report)

## Sprint status after this PR
- **SP4**: ALL 6 stories complete (A ✓ B(subsumed) ✓ C ✓ D ✓ E ✓ F ✓)
- **SP5**: SP5-A/B/C/D ✓ + SP5-E ✓; only SP5-F (epic closeout) remains
- **CourseReDesign #1555**: S1 ✓ S4 ✓ S5 ✓; S2 (#1557) + S3 (#1558) still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)