### PR TITLE
feat(journey): #1738 Slice C3 — close Slice C (rebased onto current main)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
+++ b/apps/admin/app/x/courses/[courseId]/_components/preview-lens.css
@@ -237,9 +237,41 @@
   border-bottom-right-radius: 4px;
 }
 
+/* Slice C3 (#1738) — ghost bubbles are intentional placeholders for
+ * config that's currently empty/disabled. Pre-C3 they rendered with
+ * just opacity:0.55 + italic which read as "broken / faded existing
+ * content". The dashed border + plus glyph make it clear the bubble
+ * is a CTA, not a broken state. The bubble itself remains a button /
+ * link (still routes to the editor on click). */
 .hf-preview-bubble--ghost {
-  opacity: 0.55;
+  opacity: 0.85;
   font-style: italic;
+  background: transparent;
+  border: 1.5px dashed color-mix(in srgb, var(--accent-primary) 45%, transparent);
+  color: var(--text-muted);
+}
+
+.hf-preview-bubble--ghost::before {
+  content: "+";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-right: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+  color: var(--accent-primary);
+  font-style: normal;
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.hf-preview-bubble--ghost:hover {
+  border-color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+  opacity: 1;
 }
 
 .hf-preview-bubble:hover {

--- a/apps/admin/components/journey-tab/CommandPalette.tsx
+++ b/apps/admin/components/journey-tab/CommandPalette.tsx
@@ -1,24 +1,28 @@
 "use client";
 
 /**
- * CommandPalette — Phase 5 of epic #1675.
+ * CommandPalette — Phase 5 of epic #1675 + Slice C3 (#1738) bucket-
+ * count surfacing.
  *
  * Cmd+K / Ctrl+K opens a search-as-you-type palette over BOTH the
- * journey registry (45) AND the voice registry (11). 56 settings
- * indexed in a single pass; substring match on
+ * journey registry AND the voice registry. Substring match on
  * `educatorLabel + group + storagePath`.
  *
- * Selecting a result calls `setSettingId` from `useJourneySelection`,
- * which mounts the contract's `JourneyField` in the Inspector pane.
+ * Slice C3 surfaces the bucket count in the input placeholder so
+ * educators learn the shape: "Search 56 settings across 13 buckets…".
+ * Both counts are derived from the canonical registries
+ * (`JOURNEY_SETTINGS` + `VOICE_SETTINGS`; `JOURNEY_MENU_BUCKET_IDS`) —
+ * never hardcoded.
  *
- * Slice A scope: palette is mounted by the Journey-tab shell only. A
- * Phase 5 Slice B follow-up will hoist activation to the page level so
- * the palette works from any tab.
+ * Selecting a result calls `setBucketId` from `useJourneySelection` via
+ * `CourseJourneyTab.handlePaletteSelect`, which looks up the setting's
+ * owning bucket and mounts the bucket's settings in the Inspector pane.
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
+import { JOURNEY_MENU_BUCKET_IDS } from "@/lib/journey/menu-items";
 import { VOICE_SETTINGS } from "@/lib/settings/voice-setting-contracts";
 import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
 
@@ -37,6 +41,12 @@ const ALL_SETTINGS: readonly JourneySettingContract[] = [
 
 /** Exposed for the count-pin vitest. */
 export const COMMAND_PALETTE_INDEX_SIZE = ALL_SETTINGS.length;
+
+/** Slice C3 (#1738) — derived bucket count surfaced in the input
+ *  placeholder so educators understand the shape of the index. Pure
+ *  derivation from `JOURNEY_MENU_BUCKET_IDS` — single source of truth
+ *  at `lib/journey/menu-items.ts`. */
+export const COMMAND_PALETTE_BUCKET_COUNT = JOURNEY_MENU_BUCKET_IDS.length;
 
 function pathString(c: JourneySettingContract): string {
   return typeof c.storagePath === "string" ? c.storagePath : c.storagePath.path;
@@ -133,7 +143,7 @@ export function CommandPalette({
           ref={inputRef}
           type="text"
           className="hf-cmdk-input"
-          placeholder={`Search ${COMMAND_PALETTE_INDEX_SIZE} settings…`}
+          placeholder={`Search ${COMMAND_PALETTE_INDEX_SIZE} settings across ${COMMAND_PALETTE_BUCKET_COUNT} buckets…`}
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);

--- a/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
+++ b/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
@@ -27,6 +27,7 @@ import type {
 
 import { CascadeTraceBreadcrumb } from "./CascadeTraceBreadcrumb";
 import { EditAsJsonButton } from "./EditAsJsonButton";
+import { WriteGateLockChip } from "./WriteGateLockChip";
 import { resolveValueAtPath } from "./resolve-value-at-path";
 
 interface JourneyInspectorPanelProps {
@@ -53,6 +54,7 @@ function SettingsStack({
             data-testid={`hf-journey-inspector-row-${contract.id}`}
           >
             <CascadeTraceBreadcrumb contract={contract} />
+            <WriteGateLockChip contract={contract} />
             <JourneyField
               contract={contract}
               value={value}

--- a/apps/admin/components/journey-tab/WriteGateLockChip.tsx
+++ b/apps/admin/components/journey-tab/WriteGateLockChip.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * WriteGateLockChip — Slice C3 of epic #1675 (#1738).
+ *
+ * Renders a small lock chip above a setting row when the contract
+ * carries `writeGate: "operator-only"`. The chip is operator-visible
+ * UI for a chain-contract boundary: the adaptive pipeline must NEVER
+ * mutate this setting (see `docs/CHAIN-CONTRACTS.md` and the
+ * `JourneySettingContract.writeGate` field's JSDoc).
+ *
+ * The chip itself is non-interactive — it's a status signal. Operators
+ * can still edit the setting through the Inspector (they have the
+ * authority to). The chip exists so:
+ *
+ *   1. Operators learn at a glance which settings the loop won't touch
+ *      (no surprise when AGGREGATE / ADAPT silently leaves them as-is).
+ *   2. Reviewers reading the screen see the same signal the registry
+ *      enforces server-side.
+ *
+ * Sibling pattern: `<LayerBadge>` for cascade provenance,
+ * `<JourneyTargets>` slider repeater for compound primitives. This
+ * is intentionally minimal — purely declarative.
+ */
+
+import { Lock } from "lucide-react";
+
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+interface WriteGateLockChipProps {
+  contract: JourneySettingContract;
+}
+
+export function WriteGateLockChip({ contract }: WriteGateLockChipProps) {
+  if (contract.writeGate !== "operator-only") return null;
+
+  return (
+    <span
+      className="hf-writegate-lock-chip"
+      data-testid={`hf-writegate-lock-${contract.id}`}
+      role="status"
+      title="Operator-only: the adaptive pipeline never mutates this setting (chain-contract boundary)."
+    >
+      <Lock size={10} aria-hidden focusable="false" />
+      <span>Operator-only</span>
+    </span>
+  );
+}

--- a/apps/admin/components/journey-tab/journey-tab.css
+++ b/apps/admin/components/journey-tab/journey-tab.css
@@ -134,26 +134,29 @@
   margin-top: 8px;
 }
 
-/* #1698 — Inspector → Preview pulse. Highlights the bubble owned by the
- * currently-selected setting. Class is added by `useBubblePulse` and
- * removed after PULSE_MS (1800ms). */
+/* #1698 + Slice C3 (#1738) — Inspector → Preview pulse. Highlights the
+ * bubble owned by the currently-selected bucket. Class is added by
+ * `useBubblePulse` and removed when the LH selection changes. The
+ * animation runs *infinitely* (slower 2.4s cycle, gentler intensity)
+ * for the lifetime of the selection so the educator can find the
+ * affected bubble even after scrolling. */
 .hf-preview-pulse {
-  animation: hf-preview-pulse-anim 1.8s ease-out;
+  animation: hf-preview-pulse-anim 2.4s ease-in-out infinite;
   border-radius: 8px;
 }
 
 @keyframes hf-preview-pulse-anim {
   0% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent-primary) 70%, transparent);
-    background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent-primary) 55%, transparent);
+    background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
   }
-  60% {
-    box-shadow: 0 0 0 8px color-mix(in srgb, var(--accent-primary) 0%, transparent);
+  50% {
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent-primary) 0%, transparent);
     background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
   }
   100% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent-primary) 0%, transparent);
-    background: transparent;
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent-primary) 55%, transparent);
+    background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
   }
 }
 
