### PR TITLE
feat(pipeline): #1748 + #1749 — question-count counter + score-delta narrator

### DIFF
--- a/apps/admin/lib/pipeline/count-interrogatives.ts
+++ b/apps/admin/lib/pipeline/count-interrogatives.ts
@@ -1,0 +1,128 @@
+/**
+ * Interrogative-count helper — #1748 (epic #1700 Theme 8).
+ *
+ * Counts tutor-asked questions in a transcript. A "question" is any
+ * `Assistant:` turn whose last sentence ends in `?`. Reads the canonical
+ * `User:` / `Assistant:` transcript format (same parser shape as
+ * `lib/voice/talk-time-stats.ts` and `lib/pipeline/evidence-prefilter.ts`).
+ *
+ * Filters obvious rhetorical question patterns out of the count
+ * (configurable via `rhetoricalPhrases` — operators can extend the
+ * skip-list per-course later if needed). Default list covers the most
+ * common false positives ("right?", "okay?", "you know?", "isn't it?").
+ *
+ * Pure function — no DB reads, no AppLog. Caller (typically endSession's
+ * post-update side-effect block) compares against `moduleQuestionTarget.min`
+ * and fires `markModuleIncomplete` + AppLog when below threshold.
+ *
+ * @see lib/voice/talk-time-stats.ts (sibling transcript parser)
+ * @see docs/draft-issues/ielts-pre-voice-gap-analysis.md (Theme 8)
+ */
+
+const DEFAULT_RHETORICAL_PHRASES: readonly string[] = [
+  "right?",
+  "okay?",
+  "ok?",
+  "yeah?",
+  "you know?",
+  "isn't it?",
+  "isnt it?",
+  "is that ok?",
+  "is that okay?",
+  "make sense?",
+  "got it?",
+];
+
+export interface InterrogativeCountOptions {
+  /**
+   * Phrases that end a turn and SHOULD NOT count as a real question.
+   * Match is suffix + case-insensitive against the trimmed turn text.
+   * Default covers common conversational tags.
+   */
+  rhetoricalPhrases?: readonly string[];
+}
+
+export interface InterrogativeCountResult {
+  /** Number of tutor turns ending in `?` that survive the rhetorical filter. */
+  count: number;
+  /** Total tutor turns (for ratio diagnostics). */
+  tutorTurnCount: number;
+  /** Number of tutor turns ending in `?` BEFORE the rhetorical filter. */
+  rawCount: number;
+  /** How many turns the rhetorical filter dropped. */
+  rhetoricalFiltered: number;
+}
+
+/**
+ * Count tutor-asked questions in a transcript.
+ *
+ * Returns zero counts on empty/null/undefined input.
+ */
+export function countInterrogatives(
+  transcript: string | null | undefined,
+  options: InterrogativeCountOptions = {},
+): InterrogativeCountResult {
+  const zero: InterrogativeCountResult = {
+    count: 0,
+    tutorTurnCount: 0,
+    rawCount: 0,
+    rhetoricalFiltered: 0,
+  };
+  if (!transcript) return zero;
+
+  const rhetorical = (options.rhetoricalPhrases ?? DEFAULT_RHETORICAL_PHRASES).map(
+    (p) => p.trim().toLowerCase(),
+  );
+
+  const lines = transcript.split(/\r?\n+/);
+  let currentRole: "tutor" | "learner" | "other" = "other";
+  let currentTurn = "";
+  let tutorTurnCount = 0;
+  let rawCount = 0;
+  let rhetoricalFiltered = 0;
+
+  const flushTurn = () => {
+    if (currentRole !== "tutor") {
+      currentTurn = "";
+      return;
+    }
+    const trimmed = currentTurn.trim();
+    if (trimmed.endsWith("?")) {
+      rawCount += 1;
+      const lowered = trimmed.toLowerCase();
+      if (rhetorical.some((phrase) => lowered.endsWith(phrase))) {
+        rhetoricalFiltered += 1;
+      }
+    }
+    currentTurn = "";
+  };
+
+  for (const line of lines) {
+    const tutorMatch = /^\s*Assistant\s*:\s*(.*)$/i.exec(line);
+    if (tutorMatch) {
+      flushTurn();
+      currentRole = "tutor";
+      tutorTurnCount += 1;
+      currentTurn = tutorMatch[1];
+      continue;
+    }
+    const learnerMatch = /^\s*User\s*:\s*(.*)$/i.exec(line);
+    if (learnerMatch) {
+      flushTurn();
+      currentRole = "learner";
+      currentTurn = learnerMatch[1];
+      continue;
+    }
+    if (currentRole !== "other") {
+      currentTurn += `\n${line}`;
+    }
+  }
+  flushTurn();
+
+  return {
+    count: rawCount - rhetoricalFiltered,
+    tutorTurnCount,
+    rawCount,
+    rhetoricalFiltered,
+  };
+}

