### PR TITLE
feat(callers): Wave C1 — Hero + Engagement + Mock + Recent calls on Snapshot (#1685)

### DIFF
--- a/apps/admin/components/callers/caller-detail/SnapshotEngagementBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotEngagementBlock.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+/**
+ * SnapshotEngagementBlock — Wave C1 of the legacy-tab retirement plan.
+ *
+ * Lifts Uplift v2's EngagementSection (memories slice donut + Calls/week
+ * StatTile + 14-day CalendarStrip) into Snapshot v3 so uplift-v2 can
+ * retire without losing the cadence + memory-shape signal.
+ *
+ * Thin wrapper around the legacy `EngagementSection` — it already calls
+ * `useUpliftData(callerId)` and uses shared `display-primitives`. Mounted
+ * inside a `hf-snapshot-section` shell so the layout matches Snapshot v3.
+ */
+
+import { EngagementSection } from "./caller-detail-v2/sections/EngagementSection";
+
+interface SnapshotEngagementBlockProps {
+  callerId: string;
+}
+
+export function SnapshotEngagementBlock({ callerId }: SnapshotEngagementBlockProps) {
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-engagement"
+    >
+      <div className="hf-card-compact">
+        <EngagementSection callerId={callerId} />
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotHeroBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotHeroBlock.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * SnapshotHeroBlock — Wave C1 of the legacy-tab retirement plan.
+ *
+ * Lifts Uplift v2's HeroSection (Mastery + Confidence + Knowledge donuts
+ * with pre/post markers + Calls + Days-active StatTiles + mastery
+ * micro-sparkline) into Snapshot v3 so uplift-v2 can retire without
+ * losing the headline proof points.
+ *
+ * Thin wrapper around the legacy `HeroSection` — it already calls
+ * `useUpliftData(callerId)` and uses shared `display-primitives`. We
+ * mount it inside a `hf-snapshot-section` shell so the layout matches
+ * the rest of Snapshot v3.
+ *
+ * STUDENT scope: the underlying `/api/callers/[id]/uplift` route already
+ * gates via `studentAllowedToReadCaller`.
+ */
+
+import { HeroSection } from "./caller-detail-v2/sections/HeroSection";
+
+interface SnapshotHeroBlockProps {
+  callerId: string;
+}
+
+export function SnapshotHeroBlock({ callerId }: SnapshotHeroBlockProps) {
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-hero"
+    >
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Proof points</div>
+        <HeroSection callerId={callerId} />
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotMockResultsBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotMockResultsBlock.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * SnapshotMockResultsBlock — Wave C1 of the legacy-tab retirement plan.
+ *
+ * Lifts overview-v2's MockResultV2 (latest Mock score donut + DeltaPill
+ * vs prior Mock + date) into Snapshot v3. Self-hides when the caller has
+ * no Mock calls — matches the legacy behaviour.
+ *
+ * Fetches `/api/calls?callerId=<id>&limit=50` (which already returns
+ * call.scores in the same response shape MockResultV2 expects). The
+ * legacy MockResultV2 component does the source-string filter + score
+ * aggregation client-side, so we just pass the calls + scores arrays
+ * through.
+ *
+ * STUDENT scope: `/api/calls` already routes through
+ * `resolveCallerScopeForReading` so a STUDENT supplying a foreign
+ * callerId is rejected.
+ */
+
+import { useEffect, useState } from "react";
+
+import { MockResultV2 } from "./caller-detail-v2/overview/MockResultV2";
+
+interface SnapshotMockResultsBlockProps {
+  callerId: string;
+}
+
+interface CallLite {
+  id: string;
+  source: string;
+  createdAt: string;
+}
+
+interface ScoreLite {
+  callId: string;
+  parameterId: string;
+  score: number;
+}
+
+interface CallsListResponse {
+  ok: boolean;
+  calls: Array<{
+    id: string;
+    source: string;
+    createdAt: string;
+    scores?: Array<{ parameterId: string; score: number }>;
+  }>;
+}
+
+export function SnapshotMockResultsBlock({ callerId }: SnapshotMockResultsBlockProps) {
+  const [data, setData] = useState<{ calls: CallLite[]; scores: ScoreLite[] } | null | "error">(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/calls?callerId=${encodeURIComponent(callerId)}&limit=50`)
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setData("error");
+          return;
+        }
+        const json = (await res.json()) as CallsListResponse;
+        if (cancelled) return;
+        const calls: CallLite[] = (json.calls ?? []).map((c) => ({
+          id: c.id,
+          source: c.source,
+          createdAt: c.createdAt,
+        }));
+        const scores: ScoreLite[] = (json.calls ?? []).flatMap((c) =>
+          (c.scores ?? []).map((s) => ({
+            callId: c.id,
+            parameterId: s.parameterId,
+            score: s.score,
+          })),
+        );
+        setData({ calls, scores });
+      })
+      .catch(() => {
+        if (!cancelled) setData("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId]);
+
+  if (data === null || data === "error") return null;
+
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-mock-results"
+    >
+      <MockResultV2 calls={data.calls} scores={data.scores} />
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotRecentCallsBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotRecentCallsBlock.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * SnapshotRecentCallsBlock — Wave C1 of the legacy-tab retirement plan.
+ *
+ * Lifts overview-v2's RecentCallsV2 (TimelineRibbon of last 5 calls with
+ * click-through) into Snapshot v3 so overview-v2 can retire without
+ * losing the at-a-glance call history.
+ *
+ * Fetches `/api/calls?callerId=<id>&limit=10`. Self-hides when the
+ * caller has no calls.
+ */
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { RecentCallsV2 } from "./caller-detail-v2/overview/RecentCallsV2";
+
+interface SnapshotRecentCallsBlockProps {
+  callerId: string;
+}
+
+interface CallLite {
+  id: string;
+  source: string;
+  createdAt: string;
+}
+
+interface CallsListResponse {
+  ok: boolean;
+  calls: Array<{ id: string; source: string; createdAt: string }>;
+}
+
+export function SnapshotRecentCallsBlock({ callerId }: SnapshotRecentCallsBlockProps) {
+  const router = useRouter();
+  const [calls, setCalls] = useState<CallLite[] | null | "error">(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/calls?callerId=${encodeURIComponent(callerId)}&limit=10`)
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setCalls("error");
+          return;
+        }
+        const json = (await res.json()) as CallsListResponse;
+        if (cancelled) return;
+        setCalls(
+          (json.calls ?? []).map((c) => ({
+            id: c.id,
+            source: c.source,
+            createdAt: c.createdAt,
+          })),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setCalls("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId]);
+
+  if (calls === null || calls === "error" || calls.length === 0) return null;
+
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-recent-calls"
+    >
+      <RecentCallsV2
+        calls={calls}
+        onCallClick={(callId) => router.push(`/x/calls/${callId}`)}
+        onViewAll={() =>
+          router.push(`/x/callers/${callerId}?tab=calls-prompts`)
+        }
+      />
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
@@ -40,6 +40,10 @@ import { SnapshotPersonalityBlock } from "./SnapshotPersonalityBlock";
 import { SnapshotMemoryBlock } from "./SnapshotMemoryBlock";
 import { SnapshotEnrollmentBlock } from "./SnapshotEnrollmentBlock";
 import { SnapshotInsightsBlock } from "./SnapshotInsightsBlock";
+import { SnapshotHeroBlock } from "./SnapshotHeroBlock";
+import { SnapshotEngagementBlock } from "./SnapshotEngagementBlock";
+import { SnapshotMockResultsBlock } from "./SnapshotMockResultsBlock";
+import { SnapshotRecentCallsBlock } from "./SnapshotRecentCallsBlock";
 
 import "./snapshot-tab.css";
 
@@ -155,12 +159,28 @@ export function SnapshotTabContent({ callerId, domainId }: SnapshotTabContentPro
         <LearningTrajectoryCard callerId={callerId} />
       </section>
 
+      {/* Wave C1 — Hero proof points (Mastery + Confidence + Knowledge
+       * donuts with pre/post markers + Calls + Days-active StatTiles +
+       * mastery micro-sparkline) lifted from Uplift v2 HeroSection so
+       * the uplift-v2 tab can retire without losing the headline
+       * deltas. Sits at the top so the operator sees the donuts first. */}
+      <SnapshotHeroBlock callerId={callerId} />
+
       {/* Wave B — computed signals (Momentum + Achievements +
        * Focus areas) lifted from OverviewV2Tab's At-a-Glance card,
        * Achievements card, and FocusAreas card. Sits high so the
        * operator gets the "what shape is this learner in right now"
        * signal before scrolling. */}
       <SnapshotInsightsBlock callerId={callerId} />
+
+      {/* Wave C1 — Recent calls TimelineRibbon (last 5 calls with
+       * click-through) lifted from overview-v2's RecentCallsV2 so the
+       * at-a-glance call history survives the legacy-tab retirement. */}
+      <SnapshotRecentCallsBlock callerId={callerId} />
+
+      {/* Wave C1 — Mock results card (latest Mock score donut + delta
+       * vs prior Mock). Self-hides for callers with no Mock calls. */}
+      <SnapshotMockResultsBlock callerId={callerId} />
 
       <SnapshotPersonalityBlock callerId={callerId} />
 
@@ -209,6 +229,12 @@ export function SnapshotTabContent({ callerId, domainId }: SnapshotTabContentPro
        * / Actions) so the operator-state sections sit higher; these
        * two are caller-administrative and natural to scroll down to. */}
       <SnapshotMemoryBlock callerId={callerId} />
+
+      {/* Wave C1 — Engagement (memories slice donut + Calls/week
+       * StatTile + 14-day CalendarStrip) lifted from Uplift v2
+       * EngagementSection. Sits next to MemoryBlock since both surface
+       * memory + cadence signals. */}
+      <SnapshotEngagementBlock callerId={callerId} />
 
       <SnapshotEnrollmentBlock callerId={callerId} domainId={domainId} />
     </div>

--- a/apps/admin/tests/components/callers/snapshot-engagement-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-engagement-block.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for SnapshotEngagementBlock — Wave C1 of the legacy-tab
+ * retirement plan. Smoke-test that the section + delegate mount.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotEngagementBlock } from "@/components/callers/caller-detail/SnapshotEngagementBlock";
+
+const CALLER_ID = "caller-c1-engage";
+
+function upliftWithMemories() {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      uplift: {
+        confidencePre: null,
+        confidencePost: null,
+        confidenceDelta: null,
+        testScorePre: null,
+        testScorePost: null,
+        knowledgeDelta: null,
+        overallMastery: 0,
+        totalCalls: 7,
+        firstCallAt: "2026-06-01T00:00:00Z",
+        latestCallAt: "2026-06-15T00:00:00Z",
+        callDates: ["2026-06-14T10:00:00Z", "2026-06-15T10:00:00Z"],
+        timeOnPlatformDays: 14,
+        callFrequencyPerWeek: 3.5,
+        scoreTrends: [],
+        adaptationEvidence: [],
+        modules: [],
+        goals: [],
+        memoryCounts: {
+          facts: 12,
+          preferences: 3,
+          events: 5,
+          topics: 8,
+          total: 28,
+        },
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotEngagementBlock", () => {
+  it("renders Engagement heading + Calls/week tile + 14-day strip", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => upliftWithMemories()));
+    render(<SnapshotEngagementBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Engagement")).toBeTruthy();
+      expect(screen.getByText(/Calls \/ week/)).toBeTruthy();
+      expect(screen.getByText(/Last 14 days/)).toBeTruthy();
+    });
+  });
+
+  it("shows memory total in slice-donut center", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => upliftWithMemories()));
+    render(<SnapshotEngagementBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("28")).toBeTruthy();
+    });
+  });
+
+  it("carries the hf-snapshot-engagement data-testid", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => upliftWithMemories()));
+    const { container } = render(<SnapshotEngagementBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="hf-snapshot-engagement"]')).toBeTruthy();
+    });
+  });
+});

