### PR TITLE
fix(types): revert AuthoredModule.prerequisites to string[] (#1786 half-rolled-back)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 57,
+  "tsc_errors": 49,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -883,27 +883,15 @@ export interface AuthoredModule {
   outcomesPrimary: string[];
   /**
    * Sibling modules that should be completed before this one is offered.
+   * Slugs only — matches the DB column shape (`CurriculumModule.prerequisites: String[]`).
    *
-   * Two forms accepted (#1746 — Theme 5 widened shape):
-   *
-   * - **String** (legacy): just the sibling module id/slug. Treated as
-   *   "needs at least one COMPLETED attempt on that module".
-   * - **`{moduleId, minCompletions}`** (count-based): require ≥ N
-   *   COMPLETED attempts on the sibling. e.g. IELTS Mock needs
-   *   `{moduleId: "part1", minCompletions: 2}` ("2× Part 1 done").
-   *
-   * Reader (`lib/curriculum/check-module-unlock.ts::isModuleUnlocked`)
-   * coerces both forms. Existing single-attempt prereqs migrate
-   * implicitly — no schema change needed; the JSON shape widens by
-   * union.
-   *
-   * STUDENT-role learners are blocked when prereqs are unmet (LOCKED
-   * status). OPERATOR+ bypasses the gate (testers must not be locked
-   * out — see role-bypass contract in `isModuleUnlocked`).
+   * Picker behaviour is advisory in continuous mode and gated in structured
+   * mode (`Playbook.config.strictPrerequisites`). STUDENT-role learners are
+   * blocked when an entry hasn't been completed; OPERATOR+ bypasses.
    *
    * Empty array when no prerequisites.
    */
-  prerequisites: Array<string | { moduleId: string; minCompletions: number }>;
+  prerequisites: string[];
   /** Ordinal position in a structured course's lesson plan. Optional in continuous mode. */
   position?: number;
   /**


### PR DESCRIPTION
## Summary

#1786 widened `AuthoredModule.prerequisites` to `Array<string | {moduleId, minCompletions}>` for IELTS Theme 5 count-based prereqs. Its sibling reader `lib/curriculum/check-module-unlock.ts::isModuleUnlocked` coerced both forms. #1768 then deleted that reader (and its tests) in an unrelated sweep, leaving the type widening behind with no consumer that understands the object form.

Result: 8 tsc errors across 4 consumer sites (`AuthoredModulesPanel`, `LearnerModulePicker` ×3, `detect-authored-modules`) and 2 writer sites (`sync-authored-modules-to-curriculum` ×2) — every site treats `prerequisites` as `string[]` because that's what the DB column actually is and what every reader was designed for.

Per "no half-finished implementations" — revert the type widening so the declared shape matches the DB and the consumers. If Theme 5 gets revived, restore #1786's reader and re-widen as a coherent pair.

Handoff item: `docs/draft-issues/handoff-journey-followups-2026-06-17.md` §3 — the "Wizard sync + AuthoredModulesPanel + LearnerModulePicker drift" cluster.

## Verified by

- `npx tsc --noEmit` — errors 57 → 49 (-8, the union-related sites) [verified].
- `npx vitest run` on the 5 affected suites (`recommend-next-module`, `working-set-selector`, `module-flags-defaults`, `is-course-complete`, `import-modules-prereqs`) — 66/66 pass [verified].
- `grep -rn "minCompletions" apps/admin --include="*.ts" --include="*.tsx"` — 0 hits in code repo-wide after the change. Only one doc reference remains (`docs/draft-issues/ielts-pre-voice-gap-analysis.md`) which proposes the widening as a future theme [inverse-probe: alternate name forms searched — `min_completions`, `minRequired`, `minCount` — all 0 hits].
- DB schema `prisma/schema.prisma:2817` confirms canonical column is `String[]` — DB never accepted the object form [verified].
- Lattice survey: not in any chain contract; not a guarded surface; no Cascade key; DB convention is `String[]` — convention conflict resolved by matching DB.

## Test plan

- [x] tsc count drops by 8
- [x] Prereq-touching vitest banks green (66/66)
- [x] No producer of the object form exists in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)