### PR TITLE
fix(pipeline): #1632 — REWARD filter measurements by SYSTEM target match instead of demanding 100% coverage

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -1632,12 +1632,35 @@ async function computeReward(
     where: { scope: "SYSTEM" },
   });
 
+  // #1632 — REWARD compares the AI tutor's TUNABLE BEHAVIOR (BEH-* +
+  // skill_* params, `Parameter.isAdjustable === true`) against the
+  // SYSTEM-scope BehaviorTarget cascade. STATE-type measurements
+  // (`COMP-*`, `COACH_*`, `CONV_*`, `application_score`, etc.) are
+  // OBSERVATIONS the AI made about the conversation/learner — they
+  // have no target by design and feed AGGREGATE / CallerAttribute
+  // downstream, not the reward delta loop.
+  //
+  // Pre-#1632 the guard required every BehaviorMeasurement to have a
+  // matching SYSTEM BehaviorTarget. Because SCORE_AGENT measures
+  // dozens of STATE params per call (verified live on hf-dev: Freddy
+  // Starr's call produced 22 measurements vs 6 SYSTEM targets), the
+  // guard threw on every STRUCTURED call, REWARD bailed, the
+  // RewardScore row was never written, the #1609 reward-loop sub-op
+  // had no row to process, and the Adaptations "Why" timeline stayed
+  // empty.
+  //
+  // Fix: compute diff over MATCHED measurements only. The remaining
+  // unmatched STATE measurements are not a reward signal; their
+  // absence from `parameterDiffs` is correct. The previous guard's
+  // intent (refuse to silently fall back to 0.5) is preserved by the
+  // earlier `behaviorMeasurements.length === 0` throw and the new
+  // `diffs.length === 0` throw below.
   const diffs: Array<{ parameterId: string; target: number; actual: number; diff: number }> = [];
-  const missingTargetParams: string[] = [];
+  const unmatchedMeasurements: string[] = [];
   for (const measurement of call.behaviorMeasurements) {
     const target = targets.find((t) => t.parameterId === measurement.parameterId);
     if (!target) {
-      missingTargetParams.push(measurement.parameterId);
+      unmatchedMeasurements.push(measurement.parameterId);
       continue;
     }
     const diff = Math.abs(measurement.actualValue - target.targetValue);
@@ -1649,13 +1672,22 @@ async function computeReward(
     });
   }
 
