### PR TITLE
chore(curriculum): #1615 Phase 1 — delete dead tp_status writers + close #1633 runtime ADAPT crash

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -45,7 +45,7 @@ import { extractArtifacts } from "@/lib/artifacts/extract-artifacts";
 import { deliverArtifacts } from "@/lib/artifacts/deliver-artifacts";
 import { extractActions } from "@/lib/actions/extract-actions";
 import { config as appConfig } from "@/lib/config";
-import { updateCurriculumProgress, getCurriculumProgress, completeModule, updateTpMasteryBatch } from "@/lib/curriculum/track-progress";
+import { updateCurriculumProgress, getCurriculumProgress, completeModule } from "@/lib/curriculum/track-progress";
 // initializeLessonPlanSession removed — scheduler replaces session tracking
 import { resolvePlaybookId } from "@/lib/enrollment/resolve-playbook";
 import { resolveCurriculumIdForPlaybook, resolveModuleByLogicalId } from "@/lib/curriculum/resolve-module";
@@ -3024,146 +3024,6 @@ async function trackOnboardingAfterCall(
   return true;
 }
 
-/**
- * Update per-TP mastery scores after a call.
- * Resolves LO assessment outcomes → individual TP mastery via FK chain.
- * Session advancement removed — scheduler owns pacing.
- */
-async function updateTpMasteryAfterCall(
-  callerId: string,
-  log: PipelineLogger,
-  learningAssessment?: {
-    specSlug: string;
-    moduleId: string;
-    overallMastery: number;
-    outcomes?: Record<string, number>;
-    masteryThreshold: number;
-  } | null,
-): Promise<boolean> {
-  if (!learningAssessment?.outcomes) return false;
-
-  const caller = await prisma.caller.findUnique({
-    where: { id: callerId },
-    select: { domainId: true },
-  });
-  if (!caller?.domainId) return false;
-
-  // Try playbook curriculum first (direct link)
-  const enrolledPbForAssess = await resolvePlaybookId(callerId);
-  if (enrolledPbForAssess) {
-    // #1034 — PlaybookCurriculum-first read with deprecated-column fallback.
-    const pbcLink = await prisma.playbookCurriculum.findFirst({
-      where: { playbookId: enrolledPbForAssess },
-      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
-      select: { curriculum: { select: { slug: true } } },
-    });
-    const pbCurr = pbcLink?.curriculum;
-    if (pbCurr) {
-      // #1008 (Finding C) — AI-returned masteryThreshold is authoritative when present;
-      // fall back to CURRICULUM_PROGRESS_V1 contract, hard literal only if registry empty.
-      // NOTE: threshold itself is not consumed by this branch (per-LO scores are
-      // persisted raw); the comparison happens at LO read time via the same cascade.
-      const assessedLoRefs = Object.keys(learningAssessment.outcomes);
-      const loRows = await prisma.learningObjective.findMany({
-        where: {
-          ref: { in: assessedLoRefs },
-          module: { curriculum: { slug: pbCurr.slug }, isActive: true },
-        },
-        select: { id: true, ref: true },
-      });
-      if (loRows.length > 0) {
-        // #1177 Slice 3 (partial — pipeline route hardcoded shape) — rekey to
-        // `playbook:{playbookId}:lo:{loRef}`. Variant Playbooks of the same
-        // Curriculum no longer collide on this key shape: each variant has
-        // its own playbookId, so per-LO assessment scores stay isolated.
-        // The 20260606152558 migration purges all legacy `curriculum:*:lo:*`
-        // rows in the same PR. (The lo_mastery:* contract-driven shape in
-        // track-progress.ts is its own rekey, deferred to a focused Slice 3
-        // ticket — see docs/CONTRACTS-PLAYBOOK-CURRICULUM.md §6.)
-        for (const lo of loRows) {
-          const score = learningAssessment.outcomes[lo.ref];
-          if (score !== undefined) {
-            const key = `playbook:${enrolledPbForAssess}:lo:${lo.ref}`;
-            await prisma.callerAttribute.upsert({
-              where: { callerId_key: { callerId, key } },
-              update: { value: String(score), updatedAt: new Date() },
-              create: { callerId, key, value: String(score) },
-            });
-          }
-        }
-        return true;
-      }
-    }
-  }
-
-  // Fallback: domain-wide Subject curriculum (legacy)
-  const subjectDomains = await prisma.subjectDomain.findMany({
-    where: { domainId: caller.domainId },
-    include: {
-      subject: {
-        include: {
-          curricula: {
-            orderBy: { updatedAt: "desc" },
-            take: 1,
-            select: { slug: true },
-          },
-        },
-      },
-    },
-  });
-
-  for (const sd of subjectDomains) {
-    const curriculum = sd.subject.curricula[0];
-    if (!curriculum) continue;
-
-    // #1008 (Finding C) — AI-returned masteryThreshold is authoritative when present;
-    // fall back to CURRICULUM_PROGRESS_V1 contract, hard literal only if registry empty.
-    const threshold =
-      learningAssessment.masteryThreshold ||
-      (await ContractRegistry.getThresholds('CURRICULUM_PROGRESS_V1'))?.masteryComplete ||
-      0.7;
-
-    // Resolve LO ref strings → IDs, then query assertions by FK
-    const assessedLoRefs = Object.keys(learningAssessment.outcomes);
-    const loRows = await prisma.learningObjective.findMany({
-      where: {
-        ref: { in: assessedLoRefs },
-        module: { curriculum: { slug: curriculum.slug }, isActive: true },
-      },
-      select: { id: true, ref: true },
-    });
-    const assessedLoIds = loRows.map((lo) => lo.id);
-
-    const assessedTps = assessedLoIds.length > 0
-      ? await prisma.contentAssertion.findMany({
-          where: { learningObjectiveId: { in: assessedLoIds } },
-          select: { id: true, learningObjectiveId: true },
-        })
-      : [];
-
-    const loIdToRef = new Map(loRows.map((lo) => [lo.id, lo.ref]));
-
-    const updates: Record<string, { mastery: number; status: "not_started" | "in_progress" | "mastered" }> = {};
-    for (const tp of assessedTps) {
-      const loRef = tp.learningObjectiveId ? loIdToRef.get(tp.learningObjectiveId) : null;
-      const loScore = loRef ? learningAssessment.outcomes[loRef] ?? 0 : 0;
-      updates[tp.id] = {
-        mastery: loScore,
-        status: loScore >= threshold ? "mastered" : loScore > 0 ? "in_progress" : "not_started",
-      };
-    }
-
-    if (Object.keys(updates).length > 0) {
-      await updateTpMasteryBatch(callerId, curriculum.slug, updates);
-      log.info(`Updated ${Object.keys(updates).length} TP mastery scores`);
-      return true;
-    }
-
-    break;
-  }
-
-  return false;
-}
 
 // =====================================================
 // SPEC-DRIVEN PIPELINE EXECUTION
