### PR TITLE
chore(journey): tolCarryForwardBoost D_question_flow → K_between_calls

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -1432,7 +1432,7 @@ const G7_TOL_MEMORY_DECAY: JourneySettingContract = {
 
 const G7_TOL_CARRY_FORWARD: JourneySettingContract = {
   id: "tolCarryForwardBoost",
-  menuGroupKey: "D_question_flow",
+  menuGroupKey: "K_between_calls",
   group: "G7",
   educatorLabel: "Carry-forward priority boost",
   helpText:


### PR DESCRIPTION
## Summary

Tech-lead review of the 4 tolerance-bucket assignments shipped in Lane 3 PR9 (#1799). 3 of 4 stand; one bucket move needed.

Resolves journey-tab close-out follow-up #3 (tolerances bucket review).

## What changed

**`tolCarryForwardBoost`: `D_question_flow` → `K_between_calls`** (one line).

Why: the boost is a priority bump applied to TPs that were planned in the prior call but never covered (hangup, time-out). Its moment is "between calls → what gets planned for the next session", not "within-call question ordering." An educator browsing `D_question_flow` ("what gets asked + in what order *during* a session") would not expect to find a cross-call carryover knob there. `K_between_calls` ("Cadence, recommendations, prereqs") fires when the scheduler plans the next session — exact fit.

## TL verdicts on the other three

| Contract | Bucket | TL verdict |
|---|---|---|
| `tolMasteryThreshold` | `I_scoring` | ✓ AGREE — passing-bar override is squarely scoring |
| `tolRetrievalCadence` | `K_between_calls` | ✓ AGREE — spaced-repetition cadence is between-calls |
| `tolMemoryDecay` | `K_between_calls` | ✓ AGREE — forgetting curve fires between sessions |

## Verified by

- **TL agent verdict** reasoned from `lib/tolerance/*` helper + the bucket caption taxonomy in `docs/CONTRACTS-JOURNEY.md` §17. Full review captured in commit message.
- **Tests:** \`npx vitest run tests/lib/journey/ tests/components/journey-tab/\` — 110/110 pass. No count rebases needed (bucket-count chip tests count populated buckets, not specific contracts per bucket).
- **Lint:** \`no-bucketless-journey-setting\` ESLint rule still passes.

## Out of scope (deferred follow-ons)

TL flagged two additional concerns that are out of scope for a single bucket-move PR:

1. **Issue-number suffixes in helpText** (e.g. \`"(#598)"\`) are noise from an educator's perspective. But this is a site-wide convention — 28 instances across the contracts file. All-or-none change; not bundling here.
2. **\`tolRetrievalCadence\` control type** is currently \`number\` (free-entry). If \`resolve-tolerance.ts\` has a bounded range, \`slider\` would be the better UX. Needs investigation of the helper's clamping behaviour.

## Pre-push escape hatch

Pushed with \`HF_SKIP_PREPUSH=1\` for the same reason as #1813 and #1814: \`.ratchet.json\` \`tsc_errors\` baseline is **43** but main has drifted to **59** (handoff #7 — queued as a separate follow-on PR). None of those errors reference my changes.

## Test plan

- [x] All journey + journey-tab vitests pass
- [x] ESLint clean on changed contract file
- [ ] Cmd+K menu in \`/x/courses/<id>?tab=journey\` shows "Carry-forward priority boost" under \`K_between_calls\` bucket, not \`D_question_flow\` (manual verify on hf-dev after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)