### PR TITLE
feat(voice): #1742 follow-on — cue-scheduler tick runner

### DIFF
--- a/apps/admin/instrumentation.ts
+++ b/apps/admin/instrumentation.ts
@@ -1,18 +1,24 @@
 /**
  * Next.js instrumentation hook — runs once at server startup.
  *
- * Today this fires the skill-tier deploy-readiness invariant (#1657) so a
- * deploy that flipped the SKILL_MEASURE_V1 contract to Generic WITHOUT
- * also running `scripts/migrate-ielts-playbook-mapping.ts --execute`
- * produces an immediately visible ERROR log line — operator can spot it
- * in Cloud Run logs before learners see degraded scoring.
+ * Today this fires:
  *
- * The invariant is read-only — it never mutates state.
+ *   1. The skill-tier deploy-readiness invariant (#1657). Read-only —
+ *      surfaces an immediately visible ERROR log line if a deploy
+ *      flipped SKILL_MEASURE_V1 to Generic without running
+ *      `scripts/migrate-ielts-playbook-mapping.ts --execute`.
+ *   2. The cue-scheduler tick runner (#1742 follow-on). Drains
+ *      `CueScheduleEntry` every 100ms so server-initiated speech
+ *      (`VoiceProvider.sayMessage`) fires at the scheduled time.
+ *      Idempotent + HMR-safe.
+ *
+ * Skipped when `NEXT_RUNTIME !== "nodejs"` (edge runtime) and when
+ * `NODE_ENV === "test"` (the tick runner is unit-tested via direct
+ * `tick()` calls — no real timer spins up in vitest).
  *
  * Failures inside `register()` are swallowed to avoid blocking server
- * startup on a Prisma blip; the operator-facing preflight script
- * (`scripts/check-skill-tier-deploy-readiness.ts`) is the canonical
- * gate.
+ * startup on a Prisma blip; the operator-facing preflight scripts are
+ * the canonical gates.
  */
 
 export async function register(): Promise<void> {
@@ -26,6 +32,22 @@ export async function register(): Promise<void> {
   } catch (err) {
     console.warn(
       "[skill-tier][deploy-invariant] startup check failed (non-fatal):",
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  // #1742 follow-on — cue-scheduler tick runner. Skip in test
+  // environments so vitest doesn't spawn a real timer; tests drive
+  // `tick()` directly via the runner's exported entry point.
+  if (process.env.NODE_ENV === "test") return;
+  try {
+    const { startCueSchedulerRunner } = await import(
+      "@/lib/voice/cue-scheduler-runner"
+    );
+    startCueSchedulerRunner();
+  } catch (err) {
+    console.warn(
+      "[voice][cue-scheduler-runner] startup failed (non-fatal):",
       err instanceof Error ? err.message : err,
     );
   }

--- a/apps/admin/lib/voice/cue-scheduler-runner.ts
+++ b/apps/admin/lib/voice/cue-scheduler-runner.ts
@@ -1,0 +1,147 @@
+/**
+ * Cue-scheduler tick runner — drains `CueScheduleEntry` on a short
+ * interval so `VoiceProvider.sayMessage()` fires at the scheduled
+ * time (#1742 follow-on).
+ *
+ * Why this exists separately from `cue-scheduler.ts`:
+ *
+ *   - `cue-scheduler.ts` is pure module — it persists rows and drains
+ *     on demand. Production needs SOMETHING to tick.
+ *   - Next.js `instrumentation.ts` runs once at server bootstrap, so it's
+ *     the canonical home for the start call. The runner module itself
+ *     stays import-side-effect-free so tests can import it without
+ *     spawning a timer.
+ *
+ * Guards:
+ *
+ *   1. **Single-instance:** `start()` is idempotent — calling it twice
+ *      returns the same handle, never spawns a second timer.
+ *   2. **Overlap-safe:** if a tick is already in flight when the next
+ *      interval fires, the new tick is skipped (a slow `drainDueCues`
+ *      must not stack).
+ *   3. **HMR-safe:** dev-mode hot-reload calls `register()` repeatedly;
+ *      the global symbol keeps a single timer across reloads.
+ *   4. **Error-swallowing:** an unexpected throw in `drainDueCues` is
+ *      logged and the loop continues — one bad tick doesn't tear down
+ *      the runner.
+ *   5. **Env-gated:** test environments skip the start call (no real
+ *      DB connection); the unit-test bank exercises `tick()` directly.
+ *
+ * AppLog subjects emitted from here:
+ *
+ *   - `voice.cue_scheduler_runner.started`  — once at bootstrap
+ *   - `voice.cue_scheduler_runner.stopped`  — on graceful shutdown
+ *   - `voice.cue_scheduler_runner.tick_error` — drain threw; loop continues
+ *
+ * See docs/decisions/2026-06-16-voice-say-message-primitive.md.
+ */
+
+import { log } from "@/lib/logger";
+import { drainDueCues, type DrainDueCuesOptions } from "./cue-scheduler";
+
+const DEFAULT_INTERVAL_MS = 100;
+
+interface RunnerHandle {
+  /** Underlying timer id. */
+  timer: ReturnType<typeof setInterval>;
+  /** Stop the runner. Idempotent. */
+  stop: () => void;
+  /** True when a tick is currently in flight (set/cleared inside tick). */
+  inFlight: boolean;
+  /** Configured interval (ms). */
+  intervalMs: number;
+}
+
+/**
+ * Module-level symbol pinned to globalThis so HMR replays of this file
+ * during dev don't spawn duplicate timers. The symbol is intentionally
+ * unique per module path so test imports don't collide with the bootstrap
+ * timer.
+ */
+const RUNNER_SYMBOL = Symbol.for("hf:voice:cue-scheduler-runner@1");
+
+interface GlobalWithRunner {
+  [RUNNER_SYMBOL]?: RunnerHandle;
+}
+
+function getGlobal(): GlobalWithRunner {
+  return globalThis as unknown as GlobalWithRunner;
+}
+
+export interface StartRunnerOptions {
+  /** Tick interval in ms. Default 100. */
+  intervalMs?: number;
+  /** Forwarded to `drainDueCues`. Tests inject stubs. */
+  drainOptions?: DrainDueCuesOptions;
+}
+
+/**
+ * Start the tick runner. Idempotent — subsequent calls return the same
+ * handle and do not spawn a second timer.
+ *
+ * Throws nothing. On startup failure (e.g. setInterval unavailable in a
+ * runtime that shouldn't be calling this), logs + returns null.
+ */
+export function startCueSchedulerRunner(
+  opts: StartRunnerOptions = {},
+): RunnerHandle | null {
+  const g = getGlobal();
+  if (g[RUNNER_SYMBOL]) {
+    return g[RUNNER_SYMBOL] ?? null;
+  }
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+
+  const handle: RunnerHandle = {
+    timer: setInterval(() => void tick(handle, opts.drainOptions), intervalMs),
+    inFlight: false,
+    intervalMs,
+    stop: () => stopCueSchedulerRunner(),
+  };
+  g[RUNNER_SYMBOL] = handle;
+
+  log("system", "voice.cue_scheduler_runner.started", { intervalMs });
+  return handle;
+}
+
+/**
+ * Stop the runner if running. Idempotent.
+ */
+export function stopCueSchedulerRunner(): void {
+  const g = getGlobal();
+  const handle = g[RUNNER_SYMBOL];
+  if (!handle) return;
+  clearInterval(handle.timer);
+  delete g[RUNNER_SYMBOL];
+  log("system", "voice.cue_scheduler_runner.stopped", {});
+}
+
+/**
+ * Test-only: returns the live runner handle (or null). Production code
+ * MUST NOT depend on this — use the symbol-keyed start function instead.
+ */
+export function __getRunnerHandle(): RunnerHandle | null {
+  return getGlobal()[RUNNER_SYMBOL] ?? null;
+}
+
+/**
+ * One tick. Exported so tests can drive it deterministically without
+ * waiting for setInterval. Production: the symbol-pinned timer calls
+ * this.
+ */
+export async function tick(
+  handle: RunnerHandle,
+  drainOptions?: DrainDueCuesOptions,
+): Promise<void> {
+  if (handle.inFlight) return; // overlap guard — drop this tick
+  handle.inFlight = true;
+  try {
+    await drainDueCues(drainOptions);
+  } catch (err) {
+    log("system", "voice.cue_scheduler_runner.tick_error", {
+      level: "warn",
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    handle.inFlight = false;
+  }
+}

--- a/apps/admin/tests/lib/voice/cue-scheduler-runner.test.ts
+++ b/apps/admin/tests/lib/voice/cue-scheduler-runner.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for lib/voice/cue-scheduler-runner.ts (#1742 follow-on).
+ *
+ * Pinned acceptance:
+ *   1. `startCueSchedulerRunner` returns a handle and persists it under
+ *      a single global symbol — double-start returns the same handle,
+ *      no second timer
+ *   2. `stopCueSchedulerRunner` clears the timer and the global symbol
+ *   3. `tick()` calls drainDueCues with the supplied options
+ *   4. Overlap guard — a tick that fires while another is in flight is
+ *      skipped (no concurrent drainDueCues calls)
+ *   5. Errors thrown by drainDueCues are swallowed + AppLogged; the
+ *      runner keeps ticking
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockDrain } = vi.hoisted(() => ({
+  mockDrain: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({ log: vi.fn() }));
+vi.mock("@/lib/voice/cue-scheduler", () => ({
+  drainDueCues: mockDrain,
+}));
+
+import {
+  startCueSchedulerRunner,
+  stopCueSchedulerRunner,
+  __getRunnerHandle,
+  tick,
+} from "@/lib/voice/cue-scheduler-runner";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDrain.mockReset();
+  mockDrain.mockResolvedValue({ fired: 0, failed: 0, skipped: 0 });
+  // Ensure any prior test's runner is gone.
+  stopCueSchedulerRunner();
+});
+
+afterEach(() => {
+  stopCueSchedulerRunner();
+});
+
+describe("startCueSchedulerRunner", () => {
+  it("starts a runner and stores it under the global symbol", () => {
+    const handle = startCueSchedulerRunner({ intervalMs: 50 });
+    expect(handle).not.toBeNull();
+    expect(handle?.intervalMs).toBe(50);
+    expect(__getRunnerHandle()).toBe(handle);
+  });
+
+  it("is idempotent — second call returns the same handle without spawning a second timer", () => {
+    const h1 = startCueSchedulerRunner({ intervalMs: 50 });
+    const h2 = startCueSchedulerRunner({ intervalMs: 50 });
+    expect(h2).toBe(h1);
+  });
+});
+
+describe("stopCueSchedulerRunner", () => {
+  it("clears the timer and the global symbol", () => {
+    startCueSchedulerRunner({ intervalMs: 50 });
+    expect(__getRunnerHandle()).not.toBeNull();
+    stopCueSchedulerRunner();
+    expect(__getRunnerHandle()).toBeNull();
+  });
+
+  it("is idempotent — second call is a no-op", () => {
+    stopCueSchedulerRunner();
+    stopCueSchedulerRunner();
+    expect(__getRunnerHandle()).toBeNull();
+  });
+});
+
+describe("tick", () => {
+  it("invokes drainDueCues with the supplied options", async () => {
+    const handle = startCueSchedulerRunner();
+    const drainOptions = { batchLimit: 8 };
+    await tick(handle!, drainOptions);
+    expect(mockDrain).toHaveBeenCalledWith(drainOptions);
+  });
+
+  it("overlap guard — a concurrent tick is dropped (inFlight=true skips)", async () => {
+    const handle = startCueSchedulerRunner();
+    let resolveDrain: (() => void) | undefined;
+    mockDrain.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDrain = () => resolve();
+        }),
+    );
+    const first = tick(handle!);
+    // Second tick fires while the first is still pending → should drop
+    const second = tick(handle!);
+    await second;
+    expect(mockDrain).toHaveBeenCalledTimes(1);
+    resolveDrain?.();
+    await first;
+  });
+
+  it("swallows drain errors and clears inFlight so the next tick runs", async () => {
+    const handle = startCueSchedulerRunner();
+    mockDrain.mockRejectedValueOnce(new Error("boom"));
+    await tick(handle!);
+    expect(handle!.inFlight).toBe(false);
+
+    mockDrain.mockResolvedValueOnce({ fired: 0, failed: 0, skipped: 0 });
+    await tick(handle!);
+    expect(mockDrain).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Production tick for `lib/voice/cue-scheduler.ts`. Without this the scheduler stores rows but never fires; #1742 (just shipped) had no live driver. With this in, #1743 Theme 2b cue wiring becomes a one-PR exercise.

### What ships

- `lib/voice/cue-scheduler-runner.ts`:
  - `startCueSchedulerRunner({intervalMs?, drainOptions?})` — pins a single timer under `Symbol.for("hf:voice:cue-scheduler-runner@1")` on `globalThis` so HMR replays + double-imports never spawn a second timer. Default 100ms (±200ms p99 budget per the ADR).
  - `stopCueSchedulerRunner()` — clears the timer + global symbol. Idempotent.
  - `tick(handle, drainOptions?)` — one drain cycle. Overlap guard: if a tick is in flight, the next is skipped. Errors swallowed + AppLogged so one bad tick can't tear the runner down.
  - AppLog subjects: `voice.cue_scheduler_runner.started` / `.stopped` / `.tick_error`.
- `instrumentation.ts` — extended to call `startCueSchedulerRunner()` alongside the existing skill-tier deploy-readiness check. Skipped when `NEXT_RUNTIME !== "nodejs"` (edge runtime) and when `NODE_ENV === "test"` (vitests drive `tick()` directly). Failures swallowed — non-fatal at boot.

## Lattice survey [verified]

- **Sibling-writer drift:** NIL — single new tick caller for the existing pure `drainDueCues` chokepoint at `apps/admin/lib/voice/cue-scheduler.ts`.
- **Default-deny gates:** test-env skip in instrumentation; symbol guard against double-start.
- **Cascade respect:** N/A — pure timer wiring.
- **Convention conflict:** NIL — instrumentation pattern already established for the skill-tier invariant.
- **HMR safety:** symbol pinned on globalThis so dev-mode hot reload + Next.js's `register()` re-invocation cannot spawn duplicate timers [verified by test "idempotent — second call returns the same handle"].

## Verified by

- ✅ vitest `tests/lib/voice/cue-scheduler-runner.test.ts` 7/7 (start idempotence + stop idempotence + tick → drain + overlap guard + error swallowing). [verified — `npx vitest run tests/lib/voice/cue-scheduler-runner.test.ts` exits 0].
- ✅ Full voice bank: 346/346 tests pass, zero regression. [verified — `npx vitest run tests/lib/voice/` exits 0].
- ✅ tsc on changed files: 0 errors. [verified — `npx tsc --noEmit | grep -E 'cue-scheduler-runner|instrumentation'` returns no rows].
- ✅ pre-push hook: tsc 0 errors (baseline 43, -43), lint 0 errors in changed files. [verified at log above].
- ✅ Lattice survey result inline above.

## Test plan

- [ ] `/vm-cp` — no migration needed.
- [ ] On hf-dev: tail `/tmp/hf-dev.log` after restart and confirm `voice.cue_scheduler_runner.started` AppLog appears once.
- [ ] Schedule a cue 5s in the future via SQL probe: `INSERT INTO "CueScheduleEntry" (id, "externalCallId", "scheduledFor", content, status, "createdAt") VALUES (gen_random_uuid(), 'ext-test', NOW() + INTERVAL '5 seconds', 'tick test', 'pending', NOW());` then wait — the row should flip to `status='skipped'` (no matching Call row → `no_call_row`). Confirms the tick is firing.

Closes the production gap for #1742; unblocks #1743 Theme 2b.
