### PR TITLE
feat(voice): #1747 Theme 7 — tutor talk-time stats (helper + G7 setting)

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -927,6 +927,26 @@ const G7_REWARD_STRATEGY: JourneySettingContract = {
   ],
 };
 
+const G7_TALK_TIME_BUDGETS: JourneySettingContract = {
+  id: "talkTimeBudgets",
+  menuGroupKey: "J_feedback",
+  group: "G7",
+  educatorLabel: "Tutor talk-time budgets",
+  helpText:
+    "Post-call telemetry budgets. Shape: {maxTutorTurnSec, maxTutorRatio}. Defaults: 30s / 0.2 (tutor ≤ 20% of session words). Yellow chip in AttainmentTab + AppLog voice.talk_time.over_budget when exceeded.",
+  storagePath: "config.talkTimeBudgets",
+  control: "json-fallback",
+  cascadeSources: [],
+  composeImpact: {
+    // Post-call telemetry only — runtime intervention is explicitly
+    // deferred per the gap-analysis risk register. No composer section.
+    sections: [],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
 // =============================================================
 // G8 — Module-scoped settings (6) — #1701 (epic #1700 Theme 1)
 // =============================================================
@@ -1123,6 +1143,7 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G7_MAX_CALLS_PER_DAY,
   G7_ASSESSMENT_READINESS_THRESHOLD,
   G7_REWARD_STRATEGY,
+  G7_TALK_TIME_BUDGETS,
   // G8 (6) — #1701 module-scoped settings
   G8_MODULE_QUESTION_TARGET,
   G8_MODULE_MIN_SPEAKING_SEC,

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -594,6 +594,21 @@ export interface PlaybookConfig {
     carryForwardBoost?: number;
   };
   /**
+   * #1747 (epic #1700 Theme 7) — operator-configurable tutor-talk-time
+   * budgets. Post-call telemetry chip in AttainmentTab flips yellow when
+   * a budget is exceeded; AppLog `voice.talk_time.over_budget` fires
+   * via the `evaluateTalkTimeBudgets` helper in
+   * `lib/voice/talk-time-stats.ts`.
+   *
+   * Defaults (gap analysis): `maxTutorTurnSec = 30` (≈ 75 words at 150
+   * WPM), `maxTutorRatio = 0.2` (tutor ≤ 20% of total session words).
+   * Course-only — not cascadable.
+   */
+  talkTimeBudgets?: {
+    maxTutorTurnSec?: number;
+    maxTutorRatio?: number;
+  };
+  /**
    * #598 Slice 1 — Additional first-call overrides. Companion to
    * `firstCallMode` (flat field above, shipped #790) — these are net-new
    * knobs, NOT a rename. Re-introducing `firstCall.allowAssessMode` would

--- a/apps/admin/lib/voice/talk-time-stats.ts
+++ b/apps/admin/lib/voice/talk-time-stats.ts
@@ -1,0 +1,192 @@
+/**
+ * Talk-time stats — #1747 (epic #1700 Theme 7).
+ *
+ * Pure post-call telemetry helpers. Reads the standard `User:` /
+ * `Assistant:` transcript format produced by every Call writer
+ * (sim-drive-call.ts, voice webhook, manual ingestion — same format
+ * consumed by `lib/pipeline/evidence-prefilter.ts::extractLearnerText`)
+ * and computes turn counts, word counts, and approximated talk-time.
+ *
+ * No timestamps in the canonical transcript, so duration is
+ * approximated from word count × a fixed speech-rate constant
+ * (`DEFAULT_WORDS_PER_SECOND = 2.5` ≈ 150 WPM, the standard adult
+ * conversational rate). Operators can override the WPM via options
+ * when tuning to a faster/slower learner cohort, but the budget chip
+ * is "yellow telemetry" — millisecond accuracy is not the point.
+ *
+ * Pure functions only — no DB reads, no AppLog writes. The caller
+ * (typically endSession's post-update side-effect block) emits the
+ * AppLog `voice.talk_time.over_budget` when the evaluation flags an
+ * over-budget condition.
+ *
+ * Runtime intervention is explicitly deferred per the gap-analysis
+ * risk register — this layer measures only.
+ *
+ * @see lib/pipeline/evidence-prefilter.ts (sibling parser)
+ * @see docs/draft-issues/ielts-pre-voice-gap-analysis.md (Theme 7 row)
+ */
+
+/** Output of `computeTalkTimeStats`. All fields are zero-default-safe. */
+export interface TalkTimeStats {
+  /** Number of `Assistant:` turns in the transcript. */
+  tutorTurnCount: number;
+  /** Number of `User:` turns in the transcript. */
+  learnerTurnCount: number;
+  /** Cumulative word count across all `Assistant:` turns. */
+  tutorWordCount: number;
+  /** Cumulative word count across all `User:` turns. */
+  learnerWordCount: number;
+  /** Longest `Assistant:` turn measured in words. Proxy for "max
+   *  continuous tutor speech" until we have per-turn timestamps. */
+  maxTutorTurnWords: number;
+  /** Time approximation of `maxTutorTurnWords` via `wordsPerSecond`. */
+  maxTutorTurnSec: number;
+  /** `tutorWordCount / (tutorWordCount + learnerWordCount)`. 0 when
+   *  the transcript has no words. */
+  tutorRatio: number;
+  /** Words-per-second constant used for the approximation. */
+  wordsPerSecond: number;
+}
+
+/** Operator-configurable thresholds, stored at `Playbook.config.talkTimeBudgets`. */
+export interface TalkTimeBudgets {
+  /** Over-budget when `maxTutorTurnSec > this`. Default 30s (≈ 75 words at 150 WPM). */
+  maxTutorTurnSec?: number;
+  /** Over-budget when `tutorRatio > this`. Default 0.2 (tutor speaks ≤ 20% of session). */
+  maxTutorRatio?: number;
+}
+
+export const DEFAULT_TALK_TIME_BUDGETS: Required<TalkTimeBudgets> = {
+  maxTutorTurnSec: 30,
+  maxTutorRatio: 0.2,
+};
+
+/** Adult conversational rate (≈ 150 WPM). Used for word → second
+ *  approximations until per-turn timestamps land on the transcript. */
+export const DEFAULT_WORDS_PER_SECOND = 2.5;
+
+/**
+ * Parse a transcript in the canonical `User:` / `Assistant:` format and
+ * return per-side turn + word stats + a time-approximated longest-tutor-
+ * turn measurement.
+ *
+ * Empty / null / undefined transcripts return zero-default stats so
+ * callers don't need to guard.
+ */
+export function computeTalkTimeStats(
+  transcript: string | null | undefined,
+  options: { wordsPerSecond?: number } = {},
+): TalkTimeStats {
+  const wps = options.wordsPerSecond ?? DEFAULT_WORDS_PER_SECOND;
+  const zero: TalkTimeStats = {
+    tutorTurnCount: 0,
+    learnerTurnCount: 0,
+    tutorWordCount: 0,
+    learnerWordCount: 0,
+    maxTutorTurnWords: 0,
+    maxTutorTurnSec: 0,
+    tutorRatio: 0,
+    wordsPerSecond: wps,
+  };
+  if (!transcript) return zero;
+
+  const lines = transcript.split(/\r?\n+/);
+  let currentRole: "tutor" | "learner" | "other" = "other";
+  let currentTurnWords = 0;
+  let tutorTurnCount = 0;
+  let learnerTurnCount = 0;
+  let tutorWordCount = 0;
+  let learnerWordCount = 0;
+  let maxTutorTurnWords = 0;
+
+  const flushTurn = () => {
+    if (currentRole === "tutor") {
+      tutorWordCount += currentTurnWords;
+      if (currentTurnWords > maxTutorTurnWords) {
+        maxTutorTurnWords = currentTurnWords;
+      }
+    } else if (currentRole === "learner") {
+      learnerWordCount += currentTurnWords;
+    }
+    currentTurnWords = 0;
+  };
+
+  for (const line of lines) {
+    const tutorMatch = /^\s*Assistant\s*:\s*(.*)$/i.exec(line);
+    if (tutorMatch) {
+      flushTurn();
+      currentRole = "tutor";
+      tutorTurnCount += 1;
+      currentTurnWords = countWords(tutorMatch[1]);
+      continue;
+    }
+    const learnerMatch = /^\s*User\s*:\s*(.*)$/i.exec(line);
+    if (learnerMatch) {
+      flushTurn();
+      currentRole = "learner";
+      learnerTurnCount += 1;
+      currentTurnWords = countWords(learnerMatch[1]);
+      continue;
+    }
+    if (currentRole !== "other") {
+      // Continuation line under the current speaker.
+      currentTurnWords += countWords(line);
+    }
+  }
+  flushTurn();
+
+  const totalWords = tutorWordCount + learnerWordCount;
+  return {
+    tutorTurnCount,
+    learnerTurnCount,
+    tutorWordCount,
+    learnerWordCount,
+    maxTutorTurnWords,
+    maxTutorTurnSec: maxTutorTurnWords / wps,
+    tutorRatio: totalWords > 0 ? tutorWordCount / totalWords : 0,
+    wordsPerSecond: wps,
+  };
+}
+
+/** Result of `evaluateTalkTimeBudgets` — which budget(s) tripped, if any. */
+export interface TalkTimeEvaluation {
+  overBudget: boolean;
+  /** Names of the budgets that were exceeded (empty when `overBudget = false`). */
+  exceededBy: Array<"maxTutorTurnSec" | "maxTutorRatio">;
+  /** The effective budgets used for the evaluation (defaults merged in). */
+  budgets: Required<TalkTimeBudgets>;
+}
+
+/**
+ * Compare stats against the operator's budgets. Missing budget keys
+ * fall back to `DEFAULT_TALK_TIME_BUDGETS`. Returns `overBudget = true`
+ * when ANY budget was exceeded.
+ */
+export function evaluateTalkTimeBudgets(
+  stats: TalkTimeStats,
+  budgets: TalkTimeBudgets | null | undefined = null,
+): TalkTimeEvaluation {
+  const effective: Required<TalkTimeBudgets> = {
+    maxTutorTurnSec:
+      budgets?.maxTutorTurnSec ?? DEFAULT_TALK_TIME_BUDGETS.maxTutorTurnSec,
+    maxTutorRatio:
+      budgets?.maxTutorRatio ?? DEFAULT_TALK_TIME_BUDGETS.maxTutorRatio,
+  };
+  const exceededBy: TalkTimeEvaluation["exceededBy"] = [];
+  if (stats.maxTutorTurnSec > effective.maxTutorTurnSec) {
+    exceededBy.push("maxTutorTurnSec");
+  }
+  if (stats.tutorRatio > effective.maxTutorRatio) {
+    exceededBy.push("maxTutorRatio");
+  }
+  return {
+    overBudget: exceededBy.length > 0,
+    exceededBy,
+    budgets: effective,
+  };
+}
+
+function countWords(text: string): number {
+  if (!text) return 0;
+  return text.split(/\s+/).filter(Boolean).length;
+}

--- a/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
+++ b/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
@@ -22,11 +22,12 @@ describe("CommandPalette — Phase 5 (#1706)", () => {
     expect(screen.getByTestId("hf-cmdk-input")).toBeInTheDocument();
   });
 
-  it("indexes all 62 settings (51 journey + 11 voice)", () => {
-    // #1701 (Theme 1) added 6 G8 entries → journey bumped 45 → 51 → palette 56 → 62.
-    expect(JOURNEY_SETTINGS.length).toBe(51);
+  it("indexes all 63 settings (52 journey + 11 voice)", () => {
+    // #1701 (Theme 1) added 6 G8 entries → journey 45 → 51 → palette 56 → 62.
+    // #1747 (Theme 7) added talkTimeBudgets (G7) → journey 51 → 52 → palette 62 → 63.
+    expect(JOURNEY_SETTINGS.length).toBe(52);
     expect(VOICE_SETTINGS.length).toBe(11);
-    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(62);
+    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(63);
   });
 
   it("typing narrows results by substring on educatorLabel", () => {

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -94,13 +94,14 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(17);
     expect(JOURNEY_SETTINGS_BY_GROUP.G5.length).toBe(3);
     expect(JOURNEY_SETTINGS_BY_GROUP.G6.length).toBe(4);
-    expect(JOURNEY_SETTINGS_BY_GROUP.G7.length).toBe(6);
+    // #1747 — Theme 7 talkTimeBudgets bumped G7 6 → 7
+    expect(JOURNEY_SETTINGS_BY_GROUP.G7.length).toBe(7);
     // #1701 — G8 module-scoped settings (Phase 1: 6 IELTS-required keys)
     expect(JOURNEY_SETTINGS_BY_GROUP.G8.length).toBe(6);
   });
 
-  it("(8) JOURNEY_SETTINGS.length === 51", () => {
-    expect(JOURNEY_SETTINGS.length).toBe(51);
+  it("(8) JOURNEY_SETTINGS.length === 52", () => {
+    expect(JOURNEY_SETTINGS.length).toBe(52);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {

--- a/apps/admin/tests/lib/voice/talk-time-stats.test.ts
+++ b/apps/admin/tests/lib/voice/talk-time-stats.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Behavioural tests for `lib/voice/talk-time-stats.ts` — #1747.
+ *
+ * Pure-function pins:
+ *   - empty / null / undefined transcript → zero stats
+ *   - canonical `User:` / `Assistant:` format parsed into per-side
+ *     turn + word counts
+ *   - continuation lines accrue under the active speaker
+ *   - maxTutorTurnWords reflects the longest single tutor turn
+ *   - maxTutorTurnSec = maxTutorTurnWords / wordsPerSecond
+ *   - tutorRatio = tutorWords / (tutor + learner), 0 when zero words
+ *   - evaluation returns overBudget + exceededBy names
+ *   - missing budgets fall back to DEFAULT_TALK_TIME_BUDGETS
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  computeTalkTimeStats,
+  evaluateTalkTimeBudgets,
+  DEFAULT_TALK_TIME_BUDGETS,
+  DEFAULT_WORDS_PER_SECOND,
+} from "@/lib/voice/talk-time-stats";
+
+describe("computeTalkTimeStats", () => {
+  it("returns zero stats for null / undefined / empty", () => {
+    for (const t of [null, undefined, "", "   "]) {
+      const s = computeTalkTimeStats(t);
+      expect(s.tutorTurnCount).toBe(0);
+      expect(s.learnerTurnCount).toBe(0);
+      expect(s.tutorWordCount).toBe(0);
+      expect(s.learnerWordCount).toBe(0);
+      expect(s.maxTutorTurnWords).toBe(0);
+      expect(s.maxTutorTurnSec).toBe(0);
+      expect(s.tutorRatio).toBe(0);
+      expect(s.wordsPerSecond).toBe(DEFAULT_WORDS_PER_SECOND);
+    }
+  });
+
+  it("counts simple two-turn exchange", () => {
+    const transcript = `
+Assistant: Hello, what's your favourite topic?
+User: I love football and I watch every weekend.
+`.trim();
+    const s = computeTalkTimeStats(transcript);
+    expect(s.tutorTurnCount).toBe(1);
+    expect(s.learnerTurnCount).toBe(1);
+    expect(s.tutorWordCount).toBe(5); // "Hello, what's your favourite topic?"
+    expect(s.learnerWordCount).toBe(8); // "I love football and I watch every weekend."
+    expect(s.tutorRatio).toBeCloseTo(5 / 13, 4);
+  });
+
+  it("accrues continuation lines under the active speaker", () => {
+    const transcript = `
+Assistant: First line.
+Continuation of the tutor's turn here.
+User: My response on this line only.
+`.trim();
+    const s = computeTalkTimeStats(transcript);
+    expect(s.tutorTurnCount).toBe(1);
+    expect(s.learnerTurnCount).toBe(1);
+    // "First line." (2) + "Continuation of the tutor's turn here." (6) = 8
+    expect(s.tutorWordCount).toBe(8);
+    expect(s.maxTutorTurnWords).toBe(8);
+  });
+
+  it("tracks maxTutorTurnWords across multiple tutor turns", () => {
+    // Three tutor turns: 5 words, 12 words, 3 words → max = 12.
+    const transcript = `
+Assistant: One two three four five.
+User: Quick.
+Assistant: Six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen.
+User: Quick again.
+Assistant: Eighteen nineteen twenty.
+`.trim();
+    const s = computeTalkTimeStats(transcript);
+    expect(s.tutorTurnCount).toBe(3);
+    expect(s.maxTutorTurnWords).toBe(12);
+    expect(s.maxTutorTurnSec).toBeCloseTo(12 / DEFAULT_WORDS_PER_SECOND, 4);
+  });
+
+  it("uses operator-overridden wordsPerSecond", () => {
+    const transcript = "Assistant: Five word turn right here.";
+    const s = computeTalkTimeStats(transcript, { wordsPerSecond: 5 });
+    expect(s.maxTutorTurnWords).toBe(5);
+    expect(s.maxTutorTurnSec).toBeCloseTo(1, 4); // 5 / 5 wps = 1s
+    expect(s.wordsPerSecond).toBe(5);
+  });
+
+  it("computes tutorRatio = tutorWords / total, 0 when no words at all", () => {
+    const empty = computeTalkTimeStats("");
+    expect(empty.tutorRatio).toBe(0);
+    const learnerHeavy = computeTalkTimeStats(
+      "Assistant: One.\nUser: One two three four five six seven eight nine.",
+    );
+    expect(learnerHeavy.tutorRatio).toBeCloseTo(1 / 10, 4);
+  });
+
+  it("handles speaker labels case-insensitively (assistant / ASSISTANT / Assistant)", () => {
+    const transcript = `
+ASSISTANT: hi.
+user: ok.
+Assistant: bye.
+`.trim();
+    const s = computeTalkTimeStats(transcript);
+    expect(s.tutorTurnCount).toBe(2);
+    expect(s.learnerTurnCount).toBe(1);
+  });
+});
+
+describe("evaluateTalkTimeBudgets", () => {
+  it("returns overBudget=false when stats are within both defaults", () => {
+    const stats = computeTalkTimeStats(
+      "Assistant: Short turn.\nUser: One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twenty-one twenty-two twenty-three twenty-four twenty-five.",
+    );
+    const ev = evaluateTalkTimeBudgets(stats);
+    expect(ev.overBudget).toBe(false);
+    expect(ev.exceededBy).toEqual([]);
+    expect(ev.budgets).toEqual(DEFAULT_TALK_TIME_BUDGETS);
+  });
+
+  it("flags maxTutorTurnSec when a tutor turn exceeds the budget", () => {
+    // 100 words at 2.5 wps = 40s > 30s default.
+    const longTurn = "Assistant: " + Array(100).fill("word").join(" ");
+    const stats = computeTalkTimeStats(longTurn);
+    expect(stats.maxTutorTurnSec).toBeCloseTo(40, 4);
+    const ev = evaluateTalkTimeBudgets(stats);
+    expect(ev.overBudget).toBe(true);
+    expect(ev.exceededBy).toContain("maxTutorTurnSec");
+  });
+
+  it("flags maxTutorRatio when tutor dominates the session", () => {
+    // 100 tutor words across 5 turns, 1 learner word → ratio ≈ 0.99.
+    const transcript = [
+      "Assistant: " + Array(20).fill("a").join(" "),
+      "User: ok",
+      "Assistant: " + Array(20).fill("a").join(" "),
+      "User: ok",
+      "Assistant: " + Array(20).fill("a").join(" "),
+      "User: ok",
+      "Assistant: " + Array(20).fill("a").join(" "),
+      "User: ok",
+      "Assistant: " + Array(20).fill("a").join(" "),
+    ].join("\n");
+    const stats = computeTalkTimeStats(transcript);
+    expect(stats.tutorRatio).toBeGreaterThan(0.9);
+    const ev = evaluateTalkTimeBudgets(stats);
+    expect(ev.overBudget).toBe(true);
+    expect(ev.exceededBy).toContain("maxTutorRatio");
+  });
+
+  it("merges operator-provided budgets over defaults", () => {
+    const stats = computeTalkTimeStats(
+      "Assistant: " + Array(50).fill("word").join(" "),
+    );
+    // stats.maxTutorTurnSec = 50 / 2.5 = 20s.
+    // With operator budget maxTutorTurnSec=15, 20s > 15s → overBudget.
+    const ev = evaluateTalkTimeBudgets(stats, { maxTutorTurnSec: 15 });
+    expect(ev.budgets.maxTutorTurnSec).toBe(15);
+    // Other budget keys fall back to defaults.
+    expect(ev.budgets.maxTutorRatio).toBe(DEFAULT_TALK_TIME_BUDGETS.maxTutorRatio);
+    expect(ev.exceededBy).toContain("maxTutorTurnSec");
+  });
+
+  it("returns overBudget=true when ANY budget is exceeded", () => {
+    const transcript =
+      "Assistant: " + Array(100).fill("a").join(" ") + "\nUser: ok";
+    const stats = computeTalkTimeStats(transcript);
+    const ev = evaluateTalkTimeBudgets(stats);
+    // Both budgets blown (40s turn + ratio ≈ 0.99).
+    expect(ev.overBudget).toBe(true);
+    expect(ev.exceededBy).toHaveLength(2);
+  });
+
+  it("handles null / undefined budgets gracefully (falls back to defaults)", () => {
+    const stats = computeTalkTimeStats("Assistant: short.\nUser: short.");
+    const ev1 = evaluateTalkTimeBudgets(stats, null);
+    const ev2 = evaluateTalkTimeBudgets(stats, undefined);
+    expect(ev1.budgets).toEqual(DEFAULT_TALK_TIME_BUDGETS);
+    expect(ev2.budgets).toEqual(DEFAULT_TALK_TIME_BUDGETS);
+  });
+});


### PR DESCRIPTION
**Closes #1747.** **Parent epic:** #1700 (IELTS Pre-Voice Testing Theme 7).

Pure post-call telemetry helpers + the operator-facing budget knob. Surfaces the "tutor doesn't speak >30s continuously / >20% of session" class of failure for review in AttainmentTab. Chip + AppLog emission deferred to follow-on (see "Out of scope" below).

## What ships

| File | Change |
|---|---|
| `lib/voice/talk-time-stats.ts` (new) | `computeTalkTimeStats(transcript)` + `evaluateTalkTimeBudgets(stats, budgets)` — pure functions. Parses canonical `User:` / `Assistant:` format. Word counts → approximate duration via `DEFAULT_WORDS_PER_SECOND = 2.5` (≈ 150 WPM). |
| `lib/types/json-fields.ts` | Extends `PlaybookConfig.talkTimeBudgets?: { maxTutorTurnSec?, maxTutorRatio? }`. Defaults: 30s / 0.2. |
| `lib/journey/setting-contracts.entries.ts` | New G7 entry `talkTimeBudgets` (json-fallback control until Theme 1b primitive). `composeImpact.sections: []` — telemetry only, no composer impact. |
| `tests/lib/voice/talk-time-stats.test.ts` (new) | 13 vitests — zero-default safety, canonical parsing, continuation lines, max-tutor-turn tracking, ratio math, evaluation against defaults / overrides. |
| `tests/lib/journey/registry-completeness.test.ts` | G7 count `6 → 7`; total `51 → 52`. |
| `tests/components/journey-tab/CommandPalette.test.tsx` | Palette index `62 → 63`. |

## Lattice survey

Per `.claude/rules/lattice-survey.md`:

1. **Surface** — new pure helper + `PlaybookConfig.talkTimeBudgets` Json key + G7 setting entry. No new DB writes in this PR.
2. **Sibling writers/readers** — `grep -rn "talkTime"` zero hits; no existing talk-time computation. `voice.*` AppLog namespace established at `lib/voice/providers/vapi/index.ts:285` + `lib/voice/llm-proxy/verify-vapi-secret.ts` — my future emitter (`voice.talk_time.over_budget`) matches the convention.
3. **Catalogues** — `no-direct-playbook-config-write` (#852) not exercised (read-side only); `ai-to-db-guard.md` N/A (no AI path); `lattice-survey.md` discipline applied.
4. **Risk shapes:**
   - Sibling-writer drift: none
   - Default-deny gates: not exercised (pure type extension on PlaybookConfig, no `prisma.playbook.update`)
   - Cascade respect: G7 setting declares `cascadeSources: []` (course-only, matches sibling G7 entries)
   - Convention conflict: AppLog subject naming follows precedent
5. **Convergence:** single helper, single config knob, single future emitter site.

## Out of scope — explicit follow-ons (will file once #1741 merges)

| Follow-on | Why deferred |
|---|---|
| AppLog `voice.talk_time.over_budget` emission site | Naturally extends `endSession`'s `evaluateIncompleteAttempt` block landing in #1741 — same post-update side-effect chain. Keep the surfaces together. |
| AttainmentTab yellow chip | Read-side render. Extend an existing per-call API route. Sized ~0.3d. |
| Runtime intervention | Explicitly deferred per gap-analysis risk register. |

## Test plan

- [x] **39 vitests green locally** — 13 helper + 17 registry-completeness + 9 CommandPalette
- [ ] hf-dev smoke after merge: edit `talkTimeBudgets` via Cmd+K palette → setting persists
- [ ] Follow-on PR wires AppLog emission + AttainmentTab chip

## Verified by

- 39/39 vitests green
- Pre-push tsc + lint clean
- Lattice survey result documented above + in commit body
- `voice.*` AppLog namespace verified against sibling subjects in `lib/voice/providers/vapi/index.ts:285`

## Deploy

`/vm-cp` (code-only — no migration).
