### PR TITLE
fix(journey): scope JourneyTargets to the slider repeater only

### DIFF
--- a/apps/admin/components/course-design/FirstSessionSettings.tsx
+++ b/apps/admin/components/course-design/FirstSessionSettings.tsx
@@ -59,6 +59,15 @@ interface FirstSessionSettingsProps {
   courseId: string;
   playbookConfig?: PlaybookConfig | Record<string, unknown> | null;
   onSaved?: () => void;
+  /** Hide the signpost summary list (Goals / About You / Knowledge Check
+   *  / AI Intro Call / Welcome / Onboarding phases). Used by the Journey
+   *  tab where those settings already have their own LH menu entries —
+   *  the duplication is confusing. Default false preserves the existing
+   *  Design-tab full-panel behaviour. */
+  hideSignposts?: boolean;
+  /** Hide the Call 1 mode picker. Used by the Journey tab where Call 1
+   *  mode is its own G2 setting. Default false. */
+  hideModePicker?: boolean;
 }
 
 type FirstCallMode = "onboarding" | "teach_immediately" | "baseline_assessment";
@@ -143,6 +152,8 @@ export function FirstSessionSettings({
   courseId,
   playbookConfig,
   onSaved,
+  hideSignposts = false,
+  hideModePicker = false,
 }: FirstSessionSettingsProps): React.ReactElement {
   const cfg = (playbookConfig ?? {}) as PlaybookConfig;
 
@@ -317,24 +328,27 @@ export function FirstSessionSettings({
       </div>
 
       {/* ── Signpost: read-only summary of SessionFlowEditor state ───────── */}
-      <div className="hf-mb-lg">
-        <div className="hf-text-xs hf-text-muted hf-mb-xs">
-          Owned by Session Flow editor — scroll up to edit
+      {hideSignposts ? null : (
+        <div className="hf-mb-lg">
+          <div className="hf-text-xs hf-text-muted hf-mb-xs">
+            Owned by Session Flow editor — scroll up to edit
+          </div>
+          <div className="hf-card-compact">
+            {signpost.map((row) => (
+              <div
+                key={row.label}
+                className="hf-flex hf-gap-sm hf-items-center hf-list-row"
+              >
+                <div className="hf-flex-1 hf-text-sm">{row.label}</div>
+                <div className="hf-text-xs hf-text-muted">{row.value}</div>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="hf-card-compact">
-          {signpost.map((row) => (
-            <div
-              key={row.label}
-              className="hf-flex hf-gap-sm hf-items-center hf-list-row"
-            >
-              <div className="hf-flex-1 hf-text-sm">{row.label}</div>
-              <div className="hf-text-xs hf-text-muted">{row.value}</div>
-            </div>
-          ))}
-        </div>
-      </div>
+      )}
 
       {/* ── firstCallMode radio group (#790 S8) ───────────────────────────── */}
+      {hideModePicker ? null : (
       <div className="hf-mb-lg">
         <div className="hf-text-sm hf-text-bold hf-mb-xs">
           How should the AI approach the learner&apos;s first call?
@@ -361,6 +375,7 @@ export function FirstSessionSettings({
           ))}
         </div>
       </div>
+      )}
 
       {/* ── firstSessionTargets repeater (#784 S6) ────────────────────────── */}
       <div className="hf-mb-lg">

--- a/apps/admin/components/journey-controls/JourneyTargets.tsx
+++ b/apps/admin/components/journey-controls/JourneyTargets.tsx
@@ -52,6 +52,8 @@ export function JourneyTargets({ contract, value }: JourneyFieldProps) {
           courseId={ctx.courseId}
           playbookConfig={ctx.playbookConfig}
           onSaved={ctx.onCompoundSaved}
+          hideSignposts
+          hideModePicker
         />
       </div>
     </_FieldShell>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",


### PR DESCRIPTION
## Summary

Live testing on hf-dev showed **Call 1 skill targets** in the Journey Inspector opening a duplicate panel — the wrapped `FirstSessionSettings` rendered its full Design-tab shape including the signpost summary (Goals / About You / Knowledge Check / AI intro / Welcome / Onboarding phases — all already in G1 of the LH menu) AND the first-call mode radio group (already a G2 setting). Educator sees the same settings twice.

## Fix

Added two additive optional props to `FirstSessionSettings`:
- `hideSignposts?: boolean` — hides the read-only signpost summary list
- `hideModePicker?: boolean` — hides the Call 1 mode radio group

Both default `false` so Design-tab behaviour is unchanged. `JourneyTargets` passes both `true`, leaving ONLY the per-parameter slider repeater — which is what *Call 1 skill targets* is supposed to be.

## Wrap-only constraint preserved

Phase 1's reuse-finder flagged FirstSessionSettings as "wrap-only — do not refactor". The changes here are purely additive (new optional props with safe defaults). No logic removed, no behaviour change in the existing Design-tab mount path, no existing tests touched.

## Verified by

- `npx vitest run tests/components/journey-controls/JourneyTargets.test.tsx` — 3/3 pass
- `npx tsc --noEmit` — clean on touched files
- `npx eslint components/course-design/FirstSessionSettings.tsx components/journey-controls/JourneyTargets.tsx` — 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)