### PR TITLE
fix(journey): populate select options + route Preview clicks to Inspector

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -64,6 +64,11 @@ interface PreviewLensProps {
    *  section-summary alongside the live edit sidetray. Pure addition
    *  — no behaviour change when prop omitted (today's mount path). */
   onSelectSection?: (section: ComposeSectionKey | null) => void;
+  /** Journey tab Phase 4 — when true, suppress the legacy click-to-edit
+   *  sidetray and route bubble clicks only through `onSelectSection`
+   *  (which the Journey tab uses to mount editors in the Inspector pane).
+   *  Default false preserves the existing Design-tab behaviour. */
+  suppressSidetray?: boolean;
 }
 
 interface SessionFlowResp {
@@ -148,7 +153,7 @@ const SIDETRAY_TITLES: Record<SessionFlowLens, string> = {
   moduleVisibility: "Module visibility — when modules get named",
 };
 
-export function PreviewLens({ courseId, onSelectSection }: PreviewLensProps): React.ReactElement {
+export function PreviewLens({ courseId, onSelectSection, suppressSidetray = false }: PreviewLensProps): React.ReactElement {
   const { demoAnnotationsVisible } = useChatContext();
   const [mode, setMode] = useState<ViewMode>("educator");
   const [flow, setFlow] = useState<SessionFlowResp | null>(null);
@@ -212,7 +217,10 @@ export function PreviewLens({ courseId, onSelectSection }: PreviewLensProps): Re
 
   const openSidetray = useCallback((lensId: string) => {
     const mapped = SIDETRAY_LENS_MAP[lensId];
-    if (mapped) setSidetrayLens(mapped);
+    // Journey tab (Phase 4) suppresses the sidetray so the educator
+    // doesn't see two overlapping editors — the bubble click routes
+    // only through the Inspector pane via onSelectSection.
+    if (mapped && !suppressSidetray) setSidetrayLens(mapped);
     // #1623 — Designer Inspector hook. The sidetray (edit affordance)
     // and the Inspector (preview-summary surface) are independent: the
     // sidetray stays the educator's "tweak this" entry; the Inspector
@@ -221,7 +229,7 @@ export function PreviewLens({ courseId, onSelectSection }: PreviewLensProps): Re
       const section = SIDETRAY_LENS_TO_SECTION[lensId];
       if (section) onSelectSection(section);
     }
-  }, [onSelectSection]);
+  }, [onSelectSection, suppressSidetray]);
 
   const closeSidetray = useCallback(() => {
     setSidetrayLens(null);

--- a/apps/admin/components/journey-controls/JourneySelect.tsx
+++ b/apps/admin/components/journey-controls/JourneySelect.tsx
@@ -61,13 +61,13 @@ export function JourneySelect({
             id={`hf-jf-${contract.id}`}
             className="hf-input hf-jf-input"
             value={f.draftValue}
-            disabled={disabled || f.isSaving}
+            disabled={disabled || f.isSaving || opts.length === 0}
             data-testid={`hf-jf-select-${contract.id}`}
             onChange={(e) => void onPick(e.target.value)}
           >
             {opts.length === 0 ? (
               <option value="" disabled>
-                no options
+                Options load at runtime — use the JSON button to set
               </option>
             ) : (
               opts.map((o) => (

--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -18,6 +18,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { ComposeSectionKey } from "@/lib/compose";
+import { getSettingsForSection } from "@/lib/journey/section-staleness-bridge";
 
 import { CommandPalette } from "./CommandPalette";
 import { JourneyInspectorPanel } from "./JourneyInspectorPanel";
@@ -57,6 +59,23 @@ export function CourseJourneyTab({
     [selection],
   );
 
+  // Bubble click in PreviewLens → mount the first matching setting in
+  // the Inspector pane. Replaces the legacy click-to-edit sidetray
+  // (which we also suppress on PreviewLens below) so the educator
+  // never sees two overlapping editors.
+  const handlePreviewSectionSelect = useCallback(
+    (section: ComposeSectionKey | null) => {
+      if (!section) {
+        selection.setSettingId(null);
+        return;
+      }
+      const settings = getSettingsForSection(section);
+      const first = settings[0];
+      if (first) selection.setSettingId(first.id);
+    },
+    [selection],
+  );
+
   return (
     <JourneySettingMutatorProvider
       courseId={courseId}
@@ -79,7 +98,11 @@ export function CourseJourneyTab({
           />
         </aside>
         <main className="hf-journey-pane hf-journey-canvas">
-          <PreviewLens courseId={courseId} />
+          <PreviewLens
+            courseId={courseId}
+            onSelectSection={handlePreviewSectionSelect}
+            suppressSidetray
+          />
         </main>
         <aside
           className="hf-journey-pane hf-journey-inspector"

--- a/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
+++ b/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
@@ -64,6 +64,7 @@ export function JourneyInspectorPanel({
       <JourneyField
         contract={contract}
         value={value}
+        options={contract.options}
         onSave={(next) => ctx.saveSetting(selectedSettingId, next)}
       />
       <div className="hf-journey-inspector-actions">

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -148,6 +148,11 @@ const G2_FIRST_CALL_MODE: JourneySettingContract = {
         "Baseline Assessment mode runs the pre-test stop at the top of Call 1.",
     },
   ],
+  options: [
+    { value: "onboarding", label: "Onboarding (default)" },
+    { value: "teach_immediately", label: "Teach Immediately" },
+    { value: "baseline_assessment", label: "Baseline Assessment" },
+  ],
 };
 
 const G2_WELCOME_MESSAGE: JourneySettingContract = {
@@ -239,6 +244,11 @@ const G2_BASELINE_ASSESSMENT_DEPTH: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "firstCallMode", hint: "assessment depth" }],
+  options: [
+    { value: "light", label: "Light — 3 questions" },
+    { value: "standard", label: "Standard — 5 questions" },
+    { value: "deep", label: "Deep — 8 questions" },
+  ],
 };
 
 // =============================================================
@@ -261,6 +271,11 @@ const G3_TEACHING_STYLE: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "modePolicy" }],
+  options: [
+    { value: "socratic", label: "Socratic — ask, don't tell" },
+    { value: "direct", label: "Direct — explain and check" },
+    { value: "adaptive", label: "Adaptive — read the room" },
+  ],
 };
 
 const G3_MODULE_SEQUENCE_POLICY: JourneySettingContract = {
@@ -277,6 +292,11 @@ const G3_MODULE_SEQUENCE_POLICY: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "modulesGate", hint: "module ordering" }],
+  options: [
+    { value: "strict", label: "Strict prerequisites" },
+    { value: "interleaved", label: "Interleaved review" },
+    { value: "learner_led", label: "Learner picks next" },
+  ],
 };
 
 const G3_FIRST_CALL_CURRICULUM_FOCUS: JourneySettingContract = {
@@ -329,6 +349,11 @@ const G4_MODE_POLICY: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "modePolicy" }],
+  options: [
+    { value: "teach", label: "Teach — explain & ask" },
+    { value: "quiz", label: "Quiz — drill & test" },
+    { value: "mix", label: "Mix — adaptive ratio" },
+  ],
 };
 
 const G4_TOLERANCE_ACCURACY: JourneySettingContract = {
@@ -446,6 +471,12 @@ const G4_MAX_MASTERY_TIER: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "moduleMastery" }],
+  options: [
+    { value: "FOUNDATION", label: "Foundation" },
+    { value: "DEVELOPING", label: "Developing" },
+    { value: "PRACTITIONER", label: "Practitioner" },
+    { value: "DISTINCTION", label: "Distinction" },
+  ],
 };
 
 const G4_USE_FRESH_MASTERY: JourneySettingContract = {
@@ -479,6 +510,11 @@ const G4_SCORING_MODE: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "instructions" }],
+  options: [
+    { value: "strict", label: "Strict" },
+    { value: "lenient", label: "Lenient" },
+    { value: "adaptive", label: "Adaptive" },
+  ],
 };
 
 const G4_RECAP_ENABLED: JourneySettingContract = {
@@ -632,6 +668,10 @@ const G5_MID_JOURNEY_STOP_TRIGGER: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "modulesGate" }],
+  options: [
+    { value: "mastery_threshold", label: "Mastery threshold reached" },
+    { value: "session_count", label: "After N sessions" },
+  ],
 };
 
 const G5_NPS_STOP: JourneySettingContract = {
@@ -719,6 +759,11 @@ const G6_COMPLETION_CRITERIA: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "offboarding" }],
+  options: [
+    { value: "all_modules", label: "All modules mastered" },
+    { value: "any_module", label: "Any module mastered" },
+    { value: "mastery_threshold", label: "Overall mastery threshold" },
+  ],
 };
 
 // =============================================================
