### PR TITLE
fix(journey): Lane 2 — RHS Inspector usability pass (overflow menu, real CTAs, saved/unsaved labels)

### DIFF
--- a/apps/admin/components/journey-controls/JourneyPhases.tsx
+++ b/apps/admin/components/journey-controls/JourneyPhases.tsx
@@ -24,15 +24,21 @@ export function JourneyPhases({ contract, value }: JourneyFieldProps) {
         className="hf-jf-compound-placeholder"
         data-testid={`hf-jf-phases-${contract.id}`}
       >
-        {phases.length === 0
-          ? "No phases configured."
-          : `${phases.length} phase${phases.length === 1 ? "" : "s"}: ${phases
-              .map((p) => p.name ?? "(unnamed)")
-              .join(" → ")}`}
-        <div className="hf-jf-help">
-          Inline phase-editing ships in Phase 3. For now, edit via the legacy
-          lens (existing Design tab).
-        </div>
+        {phases.length === 0 ? (
+          <div className="hf-jf-compound-empty">
+            <strong>No phases configured.</strong>{" "}
+            <span>Use the ⋯ menu → Edit as JSON to set the phase list.</span>
+          </div>
+        ) : (
+          <div className="hf-jf-compound-summary">
+            <strong>
+              {phases.length} phase{phases.length === 1 ? "" : "s"}:
+            </strong>{" "}
+            <span>
+              {phases.map((p) => p.name ?? "(unnamed)").join(" → ")}
+            </span>
+          </div>
+        )}
       </div>
     </_FieldShell>
   );

--- a/apps/admin/components/journey-controls/JourneySelect.tsx
+++ b/apps/admin/components/journey-controls/JourneySelect.tsx
@@ -67,7 +67,7 @@ export function JourneySelect({
           >
             {opts.length === 0 ? (
               <option value="" disabled>
-                Options load at runtime — use the JSON button to set
+                {f.draftValue ? `Current: ${f.draftValue}` : "Not set"}
               </option>
             ) : (
               opts.map((o) => (
@@ -79,6 +79,15 @@ export function JourneySelect({
           </select>
         )}
       </div>
+      {opts.length === 0 ? (
+        <div
+          className="hf-jf-options-empty"
+          data-testid={`hf-jf-options-empty-${contract.id}`}
+        >
+          No options available right now. Use the ⋯ menu → Edit as JSON to
+          set this manually.
+        </div>
+      ) : null}
     </_FieldShell>
   );
 }

--- a/apps/admin/components/journey-controls/JourneyStop.tsx
+++ b/apps/admin/components/journey-controls/JourneyStop.tsx
@@ -21,14 +21,20 @@ export function JourneyStop({ contract, value }: JourneyFieldProps) {
         className="hf-jf-compound-placeholder"
         data-testid={`hf-jf-stop-${contract.id}`}
       >
-        {stop === null
-          ? "Stop not configured."
-          : `${stop.enabled ? "Enabled" : "Disabled"}${
-              stop.kind ? ` · kind: ${stop.kind}` : ""
-            }${stop.trigger ? ` · trigger: ${JSON.stringify(stop.trigger)}` : ""}`}
-        <div className="hf-jf-help">
-          Stop editor mounts in Phase 3.
-        </div>
+        {stop === null ? (
+          <div className="hf-jf-compound-empty">
+            <strong>Not configured.</strong>{" "}
+            <span>Use the ⋯ menu → Edit as JSON to set the stop shape.</span>
+          </div>
+        ) : (
+          <div className="hf-jf-compound-summary">
+            <strong>{stop.enabled ? "Enabled" : "Disabled"}</strong>
+            {stop.kind ? <span> · kind: {stop.kind}</span> : null}
+            {stop.trigger ? (
+              <span> · trigger: {JSON.stringify(stop.trigger)}</span>
+            ) : null}
+          </div>
+        )}
       </div>
     </_FieldShell>
   );

--- a/apps/admin/components/journey-controls/_FieldShell.tsx
+++ b/apps/admin/components/journey-controls/_FieldShell.tsx
@@ -61,7 +61,20 @@ export function _FieldShell({
               from {effectiveSource.level}
             </span>
           ) : null}
-          {isDirty ? <span className="hf-jf-dirty-dot" aria-label="unsaved" /> : null}
+          {isActive ? (
+            <span
+              className="hf-jf-saved-flash"
+              aria-live="polite"
+              data-testid={`hf-jf-saved-${contract.id}`}
+            >
+              ✓ Saved
+            </span>
+          ) : null}
+          {isDirty && !isActive ? (
+            <span className="hf-jf-dirty-dot" aria-label="unsaved">
+              • Unsaved
+            </span>
+          ) : null}
         </div>
       </div>
       {children}

--- a/apps/admin/components/journey-controls/journey-controls.css
+++ b/apps/admin/components/journey-controls/journey-controls.css
@@ -188,3 +188,64 @@
   font-size: 12px;
   font-style: italic;
 }
+
+/* Lane 2 — RHS Inspector usability pass (post-Slice-C audit). */
+
+/* Saved-flash indicator: shows for the duration of `isActive` glow. */
+.hf-jf-saved-flash {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--status-success-text);
+  background: color-mix(in srgb, var(--status-success-text) 12%, transparent);
+  padding: 1px 6px;
+  border-radius: 999px;
+  animation: hf-jf-fadein 0.2s ease-out;
+}
+
+/* Unsaved indicator: replaces the bare dot with a clearer label. */
+.hf-jf-dirty-dot {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--status-warning-text);
+  background: color-mix(in srgb, var(--status-warning-text) 12%, transparent);
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+
+@keyframes hf-jf-fadein {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Empty-options fallback caption for JourneySelect. */
+.hf-jf-options-empty {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+  margin-top: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--surface-secondary) 60%, transparent);
+  border-left: 2px solid var(--border-default);
+  border-radius: 4px;
+}
+
+/* Compound (Stop / Phases) empty + summary layouts. */
+.hf-jf-compound-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: normal;
+}
+.hf-jf-compound-empty strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.hf-jf-compound-summary {
+  font-size: 12px;
+  font-style: normal;
+  color: var(--text-primary);
+}
+.hf-jf-compound-summary strong {
+  font-weight: 600;
+}

