### PR TITLE
fix(goals): #1614 — Goal.progressMetrics writer-extension on trackGoalProgress

### DIFF
--- a/apps/admin/lib/goals/append-progress-entry.ts
+++ b/apps/admin/lib/goals/append-progress-entry.ts
@@ -1,0 +1,116 @@
+/**
+ * append-progress-entry.ts (#1614 / Epic #1618)
+ *
+ * Pure helper for updating `Goal.progressMetrics` when a strategy fires
+ * a progress delta. Matches the shape already written by
+ * `lib/goals/extract-goals.ts::extractGoals` and read by the Attainment
+ * tab's goal evidence trail (`app/api/callers/[callerId]/attainment/route.ts::buildGoalTrail`)
+ * — extending the existing `evidence[]` + mention-tracking contract
+ * rather than introducing a parallel shape.
+ *
+ * Pre-#1614 the writer at `lib/goals/track-progress.ts::trackGoalProgress`
+ * incremented `Goal.progress` (the scalar) but never touched
+ * `progressMetrics`. As a result every Goal in the DB has either NULL
+ * `progressMetrics` (1,000 rows on hf-dev sandbox 2026-06-14) or
+ * extraction-time metadata frozen at create time (113 rows). The
+ * Attainment tab's `mentionCount` never advanced once the goal was
+ * created; the evidence trail rendered "First noticed N days ago"
+ * indefinitely.
+ *
+ * This helper extends the existing shape by:
+ *   - bootstrapping `progressMetrics = {}` when the goal was created
+ *     programmatically (NULL pre-fix) so per-call progress still leaves
+ *     a trail
+ *   - pushing the strategy's `evidence` string onto `evidence[]`
+ *     (newest-last; the reader reverses to show newest-first)
+ *   - capping `evidence[]` at `capN` entries (default 50)
+ *   - updating `lastMentionedCallId`, `lastMentionedAt`, `mentionCount`
+ *   - never overwriting extraction metadata (`extractionMethod`,
+ *     `confidence`, `sourceCallId`, `extractedAt`, original `evidence[]`
+ *     entries) — strategy writes APPEND, they never overwrite
+ *   - idempotent on (currentMetrics, callId): if the last call to
+ *     update was the same `callId`, the existing evidence + counter
+ *     update is replayed in place (no double-count on pipeline retry)
+ */
+
+import type { StrategyKey } from "@/lib/goals/strategies/types";
+
+/**
+ * The `Goal.progressMetrics` shape this helper produces. Matches the
+ * existing `extract-goals.ts` writer + `buildGoalTrail` reader contract.
+ * Extra fields tolerated; missing fields default sensibly.
+ */
+export interface GoalProgressMetricsShape {
+  extractionMethod?: string;
+  confidence?: number;
+  evidence?: string[];
+  sourceCallId?: string;
+  extractedAt?: string;
+  lastMentionedCallId?: string;
+  lastMentionedAt?: string;
+  mentionCount?: number;
+  /** Optional per-strategy hint so the trail can label "scored on call N by skill_ema". */
+  lastStrategy?: StrategyKey;
+}
+
+export interface NewProgressEntry {
+  callId: string;
+  /** ISO timestamp — caller passes a stable instant so tests stay deterministic. */
+  at: string;
+  /** Evidence the strategy produced for this delta. May be undefined when the strategy is a rollup with no per-call quote. */
+  evidence?: string;
+  /** Which strategy fired. */
+  sourceStrategy: StrategyKey;
+}
+
+/** Default cap on the evidence array. ~5 KB at 50 entries. */
+export const DEFAULT_EVIDENCE_CAP = 50;
+
+/**
+ * Compute the new `progressMetrics` value for a `Goal.update` call. Pure —
+ * no I/O, no side effects. Caller passes the result straight to
+ * `prisma.goal.update({ data: { progressMetrics } })`.
+ *
+ * Idempotency: if `currentMetrics.lastMentionedCallId === entry.callId`,
+ * the function REPLAYS the previous update in place (replaces the last
+ * evidence entry with the new one, leaves `mentionCount` at its
+ * previous value). Pipeline retries against the same call don't grow
+ * the array or inflate the counter.
+ */
+export function appendGoalProgressEntry(
+  currentMetrics: GoalProgressMetricsShape | null | undefined,
+  entry: NewProgressEntry,
+  capN: number = DEFAULT_EVIDENCE_CAP,
+): GoalProgressMetricsShape {
+  const base: GoalProgressMetricsShape = { ...(currentMetrics ?? {}) };
+  const existingEvidence: string[] = Array.isArray(base.evidence) ? [...base.evidence] : [];
+
+  const isReplayOfSameCall = base.lastMentionedCallId === entry.callId;
+
+  // Append (or replace on replay) the strategy's evidence string.
+  if (entry.evidence) {
+    if (isReplayOfSameCall && existingEvidence.length > 0) {
+      existingEvidence[existingEvidence.length - 1] = entry.evidence;
+    } else {
+      existingEvidence.push(entry.evidence);
+    }
+  }
+
+  // Trim to last N. Oldest entries roll off the front.
+  const trimmedEvidence =
+    existingEvidence.length > capN
+      ? existingEvidence.slice(existingEvidence.length - capN)
+      : existingEvidence;
+
+  return {
+    ...base,
+    // Always present (even when no strategy evidence string is produced).
+    evidence: trimmedEvidence,
+    lastMentionedCallId: entry.callId,
+    lastMentionedAt: entry.at,
+    mentionCount: isReplayOfSameCall
+      ? base.mentionCount ?? 1
+      : (base.mentionCount ?? 0) + 1,
+    lastStrategy: entry.sourceStrategy,
+  };
+}

