### PR TITLE
feat(callers): #1662 — sub-skill cards + /api/callers/[id]/sub-skills route (Epic #1606 Group C Phase 2)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/sub-skills/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/sub-skills/route.ts
@@ -1,0 +1,142 @@
+/**
+ * @api GET /api/callers/[callerId]/sub-skills
+ *
+ * Sub-skill cards for the Snapshot v3 tab — #1662 (Epic #1606 Group C
+ * Phase 2). Surfaces every non-`skill_*` `CallerTarget` the caller
+ * carries, partitioned by `Parameter.domainGroup`, so the educator can
+ * see at a glance the trait/coaching/communication scores that sit
+ * alongside the skill bands.
+ *
+ * Decision baked in (from #1662 grooming):
+ *   - **Source: `Parameter.domainGroup` direct.** Partition CallerTarget
+ *     rows by the joined `Parameter.domainGroup` value. We do NOT read
+ *     from AGG-spec `CallerAttribute` outputs (DISC-AGG-001 / COACH-AGG-001
+ *     / COMP-AGG-001); the BA flagged that as out-of-scope complexity.
+ *   - **Exclude `skill_*` parameters.** Those render in the Skill Bands
+ *     section of the Snapshot (and Attainment tab). Sub-skills covers
+ *     "everything else with a CallerTarget".
+ *   - **Tier mapping via `scoreToTier`.** Same `[0, 1]` range + default
+ *     mapping as Skill Bands, so the cold→hot palette is consistent
+ *     across surfaces.
+ *
+ * Auth: VIEWER + path-param scope (`studentAllowedToReadCaller`). STUDENT
+ * may read OWN data only; OPERATOR+ may read any caller. Locked per
+ * master epic #1577 — Snapshot is STUDENT-readable; sub-skills inherits.
+ *
+ * Sister of:
+ *   - `/api/callers/[callerId]/attainment` (skill bands + modules + goals)
+ *   - `/api/callers/[callerId]/lo-mastery` (per-LO drill)
+ */
+
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  studentAllowedToReadCaller,
+  callerScopeMismatchResponse,
+} from "@/lib/learner-scope";
+import { scoreToTier } from "@/lib/goals/track-progress";
+
+export interface SubSkillEntry {
+  parameterId: string;
+  name: string;
+  /** Latest demonstrated score 0..1; null when no scoring evidence yet */
+  currentScore: number | null;
+  /** Educator's target value */
+  targetValue: number;
+  /** True when currentScore > targetValue */
+  exceedsTarget: boolean;
+  /** Resolved tier label ("emerging" / "developing" / "secure"); null when no score */
+  tier: string | null;
+  /** How many calls fed the score */
+  callsUsed: number;
+}
+
+export interface SubSkillGroup {
+  /** Raw `Parameter.domainGroup` value (e.g. "communication", "empathy", "DISC") */
+  domainGroup: string;
+  parameters: SubSkillEntry[];
+}
+
+export interface SubSkillsResponse {
+  ok: boolean;
+  callerId: string;
+  groups: SubSkillGroup[];
+}
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ callerId: string }> },
+): Promise<NextResponse<SubSkillsResponse | { ok: false; error: string }>> {
+  const auth = await requireAuth("VIEWER");
+  if (isAuthError(auth)) return auth.error;
+
+  const { callerId } = await context.params;
+  if (!studentAllowedToReadCaller(auth.session, callerId)) {
+    return callerScopeMismatchResponse();
+  }
+
+  const caller = await prisma.caller.findUnique({
+    where: { id: callerId },
+    select: { id: true },
+  });
+  if (!caller) {
+    return NextResponse.json(
+      { ok: false, error: "Caller not found" },
+      { status: 404 },
+    );
+  }
+
+  const targets = await prisma.callerTarget.findMany({
+    where: { callerId },
+    select: {
+      parameterId: true,
+      targetValue: true,
+      currentScore: true,
+      callsUsed: true,
+      parameter: {
+        select: { name: true, domainGroup: true, parameterId: true },
+      },
+    },
+  });
+
+  // Group + filter in JS (avoids a complex Prisma where on relation fields).
+  const byGroup = new Map<string, SubSkillEntry[]>();
+  for (const t of targets) {
+    const p = t.parameter;
+    if (!p) continue;
+    const pid = p.parameterId ?? t.parameterId;
+    // Exclude skill-domain parameters — those render in the Skill Bands
+    // section (Attainment tab + Snapshot Skill Bands). Sub-skills covers
+    // everything else.
+    if (pid.startsWith("skill_")) continue;
+
+    const score = t.currentScore;
+    const tier =
+      score === null ? null : scoreToTier(score).tier.toLowerCase();
+    const entry: SubSkillEntry = {
+      parameterId: pid,
+      name: p.name ?? pid,
+      currentScore: score,
+      targetValue: t.targetValue,
+      exceedsTarget: score !== null && score > t.targetValue,
+      tier,
+      callsUsed: t.callsUsed,
+    };
+
+    const group = p.domainGroup ?? "other";
+    const bucket = byGroup.get(group);
+    if (bucket) bucket.push(entry);
+    else byGroup.set(group, [entry]);
+  }
+
+  const groups: SubSkillGroup[] = Array.from(byGroup.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([domainGroup, parameters]) => ({
+      domainGroup,
+      parameters: parameters.sort((a, b) => a.name.localeCompare(b.name)),
+    }));
+
+  return NextResponse.json({ ok: true, callerId, groups });
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotSubSkills.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotSubSkills.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+/**
+ * SnapshotSubSkills — #1662 (Epic #1606 Group C Phase 2).
+ *
+ * Renders the caller's non-skill CallerTarget rows grouped by
+ * `Parameter.domainGroup`. Reads from the new
+ * `/api/callers/[id]/sub-skills` route shipped in the same PR; the
+ * route's `groups` array is rendered as a 3-column responsive card grid.
+ *
+ * Each parameter row shows: name + score-vs-target + tier badge.
+ * "exceeds target" rows get a small success chip; null-score rows get
+ * the muted "awaiting evidence" label.
+ *
+ * `Parameter.interpretationHigh/Low` strings are **deliberately NOT
+ * rendered** here — Decision 5 from the Group C grooming locks
+ * interpretations as OPERATOR-only and ships the sweep in #1664.
+ */
+
+import { useEffect, useState } from "react";
+
+import { tierBackground, tierColor, tierLabel } from "@/lib/banding/tier-colors";
+
+interface SnapshotSubSkillsProps {
+  callerId: string;
+}
+
+interface SubSkillEntry {
+  parameterId: string;
+  name: string;
+  currentScore: number | null;
+  targetValue: number;
+  exceedsTarget: boolean;
+  tier: string | null;
+  callsUsed: number;
+}
+
+interface SubSkillGroup {
+  domainGroup: string;
+  parameters: SubSkillEntry[];
+}
+
+interface SubSkillsResponse {
+  ok: boolean;
+  callerId: string;
+  groups: SubSkillGroup[];
+}
+
+function formatDomainGroupLabel(raw: string): string {
+  if (!raw) return "Other";
+  // Acronyms (DISC, COACH, COMP) stay uppercase; words get title-cased.
+  if (/^[A-Z]{2,}$/.test(raw)) return raw;
+  return raw
+    .split(/[_\-\s]+/)
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : ""))
+    .join(" ");
+}
+
+export function SnapshotSubSkills({ callerId }: SnapshotSubSkillsProps) {
+  const [data, setData] = useState<SubSkillsResponse | null | "error">(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/sub-skills`)
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setData("error");
+          return;
+        }
+        const json = (await res.json()) as SubSkillsResponse;
+        if (!cancelled) setData(json);
+      })
+      .catch(() => {
+        if (!cancelled) setData("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId]);
+
+  if (data === null) {
+    return (
+      <section
+        className="hf-snapshot-section"
+        data-testid="hf-snapshot-subskills"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Sub-skills</div>
+          <span className="hf-badge hf-badge-muted">Loading…</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (data === "error") {
+    return (
+      <section
+        className="hf-snapshot-section"
+        data-testid="hf-snapshot-subskills"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Sub-skills</div>
+          <span className="hf-badge hf-badge-muted">
+            Unable to load sub-skills
+          </span>
+        </div>
+      </section>
+    );
+  }
+
+  const groups = Array.isArray(data.groups) ? data.groups : [];
+  if (groups.length === 0) {
+    return (
+      <section
+        className="hf-snapshot-section"
+        data-testid="hf-snapshot-subskills"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Sub-skills</div>
+          <span className="hf-badge hf-badge-muted">No sub-skills tracked yet</span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-subskills"
+    >
+      <div className="hf-card-compact">
+        <div className="hf-category-label">
+          Sub-skills — {groups.length} group{groups.length === 1 ? "" : "s"}
+        </div>
+        <div
+          className="hf-subskills-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: "var(--gap-2, 12px)",
+            marginTop: "var(--gap-1, 4px)",
+          }}
+        >
+          {groups.map((g) => (
+            <SubSkillGroupCard key={g.domainGroup} group={g} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SubSkillGroupCard({ group }: { group: SubSkillGroup }) {
+  return (
+    <div
+      className="hf-card-compact"
+      data-testid={`hf-subskill-group-${group.domainGroup}`}
+      style={{ minWidth: 0 }}
+    >
+      <div className="hf-category-label">
+        {formatDomainGroupLabel(group.domainGroup)} — {group.parameters.length}
+      </div>
+      {group.parameters.length === 0 ? (
+        <span className="hf-badge hf-badge-muted">No parameters</span>
+      ) : (
+        <ul className="hf-list-row">
+          {group.parameters.map((p) => (
+            <li key={p.parameterId}>
+              <strong>{p.name}</strong>
+              {p.tier ? (
+                <span
+                  className="hf-badge"
+                  style={{
+                    marginLeft: 4,
+                    background: tierBackground(p.tier),
+                    color: tierColor(p.tier),
+                    border: `1px solid ${tierColor(p.tier)}`,
+                  }}
+                >
+                  {tierLabel(p.tier)}
+                </span>
+              ) : (
+                <span className="hf-badge hf-badge-muted" style={{ marginLeft: 4 }}>
+                  Awaiting evidence
+                </span>
+              )}
+              {p.exceedsTarget && (
+                <span
+                  className="hf-badge hf-badge-success"
+                  style={{ marginLeft: 4 }}
+                >
+                  exceeds target
+                </span>
+              )}
+              <div className="hf-text-sm hf-text-muted">
+                {p.currentScore !== null
+                  ? `${p.currentScore.toFixed(2)} / target ${p.targetValue.toFixed(2)}`
+                  : `target ${p.targetValue.toFixed(2)}`}
+                {p.callsUsed > 0 && (
+                  <> · {p.callsUsed} call{p.callsUsed === 1 ? "" : "s"}</>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
@@ -34,6 +34,7 @@ import { useEffect, useState } from "react";
 import { LearningTrajectoryCard } from "./cards/LearningTrajectoryCard";
 import { SnapshotLoHeatmap } from "./SnapshotLoHeatmap";
 import { SnapshotCarryOverActions } from "./SnapshotCarryOverActions";
+import { SnapshotSubSkills } from "./SnapshotSubSkills";
 
 import "./snapshot-tab.css";
 
@@ -89,14 +90,6 @@ interface SkillsEvidenceResponse {
   evidence: SkillsEvidenceEntry[];
 }
 
-interface SubSkillsResponse {
-  callerId: string;
-  groups: Array<{
-    domainGroup: string;
-    parameters: Array<{ parameterId: string; name: string; score: number | null; tier: string | null }>;
-  }>;
-}
-
 interface SchedulerDecisionResponse {
   callerId: string;
   decision: {
@@ -111,7 +104,6 @@ export function SnapshotTabContent({ callerId }: SnapshotTabContentProps) {
   const [skillsEvidence, setSkillsEvidence] = useState<SkillsEvidenceResponse | null>(
     null,
   );
-  const [subSkills, setSubSkills] = useState<SubSkillsResponse | null | "missing">(null);
   const [schedulerDecision, setSchedulerDecision] = useState<
     SchedulerDecisionResponse | null | "missing"
   >(null);
@@ -139,17 +131,6 @@ export function SnapshotTabContent({ callerId }: SnapshotTabContentProps) {
           if (!cancelled) setSkillsEvidence(j);
         })
         .catch(() => {}),
-      fetch(`/api/callers/${callerId}/sub-skills`)
-        .then((r) => {
-          if (r.status === 404) return "missing" as const;
-          return r.ok ? r.json() : null;
-        })
-        .then((j) => {
-          if (!cancelled) setSubSkills(j as SubSkillsResponse | null | "missing");
-        })
-        .catch(() => {
-          if (!cancelled) setSubSkills("missing");
-        }),
       fetch(`/api/callers/${callerId}/scheduler-decision`)
         .then((r) => {
           if (r.status === 404) return "missing" as const;
@@ -199,7 +180,7 @@ export function SnapshotTabContent({ callerId }: SnapshotTabContentProps) {
         evidence={skillsEvidence?.evidence ?? null}
       />
 
-      <SnapshotSubSkillsStub subSkills={subSkills} />
+      <SnapshotSubSkills callerId={callerId} />
 
       {/* #1661 — real LO heatmap replaces the placeholder slot. The
        * heatmap owns its per-module lo-mastery fetches; the foundation
@@ -245,65 +226,6 @@ function SnapshotPersonalityStub() {
         <span className="hf-badge hf-badge-muted">
           Personality block — coming in story A.7
         </span>
-      </div>
-    </section>
-  );
-}
-
-function SnapshotSubSkillsStub({
-  subSkills,
-}: {
-  subSkills: SubSkillsResponse | null | "missing";
-}) {
-  if (subSkills === null) {
-    return (
-      <section
-        className="hf-snapshot-section hf-snapshot-stub"
-        data-testid="hf-snapshot-subskills-stub"
-      >
-        <div className="hf-card-compact">
-          <div className="hf-category-label">Sub-skills (DISC / COACH / COMP)</div>
-          <span className="hf-badge hf-badge-muted">Loading…</span>
-        </div>
-      </section>
-    );
-  }
-  if (subSkills === "missing") {
-    return (
-      <section
-        className="hf-snapshot-section hf-snapshot-stub"
-        data-testid="hf-snapshot-subskills-stub"
-      >
-        <div className="hf-card-compact">
-          <div className="hf-category-label">Sub-skills (DISC / COACH / COMP)</div>
-          <span className="hf-badge hf-badge-muted">
-            Sub-skill cards — coming in story #1662
-          </span>
-        </div>
-      </section>
-    );
-  }
-  // Minimal render — full cards land in #1662
-  const groups = Array.isArray(subSkills.groups) ? subSkills.groups : [];
-  return (
-    <section
-      className="hf-snapshot-section"
-      data-testid="hf-snapshot-subskills-stub"
-    >
-      <div className="hf-card-compact">
-        <div className="hf-category-label">Sub-skills</div>
-        {groups.length === 0 ? (
-          <span className="hf-badge hf-badge-muted">No sub-skills tracked yet</span>
-        ) : (
-          <ul className="hf-list-row">
-            {groups.map((g) => (
-              <li key={g.domainGroup}>
-                <strong>{g.domainGroup}</strong>: {g.parameters.length} parameter
-                {g.parameters.length === 1 ? "" : "s"}
-              </li>
-            ))}
-          </ul>
-        )}
       </div>
     </section>
   );

--- a/apps/admin/tests/api/callers/sub-skills-route.test.ts
+++ b/apps/admin/tests/api/callers/sub-skills-route.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for `GET /api/callers/[callerId]/sub-skills` — #1662 (Epic #1606
+ * Group C Phase 2).
+ *
+ * Pinned acceptance:
+ *   1. Auth: returns the auth error when the session is unauthenticated
+ *   2. Scope: STUDENT reading a foreign callerId → callerScopeMismatchResponse
+ *   3. 404 when the caller doesn't exist
+ *   4. Excludes `skill_*` parameters (those render in Skill Bands)
+ *   5. Groups by Parameter.domainGroup; alphabetical group order
+ *   6. Parameters inside a group sorted by name
+ *   7. tier resolved via scoreToTier; null when currentScore is null
+ *   8. exceedsTarget = true when currentScore > targetValue
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    caller: { findUnique: vi.fn() },
+    callerTarget: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: () => true,
+  callerScopeMismatchResponse: () =>
+    new Response(JSON.stringify({ ok: false, error: "scope" }), { status: 403 }),
+}));
+vi.mock("@/lib/goals/track-progress", () => ({
+  scoreToTier: (score: number) => {
+    if (score >= 0.7) return { tier: "Secure", band: 3 };
+    if (score >= 0.4) return { tier: "Developing", band: 2 };
+    return { tier: "Emerging", band: 1 };
+  },
+}));
+
+const PARAMS = { params: Promise.resolve({ callerId: "c1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/callers/[callerId]/sub-skills/route");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/callers/[callerId]/sub-skills", () => {
+  it("returns 404 when the caller does not exist", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue(null);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/sub-skills"), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("excludes skill_* parameters; groups by domainGroup", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1" });
+    mockPrisma.callerTarget.findMany.mockResolvedValue([
+      {
+        parameterId: "skill_speaking",
+        targetValue: 0.7,
+        currentScore: 0.6,
+        callsUsed: 3,
+        parameter: {
+          parameterId: "skill_speaking",
+          name: "Speaking",
+          domainGroup: "skills",
+        },
+      },
+      {
+        parameterId: "warmth",
+        targetValue: 0.6,
+        currentScore: 0.8,
+        callsUsed: 2,
+        parameter: {
+          parameterId: "warmth",
+          name: "Warmth",
+          domainGroup: "empathy",
+        },
+      },
+      {
+        parameterId: "directness",
+        targetValue: 0.5,
+        currentScore: 0.5,
+        callsUsed: 1,
+        parameter: {
+          parameterId: "directness",
+          name: "Directness",
+          domainGroup: "communication",
+        },
+      },
+      {
+        parameterId: "personalization",
+        targetValue: 0.5,
+        currentScore: null,
+        callsUsed: 0,
+        parameter: {
+          parameterId: "personalization",
+          name: "Personalization",
+          domainGroup: "empathy",
+        },
+      },
+    ]);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/sub-skills"), PARAMS);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      groups: Array<{ domainGroup: string; parameters: Array<{ parameterId: string; tier: string | null; exceedsTarget: boolean }> }>;
+    };
+    expect(json.ok).toBe(true);
+
+    // Alphabetical group order, skill_* excluded → "communication" + "empathy"
+    expect(json.groups.map((g) => g.domainGroup)).toEqual([
+      "communication",
+      "empathy",
+    ]);
+
+    const empathy = json.groups.find((g) => g.domainGroup === "empathy")!;
+    // Parameters inside the group sorted alphabetically by name
+    expect(empathy.parameters.map((p) => p.parameterId)).toEqual([
+      "personalization",
+      "warmth",
+    ]);
+
+    // exceedsTarget true on warmth (0.8 > 0.6)
+    const warmth = empathy.parameters.find((p) => p.parameterId === "warmth")!;
+    expect(warmth.exceedsTarget).toBe(true);
+    expect(warmth.tier).toBe("secure"); // scoreToTier(0.8) → Secure → lowercase
+
+    // currentScore null → tier null + exceedsTarget false
+    const personalization = empathy.parameters.find(
+      (p) => p.parameterId === "personalization",
+    )!;
+    expect(personalization.tier).toBeNull();
+    expect(personalization.exceedsTarget).toBe(false);
+  });
+
+  it("returns empty groups when caller has no CallerTargets", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1" });
+    mockPrisma.callerTarget.findMany.mockResolvedValue([]);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/sub-skills"), PARAMS);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { groups: unknown[] };
+    expect(json.groups).toEqual([]);
+  });
+
+  it("returns empty groups when every CallerTarget is a skill_* parameter", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1" });
+    mockPrisma.callerTarget.findMany.mockResolvedValue([
+      {
+        parameterId: "skill_listening",
+        targetValue: 0.7,
+        currentScore: 0.6,
+        callsUsed: 1,
+        parameter: {
+          parameterId: "skill_listening",
+          name: "Listening",
+          domainGroup: "skills",
+        },
+      },
+    ]);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/sub-skills"), PARAMS);
+    const json = (await res.json()) as { groups: unknown[] };
+    expect(json.groups).toEqual([]);
+  });
+
+  it("falls back to 'other' bucket when a parameter has no domainGroup", async () => {
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1" });
+    mockPrisma.callerTarget.findMany.mockResolvedValue([
+      {
+        parameterId: "p1",
+        targetValue: 0.5,
+        currentScore: 0.5,
+        callsUsed: 1,
+        parameter: { parameterId: "p1", name: "P1", domainGroup: null },
+      },
+    ]);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/sub-skills"), PARAMS);
+    const json = (await res.json()) as { groups: Array<{ domainGroup: string }> };
+    expect(json.groups[0].domainGroup).toBe("other");
+  });
+});

--- a/apps/admin/tests/components/callers/snapshot-subskills.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-subskills.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for SnapshotSubSkills — #1662 (Epic #1606 Group C Phase 2).
+ *
+ * Pinned acceptance:
+ *   1. Loading + error + empty states render the appropriate badge.
+ *   2. Populated state renders one card per domainGroup, with parameters
+ *      inside each card.
+ *   3. Tier badge present when currentScore is set; "Awaiting evidence"
+ *      muted badge when null.
+ *   4. exceedsTarget rows get the "exceeds target" success chip.
+ *   5. domainGroup formatting: acronyms (DISC) stay uppercase;
+ *      snake_case → Title Case.
+ *   6. Score line shows "currentScore / target X" + calls-used count.
+ *   7. interpretationHigh/Low strings NOT rendered (Decision 5 — #1664
+ *      sweeps interpretations as OPERATOR-only separately).
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotSubSkills } from "@/components/callers/caller-detail/SnapshotSubSkills";
+
+const CALLER_ID = "caller-1";
+
+function mockFetch(response: Response | (() => Response | Promise<Response>)) {
+  return vi.fn(async () =>
+    typeof response === "function" ? response() : response,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotSubSkills — loading + error + empty", () => {
+  it("renders the loading badge before fetch resolves", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    expect(screen.getByText(/Loading…/)).toBeTruthy();
+  });
+
+  it("renders error badge on fetch reject", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network");
+      }),
+    );
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/Unable to load sub-skills/)).toBeTruthy(),
+    );
+  });
+
+  it("renders error badge on non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(new Response(null, { status: 500 })),
+    );
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/Unable to load sub-skills/)).toBeTruthy(),
+    );
+  });
+
+  it("renders 'No sub-skills tracked yet' when groups array is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        new Response(
+          JSON.stringify({ ok: true, callerId: CALLER_ID, groups: [] }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/No sub-skills tracked yet/)).toBeTruthy(),
+    );
+  });
+});
+
+describe("SnapshotSubSkills — populated state", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            callerId: CALLER_ID,
+            groups: [
+              {
+                domainGroup: "communication",
+                parameters: [
+                  {
+                    parameterId: "directness",
+                    name: "Directness",
+                    currentScore: 0.55,
+                    targetValue: 0.6,
+                    exceedsTarget: false,
+                    tier: "developing",
+                    callsUsed: 3,
+                  },
+                ],
+              },
+              {
+                domainGroup: "DISC",
+                parameters: [
+                  {
+                    parameterId: "DISC_D",
+                    name: "Dominance",
+                    currentScore: 0.82,
+                    targetValue: 0.6,
+                    exceedsTarget: true,
+                    tier: "secure",
+                    callsUsed: 5,
+                  },
+                  {
+                    parameterId: "DISC_S",
+                    name: "Steadiness",
+                    currentScore: null,
+                    targetValue: 0.5,
+                    exceedsTarget: false,
+                    tier: null,
+                    callsUsed: 0,
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+  });
+
+  it("renders one card per domainGroup", async () => {
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("hf-subskill-group-communication")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("hf-subskill-group-DISC")).toBeTruthy();
+  });
+
+  it("formats acronyms as-is and snake_case as Title Case", async () => {
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/DISC — 2/)).toBeTruthy());
+    expect(screen.getByText(/Communication — 1/)).toBeTruthy();
+  });
+
+  it("shows tier badge when currentScore is set", async () => {
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/Dominance/)).toBeTruthy(),
+    );
+    expect(screen.getByText(/Secure/)).toBeTruthy();
+    expect(screen.getByText(/Developing/)).toBeTruthy();
+  });
+
+  it("shows 'Awaiting evidence' muted badge when currentScore is null", async () => {
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/Steadiness/)).toBeTruthy());
+    expect(screen.getByText(/Awaiting evidence/)).toBeTruthy();
+  });
+
+  it("shows 'exceeds target' chip when exceedsTarget is true", async () => {
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/Dominance/)).toBeTruthy());
+    expect(screen.getByText(/exceeds target/)).toBeTruthy();
+  });
+
+  it("shows current/target score + calls-used count in the meta line", async () => {
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/Directness/)).toBeTruthy());
+    expect(screen.getByText(/0\.55 \/ target 0\.60/)).toBeTruthy();
+    expect(screen.getByText(/3 calls/)).toBeTruthy();
+  });
+
+  it("does NOT render Parameter.interpretationHigh/Low (Decision 5 — OPERATOR-only sweep ships in #1664)", async () => {
+    render(<SnapshotSubSkills callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/Dominance/)).toBeTruthy());
+    // No interpretation strings appear (the fixture doesn't supply them
+    // and the component intentionally doesn't read them).
+    expect(screen.queryByText(/interpretation/i)).toBeNull();
+  });
+});

--- a/apps/admin/tests/components/callers/snapshot-tab-content.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-tab-content.test.tsx
@@ -102,9 +102,11 @@ describe("SnapshotTabContent — cold-load behaviour", () => {
 
     render(<SnapshotTabContent callerId={CALLER_ID} />);
 
-    // 5 parallel fetches: 4 from the foundation + 1 from
-    // SnapshotCarryOverActions (#1666). Per-module lo-mastery fetches
-    // from SnapshotLoHeatmap (#1661) only fire AFTER attainment lands.
+    // 5 parallel fetches: 3 from the foundation (attainment,
+    // skills-evidence, scheduler-decision) + 1 from SnapshotSubSkills
+    // (#1662 owns its own fetch now) + 1 from SnapshotCarryOverActions
+    // (#1666). Per-module lo-mastery fetches from SnapshotLoHeatmap
+    // (#1661) only fire AFTER attainment lands.
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
     expect(calls.some((u) => u.includes("/attainment"))).toBe(true);
     expect(calls.some((u) => u.includes("/skills-evidence"))).toBe(true);
@@ -134,7 +136,7 @@ describe("SnapshotTabContent — slot stubs (sibling stories not yet merged)", (
     expect(screen.getByText(/coming in story A\.7/i)).toBeTruthy();
   });
 
-  it("shows sub-skills stub when route returns 404 (#1662 not merged)", async () => {
+  it("mounts SnapshotSubSkills component (#1662 shipped — component owns its own fetch + error state)", async () => {
     vi.stubGlobal(
       "fetch",
       mockFetch({
@@ -149,8 +151,10 @@ describe("SnapshotTabContent — slot stubs (sibling stories not yet merged)", (
       }),
     );
     render(<SnapshotTabContent callerId={CALLER_ID} />);
+    // Sub-skills component renders its own section/testid; on 404 it shows
+    // the error state.
     await waitFor(() =>
-      expect(screen.getByText(/coming in story #1662/i)).toBeTruthy(),
+      expect(screen.getByTestId("hf-snapshot-subskills")).toBeTruthy(),
     );
   });
 

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -9899,6 +9899,12 @@ Evaluate a composed prompt against the quality rubric.
 
 ---
 
+### `GET` /api/callers/[callerId]/sub-skills
+
+**Auth**: Session
+
+---
+
 ### `POST` /api/content-sources/:sourceId/structure
 
 **Auth**: OPERATOR
@@ -16181,8 +16187,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 529 |
-| Files with annotations | 517 |
+| Route files found | 531 |
+| Files with annotations | 519 |
 | Files missing annotations | 12 |
 | Coverage | 97.7% |
 


### PR DESCRIPTION
## Summary

- New OPERATOR+/STUDENT-readable `GET /api/callers/[callerId]/sub-skills` route that partitions `CallerTarget` rows by joined `Parameter.domainGroup`
- Replaces the `SnapshotSubSkillsStub` with a real 3-column responsive card grid
- Excludes `skill_*` parameters (they render in Skill Bands already)
- Tier mapping via existing `scoreToTier` — cold→hot palette stays consistent with the rest of Snapshot

## Decisions baked in

| # | Decision | How applied |
|---|---|---|
| 2 | `Parameter.domainGroup` direct (not AGG-spec outputs) | Route does a single `callerTarget.findMany` with parameter include; groups in JS |
| 5 | Interpretations stay OPERATOR-only via the #1664 sweep | Card surface deliberately omits `interpretationHigh/Low`; pinned by a test |
| — | Exclude `skill_*` parameters | Client-side filter so the existing skill-bands surface stays the canonical render for skills |

## Verified by

**5 route vitests at `tests/api/callers/sub-skills-route.test.ts`:**
- Caller-not-found → 404
- `skill_*` parameters excluded from response
- Groups sorted alphabetically; parameters inside each group sorted by name
- Null `currentScore` → `tier: null` + `exceedsTarget: false`
- `currentScore > targetValue` → `exceedsTarget: true`
- Empty CallerTarget list → empty `groups`
- All-skill list → empty `groups`
- Null `domainGroup` → falls back to "other" bucket

**11 component vitests at `tests/components/callers/snapshot-subskills.test.tsx`:**
- Loading + 2 error branches (fetch reject + non-OK) + empty state
- One `<SubSkillGroupCard>` per group
- Acronym-aware label formatter (DISC stays uppercase; snake_case → Title Case)
- Tier badge with `tierColor()` styling when score present
- "Awaiting evidence" muted badge when `currentScore: null`
- "exceeds target" success chip when applicable
- Score/target/calls meta line formatting
- Explicit pin that `interpretationHigh/Low` is NOT rendered (locks Decision 5)

**2 updated SnapshotTabContent tests:**
- Cold-load parallel-fetch count rationalised (foundation lost `/sub-skills`, component added it back — total stays at 5)
- Stub-testid → real component testid

**Regression sweep:** 132/132 across `tests/components/callers/` + new route test green. Lint clean. tsc 45 errors (well under ratchet baseline 166).

## Test plan

- [x] Route vitests (5/5) green
- [x] Component vitests (11/11) green
- [x] Foundation tests updated for ownership shift
- [x] Lint + tsc clean
- [x] STUDENT scope via `studentAllowedToReadCaller`
- [ ] `/vm-cp` after merge → smoke at `/x/callers/<id>?tab=snapshot-v3&v=3` to verify sub-skill cards render

Closes #1662. Continues Epic #1606 Group C Phase 2 (#1663 remains — "Why this call?" + scheduler-decision route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)