--- a/apps/admin/components/journey-tab/InspectorRowMenu.tsx
+++ b/apps/admin/components/journey-tab/InspectorRowMenu.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * InspectorRowMenu — Lane 2 RHS Inspector usability pass.
+ *
+ * Replaces the per-row `{} JSON` button (which dominated every row's
+ * visual weight in Slice C) with a single overflow `⋯` button. The
+ * power-user JSON path lives behind the menu, not as a foreground
+ * affordance.
+ *
+ * Operator feedback (4 screenshots, 2026-06-16): "I cannot believe you
+ * have a JSON button on every row." The fix: the JSON editor is still
+ * one click away — it's just no longer the dominant visual.
+ *
+ * Menu contains:
+ *   - Edit as JSON (advanced) — opens JsonEditorModal (the old behaviour)
+ *   - Copy current value — copies the JSON-stringified value to clipboard
+ *   - Copy storage path — copies the contract's storagePath for debug
+ *
+ * Replaces: EditAsJsonButton (kept around as the JSON-edit modal handler
+ * the menu invokes).
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { MoreHorizontal, Braces, Copy, Hash } from "lucide-react";
+
+import { JsonEditorModal } from "@/components/settings/JsonEditorModal";
+import { useJourneySetting } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+interface InspectorRowMenuProps {
+  contract: JourneySettingContract;
+  value: unknown;
+}
+
+function getStoragePathString(c: JourneySettingContract): string {
+  if (typeof c.storagePath === "string") return c.storagePath;
+  return c.storagePath.path;
+}
+
+function formatJson(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return "";
+  }
+}
+
+export function InspectorRowMenu({ contract, value }: InspectorRowMenuProps) {
+  const ctx = useJourneySetting();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [jsonOpen, setJsonOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!wrapRef.current) return;
+      if (!wrapRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [menuOpen]);
+
+  if (ctx.readonly || !ctx.courseId) return null;
+
+  const valueJson = formatJson(value);
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // ignore — copy is best-effort
+    }
+    setMenuOpen(false);
+  };
+
+  return (
+    <div
+      ref={wrapRef}
+      className="hf-inspector-row-menu-wrap"
+      data-testid={`hf-inspector-row-menu-${contract.id}`}
+    >
+      <button
+        type="button"
+        className="hf-inspector-row-menu-button"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        aria-label="Row actions"
+        title="More actions"
+        onClick={() => setMenuOpen((v) => !v)}
+        data-testid={`hf-inspector-row-menu-trigger-${contract.id}`}
+      >
+        <MoreHorizontal size={14} aria-hidden focusable="false" />
+      </button>
+      {menuOpen ? (
+        <div
+          className="hf-inspector-row-menu"
+          role="menu"
+          aria-label={`${contract.educatorLabel} actions`}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="hf-inspector-row-menu-item"
+            onClick={() => {
+              setMenuOpen(false);
+              setJsonOpen(true);
+            }}
+            data-testid={`hf-inspector-row-menu-edit-json-${contract.id}`}
+          >
+            <Braces size={12} aria-hidden focusable="false" />
+            <span>Edit as JSON</span>
+            <span className="hf-inspector-row-menu-hint">advanced</span>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="hf-inspector-row-menu-item"
+            onClick={() => void copyToClipboard(valueJson)}
+            disabled={!valueJson}
+            data-testid={`hf-inspector-row-menu-copy-value-${contract.id}`}
+          >
+            <Copy size={12} aria-hidden focusable="false" />
+            <span>Copy current value</span>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="hf-inspector-row-menu-item"
+            onClick={() => void copyToClipboard(getStoragePathString(contract))}
+            data-testid={`hf-inspector-row-menu-copy-path-${contract.id}`}
+          >
+            <Hash size={12} aria-hidden focusable="false" />
+            <span>Copy storage path</span>
+          </button>
+        </div>
+      ) : null}
+      <JsonEditorModal
+        isOpen={jsonOpen}
+        onClose={() => setJsonOpen(false)}
+        label={contract.educatorLabel}
+        settingKey={contract.id}
+        initialText={valueJson}
+        onSave={async (_key, parsed) => {
+          await ctx.saveSetting(contract.id, parsed);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
+++ b/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
@@ -26,7 +26,7 @@ import type {
 } from "@/lib/journey/setting-contracts";
 
 import { CascadeTraceBreadcrumb } from "./CascadeTraceBreadcrumb";
-import { EditAsJsonButton } from "./EditAsJsonButton";
+import { InspectorRowMenu } from "./InspectorRowMenu";
 import { WriteGateLockChip } from "./WriteGateLockChip";
 import { resolveValueAtPath } from "./resolve-value-at-path";
 
@@ -53,17 +53,19 @@ function SettingsStack({
             className="hf-journey-inspector-row"
             data-testid={`hf-journey-inspector-row-${contract.id}`}
           >
-            <CascadeTraceBreadcrumb contract={contract} />
-            <WriteGateLockChip contract={contract} />
+            <div className="hf-journey-inspector-row-head">
+              <div className="hf-journey-inspector-row-head-meta">
+                <CascadeTraceBreadcrumb contract={contract} />
+                <WriteGateLockChip contract={contract} />
+              </div>
+              <InspectorRowMenu contract={contract} value={value} />
+            </div>
             <JourneyField
               contract={contract}
               value={value}
               options={contract.options}
               onSave={(next) => ctx.saveSetting(contract.id, next)}
             />
-            <div className="hf-journey-inspector-actions">
-              <EditAsJsonButton contract={contract} value={value} />
-            </div>
           </div>
         );
       })}

--- a/apps/admin/components/journey-tab/journey-tab.css
+++ b/apps/admin/components/journey-tab/journey-tab.css
@@ -317,3 +317,95 @@
     display: none;
   }
 }
