### PR TITLE
feat(journey): #1697 Slice A — new Journey tab tri-pane as first tab

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -25,6 +25,7 @@ import type { InteractionPattern } from '@/lib/content-trust/resolve-config';
 import { CourseWhoTab } from './CourseWhoTab';
 import { CourseGoalsTab } from './CourseGoalsTab';
 import { CourseDesignTab } from './CourseDesignTab';
+import { CourseJourneyTab } from '@/components/journey-tab/CourseJourneyTab';
 import { CourseLearnersTab } from './CourseLearnersTab';
 import { CourseProofTab } from './CourseProofTab';
 import { SessionDetailPanel } from '@/components/shared/SessionDetailPanel';
@@ -150,9 +151,9 @@ type SessionTabData = {
 
 import { SectionHeader } from './SectionHeader';
 
-const VALID_TABS = ['intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'skills', 'voice', 'settings',
+const VALID_TABS = ['journey', 'intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'skills', 'voice', 'settings',
   // Legacy tab IDs — redirected in handleTabChange
-  'overview', 'journey', 'genome', 'audience', 'session-flow',
+  'overview', 'genome', 'audience', 'session-flow',
 ];
 
 const statusMap: Record<string, 'draft' | 'active' | 'archived'> = {
@@ -207,7 +208,9 @@ export default function CourseDetailPage() {
   // Tabs — synced to ?tab= URL param for browser back/forward
   const tabFromUrl = searchParams.get('tab');
   const [activeTab, setActiveTab] = useState<string>(
-    tabFromUrl && VALID_TABS.includes(tabFromUrl) ? tabFromUrl : 'design'
+    // #1697 Phase 4: Journey tab is the new default landing surface.
+    // Existing Design tab kept (amber chip) until parity reached.
+    tabFromUrl && VALID_TABS.includes(tabFromUrl) ? tabFromUrl : 'journey'
   );
 
   // Sessions tab
@@ -401,8 +404,23 @@ export default function CourseDetailPage() {
   // directly (verified by inspection); the prior dep was over-broad and
   // caused tabs to re-memoise on every sessions refresh + every poll tick.
   const tabs: TabDefinition[] = useMemo(() => [
+    // #1697 Phase 4 — Journey is the new first tab, becoming the default
+    // landing surface. Design tab kept with amber retirement chip until
+    // Journey reaches parity (Phase 2 Slice B / Phase 3 Slice B + #1695).
+    { id: 'journey', label: <TabWithHelp tabId="journey">Journey</TabWithHelp>, icon: <Wand2 size={14} /> },
     { id: 'intelligence', label: <TabWithHelp tabId="intelligence">Content</TabWithHelp>, icon: <BookMarked size={14} />, count: totalSources || null },
-    { id: 'design', label: <TabWithHelp tabId="design">Design</TabWithHelp>, icon: <Wand2 size={14} /> },
+    {
+      id: 'design',
+      label: (
+        <TabWithHelp tabId="design">
+          Design
+          <span className="hf-journey-amber-chip" title="Retiring — will be removed when Journey reaches parity">
+            retiring
+          </span>
+        </TabWithHelp>
+      ),
+      icon: <Wand2 size={14} />,
+    },
     { id: 'curriculum', label: <TabWithHelp tabId="curriculum">Curriculum</TabWithHelp>, icon: <GraduationCap size={14} /> },
     { id: 'learners', label: <TabWithHelp tabId="learners">Learners</TabWithHelp>, icon: <Users2 size={14} /> },
     { id: 'proof', label: <TabWithHelp tabId="proof">Proof Points</TabWithHelp>, icon: <BarChart3 size={14} /> },
@@ -443,7 +461,8 @@ export default function CourseDetailPage() {
     // URL compat: redirect retired tab IDs to their new homes
     const TAB_REDIRECTS: Record<string, string> = {
       sessions: 'design', onboarding: 'design', overview: 'design',
-      journey: 'design', genome: 'intelligence', audience: 'design',
+      // #1697 Phase 4: `journey` is now a real tab, not an alias for design.
+      genome: 'intelligence', audience: 'design',
       content: 'intelligence', 'session-flow': 'design',
     };
     const resolvedTab = TAB_REDIRECTS[tab] ?? tab;
@@ -1700,6 +1719,16 @@ export default function CourseDetailPage() {
       {/* ═══════════════════════════════════════════════ */}
       {activeTab === 'skills' && (
         <CourseSkillsTab courseId={courseId!} />
+      )}
+
+      {/* ═══════════════════════════════════════════════ */}
+      {/* JOURNEY TAB (#1697 Phase 4)                    */}
+      {/* ═══════════════════════════════════════════════ */}
+      {activeTab === 'journey' && (
+        <CourseJourneyTab
+          courseId={courseId!}
+          playbookConfig={detail?.config as Record<string, unknown> | null}
+        />
       )}
 
       {/* ═══════════════════════════════════════════════ */}

--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * CourseJourneyTab — Phase 4 of epic #1675 (story #1697).
+ *
+ * The new first tab on the Course Design page. Tri-pane shape:
+ *   - LH: 7 group accordions + phase filter chips
+ *   - Canvas: existing `<PreviewLens>` mounted read-only inline
+ *   - RH: `<JourneyInspectorPanel>` mounting the selected setting's
+ *         JourneyField primitive
+ *
+ * Slice A scope: structural mount + selection routing. Bidirectional
+ * Preview↔Inspector hover/click sync is Slice B (#TBD). Cmd+K + edit-
+ * as-JSON + cascade-trace breadcrumbs land in Phase 5.
+ */
+
+import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+
+import { JourneyInspectorPanel } from "./JourneyInspectorPanel";
+import { JourneyLhMenu } from "./JourneyLhMenu";
+import "./journey-tab.css";
+import { useJourneySelection } from "./use-journey-selection";
+
+interface CourseJourneyTabProps {
+  courseId: string;
+  playbookConfig: Record<string, unknown> | null;
+}
+
+export function CourseJourneyTab({
+  courseId,
+  playbookConfig,
+}: CourseJourneyTabProps) {
+  const selection = useJourneySelection();
+
+  return (
+    <JourneySettingMutatorProvider
+      courseId={courseId}
+      playbookConfig={playbookConfig}
+    >
+      <div className="hf-journey-tab" data-testid="hf-journey-tab">
+        <aside
+          className="hf-journey-pane"
+          aria-label="Journey navigation"
+        >
+          <JourneyLhMenu
+            selectedSettingId={selection.settingId}
+            onSelectSetting={selection.setSettingId}
+            filter={selection.filter}
+            onFilterChange={selection.setFilter}
+          />
+        </aside>
+        <main className="hf-journey-pane hf-journey-canvas">
+          <PreviewLens courseId={courseId} />
+        </main>
+        <aside
+          className="hf-journey-pane hf-journey-inspector"
+          aria-label="Inspector"
+        >
+          <JourneyInspectorPanel selectedSettingId={selection.settingId} />
+        </aside>
+      </div>
+    </JourneySettingMutatorProvider>
+  );
+}

--- a/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
+++ b/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * JourneyInspectorPanel — Phase 4 of epic #1675.
+ *
+ * Right-hand pane of the Journey tri-pane. When a setting is selected
+ * in the LH menu, this panel mounts the contract's `<JourneyField>`
+ * primitive. Live value comes from the `playbookConfig` carried on the
+ * `JourneySettingMutatorProvider` context (Phase 3 plumbing).
+ *
+ * Save is owned by the JourneyField primitive — it calls
+ * `ctx.saveSetting(settingId, value)` which fires the journey-setting
+ * PATCH route.
+ */
+
+import { JourneyField } from "@/components/journey-controls";
+import { useJourneySetting } from "@/components/shared/preview-renderers/_journey-setting-context";
+import { JOURNEY_SETTINGS_BY_ID } from "@/lib/journey/setting-contracts.entries";
+import { VOICE_SETTINGS_BY_ID } from "@/lib/settings/voice-setting-contracts";
+
+import { resolveValueAtPath } from "./resolve-value-at-path";
+
+interface JourneyInspectorPanelProps {
+  selectedSettingId: string | null;
+}
+
+export function JourneyInspectorPanel({
+  selectedSettingId,
+}: JourneyInspectorPanelProps) {
+  const ctx = useJourneySetting();
+
+  if (!selectedSettingId) {
+    return (
+      <div
+        className="hf-journey-inspector-empty"
+        data-testid="hf-journey-inspector-empty"
+      >
+        Select a setting from the left menu to edit.
+      </div>
+    );
+  }
+
+  const contract =
+    JOURNEY_SETTINGS_BY_ID[selectedSettingId] ??
+    VOICE_SETTINGS_BY_ID[selectedSettingId];
+  if (!contract) {
+    return (
+      <div className="hf-journey-inspector-empty">
+        Unknown setting: <code>{selectedSettingId}</code>
+      </div>
+    );
+  }
+
+  const value = resolveValueAtPath(
+    ctx.playbookConfig ?? null,
+    contract.storagePath,
+  );
+
+  return (
+    <div data-testid={`hf-journey-inspector-${selectedSettingId}`}>
+      <JourneyField
+        contract={contract}
+        value={value}
+        onSave={(next) => ctx.saveSetting(selectedSettingId, next)}
+      />
+    </div>
+  );
+}

--- a/apps/admin/components/journey-tab/JourneyLhMenu.tsx
+++ b/apps/admin/components/journey-tab/JourneyLhMenu.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * JourneyLhMenu — Phase 4 of epic #1675.
+ *
+ * Left-hand navigation for the Journey tab. Renders the 7 group
+ * accordions (G1..G7) in chronological order. Each group is
+ * individually collapsible (state persisted via sessionStorage).
+ *
+ * Phase filter chips at the top narrow visibility by educator phase.
+ * Clicking a setting row selects it (mounts the corresponding
+ * `<JourneyField>` in the Inspector panel via the parent's selection
+ * state).
+ */
+
+import { useEffect, useState } from "react";
+
+
+import {
+  JOURNEY_GROUPS,
+  type JourneyGroup,
+  type JourneyPhaseFilter,
+} from "@/lib/journey/setting-groups";
+import {
+  JOURNEY_SETTINGS_BY_GROUP,
+} from "@/lib/journey/setting-contracts.entries";
+
+import { JourneyPhaseFilters } from "./JourneyPhaseFilters";
+
+interface JourneyLhMenuProps {
+  selectedSettingId: string | null;
+  onSelectSetting: (id: string) => void;
+  filter: JourneyPhaseFilter;
+  onFilterChange: (next: JourneyPhaseFilter) => void;
+}
+
+const GROUP_ORDER: JourneyGroup[] = ["G1", "G2", "G3", "G4", "G5", "G6", "G7"];
+
+const SESSION_OPEN_KEY = "hf.journey.lh.openGroups";
+
+export function JourneyLhMenu({
+  selectedSettingId,
+  onSelectSetting,
+  filter,
+  onFilterChange,
+}: JourneyLhMenuProps) {
+  const [openGroups, setOpenGroups] = useState<Set<JourneyGroup>>(() => {
+    // Lazy init: restore last-open groups from sessionStorage (cap to 3
+    // so the educator's last interaction is honoured but we don't dump
+    // all 7 open). Falls back to G1+G2 expanded by default.
+    if (typeof window === "undefined") return new Set(["G1", "G2"]);
+    try {
+      const raw = sessionStorage.getItem(SESSION_OPEN_KEY);
+      if (raw) {
+        const arr = JSON.parse(raw) as JourneyGroup[];
+        if (Array.isArray(arr)) return new Set(arr.slice(0, 3));
+      }
+    } catch {
+      // fall through to default
+    }
+    return new Set(["G1", "G2"]);
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    sessionStorage.setItem(
+      SESSION_OPEN_KEY,
+      JSON.stringify(Array.from(openGroups)),
+    );
+  }, [openGroups]);
+
+  const toggleGroup = (g: JourneyGroup) => {
+    setOpenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(g)) next.delete(g);
+      else next.add(g);
+      return next;
+    });
+  };
+
+  const groupMatchesFilter = (g: JourneyGroup): boolean => {
+    if (filter === "All") return true;
+    return JOURNEY_GROUPS[g].phaseFilter === filter;
+  };
+
+  return (
+    <div className="hf-journey-lh" data-testid="hf-journey-lh-menu">
+      <JourneyPhaseFilters active={filter} onChange={onFilterChange} />
+      <div className="hf-journey-lh-groups">
+        {GROUP_ORDER.filter(groupMatchesFilter).map((g) => {
+          const spec = JOURNEY_GROUPS[g];
+          const settings = JOURNEY_SETTINGS_BY_GROUP[g] ?? [];
+          const isOpen = openGroups.has(g);
+          return (
+            <div
+              key={g}
+              className="hf-journey-group"
+              data-testid={`hf-journey-group-${g}`}
+            >
+              <button
+                type="button"
+                className="hf-journey-group-header"
+                aria-expanded={isOpen}
+                onClick={() => toggleGroup(g)}
+              >
+                <span>
+                  {spec.label}
+                  <span className="hf-journey-group-caption">
+                    {" · "}
+                    {spec.caption}
+                  </span>
+                </span>
+                <span className="hf-journey-group-count">
+                  {settings.length}
+                </span>
+              </button>
+              {isOpen ? (
+                <div className="hf-journey-group-body">
+                  {settings.map((s) => (
+                    <button
+                      key={s.id}
+                      type="button"
+                      className={`hf-journey-setting-row ${
+                        selectedSettingId === s.id ? "hf-selected" : ""
+                      }`}
+                      onClick={() => onSelectSetting(s.id)}
+                      data-testid={`hf-journey-setting-row-${s.id}`}
+                    >
+                      <span>{s.educatorLabel}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/journey-tab/JourneyPhaseFilters.tsx
+++ b/apps/admin/components/journey-tab/JourneyPhaseFilters.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * JourneyPhaseFilters — Phase 4 of epic #1675.
+ *
+ * Sticky chip row at the top of the LH menu. Selecting a chip narrows
+ * which group accordions are visible. "All" is the default.
+ */
+
+import {
+  JOURNEY_PHASE_FILTERS,
+  type JourneyPhaseFilter,
+} from "@/lib/journey/setting-groups";
+
+interface JourneyPhaseFiltersProps {
+  active: JourneyPhaseFilter;
+  onChange: (next: JourneyPhaseFilter) => void;
+}
+
+export function JourneyPhaseFilters({
+  active,
+  onChange,
+}: JourneyPhaseFiltersProps) {
+  return (
+    <div
+      className="hf-journey-lh-filters"
+      role="tablist"
+      aria-label="Journey phase filters"
+      data-testid="hf-journey-phase-filters"
+    >
+      {JOURNEY_PHASE_FILTERS.map((f) => (
+        <button
+          key={f}
+          type="button"
+          role="tab"
+          aria-selected={active === f}
+          className={`hf-chip ${active === f ? "hf-chip-selected" : ""}`}
+          onClick={() => onChange(f)}
+        >
+          {f}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/components/journey-tab/journey-tab.css
+++ b/apps/admin/components/journey-tab/journey-tab.css
@@ -1,0 +1,150 @@
+/**
+ * Journey tab — Phase 4 of epic #1675.
+ *
+ * Tokens only. color-mix for alpha. Co-located convention.
+ */
+
+.hf-journey-tab {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 360px;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.hf-journey-pane {
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.hf-journey-lh {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 200px);
+}
+
+.hf-journey-lh-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px;
+  border-bottom: 1px solid var(--border-default);
+  position: sticky;
+  top: 0;
+  background: var(--surface-primary);
+  z-index: 2;
+}
+
+.hf-journey-lh-groups {
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.hf-journey-group {
+  border-bottom: 1px solid color-mix(in srgb, var(--border-default) 60%, transparent);
+}
+
+.hf-journey-group:last-child {
+  border-bottom: 0;
+}
+
+.hf-journey-group-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.hf-journey-group-header:hover {
+  background: color-mix(in srgb, var(--surface-secondary) 60%, transparent);
+}
+
+.hf-journey-group-caption {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 6px;
+}
+
+.hf-journey-group-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.hf-journey-group-body {
+  padding: 4px 0 6px;
+}
+
+.hf-journey-setting-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px 6px 22px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  font-size: 12px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.hf-journey-setting-row:hover {
+  background: color-mix(in srgb, var(--surface-secondary) 50%, transparent);
+}
+
+.hf-journey-setting-row.hf-selected {
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.hf-journey-canvas {
+  padding: 16px;
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
+}
+
+.hf-journey-inspector {
+  padding: 16px;
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
+}
+
+.hf-journey-inspector-empty {
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 24px 12px;
+  text-align: center;
+}
+
+.hf-journey-amber-chip {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--status-warning-text) 18%, transparent);
+  color: var(--status-warning-text);
+  border: 1px solid color-mix(in srgb, var(--status-warning-text) 35%, transparent);
+}
+
+@media (max-width: 1199px) {
+  .hf-journey-tab {
+    grid-template-columns: 240px minmax(0, 1fr);
+  }
+  .hf-journey-inspector {
+    display: none;
+  }
+}

--- a/apps/admin/components/journey-tab/resolve-value-at-path.ts
+++ b/apps/admin/components/journey-tab/resolve-value-at-path.ts
@@ -1,0 +1,94 @@
+/**
+ * Resolve a current value at a `StoragePath` against the live
+ * playbookConfig snapshot — Phase 4 of epic #1675.
+ *
+ * Mirrors the write-side `applyAtPath` from
+ * `lib/journey/storage-path-applier.ts`. Returns `undefined` when the
+ * path doesn't resolve.
+ */
+
+import type { StoragePath } from "@/lib/journey/setting-contracts";
+
+export function resolveValueAtPath(
+  config: Record<string, unknown> | null,
+  storage: StoragePath,
+): unknown {
+  if (!config) return undefined;
+
+  const path = typeof storage === "string" ? storage : storage.path;
+  const arraySelector =
+    typeof storage !== "string" &&
+    storage.arrayKey &&
+    storage.selectorValue !== undefined
+      ? { key: storage.arrayKey, value: storage.selectorValue }
+      : null;
+
+  const segments = stripRoot(path).split(".").map((s) => s.replace(/\[\]$/, ""));
+  const root = detectRoot(path);
+
+  // Step into the root bucket inside `config`.
+  let node: unknown = pickRoot(config, root);
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (!isObj(node)) return undefined;
+    node = node[segments[i]];
+  }
+  const finalKey = segments[segments.length - 1];
+  if (!finalKey) return undefined;
+
+  if (arraySelector) {
+    if (!isObj(node)) return undefined;
+    const arr = node[finalKey];
+    if (!Array.isArray(arr)) return undefined;
+    const match = arr.find(
+      (it) =>
+        isObj(it) && it[arraySelector.key] === arraySelector.value,
+    );
+    return match;
+  }
+
+  if (!isObj(node)) return undefined;
+  return node[finalKey];
+}
+
+function detectRoot(path: string): string {
+  if (path.startsWith("config.")) return "config";
+  if (path.startsWith("sessionFlow.")) return "sessionFlow";
+  if (path.startsWith("tolerances.")) return "tolerances";
+  if (path.startsWith("playbook.voiceConfig.")) return "voiceConfig";
+  if (path.startsWith("domain.")) return "domain";
+  if (path.startsWith("behaviorTargets")) return "behaviorTargets";
+  return "unknown";
+}
+
+function pickRoot(
+  config: Record<string, unknown>,
+  root: string,
+): unknown {
+  switch (root) {
+    case "config":
+      // config.* paths read directly off the top-level PlaybookConfig
+      return config;
+    case "sessionFlow":
+      return config.sessionFlow ?? null;
+    case "tolerances":
+      return config.tolerances ?? null;
+    case "voiceConfig":
+      return config.voiceConfig ?? null;
+    default:
+      // domain / behaviorTargets / unknown → not in playbookConfig
+      return null;
+  }
+}
+
+function stripRoot(path: string): string {
+  if (path.startsWith("config.")) return path.slice("config.".length);
+  if (path.startsWith("sessionFlow.")) return path.slice("sessionFlow.".length);
+  if (path.startsWith("tolerances.")) return path.slice("tolerances.".length);
+  if (path.startsWith("playbook.voiceConfig.")) return path.slice("playbook.voiceConfig.".length);
+  if (path.startsWith("domain.")) return path.slice("domain.".length);
+  return path;
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/apps/admin/components/journey-tab/use-journey-selection.ts
+++ b/apps/admin/components/journey-tab/use-journey-selection.ts
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * Journey-tab URL-state hook — Phase 4 of epic #1675.
+ *
+ * Tracks the selected settingId + phase filter via `?j_setting=` and
+ * `?j_filter=` query params so the state survives browser back/forward
+ * and is shareable.
+ */
+
+import { useCallback, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import {
+  JOURNEY_PHASE_FILTERS,
+  type JourneyPhaseFilter,
+} from "@/lib/journey/setting-groups";
+
+export interface JourneySelection {
+  /** Currently-selected setting id (null when nothing chosen). */
+  settingId: string | null;
+  /** Active phase filter chip. Defaults to "All". */
+  filter: JourneyPhaseFilter;
+  setSettingId: (next: string | null) => void;
+  setFilter: (next: JourneyPhaseFilter) => void;
+}
+
+const SETTING_PARAM = "j_setting";
+const FILTER_PARAM = "j_filter";
+
+export function useJourneySelection(): JourneySelection {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const settingId = params.get(SETTING_PARAM);
+  const filterRaw = params.get(FILTER_PARAM) as JourneyPhaseFilter | null;
+  const filter: JourneyPhaseFilter =
+    filterRaw && (JOURNEY_PHASE_FILTERS as readonly string[]).includes(filterRaw)
+      ? filterRaw
+      : "All";
+
+  const pushQuery = useCallback(
+    (key: string, value: string | null) => {
+      const next = new URLSearchParams(params.toString());
+      if (value === null || value === "") next.delete(key);
+      else next.set(key, value);
+      router.replace(`?${next.toString()}`, { scroll: false });
+    },
+    [params, router],
+  );
+
+  const setSettingId = useCallback(
+    (next: string | null) => pushQuery(SETTING_PARAM, next),
+    [pushQuery],
+  );
+  const setFilter = useCallback(
+    (next: JourneyPhaseFilter) =>
+      pushQuery(FILTER_PARAM, next === "All" ? null : next),
+    [pushQuery],
+  );
+
+  return useMemo(
+    () => ({ settingId, filter, setSettingId, setFilter }),
+    [settingId, filter, setSettingId, setFilter],
+  );
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/journey-tab/JourneyInspectorPanel.test.tsx
+++ b/apps/admin/tests/components/journey-tab/JourneyInspectorPanel.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspectorPanel";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+
+global.fetch = vi.fn();
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockReset();
+});
+
+describe("JourneyInspectorPanel — Phase 4 (#1697)", () => {
+  it("shows empty state when no setting selected", () => {
+    render(
+      <JourneySettingMutatorProvider courseId="c1" playbookConfig={{}}>
+        <JourneyInspectorPanel selectedSettingId={null} />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByTestId("hf-journey-inspector-empty")).toBeInTheDocument();
+  });
+
+  it("mounts JourneyField for a registered settingId", () => {
+    render(
+      <JourneySettingMutatorProvider
+        courseId="c1"
+        playbookConfig={{ sessionFlow: { welcomeMessage: "hi" } }}
+      >
+        <JourneyInspectorPanel selectedSettingId="welcomeMessage" />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByTestId("hf-journey-inspector-welcomeMessage")).toBeInTheDocument();
+    expect(screen.getByTestId("hf-jf-row-welcomeMessage")).toBeInTheDocument();
+  });
+
+  it("renders unknown-setting state for an unregistered id", () => {
+    render(
+      <JourneySettingMutatorProvider courseId="c1" playbookConfig={{}}>
+        <JourneyInspectorPanel selectedSettingId="not_real" />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(screen.getByText(/Unknown setting/)).toBeInTheDocument();
+  });
+});

--- a/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
+++ b/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+import { JourneyLhMenu } from "@/components/journey-tab/JourneyLhMenu";
+
+afterEach(() => cleanup());
+
+describe("JourneyLhMenu — Phase 4 (#1697)", () => {
+  it("renders all 7 group headers in chronological order", () => {
+    render(
+      <JourneyLhMenu
+        selectedSettingId={null}
+        onSelectSetting={vi.fn()}
+        filter="All"
+        onFilterChange={vi.fn()}
+      />,
+    );
+    for (const g of ["G1", "G2", "G3", "G4", "G5", "G6", "G7"]) {
+      expect(screen.getByTestId(`hf-journey-group-${g}`)).toBeInTheDocument();
+    }
+  });
+
+  it("phase filter chip narrows visible groups (e.g. 'End' shows only G6)", () => {
+    render(
+      <JourneyLhMenu
+        selectedSettingId={null}
+        onSelectSetting={vi.fn()}
+        filter="End"
+        onFilterChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("hf-journey-group-G6")).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-journey-group-G1")).toBeNull();
+    expect(screen.queryByTestId("hf-journey-group-G4")).toBeNull();
+  });
+
+  it("clicking a setting row fires onSelectSetting with its id", () => {
+    const onSelect = vi.fn();
+    render(
+      <JourneyLhMenu
+        selectedSettingId={null}
+        onSelectSetting={onSelect}
+        filter="All"
+        onFilterChange={vi.fn()}
+      />,
+    );
+    // G1 is open by default — pick the first intake setting
+    fireEvent.click(screen.getByTestId("hf-journey-setting-row-intakeKnowledgeCheck"));
+    expect(onSelect).toHaveBeenCalledWith("intakeKnowledgeCheck");
+  });
+
+  it("phase filter button clicks call onFilterChange", () => {
+    const onFilter = vi.fn();
+    render(
+      <JourneyLhMenu
+        selectedSettingId={null}
+        onSelectSetting={vi.fn()}
+        filter="All"
+        onFilterChange={onFilter}
+      />,
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Call 1" }));
+    expect(onFilter).toHaveBeenCalledWith("Call 1");
+  });
+});

--- a/apps/admin/tests/components/journey-tab/resolve-value-at-path.test.ts
+++ b/apps/admin/tests/components/journey-tab/resolve-value-at-path.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveValueAtPath } from "@/components/journey-tab/resolve-value-at-path";
+
+describe("resolveValueAtPath — Phase 4 (#1697)", () => {
+  it("reads config.* roots from the playbookConfig root", () => {
+    const config = { firstCallMode: "teach_immediately" };
+    expect(resolveValueAtPath(config, "config.firstCallMode")).toBe(
+      "teach_immediately",
+    );
+  });
+
+  it("reads sessionFlow.* under sessionFlow", () => {
+    const config = { sessionFlow: { welcomeMessage: "hi" } };
+    expect(resolveValueAtPath(config, "sessionFlow.welcomeMessage")).toBe("hi");
+  });
+
+  it("reads tolerances.* under tolerances", () => {
+    const config = { tolerances: { accuracy: 0.8 } };
+    expect(resolveValueAtPath(config, "tolerances.accuracy")).toBe(0.8);
+  });
+
+  it("reads voiceConfig.* via playbook.voiceConfig.*", () => {
+    const config = { voiceConfig: { voiceId: "v-1" } };
+    expect(resolveValueAtPath(config, "playbook.voiceConfig.voiceId")).toBe("v-1");
+  });
+
+  it("returns undefined for missing paths", () => {
+    expect(resolveValueAtPath({}, "config.firstCallMode")).toBeUndefined();
+    expect(resolveValueAtPath({}, "sessionFlow.welcomeMessage")).toBeUndefined();
+  });
+
+  it("returns undefined for domain.* / behaviorTargets / unknown roots (not in playbookConfig)", () => {
+    expect(
+      resolveValueAtPath({}, "domain.onboardingIdentitySpecId"),
+    ).toBeUndefined();
+    expect(
+      resolveValueAtPath({}, "behaviorTargets[firstCall]"),
+    ).toBeUndefined();
+  });
+
+  it("returns the matching array element for structured path + arrayKey/selectorValue", () => {
+    const config = {
+      sessionFlow: {
+        stops: [
+          { kind: "pre_test", enabled: true },
+          { kind: "post_test", enabled: false },
+        ],
+      },
+    };
+    const v = resolveValueAtPath(config, {
+      path: "sessionFlow.stops[]",
+      arrayKey: "kind",
+      selectorValue: "pre_test",
+    });
+    expect(v).toEqual({ kind: "pre_test", enabled: true });
+  });
+
+  it("returns undefined for a null config", () => {
+    expect(resolveValueAtPath(null, "config.firstCallMode")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 Slice A of epic #1675. Closes #1697 Slice A; follow-up #1698 for bidirectional sync.

Adds the new **Journey tab** as the first tab on the Course Design page with tri-pane layout:

| Pane | Component | What it shows |
|---|---|---|
| **LH** | `JourneyLhMenu` | 7 group accordions (G1..G7 chronological) + sticky phase filter chips at top |
| **Canvas** | `PreviewLens` (existing) | Read-only inline mount of the existing preview canvas |
| **RH** | `JourneyInspectorPanel` | Selected setting's `JourneyField` mounted with live value resolved from `playbookConfig` |

### Page changes

- `'journey'` becomes the FIRST `VALID_TABS` entry
- **Default landing changes** from `'design'` to `'journey'` when no `?tab=`
- Removed legacy `journey → design` redirect; `journey` is now a real tab
- **Amber chip** on Design tab label: "retiring" (color-mixed `--status-warning-text` token, tooltip explains)

### Per-group state persistence

- `sessionStorage[hf.journey.lh.openGroups]` (cap 3 open at once)
- Lazy init in `useState` (no `setState`-in-effect — clean ratchet)
- URL params `?j_setting=` + `?j_filter=` for shareable selections

## Verified by

```
$ cd apps/admin && npx vitest run tests/components/journey-tab/

✓ tests/components/journey-tab/resolve-value-at-path.test.ts (8 tests)
  ✓ reads config.* / sessionFlow.* / tolerances.* / playbook.voiceConfig.* roots
  ✓ returns undefined for missing paths
  ✓ returns undefined for domain.* / behaviorTargets / unknown roots
  ✓ returns matching array element for structured path + arrayKey/selectorValue
  ✓ returns undefined for null config

✓ tests/components/journey-tab/JourneyLhMenu.test.tsx (4 tests)
  ✓ renders all 7 group headers in chronological order
  ✓ phase filter chip narrows visible groups (e.g. 'End' shows only G6)
  ✓ clicking a setting row fires onSelectSetting with its id
  ✓ phase filter button clicks call onFilterChange

✓ tests/components/journey-tab/JourneyInspectorPanel.test.tsx (3 tests)
  ✓ shows empty state when no setting selected
  ✓ mounts JourneyField for a registered settingId
  ✓ renders unknown-setting state for an unregistered id

Test Files  3 passed (3)
     Tests  15 passed (15)
```

- `npx tsc --noEmit` — clean on the 8 new files (existing `page.tsx` errors unrelated)
- `npx eslint components/journey-tab tests/components/journey-tab` — 0 errors / 0 warnings

## Out of scope (Slice B #1698)

- Bidirectional Preview↔Inspector hover/click sync — the registry already carries `previewLocators` and Slice A's `getSettingsForSection` already inverts the relation. Slice B wires the handlers.

## Out of scope (later phases)

- Phase 5: Cmd+K + Edit-as-JSON modal + cascade-trace breadcrumb
- Phase 6: Voice migration to Settings tab
- Phase 2 Slice B (#1689 follow-up): 7 deferred renderers
- Phase 3 Slice B (#1695): Phases + Stop compound primitives

🤖 Generated with [Claude Code](https://claude.com/claude-code)