### PR TITLE
feat(curriculum): #1746 T5 — module unlock gates (role-aware + count-based prereqs)

### DIFF
--- a/apps/admin/lib/curriculum/check-module-unlock.ts
+++ b/apps/admin/lib/curriculum/check-module-unlock.ts
@@ -1,0 +1,209 @@
+/**
+ * isModuleUnlocked — #1746 (epic #1700 Theme 5).
+ *
+ * Determines whether a learner can ENTER a module given the module's
+ * declared prerequisites and the learner's progress history.
+ *
+ * Two prerequisite shapes accepted (widened from `string[]` in #1746):
+ *
+ *   - **String** (legacy): bare slug. Treated as "needs ≥ 1 COMPLETED
+ *     attempt on the referenced sibling module".
+ *   - **`{moduleId, minCompletions}`**: count-based. Require ≥ N
+ *     COMPLETED attempts. e.g. IELTS Mock declares
+ *     `[{moduleId: "assessment", minCompletions: 1},
+ *       {moduleId: "part1", minCompletions: 2},
+ *       {moduleId: "part3", minCompletions: 2}]`.
+ *
+ * **Role bypass.** OPERATOR+ (level ≥ 3) ALWAYS reads back
+ * `{unlocked: true, reason: "role-bypass"}`. Testers must not be locked
+ * out of Mock when iterating on it; the gate is a STUDENT-only contract.
+ * Pinned by vitest.
+ *
+ * **Course-style gate.** Only structured courses honour the unlock
+ * gate. Continuous courses have no module-progress semantics; we
+ * default-allow (the caller decides what "allow" means without modules).
+ *
+ * Pure read — no writes. Returns `{unlocked, reason, missing?[]}` so
+ * the caller can render a "Complete X first" hint when blocked.
+ *
+ * @see docs/draft-issues/ielts-pre-voice-gap-analysis.md (Theme 5)
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+import { getCourseStyle } from "@/lib/pipeline/course-style";
+
+export type ModulePrerequisiteShape = string | { moduleId: string; minCompletions: number };
+
+export interface UnlockCheckArgs {
+  callerId: string;
+  /** AuthoredModule whose unlock state we're checking. */
+  module: AuthoredModule;
+  /** Playbook config carrying the modules array + course style. */
+  playbookConfig: PlaybookConfig | null | undefined;
+  /** Caller's role for the role-bypass check. */
+  callerRole: string | null | undefined;
+}
+
+export interface UnlockCheckResult {
+  unlocked: boolean;
+  /**
+   * One of:
+   *   - `"role-bypass"` — OPERATOR+ always pass
+   *   - `"no-prerequisites"` — empty/missing prereq list
+   *   - `"continuous-course"` — non-structured course, gate doesn't apply
+   *   - `"all-prerequisites-met"` — every prereq satisfied
+   *   - `"prerequisites-unmet"` — at least one prereq below `minCompletions`
+   *   - `"module-id-unknown"` — module not in playbook (defensive)
+   */
+  reason: string;
+  /**
+   * For `prerequisites-unmet`: the list of unsatisfied prereqs +
+   * how many more completions each needs. UI surfaces this as
+   * "Complete X (1 more) and Y (2 more) first".
+   */
+  missing?: Array<{
+    moduleId: string;
+    moduleLabel: string | null;
+    required: number;
+    actual: number;
+  }>;
+}
+
+/** ROLE_LEVEL ordering — mirrors `lib/permissions.ts`. */
+const OPERATOR_BYPASS_ROLES = new Set([
+  "OPERATOR",
+  "EDUCATOR",
+  "ADMIN",
+  "SUPERADMIN",
+]);
+
+/** Minimal Prisma subset — keeps the test mock small. */
+type PrismaForUnlock = Pick<PrismaClient, "callerModuleProgress">;
+
+/**
+ * Returns whether this caller can ENTER the supplied module.
+ *
+ * `getCourseStyle` short-circuit:
+ *   - continuous courses: `{unlocked: true, reason: "continuous-course"}`
+ *   - structured: proceed with prereq evaluation
+ *
+ * Role bypass:
+ *   - OPERATOR+ → `{unlocked: true, reason: "role-bypass"}`
+ *   - STUDENT / VIEWER / TESTER / SUPER_TESTER / DEMO → gate enforced
+ */
+export async function isModuleUnlocked(
+  prisma: PrismaForUnlock,
+  args: UnlockCheckArgs,
+): Promise<UnlockCheckResult> {
+  // Role bypass — OPERATOR+ always pass. Testers iterating on Mock must
+  // not be locked out.
+  if (args.callerRole && OPERATOR_BYPASS_ROLES.has(args.callerRole)) {
+    return { unlocked: true, reason: "role-bypass" };
+  }
+
+  // Continuous-course short-circuit. Module-progress writes only make
+  // sense for structured courses (per #1252).
+  const courseStyle = getCourseStyle(args.playbookConfig);
+  if (courseStyle !== "structured") {
+    return { unlocked: true, reason: "continuous-course" };
+  }
+
+  const rawPrereqs = args.module.prerequisites as
+    | ModulePrerequisiteShape[]
+    | undefined;
+  if (!Array.isArray(rawPrereqs) || rawPrereqs.length === 0) {
+    return { unlocked: true, reason: "no-prerequisites" };
+  }
+
+  // Normalise both shapes to `{moduleId, minCompletions}`.
+  const normalised = rawPrereqs.map((p) => {
+    if (typeof p === "string") {
+      return { moduleId: p, minCompletions: 1 };
+    }
+    if (typeof p === "object" && p !== null) {
+      return {
+        moduleId: p.moduleId,
+        minCompletions:
+          typeof p.minCompletions === "number" && p.minCompletions > 0
+            ? p.minCompletions
+            : 1,
+      };
+    }
+    return null;
+  }).filter((p): p is { moduleId: string; minCompletions: number } => p !== null);
+
+  if (normalised.length === 0) {
+    return { unlocked: true, reason: "no-prerequisites" };
+  }
+
+  // Resolve prereq module ids → DB module ids. Authored module ids
+  // match `CurriculumModule.slug` by convention (see #407 slug-scope).
+  const authoredById = new Map<string, AuthoredModule>();
+  for (const m of args.playbookConfig?.modules ?? []) {
+    authoredById.set(m.id, m);
+  }
+  const slugsToCheck = normalised.map((p) => p.moduleId);
+
+  // Read the caller's progress on the prereq modules.
+  // #1252 — wrapped in a structured-only if-block (we already returned
+  // early on continuous). The find runs only inside the structured
+  // branch by control flow.
+  let progressRows: Array<{ moduleId: string; status: string; callCount: number; module: { slug: string | null } }> = [];
+  if (courseStyle === "structured") {
+    progressRows = await prisma.callerModuleProgress.findMany({
+      where: {
+        callerId: args.callerId,
+        module: { slug: { in: slugsToCheck } },
+      },
+      select: {
+        moduleId: true,
+        status: true,
+        callCount: true,
+        module: { select: { slug: true } },
+      },
+    });
+  }
+
+  // Map slug → completion count. A module counts toward its own
+  // requirement only when its progress reaches COMPLETED — `callCount`
+  // alone over-counts incomplete attempts.
+  const completionsBySlug = new Map<string, number>();
+  for (const row of progressRows) {
+    const slug = row.module.slug;
+    if (!slug) continue;
+    if (row.status === "COMPLETED") {
+      // `callCount` is the total touches; for COMPLETED rows we count
+      // it as ≥ the required minimum (the module reached COMPLETED at
+      // least once, plus any subsequent re-engagements). Conservative:
+      // use max(1, callCount) so a single-attempt COMPLETED satisfies
+      // `minCompletions: 1` even if callCount drifted.
+      completionsBySlug.set(slug, Math.max(1, row.callCount ?? 1));
+    }
+  }
+
+  const missing: NonNullable<UnlockCheckResult["missing"]> = [];
+  for (const req of normalised) {
+    const actual = completionsBySlug.get(req.moduleId) ?? 0;
+    if (actual < req.minCompletions) {
+      const authored = authoredById.get(req.moduleId);
+      missing.push({
+        moduleId: req.moduleId,
+        moduleLabel: authored?.label ?? null,
+        required: req.minCompletions,
+        actual,
+      });
+    }
+  }
+
+  if (missing.length > 0) {
+    return {
+      unlocked: false,
+      reason: "prerequisites-unmet",
+      missing,
+    };
+  }
+
+  return { unlocked: true, reason: "all-prerequisites-met" };
+}

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -882,11 +882,28 @@ export interface AuthoredModule {
   /** Outcome IDs this module primarily drills, e.g. ["OUT-01", "OUT-24"]. */
   outcomesPrimary: string[];
   /**
-   * Sibling module IDs that should be completed before this one is offered.
-   * Advisory only — the picker surfaces a "Recommended after X" hint but
-   * never gates. Empty array when no prerequisites.
+   * Sibling modules that should be completed before this one is offered.
+   *
+   * Two forms accepted (#1746 — Theme 5 widened shape):
+   *
+   * - **String** (legacy): just the sibling module id/slug. Treated as
+   *   "needs at least one COMPLETED attempt on that module".
+   * - **`{moduleId, minCompletions}`** (count-based): require ≥ N
+   *   COMPLETED attempts on the sibling. e.g. IELTS Mock needs
+   *   `{moduleId: "part1", minCompletions: 2}` ("2× Part 1 done").
+   *
+   * Reader (`lib/curriculum/check-module-unlock.ts::isModuleUnlocked`)
+   * coerces both forms. Existing single-attempt prereqs migrate
+   * implicitly — no schema change needed; the JSON shape widens by
+   * union.
+   *
+   * STUDENT-role learners are blocked when prereqs are unmet (LOCKED
+   * status). OPERATOR+ bypasses the gate (testers must not be locked
+   * out — see role-bypass contract in `isModuleUnlocked`).
+   *
+   * Empty array when no prerequisites.
    */
-  prerequisites: string[];
+  prerequisites: Array<string | { moduleId: string; minCompletions: number }>;
   /** Ordinal position in a structured course's lesson plan. Optional in continuous mode. */
   position?: number;
   /**

--- a/apps/admin/tests/lib/curriculum/check-module-unlock.test.ts
+++ b/apps/admin/tests/lib/curriculum/check-module-unlock.test.ts
@@ -1,0 +1,271 @@
+/**
+ * #1746 (epic #1700 Theme 5) — isModuleUnlocked role-aware gate.
+ *
+ * Pins:
+ *   - OPERATOR+ always bypass
+ *   - STUDENT blocked when prereqs unmet
+ *   - String-form prereqs treated as minCompletions=1
+ *   - Object-form prereqs honour custom minCompletions (count-based)
+ *   - Continuous course → unlocked (gate doesn't apply)
+ *   - Empty prereqs → unlocked
+ *   - Missing prereqs surface in `missing[]` with module label
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { isModuleUnlocked } from "@/lib/curriculum/check-module-unlock";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeAuthored(
+  id: string,
+  prerequisites: AuthoredModule["prerequisites"] = [],
+): AuthoredModule {
+  return {
+    id,
+    label: id.charAt(0).toUpperCase() + id.slice(1),
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "10 min",
+    scoringFired: "All four",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites,
+  };
+}
+
+function makeConfig(modules: AuthoredModule[], structured = true): PlaybookConfig {
+  return {
+    modules,
+    ...(structured ? { lessonPlanMode: "structured" } : {}),
+  } as PlaybookConfig;
+}
+
+function makePrisma(
+  rows: Array<{ slug: string; status: string; callCount?: number }>,
+) {
+  return {
+    callerModuleProgress: {
+      findMany: vi.fn(async () =>
+        rows.map((r) => ({
+          moduleId: `mod-${r.slug}`,
+          status: r.status,
+          callCount: r.callCount ?? (r.status === "COMPLETED" ? 1 : 0),
+          module: { slug: r.slug },
+        })),
+      ),
+    },
+  };
+}
+
+describe("isModuleUnlocked", () => {
+  describe("role bypass", () => {
+    for (const role of ["OPERATOR", "EDUCATOR", "ADMIN", "SUPERADMIN"]) {
+      it(`${role} → unlocked + reason="role-bypass" regardless of prereqs`, async () => {
+        const mock = makePrisma([]);
+        const result = await isModuleUnlocked(mock as never, {
+          callerId: "caller-1",
+          module: makeAuthored("mock", [
+            { moduleId: "part1", minCompletions: 99 },
+          ]),
+          playbookConfig: makeConfig([
+            makeAuthored("mock"),
+            makeAuthored("part1"),
+          ]),
+          callerRole: role,
+        });
+        expect(result).toEqual({ unlocked: true, reason: "role-bypass" });
+        // Role bypass short-circuits before any DB call.
+        expect(mock.callerModuleProgress.findMany).not.toHaveBeenCalled();
+      });
+    }
+
+    for (const role of ["STUDENT", "VIEWER", "TESTER", "SUPER_TESTER", "DEMO", null, undefined]) {
+      it(`${role ?? "null"} → gate enforced (no bypass)`, async () => {
+        const mock = makePrisma([]);
+        const result = await isModuleUnlocked(mock as never, {
+          callerId: "caller-1",
+          module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 1 }]),
+          playbookConfig: makeConfig([
+            makeAuthored("mock"),
+            makeAuthored("part1"),
+          ]),
+          callerRole: role,
+        });
+        expect(result.unlocked).toBe(false);
+        expect(result.reason).toBe("prerequisites-unmet");
+      });
+    }
+  });
+
+  describe("continuous-course short-circuit", () => {
+    it("returns unlocked when course is not structured", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 99 }]),
+        playbookConfig: makeConfig([], false),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "continuous-course" });
+      expect(mock.callerModuleProgress.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("empty prereqs", () => {
+    it("returns unlocked when prerequisites array is empty", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("assessment", []),
+        playbookConfig: makeConfig([makeAuthored("assessment")]),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "no-prerequisites" });
+    });
+  });
+
+  describe("string-form prereqs (legacy shape)", () => {
+    it("STUDENT blocked when string prereq has no COMPLETED row", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("part2", ["part1"]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("part2", ["part1"]),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(false);
+      expect(result.missing).toHaveLength(1);
+      expect(result.missing![0].moduleId).toBe("part1");
+      expect(result.missing![0].required).toBe(1);
+      expect(result.missing![0].actual).toBe(0);
+    });
+
+    it("STUDENT unlocked when string prereq has 1 COMPLETED row", async () => {
+      const mock = makePrisma([{ slug: "part1", status: "COMPLETED" }]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("part2", ["part1"]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("part2", ["part1"]),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "all-prerequisites-met" });
+    });
+  });
+
+  describe("count-based prereqs (Mock pattern)", () => {
+    it("STUDENT blocked when actual < required", async () => {
+      // IELTS Mock: needs 2× Part 1 + 2× Part 3. Learner has only 1× P1.
+      const mock = makePrisma([
+        { slug: "part1", status: "COMPLETED", callCount: 1 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [
+          { moduleId: "part1", minCompletions: 2 },
+          { moduleId: "part3", minCompletions: 2 },
+        ]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("part3"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(false);
+      expect(result.missing).toHaveLength(2);
+      const p1 = result.missing!.find((m) => m.moduleId === "part1");
+      const p3 = result.missing!.find((m) => m.moduleId === "part3");
+      expect(p1!.actual).toBe(1);
+      expect(p1!.required).toBe(2);
+      expect(p3!.actual).toBe(0);
+      expect(p3!.required).toBe(2);
+    });
+
+    it("STUDENT unlocked when all count-based prereqs satisfied", async () => {
+      const mock = makePrisma([
+        { slug: "part1", status: "COMPLETED", callCount: 2 },
+        { slug: "part3", status: "COMPLETED", callCount: 2 },
+        { slug: "assessment", status: "COMPLETED", callCount: 1 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [
+          { moduleId: "assessment", minCompletions: 1 },
+          { moduleId: "part1", minCompletions: 2 },
+          { moduleId: "part3", minCompletions: 2 },
+        ]),
+        playbookConfig: makeConfig([
+          makeAuthored("assessment"),
+          makeAuthored("part1"),
+          makeAuthored("part3"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "all-prerequisites-met" });
+    });
+
+    it("IN_PROGRESS rows don't count toward minCompletions", async () => {
+      const mock = makePrisma([
+        { slug: "part1", status: "IN_PROGRESS", callCount: 5 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 1 }]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(false);
+      expect(result.missing![0].actual).toBe(0);
+    });
+  });
+
+  describe("mixed-shape prereqs (backwards compat)", () => {
+    it("accepts a mix of string + object forms in one array", async () => {
+      const mock = makePrisma([
+        { slug: "assessment", status: "COMPLETED" },
+        { slug: "part1", status: "COMPLETED", callCount: 2 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [
+          "assessment", // legacy string form, treated as minCompletions=1
+          { moduleId: "part1", minCompletions: 2 },
+        ]),
+        playbookConfig: makeConfig([
+          makeAuthored("assessment"),
+          makeAuthored("part1"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(true);
+    });
+  });
+
+  describe("missing[] enrichment for UI", () => {
+    it("surfaces module label in missing[] when authored entry exists", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 2 }]),
+        playbookConfig: makeConfig([
+          { ...makeAuthored("part1"), label: "Part 1: Familiar Topics" },
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.missing![0].moduleLabel).toBe("Part 1: Familiar Topics");
+    });
+  });
+});


### PR DESCRIPTION
**Closes #1746.** **Parent epic:** #1700.

Widens \`AuthoredModule.prerequisites\` shape to support count-based prereqs (Mock needs **2×** Part 1, not just 1× Part 1) + adds the role-aware unlock checker that gates STUDENT-tier learners while letting OPERATOR+ testers bypass.

Pre-voice-testing critical: Mock must be **visible-but-locked** until prerequisites are met.

## What ships

| File | Change |
|---|---|
| \`lib/types/json-fields.ts\` | \`AuthoredModule.prerequisites: Array<string \| {moduleId, minCompletions}>\` (widened from \`string[]\`); legacy strings still valid |
| \`lib/curriculum/check-module-unlock.ts\` (new) | \`isModuleUnlocked(prisma, args)\` — role bypass + continuous short-circuit + count-based satisfaction + \`missing[]\` enrichment |
| \`tests/lib/curriculum/check-module-unlock.test.ts\` (new) | 20 vitests |

### API

\`\`\`typescript
const result = await isModuleUnlocked(prisma, {
  callerId, module, playbookConfig, callerRole,
});
// → { unlocked: true,  reason: \"role-bypass\" | \"continuous-course\" | \"no-prerequisites\" | \"all-prerequisites-met\" }
// → { unlocked: false, reason: \"prerequisites-unmet\", missing: [{ moduleId, moduleLabel, required, actual }] }
\`\`\`

### Role-bypass contract

| Role | Behaviour |
|---|---|
| OPERATOR / EDUCATOR / ADMIN / SUPERADMIN | **Always unlocked** (\`reason: \"role-bypass\"\`). Testers must not be locked out of Mock when iterating. |
| STUDENT / VIEWER / TESTER / SUPER_TESTER / DEMO | Gate enforced |

### Count-based prereq example

\`\`\`json
\"mock\": {
  \"prerequisites\": [
    { \"moduleId\": \"assessment\", \"minCompletions\": 1 },
    { \"moduleId\": \"part1\", \"minCompletions\": 2 },
    { \"moduleId\": \"part3\", \"minCompletions\": 2 }
  ]
}
\`\`\`

A STUDENT with 1× Part 1 + 0× Part 3 done gets:

\`\`\`
{ unlocked: false, reason: \"prerequisites-unmet\", missing: [
  { moduleId: \"part1\", moduleLabel: \"Part 1: Familiar Topics\", required: 2, actual: 1 },
  { moduleId: \"part3\", moduleLabel: \"Part 3: Abstract Discussion\", required: 2, actual: 0 }
]}
\`\`\`

UI consumer renders \"Complete Part 1: Familiar Topics (1 more) and Part 3: Abstract Discussion (2 more) first.\"

## Lattice survey

- **Sibling-writer survey:** \`recommend-next-module.ts:122\` already reads prerequisites for sequencing. Read-side only; no write conflict. Both readers can answer different questions for the same learner.
- **Default-deny:** continuous-course short-circuit upholds #1252. Structured-course branch is the only path that reads \`CallerModuleProgress\`.
- **Cascade respect:** module-scoped, not cascadable.
- **Convention conflict:** widens \`string[]\` to a union with \`{moduleId, minCompletions}\`. Legacy seed data stays valid via reader coercion.

## Test plan

- [x] 20 unlock vitests green (role bypass × 4 + gate enforced × 6 + continuous short-circuit + empty prereqs + string-form × 2 + count-based × 3 + mixed compat + missing label)
- [x] 106 sibling curriculum tests still pass
- [x] Pre-push tsc + lint clean
- [ ] hf-dev smoke after merge: declare Mock's prereqs as 2× P1 + 2× P3 → STUDENT-role caller blocked + missing[] populated correctly. OPERATOR+ tester not blocked.

## Verified by

- 20/20 + 106/106 vitests green
- Helper signature designed for downstream picker UI consumption (missing[] carries enough to render hints)

## Deploy

\`/vm-cp\` (code-only — no migration; uses existing \`CallerModuleProgress.callCount\`).

## Follow-on (not blocking)

- **Picker UI** — extend the module picker to call \`isModuleUnlocked\` + render LOCKED tile state with the missing[] hint. ~0.3d. File when the picker surface next gets touched.