### PR TITLE
feat(journey): JourneyStop typed compound editor

### DIFF
--- a/apps/admin/components/journey-controls/JourneyStop.tsx
+++ b/apps/admin/components/journey-controls/JourneyStop.tsx
@@ -1,45 +1,373 @@
 "use client";
 
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+import { useJourneySetting } from "@/components/shared/preview-renderers/_journey-setting-context";
+
 import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
 import type { JourneyFieldProps } from "./JourneyField";
 
-/** JourneyStop primitive — a JourneyStop is the discriminated-union
- *  shape (`{kind, enabled, trigger}`) used for pre-test / mid-test /
- *  post-test / NPS. Phase 1 ships the placeholder; Phase 3 wraps the
- *  existing `SurveyStopDetail` / sidetray editor with a typed-form
- *  surface. */
+/** Trigger discriminated-union types — mirror of `JourneyStopTrigger`
+ *  in `lib/types/json-fields.ts`. The editor only commits one of these. */
+const TRIGGER_TYPES = [
+  { value: "first_session", label: "On the first session" },
+  { value: "before_session", label: "Before session N" },
+  { value: "after_session", label: "After session N" },
+  { value: "midpoint", label: "At journey midpoint" },
+  { value: "mastery_reached", label: "When mastery threshold reached" },
+  { value: "session_count", label: "After N sessions" },
+  { value: "course_complete", label: "When course completes" },
+] as const;
+
+type TriggerType = (typeof TRIGGER_TYPES)[number]["value"];
+
+interface TriggerWithIndex {
+  type: "before_session" | "after_session";
+  index: number;
+}
+interface TriggerWithThreshold {
+  type: "mastery_reached";
+  threshold: number;
+}
+interface TriggerWithCount {
+  type: "session_count";
+  count: number;
+}
+interface TriggerSimple {
+  type: "first_session" | "midpoint" | "course_complete";
+}
+type Trigger = TriggerSimple | TriggerWithIndex | TriggerWithThreshold | TriggerWithCount;
+
+interface StopDraft {
+  enabled: boolean;
+  trigger: Trigger;
+  /** Preserved from the existing value so we don't drop `id`, `kind`,
+   *  `delivery`, `payload` etc. on save. */
+  extra: Record<string, unknown>;
+}
+
+/** JourneyStop primitive — typed compound editor for the discriminated-
+ *  union shape `{kind, enabled, trigger, …}`. Saves the full object via
+ *  the journey-setting PATCH route.
+ *
+ *  Educator sees:
+ *    - Enabled toggle
+ *    - Trigger type dropdown (7 options)
+ *    - Conditional sub-fields (index / threshold / count) based on type
+ *
+ *  Edits auto-commit debounced (matches JourneyText / JourneyNumber).
+ *  Any extra fields on the stored value (`id`, `kind`, `delivery`,
+ *  `payload`) are preserved across saves.
+ *
+ *  Falls back to a read-only placeholder when there is no course context
+ *  (legacy callers, Preview tab read-only window). */
 export function JourneyStop({ contract, value }: JourneyFieldProps) {
-  const stop = isStop(value) ? value : null;
+  const ctx = useJourneySetting();
+  const initialDraft = parseStopValue(value);
+
+  const f = useCascadeEditField<StopDraft>({
+    contract,
+    value: initialDraft,
+    onSave: async (next) => {
+      const fullValue = serializeStop(next);
+      await ctx.saveSetting(contract.id, fullValue);
+    },
+  });
+
+  if (!ctx.courseId || ctx.readonly) {
+    return (
+      <_FieldShell
+        contract={contract}
+        effectiveSource={_firstCascadeSource(contract)}
+        isDirty={false}
+        isActive={false}
+      >
+        <div
+          className="hf-jf-compound-placeholder"
+          data-testid={`hf-jf-stop-${contract.id}`}
+        >
+          {isEmptyStop(value) ? (
+            <div className="hf-jf-compound-empty">
+              <strong>Not configured.</strong>
+            </div>
+          ) : (
+            <div className="hf-jf-compound-summary">
+              <strong>{initialDraft.enabled ? "Enabled" : "Disabled"}</strong>
+              <span> · {describeTrigger(initialDraft.trigger)}</span>
+            </div>
+          )}
+          <div className="hf-jf-help">
+            {!ctx.courseId
+              ? "Editor mounts when course context is available."
+              : "Read-only mode."}
+          </div>
+        </div>
+      </_FieldShell>
+    );
+  }
+
+  const onEnabledChange = (next: boolean) => {
+    f.setDraftValue({ ...f.draftValue, enabled: next });
+    f.commitDebounced();
+  };
+
+  const onTypeChange = (next: TriggerType) => {
+    f.setDraftValue({
+      ...f.draftValue,
+      trigger: defaultTriggerForType(next),
+    });
+    f.commitDebounced();
+  };
+
+  const onIndexChange = (n: number) => {
+    const t = f.draftValue.trigger;
+    if (t.type !== "before_session" && t.type !== "after_session") return;
+    f.setDraftValue({ ...f.draftValue, trigger: { ...t, index: n } });
+    f.commitDebounced();
+  };
+
+  const onThresholdChange = (n: number) => {
+    const t = f.draftValue.trigger;
+    if (t.type !== "mastery_reached") return;
+    f.setDraftValue({ ...f.draftValue, trigger: { ...t, threshold: n } });
+    f.commitDebounced();
+  };
+
+  const onCountChange = (n: number) => {
+    const t = f.draftValue.trigger;
+    if (t.type !== "session_count") return;
+    f.setDraftValue({ ...f.draftValue, trigger: { ...t, count: n } });
+    f.commitDebounced();
+  };
+
+  const draft = f.draftValue;
+  const trigger = draft.trigger;
+
   return (
     <_FieldShell
       contract={contract}
       effectiveSource={_firstCascadeSource(contract)}
-      isDirty={false}
-      isActive={false}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
     >
       <div
-        className="hf-jf-compound-placeholder"
+        className="hf-jf-control hf-jf-stop-editor"
         data-testid={`hf-jf-stop-${contract.id}`}
       >
-        {stop === null
-          ? "Stop not configured."
-          : `${stop.enabled ? "Enabled" : "Disabled"}${
-              stop.kind ? ` · kind: ${stop.kind}` : ""
-            }${stop.trigger ? ` · trigger: ${JSON.stringify(stop.trigger)}` : ""}`}
-        <div className="hf-jf-help">
-          Stop editor mounts in Phase 3.
+        <div className="hf-jf-stop-row">
+          <label
+            className="hf-jf-stop-sub-label"
+            htmlFor={`hf-jf-${contract.id}-enabled`}
+          >
+            Enabled
+          </label>
+          <button
+            id={`hf-jf-${contract.id}-enabled`}
+            type="button"
+            role="switch"
+            aria-checked={draft.enabled}
+            disabled={f.isSaving}
+            onClick={() => onEnabledChange(!draft.enabled)}
+            className="hf-jf-toggle"
+            data-testid={`hf-jf-stop-${contract.id}-enabled`}
+          />
         </div>
+
+        <div className="hf-jf-stop-row">
+          <label
+            className="hf-jf-stop-sub-label"
+            htmlFor={`hf-jf-${contract.id}-trigger-type`}
+          >
+            Trigger
+          </label>
+          <select
+            id={`hf-jf-${contract.id}-trigger-type`}
+            className="hf-input hf-jf-select"
+            value={trigger.type}
+            disabled={f.isSaving}
+            onChange={(e) => onTypeChange(e.target.value as TriggerType)}
+            data-testid={`hf-jf-stop-${contract.id}-trigger-type`}
+          >
+            {TRIGGER_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {(trigger.type === "before_session" || trigger.type === "after_session") && (
+          <div className="hf-jf-stop-row">
+            <label
+              className="hf-jf-stop-sub-label"
+              htmlFor={`hf-jf-${contract.id}-trigger-index`}
+            >
+              Session N
+            </label>
+            <input
+              id={`hf-jf-${contract.id}-trigger-index`}
+              type="number"
+              className="hf-input hf-jf-input"
+              min={1}
+              step={1}
+              value={trigger.index}
+              disabled={f.isSaving}
+              onChange={(e) => onIndexChange(Number(e.target.value))}
+              onBlur={() => void f.commit()}
+              data-testid={`hf-jf-stop-${contract.id}-trigger-index`}
+            />
+          </div>
+        )}
+
+        {trigger.type === "mastery_reached" && (
+          <div className="hf-jf-stop-row">
+            <label
+              className="hf-jf-stop-sub-label"
+              htmlFor={`hf-jf-${contract.id}-trigger-threshold`}
+            >
+              Threshold (0–1)
+            </label>
+            <input
+              id={`hf-jf-${contract.id}-trigger-threshold`}
+              type="number"
+              className="hf-input hf-jf-input"
+              min={0}
+              max={1}
+              step={0.05}
+              value={trigger.threshold}
+              disabled={f.isSaving}
+              onChange={(e) => onThresholdChange(Number(e.target.value))}
+              onBlur={() => void f.commit()}
+              data-testid={`hf-jf-stop-${contract.id}-trigger-threshold`}
+            />
+          </div>
+        )}
+
+        {trigger.type === "session_count" && (
+          <div className="hf-jf-stop-row">
+            <label
+              className="hf-jf-stop-sub-label"
+              htmlFor={`hf-jf-${contract.id}-trigger-count`}
+            >
+              Sessions
+            </label>
+            <input
+              id={`hf-jf-${contract.id}-trigger-count`}
+              type="number"
+              className="hf-input hf-jf-input"
+              min={1}
+              step={1}
+              value={trigger.count}
+              disabled={f.isSaving}
+              onChange={(e) => onCountChange(Number(e.target.value))}
+              onBlur={() => void f.commit()}
+              data-testid={`hf-jf-stop-${contract.id}-trigger-count`}
+            />
+          </div>
+        )}
       </div>
     </_FieldShell>
   );
 }
 
-interface StopShape {
-  kind?: string;
-  enabled?: boolean;
-  trigger?: unknown;
+function parseStopValue(value: unknown): StopDraft {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {
+      enabled: false,
+      trigger: { type: "first_session" },
+      extra: {},
+    };
+  }
+  const obj = value as Record<string, unknown>;
+  const { enabled: rawEnabled, trigger: rawTrigger, ...extra } = obj;
+  return {
+    enabled: typeof rawEnabled === "boolean" ? rawEnabled : false,
+    trigger: parseTrigger(rawTrigger),
+    extra,
+  };
 }
 
-function isStop(v: unknown): v is StopShape {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+function parseTrigger(raw: unknown): Trigger {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { type: "first_session" };
+  }
+  const t = raw as Record<string, unknown>;
+  const type = typeof t.type === "string" ? t.type : "first_session";
+  switch (type) {
+    case "before_session":
+    case "after_session":
+      return {
+        type,
+        index: typeof t.index === "number" && t.index > 0 ? t.index : 1,
+      };
+    case "mastery_reached":
+      return {
+        type,
+        threshold:
+          typeof t.threshold === "number" && t.threshold >= 0 && t.threshold <= 1
+            ? t.threshold
+            : 0.7,
+      };
+    case "session_count":
+      return {
+        type,
+        count: typeof t.count === "number" && t.count > 0 ? t.count : 3,
+      };
+    case "first_session":
+    case "midpoint":
+    case "course_complete":
+      return { type };
+    default:
+      return { type: "first_session" };
+  }
+}
+
+function defaultTriggerForType(type: TriggerType): Trigger {
+  switch (type) {
+    case "before_session":
+    case "after_session":
+      return { type, index: 1 };
+    case "mastery_reached":
+      return { type, threshold: 0.7 };
+    case "session_count":
+      return { type, count: 3 };
+    case "first_session":
+    case "midpoint":
+    case "course_complete":
+      return { type };
+  }
+}
+
+function serializeStop(draft: StopDraft): Record<string, unknown> {
+  return {
+    ...draft.extra,
+    enabled: draft.enabled,
+    trigger: draft.trigger,
+  };
+}
+
+function describeTrigger(t: Trigger): string {
+  switch (t.type) {
+    case "first_session":
+      return "On the first session";
+    case "before_session":
+      return `Before session ${t.index}`;
+    case "after_session":
+      return `After session ${t.index}`;
+    case "midpoint":
+      return "At journey midpoint";
+    case "mastery_reached":
+      return `When mastery reaches ${Math.round(t.threshold * 100)}%`;
+    case "session_count":
+      return `After ${t.count} sessions`;
+    case "course_complete":
+      return "When course completes";
+  }
+}
+
+function isEmptyStop(v: unknown): boolean {
+  return (
+    typeof v !== "object" ||
+    v === null ||
+    Object.keys(v as Record<string, unknown>).length === 0
+  );
 }

--- a/apps/admin/components/journey-controls/journey-controls.css
+++ b/apps/admin/components/journey-controls/journey-controls.css
@@ -276,3 +276,28 @@
 .hf-jf-array-add-row {
   display: flex;
 }
+
+/* Stop editor (#2a — typed compound for JourneyStop discriminated-union) */
+
+.hf-jf-stop-editor {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+.hf-jf-stop-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.hf-jf-stop-sub-label {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  min-width: 92px;
+  flex-shrink: 0;
+}
+.hf-jf-select {
+  flex: 1;
+  min-width: 0;
+}

--- a/apps/admin/tests/components/journey-controls/JourneyStop.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyStop.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+
+import { JourneyStop } from "@/components/journey-controls/JourneyStop";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+const contract: JourneySettingContract = {
+  id: "preTestStop",
+  group: "G2",
+  educatorLabel: "Pre-test stop",
+  storagePath: "sessionFlow.stops.preTest",
+  control: "stop",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["modulesGate", "instructions"],
+    kinds: ["section-enable", "stop-timing"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, effectiveValue: null, autoEnabled: [], bumpedSections: [] }),
+    } as Response),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderWithProvider(value: unknown) {
+  return render(
+    <JourneySettingMutatorProvider courseId="course-1">
+      <JourneyStop contract={contract} value={value} onSave={vi.fn()} />
+    </JourneySettingMutatorProvider>,
+  );
+}
+
+describe("JourneyStop — typed compound editor", () => {
+  it("shows placeholder when there is no provider", () => {
+    render(
+      <JourneyStop
+        contract={contract}
+        value={null}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    // No editable controls — only the placeholder shell.
+    expect(
+      screen.queryByTestId("hf-jf-stop-preTestStop-enabled"),
+    ).toBeNull();
+    expect(screen.getByTestId("hf-jf-stop-preTestStop")).toBeInTheDocument();
+  });
+
+  it("renders enabled toggle + trigger dropdown when provider is set", () => {
+    renderWithProvider({ enabled: false, trigger: { type: "first_session" } });
+    expect(
+      screen.getByTestId("hf-jf-stop-preTestStop-enabled"),
+    ).toBeInTheDocument();
+    const select = screen.getByTestId("hf-jf-stop-preTestStop-trigger-type") as HTMLSelectElement;
+    expect(select.value).toBe("first_session");
+  });
+
+  it("commits with new enabled + preserved extras when toggle is clicked", async () => {
+    renderWithProvider({
+      id: "preTestStop-1",
+      kind: "assessment",
+      delivery: { mode: "voice" },
+      enabled: false,
+      trigger: { type: "first_session" },
+    });
+    fireEvent.click(screen.getByTestId("hf-jf-stop-preTestStop-enabled"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled(), { timeout: 2000 });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.settingId).toBe("preTestStop");
+    // Extras preserved across save:
+    expect(body.value.id).toBe("preTestStop-1");
+    expect(body.value.kind).toBe("assessment");
+    expect(body.value.delivery).toEqual({ mode: "voice" });
+    // New enabled committed:
+    expect(body.value.enabled).toBe(true);
+    expect(body.value.trigger).toEqual({ type: "first_session" });
+  });
+
+  it("shows index input when trigger type is before_session", () => {
+    renderWithProvider({ enabled: true, trigger: { type: "before_session", index: 2 } });
+    const indexInput = screen.getByTestId(
+      "hf-jf-stop-preTestStop-trigger-index",
+    ) as HTMLInputElement;
+    expect(indexInput.value).toBe("2");
+  });
+
+  it("shows threshold input when trigger type is mastery_reached", () => {
+    renderWithProvider({ enabled: true, trigger: { type: "mastery_reached", threshold: 0.8 } });
+    const input = screen.getByTestId(
+      "hf-jf-stop-preTestStop-trigger-threshold",
+    ) as HTMLInputElement;
+    expect(input.value).toBe("0.8");
+  });
+
+  it("shows count input when trigger type is session_count", () => {
+    renderWithProvider({ enabled: true, trigger: { type: "session_count", count: 5 } });
+    const input = screen.getByTestId(
+      "hf-jf-stop-preTestStop-trigger-count",
+    ) as HTMLInputElement;
+    expect(input.value).toBe("5");
+  });
+
+  it("switching trigger type to mastery_reached defaults threshold to 0.7", async () => {
+    renderWithProvider({ enabled: true, trigger: { type: "first_session" } });
+    const select = screen.getByTestId(
+      "hf-jf-stop-preTestStop-trigger-type",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "mastery_reached" } });
+    const threshold = await waitFor(() =>
+      screen.getByTestId("hf-jf-stop-preTestStop-trigger-threshold"),
+    ) as HTMLInputElement;
+    expect(threshold.value).toBe("0.7");
+  });
+});


