### PR TITLE
feat(journey): add N_voice bucket — 11 voice settings reachable from Cmd+K + LH

### DIFF
--- a/apps/admin/components/journey-tab/CommandPalette.tsx
+++ b/apps/admin/components/journey-tab/CommandPalette.tsx
@@ -9,10 +9,15 @@
  * `educatorLabel + group + storagePath`.
  *
  * Slice C3 surfaces the bucket count in the input placeholder so
- * educators learn the shape: "Search 56 settings across 13 buckets…".
+ * educators learn the shape: "Search 63 settings across 14 buckets…".
  * Both counts are derived from the canonical registries
  * (`JOURNEY_SETTINGS` + `VOICE_SETTINGS`; `JOURNEY_MENU_BUCKET_IDS`) —
  * never hardcoded.
+ *
+ * Voice-bucket follow-on (post-#1738): the 11 voice settings now also
+ * land in a bucket (`N_voice`) and `handlePaletteSelect` looks them up
+ * via `VOICE_SETTINGS_BY_ID` so Cmd+K → Enter on a voice result
+ * navigates to the Inspector instead of silently doing nothing.
  *
  * Selecting a result calls `setBucketId` from `useJourneySelection` via
  * `CourseJourneyTab.handlePaletteSelect`, which looks up the setting's

--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -23,6 +23,7 @@ import { JourneySettingMutatorProvider } from "@/components/shared/preview-rende
 import type { ComposeSectionKey } from "@/lib/compose";
 import { getBucketsForSection } from "@/lib/journey/bucket-relations";
 import { JOURNEY_SETTINGS_BY_ID } from "@/lib/journey/setting-contracts.entries";
+import { VOICE_SETTINGS_BY_ID } from "@/lib/settings/voice-setting-contracts";
 
 import { CommandPalette } from "./CommandPalette";
 import { JourneyInspectorPanel } from "./JourneyInspectorPanel";
@@ -63,9 +64,13 @@ export function CourseJourneyTab({
 
   // Cmd+K hit → setting id. Find its owning bucket + select. Clear the
   // pick-strip in the same step (palette nav is a fresh user intent).
+  // Voice settings (registered under N_voice via Slice C follow-on) are
+  // found in VOICE_SETTINGS_BY_ID — the same bucket select navigates to
+  // them within the Journey tab; their Settings-tab home is preserved.
   const handlePaletteSelect = useCallback(
     (settingId: string) => {
-      const owner = JOURNEY_SETTINGS_BY_ID[settingId];
+      const owner =
+        JOURNEY_SETTINGS_BY_ID[settingId] ?? VOICE_SETTINGS_BY_ID[settingId];
       if (owner?.menuGroupKey) {
         selection.setBucketId(owner.menuGroupKey);
         setPickStripSection(null);

--- a/apps/admin/lib/journey/bucket-relations.ts
+++ b/apps/admin/lib/journey/bucket-relations.ts
@@ -27,12 +27,24 @@ import type { ComposeSectionKey } from "@/lib/compose";
 
 import type { JourneyMenuBucketId, JourneySettingContract } from "./setting-contracts";
 import { JOURNEY_SETTINGS } from "./setting-contracts.entries";
+import { VOICE_SETTINGS } from "@/lib/settings/voice-setting-contracts";
 
-/** All settings in the named bucket. */
+/** Combined corpus the bucket model searches over. The voice 11 are
+ *  stamped with `menuGroupKey: "N_voice"` so they surface in the
+ *  Journey LH + Cmd+K under their own bucket while ALSO remaining
+ *  Settings-tab citizens. The two surfaces share the SAME registry
+ *  entries — there is no second copy. */
+const ALL_BUCKETED_SETTINGS: readonly JourneySettingContract[] = [
+  ...JOURNEY_SETTINGS,
+  ...VOICE_SETTINGS,
+];
+
+/** All settings in the named bucket. Spans journey + voice registries
+ *  via `menuGroupKey`. */
 export function getSettingsForBucket(
   bucketId: JourneyMenuBucketId,
 ): readonly JourneySettingContract[] {
-  return JOURNEY_SETTINGS.filter((s) => s.menuGroupKey === bucketId);
+  return ALL_BUCKETED_SETTINGS.filter((s) => s.menuGroupKey === bucketId);
 }
 
 /** Every ComposeSectionKey any setting in the bucket touches. Used by
@@ -57,7 +69,7 @@ export function getBucketsForSection(
   sectionKey: ComposeSectionKey,
 ): readonly JourneyMenuBucketId[] {
   const out = new Set<JourneyMenuBucketId>();
-  for (const s of JOURNEY_SETTINGS) {
+  for (const s of ALL_BUCKETED_SETTINGS) {
     if (!s.menuGroupKey) continue;
     if (s.previewLocators.some((l) => l.section === sectionKey)) {
       out.add(s.menuGroupKey);

--- a/apps/admin/lib/journey/menu-items.ts
+++ b/apps/admin/lib/journey/menu-items.ts
@@ -129,6 +129,13 @@ export const JOURNEY_MENU_ITEMS: readonly JourneyMenuBucket[] = [
     caption: "Wrap-up, results delivery, completion",
     parentGroup: "G6",
   },
+  {
+    id: "N_voice",
+    label: "Voice & how the tutor sounds",
+    caption:
+      "Provider, voice, speed, interruption tolerance — also editable in the Settings tab",
+    parentGroup: "G4",
+  },
 ];
 
 export const JOURNEY_MENU_ITEMS_BY_ID: Readonly<
@@ -138,7 +145,7 @@ export const JOURNEY_MENU_ITEMS_BY_ID: Readonly<
   JourneyMenuBucket
 >;
 
-/** The 13 IDs as an ordered tuple — useful for stable URL state +
+/** The 14 IDs as an ordered tuple — useful for stable URL state +
  *  registry-completeness assertions. */
 export const JOURNEY_MENU_BUCKET_IDS: readonly JourneyMenuBucketId[] =
   JOURNEY_MENU_ITEMS.map((b) => b.id);

--- a/apps/admin/lib/journey/setting-contracts.ts
+++ b/apps/admin/lib/journey/setting-contracts.ts
@@ -174,11 +174,18 @@ export interface AutoEnableLink {
 // Slice C (#1721) — menu buckets
 // =============================================================
 
-/** The 13 educator-intent buckets, chronological by session moment.
+/** The 14 educator-intent buckets, chronological by session moment.
  *  Authored against `docs/draft-issues/ielts-pre-voice-gap-analysis.md` —
  *  the IELTS spec organises by *what happens in a session* rather than
  *  by which DB column the value lives in. See `lib/journey/menu-items.ts`
- *  for the labels + captions + journey-group dividers. */
+ *  for the labels + captions + journey-group dividers.
+ *
+ *  `N_voice` is the cross-call exception — voice provider / id / speed
+ *  / interruption tolerance affect every call uniformly rather than a
+ *  specific session moment. It surfaces in the Journey LH (and Cmd+K)
+ *  alongside the chronological buckets so the educator has one
+ *  navigation index, not two. The 11 voice settings ALSO appear in the
+ *  Settings tab under S1_voice — same registry entries, two surfaces. */
 export type JourneyMenuBucketId =
   | "A_intake"
   | "B_call1_opening"
@@ -192,7 +199,8 @@ export type JourneyMenuBucketId =
   | "J_feedback"
   | "K_between_calls"
   | "L_mid_journey"
-  | "M_end_of_course";
+  | "M_end_of_course"
+  | "N_voice";
 
 // =============================================================
 // JourneySettingContract — the registry entry

--- a/apps/admin/lib/settings/voice-setting-contracts.ts
+++ b/apps/admin/lib/settings/voice-setting-contracts.ts
@@ -62,6 +62,7 @@ export type SettingsGroup = keyof typeof SETTINGS_GROUPS;
 
 const V_PROVIDER: JourneySettingContract = {
   id: "voiceProvider",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Voice provider",
   helpText: "VAPI / Deepgram / OpenAI / ElevenLabs / Azure / PlayHT.",
@@ -76,6 +77,7 @@ const V_PROVIDER: JourneySettingContract = {
 
 const V_ID: JourneySettingContract = {
   id: "voiceId",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Voice",
   helpText: "Provider-specific voice id; preview with the [▶] button.",
@@ -90,6 +92,7 @@ const V_ID: JourneySettingContract = {
 
 const V_BACKGROUND_SOUND: JourneySettingContract = {
   id: "backgroundSound",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Background sound",
   helpText: "off / office / custom URL.",
@@ -106,6 +109,7 @@ const V_BACKGROUND_SOUND: JourneySettingContract = {
  *  entries share the same storagePath. */
 const V_INTERRUPT_SENSITIVITY: JourneySettingContract = {
   id: "interruptSensitivity",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Interrupt sensitivity (voice copy)",
   helpText:
@@ -123,6 +127,7 @@ const V_INTERRUPT_SENSITIVITY: JourneySettingContract = {
 
 const V_SPEED: JourneySettingContract = {
   id: "voiceSpeed",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Voice speed",
   helpText: "Playback rate multiplier (1.0 default).",
@@ -137,6 +142,7 @@ const V_SPEED: JourneySettingContract = {
 
 const V_PITCH: JourneySettingContract = {
   id: "voicePitch",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Voice pitch",
   helpText: "Provider-supported pitch offset.",
@@ -151,6 +157,7 @@ const V_PITCH: JourneySettingContract = {
 
 const V_SILENCE_THRESHOLD: JourneySettingContract = {
   id: "silenceThreshold",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Silence threshold",
   helpText: "Seconds of silence before the AI re-prompts.",
@@ -165,6 +172,7 @@ const V_SILENCE_THRESHOLD: JourneySettingContract = {
 
 const V_END_CALL_AFTER_SILENCE: JourneySettingContract = {
   id: "endCallAfterSilence",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "End call after silence",
   helpText: "Hard hang-up after N seconds of silence.",
@@ -179,6 +187,7 @@ const V_END_CALL_AFTER_SILENCE: JourneySettingContract = {
 
 const V_MAX_CALL_DURATION: JourneySettingContract = {
   id: "maxCallDuration",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Max call duration",
   helpText: "Hard cap; VAPI hangs up at this point.",
@@ -194,6 +203,7 @@ const V_MAX_CALL_DURATION: JourneySettingContract = {
 
 const V_PHONE_NUMBER: JourneySettingContract = {
   id: "phoneNumber",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "Outbound phone number",
   helpText: "Caller-id phone number for outbound dialling.",
@@ -207,6 +217,7 @@ const V_PHONE_NUMBER: JourneySettingContract = {
 
 const V_VAPI_ASSISTANT_ID: JourneySettingContract = {
   id: "vapiAssistantId",
+  menuGroupKey: "N_voice",
   group: "S1_voice",
   educatorLabel: "VAPI assistant ID",
   helpText: "Provider-specific assistant id (advanced).",

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.33",
+      "version": "0.8.34",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/lib/journey/n-voice-bucket.test.ts
+++ b/apps/admin/tests/lib/journey/n-voice-bucket.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins the N_voice bucket — Slice C follow-on (post-#1738).
+ *
+ * The voice 11 settings live in `lib/settings/voice-setting-contracts.ts`
+ * (Settings tab citizens) but ALSO land in the Journey LH bucket
+ * `N_voice` so Cmd+K → Enter on a voice setting navigates to the
+ * Inspector instead of silently doing nothing.
+ *
+ * Invariants:
+ *  1. All 11 VOICE_SETTINGS carry `menuGroupKey: "N_voice"`.
+ *  2. `JOURNEY_MENU_ITEMS` contains the N_voice bucket.
+ *  3. `getSettingsForBucket("N_voice")` returns all 11 voice settings.
+ *  4. `JOURNEY_MENU_BUCKET_IDS` now has 14 entries.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  JOURNEY_MENU_BUCKET_IDS,
+  JOURNEY_MENU_ITEMS,
+  JOURNEY_MENU_ITEMS_BY_ID,
+} from "@/lib/journey/menu-items";
+import { getSettingsForBucket } from "@/lib/journey/bucket-relations";
+import { VOICE_SETTINGS } from "@/lib/settings/voice-setting-contracts";
+
+describe("N_voice bucket — voice settings in Cmd+K + Journey LH", () => {
+  it("includes N_voice in JOURNEY_MENU_BUCKET_IDS", () => {
+    expect(JOURNEY_MENU_BUCKET_IDS).toContain("N_voice");
+  });
+
+  it("declares N_voice in JOURNEY_MENU_ITEMS with sensible label + caption", () => {
+    const bucket = JOURNEY_MENU_ITEMS_BY_ID.N_voice;
+    expect(bucket).toBeDefined();
+    expect(bucket.label).toMatch(/Voice/i);
+    expect(bucket.caption).toBeTruthy();
+    expect(bucket.parentGroup).toBeDefined();
+  });
+
+  it("stamps all 11 VOICE_SETTINGS with menuGroupKey: 'N_voice'", () => {
+    for (const v of VOICE_SETTINGS) {
+      expect(
+        v.menuGroupKey,
+        `voice setting ${v.id} must carry menuGroupKey "N_voice"`,
+      ).toBe("N_voice");
+    }
+  });
+
+  it("getSettingsForBucket('N_voice') returns all 11 voice settings", () => {
+    const bucket = getSettingsForBucket("N_voice");
+    expect(bucket.length).toBe(VOICE_SETTINGS.length);
+    const ids = new Set(bucket.map((s) => s.id));
+    for (const v of VOICE_SETTINGS) {
+      expect(ids.has(v.id), `bucket missing voice setting ${v.id}`).toBe(true);
+    }
+  });
+
+  it("JOURNEY_MENU_ITEMS has 14 entries (was 13 pre-follow-on)", () => {
+    expect(JOURNEY_MENU_ITEMS.length).toBe(14);
+  });
+});

--- a/docs/CONTRACTS-JOURNEY.md
+++ b/docs/CONTRACTS-JOURNEY.md
@@ -281,7 +281,7 @@ truth.
 See [`docs/decisions/2026-06-16-journey-bucket-shape.md`](./decisions/2026-06-16-journey-bucket-shape.md)
 for the rationale + alternatives considered.
 
-### §17.1 — The 13 buckets
+### §17.1 — The 14 buckets
 
 Authored in `lib/journey/menu-items.ts::JOURNEY_MENU_ITEMS`. Each bucket
 declares `id`, `label`, `caption`, `parentGroup` (visual G1..G7
@@ -295,15 +295,27 @@ type JourneyMenuBucketId =
   | "C_teaching_style"
   | "D_question_flow"
   | "E_learner_visual"      // reserved for IELTS Theme 3
-  | "F_stall_recovery"      // reserved for IELTS Theme 2 / 7
+  | "F_stall_recovery"      // reserved for IELTS Theme 2
   | "G_session_length"
   | "H_closing"
   | "I_scoring"
   | "J_feedback"
   | "K_between_calls"
   | "L_mid_journey"
-  | "M_end_of_course";
+  | "M_end_of_course"
+  | "N_voice";              // 11 voice settings — also live in Settings tab
 ```
+
+`N_voice` is the cross-call exception (the 13 letter-named buckets are
+ordered by *session moment*; voice is configuration that applies
+uniformly across every call). It exists so educators can reach the 11
+voice settings via Cmd+K + the Journey LH without leaving the Journey
+tab. The same registry entries also surface in the Settings tab
+under `S1_voice` — there's no second copy.
+
+`bucket-relations.ts` filters over `JOURNEY_SETTINGS + VOICE_SETTINGS`
+together so `getSettingsForBucket("N_voice")` returns the 11 voice
+entries without duplicating them.
 
 ### §17.2 — Registry additions (additive)
 


### PR DESCRIPTION
## Summary

Closes the silent-failure gap surfaced post-Slice-C: the Cmd+K palette indexed 63 settings (52 journey + 11 voice) but voice picks did nothing — voice entries had no \`menuGroupKey\` so \`handlePaletteSelect\` bailed.

Operator decision: add a 14th bucket \`N_voice\` rather than route to the Settings tab. Voice settings now have two homes (Journey LH + Settings tab) — same registry entries, no duplication.

## Changes

- **\`JourneyMenuBucketId\`** gains \`"N_voice"\` — 14 buckets total
- **\`JOURNEY_MENU_ITEMS\`** gets the N_voice entry under parentGroup G4 (voice IS teaching territory)
- **All 11 \`VOICE_SETTINGS\`** stamped with \`menuGroupKey: "N_voice"\` (\`group: "S1_voice"\` unchanged)
- **\`bucket-relations.ts::getSettingsForBucket()\`** filters \`JOURNEY_SETTINGS + VOICE_SETTINGS\` together — same registry, no copy
- **\`CourseJourneyTab.handlePaletteSelect\`** falls through to \`VOICE_SETTINGS_BY_ID\`
- **CommandPalette docstring** updated; placeholder still derives counts ("Search 63 settings across 14 buckets…")

## PATCH save path — already wired

\`app/api/courses/[courseId]/journey-setting/route.ts\` already covers both registries (\`JOURNEY_SETTINGS_BY_ID ?? VOICE_SETTINGS_BY_ID\`). \`storage-path-applier.ts\` already handles \`playbook.voiceConfig.*\`. Zero server changes.

## Why N_voice (not folded into C_teaching_style)

C_teaching_style already has 8 entries and is the busiest bucket. Voice deserves its own attention surface — provider/voiceId is a high-stakes "what does this tutor sound like" decision, not a sub-knob.

## Verified by

- **213/213 tests** across journey + cascade + ESLint-rule banks
- **5 new vitests** in \`tests/lib/journey/n-voice-bucket.test.ts\` pin every invariant
- **ESLint clean**, no new tsc errors

## Test plan

- [ ] Cmd+K → type "voice" → pick "Voice provider" → Enter → Inspector mounts N_voice with all 11 voice settings stacked
- [ ] LH menu → expand G4 → click "Voice & how the tutor sounds" → same Inspector mount
- [ ] Edit \`voiceProvider\` → Save persists to \`Playbook.config.voiceConfig.voiceProvider\`
- [ ] Settings tab → S1_voice group still shows the same 11 voice settings (no regression)