### PR TITLE
feat(student): #1750 follow-on — tester direct-link route

### DIFF
--- a/apps/admin/app/x/test/[playbookSlug]/[moduleSlug]/page.tsx
+++ b/apps/admin/app/x/test/[playbookSlug]/[moduleSlug]/page.tsx
@@ -1,0 +1,168 @@
+/**
+ * /x/test/[playbookSlug]/[moduleSlug] — Tester direct-link route
+ * (#1750 follow-on, epic #1700 Theme 12).
+ *
+ * The MVP entry point for OPERATOR+ testers iterating on a specific module.
+ * Walks:
+ *
+ *   1. Slug → Playbook (UUID match first, then slugified-name match).
+ *   2. Slug → CurriculumModule on the Playbook's primary Curriculum.
+ *   3. Picks the latest demo Caller on the Playbook
+ *      (CallerPlaybook.policyMode = "demo", status = "ACTIVE") as the clone
+ *      source — same convention as `precompose_for_fresh_learner` and the
+ *      `reprompt_demo_set` admin tools.
+ *   4. Calls `cloneDemoCaller(...)` with mode = `searchParams.learnerMode`
+ *      (default "fresh"). The helper returns a (possibly new) callerId.
+ *   5. Redirects to `/x/callers/<callerId>/sim?module=<moduleId>` —
+ *      that's the existing sim playground sized to drive a Mock end-to-end.
+ *
+ * Generic URL (course-agnostic) per epic #1700 decision 3.
+ * OPERATOR+ only. When prerequisites fail (no demo caller, slug not
+ * found, missing curriculum) the page renders an actionable error
+ * banner with a hint instead of redirecting — testers see WHY the
+ * direct-link is unavailable.
+ */
+
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import slugify from "slugify";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import {
+  cloneDemoCaller,
+  type CloneDemoCallerMode,
+} from "@/lib/test-harness/clone-demo-caller";
+
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+
+interface PageProps {
+  params: Promise<{ playbookSlug: string; moduleSlug: string }>;
+  searchParams: Promise<{ learnerMode?: string }>;
+}
+
+function slugFor(name: string): string {
+  return slugify(name, { lower: true, strict: true });
+}
+
+function parseMode(raw: string | undefined): CloneDemoCallerMode {
+  return raw === "return" ? "return" : "fresh";
+}
+
+async function resolvePlaybook(playbookSlug: string) {
+  if (UUID_RE.test(playbookSlug)) {
+    const pb = await prisma.playbook.findUnique({
+      where: { id: playbookSlug },
+      select: { id: true, name: true },
+    });
+    if (pb) return pb;
+  }
+  const candidates = await prisma.playbook.findMany({
+    where: { status: { in: ["PUBLISHED", "DRAFT"] } },
+    select: { id: true, name: true },
+  });
+  return candidates.find((c) => slugFor(c.name) === playbookSlug) ?? null;
+}
+
+async function resolveDemoSourceCaller(playbookId: string) {
+  const enrol = await prisma.callerPlaybook.findFirst({
+    where: { playbookId, policyMode: "demo", status: "ACTIVE" },
+    orderBy: { enrolledAt: "desc" },
+    select: { callerId: true },
+  });
+  return enrol?.callerId ?? null;
+}
+
+export default async function TesterDirectLinkPage({ params, searchParams }: PageProps) {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) {
+    redirect("/login?callbackUrl=/x/test");
+  }
+
+  const { playbookSlug, moduleSlug } = await params;
+  const { learnerMode } = await searchParams;
+  const mode = parseMode(learnerMode);
+
+  const playbook = await resolvePlaybook(playbookSlug);
+  if (!playbook) {
+    return (
+      <ErrorPanel
+        title="Course not found"
+        body={`No published or draft course matched slug "${playbookSlug}".`}
+        hint="Use the course's UUID or the slugified course name (lower-case, hyphenated)."
+      />
+    );
+  }
+
+  const primaryCurriculum = await prisma.curriculum.findFirst({
+    where: { playbookLinks: { some: { playbookId: playbook.id, role: "primary" } } },
+    select: { id: true },
+  });
+  if (!primaryCurriculum) {
+    return (
+      <ErrorPanel
+        title="No primary curriculum"
+        body={`"${playbook.name}" has no primary curriculum linked yet.`}
+        hint="Run the curriculum projection (course → modules) before using the tester direct-link."
+      />
+    );
+  }
+
+  const targetModule = await prisma.curriculumModule.findFirst({
+    where: { curriculumId: primaryCurriculum.id, slug: moduleSlug },
+    select: { id: true, slug: true },
+  });
+  if (!targetModule) {
+    return (
+      <ErrorPanel
+        title="Module not found"
+        body={`Module "${moduleSlug}" does not exist on "${playbook.name}".`}
+        hint="Check the curriculum's module list."
+      />
+    );
+  }
+
+  const sourceCallerId = await resolveDemoSourceCaller(playbook.id);
+  if (!sourceCallerId) {
+    return (
+      <ErrorPanel
+        title="No demo caller available"
+        body={`No demo caller is enrolled on "${playbook.name}" yet.`}
+        hint="Mint one via /x/intake/v2 (admin escape hatch — test-admin-*@hf-admin.local) and reopen this link."
+      />
+    );
+  }
+
+  const testerEmail = auth.session.user.email ?? "test-operator@hf-admin.local";
+
+  const clone = await cloneDemoCaller(prisma, {
+    sourceCallerId,
+    playbookId: playbook.id,
+    testerEmail,
+    mode,
+  });
+
+  redirect(`/x/callers/${clone.callerId}/sim?module=${targetModule.id}`);
+}
+
+function ErrorPanel({
+  title,
+  body,
+  hint,
+}: {
+  title: string;
+  body: string;
+  hint: string;
+}) {
+  return (
+    <main className="hf-page-shell">
+      <h1 className="hf-page-title">{title}</h1>
+      <p className="hf-section-desc">{body}</p>
+      <p className="hf-section-desc">{hint}</p>
+      <Link className="hf-link" href="/x">
+        ← Back to admin
+      </Link>
+    </main>
+  );
+}

