### PR TITLE
feat(skill-tier): #1657 — flip SYSTEM default from IELTS to Generic 4-tier

### DIFF
--- a/apps/admin/components/shared/BandingPicker.tsx
+++ b/apps/admin/components/shared/BandingPicker.tsx
@@ -8,7 +8,7 @@
  * Presets defined in `lib/banding/presets.ts`. Custom shape is hand-edited
  * JSON for now (advanced — preset names cover 90% of cases).
  *
- * #417 Story C.
+ * #417 Story C / #1647 Source-derived / #1657 Generic default.
  */
 import { useState } from "react";
 import {
@@ -52,11 +52,12 @@ function labelsMatch(mapping: Mapping, preset: TierPreset): boolean {
  * radio.
  *
  * Order matters:
- *  - First match label-bearing presets (CEFR, 5-Level) on BOTH numbers and
- *    labels. A mapping with cefr numbers but Foundation/Developing/... labels
- *    must NOT collapse into the CEFR radio.
- *  - Then match label-free presets (IELTS, custom) on numbers only when the
- *    current mapping ALSO has no labels.
+ *  - Null mapping → "generic" (the #1657 HF default).
+ *  - First match label-bearing presets (IELTS, CEFR, 5-Level) on BOTH
+ *    numbers and labels. A mapping with cefr numbers but Foundation/…
+ *    labels must NOT collapse into the CEFR radio.
+ *  - Then match label-free presets (generic, custom) on numbers only when
+ *    the current mapping ALSO has no labels.
  *  - If labels are present but didn't match any baked preset → "source-derived"
  *    (the #1635 derivation path — labels parsed from the uploaded document).
  *  - Otherwise fall through to "custom" (hand-edited mapping with no labels).
@@ -65,7 +66,7 @@ function labelsMatch(mapping: Mapping, preset: TierPreset): boolean {
  * placeholder; the live shape is read from `current` at render time.
  */
 function detectPresetId(mapping: PlaybookConfig["skillTierMapping"]): TierPresetId {
-  if (!mapping) return "ielts-speaking";
+  if (!mapping) return "generic";
   const m = mapping as Mapping;
 
   for (const [id, p] of Object.entries(TIER_PRESETS) as [TierPresetId, TierPreset][]) {
@@ -99,13 +100,14 @@ export function BandingPicker({ courseId, current, onSaved }: BandingPickerProps
     setSuccess(false);
     try {
       if (selected === "source-derived") {
+        // Banding is already set by the #1635 derivation; nothing to save.
         setSuccess(true);
         onSaved?.();
         return;
       }
       const body =
-        selected === "ielts-speaking"
-          ? { skillTierMapping: null } // null = clear → fall back to contract default
+        selected === "generic"
+          ? { skillTierMapping: null } // null = clear → fall back to contract default (Generic post-#1657)
           : {
               skillTierMapping: {
                 thresholds: preset.mapping.thresholds,
@@ -135,8 +137,10 @@ export function BandingPicker({ courseId, current, onSaved }: BandingPickerProps
     <div className="hf-card-compact">
       <div className="hf-text-xs hf-text-muted hf-mb-md">
         How <Acronym>SKILL-NN</Acronym> ACHIEVE goal progress maps to a tier
-        label + band number. Default is IELTS Speaking. Change this when the
-        course isn&apos;t an IELTS-style criterion exam.
+        label + band number. Default is HF&apos;s neutral 4-tier scheme.
+        Pick <span className="hf-text-bold">IELTS Speaking</span> or{" "}
+        <span className="hf-text-bold">CEFR</span> if your course uses one of
+        those frameworks.
       </div>
       <div className="hf-flex-col hf-gap-sm">
         {(Object.values(TIER_PRESETS) as TierPreset[]).map((p) => {

--- a/apps/admin/docs-archive/bdd-specs/contracts/SKILL_MEASURE_V1.contract.json
+++ b/apps/admin/docs-archive/bdd-specs/contracts/SKILL_MEASURE_V1.contract.json
@@ -3,7 +3,8 @@
   "version": "1.0",
   "status": "active",
   "_reverted_2026_06_06": "Prod values restored per audit G8 (#1151). Active values match SKILL-AGG-001 spec. Per-playbook overrides via Playbook.config.skillScoringEmaHalfLifeDays + Playbook.config.skillMinCallsToFull are the canonical mechanism for course-specific tuning.",
-  "description": "Contract for per-skill EMA scoring + ACHIEVE goal banding (#417). Defines the running-score thresholds, tier→band mapping, EMA half-life, and first-call cap used to translate CallerTarget.currentScore into a tier label and an IELTS-style band number for ACHIEVE goal progress + tutor feedback.",
+  "_reseeded_2026_06_14": "Flipped from IELTS-shape (3/4/5.5/7) to Generic 4-tier (1/2/3/4) per #1657. IELTS courses now carry explicit Playbook.config.skillTierMapping written by scripts/migrate-ielts-playbook-mapping.ts. The contract is now the institutional default for non-IELTS courses.",
+  "description": "Contract for per-skill EMA scoring + ACHIEVE goal banding (#417). Defines the running-score thresholds, tier→band mapping, EMA half-life, and first-call cap used to translate CallerTarget.currentScore into a tier label and a generic band number for ACHIEVE goal progress + tutor feedback. IELTS courses override via Playbook.config.skillTierMapping with IELTS-specific bands 3/4/5.5/7.",
 
   "appliesTo": {
     "specRoles": ["MEASURE", "CONTENT"],
@@ -11,17 +12,17 @@
   },
 
   "thresholds": {
-    "approachingEmerging": 0.3,
-    "emerging": 0.55,
-    "developing": 0.7,
+    "approachingEmerging": 0.25,
+    "emerging": 0.5,
+    "developing": 0.75,
     "secure": 1.0
   },
 
   "tierBands": {
-    "approachingEmerging": 3,
-    "emerging": 4,
-    "developing": 5.5,
-    "secure": 7
+    "approachingEmerging": 1,
+    "emerging": 2,
+    "developing": 3,
+    "secure": 4
   },
 
   "bandDescriptorsSource": {

--- a/apps/admin/instrumentation.ts
+++ b/apps/admin/instrumentation.ts
@@ -1,0 +1,32 @@
+/**
+ * Next.js instrumentation hook — runs once at server startup.
+ *
+ * Today this fires the skill-tier deploy-readiness invariant (#1657) so a
+ * deploy that flipped the SKILL_MEASURE_V1 contract to Generic WITHOUT
+ * also running `scripts/migrate-ielts-playbook-mapping.ts --execute`
+ * produces an immediately visible ERROR log line — operator can spot it
+ * in Cloud Run logs before learners see degraded scoring.
+ *
+ * The invariant is read-only — it never mutates state.
+ *
+ * Failures inside `register()` are swallowed to avoid blocking server
+ * startup on a Prisma blip; the operator-facing preflight script
+ * (`scripts/check-skill-tier-deploy-readiness.ts`) is the canonical
+ * gate.
+ */
+
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  try {
+    const { checkSkillTierDeployReadiness, logSkillTierDeployVerdict } =
+      await import("@/lib/banding/skill-tier-deploy-invariant");
+    const verdict = await checkSkillTierDeployReadiness();
+    logSkillTierDeployVerdict(verdict);
+  } catch (err) {
+    console.warn(
+      "[skill-tier][deploy-invariant] startup check failed (non-fatal):",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}

--- a/apps/admin/lib/banding/presets.ts
+++ b/apps/admin/lib/banding/presets.ts
@@ -1,18 +1,22 @@
 /**
- * Per-playbook tier-mapping presets (#417 / Story C).
+ * Per-playbook tier-mapping presets (#417 / Story C / #1647 / #1657).
  *
- * Three presets out of the box plus a "custom" escape hatch. The shape
- * matches `SkillTierMapping` from `lib/goals/track-progress.ts` so
- * `scoreToTier()` consumes them directly.
+ * The shape matches `SkillTierMapping` from `lib/goals/track-progress.ts`
+ * so `scoreToTier()` consumes them directly.
  *
  * Selection mechanism (highest precedence first):
  *   1. `Playbook.config.skillTierMapping` (full mapping override)
  *   2. `SKILL_MEASURE_V1` contract thresholds / tierBands
  *   3. Built-in defaults inside `scoreToTier`
+ *
+ * Default is **Generic 4-tier** (#1657). IELTS Speaking, CEFR, and 5-Level
+ * are framework-specific explicit picks. `source-derived` is the synthetic
+ * 5th entry (#1647) that surfaces #1635's auto-derived mapping in the picker.
  */
 import type { SkillTierMapping } from "@/lib/goals/track-progress";
 
 export type TierPresetId =
+  | "generic"
   | "ielts-speaking"
   | "cefr"
   | "5-level"
@@ -27,8 +31,8 @@ export interface TierPreset {
    * The mapping itself. NOTE: `scoreToTier` uses 4 tiers in fixed slots
    * (`approachingEmerging` / `emerging` / `developing` / `secure`).
    * Custom band labels surface via `tierLabels` (consumer UI override),
-   * but the threshold slots stay the same. CEFR / 5-Level map their
-   * native labels onto these 4 slots.
+   * but the threshold slots stay the same. CEFR / 5-Level / IELTS map
+   * their native labels onto these 4 slots.
    */
   mapping: SkillTierMapping;
   /**
@@ -45,11 +49,31 @@ export interface TierPreset {
 }
 
 export const TIER_PRESETS: Record<TierPresetId, TierPreset> = {
+  generic: {
+    id: "generic",
+    label: "Generic 4-tier (HF default)",
+    description:
+      "Neutral 4-tier scheme for any course. Tiers map to bands 1 / 2 / 3 / 4. Pick a framework-specific preset (IELTS, CEFR) if your course uses one.",
+    mapping: {
+      thresholds: {
+        approachingEmerging: 0.25,
+        emerging: 0.5,
+        developing: 0.75,
+        secure: 1.0,
+      },
+      tierBands: {
+        approachingEmerging: 1,
+        emerging: 2,
+        developing: 3,
+        secure: 4,
+      },
+    },
+  },
   "ielts-speaking": {
     id: "ielts-speaking",
     label: "IELTS Speaking",
     description:
-      "Default IELTS Speaking criterion banding (Approaching Emerging / Emerging / Developing / Secure mapping to bands 3 / 4 / 5.5 / 7).",
+      "IELTS Speaking criterion banding. Tiers map to IELTS bands 3 / 4 / 5.5 / 7. Pick this for IELTS preparation courses.",
     mapping: {
       thresholds: {
         approachingEmerging: 0.3,
@@ -63,6 +87,12 @@ export const TIER_PRESETS: Record<TierPresetId, TierPreset> = {
         developing: 5.5,
         secure: 7,
       },
+    },
+    tierLabels: {
+      approachingEmerging: "Band 3",
+      emerging: "Band 4",
+      developing: "Band 5.5",
+      secure: "Band 7",
     },
   },
   cefr: {
@@ -144,23 +174,23 @@ export const TIER_PRESETS: Record<TierPresetId, TierPreset> = {
       "Educator-defined thresholds + band numbers + tier labels. Set via `Playbook.config.skillTierMapping`.",
     mapping: {
       thresholds: {
-        approachingEmerging: 0.3,
-        emerging: 0.55,
-        developing: 0.7,
+        approachingEmerging: 0.25,
+        emerging: 0.5,
+        developing: 0.75,
         secure: 1.0,
       },
       tierBands: {
-        approachingEmerging: 3,
-        emerging: 4,
-        developing: 5.5,
-        secure: 7,
+        approachingEmerging: 1,
+        emerging: 2,
+        developing: 3,
+        secure: 4,
       },
     },
   },
 };
 
-/** Resolve a preset by id; defaults to IELTS Speaking if no match. */
+/** Resolve a preset by id; defaults to Generic 4-tier when no match. */
 export function getPreset(id: TierPresetId | string | undefined | null): TierPreset {
-  if (!id) return TIER_PRESETS["ielts-speaking"];
-  return TIER_PRESETS[id as TierPresetId] ?? TIER_PRESETS["ielts-speaking"];
+  if (!id) return TIER_PRESETS.generic;
+  return TIER_PRESETS[id as TierPresetId] ?? TIER_PRESETS.generic;
 }

--- a/apps/admin/lib/banding/skill-tier-deploy-invariant.ts
+++ b/apps/admin/lib/banding/skill-tier-deploy-invariant.ts
@@ -1,0 +1,176 @@
+/**
+ * Skill-tier deploy invariant (#1657).
+ *
+ * After the #1657 SYSTEM-default flip from IELTS to Generic 4-tier,
+ * any IELTS-signal Playbook that doesn't carry an EXPLICIT
+ * `Playbook.config.skillTierMapping` will silently start scoring on
+ * Generic bands (1/2/3/4) instead of IELTS bands (3/4/5.5/7).
+ *
+ * Two pre-deploy migration scripts exist to prevent this:
+ *   - `scripts/migrate-ielts-playbook-mapping.ts` — writes explicit
+ *     IELTS mapping on IELTS-signal Playbooks.
+ *   - `scripts/reseed-skill-measure-contract-generic.ts` — reseeds the
+ *     SystemSetting contract to Generic.
+ *
+ * This invariant runs at server startup (`instrumentation.ts`) and at
+ * operator request (`scripts/check-skill-tier-deploy-readiness.ts`).
+ * Output is read-only — it never mutates state.
+ *
+ * Return value classes:
+ *   - `safe-pre-1657`: contract still IELTS-shaped (the flip hasn't
+ *     been applied to this env yet). Behavior is pre-#1657. OK.
+ *   - `safe-post-1657`: contract Generic AND no unsafe IELTS playbooks.
+ *     The deploy ran the migrations correctly. OK.
+ *   - `UNSAFE-MIGRATION-MISSED`: contract Generic but IELTS-signal
+ *     playbooks STILL have null mapping. These playbooks will score on
+ *     Generic bands at runtime — the migration step was skipped. The
+ *     operator must run `migrate-ielts-playbook-mapping.ts --execute`.
+ *
+ * Defence-in-depth — the cleanest fix is the operator running the
+ * preflight check before deploy. This invariant is the safety net.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+export type SkillTierDeployStatus =
+  | "safe-pre-1657"
+  | "safe-post-1657"
+  | "UNSAFE-MIGRATION-MISSED";
+
+export interface SkillTierDeployVerdict {
+  status: SkillTierDeployStatus;
+  contractShape: "ielts-3-4-5.5-7" | "generic-1-2-3-4" | "unknown" | "missing";
+  unsafePlaybookCount: number;
+  unsafePlaybookSample: Array<{ id: string; name: string; ieltsSignal: string }>;
+  summary: string;
+}
+
+const CONTRACT_KEY = "contract:SKILL_MEASURE_V1";
+
+interface PlaybookRow {
+  id: string;
+  name: string;
+  config: Record<string, unknown> | null;
+  subjects: { subject: { name: string } }[];
+}
+
+function identifyIeltsSignal(p: PlaybookRow): string | null {
+  for (const s of p.subjects) {
+    if (/ielts/i.test(s.subject.name)) return `subject:${s.subject.name}`;
+  }
+  const cfg = p.config ?? {};
+  if (cfg.tierPresetId === "ielts-speaking") return "config.tierPresetId=ielts-speaking";
+  if (cfg.assessmentMode === "ielts-speaking") return "config.assessmentMode=ielts-speaking";
+  return null;
+}
+
+function hasExplicitMapping(cfg: Record<string, unknown> | null): boolean {
+  if (!cfg) return false;
+  const m = cfg.skillTierMapping as
+    | { thresholds?: { secure?: unknown }; tierBands?: { secure?: unknown } }
+    | null
+    | undefined;
+  if (!m || typeof m !== "object") return false;
+  return (
+    typeof m.thresholds?.secure === "number" &&
+    typeof m.tierBands?.secure === "number"
+  );
+}
+
+function classifyContractShape(
+  thresholds: Record<string, unknown> | undefined,
+  tierBands: Record<string, unknown> | undefined,
+): SkillTierDeployVerdict["contractShape"] {
+  if (!thresholds || !tierBands) return "missing";
+  if (
+    tierBands.approachingEmerging === 3 &&
+    tierBands.emerging === 4 &&
+    tierBands.developing === 5.5 &&
+    tierBands.secure === 7
+  ) {
+    return "ielts-3-4-5.5-7";
+  }
+  if (
+    tierBands.approachingEmerging === 1 &&
+    tierBands.emerging === 2 &&
+    tierBands.developing === 3 &&
+    tierBands.secure === 4
+  ) {
+    return "generic-1-2-3-4";
+  }
+  return "unknown";
+}
+
+export async function checkSkillTierDeployReadiness(): Promise<SkillTierDeployVerdict> {
+  const setting = await prisma.systemSetting.findUnique({
+    where: { key: CONTRACT_KEY },
+  });
+
+  let contractShape: SkillTierDeployVerdict["contractShape"] = "missing";
+  if (setting) {
+    try {
+      const parsed = JSON.parse(setting.value);
+      contractShape = classifyContractShape(parsed.thresholds, parsed.tierBands);
+    } catch {
+      contractShape = "unknown";
+    }
+  }
+
+  if (contractShape !== "generic-1-2-3-4") {
+    return {
+      status: "safe-pre-1657",
+      contractShape,
+      unsafePlaybookCount: 0,
+      unsafePlaybookSample: [],
+      summary: `Contract shape is ${contractShape} — pre-#1657 state. No invariant check needed.`,
+    };
+  }
+
+  const playbooks = (await prisma.playbook.findMany({
+    select: {
+      id: true,
+      name: true,
+      config: true,
+      subjects: { select: { subject: { select: { name: true } } } },
+    },
+  })) as PlaybookRow[];
+
+  const unsafe: Array<{ id: string; name: string; ieltsSignal: string }> = [];
+  for (const p of playbooks) {
+    const signal = identifyIeltsSignal(p);
+    if (!signal) continue;
+    if (hasExplicitMapping(p.config)) continue;
+    unsafe.push({ id: p.id, name: p.name, ieltsSignal: signal });
+  }
+
+  if (unsafe.length === 0) {
+    return {
+      status: "safe-post-1657",
+      contractShape: "generic-1-2-3-4",
+      unsafePlaybookCount: 0,
+      unsafePlaybookSample: [],
+      summary: "Contract is Generic 4-tier; no IELTS-signal playbook is missing an explicit mapping. Safe.",
+    };
+  }
+
+  return {
+    status: "UNSAFE-MIGRATION-MISSED",
+    contractShape: "generic-1-2-3-4",
+    unsafePlaybookCount: unsafe.length,
+    unsafePlaybookSample: unsafe.slice(0, 5),
+    summary: `Contract is Generic 4-tier BUT ${unsafe.length} IELTS-signal playbook(s) have null skillTierMapping — they will score on Generic bands (1/2/3/4) instead of IELTS bands (3/4/5.5/7). Run \`npx tsx apps/admin/scripts/migrate-ielts-playbook-mapping.ts --execute\` immediately.`,
+  };
+}
+
+export function logSkillTierDeployVerdict(verdict: SkillTierDeployVerdict): void {
+  const prefix = "[skill-tier][deploy-invariant]";
+  if (verdict.status === "UNSAFE-MIGRATION-MISSED") {
+    console.error(`${prefix} ❌ UNSAFE DEPLOY STATE`);
+    console.error(`${prefix} ${verdict.summary}`);
+    for (const p of verdict.unsafePlaybookSample) {
+      console.error(`${prefix}   - ${p.name} (id=${p.id.slice(0, 8)}, signal=${p.ieltsSignal})`);
+    }
+    return;
+  }
+  console.log(`${prefix} ${verdict.status} — ${verdict.summary}`);
+}

--- a/apps/admin/lib/goals/track-progress.ts
+++ b/apps/admin/lib/goals/track-progress.ts
@@ -28,19 +28,30 @@ export interface GoalProgressUpdate {
 
 // ── #417 Phase D — banding helper + ACHIEVE skill progress ────────────────
 
-/** Default banding when SKILL_MEASURE_V1 contract isn't seeded yet. */
+/**
+ * Default banding when SKILL_MEASURE_V1 contract isn't seeded yet.
+ *
+ * #1657 — flipped from IELTS-shape (3/4/5.5/7) to Generic 4-tier (1/2/3/4)
+ * so non-IELTS courses get meaningful band numbers by default. IELTS
+ * courses now carry an explicit per-Playbook `skillTierMapping` written
+ * by `scripts/migrate-ielts-playbook-mapping.ts`.
+ *
+ * Defence-in-depth only — the SKILL_MEASURE_V1 contract intercepts at
+ * layer 2 before this default fires. The contract was reseeded to match
+ * via `scripts/reseed-skill-measure-contract-generic.ts`.
+ */
 const SKILL_TIER_DEFAULTS = {
   thresholds: {
-    approachingEmerging: 0.3,
-    emerging: 0.55,
-    developing: 0.7,
+    approachingEmerging: 0.25,
+    emerging: 0.5,
+    developing: 0.75,
     secure: 1.0,
   },
   tierBands: {
-    approachingEmerging: 3,
-    emerging: 4,
-    developing: 5.5,
-    secure: 7,
+    approachingEmerging: 1,
+    emerging: 2,
+    developing: 3,
+    secure: 4,
   },
 };
 
@@ -61,9 +72,10 @@ export interface SkillTierMapping {
 
 /**
  * Pure-function tier classifier — exported for unit tests. Maps a 0-1
- * running skill score to a named tier and an IELTS-style band number.
- * Thresholds are inclusive at the upper end of each tier; see contract
- * notes for the IELTS band correspondence.
+ * running skill score to a named tier and a band number.
+ * Thresholds are inclusive at the upper end of each tier. Band-number
+ * semantics depend on the supplied `mapping` — IELTS courses pass an
+ * IELTS-shape mapping; Generic 4-tier courses get bands 1–4.
  */
 export function scoreToTier(
   score: number,

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -499,7 +499,7 @@ export interface PlaybookConfig {
    * `lib/banding/presets.ts::TierPresetId`. Type imported lazily there
    * to avoid a circular import via the JSON-shape file.
    */
-  tierPresetId?: "ielts-speaking" | "cefr" | "5-level" | "custom";
+  tierPresetId?: "generic" | "ielts-speaking" | "cefr" | "5-level" | "custom";
   /**
    * #779 — Felt Progress S1. Controls the `progressNarrative` composer
    * section that gives the AI evidence of LO mastery for mid-call

--- a/apps/admin/scripts/check-skill-tier-deploy-readiness.ts
+++ b/apps/admin/scripts/check-skill-tier-deploy-readiness.ts
@@ -1,0 +1,48 @@
+/**
+ * Operator-facing preflight check for #1657 deploy safety.
+ *
+ * Verifies that the SKILL_MEASURE_V1 contract + the per-Playbook
+ * skillTierMapping rows are in a consistent state before the code is
+ * deployed.
+ *
+ * Run before `/deploy` or `/vm-cpp` on each environment:
+ *
+ *   npx tsx apps/admin/scripts/check-skill-tier-deploy-readiness.ts
+ *
+ * Exit codes:
+ *   0  — safe-pre-1657 (contract still IELTS) OR safe-post-1657
+ *        (contract Generic + no unsafe IELTS playbooks). Deploy may
+ *        proceed.
+ *   2  — UNSAFE-MIGRATION-MISSED. Contract flipped to Generic but
+ *        IELTS-signal playbooks still have null mapping. The deploy
+ *        will silently degrade IELTS course scoring. Run
+ *        `migrate-ielts-playbook-mapping.ts --execute` immediately.
+ *   1  — unexpected error (DB unreachable, etc.).
+ *
+ * If you're running this AFTER a deploy and it returns 2: roll back or
+ * run the migration script + redeploy.
+ */
+
+import {
+  checkSkillTierDeployReadiness,
+  logSkillTierDeployVerdict,
+} from "../lib/banding/skill-tier-deploy-invariant";
+
+async function main(): Promise<void> {
+  const verdict = await checkSkillTierDeployReadiness();
+  logSkillTierDeployVerdict(verdict);
+
+  if (verdict.status === "UNSAFE-MIGRATION-MISSED") {
+    console.error("");
+    console.error("DEPLOY GATE FAILED. Run the following before retrying:");
+    console.error("  npx tsx apps/admin/scripts/migrate-ielts-playbook-mapping.ts");
+    console.error("  npx tsx apps/admin/scripts/migrate-ielts-playbook-mapping.ts --execute");
+    process.exit(2);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("[check-skill-tier-deploy-readiness] failed:", e);
+  process.exit(1);
+});

--- a/apps/admin/scripts/migrate-ielts-playbook-mapping.ts
+++ b/apps/admin/scripts/migrate-ielts-playbook-mapping.ts
@@ -1,0 +1,171 @@
+/**
+ * One-off migration — write explicit IELTS Speaking tier mapping on
+ * Playbooks that are IELTS-signal but rely on the silent IELTS fallback
+ * (null `Playbook.config.skillTierMapping`) (#1657).
+ *
+ * Why a separate script and not the seed:
+ *   - The pre-#1657 IELTS default lived in two layers below the per-Playbook
+ *     override: SKILL_MEASURE_V1 contract (layer 2) and SKILL_TIER_DEFAULTS
+ *     (layer 3). Both flip to Generic 4-tier in the same PR — so any
+ *     IELTS course that was relying on either silent fallback will lose
+ *     its IELTS bands the moment the reseed lands.
+ *   - Running this script BEFORE the reseed pins IELTS bands per-course
+ *     so IELTS scoring is unaffected by the SYSTEM-default change.
+ *
+ * Identification signals (any single signal is sufficient):
+ *   1. Joined Subject name (via PlaybookSubject) contains "IELTS" (case-insensitive).
+ *   2. `Playbook.config.tierPresetId === "ielts-speaking"`.
+ *   3. `Playbook.config.assessmentMode === "ielts-speaking"`.
+ *
+ * Safety rules (run-anywhere idempotent):
+ *   - Touches every Playbook row but only mutates when (a) it matches an
+ *     IELTS signal AND (b) `config.skillTierMapping` is null/missing.
+ *   - Rows with an explicit mapping already are left alone.
+ *   - `--dry-run` (default) prints planned changes without writing.
+ *   - `--execute` actually writes.
+ *   - Re-runs are no-ops.
+ *
+ * Usage:
+ *   npx tsx apps/admin/scripts/migrate-ielts-playbook-mapping.ts
+ *   npx tsx apps/admin/scripts/migrate-ielts-playbook-mapping.ts --execute
+ */
+
+import { PrismaClient, Prisma } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const IELTS_MAPPING = {
+  thresholds: {
+    approachingEmerging: 0.3,
+    emerging: 0.55,
+    developing: 0.7,
+    secure: 1.0,
+  },
+  tierBands: {
+    approachingEmerging: 3,
+    emerging: 4,
+    developing: 5.5,
+    secure: 7,
+  },
+  tierLabels: {
+    approachingEmerging: "Band 3",
+    emerging: "Band 4",
+    developing: "Band 5.5",
+    secure: "Band 7",
+  },
+} as const;
+
+interface ConfigBlob {
+  skillTierMapping?: unknown;
+  tierPresetId?: unknown;
+  assessmentMode?: unknown;
+  [key: string]: unknown;
+}
+
+interface MappingShape {
+  thresholds?: { secure?: unknown };
+  tierBands?: { secure?: unknown };
+}
+
+function hasExplicitMapping(cfg: ConfigBlob): boolean {
+  const m = cfg.skillTierMapping as MappingShape | null | undefined;
+  if (!m || typeof m !== "object") return false;
+  const thresholds = m.thresholds;
+  const tierBands = m.tierBands;
+  return (
+    !!thresholds &&
+    !!tierBands &&
+    typeof thresholds.secure === "number" &&
+    typeof tierBands.secure === "number"
+  );
+}
+
+interface PlaybookRow {
+  id: string;
+  name: string;
+  config: ConfigBlob | null;
+  subjects: { subject: { name: string } }[];
+}
+
+function identifyIeltsSignal(p: PlaybookRow): string | null {
+  const subjectNames = p.subjects.map((s) => s.subject.name);
+  if (subjectNames.some((n) => /ielts/i.test(n))) {
+    return `subject:${subjectNames.find((n) => /ielts/i.test(n))}`;
+  }
+  const cfg = p.config ?? {};
+  if (cfg.tierPresetId === "ielts-speaking") return "config.tierPresetId=ielts-speaking";
+  if (cfg.assessmentMode === "ielts-speaking") return "config.assessmentMode=ielts-speaking";
+  return null;
+}
+
+async function main(): Promise<void> {
+  const execute = process.argv.includes("--execute");
+  const mode = execute ? "EXECUTE" : "DRY-RUN";
+  console.log(`[migrate-ielts-mapping] running in ${mode} mode`);
+
+  const rows = await prisma.playbook.findMany({
+    select: {
+      id: true,
+      name: true,
+      config: true,
+      subjects: { select: { subject: { select: { name: true } } } },
+    },
+  });
+
+  console.log(`[migrate-ielts-mapping] scanning ${rows.length} playbooks…`);
+
+  let migrated = 0;
+  let skippedAlreadyExplicit = 0;
+  let skippedNotIelts = 0;
+
+  for (const p of rows as PlaybookRow[]) {
+    const cfg = p.config ?? {};
+    const signal = identifyIeltsSignal(p);
+    if (!signal) {
+      skippedNotIelts++;
+      continue;
+    }
+    if (hasExplicitMapping(cfg)) {
+      skippedAlreadyExplicit++;
+      console.log(
+        `  - SKIP (already explicit) ${p.name} (id=${p.id.slice(0, 8)}) — signal: ${signal}`,
+      );
+      continue;
+    }
+    console.log(
+      `  - ${execute ? "WRITE" : "WOULD WRITE"} IELTS mapping on ${p.name} (id=${p.id.slice(
+        0,
+        8,
+      )}) — signal: ${signal}`,
+    );
+    if (execute) {
+      const nextConfig = {
+        ...cfg,
+        skillTierMapping: IELTS_MAPPING,
+      };
+      await prisma.playbook.update({
+        where: { id: p.id },
+        data: { config: nextConfig as Prisma.InputJsonValue },
+      });
+    }
+    migrated++;
+  }
+
+  console.log("");
+  console.log("[migrate-ielts-mapping] summary:");
+  console.log(`  ${execute ? "migrated" : "would migrate"}:    ${migrated}`);
+  console.log(`  skipped (already explicit): ${skippedAlreadyExplicit}`);
+  console.log(`  skipped (no IELTS signal):  ${skippedNotIelts}`);
+  if (!execute && migrated > 0) {
+    console.log("");
+    console.log("[migrate-ielts-mapping] re-run with --execute to apply.");
+  }
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(async (e) => {
+    console.error("[migrate-ielts-mapping] failed:", e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/admin/scripts/reseed-skill-measure-contract-generic.ts
+++ b/apps/admin/scripts/reseed-skill-measure-contract-generic.ts
@@ -1,0 +1,133 @@
+/**
+ * One-off migration — reseed the `SKILL_MEASURE_V1` DataContract from
+ * IELTS-shape (3/4/5.5/7) to Generic 4-tier (1/2/3/4) (#1657).
+ *
+ * Why a separate script and not the seed JSON:
+ *   - The contract is loaded at runtime from `SystemSetting` (key:
+ *     `contract:SKILL_MEASURE_V1`). The JSON file at
+ *     `docs-archive/bdd-specs/contracts/SKILL_MEASURE_V1.contract.json`
+ *     is the SEED source — only writes on fresh-seed paths.
+ *   - hf-prod / hf-staging / hf-dev hold the pre-#1657 IELTS values in
+ *     `SystemSetting` already; running the seed doesn't stomp them.
+ *
+ * Safety rules (run-anywhere idempotent):
+ *   - Refuses to run if `SystemSetting` row for `contract:SKILL_MEASURE_V1`
+ *     doesn't exist (caller must seed first).
+ *   - Refuses to run if values already match Generic shape (no-op).
+ *   - Preserves every other field on the contract — only replaces
+ *     `thresholds` + `tierBands`.
+ *   - Adds an audit marker `_reseeded_2026_06_14` documenting the change.
+ *   - `--dry-run` (default) prints planned change without writing.
+ *   - `--execute` actually writes.
+ *
+ * CRITICAL: run `migrate-ielts-playbook-mapping.ts --execute` BEFORE this
+ * script. Without it, every IELTS course currently relying on the silent
+ * IELTS contract fallback will see learner bands shift from 3/4/5.5/7 to
+ * 1/2/3/4 the moment this reseed lands.
+ *
+ * Usage:
+ *   npx tsx apps/admin/scripts/reseed-skill-measure-contract-generic.ts
+ *   npx tsx apps/admin/scripts/reseed-skill-measure-contract-generic.ts --execute
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const KEY = "contract:SKILL_MEASURE_V1";
+
+const GENERIC_THRESHOLDS = {
+  approachingEmerging: 0.25,
+  emerging: 0.5,
+  developing: 0.75,
+  secure: 1.0,
+};
+const GENERIC_TIER_BANDS = {
+  approachingEmerging: 1,
+  emerging: 2,
+  developing: 3,
+  secure: 4,
+};
+
+function isGenericShape(
+  thresholds: Record<string, unknown> | undefined,
+  tierBands: Record<string, unknown> | undefined,
+): boolean {
+  if (!thresholds || !tierBands) return false;
+  return (
+    thresholds.approachingEmerging === GENERIC_THRESHOLDS.approachingEmerging &&
+    thresholds.emerging === GENERIC_THRESHOLDS.emerging &&
+    thresholds.developing === GENERIC_THRESHOLDS.developing &&
+    thresholds.secure === GENERIC_THRESHOLDS.secure &&
+    tierBands.approachingEmerging === GENERIC_TIER_BANDS.approachingEmerging &&
+    tierBands.emerging === GENERIC_TIER_BANDS.emerging &&
+    tierBands.developing === GENERIC_TIER_BANDS.developing &&
+    tierBands.secure === GENERIC_TIER_BANDS.secure
+  );
+}
+
+async function main(): Promise<void> {
+  const execute = process.argv.includes("--execute");
+  const mode = execute ? "EXECUTE" : "DRY-RUN";
+  console.log(`[reseed-skill-measure-contract] running in ${mode} mode`);
+
+  const setting = await prisma.systemSetting.findUnique({ where: { key: KEY } });
+  if (!setting) {
+    console.error(
+      `[reseed-skill-measure-contract] ${KEY} not found — seed it first via the normal seed path.`,
+    );
+    process.exit(2);
+  }
+
+  let contract: Record<string, unknown>;
+  try {
+    contract = JSON.parse(setting.value);
+  } catch (e) {
+    console.error(`[reseed-skill-measure-contract] could not parse contract JSON:`, e);
+    process.exit(2);
+  }
+
+  const currentThresholds = contract.thresholds as Record<string, unknown> | undefined;
+  const currentTierBands = contract.tierBands as Record<string, unknown> | undefined;
+
+  if (isGenericShape(currentThresholds, currentTierBands)) {
+    console.log(`[reseed-skill-measure-contract] already Generic 4-tier shape — no-op.`);
+    return;
+  }
+
+  console.log(`[reseed-skill-measure-contract] current shape:`);
+  console.log(`  thresholds: ${JSON.stringify(currentThresholds)}`);
+  console.log(`  tierBands:  ${JSON.stringify(currentTierBands)}`);
+  console.log(`[reseed-skill-measure-contract] target shape (Generic 4-tier):`);
+  console.log(`  thresholds: ${JSON.stringify(GENERIC_THRESHOLDS)}`);
+  console.log(`  tierBands:  ${JSON.stringify(GENERIC_TIER_BANDS)}`);
+
+  if (!execute) {
+    console.log("");
+    console.log("[reseed-skill-measure-contract] re-run with --execute to apply.");
+    return;
+  }
+
+  const next = {
+    ...contract,
+    thresholds: GENERIC_THRESHOLDS,
+    tierBands: GENERIC_TIER_BANDS,
+    _reseeded_2026_06_14:
+      "Flipped from IELTS-shape (3/4/5.5/7) to Generic 4-tier (1/2/3/4) per #1657. IELTS courses now carry explicit Playbook.config.skillTierMapping written by scripts/migrate-ielts-playbook-mapping.ts. The contract is now the institutional default for non-IELTS courses.",
+  };
+
+  await prisma.systemSetting.update({
+    where: { key: KEY },
+    data: { value: JSON.stringify(next, null, 2) },
+  });
+
+  console.log(`[reseed-skill-measure-contract] ✓ contract reseeded to Generic 4-tier.`);
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(async (e) => {
+    console.error("[reseed-skill-measure-contract] failed:", e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/admin/tests/components/shared/BandingPicker.test.tsx
+++ b/apps/admin/tests/components/shared/BandingPicker.test.tsx
@@ -1,12 +1,18 @@
 /**
  * Tests for `<BandingPicker>` — the per-playbook skill-tier-mapping picker.
  *
+ * Combines coverage from #1647 (source-derived preset) and #1657 (Generic
+ * SYSTEM-default flip).
+ *
  * Pins:
- *   1. detectPresetId — IELTS / CEFR / 5-Level / Custom / Source-derived
+ *   1. detectPresetId — Generic (null) / IELTS / CEFR / 5-Level / Custom / Source-derived
  *   2. Source-derived render branch shows `current.tierLabels` + `current.tierBands`
  *   3. Source-derived radio is hidden when `current.tierLabels` is absent
  *   4. Save handler short-circuits (no fetch) when source-derived is selected
- *   5. CTO mapping with 5-Level numbers + Foundation labels detects as
+ *   5. Save handler writes null when Generic is selected (the new clear-to-fallback)
+ *   6. Save handler writes explicit IELTS mapping when IELTS is selected
+ *   7. Microcopy mentions HF's neutral 4-tier scheme (post-#1657)
+ *   8. CTO mapping with 5-Level numbers + Foundation labels detects as
  *      source-derived, NOT 5-Level — pins the #1647 / #1635 fingerprint
  */
 
@@ -46,8 +52,28 @@ describe("<BandingPicker> detectPresetId via initial radio selection", () => {
     global.fetch = vi.fn();
   });
 
-  it("ielts-speaking preset selected when current is null", () => {
+  it("generic preset selected when current is null (post-#1657)", () => {
     render(<BandingPicker courseId="c1" current={undefined} />);
+    expect(
+      (screen.getByDisplayValue("generic") as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (screen.getByDisplayValue("ielts-speaking") as HTMLInputElement).checked,
+    ).toBe(false);
+  });
+
+  it("ielts-speaking preset selected when current matches IELTS numbers + labels", () => {
+    const ielts = TIER_PRESETS["ielts-speaking"];
+    render(
+      <BandingPicker
+        courseId="c1"
+        current={{
+          thresholds: ielts.mapping.thresholds,
+          tierBands: ielts.mapping.tierBands,
+          tierLabels: ielts.tierLabels,
+        }}
+      />,
+    );
     expect(
       (screen.getByDisplayValue("ielts-speaking") as HTMLInputElement).checked,
     ).toBe(true);
@@ -166,11 +192,50 @@ describe("<BandingPicker> save handler", () => {
     expect(onSaved).toHaveBeenCalledTimes(1);
   });
 
-  it("calls fetch for non-source-derived selections", async () => {
+  it("writes skillTierMapping: null when Generic is selected (clear-to-fallback)", async () => {
+    render(<BandingPicker courseId="c1" current={undefined} />);
+    fireEvent.click(screen.getByText(/save banding/i));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect(body).toEqual({ skillTierMapping: null });
+  });
+
+  it("writes explicit IELTS mapping with Band 7 label when IELTS is selected", async () => {
+    render(<BandingPicker courseId="c1" current={undefined} />);
+    fireEvent.click(screen.getByDisplayValue("ielts-speaking"));
+    fireEvent.click(screen.getByText(/save banding/i));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect(body.skillTierMapping).toBeTruthy();
+    expect(body.skillTierMapping.tierBands.secure).toBe(7);
+    expect(body.skillTierMapping.tierLabels.secure).toBe("Band 7");
+  });
+
+  it("calls fetch for CEFR selections too", async () => {
     render(<BandingPicker courseId="c1" current={CTO_MAPPING} />);
     fireEvent.click(screen.getByDisplayValue("cefr"));
     fireEvent.click(screen.getByText(/save banding/i));
     await new Promise((r) => setTimeout(r, 0));
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("<BandingPicker> #1657 microcopy", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it("mentions HF's neutral 4-tier scheme (not 'Default is IELTS')", () => {
+    const { container } = render(<BandingPicker courseId="c1" current={undefined} />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("HF");
+    expect(text).toContain("neutral 4-tier");
+    expect(text).not.toContain("Default is IELTS Speaking");
   });
 });

--- a/apps/admin/tests/lib/skill-tier-default-flip.test.ts
+++ b/apps/admin/tests/lib/skill-tier-default-flip.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Round-trip pin for #1657 — the IELTS → Generic 4-tier SYSTEM-default flip.
+ *
+ * Together with `skill-tier-mapping.test.ts`, these vitests assert that:
+ *   1. `getPreset(null)` returns the new Generic preset (not IELTS).
+ *   2. `getPreset("ielts-speaking")` returns the IELTS preset with bands 3/4/5.5/7.
+ *   3. `scoreToTier` with no mapping arg produces Generic bands.
+ *   4. `scoreToTier` with the IELTS preset mapping produces IELTS bands.
+ *   5. The Custom preset seed is no longer IELTS-shaped.
+ *   6. Every preset's mapping is internally consistent (thresholds + tierBands shape).
+ */
+
+import { describe, it, expect } from "vitest";
+import { TIER_PRESETS, getPreset } from "@/lib/banding/presets";
+import { scoreToTier } from "@/lib/goals/track-progress";
+
+describe("#1657 — IELTS → Generic SYSTEM-default flip", () => {
+  it("getPreset(null) returns the Generic 4-tier preset", () => {
+    const p = getPreset(null);
+    expect(p.id).toBe("generic");
+    expect(p.label).toContain("Generic");
+    expect(p.mapping.tierBands.secure).toBe(4);
+    expect(p.mapping.tierBands.approachingEmerging).toBe(1);
+  });
+
+  it("getPreset(undefined) returns Generic", () => {
+    expect(getPreset(undefined).id).toBe("generic");
+  });
+
+  it("getPreset('unknown-string') falls back to Generic, not IELTS", () => {
+    expect(getPreset("does-not-exist").id).toBe("generic");
+  });
+
+  it("IELTS Speaking preset still carries IELTS bands 3/4/5.5/7", () => {
+    const p = TIER_PRESETS["ielts-speaking"];
+    expect(p.mapping.tierBands.approachingEmerging).toBe(3);
+    expect(p.mapping.tierBands.emerging).toBe(4);
+    expect(p.mapping.tierBands.developing).toBe(5.5);
+    expect(p.mapping.tierBands.secure).toBe(7);
+  });
+
+  it("IELTS Speaking preset has explicit 'Band X' tier labels", () => {
+    const p = TIER_PRESETS["ielts-speaking"];
+    expect(p.tierLabels?.secure).toBe("Band 7");
+    expect(p.tierLabels?.approachingEmerging).toBe("Band 3");
+  });
+
+  it("Custom preset seed is Generic-shaped (no longer IELTS)", () => {
+    const p = TIER_PRESETS.custom;
+    expect(p.mapping.tierBands.secure).toBe(4);
+    expect(p.mapping.thresholds.emerging).toBe(0.5);
+  });
+
+  it("scoreToTier(0.99) with no mapping arg returns Generic band 4", () => {
+    const r = scoreToTier(0.99);
+    expect(r.band).toBe(4);
+    expect(r.tier).toBe("Secure");
+  });
+
+  it("scoreToTier(0.99, IELTS mapping) returns IELTS band 7", () => {
+    const r = scoreToTier(0.99, TIER_PRESETS["ielts-speaking"].mapping);
+    expect(r.band).toBe(7);
+    expect(r.tier).toBe("Secure");
+  });
+
+  it("scoreToTier(0.4) with no mapping arg sits in Generic emerging tier (band 2)", () => {
+    const r = scoreToTier(0.4);
+    expect(r.band).toBe(2);
+    expect(r.tier).toBe("Emerging");
+  });
+
+  it("scoreToTier(0.1) with no mapping arg sits below Generic approachingEmerging (band 1)", () => {
+    const r = scoreToTier(0.1);
+    expect(r.band).toBe(1);
+  });
+
+  it("every preset has the four tier slots populated for thresholds + tierBands", () => {
+    for (const id of Object.keys(TIER_PRESETS) as (keyof typeof TIER_PRESETS)[]) {
+      const p = TIER_PRESETS[id];
+      const t = p.mapping.thresholds;
+      const b = p.mapping.tierBands;
+      expect(typeof t.approachingEmerging).toBe("number");
+      expect(typeof t.emerging).toBe("number");
+      expect(typeof t.developing).toBe("number");
+      expect(typeof t.secure).toBe("number");
+      expect(typeof b.approachingEmerging).toBe("number");
+      expect(typeof b.emerging).toBe("number");
+      expect(typeof b.developing).toBe("number");
+      expect(typeof b.secure).toBe("number");
+    }
+  });
+});

--- a/apps/admin/tests/lib/skill-tier-deploy-invariant.test.ts
+++ b/apps/admin/tests/lib/skill-tier-deploy-invariant.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for #1657's deploy-readiness invariant.
+ *
+ * Pins the three verdict classes:
+ *   - safe-pre-1657 (contract still IELTS-shaped)
+ *   - safe-post-1657 (contract Generic + no unsafe playbooks)
+ *   - UNSAFE-MIGRATION-MISSED (contract Generic + IELTS playbook with null mapping)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFindUnique = vi.fn();
+const mockFindMany = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    systemSetting: { findUnique: (...a: unknown[]) => mockFindUnique(...a) },
+    playbook: { findMany: (...a: unknown[]) => mockFindMany(...a) },
+  },
+}));
+
+import { checkSkillTierDeployReadiness } from "@/lib/banding/skill-tier-deploy-invariant";
+
+const IELTS_CONTRACT = JSON.stringify({
+  thresholds: { approachingEmerging: 0.3, emerging: 0.55, developing: 0.7, secure: 1.0 },
+  tierBands: { approachingEmerging: 3, emerging: 4, developing: 5.5, secure: 7 },
+});
+
+const GENERIC_CONTRACT = JSON.stringify({
+  thresholds: { approachingEmerging: 0.25, emerging: 0.5, developing: 0.75, secure: 1.0 },
+  tierBands: { approachingEmerging: 1, emerging: 2, developing: 3, secure: 4 },
+});
+
+const IELTS_MAPPING = {
+  thresholds: { approachingEmerging: 0.3, emerging: 0.55, developing: 0.7, secure: 1.0 },
+  tierBands: { approachingEmerging: 3, emerging: 4, developing: 5.5, secure: 7 },
+};
+
+describe("checkSkillTierDeployReadiness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns safe-pre-1657 when contract is still IELTS-shaped", async () => {
+    mockFindUnique.mockResolvedValue({ value: IELTS_CONTRACT });
+
+    const v = await checkSkillTierDeployReadiness();
+
+    expect(v.status).toBe("safe-pre-1657");
+    expect(v.contractShape).toBe("ielts-3-4-5.5-7");
+    expect(v.unsafePlaybookCount).toBe(0);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns safe-pre-1657 when contract is missing entirely", async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const v = await checkSkillTierDeployReadiness();
+
+    expect(v.status).toBe("safe-pre-1657");
+    expect(v.contractShape).toBe("missing");
+  });
+
+  it("returns safe-post-1657 when contract is Generic and no IELTS playbooks have null mapping", async () => {
+    mockFindUnique.mockResolvedValue({ value: GENERIC_CONTRACT });
+    mockFindMany.mockResolvedValue([
+      {
+        id: "pb-ielts-1",
+        name: "IELTS Speaking Course",
+        config: { skillTierMapping: IELTS_MAPPING },
+        subjects: [{ subject: { name: "IELTS Speaking" } }],
+      },
+      {
+        id: "pb-non-ielts",
+        name: "CTO Standard",
+        config: { skillTierMapping: null },
+        subjects: [{ subject: { name: "CTO Standard – Revision Aid" } }],
+      },
+    ]);
+
+    const v = await checkSkillTierDeployReadiness();
+
+    expect(v.status).toBe("safe-post-1657");
+    expect(v.contractShape).toBe("generic-1-2-3-4");
+    expect(v.unsafePlaybookCount).toBe(0);
+  });
+
+  it("returns UNSAFE-MIGRATION-MISSED when contract is Generic but IELTS-signal playbook has null mapping", async () => {
+    mockFindUnique.mockResolvedValue({ value: GENERIC_CONTRACT });
+    mockFindMany.mockResolvedValue([
+      {
+        id: "pb-ielts-unsafe",
+        name: "IELTS Speaking PAW",
+        config: { skillTierMapping: null },
+        subjects: [{ subject: { name: "IELTS Speaking PAW" } }],
+      },
+    ]);
+
+    const v = await checkSkillTierDeployReadiness();
+
+    expect(v.status).toBe("UNSAFE-MIGRATION-MISSED");
+    expect(v.unsafePlaybookCount).toBe(1);
+    expect(v.unsafePlaybookSample[0].ieltsSignal).toContain("subject:IELTS Speaking PAW");
+    expect(v.summary).toContain("migrate-ielts-playbook-mapping");
+  });
+
+  it("detects IELTS signal via config.tierPresetId", async () => {
+    mockFindUnique.mockResolvedValue({ value: GENERIC_CONTRACT });
+    mockFindMany.mockResolvedValue([
+      {
+        id: "pb-tier-preset",
+        name: "Custom course",
+        config: { tierPresetId: "ielts-speaking" },
+        subjects: [{ subject: { name: "Some other subject" } }],
+      },
+    ]);
+
+    const v = await checkSkillTierDeployReadiness();
+
+    expect(v.status).toBe("UNSAFE-MIGRATION-MISSED");
+    expect(v.unsafePlaybookSample[0].ieltsSignal).toBe("config.tierPresetId=ielts-speaking");
+  });
+
+  it("caps unsafePlaybookSample at 5 entries even with more unsafe rows", async () => {
+    mockFindUnique.mockResolvedValue({ value: GENERIC_CONTRACT });
+    mockFindMany.mockResolvedValue(
+      Array.from({ length: 12 }, (_, i) => ({
+        id: `pb-${i}`,
+        name: `IELTS Course ${i}`,
+        config: { skillTierMapping: null },
+        subjects: [{ subject: { name: "IELTS Speaking" } }],
+      })),
+    );
+
+    const v = await checkSkillTierDeployReadiness();
+
+    expect(v.unsafePlaybookCount).toBe(12);
+    expect(v.unsafePlaybookSample).toHaveLength(5);
+  });
+});

--- a/apps/admin/tests/lib/skill-tier-mapping.test.ts
+++ b/apps/admin/tests/lib/skill-tier-mapping.test.ts
@@ -58,8 +58,10 @@ describe("getSkillTierMapping — SKILL_MEASURE_V1 contract resolution", () => {
 
     const mapping = await getSkillTierMapping(null);
 
-    // SKILL_TIER_DEFAULTS.thresholds.emerging is 0.55 — distinct from the tuned 0.45.
-    expect(mapping.thresholds.emerging).toBe(0.55);
+    // Post-#1657: SKILL_TIER_DEFAULTS.thresholds.emerging is 0.5 (Generic 4-tier),
+    // not 0.55 (legacy IELTS). Distinct from the tuned 0.45.
+    expect(mapping.thresholds.emerging).toBe(0.5);
+    expect(mapping.tierBands.secure).toBe(4);
   });
 
   it("falls back to defaults (does not throw) when the contract read errors", async () => {
@@ -67,7 +69,8 @@ describe("getSkillTierMapping — SKILL_MEASURE_V1 contract resolution", () => {
 
     const mapping = await getSkillTierMapping(null);
 
-    expect(mapping.thresholds.emerging).toBe(0.55);
+    expect(mapping.thresholds.emerging).toBe(0.5);
+    expect(mapping.tierBands.secure).toBe(4);
   });
 
   it("playbook config override takes precedence over the contract", async () => {


### PR DESCRIPTION
## Summary

Closes #1657. Decouples "IELTS Speaking" from the HF default 4-tier banding scheme. Non-IELTS courses (CTO Standard, sales coaching, NHS clinical, executive leadership) now get meaningful neutral band numbers (1/2/3/4) by default instead of silently inheriting IELTS bands 3/4/5.5/7.

Follow-on from #1635 (auto-derivation) + #1647 / PR #1649 (source-derived preset). Sibling PR to #1649 — both edit `lib/banding/presets.ts` and `components/shared/BandingPicker.tsx`. Conflict at merge time will be a clean union of two preset entries + sibling detectPresetId/save changes.

## The fix

The architecture was already mostly right: `getSkillTierMapping(playbookId)` in `lib/goals/track-progress.ts:86` is the single read entry point. The leak was the cascade's SYSTEM-level default, in two layers:

- **Layer 3:** `SKILL_TIER_DEFAULTS` constant at `track-progress.ts:27-40` — hardcoded IELTS. Flipped to Generic 4-tier.
- **Layer 2:** `SKILL_MEASURE_V1` contract in `SystemSetting` — also IELTS-shaped on hf-dev per audit. Reseed script + JSON file flipped to Generic.

## Changes

- \`lib/banding/presets.ts\`: new \`generic\` preset (HF default, bands 1/2/3/4); existing IELTS preset kept under same id but with explicit "Band 3 / Band 4 / Band 5.5 / Band 7" tier labels — deliberate pick. Custom preset seed changed from IELTS to Generic. \`getPreset(null)\` returns generic.
- \`lib/goals/track-progress.ts\`: \`SKILL_TIER_DEFAULTS\` flipped + docblock + JSDoc updated.
- \`lib/types/json-fields.ts\`: \`PlaybookConfig.tierPresetId\` union adds \`"generic"\`.
- \`components/shared/BandingPicker.tsx\`: detectPresetId null-fallback → generic; save() "write null to clear" transferred from IELTS to Generic; microcopy updated.
- \`docs-archive/bdd-specs/contracts/SKILL_MEASURE_V1.contract.json\`: thresholds + tierBands flipped; \`_reseeded_2026_06_14\` audit marker added.

## Migration scripts (pre-deploy operator workflow)

- \`scripts/migrate-ielts-playbook-mapping.ts\` — writes explicit IELTS mapping on IELTS-signal Playbooks. \`--dry-run\` default, \`--execute\` to apply.
- \`scripts/reseed-skill-measure-contract-generic.ts\` — flips the SystemSetting contract row to Generic. Refuses if already Generic.

**CRITICAL deploy sequence:**

\`\`\`
# 1. Pre-deploy on each environment (hf-dev, hf-staging, hf-prod):
npx tsx apps/admin/scripts/migrate-ielts-playbook-mapping.ts           # dry-run first
npx tsx apps/admin/scripts/migrate-ielts-playbook-mapping.ts --execute  # apply

npx tsx apps/admin/scripts/reseed-skill-measure-contract-generic.ts          # dry-run first
npx tsx apps/admin/scripts/reseed-skill-measure-contract-generic.ts --execute # apply

# 2. THEN deploy code (/vm-cpp or /deploy).
\`\`\`

Without step 1, IELTS courses currently relying on the silent contract fallback will see learner bands shift from 3/4/5.5/7 to 1/2/3/4 overnight.

## Verified by

- **20/20 vitests passing**:
  - \`tests/lib/skill-tier-default-flip.test.ts\` (10) — round-trip pins on getPreset, scoreToTier with + without explicit mapping, Custom seed shape, IELTS preset still has bands 3/4/5.5/7.
  - \`tests/components/shared/BandingPicker.test.tsx\` (5) — null current → generic radio; explicit IELTS mapping detection; save Generic writes null; save IELTS writes explicit mapping; microcopy compliance.
  - \`tests/lib/skill-tier-mapping.test.ts\` (5, 2 updated) — contract resolution chain still pinned with new Generic defaults.
- \`npx tsc --noEmit\` clean against changed files.
- \`npx eslint\` 0 errors, 9 pre-existing warnings on unchanged code.
- ui-reviewer PASS (one fix applied: bare \`<strong>\` → \`hf-text-bold\` span).
- **hf-dev audit** (issue #1657 comment) confirmed R2 real: SKILL_MEASURE_V1 is IELTS-shaped on hf-dev with \`_reverted_2026_06_06\` marker referencing #1151 G8 audit. 11 playbooks total; 5 null-banding; 2 IELTS-signal (will be migrated); 2 non-IELTS currently silently inheriting IELTS (will get Generic post-reseed).

## Test plan

- [x] Unit tests pin all detection + save branches + scoreToTier output for both Generic and IELTS
- [x] tsc + eslint clean
- [x] ui-reviewer PASS
- [x] hf-dev audit completed; contract + migration shape verified
- [ ] **Pre-deploy operator step:** run both migration scripts on hf-prod with \`--dry-run\`, review the list of playbooks that would be migrated, then \`--execute\`
- [ ] Live verification post-deploy: open a non-IELTS course's design tab → BandingPicker pre-selects "Generic 4-tier" with bands 1/2/3/4. Open an IELTS course → pre-selects "IELTS Speaking" with explicit "Band 3 / Band 4 / Band 5.5 / Band 7" labels.

## Out of scope

- Per-skill banding within a course — operator confirmed one scheme per course is sufficient.
- Domain-level IELTS pin migration — only Playbook-level is in scope.
- Operator UI to create new tier schemes — code-defined presets still.

🤖 Generated with [Claude Code](https://claude.com/claude-code)