### PR TITLE
feat(journey): #1689 — Slice B Inspector renderers editable + DesignTab wired

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
@@ -28,6 +28,7 @@ import {
   useDesignerSelection,
 } from "@/components/shared/designer-shell";
 import "@/components/shared/preview-renderers";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import type {
   ConversationArtifactsRendererData,
   FreshnessWarning,
@@ -394,17 +395,19 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
   );
 
   return (
-    <DesignerShell
-      nav={null}
-      canvas={
-        <CourseDesignConsole
-          courseId={courseId}
-          playbookConfig={playbookConfig}
-          onSelectSection={onSelectSection}
-        />
-      }
-      inspector={inspectorNode}
-      headerBanner={headerBanner}
-    />
+    <JourneySettingMutatorProvider courseId={courseId}>
+      <DesignerShell
+        nav={null}
+        canvas={
+          <CourseDesignConsole
+            courseId={courseId}
+            playbookConfig={playbookConfig}
+            onSelectSection={onSelectSection}
+          />
+        }
+        inspector={inspectorNode}
+        headerBanner={headerBanner}
+      />
+    </JourneySettingMutatorProvider>
   );
 }

--- a/apps/admin/components/shared/preview-renderers/ContentTrustRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/ContentTrustRenderer.tsx
@@ -12,6 +12,11 @@
  * Empty state: when the warnings array is empty AND the course has
  * sources, render a "All sources fresh" green chip. When the course
  * has zero sources, render a muted "No content sources attached" chip.
