### PR TITLE
feat(curriculum): #1785 — DB-driven Mock segmentation cues (course-agnostic)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -581,23 +581,35 @@ async function runPerSegmentScoring(
   });
   if (!boundModule || boundModule.coversModules.length === 0) return 0;
 
-  // Resolve each declared slug → CurriculumModule.id, scoped to the
-  // bound module's curriculum (#407 — never a global slug lookup).
-  const slugToId = new Map<string, string>();
+  // Resolve each declared slug → CurriculumModule (id + segmentCues), scoped
+  // to the bound module's curriculum (#407 — never a global slug lookup).
+  // Batched as a single findMany to avoid N+1; #1785 also reads `segmentCues`
+  // so the segmenter's heuristic matchers are course-agnostic (DB-driven
+  // tutor cue phrases instead of an IELTS-hardcoded regex map).
+  const subModules = await prisma.curriculumModule.findMany({
+    where: { curriculumId: boundModule.curriculumId, slug: { in: boundModule.coversModules } },
+    select: { id: true, slug: true, segmentCues: true },
+  });
+  const slugToId = new Map<string, string>(subModules.map((m) => [m.slug, m.id]));
+  const slugToCues: Record<string, string[]> = {};
+  for (const m of subModules) {
+    if (m.segmentCues.length > 0) slugToCues[m.slug] = m.segmentCues;
+  }
   for (const slug of boundModule.coversModules) {
-    const resolved = await resolveModuleByLogicalId(boundModule.curriculumId, slug);
-    if (resolved) slugToId.set(slug, resolved.id);
-    else log.warn("Per-part MEASURE: coversModules slug not found in curriculum", {
-      slug,
-      curriculumId: boundModule.curriculumId,
-      boundSlug: boundModule.slug,
-    });
+    if (!slugToId.has(slug)) {
+      log.warn("Per-part MEASURE: coversModules slug not found in curriculum", {
+        slug,
+        curriculumId: boundModule.curriculumId,
+        boundSlug: boundModule.slug,
+      });
+    }
   }
   if (slugToId.size === 0) return 0;
 
   const segments = await segmentMockTranscript({
     transcript,
     coversModuleSlugs: boundModule.coversModules.filter((s) => slugToId.has(s)),
+    slugToCues,
     engine,
     log,
   });

--- a/apps/admin/lib/curriculum/segment-mock-transcript.ts
+++ b/apps/admin/lib/curriculum/segment-mock-transcript.ts
@@ -48,31 +48,38 @@ export type TranscriptSegment = {
 };
 
 /**
- * Per-slug ordered regex patterns. Each pattern targets phrases the
- * tutor reliably uses to introduce a part. Patterns are intentionally
- * conservative — false positives (treating a casual mention as a
- * boundary) corrupt downstream scoring, while false negatives just
- * trigger the AI fallback.
+ * Compile DB-supplied cue strings into per-slug ordered RegExp arrays.
  *
- * Ordered: the matcher walks slugs left-to-right; the first match per
- * slug after the previous boundary becomes that slug's start. This
- * guards against "Part 2" appearing inside a Part 3 question.
+ * Each entry in `slugToCues` is treated as a regex SOURCE (not a literal
+ * string) so authors can use alternation / character classes / `\s+`.
+ * Authors who want literal matching must escape metacharacters themselves
+ * — same contract as `new RegExp(source, "i")` everywhere else.
+ *
+ * When a slug has no DB-supplied cues, fall back to `\b<escapedSlug>\b`
+ * so a non-IELTS course (whose transcripts mention "history" / "examination"
+ * verbatim) still gets a reasonable first-pass match. The AI fallback
+ * covers everything the fallback regex misses.
+ *
+ * Patterns deliberately omit the trailing `\b` because some cue phrases
+ * end in punctuation (`say:`, `card:`) where the regex engine would fail
+ * to find a word boundary between `:` and the following whitespace.
  */
