### PR TITLE
feat(callers): Wave C3 — TrustFooter (#566) on Snapshot (#1685)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/uplift/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/uplift/route.ts
@@ -58,12 +58,17 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
     }),
 
     // 2. Call scores with call dates for trend sparklines
+    //    `hasLearnerEvidence` (Wave C3 — #566 evidence-aware scoring)
+    //    powers TrustFooterV2's Evidence-backed / Goodhart-drops tiles
+    //    + per-call evidence-ratio sparkline.
     prisma.callScore.findMany({
       where: { call: { callerId } },
       select: {
+        callId: true,
         parameterId: true,
         score: true,
         confidence: true,
+        hasLearnerEvidence: true,
         scoredAt: true,
         parameter: {
           select: {
@@ -97,9 +102,11 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
     }),
 
     // 4. Call dates for engagement metrics
+    //    `id` (Wave C3) lets TrustFooterV2 join against `callScores`
+    //    by `callId` to compute the per-call evidence-ratio sparkline.
     prisma.call.findMany({
       where: { callerId },
-      select: { createdAt: true },
+      select: { id: true, createdAt: true },
       orderBy: { createdAt: "asc" },
     }),
 
@@ -274,6 +281,21 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
     ? (memorySummary.topTopics as Array<{ topic: string; lastMentioned?: string }>)
     : [];
 
+  // Wave C3 — TrustFooterV2 row shape (#566 evidence-aware scoring).
+  // Flattens `callScores` to (callId, score, hasLearnerEvidence) so the
+  // footer can compute Evidence-backed / Goodhart-drops tiles + the
+  // per-call evidence-ratio sparkline. Self-hides when all rows have
+  // `hasLearnerEvidence` null (older callers predating #566).
+  const trustScores = callScores.map((s) => ({
+    callId: s.callId,
+    score: s.score,
+    hasLearnerEvidence: s.hasLearnerEvidence,
+  }));
+  const trustCalls = calls.map((c) => ({
+    id: c.id,
+    createdAt: c.createdAt.toISOString(),
+  }));
+
   return NextResponse.json({
     ok: true,
     uplift: {
@@ -294,6 +316,8 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
       adaptationEvidence,
       memoryCounts,
       topTopics,
+      trustScores,
+      trustCalls,
       callFrequencyPerWeek,
       callDates,
     },

--- a/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotTabContent.tsx
@@ -47,6 +47,7 @@ import { SnapshotRecentCallsBlock } from "./SnapshotRecentCallsBlock";
 import { SnapshotScoreTrendsBlock } from "./SnapshotScoreTrendsBlock";
 import { SnapshotSkillChartBlock } from "./SnapshotSkillChartBlock";
 import { SnapshotTopicsBlock } from "./SnapshotTopicsBlock";
+import { SnapshotTrustFooterBlock } from "./SnapshotTrustFooterBlock";
 
 import "./snapshot-tab.css";
 
@@ -250,6 +251,13 @@ export function SnapshotTabContent({ callerId, domainId }: SnapshotTabContentPro
       <SnapshotEngagementBlock callerId={callerId} />
 
       <SnapshotEnrollmentBlock callerId={callerId} domainId={domainId} />
+
+      {/* Wave C3 — Trust footer (#566 evidence-aware scoring) lifted
+       * from overview-v2's TrustFooterV2. Sits at the bottom as a
+       * measurement-transparency footer to the rest of Snapshot.
+       * Self-hides when no score row has hasLearnerEvidence set
+       * (callers predating #566). */}
+      <SnapshotTrustFooterBlock callerId={callerId} />
     </div>
   );
 }

--- a/apps/admin/components/callers/caller-detail/SnapshotTrustFooterBlock.tsx
+++ b/apps/admin/components/callers/caller-detail/SnapshotTrustFooterBlock.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * SnapshotTrustFooterBlock — Wave C3 of the legacy-tab retirement plan.
+ *
+ * Lifts overview-v2's TrustFooterV2 (#566 evidence-aware scoring) into
+ * Snapshot v3 so overview-v2 can retire without losing the
+ * "measurement transparency" surface.
+ *
+ * Source: `trustScores` + `trustCalls` were added to the
+ * `/api/callers/[id]/uplift` response in Wave C3. The legacy
+ * TrustFooterV2 takes `(calls, scores)` props and self-hides when no
+ * row has `hasLearnerEvidence` set (older callers predating #566) — we
+ * pass the values straight through.
+ */
+
+import { useEffect, useState } from "react";
+
+import { TrustFooterV2 } from "./caller-detail-v2/overview/TrustFooterV2";
+
+interface SnapshotTrustFooterBlockProps {
+  callerId: string;
+}
+
+interface TrustCall {
+  id: string;
+  createdAt: string;
+}
+
+interface TrustScore {
+  callId: string;
+  score: number;
+  hasLearnerEvidence: boolean | null;
+}
+
+interface UpliftResponse {
+  ok: boolean;
+  uplift?: {
+    trustCalls?: TrustCall[];
+    trustScores?: TrustScore[];
+  };
+}
+
+export function SnapshotTrustFooterBlock({ callerId }: SnapshotTrustFooterBlockProps) {
+  const [data, setData] = useState<
+    { calls: TrustCall[]; scores: TrustScore[] } | null | "error"
+  >(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/callers/${callerId}/uplift`)
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setData("error");
+          return;
+        }
+        const json = (await res.json()) as UpliftResponse;
+        if (cancelled) return;
+        setData({
+          calls: json.uplift?.trustCalls ?? [],
+          scores: json.uplift?.trustScores ?? [],
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setData("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [callerId]);
+
+  if (data === null || data === "error") return null;
+
+  return (
+    <section
+      className="hf-snapshot-section"
+      data-testid="hf-snapshot-trust-footer"
+    >
+      <TrustFooterV2
+        calls={data.calls}
+        scores={data.scores.map((s) => ({
+          callId: s.callId,
+          score: s.score,
+          hasLearnerEvidence: s.hasLearnerEvidence ?? undefined,
+        }))}
+      />
+    </section>
+  );
+}

--- a/apps/admin/tests/components/callers/snapshot-trust-footer-block.test.tsx
+++ b/apps/admin/tests/components/callers/snapshot-trust-footer-block.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests for SnapshotTrustFooterBlock — Wave C3 of the legacy-tab
+ * retirement plan. Pinned by `gh pr view 1685` gap #13.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SnapshotTrustFooterBlock } from "@/components/callers/caller-detail/SnapshotTrustFooterBlock";
+
+const CALLER_ID = "caller-c3-trust";
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SnapshotTrustFooterBlock", () => {
+  it("self-hides when no score row has hasLearnerEvidence (pre-#566 callers)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            uplift: {
+              trustCalls: [{ id: "c1", createdAt: "2026-06-14T00:00:00Z" }],
+              trustScores: [
+                { callId: "c1", score: 0.6, hasLearnerEvidence: null },
+                { callId: "c1", score: 0.7, hasLearnerEvidence: null },
+              ],
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotTrustFooterBlock callerId={CALLER_ID} />);
+    // Wait a microtask so the fetch resolves and the TrustFooterV2
+    // self-hide branch runs.
+    await waitFor(() => {
+      expect(screen.queryByText("Trust footer")).toBeNull();
+    });
+  });
+
+  it("renders Evidence-backed + Goodhart drops tiles when scores carry the flag", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            uplift: {
+              trustCalls: [
+                { id: "c1", createdAt: "2026-06-10T00:00:00Z" },
+                { id: "c2", createdAt: "2026-06-14T00:00:00Z" },
+              ],
+              trustScores: [
+                { callId: "c1", score: 0.8, hasLearnerEvidence: true },
+                { callId: "c1", score: 0.6, hasLearnerEvidence: false },
+                { callId: "c2", score: 0.9, hasLearnerEvidence: true },
+              ],
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotTrustFooterBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Trust footer")).toBeTruthy();
+      expect(screen.getByText("Evidence-backed")).toBeTruthy();
+      expect(screen.getByText("Goodhart drops")).toBeTruthy();
+    });
+  });
+
+  it("renders evidence-ratio sparkline when 2+ calls have scored rows", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            uplift: {
+              trustCalls: [
+                { id: "c1", createdAt: "2026-06-10T00:00:00Z" },
+                { id: "c2", createdAt: "2026-06-12T00:00:00Z" },
+                { id: "c3", createdAt: "2026-06-14T00:00:00Z" },
+              ],
+              trustScores: [
+                { callId: "c1", score: 0.8, hasLearnerEvidence: true },
+                { callId: "c2", score: 0.6, hasLearnerEvidence: false },
+                { callId: "c3", score: 0.7, hasLearnerEvidence: true },
+              ],
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    render(<SnapshotTrustFooterBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Evidence ratio per call/)).toBeTruthy();
+    });
+  });
+
+  it("self-hides on fetch error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 500 })),
+    );
+    const { container } = render(<SnapshotTrustFooterBlock callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="hf-snapshot-trust-footer"]'),
+      ).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes **gap #13** from #1685 — overview-v2's TrustFooterV2 (#566 evidence-aware scoring) lifted into Snapshot v3.

Cumulative: **8 of 13** retirement-coverage gaps now closed (Wave C1: 1-4, 8, 9, 11, 12 / Wave C2: 5, 6, 7 / **Wave C3: 13**). Outstanding: #14 (Adaptations RBAC — pending PM call) + #10 (Export PDF — deferred).

## Route widening

Adds two arrays to \`/api/callers/[callerId]/uplift\` response:

- \`trustScores\`: \`(callId, score, hasLearnerEvidence)\` per CallScore row. \`hasLearnerEvidence\` is \`boolean | null\` per the #566 schema — null rows belong to callers predating the evidence-aware scoring rollout.
- \`trustCalls\`: \`(id, createdAt)\` per Call row — needed for the per-call evidence-ratio sparkline join.

Also adds \`id\` to the \`Call\` query \`select\` (was \`createdAt\` only) so trustCalls has an id to join against.

## Behaviour

\`SnapshotTrustFooterBlock\` wraps the legacy \`TrustFooterV2\`. The footer self-hides when no score row has \`hasLearnerEvidence\` set — no empty card for pre-#566 callers.

## Verified by

- \`npx vitest run tests/components/callers/snapshot-trust-footer-block.test.tsx\` → **4/4 passing**
  - Self-hide on all-null hasLearnerEvidence (pre-#566 caller)
  - Renders Evidence-backed + Goodhart-drops tiles when flags exist
  - Renders \`Evidence ratio per call\` sparkline with 2+ scored calls
  - Self-hide on fetch error
- \`npx vitest run tests/api/callers\` → 120/121 passing (same 1 pre-existing failure on main in adaptations-route.test.ts — not introduced)
- \`npx tsc --noEmit\` → 55 errors (under 166 ratchet baseline; same as main)

## Status of remaining gaps

- **#14 (Adaptations RBAC)** — TL flagged as deliberate per master epic #1577; BA proposed subset response for VIEWER/STUDENT rather than fully relaxing the route. **Needs PM call before shipping.**
- **#10 (Export PDF)** — deferred to Wave C4; low value during the retirement window.

After this lands, only #14 blocks flipping \`NEXT_PUBLIC_HF_TAB_LAYOUT=retire\`.

## Test plan

- [ ] Caller with #566-era CallScore rows → see Trust footer card with Evidence-backed + Goodhart-drops tiles + evidence-ratio sparkline
- [ ] Pre-#566 caller (null hasLearnerEvidence) → no Trust footer card (silently absent)