@@ -739,6 +784,11 @@ const G7_MODULE_VISIBILITY: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "modulesGate", hint: "module naming" }],
+  options: [
+    { value: "mention_from_call_1", label: "Mention module names from Call 1" },
+    { value: "hide_until_call_2", label: "Hide until Call 2" },
+    { value: "hide_until_learner_picks", label: "Hide until learner picks" },
+  ],
 };
 
 const G7_LO_MASTERY_THRESHOLD: JourneySettingContract = {
@@ -771,6 +821,11 @@ const G7_CALL_COUNT_POLICY: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [],
+  options: [
+    { value: "hard_cap", label: "Hard cap — refuse after limit" },
+    { value: "soft_cap", label: "Soft cap — warn but allow" },
+    { value: "unlimited", label: "Unlimited" },
+  ],
 };
 
 const G7_MAX_CALLS_PER_DAY: JourneySettingContract = {
@@ -820,6 +875,11 @@ const G7_REWARD_STRATEGY: JourneySettingContract = {
   },
   previewLocators: [{ section: "instructions" }],
   writeGate: "operator-only",
+  options: [
+    { value: "learner_mastery", label: "Learner mastery growth" },
+    { value: "educator_drift", label: "Educator-target drift" },
+    { value: "blended", label: "Blended (mastery + drift)" },
+  ],
 };
 
 // =============================================================