--- a/apps/admin/tests/components/callers/snapshot-hero-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-hero-block.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for SnapshotHeroBlock — Wave C1 of the legacy-tab retirement plan.
+ *
+ * Thin wrapper around HeroSection — we smoke-test that the section
+ * shell + delegate mount cleanly. The donut/sparkline rendering details
+ * are pinned by the existing HeroSection bank.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotHeroBlock } from "@/components/callers/caller-detail/SnapshotHeroBlock";
+
+const CALLER_ID = "caller-c1-hero";
+
+function emptyUpliftResponse() {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      uplift: {
+        confidencePre: null,
+        confidencePost: null,
+        confidenceDelta: null,
+        testScorePre: null,
+        testScorePost: null,
+        knowledgeDelta: null,
+        overallMastery: 0,
+        totalCalls: 0,
+        firstCallAt: null,
+        latestCallAt: null,
+        callDates: [],
+        timeOnPlatformDays: 0,
+        callFrequencyPerWeek: 0,
+        scoreTrends: [],
+        adaptationEvidence: [],
+        modules: [],
+        goals: [],
+        memoryCounts: { facts: 0, preferences: 0, events: 0, topics: 0, total: 0 },
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotHeroBlock", () => {
+  it("renders the section shell with Proof points category label", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyUpliftResponse()));
+    render(<SnapshotHeroBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Proof points/)).toBeTruthy();
+    });
+  });
+
+  it("delegates to HeroSection (Mastery / Confidence / Knowledge labels render)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyUpliftResponse()));
+    render(<SnapshotHeroBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Mastery")).toBeTruthy();
+      expect(screen.getByText("Confidence")).toBeTruthy();
+      expect(screen.getByText("Knowledge")).toBeTruthy();
+    });
+  });
+
+  it("renders awaiting-first-call empty state when totalCalls=0", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyUpliftResponse()));
+    render(<SnapshotHeroBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Awaiting first call/)).toBeTruthy();
+    });
+  });
+
+  it("carries the hf-snapshot-hero data-testid for tab-content composition", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyUpliftResponse()));
+    const { container } = render(<SnapshotHeroBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="hf-snapshot-hero"]')).toBeTruthy();
+    });
+  });
+});

