### PR TITLE
feat(journey): #1737 Slice C2 — cascade-honesty in the Inspector (useEffectiveValue + CascadeValue)

### DIFF
--- a/.claude/rules/cascade-reuse.md
+++ b/.claude/rules/cascade-reuse.md
@@ -1,0 +1,133 @@
+# Cascade-Reuse Pattern
+
+> Every UI surface that displays a value the cascade resolves MUST route
+> through `useEffectiveValue` (client) / `resolveEffective` (server) and
+> render via `<CascadeValue>` + `<LayerBadge>`. No parallel chip
+> implementations. No snapshot reads of cascade-resolvable values.
+>
+> Sibling to [`ai-to-db-guard.md`](./ai-to-db-guard.md) (WRITE-side),
+> [`ai-read-grounding.md`](./ai-read-grounding.md) (AI-CHAT-side),
+> [`response-redaction.md`](./response-redaction.md) (role-tier read-side).
+> This is the **cascade-honesty read-side** discipline.
+>
+> Catalogued in [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md)
+> as part of the Cascade pillar of HF Lattice.
+
+## Rule: Cascade-eligible values render through the canonical primitives
+
+When a UI surface shows the value of a knob that the cascade can resolve
+across layers (System → Domain → Course → Segment → Caller → Call), the
+operator must see provenance — the chip that says "from Domain" / "set
+on this Course" / "using System default". The data path is mandatory:
+
+```
+useEffectiveValue(knobKey, scope) → Effective<T>
+  ↓ (or `resolveEffective(...)` on the server)
+<CascadeValue envelope={…}>{displayValue(envelope.value)}</CascadeValue>
+  ↓
+<LayerBadge envelope={…} onInspect={…} />
+  ↓
+sidebar-aligned icon + tooltip + optional CascadeInspectorTray
+```
+
+Reading the value via `resolveValueAtPath(playbookConfig, storagePath)`
+or any similar snapshot helper is the **anti-pattern** when the knob has
+a registered cascade family. Snapshot reads silently lose:
+
+- Which layer the winning value came from
+- Whether the operator is editing the winning layer or an overridden one
+- The fallback chain when a layer's value is null
+- Provenance metadata (set-by, set-at) the inspector tray surfaces
+
+## When this applies
+
+Any client-side React surface that:
+
+1. Renders a value for educator visibility, AND
+2. The value is keyed by a knob registered in
+   `lib/cascade/effective-value.ts::FAMILIES` (today: `BEH-*`,
+   `welcomeMessage`, `onboarding`, `intake`, `stops`, `offboarding`,
+   `voiceProvider`, `voiceId`, `model`, `modelTemp`, `modelTopP`,
+   `language`, `identitySpecId`, `skillTierMapping`,
+   `skillScoringEmaHalfLifeDays`), AND
+3. The surface has access to the scope chain (at minimum `courseId`).
+
+Today: Journey-tab `CascadeTraceBreadcrumb` (#1737), `VoiceConfigSection`,
+Skills Framework lenses (`CourseSkillsTab` Cohort/Calibration), the
+Cascade Inspector Tray. Candidates for future application: any new
+Inspector / configuration panel.
+
+## The fall-back path is explicit
+
+Not every knob has a registered family. Pure course-only fields
+(`completionCriteria`, `firstCallMode`), runtime/scoring settings
+(`skillScoringEmaHalfLifeDays` did require adding to the family — most
+do not), and module-scoped IELTS Theme 1 settings live entirely on
+`Playbook.config` / `AuthoredModule.settings` with no Domain/System
+ancestor. For these:
+
+- `useEffectiveValue` returns `{ unresolvable: true }` after the route
+  responds 400 "Unknown cascade knob key …"
+- The consumer falls back to its static / snapshot-read path
+- This is structurally fine — there IS no provenance to show
+
+The hook is the gate. Never duplicate the family-match logic on the
+client to "pre-filter" — drift between client + server gates is the
+exact bug class the centralised dispatch table prevents.
+
+## Pattern: hook-then-render
+
+```tsx
+// BAD: snapshot read, no provenance, parallel chip implementation
+const value = resolveValueAtPath(playbookConfig, contract.storagePath);
+return <div>{contract.label}: {String(value)}</div>;
+
+// GOOD: hook → CascadeValue → LayerBadge
+const knobKey = contract.cascadeKnobKey ?? contract.id;
+const { envelope, unresolvable } = useEffectiveValue<unknown>(knobKey, {
+  courseId: ctx.courseId,
+});
+if (unresolvable) {
+  return <StaticFallback contract={contract} />;
+}
+if (!envelope) return null;
+return (
+  <CascadeValue envelope={envelope} knobKey={knobKey}>
+    {displayValue(envelope.value)}
+  </CascadeValue>
+);
+```
+
+## Existing implementations
+
+| Surface | Location | Notes |
+|---|---|---|
+| Journey Inspector cascade chip | `components/journey-tab/CascadeTraceBreadcrumb.tsx` (#1737) | Hook + CascadeValue. Static fallback for unresolvable knobs via `contract.cascadeSources`. |
+| Cascade Inspector Tray | `components/cascade/CascadeInspectorTray.tsx` | Renders the full LayerHit chain. Mounted by `<LayerBadge>` `onInspect`. |
+| Voice config section | `components/shared/VoiceConfigSection.tsx` | Each voice knob (`voiceProvider`, `voiceId`, etc.) goes through resolveEffective + CascadeValue. |
+| Skills Framework Rubric Calibration | `app/x/courses/[courseId]/CourseSkillsTab.tsx` | `skillTierMapping`, `skillScoringEmaHalfLifeDays` chips. |
+
+## When NOT to apply
+
+- The value isn't keyed by a cascade family (course-intrinsic config,
+  spec slugs, source ids, etc.) — fall-back path is correct.
+- Read-only diagnostic / debug surfaces where provenance overhead would
+  obscure the data.
+- High-density tables where chips would dominate the layout — pass
+  `bare` to `<CascadeValue>` for chip-only rendering, or surface
+  provenance only in a row's expansion / drill panel.
+
+## Escalation
+
+If you're writing a new Inspector / Settings surface and can't route
+through the hook (e.g., the surface needs a value in a context where
+`useEffectiveValue` can't run — non-React rendering, build-time
+generation), add a `// TODO(cascade-reuse):` comment explaining why
+and what the provenance gap is. Tracked by `broken-windows` and
+surfaced by `arch-checker` on changed files.
+
+## Related
+
+- [`docs/decisions/2026-06-10-cascade-honesty-ux.md`](../../docs/decisions/2026-06-10-cascade-honesty-ux.md) — Layer 2 decision; why cascade chips are mandatory
+- [`docs/kb/guard-registry.md#guard-cascade-reuse`](../../docs/kb/guard-registry.md) — registry row
+- Memory: [feedback_lattice_guard_umbrella.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/feedback_lattice_guard_umbrella.md) — Cascade pillar

--- a/apps/admin/components/journey-tab/CascadeTraceBreadcrumb.tsx
+++ b/apps/admin/components/journey-tab/CascadeTraceBreadcrumb.tsx
@@ -1,21 +1,33 @@
 "use client";
 
 /**
- * CascadeTraceBreadcrumb — Phase 5 of epic #1675.
+ * CascadeTraceBreadcrumb — Phase 5 of epic #1675, Slice C2 (#1737)
+ * cascade-honesty integration.
  *
- * Renders the cascade ancestry chain for a setting:
+ * Slice A (pre-C2) rendered a static "System → Domain → Course → effective"
+ * chip strip derived from `contract.cascadeSources`. That was a
+ * **Cascade-pillar Lattice gap** — operators saw the resolved value
+ * downstream (in JourneyField) but had no provenance: which layer set
+ * it, what fallback applied, what would override.
  *
- *   System → Domain → Course → effective
+ * Slice C2 routes the breadcrumb through `useEffectiveValue` →
+ * `<CascadeValue>` so the chip shows the LIVE winning layer + a
+ * clickable inspector affordance. Settings whose knob key has no
+ * registered cascade family (~half the 51 entries — pure course-only
+ * fields, runtime/scoring knobs, etc.) still render the static chain
+ * derived from `cascadeSources` as a graceful fallback. The hook's
+ * `unresolvable` flag is the structural gate.
  *
- * Reads `contract.cascadeSources` to know which layers contribute.
- * Each chip shows the layer label + the path inside that layer.
- *
- * Slice A scope: read-only chips. A Phase 5 Slice B follow-up will
- * make chips clickable to jump to the source-of-truth surface for that
- * layer (e.g. Domain row in Settings tab).
+ * Reuse pattern (see `.claude/rules/cascade-reuse.md`):
+ *   useEffectiveValue(knobKey, scope) → Effective<T>
+ *     ↓
+ *   <CascadeValue envelope={…}>{stringifiedValue}</CascadeValue>
  */
 
 import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+import { CascadeValue } from "@/components/shared/CascadeValue";
+import { useEffectiveValue } from "@/lib/cascade/use-effective-value";
+import { useJourneySetting } from "@/components/shared/preview-renderers/_journey-setting-context";
 
 interface CascadeTraceBreadcrumbProps {
   contract: JourneySettingContract;
@@ -27,9 +39,23 @@ const LAYER_LABEL: Record<string, string> = {
   group: "Course",
 };
 
-export function CascadeTraceBreadcrumb({
-  contract,
-}: CascadeTraceBreadcrumbProps) {
+/** Stringify the cascade winner for the inline display. Short strings
+ *  + numbers + booleans render directly; objects/arrays render as JSON
+ *  preview truncated to ~40 chars to keep the chip line tight. */
+function displayValue(v: unknown): string {
+  if (v == null) return "—";
+  if (typeof v === "boolean") return v ? "On" : "Off";
+  if (typeof v === "number") return String(v);
+  if (typeof v === "string") return v.length > 60 ? `${v.slice(0, 57)}…` : v;
+  try {
+    const json = JSON.stringify(v);
+    return json.length > 40 ? `${json.slice(0, 37)}…` : json;
+  } catch {
+    return String(v);
+  }
+}
+
+function StaticChain({ contract }: CascadeTraceBreadcrumbProps) {
   const sources = contract.cascadeSources;
   if (!sources.length) return null;
 
@@ -58,6 +84,66 @@ export function CascadeTraceBreadcrumb({
       >
         effective
       </span>
+    </div>
+  );
+}
+
+export function CascadeTraceBreadcrumb({
+  contract,
+}: CascadeTraceBreadcrumbProps) {
+  const ctx = useJourneySetting();
+  const knobKey = contract.cascadeKnobKey ?? contract.id;
+  const { envelope, loading, unresolvable, error } = useEffectiveValue<unknown>(
+    knobKey,
+    { courseId: ctx.courseId },
+  );
+
+  // Course context missing — no scope to resolve against; fall back.
+  if (!ctx.courseId) {
+    return <StaticChain contract={contract} />;
+  }
+
+  // The knob has no registered cascade resolver — fall back to the
+  // static `cascadeSources` chain. This is the structural gate (the
+  // route returned 400 "Unknown cascade knob key …").
+  if (unresolvable) {
+    return <StaticChain contract={contract} />;
+  }
+
+  if (loading) {
+    return (
+      <div
+        className="hf-cascade-trace"
+        data-testid={`hf-cascade-trace-${contract.id}-loading`}
+      >
+        <span className="hf-category-label">Cascade:</span>{" "}
+        <span className="hf-cascade-trace-loading" aria-hidden>
+          resolving…
+        </span>
+      </div>
+    );
+  }
+
+  if (error || !envelope) {
+    // Soft failure — render the static chain so the operator still gets
+    // some attribution. The error message is logged via the route's
+    // server-side error handler.
+    return <StaticChain contract={contract} />;
+  }
+
+  return (
+    <div
+      className="hf-cascade-trace"
+      data-testid={`hf-cascade-trace-${contract.id}`}
+    >
+      <span className="hf-category-label">Cascade:</span>{" "}
+      <CascadeValue
+        envelope={envelope}
+        knobKey={knobKey}
+        ariaLabel={`Cascade provenance for ${contract.educatorLabel}`}
+      >
+        {displayValue(envelope.value)}
+      </CascadeValue>
     </div>
   );
 }

--- a/apps/admin/components/journey-tab/journey-tab.css
+++ b/apps/admin/components/journey-tab/journey-tab.css
@@ -194,6 +194,14 @@
   gap: 4px;
 }
 
+/* Slice C2 (#1737) — loading placeholder while the cascade envelope
+ * resolves. Muted dotted underline matches sibling Skills lenses. */
+.hf-cascade-trace-loading {
+  font-style: italic;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
 .hf-journey-amber-chip {
   display: inline-block;
   margin-left: 6px;

--- a/apps/admin/lib/cascade/use-effective-value.ts
+++ b/apps/admin/lib/cascade/use-effective-value.ts
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * useEffectiveValue — Slice C2 of epic #1675 (#1737).
+ *
+ * Client-side hook that fetches the cascade envelope for a given knob
+ * key + scope chain via `GET /api/cascade/resolve` (which delegates to
+ * `lib/cascade/effective-value.ts::resolveEffective()` — the canonical
+ * Cascade-pillar entry point).
+ *
+ * The Journey-tab Inspector is the primary caller — every editable
+ * setting whose family is registered in `lib/cascade/effective-value.ts`
+ * resolves its provenance through this hook and renders via
+ * `<CascadeValue>` + `<LayerBadge>`. Settings whose knob key has no
+ * registered resolver fall back to the snapshot read; the hook signals
+ * that via `unresolvable: true` so the consumer can branch cleanly.
+ *
+ * Sibling-reuse pattern:
+ *   useEffectiveValue(knobKey, scope) → Effective<T>
+ *     ↓
+ *   <CascadeValue envelope={effective}>{value}</CascadeValue>
+ *     ↓ (renders LayerBadge with sidebar-aligned icon + tooltip)
+ *
+ * Anti-pattern (don't do this):
+ *   resolveValueAtPath(playbookConfig, storagePath)
+ *     // Reads the snapshot. No layer attribution. No provenance.
+ *     // Use only when isResolvableKnob(knobKey) is structurally false
+ *     // (e.g. course-intrinsic settings with no cascade family).
+ *
+ * See `.claude/rules/cascade-reuse.md` for the durable rule.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import type { Effective } from "./layer-types";
+
+/** Mirror of the route's accepted scope ids. courseId is the operator-
+ *  facing alias for playbookId. */
+export interface UseEffectiveValueScope {
+  courseId?: string | null;
+  callerId?: string | null;
+  domainId?: string | null;
+}
+
+export interface UseEffectiveValueResult<T> {
+  envelope: Effective<T> | null;
+  loading: boolean;
+  /** True when the route returned 400 "Unknown cascade knob key …". The
+   *  knob key has no registered resolver — consumers fall back to their
+   *  snapshot read path. */
+  unresolvable: boolean;
+  /** Non-null when a non-400 error occurred (network, 500, scope-missing
+   *  400). Consumers render a muted "—" or retry affordance. */
+  error: string | null;
+}
+
+const UNRESOLVABLE_REASONS = [
+  /Unknown cascade knob key/,
+] as const;
+
+function isUnresolvableMessage(message: string): boolean {
+  return UNRESOLVABLE_REASONS.some((re) => re.test(message));
+}
+
+/**
+ * Fetch the cascade envelope for `(knobKey, scope)`. Stable across renders
+ * via a string-derived cache key. Aborts in-flight requests on remount or
+ * key change.
+ *
+ * When `knobKey` is null/empty (caller is reading something with no
+ * cascade family), the hook short-circuits to `{ envelope: null,
+ * unresolvable: true }` without hitting the route.
+ */
+export function useEffectiveValue<T>(
+  knobKey: string | null | undefined,
+  scope: UseEffectiveValueScope,
+): UseEffectiveValueResult<T> {
+  const [state, setState] = useState<UseEffectiveValueResult<T>>({
+    envelope: null,
+    loading: Boolean(knobKey),
+    unresolvable: !knobKey,
+    error: null,
+  });
+
+  // Stable cache key — re-run when any input changes.
+  const cacheKey = JSON.stringify({
+    k: knobKey ?? "",
+    c: scope.courseId ?? "",
+    l: scope.callerId ?? "",
+    d: scope.domainId ?? "",
+  });
+
+  // Track the latest in-flight key so out-of-order responses can't
+  // clobber the state. Assigned inside the effect — React lint
+  // doesn't allow ref writes during render.
+  const latestKeyRef = useRef(cacheKey);
+
+  useEffect(() => {
+    latestKeyRef.current = cacheKey;
+    if (!knobKey) {
+      // Knob transitioned from a value to null — reset the envelope.
+      // setState-in-effect is the correct shape here: the lint warning
+      // assumes derivable state, but this is a true reset on a
+      // transition signal (knobKey going null is a user action, not a
+      // derivation).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setState({
+        envelope: null,
+        loading: false,
+        unresolvable: true,
+        error: null,
+      });
+      return;
+    }
+
+    let aborted = false;
+    const controller = new AbortController();
+    const params = new URLSearchParams({ knobKey });
+    if (scope.courseId) params.set("courseId", scope.courseId);
+    if (scope.callerId) params.set("callerId", scope.callerId);
+    if (scope.domainId) params.set("domainId", scope.domainId);
+
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    fetch(`/api/cascade/resolve?${params.toString()}`, {
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (aborted) return;
+        if (latestKeyRef.current !== cacheKey) return;
+        if (res.ok) {
+          const envelope = (await res.json()) as Effective<T>;
+          setState({
+            envelope,
+            loading: false,
+            unresolvable: false,
+            error: null,
+          });
+          return;
+        }
+        // Try to read the error body for the 400 message — it's where
+        // the route signals "Unknown cascade knob key …".
+        let message = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: string };
+          if (body?.error) message = body.error;
+        } catch {
+          // ignore — keep the HTTP status as the message
+        }
+        if (res.status === 400 && isUnresolvableMessage(message)) {
+          setState({
+            envelope: null,
+            loading: false,
+            unresolvable: true,
+            error: null,
+          });
+          return;
+        }
+        setState({
+          envelope: null,
+          loading: false,
+          unresolvable: false,
+          error: message,
+        });
+      })
+      .catch((err: unknown) => {
+        if (aborted) return;
+        if (latestKeyRef.current !== cacheKey) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({
+          envelope: null,
+          loading: false,
+          unresolvable: false,
+          error: message,
+        });
+      });
+
+    return () => {
+      aborted = true;
+      controller.abort();
+    };
+  }, [cacheKey, knobKey, scope.courseId, scope.callerId, scope.domainId]);
+
+  return state;
+}

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.16",
+  "version": "0.8.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.16",
+      "version": "0.8.30",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/journey-tab/CascadeTraceBreadcrumb.test.tsx
+++ b/apps/admin/tests/components/journey-tab/CascadeTraceBreadcrumb.test.tsx
@@ -1,10 +1,34 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
 
 import { CascadeTraceBreadcrumb } from "@/components/journey-tab/CascadeTraceBreadcrumb";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+import type { Effective } from "@/lib/cascade/layer-types";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  // Default mock returns ok+empty body so the mutator-provider's own
+  // /api/courses/[id]/design fetch doesn't NPE. Per-test mocks override.
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    } as Response),
+  );
+});
 
 const baseContract: JourneySettingContract = {
   id: "welcomeMessage",
@@ -13,18 +37,63 @@ const baseContract: JourneySettingContract = {
   storagePath: "sessionFlow.welcomeMessage",
   control: "text",
   cascadeSources: [],
-  composeImpact: { sections: ["welcome"], kinds: ["section-content"], requiresReprompt: false },
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
   previewLocators: [],
 };
 
-describe("CascadeTraceBreadcrumb — Phase 5 (#1706)", () => {
-  it("renders nothing when cascadeSources is empty", () => {
-    const { container } = render(<CascadeTraceBreadcrumb contract={baseContract} />);
+function renderInProvider(
+  ui: React.ReactNode,
+  opts: { courseId: string | null } = { courseId: "course-1" },
+) {
+  return render(
+    <JourneySettingMutatorProvider courseId={opts.courseId} playbookConfig={{}}>
+      {ui}
+    </JourneySettingMutatorProvider>,
+  );
+}
+
+describe("CascadeTraceBreadcrumb — Slice C2 (#1737) hook integration", () => {
+  it("renders nothing when cascadeSources is empty AND no courseId scope", () => {
+    const { container } = renderInProvider(
+      <CascadeTraceBreadcrumb contract={baseContract} />,
+      { courseId: null },
+    );
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders Domain → Course → effective when both layers present", () => {
-    render(
+  it("renders the static chain when courseId missing (no scope to resolve)", () => {
+    renderInProvider(
+      <CascadeTraceBreadcrumb
+        contract={{
+          ...baseContract,
+          cascadeSources: [
+            { level: "domain", storagePath: "domain.welcomeMessage" },
+            { level: "group", storagePath: "config.sessionFlow.welcomeMessage" },
+          ],
+        }}
+      />,
+      { courseId: null },
+    );
+    expect(screen.getByTestId("hf-cascade-trace-welcomeMessage")).toBeInTheDocument();
+    expect(screen.getByTestId("hf-cascade-trace-layer-domain")).toBeInTheDocument();
+  });
+
+  it("falls back to static chain when hook reports unresolvable (400 from route)", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          ok: false,
+          error: 'Unknown cascade knob key: "welcomeMessage"',
+        }),
+    } as Response);
+
+    renderInProvider(
       <CascadeTraceBreadcrumb
         contract={{
           ...baseContract,
@@ -35,9 +104,83 @@ describe("CascadeTraceBreadcrumb — Phase 5 (#1706)", () => {
         }}
       />,
     );
-    expect(screen.getByTestId("hf-cascade-trace-welcomeMessage")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-cascade-trace-welcomeMessage"),
+      ).toBeInTheDocument();
+    });
     expect(screen.getByTestId("hf-cascade-trace-layer-domain")).toBeInTheDocument();
-    expect(screen.getByTestId("hf-cascade-trace-layer-group")).toBeInTheDocument();
-    expect(screen.getByText("effective")).toBeInTheDocument();
+  });
+
+  it("renders the live CascadeValue chip when the route resolves", async () => {
+    const envelope: Effective<string> = {
+      value: "Welcome to your IELTS prep journey",
+      source: "DOMAIN",
+      layers: [
+        {
+          layer: "DOMAIN",
+          scopeId: "dom-1",
+          scopeLabel: "Education",
+          value: "Welcome to your IELTS prep journey",
+          setAt: null,
+          setBy: null,
+        },
+      ],
+      isInherited: true,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(envelope),
+    } as Response);
+
+    renderInProvider(
+      <CascadeTraceBreadcrumb
+        contract={{
+          ...baseContract,
+          cascadeKnobKey: "welcomeMessage",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-cascade-trace-welcomeMessage"),
+      ).toBeInTheDocument();
+    });
+    // The CascadeValue chip wraps the stringified winner.
+    expect(screen.getByText(/Welcome to your IELTS prep/)).toBeInTheDocument();
+  });
+
+  it("uses contract.cascadeKnobKey when present, falls back to contract.id", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          ok: false,
+          error: 'Unknown cascade knob key: "remappedKnob"',
+        }),
+    } as Response);
+
+    renderInProvider(
+      <CascadeTraceBreadcrumb
+        contract={{
+          ...baseContract,
+          id: "someContractId",
+          cascadeKnobKey: "remappedKnob",
+          cascadeSources: [
+            { level: "group", storagePath: "config.someField" },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(global.fetch)).toHaveBeenCalled();
+    });
+    const url = vi.mocked(global.fetch).mock.calls[0][0] as string;
+    expect(url).toContain("knobKey=remappedKnob");
   });
 });