-  if (missingTargetParams.length > 0) {
-    // Hard error — every MEASURE-emitted parameter must have a SYSTEM
-    // BehaviorTarget. The 0.5 fallback would have silently scored these
-    // against a guessed midpoint.
+  // #1632 — only flag the unmatched set when ZERO measurements matched a
+  // target. That's the "REWARD has nothing to score" condition the old
+  // guard was trying (and failing) to catch. Partial matches are
+  // expected — STATE measurements outnumber BEHAVIOR targets by ~3:1
+  // on a typical structured call. Log the unmatched set at debug level
+  // for forensics without spamming.
+  if (diffs.length === 0) {
     throw new Error(
-      `REWARD: STRUCTURED call ${callId} produced measurements for parameters with no SYSTEM BehaviorTarget — refusing silent 0.5 fallback (#1256). Missing: ${missingTargetParams.join(", ")}`,
+      `REWARD: STRUCTURED call ${callId} produced ${call.behaviorMeasurements.length} BehaviorMeasurement(s) but NONE matched a SYSTEM BehaviorTarget — refusing silent 0.5 fallback (#1256/#1632). Measured: ${call.behaviorMeasurements.map((m) => m.parameterId).slice(0, 10).join(", ")}${call.behaviorMeasurements.length > 10 ? "..." : ""}. Expected at least one BEH-* or skill_* parameter with a SYSTEM target.`,
     );
+  }
+  if (unmatchedMeasurements.length > 0) {
+    log.debug("REWARD: skipping STATE measurements without SYSTEM targets (expected)", {
+      count: unmatchedMeasurements.length,
+      sample: unmatchedMeasurements.slice(0, 5),
+    });
   }
 
   const avgDiff = diffs.length > 0 ? diffs.reduce((sum, d) => sum + d.diff, 0) / diffs.length : 0;

--- a/apps/admin/tests/lib/pipeline/reward-target-filter.test.ts
+++ b/apps/admin/tests/lib/pipeline/reward-target-filter.test.ts
@@ -1,0 +1,124 @@
+/**
+ * reward-target-filter.test.ts (#1632)
+ *
+ * Pins the post-#1632 REWARD diff semantics:
+ *   - measurements with a matching SYSTEM BehaviorTarget contribute to
+ *     the parameter-diffs array
+ *   - measurements without a matching target (STATE observations) are
+ *     skipped silently
+ *   - throw ONLY when zero matches occurred (the "nothing to reward"
+ *     condition the original #1256 guard was trying to catch)
+ *
+ * Direct end-to-end testing of `computeReward` would require mocking
+ * Prisma findUnique + findMany + upsert + the surrounding pipeline
+ * context. The fix is small and surgical (filter logic only) so this
+ * test exercises the core filter shape via a faithful copy of the
+ * filter loop. The live smoke on hf-dev is the integration verification.
+ */
+import { describe, it, expect } from "vitest";
+
+/** Shape mirrors the inline loop in `route.ts::computeReward`. */
+function computeDiffs(
+  measurements: Array<{ parameterId: string; actualValue: number }>,
+  targets: Array<{ parameterId: string; targetValue: number }>,
+): {
+  diffs: Array<{ parameterId: string; target: number; actual: number; diff: number }>;
+  unmatched: string[];
+} {
+  const diffs: Array<{ parameterId: string; target: number; actual: number; diff: number }> = [];
+  const unmatched: string[] = [];
+  for (const measurement of measurements) {
+    const target = targets.find((t) => t.parameterId === measurement.parameterId);
+    if (!target) {
+      unmatched.push(measurement.parameterId);
+      continue;
+    }
+    const diff = Math.abs(measurement.actualValue - target.targetValue);
+    diffs.push({
+      parameterId: measurement.parameterId,
+      target: target.targetValue,
+      actual: measurement.actualValue,
+      diff,
+    });
+  }
+  return { diffs, unmatched };
+}
+
+const FREDDY_FIXTURE = [
+  // BEHAVIOR params with SYSTEM targets — must be in diffs
+  { parameterId: "BEH-WARMTH", actualValue: 0.75 },
+  { parameterId: "BEH-FORMALITY", actualValue: 0.42 },
+  { parameterId: "BEH-RESPONSE-LEN", actualValue: 0.22 },
+  // STATE params WITHOUT SYSTEM targets — pre-#1632 these threw;
+  // post-#1632 they're silently skipped
+  { parameterId: "COMP-ENGAGEMENT", actualValue: 0.6 },
+  { parameterId: "COACH_CLARITY", actualValue: 0.5 },
+  { parameterId: "CONV_PACE", actualValue: 0.7 },
+  { parameterId: "application_score", actualValue: 0.55 },
+  { parameterId: "TONE_ASSERT", actualValue: 0.4 },
+];
+
+const FREDDY_SYSTEM_TARGETS = [
+  { parameterId: "BEH-WARMTH", targetValue: 0.7 },
+  { parameterId: "BEH-FORMALITY", targetValue: 0.4 },
+  { parameterId: "BEH-RESPONSE-LEN", targetValue: 0.2 },
+  { parameterId: "BEH-CONVERSATIONAL-TONE", targetValue: 0.5 },
+  { parameterId: "BEH-PAUSE-TOLERANCE", targetValue: 0.75 },
+  { parameterId: "BEH-TURN-LENGTH", targetValue: 0.5 },
+];
+
+describe("REWARD target-matching filter (#1632)", () => {
+  it("only diffs measurements with a matching SYSTEM target", () => {
+    const { diffs, unmatched } = computeDiffs(FREDDY_FIXTURE, FREDDY_SYSTEM_TARGETS);
+    expect(diffs).toHaveLength(3);
+    expect(diffs.map((d) => d.parameterId).sort()).toEqual([
+      "BEH-FORMALITY",
+      "BEH-RESPONSE-LEN",
+      "BEH-WARMTH",
+    ]);
+  });
+
+  it("STATE measurements without targets land in the unmatched set", () => {
+    const { unmatched } = computeDiffs(FREDDY_FIXTURE, FREDDY_SYSTEM_TARGETS);
+    expect(unmatched.sort()).toEqual([
+      "COACH_CLARITY",
+      "COMP-ENGAGEMENT",
+      "CONV_PACE",
+      "TONE_ASSERT",
+      "application_score",
+    ]);
+  });
+
+  it("diff values are |actual - target|, never silent fallback", () => {
+    const { diffs } = computeDiffs(FREDDY_FIXTURE, FREDDY_SYSTEM_TARGETS);
+    const warmth = diffs.find((d) => d.parameterId === "BEH-WARMTH")!;
+    expect(warmth.actual).toBe(0.75);
+    expect(warmth.target).toBe(0.7);
+    expect(warmth.diff).toBeCloseTo(0.05, 5);
+  });
+
+  it("returns empty diffs when only STATE measurements exist (zero matched)", () => {
+    const stateOnly = FREDDY_FIXTURE.filter((m) => !m.parameterId.startsWith("BEH-"));
+    const { diffs, unmatched } = computeDiffs(stateOnly, FREDDY_SYSTEM_TARGETS);
+    expect(diffs).toHaveLength(0);
+    expect(unmatched).toHaveLength(5);
+    // This is the condition the post-#1632 guard throws on.
+  });
+
+  it("permits skill_* params when a matching SYSTEM target exists (forward-compat)", () => {
+    // Today no skill_* params have SYSTEM targets (only PLAYBOOK-scope
+    // targets are seeded). The filter is shape-agnostic: if a SYSTEM
+    // target lands tomorrow, the diff just includes it.
+    const skillMeasurement = [
+      { parameterId: "skill_fluency_and_coherence_fc", actualValue: 0.65 },
+      { parameterId: "BEH-WARMTH", actualValue: 0.75 },
+    ];
+    const skillTarget = [
+      ...FREDDY_SYSTEM_TARGETS,
+      { parameterId: "skill_fluency_and_coherence_fc", targetValue: 1.0 },
+    ];
+    const { diffs } = computeDiffs(skillMeasurement, skillTarget);
+    expect(diffs).toHaveLength(2);
+    expect(diffs.find((d) => d.parameterId === "skill_fluency_and_coherence_fc")?.diff).toBeCloseTo(0.35, 5);
+  });
+});


### PR DESCRIPTION
Closes #1632. Unblocks #1609 (PR #1629) from firing live.

## Verified by

Live diff on hf-dev sandbox 2026-06-14 against Freddy Starr:

\`\`\`
SCORE_AGENT measured 22 params:
  3 BEHAVIOR-type (BEH-WARMTH, skill_*, …)
  19 STATE-type (COMP-*, COACH_*, CONV_*, application_score, …)

SYSTEM-scope BehaviorTargets exist for 6 params (all BEH-*):
  BEH-CONVERSATIONAL-TONE, BEH-FORMALITY, BEH-PAUSE-TOLERANCE,
  BEH-RESPONSE-LEN, BEH-TURN-LENGTH, BEH-WARMTH

Pre-fix: guard required 100% target coverage → threw on every call.
Post-fix: filter measurements to matched targets → 3-5 diffs, rest skipped.
\`\`\`

## Root cause + fix

The #1256 guard required every BehaviorMeasurement to have a matching SYSTEM target. But \`Parameter.parameterType\` distinguishes BEHAVIOR (tunable via BehaviorTarget) from STATE (observations). SCORE_AGENT measures both kinds; only BEHAVIOR ones belong in REWARD's diff loop.

This PR filters by target-match before computing diffs. The original #1256 intent ("refuse silent 0.5 fallback") is preserved:
- Existing throw on \`behaviorMeasurements.length === 0\` stays
- New throw on \`diffs.length === 0\` catches "measurements exist but none matched a target" — the actual problem class

## Test plan

- [x] vitest \`tests/lib/pipeline/reward-target-filter.test.ts\` → 5/5 green
- [x] tsc clean on touched files (1 pre-existing unrelated TS2322 at line 1701)
- [ ] Smoke on hf-dev after \`/vm-cp\`:
  1. Force-rerun pipeline on Freddy's most-recent call
  2. Confirm no REWARD failure in response logs
  3. \`SELECT "targetUpdatesApplied" FROM "RewardScore" WHERE "callId" = '<callId>';\` → empty array or populated (was always NULL pre-fix)
  4. PR #1625's \`/x/system/pipeline-health\` ADAPT.callerTarget non-silent for new calls

## What this unblocks

Once merged + live:
- REWARD writes RewardScore rows for STRUCTURED calls (currently 73 historic NULL rows + every new call failing)
- #1609 reward-loop sub-op 8 actually fires
- Adaptations "Why" timeline starts populating in real-time

## What this does NOT do

- Doesn't add new BehaviorTargets — if a course wants to tune COMP-* / COACH_* params that's a separate AgentTuner story
- Doesn't change SCORE_AGENT's param set
- Doesn't backfill 73 historic NULL \`targetUpdatesApplied\` rows (gated by #1609 Slice 3)

## Sprint context

Today's reward-loop story chain: #1608 (evidence) → #1622 (alarms) → #1614 (Goal trail) → #1609 (wire-up) → #1615 Phase 1 (deletes ADAPT crash) → **#1632 (this PR, removes REWARD bail)**. After this lands the loop fires end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)