+
+/* Lane 2 — Inspector row head + overflow menu (post-Slice-C audit). */
+.hf-journey-inspector-row-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.hf-journey-inspector-row-head-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.hf-inspector-row-menu-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+.hf-inspector-row-menu-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.hf-inspector-row-menu-button:hover,
+.hf-inspector-row-menu-button[aria-expanded="true"] {
+  background: color-mix(in srgb, var(--surface-secondary) 70%, transparent);
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+.hf-inspector-row-menu {
+  position: absolute;
+  top: 26px;
+  right: 0;
+  min-width: 200px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px color-mix(in srgb, #000 10%, transparent);
+  padding: 4px 0;
+  z-index: 50;
+}
+.hf-inspector-row-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  font-size: 12px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.hf-inspector-row-menu-item:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--surface-secondary) 70%, transparent);
+}
+.hf-inspector-row-menu-item[disabled] {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+.hf-inspector-row-menu-hint {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+/* Lane 2 — promote scope subgroup headers to a real divider style. */
+.hf-journey-inspector-subgroup > .hf-category-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 6px 0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-default) 50%, transparent);
+}

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.35",
+      "version": "0.8.36",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/journey-tab/InspectorRowMenu.test.tsx
+++ b/apps/admin/tests/components/journey-tab/InspectorRowMenu.test.tsx
@@ -1,0 +1,122 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+  beforeEach,
+} from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+} from "@testing-library/react";
+
+import { InspectorRowMenu } from "@/components/journey-tab/InspectorRowMenu";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+const contract: JourneySettingContract = {
+  id: "welcomeMessage",
+  group: "G2",
+  educatorLabel: "Welcome message",
+  storagePath: "sessionFlow.welcomeMessage",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    } as Response),
+  );
+  // jsdom clipboard mock
+  Object.assign(navigator, {
+    clipboard: { writeText: vi.fn(() => Promise.resolve()) },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderInProvider(ui: React.ReactNode) {
+  return render(
+    <JourneySettingMutatorProvider courseId="c1" playbookConfig={{}}>
+      {ui}
+    </JourneySettingMutatorProvider>,
+  );
+}
+
+describe("InspectorRowMenu — Lane 2 RHS usability pass", () => {
+  it("renders nothing when readonly / no courseId", () => {
+    const { container } = render(
+      <JourneySettingMutatorProvider courseId={null} playbookConfig={{}}>
+        <InspectorRowMenu contract={contract} value="hi" />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(container.querySelector('[data-testid="hf-inspector-row-menu-welcomeMessage"] .hf-inspector-row-menu-button')).toBeNull();
+  });
+
+  it("renders the overflow trigger ⋯ button when wired", () => {
+    renderInProvider(<InspectorRowMenu contract={contract} value="hi" />);
+    expect(
+      screen.getByTestId("hf-inspector-row-menu-trigger-welcomeMessage"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the menu and exposes Edit as JSON / Copy current / Copy path actions", () => {
+    renderInProvider(<InspectorRowMenu contract={contract} value="hi" />);
+    fireEvent.click(
+      screen.getByTestId("hf-inspector-row-menu-trigger-welcomeMessage"),
+    );
+    expect(
+      screen.getByTestId("hf-inspector-row-menu-edit-json-welcomeMessage"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-inspector-row-menu-copy-value-welcomeMessage"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-inspector-row-menu-copy-path-welcomeMessage"),
+    ).toBeInTheDocument();
+  });
+
+  it("Copy storage path copies the contract's storagePath to clipboard", () => {
+    renderInProvider(<InspectorRowMenu contract={contract} value="hi" />);
+    fireEvent.click(
+      screen.getByTestId("hf-inspector-row-menu-trigger-welcomeMessage"),
+    );
+    fireEvent.click(
+      screen.getByTestId("hf-inspector-row-menu-copy-path-welcomeMessage"),
+    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "sessionFlow.welcomeMessage",
+    );
+  });
+
+  it("Edit as JSON opens the JSON modal", () => {
+    renderInProvider(<InspectorRowMenu contract={contract} value="hi" />);
+    fireEvent.click(
+      screen.getByTestId("hf-inspector-row-menu-trigger-welcomeMessage"),
+    );
+    fireEvent.click(
+      screen.getByTestId("hf-inspector-row-menu-edit-json-welcomeMessage"),
+    );
+    // The JsonEditorModal renders by setting body content; just verify
+    // some content from the modal title or textarea is reachable.
+    // The exact testid depends on JsonEditorModal — generic content
+    // check.
+    expect(document.body.textContent).toMatch(/Welcome message/);
+  });
+});


### PR DESCRIPTION
## Summary

Lane 2 of the post-Slice-C audit recovery. Closes the operator feedback from the 4 screenshots: "I cannot believe you have a JSON button on every row" + "no idea how to use the JSON" + "Stop editor mounts in Phase 3" + "Options load at runtime — use the JSON button to set".

Sibling: Lane 1 (#1780 — structural coverage check), Lane 3 (queued — contract-add follow-ons).

## What ships

| Issue | Fix |
|---|---|
| **`{} JSON` button on every row dominates the visual** | New `InspectorRowMenu.tsx` mounts a single `⋯` overflow button in the row head; the JSON-edit modal, Copy value, Copy storage path all live behind it. The JSON path is still one click — it's just no longer the foreground affordance. |
| **JourneySelect: "Options load at runtime — use the JSON button to set"** | Replaced with a real fallback: dropdown shows "Current: <value>" or "Not set", and a captioned hint below points the educator to the `⋯` menu. Stops blaming the operator for a non-fetched options list. |
| **"Stop editor mounts in Phase 3" / "Inline phase-editing ships in Phase 3."** | Dev notes leaking to production UI. Replaced with educator-targeted "Not configured. Use the ⋯ menu → Edit as JSON to set the stop shape." (or phase list). |
| **No visible save indicator** | `_FieldShell` now renders "✓ Saved" (green pill) during the post-save glow + "• Unsaved" (amber pill) when dirty. Educators see whether their change landed without having to decode the row-border glow. |
| **Scope subgroup headers "Course defaults" / "This module" were tiny grey caps** | Promoted to a bottom-border uppercase divider so the mixed-scope split reads at a glance. |

## What's NOT in this PR (intentional)

- Real Stop / Phases form editors → Phase 3 follow-on epic, not a UX fix
- Fetch-error state for `intakeSpecId` (needs loading-hook refactor) → small follow-on
- Full chip-overload consolidation (CASCADE + FROM DOMAIN + Operator-only + JSON) → JSON moved out; the rest is a separate visual pass

## Verified by

- **132/132 tests** across journey-controls + journey-tab + lib/journey
- 5 new vitests pin: readonly hides menu, trigger renders, menu items exist, copy storage path → clipboard, Edit JSON → modal opens
- ESLint clean, no new tsc errors

## Test plan

- [ ] \`/x/courses/<id>\` → Design tab → select any bucket. Confirm no \`{} JSON\` button on every row anymore; `⋯` button instead.
- [ ] Click `⋯` → confirm "Edit as JSON", "Copy current value", "Copy storage path" all present.
- [ ] Click "Copy storage path" → clipboard contains the contract's storagePath.
- [ ] Click "Edit as JSON" → JSON modal opens with the current value pre-filled.
- [ ] Select A_intake → "Intake form" — confirm the "use the JSON button" copy is gone; "No options available right now" hint shows below the dropdown.
- [ ] Select L_mid_journey → mid-journey stops show "Not configured. Use the ⋯ menu → Edit as JSON..." (not "mounts in Phase 3").
- [ ] Edit any toggle → confirm "✓ Saved" pill flashes for ~2s after save.
- [ ] Select a mixed-scope bucket (e.g. one with both course + module settings) → confirm "Course defaults" / "This module" subheaders now read clearly with divider.

## Lattice audit

UI change, not registry change. Pillars unchanged.