### PR TITLE
feat(rbac): Wave C5 — hf-rbac/require-tiered-redactor ESLint rule

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/adaptations/route.ts
@@ -18,6 +18,12 @@
  *   - SP5-D "Next call's adaptation" — `goalAdaptationGuidance`
  *     LOW/MID/HIGH preview.
  *
+ * @tieredVisibility — opt-in for the
+ * `hf-rbac/require-tiered-redactor` ESLint rule (Wave C5 of #1685).
+ * The rule keeps this route honest about wiring
+ * `visibilityTierForRole(...)` + `redactAdaptationsForTier(...)` before
+ * returning.
+ *
  * **Auth (Wave C3b — #1577 visibility-policy revision):**
  * `requireAuth("VIEWER")` + STUDENT path-param scope via
  * `studentAllowedToReadCaller`. The OPERATOR+ safety property from

--- a/apps/admin/eslint-rules/require-tiered-redactor.mjs
+++ b/apps/admin/eslint-rules/require-tiered-redactor.mjs
@@ -1,0 +1,172 @@
+/**
+ * Wave C5 (epic #1685) — Tier-sensitive response routes MUST wire the
+ * redactor pattern from `lib/rbac/visibility.ts` + `lib/rbac/policies/*`.
+ *
+ * **Opt-in:** routes opt into the check by adding `@tieredVisibility`
+ * to a JSDoc comment in the file (typically the `@api` block at the
+ * top of the route). Once tagged, the rule enforces:
+ *
+ *   1. The file imports `visibilityTierForRole` from `@/lib/rbac/visibility`.
+ *   2. The file imports at least one `redact*ForTier` function from
+ *      `@/lib/rbac/policies/*`.
+ *   3. The handler body calls `visibilityTierForRole(...)` somewhere.
+ *   4. The handler body calls a `redact*ForTier(...)` somewhere.
+ *
+ * The TypeScript types do the rest — the redactor's return shape is
+ * structurally distinct from the raw response, so a developer who
+ * imports the redactor but skips invoking it gets a type error on the
+ * `NextResponse.json(raw)` call.
+ *
+ * **Why opt-in over implicit:** we can't reliably detect tier-sensitive
+ * data from AST alone (a route may return sensitive data without ever
+ * importing a "TieredResponse" marker type). Opt-in lets the route
+ * author declare the property; the rule keeps them honest from that
+ * point forward.
+ *
+ * **What this prevents:** a developer tags `@tieredVisibility` (or
+ * inherits a tag from a file template) but forgets to invoke the
+ * redactor — sensitive fields leak to lower-tier viewers. Without this
+ * rule, the gap is only caught at PR review.
+ *
+ * Sibling to:
+ *   - `.claude/rules/response-redaction.md` — the pattern doc
+ *   - `lib/rbac/visibility.ts` — `visibilityTierForRole`
+ *   - `lib/rbac/policies/<resource>.ts` — per-resource redactor
+ *   - `tests/eslint-rules/require-tiered-redactor.test.ts` — RuleTester pins
+ */
+
+const TAG = "@tieredVisibility";
+const VISIBILITY_IMPORT = "@/lib/rbac/visibility";
+const POLICY_IMPORT_PREFIX = "@/lib/rbac/policies/";
+const REDACTOR_NAME_RE = /^redact[A-Z][A-Za-z0-9]*ForTier$/;
+
+// Skip files that legitimately mention `@tieredVisibility` as data (test
+// fixtures, rule source itself, KB docs). Same allow-list convention as
+// `no-bare-strategy-key.mjs`.
+const ALLOWLIST_PATH_FRAGMENTS = [
+  ".test.",
+  ".spec.",
+  "/__tests__/",
+  "/tests/",
+  "/eslint-rules/",
+  "/docs/",
+];
+
+function isAllowlistedFile(filename) {
+  if (!filename) return false;
+  return ALLOWLIST_PATH_FRAGMENTS.some((p) => filename.includes(p));
+}
+
+function fileHasTag(context) {
+  const sourceCode =
+    typeof context.getSourceCode === "function"
+      ? context.getSourceCode()
+      : context.sourceCode;
+  if (!sourceCode || typeof sourceCode.getText !== "function") return false;
+  const text = sourceCode.getText();
+  return typeof text === "string" && text.includes(TAG);
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Routes tagged @tieredVisibility must import + invoke visibilityTierForRole and a redact*ForTier function.",
+      url: "https://github.com/WANDERCOLTD/HF/blob/main/docs/kb/guard-registry.md#guard-require-tiered-redactor",
+    },
+    schema: [],
+    messages: {
+      missingVisibilityImport:
+        "@tieredVisibility route must import { visibilityTierForRole } from '@/lib/rbac/visibility'.",
+      missingPolicyImport:
+        "@tieredVisibility route must import a redactor (e.g. `redactAdaptationsForTier`) from '@/lib/rbac/policies/*'.",
+      missingVisibilityCall:
+        "@tieredVisibility route must call visibilityTierForRole(...) to derive the tier before redacting.",
+      missingRedactorCall:
+        "@tieredVisibility route must invoke the imported redact*ForTier(...) before returning. See .claude/rules/response-redaction.md.",
+    },
+  },
+  create(context) {
+    // Visitors always returned so smokeRule's probeVisitors sees them
+    // (the helper's mock context has no `getText`, so we can't check
+    // the tag at create-time). The visitors themselves short-circuit on
+    // files that don't carry the tag, keeping the rule dormant on
+    // every untagged file.
+    let hasVisibilityImport = false;
+    let hasPolicyImport = false;
+    const importedRedactorNames = new Set();
+    let visibilityCalled = false;
+    let redactorCalled = false;
+    let active = null; // lazy-init in Program — depends on source text
+
+    return {
+      Program() {
+        const filename = context.filename ?? context.getFilename?.();
+        if (isAllowlistedFile(filename)) {
+          active = false;
+          return;
+        }
+        active = fileHasTag(context);
+      },
+      ImportDeclaration(node) {
+        if (active === false) return;
+        const src = node.source && node.source.value;
+        if (typeof src !== "string") return;
+        if (src === VISIBILITY_IMPORT) {
+          for (const spec of node.specifiers || []) {
+            if (
+              spec.type === "ImportSpecifier" &&
+              spec.imported &&
+              spec.imported.name === "visibilityTierForRole"
+            ) {
+              hasVisibilityImport = true;
+            }
+          }
+        } else if (src.startsWith(POLICY_IMPORT_PREFIX)) {
+          for (const spec of node.specifiers || []) {
+            if (
+              spec.type === "ImportSpecifier" &&
+              spec.imported &&
+              REDACTOR_NAME_RE.test(spec.imported.name)
+            ) {
+              hasPolicyImport = true;
+              const localName =
+                spec.local && spec.local.name
+                  ? spec.local.name
+                  : spec.imported.name;
+              importedRedactorNames.add(localName);
+            }
+          }
+        }
+      },
+      CallExpression(node) {
+        if (active === false) return;
+        const callee = node.callee;
+        if (!callee) return;
+        if (callee.type === "Identifier") {
+          if (callee.name === "visibilityTierForRole") {
+            visibilityCalled = true;
+          } else if (importedRedactorNames.has(callee.name)) {
+            redactorCalled = true;
+          }
+        }
+      },
+      "Program:exit"(node) {
+        if (active !== true) return;
+        if (!hasVisibilityImport) {
+          context.report({ node, messageId: "missingVisibilityImport" });
+        }
+        if (!hasPolicyImport) {
+          context.report({ node, messageId: "missingPolicyImport" });
+        }
+        if (hasVisibilityImport && !visibilityCalled) {
+          context.report({ node, messageId: "missingVisibilityCall" });
+        }
+        if (hasPolicyImport && !redactorCalled) {
+          context.report({ node, messageId: "missingRedactorCall" });
+        }
+      },
+    };
+  },
+};

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -22,6 +22,7 @@ import noHardcodedSpecSlug from "./eslint-rules/no-hardcoded-spec-slug.mjs";
 import noBareStrategyKey from "./eslint-rules/no-bare-strategy-key.mjs";
 import noUnscopedCallerIdRoute from "./eslint-rules/no-unscoped-caller-id-route.mjs";
 import requireHtmlSafetyComment from "./eslint-rules/require-html-safety-comment.mjs";
