### PR TITLE
feat(compose): #1558 S3a — section-loaders contract + executor sectionsOnly option

### DIFF
--- a/apps/admin/lib/compose/section-loaders.ts
+++ b/apps/admin/lib/compose/section-loaders.ts
@@ -1,0 +1,125 @@
+/**
+ * Section → loader / output-key mappings — #1558 (Story 3 of EPIC #1555).
+ *
+ * Companion to `section.ts` (the section taxonomy). This file is the
+ * **dependency graph** layer over the taxonomy: which loaders does each
+ * section need (read-side), and which `llmPrompt` outputKeys does it
+ * write to (write-side).
+ *
+ * Authored against the live `getDefaultSections()` registry in
+ * `CompositionExecutor.ts:700-1080` plus the transform set in
+ * `transforms/*.ts`. Cross-checked by `section-loaders.test.ts`. When a
+ * transform changes which outputKey it writes, or a new section is added,
+ * update BOTH this file AND `PIPELINE_STATE_SECTION_LOADERS` in the same
+ * PR — section-scoped recompose silently uses stale data otherwise.
+ *
+ * ## Section→outputKey mapping is many-to-many
+ *
+ * The S1 taxonomy is opinionated at the **educator-meaningful** level (a
+ * "section" is a region a teacher wants to think about), while the composer
+ * works at the **implementation** level (each transform writes one
+ * outputKey). One section may correspond to several outputKeys (e.g.
+ * `welcome` config flows into `_quickStart` AND influences first-line
+ * generation), and one outputKey may be written by transforms attributed
+ * to several sections (e.g. `curriculum` carries module structure,
+ * per-module mastery, AND per-LO mastery).
+ *
+ * For partial recompose, the route mints a NEW full `ComposedPrompt`
+ * via `executeComposition()` (deterministic, no LLM calls), then patches
+ * ONLY the outputKeys listed for the target section into every active
+ * stored prompt. Sibling outputKeys are preserved byte-for-byte from
+ * the prior stored prompt — the byte-identical-sibling AC is satisfied
+ * by construction.
+ *
+ * ## Why the map is conservative
+ *
+ * Where a section's content could reasonably live in MULTIPLE outputKeys,
+ * we list ALL of them. False positives (patching one extra outputKey) are
+ * acceptable — the result is a slightly broader patch, not a semantic
+ * bug. False negatives (forgetting an outputKey) leave stale text behind
+ * after a section-scoped recompose, which IS a bug. Err on the side of
+ * over-listing.
+ */
+
+import { PIPELINE_STATE_SECTION_LOADERS } from "./section";
+import type { ComposeSectionKey } from "./section";
+
+/**
+ * For each `ComposeSection`, the `llmPrompt` outputKey(s) that carry the
+ * section's text in a composed prompt. Used by
+ * `POST /api/courses/[courseId]/recompose-section` to patch only the
+ * affected outputKeys into stored `ComposedPrompt` rows.
+ *
+ * Empty array means the section is structurally not patchable — recompose
+ * for these returns 422. None of the S1 sections fall here; the type
+ * keeps the door open for future additions.
+ */
+export const SECTION_OUTPUT_KEYS: Record<ComposeSectionKey, readonly string[]> = {
+  // kind: "config" — these influence other sections' outputs (via
+  // computePedagogyMode + computeAudienceGuidance) but don't write a
+  // dedicated outputKey themselves. The transforms that READ them are
+  // attributed to the sections they affect (modulesGate, instructions).
+  // Section-scoped recompose on these falls through to a full sweep of
+  // the influenced outputKeys.
+  firstCallMode: ["_quickStart", "instructions"],
+  modePolicy: ["pedagogyMode", "audienceGuidance", "teachingStyle"],
+
+  // kind: "runtime", config-sourced.
+  intake: ["_quickStart"],
+  welcome: ["_quickStart"],
+  onboarding: ["_quickStart"],
+  offboarding: ["offboarding"],
+  nps: ["_quickStart"],
+
+  // kind: "runtime", pipeline-state.
+  modulesGate: ["curriculum"],
+  instructions: ["instructions", "instructions_pedagogy", "instructions_voice"],
+  moduleMastery: ["curriculum"],
+  loMastery: ["curriculum"],
+  behaviorTargets: ["behaviorTargets"],
+  personality: ["personality"],
+  contentTrust: ["contentTrust"],
+  carryOverActions: ["_quickStart", "instructions"],
+  priorCallFeedback: ["priorCallFeedback"],
+};
+
+/**
+ * Returns the union of loader names that must be fresh to recompose the
+ * supplied sections in isolation. Derived from
+ * `PIPELINE_STATE_SECTION_LOADERS`. Used by the route for documentation
+ * and by the dry-run preview to surface "these loaders will run".
+ *
+ * Empty result is meaningful: the section is config-sourced (no per-call
+ * state) and the recompose is a pure config read.
+ */
+export function getLoaderDepsForSections(
+  sectionKeys: readonly ComposeSectionKey[],
+): readonly string[] {
+  const set = new Set<string>();
+  for (const key of sectionKeys) {
+    for (const loader of PIPELINE_STATE_SECTION_LOADERS[key] ?? []) {
+      set.add(loader);
+    }
+  }
+  return Array.from(set).sort();
+}
+
+/**
+ * Returns the union of `llmPrompt` outputKeys that carry the supplied
+ * sections' text. Used by the route to scope the patch on stored
+ * `ComposedPrompt` rows.
+ *
+ * Empty result is meaningful: the section is structurally non-patchable
+ * (route returns 422). None of the S1 sections fall here today.
+ */
+export function getOutputKeysForSections(
+  sectionKeys: readonly ComposeSectionKey[],
+): readonly string[] {
+  const set = new Set<string>();
+  for (const key of sectionKeys) {
+    for (const outputKey of SECTION_OUTPUT_KEYS[key] ?? []) {
+      set.add(outputKey);
+    }
+  }
+  return Array.from(set).sort();
+}

