### PR TITLE
feat(vm): #1763 VM migration lock — prevent concurrent prisma migrate dev races

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -187,6 +187,13 @@ fi
 if [ "$PEER_COUNT" -gt 1 ]; then
   MSG="${MSG}🚨 $PEER_COUNT concurrent claude processes detected. They share this working tree — peer 'git checkout' calls will swap HEAD under you. Treat any unexplained branch change as confirmation. See memory/feedback_concurrent_claude_processes.md for recovery. "
 fi
+# VM migration lock (S8 / #1763) — warn if another operator has a pending Prisma migration on shared hf_sandbox.
+if [ -x "$REPO_ROOT/scripts/check-vm-migration-lock.sh" ]; then
+  LOCK_MSG="$("$REPO_ROOT/scripts/check-vm-migration-lock.sh" summary 2>/dev/null || true)"
+  if [ -n "$LOCK_MSG" ]; then
+    MSG="${MSG}${LOCK_MSG} "
+  fi
+fi
 # Tell claude which lock role it claimed so it surfaces the right
 # expectations to the user.
 if [ "$LOCK_ROLE" = "secondary" ]; then

--- a/.claude/rules/vm-migration-lock.md
+++ b/.claude/rules/vm-migration-lock.md
@@ -1,0 +1,66 @@
+# VM Migration Lock
+
+> When two operators share the `hf-dev` VM + `hf_sandbox` DB, simultaneous
+> `npx prisma migrate dev` calls produce non-deterministic migration history
+> divergence. The lock makes the second operator wait.
+>
+> Story: [#1763](https://github.com/WANDERCOLTD/HF/issues/1763) (S8 of release-pipeline epic #1723).
+
+## Rule
+
+On the `hf-dev` VM, run migrations via the wrapper:
+
+```bash
+scripts/vm-migrate.sh --name <slug>
+```
+
+**Not** the bare `npx prisma migrate dev --name <slug>` command.
+
+The wrapper:
+1. Refuses to start if another operator holds a fresh lock (<30 min)
+2. Acquires the lock for you on entry
+3. Releases on success; retains on failure (you investigate + retry)
+
+## When this applies
+
+- The VM `hf-dev` shared by Paul + Boaz, both running migrations against `hf_sandbox`
+- Any future shared dev surface (e.g., remote pair-programming session)
+
+**Not** applicable when:
+- Single operator on the VM (lock acquired + released by the same person — no contention)
+- Local Mac (no shared filesystem; per CLAUDE.local.md operators don't run dev locally)
+- Cloud Run migrate jobs (run via `hf-migrate-*` job, single-threaded by GCP)
+
+## Lock file convention
+
+- Location: `<repo-root>/.vm-migration-lock` (git-ignored — local only)
+- Format: `<owner>|<iso-timestamp>|<branch>|<intent>` on a single line
+- Stale threshold: 30 min of mtime age. Stale locks warn-only; can be reclaimed.
+
+## Session-start warning
+
+`.claude/hooks/session-start.sh` calls `scripts/check-vm-migration-lock.sh`
+on session open. If a fresh lock is held by another operator, the warning
+surfaces immediately so you know not to start a migration.
+
+## Failure modes the lock prevents
+
+1. **History divergence** — both operators run migrate dev with the same starting state; second migration's parent SHA in `_prisma_migrations` differs from what `migrate deploy` expects upstream
+2. **Drift between operator's local migration file and pushed migration** — Paul writes migration A locally, Boaz pulls + writes migration B without seeing A, two migration files target the same starting state
+3. **Mid-shadow-db races** — Prisma's shadow DB used during `migrate dev` doesn't tolerate two writers; symptoms are confusing "table already exists" errors
+
+## Bypass (rare)
+
+`HF_VM_MIGRATE_BYPASS=1 scripts/vm-migrate.sh ...` skips the pre-flight check. Use only when:
+- You confirmed via Slack/voice the other operator is done
+- Their lock file is stale (>30 min) AND you can't reach them
+- A real emergency requires the migration immediately
+
+Document the bypass in the migration's commit body.
+
+## Related
+
+- [`scripts/check-vm-migration-lock.sh`](../../scripts/check-vm-migration-lock.sh) — the standalone check
+- [`scripts/vm-migrate.sh`](../../scripts/vm-migrate.sh) — the wrapper
+- [`docs/CHAIN-CONTRACTS.md`](../../docs/CHAIN-CONTRACTS.md) — for the broader concurrency model
+- CLAUDE.md "No concurrent claude sessions" section — the working-tree lock sibling

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ A-Sample Docs/
 *.docx
 docs/market-test-plan.md
 .claude/scheduled_tasks.lock
+.vm-migration-lock

--- a/scripts/check-vm-migration-lock.sh
+++ b/scripts/check-vm-migration-lock.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/check-vm-migration-lock.sh
+#
+# Reads .vm-migration-lock at repo root and warns if another operator has
+# a pending Prisma migration. Used by:
+#   - .claude/hooks/session-start.sh (warn-only at session open)
+#   - scripts/vm-migrate.sh (block before starting a new migration)
+#
+# Lock-file format (single line, pipe-separated):
+#   <owner>|<iso8601-timestamp>|<branch>|<migration-intent>
+#
+# Lock is considered STALE after 30 min (operator forgot to /vm-cpp).
+# Stale locks warn but don't block — operator can rerun the wrapper to reclaim.
+#
+# Exit codes:
+#   0 — no lock, OR lock held by current operator, OR lock is stale (warn)
+#   1 — lock held by another operator, fresh (< 30 min)
+#
+# Used by scripts/vm-migrate.sh with --strict to convert exit 1 → block.
+
+set -euo pipefail
+
+MODE="${1:-warn}"  # warn (default) | strict | summary
+# summary: emit ONE line to stdout (for session-start.sh embedding), exit 0
+# warn:    multi-line stderr, exit 0 (default; pre-action visibility)
+# strict:  multi-line stderr + exit 1 if lock held by another operator (block)
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$REPO_ROOT" ] && exit 0
+LOCK_FILE="$REPO_ROOT/.vm-migration-lock"
+
+# No lock — clean state.
+[ ! -f "$LOCK_FILE" ] && exit 0
+
+LOCK_LINE="$(head -1 "$LOCK_FILE" 2>/dev/null || true)"
+[ -z "$LOCK_LINE" ] && exit 0
+
+IFS='|' read -r LOCK_OWNER LOCK_TS LOCK_BRANCH LOCK_INTENT <<< "$LOCK_LINE"
+
+# Current operator: prefer GIT_AUTHOR_NAME, fall back to git config, then $USER.
+ME="${GIT_AUTHOR_NAME:-$(git config --get user.name 2>/dev/null || echo "$USER")}"
+
+# Stale check (30 min). Lock file mtime is the source of truth (more reliable
+# than the embedded timestamp which may not match TZ).
+LOCK_MTIME=$(stat -f '%m' "$LOCK_FILE" 2>/dev/null || stat -c '%Y' "$LOCK_FILE" 2>/dev/null || echo 0)
+NOW=$(date +%s)
+AGE_SECS=$(( NOW - LOCK_MTIME ))
+
+AGE_MIN=$((AGE_SECS / 60))
+
+if [ "$AGE_SECS" -gt 1800 ]; then
+  if [ "$MODE" = "summary" ]; then
+    echo "🟡 VM-migration-lock stale (${AGE_MIN}m): $LOCK_OWNER on $LOCK_BRANCH — safe to reclaim."
+  else
+    echo "" >&2
+    echo "[vm-migration-lock] ⚠ Stale lock detected (>30 min old):" >&2
+    echo "  owner:    $LOCK_OWNER" >&2
+    echo "  branch:   $LOCK_BRANCH" >&2
+    echo "  age:      ${AGE_MIN} min" >&2
+    echo "  intent:   $LOCK_INTENT" >&2
+    echo "  Path:     $LOCK_FILE" >&2
+    echo "  Stale — safe to reclaim. Run scripts/vm-migrate.sh to take over." >&2
+  fi
+  exit 0
+fi
+
+# Lock held by current operator — no warn.
+[ "$LOCK_OWNER" = "$ME" ] && exit 0
+
+# Fresh lock held by someone else — warn (or block in strict mode).
+if [ "$MODE" = "summary" ]; then
+  echo "🛑 VM-migration-lock held by $LOCK_OWNER on $LOCK_BRANCH (${AGE_MIN}m ago) — don't run prisma migrate dev."
+  exit 0
+fi
+
+echo "" >&2
+echo "[vm-migration-lock] 🛑 Another operator has a pending Prisma migration:" >&2
+echo "  owner:    $LOCK_OWNER" >&2
+echo "  branch:   $LOCK_BRANCH" >&2
+echo "  age:      ${AGE_MIN} min" >&2
+echo "  intent:   $LOCK_INTENT" >&2
+echo "" >&2
+echo "  DO NOT run 'npx prisma migrate dev' until lock clears." >&2
+echo "  Coordinate with $LOCK_OWNER or wait for their /vm-cpp push." >&2
+echo "" >&2
+
+if [ "$MODE" = "strict" ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/vm-migrate.sh
+++ b/scripts/vm-migrate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/vm-migrate.sh
+#
+# Wrapper for `npx prisma migrate dev` that adds the multi-operator lock
+# discipline (S8 / #1763). Use this on the VM instead of bare `npx prisma
+# migrate dev` to prevent concurrent-migration races between Paul + Boaz
+# on shared hf_sandbox.
+#
+# Usage:
+#   scripts/vm-migrate.sh --name <migration-slug>
+#   scripts/vm-migrate.sh --name add_xyz_table --create-only
+#   scripts/vm-migrate.sh --help
+#
+# All args after the wrapper's own are passed through to `prisma migrate dev`.
+#
+# Lifecycle:
+#   1. Pre-flight check via scripts/check-vm-migration-lock.sh --strict.
+#      If another operator holds a fresh lock, exit 1.
+#   2. Write .vm-migration-lock with this operator's identity.
+#   3. Run npx prisma migrate dev "$@" inside apps/admin/.
+#   4. On success: delete the lock.
+#   5. On failure: keep the lock (operator may retry).
+#   6. .vm-migration-lock is in .gitignore — never committed.
+#
+# Bypass (not recommended): set HF_VM_MIGRATE_BYPASS=1 to skip the lock check.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+  echo "[vm-migrate] ✗ not in a git repo — aborting" >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+# ── Pre-flight ────────────────────────────────────────────────────────────
+if [ "${HF_VM_MIGRATE_BYPASS:-0}" != "1" ]; then
+  if ! ./scripts/check-vm-migration-lock.sh strict; then
+    echo "[vm-migrate] Blocked by fresh lock from another operator." >&2
+    echo "[vm-migrate] If you must proceed: HF_VM_MIGRATE_BYPASS=1 scripts/vm-migrate.sh ..." >&2
+    exit 1
+  fi
+fi
+
+# ── Acquire lock ─────────────────────────────────────────────────────────
+LOCK_FILE="$REPO_ROOT/.vm-migration-lock"
+OWNER="${GIT_AUTHOR_NAME:-$(git config --get user.name 2>/dev/null || echo "$USER")}"
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "<detached>")"
+INTENT="$*"
+[ -z "$INTENT" ] && INTENT="(bare prisma migrate dev)"
+
+printf '%s|%s|%s|%s\n' "$OWNER" "$TIMESTAMP" "$BRANCH" "$INTENT" > "$LOCK_FILE"
+echo "[vm-migrate] 🔒 Acquired lock: $OWNER on $BRANCH at $TIMESTAMP" >&2
+
+# ── Run migration ────────────────────────────────────────────────────────
+cd apps/admin
+if npx prisma migrate dev "$@"; then
+  rm -f "$LOCK_FILE"
+  echo "[vm-migrate] 🔓 Lock released — migration succeeded" >&2
+  echo "[vm-migrate] Don't forget to commit + push (/vm-cpp) so the migration reaches other envs." >&2
+  exit 0
+else
+  RC=$?
+  echo "[vm-migrate] ✗ Migration failed (exit $RC); LOCK RETAINED." >&2
+  echo "[vm-migrate] Investigate, retry, or manually delete $LOCK_FILE if abandoning." >&2
+  exit "$RC"
+fi


### PR DESCRIPTION
## Summary

S8 of release-pipeline epic #1723. Prepares the VM for Boaz joining — when two operators share `hf_sandbox`, simultaneous `prisma migrate dev` produces history divergence + shadow-DB races. The lock makes the second operator wait.

## What landed

- `scripts/check-vm-migration-lock.sh` — read-only check, 3 modes (`warn` / `strict` / `summary`)
- `scripts/vm-migrate.sh` — wrapper that acquires lock, runs migrate, releases on success
- `.claude/hooks/session-start.sh` — embeds the summary line in session-start MSG so the warning surfaces immediately
- `.claude/rules/vm-migration-lock.md` — discipline docs
- `.gitignore` — `.vm-migration-lock` (local-only)

## Lock semantics

- Format: `<owner>|<iso-timestamp>|<branch>|<intent>` (one line)
- Stale threshold: 30 min mtime age (warn-only, reclaim allowed)
- Bypass: `HF_VM_MIGRATE_BYPASS=1 scripts/vm-migrate.sh ...`

## Verified by

- Unit-test via 3 in-repo scenarios:
  1. **No lock present** → silent (exit 0) — [verified]
  2. **Other operator's fresh lock** → `🛑 VM-migration-lock held by Boaz on feat/test (0m ago) — don't run prisma migrate dev.` — [verified]
  3. **My own lock** → silent (no warn against self) — [verified]
- Bash syntax (`bash -n`) clean — [verified]
- `.vm-migration-lock` added to `.gitignore` so the local-only convention is preserved — [verified] read .gitignore
- session-start.sh modification preserves existing structure — [verified] new check appended between PEER_COUNT block and LOCK_ROLE block

## Out of scope

- Automatic detection of bare `npx prisma migrate dev` (operator must use the wrapper) — could be enforced via a Prisma config plugin later, not worth the engineering today
- Cross-VM lock (e.g. if HF ever runs multiple shared VMs) — single VM today
- Hook into `/vm-cpp` slash command to auto-release on successful push — wrapper releases on its own success path; if operator runs bare migrate + manually pushes, lock stays until next wrapper run reclaims it. Acceptable trade-off.

## Test plan

- [x] 3-case in-repo unit test passes
- [ ] Post-merge: re-install hooks on the VM (one-shot per-machine setup happens naturally on next `git pull` workflow)
- [ ] Post-merge: Boaz dry-run on the VM — verify session-start shows the warning when I hold a lock
- [ ] Post-merge: a real migration via `scripts/vm-migrate.sh --name <slug>` — verify lock is acquired + released cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)