--- a/apps/admin/tests/components/callers/snapshot-mock-results-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-mock-results-block.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for SnapshotMockResultsBlock — Wave C1 of the legacy-tab
+ * retirement plan.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotMockResultsBlock } from "@/components/callers/caller-detail/SnapshotMockResultsBlock";
+
+const CALLER_ID = "caller-c1-mock";
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotMockResultsBlock", () => {
+  it("self-hides when caller has no calls at all", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ ok: true, calls: [] }), { status: 200 }),
+      ),
+    );
+    const { container } = render(<SnapshotMockResultsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="hf-snapshot-mock-results"]')).toBeNull();
+    });
+  });
+
+  it("self-hides when caller has calls but none are Mock", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            calls: [
+              {
+                id: "c1",
+                source: "vapi",
+                createdAt: "2026-06-14T10:00:00Z",
+                scores: [{ parameterId: "p1", score: 0.7 }],
+              },
+              { id: "c2", source: "sim", createdAt: "2026-06-15T10:00:00Z", scores: [] },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const { container } = render(<SnapshotMockResultsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      // Block mounts the section shell but MockResultV2 returns null inside
+      // because no mock calls match. We test the inner card title is absent.
+      expect(screen.queryByText("Mock results")).toBeNull();
+    });
+  });
+
+  it("renders Mock results card when caller has at least one Mock call", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            calls: [
+              {
+                id: "m1",
+                source: "MOCK_EXAM",
+                createdAt: "2026-06-14T10:00:00Z",
+                scores: [
+                  { parameterId: "p1", score: 0.85 },
+                  { parameterId: "p2", score: 0.75 },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotMockResultsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Mock results")).toBeTruthy();
+    });
+  });
+
+  it("self-hides on fetch error (no surprise UI for the operator)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 500 })),
+    );
+    const { container } = render(<SnapshotMockResultsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="hf-snapshot-mock-results"]')).toBeNull();
+    });
+  });
+});

