### PR TITLE
feat(banding): #1647 — source-derived preset entry in BandingPicker

### DIFF
--- a/apps/admin/components/shared/BandingPicker.tsx
+++ b/apps/admin/components/shared/BandingPicker.tsx
@@ -25,29 +25,63 @@ interface BandingPickerProps {
   onSaved?: () => void;
 }
 
+type Mapping = NonNullable<PlaybookConfig["skillTierMapping"]>;
+type TierSlot = "approachingEmerging" | "emerging" | "developing" | "secure";
+const SLOTS: readonly TierSlot[] = [
+  "approachingEmerging",
+  "emerging",
+  "developing",
+  "secure",
+];
+
+function numbersMatch(mapping: Mapping, preset: TierPreset): boolean {
+  return SLOTS.every(
+    (s) =>
+      mapping.thresholds[s] === preset.mapping.thresholds[s] &&
+      mapping.tierBands[s] === preset.mapping.tierBands[s],
+  );
+}
+
+function labelsMatch(mapping: Mapping, preset: TierPreset): boolean {
+  if (!mapping.tierLabels || !preset.tierLabels) return false;
+  return SLOTS.every((s) => mapping.tierLabels![s] === preset.tierLabels![s]);
+}
+
 /**
- * Best-effort: detect which preset the current mapping matches. Used to
- * pre-select the radio. When custom thresholds are in use, falls back to
- * "custom".
+ * Detect which preset the current mapping matches. Used to pre-select the
+ * radio.
+ *
+ * Order matters:
+ *  - First match label-bearing presets (CEFR, 5-Level) on BOTH numbers and
+ *    labels. A mapping with cefr numbers but Foundation/Developing/... labels
+ *    must NOT collapse into the CEFR radio.
+ *  - Then match label-free presets (IELTS, custom) on numbers only when the
+ *    current mapping ALSO has no labels.
+ *  - If labels are present but didn't match any baked preset → "source-derived"
+ *    (the #1635 derivation path — labels parsed from the uploaded document).
+ *  - Otherwise fall through to "custom" (hand-edited mapping with no labels).
+ *
+ * Skips "source-derived" in the matching loop — its registry mapping is a
+ * placeholder; the live shape is read from `current` at render time.
  */
 function detectPresetId(mapping: PlaybookConfig["skillTierMapping"]): TierPresetId {
   if (!mapping) return "ielts-speaking";
-  for (const [id, p] of Object.entries(TIER_PRESETS)) {
-    const t = p.mapping.thresholds;
-    const b = p.mapping.tierBands;
-    if (
-      mapping.thresholds.approachingEmerging === t.approachingEmerging &&
-      mapping.thresholds.emerging === t.emerging &&
-      mapping.thresholds.developing === t.developing &&
-      mapping.thresholds.secure === t.secure &&
-      mapping.tierBands.approachingEmerging === b.approachingEmerging &&
-      mapping.tierBands.emerging === b.emerging &&
-      mapping.tierBands.developing === b.developing &&
-      mapping.tierBands.secure === b.secure
-    ) {
-      return id as TierPresetId;
-    }
+  const m = mapping as Mapping;
+
+  for (const [id, p] of Object.entries(TIER_PRESETS) as [TierPresetId, TierPreset][]) {
+    if (id === "source-derived") continue;
+    if (!p.tierLabels) continue;
+    if (numbersMatch(m, p) && labelsMatch(m, p)) return id;
   }
+
+  const hasLabels = !!m.tierLabels;
+  for (const [id, p] of Object.entries(TIER_PRESETS) as [TierPresetId, TierPreset][]) {
+    if (id === "source-derived") continue;
+    if (p.tierLabels) continue;
+    if (!hasLabels && numbersMatch(m, p)) return id;
+  }
+
+  if (hasLabels) return "source-derived";
   return "custom";
 }
 
@@ -64,6 +98,11 @@ export function BandingPicker({ courseId, current, onSaved }: BandingPickerProps
     setError(null);
     setSuccess(false);
     try {
+      if (selected === "source-derived") {
+        setSuccess(true);
+        onSaved?.();
+        return;
+      }
       const body =
         selected === "ielts-speaking"
           ? { skillTierMapping: null } // null = clear → fall back to contract default
@@ -100,44 +139,53 @@ export function BandingPicker({ courseId, current, onSaved }: BandingPickerProps
         course isn&apos;t an IELTS-style criterion exam.
       </div>
       <div className="hf-flex-col hf-gap-sm">
-        {(Object.values(TIER_PRESETS) as TierPreset[]).map((p) => (
-          <label key={p.id} className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer">
-            <input
-              type="radio"
-              name="banding-preset"
-              value={p.id}
-              checked={selected === p.id}
-              onChange={() => setSelected(p.id)}
-              disabled={saving}
-            />
-            <div className="hf-flex-1">
-              <div className="hf-text-sm hf-text-bold">{p.label}</div>
-              <div className="hf-text-xs hf-text-muted">{p.description}</div>
-              <div className="hf-text-xs hf-text-muted hf-mt-xs">
-                Tiers:{" "}
-                {(["approachingEmerging", "emerging", "developing", "secure"] as const).map(
-                  (slot, i) => {
-                    const label = p.tierLabels?.[slot] ?? (
-                      slot === "approachingEmerging"
+        {(Object.values(TIER_PRESETS) as TierPreset[]).map((p) => {
+          const isSourceDerived = p.id === "source-derived";
+          if (isSourceDerived && !current?.tierLabels) return null;
+          const sourceLabels = isSourceDerived ? current?.tierLabels : undefined;
+          const sourceBands = isSourceDerived ? current?.tierBands : undefined;
+          return (
+            <label
+              key={p.id}
+              className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer"
+            >
+              <input
+                type="radio"
+                name="banding-preset"
+                value={p.id}
+                checked={selected === p.id}
+                onChange={() => setSelected(p.id)}
+                disabled={saving}
+              />
+              <div className="hf-flex-1">
+                <div className="hf-text-sm hf-text-bold">{p.label}</div>
+                <div className="hf-text-xs hf-text-muted">{p.description}</div>
+                <div className="hf-text-xs hf-text-muted hf-mt-xs">
+                  Tiers:{" "}
+                  {SLOTS.map((slot, i) => {
+                    const label =
+                      sourceLabels?.[slot] ??
+                      p.tierLabels?.[slot] ??
+                      (slot === "approachingEmerging"
                         ? "Approaching Emerging"
                         : slot === "emerging"
                           ? "Emerging"
                           : slot === "developing"
                             ? "Developing"
-                            : "Secure"
-                    );
+                            : "Secure");
+                    const band = sourceBands?.[slot] ?? p.mapping.tierBands[slot];
                     return (
                       <span key={slot}>
                         {i > 0 && " · "}
-                        <Acronym>{label}</Acronym> (band {p.mapping.tierBands[slot]})
+                        <Acronym>{label}</Acronym> (band {band})
                       </span>
                     );
-                  },
-                )}
+                  })}
+                </div>
               </div>
-            </div>
-          </label>
-        ))}
+            </label>
+          );
+        })}
       </div>
       <div className="hf-flex hf-gap-sm hf-items-center hf-mt-md">
         <button

--- a/apps/admin/lib/banding/presets.ts
+++ b/apps/admin/lib/banding/presets.ts
@@ -12,7 +12,12 @@
  */
 import type { SkillTierMapping } from "@/lib/goals/track-progress";
 
-export type TierPresetId = "ielts-speaking" | "cefr" | "5-level" | "custom";
+export type TierPresetId =
+  | "ielts-speaking"
+  | "cefr"
+  | "5-level"
+  | "source-derived"
+  | "custom";
 
 export interface TierPreset {
   id: TierPresetId;
@@ -110,6 +115,26 @@ export const TIER_PRESETS: Record<TierPresetId, TierPreset> = {
       emerging: "Beginner",
       developing: "Intermediate",
       secure: "Advanced",
+    },
+  },
+  "source-derived": {
+    id: "source-derived",
+    label: "Source-derived",
+    description:
+      "Parsed from your uploaded course document by the rubric extractor (#1635). The actual labels + bands below come from your source — this registry entry is a placeholder so the picker can list it alongside the baked presets.",
+    mapping: {
+      thresholds: {
+        approachingEmerging: 0.25,
+        emerging: 0.5,
+        developing: 0.75,
+        secure: 1.0,
+      },
+      tierBands: {
+        approachingEmerging: 1,
+        emerging: 2,
+        developing: 3,
+        secure: 4,
+      },
     },
   },
   custom: {

--- a/apps/admin/tests/components/shared/BandingPicker.test.tsx
+++ b/apps/admin/tests/components/shared/BandingPicker.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Tests for `<BandingPicker>` — the per-playbook skill-tier-mapping picker.
+ *
+ * Pins:
+ *   1. detectPresetId — IELTS / CEFR / 5-Level / Custom / Source-derived
+ *   2. Source-derived render branch shows `current.tierLabels` + `current.tierBands`
+ *   3. Source-derived radio is hidden when `current.tierLabels` is absent
+ *   4. Save handler short-circuits (no fetch) when source-derived is selected
+ *   5. CTO mapping with 5-Level numbers + Foundation labels detects as
+ *      source-derived, NOT 5-Level — pins the #1647 / #1635 fingerprint
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BandingPicker } from "@/components/shared/BandingPicker";
+import { TIER_PRESETS } from "@/lib/banding/presets";
+
+const CTO_MAPPING = {
+  thresholds: TIER_PRESETS["5-level"].mapping.thresholds,
+  tierBands: TIER_PRESETS["5-level"].mapping.tierBands,
+  tierLabels: {
+    approachingEmerging: "Foundation",
+    emerging: "Developing",
+    developing: "Practitioner",
+    secure: "Distinction",
+  },
+};
+
+const HAND_EDITED_NUMBERS_ONLY = {
+  thresholds: {
+    approachingEmerging: 0.2,
+    emerging: 0.4,
+    developing: 0.6,
+    secure: 0.9,
+  },
+  tierBands: {
+    approachingEmerging: 1,
+    emerging: 2,
+    developing: 3,
+    secure: 5,
+  },
+};
+
+describe("<BandingPicker> detectPresetId via initial radio selection", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it("ielts-speaking preset selected when current is null", () => {
+    render(<BandingPicker courseId="c1" current={undefined} />);
+    expect(
+      (screen.getByDisplayValue("ielts-speaking") as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it("cefr preset selected when current matches CEFR numbers + labels", () => {
+    const cefr = TIER_PRESETS["cefr"];
+    render(
+      <BandingPicker
+        courseId="c1"
+        current={{
+          thresholds: cefr.mapping.thresholds,
+          tierBands: cefr.mapping.tierBands,
+          tierLabels: cefr.tierLabels,
+        }}
+      />,
+    );
+    expect((screen.getByDisplayValue("cefr") as HTMLInputElement).checked).toBe(
+      true,
+    );
+  });
+
+  it("5-level preset selected when current matches 5-Level numbers + labels", () => {
+    const five = TIER_PRESETS["5-level"];
+    render(
+      <BandingPicker
+        courseId="c1"
+        current={{
+          thresholds: five.mapping.thresholds,
+          tierBands: five.mapping.tierBands,
+          tierLabels: five.tierLabels,
+        }}
+      />,
+    );
+    expect(
+      (screen.getByDisplayValue("5-level") as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it("source-derived preset selected for CTO mapping (5-Level numbers + Foundation labels) — #1647 fingerprint", () => {
+    render(<BandingPicker courseId="c1" current={CTO_MAPPING} />);
+    expect(
+      (screen.getByDisplayValue("source-derived") as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (screen.getByDisplayValue("5-level") as HTMLInputElement).checked,
+    ).toBe(false);
+  });
+
+  it("custom preset selected for hand-edited mapping with no tierLabels", () => {
+    render(<BandingPicker courseId="c1" current={HAND_EDITED_NUMBERS_ONLY} />);
+    expect(
+      (screen.getByDisplayValue("custom") as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+});
+
+describe("<BandingPicker> source-derived render branch", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it("renders CTO labels + bands from current, not from registry placeholder", () => {
+    const { container } = render(
+      <BandingPicker courseId="c1" current={CTO_MAPPING} />,
+    );
+    const sourceRadio = container.querySelector(
+      'input[value="source-derived"]',
+    );
+    const wrapper = sourceRadio?.closest("label");
+    expect(wrapper).toBeTruthy();
+    const text = wrapper!.textContent ?? "";
+    expect(text).toContain("Foundation");
+    expect(text).toContain("Developing");
+    expect(text).toContain("Practitioner");
+    expect(text).toContain("Distinction");
+    expect(text).toContain("band 1");
+    expect(text).toContain("band 4");
+    expect(text).not.toContain("Novice");
+    expect(text).not.toContain("Beginner");
+  });
+
+  it("hides the source-derived radio entirely when current has no tierLabels", () => {
+    const { container } = render(
+      <BandingPicker courseId="c1" current={HAND_EDITED_NUMBERS_ONLY} />,
+    );
+    expect(container.querySelector('input[value="source-derived"]')).toBeNull();
+  });
+
+  it("hides the source-derived radio when current is undefined", () => {
+    const { container } = render(
+      <BandingPicker courseId="c1" current={undefined} />,
+    );
+    expect(container.querySelector('input[value="source-derived"]')).toBeNull();
+  });
+});
+
+describe("<BandingPicker> save handler", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      } as Response),
+    );
+  });
+
+  it("short-circuits without fetch when source-derived is selected", async () => {
+    const onSaved = vi.fn();
+    render(
+      <BandingPicker courseId="c1" current={CTO_MAPPING} onSaved={onSaved} />,
+    );
+    fireEvent.click(screen.getByText(/save banding/i));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls fetch for non-source-derived selections", async () => {
+    render(<BandingPicker courseId="c1" current={CTO_MAPPING} />);
+    fireEvent.click(screen.getByDisplayValue("cefr"));
+    fireEvent.click(screen.getByText(/save banding/i));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1647. CTO + future source-derived `Playbook.config.skillTierMapping` now surface their parsed labels (e.g. Foundation/Developing/Practitioner/Distinction) directly in the BandingPicker UI, instead of collapsing into the wrong baked preset.
- The pre-fix bug: `#1635`'s CTO derivation writes 5-Level numbers with CTO `tierLabels`. The old `detectPresetId` matched on numbers only → returned `"5-level"` → render loop pulled labels from the registry preset → operator saw Novice/Beginner/Intermediate/Advanced. The Foundation labels stored in DB were completely invisible. Same shape (different optics) as the "Custom"-fingerprint the original issue body described; corrected in #1647 issue comment.
- Implementation per the issue body's option (a) — synthetic 5th preset entry. No new save path (the banding is already in the DB when this preset is detected). Backward-compatible for IELTS / CEFR / hand-edited custom courses.

## Changes

- `apps/admin/lib/banding/presets.ts`: `source-derived` added to `TierPresetId` union and `TIER_PRESETS` registry. Registry mapping is a placeholder (real shape read from `current` at render time).
- `apps/admin/components/shared/BandingPicker.tsx`:
  - `detectPresetId` rewritten to discriminate on `tierLabels` AND numbers (4 branches: label-bearing preset match → 5-Level / CEFR; label-free preset match → IELTS / custom; labels present unmatched → source-derived; otherwise → custom).
  - Render loop substitutes `current.tierLabels` + `current.tierBands` when iterating the source-derived entry.
  - Source-derived radio conditionally hidden when `current?.tierLabels` absent — IELTS / hand-edited custom courses never see it.
  - Save handler short-circuits to no-op for source-derived.
- `apps/admin/tests/components/shared/BandingPicker.test.tsx`: 10 new vitests.

## Verified by

- `tests/components/shared/BandingPicker.test.tsx` — 10/10 passing:
  - 5 detectPresetId branches: IELTS null → ielts-speaking; CEFR → cefr; 5-Level → 5-level; CTO mapping (5-Level numbers + Foundation labels) → source-derived (the #1647 fingerprint); bare numbers → custom.
  - Source-derived render: shows Foundation/Developing/Practitioner/Distinction at bands 1–4 (NOT Novice/Beginner/… from registry placeholder).
  - Source-derived radio hidden when `current.tierLabels` absent / current undefined.
  - Save short-circuits without fetch for source-derived; fetches normally for cefr.
- \`npx tsc --noEmit\` clean against changed files (baseline noise unrelated).
- \`npx eslint\`: 0 errors, 1 pre-existing warning (\`catch (e: any)\` at BandingPicker.tsx:127 — not mine).
- ui-reviewer: PASS — no design system violations.
- Live verification path post-merge: \`/x/courses/<cio-cto-id>?tab=design&design_view=skillBanding\` on hf-dev now shows "Source-derived" radio selected with Foundation/Developing/Practitioner/Distinction labels visible, instead of "5-Level" with Novice/Beginner/Intermediate/Advanced.

## Test plan

- [x] Unit tests pin all 5 detectPresetId branches + render branch + hidden-radio branches + save short-circuit
- [x] \`npx tsc --noEmit\` clean against changed files
- [x] ui-reviewer PASS — no design system violations
- [ ] Live verification on CIO/CTO course after merge (operator step — open \`/x/courses/<cio-cto-id>?tab=design&design_view=skillBanding\` on hf-dev)
- [ ] Regression spot-check: open an IELTS course's design tab — confirm Source-derived radio is NOT shown (current.tierLabels is null)

## Out of scope

- Re-projecting the other 7 non-CTO playbooks (\`NO_SKILLS_WITH_TIER_SCHEME\`) — operator step, not gated by this UI change.
- Changing the underlying \`SkillTierMapping\` shape — this is render-only.

## Related

- Follow-on from #1635 Q5/Q6 carve-out.
- Sibling presets: \`TIER_PRESETS\` at \`apps/admin/lib/banding/presets.ts:42\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)