### PR TITLE
feat(journey): Lane 3 PR1 — A_intake (intakeGoals + intakeAiIntroCall + intakeKnowledgeCheckMode)

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -84,6 +84,70 @@ const G1_INTAKE_ABOUT_YOU: JourneySettingContract = {
   previewLocators: [{ section: "intake", hint: "about-you block" }],
 };
 
+// Lane 3 — A_intake contracts (catch-up follow-on from #1780).
+// The "AI Intro Call" bubble was the originally-spotted gap (operator
+// clicked it on the Preview canvas; the Inspector had no control for
+// it). This entry closes that gap; sibling entries below complete
+// A_intake coverage.
+
+const G1_INTAKE_GOALS: JourneySettingContract = {
+  id: "intakeGoals",
+  menuGroupKey: "A_intake",
+  group: "G1",
+  educatorLabel: "Pre-call learner goals",
+  helpText:
+    "Show the learner-goals capture block in the sign-up form so learners declare what they want to work on before Call 1.",
+  storagePath: "sessionFlow.intake.goals",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "learner-goals block" }],
+};
+
+const G1_INTAKE_AI_INTRO_CALL: JourneySettingContract = {
+  id: "intakeAiIntroCall",
+  menuGroupKey: "A_intake",
+  group: "G1",
+  educatorLabel: "AI Intro Call after sign-up",
+  helpText:
+    "Optional 1–2 min AI call right after sign-up to confirm name + level + give the learner a low-stakes taste of the voice surface before Call 1.",
+  storagePath: "sessionFlow.intake.aiIntroCall",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-enable"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "AI Intro Call card" }],
+};
+
+const G1_INTAKE_KNOWLEDGE_CHECK_MODE: JourneySettingContract = {
+  id: "intakeKnowledgeCheckMode",
+  menuGroupKey: "A_intake",
+  group: "G1",
+  educatorLabel: "Knowledge check delivery mode",
+  helpText:
+    "MCQ batch (post Call 1) vs Socratic probe (in Call 1). Implemented in #222; only relevant when the parent Knowledge check toggle is on.",
+  storagePath: "sessionFlow.intake.knowledgeCheck.deliveryMode",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "knowledge check block" }],
+  options: [
+    { value: "mcq", label: "MCQ batch (post Call 1)" },
+    { value: "socratic", label: "Socratic probe (in Call 1)" },
+  ],
+};
+
 const G1_INTAKE_SKIP_IF_RETURNING: JourneySettingContract = {
   id: "intakeSkipIfReturning",
   menuGroupKey: "A_intake",
@@ -1095,6 +1159,9 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G1_INTAKE_SPEC_ID,
   G1_INTAKE_KNOWLEDGE_CHECK,
   G1_INTAKE_ABOUT_YOU,
+  G1_INTAKE_GOALS,
+  G1_INTAKE_AI_INTRO_CALL,
+  G1_INTAKE_KNOWLEDGE_CHECK_MODE,
   G1_INTAKE_SKIP_IF_RETURNING,
   G1_INTAKE_CONSENT_FLOW,
   // G2 (6)

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.36",
+      "version": "0.8.37",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
+++ b/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
@@ -22,12 +22,13 @@ describe("CommandPalette — Phase 5 (#1706)", () => {
     expect(screen.getByTestId("hf-cmdk-input")).toBeInTheDocument();
   });
 
-  it("indexes all 63 settings (52 journey + 11 voice)", () => {
+  it("indexes all 66 settings (55 journey + 11 voice)", () => {
     // #1701 (Theme 1) added 6 G8 entries → journey 45 → 51 → palette 56 → 62.
     // #1747 (Theme 7) added talkTimeBudgets (G7) → journey 51 → 52 → palette 62 → 63.
-    expect(JOURNEY_SETTINGS.length).toBe(52);
+    // Lane 3 PR1 added 3 A_intake (G1) entries → journey 52 → 55 → palette 63 → 66.
+    expect(JOURNEY_SETTINGS.length).toBe(55);
     expect(VOICE_SETTINGS.length).toBe(11);
-    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(63);
+    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(66);
   });
 
   it("typing narrows results by substring on educatorLabel", () => {

--- a/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
+++ b/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
@@ -72,8 +72,8 @@ describe("JourneyLhMenu — Slice C (#1721) bucket-grained menu", () => {
         onFilterChange={vi.fn()}
       />,
     );
-    // A_intake has 5 settings stamped to it.
+    // A_intake has 8 settings stamped to it (Lane 3 PR1 added 3).
     const row = screen.getByTestId("hf-journey-bucket-row-A_intake");
-    expect(row.textContent).toMatch(/5/);
+    expect(row.textContent).toMatch(/8/);
   });
 });

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -88,7 +88,10 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
   });
 
   it("(7) exact group counts match the audit", () => {
-    expect(JOURNEY_SETTINGS_BY_GROUP.G1.length).toBe(5);
+    // Lane 3 PR1 — A_intake (G1) gained 3 contracts: intakeGoals,
+    // intakeAiIntroCall, intakeKnowledgeCheckMode (catch-up follow-on
+    // from #1780 coverage audit).
+    expect(JOURNEY_SETTINGS_BY_GROUP.G1.length).toBe(8);
     expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(6);
     expect(JOURNEY_SETTINGS_BY_GROUP.G3.length).toBe(4);
     expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(17);
@@ -100,8 +103,8 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G8.length).toBe(6);
   });
 
