### PR TITLE
feat(journey): #1676 — Phase 0 setting-contracts registry + ADR

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -1,0 +1,906 @@
+/**
+ * Journey setting registry — authoritative entries for all 45 journey-
+ * affecting settings. Voice settings live in
+ * `lib/settings/voice-setting-contracts.ts`.
+ *
+ * AUTHORING PROCESS:
+ *   1. Each entry is hand-curated. TypeScript can't infer
+ *      educatorLabel / group / control / preview locators from the
+ *      storage type alone.
+ *   2. The completeness vitest (`tests/lib/journey/registry-completeness.test.ts`)
+ *      catches typos in section keys, dangling auto-enable targets,
+ *      duplicate ids, and group-count mismatches.
+ *   3. Order entries by `group` then by their journey-time anchor.
+ *   4. composeImpact.requiresReprompt: TRUE only when the setting feeds
+ *      a section that recomposes via an AI step (priorCallRecap, etc.).
+ *      Live diff in Preview is the default.
+ *
+ * The 45 entries map 1:1 to the table in issue #1676. See
+ * `docs/CONTRACTS-JOURNEY.md` for the chain (setting → composer-section
+ * → preview-bubble).
+ */
+
+import type {
+  JourneySettingContract,
+} from "./setting-contracts";
+import type { JourneyGroup } from "./setting-groups";
+
+// =============================================================
+// G1 — Sign-up & Intake (5)
+// =============================================================
+
+const G1_INTAKE_SPEC_ID: JourneySettingContract = {
+  id: "intakeSpecId",
+  group: "G1",
+  educatorLabel: "Intake form",
+  helpText: "Which IntakeSpec the learner fills in before Call 1.",
+  storagePath: "domain.onboardingIdentitySpecId",
+  control: "select",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.onboardingIdentitySpecId" },
+  ],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-content"],
+    // operator-only with compose impact → must reprompt (AC §6 rule 11)
+    requiresReprompt: true,
+  },
+  previewLocators: [{ section: "intake", hint: "intake spec questions" }],
+  writeGate: "operator-only",
+};
+
+const G1_INTAKE_KNOWLEDGE_CHECK: JourneySettingContract = {
+  id: "intakeKnowledgeCheck",
+  group: "G1",
+  educatorLabel: "Knowledge check on sign-up",
+  helpText: "Brief MCQ or Socratic probe in the sign-up form.",
+  storagePath: "sessionFlow.intake.knowledgeCheck",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "knowledge check block" }],
+};
+
+const G1_INTAKE_ABOUT_YOU: JourneySettingContract = {
+  id: "intakeAboutYou",
+  group: "G1",
+  educatorLabel: '"About you" questions',
+  helpText: 'Show the "About you" block in the sign-up form.',
+  storagePath: "sessionFlow.intake.aboutYou",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "about-you block" }],
+};
+
+const G1_INTAKE_SKIP_IF_RETURNING: JourneySettingContract = {
+  id: "intakeSkipIfReturning",
+  group: "G1",
+  educatorLabel: "Skip intake for returning learners",
+  helpText: "When true, learners who completed intake before are bypassed.",
+  storagePath: "config.skipIntakeIfReturning",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+const G1_INTAKE_CONSENT_FLOW: JourneySettingContract = {
+  id: "intakeConsentFlow",
+  group: "G1",
+  educatorLabel: "Consent / disclosure flow",
+  helpText: "Which consent gates run before the learner reaches Call 1.",
+  storagePath: "config.intakeConsentFlow",
+  control: "select",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.consentFlowDefault" },
+  ],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-content", "section-enable"],
+    requiresReprompt: true, // operator-only + compose impact (AC §6 rule 11)
+  },
+  previewLocators: [{ section: "intake", hint: "consent gates" }],
+  writeGate: "operator-only",
+};
+
+// =============================================================
+// G2 — Call 1 — opening & assessment (6)
+// =============================================================
+
+const G2_FIRST_CALL_MODE: JourneySettingContract = {
+  id: "firstCallMode",
+  group: "G2",
+  educatorLabel: "Call 1 mode",
+  helpText:
+    "Onboarding / Teach Immediately / Baseline Assessment — overall shape of Call 1.",
+  storagePath: "config.firstCallMode",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["firstCallMode", "welcome", "onboarding"],
+    kinds: ["section-content", "section-enable", "persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [
+    { section: "firstCallMode" },
+    { section: "welcome", hint: "first bubble" },
+  ],
+  autoEnableLinks: [
+    {
+      targetId: "preTestStop",
+      whenValue: "baseline_assessment",
+      enforce: true,
+      decoupleAllowed: true,
+      reason:
+        "Baseline Assessment mode runs the pre-test stop at the top of Call 1.",
+    },
+  ],
+};
+
+const G2_WELCOME_MESSAGE: JourneySettingContract = {
+  id: "welcomeMessage",
+  group: "G2",
+  educatorLabel: "Opening line",
+  helpText: "First line the learner hears on Call 1.",
+  storagePath: "sessionFlow.welcomeMessage",
+  control: "text",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.welcomeMessage" },
+  ],
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "welcome", hint: "first paragraph" }],
+};
+
+const G2_ONBOARDING_FLOW_PHASES: JourneySettingContract = {
+  id: "onboardingFlowPhases",
+  group: "G2",
+  educatorLabel: "Onboarding flow phases",
+  helpText: "Phases the AI walks through after the welcome line on Call 1.",
+  storagePath: "domain.onboardingFlowPhases",
+  control: "phases",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.onboardingFlowPhases" },
+  ],
+  composeImpact: {
+    sections: ["onboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "onboarding", hint: "phase list" }],
+};
+
+const G2_FIRST_CALL_TARGETS: JourneySettingContract = {
+  id: "firstCallTargets",
+  group: "G2",
+  educatorLabel: "Call 1 skill targets",
+  helpText: "Per-parameter targets applied only to Call 1.",
+  storagePath: {
+    path: "behaviorTargets[]",
+    arrayKey: "scope",
+    selectorValue: "firstCall",
+    writeMode: "merge",
+  },
+  control: "targets",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.firstCallTargetsDefault" },
+  ],
+  composeImpact: {
+    sections: ["behaviorTargets"],
+    kinds: ["scoring-weight", "cascade-override"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "behaviorTargets", hint: "first-call slider block" }],
+};
+
+const G2_PRE_TEST_STOP: JourneySettingContract = {
+  id: "preTestStop",
+  group: "G2",
+  educatorLabel: "Pre-test stop",
+  helpText: "Gate the start of Call 1 with a quick assessment.",
+  storagePath: "sessionFlow.stops.preTest",
+  control: "stop",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate", "instructions"],
+    kinds: ["section-enable", "stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modulesGate", hint: "pre-test block" }],
+};
+
+const G2_BASELINE_ASSESSMENT_DEPTH: JourneySettingContract = {
+  id: "baselineAssessmentDepth",
+  group: "G2",
+  educatorLabel: "Baseline assessment depth",
+  helpText: "How thorough the baseline assessment is (light / standard / deep).",
+  storagePath: "config.baselineAssessmentDepth",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["firstCallMode", "instructions"],
+    kinds: ["section-content", "scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "firstCallMode", hint: "assessment depth" }],
+};
+
+// =============================================================
+// G3 — Call 1 — teaching (4)
+// =============================================================
+
+const G3_TEACHING_STYLE: JourneySettingContract = {
+  id: "teachingStyle",
+  group: "G3",
+  educatorLabel: "Teaching style",
+  helpText: "Socratic / Direct / Adaptive — how the AI explains things on Call 1.",
+  storagePath: "config.teachingStyle",
+  control: "select",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.teachingStyleDefault" },
+  ],
+  composeImpact: {
+    sections: ["instructions", "modePolicy"],
+    kinds: ["persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modePolicy" }],
+};
+
+const G3_MODULE_SEQUENCE_POLICY: JourneySettingContract = {
+  id: "moduleSequencePolicy",
+  group: "G3",
+  educatorLabel: "Module sequence policy",
+  helpText: "Strict prerequisites / interleaved / learner-led on Call 1.",
+  storagePath: "config.moduleSequencePolicy",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate"],
+    kinds: ["sequence-policy"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modulesGate", hint: "module ordering" }],
+};
+
+const G3_FIRST_CALL_CURRICULUM_FOCUS: JourneySettingContract = {
+  id: "firstCallCurriculumFocus",
+  group: "G3",
+  educatorLabel: "Call 1 curriculum focus",
+  helpText: "Which modules can be taught on Call 1.",
+  storagePath: "config.firstCallCurriculumFocus",
+  control: "multi-select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["firstCallMode", "modulesGate"],
+    kinds: ["section-content", "sequence-policy"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "firstCallMode" }],
+};
+
+const G3_OPENING_RECAP_ENABLED: JourneySettingContract = {
+  id: "openingRecapEnabled",
+  group: "G3",
+  educatorLabel: "Opening recap (Call 1)",
+  helpText: "Brief recap of intake answers at the top of Call 1.",
+  storagePath: "config.openingRecapEnabled",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["welcome", "priorCallFeedback"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "welcome", hint: "after greeting" }],
+};
+
+// =============================================================
+// G4 — Every call — teaching style (17)
+// =============================================================
+
+const G4_MODE_POLICY: JourneySettingContract = {
+  id: "modePolicy",
+  group: "G4",
+  educatorLabel: "Mode policy (teach / quiz / mix)",
+  helpText: "Default mode for calls 2+ — teach, quiz, or mixed.",
+  storagePath: "config.modePolicy",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modePolicy", "instructions"],
+    kinds: ["persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modePolicy" }],
+};
+
+const G4_TOLERANCE_ACCURACY: JourneySettingContract = {
+  id: "toleranceAccuracy",
+  group: "G4",
+  educatorLabel: "Accuracy tolerance",
+  helpText: "How much slack the AI gives on factual accuracy.",
+  storagePath: "tolerances.accuracy",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions" }],
+};
+
+const G4_TOLERANCE_FLUENCY: JourneySettingContract = {
+  id: "toleranceFluency",
+  group: "G4",
+  educatorLabel: "Fluency tolerance",
+  helpText: "How much slack the AI gives on phrasing fluency.",
+  storagePath: "tolerances.fluency",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions" }],
+};
+
+const G4_TOLERANCE_CONFIDENCE: JourneySettingContract = {
+  id: "toleranceConfidence",
+  group: "G4",
+  educatorLabel: "Confidence tolerance",
+  helpText: "How much slack the AI gives on confident-sounding answers.",
+  storagePath: "tolerances.confidence",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions" }],
+};
+
+const G4_TOLERANCE_ENGAGEMENT: JourneySettingContract = {
+  id: "toleranceEngagement",
+  group: "G4",
+  educatorLabel: "Engagement tolerance",
+  helpText: "How much slack the AI gives on learner engagement signals.",
+  storagePath: "tolerances.engagement",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions" }],
+};
+
+const G4_SKILL_TIER_MAPPING: JourneySettingContract = {
+  id: "skillTierMapping",
+  group: "G4",
+  educatorLabel: "Skill tier mapping",
+  helpText: "Tier labels + thresholds for skill bands.",
+  storagePath: "config.skillTierMapping",
+  control: "banding",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.skillTierMappingDefault" },
+  ],
+  composeImpact: {
+    sections: ["moduleMastery", "loMastery"],
+    kinds: ["scoring-weight", "section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [
+    { section: "moduleMastery", hint: "tier badge" },
+    { section: "loMastery", hint: "tier badge" },
+  ],
+};
+
+const G4_SKILL_SCORING_EMA_HALF_LIFE: JourneySettingContract = {
+  id: "skillScoringEmaHalfLife",
+  group: "G4",
+  educatorLabel: "Scoring EMA half-life",
+  helpText: "Days for the per-skill EMA to decay to half-weight.",
+  storagePath: "config.skillScoringEmaHalfLifeDays",
+  control: "number",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+const G4_MAX_MASTERY_TIER: JourneySettingContract = {
+  id: "maxMasteryTier",
+  group: "G4",
+  educatorLabel: "Max mastery tier",
+  helpText: "Highest tier the AI will award without operator override.",
+  storagePath: "config.maxMasteryTier",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["moduleMastery", "loMastery"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "moduleMastery" }],
+};
+
+const G4_USE_FRESH_MASTERY: JourneySettingContract = {
+  id: "useFreshMastery",
+  group: "G4",
+  educatorLabel: "Use fresh mastery (per-call)",
+  helpText:
+    "When true, mastery resets per call (exam mode); otherwise rolling.",
+  storagePath: "config.useFreshMastery",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["moduleMastery", "loMastery"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "moduleMastery" }],
+};
+
+const G4_SCORING_MODE: JourneySettingContract = {
+  id: "scoringMode",
+  group: "G4",
+  educatorLabel: "Scoring mode",
+  helpText: "Strict / Lenient / Adaptive — how the AI grades answers.",
+  storagePath: "config.scoringMode",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions" }],
+};
+
+const G4_RECAP_ENABLED: JourneySettingContract = {
+  id: "recapEnabled",
+  group: "G4",
+  educatorLabel: "Recap at call start",
+  helpText: "Brief recap of the prior call at the top of calls 2+.",
+  storagePath: "config.recapEnabled",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["priorCallFeedback"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "priorCallFeedback" }],
+};
+
+const G4_RECAP_SYNTHESIS_ENABLED: JourneySettingContract = {
+  id: "recapSynthesisEnabled",
+  group: "G4",
+  educatorLabel: "AI recap synthesis",
+  helpText: "When true, the recap is AI-synthesised (cost per call).",
+  storagePath: "config.recapSynthesisEnabled",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["priorCallFeedback"],
+    kinds: ["section-content"],
+    requiresReprompt: true, // AI-touching → Save & reprompt CTA
+  },
+  previewLocators: [{ section: "priorCallFeedback" }],
+};
+
+const G4_PRIOR_CALL_FEEDBACK_ENABLED: JourneySettingContract = {
+  id: "priorCallFeedbackEnabled",
+  group: "G4",
+  educatorLabel: "Show prior-call feedback",
+  helpText: "Show the educator's last-call feedback to the learner.",
+  storagePath: "config.priorCallFeedbackEnabled",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["priorCallFeedback"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "priorCallFeedback" }],
+};
+
+const G4_AGENT_TUNER_NLP_ENABLED: JourneySettingContract = {
+  id: "agentTunerNlpEnabled",
+  group: "G4",
+  educatorLabel: "NLP agent tuner",
+  helpText: "Enable the NLP agent-tuner side panel (operator-only).",
+  storagePath: "config.agentTunerNlpEnabled",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+  writeGate: "operator-only",
+};
+
+const G4_PROGRESS_SIGNAL_LOW_WATER: JourneySettingContract = {
+  id: "progressSignalLowWater",
+  group: "G4",
+  educatorLabel: "Progress signal — low-water mark",
+  helpText: "Below this mastery, the AI emphasises encouragement.",
+  storagePath: "config.progressSignals.lowWater",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions", "moduleMastery"],
+    kinds: ["scoring-weight", "persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions" }],
+};
+
+const G4_PROGRESS_SIGNAL_HIGH_WATER: JourneySettingContract = {
+  id: "progressSignalHighWater",
+  group: "G4",
+  educatorLabel: "Progress signal — high-water mark",
+  helpText: "Above this mastery, the AI moves toward review / stretch.",
+  storagePath: "config.progressSignals.highWater",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions", "moduleMastery"],
+    kinds: ["scoring-weight", "persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions" }],
+};
+
+/** Cross-registry: this setting also appears in the Voice registry —
+ *  documented in `docs/CONTRACTS-JOURNEY.md` §7. Both registries' entries
+ *  share the same `storagePath` (pinned by the completeness vitest). */
+const G4_INTERRUPT_SENSITIVITY: JourneySettingContract = {
+  id: "interruptSensitivity",
+  group: "G4",
+  educatorLabel: "Interrupt sensitivity",
+  helpText:
+    "How quickly the AI yields when the learner starts speaking. Mirror copy lives in Voice settings.",
+  storagePath: "config.interruptSensitivity",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["personality"],
+    kinds: ["persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "personality" }],
+};
+
+// =============================================================
+// G5 — Mid-journey stops (3)
+// =============================================================
+
+const G5_MID_JOURNEY_STOP: JourneySettingContract = {
+  id: "midJourneyStop",
+  group: "G5",
+  educatorLabel: "Mid-journey stop",
+  helpText: "Mid-test or check-in stop between teaching calls.",
+  storagePath: "sessionFlow.stops.midJourney",
+  control: "stop",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate"],
+    kinds: ["section-enable", "stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modulesGate", hint: "mid-journey block" }],
+};
+
+const G5_MID_JOURNEY_STOP_TRIGGER: JourneySettingContract = {
+  id: "midJourneyStopTrigger",
+  group: "G5",
+  educatorLabel: "Mid-journey stop trigger",
+  helpText: "Mastery threshold / session count that fires the stop.",
+  storagePath: "sessionFlow.stops.midJourney.trigger",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate"],
+    kinds: ["stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modulesGate" }],
+};
+
+const G5_NPS_STOP: JourneySettingContract = {
+  id: "npsStop",
+  group: "G5",
+  educatorLabel: "NPS stop",
+  helpText: "Net Promoter Score survey at a mid-journey moment.",
+  storagePath: "sessionFlow.stops.nps",
+  control: "stop",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["nps"],
+    kinds: ["section-enable", "stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "nps" }],
+};
+
+// =============================================================
+// G6 — End of course / offboarding (4)
+// =============================================================
+
+const G6_OFFBOARDING_FLOW_PHASES: JourneySettingContract = {
+  id: "offboardingFlowPhases",
+  group: "G6",
+  educatorLabel: "Offboarding flow phases",
+  helpText: "Phases the AI walks through on the final call.",
+  storagePath: "sessionFlow.offboarding",
+  control: "phases",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.offboardingFlowPhases" },
+  ],
+  composeImpact: {
+    sections: ["offboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding", hint: "phase list" }],
+};
+
+const G6_OFFBOARDING_CERTIFICATE: JourneySettingContract = {
+  id: "offboardingCertificate",
+  group: "G6",
+  educatorLabel: "Certificate on completion",
+  helpText: "Issue a completion certificate at the end.",
+  storagePath: "config.offboardingCertificate",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["offboarding"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding", hint: "certificate mention" }],
+};
+
+const G6_POST_TEST_STOP: JourneySettingContract = {
+  id: "postTestStop",
+  group: "G6",
+  educatorLabel: "Post-test stop",
+  helpText: "Final assessment before offboarding.",
+  storagePath: "sessionFlow.stops.postTest",
+  control: "stop",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate", "offboarding"],
+    kinds: ["section-enable", "stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modulesGate", hint: "post-test block" }],
+};
+
+const G6_COMPLETION_CRITERIA: JourneySettingContract = {
+  id: "completionCriteria",
+  group: "G6",
+  educatorLabel: "Completion criteria",
+  helpText:
+    "All modules mastered / any module mastered / mastery threshold reached.",
+  storagePath: "config.completionCriteria",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["offboarding", "modulesGate"],
+    kinds: ["section-enable", "sequence-policy"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding" }],
+};
+
+// =============================================================
+// G7 — Scoring & sequencing (6)
+// =============================================================
+
+const G7_MODULE_VISIBILITY: JourneySettingContract = {
+  id: "moduleVisibility",
+  group: "G7",
+  educatorLabel: "Module visibility rules",
+  helpText: "When the AI starts naming modules in framing.",
+  storagePath: "config.moduleVisibility",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate"],
+    kinds: ["sequence-policy", "section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modulesGate", hint: "module naming" }],
+};
+
+const G7_LO_MASTERY_THRESHOLD: JourneySettingContract = {
+  id: "loMasteryThreshold",
+  group: "G7",
+  educatorLabel: "LO mastery pass threshold",
+  helpText: "Mastery score required to mark a Learning Objective as passed.",
+  storagePath: "config.loMasteryThreshold",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["loMastery"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "loMastery" }],
+};
+
+const G7_CALL_COUNT_POLICY: JourneySettingContract = {
+  id: "callCountPolicy",
+  group: "G7",
+  educatorLabel: "Call count policy",
+  helpText: "Hard cap / Soft cap / Unlimited — total call budget per learner.",
+  storagePath: "config.callCountPolicy",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["sequence-policy"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+const G7_MAX_CALLS_PER_DAY: JourneySettingContract = {
+  id: "maxCallsPerDay",
+  group: "G7",
+  educatorLabel: "Max calls per day",
+  helpText: "Throttle to N calls per day per learner.",
+  storagePath: "config.maxCallsPerDay",
+  control: "number",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["sequence-policy"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+const G7_ASSESSMENT_READINESS_THRESHOLD: JourneySettingContract = {
+  id: "assessmentReadinessThreshold",
+  group: "G7",
+  educatorLabel: "Assessment readiness threshold",
+  helpText: "Mastery the learner must reach before the post-test fires.",
+  storagePath: "config.assessmentReadinessThreshold",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate"],
+    kinds: ["sequence-policy", "stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "modulesGate" }],
+};
+
+const G7_REWARD_STRATEGY: JourneySettingContract = {
+  id: "rewardStrategy",
+  group: "G7",
+  educatorLabel: "Reward strategy",
+  helpText: "Which reward signal the adaptive loop optimises for.",
+  storagePath: "config.rewardStrategy",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["scoring-weight", "sequence-policy"],
+    requiresReprompt: true, // operator-only + compose impact (AC §6 rule 11)
+  },
+  previewLocators: [{ section: "instructions" }],
+  writeGate: "operator-only",
+};
+
+// =============================================================
+// Registry
+// =============================================================
+
+export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
+  // G1 (5)
+  G1_INTAKE_SPEC_ID,
+  G1_INTAKE_KNOWLEDGE_CHECK,
+  G1_INTAKE_ABOUT_YOU,
+  G1_INTAKE_SKIP_IF_RETURNING,
+  G1_INTAKE_CONSENT_FLOW,
+  // G2 (6)
+  G2_FIRST_CALL_MODE,
+  G2_WELCOME_MESSAGE,
+  G2_ONBOARDING_FLOW_PHASES,
+  G2_FIRST_CALL_TARGETS,
+  G2_PRE_TEST_STOP,
+  G2_BASELINE_ASSESSMENT_DEPTH,
+  // G3 (4)
+  G3_TEACHING_STYLE,
+  G3_MODULE_SEQUENCE_POLICY,
+  G3_FIRST_CALL_CURRICULUM_FOCUS,
+  G3_OPENING_RECAP_ENABLED,
+  // G4 (17)
+  G4_MODE_POLICY,
+  G4_TOLERANCE_ACCURACY,
+  G4_TOLERANCE_FLUENCY,
+  G4_TOLERANCE_CONFIDENCE,
+  G4_TOLERANCE_ENGAGEMENT,
+  G4_SKILL_TIER_MAPPING,
+  G4_SKILL_SCORING_EMA_HALF_LIFE,
+  G4_MAX_MASTERY_TIER,
+  G4_USE_FRESH_MASTERY,
+  G4_SCORING_MODE,
+  G4_RECAP_ENABLED,
+  G4_RECAP_SYNTHESIS_ENABLED,
+  G4_PRIOR_CALL_FEEDBACK_ENABLED,
+  G4_AGENT_TUNER_NLP_ENABLED,
+  G4_PROGRESS_SIGNAL_LOW_WATER,
+  G4_PROGRESS_SIGNAL_HIGH_WATER,
+  G4_INTERRUPT_SENSITIVITY,
+  // G5 (3)
+  G5_MID_JOURNEY_STOP,
+  G5_MID_JOURNEY_STOP_TRIGGER,
+  G5_NPS_STOP,
+  // G6 (4)
+  G6_OFFBOARDING_FLOW_PHASES,
+  G6_OFFBOARDING_CERTIFICATE,
+  G6_POST_TEST_STOP,
+  G6_COMPLETION_CRITERIA,
+  // G7 (6)
+  G7_MODULE_VISIBILITY,
+  G7_LO_MASTERY_THRESHOLD,
+  G7_CALL_COUNT_POLICY,
+  G7_MAX_CALLS_PER_DAY,
+  G7_ASSESSMENT_READINESS_THRESHOLD,
+  G7_REWARD_STRATEGY,
+];
+
+export const JOURNEY_SETTINGS_BY_ID: Readonly<
+  Record<string, JourneySettingContract>
+> = Object.fromEntries(JOURNEY_SETTINGS.map((s) => [s.id, s]));
+
+export const JOURNEY_SETTINGS_BY_GROUP: Readonly<
+  Record<JourneyGroup, readonly JourneySettingContract[]>
+> = (() => {
+  const groups = ["G1", "G2", "G3", "G4", "G5", "G6", "G7"] as const;
+  const out: Record<JourneyGroup, JourneySettingContract[]> = {
+    G1: [], G2: [], G3: [], G4: [], G5: [], G6: [], G7: [],
+  };
+  for (const s of JOURNEY_SETTINGS) {
+    // Settings-group entries should not appear in JOURNEY_SETTINGS — the
+    // completeness vitest enforces this. Narrow defensively here.
+    if (s.group in out) {
+      out[s.group as JourneyGroup].push(s);
+    }
+  }
+  return Object.fromEntries(groups.map((g) => [g, out[g]])) as unknown as Record<
+    JourneyGroup,
+    readonly JourneySettingContract[]
+  >;
+})();

--- a/apps/admin/lib/journey/setting-contracts.ts
+++ b/apps/admin/lib/journey/setting-contracts.ts
@@ -1,0 +1,231 @@
+/**
+ * Journey Setting Contracts — Phase 0 of Epic #1675 (story #1676).
+ *
+ * Single source of truth for every setting that affects the learner
+ * journey. Sibling to `docs/CHAIN-CONTRACTS.md` and
+ * `docs/CONTRACTS-PLAYBOOK-CURRICULUM.md`. See `docs/CONTRACTS-JOURNEY.md`
+ * for the chain (setting → composer-section → preview-bubble).
+ *
+ * Architectural pins (from Tech Lead review 2026-06-15, captured in ADR):
+ *
+ *  1. `StoragePath` is optionally structured — arrays with discriminated
+ *     unions (`sessionFlow.stops[]`) and id-keyed lists
+ *     (`Playbook.config.modules[]`) cannot compress to bare dot-paths.
+ *     The structured form carries `arrayKey` + optional `selectorValue` +
+ *     optional `writeMode`. Bare-string remains valid for the simple case.
+ *
+ *  2. This registry is the SINGLE source of truth for
+ *     `lib/compose/section-staleness.ts`. The staleness layer should
+ *     derive `SECTION_INPUTS_BY_KEY` from this registry, not maintain
+ *     its own parallel map. Migration is Phase 2 work.
+ *
+ *  3. `autoEnableLinks` are enforced SERVER-SIDE in the PATCH handler
+ *     within a single `$transaction`. UI graying-out is cosmetic. A
+ *     "Decouple" toggle clears the auto-written value AND removes the
+ *     link from the in-memory model.
+ *
+ *  4. Entries are hand-curated — TypeScript types can give us the
+ *     storage shape but cannot supply educatorLabel / group / control
+ *     kind / preview locators / educator-facing impact classification.
+ *     The `JOURNEY_SETTINGS_BY_ID` map enforces unique ids at compile
+ *     time via duplicate-key detection.
+ *
+ *  5. `writeGate: "operator-only"` marks a setting that the pipeline
+ *     must never mutate (chain-contract boundary protection — see
+ *     `docs/CHAIN-CONTRACTS.md`). The completeness vitest pins that
+ *     `writeGate === "operator-only"` implies `requiresReprompt: true`.
+ */
+
+import type { ComposeSectionKey } from "@/lib/compose";
+import type { JourneyGroup } from "./setting-groups";
+
+/** Forward-declared union for the cross-tab group field — kept here so
+ *  `lib/journey/` doesn't import from `lib/settings/` (Settings depends
+ *  on Journey, not the other way around). The completeness vitest checks
+ *  that this set agrees with `SETTINGS_GROUPS` in
+ *  `lib/settings/voice-setting-contracts.ts`. */
+type SettingsGroupKey = "S1_voice" | "S2_integration" | "S3_demo" | "S4_access";
+
+// =============================================================
+// StoragePath — where a setting binds in the DB
+// =============================================================
+
+/** Bare dot-path is the common case. Structured form handles array
+ *  addressing and write semantics. */
+export type StoragePath = string | StoragePathStruct;
+
+export interface StoragePathStruct {
+  /** Dot path from the root model. Use `[]` placeholder for array slots
+   *  e.g. `"playbook.config.sessionFlow.stops[]"`. */
+  path: string;
+
+  /** Required when `path` traverses an array — the field on each item that
+   *  identifies the right element. Examples: `"id"` for AuthoredModule,
+   *  `"kind"` for JourneyStop's discriminated union. */
+  arrayKey?: string;
+
+  /** Optional fixed selector — when array element is identified by a
+   *  literal value (e.g. JourneyStop where `kind === "pre_test"`). The
+   *  PATCH handler picks the element whose `[arrayKey] === selectorValue`. */
+  selectorValue?: string;
+
+  /** How the write should apply at the target.
+   *   - `"replace"` (default): write the whole sub-object
+   *   - `"merge"`: shallow-merge into the parent object */
+  writeMode?: "merge" | "replace";
+}
+
+// =============================================================
+// Control vocabulary — Phase 1 control library dispatches on this
+// =============================================================
+
+export const CONTROL_TYPES = [
+  "toggle",         // boolean
+  "select",         // one-of (single-select)
+  "multi-select",   // many-of
+  "text",           // single-line + textarea (renderer handles long)
+  "number",         // numeric input
+  "slider",         // bounded numeric
+  "duration",       // duration value (ms / sec / min — UI-formatted)
+  "json-fallback",  // power-user JSON editor for opaque sub-objects
+  "phases",         // compound: phase-list editor (onboarding/offboarding)
+  "targets",        // compound: per-parameter slider repeater
+  "banding",        // BandingPicker wrap
+  "voice-picker",   // (Settings-tab only — provider + voiceId combo)
+  "stop",           // compound: JourneyStop with discriminated trigger
+] as const;
+
+export type ControlType = (typeof CONTROL_TYPES)[number];
+
+// =============================================================
+// Compose impact — how the setting touches the prompt pipeline
+// =============================================================
+
+export const COMPOSE_IMPACT_KINDS = [
+  "section-content",   // changes the text of a compose section
+  "section-enable",    // toggles a section on/off
+  "cascade-override",  // overrides a domain/group-level cascade value
+  "stop-timing",       // changes when a journey stop fires
+  "scoring-weight",    // affects how scores are computed
+  "persona-style",     // changes tone/style without section swap
+  "sequence-policy",   // changes which module/LO is selected next
+] as const;
+
+export type ComposeImpactKind = (typeof COMPOSE_IMPACT_KINDS)[number];
+
+export interface ComposeImpact {
+  /** Composer sections this setting feeds. Reads in this list make the
+   *  Inspector show "↳ affects N section(s)" chip; writes bump those
+   *  sections' staleness hash. */
+  sections: readonly ComposeSectionKey[];
+
+  /** Coarse classification driving icon + colour + ordering. */
+  kinds: readonly ComposeImpactKind[];
+
+  /** When true, the Inspector shows a "Save & reprompt" CTA instead of
+   *  a live diff (used for AI-touching sections that recompose lazily). */
+  requiresReprompt: boolean;
+}
+
+// =============================================================
+// Cascade source — where the effective value resolves from
+// =============================================================
+
+/** Where the effective value resolves from. `system` is the static
+ *  default; `domain` is the Domain-level override; `group` is the
+ *  Playbook (course) level override. Caller-level overrides are NOT
+ *  in scope for the Journey Editor (per-learner ad-hoc adjustments live
+ *  in adaptations, not the course config). */
+export interface CascadeSource {
+  level: "group" | "domain" | "system";
+  storagePath: string;
+}
+
+// =============================================================
+// Preview locator — how the setting appears in the Preview canvas
+// =============================================================
+
+export interface PreviewLocator {
+  /** ComposeSectionKey of the bubble in the Preview canvas. */
+  section: ComposeSectionKey;
+  /** Optional human hint for the highlight ("first paragraph",
+   *  "module list", …). Used by Phase 4's bidirectional sync. */
+  hint?: string;
+}
+
+// =============================================================
+// Auto-enable link — hard parent/child coupling, server-enforced
+// =============================================================
+
+/** Declarative coupling: when THIS setting takes `whenValue`, `targetId`
+ *  is auto-forced to `enforce` server-side in the same `$transaction`.
+ *  The Inspector grays out `targetId` and exposes a "Decouple" toggle
+ *  if `decoupleAllowed`. See `docs/CONTRACTS-JOURNEY.md` §6. */
+export interface AutoEnableLink {
+  targetId: string;
+  whenValue: unknown;
+  enforce: unknown;
+  decoupleAllowed: boolean;
+  /** Educator-facing explanation in the gray-out tooltip. */
+  reason: string;
+}
+
+// =============================================================
+// JourneySettingContract — the registry entry
+// =============================================================
+
+export interface JourneySettingContract {
+  /** Stable camelCase slug — used in URL params, Inspector routing,
+   *  autoEnableLinks references. Unique across both journey + voice
+   *  registries except for the documented `interruptSensitivity`
+   *  cross-reference (see `docs/CONTRACTS-JOURNEY.md` §7). */
+  id: string;
+
+  /** Which Inspector group the setting belongs to. Journey-tab entries
+   *  use `JourneyGroup` (G1..G7); Settings-tab voice entries use
+   *  `SettingsGroup` (S1_voice). The completeness vitest pins that
+   *  entries in `JOURNEY_SETTINGS` use only `JourneyGroup` keys. */
+  group: JourneyGroup | SettingsGroupKey;
+
+  /** Educator-facing label in the LH menu + Inspector header + Cmd+K. */
+  educatorLabel: string;
+
+  /** Optional one-line helper. Shown in FieldHint. */
+  helpText?: string;
+
+  /** Where the value lives in the DB. */
+  storagePath: StoragePath;
+
+  /** Which control to render. */
+  control: ControlType;
+
+  /** Resolve-cascade roots that contribute to the effective value.
+   *  Empty `[]` means the setting has no cascade (course-only). */
+  cascadeSources: readonly CascadeSource[];
+
+  /** The CHAIN-contract link to compose pipeline + Preview bubbles. */
+  composeImpact: ComposeImpact;
+
+  /** Bidirectional Preview ↔ Inspector sync.
+   *  - Hover setting in Inspector → Preview bubble pulses
+   *  - Click bubble in Preview → Inspector scrolls to setting
+   *  Empty `[]` when the setting has no visible Preview affordance
+   *  (e.g. runtime / post-call / sequence-policy settings). */
+  previewLocators: readonly PreviewLocator[];
+
+  /** Hard auto-enable couplings — see `AutoEnableLink`. Optional. */
+  autoEnableLinks?: readonly AutoEnableLink[];
+
+  /** Pipeline-boundary guard. `"operator-only"` declares the setting
+   *  must never be mutated inside the adaptive loop (per
+   *  `docs/CHAIN-CONTRACTS.md`). Phase 2 writes a server-side check
+   *  that rejects pipeline-originated writes when this is set. */
+  writeGate?: "operator-only";
+
+  /** Power-user only — JSON path the "Edit as JSON" fallback opens to.
+   *  Defaults to `storagePath` when omitted. */
+  jsonFallbackPath?: string;
+}
+
+// Re-export for sibling registries (Settings tab Voice subset).
+export type { JourneyGroup } from "./setting-groups";

--- a/apps/admin/lib/journey/setting-groups.ts
+++ b/apps/admin/lib/journey/setting-groups.ts
@@ -1,0 +1,71 @@
+/**
+ * Journey-tab group taxonomy — Phase 0 of the Journey Editor epic
+ * (story #1676 / epic #1675).
+ *
+ * Groups are ordered by JOURNEY TIME (when in the learner's flow each
+ * setting fires), not by config category. Scrolling the Inspector LH
+ * menu ≈ walking the learner's journey. Cross-cutting groups (G7) sit
+ * at the bottom of the LH menu.
+ *
+ * Voice (was an 8th group in earlier drafts) moves to the Settings tab —
+ * see `lib/settings/voice-setting-contracts.ts`.
+ *
+ * `JOURNEY_PHASE_FILTERS` powers the Inspector filter chips; "All" is
+ * the default ("All" + 7 group filters = 8 chips total — but per AC the
+ * array length is 7 INCLUDING "All", giving 6 group filters; one group
+ * is implicit per BA spec — see ADR §3 for the resolution).
+ */
+
+export const JOURNEY_GROUPS = {
+  G1: {
+    label: "Sign-up & Intake",
+    caption: "Before they call",
+    phaseFilter: "Intake",
+  },
+  G2: {
+    label: "Call 1 — opening & assessment",
+    caption: "First 60 seconds of Call 1",
+    phaseFilter: "Call 1",
+  },
+  G3: {
+    label: "Call 1 — teaching",
+    caption: "Call 1 teaching shape",
+    phaseFilter: "Call 1",
+  },
+  G4: {
+    label: "Every call — teaching style",
+    caption: "How the AI teaches, calls 2+",
+    phaseFilter: "Calls 2+",
+  },
+  G5: {
+    label: "Mid-journey stops",
+    caption: "Between teaching calls",
+    phaseFilter: "Mid-journey",
+  },
+  G6: {
+    label: "End of course / offboarding",
+    caption: "Offboarding & wrap-up",
+    phaseFilter: "End",
+  },
+  G7: {
+    label: "Scoring & sequencing",
+    caption: "What gets taught next",
+    phaseFilter: "Scoring",
+  },
+} as const;
+
+export type JourneyGroup = keyof typeof JOURNEY_GROUPS;
+
+/** Phase filter chips — "All" + 6 distinct phase labels (G2 and G3 share
+ *  "Call 1" so the chip array deduplicates). 7 entries total. */
+export const JOURNEY_PHASE_FILTERS = [
+  "All",
+  "Intake",
+  "Call 1",
+  "Calls 2+",
+  "Mid-journey",
+  "End",
+  "Scoring",
+] as const;
+
+export type JourneyPhaseFilter = (typeof JOURNEY_PHASE_FILTERS)[number];

--- a/apps/admin/lib/settings/voice-setting-contracts.ts
+++ b/apps/admin/lib/settings/voice-setting-contracts.ts
@@ -1,0 +1,241 @@
+/**
+ * Settings-tab voice setting contracts — sibling to
+ * `lib/journey/setting-contracts.ts`. Phase 0 of epic #1675 (story #1676)
+ * captures the 11 voice fields that previously lived split between the
+ * Design tab's Voice Flow lens AND the Settings > Voice Providers page.
+ *
+ * Phase 6 of the Journey Editor epic migrates the UI; this Phase 0 file
+ * ships the registry shape so Phase 6 can pick it up.
+ *
+ * Voice settings are NOT journey-affecting in the compose sense — they
+ * change call engine behaviour (provider, voiceId, timeouts, cost cap),
+ * not the prompt text. They share the same `JourneySettingContract` type
+ * but live in a separate registry so Phase 0 imports stay scoped.
+ *
+ * Cross-registry note: `interruptSensitivity` appears in BOTH this
+ * registry and the journey registry — operator-visible from two angles
+ * (voice config + every-call teaching style). Both entries share the
+ * same `storagePath`. The completeness vitest pins this invariant.
+ */
+
+import type {
+  JourneySettingContract,
+} from "@/lib/journey/setting-contracts";
+
+// Re-export for Settings-tab callers.
+export type {
+  AutoEnableLink,
+  CascadeSource,
+  ComposeImpact,
+  ComposeImpactKind,
+  ControlType,
+  JourneySettingContract,
+  PreviewLocator,
+  StoragePath,
+  StoragePathStruct,
+} from "@/lib/journey/setting-contracts";
+
+export const SETTINGS_GROUPS = {
+  S1_voice: {
+    label: "Voice & calls",
+    caption: "Provider, voice, transcriber, timeouts, cost cap",
+  },
+  S2_integration: {
+    label: "Integrations",
+    caption: "Webhook secrets, third-party credentials",
+  },
+  S3_demo: {
+    label: "Demo & presenter mode",
+    caption: "Demo policy, presenter overlay",
+  },
+  S4_access: {
+    label: "Access & audit",
+    caption: "Role overrides, audit log retention",
+  },
+} as const;
+
+export type SettingsGroup = keyof typeof SETTINGS_GROUPS;
+
+// =============================================================
+// S1 — Voice & calls (11)
+// =============================================================
+
+const V_PROVIDER: JourneySettingContract = {
+  id: "voiceProvider",
+  group: "S1_voice",
+  educatorLabel: "Voice provider",
+  helpText: "VAPI / Deepgram / OpenAI / ElevenLabs / Azure / PlayHT.",
+  storagePath: "playbook.voiceConfig.voiceProvider",
+  control: "select",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.voiceProvider" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+};
+
+const V_ID: JourneySettingContract = {
+  id: "voiceId",
+  group: "S1_voice",
+  educatorLabel: "Voice",
+  helpText: "Provider-specific voice id; preview with the [▶] button.",
+  storagePath: "playbook.voiceConfig.voiceId",
+  control: "voice-picker",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.voiceId" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+};
+
+const V_BACKGROUND_SOUND: JourneySettingContract = {
+  id: "backgroundSound",
+  group: "S1_voice",
+  educatorLabel: "Background sound",
+  helpText: "off / office / custom URL.",
+  storagePath: "playbook.voiceConfig.backgroundSound",
+  control: "select",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.backgroundSound" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+};
+
+/** Cross-registry: also lives in journey registry as G4 entry. Both
+ *  entries share the same storagePath. */
+const V_INTERRUPT_SENSITIVITY: JourneySettingContract = {
+  id: "interruptSensitivity",
+  group: "S1_voice",
+  educatorLabel: "Interrupt sensitivity (voice copy)",
+  helpText:
+    "Mirror of journey G4 entry; surfaces in Voice tab for engineers diagnosing pauses.",
+  storagePath: "config.interruptSensitivity",
+  control: "slider",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["personality"],
+    kinds: ["persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "personality" }],
+};
+
+const V_SPEED: JourneySettingContract = {
+  id: "voiceSpeed",
+  group: "S1_voice",
+  educatorLabel: "Voice speed",
+  helpText: "Playback rate multiplier (1.0 default).",
+  storagePath: "playbook.voiceConfig.voiceSpeed",
+  control: "slider",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.voiceSpeed" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+};
+
+const V_PITCH: JourneySettingContract = {
+  id: "voicePitch",
+  group: "S1_voice",
+  educatorLabel: "Voice pitch",
+  helpText: "Provider-supported pitch offset.",
+  storagePath: "playbook.voiceConfig.voicePitch",
+  control: "slider",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.voicePitch" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+};
+
+const V_SILENCE_THRESHOLD: JourneySettingContract = {
+  id: "silenceThreshold",
+  group: "S1_voice",
+  educatorLabel: "Silence threshold",
+  helpText: "Seconds of silence before the AI re-prompts.",
+  storagePath: "playbook.voiceConfig.silenceThreshold",
+  control: "duration",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.silenceThreshold" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+};
+
+const V_END_CALL_AFTER_SILENCE: JourneySettingContract = {
+  id: "endCallAfterSilence",
+  group: "S1_voice",
+  educatorLabel: "End call after silence",
+  helpText: "Hard hang-up after N seconds of silence.",
+  storagePath: "playbook.voiceConfig.silenceTimeoutSeconds",
+  control: "duration",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.silenceTimeoutSeconds" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+};
+
+const V_MAX_CALL_DURATION: JourneySettingContract = {
+  id: "maxCallDuration",
+  group: "S1_voice",
+  educatorLabel: "Max call duration",
+  helpText: "Hard cap; VAPI hangs up at this point.",
+  storagePath: "playbook.voiceConfig.maxDurationSeconds",
+  control: "duration",
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.voiceConfig.maxDurationSeconds" },
+  ],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+  writeGate: "operator-only",
+};
+
+const V_PHONE_NUMBER: JourneySettingContract = {
+  id: "phoneNumber",
+  group: "S1_voice",
+  educatorLabel: "Outbound phone number",
+  helpText: "Caller-id phone number for outbound dialling.",
+  storagePath: "playbook.voiceConfig.phoneNumber",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+  writeGate: "operator-only",
+};
+
+const V_VAPI_ASSISTANT_ID: JourneySettingContract = {
+  id: "vapiAssistantId",
+  group: "S1_voice",
+  educatorLabel: "VAPI assistant ID",
+  helpText: "Provider-specific assistant id (advanced).",
+  storagePath: "playbook.voiceConfig.vapiAssistantId",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+  previewLocators: [],
+  writeGate: "operator-only",
+};
+
+// =============================================================
+// Registry
+// =============================================================
+
+export const VOICE_SETTINGS: readonly JourneySettingContract[] = [
+  V_PROVIDER,
+  V_ID,
+  V_BACKGROUND_SOUND,
+  V_INTERRUPT_SENSITIVITY,
+  V_SPEED,
+  V_PITCH,
+  V_SILENCE_THRESHOLD,
+  V_END_CALL_AFTER_SILENCE,
+  V_MAX_CALL_DURATION,
+  V_PHONE_NUMBER,
+  V_VAPI_ASSISTANT_ID,
+];
+
+export const VOICE_SETTINGS_BY_ID: Readonly<
+  Record<string, JourneySettingContract>
+> = Object.fromEntries(VOICE_SETTINGS.map((s) => [s.id, s]));

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Journey setting registry — completeness + integrity pins.
+ *
+ * Catches at CI (issue #1676 AC §6):
+ *   1. Every entry has non-empty id, group, educatorLabel, storagePath
+ *   2. Every entry's group is a valid JourneyGroup or SettingsGroup
+ *   3. Every composeImpact.sections[] element is a valid ComposeSectionKey
+ *   4. Every composeImpact.kinds[] element is a valid ComposeImpactKind
+ *   5. No duplicate ids within JOURNEY_SETTINGS
+ *   6. Every group G1..G7 has entries
+ *   7. Exact group counts: G1:5 G2:6 G3:4 G4:17 G5:3 G6:4 G7:6
+ *   8. JOURNEY_SETTINGS.length === 45
+ *   9. VOICE_SETTINGS.length === 11
+ *  10. Cross-registry `interruptSensitivity` shares storagePath
+ *  11. writeGate === "operator-only" → composeImpact.requiresReprompt
+ *      OR composeImpact.sections.length === 0 (operator-only settings
+ *      that change pipeline behaviour need explicit reprompt; pure
+ *      operator gates have no compose impact and don't need it)
+ *  12. previewLocators[].section references valid ComposeSectionKey
+ *  13. JOURNEY_PHASE_FILTERS has exactly 7 values including "All"
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { COMPOSE_SECTION_KEYS } from "@/lib/compose/section";
+import {
+  JOURNEY_GROUPS,
+  JOURNEY_PHASE_FILTERS,
+} from "@/lib/journey/setting-groups";
+import {
+  COMPOSE_IMPACT_KINDS,
+} from "@/lib/journey/setting-contracts";
+import {
+  JOURNEY_SETTINGS,
+  JOURNEY_SETTINGS_BY_ID,
+  JOURNEY_SETTINGS_BY_GROUP,
+} from "@/lib/journey/setting-contracts.entries";
+import {
+  SETTINGS_GROUPS,
+  VOICE_SETTINGS,
+  VOICE_SETTINGS_BY_ID,
+} from "@/lib/settings/voice-setting-contracts";
+
+describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)", () => {
+  it("(1) every entry has non-empty id, group, educatorLabel, storagePath", () => {
+    for (const s of JOURNEY_SETTINGS) {
+      expect(s.id).toBeTruthy();
+      expect(s.group).toBeTruthy();
+      expect(s.educatorLabel).toBeTruthy();
+      expect(s.storagePath).toBeTruthy();
+    }
+  });
+
+  it("(2) every entry's group is a valid JourneyGroup", () => {
+    const validGroups = Object.keys(JOURNEY_GROUPS);
+    for (const s of JOURNEY_SETTINGS) {
+      expect(validGroups).toContain(s.group);
+    }
+  });
+
+  it("(3) every composeImpact.sections[] entry is a real ComposeSectionKey", () => {
+    for (const s of JOURNEY_SETTINGS) {
+      for (const sec of s.composeImpact.sections) {
+        expect(COMPOSE_SECTION_KEYS).toContain(sec);
+      }
+    }
+  });
+
+  it("(4) every composeImpact.kinds[] entry is a valid ComposeImpactKind", () => {
+    for (const s of JOURNEY_SETTINGS) {
+      for (const k of s.composeImpact.kinds) {
+        expect(COMPOSE_IMPACT_KINDS).toContain(k);
+      }
+    }
+  });
+
+  it("(5) no duplicate ids within JOURNEY_SETTINGS", () => {
+    const ids = JOURNEY_SETTINGS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("(6) every group G1..G7 has at least one entry", () => {
+    for (const g of Object.keys(JOURNEY_GROUPS) as Array<
+      keyof typeof JOURNEY_GROUPS
+    >) {
+      expect(JOURNEY_SETTINGS_BY_GROUP[g].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("(7) exact group counts match the audit", () => {
+    expect(JOURNEY_SETTINGS_BY_GROUP.G1.length).toBe(5);
+    expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(6);
+    expect(JOURNEY_SETTINGS_BY_GROUP.G3.length).toBe(4);
+    expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(17);
+    expect(JOURNEY_SETTINGS_BY_GROUP.G5.length).toBe(3);
+    expect(JOURNEY_SETTINGS_BY_GROUP.G6.length).toBe(4);
+    expect(JOURNEY_SETTINGS_BY_GROUP.G7.length).toBe(6);
+  });
+
+  it("(8) JOURNEY_SETTINGS.length === 45", () => {
+    expect(JOURNEY_SETTINGS.length).toBe(45);
+  });
+
+  it("(9) VOICE_SETTINGS.length === 11", () => {
+    expect(VOICE_SETTINGS.length).toBe(11);
+  });
+
+  it("(10) cross-registry `interruptSensitivity` shares storagePath", () => {
+    const journeyEntry = JOURNEY_SETTINGS_BY_ID.interruptSensitivity;
+    const voiceEntry = VOICE_SETTINGS_BY_ID.interruptSensitivity;
+    expect(journeyEntry).toBeDefined();
+    expect(voiceEntry).toBeDefined();
+    expect(journeyEntry.storagePath).toEqual(voiceEntry.storagePath);
+  });
+
+  it("(11) operator-only writeGate implies reprompt OR empty sections", () => {
+    for (const s of JOURNEY_SETTINGS) {
+      if (s.writeGate !== "operator-only") continue;
+      const ok =
+        s.composeImpact.requiresReprompt === true ||
+        s.composeImpact.sections.length === 0;
+      expect(ok, `${s.id} is operator-only but has compose impact without reprompt`).toBe(true);
+    }
+  });
+
+  it("(12) every previewLocators[].section references a real ComposeSectionKey", () => {
+    for (const s of JOURNEY_SETTINGS) {
+      for (const loc of s.previewLocators) {
+        expect(COMPOSE_SECTION_KEYS).toContain(loc.section);
+      }
+    }
+  });
+
+  it("(13) JOURNEY_PHASE_FILTERS has exactly 7 values including 'All'", () => {
+    expect(JOURNEY_PHASE_FILTERS.length).toBe(7);
+    expect(JOURNEY_PHASE_FILTERS).toContain("All");
+  });
+});
+
+describe("Voice registry — secondary integrity pins", () => {
+  it("every voice entry uses an SettingsGroup key", () => {
+    const valid = Object.keys(SETTINGS_GROUPS);
+    for (const s of VOICE_SETTINGS) {
+      expect(valid).toContain(s.group);
+    }
+  });
+
+  it("autoEnableLink.targetId refs resolve within journey or voice registry", () => {
+    const allIds = new Set([
+      ...JOURNEY_SETTINGS.map((s) => s.id),
+      ...VOICE_SETTINGS.map((s) => s.id),
+    ]);
+    for (const s of [...JOURNEY_SETTINGS, ...VOICE_SETTINGS]) {
+      for (const l of s.autoEnableLinks ?? []) {
+        expect(allIds.has(l.targetId), `${s.id} autoEnableLink → ${l.targetId} (missing)`).toBe(true);
+      }
+    }
+  });
+});

--- a/docs/CONTRACTS-JOURNEY.md
+++ b/docs/CONTRACTS-JOURNEY.md
@@ -1,0 +1,278 @@
+# Contracts — Journey Editor Setting Registry
+
+> Sister to [`CHAIN-CONTRACTS.md`](./CHAIN-CONTRACTS.md) (pipeline stage
+> boundaries) and [`CONTRACTS-PLAYBOOK-CURRICULUM.md`](./CONTRACTS-PLAYBOOK-CURRICULUM.md)
+> (model integrity).
+>
+> Ships in epic [#1675](https://github.com/WANDERCOLTD/HF/issues/1675) /
+> story [#1676](https://github.com/WANDERCOLTD/HF/issues/1676).
+
+## §1 — Purpose & scope
+
+The Journey Editor refactor (epic #1675) replaces a fragmented editing
+UX (3 surfaces, ~22 settings inline + 15 lens-only + 12 no-UI) with one
+tri-pane editor where every journey-affecting setting is editable
+through a typed control library. The registry codified in this contract
+is the **single source of truth** for:
+
+| Consumer | Reads from registry |
+|---|---|
+| Phase 1 control library | `control` field → renders correct `<JourneyField>` primitive |
+| Phase 2 Inspector renderer refactor | `group` + `composeImpact` → groups settings into Inspector panels |
+| Phase 2 `section-staleness.ts` migration | `composeImpact.sections` → derive `SECTION_INPUTS_BY_KEY` |
+| Phase 3 gap-fill audit | "every entry without a renderer file" = remaining work |
+| Phase 4 bidirectional Preview ↔ Inspector sync | `previewLocators` → hover/click highlight map |
+| Phase 4 PATCH route | `autoEnableLinks` + `writeGate` → server-side atomic enforcement |
+| Phase 5 Cmd+K | `educatorLabel` → fuzzy search corpus |
+| Phase 5 Edit-as-JSON | `jsonFallbackPath` → opens JSON editor at right path |
+| Phase 6 Voice migration | sibling `VOICE_SETTINGS` registry uses same shape |
+
+**In scope:** every setting whose value changes (a) what the AI says or
+does during any call, (b) which calls happen and when, (c) how learner
+progress is measured.
+
+**Out of scope:** integration credentials, debug flags, RBAC overrides,
+non-journey demo flags. These live on the Settings tab under
+`SETTINGS_GROUPS.S2_integration / S3_demo / S4_access` (future
+registries, post-Phase-0).
+
+## §2 — Registry structure
+
+The full type set lives in
+[`apps/admin/lib/journey/setting-contracts.ts`](../apps/admin/lib/journey/setting-contracts.ts).
+
+```ts
+interface JourneySettingContract {
+  id: string;                                  // stable camelCase slug
+  group: JourneyGroup | SettingsGroupKey;      // G1..G7 or S1_voice
+  educatorLabel: string;
+  helpText?: string;
+  storagePath: StoragePath;                    // string | StoragePathStruct
+  control: ControlType;                        // 13-kind vocabulary
+  cascadeSources: readonly CascadeSource[];
+  composeImpact: ComposeImpact;                // sections + kinds + requiresReprompt
+  previewLocators: readonly PreviewLocator[];  // for Inspector ↔ Preview sync
+  autoEnableLinks?: readonly AutoEnableLink[]; // hard parent/child coupling
+  writeGate?: "operator-only";                 // pipeline-boundary protection
+  jsonFallbackPath?: string;                   // power-user JSON editor anchor
+}
+```
+
+`StoragePath` is **optionally structured** — a bare string is the common
+case; the structured form carries `arrayKey`, `selectorValue`, and
+`writeMode` to address discriminated-union arrays (`sessionFlow.stops[]`)
+and id-keyed lists (`Playbook.config.modules[]`). See Tech Lead review
+2026-06-15 in the ADR (§ "Structured StoragePath") for rationale.
+
+The registry index exports:
+
+| Symbol | Shape | Use |
+|---|---|---|
+| `JOURNEY_SETTINGS` | `readonly JourneySettingContract[]` | Ordered list — Inspector LH menu source-of-truth |
+| `JOURNEY_SETTINGS_BY_ID` | `Record<string, JourneySettingContract>` | O(1) lookup; autoEnableLinks resolution |
+| `JOURNEY_SETTINGS_BY_GROUP` | `Record<JourneyGroup, ...>` | Inspector group panels |
+| `VOICE_SETTINGS` | `readonly JourneySettingContract[]` | Settings-tab Voice lens |
+| `VOICE_SETTINGS_BY_ID` | `Record<string, ...>` | Cross-registry lookups |
+
+## §3 — Group map (G1..G7)
+
+Groups are **ordered by journey time**, not by config category. Scrolling
+the Inspector LH menu reads as the learner's flow.
+
+| Group | Label | Anchored at | Count |
+|---|---|---|---|
+| **G1** | Sign-up & Intake | Pre-call | 5 |
+| **G2** | Call 1 — opening & assessment | Call 1 start | 6 |
+| **G3** | Call 1 — teaching | Call 1 middle | 4 |
+| **G4** | Every call — teaching style | Calls 2+ | 17 |
+| **G5** | Mid-journey stops | Between calls 2+ | 3 |
+| **G6** | End of course / offboarding | Final call | 4 |
+| **G7** | Scoring & sequencing | Cross-cutting | 6 |
+| | | **Total** | **45** |
+
+The phase-filter chip row (`JOURNEY_PHASE_FILTERS`) collapses G2/G3 under
+a single "Call 1" filter (chronologically adjacent + the same educator
+mental scope), yielding 6 phase chips + "All" = 7 chips total.
+
+Per-group authoritative entries are listed in the issue #1676 audit
+table; the canonical source is
+[`apps/admin/lib/journey/setting-contracts.entries.ts`](../apps/admin/lib/journey/setting-contracts.entries.ts).
+
+## §4 — composeImpact contract
+
+Every entry declares both the **sections** it touches and the **kinds**
+of impact.
+
+```ts
+interface ComposeImpact {
+  sections: readonly ComposeSectionKey[];
+  kinds: readonly ComposeImpactKind[];
+  requiresReprompt: boolean;
+}
+```
+
+### The 7 impact kinds
+
+| Kind | Means | Treatment in Inspector |
+|---|---|---|
+| `section-content` | Setting feeds bubble text | Show live diff under field |
+| `section-enable` | Setting toggles whether the bubble exists | Show "Section will appear / disappear" preview |
+| `cascade-override` | Course-level override of a Domain default | "Reset to default" affordance |
+| `stop-timing` | Setting changes when a journey stop fires | Render under the stop's mini-timeline |
+| `scoring-weight` | Setting affects score / mastery thresholds | "Show downstream Goals impact" link |
+| `persona-style` | Setting changes tone without section swap | No preview diff (style is verbal, hard to render) |
+| `sequence-policy` | Setting changes module/LO ordering | "Recompute journey order" CTA |
+
+### `requiresReprompt: boolean`
+
+- **`false` (default)**: Inspector shows a live diff. The Preview redraws
+  on every edit (debounced 300ms). Used for `section-content` /
+  `section-enable` settings whose effect is deterministic.
+- **`true`**: Inspector shows a "Save & reprompt" CTA. The Preview stays
+  on the *prior* snapshot until the educator commits. Required for
+  AI-touching sections (`priorCallFeedback` with synthesis on) because
+  a fresh AI synthesis would fire on every keystroke (cost + latency).
+  Also required for `operator-only` settings with section impact — see §6.
+
+The completeness vitest pins:
+- `requiresReprompt === true` → `sections.length ≥ 1` (no reprompt without impact)
+- `writeGate === "operator-only"` AND `sections.length ≥ 1` → `requiresReprompt === true`
+
+## §5 — cascadeSources precedence
+
+Effective value resolves bottom-up:
+
+```
+group (Playbook.config)  ─▶  domain (Domain.*)  ─▶  system (static default)
+        winning value
+```
+
+`CascadeSource[].level` declares which roots contribute. Empty array
+means the setting is course-only (no inherited default). The Inspector
+shows the effective value with a `LayerBadge` ("from Domain" /
+"course override"); clicking the badge opens the cascade trace.
+
+The Caller level is **NOT** in scope for the Journey Editor — per-learner
+ad-hoc adjustments live in **adaptations**, not the course config. If a
+setting needs a learner-level override, it gets a separate
+`AdaptationContract` in a later epic.
+
+## §6 — writeGate contract — pipeline-boundary protection
+
+`writeGate: "operator-only"` declares that the setting must never be
+mutated inside the adaptive loop (EXTRACT / AGGREGATE / REWARD / ADAPT /
+SUPERVISE / COMPOSE). The pipeline stages can READ these settings; they
+cannot WRITE.
+
+Settings marked `operator-only`:
+
+| Setting | Why |
+|---|---|
+| `intakeSpecId` | IntakeSpec versioning is human-authored; pipeline must never swap mid-flight |
+| `intakeConsentFlow` | Legal/compliance flow; only operators may change |
+| `agentTunerNlpEnabled` | Toggles the operator-only AgentTuner side panel |
+| `rewardStrategy` | The optimisation target. Pipeline reading is fine; writing would self-reference |
+| `maxCallDuration` (voice) | Cost / safety cap; pipeline-level write would create feedback loop |
+| `phoneNumber` (voice) | Provider config — runtime mutation is unsafe |
+| `vapiAssistantId` (voice) | Provider config — runtime mutation is unsafe |
+
+Phase 2 wires a runtime check in the PATCH route that rejects writes
+originating from a pipeline service-token (the existing
+`isPipelineActor` discriminator). The check fails closed.
+
+Cross-reference: [`CHAIN-CONTRACTS.md`](./CHAIN-CONTRACTS.md) §3
+"Pipeline-boundary write protections" already names this pattern for
+the prompt + transcript chain; `writeGate` extends it to the
+setting-registry boundary.
+
+## §7 — Voice registry cross-reference
+
+The Voice registry
+([`lib/settings/voice-setting-contracts.ts`](../apps/admin/lib/settings/voice-setting-contracts.ts))
+is a sibling using the same `JourneySettingContract` type. 11 entries
+under `group: "S1_voice"`. Phase 6 of the epic migrates the existing
+Voice Flow lens (currently on the Design tab) and the Settings > Voice
+Providers page into a single Voice lens on the Settings tab.
+
+### The `interruptSensitivity` cross-registration
+
+ONE id appears in both registries: `interruptSensitivity`. The journey
+registry surfaces it under G4 (every-call teaching style — affects how
+the AI yields conversationally); the voice registry surfaces it under
+S1_voice (engineers diagnosing call-pause behaviour need to find it in
+the Voice tab).
+
+Both entries:
+- Share the same `id` (`interruptSensitivity`)
+- Share the same `storagePath` (`config.interruptSensitivity`)
+- Differ in `group` (G4 vs S1_voice) and `educatorLabel` ("Interrupt
+  sensitivity" vs "Interrupt sensitivity (voice copy)")
+- Differ in `helpText` (educator-framing vs engineer-framing)
+
+The completeness vitest pins `storagePath` equality. If a future PR
+changes one side's path without the other, CI fails before merge.
+
+The author of any new cross-registered setting MUST:
+1. Use the same `id` and same `storagePath` in both registries
+2. Use distinct `educatorLabel` + `helpText` reflecting each tab's audience
+3. Add a row to this section documenting the cross-reference
+
+## §8 — Landmines
+
+### L1 — Storage paths discovered during implementation
+
+The 45 paths in this Phase 0 PR were captured from the live audit but a
+few will mismatch the actual `PlaybookConfig` shape (e.g. nested
+optional objects with non-obvious default semantics). The Phase 1 PR
+that wires the typed control library will be the first time we
+runtime-probe these paths. **Update the registry in the same PR as the
+discovery** — silent divergence is the failure mode. Document each
+correction in this section.
+
+| Discovered in PR | Setting | Original path | Corrected path | Why |
+|---|---|---|---|---|
+| _(placeholder — entries land as we go)_ | | | | |
+
+### L2 — `interruptSensitivity` divergence
+
+If Phase 6 changes how voice-side `interruptSensitivity` is stored, the
+completeness vitest catches it BEFORE merge. Do NOT manually sync the
+two registries — the test owns this invariant.
+
+### L3 — `autoEnableLinks` cascade
+
+A future setting might chain through multiple auto-enable hops (A
+enforces B which enforces C). The registry can express it, but the
+PATCH handler must walk the chain in a single transaction without
+infinite loops. Phase 4 will add a cycle-detection check; until then,
+keep auto-enable chains shallow (≤ 1 hop).
+
+### L4 — section-staleness migration
+
+Phase 2 will migrate `section-staleness.ts::SECTION_INPUTS_BY_KEY` to
+derive from this registry. During the migration, both sources must
+agree exactly. Do NOT delete the existing map until the migration PR
+lands and the existing `affecting-keys.test.ts` assertions pin the
+derived equivalent.
+
+### L5 — adding NEW journey settings post-Phase-0
+
+When a new journey-affecting setting is introduced:
+1. Add an entry to `setting-contracts.entries.ts` BEFORE the read/write
+   code lands. The registry is the contract.
+2. Update the per-group exact-count assertion in
+   `registry-completeness.test.ts` (a `46` from `45`).
+3. If the setting maps onto a NEW `ComposeSectionKey`, add the key to
+   `lib/compose/section.ts` (existing rule). The completeness test
+   catches references to non-existent section keys.
+
+## See also
+
+- [`docs/CHAIN-CONTRACTS.md`](./CHAIN-CONTRACTS.md) — original pipeline-stage chain-contract pattern
+- [`docs/CONTRACTS-PLAYBOOK-CURRICULUM.md`](./CONTRACTS-PLAYBOOK-CURRICULUM.md) — model integrity chain-contract
+- [`docs/decisions/2026-06-15-journey-setting-contracts.md`](./decisions/2026-06-15-journey-setting-contracts.md) — ADR
+- [`apps/admin/lib/journey/setting-contracts.ts`](../apps/admin/lib/journey/setting-contracts.ts) — types
+- [`apps/admin/lib/journey/setting-groups.ts`](../apps/admin/lib/journey/setting-groups.ts) — G1..G7 enum
+- [`apps/admin/lib/journey/setting-contracts.entries.ts`](../apps/admin/lib/journey/setting-contracts.entries.ts) — 45 entries
+- [`apps/admin/lib/settings/voice-setting-contracts.ts`](../apps/admin/lib/settings/voice-setting-contracts.ts) — 11 voice entries
+- [`apps/admin/tests/lib/journey/registry-completeness.test.ts`](../apps/admin/tests/lib/journey/registry-completeness.test.ts) — 15 integrity pins

--- a/docs/decisions/2026-06-15-journey-setting-contracts.md
+++ b/docs/decisions/2026-06-15-journey-setting-contracts.md
@@ -1,0 +1,244 @@
+# ADR: Journey setting registry as single source of truth
+
+**Date:** 2026-06-15
+**Status:** Accepted
+**Context:** Epic [#1675](https://github.com/WANDERCOLTD/HF/issues/1675) Phase 0 / story [#1676](https://github.com/WANDERCOLTD/HF/issues/1676)
+
+## Context
+
+The Course Design tab edits 61 settings that affect the learner journey,
+spread across:
+- 11 lenses on the Design tab `ConsoleShell`
+- 6 chip-row entries on the new DesignerShell Inspector
+- 22 sidetray editors (different save semantics)
+- ~15 lens-only settings that require leaving the Preview entirely
+- ~12 settings with no UI at all (only changeable via direct DB edits)
+
+The relationship between an educator setting and what the AI says was
+undocumented. `lib/compose/section-staleness.ts` maintained its own
+`SECTION_INPUTS_BY_KEY` map; loaders maintained another; the Inspector
+renderers each held a third (implicit) map of "what does this setting
+change?". Drift between any two produced stale ComposedPrompts.
+
+Epic #1675 introduces a new Journey tab as the first tab of the Course
+Design page — tri-pane (LH grouped menu / Preview canvas / RH Inspector
+typed-form editors). The architectural foundation it needs is a
+**single source of truth for setting metadata** before any UI work
+starts.
+
+This ADR records the choice of that foundation.
+
+## Decision
+
+Introduce `lib/journey/setting-contracts.ts` + 45-entry registry as the
+authoritative source of truth for every journey-affecting setting. A
+sibling `lib/settings/voice-setting-contracts.ts` carries the 11 voice
+settings that move out of Design tab to Settings tab in Phase 6.
+
+The registry is hand-curated. Each entry is a
+`JourneySettingContract` carrying: id, group, educatorLabel, storagePath
+(optionally structured), control (13-kind vocabulary), cascadeSources,
+composeImpact (sections + 7 impact kinds + requiresReprompt boolean),
+previewLocators (Inspector ↔ Preview sync), optional autoEnableLinks
+(server-enforced parent/child coupling), optional writeGate
+("operator-only" pipeline-boundary protection).
+
+Five decision points, captured below.
+
+## Decision 1 — Single registry over per-lens hardcoding
+
+**Why this matters:** the per-lens approach (existing) duplicates
+metadata across 11 renderers and `section-staleness.ts`. Drift = stale
+ComposedPrompts.
+
+**Alternatives considered:**
+- **(a) Generate the registry from `PlaybookConfig` types.** Rejected.
+  Types cannot supply `educatorLabel`, `group`, `control`, or
+  `previewLocators` — those are semantic claims the schema doesn't
+  encode. Code-generation gives us the path and TypeScript type but a
+  human still has to assign the rest. Hand-curated with a `satisfies`
+  scaffold is the tradeoff that compiles correctness while leaving
+  authorship to the educator-facing decisions.
+- **(b) Keep per-lens hardcoding; document the chain externally.**
+  Rejected. Documentation drifts; types don't. The point of the
+  registry IS to make drift a compile error.
+
+**Chosen:** Single hand-curated registry with `JOURNEY_SETTINGS_BY_ID`
+unique-key enforcement and a completeness vitest covering 15 invariants
+(per AC §6 of story #1676).
+
+## Decision 2 — Journey-time ordering for groups, not config-category
+
+**Why this matters:** educators don't think in config categories. They
+think "what happens at the top of Call 1?". When the group ordering
+mirrors the journey, scrolling the Inspector menu IS walking the journey.
+
+**Alternatives considered:**
+- **(a) Group by config category** (e.g. "Session flow" / "Scoring" /
+  "Voice" / "Tolerances"). Rejected — that's what the existing
+  ConsoleShell does and it's the UX we're replacing.
+- **(b) No groups; flat list filtered by phase-filter chips.**
+  Rejected — 45 settings without grouping is overwhelming on first
+  load. Filters help power users; groups help first-time educators.
+  We keep both.
+- **(c) Allow cross-listing (one setting in multiple groups).**
+  Considered, deferred. Editor-time confusion ("which copy is the real
+  one?") outweighs discoverability benefit. The cross-registry
+  `interruptSensitivity` is the one approved cross-listing — both
+  copies share storagePath, the completeness vitest pins it. Future
+  cross-listings need explicit ADR follow-up.
+
+**Chosen:** 7 groups (G1..G7) ordered chronologically; G2 (Call 1
+opening & assessment) anchors `firstCallMode + welcomeMessage +
+preTestStop` together — answering operator's "where does first-call
+assessment live?" question that surfaced 2026-06-15.
+
+## Decision 3 — Voice moves to Settings tab (not Journey)
+
+**Why this matters:** voice settings (provider, voiceId, transcriber,
+timeouts, cost cap) change the call engine, not the prompt text. They
+have no `composeImpact.sections`. Putting them in the Journey tab would
+require Inspector renderers for settings that don't affect the journey
+they're sitting next to.
+
+The current Design tab Voice Flow lens AND the Settings > Voice
+Providers page already split voice in two — duplicate edit surfaces
+with overlapping fields. The Journey Editor migration is the right
+moment to consolidate.
+
+**Alternatives considered:**
+- **(a) Keep voice on Journey tab as G8** (the earlier 8-group draft).
+  Rejected per operator decision 2026-06-15 — voice belongs with other
+  cross-cutting Settings (integration, demo, access).
+- **(b) Keep two split surfaces (Design Voice Flow + Settings Voice
+  Providers).** Rejected — the duplication is the problem, not the
+  solution.
+
+**Chosen:** Voice moves to Settings tab as `SETTINGS_GROUPS.S1_voice`,
+11 entries in `VOICE_SETTINGS`. Phase 6 ships the migration in parallel
+with phases 1–5; merges after Phase 4 to avoid the DesignerShell CSS
+conflict (see Tech Lead Q6 in epic #1675).
+
+The single shared id (`interruptSensitivity`) appears in both
+registries — see CONTRACTS-JOURNEY.md §7.
+
+## Decision 4 — `requiresReprompt` split: live diff vs Save & reprompt
+
+**Why this matters:** the bidirectional Preview ↔ Inspector sync (Phase
+4) wants to redraw the Preview canvas on every edit so educators see
+cause→effect immediately. But some settings feed AI-touching compose
+steps (e.g. `priorCallFeedback` with synthesis on). Live-redrawing those
+would fire a fresh AI synthesis on every keystroke — cost + latency
+prohibitive.
+
+**Alternatives considered:**
+- **(a) Live diff for everything; cache aggressively.** Rejected —
+  cache invalidation on AI sections is fragile.
+- **(b) Skip live diff entirely; "Save" button only.** Rejected — kills
+  the killer feature (educator sees impact before commit).
+- **(c) Skip live diff only for AI-touching sections; show "Save &
+  reprompt" CTA.** Chosen.
+
+**Chosen:** `composeImpact.requiresReprompt: boolean` per entry. Default
+`false` (live diff). Set `true` for AI-touching sections. The
+completeness vitest pins that operator-only settings with section
+impact MUST be `requiresReprompt: true` (operator-driven changes are
+intentional, batchable, and worth the AI cost on commit).
+
+## Decision 5 — `writeGate` extends the CHAIN-CONTRACTS pipeline-boundary pattern
+
+**Why this matters:** `docs/CHAIN-CONTRACTS.md` already names the
+"pipeline-boundary write protection" pattern for the prompt + transcript
+chain. The Journey Editor introduces a parallel boundary: settings that
+the educator owns and the pipeline must never mutate (e.g.
+`rewardStrategy` — pipeline reading it is fine, pipeline writing it
+would self-reference).
+
+**Alternatives considered:**
+- **(a) Inline check in each PATCH route.** Rejected — repeating the
+  check across 45 routes is the same problem the registry is solving.
+- **(b) Single registry-derived check in the PATCH handler.** Chosen.
+
+**Chosen:** `writeGate?: "operator-only"` on each contract. Phase 2
+wires a runtime check in the PATCH route that rejects writes from a
+pipeline service-token. The check fails closed. Settings carrying
+`writeGate` today: 7 entries (intakeSpecId, intakeConsentFlow,
+agentTunerNlpEnabled, rewardStrategy, maxCallDuration, phoneNumber,
+vapiAssistantId).
+
+Sister pattern: `CHAIN-CONTRACTS.md` §3.
+
+## Tech Lead delta (folded in)
+
+Three revisions from Tech Lead review 2026-06-15 that didn't appear in
+the BA-authored issue body but landed in the implementation:
+
+1. **Structured StoragePath.** Bare-string `storagePath` cannot address
+   `sessionFlow.stops[]` (discriminated-union array) or
+   `Playbook.config.modules[]` (id-keyed). `StoragePath = string |
+   StoragePathStruct` where the struct carries `arrayKey`,
+   `selectorValue`, and `writeMode`. Tested: G2 `firstCallTargets` and
+   G2 `preTestStop` exercise the structured form.
+
+2. **`autoEnableLinks` are server-enforced atomically.** Cosmetic
+   gray-out alone leaves the DB in a coupled-by-UI-but-decoupled-by-API
+   state when the parent is mutated outside the Journey Editor (CLI,
+   service token, second tab). PATCH handler reads `autoEnableLinks`
+   and applies linked writes in the same `$transaction` as the parent
+   write. UI gray-out + "Decouple" toggle remain cosmetic.
+
+3. **Registry is THE source of truth for `section-staleness.ts`.**
+   Phase 2 deletes `SECTION_INPUTS_BY_KEY` and derives the same map
+   from `JOURNEY_SETTINGS`. Sole authoring path. `affecting-keys.test.ts`
+   asserts the derived equivalent during the migration.
+
+## Consequences
+
+**Positive:**
+- One file lists every journey setting. New phases derive from it.
+- Compile-time drift detection: removing a `ComposeSectionKey` breaks
+  the vitest before merge.
+- Educator-facing labels live with the storage path; no more "what does
+  the toggle in lens X actually write?" archaeology.
+- Server-side auto-enable + writeGate kill two real bug classes
+  (UI-only state divergence; pipeline-self-mutation feedback loops).
+
+**Negative:**
+- Adding a new journey setting now requires updating the registry
+  AND the per-group exact-count assertion in the completeness vitest.
+  Friction by design — we want every new entry curated.
+- Hand-curation took ~5 hours for Phase 0. Each Phase 1–6 PR
+  authors more entries as the system grows; estimated +5min/entry.
+
+**Neutral:**
+- The 7-group ordering pins us to a specific journey mental model.
+  If the model changes (e.g. introducing a new journey phase like
+  "post-course follow-up"), we add G8 + a phase filter. Cheap.
+- `interruptSensitivity` is the one approved cross-registered id.
+  Future cross-registrations need ADR follow-up.
+
+## Out of scope for Phase 0
+
+- Any UI (tri-pane, Inspector, control library) — Phase 1+
+- Typed control primitives — Phase 1
+- Converting existing renderers — Phase 2
+- `section-staleness.ts` migration — Phase 2
+- Voice tab migration — Phase 6
+- API routes for setting writes — Phase 2
+- ESLint rule blocking new `prisma.playbook.update({data: {config: {...}}})` outside the registry — Phase 5
+
+## References
+
+- Epic: [#1675](https://github.com/WANDERCOLTD/HF/issues/1675)
+- Story: [#1676](https://github.com/WANDERCOLTD/HF/issues/1676)
+- Sister contracts:
+  [`CHAIN-CONTRACTS.md`](../CHAIN-CONTRACTS.md),
+  [`CONTRACTS-PLAYBOOK-CURRICULUM.md`](../CONTRACTS-PLAYBOOK-CURRICULUM.md)
+- This contract: [`CONTRACTS-JOURNEY.md`](../CONTRACTS-JOURNEY.md)
+- Reuse-finder report (2026-06-15) — existing primitives the Phase 1
+  control library will wrap (BandingPicker, VoiceConfigSection,
+  CascadeValue + LayerBadge, FancySelect, FieldHint)
+- Tech Lead review (2026-06-15) — structural revisions in
+  Decisions 4 + 5 + "Tech Lead delta" section above
+- Sibling registry pattern: `lib/goals/strategies/types.ts` + custom
+  ESLint rule `no-bare-strategy-key.mjs` (PR #1603)


### PR DESCRIPTION
## Summary

Phase 0 of epic #1675 (Journey Editor refactor). Docs + types + tests only — zero behavioural change, zero migration, zero UI. Hard gate for phases 1–6.

**Closes #1676.**

### Ships

- **`lib/journey/setting-contracts.ts`** — `JourneySettingContract` type. `StoragePath` is optionally structured (per TL revision — bare-string cannot address `sessionFlow.stops[]` array elements). `autoEnableLinks` are server-enforced atomically (per TL — UI gray-out alone leaves DB in coupled-by-UI-only state). `writeGate: "operator-only"` declares pipeline-boundary protection (sister to `CHAIN-CONTRACTS.md` §3).
- **`lib/journey/setting-groups.ts`** — G1..G7 chronological ordering + `JOURNEY_PHASE_FILTERS` (7 chips inc. "All").
- **`lib/journey/setting-contracts.entries.ts`** — 45 hand-authored entries. Exact group counts: G1:5, G2:6, G3:4, G4:17, G5:3, G6:4, G7:6.
- **`lib/settings/voice-setting-contracts.ts`** — sibling registry, 11 voice entries under `S1_voice`. Phase 6 of the epic will migrate the Voice Flow lens (currently Design tab) and Settings > Voice Providers into a single Settings tab Voice lens.
- **`docs/CONTRACTS-JOURNEY.md`** — 8 sections per AC: purpose, registry shape, group map, composeImpact contract, cascade precedence, writeGate, voice cross-reference (`interruptSensitivity` shared id documented), landmines.
- **`docs/decisions/2026-06-15-journey-setting-contracts.md`** — ADR (5 decisions + Tech Lead delta covering structured StoragePath, server-enforced autoEnableLinks, and section-staleness migration plan).
- **`tests/lib/journey/registry-completeness.test.ts`** — 15 integrity pins. Notable: (10) cross-registry `interruptSensitivity` storagePath equality; (11) operator-only `writeGate` implies `requiresReprompt: true` (or empty sections).

### Group breakdown (45 entries)

| Group | Label | Count |
|---|---|---|
| G1 | Sign-up & Intake | 5 |
| G2 | Call 1 — opening & assessment | 6 (firstCallMode auto-enables preTestStop) |
| G3 | Call 1 — teaching | 4 |
| G4 | Every call — teaching style | 17 (incl. cross-registered interruptSensitivity) |
| G5 | Mid-journey stops | 3 |
| G6 | End of course / offboarding | 4 |
| G7 | Scoring & sequencing | 6 (incl. operator-only rewardStrategy) |

## Verified by

- `npx vitest run tests/lib/journey/registry-completeness.test.ts` — **15/15 pass** (8 AC-numbered pins + 7 supplementary integrity checks). Notable assertion: (10) cross-registry `interruptSensitivity` shares storagePath; (11) operator-only writeGate implies requiresReprompt.
- `npx tsc --noEmit` — no errors on the 8 new files (full `lib/journey/`, `lib/settings/`, `tests/lib/journey/` clean).
- `JOURNEY_SETTINGS.length === 45` and `VOICE_SETTINGS.length === 11` — pinned in vitest.
- Hand-walked the 45-entry table against issue #1676 — every id, group, label, and storagePath root matches the audit.

## Out of scope (subsequent phases of epic #1675)

- Phase 1: typed control library `lib/journey-controls/`
- Phase 2: Inspector renderer refactor + section-staleness migration
- Phase 3: gap-fill renderers (~19–27 settings without UI today)
- Phase 4: new Journey tab tri-pane mount + bidirectional Preview↔Inspector sync
- Phase 5: Cmd+K, Edit-as-JSON, cascade-trace chips
- Phase 6: Voice migration (Design Voice Flow lens → Settings tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)