### PR TITLE
feat(rbac): Wave C3b — role-tiered visibility policy + Adaptations VIEWER redaction (#1685)

### DIFF
--- a/.claude/rules/response-redaction.md
+++ b/.claude/rules/response-redaction.md
@@ -1,0 +1,123 @@
+# Response Redaction Pattern (Role-Tiered Visibility)
+
+> When a route returns a payload with operator-only fields next to learner-safe
+> fields, do not branch the route by role and do not duplicate the route. Use
+> a declarative redactor at the route boundary that projects the full response
+> onto the tier-appropriate shape.
+>
+> Sibling to [`ai-to-db-guard.md`](./ai-to-db-guard.md) (write-side
+> validate-before-execute), [`ai-read-grounding.md`](./ai-read-grounding.md)
+> (chat-side verify-before-claim), and [`verify-before-fix.md`](./verify-before-fix.md)
+> (developer-side symptom-then-cite). This is the **read-side
+> visibility-policy** sibling — least-privilege-by-role on response shape.
+
+## Rule: Tier-then-redact at the route boundary
+
+When a route's response contains fields that are safe for some roles but
+sensitive for others, route the data through a resource-specific redactor
+**before** the `NextResponse.json(...)` call. The redactor decides what each
+tier sees; the route never branches on role.
+
+```
+requireAuth(lowest-admit-tier) → scope-check → compute raw response →
+  visibilityTierForRole(role) → redact<Resource>ForTier(raw, tier) → respond
+```
+
+## When This Applies
+
+Any route where:
+
+1. The natural admit gate is broader than the natural full-payload gate
+   (e.g. STUDENT may read their own data, OPERATOR may read the full
+   payload of any caller).
+2. The response contains fields that fall into different sensitivity
+   classes — numeric internals, free-text rationale, forward-planning,
+   per-call evidence excerpts, etc.
+3. The shape difference is per-field, not per-section. (If it's
+   per-section, separate routes may be cleaner.)
+
+Today: `/api/callers/[callerId]/adaptations` (the canonical example).
+Candidates for future application: `/skills-evidence` (rationale text),
+`/uplift` (REWARD rationale arrays), `/lo-mastery` (evidence excerpts).
+
+## The Tiers
+
+| Tier | Roles (level via `ROLE_LEVEL`) | Intent |
+|---|---|---|
+| `redacted` | STUDENT (1) / VIEWER (1) / TESTER (1) / SUPER_TESTER (2) / DEMO (0) | Learner-facing or audit-only views. Numeric values, free-text reasoning, and forward-planning fields are dropped. |
+| `full` | OPERATOR / EDUCATOR (3) / ADMIN (4) | The full educator payload. |
+| `diagnostic` | SUPERADMIN (5) | Reserved for future debug fields (timing data, raw cascade internals). Functionally same as `full` today. |
+
+Coarse on purpose. Three tiers, not seven — per-role response shapes
+explode the test surface and harden into accidental contracts.
+
+## Required Pattern
+
+```typescript
+// In the route file:
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import { redactAdaptationsForTier } from "@/lib/rbac/policies/adaptations";
+
+export async function GET(req, { params }) {
+  const auth = await requireAuth("VIEWER");   // widest admit gate
+  if (isAuthError(auth)) return auth.error;
+
+  const { callerId } = await params;
+  if (!studentAllowedToReadCaller(auth.session, callerId)) {
+    return callerScopeMismatchResponse();
+  }
+
+  const viewerTier = visibilityTierForRole(auth.session.user.role);
+  const raw = await computeRawResponse(callerId);
+  return NextResponse.json(redactAdaptationsForTier(raw, viewerTier));
+}
+```
+
+The redactor lives at `lib/rbac/policies/<resource>.ts` and is a pure
+function — no I/O, easy to test exhaustively per tier.
+
+## Whitelist-default-safe
+
+When a new field is added to the raw response, it does NOT auto-flow
+to the `redacted` tier. The redactor's `redacted` branch must
+explicitly forward each field; if you add a sensitive field and forget
+to update the redactor, the type system fires (the redacted shape
+type is a structurally distinct interface, not `Partial<Raw>`).
+
+The corresponding vitest pins the absence of every sensitive field
+per tier so a regression like "I made the redacted shape forward
+sourceScope" gets caught at test time.
+
+## Response carries its tier
+
+Every redactor returns a discriminated union with `viewerTier:
+"redacted" | "full" | "diagnostic"`. The client branches on this
+discriminator, NOT on its own copy of the user role. Two reasons:
+
+1. The server is the source of truth — a stale or impersonated role
+   on the client can't elevate the response shape.
+2. The client doesn't need to know the role-to-tier mapping (it can
+   change in `lib/rbac/visibility.ts` without touching client code).
+
+## Existing Implementations
+
+| Resource | Redactor | Route | Pinned by |
+|---|---|---|---|
+| Adaptations | `lib/rbac/policies/adaptations.ts::redactAdaptationsForTier` | `/api/callers/[callerId]/adaptations` | `tests/lib/rbac/policies/adaptations-redact.test.ts` + `tests/api/callers/adaptations-route.test.ts` |
+
+## When NOT to apply
+
+- Routes where everyone sees the same shape (most reads).
+- Per-route role gating that's coarser than field-level (e.g. an
+  endpoint is OPERATOR-only — keep `requireAuth("OPERATOR")`, no
+  redactor needed).
+- Section-level rather than field-level differences (consider
+  separate routes if the redacted shape barely overlaps the full
+  shape).
+
+## Escalation
+
+If you're writing a new route that has tier-sensitive fields and
+can't add a redactor in the same PR, add a `// TODO(visibility):`
+comment describing what the lower-tier shape should be. These are
+tracked by `broken-windows` agent.

--- a/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
@@ -18,10 +18,23 @@
  *   - SP5-D "Next call's adaptation" — `goalAdaptationGuidance`
  *     LOW/MID/HIGH preview.
  *
