### PR TITLE
feat(test-harness): #1750 T12 — cloneDemoCaller helper (fresh + return modes)

### DIFF
--- a/apps/admin/lib/test-harness/clone-demo-caller.ts
+++ b/apps/admin/lib/test-harness/clone-demo-caller.ts
@@ -1,0 +1,263 @@
+/**
+ * cloneDemoCaller — #1750 (epic #1700 Theme 12).
+ *
+ * Tester direct-link primitive. Spins up (or reuses) a learner-shaped
+ * caller for OPERATOR+ testers iterating on a specific module without
+ * hunting for a fresh DB row each cycle.
+ *
+ * Two modes:
+ *
+ *   - **`fresh`** — always creates a NEW Caller. Copies the source's
+ *     `profile:*` CallerAttribute rows (so intake-driven test runs
+ *     start with the right learner shape) but blanks
+ *     `CallerModuleProgress.loScoresJson` / `incompleteAttempts` /
+ *     `orientationShown` so the new caller starts at "zero progress."
+ *   - **`return`** — finds the tester's MOST RECENT prior clone (matched
+ *     by `scope="TEST_HARNESS"` CallerAttribute markers) and returns
+ *     it. If no prior clone exists, falls through to `fresh`.
+ *
+ * Lineage tracking lives in `CallerAttribute` under a dedicated scope:
+ *
+ *   - `scope="TEST_HARNESS" key="source_caller_id"  value=<sourceCallerId>`
+ *   - `scope="TEST_HARNESS" key="tester_email"      value=<testerEmail>`
+ *   - `scope="TEST_HARNESS" key="created_at"        value=<ISO ts>`
+ *
+ * Sibling-writer survey: existing test-learner creator
+ * (`lib/enrollment/create-test-learner.ts`) creates a fresh random-name
+ * Caller with no lineage; this helper differs by (a) carrying source
+ * profile state and (b) tracking lineage so `return` mode can find
+ * prior clones.
+ *
+ * @see docs/draft-issues/ielts-pre-voice-gap-analysis.md (Theme 12)
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+import { enrollCaller } from "@/lib/enrollment";
+import { instantiatePlaybookGoals } from "@/lib/enrollment/instantiate-goals";
+import { instantiatePlaybookTargets } from "@/lib/enrollment/instantiate-targets";
+import { instantiatePlaybookModuleProgress } from "@/lib/enrollment/instantiate-module-progress";
+import { randomFakeName } from "@/lib/fake-names";
+
+export const TEST_HARNESS_SCOPE = "TEST_HARNESS";
+export const TEST_HARNESS_KEYS = {
+  sourceCallerId: "source_caller_id",
+  testerEmail: "tester_email",
+  createdAt: "created_at",
+} as const;
+
+export type CloneDemoCallerMode = "fresh" | "return";
+
+export interface CloneDemoCallerArgs {
+  /** The "template" caller — clones carry their `profile:*` CallerAttribute. */
+  sourceCallerId: string;
+  /** Playbook to enrol the new clone into. */
+  playbookId: string;
+  /** Tester identity (typically session.user.email). Scopes `return` mode. */
+  testerEmail: string;
+  /** `fresh` always creates a new clone; `return` reuses if one exists. */
+  mode: CloneDemoCallerMode;
+}
+
+export interface CloneDemoCallerResult {
+  callerId: string;
+  callerName: string;
+  /** True when a new Caller was created; false when an existing clone was reused. */
+  isNew: boolean;
+  sourceCallerId: string;
+}
+
+type PrismaForClone = Pick<
+  PrismaClient,
+  "caller" | "callerAttribute" | "playbook"
+>;
+
+/**
+ * Resolve the tester's clone (returning existing or creating fresh).
+ */
+export async function cloneDemoCaller(
+  prisma: PrismaForClone,
+  args: CloneDemoCallerArgs,
+): Promise<CloneDemoCallerResult> {
+  if (!args.sourceCallerId) throw new Error("cloneDemoCaller: sourceCallerId is required");
+  if (!args.playbookId) throw new Error("cloneDemoCaller: playbookId is required");
+  if (!args.testerEmail) throw new Error("cloneDemoCaller: testerEmail is required");
+
+  const sourceCaller = await prisma.caller.findUnique({
+    where: { id: args.sourceCallerId },
+    select: { id: true, name: true, domainId: true },
+  });
+  if (!sourceCaller) {
+    throw new Error(`cloneDemoCaller: source caller ${args.sourceCallerId} not found`);
+  }
+  if (!sourceCaller.domainId) {
+    throw new Error(
+      `cloneDemoCaller: source caller ${args.sourceCallerId} has no domainId — cannot clone`,
+    );
+  }
+
+  // `return` mode — try to find an existing clone first.
+  if (args.mode === "return") {
+    const existing = await findExistingClone(prisma, args);
+    if (existing) {
+      return existing;
+    }
+    // Fall through to fresh creation if no prior clone.
+  }
+
+  // `fresh` mode (or `return` with no match) — create a new clone.
+  return createFreshClone(prisma, args, sourceCaller.domainId, sourceCaller.name);
+}
+
+/**
+ * Find the tester's most recent clone of the given source caller.
+ * Returns null when no prior clone exists.
+ */
+async function findExistingClone(
+  prisma: PrismaForClone,
+  args: CloneDemoCallerArgs,
+): Promise<CloneDemoCallerResult | null> {
+  // Match on (sourceCallerId, testerEmail) via CallerAttribute rows.
+  // Walk: find all callers with matching sourceCallerId attribute, then
+  // narrow to those whose tester_email attribute also matches. Order by
+  // updatedAt desc; pick most recent.
+  const sourceMatches = await prisma.callerAttribute.findMany({
+    where: {
+      scope: TEST_HARNESS_SCOPE,
+      key: TEST_HARNESS_KEYS.sourceCallerId,
+      stringValue: args.sourceCallerId,
+    },
+    select: { callerId: true },
+  });
+  if (sourceMatches.length === 0) return null;
+
+  const candidateCallerIds = sourceMatches.map((m) => m.callerId);
+  const testerMatches = await prisma.callerAttribute.findMany({
+    where: {
+      callerId: { in: candidateCallerIds },
+      scope: TEST_HARNESS_SCOPE,
+      key: TEST_HARNESS_KEYS.testerEmail,
+      stringValue: args.testerEmail,
+    },
+    select: { callerId: true, updatedAt: true },
+    orderBy: { updatedAt: "desc" },
+  });
+  if (testerMatches.length === 0) return null;
+
+  const mostRecentCallerId = testerMatches[0].callerId;
+  const cloneCaller = await prisma.caller.findUnique({
+    where: { id: mostRecentCallerId },
+    select: { id: true, name: true },
+  });
+  if (!cloneCaller) return null;
+
+  return {
+    callerId: cloneCaller.id,
+    callerName: cloneCaller.name ?? "Test Clone",
+    isNew: false,
+    sourceCallerId: args.sourceCallerId,
+  };
+}
+
+/**
+ * Create a fresh clone — new Caller, profile:* CallerAttribute copied
+ * from source, blank progress.
+ */
+async function createFreshClone(
+  prisma: PrismaForClone,
+  args: CloneDemoCallerArgs,
+  domainId: string,
+  sourceName: string | null,
+): Promise<CloneDemoCallerResult> {
+  const callerName = `${randomFakeName()} (test clone of ${sourceName ?? args.sourceCallerId.slice(0, 8)})`;
+
+  const newCaller = await prisma.caller.create({
+    data: {
+      name: callerName,
+      domainId,
+    },
+  });
+
+  // Carry source's profile:* CallerAttribute rows (intake answers,
+  // target band, timeline, self-level, etc.).
+  const sourceProfileAttrs = await prisma.callerAttribute.findMany({
+    where: {
+      callerId: args.sourceCallerId,
+      key: { startsWith: "profile:" },
+    },
+    select: {
+      key: true,
+      scope: true,
+      domain: true,
+      valueType: true,
+      stringValue: true,
+      numberValue: true,
+      booleanValue: true,
+      jsonValue: true,
+    },
+  });
+
+  for (const attr of sourceProfileAttrs) {
+    await prisma.callerAttribute.create({
+      data: {
+        callerId: newCaller.id,
+        key: attr.key,
+        scope: attr.scope,
+        domain: attr.domain,
+        valueType: attr.valueType,
+        stringValue: attr.stringValue,
+        numberValue: attr.numberValue,
+        booleanValue: attr.booleanValue,
+        jsonValue: attr.jsonValue ?? undefined,
+      },
+    });
+  }
+
+  // Write lineage markers (so future `return` mode finds this clone).
+  const now = new Date().toISOString();
+  await prisma.callerAttribute.create({
+    data: {
+      callerId: newCaller.id,
+      key: TEST_HARNESS_KEYS.sourceCallerId,
+      scope: TEST_HARNESS_SCOPE,
+      valueType: "STRING",
+      stringValue: args.sourceCallerId,
+    },
+  });
+  await prisma.callerAttribute.create({
+    data: {
+      callerId: newCaller.id,
+      key: TEST_HARNESS_KEYS.testerEmail,
+      scope: TEST_HARNESS_SCOPE,
+      valueType: "STRING",
+      stringValue: args.testerEmail,
+    },
+  });
+  await prisma.callerAttribute.create({
+    data: {
+      callerId: newCaller.id,
+      key: TEST_HARNESS_KEYS.createdAt,
+      scope: TEST_HARNESS_SCOPE,
+      valueType: "STRING",
+      stringValue: now,
+    },
+  });
+
+  // Enroll + instantiate progress shells (zero callCount, no
+  // loScoresJson, no incompleteAttempts, no orientationShown).
+  // instantiatePlaybookGoals + instantiatePlaybookTargets read
+  // enrollments by callerId (no per-playbook arg), so they must run
+  // AFTER enrollCaller writes the CallerPlaybook row.
+  await enrollCaller(newCaller.id, args.playbookId, "test-harness-clone");
+  // All three instantiators read enrollments by callerId — single-arg form.
+  await instantiatePlaybookModuleProgress(newCaller.id);
+  await instantiatePlaybookGoals(newCaller.id);
+  await instantiatePlaybookTargets(newCaller.id);
+
+  return {
+    callerId: newCaller.id,
+    callerName,
+    isNew: true,
+    sourceCallerId: args.sourceCallerId,
+  };
+}

