### PR TITLE
feat(ielts): #1702 Theme 6 — per-part Mock scoring (CallScore.segmentKey)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -63,7 +63,7 @@ import { carryThroughCompose } from "@/lib/voice/carry-through-compose";
 import { renderPromptSummary } from "@/lib/prompt/composition/renderPromptSummary";
 import { getAudienceOption, type AudienceId } from "@/lib/prompt/composition/transforms/audience";
 import { getPipelineGates, getAITimeoutSettings } from "@/lib/system-settings";
-import { logAI } from "@/lib/logger";
+import { logAI, log as appLog } from "@/lib/logger";
 import { createLogger, type PipelineLogger } from "@/lib/pipeline/logger";
 import { mapToMemoryCategory } from "@/lib/pipeline/memory";
 import { loadGuardrails, type GuardrailsConfig } from "@/lib/pipeline/guardrails";
@@ -601,10 +601,26 @@ async function runPerSegmentScoring(
     engine,
     log,
   });
-  if (segments.length === 0) {
-    log.info("Per-part MEASURE: segmentation returned no segments, skipping", {
+  // Loud-skip fallback (#1700 Theme 6 / #1702). The bound module declares a
+  // multi-part Mock (`coversModules.length > 0`, guaranteed above) but the
+  // segmenter resolved 0 or 1 boundary — per-part scoring is not viable, so
+  // we fall back to bound-module scoring. Promote this to an AppLog subject
+  // (precedent: `pipeline.aggregate.lo_mastery_skipped`) so a 24h dashboard
+  // can spot "Mock call → no per-part scores" instead of it dying in the
+  // response-only PipelineLogger.
+  if (segments.length <= 1) {
+    appLog("system", "prosody.segmentation.fallback", {
+      message:
+        "Per-part MEASURE fell back to bound-module scoring — segmenter resolved ≤1 boundary",
+      callId: call.id,
+      moduleSlug: boundModule.slug,
+      coversModules: boundModule.coversModules,
+      segmentsReturned: segments.length,
+    });
+    log.info("Per-part MEASURE: segmentation returned ≤1 segment, skipping", {
       callId: call.id,
       boundSlug: boundModule.slug,
+      segmentsReturned: segments.length,
     });
     return 0;
   }
@@ -619,8 +635,21 @@ async function runPerSegmentScoring(
   let segmentScoresCreated = 0;
 
   for (const segment of segments) {
+    // Whitelist guard (#1700 Theme 6 / #1702). The segment slug MUST resolve
+    // to a curriculum-declared sub-module (`coversModules` → `slugToId`). A
+    // slug outside that set is a segmentation mismatch — promote to AppLog
+    // and skip only that segment's writes (other segments still score).
     const segmentModuleId = slugToId.get(segment.slug);
-    if (!segmentModuleId) continue;
+    if (!segmentModuleId) {
+      appLog("system", "prosody.segmentation.mismatch", {
+        message:
+          "Per-part MEASURE skipped a segment — slug not in curriculum coversModules whitelist",
+        callId: call.id,
+        slug: segment.slug,
+        knownKeys: [...slugToId.keys()],
+      });
+      continue;
+    }
 
     // IELTS-focused per-segment prompt: scopes scoring to the 4
     // IELTS Speaking skills, embeds the band rubric, gives per-part
@@ -738,6 +767,11 @@ async function runPerSegmentScoring(
           parameterId,
           analysisSpecId: parentSpec?.analysisSpecId ?? MEASUREMENT_SENTINEL_SPEC_IDS.MOCK,
           moduleId: segmentModuleId,
+          // #1700 Theme 6 / #1702 — annotate which Mock part produced this
+          // score so the Results screen (Theme 13a) can render per-part
+          // criterion bands. Bound-module/whole-call writes omit this →
+          // `segmentKey = null`, zero regression on non-Mock paths.
+          segmentKey: segment.slug,
           score,
           confidence,
           reasoning,

--- a/apps/admin/lib/measurement/write-call-score.ts
+++ b/apps/admin/lib/measurement/write-call-score.ts
@@ -47,6 +47,17 @@ export interface WriteCallScoreInput {
   /** Module attribution. `null` for unbound calls; the `CurriculumModule.id`
    *  for module-bound calls (#491 Slice 1.2). */
   moduleId: string | null;
+  /** Transcript-segment annotation (#1700 Theme 6, story #1702). The
+   *  per-part Mock scorer passes the segment slug (e.g. `"part1"`) so the
+   *  Results screen (Theme 13a) can render per-part criterion scores.
+   *  Free-text, course-agnostic. `null` / omitted for whole-call and
+   *  bound-module writes — zero behaviour change on non-Mock paths.
+   *
+   *  **NOT part of the `(callId, parameterId, moduleId)` idempotence key**
+   *  (epic #1700 decision 1) — purely an annotation column. Widening the
+   *  unique key would let one pass write multiple rows per criterion for
+   *  the same module. */
+  segmentKey?: string | null;
   /** 0-1 normalised score. NOT clamped here — clamp at the caller. */
   score: number;
   /** 0-1 confidence band. Defaults to 0.5 in the schema if omitted. */
@@ -117,6 +128,7 @@ export async function writeCallScore(
         analysisSpecId: input.analysisSpecId,
         hasLearnerEvidence: input.hasLearnerEvidence ?? null,
         evidenceQuality: input.evidenceQuality ?? null,
+        segmentKey: input.segmentKey ?? null,
       },
     });
     return { id: existing.id, created: false };
@@ -136,6 +148,7 @@ export async function writeCallScore(
       analysisSpecId: input.analysisSpecId,
       hasLearnerEvidence: input.hasLearnerEvidence ?? null,
       evidenceQuality: input.evidenceQuality ?? null,
+      ...(input.segmentKey ? { segmentKey: input.segmentKey } : {}),
     },
     select: { id: true },
   });

--- a/apps/admin/tests/lib/measurement/call-score-segmentkey-constraint.test.ts
+++ b/apps/admin/tests/lib/measurement/call-score-segmentkey-constraint.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Critical PR-time flag for #1700 Theme 6 / story #1702.
+ *
+ * `CallScore.segmentKey` is an ANNOTATION column — it records which Mock
+ * part produced a score. Epic #1700 decision 1 is explicit: the
+ * `(callId, parameterId, moduleId)` unique key MUST stay untouched.
+ *
+ * Widening it to include `segmentKey` would let one PROSODY / per-segment
+ * pass write multiple rows per criterion for the same module, breaking the
+ * idempotence `writeCallScore` relies on. This test pins the constraint
+ * shape so a future migration that widens it fails the bank before it
+ * reaches hf-staging.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const schema = readFileSync(
+  join(process.cwd(), "prisma", "schema.prisma"),
+  "utf8",
+);
+
+/** Extract the `model CallScore { ... }` block from the schema text. */
+function callScoreBlock(): string {
+  const start = schema.indexOf("model CallScore {");
+  expect(start).toBeGreaterThan(-1);
+  // Find the matching closing brace at column 0 (`\n}`).
+  const end = schema.indexOf("\n}", start);
+  expect(end).toBeGreaterThan(start);
+  return schema.slice(start, end);
+}
+
+describe("CallScore.segmentKey — annotation, not idempotence key (#1702)", () => {
+  const block = callScoreBlock();
+
+  it("declares segmentKey as a nullable String annotation column", () => {
+    expect(block).toMatch(/\n\s+segmentKey\s+String\?/);
+  });
+
+  it("keeps the unique key exactly (callId, parameterId, moduleId)", () => {
+    expect(block).toContain("@@unique([callId, parameterId, moduleId])");
+  });
+
+  it("never widens the unique key to include segmentKey", () => {
+    // Any @@unique line in the CallScore block that mentions segmentKey is a
+    // regression of epic #1700 decision 1.
+    const uniqueLines = block
+      .split("\n")
+      .filter((l) => l.includes("@@unique"));
+    for (const line of uniqueLines) {
+      expect(line).not.toContain("segmentKey");
+    }
+  });
+});

--- a/apps/admin/tests/lib/measurement/per-part-segmentkey-roundtrip.test.ts
+++ b/apps/admin/tests/lib/measurement/per-part-segmentkey-roundtrip.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Round-trip pin for #1700 Theme 6 / story #1702.
+ *
+ * Exercises the contract the per-part Mock scorer
+ * (`route.ts::runPerSegmentScoring`) relies on: a Mock-shaped transcript →
+ * real heuristic segmentation (`segmentMockTranscript`) → one
+ * `writeCallScore` per (segment × criterion), each carrying the segment slug
+ * as `segmentKey`. The route's own AI scoring is not exercised here (that
+ * needs a live engine); this pins the segmentation → writer hand-off, which
+ * is the surface #1702 changes.
+ *
+ * Asserts:
+ *   - 12 CallScore writes (4 IELTS criteria × 3 parts) for a Mock call, each
+ *     stamped with the correct segmentKey ("part1" / "part2" / "part3").
+ *   - A non-Mock (single-segment) write carries no segmentKey → null default.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    callScore: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { writeCallScore } from "@/lib/measurement/write-call-score";
+import { segmentMockTranscript } from "@/lib/curriculum/segment-mock-transcript";
+
+const mockedFindFirst = prisma.callScore.findFirst as unknown as ReturnType<typeof vi.fn>;
+const mockedCreate = prisma.callScore.create as unknown as ReturnType<typeof vi.fn>;
+
+const IELTS_CRITERIA = [
+  "skill_fluency_and_coherence_fc",
+  "skill_pronunciation_p",
+  "skill_lexical_resource_lr",
+  "skill_grammatical_range_and_accuracy_gra",
+];
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() } as any;
+}
+
+beforeEach(() => {
+  mockedFindFirst.mockReset();
+  mockedCreate.mockReset();
+  mockedFindFirst.mockResolvedValue(null);
+  mockedCreate.mockResolvedValue({ id: "score-new" });
+});
+
+describe("per-part segmentKey round-trip (#1702)", () => {
+  it("writes 12 rows (4 criteria × 3 parts), each stamped with its segment slug", async () => {
+    const transcript = [
+      "Assistant: Hi! Let's start with Part 1. Tell me about where you live.",
+      "User: I live in Warsaw, Poland.",
+      "Assistant: Now let's move to Part 2. Here's your cue card. You should say:",
+      "User: I want to talk about my morning routine...",
+      "Assistant: Now we'll discuss this topic more broadly. What do people think about routines?",
+      "User: Most people prefer fixed schedules.",
+    ].join("\n\n");
+
+    const segments = await segmentMockTranscript({
+      transcript,
+      coversModuleSlugs: ["part1", "part2", "part3"],
+      engine: "claude",
+      log: makeLog(),
+    });
+    expect(segments.map((s) => s.slug)).toEqual(["part1", "part2", "part3"]);
+
+    // Mirror the route's per-(segment × criterion) write loop.
+    const slugToModuleId: Record<string, string> = {
+      part1: "mod-part1",
+      part2: "mod-part2",
+      part3: "mod-part3",
+    };
+    for (const segment of segments) {
+      for (const parameterId of IELTS_CRITERIA) {
+        await writeCallScore({
+          callId: "call-mock-1",
+          callerId: "caller-1",
+          parameterId,
+          analysisSpecId: "spec-ielts",
+          moduleId: slugToModuleId[segment.slug],
+          segmentKey: segment.slug,
+          score: 0.7,
+          confidence: 0.8,
+          evidence: [`Segment: ${segment.slug}`],
+        });
+      }
+    }
+
+    expect(mockedCreate).toHaveBeenCalledTimes(12);
+
+    // Tally segmentKey distribution across the 12 writes.
+    const byKey: Record<string, number> = {};
+    for (const call of mockedCreate.mock.calls) {
+      const key = call[0].data.segmentKey as string;
+      byKey[key] = (byKey[key] ?? 0) + 1;
+    }
+    expect(byKey).toEqual({ part1: 4, part2: 4, part3: 4 });
+
+    // Every row's moduleId matches its segmentKey's module.
+    for (const call of mockedCreate.mock.calls) {
+      const { segmentKey, moduleId } = call[0].data;
+      expect(moduleId).toBe(slugToModuleId[segmentKey]);
+    }
+  });
+
+  it("non-Mock (single-segment) write carries no segmentKey → null default", async () => {
+    await writeCallScore({
+      callId: "call-assessment-1",
+      callerId: "caller-1",
+      parameterId: "skill_fluency_and_coherence_fc",
+      analysisSpecId: "spec-ielts",
+      moduleId: "mod-assessment",
+      score: 0.6,
+      confidence: 0.8,
+      evidence: ["AI batched analysis"],
+    });
+
+    expect(mockedCreate).toHaveBeenCalledOnce();
+    expect("segmentKey" in mockedCreate.mock.calls[0]![0].data).toBe(false);
+  });
+});

