### PR TITLE
fix(pipeline): #1641 — REWARD load PLAYBOOK-scope targets via SYSTEM+PLAYBOOK cascade merge

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -1627,10 +1627,40 @@ async function computeReward(
     );
   }
 
-  // Load system targets
-  const targets = await prisma.behaviorTarget.findMany({
-    where: { scope: "SYSTEM" },
+  // #1641 — Load BOTH SYSTEM-scope and PLAYBOOK-scope targets, then
+  // cascade-merge: PLAYBOOK row wins over SYSTEM row on parameterId
+  // collision. This matches the BehaviorTarget cascade contract
+  // (`loadBehaviorTargetsWithCascade` for the SCORE_AGENT read side)
+  // and unblocks STRUCTURED courses that measure `skill_*` params with
+  // PLAYBOOK-scope targets but no SYSTEM-scope target (e.g. IELTS
+  // Speaking V1.0 / PAW / PLS USE NEW V1.0 — verified 2026-06-14:
+  // SCORE_AGENT measured `skill_fluency_and_coherence_fc` against a
+  // PLAYBOOK target of 0.70, but REWARD's SYSTEM-only findMany missed
+  // it and the #1632 guard threw "0 measurements matched").
+  //
+  // Pre-#1641 the cascade was effectively SYSTEM-only at REWARD; this
+  // PR adds the PLAYBOOK overlay. CALLER-scope overrides are still
+  // out of scope here — those flow through ADAPT's `updateTargets`
+  // sub-op (#1609) once REWARD writes a RewardScore row.
+  const rawTargets = await prisma.behaviorTarget.findMany({
+    where: call.playbookId
+      ? {
+          OR: [
+            { scope: "SYSTEM" },
+            { scope: "PLAYBOOK", playbookId: call.playbookId },
+          ],
+        }
+      : { scope: "SYSTEM" },
   });
+
+  // Cascade merge: PLAYBOOK overrides SYSTEM on parameterId collision.
+  const targetByParam = new Map<string, (typeof rawTargets)[number]>();
+  for (const t of rawTargets) {
+    if (t.scope === "SYSTEM") targetByParam.set(t.parameterId, t);
+  }
+  for (const t of rawTargets) {
+    if (t.scope === "PLAYBOOK") targetByParam.set(t.parameterId, t);
+  }
 
   // #1632 — REWARD compares the AI tutor's TUNABLE BEHAVIOR (BEH-* +
   // skill_* params, `Parameter.isAdjustable === true`) against the
@@ -1655,10 +1685,10 @@ async function computeReward(
   // intent (refuse to silently fall back to 0.5) is preserved by the
   // earlier `behaviorMeasurements.length === 0` throw and the new
   // `diffs.length === 0` throw below.
-  const diffs: Array<{ parameterId: string; target: number; actual: number; diff: number }> = [];
+  const diffs: Array<{ parameterId: string; target: number; actual: number; diff: number; scope: string }> = [];
   const unmatchedMeasurements: string[] = [];
   for (const measurement of call.behaviorMeasurements) {
-    const target = targets.find((t) => t.parameterId === measurement.parameterId);
+    const target = targetByParam.get(measurement.parameterId);
     if (!target) {
       unmatchedMeasurements.push(measurement.parameterId);
       continue;
@@ -1669,6 +1699,11 @@ async function computeReward(
       target: target.targetValue,
       actual: measurement.actualValue,
       diff,
+      // #1641 — stamp which scope's target won the cascade. Lets the
+      // operator-facing pipeline diagnostic at /x/logs distinguish
+      // "scored against the SYSTEM default" (suggests an unset playbook
+      // target) from "scored against an explicit PLAYBOOK override".
+      scope: target.scope,
     });
   }
 
@@ -1680,15 +1715,24 @@ async function computeReward(
   // for forensics without spamming.
   if (diffs.length === 0) {
     throw new Error(
-      `REWARD: STRUCTURED call ${callId} produced ${call.behaviorMeasurements.length} BehaviorMeasurement(s) but NONE matched a SYSTEM BehaviorTarget — refusing silent 0.5 fallback (#1256/#1632). Measured: ${call.behaviorMeasurements.map((m) => m.parameterId).slice(0, 10).join(", ")}${call.behaviorMeasurements.length > 10 ? "..." : ""}. Expected at least one BEH-* or skill_* parameter with a SYSTEM target.`,
+      `REWARD: STRUCTURED call ${callId} produced ${call.behaviorMeasurements.length} BehaviorMeasurement(s) but NONE matched a SYSTEM or PLAYBOOK BehaviorTarget — refusing silent 0.5 fallback (#1256/#1632/#1641). Measured: ${call.behaviorMeasurements.map((m) => m.parameterId).slice(0, 10).join(", ")}${call.behaviorMeasurements.length > 10 ? "..." : ""}. Targets loaded: ${targetByParam.size} (SYSTEM + PLAYBOOK for playbook ${call.playbookId ?? "(null)"}). Expected at least one BEH-* or skill_* parameter with a target at either scope.`,
     );
   }
   if (unmatchedMeasurements.length > 0) {
-    log.debug("REWARD: skipping STATE measurements without SYSTEM targets (expected)", {
+    log.debug("REWARD: skipping STATE measurements without cascade targets (expected)", {
       count: unmatchedMeasurements.length,
       sample: unmatchedMeasurements.slice(0, 5),
     });
   }
+  // #1641 — log the cascade composition for operator-facing diagnostics.
+  const systemHits = diffs.filter((d) => d.scope === "SYSTEM").length;
+  const playbookHits = diffs.filter((d) => d.scope === "PLAYBOOK").length;
+  log.info("REWARD cascade composition", {
+    totalMatched: diffs.length,
+    bySystemTarget: systemHits,
+    byPlaybookOverride: playbookHits,
+    unmatchedCount: unmatchedMeasurements.length,
+  });
 
   const avgDiff = diffs.length > 0 ? diffs.reduce((sum, d) => sum + d.diff, 0) / diffs.length : 0;
   const behaviorScore = Math.max(0, 1 - avgDiff);

--- a/apps/admin/tests/lib/pipeline/reward-cascade-merge.test.ts
+++ b/apps/admin/tests/lib/pipeline/reward-cascade-merge.test.ts
@@ -1,0 +1,110 @@
+/**
+ * reward-cascade-merge.test.ts (#1641)
+ *
+ * Pins the SYSTEM + PLAYBOOK cascade-merge contract on REWARD's target
+ * lookup. The diff loop in `computeReward` reads from a Map populated
+ * by an OR-where findMany + a two-pass merge; pinning the merge shape
+ * separately from the inline call site keeps the test light + readable.
+ *
+ * The bug class this guard against: REWARD previously loaded SYSTEM
+ * targets only, so STRUCTURED courses with PLAYBOOK-scope skill_*
+ * targets (e.g. IELTS Speaking V1.0) had every BehaviorMeasurement
+ * marked as unmatched and the #1632 guard threw "0 measurements
+ * matched a SYSTEM target". The merge gives PLAYBOOK precedence over
+ * SYSTEM on parameterId collision so a course-specific override (e.g.
+ * BEH-WARMTH PLAYBOOK=0.21 vs SYSTEM=0.5) wins the diff comparison.
+ */
+import { describe, it, expect } from "vitest";
+
+interface TargetRow {
+  parameterId: string;
+  scope: "SYSTEM" | "PLAYBOOK" | "CALLER";
+  targetValue: number;
+  playbookId?: string | null;
+}
+
+/** Mirrors the inline merge in `route.ts::computeReward`. */
+function mergeCascade(rawTargets: TargetRow[]): Map<string, TargetRow> {
+  const targetByParam = new Map<string, TargetRow>();
+  for (const t of rawTargets) {
+    if (t.scope === "SYSTEM") targetByParam.set(t.parameterId, t);
+  }
+  for (const t of rawTargets) {
+    if (t.scope === "PLAYBOOK") targetByParam.set(t.parameterId, t);
+  }
+  return targetByParam;
+}
+
+describe("REWARD SYSTEM + PLAYBOOK cascade merge (#1641)", () => {
+  it("PLAYBOOK target overrides SYSTEM target on parameterId collision", () => {
+    const merged = mergeCascade([
+      { parameterId: "BEH-WARMTH", scope: "SYSTEM", targetValue: 0.5 },
+      { parameterId: "BEH-WARMTH", scope: "PLAYBOOK", targetValue: 0.21, playbookId: "pb-A" },
+    ]);
+    const warmth = merged.get("BEH-WARMTH");
+    expect(warmth?.scope).toBe("PLAYBOOK");
+    expect(warmth?.targetValue).toBe(0.21);
+  });
+
+  it("PLAYBOOK-only targets win when no SYSTEM sibling exists (the IELTS skill_* case)", () => {
+    const merged = mergeCascade([
+      { parameterId: "BEH-WARMTH", scope: "SYSTEM", targetValue: 0.5 },
+      { parameterId: "skill_fluency_and_coherence_fc", scope: "PLAYBOOK", targetValue: 0.7, playbookId: "pb-A" },
+      { parameterId: "skill_grammatical_range_and_accuracy_gra", scope: "PLAYBOOK", targetValue: 0.7, playbookId: "pb-A" },
+    ]);
+    expect(merged.size).toBe(3);
+    expect(merged.get("skill_fluency_and_coherence_fc")?.scope).toBe("PLAYBOOK");
+    expect(merged.get("skill_fluency_and_coherence_fc")?.targetValue).toBe(0.7);
+  });
+
+  it("SYSTEM-only targets pass through unchanged when no PLAYBOOK exists", () => {
+    const merged = mergeCascade([
+      { parameterId: "BEH-WARMTH", scope: "SYSTEM", targetValue: 0.5 },
+      { parameterId: "BEH-FORMALITY", scope: "SYSTEM", targetValue: 0.5 },
+    ]);
+    expect(merged.size).toBe(2);
+    expect(merged.get("BEH-WARMTH")?.scope).toBe("SYSTEM");
+    expect(merged.get("BEH-FORMALITY")?.scope).toBe("SYSTEM");
+  });
+
+  it("empty input → empty map", () => {
+    expect(mergeCascade([]).size).toBe(0);
+  });
+
+  it("ignores CALLER-scope rows in this layer (ADAPT writes those, not REWARD)", () => {
+    // ADAPT's `updateTargets` sub-op writes CALLER-scope rows after
+    // REWARD. The cascade-merge layer above sees PLAYBOOK + SYSTEM only.
+    const merged = mergeCascade([
+      { parameterId: "BEH-WARMTH", scope: "SYSTEM", targetValue: 0.5 },
+      { parameterId: "BEH-WARMTH", scope: "CALLER", targetValue: 0.9 },
+    ]);
+    expect(merged.get("BEH-WARMTH")?.scope).toBe("SYSTEM");
+    expect(merged.get("BEH-WARMTH")?.targetValue).toBe(0.5);
+  });
+
+  it("Freddy Starr real-data fixture: skill_* PLAYBOOK + BEH-* PLAYBOOK over BEH-* SYSTEM", () => {
+    // Live diff from hf-dev sandbox 2026-06-14 — IELTS PLS USE NEW
+    // V1.0 playbook (ec4127a1). Pre-#1641 REWARD's SYSTEM-only load
+    // missed ALL these PLAYBOOK targets, throwing the #1632 guard.
+    const merged = mergeCascade([
+      // SYSTEM defaults
+      { parameterId: "BEH-WARMTH", scope: "SYSTEM", targetValue: 0.5 },
+      { parameterId: "BEH-FORMALITY", scope: "SYSTEM", targetValue: 0.5 },
+      { parameterId: "BEH-CONVERSATIONAL-TONE", scope: "SYSTEM", targetValue: 0.5 },
+      { parameterId: "BEH-RESPONSE-LEN", scope: "SYSTEM", targetValue: 0.5 },
+      // PLAYBOOK overrides
+      { parameterId: "BEH-WARMTH", scope: "PLAYBOOK", targetValue: 0.21, playbookId: "ec4127a1" },
+      { parameterId: "BEH-FORMALITY", scope: "PLAYBOOK", targetValue: 0.4, playbookId: "ec4127a1" },
+      { parameterId: "BEH-CONVERSATIONAL-TONE", scope: "PLAYBOOK", targetValue: 0.48, playbookId: "ec4127a1" },
+      { parameterId: "BEH-RESPONSE-LEN", scope: "PLAYBOOK", targetValue: 0.44, playbookId: "ec4127a1" },
+      // PLAYBOOK-only (skill family)
+      { parameterId: "skill_fluency_and_coherence_fc", scope: "PLAYBOOK", targetValue: 0.7, playbookId: "ec4127a1" },
+      { parameterId: "skill_grammatical_range_and_accuracy_gra", scope: "PLAYBOOK", targetValue: 0.7, playbookId: "ec4127a1" },
+    ]);
+    expect(merged.size).toBe(6);
+    expect(merged.get("BEH-WARMTH")?.targetValue).toBe(0.21);
+    expect(merged.get("BEH-FORMALITY")?.targetValue).toBe(0.4);
+    expect(merged.get("skill_fluency_and_coherence_fc")?.targetValue).toBe(0.7);
+    expect(merged.get("skill_fluency_and_coherence_fc")?.scope).toBe("PLAYBOOK");
+  });
+});


### PR DESCRIPTION
Closes #1641. Last upstream block on the writer-completeness chain firing end-to-end.

## Verified by

Live diff on hf-dev sandbox 2026-06-14 after PR #1639 + #1640 landed — REWARD still bailed:

> Stage REWARD failed: produced 20 BehaviorMeasurement(s) but NONE matched a SYSTEM BehaviorTarget — refusing silent 0.5 fallback (#1256/#1632). Measured: CONV_PACE, COACH_FOLLOWUP, ..., skill_fluency_and_coherence_fc, skill_grammatical_range_and_accuracy_gra.

Root cause: SCORE_AGENT measures \`skill_*\` params (BEHAVIOR-type, isAdjustable=true) which have PLAYBOOK-scope targets (\`skill_fluency_and_coherence_fc=0.7\`, \`skill_grammatical_range_and_accuracy_gra=0.7\`, etc.) but no SYSTEM-scope target. REWARD's old findMany filter \`{scope:'SYSTEM'}\` missed all 13 PLAYBOOK targets for this IELTS playbook.

## Summary

- Cascade-aware findMany: \`OR: [{scope:'SYSTEM'}, {scope:'PLAYBOOK', playbookId}]\`
- Cascade merge: \`targetByParam\` Map populated SYSTEM-first, then PLAYBOOK-second so PLAYBOOK rows win on parameterId collision (e.g. \`BEH-WARMTH\` SYSTEM=0.5 vs PLAYBOOK=0.21)
- Scope-stamped diffs: each diff entry carries the winning scope so operators can distinguish "scored against SYSTEM default" from "scored against PLAYBOOK override"
- Cascade composition log: \`{totalMatched, bySystemTarget, byPlaybookOverride, unmatchedCount}\` per call
- Guard message updated to mention both scopes + report \`targetByParam.size\` for forensics
- 6 vitests pin the merge contract (PLAYBOOK over SYSTEM, PLAYBOOK-only wins, SYSTEM-only passthrough, empty, CALLER ignored at this layer, Freddy live-data fixture)

## Test plan

- [x] vitest 6/6 green
- [x] tsc clean for touched files
- [ ] Smoke on hf-dev after \`/vm-cp\`:
  1. Force-rerun pipeline on Freddy's most-recent call
  2. Confirm REWARD writes a RewardScore row (was: throwing)
  3. \`SELECT "targetUpdatesApplied" FROM "RewardScore" WHERE "callId" = '<callId>';\` → \`[]\` sentinel or populated array
  4. \`/x/system/pipeline-health\` shows \`reward\` stage non-silent for new calls
  5. \`/x/callers/<freddy>?tab=adaptations\` shows entries in "Why" timeline

## What this does NOT do

- CALLER-scope cascade at REWARD — ADAPT's \`updateTargets\` sub-op writes CALLER overrides AFTER REWARD; reading them here would create a circular flow. CALLER targets correctly apply at NEXT call's SCORE_AGENT via the existing \`loadBehaviorTargetsWithCascade\` read
- Seed defaults for STATE params (COMP-*, COACH_*, CONV_*) — those don't need REWARD targets; they're observations not behaviors
- Backfill 73 historic NULL \`targetUpdatesApplied\` rows (gated by #1609 Slice 3)

## Today's chain status (after this lands)

| Stage | Status |
|---|---|
| SCORE_AGENT real evidence (#1608) | ✅ |
| Goal trail (#1614) | ✅ |
| Silent-writer alarms (#1622) | ✅ |
| Reward-loop wire-up (#1609) | ✅ fires |
| ADAPT checkpoint upsert (#1640) | ✅ |
| REWARD cascade merge (this PR) | ✅ closes loop |
| Adaptations Why timeline | will populate after merge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)