### PR TITLE
feat(skills): SP3-B — Source Lineage lens + Re-project button

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/reproject-skills/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/reproject-skills/route.ts
@@ -1,0 +1,74 @@
+/* eslint-disable hf-security/no-unscoped-caller-id-route --
+ * Course-scoped write. OPERATOR+ gate at requireAuth. Not a per-learner
+ * read; rule's path-param-IDOR heuristic doesn't apply.
+ */
+/**
+ * @api POST /api/courses/[courseId]/reproject-skills
+ *
+ * Sprint 3 SP3-B — Re-project button on the Source Lineage lens.
+ * Triggers `runProjectionForPlaybook(courseId)` so the educator can
+ * pull the latest COURSE_REFERENCE content through projection without
+ * leaving the page.
+ *
+ * The projection layer already handles all the side effects:
+ *   - Idempotent upsert of `Parameter` + `BehaviorTarget` + `Goal` rows
+ *   - `bumpPlaybookComposeTimestamp` post-tx (apply-projection.ts:866)
+ *     so Preview re-renders staleness
+ *   - Cascade fan-out to sibling playbooks sharing the curriculum
+ *
+ * This route is a thin wrapper — auth gate, course-exists check,
+ * delegate, return counts.
+ *
+ * Auth: OPERATOR+ only. Mutates `Parameter`, `BehaviorTarget`, `Goal`,
+ * and `CurriculumModule` for the playbook.
+ */
+
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { runProjectionForPlaybook } from "@/lib/wizard/run-projection-for-playbook";
+
+export interface ReprojectSkillsResponse {
+  ok: true;
+  courseId: string;
+  appliedSourcesCount: number;
+  skippedSourcesCount: number;
+  /** Per-source result narrative — short summary the UI shows in a toast. */
+  summary: string;
+}
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ courseId: string }> },
+) {
+  const { courseId } = await params;
+
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    select: { id: true },
+  });
+  if (!playbook) {
+    return NextResponse.json({ error: "Course not found" }, { status: 404 });
+  }
+
+  const result = await runProjectionForPlaybook(courseId);
+
+  const summary =
+    result.appliedSources.length > 0
+      ? `Re-projected from ${result.appliedSources.length} source${
+          result.appliedSources.length === 1 ? "" : "s"
+        }.`
+      : "No sources were applied — see skipped reasons.";
+
+  return NextResponse.json({
+    ok: true as const,
+    courseId,
+    appliedSourcesCount: result.appliedSources.length,
+    skippedSourcesCount: result.skippedSources.length,
+    summary,
+  } satisfies ReprojectSkillsResponse);
+}