--- a/apps/admin/tests/lib/measurement/write-call-score.test.ts
+++ b/apps/admin/tests/lib/measurement/write-call-score.test.ts
@@ -187,6 +187,78 @@ describe("writeCallScore — structural contract", () => {
     expect("moduleId" in createArg.data).toBe(false);
   });
 
+  it("forwards segmentKey into the create payload (#1702 per-part annotation)", async () => {
+    mockedFindFirst.mockResolvedValueOnce(null);
+    mockedCreate.mockResolvedValueOnce({ id: "score-seg" });
+
+    await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "skill_fluency_and_coherence_fc",
+      analysisSpecId: "spec-abc",
+      moduleId: "mod-part2",
+      score: 0.7,
+      confidence: 0.8,
+      evidence: ["Segment: part2"],
+      segmentKey: "part2",
+    });
+
+    expect(mockedCreate.mock.calls[0]![0].data.segmentKey).toBe("part2");
+  });
+
+  it("forwards segmentKey into the update payload on re-run", async () => {
+    mockedFindFirst.mockResolvedValueOnce({ id: "score-existing" });
+    mockedUpdate.mockResolvedValueOnce({ id: "score-existing" });
+
+    await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "skill_fluency_and_coherence_fc",
+      analysisSpecId: "spec-abc",
+      moduleId: "mod-part2",
+      score: 0.9,
+      confidence: 0.9,
+      evidence: ["Segment: part2 (re-run)"],
+      segmentKey: "part2",
+    });
+
+    expect(mockedUpdate.mock.calls[0]![0].data.segmentKey).toBe("part2");
+  });
+
+  it("defaults segmentKey to null when omitted (non-Mock paths unchanged)", async () => {
+    mockedFindFirst.mockResolvedValueOnce(null);
+    mockedCreate.mockResolvedValueOnce({ id: "score-whole-call" });
+
+    await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "skill_pronunciation_p",
+      analysisSpecId: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
+      moduleId: null,
+      score: 0.6,
+      confidence: 0.9,
+      evidence: ["prosody/ielts:band=6.0"],
+    });
+
+    // create branch omits the key entirely when null → schema default (null).
+    expect("segmentKey" in mockedCreate.mock.calls[0]![0].data).toBe(false);
+
+    // update branch always writes it explicitly as null.
+    mockedFindFirst.mockResolvedValueOnce({ id: "score-existing" });
+    mockedUpdate.mockResolvedValueOnce({ id: "score-existing" });
+    await writeCallScore({
+      callId: "call-1",
+      callerId: "caller-1",
+      parameterId: "skill_pronunciation_p",
+      analysisSpecId: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
+      moduleId: null,
+      score: 0.6,
+      confidence: 0.9,
+      evidence: ["prosody/ielts:band=6.0"],
+    });
+    expect(mockedUpdate.mock.calls[0]![0].data.segmentKey).toBe(null);
+  });
+
   it("accepts sentinel spec ids for non-LLM writers", async () => {
     mockedFindFirst.mockResolvedValueOnce(null);
     mockedCreate.mockResolvedValueOnce({ id: "score-prosody" });


### PR DESCRIPTION
Closes #1702 · Parent epic #1700 (Lane B / Theme 6)

## What

Per-part Mock scoring: each Mock `CallScore` row is now annotated with the
transcript segment it came from (`segmentKey = "part1" | "part2" | "part3"`),
so the Results screen (Theme 13a) can render per-part criterion bands.

- **`writeCallScore`**: add optional `segmentKey`, forwarded into create/update.
  The `@@unique([callId, parameterId, moduleId])` key is **NOT** widened —
  `segmentKey` is an annotation column (epic #1700 decision 1).
- **`runPerSegmentScoring`** (`pipeline/route.ts`): pass `segmentKey = segment.slug`;
  promote the ≤1-boundary fallback to AppLog `prosody.segmentation.fallback`;
  promote slug-not-in-whitelist to AppLog `prosody.segmentation.mismatch` + skip
  only that segment.
- **Tests**: segmentKey forwarding (create/update/null default); unique-constraint
  shape pin (the critical "do not widen" flag); segmenter→writer round-trip
  (12 rows for a Mock call, `segmentKey = null` for non-Mock).

Migration D (`CallScore.segmentKey`) already landed in the #1700 bundle (#1714);
this PR is the code wiring only.

## Two deviations from the story brief (please sanity-check, @paw2paw)

1. The brief named `prosody-consumer.ts` as the per-part writer. Grounding against
   live code, that file consumes the **whole-call** `voiceProsody` envelope and
   writes 4 bands with `moduleId: null` [verified: `lib/pipeline/prosody-consumer.ts:99-118`
   reads `envelope.ieltsScores`, never calls `segmentMockTranscript`]. The actual
   per-part writer is `runPerSegmentScoring` [verified: `pipeline/route.ts:598`
   is the sole call site of `segmentMockTranscript` — `grep -rn segmentMockTranscript lib app`].
   Built against the real writer.
2. Whitelist sourced from curriculum `coversModules` (always in scope) rather than
   `Session.metadata.segmentLabels`. `Session` is flag-gated behind
   `HF_FLAG_SESSION_MODEL_V2` and `Call.sessionId` is nullable [verified:
   `schema.prisma:1699` `sessionId String? @unique`; flag usage in
   `lib/voice/session-flag.ts`], so keying the guard to `segmentLabels` would make
   it a silent no-op on the calls this path runs against. The
   `segmentLabels`-write-at-session-start is handed to Theme 3 (Session.metadata owner).

All #1702 acceptance criteria are still met by this sourcing.

## Verified by

- `vitest run tests/lib/measurement/write-call-score.test.ts call-score-segmentkey-constraint.test.ts per-part-segmentkey-roundtrip.test.ts tests/eslint-rules/no-bare-call-score-write.test.ts` → **17 passed**.
- Constraint pin reads `prisma/schema.prisma` live and asserts `@@unique([callId, parameterId, moduleId])` contains no `segmentKey` [verified: `schema.prisma:70`].
- `tsc --noEmit`: 0 new errors on changed lines (pre-existing main-red fixtures unrelated; route.ts:1779 `Goal` error predates this branch).
- eslint on both changed source files: 0 errors (54 pre-existing `any` warnings, none on added lines).
- Shadowing check: module `log` import aliased to `appLog` so it isn't shadowed by the `log: PipelineLogger` parameter [verified: `pipeline/route.ts` import line + 3 call sites].

## Deploy

`/vm-cpp` framing (Migration D), though the migration itself already deployed via #1714 — no new migration in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
