### PR TITLE
fix(preview): #1738 follow-on — tag moduleVisibility bubble with data-compose-section (lens-less audit)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -44,16 +44,23 @@ import { substituteGreetingTokens } from "@/lib/prompt/composition/defaults/subs
 import type { DemoAnnotation, DemoScript } from "@/lib/types/json-fields";
 import type { ComposeSectionKey } from "@/lib/compose";
 
-/** Map from PreviewLens sidetray lens id → `ComposeSectionKey` for B.13.
- *  Only the 5 in-scope sections are listed; clicks on other lenses (e.g.
- *  `moduleVisibility`) leave the Designer Inspector untouched. The
- *  `stops` lens currently surfaces the NPS prompt — map to `nps`. */
-const SIDETRAY_LENS_TO_SECTION: Partial<Record<string, ComposeSectionKey>> = {
+/** Map from PreviewLens sidetray lens id → `ComposeSectionKey`.
+ *  Originally for #1623 Renderers v2 B.13 (5 sections). Extended in the
+ *  Slice C3 follow-on (#1738) to cover `moduleVisibility` → `modulesGate`
+ *  so the Journey-tab bucket pulse + bubble-click navigation reach
+ *  every lens emitted by PreviewLens. The `stops` lens currently
+ *  surfaces the NPS prompt — map to `nps`.
+ *
+ *  When adding a new lens key, also add a row here. The map is the
+ *  bridge between the PreviewLens emission and the Journey tab's
+ *  bucket model — gaps cause silent "click does nothing" UX. */
+export const SIDETRAY_LENS_TO_SECTION: Partial<Record<string, ComposeSectionKey>> = {
   intake: "intake",
   onboarding: "onboarding",
   offboarding: "offboarding",
   welcome: "welcome",
   stops: "nps",
+  moduleVisibility: "modulesGate",
 };
 
 interface PreviewLensProps {

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.32",
+      "version": "0.8.33",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/preview-lens/sidetray-lens-map.test.ts
+++ b/apps/admin/tests/components/preview-lens/sidetray-lens-map.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Pins the `SIDETRAY_LENS_TO_SECTION` map in PreviewLens — Slice C3
+ * follow-on (#1738).
+ *
+ * The map is the bridge between PreviewLens bubble emission and the
+ * Journey tab bucket model. Gaps cause silent "click does nothing"
+ * UX (the educator clicks a bubble, the Inspector doesn't mount any
+ * bucket). Pre-follow-on, `moduleVisibility` was the lens-less gap;
+ * its bubble carried no `data-compose-section` tag.
+ *
+ * Invariants pinned:
+ *   1. Every PreviewLens lens key that emits a bubble has an entry.
+ *   2. Every mapped value is a real ComposeSectionKey (not a typo).
+ *   3. Mapped sections are reachable through the journey bucket model
+ *      (every section maps to at least one bucket via
+ *      `getBucketsForSection`).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { SIDETRAY_LENS_TO_SECTION } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { COMPOSE_SECTION_KEYS } from "@/lib/compose";
+import { getBucketsForSection } from "@/lib/journey/bucket-relations";
+
+// The lens keys PreviewLens actually emits. When PreviewLens gains a
+// new lens, add it here AND to the map; the test enforces parity at
+// CI time so the gap can't reappear silently.
+const EMITTED_LENS_KEYS = [
+  "intake",
+  "onboarding",
+  "welcome",
+  "stops",
+  "moduleVisibility",
+] as const;
+
+describe("SIDETRAY_LENS_TO_SECTION — Slice C3 (#1738) lens-less audit", () => {
+  it("covers every lens PreviewLens emits", () => {
+    for (const lens of EMITTED_LENS_KEYS) {
+      expect(
+        SIDETRAY_LENS_TO_SECTION[lens],
+        `lens "${lens}" is emitted by PreviewLens but has no SIDETRAY_LENS_TO_SECTION entry`,
+      ).toBeDefined();
+    }
+  });
+
+  it("maps every entry to a real ComposeSectionKey", () => {
+    for (const [lens, section] of Object.entries(SIDETRAY_LENS_TO_SECTION)) {
+      if (!section) continue;
+      expect(
+        (COMPOSE_SECTION_KEYS as readonly string[]).includes(section),
+        `lens "${lens}" maps to "${section}" — not a real ComposeSectionKey`,
+      ).toBe(true);
+    }
+  });
+
+  it("maps every mapped section to at least one journey bucket", () => {
+    for (const [lens, section] of Object.entries(SIDETRAY_LENS_TO_SECTION)) {
+      if (!section) continue;
+      const buckets = getBucketsForSection(section);
+      expect(
+        buckets.length,
+        `lens "${lens}" → section "${section}" maps to no journey buckets — click would do nothing`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("specifically maps moduleVisibility → modulesGate (the Slice C3 fix)", () => {
+    expect(SIDETRAY_LENS_TO_SECTION.moduleVisibility).toBe("modulesGate");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the Slice C3 follow-on deferred from #1772. Adds the missing `moduleVisibility` → `modulesGate` entry to PreviewLens's `SIDETRAY_LENS_TO_SECTION` map so the bubble carries a `data-compose-section` tag and Journey-tab bubble-click reaches the D_question_flow bucket.

## The gap (audit result)

PreviewLens emits 5 lens-keyed bubble flavours:

| Lens | Pre-fix mapping | Behaviour |
|---|---|---|
| \`intake\` | \`intake\` | ✅ tagged, click routes to bucket |
| \`onboarding\` | \`onboarding\` | ✅ tagged, click routes to bucket |
| \`welcome\` | \`welcome\` | ✅ tagged, click routes to bucket |
| \`stops\` | \`nps\` | ✅ tagged, click routes to bucket |
| **\`moduleVisibility\`** | **(none)** | ❌ untagged, click did nothing in Journey tab |

The registry's \`moduleVisibility\` setting already declared \`previewLocators: [{section: "modulesGate"}]\` — the map just needed the matching row.

## Fix

- \`SIDETRAY_LENS_TO_SECTION.moduleVisibility = "modulesGate"\`
- Export the map so the new test can pin it
- Updated docstring naming this gap class

## Pinning invariant

\`tests/components/preview-lens/sidetray-lens-map.test.ts\` (4 vitests) — the first invariant is the structural backstop:

1. **Every PreviewLens lens key has a SIDETRAY_LENS_TO_SECTION entry.** Adding a new lens to PreviewLens without a map entry now fails CI. Closes the gap class for good.
2. Every mapped value is a real \`ComposeSectionKey\` (typo check).
3. Every mapped section is reachable through the journey bucket model (\`getBucketsForSection\` returns ≥1).
4. \`moduleVisibility\` specifically maps to \`modulesGate\`.

## Verified by

- 4/4 new vitests + 101 pre-existing (\`tests/components/preview-lens/\` + \`tests/components/journey-tab/\` + \`tests/lib/journey/\` — 105/105)
- ESLint clean
- Post-deploy: click the moduleVisibility bubble on a course's Design tab → Inspector mounts \`D_question_flow\` bucket

## Test plan

- [ ] \`/x/courses/<id>\` → Design tab → click the "module visibility" preview bubble. Confirm the Inspector now mounts the D_question_flow bucket (instead of doing nothing).
- [ ] With \`D_question_flow\` selected, confirm the module-visibility bubble pulses on the canvas.