+ *
+ * Read-only by design (epic #1675 Slice B note): freshness state is
+ * computed by the trust transform, not an educator setting. Source
+ * management lives in the Content tab. This renderer remains a
+ * read-only display.
  */
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";

--- a/apps/admin/components/shared/preview-renderers/ConversationArtifactsRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/ConversationArtifactsRenderer.tsx
@@ -13,6 +13,10 @@
  * + an extra `loading` discriminant so the DesignTab can render a
  * "loading…" state while the preview route fetches.
  *
+ * Read-only by design (epic #1675 Slice B note): conversation artifacts
+ * are computed by the pipeline transform from prior-call data, not an
+ * educator-tunable setting. This renderer remains a read-only display.
+ *
  * Empty states:
  *  - `loading: true` → muted "Loading recent artifacts…" placeholder
  *  - `hasArtifacts: false` AND no prior call yet → muted

--- a/apps/admin/components/shared/preview-renderers/InstructionsRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/InstructionsRenderer.tsx
@@ -10,6 +10,11 @@
  * course has goals, the in-use types are highlighted and the rest
  * are dimmed.
  *
+ * Read-only by design (epic #1675 Slice B note): the goal-adaptation
+ * matrix is a static reference table, not an educator-tunable setting.
+ * No journey-contract entry exists; this renderer remains a read-only
+ * display regardless of the JourneySettingMutatorProvider context.
+ *
  * Source of truth for the labels: GOAL_ADAPTATION in
  * `lib/prompt/composition/transforms/instructions.ts`. Mirroring here
  * keeps the renderer free of a server import and free of a fetch —

--- a/apps/admin/components/shared/preview-renderers/IntakeRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/IntakeRenderer.tsx
@@ -15,7 +15,10 @@
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
 import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+import { JourneyField } from "@/components/journey-controls";
+import { JOURNEY_SETTINGS_BY_ID } from "@/lib/journey/setting-contracts.entries";
 
+import { useJourneySetting } from "./_journey-setting-context";
 import type { SessionFlowData } from "./types";
 
 export interface IntakeRendererData {
@@ -35,6 +38,7 @@ function StateChip({ enabled, label }: { enabled: boolean; label: string }) {
 export function IntakeRenderer({
   data,
 }: PreviewRendererProps<IntakeRendererData>) {
+  const ctx = useJourneySetting();
   const sf = data.sessionFlow;
   if (!sf) {
     return (
@@ -45,6 +49,39 @@ export function IntakeRenderer({
     );
   }
   const kcMode = sf.intake.knowledgeCheck.deliveryMode ?? "mcq";
+
+  if (ctx.courseId && !ctx.readonly) {
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Intake — pre-call questions</div>
+        {(["intakeKnowledgeCheck", "intakeAboutYou"] as const).map((id) => {
+          const c = JOURNEY_SETTINGS_BY_ID[id];
+          if (!c) return null;
+          const v =
+            id === "intakeKnowledgeCheck"
+              ? sf.intake.knowledgeCheck.enabled
+              : sf.intake.aboutYou.enabled;
+          return (
+            <JourneyField
+              key={id}
+              contract={c}
+              value={v}
+              onSave={(next) => ctx.saveSetting(id, next)}
+            />
+          );
+        })}
+        <div className="hf-category-label">Read-only (settings without editable mode yet)</div>
+        <StateChip enabled={sf.intake.goals.enabled} label="Goals" />
+        <StateChip enabled={sf.intake.aiIntroCall.enabled} label="AI intro call" />
+        {sf.source?.intake ? (
+          <span className="hf-badge hf-badge-muted">
+            source: {sf.source.intake} · KC mode: {kcMode === "socratic" ? "Socratic" : "MCQ"}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
   return (
     <div className="hf-card-compact">
       <div className="hf-category-label">Intake — pre-call questions</div>

--- a/apps/admin/components/shared/preview-renderers/MemoryDeltasRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/MemoryDeltasRenderer.tsx
@@ -13,6 +13,10 @@
  * no-learner + Call 1 + empty + populated states, but the populated
  * block distinguishes ADDED rows (full chip) from UPDATED rows
  * (chip + diff arrow showing prior → new value).
+ *
+ * Read-only by design (epic #1675 Slice B note): memory deltas are
+ * computed from CallerMemory diffs, not educator settings. This
+ * renderer remains a read-only display.
  */
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";

--- a/apps/admin/components/shared/preview-renderers/ModePolicyRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/ModePolicyRenderer.tsx
@@ -19,6 +19,10 @@
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
 import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+import { JourneyField } from "@/components/journey-controls";
+import { JOURNEY_SETTINGS_BY_ID } from "@/lib/journey/setting-contracts.entries";
+
+import { useJourneySetting } from "./_journey-setting-context";
 
 export interface ModePolicyRendererData {
   teachingMode: string | undefined;
@@ -43,6 +47,43 @@ const TIER_LABEL: Record<string, string> = {
 export function ModePolicyRenderer({
   data,
 }: PreviewRendererProps<ModePolicyRendererData>) {
+  const ctx = useJourneySetting();
+
+  if (ctx.courseId && !ctx.readonly) {
+    const freshContract = JOURNEY_SETTINGS_BY_ID.useFreshMastery;
+    const maxTierContract = JOURNEY_SETTINGS_BY_ID.maxMasteryTier;
+    return (
+      <div className="hf-card-compact">
+        <div className="hf-category-label">Teaching mode</div>
+        {data.teachingMode ? (
+          <span className="hf-badge hf-badge-info">
+            {TEACHING_MODE_LABEL[data.teachingMode] ?? data.teachingMode}
+          </span>
+        ) : (
+          <span className="hf-badge hf-badge-muted">Unset (default)</span>
+        )}
+        {freshContract ? (
+          <JourneyField
+            contract={freshContract}
+            value={data.useFreshMastery ?? false}
+            onSave={(v) => ctx.saveSetting("useFreshMastery", v)}
+          />
+        ) : null}
+        {maxTierContract ? (
+          <JourneyField
+            contract={maxTierContract}
+            value={data.maxMasteryTier ?? ""}
+            options={Object.entries(TIER_LABEL).map(([value, label]) => ({
+              value,
+              label,
+            }))}
+            onSave={(v) => ctx.saveSetting("maxMasteryTier", v)}
+          />
+        ) : null}
+      </div>
+    );
+  }
+
   const teachingModeLabel =
     data.teachingMode === undefined
       ? null

--- a/apps/admin/components/shared/preview-renderers/NpsRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/NpsRenderer.tsx
@@ -10,6 +10,11 @@
  * Section: `nps` (kind: "runtime" config-sourced). Surfaces in
  * PreviewLens via the `stops` sidetray lens; the registry section key
  * is `nps` (the actual stop type).
+ *
+ * Editability deferred to Phase 3 of epic #1675: npsStop uses the
+ * `stop` compound control, which Phase 1 ships as a placeholder.
+ * Phase 3 wraps the existing SurveyStopDetail-style editor. Until then
+ * this renderer stays read-only regardless of provider context.
  */
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";

--- a/apps/admin/components/shared/preview-renderers/OffboardingRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/OffboardingRenderer.tsx
@@ -6,6 +6,11 @@
  * Shows end-of-course offboarding phases + the call-count trigger.
  *
  * Section: `offboarding` (kind: "runtime" config-sourced).
+ *
+ * Editability deferred to Phase 3 of epic #1675: the offboardingFlowPhases
+ * setting uses the `phases` compound control, which Phase 1 ships as a
+ * placeholder. Phase 3 unlocks inline editing here. Until then this
+ * renderer stays read-only regardless of provider context.
  */
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";

--- a/apps/admin/components/shared/preview-renderers/OnboardingRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/OnboardingRenderer.tsx
@@ -7,6 +7,12 @@
  * row with phase label + optional duration + first goal preview.
  *
  * Section: `onboarding` (kind: "runtime" config-sourced).
+ *
+ * Editability deferred to Phase 3 of epic #1675: the onboarding setting
+ * uses the `phases` compound control, which Phase 1 ships as a
+ * documented placeholder. Phase 3 wraps the existing `OnboardingEditor`
+ * and unlocks inline editing here. Until then, this renderer stays
+ * read-only regardless of the JourneySettingMutatorProvider context.
  */
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";

--- a/apps/admin/components/shared/preview-renderers/WelcomeRenderer.tsx
+++ b/apps/admin/components/shared/preview-renderers/WelcomeRenderer.tsx
@@ -14,7 +14,10 @@
 
 import { registerPreviewRenderer } from "@/components/shared/designer-shell/section-registry";
 import type { PreviewRendererProps } from "@/components/shared/designer-shell/section-registry";
+import { JourneyField } from "@/components/journey-controls";
+import { JOURNEY_SETTINGS_BY_ID } from "@/lib/journey/setting-contracts.entries";
 
+import { useJourneySetting } from "./_journey-setting-context";
 import type { SessionFlowData } from "./types";
 
 export interface WelcomeRendererData {
@@ -36,6 +39,7 @@ const SOURCE_LABEL: Record<NonNullable<SessionFlowData["source"]>["welcomeMessag
 export function WelcomeRenderer({
   data,
 }: PreviewRendererProps<WelcomeRendererData>) {
+  const ctx = useJourneySetting();
   const sf = data.sessionFlow;
   if (!sf) {
     return (
@@ -45,6 +49,35 @@ export function WelcomeRenderer({
       </div>
     );
   }
+
+  // Editable branch — mount JourneyField for welcomeMessage. Other
+  // settings (ack mode, course intro) ship in a sibling commit; for now
+  // they fall back to the read-only display below the editable field.
+  if (ctx.courseId && !ctx.readonly) {
+    const welcomeContract = JOURNEY_SETTINGS_BY_ID.welcomeMessage;
+    return (
+      <div className="hf-card-compact">
+        {welcomeContract ? (
+          <JourneyField
+            contract={welcomeContract}
+            value={sf.welcomeMessage ?? ""}
+            onSave={(v) => ctx.saveSetting("welcomeMessage", v)}
+          />
+        ) : null}
+        <div className="hf-category-label">Ack gate</div>
+        <span className="hf-badge hf-badge-info">
+          {ACK_LABEL[sf.firstCallWaitForAck]}
+        </span>
+        {sf.firstCallCourseIntro ? (
+          <>
+            <div className="hf-category-label">Course intro</div>
+            <p className="hf-text-sm">{sf.firstCallCourseIntro}</p>
+          </>
+        ) : null}
+      </div>
+    );
+  }
+
   const welcomeSource = sf.source?.welcomeMessage;
   return (
     <div className="hf-card-compact">

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/preview-renderers/IntakeRenderer.editable.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/IntakeRenderer.editable.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+import { IntakeRenderer } from "@/components/shared/preview-renderers/IntakeRenderer";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+
+global.fetch = vi.fn();
+
+const sf = {
+  intake: {
+    goals: { enabled: true },
+    aboutYou: { enabled: false },
+    knowledgeCheck: { enabled: true, deliveryMode: "mcq" as const },
+    aiIntroCall: { enabled: false },
+  },
+  onboarding: { phases: [] },
+  welcomeMessage: null,
+  firstCallCourseIntro: null,
+  firstCallWaitForAck: "none" as const,
+  offboarding: { phases: [] },
+  stops: [],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockReset();
+});
+
+describe("IntakeRenderer — editable (#1689)", () => {
+  it("read-only when no provider", () => {
+    render(
+      <IntakeRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "intake" }}
+      />,
+    );
+    expect(screen.getByText("Intake — pre-call questions")).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-jf-row-intakeKnowledgeCheck")).toBeNull();
+  });
+
+  it("editable mounts JourneyFields for intakeKnowledgeCheck + intakeAboutYou", () => {
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <IntakeRenderer
+          data={{ sessionFlow: sf }}
+          selection={{ selectedKey: "intake" }}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByTestId("hf-jf-row-intakeKnowledgeCheck")).toBeInTheDocument();
+    expect(screen.getByTestId("hf-jf-row-intakeAboutYou")).toBeInTheDocument();
+  });
+
+  it("toggling intakeAboutYou fires PATCH", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <IntakeRenderer
+          data={{ sessionFlow: sf }}
+          selection={{ selectedKey: "intake" }}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    fireEvent.click(screen.getByTestId("hf-jf-toggle-intakeAboutYou"));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const init = vi.mocked(global.fetch).mock.calls[0][1]!;
+    const body = JSON.parse(init.body as string);
+    expect(body.settingId).toBe("intakeAboutYou");
+    expect(body.value).toBe(true);
+  });
+});

--- a/apps/admin/tests/components/preview-renderers/ModePolicyRenderer.editable.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/ModePolicyRenderer.editable.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+import { ModePolicyRenderer } from "@/components/shared/preview-renderers/ModePolicyRenderer";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+
+global.fetch = vi.fn();
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockReset();
+});
+
+describe("ModePolicyRenderer — editable (#1689)", () => {
+  const data = {
+    teachingMode: "recall",
+    useFreshMastery: false,
+    maxMasteryTier: "FOUNDATION",
+  };
+
+  it("read-only when no provider", () => {
+    render(
+      <ModePolicyRenderer data={data} selection={{ selectedKey: "modePolicy" }} />,
+    );
+    expect(screen.getByText("Recall")).toBeInTheDocument();
+  });
+
+  it("editable mounts JourneyFields for useFreshMastery + maxMasteryTier", () => {
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <ModePolicyRenderer
+          data={data}
+          selection={{ selectedKey: "modePolicy" }}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByTestId("hf-jf-row-useFreshMastery")).toBeInTheDocument();
+    expect(screen.getByTestId("hf-jf-row-maxMasteryTier")).toBeInTheDocument();
+  });
+
+  it("toggle useFreshMastery fires PATCH with new value", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <ModePolicyRenderer
+          data={data}
+          selection={{ selectedKey: "modePolicy" }}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    fireEvent.click(screen.getByTestId("hf-jf-toggle-useFreshMastery"));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const init = vi.mocked(global.fetch).mock.calls[0][1]!;
+    const body = JSON.parse(init.body as string);
+    expect(body.settingId).toBe("useFreshMastery");
+    expect(body.value).toBe(true);
+  });
+});

--- a/apps/admin/tests/components/preview-renderers/WelcomeRenderer.editable.test.tsx
+++ b/apps/admin/tests/components/preview-renderers/WelcomeRenderer.editable.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+
+import { WelcomeRenderer } from "@/components/shared/preview-renderers/WelcomeRenderer";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+
+global.fetch = vi.fn();
+
+const sf = {
+  intake: {
+    goals: { enabled: true },
+    aboutYou: { enabled: true },
+    knowledgeCheck: { enabled: false },
+    aiIntroCall: { enabled: false },
+  },
+  onboarding: { phases: [] },
+  welcomeMessage: "hi there",
+  firstCallCourseIntro: null,
+  firstCallWaitForAck: "none" as const,
+  offboarding: { phases: [] },
+  stops: [],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockReset();
+});
+
+describe("WelcomeRenderer — editable (#1689)", () => {
+  it("read-only when no provider", () => {
+    render(
+      <WelcomeRenderer
+        data={{ sessionFlow: sf }}
+        selection={{ selectedKey: "welcome" }}
+      />,
+    );
+    expect(screen.getByText("Welcome set")).toBeInTheDocument();
+  });
+
+  it("editable when courseId present", () => {
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <WelcomeRenderer
+          data={{ sessionFlow: sf }}
+          selection={{ selectedKey: "welcome" }}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByTestId("hf-jf-row-welcomeMessage")).toBeInTheDocument();
+  });
+
+  it("PATCHes welcomeMessage on blur", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <WelcomeRenderer
+          data={{ sessionFlow: sf }}
+          selection={{ selectedKey: "welcome" }}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    const input = screen.getByTestId("hf-jf-text-welcomeMessage");
+    fireEvent.change(input, { target: { value: "hello!" } });
+    await act(async () => {
+      fireEvent.blur(input);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const init = vi.mocked(global.fetch).mock.calls[0][1]!;
+    expect(init.method).toBe("PATCH");
+    const body = JSON.parse(init.body as string);
+    expect(body.settingId).toBe("welcomeMessage");
+    expect(body.value).toBe("hello!");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2A Slice B of epic #1675. Builds on Slice A (#1690 / commit `cf61e146`). Closes #1689.

The 11 PREVIEW_RENDERERS split into three categories — Slice B handles each distinctly:

### Editable (4 of 11 — 3 newly converted this slice + 1 reference from Slice A)

| Renderer | Settings mounted as `<JourneyField>` |
|---|---|
| FirstCallModeRenderer | firstCallMode (shipped in Slice A) |
| WelcomeRenderer | welcomeMessage |
| ModePolicyRenderer | useFreshMastery + maxMasteryTier |
| IntakeRenderer | intakeKnowledgeCheck + intakeAboutYou |

Each preserves its existing read-only fallback verbatim for the legacy Preview tab during the dual-running window.

### Deferred to Phase 3 (3 — compound primitives ship as placeholders today)

| Renderer | Primitive needed | Wired by |
|---|---|---|
| OnboardingRenderer | `phases` (wraps OnboardingEditor) | Phase 3 |
| OffboardingRenderer | `phases` | Phase 3 |
| NpsRenderer | `stop` (wraps SurveyStopDetail) | Phase 3 |

Header comments on each document the deferral + rationale.

### Inherently read-only by design (4 — these are computed displays, not educator-tunable)

| Renderer | Reason |
|---|---|
| InstructionsRenderer | Static GOAL_ADAPTATION matrix |
| ContentTrustRenderer | Pipeline-computed freshness |
| ConversationArtifactsRenderer | Caller-scoped runtime data |
| MemoryDeltasRenderer | Caller-scoped runtime data |

Header comments on each document why they stay read-only forever.

### Infrastructure

- `DesignTab.tsx` wraps `<DesignerShell>` in `<JourneySettingMutatorProvider courseId={courseId}>` so the Inspector automatically receives the mutator context. Phase 4's tri-pane refactor will lift this into the new Journey tab.

## Verified by

```
$ cd apps/admin && npx vitest run tests/components/preview-renderers/WelcomeRenderer.editable.test.tsx tests/components/preview-renderers/ModePolicyRenderer.editable.test.tsx tests/components/preview-renderers/IntakeRenderer.editable.test.tsx

✓ tests/components/preview-renderers/WelcomeRenderer.editable.test.tsx (3 tests)
  ✓ read-only when no provider
  ✓ editable when courseId present
  ✓ PATCHes welcomeMessage on blur

✓ tests/components/preview-renderers/ModePolicyRenderer.editable.test.tsx (3 tests)
  ✓ read-only when no provider
  ✓ editable mounts JourneyFields for useFreshMastery + maxMasteryTier
  ✓ toggle useFreshMastery fires PATCH with new value

✓ tests/components/preview-renderers/IntakeRenderer.editable.test.tsx (3 tests)
  ✓ read-only when no provider
  ✓ editable mounts JourneyFields for intakeKnowledgeCheck + intakeAboutYou
  ✓ toggling intakeAboutYou fires PATCH

Test Files  3 passed (3)
     Tests  9 passed (9)
```

- `npx tsc --noEmit` — clean on the 11 touched files (the 1 pre-existing page.tsx error is unrelated)
- `npx eslint` — 0 errors / 0 warnings on touched files

## Out of scope

- Phase 3 (issue TBD): wire compound primitives — Phase 1 placeholders for `phases` / `targets` / `banding` / `voice-picker` / `stop` get real wrappers around existing editors (OnboardingEditor, FirstSessionSettings, BandingPicker, VoiceConfigSection, SurveyStopDetail). Unblocks editability of Onboarding/Offboarding/Nps renderers + adds firstCallTargets/skillTierMapping/etc.
- Phase 4: new Journey tab tri-pane (replaces DesignTab as the first tab)
- Phase 5: Cmd+K + Edit-as-JSON + cascade-trace
- Phase 6: Voice migration to Settings tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)