### PR DESCRIPTION
## Summary

Followup #2a from the journey-tab closeout. Replaces the placeholder "Use ⋯ → Edit as JSON" shell in `JourneyStop.tsx` with a typed-form editor for the JourneyStop discriminated-union shape.

## What the editor exposes

| Field | Control | Behavior |
|---|---|---|
| Enabled | Toggle (`role="switch"`) | Auto-commit debounced |
| Trigger type | Dropdown (7 options) | Mirrors `JourneyStopTrigger` discriminated union from `lib/types/json-fields.ts` |
| Session N | Number input | Conditional: only shown when trigger is `before_session` or `after_session` |
| Threshold (0–1) | Number input | Conditional: only shown when trigger is `mastery_reached` |
| Sessions | Number input | Conditional: only shown when trigger is `session_count` |

Trigger types covered: `first_session` / `before_session` / `after_session` / `midpoint` / `mastery_reached` / `session_count` / `course_complete` (full set of 7).

## Why preserve "extras"?

The `JourneyStop` type carries more than `{enabled, trigger}` — it also has `id`, `kind`, `delivery`, `payload?`. The editor exposes only the two operator-facing fields but **preserves the rest** by capturing them into a `StopDraft.extra: Record<string, unknown>` slot at parse time and merging back on serialise. Without this, opening the editor and clicking the toggle would silently drop `delivery` from the stored value.

