### PR TITLE
fix(pipeline): #1609 Slice 2 — wire updateTargets into ADAPT executor as sub-op 8

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -73,6 +73,7 @@ import { getTranscriptLimit, getSystemSpecs, getSpecsByOutputType, getPlaybookSp
 import { writeCallScore, MEASUREMENT_SENTINEL_SPEC_IDS } from "@/lib/measurement/write-call-score";
 import { normalizeScoreAgentEvidence } from "@/lib/pipeline/normalize-score-agent-evidence";
 import { logStageWriteCounts } from "@/lib/pipeline/write-count-logger";
+import { updateTargets } from "@/lib/ops/update-targets";
 import { buildParameterSpecMap, type ParameterWithSpec } from "@/lib/measurement/parameter-spec-map";
 import { buildBatchedMeasurePrompt } from "@/lib/measurement/build-batched-measure-prompt";
 import type { SpecConfig } from "@/lib/types/json-fields";
@@ -3821,14 +3822,66 @@ const stageExecutors: Record<string, StageExecutor> = {
       }
     }
 
+    // 8. Reward-loop target update (#1609 / Epic #1618) — closes the
+    //    per-call reward-feedback loop. Reads this call's RewardScore
+    //    row (written by REWARD stage 40) + ParameterDiff array,
+    //    computes BehaviorTarget adjustments via TARGET_LEARN spec
+    //    rules, writes new BehaviorTarget versions, AND stamps
+    //    `RewardScore.targetUpdatesApplied` with the applied updates
+    //    (or `[]` when no updates were needed). Pre-#1609 this
+    //    function was admin-ops/CLI-only — 73/73 RewardScore rows on
+    //    hf-dev sandbox 2026-06-14 had `targetUpdatesApplied = NULL`,
+    //    so the Adaptations tab's "Why" timeline (SP5-C) was always
+    //    empty. Slice 2 of #1609 wires it into the ADAPT executor as
+    //    its 8th sub-op (sequential AFTER the failure-adaptation
+    //    signal — ordering invariant: REWARD stage 40 must have
+    //    written the RewardScore before ADAPT stage 50 reads it).
+    //
+    //    Scoped to this call only via `{callId: ctx.callId, limit: 1}`
+    //    — never touches sibling RewardScore rows even if they exist
+    //    with NULL targetUpdatesApplied (those are the Slice 3
+    //    backfill's job, gated behind operator opt-in).
+    //
+    //    Non-blocking — errors are logged but never abort the rest of
+    //    the pipeline. Matches the pattern of every other ADAPT
+    //    sub-op (the loop should not fall apart because the reward
+    //    closer hit a Prisma timeout on one call).
+    let rewardLoopUpdates = 0;
+    let rewardLoopProcessed = 0;
+    try {
+      const targetsLoop = await updateTargets({
+        callId: ctx.callId,
+        limit: 1,
+        verbose: false,
+        plan: false,
+      });
+      rewardLoopProcessed = targetsLoop.rewardsProcessed;
+      rewardLoopUpdates = targetsLoop.updates.reduce((sum, u) => sum + u.updateCount, 0);
+      if (targetsLoop.errors.length > 0) {
+        ctx.log.error("Reward-loop target update failed (non-blocking)", {
+          errors: targetsLoop.errors,
+        });
+      } else {
+        ctx.log.info("Reward-loop targets updated", {
+          rewardsProcessed: rewardLoopProcessed,
+          updateCount: rewardLoopUpdates,
+        });
+      }
+    } catch (err: any) {
+      ctx.log.error("Reward-loop target update threw (non-blocking)", {
+        error: err?.message ?? String(err),
+      });
+    }
+
     ctx.log.info(`ADAPT parallel ops completed in ${Date.now() - startTime}ms`);
 
-    // #1622 — emit per-stage write counts for the seven ADAPT sub-ops.
+    // #1622 — emit per-stage write counts for the eight ADAPT sub-ops.
     // The Goal counters here are the #1614 fingerprint surface (goals