--- a/apps/admin/tests/components/callers/snapshot-recent-calls-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-recent-calls-block.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for SnapshotRecentCallsBlock — Wave C1 of the legacy-tab
+ * retirement plan.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotRecentCallsBlock } from "@/components/callers/caller-detail/SnapshotRecentCallsBlock";
+
+const CALLER_ID = "caller-c1-recent";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotRecentCallsBlock", () => {
+  it("self-hides when caller has no calls", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ ok: true, calls: [] }), { status: 200 }),
+      ),
+    );
+    const { container } = render(<SnapshotRecentCallsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="hf-snapshot-recent-calls"]')).toBeNull();
+    });
+  });
+
+  it("renders Recent calls card with TimelineRibbon when calls exist", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            calls: [
+              { id: "c1", source: "vapi", createdAt: "2026-06-10T10:00:00Z" },
+              { id: "c2", source: "sim", createdAt: "2026-06-12T10:00:00Z" },
+              { id: "c3", source: "vapi", createdAt: "2026-06-14T10:00:00Z" },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotRecentCallsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Recent calls")).toBeTruthy();
+      expect(screen.getByText("View all")).toBeTruthy();
+    });
+  });
+
+  it("self-hides on fetch error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 500 })),
+    );
+    const { container } = render(<SnapshotRecentCallsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="hf-snapshot-recent-calls"]')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes **4 of the 13** retirement-coverage gaps from #1685.