-  it("(8) JOURNEY_SETTINGS.length === 52", () => {
-    expect(JOURNEY_SETTINGS.length).toBe(52);
+  it("(8) JOURNEY_SETTINGS.length === 55", () => {
+    expect(JOURNEY_SETTINGS.length).toBe(55);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {

--- a/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
@@ -295,12 +295,13 @@ const REGISTRY_EXEMPT_PATHS: Record<string, string> = {
   // These will graduate to covered as each contract lands. The exempt
   // entry exists so CI doesn't block the structural test ship while we
   // queue the contract-add PRs.
-  "sessionFlow.intake.goals":
-    "catch-up: intakeGoals contract pending (A_intake bucket)",
-  "sessionFlow.intake.aiIntroCall":
-    "catch-up: intakeAiIntroCall contract pending (A_intake bucket) — user spotted",
-  "sessionFlow.intake.knowledgeCheck.deliveryMode":
-    "catch-up: intakeKnowledgeCheckMode contract pending (A_intake bucket)",
+  // ── A_intake — graduated to contracts (Lane 3 PR1) ───────────────
+  // The 3 A_intake catch-up exempts moved into the registry:
+  //   - intakeGoals → sessionFlow.intake.goals
+  //   - intakeAiIntroCall → sessionFlow.intake.aiIntroCall (user-spotted gap)
+  //   - intakeKnowledgeCheckMode → sessionFlow.intake.knowledgeCheck.deliveryMode
+  // Coverage is satisfied via getStoragePathString lookup over
+  // JOURNEY_SETTINGS.
   "config.firstCallCourseIntro":
     "catch-up: firstCallCourseIntro contract pending (B_call1_opening bucket) — #1403",
   "config.firstCallWaitForAck":
@@ -504,7 +505,9 @@ describe("Registry ↔ Schema coverage — 5th Lattice piece", () => {
     const catchUpCount = Array.from(exempt).filter((path) =>
       REGISTRY_EXEMPT_PATHS[path]?.startsWith("catch-up:"),
     ).length;
-    const BASELINE_CATCH_UP_CEILING = 36;
+    // Lane 3 PR1 (A_intake) — ratchet dropped 36 → 33 as the 3 A_intake
+    // exempts graduated to contracts.
+    const BASELINE_CATCH_UP_CEILING = 33;
     expect(
       catchUpCount,
       `catch-up exempts: ${catchUpCount} (ceiling ${BASELINE_CATCH_UP_CEILING}). If this went UP, you exempted a new field — add the contract instead.`,


### PR DESCRIPTION
## Summary

First Lane 3 contract-add from #1780 (registry-schema-coverage). **Closes the originally-spotted gap** — \`intakeAiIntroCall\`. The operator clicked "AI Intro Call" on Preview, Inspector had no control. Now it does.

Sibling: Lane 1 (#1780) · Lane 2 (#1784) · Lane 3 (this is PR1 of ~8).

## Contracts

| id | storagePath | control | menuGroupKey |
|---|---|---|---|
| intakeGoals | sessionFlow.intake.goals | toggle | A_intake |
| **intakeAiIntroCall** | sessionFlow.intake.aiIntroCall | toggle | A_intake |
| intakeKnowledgeCheckMode | sessionFlow.intake.knowledgeCheck.deliveryMode | select (mcq / socratic) | A_intake |

## Ratchet

\`BASELINE_CATCH_UP_CEILING\` drops 36 → 33. The catch-up exempt block in \`registry-schema-coverage.test.ts\` graduates these 3 paths out, with a comment marker for audit trail.

## Updated pins

- \`JOURNEY_SETTINGS_BY_GROUP.G1.length\` 5 → 8
- \`JOURNEY_SETTINGS.length\` 52 → 55
- \`COMMAND_PALETTE_INDEX_SIZE\` 63 → 66
- \`JourneyLhMenu\` A_intake count chip 5 → 8

## Verified by

- 216/216 tests across journey + cascade banks
- ESLint clean, no new tsc errors

## Test plan

- [ ] \`/x/courses/<id>\` → Design tab → A_intake bucket. Confirm 8 rows including "Pre-call learner goals", "AI Intro Call after sign-up", "Knowledge check delivery mode"
- [ ] Toggle "AI Intro Call after sign-up" → Save → "✓ Saved" pill flashes
- [ ] Reload page — toggle persists
- [ ] Click "AI Intro Call" Preview bubble → Inspector mounts A_intake bucket with intakeAiIntroCall row visible (the original-spotted gap is closed)

## Lane 3 queue (7 PRs remaining)

| PR# | Bucket | Contracts |
|---|---|---|
| 2 | B_call1_opening | firstCallCourseIntro, firstCallWaitForAck, firstCallDurationOverride, firstCallIntroducePedagogy (4) |
| 3 | C_teaching_style | shareMaterials (1) |
| 4 | I_scoring | tierPresetId, skillMinCallsToFull (2) |
| 5 | J_feedback | progressNarrative.* (4) + priorCallRecap.* (3) (7) |
| 6 | K_between_calls | interleaveReviewMinDays (1) |
| 7 | L_mid_journey | nps.* (3) |
| 8 | M_end_of_course | offboardingSummary.* (5) + offboarding.* (2 — needs sessionFlow.offboarding disambiguation) (7) |

Tolerances (4) + ambiguous overlaps (2) need separate small disambiguation PRs.

When the catch-up count reaches 0, the BA failure is fully closed.