### PR TITLE
feat(renderers): #1645 — MemoryDeltasRenderer Inspector sticky (Epic #1606 Group A.5)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/memory-deltas-preview/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/memory-deltas-preview/route.ts
@@ -1,0 +1,83 @@
+/**
+ * @api GET /api/courses/[courseId]/memory-deltas-preview
+ *
+ * Inspector preview of the `memoryDeltas` composer section (#1645 —
+ * Epic #1606 Group A.5). Caller-scoped section, so the route picks a
+ * representative learner from the course — the most-recent active
+ * `CallerPlaybook` enrollment — and runs the loader shipped in
+ * #1644 against their state.
+ *
+ * Auth: OPERATOR+. Read-only. Returns the empty shape when the course
+ * has no enrolled learners yet.
+ */
+
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  loadMemoryDeltas,
+  type MemoryDeltasData,
+} from "@/lib/prompt/composition/loaders/memoryDeltas";
+
+interface MemoryDeltasPreviewResponse {
+  ok: boolean;
+  previewCallerName: string | null;
+  data: MemoryDeltasData;
+}
+
+const EMPTY_DATA: MemoryDeltasData = {
+  hasDeltas: false,
+  priorCallId: null,
+  priorPriorCallId: null,
+  added: [],
+  updated: [],
+};
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse<MemoryDeltasPreviewResponse>> {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) {
+    return auth.error as NextResponse<MemoryDeltasPreviewResponse>;
+  }
+  const { courseId } = await context.params;
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: courseId },
+    select: { id: true },
+  });
+  if (!playbook) {
+    return NextResponse.json(
+      { ok: false, previewCallerName: null, data: EMPTY_DATA },
+      { status: 404 },
+    );
+  }
+
+  const enrollment = await prisma.callerPlaybook.findFirst({
+    where: { playbookId: courseId, status: "ACTIVE" },
+    orderBy: { startedAt: "desc" },
+    select: {
+      caller: { select: { id: true, name: true } },
+    },
+  });
+
+  if (!enrollment?.caller) {
+    return NextResponse.json({
+      ok: true,
+      previewCallerName: null,
+      data: EMPTY_DATA,
+    });
+  }
+
+  const data = await loadMemoryDeltas(prisma, {
+    callerId: enrollment.caller.id,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    previewCallerName: enrollment.caller.name ?? null,
+    data,
+  });
+}

--- a/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
@@ -10,7 +10,10 @@
  * click handlers ALSO trigger the Inspector for the 5 hand-wired
  * sections. #1628 (A.2) added the modePolicy chip. #1634 (A.4 + A.8)
  * closes out the Inspector pattern with the goal-adaptation guidance
- * template and the content-trust freshness renderer.
+ * template and the content-trust freshness renderer. #1643 + #1645
+ * (Group A.5) added conversationArtifacts + memoryDeltas chips for
+ * caller-scoped composer sections — both fetched from per-course
+ * preview routes that sample the most-recent active learner.
  *
  * Side-effect: importing the preview-renderers barrel triggers all
  * `registerPreviewRenderer()` calls at module load, before the
@@ -29,6 +32,7 @@ import type {
   ConversationArtifactsRendererData,
   FreshnessWarning,
   GoalType,
+  MemoryDeltasRendererData,
   SessionFlowData,
 } from "@/components/shared/preview-renderers";
 import type { ComposeSectionKey } from "@/lib/compose";
@@ -69,6 +73,7 @@ function resolveRendererData(
   sessionFlow: SessionFlowData | null,
   contentTrust: ContentTrustData | null,
   conversationArtifacts: ConversationArtifactsRendererData | null,
+  memoryDeltas: MemoryDeltasRendererData | null,
   goalTypesInUse: GoalType[] | undefined,
 ): unknown {
   if (selectedKey === "firstCallMode") {
@@ -99,6 +104,18 @@ function resolveRendererData(
       }
     );
   }
+  if (selectedKey === "memoryDeltas") {
+    return (
+      memoryDeltas ?? {
+        loading: true,
+        hasDeltas: false,
+        priorCallId: null,
+        priorPriorCallId: null,
+        added: [],
+        updated: [],
+      }
+    );
+  }
   if (SESSION_FLOW_SECTIONS.has(selectedKey)) {
     return { sessionFlow };
   }