@@ -3300,8 +3160,17 @@ const stageExecutors: Record<string, StageExecutor> = {
     }
     const deltaResult = await computeAdapt(ctx.callId, ctx.callerId, ctx.log);
 
-    // Run all 5 non-blocking post-analysis ops in parallel
-    const [currSettled, onboardSettled, lessonSettled, artifactSettled, actionSettled] =
+    // Run all 4 non-blocking post-analysis ops in parallel.
+    // #1615 — TP-mastery sub-op (was sub-op 3) removed; the function
+    // `updateTpMasteryAfterCall` was dead in practice — both branches
+    // produced 0 rows DB-wide (Branch A's `playbook:*:lo:*` write +
+    // Branch B's `tp_status:*`/`tp_mastery:*` write). The active per-LO
+    // mastery store is `curriculum:{specSlug}:lo_mastery:{moduleSlug}:{loRef}`
+    // written by `updateCurriculumProgress` in the AGGREGATE stage above.
+    // Removing this op also closes the runtime crash filed as #1633
+    // (the dead Branch A's `CallerAttribute.upsert` was missing the
+    // `caller` relation).
+    const [currSettled, onboardSettled, artifactSettled, actionSettled] =
       await Promise.allSettled([
         // 1. Curriculum progress + CurriculumModule FK write
         // #1081 Slice 1 — `callerResult.playbookUsed` threaded through so the
@@ -3340,9 +3209,7 @@ const stageExecutors: Record<string, StageExecutor> = {
           }),
         // 2. Onboarding completion
         trackOnboardingAfterCall(ctx.callerId, ctx.callId, ctx.log),
-        // 3. TP mastery update (scheduler reads these next call)
-        updateTpMasteryAfterCall(ctx.callerId, ctx.log, callerResult.learningAssessment),
-        // 4. Artifact extraction + delivery
+        // 3. Artifact extraction + delivery
         appConfig.artifacts.enabled
           ? extractArtifacts(ctx.call, ctx.callerId, ctx.engine, ctx.log)
               .then(async (r) => {
@@ -3353,7 +3220,7 @@ const stageExecutors: Record<string, StageExecutor> = {
                 return r;
               })
           : Promise.resolve({ artifactsCreated: 0, artifactsSkipped: 0, errors: [] as string[] }),
-        // 5. Action extraction
+        // 4. Action extraction
         appConfig.actions.enabled
           ? extractActions(ctx.call, ctx.callerId, ctx.engine, ctx.log)
           : Promise.resolve({ actionsCreated: 0, actionsSkipped: 0, errors: [] as string[] }),
@@ -3369,11 +3236,10 @@ const stageExecutors: Record<string, StageExecutor> = {
     if (onboardSettled.status === "rejected") {
       ctx.log.warn(`Onboarding tracking failed (non-blocking): ${onboardSettled.reason?.message || String(onboardSettled.reason)}`);
     }
-
-    const sessionAdvanced = lessonSettled.status === "fulfilled" ? lessonSettled.value : false;
-    if (lessonSettled.status === "rejected") {
-      ctx.log.warn(`Lesson plan advancement failed (non-blocking): ${lessonSettled.reason?.message || String(lessonSettled.reason)}`);
-    }
+    // #1615 — sessionAdvanced was derived from the removed TP-mastery
+    // op's return; it was logged only on rejection and never consumed
+    // downstream. Dropped along with `lessonSettled`.
+    const sessionAdvanced = false;
 
     const artifactsExtracted = artifactSettled.status === "fulfilled" ? artifactSettled.value.artifactsCreated : 0;
     if (artifactSettled.status === "rejected") {

--- a/apps/admin/lib/curriculum/track-progress.ts
+++ b/apps/admin/lib/curriculum/track-progress.ts
@@ -1195,70 +1195,17 @@ export async function getTpProgressSummaryBatch(
   return result;
 }
 
-/**
- * Batch-write TP mastery for multiple assertions.
- * Used by pipeline after continuous-mode assessment.
- */
-export async function updateTpMasteryBatch(
-  callerId: string,
-  specSlug: string,
-  updates: Record<string, TpProgress>,
-): Promise<void> {
-  const keyPattern = await ContractRegistry.getKeyPattern('CURRICULUM_PROGRESS_V1');
-  if (!keyPattern) throw new Error('CURRICULUM_PROGRESS_V1 contract not loaded');
-
-  const prefix = keyPattern
-    .replace('{specSlug}', specSlug)
-    .replace(':{key}', ':');
-
-  const writes: Promise<unknown>[] = [];
-
-  for (const [assertionId, progress] of Object.entries(updates)) {
-    const statusKey = `${prefix}tp_status:${assertionId}`;
-    const masteryKey = `${prefix}tp_mastery:${assertionId}`;
-
-    writes.push(
-      prisma.callerAttribute.upsert({
-        where: { callerId_key_scope: { callerId, key: statusKey, scope: 'CURRICULUM' } },
-        create: { callerId, key: statusKey, scope: 'CURRICULUM', valueType: 'STRING', stringValue: progress.status },
-        update: { stringValue: progress.status },
-      }),
-      prisma.callerAttribute.upsert({
-        where: { callerId_key_scope: { callerId, key: masteryKey, scope: 'CURRICULUM' } },
-        create: { callerId, key: masteryKey, scope: 'CURRICULUM', valueType: 'NUMBER', numberValue: progress.mastery },
-        update: { numberValue: progress.mastery },
-      }),
-    );
-  }
-
-  await Promise.all(writes);
-}
-
-/**
- * Initialize TP tracking for all assertions in a continuous-mode curriculum.
- * Creates tp_status = "not_started" for each assertion that doesn't already have a status.
- * Called once when a learner first enters a continuous-mode course.
- */
-export async function initializeTpTracking(
-  callerId: string,
-  specSlug: string,
-  assertionIds: string[],
-): Promise<void> {
-  if (assertionIds.length === 0) return;
-
-  const existing = await getTpProgressBatch(callerId, specSlug, assertionIds);
-  const toInit: Record<string, TpProgress> = {};
-
-  for (const id of assertionIds) {
-    if (!existing[id] || existing[id].status === "not_started") {
-      toInit[id] = { mastery: 0, status: "not_started" };
-    }
-  }
-
-  if (Object.keys(toInit).length > 0) {
-    await updateTpMasteryBatch(callerId, specSlug, toInit);
-  }
-}
+// #1615 Phase 1 — `updateTpMasteryBatch` and `initializeTpTracking` deleted.
+// `updateTpMasteryBatch` was reached only by the legacy fallback branch of
+// `updateTpMasteryAfterCall` (now also removed in `app/api/calls/[callId]/pipeline/route.ts`),
+// which produced 0 rows DB-wide across the entire system. `initializeTpTracking`
+// had zero callers anywhere in the codebase. The readers
+// (`getTpProgressBatch`, `getTpProgressSummary`, `getTpProgressSummaryBatch`)
+// remain temporarily for backwards compatibility with their external call
+// sites; they now always return the default-empty shape. Phase 2 (separate
+// PR) will refactor those reader sites and delete the readers + the
+// `TpProgress` type along with the continuous-mode working-set-selector
+// branch that consumes them.
 
 export async function storeTrustWeightedProgress(
   callerId: string,

--- a/apps/admin/lib/pipeline/write-count-logger.ts
+++ b/apps/admin/lib/pipeline/write-count-logger.ts
@@ -48,8 +48,6 @@ export interface PipelineStageWriteCounts {
   callerTarget?: number;
   /** AGGREGATE, monotonic per-LO mastery ratchet (curriculum:{spec}:lo_mastery:{module}:{lo}) */
   callerAttribute_lo_mastery?: number;
-  /** AGGREGATE / enrollment, per-teaching-point continuous-mode status (curriculum:{spec}:tp_status:{assertion}) */
-  callerAttribute_tp_status?: number;
   /** AGGREGATE, per-module rolled-up mastery (structured courses only) */
   callerModuleProgress?: number;
   /** REWARD, overall call quality */


### PR DESCRIPTION
Closes #1615 (Phase 1). Closes #1633 (runtime CallerAttribute upsert crash) as a side effect. Phase 2 follow-up filed as #1636.

## Net: 218 lines deleted, 29 added

| File | Change |
|---|---|
| \`app/api/calls/[callId]/pipeline/route.ts\` | Delete \`updateTpMasteryAfterCall\` (140 lines) + its sub-op in the AGGREGATE \`Promise.allSettled\` + the unused destructure / log block |
| \`lib/curriculum/track-progress.ts\` | Delete \`updateTpMasteryBatch\` (34 lines) + \`initializeTpTracking\` (20 lines) |
| \`lib/pipeline/write-count-logger.ts\` | Remove \`callerAttribute_tp_status\` field from \`PipelineStageWriteCounts\` |

## Verified by

Live smoke 2026-06-14 on Freddy Starr \`f17d8616-3c31-4814-8de1-626fb42f16f6\` (call \`164239c2-6dfe-4263-a832-3dd2ab66696d\`) confirmed the runtime crash pre-fix:

> Stage ADAPT failed (non-blocking): Invalid \`prisma.callerAttribute.upsert()\` invocation in \`.next/dev/server/chunks/lib_e90f78a4._.js:13171:149\`. Argument \`caller\` is missing.

This was hidden by \`Promise.allSettled\` so didn't break the response, but it consistently aborted ADAPT before reaching #1609's reward-loop sub-op 8. The #1622 silent-writer alarm (just shipped) flagged it via the missing ADAPT write-count log row.

DB confirms zero rows DB-wide for the namespace:

\`\`\`
key shape                       rows
─────────────────────────────────────
curriculum:*:tp_status:*          0
curriculum:*:tp_mastery:*         0
playbook:*:lo:*                   0   (Branch A's write — also dead)
curriculum:*:lo_mastery:*       157   (the actively-used store)
\`\`\`

The active path (\`updateCurriculumProgress\` writing \`curriculum:{specSlug}:lo_mastery:{moduleSlug}:{loRef}\`) is untouched by this PR and continues to handle the per-LO mastery store for all modern courses.

## Test plan

- [x] tsc clean on touched files (1 pre-existing \`route.ts:1669\` error unrelated)
- [x] vitest: \`tests/lib/pipeline/\` 16/16 green (\`write-count-logger\` + \`detect-silent-writers\`)
- [ ] Smoke on hf-dev after \`/vm-cp\`:
  1. Re-run pipeline on Freddy Starr's most-recent call with \`force=true\`
  2. Confirm no \`ADAPT failed\` error in the response logs
  3. Confirm the \`pipeline.stage.write_counts:adapt\` AppLog row appears (was missing pre-fix)
  4. Confirm #1609's reward-loop counter (\`rewardLoopProcessed\`, \`rewardLoopUpdates\`) populates in the response payload — assuming the upstream #1632 REWARD bail doesn't block first

## What Phase 1 does NOT do

- Refactor the 5 reader sites that dynamically-import \`getTpProgressSummary*\` / \`getTpProgressBatch\` — they continue to fetch always-empty data (filed as #1636)
- Delete \`TpProgress\` / \`TpProgressSummary\` types — used by the readers above (filed as #1636)
- Audit the continuous-mode working-set-selector to confirm LO-only behaviour is identical (filed as #1636)

These are deferred because they need a UX audit + algorithm regression test that's larger than the spike's "delete the actively-broken bits" guidance. Phase 1 ships the runtime crash fix + the obvious dead code; Phase 2 (#1636) finishes the namespace sweep.

## Related

- **#1615** — the spike that found this (this PR closes it)
- **#1633** — runtime crash (closed as side effect of this PR)
- **#1632** — upstream REWARD bail (separate; still blocks #1609 from fully firing)
- **#1622 / PR #1625** — silent-writer alarms (caught the missing ADAPT log row that surfaced #1633)
- **#1636** — Phase 2 sweep (filed during this PR)
- **Epic #1618** — writer-completeness contract layer

Needs \`/vm-cp\` then smoke per the test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)