| Gap | Section | New block |
|---|---|---|
| 1, 2, 3, 4 | Hero proof points (Mastery + Confidence + Knowledge donuts, Calls + Days-active, mastery micro-spark) | \`SnapshotHeroBlock\` |
| 8, 9 | Engagement (memories slice donut, Calls/week tile, 14-day CalendarStrip) | \`SnapshotEngagementBlock\` |
| 11 | Mock results (latest score donut + delta vs prior Mock) | \`SnapshotMockResultsBlock\` |
| 12 | Recent calls (TimelineRibbon, last 5 with click-through) | \`SnapshotRecentCallsBlock\` |

All 4 are thin wrappers around the existing legacy components (\`HeroSection\`, \`EngagementSection\`, \`MockResultV2\`, \`RecentCallsV2\`) so we lift the data + viz with zero new chart code. Once Waves C2 + C3 close the remaining 9 gaps, we can flip \`NEXT_PUBLIC_HF_TAB_LAYOUT=retire\`.

## Data sources (reused — no new routes)

- \`/api/callers/[id]/uplift\` → Hero + Engagement
- \`/api/calls?callerId=<id>\` → Mock + Recent

Both routes gate STUDENT scope via \`studentAllowedToReadCaller\` / \`resolveCallerScopeForReading\`.

## Verified by

- \`npx vitest run tests/components/callers/snapshot-hero-block.test.tsx tests/components/callers/snapshot-engagement-block.test.tsx tests/components/callers/snapshot-mock-results-block.test.tsx tests/components/callers/snapshot-recent-calls-block.test.tsx\` → **14/14 passing**
  - \`snapshot-hero-block.test.tsx\` (4 tests — renders shell, delegates Mastery/Confidence/Knowledge labels, awaiting-first-call state, hf-snapshot-hero testid)
  - \`snapshot-engagement-block.test.tsx\` (3 — renders Engagement heading + Calls/week + 14-day strip, slice-donut center total, hf-snapshot-engagement testid)
  - \`snapshot-mock-results-block.test.tsx\` (4 — self-hide empty/no-mock/fetch-error, renders on MOCK_EXAM call)
  - \`snapshot-recent-calls-block.test.tsx\` (3 — self-hide empty/error, renders TimelineRibbon + View all)
- \`gcloud compute ssh hf-dev … "SELECT DISTINCT source FROM Call …"\` → confirmed enum values are sim/vapi/vapi-import/demo-course-seed/e2e-fixture (no MOCK), so MockResultsBlock self-hides correctly on hf_sandbox today — pinned by vitest fixtures
- \`npx tsc --noEmit\` → 55 errors (under 166 ratchet baseline; none from this PR)
- Lint clean on the 4 new files

## Test plan

- [ ] Open \`/x/callers/<id>?v=3\` for a caller with calls → see Hero donuts, Recent calls ribbon, Engagement (calls/week + 14-day strip + memory donut)
- [ ] Caller with mock calls → Mock results card appears; without → silently absent
- [ ] Empty-state caller → Hero "Awaiting first call" + Engagement zero-memory; Mock + Recent absent