@@ -113,6 +130,8 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
   );
   const [conversationArtifacts, setConversationArtifacts] =
     useState<ConversationArtifactsRendererData | null>(null);
+  const [memoryDeltas, setMemoryDeltas] =
+    useState<MemoryDeltasRendererData | null>(null);
   const pbConfig = useMemo(
     () => (playbookConfig ?? {}) as PlaybookConfig,
     [playbookConfig],
@@ -130,6 +149,7 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
   const instructionsSelected = selectedKey === "instructions";
   const contentTrustSelected = selectedKey === "contentTrust";
   const conversationArtifactsSelected = selectedKey === "conversationArtifacts";
+  const memoryDeltasSelected = selectedKey === "memoryDeltas";
 
   // A.4: Goal types currently in use on this course. The playbook config
   // doesn't carry this directly today — read it from session-flow OR
@@ -210,6 +230,44 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
     };
   }, [courseId]);
 
+  // #1645 (A.5): memory-deltas preview. Caller-scoped data sampled
+  // from the course's most-recent active enrollment. Renderer handles
+  // loading + null-caller + Call 1 + empty + populated states.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/memory-deltas-preview`)
+      .then((res) => res.json())
+      .then(
+        (j: {
+          ok: boolean;
+          previewCallerName: string | null;
+          data: {
+            hasDeltas: boolean;
+            priorCallId: string | null;
+            priorPriorCallId: string | null;
+            added: MemoryDeltasRendererData["added"];
+            updated: MemoryDeltasRendererData["updated"];
+          };
+        }) => {
+          if (!cancelled && j.ok) {
+            setMemoryDeltas({
+              loading: false,
+              previewCallerName: j.previewCallerName,
+              hasDeltas: j.data.hasDeltas,
+              priorCallId: j.data.priorCallId,
+              priorPriorCallId: j.data.priorPriorCallId,
+              added: j.data.added,
+              updated: j.data.updated,
+            });
+          }
+        },
+      )
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
   const inspectorNode = useMemo(() => {
     if (!selectedKey) return null;
     const renderer = getPreviewRenderer(selectedKey);
@@ -221,6 +279,7 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
         sessionFlow,
         contentTrust,
         conversationArtifacts,
+        memoryDeltas,
         goalTypesInUse,
       ),
       selection: { selectedKey },
@@ -231,6 +290,7 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
     sessionFlow,
     contentTrust,
     conversationArtifacts,
+    memoryDeltas,
     goalTypesInUse,
   ]);
 
@@ -312,6 +372,23 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
             : !conversationArtifacts.hasArtifacts
               ? "none from last call"
               : `${conversationArtifacts.totalCount ?? conversationArtifacts.artifacts.length} from last call`}
+      </button>
+      <button
+        type="button"
+        className={`hf-chip ${memoryDeltasSelected ? "hf-chip-selected" : ""}`}
+        aria-pressed={memoryDeltasSelected}
+        onClick={() =>
+          setSelectedKey(memoryDeltasSelected ? null : "memoryDeltas")
+        }
+      >
+        <span className="hf-category-label">Memory deltas:</span>{" "}
+        {memoryDeltas === null
+          ? "loading…"
+          : memoryDeltas.previewCallerName === null
+            ? "no learners"
+            : !memoryDeltas.hasDeltas
+              ? "none since last call"
+              : `${memoryDeltas.added.length}+ / ${memoryDeltas.updated.length}↑`}
       </button>
     </div>
   );

