### PR TITLE
feat(journey): JourneyPhases typed compound editor

### DIFF
--- a/apps/admin/components/journey-controls/JourneyPhases.tsx
+++ b/apps/admin/components/journey-controls/JourneyPhases.tsx
@@ -1,39 +1,315 @@
 "use client";
 
+import { useCascadeEditField } from "@/lib/journey/use-cascade-edit-field";
+import { useJourneySetting } from "@/components/shared/preview-renderers/_journey-setting-context";
+
 import { _FieldShell, _firstCascadeSource } from "./_FieldShell";
 import type { JourneyFieldProps } from "./JourneyField";
 
-/** Compound phase-builder primitive. Phase 1 ships a placeholder shell
- *  with a click-through to the existing `OnboardingEditor`-style sidetray
- *  (when wired in Phase 2). For Phase 1 the placeholder is read-only and
- *  documents that editing currently lives in the legacy lens.
+interface PhaseDraft {
+  phase: string;
+  duration: string;
+  goals: string[];
+  /** Preserve `content`, `surveySteps` (and any future fields) across saves. */
+  extra: Record<string, unknown>;
+}
+
+interface PhasesDraft {
+  phases: PhaseDraft[];
+  /** Preserve `successMetrics` (OnboardingFlowPhases) / `triggerAfterCalls`
+   *  / `bannerMessage` (OffboardingConfig) across saves. */
+  extra: Record<string, unknown>;
+}
+
+/** Compound phase-builder primitive — Phase 3 of epic #1675 (#1693).
  *
- *  Generalisation to a real `<PhaseSequenceBuilder>` is the Phase 2/3
- *  task — `OnboardingEditor` is tightly scoped today. */
+ *  Used for `onboardingFlowPhases` + `offboardingFlowPhases`. The stored
+ *  value is a wrapper object (`OnboardingFlowPhases` /
+ *  `OffboardingConfig`) whose `phases` slot is an array of
+ *  `OnboardingPhase = { phase, duration, goals, content?, surveySteps? }`.
+ *
+ *  Educator sees a row per phase with three editable fields:
+ *    - Phase name (text)
+ *    - Duration (text — free-form, e.g. "5 minutes")
+ *    - Goals (multi-line — one goal per line)
+ *
+ *  Plus add / remove / reorder buttons per row. Auto-commit debounced
+ *  for text changes (matches JourneyText), immediate for structural
+ *  changes (matches JourneyArrayEditor).
+ *
+ *  Extras at the wrapper level (`successMetrics` / `triggerAfterCalls` /
+ *  `bannerMessage`) AND per-phase (`content` / `surveySteps`) are
+ *  preserved across saves — the editor only exposes the 3 fields above
+ *  but never drops the other shape.
+ *
+ *  Falls back to a read-only placeholder when no provider is mounted.
+ */
 export function JourneyPhases({ contract, value }: JourneyFieldProps) {
-  const phases = Array.isArray(value) ? (value as Array<{ name?: string }>) : [];
+  const ctx = useJourneySetting();
+  const initialDraft = parsePhases(value);
+
+  const saveDraft = async (next: PhasesDraft) => {
+    await ctx.saveSetting(contract.id, serializePhases(next));
+  };
+
+  const f = useCascadeEditField<PhasesDraft>({
+    contract,
+    value: initialDraft,
+    onSave: saveDraft,
+  });
+
+  if (!ctx.courseId || ctx.readonly) {
+    return (
+      <_FieldShell
+        contract={contract}
+        effectiveSource={_firstCascadeSource(contract)}
+        isDirty={false}
+        isActive={false}
+      >
+        <div
+          className="hf-jf-compound-placeholder"
+          data-testid={`hf-jf-phases-${contract.id}`}
+        >
+          {initialDraft.phases.length === 0 ? (
+            <div className="hf-jf-compound-empty">
+              <strong>No phases configured.</strong>
+            </div>
+          ) : (
+            <div className="hf-jf-compound-summary">
+              <strong>
+                {initialDraft.phases.length} phase
+                {initialDraft.phases.length === 1 ? "" : "s"}:
+              </strong>{" "}
+              <span>
+                {initialDraft.phases.map((p) => p.phase || "(unnamed)").join(" → ")}
+              </span>
+            </div>
+          )}
+          <div className="hf-jf-help">
+            {!ctx.courseId
+              ? "Editor mounts when course context is available."
+              : "Read-only mode."}
+          </div>
+        </div>
+      </_FieldShell>
+    );
+  }
+
+  function commitImmediate(next: PhasesDraft) {
+    // Structural changes (add / remove / reorder) commit directly with
+    // the new draft rather than via f.commit(), which reads draftRef
+    // and would see the stale pre-setDraftValue snapshot synchronously.
+    // Mirrors JourneyArrayEditor's pattern.
+    f.setDraftValue(next);
+    void saveDraft(next);
+  }
+
+  function updateDebounced(next: PhasesDraft) {
+    f.setDraftValue(next);
+    f.commitDebounced();
+  }
+
+  function addPhase() {
+    commitImmediate({
+      ...f.draftValue,
+      phases: [
+        ...f.draftValue.phases,
+        { phase: "", duration: "", goals: [], extra: {} },
+      ],
+    });
+  }
+
+  function removePhase(index: number) {
+    commitImmediate({
+      ...f.draftValue,
+      phases: f.draftValue.phases.filter((_, i) => i !== index),
+    });
+  }
+
+  function movePhase(index: number, delta: -1 | 1) {
+    const next = [...f.draftValue.phases];
+    const target = index + delta;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    commitImmediate({ ...f.draftValue, phases: next });
+  }
+
+  function setPhaseField(
+    index: number,
+    field: "phase" | "duration" | "goalsRaw",
+    raw: string,
+  ) {
+    const next = [...f.draftValue.phases];
+    const current = next[index];
+    if (field === "goalsRaw") {
+      next[index] = {
+        ...current,
+        goals: raw
+          .split(/\r?\n/)
+          .map((l) => l.trim())
+          .filter((l) => l.length > 0),
+      };
+    } else {
+      next[index] = { ...current, [field]: raw };
+    }
+    updateDebounced({ ...f.draftValue, phases: next });
+  }
 
   return (
     <_FieldShell
       contract={contract}
       effectiveSource={_firstCascadeSource(contract)}
-      isDirty={false}
-      isActive={false}
+      isDirty={f.isDirty}
+      isActive={f.glow.isActive}
     >
-      <div
-        className="hf-jf-compound-placeholder"
-        data-testid={`hf-jf-phases-${contract.id}`}
-      >
-        {phases.length === 0
-          ? "No phases configured."
-          : `${phases.length} phase${phases.length === 1 ? "" : "s"}: ${phases
-              .map((p) => p.name ?? "(unnamed)")
-              .join(" → ")}`}
-        <div className="hf-jf-help">
-          Inline phase-editing ships in Phase 3. For now, edit via the legacy
-          lens (existing Design tab).
+      <div className="hf-jf-array-editor" data-testid={`hf-jf-phases-${contract.id}`}>
+        {f.draftValue.phases.length === 0 ? (
+          <div className="hf-jf-array-empty">No phases yet.</div>
+        ) : (
+          <ol className="hf-jf-array-rows">
+            {f.draftValue.phases.map((p, index) => (
+              <li
+                key={index}
+                className="hf-jf-array-row"
+                data-testid={`hf-jf-phase-${contract.id}-${index}`}
+              >
+                <div className="hf-jf-array-row-header">
+                  <span className="hf-jf-array-row-title">
+                    Phase {index + 1}
+                  </span>
+                  <div className="hf-jf-array-row-actions">
+                    <button
+                      type="button"
+                      className="hf-btn hf-btn-ghost hf-btn-icon"
+                      aria-label="Move up"
+                      disabled={f.isSaving || index === 0}
+                      onClick={() => movePhase(index, -1)}
+                      data-testid={`hf-jf-phase-up-${contract.id}-${index}`}
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      className="hf-btn hf-btn-ghost hf-btn-icon"
+                      aria-label="Move down"
+                      disabled={f.isSaving || index === f.draftValue.phases.length - 1}
+                      onClick={() => movePhase(index, 1)}
+                      data-testid={`hf-jf-phase-down-${contract.id}-${index}`}
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      className="hf-btn hf-btn-ghost hf-btn-icon hf-btn-danger"
+                      aria-label="Remove"
+                      disabled={f.isSaving}
+                      onClick={() => removePhase(index)}
+                      data-testid={`hf-jf-phase-remove-${contract.id}-${index}`}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+                <div className="hf-jf-array-row-fields">
+                  <label className="hf-jf-array-field">
+                    <span className="hf-jf-array-field-label">Name</span>
+                    <input
+                      type="text"
+                      className="hf-input hf-jf-input"
+                      value={p.phase}
+                      disabled={f.isSaving}
+                      onChange={(e) => setPhaseField(index, "phase", e.target.value)}
+                      onBlur={() => void f.commit()}
+                      data-testid={`hf-jf-phase-${contract.id}-${index}-name`}
+                    />
+                  </label>
+                  <label className="hf-jf-array-field">
+                    <span className="hf-jf-array-field-label">Duration</span>
+                    <input
+                      type="text"
+                      className="hf-input hf-jf-input"
+                      value={p.duration}
+                      placeholder="e.g. 5 minutes"
+                      disabled={f.isSaving}
+                      onChange={(e) =>
+                        setPhaseField(index, "duration", e.target.value)
+                      }
+                      onBlur={() => void f.commit()}
+                      data-testid={`hf-jf-phase-${contract.id}-${index}-duration`}
+                    />
+                  </label>
+                  <label className="hf-jf-array-field">
+                    <span className="hf-jf-array-field-label">Goals</span>
+                    <textarea
+                      className="hf-input hf-jf-input"
+                      rows={3}
+                      value={p.goals.join("\n")}
+                      disabled={f.isSaving}
+                      onChange={(e) =>
+                        setPhaseField(index, "goalsRaw", e.target.value)
+                      }
+                      onBlur={() => void f.commit()}
+                      data-testid={`hf-jf-phase-${contract.id}-${index}-goals`}
+                    />
+                    <span className="hf-jf-help hf-jf-array-field-hint">
+                      One goal per line.
+                    </span>
+                  </label>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+        <div className="hf-jf-array-add-row">
+          <button
+            type="button"
+            className="hf-btn hf-btn-secondary"
+            disabled={f.isSaving}
+            onClick={addPhase}
+            data-testid={`hf-jf-phases-add-${contract.id}`}
+          >
+            + Add phase
+          </button>
         </div>
       </div>
     </_FieldShell>
   );
+}
+
+function parsePhases(value: unknown): PhasesDraft {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { phases: [], extra: {} };
+  }
+  const obj = value as Record<string, unknown>;
+  const { phases: rawPhases, ...extra } = obj;
+  const phases = Array.isArray(rawPhases)
+    ? rawPhases
+        .filter((p): p is Record<string, unknown> => !!p && typeof p === "object" && !Array.isArray(p))
+        .map(parsePhase)
+    : [];
+  return { phases, extra };
+}
+
+function parsePhase(raw: Record<string, unknown>): PhaseDraft {
+  const { phase, duration, goals, ...extra } = raw;
+  return {
+    phase: typeof phase === "string" ? phase : "",
+    duration: typeof duration === "string" ? duration : "",
+    goals: Array.isArray(goals)
+      ? goals.filter((g): g is string => typeof g === "string")
+      : [],
+    extra,
+  };
+}
+
+function serializePhases(draft: PhasesDraft): Record<string, unknown> {
+  return {
+    ...draft.extra,
+    phases: draft.phases.map((p) => ({
+      ...p.extra,
+      phase: p.phase,
+      duration: p.duration,
+      goals: p.goals,
+    })),
+  };
 }

--- a/apps/admin/tests/components/journey-controls/JourneyPhases.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyPhases.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+
+import { JourneyPhases } from "@/components/journey-controls/JourneyPhases";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import type { JourneySettingContract } from "@/lib/journey/setting-contracts";
+
+const contract: JourneySettingContract = {
+  id: "onboardingFlowPhases",
+  group: "G2",
+  educatorLabel: "Onboarding phases",
+  storagePath: "config.onboardingFlowPhases",
+  control: "phases",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["onboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          effectiveValue: null,
+          autoEnabled: [],
+          bumpedSections: [],
+        }),
+    } as Response),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderWithProvider(value: unknown) {
+  return render(
+    <JourneySettingMutatorProvider courseId="course-1">
+      <JourneyPhases contract={contract} value={value} onSave={vi.fn()} />
+    </JourneySettingMutatorProvider>,
+  );
+}
+
+describe("JourneyPhases — typed compound editor", () => {
+  it("shows placeholder when there is no provider", () => {
+    render(
+      <JourneyPhases
+        contract={contract}
+        value={{ phases: [{ phase: "Intro", duration: "5m", goals: [] }] }}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    // Placeholder summarises phases but does not render add/edit affordances.
+    expect(screen.getByTestId("hf-jf-phases-onboardingFlowPhases")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("hf-jf-phases-add-onboardingFlowPhases"),
+    ).toBeNull();
+  });
+
+  it("renders empty state + Add phase button when provider is set", () => {
+    renderWithProvider({ phases: [] });
+    expect(screen.getByText(/No phases yet/)).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-jf-phases-add-onboardingFlowPhases"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders existing phases with name/duration/goals fields", () => {
+    renderWithProvider({
+      phases: [
+        { phase: "Intro", duration: "5 minutes", goals: ["Welcome", "Orient"] },
+        { phase: "Setup", duration: "2 minutes", goals: ["Configure"] },
+      ],
+    });
+    const nameInput = screen.getByTestId(
+      "hf-jf-phase-onboardingFlowPhases-0-name",
+    ) as HTMLInputElement;
+    expect(nameInput.value).toBe("Intro");
+    const goals = screen.getByTestId(
+      "hf-jf-phase-onboardingFlowPhases-0-goals",
+    ) as HTMLTextAreaElement;
+    expect(goals.value).toBe("Welcome\nOrient");
+  });
+
+  it("clicking Add phase appends and commits", async () => {
+    renderWithProvider({ phases: [] });
+    fireEvent.click(
+      screen.getByTestId("hf-jf-phases-add-onboardingFlowPhases"),
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.value.phases).toHaveLength(1);
+    expect(body.value.phases[0]).toMatchObject({
+      phase: "",
+      duration: "",
+      goals: [],
+    });
+  });
+
+  it("removing a phase commits the shorter list", async () => {
+    renderWithProvider({
+      phases: [
+        { phase: "A", duration: "1m", goals: [] },
+        { phase: "B", duration: "2m", goals: [] },
+      ],
+    });
+    fireEvent.click(
+      screen.getByTestId("hf-jf-phase-remove-onboardingFlowPhases-0"),
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.value.phases).toHaveLength(1);
+    expect(body.value.phases[0].phase).toBe("B");
+  });
+
+  it("preserves wrapper extras (successMetrics) and per-phase extras (content/surveySteps)", async () => {
+    renderWithProvider({
+      successMetrics: ["learner can describe goals"],
+      phases: [
+        {
+          phase: "Intro",
+          duration: "5m",
+          goals: [],
+          content: [{ mediaId: "vid-1" }],
+          surveySteps: [{ id: "s1", prompt: "ok?" }],
+        },
+      ],
+    });
+    fireEvent.click(
+      screen.getByTestId("hf-jf-phases-add-onboardingFlowPhases"),
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.value.successMetrics).toEqual(["learner can describe goals"]);
+    expect(body.value.phases[0].content).toEqual([{ mediaId: "vid-1" }]);
+    expect(body.value.phases[0].surveySteps).toEqual([{ id: "s1", prompt: "ok?" }]);
+  });
+
+  it("Move down swaps adjacent phases", async () => {
+    renderWithProvider({
+      phases: [
+        { phase: "A", duration: "1m", goals: [] },
+        { phase: "B", duration: "2m", goals: [] },
+      ],
+    });
+    fireEvent.click(
+      screen.getByTestId("hf-jf-phase-down-onboardingFlowPhases-0"),
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.value.phases.map((p: { phase: string }) => p.phase)).toEqual(["B", "A"]);
+  });
+});


### PR DESCRIPTION
## Summary

Followup #2b from the journey-tab closeout. Replaces the placeholder "Use ⋯ → Edit as JSON" shell in `JourneyPhases.tsx` with a typed-form editor for the wrapping `OnboardingFlowPhases` / `OffboardingConfig` shape.

Used by the 2 phases-control contracts:
- `onboardingFlowPhases` (G2 — `domain.onboardingFlowPhases`)
- `offboardingFlowPhases` (G6 — `sessionFlow.offboarding`)

## What the editor exposes

Per row (one row per phase):

| Field | Control | Behavior |
|---|---|---|
| Phase name | Text input | Auto-commit debounced |
| Duration | Text input (free-form, e.g. "5 minutes") | Auto-commit debounced |
| Goals | Textarea | Multi-line — one goal per line, parsed to `string[]` |

Row affordances: **add** / **remove** / **move up** / **move down** (mirrors `JourneyArrayEditor`). Structural changes commit immediately; text edits commit debounced (matches `JourneyText`).

## Two-level extras preservation

The `OnboardingPhase` type and the wrapping `OnboardingFlowPhases` / `OffboardingConfig` carry fields the editor doesn't expose:

| Layer | Extras preserved |
|---|---|
| Wrapper (OnboardingFlowPhases) | `successMetrics` |
| Wrapper (OffboardingConfig) | `triggerAfterCalls`, `bannerMessage` |
| Per phase (OnboardingPhase) | `content`, `surveySteps` |

Without these, opening the editor and adding/removing a phase would silently drop those fields. Captured at parse → merged back on serialise at both layers.

## One subtle fix worth flagging

Structural changes (add / remove / move) use a direct \`saveDraft(next)\` call rather than \`f.commit()\` because \`useCascadeEditField.commit()\` reads \`draftRef.current\` synchronously — and \`setDraftValue(next)\` doesn't flush React state until the next render, so \`commit()\` would see the stale pre-add draft and short-circuit on "no change".

\`JourneyArrayEditor\` has the same pattern. Documenting it inline to save the next author the lookup.

## Falls back to placeholder

When no \`JourneySettingMutatorProvider\` is mounted (legacy callers, Preview tab read-only window), the editor renders a read-only placeholder that summarises phases readably ("3 phases: Intro → Setup → Wrap-up") instead of dumping JSON.

## Verified by

- **7 new vitests** at \`tests/components/journey-controls/JourneyPhases.test.tsx\`:
  1. Placeholder when no provider
  2. Empty state + Add phase button when provider is set
  3. Renders existing phases with name/duration/goals fields
  4. Clicking Add phase appends and commits
  5. Removing a phase commits the shorter list
  6. Wrapper extras + per-phase extras preserved across saves
  7. Move down swaps adjacent phases
- **Full journey-controls suite** still passes (35/35).
- **TypeScript:** 0 new tsc errors introduced. Verified by diffing pre/post tsc output.
- **ESLint clean** on \`JourneyPhases.tsx\`.

## Out of scope (future work)

- **Content / surveySteps editing:** the editor preserves them but doesn't expose them. Add when product wants per-phase content / survey editing in the journey-setting Inspector. Today they're authored in the legacy lens.
- **Drag-reorder:** up/down arrows match the existing JourneyArrayEditor pattern. Drag-and-drop would require a hf-* dnd primitive — out of scope.

## Pre-push escape hatch

Pushed with \`HF_SKIP_PREPUSH=1\` for the same reason as #1813 / #1814 / #1817 / #1818 / #1820: \`.ratchet.json\` baseline drift from main. Queued in PR8 (#7).

## Test plan

- [x] 7 new vitests pass
- [x] Full journey-controls suite (35/35) still passes
- [x] No new tsc errors introduced
- [x] ESLint clean
- [ ] Manual: open \`/x/courses/<id>?tab=journey\` → click \"Onboarding phases\" or \"Offboarding phases\" → verify the editor renders, edits, and saves (hf-dev after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)