### PR TITLE
feat(voice): #1742 — sayMessage primitive + cue-scheduler (Theme 2a)

### DIFF
--- a/apps/admin/lib/voice/cue-scheduler.ts
+++ b/apps/admin/lib/voice/cue-scheduler.ts
@@ -1,0 +1,297 @@
+/**
+ * Cue scheduler — restart-safe orchestrator for `VoiceProvider.sayMessage()`
+ * (#1742).
+ *
+ * Responsibilities:
+ *
+ *   1. **`scheduleCue`** — persist a `CueScheduleEntry` row pinned to an
+ *      `externalCallId` + `scheduledFor` timestamp. Callable from anywhere
+ *      (e.g. Theme 2b's session-start path registers Part 2 cues from
+ *      `moduleScheduledCues`).
+ *   2. **`cancelCuesForCall`** — mark every pending cue for an
+ *      `externalCallId` as cancelled. Called at end-of-call.
+ *   3. **`drainDueCues`** — pull every row where `scheduledFor <= NOW()`,
+ *      `status === "pending"`, dispatch each via the matching adapter's
+ *      `sayMessage()`, stamp `firedAt` + `status`. Designed to be called
+ *      from a short-interval tick loop (production runner) OR directly
+ *      from tests.
+ *
+ * Restart safety: rows live in the DB, not in memory. A server restart
+ * between `scheduleCue` and `scheduledFor` does not lose the cue — the
+ * tick loop picks it up on resume.
+ *
+ * Tick interval: production runner ticks at 100ms (configurable). Combined
+ * with the VAPI control-URL POST latency (~50–150ms), this gives a ±200ms
+ * p99 budget. See ADR.
+ *
+ * Capability-flag gate: providers that declare
+ * `getCapabilities().supportsProactiveSpeech === false` (e.g. Retell
+ * pre-LLM-WSS-handler) skip with `status: "skipped"` and emit
+ * `voice.cue_scheduler.skipped_no_capability` AppLog instead of failing.
+ *
+ * See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+ */
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { log } from "@/lib/logger";
+import { getVoiceProvider } from "./provider-factory";
+import type { SayMessageOptions } from "./types";
+
+const CUE_STATUS = {
+  pending: "pending",
+  fired: "fired",
+  failed: "failed",
+  cancelled: "cancelled",
+  skipped: "skipped",
+} as const;
+
+export type CueStatus = (typeof CUE_STATUS)[keyof typeof CUE_STATUS];
+
+export interface ScheduleCueArgs {
+  externalCallId: string;
+  callId?: string | null;
+  scheduledFor: Date;
+  content: string;
+  noInterruption?: boolean;
+  queueOnly?: boolean;
+  traceId?: string;
+}
+
+export interface ScheduledCue {
+  id: string;
+  externalCallId: string;
+  callId: string | null;
+  scheduledFor: Date;
+  content: string;
+  status: CueStatus;
+}
+
+/**
+ * Persist a new cue. Returns the created row's id so callers can hold it
+ * for individual cancellation.
+ */
+export async function scheduleCue(args: ScheduleCueArgs): Promise<ScheduledCue> {
+  if (!args.externalCallId) {
+    throw new Error("scheduleCue: externalCallId is required");
+  }
+  if (!args.content || typeof args.content !== "string") {
+    throw new Error("scheduleCue: content must be a non-empty string");
+  }
+  const row = await prisma.cueScheduleEntry.create({
+    data: {
+      externalCallId: args.externalCallId,
+      callId: args.callId ?? null,
+      scheduledFor: args.scheduledFor,
+      content: args.content,
+      options: serialiseOptions(args) as Prisma.InputJsonValue,
+      status: CUE_STATUS.pending,
+      traceId: args.traceId ?? null,
+    },
+    select: {
+      id: true,
+      externalCallId: true,
+      callId: true,
+      scheduledFor: true,
+      content: true,
+      status: true,
+    },
+  });
+  log("system", "voice.cue_scheduler.registered", {
+    externalCallId: args.externalCallId,
+    cueId: row.id,
+    scheduledFor: args.scheduledFor.toISOString(),
+    traceId: args.traceId,
+  });
+  return { ...row, status: row.status as CueStatus };
+}
+
+/**
+ * Mark every pending cue for a call as cancelled. Idempotent: cues
+ * already in a terminal state are left alone.
+ */
+export async function cancelCuesForCall(externalCallId: string): Promise<number> {
+  const result = await prisma.cueScheduleEntry.updateMany({
+    where: { externalCallId, status: CUE_STATUS.pending },
+    data: { status: CUE_STATUS.cancelled, cancelledAt: new Date() },
+  });
+  if (result.count > 0) {
+    log("system", "voice.cue_scheduler.cancelled", {
+      externalCallId,
+      count: result.count,
+    });
+  }
+  return result.count;
+}
+
+export interface DrainDueCuesOptions {
+  /** Provider slug → instance lookup. Defaults to the production factory;
+   *  tests inject a deterministic stub. */
+  getProvider?: (slug: string) => Promise<{
+    slug: string;
+    getCapabilities: () => { supportsProactiveSpeech: boolean };
+    sayMessage?: (
+      externalCallId: string,
+      options: SayMessageOptions,
+    ) => Promise<{ status: "spoken" | "queued" | "skipped" | "failed" }>;
+  } | null>;
+  /** Override "now" for tests. Defaults to `new Date()`. */
+  now?: () => Date;
+  /** Per-tick batch cap — prevents one tick from dispatching thousands of
+   *  cues in pathological cases. Default 32. */
+  batchLimit?: number;
+  /**
+   * For multi-provider routing: rows store `externalCallId` but not the
+   * provider slug. Resolve it from `Call.source` via the local DB. The
+   * caller can override (tests) to bypass the DB.
+   */
+  resolveSlug?: (externalCallId: string) => Promise<string | null>;
+}
+
+interface DrainResult {
+  fired: number;
+  failed: number;
+  skipped: number;
+}
+
+/**
+ * Drain every pending cue whose `scheduledFor` is in the past. Returns
+ * a count breakdown by terminal status.
+ */
+export async function drainDueCues(
+  options: DrainDueCuesOptions = {},
+): Promise<DrainResult> {
+  const now = (options.now ?? (() => new Date()))();
+  const batchLimit = options.batchLimit ?? 32;
+  const getProvider = options.getProvider ?? defaultGetProvider;
+  const resolveSlug = options.resolveSlug ?? defaultResolveSlug;
+
+  const dueRows = await prisma.cueScheduleEntry.findMany({
+    where: { status: CUE_STATUS.pending, scheduledFor: { lte: now } },
+    orderBy: { scheduledFor: "asc" },
+    take: batchLimit,
+  });
+
+  let fired = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const row of dueRows) {
+    const slug = await resolveSlug(row.externalCallId);
+    if (!slug) {
+      await markCueTerminal(row.id, CUE_STATUS.skipped, "no_call_row");
+      skipped += 1;
+      continue;
+    }
+
+    const provider = await getProvider(slug);
+    if (!provider) {
+      await markCueTerminal(row.id, CUE_STATUS.skipped, "no_provider");
+      skipped += 1;
+      continue;
+    }
+
+    const caps = provider.getCapabilities();
+    if (!caps.supportsProactiveSpeech || !provider.sayMessage) {
+      log("system", "voice.cue_scheduler.skipped_no_capability", {
+        externalCallId: row.externalCallId,
+        cueId: row.id,
+        slug,
+      });
+      await markCueTerminal(row.id, CUE_STATUS.skipped, "no_capability");
+      skipped += 1;
+      continue;
+    }
+
+    const opts = deserialiseOptions(row.options, row.content, row.traceId);
+    const result = await provider.sayMessage(row.externalCallId, opts);
+
+    if (result.status === "spoken" || result.status === "queued") {
+      const lagMs = now.getTime() - row.scheduledFor.getTime();
+      if (lagMs > 500) {
+        log("system", "voice.cue_scheduler.late", {
+          externalCallId: row.externalCallId,
+          cueId: row.id,
+          lagMs,
+        });
+      }
+      log("system", "voice.cue_scheduler.fired", {
+        externalCallId: row.externalCallId,
+        cueId: row.id,
+        slug,
+        outcome: result.status,
+      });
+      await markCueTerminal(row.id, CUE_STATUS.fired, result.status);
+      fired += 1;
+    } else if (result.status === "skipped") {
+      await markCueTerminal(row.id, CUE_STATUS.skipped, "provider_skipped");
+      skipped += 1;
+    } else {
+      await markCueTerminal(row.id, CUE_STATUS.failed, "provider_failed");
+      failed += 1;
+    }
+  }
+
+  return { fired, failed, skipped };
+}
+
+async function markCueTerminal(
+  id: string,
+  status: CueStatus,
+  reason: string,
+): Promise<void> {
+  const now = new Date();
+  await prisma.cueScheduleEntry.update({
+    where: { id },
+    data: {
+      status,
+      firedAt: status === CUE_STATUS.fired ? now : undefined,
+      cancelledAt: status === CUE_STATUS.cancelled ? now : undefined,
+    },
+  });
+  if (status !== CUE_STATUS.fired) {
+    log("system", `voice.cue_scheduler.${status}`, {
+      cueId: id,
+      reason,
+    });
+  }
+}
+
+async function defaultResolveSlug(externalCallId: string): Promise<string | null> {
+  const row = await prisma.call.findFirst({
+    where: { externalId: externalCallId },
+    select: { source: true },
+  });
+  return row?.source ?? null;
+}
+
+async function defaultGetProvider(slug: string) {
+  try {
+    const provider = await getVoiceProvider(slug);
+    return provider;
+  } catch {
+    return null;
+  }
+}
+
+function serialiseOptions(args: ScheduleCueArgs): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (args.noInterruption !== undefined) out.noInterruption = args.noInterruption;
+  if (args.queueOnly !== undefined) out.queueOnly = args.queueOnly;
+  if (args.traceId !== undefined) out.traceId = args.traceId;
+  return out;
+}
+
+function deserialiseOptions(
+  options: unknown,
+  content: string,
+  traceId: string | null,
+): SayMessageOptions {
+  const raw = (options ?? {}) as Record<string, unknown>;
+  return {
+    content,
+    noInterruption: typeof raw.noInterruption === "boolean" ? raw.noInterruption : undefined,
+    queueOnly: typeof raw.queueOnly === "boolean" ? raw.queueOnly : undefined,
+    traceId: traceId ?? undefined,
+  };
+}

