### PR TITLE
feat(compose): #1735 — G8 consumer D + render-side fix for all 4 G8 directives

### DIFF
--- a/apps/admin/eslint-rules/no-bare-module-progress-update.mjs
+++ b/apps/admin/eslint-rules/no-bare-module-progress-update.mjs
@@ -43,6 +43,13 @@ const ALLOWED_PATH_SUFFIXES = [
   "app/api/callers/[callerId]/reset/route.ts",
   "scripts/backfill-950-stuck-module-status.ts",
   "scripts/cleanup-placeholder-lo-scores.ts",
+  // #1735 (epic #1730 G8 consumer D) — endSession writes
+  // `orientationShown=true` on first successful module completion. The
+  // write is a single boolean flag with a stable shape (no
+  // status/mastery semantics — orthogonal to the chokepoint's
+  // increment-and-waiver concern). Allow-listed inline because the
+  // semantics are too different to share `markModuleIncomplete`.
+  "lib/voice/end-session.ts",
 ];
 
 const ALLOWED_PATH_CONTAINS = [

--- a/apps/admin/lib/prompt/composition/renderPromptSummary.ts
+++ b/apps/admin/lib/prompt/composition/renderPromptSummary.ts
@@ -141,6 +141,22 @@ interface LLMPrompt {
       meaning?: string;
     }>;
     teaching_content?: string | null;
+    /** #1732 (epic #1730 G8 consumer A) — module-scoped question count directive. */
+    module_question_target?: { min: number; target: number; directive: string } | null;
+    /** #1733 (epic #1730 G8 consumer B) — module-scoped cue card pick. */
+    module_cue_card?: {
+      kind: "cueCard";
+      topic: string;
+      bullets: string[];
+      secondaryNote?: string;
+      directive: string;
+    } | null;
+    /** #1735 (epic #1730 G8 consumer D) — first-time orientation line. */
+    module_orientation_line?: { line: string; directive: string } | null;
+  };
+  /** #1734 (epic #1730 G8 consumer C) — offboarding transform output (module-scoped close). */
+  offboarding?: {
+    moduleClosingLine?: string | null;
   };
   callHistory?: {
     totalCalls?: number;
@@ -380,6 +396,45 @@ export function renderProviderPrompt(
     parts.push("");
     parts.push(qs.offboarding_guidance);
   }
+
+  // #1734 (epic #1730 G8 consumer C) — module-scoped verbatim closing line.
+  // Appended after the existing offboarding guidance so the model reads it
+  // last when wrapping up. Operator-set value; only renders when the
+  // HF_FLAG_IELTS_MODULE_SETTINGS flag is on AND the locked module has
+  // settings.closingLine set.
+  const moduleClosingLine = llmPrompt.offboarding?.moduleClosingLine;
+  if (typeof moduleClosingLine === "string" && moduleClosingLine.trim().length > 0) {
+    parts.push("");
+    parts.push(
+      `VERBATIM CLOSING LINE — speak these exact words to end the call: "${moduleClosingLine}"`,
+    );
+  }
+
+  // #1735 (epic #1730 G8 consumer D) — first-time-only orientation line.
+  // Renders ONLY when CallerModuleProgress.orientationShown === false for
+  // this (caller, module). endSession writes orientationShown=true after
+  // first render so subsequent calls skip the line.
+  const orientation = llmPrompt.instructions?.module_orientation_line;
+  if (orientation?.directive) {
+    parts.push("");
+    parts.push(orientation.directive);
+  }
+
+  // #1732 (epic #1730 G8 consumer A) — module-scoped question count directive.
+  const questionTarget = llmPrompt.instructions?.module_question_target;
+  if (questionTarget?.directive) {
+    parts.push("");
+    parts.push(questionTarget.directive);
+  }
+
+  // #1733 (epic #1730 G8 consumer B) — module-scoped cue card.
+  // Deterministic per-call pick from cueCardPool.
+  const cueCard = llmPrompt.instructions?.module_cue_card;
+  if (cueCard?.directive) {
+    parts.push("");
+    parts.push(cueCard.directive);
+  }
+
   // Anti-hallucination guard: if no curriculum data at all, make it explicit
   if (!curr?.hasData && !qs?.curriculum_progress) {
     parts.push("IMPORTANT: No curriculum is loaded for this caller. Do NOT invent or assume specific academic topics, modules, or subject matter.");

--- a/apps/admin/lib/prompt/composition/transforms/instructions.ts
+++ b/apps/admin/lib/prompt/composition/transforms/instructions.ts
@@ -335,6 +335,18 @@ registerTransform("computeInstructions", (
       (loadedData.playbooks?.[0]?.config ?? {}) as PlaybookConfig,
       sharedState,
     ),
+
+    // #1735 (epic #1730 G8 consumer D) — module-scoped first-time
+    // orientation line. Renders ONLY when the learner has never seen
+    // this module's orientation yet (`CallerModuleProgress.orientationShown
+    // === false`). After the line renders, `endSession` writes
+    // orientationShown=true so subsequent calls skip it. Gated by
+    // `HF_FLAG_IELTS_MODULE_SETTINGS` per epic #1700 decision 5.
+    module_orientation_line: resolveModuleOrientationLine(
+      (loadedData.playbooks?.[0]?.config ?? {}) as PlaybookConfig,
+      sharedState,
+      loadedData,
+    ),
   };
 });
 
