### PR TITLE
feat(ci): #1725 auto-deploy DEV on push to main

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,12 @@ name: Deploy to Staging
 # preserve the repository_dispatch token reference.
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'memory/**'
   workflow_dispatch:
   repository_dispatch:
     types: [deploy-dev, deploy-staging]
@@ -115,7 +121,7 @@ jobs:
         run: |
           gcloud run jobs update hf-seed-dev \
             --image=${{ env.REGISTRY }}/hf-seed:dev \
-            --set-env-vars=SEED_PROFILE=full \
+            --set-env-vars=SEED_PROFILE=demo \
             --region=${{ env.REGION }}
           gcloud run jobs execute hf-seed-dev \
             --region=${{ env.REGION }} --wait


### PR DESCRIPTION
## Summary

- Adds `push: branches: [main]` trigger to `deploy-dev.yml` so every merge auto-deploys `hf-admin-dev`
- `paths-ignore` skips docs-only commits (`**.md`, `.github/ISSUE_TEMPLATE/**`, `memory/**`) — no wasted Cloud Build run on README/CLAUDE.md edits
- Switches `SEED_PROFILE` from `full` → `demo` per locked decision H — gives DEV a clean named-caller baseline without e2e fixtures

Closes #1725.

## Verified by

- `demo` profile exists and is defined at `apps/admin/prisma/seed-full.ts:13` ("DEMO — clean demo data, no e2e junk") — confirmed via grep
- Profile composition verified at `apps/admin/prisma/seed-full.ts:74-90`: `demo` includes foundation (run-configs + dedup), seed-golden, seed-demo-course, seed-demo-logins. Excludes seed-e2e (test fixtures). Exactly the surface decision H asked for.
- `workflow_dispatch` + `repository_dispatch` triggers preserved — no regression to manual deploy paths
- Diff is minimal (7 insertions, 1 deletion in one file)
- [unverified] Runtime: the workflow actually firing on push-to-main requires this PR to merge first. Will verify post-merge by watching the Actions tab on the first non-docs commit after this lands. Rollback is a 60s `gcloud run services update-traffic hf-admin-dev --to-revisions=PREV=100`.

## Out of scope

- Renaming the workflow name "Deploy to Staging" → "Deploy to DEV" (belongs to S1b #1769, naming sweep)
- Updating the outdated top-of-file comment that references "Phase 4 renames to hf-admin-staging" (also S1b — locked decision L says hf-admin-dev stays as DEV)
- Adding branch protection on main (S7 #1731 — needs the `hf-vm-bot` machine user prereq first)

## Test plan

- [x] YAML diff reviewed — trigger + paths-ignore + seed profile only
- [x] `demo` profile composition verified against `seed-full.ts:74-90`
- [ ] Post-merge: push a no-op commit to main, watch Actions tab fire, verify Cloud Run revision rotates on `hf-admin-dev`
- [ ] Post-merge: `curl https://dev.humanfirstfoundation.com/api/health` returns 200
- [ ] Post-merge: confirm `gcloud run jobs executions list --job=hf-seed-dev --region=europe-west2 --limit=1` shows recent SUCCEEDED run with `SEED_PROFILE=demo` in env

🤖 Generated with [Claude Code](https://claude.com/claude-code)