### PR TITLE
feat(ielts): #1700 Phase 1 — migration bundle A/B/C/D

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 166,
+  "tsc_errors": 43,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -937,3 +937,55 @@ export interface ValidationWarning {
   path?: string;
   severity: "warning" | "error";
 }
+
+// ---------------------------------------------------------------------------
+// Session.metadata — general-purpose per-session bag (epic #1700 Migration A).
+//
+// All keys are optional. Writers set only the keys they own; readers default
+// missing keys to safe values. Distinct from `Session.voiceConfigSnapshot`
+// (voice-specific, set once at session-start).
+// ---------------------------------------------------------------------------
+
+/**
+ * Pinned card content rendered above SimChat for Part 2 cue card / Part 3
+ * topic-focus banner / Mock subPhase cue cards (Theme 3, story TBD).
+ */
+export interface PinnedCardContent {
+  /** Discriminator — drives the renderer variant. */
+  kind: "cueCard" | "topicFocus";
+  /** Cue card topic line OR Part 3 topic. */
+  topic: string;
+  /** Cue card bullets (kind="cueCard" only). */
+  bullets?: string[];
+  /** Optional secondary line beneath bullets (PPF prompt, note-taking instruction). */
+  secondaryNote?: string;
+  /** Part 3 focus area, e.g. "giving reasons" (kind="topicFocus" only). */
+  focusArea?: string;
+}
+
+/**
+ * Human-readable label for a CallScore.segmentKey value. Course-agnostic —
+ * IELTS uses ("p1", "Part 1") / ("p2", "Part 2") / ("p3", "Part 3");
+ * other courses define their own (Theme 6, story #1702).
+ */
+export interface SegmentLabel {
+  key: string;
+  label: string;
+  ordinal: number;
+}
+
+/** Per-criterion score delta + Part 3 focus delta (Theme 11). */
+export interface SessionScoreDeltas {
+  /** Map of parameter slug → previous-session score. Composer renders the diff. */
+  priorCriterionScores?: Record<string, number>;
+  /** Part 3 focus parameter slug + (current - prior) delta. */
+  focusDelta?: { parameterSlug: string; delta: number };
+}
+
+export interface SessionMetadata {
+  pinnedCard?: PinnedCardContent;
+  segmentLabels?: SegmentLabel[];
+  scoreDeltas?: SessionScoreDeltas;
+  /** Overall band estimate for Mock sessions — mean-of-12, half-band rounded (Theme 6). */
+  overallBand?: number;
+}

