### PR TITLE
feat(voice): T7 follow-on — endSession emits voice.talk_time.over_budget AppLog

### DIFF
--- a/apps/admin/lib/voice/end-session.ts
+++ b/apps/admin/lib/voice/end-session.ts
@@ -33,6 +33,11 @@ import {
 import { markModuleIncomplete } from "@/lib/curriculum/mark-module-incomplete";
 import { getCourseStyle } from "@/lib/pipeline/course-style";
 import { isIeltsModuleSettingsEnabled } from "@/lib/journey/module-settings-flag";
+import {
+  computeTalkTimeStats,
+  evaluateTalkTimeBudgets,
+} from "@/lib/voice/talk-time-stats";
+import { log as appLog } from "@/lib/logger";
 import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
 
 export type SessionOutcome = SessionOutcomeString;
@@ -154,6 +159,20 @@ export async function endSession(
     kind,
     outcome: args.outcome,
     durationSeconds,
+  });
+
+  // #1747 follow-on (epic #1700 Theme 7) — post-call talk-time
+  // telemetry. Computes tutor-speech budgets from the transcript and
+  // emits `voice.talk_time.over_budget` AppLog when exceeded. Best-
+  // effort write — helper failures don't roll back the durable Session
+  // state. Runs only for transcript-bearing sessions
+  // (VOICE_CALL / SIM_CALL).
+  evaluateTalkTimeBudgetsForSession({
+    callerId: updated.callerId,
+    sessionId: updated.id,
+    kind,
+    transcript: args.transcript ?? null,
+    playbookConfig: existing.playbook?.config as PlaybookConfig | null | undefined,
   });
 
   // Fire-and-forget pipeline trigger. Must NOT be awaited and must