--- a/apps/admin/lib/goals/track-progress.ts
+++ b/apps/admin/lib/goals/track-progress.ts
@@ -6,7 +6,11 @@
  */
 
 import { prisma } from "@/lib/prisma";
-import { GoalStatus } from "@prisma/client";
+import { GoalStatus, Prisma } from "@prisma/client";
+import {
+  appendGoalProgressEntry,
+  type GoalProgressMetricsShape,
+} from "@/lib/goals/append-progress-entry";
 import { PARAMS } from "@/lib/registry";
 import { ContractRegistry } from "@/lib/contracts/registry";
 import {
@@ -14,6 +18,7 @@ import {
   loadGoalProgressSpec,
   resolveStrategyKey,
 } from "./strategies";
+import type { StrategyKey } from "./strategies/types";
 
 export interface GoalProgressUpdate {
   goalId: string;
@@ -231,10 +236,35 @@ export async function trackGoalProgress(
       const newProgress = Math.min(1.0, goal.progress + progressUpdate.progressDelta);
       const shouldAutoComplete = newProgress >= 1.0 && !goal.isAssessmentTarget;
 
+      // #1614 — append a per-call entry to progressMetrics so the
+      // Attainment tab's goal evidence trail accumulates. Pre-fix the
+      // writer only bumped `progress` (the scalar); progressMetrics
+      // stayed frozen at extraction-time metadata (113 rows on hf-dev
+      // sandbox) or NULL (1,000 rows), so the trail never advanced.
+      // Idempotent on (goal, callId): pipeline retry against the same
+      // call replays in place, never double-counts mentionCount or
+      // duplicates evidence.
+      const nextProgressMetrics = appendGoalProgressEntry(
+        goal.progressMetrics as GoalProgressMetricsShape | null,
+        {
+          callId,
+          at: new Date().toISOString(),
+          evidence: progressUpdate.evidence,
+          // strategyKey carries the resolved StrategyKey union here — the
+          // `??` left-hand `goal.progressStrategy` is `string | null` from
+          // Prisma but the resolver branch returns a canonical
+          // StrategyKey. The cast is safe because the dispatch at
+          // `getStrategy(strategyKey)` would have thrown above on an
+          // invalid string before we reach this write site.
+          sourceStrategy: strategyKey as StrategyKey,
+        },
+      );
+
       await prisma.goal.update({
         where: { id: goal.id },
         data: {
           progress: newProgress,
+          progressMetrics: nextProgressMetrics as Prisma.InputJsonValue,
           updatedAt: new Date(),
           ...(shouldAutoComplete && {
             status: GoalStatus.COMPLETED,

--- a/apps/admin/tests/lib/goals/append-progress-entry.test.ts
+++ b/apps/admin/tests/lib/goals/append-progress-entry.test.ts
@@ -1,0 +1,172 @@
+/**
+ * append-progress-entry.test.ts (#1614)
+ *
+ * Pins the canonical `Goal.progressMetrics` writer-extension. The
+ * pre-fix gap was structural — `trackGoalProgress` incremented
+ * `Goal.progress` (the scalar) but never touched `progressMetrics`,
+ * so the Attainment tab's evidence trail rendered "First noticed N
+ * days ago" indefinitely. This file pins the new contract:
+ *
+ *   - bootstrapping NULL → `{}` when the goal was programmatically
+ *     created (1,000 rows on hf-dev sandbox pre-fix)
+ *   - appending evidence to the existing `evidence[]` shape — same
+ *     contract `extract-goals.ts` writes and `buildGoalTrail` reads
+ *   - preserving extraction metadata (extractionMethod, confidence,
+ *     sourceCallId, extractedAt, original evidence[]) on every write
+ *   - idempotent on (currentMetrics, callId) so pipeline retry
+ *     against the same call doesn't double-count
+ *   - cap on evidence[] to keep the JSON column bounded
+ */
+import { describe, it, expect } from "vitest";
+import {
+  appendGoalProgressEntry,
+  DEFAULT_EVIDENCE_CAP,
+  type GoalProgressMetricsShape,
+  type NewProgressEntry,
+} from "@/lib/goals/append-progress-entry";
+import { StrategyKey } from "@/lib/goals/strategies/types";
+
+const ENTRY_BASE: NewProgressEntry = {
+  callId: "call-A",
+  at: "2026-06-14T12:00:00.000Z",
+  evidence: "I think it depends on the situation",
+  sourceStrategy: StrategyKey.skill_ema,
+};
+
+describe("appendGoalProgressEntry", () => {
+  it("bootstraps progressMetrics from null with a single evidence entry", () => {
+    // Repairs the 1,000-row pre-fix gap (NULL progressMetrics).
+    const result = appendGoalProgressEntry(null, ENTRY_BASE);
+    expect(result.evidence).toEqual(["I think it depends on the situation"]);
+    expect(result.mentionCount).toBe(1);
+    expect(result.lastMentionedCallId).toBe("call-A");
+    expect(result.lastMentionedAt).toBe("2026-06-14T12:00:00.000Z");
+    expect(result.lastStrategy).toBe("skill_ema");
+  });
+
+  it("bootstraps progressMetrics from undefined (treats same as null)", () => {
+    const result = appendGoalProgressEntry(undefined, ENTRY_BASE);
+    expect(result.evidence).toEqual(["I think it depends on the situation"]);
+    expect(result.mentionCount).toBe(1);
+  });
+
+  it("preserves extraction metadata when extending the trail", () => {
+    // Repairs the 113-row pre-fix gap (frozen extraction metadata).
+    const extracted: GoalProgressMetricsShape = {
+      extractionMethod: "EXPLICIT",
+      confidence: 0.9,
+      evidence: ["original quote at extraction"],
+      sourceCallId: "call-original",
+      extractedAt: "2026-06-01T10:00:00.000Z",
+    };
+    const result = appendGoalProgressEntry(extracted, ENTRY_BASE);
+    expect(result.extractionMethod).toBe("EXPLICIT");
+    expect(result.confidence).toBe(0.9);
+    expect(result.sourceCallId).toBe("call-original");
+    expect(result.extractedAt).toBe("2026-06-01T10:00:00.000Z");
+    expect(result.evidence).toEqual([
+      "original quote at extraction",
+      "I think it depends on the situation",
+    ]);
+    expect(result.mentionCount).toBe(1);
+  });
+
+  it("increments mentionCount across distinct calls", () => {
+    let metrics: GoalProgressMetricsShape = appendGoalProgressEntry(null, ENTRY_BASE);
+    metrics = appendGoalProgressEntry(metrics, {
+      ...ENTRY_BASE,
+      callId: "call-B",
+      at: "2026-06-14T13:00:00.000Z",
+      evidence: "Like for example when I was younger",
+    });
+    metrics = appendGoalProgressEntry(metrics, {
+      ...ENTRY_BASE,
+      callId: "call-C",
+      at: "2026-06-14T14:00:00.000Z",
+      evidence: "So basically I think",
+    });
+    expect(metrics.mentionCount).toBe(3);
+    expect(metrics.evidence).toEqual([
+      "I think it depends on the situation",
+      "Like for example when I was younger",
+      "So basically I think",
+    ]);
+    expect(metrics.lastMentionedCallId).toBe("call-C");
+    expect(metrics.lastMentionedAt).toBe("2026-06-14T14:00:00.000Z");
+  });
+
+  it("is idempotent on pipeline retry against the same callId", () => {
+    let metrics = appendGoalProgressEntry(null, ENTRY_BASE);
+    // Pipeline retry — same callId, possibly different evidence string.
+    metrics = appendGoalProgressEntry(metrics, {
+      ...ENTRY_BASE,
+      evidence: "I think it depends on the situation (retry)",
+    });
+    metrics = appendGoalProgressEntry(metrics, {
+      ...ENTRY_BASE,
+      evidence: "I think it depends on the situation (retry 2)",
+    });
+    // mentionCount stays at 1 — three writes against the same callId.
+    expect(metrics.mentionCount).toBe(1);
+    // Latest evidence wins (replays in place).
+    expect(metrics.evidence).toEqual([
+      "I think it depends on the situation (retry 2)",
+    ]);
+  });
+
+  it("handles strategies that emit no evidence string", () => {
+    // lo_rollup typically rolls up per-LO mastery without a quote.
+    const result = appendGoalProgressEntry(null, {
+      callId: "call-D",
+      at: "2026-06-14T15:00:00.000Z",
+      sourceStrategy: StrategyKey.lo_rollup,
+      // evidence: undefined
+    });
+    expect(result.evidence).toEqual([]);
+    expect(result.mentionCount).toBe(1);
+    expect(result.lastMentionedCallId).toBe("call-D");
+    expect(result.lastStrategy).toBe("lo_rollup");
+  });
+
+  it("caps the evidence array at DEFAULT_EVIDENCE_CAP entries", () => {
+    let metrics: GoalProgressMetricsShape = {};
+    for (let i = 0; i < DEFAULT_EVIDENCE_CAP + 5; i++) {
+      metrics = appendGoalProgressEntry(metrics, {
+        callId: `call-${i}`,
+        at: `2026-06-14T${String(12 + (i % 12)).padStart(2, "0")}:00:00.000Z`,
+        evidence: `quote ${i}`,
+        sourceStrategy: StrategyKey.skill_ema,
+      });
+    }
+    expect(metrics.evidence?.length).toBe(DEFAULT_EVIDENCE_CAP);
+    // Oldest entries rolled off the front.
+    expect(metrics.evidence?.[0]).toBe("quote 5");
+    expect(metrics.evidence?.[DEFAULT_EVIDENCE_CAP - 1]).toBe(`quote ${DEFAULT_EVIDENCE_CAP + 4}`);
+    // mentionCount tracks ALL invocations, not just the cap.
+    expect(metrics.mentionCount).toBe(DEFAULT_EVIDENCE_CAP + 5);
+  });
+
+  it("respects custom cap parameter", () => {
+    let metrics: GoalProgressMetricsShape = {};
+    for (let i = 0; i < 7; i++) {
+      metrics = appendGoalProgressEntry(
+        metrics,
+        {
+          callId: `call-${i}`,
+          at: `2026-06-14T${String(12 + i).padStart(2, "0")}:00:00.000Z`,
+          evidence: `quote ${i}`,
+          sourceStrategy: StrategyKey.skill_ema,
+        },
+        3,
+      );
+    }
+    expect(metrics.evidence).toEqual(["quote 4", "quote 5", "quote 6"]);
+  });
+
+  it("does not duplicate the same evidence string when called twice with identical input", () => {
+    const first = appendGoalProgressEntry(null, ENTRY_BASE);
+    const second = appendGoalProgressEntry(first, ENTRY_BASE);
+    expect(second.evidence).toEqual(["I think it depends on the situation"]);
+    expect(second.mentionCount).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #1614. Part of Epic #1618 (Writer-completeness contract layer).

## Verified by

Live SQL on hf-dev sandbox 2026-06-14 (the chain audit):

| `Goal.progressMetrics` shape | rows |
|---|---|
| NULL (programmatically-created — never extracted) | **1,000** |
| Non-NULL but `.evidence` array frozen at extraction time | 113 |
| Non-NULL with per-call accumulation | **0** |

Code-walk confirms the write-side gap: `lib/goals/extract-goals.ts` writes `progressMetrics` on create + on caller-re-mention. `lib/goals/track-progress.ts::trackGoalProgress` (ADAPT sub-op 4) has zero references to `progressMetrics` — it only updates the scalar `Goal.progress`. So the trail never advances after extraction.

## Summary

- New pure helper `apps/admin/lib/goals/append-progress-entry.ts` — extends the **existing** `extract-goals.ts` shape (no parallel format introduced, no reader change):
  - bootstraps `null` → `{}` (closes the 1,000-row gap)
  - appends to existing `evidence[]` (closes the 113-row gap)
  - preserves extraction metadata (`extractionMethod`, `confidence`, `sourceCallId`, `extractedAt`, original evidence entries) on every write
  - idempotent on `(currentMetrics, callId)` — pipeline retry replays in place
  - cap on evidence array (default 50)
  - records `lastStrategy` for educator-facing trail labels
- Wired into `trackGoalProgress` as a single new call inside the existing `prisma.goal.update` block. No restructuring.
- 9 vitests pinning the contract.

## Test plan

- [x] `npx vitest run tests/lib/goals/` → 14/14 green locally (9 new + 5 sibling)
- [x] tsc clean on touched files
- [ ] Smoke on hf-dev after `/vm-cp`:
  1. Run a sim call on Freddy Starr (`f17d8616-3c31-4814-8de1-626fb42f16f6`) — IELTS PLS USE NEW V1.0, 14 prior calls, 17 active goals
  2. After pipeline completes, `SELECT id, "progressMetrics"->>'mentionCount', "progressMetrics"->>'lastMentionedCallId' FROM "Goal" WHERE "callerId" = '…' AND status = 'ACTIVE';`
  3. Confirm `mentionCount` advanced (was 1 / null pre-fix) and `lastMentionedCallId` = the just-completed call
  4. Visit `/x/callers/<freddy>?tab=attainment` — the goal evidence trail should now show "Last mentioned: just now"
  5. Confirm the AGGREGATE/ADAPT empty-result alarm (PR #1625) shows the `goal` table as non-silent for new calls

## Reader contract preserved

`app/api/callers/[callerId]/attainment/route.ts::buildGoalTrail` reads:

```ts
{ evidence: string[], extractionMethod, confidence, sourceCallId,
  extractedAt, lastMentionedAt, lastMentionedCallId, mentionCount }
```

This writer extends that shape exactly. **Zero reader-side change**. The Attainment tab automatically starts showing per-call trail growth.

## Pairs with PR #1625

Once both merge, the empty-result detector's `ADAPT × goal` counter goes from "silent" (the #1614 fingerprint) to populated. Sprint 5's writer-completeness theme: alarm layer (#1625) + the three known gaps (#1608 shipped via PR #1613 / commit `5d527986`; #1614 this PR; #1609 next).

## What this does NOT do

- Backfill historic 1,000 NULL or 113 frozen rows. Fix-forward only. New writes from merge-time will accumulate.
- Reader/UI change. Existing trail rendering works against the extended shape.
- Per-strategy custom evidence shape — `lastStrategy` is a single string identifying which writer fired. A richer per-event timeline can come later if educators ask.

Needs `/vm-cp` then a smoke pipeline run on a real caller to verify the trail advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)