### PR TITLE
docs(dr): #1756 DR-POSTURE.md + patch CLOUD-DEPLOYMENT.md footgun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,7 @@ These memory files are kept in sync with the codebase. Consult them first.
 | [memory/async-patterns.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/async-patterns.md) | useTaskPoll / useAsyncStep / WizardShell / spinner-vs-glow | New hook, polling pattern, wizard framework change |
 | [memory/extraction.md](~/.claude/projects/-Users-paulwander-projects-HF/memory/extraction.md) | DocumentTypes, resolution chain, ContentAssertion shape, trust levels | New DocumentType, extraction category, new resolveExtractionConfig caller |
 | [`docs/glossary-skills-mastery.md`](./docs/glossary-skills-mastery.md) | Canonical vocab: Course/Source/Skill/LO/TP/Mastery. Educator label ↔ DB shape. Surfaced at `/x/help/glossary`. | New entity in the 7 layers; UI label change; new tier scheme; new mastery store |
+| [`docs/DR-POSTURE.md`](./docs/DR-POSTURE.md) | RPO/RTO targets, top-8 disaster scenarios + runbook links, known unmitigated risks (single-region, GDPR §17 re-emergence, unguarded `gcloud run jobs execute`), cross-region trigger event | DR target changes; new scenario added; drill RTO re-measured; PROD provisions |
 
 ### Hard-prereq contract docs (read before touching the surface)
 

--- a/docs/CLOUD-DEPLOYMENT.md
+++ b/docs/CLOUD-DEPLOYMENT.md
@@ -568,12 +568,10 @@ Prisma doesn't support automatic migration rollback. If a migration causes issue
 
 ### Worst case: restore from backup
 
-Cloud SQL has automated daily backups. To restore:
-
-```bash
-gcloud sql backups list --instance=hf-db
-gcloud sql backups restore BACKUP_ID --restore-instance=hf-db
-```
+> **STOP — do not run `gcloud sql backups restore --restore-instance=hf-db`.**
+> That command restores INTO the source instance and wipes the live database.
+> Follow [`docs/runbooks/RB-1394-CLOUD-SQL-RESTORE.md`](./runbooks/RB-1394-CLOUD-SQL-RESTORE.md) — the clone-first procedure restores to a separate instance, validates row counts, then promotes.
+> See also [`docs/DR-POSTURE.md`](./DR-POSTURE.md) for RPO/RTO targets and scenario coverage.
 
 ---
 

