### PR TITLE
fix(journey): clarify tolRetrievalCadence helpText — override not multiplier

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -1335,7 +1335,7 @@ const G7_TOL_RETRIEVAL_CADENCE: JourneySettingContract = {
   group: "G7",
   educatorLabel: "Retrieval cadence override",
   helpText:
-    "Multiplier on the SchedulerPolicy retrieval cadence. Lower = faster spaced-repetition cycle. Per-learner override intentionally NOT supported (would defeat interleaving). (#598)",
+    "Absolute override (positive integer) for the SchedulerPolicy retrieval cadence — replaces the preset value, not a multiplier. Cadence = how many calls between retrieval sessions: 1 retrieves every call, 4 retrieves every 4th. Lower = faster spaced-repetition cycle. Typical range 1–5 (presets pick 2–4). Per-learner override intentionally NOT supported (would defeat interleaving). (#598)",
   storagePath: "config.tolerances.retrievalCadenceOverride",
   control: "number",
   cascadeSources: [],


### PR DESCRIPTION
## Summary

Investigation result from handoff item #4: the TL agent suggested swapping `control: "number"` to `"slider"` if the field is bounded. Reader audit at `lib/pipeline/scheduler-presets.ts:283-293` shows:

1. The override **REPLACES** the preset's retrievalCadence — it is NOT a multiplier (previous helpText said "multiplier on the SchedulerPolicy retrieval cadence").
2. The validation gate is `typeof === "number" && Number.isFinite && > 0` — any positive integer accepted. No upper bound.
3. Built-in presets use 1, 2, 2, 2, 3, 4, **999** — the 999 is a debug sentinel ("never retrieve"). A slider cannot represent both human-typical (1–5) AND the 999 sentinel.

**Decision: keep `control: "number"`.** Slider is wrong here. Update the helpText to:
- Call it an "absolute override", not a "multiplier"
- Explain cadence semantics ("1 retrieves every call, 4 retrieves every 4th")
- State typical range (1–5; presets pick 2–4)

Handoff item: `docs/draft-issues/handoff-journey-followups-2026-06-17.md` §4.

## Verified by

- Reader source `lib/pipeline/scheduler-presets.ts:290-291` — `return { ...basePreset, retrievalCadence: Math.floor(override) }` → REPLACE not multiply [verified].
- Reader's only validation: positive finite number, no max clamp [verified].
- Presets `lib/pipeline/scheduler-presets.ts:95-214` span 1–999 — `slider` cannot represent 999 debug sentinel [verified].
- `npx vitest run tests/lib/journey/registry-completeness.test.ts tests/lib/journey/registry-options-coverage.test.ts` — 21/21 pass.

## Test plan

- [x] HelpText accuracy verified against reader source
- [x] Control type decision justified
- [x] Registry coverage tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)