### PR TITLE
feat(callers): Wave A2 — Cert Progress + Score Reasoning on Attainment

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts
@@ -32,6 +32,17 @@ export interface CallerSkillEvidenceItem {
   score: number;
   confidence: number;
   excerpts: string[];
+  // Wave A2 — score-provenance fields lifted from the sibling CallScore
+  // row via (callId, parameterId). Surfaces what ProgressTab v1's
+  // ScoresSection used to show in its score-detail expander, so the
+  // Attainment Evidence Panel can replace it before that legacy tab
+  // retires. All optional — legacy paths (mock engine, manual scoring)
+  // may not have CallScore rows or may leave individual fields null.
+  reasoning: string | null;
+  analysisSpecName: string | null;
+  hasLearnerEvidence: boolean | null;
+  evidenceQuality: number | null;
+  scoredBy: string | null;
 }
 
 export interface CallerSkillEvidenceRow {
@@ -117,6 +128,10 @@ export async function GET(
 
   // Per-skill bounded fetch — uses @@index([parameterId]) + @@index([measuredAt]).
   // N skills × 1 indexed seek = small even when called repeatedly.
+  // Wave A2 — also pulls the sibling CallScore row for each
+  // (callId, parameterId) so the Evidence Panel can render reasoning +
+  // analysisSpec provenance + #566 hasLearnerEvidence/evidenceQuality
+  // badges in place of the now-retiring ProgressTab v1 ScoresSection.
   const rows: CallerSkillEvidenceRow[] = await Promise.all(
     skills.map(async (s) => {
       const measurements = await prisma.behaviorMeasurement.findMany({
@@ -134,17 +149,44 @@ export async function GET(
         orderBy: { measuredAt: "desc" },
         take: limit,
       });
+      const callIds = measurements.map((m) => m.callId);
+      const callScores =
+        callIds.length === 0
+          ? []
+          : await prisma.callScore.findMany({
+              where: {
+                callId: { in: callIds },
+                parameterId: s.parameterId,
+              },
+              select: {
+                callId: true,
+                reasoning: true,
+                hasLearnerEvidence: true,
+                evidenceQuality: true,
+                scoredBy: true,
+                analysisSpec: { select: { name: true } },
+              },
+            });
+      const scoreByCall = new Map(callScores.map((cs) => [cs.callId, cs]));
       return {
         skillRef: s.skillRef,
         parameterId: s.parameterId,
         parameterName: paramName.get(s.parameterId) ?? s.parameterId,
-        evidence: measurements.map((m) => ({
-          callId: m.callId,
-          measuredAt: m.measuredAt.toISOString(),
-          score: m.actualValue,
-          confidence: m.confidence,
-          excerpts: m.evidence,
-        })),
+        evidence: measurements.map((m) => {
+          const cs = scoreByCall.get(m.callId);
+          return {
+            callId: m.callId,
+            measuredAt: m.measuredAt.toISOString(),
+            score: m.actualValue,
+            confidence: m.confidence,
+            excerpts: m.evidence,
+            reasoning: cs?.reasoning ?? null,
+            analysisSpecName: cs?.analysisSpec?.name ?? null,
+            hasLearnerEvidence: cs?.hasLearnerEvidence ?? null,
+            evidenceQuality: cs?.evidenceQuality ?? null,
+            scoredBy: cs?.scoredBy ?? null,
+          };
+        }),
       };
     }),
   );

--- a/apps/admin/components/callers/caller-detail/AttainmentCertProgressSection.tsx
+++ b/apps/admin/components/callers/caller-detail/AttainmentCertProgressSection.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+/**
+ * AttainmentCertProgressSection — Wave A2 of the legacy-tab retirement
+ * plan. Lifts ProgressTab v1's TrustProgressSection (dual-track
+ * Certification Readiness / General Understanding bars + per-module
+ * L0-L5 trust badges) into the Attainment tab, so progress-v2 + v1 can
+ * retire without losing the cert-readiness signal.
+ *
+ * Reads `/api/callers/[id]/trust-progress` (existing route).
+ *
+ * Per-curriculum card shows:
+ *  - Cert readiness (certifiedMastery × trust-weighted; 0..1)
+ *  - Supplementary mastery (all modules; 0..1)
+ *  - Per-module rows: name + mastery % + trustLevel chip
+ *    (L0–L5 / UNVERIFIED) + countsToCertification flag
+ *
+ * Empty states:
+ *  - No active curricula → muted "No certification track yet"
+ *  - Per-curriculum with zero modules → "No modules registered yet"
+ *
+ * Auth: inherits caller-scoped VIEWER + STUDENT-scope from the
+ * underlying route.
+ */
+
+import { useEffect, useState } from "react";
+
+interface AttainmentCertProgressSectionProps {
+  callerId: string;
+}
+
+interface TrustModuleBreakdown {
+  mastery: number;
+  trustLevel: string;
+  trustWeight: number;
+  countsToCertification: boolean;
+}
+
+interface TrustCurriculum {
+  specSlug: string;
+  specName: string | null;
+  specId: string | null;
+  currentModuleId: string | null;
+  lastAccessedAt: string | null;
+  certifiedMastery: number;
+  supplementaryMastery: number;
+  certificationReadiness: number;
+  moduleBreakdown: Record<string, TrustModuleBreakdown>;
+}
+
+interface TrustProgressResponse {
+  ok: boolean;
+  curricula: TrustCurriculum[];
+}
+
+function trustBadgeVariant(trustLevel: string): string {
+  switch (trustLevel.toUpperCase()) {
+    case "L5":
+    case "L4":
+      return "hf-badge-success";
+    case "L3":
+      return "hf-badge-info";
+    case "L2":
+    case "L1":
+      return "hf-badge-warning";
+    case "L0":
+    case "UNVERIFIED":
+    default:
+      return "hf-badge-muted";
+  }
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round((value ?? 0) * 100)}%`;
+}
+
+export function AttainmentCertProgressSection({
+  callerId,
+}: AttainmentCertProgressSectionProps) {
+  const [data, setData] = useState<TrustProgressResponse | null | "error">(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/trust-progress`)
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setData("error");
+          return;
+        }
+        const json = (await res.json()) as TrustProgressResponse;
+        if (!cancelled) setData(json);
+      })
+      .catch(() => {
+        if (!cancelled) setData("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId]);
+
+  if (data === null) {
+    return (
+      <section
+        className="hf-attainment-section"
+        data-testid="hf-attainment-cert-progress"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Certification progress</div>
+          <span className="hf-badge hf-badge-muted">Loading…</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (data === "error") {
+    return (
+      <section
+        className="hf-attainment-section"
+        data-testid="hf-attainment-cert-progress"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Certification progress</div>
+          <span className="hf-badge hf-badge-muted">
+            Unable to load certification progress
+          </span>
+        </div>
+      </section>
+    );
+  }
+
+  const curricula = Array.isArray(data.curricula) ? data.curricula : [];
+
+  if (curricula.length === 0) {
+    return (
+      <section
+        className="hf-attainment-section"
+        data-testid="hf-attainment-cert-progress"
+      >
+        <div className="hf-card-compact">
+          <div className="hf-category-label">Certification progress</div>
+          <span className="hf-badge hf-badge-muted">
+            No certification track yet
+          </span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="hf-attainment-section"
+      data-testid="hf-attainment-cert-progress"
+    >
+      <div className="hf-card-compact">
+        <div className="hf-category-label">
+          Certification progress — {curricula.length} curricul
+          {curricula.length === 1 ? "um" : "a"}
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+            gap: "var(--gap-2, 12px)",
+            marginTop: "var(--gap-1, 4px)",
+          }}
+        >
+          {curricula.map((c) => (
+            <CurriculumCard key={c.specSlug} curriculum={c} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface CurriculumCardProps {
+  curriculum: TrustCurriculum;
+}
+
+function CurriculumCard({ curriculum }: CurriculumCardProps) {
+  const c = curriculum;
+  const modules = Object.entries(c.moduleBreakdown ?? {});
+  const totalCounted = modules.filter(
+    ([, m]) => m.countsToCertification,
+  ).length;
+
+  return (
+    <div
+      className="hf-card-compact"
+      data-testid={`hf-cert-curriculum-${c.specSlug}`}
+      style={{ minWidth: 0 }}
+    >
+      <div className="hf-category-label">{c.specName ?? c.specSlug}</div>
+      <div className="hf-text-sm hf-text-muted">
+        Cert readiness {formatPercent(c.certificationReadiness)} ·
+        supplementary {formatPercent(c.supplementaryMastery)}
+      </div>
+      <div
+        className="hf-text-sm hf-text-muted"
+        style={{ marginTop: 2 }}
+        data-testid={`hf-cert-counted-${c.specSlug}`}
+      >
+        {totalCounted} of {modules.length} module
+        {modules.length === 1 ? "" : "s"} count toward certification
+      </div>
+
+      {modules.length === 0 ? (
+        <span className="hf-badge hf-badge-muted" style={{ marginTop: 8 }}>
+          No modules registered yet
+        </span>
+      ) : (
+        <ol className="hf-list-row" style={{ marginTop: 8 }}>
+          {modules.map(([moduleKey, m]) => (
+            <li key={moduleKey}>
+              <strong>{moduleKey}</strong>{" "}
+              <span
+                className={`hf-badge ${trustBadgeVariant(m.trustLevel)}`}
+                style={{ marginLeft: 4 }}
+              >
+                {m.trustLevel}
+              </span>
+              {m.countsToCertification ? (
+                <span
+                  className="hf-badge hf-badge-success"
+                  style={{ marginLeft: 4 }}
+                >
+                  counts
+                </span>
+              ) : (
+                <span
+                  className="hf-badge hf-badge-muted"
+                  style={{ marginLeft: 4 }}
+                >
+                  supplementary
+                </span>
+              )}
+              <div className="hf-text-sm hf-text-muted">
+                {formatPercent(m.mastery)} mastery · trust weight{" "}
+                {(m.trustWeight ?? 0).toFixed(2)}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/components/shared/TierCell";
 import { tierLabel } from "@/lib/banding/tier-colors";
 
+import { AttainmentCertProgressSection } from "./AttainmentCertProgressSection";
+
 import "./attainment-tab.css";
 
 /**
@@ -104,6 +106,15 @@ interface SkillEvidenceItem {
   score: number;
   confidence: number;
   excerpts: string[];
+  // Wave A2 — score-provenance fields from CallScore via (callId,
+  // parameterId). Surface the AI's reasoning + spec + #566 badges so
+  // ProgressTab v1's ScoresSection can retire without losing this
+  // detail. All optional — legacy paths leave them null.
+  reasoning?: string | null;
+  analysisSpecName?: string | null;
+  hasLearnerEvidence?: boolean | null;
+  evidenceQuality?: number | null;
+  scoredBy?: string | null;
 }
 
 interface SkillEvidenceRow {
@@ -342,6 +353,12 @@ export function AttainmentTab({ callerId }: Props) {
           setExpandedGoalId((current) => (current === id ? null : id))
         }
       />
+
+      {/* Wave A2 — lifted from ProgressTab v1's TrustProgressSection.
+       * Renders trust-weighted certification readiness + per-module
+       * L0–L5 chips so progress-v2 + v1 can retire without losing the
+       * cert-readiness signal educators rely on. */}
+      <AttainmentCertProgressSection callerId={callerId} />
     </div>
   );
 }
@@ -478,6 +495,43 @@ function SkillEvidencePanel({
               Score {(item.score * 10).toFixed(1)} · conf{" "}
               {(item.confidence * 100).toFixed(0)}%
             </span>
+            {/* Wave A2 — score-provenance badges (#566 + analysis spec
+              + scoredBy) lifted from ProgressTab v1 detail-expand. */}
+            {item.hasLearnerEvidence === true && (
+              <span
+                className="hf-badge hf-badge-success"
+                style={{ marginLeft: 4 }}
+                title="Score backed by learner transcript"
+              >
+                learner-backed
+              </span>
+            )}
+            {item.hasLearnerEvidence === false && (
+              <span
+                className="hf-badge hf-badge-warning"
+                style={{ marginLeft: 4 }}
+                title="Score derived from tutor prose only (#566)"
+              >
+                tutor-only
+              </span>
+            )}
+            {typeof item.evidenceQuality === "number" && (
+              <span
+                className="hf-badge hf-badge-muted"
+                style={{ marginLeft: 4 }}
+                title="Scorer's evidence-quality judgment (0..1, #566)"
+              >
+                evidence q {(item.evidenceQuality * 100).toFixed(0)}%
+              </span>
+            )}
+            {item.scoredBy && (
+              <span
+                className="hf-text-sm hf-text-muted"
+                style={{ marginLeft: 4 }}
+              >
+                via {item.scoredBy}
+              </span>
+            )}
           </div>
           {item.excerpts.length > 0 ? (
             <ul className="hf-attainment-evidence-quotes">
@@ -489,6 +543,24 @@ function SkillEvidencePanel({
             <em className="hf-attainment-evidence-quote-empty">
               No transcript excerpts recorded for this measurement.
             </em>
+          )}
+          {item.reasoning && (
+            <div
+              className="hf-text-sm hf-text-muted"
+              style={{ marginTop: 4 }}
+              data-testid="hf-attainment-evidence-reasoning"
+            >
+              <strong>Reasoning:</strong> {item.reasoning}
+            </div>
+          )}
+          {item.analysisSpecName && (
+            <div
+              className="hf-text-sm hf-text-muted"
+              style={{ marginTop: 2 }}
+              data-testid="hf-attainment-evidence-spec"
+            >
+              Spec: {item.analysisSpecName}
+            </div>
           )}
         </div>
       ))}

--- a/apps/admin/tests/api/callers/skills-evidence-route-provenance.test.ts
+++ b/apps/admin/tests/api/callers/skills-evidence-route-provenance.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for `GET /api/callers/[callerId]/skills-evidence` —
+ * Wave A2 extension that joins CallScore provenance into each
+ * evidence item.
+ *
+ * Pinned acceptance:
+ *   1. Per-skill query also fires a CallScore findMany scoped to the
+ *      measurements' callIds + parameterId
+ *   2. Each evidence item carries reasoning + analysisSpecName +
+ *      hasLearnerEvidence + evidenceQuality + scoredBy when CallScore
+ *      row exists
+ *   3. Missing CallScore row → all 5 provenance fields are null
+ *   4. CallScore lookup is skipped entirely when measurements are empty
+ *      (no wasted query)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, mockResolveSkills, mockStudentAllowed } = vi.hoisted(
+  () => ({
+    mockPrisma: {
+      caller: { findUnique: vi.fn() },
+      callerPlaybook: { findFirst: vi.fn() },
+      parameter: { findMany: vi.fn() },
+      behaviorMeasurement: { findMany: vi.fn() },
+      callScore: { findMany: vi.fn() },
+    },
+    mockResolveSkills: vi.fn(),
+    mockStudentAllowed: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: mockStudentAllowed,
+  callerScopeMismatchResponse: () =>
+    new Response(JSON.stringify({ ok: false, error: "scope" }), { status: 403 }),
+}));
+vi.mock("@/lib/curriculum/resolve-skill", () => ({
+  resolveAllSkillsForPlaybook: mockResolveSkills,
+}));
+
+const PARAMS = { params: Promise.resolve({ callerId: "c1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/callers/[callerId]/skills-evidence/route");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStudentAllowed.mockReturnValue(true);
+  mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1" });
+  mockPrisma.callerPlaybook.findFirst.mockResolvedValue({ playbookId: "pb1" });
+});
+
+describe("skills-evidence — CallScore provenance join", () => {
+  it("merges CallScore provenance into each evidence item", async () => {
+    mockResolveSkills.mockResolvedValue([
+      { skillRef: "SKILL-01", parameterId: "p1" },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "p1", name: "Fluency" },
+    ]);
+    mockPrisma.behaviorMeasurement.findMany.mockResolvedValue([
+      {
+        callId: "call-7",
+        actualValue: 0.62,
+        confidence: 0.85,
+        evidence: ["Spoke clearly about chain rule"],
+        measuredAt: new Date("2026-06-14T10:00:00.000Z"),
+      },
+      {
+        callId: "call-6",
+        actualValue: 0.55,
+        confidence: 0.8,
+        evidence: ["Hesitated on derivatives"],
+        measuredAt: new Date("2026-06-13T09:00:00.000Z"),
+      },
+    ]);
+    mockPrisma.callScore.findMany.mockResolvedValue([
+      {
+        callId: "call-7",
+        reasoning: "Strong fluency on the open-ended prompt",
+        hasLearnerEvidence: true,
+        evidenceQuality: 0.88,
+        scoredBy: "llm_v1",
+        analysisSpec: { name: "IELTS Fluency Scorer" },
+      },
+      // call-6 deliberately missing → null provenance fields expected
+    ]);
+
+    const route = await loadRoute();
+    const res = await route.GET(
+      new Request("http://x/skills-evidence"),
+      PARAMS,
+    );
+    const json = (await res.json()) as {
+      rows: Array<{
+        evidence: Array<{
+          callId: string;
+          reasoning: string | null;
+          analysisSpecName: string | null;
+          hasLearnerEvidence: boolean | null;
+          evidenceQuality: number | null;
+          scoredBy: string | null;
+        }>;
+      }>;
+    };
+
+    const items = json.rows[0].evidence;
+    // call-7 has a CallScore → full provenance
+    const c7 = items.find((e) => e.callId === "call-7")!;
+    expect(c7.reasoning).toBe("Strong fluency on the open-ended prompt");
+    expect(c7.analysisSpecName).toBe("IELTS Fluency Scorer");
+    expect(c7.hasLearnerEvidence).toBe(true);
+    expect(c7.evidenceQuality).toBe(0.88);
+    expect(c7.scoredBy).toBe("llm_v1");
+
+    // call-6 has no CallScore row → all 5 provenance fields null
+    const c6 = items.find((e) => e.callId === "call-6")!;
+    expect(c6.reasoning).toBeNull();
+    expect(c6.analysisSpecName).toBeNull();
+    expect(c6.hasLearnerEvidence).toBeNull();
+    expect(c6.evidenceQuality).toBeNull();
+    expect(c6.scoredBy).toBeNull();
+  });
+
+  it("skips the CallScore findMany when measurements array is empty", async () => {
+    mockResolveSkills.mockResolvedValue([
+      { skillRef: "SKILL-01", parameterId: "p1" },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "p1", name: "Fluency" },
+    ]);
+    mockPrisma.behaviorMeasurement.findMany.mockResolvedValue([]);
+
+    const route = await loadRoute();
+    await route.GET(new Request("http://x/skills-evidence"), PARAMS);
+
+    expect(mockPrisma.callScore.findMany).not.toHaveBeenCalled();
+  });
+
+  it("scopes the CallScore findMany to the measurement callIds + the parameterId", async () => {
+    mockResolveSkills.mockResolvedValue([
+      { skillRef: "SKILL-01", parameterId: "p1" },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "p1", name: "Fluency" },
+    ]);
+    mockPrisma.behaviorMeasurement.findMany.mockResolvedValue([
+      {
+        callId: "call-9",
+        actualValue: 0.5,
+        confidence: 0.7,
+        evidence: [],
+        measuredAt: new Date(),
+      },
+    ]);
+    mockPrisma.callScore.findMany.mockResolvedValue([]);
+
+    const route = await loadRoute();
+    await route.GET(new Request("http://x/skills-evidence"), PARAMS);
+
+    const args = mockPrisma.callScore.findMany.mock.calls[0][0] as {
+      where: { callId: { in: string[] }; parameterId: string };
+    };
+    expect(args.where.callId.in).toEqual(["call-9"]);
+    expect(args.where.parameterId).toBe("p1");
+  });
+});

--- a/apps/admin/tests/components/callers/attainment-cert-progress.test.tsx
+++ b/apps/admin/tests/components/callers/attainment-cert-progress.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tests for AttainmentCertProgressSection — Wave A2 of the legacy-tab
+ * retirement plan. Lifts ProgressTab v1's TrustProgressSection into
+ * AttainmentTab.
+ *
+ * Pinned acceptance:
+ *   1. Loading + error + empty (no curricula) + empty-modules states
+ *   2. Per-curriculum card renders name + cert readiness % + supplementary %
+ *   3. Per-module row renders trustLevel badge (L0-L5/UNVERIFIED) + counts/supplementary flag + mastery %
+ *   4. "N of M modules count toward certification" summary line
+ *   5. Multiple curricula render as separate cards in a grid
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { AttainmentCertProgressSection } from "@/components/callers/caller-detail/AttainmentCertProgressSection";
+
+const CALLER_ID = "caller-1";
+
+function mockFetch(response: Response | (() => Response | Promise<Response>)) {
+  return vi.fn(async () =>
+    typeof response === "function" ? response() : response,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("AttainmentCertProgressSection — loading + error + empty", () => {
+  it("renders loading badge before fetch resolves", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    expect(screen.getByText(/Loading…/)).toBeTruthy();
+  });
+
+  it("renders error badge on non-OK", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(new Response(null, { status: 500 })),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Unable to load certification progress/),
+      ).toBeTruthy(),
+    );
+  });
+
+  it("renders 'No certification track yet' when curricula array empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        new Response(JSON.stringify({ ok: true, curricula: [] }), {
+          status: 200,
+        }),
+      ),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/No certification track yet/)).toBeTruthy(),
+    );
+  });
+});
+
+describe("AttainmentCertProgressSection — populated state", () => {
+  function populatedFixture() {
+    return {
+      ok: true,
+      curricula: [
+        {
+          specSlug: "ielts-speaking-v1",
+          specName: "IELTS Speaking",
+          specId: "spec-1",
+          currentModuleId: "part1",
+          lastAccessedAt: "2026-06-14T09:00:00.000Z",
+          certifiedMastery: 0.55,
+          supplementaryMastery: 0.62,
+          certificationReadiness: 0.5,
+          moduleBreakdown: {
+            part1: {
+              mastery: 0.7,
+              trustLevel: "L4",
+              trustWeight: 0.85,
+              countsToCertification: true,
+            },
+            mock: {
+              mastery: 0.4,
+              trustLevel: "UNVERIFIED",
+              trustWeight: 0.05,
+              countsToCertification: false,
+            },
+          },
+        },
+      ],
+    };
+  }
+
+  it("renders the curriculum card with name + cert readiness + supplementary", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(new Response(JSON.stringify(populatedFixture()), { status: 200 })),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("hf-cert-curriculum-ielts-speaking-v1"),
+      ).toBeTruthy(),
+    );
+    expect(screen.getByText(/IELTS Speaking/)).toBeTruthy();
+    expect(screen.getByText(/Cert readiness 50%/)).toBeTruthy();
+    expect(screen.getByText(/supplementary 62%/)).toBeTruthy();
+  });
+
+  it("renders the 'N of M modules count' summary line", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(new Response(JSON.stringify(populatedFixture()), { status: 200 })),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/1 of 2 modules count toward certification/),
+      ).toBeTruthy(),
+    );
+  });
+
+  it("renders per-module trust badges (L4 success, UNVERIFIED muted) + counts/supplementary flag", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(new Response(JSON.stringify(populatedFixture()), { status: 200 })),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText("part1")).toBeTruthy());
+    expect(screen.getByText("L4")).toBeTruthy();
+    expect(screen.getByText("UNVERIFIED")).toBeTruthy();
+    expect(screen.getByText("counts")).toBeTruthy();
+    expect(screen.getByText("supplementary")).toBeTruthy();
+  });
+
+  it("renders mastery % + trust-weight per module", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(new Response(JSON.stringify(populatedFixture()), { status: 200 })),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    await waitFor(() => expect(screen.getByText(/70% mastery/)).toBeTruthy());
+    expect(screen.getByText(/40% mastery/)).toBeTruthy();
+    expect(screen.getByText(/trust weight 0\.85/)).toBeTruthy();
+    expect(screen.getByText(/trust weight 0\.05/)).toBeTruthy();
+  });
+
+  it("renders 'No modules registered yet' when moduleBreakdown is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            curricula: [
+              {
+                specSlug: "empty-curr",
+                specName: "Empty Curriculum",
+                specId: null,
+                currentModuleId: null,
+                lastAccessedAt: null,
+                certifiedMastery: 0,
+                supplementaryMastery: 0,
+                certificationReadiness: 0,
+                moduleBreakdown: {},
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<AttainmentCertProgressSection callerId={CALLER_ID} />);
+    await waitFor(() =>
+      expect(screen.getByText(/No modules registered yet/)).toBeTruthy(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Step 2 of the legacy-tab retirement plan.** Lifts two of ProgressTab v1's most-relied-on details into AttainmentTab so progress-v2 + v1 can retire without educators losing cert-readiness or score-provenance visibility.
- Extended `/api/callers/[id]/skills-evidence` to merge `CallScore.reasoning + analysisSpec.name + hasLearnerEvidence + evidenceQuality + scoredBy` into each evidence item via a single bounded join.
- New `AttainmentCertProgressSection` consumes the existing `/trust-progress` route and renders per-curriculum cert-readiness cards with L0–L5 module trust badges.

## Surfaces shipped

| Surface | What it does |
|---|---|
| `/api/callers/[id]/skills-evidence` (extended) | After the existing BehaviorMeasurement fetch, single bounded `callScore.findMany({ callId IN(...), parameterId })` per skill. Adds 5 new provenance fields to each evidence item (all nullable; legacy paths leave them null). |
| `AttainmentCertProgressSection.tsx` (new) | One card per active curriculum: cert readiness % · supplementary % · "N of M count toward cert" · per-module trustLevel badge + mastery % + trust-weight + counts/supplementary flag. |
| `AttainmentTab.tsx` | `<SkillEvidenceItem>` extended with 5 new optional fields. Evidence panel renders #566 learner-backed/tutor-only chips + evidence-quality % + `via <scoredBy>` provenance + the full reasoning + spec-name lines beneath the excerpt list. Mounts `<AttainmentCertProgressSection>` after Goals. |

## Verified by

**3 route vitests** at `tests/api/callers/skills-evidence-route-provenance.test.ts`:
- CallScore join merges all 5 provenance fields when row exists
- Missing CallScore row → all 5 fields null (no crashes)
- CallScore findMany skipped entirely when measurements array empty (no wasted query)
- Lookup scoped to measurement callIds + the parameterId

**8 component vitests** at `tests/components/callers/attainment-cert-progress.test.tsx`:
- Loading + error + 2 empty states (no curricula, empty modules)
- Per-curriculum name + cert readiness % + supplementary %
- "N of M modules count toward certification" summary line
- Per-module trust badges (L4 success, UNVERIFIED muted)
- counts/supplementary flag rendering
- Mastery % + trust-weight per row

**Regression sweep:** 227/228 across `tests/components/callers/` + `tests/api/callers/` green. The 1 failure is `adaptations-route.test.ts` — pre-existing drift on main, not touched by this PR. Lint clean. tsc 51 errors (well under ratchet baseline 166).

## Test plan

- [x] Route vitests (3/3) green
- [x] CertProgressSection vitests (8/8) green
- [x] Lint + tsc clean
- [x] Reuses existing `/trust-progress` route (no new backend for cert progress)
- [ ] `/vm-cp` after merge → smoke at `/x/callers/<id>?tab=attainment` to confirm cert progress + evidence panel reasoning visible

Closes Wave A2. **What's next:**

| Wave | Scope |
|---|---|
| **B (next)** | Focus areas + Achievements + Momentum on Snapshot · per-parameter EMA history drill |
| C | Show-only-changed filter · trait history sparklines · delete OCEAN deprecated |
| D | Bucket 2 opportunistic — voiceProsody / voiceAnalysisSummary / CallScore badges (some shipped here as part of A2) |
| E | FF (`HF_TAB_LAYOUT=both\|retire`) + amber pills + redirects + tab promotion |

🤖 Generated with [Claude Code](https://claude.com/claude-code)