--- a/apps/admin/app/api/courses/[courseId]/skills-source-lineage/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/skills-source-lineage/route.ts
@@ -1,0 +1,123 @@
+/* eslint-disable hf-security/no-unscoped-caller-id-route --
+ * Course-scoped route. The rule's path-param-IDOR class fires on the
+ * `[courseId]` segment because the path bracket matches the heuristic,
+ * but Course is the educator-owned authoring surface, not a per-learner
+ * read. OPERATOR+ gate at requireAuth is the right boundary; there is
+ * no STUDENT-readable shape of this data.
+ */
+/**
+ * @api GET /api/courses/[courseId]/skills-source-lineage
+ *
+ * Sprint 3 SP3-B — Source Lineage lens data source. Returns the
+ * COURSE_REFERENCE sources currently feeding the Skills Framework
+ * projection for this course, with provenance + last-touched
+ * timestamps so the educator can answer "where did this rubric come
+ * from?" without leaving the page.
+ *
+ * Companion to `POST /api/courses/[courseId]/reproject-skills` (the
+ * "Re-project" button on the lens). The GET surface is read-only —
+ * fetches `PlaybookSource` rows + the Source rows they link to, with
+ * `ContentAssertion.length` so the educator can see "how many
+ * statements did this source produce".
+ *
+ * Auth: OPERATOR+ only. Authoring-side surface, not learner-readable.
+ */
+
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+
+export interface SourceLineageEntry {
+  /** Source.id — useful for follow-up actions or deep-links. */
+  id: string;
+  name: string;
+  /** "COURSE_REFERENCE" / "COURSE_REFERENCE_CANONICAL" / "COURSE_REFERENCE_TUTOR_BRIEFING". */
+  documentType: string;
+  /** ISO timestamp of the most recent Source.updatedAt — the educator's
+   *  signal that the source changed since the last projection. */
+  updatedAt: string;
+  /** Number of ContentAssertion rows produced from this source. */
+  assertionCount: number;
+}
+
+export interface SkillsSourceLineageResponse {
+  courseId: string;
+  /** Playbook this course resolves to (single playbook per course in the
+   *  current model; multi-variant courses get the most-recent active). */
+  playbookId: string | null;
+  sources: SourceLineageEntry[];
+  /** True when no COURSE_REFERENCE source is linked — projection has
+   *  nothing to work from. UI flips to the "link a course reference"
+   *  empty state. */
+  empty: boolean;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ courseId: string }> },
+) {
+  const { courseId } = await params;
+
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) return auth.error;
+
+  // `courseId` is the Playbook UUID in the URL convention used across
+  // the rest of /x/courses/*. Confirm the Playbook exists so a typo'd
+  // URL gives a 404 not a misleading empty result.
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    select: { id: true },
+  });
+  if (!playbook) {
+    return NextResponse.json({ error: "Course not found" }, { status: 404 });
+  }
+
+  // Same filter as `runProjectionForPlaybook` — these are the document
+  // types the projection layer consumes. Keeps the lineage in sync with
+  // what re-projection will actually re-read.
+  const links = await prisma.playbookSource.findMany({
+    where: {
+      playbookId: courseId,
+      source: {
+        documentType: {
+          in: [
+            "COURSE_REFERENCE",
+            "COURSE_REFERENCE_CANONICAL",
+            "COURSE_REFERENCE_TUTOR_BRIEFING",
+          ],
+        },
+      },
+    },
+    select: {
+      source: {
+        select: {
+          id: true,
+          name: true,
+          documentType: true,
+          updatedAt: true,
+          _count: { select: { assertions: true } },
+        },
+      },
+    },
+  });
+
+  const sources: SourceLineageEntry[] = links
+    .map((l) => l.source)
+    .filter((s): s is NonNullable<typeof s> => s != null)
+    .map((s) => ({
+      id: s.id,
+      name: s.name,
+      documentType: s.documentType,
+      updatedAt: s.updatedAt.toISOString(),
+      assertionCount: s._count.assertions,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return NextResponse.json({
+    courseId,
+    playbookId: courseId,
+    sources,
+    empty: sources.length === 0,
+  } satisfies SkillsSourceLineageResponse);
+}

--- a/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
@@ -8,6 +8,9 @@ import {
   Grid3X3,
   Users,
   Sliders,
+  FileText,
+  RefreshCw,
+  CheckCircle2,
   X,
 } from "lucide-react";
 
@@ -29,6 +32,7 @@ type LensId =
   | "framework-map"
   | "cohort-heatmap"
   | "rubric-calibration"
+  | "source-lineage"
   | "mastery-vs-skill";
 
 interface LensSpec {
@@ -56,6 +60,12 @@ const LENSES: LensSpec[] = [
     label: "Rubric Calibration",
     icon: <Sliders size={14} />,
     blurb: "What the AI tutor reads — per-skill MEASURE prompt + tuning knobs.",
+  },
+  {
+    id: "source-lineage",
+    label: "Source Lineage",
+    icon: <FileText size={14} />,
+    blurb: "Where this rubric came from — COURSE_REFERENCE source chain + Re-project.",
   },
   {
     id: "mastery-vs-skill",
@@ -193,6 +203,8 @@ export function CourseSkillsTab({ courseId }: Props) {
         <CohortHeatmapLens courseId={courseId} />
       ) : activeLens === "rubric-calibration" ? (
         <RubricCalibrationLens courseId={courseId} />
+      ) : activeLens === "source-lineage" ? (
+        <SourceLineageLens courseId={courseId} />
       ) : (
         <MasteryVsSkillExplainerLens />
       )}
@@ -1306,6 +1318,189 @@ function MasteryVsSkillExplainerLens() {
           </dd>
         </dl>
       </div>
+    </section>
+  );
+}
+
+// ── Lens: Source Lineage (SP3-B) ────────────────────────────────────────────
+
+interface SourceLineageEntry {
+  id: string;
+  name: string;
+  documentType: string;
+  updatedAt: string;
+  assertionCount: number;
+}
+
+interface SkillsSourceLineageResponse {
+  courseId: string;
+  playbookId: string | null;
+  sources: SourceLineageEntry[];
+  empty: boolean;
+}
+
+/**
+ * Source Lineage lens — shows the COURSE_REFERENCE sources currently
+ * feeding the Skills Framework projection for this course, with a
+ * "Re-project" button that triggers `runProjectionForPlaybook` so the
+ * educator can pull the latest source content through without leaving
+ * the page.
+ *
+ * The lens answers two operator questions repeatedly heard in support:
+ *   1. "Where did this rubric come from?" — the source rows.
+ *   2. "I edited the doc; why hasn't the rubric updated?" — the
+ *      Re-project button + the source's updatedAt vs last-projection
+ *      hint (when the projection layer surfaces that timestamp).
+ */
+function SourceLineageLens({ courseId }: { courseId: string }) {
+  const [data, setData] = useState<SkillsSourceLineageResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reprojectStatus, setReprojectStatus] = useState<
+    | { kind: "idle" }
+    | { kind: "running" }
+    | { kind: "success"; summary: string }
+    | { kind: "error"; message: string }
+  >({ kind: "idle" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/courses/${courseId}/skills-source-lineage`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `${res.status} ${res.statusText}`);
+        }
+        return res.json();
+      })
+      .then((payload: SkillsSourceLineageResponse) => {
+        if (!cancelled) setData(payload);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  const handleReproject = async () => {
+    setReprojectStatus({ kind: "running" });
+    try {
+      const res = await fetch(`/api/courses/${courseId}/reproject-skills`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `${res.status} ${res.statusText}`);
+      }
+      const body = (await res.json()) as { summary: string };
+      setReprojectStatus({ kind: "success", summary: body.summary });
+    } catch (err) {
+      setReprojectStatus({ kind: "error", message: (err as Error).message });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="hf-skills-lineage-loading" role="status" aria-live="polite">
+        Loading source lineage…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="hf-skills-lineage-error hf-banner-error" role="alert">
+        <AlertTriangle size={14} />
+        <span>{error}</span>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <section className="hf-skills-lineage" role="region" aria-label="Source Lineage">
+      <header className="hf-skills-lineage-header">
+        <div>
+          <h3 className="hf-skills-lineage-title">Sources feeding this rubric</h3>
+          <p className="hf-skills-lineage-desc">
+            The COURSE_REFERENCE documents the Skills Framework projection
+            reads from. Re-projecting pulls the latest content from every
+            row below into the rubric + behaviour-target writes for this
+            course.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="hf-skills-lineage-reproject"
+          onClick={handleReproject}
+          disabled={reprojectStatus.kind === "running" || data.empty}
+        >
+          <RefreshCw
+            size={12}
+            className={
+              reprojectStatus.kind === "running"
+                ? "hf-skills-lineage-spin"
+                : undefined
+            }
+          />
+          {reprojectStatus.kind === "running" ? "Re-projecting…" : "Re-project"}
+        </button>
+      </header>
+
+      {reprojectStatus.kind === "success" ? (
+        <div
+          className="hf-skills-lineage-toast hf-skills-lineage-toast-success"
+          role="status"
+        >
+          <CheckCircle2 size={14} />
+          <span>{reprojectStatus.summary}</span>
+        </div>
+      ) : reprojectStatus.kind === "error" ? (
+        <div
+          className="hf-skills-lineage-toast hf-skills-lineage-toast-error"
+          role="alert"
+        >
+          <AlertTriangle size={14} />
+          <span>Re-project failed: {reprojectStatus.message}</span>
+        </div>
+      ) : null}
+
+      {data.empty ? (
+        <div className="hf-skills-lineage-empty">
+          <Info size={14} aria-hidden />
+          <span>
+            No COURSE_REFERENCE source linked to this course yet. Link a
+            course-reference document from the Course Settings tab to give
+            the projection something to read.
+          </span>
+        </div>
+      ) : (
+        <ul className="hf-skills-lineage-rows">
+          {data.sources.map((s) => (
+            <li key={s.id} className="hf-skills-lineage-row">
+              <FileText size={14} className="hf-skills-lineage-row-icon" />
+              <div className="hf-skills-lineage-row-body">
+                <div className="hf-skills-lineage-row-head">
+                  <strong className="hf-skills-lineage-row-name">{s.name}</strong>
+                  <span className="hf-skills-lineage-row-doctype">
+                    {s.documentType.replace(/_/g, " ").toLowerCase()}
+                  </span>
+                </div>
+                <div className="hf-skills-lineage-row-meta">
+                  Last updated {new Date(s.updatedAt).toLocaleDateString()} ·{" "}
+                  {s.assertionCount} assertion{s.assertionCount === 1 ? "" : "s"}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/apps/admin/app/x/courses/[courseId]/course-skills-tab.css
+++ b/apps/admin/app/x/courses/[courseId]/course-skills-tab.css
@@ -869,3 +869,175 @@
 .hf-skills-explainer-link:hover {
   background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
 }
+
+/* ── SP3-B: Source Lineage lens ──────────────────────────────────────── */
+
+.hf-skills-lineage {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+}
+
+.hf-skills-lineage-loading,
+.hf-skills-lineage-error {
+  padding: 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hf-skills-lineage-error {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.hf-skills-lineage-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.hf-skills-lineage-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 4px 0;
+}
+
+.hf-skills-lineage-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.5;
+  max-width: 60ch;
+}
+
+.hf-skills-lineage-reproject {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--surface-primary);
+  background: var(--accent-primary);
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.hf-skills-lineage-reproject:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-primary) 85%, var(--text-primary));
+}
+
+.hf-skills-lineage-reproject:disabled {
+  background: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.hf-skills-lineage-spin {
+  animation: hf-skills-lineage-spin 1s linear infinite;
+}
+
+@keyframes hf-skills-lineage-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.hf-skills-lineage-toast {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.hf-skills-lineage-toast-success {
+  background: color-mix(in srgb, var(--status-success-text) 12%, transparent);
+  color: var(--status-success-text);
+}
+
+.hf-skills-lineage-toast-error {
+  background: color-mix(in srgb, var(--status-error-text) 12%, transparent);
+  color: var(--status-error-text);
+}
+
+.hf-skills-lineage-empty {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 12px 16px;
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+  font-size: 12px;
+  border-radius: 6px;
+  line-height: 1.5;
+}
+
+.hf-skills-lineage-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hf-skills-lineage-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+}
+
+.hf-skills-lineage-row-icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.hf-skills-lineage-row-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.hf-skills-lineage-row-head {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.hf-skills-lineage-row-name {
+  font-size: 13px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.hf-skills-lineage-row-doctype {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.hf-skills-lineage-row-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+}

--- a/apps/admin/tests/api/courses/skills-source-lineage-route.test.ts
+++ b/apps/admin/tests/api/courses/skills-source-lineage-route.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for `GET /api/courses/[courseId]/skills-source-lineage` — SP3-B.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: { findUnique: vi.fn() },
+    playbookSource: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: (v: unknown) =>
+    typeof v === "object" && v !== null && "error" in v,
+}));
+
+const PARAMS = { params: Promise.resolve({ courseId: "course-1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/courses/[courseId]/skills-source-lineage/route");
+}
+
+describe("GET /api/courses/[courseId]/skills-source-lineage — SP3-B", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 for STUDENT (refused at requireAuth OPERATOR gate)", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      error: new Response("forbidden", { status: 403 }),
+    } as never);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when playbook missing", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns empty=true + empty sources when no COURSE_REFERENCE linked", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({ id: "course-1" });
+    mockPrisma.playbookSource.findMany.mockResolvedValue([]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.empty).toBe(true);
+    expect(body.sources).toEqual([]);
+    expect(body.playbookId).toBe("course-1");
+  });
+
+  it("returns alphabetised source rows when linked", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({ id: "course-1" });
+    mockPrisma.playbookSource.findMany.mockResolvedValue([
+      {
+        source: {
+          id: "src-b",
+          name: "Course Reference B",
+          documentType: "COURSE_REFERENCE",
+          updatedAt: new Date("2026-06-10T12:00:00Z"),
+          _count: { assertions: 47 },
+        },
+      },
+      {
+        source: {
+          id: "src-a",
+          name: "Course Reference A",
+          documentType: "COURSE_REFERENCE_TUTOR_BRIEFING",
+          updatedAt: new Date("2026-06-08T09:00:00Z"),
+          _count: { assertions: 12 },
+        },
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.empty).toBe(false);
+    expect(body.sources).toHaveLength(2);
+    // Alpha order
+    expect(body.sources[0].name).toBe("Course Reference A");
+    expect(body.sources[1].name).toBe("Course Reference B");
+    expect(body.sources[0].assertionCount).toBe(12);
+    expect(body.sources[1].assertionCount).toBe(47);
+  });
+
+  it("filters out rows with null source (defensive against orphan join rows)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({ id: "course-1" });
+    mockPrisma.playbookSource.findMany.mockResolvedValue([
+      { source: null },
+      {
+        source: {
+          id: "src-a",
+          name: "Valid",
+          documentType: "COURSE_REFERENCE",
+          updatedAt: new Date("2026-06-10T12:00:00Z"),
+          _count: { assertions: 5 },
+        },
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.sources).toHaveLength(1);
+    expect(body.sources[0].name).toBe("Valid");
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -10095,6 +10095,12 @@ Parse a Course Reference markdown body for an author-declared
 
 ---
 
+### `POST` /api/courses/[courseId]/reproject-skills
+
+**Auth**: Session
+
+---
+
 ### `PUT` /api/courses/[courseId]/session-flow
 
 Partial update of Playbook.config — accepts a sessionFlow
@@ -10143,6 +10149,12 @@ Partial update of Playbook.config — accepts a sessionFlow
 ---
 
 ### `GET` /api/courses/[courseId]/skills-rubric-calibration
+
+**Auth**: Session
+
+---
+
+### `GET` /api/courses/[courseId]/skills-source-lineage
 
 **Auth**: Session
 
@@ -16062,8 +16074,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 522 |
-| Files with annotations | 510 |
+| Route files found | 524 |
+| Files with annotations | 512 |
 | Files missing annotations | 12 |
 | Coverage | 97.7% |
 


### PR DESCRIPTION
Sprint 3 SP3-B — fifth lens on the Skills Framework Inspector. Closes the educator question "where did this rubric come from?".

## Verified by
`npx vitest run tests/api/courses/skills-source-lineage-route.test.ts` → **5/5 pass**.

## What ships
- **GET /api/courses/[courseId]/skills-source-lineage** — returns COURSE_REFERENCE source rows with id+name+documentType+updatedAt+assertionCount. Filters by the same document-type set `runProjectionForPlaybook` consumes so the lineage stays in sync with what re-projection reads.
- **POST /api/courses/[courseId]/reproject-skills** — thin wrapper around `runProjectionForPlaybook`. Returns a summary string the UI shows in a toast.
- **`<SourceLineageLens>`** appended to `CourseSkillsTab.tsx` — header with Re-project button, success/error toast, source rows (alpha-sorted), empty state.
- ~150 lines new `.hf-skills-lineage-*` CSS, tokens only.

## Cascade / Chain / Guards
- ✅ `apply-projection.ts:866` already bumps `composeInputsUpdatedAt` post-tx — no double-bump.
- ✅ Document-type filter matches the projection layer's read filter.
- ✅ Both routes carry `eslint-disable hf-security/no-unscoped-caller-id-route` with educator-authoring-surface rationale.

## Sprint 3 status after this PR
- SP3-A Rubric Calibration ✅ #1579
- **SP3-B Source Lineage ✅ this PR**
- SP3-C Mastery vs Skill explainer ✅ #1596
- SP3-D Renderer migrations Group A batch 3 — still queued (needs renderer registry population)

🤖 Generated with [Claude Code](https://claude.com/claude-code)