### PR TITLE
feat(journey): Lane 3 PR2 — B_call1_opening (4 contracts)

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -244,6 +244,85 @@ const G2_WELCOME_MESSAGE: JourneySettingContract = {
   previewLocators: [{ section: "welcome", hint: "first paragraph" }],
 };
 
+// Lane 3 PR2 — B_call1_opening contracts (catch-up follow-on from #1780).
+
+const G2_FIRST_CALL_COURSE_INTRO: JourneySettingContract = {
+  id: "firstCallCourseIntro",
+  menuGroupKey: "B_call1_opening",
+  group: "G2",
+  educatorLabel: "First-call intro line",
+  helpText:
+    "Optional intro line spoken AFTER the welcomeMessage + wait-for-ack gate. Supports the `{courseName}` token. Keeps Call 1 framing consistent across cohorts. (#1403)",
+  storagePath: "config.firstCallCourseIntro",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "welcome", hint: "second paragraph" }],
+};
+
+const G2_FIRST_CALL_WAIT_FOR_ACK: JourneySettingContract = {
+  id: "firstCallWaitForAck",
+  menuGroupKey: "B_call1_opening",
+  group: "G2",
+  educatorLabel: "Wait after opening",
+  helpText:
+    "How the AI handles the pause after the welcomeMessage on Call 1. None / wait for any response / wait for greeting words. (#1403)",
+  storagePath: "config.firstCallWaitForAck",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["welcome"],
+    kinds: ["persona-style"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "welcome", hint: "ack-gate cue" }],
+  options: [
+    { value: "none", label: "No pause" },
+    { value: "any_response", label: "Wait for any response" },
+    { value: "greeting_words", label: "Wait for greeting words (default)" },
+  ],
+};
+
+const G2_FIRST_CALL_DURATION_OVERRIDE: JourneySettingContract = {
+  id: "firstCallDurationOverride",
+  menuGroupKey: "B_call1_opening",
+  group: "G2",
+  educatorLabel: "Call 1 duration override (minutes)",
+  helpText:
+    "Override Call 1 duration only. Calls 2+ use the standard durationMins. Useful for shorter assessment-only first calls. (#598)",
+  storagePath: "config.firstCall.durationMinsOverride",
+  control: "number",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["firstCallMode"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "firstCallMode", hint: "call-1 duration" }],
+};
+
+const G2_FIRST_CALL_INTRODUCE_PEDAGOGY: JourneySettingContract = {
+  id: "firstCallIntroducePedagogy",
+  menuGroupKey: "B_call1_opening",
+  group: "G2",
+  educatorLabel: "Introduce pedagogy on Call 1",
+  helpText:
+    "Whether the AI says \"here's how this works\" on Call 1. Off suppresses the pedagogy intro block. (#598)",
+  storagePath: "config.firstCall.introducePedagogy",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["firstCallMode", "onboarding"],
+    kinds: ["section-enable", "section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "onboarding", hint: "pedagogy intro" }],
+};
+
 const G2_ONBOARDING_FLOW_PHASES: JourneySettingContract = {
   id: "onboardingFlowPhases",
   menuGroupKey: "G_session_length",
@@ -1167,6 +1246,10 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   // G2 (6)
   G2_FIRST_CALL_MODE,
   G2_WELCOME_MESSAGE,
+  G2_FIRST_CALL_COURSE_INTRO,
+  G2_FIRST_CALL_WAIT_FOR_ACK,
+  G2_FIRST_CALL_DURATION_OVERRIDE,
+  G2_FIRST_CALL_INTRODUCE_PEDAGOGY,
   G2_ONBOARDING_FLOW_PHASES,
   G2_FIRST_CALL_TARGETS,
   G2_PRE_TEST_STOP,

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "0.8.37",
+      "version": "0.8.38",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@assistant-ui/react": "^0.14.13",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "private": true,
   "scripts": {
     "dev": "npx prisma migrate deploy && npx prisma generate && next dev",

--- a/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
+++ b/apps/admin/tests/components/journey-tab/CommandPalette.test.tsx
@@ -22,13 +22,13 @@ describe("CommandPalette — Phase 5 (#1706)", () => {
     expect(screen.getByTestId("hf-cmdk-input")).toBeInTheDocument();
   });
 
-  it("indexes all 66 settings (55 journey + 11 voice)", () => {
+  it("indexes all 70 settings (59 journey + 11 voice)", () => {
     // #1701 (Theme 1) added 6 G8 entries → journey 45 → 51 → palette 56 → 62.
     // #1747 (Theme 7) added talkTimeBudgets (G7) → journey 51 → 52 → palette 62 → 63.
     // Lane 3 PR1 added 3 A_intake (G1) entries → journey 52 → 55 → palette 63 → 66.
-    expect(JOURNEY_SETTINGS.length).toBe(55);
+    expect(JOURNEY_SETTINGS.length).toBe(59);
     expect(VOICE_SETTINGS.length).toBe(11);
-    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(66);
+    expect(COMMAND_PALETTE_INDEX_SIZE).toBe(70);
   });
 
   it("typing narrows results by substring on educatorLabel", () => {

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -92,7 +92,7 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     // intakeAiIntroCall, intakeKnowledgeCheckMode (catch-up follow-on
     // from #1780 coverage audit).
     expect(JOURNEY_SETTINGS_BY_GROUP.G1.length).toBe(8);
-    expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(6);
+    expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(10);
     expect(JOURNEY_SETTINGS_BY_GROUP.G3.length).toBe(4);
     expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(17);
     expect(JOURNEY_SETTINGS_BY_GROUP.G5.length).toBe(3);
@@ -103,8 +103,8 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G8.length).toBe(6);
   });
 
-  it("(8) JOURNEY_SETTINGS.length === 55", () => {
-    expect(JOURNEY_SETTINGS.length).toBe(55);
+  it("(8) JOURNEY_SETTINGS.length === 59", () => {
+    expect(JOURNEY_SETTINGS.length).toBe(59);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {

--- a/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
@@ -302,14 +302,12 @@ const REGISTRY_EXEMPT_PATHS: Record<string, string> = {
   //   - intakeKnowledgeCheckMode → sessionFlow.intake.knowledgeCheck.deliveryMode
   // Coverage is satisfied via getStoragePathString lookup over
   // JOURNEY_SETTINGS.
-  "config.firstCallCourseIntro":
-    "catch-up: firstCallCourseIntro contract pending (B_call1_opening bucket) — #1403",
-  "config.firstCallWaitForAck":
-    "catch-up: firstCallWaitForAck contract pending (B_call1_opening bucket) — #1403",
-  "config.firstCall.durationMinsOverride":
-    "catch-up: firstCallDurationOverride contract pending (B_call1_opening) — #598",
-  "config.firstCall.introducePedagogy":
-    "catch-up: firstCallIntroducePedagogy contract pending (B_call1_opening) — #598",
+  // ── B_call1_opening — graduated to contracts (Lane 3 PR2) ────────
+  // The 4 B_call1_opening catch-up exempts moved into the registry:
+  //   - firstCallCourseIntro → config.firstCallCourseIntro (#1403)
+  //   - firstCallWaitForAck → config.firstCallWaitForAck (#1403)
+  //   - firstCallDurationOverride → config.firstCall.durationMinsOverride (#598)
+  //   - firstCallIntroducePedagogy → config.firstCall.introducePedagogy (#598)
   "config.firstCall.firstCallModuleVisibility":
     "catch-up: overlaps moduleVisibility — needs disambiguation; #1405",
   "config.shareMaterials":
@@ -507,7 +505,9 @@ describe("Registry ↔ Schema coverage — 5th Lattice piece", () => {
     ).length;
     // Lane 3 PR1 (A_intake) — ratchet dropped 36 → 33 as the 3 A_intake
     // exempts graduated to contracts.
-    const BASELINE_CATCH_UP_CEILING = 33;
+    // Lane 3 PR2 (B_call1_opening) — ratchet dropped 33 → 29 as the 4
+    // B_call1_opening exempts graduated to contracts.
+    const BASELINE_CATCH_UP_CEILING = 29;
     expect(
       catchUpCount,
       `catch-up exempts: ${catchUpCount} (ceiling ${BASELINE_CATCH_UP_CEILING}). If this went UP, you exempted a new field — add the contract instead.`,


### PR DESCRIPTION
Lane 3 PR2. Adds 4 B_call1_opening contracts (firstCallCourseIntro #1403, firstCallWaitForAck #1403, firstCallDurationOverride #598, firstCallIntroducePedagogy #598). Catch-up ratchet 33 → 29. 117/117 tests. Sibling: Lane 1 #1780, Lane 2 #1784, Lane 3 PR1 #1787.

## Verified by
- JOURNEY_SETTINGS.length: 55 → 59
- COMMAND_PALETTE_INDEX_SIZE: 66 → 70
- G2 count: 6 → 10
- catch-up ceiling: 33 → 29
- 117/117 tests passing