-// Patterns deliberately omit the trailing `\b` because some cue
-// phrases end in punctuation (`say:`, `card:`) where the regex engine
-// would fail to find a word boundary between `:` and the following
-// whitespace.
-const HEURISTIC_PATTERNS: Record<string, RegExp[]> = {
-  part1: [
-    /\b(let'?s\s+(?:start|begin)\s+with\s+part\s*1|part\s*1\s*\.\s*[A-Z]|now\s+(?:in|for)\s+part\s*1|i'?ll?\s+ask\s+you\s+some\s+(?:general|familiar)\s+questions)/i,
-  ],
-  part2: [
-    /\b(now\s+(?:let'?s\s+)?(?:move\s+(?:on\s+)?to|move\s+into|turn\s+to|go\s+to)\s+part\s*2|let'?s\s+(?:start|begin)\s+part\s*2|here'?s?\s+your\s+(?:cue\s+card|topic\s+card)|i'?ll?\s+(?:now\s+)?(?:give|hand)\s+you\s+(?:a|your)\s+(?:cue|topic)\s+card|you'?ll?\s+have\s+(?:one\s+minute|1\s+minute)\s+to\s+prepare|describe\s+a\s+[a-z]+\s+(?:you|that)|you\s+should\s+say)/i,
-  ],
-  part3: [
-    /\b(now\s+(?:let'?s\s+)?(?:move\s+(?:on\s+)?to|move\s+into|turn\s+to|go\s+to)\s+part\s*3|let'?s\s+(?:start|begin)\s+part\s*3|i'?d?\s+like\s+to\s+(?:discuss|talk\s+about)\s+(?:some\s+)?(?:more\s+)?(?:general|abstract|broader)|let'?s\s+(?:now\s+)?(?:discuss|talk\s+about)\s+(?:this|the\s+topic)\s+more\s+(?:broadly|generally|abstractly)|now\s+we'?ll?\s+discuss|now\s+(?:i'?d?\s+like\s+to\s+)?(?:explore|consider)\s+(?:some\s+)?broader)/i,
-  ],
-};
+function compileCuesToPatterns(
+  slugToCues: Record<string, string[]> | undefined,
+  coversModuleSlugs: string[],
+): Record<string, RegExp[]> {
+  const out: Record<string, RegExp[]> = {};
+  for (const slug of coversModuleSlugs) {
+    const cues = slugToCues?.[slug];
+    if (cues && cues.length > 0) {
+      out[slug] = cues.map((src) => new RegExp(src, "i"));
+    } else {
+      const escaped = slug.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      out[slug] = [new RegExp(`\\b${escaped}\\b`, "i")];
+    }
+  }
+  return out;
+}
 
 /**
  * Find the start offset for each slug using ordered regex. Returns a
@@ -83,12 +90,13 @@ const HEURISTIC_PATTERNS: Record<string, RegExp[]> = {
 function findHeuristicBoundaries(
   transcript: string,
   coversModuleSlugs: string[],
+  slugToPatterns: Record<string, RegExp[]>,
 ): Map<string, number> {
   const boundaries = new Map<string, number>();
   let searchFrom = 0;
 
   for (const slug of coversModuleSlugs) {
-    const patterns = HEURISTIC_PATTERNS[slug];
+    const patterns = slugToPatterns[slug];
     if (!patterns || patterns.length === 0) continue;
 
     for (const pattern of patterns) {
@@ -254,6 +262,14 @@ export interface SegmentMockTranscriptOptions {
   transcript: string;
   /** Ordered slug list — first slug owns the transcript prefix. */
   coversModuleSlugs: string[];
+  /**
+   * Per-slug cue strings sourced from `CurriculumModule.segmentCues`. Each
+   * cue is a regex source compiled with the `i` flag. When a slug is absent
+   * (or its array empty), the segmenter falls back to `\b<slug>\b` — safe
+   * default for new courses authored without explicit cues. IELTS Mock
+   * relies on the seed populating this map; see `prisma/seed-ielts-course.ts`.
+   */
+  slugToCues?: Record<string, string[]>;
   engine: AIEngine;
   log: PipelineLogger;
 }
@@ -267,16 +283,18 @@ export interface SegmentMockTranscriptOptions {
 export async function segmentMockTranscript(
   options: SegmentMockTranscriptOptions,
 ): Promise<TranscriptSegment[]> {
-  const { transcript, coversModuleSlugs, engine, log } = options;
+  const { transcript, coversModuleSlugs, slugToCues, engine, log } = options;
 
   if (coversModuleSlugs.length === 0) return [];
   if (transcript.trim().length === 0) return [];
+
+  const slugToPatterns = compileCuesToPatterns(slugToCues, coversModuleSlugs);
 
   // Phase 1 — heuristic. Skip AI only when ALL N slugs were found via
   // regex; if even one is missing, ask the AI to fill the gap. This
   // preserves the common case (clean transcripts → no AI cost) while
   // recovering from a single missing cue.
-  const heuristicBoundaries = findHeuristicBoundaries(transcript, coversModuleSlugs);
+  const heuristicBoundaries = findHeuristicBoundaries(transcript, coversModuleSlugs, slugToPatterns);
 
   if (heuristicBoundaries.size === coversModuleSlugs.length) {
     const segments = buildSegmentsFromBoundaries(
@@ -330,5 +348,5 @@ export const __internals = {
   findHeuristicBoundaries,
   buildSegmentsFromBoundaries,
   validateAndExtractBoundaries,
-  HEURISTIC_PATTERNS,
+  compileCuesToPatterns,
 };

--- a/apps/admin/prisma/migrations/20260616180000_1785_curriculum_module_segment_cues/migration.sql
+++ b/apps/admin/prisma/migrations/20260616180000_1785_curriculum_module_segment_cues/migration.sql
@@ -1,0 +1,14 @@
+-- #1785 — Course-agnostic Mock segmentation cues.
+--
+-- `CurriculumModule.segmentCues` is a per-sub-module array of tutor cue
+-- phrases (or regex fragments) used by `lib/curriculum/segment-mock-transcript.ts`
+-- to detect where THIS sub-module's segment begins in a multi-part Mock
+-- transcript. Default `[]` so the reader's fallback (`\bslug\b` regex)
+-- governs every existing row until a seed populates the column.
+--
+-- Additive + safe-default. No rewrites of existing rows; no unique-key
+-- changes; no CHECK constraints. Matches the #494 `coversModules`
+-- column pattern.
+
+ALTER TABLE "CurriculumModule"
+  ADD COLUMN IF NOT EXISTS "segmentCues" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -2790,6 +2790,15 @@ model CurriculumModule {
   terminal      Boolean  @default(false)
   coversModules String[]
 
+  // #1785 — Course-agnostic segmentation cues for the Mock transcript
+  // segmenter (`lib/curriculum/segment-mock-transcript.ts`). Per-curriculum
+  // tutor cue phrases that mark the start of THIS sub-module's segment in a
+  // multi-part Mock transcript. Default `[]` → segmenter falls back to a
+  // `\bslug\b` regex (preserves IELTS behaviour during the migration
+  // window). Authored in the curriculum spec (not the playbook variant);
+  // sibling to `coversModules` above.
+  segmentCues String[]
+
   // Lifecycle
   isActive  Boolean  @default(true)
   createdAt DateTime @default(now())

--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -218,6 +218,34 @@ export async function main(prisma: PrismaClient): Promise<void> {
     if (mockSet.count > 0) {
       console.log(`  Mock module coversModules → [part1, part2, part3] (${mockSet.count} row)`);
     }
+
+    // #1785 — Per-sub-module segmentation cues for `segmentMockTranscript`.
+    // Mirror the legacy IELTS-hardcoded `HEURISTIC_PATTERNS` so behaviour
+    // matches pre-refactor exactly. Each cue string is a regex SOURCE
+    // (alternation / `\s+` / `\b`); the segmenter compiles with the `i`
+    // flag. Patterns deliberately omit a trailing `\b` because some cue
+    // phrases end in punctuation (`say:`, `card:`) — see
+    // `lib/curriculum/segment-mock-transcript.ts` header.
+    const IELTS_SEGMENT_CUES: Record<string, string[]> = {
+      part1: [
+        "\\b(let'?s\\s+(?:start|begin)\\s+with\\s+part\\s*1|part\\s*1\\s*\\.\\s*[A-Z]|now\\s+(?:in|for)\\s+part\\s*1|i'?ll?\\s+ask\\s+you\\s+some\\s+(?:general|familiar)\\s+questions)",
+      ],
+      part2: [
+        "\\b(now\\s+(?:let'?s\\s+)?(?:move\\s+(?:on\\s+)?to|move\\s+into|turn\\s+to|go\\s+to)\\s+part\\s*2|let'?s\\s+(?:start|begin)\\s+part\\s*2|here'?s?\\s+your\\s+(?:cue\\s+card|topic\\s+card)|i'?ll?\\s+(?:now\\s+)?(?:give|hand)\\s+you\\s+(?:a|your)\\s+(?:cue|topic)\\s+card|you'?ll?\\s+have\\s+(?:one\\s+minute|1\\s+minute)\\s+to\\s+prepare|describe\\s+a\\s+[a-z]+\\s+(?:you|that)|you\\s+should\\s+say)",
+      ],
+      part3: [
+        "\\b(now\\s+(?:let'?s\\s+)?(?:move\\s+(?:on\\s+)?to|move\\s+into|turn\\s+to|go\\s+to)\\s+part\\s*3|let'?s\\s+(?:start|begin)\\s+part\\s*3|i'?d?\\s+like\\s+to\\s+(?:discuss|talk\\s+about)\\s+(?:some\\s+)?(?:more\\s+)?(?:general|abstract|broader)|let'?s\\s+(?:now\\s+)?(?:discuss|talk\\s+about)\\s+(?:this|the\\s+topic)\\s+more\\s+(?:broadly|generally|abstractly)|now\\s+we'?ll?\\s+discuss|now\\s+(?:i'?d?\\s+like\\s+to\\s+)?(?:explore|consider)\\s+(?:some\\s+)?broader)",
+      ],
+    };
+    for (const [slug, cues] of Object.entries(IELTS_SEGMENT_CUES)) {
+      const cuesSet = await prisma.curriculumModule.updateMany({
+        where: { curriculumId: ieltsCurriculum.id, slug },
+        data: { segmentCues: cues },
+      });
+      if (cuesSet.count > 0) {
+        console.log(`  ${slug} segmentCues populated (${cuesSet.count} row)`);
+      }
+    }
   }
 
   // ── 5. CONTENT-role spec for trust-weighted certification progress (#457) ──

--- a/apps/admin/tests/lib/measurement/per-part-segmentkey-roundtrip.test.ts
+++ b/apps/admin/tests/lib/measurement/per-part-segmentkey-roundtrip.test.ts
@@ -63,9 +63,25 @@ describe("per-part segmentKey round-trip (#1702)", () => {
       "User: Most people prefer fixed schedules.",
     ].join("\n\n");
 
+    // #1785 — segmenter is course-agnostic; production pipeline reads cues
+    // from `CurriculumModule.segmentCues`. This test mirrors the IELTS seed
+    // so the heuristic path matches part1/part2/part3 deterministically.
+    const IELTS_CUES: Record<string, string[]> = {
+      part1: [
+        "\\b(let'?s\\s+(?:start|begin)\\s+with\\s+part\\s*1|part\\s*1\\s*\\.\\s*[A-Z]|now\\s+(?:in|for)\\s+part\\s*1|i'?ll?\\s+ask\\s+you\\s+some\\s+(?:general|familiar)\\s+questions)",
+      ],
+      part2: [
+        "\\b(now\\s+(?:let'?s\\s+)?(?:move\\s+(?:on\\s+)?to|move\\s+into|turn\\s+to|go\\s+to)\\s+part\\s*2|let'?s\\s+(?:start|begin)\\s+part\\s*2|here'?s?\\s+your\\s+(?:cue\\s+card|topic\\s+card)|i'?ll?\\s+(?:now\\s+)?(?:give|hand)\\s+you\\s+(?:a|your)\\s+(?:cue|topic)\\s+card|you'?ll?\\s+have\\s+(?:one\\s+minute|1\\s+minute)\\s+to\\s+prepare|describe\\s+a\\s+[a-z]+\\s+(?:you|that)|you\\s+should\\s+say)",
+      ],
+      part3: [
+        "\\b(now\\s+(?:let'?s\\s+)?(?:move\\s+(?:on\\s+)?to|move\\s+into|turn\\s+to|go\\s+to)\\s+part\\s*3|let'?s\\s+(?:start|begin)\\s+part\\s*3|i'?d?\\s+like\\s+to\\s+(?:discuss|talk\\s+about)\\s+(?:some\\s+)?(?:more\\s+)?(?:general|abstract|broader)|let'?s\\s+(?:now\\s+)?(?:discuss|talk\\s+about)\\s+(?:this|the\\s+topic)\\s+more\\s+(?:broadly|generally|abstractly)|now\\s+we'?ll?\\s+discuss|now\\s+(?:i'?d?\\s+like\\s+to\\s+)?(?:explore|consider)\\s+(?:some\\s+)?broader)",
+      ],
+    };
+
     const segments = await segmentMockTranscript({
       transcript,
       coversModuleSlugs: ["part1", "part2", "part3"],
+      slugToCues: IELTS_CUES,
       engine: "claude",
       log: makeLog(),
     });

--- a/apps/admin/tests/lib/segment-mock-transcript.test.ts
+++ b/apps/admin/tests/lib/segment-mock-transcript.test.ts
@@ -32,6 +32,22 @@ function makeLog() {
   } as any;
 }
 
+// Mirror of `prisma/seed-ielts-course.ts::IELTS_SEGMENT_CUES`. The
+// production segmenter is course-agnostic (#1785) — these cues live in
+// `CurriculumModule.segmentCues` and the seed populates them. Tests load
+// them inline so the test bank is independent of the DB seed.
+const IELTS_CUES: Record<string, string[]> = {
+  part1: [
+    "\\b(let'?s\\s+(?:start|begin)\\s+with\\s+part\\s*1|part\\s*1\\s*\\.\\s*[A-Z]|now\\s+(?:in|for)\\s+part\\s*1|i'?ll?\\s+ask\\s+you\\s+some\\s+(?:general|familiar)\\s+questions)",
+  ],
+  part2: [
+    "\\b(now\\s+(?:let'?s\\s+)?(?:move\\s+(?:on\\s+)?to|move\\s+into|turn\\s+to|go\\s+to)\\s+part\\s*2|let'?s\\s+(?:start|begin)\\s+part\\s*2|here'?s?\\s+your\\s+(?:cue\\s+card|topic\\s+card)|i'?ll?\\s+(?:now\\s+)?(?:give|hand)\\s+you\\s+(?:a|your)\\s+(?:cue|topic)\\s+card|you'?ll?\\s+have\\s+(?:one\\s+minute|1\\s+minute)\\s+to\\s+prepare|describe\\s+a\\s+[a-z]+\\s+(?:you|that)|you\\s+should\\s+say)",
+  ],
+  part3: [
+    "\\b(now\\s+(?:let'?s\\s+)?(?:move\\s+(?:on\\s+)?to|move\\s+into|turn\\s+to|go\\s+to)\\s+part\\s*3|let'?s\\s+(?:start|begin)\\s+part\\s*3|i'?d?\\s+like\\s+to\\s+(?:discuss|talk\\s+about)\\s+(?:some\\s+)?(?:more\\s+)?(?:general|abstract|broader)|let'?s\\s+(?:now\\s+)?(?:discuss|talk\\s+about)\\s+(?:this|the\\s+topic)\\s+more\\s+(?:broadly|generally|abstractly)|now\\s+we'?ll?\\s+discuss|now\\s+(?:i'?d?\\s+like\\s+to\\s+)?(?:explore|consider)\\s+(?:some\\s+)?broader)",
+  ],
+};
+
 describe("segmentMockTranscript — heuristic path", () => {
   beforeEach(() => {
     mockGetConfiguredMeteredAICompletion.mockReset();
@@ -50,6 +66,7 @@ describe("segmentMockTranscript — heuristic path", () => {
     const segments = await segmentMockTranscript({
       transcript,
       coversModuleSlugs: ["part1", "part2", "part3"],
+      slugToCues: IELTS_CUES,
       engine: "claude",
       log: makeLog(),
     });
@@ -90,6 +107,7 @@ describe("segmentMockTranscript — heuristic path", () => {
     const segments = await segmentMockTranscript({
       transcript,
       coversModuleSlugs: ["part1", "part2", "part3"],
+      slugToCues: IELTS_CUES,
       engine: "claude",
       log: makeLog(),
     });
@@ -121,6 +139,7 @@ describe("segmentMockTranscript — AI fallback validation", () => {
     const segments = await segmentMockTranscript({
       transcript,
       coversModuleSlugs: ["part1", "part2", "part3"],
+      slugToCues: IELTS_CUES,
       engine: "claude",
       log: makeLog(),
     });
@@ -139,6 +158,7 @@ describe("segmentMockTranscript — AI fallback validation", () => {
     const segments = await segmentMockTranscript({
       transcript,
       coversModuleSlugs: ["part1", "part2", "part3"],
+      slugToCues: IELTS_CUES,
       engine: "claude",
       log: makeLog(),
     });
@@ -234,6 +254,12 @@ describe("segmentMockTranscript — Part 2 cue card phrases", () => {
     mockGetConfiguredMeteredAICompletion.mockReset();
   });
 
+  const IELTS_PATTERNS = __internals.compileCuesToPatterns(IELTS_CUES, [
+    "part1",
+    "part2",
+    "part3",
+  ]);
+
   it("Part 2 detected via 'Here's your cue card'", () => {
     const transcript =
       "Assistant: Let's start with Part 1. Hello.\n" +
@@ -242,7 +268,11 @@ describe("segmentMockTranscript — Part 2 cue card phrases", () => {
       "User: Okay.\n" +
       "Assistant: Now let's move to Part 3. Final question.\n" +
       "User: Sure.";
-    const boundaries = __internals.findHeuristicBoundaries(transcript, ["part1", "part2", "part3"]);
+    const boundaries = __internals.findHeuristicBoundaries(
+      transcript,
+      ["part1", "part2", "part3"],
+      IELTS_PATTERNS,
+    );
     expect(boundaries.has("part1")).toBe(true);
     expect(boundaries.has("part2")).toBe(true);
     expect(boundaries.has("part3")).toBe(true);
@@ -253,8 +283,80 @@ describe("segmentMockTranscript — Part 2 cue card phrases", () => {
       "Assistant: Let's start with Part 1. Hello.\n" +
       "Assistant: Describe a person. You should say: who they are.\n" +
       "Assistant: Now let's move to Part 3.";
-    const boundaries = __internals.findHeuristicBoundaries(transcript, ["part1", "part2", "part3"]);
+    const boundaries = __internals.findHeuristicBoundaries(
+      transcript,
+      ["part1", "part2", "part3"],
+      IELTS_PATTERNS,
+    );
     expect(boundaries.size).toBeGreaterThanOrEqual(2);
     expect(boundaries.has("part2")).toBe(true);
+  });
+});
+
+describe("segmentMockTranscript — #1785 course-agnostic cues", () => {
+  beforeEach(() => {
+    mockGetConfiguredMeteredAICompletion.mockReset();
+  });
+
+  it("non-IELTS course with custom DB-supplied cues segments by those cues", async () => {
+    // A hypothetical driving-test Mock that walks through theory → manoeuvres → drive.
+    const transcript = [
+      "Assistant: We'll start with the theory section. What does a red triangle sign mean?",
+      "User: A warning of hazard ahead.",
+      "Assistant: Now let's run the manoeuvres section. Parallel park here.",
+      "User: Okay, reversing now.",
+      "Assistant: Finally we'll do the open-road drive. Pull out when safe.",
+      "User: Right.",
+    ].join("\n\n");
+
+    const drivingCues: Record<string, string[]> = {
+      theory: ["\\btheory\\s+section\\b"],
+      manoeuvres: ["\\bmanoeuvres\\s+section\\b"],
+      drive: ["\\bopen-road\\s+drive\\b"],
+    };
+
+    const segments = await segmentMockTranscript({
+      transcript,
+      coversModuleSlugs: ["theory", "manoeuvres", "drive"],
+      slugToCues: drivingCues,
+      engine: "claude",
+      log: makeLog(),
+    });
+
+    expect(segments.map((s) => s.slug)).toEqual(["theory", "manoeuvres", "drive"]);
+    expect(segments.every((s) => s.method === "heuristic")).toBe(true);
+    expect(mockGetConfiguredMeteredAICompletion).not.toHaveBeenCalled();
+  });
+
+  it("empty slugToCues — falls back to \\bslug\\b regex per slug", () => {
+    const patterns = __internals.compileCuesToPatterns(undefined, ["intro", "core", "wrap-up"]);
+
+    expect(patterns.intro).toHaveLength(1);
+    // The fallback `\b<slug>\b` is a word-boundary match: the bare token
+    // "intro" matches, but "introduction" does NOT (no word boundary
+    // between "intro" and "duction").
+    expect("now intro begins".match(patterns.intro[0])).toBeTruthy();
+    expect("INTRO section".match(patterns.intro[0])).toBeTruthy();
+    expect("introduction matches".match(patterns.intro[0])).toBeNull();
+    // "wrap-up" — `-` is a regex metachar; the fallback escapes it so
+    // the literal slug "wrap-up" matches.
+    expect("then wrap-up follows".match(patterns["wrap-up"][0])).toBeTruthy();
+    // Non-matching word stays non-matching.
+    expect("kernel".match(patterns.core[0])).toBeNull();
+  });
+
+  it("slug absent from slugToCues — fallback regex used for that slug only", () => {
+    const partial: Record<string, string[]> = {
+      part1: ["\\bcustom\\s+part\\s*1\\b"],
+      // part2 absent → falls back to \bpart2\b
+    };
+    const patterns = __internals.compileCuesToPatterns(partial, ["part1", "part2"]);
+    expect(patterns.part1[0].source).toContain("custom");
+    expect(patterns.part2[0].source).toBe("\\bpart2\\b");
+  });
+
+  it("empty cues array for a slug — uses fallback", () => {
+    const patterns = __internals.compileCuesToPatterns({ part1: [] }, ["part1"]);
+    expect(patterns.part1[0].source).toBe("\\bpart1\\b");
   });
 });


### PR DESCRIPTION
## Summary

- Replaces IELTS-hardcoded `HEURISTIC_PATTERNS` in `lib/curriculum/segment-mock-transcript.ts` with a per-call `slugToCues` option sourced from a new `CurriculumModule.segmentCues String[]` column. Fallback `\b<slug>\b` regex preserves a safe default for new courses; AI fallback still covers the rest.
- Pipeline route's per-segment scoring helper switches from per-slug `resolveModuleByLogicalId` loop to one `findMany` that fetches `id + slug + segmentCues` together (still curriculumId-scoped per #407, no N+1).
- IELTS seed populates the 3 legacy regex strings onto `part1 / part2 / part3` modules in a post-projection `updateMany`, mirroring the existing `coversModules` sibling block. Byte-identical heuristic behaviour for IELTS Mock.
- Boaz's #1739 `writeCallScore` segmentKey writer is transparent — `TranscriptSegment.slug` return shape unchanged.

## Migration

`20260616180000_1785_curriculum_module_segment_cues` — additive:

```sql
ALTER TABLE "CurriculumModule"
  ADD COLUMN IF NOT EXISTS "segmentCues" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
```

Matches the #494 `coversModules` pattern. No unique-key changes; no row rewrites. Needs `/vm-cpp` on hf-dev.

## Lattice survey [verified]

- Surface: new column `CurriculumModule.segmentCues` ([apps/admin/prisma/schema.prisma:2799](apps/admin/prisma/schema.prisma#L2799)); reader `lib/curriculum/segment-mock-transcript.ts:84` (`compileCuesToPatterns`); sole writer `prisma/seed-ielts-course.ts:222` (post-projection IELTS upsert).
- **Sibling-writer drift:** NIL — single producer; fixture parser doesn't yet handle the column [verified via `qmd search segmentCues`].
- **Default-deny gates:** the existing `coversModules.length > 0` gate at [apps/admin/app/api/calls/[callId]/pipeline/route.ts:582](apps/admin/app/api/calls/[callId]/pipeline/route.ts#L582) is unchanged — segmentation still short-circuits when the bound module has no `coversModules` [verified].
- **Cascade respect:** segmentCues is per-curriculum-module identity, not cascadable [verified — `lib/cascade/knob-keys.ts` has no entry].
- **Convention conflict:** matches existing `String[]` columns (`prerequisites`, `keyTerms`, `assessmentCriteria`, `coversModules`) on the model [verified via schema read].
- **`hf-curriculum/no-unscoped-slug-lookup` ESLint rule:** new `prisma.curriculumModule.findMany({where:{curriculumId, slug:{in:…}}})` includes `curriculumId` — passes [verified at pre-push lint].

## Verified by

- ✅ vitest pin: `tests/lib/segment-mock-transcript.test.ts` 15/15 (11 existing tests threaded with `slugToCues: IELTS_CUES`; 4 new: non-IELTS driving-test cues / undefined→fallback / partial map / empty cues per slug). [verified by running locally — see commit body].
- ✅ vitest pin: `tests/lib/measurement/per-part-segmentkey-roundtrip.test.ts` 2/2 (IELTS round-trip with explicit cues pinned). [verified].
- ✅ pre-push tsc: 0 errors, lint: 0 errors in changed files. [verified — log output above].
- ✅ Lattice survey result inline above; each risk shape probed and cited.

## Test plan

- [ ] `/vm-cpp` to apply `20260616180000_1785_curriculum_module_segment_cues` + run IELTS seed on hf-dev (or `npm run db:seed`).
- [ ] Run an IELTS Mock transcript end-to-end on hf-dev — confirm the heuristic still resolves 3 segments (no AI fallback triggered for a clean transcript).
- [ ] Optional: seed a non-IELTS course module with custom `segmentCues` and confirm segmentation by those cues.

Closes #1785.