### PR TITLE
docs(dr): #1757 3 of 8 DR scenario runbooks (bad-migration / Cloud Run rollback / seed-on-PROD)

### DIFF
--- a/docs/runbooks/RB-DR-S1-BAD-MIGRATION-PITR.md
+++ b/docs/runbooks/RB-DR-S1-BAD-MIGRATION-PITR.md
@@ -1,0 +1,128 @@
+# Runbook RB-DR-S1 — Bad migration corrupts data → PITR restore
+
+**Owner:** operator (you) · **Created:** 2026-06-16 · **Last verified:** 2026-06-16 (write-only — never executed in anger) · **Scenario:** 1 of 8 in [`docs/DR-POSTURE.md`](../DR-POSTURE.md)
+
+## When to use this
+
+A Prisma migration deployed to PROD (or DEV/TEST during validation) and **data is now wrong**: a backfill flipped values, a column got nullified incorrectly, a cascade deleted more than expected, an `ALTER TABLE` rewrote rows in a way the seed couldn't replay.
+
+**Symptoms that point here, not elsewhere:**
+- The 5xx rate is **not** elevated (Cloud Run revision is healthy) → not Scenario 3
+- No seed job ran near the failure timestamp → not Scenario 5
+- The schema change applied successfully (`prisma migrate status` shows the migration in the applied list)
+- A `SELECT COUNT(*) FROM "AffectedTable"` returns wrong numbers OR `SELECT … LIMIT 10` shows garbled values
+
+## Decision tree
+
+```
+Is the migration COMMITTED but not yet applied to PROD?
+├─ YES  → revert the commit, write a new forward-fix migration. No PITR needed.
+└─ NO (already applied)
+   │
+   Did users write rows AFTER the migration ran?
+   ├─ NO  (within minutes, low traffic) → §A: clone-and-promote (clean restore)
+   └─ YES → §B: clone + delta-replay (preserves user writes; complex)
+```
+
+## §A — Clean restore (no user writes after migration)
+
+Use when traffic is low and you can confirm `SELECT … FROM <table> WHERE "updatedAt" > '<migration timestamp>'` returns zero or near-zero rows.
+
+```bash
+# 1. Identify the exact migration timestamp from Cloud Build / Cloud Run logs
+#    OR from the migrations table:
+#    SELECT migration_name, finished_at FROM _prisma_migrations ORDER BY finished_at DESC LIMIT 5;
+MIGRATION_TS="2026-06-16T14:32:00.000Z"     # ← edit
+PIT_BEFORE="2026-06-16T14:31:00.000Z"        # 1 minute before — gives clean cutpoint
+
+# 2. Clone hf-db to the pre-migration point in time
+SRC="hf-db"
+DST="hf-db-rollback-$(date +%Y%m%d-%H%M)"
+gcloud sql instances clone "$SRC" "$DST" \
+  --point-in-time="$PIT_BEFORE" \
+  --project=hf-admin-prod
+
+# 3. Wait for clone to be RUNNABLE (~10 min)
+gcloud sql instances describe "$DST" --format='value(state)' \
+  | grep -E "RUNNABLE" || echo "still creating..."
+
+# 4. Verify the clone has pre-migration shape:
+#    `_prisma_migrations` table should NOT contain the offending migration row.
+./cloud-sql-proxy "$(gcloud sql instances describe "$DST" --format='value(connectionName)')" --port 5433 &
+PGPASSWORD="<from Secret Manager>" psql -h localhost -p 5433 -U postgres -d hf_prod \
+  -c "SELECT migration_name FROM _prisma_migrations ORDER BY finished_at DESC LIMIT 5;"
+# Expect: the bad migration is ABSENT.
+
+# 5. Dump the database from the clone
+PGPASSWORD="<...>" pg_dump -h localhost -p 5433 -U postgres -d hf_prod \
+  -Fc -f /tmp/hf_prod_clean.dump
+
+# 6. Restore into the LIVE hf-db (separate proxy on a different port)
+./cloud-sql-proxy "$(gcloud sql instances describe hf-db --format='value(connectionName)')" --port 5432 &
+PGPASSWORD="<...>" pg_restore -h localhost -p 5432 -U postgres -d hf_prod \
+  --clean --if-exists /tmp/hf_prod_clean.dump
+
+# 7. Drop the clone
+gcloud sql instances delete "$DST" --project=hf-admin-prod --quiet
+
+# 8. Write a forward-fix migration that does the migration's INTENT correctly
+#    (do NOT just re-apply the broken one — it'll re-corrupt)
+```
+
+## §B — Clone + delta-replay (user writes preserved)
+
+Use when traffic was active during the corruption window and you can't afford to lose user writes.
+
+This procedure is **complex** and requires per-table reasoning. Document each step in the post-incident ticket.
+
+```bash
+# 1. Identify all tables affected by the bad migration (read the migration SQL).
+#    For each affected table:
+#    - Are there UPDATE/DELETE statements? Those mutated rows can't be cleanly recovered.
+#    - Are there ALTER COLUMN (NOT NULL with default)? Those rewrote ALL rows.
+
+# 2. Clone to pre-migration PIT as in §A step 1–4.
+
+# 3. For each table NOT affected by destructive ops, replay user writes:
+#    Export rows with createdAt > MIGRATION_TS from the LIVE (corrupted) DB:
+PGPASSWORD="<...>" psql -h localhost -p 5432 -U postgres -d hf_prod \
+  -c "\COPY (SELECT * FROM \"Call\" WHERE \"createdAt\" > '$MIGRATION_TS') TO '/tmp/calls_after.csv' WITH CSV HEADER"
+
+#    Restore the CLEAN dump as in §A step 5–6.
+#    Then re-insert the post-migration rows into the now-clean DB:
+PGPASSWORD="<...>" psql -h localhost -p 5432 -U postgres -d hf_prod \
+  -c "\COPY \"Call\" FROM '/tmp/calls_after.csv' WITH CSV HEADER"
+
+# 4. For tables WITH destructive ops in the migration: user writes between migration
+#    and now MAY be lost. Quantify the loss; document; communicate to affected users.
+```
+
+## Verification (after restore — before declaring done)
+
+```bash
+# Migration history must NOT show the bad migration
+PGPASSWORD="<...>" psql -h localhost -p 5432 -U postgres -d hf_prod \
+  -c "SELECT migration_name FROM _prisma_migrations ORDER BY finished_at DESC LIMIT 5;"
+
+# Sentinel row count: pick a table the bad migration affected, compare to known-good baseline
+PGPASSWORD="<...>" psql -h localhost -p 5432 -U postgres -d hf_prod \
+  -c "SELECT COUNT(*) FROM \"AffectedTable\";"
+
+# `/api/health` returns 200
+curl -sf "$(gcloud run services describe hf-admin --region=europe-west2 --format='value(status.url)')/api/health"
+
+# A representative learner-scoped query returns expected data
+# (run a known curl probe against /api/callers/<id>)
+```
+
+## Post-incident (within 24h)
+
+1. **File `dr-gap` issue** describing: which table was affected, how long the corruption was live, what the forward-fix migration was, whether any user writes were lost.
+2. **Update this runbook** with anything you learned (PR alongside the fix). Bump `Last verified` date.
+3. **Add a guard** if the migration shape was preventable: e.g., a Prisma migration linting rule, a destructive-op detector, an integration test.
+
+## Related
+
+- [`docs/runbooks/RB-1394-CLOUD-SQL-RESTORE.md`](./RB-1394-CLOUD-SQL-RESTORE.md) — the canonical PITR procedure this runbook builds on
+- [`docs/DR-POSTURE.md`](../DR-POSTURE.md) — RPO/RTO targets and scenario index
+- [`apps/admin/scripts/check-migration-has-backfill.ts`](../../apps/admin/scripts/check-migration-has-backfill.ts) — the PR-time gate that prevents most cases that lead here (S5 #1728, when shipped)

--- a/docs/runbooks/RB-DR-S3-CLOUD-RUN-ROLLBACK.md
+++ b/docs/runbooks/RB-DR-S3-CLOUD-RUN-ROLLBACK.md
@@ -1,0 +1,92 @@
+# Runbook RB-DR-S3 — Broken Cloud Run revision → traffic-split rollback
+
+**Owner:** operator (you) · **Created:** 2026-06-16 · **Last verified:** 2026-06-16 (write-only — never executed in anger) · **Scenario:** 3 of 8 in [`docs/DR-POSTURE.md`](../DR-POSTURE.md)
+
+## When to use this
+
+A Cloud Run revision deployed and **traffic is now hitting broken code**: 5xx rate spiked, a critical page returns 500, the wizard refuses to advance, a route is missing or returning the wrong shape.
+
+**Symptoms that point here, not elsewhere:**
+- `gcloud run revisions list --service=<svc>` shows the latest revision serving 100% traffic
+- `gcloud run revisions logs read <latest-revision>` shows errors immediately on request
+- DB looks fine (`SELECT 1` works; data shape is correct) → not Scenario 1
+- No seed ran near deploy → not Scenario 5
+
+**Time budget: 60 seconds to rollback, < 5 min to verify.** This is the fastest of the 8 runbooks.
+
+## Decision tree
+
+```
+Did the bad deploy include a schema migration?
+├─ NO  → §A: traffic-split rollback (image only). Done in 60s.
+└─ YES → §B: traffic-split rollback + assess migration safety
+         Migrations are forward-only — the rollback REVISION may not work
+         against the NEW schema. If it doesn't, this becomes Scenario 1.
+```
+
+## §A — Image-only rollback (most common path)
+
+```bash
+SVC="hf-admin"                # or hf-admin-dev / hf-admin-test
+REGION="europe-west2"
+
+# 1. List recent revisions, find the last-known-good
+gcloud run revisions list --service="$SVC" --region="$REGION" --limit=10 \
+  --format='table(metadata.name,status.conditions[0].lastTransitionTime,spec.containers[0].image)'
+
+# 2. Pin traffic to the previous revision (60s)
+PREV_REVISION="<paste-from-step-1>"
+gcloud run services update-traffic "$SVC" \
+  --region="$REGION" \
+  --to-revisions="$PREV_REVISION=100"
+
+# 3. Verify
+curl -sf "https://<env>.humanfirstfoundation.com/api/health" | jq .
+curl -sf "https://<env>.humanfirstfoundation.com/api/ready" | jq .
+```
+
+If `/api/health` returns 200, you're back to a known-good state. **Do not redeploy until you've identified the cause.**
+
+## §B — Rollback when the bad deploy included a migration
+
+```bash
+# Check what migrations ran in the bad deploy:
+gcloud run jobs executions list --job=hf-migrate-<env> --region="$REGION" --limit=3 \
+  --format='value(name,startTime,status.completionTime)'
+
+# Read the most recent migrate-job log to see which migrations applied:
+gcloud run jobs executions logs read <latest-execution> --region="$REGION" | grep "Applying migration"
+```
+
+**Decision:**
+- **Migration is additive only** (new table, new nullable column, new index) → the previous revision still works against the new schema. Run §A as normal. Roll forward later.
+- **Migration is destructive** (dropped column, dropped table, NOT NULL added, type narrowed) → previous revision will break against the new schema. This is now also Scenario 1 (data corruption). Run §A to stop the bleeding, then jump to [`RB-DR-S1-BAD-MIGRATION-PITR.md`](./RB-DR-S1-BAD-MIGRATION-PITR.md) §A.
+
+## Verification (after rollback)
+
+```bash
+# Traffic is now on the rolled-back revision
+gcloud run services describe "$SVC" --region="$REGION" \
+  --format='value(status.traffic)'
+# Expect: 100% on the previous revision
+
+# Health endpoints
+curl -sf "https://<env>.humanfirstfoundation.com/api/health" | jq .
+curl -sf "https://<env>.humanfirstfoundation.com/api/ready" | jq .
+
+# A representative end-user surface still works
+# (login → load /x/callers → click a caller → load tab)
+```
+
+## Post-incident (within 24h)
+
+1. **File `dr-gap` issue** describing: which revision was bad, what error class, how long traffic was on it (compute from revision deploy time → rollback time).
+2. **Verify the bad image is NOT auto-redeployed.** Cloud Run can re-route to a revision if `--no-traffic` is misread. Confirm the bad revision shows `0%` in `gcloud run services describe`.
+3. **Forward-fix the underlying bug** in a new PR. The fix must include a test that would have caught this; otherwise the gh-pr-create gate will block (per `.claude/rules/verify-before-fix.md`).
+4. **Update this runbook** if you learned anything (PR alongside the fix). Bump `Last verified` date.
+
+## Related
+
+- [`docs/DR-POSTURE.md`](../DR-POSTURE.md) — scenario index + targets
+- [`docs/CLOUD-DEPLOYMENT.md`](../CLOUD-DEPLOYMENT.md) — Cloud Run service inventory
+- [`RB-DR-S1-BAD-MIGRATION-PITR.md`](./RB-DR-S1-BAD-MIGRATION-PITR.md) — when rollback alone isn't enough

--- a/docs/runbooks/RB-DR-S5-SEED-ON-PROD-RECOVERY.md
+++ b/docs/runbooks/RB-DR-S5-SEED-ON-PROD-RECOVERY.md
@@ -1,0 +1,165 @@
+# Runbook RB-DR-S5 — Seed ran on PROD by accident → PITR + delta-replay
+
+**Owner:** operator (you) · **Created:** 2026-06-16 · **Last verified:** 2026-06-16 (write-only — never executed in anger) · **Scenario:** 5 of 8 in [`docs/DR-POSTURE.md`](../DR-POSTURE.md) — **highest blast radius**
+
+## When to use this
+
+Someone ran `gcloud run jobs execute hf-seed --region=europe-west2 --wait` against the **PROD** seed job by accident. Or the staging seed job's `DATABASE_URL_STAGING` was misbound and pointed at the PROD database.
+
+**Why this is the worst-blast-radius scenario in HF today:**
+- The seed scripts UPSERT — they don't wipe — but they DO mutate existing rows when properties differ from spec defaults (e.g., voice config, parameter weights, default playbook config)
+- The `gcloud run jobs execute` command has **no env-target guard** (unlike `/db-route` / `/db-switch`)
+- A tired operator running this from command history is the most-feasible production-disaster path
+
+## Detection (you may not know this happened immediately)
+
+**Symptoms:**
+- Operators report demo callers showing wrong voice / wrong playbook config
+- ComposedPrompt content reverted to a stale seed shape
+- New spec rows appeared in PROD that match the demo cohort (Bertie, IELTS)
+- `AppLog` shows entries with `subject: 'seed.*'` near a recent timestamp
+
+**Confirm:**
+```bash
+# 1. Did any seed job execution complete in the suspect window?
+gcloud run jobs executions list --job=hf-seed-prod --region=europe-west2 --limit=5 \
+  --format='table(name,startTime,status.completionTime,status.conditions[0].type)'
+
+# 2. If yes, read the log to see what profile ran and against which DB
+gcloud run jobs executions logs read <execution-name> --region=europe-west2 \
+  | head -50
+# Look for: SEED_PROFILE=<...> and the first line of seed-full.ts output
+```
+
+## Decision tree
+
+```
+Did the seed job execution complete or fail mid-run?
+├─ Failed mid-run → partial mutation. Same procedure but smaller blast.
+└─ Completed
+   │
+   What's the elapsed time since seed completion?
+   ├─ < 5 min  AND  zero user writes since  → §A: simple PITR restore
+   ├─ < 1 hour AND  trace-able user writes  → §B: PITR + delta-replay
+   └─ > 1 hour OR untrace-able writes       → §C: damage-control + assess
+```
+
+## §A — Simple PITR (rare — only if you caught it within minutes)
+
+```bash
+# 1. Identify exact seed start time from the Cloud Run job execution
+SEED_START="<from Cloud Run execution startTime>"      # RFC3339 UTC
+PIT_BEFORE=$(date -u -d "$SEED_START - 1 minute" +"%Y-%m-%dT%H:%M:%SZ")
+
+# 2. Stop traffic to the affected service (prevent new user writes)
+gcloud run services update-traffic hf-admin --region=europe-west2 --to-revisions=PREV=0
+# (this is aggressive — you're taking PROD offline. Acceptable for §A given the < 5 min window)
+
+# 3. Clone hf-db to pre-seed PIT (see RB-1394-CLOUD-SQL-RESTORE.md §2a)
+gcloud sql instances clone hf-db "hf-db-pre-seed-$(date +%Y%m%d-%H%M)" \
+  --point-in-time="$PIT_BEFORE" --project=hf-admin-prod
+
+# 4. Verify the clone (see RB-1394 §2b) — no seed traces in AppLog after PIT
+# 5. Dump + restore the clone over hf_prod (see RB-1394 §2c, §2d)
+# 6. Bring traffic back online
+gcloud run services update-traffic hf-admin --region=europe-west2 --to-revisions=LATEST=100
+```
+
+## §B — PITR + delta-replay (most likely path)
+
+This is what the **DR-S6 tabletop exercise** rehearses. The hard part: identifying and re-applying user writes that landed between the seed timestamp and recovery.
+
+```bash
+SEED_START="<from execution startTime>"
+PIT_BEFORE=$(date -u -d "$SEED_START - 1 minute" +"%Y-%m-%dT%H:%M:%SZ")
+
+# 1. Identify tables the seed touches (read seed-full.ts step list).
+#    For PROD-relevant SEED_PROFILE=core: spec rows, RunConfig, default voices.
+#    For SEED_PROFILE=demo or full: also Caller, Playbook, ComposedPrompt, demo logins.
+
+# 2. Quantify the delta — for each touched table, count rows with createdAt/updatedAt > $SEED_START
+PGPASSWORD="<...>" psql -h proxy -d hf_prod -c "
+SELECT 'Call' AS table, COUNT(*) FROM \"Call\" WHERE \"updatedAt\" > '$SEED_START'
+UNION ALL SELECT 'CallerAttribute', COUNT(*) FROM \"CallerAttribute\" WHERE \"validFrom\" > '$SEED_START'
+UNION ALL SELECT 'ComposedPrompt', COUNT(*) FROM \"ComposedPrompt\" WHERE \"createdAt\" > '$SEED_START'
+-- add more tables as relevant
+;"
+
+# 3. For each table with user writes: export the affected rows BEFORE restoring
+#    (this is the "save the irreplaceable" step)
+PGPASSWORD="<...>" psql -h proxy -d hf_prod -c "
+\\COPY (SELECT * FROM \"Call\" WHERE \"createdAt\" > '$SEED_START') TO '/tmp/calls_after_seed.csv' WITH CSV HEADER
+"
+# Repeat for each affected table.
+
+# 4. Clone hf-db to PIT_BEFORE; verify clone; dump; restore over live hf_prod
+#    (see RB-DR-S1 §A steps 2–7)
+
+# 5. Re-insert the saved user writes
+#    CAUTION: foreign-key order matters. Insert in this order generally:
+#    Caller → Call → CallerAttribute → ComposedPrompt → BehaviorMeasurement
+PGPASSWORD="<...>" psql -h proxy -d hf_prod -c "
+\\COPY \"Call\" FROM '/tmp/calls_after_seed.csv' WITH CSV HEADER
+"
+# Repeat per table.
+
+# 6. Verify each replayed row resolves its foreign keys
+PGPASSWORD="<...>" psql -h proxy -d hf_prod -c "
+SELECT c.id FROM \"Call\" c LEFT JOIN \"Caller\" ca ON c.\"callerId\" = ca.id
+WHERE c.\"createdAt\" > '$SEED_START' AND ca.id IS NULL;
+"
+# Expect: 0 rows. Any result means a Call lost its Caller link → escalate to §C.
+```
+
+## §C — Damage control (> 1 hour or untraceable writes)
+
+If the seed has been live for hours and you can't enumerate user writes:
+
+1. **Stop further damage:** disable the PROD seed job binding immediately.
+   ```bash
+   # Rotate DATABASE_URL_PROD to a value the seed job can't reach
+   # (or delete the IAM role allowing job execution against the PROD job)
+   ```
+2. **Document the corrupt window** in a `dr-gap` issue. Affected user-visible columns + estimated impact.
+3. **Communicate to affected users.** GDPR / data-accuracy obligation if user-visible content reverted.
+4. **Decide:** restore from PITR and accept all user writes from the window are lost, OR live with the seed-mutated state and forward-fix specific rows.
+5. **This decision is a stakeholder conversation, not a technical one.** Document the reasoning in the post-incident report.
+
+## Pre-incident prevention (open work)
+
+Today the `gcloud run jobs execute hf-seed-prod` path has no env-target guard. Mitigations to consider (file as `sev-2` or fold into DR-S3 #1757 once a hardening story is filed):
+
+1. **Wrap the PROD seed job invocation** in a script that checks an env-confirmation flag (e.g., requires `--target=PROD --i-mean-production-really`).
+2. **Make the seed-clean.ts script self-aware:** if `NODE_ENV=production` AND `FORCE_PROD_SEED` is not set, exit 1 with a loud message.
+3. **Tighten IAM on the PROD seed job:** require a separate role assertion to execute, so a routine GCP login can't fire it.
+4. **The `/db-route` + `/db-switch` refusals are for the Cloud Run service DATABASE_URL bindings — they do NOT cover direct `gcloud run jobs execute` invocation.** Document this gap in `docs/DR-POSTURE.md` (already flagged 2026-06-16).
+
+## Verification (after recovery)
+
+```bash
+# No seed entries in AppLog after the recovery PIT
+PGPASSWORD="<...>" psql -h proxy -d hf_prod -c "
+SELECT subject, timestamp FROM \"AppLog\"
+WHERE subject LIKE 'seed.%' AND timestamp > '$PIT_BEFORE'
+ORDER BY timestamp DESC LIMIT 10;
+"
+
+# Spec row checksums match pre-seed state
+# (you'll need to define what "pre-seed state" looks like — captured by the regular monthly drill)
+
+# A representative user's data is intact — login + load /x/callers → click a known active caller
+```
+
+## Post-incident (within 24h)
+
+1. **File `dr-gap` issue** with the full timeline, blast-radius assessment, and recovery decision.
+2. **File a hardening story** for one of the pre-incident prevention items above.
+3. **Run the DR-S6 tabletop** with the actual incident as the scenario — this is your most-valuable rehearsal data.
+4. **Bump `Last verified` date** on this runbook.
+
+## Related
+
+- [`docs/DR-POSTURE.md`](../DR-POSTURE.md) — scenario index + the unguarded `gcloud run jobs execute` documented risk
+- [`docs/runbooks/RB-1394-CLOUD-SQL-RESTORE.md`](./RB-1394-CLOUD-SQL-RESTORE.md) — PITR fundamentals this builds on
+- [`RB-DR-S1-BAD-MIGRATION-PITR.md`](./RB-DR-S1-BAD-MIGRATION-PITR.md) — sibling scenario; same PITR mechanics, smaller blast
+- Future DR-S6 tabletop exercise (#1760) — this scenario is the chosen target


### PR DESCRIPTION
## Summary

3 of 8 DR scenario runbooks — the most-likely-to-be-needed slice before PROD provisions:

- **RB-DR-S1** — Bad migration → PITR (clean restore vs delta-replay decision tree)
- **RB-DR-S3** — Broken Cloud Run revision → 60-second traffic-split rollback
- **RB-DR-S5** — Seed ran on PROD by accident (highest blast radius; DR-S6 tabletop target)

Each carries a `Last verified` header (TL bit-rot defence) and a 24h `dr-gap` issue mandate post-incident.

Closes part of #1757 (3 of 8 scenarios). Remaining: Scenarios 2/4/6/7/8.

## Verified by

- `docs/runbooks/` exists — [probed] `ls docs/runbooks/` shows RB-1117, RB-1394 × 2, voice-analysis-connection.md
- Format mirrors `RB-1394-CLOUD-SQL-RESTORE.md` — [verified] read the file before drafting
- Scenario index in `docs/DR-POSTURE.md` references these — [verified] §"Scenario coverage" table rows 1, 3, 5
- All in-doc links resolve (`../DR-POSTURE.md`, `./RB-1394-CLOUD-SQL-RESTORE.md`, sibling runbook cross-refs)
- [unverified] Runtime: these runbooks were never executed in anger — `Last verified` header explicitly says "write-only" for each. The DR-S6 tabletop (#1760) is the first dry-run trigger.

## Out of scope

- Remaining 5 scenarios (2 accidental force-reset, 4 secret-leak, 6 VAPI rotation, 7 Anthropic rotation, 8 backup retention erosion) — second slice of #1757
- Pre-incident prevention hardening for §C of RB-DR-S5 (env-target guard on `gcloud run jobs execute`) — separate story
- `RestoreDrillRun` audit surface — DR-S4 (#1758)

## Test plan

- [x] All 3 files render as valid markdown
- [x] All decision trees follow ASCII-art convention
- [x] Cross-refs resolve (`../DR-POSTURE.md`, sibling runbooks)
- [x] Each runbook has trigger / decision-tree / steps / verification / post-incident sections
- [ ] Post-merge: `qmd search "RB-DR-S5"` returns these documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)