+import requireTieredRedactor from "./eslint-rules/require-tiered-redactor.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -226,6 +227,16 @@ const eslintConfig = defineConfig([
           "no-bare-strategy-key": noBareStrategyKey,
         },
       },
+      // Wave C5 of epic #1685 — opt-in @tieredVisibility tag enforces
+      // that the route imports + invokes the
+      // `lib/rbac/visibility.ts` + `lib/rbac/policies/*` pattern.
+      // Hardens the whitelist-default-safe property of Wave C3b's
+      // visibility-policy.
+      "hf-rbac": {
+        rules: {
+          "require-tiered-redactor": requireTieredRedactor,
+        },
+      },
     },
     rules: {
       "hf-curriculum/no-unscoped-slug-lookup": "error",
@@ -278,6 +289,14 @@ const eslintConfig = defineConfig([
       // `StrategyKey` enum fails CI. Allow-list (in the rule itself):
       // `lib/goals/strategies/registry.ts` (the alias map) + test files.
       "hf-goals/no-bare-strategy-key": "error",
+
+      // Wave C5 of epic #1685 — error severity from day 1.
+      // Opt-in: routes self-declare with `@tieredVisibility` JSDoc tag.
+      // No false-positives possible — the rule is dormant on untagged
+      // files. The first wired route (Wave C3b) is
+      // `app/api/callers/[callerId]/adaptations/route.ts`; new tier-sensitive
+      // routes copy the tag pattern.
+      "hf-rbac/require-tiered-redactor": "error",
 
       // #1395 / #1423 — Block app/api routes from importing the 5 lib/ops/*
       // files that instantiate their own PrismaClient (bypass the singleton).

--- a/apps/admin/tests/eslint-rules/require-tiered-redactor.test.ts
+++ b/apps/admin/tests/eslint-rules/require-tiered-redactor.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Behavioural + structural tests for `eslint-rules/require-tiered-redactor.mjs` —
+ * Wave C5 of epic #1685.
+ *
+ * Pins:
+ *   - Dormant on files without `@tieredVisibility` (no false positives — every
+ *     untagged route in the repo must still pass).
+ *   - Fires when tagged file is missing the visibility import.
+ *   - Fires when tagged file is missing a redactor import.
+ *   - Fires when imports present but the helpers aren't actually invoked.
+ *   - Passes when tagged file imports + invokes both.
+ *   - Accepts redactors named `redact<Anything>ForTier` (regex contract).
+ */
+
+import { describe, it } from "vitest";
+import { RuleTester } from "eslint";
+import rule from "../../eslint-rules/require-tiered-redactor.mjs";
+import { smokeRule } from "./_helpers.js";
+
+describe("require-tiered-redactor", () => {
+  it("has the structural pieces (meta.docs.url to KB, messages, create)", () => {
+    smokeRule("require-tiered-redactor", rule as never);
+  });
+});
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+tester.run("require-tiered-redactor", rule as never, {
+  valid: [
+    {
+      name: "untagged route — rule dormant",
+      code: `
+        import { NextResponse } from "next/server";
+        import { requireAuth } from "@/lib/permissions";
+        export async function GET() {
+          const auth = await requireAuth("VIEWER");
+          return NextResponse.json({ ok: true, sensitive: 42 });
+        }
+      `,
+    },
+    {
+      name: "tagged route with full wiring",
+      code: `
+        /**
+         * @tieredVisibility
+         */
+        import { NextResponse } from "next/server";
+        import { visibilityTierForRole } from "@/lib/rbac/visibility";
+        import { redactAdaptationsForTier } from "@/lib/rbac/policies/adaptations";
+        export async function GET() {
+          const tier = visibilityTierForRole("OPERATOR");
+          const raw = { x: 1 };
+          return NextResponse.json(redactAdaptationsForTier(raw, tier));
+        }
+      `,
+    },
+    {
+      name: "tagged route with renamed redactor import (local alias)",
+      code: `
+        /** @tieredVisibility */
+        import { visibilityTierForRole } from "@/lib/rbac/visibility";
+        import { redactAdaptationsForTier as redact } from "@/lib/rbac/policies/adaptations";
+        export async function GET() {
+          const tier = visibilityTierForRole("STUDENT");
+          return Response.json(redact({}, tier));
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "tagged route missing the visibility import (call error cascade-suppressed)",
+      code: `
+        /** @tieredVisibility */
+        import { redactAdaptationsForTier } from "@/lib/rbac/policies/adaptations";
+        export async function GET() {
+          return Response.json(redactAdaptationsForTier({}, "full"));
+        }
+      `,
+      errors: [{ messageId: "missingVisibilityImport" }],
+    },
+    {
+      name: "tagged route missing the redactor import (call error cascade-suppressed)",
+      code: `
+        /** @tieredVisibility */
+        import { visibilityTierForRole } from "@/lib/rbac/visibility";
+        export async function GET() {
+          const tier = visibilityTierForRole("OPERATOR");
+          return Response.json({ tier });
+        }
+      `,
+      errors: [{ messageId: "missingPolicyImport" }],
+    },
+    {
+      name: "tagged route imports both but never calls visibilityTierForRole",
+      code: `
+        /** @tieredVisibility */
+        import { visibilityTierForRole } from "@/lib/rbac/visibility";
+        import { redactAdaptationsForTier } from "@/lib/rbac/policies/adaptations";
+        export async function GET() {
+          return Response.json(redactAdaptationsForTier({}, "full"));
+        }
+      `,
+      errors: [{ messageId: "missingVisibilityCall" }],
+    },
+    {
+      name: "tagged route imports both but never invokes the redactor",
+      code: `
+        /** @tieredVisibility */
+        import { visibilityTierForRole } from "@/lib/rbac/visibility";
+        import { redactAdaptationsForTier } from "@/lib/rbac/policies/adaptations";
+        export async function GET() {
+          const tier = visibilityTierForRole("OPERATOR");
+          return Response.json({ tier });
+        }
+      `,
+      errors: [{ messageId: "missingRedactorCall" }],
+    },
+    {
+      name: "tagged route with neither import — all 4 messages fire",
+      code: `
+        /** @tieredVisibility */
+        export async function GET() {
+          return Response.json({ secret: 42 });
+        }
+      `,
+      errors: [
+        { messageId: "missingVisibilityImport" },
+        { messageId: "missingPolicyImport" },
+      ],
+    },
+  ],
+});

--- a/docs/kb/guard-registry.md
+++ b/docs/kb/guard-registry.md
@@ -71,6 +71,7 @@ The meta-ratchet (`check-guard-kb-links.ts`) holds this at 12/12.
 | [`hf-security/no-secrets-in-client`](#guard-no-secrets-in-client) | Plaintext credentials / secret-shaped literals in `"use client"` files (they ship in the browser bundle) | HF-J / 2026-06-11 | **a** |
 | [`hf-config/no-hardcoded-spec-slug`](#guard-no-hardcoded-spec-slug) | Hardcoded spec-slug literals (`TUT-001`, `GOAL-001`, …) in `lib/`+`app/` runtime; use `config.specs.*`. **Active (error)** after HF-I sweep | HF-I / 2026-06-11 | **b** |
 | [`hf-goals/no-bare-strategy-key`](#guard-no-bare-strategy-key) | Bare string literals assigned to `Goal.progressStrategy` outside the canonical `StrategyKey` enum; allow-list covers the strategies registry alias map + test files | #1599 | **a** |
+| [`hf-rbac/require-tiered-redactor`](#guard-require-tiered-redactor) | Routes tagged `@tieredVisibility` (JSDoc) must import + invoke `visibilityTierForRole(...)` and a `redact<Resource>ForTier(...)` from `lib/rbac/policies/*`; hardens the whitelist-default-safe property of the visibility-policy pattern | #1685 Wave C5 | **a** |
 
 ### Guard detail
 
@@ -392,6 +393,7 @@ data-safety invariant.
 | `lib/prompt/composition/compose-invariants.ts` | Runtime COMPOSE-stage invariants | **a** |
 | `.claude/rules/ai-to-db-guard.md` catalogue | ~15 AI-to-DB structural guards (validate-then-write) | **a** (see `invariants.md`) |
 | `.claude/rules/response-redaction.md` + `lib/rbac/visibility.ts` + `lib/rbac/policies/<resource>.ts` | Role-tiered field-level redaction at route boundary — `redacted` / `full` / `diagnostic` tiers; whitelist-default-safe. First wired on `/api/callers/[callerId]/adaptations` (Wave C3b — #1577 visibility-policy revision). | **a** |
+| <a id="guard-require-tiered-redactor"></a>`eslint-rules/require-tiered-redactor.mjs` (rule `hf-rbac/require-tiered-redactor`) | Opt-in via `@tieredVisibility` JSDoc tag — routes that opt in MUST import + invoke `visibilityTierForRole(...)` + a `redact<Resource>ForTier(...)` function. Hardens the whitelist-default-safe property by catching a missing redactor at lint time (Wave C5 of epic #1685). | **a** |
 
 ## Plan-guard agents — `.claude/agents/`
 


### PR DESCRIPTION
## Summary

Closes the deferred (3) item from the post-#1685 followup. Hardens the **whitelist-default-safe** property of the Wave C3b visibility-policy pattern by enforcing redactor wiring at lint time.

The pattern is **opt-in via \`@tieredVisibility\` JSDoc tag**. Routes that opt in MUST:

1. Import \`{ visibilityTierForRole }\` from \`@/lib/rbac/visibility\`
2. Import a \`redact<Resource>ForTier\` function from \`@/lib/rbac/policies/*\`
3. Invoke both inside the handler

Untagged routes are dormant — no false-positive surface. Currently tagged routes: \`/api/callers/[callerId]/adaptations\` (Wave C3b). New tier-sensitive routes opt in by copying the JSDoc tag.

## Cascade behaviour

When an import is missing, the corresponding "call missing" error is suppressed — developer fixes one issue at a time. Once the import lands, the call-missing error surfaces on the next lint pass.

## Why opt-in over implicit detection

We can't reliably detect tier-sensitive data from AST alone — a route may return sensitive data without ever importing a marker type. Opt-in lets the route author declare the property; the rule keeps them honest from that point forward. Discovery of untagged-but-tier-sensitive routes stays a human concern (and is the agent-sweep's job per \`.claude/rules/response-redaction.md\`).

## File-path allow-list

Test files, the rule source itself, and KB docs are exempt — they legitimately mention \`@tieredVisibility\` as data (fixtures, examples). Same convention as \`no-bare-strategy-key.mjs\`.

## Verified by

- \`npx vitest run tests/eslint-rules/require-tiered-redactor.test.ts\` → **9/9 passing**
  - smokeRule structural check (meta.type, KB back-link, messages, visitors returned)
  - Untagged file → rule dormant
  - Tagged + full wiring (including local-aliased redactor import) → valid
  - Tagged missing visibility import → 1 error (call error cascade-suppressed)
  - Tagged missing redactor import → 1 error (call error cascade-suppressed)
  - Tagged imports both but never calls visibilityTierForRole → 1 error
  - Tagged imports both but never invokes redactor → 1 error
  - Tagged with neither import → 2 errors
- Lint sweep on the entire \`app/api/**\` tree → 0 false positives on untagged routes
- Manual probe: removed redactor import from \`adaptations/route.ts\` → \`hf-rbac/require-tiered-redactor\` fires with \`missingPolicyImport\`; restored → clean

## Doc updates

- \`docs/kb/guard-registry.md\` — KB row in the ESLint rules table + \`<a id="guard-require-tiered-redactor">\` anchor for the \`meta.docs.url\` back-link convention
- \`app/api/callers/[callerId]/adaptations/route.ts\` — adds the \`@tieredVisibility\` tag to the JSDoc header

## Test plan

- [ ] Confirm lint passes on main branch after merge
- [ ] Manual probe: temporarily remove a needed import from the adaptations route → confirm rule fires
- [ ] Confirm follow-on routes (e.g. when \`/skills-evidence\` gets a redactor) can be wired by copying the JSDoc tag