## Why auto-commit debounced (not an explicit Save button)?

Matches the existing `JourneyText` / `JourneyNumber` pattern — `useCascadeEditField` debounces commits 600ms, the `_FieldShell` renders **• Unsaved** / ✓ Saved pills for feedback. Consistency with the other JourneyField primitives matters more than the marginal advantage of an explicit Save button for a 2–3-field editor.

## Falls back to placeholder

When no `JourneySettingMutatorProvider` is mounted (legacy callers, Preview tab read-only window), the editor renders a read-only placeholder that summarises the trigger humanly ("When mastery reaches 70%") instead of dumping JSON. This is the path the original placeholder served.

## Wires into

The 4 existing stop contracts: `preTestStop`, `midJourneyStop`, `npsStop`, `postTestStop` (all use `control: "stop"`). No registry changes needed — the dispatch table in `JourneyField.tsx` already routes `control: "stop"` → `JourneyStop`.

## Verified by

- **7 new vitests** at `tests/components/journey-controls/JourneyStop.test.tsx`:
  1. Placeholder when no provider
  2. Editor renders when provider mounted
  3. Toggle commit preserves extras (id, kind, delivery)
  4. Conditional index input for `before_session`
  5. Conditional threshold input for `mastery_reached`
  6. Conditional count input for `session_count`
  7. Switching to `mastery_reached` defaults threshold to 0.7
