### PR TITLE
feat(renderers): #1623 — PreviewLens 5-section migration (B.13, unlocks A.2-A.10)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/CourseDesignConsole.tsx
@@ -113,6 +113,11 @@ interface LensProps {
    *  config). Bumps `staleRefreshTick` so `StalePromptPillForCourse`
    *  re-fetches without a page reload (#1478 Amendment A). */
   onComposeInputChange?: () => void;
+  /** #1623 — Renderers v2 B.13. PreviewLens calls this on a sidetray-
+   *  triggering bubble click so the Designer Inspector slot can mount
+   *  the section-summary renderer. Toggle semantics: clicking the same
+   *  section a second time should pass `null` to clear. */
+  onSelectSection?: (section: import("@/lib/compose").ComposeSectionKey | null) => void;
 }
 
 const ICON_SIZE = 14;
@@ -172,8 +177,8 @@ const ProgressSignalsLens: React.FC<LensProps> = ({ courseId, playbookConfig }) 
 );
 ProgressSignalsLens.displayName = "ProgressSignalsLens";
 
-const PreviewLensWrap: React.FC<LensProps> = ({ courseId }) => (
-  <PreviewLens courseId={courseId} />
+const PreviewLensWrap: React.FC<LensProps> = ({ courseId, onSelectSection }) => (
+  <PreviewLens courseId={courseId} onSelectSection={onSelectSection} />
 );
 PreviewLensWrap.displayName = "PreviewLensWrap";
 
@@ -313,11 +318,15 @@ const COMING_SOON_HELP = (
 export interface CourseDesignConsoleProps {
   courseId: string;
   playbookConfig?: PlaybookConfig | Record<string, unknown> | null;
+  /** #1623 — wired through to PreviewLens so chat-bubble clicks ALSO
+   *  drive the Designer Inspector slot in `DesignTab`. */
+  onSelectSection?: (section: import("@/lib/compose").ComposeSectionKey | null) => void;
 }
 
 export function CourseDesignConsole({
   courseId,
   playbookConfig,
+  onSelectSection,
 }: CourseDesignConsoleProps): React.ReactElement {
   const { view, setView } = useConsoleView<DesignLensId>({
     isValidId: isDesignLensId,
@@ -339,7 +348,7 @@ export function CourseDesignConsole({
       <ConsoleShell<DesignLensId, LensProps>
         lensOrder={DESIGN_LENS_ORDER}
         lenses={DESIGN_LENSES}
-        lensProps={{ courseId, playbookConfig, onComposeInputChange }}
+        lensProps={{ courseId, playbookConfig, onComposeInputChange, onSelectSection }}
         activeLensId={view}
         onLensChange={setView}
         ariaNavLabel="Course design lenses"

--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -42,9 +42,28 @@ import { getArchetypeLabel } from "@/lib/domain/generate-identity";
 import type { Effective, Layer } from "@/lib/cascade/layer-types";
 import { substituteGreetingTokens } from "@/lib/prompt/composition/defaults/substitute-greeting-tokens";
 import type { DemoAnnotation, DemoScript } from "@/lib/types/json-fields";
+import type { ComposeSectionKey } from "@/lib/compose";
+
+/** Map from PreviewLens sidetray lens id → `ComposeSectionKey` for B.13.
+ *  Only the 5 in-scope sections are listed; clicks on other lenses (e.g.
+ *  `moduleVisibility`) leave the Designer Inspector untouched. The
+ *  `stops` lens currently surfaces the NPS prompt — map to `nps`. */
+const SIDETRAY_LENS_TO_SECTION: Partial<Record<string, ComposeSectionKey>> = {
+  intake: "intake",
+  onboarding: "onboarding",
+  offboarding: "offboarding",
+  welcome: "welcome",
+  stops: "nps",
+};
 
 interface PreviewLensProps {
   courseId: string;
+  /** #1623 — Renderers v2 B.13. Optional. When supplied, PreviewLens
+   *  ALSO fires this callback alongside its existing `openSidetray`
+   *  flow on bubble click, so the Designer Inspector can render a
+   *  section-summary alongside the live edit sidetray. Pure addition
+   *  — no behaviour change when prop omitted (today's mount path). */
+  onSelectSection?: (section: ComposeSectionKey | null) => void;
 }
 
 interface SessionFlowResp {
@@ -129,7 +148,7 @@ const SIDETRAY_TITLES: Record<SessionFlowLens, string> = {
   moduleVisibility: "Module visibility — when modules get named",
 };
 
-export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement {
+export function PreviewLens({ courseId, onSelectSection }: PreviewLensProps): React.ReactElement {
   const { demoAnnotationsVisible } = useChatContext();
   const [mode, setMode] = useState<ViewMode>("educator");
   const [flow, setFlow] = useState<SessionFlowResp | null>(null);
@@ -194,7 +213,15 @@ export function PreviewLens({ courseId }: PreviewLensProps): React.ReactElement 
   const openSidetray = useCallback((lensId: string) => {
     const mapped = SIDETRAY_LENS_MAP[lensId];
     if (mapped) setSidetrayLens(mapped);
-  }, []);
+    // #1623 — Designer Inspector hook. The sidetray (edit affordance)
+    // and the Inspector (preview-summary surface) are independent: the
+    // sidetray stays the educator's "tweak this" entry; the Inspector
+    // mirrors which section was last clicked for the Designer rail.
+    if (onSelectSection) {
+      const section = SIDETRAY_LENS_TO_SECTION[lensId];
+      if (section) onSelectSection(section);
+    }
+  }, [onSelectSection]);
 
   const closeSidetray = useCallback(() => {
     setSidetrayLens(null);

--- a/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
@@ -4,28 +4,20 @@
  * DesignTab — DesignerShell wiring for the course Design tab.
  *
  * S4 of #1555 shipped this as an unrouted scaffold. #1607 (Epic #1606
- * A.1 firstCallMode renderer) wires it into the live Design tab via
- * `CourseDesignTab.tsx`, and gives the Inspector slot a real first
- * renderer to mount.
- *
- * Responsibilities:
- *   - Own the `DesignerShell` three-slot layout for the live Design tab
- *   - Track section selection via `useDesignerSelection`
- *   - Render a header-banner entry point chip for `firstCallMode` (no
- *     canvas bubble exists for `kind: "config"` sections in PreviewLens
- *     today; this chip is the smoke-test entry point). Click to open the
- *     Inspector; click again to close.
- *   - Resolve per-section `data` for the Inspector renderer. Today: only
- *     `firstCallMode` is wired (from `playbookConfig.firstCallMode`).
- *     Group B (epic #1606 story #13) will add the rest as it migrates
- *     PreviewLens's inline sections into the registry.
+ * A.1 firstCallMode renderer) wired it into the live Design tab via
+ * `CourseDesignTab.tsx`, with a header-banner entry-point chip.
+ * #1623 (B.13) extends it to thread `onSelectSection` down to
+ * `PreviewLens` so the existing chat-bubble click handlers ALSO
+ * trigger the Inspector for 5 hand-wired sections (intake / welcome /
+ * onboarding / offboarding / nps), and fetches the session-flow data
+ * the new section renderers need.
  *
  * Side-effect: importing the preview-renderers barrel triggers all
  * `registerPreviewRenderer()` calls at module load, before the Inspector
  * attempts a lookup.
  */
 
-import { createElement, useMemo } from "react";
+import { createElement, useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   DesignerShell,
@@ -33,6 +25,7 @@ import {
   useDesignerSelection,
 } from "@/components/shared/designer-shell";
 import "@/components/shared/preview-renderers";
+import type { SessionFlowData } from "@/components/shared/preview-renderers";
 import type { ComposeSectionKey } from "@/lib/compose";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 
@@ -52,18 +45,32 @@ const FIRST_CALL_MODE_LABEL: Record<
   baseline_assessment: "Baseline Assessment",
 };
 
+/** Sections whose data comes from the session-flow API (B.13). */
+const SESSION_FLOW_SECTIONS = new Set<ComposeSectionKey>([
+  "intake",
+  "welcome",
+  "onboarding",
+  "offboarding",
+  "nps",
+]);
+
 function resolveRendererData(
   selectedKey: ComposeSectionKey,
   pbConfig: PlaybookConfig,
+  sessionFlow: SessionFlowData | null,
 ): unknown {
   if (selectedKey === "firstCallMode") {
     return { firstCallMode: pbConfig.firstCallMode };
+  }
+  if (SESSION_FLOW_SECTIONS.has(selectedKey)) {
+    return { sessionFlow };
   }
   return undefined;
 }
 
 export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
   const { selectedKey, setSelectedKey } = useDesignerSelection();
+  const [sessionFlow, setSessionFlow] = useState<SessionFlowData | null>(null);
   const pbConfig = useMemo(
     () => (playbookConfig ?? {}) as PlaybookConfig,
     [playbookConfig],
@@ -75,15 +82,44 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
       : FIRST_CALL_MODE_LABEL[firstCallMode];
   const firstCallModeSelected = selectedKey === "firstCallMode";
 
+  // Fetch session-flow once on mount — feeds the 5 new B.13 renderers.
+  // PreviewLens fetches the same endpoint independently; that duplication
+  // is acceptable for V1 and can be deduped via lifted state in a
+  // follow-on cleanup.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/session-flow`)
+      .then((res) => res.json())
+      .then((j: { ok: boolean; sessionFlow?: SessionFlowData }) => {
+        if (!cancelled && j.ok && j.sessionFlow) {
+          setSessionFlow(j.sessionFlow);
+        }
+      })
+      .catch(() => {
+        // Renderer handles the null state gracefully — no need to surface
+        // the error in the Inspector slot.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
   const inspectorNode = useMemo(() => {
     if (!selectedKey) return null;
     const renderer = getPreviewRenderer(selectedKey);
     if (!renderer) return null;
     return createElement(renderer, {
-      data: resolveRendererData(selectedKey, pbConfig),
+      data: resolveRendererData(selectedKey, pbConfig, sessionFlow),
       selection: { selectedKey },
     });
-  }, [selectedKey, pbConfig]);
+  }, [selectedKey, pbConfig, sessionFlow]);
+
+  const onSelectSection = useCallback(
+    (section: ComposeSectionKey | null) => {
+      setSelectedKey((prev) => (prev === section ? null : section));
+    },
+    [setSelectedKey],
+  );
 
   const headerBanner = (
     <div className="hf-chip-row" data-testid="hf-designer-entry-points">
@@ -108,6 +144,7 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
         <CourseDesignConsole
           courseId={courseId}
           playbookConfig={playbookConfig}
+          onSelectSection={onSelectSection}
         />
       }
       inspector={inspectorNode}

--- a/apps/admin/components/shared/designer-shell/useDesignerSelection.ts
+++ b/apps/admin/components/shared/designer-shell/useDesignerSelection.ts
@@ -12,7 +12,7 @@
  * type-safety + dispatch; this hook just tracks "what is selected".
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, type Dispatch, type SetStateAction } from "react";
 
 import type { ComposeSectionKey } from "@/lib/compose";
 
@@ -21,7 +21,10 @@ export interface DesignerSelection {
 }
 
 export interface UseDesignerSelectionResult extends DesignerSelection {
-  setSelectedKey: (next: ComposeSectionKey | null) => void;
+  /** Accepts either a raw value or a `(prev) => next` updater — matches
+   *  React's `Dispatch<SetStateAction<T>>` so functional updates work in
+   *  callbacks without stale-closure pain. */
+  setSelectedKey: Dispatch<SetStateAction<ComposeSectionKey | null>>;
   clear: () => void;
 }
 

--- a/apps/admin/components/shared/preview-renderers/IntakeRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/IntakeRenderer.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+/**
+ * IntakeRenderer — Group B.13 (Epic #1606).
+ *
+ * Shows enabled/disabled state of the four intake questions:
+ *   - Goals
+ *   - About you
+ *   - Knowledge check (with delivery mode: MCQ / Socratic)
+ *   - AI intro call
+ *
+ * Section: `intake` (kind: "runtime" config-sourced — reads from
+ * `Playbook.config.intake` via the session-flow resolver).
+ */
+
+import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
+import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+
+import type { SessionFlowData } from "./types";
+
+export interface IntakeRendererData {
+  sessionFlow: SessionFlowData | null;
+}
+
+function StateChip({ enabled, label }: { enabled: boolean; label: string }) {
+  return (
+    <span
+      className={`hf-badge ${enabled ? "hf-badge-info" : "hf-badge-muted"}`}
+    >
+      {label}: {enabled ? "ON" : "OFF"}
+    </span>
+  );
+}
+
+export function IntakeRenderer({
+  data,
+}: PreviewRendererProps<IntakeRendererData>) {
+  const sf = data.sessionFlow;
+  if (!sf) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Intake</div>
+        <span className="hf-badge hf-badge-muted">Session flow not loaded</span>
+      </div>
+    );
+  }
+  const kcMode = sf.intake.knowledgeCheck.deliveryMode ?? "mcq";
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-category-label">Intake — pre-call questions</div>
+      <StateChip enabled={sf.intake.goals.enabled} label="Goals" />
+      <StateChip enabled={sf.intake.aboutYou.enabled} label="About you" />
+      <StateChip
+        enabled={sf.intake.knowledgeCheck.enabled}
+        label={`Knowledge check (${kcMode === "socratic" ? "Socratic" : "MCQ"})`}
+      />
+      <StateChip enabled={sf.intake.aiIntroCall.enabled} label="AI intro call" />
+      {sf.source?.intake ? (
+        <span className="hf-badge hf-badge-muted">
+          source: {sf.source.intake}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+registerPreviewRenderer<"intake", IntakeRendererData>("intake", IntakeRenderer);

--- a/apps/admin/components/shared/preview-renderers/NpsRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/NpsRenderer.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * NpsRenderer — Group B.13 (Epic #1606).
+ *
+ * Shows the NPS Session Stop trigger configuration. Locates the `nps`
+ * entry inside `sessionFlow.stops[]` and renders a human-readable
+ * trigger summary.
+ *
+ * Section: `nps` (kind: "runtime" config-sourced). Surfaces in
+ * PreviewLens via the `stops` sidetray lens; the registry section key
+ * is `nps` (the actual stop type).
+ */
+
+import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
+import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+
+import type { SessionFlowData } from "./types";
+
+export interface NpsRendererData {
+  sessionFlow: SessionFlowData | null;
+}
+
+function describeTrigger(t: {
+  type: string;
+  threshold?: number;
+  count?: number;
+}): string {
+  if (t.type === "mastery_reached" && typeof t.threshold === "number") {
+    return `Mastery ≥ ${Math.round(t.threshold * 100)}%`;
+  }
+  if (t.type === "after_n_calls" && typeof t.count === "number") {
+    return `After ${t.count} call${t.count === 1 ? "" : "s"}`;
+  }
+  if (t.type === "course_end") {
+    return "Course end";
+  }
+  return t.type;
+}
+
+export function NpsRenderer({
+  data,
+}: PreviewRendererProps<NpsRendererData>) {
+  const sf = data.sessionFlow;
+  if (!sf) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">NPS prompt</div>
+        <span className="hf-badge hf-badge-muted">Session flow not loaded</span>
+      </div>
+    );
+  }
+  const npsStop = sf.stops.find((s) => s.kind === "nps");
+  if (!npsStop) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">NPS prompt</div>
+        <span className="hf-badge hf-badge-muted">No NPS stop configured</span>
+      </div>
+    );
+  }
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-category-label">NPS prompt</div>
+      <span className="hf-badge hf-badge-info">
+        Triggers: {npsStop.trigger ? describeTrigger(npsStop.trigger) : "—"}
+      </span>
+      {sf.source?.stops ? (
+        <span className="hf-badge hf-badge-muted">
+          source: {sf.source.stops}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+registerPreviewRenderer<"nps", NpsRendererData>("nps", NpsRenderer);

--- a/apps/admin/components/shared/preview-renderers/OffboardingRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/OffboardingRenderer.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/**
+ * OffboardingRenderer — Group B.13 (Epic #1606).
+ *
+ * Shows end-of-course offboarding phases + the call-count trigger.
+ *
+ * Section: `offboarding` (kind: "runtime" config-sourced).
+ */
+
+import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
+import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+
+import type { SessionFlowData } from "./types";
+
+export interface OffboardingRendererData {
+  sessionFlow: SessionFlowData | null;
+}
+
+export function OffboardingRenderer({
+  data,
+}: PreviewRendererProps<OffboardingRendererData>) {
+  const sf = data.sessionFlow;
+  if (!sf) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Offboarding</div>
+        <span className="hf-badge hf-badge-muted">Session flow not loaded</span>
+      </div>
+    );
+  }
+  const phases = sf.offboarding.phases;
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-category-label">
+        Offboarding — end-of-course phases ({phases.length})
+      </div>
+      {phases.length === 0 ? (
+        <span className="hf-badge hf-badge-muted">
+          No phases configured
+        </span>
+      ) : (
+        <ol className="hf-list-row">
+          {phases.map((p, i) => (
+            <li key={`${p.phase}-${i}`}>
+              <span className="hf-badge hf-badge-info">{p.phase}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+      {typeof sf.offboarding.triggerAfterCalls === "number" ? (
+        <>
+          <div className="hf-category-label">Trigger</div>
+          <span className="hf-badge hf-badge-info">
+            After {sf.offboarding.triggerAfterCalls} call
+            {sf.offboarding.triggerAfterCalls === 1 ? "" : "s"}
+          </span>
+        </>
+      ) : null}
+      {sf.source?.offboarding ? (
+        <span className="hf-badge hf-badge-muted">
+          source: {sf.source.offboarding}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+registerPreviewRenderer<"offboarding", OffboardingRendererData>(
+  "offboarding",
+  OffboardingRenderer,
+);

--- a/apps/admin/components/shared/preview-renderers/OnboardingRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/OnboardingRenderer.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * OnboardingRenderer — Group B.13 (Epic #1606).
+ *
+ * Shows the configured first-call onboarding phases. Each phase = a
+ * row with phase label + optional duration + first goal preview.
+ *
+ * Section: `onboarding` (kind: "runtime" config-sourced).
+ */
+
+import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
+import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+
+import type { SessionFlowData } from "./types";
+
+export interface OnboardingRendererData {
+  sessionFlow: SessionFlowData | null;
+}
+
+export function OnboardingRenderer({
+  data,
+}: PreviewRendererProps<OnboardingRendererData>) {
+  const sf = data.sessionFlow;
+  if (!sf) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Onboarding</div>
+        <span className="hf-badge hf-badge-muted">Session flow not loaded</span>
+      </div>
+    );
+  }
+  const phases = sf.onboarding.phases;
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-category-label">
+        Onboarding — first-call phases ({phases.length})
+      </div>
+      {phases.length === 0 ? (
+        <span className="hf-badge hf-badge-muted">
+          No phases configured — using fallback
+        </span>
+      ) : (
+        <ol className="hf-list-row">
+          {phases.map((p, i) => (
+            <li key={`${p.phase}-${i}`}>
+              <span className="hf-badge hf-badge-info">{p.phase}</span>
+              {p.duration ? (
+                <span className="hf-badge hf-badge-muted">{p.duration}</span>
+              ) : null}
+              {p.goals && p.goals.length > 0 ? (
+                <p className="hf-text-sm">{p.goals[0]}</p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
+      {sf.source?.onboarding ? (
+        <span className="hf-badge hf-badge-muted">
+          source: {sf.source.onboarding}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+registerPreviewRenderer<"onboarding", OnboardingRendererData>(
+  "onboarding",
+  OnboardingRenderer,
+);

--- a/apps/admin/components/shared/preview-renderers/WelcomeRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/WelcomeRenderer.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+/**
+ * WelcomeRenderer — Group B.13 (Epic #1606) sibling of FirstCallModeRenderer.
+ *
+ * Shows the live greeting state from `GET /api/courses/:id/session-flow`:
+ *   - Resolved welcome message (chip badge: PLAYBOOK / DOMAIN / GENERIC source)
+ *   - Wait-for-ack mode (none / any response / greeting words)
+ *   - Course-intro presence (chip + excerpt when authored)
+ *
+ * Section: `welcome` (kind: "runtime" config-sourced — no compose-time
+ * loader; reads `Playbook.config` via the session-flow resolver).
+ */
+
+import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
+import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+
+import type { SessionFlowData } from "./types";
+
+export interface WelcomeRendererData {
+  sessionFlow: SessionFlowData | null;
+}
+
+const ACK_LABEL: Record<SessionFlowData["firstCallWaitForAck"], string> = {
+  none: "No acknowledgement gate",
+  any_response: "Waits for any reply",
+  greeting_words: "Waits for hi / hello / yes / …",
+};
+
+const SOURCE_LABEL: Record<NonNullable<SessionFlowData["source"]>["welcomeMessage"] & string, string> = {
+  playbook: "PLAYBOOK",
+  domain: "DOMAIN",
+  generic: "GENERIC",
+};
+
+export function WelcomeRenderer({
+  data,
+}: PreviewRendererProps<WelcomeRendererData>) {
+  const sf = data.sessionFlow;
+  if (!sf) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Greeting</div>
+        <span className="hf-badge hf-badge-muted">Session flow not loaded</span>
+      </div>
+    );
+  }
+  const welcomeSource = sf.source?.welcomeMessage;
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-category-label">Greeting</div>
+      {sf.welcomeMessage ? (
+        <>
+          <span className="hf-badge hf-badge-info">Welcome set</span>
+          {welcomeSource ? (
+            <span className="hf-badge hf-badge-muted">
+              from {SOURCE_LABEL[welcomeSource]}
+            </span>
+          ) : null}
+          <p className="hf-text-sm">{sf.welcomeMessage}</p>
+        </>
+      ) : (
+        <span className="hf-badge hf-badge-muted">Using generic fallback</span>
+      )}
+      <div className="hf-category-label">Ack gate</div>
+      <span className="hf-badge hf-badge-info">
+        {ACK_LABEL[sf.firstCallWaitForAck]}
+      </span>
+      {sf.firstCallCourseIntro ? (
+        <>
+          <div className="hf-category-label">Course intro</div>
+          <span className="hf-badge hf-badge-info">Authored</span>
+          <p className="hf-text-sm">{sf.firstCallCourseIntro}</p>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+registerPreviewRenderer<"welcome", WelcomeRendererData>(
+  "welcome",
+  WelcomeRenderer,
+);

--- a/apps/admin/components/shared/preview-renderers/index.ts
+++ b/apps/admin/components/shared/preview-renderers/index.ts
@@ -9,3 +9,20 @@
 
 export { FirstCallModeRenderer } from "./FirstCallModeRenderer";
 export type { FirstCallModeRendererData } from "./FirstCallModeRenderer";
+
+export { WelcomeRenderer } from "./WelcomeRenderer";
+export type { WelcomeRendererData } from "./WelcomeRenderer";
+
+export { IntakeRenderer } from "./IntakeRenderer";
+export type { IntakeRendererData } from "./IntakeRenderer";
+
+export { OnboardingRenderer } from "./OnboardingRenderer";
+export type { OnboardingRendererData } from "./OnboardingRenderer";
+
+export { OffboardingRenderer } from "./OffboardingRenderer";
+export type { OffboardingRendererData } from "./OffboardingRenderer";
+
+export { NpsRenderer } from "./NpsRenderer";
+export type { NpsRendererData } from "./NpsRenderer";
+
+export type { SessionFlowData } from "./types";

--- a/apps/admin/components/shared/preview-renderers/types.ts
+++ b/apps/admin/components/shared/preview-renderers/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared types for the Preview renderers (Epic #1606).
+ *
+ * Mirrors the `SessionFlowResp` shape served by
+ * `GET /api/courses/:id/session-flow`. Extracted here so renderer
+ * modules don't depend on `PreviewLens.tsx` internals — keeps the
+ * registry decoupled from the canvas component.
+ */
+
+export interface SessionFlowData {
+  intake: {
+    goals: { enabled: boolean };
+    aboutYou: { enabled: boolean };
+    knowledgeCheck: {
+      enabled: boolean;
+      deliveryMode?: "mcq" | "socratic";
+    };
+    aiIntroCall: { enabled: boolean };
+  };
+  onboarding: {
+    phases: Array<{ phase: string; duration?: string; goals?: string[] }>;
+  };
+  welcomeMessage: string | null;
+  firstCallCourseIntro: string | null;
+  firstCallWaitForAck: "none" | "any_response" | "greeting_words";
+  offboarding: {
+    phases: Array<{ phase: string }>;
+    triggerAfterCalls?: number;
+  };
+  stops: Array<{
+    id: string;
+    kind: string;
+    trigger?: { type: string; threshold?: number; count?: number };
+  }>;
+  source?: {
+    intake?: "new-shape" | "legacy-welcome" | "defaults";
+    onboarding?: "new-shape" | "playbook-legacy" | "domain" | "init001";
+    stops?: "new-shape" | "synthesized-from-legacy";
+    offboarding?: "new-shape" | "playbook-legacy" | "defaults";
+    welcomeMessage?: "playbook" | "domain" | "generic";
+    firstCallCourseIntro?: "playbook" | "none";
+    firstCallWaitForAck?: "playbook" | "default";
+  };
+}

--- a/apps/admin/tests/components/preview-renderers/b13-renderers.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/b13-renderers.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * B.13 renderer suite (#1623) — registry contract + per-section render
+ * output for the 5 migrated PreviewLens sections.
+ *
+ * Pinned acceptance per section:
+ *   1. Registry contract — `getPreviewRenderer(<key>)` returns the
+ *      registered component after the renderer module loads.
+ *   2. Empty / null session-flow state — muted fallback, never crashes.
+ *   3. Populated state — chips render with the expected labels.
+ *   4. Source labels surface when present (provenance discipline).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import {
+  WelcomeRenderer,
+  type WelcomeRendererData,
+  IntakeRenderer,
+  type IntakeRendererData,
+  OnboardingRenderer,
+  type OnboardingRendererData,
+  OffboardingRenderer,
+  type OffboardingRendererData,
+  NpsRenderer,
+  type NpsRendererData,
+  type SessionFlowData,
+} from "@/components/shared/preview-renderers";
+import {
+  getPreviewRenderer,
+  registerPreviewRenderer,
+} from "@/components/shared/designer-shell";
+import { __resetPreviewRenderersForTesting } from "@/components/shared/designer-shell/section-registry";
+
+afterEach(() => {
+  cleanup();
+  __resetPreviewRenderersForTesting();
+});
+
+beforeEach(() => {
+  registerPreviewRenderer<"welcome", WelcomeRendererData>("welcome", WelcomeRenderer);
+  registerPreviewRenderer<"intake", IntakeRendererData>("intake", IntakeRenderer);
+  registerPreviewRenderer<"onboarding", OnboardingRendererData>(
+    "onboarding",
+    OnboardingRenderer,
+  );
+  registerPreviewRenderer<"offboarding", OffboardingRendererData>(
+    "offboarding",
+    OffboardingRenderer,
+  );
+  registerPreviewRenderer<"nps", NpsRendererData>("nps", NpsRenderer);
+});
+
+function makeSessionFlow(
+  overrides: Partial<SessionFlowData> = {},
+): SessionFlowData {
+  return {
+    intake: {
+      goals: { enabled: false },
+      aboutYou: { enabled: false },
+      knowledgeCheck: { enabled: false, deliveryMode: "mcq" },
+      aiIntroCall: { enabled: false },
+    },
+    onboarding: { phases: [] },
+    welcomeMessage: null,
+    firstCallCourseIntro: null,
+    firstCallWaitForAck: "none",
+    offboarding: { phases: [] },
+    stops: [],
+    ...overrides,
+  };
+}
+
+describe("B.13 renderers — registry contract", () => {
+  it("registers all 5 section renderers under their canonical keys", () => {
+    expect(getPreviewRenderer("welcome")).toBe(WelcomeRenderer);
+    expect(getPreviewRenderer("intake")).toBe(IntakeRenderer);
+    expect(getPreviewRenderer("onboarding")).toBe(OnboardingRenderer);
+    expect(getPreviewRenderer("offboarding")).toBe(OffboardingRenderer);
+    expect(getPreviewRenderer("nps")).toBe(NpsRenderer);
+  });
+});
+
+describe("WelcomeRenderer", () => {
+  it("renders muted fallback when sessionFlow is null", () => {
+    render(
+      <WelcomeRenderer
+        data={{ sessionFlow: null }}
+        selection={{ selectedKey: "welcome" }}
+      />,
+    );
+    expect(screen.getByText("Session flow not loaded")).toBeInTheDocument();
+  });
+
+  it("renders the resolved greeting + source badge when set", () => {
+    const sf = makeSessionFlow({
+      welcomeMessage: "Hi {firstName}, welcome to {courseName}.",
+      firstCallWaitForAck: "any_response",
+      source: { welcomeMessage: "playbook" },
+    });
+    render(
+      <WelcomeRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "welcome" }}
+      />,
+    );
+    expect(screen.getByText("Welcome set")).toBeInTheDocument();
+    expect(screen.getByText("from PLAYBOOK")).toBeInTheDocument();
+    expect(screen.getByText(/Hi \{firstName\}/)).toBeInTheDocument();
+    expect(screen.getByText("Waits for any reply")).toBeInTheDocument();
+  });
+
+  it("renders the course-intro panel when authored", () => {
+    const sf = makeSessionFlow({
+      welcomeMessage: "Welcome.",
+      firstCallCourseIntro: "Today we'll cover the basics.",
+    });
+    render(
+      <WelcomeRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "welcome" }}
+      />,
+    );
+    expect(screen.getByText("Course intro")).toBeInTheDocument();
+    expect(screen.getByText("Authored")).toBeInTheDocument();
+    expect(
+      screen.getByText("Today we'll cover the basics."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("IntakeRenderer", () => {
+  it("renders 4 OFF chips + muted source when empty", () => {
+    render(
+      <IntakeRenderer
+        data={{ sessionFlow: makeSessionFlow() }}
+        selection={{ selectedKey: "intake" }}
+      />,
+    );
+    expect(screen.getByText(/Goals: OFF/)).toBeInTheDocument();
+    expect(screen.getByText(/About you: OFF/)).toBeInTheDocument();
+    expect(screen.getByText(/Knowledge check \(MCQ\): OFF/)).toBeInTheDocument();
+    expect(screen.getByText(/AI intro call: OFF/)).toBeInTheDocument();
+  });
+
+  it("flips chips to ON and surfaces Socratic delivery mode", () => {
+    const sf = makeSessionFlow({
+      intake: {
+        goals: { enabled: true },
+        aboutYou: { enabled: true },
+        knowledgeCheck: { enabled: true, deliveryMode: "socratic" },
+        aiIntroCall: { enabled: false },
+      },
+      source: { intake: "new-shape" },
+    });
+    render(
+      <IntakeRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "intake" }}
+      />,
+    );
+    expect(screen.getByText(/Goals: ON/)).toBeInTheDocument();
+    expect(screen.getByText(/About you: ON/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Knowledge check \(Socratic\): ON/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/AI intro call: OFF/)).toBeInTheDocument();
+    expect(screen.getByText("source: new-shape")).toBeInTheDocument();
+  });
+});
+
+describe("OnboardingRenderer", () => {
+  it("renders empty state when no phases", () => {
+    render(
+      <OnboardingRenderer
+        data={{ sessionFlow: makeSessionFlow() }}
+        selection={{ selectedKey: "onboarding" }}
+      />,
+    );
+    expect(
+      screen.getByText("No phases configured — using fallback"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders phase chips with optional duration + goal preview", () => {
+    const sf = makeSessionFlow({
+      onboarding: {
+        phases: [
+          { phase: "Intro", duration: "2m", goals: ["Set context"] },
+          { phase: "Goal capture" },
+        ],
+      },
+      source: { onboarding: "playbook-legacy" },
+    });
+    render(
+      <OnboardingRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "onboarding" }}
+      />,
+    );
+    expect(screen.getByText("Intro")).toBeInTheDocument();
+    expect(screen.getByText("2m")).toBeInTheDocument();
+    expect(screen.getByText("Set context")).toBeInTheDocument();
+    expect(screen.getByText("Goal capture")).toBeInTheDocument();
+    expect(screen.getByText("source: playbook-legacy")).toBeInTheDocument();
+  });
+});
+
+describe("OffboardingRenderer", () => {
+  it("renders empty state when no phases", () => {
+    render(
+      <OffboardingRenderer
+        data={{ sessionFlow: makeSessionFlow() }}
+        selection={{ selectedKey: "offboarding" }}
+      />,
+    );
+    expect(screen.getByText("No phases configured")).toBeInTheDocument();
+  });
+
+  it("renders phases + the call-count trigger pluralised correctly", () => {
+    const sf = makeSessionFlow({
+      offboarding: {
+        phases: [{ phase: "Wrap-up" }, { phase: "Survey" }],
+        triggerAfterCalls: 5,
+      },
+    });
+    render(
+      <OffboardingRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "offboarding" }}
+      />,
+    );
+    expect(screen.getByText("Wrap-up")).toBeInTheDocument();
+    expect(screen.getByText("Survey")).toBeInTheDocument();
+    expect(screen.getByText("After 5 calls")).toBeInTheDocument();
+  });
+
+  it("uses singular call-count copy when triggerAfterCalls is 1", () => {
+    const sf = makeSessionFlow({
+      offboarding: { phases: [{ phase: "Wrap-up" }], triggerAfterCalls: 1 },
+    });
+    render(
+      <OffboardingRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "offboarding" }}
+      />,
+    );
+    expect(screen.getByText("After 1 call")).toBeInTheDocument();
+  });
+});
+
+describe("NpsRenderer", () => {
+  it("renders muted state when no nps stop in the flow", () => {
+    render(
+      <NpsRenderer
+        data={{ sessionFlow: makeSessionFlow() }}
+        selection={{ selectedKey: "nps" }}
+      />,
+    );
+    expect(screen.getByText("No NPS stop configured")).toBeInTheDocument();
+  });
+
+  it("describes the mastery_reached trigger as a percentage", () => {
+    const sf = makeSessionFlow({
+      stops: [
+        {
+          id: "s1",
+          kind: "nps",
+          trigger: { type: "mastery_reached", threshold: 0.85 },
+        },
+      ],
+    });
+    render(
+      <NpsRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "nps" }}
+      />,
+    );
+    expect(screen.getByText(/Mastery ≥ 85%/)).toBeInTheDocument();
+  });
+
+  it("describes the after_n_calls trigger pluralised", () => {
+    const sf = makeSessionFlow({
+      stops: [
+        {
+          id: "s2",
+          kind: "nps",
+          trigger: { type: "after_n_calls", count: 3 },
+        },
+      ],
+    });
+    render(
+      <NpsRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "nps" }}
+      />,
+    );
+    expect(screen.getByText(/After 3 calls/)).toBeInTheDocument();
+  });
+});

--- a/apps/admin/tests/components/preview-renderers/design-tab-first-call-mode.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/design-tab-first-call-mode.test.tsx
@@ -39,6 +39,14 @@ beforeAll(() => {
       }),
     });
   }
+  // #1623 — DesignTab now fetches session-flow on mount for the B.13
+  // renderers. Stub a benign response so the A.1-only tests don't trip
+  // on the new side-effect. Returns the empty/null shape — the A.1
+  // renderer doesn't consume it.
+  globalThis.fetch = (() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ ok: true, sessionFlow: null })),
+    )) as typeof globalThis.fetch;
 });
 
 import { DesignTab } from "@/app/x/courses/[courseId]/_tab/DesignTab";

--- a/apps/admin/tests/components/preview-renderers/preview-lens-on-select-section.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/preview-lens-on-select-section.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * PreviewLens → onSelectSection callback wiring — #1623.
+ *
+ * Pinned behaviour:
+ *   - Bubble click whose sidetray-lens id maps to a `ComposeSectionKey`
+ *     (intake / welcome / onboarding / offboarding / stops→nps) fires
+ *     `onSelectSection` AND opens the sidetray (sidetray stays the
+ *     edit affordance; the callback is the new B.13 hook).
+ *   - Lens ids without a `ComposeSectionKey` (e.g. `moduleVisibility`)
+ *     leave the callback untouched.
+ *   - When the prop is omitted, PreviewLens behaviour is unchanged
+ *     (byte-identical sidetray-only).
+ */
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+// Stub matchMedia + ChatContext + SessionFlowEditor + CascadeInspectorTray —
+// the preview-lens.css import + heavy child trees aren't part of the
+// behaviour under test.
+
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+vi.mock("@/contexts/ChatContext", () => ({
+  useChatContext: () => ({ demoAnnotationsVisible: false }),
+}));
+
+vi.mock("@/components/session-flow/SessionFlowEditor", () => ({
+  SessionFlowEditor: () => <div data-testid="mock-editor" />,
+}));
+
+vi.mock("@/components/course-design/ModuleVisibilitySettings", () => ({
+  ModuleVisibilitySettings: () => <div data-testid="mock-mvs" />,
+}));
+
+vi.mock("@/components/cascade/CascadeInspectorTray", () => ({
+  CascadeInspectorTray: () => null,
+}));
+
+vi.mock("@/components/cascade/LayerBadge", () => ({
+  LayerBadge: () => null,
+}));
+
+import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import type { ComposeSectionKey } from "@/lib/compose";
+
+type SelectFn = (section: ComposeSectionKey | null) => void;
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function mountWithFlow(opts: {
+  flow: object;
+  onSelectSection?: SelectFn;
+}) {
+  // Mock the three fetches PreviewLens fires on mount.
+  // Session-flow + dry-run are required for paint; demo-script is best-effort.
+  const flowResp = { ok: true, sessionFlow: opts.flow, courseName: "Test" };
+  const dryResp = { ok: true, promptSummary: "[preview]" };
+  const demoResp = { ok: true, demoScript: { annotations: [] } };
+  globalThis.fetch = vi.fn((url: string) => {
+    const u = String(url);
+    if (u.endsWith("/session-flow")) {
+      return Promise.resolve(new Response(JSON.stringify(flowResp)));
+    }
+    if (u.endsWith("/dry-run-prompt")) {
+      return Promise.resolve(new Response(JSON.stringify(dryResp)));
+    }
+    if (u.endsWith("/demo-script")) {
+      return Promise.resolve(new Response(JSON.stringify(demoResp)));
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  }) as typeof globalThis.fetch;
+
+  return render(
+    <PreviewLens courseId="c1" onSelectSection={opts.onSelectSection} />,
+  );
+}
+
+function welcomeFlow() {
+  return {
+    intake: {
+      goals: { enabled: false },
+      aboutYou: { enabled: false },
+      knowledgeCheck: { enabled: false },
+      aiIntroCall: { enabled: false },
+    },
+    onboarding: { phases: [{ phase: "Intro" }] },
+    welcomeMessage: "Hello.",
+    firstCallCourseIntro: null,
+    firstCallWaitForAck: "none",
+    offboarding: { phases: [] },
+    stops: [],
+  };
+}
+
+describe("PreviewLens onSelectSection callback — #1623", () => {
+  it("fires onSelectSection('welcome') when the welcome bubble is clicked", async () => {
+    const onSelectSection = vi.fn<SelectFn>();
+    mountWithFlow({ flow: welcomeFlow(), onSelectSection });
+    // Wait for the welcome bubble to paint — it carries the "Edit Greeting"
+    // lens label as its click affordance.
+    const editButton = await waitFor(
+      () => screen.getAllByText(/Edit Greeting/).at(0),
+      { timeout: 2000 },
+    );
+    if (!editButton) throw new Error("Edit Greeting affordance not found");
+    fireEvent.click(editButton);
+    await waitFor(() => {
+      expect(onSelectSection).toHaveBeenCalledWith("welcome");
+    });
+  });
+
+  it("does NOT fire onSelectSection for moduleVisibility lens click", async () => {
+    const onSelectSection = vi.fn<SelectFn>();
+    mountWithFlow({ flow: welcomeFlow(), onSelectSection });
+    const editButton = await waitFor(
+      () => screen.getAllByText(/Edit module visibility/).at(0),
+      { timeout: 2000 },
+    );
+    if (!editButton) throw new Error("moduleVisibility affordance not found");
+    fireEvent.click(editButton);
+    // The sidetray still opens for module-visibility (existing behaviour);
+    // onSelectSection should NOT fire because moduleVisibility doesn't map
+    // to a ComposeSectionKey.
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-mvs")).toBeInTheDocument();
+    });
+    expect(onSelectSection).not.toHaveBeenCalled();
+  });
+
+  it("is a pure addition — omitting the prop is allowed and unchanged", async () => {
+    // The prop is optional; no onSelectSection passed. Behaviour must be
+    // byte-identical to pre-#1623 PreviewLens — i.e. clicking the
+    // welcome bubble still opens the SessionFlowEditor sidetray.
+    mountWithFlow({ flow: welcomeFlow() });
+    const editButton = await waitFor(
+      () => screen.getAllByText(/Edit Greeting/).at(0),
+      { timeout: 2000 },
+    );
+    if (!editButton) throw new Error("Edit Greeting affordance not found");
+    fireEvent.click(editButton);
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-editor")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #1623 · Part of EPIC #1606 (Designer Renderers v2).

**B.13 of the epic. Sequencing-unlock story** — adds the canvas click handlers that drive \`selectedKey\` on \`useDesignerSelection\`, making Group A renderers #2–#10 structurally reachable in the UI (per the TL Q1 ruling on [#1606](https://github.com/WANDERCOLTD/HF/issues/1606#issuecomment-4701378862)).

A.1 (PR #1612) proved the registry pattern via a header-banner chip. This PR extends it to PreviewLens's existing chat-bubble click handlers without disrupting them — the migration is purely additive.

## Summary

- **5 new section renderers** in \`apps/admin/components/shared/preview-renderers/\`: \`WelcomeRenderer\`, \`IntakeRenderer\`, \`OnboardingRenderer\`, \`OffboardingRenderer\`, \`NpsRenderer\`. Each reads \`SessionFlowData\` and renders a section-summary card with chips, source provenance, and empty-state handling.
- **\`PreviewLens\` accepts an optional \`onSelectSection\` prop** and fires it inside its existing \`openSidetray\` callback. New \`SIDETRAY_LENS_TO_SECTION\` map: \`intake → intake · welcome → welcome · onboarding → onboarding · offboarding → offboarding · stops → nps\`. \`moduleVisibility\` deliberately omitted (no \`ComposeSectionKey\` counterpart).
- **\`DesignTab\` fetches \`/api/courses/:id/session-flow\` once on mount** and dispatches per-section data via the extended \`resolveRendererData\` switch. Threads \`onSelectSection\` down through \`CourseDesignConsole\` → \`PreviewLens\` via the existing \`LensProps\` interface.
- **\`useDesignerSelection.setSelectedKey\` widened** to React's \`Dispatch<SetStateAction<...>>\` shape.

## Sidetray-vs-Inspector UX decision (TL risk from #1623)

Kept BOTH affordances. Sidetray stays the educator "edit this" surface unchanged. Inspector is a new parallel surface showing a section-summary card. Preserves byte-identical existing editor flow. A future story can consolidate if educator feedback warrants.

## Test plan

- [x] \`npx vitest run tests/components/preview-renderers/\` → **32/32 green**
- [x] Regression sweep \`tests/components/{designer-shell,course-design,courses}/\` → **52/52 green**
- [x] \`tsc --noEmit\` clean for touched files
- [x] \`eslint\` clean for touched files

## Verified by

- Live \`npx vitest run tests/components/preview-renderers/\` against the worktree branch: \`b13-renderers.test.tsx\` 14/14 + \`preview-lens-on-select-section.test.tsx\` 3/3 + \`first-call-mode-renderer.test.tsx\` 8/8 + \`design-tab-first-call-mode.test.tsx\` 7/7 — all 32 tests pass.
- Live regression sweep \`npx vitest run tests/components/designer-shell.test.tsx tests/components/course-design/ tests/components/courses/\`: 8 files, 52/52 pass — confirms no regression in DesignerShell contract, S4 registry, or Course Design Console nav from the \`useDesignerSelection.setSelectedKey\` widening or the \`LensProps.onSelectSection\` addition.
- Read of \`apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx:109-119\` confirms \`SIDETRAY_LENS_MAP\` is the canonical 6-entry lens id space; my \`SIDETRAY_LENS_TO_SECTION\` mirrors the 5 entries that overlap with \`ComposeSectionKey\` (\`moduleVisibility\` is intentionally omitted because it has no compose-section counterpart).
- Read of \`apps/admin/lib/compose/section.ts:34\` confirms \`intake\`, \`welcome\`, \`onboarding\`, \`offboarding\`, \`nps\` are all valid \`ComposeSectionKey\` literals (kind: "runtime" config-sourced).

## What this unlocks

Group A renderer stories #2-#10 can now ship — bubbles already trigger \`selectedKey\` for the registered sections, and \`DesignTab.resolveRendererData\` is the single dispatch site for new section data shapes.

## Out of scope

- Group A.5 #11-#12 (new composer sections)
- Group C Snapshot tab content
- Storybook fixtures (B.14)
- Sidetray ↔ Inspector consolidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)