@@ -456,5 +468,63 @@ function resolveModuleCueCard(
     topic: picked.topic,
     bullets,
     directive,
+  };
+}
+
+/**
+ * #1735 (epic #1730 G8 consumer D) — first-time-only orientation line.
+ *
+ * Returns the verbatim string when ALL hold:
+ *   - `HF_FLAG_IELTS_MODULE_SETTINGS=true` (epic #1700 decision 5)
+ *   - `sharedState.lockedModule` is set
+ *   - Matching `AuthoredModule` in `Playbook.config.modules[]` has a
+ *     non-empty `settings.firstTimeOrientationLine` string
+ *   - The corresponding `CallerModuleProgress.orientationShown` for
+ *     `(callerId, moduleId)` is `false` (or row absent — first attempt)
+ *
+ * Returns `null` otherwise — the orientation line was already shown
+ * (gate hit) OR the operator hasn't set one.
+ *
+ * The "has it been shown" lookup uses `loadedData.callerModuleProgress`
+ * (loaded by the modules section). Falls back to `sharedState.modules`
+ * for older composer paths.
+ *
+ * After this line renders for the first time, `endSession`'s
+ * `evaluateOrientationShown` writes `orientationShown = true` so the
+ * next composition for this caller skips the line.
+ */
+function resolveModuleOrientationLine(
+  config: PlaybookConfig,
+  sharedState: AssembledContext["sharedState"],
+  loadedData: AssembledContext["loadedData"],
+): { line: string; directive: string } | null {
+  if (!isIeltsModuleSettingsEnabled()) return null;
+  const lockedModule = sharedState.lockedModule;
+  if (!lockedModule) return null;
+
+  const authoredModules: AuthoredModule[] = config.modules ?? [];
+  const matched = authoredModules.find(
+    (m) => m.id === lockedModule.id || m.id === lockedModule.slug,
+  );
+  if (!matched) return null;
+
+  const line = matched.settings?.firstTimeOrientationLine;
+  if (typeof line !== "string" || line.trim().length === 0) return null;
+
+  // Has the learner seen this module's orientation already? The
+  // `callerModuleProgress` rows live on `loadedData` when the modules
+  // loader has run; fall back to `sharedState.modules.progress` (the
+  // older composer path also carries this).
+  const progressRows = (
+    loadedData as { callerModuleProgress?: Array<{ moduleId: string; orientationShown?: boolean }> }
+  ).callerModuleProgress ?? [];
+  const progressRow = progressRows.find(
+    (r) => r.moduleId === matched.id || r.moduleId === lockedModule.id,
+  );
+  if (progressRow?.orientationShown === true) return null;
+
+  return {
+    line,
+    directive: `FIRST-TIME ORIENTATION (one-shot — speak these exact words once before starting the module): "${line}"`,
   };
 }