--- a/apps/admin/lib/voice/providers/retell/index.ts
+++ b/apps/admin/lib/voice/providers/retell/index.ts
@@ -249,6 +249,14 @@ export class RetellProvider implements VoiceProvider {
       hasKnowledgeCallback: false,
       toolCallsOverWebSocket: true,
       supportsRequestEndCall: true,
+      // #1742 — Retell's proactive-speech path is the LLM-WSS
+      // `agent_interrupt` frame, which requires an HF-side WSS handler
+      // queue. That handler is out of scope for the #1742 primitive;
+      // until the LLM-WSS-side enqueue lands, the cue scheduler treats
+      // Retell calls as no-capability and emits
+      // `voice.cue_scheduler.skipped_no_capability` instead of attempting
+      // a dispatch.
+      supportsProactiveSpeech: false,
       // #1337 — Retell runs its agent loop in their cloud (custom-LLM
       // mode still delegates to a Retell-managed orchestrator via WSS),
       // so it's "vendor-cloud" — same dispatch class as VAPI.

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -31,12 +31,15 @@ import type {
   ParsedTranscriptUpdate,
   ProviderAssistantConfig,
   ProviderConfigSchema,
+  SayMessageOptions,
+  SayMessageResult,
   VoiceCatalogEntry,
   VoiceProvider,
   VoiceProviderCapabilities,
 } from "../../types";
 import { verifyVapiRequest } from "./auth";
 import { log } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
 
 /**
  * Valid `assistant.backgroundSound` values accepted by the VAPI API.
@@ -211,6 +214,14 @@ export class VapiProvider implements VoiceProvider {
       ...(typeof ctx.customLlmSecret === "string" && ctx.customLlmSecret.length > 0
         ? { serverUrlSecret: ctx.customLlmSecret }
         : {}),
+      // #1742 — Enable VAPI's live-call control surface. With this flag,
+      // the Call response carries `monitor.controlUrl` — a per-call HTTP
+      // endpoint that accepts `{type:"say"|"add-message",…}` POST bodies.
+      // `sayMessage()` reads the URL via `extractControlUrl()` and POSTs
+      // to it. Without this flag the URL is omitted from the Call object
+      // and `sayMessage` returns `{status:"skipped"}` at run time.
+      // See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+      monitorPlan: { controlEnabled: true, listenEnabled: false },
     };
 
     if (ctx.firstLine) {
@@ -673,6 +684,10 @@ export class VapiProvider implements VoiceProvider {
       hasKnowledgeCallback: true,
       toolCallsOverWebSocket: false,
       supportsRequestEndCall: true,
+      // #1742 — VAPI accepts server-initiated speech via per-call
+      // `monitor.controlUrl` HTTP POST. URL is captured at call-start
+      // via `monitorPlan.controlEnabled = true` in buildAssistantConfig.
+      supportsProactiveSpeech: true,
       // #1337 — VAPI runs the agent loop in their cloud and calls back over
       // HTTP for tools / knowledge / end-of-call. LiveKit/Pipecat-style
       // providers would declare "self-hosted-agent" here.
@@ -915,6 +930,123 @@ export class VapiProvider implements VoiceProvider {
       );
     }
   }
+
+  /**
+   * #1742 — inject a synthesised utterance into the live VAPI call.
+   *
+   * Reads the per-call controlUrl from `Call.voiceProviderRaw.monitor.controlUrl`
+   * (stamped at outbound-dial / call-start time when
+   * `monitorPlan.controlEnabled = true` — see `buildAssistantConfig`).
+   * POSTs `{type: "say"|"add-message", …}` to it.
+   *
+   * Idempotent on the wire: VAPI returns 200 on a fresh say, and silently
+   * accepts duplicates. We swallow transport errors and emit
+   * `voice.vapi.say_message_failed` to AppLog.
+   *
+   * See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+   */
+  async sayMessage(
+    externalCallId: string,
+    options: SayMessageOptions,
+  ): Promise<SayMessageResult> {
+    const controlUrl = await this.resolveControlUrl(externalCallId);
+    if (!controlUrl) {
+      log("system", "voice.vapi.say_message_skipped_no_control_url", {
+        level: "warn",
+        externalCallId,
+        traceId: options.traceId,
+      });
+      return { status: "skipped" };
+    }
+
+    const body = options.queueOnly
+      ? {
+          type: "add-message",
+          message: { role: "assistant", content: options.content },
+          triggerResponseEnabled: false,
+        }
+      : {
+          type: "say",
+          content: options.content,
+          endCallAfterSpoken: false,
+        };
+
+    try {
+      const res = await fetch(controlUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        log("system", "voice.vapi.say_message_failed", {
+          level: "warn",
+          externalCallId,
+          httpStatus: res.status,
+          traceId: options.traceId,
+        });
+        return { status: "failed" };
+      }
+      return { status: options.queueOnly ? "queued" : "spoken" };
+    } catch (err) {
+      log("system", "voice.vapi.say_message_failed", {
+        level: "warn",
+        externalCallId,
+        error: err instanceof Error ? err.message : String(err),
+        traceId: options.traceId,
+      });
+      return { status: "failed" };
+    }
+  }
+
+  /**
+   * Resolve the per-call controlUrl from `Call.voiceProviderRaw`. Pre-#1742
+   * VAPI calls have no monitor.controlUrl stamped — those paths short-
+   * circuit `sayMessage` with `{status: "skipped"}`. New calls created with
+   * `monitorPlan.controlEnabled = true` (from `buildAssistantConfig` above)
+   * carry `monitor.controlUrl` on the call response, which the outbound-
+   * dial route stamps onto `Call.voiceProviderRaw.monitor.controlUrl` at
+   * call-start (or `extractControlUrl()` stamps it from a webhook arrival).
+   */
+  private async resolveControlUrl(externalCallId: string): Promise<string | null> {
+    if (!externalCallId) return null;
+    const row = await prisma.call.findFirst({
+      where: { externalId: externalCallId, source: this.slug },
+      select: { voiceProviderRaw: true },
+    });
+    return extractControlUrl(row?.voiceProviderRaw ?? null);
+  }
+}
+
+/**
+ * #1742 — Read `monitor.controlUrl` from a VAPI call payload.
+ *
+ * VAPI nests the URL under either:
+ *   - the top-level Call response object (from `POST /call`), OR
+ *   - `message.call.monitor.controlUrl` (webhook payloads).
+ *
+ * Returns null when the URL is absent — typically because the call was
+ * created before `monitorPlan.controlEnabled = true` was wired, or VAPI
+ * suppressed the URL for a sandbox/staging assistant.
+ */
+export function extractControlUrl(raw: unknown): string | null {
+  if (!raw || typeof raw !== "object") return null;
+  const candidates: Array<Record<string, unknown> | null> = [];
+  const root = raw as Record<string, unknown>;
+  candidates.push(root);
+  candidates.push(root.message as Record<string, unknown> | null);
+  candidates.push(root.call as Record<string, unknown> | null);
+  const message = root.message as Record<string, unknown> | undefined;
+  candidates.push((message?.call ?? null) as Record<string, unknown> | null);
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const monitor = candidate.monitor as Record<string, unknown> | undefined;
+    const controlUrl = monitor?.controlUrl;
+    if (typeof controlUrl === "string" && controlUrl.length > 0) {
+      return controlUrl;
+    }
+  }
+  return null;
 }
 
 /**

--- a/apps/admin/lib/voice/types.ts
+++ b/apps/admin/lib/voice/types.ts
@@ -332,6 +332,36 @@ export interface VoiceCatalogEntry {
  * webhook URLs that apply and the telemetry layer apply only the
  * controls the provider supports.
  */
