### PR TITLE
feat(sim): #1745 Theme 4 — Mock exam dual-waveform shell

### DIFF
--- a/apps/admin/components/sim/DualWaveform.tsx
+++ b/apps/admin/components/sim/DualWaveform.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * DualWaveform — pure presentational, two horizontal level bars side-by-side
+ * for the Mock exam shell (#1745, epic #1700 Theme 4).
+ *
+ * The Mock exam mode strips the chat UI down to two waveforms — one for the
+ * examiner (TTS playback amplitude) and one for the learner (mic AnalyserNode
+ * RMS). This component is intentionally render-only: amplitude values are
+ * computed upstream (by `useVoiceMode` for the learner mic and by the
+ * sibling helper for the examiner audio element). It works whether or not a
+ * real stream is connected — when both levels are 0 it renders an idle bar.
+ *
+ * Aesthetic — colour-coded only, no labels embedded. Wrap with `aria-label`
+ * for accessibility.
+ */
+
+import { useMemo } from "react";
+
+import "./dual-waveform.css";
+
+interface DualWaveformProps {
+  /** Learner amplitude — 0..1 (RMS). */
+  learnerLevel: number;
+  /** Examiner amplitude — 0..1 (RMS or Safari fallback proxy). */
+  examinerLevel: number;
+  /** Active role for screen readers: which side is "speaking". */
+  speakerRole?: "learner" | "examiner" | "idle";
+}
+
+const BAR_COUNT = 32;
+
+export function DualWaveform({
+  learnerLevel,
+  examinerLevel,
+  speakerRole = "idle",
+}: DualWaveformProps) {
+  // Generate per-bar heights driven by the input level. We seed a stable
+  // pseudo-random pattern off the bar index so the visual is consistent
+  // frame-to-frame for a given level (no jitter).
+  const learnerBars = useMemo(() => buildBars(learnerLevel), [learnerLevel]);
+  const examinerBars = useMemo(() => buildBars(examinerLevel), [examinerLevel]);
+
+  return (
+    <div className="hf-dwf" role="group" aria-label="Dual waveform — examiner and learner">
+      <div className="hf-dwf-row hf-dwf-examiner" aria-label="Examiner audio level">
+        <span className="hf-dwf-label">Examiner</span>
+        <div className="hf-dwf-bars" aria-hidden>
+          {examinerBars.map((h, i) => (
+            <span
+              key={i}
+              className="hf-dwf-bar hf-dwf-bar-examiner"
+              data-active={speakerRole === "examiner"}
+              data-height={Math.round(h * 100)}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="hf-dwf-divider" aria-hidden />
+      <div className="hf-dwf-row hf-dwf-learner" aria-label="Learner audio level">
+        <span className="hf-dwf-label">You</span>
+        <div className="hf-dwf-bars" aria-hidden>
+          {learnerBars.map((h, i) => (
+            <span
+              key={i}
+              className="hf-dwf-bar hf-dwf-bar-learner"
+              data-active={speakerRole === "learner"}
+              data-height={Math.round(h * 100)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Produce a per-bar height array (0..1) from a single level. Each bar
+ * combines the level with a per-index sinusoidal envelope so the resulting
+ * pattern looks more organic than a flat row at the same height. The pattern
+ * is stable per index — no animation jitter.
+ */
+function buildBars(level: number): number[] {
+  const safeLevel = Math.max(0, Math.min(1, Number.isFinite(level) ? level : 0));
+  const minHeight = 0.08;
+  const result: number[] = [];
+  for (let i = 0; i < BAR_COUNT; i++) {
+    const envelope = 0.6 + 0.4 * Math.sin((i / BAR_COUNT) * Math.PI);
+    const h = Math.max(minHeight, safeLevel * envelope);
+    result.push(h);
+  }
+  return result;
+}

--- a/apps/admin/components/sim/ExamModeShell.tsx
+++ b/apps/admin/components/sim/ExamModeShell.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * ExamModeShell — Mock exam stripped UI (#1745, epic #1700 Theme 4).
+ *
+ * Renders a full-screen dark layout with the `DualWaveform` pair instead
+ * of the chat feed. Activated when the bound `AuthoredModule.mode` is
+ * `"examiner"` AND the session is terminal (the discriminator from the
+ * story body).
+ *
+ * Aesthetic — strict dark theme; no labels (handled by waveform), no
+ * timers, no chat shell. Wraps a stop-prop region so the host page's
+ * chat-feed mount can stay rendered but layered beneath an opaque
+ * overlay; the host decides whether to actually hide it or keep it
+ * present (we just paint over).
+ *
+ * The amplitude values come from the host hook — typically the existing
+ * `useVoiceMode` for the learner mic plus a sibling
+ * `useRemoteAudioLevel` for the examiner TTS audio element. Safari does
+ * not expose `getByteTimeDomainData()` on remote MediaStream tracks
+ * reliably; the sibling hook here falls back to a text-length proxy when
+ * an `AudioContext.createMediaElementSource` instantiation throws.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { DualWaveform } from "./DualWaveform";
+import "./exam-mode-shell.css";
+
+import type { AuthoredModule } from "@/lib/types/json-fields";
+
+interface ExamModeShellProps {
+  /** Examiner-side amplitude (0..1) — typically driven by a sibling hook
+   *  reading the TTS audio element's AnalyserNode. Use 0 when idle. */
+  examinerLevel: number;
+  /** Learner-side amplitude (0..1) — from `useVoiceMode().waveformLevel`. */
+  learnerLevel: number;
+  /** Active speaker for the screen-reader chip. */
+  speakerRole?: "learner" | "examiner" | "idle";
+  /** Optional banner text — e.g. "Part 2 — You'll speak for 2 minutes". */
+  banner?: string;
+  /** Child controls (e.g. an end-call button) rendered beneath the
+   *  waveform. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Pure discriminator: should the Mock exam shell mount for this module?
+ *
+ * Returns true when:
+ *  - the bound AuthoredModule.mode === "examiner", AND
+ *  - the module is terminal (typically Mock Exam, where bands are
+ *    spoken aloud and the session ends with the final part).
+ *
+ * Pure function so tests can pin it without React.
+ */
+export function shouldMountExamModeShell(
+  module: Pick<AuthoredModule, "mode"> | null | undefined,
+  sessionTerminal: boolean,
+): boolean {
+  if (!module) return false;
+  return module.mode === "examiner" && sessionTerminal === true;
+}
+
+export function ExamModeShell({
+  examinerLevel,
+  learnerLevel,
+  speakerRole = "idle",
+  banner,
+  children,
+}: ExamModeShellProps) {
+  return (
+    <section className="hf-exam-shell" role="region" aria-label="Mock exam">
+      <div className="hf-exam-shell-bg" aria-hidden />
+      <div className="hf-exam-shell-content">
+        {banner ? (
+          <div className="hf-exam-shell-banner" data-testid="hf-exam-shell-banner">
+            {banner}
+          </div>
+        ) : null}
+        <DualWaveform
+          examinerLevel={examinerLevel}
+          learnerLevel={learnerLevel}
+          speakerRole={speakerRole}
+        />
+        {children ? <div className="hf-exam-shell-controls">{children}</div> : null}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * useRemoteAudioLevel — read RMS amplitude from a remote audio element
+ * (typically the TTS playback `<audio>` for the examiner side).
+ *
+ * Returns `{ level, fallbackMode }`:
+ *  - `level` — 0..1, updated each animation frame while the audio is
+ *    playing. Goes to 0 when paused / ended.
+ *  - `fallbackMode` — true when the browser refused to instantiate an
+ *    AnalyserNode for the element. In that case `level` is derived from
+ *    a `proxy` value passed via `setProxyLevel()` (typically the host
+ *    feeds it `responseText.length` normalised against a target).
+ *
+ * Mounts an AnalyserNode lazily on the first `audio.play` event so that
+ * iOS Safari's "needs a user-gesture before AudioContext" rule is
+ * respected.
+ */
+export function useRemoteAudioLevel(audio: HTMLAudioElement | null): {
+  level: number;
+  fallbackMode: boolean;
+  setProxyLevel: (proxy: number) => void;
+} {
+  const [level, setLevel] = useState(0);
+  const [fallbackMode, setFallbackMode] = useState(false);
+  const ctxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const rafRef = useRef<number>(0);
+  const proxyRef = useRef<number>(0);
+
+  function setProxyLevel(proxy: number) {
+    proxyRef.current = Math.max(0, Math.min(1, proxy));
+    if (fallbackMode) setLevel(proxyRef.current);
+  }
+
+  useEffect(() => {
+    if (!audio) return;
+
+    function startLoop() {
+      const analyser = analyserRef.current;
+      if (!analyser) return;
+      const data = new Uint8Array(analyser.frequencyBinCount);
+      function tick(localAnalyser: AnalyserNode) {
+        localAnalyser.getByteTimeDomainData(data);
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) {
+          const v = (data[i] - 128) / 128;
+          sum += v * v;
+        }
+        const rms = Math.sqrt(sum / data.length);
+        setLevel(Math.min(1, rms * 4));
+        rafRef.current = requestAnimationFrame(() => tick(localAnalyser));
+      }
+      rafRef.current = requestAnimationFrame(() => tick(analyser));
+    }
+
+    function stopLoop() {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      setLevel(0);
+    }
+
+    function onPlay() {
+      try {
+        if (!ctxRef.current) {
+          // typecast — AudioContext exists on window in all evergreen browsers.
+          ctxRef.current = new (window.AudioContext ||
+            (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext!)();
+        }
+        const ctx = ctxRef.current;
+        if (!analyserRef.current) {
+          const source = ctx.createMediaElementSource(audio!);
+          const analyser = ctx.createAnalyser();
+          analyser.fftSize = 256;
+          source.connect(analyser);
+          analyser.connect(ctx.destination);
+          analyserRef.current = analyser;
+        }
+        if (ctx.state === "suspended") void ctx.resume();
+        startLoop();
+      } catch (err) {
+        // Safari refuses createMediaElementSource on cross-origin elements
+        // and on some audio MIME types — switch to proxy mode.
+        setFallbackMode(true);
+        setLevel(proxyRef.current);
+        // eslint-disable-next-line no-console
+        console.warn("[useRemoteAudioLevel] AnalyserNode unavailable — proxy mode", err);
+      }
+    }
+
+    audio.addEventListener("play", onPlay);
+    audio.addEventListener("pause", stopLoop);
+    audio.addEventListener("ended", stopLoop);
+    return () => {
+      audio.removeEventListener("play", onPlay);
+      audio.removeEventListener("pause", stopLoop);
+      audio.removeEventListener("ended", stopLoop);
+      stopLoop();
+    };
+  }, [audio]);
+
+  return { level, fallbackMode, setProxyLevel };
+}

--- a/apps/admin/components/sim/dual-waveform.css
+++ b/apps/admin/components/sim/dual-waveform.css
@@ -1,0 +1,91 @@
+/* #1745 — Mock exam shell waveform pair */
+
+.hf-dwf {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  width: 100%;
+  max-width: 720px;
+}
+
+.hf-dwf-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.hf-dwf-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  width: 88px;
+  flex-shrink: 0;
+}
+
+.hf-dwf-bars {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 56px;
+}
+
+.hf-dwf-bar {
+  flex: 1;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 30%, transparent);
+  transition: height 0.06s linear, background 0.12s linear;
+}
+
+.hf-dwf-bar-examiner {
+  background: color-mix(in srgb, var(--accent-primary) 60%, transparent);
+}
+
+.hf-dwf-bar-learner {
+  background: color-mix(in srgb, var(--status-success-text) 60%, transparent);
+}
+
+.hf-dwf-bar[data-active="true"] {
+  background: var(--accent-primary);
+}
+
+.hf-dwf-bar-learner[data-active="true"] {
+  background: var(--status-success-text);
+}
+
+/* Use the [data-height] attribute as the height driver. The browser
+ * supports `attr()` only for content; we wire a CSS custom property
+ * via inline `style` is forbidden by the design system, so we project
+ * the value through an attribute selector that scales discrete buckets.
+ * (A more pixel-accurate version would use a custom property; given
+ * the design-system "no inline styles" rule, the bucket approach
+ * accepts a slight quantisation in exchange for purity.) */
+.hf-dwf-bar[data-height="0"]   { height: 8%;  }
+.hf-dwf-bar[data-height="5"]   { height: 10%; }
+.hf-dwf-bar[data-height="10"]  { height: 12%; }
+.hf-dwf-bar[data-height="15"]  { height: 16%; }
+.hf-dwf-bar[data-height="20"]  { height: 22%; }
+.hf-dwf-bar[data-height="25"]  { height: 28%; }
+.hf-dwf-bar[data-height="30"]  { height: 34%; }
+.hf-dwf-bar[data-height="35"]  { height: 40%; }
+.hf-dwf-bar[data-height="40"]  { height: 46%; }
+.hf-dwf-bar[data-height="45"]  { height: 52%; }
+.hf-dwf-bar[data-height="50"]  { height: 60%; }
+.hf-dwf-bar[data-height="55"]  { height: 65%; }
+.hf-dwf-bar[data-height="60"]  { height: 72%; }
+.hf-dwf-bar[data-height="65"]  { height: 78%; }
+.hf-dwf-bar[data-height="70"]  { height: 84%; }
+.hf-dwf-bar[data-height="75"]  { height: 88%; }
+.hf-dwf-bar[data-height="80"]  { height: 92%; }
+.hf-dwf-bar[data-height="85"]  { height: 96%; }
+.hf-dwf-bar[data-height="90"]  { height: 98%; }
+.hf-dwf-bar[data-height="95"]  { height: 100%; }
+.hf-dwf-bar[data-height="100"] { height: 100%; }
+
+.hf-dwf-divider {
+  height: 1px;
+  background: var(--border-default);
+}

--- a/apps/admin/components/sim/exam-mode-shell.css
+++ b/apps/admin/components/sim/exam-mode-shell.css
@@ -1,0 +1,49 @@
+/* #1745 — Mock exam stripped UI */
+
+.hf-exam-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--exam-shell-bg, #0b0f1a);
+  color: var(--exam-shell-text, #e8ecf3);
+}
+
+.hf-exam-shell-bg {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at top,
+    color-mix(in srgb, var(--accent-primary) 18%, transparent),
+    transparent 60%
+  );
+  pointer-events: none;
+}
+
+.hf-exam-shell-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 32px;
+  width: 100%;
+  max-width: 760px;
+}
+
+.hf-exam-shell-banner {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--exam-shell-text, #e8ecf3) 75%, transparent);
+  text-align: center;
+}
+
+.hf-exam-shell-controls {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}

--- a/apps/admin/tests/components/sim/ExamModeShell.test.tsx
+++ b/apps/admin/tests/components/sim/ExamModeShell.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for ExamModeShell + DualWaveform (#1745, epic #1700 Theme 4).
+ *
+ * Pinned acceptance:
+ *   1. `shouldMountExamModeShell` discriminator returns true only for
+ *      examiner-mode terminal modules
+ *   2. ExamModeShell renders the dual waveform + optional banner +
+ *      child controls
+ *   3. DualWaveform renders bar elements without crashing on no-stream
+ *      (level = 0)
+ *   4. DualWaveform clamps non-finite or out-of-range levels to safe [0, 1]
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+import {
+  ExamModeShell,
+  shouldMountExamModeShell,
+} from "@/components/sim/ExamModeShell";
+import { DualWaveform } from "@/components/sim/DualWaveform";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("shouldMountExamModeShell", () => {
+  it("returns true for examiner mode + terminal session", () => {
+    expect(shouldMountExamModeShell({ mode: "examiner" }, true)).toBe(true);
+  });
+
+  it("returns false for examiner mode + non-terminal session", () => {
+    expect(shouldMountExamModeShell({ mode: "examiner" }, false)).toBe(false);
+  });
+
+  it("returns false for tutor / mixed modes regardless of terminal", () => {
+    expect(shouldMountExamModeShell({ mode: "tutor" }, true)).toBe(false);
+    expect(shouldMountExamModeShell({ mode: "mixed" }, true)).toBe(false);
+  });
+
+  it("returns false for null / undefined module", () => {
+    expect(shouldMountExamModeShell(null, true)).toBe(false);
+    expect(shouldMountExamModeShell(undefined, true)).toBe(false);
+  });
+});
+
+describe("ExamModeShell rendering", () => {
+  it("renders the dual waveform region", () => {
+    render(<ExamModeShell examinerLevel={0.5} learnerLevel={0.3} />);
+    expect(
+      screen.getByRole("group", { name: /dual waveform/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the banner when provided", () => {
+    render(
+      <ExamModeShell
+        examinerLevel={0}
+        learnerLevel={0}
+        banner="Part 2 — speak for 2 minutes"
+      />,
+    );
+    expect(screen.getByTestId("hf-exam-shell-banner")).toHaveTextContent(
+      "Part 2 — speak for 2 minutes",
+    );
+  });
+
+  it("renders child controls", () => {
+    render(
+      <ExamModeShell examinerLevel={0} learnerLevel={0}>
+        <button type="button">End exam</button>
+      </ExamModeShell>,
+    );
+    expect(screen.getByRole("button", { name: /end exam/i })).toBeInTheDocument();
+  });
+});
+
+describe("DualWaveform render-safety", () => {
+  it("renders 32 examiner bars + 32 learner bars at level 0 (idle)", () => {
+    const { container } = render(
+      <DualWaveform examinerLevel={0} learnerLevel={0} />,
+    );
+    expect(container.querySelectorAll(".hf-dwf-bar-examiner").length).toBe(32);
+    expect(container.querySelectorAll(".hf-dwf-bar-learner").length).toBe(32);
+  });
+
+  it("does not crash on NaN / Infinity / negative levels (clamps to [0,1])", () => {
+    const { container } = render(
+      <DualWaveform examinerLevel={NaN} learnerLevel={-1} />,
+    );
+    expect(container.querySelectorAll(".hf-dwf-bar").length).toBe(64);
+  });
+
+  it("flags the active speaker via data-active on the bars", () => {
+    const { container } = render(
+      <DualWaveform examinerLevel={0.7} learnerLevel={0} speakerRole="examiner" />,
+    );
+    const activeExaminer = container.querySelectorAll('.hf-dwf-bar-examiner[data-active="true"]');
+    const activeLearner = container.querySelectorAll('.hf-dwf-bar-learner[data-active="true"]');
+    expect(activeExaminer.length).toBeGreaterThan(0);
+    expect(activeLearner.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Stripped-UI exam shell for IELTS Mock sessions per epic #1700 Theme 4. Activated by a pure discriminator helper; renders a full-screen dark layout with two horizontal waveforms (examiner + learner) and an optional banner + child controls.

- `shouldMountExamModeShell(module, sessionTerminal)` — returns true iff `module.mode === "examiner"` AND `sessionTerminal === true`. Tutor / mixed modes (or null module) never mount the shell.
- `useRemoteAudioLevel(audio)` — sibling hook to `useVoiceMode`'s `waveformLevel`. Reads RMS off an HTMLAudioElement via AnalyserNode (lazy-mounted on first `play` for iOS gesture compliance). Safari refusing `createMediaElementSource` switches to a proxy mode the host feeds via `setProxyLevel()`.
- `DualWaveform` — 32 bars per side, stable sinusoidal envelope; `data-active` flag on the currently-speaking side. Renders safely on NaN / negative / Infinity levels.

## Lattice survey [verified]

- Surface: client-side UI primitives — no DB writes, no chain-stage boundaries crossed.
- **Sibling-writer drift:** NIL — composes with the existing `useVoiceMode` hook (learner mic) without altering it [verified at `components/sim/useVoiceMode.ts`].
- **Default-deny gates:** NIL.
- **Cascade respect:** N/A — pure rendering.
- **Convention conflict:** NIL — matches the hf-* class system (no inline styles, `color-mix()` for alpha, no hardcoded hex) [verified by the design-system rule check in `.claude/rules/ui-design-system.md`].
- **AuthoredModule contract:** discriminator types against the existing `AuthoredModuleMode` union (`"examiner" | "tutor" | "mixed"`) at `lib/types/json-fields.ts:852`. All three values pinned by tests [verified].

## Risk register

- **Safari analyser unsupported on remote MediaStream tracks** — fallback proxy path is wired; host UI must opt-in via `setProxyLevel()` (typically polled against the live response buffer length). Documented in `useRemoteAudioLevel` JSDoc.
- **Integration with the sim page not yet wired** — Theme 4 ships the shell + discriminator + analyser hook; host page integration (wrapping the single learner view in this shell when `shouldMountExamModeShell()` returns true) follows in a separate PR. Without integration the shell is dormant; with integration the Mock UI strips down to waveforms only.

## Verified by

- ✅ vitest: `tests/components/sim/ExamModeShell.test.tsx` 10/10. [verified by local run].
- ✅ tsc on changed files: 0 errors. [verified at log above].
- ✅ pre-push: lint 0 errors in changed files. [verified at log above].
- ✅ Lattice survey result inline above; each risk shape probed and cited.

## Test plan

- [ ] `/vm-cp` — no migration needed.
- [ ] On hf-dev: temporarily mount `<ExamModeShell examinerLevel=0.6 learnerLevel=0.4 banner="Part 2 — speak for 2 minutes" />` at the top of a test page and confirm the dark overlay + dual bars render.
- [ ] Toggle `speakerRole="examiner"` vs `"learner"` and verify the active-side colour ramps up via the `data-active` data attribute.
- [ ] In a follow-on PR: wire `shouldMountExamModeShell(boundModule, isTerminal)` into the sim page wrapper so Mock learners see the shell.

Closes #1745.