### PR TITLE
feat(callers): #1660 — Snapshot v3 landing tab content (Epic #1606 Group C foundation)

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -28,6 +28,7 @@ import { MemoriesSection, PersonalitySection, CallerSlugsSection, CallerEnrollme
 import { SurveySection } from "./caller-detail/SurveySection";
 import { ScoresSection, LearningSection, AssessmentTargetsCard, TopicsCoveredSection, ExamReadinessSection, TopLevelAgentBehaviorSection, PlanProgressSection, ModuleProgressView } from "./caller-detail/ProgressTab";
 import { LearningTrajectoryCard } from "./caller-detail/cards/LearningTrajectoryCard";
+import { SnapshotTabContent } from "./caller-detail/SnapshotTabContent";
 import { ArtifactsSection } from "./caller-detail/ArtifactsTab";
 import { PromptTimelineRows } from "./caller-detail/PromptTimelineRows";
 import { CallsPromptsTab, type BulkActions } from "./caller-detail/CallsPromptsTab";
@@ -1155,21 +1156,14 @@ export default function CallerDetailPage() {
       {/* Section Content */}
       <div className="cdp-body">
       <div className="cdp-content">
-      {/* S5 of #1555 — Snapshot v3 beta placeholder. Renders only when
-          the flag + URL param align (see snapshotV3Active above). The
-          body is intentionally minimal "Coming soon" copy so a typed
-          ?tab=snapshot-v3 with the flag off lands somewhere coherent
-          rather than blank. Content lands in the follow-on epic. */}
+      {/* S5 of #1555 + #1660 (Epic #1606 Group C foundation) — Snapshot v3
+          beta. Renders only when the flag + URL param align (see
+          snapshotV3Active above). The S5 "Coming soon" placeholder is
+          replaced by the SnapshotTabContent composer, which mounts 5
+          sections + 3 stub slots that sibling stories #1661 / #1662 /
+          #1663 / #1665 / #1666 will fill. */}
       {activeSection === "snapshot-v3" && (
-        <div className="hf-card" role="region" aria-label="Snapshot (beta)">
-          <h2 className="hf-section-title">Snapshot (beta)</h2>
-          <p className="hf-section-desc">
-            The unified per-learner Snapshot is being built — check back
-            next sprint. In the meantime, use the legacy tabs above
-            (Overview, Progress, Attainment, Adaptations) for the same
-            information across separate surfaces.
-          </p>
-        </div>
+        <SnapshotTabContent callerId={data.caller.id} />
       )}
 
       {/* WILL_RETIRE — covered by Snapshot v3: see docs/retirement-audit/caller-detail-v3.md */}

--- a/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+/**
+ * SnapshotTabContent — #1660 (Group C foundation of Epic #1606).
+ *
+ * Replaces the S5 placeholder card at `CallerDetailPage.tsx:1163-1173`.
+ * Composes the v3 caller-detail Snapshot tab from 5 sections:
+ *
+ *   1. Header — trajectory sparklines (`LearningTrajectoryCard`)
+ *   2. "Who we think they are" — personality (A.7 fills the stub)
+ *   3. Skill Bands summary (from `/api/callers/[id]/attainment`)
+ *   4. LO heatmap slot (#1661 mounts the real component here)
+ *   5. "Why this call?" summary (#1663 fills the stub)
+ *   6. Goals + evidence trail (from same `/attainment` response)
+ *   7. Carry-over actions slot (A.9 fills the stub)
+ *
+ * Decision 4 (#1660 AC): cold load = 4 parallel fetches via `Promise.all`.
+ * Heatmap (#1661) and personality (#1665) handle their own fetches when
+ * they replace the slots. Sub-skills (#1662) and scheduler-decision
+ * (#1663) routes don't exist yet — the fetches degrade silently on 404
+ * so the foundation ships ahead of the sibling stories.
+ *
+ * Decision 4 follow-on trigger: if module count > 12, switch the heatmap
+ * to viewport-lazy via IntersectionObserver. Below the foundation's
+ * concern — only #1661 implementation needs to act on it.
+ *
+ * STUDENT scope: every underlying route (attainment, skills-evidence)
+ * already gates via `studentAllowedToReadCaller`. Sub-skills + scheduler
+ * routes inherit the same pattern when they ship.
+ */
+
+import { useEffect, useState } from "react";
+
+import { LearningTrajectoryCard } from "./cards/LearningTrajectoryCard";
+
+import "./snapshot-tab.css";
+
+interface SnapshotTabContentProps {
+  callerId: string;
+}
+
+interface AttainmentSkillBand {
+  skillRef: string;
+  parameterId: string;
+  parameterName: string;
+  currentScore: number | null;
+  targetValue: number;
+  callsUsed: number;
+  tier: string;
+  bandLabel: number | null;
+  exceedsTarget: boolean;
+}
+
+interface AttainmentGoal {
+  id: string;
+  type: string;
+  name: string;
+  description: string | null;
+  progress: number;
+  trail: {
+    excerpts: string[];
+    totalCount: number;
+    extractionMethod: "EXPLICIT" | "INFERRED" | null;
+    sourceCallId: string | null;
+  } | null;
+}
+
+interface AttainmentResponse {
+  callerId: string;
+  callerName: string | null;
+  playbookId: string | null;
+  playbookName: string | null;
+  useFreshMastery: boolean;
+  skillBands: AttainmentSkillBand[];
+  modules: Array<{ id: string; slug: string; title: string }>;
+  goals: AttainmentGoal[];
+  empty: boolean;
+}
+
+interface SkillsEvidenceEntry {
+  skillRef: string;
+  excerpts: Array<{ excerpt: string; callId: string | null; at: string | null }>;
+}
+
+interface SkillsEvidenceResponse {
+  callerId: string;
+  evidence: SkillsEvidenceEntry[];
+}
+
+interface SubSkillsResponse {
+  callerId: string;
+  groups: Array<{
+    domainGroup: string;
+    parameters: Array<{ parameterId: string; name: string; score: number | null; tier: string | null }>;
+  }>;
+}
+
+interface SchedulerDecisionResponse {
+  callerId: string;
+  decision: {
+    mode: string;
+    reason: string;
+    writtenAt: string;
+  } | null;
+}
+
+export function SnapshotTabContent({ callerId }: SnapshotTabContentProps) {
+  const [attainment, setAttainment] = useState<AttainmentResponse | null>(null);
+  const [skillsEvidence, setSkillsEvidence] = useState<SkillsEvidenceResponse | null>(
+    null,
+  );
+  const [subSkills, setSubSkills] = useState<SubSkillsResponse | null | "missing">(null);
+  const [schedulerDecision, setSchedulerDecision] = useState<
+    SchedulerDecisionResponse | null | "missing"
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+
+    // 4 parallel fetches — sibling routes that don't exist yet (sub-skills,
+    // scheduler-decision) return 404; we mark them "missing" and render
+    // their stubs so the foundation isn't blocked on the sibling stories.
+    const tasks: Promise<unknown>[] = [
+      fetch(`/api/callers/${callerId}/attainment`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((j: AttainmentResponse | null) => {
+          if (!cancelled) setAttainment(j);
+        })
+        .catch(() => {
+          if (!cancelled) setError("Failed to load attainment");
+        }),
+      fetch(`/api/callers/${callerId}/skills-evidence`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((j: SkillsEvidenceResponse | null) => {
+          if (!cancelled) setSkillsEvidence(j);
+        })
+        .catch(() => {}),
+      fetch(`/api/callers/${callerId}/sub-skills`)
+        .then((r) => {
+          if (r.status === 404) return "missing" as const;
+          return r.ok ? r.json() : null;
+        })
+        .then((j) => {
+          if (!cancelled) setSubSkills(j as SubSkillsResponse | null | "missing");
+        })
+        .catch(() => {
+          if (!cancelled) setSubSkills("missing");
+        }),
+      fetch(`/api/callers/${callerId}/scheduler-decision`)
+        .then((r) => {
+          if (r.status === 404) return "missing" as const;
+          return r.ok ? r.json() : null;
+        })
+        .then((j) => {
+          if (!cancelled)
+            setSchedulerDecision(j as SchedulerDecisionResponse | null | "missing");
+        })
+        .catch(() => {
+          if (!cancelled) setSchedulerDecision("missing");
+        }),
+    ];
+
+    Promise.all(tasks).catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId]);
+
+  if (error) {
+    return (
+      <div className="hf-card" role="alert">
+        <h2 className="hf-section-title">Snapshot</h2>
+        <p className="hf-section-desc">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hf-snapshot" data-testid="hf-snapshot-tab">
+      <section className="hf-snapshot-section hf-snapshot-header">
+        <LearningTrajectoryCard callerId={callerId} />
+      </section>
+
+      <SnapshotPersonalityStub />
+
+      <SnapshotSkillBandsSection
+        skillBands={
+          attainment === null
+            ? null
+            : Array.isArray(attainment.skillBands)
+              ? attainment.skillBands
+              : []
+        }
+        evidence={skillsEvidence?.evidence ?? null}
+      />
+
+      <SnapshotSubSkillsStub subSkills={subSkills} />
+
+      <SnapshotHeatmapPlaceholder
+        moduleCount={
+          Array.isArray(attainment?.modules) ? (attainment?.modules?.length ?? 0) : 0
+        }
+        useFreshMastery={attainment?.useFreshMastery ?? false}
+      />
+
+      <SnapshotSchedulerStub schedulerDecision={schedulerDecision} />
+
+      <SnapshotGoalsSection
+        goals={
+          attainment === null
+            ? null
+            : Array.isArray(attainment.goals)
+              ? attainment.goals
+              : []
+        }
+      />
+
+      <SnapshotCarryOverActionsStub />
+    </div>
+  );
+}
+
+// =============================================================
+// Stubs — sibling stories replace these
+// =============================================================
+
+function SnapshotPersonalityStub() {
+  return (
+    <section
+      className="hf-snapshot-section hf-snapshot-stub"
+      data-testid="hf-snapshot-personality-stub"
+    >
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Who we think they are</div>
+        <span className="hf-badge hf-badge-muted">
+          Personality block — coming in story A.7
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function SnapshotSubSkillsStub({
+  subSkills,
+}: {
+  subSkills: SubSkillsResponse | null | "missing";
+}) {
+  if (subSkills === null) {
+    return (
+      <section
+        className="hf-snapshot-section hf-snapshot-stub"
+        data-testid="hf-snapshot-subskills-stub"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Sub-skills (DISC / COACH / COMP)</div>
+          <span className="hf-badge hf-badge-muted">Loading…</span>
+        </div>
+      </section>
+    );
+  }
+  if (subSkills === "missing") {
+    return (
+      <section
+        className="hf-snapshot-section hf-snapshot-stub"
+        data-testid="hf-snapshot-subskills-stub"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Sub-skills (DISC / COACH / COMP)</div>
+          <span className="hf-badge hf-badge-muted">
+            Sub-skill cards — coming in story #1662
+          </span>
+        </div>
+      </section>
+    );
+  }
+  // Minimal render — full cards land in #1662
+  const groups = Array.isArray(subSkills.groups) ? subSkills.groups : [];
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-subskills-stub"
+    >
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Sub-skills</div>
+        {groups.length === 0 ? (
+          <span className="hf-badge hf-badge-muted">No sub-skills tracked yet</span>
+        ) : (
+          <ul className="hf-list-row">
+            {groups.map((g) => (
+              <li key={g.domainGroup}>
+                <strong>{g.domainGroup}</strong>: {g.parameters.length} parameter
+                {g.parameters.length === 1 ? "" : "s"}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SnapshotHeatmapPlaceholder({
+  moduleCount,
+  useFreshMastery,
+}: {
+  moduleCount: number;
+  useFreshMastery: boolean;
+}) {
+  return (
+    <section
+      className="hf-snapshot-section hf-snapshot-stub"
+      data-testid="hf-snapshot-heatmap-placeholder"
+    >
+      <div className="hf-card-compact">
+        <div className="hf-category-label">LO mastery heatmap</div>
+        {moduleCount === 0 ? (
+          <span className="hf-badge hf-badge-muted">No modules in curriculum yet</span>
+        ) : (
+          <>
+            <span className="hf-badge hf-badge-muted">
+              Heatmap component — coming in story #1661 ({moduleCount} module
+              {moduleCount === 1 ? "" : "s"})
+            </span>
+            {useFreshMastery && (
+              <span className="hf-badge hf-badge-info" style={{ marginLeft: 8 }}>
+                Exam Assessment mode (scratch mastery)
+              </span>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SnapshotSchedulerStub({
+  schedulerDecision,
+}: {
+  schedulerDecision: SchedulerDecisionResponse | null | "missing";
+}) {
+  if (schedulerDecision === null) {
+    return (
+      <section
+        className="hf-snapshot-section hf-snapshot-stub"
+        data-testid="hf-snapshot-scheduler-stub"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Why this call?</div>
+          <span className="hf-badge hf-badge-muted">Loading…</span>
+        </div>
+      </section>
+    );
+  }
+  if (schedulerDecision === "missing") {
+    return (
+      <section
+        className="hf-snapshot-section hf-snapshot-stub"
+        data-testid="hf-snapshot-scheduler-stub"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Why this call?</div>
+          <span className="hf-badge hf-badge-muted">
+            Scheduler reasoning — coming in story #1663
+          </span>
+        </div>
+      </section>
+    );
+  }
+  if (!schedulerDecision.decision) {
+    return (
+      <section
+        className="hf-snapshot-section"
+        data-testid="hf-snapshot-scheduler-stub"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Why this call?</div>
+          <span className="hf-badge hf-badge-muted">No scheduler decision recorded yet</span>
+        </div>
+      </section>
+    );
+  }
+  const { decision } = schedulerDecision;
+  return (
+    <section className="hf-snapshot-section" data-testid="hf-snapshot-scheduler-stub">
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Why this call?</div>
+        <div className="hf-text-sm">
+          <strong>{decision.mode}</strong> — {decision.reason}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SnapshotCarryOverActionsStub() {
+  return (
+    <section
+      className="hf-snapshot-section hf-snapshot-stub"
+      data-testid="hf-snapshot-actions-stub"
+    >
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Carry-over actions</div>
+        <span className="hf-badge hf-badge-muted">
+          Carry-over actions — coming in story A.9
+        </span>
+      </div>
+    </section>
+  );
+}
+
+// =============================================================
+// Real sections — render now (foundation ships them)
+// =============================================================
+
+function SnapshotSkillBandsSection({
+  skillBands,
+  evidence: _evidence,
+}: {
+  skillBands: AttainmentSkillBand[] | null;
+  evidence: SkillsEvidenceEntry[] | null;
+}) {
+  if (skillBands === null) {
+    return (
+      <section className="hf-snapshot-section">
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Skill bands</div>
+          <span className="hf-badge hf-badge-muted">Loading…</span>
+        </div>
+      </section>
+    );
+  }
+  if (skillBands.length === 0) {
+    return (
+      <section className="hf-snapshot-section">
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Skill bands</div>
+          <span className="hf-badge hf-badge-muted">No skills tracked yet</span>
+        </div>
+      </section>
+    );
+  }
+  return (
+    <section className="hf-snapshot-section" data-testid="hf-snapshot-skill-bands">
+      <div className="hf-card-compact">
+        <div className="hf-category-label">
+          Skill bands — {skillBands.length} tracked
+        </div>
+        <ul className="hf-list-row">
+          {skillBands.map((band) => (
+            <li key={band.parameterId}>
+              <strong>{band.parameterName}</strong>{" "}
+              <span className="hf-badge hf-badge-info">{band.tier}</span>
+              {band.exceedsTarget && (
+                <span className="hf-badge hf-badge-success" style={{ marginLeft: 4 }}>
+                  exceeds target
+                </span>
+              )}
+              {band.currentScore === null && (
+                <span className="hf-badge hf-badge-muted" style={{ marginLeft: 4 }}>
+                  awaiting evidence
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function SnapshotGoalsSection({ goals }: { goals: AttainmentGoal[] | null }) {
+  if (goals === null) {
+    return (
+      <section className="hf-snapshot-section">
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Goals</div>
+          <span className="hf-badge hf-badge-muted">Loading…</span>
+        </div>
+      </section>
+    );
+  }
+  if (goals.length === 0) {
+    return (
+      <section className="hf-snapshot-section">
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Goals</div>
+          <span className="hf-badge hf-badge-muted">No active goals</span>
+        </div>
+      </section>
+    );
+  }
+  return (
+    <section className="hf-snapshot-section" data-testid="hf-snapshot-goals">
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Goals — {goals.length} active</div>
+        <ul className="hf-list-row">
+          {goals.map((goal) => (
+            <li key={goal.id}>
+              <span className="hf-badge hf-badge-info">{goal.type}</span>{" "}
+              <strong>{goal.name}</strong>{" "}
+              <span className="hf-text-sm hf-text-muted">
+                {Math.round((goal.progress ?? 0) * 100)}%
+              </span>
+              {goal.trail && goal.trail.totalCount > 0 && (
+                <div className="hf-text-sm hf-text-muted">
+                  Last evidence ({goal.trail.extractionMethod}):{" "}
+                  {goal.trail.excerpts[0]}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/snapshot-tab.css
+++ b/apps/admin/components/callers/caller-detail/snapshot-tab.css
@@ -1,0 +1,30 @@
+/* Snapshot v3 landing tab — #1660 (Group C foundation of Epic #1606).
+ *
+ * Vertical stack of section cards. Each section is independently rendered
+ * so the foundation can ship before sibling stories fill the stub slots.
+ * The compact cards reuse the global `hf-card-compact` / `hf-badge` /
+ * `hf-list-row` design-system primitives — no new visual vocabulary.
+ */
+
+.hf-snapshot {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-2, 12px);
+}
+
+.hf-snapshot-section {
+  width: 100%;
+}
+
+.hf-snapshot-header {
+  /* Trajectory sparklines are visually loud; sit them at the top with a
+   * small bottom-margin to separate from the section stack below. */
+  margin-bottom: var(--gap-1, 4px);
+}
+
+.hf-snapshot-stub .hf-card-compact {
+  /* Stubs render in a muted state so the operator can see the slot
+   * waiting for its sibling story without confusing it for live data. */
+  border-style: dashed;
+  background: var(--surface-muted, transparent);
+}

--- a/apps/admin/tests/components/callers/snapshot-tab-content.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-tab-content.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * Tests for the Snapshot v3 landing tab — #1660 (Epic #1606 Group C
+ * foundation).
+ *
+ * Pinned acceptance:
+ *   1. 4 parallel fetches fire on mount (Promise.all, no waterfall) —
+ *      verifies cold-load behaviour from #1660 AC.
+ *   2. 404 from sub-skills + scheduler-decision degrades to stub renders
+ *      (sibling stories not yet merged) — foundation ships ahead.
+ *   3. Skill bands render from attainment response.
+ *   4. Goals render from attainment response with evidence trail.
+ *   5. Heatmap placeholder shows module count.
+ *   6. Empty attainment → empty-state badges on every section.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+import { SnapshotTabContent } from "@/components/callers/caller-detail/SnapshotTabContent";
+
+vi.mock("@/components/callers/caller-detail/cards/LearningTrajectoryCard", () => ({
+  LearningTrajectoryCard: ({ callerId }: { callerId: string }) => (
+    <div data-testid="hf-trajectory-card">trajectory-{callerId}</div>
+  ),
+}));
+
+const CALLER_ID = "caller-1";
+
+function makeAttainmentResponse() {
+  return {
+    callerId: CALLER_ID,
+    callerName: "Alex",
+    playbookId: "pb1",
+    playbookName: "Calculus 1",
+    useFreshMastery: false,
+    skillBands: [
+      {
+        skillRef: "SKILL-01",
+        parameterId: "p1",
+        parameterName: "Algebra",
+        currentScore: 0.62,
+        targetValue: 0.7,
+        callsUsed: 3,
+        tier: "developing",
+        bandLabel: 2,
+        exceedsTarget: false,
+      },
+    ],
+    modules: [
+      { id: "m1", slug: "limits", title: "Limits" },
+      { id: "m2", slug: "derivatives", title: "Derivatives" },
+    ],
+    goals: [
+      {
+        id: "g1",
+        type: "LEARN",
+        name: "Master limits",
+        description: null,
+        progress: 0.45,
+        trail: {
+          excerpts: ["Got the squeeze theorem right"],
+          totalCount: 1,
+          extractionMethod: "EXPLICIT" as const,
+          sourceCallId: "call-7",
+        },
+      },
+    ],
+    empty: false,
+  };
+}
+
+function mockFetch(handlers: Record<string, (url: string) => Response | Promise<Response>>) {
+  return vi.fn(async (url: string | URL | Request) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const [pattern, h] of Object.entries(handlers)) {
+      if (u.includes(pattern)) return h(u);
+    }
+    return new Response(null, { status: 404 });
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("SnapshotTabContent — cold-load behaviour", () => {
+  it("fires 4 parallel fetches on mount (attainment, skills-evidence, sub-skills, scheduler-decision)", async () => {
+    const calls: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const u = typeof url === "string" ? url : url.toString();
+      calls.push(u);
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    expect(calls.some((u) => u.includes("/attainment"))).toBe(true);
+    expect(calls.some((u) => u.includes("/skills-evidence"))).toBe(true);
+    expect(calls.some((u) => u.includes("/sub-skills"))).toBe(true);
+    expect(calls.some((u) => u.includes("/scheduler-decision"))).toBe(true);
+  });
+
+  it("renders the trajectory card in the header slot", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    expect(screen.getByTestId("hf-trajectory-card").textContent).toContain(CALLER_ID);
+  });
+});
+
+describe("SnapshotTabContent — slot stubs (sibling stories not yet merged)", () => {
+  it("shows personality stub on render (A.7 not merged)", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    expect(screen.getByTestId("hf-snapshot-personality-stub")).toBeTruthy();
+    expect(screen.getByText(/coming in story A\.7/i)).toBeTruthy();
+  });
+
+  it("shows sub-skills stub when route returns 404 (#1662 not merged)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/sub-skills": () => new Response(null, { status: 404 }),
+        "/attainment": () =>
+          new Response(JSON.stringify(makeAttainmentResponse()), { status: 200 }),
+        "/skills-evidence": () =>
+          new Response(JSON.stringify({ callerId: CALLER_ID, evidence: [] }), {
+            status: 200,
+          }),
+        "/scheduler-decision": () => new Response(null, { status: 404 }),
+      }),
+    );
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/coming in story #1662/i)).toBeTruthy(),
+    );
+  });
+
+  it("shows scheduler stub when route returns 404 (#1663 not merged)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/scheduler-decision": () => new Response(null, { status: 404 }),
+        "/attainment": () =>
+          new Response(JSON.stringify(makeAttainmentResponse()), { status: 200 }),
+        "/skills-evidence": () =>
+          new Response(JSON.stringify({ callerId: CALLER_ID, evidence: [] }), {
+            status: 200,
+          }),
+        "/sub-skills": () => new Response(null, { status: 404 }),
+      }),
+    );
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/coming in story #1663/i)).toBeTruthy(),
+    );
+  });
+
+  it("shows heatmap placeholder with module count (#1661 not merged)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/attainment": () =>
+          new Response(JSON.stringify(makeAttainmentResponse()), { status: 200 }),
+        "/skills-evidence": () =>
+          new Response(JSON.stringify({ callerId: CALLER_ID, evidence: [] }), {
+            status: 200,
+          }),
+        "/sub-skills": () => new Response(null, { status: 404 }),
+        "/scheduler-decision": () => new Response(null, { status: 404 }),
+      }),
+    );
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/coming in story #1661 \(2 modules\)/i)).toBeTruthy(),
+    );
+  });
+
+  it("shows carry-over actions stub (A.9 not merged)", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    expect(screen.getByTestId("hf-snapshot-actions-stub")).toBeTruthy();
+  });
+});
+
+describe("SnapshotTabContent — populated state from /attainment", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/attainment": () =>
+          new Response(JSON.stringify(makeAttainmentResponse()), { status: 200 }),
+        "/skills-evidence": () =>
+          new Response(JSON.stringify({ callerId: CALLER_ID, evidence: [] }), {
+            status: 200,
+          }),
+        "/sub-skills": () => new Response(null, { status: 404 }),
+        "/scheduler-decision": () => new Response(null, { status: 404 }),
+      }),
+    );
+  });
+
+  it("renders skill bands with parameter name + tier", async () => {
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/Algebra/)).toBeTruthy());
+    expect(screen.getByText(/developing/)).toBeTruthy();
+  });
+
+  it("renders goals with type, name, progress %, evidence excerpt", async () => {
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/Master limits/)).toBeTruthy());
+    expect(screen.getByText(/45%/)).toBeTruthy();
+    expect(screen.getByText(/squeeze theorem/i)).toBeTruthy();
+    expect(screen.getByText(/EXPLICIT/)).toBeTruthy();
+  });
+
+  it("renders the heatmap placeholder with the module count from /attainment", async () => {
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/2 modules/)).toBeTruthy(),
+    );
+  });
+});
+
+describe("SnapshotTabContent — empty attainment response", () => {
+  it("shows empty-state badges when attainment returns no skills + no goals + no modules", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/attainment": () =>
+          new Response(
+            JSON.stringify({
+              callerId: CALLER_ID,
+              callerName: null,
+              playbookId: null,
+              playbookName: null,
+              useFreshMastery: false,
+              skillBands: [],
+              modules: [],
+              goals: [],
+              empty: true,
+            }),
+            { status: 200 },
+          ),
+        "/skills-evidence": () =>
+          new Response(JSON.stringify({ callerId: CALLER_ID, evidence: [] }), {
+            status: 200,
+          }),
+        "/sub-skills": () => new Response(null, { status: 404 }),
+        "/scheduler-decision": () => new Response(null, { status: 404 }),
+      }),
+    );
+    render(<SnapshotTabContent callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/No skills tracked yet/i)).toBeTruthy());
+    expect(screen.getByText(/No active goals/i)).toBeTruthy();
+    expect(screen.getByText(/No modules in curriculum yet/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- **Foundation story for Epic #1606 Group C** — replaces the S5 placeholder at `CallerDetailPage.tsx:1163-1173` with a real Snapshot composer
- 5 real sections + 3 stub slots for sibling stories (#1661 heatmap, #1662 sub-skills, #1663 scheduler decision, #1665 personality, #1666 carry-over actions)
- 4 parallel fetches via `Promise.all`; sub-skills + scheduler-decision routes don't exist yet → 404 degrades to muted stub badges, no waterfall, no errors
- Unblocks Phase 2 (#1661/#1662/#1663/#1666 can land in parallel after this merges)

## Decisions baked in (#1660 grooming)

| # | Decision | How applied |
|---|---|---|
| 4 | Cold load ≤9 parallel for typical course; if >12 modules, switch heatmap to viewport-lazy | This PR fires 4 parallel fetches; heatmap is a placeholder slot — fan-out lives in #1661 |
| (sibling stories) | Routes inherit STUDENT scope from existing `studentAllowedToReadCaller` pattern | No new auth wiring needed; sibling routes will pick up the same gate |

## Section composition (top → bottom)

1. **Header** — `LearningTrajectoryCard` (sparklines reuse)
2. **Personality** — stub for A.7 (#1665)
3. **Skill bands** — real, from `/api/callers/[id]/attainment`
4. **Sub-skills** — fetches `/sub-skills`; 404 → stub for #1662
5. **LO heatmap placeholder** — shows module count + `useFreshMastery` flag; #1661 fills
6. **"Why this call?"** — fetches `/scheduler-decision`; 404 → stub for #1663
7. **Goals** — real, from same `/attainment` response with evidence trail
8. **Carry-over actions** — stub for A.9 (#1666)

## Verified by

**11 RTL vitests at `tests/components/callers/snapshot-tab-content.test.tsx`:**

- Cold-load behaviour — 4 parallel fetches fire on mount (no waterfall); asserts each URL pattern present
- Trajectory card mounts in header slot
- Sub-skills 404 → stub renders with #1662 reference
- Scheduler 404 → stub renders with #1663 reference
- Heatmap placeholder shows module count from `/attainment`
- Carry-over actions + personality stubs always render (sibling-story-not-merged path)
- Populated state: skill bands render with parameter name + tier
- Populated state: goals render with type + progress % + evidence excerpt + extraction method
- Empty `/attainment` → muted "No skills tracked yet" / "No active goals" / "No modules in curriculum yet" badges
- Test data shape mirrors the live `AttainmentResponse` interface from `/api/callers/[id]/attainment/route.ts:114-126`

**Regression sweep:** 93/93 across `tests/components/callers/` green. Lint clean. tsc 43 errors (well under ratchet baseline 166).

**Live verification deferred to hf-dev** — the foundation only works behind the `NEXT_PUBLIC_SNAPSHOT_V3_ENABLED=true` env gate + `?v=3` URL param (both set today on hf-dev). Will smoke after `/vm-cp` lands.

## Test plan

- [x] RTL vitests (11/11) green
- [x] Sibling tests pass (93/93 in callers bank)
- [x] Lint + tsc clean
- [ ] `/vm-cp` after merge → visit `/x/callers/<id>?tab=snapshot-v3&v=3` on hf-dev to verify all 8 sections render + stubs show correct sibling-story references

Closes #1660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)