### PR TITLE
feat(journey): #1701 — Theme 1 G8 module-scoped settings (6 IELTS keys)

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -883,6 +883,133 @@ const G7_REWARD_STRATEGY: JourneySettingContract = {
 };
 
 // =============================================================
+// G8 — Module-scoped settings (6) — #1701 (epic #1700 Theme 1)
+// =============================================================
+//
+// Per-module knobs at `Playbook.config.modules[].settings.*`, addressed
+// by `arrayKey: "id"`. Phase 1 scope: 6 IELTS-required keys. Theme 1b
+// adds dedicated primitives for min/target + array-of-structs shapes;
+// Phase 1 uses `json-fallback` for those (testers are OPERATOR+).
+//
+// Downstream readers (compose transforms / endSession / cue scheduler /
+// EXTRACT) are gated by HF_FLAG_IELTS_MODULE_SETTINGS during the
+// migration window per epic #1700 decision 5.
+
+const G8_MODULE_QUESTION_TARGET: JourneySettingContract = {
+  id: "moduleQuestionTarget",
+  group: "G8",
+  educatorLabel: "Question target",
+  helpText: "Min and target number of questions the tutor asks in this module — e.g. {min: 10, target: 13}.",
+  storagePath: {
+    path: "config.modules[].settings.questionTarget",
+    arrayKey: "id",
+  },
+  control: "json-fallback",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions", hint: "question count directive" }],
+};
+
+const G8_MODULE_MIN_SPEAKING_SEC: JourneySettingContract = {
+  id: "moduleMinSpeakingSec",
+  group: "G8",
+  educatorLabel: "Min learner speaking time (sec)",
+  helpText: "Module-scoped completion gate. endSession marks the call incomplete below this threshold (Theme 9 / #1703).",
+  storagePath: {
+    path: "config.modules[].settings.minSpeakingSec",
+    arrayKey: "id",
+  },
+  control: "number",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["sequence-policy"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+const G8_MODULE_CUE_CARD_POOL: JourneySettingContract = {
+  id: "moduleCueCardPool",
+  group: "G8",
+  educatorLabel: "Cue card pool",
+  helpText: "Array of {topic, bullets} for Part 2 monologue. Session start picks one; pinned into Session.metadata.pinnedCard.",
+  storagePath: {
+    path: "config.modules[].settings.cueCardPool",
+    arrayKey: "id",
+  },
+  control: "json-fallback",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "instructions", hint: "cue card content" }],
+};
+
+const G8_MODULE_CLOSING_LINE: JourneySettingContract = {
+  id: "moduleClosingLine",
+  group: "G8",
+  educatorLabel: "Closing line (verbatim)",
+  helpText: 'Module-specific closing line. e.g. Assessment closes with "That gives me a good picture…".',
+  storagePath: {
+    path: "config.modules[].settings.closingLine",
+    arrayKey: "id",
+  },
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["offboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding", hint: "closing line" }],
+};
+
+const G8_MODULE_FIRST_TIME_ORIENTATION_LINE: JourneySettingContract = {
+  id: "moduleFirstTimeOrientationLine",
+  group: "G8",
+  educatorLabel: "First-time orientation line",
+  helpText: 'One-shot per-module orientation — e.g. Part 2 "In Part 2 you\'ll speak for 2 minutes…". Gated by `orientationShown` on CallerModuleProgress.',
+  storagePath: {
+    path: "config.modules[].settings.firstTimeOrientationLine",
+    arrayKey: "id",
+  },
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["onboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "onboarding", hint: "orientation line" }],
+};
+
+const G8_MODULE_SCHEDULED_CUES: JourneySettingContract = {
+  id: "moduleScheduledCues",
+  group: "G8",
+  educatorLabel: "Scheduled cues",
+  helpText: 'Array of {at, text} for time-keyed tutor/examiner speech (e.g. {at: 45, text: "15 seconds left"}). Consumed by the Theme 2 cue scheduler at runtime.',
+  storagePath: {
+    path: "config.modules[].settings.scheduledCues",
+    arrayKey: "id",
+  },
+  control: "json-fallback",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+// =============================================================
 // Registry
 // =============================================================
 
@@ -939,6 +1066,13 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G7_MAX_CALLS_PER_DAY,
   G7_ASSESSMENT_READINESS_THRESHOLD,
   G7_REWARD_STRATEGY,
+  // G8 (6) — #1701 module-scoped settings
+  G8_MODULE_QUESTION_TARGET,
+  G8_MODULE_MIN_SPEAKING_SEC,
+  G8_MODULE_CUE_CARD_POOL,
+  G8_MODULE_CLOSING_LINE,
+  G8_MODULE_FIRST_TIME_ORIENTATION_LINE,
+  G8_MODULE_SCHEDULED_CUES,
 ];
 
 export const JOURNEY_SETTINGS_BY_ID: Readonly<
@@ -948,9 +1082,9 @@ export const JOURNEY_SETTINGS_BY_ID: Readonly<
 export const JOURNEY_SETTINGS_BY_GROUP: Readonly<
   Record<JourneyGroup, readonly JourneySettingContract[]>
 > = (() => {
-  const groups = ["G1", "G2", "G3", "G4", "G5", "G6", "G7"] as const;
+  const groups = ["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8"] as const;
   const out: Record<JourneyGroup, JourneySettingContract[]> = {
-    G1: [], G2: [], G3: [], G4: [], G5: [], G6: [], G7: [],
+    G1: [], G2: [], G3: [], G4: [], G5: [], G6: [], G7: [], G8: [],
   };
   for (const s of JOURNEY_SETTINGS) {
     // Settings-group entries should not appear in JOURNEY_SETTINGS — the

--- a/apps/admin/lib/journey/setting-groups.ts
+++ b/apps/admin/lib/journey/setting-groups.ts
@@ -52,6 +52,16 @@ export const JOURNEY_GROUPS = {
     caption: "What gets taught next",
     phaseFilter: "Scoring",
   },
+  G8: {
+    // #1701 (epic #1700 Theme 1) — module-scoped settings layer.
+    // Keys live at `Playbook.config.modules[].settings.*`, addressed by
+    // `arrayKey: "id"`. Scope to 6 IELTS-required keys in Phase 1;
+    // Theme 1b adds dedicated primitives for the min/target + array-of-
+    // structs shapes (Phase 1 uses `json-fallback`).
+    label: "Module-scoped settings",
+    caption: "Per-module knobs (cue cards, completion gates, scripted lines)",
+    phaseFilter: "Module",
+  },
 } as const;
 
 export type JourneyGroup = keyof typeof JOURNEY_GROUPS;
@@ -66,6 +76,7 @@ export const JOURNEY_PHASE_FILTERS = [
   "Mid-journey",
   "End",
   "Scoring",
+  "Module",
 ] as const;
 
 export type JourneyPhaseFilter = (typeof JOURNEY_PHASE_FILTERS)[number];

--- a/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
+++ b/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
@@ -22,10 +22,11 @@ describe("CommandPalette — Phase 5 (#1706)", () => {
     expect(screen.getByTestId("hf-cmdk-input")).toBeInTheDocument();
   });
 
-  it("indexes all 56 settings (45 journey + 11 voice)", () => {
-    expect(JOURNEY_SETTINGS.length).toBe(45);
+  it("indexes all 62 settings (51 journey + 11 voice)", () => {
+    // #1701 (Theme 1) added 6 G8 entries → journey bumped 45 → 51 → palette 56 → 62.
+    expect(JOURNEY_SETTINGS.length).toBe(51);
     expect(VOICE_SETTINGS.length).toBe(11);
-    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(56);
+    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(62);
   });
 
   it("typing narrows results by substring on educatorLabel", () => {

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -7,9 +7,9 @@
  *   3. Every composeImpact.sections[] element is a valid ComposeSectionKey
  *   4. Every composeImpact.kinds[] element is a valid ComposeImpactKind
  *   5. No duplicate ids within JOURNEY_SETTINGS
- *   6. Every group G1..G7 has entries
- *   7. Exact group counts: G1:5 G2:6 G3:4 G4:17 G5:3 G6:4 G7:6
- *   8. JOURNEY_SETTINGS.length === 45
+ *   6. Every group G1..G8 has entries
+ *   7. Exact group counts: G1:5 G2:6 G3:4 G4:17 G5:3 G6:4 G7:6 G8:6
+ *   8. JOURNEY_SETTINGS.length === 51 (45 base + 6 G8 from #1701)
  *   9. VOICE_SETTINGS.length === 11
  *  10. Cross-registry `interruptSensitivity` shares storagePath
  *  11. writeGate === "operator-only" → composeImpact.requiresReprompt
@@ -17,7 +17,7 @@
  *      that change pipeline behaviour need explicit reprompt; pure
  *      operator gates have no compose impact and don't need it)
  *  12. previewLocators[].section references valid ComposeSectionKey
- *  13. JOURNEY_PHASE_FILTERS has exactly 7 values including "All"
+ *  13. JOURNEY_PHASE_FILTERS has exactly 8 values including "All" + "Module" (#1701)
  */
 
 import { describe, it, expect } from "vitest";
@@ -95,10 +95,12 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G5.length).toBe(3);
     expect(JOURNEY_SETTINGS_BY_GROUP.G6.length).toBe(4);
     expect(JOURNEY_SETTINGS_BY_GROUP.G7.length).toBe(6);
+    // #1701 — G8 module-scoped settings (Phase 1: 6 IELTS-required keys)
+    expect(JOURNEY_SETTINGS_BY_GROUP.G8.length).toBe(6);
   });
 
-  it("(8) JOURNEY_SETTINGS.length === 45", () => {
-    expect(JOURNEY_SETTINGS.length).toBe(45);
+  it("(8) JOURNEY_SETTINGS.length === 51", () => {
+    expect(JOURNEY_SETTINGS.length).toBe(51);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {
@@ -131,9 +133,12 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     }
   });
 
-  it("(13) JOURNEY_PHASE_FILTERS has exactly 7 values including 'All'", () => {
-    expect(JOURNEY_PHASE_FILTERS.length).toBe(7);
+  it("(13) JOURNEY_PHASE_FILTERS has exactly 8 values including 'All'", () => {
+    // 7 distinct phase chips + "All" — bumped from 7 in #1701 to add
+    // the "Module" chip for G8 module-scoped settings.
+    expect(JOURNEY_PHASE_FILTERS.length).toBe(8);
     expect(JOURNEY_PHASE_FILTERS).toContain("All");
+    expect(JOURNEY_PHASE_FILTERS).toContain("Module");
   });
 });
 
@@ -154,6 +159,37 @@ describe("Voice registry — secondary integrity pins", () => {
       for (const l of s.autoEnableLinks ?? []) {
         expect(allIds.has(l.targetId), `${s.id} autoEnableLink → ${l.targetId} (missing)`).toBe(true);
       }
+    }
+  });
+});
+
+describe("G8 module-scoped settings — #1701 shape pins", () => {
+  const G8_IDS = [
+    "moduleQuestionTarget",
+    "moduleMinSpeakingSec",
+    "moduleCueCardPool",
+    "moduleClosingLine",
+    "moduleFirstTimeOrientationLine",
+    "moduleScheduledCues",
+  ];
+
+  it("registry exposes all 6 G8 keys", () => {
+    for (const id of G8_IDS) {
+      expect(JOURNEY_SETTINGS_BY_ID[id], `missing G8 entry: ${id}`).toBeDefined();
+      expect(JOURNEY_SETTINGS_BY_ID[id].group).toBe("G8");
+    }
+  });
+
+  it("every G8 entry uses structured storagePath with arrayKey:'id'", () => {
+    // Module-scoped settings address `Playbook.config.modules[].settings.*`
+    // and MUST resolve per-module via the modules array — no bare string
+    // path can encode that. Decision in `setting-contracts.ts` ADR Q1.
+    for (const id of G8_IDS) {
+      const entry = JOURNEY_SETTINGS_BY_ID[id];
+      expect(typeof entry.storagePath, `${id} storagePath should be structured, not bare`).toBe("object");
+      const sp = entry.storagePath as { path: string; arrayKey?: string };
+      expect(sp.path).toMatch(/^config\.modules\[\]\.settings\./);
+      expect(sp.arrayKey).toBe("id");
     }
   });
 });

--- a/apps/admin/tests/lib/journey/section-staleness-bridge.test.ts
+++ b/apps/admin/tests/lib/journey/section-staleness-bridge.test.ts
@@ -64,8 +64,10 @@ describe("section-staleness-bridge — Phase 2B derivation helpers", () => {
   it("every setting either feeds a section OR is post-call/sequence/runtime", () => {
     for (const s of JOURNEY_SETTINGS) {
       if (s.composeImpact.sections.length > 0) continue;
-      // No sections — must be a non-section-content kind.
-      const validNoSection = ["scoring-weight", "sequence-policy", "persona-style"];
+      // No sections — must be a non-section-content kind. Widened in #1701
+      // to include "stop-timing" for G8 cue-scheduler entries (consumed by
+      // Theme 2 cue scheduler at runtime, not by the composer).
+      const validNoSection = ["scoring-weight", "sequence-policy", "persona-style", "stop-timing"];
       const overlap = s.composeImpact.kinds.some((k) => validNoSection.includes(k));
       expect(
         overlap,


### PR DESCRIPTION
**Parent:** #1700 (Epic — IELTS Pre-Voice Testing).
**Closes:** #1701.
**Gates:** #1703 (reads `moduleMinSpeakingSec`) and #1704 (Boaz wires `profileFieldsToCapture` similarly).

## What

Adds **G8 — Module-scoped settings** to the Journey Inspector with 6 IELTS-required keys at `Playbook.config.modules[].settings.*`.

| Key | Control | Compose section |
|---|---|---|
| `moduleQuestionTarget` | `json-fallback` (no Phase 1 primitive for min/target pair) | `instructions` |
| `moduleMinSpeakingSec` | `number` | — (runtime gate read by endSession) |
| `moduleCueCardPool` | `json-fallback` (no array-of-structs primitive) | `instructions` |
| `moduleClosingLine` | `text` | `offboarding` |
| `moduleFirstTimeOrientationLine` | `text` | `onboarding` |
| `moduleScheduledCues` | `json-fallback` (no array-of-structs primitive) | — (runtime, consumed by Theme 2 cue scheduler) |

Phase 1 scope per epic #1700 risk register — Theme 1b will add dedicated primitives for the min/target + array-of-structs shapes. Phase 1 uses `json-fallback` because testers are OPERATOR+.

## Why this shape

- **Structured `StoragePathStruct` with `arrayKey: "id"`** is mandatory for all 6 entries — module-scoped settings can't compress to a bare dot-path (Tech Lead Q1 ruling in `setting-contracts.ts` ADR §1). Pinned by a new `G8 module-scoped settings — #1701 shape pins` sub-describe.
- **Downstream readers stay gated by `HF_FLAG_IELTS_MODULE_SETTINGS`** (epic #1700 decision 5) — compose transforms / `endSession` / cue scheduler / EXTRACT will branch on the flag. This PR only registers the entries; no compose code reads G8 yet.
- **`composeImpact.sections = []`** for runtime-only keys (`moduleMinSpeakingSec`, `moduleScheduledCues`). Established pattern from G7_CALL_COUNT_POLICY / G7_MAX_CALLS_PER_DAY.
- **`previewLocators`** point at the section each key feeds — the Inspector hover ↔ Preview bubble sync (Phase 4) picks them up automatically via `getSettingsForSection`.

## Test updates

Existing registry-completeness vitests touched:
- `(6)` widened to G1..G8
- `(7)` added `G8.length === 6`
- `(8)` total bumped from 45 → 51
- `(13)` `JOURNEY_PHASE_FILTERS.length` bumped from 7 → 8 (added `"Module"` chip)

New sub-describe `G8 module-scoped settings — #1701 shape pins`:
- All 6 G8 keys exist under `JOURNEY_SETTINGS_BY_ID`
- Every G8 entry uses structured `storagePath` with `arrayKey: "id"` and a path starting with `config.modules[].settings.`

## Test plan

- [x] `tests/lib/journey/registry-completeness.test.ts` — 17/17 green (15 existing + 2 new G8 pins)
- [ ] `/vm-cp` after merge — code-only, no migration
- [ ] After merge: post final G8 contract (file path + entry id list) in #1700 thread so Boaz can wire #1704

## Verified by

```
$ ./node_modules/.bin/vitest run tests/lib/journey/registry-completeness.test.ts --reporter=verbose
…
 ✓ tests/lib/journey/registry-completeness.test.ts > … > (7) exact group counts match the audit 0ms
 ✓ tests/lib/journey/registry-completeness.test.ts > … > (8) JOURNEY_SETTINGS.length === 51 0ms
 ✓ tests/lib/journey/registry-completeness.test.ts > … > (13) JOURNEY_PHASE_FILTERS has exactly 8 values including 'All' 0ms
 ✓ tests/lib/journey/registry-completeness.test.ts > … > G8 module-scoped settings — #1701 shape pins > registry exposes all 6 G8 keys 0ms
 ✓ tests/lib/journey/registry-completeness.test.ts > … > G8 module-scoped settings — #1701 shape pins > every G8 entry uses structured storagePath with arrayKey:'id' 0ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
```
