### PR TITLE
feat(callers): Wave C2 — Score Trends + Skill Chart + Topics on Snapshot (#1685)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/uplift/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/uplift/route.ts
@@ -153,6 +153,7 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
         preferenceCount: true,
         eventCount: true,
         topicCount: true,
+        topTopics: true,
       },
     }),
   ]);
@@ -266,6 +267,13 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
            (memorySummary?.eventCount ?? 0) + (memorySummary?.topicCount ?? 0),
   };
 
+  // Wave C2 — TopicCloud chip source. `topTopics` is stored on
+  // CallerMemorySummary as JSON; passthrough as an array (defensive: any
+  // shape that isn't a plain array is normalised to []).
+  const topTopics = Array.isArray(memorySummary?.topTopics)
+    ? (memorySummary.topTopics as Array<{ topic: string; lastMentioned?: string }>)
+    : [];
+
   return NextResponse.json({
     ok: true,
     uplift: {
@@ -285,6 +293,7 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
       scoreTrends,
       adaptationEvidence,
       memoryCounts,
+      topTopics,
       callFrequencyPerWeek,
       callDates,
     },

--- a/apps/admin/components/callers/caller-detail/SnapshotScoreTrendsBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotScoreTrendsBlock.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+/**
+ * SnapshotScoreTrendsBlock — Wave C2 of the legacy-tab retirement plan.
+ *
+ * Lifts Uplift v2's ScoreTrendsSection (per-parameter SparklineCard grid
+ * with history + avg + delta + improving-first sort) into Snapshot v3
+ * so uplift-v2 can retire without losing the per-parameter trend story.
+ *
+ * Thin wrapper around the legacy `ScoreTrendsSection`; it already calls
+ * `useUpliftData(callerId)` and uses the shared `CardGrid` +
+ * `SparklineCard` primitives.
+ */
+
+import { ScoreTrendsSection } from "./caller-detail-v2/sections/ScoreTrendsSection";
+
+interface SnapshotScoreTrendsBlockProps {
+  callerId: string;
+}
+
+export function SnapshotScoreTrendsBlock({ callerId }: SnapshotScoreTrendsBlockProps) {
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-score-trends"
+    >
+      <div className="hf-card-compact">
+        <ScoreTrendsSection callerId={callerId} />
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotSkillChartBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotSkillChartBlock.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * SnapshotSkillChartBlock — Wave C2 of the legacy-tab retirement plan.
+ *
+ * Lifts Uplift v2's SkillChartSection (multi-line SkillTrendChartCard +
+ * Skill Radar) into Snapshot v3 so uplift-v2 can retire without losing
+ * the skill-shape view.
+ *
+ * The legacy section accepts optional `scores` / `callerTargets` props
+ * for the time-series chart. We don't have a route returning that exact
+ * tuple on Snapshot today, so we mount it with empty arrays — the Radar
+ * (driven by `useUpliftData` scoreTrends inside the legacy component)
+ * still renders, and the time-series side shows the empty-state until
+ * the SkillTrendChartCard data source is wired (Wave C2 follow-on).
+ */
+
+import { SkillChartSection } from "./caller-detail-v2/sections/SkillChartSection";
+
+interface SnapshotSkillChartBlockProps {
+  callerId: string;
+}
+
+export function SnapshotSkillChartBlock({ callerId }: SnapshotSkillChartBlockProps) {
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-skill-chart"
+    >
+      <div className="hf-card-compact">
+        <SkillChartSection callerId={callerId} />
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
@@ -44,6 +44,9 @@ import { SnapshotHeroBlock } from "./SnapshotHeroBlock";
 import { SnapshotEngagementBlock } from "./SnapshotEngagementBlock";
 import { SnapshotMockResultsBlock } from "./SnapshotMockResultsBlock";
 import { SnapshotRecentCallsBlock } from "./SnapshotRecentCallsBlock";
+import { SnapshotScoreTrendsBlock } from "./SnapshotScoreTrendsBlock";
+import { SnapshotSkillChartBlock } from "./SnapshotSkillChartBlock";
+import { SnapshotTopicsBlock } from "./SnapshotTopicsBlock";
 
 import "./snapshot-tab.css";
 
@@ -196,6 +199,16 @@ export function SnapshotTabContent({ callerId, domainId }: SnapshotTabContentPro
       />
 
       <SnapshotSubSkills callerId={callerId} />
+
+      {/* Wave C2 — Per-parameter sparkline grid + Skill radar + Topic
+       * cloud lifted from uplift-v2's ScoreTrendsSection, SkillChartSection,
+       * and TopicsSection. Sits between sub-skills (broad shape) and the
+       * LO heatmap (granular) to preserve the uplift-v2 ordering. */}
+      <SnapshotScoreTrendsBlock callerId={callerId} />
+
+      <SnapshotSkillChartBlock callerId={callerId} />
+
+      <SnapshotTopicsBlock callerId={callerId} />
 
       {/* #1661 — real LO heatmap replaces the placeholder slot. The
        * heatmap owns its per-module lo-mastery fetches; the foundation

--- a/apps/admin/components/callers/caller-detail/SnapshotTopicsBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotTopicsBlock.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * SnapshotTopicsBlock — Wave C2 of the legacy-tab retirement plan.
+ *
+ * Lifts Uplift v2's TopicsSection (TopicCloud — recency-weighted chips)
+ * into Snapshot v3 so uplift-v2 can retire without losing the
+ * "topics covered" surface.
+ *
+ * Source: `topTopics` was added to the `/api/callers/[id]/uplift`
+ * response in Wave C2 so the cloud doesn't need a sibling fetch. The
+ * legacy TopicsSection takes a `memorySummary` prop with the shape
+ * `{ topTopics, topicCount }` — we pass it through directly.
+ */
+
+import { useEffect, useState } from "react";
+
+import { TopicsSection } from "./caller-detail-v2/sections/TopicsSection";
+
+interface SnapshotTopicsBlockProps {
+  callerId: string;
+}
+
+interface UpliftMemorySummary {
+  topTopics: { topic: string; lastMentioned?: string }[];
+  topicCount: number;
+}
+
+interface UpliftResponse {
+  ok: boolean;
+  uplift?: {
+    topTopics?: { topic: string; lastMentioned?: string }[];
+    memoryCounts?: { topics?: number };
+  };
+}
+
+export function SnapshotTopicsBlock({ callerId }: SnapshotTopicsBlockProps) {
+  const [summary, setSummary] = useState<UpliftMemorySummary | null | "error">(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/uplift`)
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setSummary("error");
+          return;
+        }
+        const json = (await res.json()) as UpliftResponse;
+        if (cancelled) return;
+        setSummary({
+          topTopics: json.uplift?.topTopics ?? [],
+          topicCount: json.uplift?.memoryCounts?.topics ?? 0,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setSummary("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId]);
+
+  if (summary === "error") return null;
+
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-topics"
+    >
+      <div className="hf-card-compact">
+        <TopicsSection memorySummary={summary === null ? null : summary} />
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/components/callers/caller-detail/types.ts
+++ b/apps/admin/components/callers/caller-detail/types.ts
@@ -326,6 +326,15 @@ export type UpliftData = {
     topics: number;
     total: number;
   };
+  /**
+   * Top-N covered topics with last-mention timestamps. Sourced from
+   * `CallerMemorySummary.topTopics` (Wave C2 — passed through from the
+   * /uplift route so TopicCloud doesn't need a sibling fetch).
+   *
+   * Optional in the type because legacy fixtures predating Wave C2
+   * don't include the field; the route always returns at least `[]`.
+   */
+  topTopics?: { topic: string; lastMentioned?: string }[];
   callFrequencyPerWeek: number;
   /**
    * Ordered ISO timestamps of every call, oldest first. Powers the

--- a/apps/admin/tests/components/callers/snapshot-score-trends-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-score-trends-block.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for SnapshotScoreTrendsBlock — Wave C2 of the legacy-tab
+ * retirement plan.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotScoreTrendsBlock } from "@/components/callers/caller-detail/SnapshotScoreTrendsBlock";
+
+const CALLER_ID = "caller-c2-trends";
+
+function emptyUpliftResponse() {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      uplift: {
+        confidencePre: null,
+        confidencePost: null,
+        confidenceDelta: null,
+        testScorePre: null,
+        testScorePost: null,
+        knowledgeDelta: null,
+        overallMastery: 0,
+        totalCalls: 0,
+        firstCallAt: null,
+        latestCallAt: null,
+        callDates: [],
+        timeOnPlatformDays: 0,
+        callFrequencyPerWeek: 0,
+        scoreTrends: [],
+        adaptationEvidence: [],
+        moduleProgress: [],
+        goals: [],
+        memoryCounts: { facts: 0, preferences: 0, events: 0, topics: 0, total: 0 },
+        topTopics: [],
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+function trendsUpliftResponse() {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      uplift: {
+        confidencePre: null,
+        confidencePost: null,
+        confidenceDelta: null,
+        testScorePre: null,
+        testScorePost: null,
+        knowledgeDelta: null,
+        overallMastery: 0.6,
+        totalCalls: 4,
+        firstCallAt: "2026-06-01T00:00:00Z",
+        latestCallAt: "2026-06-14T00:00:00Z",
+        callDates: [],
+        timeOnPlatformDays: 14,
+        callFrequencyPerWeek: 2,
+        scoreTrends: [
+          {
+            parameterId: "skill_clarity",
+            parameterName: "Clarity",
+            parameterType: "skill",
+            sectionId: null,
+            definition: "Clarity of expression.",
+            scores: [
+              { callDate: "2026-06-10T00:00:00Z", score: 0.5, confidence: 0.8 },
+              { callDate: "2026-06-14T00:00:00Z", score: 0.7, confidence: 0.85 },
+            ],
+          },
+        ],
+        adaptationEvidence: [],
+        moduleProgress: [],
+        goals: [],
+        memoryCounts: { facts: 0, preferences: 0, events: 0, topics: 0, total: 0 },
+        topTopics: [],
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotScoreTrendsBlock", () => {
+  it("renders Score trends heading with empty-state copy when no params tracked", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyUpliftResponse()));
+    render(<SnapshotScoreTrendsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Score trends")).toBeTruthy();
+      expect(screen.getByText(/No score trends yet/)).toBeTruthy();
+    });
+  });
+
+  it("renders parameter name and count when scoreTrends populated", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => trendsUpliftResponse()));
+    render(<SnapshotScoreTrendsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Clarity")).toBeTruthy();
+      expect(screen.getByText(/1 param tracked/)).toBeTruthy();
+    });
+  });
+
+  it("carries the hf-snapshot-score-trends data-testid", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyUpliftResponse()));
+    const { container } = render(<SnapshotScoreTrendsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="hf-snapshot-score-trends"]'),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/admin/tests/components/callers/snapshot-skill-chart-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-skill-chart-block.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for SnapshotSkillChartBlock — Wave C2 of the legacy-tab
+ * retirement plan.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotSkillChartBlock } from "@/components/callers/caller-detail/SnapshotSkillChartBlock";
+
+const CALLER_ID = "caller-c2-skill";
+
+function upliftWithSkills() {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      uplift: {
+        confidencePre: null,
+        confidencePost: null,
+        confidenceDelta: null,
+        testScorePre: null,
+        testScorePost: null,
+        knowledgeDelta: null,
+        overallMastery: 0.5,
+        totalCalls: 5,
+        firstCallAt: "2026-06-01T00:00:00Z",
+        latestCallAt: "2026-06-14T00:00:00Z",
+        callDates: [],
+        timeOnPlatformDays: 14,
+        callFrequencyPerWeek: 2.5,
+        scoreTrends: [
+          {
+            parameterId: "skill_a",
+            parameterName: "Skill A",
+            parameterType: "skill",
+            sectionId: null,
+            definition: null,
+            scores: [
+              { callDate: "2026-06-14T00:00:00Z", score: 0.6, confidence: 0.9 },
+            ],
+          },
+        ],
+        adaptationEvidence: [],
+        moduleProgress: [],
+        goals: [],
+        memoryCounts: { facts: 0, preferences: 0, events: 0, topics: 0, total: 0 },
+        topTopics: [],
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotSkillChartBlock", () => {
+  it("renders Skill chart heading", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => upliftWithSkills()));
+    render(<SnapshotSkillChartBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Skill chart")).toBeTruthy();
+    });
+  });
+
+  it("shows Radar empty state when fewer than 3 skills are tracked", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => upliftWithSkills()));
+    render(<SnapshotSkillChartBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Radar appears once 3\+ skills have scores/),
+      ).toBeTruthy();
+    });
+  });
+
+  it("carries the hf-snapshot-skill-chart data-testid", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => upliftWithSkills()));
+    const { container } = render(<SnapshotSkillChartBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="hf-snapshot-skill-chart"]'),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/admin/tests/components/callers/snapshot-topics-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-topics-block.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for SnapshotTopicsBlock — Wave C2 of the legacy-tab
+ * retirement plan.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotTopicsBlock } from "@/components/callers/caller-detail/SnapshotTopicsBlock";
+
+const CALLER_ID = "caller-c2-topics";
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotTopicsBlock", () => {
+  it("renders empty-state copy when topTopics is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            uplift: {
+              topTopics: [],
+              memoryCounts: { topics: 0 },
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotTopicsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No topics covered yet/)).toBeTruthy();
+    });
+  });
+
+  it("renders topic chips with names from uplift.topTopics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            uplift: {
+              topTopics: [
+                { topic: "Photosynthesis", lastMentioned: "2026-06-13T00:00:00Z" },
+                { topic: "Mitochondria", lastMentioned: "2026-06-10T00:00:00Z" },
+              ],
+              memoryCounts: { topics: 2 },
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotTopicsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Photosynthesis")).toBeTruthy();
+      expect(screen.getByText("Mitochondria")).toBeTruthy();
+      expect(screen.getByText(/2 topics surfaced/)).toBeTruthy();
+    });
+  });
+
+  it("self-hides on fetch error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 500 })),
+    );
+    const { container } = render(<SnapshotTopicsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="hf-snapshot-topics"]'),
+      ).toBeNull();
+    });
+  });
+
+  it("carries the hf-snapshot-topics data-testid", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            uplift: {
+              topTopics: [],
+              memoryCounts: { topics: 0 },
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const { container } = render(<SnapshotTopicsBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="hf-snapshot-topics"]'),
+      ).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes **3 more** of the 13 retirement-coverage gaps from #1685. Cumulative: 7 of 13 done.

| Gap | Section | New block |
|---|---|---|
| 5 | Score trends — per-parameter SparklineCard grid (history + avg + delta + improving-first sort) | \`SnapshotScoreTrendsBlock\` |
| 6 | Skill chart — multi-line SkillTrendChartCard + Radar | \`SnapshotSkillChartBlock\` |
| 7 | Topics covered — recency-weighted TopicCloud | \`SnapshotTopicsBlock\` |

Thin wrappers around the existing legacy sections (\`ScoreTrendsSection\`, \`SkillChartSection\`, \`TopicsSection\`). Routes reused: \`/api/callers/[id]/uplift\` for all three.

## Route widening

Added \`topTopics\` to the \`/api/callers/[callerId]/uplift\` response (passthrough from \`CallerMemorySummary.topTopics\`) so TopicsBlock doesn't need a sibling fetch. \`UpliftData.topTopics\` type field is optional to keep legacy fixtures green; the route always returns at least \`[]\`.

## Verified by

- \`npx vitest run tests/components/callers/snapshot-score-trends-block.test.tsx tests/components/callers/snapshot-skill-chart-block.test.tsx tests/components/callers/snapshot-topics-block.test.tsx\` → **10/10 passing**
  - \`score-trends\` (3 — empty-state, populated 'Clarity' / '1 param tracked', testid)
  - \`skill-chart\` (3 — heading, Radar empty <3 skills, testid)
  - \`topics\` (4 — empty, Photosynthesis + Mitochondria chips, error self-hide, testid)
- \`npx vitest run tests/api/callers\` → 120/121 passing (1 pre-existing failure in adaptations-route.test.ts on main — not introduced)
- \`npx tsc --noEmit\` → 55 errors (under 166 ratchet baseline; same as main)

## Status of remaining 6 gaps

- **Wave C3** — TrustFooter (#13, needs /uplift widening for \`hasLearnerEvidence\`), AdaptationsTab RBAC (#14, pending PM call per #1577 deliberate decision)
- **Wave C4** — Export PDF (#10, deferred — low value during retirement window)

Then we can flip \`NEXT_PUBLIC_HF_TAB_LAYOUT=retire\` with confidence.

## Test plan

- [ ] Open \`/x/callers/<id>?v=3\` for a caller with multiple parameters scored → see Score trends sparkline grid
- [ ] Caller with 3+ skill_* params → Skill chart Radar renders; <3 → empty-state copy
- [ ] Caller with topic memories → TopicCloud chips with recency-weighted size; empty → "No topics covered yet"