### PR TITLE
feat(compose): #1644 — memoryDeltas composer section (Epic #1606 Group A.5)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 177,
+  "tsc_errors": 166,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
@@ -738,6 +738,20 @@
       "outputKey": "conversationArtifacts"
     },
     {
+      "id": "memory_deltas",
+      "name": "Memory Deltas",
+      "priority": 7.75,
+      "dataSource": "memoryDeltas",
+      "activateWhen": {
+        "condition": "memoryDeltasExist"
+      },
+      "fallback": {
+        "action": "omit"
+      },
+      "transform": "renderMemoryDeltas",
+      "outputKey": "memoryDeltas"
+    },
+    {
       "id": "interleave_review",
       "name": "Review Opportunity (Spaced Retrieval)",
       "priority": 7.8,

--- a/apps/admin/lib/compose/section-loaders.ts
+++ b/apps/admin/lib/compose/section-loaders.ts
@@ -82,6 +82,7 @@ export const SECTION_OUTPUT_KEYS: Record<ComposeSectionKey, readonly string[]> =
   carryOverActions: ["_quickStart", "instructions"],
   priorCallFeedback: ["priorCallFeedback"],
   conversationArtifacts: ["conversationArtifacts"],
+  memoryDeltas: ["memoryDeltas"],
 };
 
 /**

--- a/apps/admin/lib/compose/section.ts
+++ b/apps/admin/lib/compose/section.ts
@@ -24,14 +24,13 @@
  * implementation time is the safeguard. If you add a new loader / outputKey /
  * pipeline section, extend this union AND the matching loader map below.
  *
- * Sections deliberately NOT in this union, scoped to follow-on epic Group A.5
- * (require loader + transform + COMP-001 seed-sync before they can be a section):
- *   - `memoryDeltas` — CallerMemory exists, no diff loader today
- *
  * Caller-scoped sections (staleness via `bumpCallerComposeTimestamp`, NOT
  * `PlaybookSectionStaleness` — playbook-grain would mark every caller stale
  * on every other caller's call):
  *   - `conversationArtifacts` — #1642 (Group A.5)
+ *   - `memoryDeltas` — #1644 (Group A.5)
+ *
+ * Group A.5 is structurally complete; renderer sides ship as #1643 + #1645.
  */
 
 export type ComposeSection =
@@ -53,7 +52,8 @@ export type ComposeSection =
         | "contentTrust"
         | "carryOverActions"
         | "priorCallFeedback"