--- a/apps/admin/lib/prompt/composition/CompositionExecutor.ts
+++ b/apps/admin/lib/prompt/composition/CompositionExecutor.ts
@@ -24,6 +24,31 @@ import type {
   CompositionResult,
   CompositionSectionDef,
 } from "./types";
+import type { ComposeSectionKey } from "@/lib/compose/section";
+import { getOutputKeysForSections } from "@/lib/compose/section-loaders";
+
+/**
+ * Optional invocation options for `executeComposition` — #1558 (S3 of EPIC #1555).
+ *
+ * `sectionsOnly`: when supplied, post-process `llmPrompt` to KEEP ONLY the
+ * outputKeys that carry text for the listed sections (plus structural
+ * fields `_version`, `_format`, `agentIdentitySummary`). All transforms
+ * still run; this is a **result filter**, not a transform skip — siblings
+ * stay byte-identical to a full compose by construction.
+ *
+ * Why a filter instead of a transform-skip: the assembled-section graph
+ * (`dependsOn` + `_assembled` collectors) has many cross-section reads
+ * (`instructions` depends on `memories`, `personality`, `behaviorTargets`,
+ * `curriculum`, `learner_goals`, `identity`, `content_trust`,
+ * `teaching_content`, `course_instructions`, `instructions_pedagogy`,
+ * `instructions_voice`). Skipping a transform whose output is read by
+ * another active transform would produce undefined behaviour. A future
+ * optimization pass can introduce a dependency-graph traversal; this
+ * option ships the contract surface today without that risk.
+ */
+export interface ExecuteCompositionOptions {
+  sectionsOnly?: readonly ComposeSectionKey[];
+}
 
 // Import all transform files to trigger self-registration
 import "./transforms/personality";