--- a/apps/admin/tests/lib/test-harness/clone-demo-caller.test.ts
+++ b/apps/admin/tests/lib/test-harness/clone-demo-caller.test.ts
@@ -1,0 +1,319 @@
+/**
+ * #1750 T12 — cloneDemoCaller helper pins.
+ *
+ *   - `fresh` always creates new
+ *   - `return` finds existing clone via (sourceCallerId, testerEmail) lineage
+ *   - `return` falls through to `fresh` when no prior clone
+ *   - profile:* CallerAttribute rows copied from source
+ *   - Lineage markers (sourceCallerId, testerEmail, createdAt) written
+ *   - Throws on missing args
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/fake-names", () => ({
+  randomFakeName: vi.fn(() => "Test Name"),
+}));
+
+vi.mock("@/lib/enrollment", () => ({
+  enrollCaller: vi.fn(async () => ({})),
+}));
+vi.mock("@/lib/enrollment/instantiate-goals", () => ({
+  instantiatePlaybookGoals: vi.fn(async () => ({})),
+}));
+vi.mock("@/lib/enrollment/instantiate-targets", () => ({
+  instantiatePlaybookTargets: vi.fn(async () => ({})),
+}));
+vi.mock("@/lib/enrollment/instantiate-module-progress", () => ({
+  instantiatePlaybookModuleProgress: vi.fn(async () => ({})),
+}));
+
+import {
+  cloneDemoCaller,
+  TEST_HARNESS_SCOPE,
+  TEST_HARNESS_KEYS,
+} from "@/lib/test-harness/clone-demo-caller";
+
+const SOURCE_ID = "caller-source";
+const PLAYBOOK_ID = "playbook-1";
+const TESTER = "paul@example.com";
+
+function makePrisma(opts: {
+  /** Pass `null` (explicitly) to simulate source-not-found. Omit for default. */
+  sourceCaller?: { id: string; name: string | null; domainId: string | null } | null;
+  sourceProfileAttrs?: Array<Record<string, unknown>>;
+  existingSourceMatches?: Array<{ callerId: string }>;
+  existingTesterMatches?: Array<{ callerId: string; updatedAt: Date }>;
+  existingClone?: { id: string; name: string | null };
+} = {}) {
+  // Distinguish "explicit null" from "key omitted" — the test for
+  // `source caller not found` passes `null` and expects findUnique to
+  // return null (not the default Source Caller).
+  const sourceCallerProvided = "sourceCaller" in opts;
+  const createdCallers: Array<Record<string, unknown>> = [];
+  const createdAttrs: Array<Record<string, unknown>> = [];
+
+  return {
+    caller: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+        if (where.id === SOURCE_ID) {
+          if (sourceCallerProvided) return opts.sourceCaller;
+          return { id: SOURCE_ID, name: "Source Caller", domainId: "dom-1" };
+        }
+        if (opts.existingClone && where.id === opts.existingClone.id) {
+          return opts.existingClone;
+        }
+        return null;
+      }),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        const created = { id: `new-caller-${createdCallers.length}`, ...data };
+        createdCallers.push(created);
+        return created;
+      }),
+    },
+    callerAttribute: {
+      findMany: vi.fn(
+        async ({ where }: { where: Record<string, unknown> }) => {
+          // Return matchers based on the query shape.
+          if (where.key === TEST_HARNESS_KEYS.sourceCallerId) {
+            return opts.existingSourceMatches ?? [];
+          }
+          if (where.key === TEST_HARNESS_KEYS.testerEmail) {
+            return opts.existingTesterMatches ?? [];
+          }
+          if (
+            (where.key as { startsWith?: string } | undefined)?.startsWith === "profile:"
+          ) {
+            return opts.sourceProfileAttrs ?? [];
+          }
+          return [];
+        },
+      ),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        const created = { id: `attr-${createdAttrs.length}`, ...data };
+        createdAttrs.push(created);
+        return created;
+      }),
+    },
+    playbook: { findUnique: vi.fn() },
+    _captures: { createdCallers, createdAttrs },
+  };
+}
+
+describe("cloneDemoCaller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("input validation", () => {
+    it("throws on empty sourceCallerId", async () => {
+      const prisma = makePrisma();
+      await expect(
+        cloneDemoCaller(prisma as never, {
+          sourceCallerId: "",
+          playbookId: PLAYBOOK_ID,
+          testerEmail: TESTER,
+          mode: "fresh",
+        }),
+      ).rejects.toThrow(/sourceCallerId is required/);
+    });
+
+    it("throws on empty playbookId", async () => {
+      const prisma = makePrisma();
+      await expect(
+        cloneDemoCaller(prisma as never, {
+          sourceCallerId: SOURCE_ID,
+          playbookId: "",
+          testerEmail: TESTER,
+          mode: "fresh",
+        }),
+      ).rejects.toThrow(/playbookId is required/);
+    });
+
+    it("throws on empty testerEmail", async () => {
+      const prisma = makePrisma();
+      await expect(
+        cloneDemoCaller(prisma as never, {
+          sourceCallerId: SOURCE_ID,
+          playbookId: PLAYBOOK_ID,
+          testerEmail: "",
+          mode: "fresh",
+        }),
+      ).rejects.toThrow(/testerEmail is required/);
+    });
+
+    it("throws when source caller not found", async () => {
+      const prisma = makePrisma({ sourceCaller: null });
+      await expect(
+        cloneDemoCaller(prisma as never, {
+          sourceCallerId: SOURCE_ID,
+          playbookId: PLAYBOOK_ID,
+          testerEmail: TESTER,
+          mode: "fresh",
+        }),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("throws when source caller has no domainId", async () => {
+      const prisma = makePrisma({
+        sourceCaller: { id: SOURCE_ID, name: "S", domainId: null },
+      });
+      await expect(
+        cloneDemoCaller(prisma as never, {
+          sourceCallerId: SOURCE_ID,
+          playbookId: PLAYBOOK_ID,
+          testerEmail: TESTER,
+          mode: "fresh",
+        }),
+      ).rejects.toThrow(/no domainId/);
+    });
+  });
+
+  describe("fresh mode", () => {
+    it("creates a new caller + writes lineage markers + isNew=true", async () => {
+      const prisma = makePrisma();
+      const result = await cloneDemoCaller(prisma as never, {
+        sourceCallerId: SOURCE_ID,
+        playbookId: PLAYBOOK_ID,
+        testerEmail: TESTER,
+        mode: "fresh",
+      });
+      expect(result.isNew).toBe(true);
+      expect(result.sourceCallerId).toBe(SOURCE_ID);
+      expect(result.callerId).toMatch(/^new-caller-/);
+      expect(prisma.caller.create).toHaveBeenCalledTimes(1);
+      // 3 lineage markers written (sourceCallerId, testerEmail, createdAt)
+      const lineageWrites = prisma._captures.createdAttrs.filter(
+        (a) => a.scope === TEST_HARNESS_SCOPE,
+      );
+      expect(lineageWrites.length).toBe(3);
+      expect(
+        lineageWrites.find((a) => a.key === TEST_HARNESS_KEYS.sourceCallerId)
+          ?.stringValue,
+      ).toBe(SOURCE_ID);
+      expect(
+        lineageWrites.find((a) => a.key === TEST_HARNESS_KEYS.testerEmail)
+          ?.stringValue,
+      ).toBe(TESTER);
+    });
+
+    it("copies source's profile:* CallerAttribute rows", async () => {
+      const prisma = makePrisma({
+        sourceProfileAttrs: [
+          {
+            key: "profile:targetBand",
+            scope: "GLOBAL",
+            domain: null,
+            valueType: "NUMBER",
+            stringValue: null,
+            numberValue: 7.0,
+            booleanValue: null,
+            jsonValue: null,
+          },
+          {
+            key: "profile:reason",
+            scope: "GLOBAL",
+            domain: null,
+            valueType: "STRING",
+            stringValue: "Immigration",
+            numberValue: null,
+            booleanValue: null,
+            jsonValue: null,
+          },
+        ],
+      });
+      await cloneDemoCaller(prisma as never, {
+        sourceCallerId: SOURCE_ID,
+        playbookId: PLAYBOOK_ID,
+        testerEmail: TESTER,
+        mode: "fresh",
+      });
+      const profileWrites = prisma._captures.createdAttrs.filter((a) =>
+        (a.key as string).startsWith("profile:"),
+      );
+      expect(profileWrites.length).toBe(2);
+      expect(
+        profileWrites.find((a) => a.key === "profile:targetBand")?.numberValue,
+      ).toBe(7.0);
+      expect(
+        profileWrites.find((a) => a.key === "profile:reason")?.stringValue,
+      ).toBe("Immigration");
+    });
+  });
+
+  describe("return mode", () => {
+    it("returns existing clone when lineage matches", async () => {
+      const prisma = makePrisma({
+        existingSourceMatches: [{ callerId: "existing-clone-1" }],
+        existingTesterMatches: [
+          { callerId: "existing-clone-1", updatedAt: new Date() },
+        ],
+        existingClone: { id: "existing-clone-1", name: "Prior Clone" },
+      });
+      const result = await cloneDemoCaller(prisma as never, {
+        sourceCallerId: SOURCE_ID,
+        playbookId: PLAYBOOK_ID,
+        testerEmail: TESTER,
+        mode: "return",
+      });
+      expect(result.isNew).toBe(false);
+      expect(result.callerId).toBe("existing-clone-1");
+      expect(result.callerName).toBe("Prior Clone");
+      // No new caller created.
+      expect(prisma.caller.create).not.toHaveBeenCalled();
+    });
+
+    it("falls through to fresh creation when no prior clone", async () => {
+      const prisma = makePrisma({
+        existingSourceMatches: [],
+        existingTesterMatches: [],
+      });
+      const result = await cloneDemoCaller(prisma as never, {
+        sourceCallerId: SOURCE_ID,
+        playbookId: PLAYBOOK_ID,
+        testerEmail: TESTER,
+        mode: "return",
+      });
+      expect(result.isNew).toBe(true);
+      expect(prisma.caller.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("picks the MOST RECENT clone when multiple exist", async () => {
+      const older = new Date("2026-06-01T00:00:00Z");
+      const newer = new Date("2026-06-15T00:00:00Z");
+      const prisma = makePrisma({
+        existingSourceMatches: [
+          { callerId: "clone-old" },
+          { callerId: "clone-new" },
+        ],
+        existingTesterMatches: [
+          { callerId: "clone-new", updatedAt: newer },
+          { callerId: "clone-old", updatedAt: older },
+        ],
+        existingClone: { id: "clone-new", name: "Most Recent" },
+      });
+      const result = await cloneDemoCaller(prisma as never, {
+        sourceCallerId: SOURCE_ID,
+        playbookId: PLAYBOOK_ID,
+        testerEmail: TESTER,
+        mode: "return",
+      });
+      expect(result.callerId).toBe("clone-new");
+    });
+
+    it("falls through to fresh when source matches exist but tester does not", async () => {
+      // Different tester took clones of this source — not OUR clone.
+      const prisma = makePrisma({
+        existingSourceMatches: [{ callerId: "clone-other-tester" }],
+        existingTesterMatches: [], // tester filter narrows to zero
+      });
+      const result = await cloneDemoCaller(prisma as never, {
+        sourceCallerId: SOURCE_ID,
+        playbookId: PLAYBOOK_ID,
+        testerEmail: TESTER,
+        mode: "return",
+      });
+      expect(result.isNew).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Closes the core primitive of #1750** (epic #1700 Theme 12 — Tester direct-link family). The route + page wiring is a thin wrapper deferred to a follow-on; this PR lands the load-bearing helper that the route will call.

## What ships

| File | Change |
|---|---|
| \`lib/test-harness/clone-demo-caller.ts\` (new) | \`cloneDemoCaller(prisma, args)\` — two modes (fresh / return), profile:* CallerAttribute carry-over, lineage tracking via \`scope=\"TEST_HARNESS\"\` markers |
| \`tests/lib/test-harness/clone-demo-caller.test.ts\` (new) | 11 vitests |

### Behaviour summary

**\`fresh\` mode** → always creates a new Caller (random fake name + \"(test clone of <source>)\"), copies source's \`profile:*\` CallerAttribute rows verbatim, enrols + instantiates module progress/goals/targets (all blank).

**\`return\` mode** → looks up lineage via \`scope=\"TEST_HARNESS\"\` markers; returns the tester's most-recent prior clone of this source; falls through to fresh creation when no prior clone exists. **Tester-isolated** — another operator's clones of the same source don't surface.

### Lineage markers (new scope)

\`\`\`
CallerAttribute(scope=\"TEST_HARNESS\", key=\"source_caller_id\", stringValue=<sourceCallerId>)
CallerAttribute(scope=\"TEST_HARNESS\", key=\"tester_email\",     stringValue=<testerEmail>)
CallerAttribute(scope=\"TEST_HARNESS\", key=\"created_at\",       stringValue=<ISO ts>)
\`\`\`

Structurally isolated from existing scopes (GLOBAL / SESSION / CURRICULUM / GOAL_EVENT / PROFILE) via the \`(callerId, key, scope)\` unique key. No collision with Boaz's \`profile:*\` namespace (#1768) — the helper INTENTIONALLY carries those forward.

## Lattice survey

- **Sibling-writer survey:**
  - \`lib/enrollment/create-test-learner.ts\` is the existing fresh-name creator. Different shape (no source carrying, no lineage). No conflict.
  - 8 \`prisma.caller.create\` sites across the codebase (wizard executor, voice route-handlers, ops, classroom). None track tester lineage. Clean greenfield for \`TEST_HARNESS\` scope.
  - \`CallerAttribute\` scopes already in use: GLOBAL / SESSION / CURRICULUM / GOAL_EVENT / PROFILE. \`TEST_HARNESS\` is a new sibling — isolated by \`@@unique([callerId, key, scope])\`.
- **Default-deny:** N/A — write-side primitive; OPERATOR+ gate enforced at the route layer (follow-on).
- **Cascade respect:** test-harness lineage is per-clone, not cascadable.
- **Convention conflict:** \`profile:*\` carry-over deliberately reuses Boaz's #1768 namespace; \`TEST_HARNESS\` scope is new.

## Test plan

- [x] 11 vitests green (input validation × 5, fresh × 2, return × 4)
- [x] Pre-push tsc + lint clean
- [ ] hf-dev smoke: call helper from a script with \`mode: \"fresh\"\` on an IELTS demo caller → verify new caller exists with \`profile:*\` attrs copied + lineage markers written; call again with \`mode: \"return\"\` → returns the same callerId

## Verified by

- 11/11 vitests green
- Sibling-writer survey result documented above
- Type-checked against \`enrollCaller\` + \`instantiatePlaybookModuleProgress\` + \`instantiatePlaybookGoals\` + \`instantiatePlaybookTargets\` signatures

## Deploy

\`/vm-cp\` (code-only — uses existing CallerAttribute scope mechanism, no migration).

## Out of scope (follow-on, ~0.3d)

- **Route \`/x/test/[playbookSlug]/[moduleSlug]\`** — thin wrapper that:
  - \`requireAuth(\"OPERATOR\")\`
  - Resolves slugs → playbookId / moduleId
  - Calls \`cloneDemoCaller(prisma, {sourceCallerId, playbookId, testerEmail, mode})\`
  - Redirects to \`/x/callers/<newCallerId>/sim?module=<moduleId>\`
  - Source caller resolution: either env-configured \`DEMO_DEFAULT_CALLER\` or path query param

  Sized ~0.3d. File once design is signed off.