### PR TITLE
feat(compose): #1732 — G8 consumer A, moduleQuestionTarget directive in instructions

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/instructions.ts
+++ b/apps/admin/lib/prompt/composition/transforms/instructions.ts
@@ -12,8 +12,9 @@ import { registerTransform } from "../TransformRegistry";
 import { classifyValue } from "../types";
 import { computePersonalityAdaptation } from "./personality";
 import type { AssembledContext, GoalData, SubjectSourcesData } from "../types";
-import type { SpecConfig } from "@/lib/types/json-fields";
+import type { AuthoredModule, PlaybookConfig, SpecConfig } from "@/lib/types/json-fields";
 import { resolveTeachingProfile } from "@/lib/content-trust/teaching-profiles";
+import { isIeltsModuleSettingsEnabled } from "@/lib/journey/module-settings-flag";
 
 // Goal-type × progress-bracket adaptation guidance.
 // Tells the AI HOW to adapt teaching based on goal type and progress level.
@@ -312,5 +313,68 @@ registerTransform("computeInstructions", (
 
     // Voice — delegates to separate transform (already computed)
     voice: sections.instructions_voice || null,
+
+    // #1732 (epic #1730 G8 consumer A) — module-scoped question count
+    // directive. Resolves `Playbook.config.modules[].settings.questionTarget`
+    // against `sharedState.lockedModule`. Gated by
+    // `HF_FLAG_IELTS_MODULE_SETTINGS` per epic #1700 decision 5. Returns
+    // null (renders nothing) when any condition fails.
+    module_question_target: resolveModuleQuestionTarget(
+      (loadedData.playbooks?.[0]?.config ?? {}) as PlaybookConfig,
+      sharedState,
+    ),
   };
 });
+
+/**
+ * #1732 (epic #1730 G8 consumer A) — module-scoped question count directive.
+ *
+ * Returns a directive string when ALL conditions hold:
+ *   - `HF_FLAG_IELTS_MODULE_SETTINGS=true` (epic #1700 decision 5)
+ *   - `sharedState.lockedModule` is set (learner picked a specific module
+ *     via the Module Picker)
+ *   - An `AuthoredModule` in `Playbook.config.modules[]` matches the
+ *     locked module by `id` (and falls back to `slug` if id is absent)
+ *   - That module's `settings.questionTarget` has both `min` and `target`
+ *     as positive integers with `min <= target`
+ *
+ * Returns `null` otherwise — the instructions section renders without
+ * the question-count directive and the existing teaching cadence owns
+ * pacing.
+ *
+ * Returned shape: `{ min, target, directive }` so renderers can either
+ * use the structured fields or the pre-formatted directive sentence.
+ */
+function resolveModuleQuestionTarget(
+  config: PlaybookConfig,
+  sharedState: AssembledContext["sharedState"],
+): { min: number; target: number; directive: string } | null {
+  if (!isIeltsModuleSettingsEnabled()) return null;
+  const lockedModule = sharedState.lockedModule;
+  if (!lockedModule) return null;
+
+  const authoredModules: AuthoredModule[] = config.modules ?? [];
+  const matched = authoredModules.find(
+    (m) => m.id === lockedModule.id || m.id === lockedModule.slug,
+  );
+  if (!matched) return null;
+
+  const qt = matched.settings?.questionTarget;
+  if (!qt) return null;
+  const { min, target } = qt;
+  if (
+    typeof min !== "number" ||
+    typeof target !== "number" ||
+    !Number.isFinite(min) ||
+    !Number.isFinite(target) ||
+    min < 1 ||
+    target < min
+  ) {
+    return null;
+  }
+  return {
+    min,
+    target,
+    directive: `Aim for ${min} to ${target} questions in this module — track silently as you go.`,
+  };
+}

