### PR TITLE
feat(renderers): #1643 — ConversationArtifactsRenderer Inspector card (Epic #1606 Group A.5)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 182,
+  "tsc_errors": 177,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/app/api/courses/[courseId]/conversation-artifacts-preview/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/conversation-artifacts-preview/route.ts
@@ -1,0 +1,82 @@
+/**
+ * @api GET /api/courses/[courseId]/conversation-artifacts-preview
+ *
+ * Inspector preview of the `conversationArtifacts` composer section
+ * (#1643 — Epic #1606 Group A.5). Caller-scoped section, so the route
+ * picks a representative learner from the course — the most-recent
+ * active CallerPlaybook enrollment — and runs the loader shipped in
+ * #1642 against their state.
+ *
+ * Auth: OPERATOR+. Read-only. Returns the empty shape when the course
+ * has no enrolled learners yet.
+ */
+
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  loadConversationArtifacts,
+  type ConversationArtifactsData,
+} from "@/lib/prompt/composition/loaders/conversationArtifacts";
+
+interface ConversationArtifactsPreviewResponse {
+  ok: boolean;
+  previewCallerName: string | null;
+  data: ConversationArtifactsData;
+}
+
+const EMPTY_DATA: ConversationArtifactsData = {
+  hasArtifacts: false,
+  lastCallId: null,
+  lastCallAt: null,
+  artifacts: [],
+};
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse<ConversationArtifactsPreviewResponse>> {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) {
+    return auth.error as NextResponse<ConversationArtifactsPreviewResponse>;
+  }
+  const { courseId } = await context.params;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    select: { id: true },
+  });
+  if (!playbook) {
+    return NextResponse.json(
+      { ok: false, previewCallerName: null, data: EMPTY_DATA },
+      { status: 404 },
+    );
+  }
+
+  const enrollment = await prisma.callerPlaybook.findFirst({
+    where: { playbookId: courseId, status: "ACTIVE" },
+    orderBy: { startedAt: "desc" },
+    select: {
+      caller: { select: { id: true, name: true } },
+    },
+  });
+
+  if (!enrollment?.caller) {
+    return NextResponse.json({
+      ok: true,
+      previewCallerName: null,
+      data: EMPTY_DATA,
+    });
+  }
+
+  const data = await loadConversationArtifacts(prisma, {
+    callerId: enrollment.caller.id,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    previewCallerName: enrollment.caller.name ?? null,
+    data,
+  });
+}

--- a/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/shared/designer-shell";
 import "@/components/shared/preview-renderers";
 import type {
+  ConversationArtifactsRendererData,
   FreshnessWarning,
   GoalType,
   SessionFlowData,
@@ -67,6 +68,7 @@ function resolveRendererData(
   pbConfig: PlaybookConfig,
   sessionFlow: SessionFlowData | null,
   contentTrust: ContentTrustData | null,
+  conversationArtifacts: ConversationArtifactsRendererData | null,
   goalTypesInUse: GoalType[] | undefined,
 ): unknown {
   if (selectedKey === "firstCallMode") {
@@ -86,6 +88,17 @@ function resolveRendererData(
   if (selectedKey === "contentTrust") {
     return contentTrust ?? { warnings: [], sourceCount: 0 };
   }
+  if (selectedKey === "conversationArtifacts") {
+    return (
+      conversationArtifacts ?? {
+        loading: true,
+        hasArtifacts: false,
+        lastCallId: null,
+        lastCallAt: null,
+        artifacts: [],
+      }
+    );
+  }
   if (SESSION_FLOW_SECTIONS.has(selectedKey)) {
     return { sessionFlow };
   }
@@ -98,6 +111,8 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
   const [contentTrust, setContentTrust] = useState<ContentTrustData | null>(
     null,
   );
+  const [conversationArtifacts, setConversationArtifacts] =
+    useState<ConversationArtifactsRendererData | null>(null);
   const pbConfig = useMemo(
     () => (playbookConfig ?? {}) as PlaybookConfig,
     [playbookConfig],
@@ -114,6 +129,7 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
   const modePolicySelected = selectedKey === "modePolicy";
   const instructionsSelected = selectedKey === "instructions";
   const contentTrustSelected = selectedKey === "contentTrust";
+  const conversationArtifactsSelected = selectedKey === "conversationArtifacts";
 
   // A.4: Goal types currently in use on this course. The playbook config
   // doesn't carry this directly today — read it from session-flow OR
@@ -157,6 +173,43 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
     };
   }, [courseId]);
 
+  // #1643 (A.5): conversation-artifacts preview. Caller-scoped data
+  // sampled from the course's most-recent active enrollment. The
+  // renderer handles loading + null-caller + empty + populated states.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/conversation-artifacts-preview`)
+      .then((res) => res.json())
+      .then(
+        (j: {
+          ok: boolean;
+          previewCallerName: string | null;
+          data: {
+            hasArtifacts: boolean;
+            lastCallId: string | null;
+            lastCallAt: string | null;
+            artifacts: ConversationArtifactsRendererData["artifacts"];
+          };
+        }) => {
+          if (!cancelled && j.ok) {
+            setConversationArtifacts({
+              loading: false,
+              previewCallerName: j.previewCallerName,
+              hasArtifacts: j.data.hasArtifacts,
+              lastCallId: j.data.lastCallId,
+              lastCallAt: j.data.lastCallAt,
+              totalCount: j.data.artifacts.length,
+              artifacts: j.data.artifacts,
+            });
+          }
+        },
+      )
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
   const inspectorNode = useMemo(() => {
     if (!selectedKey) return null;
     const renderer = getPreviewRenderer(selectedKey);
@@ -167,11 +220,19 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
         pbConfig,
         sessionFlow,
         contentTrust,
+        conversationArtifacts,
         goalTypesInUse,
       ),
       selection: { selectedKey },
     });
-  }, [selectedKey, pbConfig, sessionFlow, contentTrust, goalTypesInUse]);
+  }, [
+    selectedKey,
+    pbConfig,
+    sessionFlow,
+    contentTrust,
+    conversationArtifacts,
+    goalTypesInUse,
+  ]);
 
   const onSelectSection = useCallback(
     (section: ComposeSectionKey | null) => {
@@ -232,6 +293,25 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
               : `${contentTrust.warnings.length} warning${
                   contentTrust.warnings.length === 1 ? "" : "s"
                 }`}
+      </button>
+      <button
+        type="button"
+        className={`hf-chip ${conversationArtifactsSelected ? "hf-chip-selected" : ""}`}
+        aria-pressed={conversationArtifactsSelected}
+        onClick={() =>
+          setSelectedKey(
+            conversationArtifactsSelected ? null : "conversationArtifacts",
+          )
+        }
+      >
+        <span className="hf-category-label">Artifacts:</span>{" "}
+        {conversationArtifacts === null
+          ? "loading…"
+          : conversationArtifacts.previewCallerName === null
+            ? "no learners"
+            : !conversationArtifacts.hasArtifacts
+              ? "none from last call"
+              : `${conversationArtifacts.totalCount ?? conversationArtifacts.artifacts.length} from last call`}
       </button>
     </div>
   );