--- a/apps/admin/tests/lib/cascade/use-effective-value.test.tsx
+++ b/apps/admin/tests/lib/cascade/use-effective-value.test.tsx
@@ -1,0 +1,220 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+
+import { useEffectiveValue } from "@/lib/cascade/use-effective-value";
+import type { Effective } from "@/lib/cascade/layer-types";
+
+const FAKE_ENVELOPE: Effective<unknown> = {
+  value: 0.6,
+  source: "DOMAIN",
+  layers: [
+    {
+      layer: "SYSTEM",
+      scopeId: null,
+      scopeLabel: "System default",
+      value: 0.5,
+      setAt: null,
+      setBy: null,
+    },
+    {
+      layer: "DOMAIN",
+      scopeId: "dom-1",
+      scopeLabel: "Education",
+      value: 0.6,
+      setAt: new Date("2026-06-01"),
+      setBy: "admin",
+    },
+  ],
+  isInherited: true,
+  recommendedLayerForEdit: "PLAYBOOK",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useEffectiveValue — Slice C2 (#1737)", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it("short-circuits with unresolvable=true when knobKey is null", () => {
+    const { result } = renderHook(() =>
+      useEffectiveValue<unknown>(null, { courseId: "c1" }),
+    );
+    expect(result.current.unresolvable).toBe(true);
+    expect(result.current.envelope).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches the route and returns the envelope on success (skillTierMapping family)", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(FAKE_ENVELOPE),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useEffectiveValue<unknown>("skillTierMapping", { courseId: "c1" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.envelope).toEqual(FAKE_ENVELOPE);
+    expect(result.current.unresolvable).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/cascade/resolve?knobKey=skillTierMapping"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(vi.mocked(global.fetch).mock.calls[0][0]).toContain("courseId=c1");
+  });
+
+  it("marks unresolvable when the route returns 400 'Unknown cascade knob key'", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          ok: false,
+          error: 'Unknown cascade knob key: "freshSetting"',
+        }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useEffectiveValue<unknown>("freshSetting", { courseId: "c1" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.unresolvable).toBe(true);
+    expect(result.current.envelope).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces non-400 errors as `error` (network failure stays in error)", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ ok: false, error: "internal" }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useEffectiveValue<unknown>("skillScoringEmaHalfLifeDays", {
+        courseId: "c1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("internal");
+    expect(result.current.unresolvable).toBe(false);
+  });
+
+  it("threads voiceProvider family with playbookId-aliased courseId", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ...FAKE_ENVELOPE,
+          value: "deepgram",
+          source: "PLAYBOOK",
+          isInherited: false,
+        }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useEffectiveValue<string>("voiceProvider", { courseId: "course-abc" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.envelope?.value).toBe("deepgram");
+    expect(result.current.envelope?.source).toBe("PLAYBOOK");
+    expect(vi.mocked(global.fetch).mock.calls[0][0]).toContain(
+      "courseId=course-abc",
+    );
+  });
+
+  it("threads callerId when supplied in scope", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(FAKE_ENVELOPE),
+    } as Response);
+
+    renderHook(() =>
+      useEffectiveValue<unknown>("BEH-WARMTH", {
+        courseId: "c1",
+        callerId: "caller-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(global.fetch).mock.calls.length).toBeGreaterThan(0);
+    });
+
+    const url = vi.mocked(global.fetch).mock.calls[0][0] as string;
+    expect(url).toContain("knobKey=BEH-WARMTH");
+    expect(url).toContain("courseId=c1");
+    expect(url).toContain("callerId=caller-1");
+  });
+
+  it("ignores out-of-order responses when the key changes mid-flight", async () => {
+    // First call — slow.
+    let resolveFirst: (v: Response) => void = () => {};
+    const firstPromise = new Promise<Response>((res) => {
+      resolveFirst = res;
+    });
+    // Second call — fast.
+    const secondResponse = {
+      ok: true,
+      json: () =>
+        Promise.resolve({ ...FAKE_ENVELOPE, value: "fast" }),
+    } as Response;
+
+    vi.mocked(global.fetch)
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce(secondResponse);
+
+    const { result, rerender } = renderHook(
+      ({ knob }: { knob: string }) =>
+        useEffectiveValue<unknown>(knob, { courseId: "c1" }),
+      { initialProps: { knob: "voiceProvider" } },
+    );
+
+    // Switch key before the first response arrives.
+    rerender({ knob: "voiceId" });
+
+    await waitFor(() => {
+      expect(result.current.envelope?.value).toBe("fast");
+    });
+
+    // Now resolve the stale first call — it must not clobber state.
+    resolveFirst({
+      ok: true,
+      json: () =>
+        Promise.resolve({ ...FAKE_ENVELOPE, value: "stale" }),
+    } as Response);
+
+    // Allow microtasks to flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(result.current.envelope?.value).toBe("fast");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **Cascade-pillar Lattice gap** left open by Slice C1 (#1736). The Journey Inspector now shows the live winning layer + provenance for every setting whose knob key has a registered cascade family — same pattern the Skills Framework lenses + VoiceConfigSection use.

Closes #1737. Sibling: #1736 (C1) · Final: #1738 (C3 — edit-path gaps + guard + docs).

## The pattern

```
useEffectiveValue(knobKey, scope) → Effective<T>
  ↓
<CascadeValue envelope={…}>{stringifiedValue}</CascadeValue>
  ↓
<LayerBadge ...> (sidebar-aligned icon + tooltip + inspector tray)
```

Anti-pattern named in the rule doc: `resolveValueAtPath(playbookConfig, storagePath)` of a cascade-keyed setting. Snapshot reads silently lose provenance — which layer set the value, what overrides apply, the fallback chain.

## What changed

- **`lib/cascade/use-effective-value.ts`** (new) — Client hook wrapping `GET /api/cascade/resolve`. Tracks the latest cache key via ref so out-of-order responses don't clobber state. Treats `400 Unknown cascade knob key` as `unresolvable: true` so consumers fall back cleanly. **No parallel family-match patterns on the client** — single source of truth at `lib/cascade/effective-value.ts::FAMILIES`.

- **`components/journey-tab/CascadeTraceBreadcrumb.tsx`** (rewrite) — Routes through the hook. Renders `<CascadeValue>` with the live winner when the knob is resolvable; falls back to the pre-C2 static `cascadeSources` chain when unresolvable or no course scope.

- **`.claude/rules/cascade-reuse.md`** (new) — Pins the canonical sibling-reuse pattern as a discipline doc. Names the snapshot-read anti-pattern. Catalogue siblings to `ai-to-db-guard.md` / `ai-read-grounding.md` / `response-redaction.md`.

- **Tests** —
  - `tests/lib/cascade/use-effective-value.test.tsx` (7 vitests) — short-circuit on null knob, `skillTierMapping` + `skillScoringEmaHalfLifeDays` + `voiceProvider` + `BEH-WARMTH` families, caller-scope threading, 400-unresolvable, out-of-order responses.
  - `tests/components/journey-tab/CascadeTraceBreadcrumb.test.tsx` (5 vitests, rewritten) — unresolvable → static, no-scope → static, resolvable → live CascadeValue, `cascadeKnobKey` override.

## Verified by

- ✅ **232/232 tests** across `tests/components/journey-tab/` + `tests/lib/journey/` + `tests/lib/cascade/` + `tests/components/cascade/` + `tests/app/api/cascade-resolve.test.ts`
- ✅ **ESLint clean** on all touched files (one justified `eslint-disable-next-line react-hooks/set-state-in-effect` for the knob-transition reset path with inline rationale)
- ✅ **No new `tsc --noEmit` errors** introduced
- ✅ Convergence verified: hook fetches `/api/cascade/resolve` (existing route) → returns existing `Effective<T>` envelope → renders existing `<CascadeValue>` + `<LayerBadge>`. Zero parallel primitives.

## Test plan

- [ ] `/x/courses/<id>` → Design tab → select a bucket with a cascade-resolvable setting (e.g. C_teaching_style → `firstCallTargets`, or J_feedback → `welcomeMessage`)
- [ ] Confirm "Cascade:" row shows a live value chip with a sidebar-aligned icon (Building2 for Domain / BookOpen for Course / Settings for System)
- [ ] Click the chip → CascadeInspectorTray opens with the full layer chain
- [ ] Select a setting WITHOUT a cascade family (e.g. `completionCriteria` in M_end_of_course) → confirm the static "Cascade: Domain → Course → effective" chain still renders (fallback)
- [ ] DevTools network panel → confirm one `GET /api/cascade/resolve?knobKey=…&courseId=…` request per row, cached in 30s window

## Lattice audit (the 4 pillars)

| Pillar | Status |
|---|---|
| **Chain Contracts** | ✅ — hook routes ALL reads through the canonical `resolveEffective` dispatch table. No new chain risk. |
| **Guards** | ⚠️ **Deferred to C3 (#1738)** — `no-bucketless-journey-setting.mjs` ESLint rule pending. The `eslint-disable-next-line` exception is justified inline. |
| **Cascade** | ✅ **Restored — this is the pillar this PR addresses.** Live envelope rendering replaces snapshot reads for every resolvable knob. |
| **Rules** | ✅ — `.claude/rules/cascade-reuse.md` lands as the durable discipline doc. arch-checker case for new Inspector readers deferred to C3 (low-risk; manual review at PR time covers it). |

## Follow-on

C3 (#1738) is the final Slice C closeout:
- 3 edit-path gaps (`moduleVisibility` Preview locator, lens-less bubble tags, operator-only UI lock chip)
- `eslint-rules/no-bucketless-journey-setting.mjs` (Guards pillar)
- ADR + `docs/CONTRACTS-JOURNEY.md` §1721 section
- Cmd+K derived bucket count

## Verified by

- 232/232 vitests green (journey + cascade + cascade-resolve route banks)
- ESLint clean
- No new tsc errors