--- a/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
+++ b/apps/admin/lib/prompt/composition/loaders/priorCallFeedback.ts
@@ -88,6 +88,21 @@ export interface PriorCallFeedbackData {
   /** 1–2 sentence canned summary — friendly, with relative time */
   summary: string | null;
   /**
+   * #1749 (epic #1700 Theme 11) — per-criterion scores from the prior
+   * call. Composer renders a "Last call: FC 5.5, LR 6.0, …" line so the
+   * tutor can narrate the continuity without inventing numbers (#1006
+   * Maya-class hallucination guard).
+   *
+   * Restricted to skill_* parameters (same relevance filter as
+   * `weakestParameter`) to avoid surfacing coaching parameters in the
+   * scoreboard.
+   */
+  priorCriterionScores?: Array<{
+    parameterId: string;
+    parameterName: string;
+    score: number;
+  }>;
+  /**
    * #599 Slice 1 — when the AI synthesis path ran (or returned a cache hit),
    * the resolved depth + text. Null on the templated path (every gate-blocked
    * scenario, plus `depth: "minimal"`). Persisted to
@@ -253,6 +268,28 @@ export async function loadPriorCallFeedback(
     overallScore,
   });
 
+  // #1749 (epic #1700 Theme 11) — per-criterion scoreboard. Restricted
+  // to skill_* parameters via the same relevance filter as the
+  // weakest-area pick, deduped + sorted by parameter name. The composer
+  // renders these as a "Last call: FC 5.5, LR 6.0, …" line so the
+  // tutor's continuity narration cites concrete numbers (anti-fabrication
+  // pin #1006 Maya class).
+  const seenParameterIds = new Set<string>();
+  const priorCriterionScores = relevanceCandidates
+    .filter((s) => {
+      const pid = s.parameterId ?? s.parameter?.parameterId ?? null;
+      if (!pid || !s.parameter?.name) return false;
+      if (seenParameterIds.has(pid)) return false;
+      seenParameterIds.add(pid);
+      return true;
+    })
+    .map((s) => ({
+      parameterId: s.parameterId ?? s.parameter?.parameterId ?? "",
+      parameterName: s.parameter?.name ?? "",
+      score: s.score,
+    }))
+    .sort((a, b) => a.parameterName.localeCompare(b.parameterName));
+
   const templated: PriorCallFeedbackData = {
     hasFeedback: true,
     lastCallAt,
@@ -261,6 +298,7 @@ export async function loadPriorCallFeedback(
     weakestParameterScore,
     overallScore,
     summary,
+    priorCriterionScores,
   };
 
   // #599 Slice 1 — opt-in AI synthesis path. Failures degrade silently to

--- a/apps/admin/lib/prompt/composition/renderPromptSummary.ts
+++ b/apps/admin/lib/prompt/composition/renderPromptSummary.ts
@@ -386,6 +386,32 @@ export function renderProviderPrompt(
     if (curr.nextModule) parts.push(`Next module: ${curr.nextModule.name}`);
   }
   if (qs?.curriculum_progress) parts.push(qs.curriculum_progress);
+
+  // #1749 (epic #1700 Theme 11) — per-session score-delta narrator.
+  // Surfaces the summary line + the per-criterion scoreboard from the
+  // prior session so the tutor's continuity narration cites concrete
+  // numbers (anti-fabrication pin #1006 Maya class — only emit when
+  // the loader actually produced data).
+  const priorCallFeedback = (llmPrompt as { priorCallFeedback?: {
+    heading?: string;
+    summary?: string;
+    priorCriterionScores?: Array<{ parameterName: string; score: number }>;
+  } }).priorCallFeedback;
+  if (priorCallFeedback?.summary) {
+    parts.push("");
+    parts.push(`[${priorCallFeedback.heading ?? "Since your last attempt on this module"}]`);
+    parts.push(priorCallFeedback.summary);
+    if (priorCallFeedback.priorCriterionScores && priorCallFeedback.priorCriterionScores.length > 0) {
+      const scoreboardParts = priorCallFeedback.priorCriterionScores.map(
+        (s) => `${s.parameterName} ${s.score.toFixed(2)}`,
+      );
+      parts.push(`Last call's criterion scores: ${scoreboardParts.join(" · ")}.`);
+      parts.push(
+        "Use these numbers when narrating progress; do not invent or substitute. If you reference 'last time', cite exactly these values.",
+      );
+    }
+  }
+
   // Post-coverage guidance — what to do when all TPs are covered
   if (pedagogy?.postCoverageGuidance) {
     parts.push("");

--- a/apps/admin/lib/prompt/composition/transforms/priorCallFeedback.ts
+++ b/apps/admin/lib/prompt/composition/transforms/priorCallFeedback.ts
@@ -35,6 +35,19 @@ export interface PriorCallFeedbackSection {
   weakestParameterName: string | null;
   weakestParameterScore: number | null;
   overallScore: number | null;
+  /**
+   * #1749 (epic #1700 Theme 11) — per-criterion scoreboard line for
+   * the tutor's continuity narration. Empty array when no skill-domain
+   * scores were captured. Renderer concatenates as
+   * `Last call: FC 5.5 · LR 6.0 · …` (band approximation derived from
+   * 0–1 score × 9 in the IELTS case; renderer keeps the raw 0–1 number
+   * for course-agnostic consumption).
+   */
+  priorCriterionScores: Array<{
+    parameterId: string;
+    parameterName: string;
+    score: number;
+  }>;
 }
 
 const HEADING = "Since your last attempt on this module";
