### PR TITLE
feat(student): #1751 Theme 13a — Mock Results screen

### DIFF
--- a/apps/admin/app/api/student/[courseId]/results/[sessionId]/route.ts
+++ b/apps/admin/app/api/student/[courseId]/results/[sessionId]/route.ts
@@ -1,0 +1,259 @@
+/**
+ * @api GET /api/student/:courseId/results/:sessionId
+ * @visibility public
+ * @scope student:read
+ * @auth session (VIEWER+ — STUDENT scoped to own caller)
+ * @tags student, results
+ * @description Mock-exam Results screen payload for `/x/student/[courseId]/results/[sessionId]`.
+ *   Aggregates `CallScore` rows for every Call belonging to the Session, grouped by
+ *   `segmentKey` × parameter. Computes the IELTS overall band (mean of per-criterion bands,
+ *   half-band rounded) from the same rows when `Session.metadata.overallBand` is absent
+ *   — the writer for that field is a producer-gap follow-on (epic #1700 Theme 11 #1749
+ *   only writes `scoreDeltas`; `overallBand` declared in `lib/types/json-fields.ts:1082`
+ *   but never written today).
+ *
+ *   STUDENT sessions are scoped to their own Caller via `studentAllowedToReadCaller`
+ *   (mirrors the precedent at `/api/calls/[callId]/route.ts`). The `courseId` path
+ *   param must match the Session's `playbookId` (403 mismatch otherwise) — prevents
+ *   cross-course session reads.
+ *
+ *   While the Session is still recording (`status` in {STARTED, ACTIVE}) or before
+ *   the pipeline has written CallScore rows, the response returns `processing: true`
+ *   with the partial data we have. The page polls this endpoint at 5s until
+ *   `processing: false`.
+ *
+ * @pathParam courseId string - Playbook.id
+ * @pathParam sessionId string - Session.id
+ * @response 200 ResultsPayload
+ * @response 403 { ok: false, error: string }
+ * @response 404 { ok: false, error: string }
+ * @response 500 { ok: false, error: string }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
+import { scoreToTier, getSkillTierMapping } from "@/lib/goals/track-progress";
+import type { SessionMetadata } from "@/lib/types/json-fields";
+
+export interface ResultsScore {
+  parameterId: string;
+  parameterName: string;
+  segmentKey: string | null;
+  /** Mean of all CallScore.score values for this (parameter, segmentKey) pair. */
+  score: number;
+  /** Tier label from `scoreToTier`. */
+  tier: string;
+  /** Band number from `scoreToTier` (IELTS 0–9 / Generic 1–4 — depends on mapping). */
+  band: number;
+  /** Number of CallScore rows aggregated. */
+  count: number;
+}
+
+export interface ResultsPayload {
+  ok: true;
+  /** True until the Session has ended AND CallScore rows are written. */
+  processing: boolean;
+  sessionId: string;
+  courseId: string;
+  courseTitle: string | null;
+  callerId: string;
+  startedAt: string;
+  endedAt: string | null;
+  status: string;
+  /** All scores grouped — segmentKey === null means session-wide / bound-module scoring. */
+  scores: ResultsScore[];
+  /**
+   * Overall band — preferred from `Session.metadata.overallBand`; computed from
+   * `scores` as mean-of-per-criterion-band, half-band rounded, when absent.
+   * Null when no scores exist yet.
+   */
+  overallBand: number | null;
+  /** Whether `overallBand` came from metadata or was computed on the fly. */
+  overallBandSource: "metadata" | "computed" | null;
+  /** Parameter with the highest mean band across all segments. */
+  strength: { parameterId: string; parameterName: string; band: number } | null;
+  /** Parameter with the lowest mean band across all segments. */
+  area: { parameterId: string; parameterName: string; band: number } | null;
+}
+
+export type ResultsResponse =
+  | ResultsPayload
+  | { ok: false; error: string };
+
+function roundHalfBand(value: number): number {
+  return Math.round(value * 2) / 2;
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ courseId: string; sessionId: string }> },
+): Promise<NextResponse<ResultsResponse>> {
+  try {
+    const authResult = await requireAuth("VIEWER");
+    if (isAuthError(authResult)) return authResult.error;
+
+    const { courseId, sessionId } = await params;
+
+    const session = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: {
+        id: true,
+        callerId: true,
+        playbookId: true,
+        kind: true,
+        status: true,
+        startedAt: true,
+        endedAt: true,
+        metadata: true,
+        playbook: { select: { name: true } },
+      },
+    });
+
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Session not found" }, { status: 404 });
+    }
+
+    if (session.playbookId !== courseId) {
+      return NextResponse.json(
+        { ok: false, error: "Session does not belong to this course" },
+        { status: 403 },
+      );
+    }
+
+    if (!studentAllowedToReadCaller(authResult.session, session.callerId)) {
+      return callerScopeMismatchResponse() as NextResponse<ResultsResponse>;
+    }
+
+    const [scores, mapping] = await Promise.all([
+      prisma.callScore.findMany({
+        where: { call: { sessionId } },
+        select: {
+          parameterId: true,
+          segmentKey: true,
+          score: true,
+          parameter: { select: { name: true } },
+        },
+      }),
+      getSkillTierMapping(session.playbookId),
+    ]);
+
+    type Bucket = { parameterId: string; parameterName: string; segmentKey: string | null; sum: number; count: number };
+    const buckets = new Map<string, Bucket>();
+    for (const row of scores) {
+      const key = `${row.parameterId}::${row.segmentKey ?? ""}`;
+      const bucket = buckets.get(key);
+      if (bucket) {
+        bucket.sum += row.score;
+        bucket.count += 1;
+      } else {
+        buckets.set(key, {
+          parameterId: row.parameterId,
+          parameterName: row.parameter.name,
+          segmentKey: row.segmentKey ?? null,
+          sum: row.score,
+          count: 1,
+        });
+      }
+    }
+
+    const aggregated: ResultsScore[] = Array.from(buckets.values()).map((b) => {
+      const mean = b.sum / b.count;
+      const { tier, band } = scoreToTier(mean, mapping);
+      return {
+        parameterId: b.parameterId,
+        parameterName: b.parameterName,
+        segmentKey: b.segmentKey,
+        score: mean,
+        tier,
+        band,
+        count: b.count,
+      };
+    });
+
+    // Strength / area — collapse across segments, picking max / min mean band per parameter.
+    const perParam = new Map<string, { name: string; bandSum: number; cellCount: number }>();
+    for (const cell of aggregated) {
+      const existing = perParam.get(cell.parameterId);
+      if (existing) {
+        existing.bandSum += cell.band;
+        existing.cellCount += 1;
+      } else {
+        perParam.set(cell.parameterId, {
+          name: cell.parameterName,
+          bandSum: cell.band,
+          cellCount: 1,
+        });
+      }
+    }
+    const perParamMean = Array.from(perParam.entries())
+      .map(([parameterId, v]) => ({
+        parameterId,
+        parameterName: v.name,
+        band: v.bandSum / v.cellCount,
+      }))
+      .sort((a, b) => b.band - a.band);
+
+    const strength = perParamMean.length > 0 ? perParamMean[0] : null;
+    const area = perParamMean.length > 0 ? perParamMean[perParamMean.length - 1] : null;
+
+    const metadata = (session.metadata ?? {}) as SessionMetadata;
+    const overallBandFromMeta = typeof metadata.overallBand === "number" ? metadata.overallBand : null;
+
+    let overallBand: number | null = overallBandFromMeta;
+    let overallBandSource: ResultsPayload["overallBandSource"] = overallBandFromMeta !== null ? "metadata" : null;
+    if (overallBand === null && aggregated.length > 0) {
+      const meanBand = aggregated.reduce((acc, c) => acc + c.band, 0) / aggregated.length;
+      overallBand = roundHalfBand(meanBand);
+      overallBandSource = "computed";
+    }
+
+    // `processing` is true until the pipeline has both ended the Session AND
+    // landed CallScore rows. STARTED / ACTIVE sessions are always processing;
+    // COMPLETED sessions without scores are also processing (pipeline is still
+    // running EXTRACT → MEASURE).
+    const sessionEnded =
+      session.status === "COMPLETED" ||
+      session.status === "FAILED" ||
+      session.status === "GHOST";
+    const processing = !sessionEnded || aggregated.length === 0;
+
+    const payload: ResultsPayload = {
+      ok: true,
+      processing,
+      sessionId: session.id,
+      courseId,
+      courseTitle: session.playbook?.name ?? null,
+      callerId: session.callerId,
+      startedAt: session.startedAt.toISOString(),
+      endedAt: session.endedAt?.toISOString() ?? null,
+      status: session.status,
+      scores: aggregated,
+      overallBand,
+      overallBandSource,
+      strength: strength
+        ? {
+            parameterId: strength.parameterId,
+            parameterName: strength.parameterName,
+            band: roundHalfBand(strength.band),
+          }
+        : null,
+      area: area
+        ? {
+            parameterId: area.parameterId,
+            parameterName: area.parameterName,
+            band: roundHalfBand(area.band),
+          }
+        : null,
+    };
+
+    return NextResponse.json(payload);
+  } catch (err) {
+    console.error("[/api/student/results] error", err);
+    return NextResponse.json(
+      { ok: false, error: "Failed to load results" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
@@ -20,7 +20,7 @@
  * as an error banner.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import type { ResultsPayload, ResultsResponse } from "@/app/api/student/[courseId]/results/[sessionId]/route";
@@ -37,7 +37,6 @@ type FetchState =
 export default function MockResultsPage() {
   const { courseId, sessionId } = useParams<{ courseId: string; sessionId: string }>();
   const [state, setState] = useState<FetchState>({ kind: "loading" });
-  const startedAtRef = useRef<number>(Date.now());
 
   const fetchOnce = useCallback(async () => {
     try {
@@ -61,7 +60,7 @@ export default function MockResultsPage() {
 
   useEffect(() => {
     if (!courseId || !sessionId) return;
-    startedAtRef.current = Date.now();
+    const startedAt = Date.now();
     let stopped = false;
 
     void fetchOnce().then(({ processing }) => {
@@ -70,7 +69,7 @@ export default function MockResultsPage() {
 
     const interval = setInterval(async () => {
       if (stopped) return;
-      if (Date.now() - startedAtRef.current > POLL_DEADLINE_MS) {
+      if (Date.now() - startedAt > POLL_DEADLINE_MS) {
         stopped = true;
         clearInterval(interval);
         return;

--- a/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+/**
+ * /x/student/[courseId]/results/[sessionId] — Mock-exam Results screen (#1751).
+ *
+ * Renders the final IELTS-shape Results block: Overall band hero + strength /
+ * area chips + per-criterion × per-part table. Polls
+ * `/api/student/[courseId]/results/[sessionId]` at 5s until the pipeline
+ * lands (response `processing: false`) or the 3 minute deadline elapses.
+ *
+ * The `no-bespoke-async-polling` ESLint rule (`apps/admin/eslint-rules/no-bespoke-async-polling.mjs`)
+ * fires only on `setInterval` / `setTimeout` inside `while / for / do-while`
+ * loop bodies — a `useEffect` setInterval is the canonical React pattern and
+ * does not trigger the rule. Convergence with `useTaskPoll` is structural
+ * (same shape, different fetch URL); useTaskPoll itself is hardcoded to
+ * `/api/tasks` and cannot be reused for `Session.status`.
+ *
+ * STUDENT scope: server-side via `studentAllowedToReadCaller` in the API
+ * route. Client just reads — a foreign sessionId returns 403 and lands here
+ * as an error banner.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import type { ResultsPayload, ResultsResponse } from "@/app/api/student/[courseId]/results/[sessionId]/route";
+import "./results.css";
+
+const POLL_INTERVAL_MS = 5_000;
+const POLL_DEADLINE_MS = 3 * 60_000; // 3 min — pipeline EXTRACT+MEASURE budget
+
+type FetchState =
+  | { kind: "loading" }
+  | { kind: "ready"; data: ResultsPayload }
+  | { kind: "error"; message: string };
+
+export default function MockResultsPage() {
+  const { courseId, sessionId } = useParams<{ courseId: string; sessionId: string }>();
+  const [state, setState] = useState<FetchState>({ kind: "loading" });
+  const startedAtRef = useRef<number>(Date.now());
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/student/${courseId}/results/${sessionId}`);
+      const body = (await res.json()) as ResultsResponse;
+      if (!res.ok || !body.ok) {
+        const msg = !body.ok ? body.error : `Request failed (${res.status})`;
+        setState({ kind: "error", message: msg });
+        return { processing: false };
+      }
+      setState({ kind: "ready", data: body });
+      return { processing: body.processing };
+    } catch (err) {
+      setState({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Network error",
+      });
+      return { processing: false };
+    }
+  }, [courseId, sessionId]);
+
+  useEffect(() => {
+    if (!courseId || !sessionId) return;
+    startedAtRef.current = Date.now();
+    let stopped = false;
+
+    void fetchOnce().then(({ processing }) => {
+      if (!processing) return;
+    });
+
+    const interval = setInterval(async () => {
+      if (stopped) return;
+      if (Date.now() - startedAtRef.current > POLL_DEADLINE_MS) {
+        stopped = true;
+        clearInterval(interval);
+        return;
+      }
+      const { processing } = await fetchOnce();
+      if (!processing) {
+        stopped = true;
+        clearInterval(interval);
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      stopped = true;
+      clearInterval(interval);
+    };
+  }, [courseId, sessionId, fetchOnce]);
+
+  return (
+    <div className="hf-results-wrap">
+      <div className="hf-results-container">
+        <header className="hf-results-header">
+          <span className="hf-results-header-eyebrow">Mock results</span>
+          <h1 className="hf-results-header-title">
+            {state.kind === "ready" ? state.data.courseTitle ?? "Your results" : "Your results"}
+          </h1>
+        </header>
+
+        {state.kind === "loading" && <ProcessingCard />}
+
+        {state.kind === "error" && (
+          <div className="hf-results-error" role="alert">
+            {state.message}
+          </div>
+        )}
+
+        {state.kind === "ready" && state.data.processing && <ProcessingCard />}
+
+        {state.kind === "ready" && !state.data.processing && <ResultsView data={state.data} />}
+      </div>
+    </div>
+  );
+}
+
+function ProcessingCard() {
+  return (
+    <section className="hf-results-processing" aria-busy="true">
+      <Loader2 className="hf-results-processing-spinner" aria-hidden />
+      <div className="hf-results-processing-title">Reviewing your exam…</div>
+      <div className="hf-results-processing-desc">
+        Hold tight — we&rsquo;re scoring each part. This usually takes about a minute after the call
+        ends.
+      </div>
+    </section>
+  );
+}
+
+function ResultsView({ data }: { data: ResultsPayload }) {
+  // Build the per-criterion × per-part table. Rows = parameters, columns = segmentKeys.
+  const segmentKeys: (string | null)[] = Array.from(
+    new Set(data.scores.map((s) => s.segmentKey)),
+  ).sort((a, b) => {
+    if (a === null) return -1;
+    if (b === null) return 1;
+    return a.localeCompare(b);
+  });
+
+  const parameters: { parameterId: string; parameterName: string }[] = Array.from(
+    new Map(data.scores.map((s) => [s.parameterId, { parameterId: s.parameterId, parameterName: s.parameterName }])).values(),
+  );
+
+  function cellFor(parameterId: string, segmentKey: string | null) {
+    return data.scores.find((s) => s.parameterId === parameterId && s.segmentKey === segmentKey);
+  }
+
+  const hasScores = data.scores.length > 0;
+
+  return (
+    <>
+      {data.overallBand !== null && (
+        <section className="hf-results-hero">
+          <span className="hf-results-hero-label">Overall band</span>
+          <div className="hf-results-hero-band">{data.overallBand.toFixed(1)}</div>
+          {data.overallBandSource === "computed" && (
+            <span className="hf-results-hero-source">Computed from per-criterion bands</span>
+          )}
+        </section>
+      )}
+
+      {(data.strength || data.area) && (
+        <section className="hf-results-chips" aria-label="Strength and area to work on">
+          {data.strength && (
+            <div className="hf-results-chip hf-results-chip-strength">
+              <span className="hf-results-chip-label">Strength</span>
+              <span className="hf-results-chip-name">{data.strength.parameterName}</span>
+              <span className="hf-results-chip-band">Band {data.strength.band.toFixed(1)}</span>
+            </div>
+          )}
+          {data.area && (
+            <div className="hf-results-chip hf-results-chip-area">
+              <span className="hf-results-chip-label">Area to work on</span>
+              <span className="hf-results-chip-name">{data.area.parameterName}</span>
+              <span className="hf-results-chip-band">Band {data.area.band.toFixed(1)}</span>
+            </div>
+          )}
+        </section>
+      )}
+
+      <section className="hf-results-table-wrap" aria-label="Per-criterion band table">
+        {hasScores ? (
+          <table className="hf-results-table">
+            <thead>
+              <tr>
+                <th>Criterion</th>
+                {segmentKeys.map((seg) => (
+                  <th key={seg ?? "overall"}>{seg ?? "Overall"}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {parameters.map((p) => (
+                <tr key={p.parameterId}>
+                  <td>{p.parameterName}</td>
+                  {segmentKeys.map((seg) => {
+                    const cell = cellFor(p.parameterId, seg);
+                    return (
+                      <td key={seg ?? "overall"} className="hf-results-table-band">
+                        {cell ? cell.band.toFixed(1) : "—"}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="hf-results-table-empty">No scores recorded for this session.</div>
+        )}
+      </section>
+    </>
+  );
+}

--- a/apps/admin/app/x/student/[courseId]/results/[sessionId]/results.css
+++ b/apps/admin/app/x/student/[courseId]/results/[sessionId]/results.css
@@ -1,0 +1,214 @@
+/* ── Mock Results page (#1751) ── */
+
+.hf-results-wrap {
+  display: flex;
+  justify-content: center;
+  min-height: 100%;
+  padding: 24px;
+  background: var(--surface-secondary);
+}
+
+.hf-results-container {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hf-results-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hf-results-header-eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hf-results-header-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+/* ── Processing card ── */
+
+.hf-results-processing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 24px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  text-align: center;
+}
+
+.hf-results-processing-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-default);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: hf-results-spin 0.9s linear infinite;
+}
+
+@keyframes hf-results-spin {
+  to { transform: rotate(360deg); }
+}
+
+.hf-results-processing-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.hf-results-processing-desc {
+  font-size: 14px;
+  color: var(--text-muted);
+  max-width: 320px;
+}
+
+/* ── Overall band hero ── */
+
+.hf-results-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 24px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+}
+
+.hf-results-hero-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hf-results-hero-band {
+  font-size: 56px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.hf-results-hero-source {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* ── Strength / area chips ── */
+
+.hf-results-chips {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hf-results-chip {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border-default);
+  background: var(--surface-primary);
+}
+
+.hf-results-chip-strength {
+  border-left: 4px solid var(--status-success-text, #2e7d32);
+}
+
+.hf-results-chip-area {
+  border-left: 4px solid var(--status-warning-text, #c97a00);
+}
+
+.hf-results-chip-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hf-results-chip-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.hf-results-chip-band {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+/* ── Per-criterion table ── */
+
+.hf-results-table-wrap {
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.hf-results-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.hf-results-table th,
+.hf-results-table td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.hf-results-table th {
+  background: var(--surface-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hf-results-table tr:last-child td {
+  border-bottom: none;
+}
+
+.hf-results-table-band {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.hf-results-table-empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+/* ── Error ── */
+
+.hf-results-error {
+  padding: 24px;
+  background: var(--surface-primary);
+  border: 1px solid var(--status-error-border, #c33);
+  border-radius: 12px;
+  color: var(--status-error-text, #c33);
+  font-size: 14px;
+  text-align: center;
+}

--- a/apps/admin/tests/api/student/results/results-page.test.tsx
+++ b/apps/admin/tests/api/student/results/results-page.test.tsx
@@ -88,10 +88,11 @@ describe("MockResultsPage", () => {
       json: async () => READY_PAYLOAD,
     } as unknown as Response);
 
-    render(<MockResultsPage />);
+    const { container } = render(<MockResultsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("6.0")).toBeInTheDocument(); // Overall band hero
+      const hero = container.querySelector(".hf-results-hero-band");
+      expect(hero?.textContent).toBe("6.0");
     });
     expect(screen.getByText("Strength")).toBeInTheDocument();
     expect(screen.getByText("Area to work on")).toBeInTheDocument();

--- a/apps/admin/tests/api/student/results/results-page.test.tsx
+++ b/apps/admin/tests/api/student/results/results-page.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * RTL smoke tests for /x/student/[courseId]/results/[sessionId] — Theme 13a
+ * Mock Results page (#1751).
+ *
+ * Pinned acceptance:
+ *   1. While `processing: true` → spinner + "Reviewing your exam…" copy
+ *   2. After `processing: false` → renders overall band, strength chip, area
+ *      chip, and 4 × 3 (criterion × part) table
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ courseId: "course-1", sessionId: "sess-1" }),
+}));
+
+import MockResultsPage from "@/app/x/student/[courseId]/results/[sessionId]/page";
+
+const PROCESSING_PAYLOAD = {
+  ok: true,
+  processing: true,
+  sessionId: "sess-1",
+  courseId: "course-1",
+  courseTitle: "IELTS Speaking Practice",
+  callerId: "caller-1",
+  startedAt: "2026-06-16T10:00:00Z",
+  endedAt: null,
+  status: "STARTED",
+  scores: [],
+  overallBand: null,
+  overallBandSource: null,
+  strength: null,
+  area: null,
+};
+
+const READY_PAYLOAD = {
+  ok: true,
+  processing: false,
+  sessionId: "sess-1",
+  courseId: "course-1",
+  courseTitle: "IELTS Speaking Practice",
+  callerId: "caller-1",
+  startedAt: "2026-06-16T10:00:00Z",
+  endedAt: "2026-06-16T10:14:00Z",
+  status: "COMPLETED",
+  scores: [
+    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "part1", score: 0.7, tier: "Secure", band: 6, count: 1 },
+    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "part2", score: 0.7, tier: "Secure", band: 6, count: 1 },
+    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "part3", score: 0.7, tier: "Secure", band: 6, count: 1 },
+    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "part1", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
+    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "part2", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
+    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "part3", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
+  ],
+  overallBand: 6,
+  overallBandSource: "computed",
+  strength: { parameterId: "fc", parameterName: "Fluency & Coherence", band: 6 },
+  area: { parameterId: "lr", parameterName: "Lexical Resource", band: 5.5 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("MockResultsPage", () => {
+  it("renders processing spinner while server is still scoring", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => PROCESSING_PAYLOAD,
+    } as unknown as Response);
+
+    render(<MockResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reviewing your exam/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders overall band + strength/area chips + per-criterion table when ready", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => READY_PAYLOAD,
+    } as unknown as Response);
+
+    render(<MockResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("6.0")).toBeInTheDocument(); // Overall band hero
+    });
+    expect(screen.getByText("Strength")).toBeInTheDocument();
+    expect(screen.getByText("Area to work on")).toBeInTheDocument();
+    expect(screen.getAllByText("Fluency & Coherence").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Lexical Resource").length).toBeGreaterThan(0);
+    // Per-criterion table headers
+    expect(screen.getByText("part1")).toBeInTheDocument();
+    expect(screen.getByText("part2")).toBeInTheDocument();
+    expect(screen.getByText("part3")).toBeInTheDocument();
+  });
+
+  it("shows error banner when the API returns ok=false", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ ok: false, error: "Forbidden — caller scope mismatch" }),
+    } as unknown as Response);
+
+    render(<MockResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/caller scope mismatch/i);
+    });
+  });
+});

--- a/apps/admin/tests/api/student/results/results-route.test.ts
+++ b/apps/admin/tests/api/student/results/results-route.test.ts
@@ -149,12 +149,14 @@ describe("GET /api/student/[courseId]/results/[sessionId]", () => {
 
     expect(body.processing).toBe(false);
     expect(body.scores).toHaveLength(12);
-    // strength = pr (0.8 → band 7), area = gra (0.55 → band 5)
+    // Per the mocked scoreToTier (band = round(score*9*2)/2):
+    //   fc 0.7 → 6.5, lr 0.6 → 5.5, gra 0.55 → 5, pr 0.8 → 7
+    // strength = pr (7), area = gra (5).
     expect(body.strength.parameterId).toBe("pr");
     expect(body.area.parameterId).toBe("gra");
-    // overall = mean of 12 bands. Bands: 7,7,7 + 5.5,5.5,5.5 + 5,5,5 + 7,7,7 → mean = 6.25 → half-band rounded = 6.5
+    // Mean of 12 bands = (6.5+5.5+5+7) * 3 / 12 = 6.0 → half-band rounded = 6.
     expect(body.overallBandSource).toBe("computed");
-    expect(body.overallBand).toBe(6.5);
+    expect(body.overallBand).toBe(6);
   });
 
   it("prefers Session.metadata.overallBand when present", async () => {

--- a/apps/admin/tests/api/student/results/results-route.test.ts
+++ b/apps/admin/tests/api/student/results/results-route.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for `GET /api/student/[courseId]/results/[sessionId]` — Theme 13a
+ * Mock Results screen (#1751).
+ *
+ * Pinned acceptance:
+ *   1. STUDENT scope rejects foreign sessionId (callerId mismatch → 403)
+ *   2. 404 when session not found
+ *   3. 403 when session.playbookId !== courseId path param (cross-course read)
+ *   4. processing=true while Session.status STARTED/ACTIVE
+ *   5. processing=true when Session ended but no CallScore rows landed yet
+ *   6. processing=false when ended + scores present; aggregated per
+ *      (parameter × segmentKey); overallBand computed mean-of-12 / half-band
+ *      rounded; strength = max-band parameter; area = min-band parameter
+ *   7. overallBandSource === "metadata" when `Session.metadata.overallBand` set
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, mockStudentAllowed, mockMapping } = vi.hoisted(() => ({
+  mockPrisma: {
+    session: { findUnique: vi.fn() },
+    callScore: { findMany: vi.fn() },
+  },
+  mockStudentAllowed: vi.fn(),
+  mockMapping: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: mockStudentAllowed,
+  callerScopeMismatchResponse: () =>
+    new Response(JSON.stringify({ ok: false, error: "scope" }), { status: 403 }),
+}));
+vi.mock("@/lib/goals/track-progress", () => ({
+  // Identity-ish mapping: score 0–1 → band 0–9 (IELTS-like) for predictable test maths.
+  scoreToTier: (score: number) => ({ tier: "Test", band: Math.round(score * 9 * 2) / 2 }),
+  getSkillTierMapping: mockMapping,
+}));
+
+const PARAMS = { params: Promise.resolve({ courseId: "course-1", sessionId: "sess-1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/student/[courseId]/results/[sessionId]/route");
+}
+
+function makeSession(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "sess-1",
+    callerId: "caller-1",
+    playbookId: "course-1",
+    kind: "VOICE_CALL",
+    status: "COMPLETED",
+    startedAt: new Date("2026-06-16T10:00:00Z"),
+    endedAt: new Date("2026-06-16T10:14:00Z"),
+    metadata: null,
+    playbook: { name: "IELTS Speaking Practice" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStudentAllowed.mockReturnValue(true);
+  mockMapping.mockResolvedValue({}); // shape ignored by mocked scoreToTier
+});
+
+describe("GET /api/student/[courseId]/results/[sessionId]", () => {
+  it("rejects STUDENT reading foreign session (403)", async () => {
+    mockStudentAllowed.mockReturnValue(false);
+    mockPrisma.session.findUnique.mockResolvedValue(makeSession());
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    expect(res.status).toBe(403);
+    expect(mockPrisma.callScore.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when session not found", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(null);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when session.playbookId !== courseId path param", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(makeSession({ playbookId: "other-course" }));
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    expect(res.status).toBe(403);
+    expect(mockPrisma.callScore.findMany).not.toHaveBeenCalled();
+  });
+
+  it("processing=true while Session.status is STARTED", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(makeSession({ status: "STARTED", endedAt: null }));
+    mockPrisma.callScore.findMany.mockResolvedValue([]);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const body = (await res.json()) as { ok: true; processing: boolean };
+    expect(res.status).toBe(200);
+    expect(body.processing).toBe(true);
+  });
+
+  it("processing=true when Session ended but no scores landed yet", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(makeSession({ status: "COMPLETED" }));
+    mockPrisma.callScore.findMany.mockResolvedValue([]);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const body = (await res.json()) as { ok: true; processing: boolean };
+    expect(body.processing).toBe(true);
+  });
+
+  it("aggregates per (parameter × segmentKey) + computes overallBand + strength/area", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(makeSession({ status: "COMPLETED" }));
+    // 4 criteria × 3 parts, each criterion gets the same score per part for predictability
+    const criteria = [
+      { id: "fc", name: "Fluency & Coherence", score: 0.7 },
+      { id: "lr", name: "Lexical Resource", score: 0.6 },
+      { id: "gra", name: "Grammar", score: 0.55 },
+      { id: "pr", name: "Pronunciation", score: 0.8 },
+    ];
+    const segments = ["part1", "part2", "part3"];
+    const rows = criteria.flatMap((c) =>
+      segments.map((seg) => ({
+        parameterId: c.id,
+        segmentKey: seg,
+        score: c.score,
+        parameter: { name: c.name },
+      })),
+    );
+    mockPrisma.callScore.findMany.mockResolvedValue(rows);
+
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const body = (await res.json()) as {
+      ok: true;
+      processing: boolean;
+      scores: Array<{ parameterId: string; segmentKey: string | null; band: number; count: number }>;
+      overallBand: number;
+      overallBandSource: "metadata" | "computed" | null;
+      strength: { parameterId: string; band: number };
+      area: { parameterId: string; band: number };
+    };
+
+    expect(body.processing).toBe(false);
+    expect(body.scores).toHaveLength(12);
+    // strength = pr (0.8 → band 7), area = gra (0.55 → band 5)
+    expect(body.strength.parameterId).toBe("pr");
+    expect(body.area.parameterId).toBe("gra");
+    // overall = mean of 12 bands. Bands: 7,7,7 + 5.5,5.5,5.5 + 5,5,5 + 7,7,7 → mean = 6.25 → half-band rounded = 6.5
+    expect(body.overallBandSource).toBe("computed");
+    expect(body.overallBand).toBe(6.5);
+  });
+
+  it("prefers Session.metadata.overallBand when present", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(
+      makeSession({ status: "COMPLETED", metadata: { overallBand: 7.5 } }),
+    );
+    mockPrisma.callScore.findMany.mockResolvedValue([
+      { parameterId: "fc", segmentKey: "part1", score: 0.5, parameter: { name: "Fluency" } },
+    ]);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const body = (await res.json()) as {
+      overallBand: number;
+      overallBandSource: "metadata" | "computed" | null;
+    };
+    expect(body.overallBand).toBe(7.5);
+    expect(body.overallBandSource).toBe("metadata");
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -13632,6 +13632,39 @@ Lightweight status bar data — call activity (OPERATOR+) and AI spend (ADMIN+).
 
 ## Student
 
+### `GET` /api/student/:courseId/results/:sessionId
+
+Mock-exam Results screen payload for `/x/student/[courseId]/results/[sessionId]`.
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `student:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| courseId | path | string | Yes | Playbook.id |
+| sessionId | path | string | Yes | Session.id |
+
+**Response** `200`
+```json
+ResultsPayload
+```
+
+**Response** `403`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `POST` /api/student/assessment
 
 Submit pre-test, mid-test, or post-test answers. Stores each answer + correctness
@@ -16211,8 +16244,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 536 |
-| Files with annotations | 523 |
+| Route files found | 537 |
+| Files with annotations | 524 |
 | Files missing annotations | 13 |
 | Coverage | 97.6% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -4561,6 +4561,39 @@ Returns a hierarchical tree structure of ALL specs grouped by Domain > Scope > O
 
 ## Student
 
+### `GET` /api/v1/student/:courseId/results/:sessionId
+
+Mock-exam Results screen payload for `/x/student/[courseId]/results/[sessionId]`.
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `student:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| courseId | path | string | Yes | Playbook.id |
+| sessionId | path | string | Yes | Session.id |
+
+**Response** `200`
+```json
+ResultsPayload
+```
+
+**Response** `403`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `GET` /api/v1/student/courses
 
 List all course enrollments for the authenticated student. Returns playbook metadata, status, session count, and active goal count.


### PR DESCRIPTION
## Summary

New read-only route + page for the IELTS Mock exam Results block (epic #1700 Theme 13a):

- `GET /api/student/[courseId]/results/[sessionId]` — aggregates `CallScore` rows for every Call belonging to the Session, grouped by `(parameter × segmentKey)`. Returns overall band (prefers `Session.metadata.overallBand` when present, falls back to mean-of-per-criterion-band, half-band rounded), strength (max-band parameter), area (min-band parameter), and a `processing` flag.
- `/x/student/[courseId]/results/[sessionId]` — client page that polls at 5s with a 3-min deadline. Renders hero band card, strength / area chips, per-criterion × per-part band table. "Reviewing your exam…" spinner while processing.

## Lattice survey [verified]

- Surface: new read-only route + page. No DB writes. Reads `Session.metadata` (typed at `lib/types/json-fields.ts:1077`), `CallScore.segmentKey` (written via `lib/measurement/write-call-score.ts::writeCallScore` chokepoint), `studentAllowedToReadCaller` from `lib/learner-scope.ts`.
- **Sibling-writer drift:** NIL — read-only path [verified via `grep -rn 'session\.metadata\|sessionMetadata\|Session\.metadata' apps/admin`].
- **Default-deny gates:** NIL — no ESLint rule gates Session/CallScore reads [verified].
- **Cascade respect:** NIL — `Session.metadata` is per-session bag, not cascadable [verified — no entry in `lib/cascade/knob-keys.ts`].
- **Convention conflict:** NIL — `studentAllowedToReadCaller(session, session.callerId)` matches the path-param-Caller precedent at `app/api/calls/[callId]/route.ts:182` [verified].
- **`no-bespoke-async-polling` ESLint rule:** the rule's `findPollPrimitiveInside` only walks `WhileStatement / DoWhileStatement / ForStatement` ([verified at `apps/admin/eslint-rules/no-bespoke-async-polling.mjs:152-162`]). `useEffect` + `setInterval` in the page is the canonical React pattern and does not trigger.
- **Tiered-redactor (#1685 C5):** STUDENT viewing OWN session sees full bands per the parent epic AC. No `@tieredVisibility` tag added [verified — the response shape is the same regardless of role].
- **Producer-gap flagged:** `Session.metadata.overallBand` is declared in `lib/types/json-fields.ts:1082` (Theme 11 plan) but no production writer exists today. Theme 11 #1749 (closed) only writes `scoreDeltas` [verified by searching `grep -rn 'overallBand' apps/admin` — returns 2 hits, both in `lib/types/json-fields.ts`]. **The route's read-side fallback computes mean-of-per-criterion-band, half-band rounded — same formula the type doc describes.** Follow-on for the proper pipeline-stage writer is needed to land alongside Theme 6/11 hardening.

## Verified by

- ✅ vitest: `tests/api/student/results/results-route.test.ts` 7/7 (STUDENT scope guard / 404 session / 403 cross-course / processing while STARTED / processing while ended-without-scores / aggregation + strength/area + computed overallBand / metadata.overallBand preferred when set).
- ✅ RTL: `tests/api/student/results/results-page.test.tsx` 3/3 (processing spinner / ready hero + chips + table / API error banner). [verified by local run].
- ✅ pre-push tsc + lint clean on changed files. [verified at log above].
- ✅ Lattice survey result inline above; each risk shape probed and cited.

## Test plan

- [ ] `/vm-cp` — no migration needed (read-only route).
- [ ] On hf-dev: open `/x/student/<courseId>/results/<sessionId>` for an IELTS Mock session that has completed + scored — confirm hero band, strength / area chips, and per-part × per-criterion table render.
- [ ] Quick STUDENT-scope probe: a foreign sessionId in the URL → 403 + error banner.
- [ ] Optional: kick a Mock from `/x/student/<courseId>/modules`, navigate to results while still recording — confirm "Reviewing your exam…" spinner; the page auto-refreshes when the pipeline lands.

Closes #1751.