--- a/docs/DR-POSTURE.md
+++ b/docs/DR-POSTURE.md
@@ -1,0 +1,58 @@
+# DR Posture
+
+> Disaster recovery targets, scenario coverage, and known unmitigated risks for HF.
+> Companion runbooks live in [`docs/runbooks/`](./runbooks/).
+> Last verified: 2026-06-16.
+
+## Targets (operator-locked)
+
+| Target | Value | Source |
+|---|---|---|
+| **RPO** (data loss tolerance) | **5 minutes** | Cloud SQL PITR floor on `hf-db` (`europe-west2`, 7-day transaction log retention) |
+| **RTO internal** (operational drill target) | **2 hours** | Measured ~30 min for `instances clone` on `db-f1-micro`; allows headroom for proxy-ready wait, smoke, schema check, human decision |
+| **RTO external** (committed maximum if forced into an SLA) | **4 hours** | Conservative floor; do not commit to less without infra change |
+| **Drill cadence** | **Monthly**, automated, 03:00 UTC on the 1st | Cloud Scheduler → `cloud-sql-restore-drill` Cloud Run Job |
+| **Tabletop cadence** | **Annual**; output filed as `dr-gap`-tagged GitHub issue within 24h | Manual; see [`docs/runbooks/`](./runbooks/) post-tabletop |
+
+## Scenario coverage
+
+| # | Scenario | Mitigation | Runbook |
+|---|---|---|---|
+| 1 | Bad migration corrupts PROD data | PITR restore to pre-migration timestamp + forward-fix migration | `RB-1394-CLOUD-SQL-RESTORE.md` |
+| 2 | Accidental `prisma db push --force-reset` on PROD | PITR restore | `RB-1394-CLOUD-SQL-RESTORE.md` |
+| 3 | Broken Cloud Run revision in production | Traffic-split rollback (`gcloud run services update-traffic <svc> --to-revisions=PREV=100`) | TBD (DR-S3 #1757) |
+| 4 | Secret leak (generic) | Rotate in source, bump Secret Manager version, redeploy Cloud Run service | TBD (DR-S3 #1757) |
+| 5 | **Seed ran on PROD by accident** (highest blast radius) | PITR + delta-replay of writes between seed timestamp and recovery point | TBD (DR-S3 #1757 + DR-S6 tabletop scenario) |
+| 6 | VAPI key rotation | Rotate in VAPI dashboard → bump `VAPI_API_KEY` Secret Manager version → **redeploy Cloud Run** (key baked into container env at revision creation; secret version bump alone is insufficient) | TBD (DR-S3 #1757) |
+| 7 | Anthropic / OpenAI key rotation | Same shape as 6. **GDPR dimension:** call transcript content passes through these APIs; leaked key carries PII exposure | TBD (DR-S3 #1757) |
+| 8 | Backup retention silent erosion | Cloud SQL transaction-log storage fills (counts against instance disk quota); GCP silently shrinks PITR window. Detection: monthly drill asserts `transactionLogRetentionDays == 7`. Recovery: investigate quota; expand instance disk | TBD (DR-S3 #1757) |
+
+## Known unmitigated risks
+
+### Single-region (`europe-west2`)
+
+No cross-region replica. A region-level outage means accepting downtime until GCP restores the region (historically hours to days). **Cross-region trigger:** first paying customer with a contractual uptime commitment. Until then, this risk is explicitly accepted.
+
+### GDPR §17 re-emergence after PITR
+
+Once PROD has real users + right-to-be-forgotten (RTBF) requests fulfilled, a PITR restore re-introduces deleted PII rows. No deletion log exists today to replay deletions post-restore. Related: ADR [`2026-06-13-kms-envelope-encryption-prereq.md`](./decisions/2026-06-13-kms-envelope-encryption-prereq.md) (Accepted, not implemented). Must be addressed before PROD provisions and before first PROD RTBF request.
+
+### Unguarded Cloud Run job invocation path
+
+`gcloud run jobs execute hf-seed --region=europe-west2` has no env-target guard, unlike `/db-route` / `/db-switch`. A tired operator running this command from history against the wrong job binding could trigger scenario #5 above. This is the highest-blast-radius unguarded path in the stack and the explicit scenario for the DR-S6 tabletop.
+
+### `RestoreDrillRun` audit surface missing
+
+[`RB-1394-CLOUD-SQL-RESTORE.md`](./runbooks/RB-1394-CLOUD-SQL-RESTORE.md) §3 references a `RestoreDrillRun` table that does not exist in `prisma/schema.prisma`. Drill results currently flow to Cloud Logging only — no queryable in-app surface to check "did last month's drill pass?". DR-S4 (#1758) builds the model.
+
+### Cross-environment restore drill (PROD → TEST)
+
+Not exercised today. Catches IAM, VPC, and Secret-binding bugs that same-env drills miss. Committed-future obligation: add when PROD provisions.
+
+## References
+
+- [`docs/runbooks/RB-1394-CLOUD-SQL-RESTORE.md`](./runbooks/RB-1394-CLOUD-SQL-RESTORE.md) — clone-first restore procedure (the canonical recovery runbook)
+- [`docs/runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md`](./runbooks/RB-1394-RESTORE-DRILL-DEPLOY.md) — Cloud Run Job + Cloud Scheduler deployment
+- [`docs/CLOUD-DEPLOYMENT.md`](./CLOUD-DEPLOYMENT.md) — infrastructure topology
+- Epic [#1761](https://github.com/WANDERCOLTD/HF/issues/1761) — DR posture
+- Sibling epic [#1723](https://github.com/WANDERCOLTD/HF/issues/1723) — release pipeline


### PR DESCRIPTION
## Summary

- New `docs/DR-POSTURE.md` codifies operator-locked DR targets: RPO 5 min / RTO 2h internal / 4h external committed; monthly drill cadence; annual tabletop. Documents 8 scenarios + known unmitigated risks.
- **Critical doc-fix:** patches `docs/CLOUD-DEPLOYMENT.md §"Worst case"` — pre-patch it included `gcloud sql backups restore --restore-instance=hf-db` which restores INTO the source instance and **wipes the live database** under pressure. Replaced with STOP warning + redirect to the clone-first runbook.
- Adds DR-POSTURE.md to `CLAUDE.md` Reference Docs table for discoverability.

Closes #1756.

## Verified by

- TL brief explicitly flagged the in-place restore footgun (`CLOUD-DEPLOYMENT.md` line 575 pre-patch) as the highest-blast-radius doc error in the repo (`agent-report-verification.md` AR1) — [verified] by reading the file at line 575
- Target runbook `docs/runbooks/RB-1394-CLOUD-SQL-RESTORE.md` exists — [probed] via `ls docs/runbooks/`
- DR-POSTURE.md content traces back to operator-locked decisions A–L in epic #1761 + #1723 — [inverse-probe: read epic body for locked decisions A–J]
- `RestoreDrillRun` table absence — [verified] no model named `RestoreDrillRun` in `prisma/schema.prisma`; current drill writes to Cloud Logging only per `apps/admin/scripts/cloud-sql-restore-drill.sh`
- Pure docs change. No code, no schema, no runtime impact.

## Out of scope

- Building the `RestoreDrillRun` Prisma model — DR-S4 (#1758)
- Writing the 5 scenario runbooks — DR-S3 (#1757)
- Running the first verified drill execution — DR-S1 (#1755)
- Renaming "Cloud Architecture (3 environments)" → "(4 environments)" in CLAUDE.md — S1b naming sweep (#1769)

## Test plan

- [x] DR-POSTURE.md renders correctly (markdown tables, links, headings)
- [x] `docs/CLOUD-DEPLOYMENT.md §"Worst case"` no longer contains the destructive `--restore-instance=hf-db` command
- [x] All in-doc links resolve (`./runbooks/RB-1394-CLOUD-SQL-RESTORE.md`, `./DR-POSTURE.md` from sibling docs)
- [x] CLAUDE.md Reference Docs table row added; `qmd search "DR-POSTURE"` should hit after merge + qmd embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)