--- a/apps/admin/components/shared/preview-renderers/MemoryDeltasRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/MemoryDeltasRenderer.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * MemoryDeltasRenderer — #1645 (Epic #1606 Group A.5).
+ *
+ * Inspector sticky for the `memoryDeltas` composer section (loader +
+ * transform shipped in #1644 / #1653). Surfaces the CallerMemory diff
+ * between the most-recent prior call and its predecessor (via
+ * `Call.previousCallId`) so the educator can see what's "newly known"
+ * or "updated" about the learner heading into the next call.
+ *
+ * Sibling shape to `ConversationArtifactsRenderer` — same loading +
+ * no-learner + Call 1 + empty + populated states, but the populated
+ * block distinguishes ADDED rows (full chip) from UPDATED rows
+ * (chip + diff arrow showing prior → new value).
+ */
+
+import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
+import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+
+export interface MemoryDeltaAddedEntry {
+  category: string;
+  key: string;
+  value: string;
+  confidence: number;
+}
+
+export interface MemoryDeltaUpdatedEntry {
+  category: string;
+  key: string;
+  value: string;
+  priorValue: string;
+  confidence: number;
+}
+
+export interface MemoryDeltasRendererData {
+  loading?: boolean;
+  /** Caller chosen for preview ("most-recent active learner on this course"). Null when no callers enrolled yet. */
+  previewCallerName?: string | null;
+  hasDeltas: boolean;
+  priorCallId: string | null;
+  priorPriorCallId: string | null;
+  added: MemoryDeltaAddedEntry[];
+  updated: MemoryDeltaUpdatedEntry[];
+}
+
+export function MemoryDeltasRenderer({
+  data,
+}: PreviewRendererProps<MemoryDeltasRendererData>) {
+  if (data.loading) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Memory deltas</div>
+        <span className="hf-badge hf-badge-muted">
+          Loading recent memory changes…
+        </span>
+      </div>
+    );
+  }
+
+  if (data.previewCallerName === null) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Memory deltas</div>
+        <span className="hf-badge hf-badge-muted">
+          No learners enrolled yet
+        </span>
+      </div>
+    );
+  }
+
+  const callerPrefix = data.previewCallerName
+    ? ` (${data.previewCallerName})`
+    : "";
+
+  if (!data.hasDeltas) {
+    if (!data.priorCallId) {
+      return (
+        <div className="hf-card-compact">
+          <div className="hf-category-label">
+            Memory deltas{callerPrefix}
+          </div>
+          <span className="hf-badge hf-badge-muted">
+            No prior call yet — Call 1 path
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">
+          Memory deltas{callerPrefix}
+        </div>
+        <span className="hf-badge hf-badge-muted">
+          No memory changes since last call
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hf-card-compact">
+      <div className="hf-category-label">
+        Memory deltas{callerPrefix} — {data.added.length} added,{" "}
+        {data.updated.length} updated
+      </div>
+      {data.added.length > 0 && (
+        <ol className="hf-list-row">
+          {data.added.map((entry) => (
+            <li key={`added-${entry.key}`}>
+              <span className="hf-badge hf-badge-success">added</span>{" "}
+              <span className="hf-category-label">{entry.category}</span>{" "}
+              <strong>{entry.key}</strong>
+              <div className="hf-text-sm">{entry.value}</div>
+            </li>
+          ))}
+        </ol>
+      )}
+      {data.updated.length > 0 && (
+        <ol className="hf-list-row">
+          {data.updated.map((entry) => (
+            <li key={`updated-${entry.key}`}>
+              <span className="hf-badge hf-badge-warning">updated</span>{" "}
+              <span className="hf-category-label">{entry.category}</span>{" "}
+              <strong>{entry.key}</strong>
+              <div className="hf-text-sm hf-text-muted">
+                {entry.priorValue} → <span className="hf-text-strong">{entry.value}</span>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+registerPreviewRenderer<"memoryDeltas", MemoryDeltasRendererData>(
+  "memoryDeltas",
+  MemoryDeltasRenderer,
+);

--- a/apps/admin/components/shared/preview-renderers/index.ts
+++ b/apps/admin/components/shared/preview-renderers/index.ts
@@ -49,4 +49,11 @@ export type {
   ConversationArtifactsRendererArtifact,
 } from "./ConversationArtifactsRenderer";
 
+export { MemoryDeltasRenderer } from "./MemoryDeltasRenderer";
+export type {
+  MemoryDeltasRendererData,
+  MemoryDeltaAddedEntry,
+  MemoryDeltaUpdatedEntry,
+} from "./MemoryDeltasRenderer";
+
 export type { SessionFlowData } from "./types";

--- a/apps/admin/tests/components/preview-renderers/memory-deltas-renderer.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/memory-deltas-renderer.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * MemoryDeltasRenderer — #1645 (Epic #1606 Group A.5).
+ *
+ * Pinned acceptance:
+ *   1. Registry contract for the `memoryDeltas` key.
+ *   2. Loading state — placeholder rendered.
+ *   3. No-learner state — when previewCallerName is null.
+ *   4. Call 1 state — when priorCallId is null.
+ *   5. Identical-memory-sets state — hasDeltas=false with priorCallId set.
+ *   6. Populated state — added entries with category + key + value.
+ *   7. Populated state — updated entries with prior→new diff arrow.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import {
+  MemoryDeltasRenderer,
+  type MemoryDeltasRendererData,
+} from "@/components/shared/preview-renderers";
+import {
+  getPreviewRenderer,
+  registerPreviewRenderer,
+} from "@/components/shared/designer-shell";
+import { __resetPreviewRenderersForTesting } from "@/components/shared/designer-shell/section-registry";
+
+afterEach(() => {
+  cleanup();
+  __resetPreviewRenderersForTesting();
+});
+
+beforeEach(() => {
+  registerPreviewRenderer<"memoryDeltas", MemoryDeltasRendererData>(
+    "memoryDeltas",
+    MemoryDeltasRenderer,
+  );
+});
+
+describe("MemoryDeltasRenderer — registry contract", () => {
+  it("registers under 'memoryDeltas'", () => {
+    expect(getPreviewRenderer("memoryDeltas")).toBe(MemoryDeltasRenderer);
+  });
+});
+
+describe("MemoryDeltasRenderer — empty states", () => {
+  it("renders the loading placeholder", () => {
+    render(
+      <MemoryDeltasRenderer
+        data={{
+          loading: true,
+          hasDeltas: false,
+          priorCallId: null,
+          priorPriorCallId: null,
+          added: [],
+          updated: [],
+        }}
+        selection={{ selectedKey: "memoryDeltas" }}
+      />,
+    );
+    expect(screen.getByText(/loading recent memory changes/i)).toBeTruthy();
+  });
+
+  it("renders 'No learners enrolled yet' when previewCallerName is null", () => {
+    render(
+      <MemoryDeltasRenderer
+        data={{
+          previewCallerName: null,
+          hasDeltas: false,
+          priorCallId: null,
+          priorPriorCallId: null,
+          added: [],
+          updated: [],
+        }}
+        selection={{ selectedKey: "memoryDeltas" }}
+      />,
+    );
+    expect(screen.getByText(/no learners enrolled/i)).toBeTruthy();
+  });
+
+  it("renders the Call 1 state when priorCallId is null", () => {
+    render(
+      <MemoryDeltasRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasDeltas: false,
+          priorCallId: null,
+          priorPriorCallId: null,
+          added: [],
+          updated: [],
+        }}
+        selection={{ selectedKey: "memoryDeltas" }}
+      />,
+    );
+    expect(screen.getByText(/no prior call yet/i)).toBeTruthy();
+  });
+
+  it("renders the 'no memory changes' state when prior call exists but no deltas", () => {
+    render(
+      <MemoryDeltasRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasDeltas: false,
+          priorCallId: "call-prior",
+          priorPriorCallId: "call-prior-prior",
+          added: [],
+          updated: [],
+        }}
+        selection={{ selectedKey: "memoryDeltas" }}
+      />,
+    );
+    expect(screen.getByText(/no memory changes since last call/i)).toBeTruthy();
+  });
+});
+
+describe("MemoryDeltasRenderer — populated states", () => {
+  it("renders added entries with category, key, value", () => {
+    render(
+      <MemoryDeltasRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasDeltas: true,
+          priorCallId: "call-prior",
+          priorPriorCallId: null,
+          added: [
+            { category: "PREFERENCE", key: "tutor_tone", value: "warm", confidence: 0.9 },
+          ],
+          updated: [],
+        }}
+        selection={{ selectedKey: "memoryDeltas" }}
+      />,
+    );
+    expect(screen.getAllByText(/added/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/PREFERENCE/)).toBeTruthy();
+    expect(screen.getByText(/tutor_tone/)).toBeTruthy();
+    expect(screen.getByText(/warm/)).toBeTruthy();
+  });
+
+  it("renders updated entries with the prior → new diff arrow", () => {
+    render(
+      <MemoryDeltasRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasDeltas: true,
+          priorCallId: "call-prior",
+          priorPriorCallId: "call-prior-prior",
+          added: [],
+          updated: [
+            {
+              category: "FACT",
+              key: "location",
+              value: "Manchester",
+              priorValue: "London",
+              confidence: 0.85,
+            },
+          ],
+        }}
+        selection={{ selectedKey: "memoryDeltas" }}
+      />,
+    );
+    expect(screen.getAllByText(/updated/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/location/)).toBeTruthy();
+    expect(screen.getByText(/Manchester/)).toBeTruthy();
+    expect(screen.getByText(/London/)).toBeTruthy();
+  });
+
+  it("renders both added + updated counts in the header", () => {
+    render(
+      <MemoryDeltasRenderer
+        data={{
+          previewCallerName: "Bertie",
+          hasDeltas: true,
+          priorCallId: "call-prior",
+          priorPriorCallId: "call-prior-prior",
+          added: [
+            { category: "FACT", key: "k1", value: "v1", confidence: 0.8 },
+            { category: "FACT", key: "k2", value: "v2", confidence: 0.8 },
+          ],
+          updated: [
+            {
+              category: "FACT",
+              key: "k3",
+              value: "new",
+              priorValue: "old",
+              confidence: 0.8,
+            },
+          ],
+        }}
+        selection={{ selectedKey: "memoryDeltas" }}
+      />,
+    );
+    expect(screen.getByText(/2 added.*1 updated/)).toBeTruthy();
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -10177,6 +10177,12 @@ Parse a Course Reference markdown body for an author-declared
 
 ---
 
+### `GET` /api/courses/[courseId]/memory-deltas-preview
+
+**Auth**: Session
+
+---
+
 ### `GET` /api/courses/[courseId]/proof-points
 
 **Auth**: OPERATOR+


### PR DESCRIPTION
## Summary

- **Final renderer of Epic #1606 Group A.5.** Inspector sticky for the `memoryDeltas` composer section shipped in #1653 (#1644)
- Distinguishes ADDED rows (success badge, value) from UPDATED rows (warning badge, `priorValue → newValue` diff arrow) so the educator sees at a glance what's "newly known" vs "freshly changed"
- 6th header chip in DesignTab — "Memory deltas: N+/M↑" — completes the chip set (firstCallMode / modePolicy / instructions / contentTrust / conversationArtifacts / memoryDeltas)

## Stacked PR note

**This PR is stacked on #1653.** Merge order: #1650 → #1653 → #1655 (conversationArtifacts renderer) → this. After #1653 merges, GitHub rebases this cleanly.

## Verified by

**Renderer contract pinned by 8 vitests at `tests/components/preview-renderers/memory-deltas-renderer.test.tsx`:**
- Registry contract — `getPreviewRenderer('memoryDeltas')` returns the component
- 4 empty-state branches: `loading` / `previewCallerName === null` / Call 1 (priorCallId null) / no-deltas
- Added entries render with category + key + value + success badge
- Updated entries render with prior → new diff arrow + warning badge
- Combined header count ("2 added, 1 updated")

**Sibling regression sweep:** 69/69 across `tests/components/preview-renderers/`. Lint clean. tsc within ratchet (will likely report ~30 errors, well under baseline).

**Live verification deferred to hf-dev** — same as #1655. Will smoke after `/vm-cp` lands and the prereqs deploy.

## Test plan

- [x] Renderer vitests (8/8) green
- [x] Sibling tests (61/61 in the rest of the bank) still pass
- [x] Lint + tsc clean on changed files
- [ ] `/vm-cp` after merge → smoke the route on hf-dev

Closes #1645. **Closes Epic #1606 Group A.5 entirely** once all 4 stacked PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)