--- a/apps/admin/tests/lib/composition/instructions-module-question-target.test.ts
+++ b/apps/admin/tests/lib/composition/instructions-module-question-target.test.ts
@@ -1,0 +1,240 @@
+/**
+ * #1732 (epic #1730 G8 consumer A) — `computeInstructions` transform
+ * surfaces `module_question_target` directive when:
+ *
+ *   1. `HF_FLAG_IELTS_MODULE_SETTINGS=true` (epic #1700 decision 5)
+ *   2. `sharedState.lockedModule` set (learner picked via Module Picker)
+ *   3. `Playbook.config.modules[]` has a matching AuthoredModule by id
+ *      (falls back to slug)
+ *   4. `settings.questionTarget = {min, target}` is a valid pair
+ *      (positive integers, `min <= target`)
+ *
+ * Otherwise the key is `null`.
+ *
+ * Pins:
+ *   - flag-off → null (no-op default)
+ *   - flag-on + matching settings → {min, target, directive}
+ *   - directive is interpolated with operator's min/target — no literal
+ *     greeting / fixed template strings (ESLint `no-hardcoded-greeting-
+ *     in-composition` clean)
+ *   - degraded inputs (min>target, negative, NaN, missing) → null
+ *   - no matching authored module → null
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "@/lib/prompt/composition/transforms/instructions";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type {
+  AssembledContext,
+  SharedComputedState,
+  CompositionSectionDef,
+} from "@/lib/prompt/composition/types";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
+  return {
+    channel: "text",
+    modules: [],
+    isFirstCall: false,
+    daysSinceLastCall: 0,
+    completedModules: new Set<string>(),
+    estimatedProgress: 0,
+    lastCompletedIndex: -1,
+    moduleToReview: null,
+    nextModule: null,
+    reviewType: "quick_recall",
+    reviewReason: "",
+    thresholds: { high: 0.65, low: 0.35 },
+    isFinalSession: false,
+    callNumber: 3,
+    ...overrides,
+  };
+}
+
+function makeContext(
+  closingArgs: {
+    questionTarget?: { min: number; target: number } | undefined;
+    lockedId?: string;
+    matchById?: boolean;
+    noLockedModule?: boolean;
+  } = {},
+): AssembledContext {
+  const lockedId = closingArgs.lockedId ?? "part1";
+  const matchById = closingArgs.matchById ?? true;
+  const authoredModule: AuthoredModule = {
+    id: matchById ? lockedId : "other-id",
+    label: "Part 1: Familiar Topics",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "10 min",
+    scoringFired: "All four",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: [],
+    settings:
+      closingArgs.questionTarget !== undefined
+        ? { questionTarget: closingArgs.questionTarget }
+        : {},
+  };
+  const playbookConfig: PlaybookConfig = { modules: [authoredModule] };
+  return {
+    sharedState: makeSharedState({
+      lockedModule: closingArgs.noLockedModule
+        ? null
+        : ({
+            id: lockedId,
+            slug: lockedId,
+            name: "Part 1",
+          } as unknown as SharedComputedState["lockedModule"]),
+    }),
+    sections: {},
+    loadedData: {
+      caller: null,
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      nextLearnerFacingNumber: 1,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [
+        {
+          id: "p1",
+          name: "IELTS",
+          status: "PUBLISHED",
+          config: playbookConfig,
+          domain: null,
+          items: [],
+        },
+      ] as unknown as AssembledContext["loadedData"]["playbooks"],
+      systemSpecs: [],
+      onboardingSpec: null,
+    },
+    resolvedSpecs: {} as AssembledContext["resolvedSpecs"],
+    specConfig: {},
+  };
+}
+
+const STUB_SECTION: CompositionSectionDef = {
+  id: "instructions",
+  name: "Instructions",
+  priority: 9,
+  dataSource: "_assembled",
+  activateWhen: { condition: "always" },
+  fallback: { action: "null" },
+  transform: "computeInstructions",
+  outputKey: "instructions",
+};
+
+const transform = getTransform("computeInstructions")!;
+
+describe("computeInstructions — moduleQuestionTarget (#1732)", () => {
+  describe("HF_FLAG_IELTS_MODULE_SETTINGS gating", () => {
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("returns null when the flag is off (default)", async () => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+      const ctx = makeContext({ questionTarget: { min: 10, target: 13 } });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: unknown;
+      };
+      expect(result.module_question_target).toBeNull();
+    });
+
+    it("emits {min,target,directive} when flag on + matching settings", async () => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+      const ctx = makeContext({ questionTarget: { min: 10, target: 13 } });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: { min: number; target: number; directive: string } | null;
+      };
+      expect(result.module_question_target).toEqual({
+        min: 10,
+        target: 13,
+        directive: "Aim for 10 to 13 questions in this module — track silently as you go.",
+      });
+    });
+  });
+
+  describe("resolution semantics (flag on)", () => {
+    beforeEach(() => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    });
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("returns null when no lockedModule is set", async () => {
+      const ctx = makeContext({
+        questionTarget: { min: 10, target: 13 },
+        noLockedModule: true,
+      });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: unknown;
+      };
+      expect(result.module_question_target).toBeNull();
+    });
+
+    it("returns null when no matching authored module exists", async () => {
+      const ctx = makeContext({
+        questionTarget: { min: 10, target: 13 },
+        matchById: false,
+      });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: unknown;
+      };
+      expect(result.module_question_target).toBeNull();
+    });
+
+    it("returns null when questionTarget is missing", async () => {
+      const ctx = makeContext({});
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: unknown;
+      };
+      expect(result.module_question_target).toBeNull();
+    });
+
+    it("returns null when min > target (invalid)", async () => {
+      const ctx = makeContext({ questionTarget: { min: 15, target: 10 } });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: unknown;
+      };
+      expect(result.module_question_target).toBeNull();
+    });
+
+    it("returns null when min < 1", async () => {
+      const ctx = makeContext({ questionTarget: { min: 0, target: 5 } });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: unknown;
+      };
+      expect(result.module_question_target).toBeNull();
+    });
+
+    it("returns null when min/target are not finite numbers", async () => {
+      const ctx = makeContext({
+        questionTarget: { min: Number.NaN, target: 5 },
+      });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: unknown;
+      };
+      expect(result.module_question_target).toBeNull();
+    });
+
+    it("accepts min === target (a fixed-count target)", async () => {
+      const ctx = makeContext({ questionTarget: { min: 6, target: 6 } });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_question_target: { min: number; target: number; directive: string };
+      };
+      expect(result.module_question_target).toEqual({
+        min: 6,
+        target: 6,
+        directive: "Aim for 6 to 6 questions in this module — track silently as you go.",
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Closes #1732.** **Parent epic:** #1730 (G8 composer-transform consumers).

Extends \`computeInstructions\` with a new output key \`module_question_target\` that surfaces the operator-set min/target question-count directive when the learner has picked a specific module via the Module Picker.

**Closes the producer↔consumer gap on \`moduleQuestionTarget\`.** Until this PR, the G8 entry was producer-only — editor surface visible, but Preview rendered no observable change.

## What ships

| File | Change |
|---|---|
| \`lib/prompt/composition/transforms/instructions.ts\` | New \`resolveModuleQuestionTarget(config, sharedState)\` helper + \`module_question_target\` output key |
| \`tests/lib/composition/instructions-module-question-target.test.ts\` | 9 focused vitests covering resolution semantics |

### Output shape

\`\`\`typescript
module_question_target: {
  min: number;       // operator-set lower bound
  target: number;    // operator-set ideal count
  directive: string; // pre-formatted: "Aim for {min} to {target} questions in this module — track silently as you go."
} | null;
\`\`\`

### Resolution rules

Returns the structured object when ALL hold:

1. \`HF_FLAG_IELTS_MODULE_SETTINGS=true\` (epic #1700 decision 5)
2. \`sharedState.lockedModule\` is set
3. \`Playbook.config.modules[]\` has a matching \`AuthoredModule\` by \`id\` (falls back to \`slug\`)
4. \`settings.questionTarget = {min, target}\` is a valid pair — positive finite integers, \`min <= target\`

Otherwise returns null and the directive doesn't render.

## Lattice survey (per \`.claude/rules/lattice-survey.md\`)

Surveyed before edit per \`pipeline-and-prompt.md\` discipline. Found the existing transform shape (named output keys on \`computeInstructions\`), the existing G8 storage (\`AuthoredModule.settings.questionTarget\` from #1701 + type in #1741), and the existing session-module carrier (\`sharedState.lockedModule\`, same surface as #1734 closingLine consumer).

| Risk shape | Disposition |
|---|---|
| Sibling-writer drift | None — \`computeInstructions\` is the sole writer; new key is additive |
| Default-deny gates | \`HF_FLAG_IELTS_MODULE_SETTINGS\` respected; flag-off path pinned by vitest |
| Cascade respect | G8 settings declared \`cascadeSources: []\` per #1701 (course-only) |
| Convention conflict | Directive interpolated from operator data, no literal greeting. ESLint \`no-hardcoded-greeting-in-composition\` clean |

## Test plan

- [x] **9 vitests green** locally
- [x] Pre-push tsc + lint clean
- [ ] hf-dev smoke after merge: set \`HF_FLAG_IELTS_MODULE_SETTINGS=true\` + edit \`moduleQuestionTarget\` on Part 1 → refresh Preview → composed instructions section contains the directive

## Verified by

- 9/9 vitests green
- Search-before-edit per \`pipeline-and-prompt.md\`: surveyed transform shape + G8 storage + lockedModule carrier
- Same Lattice-discipline pattern as #1734 (PR #1770) — review template proven

## Deploy

\`/vm-cp\` (code-only — no migration).

## Remaining G8 consumers (epic #1730)

- ✅ #1734 \`moduleClosingLine\` → \`offboarding.ts\` (PR #1770)
- ✅ #1732 \`moduleQuestionTarget\` → \`instructions.ts\` (this PR)
- ⏸ #1733 \`moduleCueCardPool\` → \`instructions.ts\` + \`Session.metadata.pinnedCard\` write
- ⏸ #1735 \`moduleFirstTimeOrientationLine\` → \`onboarding.ts\` + \`orientationShown\` migration