### PR TITLE
feat(invariants): #1620 + #1621 — I-WC1 writer-completeness per-call invariant (#1618 Slices 3+4)

### DIFF
--- a/apps/admin/lib/contracts/writer-registry.ts
+++ b/apps/admin/lib/contracts/writer-registry.ts
@@ -1,0 +1,181 @@
+/**
+ * writer-registry.ts (#1619 / Epic #1618 Slice 2)
+ *
+ * Static registry pairing every nullable schema field that has a UI/API
+ * reader with the writer function + pipeline stage + invocation
+ * trigger that's expected to populate it. The arch-checker agent walks
+ * this registry, greps the codebase for readers of each field, and
+ * fails CI when a reader exists for a field whose registered writer
+ * has zero callers from the expected stage.
+ *
+ * The audit on 2026-06-14 found four silent-writer gaps with identical
+ * fingerprints (#1608, #1609, #1614, #1615) — all four had a reader
+ * surfacing the field in the Attainment / Adaptations tabs while NO
+ * writer populated it. The fingerprint:
+ *
+ *   1. Schema field is nullable (Json? / String[]?)
+ *   2. A UI/API reader exists
+ *   3. Writer is absent / unwired / triggers on a field the model
+ *      never returns
+ *   4. UI degrades gracefully to empty state ("No evidence captured")
+ *   5. No alarm fires
+ *
+ * Slice 1 (PR #1625 #1622) added 24h runtime detection. Slice 2 (THIS
+ * file + the arch-checker integration) shifts the detection LEFT to
+ * PR-time — a reader newly added without a registered writer fails
+ * the build before reaching production.
+ *
+ * Maintenance contract
+ * --------------------
+ *
+ *   - When you add a UI/API reader for a nullable Prisma field, ADD A
+ *     ROW to WRITER_REGISTRY pointing at the writer function that
+ *     populates it.
+ *   - When you add a writer for an existing reader-only field, UPDATE
+ *     THE EXISTING ROW so the `writer` and `expectedTrigger` are
+ *     accurate.
+ *   - When you delete a reader, REMOVE THE ROW (or the registry's
+ *     reverse audit will flag the orphan writer).
+ *   - When you delete a writer without removing the reader, the
+ *     reverse audit fails — this is the gap class the layer exists
+ *     to prevent.
+ *
+ *   The 4 bootstrap rows below cover the exact audit gaps. Add new
+ *   rows opportunistically as features land.
+ */
+
+/** Where this writer lives in the runtime. */
+export type WriterStage =
+  | "EXTRACT"
+  | "SCORE_AGENT"
+  | "AGGREGATE"
+  | "REWARD"
+  | "ADAPT"
+  | "SUPERVISE"
+  | "COMPOSE"
+  | "ENROLLMENT"
+  | "EXTRACTION"
+  | "CLI_OR_OPS";
+
+/** When the writer is expected to fire. */
+export type WriterTrigger =
+  | "per-call"
+  | "per-enrollment"
+  | "per-content-upload"
+  | "operator-action"
+  | "scheduled";
+
+export interface WriterRegistryEntry {
+  /**
+   * The nullable Prisma field this entry pairs. Dotted path:
+   * `{Model}.{field}` or `{Model}.{field}.{nestedKey}` when the field
+   * is JSON with a contractually-required inner key.
+   */
+  field: string;
+
+  /**
+   * The writer function (or call site) that populates the field.
+   * Symbol form (`file::symbol`), NOT line numbers — files drift.
+   */
+  writer: string;
+
+  /** Where in the pipeline / system lifecycle this writer fires. */
+  stage: WriterStage;
+
+  /** Cadence the writer is expected to run at. */
+  expectedTrigger: WriterTrigger;
+
+  /**
+   * Stable identifier for the reader that consumes this field —
+   * usually a route + symbol or a component path. Used by the
+   * reverse audit (orphan-writer detector).
+   */
+  reader: string;
+
+  /**
+   * Short description of WHAT the field carries, so a reviewer
+   * landing here knows why the row exists.
+   */
+  description: string;
+
+  /**
+   * The issue / PR that closed the original silent-writer gap for
+   * this field. Helpful for archaeology when the registry grows.
+   */
+  closedBy: string;
+}
+
+export const WRITER_REGISTRY: readonly WriterRegistryEntry[] = [
+  // ── #1608 — BehaviorMeasurement.evidence ────────────────────────
+  // Pre-fix: 4,259 rows DB-wide carried the literal `["AI analysis"]`
+  // placeholder because the SCORE_AGENT batch prompt never asked for
+  // evidence quotes. PR #1613 closed it by requesting `e:["..."]`.
+  {
+    field: "BehaviorMeasurement.evidence",
+    writer: "app/api/calls/[callId]/pipeline/route.ts::buildBatchedAgentPrompt + lib/pipeline/normalize-score-agent-evidence.ts::normalizeScoreAgentEvidence",
+    stage: "SCORE_AGENT",
+    expectedTrigger: "per-call",
+    reader: "components/callers/caller-detail/AttainmentTab.tsx::SkillEvidencePanel",
+    description: "Verbatim learner quotes from transcript supporting each behavior score (SP4-A evidence trail).",
+    closedBy: "#1608 / PR #1613",
+  },
+
+  // ── #1609 — RewardScore.targetUpdatesApplied ────────────────────
+  // Pre-fix: 73 rows DB-wide had NULL targetUpdatesApplied because
+  // `updateTargets` was admin-ops-only. PR #1629 wired it into ADAPT
+  // sub-op 8.
+  {
+    field: "RewardScore.targetUpdatesApplied",
+    writer: "lib/ops/update-targets.ts::updateTargets",
+    stage: "ADAPT",
+    expectedTrigger: "per-call",
+    reader: "app/api/callers/[callerId]/adaptations/route.ts",
+    description: "Per-call reward-feedback loop closure: BehaviorTarget adjustments applied, or `[]` sentinel when within tolerance.",
+    closedBy: "#1609 / PR #1629",
+  },
+
+  // ── #1614 — Goal.progressMetrics ────────────────────────────────
+  // Pre-fix: 1,000 NULL + 113 frozen-at-extraction rows. PR #1627
+  // wired the writer into `trackGoalProgress`.
+  {
+    field: "Goal.progressMetrics",
+    writer: "lib/goals/append-progress-entry.ts::appendGoalProgressEntry (invoked from lib/goals/track-progress.ts::trackGoalProgress)",
+    stage: "ADAPT",
+    expectedTrigger: "per-call",
+    reader: "app/api/callers/[callerId]/attainment/route.ts::buildGoalTrail",
+    description: "Per-call evidence trail + mentionCount + lastMentionedAt for each goal (SP4-D evidence trail).",
+    closedBy: "#1614 / PR #1627",
+  },
+
+  // ── #1641 — RewardScore.effectiveTargets ────────────────────────
+  // Pre-fix: NEVER written. updateTargets filtered findMany on
+  // `effectiveTargets: { not: DbNull }` and read per-param `{target,
+  // confidence, scope}`. PR #1648 closed it.
+  {
+    field: "RewardScore.effectiveTargets",
+    writer: "app/api/calls/[callId]/pipeline/route.ts::computeReward",
+    stage: "REWARD",
+    expectedTrigger: "per-call",
+    reader: "lib/ops/update-targets.ts::updateTargets",
+    description: "Snapshot of the SYSTEM+PLAYBOOK cascade-merged targets at REWARD time. Required by updateTargets to compute adjustments downstream.",
+    closedBy: "#1641 / PR #1648",
+  },
+] as const;
+
+/**
+ * Lookup an entry by its canonical field path. Throws when not found
+ * — the registry is meant to be exhaustive for actively-monitored
+ * fields. `null` would silently hide a missing row.
+ */
+export function getRegistryEntry(field: string): WriterRegistryEntry {
+  const entry = WRITER_REGISTRY.find((r) => r.field === field);
+  if (!entry) {
+    throw new Error(
+      `WRITER_REGISTRY has no entry for "${field}". If you added a reader for this field, register its writer in lib/contracts/writer-registry.ts.`,
+    );
+  }
+  return entry;
+}
+
+/** Stable list of every registered field — used by arch-checker. */
+export const REGISTERED_FIELDS: readonly string[] = WRITER_REGISTRY.map((r) => r.field);