-    // get created/updated/progress-bumped but the .progress timeline
-    // append on `progressMetrics` is the silent gap the alarm will
-    // catch once #1614 ships). The callTarget/callerTarget counts
-    // surface #1609 once Slice 2 lands an `updateTargets` sub-op-8.
+    // get created/updated/progress-bumped + the .progress timeline
+    // append on `progressMetrics` from #1614). The callTarget /
+    // callerTarget counts surface #1609 — once the reward loop is wired
+    // (this PR's sub-op 8 above), the rewardLoopUpdates counter is the
+    // direct silent-writer signal for the Adaptations "Why" timeline.
     logStageWriteCounts({
       stage: "ADAPT",
       callId: ctx.callId,
@@ -3836,7 +3889,7 @@ const stageExecutors: Record<string, StageExecutor> = {
       playbookId: ctx.call.playbookId ?? undefined,
       writeCounts: {
         callTarget: adaptResult.targetsCreated,
-        callerTarget: ruleBasedResult.targetsCreated + ruleBasedResult.targetsUpdated,
+        callerTarget: ruleBasedResult.targetsCreated + ruleBasedResult.targetsUpdated + rewardLoopUpdates,
         goal: goalExtractionResult.goalsCreated + goalExtractionResult.goalsUpdated + goalResult.updated,
         failureLog: failureSignal ? 1 : 0,
       },
@@ -3856,6 +3909,13 @@ const stageExecutors: Record<string, StageExecutor> = {
       completionSignalsDetected: completionSignals.signalsDetected,
       assessmentAdaptations: assessmentAdapt.adjustments,
       failureSignal,
+      // #1609 — reward-loop closure counters surface in the response
+      // payload so the operator-facing pipeline diagnostic at /x/logs
+      // can render the per-call "targets nudged by reward feedback"
+      // line WITHOUT querying RewardScore.targetUpdatesApplied
+      // separately.
+      rewardLoopProcessed,
+      rewardLoopUpdates,
     };
   },
 

--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -3664,7 +3664,7 @@ const stageExecutors: Record<string, StageExecutor> = {
       playbookId: ctx.call.playbookId ?? undefined,
       writeCounts: {
         personalityObservation: personalityResult.observationCreated ? 1 : 0,
-        callScore: primaryEvidence.created ?? 0,
+        callScore: primaryEvidence.created ? 1 : 0,
         callerModuleProgress: primaryMastery.statusFlipped ? 1 : 0,
         // CallerTarget + lo_mastery counts aren't returned by the inner runners
         // today — leave unset so detector reads "not measured here" instead

--- a/apps/admin/eslint-rules/no-ops-import-from-api.mjs
+++ b/apps/admin/eslint-rules/no-ops-import-from-api.mjs
@@ -27,7 +27,12 @@ const BYPASS_FILES = new Set([
   "compute-reward",
   "knowledge-ingest",
   "transcripts-process",
-  "update-targets",
+  // "update-targets" REMOVED 2026-06-14 (#1609 Slice 2) — the file now
+  // imports the shared `prisma` singleton from `@/lib/prisma`; the CLI
+  // entry-point uses a local `cliPrisma` instance for its own
+  // `$disconnect()` lifecycle. In-process callers (the ADAPT executor
+  // at `app/api/calls/[callId]/pipeline/route.ts::stageExecutors.ADAPT`
+  // sub-op 8) now honour the singleton's tenant-context middleware.
 ]);
 
 // Paths allowed to import bypass files (the only legitimate ops surface).

--- a/apps/admin/lib/ops/update-targets.ts
+++ b/apps/admin/lib/ops/update-targets.ts
@@ -24,10 +24,20 @@
  * This is the third step in the post-call reward loop.
  */
 
-import { PrismaClient, BehaviorTargetScope, BehaviorTargetSource, Prisma } from "@prisma/client";
+import { BehaviorTargetScope, BehaviorTargetSource, Prisma, PrismaClient } from "@prisma/client";
 import type { SpecConfig, ParameterDiff } from "@/lib/types/json-fields";
 
-const prisma = new PrismaClient();
+// #1609 — use the shared Prisma singleton from `@/lib/prisma` so the
+// per-call ADAPT executor's invocation of this module carries the
+// tenant-context injection wired in by #1395 RLS. Pre-fix this file
+// instantiated `new PrismaClient()` locally, which is why the
+// `hf-ops/no-ops-import-from-api` ESLint rule blocked API-route imports
+// of this module. The CLI self-invoke at the bottom of this file
+// still instantiates its own client because it runs outside the
+// Next.js singleton lifecycle.
+import { prisma as appPrisma } from "@/lib/prisma";
+
+const prisma = appPrisma;
 
 // Config loaded from TARGET_LEARN spec (with defaults)
 interface TargetLearnConfig {
@@ -415,7 +425,10 @@ export async function updateTargets(
   return result;
 }
 
-// CLI entry point
+// CLI entry point — runs outside the Next.js process so it needs its
+// own PrismaClient lifecycle. Disconnecting the shared `prisma`
+// singleton in the in-process path would tear down sibling routes;
+// the CLI's standalone client is fine to disconnect after the run.
 if (require.main === module) {
   const args = process.argv.slice(2);
   const options: UpdateTargetsOptions = {
@@ -426,6 +439,7 @@ if (require.main === module) {
     learningRate: parseFloat(args.find(a => a.startsWith("--rate="))?.split("=")[1] || "0.1"),
   };
 
+  const cliPrisma = new PrismaClient();
   updateTargets(options)
     .then(result => {
       console.log(JSON.stringify(result, null, 2));
@@ -435,5 +449,5 @@ if (require.main === module) {
       console.error("Fatal error:", err);
       process.exit(1);
     })
-    .finally(() => prisma.$disconnect());
+    .finally(() => cliPrisma.$disconnect());
 }

--- a/apps/admin/scripts/audit-reward-target-updates.sql
+++ b/apps/admin/scripts/audit-reward-target-updates.sql
@@ -1,0 +1,34 @@
+-- Pre/post-deploy audit for #1609 (Reward-loop close).
+--
+-- Pre-#1609 baseline (hf-dev sandbox 2026-06-14):
+--   targetUpdatesApplied IS NULL  : 73 rows  (ALL of them — writer never called)
+--   targetUpdatesApplied = []     :  0 rows
+--   targetUpdatesApplied populated:  0 rows
+--
+-- Post-#1609 expectation:
+--   NULL count stops growing (historical 73 rows remain unless Slice 3 backfill runs)
+--   Empty-array [] grows steadily — every new call where no parameter
+--     diffs cross the tolerance threshold leaves a `[]` sentinel
+--   Populated grows steadily when learners drift from their targets
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/audit-reward-target-updates.sql
+--
+-- The (a) bucket should plateau at its pre-deploy count after a few
+-- production calls land. The (b) + (c) buckets should grow. If (a)
+-- keeps growing for new calls after the deploy, the ADAPT executor's
+-- sub-op 8 wire-up is failing silently — check PR #1625's silent-writer
+-- detector at /x/system/pipeline-health for the ADAPT.callerTarget pair.
+
+SELECT
+  CASE
+    WHEN "targetUpdatesApplied" IS NULL THEN '(a) NULL — writer never fired'
+    WHEN "targetUpdatesApplied"::text = '[]' THEN '(b) [] sentinel — writer fired, no updates needed'
+    ELSE '(c) populated — writer fired with target adjustments'
+  END AS state,
+  COUNT(*) AS rows,
+  MIN("scoredAt"::date) AS earliest_scored,
+  MAX("scoredAt"::date) AS latest_scored
+FROM "RewardScore"
+GROUP BY 1
+ORDER BY 1;


### PR DESCRIPTION
Closes #1609 (Slice 2). Part of Epic #1618 (Writer-completeness contract layer).

## Verified by

Live SQL on hf-dev sandbox 2026-06-14:

| `RewardScore.targetUpdatesApplied` | rows |
|---|---|
| NULL — writer never fired | **73** |
| `[]` sentinel — writer fired, no updates needed | 0 |
| populated — writer fired with target adjustments | 0 |

Code-walk confirms `updateTargets` had exactly 2 production call sites (admin ops endpoint + CLI self-invoke). Zero per-call pipeline invocations since commit #9 (early bootstrap).

## Summary

3 commits:

1. **ADAPT executor sub-op 8** wire-up in `app/api/calls/[callId]/pipeline/route.ts::stageExecutors.ADAPT` — calls `updateTargets({callId, limit: 1})` AFTER the failure-adaptation signal. Non-blocking (try/catch + `ctx.log.error`); counter bubbles into the response payload AND PR #1625's silent-writer detector.
2. **Type fix** — `primaryEvidence.created` is `boolean`, not `number | undefined`. Ternary mirrors the sibling `personalityObservation` pattern. (This was a latent tsc error from PR #1625 my wider check exposed.)
3. **`lib/ops/update-targets.ts` refactor** to use the shared `prisma` singleton — required so the new pipeline-route import respects the `hf-ops/no-ops-import-from-api` rule's tenant-context discipline (#1395 RLS). CLI entry-point keeps its own local `cliPrisma` instance for `$disconnect()` lifecycle. Rule's `BYPASS_FILES` set updated to drop `"update-targets"` with an inline comment explaining the refactor; smoke test for the rule still passes.

## Stage-ordering invariant satisfied

Per `docs/PIPELINE.md`: `REWARD (40) → ADAPT (50)`. The new sub-op 8 runs at the end of ADAPT's executor, so it reads a `RewardScore` row that was written upstream this same call. `updateTargets({callId})` scopes findMany to this call only — never touches sibling NULL rows (those are Slice 3 backfill territory).

## NULL → `[]` sentinel preserved

`lib/ops/update-targets.ts:392-398` already writes `[]` when no updates apply. This wire-up doesn't change the semantics; it just ensures the writer fires.

## Test plan

- [x] tsc clean on touched files (1 pre-existing unrelated error in `route.ts:1669` + 3 at `:3088-3090` predate this branch)
- [x] eslint clean — `hf-ops/no-ops-import-from-api` no longer blocks the import after the refactor
- [x] `npx vitest run tests/eslint-rules/no-ops-import-from-api.test.ts` → 1/1 green (rule smoke test)
- [ ] Smoke on hf-dev after `/vm-cp`:
  1. Run a sim call on Freddy Starr (`f17d8616-3c31-4814-8de1-626fb42f16f6`)
  2. Pipeline completes; visit `/x/callers/<freddy>?tab=adaptations`
  3. The "Why" timeline should show entries for the just-completed call (was always empty pre-fix)
  4. SQL check: `SELECT "targetUpdatesApplied" FROM "RewardScore" WHERE "callId" = '<callId>';` → array, not NULL
  5. Confirm PR #1625's `/x/system/pipeline-health` shows ADAPT.callerTarget non-silent for new calls

## What this does NOT do

- **Slice 3 backfill** of historic 73 NULL rows — BLOCKED on this PR live for ≥48h with the NULL→`[]` sentinel writing on new calls
- **Vitest of the in-process call site** — `updateTargets` transitively touches `analysisSpec`, `behaviorTarget`, `parameter`, `specConfig`, `contentSpec`, `callerIdentities`, etc. Mocking all is extremely heavy for a single-line wire-up. Smoke + the empty-result alarm are the verification path. If the wire-up regresses, PR #1625's detector fires within 24h.

## Pairs with PR #1625 + PR #1627

Sprint 5 writer-completeness theme: alarms (#1622 / PR #1625 ✅) + Goal trail (#1614 / PR #1627 ✅) + this PR. After all three land, the empty-result detector should report ALL ADAPT writer counters as non-silent for new pipeline runs.

Needs `/vm-cp` then smoke per the test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)