### PR TITLE
feat(journey): #1682 — Phase 1 typed control library + 13 primitives + 2 hooks

### DIFF
--- a/apps/admin/components/journey-controls/JourneyBanding.tsx
+++ b/apps/admin/components/journey-controls/JourneyBanding.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Banding picker primitive. Phase 1 ships the placeholder; Phase 3
+ *  wraps the existing `BandingPicker` component zero-change (per AC
+ *  risk note). The shell + cascade chip live here so the Inspector
+ *  styles every banding row identically to other settings. */
+export function JourneyBanding({ contract, value }: JourneyFieldProps) {
+  const preset = isBandingValue(value) ? value.tierPresetId ?? "custom" : "custom";
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={false}
+      isActive={false}
+    >
+      <div
+        className="hf-jf-compound-placeholder"
+        data-testid={`hf-jf-banding-${contract.id}`}
+      >
+        Tier preset: <code>{preset}</code>
+        <div className="hf-jf-help">
+          BandingPicker mount ships in Phase 3 (wrap-only, no behaviour change).
+        </div>
+      </div>
+    </_FieldShell>
+  );
+}
+
+function isBandingValue(
+  v: unknown,
+): v is { tierPresetId?: string; thresholds?: unknown } {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/apps/admin/components/journey-controls/JourneyDuration.tsx
+++ b/apps/admin/components/journey-controls/JourneyDuration.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Duration input — pair (numeric value, unit). Underlying storage is
+ *  always a single number in the contract's canonical unit (Phase 2
+ *  passes a `unit: "ms" | "s" | "min"` option; Phase 1 assumes seconds
+ *  by default and converts for display). */
+type DurationUnit = "ms" | "s" | "min";
+
+const DEFAULT_UNIT: DurationUnit = "s";
+
+const UNIT_TO_SECONDS: Record<DurationUnit, number> = {
+  ms: 1 / 1000,
+  s: 1,
+  min: 60,
+};
+
+export function JourneyDuration({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const initialSeconds = typeof value === "number" ? value : 0;
+  const f = useCascadeEditField<number>({
+    contract,
+    value: initialSeconds,
+    onSave: async (next) => onSave(next),
+  });
+
+  // Phase 1: always render in seconds; Phase 2 will pass `displayUnit`.
+  const unit = DEFAULT_UNIT;
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control">
+        <input
+          id={`hf-jf-${contract.id}`}
+          type="number"
+          className="hf-input hf-jf-input"
+          value={Number.isFinite(f.draftValue) ? f.draftValue / UNIT_TO_SECONDS[unit] : ""}
+          disabled={disabled || f.isSaving}
+          aria-disabled={disabled || f.isSaving}
+          data-testid={`hf-jf-duration-${contract.id}`}
+          onChange={(e) => {
+            const next = e.target.valueAsNumber;
+            const seconds = Number.isFinite(next) ? next * UNIT_TO_SECONDS[unit] : 0;
+            f.setDraftValue(seconds);
+            f.commitDebounced();
+          }}
+          onBlur={() => {
+            void f.commit();
+          }}
+        />
+        <span className="hf-jf-help">{unit}</span>
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneyField.tsx
+++ b/apps/admin/components/journey-controls/JourneyField.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * JourneyField — typed control dispatcher for Phase 1 of epic #1675.
+ *
+ * Reads `contract.control` and mounts the right primitive. Every
+ * primitive shares the same shell (label + cascade chip + FieldHint
+ * + glow flash). Phase 2 mounts these inside Inspector renderers; from
+ * Phase 2 onward, no Inspector code ever instantiates a raw `<input>`.
+ *
+ * Wraps each primitive in `<FieldRow>`-equivalent shell so the visual
+ * style of every setting is identical regardless of control kind. Spec
+ * pinned by `tests/components/journey-controls/JourneyField.test.tsx`.
+ */
+
+import { type ReactNode } from "react";
+
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+import "./journey-controls.css";
+
+import { JourneyToggle } from "./JourneyToggle";
+import { JourneySelect } from "./JourneySelect";
+import { JourneyMultiSelect } from "./JourneyMultiSelect";
+import { JourneyText } from "./JourneyText";
+import { JourneyNumber } from "./JourneyNumber";
+import { JourneySlider } from "./JourneySlider";
+import { JourneyDuration } from "./JourneyDuration";
+import { JourneyJsonFallback } from "./JourneyJsonFallback";
+import { JourneyPhases } from "./JourneyPhases";
+import { JourneyTargets } from "./JourneyTargets";
+import { JourneyBanding } from "./JourneyBanding";
+import { JourneyVoicePicker } from "./JourneyVoicePicker";
+import { JourneyStop } from "./JourneyStop";
+
+export interface JourneyFieldProps {
+  contract: JourneySettingContract;
+  /** Current effective value (post-cascade). Type narrows per control. */
+  value: unknown;
+  /** Save handler — Phase 2 typically threads this from the Inspector. */
+  onSave: (next: unknown) => Promise<void>;
+  /** Optional extra options for select-like primitives (passed straight
+   *  through). Phase 2's Inspector renderer supplies these from its
+   *  own resolved schema. */
+  options?: ReadonlyArray<{ value: string; label: string }>;
+  /** Optional cascade-source label override (display only). */
+  cascadeSourceLabel?: string;
+  /** Optional disabled flag — used when an auto-enable link grays out
+   *  this control. */
+  disabled?: boolean;
+  /** Inspector renderer can decline default shell wrapping and own its
+   *  own layout. Default false. */
+  bare?: boolean;
+}
+
+/** Internal dispatch table — keyed off `ControlType`. */
+const PRIMITIVES = {
+  toggle: JourneyToggle,
+  select: JourneySelect,
+  "multi-select": JourneyMultiSelect,
+  text: JourneyText,
+  number: JourneyNumber,
+  slider: JourneySlider,
+  duration: JourneyDuration,
+  "json-fallback": JourneyJsonFallback,
+  phases: JourneyPhases,
+  targets: JourneyTargets,
+  banding: JourneyBanding,
+  "voice-picker": JourneyVoicePicker,
+  stop: JourneyStop,
+} as const;
+
+export function JourneyField(props: JourneyFieldProps): ReactNode {
+  const { contract } = props;
+  const Component = PRIMITIVES[contract.control];
+  if (!Component) {
+    // Defensive — completeness vitest pins that contracts use a valid
+    // ControlType, but a type-narrowing escape hatch is safer than a
+    // runtime crash in development if a NEW control kind lands without
+    // a primitive.
+    return (
+      <div className="hf-jf-compound-placeholder">
+        Unknown control kind: <code>{contract.control}</code>
+      </div>
+    );
+  }
+  return <Component {...props} />;
+}

--- a/apps/admin/components/journey-controls/JourneyJsonFallback.tsx
+++ b/apps/admin/components/journey-controls/JourneyJsonFallback.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Power-user JSON editor for opaque sub-objects. Phase 1 ships a
+ *  trivial textarea-based fallback; Phase 5 will swap in the existing
+ *  `JsonEditorModal` from `components/settings/`. */
+export function JourneyJsonFallback({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const initial = serialise(value);
+  const [text, setText] = useState(initial);
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const f = useCascadeEditField<unknown>({
+    contract,
+    value,
+    onSave: async (next) => onSave(next),
+  });
+
+  const onApply = async () => {
+    if (disabled || f.isSaving) return;
+    try {
+      const parsed: unknown = text.trim() ? JSON.parse(text) : null;
+      setParseError(null);
+      f.setDraftValue(parsed);
+      await f.commit();
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : "Invalid JSON");
+    }
+  };
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={text !== initial}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control">
+        <span className="hf-jf-json-chip">JSON</span>
+        <textarea
+          id={`hf-jf-${contract.id}`}
+          className="hf-input hf-jf-input"
+          rows={4}
+          value={text}
+          disabled={disabled || f.isSaving}
+          data-testid={`hf-jf-json-${contract.id}`}
+          onChange={(e) => setText(e.target.value)}
+        />
+      </div>
+      {parseError ? (
+        <div className="hf-jf-help" role="alert">
+          Parse error: {parseError}
+        </div>
+      ) : null}
+      <div className="hf-jf-control">
+        <button
+          type="button"
+          className="hf-btn hf-btn-secondary"
+          disabled={disabled || f.isSaving || text === initial}
+          onClick={() => void onApply()}
+        >
+          Apply
+        </button>
+      </div>
+    </_FieldShell>
+  );
+}
+
+function serialise(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return "";
+  }
+}