--- a/apps/admin/tests/api/student/test-direct-link/test-direct-link-page.test.tsx
+++ b/apps/admin/tests/api/student/test-direct-link/test-direct-link-page.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests for /x/test/[playbookSlug]/[moduleSlug] — tester direct-link
+ * route (#1750 follow-on, epic #1700 Theme 12).
+ *
+ * Server-component page. We mock `redirect` from next/navigation, the
+ * permissions helper, prisma, and `cloneDemoCaller`. The tests assert
+ * the resolution order and the redirect target.
+ *
+ * Pinned acceptance:
+ *   1. Unknown playbookSlug → renders "Course not found" panel
+ *   2. Playbook found but no primary curriculum → "No primary curriculum"
+ *   3. Module slug not on curriculum → "Module not found"
+ *   4. No demo CallerPlaybook on the playbook → "No demo caller available"
+ *   5. Happy path → invokes `cloneDemoCaller` with the resolved
+ *      `sourceCallerId` / `playbookId` / tester email; redirects to
+ *      `/x/callers/<callerId>/sim?module=<moduleId>`
+ *   6. `learnerMode=return` is propagated to the helper
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const { mockPrisma, mockRedirect, mockCloneDemoCaller } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: { findUnique: vi.fn(), findMany: vi.fn() },
+    curriculum: { findFirst: vi.fn() },
+    curriculumModule: { findFirst: vi.fn() },
+    callerPlaybook: { findFirst: vi.fn() },
+  },
+  mockRedirect: vi.fn((target: string) => {
+    // Mirror Next.js: throw a marker so execution halts the way it does
+    // in production.
+    const err = new Error(`NEXT_REDIRECT:${target}`);
+    (err as Error & { digest?: string }).digest = `NEXT_REDIRECT;${target}`;
+    throw err;
+  }),
+  mockCloneDemoCaller: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR", email: "tester@hf-admin.local" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/test-harness/clone-demo-caller", () => ({
+  cloneDemoCaller: mockCloneDemoCaller,
+}));
+
+async function loadPage() {
+  return import("@/app/x/test/[playbookSlug]/[moduleSlug]/page");
+}
+
+function makeProps(playbookSlug: string, moduleSlug: string, learnerMode?: string) {
+  return {
+    params: Promise.resolve({ playbookSlug, moduleSlug }),
+    searchParams: Promise.resolve(learnerMode ? { learnerMode } : {}),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TesterDirectLinkPage", () => {
+  it("renders 'Course not found' when slug does not resolve", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      { id: "pb-1", name: "Some Other Course" },
+    ]);
+    const { default: Page } = await loadPage();
+    const node = await Page(makeProps("ielts-speaking-practice", "mock") as never);
+    render(node as React.ReactElement);
+    expect(screen.getByText("Course not found")).toBeInTheDocument();
+  });
+
+  it("renders 'No primary curriculum' when playbook resolves but no curriculum linked", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      { id: "pb-1", name: "IELTS Speaking Practice" },
+    ]);
+    mockPrisma.curriculum.findFirst.mockResolvedValue(null);
+    const { default: Page } = await loadPage();
+    const node = await Page(makeProps("ielts-speaking-practice", "mock") as never);
+    render(node as React.ReactElement);
+    expect(screen.getByText("No primary curriculum")).toBeInTheDocument();
+  });
+
+  it("renders 'Module not found' when slug does not match any sub-module", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      { id: "pb-1", name: "IELTS Speaking Practice" },
+    ]);
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "cur-1" });
+    mockPrisma.curriculumModule.findFirst.mockResolvedValue(null);
+    const { default: Page } = await loadPage();
+    const node = await Page(makeProps("ielts-speaking-practice", "ghost-module") as never);
+    render(node as React.ReactElement);
+    expect(screen.getByText("Module not found")).toBeInTheDocument();
+  });
+
+  it("renders 'No demo caller available' when no demo CallerPlaybook on the playbook", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      { id: "pb-1", name: "IELTS Speaking Practice" },
+    ]);
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "cur-1" });
+    mockPrisma.curriculumModule.findFirst.mockResolvedValue({ id: "mod-1", slug: "mock" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
+    const { default: Page } = await loadPage();
+    const node = await Page(makeProps("ielts-speaking-practice", "mock") as never);
+    render(node as React.ReactElement);
+    expect(screen.getByText("No demo caller available")).toBeInTheDocument();
+  });
+
+  it("redirects to /x/callers/<callerId>/sim?module=<moduleId> on happy path", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      { id: "pb-1", name: "IELTS Speaking Practice" },
+    ]);
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "cur-1" });
+    mockPrisma.curriculumModule.findFirst.mockResolvedValue({ id: "mod-1", slug: "mock" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({ callerId: "src-caller-1" });
+    mockCloneDemoCaller.mockResolvedValue({
+      callerId: "new-caller-1",
+      callerName: "Test Bertie",
+      isNew: true,
+      sourceCallerId: "src-caller-1",
+    });
+
+    const { default: Page } = await loadPage();
+    await expect(Page(makeProps("ielts-speaking-practice", "mock") as never)).rejects.toThrow(
+      /NEXT_REDIRECT:\/x\/callers\/new-caller-1\/sim\?module=mod-1/,
+    );
+
+    expect(mockCloneDemoCaller).toHaveBeenCalledWith(mockPrisma, {
+      sourceCallerId: "src-caller-1",
+      playbookId: "pb-1",
+      testerEmail: "tester@hf-admin.local",
+      mode: "fresh",
+    });
+  });
+
+  it("propagates learnerMode=return to cloneDemoCaller", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      { id: "pb-1", name: "IELTS Speaking Practice" },
+    ]);
+    mockPrisma.curriculum.findFirst.mockResolvedValue({ id: "cur-1" });
+    mockPrisma.curriculumModule.findFirst.mockResolvedValue({ id: "mod-1", slug: "mock" });
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({ callerId: "src-caller-1" });
+    mockCloneDemoCaller.mockResolvedValue({
+      callerId: "returning-caller-1",
+      callerName: "Test Bertie",
+      isNew: false,
+      sourceCallerId: "src-caller-1",
+    });
+
+    const { default: Page } = await loadPage();
+    await expect(
+      Page(makeProps("ielts-speaking-practice", "mock", "return") as never),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const args = mockCloneDemoCaller.mock.calls[0][1];
+    expect(args.mode).toBe("return");
+  });
+});