- **Full journey-controls suite** still passes (35/35).
- **TypeScript:** 0 new tsc errors introduced. Verified by diffing pre/post `tsc --noEmit` output — only pre-existing main drift remains (handoff #7 / PR8).
- **ESLint clean** on `JourneyStop.tsx`.

## Out of scope (future work)

- **Stop-vs-array reconciliation:** the 4 stop contracts have `storagePath: "sessionFlow.stops.<kind>"` but `SessionFlowConfig.stops` is typed as `JourneyStop[]` (array). The contracts write to a keyed shape. Not a regression — this PR matches the existing contract behaviour. Reconciliation is a deeper schema decision out of scope here.
- **Kind editing:** the editor doesn't expose `kind` (`assessment` / `survey` / `nps` / `reflection`) because it's implied by which contract the educator opened. If product wants per-stop kind override later, add it then.
- **Delivery editing:** `delivery: { mode: "voice" | "chat" | "either" }` is preserved but not editable. Add when a use case lands.

## Pre-push escape hatch

Pushed with \`HF_SKIP_PREPUSH=1\` for the same reason as #1813 / #1814 / #1817 / #1818: \`.ratchet.json\` \`tsc_errors\` baseline is **43** but main has drifted to **68** (additional drift since PR1 — none from this branch). Queued in PR8 (#7).

## Test plan

- [x] 7 new vitests pass
- [x] Full journey-controls suite (35/35) still passes
- [x] No new tsc errors introduced
- [x] ESLint clean
- [ ] Manual: open `/x/courses/<id>?tab=journey` → click any stop setting (preTestStop, etc.) → verify the editor renders, edits, and saves (hf-dev after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)