### PR TITLE
chore(kb): split kb-integrity CI job + close pre-commit gap

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -141,19 +141,29 @@ apps/admin/docs-archive/bdd-specs/*)
 fi
 
 # 6) Auto-regen the KB Tier-2 generated facts when their inputs change.
-#    Schema edits → model-map; route edits → route-inventory; overrides
-#    edits → model-map. Adds the regenerated JSON to the same commit so
-#    the CI freshness gate (kb:check, .github/workflows/test.yml) passes
-#    without a follow-up commit. Non-blocking on failure. See docs/kb/README.md.
+#    Schema edits → model-map; route edits → route-inventory + operator-
+#    surfaces; cascade knob-keys / compose affecting-keys edits → demo-
+#    knobs; any apps/admin source edit → coupling-graph. Adds regenerated
+#    JSON to the same commit so the CI freshness gate (kb-integrity job,
+#    .github/workflows/test.yml) passes without a follow-up commit. Each
+#    regen step is non-blocking on failure. See docs/kb/README.md.
 if command -v npx >/dev/null 2>&1; then
   schema_changed="0"
   routes_changed="0"
+  knob_keys_changed="0"
+  source_changed="0"
   while IFS= read -r f; do
     case "$f" in
       apps/admin/prisma/schema.prisma|docs/kb/model-map-overrides.json)
         schema_changed="1" ;;
       apps/admin/app/api/*route.ts)
         routes_changed="1" ;;
+      apps/admin/lib/cascade/knob-keys.ts|apps/admin/lib/compose/affecting-keys.ts)
+        knob_keys_changed="1" ;;
+    esac
+    case "$f" in
+      apps/admin/*.ts|apps/admin/*.tsx)
+        source_changed="1" ;;
     esac
   done <<< "${STAGED_FILES}"
 
@@ -172,6 +182,33 @@ if command -v npx >/dev/null 2>&1; then
       git add docs/kb/generated/route-inventory.json
     else
       echo "[pre-commit] ⚠ route-inventory regen failed (non-blocking). Run: cd apps/admin && npm run kb:routes"
+    fi
+
+    echo "[pre-commit] Regenerating docs/kb/generated/operator-surfaces.json..."
+    if (cd apps/admin && npx tsx scripts/capture/operator-surfaces.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/operator-surfaces.json
+    else
+      echo "[pre-commit] ⚠ operator-surfaces regen failed (non-blocking). Run: cd apps/admin && npm run kb:operator-surfaces"
+    fi
+  fi
+
+  if [[ "$knob_keys_changed" == "1" ]]; then
+    echo "[pre-commit] Regenerating docs/kb/generated/demo-knobs.json..."
+    if (cd apps/admin && npx tsx scripts/capture/demo-knobs.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/demo-knobs.json
+    else
+      echo "[pre-commit] ⚠ demo-knobs regen failed (non-blocking). Run: cd apps/admin && npm run kb:demo-knobs"
+    fi
+  fi
+
+  # coupling-graph walks the whole apps/admin source tree (~1.4s); any
+  # staged .ts/.tsx edit there can shift import edges.
+  if [[ "$source_changed" == "1" ]]; then
+    echo "[pre-commit] Regenerating docs/kb/generated/coupling-graph.json..."
+    if (cd apps/admin && npx tsx scripts/capture/coupling-graph.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/coupling-graph.json
+    else
+      echo "[pre-commit] ⚠ coupling-graph regen failed (non-blocking). Run: cd apps/admin && npm run kb:coupling"
     fi
   fi
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,15 +107,6 @@ jobs:
       - name: AI-CAPABILITIES.md drift guard
         run: npm run docs:ai-capabilities:check
 
-      # KB integrity. Blocking. Runs the meta-ratchet that holds every
-      # custom ESLint rule pointing back at its guard-registry anchor
-      # (check-guard-kb-links.ts), and the freshness check that fails
-      # if docs/kb/generated/*.json drifted from the schema/route walk
-      # (check-kb-fresh.sh, ignores the volatile generatedAt). See
-      # docs/kb/README.md. Same one-liner as `ctl check` step 8/8.
-      - name: KB integrity (guard back-links + generated-fact freshness)
-        run: npm run kb:check
-
       # Incident → invariant → guard ritual (#1424). Only fires when this PR
       # closes an issue labelled `incident` AND that issue has a post-mortem
       # KB-additions comment. No-op for normal PRs. See:
@@ -127,7 +118,50 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx tsx scripts/capture/check-incident-guard-ritual.ts
 
-  # Job 2: Unit Tests
+  # Job 2: KB integrity
+  #
+  # Split out of the lint job (2026-06-16) so an unrelated ESLint or tsc
+  # error doesn't mask staleness. The lint step exiting 1 prevents every
+  # later step in its job from running, which let docs/kb/generated/*.json
+  # drift silently for three days while admin-merges shipped over red CI.
+  # See the closing of that gap in this PR.
+  kb-integrity:
+    name: KB Integrity
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/admin
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: apps/admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Needed by check-tsc-protected-files.ts — invokes tsc against files
+      # that reference the Prisma client; without a generated client they
+      # report phantom errors masking the real protected-file checks.
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      # KB integrity. Blocking. Runs the meta-ratchet that holds every
+      # custom ESLint rule pointing back at its guard-registry anchor
+      # (check-guard-kb-links.ts), and the freshness check that fails
+      # if docs/kb/generated/*.json drifted from the schema/route walk
+      # (check-kb-fresh.sh, ignores the volatile generatedAt). See
+      # docs/kb/README.md. Same one-liner as `ctl check` step 8/8.
+      - name: KB integrity (guard back-links + generated-fact freshness)
+        run: npm run kb:check
+
+  # Job 3: Unit Tests
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -287,12 +321,13 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [lint, unit-tests, integration-tests, build]
+    needs: [lint, kb-integrity, unit-tests, integration-tests, build]
     if: always()
     steps:
       - name: Check all jobs
         run: |
           if [ "${{ needs.lint.result }}" != "success" ] || \
+             [ "${{ needs.kb-integrity.result }}" != "success" ] || \
              [ "${{ needs.unit-tests.result }}" != "success" ] || \
              [ "${{ needs.integration-tests.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ]; then

--- a/.ratchet.json
+++ b/.ratchet.json
@@ -6,5 +6,5 @@
   "knip_unused": 162,
   "same_issue_fix_chain_max": 10,
   "memory_md_bytes": 29422,
-  "npm_audit_high_crit": 6
+  "npm_audit_high_crit": 3
 }

--- a/apps/admin/eslint-rules/no-bare-module-progress-update.mjs
+++ b/apps/admin/eslint-rules/no-bare-module-progress-update.mjs
@@ -26,6 +26,8 @@
  *   - app/api/callers/[callerId]/reset/route.ts (same)
  *   - scripts/backfill-950-stuck-module-status.ts (one-off backfill)
  *   - scripts/cleanup-placeholder-lo-scores.ts    (cleanup script)
+ *   - prisma/backfill-modules.ts                  (one-off backfill — pre-#1703 code,
+ *                                                  same shape as scripts/backfill-*)
  *
  * .createMany (enrollment-time instantiator) is intentionally NOT blocked
  * — only .update and .upsert.
@@ -43,6 +45,7 @@ const ALLOWED_PATH_SUFFIXES = [
   "app/api/callers/[callerId]/reset/route.ts",
   "scripts/backfill-950-stuck-module-status.ts",
   "scripts/cleanup-placeholder-lo-scores.ts",
+  "prisma/backfill-modules.ts",
 ];
 
 const ALLOWED_PATH_CONTAINS = [

--- a/apps/admin/eslint-rules/require-tiered-redactor.mjs
+++ b/apps/admin/eslint-rules/require-tiered-redactor.mjs
@@ -41,8 +41,8 @@ const POLICY_IMPORT_PREFIX = "@/lib/rbac/policies/";
 const REDACTOR_NAME_RE = /^redact[A-Z][A-Za-z0-9]*ForTier$/;
 
 // Skip files that legitimately mention `@tieredVisibility` as data (test
-// fixtures, rule source itself, KB docs). Same allow-list convention as
-// `no-bare-strategy-key.mjs`.
+// fixtures, rule source itself, KB docs, the eslint config that wires
+// the rule). Same allow-list convention as `no-bare-strategy-key.mjs`.
 const ALLOWLIST_PATH_FRAGMENTS = [
   ".test.",
   ".spec.",
@@ -50,6 +50,7 @@ const ALLOWLIST_PATH_FRAGMENTS = [
   "/tests/",
   "/eslint-rules/",
   "/docs/",
+  "eslint.config.",
 ];
 
 function isAllowlistedFile(filename) {

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.30",
+      "version": "0.8.31",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",
@@ -2227,12 +2227,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2251,21 +2251,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -2282,13 +2282,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -2298,14 +2298,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -2315,37 +2315,37 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2383,9 +2383,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2393,14 +2393,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2463,31 +2463,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2955,9 +2955,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2972,9 +2972,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -2989,9 +2989,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -3006,9 +3006,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -3023,9 +3023,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -3040,9 +3040,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -3074,9 +3074,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -3091,9 +3091,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -3108,9 +3108,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -3125,9 +3125,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -3142,9 +3142,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -3159,9 +3159,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -3176,9 +3176,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3193,9 +3193,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3210,9 +3210,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -3227,9 +3227,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -3244,9 +3244,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -3261,9 +3261,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -3278,9 +3278,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -3295,9 +3295,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -3329,9 +3329,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -3346,9 +3346,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -3363,9 +3363,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -3380,9 +3380,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -5910,9 +5910,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
-      "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5923,9 +5923,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6116,13 +6116,13 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
-      "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/core": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6234,14 +6234,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
-      "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.0",
-        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6252,15 +6252,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.0.tgz",
-      "integrity": "sha512-YhswtasmsbIGEFvLGvR9p/y3PVRTfFf+mgY8van4Ygpnv4sA3vooAjvh+qAn9PNWxs4/IwGGqiQS0PPsaRJ0vQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.8.0.tgz",
+      "integrity": "sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.6.0",
-        "@opentelemetry/core": "2.6.0",
-        "@opentelemetry/sdk-trace-base": "2.6.0"
+        "@opentelemetry/context-async-hooks": "2.8.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -8907,31 +8907,10 @@
         "@redis/client": "^5.12.1"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
-      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
-      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
-      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -8940,12 +8919,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
-      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -8954,12 +8936,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
-      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -8968,26 +8953,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
-      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
-      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -8996,12 +8970,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
-      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -9010,26 +8987,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
-      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
-      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -9038,12 +9004,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
-      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -9052,40 +9021,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
-      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
-      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
-      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -9094,54 +9038,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
-      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
-      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
-      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
-      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -9150,7 +9055,140 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.61.1",
@@ -9163,104 +9201,6 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
-      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
-      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
-      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
-      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
-      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
-      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
-      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -11245,9 +11185,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -11772,15 +11712,15 @@
       }
     },
     "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -12465,16 +12405,16 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
-      "integrity": "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.5",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.53",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.18.0"
       },
@@ -12482,7 +12422,7 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -15969,9 +15909,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
-      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15984,46 +15924,24 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.20.1"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
-      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.20.1",
+        "ws": "~8.21.0",
         "xmlhttprequest-ssl": "~2.1.1"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/engine.io-parser": {
@@ -16058,28 +15976,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -16340,9 +16236,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -16353,32 +16249,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -17693,17 +17589,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -18573,9 +18469,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -18840,9 +18736,9 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core": {
-      "version": "5.4.20",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.20.tgz",
-      "integrity": "sha512-3jdfmJvV67DOlzHfNgLFkRgitmly/qlq/MBqfVuFEugNe4zrYQar8IRIfby635ZpbKR4PmdmRjIjn5f0kQy2Ig==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.21.tgz",
+      "integrity": "sha512-0abFSkEk8biJ6XbvdlhteB/CPibmPX11xBi27uv2WPt8M0Rhu4RaUN638jKQ46WcsE3S4f3pb+WlkPcHiQjYkA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -18856,7 +18752,7 @@
         "dotenv": "16.4.5",
         "extend": "3.0.2",
         "file-type": "21.3.2",
-        "form-data": "4.0.4",
+        "form-data": "4.0.6",
         "isstream": "0.1.2",
         "jsonwebtoken": "9.0.3",
         "load-esm": "1.0.3",
@@ -18918,24 +18814,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/ibm-cloud-sdk-core/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/ms": {
@@ -20174,10 +20052,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -26987,50 +26875,56 @@
       "license": "BSD-2-Clause",
       "optional": true
     },
-    "node_modules/rollup": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
-      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.9"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.61.1",
-        "@rollup/rollup-android-arm64": "4.61.1",
-        "@rollup/rollup-darwin-arm64": "4.61.1",
-        "@rollup/rollup-darwin-x64": "4.61.1",
-        "@rollup/rollup-freebsd-arm64": "4.61.1",
-        "@rollup/rollup-freebsd-x64": "4.61.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
-        "@rollup/rollup-linux-arm64-musl": "4.61.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
-        "@rollup/rollup-linux-loong64-musl": "4.61.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
-        "@rollup/rollup-linux-x64-gnu": "4.61.1",
-        "@rollup/rollup-linux-x64-musl": "4.61.1",
-        "@rollup/rollup-openbsd-x64": "4.61.1",
-        "@rollup/rollup-openharmony-arm64": "4.61.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
-        "@rollup/rollup-win32-x64-gnu": "4.61.1",
-        "@rollup/rollup-win32-x64-msvc": "4.61.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
+    },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -27812,36 +27706,14 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
-      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.20.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "ws": "~8.21.0"
       }
     },
     "node_modules/socket.io-client": {
@@ -28804,9 +28676,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -29055,14 +28927,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -29803,18 +29674,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -29830,9 +29700,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -29845,13 +29716,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -29892,22 +29766,265 @@
         "vite": "*"
       }
     },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">= 12.0.0"
       },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/vite/node_modules/picomatch": {

--- a/apps/admin/tests/eslint-rules/require-tiered-redactor.test.ts
+++ b/apps/admin/tests/eslint-rules/require-tiered-redactor.test.ts
@@ -68,6 +68,14 @@ tester.run("require-tiered-redactor", rule as never, {
         }
       `,
     },
+    {
+      name: "eslint.config.mjs mentions @tieredVisibility as wiring documentation — allow-listed",
+      filename: "/repo/apps/admin/eslint.config.mjs",
+      code: `
+        // Wave C5 wiring: '@tieredVisibility' tag enforces redactor pattern.
+        export default [{ rules: { "hf-rbac/require-tiered-redactor": "error" } }];
+      `,
+    },
   ],
   invalid: [
     {

--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -14,6 +14,28 @@ and classifies everything by **"does it survive the hardening?"**.
 The work is overwhelmingly **consolidation, not creation** — most of the knowledge
 already exists, scattered across mechanisms that were never designed as one system.
 
+## Lattice — the four pillars this KB catalogues
+
+**Lattice** is the umbrella term (2026-06-16) for HF's structural-enforcement
+infrastructure. New structural infra must ship *with* its paired guard + rule.
+"Lattice violation" = bypass; "off-Lattice change" = exists outside the system.
+
+| Pillar | What it is | Lives in | KB index |
+|---|---|---|---|
+| **Chain Contracts** | Cross-stage invariants (Link 3 / Link 4 / Session boundaries) | `docs/CHAIN-CONTRACTS.md` + `docs/CONTRACTS-*.md` | Part 2 prototype |
+| **Guards** | Executable enforcement (ESLint rules + `check-*` scripts + DB-level constraints) | `apps/admin/eslint-rules/`, `scripts/capture/check-*`, `prisma/schema.prisma` | `guard-registry.md` |
+| **Cascade** | Effective-value resolvers (`resolveEffective`, presets, variant pins) | `lib/cascade/`, `lib/banding/`, `lib/config/resolve-*` | Part 1 model-map + Part 2 |
+| **Rules** | Curated guidance that explains *why* a guard exists | `.claude/rules/*.md` | linked from each guard row |
+
+Audit cue: when changes touch any pillar, audit against all four explicitly
+before merge. Lattice-survey discipline (60–90s sibling-writer survey before
+writing/modifying code that touches a shared DB column, crosses a chain-stage
+boundary, registers a new guard/contract, or extends an AI write/read path) —
+PR `## Verified by` must cite the survey result. Memory:
+`feedback_lattice_guard_umbrella.md`, `feedback_lattice_survey_discipline.md`.
+🟡 Rule file `.claude/rules/lattice-survey.md` + CLAUDE.md MANDATORY anchor
+are not yet committed — write them next when you adopt the discipline.
+
 ## Reuse map — what already exists (don't rebuild these)
 
 | Existing artifact | Role | KB tier it satisfies |

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-12T17:02:55.059Z",
+  "generatedAt": "2026-06-16T12:07:54.960Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1710,
-  "edgeCount": 3946,
+  "fileCount": 1801,
+  "edgeCount": 4180,
   "skippedEdges": 1,
   "edges": [
     {
@@ -672,6 +672,30 @@
       "to": "lib/permissions.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/rbac/policies/adaptations.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/aggregate/route.ts",
       "to": "lib/learner-scope.ts"
     },
@@ -694,6 +718,38 @@
     {
       "from": "app/api/callers/[callerId]/artifacts/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/curriculum/playbook-mastery-config.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "app/api/callers/[callerId]/available-media/route.ts",
@@ -888,6 +944,30 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/caller-utils.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/journey-progress/route.ts",
       "to": "lib/learner-scope.ts"
     },
@@ -928,6 +1008,30 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/curriculum/playbook-mastery-config.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/curriculum/scratch-mastery.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/lo-progress/route.ts",
       "to": "lib/curriculum/track-progress.ts"
     },
@@ -956,6 +1060,18 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/module-progress/route.ts",
       "to": "lib/learner-scope.ts"
     },
@@ -965,6 +1081,18 @@
     },
     {
       "from": "app/api/callers/[callerId]/module-progress/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/personality/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/personality/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/personality/route.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -1048,6 +1176,18 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "to": "lib/pipeline/scheduler-decision.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/session-flow-progress/route.ts",
       "to": "lib/config.ts"
     },
@@ -1070,6 +1210,22 @@
     {
       "from": "app/api/callers/[callerId]/session-flow-progress/route.ts",
       "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "app/api/callers/[callerId]/slugs/route.ts",
@@ -1105,6 +1261,22 @@
     },
     {
       "from": "app/api/callers/[callerId]/status/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -1393,6 +1565,10 @@
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/ops/update-targets.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/permissions.ts"
     },
     {
@@ -1445,6 +1621,10 @@
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/pipeline/normalize-score-agent-evidence.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/pipeline/prosody-consumer.ts"
     },
     {
@@ -1462,6 +1642,10 @@
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/pipeline/validate-dependencies.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/pipeline/write-count-logger.ts"
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
@@ -2692,6 +2876,26 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/courses/[courseId]/content-trust/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/content-trust/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "to": "lib/prompt/composition/loaders/conversationArtifacts.ts"
+    },
+    {
       "from": "app/api/courses/[courseId]/course-instructions/route.ts",
       "to": "lib/content-trust/resolve-config.ts"
     },
@@ -2876,6 +3080,46 @@
       "to": "lib/wizard/sync-authored-modules-to-curriculum.ts"
     },
     {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/compose/section-staleness.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/section-staleness-bridge.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/setting-contracts.entries.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/storage-path-applier.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/settings/voice-setting-contracts.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
       "from": "app/api/courses/[courseId]/learners/ensure-cohort/route.ts",
       "to": "lib/permissions.ts"
     },
@@ -2914,6 +3158,18 @@
     {
       "from": "app/api/courses/[courseId]/media/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "to": "lib/prompt/composition/loaders/memoryDeltas.ts"
     },
     {
       "from": "app/api/courses/[courseId]/onboarding/route.ts",
@@ -2996,6 +3252,26 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/compose/recompose-section.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "app/api/courses/[courseId]/reconcile-mcqs/route.ts",
       "to": "lib/content-trust/reconcile-question-linkage.ts"
     },
@@ -3034,6 +3310,30 @@
     {
       "from": "app/api/courses/[courseId]/regenerate-curriculum/route.ts",
       "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "to": "lib/wizard/run-projection-for-playbook.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "to": "lib/compose/section-staleness.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "app/api/courses/[courseId]/session-count-recommendation/route.ts",
@@ -3097,6 +3397,98 @@
     },
     {
       "from": "app/api/courses/[courseId]/setup-status/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/banding/tier-colors.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/banding/tier-colors.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/cascade/effective-value.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-source-lineage/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-source-lineage/route.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -6176,6 +6568,14 @@
       "to": "lib/system-ini.ts"
     },
     {
+      "from": "app/api/system/pipeline-health/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/system/pipeline-health/route.ts",
+      "to": "lib/pipeline/detect-silent-writers.ts"
+    },
+    {
       "from": "app/api/system/readiness/route.ts",
       "to": "lib/prisma.ts"
     },
@@ -8053,14 +8453,6 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
-      "to": "app/x/courses/[courseId]/_components/voice-flow-lens.css"
-    },
-    {
-      "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
-      "to": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx"
-    },
-    {
-      "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "to": "components/callers/caller-detail/StalePromptPillForCourse.tsx"
     },
     {
@@ -8157,6 +8549,10 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "to": "lib/domain/generate-identity.ts"
     },
     {
@@ -8168,12 +8564,32 @@
       "to": "lib/types/json-fields.ts"
     },
     {
-      "from": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
-      "to": "components/shared/HFDrawer.tsx"
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx"
     },
     {
-      "from": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
-      "to": "components/voice/VoiceConfigSection.tsx"
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/designer-shell/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/preview-renderers/_journey-setting-context.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/preview-renderers/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/preview-renderers/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "app/x/courses/[courseId]/chat/ChatLauncher.tsx",
@@ -8245,7 +8661,7 @@
     },
     {
       "from": "app/x/courses/[courseId]/CourseDesignTab.tsx",
-      "to": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx"
+      "to": "app/x/courses/[courseId]/_tab/DesignTab.tsx"
     },
     {
       "from": "app/x/courses/[courseId]/CourseDesignTab.tsx",
@@ -8376,6 +8792,38 @@
       "to": "app/x/courses/[courseId]/course-proof.css"
     },
     {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "app/x/courses/[courseId]/course-skills-tab.css"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/cascade/CascadeInspectorTray.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/BandingPicker.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/CascadeValue.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/TierCell.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/VariantPresetPill.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "lib/banding/tier-colors.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
       "from": "app/x/courses/[courseId]/CourseSummaryCard.tsx",
       "to": "lib/content-categories.ts"
     },
@@ -8473,6 +8921,10 @@
     },
     {
       "from": "app/x/courses/[courseId]/page.tsx",
+      "to": "app/x/courses/[courseId]/CourseSkillsTab.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/page.tsx",
       "to": "app/x/courses/[courseId]/CourseSummaryCard.tsx"
     },
     {
@@ -8494,6 +8946,14 @@
     {
       "from": "app/x/courses/[courseId]/page.tsx",
       "to": "components/help/TabWithHelp.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/page.tsx",
+      "to": "components/journey-tab/CourseJourneyTab.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/page.tsx",
+      "to": "components/journey-tab/SettingsTabVoiceLens.tsx"
     },
     {
       "from": "app/x/courses/[courseId]/page.tsx",
@@ -8538,10 +8998,6 @@
     {
       "from": "app/x/courses/[courseId]/page.tsx",
       "to": "components/shared/SurveyStopDetail.tsx"
-    },
-    {
-      "from": "app/x/courses/[courseId]/page.tsx",
-      "to": "components/voice/VoiceConfigSection.tsx"
     },
     {
       "from": "app/x/courses/[courseId]/page.tsx",
@@ -8762,6 +9218,10 @@
     {
       "from": "app/x/courses/page.tsx",
       "to": "lib/prompt/composition/transforms/audience.ts"
+    },
+    {
+      "from": "app/x/courses/page.tsx",
+      "to": "lib/terminology/types.ts"
     },
     {
       "from": "app/x/courses/page.tsx",
@@ -9430,6 +9890,10 @@
     {
       "from": "app/x/help/demos/page.tsx",
       "to": "lib/auth.ts"
+    },
+    {
+      "from": "app/x/help/glossary/page.tsx",
+      "to": "app/x/help/glossary/help-glossary.css"
     },
     {
       "from": "app/x/help/pipeline-health/page.tsx",
@@ -10360,6 +10824,14 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/x/system/pipeline-health/page.tsx",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/x/system/pipeline-health/page.tsx",
+      "to": "lib/pipeline/detect-silent-writers.ts"
+    },
+    {
       "from": "app/x/taxonomy-graph/page.tsx",
       "to": "components/shared/AdvancedBanner.tsx"
     },
@@ -10848,8 +11320,24 @@
       "to": "lib/roles.ts"
     },
     {
+      "from": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "to": "lib/banding/presets.ts"
+    },
+    {
+      "from": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
       "from": "lib/banding/presets.ts",
       "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "lib/banding/skill-tier-deploy-invariant.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "lib/bdd/ai-parser.ts",
@@ -10886,6 +11374,10 @@
     {
       "from": "lib/cascade/effective-value.ts",
       "to": "lib/cascade/resolvers/identity-spec.ts"
+    },
+    {
+      "from": "lib/cascade/effective-value.ts",
+      "to": "lib/cascade/resolvers/mastery-policy.ts"
     },
     {
       "from": "lib/cascade/effective-value.ts",
@@ -10933,6 +11425,18 @@
     },
     {
       "from": "lib/cascade/resolvers/identity-spec.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/cascade/resolvers/mastery-policy.ts",
+      "to": "lib/cascade/effective-value.ts"
+    },
+    {
+      "from": "lib/cascade/resolvers/mastery-policy.ts",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
+      "from": "lib/cascade/resolvers/mastery-policy.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -10998,6 +11502,10 @@
     {
       "from": "lib/cascade/set-at-layer.ts",
       "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "lib/cascade/use-effective-value.ts",
+      "to": "lib/cascade/layer-types.ts"
     },
     {
       "from": "lib/cascade/voice-explain.ts",
@@ -11368,6 +11876,18 @@
       "to": "lib/chat/wizard-tool-executor/resolvers/course-by-name.ts"
     },
     {
+      "from": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "to": "lib/content-trust/course-ref-to-assertions.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "to": "lib/knowledge/domain-sources.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "lib/chat/wizard-tool-executor/tools/create_community.ts",
       "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
     },
@@ -11377,26 +11897,106 @@
     },
     {
       "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_enroll.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_graph-guard.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_enroll.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
       "to": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
-      "to": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts"
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
-      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
-      "to": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts"
-    },
-    {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
       "to": "lib/domain/update-domain-config.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-subject.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-subject.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/domain/update-domain-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
       "to": "lib/playbook/update-playbook-config.ts"
     },
     {
@@ -11480,6 +12080,18 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/compose/affecting-keys-domain.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/affecting-keys-spec.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/affecting-keys.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
       "from": "lib/compose/bump-curriculum-fanout.ts",
       "to": "lib/compose/bump-timestamp.ts"
     },
@@ -11497,6 +12109,46 @@
     },
     {
       "from": "lib/compose/eager-reprompt-on-bump.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/compose/section-loaders.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/compose/section-staleness.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/prompt/composition/index.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/prompt/composition/renderPromptSummary.ts"
+    },
+    {
+      "from": "lib/compose/section-loaders.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/section-loaders.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/section-staleness.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/section-staleness.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -11634,6 +12286,10 @@
     {
       "from": "lib/content-trust/extract-curriculum.ts",
       "to": "lib/prompts/prompt-settings.ts"
+    },
+    {
+      "from": "lib/content-trust/extract-curriculum.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/content-trust/extract-images.ts",
@@ -12072,6 +12728,14 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/curriculum/mark-module-incomplete.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/curriculum/mark-module-incomplete.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
       "from": "lib/curriculum/playbook-mastery-config.ts",
       "to": "lib/curriculum/mastery-tiers.ts"
     },
@@ -12133,6 +12797,10 @@
     },
     {
       "from": "lib/curriculum/resolve-playbook-for-curriculum.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/curriculum/resolve-skill.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -12206,6 +12874,10 @@
     {
       "from": "lib/curriculum/track-progress.ts",
       "to": "lib/curriculum/scratch-mastery.ts"
+    },
+    {
+      "from": "lib/curriculum/track-progress.ts",
+      "to": "lib/logger.ts"
     },
     {
       "from": "lib/curriculum/track-progress.ts",
@@ -12632,6 +13304,10 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/goals/append-progress-entry.ts",
+      "to": "lib/goals/strategies/types.ts"
+    },
+    {
       "from": "lib/goals/extract-goals.ts",
       "to": "lib/ai/analyst-system-prompts.ts"
     },
@@ -12777,7 +13453,15 @@
     },
     {
       "from": "lib/goals/track-progress.ts",
+      "to": "lib/goals/append-progress-entry.ts"
+    },
+    {
+      "from": "lib/goals/track-progress.ts",
       "to": "lib/goals/strategies/index.ts"
+    },
+    {
+      "from": "lib/goals/track-progress.ts",
+      "to": "lib/goals/strategies/types.ts"
     },
     {
       "from": "lib/goals/track-progress.ts",
@@ -12986,6 +13670,74 @@
     {
       "from": "lib/jobs/curriculum-runner.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/journey/bucket-relations.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/journey/bucket-relations.ts",
+      "to": "lib/journey/setting-contracts.entries.ts"
+    },
+    {
+      "from": "lib/journey/bucket-relations.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/menu-items.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/menu-items.ts",
+      "to": "lib/journey/setting-groups.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/journey/setting-contracts.entries.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/settings/voice-setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.entries.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.entries.ts",
+      "to": "lib/journey/setting-groups.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.ts",
+      "to": "lib/journey/setting-groups.ts"
+    },
+    {
+      "from": "lib/journey/storage-path-applier.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/storage-path-applier.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/journey/use-cascade-edit-field.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/use-cascade-edit-field.ts",
+      "to": "lib/journey/use-glow-state.ts"
     },
     {
       "from": "lib/knowledge/assertions.ts",
@@ -13337,6 +14089,10 @@
     },
     {
       "from": "lib/ops/update-targets.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/ops/update-targets.ts",
       "to": "lib/types/json-fields.ts"
     },
     {
@@ -13373,6 +14129,10 @@
     },
     {
       "from": "lib/pipeline/adaptive-loop-invariants.ts",
+      "to": "lib/pipeline/writer-completeness-invariant.ts"
+    },
+    {
+      "from": "lib/pipeline/adaptive-loop-invariants.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -13406,6 +14166,18 @@
     {
       "from": "lib/pipeline/course-style.ts",
       "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/pipeline/detect-silent-writers.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/detect-silent-writers.ts",
+      "to": "lib/pipeline/write-count-logger.ts"
+    },
+    {
+      "from": "lib/pipeline/detect-silent-writers.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "lib/pipeline/event-gate.ts",
@@ -13536,6 +14308,22 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/pipeline/write-count-logger.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/writer-completeness-invariant.ts",
+      "to": "lib/contracts/writer-registry.ts"
+    },
+    {
+      "from": "lib/pipeline/writer-completeness-invariant.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/writer-completeness-invariant.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "lib/playbook/update-playbook-config.ts",
       "to": "lib/cascade/effective-value.ts"
     },
@@ -13593,6 +14381,10 @@
     },
     {
       "from": "lib/prompt/composition/buildComposeTrace.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/prompt/composition/buildComposeTrace.ts",
       "to": "lib/config.ts"
     },
     {
@@ -13606,6 +14398,14 @@
     {
       "from": "lib/prompt/composition/compose-invariants.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/compose/section-loaders.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/compose/section.ts"
     },
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
@@ -13637,6 +14437,10 @@
     },
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/prompt/composition/transforms/conversationArtifacts.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
       "to": "lib/prompt/composition/transforms/course-instructions.ts"
     },
     {
@@ -13662,6 +14466,10 @@
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
       "to": "lib/prompt/composition/transforms/memories.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/prompt/composition/transforms/memoryDeltas.ts"
     },
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
@@ -13861,11 +14669,19 @@
     },
     {
       "from": "lib/prompt/composition/SectionDataLoader.ts",
+      "to": "lib/prompt/composition/loaders/conversationArtifacts.ts"
+    },
+    {
+      "from": "lib/prompt/composition/SectionDataLoader.ts",
       "to": "lib/prompt/composition/loaders/courseComplete.ts"
     },
     {
       "from": "lib/prompt/composition/SectionDataLoader.ts",
       "to": "lib/prompt/composition/loaders/interleaveReview.ts"
+    },
+    {
+      "from": "lib/prompt/composition/SectionDataLoader.ts",
+      "to": "lib/prompt/composition/loaders/memoryDeltas.ts"
     },
     {
       "from": "lib/prompt/composition/SectionDataLoader.ts",
@@ -13918,6 +14734,14 @@
     {
       "from": "lib/prompt/composition/transforms/audience.ts",
       "to": "lib/prompt/composition/types.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/conversationArtifacts.ts",
+      "to": "lib/prompt/composition/loaders/conversationArtifacts.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/conversationArtifacts.ts",
+      "to": "lib/prompt/composition/TransformRegistry.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/course-instructions.ts",
@@ -14006,6 +14830,14 @@
     {
       "from": "lib/prompt/composition/transforms/memories.ts",
       "to": "lib/prompt/composition/types.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/memoryDeltas.ts",
+      "to": "lib/prompt/composition/loaders/memoryDeltas.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/memoryDeltas.ts",
+      "to": "lib/prompt/composition/TransformRegistry.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/mockDiagnostic.ts",
@@ -14372,6 +15204,10 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/prompt/composition/types.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
       "from": "lib/prompt/PromptTemplateCompiler.ts",
       "to": "lib/constants.ts"
     },
@@ -14394,6 +15230,18 @@
     {
       "from": "lib/prompts/spec-prompts.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/rbac/policies/adaptations.ts",
+      "to": "app/api/callers/[callerId]/adaptations/route.ts"
+    },
+    {
+      "from": "lib/rbac/policies/adaptations.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "lib/rbac/visibility.ts",
+      "to": "lib/roles.ts"
     },
     {
       "from": "lib/recompose/preview.ts",
@@ -14426,6 +15274,10 @@
     {
       "from": "lib/settings/resolver.ts",
       "to": "lib/settings/library-schema.ts"
+    },
+    {
+      "from": "lib/settings/voice-setting-contracts.ts",
+      "to": "lib/journey/setting-contracts.ts"
     },
     {
       "from": "lib/sidebar/storage.ts",
@@ -14570,6 +15422,10 @@
     {
       "from": "lib/system-settings.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/tab-layout.ts",
+      "to": "components/callers/caller-detail/types.ts"
     },
     {
       "from": "lib/terminology.ts",
@@ -14797,7 +15653,23 @@
     },
     {
       "from": "lib/voice/end-session.ts",
+      "to": "lib/curriculum/mark-module-incomplete.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
+      "to": "lib/journey/module-settings-flag.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/voice/end-session.ts",
@@ -15297,7 +16169,19 @@
     },
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/banding/derive-skill-tier-mapping-from-source.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/cascade/resolvers/mastery-policy.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
       "to": "lib/content-trust/extract-assertions.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
     },
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
@@ -15402,6 +16286,18 @@
     {
       "from": "scripts/backfill-cio-cto-playbook-configs.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-cto-projection.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-cto-projection.ts",
+      "to": "lib/wizard/apply-projection.ts"
+    },
+    {
+      "from": "scripts/backfill-cto-projection.ts",
+      "to": "lib/wizard/project-course-reference.ts"
     },
     {
       "from": "scripts/backfill-curriculum-anchors.ts",
@@ -15524,6 +16420,14 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "scripts/check-skill-tier-deploy-readiness.ts",
+      "to": "lib/banding/skill-tier-deploy-invariant.ts"
+    },
+    {
+      "from": "scripts/check-writer-registry.ts",
+      "to": "lib/contracts/writer-registry.ts"
+    },
+    {
       "from": "scripts/cleanup-orphaned-slugs.ts",
       "to": "lib/prisma.ts"
     },
@@ -15564,6 +16468,10 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "scripts/fix-cio-cto-playbooks.ts",
+      "to": "lib/goals/strategies/types.ts"
+    },
+    {
       "from": "scripts/generate-ai-capabilities.ts",
       "to": "docs-archive/bdd-specs/TOOLS-001-voice-tool-definitions.spec.json"
     },
@@ -15578,6 +16486,10 @@
     {
       "from": "scripts/generate-ai-capabilities.ts",
       "to": "lib/chat/course-ref-tools.ts"
+    },
+    {
+      "from": "scripts/generate-writer-coverage-doc.ts",
+      "to": "lib/contracts/writer-registry.ts"
     },
     {
       "from": "scripts/migrate-caller-attribute-lo-mastery-keys.ts",
@@ -15654,6 +16566,30 @@
     {
       "from": "scripts/repair-lo-linkage.ts",
       "to": "lib/content-trust/validate-lo-linkage.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/banding/derive-skill-tier-mapping-from-source.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/cascade/resolvers/mastery-policy.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
+      "from": "scripts/seed-synthetic-cohort.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "scripts/seed-system-behavior-defaults.ts",
@@ -16094,6 +17030,11 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/callers/[callerId]/adaptations/route.ts",
+      "inDegree": 1,
+      "outDegree": 6
+    },
+    {
       "path": "app/api/callers/[callerId]/aggregate/route.ts",
       "inDegree": 0,
       "outDegree": 3
@@ -16102,6 +17043,11 @@
       "path": "app/api/callers/[callerId]/artifacts/route.ts",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "app/api/callers/[callerId]/attainment/route.ts",
+      "inDegree": 0,
+      "outDegree": 8
     },
     {
       "path": "app/api/callers/[callerId]/available-media/route.ts",
@@ -16164,6 +17110,11 @@
       "outDegree": 4
     },
     {
+      "path": "app/api/callers/[callerId]/insights/route.ts",
+      "inDegree": 0,
+      "outDegree": 6
+    },
+    {
       "path": "app/api/callers/[callerId]/journey-progress/route.ts",
       "inDegree": 0,
       "outDegree": 3
@@ -16179,6 +17130,11 @@
       "outDegree": 4
     },
     {
+      "path": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "inDegree": 0,
+      "outDegree": 6
+    },
+    {
       "path": "app/api/callers/[callerId]/lo-progress/route.ts",
       "inDegree": 0,
       "outDegree": 4
@@ -16189,7 +17145,17 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/callers/[callerId]/memories/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "app/api/callers/[callerId]/module-progress/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/callers/[callerId]/personality/route.ts",
       "inDegree": 0,
       "outDegree": 3
     },
@@ -16214,9 +17180,19 @@
       "outDegree": 11
     },
     {
+      "path": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "app/api/callers/[callerId]/session-flow-progress/route.ts",
       "inDegree": 0,
       "outDegree": 6
+    },
+    {
+      "path": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "inDegree": 0,
+      "outDegree": 4
     },
     {
       "path": "app/api/callers/[callerId]/slugs/route.ts",
@@ -16232,6 +17208,11 @@
       "path": "app/api/callers/[callerId]/status/route.ts",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "inDegree": 0,
+      "outDegree": 4
     },
     {
       "path": "app/api/callers/[callerId]/survey/route.ts",
@@ -16301,7 +17282,7 @@
     {
       "path": "app/api/calls/[callId]/pipeline/route.ts",
       "inDegree": 0,
-      "outDegree": 51
+      "outDegree": 54
     },
     {
       "path": "app/api/calls/[callId]/route.ts",
@@ -16669,6 +17650,16 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/courses/[courseId]/content-trust/route.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "app/api/courses/[courseId]/course-instructions/route.ts",
       "inDegree": 0,
       "outDegree": 3
@@ -16719,6 +17710,11 @@
       "outDegree": 11
     },
     {
+      "path": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "inDegree": 0,
+      "outDegree": 10
+    },
+    {
       "path": "app/api/courses/[courseId]/learners/ensure-cohort/route.ts",
       "inDegree": 0,
       "outDegree": 2
@@ -16737,6 +17733,11 @@
       "path": "app/api/courses/[courseId]/media/route.ts",
       "inDegree": 0,
       "outDegree": 2
+    },
+    {
+      "path": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
     },
     {
       "path": "app/api/courses/[courseId]/onboarding/route.ts",
@@ -16769,6 +17770,11 @@
       "outDegree": 2
     },
     {
+      "path": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
       "path": "app/api/courses/[courseId]/reconcile-mcqs/route.ts",
       "inDegree": 0,
       "outDegree": 2
@@ -16777,6 +17783,16 @@
       "path": "app/api/courses/[courseId]/regenerate-curriculum/route.ts",
       "inDegree": 0,
       "outDegree": 8
+    },
+    {
+      "path": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
     },
     {
       "path": "app/api/courses/[courseId]/session-count-recommendation/route.ts",
@@ -16802,6 +17818,36 @@
       "path": "app/api/courses/[courseId]/setup-status/types.ts",
       "inDegree": 1,
       "outDegree": 0
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-source-lineage/route.ts",
+      "inDegree": 0,
+      "outDegree": 2
     },
     {
       "path": "app/api/courses/[courseId]/staleness-aggregate/route.ts",
@@ -18059,6 +19105,11 @@
       "outDegree": 2
     },
     {
+      "path": "app/api/system/pipeline-health/route.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
       "path": "app/api/system/readiness/route.ts",
       "inDegree": 0,
       "outDegree": 1
@@ -18879,6 +19930,11 @@
       "outDegree": 1
     },
     {
+      "path": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "inDegree": 1,
+      "outDegree": 8
+    },
+    {
       "path": "app/x/courses/[courseId]/CourseSummaryCard.tsx",
       "inDegree": 2,
       "outDegree": 3
@@ -18921,7 +19977,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "inDegree": 1,
-      "outDegree": 12
+      "outDegree": 10
     },
     {
       "path": "app/x/courses/[courseId]/_components/ImportModulesDialog.tsx",
@@ -18946,12 +20002,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "inDegree": 1,
-      "outDegree": 11
-    },
-    {
-      "path": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
-      "inDegree": 1,
-      "outDegree": 2
+      "outDegree": 12
     },
     {
       "path": "app/x/courses/[courseId]/_components/authored-modules-panel.css",
@@ -18969,9 +20020,9 @@
       "outDegree": 0
     },
     {
-      "path": "app/x/courses/[courseId]/_components/voice-flow-lens.css",
+      "path": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
       "inDegree": 1,
-      "outDegree": 0
+      "outDegree": 7
     },
     {
       "path": "app/x/courses/[courseId]/chat/ChatLauncher.tsx",
@@ -19024,9 +20075,14 @@
       "outDegree": 0
     },
     {
+      "path": "app/x/courses/[courseId]/course-skills-tab.css",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "app/x/courses/[courseId]/page.tsx",
       "inDegree": 0,
-      "outDegree": 43
+      "outDegree": 45
     },
     {
       "path": "app/x/courses/[courseId]/sessions/[sessionNum]/page.tsx",
@@ -19136,7 +20192,7 @@
     {
       "path": "app/x/courses/page.tsx",
       "inDegree": 0,
-      "outDegree": 7
+      "outDegree": 8
     },
     {
       "path": "app/x/courses/v3/page.tsx",
@@ -19437,6 +20493,16 @@
       "path": "app/x/help/demos/page.tsx",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "app/x/help/glossary/help-glossary.css",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "app/x/help/glossary/page.tsx",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "app/x/help/pipeline-health/page.tsx",
@@ -19939,6 +21005,11 @@
       "outDegree": 3
     },
     {
+      "path": "app/x/system/pipeline-health/page.tsx",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
       "path": "app/x/taxonomy-graph/page.tsx",
       "inDegree": 0,
       "outDegree": 6
@@ -20064,13 +21135,18 @@
       "outDegree": 0
     },
     {
+      "path": "components/callers/caller-detail/types.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/callers/roster/CallerRoster.tsx",
       "inDegree": 2,
       "outDegree": 0
     },
     {
       "path": "components/cascade/CascadeInspectorTray.tsx",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -20185,6 +21261,16 @@
     },
     {
       "path": "components/intake/IntakeDoneClient.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/journey-tab/CourseJourneyTab.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/journey-tab/SettingsTabVoiceLens.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -20315,7 +21401,7 @@
     },
     {
       "path": "components/shared/BandingPicker.tsx",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -20331,6 +21417,11 @@
     {
       "path": "components/shared/CallerPicker.tsx",
       "inDegree": 2,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/CascadeValue.tsx",
+      "inDegree": 1,
       "outDegree": 0
     },
     {
@@ -20430,11 +21521,6 @@
     },
     {
       "path": "components/shared/GlobalAssistant.tsx",
-      "inDegree": 1,
-      "outDegree": 0
-    },
-    {
-      "path": "components/shared/HFDrawer.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -20569,6 +21655,11 @@
       "outDegree": 0
     },
     {
+      "path": "components/shared/TierCell.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/shared/TopBar.tsx",
       "inDegree": 1,
       "outDegree": 0
@@ -20590,6 +21681,11 @@
     },
     {
       "path": "components/shared/UserContextMenu.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/VariantPresetPill.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -20629,8 +21725,23 @@
       "outDegree": 0
     },
     {
+      "path": "components/shared/designer-shell/index.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/shared/onboarding-preview.css",
       "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/preview-renderers/_journey-setting-context.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/preview-renderers/index.ts",
+      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -20675,7 +21786,7 @@
     },
     {
       "path": "components/voice/VoiceConfigSection.tsx",
-      "inDegree": 3,
+      "inDegree": 1,
       "outDegree": 0
     },
     {
@@ -21064,14 +22175,29 @@
       "outDegree": 0
     },
     {
+      "path": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "inDegree": 2,
+      "outDegree": 3
+    },
+    {
       "path": "lib/banding/glossary.ts",
       "inDegree": 0,
       "outDegree": 0
     },
     {
       "path": "lib/banding/presets.ts",
-      "inDegree": 0,
+      "inDegree": 1,
       "outDegree": 1
+    },
+    {
+      "path": "lib/banding/skill-tier-deploy-invariant.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/banding/tier-colors.ts",
+      "inDegree": 3,
+      "outDegree": 0
     },
     {
       "path": "lib/bdd/ai-parser.ts",
@@ -21135,7 +22261,7 @@
     },
     {
       "path": "lib/caller-utils.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 0
     },
     {
@@ -21150,8 +22276,8 @@
     },
     {
       "path": "lib/cascade/effective-value.ts",
-      "inDegree": 10,
-      "outDegree": 6
+      "inDegree": 12,
+      "outDegree": 7
     },
     {
       "path": "lib/cascade/knob-keys.ts",
@@ -21160,7 +22286,7 @@
     },
     {
       "path": "lib/cascade/layer-types.ts",
-      "inDegree": 10,
+      "inDegree": 14,
       "outDegree": 0
     },
     {
@@ -21172,6 +22298,11 @@
       "path": "lib/cascade/resolvers/identity-spec.ts",
       "inDegree": 2,
       "outDegree": 4
+    },
+    {
+      "path": "lib/cascade/resolvers/mastery-policy.ts",
+      "inDegree": 3,
+      "outDegree": 3
     },
     {
       "path": "lib/cascade/resolvers/session-flow.ts",
@@ -21192,6 +22323,11 @@
       "path": "lib/cascade/set-at-layer.ts",
       "inDegree": 0,
       "outDegree": 5
+    },
+    {
+      "path": "lib/cascade/use-effective-value.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "lib/cascade/voice-explain.ts",
@@ -21375,7 +22511,7 @@
     },
     {
       "path": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 1
     },
     {
@@ -21385,7 +22521,7 @@
     },
     {
       "path": "lib/chat/wizard-tool-executor/_shared/types.ts",
-      "inDegree": 11,
+      "inDegree": 16,
       "outDegree": 0
     },
     {
@@ -21424,6 +22560,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "lib/chat/wizard-tool-executor/tools/create_community.ts",
       "inDegree": 1,
       "outDegree": 2
@@ -21431,6 +22572,56 @@
     {
       "path": "lib/chat/wizard-tool-executor/tools/create_course.ts",
       "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts",
+      "inDegree": 6,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_enroll.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_graph-guard.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "inDegree": 0,
+      "outDegree": 4
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "inDegree": 1,
+      "outDegree": 5
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "inDegree": 2,
+      "outDegree": 3
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-subject.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "inDegree": 0,
       "outDegree": 6
     },
     {
@@ -21481,17 +22672,17 @@
     {
       "path": "lib/compose/affecting-keys-domain.ts",
       "inDegree": 1,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/compose/affecting-keys-spec.ts",
       "inDegree": 1,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/compose/affecting-keys.ts",
       "inDegree": 2,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/compose/bump-curriculum-fanout.ts",
@@ -21507,6 +22698,31 @@
       "path": "lib/compose/eager-reprompt-on-bump.ts",
       "inDegree": 3,
       "outDegree": 1
+    },
+    {
+      "path": "lib/compose/index.ts",
+      "inDegree": 7,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/compose/recompose-section.ts",
+      "inDegree": 1,
+      "outDegree": 6
+    },
+    {
+      "path": "lib/compose/section-loaders.ts",
+      "inDegree": 2,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/compose/section-staleness.ts",
+      "inDegree": 3,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/compose/section.ts",
+      "inDegree": 10,
+      "outDegree": 0
     },
     {
       "path": "lib/compose/staleness.ts",
@@ -21555,7 +22771,7 @@
     },
     {
       "path": "lib/content-trust/course-ref-to-assertions.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 1
     },
     {
@@ -21576,7 +22792,7 @@
     {
       "path": "lib/content-trust/extract-curriculum.ts",
       "inDegree": 9,
-      "outDegree": 4
+      "outDegree": 5
     },
     {
       "path": "lib/content-trust/extract-images.ts",
@@ -21759,6 +22975,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/contracts/writer-registry.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
       "path": "lib/course/group-specs.ts",
       "inDegree": 3,
       "outDegree": 0
@@ -21819,13 +23040,18 @@
       "outDegree": 0
     },
     {
+      "path": "lib/curriculum/mark-module-incomplete.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
       "path": "lib/curriculum/mastery-tiers.ts",
       "inDegree": 4,
       "outDegree": 0
     },
     {
       "path": "lib/curriculum/playbook-mastery-config.ts",
-      "inDegree": 1,
+      "inDegree": 3,
       "outDegree": 2
     },
     {
@@ -21864,8 +23090,13 @@
       "outDegree": 1
     },
     {
+      "path": "lib/curriculum/resolve-skill.ts",
+      "inDegree": 7,
+      "outDegree": 1
+    },
+    {
       "path": "lib/curriculum/scratch-mastery.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 1
     },
     {
@@ -21881,7 +23112,7 @@
     {
       "path": "lib/curriculum/track-progress.ts",
       "inDegree": 7,
-      "outDegree": 8
+      "outDegree": 9
     },
     {
       "path": "lib/curriculum/validate-lo-refs.ts",
@@ -22045,7 +23276,7 @@
     },
     {
       "path": "lib/domain/update-domain-config.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 3
     },
     {
@@ -22144,6 +23375,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/goals/append-progress-entry.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
       "path": "lib/goals/extract-goals.ts",
       "inDegree": 1,
       "outDegree": 6
@@ -22195,7 +23431,7 @@
     },
     {
       "path": "lib/goals/strategies/types.ts",
-      "inDegree": 6,
+      "inDegree": 9,
       "outDegree": 0
     },
     {
@@ -22210,8 +23446,8 @@
     },
     {
       "path": "lib/goals/track-progress.ts",
-      "inDegree": 7,
-      "outDegree": 4
+      "inDegree": 13,
+      "outDegree": 6
     },
     {
       "path": "lib/graph/visual-encoding.ts",
@@ -22429,6 +23665,56 @@
       "outDegree": 3
     },
     {
+      "path": "lib/journey/bucket-relations.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "lib/journey/menu-items.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/module-settings-flag.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/journey/section-staleness-bridge.ts",
+      "inDegree": 1,
+      "outDegree": 4
+    },
+    {
+      "path": "lib/journey/setting-contracts.entries.ts",
+      "inDegree": 3,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/setting-contracts.ts",
+      "inDegree": 8,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/setting-groups.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/journey/storage-path-applier.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/use-cascade-edit-field.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/use-glow-state.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "lib/knowledge/assertions.ts",
       "inDegree": 3,
       "outDegree": 2
@@ -22440,7 +23726,7 @@
     },
     {
       "path": "lib/knowledge/domain-sources.ts",
-      "inDegree": 17,
+      "inDegree": 18,
       "outDegree": 2
     },
     {
@@ -22470,7 +23756,7 @@
     },
     {
       "path": "lib/learner-scope.ts",
-      "inDegree": 42,
+      "inDegree": 51,
       "outDegree": 1
     },
     {
@@ -22540,7 +23826,7 @@
     },
     {
       "path": "lib/logger.ts",
-      "inDegree": 23,
+      "inDegree": 28,
       "outDegree": 3
     },
     {
@@ -22670,8 +23956,8 @@
     },
     {
       "path": "lib/ops/update-targets.ts",
-      "inDegree": 1,
-      "outDegree": 1
+      "inDegree": 2,
+      "outDegree": 2
     },
     {
       "path": "lib/page-roles.ts",
@@ -22680,7 +23966,7 @@
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 441,
+      "inDegree": 465,
       "outDegree": 3
     },
     {
@@ -22691,7 +23977,7 @@
     {
       "path": "lib/pipeline/adaptive-loop-invariants.ts",
       "inDegree": 5,
-      "outDegree": 2
+      "outDegree": 3
     },
     {
       "path": "lib/pipeline/aggregate-runner.ts",
@@ -22705,8 +23991,13 @@
     },
     {
       "path": "lib/pipeline/course-style.ts",
-      "inDegree": 4,
+      "inDegree": 8,
       "outDegree": 1
+    },
+    {
+      "path": "lib/pipeline/detect-silent-writers.ts",
+      "inDegree": 2,
+      "outDegree": 3
     },
     {
       "path": "lib/pipeline/event-gate.ts",
@@ -22749,6 +24040,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/pipeline/normalize-score-agent-evidence.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "lib/pipeline/prosody-consumer.ts",
       "inDegree": 1,
       "outDegree": 3
@@ -22765,7 +24061,7 @@
     },
     {
       "path": "lib/pipeline/scheduler-decision.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 1
     },
     {
@@ -22799,8 +24095,18 @@
       "outDegree": 1
     },
     {
+      "path": "lib/pipeline/write-count-logger.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/pipeline/writer-completeness-invariant.ts",
+      "inDegree": 1,
+      "outDegree": 3
+    },
+    {
       "path": "lib/playbook/update-playbook-config.ts",
-      "inDegree": 20,
+      "inDegree": 24,
       "outDegree": 5
     },
     {
@@ -22810,7 +24116,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 624,
+      "inDegree": 657,
       "outDegree": 0
     },
     {
@@ -22831,22 +24137,22 @@
     {
       "path": "lib/prompt/composition/CompositionExecutor.ts",
       "inDegree": 1,
-      "outDegree": 36
+      "outDegree": 40
     },
     {
       "path": "lib/prompt/composition/SectionDataLoader.ts",
       "inDegree": 2,
-      "outDegree": 13
+      "outDegree": 15
     },
     {
       "path": "lib/prompt/composition/TransformRegistry.ts",
-      "inDegree": 30,
+      "inDegree": 32,
       "outDegree": 1
     },
     {
       "path": "lib/prompt/composition/buildComposeTrace.ts",
       "inDegree": 1,
-      "outDegree": 3
+      "outDegree": 4
     },
     {
       "path": "lib/prompt/composition/compose-invariants.ts",
@@ -22875,7 +24181,7 @@
     },
     {
       "path": "lib/prompt/composition/index.ts",
-      "inDegree": 10,
+      "inDegree": 11,
       "outDegree": 0
     },
     {
@@ -22889,6 +24195,11 @@
       "outDegree": 5
     },
     {
+      "path": "lib/prompt/composition/loaders/conversationArtifacts.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
       "path": "lib/prompt/composition/loaders/courseComplete.ts",
       "inDegree": 1,
       "outDegree": 3
@@ -22897,6 +24208,11 @@
       "path": "lib/prompt/composition/loaders/interleaveReview.ts",
       "inDegree": 2,
       "outDegree": 1
+    },
+    {
+      "path": "lib/prompt/composition/loaders/memoryDeltas.ts",
+      "inDegree": 3,
+      "outDegree": 0
     },
     {
       "path": "lib/prompt/composition/loaders/mockDiagnostic.ts",
@@ -22920,7 +24236,7 @@
     },
     {
       "path": "lib/prompt/composition/renderPromptSummary.ts",
-      "inDegree": 12,
+      "inDegree": 13,
       "outDegree": 3
     },
     {
@@ -22936,6 +24252,11 @@
     {
       "path": "lib/prompt/composition/transforms/audience.ts",
       "inDegree": 11,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/prompt/composition/transforms/conversationArtifacts.ts",
+      "inDegree": 1,
       "outDegree": 2
     },
     {
@@ -22965,6 +24286,11 @@
     },
     {
       "path": "lib/prompt/composition/transforms/memories.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/prompt/composition/transforms/memoryDeltas.ts",
       "inDegree": 1,
       "outDegree": 2
     },
@@ -23076,7 +24402,7 @@
     {
       "path": "lib/prompt/composition/types.ts",
       "inDegree": 43,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/prompts/interpolate.ts",
@@ -23104,6 +24430,16 @@
       "outDegree": 0
     },
     {
+      "path": "lib/rbac/policies/adaptations.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/rbac/visibility.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
       "path": "lib/recompose/fanout-class-keys.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -23120,7 +24456,7 @@
     },
     {
       "path": "lib/roles.ts",
-      "inDegree": 13,
+      "inDegree": 14,
       "outDegree": 0
     },
     {
@@ -23161,6 +24497,11 @@
     {
       "path": "lib/settings/resolver.ts",
       "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/settings/voice-setting-contracts.ts",
+      "inDegree": 2,
       "outDegree": 1
     },
     {
@@ -23289,6 +24630,11 @@
       "outDegree": 3
     },
     {
+      "path": "lib/tab-layout.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "lib/tasks/constants.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -23300,7 +24646,7 @@
     },
     {
       "path": "lib/terminology/types.ts",
-      "inDegree": 9,
+      "inDegree": 10,
       "outDegree": 0
     },
     {
@@ -23315,7 +24661,7 @@
     },
     {
       "path": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 2
     },
     {
@@ -23345,7 +24691,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 106,
+      "inDegree": 113,
       "outDegree": 0
     },
     {
@@ -23401,7 +24747,7 @@
     {
       "path": "lib/voice/end-session.ts",
       "inDegree": 1,
-      "outDegree": 3
+      "outDegree": 7
     },
     {
       "path": "lib/voice/end-source.ts",
@@ -23549,6 +24895,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/voice/talk-time-stats.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
       "path": "lib/voice/telemetry.ts",
       "inDegree": 7,
       "outDegree": 1
@@ -23650,7 +25001,7 @@
     },
     {
       "path": "lib/wizard/apply-projection.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 5
     },
     {
@@ -23700,7 +25051,7 @@
     },
     {
       "path": "lib/wizard/project-course-reference.ts",
-      "inDegree": 6,
+      "inDegree": 9,
       "outDegree": 5
     },
     {
@@ -23710,8 +25061,8 @@
     },
     {
       "path": "lib/wizard/run-projection-for-playbook.ts",
-      "inDegree": 1,
-      "outDegree": 6
+      "inDegree": 2,
+      "outDegree": 9
     },
     {
       "path": "lib/wizard/sync-authored-modules-to-curriculum.ts",
@@ -23832,6 +25183,11 @@
       "path": "scripts/backfill-cio-cto-playbook-configs.ts",
       "inDegree": 0,
       "outDegree": 1
+    },
+    {
+      "path": "scripts/backfill-cto-projection.ts",
+      "inDegree": 0,
+      "outDegree": 3
     },
     {
       "path": "scripts/backfill-curriculum-anchors.ts",
@@ -24004,9 +25360,19 @@
       "outDegree": 1
     },
     {
+      "path": "scripts/check-skill-tier-deploy-readiness.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "scripts/check-uplift-visual.ts",
       "inDegree": 0,
       "outDegree": 0
+    },
+    {
+      "path": "scripts/check-writer-registry.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "scripts/cleanup-orphan-parameters.ts",
@@ -24066,7 +25432,7 @@
     {
       "path": "scripts/fix-cio-cto-playbooks.ts",
       "inDegree": 0,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "scripts/fix-cio-cto-slice-b.ts",
@@ -24094,12 +25460,22 @@
       "outDegree": 0
     },
     {
+      "path": "scripts/generate-writer-coverage-doc.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "scripts/migrate-caller-attribute-lo-mastery-keys.ts",
       "inDegree": 0,
       "outDegree": 1
     },
     {
       "path": "scripts/migrate-caller-personality.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
+      "path": "scripts/migrate-ielts-playbook-mapping.ts",
       "inDegree": 0,
       "outDegree": 0
     },
@@ -24199,6 +25575,11 @@
       "outDegree": 3
     },
     {
+      "path": "scripts/reseed-skill-measure-contract-generic.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
       "path": "scripts/seed-ielts-prosody.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -24207,6 +25588,16 @@
       "path": "scripts/seed-intake-specs.ts",
       "inDegree": 0,
       "outDegree": 0
+    },
+    {
+      "path": "scripts/seed-source-derived-skill-banding.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "scripts/seed-synthetic-cohort.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "scripts/seed-system-behavior-defaults.ts",
@@ -24347,17 +25738,17 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 624,
+      "inDegree": 657,
       "outDegree": 0
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 441,
+      "inDegree": 465,
       "outDegree": 3
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 106,
+      "inDegree": 113,
       "outDegree": 0
     },
     {
@@ -24371,29 +25762,34 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/calls/[callId]/pipeline/route.ts",
+      "inDegree": 0,
+      "outDegree": 54
+    },
+    {
       "path": "lib/system-settings.ts",
       "inDegree": 51,
       "outDegree": 3
     },
     {
-      "path": "app/api/calls/[callId]/pipeline/route.ts",
-      "inDegree": 0,
-      "outDegree": 51
+      "path": "lib/learner-scope.ts",
+      "inDegree": 51,
+      "outDegree": 1
     },
     {
       "path": "app/x/courses/[courseId]/page.tsx",
       "inDegree": 0,
-      "outDegree": 43
-    },
-    {
-      "path": "lib/learner-scope.ts",
-      "inDegree": 42,
-      "outDegree": 1
+      "outDegree": 45
     },
     {
       "path": "lib/prompt/composition/types.ts",
       "inDegree": 43,
-      "outDegree": 0
+      "outDegree": 1
+    },
+    {
+      "path": "lib/prompt/composition/CompositionExecutor.ts",
+      "inDegree": 1,
+      "outDegree": 40
     },
     {
       "path": "lib/metering/instrumented-ai.ts",
@@ -24406,9 +25802,9 @@
       "outDegree": 38
     },
     {
-      "path": "lib/prompt/composition/CompositionExecutor.ts",
-      "inDegree": 1,
-      "outDegree": 36
+      "path": "lib/prompt/composition/TransformRegistry.ts",
+      "inDegree": 32,
+      "outDegree": 1
     },
     {
       "path": "lib/voice/route-handlers.ts",
@@ -24416,9 +25812,14 @@
       "outDegree": 27
     },
     {
-      "path": "lib/prompt/composition/TransformRegistry.ts",
-      "inDegree": 30,
-      "outDegree": 1
+      "path": "lib/logger.ts",
+      "inDegree": 28,
+      "outDegree": 3
+    },
+    {
+      "path": "lib/playbook/update-playbook-config.ts",
+      "inDegree": 24,
+      "outDegree": 5
     },
     {
       "path": "app/api/content-sources/[sourceId]/extract/route.ts",
@@ -24434,16 +25835,6 @@
       "path": "components/shared/FancySelect.tsx",
       "inDegree": 26,
       "outDegree": 0
-    },
-    {
-      "path": "lib/enrollment/index.ts",
-      "inDegree": 24,
-      "outDegree": 2
-    },
-    {
-      "path": "lib/logger.ts",
-      "inDegree": 23,
-      "outDegree": 3
     }
   ]
 }

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-12T17:02:55.431Z",
+  "generatedAt": "2026-06-16T12:07:55.552Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,13 +1,13 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-12T17:02:54.055Z",
+  "generatedAt": "2026-06-16T12:07:53.426Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",
-  "modelCount": 110,
+  "modelCount": 111,
   "ratifiedCount": 8,
   "summary": {
-    "tenant-scoped": 98,
+    "tenant-scoped": 99,
     "global": 4,
     "join": 8,
     "alreadyTenantAware": 1,
@@ -1330,9 +1330,9 @@
     },
     {
       "name": "CallerModuleProgress",
-      "fieldCount": 14,
+      "fieldCount": 15,
       "relationCount": 2,
-      "meaningfulScalarCount": 6,
+      "meaningfulScalarCount": 7,
       "scalarFields": [
         "id",
         "callerId",
@@ -1343,6 +1343,7 @@
         "completedAt",
         "lastCallId",
         "callCount",
+        "incompleteAttempts",
         "loScoresJson",
         "createdAt",
         "updatedAt"
@@ -1577,15 +1578,16 @@
     },
     {
       "name": "CallScore",
-      "fieldCount": 20,
+      "fieldCount": 21,
       "relationCount": 5,
-      "meaningfulScalarCount": 8,
+      "meaningfulScalarCount": 9,
       "scalarFields": [
         "id",
         "callId",
         "callerId",
         "parameterId",
         "moduleId",
+        "segmentKey",
         "score",
         "confidence",
         "evidence",
@@ -3601,8 +3603,8 @@
     },
     {
       "name": "Playbook",
-      "fieldCount": 38,
-      "relationCount": 17,
+      "fieldCount": 39,
+      "relationCount": 18,
       "meaningfulScalarCount": 15,
       "scalarFields": [
         "id",
@@ -3695,6 +3697,10 @@
         {
           "field": "sessions",
           "target": "Session"
+        },
+        {
+          "field": "sectionStaleness",
+          "target": "PlaybookSectionStaleness"
         }
       ],
       "blockAttrs": [
@@ -3860,6 +3866,37 @@
         "@@index",
         "@@index",
         "@@index",
+        "@@index",
+        "@@index"
+      ],
+      "hasTenantHint": false,
+      "proposedClass": "tenant-scoped",
+      "confidence": "low",
+      "reviewed": false,
+      "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
+    },
+    {
+      "name": "PlaybookSectionStaleness",
+      "fieldCount": 8,
+      "relationCount": 1,
+      "meaningfulScalarCount": 3,
+      "scalarFields": [
+        "id",
+        "playbookId",
+        "sectionKey",
+        "sectionHash",
+        "staleSince",
+        "createdAt",
+        "updatedAt"
+      ],
+      "relations": [
+        {
+          "field": "playbook",
+          "target": "Playbook"
+        }
+      ],
+      "blockAttrs": [
+        "@@unique",
         "@@index",
         "@@index"
       ],
@@ -4292,9 +4329,9 @@
     },
     {
       "name": "Session",
-      "fieldCount": 27,
+      "fieldCount": 28,
       "relationCount": 8,
-      "meaningfulScalarCount": 11,
+      "meaningfulScalarCount": 12,
       "scalarFields": [
         "id",
         "callerId",
@@ -4307,6 +4344,7 @@
         "voiceProvider",
         "intentId",
         "voiceConfigSnapshot",
+        "metadata",
         "startedAt",
         "endedAt",
         "status",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-12T17:02:55.838Z",
+  "generatedAt": "2026-06-16T12:07:56.279Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,16 +1,16 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-12T17:02:54.510Z",
+  "generatedAt": "2026-06-16T12:07:54.114Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
-    "routeCount": 513,
+    "routeCount": 536,
     "byAuthLevel": {
-      "VIEWER": 113,
+      "VIEWER": 122,
       "ADMIN": 81,
       "SUPERADMIN": 9,
       "VIEWER+ADMIN": 5,
-      "OPERATOR": 130,
+      "OPERATOR": 144,
       "OPERATOR+VIEWER": 8,
       "VIEWER+OPERATOR": 67,
       "auth-gate(non-role)": 53,
@@ -25,7 +25,7 @@
       "VIEWER+TESTER": 3
     },
     "noAuthGate": 30,
-    "possiblyUnscoped": 109,
+    "possiblyUnscoped": 115,
     "internalSecret": 8
   },
   "routes": [
@@ -1268,6 +1268,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/adaptations",
+      "file": "apps/admin/app/api/callers/[callerId]/adaptations/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/aggregate",
       "file": "apps/admin/app/api/callers/[callerId]/aggregate/route.ts",
       "methods": [
@@ -1292,6 +1312,26 @@
     {
       "route": "/api/callers/[callerId]/artifacts",
       "file": "apps/admin/app/api/callers/[callerId]/artifacts/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/attainment",
+      "file": "apps/admin/app/api/callers/[callerId]/attainment/route.ts",
       "methods": [
         "GET"
       ],
@@ -1560,6 +1600,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/insights",
+      "file": "apps/admin/app/api/callers/[callerId]/insights/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/journey-progress",
       "file": "apps/admin/app/api/callers/[callerId]/journey-progress/route.ts",
       "methods": [
@@ -1620,6 +1680,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/lo-mastery",
+      "file": "apps/admin/app/api/callers/[callerId]/lo-mastery/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/lo-progress",
       "file": "apps/admin/app/api/callers/[callerId]/lo-progress/route.ts",
       "methods": [
@@ -1660,8 +1740,48 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/memories",
+      "file": "apps/admin/app/api/callers/[callerId]/memories/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/module-progress",
       "file": "apps/admin/app/api/callers/[callerId]/module-progress/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/personality",
+      "file": "apps/admin/app/api/callers/[callerId]/personality/route.ts",
       "methods": [
         "GET"
       ],
@@ -1762,6 +1882,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/scheduler-decision",
+      "file": "apps/admin/app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/session-flow-progress",
       "file": "apps/admin/app/api/callers/[callerId]/session-flow-progress/route.ts",
       "methods": [
@@ -1778,6 +1918,26 @@
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/skills-evidence",
+      "file": "apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
         "noAuthGate": false
       },
       "reviewed": false
@@ -1829,6 +1989,26 @@
         "GET"
       ],
       "authLevels": [],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/sub-skills",
+      "file": "apps/admin/app/api/callers/[callerId]/sub-skills/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
       "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
@@ -3485,6 +3665,46 @@
       "reviewed": false
     },
     {
+      "route": "/api/courses/[courseId]/content-trust",
+      "file": "apps/admin/app/api/courses/[courseId]/content-trust/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/conversation-artifacts-preview",
+      "file": "apps/admin/app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/courses/[courseId]/course-instructions",
       "file": "apps/admin/app/api/courses/[courseId]/course-instructions/route.ts",
       "methods": [
@@ -3691,6 +3911,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/courses/[courseId]/journey-setting",
+      "file": "apps/admin/app/api/courses/[courseId]/journey-setting/route.ts",
+      "methods": [
+        "PATCH"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/courses/[courseId]/learners/ensure-cohort",
       "file": "apps/admin/app/api/courses/[courseId]/learners/ensure-cohort/route.ts",
       "methods": [
@@ -3766,6 +4006,26 @@
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/memory-deltas-preview",
+      "file": "apps/admin/app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
         "noAuthGate": false
       },
       "reviewed": false
@@ -3893,6 +4153,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/courses/[courseId]/recompose-section",
+      "file": "apps/admin/app/api/courses/[courseId]/recompose-section/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/courses/[courseId]/reconcile-mcqs",
       "file": "apps/admin/app/api/courses/[courseId]/reconcile-mcqs/route.ts",
       "methods": [
@@ -3925,6 +4205,46 @@
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/reproject-skills",
+      "file": "apps/admin/app/api/courses/[courseId]/reproject-skills/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/section-staleness",
+      "file": "apps/admin/app/api/courses/[courseId]/section-staleness/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": true,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
@@ -4001,6 +4321,126 @@
       ],
       "authLevels": [
         "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-cohort-cell",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-cohort-heatmap",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-evidence",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-evidence/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-framework",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-framework/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-rubric-calibration",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-source-lineage",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-source-lineage/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
       ],
       "hasAuthGate": true,
       "tenantSignals": {
@@ -9099,6 +9539,26 @@
       ],
       "authLevels": [
         "SUPERADMIN"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/system/pipeline-health",
+      "file": "apps/admin/app/api/system/pipeline-health/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
       ],
       "hasAuthGate": true,
       "tenantSignals": {


### PR DESCRIPTION
## Summary

The KB freshness gate silently failed for 3 days. Three layered issues compounded:

1. **Pre-commit hook covered only 2 of 5 generators.** `model-map` + `route-inventory` had triggers; `coupling-graph`, `demo-knobs`, `operator-surfaces` had none. Drift accumulated without anyone noticing.
2. **CI `kb:check` ran as a later step in the "Lint & Type Check" job.** Wave C5 (#1715) introduced `hf-rbac/require-tiered-redactor`, which fired a false-positive on `apps/admin/eslint.config.mjs` (the file that wires the rule literally contains `@tieredVisibility` in a comment explaining it). ESLint exit 1 skipped every subsequent step in that job, including the KB freshness check. A sibling error masked the gate it was supposed to enforce.
3. **Red CI was admin-merged.** Last 10 main pushes all FAILURE, so the structural bypass had no operator backstop.

## Changes

- **`.githooks/pre-commit` §6 — 3 new triggers.** `operator-surfaces` regen added to the existing `routes_changed` branch; new `knob_keys_changed` flag (`lib/cascade/knob-keys.ts` | `lib/compose/affecting-keys.ts`) drives `demo-knobs`; new `source_changed` flag (any `apps/admin/*.ts(x)`) drives `coupling-graph`. All 5 generators now have triggers.
- **`.github/workflows/test.yml` — new `kb-integrity` job.** Own checkout + install + `prisma generate` + `npm run kb:check`. Removed step from `lint`. Added to `test-summary` `needs` so its failure blocks merge independently of any ESLint state.
- **`apps/admin/eslint-rules/require-tiered-redactor.mjs` — allow-list extended.** `eslint.config.` added to `ALLOWLIST_PATH_FRAGMENTS` so the wiring config (which legitimately documents the tag) isn't false-positive-matched.
- **`apps/admin/tests/eslint-rules/require-tiered-redactor.test.ts` — new pin.** Valid case with `filename: "/repo/apps/admin/eslint.config.mjs"` proving the allow-list works.
- **`docs/kb/README.md` — Lattice 4-pillar section.** Added between *What this is* and *Reuse map*. Chain Contracts / Guards / Cascade / Rules table with KB-index pointers + survey-discipline cue (from today's `feedback_lattice_*` memory entries).
- **`docs/kb/generated/` — full freshen against current `origin/main`.** Real drift in 3 files: coupling-graph (+1667), route-inventory (+468), model-map (+58). The other 2 carry timestamp-only updates.

## Verified by

- `npx vitest run tests/eslint-rules/require-tiered-redactor.test.ts` → 10/10 pass [verified] (includes the new `eslint.config.mjs` allow-list case)
- `npx eslint eslint.config.mjs` → exit 0 [verified]
- `npm run lint` → exit 0 (0 errors, 4488 pre-existing warnings) [verified]
- `bash -n .githooks/pre-commit` → syntax clean [verified]
- `node yaml.parse` on `.github/workflows/test.yml` → 6 jobs in expected order, `test-summary.needs` includes `kb-integrity` [verified]
- All 5 generators run individually → exit 0 [verified]
- `kb:fresh` against current HEAD → drift size measured (+1667 / +468 / +58 lines across coupling-graph / route-inventory / model-map) [probed]
- Pre-existing main CI was red (10/10 recent runs FAILURE per `gh run list --branch=main`) — proves the gate was bypassed structurally, not just intermittently [verified]

## Lattice survey

| Pillar | Touched? |
|---|---|
| Chain Contracts | No |
| Guards | Rule allow-list extended (no new guard); new CI job blocks merge on KB drift |
| Cascade | No |
| Rules | KB README now documents the Lattice umbrella; `.claude/rules/lattice-survey.md` is a separate follow-up the memory entries flag |

## Test plan

- [ ] CI: `kb-integrity` job goes green on this PR (proves the new gate runs even when other jobs are red)
- [ ] CI: `lint` job goes green now that the `require-tiered-redactor` false-positive is fixed
- [ ] Local: next commit that changes a `route.ts` triggers both `route-inventory` AND `operator-surfaces` regen via the hook
- [ ] Local: next commit that changes any `.ts/.tsx` under `apps/admin/` triggers `coupling-graph` regen
- [ ] Local: next commit that changes `lib/cascade/knob-keys.ts` triggers `demo-knobs` regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)