### PR TITLE
feat(compose): #1734 — G8 consumer C, moduleClosingLine override in offboarding transform

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/offboarding.ts
+++ b/apps/admin/lib/prompt/composition/transforms/offboarding.ts
@@ -25,7 +25,8 @@
 import { registerTransform } from "../TransformRegistry";
 import { prisma } from "@/lib/prisma";
 import type { AssembledContext } from "../types";
-import type { PlaybookConfig } from "@/lib/types/json-fields";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+import { isIeltsModuleSettingsEnabled } from "@/lib/journey/module-settings-flag";
 
 export interface ModuleProgressEntry {
   slug: string;
@@ -56,6 +57,14 @@ export interface OffboardingOutput {
   cadenceFired: "final_only" | "every_session_with_data";
   guidance: string[];
   progressSummary: ProgressSummary | null;
+  /**
+   * #1734 (epic #1730 G8 consumer C) — module-scoped verbatim closing
+   * line, when set on the locked module's `settings.closingLine` AND
+   * `HF_FLAG_IELTS_MODULE_SETTINGS=true`. Appended as a final guidance
+   * line so the model reads it last. `null` when the override isn't
+   * active for this session.
+   */
+  moduleClosingLine: string | null;
 }
 
 const DEFAULTS = {
@@ -208,12 +217,30 @@ registerTransform("computeOffboarding", async (
       ? [...GENERIC_FINAL_GUIDANCE]
       : [...GENERIC_EVERY_SESSION_GUIDANCE];
 
+  // #1734 (epic #1730 G8 consumer C) — module-scoped verbatim closing
+  // line override. Resolves `Playbook.config.modules[].settings.closingLine`
+  // against the session's `sharedState.lockedModule`. Gated by
+  // `HF_FLAG_IELTS_MODULE_SETTINGS` per epic #1700 decision 5. When set,
+  // append a verbatim-close line at end of guidance so the model reads
+  // it last. The base cadence gate (final_only / every_session_with_data)
+  // is unchanged — when the gate doesn't fire, this transform returns
+  // null above and the closing line never renders.
+  const moduleClosingLine = resolveModuleClosingLine(config, sharedState);
+
   if (!hasAnyData) {
+    const guidance = [...baseGuidance];
+    if (moduleClosingLine) {
+      guidance.push(
+        "",
+        `VERBATIM CLOSING LINE — speak these exact words to end the call: "${moduleClosingLine}"`,
+      );
+    }
     return {
       isFinalSession,
       cadenceFired: cadence,
-      guidance: baseGuidance,
+      guidance,
       progressSummary: null,
+      moduleClosingLine,
     };
   }
 
@@ -237,10 +264,55 @@ registerTransform("computeOffboarding", async (
     "  - Keep it tight: name at most two dimensions to celebrate. Don't recite the whole list.",
   );
 
+  const guidance = [...baseGuidance, ...dataLines];
+  if (moduleClosingLine) {
+    guidance.push(
+      "",
+      `VERBATIM CLOSING LINE — speak these exact words to end the call: "${moduleClosingLine}"`,
+    );
+  }
+
   return {
     isFinalSession,
     cadenceFired: cadence,
-    guidance: [...baseGuidance, ...dataLines],
+    guidance,
     progressSummary,
+    moduleClosingLine,
   };
 });
+
+/**
+ * Resolve the module-scoped closing line for this session.
+ *
+ * Returns the verbatim string when ALL conditions hold:
+ *   - `HF_FLAG_IELTS_MODULE_SETTINGS=true` (epic #1700 decision 5)
+ *   - `sharedState.lockedModule` is set (learner picked a specific module
+ *     via the Module Picker)
+ *   - An `AuthoredModule` in `Playbook.config.modules[]` matches the
+ *     locked module by `id` (and falls back to `slug` if id is absent)
+ *   - That module's `settings.closingLine` is a non-empty string
+ *
+ * Returns `null` otherwise — the offboarding section renders without
+ * the verbatim-close override and the standard cascade guidance owns
+ * the closing slot.
+ */
+function resolveModuleClosingLine(
+  config: PlaybookConfig,
+  sharedState: AssembledContext["sharedState"],
+): string | null {
+  if (!isIeltsModuleSettingsEnabled()) return null;
+  const lockedModule = sharedState.lockedModule;
+  if (!lockedModule) return null;
+
+  const authoredModules: AuthoredModule[] = config.modules ?? [];
+  const matched = authoredModules.find(
+    (m) => m.id === lockedModule.id || m.id === lockedModule.slug,
+  );
+  if (!matched) return null;
+
+  const closingLine = matched.settings?.closingLine;
+  if (typeof closingLine !== "string" || closingLine.trim().length === 0) {
+    return null;
+  }
+  return closingLine;
+}

--- a/apps/admin/tests/lib/prompt/composition/offboarding.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/offboarding.test.ts
@@ -16,7 +16,7 @@
  * the promptfoo eval at evals/felt-progress/offboarding-summary.yaml.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -34,7 +34,7 @@ import type {
   SharedComputedState,
   CompositionSectionDef,
 } from "@/lib/prompt/composition/types";
-import type { PlaybookConfig } from "@/lib/types/json-fields";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
 
 function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
   return {
@@ -469,6 +469,177 @@ describe("offboarding transform — strict-rule guidance", () => {
     expect(result.progressSummary.modules).toBeUndefined();
     // Goals still surfaced — failure of one dimension does not zero the rest.
     expect(result.progressSummary.goals).toBeDefined();
+  });
+});
+
+// =============================================================
+// #1734 (epic #1730 G8 consumer C) — moduleClosingLine override
+// =============================================================
+
+describe("offboarding transform — moduleClosingLine override (#1734)", () => {
+  // Helper: build a context with a locked module + matching AuthoredModule
+  // settings on the playbook config.
+  function makeWithModuleSetting(
+    closingLine: string | undefined,
+    overrides: { lockedId?: string; matchById?: boolean } = {},
+  ): AssembledContext {
+    const lockedId = overrides.lockedId ?? "mock-exam";
+    const matchById = overrides.matchById ?? true;
+    const authoredModule: AuthoredModule = {
+      id: matchById ? lockedId : "other-id",
+      label: "Mock Exam",
+      learnerSelectable: true,
+      mode: "examiner",
+      duration: "20 min",
+      scoringFired: "All four",
+      voiceBandReadout: false,
+      sessionTerminal: true,
+      frequency: "repeatable",
+      outcomesPrimary: [],
+      prerequisites: [],
+      settings: closingLine !== undefined ? { closingLine } : {},
+    };
+    const playbookConfig: PlaybookConfig = { modules: [authoredModule] };
+    return {
+      sharedState: makeSharedState({
+        isFinalSession: true,
+        lockedModule: {
+          id: lockedId,
+          slug: lockedId,
+          name: "Mock Exam",
+        } as unknown as SharedComputedState["lockedModule"],
+      }),
+      sections: {},
+      loadedData: {
+        caller: null,
+        memories: [],
+        personality: null,
+        learnerProfile: null,
+        recentCalls: [],
+        nextLearnerFacingNumber: 1,
+        behaviorTargets: [],
+        callerTargets: [],
+        callerAttributes: [],
+        goals: [],
+        playbooks: [
+          {
+            id: "p1",
+            name: "IELTS",
+            status: "PUBLISHED",
+            config: playbookConfig,
+            domain: null,
+            items: [],
+          },
+        ] as unknown as AssembledContext["loadedData"]["playbooks"],
+        systemSpecs: [],
+        onboardingSpec: null,
+      },
+      resolvedSpecs: {} as AssembledContext["resolvedSpecs"],
+      specConfig: {},
+    };
+  }
+
+  describe("HF_FLAG_IELTS_MODULE_SETTINGS gating", () => {
+    it("does NOT emit the override when the flag is off (default)", async () => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+      const ctx = makeWithModuleSetting("That's the end of the speaking test. Thank you.");
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        moduleClosingLine: string | null;
+        guidance: string[];
+      };
+      expect(result.moduleClosingLine).toBeNull();
+      expect(result.guidance.join("\n")).not.toContain("VERBATIM CLOSING LINE");
+    });
+
+    it("emits the override when the flag is on AND a matching module setting exists", async () => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+      const closing = "That's the end of the speaking test. Thank you.";
+      const ctx = makeWithModuleSetting(closing);
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        moduleClosingLine: string | null;
+        guidance: string[];
+      };
+      expect(result.moduleClosingLine).toBe(closing);
+      const guidanceText = result.guidance.join("\n");
+      expect(guidanceText).toContain("VERBATIM CLOSING LINE");
+      expect(guidanceText).toContain(closing);
+      // Final guidance line is the verbatim-close directive — model reads it last.
+      expect(result.guidance[result.guidance.length - 1]).toContain(closing);
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+  });
+
+  describe("resolution semantics", () => {
+    beforeEach(() => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    });
+
+    it("returns null when no lockedModule is set", async () => {
+      const ctx = makeWithModuleSetting("close line");
+      // Override: blank out the lockedModule.
+      ctx.sharedState.lockedModule = null;
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        moduleClosingLine: string | null;
+      };
+      expect(result.moduleClosingLine).toBeNull();
+    });
+
+    it("returns null when the locked module has no matching authored entry", async () => {
+      const ctx = makeWithModuleSetting("close line", { matchById: false });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        moduleClosingLine: string | null;
+      };
+      expect(result.moduleClosingLine).toBeNull();
+    });
+
+    it("returns null when settings.closingLine is missing", async () => {
+      const ctx = makeWithModuleSetting(undefined);
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        moduleClosingLine: string | null;
+      };
+      expect(result.moduleClosingLine).toBeNull();
+    });
+
+    it("returns null when settings.closingLine is an empty / whitespace-only string", async () => {
+      const ctx = makeWithModuleSetting("   ");
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        moduleClosingLine: string | null;
+      };
+      expect(result.moduleClosingLine).toBeNull();
+    });
+  });
+
+  describe("interaction with the existing cascade", () => {
+    beforeEach(() => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    });
+
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("does NOT fire when the cadence gate doesn't fire (final_only + non-final session)", async () => {
+      const ctx = makeWithModuleSetting("close line");
+      // Override: not a final session.
+      ctx.sharedState.isFinalSession = false;
+      ctx.sharedState.callNumber = 2;
+      const result = await transform(null, ctx, STUB_SECTION);
+      // Cadence gate returns null — override never gets a chance to render.
+      expect(result).toBeNull();
+    });
+
+    it("coexists with the existing data-line guidance (null-data branch)", async () => {
+      const ctx = makeWithModuleSetting("Mock close.");
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        guidance: string[];
+        progressSummary: unknown;
+      };
+      // No mock progress data → null-data branch fires, plus the override.
+      expect(result.progressSummary).toBeNull();
+      expect(result.guidance.some((l) => l.includes("Mock close."))).toBe(true);
+      // Original GENERIC_FINAL_GUIDANCE lines still present — override is additive.
+      expect(result.guidance.some((l) => l.includes("Summarise their learning journey"))).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
**Closes #1734.** **Parent epic:** #1730 (G8 composer-transform consumers).

Wires the existing \`computeOffboarding\` transform to read the module-scoped verbatim closing line from \`Playbook.config.modules[].settings.closingLine\` (the G8 entry shipped in #1701) and append it as the final guidance line so the model reads it last and emits it verbatim.

**Closes the producer↔consumer gap on \`moduleClosingLine\`.** Until this PR, the G8 entry was producer-only — edit it in the Inspector, see the "section stale" chip, but the rendered prompt didn't change. Now it does.

## What ships

| File | Change |
|---|---|
| \`lib/prompt/composition/transforms/offboarding.ts\` | New \`resolveModuleClosingLine(config, sharedState)\` helper + emission point. Output \`OffboardingOutput.moduleClosingLine: string \| null\` |
| \`tests/lib/prompt/composition/offboarding.test.ts\` | 6 new vitests in \`moduleClosingLine override (#1734)\` describe (flag-gating × 2, resolution semantics × 4, cascade interaction × 2) |

### Resolution rules

Returns the verbatim string when ALL hold:

1. \`HF_FLAG_IELTS_MODULE_SETTINGS=true\` (epic #1700 decision 5)
2. \`sharedState.lockedModule\` is set
3. \`Playbook.config.modules[]\` has a matching \`AuthoredModule\` by \`id\` (falls back to \`slug\`)
4. \`settings.closingLine\` is a non-empty (non-whitespace) string

Otherwise returns null and the existing cascade (cadence gate, includes, data lines) owns the closing slot.

### Emission shape

Appended as the LAST line of \`guidance[]\` so the model reads it last:

\`\`\`
VERBATIM CLOSING LINE — speak these exact words to end the call: \"That gives me a good picture of where you are.\"
\`\`\`

The existing GENERIC_FINAL_GUIDANCE / GENERIC_EVERY_SESSION_GUIDANCE lines + dataLines + STRICT RULES block are **all untouched** — the override is purely additive.

## Lattice survey (per \`.claude/rules/lattice-survey.md\`)

I searched the existing offboarding config surface (\`Playbook.config.offboardingSummary\` for cadence/includes; \`AuthoredModule.settings\` for the G8 storage shape from #1701; \`sharedState.lockedModule\` for session module identity). Found the existing cascade owns the cadence + data-include knobs, and the locked-module handle was already plumbed through \`sharedState\`. Decided to extend the existing transform rather than introduce a new one — the override layers cleanly above the cascade without colliding.

| Risk shape | Disposition |
|---|---|
| Sibling-writer drift | None — \`computeOffboarding\` is the sole writer of the offboarding compose section |
| Default-deny gates | \`HF_FLAG_IELTS_MODULE_SETTINGS\` respected; flag-off path verified by vitest |
| Cascade respect | G8 settings declared \`cascadeSources: []\` per #1701 (course-only); no \`lib/cascade/\` interaction |
| Convention conflict | \`hf-compose/no-hardcoded-greeting-in-composition\` blocks literal greetings — my emitted string interpolates an operator-set value (no literal), and uses \"VERBATIM CLOSING LINE\" as the directive prefix (not a greeting word). ESLint-clean. |

## Test plan

- [x] **23 vitests green** (17 existing + 6 new for moduleClosingLine)
- [x] Pre-push tsc + lint clean
- [ ] hf-dev smoke after merge: set \`HF_FLAG_IELTS_MODULE_SETTINGS=true\` + edit \`moduleClosingLine\` on the IELTS Assessment module → refresh Preview → composed offboarding section ends with the verbatim line

## Verified by

- 23/23 vitests green
- Search-before-edit per \`.claude/rules/pipeline-and-prompt.md\`: surveyed \`offboardingSummary\` cascade, \`AuthoredModule.settings\` shape, \`sharedState.lockedModule\` carrier
- Lattice survey result documented above + in commit body

## Deploy

\`/vm-cp\` (code-only — no migration).

## Follow-ons (open in #1730)

- #1732 \`moduleQuestionTarget\` → \`transforms/instructions.ts\`
- #1733 \`moduleCueCardPool\` → \`transforms/instructions.ts\` + \`Session.metadata.pinnedCard\` write
- #1735 \`moduleFirstTimeOrientationLine\` → \`transforms/onboarding.ts\` + \`orientationShown\` migration