--- a/apps/admin/lib/journey/setting-contracts.ts
+++ b/apps/admin/lib/journey/setting-contracts.ts
@@ -225,6 +225,12 @@ export interface JourneySettingContract {
   /** Power-user only — JSON path the "Edit as JSON" fallback opens to.
    *  Defaults to `storagePath` when omitted. */
   jsonFallbackPath?: string;
+
+  /** Enum values for `select` / `multi-select` / `radio` controls.
+   *  When present, the Inspector mounts these as the dropdown options.
+   *  Absent for free-form selects whose options come from a runtime
+   *  fetch (e.g. voiceId — needs the provider's voice catalog). */
+  options?: ReadonlyArray<{ value: string; label: string }>;
 }
 
 // Re-export for sibling registries (Settings tab Voice subset).

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary

Two related Journey-tab UX fixes surfaced during live testing on hf-dev.

### 1. "no options" in select dropdowns
`JourneyInspectorPanel` mounted `<JourneyField>` without passing `options`, and the registry didn't carry the enum vocabulary. Added optional `options?: ReadonlyArray<{value, label}>` to `JourneySettingContract`; populated **12 select-type entries** that have known enum vocab:
- firstCallMode / baselineAssessmentDepth / teachingStyle / moduleSequencePolicy / modePolicy / maxMasteryTier / scoringMode / midJourneyStopTrigger / completionCriteria / moduleVisibility / callCountPolicy / rewardStrategy

Inspector now passes `contract.options` through. Settings without static enums (intakeSpecId, intakeConsentFlow, firstCallCurriculumFocus, voice provider/ID) keep `undefined` options and show "Options load at runtime — use the JSON button to set" with the dropdown disabled.

### 2. Sidetray opens over the Inspector
PreviewLens's legacy `openSidetray` fires alongside `onSelectSection`, so clicking a Preview bubble in the Journey tab opened the old Design-tab editing sidetray ON TOP of the Inspector pane (two overlapping editors).

Added `suppressSidetray?` prop to PreviewLens; `CourseJourneyTab` sets it `true` and wires `onSelectSection` through `getSettingsForSection()` (Phase 2A bridge) to mount the first matching setting in the Inspector. The educator now sees ONE editor in the RH pane.

## Verified by

- `npx vitest run tests/lib/journey tests/components/journey-tab tests/components/journey-controls` — **97/97 pass**
- `npx tsc --noEmit` — clean on touched files
- `npx eslint` — 0 errors / 0 warnings on touched files
- Default `suppressSidetray=false` preserves the existing Design-tab behaviour — no regression for the legacy mount path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)