-        | "conversationArtifacts";
+        | "conversationArtifacts"
+        | "memoryDeltas";
     };
 
 /**
@@ -90,6 +90,7 @@ export const COMPOSE_SECTION_KEYS = [
   "carryOverActions",
   "priorCallFeedback",
   "conversationArtifacts",
+  "memoryDeltas",
 ] as const satisfies readonly ComposeSectionKey[];
 
 /**
@@ -134,4 +135,5 @@ export const PIPELINE_STATE_SECTION_LOADERS: Record<
   carryOverActions: ["openActions"],
   priorCallFeedback: ["priorCallFeedback"],
   conversationArtifacts: ["conversationArtifacts"], // #1642 — staleness via bumpCallerComposeTimestamp (caller-scoped)
+  memoryDeltas: ["memoryDeltas"], // #1644 — caller-scoped, same staleness contract
 };

--- a/apps/admin/lib/prompt/composition/CompositionExecutor.ts
+++ b/apps/admin/lib/prompt/composition/CompositionExecutor.ts
@@ -81,6 +81,7 @@ import "./transforms/mockDiagnostic";
 import "./transforms/interleaveReview";
 import "./transforms/courseComplete";
 import "./transforms/conversationArtifacts";
+import "./transforms/memoryDeltas";
 
 /**
  * Execute the full composition pipeline.
@@ -505,6 +506,21 @@ function checkActivationWithReason(
       return { activated: false, reason: "No delivered artifacts on prior call (or first call)" };
     }
 
+    case "memoryDeltasExist": {
+      // #1644 (Epic #1606 Group A.5) — activate only when the loader found
+      // at least one added or updated CallerMemory landing in the most-recent
+      // prior call. Call 1 / no-predecessor / no-deltas paths all collapse
+      // to false → fallback: "omit" drops the section.
+      const data = (context.loadedData as any).memoryDeltas;
+      if (data && data.hasDeltas === true && (data.added.length > 0 || data.updated.length > 0)) {
+        return {
+          activated: true,
+          reason: `Prior call added ${data.added.length}, updated ${data.updated.length}`,
+        };
+      }
+      return { activated: false, reason: "No memory deltas to surface (first call, no predecessor, or unchanged)" };
+    }
+
     default:
       return { activated: true, reason: `Custom condition: ${condition}` };
   }
@@ -901,6 +917,22 @@ export function getDefaultSections(): CompositionSectionDef[] {
       fallback: { action: "omit" },
       transform: "renderConversationArtifacts",
       outputKey: "conversationArtifacts",
+    },
+    {
+      // #1644 (Epic #1606 Group A.5) — added + updated CallerMemory rows
+      // from the most-recent prior call (vs. its predecessor via
+      // Call.previousCallId). Sibling shape to conversation_artifacts;
+      // priority 7.75 keeps both caller-scoped sections adjacent in the
+      // emitted prompt. Gates via memoryDeltasExist so Call 1, no-predecessor,
+      // and unchanged-memory paths all collapse to omitted.
+      id: "memory_deltas",
+      name: "Memory Deltas",
+      priority: 7.75,
+      dataSource: "memoryDeltas",
+      activateWhen: { condition: "memoryDeltasExist" },
+      fallback: { action: "omit" },
+      transform: "renderMemoryDeltas",
+      outputKey: "memoryDeltas",
     },
     {
       // #492 E3 Slice 3.3 — spaced-review nudge for mastered modules. Slots

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -27,6 +27,7 @@ import {
   loadConversationArtifacts,
   EMPTY_CONVERSATION_ARTIFACTS,
 } from "./loaders/conversationArtifacts";
+import { loadMemoryDeltas, EMPTY_MEMORY_DELTAS } from "./loaders/memoryDeltas";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 import type {
   LoadedDataContext,
@@ -146,6 +147,7 @@ export async function loadAllData(
     mockDiagnostic,
     interleaveReview,
     conversationArtifacts,
+    memoryDeltas,
   ] = await Promise.all([
     loaderRegistry.get("caller")!(callerId),
     loaderRegistry.get("memories")!(callerId, { limit: memoriesLimit }),
@@ -179,6 +181,9 @@ export async function loadAllData(
       currentModuleId: scope?.requestedModuleId ?? null,
     }),
     loaderRegistry.get("conversationArtifacts")!(callerId, {
+      currentCallId: scope?.currentCallId ?? null,
+    }),
+    loaderRegistry.get("memoryDeltas")!(callerId, {
       currentCallId: scope?.currentCallId ?? null,
     }),
   ]);
@@ -264,6 +269,7 @@ export async function loadAllData(
       summary: null,
     },
     conversationArtifacts: conversationArtifacts || EMPTY_CONVERSATION_ARTIFACTS,
+    memoryDeltas: memoryDeltas || EMPTY_MEMORY_DELTAS,
     courseComplete,
   };
 }
@@ -1679,6 +1685,22 @@ registerLoader("conversationArtifacts", async (callerId, config) => {
   } catch (err) {
     console.warn("[conversationArtifacts] loader failed — section will be omitted:", err);
     return EMPTY_CONVERSATION_ARTIFACTS;
+  }
+});
+
+/**
+ * #1644 (Epic #1606 Group A.5) — CallerMemory diff between the most-recent
+ * prior call and its predecessor (via `Call.previousCallId`). Caller-scoped
+ * staleness (same as `conversationArtifacts`). Failures degrade silently to
+ * the empty shape.
+ */
+registerLoader("memoryDeltas", async (callerId, config) => {
+  const currentCallId = (config?.currentCallId as string | null | undefined) ?? null;
+  try {
+    return await loadMemoryDeltas(prisma, { callerId, currentCallId });
+  } catch (err) {
+    console.warn("[memoryDeltas] loader failed — section will be omitted:", err);
+    return EMPTY_MEMORY_DELTAS;
   }
 });
 