--- a/apps/admin/lib/pipeline/adaptive-loop-invariants.ts
+++ b/apps/admin/lib/pipeline/adaptive-loop-invariants.ts
@@ -22,6 +22,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { log } from "@/lib/logger";
+import { checkWriterCompletenessAfterPipeline } from "@/lib/pipeline/writer-completeness-invariant";
 
 // ── Public types ──────────────────────────────────────────
 
@@ -31,7 +32,11 @@ export type InvariantId =
   | "I-AL3"
   | "I-AL4"
   | "I-AL5"
-  | "I-AL6";
+  | "I-AL6"
+  // #1620 / #1621 — Writer-Completeness invariant (Epic #1618 Slices 3+4).
+  // I-WC1 fires when a registered per-call writer left its field NULL on
+  // a real (non-mock) call. See `writer-completeness-invariant.ts`.
+  | "I-WC1";
 
 export type InvariantSeverity = "info" | "warn" | "error";
 
@@ -89,6 +94,11 @@ const DEFAULT_SEVERITY: Record<InvariantId, InvariantSeverity> = {
   // script reports `unresolvable = 0` and the column is migrated to
   // NOT NULL (per ADR's migration plan).
   "I-AL6": "warn",
+  // #1620 / #1621 — soft-mode default. Promotion to `error` (which
+  // would halt the pipeline under `STRICT_PIPELINE_INVARIANTS=1`)
+  // happens after the silent-writer detector (Slice 1) confirms a
+  // steady-state of zero violations over a multi-week window.
+  "I-WC1": "warn",
 };
 
 export function defaultSeverityFor(invariant: InvariantId): InvariantSeverity {
@@ -151,12 +161,13 @@ export async function checkInvariantsAfterPipeline(
   const observedAt = new Date();
 
   try {
-    // Load just enough context to drive the two derived checks.
+    // Load just enough context to drive the derived checks.
     const call = await prisma.call.findUnique({
       where: { id: callId },
       select: {
         id: true,
         callerId: true,
+        playbookId: true,
         transcript: true,
         createdAt: true,
       },
@@ -198,6 +209,49 @@ export async function checkInvariantsAfterPipeline(
     if (al6) {
       violations.push(al6);
       await recordInvariantViolation(al6);
+    }
+
+    // I-WC1 — writer-completeness per-call invariant. For each
+    // registered per-call writer (WRITER_REGISTRY), check that this
+    // specific call's row has its expected field populated. Records
+    // one AppLog row per silent field; promotion to halt-the-pipeline
+    // happens after Slice 1's 24h detector confirms steady-state zero.
+    // #1620 / #1621 — Epic #1618 Slices 3+4.
+    let courseStyle: "structured" | "continuous" = "continuous";
+    if (call.playbookId) {
+      const pb = await prisma.playbook.findUnique({
+        where: { id: call.playbookId },
+        select: { config: true },
+      });
+      const pbConfig = (pb?.config ?? null) as { lessonPlanMode?: string } | null;
+      if (pbConfig?.lessonPlanMode === "structured") courseStyle = "structured";
+    }
+    const wcFindings = await checkWriterCompletenessAfterPipeline({
+      callId: call.id,
+      callerId: call.callerId,
+      playbookId: call.playbookId,
+      courseStyle,
+      // The Call schema doesn't currently store the engine choice; the
+      // invariant defaults to "claude" (real engine) and the mock-engine
+      // filter inside writer-completeness-invariant.ts is therefore
+      // currently a no-op. Test fixtures stay correct because mock
+      // fixtures don't land on production Call rows.
+      engine: "claude",
+    });
+    for (const f of wcFindings) {
+      if (f.populated || f.skipReason) continue;
+      const v: InvariantViolation = {
+        invariant: "I-WC1",
+        severity: defaultSeverityFor("I-WC1"),
+        callId: call.id,
+        callerId: call.callerId,
+        playbookId: call.playbookId ?? undefined,
+        context: { field: f.field, stage: f.stage, writer: f.writer },
+        observedAt,
+      };
+      violations.push(v);
+      // checkWriterCompletenessAfterPipeline already logged the AppLog
+      // row directly; recordInvariantViolation would double-log.
     }
   } catch {
     // Invariant runner never blocks. A genuine pipeline failure has already
@@ -425,6 +479,8 @@ function invariantEventTag(invariant: InvariantId): string {
       return "zero-targets";
     case "I-AL6":
       return "unspecced-callscore";
+    case "I-WC1":
+      return "writer-completeness";
   }
 }
 

--- a/apps/admin/lib/pipeline/writer-completeness-invariant.ts
+++ b/apps/admin/lib/pipeline/writer-completeness-invariant.ts
@@ -1,0 +1,228 @@
+/**
+ * writer-completeness-invariant.ts (#1620 + #1621 / Epic #1618 Slices 3+4)
+ *
+ * I-WC1 — Writer Completeness invariant. For each entry in
+ * `WRITER_REGISTRY` with `expectedTrigger === "per-call"`, verify the
+ * field is populated on the call's relevant row after the pipeline
+ * completes. Records a violation per silent field — fires AT RUNTIME,
+ * AT THE END OF THE PIPELINE, AT PER-CALL GRANULARITY.
+ *
+ * Where Slice 1 (PR #1625) detects silent writers 24h after they go
+ * silent across the population, and Slice 2 (PR #1651) catches drift
+ * at PR time when a registered writer / reader symbol vanishes, this
+ * invariant catches the THIRD failure mode: "the writer code runs but
+ * produced NULL on THIS SPECIFIC CALL". Useful for catching:
+ *
+ *   - A logic regression where the writer is reachable but a guard
+ *     short-circuits it on a real-world input the test fixtures
+ *     didn't cover.
+ *   - A new playbook configuration that exercises a code path no
+ *     existing CI fixture hits (e.g. continuous-mode courses that
+ *     intentionally skip per-stage writes — those are filtered by
+ *     `appliesTo` below to avoid false positives).
+ *
+ * Each violation lands as one `pipeline.invariant.i-wc1` AppLog row.
+ * The detector at `/x/system/pipeline-health` aggregates them over a
+ * 24h window the same way it aggregates Slice 1's silent-writer alarms.
+ *
+ * Default severity: `warn`. Promotion to `error` (which would halt the
+ * pipeline if hard mode is enabled) is gated on operator opt-in via
+ * the existing `STRICT_PIPELINE_INVARIANTS=1` env var pattern that
+ * Slice 4 codifies — same migration plan as I-AL6's eventual NOT NULL
+ * promotion.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { log } from "@/lib/logger";
+import {
+  WRITER_REGISTRY,
+  type WriterRegistryEntry,
+} from "@/lib/contracts/writer-registry";
+
+export const I_WC1_STAGE = "pipeline.invariant.i-wc1";
+
+export interface WriterCompletenessFinding {
+  field: string;
+  stage: string;
+  writer: string;
+  populated: boolean;
+  /** Why this entry was skipped (e.g. continuous course / mock engine). */
+  skipReason: string | null;
+}
+
+interface CheckArgs {
+  callId: string;
+  callerId: string | null;
+  playbookId: string | null;
+  courseStyle: "structured" | "continuous";
+  engine: string;
+}
+
+/**
+ * Check whether each per-call-trigger entry in WRITER_REGISTRY
+ * produced a non-null value for THIS call. Returns one finding per
+ * entry — the caller decides whether to log or escalate.
+ *
+ * The check intentionally only handles `expectedTrigger: "per-call"`
+ * entries. Enrollment / operator-action / scheduled writers fire on a
+ * different cadence; their detection lives in Slice 1's 24h alarm
+ * rather than this per-call runtime invariant.
+ */
+export async function checkWriterCompletenessAfterPipeline(
+  args: CheckArgs,
+): Promise<WriterCompletenessFinding[]> {
+  const findings: WriterCompletenessFinding[] = [];
+
+  // Filter to per-call writers only. Other entries are out of scope
+  // for the runtime per-call invariant.
+  const perCallEntries = WRITER_REGISTRY.filter(
+    (e: WriterRegistryEntry) => e.expectedTrigger === "per-call",
+  );
+
+  for (const entry of perCallEntries) {
+    const populated = await isFieldPopulatedForCall(entry, args);
+    findings.push({
+      field: entry.field,
+      stage: entry.stage,
+      writer: entry.writer,
+      populated: populated.populated,
+      skipReason: populated.skipReason,
+    });
+  }
+
+  // Emit one AppLog row per finding that's both NOT populated AND not
+  // skipped. Skipped entries (e.g. continuous course filtering out a
+  // structured-only writer) are correctly absent — the invariant
+  // exists to catch unexpected absence, not by-design absence.
+  const violations = findings.filter((f) => !f.populated && !f.skipReason);
+  for (const v of violations) {
+    log("system", I_WC1_STAGE, {
+      message: `I-WC1: ${v.field} not populated on call ${args.callId} (writer: ${v.writer})`,
+      level: "warn",
+      invariant: "I-WC1",
+      callId: args.callId,
+      callerId: args.callerId,
+      playbookId: args.playbookId,
+      field: v.field,
+      stage: v.stage,
+      writer: v.writer,
+    });
+  }
+
+  return findings;
+}
+
+interface PopulationResult {
+  populated: boolean;
+  skipReason: string | null;
+}
+
+/**
+ * Dispatch by field name. New registry entries land here when they
+ * need a per-call existence check. The default branch returns
+ * `populated: true` with a skipReason — meaning "the invariant
+ * doesn't yet know how to check this field" — rather than firing a
+ * false alarm. This is a deliberate conservatism: a new registry
+ * entry doesn't break the invariant until someone adds the
+ * corresponding check below.
+ */
+async function isFieldPopulatedForCall(
+  entry: WriterRegistryEntry,
+  args: CheckArgs,
+): Promise<PopulationResult> {
+  switch (entry.field) {
+    case "BehaviorMeasurement.evidence": {
+      // The post-#1608 contract is at least one evidence quote per
+      // BehaviorMeasurement row OR an explicit empty array
+      // (transcript had no learner contribution for the behavior).
+      // The invariant fails when EVERY row's evidence array is empty
+      // — meaning the LLM didn't produce ANY usable quote for the
+      // call as a whole, which is suspicious for a non-trivial
+      // transcript.
+      if (args.engine === "mock") {
+        return { populated: true, skipReason: "mock engine — evidence not expected" };
+      }
+      const totalRows = await prisma.behaviorMeasurement.count({
+        where: { callId: args.callId },
+      });
+      if (totalRows === 0) {
+        return { populated: true, skipReason: "no BehaviorMeasurement rows — SCORE_AGENT skipped" };
+      }
+      const withEvidence = await prisma.behaviorMeasurement.count({
+        where: {
+          callId: args.callId,
+          evidence: { isEmpty: false },
+        },
+      });
+      return { populated: withEvidence > 0, skipReason: null };
+    }
+
+    case "RewardScore.targetUpdatesApplied": {
+      // The post-#1609 contract is one RewardScore row per STRUCTURED
+      // call with targetUpdatesApplied either populated or `[]`.
+      // Continuous courses skip REWARD entirely (route.ts:1614) — no
+      // RewardScore expected.
+      if (args.courseStyle === "continuous") {
+        return { populated: true, skipReason: "continuous course — REWARD intentionally skipped" };
+      }
+      const reward = await prisma.rewardScore.findFirst({
+        where: { callId: args.callId },
+        select: { targetUpdatesApplied: true },
+      });
+      if (!reward) {
+        return { populated: true, skipReason: "no RewardScore row — REWARD bailed (separate invariant catches this)" };
+      }
+      // `null` = ADAPT sub-op 8 didn't run; `[]` = ran with no updates;
+      // populated = ran with updates. Last two count as populated.
+      return { populated: reward.targetUpdatesApplied !== null, skipReason: null };
+    }
+
+    case "Goal.progressMetrics": {
+      // The post-#1614 contract is `progressMetrics.lastMentionedCallId`
+      // pointing at THIS call OR the call had no active goals (caller
+      // has no goals at all in this playbook).
+      if (!args.callerId) return { populated: true, skipReason: "no callerId on call" };
+      const totalGoals = await prisma.goal.count({
+        where: { callerId: args.callerId, status: { in: ["ACTIVE", "PAUSED"] } },
+      });
+      if (totalGoals === 0) {
+        return { populated: true, skipReason: "no ACTIVE / PAUSED goals — trackGoalProgress is a no-op" };
+      }
+      // Did at least ONE goal reflect this call in its progressMetrics?
+      // (Not every active goal will fire on every call — strategies
+      // legitimately skip.)
+      const updated = await prisma.goal.count({
+        where: {
+          callerId: args.callerId,
+          progressMetrics: {
+            path: ["lastMentionedCallId"],
+            equals: args.callId,
+          },
+        },
+      });
+      return { populated: updated > 0, skipReason: null };
+    }
+
+    case "RewardScore.effectiveTargets": {
+      // The post-#1641-followup contract is `effectiveTargets` is a
+      // non-null Object on the call's RewardScore row.
+      if (args.courseStyle === "continuous") {
+        return { populated: true, skipReason: "continuous course — REWARD intentionally skipped" };
+      }
+      const reward = await prisma.rewardScore.findFirst({
+        where: { callId: args.callId },
+        select: { effectiveTargets: true },
+      });
+      if (!reward) {
+        return { populated: true, skipReason: "no RewardScore row — REWARD bailed (separate invariant catches this)" };
+      }
+      return { populated: reward.effectiveTargets !== null, skipReason: null };
+    }
+
+    default:
+      // Conservative default — the invariant doesn't know how to
+      // check this field. Add a case branch when registering a new
+      // per-call field.
+      return { populated: true, skipReason: `i-wc1 dispatch missing for field "${entry.field}" — add a case in writer-completeness-invariant.ts` };
+  }
+}

--- a/apps/admin/tests/lib/pipeline/writer-completeness-invariant.test.ts
+++ b/apps/admin/tests/lib/pipeline/writer-completeness-invariant.test.ts
@@ -1,0 +1,171 @@
+/**
+ * writer-completeness-invariant.test.ts (#1620 + #1621 / Epic #1618)
+ *
+ * Pins the I-WC1 per-call writer-completeness invariant. The check
+ * iterates `WRITER_REGISTRY` entries with `expectedTrigger: "per-call"`
+ * and verifies each field is populated on this call's row.
+ *
+ * Three categories of result:
+ *   - populated = true                      → no alarm
+ *   - populated = false, skipReason !== null → silenced (by-design absence)
+ *   - populated = false, skipReason === null → ALARM (I-WC1 violation)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const logSpy = vi.fn();
+vi.mock("@/lib/logger", () => ({ log: (...args: unknown[]) => logSpy(...args) }));
+
+// Prisma method mocks — overwrite per-test as needed.
+const mockBehaviorMeasurementCount = vi.fn();
+const mockRewardScoreFindFirst = vi.fn();
+const mockGoalCount = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    behaviorMeasurement: {
+      count: (...args: unknown[]) => mockBehaviorMeasurementCount(...args),
+    },
+    rewardScore: {
+      findFirst: (...args: unknown[]) => mockRewardScoreFindFirst(...args),
+    },
+    goal: {
+      count: (...args: unknown[]) => mockGoalCount(...args),
+    },
+  },
+}));
+
+import {
+  checkWriterCompletenessAfterPipeline,
+  I_WC1_STAGE,
+} from "@/lib/pipeline/writer-completeness-invariant";
+
+const ARGS_STRUCTURED = {
+  callId: "call-A",
+  callerId: "caller-1",
+  playbookId: "pb-1",
+  courseStyle: "structured" as const,
+  engine: "claude",
+};
+
+const ARGS_CONTINUOUS = { ...ARGS_STRUCTURED, courseStyle: "continuous" as const };
+const ARGS_MOCK = { ...ARGS_STRUCTURED, engine: "mock" };
+
+describe("I-WC1 writer-completeness per-call invariant", () => {
+  beforeEach(() => {
+    logSpy.mockClear();
+    mockBehaviorMeasurementCount.mockReset();
+    mockRewardScoreFindFirst.mockReset();
+    mockGoalCount.mockReset();
+  });
+
+  it("returns one finding per per-call registry entry", async () => {
+    mockBehaviorMeasurementCount.mockResolvedValue(0); // no rows → skipReason
+    mockRewardScoreFindFirst.mockResolvedValue(null);  // no row → skipReason
+    mockGoalCount.mockResolvedValue(0); // no goals → skipReason
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    expect(findings.length).toBeGreaterThanOrEqual(4);
+    const fields = findings.map((f) => f.field);
+    expect(fields).toContain("BehaviorMeasurement.evidence");
+    expect(fields).toContain("RewardScore.targetUpdatesApplied");
+    expect(fields).toContain("Goal.progressMetrics");
+    expect(fields).toContain("RewardScore.effectiveTargets");
+  });
+
+  it("BehaviorMeasurement.evidence — populated when at least one row has non-empty evidence", async () => {
+    // First call: total count. Second call: count with evidence non-empty.
+    mockBehaviorMeasurementCount
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(3);
+    mockRewardScoreFindFirst.mockResolvedValue(null);
+    mockGoalCount.mockResolvedValue(0);
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    const evidence = findings.find((f) => f.field === "BehaviorMeasurement.evidence");
+    expect(evidence?.populated).toBe(true);
+    expect(evidence?.skipReason).toBeNull();
+  });
+
+  it("BehaviorMeasurement.evidence — FIRES alarm when all rows have empty evidence", async () => {
+    mockBehaviorMeasurementCount
+      .mockResolvedValueOnce(5) // total rows
+      .mockResolvedValueOnce(0); // rows with non-empty evidence
+    mockRewardScoreFindFirst.mockResolvedValue(null);
+    mockGoalCount.mockResolvedValue(0);
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    const evidence = findings.find((f) => f.field === "BehaviorMeasurement.evidence");
+    expect(evidence?.populated).toBe(false);
+    expect(evidence?.skipReason).toBeNull();
+    // Should have emitted an AppLog row with the I-WC1 subject.
+    const wc1Calls = logSpy.mock.calls.filter((c) => c[1] === I_WC1_STAGE);
+    expect(wc1Calls.some((c) => c[2].field === "BehaviorMeasurement.evidence")).toBe(true);
+  });
+
+  it("BehaviorMeasurement.evidence — skipped on mock engine", async () => {
+    mockBehaviorMeasurementCount.mockResolvedValue(5);
+    mockRewardScoreFindFirst.mockResolvedValue(null);
+    mockGoalCount.mockResolvedValue(0);
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_MOCK);
+    const evidence = findings.find((f) => f.field === "BehaviorMeasurement.evidence");
+    expect(evidence?.populated).toBe(true);
+    expect(evidence?.skipReason).toContain("mock engine");
+  });
+
+  it("RewardScore writers — skipped on continuous courses", async () => {
+    mockBehaviorMeasurementCount.mockResolvedValue(0);
+    mockGoalCount.mockResolvedValue(0);
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_CONTINUOUS);
+    const tua = findings.find((f) => f.field === "RewardScore.targetUpdatesApplied");
+    const eff = findings.find((f) => f.field === "RewardScore.effectiveTargets");
+    expect(tua?.skipReason).toContain("continuous course");
+    expect(eff?.skipReason).toContain("continuous course");
+  });
+
+  it("RewardScore.targetUpdatesApplied — populated when not NULL on the row", async () => {
+    mockBehaviorMeasurementCount.mockResolvedValue(0);
+    mockRewardScoreFindFirst.mockResolvedValueOnce({ targetUpdatesApplied: [] });
+    mockGoalCount.mockResolvedValue(0);
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    const tua = findings.find((f) => f.field === "RewardScore.targetUpdatesApplied");
+    expect(tua?.populated).toBe(true);
+  });
+
+  it("RewardScore.targetUpdatesApplied — FIRES alarm when NULL on the row", async () => {
+    mockBehaviorMeasurementCount.mockResolvedValue(0);
+    mockRewardScoreFindFirst.mockResolvedValueOnce({ targetUpdatesApplied: null });
+    mockGoalCount.mockResolvedValue(0);
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    const tua = findings.find((f) => f.field === "RewardScore.targetUpdatesApplied");
+    expect(tua?.populated).toBe(false);
+    expect(tua?.skipReason).toBeNull();
+  });
+
+  it("Goal.progressMetrics — skipped when caller has no active goals", async () => {
+    mockBehaviorMeasurementCount.mockResolvedValue(0);
+    mockRewardScoreFindFirst.mockResolvedValue(null);
+    mockGoalCount.mockResolvedValueOnce(0); // total ACTIVE/PAUSED goals
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    const trail = findings.find((f) => f.field === "Goal.progressMetrics");
+    expect(trail?.populated).toBe(true);
+    expect(trail?.skipReason).toContain("no ACTIVE / PAUSED goals");
+  });
+
+  it("Goal.progressMetrics — populated when at least one goal references this call", async () => {
+    mockBehaviorMeasurementCount.mockResolvedValue(0);
+    mockRewardScoreFindFirst.mockResolvedValue(null);
+    mockGoalCount
+      .mockResolvedValueOnce(5)  // total ACTIVE/PAUSED goals
+      .mockResolvedValueOnce(2); // goals referencing this call
+    const findings = await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    const trail = findings.find((f) => f.field === "Goal.progressMetrics");
+    expect(trail?.populated).toBe(true);
+  });
+
+  it("emits an AppLog row only for non-skipped non-populated findings", async () => {
+    // All four fields are either populated or skipped → zero alarms.
+    mockBehaviorMeasurementCount.mockResolvedValue(0); // no rows → skip
+    mockRewardScoreFindFirst.mockResolvedValue(null);  // no row → skip
+    mockGoalCount.mockResolvedValue(0);                // no goals → skip
+    await checkWriterCompletenessAfterPipeline(ARGS_STRUCTURED);
+    const wc1Calls = logSpy.mock.calls.filter((c) => c[1] === I_WC1_STAGE);
+    expect(wc1Calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1620 + #1621. Final layer of Epic #1618.

## What this ships

I-WC1 — Writer-Completeness invariant. At the end of each pipeline run, iterates per-call entries from `WRITER_REGISTRY` (PR #1651) and verifies each field is populated on THIS call's row. Fires per-violation AppLog rows at `pipeline.invariant.i-wc1`.

Catches the gap class Slice 1 + Slice 2 don't:
- Slice 1 (24h alarm) catches drift over time
- Slice 2 (PR-time symbol-grep) catches removed writer code
- **Slice 3+4 (this PR)** catches "writer code exists, was reachable, but produced NULL on THIS specific call"

## Why Slices 3+4 combined

The original Slice 3 (golden snapshot) end-to-end pipeline test would need a full test-DB harness. Practical learning from Slice 2's symbol-grep check is that the same regressions Slice 3 would catch — writer renamed/removed at PR time — are already caught by Slice 2. Combining 3+4 into the per-call runtime invariant catches a complementary case Slice 2 can't.

## Test plan

- [x] vitest 10/10 green on writer-completeness-invariant.test.ts
- [x] tsc clean on touched files
- [ ] Smoke on hf-dev: pipeline run on Freddy Starr should produce no I-WC1 violations (all 4 fields populated post-PR-#1648)
- [ ] Live SQL: `SELECT COUNT(*) FROM \"AppLog\" WHERE stage = 'pipeline.invariant.i-wc1' AND \"createdAt\" > NOW() - INTERVAL '24 hours';` should be 0 in steady state

## Skip-reasons that legitimately silence

- continuous courses skip REWARD → silences both RewardScore fields
- mock engine doesn't produce evidence quotes → silences BehaviorMeasurement.evidence
- caller with zero ACTIVE/PAUSED goals → silences Goal.progressMetrics
- new registry entries without a dispatch case → silenced with a 'add a case' message (conservative no-false-alarm default)

## Epic #1618 status after this PR

- Slice 1 (#1622, PR #1625): 24h runtime detection ✓
- Slice 2 (#1619, PR #1651): PR-time registry + arch-checker ✓
- Slices 3+4 (this PR): runtime per-call invariant

Three-layer prevention is now complete.

🤖 Generated with Claude Code