### PR TITLE
fix(api): Design preview routes use enrolledAt (not startedAt)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/conversation-artifacts-preview/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/conversation-artifacts-preview/route.ts
@@ -56,7 +56,7 @@ export async function GET(
 
   const enrollment = await prisma.callerPlaybook.findFirst({
     where: { playbookId: courseId, status: "ACTIVE" },
-    orderBy: { startedAt: "desc" },
+    orderBy: { enrolledAt: "desc" },
     select: {
       caller: { select: { id: true, name: true } },
     },

--- a/apps/admin/app/api/courses/[courseId]/memory-deltas-preview/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/memory-deltas-preview/route.ts
@@ -57,7 +57,7 @@ export async function GET(
 
   const enrollment = await prisma.callerPlaybook.findFirst({
     where: { playbookId: courseId, status: "ACTIVE" },
-    orderBy: { startedAt: "desc" },
+    orderBy: { enrolledAt: "desc" },
     select: {
       caller: { select: { id: true, name: true } },
     },

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary

`PrismaClientValidationError` thrown at runtime when opening the Design tab on a course with active enrollments. Both `conversation-artifacts-preview` and `memory-deltas-preview` routes queried `CallerPlaybook` with `orderBy: { startedAt: "desc" }` but the model has `enrolledAt`, not `startedAt`.

Pre-existing bug (TL flagged in pre-epic tsc audit); surfaced on hf-dev when the Journey tab mounted PreviewLens inline against The CIO/CTO Standard — Revision Aid course (which has active demo callers).

## Verified by

Live VM log on hf-dev surfaced the failing routes 4x in 2 minutes:

```
$ gcloud compute ssh hf-dev -- 'grep PrismaClientValidationError /tmp/hf-dev.log'

⨯ Error [PrismaClientValidationError]:
    at app/api/courses/[courseId]/conversation-artifacts-preview/route.ts:57:50
⨯ Error [PrismaClientValidationError]:
    at app/api/courses/[courseId]/memory-deltas-preview/route.ts:58:50
```

Schema proves the correct column name:

```
$ grep -A2 "model CallerPlaybook" apps/admin/prisma/schema.prisma

model CallerPlaybook {
  ...
  enrolledAt  DateTime  @default(now())   ← actual lifecycle column
  completedAt DateTime?
```

`npx tsc --noEmit` clean on both touched files after the fix (was emitting TS2353 + TS2551 pre-fix per the pre-epic drift audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)