@@ -79,6 +104,7 @@ export async function executeComposition(
   triggerType?: string,
   requestedModuleId?: string | null,
   currentCallId?: string | null,
+  options?: ExecuteCompositionOptions,
 ): Promise<CompositionResult> {
   const loadStart = Date.now();
 
@@ -232,6 +258,27 @@ export async function executeComposition(
 
   // Add agent identity summary
   llmPrompt.agentIdentitySummary = buildAgentIdentitySummary(resolvedSpecs);
+
+  // #1558 S3 — sectionsOnly result filter. When the caller asks for a
+  // section-scoped recompose, strip outputKeys that don't belong to the
+  // requested sections. Structural fields (`_*`, `agentIdentitySummary`)
+  // are always preserved so the result still validates against the
+  // CompositionResult contract; downstream consumers (e.g. the
+  // recompose-section route) pluck only the section's outputKeys to
+  // patch into stored prompts.
+  if (options?.sectionsOnly && options.sectionsOnly.length > 0) {
+    const keep = new Set<string>([
+      ...getOutputKeysForSections(options.sectionsOnly),
+      "_version",
+      "_format",
+      "_quickStart",
+      "_preamble",
+      "agentIdentitySummary",
+    ]);
+    for (const key of Object.keys(llmPrompt)) {
+      if (!keep.has(key)) delete llmPrompt[key];
+    }
+  }
 
   // #479 — per-section character-count observability. The composed prompt
   // grew from 86K → 119K across 6 calls on hf-dev IELTS Speaking, sitting

--- a/apps/admin/tests/lib/compose/section-loaders.test.ts
+++ b/apps/admin/tests/lib/compose/section-loaders.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for `lib/compose/section-loaders.ts` — #1558 (Story 3 of EPIC #1555).
+ *
+ * Pins three contract properties the route + the executor `sectionsOnly`
+ * option both depend on:
+ *
+ *   1. Every `ComposeSectionKey` has a non-empty `SECTION_OUTPUT_KEYS`
+ *      entry (no structurally non-patchable sections in the S1 taxonomy).
+ *   2. `getLoaderDepsForSections` returns the union, sorted, deduped.
+ *   3. `getOutputKeysForSections` returns the union, sorted, deduped.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  SECTION_OUTPUT_KEYS,
+  getLoaderDepsForSections,
+  getOutputKeysForSections,
+} from "@/lib/compose/section-loaders";
+import { COMPOSE_SECTION_KEYS } from "@/lib/compose/section";
+
+describe("section-loaders — #1558", () => {
+  describe("SECTION_OUTPUT_KEYS — completeness + non-emptiness", () => {
+    it("covers every ComposeSectionKey", () => {
+      const covered = Object.keys(SECTION_OUTPUT_KEYS).sort();
+      const expected = [...COMPOSE_SECTION_KEYS].sort();
+      expect(covered).toEqual(expected);
+    });
+
+    it("every section has at least one outputKey (no structurally non-patchable sections)", () => {
+      for (const key of COMPOSE_SECTION_KEYS) {
+        expect(SECTION_OUTPUT_KEYS[key].length).toBeGreaterThan(0);
+      }
+    });
+
+    it("listed outputKeys match the conservative-overlist convention (no extraneous _ prefixes outside _quickStart / _preamble)", () => {
+      const allowedUnderscorePrefixed = new Set(["_quickStart", "_preamble"]);
+      for (const [section, keys] of Object.entries(SECTION_OUTPUT_KEYS)) {
+        for (const k of keys) {
+          if (k.startsWith("_")) {
+            expect(allowedUnderscorePrefixed.has(k), `section ${section}: underscore-prefixed outputKey ${k} not in allowlist`).toBe(true);
+          }
+        }
+      }
+    });
+  });
+
+  describe("getLoaderDepsForSections — union semantics", () => {
+    it("returns empty array for empty input", () => {
+      expect(getLoaderDepsForSections([])).toEqual([]);
+    });
+
+    it("returns empty array for sections with no loader deps (config-sourced)", () => {
+      expect(getLoaderDepsForSections(["firstCallMode"])).toEqual([]);
+      expect(getLoaderDepsForSections(["welcome", "onboarding", "intake"])).toEqual([]);
+    });
+
+    it("returns the section's loader for single-section pipeline-state queries", () => {
+      expect(getLoaderDepsForSections(["loMastery"])).toEqual(["callerAttributes"]);
+      expect(getLoaderDepsForSections(["behaviorTargets"])).toEqual(["callerTargets"]);
+    });
+
+    it("returns sorted, deduped union for multi-section queries", () => {
+      const deps = getLoaderDepsForSections(["loMastery", "moduleMastery", "behaviorTargets"]);
+      // loMastery + moduleMastery share callerAttributes; behaviorTargets adds callerTargets
+      expect(deps).toEqual(["callerAttributes", "callerTargets"]);
+    });
+  });
+
+  describe("getOutputKeysForSections — union semantics", () => {
+    it("returns empty array for empty input", () => {
+      expect(getOutputKeysForSections([])).toEqual([]);
+    });
+
+    it("returns the section's outputKeys", () => {
+      expect(getOutputKeysForSections(["personality"])).toEqual(["personality"]);
+      expect(getOutputKeysForSections(["behaviorTargets"])).toEqual(["behaviorTargets"]);
+    });
+
+    it("dedupes overlapping outputKeys across sections", () => {
+      // welcome + onboarding + intake all flow into _quickStart
+      expect(getOutputKeysForSections(["welcome", "onboarding", "intake"])).toEqual(["_quickStart"]);
+    });
+
+    it("returns sorted union", () => {
+      const out = getOutputKeysForSections(["personality", "behaviorTargets"]);
+      expect(out).toEqual(["behaviorTargets", "personality"]);
+    });
+  });
+});


### PR DESCRIPTION
Foundation slice of #1558 (Story 3 of EPIC #1555). Ships the contract layer the section-scoped recompose route depends on. Route + per-caller fanout follow in #1558 S3b.

## Summary

- `lib/compose/section-loaders.ts` — `SECTION_OUTPUT_KEYS` map (ComposeSectionKey → llmPrompt outputKeys), `getLoaderDepsForSections()`, `getOutputKeysForSections()`. Both helpers return sorted, deduped unions.
- `CompositionExecutor` — new `ExecuteCompositionOptions { sectionsOnly? }` 7th param. When supplied, post-process `llmPrompt` to keep only outputKeys for the listed sections (plus structural fields). **Result filter, not transform skip** — assembled-section graph has cross-section `dependsOn` reads, skipping a transform whose output is read by another active transform would produce undefined behaviour. Future optimization pass can extend to a dependency-graph traversal; contract stays the same.
- 11 new vitests; full `tests/lib/compose/` bank 86/86 green (incl. S2 #1600 staleness primitives still passing).

## Why split S3 into two PRs

The route requires TL decisions still in motion:

1. **Prose vs llmPrompt invariant.** Patching one llmPrompt outputKey leaves the prose `ComposedPrompt.prompt` field stale. Three valid options (re-render globally, mark stale, treat llmPrompt as source of truth). Not specified in the ADR.
2. **Per-caller fanout** — sync ≤20 / async above per the ADR — but the per-caller patch helper itself needs careful handling of the active-prompt selection (most-recent vs all active).
3. **Promptfoo eval AC** — recompose is LLM-free deterministic data shaping. Byte-identical-sibling is best pinned by a vitest inside S3b, not promptfoo.

Shipping the contract surface independently lets TL review the route's invariant decisions on a clean foundation.

## Verified by

- `npx vitest run tests/lib/compose/section-loaders.test.ts` — **11/11 PASS**
- `npx vitest run tests/lib/compose/ tests/api/courses/section-staleness-route.test.ts` — **86/86 PASS** (incl. S2 #1600 staleness still passing, no regression)
- `npx tsc --noEmit` — no new errors (pre-existing failures only)
- `npx eslint lib/compose/section-loaders.ts lib/prompt/composition/CompositionExecutor.ts tests/lib/compose/section-loaders.test.ts` — 0 errors (18 pre-existing `any` warnings in CompositionExecutor)
- Contract pinned by test `tests/lib/compose/section-loaders.test.ts > SECTION_OUTPUT_KEYS — completeness + non-emptiness > covers every ComposeSectionKey` — guarantees S1 taxonomy stays in sync with the patch-key map

## Test plan

- [ ] TL review of `SECTION_OUTPUT_KEYS` map — confirm conservative-overlist convention is correct for `modePolicy` (lists `pedagogyMode + audienceGuidance + teachingStyle`) and `instructions` (lists `instructions + instructions_pedagogy + instructions_voice`)
- [ ] TL decision on the prose vs llmPrompt invariant for S3b
- [ ] No new routes; no runtime UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)