### PR TITLE
chore(kb): extend pre-commit to 5 generators + Lattice README

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -141,19 +141,29 @@ apps/admin/docs-archive/bdd-specs/*)
 fi
 
 # 6) Auto-regen the KB Tier-2 generated facts when their inputs change.
-#    Schema edits → model-map; route edits → route-inventory; overrides
-#    edits → model-map. Adds the regenerated JSON to the same commit so
-#    the CI freshness gate (kb:check, .github/workflows/test.yml) passes
-#    without a follow-up commit. Non-blocking on failure. See docs/kb/README.md.
+#    Schema edits → model-map; route edits → route-inventory + operator-
+#    surfaces; cascade knob-keys / compose affecting-keys edits → demo-
+#    knobs; any apps/admin source edit → coupling-graph. Adds regenerated
+#    JSON to the same commit so the CI freshness gate (kb:check,
+#    .github/workflows/test.yml) passes without a follow-up commit. Each
+#    regen step is non-blocking on failure. See docs/kb/README.md.
 if command -v npx >/dev/null 2>&1; then
   schema_changed="0"
   routes_changed="0"
+  knob_keys_changed="0"
+  source_changed="0"
   while IFS= read -r f; do
     case "$f" in
       apps/admin/prisma/schema.prisma|docs/kb/model-map-overrides.json)
         schema_changed="1" ;;
       apps/admin/app/api/*route.ts)
         routes_changed="1" ;;
+      apps/admin/lib/cascade/knob-keys.ts|apps/admin/lib/compose/affecting-keys.ts)
+        knob_keys_changed="1" ;;
+    esac
+    case "$f" in
+      apps/admin/*.ts|apps/admin/*.tsx)
+        source_changed="1" ;;
     esac
   done <<< "${STAGED_FILES}"
 
@@ -172,6 +182,33 @@ if command -v npx >/dev/null 2>&1; then
       git add docs/kb/generated/route-inventory.json
     else
       echo "[pre-commit] ⚠ route-inventory regen failed (non-blocking). Run: cd apps/admin && npm run kb:routes"
+    fi
+
+    echo "[pre-commit] Regenerating docs/kb/generated/operator-surfaces.json..."
+    if (cd apps/admin && npx tsx scripts/capture/operator-surfaces.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/operator-surfaces.json
+    else
+      echo "[pre-commit] ⚠ operator-surfaces regen failed (non-blocking). Run: cd apps/admin && npm run kb:operator-surfaces"
+    fi
+  fi
+
+  if [[ "$knob_keys_changed" == "1" ]]; then
+    echo "[pre-commit] Regenerating docs/kb/generated/demo-knobs.json..."
+    if (cd apps/admin && npx tsx scripts/capture/demo-knobs.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/demo-knobs.json
+    else
+      echo "[pre-commit] ⚠ demo-knobs regen failed (non-blocking). Run: cd apps/admin && npm run kb:demo-knobs"
+    fi
+  fi
+
+  # coupling-graph walks the whole apps/admin source tree (~1.4s); any
+  # staged .ts/.tsx edit there can shift import edges.
+  if [[ "$source_changed" == "1" ]]; then
+    echo "[pre-commit] Regenerating docs/kb/generated/coupling-graph.json..."
+    if (cd apps/admin && npx tsx scripts/capture/coupling-graph.ts >/dev/null 2>&1); then
+      git add docs/kb/generated/coupling-graph.json
+    else
+      echo "[pre-commit] ⚠ coupling-graph regen failed (non-blocking). Run: cd apps/admin && npm run kb:coupling"
     fi
   fi
 fi

--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -14,6 +14,28 @@ and classifies everything by **"does it survive the hardening?"**.
 The work is overwhelmingly **consolidation, not creation** — most of the knowledge
 already exists, scattered across mechanisms that were never designed as one system.
 
+## Lattice — the five pillars this KB catalogues
+
+**Lattice** is the umbrella term (2026-06-16) for HF's structural-enforcement
+infrastructure. New structural infra must ship *with* its paired guard + rule.
+"Lattice violation" = bypass; "off-Lattice change" = exists outside the system.
+
+| Pillar | What it is | Lives in | KB index |
+|---|---|---|---|
+| **Chain Contracts** | Cross-stage invariants (Link 3 / Link 4 / Session boundaries) | `docs/CHAIN-CONTRACTS.md` + `docs/CONTRACTS-*.md` | Part 2 prototype |
+| **Guards** | Executable enforcement (ESLint rules + `check-*` scripts + DB-level constraints) | `apps/admin/eslint-rules/`, `scripts/capture/check-*`, `prisma/schema.prisma` | `guard-registry.md` |
+| **Cascade** | Effective-value resolvers (`resolveEffective`, presets, variant pins) | `lib/cascade/`, `lib/banding/`, `lib/config/resolve-*` | Part 1 model-map + Part 2 |
+| **Rules** | Curated guidance that explains *why* a guard exists | `.claude/rules/*.md` | linked from each guard row |
+| **Coverage** | Schema-driven completeness check — registry incomplete vs target surface (post-Slice-C BA-failure recovery, #1780) | `apps/admin/tests/lib/journey/registry-schema-coverage.test.ts` + `registry-options-coverage.test.ts` | vitest pins (no separate catalogue) |
+
+Audit cue: when changes touch any pillar, audit against all five explicitly
+before merge. Lattice-survey discipline (60–90s sibling-writer survey before
+writing/modifying code that touches a shared DB column, crosses a chain-stage
+boundary, registers a new guard/contract, or extends an AI write/read path) —
+PR `## Verified by` must cite the survey result. Memory:
+`feedback_lattice_guard_umbrella.md`, `feedback_lattice_survey_discipline.md`,
+`feedback_lattice_5th_pillar_coverage.md`.
+
 ## Reuse map — what already exists (don't rebuild these)
 
 | Existing artifact | Role | KB tier it satisfies |

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,11 +1,11 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-12T17:02:55.059Z",
+  "generatedAt": "2026-06-17T08:48:52.734Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1710,
-  "edgeCount": 3946,
-  "skippedEdges": 1,
+  "fileCount": 1807,
+  "edgeCount": 4208,
+  "skippedEdges": 2,
   "edges": [
     {
       "from": "app/api/account/route.ts",
@@ -672,6 +672,30 @@
       "to": "lib/permissions.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/rbac/policies/adaptations.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/adaptations/route.ts",
+      "to": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/aggregate/route.ts",
       "to": "lib/learner-scope.ts"
     },
@@ -694,6 +718,42 @@
     {
       "from": "app/api/callers/[callerId]/artifacts/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/curriculum/playbook-mastery-config.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/attainment/route.ts",
+      "to": "lib/voice/talk-time-stats.ts"
     },
     {
       "from": "app/api/callers/[callerId]/available-media/route.ts",
@@ -888,6 +948,30 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/caller-utils.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/journey-progress/route.ts",
       "to": "lib/learner-scope.ts"
     },
@@ -928,6 +1012,30 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/curriculum/playbook-mastery-config.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/curriculum/scratch-mastery.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/lo-progress/route.ts",
       "to": "lib/curriculum/track-progress.ts"
     },
@@ -956,6 +1064,18 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/module-progress/route.ts",
       "to": "lib/learner-scope.ts"
     },
@@ -965,6 +1085,18 @@
     },
     {
       "from": "app/api/callers/[callerId]/module-progress/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/personality/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/personality/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/personality/route.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -1048,6 +1180,18 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "to": "lib/pipeline/scheduler-decision.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/session-flow-progress/route.ts",
       "to": "lib/config.ts"
     },
@@ -1070,6 +1214,22 @@
     {
       "from": "app/api/callers/[callerId]/session-flow-progress/route.ts",
       "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "app/api/callers/[callerId]/slugs/route.ts",
@@ -1105,6 +1265,22 @@
     },
     {
       "from": "app/api/callers/[callerId]/status/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/sub-skills/route.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -1393,6 +1569,10 @@
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/ops/update-targets.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/permissions.ts"
     },
     {
@@ -1445,6 +1625,10 @@
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/pipeline/normalize-score-agent-evidence.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/pipeline/prosody-consumer.ts"
     },
     {
@@ -1462,6 +1646,10 @@
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/pipeline/validate-dependencies.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/pipeline/write-count-logger.ts"
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
@@ -2692,6 +2880,26 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/courses/[courseId]/content-trust/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/content-trust/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "to": "lib/prompt/composition/loaders/conversationArtifacts.ts"
+    },
+    {
       "from": "app/api/courses/[courseId]/course-instructions/route.ts",
       "to": "lib/content-trust/resolve-config.ts"
     },
@@ -2876,6 +3084,46 @@
       "to": "lib/wizard/sync-authored-modules-to-curriculum.ts"
     },
     {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/compose/section-staleness.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/section-staleness-bridge.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/setting-contracts.entries.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/journey/storage-path-applier.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/settings/voice-setting-contracts.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
       "from": "app/api/courses/[courseId]/learners/ensure-cohort/route.ts",
       "to": "lib/permissions.ts"
     },
@@ -2914,6 +3162,18 @@
     {
       "from": "app/api/courses/[courseId]/media/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "to": "lib/prompt/composition/loaders/memoryDeltas.ts"
     },
     {
       "from": "app/api/courses/[courseId]/onboarding/route.ts",
@@ -2996,6 +3256,26 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/compose/recompose-section.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "app/api/courses/[courseId]/reconcile-mcqs/route.ts",
       "to": "lib/content-trust/reconcile-question-linkage.ts"
     },
@@ -3034,6 +3314,30 @@
     {
       "from": "app/api/courses/[courseId]/regenerate-curriculum/route.ts",
       "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "to": "lib/wizard/run-projection-for-playbook.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "to": "lib/compose/section-staleness.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "app/api/courses/[courseId]/session-count-recommendation/route.ts",
@@ -3097,6 +3401,98 @@
     },
     {
       "from": "app/api/courses/[courseId]/setup-status/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/banding/tier-colors.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/banding/tier-colors.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/cascade/effective-value.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/curriculum/resolve-skill.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-source-lineage/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/skills-source-lineage/route.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -5692,6 +6088,26 @@
       "to": "lib/roles.ts"
     },
     {
+      "from": "app/api/student/[courseId]/results/[sessionId]/route.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/student/[courseId]/results/[sessionId]/route.ts",
+      "to": "lib/learner-scope.ts"
+    },
+    {
+      "from": "app/api/student/[courseId]/results/[sessionId]/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/student/[courseId]/results/[sessionId]/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/student/[courseId]/results/[sessionId]/route.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
       "from": "app/api/student/artifacts/mark-read/route.ts",
       "to": "lib/prisma.ts"
     },
@@ -6174,6 +6590,14 @@
     {
       "from": "app/api/system/ini/route.ts",
       "to": "lib/system-ini.ts"
+    },
+    {
+      "from": "app/api/system/pipeline-health/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/system/pipeline-health/route.ts",
+      "to": "lib/pipeline/detect-silent-writers.ts"
     },
     {
       "from": "app/api/system/readiness/route.ts",
@@ -8053,14 +8477,6 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
-      "to": "app/x/courses/[courseId]/_components/voice-flow-lens.css"
-    },
-    {
-      "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
-      "to": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx"
-    },
-    {
-      "from": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "to": "components/callers/caller-detail/StalePromptPillForCourse.tsx"
     },
     {
@@ -8157,6 +8573,10 @@
     },
     {
       "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "to": "lib/domain/generate-identity.ts"
     },
     {
@@ -8168,12 +8588,32 @@
       "to": "lib/types/json-fields.ts"
     },
     {
-      "from": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
-      "to": "components/shared/HFDrawer.tsx"
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx"
     },
     {
-      "from": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
-      "to": "components/voice/VoiceConfigSection.tsx"
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/designer-shell/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/preview-renderers/_journey-setting-context.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/preview-renderers/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "components/shared/preview-renderers/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "app/x/courses/[courseId]/chat/ChatLauncher.tsx",
@@ -8245,7 +8685,7 @@
     },
     {
       "from": "app/x/courses/[courseId]/CourseDesignTab.tsx",
-      "to": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx"
+      "to": "app/x/courses/[courseId]/_tab/DesignTab.tsx"
     },
     {
       "from": "app/x/courses/[courseId]/CourseDesignTab.tsx",
@@ -8376,6 +8816,38 @@
       "to": "app/x/courses/[courseId]/course-proof.css"
     },
     {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "app/x/courses/[courseId]/course-skills-tab.css"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/cascade/CascadeInspectorTray.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/BandingPicker.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/CascadeValue.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/TierCell.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "components/shared/VariantPresetPill.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "lib/banding/tier-colors.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
       "from": "app/x/courses/[courseId]/CourseSummaryCard.tsx",
       "to": "lib/content-categories.ts"
     },
@@ -8473,6 +8945,10 @@
     },
     {
       "from": "app/x/courses/[courseId]/page.tsx",
+      "to": "app/x/courses/[courseId]/CourseSkillsTab.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/page.tsx",
       "to": "app/x/courses/[courseId]/CourseSummaryCard.tsx"
     },
     {
@@ -8494,6 +8970,14 @@
     {
       "from": "app/x/courses/[courseId]/page.tsx",
       "to": "components/help/TabWithHelp.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/page.tsx",
+      "to": "components/journey-tab/CourseJourneyTab.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/page.tsx",
+      "to": "components/journey-tab/SettingsTabVoiceLens.tsx"
     },
     {
       "from": "app/x/courses/[courseId]/page.tsx",
@@ -8538,10 +9022,6 @@
     {
       "from": "app/x/courses/[courseId]/page.tsx",
       "to": "components/shared/SurveyStopDetail.tsx"
-    },
-    {
-      "from": "app/x/courses/[courseId]/page.tsx",
-      "to": "components/voice/VoiceConfigSection.tsx"
     },
     {
       "from": "app/x/courses/[courseId]/page.tsx",
@@ -8762,6 +9242,10 @@
     {
       "from": "app/x/courses/page.tsx",
       "to": "lib/prompt/composition/transforms/audience.ts"
+    },
+    {
+      "from": "app/x/courses/page.tsx",
+      "to": "lib/terminology/types.ts"
     },
     {
       "from": "app/x/courses/page.tsx",
@@ -9430,6 +9914,10 @@
     {
       "from": "app/x/help/demos/page.tsx",
       "to": "lib/auth.ts"
+    },
+    {
+      "from": "app/x/help/glossary/page.tsx",
+      "to": "app/x/help/glossary/help-glossary.css"
     },
     {
       "from": "app/x/help/pipeline-health/page.tsx",
@@ -10144,6 +10632,14 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "app/x/student/[courseId]/results/[sessionId]/page.tsx",
+      "to": "app/api/student/[courseId]/results/[sessionId]/route.ts"
+    },
+    {
+      "from": "app/x/student/[courseId]/results/[sessionId]/page.tsx",
+      "to": "app/x/student/[courseId]/results/[sessionId]/results.css"
+    },
+    {
       "from": "app/x/student/calls/page.tsx",
       "to": "hooks/useStudentCallerId.ts"
     },
@@ -10360,6 +10856,14 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/x/system/pipeline-health/page.tsx",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/x/system/pipeline-health/page.tsx",
+      "to": "lib/pipeline/detect-silent-writers.ts"
+    },
+    {
       "from": "app/x/taxonomy-graph/page.tsx",
       "to": "components/shared/AdvancedBanner.tsx"
     },
@@ -10394,6 +10898,14 @@
     {
       "from": "app/x/test-harness/page.tsx",
       "to": "components/shared/FancySelect.tsx"
+    },
+    {
+      "from": "app/x/test/[playbookSlug]/[moduleSlug]/page.tsx",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/x/test/[playbookSlug]/[moduleSlug]/page.tsx",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "app/x/testimony/[specId]/page.tsx",
@@ -10848,8 +11360,24 @@
       "to": "lib/roles.ts"
     },
     {
+      "from": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "to": "lib/banding/presets.ts"
+    },
+    {
+      "from": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
       "from": "lib/banding/presets.ts",
       "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "lib/banding/skill-tier-deploy-invariant.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "lib/bdd/ai-parser.ts",
@@ -10886,6 +11414,10 @@
     {
       "from": "lib/cascade/effective-value.ts",
       "to": "lib/cascade/resolvers/identity-spec.ts"
+    },
+    {
+      "from": "lib/cascade/effective-value.ts",
+      "to": "lib/cascade/resolvers/mastery-policy.ts"
     },
     {
       "from": "lib/cascade/effective-value.ts",
@@ -10933,6 +11465,18 @@
     },
     {
       "from": "lib/cascade/resolvers/identity-spec.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/cascade/resolvers/mastery-policy.ts",
+      "to": "lib/cascade/effective-value.ts"
+    },
+    {
+      "from": "lib/cascade/resolvers/mastery-policy.ts",
+      "to": "lib/cascade/layer-types.ts"
+    },
+    {
+      "from": "lib/cascade/resolvers/mastery-policy.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -10998,6 +11542,10 @@
     {
       "from": "lib/cascade/set-at-layer.ts",
       "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "lib/cascade/use-effective-value.ts",
+      "to": "lib/cascade/layer-types.ts"
     },
     {
       "from": "lib/cascade/voice-explain.ts",
@@ -11368,6 +11916,18 @@
       "to": "lib/chat/wizard-tool-executor/resolvers/course-by-name.ts"
     },
     {
+      "from": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "to": "lib/content-trust/course-ref-to-assertions.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "to": "lib/knowledge/domain-sources.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "lib/chat/wizard-tool-executor/tools/create_community.ts",
       "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
     },
@@ -11377,26 +11937,106 @@
     },
     {
       "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_enroll.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_graph-guard.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_enroll.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
       "to": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
-      "to": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts"
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
-      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
-      "to": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts"
-    },
-    {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
       "to": "lib/domain/update-domain-config.ts"
     },
     {
-      "from": "lib/chat/wizard-tool-executor/tools/create_course.ts",
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/ensure-institution-and-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/valid-uuid.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-subject.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-subject.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/_shared/types.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "to": "lib/domain/update-domain-config.ts"
+    },
+    {
+      "from": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
       "to": "lib/playbook/update-playbook-config.ts"
     },
     {
@@ -11480,6 +12120,18 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/compose/affecting-keys-domain.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/affecting-keys-spec.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/affecting-keys.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
       "from": "lib/compose/bump-curriculum-fanout.ts",
       "to": "lib/compose/bump-timestamp.ts"
     },
@@ -11497,6 +12149,46 @@
     },
     {
       "from": "lib/compose/eager-reprompt-on-bump.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/compose/section-loaders.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/compose/section-staleness.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/prompt/composition/index.ts"
+    },
+    {
+      "from": "lib/compose/recompose-section.ts",
+      "to": "lib/prompt/composition/renderPromptSummary.ts"
+    },
+    {
+      "from": "lib/compose/section-loaders.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/section-loaders.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/section-staleness.ts",
+      "to": "lib/compose/section.ts"
+    },
+    {
+      "from": "lib/compose/section-staleness.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -11634,6 +12326,10 @@
     {
       "from": "lib/content-trust/extract-curriculum.ts",
       "to": "lib/prompts/prompt-settings.ts"
+    },
+    {
+      "from": "lib/content-trust/extract-curriculum.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/content-trust/extract-images.ts",
@@ -12072,6 +12768,14 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/curriculum/mark-module-incomplete.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/curriculum/mark-module-incomplete.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
       "from": "lib/curriculum/playbook-mastery-config.ts",
       "to": "lib/curriculum/mastery-tiers.ts"
     },
@@ -12133,6 +12837,10 @@
     },
     {
       "from": "lib/curriculum/resolve-playbook-for-curriculum.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/curriculum/resolve-skill.ts",
       "to": "lib/prisma.ts"
     },
     {
@@ -12206,6 +12914,10 @@
     {
       "from": "lib/curriculum/track-progress.ts",
       "to": "lib/curriculum/scratch-mastery.ts"
+    },
+    {
+      "from": "lib/curriculum/track-progress.ts",
+      "to": "lib/logger.ts"
     },
     {
       "from": "lib/curriculum/track-progress.ts",
@@ -12632,6 +13344,10 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/goals/append-progress-entry.ts",
+      "to": "lib/goals/strategies/types.ts"
+    },
+    {
       "from": "lib/goals/extract-goals.ts",
       "to": "lib/ai/analyst-system-prompts.ts"
     },
@@ -12777,7 +13493,15 @@
     },
     {
       "from": "lib/goals/track-progress.ts",
+      "to": "lib/goals/append-progress-entry.ts"
+    },
+    {
+      "from": "lib/goals/track-progress.ts",
       "to": "lib/goals/strategies/index.ts"
+    },
+    {
+      "from": "lib/goals/track-progress.ts",
+      "to": "lib/goals/strategies/types.ts"
     },
     {
       "from": "lib/goals/track-progress.ts",
@@ -12986,6 +13710,82 @@
     {
       "from": "lib/jobs/curriculum-runner.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/journey/bucket-relations.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/journey/bucket-relations.ts",
+      "to": "lib/journey/setting-contracts.entries.ts"
+    },
+    {
+      "from": "lib/journey/bucket-relations.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/bucket-relations.ts",
+      "to": "lib/settings/voice-setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/menu-items.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/menu-items.ts",
+      "to": "lib/journey/setting-groups.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/journey/setting-contracts.entries.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/section-staleness-bridge.ts",
+      "to": "lib/settings/voice-setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.entries.ts",
+      "to": "lib/banding/presets.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.entries.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.entries.ts",
+      "to": "lib/journey/setting-groups.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/journey/setting-contracts.ts",
+      "to": "lib/journey/setting-groups.ts"
+    },
+    {
+      "from": "lib/journey/storage-path-applier.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/storage-path-applier.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/journey/use-cascade-edit-field.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/use-cascade-edit-field.ts",
+      "to": "lib/journey/use-glow-state.ts"
     },
     {
       "from": "lib/knowledge/assertions.ts",
@@ -13337,6 +14137,10 @@
     },
     {
       "from": "lib/ops/update-targets.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/ops/update-targets.ts",
       "to": "lib/types/json-fields.ts"
     },
     {
@@ -13370,6 +14174,10 @@
     {
       "from": "lib/pipeline/adaptive-loop-invariants.ts",
       "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/adaptive-loop-invariants.ts",
+      "to": "lib/pipeline/writer-completeness-invariant.ts"
     },
     {
       "from": "lib/pipeline/adaptive-loop-invariants.ts",
@@ -13408,6 +14216,18 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/pipeline/detect-silent-writers.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/detect-silent-writers.ts",
+      "to": "lib/pipeline/write-count-logger.ts"
+    },
+    {
+      "from": "lib/pipeline/detect-silent-writers.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "lib/pipeline/event-gate.ts",
       "to": "lib/config.ts"
     },
@@ -13422,6 +14242,34 @@
     {
       "from": "lib/pipeline/evidence-gate.ts",
       "to": "lib/pipeline/event-gate.ts"
+    },
+    {
+      "from": "lib/pipeline/extract-profile-fields.ts",
+      "to": "lib/ai/client.ts"
+    },
+    {
+      "from": "lib/pipeline/extract-profile-fields.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/extract-profile-fields.ts",
+      "to": "lib/metering/instrumented-ai.ts"
+    },
+    {
+      "from": "lib/pipeline/extract-profile-fields.ts",
+      "to": "lib/pipeline/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/extract-profile-fields.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/pipeline/extract-profile-fields.ts",
+      "to": "lib/system-settings.ts"
+    },
+    {
+      "from": "lib/pipeline/extract-profile-fields.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/pipeline/guardrails.ts",
@@ -13536,6 +14384,22 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/pipeline/write-count-logger.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/writer-completeness-invariant.ts",
+      "to": "lib/contracts/writer-registry.ts"
+    },
+    {
+      "from": "lib/pipeline/writer-completeness-invariant.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/pipeline/writer-completeness-invariant.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "lib/playbook/update-playbook-config.ts",
       "to": "lib/cascade/effective-value.ts"
     },
@@ -13593,6 +14457,10 @@
     },
     {
       "from": "lib/prompt/composition/buildComposeTrace.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/prompt/composition/buildComposeTrace.ts",
       "to": "lib/config.ts"
     },
     {
@@ -13606,6 +14474,14 @@
     {
       "from": "lib/prompt/composition/compose-invariants.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/compose/section-loaders.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/compose/section.ts"
     },
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
@@ -13637,6 +14513,10 @@
     },
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/prompt/composition/transforms/conversationArtifacts.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
       "to": "lib/prompt/composition/transforms/course-instructions.ts"
     },
     {
@@ -13662,6 +14542,10 @@
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
       "to": "lib/prompt/composition/transforms/memories.ts"
+    },
+    {
+      "from": "lib/prompt/composition/CompositionExecutor.ts",
+      "to": "lib/prompt/composition/transforms/memoryDeltas.ts"
     },
     {
       "from": "lib/prompt/composition/CompositionExecutor.ts",
@@ -13861,11 +14745,19 @@
     },
     {
       "from": "lib/prompt/composition/SectionDataLoader.ts",
+      "to": "lib/prompt/composition/loaders/conversationArtifacts.ts"
+    },
+    {
+      "from": "lib/prompt/composition/SectionDataLoader.ts",
       "to": "lib/prompt/composition/loaders/courseComplete.ts"
     },
     {
       "from": "lib/prompt/composition/SectionDataLoader.ts",
       "to": "lib/prompt/composition/loaders/interleaveReview.ts"
+    },
+    {
+      "from": "lib/prompt/composition/SectionDataLoader.ts",
+      "to": "lib/prompt/composition/loaders/memoryDeltas.ts"
     },
     {
       "from": "lib/prompt/composition/SectionDataLoader.ts",
@@ -13920,6 +14812,14 @@
       "to": "lib/prompt/composition/types.ts"
     },
     {
+      "from": "lib/prompt/composition/transforms/conversationArtifacts.ts",
+      "to": "lib/prompt/composition/loaders/conversationArtifacts.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/conversationArtifacts.ts",
+      "to": "lib/prompt/composition/TransformRegistry.ts"
+    },
+    {
       "from": "lib/prompt/composition/transforms/course-instructions.ts",
       "to": "lib/content-trust/resolve-config.ts"
     },
@@ -13969,6 +14869,10 @@
     },
     {
       "from": "lib/prompt/composition/transforms/instructions.ts",
+      "to": "lib/journey/module-settings-flag.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/instructions.ts",
       "to": "lib/prompt/composition/TransformRegistry.ts"
     },
     {
@@ -14006,6 +14910,14 @@
     {
       "from": "lib/prompt/composition/transforms/memories.ts",
       "to": "lib/prompt/composition/types.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/memoryDeltas.ts",
+      "to": "lib/prompt/composition/loaders/memoryDeltas.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/memoryDeltas.ts",
+      "to": "lib/prompt/composition/TransformRegistry.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/mockDiagnostic.ts",
@@ -14050,6 +14962,10 @@
     {
       "from": "lib/prompt/composition/transforms/modules.ts",
       "to": "lib/tolerance/resolve-tolerance.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/offboarding.ts",
+      "to": "lib/journey/module-settings-flag.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/offboarding.ts",
@@ -14372,6 +15288,10 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/prompt/composition/types.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
       "from": "lib/prompt/PromptTemplateCompiler.ts",
       "to": "lib/constants.ts"
     },
@@ -14394,6 +15314,18 @@
     {
       "from": "lib/prompts/spec-prompts.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/rbac/policies/adaptations.ts",
+      "to": "app/api/callers/[callerId]/adaptations/route.ts"
+    },
+    {
+      "from": "lib/rbac/policies/adaptations.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "lib/rbac/visibility.ts",
+      "to": "lib/roles.ts"
     },
     {
       "from": "lib/recompose/preview.ts",
@@ -14426,6 +15358,10 @@
     {
       "from": "lib/settings/resolver.ts",
       "to": "lib/settings/library-schema.ts"
+    },
+    {
+      "from": "lib/settings/voice-setting-contracts.ts",
+      "to": "lib/journey/setting-contracts.ts"
     },
     {
       "from": "lib/sidebar/storage.ts",
@@ -14570,6 +15506,10 @@
     {
       "from": "lib/system-settings.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/tab-layout.ts",
+      "to": "components/callers/caller-detail/types.ts"
     },
     {
       "from": "lib/terminology.ts",
@@ -14788,6 +15728,22 @@
       "to": "lib/voice/session-rules.ts"
     },
     {
+      "from": "lib/voice/cue-scheduler.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/voice/cue-scheduler.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/voice/cue-scheduler.ts",
+      "to": "lib/voice/provider-factory.ts"
+    },
+    {
+      "from": "lib/voice/cue-scheduler.ts",
+      "to": "lib/voice/types.ts"
+    },
+    {
       "from": "lib/voice/diag.ts",
       "to": "lib/logger.ts"
     },
@@ -14797,11 +15753,35 @@
     },
     {
       "from": "lib/voice/end-session.ts",
+      "to": "lib/curriculum/mark-module-incomplete.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
+      "to": "lib/journey/module-settings-flag.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
+      "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
       "to": "lib/prisma.ts"
     },
     {
       "from": "lib/voice/end-session.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
       "to": "lib/voice/session-rules.ts"
+    },
+    {
+      "from": "lib/voice/end-session.ts",
+      "to": "lib/voice/talk-time-stats.ts"
     },
     {
       "from": "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
@@ -14906,6 +15886,10 @@
     {
       "from": "lib/voice/providers/vapi/index.ts",
       "to": "lib/logger.ts"
+    },
+    {
+      "from": "lib/voice/providers/vapi/index.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "lib/voice/providers/vapi/index.ts",
@@ -15297,7 +16281,19 @@
     },
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/banding/derive-skill-tier-mapping-from-source.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/cascade/resolvers/mastery-policy.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
       "to": "lib/content-trust/extract-assertions.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
     },
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
@@ -15402,6 +16398,18 @@
     {
       "from": "scripts/backfill-cio-cto-playbook-configs.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-cto-projection.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-cto-projection.ts",
+      "to": "lib/wizard/apply-projection.ts"
+    },
+    {
+      "from": "scripts/backfill-cto-projection.ts",
+      "to": "lib/wizard/project-course-reference.ts"
     },
     {
       "from": "scripts/backfill-curriculum-anchors.ts",
@@ -15524,6 +16532,14 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "scripts/check-skill-tier-deploy-readiness.ts",
+      "to": "lib/banding/skill-tier-deploy-invariant.ts"
+    },
+    {
+      "from": "scripts/check-writer-registry.ts",
+      "to": "lib/contracts/writer-registry.ts"
+    },
+    {
       "from": "scripts/cleanup-orphaned-slugs.ts",
       "to": "lib/prisma.ts"
     },
@@ -15564,6 +16580,10 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "scripts/fix-cio-cto-playbooks.ts",
+      "to": "lib/goals/strategies/types.ts"
+    },
+    {
       "from": "scripts/generate-ai-capabilities.ts",
       "to": "docs-archive/bdd-specs/TOOLS-001-voice-tool-definitions.spec.json"
     },
@@ -15578,6 +16598,10 @@
     {
       "from": "scripts/generate-ai-capabilities.ts",
       "to": "lib/chat/course-ref-tools.ts"
+    },
+    {
+      "from": "scripts/generate-writer-coverage-doc.ts",
+      "to": "lib/contracts/writer-registry.ts"
     },
     {
       "from": "scripts/migrate-caller-attribute-lo-mastery-keys.ts",
@@ -15654,6 +16678,30 @@
     {
       "from": "scripts/repair-lo-linkage.ts",
       "to": "lib/content-trust/validate-lo-linkage.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/banding/derive-skill-tier-mapping-from-source.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/cascade/resolvers/mastery-policy.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/playbook/update-playbook-config.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/seed-source-derived-skill-banding.ts",
+      "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
+      "from": "scripts/seed-synthetic-cohort.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "scripts/seed-system-behavior-defaults.ts",
@@ -16094,6 +17142,11 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/callers/[callerId]/adaptations/route.ts",
+      "inDegree": 1,
+      "outDegree": 6
+    },
+    {
       "path": "app/api/callers/[callerId]/aggregate/route.ts",
       "inDegree": 0,
       "outDegree": 3
@@ -16102,6 +17155,11 @@
       "path": "app/api/callers/[callerId]/artifacts/route.ts",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "app/api/callers/[callerId]/attainment/route.ts",
+      "inDegree": 0,
+      "outDegree": 9
     },
     {
       "path": "app/api/callers/[callerId]/available-media/route.ts",
@@ -16164,6 +17222,11 @@
       "outDegree": 4
     },
     {
+      "path": "app/api/callers/[callerId]/insights/route.ts",
+      "inDegree": 0,
+      "outDegree": 6
+    },
+    {
       "path": "app/api/callers/[callerId]/journey-progress/route.ts",
       "inDegree": 0,
       "outDegree": 3
@@ -16179,6 +17242,11 @@
       "outDegree": 4
     },
     {
+      "path": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "inDegree": 0,
+      "outDegree": 6
+    },
+    {
       "path": "app/api/callers/[callerId]/lo-progress/route.ts",
       "inDegree": 0,
       "outDegree": 4
@@ -16189,7 +17257,17 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/callers/[callerId]/memories/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "app/api/callers/[callerId]/module-progress/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/callers/[callerId]/personality/route.ts",
       "inDegree": 0,
       "outDegree": 3
     },
@@ -16214,9 +17292,19 @@
       "outDegree": 11
     },
     {
+      "path": "app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "app/api/callers/[callerId]/session-flow-progress/route.ts",
       "inDegree": 0,
       "outDegree": 6
+    },
+    {
+      "path": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "inDegree": 0,
+      "outDegree": 4
     },
     {
       "path": "app/api/callers/[callerId]/slugs/route.ts",
@@ -16232,6 +17320,11 @@
       "path": "app/api/callers/[callerId]/status/route.ts",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "app/api/callers/[callerId]/sub-skills/route.ts",
+      "inDegree": 0,
+      "outDegree": 4
     },
     {
       "path": "app/api/callers/[callerId]/survey/route.ts",
@@ -16301,7 +17394,7 @@
     {
       "path": "app/api/calls/[callId]/pipeline/route.ts",
       "inDegree": 0,
-      "outDegree": 51
+      "outDegree": 54
     },
     {
       "path": "app/api/calls/[callId]/route.ts",
@@ -16669,6 +17762,16 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/courses/[courseId]/content-trust/route.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "app/api/courses/[courseId]/course-instructions/route.ts",
       "inDegree": 0,
       "outDegree": 3
@@ -16719,6 +17822,11 @@
       "outDegree": 11
     },
     {
+      "path": "app/api/courses/[courseId]/journey-setting/route.ts",
+      "inDegree": 0,
+      "outDegree": 10
+    },
+    {
       "path": "app/api/courses/[courseId]/learners/ensure-cohort/route.ts",
       "inDegree": 0,
       "outDegree": 2
@@ -16737,6 +17845,11 @@
       "path": "app/api/courses/[courseId]/media/route.ts",
       "inDegree": 0,
       "outDegree": 2
+    },
+    {
+      "path": "app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
     },
     {
       "path": "app/api/courses/[courseId]/onboarding/route.ts",
@@ -16769,6 +17882,11 @@
       "outDegree": 2
     },
     {
+      "path": "app/api/courses/[courseId]/recompose-section/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
       "path": "app/api/courses/[courseId]/reconcile-mcqs/route.ts",
       "inDegree": 0,
       "outDegree": 2
@@ -16777,6 +17895,16 @@
       "path": "app/api/courses/[courseId]/regenerate-curriculum/route.ts",
       "inDegree": 0,
       "outDegree": 8
+    },
+    {
+      "path": "app/api/courses/[courseId]/reproject-skills/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/courses/[courseId]/section-staleness/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
     },
     {
       "path": "app/api/courses/[courseId]/session-count-recommendation/route.ts",
@@ -16802,6 +17930,36 @@
       "path": "app/api/courses/[courseId]/setup-status/types.ts",
       "inDegree": 1,
       "outDegree": 0
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-evidence/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-framework/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "app/api/courses/[courseId]/skills-source-lineage/route.ts",
+      "inDegree": 0,
+      "outDegree": 2
     },
     {
       "path": "app/api/courses/[courseId]/staleness-aggregate/route.ts",
@@ -17879,6 +19037,11 @@
       "outDegree": 3
     },
     {
+      "path": "app/api/student/[courseId]/results/[sessionId]/route.ts",
+      "inDegree": 1,
+      "outDegree": 5
+    },
+    {
       "path": "app/api/student/artifacts/mark-read/route.ts",
       "inDegree": 0,
       "outDegree": 2
@@ -18055,6 +19218,11 @@
     },
     {
       "path": "app/api/system/ini/route.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "app/api/system/pipeline-health/route.ts",
       "inDegree": 0,
       "outDegree": 2
     },
@@ -18879,6 +20047,11 @@
       "outDegree": 1
     },
     {
+      "path": "app/x/courses/[courseId]/CourseSkillsTab.tsx",
+      "inDegree": 1,
+      "outDegree": 8
+    },
+    {
       "path": "app/x/courses/[courseId]/CourseSummaryCard.tsx",
       "inDegree": 2,
       "outDegree": 3
@@ -18921,7 +20094,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/CourseDesignConsole.tsx",
       "inDegree": 1,
-      "outDegree": 12
+      "outDegree": 10
     },
     {
       "path": "app/x/courses/[courseId]/_components/ImportModulesDialog.tsx",
@@ -18946,12 +20119,7 @@
     {
       "path": "app/x/courses/[courseId]/_components/PreviewLens.tsx",
       "inDegree": 1,
-      "outDegree": 11
-    },
-    {
-      "path": "app/x/courses/[courseId]/_components/VoiceFlowLens.tsx",
-      "inDegree": 1,
-      "outDegree": 2
+      "outDegree": 12
     },
     {
       "path": "app/x/courses/[courseId]/_components/authored-modules-panel.css",
@@ -18969,9 +20137,9 @@
       "outDegree": 0
     },
     {
-      "path": "app/x/courses/[courseId]/_components/voice-flow-lens.css",
+      "path": "app/x/courses/[courseId]/_tab/DesignTab.tsx",
       "inDegree": 1,
-      "outDegree": 0
+      "outDegree": 7
     },
     {
       "path": "app/x/courses/[courseId]/chat/ChatLauncher.tsx",
@@ -19024,9 +20192,14 @@
       "outDegree": 0
     },
     {
+      "path": "app/x/courses/[courseId]/course-skills-tab.css",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "app/x/courses/[courseId]/page.tsx",
       "inDegree": 0,
-      "outDegree": 43
+      "outDegree": 45
     },
     {
       "path": "app/x/courses/[courseId]/sessions/[sessionNum]/page.tsx",
@@ -19136,7 +20309,7 @@
     {
       "path": "app/x/courses/page.tsx",
       "inDegree": 0,
-      "outDegree": 7
+      "outDegree": 8
     },
     {
       "path": "app/x/courses/v3/page.tsx",
@@ -19437,6 +20610,16 @@
       "path": "app/x/help/demos/page.tsx",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "app/x/help/glossary/help-glossary.css",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "app/x/help/glossary/page.tsx",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "app/x/help/pipeline-health/page.tsx",
@@ -19844,6 +21027,16 @@
       "outDegree": 4
     },
     {
+      "path": "app/x/student/[courseId]/results/[sessionId]/page.tsx",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "app/x/student/[courseId]/results/[sessionId]/results.css",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "app/x/student/calls/[callId]/page.tsx",
       "inDegree": 0,
       "outDegree": 0
@@ -19939,6 +21132,11 @@
       "outDegree": 3
     },
     {
+      "path": "app/x/system/pipeline-health/page.tsx",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
       "path": "app/x/taxonomy-graph/page.tsx",
       "inDegree": 0,
       "outDegree": 6
@@ -19957,6 +21155,11 @@
       "path": "app/x/test-harness/test-harness.css",
       "inDegree": 1,
       "outDegree": 0
+    },
+    {
+      "path": "app/x/test/[playbookSlug]/[moduleSlug]/page.tsx",
+      "inDegree": 0,
+      "outDegree": 2
     },
     {
       "path": "app/x/testimony/[specId]/page.tsx",
@@ -20064,13 +21267,18 @@
       "outDegree": 0
     },
     {
+      "path": "components/callers/caller-detail/types.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/callers/roster/CallerRoster.tsx",
       "inDegree": 2,
       "outDegree": 0
     },
     {
       "path": "components/cascade/CascadeInspectorTray.tsx",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -20185,6 +21393,16 @@
     },
     {
       "path": "components/intake/IntakeDoneClient.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/journey-tab/CourseJourneyTab.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/journey-tab/SettingsTabVoiceLens.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -20315,7 +21533,7 @@
     },
     {
       "path": "components/shared/BandingPicker.tsx",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -20331,6 +21549,11 @@
     {
       "path": "components/shared/CallerPicker.tsx",
       "inDegree": 2,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/CascadeValue.tsx",
+      "inDegree": 1,
       "outDegree": 0
     },
     {
@@ -20430,11 +21653,6 @@
     },
     {
       "path": "components/shared/GlobalAssistant.tsx",
-      "inDegree": 1,
-      "outDegree": 0
-    },
-    {
-      "path": "components/shared/HFDrawer.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -20569,6 +21787,11 @@
       "outDegree": 0
     },
     {
+      "path": "components/shared/TierCell.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/shared/TopBar.tsx",
       "inDegree": 1,
       "outDegree": 0
@@ -20590,6 +21813,11 @@
     },
     {
       "path": "components/shared/UserContextMenu.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/VariantPresetPill.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -20629,8 +21857,23 @@
       "outDegree": 0
     },
     {
+      "path": "components/shared/designer-shell/index.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/shared/onboarding-preview.css",
       "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/preview-renderers/_journey-setting-context.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/preview-renderers/index.ts",
+      "inDegree": 2,
       "outDegree": 0
     },
     {
@@ -20675,7 +21918,7 @@
     },
     {
       "path": "components/voice/VoiceConfigSection.tsx",
-      "inDegree": 3,
+      "inDegree": 1,
       "outDegree": 0
     },
     {
@@ -20935,7 +22178,7 @@
     },
     {
       "path": "lib/ai/client.ts",
-      "inDegree": 22,
+      "inDegree": 23,
       "outDegree": 3
     },
     {
@@ -21064,14 +22307,29 @@
       "outDegree": 0
     },
     {
+      "path": "lib/banding/derive-skill-tier-mapping-from-source.ts",
+      "inDegree": 2,
+      "outDegree": 3
+    },
+    {
       "path": "lib/banding/glossary.ts",
       "inDegree": 0,
       "outDegree": 0
     },
     {
       "path": "lib/banding/presets.ts",
-      "inDegree": 0,
+      "inDegree": 2,
       "outDegree": 1
+    },
+    {
+      "path": "lib/banding/skill-tier-deploy-invariant.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/banding/tier-colors.ts",
+      "inDegree": 3,
+      "outDegree": 0
     },
     {
       "path": "lib/bdd/ai-parser.ts",
@@ -21135,7 +22393,7 @@
     },
     {
       "path": "lib/caller-utils.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 0
     },
     {
@@ -21150,8 +22408,8 @@
     },
     {
       "path": "lib/cascade/effective-value.ts",
-      "inDegree": 10,
-      "outDegree": 6
+      "inDegree": 12,
+      "outDegree": 7
     },
     {
       "path": "lib/cascade/knob-keys.ts",
@@ -21160,7 +22418,7 @@
     },
     {
       "path": "lib/cascade/layer-types.ts",
-      "inDegree": 10,
+      "inDegree": 14,
       "outDegree": 0
     },
     {
@@ -21172,6 +22430,11 @@
       "path": "lib/cascade/resolvers/identity-spec.ts",
       "inDegree": 2,
       "outDegree": 4
+    },
+    {
+      "path": "lib/cascade/resolvers/mastery-policy.ts",
+      "inDegree": 3,
+      "outDegree": 3
     },
     {
       "path": "lib/cascade/resolvers/session-flow.ts",
@@ -21192,6 +22455,11 @@
       "path": "lib/cascade/set-at-layer.ts",
       "inDegree": 0,
       "outDegree": 5
+    },
+    {
+      "path": "lib/cascade/use-effective-value.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "lib/cascade/voice-explain.ts",
@@ -21375,7 +22643,7 @@
     },
     {
       "path": "lib/chat/wizard-tool-executor/_shared/apply-student-experience.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 1
     },
     {
@@ -21385,7 +22653,7 @@
     },
     {
       "path": "lib/chat/wizard-tool-executor/_shared/types.ts",
-      "inDegree": 11,
+      "inDegree": 16,
       "outDegree": 0
     },
     {
@@ -21424,6 +22692,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "lib/chat/wizard-tool-executor/tools/create_community.ts",
       "inDegree": 1,
       "outDegree": 2
@@ -21431,6 +22704,56 @@
     {
       "path": "lib/chat/wizard-tool-executor/tools/create_course.ts",
       "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_context.ts",
+      "inDegree": 6,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_enroll.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_graph-guard.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_lesson-plan.ts",
+      "inDegree": 0,
+      "outDegree": 4
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_new-path.ts",
+      "inDegree": 1,
+      "outDegree": 5
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-domain.ts",
+      "inDegree": 2,
+      "outDegree": 3
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_resolve-subject.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/chat/wizard-tool-executor/tools/create_course/_reuse-path.ts",
+      "inDegree": 0,
       "outDegree": 6
     },
     {
@@ -21481,17 +22804,17 @@
     {
       "path": "lib/compose/affecting-keys-domain.ts",
       "inDegree": 1,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/compose/affecting-keys-spec.ts",
       "inDegree": 1,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/compose/affecting-keys.ts",
       "inDegree": 2,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/compose/bump-curriculum-fanout.ts",
@@ -21507,6 +22830,31 @@
       "path": "lib/compose/eager-reprompt-on-bump.ts",
       "inDegree": 3,
       "outDegree": 1
+    },
+    {
+      "path": "lib/compose/index.ts",
+      "inDegree": 7,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/compose/recompose-section.ts",
+      "inDegree": 1,
+      "outDegree": 6
+    },
+    {
+      "path": "lib/compose/section-loaders.ts",
+      "inDegree": 2,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/compose/section-staleness.ts",
+      "inDegree": 3,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/compose/section.ts",
+      "inDegree": 10,
+      "outDegree": 0
     },
     {
       "path": "lib/compose/staleness.ts",
@@ -21555,7 +22903,7 @@
     },
     {
       "path": "lib/content-trust/course-ref-to-assertions.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 1
     },
     {
@@ -21576,7 +22924,7 @@
     {
       "path": "lib/content-trust/extract-curriculum.ts",
       "inDegree": 9,
-      "outDegree": 4
+      "outDegree": 5
     },
     {
       "path": "lib/content-trust/extract-images.ts",
@@ -21759,6 +23107,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/contracts/writer-registry.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
       "path": "lib/course/group-specs.ts",
       "inDegree": 3,
       "outDegree": 0
@@ -21819,13 +23172,18 @@
       "outDegree": 0
     },
     {
+      "path": "lib/curriculum/mark-module-incomplete.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
       "path": "lib/curriculum/mastery-tiers.ts",
       "inDegree": 4,
       "outDegree": 0
     },
     {
       "path": "lib/curriculum/playbook-mastery-config.ts",
-      "inDegree": 1,
+      "inDegree": 3,
       "outDegree": 2
     },
     {
@@ -21864,8 +23222,13 @@
       "outDegree": 1
     },
     {
+      "path": "lib/curriculum/resolve-skill.ts",
+      "inDegree": 7,
+      "outDegree": 1
+    },
+    {
       "path": "lib/curriculum/scratch-mastery.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 1
     },
     {
@@ -21881,7 +23244,7 @@
     {
       "path": "lib/curriculum/track-progress.ts",
       "inDegree": 7,
-      "outDegree": 8
+      "outDegree": 9
     },
     {
       "path": "lib/curriculum/validate-lo-refs.ts",
@@ -22045,7 +23408,7 @@
     },
     {
       "path": "lib/domain/update-domain-config.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 3
     },
     {
@@ -22144,6 +23507,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/goals/append-progress-entry.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
       "path": "lib/goals/extract-goals.ts",
       "inDegree": 1,
       "outDegree": 6
@@ -22195,7 +23563,7 @@
     },
     {
       "path": "lib/goals/strategies/types.ts",
-      "inDegree": 6,
+      "inDegree": 9,
       "outDegree": 0
     },
     {
@@ -22210,8 +23578,8 @@
     },
     {
       "path": "lib/goals/track-progress.ts",
-      "inDegree": 7,
-      "outDegree": 4
+      "inDegree": 14,
+      "outDegree": 6
     },
     {
       "path": "lib/graph/visual-encoding.ts",
@@ -22429,6 +23797,56 @@
       "outDegree": 3
     },
     {
+      "path": "lib/journey/bucket-relations.ts",
+      "inDegree": 0,
+      "outDegree": 4
+    },
+    {
+      "path": "lib/journey/menu-items.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/module-settings-flag.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/journey/section-staleness-bridge.ts",
+      "inDegree": 1,
+      "outDegree": 4
+    },
+    {
+      "path": "lib/journey/setting-contracts.entries.ts",
+      "inDegree": 3,
+      "outDegree": 3
+    },
+    {
+      "path": "lib/journey/setting-contracts.ts",
+      "inDegree": 8,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/setting-groups.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/journey/storage-path-applier.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/use-cascade-edit-field.ts",
+      "inDegree": 0,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/journey/use-glow-state.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "lib/knowledge/assertions.ts",
       "inDegree": 3,
       "outDegree": 2
@@ -22440,7 +23858,7 @@
     },
     {
       "path": "lib/knowledge/domain-sources.ts",
-      "inDegree": 17,
+      "inDegree": 18,
       "outDegree": 2
     },
     {
@@ -22470,7 +23888,7 @@
     },
     {
       "path": "lib/learner-scope.ts",
-      "inDegree": 42,
+      "inDegree": 52,
       "outDegree": 1
     },
     {
@@ -22540,7 +23958,7 @@
     },
     {
       "path": "lib/logger.ts",
-      "inDegree": 23,
+      "inDegree": 31,
       "outDegree": 3
     },
     {
@@ -22605,7 +24023,7 @@
     },
     {
       "path": "lib/metering/instrumented-ai.ts",
-      "inDegree": 34,
+      "inDegree": 35,
       "outDegree": 6
     },
     {
@@ -22670,8 +24088,8 @@
     },
     {
       "path": "lib/ops/update-targets.ts",
-      "inDegree": 1,
-      "outDegree": 1
+      "inDegree": 2,
+      "outDegree": 2
     },
     {
       "path": "lib/page-roles.ts",
@@ -22680,7 +24098,7 @@
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 441,
+      "inDegree": 467,
       "outDegree": 3
     },
     {
@@ -22691,7 +24109,7 @@
     {
       "path": "lib/pipeline/adaptive-loop-invariants.ts",
       "inDegree": 5,
-      "outDegree": 2
+      "outDegree": 3
     },
     {
       "path": "lib/pipeline/aggregate-runner.ts",
@@ -22705,8 +24123,13 @@
     },
     {
       "path": "lib/pipeline/course-style.ts",
-      "inDegree": 4,
+      "inDegree": 8,
       "outDegree": 1
+    },
+    {
+      "path": "lib/pipeline/detect-silent-writers.ts",
+      "inDegree": 2,
+      "outDegree": 3
     },
     {
       "path": "lib/pipeline/event-gate.ts",
@@ -22729,6 +24152,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/pipeline/extract-profile-fields.ts",
+      "inDegree": 0,
+      "outDegree": 7
+    },
+    {
       "path": "lib/pipeline/guardrails.ts",
       "inDegree": 1,
       "outDegree": 4
@@ -22740,11 +24168,16 @@
     },
     {
       "path": "lib/pipeline/logger.ts",
-      "inDegree": 4,
+      "inDegree": 5,
       "outDegree": 0
     },
     {
       "path": "lib/pipeline/memory.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/pipeline/normalize-score-agent-evidence.ts",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -22765,7 +24198,7 @@
     },
     {
       "path": "lib/pipeline/scheduler-decision.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 1
     },
     {
@@ -22799,8 +24232,18 @@
       "outDegree": 1
     },
     {
+      "path": "lib/pipeline/write-count-logger.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/pipeline/writer-completeness-invariant.ts",
+      "inDegree": 1,
+      "outDegree": 3
+    },
+    {
       "path": "lib/playbook/update-playbook-config.ts",
-      "inDegree": 20,
+      "inDegree": 24,
       "outDegree": 5
     },
     {
@@ -22810,7 +24253,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 624,
+      "inDegree": 662,
       "outDegree": 0
     },
     {
@@ -22831,22 +24274,22 @@
     {
       "path": "lib/prompt/composition/CompositionExecutor.ts",
       "inDegree": 1,
-      "outDegree": 36
+      "outDegree": 40
     },
     {
       "path": "lib/prompt/composition/SectionDataLoader.ts",
       "inDegree": 2,
-      "outDegree": 13
+      "outDegree": 15
     },
     {
       "path": "lib/prompt/composition/TransformRegistry.ts",
-      "inDegree": 30,
+      "inDegree": 32,
       "outDegree": 1
     },
     {
       "path": "lib/prompt/composition/buildComposeTrace.ts",
       "inDegree": 1,
-      "outDegree": 3
+      "outDegree": 4
     },
     {
       "path": "lib/prompt/composition/compose-invariants.ts",
@@ -22875,7 +24318,7 @@
     },
     {
       "path": "lib/prompt/composition/index.ts",
-      "inDegree": 10,
+      "inDegree": 11,
       "outDegree": 0
     },
     {
@@ -22889,6 +24332,11 @@
       "outDegree": 5
     },
     {
+      "path": "lib/prompt/composition/loaders/conversationArtifacts.ts",
+      "inDegree": 3,
+      "outDegree": 0
+    },
+    {
       "path": "lib/prompt/composition/loaders/courseComplete.ts",
       "inDegree": 1,
       "outDegree": 3
@@ -22897,6 +24345,11 @@
       "path": "lib/prompt/composition/loaders/interleaveReview.ts",
       "inDegree": 2,
       "outDegree": 1
+    },
+    {
+      "path": "lib/prompt/composition/loaders/memoryDeltas.ts",
+      "inDegree": 3,
+      "outDegree": 0
     },
     {
       "path": "lib/prompt/composition/loaders/mockDiagnostic.ts",
@@ -22920,7 +24373,7 @@
     },
     {
       "path": "lib/prompt/composition/renderPromptSummary.ts",
-      "inDegree": 12,
+      "inDegree": 13,
       "outDegree": 3
     },
     {
@@ -22936,6 +24389,11 @@
     {
       "path": "lib/prompt/composition/transforms/audience.ts",
       "inDegree": 11,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/prompt/composition/transforms/conversationArtifacts.ts",
+      "inDegree": 1,
       "outDegree": 2
     },
     {
@@ -22956,7 +24414,7 @@
     {
       "path": "lib/prompt/composition/transforms/instructions.ts",
       "inDegree": 2,
-      "outDegree": 6
+      "outDegree": 7
     },
     {
       "path": "lib/prompt/composition/transforms/interleaveReview.ts",
@@ -22965,6 +24423,11 @@
     },
     {
       "path": "lib/prompt/composition/transforms/memories.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/prompt/composition/transforms/memoryDeltas.ts",
       "inDegree": 1,
       "outDegree": 2
     },
@@ -22986,7 +24449,7 @@
     {
       "path": "lib/prompt/composition/transforms/offboarding.ts",
       "inDegree": 1,
-      "outDegree": 4
+      "outDegree": 5
     },
     {
       "path": "lib/prompt/composition/transforms/pedagogy-mode.ts",
@@ -23076,7 +24539,7 @@
     {
       "path": "lib/prompt/composition/types.ts",
       "inDegree": 43,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/prompts/interpolate.ts",
@@ -23104,6 +24567,16 @@
       "outDegree": 0
     },
     {
+      "path": "lib/rbac/policies/adaptations.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/rbac/visibility.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
       "path": "lib/recompose/fanout-class-keys.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -23120,7 +24593,7 @@
     },
     {
       "path": "lib/roles.ts",
-      "inDegree": 13,
+      "inDegree": 14,
       "outDegree": 0
     },
     {
@@ -23161,6 +24634,11 @@
     {
       "path": "lib/settings/resolver.ts",
       "inDegree": 1,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/settings/voice-setting-contracts.ts",
+      "inDegree": 3,
       "outDegree": 1
     },
     {
@@ -23285,8 +24763,13 @@
     },
     {
       "path": "lib/system-settings.ts",
-      "inDegree": 51,
+      "inDegree": 52,
       "outDegree": 3
+    },
+    {
+      "path": "lib/tab-layout.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "lib/tasks/constants.ts",
@@ -23300,7 +24783,7 @@
     },
     {
       "path": "lib/terminology/types.ts",
-      "inDegree": 9,
+      "inDegree": 10,
       "outDegree": 0
     },
     {
@@ -23315,7 +24798,7 @@
     },
     {
       "path": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 2
     },
     {
@@ -23345,7 +24828,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 106,
+      "inDegree": 115,
       "outDegree": 0
     },
     {
@@ -23394,6 +24877,11 @@
       "outDegree": 7
     },
     {
+      "path": "lib/voice/cue-scheduler.ts",
+      "inDegree": 0,
+      "outDegree": 4
+    },
+    {
       "path": "lib/voice/diag.ts",
       "inDegree": 3,
       "outDegree": 1
@@ -23401,7 +24889,7 @@
     {
       "path": "lib/voice/end-session.ts",
       "inDegree": 1,
-      "outDegree": 3
+      "outDegree": 9
     },
     {
       "path": "lib/voice/end-source.ts",
@@ -23460,7 +24948,7 @@
     },
     {
       "path": "lib/voice/provider-factory.ts",
-      "inDegree": 14,
+      "inDegree": 15,
       "outDegree": 3
     },
     {
@@ -23481,7 +24969,7 @@
     {
       "path": "lib/voice/providers/vapi/index.ts",
       "inDegree": 2,
-      "outDegree": 3
+      "outDegree": 4
     },
     {
       "path": "lib/voice/reconcile-missing-bootstrap.ts",
@@ -23549,6 +25037,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/voice/talk-time-stats.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
       "path": "lib/voice/telemetry.ts",
       "inDegree": 7,
       "outDegree": 1
@@ -23565,7 +25058,7 @@
     },
     {
       "path": "lib/voice/types.ts",
-      "inDegree": 13,
+      "inDegree": 14,
       "outDegree": 0
     },
     {
@@ -23650,7 +25143,7 @@
     },
     {
       "path": "lib/wizard/apply-projection.ts",
-      "inDegree": 2,
+      "inDegree": 3,
       "outDegree": 5
     },
     {
@@ -23700,7 +25193,7 @@
     },
     {
       "path": "lib/wizard/project-course-reference.ts",
-      "inDegree": 6,
+      "inDegree": 9,
       "outDegree": 5
     },
     {
@@ -23710,8 +25203,8 @@
     },
     {
       "path": "lib/wizard/run-projection-for-playbook.ts",
-      "inDegree": 1,
-      "outDegree": 6
+      "inDegree": 2,
+      "outDegree": 9
     },
     {
       "path": "lib/wizard/sync-authored-modules-to-curriculum.ts",
@@ -23832,6 +25325,11 @@
       "path": "scripts/backfill-cio-cto-playbook-configs.ts",
       "inDegree": 0,
       "outDegree": 1
+    },
+    {
+      "path": "scripts/backfill-cto-projection.ts",
+      "inDegree": 0,
+      "outDegree": 3
     },
     {
       "path": "scripts/backfill-curriculum-anchors.ts",
@@ -24004,9 +25502,19 @@
       "outDegree": 1
     },
     {
+      "path": "scripts/check-skill-tier-deploy-readiness.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "scripts/check-uplift-visual.ts",
       "inDegree": 0,
       "outDegree": 0
+    },
+    {
+      "path": "scripts/check-writer-registry.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "scripts/cleanup-orphan-parameters.ts",
@@ -24066,7 +25574,7 @@
     {
       "path": "scripts/fix-cio-cto-playbooks.ts",
       "inDegree": 0,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "scripts/fix-cio-cto-slice-b.ts",
@@ -24094,12 +25602,22 @@
       "outDegree": 0
     },
     {
+      "path": "scripts/generate-writer-coverage-doc.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "scripts/migrate-caller-attribute-lo-mastery-keys.ts",
       "inDegree": 0,
       "outDegree": 1
     },
     {
       "path": "scripts/migrate-caller-personality.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
+      "path": "scripts/migrate-ielts-playbook-mapping.ts",
       "inDegree": 0,
       "outDegree": 0
     },
@@ -24199,6 +25717,11 @@
       "outDegree": 3
     },
     {
+      "path": "scripts/reseed-skill-measure-contract-generic.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
       "path": "scripts/seed-ielts-prosody.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -24207,6 +25730,16 @@
       "path": "scripts/seed-intake-specs.ts",
       "inDegree": 0,
       "outDegree": 0
+    },
+    {
+      "path": "scripts/seed-source-derived-skill-banding.ts",
+      "inDegree": 0,
+      "outDegree": 5
+    },
+    {
+      "path": "scripts/seed-synthetic-cohort.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "scripts/seed-system-behavior-defaults.ts",
@@ -24347,17 +25880,17 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 624,
+      "inDegree": 662,
       "outDegree": 0
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 441,
+      "inDegree": 467,
       "outDegree": 3
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 106,
+      "inDegree": 115,
       "outDegree": 0
     },
     {
@@ -24372,33 +25905,38 @@
     },
     {
       "path": "lib/system-settings.ts",
-      "inDegree": 51,
+      "inDegree": 52,
       "outDegree": 3
     },
     {
       "path": "app/api/calls/[callId]/pipeline/route.ts",
       "inDegree": 0,
-      "outDegree": 51
+      "outDegree": 54
+    },
+    {
+      "path": "lib/learner-scope.ts",
+      "inDegree": 52,
+      "outDegree": 1
     },
     {
       "path": "app/x/courses/[courseId]/page.tsx",
       "inDegree": 0,
-      "outDegree": 43
-    },
-    {
-      "path": "lib/learner-scope.ts",
-      "inDegree": 42,
-      "outDegree": 1
+      "outDegree": 45
     },
     {
       "path": "lib/prompt/composition/types.ts",
       "inDegree": 43,
-      "outDegree": 0
+      "outDegree": 1
     },
     {
       "path": "lib/metering/instrumented-ai.ts",
-      "inDegree": 34,
+      "inDegree": 35,
       "outDegree": 6
+    },
+    {
+      "path": "lib/prompt/composition/CompositionExecutor.ts",
+      "inDegree": 1,
+      "outDegree": 40
     },
     {
       "path": "app/api/chat/route.ts",
@@ -24406,9 +25944,14 @@
       "outDegree": 38
     },
     {
-      "path": "lib/prompt/composition/CompositionExecutor.ts",
-      "inDegree": 1,
-      "outDegree": 36
+      "path": "lib/logger.ts",
+      "inDegree": 31,
+      "outDegree": 3
+    },
+    {
+      "path": "lib/prompt/composition/TransformRegistry.ts",
+      "inDegree": 32,
+      "outDegree": 1
     },
     {
       "path": "lib/voice/route-handlers.ts",
@@ -24416,9 +25959,9 @@
       "outDegree": 27
     },
     {
-      "path": "lib/prompt/composition/TransformRegistry.ts",
-      "inDegree": 30,
-      "outDegree": 1
+      "path": "lib/playbook/update-playbook-config.ts",
+      "inDegree": 24,
+      "outDegree": 5
     },
     {
       "path": "app/api/content-sources/[sourceId]/extract/route.ts",
@@ -24434,16 +25977,6 @@
       "path": "components/shared/FancySelect.tsx",
       "inDegree": 26,
       "outDegree": 0
-    },
-    {
-      "path": "lib/enrollment/index.ts",
-      "inDegree": 24,
-      "outDegree": 2
-    },
-    {
-      "path": "lib/logger.ts",
-      "inDegree": 23,
-      "outDegree": 3
     }
   ]
 }

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-12T17:02:55.431Z",
+  "generatedAt": "2026-06-17T08:48:53.314Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,13 +1,13 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-12T17:02:54.055Z",
+  "generatedAt": "2026-06-17T08:48:51.188Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",
-  "modelCount": 110,
+  "modelCount": 112,
   "ratifiedCount": 8,
   "summary": {
-    "tenant-scoped": 98,
+    "tenant-scoped": 100,
     "global": 4,
     "join": 8,
     "alreadyTenantAware": 1,
@@ -736,8 +736,8 @@
     },
     {
       "name": "Call",
-      "fieldCount": 44,
-      "relationCount": 18,
+      "fieldCount": 45,
+      "relationCount": 19,
       "meaningfulScalarCount": 16,
       "scalarFields": [
         "id",
@@ -839,6 +839,10 @@
         {
           "field": "messages",
           "target": "CallMessage"
+        },
+        {
+          "field": "cueScheduleEntries",
+          "target": "CueScheduleEntry"
         }
       ],
       "blockAttrs": [
@@ -1330,9 +1334,9 @@
     },
     {
       "name": "CallerModuleProgress",
-      "fieldCount": 14,
+      "fieldCount": 16,
       "relationCount": 2,
-      "meaningfulScalarCount": 6,
+      "meaningfulScalarCount": 8,
       "scalarFields": [
         "id",
         "callerId",
@@ -1343,6 +1347,8 @@
         "completedAt",
         "lastCallId",
         "callCount",
+        "incompleteAttempts",
+        "orientationShown",
         "loScoresJson",
         "createdAt",
         "updatedAt"
@@ -1577,15 +1583,16 @@
     },
     {
       "name": "CallScore",
-      "fieldCount": 20,
+      "fieldCount": 21,
       "relationCount": 5,
-      "meaningfulScalarCount": 8,
+      "meaningfulScalarCount": 9,
       "scalarFields": [
         "id",
         "callId",
         "callerId",
         "parameterId",
         "moduleId",
+        "segmentKey",
         "score",
         "confidence",
         "evidence",
@@ -2270,6 +2277,41 @@
       "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
     },
     {
+      "name": "CueScheduleEntry",
+      "fieldCount": 12,
+      "relationCount": 1,
+      "meaningfulScalarCount": 6,
+      "scalarFields": [
+        "id",
+        "externalCallId",
+        "callId",
+        "scheduledFor",
+        "content",
+        "options",
+        "firedAt",
+        "cancelledAt",
+        "status",
+        "traceId",
+        "createdAt"
+      ],
+      "relations": [
+        {
+          "field": "call",
+          "target": "Call"
+        }
+      ],
+      "blockAttrs": [
+        "@@index",
+        "@@index",
+        "@@index"
+      ],
+      "hasTenantHint": false,
+      "proposedClass": "tenant-scoped",
+      "confidence": "low",
+      "reviewed": false,
+      "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
+    },
+    {
       "name": "Curriculum",
       "fieldCount": 32,
       "relationCount": 4,
@@ -2337,9 +2379,9 @@
     },
     {
       "name": "CurriculumModule",
-      "fieldCount": 25,
+      "fieldCount": 26,
       "relationCount": 8,
-      "meaningfulScalarCount": 12,
+      "meaningfulScalarCount": 13,
       "scalarFields": [
         "id",
         "curriculumId",
@@ -2354,6 +2396,7 @@
         "assessmentCriteria",
         "terminal",
         "coversModules",
+        "segmentCues",
         "isActive",
         "createdAt",
         "updatedAt",
@@ -3601,8 +3644,8 @@
     },
     {
       "name": "Playbook",
-      "fieldCount": 38,
-      "relationCount": 17,
+      "fieldCount": 39,
+      "relationCount": 18,
       "meaningfulScalarCount": 15,
       "scalarFields": [
         "id",
@@ -3695,6 +3738,10 @@
         {
           "field": "sessions",
           "target": "Session"
+        },
+        {
+          "field": "sectionStaleness",
+          "target": "PlaybookSectionStaleness"
         }
       ],
       "blockAttrs": [
@@ -3860,6 +3907,37 @@
         "@@index",
         "@@index",
         "@@index",
+        "@@index",
+        "@@index"
+      ],
+      "hasTenantHint": false,
+      "proposedClass": "tenant-scoped",
+      "confidence": "low",
+      "reviewed": false,
+      "notes": "Default — domain data; needs a tenantId in multi-tenancy unless reachable only via a scoped parent."
+    },
+    {
+      "name": "PlaybookSectionStaleness",
+      "fieldCount": 8,
+      "relationCount": 1,
+      "meaningfulScalarCount": 3,
+      "scalarFields": [
+        "id",
+        "playbookId",
+        "sectionKey",
+        "sectionHash",
+        "staleSince",
+        "createdAt",
+        "updatedAt"
+      ],
+      "relations": [
+        {
+          "field": "playbook",
+          "target": "Playbook"
+        }
+      ],
+      "blockAttrs": [
+        "@@unique",
         "@@index",
         "@@index"
       ],
@@ -4292,9 +4370,9 @@
     },
     {
       "name": "Session",
-      "fieldCount": 27,
+      "fieldCount": 28,
       "relationCount": 8,
-      "meaningfulScalarCount": 11,
+      "meaningfulScalarCount": 12,
       "scalarFields": [
         "id",
         "callerId",
@@ -4307,6 +4385,7 @@
         "voiceProvider",
         "intentId",
         "voiceConfigSnapshot",
+        "metadata",
         "startedAt",
         "endedAt",
         "status",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-12T17:02:55.838Z",
+  "generatedAt": "2026-06-17T08:48:53.940Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,16 +1,16 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-12T17:02:54.510Z",
+  "generatedAt": "2026-06-17T08:48:51.882Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
-    "routeCount": 513,
+    "routeCount": 537,
     "byAuthLevel": {
-      "VIEWER": 113,
+      "VIEWER": 123,
       "ADMIN": 81,
       "SUPERADMIN": 9,
       "VIEWER+ADMIN": 5,
-      "OPERATOR": 130,
+      "OPERATOR": 144,
       "OPERATOR+VIEWER": 8,
       "VIEWER+OPERATOR": 67,
       "auth-gate(non-role)": 53,
@@ -25,7 +25,7 @@
       "VIEWER+TESTER": 3
     },
     "noAuthGate": 30,
-    "possiblyUnscoped": 109,
+    "possiblyUnscoped": 115,
     "internalSecret": 8
   },
   "routes": [
@@ -1268,6 +1268,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/adaptations",
+      "file": "apps/admin/app/api/callers/[callerId]/adaptations/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/aggregate",
       "file": "apps/admin/app/api/callers/[callerId]/aggregate/route.ts",
       "methods": [
@@ -1292,6 +1312,26 @@
     {
       "route": "/api/callers/[callerId]/artifacts",
       "file": "apps/admin/app/api/callers/[callerId]/artifacts/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/attainment",
+      "file": "apps/admin/app/api/callers/[callerId]/attainment/route.ts",
       "methods": [
         "GET"
       ],
@@ -1560,6 +1600,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/insights",
+      "file": "apps/admin/app/api/callers/[callerId]/insights/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/journey-progress",
       "file": "apps/admin/app/api/callers/[callerId]/journey-progress/route.ts",
       "methods": [
@@ -1620,6 +1680,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/lo-mastery",
+      "file": "apps/admin/app/api/callers/[callerId]/lo-mastery/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/lo-progress",
       "file": "apps/admin/app/api/callers/[callerId]/lo-progress/route.ts",
       "methods": [
@@ -1660,8 +1740,48 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/memories",
+      "file": "apps/admin/app/api/callers/[callerId]/memories/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/module-progress",
       "file": "apps/admin/app/api/callers/[callerId]/module-progress/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/personality",
+      "file": "apps/admin/app/api/callers/[callerId]/personality/route.ts",
       "methods": [
         "GET"
       ],
@@ -1762,6 +1882,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/callers/[callerId]/scheduler-decision",
+      "file": "apps/admin/app/api/callers/[callerId]/scheduler-decision/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/callers/[callerId]/session-flow-progress",
       "file": "apps/admin/app/api/callers/[callerId]/session-flow-progress/route.ts",
       "methods": [
@@ -1778,6 +1918,26 @@
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/skills-evidence",
+      "file": "apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
         "noAuthGate": false
       },
       "reviewed": false
@@ -1829,6 +1989,26 @@
         "GET"
       ],
       "authLevels": [],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/callers/[callerId]/sub-skills",
+      "file": "apps/admin/app/api/callers/[callerId]/sub-skills/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
       "hasAuthGate": true,
       "tenantSignals": {
         "acceptsCallerIdParam": true,
@@ -3485,6 +3665,46 @@
       "reviewed": false
     },
     {
+      "route": "/api/courses/[courseId]/content-trust",
+      "file": "apps/admin/app/api/courses/[courseId]/content-trust/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/conversation-artifacts-preview",
+      "file": "apps/admin/app/api/courses/[courseId]/conversation-artifacts-preview/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/courses/[courseId]/course-instructions",
       "file": "apps/admin/app/api/courses/[courseId]/course-instructions/route.ts",
       "methods": [
@@ -3691,6 +3911,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/courses/[courseId]/journey-setting",
+      "file": "apps/admin/app/api/courses/[courseId]/journey-setting/route.ts",
+      "methods": [
+        "PATCH"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/courses/[courseId]/learners/ensure-cohort",
       "file": "apps/admin/app/api/courses/[courseId]/learners/ensure-cohort/route.ts",
       "methods": [
@@ -3766,6 +4006,26 @@
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/memory-deltas-preview",
+      "file": "apps/admin/app/api/courses/[courseId]/memory-deltas-preview/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
         "noAuthGate": false
       },
       "reviewed": false
@@ -3893,6 +4153,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/courses/[courseId]/recompose-section",
+      "file": "apps/admin/app/api/courses/[courseId]/recompose-section/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/courses/[courseId]/reconcile-mcqs",
       "file": "apps/admin/app/api/courses/[courseId]/reconcile-mcqs/route.ts",
       "methods": [
@@ -3925,6 +4205,46 @@
       "tenantSignals": {
         "acceptsCallerIdParam": false,
         "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/reproject-skills",
+      "file": "apps/admin/app/api/courses/[courseId]/reproject-skills/route.ts",
+      "methods": [
+        "POST"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/section-staleness",
+      "file": "apps/admin/app/api/courses/[courseId]/section-staleness/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": true,
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": false,
@@ -4001,6 +4321,126 @@
       ],
       "authLevels": [
         "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-cohort-cell",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-cohort-cell/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-cohort-heatmap",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-cohort-heatmap/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-evidence",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-evidence/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-framework",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-framework/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-rubric-calibration",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-rubric-calibration/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/skills-source-lineage",
+      "file": "apps/admin/app/api/courses/[courseId]/skills-source-lineage/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
       ],
       "hasAuthGate": true,
       "tenantSignals": {
@@ -8415,6 +8855,26 @@
       "reviewed": false
     },
     {
+      "route": "/api/student/[courseId]/results/[sessionId]",
+      "file": "apps/admin/app/api/student/[courseId]/results/[sessionId]/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "VIEWER"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": true,
+        "usesScopeHelper": true,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
       "route": "/api/student/artifacts/mark-read",
       "file": "apps/admin/app/api/student/artifacts/mark-read/route.ts",
       "methods": [
@@ -9099,6 +9559,26 @@
       ],
       "authLevels": [
         "SUPERADMIN"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": false,
+        "possiblyUnscoped": false,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/system/pipeline-health",
+      "file": "apps/admin/app/api/system/pipeline-health/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
       ],
       "hasAuthGate": true,
       "tenantSignals": {


### PR DESCRIPTION
## Summary

Two small structural improvements extracted from the parked PR #1783 — the parts that don't require modifying `.github/workflows/*.yml` (which trips GitHub's workflow-approval gate and was preventing CI from firing on #1783).

## Changes

- **`.githooks/pre-commit` §6 — all 5 KB generators wired.** Previously only `model-map` + `route-inventory` regenerated on relevant input changes. `coupling-graph`, `demo-knobs`, and `operator-surfaces` silently drifted. New triggers fix that.
- **`docs/kb/README.md` — Lattice 5-pillar section.** Names the umbrella + the 5 pillars (Chain Contracts / Guards / Cascade / Rules / Coverage). Coverage was added by #1780 post-Slice-C.
- **`docs/kb/generated/` — full refresh.** Catches up the catalogue against current `origin/main`.

## What's NOT in this PR (parked)

- The `kb-integrity` CI job split (was in #1783) — needs the workflow-approval gate cleared before it can ship.
- `npm audit fix` + ratchet baseline update — separate concern, fold into a focused deps PR.
- The `prisma/backfill-modules.ts` allow-list entry — may or may not still be needed depending on whether the offence still exists on current main; check separately.

## Verified by

- `bash -n .githooks/pre-commit` → syntax clean [verified]
- All 5 KB generators run individually → exit 0 [verified]
- `npm run kb:fresh` against current `origin/main` → `✔ KB generated facts fresh` [verified]
- The Lattice memory files cited (`feedback_lattice_5th_pillar_coverage.md`) exist [verified]

## Test plan

- [ ] CI fires for this PR (proves it's not blocked by the workflow-gate issue affecting #1783)
- [ ] Next route.ts change in any future PR triggers both `route-inventory` AND `operator-surfaces` regen via the hook
- [ ] Next `apps/admin/*.ts(x)` change triggers `coupling-graph` regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)