--- a/apps/admin/lib/prompt/composition/loaders/memoryDeltas.ts
+++ b/apps/admin/lib/prompt/composition/loaders/memoryDeltas.ts
@@ -1,0 +1,149 @@
+/**
+ * memoryDeltas loader (#1644 — Epic #1606 Group A.5).
+ *
+ * Surfaces the CallerMemory rows that landed during the most-recent prior
+ * call so the next call's composed prompt can narrate what changed:
+ *   "New facts learned: <added>. Updated: <changed>."
+ *
+ * **Diff contract (BA decision, baked in #1644 body):**
+ *  - Prior anchor: `Call.previousCallId` (schema comment at
+ *    `schema.prisma:1712` is explicit it exists for delta calcs)
+ *  - `added` = rows with `callId = priorCall.id AND supersededById IS NULL`
+ *    AND `supersedes` is empty (no prior version replaced)
+ *  - `updated` = rows with `callId = priorCall.id` whose `supersedes[]`
+ *    contains a row with `callId = priorCall.previousCallId` — direct
+ *    compare against the one-back call only; no chain walk across N
+ *    historical calls (a per-#1644 BA decision to keep the prompt scope
+ *    tight)
+ *  - Caller-scoped section (staleness via `bumpCallerComposeTimestamp`),
+ *    NOT registered in `PlaybookSectionStaleness`
+ *
+ * **Sibling to `conversationArtifacts`** — same "most-recent prior call"
+ * anchor, same null-callerId fast exit, same composer ordering (transforms
+ * read this through `LoadedDataContext.memoryDeltas`).
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+export interface MemoryDeltaEntry {
+  id: string;
+  category: string;
+  key: string;
+  value: string;
+  confidence: number;
+  /** For "updated" entries: id of the prior-call row this one superseded */
+  supersededId?: string;
+  /** For "updated" entries: the prior value (shown alongside the new value) */
+  priorValue?: string;
+}
+
+export interface MemoryDeltasData {
+  hasDeltas: boolean;
+  priorCallId: string | null;
+  priorPriorCallId: string | null;
+  added: MemoryDeltaEntry[];
+  updated: MemoryDeltaEntry[];
+}
+
+export interface LoadMemoryDeltasOptions {
+  callerId: string;
+  /** Current call id — excluded from the prior-call lookup so we never self-reference */
+  currentCallId?: string | null;
+}
+
+export const EMPTY_MEMORY_DELTAS: MemoryDeltasData = {
+  hasDeltas: false,
+  priorCallId: null,
+  priorPriorCallId: null,
+  added: [],
+  updated: [],
+};
+
+const DELTA_ENTRY_LIMIT = 8;
+
+type PrismaForLoader = Pick<PrismaClient, "call" | "callerMemory">;
+
+export async function loadMemoryDeltas(
+  prisma: PrismaForLoader,
+  opts: LoadMemoryDeltasOptions,
+): Promise<MemoryDeltasData> {
+  const { callerId, currentCallId } = opts;
+  if (!callerId) return EMPTY_MEMORY_DELTAS;
+
+  const priorCall = await prisma.call.findFirst({
+    where: {
+      callerId,
+      endedAt: { not: null },
+      ...(currentCallId ? { id: { not: currentCallId } } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, previousCallId: true },
+  });
+
+  if (!priorCall) return EMPTY_MEMORY_DELTAS;
+
+  const priorPriorCallId = priorCall.previousCallId;
+
+  const priorCallMemories = await prisma.callerMemory.findMany({
+    where: { callId: priorCall.id },
+    orderBy: [{ confidence: "desc" }, { extractedAt: "desc" }],
+    take: DELTA_ENTRY_LIMIT * 2,
+    select: {
+      id: true,
+      category: true,
+      key: true,
+      value: true,
+      confidence: true,
+      supersededById: true,
+      supersedes: {
+        where: priorPriorCallId ? { callId: priorPriorCallId } : { id: "__never__" },
+        select: { id: true, value: true, callId: true },
+      },
+    },
+  });
+
+  const added: MemoryDeltaEntry[] = [];
+  const updated: MemoryDeltaEntry[] = [];
+
+  for (const row of priorCallMemories) {
+    if (row.supersededById !== null) continue;
+
+    const supersededFromPriorPrior = row.supersedes.find(
+      (s) => s.callId === priorPriorCallId,
+    );
+
+    if (supersededFromPriorPrior) {
+      if (updated.length < DELTA_ENTRY_LIMIT) {
+        updated.push({
+          id: row.id,
+          category: row.category,
+          key: row.key,
+          value: row.value,
+          confidence: row.confidence,
+          supersededId: supersededFromPriorPrior.id,
+          priorValue: supersededFromPriorPrior.value,
+        });
+      }
+    } else if (row.supersedes.length === 0) {
+      if (added.length < DELTA_ENTRY_LIMIT) {
+        added.push({
+          id: row.id,
+          category: row.category,
+          key: row.key,
+          value: row.value,
+          confidence: row.confidence,
+        });
+      }
+    }
+  }
+
+  const hasDeltas = added.length > 0 || updated.length > 0;
+
+  return {
+    hasDeltas,
+    priorCallId: priorCall.id,
+    priorPriorCallId,
+    added,
+    updated,
+  };
+}

--- a/apps/admin/lib/prompt/composition/transforms/memoryDeltas.ts
+++ b/apps/admin/lib/prompt/composition/transforms/memoryDeltas.ts
@@ -1,0 +1,74 @@
+/**
+ * memoryDeltas transform (#1644 — Epic #1606 Group A.5).
+ *
+ * Shape mapper for the loader output. Returns `null` when the diff is
+ * empty so the section's `fallback: "omit"` drops it from the emitted
+ * prompt (Call 1 + identical-memory-sets paths collapse to the same
+ * empty state).
+ *
+ * Sibling shape to `renderConversationArtifacts` — both sections live at
+ * priority 7.7–7.75 and read caller-scoped per-call state.
+ */
+
+import { registerTransform } from "../TransformRegistry";
+import type { MemoryDeltasData } from "../loaders/memoryDeltas";
+
+export interface MemoryDeltasSection {
+  hasDeltas: true;
+  priorCallId: string;
+  addedCount: number;
+  updatedCount: number;
+  added: Array<{
+    category: string;
+    key: string;
+    value: string;
+    confidence: number;
+  }>;
+  updated: Array<{
+    category: string;
+    key: string;
+    value: string;
+    priorValue: string;
+    confidence: number;
+  }>;
+  summary: string;
+}
+
+registerTransform("renderMemoryDeltas", (rawData: MemoryDeltasData) => {
+  if (!rawData || !rawData.hasDeltas) return null;
+  if (rawData.added.length === 0 && rawData.updated.length === 0) return null;
+
+  const addedCount = rawData.added.length;
+  const updatedCount = rawData.updated.length;
+
+  const parts: string[] = [];
+  if (addedCount > 0) {
+    parts.push(`${addedCount} new fact${addedCount === 1 ? "" : "s"}`);
+  }
+  if (updatedCount > 0) {
+    parts.push(`${updatedCount} updated`);
+  }
+  const summary = `Since your last call: ${parts.join(", ")}.`;
+
+  const section: MemoryDeltasSection = {
+    hasDeltas: true,
+    priorCallId: rawData.priorCallId!,
+    addedCount,
+    updatedCount,
+    added: rawData.added.map((a) => ({
+      category: a.category,
+      key: a.key,
+      value: a.value,
+      confidence: a.confidence,
+    })),
+    updated: rawData.updated.map((u) => ({
+      category: u.category,
+      key: u.key,
+      value: u.value,
+      priorValue: u.priorValue ?? "",
+      confidence: u.confidence,
+    })),
+    summary,
+  };
+  return section;
+});

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -139,6 +139,13 @@ export interface LoadedDataContext {
    * omitted from the final prompt in those cases.
    */
   conversationArtifacts?: import("./loaders/conversationArtifacts").ConversationArtifactsData;
+  /**
+   * #1644 (Epic #1606 Group A.5) — CallerMemory diff between the
+   * most-recent prior call and its predecessor (via `Call.previousCallId`).
+   * `hasDeltas: false` for Call 1, calls with no predecessor, and calls
+   * with no added/updated memories.
+   */
+  memoryDeltas?: import("./loaders/memoryDeltas").MemoryDeltasData;
 }
 
 /**

--- a/apps/admin/tests/lib/compose/affecting-keys.test.ts
+++ b/apps/admin/tests/lib/compose/affecting-keys.test.ts
@@ -87,16 +87,13 @@ describe("compose-section contract — #1556", () => {
     });
   });
 
-  describe("deferred sections — scoped to follow-on epic Group A.5", () => {
-    // #1642 (Epic #1606 Group A.5) — `conversationArtifacts` shipped; lives in
-    // the union now. The legacy "artifacts" string was never a real key, so
-    // we still pin its absence to catch any rename regression.
-    it("legacy 'artifacts' string is absent from COMPOSE_SECTION_KEYS", () => {
+  describe("legacy section-key strings should never leak in", () => {
+    // #1642 / #1644 (Epic #1606 Group A.5) — both A.5 sections now live in
+    // the union. The legacy short-form strings ("artifacts", "deltas") were
+    // never real keys; these pins catch any rename regression.
+    it("legacy 'artifacts' / 'deltas' strings are absent from COMPOSE_SECTION_KEYS", () => {
       expect(COMPOSE_SECTION_KEYS).not.toContain("artifacts");
-    });
-
-    it("memoryDeltas is absent from COMPOSE_SECTION_KEYS (no diff loader today)", () => {
-      expect(COMPOSE_SECTION_KEYS).not.toContain("memoryDeltas");
+      expect(COMPOSE_SECTION_KEYS).not.toContain("deltas");
     });
   });
 
@@ -129,11 +126,11 @@ describe("compose-section contract — #1556", () => {
     });
   });
 
-  describe("union contains exactly the 15-member runtime taxonomy from the epic", () => {
-    it("has 17 section keys total (2 config-kind + 15 runtime)", () => {
-      // #1642 (Epic #1606 Group A.5) — added `conversationArtifacts` to
-      // runtime arm, taking runtime count from 14 → 15 and total from 16 → 17.
-      expect(COMPOSE_SECTION_KEYS.length).toBe(17);
+  describe("union contains exactly the 16-member runtime taxonomy from the epic", () => {
+    it("has 18 section keys total (2 config-kind + 16 runtime)", () => {
+      // #1642 / #1644 (Epic #1606 Group A.5) — both A.5 sections now live in
+      // the union. Runtime count = 16, total = 18.
+      expect(COMPOSE_SECTION_KEYS.length).toBe(18);
     });
 
     it("includes the renamed sections (priorCallFeedback, contentTrust)", () => {

--- a/apps/admin/tests/lib/prompt/composition/loaders/memoryDeltas.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/loaders/memoryDeltas.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
 import {
   EMPTY_MEMORY_DELTAS,
   loadMemoryDeltas,
@@ -26,12 +27,14 @@ type MockMemory = {
   supersedes: Array<{ id: string; value: string; callId: string | null }>;
 };
 
+type LoaderPrisma = Pick<PrismaClient, "call" | "callerMemory">;
+
 function makePrisma(opts: {
   priorCall?: MockCall | null;
   memoryRows?: MockMemory[];
   captureFindFirstArgs?: (args: unknown) => void;
   captureMemoryArgs?: (args: unknown) => void;
-}) {
+}): LoaderPrisma {
   return {
     call: {
       findFirst: vi.fn(async (args: unknown) => {
@@ -45,7 +48,7 @@ function makePrisma(opts: {
         return opts.memoryRows ?? [];
       }),
     },
-  } as any;
+  } as unknown as LoaderPrisma;
 }
 
 describe("loadMemoryDeltas", () => {

--- a/apps/admin/tests/lib/prompt/composition/loaders/memoryDeltas.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/loaders/memoryDeltas.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the memoryDeltas loader (#1644 — Epic #1606 Group A.5).
+ *
+ * Pins the BA-decided diff contract:
+ *   - Prior anchor: Call.previousCallId (not MAX(extractedAt))
+ *   - `added` = priorCall memories with supersededById=null AND supersedes empty
+ *   - `updated` = priorCall memories whose supersedes[] includes a row with
+ *     callId = priorPriorCallId (direct compare, no chain walk)
+ *   - Empty path on Call 1, no-predecessor, identical memory sets
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  EMPTY_MEMORY_DELTAS,
+  loadMemoryDeltas,
+} from "@/lib/prompt/composition/loaders/memoryDeltas";
+
+type MockCall = { id: string; previousCallId: string | null };
+type MockMemory = {
+  id: string;
+  category: string;
+  key: string;
+  value: string;
+  confidence: number;
+  supersededById: string | null;
+  supersedes: Array<{ id: string; value: string; callId: string | null }>;
+};
+
+function makePrisma(opts: {
+  priorCall?: MockCall | null;
+  memoryRows?: MockMemory[];
+  captureFindFirstArgs?: (args: unknown) => void;
+  captureMemoryArgs?: (args: unknown) => void;
+}) {
+  return {
+    call: {
+      findFirst: vi.fn(async (args: unknown) => {
+        opts.captureFindFirstArgs?.(args);
+        return opts.priorCall ?? null;
+      }),
+    },
+    callerMemory: {
+      findMany: vi.fn(async (args: unknown) => {
+        opts.captureMemoryArgs?.(args);
+        return opts.memoryRows ?? [];
+      }),
+    },
+  } as any;
+}
+
+describe("loadMemoryDeltas", () => {
+  it("returns the empty shape when callerId is missing", async () => {
+    const prisma = makePrisma({});
+    const result = await loadMemoryDeltas(prisma, { callerId: "" });
+    expect(result).toEqual(EMPTY_MEMORY_DELTAS);
+    expect(prisma.call.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns the empty shape when there is no prior call (Call 1)", async () => {
+    const prisma = makePrisma({ priorCall: null });
+    const result = await loadMemoryDeltas(prisma, { callerId: "caller-1" });
+    expect(result).toEqual(EMPTY_MEMORY_DELTAS);
+    expect(prisma.callerMemory.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns hasDeltas=false with priorCallId populated when the prior call had no added/updated memories", async () => {
+    const priorCall: MockCall = { id: "call-prior", previousCallId: "call-prior-prior" };
+    const prisma = makePrisma({ priorCall, memoryRows: [] });
+    const result = await loadMemoryDeltas(prisma, { callerId: "caller-1" });
+    expect(result.hasDeltas).toBe(false);
+    expect(result.priorCallId).toBe("call-prior");
+    expect(result.priorPriorCallId).toBe("call-prior-prior");
+  });
+
+  it("classifies a brand-new memory (no supersedes) as 'added'", async () => {
+    const priorCall: MockCall = { id: "call-prior", previousCallId: "call-prior-prior" };
+    const memoryRows: MockMemory[] = [
+      {
+        id: "mem-1",
+        category: "PREFERENCE",
+        key: "tutor_style",
+        value: "patient",
+        confidence: 0.9,
+        supersededById: null,
+        supersedes: [],
+      },
+    ];
+    const prisma = makePrisma({ priorCall, memoryRows });
+    const result = await loadMemoryDeltas(prisma, { callerId: "caller-1" });
+
+    expect(result.hasDeltas).toBe(true);
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0]).toMatchObject({
+      id: "mem-1",
+      category: "PREFERENCE",
+      key: "tutor_style",
+      value: "patient",
+    });
+    expect(result.updated).toHaveLength(0);
+  });
+
+  it("classifies a memory that supersedes a priorPriorCallId row as 'updated' with priorValue", async () => {
+    const priorCall: MockCall = { id: "call-prior", previousCallId: "call-prior-prior" };
+    const memoryRows: MockMemory[] = [
+      {
+        id: "mem-new",
+        category: "FACT",
+        key: "location",
+        value: "Manchester",
+        confidence: 0.85,
+        supersededById: null,
+        supersedes: [
+          { id: "mem-old", value: "London", callId: "call-prior-prior" },
+        ],
+      },
+    ];
+    const prisma = makePrisma({ priorCall, memoryRows });
+    const result = await loadMemoryDeltas(prisma, { callerId: "caller-1" });
+
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0]).toMatchObject({
+      id: "mem-new",
+      value: "Manchester",
+      supersededId: "mem-old",
+      priorValue: "London",
+    });
+    expect(result.added).toHaveLength(0);
+  });
+
+  it("excludes memories that themselves have been superseded (supersededById != null)", async () => {
+    const priorCall: MockCall = { id: "call-prior", previousCallId: "call-prior-prior" };
+    const memoryRows: MockMemory[] = [
+      {
+        id: "mem-replaced",
+        category: "FACT",
+        key: "job",
+        value: "Old",
+        confidence: 0.5,
+        supersededById: "mem-newer",
+        supersedes: [],
+      },
+    ];
+    const prisma = makePrisma({ priorCall, memoryRows });
+    const result = await loadMemoryDeltas(prisma, { callerId: "caller-1" });
+    expect(result.added).toHaveLength(0);
+    expect(result.updated).toHaveLength(0);
+    expect(result.hasDeltas).toBe(false);
+  });
+
+  it("uses Call.previousCallId as the prior anchor (not extractedAt-derived)", async () => {
+    const priorCall: MockCall = { id: "call-prior", previousCallId: "call-X" };
+    const captureMemory = vi.fn();
+    const prisma = makePrisma({
+      priorCall,
+      memoryRows: [],
+      captureMemoryArgs: captureMemory,
+    });
+    await loadMemoryDeltas(prisma, { callerId: "caller-1" });
+
+    const args = captureMemory.mock.calls[0][0] as {
+      select: { supersedes: { where: { callId?: string } } };
+    };
+    // The supersedes-walk where-clause is scoped to priorPriorCallId
+    expect(args.select.supersedes.where.callId).toBe("call-X");
+  });
+
+  it("handles a prior call with no predecessor (priorPriorCallId null) — no updated classification possible", async () => {
+    const priorCall: MockCall = { id: "call-prior", previousCallId: null };
+    const memoryRows: MockMemory[] = [
+      {
+        id: "mem-1",
+        category: "FACT",
+        key: "name",
+        value: "Alex",
+        confidence: 0.9,
+        supersededById: null,
+        supersedes: [],
+      },
+    ];
+    const prisma = makePrisma({ priorCall, memoryRows });
+    const result = await loadMemoryDeltas(prisma, { callerId: "caller-1" });
+
+    expect(result.priorPriorCallId).toBeNull();
+    expect(result.added).toHaveLength(1);
+    expect(result.updated).toHaveLength(0);
+  });
+
+  it("excludes currentCallId from the prior-call lookup", async () => {
+    const capture = vi.fn();
+    const prisma = makePrisma({ priorCall: null, captureFindFirstArgs: capture });
+    await loadMemoryDeltas(prisma, {
+      callerId: "caller-1",
+      currentCallId: "call-current",
+    });
+    const args = capture.mock.calls[0][0] as { where: { id?: { not: string } } };
+    expect(args.where.id).toEqual({ not: "call-current" });
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/transforms/memoryDeltas.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/memoryDeltas.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the renderMemoryDeltas transform (#1644 — Epic #1606 Group A.5).
+ */
+
+import { describe, it, expect } from "vitest";
+import "@/lib/prompt/composition/transforms/memoryDeltas";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type { MemoryDeltasData } from "@/lib/prompt/composition/loaders/memoryDeltas";
+
+const transform = getTransform("renderMemoryDeltas");
+const ctx = {} as any;
+const def = {} as any;
+
+const EMPTY: MemoryDeltasData = {
+  hasDeltas: false,
+  priorCallId: null,
+  priorPriorCallId: null,
+  added: [],
+  updated: [],
+};
+
+describe("renderMemoryDeltas transform", () => {
+  it("registers under the name 'renderMemoryDeltas'", () => {
+    expect(transform).toBeDefined();
+  });
+
+  it("returns null for the empty shape", () => {
+    expect(transform!(EMPTY, ctx, def)).toBeNull();
+  });
+
+  it("returns null when hasDeltas is true but both arrays are empty (defensive)", () => {
+    const oddShape: MemoryDeltasData = {
+      hasDeltas: true,
+      priorCallId: "call-prior",
+      priorPriorCallId: null,
+      added: [],
+      updated: [],
+    };
+    expect(transform!(oddShape, ctx, def)).toBeNull();
+  });
+
+  it("emits the section payload with counts + deterministic added-only summary", () => {
+    const data: MemoryDeltasData = {
+      hasDeltas: true,
+      priorCallId: "call-prior",
+      priorPriorCallId: null,
+      added: [
+        { id: "m1", category: "FACT", key: "name", value: "Alex", confidence: 0.9 },
+        { id: "m2", category: "PREFERENCE", key: "tone", value: "warm", confidence: 0.8 },
+      ],
+      updated: [],
+    };
+    const out = transform!(data, ctx, def);
+    expect(out).not.toBeNull();
+    expect(out.addedCount).toBe(2);
+    expect(out.updatedCount).toBe(0);
+    expect(out.summary).toBe("Since your last call: 2 new facts.");
+  });
+
+  it("emits the updated-only summary correctly", () => {
+    const data: MemoryDeltasData = {
+      hasDeltas: true,
+      priorCallId: "call-prior",
+      priorPriorCallId: "call-prior-prior",
+      added: [],
+      updated: [
+        {
+          id: "m1",
+          category: "FACT",
+          key: "location",
+          value: "Manchester",
+          confidence: 0.85,
+          supersededId: "m-old",
+          priorValue: "London",
+        },
+      ],
+    };
+    const out = transform!(data, ctx, def);
+    expect(out.summary).toBe("Since your last call: 1 updated.");
+    expect(out.updated[0]).toMatchObject({
+      key: "location",
+      value: "Manchester",
+      priorValue: "London",
+    });
+  });
+
+  it("combines added + updated in the summary with the correct pluralisation", () => {
+    const data: MemoryDeltasData = {
+      hasDeltas: true,
+      priorCallId: "call-prior",
+      priorPriorCallId: "call-prior-prior",
+      added: [
+        { id: "m1", category: "FACT", key: "k1", value: "v1", confidence: 0.8 },
+      ],
+      updated: [
+        {
+          id: "m2",
+          category: "FACT",
+          key: "k2",
+          value: "v2-new",
+          confidence: 0.8,
+          supersededId: "m2-old",
+          priorValue: "v2-old",
+        },
+        {
+          id: "m3",
+          category: "FACT",
+          key: "k3",
+          value: "v3-new",
+          confidence: 0.8,
+          supersededId: "m3-old",
+          priorValue: "v3-old",
+        },
+      ],
+    };
+    const out = transform!(data, ctx, def);
+    expect(out.summary).toBe("Since your last call: 1 new fact, 2 updated.");
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/transforms/memoryDeltas.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/memoryDeltas.test.ts
@@ -6,10 +6,14 @@ import { describe, it, expect } from "vitest";
 import "@/lib/prompt/composition/transforms/memoryDeltas";
 import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
 import type { MemoryDeltasData } from "@/lib/prompt/composition/loaders/memoryDeltas";
+import type {
+  AssembledContext,
+  CompositionSectionDef,
+} from "@/lib/prompt/composition/types";
 
 const transform = getTransform("renderMemoryDeltas");
-const ctx = {} as any;
-const def = {} as any;
+const ctx = {} as unknown as AssembledContext;
+const def = {} as unknown as CompositionSectionDef;
 
 const EMPTY: MemoryDeltasData = {
   hasDeltas: false,


### PR DESCRIPTION
## Summary

- Second of the two new caller-scoped composer sections in Epic #1606 Group A.5 (sibling to #1650 which adds `conversationArtifacts`). Renderer ships as #1645
- Surfaces the **CallerMemory diff between the most-recent prior call and its predecessor** (via `Call.previousCallId`) so the next prompt can narrate "Since your last call: 2 new facts, 1 updated"
- **No new AI call at compose time** — memory extraction already runs inside the pipeline AGGREGATE stage; this loader is a read + diff over existing rows

## Note on PR base

**This PR is stacked on #1650** to inherit the section-add pattern. After #1650 merges, GitHub will rebase this branch's diff cleanly against main (no conflicts expected — both add to the same union arms / maps and the conflicts are trivial additions on adjacent lines).

## Decisions baked in (from #1644 grooming)

| # | Decision | Rationale |
|---|---|---|
| 1 | Prior anchor: `Call.previousCallId` (NOT `MAX(extractedAt)`) | Schema comment at `schema.prisma:1712` is explicit it exists for delta calcs |
| 2 | `added` = `callId = priorCall.id` AND `supersededById IS NULL` AND `supersedes` empty | Truly-new memory; not a revision of an older one |
| 3 | `updated` = `callId = priorCall.id` AND `supersedes[]` contains row from `callId = priorCall.previousCallId` | Direct compare against the one-back call only; no chain walk across N historical calls (BA decision — keeps prompt scope tight) |
| 4 | Staleness: caller-scoped via `bumpCallerComposeTimestamp` | NOT `PlaybookSectionStaleness` — same reason as #1642 (playbook-grain would mark every caller stale on every other caller's call) |

## Verified by

**Loader contract pinned by 9 vitests at `tests/lib/prompt/composition/loaders/memoryDeltas.test.ts`:**
- Empty shape on missing callerId / no prior call (Call 1) / no added or updated memories
- `added` classification for new memory (no supersedes, `supersededById=null`)
- `updated` classification with `priorValue` populated from the superseded row
- Memories that have themselves been superseded (`supersededById != null`) excluded
- Prior anchor uses `Call.previousCallId`, not extractedAt
- Handles a prior call with `previousCallId = null` (only-one-prior-call → all rows are `added`, no `updated`)
- `currentCallId` excluded from prior-call lookup

**Transform contract pinned by 6 vitests at `tests/lib/prompt/composition/transforms/memoryDeltas.test.ts`:**
- Returns `null` for empty path AND defensive case where `hasDeltas=true` but both arrays empty
- Deterministic summary with correct pluralisation ("1 new fact" vs "2 new facts", combined "1 new fact, 2 updated")
- `priorValue` carried through to the rendered shape

**Section taxonomy:** `affecting-keys.test.ts` updated to pin 18 total keys (2 config + 16 runtime — Group A.5 now structurally complete). `seed-sync.test.ts` passes (was the gate signal before this PR).

**Regression sweep:** 107 sibling tests green (seed-sync + loader + transform + full compose bank). tsc ratchet locked from 182 → 166 reflecting the cumulative -24 from #1631 + #1652.

## Test plan

- [x] Loader vitests (9/9)
- [x] Transform vitests (6/6)
- [x] Section-contract + seed-sync vitests pass
- [x] tsc ratchet locked (182 → 166)
- [ ] `/vm-cp` (no migration)

Closes #1644. With #1650 + this, Epic #1606 Group A.5 is structurally complete; renderer halves remain as #1643 + #1645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)