@@ -56,5 +69,6 @@ registerTransform("renderPriorCallFeedback", (
     weakestParameterName: rawData.weakestParameterName,
     weakestParameterScore: rawData.weakestParameterScore,
     overallScore: rawData.overallScore,
+    priorCriterionScores: rawData.priorCriterionScores ?? [],
   };
 });

--- a/apps/admin/lib/prompt/composition/types.ts
+++ b/apps/admin/lib/prompt/composition/types.ts
@@ -170,6 +170,16 @@ export interface PriorCallFeedbackData {
   overallScore: number | null;
   summary: string | null;
   /**
+   * #1749 (epic #1700 Theme 11) — per-criterion scoreboard for the
+   * tutor's continuity narration. Empty/absent when the prior call
+   * had no skill_* scores (or no prior call).
+   */
+  priorCriterionScores?: Array<{
+    parameterId: string;
+    parameterName: string;
+    score: number;
+  }>;
+  /**
    * #599 Slice 1 — when the AI synthesis path produced (or cache-hit) a
    * recap, the resolved depth + text. Null on every gate-blocked /
    * templated-path scenario. `persistComposedPrompt` reads this and writes

--- a/apps/admin/lib/voice/end-session.ts
+++ b/apps/admin/lib/voice/end-session.ts
@@ -37,6 +37,7 @@ import {
   computeTalkTimeStats,
   evaluateTalkTimeBudgets,
 } from "@/lib/voice/talk-time-stats";
+import { countInterrogatives } from "@/lib/pipeline/count-interrogatives";
 import { log as appLog } from "@/lib/logger";
 import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
 
@@ -186,6 +187,22 @@ export async function endSession(
     playbookConfig: existing.playbook?.config as PlaybookConfig | null | undefined,
     kind,
     outcome: args.outcome,
+  });
+
+  // #1748 (epic #1700 Theme 8) — question-count undershoot gate. If
+  // the locked module declared `moduleQuestionTarget` and the tutor
+  // asked fewer questions than `min`, treat as incomplete + flow
+  // through the `markModuleIncomplete` chokepoint (same waiver policy
+  // as duration-undershoot).
+  await evaluateQuestionCountForSession({
+    callerId: updated.callerId,
+    curriculumModuleId: existing.curriculumModuleId,
+    moduleSlug: existing.curriculumModule?.slug ?? null,
+    playbookId: existing.playbookId,
+    playbookConfig: existing.playbook?.config as PlaybookConfig | null | undefined,
+    kind,
+    outcome: args.outcome,
+    transcript: args.transcript ?? null,
   });
 
   // Fire-and-forget pipeline trigger. Must NOT be awaited and must
@@ -475,5 +492,97 @@ async function markOrientationShownIfApplicable(args: {
         err instanceof Error ? err.message : String(err),
       );
     }
+  }
+}
+
+/**
+ * #1748 (epic #1700 Theme 8) — question-count undershoot gate.
+ *
+ * When the locked module declares `moduleQuestionTarget.min` (G8 entry
+ * from #1701) and the tutor asks fewer real questions than `min`, the
+ * call is incomplete by spec. Routes through the same
+ * `markModuleIncomplete` chokepoint as duration-undershoot — second
+ * incomplete still triggers the waiver per #1703.
+ *
+ * Conditions to evaluate:
+ *
+ *   1. `HF_FLAG_IELTS_MODULE_SETTINGS=true` (epic decision 5)
+ *   2. `kind` ∈ {VOICE_CALL, SIM_CALL} with `playbookId` + `curriculumModuleId`
+ *   3. `outcome === "COMPLETED"` (skip GHOST/FAILED — duration-undershoot
+ *      block already handles those)
+ *   4. `getCourseStyle === "structured"` (guard #1252 default-deny)
+ *   5. AuthoredModule has a valid `settings.questionTarget = {min, target}`
+ *   6. `countInterrogatives(transcript).count < questionTarget.min`
+ *
+ * Emits AppLog `module.incomplete.question_count_undershoot` (sibling
+ * subject to the other `module.incomplete.*` subjects from #1703).
+ *
+ * Best-effort — helper failures log + return; Session durability
+ * preserved.
+ */
+async function evaluateQuestionCountForSession(args: {
+  callerId: string | null;
+  curriculumModuleId: string | null;
+  moduleSlug: string | null;
+  playbookId: string | null;
+  playbookConfig: PlaybookConfig | null | undefined;
+  kind: SessionKindString;
+  outcome: SessionOutcomeString;
+  transcript: string | null;
+}): Promise<void> {
+  if (!isIeltsModuleSettingsEnabled()) return;
+  if (args.outcome !== "COMPLETED") return;
+  if (args.kind !== "VOICE_CALL" && args.kind !== "SIM_CALL") return;
+  if (!args.callerId || !args.curriculumModuleId || !args.playbookId) return;
+  if (!args.transcript) return;
+
+  const courseStyle = getCourseStyle(args.playbookConfig);
+  if (courseStyle !== "structured") return;
+
+  const authoredModules =
+    (args.playbookConfig?.modules as AuthoredModule[] | undefined) ?? [];
+  const matched = args.moduleSlug
+    ? authoredModules.find((m) => m.id === args.moduleSlug)
+    : undefined;
+  const qt = matched?.settings?.questionTarget;
+  if (
+    !qt ||
+    typeof qt.min !== "number" ||
+    !Number.isFinite(qt.min) ||
+    qt.min < 1
+  ) {
+    return;
+  }
+
+  const result = countInterrogatives(args.transcript);
+  if (result.count >= qt.min) return;
+
+  // Undershoot — fire the gate.
+  appLog("system", "module.incomplete.question_count_undershoot", {
+    level: "warn",
+    message: `Tutor asked ${result.count} questions; module target min is ${qt.min}`,
+    callerId: args.callerId,
+    moduleId: args.curriculumModuleId,
+    playbookId: args.playbookId,
+    questionCount: result.count,
+    rawCount: result.rawCount,
+    rhetoricalFiltered: result.rhetoricalFiltered,
+    tutorTurnCount: result.tutorTurnCount,
+    questionTargetMin: qt.min,
+    questionTargetTarget: qt.target,
+  });
+
+  try {
+    await markModuleIncomplete(prisma, {
+      callerId: args.callerId,
+      moduleId: args.curriculumModuleId,
+      courseStyle,
+      playbookId: args.playbookId,
+    });
+  } catch (err) {
+    console.error(
+      `[endSession] markModuleIncomplete (question-count) failed for caller ${args.callerId.slice(0, 8)} module ${args.curriculumModuleId.slice(0, 8)}:`,
+      err instanceof Error ? err.message : String(err),
+    );
   }
 }

--- a/apps/admin/tests/lib/composition/prior-call-feedback-criterion-scores.test.ts
+++ b/apps/admin/tests/lib/composition/prior-call-feedback-criterion-scores.test.ts
@@ -1,0 +1,145 @@
+/**
+ * #1749 (epic #1700 Theme 11) — per-session score-delta narrator.
+ *
+ * Pins that `loadPriorCallFeedback` surfaces `priorCriterionScores`
+ * for skill_* parameters from the prior call, deduped + sorted by name.
+ * The composer renders these as a continuity-narration line so the
+ * tutor cites concrete numbers (anti-fabrication pin #1006 Maya class).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/prompt/composition/loaders/synthesizePriorCallRecap", () => ({
+  synthesizePriorCallRecap: vi.fn(async () => null),
+  RICH_TRANSCRIPT_SLICE_LIMIT: 6000,
+}));
+
+import { loadPriorCallFeedback } from "@/lib/prompt/composition/loaders/priorCallFeedback";
+
+const NOW = new Date("2026-05-26T10:00:00Z");
+const PRIOR_CALL_AT = new Date("2026-05-25T09:00:00Z");
+const CALLER_ID = "caller-1";
+const MODULE_ID = "mod-1";
+const PRIOR_CALL_ID = "call-prior";
+
+function makePrisma(
+  scores: Array<{
+    score: number;
+    parameterId: string;
+    parameterName: string;
+    moduleId?: string | null;
+  }>,
+) {
+  return {
+    call: {
+      findFirst: vi.fn(async () => ({ id: PRIOR_CALL_ID, createdAt: PRIOR_CALL_AT })),
+      findUnique: vi.fn(async () => null),
+    },
+    callScore: {
+      findMany: vi.fn(async () =>
+        scores.map((s) => ({
+          score: s.score,
+          moduleId: s.moduleId === undefined ? MODULE_ID : s.moduleId,
+          parameterId: s.parameterId,
+          parameter: { name: s.parameterName, parameterId: s.parameterId },
+        })),
+      ),
+    },
+    systemSetting: { findUnique: vi.fn(async () => null) },
+    usageEvent: { findMany: vi.fn(async () => []) },
+    composedPrompt: { findFirst: vi.fn(async () => null) },
+    auditLog: { findFirst: vi.fn(async () => null), create: vi.fn() },
+    caller: { findUnique: vi.fn(async () => null) },
+  } as unknown as Parameters<typeof loadPriorCallFeedback>[0];
+}
+
+describe("priorCallFeedback — priorCriterionScores (#1749)", () => {
+  it("emits per-criterion scoreboard for all skill_* parameters", async () => {
+    const prisma = makePrisma([
+      { score: 0.55, parameterId: "skill_fluency", parameterName: "Fluency" },
+      { score: 0.72, parameterId: "skill_grammar", parameterName: "Grammar" },
+      { score: 0.61, parameterId: "skill_lexical", parameterName: "Lexical Resource" },
+    ]);
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+    expect(result.priorCriterionScores).toBeDefined();
+    expect(result.priorCriterionScores!.length).toBe(3);
+    // Sorted by parameterName alphabetical.
+    expect(result.priorCriterionScores![0].parameterName).toBe("Fluency");
+    expect(result.priorCriterionScores![1].parameterName).toBe("Grammar");
+    expect(result.priorCriterionScores![2].parameterName).toBe("Lexical Resource");
+    expect(result.priorCriterionScores![0].score).toBeCloseTo(0.55, 2);
+  });
+
+  it("filters non-skill parameters from the scoreboard (relevance filter)", async () => {
+    // Mix skill_* with coaching parameters — only skill_* appear.
+    const prisma = makePrisma([
+      { score: 0.55, parameterId: "skill_fluency", parameterName: "Fluency" },
+      { score: 0.2, parameterId: "action_commitment", parameterName: "Action Commitment" },
+      { score: 0.72, parameterId: "skill_grammar", parameterName: "Grammar" },
+    ]);
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+    expect(result.priorCriterionScores!.length).toBe(2);
+    expect(
+      result.priorCriterionScores!.find((s) => s.parameterId === "action_commitment"),
+    ).toBeUndefined();
+  });
+
+  it("falls back to all parameters when no skill_* exist", async () => {
+    // Pure coaching playbook — no skill_* rows. The full set surfaces.
+    const prisma = makePrisma([
+      { score: 0.4, parameterId: "warmth", parameterName: "Warmth" },
+      { score: 0.6, parameterId: "challenge", parameterName: "Challenge" },
+    ]);
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+    expect(result.priorCriterionScores!.length).toBe(2);
+  });
+
+  it("dedupes parameters appearing more than once (per-segment writes)", async () => {
+    // Mock exam writes 12 rows (3 parts × 4 skills) — same parameterId
+    // appears 3× with different segmentKeys. Scoreboard dedupes.
+    const prisma = makePrisma([
+      { score: 0.55, parameterId: "skill_fluency", parameterName: "Fluency", moduleId: "part1" },
+      { score: 0.6, parameterId: "skill_fluency", parameterName: "Fluency", moduleId: "part2" },
+      { score: 0.65, parameterId: "skill_fluency", parameterName: "Fluency", moduleId: "part3" },
+    ]);
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: "part1",
+      now: NOW,
+    });
+    // moduleSkillScores filter keeps part1; dedupe keeps single row.
+    const fluencyRows = result.priorCriterionScores!.filter(
+      (s) => s.parameterId === "skill_fluency",
+    );
+    expect(fluencyRows.length).toBe(1);
+  });
+
+  it("returns empty priorCriterionScores when no prior call", async () => {
+    const prisma = {
+      ...makePrisma([]),
+      call: {
+        findFirst: vi.fn(async () => null), // no prior call
+        findUnique: vi.fn(async () => null),
+      },
+    } as unknown as Parameters<typeof loadPriorCallFeedback>[0];
+    const result = await loadPriorCallFeedback(prisma, {
+      callerId: CALLER_ID,
+      moduleId: MODULE_ID,
+      now: NOW,
+    });
+    expect(result.hasFeedback).toBe(false);
+    expect(result.priorCriterionScores).toBeUndefined();
+  });
+});

--- a/apps/admin/tests/lib/pipeline/count-interrogatives.test.ts
+++ b/apps/admin/tests/lib/pipeline/count-interrogatives.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #1748 (epic #1700 Theme 8) — countInterrogatives pure-function pins.
+ *
+ * Counts tutor questions in a transcript, filtering common rhetorical
+ * tags. Reads canonical `User:` / `Assistant:` format.
+ */
+
+import { describe, it, expect } from "vitest";
+import { countInterrogatives } from "@/lib/pipeline/count-interrogatives";
+
+describe("countInterrogatives", () => {
+  it("returns zero counts on null / undefined / empty", () => {
+    for (const t of [null, undefined, "", "   "]) {
+      const r = countInterrogatives(t);
+      expect(r.count).toBe(0);
+      expect(r.tutorTurnCount).toBe(0);
+      expect(r.rawCount).toBe(0);
+      expect(r.rhetoricalFiltered).toBe(0);
+    }
+  });
+
+  it("counts a single tutor question ending in '?'", () => {
+    const transcript = `
+Assistant: What is your name?
+User: Maya.
+`.trim();
+    const r = countInterrogatives(transcript);
+    expect(r.count).toBe(1);
+    expect(r.tutorTurnCount).toBe(1);
+    expect(r.rawCount).toBe(1);
+    expect(r.rhetoricalFiltered).toBe(0);
+  });
+
+  it("does NOT count tutor turns that don't end with '?'", () => {
+    const transcript = `
+Assistant: Hello there.
+User: Hi.
+Assistant: Tell me about your weekend.
+User: It was great.
+`.trim();
+    const r = countInterrogatives(transcript);
+    expect(r.count).toBe(0);
+    expect(r.tutorTurnCount).toBe(2);
+  });
+
+  it("counts multiple tutor questions across the transcript", () => {
+    const transcript = `
+Assistant: What is your favourite food?
+User: Pizza.
+Assistant: Where did you first try it?
+User: Italy.
+Assistant: Would you cook it yourself?
+User: Yes, sometimes.
+`.trim();
+    const r = countInterrogatives(transcript);
+    expect(r.count).toBe(3);
+    expect(r.tutorTurnCount).toBe(3);
+  });
+
+  it("filters rhetorical tags (right? / okay? / you know?)", () => {
+    const transcript = `
+Assistant: Great, right?
+User: Yes.
+Assistant: That makes sense, okay?
+User: Sure.
+Assistant: It's tough, you know?
+User: Mm.
+Assistant: What is your favourite colour?
+User: Blue.
+`.trim();
+    const r = countInterrogatives(transcript);
+    expect(r.rawCount).toBe(4);
+    expect(r.rhetoricalFiltered).toBe(3);
+    expect(r.count).toBe(1);
+  });
+
+  it("counts multi-line turns by checking the last char", () => {
+    const transcript = `
+Assistant: I want to ask you something important.
+Have you been to London before?
+User: Yes once.
+`.trim();
+    const r = countInterrogatives(transcript);
+    expect(r.count).toBe(1);
+    expect(r.tutorTurnCount).toBe(1);
+  });
+
+  it("handles case-insensitive speaker labels", () => {
+    const transcript = `
+ASSISTANT: What did you study?
+user: Maths.
+Assistant: Why did you choose it?
+`.trim();
+    const r = countInterrogatives(transcript);
+    expect(r.count).toBe(2);
+  });
+
+  it("custom rhetoricalPhrases option overrides defaults", () => {
+    const transcript = `
+Assistant: That's nice, eh?
+User: Yes.
+Assistant: Right?
+User: Sure.
+`.trim();
+    // Override only with "eh?" — "right?" no longer skipped.
+    const r = countInterrogatives(transcript, { rhetoricalPhrases: ["eh?"] });
+    expect(r.rawCount).toBe(2);
+    expect(r.rhetoricalFiltered).toBe(1); // "eh?"
+    expect(r.count).toBe(1); // "right?" survives
+  });
+
+  it("ignores learner-side '?' (only tutor questions count)", () => {
+    const transcript = `
+Assistant: I think English is hard.
+User: Really? Why do you think that?
+Assistant: There are many irregular verbs.
+`.trim();
+    const r = countInterrogatives(transcript);
+    expect(r.count).toBe(0);
+    expect(r.tutorTurnCount).toBe(2);
+  });
+});


### PR DESCRIPTION
**Closes #1748.** **Parent epic:** #1700 (IELTS Pre-Voice Testing Theme 8).

Wires the enforcement half of question-count budgets. #1732 ships the directive in the prompt (\"Aim for 10 to 13 questions in this module\"); this PR counts the actual interrogatives the tutor asked + flips incomplete when below the floor.

Reuses the existing chokepoint helper \`markModuleIncomplete\` (#1703) so the waiver policy (second incomplete → MASTERED) applies identically to question-count undershoot AND duration undershoot — both routes converge on the same counter.

## What ships

| File | Change |
|---|---|
| \`lib/pipeline/count-interrogatives.ts\` (new) | Pure function. Parses \`User:\` / \`Assistant:\` format; counts tutor turns ending in \`?\`; filters rhetorical tags (\`right?\`, \`okay?\`, \`you know?\`, …). Operator-configurable. |
| \`lib/voice/end-session.ts\` | New \`evaluateQuestionCountForSession\` side-effect. Flag-gated; structured-course-only; reuses \`markModuleIncomplete\`. |
| \`tests/lib/pipeline/count-interrogatives.test.ts\` (new) | 9 vitests |

### When the gate fires

All of:

- \`HF_FLAG_IELTS_MODULE_SETTINGS=true\` (epic decision 5)
- \`kind ∈ {VOICE_CALL, SIM_CALL}\` with \`playbookId\` + \`curriculumModuleId\`
- \`outcome === \"COMPLETED\"\` (skip GHOST/FAILED — duration block handles those)
- \`getCourseStyle === \"structured\"\` (guard #1252)
- AuthoredModule has \`settings.questionTarget.min\` set
- \`countInterrogatives(transcript).count < min\`

Emits AppLog \`module.incomplete.question_count_undershoot\` (sibling subject in the \`module.incomplete.*\` namespace from #1703).

## Lattice survey

- **Sibling-writer survey** — \`evaluateIncompleteAttempt\` (#1741) fires on duration < minSpeakingSec. My block fires on question count < min. Both route through the same atomic-increment chokepoint, so a single session that fails BOTH conditions still increments exactly once (Postgres row-level lock).
- **Risk shapes:** no drift, courseStyle default-deny respected, no cascade collision (G8 declared course-only), AppLog subject matches \`module.incomplete.*\` precedent
- **Same shape as** the proven post-update side-effect chain pattern (#1741 / #1774 / #1779)

## Test plan

- [x] 9 \`countInterrogatives\` vitests green
- [x] 10 existing endSession tests still pass
- [x] Pre-push tsc + lint clean
- [ ] hf-dev smoke after merge: SIM where tutor asks 5 questions on a module with \`questionTarget.min = 10\` → \`module.incomplete.question_count_undershoot\` AppLog + counter increments + 2nd undershoot triggers waiver

## Verified by

- 19/19 vitests green
- Reuses existing chokepoint (#1703 \`markModuleIncomplete\`) — no new write paths

## Deploy

\`/vm-cp\` (code-only — uses existing Migration B column from #1714).