### PR TITLE
docs(lattice): name the 4-pillar guard infrastructure + bake survey discipline

### DIFF
--- a/.claude/rules/lattice-survey.md
+++ b/.claude/rules/lattice-survey.md
@@ -1,0 +1,157 @@
+# The Lattice — pre-coding sibling survey
+
+> **The Lattice** is the umbrella name for HF's four interconnected guard
+> systems: **Chain Contracts** (cross-stage invariants in
+> [`docs/CHAIN-CONTRACTS.md`](../../docs/CHAIN-CONTRACTS.md)), **Guards**
+> (ESLint rules under `apps/admin/eslint-rules/`, catalogued in
+> [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md)),
+> **Cascade** (effective-value resolvers under `apps/admin/lib/cascade/`),
+> and **Rules** (the discipline files under `.claude/rules/*.md`).
+>
+> The Lattice is **multi-axis** (cross-stage × code × layers × discipline),
+> **load-bearing** (engineers feel the weight when they bypass it), and
+> **extensible** (new nodes attach without weakening existing ones — the
+> "survives hardening" classification in
+> [`docs/kb/guards-process.md`](../../docs/kb/guards-process.md)).
+>
+> This file holds the **pre-coding side** of the Lattice — a survey
+> discipline applied BEFORE writing code that touches the Lattice. It is
+> the structural answer to the 2026-06-16 #1703 fingerprint where three
+> contract risks (guard #1252 violation, track-progress.ts sticky-waiver
+> race, MASTERED-vs-COMPLETED convention conflict) were introduced
+> silently in a single helper because the author skipped the survey.
+
+## Rule: Survey the Lattice before touching it
+
+Before writing OR modifying any code that mutates a shared DB column,
+crosses a chain-stage boundary, registers a new spec/contract/guard, or
+extends an AI write/read path, you MUST run the survey below. The
+survey is a 60–90 second discipline; it consistently saves multi-hour
+rework loops.
+
+```
+Identify the surface → Map siblings → Read the contracts →
+  Decide convergence → Only then write
+```
+
+## When this applies
+
+Any code path where ANY of the following are true:
+
+1. **DB column mutation** — your code calls `prisma.<X>.{create|update|upsert|delete*|*many}` or writes a column that other code reads.
+2. **Chain-stage boundary** — your code sits on the producer or consumer side of an adaptive-loop edge (EXTRACT / AGGREGATE / REWARD / ADAPT / SUPERVISE / COMPOSE / SESSION-end / SESSION-start).
+3. **New guard or contract** — you're adding an ESLint rule, a chain-contract invariant, a CHAIN-CONTRACTS sub-contract, or a `.claude/rules/*.md` file.
+4. **AI write or read path** — your code lands a `@ai-call` annotation, drives `prisma.*` writes from LLM output, or asserts facts about a specific entity from LLM text.
+5. **Cascade-eligible knob** — your code introduces or mutates a setting that has a domain/group/system fallback chain.
+
+If none apply, the survey is not required.
+
+## The survey (run before writing)
+
+For the surface you're about to touch:
+
+1. **Identify the surface in concrete terms.** Name the DB columns, files, or stage boundaries. Don't be abstract.
+2. **Map every existing writer/reader.** Use `qmd search` first; fall back to `grep -rn` if needed.
+   ```
+   qmd search "<column or function name> write"
+   grep -rn "prisma\.<modelName>\.\(create\|update\|upsert\)" apps/admin/lib apps/admin/app
+   ```
+   Open every match. Note what each one writes/reads and under what intent.
+3. **Read the contract catalogues row-by-row.**
+   - [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md) — every active guard
+   - [`.claude/rules/ai-to-db-guard.md`](./ai-to-db-guard.md) — chokepoint writers
+   - [`.claude/rules/ai-read-grounding.md`](./ai-read-grounding.md) — chokepoint readers
+   - [`docs/CHAIN-CONTRACTS.md`](../../docs/CHAIN-CONTRACTS.md) — cross-stage invariants
+   - [`docs/CONTRACTS-PLAYBOOK-CURRICULUM.md`](../../docs/CONTRACTS-PLAYBOOK-CURRICULUM.md) — Playbook/Curriculum surface
+4. **Cross-check for the four classic risk shapes:**
+
+   | Risk shape | What to look for |
+   |---|---|
+   | **Sibling-writer drift** | Two writers to the same column with different intents → does one clobber the other? Are they in separate transactions? |
+   | **Default-deny gates** | Does an ESLint rule require a precondition (e.g. `courseStyle === "structured"` for `CallerModuleProgress`)? Does your code respect it? |
+   | **Cascade respect** | Is the value cascadable (in `lib/cascade/knob-keys.ts`)? Are you reading via the resolver, or directly from a layer? |
+   | **Convention conflict** | Does the column have multiple in-use values (e.g. `MASTERED` vs `COMPLETED`)? Pick the existing DB convention; presentation layer maps it. |
+
+5. **Decide convergence with sibling writers.** If two writers can disagree, design the agreement (sticky-marker, ordering, locking) BEFORE writing the second one.
+6. **THEN write.** Include the survey result in the PR's `## Verified by` section so the reader can re-check.
+
+## Pattern: survey-then-write
+
+```typescript
+// BAD: jump to implementation
+// (You write a clever helper. It clobbers a sibling writer's invariant.
+//  The race is silent until production data drifts.)
+
+// GOOD: survey-then-write
+// 1. `qmd search "callerModuleProgress write"` → 7 sites
+// 2. Read each: track-progress (mastery), pipeline (call-count), admin (reset), …
+// 3. Cross-check guard-registry: #1252 default-deny by courseStyle.
+// 4. Decide: my helper coexists with track-progress via sticky-waiver marker
+//    (incompleteAttempts >= 2 + status=COMPLETED). Document in track-progress.
+// 5. NOW write the helper AND the sticky-waiver guard in track-progress.
+```
+
+## When the survey saves time
+
+A 90-second survey would have caught all three risk shapes in #1703:
+
+| Skipped | Cost when uncaught |
+|---|---|
+| Sibling-writer survey on `CallerModuleProgress` | track-progress.ts:665 clobbers waived status on next pipeline run (silent un-advance) |
+| Guard-registry read | #1252 ESLint failure at push (rework + post-CI redo) |
+| Convention check | `MASTERED` written where `COMPLETED` is the DB convention (silent label drift) |
+
+## Existing enforcement
+
+| Location | Mechanism | What it prevents |
+|---|---|---|
+| This rule | Author discipline — `## Verified by` PR section MUST cite the survey result | Skipped surveys reaching code review (the 2026-06-16 #1703 fingerprint) |
+| `qmd search` over [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md) | Catalogued guards — survey step 3 | Author missing an ESLint rule that gates the surface |
+| ESLint rules under `apps/admin/eslint-rules/` | Build-time | Bypass attempts that slip past the survey |
+| Sibling rule files in this directory | Per-surface discipline | Pattern reuse without the survey is structurally near-identical to having done one |
+| Convention: NEVER cite "I followed the rule" without the survey result | PR review | A claimed-but-unverified survey reaching merge |
+
+## When NOT to apply
+
+- Trivial typo / comment-only fixes
+- README / docs commits that don't reference Lattice entries
+- Reverts (the reverted commit IS the survey)
+- Greenfield code that touches no existing column, no chain-stage boundary, no shared registry, and no AI path
+
+## Why the Lattice name
+
+Four pillars, interlocked, load-bearing, extensible:
+
+- **C**hain Contracts × **G**uards × **C**ascade × **R**ules
+- A lattice grows by attaching nodes; old nodes don't weaken
+- "Off-Lattice change" / "Lattice violation" / "Lattice check" reads naturally
+- Distinct from "scaffold" (already used for class **b** guards), "guard" (subset), "contract" (subset)
+
+## Producer ↔ consumer pairing (Preview-lens discovery)
+
+A setting that has a registry entry but no consuming transform is a
+**producer-only Lattice entry**. The Inspector shows it; the operator
+edits it; the Preview lens shows a "section stale" chip — but the
+composed prompt content does not change because no transform reads the
+key.
+
+This is a Lattice violation in its own right: the registry promises the
+setting affects a section, but the transform that renders that section
+doesn't honour the promise. The Preview lens becomes misleading.
+
+**Rule:** when you register a new G-group entry (or a new VOICE entry,
+or any setting with non-empty `composeImpact.sections`), you MUST land
+the consuming transform in the same PR OR file a follow-on with the
+matching `composeImpact.sections[]` rows so the gap is tracked.
+
+The 2026-06-16 #1701 G8 cohort intentionally landed as producer-only
+(per epic #1700 decision 5 — `HF_FLAG_IELTS_MODULE_SETTINGS`); the
+consumers are Phase 2 work (Themes 8, 10, plus the closing/orientation
+transform wires). Tracked at <follow-on issue TBD>.
+
+## Escalation
+
+If the survey turns up a contract gap (an existing pair of sibling writers
+with no convergence design), document it in the PR body under
+`## Lattice gap` and file a follow-on. Do NOT silently make your code the
+third party to an existing two-writer disagreement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,18 @@ Both configured in `.mcp.json` — auto-connect on project open.
 
 ---
 
+## ⚠️ MANDATORY: The Lattice — survey before you touch it
+
+**The Lattice** is HF's umbrella for four interlocked guard systems: **Chain Contracts** (cross-stage invariants — [`docs/CHAIN-CONTRACTS.md`](./docs/CHAIN-CONTRACTS.md)) × **Guards** (ESLint rules — [`docs/kb/guard-registry.md`](./docs/kb/guard-registry.md)) × **Cascade** (effective-value resolvers — `apps/admin/lib/cascade/`) × **Rules** (`.claude/rules/*.md`).
+
+**Before writing OR modifying any code that mutates a shared DB column, crosses a chain-stage boundary, registers a new guard/contract, or extends an AI write/read path, you MUST run the 60–90 second sibling-writer survey** in [`.claude/rules/lattice-survey.md`](./.claude/rules/lattice-survey.md).
+
+The survey: identify the surface → map every existing writer/reader (qmd + grep) → read the contract catalogues row-by-row → cross-check the 4 classic risk shapes (sibling-writer drift, default-deny gates, cascade respect, convention conflict) → decide convergence → only then write.
+
+Skipping the survey is how the 2026-06-16 #1703 fingerprint happened — three contract risks introduced silently in a single helper because no one mapped sibling writers first. Every PR's `## Verified by` section MUST cite the survey result for code that touches the Lattice.
+
+---
+
 ## ⚠️ MANDATORY: You CAN hit authenticated API routes via the VM
 
 **Do not say "I can't authenticate"** — you can. The hf-dev VM has seeded SUPERADMIN credentials (`admin@test.com` / `admin123`) on the local DB and can mint a next-auth session cookie via curl. Use this whenever you need to verify a session-gated endpoint without asking the operator to load it in the browser.


### PR DESCRIPTION
## What

Coins **"the Lattice"** as the umbrella name for HF's four interlocked guard systems:

- **Chain Contracts** — cross-stage invariants in [`docs/CHAIN-CONTRACTS.md`](https://github.com/WANDERCOLTD/HF/blob/main/docs/CHAIN-CONTRACTS.md)
- **Guards** — ESLint rules under `apps/admin/eslint-rules/`, catalogued in [`docs/kb/guard-registry.md`](https://github.com/WANDERCOLTD/HF/blob/main/docs/kb/guard-registry.md)
- **Cascade** — effective-value resolvers under `apps/admin/lib/cascade/`
- **Rules** — discipline files under `.claude/rules/*.md`

Two files only — pure docs:

- `.claude/rules/lattice-survey.md` (new) — the **pre-coding sibling-writer survey**. Mandatory before writing or modifying code that mutates a shared DB column, crosses a chain-stage boundary, registers a new guard/contract, or extends an AI write/read path.
- `CLAUDE.md` (modified) — adds the MANDATORY anchor so every session loads the rule on start.

## Why now (urgent docs-only land)

Lane B (Boaz) is about to start #1702 and #1704. The survey discipline catches the same class of contract risks that the 2026-06-16 #1703 fingerprint surfaced (sibling-writer drift, default-deny gate violation, convention conflict — all three introduced silently in a single helper because no one mapped sibling writers first).

Shipping the rule on main NOW means Boaz's first `claude` session in `~/projects/HF-1702` loads the discipline. Bundling it in #1703's code PR would mean Boaz could start before the rule is live.

## The survey (60–90s discipline)

```
1. Identify the surface concretely (DB columns / files / stage boundaries)
2. Map every existing writer/reader (qmd search, then grep -rn)
3. Read the contract catalogues row-by-row
4. Cross-check 4 risk shapes:
   - Sibling-writer drift
   - Default-deny gates
   - Cascade respect
   - Convention conflict
5. Decide convergence with siblings BEFORE writing
6. Cite the survey result in the PR's ## Verified by section
```

## Producer ↔ consumer pairing rule

The rule also encodes the **producer ↔ consumer pairing** rule for new G-group / V entries: a setting that registers with the Lattice but has no consuming transform creates a misleading "section stale" chip in the Preview lens. Consumers must land in the same PR or a tracked follow-on.

The #1701 G8 cohort is the live producer-only example (intentional per epic #1700 decision 5 — `HF_FLAG_IELTS_MODULE_SETTINGS`). Phase 2 themes wire the consumers.

## Out of scope (deferred to #1703)

The new `hf-curriculum/no-bare-module-progress-update` ESLint rule and the `markModuleIncomplete` chokepoint helper land in #1703 (Lane A Theme 9 — story-in-flight). Their `guard-registry.md` + `ai-to-db-guard.md` rows ship with #1703 because they reference code that doesn't exist on main yet.

## Test plan

- [ ] Boaz's first session in `~/projects/HF-1702` reads `.claude/rules/lattice-survey.md` at session start
- [ ] CLAUDE.md MANDATORY anchor renders correctly on GitHub
- [ ] `gh-pr-create.sh` `## Verified by` gate validates the section is present

## Verified by

- [verified] feedback_lattice_guard_umbrella.md (operator memory, 2026-06-16 originSessionId 198f5033) — alignment with already-coined naming
- [verified] sibling-rule structural shape against `.claude/rules/agent-report-verification.md`, `ai-to-db-guard.md`, `ai-read-grounding.md`, `verify-before-fix.md` — same `## Rule` / `## When This Applies` / `## Existing Enforcement` / `## When NOT to apply` / `## Escalation` shape
- [verified] CLAUDE.md anchor placement mirrors `qmd-not-grep` and `concurrent-sessions` sections
- [verified] 2 files changed, 169 insertions — clean docs-only diff