--- a/apps/admin/prisma/migrations/20260615162940_1700_ielts_pre_voice_migration_bundle/migration.sql
+++ b/apps/admin/prisma/migrations/20260615162940_1700_ielts_pre_voice_migration_bundle/migration.sql
@@ -1,0 +1,27 @@
+-- Epic #1700 — IELTS Pre-Voice Testing migration bundle (A/B/C/D).
+--
+-- All four columns are additive + nullable (A/D) or NOT NULL with a safe
+-- DEFAULT (B). No rewrites of existing rows; no unique-key widening; no
+-- CHECK constraints. Ship together in one /vm-cpp cycle so the four
+-- consuming stories (#1701/#1702/#1703/#1704) start from a stable schema.
+--
+-- Migration C is comment-only — `CallerModuleProgress.status` is a plain
+-- String column (no Postgres enum, no Prisma enum). Adding "LOCKED" as a
+-- permitted value requires no DDL; documentation lives in
+-- `schema.prisma` and the Theme 5 enforcement story.
+
+-- Migration A — Session.metadata (Theme 3 pinned card + Theme 6 segment
+-- labels + Theme 11 focus delta / overall band). Shape declared at
+-- `lib/types/json-fields.ts::SessionMetadata`.
+ALTER TABLE "Session" ADD COLUMN "metadata" JSONB;
+
+-- Migration B — CallerModuleProgress.incompleteAttempts (Theme 9).
+-- Story #1703 writer (`markModuleIncomplete`) increments atomically;
+-- waiver triggers on second exit. NOT NULL + DEFAULT 0 backfills cleanly.
+ALTER TABLE "CallerModuleProgress"
+  ADD COLUMN "incompleteAttempts" INTEGER NOT NULL DEFAULT 0;
+
+-- Migration D — CallScore.segmentKey (Theme 6). Free-text annotation
+-- column (course-agnostic). NOT part of any unique constraint — see
+-- epic #1700 decision 1 for the idempotence-key rationale.
+ALTER TABLE "CallScore" ADD COLUMN "segmentKey" TEXT;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -910,6 +910,14 @@ model Session {
   // Shape: `VoiceConfig` from lib/voice/types.ts (#1269 / #1270).
   voiceConfigSnapshot Json?
 
+  // Epic #1700 Migration A — general-purpose per-session metadata bag.
+  // Shape declared at `lib/types/json-fields.ts::SessionMetadata` (added
+  // alongside this column). Known keys today: `pinnedCard` (Theme 3),
+  // `segmentLabels` (Theme 6), `focusDelta` / `overallBand` (Theme 11).
+  // Distinct from `voiceConfigSnapshot` (voice-specific, set once at
+  // session-start). Write path: section-loaders + pipeline post-write.
+  metadata Json?
+
   startedAt DateTime  @default(now())
   endedAt   DateTime?
 
@@ -1862,6 +1870,16 @@ model CallScore {
   // the same (callId, parameterId) pair can produce SEPARATE scores per
   // sub-module — see the unique constraint below.
   moduleId String?
+
+  // Epic #1700 Migration D (Theme 6, story #1702) — annotation column
+  // recording which transcript segment produced this score. Free-text,
+  // course-agnostic (IELTS uses "p1" / "p2" / "p3"; future courses may
+  // use other labels via `Session.metadata.segmentLabels`). The
+  // `@@unique([callId, parameterId, moduleId])` key is INTENTIONALLY NOT
+  // widened — segmentKey is annotation, not idempotence key (see epic
+  // #1700 decision 1). PROSODY iterates segments via the existing
+  // `lib/curriculum/segment-mock-transcript.ts` helper.
+  segmentKey String?
 
   // Scoring result
   score      Float
@@ -2893,12 +2911,26 @@ model CallerModuleProgress {
   module   CurriculumModule @relation(fields: [moduleId], references: [id], onDelete: Cascade)
 
   mastery     Float     @default(0) // 0.0-1.0
-  status      String    @default("NOT_STARTED") // NOT_STARTED | IN_PROGRESS | COMPLETED
+  // Free-text status. Values currently in use:
+  //   NOT_STARTED | IN_PROGRESS | COMPLETED | MASTERED
+  // Epic #1700 Migration C — `LOCKED` added (Theme 5 unlock-gate state).
+  // Doc-only entry — the column stays plain String for backwards-compat;
+  // a CHECK constraint would reject pre-existing rows. Theme 5 enforces
+  // role-bypassed read-side gating; Theme 9 sets MASTERED on incomplete
+  // waiver (story #1703).
+  status      String    @default("NOT_STARTED")
   startedAt   DateTime?
   completedAt DateTime?
 
   lastCallId String? // Most recent call that updated this
   callCount  Int     @default(0) // How many calls touched this module
+
+  // Epic #1700 Migration B (Theme 9, story #1703) — count of incomplete
+  // session exits (< `moduleSettings.minSpeakingSec` or terminated
+  // GHOST/FAILED) recorded per (caller, module). `markModuleIncomplete`
+  // increments atomically; second exit (>= 1 prior) triggers the waiver
+  // policy — sets `status = "MASTERED"` regardless of mastery score.
+  incompleteAttempts Int @default(0)
 
   // #397 Phase 1 — per-LO running average. Shape:
   //   { [loRef: string]: { mastery: number; callCount: number } }


### PR DESCRIPTION
**Parent:** #1700 (Epic — IELTS Pre-Voice Testing).
**Gates:** #1701 (Theme 1 G8) / #1702 (Theme 6 segmentKey) / #1703 (Theme 9 incomplete-attempts) / #1704 (Theme 10 profile capture).

## What

Four schema additions bundled into one PR / one `/vm-cpp` cycle so the four Phase 1 stories start from a stable schema:

| Migration | Column | Story | Shape |
|---|---|---|---|
| A | `Session.metadata` | Theme 3 / 6 / 11 | `JSONB` nullable; shape declared at `lib/types/json-fields.ts::SessionMetadata` (4 optional keys — `pinnedCard`, `segmentLabels`, `scoreDeltas`, `overallBand`) |
| B | `CallerModuleProgress.incompleteAttempts` | #1703 (Theme 9) | `INTEGER NOT NULL DEFAULT 0` — safe backfill |
| C | `CallerModuleProgress.status` (LOCKED) | Theme 5 (Phase 2) | Doc-only. Column is plain `String` already; new value adds via comment update. **No DDL.** |
| D | `CallScore.segmentKey` | #1702 (Theme 6) | `TEXT` nullable. **NOT** added to `@@unique([callId, parameterId, moduleId])` — epic decision 1 |

## Why this shape (not the alternatives)

- **A — `Session.metadata Json?` over a sibling `SessionMetadata` table.** Json bag matches the existing `voiceConfigSnapshot Json?` precedent at `Session:911`. Three known keys today, no row-level locking required. Probed 2026-06-15 against the gap analysis (no general-purpose metadata bag exists on `Session`).
- **C is doc-only.** `CallerModuleProgress.status` is plain `String` with no enum/CHECK enforcement. Existing values in production: `NOT_STARTED` / `IN_PROGRESS` / `COMPLETED` / `MASTERED` (all observed in `lib/curriculum/track-progress.ts:665` + `lib/types/json-fields.ts:887`). Adding `LOCKED` is comment-only — Theme 5 will wire enforcement; #1703 sets `MASTERED` on waiver.
- **D leaves `@@unique` untouched.** Widening to `(callId, parameterId, moduleId, segmentKey)` would let one PROSODY pass write 3 rows per criterion per module — breaks idempotence. `segmentKey` is annotation only. (Epic #1700 decision 1.)

## Lane coordination

- **Owner (Lane A — Paul):** this PR. After merge, run `/vm-cpp` once to apply on hf-dev.
- **Lane B (Boaz):** waits for this PR to merge **and** hf-dev confirmation before starting #1702. Then `/vm-pull` to refresh.
- **Both lanes** continue from `origin/main` after the bundle lands.

## Test plan

- [ ] `/vm-cpp` on hf-dev — confirm `prisma migrate deploy` applies the 4 ALTERs without error
- [ ] `SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_name IN ('Session','CallerModuleProgress','CallScore') AND column_name IN ('metadata','incompleteAttempts','segmentKey')` — 3 rows, shapes match
- [ ] `npm run ctl check` on hf-dev (lint + tsc + tests) — passes
- [ ] Confirm no new fix-chain commits needed on hf_sandbox after deploy

## Verified by

- Hand-rolled migration SQL pinned against existing pattern (`20260614011407_1557_playbook_section_staleness/migration.sql`)
- `schema.prisma` model edits verified via grep against `apps/admin/lib/curriculum/track-progress.ts:665` + `apps/admin/lib/types/json-fields.ts:887` (status literals)
- `lib/types/json-fields.ts::SessionMetadata` shape derived from the gap analysis (`docs/draft-issues/ielts-pre-voice-gap-analysis.md` on main `2945a0e8`) — `pinnedCard` (Theme 3 line 78–80), `segmentLabels` (Theme 6 decision 1), `scoreDeltas` (Theme 11 line 66), `overallBand` (Theme 6 line 167)
- [unverified — verified by live apply at merge-time] Production-DB schema change confirmation