+/**
+ * #1742 — Inputs to `VoiceProvider.sayMessage()`.
+ * See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+ */
+export interface SayMessageOptions {
+  /** Free-text utterance to speak. */
+  content: string;
+  /**
+   * Suppress learner barge-in for the duration of this utterance.
+   * Retell honours this natively (`no_interruption_allowed: true`).
+   * VAPI does not have a flag — the adapter ignores the option.
+   */
+  noInterruption?: boolean;
+  /**
+   * When true, the message lands in conversation history but is NOT
+   * spoken immediately — useful for tutor notes the LLM should be
+   * aware of on its NEXT turn. Maps to VAPI's `add-message` control;
+   * Retell does not support a queue-only variant, so a Retell adapter
+   * that receives `queueOnly: true` returns `{status: "skipped"}`.
+   */
+  queueOnly?: boolean;
+  /** Caller-supplied correlation id for tracing. Echoed into AppLog. */
+  traceId?: string;
+}
+
+/** #1742 — Result of `VoiceProvider.sayMessage()`. Never thrown. */
+export interface SayMessageResult {
+  status: "spoken" | "queued" | "skipped" | "failed";
+}
+
 export interface VoiceProviderCapabilities {
   /** "single" = one end-of-call webhook (VAPI). "split" = two webhooks
    *  merged by externalCallId (Retell: call_ended + call_analyzed). */
@@ -349,6 +379,16 @@ export interface VoiceProviderCapabilities {
    *  prevention). When false, the cost-cap watcher in #1080 logs but
    *  cannot terminate the call. */
   supportsRequestEndCall: boolean;
+  /**
+   * #1742 — Provider accepts server-initiated speech injection during
+   * a live call (VAPI controlUrl POST, Retell `agent_interrupt` frame).
+   * When false, `lib/voice/cue-scheduler.ts` skips the cue and emits
+   * `voice.cue_scheduler.skipped_no_capability` for telemetry instead
+   * of failing the schedule.
+   *
+   * See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+   */
+  supportsProactiveSpeech: boolean;
   /** Orchestration shape (#1337). "vendor-cloud" = provider runs the
    *  agent loop in their own cloud and calls back over HTTP/WSS (VAPI,
    *  Retell). "self-hosted-agent" = the agent loop runs INSIDE HF's
@@ -442,6 +482,26 @@ export interface VoiceProvider {
    * call. Implementation should be idempotent for already-ended calls.
    */
   requestEndCall?(externalCallId: string): Promise<void>;
+
+  /**
+   * #1742 — Inject a synthesised utterance into the live call.
+   *
+   * Optional — providers that can't push speech declare
+   * `supportsProactiveSpeech: false` in capabilities and the cue
+   * scheduler short-circuits before reaching this method.
+   *
+   * MUST be idempotent for a given (externalCallId, traceId) pair —
+   * the scheduler may retry on transient transport errors. MUST NOT
+   * throw — returns `{status: "failed"}` and emits an AppLog subject
+   * (`voice.<slug>.say_message_failed`).
+   *
+   * See docs/decisions/2026-06-16-voice-say-message-primitive.md
+   * for transport-level details (VAPI controlUrl, Retell agent_interrupt).
+   */
+  sayMessage?(
+    externalCallId: string,
+    options: SayMessageOptions,
+  ): Promise<SayMessageResult>;
 
   /**
    * Parse the provider's per-turn knowledge-base callback into a

--- a/apps/admin/prisma/migrations/20260616190000_1742_cue_schedule_entry/migration.sql
+++ b/apps/admin/prisma/migrations/20260616190000_1742_cue_schedule_entry/migration.sql
@@ -1,0 +1,38 @@
+-- #1742 — CueScheduleEntry: restart-safe cue scheduling for
+-- `VoiceProvider.sayMessage()`.
+--
+-- The `lib/voice/cue-scheduler.ts` drain loop scans this table on a
+-- short interval and dispatches due rows. DB-backed (not in-memory)
+-- so cues scheduled before a server restart survive the restart.
+--
+-- See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+
+CREATE TABLE IF NOT EXISTS "CueScheduleEntry" (
+  "id"             TEXT NOT NULL,
+  "externalCallId" TEXT NOT NULL,
+  "callId"         TEXT,
+  "scheduledFor"   TIMESTAMP(3) NOT NULL,
+  "content"        TEXT NOT NULL,
+  "options"        JSONB,
+  "firedAt"        TIMESTAMP(3),
+  "cancelledAt"    TIMESTAMP(3),
+  "status"         TEXT NOT NULL DEFAULT 'pending',
+  "traceId"        TEXT,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "CueScheduleEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- Cancel-on-call-delete is SetNull (mirrors Prisma `onDelete: SetNull`).
+ALTER TABLE "CueScheduleEntry"
+  ADD CONSTRAINT "CueScheduleEntry_callId_fkey"
+  FOREIGN KEY ("callId") REFERENCES "Call"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Hot lookups: scheduler tick + per-call cancellation.
+CREATE INDEX IF NOT EXISTS "CueScheduleEntry_externalCallId_status_idx"
+  ON "CueScheduleEntry"("externalCallId", "status");
+CREATE INDEX IF NOT EXISTS "CueScheduleEntry_scheduledFor_status_idx"
+  ON "CueScheduleEntry"("scheduledFor", "status");
+CREATE INDEX IF NOT EXISTS "CueScheduleEntry_callId_idx"
+  ON "CueScheduleEntry"("callId");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -1062,6 +1062,39 @@ model CallerSequenceCounter {
   @@id([callerId, kind])
 }
 
+// #1742 — Cue scheduling for `VoiceProvider.sayMessage()`. The
+// `lib/voice/cue-scheduler.ts` drain loop reads rows where
+// `scheduledFor <= NOW() AND firedAt IS NULL AND cancelledAt IS NULL`,
+// dispatches each via the provider adapter, and stamps `firedAt`. Cues
+// scheduled before a server restart survive the restart because the
+// drain loop scans on resume.
+//
+// `externalCallId` is the provider's external call id (matches
+// `Call.externalId`). `callId` is the optional HF Call.id link kept for
+// admin browse. `options` carries the rest of `SayMessageOptions`
+// (`noInterruption`, `queueOnly`, `traceId`). `status` enum: "pending"
+// | "fired" | "failed" | "cancelled" | "skipped".
+//
+// See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+model CueScheduleEntry {
+  id             String   @id @default(uuid())
+  externalCallId String
+  callId         String?
+  call           Call?    @relation("CueScheduleEntries", fields: [callId], references: [id], onDelete: SetNull)
+  scheduledFor   DateTime
+  content        String   @db.Text
+  options        Json?
+  firedAt        DateTime?
+  cancelledAt    DateTime?
+  status         String   @default("pending")
+  traceId        String?
+  createdAt      DateTime @default(now())
+
+  @@index([externalCallId, status])
+  @@index([scheduledFor, status])
+  @@index([callId])
+}
+
 // Required by NextAuth EmailProvider (magic link) AND by OAuth providers
 // that issue email verification. Adding this finally makes the magic-link
 // flow shipped in #1172 actually work end-to-end. identifier = email,
@@ -1826,6 +1859,9 @@ model Call {
   // Assessment scoring doesn't pollute the learner's long-term mastery state
   // (#1081 Slice 1, AC11/AC12).
   scratchMastery Json?
+
+  // #1742 — Reverse relation for cue-scheduler entries.
+  cueScheduleEntries CueScheduleEntry[] @relation("CueScheduleEntries")
 
   @@index([source])
   @@index([externalId])

--- a/apps/admin/tests/lib/voice/cue-scheduler.test.ts
+++ b/apps/admin/tests/lib/voice/cue-scheduler.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for lib/voice/cue-scheduler.ts (#1742 Theme 2a).
+ *
+ * Pinned acceptance:
+ *   1. `scheduleCue` rejects empty externalCallId / empty content
+ *   2. `scheduleCue` creates a pending row with the supplied scheduledFor
+ *   3. `cancelCuesForCall` flips every pending row for the call to cancelled
+ *   4. `drainDueCues` ignores future cues (scheduledFor > now)
+ *   5. `drainDueCues` fires due cues via the resolved provider's sayMessage,
+ *      stamps `firedAt`, status="fired"
+ *   6. Capability-flag-off provider → status="skipped" + no fetch call
+ *   7. Provider returns `{status:"failed"}` → row stamped status="failed"
+ *   8. Cue with no resolvable Call.source → status="skipped" + provider not
+ *      consulted
+ *   9. Batch limit honoured — drain returns at most `batchLimit` per call
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    cueScheduleEntry: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    call: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/logger", () => ({ log: vi.fn() }));
+vi.mock("@/lib/voice/provider-factory", () => ({
+  getVoiceProvider: vi.fn(),
+}));
+
+import {
+  scheduleCue,
+  cancelCuesForCall,
+  drainDueCues,
+} from "@/lib/voice/cue-scheduler";
+
+const NOW = new Date("2026-06-16T12:00:00Z");
+
+function makeProvider({
+  supports,
+  sayResult,
+}: {
+  supports: boolean;
+  sayResult?: { status: "spoken" | "queued" | "skipped" | "failed" };
+}) {
+  return {
+    slug: "vapi",
+    getCapabilities: () => ({ supportsProactiveSpeech: supports }),
+    sayMessage: sayResult
+      ? vi.fn(async () => sayResult)
+      : undefined,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.cueScheduleEntry.create.mockReset();
+  mockPrisma.cueScheduleEntry.findMany.mockReset();
+  mockPrisma.cueScheduleEntry.update.mockReset();
+  mockPrisma.cueScheduleEntry.updateMany.mockReset();
+  mockPrisma.call.findFirst.mockReset();
+});
+
+describe("scheduleCue", () => {
+  it("throws on empty externalCallId", async () => {
+    await expect(
+      scheduleCue({
+        externalCallId: "",
+        scheduledFor: NOW,
+        content: "hi",
+      }),
+    ).rejects.toThrow(/externalCallId/);
+  });
+
+  it("throws on empty content", async () => {
+    await expect(
+      scheduleCue({
+        externalCallId: "ext-1",
+        scheduledFor: NOW,
+        content: "",
+      }),
+    ).rejects.toThrow(/content/);
+  });
+
+  it("persists with status='pending' and serialised options", async () => {
+    mockPrisma.cueScheduleEntry.create.mockResolvedValue({
+      id: "cue-1",
+      externalCallId: "ext-1",
+      callId: null,
+      scheduledFor: NOW,
+      content: "fifteen seconds left",
+      status: "pending",
+    });
+    await scheduleCue({
+      externalCallId: "ext-1",
+      scheduledFor: NOW,
+      content: "fifteen seconds left",
+      noInterruption: true,
+      traceId: "tr-1",
+    });
+    const args = mockPrisma.cueScheduleEntry.create.mock.calls[0][0] as {
+      data: { status: string; options: { noInterruption: boolean; traceId: string } };
+    };
+    expect(args.data.status).toBe("pending");
+    expect(args.data.options).toEqual({ noInterruption: true, traceId: "tr-1" });
+  });
+});
+
+describe("cancelCuesForCall", () => {
+  it("flips pending rows to cancelled and returns the count", async () => {
+    mockPrisma.cueScheduleEntry.updateMany.mockResolvedValue({ count: 3 });
+    const n = await cancelCuesForCall("ext-1");
+    expect(n).toBe(3);
+    const args = mockPrisma.cueScheduleEntry.updateMany.mock.calls[0][0] as {
+      where: { externalCallId: string; status: string };
+      data: { status: string };
+    };
+    expect(args.where).toEqual({ externalCallId: "ext-1", status: "pending" });
+    expect(args.data.status).toBe("cancelled");
+  });
+
+  it("returns 0 (idempotent) when no pending cues match", async () => {
+    mockPrisma.cueScheduleEntry.updateMany.mockResolvedValue({ count: 0 });
+    expect(await cancelCuesForCall("ext-unknown")).toBe(0);
+  });
+});
+
+describe("drainDueCues", () => {
+  it("ignores future cues by passing scheduledFor: { lte: now }", async () => {
+    mockPrisma.cueScheduleEntry.findMany.mockResolvedValue([]);
+    await drainDueCues({ now: () => NOW });
+    const args = mockPrisma.cueScheduleEntry.findMany.mock.calls[0][0] as {
+      where: { scheduledFor: { lte: Date } };
+    };
+    expect(args.where.scheduledFor.lte).toEqual(NOW);
+  });
+
+  it("fires a due cue via provider.sayMessage and stamps status='fired'", async () => {
+    mockPrisma.cueScheduleEntry.findMany.mockResolvedValue([
+      {
+        id: "cue-1",
+        externalCallId: "ext-1",
+        content: "fifteen seconds left",
+        scheduledFor: new Date(NOW.getTime() - 1000),
+        options: { noInterruption: true },
+        traceId: "tr-1",
+      },
+    ]);
+    const provider = makeProvider({
+      supports: true,
+      sayResult: { status: "spoken" },
+    });
+    mockPrisma.cueScheduleEntry.update.mockResolvedValue({});
+
+    const result = await drainDueCues({
+      now: () => NOW,
+      getProvider: async () => provider,
+      resolveSlug: async () => "vapi",
+    });
+
+    expect(result.fired).toBe(1);
+    expect(provider.sayMessage).toHaveBeenCalledWith("ext-1", {
+      content: "fifteen seconds left",
+      noInterruption: true,
+      queueOnly: undefined,
+      traceId: "tr-1",
+    });
+    const updateArgs = mockPrisma.cueScheduleEntry.update.mock.calls[0][0] as {
+      where: { id: string };
+      data: { status: string; firedAt: Date };
+    };
+    expect(updateArgs.where).toEqual({ id: "cue-1" });
+    expect(updateArgs.data.status).toBe("fired");
+    expect(updateArgs.data.firedAt).toBeInstanceOf(Date);
+  });
+
+  it("skips when provider declares supportsProactiveSpeech: false", async () => {
+    mockPrisma.cueScheduleEntry.findMany.mockResolvedValue([
+      {
+        id: "cue-1",
+        externalCallId: "ext-1",
+        content: "hi",
+        scheduledFor: new Date(NOW.getTime() - 1000),
+        options: {},
+        traceId: null,
+      },
+    ]);
+    const provider = makeProvider({
+      supports: false,
+      sayResult: { status: "spoken" }, // would fire if asked, but capability gate stops it
+    });
+    mockPrisma.cueScheduleEntry.update.mockResolvedValue({});
+
+    const result = await drainDueCues({
+      now: () => NOW,
+      getProvider: async () => provider,
+      resolveSlug: async () => "retell",
+    });
+
+    expect(result.skipped).toBe(1);
+    expect(result.fired).toBe(0);
+    expect(provider.sayMessage).not.toHaveBeenCalled();
+    expect(mockPrisma.cueScheduleEntry.update).toHaveBeenCalled();
+  });
+
+  it("stamps status='failed' when provider returns {status:'failed'}", async () => {
+    mockPrisma.cueScheduleEntry.findMany.mockResolvedValue([
+      {
+        id: "cue-1",
+        externalCallId: "ext-1",
+        content: "hi",
+        scheduledFor: new Date(NOW.getTime() - 1000),
+        options: {},
+        traceId: null,
+      },
+    ]);
+    const provider = makeProvider({
+      supports: true,
+      sayResult: { status: "failed" },
+    });
+    mockPrisma.cueScheduleEntry.update.mockResolvedValue({});
+
+    const result = await drainDueCues({
+      now: () => NOW,
+      getProvider: async () => provider,
+      resolveSlug: async () => "vapi",
+    });
+
+    expect(result.failed).toBe(1);
+    const updateArgs = mockPrisma.cueScheduleEntry.update.mock.calls[0][0] as {
+      data: { status: string };
+    };
+    expect(updateArgs.data.status).toBe("failed");
+  });
+
+  it("skips cue when externalCallId can't be resolved to a Call.source", async () => {
+    mockPrisma.cueScheduleEntry.findMany.mockResolvedValue([
+      {
+        id: "cue-1",
+        externalCallId: "ext-orphan",
+        content: "hi",
+        scheduledFor: new Date(NOW.getTime() - 1000),
+        options: {},
+        traceId: null,
+      },
+    ]);
+    mockPrisma.cueScheduleEntry.update.mockResolvedValue({});
+    const getProvider = vi.fn();
+
+    const result = await drainDueCues({
+      now: () => NOW,
+      getProvider,
+      resolveSlug: async () => null,
+    });
+
+    expect(result.skipped).toBe(1);
+    expect(getProvider).not.toHaveBeenCalled();
+  });
+
+  it("honours batchLimit (passed via Prisma findMany.take)", async () => {
+    mockPrisma.cueScheduleEntry.findMany.mockResolvedValue([]);
+    await drainDueCues({ now: () => NOW, batchLimit: 8 });
+    const args = mockPrisma.cueScheduleEntry.findMany.mock.calls[0][0] as { take: number };
+    expect(args.take).toBe(8);
+  });
+});

--- a/apps/admin/tests/lib/voice/vapi-say-message.test.ts
+++ b/apps/admin/tests/lib/voice/vapi-say-message.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for VAPI adapter sayMessage (#1742 Theme 2a).
+ *
+ * Pinned acceptance:
+ *   1. `extractControlUrl` pulls `monitor.controlUrl` from VAPI's nested
+ *      payload shapes (top-level, message-nested, message.call-nested)
+ *   2. `sayMessage` returns `{status:"skipped"}` when no controlUrl on
+ *      Call.voiceProviderRaw (call created before #1742)
+ *   3. `sayMessage` POSTs `{type:"say", content, endCallAfterSpoken:false}`
+ *      to the controlUrl when `queueOnly: false`
+ *   4. `sayMessage` POSTs `{type:"add-message", message:{role,content},
+ *      triggerResponseEnabled:false}` when `queueOnly: true`
+ *   5. Returns `{status:"failed"}` on non-2xx response — no throw
+ *   6. Returns `{status:"failed"}` on network error — no throw
+ *   7. `buildAssistantConfig` adds `monitorPlan.controlEnabled = true` so
+ *      VAPI returns the controlUrl on the call response
+ *   8. Capability flag `supportsProactiveSpeech: true` is declared
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    call: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/logger", () => ({ log: vi.fn() }));
+
+import { VapiProvider, extractControlUrl } from "@/lib/voice/providers/vapi";
+
+const CONTROL_URL = "https://vapi.daily.co/control/abc";
+
+const buildCtx = (overrides: Partial<Record<string, unknown>> = {}) =>
+  ({
+    voicePrompt: "Be helpful.",
+    serverUrlBase: "https://hf-dev.example/api/voice/vapi",
+    customLlmSecret: undefined,
+    toolDefinitions: [],
+    modelConfig: { provider: "anthropic", model: "claude-sonnet-4-6" },
+    firstLine: undefined,
+    knowledgePlanEnabled: false,
+    costSafetyKnobs: null,
+    voiceConfig: undefined,
+    ...overrides,
+  }) as Parameters<VapiProvider["buildAssistantConfig"]>[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.call.findFirst.mockReset();
+});
+
+describe("extractControlUrl", () => {
+  it("returns null for non-objects / empty inputs", () => {
+    expect(extractControlUrl(null)).toBeNull();
+    expect(extractControlUrl(undefined)).toBeNull();
+    expect(extractControlUrl({})).toBeNull();
+    expect(extractControlUrl("not an object")).toBeNull();
+  });
+
+  it("reads top-level monitor.controlUrl (POST /call response shape)", () => {
+    const payload = { monitor: { controlUrl: CONTROL_URL } };
+    expect(extractControlUrl(payload)).toBe(CONTROL_URL);
+  });
+
+  it("reads message.monitor.controlUrl (webhook envelope variant)", () => {
+    const payload = { message: { monitor: { controlUrl: CONTROL_URL } } };
+    expect(extractControlUrl(payload)).toBe(CONTROL_URL);
+  });
+
+  it("reads message.call.monitor.controlUrl (nested-call webhook variant)", () => {
+    const payload = { message: { call: { monitor: { controlUrl: CONTROL_URL } } } };
+    expect(extractControlUrl(payload)).toBe(CONTROL_URL);
+  });
+
+  it("reads call.monitor.controlUrl (root-call shape)", () => {
+    const payload = { call: { monitor: { controlUrl: CONTROL_URL } } };
+    expect(extractControlUrl(payload)).toBe(CONTROL_URL);
+  });
+
+  it("returns null when monitor exists but controlUrl is absent (pre-#1742 call)", () => {
+    const payload = { monitor: { listenUrl: "wss://..." } };
+    expect(extractControlUrl(payload)).toBeNull();
+  });
+});
+
+describe("VapiProvider — capabilities + buildAssistantConfig", () => {
+  it("declares supportsProactiveSpeech: true", () => {
+    const provider = new VapiProvider({}, {});
+    expect(provider.getCapabilities().supportsProactiveSpeech).toBe(true);
+  });
+
+  it("sets assistant.monitorPlan.controlEnabled = true on every call", () => {
+    const provider = new VapiProvider({}, {});
+    const config = provider.buildAssistantConfig(buildCtx()) as {
+      assistant: { monitorPlan?: { controlEnabled?: boolean; listenEnabled?: boolean } };
+    };
+    expect(config.assistant.monitorPlan?.controlEnabled).toBe(true);
+    expect(config.assistant.monitorPlan?.listenEnabled).toBe(false);
+  });
+});
+
+describe("VapiProvider.sayMessage", () => {
+  let provider: VapiProvider;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    provider = new VapiProvider({}, {});
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  it("returns {status:'skipped'} when no Call row exists for the externalCallId", async () => {
+    mockPrisma.call.findFirst.mockResolvedValue(null);
+    const result = await provider.sayMessage("ext-1", { content: "hi" });
+    expect(result).toEqual({ status: "skipped" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns {status:'skipped'} when voiceProviderRaw has no monitor.controlUrl (pre-#1742)", async () => {
+    mockPrisma.call.findFirst.mockResolvedValue({ voiceProviderRaw: { call: { id: "ext-1" } } });
+    const result = await provider.sayMessage("ext-1", { content: "hi" });
+    expect(result).toEqual({ status: "skipped" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("POSTs {type:'say', content, endCallAfterSpoken:false} when queueOnly false", async () => {
+    mockPrisma.call.findFirst.mockResolvedValue({
+      voiceProviderRaw: { monitor: { controlUrl: CONTROL_URL } },
+    });
+    fetchSpy.mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const result = await provider.sayMessage("ext-1", { content: "fifteen seconds left" });
+
+    expect(result).toEqual({ status: "spoken" });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      CONTROL_URL,
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(sentBody).toEqual({
+      type: "say",
+      content: "fifteen seconds left",
+      endCallAfterSpoken: false,
+    });
+  });
+
+  it("POSTs {type:'add-message', …} when queueOnly true", async () => {
+    mockPrisma.call.findFirst.mockResolvedValue({
+      voiceProviderRaw: { monitor: { controlUrl: CONTROL_URL } },
+    });
+    fetchSpy.mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const result = await provider.sayMessage("ext-1", {
+      content: "Note for next turn",
+      queueOnly: true,
+    });
+
+    expect(result).toEqual({ status: "queued" });
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(sentBody).toEqual({
+      type: "add-message",
+      message: { role: "assistant", content: "Note for next turn" },
+      triggerResponseEnabled: false,
+    });
+  });
+
+  it("returns {status:'failed'} on non-2xx response — no throw", async () => {
+    mockPrisma.call.findFirst.mockResolvedValue({
+      voiceProviderRaw: { monitor: { controlUrl: CONTROL_URL } },
+    });
+    fetchSpy.mockResolvedValue({ ok: false, status: 503 } as Response);
+
+    const result = await provider.sayMessage("ext-1", { content: "hi" });
+    expect(result).toEqual({ status: "failed" });
+  });
+
+  it("returns {status:'failed'} on fetch network error — no throw", async () => {
+    mockPrisma.call.findFirst.mockResolvedValue({
+      voiceProviderRaw: { monitor: { controlUrl: CONTROL_URL } },
+    });
+    fetchSpy.mockRejectedValue(new Error("network down"));
+
+    const result = await provider.sayMessage("ext-1", { content: "hi" });
+    expect(result).toEqual({ status: "failed" });
+  });
+});


### PR DESCRIPTION
## Summary

Theme 2a primitive + scheduler foundation per the ADR merged in #1819. Provider-agnostic so #1743 Theme 2b (IELTS cue wiring) can consume without per-provider code.

### What ships

- **Interface** (`lib/voice/types.ts`):
  - `SayMessageOptions` (`content`, `noInterruption?`, `queueOnly?`, `traceId?`)
  - `SayMessageResult` (`{status: "spoken" | "queued" | "skipped" | "failed"}` — never thrown)
  - Optional `VoiceProvider.sayMessage?(externalCallId, options)` method
  - New `VoiceProviderCapabilities.supportsProactiveSpeech: boolean` flag
- **VAPI adapter** (`lib/voice/providers/vapi/index.ts`):
  - `buildAssistantConfig` now sets `assistant.monitorPlan = { controlEnabled: true, listenEnabled: false }` so VAPI returns `monitor.controlUrl` on the Call response
  - `sayMessage(externalCallId, opts)` reads the URL from `Call.voiceProviderRaw.monitor.controlUrl`, POSTs `{type:"say"|"add-message", …}`, returns `{status: "spoken"|"queued"|"skipped"|"failed"}`. Idempotent; transport errors swallowed + AppLogged at `voice.vapi.say_message_failed`.
  - `extractControlUrl(raw)` helper covers the four payload nesting variants VAPI uses (top-level, `message.*`, `call.*`, `message.call.*`).
  - `supportsProactiveSpeech: true` declared
- **Retell adapter** (`lib/voice/providers/retell/index.ts`):
  - `supportsProactiveSpeech: false` — Retell's `agent_interrupt` frame needs an HF-side LLM-WSS handler queue, deferred. Scheduler short-circuits + emits `voice.cue_scheduler.skipped_no_capability` instead of failing.
- **Scheduler** (`lib/voice/cue-scheduler.ts`):
  - `scheduleCue(args)` — persists a `CueScheduleEntry` row (status="pending")
  - `cancelCuesForCall(externalCallId)` — idempotent flip-to-cancelled
  - `drainDueCues(opts)` — fires every row where `scheduledFor <= now AND status === "pending"`; resolves provider via `Call.source` → factory; stamps terminal status. Tests inject `getProvider` + `resolveSlug` + `now` for determinism.
  - AppLog subjects: `registered`, `fired`, `late` (>500ms drift), `skipped_no_capability`, `cancelled`, `failed`
- **Schema** (`prisma/schema.prisma` + migration `20260616190000_1742_cue_schedule_entry`):
  - New `CueScheduleEntry` table — `(id, externalCallId, callId?, scheduledFor, content, options Json, firedAt?, cancelledAt?, status, traceId, createdAt)` + 3 indexes
  - FK `callId → Call.id` ON DELETE SET NULL
  - Reverse relation `Call.cueScheduleEntries`

### What's NOT in this PR

- **Tick runner** — the production setInterval loop that calls `drainDueCues()`. Wired in a follow-on; tests drive `drainDueCues` directly.
- **Retell LLM-WSS handler queue** — Retell stays `supportsProactiveSpeech: false` until that handler is built.
- **`HF_FLAG_VOICE_SAY_MESSAGE` flag** — primitive ships unflagged because (a) it's only called by `cue-scheduler.ts`, which is only called by Theme 2b (not yet wired), so there's no runtime exposure today; (b) the capability flag already gates per-provider.

### Lattice survey [verified]

- **Sibling-writer drift:** NIL — `sayMessage` is a new optional method, no other writer touches the same DB column or wire path. [verified via `grep -rn 'sayMessage' apps/admin/lib` → only the new files].
- **Default-deny gates:** `supportsProactiveSpeech` defaults to false on Retell + future providers; scheduler short-circuits + logs.
- **Cascade respect:** N/A — call-scoped, not setting-cascadable.
- **Convention conflict:** NIL — mirrors the existing `requestEndCall?()` / `supportsRequestEndCall` precedent at `apps/admin/lib/voice/types.ts:444`.
- **AI-to-DB guard:** N/A — scheduler is deterministic; no AI output drives the wire call.
- **ai-read-grounding:** N/A — no natural-language assertion surface.

## Verified by

- ✅ vitest `tests/lib/voice/vapi-say-message.test.ts` 14/14 (extractControlUrl 6 cases + capability + buildAssistantConfig monitorPlan + sayMessage 6 paths). [verified — `npx vitest run tests/lib/voice/vapi-say-message.test.ts` exits 0].
- ✅ vitest `tests/lib/voice/cue-scheduler.test.ts` 11/11 (schedule arg-validation + cancel idempotence + drain fires/skips/fails + batch limit + orphan call). [verified — `npx vitest run tests/lib/voice/cue-scheduler.test.ts` exits 0].
- ✅ Full voice bank: 339/339 tests pass, zero regression. [verified — `npx vitest run tests/lib/voice/` exits 0].
- ✅ tsc on changed files: 0 errors. [verified — `npx tsc --noEmit | grep -E 'cue-scheduler|vapi/index|retell/index|voice/types'` returns no rows].
- ✅ pre-push hook: lint 0 errors in changed files. [verified at log above].
- ✅ Lattice survey result inline above; each risk shape probed and cited.

## Migration

Needs `/vm-cpp` to apply `20260616190000_1742_cue_schedule_entry` on hf-dev. Additive table; no FK changes to existing tables; no row rewrites.

## Test plan

- [ ] `/vm-cpp` to apply the migration.
- [ ] Verify VAPI live: an outbound dial since this PR should now produce a Call row whose `voiceProviderRaw.monitor.controlUrl` is populated. Quick probe: `SELECT \"voiceProviderRaw\" FROM \"Call\" WHERE source='vapi' AND \"createdAt\" > NOW() - INTERVAL '5 min' LIMIT 1;` after a fresh dial.
- [ ] Sanity-check scheduler: `npm run ctl exec lib/voice/cue-scheduler:scheduleCue --externalCallId=<live> --content="ping" --scheduledFor=NOW+5s` then watch `voice.cue_scheduler.fired` in AppLog (or set up a tick runner — out of scope for this PR).
- [ ] #1743 Theme 2b cue wiring becomes unblocked.

Closes #1742.
