### PR TITLE
fix(tests): use NextRequest in results-route test fixtures

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 48,
+  "tsc_errors": 41,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/tests/api/student/results/results-route.test.ts
+++ b/apps/admin/tests/api/student/results/results-route.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
 
 const { mockPrisma, mockStudentAllowed, mockMapping } = vi.hoisted(() => ({
   mockPrisma: {
@@ -76,7 +77,7 @@ describe("GET /api/student/[courseId]/results/[sessionId]", () => {
     mockStudentAllowed.mockReturnValue(false);
     mockPrisma.session.findUnique.mockResolvedValue(makeSession());
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x/results"), PARAMS);
     expect(res.status).toBe(403);
     expect(mockPrisma.callScore.findMany).not.toHaveBeenCalled();
   });
@@ -84,14 +85,14 @@ describe("GET /api/student/[courseId]/results/[sessionId]", () => {
   it("returns 404 when session not found", async () => {
     mockPrisma.session.findUnique.mockResolvedValue(null);
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x/results"), PARAMS);
     expect(res.status).toBe(404);
   });
 
   it("returns 403 when session.playbookId !== courseId path param", async () => {
     mockPrisma.session.findUnique.mockResolvedValue(makeSession({ playbookId: "other-course" }));
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x/results"), PARAMS);
     expect(res.status).toBe(403);
     expect(mockPrisma.callScore.findMany).not.toHaveBeenCalled();
   });
@@ -100,7 +101,7 @@ describe("GET /api/student/[courseId]/results/[sessionId]", () => {
     mockPrisma.session.findUnique.mockResolvedValue(makeSession({ status: "STARTED", endedAt: null }));
     mockPrisma.callScore.findMany.mockResolvedValue([]);
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x/results"), PARAMS);
     const body = (await res.json()) as { ok: true; processing: boolean };
     expect(res.status).toBe(200);
     expect(body.processing).toBe(true);
@@ -110,7 +111,7 @@ describe("GET /api/student/[courseId]/results/[sessionId]", () => {
     mockPrisma.session.findUnique.mockResolvedValue(makeSession({ status: "COMPLETED" }));
     mockPrisma.callScore.findMany.mockResolvedValue([]);
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x/results"), PARAMS);
     const body = (await res.json()) as { ok: true; processing: boolean };
     expect(body.processing).toBe(true);
   });
@@ -136,7 +137,7 @@ describe("GET /api/student/[courseId]/results/[sessionId]", () => {
     mockPrisma.callScore.findMany.mockResolvedValue(rows);
 
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x/results"), PARAMS);
     const body = (await res.json()) as {
       ok: true;
       processing: boolean;
@@ -167,7 +168,7 @@ describe("GET /api/student/[courseId]/results/[sessionId]", () => {
       { parameterId: "fc", segmentKey: "part1", score: 0.5, parameter: { name: "Fluency" } },
     ]);
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x/results"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x/results"), PARAMS);
     const body = (await res.json()) as {
       overallBand: number;
       overallBandSource: "metadata" | "computed" | null;


### PR DESCRIPTION
## Summary

The GET handler at `app/api/student/[courseId]/results/[sessionId]/route.ts:89` takes `NextRequest` as its first formal param, but `tests/api/student/results/results-route.test.ts` was passing `new Request(...)` for all 7 cases. TS2345 because `Request` is not assignable to `NextRequest`.

Imports `NextRequest` from `next/server` and replaces the 7 call sites with `new NextRequest(...)`. The handler ignores `_req` entirely (underscore-prefixed), so this is a pure type-level fix — no runtime behaviour change.

Handoff item: `docs/draft-issues/handoff-journey-followups-2026-06-17.md` §3 — the "Request vs NextRequest test fixtures" cluster.

## Verified by

- `npx tsc --noEmit` — errors 57 → 50 (-7: all the call sites at lines 79/87/94/103/113/139/170) [verified].
- `npx vitest run tests/api/student/results/results-route.test.ts` — 7/7 pass [verified].
- Pattern matches existing `new NextRequest(...)` usage in `tests/lib/intake-session-cookie.test.ts`, `tests/wizard/picker-dedup-harness.test.ts`, `tests/integration/journey/session-flow-routes.integration.test.ts` [verified — `grep -rn "new NextRequest" tests/`].

## Test plan

- [x] tsc count drops by 7
- [x] Test bank green (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)