--- a/apps/admin/components/shared/preview-renderers/ConversationArtifactsRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/ConversationArtifactsRenderer.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * ConversationArtifactsRenderer — #1643 (Epic #1606 Group A.5).
+ *
+ * Inspector card for the `conversationArtifacts` composer section
+ * (loader + transform shipped in #1642). Surfaces the
+ * DELIVERED/READ artifacts the AI emitted after the most-recent prior
+ * call so the educator can see what's about to be referenced in the
+ * next composed prompt.
+ *
+ * Data shape mirrors the `renderConversationArtifacts` transform output
+ * + an extra `loading` discriminant so the DesignTab can render a
+ * "loading…" state while the preview route fetches.
+ *
+ * Empty states:
+ *  - `loading: true` → muted "Loading recent artifacts…" placeholder
+ *  - `hasArtifacts: false` AND no prior call yet → muted
+ *    "No prior call on this course yet — Call 1 path"
+ *  - `hasArtifacts: false` AND prior call had zero DELIVERED → muted
+ *    "Last call shared no artifacts" with the call timestamp
+ *  - `hasArtifacts: true` → totalCount summary + per-artifact list with
+ *    type/title/snippet
+ */
+
+import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
+import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+
+export interface ConversationArtifactsRendererArtifact {
+  id: string;
+  type: string;
+  title: string;
+  snippet: string;
+  confidence: number;
+  deliveredAt: string | null;
+}
+
+export interface ConversationArtifactsRendererData {
+  loading?: boolean;
+  /** Caller chosen for preview ("most-recent active learner on this course"). Null when no callers enrolled yet. */
+  previewCallerName?: string | null;
+  hasArtifacts: boolean;
+  lastCallId: string | null;
+  lastCallAt: string | null;
+  totalCount?: number;
+  artifacts: ConversationArtifactsRendererArtifact[];
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(ms / (1000 * 60 * 60 * 24));
+  if (days < 1) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days} days ago`;
+  if (days < 30) return `${Math.floor(days / 7)} weeks ago`;
+  return `${Math.floor(days / 30)} months ago`;
+}
+
+export function ConversationArtifactsRenderer({
+  data,
+}: PreviewRendererProps<ConversationArtifactsRendererData>) {
+  if (data.loading) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Conversation artifacts</div>
+        <span className="hf-badge hf-badge-muted">
+          Loading recent artifacts…
+        </span>
+      </div>
+    );
+  }
+
+  if (data.previewCallerName === null) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Conversation artifacts</div>
+        <span className="hf-badge hf-badge-muted">
+          No learners enrolled yet
+        </span>
+      </div>
+    );
+  }
+
+  const callerPrefix = data.previewCallerName
+    ? ` (${data.previewCallerName})`
+    : "";
+
+  if (!data.hasArtifacts) {
+    const lastCallRelative = data.lastCallAt ? formatRelative(data.lastCallAt) : "";
+    if (!data.lastCallId) {
+      return (
+        <div className="hf-card-compact">
+          <div className="hf-category-label">
+            Conversation artifacts{callerPrefix}
+          </div>
+          <span className="hf-badge hf-badge-muted">
+            No prior call yet — Call 1 path
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">
+          Conversation artifacts{callerPrefix}
+        </div>
+        <span className="hf-badge hf-badge-muted">
+          Last call ({lastCallRelative}) shared no artifacts
+        </span>
+      </div>
+    );
+  }
+
+  const totalCount = data.totalCount ?? data.artifacts.length;
+  const lastCallRelative = data.lastCallAt ? formatRelative(data.lastCallAt) : "";
+
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-category-label">
+        Conversation artifacts{callerPrefix} — {totalCount} from{" "}
+        {lastCallRelative || "last call"}
+      </div>
+      <ol className="hf-list-row">
+        {data.artifacts.map((a) => (
+          <li key={a.id}>
+            <span className="hf-badge hf-badge-info">{a.type}</span>{" "}
+            <strong>{a.title}</strong>
+            <div className="hf-text-sm hf-text-muted">{a.snippet}</div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+registerPreviewRenderer<"conversationArtifacts", ConversationArtifactsRendererData>(
+  "conversationArtifacts",
+  ConversationArtifactsRenderer,
+);

--- a/apps/admin/components/shared/preview-renderers/index.ts
+++ b/apps/admin/components/shared/preview-renderers/index.ts
@@ -43,4 +43,10 @@ export type {
   FreshnessWarning,
 } from "./ContentTrustRenderer";
 
+export { ConversationArtifactsRenderer } from "./ConversationArtifactsRenderer";
+export type {
+  ConversationArtifactsRendererData,
+  ConversationArtifactsRendererArtifact,
+} from "./ConversationArtifactsRenderer";
+
 export type { SessionFlowData } from "./types";

--- a/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json
@@ -724,6 +724,20 @@
       "dependsOn": ["curriculum"]
     },
     {
+      "id": "conversation_artifacts",
+      "name": "Conversation Artifacts",
+      "priority": 7.7,
+      "dataSource": "conversationArtifacts",
+      "activateWhen": {
+        "condition": "conversationArtifactsExists"
+      },
+      "fallback": {
+        "action": "omit"
+      },
+      "transform": "renderConversationArtifacts",
+      "outputKey": "conversationArtifacts"
+    },
+    {
       "id": "interleave_review",
       "name": "Review Opportunity (Spaced Retrieval)",
       "priority": 7.8,

--- a/apps/admin/lib/compose/section-loaders.ts
+++ b/apps/admin/lib/compose/section-loaders.ts
@@ -81,6 +81,7 @@ export const SECTION_OUTPUT_KEYS: Record<ComposeSectionKey, readonly string[]> =
   contentTrust: ["contentTrust"],
   carryOverActions: ["_quickStart", "instructions"],
   priorCallFeedback: ["priorCallFeedback"],
+  conversationArtifacts: ["conversationArtifacts"],
 };
 
 /**

--- a/apps/admin/lib/compose/section.ts
+++ b/apps/admin/lib/compose/section.ts
@@ -26,8 +26,12 @@
  *
  * Sections deliberately NOT in this union, scoped to follow-on epic Group A.5
  * (require loader + transform + COMP-001 seed-sync before they can be a section):
- *   - `conversationArtifacts` — ConversationArtifact table exists, no loader/transform today
  *   - `memoryDeltas` — CallerMemory exists, no diff loader today
+ *
+ * Caller-scoped sections (staleness via `bumpCallerComposeTimestamp`, NOT
+ * `PlaybookSectionStaleness` — playbook-grain would mark every caller stale
+ * on every other caller's call):
+ *   - `conversationArtifacts` — #1642 (Group A.5)
  */
 
 export type ComposeSection =
@@ -48,7 +52,8 @@ export type ComposeSection =
         | "personality"
         | "contentTrust"
         | "carryOverActions"
-        | "priorCallFeedback";
+        | "priorCallFeedback"
+        | "conversationArtifacts";
     };
 
 /**
@@ -84,6 +89,7 @@ export const COMPOSE_SECTION_KEYS = [
   "contentTrust",
   "carryOverActions",
   "priorCallFeedback",
+  "conversationArtifacts",
 ] as const satisfies readonly ComposeSectionKey[];
 
 /**
@@ -127,4 +133,5 @@ export const PIPELINE_STATE_SECTION_LOADERS: Record<
   contentTrust: ["subjectSources"], // checkFreshness runs at compose time via transforms/trust.ts
   carryOverActions: ["openActions"],
   priorCallFeedback: ["priorCallFeedback"],
+  conversationArtifacts: ["conversationArtifacts"], // #1642 — staleness via bumpCallerComposeTimestamp (caller-scoped)
 };

--- a/apps/admin/lib/prompt/composition/CompositionExecutor.ts
+++ b/apps/admin/lib/prompt/composition/CompositionExecutor.ts
@@ -80,6 +80,7 @@ import "./transforms/priorCallFeedback";
 import "./transforms/mockDiagnostic";
 import "./transforms/interleaveReview";
 import "./transforms/courseComplete";
+import "./transforms/conversationArtifacts";
 
 /**
  * Execute the full composition pipeline.
@@ -489,6 +490,21 @@ function checkActivationWithReason(
       return { activated: false, reason: "Course not yet complete" };
     }
 
+    case "conversationArtifactsExists": {
+      // #1642 (Epic #1606 Group A.5) — activate only when the loader found
+      // at least one DELIVERED/READ artifact on the most-recent prior call.
+      // Call 1 path and zero-DELIVERED path collapse into the same false
+      // verdict; fallback.action: "omit" drops the section entirely.
+      const data = (context.loadedData as any).conversationArtifacts;
+      if (data && data.hasArtifacts === true && Array.isArray(data.artifacts) && data.artifacts.length > 0) {
+        return {
+          activated: true,
+          reason: `Prior call has ${data.artifacts.length} delivered artifact${data.artifacts.length === 1 ? "" : "s"}`,
+        };
+      }
+      return { activated: false, reason: "No delivered artifacts on prior call (or first call)" };
+    }
+
     default:
       return { activated: true, reason: `Custom condition: ${condition}` };
   }
@@ -866,6 +882,25 @@ export function getDefaultSections(): CompositionSectionDef[] {
       transform: "renderMockDiagnostic",
       outputKey: "mockDiagnostic",
       dependsOn: ["curriculum"],
+    },
+    {
+      // #1642 (Epic #1606 Group A.5) — quote-worthy artifacts the AI already
+      // delivered after the most-recent prior call. Slots between
+      // mock_diagnostic (7.6) and interleave_review (7.8) so the tutor's
+      // "what happened last time on this module" → "what the Mock showed" →
+      // "what we shared after the last call" narrative flows naturally.
+      // activateWhen=conversationArtifactsExists gates on
+      // loadedData.conversationArtifacts.hasArtifacts === true so the
+      // section is OMITTED on Call 1 and on calls with no DELIVERED/READ
+      // artifacts on the prior call.
+      id: "conversation_artifacts",
+      name: "Conversation Artifacts",
+      priority: 7.7,
+      dataSource: "conversationArtifacts",
+      activateWhen: { condition: "conversationArtifactsExists" },
+      fallback: { action: "omit" },
+      transform: "renderConversationArtifacts",
+      outputKey: "conversationArtifacts",
     },
     {
       // #492 E3 Slice 3.3 — spaced-review nudge for mastered modules. Slots

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -23,6 +23,10 @@ import { loadPriorCallFeedback } from "./loaders/priorCallFeedback";
 import { loadMockDiagnostic } from "./loaders/mockDiagnostic";
 import { loadInterleaveReview } from "./loaders/interleaveReview";
 import { loadCourseComplete } from "./loaders/courseComplete";
+import {
+  loadConversationArtifacts,
+  EMPTY_CONVERSATION_ARTIFACTS,
+} from "./loaders/conversationArtifacts";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 import type {
   LoadedDataContext,
@@ -141,6 +145,7 @@ export async function loadAllData(
     priorCallFeedback,
     mockDiagnostic,
     interleaveReview,
+    conversationArtifacts,
   ] = await Promise.all([
     loaderRegistry.get("caller")!(callerId),
     loaderRegistry.get("memories")!(callerId, { limit: memoriesLimit }),
@@ -172,6 +177,9 @@ export async function loadAllData(
     }),
     loaderRegistry.get("interleaveReview")!(callerId, {
       currentModuleId: scope?.requestedModuleId ?? null,
+    }),
+    loaderRegistry.get("conversationArtifacts")!(callerId, {
+      currentCallId: scope?.currentCallId ?? null,
     }),
   ]);
 
@@ -255,6 +263,7 @@ export async function loadAllData(
       mastery: null,
       summary: null,
     },
+    conversationArtifacts: conversationArtifacts || EMPTY_CONVERSATION_ARTIFACTS,
     courseComplete,
   };
 }
@@ -1656,6 +1665,21 @@ registerLoader("visualAids", async (_callerId, loaderConfig) => {
     chapter: mediaChapterMap.get(sm.media.id) || null,
     mimeType: sm.media.mimeType,
   }));
+});
+
+/**
+ * #1642 (Epic #1606 Group A.5) — delivered ConversationArtifact rows from the
+ * caller's most-recent prior call. Reads existing AI-extracted rows; no new
+ * AI call at compose time. Failures degrade silently to the empty shape.
+ */
+registerLoader("conversationArtifacts", async (callerId, config) => {
+  const currentCallId = (config?.currentCallId as string | null | undefined) ?? null;
+  try {
+    return await loadConversationArtifacts(prisma, { callerId, currentCallId });
+  } catch (err) {
+    console.warn("[conversationArtifacts] loader failed — section will be omitted:", err);
+    return EMPTY_CONVERSATION_ARTIFACTS;
+  }
 });
 
 /**

--- a/apps/admin/lib/prompt/composition/loaders/conversationArtifacts.ts
+++ b/apps/admin/lib/prompt/composition/loaders/conversationArtifacts.ts
@@ -1,0 +1,123 @@
+/**
+ * conversationArtifacts loader (#1642 — Epic #1606 Group A.5).
+ *
+ * Surfaces quote-worthy lines + artifacts the AI already extracted from the
+ * caller's most-recent prior call so the next call's composed prompt can
+ * reference them ("From last call you shared: <title>").
+ *
+ * **No new AI call at compose time.** `lib/artifacts/extract-artifacts.ts`
+ * runs inside the pipeline EXTRACT stage and writes `ConversationArtifact`
+ * rows. This loader just reads what's already there.
+ *
+ * Filter contract (BA decision, baked in #1642 body):
+ *  - `status IN ('DELIVERED', 'READ')` — PENDING / SENT / FAILED excluded.
+ *  - Scope: most-recent prior call only (not the current call we're
+ *    composing for).
+ *
+ * Staleness contract (BA decision, baked in #1642 body): this is a
+ * caller-scoped section. It is NOT registered in `PlaybookSectionStaleness`.
+ * `bumpCallerComposeTimestamp` (`lib/compose/bump-timestamp.ts`) acts as
+ * the staleness proxy via end-of-call.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+export interface ConversationArtifactSummary {
+  id: string;
+  type: string;
+  title: string;
+  /** Truncated to keep prompt budget tight; full content lives in the renderer */
+  snippet: string;
+  confidence: number;
+  deliveredAt: string | null;
+}
+
+export interface ConversationArtifactsData {
+  hasArtifacts: boolean;
+  lastCallId: string | null;
+  lastCallAt: string | null;
+  artifacts: ConversationArtifactSummary[];
+}
+
+export interface LoadConversationArtifactsOptions {
+  callerId: string;
+  /** Current call id — excluded from the prior-call lookup so we never self-reference */
+  currentCallId?: string | null;
+}
+
+export const EMPTY_CONVERSATION_ARTIFACTS: ConversationArtifactsData = {
+  hasArtifacts: false,
+  lastCallId: null,
+  lastCallAt: null,
+  artifacts: [],
+};
+
+const SNIPPET_MAX_CHARS = 200;
+const ARTIFACT_LIMIT = 6;
+
+type PrismaForLoader = Pick<PrismaClient, "call" | "conversationArtifact">;
+
+export async function loadConversationArtifacts(
+  prisma: PrismaForLoader,
+  opts: LoadConversationArtifactsOptions,
+): Promise<ConversationArtifactsData> {
+  const { callerId, currentCallId } = opts;
+  if (!callerId) return EMPTY_CONVERSATION_ARTIFACTS;
+
+  const priorCall = await prisma.call.findFirst({
+    where: {
+      callerId,
+      endedAt: { not: null },
+      ...(currentCallId ? { id: { not: currentCallId } } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, createdAt: true },
+  });
+
+  if (!priorCall) return EMPTY_CONVERSATION_ARTIFACTS;
+
+  const artifactRows = await prisma.conversationArtifact.findMany({
+    where: {
+      callId: priorCall.id,
+      status: { in: ["DELIVERED", "READ"] },
+    },
+    orderBy: [{ deliveredAt: "desc" }, { createdAt: "desc" }],
+    take: ARTIFACT_LIMIT,
+    select: {
+      id: true,
+      type: true,
+      title: true,
+      content: true,
+      confidence: true,
+      deliveredAt: true,
+    },
+  });
+
+  if (artifactRows.length === 0) {
+    return {
+      hasArtifacts: false,
+      lastCallId: priorCall.id,
+      lastCallAt: priorCall.createdAt.toISOString(),
+      artifacts: [],
+    };
+  }
+
+  return {
+    hasArtifacts: true,
+    lastCallId: priorCall.id,
+    lastCallAt: priorCall.createdAt.toISOString(),
+    artifacts: artifactRows.map((row) => ({
+      id: row.id,
+      type: row.type,
+      title: row.title,
+      snippet: truncate(row.content, SNIPPET_MAX_CHARS),
+      confidence: row.confidence,
+      deliveredAt: row.deliveredAt ? row.deliveredAt.toISOString() : null,
+    })),
+  };
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1).trimEnd() + "…";
+}

--- a/apps/admin/lib/prompt/composition/transforms/conversationArtifacts.ts
+++ b/apps/admin/lib/prompt/composition/transforms/conversationArtifacts.ts
@@ -1,0 +1,67 @@
+/**
+ * conversationArtifacts transform (#1642 — Epic #1606 Group A.5).
+ *
+ * Pure shape mapper. The loader already filtered + truncated; this just
+ * shapes the payload the renderer + the LLM prompt section consume.
+ *
+ * Returns `null` when there are no delivered artifacts so the section's
+ * `fallback: "omit"` drops it from the emitted prompt entirely (Call 1
+ * path + no-DELIVERED-artifacts path collapse to the same empty state).
+ */
+
+import { registerTransform } from "../TransformRegistry";
+import type { ConversationArtifactsData } from "../loaders/conversationArtifacts";
+
+export interface ConversationArtifactsSection {
+  hasArtifacts: true;
+  lastCallId: string;
+  lastCallAt: string;
+  totalCount: number;
+  byType: Record<string, number>;
+  artifacts: Array<{
+    id: string;
+    type: string;
+    title: string;
+    snippet: string;
+    confidence: number;
+    deliveredAt: string | null;
+  }>;
+  summary: string;
+}
+
+registerTransform("renderConversationArtifacts", (rawData: ConversationArtifactsData) => {
+  if (!rawData || !rawData.hasArtifacts || rawData.artifacts.length === 0) {
+    return null;
+  }
+
+  const byType = rawData.artifacts.reduce<Record<string, number>>((acc, a) => {
+    acc[a.type] = (acc[a.type] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const totalCount = rawData.artifacts.length;
+  const typeBreakdown = Object.entries(byType)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([type, n]) => `${n} ${type}`)
+    .join(", ");
+
+  const summary = `From your last call: ${totalCount} item${totalCount === 1 ? "" : "s"} shared (${typeBreakdown}).`;
+
+  const section: ConversationArtifactsSection = {
+    hasArtifacts: true,
+    lastCallId: rawData.lastCallId!,
+    lastCallAt: rawData.lastCallAt!,
+    totalCount,
+    byType,
+    artifacts: rawData.artifacts.map((a) => ({
+      id: a.id,
+      type: a.type,
+      title: a.title,
+      snippet: a.snippet,
+      confidence: a.confidence,
+      deliveredAt: a.deliveredAt,
+    })),
+    summary,
+  };
+  return section;
+});

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -132,6 +132,13 @@ export interface LoadedDataContext {
    * resolve a curriculum.
    */
   courseComplete?: CourseCompleteLoadedData | null;
+  /**
+   * #1642 (Epic #1606 Group A.5) — delivered/read ConversationArtifact rows
+   * from the most-recent prior call. `hasArtifacts: false` for Call 1 and
+   * for any prior call with zero DELIVERED+READ artifacts; the section is
+   * omitted from the final prompt in those cases.
+   */
+  conversationArtifacts?: import("./loaders/conversationArtifacts").ConversationArtifactsData;
 }
 
 /**

--- a/apps/admin/tests/components/preview-renderers/conversation-artifacts-renderer.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/conversation-artifacts-renderer.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * ConversationArtifactsRenderer — #1643 (Epic #1606 Group A.5).
+ *
+ * Pinned acceptance:
+ *   1. Registry contract for the `conversationArtifacts` key.
+ *   2. Loading state — renders "Loading recent artifacts…" placeholder.
+ *   3. No-learners-enrolled state — when previewCallerName is null.
+ *   4. Call 1 empty state — no prior call yet.
+ *   5. Last-call-empty state — prior call shared zero DELIVERED artifacts.
+ *   6. Populated state — renders per-artifact type + title + snippet.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import {
+  ConversationArtifactsRenderer,
+  type ConversationArtifactsRendererData,
+} from "@/components/shared/preview-renderers";
+import {
+  getPreviewRenderer,
+  registerPreviewRenderer,
+} from "@/components/shared/designer-shell";
+import { __resetPreviewRenderersForTesting } from "@/components/shared/designer-shell/section-registry";
+
+afterEach(() => {
+  cleanup();
+  __resetPreviewRenderersForTesting();
+});
+
+beforeEach(() => {
+  registerPreviewRenderer<
+    "conversationArtifacts",
+    ConversationArtifactsRendererData
+  >("conversationArtifacts", ConversationArtifactsRenderer);
+});
+
+describe("ConversationArtifactsRenderer — registry contract", () => {
+  it("registers under 'conversationArtifacts'", () => {
+    expect(getPreviewRenderer("conversationArtifacts")).toBe(
+      ConversationArtifactsRenderer,
+    );
+  });
+});
+
+describe("ConversationArtifactsRenderer — empty states", () => {
+  it("renders the loading placeholder when loading is true", () => {
+    render(
+      <ConversationArtifactsRenderer
+        data={{
+          loading: true,
+          hasArtifacts: false,
+          lastCallId: null,
+          lastCallAt: null,
+          artifacts: [],
+        }}
+        selection={{ selectedKey: "conversationArtifacts" }}
+      />,
+    );
+    expect(screen.getByText(/loading recent artifacts/i)).toBeTruthy();
+  });
+
+  it("renders 'No learners enrolled yet' when previewCallerName is null", () => {
+    render(
+      <ConversationArtifactsRenderer
+        data={{
+          previewCallerName: null,
+          hasArtifacts: false,
+          lastCallId: null,
+          lastCallAt: null,
+          artifacts: [],
+        }}
+        selection={{ selectedKey: "conversationArtifacts" }}
+      />,
+    );
+    expect(screen.getByText(/no learners enrolled/i)).toBeTruthy();
+  });
+
+  it("renders the Call 1 empty path when learner has no prior call", () => {
+    render(
+      <ConversationArtifactsRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasArtifacts: false,
+          lastCallId: null,
+          lastCallAt: null,
+          artifacts: [],
+        }}
+        selection={{ selectedKey: "conversationArtifacts" }}
+      />,
+    );
+    expect(screen.getByText(/no prior call yet/i)).toBeTruthy();
+    expect(screen.getByText(/Bertie/)).toBeTruthy();
+  });
+
+  it("renders the 'last call shared no artifacts' state when prior call exists but has zero DELIVERED", () => {
+    render(
+      <ConversationArtifactsRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasArtifacts: false,
+          lastCallId: "call-prior",
+          lastCallAt: new Date(Date.now() - 86400000).toISOString(),
+          artifacts: [],
+        }}
+        selection={{ selectedKey: "conversationArtifacts" }}
+      />,
+    );
+    expect(screen.getByText(/shared no artifacts/i)).toBeTruthy();
+  });
+});
+
+describe("ConversationArtifactsRenderer — populated state", () => {
+  it("renders the artifact list with type, title, and snippet", () => {
+    render(
+      <ConversationArtifactsRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasArtifacts: true,
+          lastCallId: "call-prior",
+          lastCallAt: new Date(Date.now() - 86400000).toISOString(),
+          totalCount: 2,
+          artifacts: [
+            {
+              id: "art-1",
+              type: "KEY_FACT",
+              title: "Pythagorean identity",
+              snippet: "a² + b² = c²",
+              confidence: 0.92,
+              deliveredAt: new Date().toISOString(),
+            },
+            {
+              id: "art-2",
+              type: "STUDY_NOTE",
+              title: "Right triangle",
+              snippet: "Use the identity to find hypotenuse",
+              confidence: 0.8,
+              deliveredAt: null,
+            },
+          ],
+        }}
+        selection={{ selectedKey: "conversationArtifacts" }}
+      />,
+    );
+    expect(screen.getByText(/Pythagorean identity/)).toBeTruthy();
+    expect(screen.getByText(/KEY_FACT/)).toBeTruthy();
+    expect(screen.getByText(/Right triangle/)).toBeTruthy();
+    expect(screen.getByText(/STUDY_NOTE/)).toBeTruthy();
+    expect(screen.getByText(/a² \+ b² = c²/)).toBeTruthy();
+  });
+
+  it("includes the caller name in the header when populated", () => {
+    render(
+      <ConversationArtifactsRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasArtifacts: true,
+          lastCallId: "call-prior",
+          lastCallAt: new Date().toISOString(),
+          totalCount: 1,
+          artifacts: [
+            {
+              id: "art-1",
+              type: "SUMMARY",
+              title: "Call recap",
+              snippet: "We covered limits",
+              confidence: 0.85,
+              deliveredAt: null,
+            },
+          ],
+        }}
+        selection={{ selectedKey: "conversationArtifacts" }}
+      />,
+    );
+    expect(screen.getByText(/Bertie/)).toBeTruthy();
+  });
+});

--- a/apps/admin/tests/lib/compose/affecting-keys.test.ts
+++ b/apps/admin/tests/lib/compose/affecting-keys.test.ts
@@ -88,9 +88,11 @@ describe("compose-section contract — #1556", () => {
   });
 
   describe("deferred sections — scoped to follow-on epic Group A.5", () => {
-    it("artifacts is absent from COMPOSE_SECTION_KEYS (no backing composer section today)", () => {
+    // #1642 (Epic #1606 Group A.5) — `conversationArtifacts` shipped; lives in
+    // the union now. The legacy "artifacts" string was never a real key, so
+    // we still pin its absence to catch any rename regression.
+    it("legacy 'artifacts' string is absent from COMPOSE_SECTION_KEYS", () => {
       expect(COMPOSE_SECTION_KEYS).not.toContain("artifacts");
-      expect(COMPOSE_SECTION_KEYS).not.toContain("conversationArtifacts");
     });
 
     it("memoryDeltas is absent from COMPOSE_SECTION_KEYS (no diff loader today)", () => {
@@ -127,12 +129,11 @@ describe("compose-section contract — #1556", () => {
     });
   });
 
-  describe("union contains exactly the 14-member taxonomy from the epic", () => {
-    it("has 16 section keys total (2 config-kind + 14 runtime)", () => {
-      // Note: epic title says "14-member" referring to the union arms; in
-      // practice the discriminated union expands to 16 `section` string
-      // values (2 config + 14 runtime). Both readings are consistent.
-      expect(COMPOSE_SECTION_KEYS.length).toBe(16);
+  describe("union contains exactly the 15-member runtime taxonomy from the epic", () => {
+    it("has 17 section keys total (2 config-kind + 15 runtime)", () => {
+      // #1642 (Epic #1606 Group A.5) — added `conversationArtifacts` to
+      // runtime arm, taking runtime count from 14 → 15 and total from 16 → 17.
+      expect(COMPOSE_SECTION_KEYS.length).toBe(17);
     });
 
     it("includes the renamed sections (priorCallFeedback, contentTrust)", () => {

--- a/apps/admin/tests/lib/prompt/composition/loaders/conversationArtifacts.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/loaders/conversationArtifacts.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
 import {
   EMPTY_CONVERSATION_ARTIFACTS,
   loadConversationArtifacts,
@@ -23,12 +24,14 @@ type MockArtifact = {
   deliveredAt: Date | null;
 };
 
+type LoaderPrisma = Pick<PrismaClient, "call" | "conversationArtifact">;
+
 function makePrisma(opts: {
   priorCall?: MockCall | null;
   artifactRows?: MockArtifact[];
   captureFindFirstArgs?: (args: unknown) => void;
   captureArtifactArgs?: (args: unknown) => void;
-}) {
+}): LoaderPrisma {
   return {
     call: {
       findFirst: vi.fn(async (args: unknown) => {
@@ -42,7 +45,7 @@ function makePrisma(opts: {
         return opts.artifactRows ?? [];
       }),
     },
-  } as any;
+  } as unknown as LoaderPrisma;
 }
 
 describe("loadConversationArtifacts", () => {

--- a/apps/admin/tests/lib/prompt/composition/loaders/conversationArtifacts.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/loaders/conversationArtifacts.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the conversationArtifacts loader (#1642 — Epic #1606 Group A.5).
+ *
+ * Pins the BA-decided contract:
+ *   - Status filter: DELIVERED + READ only (PENDING, SENT, FAILED excluded)
+ *   - Scope: most-recent prior call only (currentCallId excluded)
+ *   - Empty path: Call 1 / no prior call / no DELIVERED artifacts on prior call
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  EMPTY_CONVERSATION_ARTIFACTS,
+  loadConversationArtifacts,
+} from "@/lib/prompt/composition/loaders/conversationArtifacts";
+
+type MockCall = { id: string; createdAt: Date };
+type MockArtifact = {
+  id: string;
+  type: string;
+  title: string;
+  content: string;
+  confidence: number;
+  deliveredAt: Date | null;
+};
+
+function makePrisma(opts: {
+  priorCall?: MockCall | null;
+  artifactRows?: MockArtifact[];
+  captureFindFirstArgs?: (args: unknown) => void;
+  captureArtifactArgs?: (args: unknown) => void;
+}) {
+  return {
+    call: {
+      findFirst: vi.fn(async (args: unknown) => {
+        opts.captureFindFirstArgs?.(args);
+        return opts.priorCall ?? null;
+      }),
+    },
+    conversationArtifact: {
+      findMany: vi.fn(async (args: unknown) => {
+        opts.captureArtifactArgs?.(args);
+        return opts.artifactRows ?? [];
+      }),
+    },
+  } as any;
+}
+
+describe("loadConversationArtifacts", () => {
+  it("returns the empty shape when callerId is missing", async () => {
+    const prisma = makePrisma({});
+    const result = await loadConversationArtifacts(prisma, { callerId: "" });
+    expect(result).toEqual(EMPTY_CONVERSATION_ARTIFACTS);
+    expect(prisma.call.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns the empty shape when there is no prior call (Call 1 path)", async () => {
+    const prisma = makePrisma({ priorCall: null });
+    const result = await loadConversationArtifacts(prisma, { callerId: "caller-1" });
+    expect(result).toEqual(EMPTY_CONVERSATION_ARTIFACTS);
+    expect(prisma.conversationArtifact.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns hasArtifacts=false but populates lastCallId when the prior call had no DELIVERED artifacts", async () => {
+    const priorCall: MockCall = {
+      id: "call-prior",
+      createdAt: new Date("2026-06-13T10:00:00Z"),
+    };
+    const prisma = makePrisma({ priorCall, artifactRows: [] });
+    const result = await loadConversationArtifacts(prisma, { callerId: "caller-1" });
+    expect(result.hasArtifacts).toBe(false);
+    expect(result.lastCallId).toBe("call-prior");
+    expect(result.lastCallAt).toBe("2026-06-13T10:00:00.000Z");
+    expect(result.artifacts).toEqual([]);
+  });
+
+  it("returns DELIVERED + READ artifacts shaped for the prompt", async () => {
+    const priorCall: MockCall = {
+      id: "call-prior",
+      createdAt: new Date("2026-06-13T10:00:00Z"),
+    };
+    const artifactRows: MockArtifact[] = [
+      {
+        id: "art-1",
+        type: "KEY_FACT",
+        title: "Pythagoras",
+        content: "a² + b² = c²",
+        confidence: 0.92,
+        deliveredAt: new Date("2026-06-13T10:15:00Z"),
+      },
+      {
+        id: "art-2",
+        type: "STUDY_NOTE",
+        title: "Right triangle",
+        content: "Use Pythagoras to find hypotenuse",
+        confidence: 0.8,
+        deliveredAt: new Date("2026-06-13T10:14:00Z"),
+      },
+    ];
+    const prisma = makePrisma({ priorCall, artifactRows });
+    const result = await loadConversationArtifacts(prisma, { callerId: "caller-1" });
+
+    expect(result.hasArtifacts).toBe(true);
+    expect(result.lastCallId).toBe("call-prior");
+    expect(result.artifacts).toHaveLength(2);
+    expect(result.artifacts[0]).toMatchObject({
+      id: "art-1",
+      type: "KEY_FACT",
+      title: "Pythagoras",
+      snippet: "a² + b² = c²",
+      confidence: 0.92,
+      deliveredAt: "2026-06-13T10:15:00.000Z",
+    });
+  });
+
+  it("scopes the Prisma artifact query to status IN ['DELIVERED','READ']", async () => {
+    const priorCall: MockCall = {
+      id: "call-prior",
+      createdAt: new Date("2026-06-13T10:00:00Z"),
+    };
+    const capture = vi.fn();
+    const prisma = makePrisma({
+      priorCall,
+      artifactRows: [],
+      captureArtifactArgs: capture,
+    });
+    await loadConversationArtifacts(prisma, { callerId: "caller-1" });
+
+    expect(capture).toHaveBeenCalledOnce();
+    const args = capture.mock.calls[0][0] as { where: { status: { in: string[] } } };
+    expect(args.where.status.in).toEqual(["DELIVERED", "READ"]);
+  });
+
+  it("excludes currentCallId from the prior-call lookup", async () => {
+    const capture = vi.fn();
+    const prisma = makePrisma({
+      priorCall: null,
+      captureFindFirstArgs: capture,
+    });
+    await loadConversationArtifacts(prisma, {
+      callerId: "caller-1",
+      currentCallId: "call-current",
+    });
+
+    const args = capture.mock.calls[0][0] as {
+      where: { id?: { not: string } };
+    };
+    expect(args.where.id).toEqual({ not: "call-current" });
+  });
+
+  it("omits the id-not filter when currentCallId is absent", async () => {
+    const capture = vi.fn();
+    const prisma = makePrisma({
+      priorCall: null,
+      captureFindFirstArgs: capture,
+    });
+    await loadConversationArtifacts(prisma, { callerId: "caller-1" });
+
+    const args = capture.mock.calls[0][0] as { where: Record<string, unknown> };
+    expect(args.where.id).toBeUndefined();
+  });
+
+  it("truncates long content to a snippet (≤200 chars) with an ellipsis", async () => {
+    const priorCall: MockCall = {
+      id: "call-prior",
+      createdAt: new Date("2026-06-13T10:00:00Z"),
+    };
+    const longContent = "x".repeat(500);
+    const prisma = makePrisma({
+      priorCall,
+      artifactRows: [
+        {
+          id: "art-1",
+          type: "STUDY_NOTE",
+          title: "Long one",
+          content: longContent,
+          confidence: 0.8,
+          deliveredAt: null,
+        },
+      ],
+    });
+    const result = await loadConversationArtifacts(prisma, { callerId: "caller-1" });
+
+    expect(result.artifacts[0].snippet.length).toBeLessThanOrEqual(200);
+    expect(result.artifacts[0].snippet.endsWith("…")).toBe(true);
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/transforms/conversationArtifacts.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/conversationArtifacts.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the renderConversationArtifacts transform (#1642 — Epic #1606 Group A.5).
+ *
+ * Pins:
+ *   - Empty + no-prior-call paths both return null so the section is omitted
+ *   - Output carries totalCount + byType breakdown + summary string
+ *   - Summary line includes the by-type counts sorted alphabetically (deterministic)
+ */
+
+import { describe, it, expect } from "vitest";
+import "@/lib/prompt/composition/transforms/conversationArtifacts";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type { ConversationArtifactsData } from "@/lib/prompt/composition/loaders/conversationArtifacts";
+
+const transform = getTransform("renderConversationArtifacts");
+
+const dummyContext = {} as any;
+const dummySection = {} as any;
+
+describe("renderConversationArtifacts transform", () => {
+  it("registers under the name 'renderConversationArtifacts'", () => {
+    expect(transform).toBeDefined();
+  });
+
+  it("returns null for the empty shape (Call 1 path)", () => {
+    const empty: ConversationArtifactsData = {
+      hasArtifacts: false,
+      lastCallId: null,
+      lastCallAt: null,
+      artifacts: [],
+    };
+    expect(transform!(empty, dummyContext, dummySection)).toBeNull();
+  });
+
+  it("returns null when hasArtifacts=false even if lastCallId is populated", () => {
+    const noDelivered: ConversationArtifactsData = {
+      hasArtifacts: false,
+      lastCallId: "call-prior",
+      lastCallAt: "2026-06-13T10:00:00.000Z",
+      artifacts: [],
+    };
+    expect(transform!(noDelivered, dummyContext, dummySection)).toBeNull();
+  });
+
+  it("emits the section payload with totalCount, byType, and a deterministic summary", () => {
+    const data: ConversationArtifactsData = {
+      hasArtifacts: true,
+      lastCallId: "call-prior",
+      lastCallAt: "2026-06-13T10:00:00.000Z",
+      artifacts: [
+        {
+          id: "art-1",
+          type: "STUDY_NOTE",
+          title: "Right triangle",
+          snippet: "Use Pythagoras",
+          confidence: 0.8,
+          deliveredAt: null,
+        },
+        {
+          id: "art-2",
+          type: "KEY_FACT",
+          title: "Pythagoras",
+          snippet: "a² + b² = c²",
+          confidence: 0.92,
+          deliveredAt: "2026-06-13T10:15:00.000Z",
+        },
+        {
+          id: "art-3",
+          type: "STUDY_NOTE",
+          title: "Trig basics",
+          snippet: "SOHCAHTOA",
+          confidence: 0.7,
+          deliveredAt: null,
+        },
+      ],
+    };
+
+    const out = transform!(data, dummyContext, dummySection);
+    expect(out).not.toBeNull();
+    expect(out.totalCount).toBe(3);
+    expect(out.byType).toEqual({ KEY_FACT: 1, STUDY_NOTE: 2 });
+    expect(out.lastCallId).toBe("call-prior");
+    expect(out.summary).toBe(
+      "From your last call: 3 items shared (1 KEY_FACT, 2 STUDY_NOTE).",
+    );
+    expect(out.artifacts).toHaveLength(3);
+  });
+
+  it("uses singular form in the summary when a single artifact was shared", () => {
+    const data: ConversationArtifactsData = {
+      hasArtifacts: true,
+      lastCallId: "call-prior",
+      lastCallAt: "2026-06-13T10:00:00.000Z",
+      artifacts: [
+        {
+          id: "art-1",
+          type: "SUMMARY",
+          title: "Call recap",
+          snippet: "We covered limits",
+          confidence: 0.85,
+          deliveredAt: null,
+        },
+      ],
+    };
+
+    const out = transform!(data, dummyContext, dummySection);
+    expect(out.summary).toBe("From your last call: 1 item shared (1 SUMMARY).");
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/transforms/conversationArtifacts.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/conversationArtifacts.test.ts
@@ -11,11 +11,15 @@ import { describe, it, expect } from "vitest";
 import "@/lib/prompt/composition/transforms/conversationArtifacts";
 import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
 import type { ConversationArtifactsData } from "@/lib/prompt/composition/loaders/conversationArtifacts";
+import type {
+  AssembledContext,
+  CompositionSectionDef,
+} from "@/lib/prompt/composition/types";
 
 const transform = getTransform("renderConversationArtifacts");
 
-const dummyContext = {} as any;
-const dummySection = {} as any;
+const dummyContext = {} as unknown as AssembledContext;
+const dummySection = {} as unknown as CompositionSectionDef;
 
 describe("renderConversationArtifacts transform", () => {
   it("registers under the name 'renderConversationArtifacts'", () => {

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -10065,6 +10065,12 @@ List all classrooms (cohort groups) assigned to a course (playbook).
 
 ---
 
+### `GET` /api/courses/[courseId]/conversation-artifacts-preview
+
+**Auth**: Session
+
+---
+
 ### `GET` /api/courses/[courseId]/demo-script
 
 Returns the operator-only demo script for a course. This
@@ -16169,8 +16175,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 528 |
-| Files with annotations | 516 |
+| Route files found | 529 |
+| Files with annotations | 517 |
 | Files missing annotations | 12 |
 | Coverage | 97.7% |
 


### PR DESCRIPTION
## Summary

- Inspector renderer for the `conversationArtifacts` composer section shipped in #1650 (#1642). Surfaces the DELIVERED/READ artifacts the AI emitted after the most-recent prior call
- 5th header chip in DesignTab — "Artifacts: N from last call" — toggles the Inspector slot, matching the existing 4 chips' shape (firstCallMode / modePolicy / instructions / contentTrust)
- New OPERATOR+ preview route `GET /api/courses/[courseId]/conversation-artifacts-preview` picks the course's most-recent active learner as the representative caller, returns empty shape when no learners enrolled

## Stacked PR note

**This PR is stacked on #1650.** GitHub shows the full diff against main once the base merges. The merge order should be #1650 → this PR → #1653 → #1645 (renderer for memoryDeltas, blocked on #1653).

## Verified by

**Renderer contract pinned by 7 vitests at `tests/components/preview-renderers/conversation-artifacts-renderer.test.tsx`:**
- Registry contract — `getPreviewRenderer('conversationArtifacts')` returns the component
- 4 empty-state branches: `loading: true` / `previewCallerName === null` / Call 1 (no prior call) / prior call existed but zero artifacts
- Populated state renders type chip + title + snippet for each artifact
- Caller name surfaces in the header for context

**Sibling regression sweep:** 95/95 across `tests/components/preview-renderers/` + `tests/components/course-design/`. Lint clean. tsc within ratchet.

**Live verification deferred to hf-dev** — the preview route can't be exercised cleanly in vitest (DB-shaped Prisma reads). Will smoke after `/vm-cp` lands and #1650 deploys (so the loader exists in the live image).

## Test plan

- [x] Renderer vitests (7/7) green
- [x] Registry contract pin (sibling to A.4/A.8 pattern)
- [x] Lint + tsc clean on changed files
- [x] DesignTab integration follows the established header-chip + fetch-on-mount pattern
- [ ] `/vm-cp` after merge → smoke the route on hf-dev

Closes #1643. Group A.5 final renderer ships as #1645 (stacked on #1653).

🤖 Generated with [Claude Code](https://claude.com/claude-code)