@@ -307,6 +326,68 @@ async function evaluateIncompleteAttempt(args: {
   } catch (err) {
     console.error(
       `[endSession] markModuleIncomplete failed for caller ${args.callerId.slice(0, 8)} module ${args.curriculumModuleId.slice(0, 8)}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
+ * #1747 follow-on (epic #1700 Theme 7) — compute tutor talk-time stats
+ * for this session and emit `voice.talk_time.over_budget` AppLog when
+ * any budget is exceeded.
+ *
+ * Conditions to compute:
+ *
+ *   1. Session has a transcript (passed via `endSession({transcript})`)
+ *   2. `kind` ∈ {VOICE_CALL, SIM_CALL} — chat / enrolment / assessment
+ *      don't have a measurable tutor-speech budget
+ *
+ * Reads operator budgets from `Playbook.config.talkTimeBudgets`;
+ * `evaluateTalkTimeBudgets` falls back to `DEFAULT_TALK_TIME_BUDGETS`
+ * (`maxTutorTurnSec: 30`, `maxTutorRatio: 0.2`) when keys are unset.
+ *
+ * **Best-effort** — runs synchronously (compute is fast, AppLog write
+ * is fire-and-forget inside `log()`) but any throw is swallowed so
+ * Session durability is unaffected.
+ */
+function evaluateTalkTimeBudgetsForSession(args: {
+  callerId: string | null;
+  sessionId: string;
+  kind: SessionKindString;
+  transcript: string | null;
+  playbookConfig: PlaybookConfig | null | undefined;
+}): void {
+  if (args.kind !== "VOICE_CALL" && args.kind !== "SIM_CALL") return;
+  if (!args.transcript) return;
+
+  try {
+    const stats = computeTalkTimeStats(args.transcript);
+    const budgets = args.playbookConfig?.talkTimeBudgets ?? null;
+    const evaluation = evaluateTalkTimeBudgets(stats, budgets);
+
+    if (!evaluation.overBudget) return;
+
+    appLog("system", "voice.talk_time.over_budget", {
+      level: "warn",
+      message: `Tutor talk-time exceeded budget(s): ${evaluation.exceededBy.join(", ")}`,
+      sessionId: args.sessionId,
+      callerId: args.callerId ?? null,
+      kind: args.kind,
+      exceededBy: evaluation.exceededBy,
+      budgets: evaluation.budgets,
+      stats: {
+        tutorTurnCount: stats.tutorTurnCount,
+        learnerTurnCount: stats.learnerTurnCount,
+        tutorWordCount: stats.tutorWordCount,
+        learnerWordCount: stats.learnerWordCount,
+        maxTutorTurnWords: stats.maxTutorTurnWords,
+        maxTutorTurnSec: stats.maxTutorTurnSec,
+        tutorRatio: stats.tutorRatio,
+      },
+    });
+  } catch (err) {
+    console.error(
+      `[endSession] talk-time evaluation failed for session ${args.sessionId.slice(0, 8)}:`,
       err instanceof Error ? err.message : String(err),
     );
   }

--- a/apps/admin/tests/lib/voice/end-session-talk-time.test.ts
+++ b/apps/admin/tests/lib/voice/end-session-talk-time.test.ts
@@ -1,0 +1,212 @@
+/**
+ * T7 follow-on (epic #1700 Theme 7 / #1747) — endSession emits
+ * `voice.talk_time.over_budget` AppLog when the tutor-talk-time
+ * budgets are exceeded.
+ *
+ * Pins:
+ *   - VOICE_CALL with tutor-heavy transcript → log fires
+ *   - SIM_CALL with tutor-heavy transcript → log fires
+ *   - TEXT_CHAT / ENROLLMENT / ASSESSMENT → log NOT fired
+ *   - No transcript → log NOT fired
+ *   - Within budget → log NOT fired
+ *   - Operator-set budgets override defaults
+ *   - Compute failure swallowed (best-effort)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockPrisma = {
+  session: { findUnique: vi.fn(), update: vi.fn() },
+  call: { findFirst: vi.fn() },
+  callerModuleProgress: { findUnique: vi.fn(), update: vi.fn() },
+};
+
+const mockLog = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/config", () => ({
+  config: {
+    app: { url: "http://localhost:3000" },
+    security: { internalApiSecret: "test-secret" },
+  },
+}));
+vi.mock("@/lib/logger", () => ({
+  log: (...args: unknown[]) => mockLog(...args),
+}));
+
+function makeSessionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "session-1",
+    kind: "VOICE_CALL",
+    startedAt: new Date(Date.now() - 60_000),
+    endedAt: null,
+    status: "STARTED",
+    countsTowardLearnerNumber: true,
+    countsTowardPipelineNumber: true,
+    skipStages: [],
+    callerId: "caller-1",
+    playbookId: null,
+    curriculumModuleId: null,
+    curriculumModule: null,
+    playbook: null,
+    ...overrides,
+  };
+}
+
+const TUTOR_HEAVY_TRANSCRIPT = `
+Assistant: ${Array(120).fill("word").join(" ")}
+User: ok
+`.trim();
+
+// Within both default budgets — short tutor turns + learner dominates word
+// count → maxTutorTurnSec ≪ 30s AND tutorRatio ≪ 0.2.
+const SHORT_TRANSCRIPT = `
+Assistant: Hi.
+User: ${Array(60).fill("word").join(" ")}
+Assistant: Go on.
+User: ${Array(60).fill("word").join(" ")}
+`.trim();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLog.mockClear();
+  mockPrisma.session.update.mockImplementation(
+    ({ data, where }: { data: Record<string, unknown>; where: { id: string } }) =>
+      Promise.resolve({
+        id: where.id,
+        status: data.status ?? "COMPLETED",
+        endedAt: data.endedAt ?? new Date(),
+        skipStages: data.skipStages ?? [],
+        countsTowardLearnerNumber: data.countsTowardLearnerNumber ?? true,
+        countsTowardPipelineNumber: data.countsTowardPipelineNumber ?? true,
+        callerId: "caller-1",
+      }),
+  );
+  mockPrisma.call.findFirst.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("endSession — talk-time AppLog emission (#1747 follow-on)", () => {
+  it("fires voice.talk_time.over_budget on VOICE_CALL with tutor-heavy transcript", async () => {
+    mockPrisma.session.findUnique.mockResolvedValueOnce(makeSessionRow({ kind: "VOICE_CALL" }));
+    const { endSession } = await import("@/lib/voice/end-session");
+    await endSession("session-1", {
+      outcome: "COMPLETED",
+      transcript: TUTOR_HEAVY_TRANSCRIPT,
+      triggerPipelineAsync: false,
+    });
+    const overBudgetCall = mockLog.mock.calls.find(
+      (c) => c[1] === "voice.talk_time.over_budget",
+    );
+    expect(overBudgetCall, "expected over_budget AppLog").toBeDefined();
+    const payload = overBudgetCall![2] as Record<string, unknown>;
+    expect(payload.level).toBe("warn");
+    expect(payload.sessionId).toBe("session-1");
+    expect(payload.callerId).toBe("caller-1");
+    expect(payload.kind).toBe("VOICE_CALL");
+    expect(Array.isArray(payload.exceededBy)).toBe(true);
+    expect((payload.exceededBy as string[]).length).toBeGreaterThan(0);
+  });
+
+  it("fires for SIM_CALL with tutor-heavy transcript", async () => {
+    mockPrisma.session.findUnique.mockResolvedValueOnce(makeSessionRow({ kind: "SIM_CALL" }));
+    const { endSession } = await import("@/lib/voice/end-session");
+    await endSession("session-1", {
+      outcome: "COMPLETED",
+      transcript: TUTOR_HEAVY_TRANSCRIPT,
+      triggerPipelineAsync: false,
+    });
+    const overBudgetCall = mockLog.mock.calls.find(
+      (c) => c[1] === "voice.talk_time.over_budget",
+    );
+    expect(overBudgetCall).toBeDefined();
+  });
+
+  it("does NOT fire for TEXT_CHAT", async () => {
+    mockPrisma.session.findUnique.mockResolvedValueOnce(makeSessionRow({ kind: "TEXT_CHAT" }));
+    const { endSession } = await import("@/lib/voice/end-session");
+    await endSession("session-1", {
+      outcome: "COMPLETED",
+      transcript: TUTOR_HEAVY_TRANSCRIPT,
+      triggerPipelineAsync: false,
+    });
+    const overBudgetCall = mockLog.mock.calls.find(
+      (c) => c[1] === "voice.talk_time.over_budget",
+    );
+    expect(overBudgetCall).toBeUndefined();
+  });
+
+  it("does NOT fire when no transcript provided", async () => {
+    mockPrisma.session.findUnique.mockResolvedValueOnce(makeSessionRow({ kind: "VOICE_CALL" }));
+    const { endSession } = await import("@/lib/voice/end-session");
+    await endSession("session-1", {
+      outcome: "COMPLETED",
+      triggerPipelineAsync: false,
+    });
+    const overBudgetCall = mockLog.mock.calls.find(
+      (c) => c[1] === "voice.talk_time.over_budget",
+    );
+    expect(overBudgetCall).toBeUndefined();
+  });
+
+  it("does NOT fire when transcript is within budget", async () => {
+    mockPrisma.session.findUnique.mockResolvedValueOnce(makeSessionRow({ kind: "VOICE_CALL" }));
+    const { endSession } = await import("@/lib/voice/end-session");
+    await endSession("session-1", {
+      outcome: "COMPLETED",
+      transcript: SHORT_TRANSCRIPT,
+      triggerPipelineAsync: false,
+    });
+    const overBudgetCall = mockLog.mock.calls.find(
+      (c) => c[1] === "voice.talk_time.over_budget",
+    );
+    expect(overBudgetCall).toBeUndefined();
+  });
+
+  it("respects operator-set Playbook.config.talkTimeBudgets", async () => {
+    // Generous budgets — even the tutor-heavy transcript stays within.
+    mockPrisma.session.findUnique.mockResolvedValueOnce(
+      makeSessionRow({
+        kind: "VOICE_CALL",
+        playbook: {
+          config: {
+            talkTimeBudgets: { maxTutorTurnSec: 10000, maxTutorRatio: 0.9999 },
+          },
+        },
+      }),
+    );
+    const { endSession } = await import("@/lib/voice/end-session");
+    await endSession("session-1", {
+      outcome: "COMPLETED",
+      transcript: TUTOR_HEAVY_TRANSCRIPT,
+      triggerPipelineAsync: false,
+    });
+    const overBudgetCall = mockLog.mock.calls.find(
+      (c) => c[1] === "voice.talk_time.over_budget",
+    );
+    expect(overBudgetCall, "generous budgets should not trip").toBeUndefined();
+  });
+
+  it("payload includes stats + budgets for forensic context", async () => {
+    mockPrisma.session.findUnique.mockResolvedValueOnce(makeSessionRow({ kind: "VOICE_CALL" }));
+    const { endSession } = await import("@/lib/voice/end-session");
+    await endSession("session-1", {
+      outcome: "COMPLETED",
+      transcript: TUTOR_HEAVY_TRANSCRIPT,
+      triggerPipelineAsync: false,
+    });
+    const overBudgetCall = mockLog.mock.calls.find(
+      (c) => c[1] === "voice.talk_time.over_budget",
+    );
+    const payload = overBudgetCall![2] as Record<string, unknown>;
+    expect(payload.stats).toBeDefined();
+    expect(payload.budgets).toBeDefined();
+    const stats = payload.stats as Record<string, unknown>;
+    expect(typeof stats.tutorTurnCount).toBe("number");
+    expect(typeof stats.maxTutorTurnSec).toBe("number");
+    expect(typeof stats.tutorRatio).toBe("number");
+  });
+});


### PR DESCRIPTION
**Closes the AppLog emission gap on #1747.** Helpers shipped in #1766; this PR wires the emitter into \`endSession\`'s post-update side-effect chain.

Same shape as #1741's \`evaluateIncompleteAttempt\` block — one cohesive best-effort post-Session-commit side-effect chain.

## What ships

| File | Change |
|---|---|
| \`lib/voice/end-session.ts\` | New \`evaluateTalkTimeBudgetsForSession\` helper |
| \`tests/lib/voice/end-session-talk-time.test.ts\` (new) | 7 vitests |

### Fire conditions

- \`kind ∈ {VOICE_CALL, SIM_CALL}\` (chat/enrolment/assessment have no meaningful tutor-speech budget)
- \`args.transcript\` is non-null
- \`evaluateTalkTimeBudgets()\` returns \`overBudget: true\` against operator budgets (falls back to \`DEFAULT_TALK_TIME_BUDGETS\` if \`Playbook.config.talkTimeBudgets\` is unset)

### AppLog payload

\`\`\`
subject:   voice.talk_time.over_budget
level:     warn
message:   "Tutor talk-time exceeded budget(s): maxTutorTurnSec, maxTutorRatio"
sessionId, callerId, kind
exceededBy: ["maxTutorTurnSec", "maxTutorRatio"]
budgets:    { maxTutorTurnSec: 30, maxTutorRatio: 0.2 }
stats:      { tutorTurnCount, learnerTurnCount, tutorWordCount,
              learnerWordCount, maxTutorTurnWords, maxTutorTurnSec, tutorRatio }
\`\`\`

## Lattice survey

- **Sibling-writer survey** — \`endSession\`'s post-update chain already contains \`evaluateIncompleteAttempt\` (#1741) + the pipeline trigger. New helper sits in the same block, additive.
- **Convention** — \`voice.talk_time.over_budget\` matches \`voice.*\` AppLog namespace precedent (\`voice.vapi.background_sound_invalid\` at \`lib/voice/providers/vapi/index.ts:285\`, \`voice.llm_proxy.*\` in \`verify-vapi-secret.ts\`).
- **Risk shapes** — none triggered: pure read-then-emit, no DB writes from this helper. Helper catch swallows errors — Session durability unaffected.

## Test plan

- [x] 17 vitests green (7 new + 10 existing endSession unaffected)
- [x] Pre-push tsc + lint clean
- [ ] hf-dev smoke: trigger a tutor-heavy SIM run on IELTS Mock → \`/x/logs?filter=voice.talk_time\` shows the row

## Verified by

- 17/17 vitests green
- \`voice.*\` AppLog namespace verified against \`lib/voice/providers/vapi/index.ts:285\`
- Same post-update side-effect chain pattern as #1741's \`evaluateIncompleteAttempt\` (review template proven)

## Deploy

\`/vm-cp\` (code-only).

## Out of scope (follow-on)

- **AttainmentTab yellow chip** for over-budget calls. ~0.3d. File when AttainmentTab next gets a telemetry pass.