--- a/apps/admin/lib/voice/end-session.ts
+++ b/apps/admin/lib/voice/end-session.ts
@@ -175,6 +175,19 @@ export async function endSession(
     playbookConfig: existing.playbook?.config as PlaybookConfig | null | undefined,
   });
 
+  // #1735 (epic #1730 G8 consumer D) — write `orientationShown = true`
+  // on first successful completion of a module that has
+  // `moduleFirstTimeOrientationLine` set. Best-effort; helper failure
+  // doesn't roll back the Session.
+  await markOrientationShownIfApplicable({
+    callerId: updated.callerId,
+    curriculumModuleId: existing.curriculumModuleId,
+    moduleSlug: existing.curriculumModule?.slug ?? null,
+    playbookConfig: existing.playbook?.config as PlaybookConfig | null | undefined,
+    kind,
+    outcome: args.outcome,
+  });
+
   // Fire-and-forget pipeline trigger. Must NOT be awaited and must
   // NOT be inside the transaction. The reconciler (Slice 5) catches
   // any Session that never gets its COMPOSE within 60s.
@@ -390,5 +403,77 @@ function evaluateTalkTimeBudgetsForSession(args: {
       `[endSession] talk-time evaluation failed for session ${args.sessionId.slice(0, 8)}:`,
       err instanceof Error ? err.message : String(err),
     );
+  }
+}
+
+/**
+ * #1735 (epic #1730 G8 consumer D) — set `CallerModuleProgress.orientationShown
+ * = true` for `(callerId, curriculumModuleId)` after the first
+ * successful session of a module whose authored entry carries
+ * `settings.firstTimeOrientationLine`.
+ *
+ * Conditions:
+ *   - Outcome `COMPLETED` (don't gate-burn on GHOST/FAILED — those
+ *     re-attempt fresh and the learner should see the orientation
+ *     again on retry)
+ *   - `kind` ∈ {VOICE_CALL, SIM_CALL} (other classes don't render the
+ *     orientation line)
+ *   - `playbookConfig.modules[]` has a matching `AuthoredModule` with a
+ *     non-empty `settings.firstTimeOrientationLine`
+ *
+ * Best-effort — does NOT throw. The composer's resolveModuleOrientationLine
+ * re-checks the flag on next compose, so a failure here just means
+ * the learner sees the orientation again on the next attempt (harmless).
+ *
+ * Uses `update` with `where: { callerId_moduleId }` so a missing row
+ * raises a Prisma error (caught + logged) — the row should exist
+ * because the modules-instantiator (`lib/enrollment/instantiate-module-progress.ts`)
+ * creates one per (caller, module) at enrollment time.
+ */
+async function markOrientationShownIfApplicable(args: {
+  callerId: string | null;
+  curriculumModuleId: string | null;
+  moduleSlug: string | null;
+  playbookConfig: PlaybookConfig | null | undefined;
+  kind: SessionKindString;
+  outcome: SessionOutcomeString;
+}): Promise<void> {
+  if (args.outcome !== "COMPLETED") return;
+  if (args.kind !== "VOICE_CALL" && args.kind !== "SIM_CALL") return;
+  if (!args.callerId || !args.curriculumModuleId) return;
+
+  // Resolve the AuthoredModule and check if orientation is configured.
+  const authoredModules =
+    (args.playbookConfig?.modules as AuthoredModule[] | undefined) ?? [];
+  const matched = args.moduleSlug
+    ? authoredModules.find((m) => m.id === args.moduleSlug)
+    : undefined;
+  const line = matched?.settings?.firstTimeOrientationLine;
+  if (typeof line !== "string" || line.trim().length === 0) return;
+
+  // Guard #1252 — default-deny on continuous courses. Module-progress
+  // writes only make sense for structured courses. The
+  // `hf-pipeline/no-module-read-without-course-style-guard` ESLint rule
+  // requires the prisma call to sit inside this explicit if-block (an
+  // early-return + flag-check doesn't satisfy the AST shape it scans
+  // for — only an enclosing IfStatement with the structured check).
+  const courseStyle = getCourseStyle(args.playbookConfig);
+  if (courseStyle === "structured") {
+    try {
+      await prisma.callerModuleProgress.update({
+        where: {
+          callerId_moduleId: {
+            callerId: args.callerId,
+            moduleId: args.curriculumModuleId,
+          },
+        },
+        data: { orientationShown: true },
+      });
+    } catch (err) {
+      console.error(
+        `[endSession] markOrientationShown failed for caller ${args.callerId.slice(0, 8)} module ${args.curriculumModuleId.slice(0, 8)}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
   }
 }

--- a/apps/admin/prisma/migrations/20260616133830_1735_orientation_shown/migration.sql
+++ b/apps/admin/prisma/migrations/20260616133830_1735_orientation_shown/migration.sql
@@ -1,0 +1,14 @@
+-- #1735 (epic #1700 Theme 1 G8 consumer D) — orientation-shown gate column.
+--
+-- Adds the `orientationShown` flag to `CallerModuleProgress`. Default false
+-- so existing rows pre-#1735 backfill cleanly (every prior caller is
+-- treated as "hasn't seen orientation yet", which is acceptable — the
+-- orientation line will fire once and never again).
+--
+-- Read by the composer (`transforms/instructions.ts::resolveModuleOrientationLine`)
+-- gated by `HF_FLAG_IELTS_MODULE_SETTINGS`. Written by `endSession`'s
+-- `evaluateOrientationShown` block on first successful completion of a
+-- module that has `moduleFirstTimeOrientationLine` set.
+
+ALTER TABLE "CallerModuleProgress"
+  ADD COLUMN "orientationShown" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -2932,6 +2932,14 @@ model CallerModuleProgress {
   // policy — sets `status = "MASTERED"` regardless of mastery score.
   incompleteAttempts Int @default(0)
 
+  // #1735 (epic #1700 Theme 1 G8 consumer D) — gates the one-shot
+  // `moduleFirstTimeOrientationLine` G8 entry. `false` (default) means
+  // the learner has never seen the orientation for this module; the
+  // composer renders the orientation line on first encounter.
+  // `endSession` writes `true` for the (caller, module) pair on first
+  // successful completion so subsequent calls skip the orientation.
+  orientationShown Boolean @default(false)
+
   // #397 Phase 1 — per-LO running average. Shape:
   //   { [loRef: string]: { mastery: number; callCount: number } }
   // Module mastery is derived as mean(mastery) over LOs present in this map

--- a/apps/admin/tests/lib/composition/instructions-module-orientation-line.test.ts
+++ b/apps/admin/tests/lib/composition/instructions-module-orientation-line.test.ts
@@ -1,0 +1,239 @@
+/**
+ * #1735 (epic #1730 G8 consumer D) — `computeInstructions` surfaces
+ * `module_orientation_line` when the learner has never seen this
+ * module's orientation yet.
+ *
+ * Pins:
+ *   - flag-off → null
+ *   - flag-on + matching settings + orientationShown=false → directive
+ *   - orientationShown=true → null (gate hit)
+ *   - no lockedModule → null
+ *   - no matching authored module → null
+ *   - missing / empty firstTimeOrientationLine → null
+ *   - missing CallerModuleProgress row (no `orientationShown` to read) →
+ *     treats as not-shown (first attempt — show the line)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "@/lib/prompt/composition/transforms/instructions";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+import type {
+  AssembledContext,
+  SharedComputedState,
+  CompositionSectionDef,
+} from "@/lib/prompt/composition/types";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeSharedState(overrides: Partial<SharedComputedState> = {}): SharedComputedState {
+  return {
+    channel: "text",
+    modules: [],
+    isFirstCall: false,
+    daysSinceLastCall: 0,
+    completedModules: new Set<string>(),
+    estimatedProgress: 0,
+    lastCompletedIndex: -1,
+    moduleToReview: null,
+    nextModule: null,
+    reviewType: "quick_recall",
+    reviewReason: "",
+    thresholds: { high: 0.65, low: 0.35 },
+    isFinalSession: false,
+    callNumber: 1,
+    ...overrides,
+  };
+}
+
+function makeContext(opts: {
+  orientationLine?: string;
+  orientationShown?: boolean | null;
+  lockedId?: string;
+  matchById?: boolean;
+  noLockedModule?: boolean;
+  noProgressRow?: boolean;
+} = {}): AssembledContext {
+  const lockedId = opts.lockedId ?? "part2";
+  const matchById = opts.matchById ?? true;
+  const authoredModule: AuthoredModule = {
+    id: matchById ? lockedId : "other-id",
+    label: "Part 2",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "4 min",
+    scoringFired: "All four",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites: [],
+    settings:
+      opts.orientationLine !== undefined
+        ? { firstTimeOrientationLine: opts.orientationLine }
+        : {},
+  };
+  const playbookConfig: PlaybookConfig = { modules: [authoredModule] };
+
+  const callerModuleProgress = opts.noProgressRow
+    ? []
+    : [{ moduleId: lockedId, orientationShown: opts.orientationShown ?? false }];
+
+  return {
+    sharedState: makeSharedState({
+      lockedModule: opts.noLockedModule
+        ? null
+        : ({
+            id: lockedId,
+            slug: lockedId,
+            name: "Part 2",
+          } as unknown as SharedComputedState["lockedModule"]),
+    }),
+    sections: {},
+    loadedData: {
+      caller: null,
+      memories: [],
+      personality: null,
+      learnerProfile: null,
+      recentCalls: [],
+      nextLearnerFacingNumber: 1,
+      behaviorTargets: [],
+      callerTargets: [],
+      callerAttributes: [],
+      goals: [],
+      playbooks: [
+        {
+          id: "p1",
+          name: "IELTS",
+          status: "PUBLISHED",
+          config: playbookConfig,
+          domain: null,
+          items: [],
+        },
+      ] as unknown as AssembledContext["loadedData"]["playbooks"],
+      systemSpecs: [],
+      onboardingSpec: null,
+      ...({ callerModuleProgress } as Record<string, unknown>),
+    } as AssembledContext["loadedData"],
+    resolvedSpecs: {} as AssembledContext["resolvedSpecs"],
+    specConfig: {},
+  };
+}
+
+const STUB_SECTION: CompositionSectionDef = {
+  id: "instructions",
+  name: "Instructions",
+  priority: 9,
+  dataSource: "_assembled",
+  activateWhen: { condition: "always" },
+  fallback: { action: "null" },
+  transform: "computeInstructions",
+  outputKey: "instructions",
+};
+
+const transform = getTransform("computeInstructions")!;
+const LINE = 'In Part 2 you will speak for 2 minutes about a familiar topic.';
+
+describe("computeInstructions — module_orientation_line (#1735)", () => {
+  describe("HF_FLAG_IELTS_MODULE_SETTINGS gating", () => {
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("returns null when the flag is off (default)", async () => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+      const ctx = makeContext({ orientationLine: LINE, orientationShown: false });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: unknown;
+      };
+      expect(result.module_orientation_line).toBeNull();
+    });
+
+    it("emits directive when flag on + first attempt (orientationShown=false)", async () => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+      const ctx = makeContext({ orientationLine: LINE, orientationShown: false });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: { line: string; directive: string } | null;
+      };
+      expect(result.module_orientation_line).not.toBeNull();
+      expect(result.module_orientation_line!.line).toBe(LINE);
+      expect(result.module_orientation_line!.directive).toContain(LINE);
+      expect(result.module_orientation_line!.directive).toContain(
+        "FIRST-TIME ORIENTATION",
+      );
+    });
+  });
+
+  describe("orientationShown gate", () => {
+    beforeEach(() => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    });
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("returns null when orientationShown=true (already shown)", async () => {
+      const ctx = makeContext({ orientationLine: LINE, orientationShown: true });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: unknown;
+      };
+      expect(result.module_orientation_line).toBeNull();
+    });
+
+    it("emits when no CallerModuleProgress row exists (first attempt)", async () => {
+      const ctx = makeContext({ orientationLine: LINE, noProgressRow: true });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: { line: string } | null;
+      };
+      expect(result.module_orientation_line).not.toBeNull();
+      expect(result.module_orientation_line!.line).toBe(LINE);
+    });
+  });
+
+  describe("resolution edge cases", () => {
+    beforeEach(() => {
+      process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    });
+    afterEach(() => {
+      delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+    });
+
+    it("returns null when no lockedModule", async () => {
+      const ctx = makeContext({
+        orientationLine: LINE,
+        orientationShown: false,
+        noLockedModule: true,
+      });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: unknown;
+      };
+      expect(result.module_orientation_line).toBeNull();
+    });
+
+    it("returns null when no matching authored module", async () => {
+      const ctx = makeContext({
+        orientationLine: LINE,
+        orientationShown: false,
+        matchById: false,
+      });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: unknown;
+      };
+      expect(result.module_orientation_line).toBeNull();
+    });
+
+    it("returns null when firstTimeOrientationLine is missing", async () => {
+      const ctx = makeContext({ orientationShown: false });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: unknown;
+      };
+      expect(result.module_orientation_line).toBeNull();
+    });
+
+    it("returns null when firstTimeOrientationLine is whitespace-only", async () => {
+      const ctx = makeContext({ orientationLine: "   ", orientationShown: false });
+      const result = (await transform(null, ctx, STUB_SECTION)) as {
+        module_orientation_line: unknown;
+      };
+      expect(result.module_orientation_line).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
**Closes #1735.** **Parent epic:** #1730 (G8 composer-transform consumers).

Two things in one PR:

1. **#1735 ships** — moduleFirstTimeOrientationLine consumer + \`CallerModuleProgress.orientationShown\` migration + endSession write.

2. **Lattice gap closed** — survey on \`renderPromptSummary.ts\` revealed none of #1734/#1773/#1777's G8 directives reach the LLM. Transforms compute the data; the renderer never pushes it into the final prompt. Same shape of bug as the producer-only-Lattice-violation warned about in \`.claude/rules/lattice-survey.md\`, one layer deeper. **This PR wires all 4 G8 directives into the renderer in one sweep.**

After this lands, editing any G8 setting in the Inspector + flag on → composed prompt **actually contains** the directive. Preview lens stops being misleading.

## What ships

| File | Change |
|---|---|
| \`prisma/schema.prisma\` | New \`orientationShown Boolean @default(false)\` on \`CallerModuleProgress\` |
| \`prisma/migrations/20260616133830_1735_orientation_shown/migration.sql\` | Safe additive migration |
| \`lib/prompt/composition/transforms/instructions.ts\` | New \`resolveModuleOrientationLine\` + \`module_orientation_line\` output key |
| \`lib/prompt/composition/renderPromptSummary.ts\` | **Pushes all 4 G8 directives** into the final prompt (\`moduleClosingLine\`, \`module_question_target\`, \`module_cue_card\`, \`module_orientation_line\`) |
| \`lib/voice/end-session.ts\` | New \`markOrientationShownIfApplicable\` — sets \`orientationShown=true\` on first COMPLETED session of a module with the orientation line set. Guard #1252-respecting (structured-only if-block) |
| \`eslint-rules/no-bare-module-progress-update.mjs\` | Allow-list adds \`lib/voice/end-session.ts\` |
| \`tests/lib/composition/instructions-module-orientation-line.test.ts\` | 8 vitests pinning the resolver |

## Lattice survey

Pre-coding survey on \`renderPromptSummary.ts\` (per \`.claude/rules/pipeline-and-prompt.md\`'s mandate to search before editing transforms) immediately found that none of #1734/#1773/#1777's keys were referenced in the renderer. I shipped 3 G8 consumer PRs without checking the consumer side and they were quietly producer-only.

This is the **exact failure mode** the Lattice survey rule asks me to catch with the sibling-writer-and-consumer survey. The pre-coding habit needs to extend one layer past transforms — into renderers. Documenting it here as a self-correction:

> When a transform adds a new output key that's intended to influence the model, the survey MUST cross-check \`renderPromptSummary.ts\` (or its sibling renderers) for a corresponding \`parts.push(...)\` consumer.

Discipline now applied retroactively across the cohort.

### Risk shapes cross-check

| Risk shape | Disposition |
|---|---|
| Sibling-writer drift | None — \`computeInstructions\` owns the new key; \`endSession.markOrientationShownIfApplicable\` is the sole writer of \`orientationShown\` |
| Default-deny gates | \`HF_FLAG_IELTS_MODULE_SETTINGS\` respected on transform; guard #1252 enforces \`courseStyle === \"structured\"\` if-block around the prisma call (the AST shape the lint rule scans for) |
| Cascade respect | G8 settings declared \`cascadeSources: []\` per #1701 (course-only) |
| Convention conflict | All directives interpolated from operator data; ESLint \`no-hardcoded-greeting-in-composition\` clean |

## Test plan

- [x] 8 new vitests for \`module_orientation_line\` resolver
- [x] 29 G8-consumer transform tests green (8 new + 21 sibling)
- [x] 41 regression tests across affected suites green (ESLint rule + registry + endSession base)
- [x] Pre-push tsc + lint clean (after restructuring the prisma call to sit inside the explicit \`if (courseStyle === \"structured\")\` block the lint rule requires)
- [ ] **hf-dev smoke after \`/vm-cpp\`:** flip \`HF_FLAG_IELTS_MODULE_SETTINGS=true\` → all 4 G8 directives visible in Preview's instructions / offboarding sections + \`orientationShown\` flips true after first completion

## Verified by

- Vitest 8/8 (new) + 29/29 (G8 cohort) + 41/41 (regression)
- Lattice gap discovered + closed in same PR for all 4 G8 consumers
- ESLint #1252 guard satisfied via explicit if-block wrapping the prisma write

## Deploy

**\`/vm-cpp\` required** — schema-touching migration. Additive only (NOT NULL DEFAULT false). After merge:

1. \`/vm-cpp\` from main → applies migration on hf-dev
2. Flip env: \`echo 'HF_FLAG_IELTS_MODULE_SETTINGS=true' >> ~/HF/apps/admin/.env.local && restart dev server\`
3. Smoke all 4 G8 surfaces (see "What testable" section in the smoke list)

## Epic #1730 — ALL 4 G8 CONSUMERS CLOSED

- ✅ #1734 \`moduleClosingLine\` → offboarding
- ✅ #1732 \`moduleQuestionTarget\` → instructions
- ✅ #1733 \`moduleCueCardPool\` → instructions
- ✅ #1735 \`moduleFirstTimeOrientationLine\` → instructions (this PR) **+ render-side wiring for all 4**