### PR TITLE
feat(compose): #1733 — G8 consumer B, moduleCueCardPool directive in instructions

### DIFF
--- a/apps/admin/lib/prompt/composition/transforms/instructions.ts
+++ b/apps/admin/lib/prompt/composition/transforms/instructions.ts
@@ -323,6 +323,18 @@ registerTransform("computeInstructions", (
       (loadedData.playbooks?.[0]?.config ?? {}) as PlaybookConfig,
       sharedState,
     ),
+
+    // #1733 (epic #1730 G8 consumer B) — module-scoped cue card. Picks
+    // one card from `Playbook.config.modules[].settings.cueCardPool`
+    // deterministically by `sharedState.callNumber` so the same call
+    // always sees the same card (idempotent reads). Gated by
+    // `HF_FLAG_IELTS_MODULE_SETTINGS` per epic #1700 decision 5.
+    // Theme 3 (`<PinnedCardSlot>`) will cache the pick to
+    // `Session.metadata.pinnedCard` later for cross-process consistency.
+    module_cue_card: resolveModuleCueCard(
+      (loadedData.playbooks?.[0]?.config ?? {}) as PlaybookConfig,
+      sharedState,
+    ),
   };
 });
 
@@ -376,5 +388,73 @@ function resolveModuleQuestionTarget(
     min,
     target,
     directive: `Aim for ${min} to ${target} questions in this module — track silently as you go.`,
+  };
+}
+
+/**
+ * #1733 (epic #1730 G8 consumer B) — module-scoped cue card pick.
+ *
+ * Reads `Playbook.config.modules[].settings.cueCardPool` for the locked
+ * module and picks ONE card deterministically by
+ * `sharedState.callNumber % pool.length`. Same call sees the same card
+ * across re-renders — idempotent for prompt-side reads.
+ *
+ * Returns `{ kind, topic, bullets, secondaryNote?, directive }` when:
+ *   - `HF_FLAG_IELTS_MODULE_SETTINGS=true` (epic #1700 decision 5)
+ *   - `sharedState.lockedModule` is set
+ *   - A matching `AuthoredModule` in `Playbook.config.modules[]` carries
+ *     a non-empty `settings.cueCardPool`
+ *   - The picked card has both a `topic` string and a non-empty
+ *     `bullets` array
+ *
+ * Returns `null` otherwise — no cue-card directive renders.
+ *
+ * Selection policy is deliberately deterministic (callNumber-modulo)
+ * rather than random so Preview-lens previews + actual call composition
+ * agree byte-for-byte. Theme 3 (`<PinnedCardSlot>`) will cache the
+ * pick to `Session.metadata.pinnedCard` so the UI shows the same card
+ * the prompt was composed with.
+ */
+function resolveModuleCueCard(
+  config: PlaybookConfig,
+  sharedState: AssembledContext["sharedState"],
+): {
+  kind: "cueCard";
+  topic: string;
+  bullets: string[];
+  secondaryNote?: string;
+  directive: string;
+} | null {
+  if (!isIeltsModuleSettingsEnabled()) return null;
+  const lockedModule = sharedState.lockedModule;
+  if (!lockedModule) return null;
+
+  const authoredModules: AuthoredModule[] = config.modules ?? [];
+  const matched = authoredModules.find(
+    (m) => m.id === lockedModule.id || m.id === lockedModule.slug,
+  );
+  if (!matched) return null;
+
+  const pool = matched.settings?.cueCardPool;
+  if (!Array.isArray(pool) || pool.length === 0) return null;
+
+  // Deterministic pick — callNumber starts at 1 for first call.
+  const callIndex = Math.max(0, (sharedState.callNumber ?? 1) - 1);
+  const picked = pool[callIndex % pool.length];
+  if (!picked || typeof picked.topic !== "string" || picked.topic.trim().length === 0) {
+    return null;
+  }
+  const bullets = Array.isArray(picked.bullets)
+    ? picked.bullets.filter((b) => typeof b === "string" && b.trim().length > 0)
+    : [];
+  if (bullets.length === 0) return null;
+
+  const bulletsList = bullets.map((b) => `  - ${b}`).join("\n");
+  const directive = `CUE CARD for this module — keep this topic central:\nTopic: ${picked.topic}\nBullets:\n${bulletsList}`;
+  return {
+    kind: "cueCard",
+    topic: picked.topic,
+    bullets,
+    directive,
   };
 }