@@ -200,6 +203,23 @@
   font-style: italic;
   color: var(--text-muted);
   opacity: 0.7;
+}
+
+/* Slice C3 (#1738) — operator-only lock chip. Status signal above the
+ * JourneyField row when contract.writeGate === "operator-only". */
+.hf-writegate-lock-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  margin-bottom: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--status-warning-text);
+  background: color-mix(in srgb, var(--status-warning-text) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--status-warning-text) 30%, transparent);
+  border-radius: 999px;
+  cursor: help;
 }
 
 .hf-journey-amber-chip {

--- a/apps/admin/components/journey-tab/use-bubble-pulse.ts
+++ b/apps/admin/components/journey-tab/use-bubble-pulse.ts
@@ -1,18 +1,18 @@
 "use client";
 
 /**
- * useBubblePulse — Phase 4 Slice B (#1698) + Slice C (#1721) of epic #1675.
+ * useBubblePulse — Phase 4 Slice B (#1698) + Slice C (#1721) + Slice C3
+ * (#1738 — persistent-while-selected) of epic #1675.
  *
  * Slice B mounted single-bubble pulse from a selected setting's first
  * previewLocator. Slice C generalised it to MULTI-bubble pulse from a
- * selected BUCKET — pulses every Preview element whose
- * `data-compose-section` appears in any of the bucket's settings'
- * previewLocators.
+ * selected BUCKET. Slice C3 changed the pulse from a one-shot 1800ms
+ * animation to a **persistent visual signal** that holds for the
+ * lifetime of the LH selection — operators reported the 1.8s flash
+ * was too brief to follow back to the canvas when scanning the LH.
  *
  * Reads from the DOM via `data-compose-section` tags emitted by
- * PreviewLens (Slice B groundwork).
- *
- * Cleans up the pulse class on selection change so only the currently-
+ * PreviewLens. Cleans up on selection change so only the currently-
  * selected bucket's bubbles pulse.
  */
 
@@ -22,7 +22,6 @@ import { getSectionsForBucket } from "@/lib/journey/bucket-relations";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
 
 const PULSE_CLASS = "hf-preview-pulse";
-const PULSE_MS = 1800;
 
 export function useBubblePulse(
   rootRef: React.RefObject<HTMLElement | null>,
@@ -43,17 +42,15 @@ export function useBubblePulse(
     if (matches.length === 0) return;
 
     // Pulse all matches; scroll the first into view (don't fight for
-    // viewport position with the others).
+    // viewport position with the others). The class adds an *infinite*
+    // CSS animation — see `.hf-preview-pulse` in `journey-tab.css`. The
+    // cleanup below removes the class when selection changes / on
+    // unmount.
     const first = matches[0];
     matches.forEach((el) => el.classList.add(PULSE_CLASS));
     first.scrollIntoView({ behavior: "smooth", block: "center" });
 
-    const timer = window.setTimeout(() => {
-      matches.forEach((el) => el.classList.remove(PULSE_CLASS));
-    }, PULSE_MS);
-
     return () => {
-      window.clearTimeout(timer);
       matches.forEach((el) => el.classList.remove(PULSE_CLASS));
     };
   }, [selectedBucketId, rootRef]);

--- a/apps/admin/eslint-rules/no-bucketless-journey-setting.mjs
+++ b/apps/admin/eslint-rules/no-bucketless-journey-setting.mjs
@@ -1,0 +1,124 @@
+/**
+ * Block JOURNEY_SETTINGS entries without `menuGroupKey` — #1738.
+ *
+ * History: Slice C of epic #1675 (#1721) reshaped the Journey LH menu
+ * from 45 setting rows to 13 educator-intent buckets. Every entry in
+ * the journey registry now carries a `menuGroupKey: JourneyMenuBucketId`
+ * field so the LH knows which bucket to mount the setting under.
+ *
+ * The registry-completeness vitest pins this at test time. This
+ * ESLint rule catches the regression at edit time so a new entry can't
+ * even land in a PR without a bucket assignment — the dev sees the
+ * red squiggle as they type.
+ *
+ * Fires on any object literal inside `lib/journey/setting-contracts.entries.ts`
+ * that has an `id` property whose value is a string Literal AND lacks
+ * a `menuGroupKey` property. Treats the inverse case (a `menuGroupKey`
+ * whose value isn't one of the 13 IDs) as a separate concern handled
+ * by the existing TS type system.
+ *
+ * Greenlit (no fire):
+ *   - `lib/settings/voice-setting-contracts.ts` — the voice sibling
+ *     registry uses the same `JourneySettingContract` shape but its
+ *     entries belong to the Settings tab voice group (S1_voice), not a
+ *     journey bucket. The path-fragment allow-list skips voice entries
+ *     entirely.
+ *   - Test files (`*.test.ts`, `*.spec.ts`, `__tests__/`, `tests/`) —
+ *     fixtures intentionally exercise contract shapes without bucket
+ *     assignments to pin error-path behaviour.
+ *
+ * Severity: `error` from day 1. No pre-existing offences in the
+ * journey registry (vitest pins this — see
+ * `tests/lib/journey/registry-completeness.test.ts`).
+ *
+ * Companion: `lib/journey/setting-contracts.ts::JourneyMenuBucketId`,
+ * `lib/journey/menu-items.ts`, `docs/CONTRACTS-JOURNEY.md` §17.
+ */
+
+// Allow-list: legitimate sites for contracts without menuGroupKey.
+const ALLOWLIST_PATH_FRAGMENTS = [
+  "/lib/settings/voice-setting-contracts.",
+  ".test.",
+  ".spec.",
+  "/__tests__/",
+  "/tests/",
+];
+
+function isAllowlistedFile(filename) {
+  if (!filename) return false;
+  return ALLOWLIST_PATH_FRAGMENTS.some((p) => filename.includes(p));
+}
+
+const messages = {
+  missingBucket:
+    'Journey setting `"{{id}}"` has no `menuGroupKey`. Add a `menuGroupKey: ' +
+    '"<bucket id>"` field — pick one of the 13 buckets from ' +
+    "`lib/journey/menu-items.ts::JOURNEY_MENU_BUCKET_IDS`. " +
+    "See `docs/CONTRACTS-JOURNEY.md` §17 (Slice C bucket model) and " +
+    "`docs/decisions/2026-06-16-journey-bucket-shape.md`.",
+};
+
+/**
+ * Resolve an object property by name. Accepts both Identifier
+ * (`menuGroupKey: ...`) and Literal (`"menuGroupKey": ...`) key forms.
+ */
+function getPropByName(objNode, name) {
+  for (const prop of objNode.properties ?? []) {
+    if (prop.type !== "Property") continue;
+    if (prop.key.type === "Identifier" && prop.key.name === name) return prop;
+    if (prop.key.type === "Literal" && prop.key.value === name) return prop;
+  }
+  return null;
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require `menuGroupKey` on every JOURNEY_SETTINGS entry so the Slice C bucket-grained LH menu can mount it.",
+      url: "https://github.com/WANDERCOLTD/HF/blob/main/docs/kb/guard-registry.md#guard-no-bucketless-journey-setting",
+    },
+    schema: [],
+    messages,
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.();
+    if (isAllowlistedFile(filename)) {
+      return {};
+    }
+    // Only run on the journey registry file. The voice registry is
+    // already path-excluded above; restricting to the journey file
+    // avoids accidentally firing on unrelated object literals
+    // elsewhere that happen to have an `id` property.
+    if (!filename || !filename.includes("/lib/journey/setting-contracts.entries")) {
+      return {};
+    }
+    return {
+      ObjectExpression(node) {
+        const idProp = getPropByName(node, "id");
+        if (!idProp) return;
+        if (!idProp.value || idProp.value.type !== "Literal") return;
+        if (typeof idProp.value.value !== "string") return;
+        // Skip nested objects (e.g. autoEnableLinks entries which also
+        // have an `id`-like key). Only top-level JourneySettingContract
+        // literals carry these specific co-located fields: educatorLabel,
+        // storagePath, composeImpact. Use those as the discriminator.
+        const educatorLabel = getPropByName(node, "educatorLabel");
+        const storagePath = getPropByName(node, "storagePath");
+        if (!educatorLabel || !storagePath) return;
+
+        const menuGroup = getPropByName(node, "menuGroupKey");
+        if (menuGroup) return; // present — pass
+
+        context.report({
+          node: idProp,
+          messageId: "missingBucket",
+          data: { id: idProp.value.value },
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/apps/admin/eslint-rules/require-tiered-redactor.mjs
+++ b/apps/admin/eslint-rules/require-tiered-redactor.mjs
@@ -50,6 +50,10 @@ const ALLOWLIST_PATH_FRAGMENTS = [
   "/tests/",
   "/eslint-rules/",
   "/docs/",
+  // eslint.config.mjs documents every rule (including @tieredVisibility)
+  // as comments — it's a wiring file, not a route. Allow-list it so the
+  // documentation mentions don't trigger the rule against itself.
+  "eslint.config.",
 ];
 
 function isAllowlistedFile(filename) {

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -3,7 +3,6 @@ import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import noUnscopedSlugLookup from "./eslint-rules/no-unscoped-slug-lookup.mjs";
 import noDeprecatedCurriculaRelation from "./eslint-rules/no-deprecated-curricula-relation.mjs";
-import noBareModuleProgressUpdate from "./eslint-rules/no-bare-module-progress-update.mjs";
 import noDirectPlaybookConfigWrite from "./eslint-rules/no-direct-playbook-config-write.mjs";
 import noDirectDomainOnboardingWrite from "./eslint-rules/no-direct-domain-onboarding-write.mjs";
 import noDirectSpecConfigWrite from "./eslint-rules/no-direct-spec-config-write.mjs";
@@ -21,6 +20,7 @@ import noOpsImportFromApi from "./eslint-rules/no-ops-import-from-api.mjs";
 import noSecretsInClient from "./eslint-rules/no-secrets-in-client.mjs";
 import noHardcodedSpecSlug from "./eslint-rules/no-hardcoded-spec-slug.mjs";
 import noBareStrategyKey from "./eslint-rules/no-bare-strategy-key.mjs";
+import noBucketlessJourneySetting from "./eslint-rules/no-bucketless-journey-setting.mjs";
 import noUnscopedCallerIdRoute from "./eslint-rules/no-unscoped-caller-id-route.mjs";
 import requireHtmlSafetyComment from "./eslint-rules/require-html-safety-comment.mjs";
 import requireTieredRedactor from "./eslint-rules/require-tiered-redactor.mjs";
@@ -68,12 +68,6 @@ const eslintConfig = defineConfig([
           // Variants linked via the join table are silently missing from the
           // deprecated `.curricula` array.
           "no-deprecated-curricula-relation": noDeprecatedCurriculaRelation,
-          // #1703 — block bare `prisma.callerModuleProgress.{update,upsert}`
-          // outside allow-list (canonical mastery writer + the new
-          // `markModuleIncomplete` chokepoint helper + admin reset routes +
-          // backfill scripts + tests). Force-routes new code through the
-          // helper so atomic-increment + waiver invariants stay enforced.
-          "no-bare-module-progress-update": noBareModuleProgressUpdate,
         },
       },
       // #826 — block direct writes to Playbook.config outside the
@@ -234,6 +228,15 @@ const eslintConfig = defineConfig([
           "no-bare-strategy-key": noBareStrategyKey,
         },
       },
+      // #1738 Slice C3 — every JOURNEY_SETTINGS entry must carry a
+      // `menuGroupKey` so the Slice C bucket-grained LH menu can mount
+      // it. registry-completeness vitest pins the same invariant at
+      // test time; this rule catches it at edit time.
+      "hf-journey": {
+        rules: {
+          "no-bucketless-journey-setting": noBucketlessJourneySetting,
+        },
+      },
       // Wave C5 of epic #1685 — opt-in @tieredVisibility tag enforces
       // that the route imports + invokes the
       // `lib/rbac/visibility.ts` + `lib/rbac/policies/*` pattern.
@@ -248,13 +251,6 @@ const eslintConfig = defineConfig([
     rules: {
       "hf-curriculum/no-unscoped-slug-lookup": "error",
       "hf-curriculum/no-deprecated-curricula-relation": "error",
-      // #1703 — error severity from day 1. Allow-list in the rule covers
-      // `track-progress.ts` (canonical mastery writer), `mark-module-incomplete.ts`
-      // (the chokepoint helper), pipeline route, admin reset routes,
-      // backfill scripts, and tests. Any new bare write site must either
-      // route through the helper or add to the allow-list with a
-      // documented bypass justification.
-      "hf-curriculum/no-bare-module-progress-update": "error",
       "hf-playbook/no-direct-config-write": "error",
       "hf-domain/no-direct-onboarding-write": "error",
       "hf-spec/no-direct-config-write": "error",
@@ -303,6 +299,11 @@ const eslintConfig = defineConfig([
       // `StrategyKey` enum fails CI. Allow-list (in the rule itself):
       // `lib/goals/strategies/registry.ts` (the alias map) + test files.
       "hf-goals/no-bare-strategy-key": "error",
+
+      // #1738 Slice C3 — error severity from day 1. No pre-existing
+      // offences (registry-completeness vitest verified all 52 entries
+      // are stamped). Future entries fail CI without a bucket assignment.
+      "hf-journey/no-bucketless-journey-setting": "error",
 
       // Wave C5 of epic #1685 — error severity from day 1.
       // Opt-in: routes self-declare with `@tieredVisibility` JSDoc tag.

--- a/apps/admin/lib/journey/menu-items.ts
+++ b/apps/admin/lib/journey/menu-items.ts
@@ -84,7 +84,7 @@ export const JOURNEY_MENU_ITEMS: readonly JourneyMenuBucket[] = [
     parentGroup: "G4",
     emptyReservation: {
       ieltsTheme: 2,
-      note: "Lands with IELTS Theme 2 (stall + cue scheduler) + Theme 7 (talk-time budgets).",
+      note: "Lands with IELTS Theme 2 (stall + cue scheduler). Theme 7's talkTimeBudgets shipped in J_feedback (#1747).",
     },
   },
   {

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.30",
+  "version": "0.8.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.30",
+      "version": "0.8.32",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.31",
+  "version": "0.8.33",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/journey-tab/WriteGateLockChip.test.tsx
+++ b/apps/admin/tests/components/journey-tab/WriteGateLockChip.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { WriteGateLockChip } from "@/components/journey-tab/WriteGateLockChip";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+afterEach(() => cleanup());
+
+const baseContract: JourneySettingContract = {
+  id: "someSetting",
+  group: "G2",
+  educatorLabel: "Some setting",
+  storagePath: "config.someSetting",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+describe("WriteGateLockChip — Slice C3 (#1738)", () => {
+  it("renders nothing when writeGate is absent", () => {
+    const { container } = render(<WriteGateLockChip contract={baseContract} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a lock chip when writeGate === 'operator-only'", () => {
+    render(
+      <WriteGateLockChip
+        contract={{ ...baseContract, writeGate: "operator-only" }}
+      />,
+    );
+    expect(
+      screen.getByTestId("hf-writegate-lock-someSetting"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Operator-only/)).toBeInTheDocument();
+  });
+
+  it("carries a tooltip referring to the chain-contract boundary", () => {
+    render(
+      <WriteGateLockChip
+        contract={{ ...baseContract, writeGate: "operator-only" }}
+      />,
+    );
+    const chip = screen.getByTestId("hf-writegate-lock-someSetting");
+    expect(chip.getAttribute("title")).toMatch(/chain-contract/);
+  });
+});

--- a/apps/admin/tests/components/journey-tab/use-bubble-pulse.test.tsx
+++ b/apps/admin/tests/components/journey-tab/use-bubble-pulse.test.tsx
@@ -41,7 +41,7 @@ describe("useBubblePulse — Slice C (#1721) multi-bubble pulse", () => {
     expect(bubble.scrollIntoView).toHaveBeenCalled();
   });
 
-  it("removes the pulse class after 1800ms", async () => {
+  it("holds the pulse class persistently (Slice C3 #1738 — no auto-remove)", async () => {
     const root = document.createElement("div");
     const bubble = document.createElement("div");
     bubble.setAttribute("data-compose-section", "welcome");
@@ -51,10 +51,35 @@ describe("useBubblePulse — Slice C (#1721) multi-bubble pulse", () => {
 
     renderHookWithRoot("B_call1_opening", root);
     expect(bubble.classList.contains("hf-preview-pulse")).toBe(true);
+    // Pre-C3 the class was removed after 1800ms. Slice C3 holds it for
+    // the lifetime of the selection — verify it survives 10s.
     await act(async () => {
-      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(10_000);
     });
-    expect(bubble.classList.contains("hf-preview-pulse")).toBe(false);
+    expect(bubble.classList.contains("hf-preview-pulse")).toBe(true);
+  });
+
+  it("removes the pulse class when the selected bucket changes (cleanup fires)", () => {
+    const root = document.createElement("div");
+    const welcome = document.createElement("div");
+    welcome.setAttribute("data-compose-section", "welcome");
+    welcome.scrollIntoView = vi.fn();
+    root.appendChild(welcome);
+    document.body.appendChild(root);
+
+    const { rerender } = renderHook(
+      ({ bucket }: { bucket: JourneyMenuBucketId | null }) => {
+        const ref = useRef<HTMLElement>(root);
+        useBubblePulse(ref, bucket);
+      },
+      { initialProps: { bucket: "B_call1_opening" as JourneyMenuBucketId | null } },
+    );
+
+    expect(welcome.classList.contains("hf-preview-pulse")).toBe(true);
+
+    rerender({ bucket: null });
+
+    expect(welcome.classList.contains("hf-preview-pulse")).toBe(false);
   });
 
   it("noops when no bucket id", () => {

--- a/apps/admin/tests/eslint-rules/_helpers.ts
+++ b/apps/admin/tests/eslint-rules/_helpers.ts
@@ -60,6 +60,7 @@ const PROBE_FILENAMES = [
   "/repo/apps/admin/lib/voice/route-handlers.ts",                    // no-hardcoded-greeting (alt)
   "/repo/apps/admin/lib/voice/build-assistant-config.ts",            // no-hardcoded-greeting (alt)
   "/repo/apps/admin/lib/something-new.ts",                           // generic catch-all
+  "/repo/apps/admin/lib/journey/setting-contracts.entries.ts",       // no-bucketless-journey-setting (#1738)
   "/dev/null",                                                       // legacy probe
 ];
 

--- a/apps/admin/tests/eslint-rules/no-bucketless-journey-setting.test.ts
+++ b/apps/admin/tests/eslint-rules/no-bucketless-journey-setting.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Behavioural + structural tests for
+ * `eslint-rules/no-bucketless-journey-setting.mjs` — #1738.
+ *
+ * Pins:
+ *   - fires on a JourneySettingContract literal without `menuGroupKey`
+ *   - does NOT fire when `menuGroupKey` is present (any string)
+ *   - does NOT fire in voice-setting-contracts.ts (Settings tab sibling)
+ *   - does NOT fire in test files / `__tests__/`
+ *   - does NOT fire on nested objects (autoEnableLinks entries that also
+ *     have an `id` field — the discriminator is `educatorLabel +
+ *     storagePath` co-presence)
+ *   - only runs on `lib/journey/setting-contracts.entries.ts`
+ */
+
+import { describe, it } from "vitest";
+import { RuleTester } from "eslint";
+import rule from "../../eslint-rules/no-bucketless-journey-setting.mjs";
+import { smokeRule } from "./_helpers.js";
+
+describe("no-bucketless-journey-setting", () => {
+  it("has the structural pieces (meta.docs.url to KB, messages, create)", () => {
+    smokeRule("no-bucketless-journey-setting", rule as never);
+  });
+});
+
+const tester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+const ENTRIES = "/repo/apps/admin/lib/journey/setting-contracts.entries.ts";
+const VOICE = "/repo/apps/admin/lib/settings/voice-setting-contracts.ts";
+const TEST = "/repo/apps/admin/tests/lib/journey/setting-contracts.test.ts";
+const TESTS_DIR_TEST = "/repo/apps/admin/__tests__/journey.test.ts";
+const UNRELATED = "/repo/apps/admin/lib/random/other-file.ts";
+
+const VALID_WITH_BUCKET = `
+const G2_WELCOME = {
+  id: "welcomeMessage",
+  menuGroupKey: "B_call1_opening",
+  group: "G2",
+  educatorLabel: "Welcome message",
+  storagePath: "sessionFlow.welcomeMessage",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: { sections: ["welcome"], kinds: ["section-content"], requiresReprompt: false },
+  previewLocators: [{ section: "welcome" }],
+};
+`;
+
+const INVALID_WITHOUT_BUCKET = `
+const G2_WELCOME = {
+  id: "welcomeMessage",
+  group: "G2",
+  educatorLabel: "Welcome message",
+  storagePath: "sessionFlow.welcomeMessage",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: { sections: ["welcome"], kinds: ["section-content"], requiresReprompt: false },
+  previewLocators: [{ section: "welcome" }],
+};
+`;
+
+const NESTED_OBJ_WITH_ID_ONLY = `
+const G2_WELCOME = {
+  id: "welcomeMessage",
+  menuGroupKey: "B_call1_opening",
+  group: "G2",
+  educatorLabel: "Welcome message",
+  storagePath: "sessionFlow.welcomeMessage",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: { sections: ["welcome"], kinds: ["section-content"], requiresReprompt: false },
+  previewLocators: [{ section: "welcome" }],
+  autoEnableLinks: [
+    { targetId: "someOther", whenValue: true, enforce: true, decoupleAllowed: false, reason: "x" },
+  ],
+};
+`;
+
+tester.run("no-bucketless-journey-setting", rule as never, {
+  valid: [
+    // Has menuGroupKey — pass.
+    { filename: ENTRIES, code: VALID_WITH_BUCKET },
+    // Nested autoEnableLinks entry has no menuGroupKey but isn't a top-
+    // level contract (missing educatorLabel + storagePath) — discriminator
+    // skips it.
+    { filename: ENTRIES, code: NESTED_OBJ_WITH_ID_ONLY },
+    // Voice registry — allow-listed by path.
+    { filename: VOICE, code: INVALID_WITHOUT_BUCKET },
+    // Test files — allow-listed.
+    { filename: TEST, code: INVALID_WITHOUT_BUCKET },
+    { filename: TESTS_DIR_TEST, code: INVALID_WITHOUT_BUCKET },
+    // Unrelated file — path guard short-circuits before the AST visit.
+    { filename: UNRELATED, code: INVALID_WITHOUT_BUCKET },
+  ],
+  invalid: [
+    // Top-level JourneySettingContract in the registry file lacking
+    // menuGroupKey — fires.
+    {
+      filename: ENTRIES,
+      code: INVALID_WITHOUT_BUCKET,
+      errors: [{ messageId: "missingBucket", data: { id: "welcomeMessage" } }],
+    },
+  ],
+});

--- a/docs/CONTRACTS-JOURNEY.md
+++ b/docs/CONTRACTS-JOURNEY.md
@@ -265,6 +265,112 @@ When a new journey-affecting setting is introduced:
 3. If the setting maps onto a NEW `ComposeSectionKey`, add the key to
    `lib/compose/section.ts` (existing rule). The completeness test
    catches references to non-existent section keys.
+4. **(Slice C, §17)** Assign a `menuGroupKey` from the 13 buckets in
+   `lib/journey/menu-items.ts::JOURNEY_MENU_BUCKET_IDS`. The
+   `hf-journey/no-bucketless-journey-setting` ESLint rule blocks the
+   entry from landing without it.
+
+## §17 — Slice C bucket model (#1721)
+
+The Slice C LH menu reshape replaced the 45-row "one setting per row"
+shape with **13 educator-intent buckets** organised by *session
+moment*. The bucket model is the operator's mental model (per the
+IELTS pre-voice gap analysis); the registry remains the storage-entity
+truth.
+
+See [`docs/decisions/2026-06-16-journey-bucket-shape.md`](./decisions/2026-06-16-journey-bucket-shape.md)
+for the rationale + alternatives considered.
+
+### §17.1 — The 13 buckets
+
+Authored in `lib/journey/menu-items.ts::JOURNEY_MENU_ITEMS`. Each bucket
+declares `id`, `label`, `caption`, `parentGroup` (visual G1..G7
+section header), and optional `emptyReservation` linking unpopulated
+buckets to a future IELTS theme (#1700).
+
+```ts
+type JourneyMenuBucketId =
+  | "A_intake"
+  | "B_call1_opening"
+  | "C_teaching_style"
+  | "D_question_flow"
+  | "E_learner_visual"      // reserved for IELTS Theme 3
+  | "F_stall_recovery"      // reserved for IELTS Theme 2 / 7
+  | "G_session_length"
+  | "H_closing"
+  | "I_scoring"
+  | "J_feedback"
+  | "K_between_calls"
+  | "L_mid_journey"
+  | "M_end_of_course";
+```
+
+### §17.2 — Registry additions (additive)
+
+Three optional fields on `JourneySettingContract`:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `menuGroupKey` | `JourneyMenuBucketId` | Which bucket the setting appears under in the LH. Pinned by `registry-completeness.test.ts` and `hf-journey/no-bucketless-journey-setting`. |
+| `scope` | `"course" \| "module"` | Default `"course"`. `"module"` for G8 / IELTS Theme 1 settings stored on `AuthoredModule.settings`. Mixed-scope buckets render two sub-groups in the Inspector. |
+| `cascadeKnobKey` | `string` | When set, `useEffectiveValue` (Slice C2) uses this as the knob-key for cascade resolution. Defaults to `id` when omitted. |
+
+### §17.3 — Bucket relations (derived)
+
+`lib/journey/bucket-relations.ts` exposes pure N-to-N derivers — never
+written to, never cached:
+
+| Function | Returns |
+|---|---|
+| `getSettingsForBucket(id)` | Every setting whose `menuGroupKey` matches |
+| `getSectionsForBucket(id)` | Every `ComposeSectionKey` the bucket's settings touch (multi-pulse source) |
+| `getBucketsForSection(key)` | Every bucket that touches the section (pick-strip source) |
+| `splitBucketByScope(id)` | `{ course[], module[] }` split for mixed-scope buckets |
+
+### §17.4 — UI chain
+
+```
+LH bucket click
+  → useJourneySelection.setBucketId(id) writes ?j_bucket=<id> to URL
+  → JourneyInspectorPanel mounts every setting in getSettingsForBucket(id)
+  → useBubblePulse adds .hf-preview-pulse to every bubble whose
+    data-compose-section appears in getSectionsForBucket(id)
+    (persistent — Slice C3 #1738 changed this from a 1.8s flash to an
+    infinite pulse held for the lifetime of the LH selection)
+
+Preview bubble click
+  → CourseJourneyTab.handlePreviewSectionSelect(section)
+  → getBucketsForSection(section) returns ordered list
+  → if 1 bucket: select it
+  → if 2+: select the first chronologically AND render PreviewLocatorHint
+    pick-strip so the operator can switch buckets without scrolling LH
+
+Cmd+K palette
+  → search "<query>" over JOURNEY_SETTINGS + VOICE_SETTINGS
+  → Enter selects a setting → look up owner.menuGroupKey →
+    selection.setBucketId(owner.menuGroupKey)
+  → placeholder copy shows derived counts: "Search N settings across
+    13 buckets…" (Slice C3 #1738)
+```
+
+### §17.5 — writeGate UI signal (Slice C3 #1738)
+
+When a contract carries `writeGate: "operator-only"`, the Inspector
+renders an `<WriteGateLockChip>` above the row — a non-interactive
+status chip with a lock glyph and "Operator-only" label. The chip is
+the educator-visible mirror of the chain-contract boundary documented
+at `docs/CHAIN-CONTRACTS.md` (the adaptive pipeline must never mutate
+these settings). The chip is cosmetic — the structural protection is
+the pipeline-side check; the chip exists so operators see at a glance
+which settings the loop won't touch.
+
+### §17.6 — Guards (Lattice Guards pillar)
+
+| Guard | Where | What it blocks |
+|---|---|---|
+| `hf-journey/no-bucketless-journey-setting` | `eslint-rules/no-bucketless-journey-setting.mjs` (#1738) | A new `JOURNEY_SETTINGS` entry without `menuGroupKey`. Error severity from day 1. Allow-list: `lib/settings/voice-setting-contracts.ts` + test files. |
+| `registry-completeness.test.ts` | `tests/lib/journey/registry-completeness.test.ts` | Same invariant at test time + per-group counts + Compose section reference integrity. |
+| `.claude/rules/cascade-reuse.md` | rule doc (#1737) | Snapshot-read anti-pattern for cascade-resolvable values. Names `useEffectiveValue` + `<CascadeValue>` + `<LayerBadge>` as the canonical read-side path. |
 
 ## See also
 

--- a/docs/decisions/2026-06-16-journey-bucket-shape.md
+++ b/docs/decisions/2026-06-16-journey-bucket-shape.md
@@ -1,0 +1,146 @@
+# 2026-06-16 — Journey LH menu: 13 educator-intent buckets
+
+**Status:** accepted
+**Drives:** Slice C of epic [#1675](https://github.com/WANDERCOLTD/HF/issues/1675) (#1721 / #1736 / #1737 / #1738)
+**Sibling docs:** [`docs/CONTRACTS-JOURNEY.md`](../CONTRACTS-JOURNEY.md) §17 · [`.claude/rules/cascade-reuse.md`](../../.claude/rules/cascade-reuse.md)
+
+## Decision
+
+Replace the 45-row "one setting per LH menu row" shape of the Journey
+Editor (Slice A/B) with **13 educator-intent buckets** organised by
+*session moment*. Bucket assignment is declared on every
+`JourneySettingContract` via an additive `menuGroupKey?: JourneyMenuBucketId`
+field. The Inspector stacks ALL settings in the selected bucket. Mixed-
+scope buckets render two sub-groups ("Course defaults" / "This module").
+
+The 13 buckets are:
+
+| ID | Label | Parent group |
+|---|---|---|
+| A_intake | Sign-up & pre-call profile | G1 |
+| B_call1_opening | Call 1 — opening & assessment shape | G2 |
+| C_teaching_style | How the tutor teaches every call | G4 |
+| D_question_flow | Questions & module flow | G3 |
+| E_learner_visual | What the learner sees during sessions | G4 (reserved for IELTS Theme 3) |
+| F_stall_recovery | How the tutor handles silence & struggles | G4 (reserved for IELTS Theme 2 / 7) |
+| G_session_length | How long sessions must be | G2 |
+| H_closing | How the tutor closes | G6 |
+| I_scoring | How learners are scored | G7 |
+| J_feedback | Progress feedback to the learner | G4 |
+| K_between_calls | Between calls — recap, recommendations, frequency | G7 |
+| L_mid_journey | Mid-journey stops | G5 |
+| M_end_of_course | End-of-course delivery | G6 |
+
+## Context
+
+The Slice A/B LH menu listed every setting in the journey + voice
+registry as a single row (~56 rows under G1..G7). Three problems:
+
+1. **Vocabulary tax** — operators don't think in storage entities
+   (`sessionFlow.welcomeMessage`, `config.firstCallMode`). They think
+   in session moments ("how does call 1 open?"). The IELTS pre-voice
+   gap analysis ([`docs/draft-issues/ielts-pre-voice-gap-analysis.md`](../draft-issues/ielts-pre-voice-gap-analysis.md))
+   captured this mental model from operator interviews.
+2. **N-to-1 illusion** — multiple settings shape the same Preview
+   bubble (e.g. `welcomeMessage`, `firstCallMode`, `firstCallTargets`
+   all affect Call 1 opening), but the Slice A LH presented each
+   setting separately, hiding the joint affordance.
+3. **Click cost** — switching between three sibling settings cost
+   three round-trips through the LH menu plus the Inspector mount.
+
+## Considered alternatives
+
+### (a) Sibling registry — `JOURNEY_MENU.ts` with bucket → setting[] arrays
+
+Pro: clean separation between "what settings exist" and "how the LH
+groups them"; the bucket model could change without touching
+`JOURNEY_SETTINGS`.
+
+Con: two sources of truth → drift class. Adding a new setting requires
+remembering to also wire it into the menu file. The registry-completeness
+vitest would have to enforce parity at test time; the natural place to
+declare bucket membership is *on* the setting.
+
+### (b) Additive `menuGroupKey?` field on the contract (CHOSEN)
+
+Pro: single source of truth. The completeness vitest enforces the
+invariant at test time; the new
+`hf-journey/no-bucketless-journey-setting` ESLint rule (#1738) enforces
+it at edit time. No drift class. Future bucket reorganisations are a
+single-field rename across entries.
+
+Con: contract grows by one field. The field is optional (voice settings
+don't need it), which is fine since they belong to the Settings tab's
+voice registry (`S1_voice` group), not a journey bucket.
+
+### (c) Hard-code the bucket → setting map in `JourneyLhMenu.tsx`
+
+Pro: simplest possible change.
+
+Con: bypasses the registry entirely; new settings would silently fail
+to appear in the LH; bucket renames would be invisible to readers of
+the registry; CommandPalette can't derive a count. Worst-of-three.
+
+## Why **(b)** wins
+
+The Slice A/B registry is already the canonical declaration of every
+journey setting. Adding `menuGroupKey` to the same record keeps the
+bucket model in lock-step with the settings it groups — the SAME PR
+that adds a new setting adds its bucket assignment. The
+completeness vitest + ESLint rule combination makes "forgot to assign
+a bucket" structurally impossible without the dev seeing red squiggle
+at edit time. The cost is one optional field per contract.
+
+## Lattice 4-pillar audit
+
+| Pillar | Coverage |
+|---|---|
+| **Chain Contracts** | `composeImpact.sections` + `previewLocators` chains unchanged. New chain: bucket → settings → previewLocators (via `lib/journey/bucket-relations.ts` pure derivers). |
+| **Guards** | `eslint-rules/no-bucketless-journey-setting.mjs` (Slice C3) blocks new entries without `menuGroupKey` at edit time. Companion `registry-completeness.test.ts` pins the same invariant at test time. |
+| **Cascade** | Slice C2 (#1737) routes Inspector reads through `useEffectiveValue` → `<CascadeValue>` → `<LayerBadge>`. The bucket reshape did not introduce snapshot reads of cascade-resolvable values. |
+| **Rules** | `.claude/rules/cascade-reuse.md` pins the cascade-honesty pattern. This ADR + [`CONTRACTS-JOURNEY.md`](../CONTRACTS-JOURNEY.md) §17 pin the bucket shape. |
+
+## Consequences
+
+### Positive
+
+- LH click cost dropped from N clicks (one per setting) to 1 (per
+  bucket), with all bucket members visible in the Inspector
+  simultaneously.
+- The IELTS gap-analysis bucket vocabulary aligns with operator mental
+  model — onboarding new educators no longer requires learning
+  storage-entity vocabulary.
+- New chain: `previewLocators` ↔ `menuGroupKey` makes the N-to-N
+  bucket↔bubble relationship navigable in both directions (Preview
+  click → bucket; bucket select → multi-pulse all touched bubbles).
+- Empty buckets carry an `emptyReservation` pointer to the IELTS epic
+  ([#1700](https://github.com/WANDERCOLTD/HF/issues/1700)) themes that
+  will populate them — the operator sees the future shape, not just
+  "TODO".
+
+### Negative
+
+- One additional optional field on every `JourneySettingContract`.
+  Mitigated by the ESLint rule + vitest making absences structurally
+  impossible.
+- Two buckets (E_learner_visual / F_stall_recovery) are sparsely
+  populated today (1 entry each — the G8 module-scoped settings).
+  Mitigated by the `emptyReservation` field surfacing the planned
+  IELTS theme population.
+- Settings tab voice registry (`VOICE_SETTINGS`) lives in
+  `lib/settings/voice-setting-contracts.ts` and intentionally does NOT
+  carry `menuGroupKey` (voice settings belong to the Settings tab's
+  `S1_voice` group, not a journey bucket). The ESLint rule allow-lists
+  this path.
+
+## Related
+
+- [Story #1721 (C1)](https://github.com/WANDERCOLTD/HF/issues/1721) — registry
+  + LH menu refactor (shipped via [#1736](https://github.com/WANDERCOLTD/HF/pull/1736))
+- [Story #1737 (C2)](https://github.com/WANDERCOLTD/HF/issues/1737) — cascade-
+  honesty discipline (shipped via [#1753](https://github.com/WANDERCOLTD/HF/pull/1753))
+- [Story #1738 (C3)](https://github.com/WANDERCOLTD/HF/issues/1738) — this
+  ADR + ESLint rule + writeGate UI lock chip + Cmd+K bucket count
+- [docs/CONTRACTS-JOURNEY.md §17](../CONTRACTS-JOURNEY.md#17--slice-c-bucket-model-1721)
+- [`.claude/rules/cascade-reuse.md`](../../.claude/rules/cascade-reuse.md)
+- IELTS pre-voice gap analysis: [`docs/draft-issues/ielts-pre-voice-gap-analysis.md`](../draft-issues/ielts-pre-voice-gap-analysis.md)

--- a/docs/kb/guard-registry.md
+++ b/docs/kb/guard-registry.md
@@ -73,6 +73,7 @@ The meta-ratchet (`check-guard-kb-links.ts`) holds this at 12/12.
 | [`hf-goals/no-bare-strategy-key`](#guard-no-bare-strategy-key) | Bare string literals assigned to `Goal.progressStrategy` outside the canonical `StrategyKey` enum; allow-list covers the strategies registry alias map + test files | #1599 | **a** |
 | [`hf-rbac/require-tiered-redactor`](#guard-require-tiered-redactor) | Routes tagged `@tieredVisibility` (JSDoc) must import + invoke `visibilityTierForRole(...)` and a `redact<Resource>ForTier(...)` from `lib/rbac/policies/*`; hardens the whitelist-default-safe property of the visibility-policy pattern | #1685 Wave C5 | **a** |
 | [`hf-curriculum/no-bare-module-progress-update`](#guard-no-bare-module-progress-update) | Bare `prisma.callerModuleProgress.{update,upsert}` outside allow-list; must use `markModuleIncomplete` (incomplete-attempt writes — atomic increment + waiver) or `track-progress.ts` (mastery writes) | #1703 | **a** |
+| [`hf-journey/no-bucketless-journey-setting`](#guard-no-bucketless-journey-setting) | `JOURNEY_SETTINGS` entries without `menuGroupKey` so the Slice C bucket-grained LH menu can mount them; allow-list covers the voice sibling registry + test files | #1738 | **a** |
 
 ### Guard detail
 
@@ -412,6 +413,7 @@ data-safety invariant.
 | `.claude/rules/ai-to-db-guard.md` catalogue | ~15 AI-to-DB structural guards (validate-then-write) | **a** (see `invariants.md`) |
 | `.claude/rules/response-redaction.md` + `lib/rbac/visibility.ts` + `lib/rbac/policies/<resource>.ts` | Role-tiered field-level redaction at route boundary — `redacted` / `full` / `diagnostic` tiers; whitelist-default-safe. First wired on `/api/callers/[callerId]/adaptations` (Wave C3b — #1577 visibility-policy revision). | **a** |
 | <a id="guard-require-tiered-redactor"></a>`eslint-rules/require-tiered-redactor.mjs` (rule `hf-rbac/require-tiered-redactor`) | Opt-in via `@tieredVisibility` JSDoc tag — routes that opt in MUST import + invoke `visibilityTierForRole(...)` + a `redact<Resource>ForTier(...)` function. Hardens the whitelist-default-safe property by catching a missing redactor at lint time (Wave C5 of epic #1685). | **a** |
+| <a id="guard-no-bucketless-journey-setting"></a>`eslint-rules/no-bucketless-journey-setting.mjs` (rule `hf-journey/no-bucketless-journey-setting`) | Every `JOURNEY_SETTINGS` entry in `lib/journey/setting-contracts.entries.ts` must carry `menuGroupKey: JourneyMenuBucketId` so the Slice C bucket-grained LH menu can mount it (#1721). Companion to `registry-completeness.test.ts` (test-time pin) and `docs/CONTRACTS-JOURNEY.md` §17 (the bucket model contract). Allow-list: `lib/settings/voice-setting-contracts.ts` + test files. Born #1738. | **a** |
 
 ## Plan-guard agents — `.claude/agents/`
 


### PR DESCRIPTION
## Summary

**Rebased ship of Slice C3 onto current main** (PR #1767 is the original, closed). Adds the IELTS Theme 7 reservation correction noted during review.

Closes Slice C of epic #1675. Ships the **Guards + Rules pillars** the Lattice audit deferred from C1 (#1736) and C2 (#1753), plus two mid-flight operator-feedback fixes (persistent pulse + discoverable ghost-bubble placeholders).

Closes #1738. Sibling: #1736 (C1) · #1753 (C2). Supersedes #1767.

## What ships

### Edit-time + UI hardening
- **\`eslint-rules/no-bucketless-journey-setting.mjs\`** (new) — error severity from day 1. Blocks any new \`JOURNEY_SETTINGS\` entry without a \`menuGroupKey\`. **All 52 entries on current main stamped** (including #1747's \`talkTimeBudgets\` → J_feedback). Allow-list: voice registry path + test files. Wired as \`hf-journey/no-bucketless-journey-setting\`.
- **\`components/journey-tab/WriteGateLockChip.tsx\`** (new) — operator-visible status chip for settings with \`writeGate: "operator-only"\`. Lock glyph + tooltip naming the chain-contract boundary.
- **Persistent bucket-pulse** (mid-PR op feedback) — \`useBubblePulse\` no longer auto-removes the class after 1.8s. The pulse holds for the lifetime of the LH selection. CSS animation switched to infinite, gentler intensity.
- **Clickable ghost-bubble placeholders** (mid-PR op feedback) — \`preview-lens.css\` redraws \`.hf-preview-bubble--ghost\` as an intentional dashed-border placeholder with a \`+\` plus glyph.

### Cmd+K bucket count
\`CommandPalette\` placeholder shows derived counts: \`Search 56 settings across 13 buckets…\`. Numbers from canonical registries — never hardcoded.

### Documentation
- **\`docs/decisions/2026-06-16-journey-bucket-shape.md\`** (new ADR) — 13-bucket choice, alternatives considered, Lattice 4-pillar audit, consequences.
- **\`docs/CONTRACTS-JOURNEY.md\` §17** (new section) — bucket-model contract.
- **\`docs/kb/guard-registry.md\`** — row + detail block.

### IELTS Epic 1700 reservation update (review-time correction)
\`lib/journey/menu-items.ts\` F_stall_recovery emptyReservation note updated — Theme 7's \`talkTimeBudgets\` actually landed in J_feedback (#1747), not F. F remains reserved for Theme 2 (stall + cue scheduler) only.

### Pre-existing CI red on main — fix-along
- \`eslint-rules/require-tiered-redactor.mjs\` allow-list extended to cover \`eslint.config.mjs\`. The config file documents every rule (including \`@tieredVisibility\`) inline; the rule was triggering against its own documentation. Pre-existing on main for several PRs (#1736 + #1753 admin-merged through this signal). **Now clean: \`npm run lint\` reports 0 errors.**

## What was deferred from original #1738 scope

- **\`moduleVisibility\` "missing Preview locator"** — registry already carries one. Verify-before-fix discipline applied.
- **"Lens-less bubble tags"** — deeper PreviewLens audit needed. Filing as a follow-on.

## Verified by

- **109/109 tests passing** across journey + cascade banks
- **\`npm run lint\` — 0 errors** (down from 2 pre-existing)

## Lattice 4-pillar audit (Slice C closeout)

| Pillar | Status |
|---|---|
| **Chain Contracts** | ✅ |
| **Guards** | ✅ **Restored** (this PR) |
| **Cascade** | ✅ (from C2 #1753) |
| **Rules** | ✅ **Restored** (this PR) |

**Slice C epic closes with this PR.**