- * Auth: **OPERATOR+ only.** Locked per master epic #1577 — Adaptations
- * is operator-private; STUDENT can read their OWN attainment but NEVER
- * the change-log. `requireAuth("OPERATOR")` is the structural gate; no
- * path-param scope is needed because STUDENT can't reach this method.
+ * **Auth (Wave C3b — #1577 visibility-policy revision):**
+ * `requireAuth("VIEWER")` + STUDENT path-param scope via
+ * `studentAllowedToReadCaller`. The OPERATOR+ safety property from
+ * the original #1577 design is preserved by **server-side response
+ * redaction** (`lib/rbac/policies/adaptations.ts::redactAdaptationsForTier`):
+ *
+ *   - STUDENT / VIEWER / TESTER (tier `redacted`) — see parameter
+ *     names + adjustment direction + a reason count. Numeric values,
+ *     free-text rationale, and next-call preview are dropped.
+ *   - OPERATOR / EDUCATOR / ADMIN (tier `full`) — full payload.
+ *   - SUPERADMIN (tier `diagnostic`) — reserved for future debug
+ *     fields; functionally same as `full` today.
+ *
+ * The response always carries a `viewerTier` discriminator so the
+ * client knows which shape it received. Adding a new sensitive field
+ * means updating the redactor's `redacted` branch — the type system
+ * keeps it whitelist-default-safe.
  *
  * Single-load: the response carries the three section envelopes
  * needed for first paint. Real-data sections that grow large will
@@ -29,16 +42,16 @@
  * pattern (SP4-C's `/lo-mastery` lazy fetch on module-row click).
  */
 
-/* eslint-disable hf-security/no-unscoped-caller-id-route --
- * OPERATOR+ only per master epic #1577 (Adaptations is operator-private,
- * STUDENT may only read their own Attainment). `requireAuth("OPERATOR")`
- * structurally refuses STUDENT/VIEWER at the auth gate, so the
- * studentAllowedToReadCaller path-param guard is moot for this surface.
- */
 import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  studentAllowedToReadCaller,
+  callerScopeMismatchResponse,
+} from "@/lib/learner-scope";
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import { redactAdaptationsForTier } from "@/lib/rbac/policies/adaptations";
 import { getEffectiveBehaviorTargetsForCaller } from "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller";
 
 /** What changed for this learner vs the playbook default. Each row is one
@@ -121,11 +134,19 @@ export async function GET(
 ) {
   const { callerId } = await params;
 
-  // OPERATOR+ gate. No `studentAllowedToReadCaller` — STUDENT is below
-  // OPERATOR and is refused at this line, so per-caller path-param
-  // scope is moot.
-  const auth = await requireAuth("OPERATOR");
+  // Wave C3b — VIEWER+ gate with STUDENT path-param scope. The
+  // OPERATOR+ safety property is preserved via response redaction
+  // (see header), not by the auth gate. STUDENT is admitted here so
+  // their own adaptation summary is visible; the redactor strips the
+  // sensitive fields before the response leaves the route.
+  const auth = await requireAuth("VIEWER");
   if (isAuthError(auth)) return auth.error;
+
+  if (!studentAllowedToReadCaller(auth.session, callerId)) {
+    return callerScopeMismatchResponse();
+  }
+
+  const viewerTier = visibilityTierForRole(auth.session.user.role);
 
   const caller = await prisma.caller.findUnique({
     where: { id: callerId },
@@ -147,7 +168,7 @@ export async function GET(
   });
 
   if (!enrolment) {
-    return NextResponse.json({
+    const rawEmpty: AdaptationsResponse = {
       callerId,
       callerName: caller.name,
       playbookId: null,
@@ -156,7 +177,8 @@ export async function GET(
       why: [],
       nextAdaptation: [],
       empty: true,
-    } satisfies AdaptationsResponse);
+    };
+    return NextResponse.json(redactAdaptationsForTier(rawEmpty, viewerTier));
   }
 
   const playbookId = enrolment.playbookId;
@@ -351,7 +373,7 @@ export async function GET(
     };
   });
 
-  return NextResponse.json({
+  const raw: AdaptationsResponse = {
     callerId,
     callerName: caller.name,
     playbookId,
@@ -363,7 +385,8 @@ export async function GET(
       whatWasAdapted.length === 0 &&
       whyTrimmed.length === 0 &&
       nextAdaptation.length === 0,
-  } satisfies AdaptationsResponse);
+  };
+  return NextResponse.json(redactAdaptationsForTier(raw, viewerTier));
 }
 
 /**

--- a/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AdaptationsTab.tsx
@@ -1,40 +1,40 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useSession } from "next-auth/react";
-import { SlidersHorizontal, AlertTriangle, Info, Lock } from "lucide-react";
-
-import { ROLE_LEVEL } from "@/lib/roles";
-import type { UserRole } from "@prisma/client";
+import { useEffect, useState } from "react";
+import { SlidersHorizontal, AlertTriangle, Info } from "lucide-react";
 
 import "./adaptations-tab.css";
 
 /**
- * Caller Detail → Adaptations tab (SP5-A shell).
+ * Caller Detail → Adaptations tab.
  *
  * Sister of `AttainmentTab` (SP4-A) — Attainment shows "where this
  * learner IS"; Adaptations shows "what the engine CHANGED for this
- * learner, why, and what's next". Replaces fragmented coverage in
- * `AdaptationLens` + the Tune-tab adaptation sections (those land in
- * SP5-E's `WILL_RETIRE` audit once the S5 registry ships).
+ * learner, why, and what's next".
  *
- * SP5-A SHELL — three section placeholders rendered with educator-
- * meaningful "coming next" copy so the operator can SEE the layout
- * before SP5-B/C/D fill the boxes:
+ * **Wave C3b — role-tiered visibility** (replaces the SP5-A OPERATOR+
+ * client lock). The route is now `requireAuth("VIEWER")` + STUDENT
+ * path-param scope; the server applies `redactAdaptationsForTier`
+ * before responding. The component reads the `viewerTier`
+ * discriminator on the response:
+ *
+ *   - `redacted` (STUDENT / VIEWER / TESTER) — parameter names +
+ *     direction chips + "N adjustments since you started"; nextAdaptation
+ *     section omitted.
+ *   - `full` / `diagnostic` (OPERATOR+) — full sections (cascade chips,
+ *     numeric values, rationale text, next-call preview).
+ *
+ * Sections:
  *
  *   - SP5-B "What was adapted" — `CallerTarget` overrides vs PLAYBOOK
- *     default + cascade chips
- *   - SP5-C "Why" — `RewardScore` + `Goal.progressMetrics` evidence
+ *     default + cascade chips (full tier) / direction chip (redacted)
+ *   - SP5-C "Why" — `RewardScore` rationale timeline (full) / count +
+ *     most-recent date (redacted)
  *   - SP5-D "Next call's adaptation" — `goalAdaptationGuidance`
- *     LOW/MID/HIGH preview
- *
- * **OPERATOR+ only.** STUDENT/VIEWER → "Operator-only view" message
- * (mirrors `CascadeLensPanel.tsx`'s pattern). The API route also
- * refuses (`requireAuth("OPERATOR")`) so client-side hiding is the
- * cosmetic layer, not the security boundary.
+ *     LOW/MID/HIGH preview (full only)
  */
 
-interface AdaptationOverride {
+interface AdaptationOverrideFull {
   parameterId: string;
   parameterName: string;
   defaultValue: number;
@@ -42,6 +42,13 @@ interface AdaptationOverride {
   sourceScope: "SYSTEM" | "PLAYBOOK" | "CALLER";
   confidence: number | null;
   callsApplied: number;
+  updatedAt: string | null;
+}
+
+interface AdaptationOverrideRedacted {
+  parameterId: string;
+  parameterName: string;
+  direction: "up" | "down" | "hold";
   updatedAt: string | null;
 }
 
@@ -55,6 +62,11 @@ interface AdaptationReason {
   delta: number | null;
 }
 
+interface AdaptationReasonRedacted {
+  count: number;
+  mostRecentAt: string | null;
+}
+
 interface NextAdaptationGuidanceEntry {
   goalId: string;
   goalName: string;
@@ -65,15 +77,36 @@ interface NextAdaptationGuidanceEntry {
   isAssessmentTarget: boolean;
 }
 
-interface AdaptationsResponse {
+interface AdaptationsResponseFull {
   callerId: string;
   callerName: string | null;
   playbookId: string | null;
   playbookName: string | null;
-  whatWasAdapted: AdaptationOverride[];
+  whatWasAdapted: AdaptationOverrideFull[];
   why: AdaptationReason[];
   nextAdaptation: NextAdaptationGuidanceEntry[];
   empty: boolean;
+  viewerTier: "full" | "diagnostic";
+}
+
+interface AdaptationsResponseRedacted {
+  callerId: string;
+  callerName: string | null;
+  playbookId: string | null;
+  playbookName: string | null;
+  whatWasAdapted: AdaptationOverrideRedacted[];
+  whyRedacted: AdaptationReasonRedacted;
+  nextAdaptation: never[];
+  empty: boolean;
+  viewerTier: "redacted";
+}
+
+type AdaptationsResponse = AdaptationsResponseFull | AdaptationsResponseRedacted;
+
+function isRedacted(
+  r: AdaptationsResponse,
+): r is AdaptationsResponseRedacted {
+  return r.viewerTier === "redacted";
 }
 
 interface Props {
@@ -81,23 +114,11 @@ interface Props {
 }
 
 export function AdaptationsTab({ callerId }: Props) {
-  const { data: session } = useSession();
-  const userLevel = useMemo(() => {
-    const role = session?.user?.role as UserRole | undefined;
-    if (!role) return 0;
-    return ROLE_LEVEL[role] ?? 0;
-  }, [session?.user?.role]);
-  const operatorOrBetter = userLevel >= ROLE_LEVEL.OPERATOR;
-
   const [data, setData] = useState<AdaptationsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!operatorOrBetter) {
-      setLoading(false);
-      return;
-    }
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -121,22 +142,7 @@ export function AdaptationsTab({ callerId }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [callerId, operatorOrBetter]);
-
-  if (!operatorOrBetter) {
-    return (
-      <div className="hf-adaptations-locked" role="status">
-        <Lock size={18} aria-hidden />
-        <div>
-          <strong>Operator-only view.</strong>
-          <p>
-            Adaptations show what the engine changed for this learner.
-            Sign in as an operator to see the change log.
-          </p>
-        </div>
-      </div>
-    );
-  }
+  }, [callerId]);
 
   if (loading) {
     return (
@@ -194,9 +200,32 @@ export function AdaptationsTab({ callerId }: Props) {
         </p>
       </header>
 
-      <WhatWasAdaptedSection overrides={data.whatWasAdapted} empty={data.empty} />
-      <WhySection reasons={data.why} empty={data.empty} />
-      <NextAdaptationSection guidance={data.nextAdaptation} empty={data.empty} />
+      {isRedacted(data) ? (
+        <>
+          <WhatWasAdaptedRedactedSection
+            overrides={data.whatWasAdapted}
+            empty={data.empty}
+          />
+          <WhyRedactedSection
+            redacted={data.whyRedacted}
+            empty={data.empty}
+          />
+          {/* Next-call preview is hidden at the redacted tier so the
+              learner can't pre-read the plan. */}
+        </>
+      ) : (
+        <>
+          <WhatWasAdaptedSection
+            overrides={data.whatWasAdapted}
+            empty={data.empty}
+          />
+          <WhySection reasons={data.why} empty={data.empty} />
+          <NextAdaptationSection
+            guidance={data.nextAdaptation}
+            empty={data.empty}
+          />
+        </>
+      )}
     </div>
   );
 }
@@ -207,7 +236,7 @@ function WhatWasAdaptedSection({
   overrides,
   empty,
 }: {
-  overrides: AdaptationOverride[];
+  overrides: AdaptationOverrideFull[];
   empty: boolean;
 }) {
   return (
@@ -236,7 +265,7 @@ function WhatWasAdaptedSection({
   );
 }
 
-function OverrideRow({ override }: { override: AdaptationOverride }) {
+function OverrideRow({ override }: { override: AdaptationOverrideFull }) {
   const defaultPct = Math.round(override.defaultValue * 100);
   const overridePct = Math.round(override.overrideValue * 100);
   const delta = override.overrideValue - override.defaultValue;
@@ -447,5 +476,108 @@ function NextRow({ entry }: { entry: NextAdaptationGuidanceEntry }) {
       </div>
       <p className="hf-adaptations-next-guidance">{entry.guidance}.</p>
     </li>
+  );
+}
+
+// ── Redacted sections (STUDENT / VIEWER / TESTER tier) ──────────────────────
+
+function WhatWasAdaptedRedactedSection({
+  overrides,
+  empty,
+}: {
+  overrides: AdaptationOverrideRedacted[];
+  empty: boolean;
+}) {
+  return (
+    <section
+      className="hf-adaptations-section"
+      data-testid="hf-adaptations-what-redacted"
+    >
+      <h3 className="hf-adaptations-section-title">What was adapted</h3>
+      <p className="hf-adaptations-section-desc">
+        Parameters the engine has nudged for this learner. Direction-only —
+        numeric values, source layer, and confidence are operator-only.
+      </p>
+      {overrides.length === 0 ? (
+        <p className="hf-adaptations-empty-text">
+          {empty
+            ? "No adaptations yet — the engine starts with the playbook's defaults and adapts after the first scoring call."
+            : "No per-parameter overrides recorded yet."}
+        </p>
+      ) : (
+        <ul className="hf-adaptations-override-rows">
+          {overrides.map((o) => (
+            <li
+              key={o.parameterId}
+              className="hf-adaptations-override-row hf-adaptations-override-row-redacted"
+            >
+              <div className="hf-adaptations-override-head">
+                <span className="hf-adaptations-override-name">
+                  {o.parameterName}
+                </span>
+                <span
+                  className={`hf-adaptations-override-delta hf-adaptations-override-delta-${
+                    o.direction === "hold" ? "flat" : o.direction
+                  }`}
+                  aria-label={`Direction ${o.direction}`}
+                >
+                  {o.direction === "up"
+                    ? "↑ nudged up"
+                    : o.direction === "down"
+                      ? "↓ nudged down"
+                      : "→ holding"}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function WhyRedactedSection({
+  redacted,
+  empty,
+}: {
+  redacted: AdaptationReasonRedacted;
+  empty: boolean;
+}) {
+  return (
+    <section
+      className="hf-adaptations-section"
+      data-testid="hf-adaptations-why-redacted"
+    >
+      <h3 className="hf-adaptations-section-title">Why</h3>
+      <p className="hf-adaptations-section-desc">
+        Summary of recent adaptation activity. Per-event rationale is
+        operator-only.
+      </p>
+      {redacted.count === 0 ? (
+        <p className="hf-adaptations-empty-text">
+          {empty
+            ? "No adaptation activity yet — appears after the first scoring call."
+            : "No target updates have been logged in the most recent calls."}
+        </p>
+      ) : (
+        <p className="hf-adaptations-redacted-summary">
+          <strong>
+            {redacted.count} adjustment{redacted.count === 1 ? "" : "s"}
+          </strong>{" "}
+          recorded
+          {redacted.mostRecentAt ? (
+            <>
+              {" "}— most recent on{" "}
+              <time dateTime={redacted.mostRecentAt}>
+                {formatReasonDate(redacted.mostRecentAt)}
+              </time>
+            </>
+          ) : (
+            ""
+          )}
+          .
+        </p>
+      )}
+    </section>
   );
 }

--- a/apps/admin/lib/rbac/policies/adaptations.ts
+++ b/apps/admin/lib/rbac/policies/adaptations.ts
@@ -1,0 +1,158 @@
+/**
+ * Adaptations response redactor — Wave C3b of the legacy-tab retirement
+ * plan. Master epic #1577 kept this surface OPERATOR+ for safety; the
+ * redactor restores VIEWER/STUDENT visibility WITHOUT exposing the
+ * sensitive payload.
+ *
+ * **What gets hidden at the `redacted` tier:**
+ * - Per-override numeric values (defaultValue, overrideValue) — kept as
+ *   a direction-only chip (up/down/hold)
+ * - sourceScope (SYSTEM vs PLAYBOOK vs CALLER) — internal cascade layer
+ * - confidence + callsApplied — AI-internal rollup metadata
+ * - Per-reason rationale text — free-text REWARD-stage logs that may
+ *   reveal operator strategy or contain learner-side names
+ * - nextAdaptation entirely — forward-planning that would spoil the
+ *   learning experience if the learner reads it pre-call
+ *
+ * **What stays visible at the `redacted` tier:**
+ * - Identity (callerId, callerName, playbookId, playbookName)
+ * - whatWasAdapted parameter names + adjustment direction
+ * - Reason count + most-recent date ("3 adjustments, last on 12 Jun")
+ *
+ * **Whitelist-default-safe:** if a new field is added to
+ * `AdaptationsResponse`, the redactor's `redacted` branch will NOT
+ * forward it unless this file is updated. The corresponding vitest
+ * pins the absence of the sensitive fields per tier.
+ *
+ * Sibling to `.claude/rules/ai-to-db-guard.md` (write-side); the
+ * pattern is documented at the top of `lib/rbac/visibility.ts`.
+ */
+
+import type { VisibilityTier } from "@/lib/rbac/visibility";
+import type {
+  AdaptationsResponse,
+  AdaptationOverride,
+  AdaptationReason,
+  NextAdaptationGuidanceEntry,
+} from "@/app/api/callers/[callerId]/adaptations/route";
+
+/** Redacted shape of `AdaptationOverride` — only parameter identity +
+ *  direction survives the redactor. Numeric values + cascade-layer
+ *  metadata are stripped.  */
+export interface AdaptationOverrideRedacted {
+  parameterId: string;
+  parameterName: string;
+  direction: "up" | "down" | "hold";
+  updatedAt: string | null;
+}
+
+/** Redacted shape of the `why` array — collapsed to a count + most-recent
+ *  timestamp so the learner sees "you've been adapted recently" without
+ *  the free-text rationale. */
+export interface AdaptationReasonRedacted {
+  count: number;
+  mostRecentAt: string | null;
+}
+
+/** What clients receive at the `redacted` tier. Same identity envelope
+ *  as the full response so client navigation doesn't break. */
+export interface AdaptationsResponseRedacted {
+  callerId: string;
+  callerName: string | null;
+  playbookId: string | null;
+  playbookName: string | null;
+  whatWasAdapted: AdaptationOverrideRedacted[];
+  whyRedacted: AdaptationReasonRedacted;
+  /** Always empty array at the `redacted` tier — kept for client shape
+   *  stability so the NextAdaptation section can render its empty
+   *  state without conditional chains.  */
+  nextAdaptation: never[];
+  empty: boolean;
+  viewerTier: "redacted";
+}
+
+/** What clients receive at the `full` or `diagnostic` tier — the raw
+ *  response with the viewerTier discriminator appended. */
+export interface AdaptationsResponseFull extends AdaptationsResponse {
+  viewerTier: "full" | "diagnostic";
+}
+
+export type AdaptationsResponseForViewer =
+  | AdaptationsResponseRedacted
+  | AdaptationsResponseFull;
+
+function directionFor(o: AdaptationOverride): "up" | "down" | "hold" {
+  const delta = o.overrideValue - o.defaultValue;
+  if (Math.abs(delta) < 0.005) return "hold";
+  return delta > 0 ? "up" : "down";
+}
+
+function mostRecentAt(why: AdaptationReason[]): string | null {
+  if (why.length === 0) return null;
+  // `why` is already sorted descending by REWARD scoredAt in the route,
+  // but defensive sort here so a future re-order at the route doesn't
+  // silently produce the wrong "most recent" stamp.
+  const sorted = [...why].sort((a, b) =>
+    a.at < b.at ? 1 : a.at > b.at ? -1 : 0,
+  );
+  return sorted[0].at;
+}
+
+/**
+ * Project an `AdaptationsResponse` onto the redacted surface. Pure
+ * function — no I/O. Pinned by tests in
+ * `tests/lib/rbac/policies/adaptations-redact.test.ts`.
+ */
+export function redactAdaptationsForTier(
+  raw: AdaptationsResponse,
+  tier: VisibilityTier,
+): AdaptationsResponseForViewer {
+  if (tier === "full" || tier === "diagnostic") {
+    return { ...raw, viewerTier: tier };
+  }
+
+  // `redacted` tier — STUDENT / VIEWER / TESTER. Default-safe: only
+  // the whitelisted fields below are forwarded.
+  const whatWasAdapted: AdaptationOverrideRedacted[] = raw.whatWasAdapted.map(
+    (o) => ({
+      parameterId: o.parameterId,
+      parameterName: o.parameterName,
+      direction: directionFor(o),
+      updatedAt: o.updatedAt,
+    }),
+  );
+
+  const whyRedacted: AdaptationReasonRedacted = {
+    count: raw.why.length,
+    mostRecentAt: mostRecentAt(raw.why),
+  };
+
+  return {
+    callerId: raw.callerId,
+    callerName: raw.callerName,
+    playbookId: raw.playbookId,
+    playbookName: raw.playbookName,
+    whatWasAdapted,
+    whyRedacted,
+    nextAdaptation: [] as never[],
+    empty: raw.empty,
+    viewerTier: "redacted",
+  };
+}
+
+/**
+ * Type guard so the AdaptationsTab client can branch on the redaction
+ * envelope without unsafe casts.
+ */
+export function isRedacted(
+  response: AdaptationsResponseForViewer,
+): response is AdaptationsResponseRedacted {
+  return response.viewerTier === "redacted";
+}
+
+/**
+ * Same Next.js NextResponse signature as a normal route — the route
+ * file uses this as the only return path so callers can't accidentally
+ * skip the redactor.
+ */
+export type { NextAdaptationGuidanceEntry };

--- a/apps/admin/lib/rbac/visibility.ts
+++ b/apps/admin/lib/rbac/visibility.ts
@@ -1,0 +1,66 @@
+/**
+ * Response visibility tiers — declarative, role-driven redaction at
+ * the route boundary.
+ *
+ * **The pattern:** every route that returns a payload with sensitive
+ * vs reference-grade fields computes a tier from the session role and
+ * passes the raw response through a resource-specific redactor:
+ *
+ *   ```ts
+ *   import { visibilityTierForRole } from "@/lib/rbac/visibility";
+ *   import { redactAdaptationsForTier } from "@/lib/rbac/policies/adaptations";
+ *
+ *   const auth = await requireAuth("VIEWER");
+ *   if (isAuthError(auth)) return auth.error;
+ *   if (!studentAllowedToReadCaller(auth.session, callerId)) return ...;
+ *
+ *   const tier = visibilityTierForRole(auth.session.user.role);
+ *   const raw = await computeAdaptationsResponse(callerId);
+ *   return NextResponse.json({ ...redactAdaptationsForTier(raw, tier), viewerTier: tier });
+ *   ```
+ *
+ * **Why tier-then-redact (not 3 routes / not GraphQL):**
+ * - Single route URL — client doesn't have to know its own role to fetch
+ * - Server-enforced — client can never opt up
+ * - Redactor is per-resource so each policy is co-located with its
+ *   response type (see `lib/rbac/policies/<resource>.ts`)
+ * - Default-safe by whitelist — new fields aren't auto-exposed to
+ *   lower tiers; the redactor's lower-tier branch must explicitly
+ *   forward them
+ *
+ * **The three tiers:**
+ * - `redacted` — STUDENT / TESTER / VIEWER. Learner-facing or
+ *   audit-only views. Numeric values, free-text reasoning, and
+ *   forward-planning fields are dropped.
+ * - `full` — OPERATOR / EDUCATOR / ADMIN. The full educator payload.
+ * - `diagnostic` — SUPERADMIN. Reserved for future debug fields
+ *   (timing data, raw cascade internals). For now functionally the
+ *   same as `full`.
+ *
+ * Sibling to `.claude/rules/ai-to-db-guard.md` (write-side) and
+ * `.claude/rules/ai-read-grounding.md` (chat-side). This is the
+ * **route-response visibility-policy** sibling — read-side
+ * least-privilege-by-role.
+ */
+
+import type { UserRole } from "@prisma/client";
+
+import { ROLE_LEVEL } from "@/lib/roles";
+
+export type VisibilityTier = "redacted" | "full" | "diagnostic";
+
+/**
+ * Maps a session role to its response-visibility tier.
+ *
+ * The mapping is intentionally coarse — three tiers, not seven —
+ * because per-role response shapes explode the test surface and
+ * harden into accidental contracts. Two cuts (educator vs learner,
+ * superadmin diagnostics) cover every read surface we have today.
+ */
+export function visibilityTierForRole(role: UserRole | undefined): VisibilityTier {
+  if (!role) return "redacted";
+  const level = ROLE_LEVEL[role] ?? 0;
+  if (level >= ROLE_LEVEL.SUPERADMIN) return "diagnostic";
+  if (level >= ROLE_LEVEL.OPERATOR) return "full";
+  return "redacted";
+}

--- a/apps/admin/tests/api/callers/adaptations-route.test.ts
+++ b/apps/admin/tests/api/callers/adaptations-route.test.ts
@@ -1,13 +1,21 @@
 /**
- * Tests for `GET /api/callers/[callerId]/adaptations` — Sprint 5 SP5-A
- * shell. Pins:
+ * Tests for `GET /api/callers/[callerId]/adaptations`.
  *
- *   1. OPERATOR+ only — STUDENT/VIEWER refused at the auth gate.
- *   2. 404 when caller missing.
- *   3. Empty enrolment response when caller has no playbook.
- *   4. Empty shell when caller is enrolled but has zero CallerTarget
- *      overrides (empty=true so the UI can render the right copy).
- *   5. empty=false when ≥1 override exists (SP5-B will fill the array).
+ * Pins (post Wave C3b — visibility-policy revision of #1577):
+ *
+ *   1. **VIEWER+ admit gate.** STUDENT is admitted (own caller); STUDENT
+ *      with a foreign callerId is refused by `studentAllowedToReadCaller`.
+ *      A non-authenticated session is refused at `requireAuth("VIEWER")`.
+ *   2. **viewerTier discriminator.** Every successful response carries
+ *      `viewerTier`. STUDENT/VIEWER/TESTER → `redacted`; OPERATOR/EDUCATOR
+ *      /ADMIN → `full`; SUPERADMIN → `diagnostic`.
+ *   3. **Redacted shape.** At the `redacted` tier, `whatWasAdapted`
+ *      carries only `(parameterId, parameterName, direction, updatedAt)`;
+ *      `why` is replaced by `whyRedacted: { count, mostRecentAt }`;
+ *      `nextAdaptation` is forced to `[]`.
+ *   4. 404 when caller missing.
+ *   5. Empty enrolment response when caller has no playbook.
+ *   6. empty=false at full tier when ≥1 override exists.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -30,15 +38,28 @@ vi.mock(
   () => ({ getEffectiveBehaviorTargetsForCaller: vi.fn(async () => []) }),
 );
 
-// Default mock — OPERATOR session passes. Per-test overrides simulate
-// STUDENT/VIEWER refusal at the auth gate.
+// Default mock — OPERATOR session passes (returns `full` tier).
+// Per-test overrides simulate STUDENT (`redacted`) / forbidden.
 vi.mock("@/lib/permissions", () => ({
   requireAuth: vi.fn(async () => ({
     ok: true,
-    session: { user: { id: "u1", role: "OPERATOR" } },
+    session: { user: { id: "u1", role: "OPERATOR", callerId: null } },
   })),
   isAuthError: (v: unknown) =>
     typeof v === "object" && v !== null && "error" in v,
+}));
+
+// Scope helper — STUDENT can only read OWN caller; OPERATOR+ unrestricted.
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: (
+    session: { user: { role: string; callerId: string | null } },
+    callerId: string,
+  ) => {
+    if (session.user.role !== "STUDENT") return true;
+    return session.user.callerId === callerId;
+  },
+  callerScopeMismatchResponse: () =>
+    new Response(JSON.stringify({ error: "scope mismatch" }), { status: 403 }),
 }));
 
 const PARAMS = { params: Promise.resolve({ callerId: "c1" }) };
@@ -47,16 +68,41 @@ async function loadRoute() {
   return import("@/app/api/callers/[callerId]/adaptations/route");
 }
 
-describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
+describe("GET /api/callers/[callerId]/adaptations — auth + scope", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Defaults: no RewardScore rows, no Goal rows. Individual SP5-C/D
-    // tests override.
     mockPrisma.rewardScore.findMany.mockResolvedValue([]);
     mockPrisma.goal.findMany.mockResolvedValue([]);
   });
 
-  it("returns 403 for STUDENT (refused at requireAuth OPERATOR gate)", async () => {
+  it("admits STUDENT for own caller (returns 200 with redacted tier)", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: "u2", role: "STUDENT", callerId: "c1" } },
+    } as never);
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
+
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.viewerTier).toBe("redacted");
+  });
+
+  it("refuses STUDENT for foreign caller (scope mismatch)", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: "u2", role: "STUDENT", callerId: "OTHER" } },
+    } as never);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 for non-authenticated session (requireAuth refuses)", async () => {
     const permissions = await import("@/lib/permissions");
     vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
       error: new Response("forbidden", { status: 403 }),
@@ -72,6 +118,67 @@ describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
     const res = await GET(new Request("http://x"), PARAMS);
     expect(res.status).toBe(404);
   });
+});
+
+describe("GET /api/callers/[callerId]/adaptations — viewerTier discriminator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.rewardScore.findMany.mockResolvedValue([]);
+    mockPrisma.goal.findMany.mockResolvedValue([]);
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
+  });
+
+  it("tags response 'full' for OPERATOR", async () => {
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.viewerTier).toBe("full");
+  });
+
+  it("tags response 'redacted' for STUDENT", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: "u2", role: "STUDENT", callerId: "c1" } },
+    } as never);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.viewerTier).toBe("redacted");
+  });
+
+  it("tags response 'redacted' for VIEWER (legacy alias)", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: "u2", role: "VIEWER", callerId: null } },
+    } as never);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.viewerTier).toBe("redacted");
+  });
+
+  it("tags response 'diagnostic' for SUPERADMIN", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: "u2", role: "SUPERADMIN", callerId: null } },
+    } as never);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.viewerTier).toBe("diagnostic");
+  });
+});
+
+describe("GET /api/callers/[callerId]/adaptations — SP5-A shell at full tier", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.rewardScore.findMany.mockResolvedValue([]);
+    mockPrisma.goal.findMany.mockResolvedValue([]);
+  });
 
   it("returns shell with empty=true and null playbook when caller has no enrolment", async () => {
     mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
@@ -85,21 +192,20 @@ describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
     expect(body.empty).toBe(true);
     expect(body.whatWasAdapted).toEqual([]);
     expect(body.why).toEqual([]);
-    expect(body.nextAdaptation).toBeNull();
+    expect(body.nextAdaptation).toEqual([]);
   });
 
   it("returns shell with empty=true when enrolled but zero overrides", async () => {
     mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
     mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
       playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
+      playbook: { id: "pb1", name: "Sample" },
     });
     const { GET } = await loadRoute();
     const res = await GET(new Request("http://x"), PARAMS);
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body.playbookId).toBe("pb1");
-    expect(body.playbookName).toBe("IELTS Speaking");
     expect(body.empty).toBe(true);
     expect(body.whatWasAdapted).toEqual([]);
   });
@@ -108,287 +214,145 @@ describe("GET /api/callers/[callerId]/adaptations — SP5-A shell", () => {
     mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
     mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
       playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
+      playbook: { id: "pb1", name: "Sample" },
     });
-    const effective = await import(
+    const { getEffectiveBehaviorTargetsForCaller } = await import(
       "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller"
     );
-    vi.mocked(effective.getEffectiveBehaviorTargetsForCaller).mockResolvedValueOnce([
+    vi.mocked(getEffectiveBehaviorTargetsForCaller).mockResolvedValueOnce([
       {
-        parameterId: "BEH_QUESTION_RATE",
-        effectiveValue: 0.6,
-        sourceScope: "SYSTEM",
-        systemValue: 0.6,
-        playbookValue: null,
-        callerValue: null,
-      },
-      {
-        parameterId: "BEH_PRAISE_RATE",
-        effectiveValue: 0.4,
-        sourceScope: "PLAYBOOK",
+        parameterId: "p1",
+        effectiveValue: 0.7,
+        sourceScope: "CALLER" as const,
         systemValue: 0.5,
-        playbookValue: 0.4,
-        callerValue: null,
       },
-    ]);
-    mockPrisma.parameter.findMany.mockResolvedValue([
-      { parameterId: "BEH_PRAISE_RATE", name: "Praise rate" },
-    ]);
-    mockPrisma.callerTarget.findMany.mockResolvedValue([]);
-    mockPrisma.behaviorTarget.findMany.mockResolvedValue([
       {
-        parameterId: "BEH_PRAISE_RATE",
-        updatedAt: new Date("2026-06-10T10:00:00Z"),
+        parameterId: "p2",
+        effectiveValue: 0.5,
+        sourceScope: "SYSTEM" as const,
+        systemValue: 0.5,
+      },
+    ] as never);
+    mockPrisma.parameter.findMany.mockResolvedValueOnce([
+      { parameterId: "p1", name: "Clarity" },
+    ]);
+    mockPrisma.callerTarget.findMany.mockResolvedValueOnce([
+      {
+        parameterId: "p1",
+        confidence: 0.9,
+        callsUsed: 3,
+        updatedAt: new Date("2026-06-12T10:00:00Z"),
       },
     ]);
     const { GET } = await loadRoute();
     const res = await GET(new Request("http://x"), PARAMS);
     const body = await res.json();
-    // SYSTEM-only row dropped; PLAYBOOK survived.
     expect(body.whatWasAdapted).toHaveLength(1);
-    expect(body.whatWasAdapted[0]).toMatchObject({
-      parameterId: "BEH_PRAISE_RATE",
-      parameterName: "Praise rate",
-      defaultValue: 0.5,
-      overrideValue: 0.4,
-      sourceScope: "PLAYBOOK",
-      confidence: null,
-      callsApplied: 0,
-    });
-    expect(body.empty).toBe(false);
+    expect(body.whatWasAdapted[0].parameterId).toBe("p1");
+  });
+});
+
+describe("GET /api/callers/[callerId]/adaptations — redacted shape", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.rewardScore.findMany.mockResolvedValue([]);
+    mockPrisma.goal.findMany.mockResolvedValue([]);
   });
 
-  it("SP5-C: derives why-entries from RewardScore.targetUpdatesApplied with direction + delta", async () => {
+  async function asStudent() {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      ok: true,
+      session: { user: { id: "u2", role: "STUDENT", callerId: "c1" } },
+    } as never);
+  }
+
+  it("strips numeric values from whatWasAdapted (only direction + name)", async () => {
+    await asStudent();
     mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
     mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
       playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
+      playbook: { id: "pb1", name: "Sample" },
+    });
+    const { getEffectiveBehaviorTargetsForCaller } = await import(
+      "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller"
+    );
+    vi.mocked(getEffectiveBehaviorTargetsForCaller).mockResolvedValueOnce([
+      {
+        parameterId: "p1",
+        effectiveValue: 0.7,
+        sourceScope: "CALLER" as const,
+        systemValue: 0.5,
+      },
+    ] as never);
+    mockPrisma.parameter.findMany.mockResolvedValueOnce([
+      { parameterId: "p1", name: "Clarity" },
+    ]);
+    mockPrisma.callerTarget.findMany.mockResolvedValueOnce([
+      {
+        parameterId: "p1",
+        confidence: 0.9,
+        callsUsed: 3,
+        updatedAt: new Date("2026-06-12T10:00:00Z"),
+      },
+    ]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.viewerTier).toBe("redacted");
+    expect(body.whatWasAdapted[0]).toMatchObject({
+      parameterId: "p1",
+      parameterName: "Clarity",
+      direction: "up",
+    });
+    expect("defaultValue" in body.whatWasAdapted[0]).toBe(false);
+    expect("overrideValue" in body.whatWasAdapted[0]).toBe(false);
+    expect("confidence" in body.whatWasAdapted[0]).toBe(false);
+    expect("sourceScope" in body.whatWasAdapted[0]).toBe(false);
+  });
+
+  it("collapses why to count + mostRecentAt and hides nextAdaptation entirely", async () => {
+    await asStudent();
+    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbookId: "pb1",
+      playbook: { id: "pb1", name: "Sample" },
     });
     mockPrisma.rewardScore.findMany.mockResolvedValueOnce([
       {
-        callId: "call-99",
+        callId: "call_1",
         scoredAt: new Date("2026-06-12T10:00:00Z"),
         targetUpdatesApplied: [
           {
-            parameterId: "BEH_QUESTION_RATE",
+            parameterId: "p_clarity",
             oldTarget: 0.5,
             newTarget: 0.7,
-            reason: "Assessment near threshold — raise questioning",
-          },
-          {
-            parameterId: "BEH_PRAISE_RATE",
-            oldTarget: 0.5,
-            newTarget: 0.5,
-            reason: "No change warranted this call",
+            reason: "Sensitive operator rationale",
           },
         ],
       },
     ]);
-    mockPrisma.parameter.findMany.mockResolvedValue([
-      { parameterId: "BEH_QUESTION_RATE", name: "Question rate" },
-      { parameterId: "BEH_PRAISE_RATE", name: "Praise rate" },
+    mockPrisma.parameter.findMany.mockResolvedValueOnce([
+      { parameterId: "p_clarity", name: "Clarity" },
     ]);
-    const { GET } = await loadRoute();
-    const res = await GET(new Request("http://x"), PARAMS);
-    const body = await res.json();
-    expect(body.why).toHaveLength(2);
-    const up = body.why.find((r: { direction: string }) => r.direction === "up");
-    const hold = body.why.find((r: { direction: string }) => r.direction === "hold");
-    expect(up).toMatchObject({
-      parameterName: "Question rate",
-      direction: "up",
-      callId: "call-99",
-    });
-    expect(up.delta).toBeCloseTo(0.2, 5);
-    expect(hold).toMatchObject({
-      parameterName: "Praise rate",
-      direction: "hold",
-    });
-    expect(hold.delta).toBeCloseTo(0, 5);
-    expect(body.empty).toBe(false);
-  });
-
-  it("SP5-C: down direction when newTarget < oldTarget", async () => {
-    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
-    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
-      playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
-    });
-    mockPrisma.rewardScore.findMany.mockResolvedValueOnce([
-      {
-        callId: "call-7",
-        scoredAt: new Date("2026-06-10T10:00:00Z"),
-        targetUpdatesApplied: [
-          {
-            parameterId: "BEH_INTERRUPTIONS",
-            oldTarget: 0.4,
-            newTarget: 0.2,
-            reason: "Too many interruptions — soften",
-          },
-        ],
-      },
-    ]);
-    mockPrisma.parameter.findMany.mockResolvedValue([
-      { parameterId: "BEH_INTERRUPTIONS", name: "Interruptions" },
-    ]);
-    const { GET } = await loadRoute();
-    const res = await GET(new Request("http://x"), PARAMS);
-    const body = await res.json();
-    expect(body.why[0].direction).toBe("down");
-    expect(body.why[0].delta).toBeCloseTo(-0.2, 5);
-  });
-
-  it("SP5-C: tolerates malformed targetUpdatesApplied entries", async () => {
-    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
-    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
-      playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
-    });
-    mockPrisma.rewardScore.findMany.mockResolvedValueOnce([
-      {
-        callId: "call-1",
-        scoredAt: new Date("2026-06-10T10:00:00Z"),
-        targetUpdatesApplied: [
-          null,
-          { parameterId: 42 }, // non-string parameterId
-          { reason: "missing both targets" },
-          { parameterId: "OK", oldTarget: 0.3, newTarget: 0.5, reason: "valid" },
-        ],
-      },
-    ]);
-    mockPrisma.parameter.findMany.mockResolvedValue([
-      { parameterId: "OK", name: "OK param" },
-    ]);
-    const { GET } = await loadRoute();
-    const res = await GET(new Request("http://x"), PARAMS);
-    const body = await res.json();
-    expect(body.why).toHaveLength(3); // null skipped; non-object skipped; others kept
-    const valid = body.why.find((r: { parameterId: string }) => r.parameterId === "OK");
-    expect(valid?.direction).toBe("up");
-    const missingBoth = body.why.find(
-      (r: { rationale: string }) => r.rationale === "missing both targets",
-    );
-    expect(missingBoth?.direction).toBe("hold");
-    expect(missingBoth?.delta).toBeNull();
-  });
-
-  it("SP5-D: bands top-3 goals as LOW/MID/HIGH from progress", async () => {
-    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
-    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
-      playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
-    });
-    mockPrisma.goal.findMany.mockResolvedValue([
+    mockPrisma.goal.findMany.mockResolvedValueOnce([
       {
         id: "g1",
-        name: "Foundations",
+        name: "Master fractions",
         type: "LEARN",
-        progress: 0.1,
-        isAssessmentTarget: false,
-      },
-      {
-        id: "g2",
-        name: "Mid track",
-        type: "ACHIEVE",
-        progress: 0.55,
-        isAssessmentTarget: true,
-      },
-      {
-        id: "g3",
-        name: "Almost there",
-        type: "LEARN",
-        progress: 0.9,
+        progress: 0.4,
         isAssessmentTarget: false,
       },
     ]);
     const { GET } = await loadRoute();
     const res = await GET(new Request("http://x"), PARAMS);
     const body = await res.json();
-    expect(body.nextAdaptation).toHaveLength(3);
-    const low = body.nextAdaptation.find(
-      (e: { goalId: string }) => e.goalId === "g1",
-    );
-    const mid = body.nextAdaptation.find(
-      (e: { goalId: string }) => e.goalId === "g2",
-    );
-    const high = body.nextAdaptation.find(
-      (e: { goalId: string }) => e.goalId === "g3",
-    );
-    expect(low.band).toBe("low");
-    expect(low.guidance).toMatch(/Introduce concepts gently/);
-    expect(mid.band).toBe("mid");
-    expect(mid.guidance).toMatch(/Track milestones/);
-    expect(mid.isAssessmentTarget).toBe(true);
-    expect(high.band).toBe("high");
-    expect(high.guidance).toMatch(/Challenge with application/);
-    expect(body.empty).toBe(false);
-  });
-
-  it("SP5-D: unknown goal type falls back to LEARN guidance", async () => {
-    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
-    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
-      playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
+    expect(body.viewerTier).toBe("redacted");
+    expect(body.whyRedacted).toMatchObject({
+      count: 1,
+      mostRecentAt: "2026-06-12T10:00:00.000Z",
     });
-    mockPrisma.goal.findMany.mockResolvedValue([
-      {
-        id: "g1",
-        name: "Unknown-type goal",
-        type: "FOOBAR",
-        progress: 0.5,
-        isAssessmentTarget: false,
-      },
-    ]);
-    const { GET } = await loadRoute();
-    const res = await GET(new Request("http://x"), PARAMS);
-    const body = await res.json();
-    expect(body.nextAdaptation[0].guidance).toMatch(
-      /Build on prior foundations/,
-    );
-  });
-
-  it("SP5-B: CALLER-scope override carries confidence + callsApplied from CallerTarget", async () => {
-    mockPrisma.caller.findUnique.mockResolvedValue({ id: "c1", name: "Alex" });
-    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
-      playbookId: "pb1",
-      playbook: { id: "pb1", name: "IELTS Speaking" },
-    });
-    const effective = await import(
-      "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller"
-    );
-    vi.mocked(effective.getEffectiveBehaviorTargetsForCaller).mockResolvedValueOnce([
-      {
-        parameterId: "skill_fluency",
-        effectiveValue: 0.78,
-        sourceScope: "CALLER",
-        systemValue: 0.5,
-        playbookValue: null,
-        callerValue: 0.78,
-      },
-    ]);
-    mockPrisma.parameter.findMany.mockResolvedValue([
-      { parameterId: "skill_fluency", name: "Fluency" },
-    ]);
-    mockPrisma.callerTarget.findMany.mockResolvedValue([
-      {
-        parameterId: "skill_fluency",
-        confidence: 0.85,
-        callsUsed: 4,
-        updatedAt: new Date("2026-06-12T09:00:00Z"),
-      },
-    ]);
-    mockPrisma.behaviorTarget.findMany.mockResolvedValue([]);
-    const { GET } = await loadRoute();
-    const res = await GET(new Request("http://x"), PARAMS);
-    const body = await res.json();
-    expect(body.whatWasAdapted[0]).toMatchObject({
-      parameterId: "skill_fluency",
-      sourceScope: "CALLER",
-      confidence: 0.85,
-      callsApplied: 4,
-      overrideValue: 0.78,
-      defaultValue: 0.5,
-    });
-    expect(body.whatWasAdapted[0].updatedAt).toBe("2026-06-12T09:00:00.000Z");
+    expect("why" in body).toBe(false);
+    expect(body.nextAdaptation).toEqual([]);
   });
 });

--- a/apps/admin/tests/lib/rbac/policies/adaptations-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/adaptations-redact.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for redactAdaptationsForTier — the per-resource redactor that
+ * projects the full AdaptationsResponse onto the tier-appropriate
+ * shape. Whitelist-default-safe: a new sensitive field added to the
+ * raw response should NOT appear at the `redacted` tier unless the
+ * redactor's branch is explicitly updated.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  redactAdaptationsForTier,
+  isRedacted,
+} from "@/lib/rbac/policies/adaptations";
+import type { AdaptationsResponse } from "@/app/api/callers/[callerId]/adaptations/route";
+
+function makeRaw(overrides: Partial<AdaptationsResponse> = {}): AdaptationsResponse {
+  return {
+    callerId: "c1",
+    callerName: "Test Learner",
+    playbookId: "pb1",
+    playbookName: "Sample Course",
+    whatWasAdapted: [
+      {
+        parameterId: "p_clarity",
+        parameterName: "Clarity",
+        defaultValue: 0.5,
+        overrideValue: 0.72,
+        sourceScope: "CALLER",
+        confidence: 0.84,
+        callsApplied: 6,
+        updatedAt: "2026-06-12T10:00:00Z",
+      },
+      {
+        parameterId: "p_pace",
+        parameterName: "Pace",
+        defaultValue: 0.5,
+        overrideValue: 0.34,
+        sourceScope: "PLAYBOOK",
+        confidence: null,
+        callsApplied: 0,
+        updatedAt: "2026-06-10T10:00:00Z",
+      },
+    ],
+    why: [
+      {
+        callId: "call_2",
+        at: "2026-06-12T10:00:00Z",
+        rationale: "Learner asked for clearer recap — push clarity up",
+        direction: "up",
+        parameterId: "p_clarity",
+        parameterName: "Clarity",
+        delta: 0.1,
+      },
+      {
+        callId: "call_1",
+        at: "2026-06-10T10:00:00Z",
+        rationale: "Initial calibration based on intake survey",
+        direction: "down",
+        parameterId: "p_pace",
+        parameterName: "Pace",
+        delta: -0.16,
+      },
+    ],
+    nextAdaptation: [
+      {
+        goalId: "g1",
+        goalName: "Master fractions",
+        goalType: "LEARN",
+        progress: 0.4,
+        band: "mid",
+        guidance: "Build on prior foundations, connect to what they already know",
+        isAssessmentTarget: false,
+      },
+    ],
+    empty: false,
+    ...overrides,
+  };
+}
+
+describe("redactAdaptationsForTier — full tier", () => {
+  it("passes through every field of the raw response", () => {
+    const raw = makeRaw();
+    const out = redactAdaptationsForTier(raw, "full");
+    expect(out.viewerTier).toBe("full");
+    if (isRedacted(out)) throw new Error("expected non-redacted");
+    expect(out.whatWasAdapted).toEqual(raw.whatWasAdapted);
+    expect(out.why).toEqual(raw.why);
+    expect(out.nextAdaptation).toEqual(raw.nextAdaptation);
+    expect(out.empty).toBe(false);
+  });
+});
+
+describe("redactAdaptationsForTier — diagnostic tier", () => {
+  it("currently identical to 'full' (reserved for future debug fields)", () => {
+    const raw = makeRaw();
+    const out = redactAdaptationsForTier(raw, "diagnostic");
+    expect(out.viewerTier).toBe("diagnostic");
+    if (isRedacted(out)) throw new Error("expected non-redacted");
+    expect(out.whatWasAdapted).toEqual(raw.whatWasAdapted);
+  });
+});
+
+describe("redactAdaptationsForTier — redacted tier", () => {
+  it("strips numeric values from whatWasAdapted (only name + direction survive)", () => {
+    const raw = makeRaw();
+    const out = redactAdaptationsForTier(raw, "redacted");
+    if (!isRedacted(out)) throw new Error("expected redacted shape");
+    expect(out.whatWasAdapted).toEqual([
+      {
+        parameterId: "p_clarity",
+        parameterName: "Clarity",
+        direction: "up",
+        updatedAt: "2026-06-12T10:00:00Z",
+      },
+      {
+        parameterId: "p_pace",
+        parameterName: "Pace",
+        direction: "down",
+        updatedAt: "2026-06-10T10:00:00Z",
+      },
+    ]);
+    // Type-level + runtime check: numeric fields gone
+    const first = out.whatWasAdapted[0] as unknown as Record<string, unknown>;
+    expect("defaultValue" in first).toBe(false);
+    expect("overrideValue" in first).toBe(false);
+    expect("confidence" in first).toBe(false);
+    expect("callsApplied" in first).toBe(false);
+    expect("sourceScope" in first).toBe(false);
+  });
+
+  it("collapses 'why' to count + mostRecentAt (rationale text dropped)", () => {
+    const raw = makeRaw();
+    const out = redactAdaptationsForTier(raw, "redacted");
+    if (!isRedacted(out)) throw new Error("expected redacted shape");
+    expect(out.whyRedacted.count).toBe(2);
+    expect(out.whyRedacted.mostRecentAt).toBe("2026-06-12T10:00:00Z");
+    // The raw `why` array is NOT present on the redacted shape
+    expect("why" in out).toBe(false);
+  });
+
+  it("hides nextAdaptation entirely at the redacted tier", () => {
+    const raw = makeRaw();
+    const out = redactAdaptationsForTier(raw, "redacted");
+    if (!isRedacted(out)) throw new Error("expected redacted shape");
+    expect(out.nextAdaptation).toEqual([]);
+  });
+
+  it("classifies near-zero delta as 'hold'", () => {
+    const raw = makeRaw({
+      whatWasAdapted: [
+        {
+          parameterId: "p_steady",
+          parameterName: "Steady",
+          defaultValue: 0.5,
+          overrideValue: 0.501,
+          sourceScope: "CALLER",
+          confidence: 0.9,
+          callsApplied: 4,
+          updatedAt: "2026-06-12T10:00:00Z",
+        },
+      ],
+    });
+    const out = redactAdaptationsForTier(raw, "redacted");
+    if (!isRedacted(out)) throw new Error("expected redacted shape");
+    expect(out.whatWasAdapted[0].direction).toBe("hold");
+  });
+
+  it("returns mostRecentAt null when why is empty", () => {
+    const raw = makeRaw({ why: [] });
+    const out = redactAdaptationsForTier(raw, "redacted");
+    if (!isRedacted(out)) throw new Error("expected redacted shape");
+    expect(out.whyRedacted.count).toBe(0);
+    expect(out.whyRedacted.mostRecentAt).toBeNull();
+  });
+
+  it("preserves identity fields (callerId, callerName, playbookId, playbookName, empty)", () => {
+    const raw = makeRaw();
+    const out = redactAdaptationsForTier(raw, "redacted");
+    if (!isRedacted(out)) throw new Error("expected redacted shape");
+    expect(out.callerId).toBe("c1");
+    expect(out.callerName).toBe("Test Learner");
+    expect(out.playbookId).toBe("pb1");
+    expect(out.playbookName).toBe("Sample Course");
+    expect(out.empty).toBe(false);
+  });
+
+  it("tags the response with viewerTier='redacted'", () => {
+    const raw = makeRaw();
+    const out = redactAdaptationsForTier(raw, "redacted");
+    expect(out.viewerTier).toBe("redacted");
+  });
+
+  it("sorts why by `at` desc when picking mostRecentAt (defensive vs route order)", () => {
+    const raw = makeRaw({
+      why: [
+        {
+          callId: "old",
+          at: "2026-05-01T00:00:00Z",
+          rationale: "old",
+          direction: "up",
+          parameterId: null,
+          parameterName: null,
+          delta: 0.1,
+        },
+        {
+          callId: "new",
+          at: "2026-06-14T00:00:00Z",
+          rationale: "new",
+          direction: "down",
+          parameterId: null,
+          parameterName: null,
+          delta: -0.1,
+        },
+      ],
+    });
+    const out = redactAdaptationsForTier(raw, "redacted");
+    if (!isRedacted(out)) throw new Error("expected redacted shape");
+    expect(out.whyRedacted.mostRecentAt).toBe("2026-06-14T00:00:00Z");
+  });
+});

--- a/apps/admin/tests/lib/rbac/visibility.test.ts
+++ b/apps/admin/tests/lib/rbac/visibility.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for visibilityTierForRole — the role → tier mapping.
+ * Sibling to `tests/lib/rbac/policies/adaptations-redact.test.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+
+describe("visibilityTierForRole", () => {
+  it("returns 'redacted' for STUDENT", () => {
+    expect(visibilityTierForRole("STUDENT")).toBe("redacted");
+  });
+
+  it("returns 'redacted' for VIEWER (legacy alias)", () => {
+    expect(visibilityTierForRole("VIEWER")).toBe("redacted");
+  });
+
+  it("returns 'redacted' for TESTER", () => {
+    expect(visibilityTierForRole("TESTER")).toBe("redacted");
+  });
+
+  it("returns 'redacted' for DEMO", () => {
+    expect(visibilityTierForRole("DEMO")).toBe("redacted");
+  });
+
+  it("returns 'redacted' for SUPER_TESTER (below OPERATOR threshold)", () => {
+    expect(visibilityTierForRole("SUPER_TESTER")).toBe("redacted");
+  });
+
+  it("returns 'full' for OPERATOR", () => {
+    expect(visibilityTierForRole("OPERATOR")).toBe("full");
+  });
+
+  it("returns 'full' for EDUCATOR", () => {
+    expect(visibilityTierForRole("EDUCATOR")).toBe("full");
+  });
+
+  it("returns 'full' for ADMIN", () => {
+    expect(visibilityTierForRole("ADMIN")).toBe("full");
+  });
+
+  it("returns 'diagnostic' for SUPERADMIN", () => {
+    expect(visibilityTierForRole("SUPERADMIN")).toBe("diagnostic");
+  });
+
+  it("defaults to 'redacted' when role is undefined", () => {
+    expect(visibilityTierForRole(undefined)).toBe("redacted");
+  });
+});

--- a/docs/kb/guard-registry.md
+++ b/docs/kb/guard-registry.md
@@ -391,6 +391,7 @@ data-safety invariant.
 | `lib/contracts/registry.ts` (+ `types.ts`) | DB-backed `DataContract` registry (30s TTL) — producer/consumer shape agreement | **a** |
 | `lib/prompt/composition/compose-invariants.ts` | Runtime COMPOSE-stage invariants | **a** |
 | `.claude/rules/ai-to-db-guard.md` catalogue | ~15 AI-to-DB structural guards (validate-then-write) | **a** (see `invariants.md`) |
+| `.claude/rules/response-redaction.md` + `lib/rbac/visibility.ts` + `lib/rbac/policies/<resource>.ts` | Role-tiered field-level redaction at route boundary — `redacted` / `full` / `diagnostic` tiers; whitelist-default-safe. First wired on `/api/callers/[callerId]/adaptations` (Wave C3b — #1577 visibility-policy revision). | **a** |
 
 ## Plan-guard agents — `.claude/agents/`
 


### PR DESCRIPTION
## Summary

Closes the last data gap from #1685 — **gap #14 Adaptations RBAC** — by introducing a **role-tiered field-level redaction pattern** at the route boundary. Adaptations becomes VIEWER/STUDENT-readable WITHOUT breaking the OPERATOR+ safety property from master epic #1577 (TL flagged that as a deliberate decision; the redactor preserves it server-side rather than reverting it).

**Cumulative:** 12 of 13 retirement gaps closed. Only #10 (Export PDF, deferred) remains. Ready to flip \`NEXT_PUBLIC_HF_TAB_LAYOUT=retire\` after this lands.

## The pattern (the answer to "robust + extendable")

Three layers, reusable across any future route with tier-sensitive fields:

1. \`lib/rbac/visibility.ts::visibilityTierForRole(role)\` — role → tier (\`redacted\` / \`full\` / \`diagnostic\`). Coarse on purpose; three tiers, not seven.
2. \`lib/rbac/policies/<resource>.ts::redact<Resource>ForTier(raw, tier)\` — per-resource pure-function projection. Whitelist-default-safe — the redacted shape is a structurally distinct interface so a new sensitive field added to \`Raw\` does NOT auto-flow.
3. Response carries \`viewerTier\` discriminator. Client branches on this, not its own role copy — the server is the source of truth.

Route boundary becomes:
\`\`\`ts
const auth = await requireAuth("VIEWER");
if (isAuthError(auth)) return auth.error;
if (!studentAllowedToReadCaller(auth.session, callerId)) return ...;
const tier = visibilityTierForRole(auth.session.user.role);
const raw = await computeRaw(callerId);
return NextResponse.json(redactAdaptationsForTier(raw, tier));
\`\`\`

## What gets hidden at the \`redacted\` tier

| Field | Redacted shape |
|---|---|
| \`whatWasAdapted[].defaultValue\` / \`overrideValue\` | Dropped — only direction chip (\`up\` / \`down\` / \`hold\`) |
| \`whatWasAdapted[].sourceScope\` (SYSTEM/PLAYBOOK/CALLER) | Dropped — internal cascade layer |
| \`whatWasAdapted[].confidence\` + \`callsApplied\` | Dropped — AI-internal rollup metadata |
| \`why[].rationale\` (free-text REWARD log) | Dropped — collapsed to \`whyRedacted: { count, mostRecentAt }\` |
| \`why[].parameterId\` / \`delta\` / \`direction\` etc | Dropped — same |
| \`nextAdaptation[]\` | Dropped entirely — forced to \`[]\` (forward planning that would spoil the experience if learner pre-reads) |

OPERATOR/EDUCATOR/ADMIN get full payload (no behaviour change). SUPERADMIN tagged \`diagnostic\` for future debug fields.

## Verified by

- \`npx vitest run tests/lib/rbac tests/api/callers/adaptations-route.test.ts\` → **33/33 passing**
  - \`visibility.test.ts\` (10) — role-to-tier mapping per role (STUDENT/VIEWER/TESTER/SUPER_TESTER/DEMO → redacted; OPERATOR/EDUCATOR/ADMIN → full; SUPERADMIN → diagnostic)
  - \`adaptations-redact.test.ts\` (10) — full passthrough; redacted strips numeric/sourceScope/confidence/callsApplied; why collapses to count+date; nextAdaptation forced to []; near-zero delta classifies as 'hold'; mostRecentAt picks latest defensively
  - \`adaptations-route.test.ts\` (13) — STUDENT admitted for own caller; foreign caller refused; tier discriminator per role; redacted shape contract; sensitive-field-absence pinned
- Wider sweep \`npx vitest run tests/lib/rbac tests/api/callers tests/components/callers/snapshot-trust-footer-block.test.tsx\` → 147/147
- \`npx tsc --noEmit\` → 55 errors (under 166 ratchet baseline; same as main)
- Lint clean on the 4 new files

## Rule + registry

- \`.claude/rules/response-redaction.md\` documents the pattern as sibling to ai-to-db-guard / ai-read-grounding / verify-before-fix.
- \`docs/kb/guard-registry.md\` catalogues it as class (a) invariant.

## Test plan

- [ ] Log in as OPERATOR → \`/x/callers/<id>?tab=adaptations\` shows full cascade chips, numeric bars, rationale timeline, next-call preview
- [ ] Log in as STUDENT → \`/x/callers/<own-id>?tab=adaptations\` shows parameter names + direction chips + "N adjustments" summary; no rationale, no numbers, no next-call section
- [ ] STUDENT supplying foreign callerId → 403 scope mismatch
- [ ] After verifying both tiers render correctly → flip \`NEXT_PUBLIC_HF_TAB_LAYOUT=retire\` to retire legacy tabs