--- a/apps/admin/components/journey-controls/JourneyMultiSelect.tsx
+++ b/apps/admin/components/journey-controls/JourneyMultiSelect.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Multi-select chip group. Commits on each toggle. Value is a
+ *  string[]; defaults to []. */
+export function JourneyMultiSelect({
+  contract,
+  value,
+  onSave,
+  options,
+  disabled,
+}: JourneyFieldProps) {
+  const initial = Array.isArray(value) ? (value as string[]) : [];
+  const f = useCascadeEditField<string[]>({
+    contract,
+    value: initial,
+    onSave: async (next) => onSave(next),
+  });
+
+  const onToggle = async (v: string) => {
+    if (disabled || f.isSaving) return;
+    const has = f.draftValue.includes(v);
+    const next = has ? f.draftValue.filter((x) => x !== v) : [...f.draftValue, v];
+    f.setDraftValue(next);
+    await Promise.resolve();
+    await f.commit();
+  };
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div
+        className="hf-jf-control"
+        role="group"
+        aria-label={contract.educatorLabel}
+        data-testid={`hf-jf-multiselect-${contract.id}`}
+      >
+        {(options ?? []).map((o) => {
+          const on = f.draftValue.includes(o.value);
+          return (
+            <button
+              key={o.value}
+              type="button"
+              className={`hf-chip ${on ? "hf-chip-selected" : ""}`}
+              aria-pressed={on}
+              disabled={disabled || f.isSaving}
+              onClick={() => void onToggle(o.value)}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneyNumber.tsx
+++ b/apps/admin/components/journey-controls/JourneyNumber.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Plain numeric input with debounced commit-on-blur. */
+export function JourneyNumber({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const initial = typeof value === "number" ? value : 0;
+  const f = useCascadeEditField<number>({
+    contract,
+    value: initial,
+    onSave: async (next) => onSave(next),
+  });
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control">
+        <input
+          id={`hf-jf-${contract.id}`}
+          type="number"
+          className="hf-input hf-jf-input"
+          value={Number.isFinite(f.draftValue) ? f.draftValue : ""}
+          disabled={disabled || f.isSaving}
+          aria-disabled={disabled || f.isSaving}
+          data-testid={`hf-jf-number-${contract.id}`}
+          onChange={(e) => {
+            const next = e.target.valueAsNumber;
+            f.setDraftValue(Number.isFinite(next) ? next : 0);
+            f.commitDebounced();
+          }}
+          onBlur={() => {
+            void f.commit();
+          }}
+        />
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneyPhases.tsx
+++ b/apps/admin/components/journey-controls/JourneyPhases.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Compound phase-builder primitive. Phase 1 ships a placeholder shell
+ *  with a click-through to the existing `OnboardingEditor`-style sidetray
+ *  (when wired in Phase 2). For Phase 1 the placeholder is read-only and
+ *  documents that editing currently lives in the legacy lens.
+ *
+ *  Generalisation to a real `<PhaseSequenceBuilder>` is the Phase 2/3
+ *  task — `OnboardingEditor` is tightly scoped today. */
+export function JourneyPhases({ contract, value }: JourneyFieldProps) {
+  const phases = Array.isArray(value) ? (value as Array<{ name?: string }>) : [];
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={false}
+      isActive={false}
+    >
+      <div
+        className="hf-jf-compound-placeholder"
+        data-testid={`hf-jf-phases-${contract.id}`}
+      >
+        {phases.length === 0
+          ? "No phases configured."
+          : `${phases.length} phase${phases.length === 1 ? "" : "s"}: ${phases
+              .map((p) => p.name ?? "(unnamed)")
+              .join(" → ")}`}
+        <div className="hf-jf-help">
+          Inline phase-editing ships in Phase 3. For now, edit via the legacy
+          lens (existing Design tab).
+        </div>
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneySelect.tsx
+++ b/apps/admin/components/journey-controls/JourneySelect.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Single-select dropdown. Commits on change. Renders segmented when
+ *  ≤4 options, dropdown otherwise. */
+export function JourneySelect({
+  contract,
+  value,
+  onSave,
+  options,
+  disabled,
+}: JourneyFieldProps) {
+  const initial = typeof value === "string" ? value : "";
+  const f = useCascadeEditField<string>({
+    contract,
+    value: initial,
+    onSave: async (next) => onSave(next),
+  });
+
+  const opts = options ?? [];
+  const useSegmented = opts.length > 0 && opts.length <= 4;
+
+  const onPick = async (next: string) => {
+    if (disabled || f.isSaving) return;
+    f.setDraftValue(next);
+    await Promise.resolve();
+    await f.commit();
+  };
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control">
+        {useSegmented ? (
+          <div
+            className="hf-jf-segment"
+            data-testid={`hf-jf-select-${contract.id}`}
+          >
+            {opts.map((o) => (
+              <button
+                key={o.value}
+                type="button"
+                aria-pressed={f.draftValue === o.value}
+                disabled={disabled || f.isSaving}
+                onClick={() => void onPick(o.value)}
+              >
+                {o.label}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <select
+            id={`hf-jf-${contract.id}`}
+            className="hf-input hf-jf-input"
+            value={f.draftValue}
+            disabled={disabled || f.isSaving}
+            data-testid={`hf-jf-select-${contract.id}`}
+            onChange={(e) => void onPick(e.target.value)}
+          >
+            {opts.length === 0 ? (
+              <option value="" disabled>
+                no options
+              </option>
+            ) : (
+              opts.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))
+            )}
+          </select>
+        )}
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneySlider.tsx
+++ b/apps/admin/components/journey-controls/JourneySlider.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Bounded numeric slider. Commits on release (onMouseUp / onChange-end);
+ *  the draft updates live as the user drags. */
+export function JourneySlider({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const initial = typeof value === "number" ? value : 0;
+  const f = useCascadeEditField<number>({
+    contract,
+    value: initial,
+    onSave: async (next) => onSave(next),
+  });
+
+  // Phase 1 uses a 0..1 default range; Phase 2 will pass a `range` prop
+  // from the Inspector renderer (e.g. tolerance is 0..1, half-life is
+  // 1..90). Conservative defaults satisfy every existing contract.
+  const min = 0;
+  const max = 1;
+  const step = 0.05;
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control">
+        <input
+          id={`hf-jf-${contract.id}`}
+          type="range"
+          className="hf-jf-slider"
+          min={min}
+          max={max}
+          step={step}
+          value={f.draftValue}
+          disabled={disabled || f.isSaving}
+          aria-disabled={disabled || f.isSaving}
+          data-testid={`hf-jf-slider-${contract.id}`}
+          onChange={(e) => {
+            f.setDraftValue(e.target.valueAsNumber);
+          }}
+          onMouseUp={() => {
+            void f.commit();
+          }}
+          onTouchEnd={() => {
+            void f.commit();
+          }}
+          onBlur={() => {
+            void f.commit();
+          }}
+        />
+        <span className="hf-jf-slider-value">
+          {f.draftValue.toFixed(2)}
+        </span>
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneyStop.tsx
+++ b/apps/admin/components/journey-controls/JourneyStop.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** JourneyStop primitive — a JourneyStop is the discriminated-union
+ *  shape (`{kind, enabled, trigger}`) used for pre-test / mid-test /
+ *  post-test / NPS. Phase 1 ships the placeholder; Phase 3 wraps the
+ *  existing `SurveyStopDetail` / sidetray editor with a typed-form
+ *  surface. */
+export function JourneyStop({ contract, value }: JourneyFieldProps) {
+  const stop = isStop(value) ? value : null;
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={false}
+      isActive={false}
+    >
+      <div
+        className="hf-jf-compound-placeholder"
+        data-testid={`hf-jf-stop-${contract.id}`}
+      >
+        {stop === null
+          ? "Stop not configured."
+          : `${stop.enabled ? "Enabled" : "Disabled"}${
+              stop.kind ? ` · kind: ${stop.kind}` : ""
+            }${stop.trigger ? ` · trigger: ${JSON.stringify(stop.trigger)}` : ""}`}
+        <div className="hf-jf-help">
+          Stop editor mounts in Phase 3.
+        </div>
+      </div>
+    </_FieldShell>
+  );
+}
+
+interface StopShape {
+  kind?: string;
+  enabled?: boolean;
+  trigger?: unknown;
+}
+
+function isStop(v: unknown): v is StopShape {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/apps/admin/components/journey-controls/JourneyTargets.tsx
+++ b/apps/admin/components/journey-controls/JourneyTargets.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Compound first-call BehaviorTarget repeater. Phase 1 ships a
+ *  read-only placeholder showing the override count; the real
+ *  per-parameter slider repeater ships in Phase 3 wrapping the existing
+ *  `FirstSessionSettings` editor. */
+export function JourneyTargets({ contract, value }: JourneyFieldProps) {
+  const overrides = isTargetMap(value) ? Object.keys(value).length : 0;
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={false}
+      isActive={false}
+    >
+      <div
+        className="hf-jf-compound-placeholder"
+        data-testid={`hf-jf-targets-${contract.id}`}
+      >
+        {overrides === 0
+          ? "No first-call target overrides set."
+          : `${overrides} target override${overrides === 1 ? "" : "s"} active.`}
+        <div className="hf-jf-help">
+          Per-parameter editing ships in Phase 3.
+        </div>
+      </div>
+    </_FieldShell>
+  );
+}
+
+function isTargetMap(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/apps/admin/components/journey-controls/JourneyText.tsx
+++ b/apps/admin/components/journey-controls/JourneyText.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+const LONG_TEXT_THRESHOLD = 80;
+
+/** Text input. Auto-debounces on change; commits on blur. Renders as
+ *  textarea when the current value or helpText hints at longer text. */
+export function JourneyText({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const initial = typeof value === "string" ? value : "";
+  const f = useCascadeEditField<string>({
+    contract,
+    value: initial,
+    onSave: async (next) => onSave(next),
+  });
+
+  const isLong = (f.draftValue ?? "").length > LONG_TEXT_THRESHOLD;
+
+  const sharedProps = {
+    id: `hf-jf-${contract.id}`,
+    className: "hf-input hf-jf-input",
+    value: f.draftValue,
+    disabled: disabled || f.isSaving,
+    "aria-disabled": disabled || f.isSaving,
+    "data-testid": `hf-jf-text-${contract.id}`,
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      f.setDraftValue(e.target.value);
+      f.commitDebounced();
+    },
+    onBlur: () => {
+      void f.commit();
+    },
+  };
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control">
+        {isLong ? (
+          <textarea {...sharedProps} rows={3} />
+        ) : (
+          <input type="text" {...sharedProps} />
+        )}
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneyToggle.tsx
+++ b/apps/admin/components/journey-controls/JourneyToggle.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Boolean control. Commits immediately on click — no debounce.
+ *  Visual style matches the existing `hf-toggle-btn-active` family. */
+export function JourneyToggle({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const f = useCascadeEditField<boolean>({
+    contract,
+    value: !!value,
+    onSave: async (next) => onSave(next),
+  });
+
+  const onClick = async () => {
+    if (disabled || f.isSaving) return;
+    f.setDraftValue(!f.draftValue);
+    // Commit on next tick so draft state is updated first.
+    await Promise.resolve();
+    await f.commit();
+  };
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control">
+        <button
+          id={`hf-jf-${contract.id}`}
+          type="button"
+          role="switch"
+          aria-checked={f.draftValue}
+          aria-disabled={disabled || f.isSaving}
+          disabled={disabled || f.isSaving}
+          onClick={onClick}
+          className="hf-jf-toggle"
+          data-testid={`hf-jf-toggle-${contract.id}`}
+        />
+        <span className="hf-jf-help">{f.draftValue ? "On" : "Off"}</span>
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneyVoicePicker.tsx
+++ b/apps/admin/components/journey-controls/JourneyVoicePicker.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/** Voice picker primitive — provider + voiceId combo for the Settings
+ *  tab. Phase 1 ships the shell; Phase 6 mounts the existing
+ *  `VoiceConfigSection` (its autosave loop is untouched per AC risk
+ *  note — Phase 1 must not alter VoiceConfigSection). */
+export function JourneyVoicePicker({ contract, value }: JourneyFieldProps) {
+  const voiceId = typeof value === "string" ? value : "(none)";
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={false}
+      isActive={false}
+    >
+      <div
+        className="hf-jf-compound-placeholder"
+        data-testid={`hf-jf-voice-${contract.id}`}
+      >
+        Voice id: <code>{voiceId}</code>
+        <div className="hf-jf-help">
+          Voice editor mounts in Phase 6 (Settings tab migration —
+          wraps existing VoiceConfigSection).
+        </div>
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/_FieldShell.tsx
+++ b/apps/admin/components/journey-controls/_FieldShell.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * _FieldShell — internal shared wrapper for every JourneyField primitive.
+ *
+ * Renders the row of: label + cascade chip + dirty indicator + glow
+ * border. Children = the control surface itself (rendered by the
+ * primitive). Centralised so changes to the visual frame land in one
+ * place.
+ *
+ * Underscore-prefixed = internal export; not part of the public barrel.
+ */
+
+import type { ReactNode } from "react";
+
+import type {
+  CascadeSource,
+  JourneySettingContract,
+} from "@/lib/journey/setting-contracts";
+
+interface FieldShellProps {
+  contract: JourneySettingContract;
+  /** Cascade source whose value is currently effective. Empty cascadeSources
+   *  on the contract → null here. */
+  effectiveSource: CascadeSource | null;
+  /** Caller passes glow + dirty flags so the shell visualises them. */
+  isDirty: boolean;
+  isActive: boolean;
+  /** The control surface. */
+  children: ReactNode;
+  /** Optional override label suffix (e.g. "(unchanged)"). */
+  labelSuffix?: ReactNode;
+}
+
+export function _FieldShell({
+  contract,
+  effectiveSource,
+  isDirty,
+  isActive,
+  children,
+  labelSuffix,
+}: FieldShellProps): ReactNode {
+  const className = [
+    "hf-jf-row",
+    isDirty ? "hf-jf-row-dirty" : "",
+    isActive ? "hf-glow-active" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={className} data-testid={`hf-jf-row-${contract.id}`}>
+      <div className="hf-jf-label-row">
+        <label className="hf-jf-label" htmlFor={`hf-jf-${contract.id}`}>
+          {contract.educatorLabel}
+          {labelSuffix}
+        </label>
+        <div className="hf-jf-meta">
+          {effectiveSource ? (
+            <span className="hf-category-label" title={effectiveSource.storagePath}>
+              from {effectiveSource.level}
+            </span>
+          ) : null}
+          {isDirty ? <span className="hf-jf-dirty-dot" aria-label="unsaved" /> : null}
+        </div>
+      </div>
+      {children}
+      {contract.helpText ? (
+        <div className="hf-jf-help">{contract.helpText}</div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Helper — resolve the effective cascade source for display. Phase 1
+ *  uses a simple first-listed approach; Phase 2 will plumb the real
+ *  resolveEffective envelope through and pick the WINNING source. */
+export function _firstCascadeSource(
+  contract: JourneySettingContract,
+): CascadeSource | null {
+  return contract.cascadeSources[0] ?? null;
+}

--- a/apps/admin/components/journey-controls/index.ts
+++ b/apps/admin/components/journey-controls/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Journey controls barrel — Phase 1 of epic #1675.
+ *
+ * Phase 2+ imports `JourneyField` only; the 13 primitives are dispatched
+ * internally. Direct imports of primitives are allowed for tests + for
+ * niche Inspector renderers that need a custom shell (rare — use the
+ * default `JourneyField` shell whenever possible).
+ */
+
+export { JourneyField, type JourneyFieldProps } from "./JourneyField";
+export { JourneyToggle } from "./JourneyToggle";
+export { JourneyText } from "./JourneyText";
+export { JourneyNumber } from "./JourneyNumber";
+export { JourneySlider } from "./JourneySlider";
+export { JourneySelect } from "./JourneySelect";
+export { JourneyMultiSelect } from "./JourneyMultiSelect";
+export { JourneyDuration } from "./JourneyDuration";
+export { JourneyJsonFallback } from "./JourneyJsonFallback";
+export { JourneyPhases } from "./JourneyPhases";
+export { JourneyTargets } from "./JourneyTargets";
+export { JourneyBanding } from "./JourneyBanding";
+export { JourneyVoicePicker } from "./JourneyVoicePicker";
+export { JourneyStop } from "./JourneyStop";

--- a/apps/admin/components/journey-controls/journey-controls.css
+++ b/apps/admin/components/journey-controls/journey-controls.css
@@ -1,0 +1,190 @@
+/**
+ * Journey-controls shared CSS — Phase 1 of epic #1675.
+ *
+ * Tokens only — no hardcoded hex. `color-mix()` for alpha. Co-located
+ * convention follows `BandingPicker` precedent.
+ *
+ * Visual hierarchy:
+ *   .hf-jf-row     — wraps one control (label + control + cascade chip + glow)
+ *   .hf-jf-label   — educator-facing label
+ *   .hf-jf-control — the actual control surface (input/select/etc.)
+ *   .hf-jf-meta    — cascade chip + dirty indicator
+ *   .hf-jf-hint    — slot for FieldHint
+ */
+
+.hf-jf-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.hf-jf-row:hover {
+  background: color-mix(in srgb, var(--surface-secondary) 60%, transparent);
+}
+
+.hf-jf-row.hf-glow-active {
+  border-color: color-mix(in srgb, var(--status-success-text) 40%, transparent);
+  background: color-mix(in srgb, var(--status-success-text) 8%, transparent);
+}
+
+.hf-jf-row-dirty {
+  border-color: color-mix(in srgb, var(--accent-primary) 30%, transparent);
+}
+
+.hf-jf-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.hf-jf-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.hf-jf-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.hf-jf-dirty-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.hf-jf-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.hf-jf-help {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+/* Toggle */
+
+.hf-jf-toggle {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--border-default);
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  transition: background-color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.hf-jf-toggle::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--surface-primary);
+  transition: transform 0.15s ease;
+}
+
+.hf-jf-toggle[aria-checked="true"] {
+  background: var(--accent-primary);
+}
+
+.hf-jf-toggle[aria-checked="true"]::after {
+  transform: translateX(16px);
+}
+
+.hf-jf-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Slider */
+
+.hf-jf-slider {
+  flex: 1;
+  cursor: pointer;
+}
+
+.hf-jf-slider-value {
+  min-width: 40px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+/* Number / Text */
+
+.hf-jf-input {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Radio / Select group buttons */
+
+.hf-jf-segment {
+  display: inline-flex;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.hf-jf-segment button {
+  background: transparent;
+  border: 0;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-right: 1px solid var(--border-default);
+}
+
+.hf-jf-segment button:last-child {
+  border-right: 0;
+}
+
+.hf-jf-segment button[aria-pressed="true"] {
+  background: var(--accent-primary);
+  color: var(--surface-primary);
+}
+
+/* JSON fallback — opens a modal; chip indicates fallback mode */
+
+.hf-jf-json-chip {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+}
+
+/* Placeholder pane for compound controls (Phase 2 wires real ones) */
+
+.hf-jf-compound-placeholder {
+  padding: 12px;
+  border: 1px dashed var(--border-default);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+}

--- a/apps/admin/lib/journey/use-cascade-edit-field.ts
+++ b/apps/admin/lib/journey/use-cascade-edit-field.ts
@@ -1,0 +1,152 @@
+/**
+ * useCascadeEditField — canonical hook for the inline cascade-aware edit
+ * pattern, codifying `VoiceConfigSection`'s autosave loop.
+ *
+ *   1. Caller provides: `contract` (JourneySettingContract), `value`
+ *      (current effective value), `cascadeSource` (origin layer),
+ *      `onSave(newValue) → Promise<void>`.
+ *   2. Hook returns: `draftValue`, `setDraftValue`, `isDirty`,
+ *      `isSaving`, `commit()`, `reset()`, `glow`.
+ *   3. Toggles / selects / radios should call `commit()` immediately on
+ *      change. Text / number / textarea should call `commit()` on blur
+ *      OR after the auto-debounce (default 600ms).
+ *   4. On commit error: draft stays, isDirty stays true, caller
+ *      surfaces the error. The glow auto-removes (failure path).
+ *   5. When the upstream `value` prop changes (e.g. websocket update
+ *      or cascade re-resolved), the hook resets the draft IF the user
+ *      is not dirty. If dirty, the new server value is ignored until
+ *      `reset()` is called explicitly.
+ *
+ * Sister hook: `useGlowState` (this hook composes it).
+ *
+ * Phase 1 ships this; Phase 2 wires it into every Inspector renderer.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { JourneySettingContract } from "./setting-contracts";
+import { useGlowState, type UseGlowStateResult } from "./use-glow-state";
+
+const DEFAULT_DEBOUNCE_MS = 600;
+
+export interface UseCascadeEditFieldOptions<T> {
+  /** The contract entry. */
+  contract: JourneySettingContract;
+  /** Current effective value (post-cascade). */
+  value: T;
+  /** Save handler — typically a debounced PATCH route call. */
+  onSave: (next: T) => Promise<void>;
+  /** Debounce ms for blur/auto save. Default 600. */
+  debounceMs?: number;
+}
+
+export interface UseCascadeEditFieldResult<T> {
+  /** Current draft (uncommitted) value. */
+  draftValue: T;
+  /** Update the draft without saving. */
+  setDraftValue: (next: T) => void;
+  /** True when draft !== upstream value. */
+  isDirty: boolean;
+  /** True while a save is in flight. */
+  isSaving: boolean;
+  /** Commit the current draft. */
+  commit: () => Promise<void>;
+  /** Commit the current draft after `debounceMs` (cancel pending). */
+  commitDebounced: () => void;
+  /** Drop the draft and reset to upstream value. */
+  reset: () => void;
+  /** Glow handle for the inline save-flash. */
+  glow: UseGlowStateResult;
+}
+
+export function useCascadeEditField<T>(
+  options: UseCascadeEditFieldOptions<T>,
+): UseCascadeEditFieldResult<T> {
+  const { value, onSave, debounceMs = DEFAULT_DEBOUNCE_MS } = options;
+  const [draft, setDraft] = useState<T>(value);
+  const [isSaving, setSaving] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  const upstreamRef = useRef(value);
+  const glow = useGlowState();
+
+  const isDirty = !objectEqual(draft, value);
+
+  // Upstream changed and user isn't dirty → adopt new value.
+  useEffect(() => {
+    const prevUpstream = upstreamRef.current;
+    if (objectEqual(prevUpstream, value)) return;
+    const userWasDirty = !objectEqual(draftRef.current, prevUpstream);
+    upstreamRef.current = value;
+    if (userWasDirty) {
+      // dirty — leave the user's draft alone
+      return;
+    }
+    setDraft(value);
+  }, [value]);
+
+  useEffect(() => () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  }, []);
+
+  const commit = useCallback(async () => {
+    const current = draftRef.current;
+    if (objectEqual(current, upstreamRef.current)) return;
+    setSaving(true);
+    try {
+      await glow.run(onSave(current));
+    } finally {
+      setSaving(false);
+    }
+  }, [glow, onSave]);
+
+  const commitDebounced = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void commit();
+    }, debounceMs);
+  }, [commit, debounceMs]);
+
+  const reset = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setDraft(upstreamRef.current);
+  }, []);
+
+  return {
+    draftValue: draft,
+    setDraftValue: setDraft,
+    isDirty,
+    isSaving,
+    commit,
+    commitDebounced,
+    reset,
+    glow,
+  };
+}
+
+/** Cheap structural equality. Handles primitives, arrays, plain objects.
+ *  Sufficient for setting values; not a deep clone helper. */
+function objectEqual<T>(a: T, b: T): boolean {
+  if (a === b) return true;
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
+    return false;
+  }
+  const aKeys = Object.keys(a as Record<string, unknown>);
+  const bKeys = Object.keys(b as Record<string, unknown>);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (
+      !objectEqual(
+        (a as Record<string, unknown>)[k],
+        (b as Record<string, unknown>)[k],
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/apps/admin/lib/journey/use-glow-state.ts
+++ b/apps/admin/lib/journey/use-glow-state.ts
@@ -1,0 +1,64 @@
+/**
+ * useGlowState — canonical hook for the `hf-glow-active` save flash.
+ *
+ * Replaces ~12 ad-hoc `setSavedFlash` / `setSavedRecently` impls scattered
+ * across components/course-design/* and components/voice/*. The glow
+ * communicates "background save in progress / just succeeded" without
+ * blocking the UI — distinct from `hf-spinner` which means "user must wait".
+ *
+ * Usage:
+ *
+ *   const glow = useGlowState();
+ *   const onSave = async () => {
+ *     await glow.run(async () => {
+ *       await fetch("/api/...", { method: "PATCH", body });
+ *     });
+ *   };
+ *   return <button className={glow.isActive ? "hf-glow-active" : ""}>Save</button>;
+ *
+ * Semantics:
+ *  - `isActive` flips true as soon as `run` is called
+ *  - stays true while the promise pends
+ *  - stays true for `durationMs` after it resolves (default 1500ms)
+ *  - on rejection: flips off immediately (caller surfaces the error)
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const DEFAULT_FLASH_MS = 1500;
+
+export interface UseGlowStateResult {
+  /** True while the save promise pends OR for `durationMs` after success. */
+  isActive: boolean;
+  /** Wrap your save promise. Returns the same promise. */
+  run: <T>(promise: Promise<T>) => Promise<T>;
+}
+
+export function useGlowState(durationMs: number = DEFAULT_FLASH_MS): UseGlowStateResult {
+  const [isActive, setActive] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  const run = useCallback(<T,>(promise: Promise<T>): Promise<T> => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setActive(true);
+    return promise.then(
+      (value) => {
+        timerRef.current = setTimeout(() => setActive(false), durationMs);
+        return value;
+      },
+      (err) => {
+        setActive(false);
+        throw err;
+      },
+    );
+  }, [durationMs]);
+
+  return { isActive, run };
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/journey-controls/JourneyField.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyField.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { JourneyField } from "@/components/journey-controls/JourneyField";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+import { CONTROL_TYPES } from "@/lib/journey/setting-contracts";
+
+afterEach(() => cleanup());
+
+function baseContract(
+  overrides: Partial<JourneySettingContract> = {},
+): JourneySettingContract {
+  return {
+    id: "test_id",
+    group: "G1",
+    educatorLabel: "Test setting",
+    storagePath: "config.test",
+    control: "toggle",
+    cascadeSources: [],
+    composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+    previewLocators: [],
+    ...overrides,
+  };
+}
+
+describe("JourneyField — dispatcher (Phase 1 #1682)", () => {
+  it("smoke-renders every ControlType without crashing", () => {
+    for (const control of CONTROL_TYPES) {
+      const contract = baseContract({ id: `id_${control}`, control });
+      const { container } = render(
+        <JourneyField
+          contract={contract}
+          value={undefined}
+          onSave={vi.fn(() => Promise.resolve())}
+          options={[
+            { value: "a", label: "A" },
+            { value: "b", label: "B" },
+          ]}
+        />,
+      );
+      // FieldShell row always present, keyed by contract.id
+      expect(container.querySelector(`[data-testid="hf-jf-row-id_${control}"]`)).not.toBeNull();
+      cleanup();
+    }
+  });
+
+  it("renders the educatorLabel and helpText", () => {
+    const contract = baseContract({
+      id: "label_test",
+      educatorLabel: "Opening line",
+      helpText: "First line the learner hears.",
+      control: "text",
+    });
+    render(
+      <JourneyField
+        contract={contract}
+        value="hello"
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.getByText("Opening line")).toBeInTheDocument();
+    expect(screen.getByText("First line the learner hears.")).toBeInTheDocument();
+  });
+
+  it("renders cascade source label when cascadeSources non-empty", () => {
+    const contract = baseContract({
+      id: "casc",
+      control: "toggle",
+      cascadeSources: [{ level: "domain", storagePath: "domain.x" }],
+    });
+    render(
+      <JourneyField
+        contract={contract}
+        value={false}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.getByText(/from domain/)).toBeInTheDocument();
+  });
+
+  it("does not render cascade source when cascadeSources empty", () => {
+    const contract = baseContract({
+      id: "no_casc",
+      control: "toggle",
+      cascadeSources: [],
+    });
+    render(
+      <JourneyField
+        contract={contract}
+        value={false}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.queryByText(/from /)).toBeNull();
+  });
+});

--- a/apps/admin/tests/components/journey-controls/JourneyText.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyText.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+
+import { JourneyText } from "@/components/journey-controls/JourneyText";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+const contract: JourneySettingContract = {
+  id: "welcomeMessage",
+  group: "G2",
+  educatorLabel: "Opening line",
+  storagePath: "sessionFlow.welcomeMessage",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("JourneyText (Phase 1 #1682)", () => {
+  it("renders the upstream value", () => {
+    render(
+      <JourneyText
+        contract={contract}
+        value="hi there"
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect((screen.getByTestId("hf-jf-text-welcomeMessage") as HTMLInputElement).value).toBe(
+      "hi there",
+    );
+  });
+
+  it("fires onSave on blur with the new value", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyText
+        contract={contract}
+        value="hi"
+        onSave={onSave}
+      />,
+    );
+    const input = screen.getByTestId("hf-jf-text-welcomeMessage");
+    fireEvent.change(input, { target: { value: "hi there" } });
+    await act(async () => {
+      fireEvent.blur(input);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith("hi there");
+  });
+});

--- a/apps/admin/tests/components/journey-controls/JourneyToggle.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyToggle.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+import { JourneyToggle } from "@/components/journey-controls/JourneyToggle";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+const contract: JourneySettingContract = {
+  id: "intakeAboutYou",
+  group: "G1",
+  educatorLabel: "About you",
+  storagePath: "sessionFlow.intake.aboutYou",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: { sections: ["intake"], kinds: ["section-enable"], requiresReprompt: false },
+  previewLocators: [],
+};
+
+afterEach(() => cleanup());
+
+describe("JourneyToggle (Phase 1 #1682)", () => {
+  it("renders with aria-checked reflecting the value (role=switch)", () => {
+    render(
+      <JourneyToggle
+        contract={contract}
+        value={true}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    const btn = screen.getByTestId("hf-jf-toggle-intakeAboutYou");
+    expect(btn.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("commits onSave with the flipped value when clicked", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyToggle
+        contract={contract}
+        value={false}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("hf-jf-toggle-intakeAboutYou"));
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(true));
+  });
+
+  it("does not commit when disabled", () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyToggle
+        contract={contract}
+        value={false}
+        onSave={onSave}
+        disabled
+      />,
+    );
+    fireEvent.click(screen.getByTestId("hf-jf-toggle-intakeAboutYou"));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/journey/use-cascade-edit-field.test.ts
+++ b/apps/admin/tests/lib/journey/use-cascade-edit-field.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+const contract: JourneySettingContract = {
+  id: "welcomeMessage",
+  group: "G2",
+  educatorLabel: "Opening line",
+  storagePath: "sessionFlow.welcomeMessage",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+describe("useCascadeEditField", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts not dirty with draft === value", () => {
+    const onSave = vi.fn();
+    const { result } = renderHook(() =>
+      useCascadeEditField<string>({ contract, value: "hello", onSave }),
+    );
+    expect(result.current.draftValue).toBe("hello");
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it("flips dirty when setDraftValue changes", () => {
+    const { result } = renderHook(() =>
+      useCascadeEditField<string>({ contract, value: "a", onSave: vi.fn() }),
+    );
+    act(() => result.current.setDraftValue("b"));
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("commit fires onSave with draft", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useCascadeEditField<string>({ contract, value: "a", onSave }),
+    );
+    act(() => result.current.setDraftValue("b"));
+    await act(async () => {
+      await result.current.commit();
+    });
+    expect(onSave).toHaveBeenCalledWith("b");
+  });
+
+  it("commitDebounced delays the save by debounceMs", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useCascadeEditField<string>({
+        contract,
+        value: "a",
+        onSave,
+        debounceMs: 200,
+      }),
+    );
+    act(() => {
+      result.current.setDraftValue("b");
+      result.current.commitDebounced();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset drops the draft back to upstream value", () => {
+    const { result } = renderHook(() =>
+      useCascadeEditField<string>({
+        contract,
+        value: "a",
+        onSave: vi.fn(),
+      }),
+    );
+    act(() => result.current.setDraftValue("dirty"));
+    expect(result.current.isDirty).toBe(true);
+    act(() => result.current.reset());
+    expect(result.current.draftValue).toBe("a");
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("upstream value change is adopted when not dirty", () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) =>
+        useCascadeEditField<string>({ contract, value: v, onSave: vi.fn() }),
+      { initialProps: { v: "a" } },
+    );
+    rerender({ v: "b" });
+    expect(result.current.draftValue).toBe("b");
+  });
+
+  it("upstream value change is ignored when dirty", () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) =>
+        useCascadeEditField<string>({ contract, value: v, onSave: vi.fn() }),
+      { initialProps: { v: "a" } },
+    );
+    act(() => result.current.setDraftValue("draft"));
+    rerender({ v: "b" });
+    expect(result.current.draftValue).toBe("draft");
+  });
+});

--- a/apps/admin/tests/lib/journey/use-glow-state.test.ts
+++ b/apps/admin/tests/lib/journey/use-glow-state.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useGlowState } from "@/lib/journey/use-glow-state";
+
+describe("useGlowState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts inactive", () => {
+    const { result } = renderHook(() => useGlowState());
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("activates while a save promise pends", async () => {
+    const { result } = renderHook(() => useGlowState(100));
+    let resolve!: () => void;
+    const p = new Promise<void>((r) => {
+      resolve = r;
+    });
+    act(() => {
+      void result.current.run(p);
+    });
+    expect(result.current.isActive).toBe(true);
+    await act(async () => {
+      resolve();
+      await Promise.resolve();
+    });
+    // Glow stays on for `durationMs` after success
+    expect(result.current.isActive).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("deactivates immediately on rejection", async () => {
+    const { result } = renderHook(() => useGlowState(100));
+    let reject!: (e: Error) => void;
+    const p = new Promise<void>((_, r) => {
+      reject = r;
+    });
+    act(() => {
+      void result.current.run(p).catch(() => {});
+    });
+    expect(result.current.isActive).toBe(true);
+    await act(async () => {
+      reject(new Error("boom"));
+      await Promise.resolve();
+    });
+    expect(result.current.isActive).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of epic #1675. Ships the typed control library that Phases 2–6 consume. **Zero wiring into the Inspector yet — that's Phase 2.** Closes #1682.

### Ships

**Hooks (`lib/journey/`):**
- `use-glow-state.ts` — canonical `hf-glow-active` save-flash hook
- `use-cascade-edit-field.ts` — autosave loop codifying `VoiceConfigSection` pattern (without modifying it — Phase 6 owns that migration)

**Components (`components/journey-controls/`):**
- `JourneyField.tsx` — dispatcher; reads `contract.control` → mounts the right primitive
- `_FieldShell.tsx` — shared internal wrapper: label + cascade chip + dirty dot + glow border
- 13 primitives: Toggle/Text/Number/Slider/Select/MultiSelect/Duration/JsonFallback (functional); Phases/Targets/Banding/VoicePicker/Stop (placeholders — Phase 3 wraps `OnboardingEditor`/`FirstSessionSettings`/`BandingPicker`/`SurveyStopDetail` zero-change; Phase 6 wraps `VoiceConfigSection` zero-change)
- `journey-controls.css` — shared CSS, tokens only, `color-mix()` for alpha
- `index.ts` — barrel

### Storybook decision (flagged in story #1682 AC)

**Deferred to Phase 2.** Rationale: every primitive smoke renders in vitest; Storybook adds value for visual review but isn't structurally needed.

## Verified by

```
$ cd apps/admin && npx vitest run tests/lib/journey/ tests/components/journey-controls/

✓ tests/lib/journey/use-glow-state.test.ts (3 tests)
  ✓ starts inactive
  ✓ activates while a save promise pends
  ✓ deactivates immediately on rejection

✓ tests/lib/journey/use-cascade-edit-field.test.ts (7 tests)
  ✓ starts not dirty with draft === value
  ✓ flips dirty when setDraftValue changes
  ✓ commit fires onSave with draft
  ✓ commitDebounced delays the save by debounceMs
  ✓ reset drops the draft back to upstream value
  ✓ upstream value change is adopted when not dirty
  ✓ upstream value change is ignored when dirty

✓ tests/components/journey-controls/JourneyField.test.tsx (4 tests)
  ✓ smoke-renders every ControlType without crashing
  ✓ renders the educatorLabel and helpText
  ✓ renders cascade source label when cascadeSources non-empty
  ✓ does not render cascade source when cascadeSources empty

✓ tests/components/journey-controls/JourneyToggle.test.tsx (3 tests)
  ✓ renders with aria-checked reflecting the value (role=switch)
  ✓ commits onSave with the flipped value when clicked
  ✓ does not commit when disabled

✓ tests/components/journey-controls/JourneyText.test.tsx (2 tests)
  ✓ renders the upstream value
  ✓ fires onSave on blur with the new value

Test Files  6 passed (6)
     Tests  34 passed (34)  ← Phase 0's 15 + Phase 1's 19
```

- `npx tsc --noEmit` — clean on the 23 touched files (verified via pre-push gate: `tsc (filtered to 23 changed file(s)) ... ✓ pass`)
- `npx eslint components/journey-controls lib/journey/use-glow-state.ts lib/journey/use-cascade-edit-field.ts tests/lib/journey/use-cascade-edit-field.test.ts tests/lib/journey/use-glow-state.test.ts tests/components/journey-controls/` — **0 errors, 0 warnings** (initial 2 jsx-a11y warnings on `aria-pressed` for `role=switch` fixed by switching to `aria-checked` + matching CSS selector)

## Out of scope

- Phase 2: Inspector renderer refactor wires `<JourneyField>` everywhere
- Phase 3: gap-fill renderers (compound primitives mount real editors)
- Phase 4: new Journey tab tri-pane
- Phase 5: Cmd+K, Edit-as-JSON modal upgrade, cascade-trace chip
- Phase 6: Voice migration to Settings tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)