### PR TITLE
feat(rbac): #1664 — interpretationHigh/Low OPERATOR-only chip sweep (Epic #1606 Group C Phase 3)

### DIFF
--- a/apps/admin/components/callers/caller-detail/CallsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/CallsTab.tsx
@@ -5,6 +5,7 @@ import { VerticalSlider } from "@/components/shared/VerticalSlider";
 import { AIConfigButton } from "@/components/shared/AIConfigButton";
 import { DraggableTabs } from "@/components/shared/DraggableTabs";
 import { SectionSelector, useSectionVisibility } from "@/components/shared/SectionSelector";
+import { useIsOperatorOrAbove } from "@/hooks/useIsOperatorOrAbove";
 import { FileText as FileTextIcon, FileSearch, Brain, MessageCircle, BarChart3, Target, ClipboardCheck, CheckSquare, Gauge } from "lucide-react";
 import { useViewMode } from "@/contexts/ViewModeContext";
 import { useTerminology } from "@/contexts/TerminologyContext";
@@ -2030,6 +2031,8 @@ export function TwoColumnTargetsDisplay({
 }) {
   const { isAdvanced } = useViewMode();
   const [expandedTarget, setExpandedTarget] = useState<string | null>(null);
+  // #1664 Decision 5 — interpretation chips OPERATOR-only.
+  const operatorOrBetter = useIsOperatorOrAbove();
 
   // Create measurement lookup
   const measurementMap = new Map(measurements.map((m: any) => [m.parameterId, m.actualValue]));
@@ -2247,8 +2250,8 @@ export function TwoColumnTargetsDisplay({
               ))}
             </div>
 
