### PR TITLE
feat(callers): Wave E — HF_TAB_LAYOUT FF + amber Retiring pills + redirects

### DIFF
--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -48,6 +48,11 @@ import { GuideLens } from "./caller-detail/lenses/GuideLens";
 
 // Shared types
 import type { CallerData, CallerProfile, CallerRole, Domain, ComposedPrompt, SectionId, ParamConfig } from "./caller-detail/types";
+import {
+  getTabLayout,
+  computeVisibleTabs,
+  RETIRING_TABS,
+} from "@/lib/tab-layout";
 
 // Journey progress hook
 import { useEnrollmentJourney } from "@/hooks/useEnrollmentJourney";
@@ -100,28 +105,48 @@ export default function CallerDetailPage() {
     process.env.NEXT_PUBLIC_SNAPSHOT_V3_ENABLED === "true";
   const snapshotV3Requested = searchParams.get("v") === "3";
   const snapshotV3Active = snapshotV3FlagEnabled && snapshotV3Requested;
+  // Wave E — HF_TAB_LAYOUT FF drives visible-tab composition. `both`
+  // (default) shows v3 primary (Attainment + Adaptations) + legacy
+  // with amber Retiring pill. `retire` hides legacy from the bar and
+  // redirects URL hits via `retirementRedirect` below.
+  const tabLayout = getTabLayout();
+  const tabLayoutResult = computeVisibleTabs(tabLayout);
   // Tabs that may render but DO NOT appear in the tab bar (legacy / hidden).
   // The validTabs list keeps render branches reachable via ?tab=<id>; the
   // tab bar itself is built from the VISIBLE_TABS subset below.
   const validTabs: SectionId[] = ["overview", "overview-v2", "uplift", "uplift-v2", "calls-prompts", "tune", "how", "what", "progress-v2", "artifacts", "ai-call", "session-flow", "attainment", "adaptations", "snapshot-v3"];
-  const VISIBLE_TABS = new Set<SectionId>([
-    "overview-v2",
-    "calls-prompts",
-    "tune",
-    "progress-v2",
-    "uplift-v2",
-    "session-flow",
-    "how",
-    "ai-call",
-    ...(snapshotV3Active ? (["snapshot-v3"] as const) : []),
-  ]);
-  const mappedTab = rawTab ? (tabRedirects[rawTab] || rawTab) as SectionId : null;
+  const VISIBLE_TABS = new Set<SectionId>(tabLayoutResult.visible);
+  // Snapshot v3 stays gated behind the `?v=3` URL param even when
+  // HF_TAB_LAYOUT=both — beta gate, until the dedicated promotion lands.
+  // Operators who want it visible flip `NEXT_PUBLIC_SNAPSHOT_V3_ENABLED=true`
+  // AND `?v=3`.
+  if (!snapshotV3Active) {
+    VISIBLE_TABS.delete("snapshot-v3");
+  }
+  // Wave E — retire-mode redirect: if the raw tab is a retiring one and
+  // the FF flipped to `retire`, route the user to the v3 replacement so
+  // bookmarked URLs don't 404.
+  const retirementRedirect = (rawTab && tabLayout === "retire"
+    ? tabLayoutResult.retirementRedirect(rawTab as SectionId)
+    : null) as SectionId | null;
+  // Wave E — retire-mode redirect wins over the legacy tabRedirects map.
+  // If the FF is `retire` and the user lands on a retiring tab, take them
+  // straight to the v3 replacement.
+  const mappedTab = rawTab
+    ? (retirementRedirect ??
+      ((tabRedirects[rawTab] || rawTab) as SectionId))
+    : null;
   const lastTabKey = `hf.caller-tab.${callerId}`;
   // Also redirect a v1 / hidden id from localStorage so returning users land
   // on the new equivalent instead of a hidden tab they can no longer reach.
+  // Wave E — same retire-mode override applies to the saved-tab path.
   const savedTabRaw = typeof window !== "undefined" ? window.localStorage.getItem(lastTabKey) : null;
+  const savedTabRetirementTarget = savedTabRaw && tabLayout === "retire"
+    ? tabLayoutResult.retirementRedirect(savedTabRaw as SectionId)
+    : null;
   const savedTab = savedTabRaw
-    ? ((tabRedirects[savedTabRaw] || savedTabRaw) as SectionId)
+    ? (savedTabRetirementTarget ??
+      ((tabRedirects[savedTabRaw] || savedTabRaw) as SectionId))
     : null;
   // #641: migrate from the old slide-out toggle (`hf.tuner.open.<callerId>`).
   // If the user had Tune open last visit AND no explicit ?tab= is set, send
@@ -1093,11 +1118,18 @@ export default function CallerDetailPage() {
         {sections.map((section) => {
           const isActive = activeSection === section.id;
           const isSpecial = section.special;
+          // Wave E — amber "Retiring" pill on legacy tabs in `both`
+          // mode. Tooltip names the v3 replacement so the operator can
+          // self-onboard without docs. `retire` mode hides the tab
+          // entirely so the pill never renders there.
+          const retiringEntry =
+            tabLayout === "both" ? RETIRING_TABS[section.id] : undefined;
 
           const cls = [
             "cdp-tab",
             isActive && "cdp-tab-active",
             isSpecial && "cdp-tab-special",
+            retiringEntry && "cdp-tab-retiring",
           ].filter(Boolean).join(" ");
 
           return (
@@ -1105,9 +1137,19 @@ export default function CallerDetailPage() {
               <button
                 onClick={() => setActiveSection(section.id)}
                 className={cls}
+                title={retiringEntry?.tooltip}
               >
                 <span className="cdp-tab-icon">{section.icon}</span>
                 {section.label}
+                {retiringEntry && (
+                  <span
+                    className="cdp-tab-retiring-pill"
+                    aria-label="Retiring tab"
+                    data-testid={`cdp-retiring-pill-${section.id}`}
+                  >
+                    Retiring
+                  </span>
+                )}
                 {section.count !== undefined && section.count > 0 && (
                   <span className="cdp-tab-count">
                     {section.count}

--- a/apps/admin/components/callers/caller-detail-page.css
+++ b/apps/admin/components/callers/caller-detail-page.css
@@ -639,6 +639,31 @@
   color: var(--button-primary-bg);
 }
 
+/* Wave E — amber "Retiring" pill on legacy tabs in HF_TAB_LAYOUT=both
+ * mode. Pill itself is amber, with the tab text + icon slightly muted
+ * so the operator's eye is drawn to the v3 surfaces above it without
+ * the legacy tab feeling broken. */
+.cdp-tab-retiring {
+  color: var(--text-muted);
+}
+
+.cdp-tab-retiring .cdp-tab-icon {
+  opacity: 0.7;
+}
+
+.cdp-tab-retiring-pill {
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--status-warning-text) 18%, transparent);
+  color: var(--status-warning-text);
+  border: 1px solid color-mix(in srgb, var(--status-warning-text) 35%, transparent);
+}
+
 /* Pulsing dot — shown on tabs affected by pipeline processing */
 .cdp-tab-processing {
   width: 7px;

--- a/apps/admin/lib/tab-layout.ts
+++ b/apps/admin/lib/tab-layout.ts
@@ -1,0 +1,119 @@
+/**
+ * Tab-layout feature flag — Wave E of the legacy-tab retirement plan.
+ *
+ * Single env-var-driven knob controlling whether legacy caller-detail
+ * tabs (Overview-v2, Progress-v2, Uplift-v2, Profile) ship alongside
+ * the new v3 surfaces (Snapshot, Attainment, Adaptations) or are
+ * hidden + redirected.
+ *
+ * Two states:
+ *
+ *   - **`both`** (default everywhere) — v3 tabs primary (leftmost).
+ *     Legacy tabs visible to the right with an amber "Retiring" pill
+ *     so educators know they're going away and can drift into the v3
+ *     equivalents at their own pace.
+ *
+ *   - **`retire`** (set per-env when ready) — legacy tabs hidden from
+ *     the tab bar. Their render branches stay reachable via direct
+ *     URL so deep-links don't 404 during transition, but the tab bar
+ *     no longer surfaces them and `localStorage`-saved-tab pointers
+ *     redirect to the v3 replacement.
+ *
+ * Why env-var (not DB SystemSetting): all-or-nothing per env, no
+ * per-user override needed, trivial rollback (flip the var). Why no
+ * "off" state: post-Wave-B the v3 tabs are production-ready; there's
+ * no reason to hide them once shipped. Keeps the state machine tiny.
+ */
+
+import type { SectionId } from "@/components/callers/caller-detail/types";
+
+export type TabLayout = "both" | "retire";
+
+/** Resolves the FF from `NEXT_PUBLIC_HF_TAB_LAYOUT`. Defaults to `both`. */
+export function getTabLayout(): TabLayout {
+  if (typeof process === "undefined") return "both";
+  return process.env.NEXT_PUBLIC_HF_TAB_LAYOUT === "retire" ? "retire" : "both";
+}
+
+/**
+ * The 3 v3 tabs that get promoted to primary visible position by Wave E.
+ * Order matters — first entry sits leftmost in the bar.
+ */
+export const V3_PRIMARY_TABS: readonly SectionId[] = [
+  "snapshot-v3",
+  "attainment",
+  "adaptations",
+] as const;
+
+/**
+ * Legacy tabs that:
+ *   - in `both` mode: still visible but marked with the amber "Retiring" pill
+ *   - in `retire` mode: hidden from the tab bar; URL hits redirect to v3
+ *
+ * Each entry maps to its v3 replacement so the retire-mode redirect can
+ * route correctly + the amber pill's tooltip can name the destination.
+ */
+export const RETIRING_TABS: Record<
+  SectionId,
+  { replacedBy: SectionId; tooltip: string }
+> = {
+  "overview-v2": {
+    replacedBy: "snapshot-v3",
+    tooltip: "Moving to Snapshot — try the new tab",
+  },
+  "progress-v2": {
+    replacedBy: "attainment",
+    tooltip: "Moving to Attainment — try the new tab",
+  },
+  "uplift-v2": {
+    replacedBy: "snapshot-v3",
+    tooltip: "Moving to Snapshot — try the new tab",
+  },
+  how: {
+    replacedBy: "snapshot-v3",
+    tooltip: "Folded into Snapshot — try the new tab",
+  },
+} as Record<SectionId, { replacedBy: SectionId; tooltip: string }>;
+
+/**
+ * The tabs that survive retirement (educator tools that have no v3
+ * equivalent). Visible in both states.
+ */
+export const KEEP_TABS: readonly SectionId[] = [
+  "calls-prompts",
+  "tune",
+  "session-flow",
+  "ai-call",
+] as const;
+
+/**
+ * Compute the visible-tab set + ordered render list for the current FF state.
+ *
+ *   - `both`: V3_PRIMARY first, then KEEP, then RETIRING (with amber pill)
+ *   - `retire`: V3_PRIMARY first, then KEEP. RETIRING tabs are hidden from
+ *     the bar but their render branches stay reachable via URL.
+ *
+ * Returns the set + a redirect map for retired tabs (used by the URL +
+ * localStorage redirect path).
+ */
+export function computeVisibleTabs(layout: TabLayout): {
+  visible: Set<SectionId>;
+  isRetiring: (id: SectionId) => boolean;
+  retirementRedirect: (id: SectionId) => SectionId | null;
+} {
+  const visible = new Set<SectionId>([...V3_PRIMARY_TABS, ...KEEP_TABS]);
+  if (layout === "both") {
+    for (const id of Object.keys(RETIRING_TABS) as SectionId[]) {
+      visible.add(id);
+    }
+  }
+  return {
+    visible,
+    isRetiring: (id) => id in RETIRING_TABS,
+    retirementRedirect: (id) => {
+      const entry = RETIRING_TABS[id];
+      if (!entry) return null;
+      return layout === "retire" ? entry.replacedBy : null;
+    },
+  };
+}

--- a/apps/admin/tests/lib/tab-layout.test.ts
+++ b/apps/admin/tests/lib/tab-layout.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for `lib/tab-layout.ts` — Wave E of the legacy-tab retirement
+ * plan. Drives the HF_TAB_LAYOUT FF + amber pills + retire-mode
+ * redirects.
+ *
+ * Pinned acceptance:
+ *   1. Default to "both" when env var unset
+ *   2. "both" returns visible-set with V3_PRIMARY + KEEP + RETIRING
+ *   3. "retire" returns visible-set with V3_PRIMARY + KEEP ONLY (no retiring)
+ *   4. isRetiring identifies legacy tabs
+ *   5. retirementRedirect returns null in `both` mode (no redirect)
+ *   6. retirementRedirect returns v3 replacement in `retire` mode
+ *   7. Non-retiring tabs return null from retirementRedirect always
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  getTabLayout,
+  computeVisibleTabs,
+  RETIRING_TABS,
+  V3_PRIMARY_TABS,
+  KEEP_TABS,
+} from "@/lib/tab-layout";
+
+const ORIGINAL_ENV = process.env.NEXT_PUBLIC_HF_TAB_LAYOUT;
+
+beforeEach(() => {
+  delete process.env.NEXT_PUBLIC_HF_TAB_LAYOUT;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.NEXT_PUBLIC_HF_TAB_LAYOUT;
+  } else {
+    process.env.NEXT_PUBLIC_HF_TAB_LAYOUT = ORIGINAL_ENV;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("getTabLayout", () => {
+  it("defaults to 'both' when env var unset", () => {
+    expect(getTabLayout()).toBe("both");
+  });
+
+  it("returns 'both' when env var is any string other than 'retire'", () => {
+    process.env.NEXT_PUBLIC_HF_TAB_LAYOUT = "anything";
+    expect(getTabLayout()).toBe("both");
+  });
+
+  it("returns 'retire' when env var explicitly set", () => {
+    process.env.NEXT_PUBLIC_HF_TAB_LAYOUT = "retire";
+    expect(getTabLayout()).toBe("retire");
+  });
+});
+
+describe("computeVisibleTabs", () => {
+  it("in 'both' mode includes V3_PRIMARY + KEEP + RETIRING tabs", () => {
+    const result = computeVisibleTabs("both");
+    for (const id of V3_PRIMARY_TABS) {
+      expect(result.visible.has(id)).toBe(true);
+    }
+    for (const id of KEEP_TABS) {
+      expect(result.visible.has(id)).toBe(true);
+    }
+    for (const id of Object.keys(RETIRING_TABS)) {
+      expect(result.visible.has(id as never)).toBe(true);
+    }
+  });
+
+  it("in 'retire' mode includes V3_PRIMARY + KEEP ONLY (no retiring tabs)", () => {
+    const result = computeVisibleTabs("retire");
+    for (const id of V3_PRIMARY_TABS) {
+      expect(result.visible.has(id)).toBe(true);
+    }
+    for (const id of KEEP_TABS) {
+      expect(result.visible.has(id)).toBe(true);
+    }
+    for (const id of Object.keys(RETIRING_TABS)) {
+      expect(result.visible.has(id as never)).toBe(false);
+    }
+  });
+
+  it("isRetiring identifies retiring tabs in both modes", () => {
+    const both = computeVisibleTabs("both");
+    const retire = computeVisibleTabs("retire");
+    for (const id of Object.keys(RETIRING_TABS)) {
+      expect(both.isRetiring(id as never)).toBe(true);
+      expect(retire.isRetiring(id as never)).toBe(true);
+    }
+  });
+
+  it("isRetiring returns false for non-retiring tabs", () => {
+    const result = computeVisibleTabs("both");
+    for (const id of V3_PRIMARY_TABS) {
+      expect(result.isRetiring(id)).toBe(false);
+    }
+    for (const id of KEEP_TABS) {
+      expect(result.isRetiring(id)).toBe(false);
+    }
+  });
+
+  it("retirementRedirect returns null in 'both' mode (no redirect needed)", () => {
+    const result = computeVisibleTabs("both");
+    for (const id of Object.keys(RETIRING_TABS)) {
+      expect(result.retirementRedirect(id as never)).toBeNull();
+    }
+  });
+
+  it("retirementRedirect returns v3 replacement in 'retire' mode", () => {
+    const result = computeVisibleTabs("retire");
+    expect(result.retirementRedirect("overview-v2")).toBe("snapshot-v3");
+    expect(result.retirementRedirect("progress-v2")).toBe("attainment");
+    expect(result.retirementRedirect("uplift-v2")).toBe("snapshot-v3");
+    expect(result.retirementRedirect("how")).toBe("snapshot-v3");
+  });
+
+  it("retirementRedirect returns null for non-retiring tabs even in 'retire' mode", () => {
+    const result = computeVisibleTabs("retire");
+    expect(result.retirementRedirect("snapshot-v3")).toBeNull();
+    expect(result.retirementRedirect("attainment")).toBeNull();
+    expect(result.retirementRedirect("calls-prompts")).toBeNull();
+    expect(result.retirementRedirect("tune")).toBeNull();
+  });
+});
+
+describe("RETIRING_TABS map", () => {
+  it("includes all 4 expected legacy tabs", () => {
+    const ids = Object.keys(RETIRING_TABS).sort();
+    expect(ids).toEqual(["how", "overview-v2", "progress-v2", "uplift-v2"].sort());
+  });
+
+  it("every replacement is a v3 primary or a keep tab", () => {
+    const allowed = new Set<string>([...V3_PRIMARY_TABS, ...KEEP_TABS]);
+    for (const entry of Object.values(RETIRING_TABS)) {
+      expect(allowed.has(entry.replacedBy)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Wave E of the legacy-tab retirement plan. Promotes the 3 new v3 surfaces (Snapshot, Attainment, Adaptations) to primary visible position on the caller-detail page and marks the legacy tabs (Overview-v2, Progress-v2, Uplift-v2, Profile/How) with an amber "Retiring" pill.

Two FF states via `NEXT_PUBLIC_HF_TAB_LAYOUT`:

- **`both`** (default everywhere) — v3 tabs leftmost; legacy tabs visible with amber "Retiring" pill + tooltip naming the v3 destination.
- **`retire`** — legacy tabs hidden from the tab bar. URL hits + `localStorage` saved-tab pointers redirect to the v3 replacement; render branches stay reachable via direct URL so deep-links don't 404 during transition.

Snapshot v3 stays gated behind `?v=3` even in `both` mode — the prior waves shipped its content:

- **Wave A1** (#1677): Memories + Enrollments folds
- **Wave A2** (#1678): Cert Progress + Score Reasoning on Attainment
- **Wave B** (#1681): Insights block (Momentum + Achievements + Focus areas)

Once we soak `both` mode and flip to `retire`, the v3 tabs become the only learner-detail surface.

## Files

- `apps/admin/lib/tab-layout.ts` (new) — `getTabLayout()`, `computeVisibleTabs()`, `RETIRING_TABS`, `V3_PRIMARY_TABS`, `KEEP_TABS`
- `apps/admin/components/callers/CallerDetailPage.tsx` — replaces hardcoded `VISIBLE_TABS` Set with FF-driven `computeVisibleTabs(getTabLayout())`. Adds `retirementRedirect` for URL + localStorage saved-tab paths. Renders amber pill in `both` mode.
- `apps/admin/components/callers/caller-detail-page.css` — `.cdp-tab-retiring` + `.cdp-tab-retiring-pill` (amber via `var(--status-warning-text)`)
- `apps/admin/tests/lib/tab-layout.test.ts` (new) — 12 vitests pinning FF logic + redirect map + `isRetiring` contract

## Verified by

- `npx vitest run tests/lib/tab-layout.test.ts` → **12/12 passing**
- `npx tsc --noEmit` → 55 errors (well under the 166 ratchet baseline; none introduced by this PR)
- Broader vitest sweep — pre-existing failures only (`goals-track-progress.test.ts`, `page-help.test.ts`, `playbook-source-isolation.test.ts`, `prisma-event-store.test.ts`, `session-store-hash-chain-contract.test.ts`) — same drift documented on prior Wave PRs (#1677/#1678/#1681)
- Lint clean on all changed files

## Test plan

- [ ] Set `NEXT_PUBLIC_HF_TAB_LAYOUT=both` (or leave unset) → see new tabs leftmost + amber "Retiring" pill on legacy tabs
- [ ] Set `NEXT_PUBLIC_HF_TAB_LAYOUT=retire` → legacy tabs hidden from bar
- [ ] In `retire` mode: navigate to `?tab=overview-v2` → redirects to `snapshot-v3`
- [ ] In `retire` mode: refresh on a caller with localStorage saved-tab = "progress-v2" → opens on `attainment`