### PR TITLE
chore(tsc): round 2 — drop 11 more high-risk drift errors

### DIFF
--- a/apps/admin/app/x/courses/page.tsx
+++ b/apps/admin/app/x/courses/page.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { BookOpen, Users, Plus, Trash2, X, BookMarked } from 'lucide-react';
 import { useTerminology } from '@/contexts/TerminologyContext';
+import type { TermKey } from '@/lib/terminology/types';
 import { StatusBadge, DomainPill } from '@/src/components/shared/EntityPill';
 import { FancySelect } from '@/components/shared/FancySelect';
 import { AdvancedBanner } from '@/components/shared/AdvancedBanner';
@@ -170,7 +171,7 @@ function CourseInsightBadges({ course }: { course: CourseListItem }) {
 
 function CourseCard({ course, plural, deleteMode, selected, onToggle, onArchive }: {
   course: CourseListItem;
-  plural: (k: string) => string;
+  plural: (k: TermKey) => string;
   deleteMode?: boolean;
   selected?: boolean;
   onToggle?: (id: string) => void;

--- a/apps/admin/components/help/HelpOverlay.tsx
+++ b/apps/admin/components/help/HelpOverlay.tsx
@@ -15,7 +15,7 @@ import "./help-overlay.css";
 // from lib/chat/commands.ts — kept as a static mirror here because that file
 // is server-side (imports prisma). Update both if you add or remove commands.
 const CHAT_COMMAND_HELP: Record<ChatMode, Array<{ name: string; description: string }>> = {
-  DATA: [
+  ASSISTANT: [
     { name: "/help", description: "Show available commands" },
     { name: "/clear", description: "Clear chat history for this mode" },
     { name: "/context", description: "Show current entity context" },
@@ -23,12 +23,10 @@ const CHAT_COMMAND_HELP: Record<ChatMode, Array<{ name: string; description: str
     { name: "/buildprompt", description: "Show the composed prompt for current caller" },
     { name: "/caller", description: "Show information about the current caller" },
   ],
-  TUNING: [
+  DEMO: [
     { name: "/help", description: "Show available commands" },
     { name: "/clear", description: "Clear chat history for this mode" },
     { name: "/context", description: "Show current entity context" },
-    { name: "/scope", description: "Show current tuning scope (LEARNER or PLAYBOOK)" },
-    { name: "/params", description: "List tunable parameters for current context" },
   ],
 };
 

--- a/apps/admin/components/playbook/PlaybookBuilder.tsx
+++ b/apps/admin/components/playbook/PlaybookBuilder.tsx
@@ -1890,7 +1890,7 @@ export function PlaybookBuilder({ playbookId, routePrefix = "" }: PlaybookBuilde
         title={
           <EditableTitle
             value={playbook.name}
-            as="span"
+            as="h1"
             disabled={playbook.status === "PUBLISHED"}
             onSave={async (newName) => {
               const res = await fetch(`/api/playbooks/${playbookId}`, {

--- a/apps/admin/lib/caller-utils.ts
+++ b/apps/admin/lib/caller-utils.ts
@@ -104,8 +104,9 @@ export function computeTriage(
     return "attention";
   }
 
-  // Ready to advance: high mastery AND good momentum
-  if (mastery !== null && mastery >= ADVANCE_THRESHOLD && momentum !== "slowing") {
+  // Ready to advance: high mastery. (Momentum already narrowed —
+  // "slowing" returned "attention" above, so it can't reach here.)
+  if (mastery !== null && mastery >= ADVANCE_THRESHOLD) {
     return "advancing";
   }
 

--- a/apps/admin/lib/curriculum/sync-modules.ts
+++ b/apps/admin/lib/curriculum/sync-modules.ts
@@ -118,7 +118,7 @@ export async function syncModulesToDB(
   modules: LegacyCurriculumModuleJSON[],
   options?: SyncModulesOptions,
 ): Promise<{ count: number; reconcile: ReconcileResult | null; warnings: string[]; classification: ReclassifyLosResult | null }> {
-  if (!modules || modules.length === 0) return { count: 0, reconcile: null, warnings: [] };
+  if (!modules || modules.length === 0) return { count: 0, reconcile: null, warnings: [], classification: null };
 
   const mode: SyncModulesMode = options?.mode ?? "merge";
   const warnings: string[] = [];

--- a/apps/admin/lib/demonstrate/suggest-goals.ts
+++ b/apps/admin/lib/demonstrate/suggest-goals.ts
@@ -66,7 +66,7 @@ export async function suggestGoals(params: SuggestGoalsParams): Promise<string[]
   ];
 
   if (caller) {
-    contextParts.push(`Learner: ${caller.name || caller.email || caller.id}`);
+    contextParts.push(`Learner: ${caller.name || caller.email || callerId}`);
   } else {
     contextParts.push("No specific learner selected (generic session)");
   }

--- a/apps/admin/lib/domain/instant-curriculum.ts
+++ b/apps/admin/lib/domain/instant-curriculum.ts
@@ -158,7 +158,7 @@ export async function generateInstantCurriculum(
       console.log(`[instant-curriculum] assertion-based curriculum generated: ${result.moduleCount} modules from ${result.assertionCount} assertions`);
       return {
         ok: true,
-        contentSpecId: null,
+        contentSpecId: undefined,
         moduleCount: result.moduleCount,
         path: "assertions",
       };

--- a/apps/admin/lib/goals/extract-goals.ts
+++ b/apps/admin/lib/goals/extract-goals.ts
@@ -526,6 +526,7 @@ If no signals, return: {"signals":[]}`;
             callerId,
             key: `goal_completion_signal:${signal.goalId}`,
             scope: "GOAL_EVENT",
+            valueType: "JSON",
             jsonValue: {
               goalId: signal.goalId,
               goalName: matchingGoal.name,

--- a/apps/admin/lib/jobs/auto-trigger.ts
+++ b/apps/admin/lib/jobs/auto-trigger.ts
@@ -161,7 +161,7 @@ export async function checkAutoTriggerCurriculum(
           }
           break;
         }
-        if (task.status === "abandoned" || task.status === "failed") {
+        if (task.status === "abandoned") {
           console.error(
             `[auto-trigger] 🚨 task ${taskId} (subject ${subjectId}) ${task.status}. ` +
               `Blockers: ${JSON.stringify(task.blockers)}. ` +

--- a/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
+++ b/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
@@ -163,7 +163,7 @@ export async function syncAuthoredModulesToCurriculum(
     if (Array.isArray(m.outcomesPrimary) && m.outcomesPrimary.length > 0) {
       // #1117 — reject placeholder refs + intra-batch duplicates before any
       // DB write. Anchor-agnostic (CERTIFIED + UNCERTIFIED courses).
-      assertValidLoRefBatch(m.outcomesPrimary, m.slug);
+      assertValidLoRefBatch(m.outcomesPrimary, m.id);
       for (const [loIdx, ref] of m.outcomesPrimary.entries()) {
         const description = outcomes?.[ref] ?? ref;
         await tx.learningObjective.upsert({


### PR DESCRIPTION
## Summary

Follow-on to #1631. Drops another 11 tsc errors (46 → 35) — same shape as the previous PR: dead comparisons, missing required fields, removed schema names.

| File | Class | Fix |
|---|---|---|
| `lib/caller-utils.ts:108` | Dead comparison | `momentum !== "slowing"` after L102 already returns on slowing — dropped + comment |
| `lib/jobs/auto-trigger.ts:164` | Dead comparison | TaskStatus has no \`failed\` member — dropped the dead branch |
| `lib/wizard/sync-authored-modules-to-curriculum.ts:166` | Removed field | AuthoredModule has \`id\`/\`label\`, not \`slug\` — switched to \`m.id\` |
| `lib/domain/instant-curriculum.ts:161` | null vs optional | \`contentSpecId?: string\` rejected \`null\` — switched to \`undefined\` |
| `lib/demonstrate/suggest-goals.ts:69` | Field not selected | caller select picks \`{name, email}\`; reused \`callerId\` from closure |
| `lib/goals/extract-goals.ts:524` | Missing required field | CallerAttribute.create missing \`valueType\` discriminator — added \`"JSON"\` |
| `lib/curriculum/sync-modules.ts:121` | Missing required field | empty-modules early-return missing \`classification: null\` |
| `components/help/HelpOverlay.tsx:18` | Schema rename | ChatMode is now \`"ASSISTANT" \| "DEMO"\`, not DATA/TUNING — renamed keys |
| `components/playbook/PlaybookBuilder.tsx:1893` | Invalid enum | EditableTitle accepts \`"h1" \| "h2"\`, not \`"span"\` — switched to \`"h1"\` |
| `app/x/courses/page.tsx` | Type-narrowing | CourseCard \`plural\` prop widened to \`(k: string)\` rejected typed \`(k: TermKey)\` — narrowed prop to TermKey |

Net error count: 46 → 35 (-11).

## Verified by

- \`npx tsc --noEmit\` from worktree: targeted errors gone, no new regressions
- Pre-push hook passed (tsc + eslint on changed files)
- Each fix grounded in a citation (schema line, type-def line, or test of the actual narrowing) — no speculative casts

## Test plan

- [x] tsc clean on all targeted files
- [ ] Smoke: \`/x/courses\` page renders the card grid (CourseCard signature change)
- [ ] Smoke: Cmd+? help overlay shows ASSISTANT + DEMO sections
- [ ] Smoke: PlaybookBuilder shows h1 page-header instead of span (a11y improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)