### PR DESCRIPTION
## Summary

Generic-URL tester entry point per epic #1700 decision 3. `/x/test/[playbookSlug]/[moduleSlug]?learnerMode=fresh|return` — OPERATOR+ only.

Walks: slug → Playbook (UUID first, then slugified-name match) → primary Curriculum → CurriculumModule → latest demo CallerPlaybook → `cloneDemoCaller(...)` → redirect to `/x/callers/<callerId>/sim?module=<moduleId>`.

When prerequisites fail (slug missing, no primary curriculum, no demo caller minted yet), renders an actionable error panel with a hint instead of a generic 404.

## Lattice survey [verified]

- Surface: new server-component page; no DB writes outside the existing `cloneDemoCaller` chokepoint. [verified at `apps/admin/app/x/test/[playbookSlug]/[moduleSlug]/page.tsx`].
- **Sibling-writer drift:** NIL — routes through the canonical helper at `lib/test-harness/clone-demo-caller.ts` (shipped in #1798) [verified via `grep -rn 'cloneDemoCaller' apps/admin` — only the helper, test, and this page].
- **Default-deny gates:** NIL — no ESLint rule gates this surface [verified].
- **Cascade respect:** N/A — pure read + helper-call.
- **Convention conflict:** NIL — `slugify` import + primary-curriculum resolution shape match existing patterns (`PlaybookCurriculum role: \"primary\"` join from #1177) [verified at `lib/chat/admin-tool-handlers.ts:3029` for the demo CallerPlaybook source-picking convention].

## Verified by

- ✅ vitest: `tests/api/student/test-direct-link/test-direct-link-page.test.tsx` 6/6 (unknown course slug / no primary curriculum / module not found / no demo caller / happy-path redirect target / `learnerMode=return` propagation). [verified by local run].
- ✅ pre-push: tsc 0 errors (baseline 43, -43), lint 0 errors in changed files. [verified at log above].
- ✅ Lattice survey result inline above; each risk shape probed and cited.

## Test plan

- [ ] `/vm-cp` — no migration needed.
- [ ] On hf-dev: open `/x/test/ielts-speaking-practice/mock` while authenticated as an OPERATOR — should redirect to `/x/callers/<newCallerId>/sim?module=<mockModuleId>`.
- [ ] Re-open the same link with `?learnerMode=return` — should reuse the prior clone rather than creating a new one.
- [ ] Sign out and try the URL — redirected to login.

Closes the route side of #1750 (helper landed via #1798).