--- a/apps/admin/tests/lib/composition/instructions-module-cue-card.test.ts
+++ b/apps/admin/tests/lib/composition/instructions-module-cue-card.test.ts
@@ -1,0 +1,252 @@
+/**
+ * #1733 (epic #1730 G8 consumer B) — `computeInstructions` surfaces
+ * `module_cue_card` directive when:
+ *
+ *   1. `HF_FLAG_IELTS_MODULE_SETTINGS=true` (epic #1700 decision 5)
+ *   2. `sharedState.lockedModule` set
+ *   3. `Playbook.config.modules[]` has a matching `AuthoredModule` with
+ *      a non-empty `settings.cueCardPool`
+ *   4. The picked card has both a `topic` (non-empty string) and a
+ *      non-empty `bullets[]`
+ *
+ * Pins:
+ *   - flag-off → null
+ *   - flag-on + valid pool + lockedModule → directive
+ *   - deterministic pick by `callNumber % pool.length` (same call sees
+ *     same card)
+ *   - null on empty / missing pool / missing topic / empty bullets
+ *   - no matching authored module → null
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "@/lib/prompt/composition/transforms/instructions";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type {
+  AssembledContext,
+  SharedComputedState,
+  CompositionSectionDef,
+} from "@/lib/prompt/composition/types";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
+  return {
+    channel: "text",
+    modules: [],
+    isFirstCall: false,
+    daysSinceLastCall: 0,
+    completedModules: new Set<string>(),
+    estimatedProgress: 0,
+    lastCompletedIndex: -1,
+    moduleToReview: null,
+    nextModule: null,
+    reviewType: "quick_recall",
+    reviewReason: "",
+    thresholds: { high: 0.65, low: 0.35 },
+    isFinalSession: false,
+    callNumber: 1,
+    ...overrides,
+  };
+}
+
+function makeContext(opts: {
+  cueCardPool?: Array<{ topic: string; bullets: string[] }>;
+  callNumber?: number;
+  lockedId?: string;
+  matchById?: boolean;
+  noLockedModule?: boolean;
+} = {}): AssembledContext {
+  const lockedId = opts.lockedId ?? "part2";
+  const matchById = opts.matchById ?? true;
+  const authoredModule: AuthoredModule = {
+    id: matchById ? lockedId : "other-id",
+    label: "Part 2: Cue Card",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "4 min",
+    scoringFired: "All four",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: [],
+    settings: opts.cueCardPool !== undefined ? { cueCardPool: opts.cueCardPool } : {},
+  };
+  const playbookConfig: PlaybookConfig = { modules: [authoredModule] };
+  return {
+    sharedState: makeSharedState({
+      callNumber: opts.callNumber ?? 1,
+      lockedModule: opts.noLockedModule
+        ? null
+        : ({
+            id: lockedId,
+            slug: lockedId,
+            name: "Part 2",
+          } as unknown as SharedComputedState["lockedModule"]),
+    }),
+    sections: {},
+    loadedData: {
+      caller: null,
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      nextLearnerFacingNumber: 1,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [
+        {
+          id: "p1",
+          name: "IELTS",
+          status: "PUBLISHED",
+          config: playbookConfig,
+          domain: null,
+          items: [],
+        },
+      ] as unknown as AssembledContext["loadedData"]["playbooks"],
+      systemSpecs: [],
+      onboardingSpec: null,
+    },
+    resolvedSpecs: {} as AssembledContext["resolvedSpecs"],
+    specConfig: {},
+  };
+}
+
+const STUB_SECTION: CompositionSectionDef = {
+  id: "instructions",
+  name: "Instructions",
+  priority: 9,
+  dataSource: "_assembled",
+  activateWhen: { condition: "always" },
+  fallback: { action: "null" },
+  transform: "computeInstructions",
+  outputKey: "instructions",
+};
+
+const transform = getTransform("computeInstructions")!;
+
+const POOL_FIXTURE = [
+  { topic: "Describe a meal you enjoyed.", bullets: ["When", "Where", "Why memorable"] },
+  { topic: "Describe a time you were nervous.", bullets: ["Situation", "Reason", "Outcome"] },
+  { topic: "Describe a useful skill.", bullets: ["Skill", "How learned", "Why useful"] },
+];
+
+describe("computeInstructions — module_cue_card (#1733)", () => {
+  describe("HF_FLAG_IELTS_MODULE_SETTINGS gating", () => {
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("returns null when the flag is off (default)", async () => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+      const ctx = makeContext({ cueCardPool: POOL_FIXTURE });
+      const result = (await transform(null, ctx, STUB_SECTION)) as { module_cue_card: unknown };
+      expect(result.module_cue_card).toBeNull();
+    });
+
+    it("emits picked card when flag on + valid pool", async () => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+      const ctx = makeContext({ cueCardPool: POOL_FIXTURE, callNumber: 1 });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_cue_card: { kind: string; topic: string; bullets: string[]; directive: string } | null;
+      };
+      expect(result.module_cue_card).not.toBeNull();
+      expect(result.module_cue_card!.kind).toBe("cueCard");
+      expect(result.module_cue_card!.topic).toBe(POOL_FIXTURE[0].topic);
+      expect(result.module_cue_card!.bullets).toEqual(POOL_FIXTURE[0].bullets);
+      expect(result.module_cue_card!.directive).toContain(POOL_FIXTURE[0].topic);
+    });
+  });
+
+  describe("deterministic round-robin by callNumber", () => {
+    beforeEach(() => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    });
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("call 1 picks index 0", async () => {
+      const ctx = makeContext({ cueCardPool: POOL_FIXTURE, callNumber: 1 });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_cue_card: { topic: string };
+      };
+      expect(result.module_cue_card.topic).toBe(POOL_FIXTURE[0].topic);
+    });
+
+    it("call 2 picks index 1", async () => {
+      const ctx = makeContext({ cueCardPool: POOL_FIXTURE, callNumber: 2 });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_cue_card: { topic: string };
+      };
+      expect(result.module_cue_card.topic).toBe(POOL_FIXTURE[1].topic);
+    });
+
+    it("call 4 wraps round to index 0 (4 % 3 = 1, callIndex 3 → 3 mod 3 = 0)", async () => {
+      const ctx = makeContext({ cueCardPool: POOL_FIXTURE, callNumber: 4 });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_cue_card: { topic: string };
+      };
+      // callNumber=4 → callIndex=3 → 3 mod 3 = 0
+      expect(result.module_cue_card.topic).toBe(POOL_FIXTURE[0].topic);
+    });
+
+    it("same call → same card across re-renders (idempotent)", async () => {
+      const ctx1 = makeContext({ cueCardPool: POOL_FIXTURE, callNumber: 7 });
+      const r1 = (await transform(null, ctx1, STUB_SECTION)) as { module_cue_card: { topic: string } };
+      const ctx2 = makeContext({ cueCardPool: POOL_FIXTURE, callNumber: 7 });
+      const r2 = (await transform(null, ctx2, STUB_SECTION)) as { module_cue_card: { topic: string } };
+      expect(r1.module_cue_card.topic).toBe(r2.module_cue_card.topic);
+    });
+  });
+
+  describe("resolution edge cases", () => {
+    beforeEach(() => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    });
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("returns null when no lockedModule", async () => {
+      const ctx = makeContext({ cueCardPool: POOL_FIXTURE, noLockedModule: true });
+      const result = (await transform(null, ctx, STUB_SECTION)) as { module_cue_card: unknown };
+      expect(result.module_cue_card).toBeNull();
+    });
+
+    it("returns null when no matching authored module", async () => {
+      const ctx = makeContext({ cueCardPool: POOL_FIXTURE, matchById: false });
+      const result = (await transform(null, ctx, STUB_SECTION)) as { module_cue_card: unknown };
+      expect(result.module_cue_card).toBeNull();
+    });
+
+    it("returns null when pool is empty", async () => {
+      const ctx = makeContext({ cueCardPool: [] });
+      const result = (await transform(null, ctx, STUB_SECTION)) as { module_cue_card: unknown };
+      expect(result.module_cue_card).toBeNull();
+    });
+
+    it("returns null when pool is missing", async () => {
+      const ctx = makeContext({});
+      const result = (await transform(null, ctx, STUB_SECTION)) as { module_cue_card: unknown };
+      expect(result.module_cue_card).toBeNull();
+    });
+
+    it("returns null when picked card has empty topic", async () => {
+      const ctx = makeContext({
+        cueCardPool: [{ topic: "   ", bullets: ["a", "b"] }],
+      });
+      const result = (await transform(null, ctx, STUB_SECTION)) as { module_cue_card: unknown };
+      expect(result.module_cue_card).toBeNull();
+    });
+
+    it("returns null when picked card has no usable bullets", async () => {
+      const ctx = makeContext({
+        cueCardPool: [{ topic: "topic", bullets: [""] }],
+      });
+      const result = (await transform(null, ctx, STUB_SECTION)) as { module_cue_card: unknown };
+      expect(result.module_cue_card).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
**Closes the prompt-side of #1733.** Parent epic #1730 (G8 composer-transform consumers).

Picks one cue card deterministically from \`Playbook.config.modules[].settings.cueCardPool\` and surfaces \`module_cue_card\` on the composer output. Same call → same card across re-renders.

### Scope decision

Story spec also called for a \`Session.metadata.pinnedCard\` write at session-start. **Deferred** — that requires modifying \`lib/voice/create-session.ts\` (chokepoint per #1342) + a new composer-side loader for Session.metadata. Theme 3 (#1744, \`<PinnedCardSlot>\` UI primitive) will cache the deterministic pick into \`Session.metadata.pinnedCard\` when the UI surface lands, keeping prompt-side and UI-side agreement in one cohesive change.

**Prompt-side ships in full today.** The model receives topic + bullets when the locked module has a cueCardPool and the flag is on.

### What ships

| File | Change |
|---|---|
| \`lib/prompt/composition/transforms/instructions.ts\` | New \`resolveModuleCueCard\` helper + \`module_cue_card\` output key (deterministic pick by \`callNumber % pool.length\`) |
| \`tests/lib/composition/instructions-module-cue-card.test.ts\` | 12 vitests |

### Selection policy

\`callIndex = max(0, sharedState.callNumber - 1)\`
\`picked = pool[callIndex % pool.length]\`

Idempotent — re-renders for the same call always pick the same card. Preview lens shows what the call will use.

### Lattice survey

Same pattern as #1770 (closingLine) + #1773 (questionTarget):

| Risk shape | Disposition |
|---|---|
| Sibling-writer drift | None — \`computeInstructions\` sole writer; additive key |
| Default-deny | \`HF_FLAG_IELTS_MODULE_SETTINGS\` respected; pinned by flag-off test |
| Cascade respect | G8 \`cascadeSources: []\` per #1701 (course-only) |
| Convention conflict | Topic + bullets interpolated from operator data; ESLint-clean |

### Test plan

- [x] 12 vitests green
- [x] 9 sibling \`questionTarget\` vitests still pass (additive)
- [x] Pre-push tsc + lint clean
- [ ] hf-dev smoke after merge: \`HF_FLAG_IELTS_MODULE_SETTINGS=true\` + populate \`moduleCueCardPool\` on Part 2 → refresh Preview → composed instructions section contains the cue card

### Verified by

- 21/21 vitests green
- Producer↔consumer pairing: prompt-side ships in full; UI-side tracked to Theme 3 (#1744)

### Deploy

\`/vm-cp\` (code-only).

### Remaining G8 consumers in epic #1730

- ✅ #1734 \`moduleClosingLine\` → offboarding
- ✅ #1732 \`moduleQuestionTarget\` → instructions
- ✅ #1733 \`moduleCueCardPool\` → instructions (this PR)
- ⏸ #1735 \`moduleFirstTimeOrientationLine\` → onboarding + \`orientationShown\` migration (needs \`/vm-cpp\`)