### PR TITLE
fix(assessment): #1640 — checkpoint CallerAttribute upsert uses caller relation instead of bare callerId

### DIFF
--- a/apps/admin/lib/assessment/checkpoint-evaluator.ts
+++ b/apps/admin/lib/assessment/checkpoint-evaluator.ts
@@ -73,7 +73,14 @@ export async function evaluateCheckpoints(
 
   const status = avgScore >= threshold ? "PASSED" as const : "NOT_MET" as const;
 
-  // Store result as CallerAttribute
+  // Store result as CallerAttribute. #1640 — use `caller: { connect }`
+  // instead of bare `callerId` so the generated Prisma input shape
+  // accepts the create. Bare-FK on a relation-required input was
+  // throwing at runtime ("Argument `caller` is missing") on every
+  // STRUCTURED call, aborting ADAPT before sub-op 8 (the #1609
+  // reward-loop writer) could fire. Discovered via live smoke after
+  // PR #1639 — same Prisma error class that previously hid in the
+  // deleted `updateTpMasteryAfterCall` function (#1633 / #1615 Phase 1).
   await prisma.callerAttribute.upsert({
     where: {
       callerId_key_scope: {
@@ -83,13 +90,12 @@ export async function evaluateCheckpoints(
       },
     },
     create: {
-      callerId,
+      caller: { connect: { id: callerId } },
       key: checkpointLabel,
       scope: "CHECKPOINT",
       valueType: "STRING",
       stringValue: status,
       numberValue: avgScore,
-      confidence: null,
     },
     update: {
       stringValue: status,


### PR DESCRIPTION
Closes the last runtime block on #1609 firing live.

## Verified by

Live smoke after PR #1639 merged — ADAPT still failed with:

> Stage ADAPT failed (non-blocking): Invalid \`prisma.callerAttribute.upsert()\` invocation … Argument \`caller\` is missing.

Traced to \`lib/assessment/checkpoint-evaluator.ts:77\` — different surface from the deleted \`updateTpMasteryAfterCall\` (#1633 / #1615 Phase 1). Same Prisma error class: newer generated input typing requires the \`caller: { connect }\` relation on the create branch, not the bare \`callerId\` FK column.

## Summary

\`\`\`diff
  create: {
-   callerId,
+   caller: { connect: { id: callerId } },
    key: checkpointLabel,
    ...
-   confidence: null,
  }
\`\`\`

- Swap \`callerId\` for \`caller: { connect: { id: callerId } }\` — matches sibling working upserts (\`compose-next-prompt\`, \`enrollment/*\`)
- Drop \`confidence: null\` — explicit null on an optional field is unnecessary

## Test plan

- [x] tsc clean on touched file
- [ ] Smoke on hf-dev after \`/vm-cp\`:
  1. Force-rerun pipeline on Freddy's most-recent call
  2. Confirm no ADAPT failure in response logs
  3. \`pipeline.stage.write_counts:adapt\` AppLog row appears (was missing pre-fix)
  4. \`SELECT "targetUpdatesApplied" FROM "RewardScore" WHERE "callId" = '<callId>';\` → \`[]\` (empty array — REWARD wrote the row, ADAPT sub-op 8 marked it processed with no diffs)
  5. \`/x/system/pipeline-health\` shows ADAPT.callerTarget non-silent

## What this unblocks

This is the LAST runtime block on today's reward-loop story chain. After this lands, all 6 PRs from today (#1599, #1608, #1609, #1614, #1622, #1632) fire as designed on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)