### PR TITLE
feat(journey): #1693 Slice A — Banding + Targets compound primitives wired

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/journey-setting/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/journey-setting/route.ts
@@ -60,6 +60,10 @@ interface PatchResponse {
   autoEnabled: Array<{ targetId: string; enforce: unknown }>;
   /** Compose sections whose staleness hash was bumped. */
   bumpedSections: string[];
+  /** Phase 3 (#1693): true when the storage root is `behaviorTargets` —
+   *  the wrapped compound editor (FirstSessionSettings) owns the save
+   *  via its own internal save loop. */
+  compoundOwnedSave?: boolean;
 }
 
 interface PatchError {
@@ -128,9 +132,26 @@ export async function PATCH(
 
   // Resolve storage root
   const resolved = resolveStoragePath(contract.storagePath);
+
+  // Phase 3 (#1693): behaviorTargets is a separate model — the storage
+  // path applier doesn't write to it. The existing FirstSessionSettings
+  // editor mounted via JourneyTargets has its own internal save loop
+  // hitting /api/courses/[courseId]/first-session route, so the journey-
+  // setting PATCH route SHOULDN'T intercept it. Return a documented
+  // 200 + nothing-applied response so the client can detect this code
+  // path and let the compound editor own the save.
+  if (resolved.root === "behaviorTargets") {
+    return NextResponse.json({
+      ok: true,
+      effectiveValue: value,
+      autoEnabled: [],
+      bumpedSections: [],
+      compoundOwnedSave: true,
+    });
+  }
+
   if (
     resolved.root === "domain" ||
-    resolved.root === "behaviorTargets" ||
     resolved.root === "unknown"
   ) {
     return NextResponse.json(

--- a/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_tab/DesignTab.tsx
@@ -395,7 +395,10 @@ export function DesignTab({ courseId, playbookConfig }: DesignTabProps) {
   );
 
   return (
-    <JourneySettingMutatorProvider courseId={courseId}>
+    <JourneySettingMutatorProvider
+      courseId={courseId}
+      playbookConfig={pbConfig as Record<string, unknown> | null}
+    >
       <DesignerShell
         nav={null}
         canvas={

--- a/apps/admin/components/journey-controls/JourneyBanding.tsx
+++ b/apps/admin/components/journey-controls/JourneyBanding.tsx
@@ -1,14 +1,43 @@
 "use client";
 
+import { BandingPicker } from "@/components/shared/BandingPicker";
+import { useJourneySetting } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
 import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
 import type { JourneyFieldProps } from "./JourneyField";
 
-/** Banding picker primitive. Phase 1 ships the placeholder; Phase 3
- *  wraps the existing `BandingPicker` component zero-change (per AC
- *  risk note). The shell + cascade chip live here so the Inspector
- *  styles every banding row identically to other settings. */
-export function JourneyBanding({ contract, value }: JourneyFieldProps) {
-  const preset = isBandingValue(value) ? value.tierPresetId ?? "custom" : "custom";
+/** Banding picker primitive — Phase 3 of epic #1675 (#1693).
+ *
+ *  Wraps the existing `BandingPicker` zero-change. Needs `courseId` +
+ *  `playbookConfig` from the JourneySettingMutatorProvider context.
+ *  Falls back to the placeholder when the context isn't set (legacy
+ *  callers). */
+export function JourneyBanding({ contract }: JourneyFieldProps) {
+  const ctx = useJourneySetting();
+  const config = ctx.playbookConfig as PlaybookConfig | null | undefined;
+
+  if (!ctx.courseId || ctx.readonly || !config) {
+    return (
+      <_FieldShell
+        contract={contract}
+        effectiveSource={_firstCascadeSource(contract)}
+        isDirty={false}
+        isActive={false}
+      >
+        <div
+          className="hf-jf-compound-placeholder"
+          data-testid={`hf-jf-banding-${contract.id}`}
+        >
+          {!ctx.courseId
+            ? "BandingPicker mounts when course context is available."
+            : !config
+              ? "Waiting for playbookConfig…"
+              : "Read-only mode."}
+        </div>
+      </_FieldShell>
+    );
+  }
 
   return (
     <_FieldShell
@@ -17,21 +46,13 @@ export function JourneyBanding({ contract, value }: JourneyFieldProps) {
       isDirty={false}
       isActive={false}
     >
-      <div
-        className="hf-jf-compound-placeholder"
-        data-testid={`hf-jf-banding-${contract.id}`}
-      >
-        Tier preset: <code>{preset}</code>
-        <div className="hf-jf-help">
-          BandingPicker mount ships in Phase 3 (wrap-only, no behaviour change).
-        </div>
+      <div data-testid={`hf-jf-banding-${contract.id}`}>
+        <BandingPicker
+          courseId={ctx.courseId}
+          current={config.skillTierMapping}
+          onSaved={ctx.onCompoundSaved}
+        />
       </div>
     </_FieldShell>
   );
-}
-
-function isBandingValue(
-  v: unknown,
-): v is { tierPresetId?: string; thresholds?: unknown } {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
 }

--- a/apps/admin/components/journey-controls/JourneyTargets.tsx
+++ b/apps/admin/components/journey-controls/JourneyTargets.tsx
@@ -1,14 +1,44 @@
 "use client";
 
+import { FirstSessionSettings } from "@/components/course-design/FirstSessionSettings";
+import { useJourneySetting } from "@/components/shared/preview-renderers/_journey-setting-context";
+
 import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
 import type { JourneyFieldProps } from "./JourneyField";
 
-/** Compound first-call BehaviorTarget repeater. Phase 1 ships a
- *  read-only placeholder showing the override count; the real
- *  per-parameter slider repeater ships in Phase 3 wrapping the existing
- *  `FirstSessionSettings` editor. */
+/** First-call BehaviorTarget primitive — Phase 3 of epic #1675 (#1693).
+ *
+ *  Wraps the existing `FirstSessionSettings` editor zero-change. Needs
+ *  `courseId` + `playbookConfig` from the JourneySettingMutatorProvider.
+ *  Falls back to placeholder when context isn't set. */
 export function JourneyTargets({ contract, value }: JourneyFieldProps) {
+  const ctx = useJourneySetting();
   const overrides = isTargetMap(value) ? Object.keys(value).length : 0;
+
+  if (!ctx.courseId || ctx.readonly || !ctx.playbookConfig) {
+    return (
+      <_FieldShell
+        contract={contract}
+        effectiveSource={_firstCascadeSource(contract)}
+        isDirty={false}
+        isActive={false}
+      >
+        <div
+          className="hf-jf-compound-placeholder"
+          data-testid={`hf-jf-targets-${contract.id}`}
+        >
+          {overrides === 0
+            ? "No first-call target overrides set."
+            : `${overrides} target override${overrides === 1 ? "" : "s"} active.`}
+          <div className="hf-jf-help">
+            {!ctx.courseId
+              ? "FirstSessionSettings mounts when course context is available."
+              : "Read-only mode."}
+          </div>
+        </div>
+      </_FieldShell>
+    );
+  }
 
   return (
     <_FieldShell
@@ -17,16 +47,12 @@ export function JourneyTargets({ contract, value }: JourneyFieldProps) {
       isDirty={false}
       isActive={false}
     >
-      <div
-        className="hf-jf-compound-placeholder"
-        data-testid={`hf-jf-targets-${contract.id}`}
-      >
-        {overrides === 0
-          ? "No first-call target overrides set."
-          : `${overrides} target override${overrides === 1 ? "" : "s"} active.`}
-        <div className="hf-jf-help">
-          Per-parameter editing ships in Phase 3.
-        </div>
+      <div data-testid={`hf-jf-targets-${contract.id}`}>
+        <FirstSessionSettings
+          courseId={ctx.courseId}
+          playbookConfig={ctx.playbookConfig}
+          onSaved={ctx.onCompoundSaved}
+        />
       </div>
     </_FieldShell>
   );

--- a/apps/admin/components/shared/preview-renderers/_journey-setting-context.tsx
+++ b/apps/admin/components/shared/preview-renderers/_journey-setting-context.tsx
@@ -5,9 +5,13 @@
  *
  * Lets the Inspector renderers opt into editability WITHOUT changing the
  * `PreviewRendererProps` signature (which would ripple through 11 sites
- * + DesignTab.tsx). Consumers read `useJourneySettingContext()` — when
+ * + DesignTab.tsx). Consumers read `useJourneySetting()` — when
  * `courseId` is present, render `<JourneyField>` primitives; when null,
  * fall back to the legacy read-only display.
+ *
+ * Phase 3 (#1693) extends the context with optional `playbookConfig` so
+ * compound primitives (Banding, Targets) can seed their wrapped
+ * editor's initial state.
  *
  * Wired by `DesignTab.tsx` (Phase 4) and `CourseDesignSidetray.tsx`
  * (Phase 2 follow-up). Anywhere a renderer mounts inside an editable
@@ -29,6 +33,14 @@ export interface JourneySettingContextValue {
    *  if `courseId` is set. Used by the legacy Preview tab during the
    *  Journey-tab dual-running window. */
   readonly: boolean;
+  /** Phase 3: optional playbookConfig snapshot. Compound primitives
+   *  (Banding, Targets) read this to seed their wrapped editor. When
+   *  absent, those primitives fall back to placeholder mode. */
+  playbookConfig?: Record<string, unknown> | null;
+  /** Phase 3: optional callback fired when a compound editor saves
+   *  via its own internal save loop (bypassing the journey-setting
+   *  PATCH route). DesignTab uses this to re-fetch playbookConfig. */
+  onCompoundSaved?: () => void;
 }
 
 const JourneySettingContext = createContext<JourneySettingContextValue>({
@@ -42,12 +54,18 @@ const JourneySettingContext = createContext<JourneySettingContextValue>({
 export interface JourneySettingMutatorProviderProps {
   courseId: string | null;
   readonly?: boolean;
+  /** Phase 3: pass playbookConfig so compound primitives can mount. */
+  playbookConfig?: Record<string, unknown> | null;
+  /** Phase 3: fired after a compound editor's internal save loop runs. */
+  onCompoundSaved?: () => void;
   children: ReactNode;
 }
 
 export function JourneySettingMutatorProvider({
   courseId,
   readonly = false,
+  playbookConfig,
+  onCompoundSaved,
   children,
 }: JourneySettingMutatorProviderProps) {
   const mutator = useJourneySettingMutator(courseId);
@@ -56,8 +74,10 @@ export function JourneySettingMutatorProvider({
       courseId,
       saveSetting: mutator,
       readonly: readonly || courseId === null,
+      playbookConfig,
+      onCompoundSaved,
     }),
-    [courseId, mutator, readonly],
+    [courseId, mutator, readonly, playbookConfig, onCompoundSaved],
   );
   return (
     <JourneySettingContext.Provider value={value}>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/api/courses/journey-setting-route.test.ts
+++ b/apps/admin/tests/api/courses/journey-setting-route.test.ts
@@ -154,12 +154,16 @@ describe("PATCH /api/courses/[courseId]/journey-setting — Phase 2 #1687", () =
     expect(body.code).toBe("STORAGE_ROOT_NOT_SUPPORTED");
   });
 
-  it("501s when storage root is behaviorTargets (Phase 3 work)", async () => {
+  it("Phase 3 #1693: behaviorTargets returns 200 with compoundOwnedSave flag", async () => {
     const { PATCH } = await loadRoute();
     const res = await PATCH(
       makeReq({ settingId: "firstCallTargets", value: {} }) as never,
       PARAMS as never,
     );
-    expect(res.status).toBe(501);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.compoundOwnedSave).toBe(true);
+    expect(body.bumpedSections).toEqual([]);
   });
 });

--- a/apps/admin/tests/components/journey-controls/JourneyBanding.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyBanding.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { JourneyBanding } from "@/components/journey-controls/JourneyBanding";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+vi.mock("@/components/shared/BandingPicker", () => ({
+  BandingPicker: ({ courseId }: { courseId: string }) => (
+    <div data-testid="hf-bp-mock">BandingPicker(courseId={courseId})</div>
+  ),
+}));
+
+const contract: JourneySettingContract = {
+  id: "skillTierMapping",
+  group: "G4",
+  educatorLabel: "Skill tier mapping",
+  storagePath: "config.skillTierMapping",
+  control: "banding",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["moduleMastery", "loMastery"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+afterEach(() => cleanup());
+
+describe("JourneyBanding (Phase 3 #1693)", () => {
+  it("shows placeholder when no provider", () => {
+    render(
+      <JourneyBanding
+        contract={contract}
+        value={null}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.getByTestId("hf-jf-banding-skillTierMapping")).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-bp-mock")).toBeNull();
+  });
+
+  it("shows placeholder when no playbookConfig", () => {
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <JourneyBanding
+          contract={contract}
+          value={null}
+          onSave={vi.fn(() => Promise.resolve())}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.queryByTestId("hf-bp-mock")).toBeNull();
+  });
+
+  it("mounts BandingPicker when courseId + playbookConfig present", () => {
+    render(
+      <JourneySettingMutatorProvider
+        courseId="course-1"
+        playbookConfig={{ skillTierMapping: { tierLabels: ["A", "B"] } }}
+      >
+        <JourneyBanding
+          contract={contract}
+          value={null}
+          onSave={vi.fn(() => Promise.resolve())}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByTestId("hf-bp-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("hf-bp-mock").textContent).toContain("course-1");
+  });
+});

--- a/apps/admin/tests/components/journey-controls/JourneyTargets.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyTargets.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { JourneyTargets } from "@/components/journey-controls/JourneyTargets";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+vi.mock("@/components/course-design/FirstSessionSettings", () => ({
+  FirstSessionSettings: ({ courseId }: { courseId: string }) => (
+    <div data-testid="hf-fss-mock">FirstSessionSettings(courseId={courseId})</div>
+  ),
+}));
+
+const contract: JourneySettingContract = {
+  id: "firstCallTargets",
+  group: "G2",
+  educatorLabel: "Call 1 skill targets",
+  storagePath: {
+    path: "behaviorTargets[]",
+    arrayKey: "scope",
+    selectorValue: "firstCall",
+    writeMode: "merge",
+  },
+  control: "targets",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["behaviorTargets"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+afterEach(() => cleanup());
+
+describe("JourneyTargets (Phase 3 #1693)", () => {
+  it("shows placeholder when no provider", () => {
+    render(
+      <JourneyTargets
+        contract={contract}
+        value={{}}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.queryByTestId("hf-fss-mock")).toBeNull();
+  });
+
+  it("shows placeholder when no playbookConfig", () => {
+    render(
+      <JourneySettingMutatorProvider courseId="course-1">
+        <JourneyTargets
+          contract={contract}
+          value={{}}
+          onSave={vi.fn(() => Promise.resolve())}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.queryByTestId("hf-fss-mock")).toBeNull();
+  });
+
+  it("mounts FirstSessionSettings when courseId + playbookConfig set", () => {
+    render(
+      <JourneySettingMutatorProvider
+        courseId="course-1"
+        playbookConfig={{ firstSessionTargets: {} }}
+      >
+        <JourneyTargets
+          contract={contract}
+          value={{}}
+          onSave={vi.fn(() => Promise.resolve())}
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByTestId("hf-fss-mock")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 Slice A of epic #1675. Replaces 2 of 5 placeholder compound primitives with thin wraps of existing editors. Closes #1693 Slice A; follow-up #1695 for Slice B.

### Ships

| Primitive | Wraps | Save loop |
|---|---|---|
| `JourneyBanding` | `components/shared/BandingPicker.tsx` (zero-change) | BandingPicker's existing `/api/courses/[id]/banding` route |
| `JourneyTargets` | `components/course-design/FirstSessionSettings.tsx` (zero-change) | FirstSessionSettings's existing `/api/courses/[id]/first-session` route |

**Context extension** — `JourneySettingMutatorProvider` gains 2 optional fields:
- `playbookConfig` — compound primitives read this to seed their wrapped editor's initial state
- `onCompoundSaved` — fired after the compound editor's internal save loop runs (Phase 4 will wire DesignTab refetch)

**DesignTab.tsx** now passes `pbConfig` through the provider so Banding + Targets can mount.

**Storage-path route change** — `behaviorTargets` storage root now returns `200 + compoundOwnedSave: true` (previously `501 STORAGE_ROOT_NOT_SUPPORTED`). The wrapped compound editor owns the save; the journey-setting PATCH route reports the delegation to the client. `bumpedSections` is empty for this path — the compound editor's own route handles staleness.

## Verified by

```
$ cd apps/admin && npx vitest run tests/components/journey-controls/JourneyBanding.test.tsx tests/components/journey-controls/JourneyTargets.test.tsx tests/api/courses/journey-setting-route.test.ts

✓ tests/components/journey-controls/JourneyBanding.test.tsx (3 tests)
  ✓ shows placeholder when no provider
  ✓ shows placeholder when no playbookConfig
  ✓ mounts BandingPicker when courseId + playbookConfig present

✓ tests/components/journey-controls/JourneyTargets.test.tsx (3 tests)
  ✓ shows placeholder when no provider
  ✓ shows placeholder when no playbookConfig
  ✓ mounts FirstSessionSettings when courseId + playbookConfig set

✓ tests/api/courses/journey-setting-route.test.ts (10 tests)
  ✓ Phase 3 #1693: behaviorTargets returns 200 with compoundOwnedSave flag (replaces previous 501 assertion)
  ✓ all 9 baseline Slice A cases still green

Test Files  3 passed (3)
     Tests  16 passed (16)
```

- `npx tsc --noEmit` — clean on touched files (1 pre-existing page.tsx error unrelated)
- `npx eslint` — 0 errors / 0 warnings on touched files

## Out of scope (Slice B #1695)

- JourneyPhases (wraps OnboardingEditor — needs domain context plumbing)
- JourneyStop (wraps SurveyStopDetail)
- Convert deferred renderers Onboarding/Offboarding/Nps to editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)