-            {/* Interpretation hints */}
-            {(target.parameter?.interpretationHigh || target.parameter?.interpretationLow) && (
+            {/* Interpretation hints — OPERATOR-only per #1664 Decision 5. */}
+            {operatorOrBetter && (target.parameter?.interpretationHigh || target.parameter?.interpretationLow) && (
               <div className="hf-mt-sm hf-text-xxs" style={{ borderTop: "1px solid var(--border-default)", paddingTop: 8 }}>
                 <div className="hf-text-muted hf-mb-xs hf-text-500">Interpretation:</div>
                 {target.parameter?.interpretationHigh && (

--- a/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
+++ b/apps/admin/components/callers/caller-detail/PromptTunerSidebar.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { X, RotateCcw, ChevronDown, ChevronRight } from "lucide-react";
 import "./prompt-tuner.css";
 import { usePendingChangesTray } from "@/hooks/use-pending-changes-tray";
+import { useIsOperatorOrAbove } from "@/hooks/useIsOperatorOrAbove";
 // #911 — type-only import (stripped at build) signals to the audit-epic-100
 // `authoringBehTargetBypassCount` static check that this component now reads
 // the SYSTEM→PLAYBOOK→CALLER cascade through the canonical bulk helper. The
@@ -196,6 +197,11 @@ export function PromptTunerSidebar({
   onClose,
   inline,
 }: PromptTunerSidebarProps): React.ReactElement | null {
+  // #1664 Decision 5 — tooltip interpretation lines + low/high labels
+  // are OPERATOR-only. The PromptTuner sits inside the caller's Tune
+  // tab which is OPERATOR-gated at the route level today, but the
+  // hook is belt-and-suspenders.
+  const operatorOrBetter = useIsOperatorOrAbove();
   // --- Fetch real parameters from the targets API ---
   const [parameters, setParameters] = useState<TunerParameter[]>([]);
   const [paramsLoading, setParamsLoading] = useState(false);
@@ -1040,14 +1046,18 @@ export function PromptTunerSidebar({
                     const changed = Math.abs(p.effectiveValue - draft) > 0.01;
                     const displayName = p.name || humanise(p.parameterId);
                     const abbr = abbreviate(displayName);
-                    const lowLabel = p.interpretationLow?.split(":")[0] || "Low";
-                    const highLabel = p.interpretationHigh?.split(":")[0] || "High";
+                    const lowLabel = operatorOrBetter
+                      ? (p.interpretationLow?.split(":")[0] || "Low")
+                      : "Low";
+                    const highLabel = operatorOrBetter
+                      ? (p.interpretationHigh?.split(":")[0] || "High")
+                      : "High";
                     const tooltipLines = [
                       displayName,
                       p.definition || "",
                       "",
-                      p.interpretationHigh ? `High: ${p.interpretationHigh}` : "",
-                      p.interpretationLow ? `Low: ${p.interpretationLow}` : "",
+                      operatorOrBetter && p.interpretationHigh ? `High: ${p.interpretationHigh}` : "",
+                      operatorOrBetter && p.interpretationLow ? `Low: ${p.interpretationLow}` : "",
                     ].filter(Boolean).join("\n");
 
                     return (

--- a/apps/admin/components/playbook/PlaybookBuilder.tsx
+++ b/apps/admin/components/playbook/PlaybookBuilder.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useIsOperatorOrAbove } from "@/hooks/useIsOperatorOrAbove";
 import { SourcePageHeader } from "@/components/shared/SourcePageHeader";
 import { EditableTitle } from "@/components/shared/EditableTitle";
 import { VerticalSlider, SliderGroup } from "@/components/shared/VerticalSlider";
@@ -29,6 +30,8 @@ export function PlaybookBuilder({ playbookId, routePrefix = "" }: PlaybookBuilde
   const router = useRouter();
   const { pushEntity } = useEntityContext();
   const { terms, plural } = useTerminology();
+  // #1664 Decision 5 — interpretation chips are OPERATOR-only.
+  const operatorOrBetter = useIsOperatorOrAbove();
 
   const [playbook, setPlaybook] = useState<Playbook | null>(null);
   const [availableItems, setAvailableItems] = useState<AvailableItems | null>(null);
@@ -2585,20 +2588,22 @@ export function PlaybookBuilder({ playbookId, routePrefix = "" }: PlaybookBuilde
                                                         {action.parameter.definition}
                                                       </div>
                                                     )}
-                                                    <div className="hf-flex hf-gap-lg hf-text-xs hf-mt-sm">
-                                                      {action.parameter.interpretationHigh && (
-                                                        <div>
-                                                          <span className="hf-text-bold" style={{ color: "var(--status-success-text)" }}>High:</span>{" "}
-                                                          <span className="hf-text-muted">{action.parameter.interpretationHigh}</span>
-                                                        </div>
-                                                      )}
-                                                      {action.parameter.interpretationLow && (
-                                                        <div>
-                                                          <span className="hf-text-bold" style={{ color: "var(--status-error-text)" }}>Low:</span>{" "}
-                                                          <span className="hf-text-muted">{action.parameter.interpretationLow}</span>
-                                                        </div>
-                                                      )}
-                                                    </div>
+                                                    {operatorOrBetter && (
+                                                      <div className="hf-flex hf-gap-lg hf-text-xs hf-mt-sm">
+                                                        {action.parameter.interpretationHigh && (
+                                                          <div>
+                                                            <span className="hf-text-bold" style={{ color: "var(--status-success-text)" }}>High:</span>{" "}
+                                                            <span className="hf-text-muted">{action.parameter.interpretationHigh}</span>
+                                                          </div>
+                                                        )}
+                                                        {action.parameter.interpretationLow && (
+                                                          <div>
+                                                            <span className="hf-text-bold" style={{ color: "var(--status-error-text)" }}>Low:</span>{" "}
+                                                            <span className="hf-text-muted">{action.parameter.interpretationLow}</span>
+                                                          </div>
+                                                        )}
+                                                      </div>
+                                                    )}
                                                   </div>
 
                                                   {/* Scoring Anchors */}

--- a/apps/admin/components/playbook/playbook-builder/ParametersTab.tsx
+++ b/apps/admin/components/playbook/playbook-builder/ParametersTab.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useIsOperatorOrAbove } from "@/hooks/useIsOperatorOrAbove";
+
 import "./parameters-tab.css";
 
 export type ParameterCategory = {
@@ -67,6 +69,12 @@ export function ParametersTabContent({
   expandedParams,
   toggleParamExpand,
 }: ParametersTabContentProps) {
+  // #1664 Decision 5 — interpretation chips are OPERATOR-only.
+  // PlaybookBuilder is OPERATOR-gated at the route level today; the
+  // hook is belt-and-suspenders defence-in-depth so the chips don't
+  // leak if this component is ever reused inside a STUDENT-visible
+  // surface.
+  const operatorOrBetter = useIsOperatorOrAbove();
   return (
         <div className="pt-root">
           {parametersLoading ? (
@@ -190,7 +198,7 @@ export function ParametersTabContent({
                                     <span className="pt-param-meta-value">{param.parameterType}</span>
                                   </div>
                                 </div>
-                                {(param.interpretationHigh || param.interpretationLow) && (
+                                {operatorOrBetter && (param.interpretationHigh || param.interpretationLow) && (
                                   <div className="pt-interpretation">
                                     {param.interpretationHigh && (
                                       <div className="pt-interpretation-row">

--- a/apps/admin/components/shared/PersonalityRadar.tsx
+++ b/apps/admin/components/shared/PersonalityRadar.tsx
@@ -6,6 +6,8 @@
 // Two modes: hero (280px, labels + grid) and compact (56px, shape only)
 // =====================================================
 
+import { useIsOperatorOrAbove } from "@/hooks/useIsOperatorOrAbove";
+
 export interface RadarTrait {
   id: string;           // e.g., "B5-O"
   label: string;        // e.g., "Openness"
@@ -79,6 +81,10 @@ export function PersonalityRadar({
   compact = false,
   animated = true,
 }: PersonalityRadarProps) {
+  // #1664 Decision 5 — interpretation strings are OPERATOR-only. The
+  // radar tooltip suppresses interpretationHigh/Low text for
+  // STUDENT-level sessions; numeric value + label still render.
+  const operatorOrBetter = useIsOperatorOrAbove();
   const n = traits.length;
   if (n < 3) return null;
 
@@ -264,10 +270,14 @@ export function PersonalityRadar({
           >
             <title>
               {traits[i].label}: {(traits[i].value * 100).toFixed(0)}%
-              {traits[i].interpretationHigh && traits[i].value >= 0.6
+              {operatorOrBetter &&
+              traits[i].interpretationHigh &&
+              traits[i].value >= 0.6
                 ? `\n${traits[i].interpretationHigh}`
                 : ""}
-              {traits[i].interpretationLow && traits[i].value < 0.4
+              {operatorOrBetter &&
+              traits[i].interpretationLow &&
+              traits[i].value < 0.4
                 ? `\n${traits[i].interpretationLow}`
                 : ""}
             </title>

--- a/apps/admin/hooks/useIsOperatorOrAbove.ts
+++ b/apps/admin/hooks/useIsOperatorOrAbove.ts
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * useIsOperatorOrAbove — shared role-gate hook.
+ *
+ * Returns `true` when the current session user holds at least OPERATOR
+ * level (OPERATOR / ADMIN / SUPERADMIN). Returns `false` when the
+ * session is loading, unauthenticated, or held by a STUDENT / TESTER /
+ * VIEWER / DEMO.
+ *
+ * Use this to gate UI that should be visible only to educators /
+ * operators, with read-only fallback (or hidden render) for learners.
+ * Mirrors the inline pattern already established at
+ * `AdaptationsTab.tsx:84-90`; lifted here so the
+ * `interpretationHigh/Low` OPERATOR-only sweep (#1664) and any
+ * future cross-cutting role-gate has one place to import from.
+ *
+ * **Decision 5 (Group C grooming) — interpretationHigh/Low chip
+ * surfaces.** The 5 sites that render `Parameter.interpretationHigh`
+ * or `interpretationLow` consume this hook:
+ *   - `components/playbook/playbook-builder/ParametersTab.tsx`
+ *   - `components/playbook/PlaybookBuilder.tsx`
+ *   - `components/shared/PersonalityRadar.tsx`
+ *   - `components/callers/caller-detail/PromptTunerSidebar.tsx`
+ *   - `components/callers/caller-detail/CallsTab.tsx`
+ *
+ * Most of those surfaces are inside admin-only pages today; the hook
+ * is belt-and-suspenders defence-in-depth so when (not if) one of
+ * them gets reused inside a STUDENT-visible surface, the
+ * interpretation chips don't leak.
+ */
+
+import { useMemo } from "react";
+import { useSession } from "next-auth/react";
+import type { UserRole } from "@prisma/client";
+
+import { ROLE_LEVEL } from "@/lib/roles";
+
+export function useIsOperatorOrAbove(): boolean {
+  const { data: session } = useSession();
+  return useMemo(() => {
+    const role = session?.user?.role as UserRole | undefined;
+    if (!role) return false;
+    const level = ROLE_LEVEL[role] ?? 0;
+    return level >= ROLE_LEVEL.OPERATOR;
+  }, [session?.user?.role]);
+}

--- a/apps/admin/tests/components/PromptTunerSidebar-learner-override.test.tsx
+++ b/apps/admin/tests/components/PromptTunerSidebar-learner-override.test.tsx
@@ -28,6 +28,14 @@ vi.mock("@/hooks/use-pending-changes-tray", () => ({
   }),
 }));
 
+// #1664 — PromptTunerSidebar now consults useIsOperatorOrAbove (via
+// useSession) to gate the interpretation tooltip text. Default to an
+// OPERATOR session so existing slider assertions keep their current
+// shape; this test isn't checking interpretation strings.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { role: "OPERATOR" } } }),
+}));
+
 import { PromptTunerSidebar } from "@/components/callers/caller-detail/PromptTunerSidebar";
 
 // Sample SYSTEM+PLAYBOOK response from /api/playbooks/[id]/targets.

--- a/apps/admin/tests/components/callers/caller-detail-v2/pr4-sections.test.tsx
+++ b/apps/admin/tests/components/callers/caller-detail-v2/pr4-sections.test.tsx
@@ -7,6 +7,13 @@ import React from "react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 
+// #1664 — PersonalityRadar now calls useSession to gate interpretation
+// tooltips. Default to a STUDENT session (no interpretation text) so
+// these radar smoke tests don't depend on operator UI surface.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { role: "STUDENT" } } }),
+}));
+
 import { SkillChartSection } from "@/components/callers/caller-detail/caller-detail-v2/sections/SkillChartSection";
 import { TopicsSection } from "@/components/callers/caller-detail/caller-detail-v2/sections/TopicsSection";
 import { EngagementSection } from "@/components/callers/caller-detail/caller-detail-v2/sections/EngagementSection";

--- a/apps/admin/tests/components/callers/caller-detail-v2/pr7-lenses.test.tsx
+++ b/apps/admin/tests/components/callers/caller-detail-v2/pr7-lenses.test.tsx
@@ -6,6 +6,13 @@ import React from "react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 
+// #1664 — PersonalityRadar now calls useSession to gate interpretation
+// tooltips. Default to STUDENT (no interpretation text) so these lens
+// smoke tests don't depend on operator UI surface.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { role: "STUDENT" } } }),
+}));
+
 import { GoalsLens } from "@/components/callers/caller-detail/caller-detail-v2/lenses/GoalsLens";
 import { TopicsLens } from "@/components/callers/caller-detail/caller-detail-v2/lenses/TopicsLens";
 import { ExamLens } from "@/components/callers/caller-detail/caller-detail-v2/lenses/ExamLens";

--- a/apps/admin/tests/components/personality-radar-interpretation-gate.test.tsx
+++ b/apps/admin/tests/components/personality-radar-interpretation-gate.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for PersonalityRadar interpretation-tooltip gate — #1664
+ * (Epic #1606 Group C Phase 3).
+ *
+ * Decision 5: interpretation strings are OPERATOR-only. The radar
+ * tooltip suppresses interpretationHigh/Low text for STUDENT-level
+ * sessions; numeric value + label still render so the chart stays
+ * useful.
+ *
+ * Pinned acceptance:
+ *   1. STUDENT session → tooltip omits interpretation strings.
+ *   2. OPERATOR session → tooltip includes interpretationHigh when
+ *      value ≥ 0.6 and interpretationLow when value < 0.4.
+ *   3. Trait label + percentage always render regardless of role.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+const { mockUseSession } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: mockUseSession,
+}));
+
+import { PersonalityRadar } from "@/components/shared/PersonalityRadar";
+
+function makeTraits() {
+  return [
+    {
+      id: "B5-O",
+      label: "Openness",
+      value: 0.85,
+      color: "#000",
+      interpretationHigh: "OPERATOR_ONLY_HIGH_TEXT_O",
+      interpretationLow: "OPERATOR_ONLY_LOW_TEXT_O",
+    },
+    {
+      id: "B5-C",
+      label: "Conscientiousness",
+      value: 0.25,
+      color: "#000",
+      interpretationHigh: "OPERATOR_ONLY_HIGH_TEXT_C",
+      interpretationLow: "OPERATOR_ONLY_LOW_TEXT_C",
+    },
+    {
+      id: "B5-E",
+      label: "Extraversion",
+      value: 0.5,
+      color: "#000",
+      interpretationHigh: "OPERATOR_ONLY_HIGH_TEXT_E",
+      interpretationLow: "OPERATOR_ONLY_LOW_TEXT_E",
+    },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PersonalityRadar — interpretation gate (#1664 Decision 5)", () => {
+  it("STUDENT session: tooltip <title> elements do NOT contain interpretation strings", () => {
+    mockUseSession.mockReturnValue({ data: { user: { role: "STUDENT" } } });
+    const { container } = render(
+      <PersonalityRadar traits={makeTraits()} animated={false} />,
+    );
+    const tooltipText = Array.from(container.querySelectorAll("title"))
+      .map((el) => el.textContent ?? "")
+      .join(" ");
+    // Labels + percentages still render
+    expect(tooltipText).toContain("Openness");
+    expect(tooltipText).toContain("85%");
+    expect(tooltipText).toContain("Conscientiousness");
+    expect(tooltipText).toContain("25%");
+    // Interpretation strings explicitly absent
+    expect(tooltipText).not.toContain("OPERATOR_ONLY_HIGH_TEXT_O");
+    expect(tooltipText).not.toContain("OPERATOR_ONLY_LOW_TEXT_C");
+  });
+
+  it("OPERATOR session: tooltip includes interpretationHigh when value ≥ 0.6 and interpretationLow when value < 0.4", () => {
+    mockUseSession.mockReturnValue({ data: { user: { role: "OPERATOR" } } });
+    const { container } = render(
+      <PersonalityRadar traits={makeTraits()} animated={false} />,
+    );
+    const tooltipText = Array.from(container.querySelectorAll("title"))
+      .map((el) => el.textContent ?? "")
+      .join(" ");
+    // Openness value 0.85 ≥ 0.6 → high interpretation rendered
+    expect(tooltipText).toContain("OPERATOR_ONLY_HIGH_TEXT_O");
+    // Conscientiousness value 0.25 < 0.4 → low interpretation rendered
+    expect(tooltipText).toContain("OPERATOR_ONLY_LOW_TEXT_C");
+    // Extraversion at 0.5 sits in the middle band — neither high nor low
+    // text rendered for it.
+    expect(tooltipText).not.toContain("OPERATOR_ONLY_HIGH_TEXT_E");
+    expect(tooltipText).not.toContain("OPERATOR_ONLY_LOW_TEXT_E");
+  });
+
+  it("STUDENT vs OPERATOR: numeric value + label render in both modes", () => {
+    mockUseSession.mockReturnValue({ data: { user: { role: "STUDENT" } } });
+    const { container: studentContainer } = render(
+      <PersonalityRadar traits={makeTraits()} animated={false} />,
+    );
+    const studentText = Array.from(studentContainer.querySelectorAll("title"))
+      .map((el) => el.textContent ?? "")
+      .join(" ");
+    cleanup();
+
+    mockUseSession.mockReturnValue({ data: { user: { role: "OPERATOR" } } });
+    const { container: operatorContainer } = render(
+      <PersonalityRadar traits={makeTraits()} animated={false} />,
+    );
+    const operatorText = Array.from(operatorContainer.querySelectorAll("title"))
+      .map((el) => el.textContent ?? "")
+      .join(" ");
+
+    for (const t of makeTraits()) {
+      expect(studentText).toContain(t.label);
+      expect(operatorText).toContain(t.label);
+      const pct = `${Math.round(t.value * 100)}%`;
+      expect(studentText).toContain(pct);
+      expect(operatorText).toContain(pct);
+    }
+  });
+});

--- a/apps/admin/tests/components/shared/display-primitives/primitives.test.tsx
+++ b/apps/admin/tests/components/shared/display-primitives/primitives.test.tsx
@@ -7,8 +7,15 @@
  */
 
 import React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
+
+// #1664 — PersonalityRadar now calls useSession to gate interpretation
+// tooltips. Default to STUDENT (no interpretation text) so these smoke
+// tests don't depend on operator UI surface.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { role: "STUDENT" } } }),
+}));
 
 import {
   CardGrid,

--- a/apps/admin/tests/hooks/useIsOperatorOrAbove.test.tsx
+++ b/apps/admin/tests/hooks/useIsOperatorOrAbove.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for `useIsOperatorOrAbove` — #1664 (Epic #1606 Group C
+ * Phase 3, final story).
+ *
+ * Pinned acceptance:
+ *   1. Unauthenticated session → false (safe default for the
+ *      interpretation-chip sweep).
+ *   2. STUDENT / VIEWER / TESTER / DEMO sessions → false.
+ *   3. OPERATOR / EDUCATOR session → true.
+ *   4. ADMIN / SUPERADMIN session → true.
+ *   5. Unknown role string → false (graceful degradation).
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+
+const { mockUseSession } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: mockUseSession,
+}));
+
+import { useIsOperatorOrAbove } from "@/hooks/useIsOperatorOrAbove";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useIsOperatorOrAbove", () => {
+  it("returns false when no session is available", () => {
+    mockUseSession.mockReturnValue({ data: null });
+    const { result } = renderHook(() => useIsOperatorOrAbove());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when session lacks a role", () => {
+    mockUseSession.mockReturnValue({ data: { user: {} } });
+    const { result } = renderHook(() => useIsOperatorOrAbove());
+    expect(result.current).toBe(false);
+  });
+
+  it.each([["STUDENT"], ["VIEWER"], ["TESTER"], ["DEMO"]])(
+    "returns false for low-level role %s",
+    (role) => {
+      mockUseSession.mockReturnValue({ data: { user: { role } } });
+      const { result } = renderHook(() => useIsOperatorOrAbove());
+      expect(result.current).toBe(false);
+    },
+  );
+
+  it.each([["OPERATOR"], ["EDUCATOR"], ["ADMIN"], ["SUPERADMIN"]])(
+    "returns true for elevated role %s",
+    (role) => {
+      mockUseSession.mockReturnValue({ data: { user: { role } } });
+      const { result } = renderHook(() => useIsOperatorOrAbove());
+      expect(result.current).toBe(true);
+    },
+  );
+
+  it("returns false when role string is unknown (graceful degradation)", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { role: "UNKNOWN_FUTURE_ROLE" } },
+    });
+    const { result } = renderHook(() => useIsOperatorOrAbove());
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **CLOSES EPIC #1606 GROUP C.** Last Phase 3 story
- Cross-cutting render gate: `Parameter.interpretationHigh`/`interpretationLow` strings render only for OPERATOR+ sessions. STUDENTs see numeric values + tier labels only
- New shared `useIsOperatorOrAbove()` hook — lifted from the inline pattern at `AdaptationsTab.tsx:84-90` so future role-gate sweeps have one import surface
- 5 surfaces gated; most sit inside OPERATOR-gated routes today — chip gate is belt-and-suspenders for any future reuse inside STUDENT-visible surfaces

## Decisions baked in

**Decision 5 (from Group C grooming):** gate interpretation chips behind a session-role check. Do NOT add `learnerInterpretation` schema field (too big for this epic). Do NOT make Snapshot fully OPERATOR-only (breaks the retirement-audit intent).

## Surfaces gated

| File | Line | Gated render |
|---|---|---|
| `playbook-builder/ParametersTab.tsx` | 193-204 | Parameter inspector inline chips |
| `playbook/PlaybookBuilder.tsx` | 2589-2598 | Action inspector inline chips |
| `shared/PersonalityRadar.tsx` | 267-271 | SVG `<title>` tooltip text |
| `caller-detail/PromptTunerSidebar.tsx` | 1043-1050 | Tooltip lines + low/high labels |
| `caller-detail/CallsTab.tsx` | 2251-2263 | Target row interpretation block |

## Verified by

**11 hook vitests at `tests/hooks/useIsOperatorOrAbove.test.tsx`:**
- Null session → false
- Missing role → false  
- Each of STUDENT / VIEWER / TESTER / DEMO → false
- Each of OPERATOR / EDUCATOR / ADMIN / SUPERADMIN → true
- Unknown role string → false (graceful degradation)

**3 PersonalityRadar integration vitests at `tests/components/personality-radar-interpretation-gate.test.tsx`:**
- STUDENT session → tooltip `<title>` text suppresses `interpretationHigh`/`Low`
- OPERATOR session → tooltip includes `interpretationHigh` when value ≥ 0.6 AND `interpretationLow` when value < 0.4 (mid-band trait at 0.5 still suppressed)
- Both modes → trait label + percentage still render (chart stays useful)

**4 existing test files updated to mock `next-auth/react`:**
- `PromptTunerSidebar-learner-override.test.tsx` — defaults OPERATOR (keeps existing slider-shape assertions)
- `pr4-sections.test.tsx` / `pr7-lenses.test.tsx` / `display-primitives/primitives.test.tsx` — default STUDENT (smoke tests don't depend on operator surface)

**Regression sweep:** 569/569 across `tests/components/` + `tests/hooks/` green. Lint clean. tsc 49 errors (well under ratchet baseline 166).

## Test plan

- [x] Hook vitests (11/11) green
- [x] PersonalityRadar integration vitests (3/3) green
- [x] 4 existing tests updated for new `useSession` mock
- [x] Lint + tsc clean
- [x] Broader regression sweep — 569/569 components+hooks
- [ ] `/vm-cp` after merge → smoke as STUDENT (no interpretation strings anywhere) + as OPERATOR (interpretation strings visible)

Closes #1664. **Closes Epic #1606 entirely.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)