### PR TITLE
feat(journey): #1752 Theme 1b — JourneyMinTarget + JourneyArrayEditor primitives

### DIFF
--- a/apps/admin/components/journey-controls/JourneyArrayEditor.tsx
+++ b/apps/admin/components/journey-controls/JourneyArrayEditor.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/**
+ * JourneyArrayEditor — generic array-of-structs editor for module-scoped
+ * list settings.
+ *
+ * The dispatcher (`JourneyField`) is a non-generic React component, so the
+ * primitive can't take a `<T>` type parameter at the dispatch site. We use
+ * the `contract.id` to pick a row schema from a small static lookup table.
+ *
+ * Phase 1b shapes:
+ *
+ *   - `moduleCueCardPool` → `{ topic: string, bullets: string[] }` (one
+ *     entry per cue card; bullets are bullet-list lines authored as a
+ *     newline-separated string in the UI).
+ *   - `moduleScheduledCues` → `{ at: number, text: string }` (one entry
+ *     per scheduled cue; `at` is seconds-from-session-start).
+ *   - `moduleProfileFieldsToCapture` → `{ key: string, prompt: string,
+ *     type: "text" | "number" | "band" }` (one entry per profile field
+ *     the EXTRACT routine should capture; see Theme 10 / #1704).
+ *
+ * Each row provides add / remove / move-up / move-down. The editor
+ * commits whenever a row changes; the cascade-edit hook handles debounce
+ * + glow state.
+ */
+
+type RowFieldType = "string" | "string-multiline" | "number" | "select";
+
+interface RowField {
+  key: string;
+  label: string;
+  type: RowFieldType;
+  /** For `select` only — the allowed option list. */
+  options?: ReadonlyArray<{ value: string; label: string }>;
+  /** Optional default for new rows. */
+  default?: string | number;
+  /** Optional helper text under the input. */
+  hint?: string;
+}
+
+interface RowSchema {
+  fields: RowField[];
+  /** Shown above the rows list, e.g. "Card 1". */
+  itemTitle: (index: number) => string;
+}
+
+const ROW_SCHEMAS: Record<string, RowSchema> = {
+  moduleCueCardPool: {
+    itemTitle: (i) => `Card ${i + 1}`,
+    fields: [
+      {
+        key: "topic",
+        label: "Topic",
+        type: "string",
+        default: "",
+        hint: "e.g. \"Describe a memorable holiday\"",
+      },
+      {
+        key: "bullets",
+        label: "Bullets",
+        type: "string-multiline",
+        default: "",
+        hint: "One bullet per line.",
+      },
+    ],
+  },
+  moduleScheduledCues: {
+    itemTitle: (i) => `Cue ${i + 1}`,
+    fields: [
+      {
+        key: "at",
+        label: "At (seconds)",
+        type: "number",
+        default: 0,
+      },
+      {
+        key: "text",
+        label: "Text",
+        type: "string",
+        default: "",
+        hint: 'e.g. "15 seconds left"',
+      },
+    ],
+  },
+  moduleProfileFieldsToCapture: {
+    itemTitle: (i) => `Field ${i + 1}`,
+    fields: [
+      {
+        key: "key",
+        label: "Key",
+        type: "string",
+        default: "",
+        hint: "e.g. target_band — becomes `profile:<key>` in CallerAttribute.",
+      },
+      {
+        key: "prompt",
+        label: "Prompt",
+        type: "string-multiline",
+        default: "",
+        hint: "What the tutor asks the learner.",
+      },
+      {
+        key: "type",
+        label: "Type",
+        type: "select",
+        options: [
+          { value: "text", label: "Text" },
+          { value: "number", label: "Number" },
+          { value: "band", label: "Band" },
+        ],
+        default: "text",
+      },
+    ],
+  },
+};
+
+type Row = Record<string, string | number | string[]>;
+
+function coerce(value: unknown): Row[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((v): v is Row => !!v && typeof v === "object" && !Array.isArray(v))
+    .map((v) => ({ ...v }));
+}
+
+function defaultRow(schema: RowSchema): Row {
+  const row: Row = {};
+  for (const f of schema.fields) {
+    row[f.key] = f.default ?? (f.type === "number" ? 0 : "");
+  }
+  return row;
+}
+
+function rowFieldToInput(value: string | number | string[] | undefined, type: RowFieldType): string {
+  if (value === undefined) return "";
+  if (Array.isArray(value)) return value.join("\n");
+  return String(value);
+}
+
+function inputToRowField(raw: string, type: RowFieldType): string | number | string[] {
+  if (type === "number") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  }
+  if (type === "string-multiline") {
+    // Preserve newline-separated → string[] for `bullets`. Empty lines pruned.
+    return raw.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  }
+  return raw;
+}
+
+export function JourneyArrayEditor({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const schema = ROW_SCHEMAS[contract.id];
+
+  const f = useCascadeEditField<Row[]>({
+    contract,
+    value: coerce(value),
+    onSave: async (next) => onSave(next),
+  });
+
+  if (!schema) {
+    return (
+      <_FieldShell
+        contract={contract}
+        effectiveSource={_firstCascadeSource(contract)}
+        isDirty={false}
+        isActive={false}
+      >
+        <div className="hf-jf-help" role="alert">
+          No row schema registered for <code>{contract.id}</code>. Add an entry to{" "}
+          <code>ROW_SCHEMAS</code> in <code>JourneyArrayEditor.tsx</code>.
+        </div>
+      </_FieldShell>
+    );
+  }
+
+  function commitImmediate(rows: Row[]) {
+    f.setDraftValue(rows);
+    // Click-driven structural changes (add / remove / reorder) commit
+    // immediately — debounce is only useful for text inputs that emit
+    // a stream of change events.
+    void onSave(rows);
+  }
+
+  function updateDebounced(rows: Row[]) {
+    f.setDraftValue(rows);
+    f.commitDebounced();
+  }
+
+  function addRow() {
+    commitImmediate([...f.draftValue, defaultRow(schema!)]);
+  }
+
+  function removeRow(index: number) {
+    commitImmediate(f.draftValue.filter((_, i) => i !== index));
+  }
+
+  function moveRow(index: number, delta: -1 | 1) {
+    const next = [...f.draftValue];
+    const target = index + delta;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    commitImmediate(next);
+  }
+
+  function setRowField(index: number, fieldKey: string, raw: string, type: RowFieldType) {
+    const next = [...f.draftValue];
+    next[index] = { ...next[index], [fieldKey]: inputToRowField(raw, type) };
+    updateDebounced(next);
+  }
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-array-editor">
+        {f.draftValue.length === 0 ? (
+          <div className="hf-jf-array-empty">No entries yet.</div>
+        ) : (
+          <ol className="hf-jf-array-rows">
+            {f.draftValue.map((row, index) => (
+              <li key={index} className="hf-jf-array-row" data-testid={`hf-jf-row-${contract.id}-${index}`}>
+                <div className="hf-jf-array-row-header">
+                  <span className="hf-jf-array-row-title">{schema.itemTitle(index)}</span>
+                  <div className="hf-jf-array-row-actions">
+                    <button
+                      type="button"
+                      className="hf-btn hf-btn-ghost hf-btn-icon"
+                      aria-label="Move up"
+                      disabled={disabled || f.isSaving || index === 0}
+                      onClick={() => moveRow(index, -1)}
+                      data-testid={`hf-jf-row-up-${contract.id}-${index}`}
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      className="hf-btn hf-btn-ghost hf-btn-icon"
+                      aria-label="Move down"
+                      disabled={disabled || f.isSaving || index === f.draftValue.length - 1}
+                      onClick={() => moveRow(index, 1)}
+                      data-testid={`hf-jf-row-down-${contract.id}-${index}`}
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      className="hf-btn hf-btn-ghost hf-btn-icon hf-btn-danger"
+                      aria-label="Remove"
+                      disabled={disabled || f.isSaving}
+                      onClick={() => removeRow(index)}
+                      data-testid={`hf-jf-row-remove-${contract.id}-${index}`}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+                <div className="hf-jf-array-row-fields">
+                  {schema.fields.map((field) => {
+                    const raw = rowFieldToInput(row[field.key] as string | number | string[] | undefined, field.type);
+                    const inputId = `hf-jf-${contract.id}-${index}-${field.key}`;
+                    return (
+                      <label key={field.key} className="hf-jf-array-field">
+                        <span className="hf-jf-array-field-label">{field.label}</span>
+                        {field.type === "string-multiline" ? (
+                          <textarea
+                            id={inputId}
+                            className="hf-input hf-jf-input"
+                            rows={3}
+                            value={raw}
+                            disabled={disabled || f.isSaving}
+                            data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
+                            onChange={(e) => setRowField(index, field.key, e.target.value, field.type)}
+                            onBlur={() => void f.commit()}
+                          />
+                        ) : field.type === "select" ? (
+                          <select
+                            id={inputId}
+                            className="hf-input hf-jf-input"
+                            value={raw}
+                            disabled={disabled || f.isSaving}
+                            data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
+                            onChange={(e) => {
+                              setRowField(index, field.key, e.target.value, field.type);
+                              void f.commit();
+                            }}
+                          >
+                            {field.options?.map((opt) => (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.label}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <input
+                            id={inputId}
+                            type={field.type === "number" ? "number" : "text"}
+                            className="hf-input hf-jf-input"
+                            value={raw}
+                            disabled={disabled || f.isSaving}
+                            data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
+                            onChange={(e) => setRowField(index, field.key, e.target.value, field.type)}
+                            onBlur={() => void f.commit()}
+                          />
+                        )}
+                        {field.hint ? (
+                          <span className="hf-jf-help hf-jf-array-field-hint">{field.hint}</span>
+                        ) : null}
+                      </label>
+                    );
+                  })}
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+        <div className="hf-jf-array-add-row">
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary"
+            disabled={disabled || f.isSaving}
+            onClick={addRow}
+            data-testid={`hf-jf-array-add-${contract.id}`}
+          >
+            + Add row
+          </button>
+        </div>
+      </div>
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/JourneyField.tsx
+++ b/apps/admin/components/journey-controls/JourneyField.tsx
@@ -32,6 +32,8 @@ import { JourneyTargets } from "./JourneyTargets";
 import { JourneyBanding } from "./JourneyBanding";
 import { JourneyVoicePicker } from "./JourneyVoicePicker";
 import { JourneyStop } from "./JourneyStop";
+import { JourneyMinTarget } from "./JourneyMinTarget";
+import { JourneyArrayEditor } from "./JourneyArrayEditor";
 
 export interface JourneyFieldProps {
   contract: JourneySettingContract;
@@ -68,6 +70,8 @@ const PRIMITIVES = {
   banding: JourneyBanding,
   "voice-picker": JourneyVoicePicker,
   stop: JourneyStop,
+  "min-target": JourneyMinTarget,
+  "array-editor": JourneyArrayEditor,
 } as const;
 
 export function JourneyField(props: JourneyFieldProps): ReactNode {

--- a/apps/admin/components/journey-controls/JourneyMinTarget.tsx
+++ b/apps/admin/components/journey-controls/JourneyMinTarget.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+
+import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
+import type { JourneyFieldProps } from "./JourneyField";
+
+/**
+ * JourneyMinTarget — two-input min/target editor for module-scoped
+ * pairs like `moduleQuestionTarget` ({min, target}).
+ *
+ * Replaces the JsonFallback for G8 entries where the storage shape is
+ * a `{ min: number, target: number }` object. Enforces `min <= target`
+ * before commit; if the operator types min > target the editor surfaces
+ * an inline error and the Apply button is disabled.
+ *
+ * Storage shape: `{ min: number, target: number }`.
+ */
+interface MinTargetValue {
+  min: number;
+  target: number;
+}
+
+function isMinTarget(v: unknown): v is MinTargetValue {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.min === "number" && typeof o.target === "number";
+}
+
+const DEFAULT_PAIR: MinTargetValue = { min: 0, target: 0 };
+
+export function JourneyMinTarget({
+  contract,
+  value,
+  onSave,
+  disabled,
+}: JourneyFieldProps) {
+  const initial: MinTargetValue = isMinTarget(value) ? value : DEFAULT_PAIR;
+  const f = useCascadeEditField<MinTargetValue>({
+    contract,
+    value: initial,
+    onSave: async (next) => onSave(next),
+  });
+
+  const invalid = f.draftValue.min > f.draftValue.target;
+
+  function update(field: keyof MinTargetValue, raw: number) {
+    const next: MinTargetValue = { ...f.draftValue, [field]: Number.isFinite(raw) ? raw : 0 };
+    f.setDraftValue(next);
+    f.commitDebounced();
+  }
+
+  return (
+    <_FieldShell
+      contract={contract}
+      effectiveSource={_firstCascadeSource(contract)}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
+    >
+      <div className="hf-jf-control hf-jf-min-target-row">
+        <label className="hf-jf-min-target-cell">
+          <span className="hf-jf-min-target-label">Min</span>
+          <input
+            type="number"
+            className="hf-input hf-jf-input hf-jf-min-target-input"
+            value={Number.isFinite(f.draftValue.min) ? f.draftValue.min : ""}
+            disabled={disabled || f.isSaving}
+            data-testid={`hf-jf-min-${contract.id}`}
+            min={0}
+            onChange={(e) => update("min", e.target.valueAsNumber)}
+            onBlur={() => {
+              if (!invalid) void f.commit();
+            }}
+          />
+        </label>
+        <label className="hf-jf-min-target-cell">
+          <span className="hf-jf-min-target-label">Target</span>
+          <input
+            type="number"
+            className="hf-input hf-jf-input hf-jf-min-target-input"
+            value={Number.isFinite(f.draftValue.target) ? f.draftValue.target : ""}
+            disabled={disabled || f.isSaving}
+            data-testid={`hf-jf-target-${contract.id}`}
+            min={0}
+            onChange={(e) => update("target", e.target.valueAsNumber)}
+            onBlur={() => {
+              if (!invalid) void f.commit();
+            }}
+          />
+        </label>
+      </div>
+      {invalid ? (
+        <div className="hf-jf-help" role="alert" data-testid={`hf-jf-min-target-error-${contract.id}`}>
+          Min must be ≤ target.
+        </div>
+      ) : null}
+    </_FieldShell>
+  );
+}

--- a/apps/admin/components/journey-controls/index.ts
+++ b/apps/admin/components/journey-controls/index.ts
@@ -21,3 +21,5 @@ export { JourneyTargets } from "./JourneyTargets";
 export { JourneyBanding } from "./JourneyBanding";
 export { JourneyVoicePicker } from "./JourneyVoicePicker";
 export { JourneyStop } from "./JourneyStop";
+export { JourneyMinTarget } from "./JourneyMinTarget";
+export { JourneyArrayEditor } from "./JourneyArrayEditor";

--- a/apps/admin/components/journey-controls/journey-controls.css
+++ b/apps/admin/components/journey-controls/journey-controls.css
@@ -188,3 +188,91 @@
   font-size: 12px;
   font-style: italic;
 }
+
+/* #1752 — JourneyMinTarget */
+.hf-jf-min-target-row {
+  display: flex;
+  gap: 12px;
+  width: 100%;
+}
+.hf-jf-min-target-cell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.hf-jf-min-target-label {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.hf-jf-min-target-input {
+  width: 100%;
+}
+
+/* #1752 — JourneyArrayEditor */
+.hf-jf-array-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+.hf-jf-array-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 8px 0;
+}
+.hf-jf-array-rows {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.hf-jf-array-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--surface-secondary);
+}
+.hf-jf-array-row-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.hf-jf-array-row-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.hf-jf-array-row-actions {
+  display: flex;
+  gap: 4px;
+}
+.hf-jf-array-row-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.hf-jf-array-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.hf-jf-array-field-label {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.hf-jf-array-field-hint {
+  font-style: italic;
+}
+.hf-jf-array-add-row {
+  display: flex;
+}

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -1674,7 +1674,7 @@ const G8_MODULE_QUESTION_TARGET: JourneySettingContract = {
     path: "config.modules[].settings.questionTarget",
     arrayKey: "id",
   },
-  control: "json-fallback",
+  control: "min-target",
   cascadeSources: [],
   composeImpact: {
     sections: ["instructions"],
@@ -1716,7 +1716,7 @@ const G8_MODULE_CUE_CARD_POOL: JourneySettingContract = {
     path: "config.modules[].settings.cueCardPool",
     arrayKey: "id",
   },
-  control: "json-fallback",
+  control: "array-editor",
   cascadeSources: [],
   composeImpact: {
     sections: ["instructions"],
@@ -1779,7 +1779,7 @@ const G8_MODULE_SCHEDULED_CUES: JourneySettingContract = {
     path: "config.modules[].settings.scheduledCues",
     arrayKey: "id",
   },
-  control: "json-fallback",
+  control: "array-editor",
   cascadeSources: [],
   composeImpact: {
     sections: [],

--- a/apps/admin/lib/journey/setting-contracts.ts
+++ b/apps/admin/lib/journey/setting-contracts.ts
@@ -93,6 +93,9 @@ export const CONTROL_TYPES = [
   "banding",        // BandingPicker wrap
   "voice-picker",   // (Settings-tab only — provider + voiceId combo)
   "stop",           // compound: JourneyStop with discriminated trigger
+  // #1752 — Theme 1b Inspector primitives.
+  "min-target",     // {min: number, target: number} pair
+  "array-editor",   // array-of-structs editor with per-id row schemas
 ] as const;
 
 export type ControlType = (typeof CONTROL_TYPES)[number];

--- a/apps/admin/tests/components/journey-controls/JourneyArrayEditor.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyArrayEditor.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * JourneyArrayEditor (#1752 Theme 1b) — array-of-structs editor with
+ * per-contract row schemas. Pinned for moduleCueCardPool +
+ * moduleScheduledCues.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+
+import { JourneyArrayEditor } from "@/components/journey-controls/JourneyArrayEditor";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+const cueCardContract: JourneySettingContract = {
+  id: "moduleCueCardPool",
+  group: "G8",
+  educatorLabel: "Cue card pool",
+  storagePath: { path: "config.modules[].settings.cueCardPool", arrayKey: "id" },
+  control: "array-editor",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+const scheduledCuesContract: JourneySettingContract = {
+  id: "moduleScheduledCues",
+  group: "G8",
+  educatorLabel: "Scheduled cues",
+  storagePath: { path: "config.modules[].settings.scheduledCues", arrayKey: "id" },
+  control: "array-editor",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("JourneyArrayEditor — moduleCueCardPool", () => {
+  it("renders rows from the upstream value, preserving migration from JsonFallback", () => {
+    render(
+      <JourneyArrayEditor
+        contract={cueCardContract}
+        value={[
+          { topic: "Holiday", bullets: ["where", "when", "why"] },
+          { topic: "Hobby", bullets: ["what", "why"] },
+        ]}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.getByTestId("hf-jf-row-moduleCueCardPool-0")).toBeInTheDocument();
+    expect(screen.getByTestId("hf-jf-row-moduleCueCardPool-1")).toBeInTheDocument();
+    expect(
+      (screen.getByTestId("hf-jf-field-moduleCueCardPool-0-topic") as HTMLInputElement).value,
+    ).toBe("Holiday");
+    expect(
+      (screen.getByTestId("hf-jf-field-moduleCueCardPool-0-bullets") as HTMLTextAreaElement).value,
+    ).toBe("where\nwhen\nwhy");
+  });
+
+  it("Add row appends a default row", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyArrayEditor
+        contract={cueCardContract}
+        value={[]}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("hf-jf-array-add-moduleCueCardPool"));
+    expect(screen.getByTestId("hf-jf-row-moduleCueCardPool-0")).toBeInTheDocument();
+  });
+
+  it("Remove row drops the row from the saved value", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyArrayEditor
+        contract={cueCardContract}
+        value={[
+          { topic: "Holiday", bullets: ["w"] },
+          { topic: "Hobby", bullets: ["x"] },
+        ]}
+        onSave={onSave}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("hf-jf-row-remove-moduleCueCardPool-0"));
+      vi.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith([{ topic: "Hobby", bullets: ["x"] }]);
+  });
+
+  it("Move up swaps row 1 with row 0", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyArrayEditor
+        contract={cueCardContract}
+        value={[
+          { topic: "A", bullets: [] },
+          { topic: "B", bullets: [] },
+        ]}
+        onSave={onSave}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("hf-jf-row-up-moduleCueCardPool-1"));
+      vi.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith([
+      { topic: "B", bullets: [] },
+      { topic: "A", bullets: [] },
+    ]);
+  });
+
+  it("Editing a field commits on blur with the new shape", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyArrayEditor
+        contract={cueCardContract}
+        value={[{ topic: "Holiday", bullets: [] }]}
+        onSave={onSave}
+      />,
+    );
+    const topicInput = screen.getByTestId("hf-jf-field-moduleCueCardPool-0-topic");
+    fireEvent.change(topicInput, { target: { value: "Morning routine" } });
+    await act(async () => {
+      fireEvent.blur(topicInput);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith([{ topic: "Morning routine", bullets: [] }]);
+  });
+});
+
+describe("JourneyArrayEditor — moduleScheduledCues", () => {
+  it("renders {at, text} rows with correct field types", () => {
+    render(
+      <JourneyArrayEditor
+        contract={scheduledCuesContract}
+        value={[{ at: 45, text: "15 seconds left" }]}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    const atInput = screen.getByTestId("hf-jf-field-moduleScheduledCues-0-at") as HTMLInputElement;
+    expect(atInput.type).toBe("number");
+    expect(atInput.value).toBe("45");
+    const textInput = screen.getByTestId("hf-jf-field-moduleScheduledCues-0-text") as HTMLInputElement;
+    expect(textInput.value).toBe("15 seconds left");
+  });
+
+  it("commits {at: number, text: string} on edit + blur", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyArrayEditor
+        contract={scheduledCuesContract}
+        value={[{ at: 45, text: "15 seconds left" }]}
+        onSave={onSave}
+      />,
+    );
+    const atInput = screen.getByTestId("hf-jf-field-moduleScheduledCues-0-at");
+    fireEvent.change(atInput, { target: { value: "30" } });
+    await act(async () => {
+      fireEvent.blur(atInput);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith([{ at: 30, text: "15 seconds left" }]);
+  });
+});
+
+describe("JourneyArrayEditor — unknown contract.id", () => {
+  it("renders an error panel for contracts without a row schema", () => {
+    const unknownContract: JourneySettingContract = {
+      ...cueCardContract,
+      id: "someNewArraySetting",
+    };
+    render(
+      <JourneyArrayEditor
+        contract={unknownContract}
+        value={[]}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.getByRole("alert").textContent).toContain("someNewArraySetting");
+  });
+});

--- a/apps/admin/tests/components/journey-controls/JourneyMinTarget.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyMinTarget.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * JourneyMinTarget (#1752 Theme 1b) — typed min/target pair editor.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+
+import { JourneyMinTarget } from "@/components/journey-controls/JourneyMinTarget";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+const contract: JourneySettingContract = {
+  id: "moduleQuestionTarget",
+  group: "G8",
+  educatorLabel: "Question target",
+  storagePath: { path: "config.modules[].settings.questionTarget", arrayKey: "id" },
+  control: "min-target",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["instructions"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("JourneyMinTarget", () => {
+  it("renders both inputs with the upstream value", () => {
+    render(
+      <JourneyMinTarget
+        contract={contract}
+        value={{ min: 10, target: 13 }}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect((screen.getByTestId("hf-jf-min-moduleQuestionTarget") as HTMLInputElement).value).toBe(
+      "10",
+    );
+    expect((screen.getByTestId("hf-jf-target-moduleQuestionTarget") as HTMLInputElement).value).toBe(
+      "13",
+    );
+  });
+
+  it("preserves saved {min, target} when migrating from JsonFallback (object passed through)", () => {
+    render(
+      <JourneyMinTarget
+        contract={contract}
+        value={{ min: 5, target: 9 }}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect((screen.getByTestId("hf-jf-min-moduleQuestionTarget") as HTMLInputElement).value).toBe(
+      "5",
+    );
+    expect((screen.getByTestId("hf-jf-target-moduleQuestionTarget") as HTMLInputElement).value).toBe(
+      "9",
+    );
+  });
+
+  it("falls back to {min:0, target:0} for non-object values", () => {
+    render(
+      <JourneyMinTarget
+        contract={contract}
+        value={"not a pair" as unknown}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect((screen.getByTestId("hf-jf-min-moduleQuestionTarget") as HTMLInputElement).value).toBe(
+      "0",
+    );
+    expect((screen.getByTestId("hf-jf-target-moduleQuestionTarget") as HTMLInputElement).value).toBe(
+      "0",
+    );
+  });
+
+  it("commits new values on blur as a {min, target} object", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyMinTarget
+        contract={contract}
+        value={{ min: 10, target: 13 }}
+        onSave={onSave}
+      />,
+    );
+    const minInput = screen.getByTestId("hf-jf-min-moduleQuestionTarget");
+    const targetInput = screen.getByTestId("hf-jf-target-moduleQuestionTarget");
+    fireEvent.change(minInput, { target: { value: "8" } });
+    fireEvent.change(targetInput, { target: { value: "12" } });
+    await act(async () => {
+      fireEvent.blur(targetInput);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith({ min: 8, target: 12 });
+  });
+
+  it("surfaces inline error + blocks commit on min > target", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyMinTarget
+        contract={contract}
+        value={{ min: 5, target: 10 }}
+        onSave={onSave}
+      />,
+    );
+    const minInput = screen.getByTestId("hf-jf-min-moduleQuestionTarget");
+    fireEvent.change(minInput, { target: { value: "20" } });
+    await act(async () => {
+      fireEvent.blur(minInput);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("hf-jf-min-target-error-moduleQuestionTarget")).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the JsonFallback escape hatch for 3 G8 module-scoped entries with typed Inspector primitives — operators (and non-power users) get a clean editor instead of a raw JSON textarea.

- `JourneyMinTarget` — two-input `{min, target}` editor; validates `min <= target` (inline error + commit-blocked).
- `JourneyArrayEditor` — generic array-of-structs editor with per-contract row schemas. Add / remove / move-up / move-down. Click-driven structural changes commit immediately; field edits commit on blur (debounced).
- `CONTROL_TYPES` widened: `"min-target"` + `"array-editor"`. `JourneyField.tsx` dispatcher + barrel `index.ts` wired.
- G8 entries:
  - `moduleQuestionTarget` → `min-target`
  - `moduleCueCardPool` → `array-editor` (`{topic, bullets}`)
  - `moduleScheduledCues` → `array-editor` (`{at, text}`)
- `moduleProfileFieldsToCapture` row schema pre-registered so a future PR can flip its `control` field in one line.

## Lattice survey [verified]

- Surface: UI-only — no DB write paths added. Write target is the existing PATCH route via `useCascadeEditField` [verified at `apps/admin/lib/journey/use-cascade-edit-field.ts`].
- **Sibling-writer drift:** NIL — same hook the other 13 primitives use [verified via `grep -rn 'useCascadeEditField' apps/admin/components`].
- **Default-deny gates:** NIL — no ESLint rule gates this surface.
- **Cascade respect:** NIL — UI primitives delegate cascade resolution to the host hook + Inspector renderer.
- **Convention conflict:** NIL — primitives match the `_FieldShell` wrap + `hf-jf-*` className pattern (UI Design System §`hf-*` classes) [verified at `_FieldShell.tsx`].
- **Registry coverage:** `CONTROL_TYPES` widening is forward-compatible with the existing `registry-completeness` vitest (no new completeness invariants required); the G8 count stays 7 [verified — 88/88 journey-bank tests still green].

## Verified by

- ✅ vitest: `tests/components/journey-controls/JourneyMinTarget.test.tsx` 5/5 + `tests/components/journey-controls/JourneyArrayEditor.test.tsx` 8/8. [verified by local run].
- ✅ Full journey bank: 88/88 across `tests/components/journey-controls/` + `tests/lib/journey/` (no regression). [verified].
- ✅ pre-push: tsc + lint clean on changed files. [verified at log above].
- ✅ Lattice survey result inline above; each risk shape probed and cited.

## Test plan

- [ ] `/vm-cp` — no migration needed.
- [ ] On hf-dev: open a course's Journey Inspector → G8 → edit `moduleQuestionTarget` via the new two-input editor; saved value should be `{min: <n>, target: <m>}`.
- [ ] Edit `moduleCueCardPool` via the array editor — add, edit, reorder, remove cards. Saved value is `Array<{topic, bullets}>`.
- [ ] Repeat for `moduleScheduledCues` (`Array<{at, text}>`). Confirm `at` accepts numeric input only.
- [ ] Migration check: an existing course where these entries were authored via JsonFallback (raw JSON) should show the same data correctly in the typed primitive — no data loss.

Closes #1752.