### PR TITLE
fix(journey): structured storagePath for the 4 stop contracts (#2 from journey-r2 handoff)

### DIFF
--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -353,7 +353,16 @@ const G2_PRE_TEST_STOP: JourneySettingContract = {
   group: "G2",
   educatorLabel: "Pre-test stop",
   helpText: "Gate the start of Call 1 with a quick assessment.",
-  storagePath: "sessionFlow.stops.preTest",
+  // `Playbook.config.sessionFlow.stops` is a JourneyStop[] keyed by stable
+  // synthetic id (`"pre-test" | "mid-test" | "post-test" | "nps"` — set
+  // by `lib/session-flow/resolver.ts` synthesis and SessionFlowEditor
+  // creation paths). Structured storagePath addresses the array element.
+  storagePath: {
+    path: "sessionFlow.stops[]",
+    arrayKey: "id",
+    selectorValue: "pre-test",
+    writeMode: "merge",
+  },
   control: "stop",
   cascadeSources: [],
   composeImpact: {
@@ -1003,8 +1012,16 @@ const G5_MID_JOURNEY_STOP: JourneySettingContract = {
   menuGroupKey: "L_mid_journey",
   group: "G5",
   educatorLabel: "Mid-journey stop",
-  helpText: "Mid-test or check-in stop between teaching calls.",
-  storagePath: "sessionFlow.stops.midJourney",
+  helpText: "Mid-test or check-in stop between teaching calls. Trigger type is edited from the stop's own trigger picker.",
+  // Stable synthetic id for the array element — matches SessionFlowEditor's
+  // row id taxonomy (lib/session-flow/resolver.ts synthesises `"pre-test"` /
+  // `"post-test"` / `"nps"`; this is the sibling canonical id).
+  storagePath: {
+    path: "sessionFlow.stops[]",
+    arrayKey: "id",
+    selectorValue: "mid-test",
+    writeMode: "merge",
+  },
   control: "stop",
   cascadeSources: [],
   composeImpact: {
@@ -1015,26 +1032,12 @@ const G5_MID_JOURNEY_STOP: JourneySettingContract = {
   previewLocators: [{ section: "modulesGate", hint: "mid-journey block" }],
 };
 
-const G5_MID_JOURNEY_STOP_TRIGGER: JourneySettingContract = {
-  id: "midJourneyStopTrigger",
-  menuGroupKey: "L_mid_journey",
-  group: "G5",
-  educatorLabel: "Mid-journey stop trigger",
-  helpText: "Mastery threshold / session count that fires the stop.",
-  storagePath: "sessionFlow.stops.midJourney.trigger",
-  control: "select",
-  cascadeSources: [],
-  composeImpact: {
-    sections: ["modulesGate"],
-    kinds: ["stop-timing"],
-    requiresReprompt: false,
-  },
-  previewLocators: [{ section: "modulesGate" }],
-  options: [
-    { value: "mastery_threshold", label: "Mastery threshold reached" },
-    { value: "session_count", label: "After N sessions" },
-  ],
-};
+// midJourneyStopTrigger removed — was a `control: "select"` sibling that
+// tried to write `sessionFlow.stops.midJourney.trigger` (nested into the
+// array element), which the storage-path applier cannot express. The
+// trigger picker is already part of the `midJourneyStop` compound editor
+// above. Removing the redundant entry closes the storage-path/applier
+// mismatch.
 
 // Lane 3 PR6 — L_mid_journey NPS contracts (catch-up from #1780).
 
@@ -1102,7 +1105,12 @@ const G5_NPS_STOP: JourneySettingContract = {
   group: "G5",
   educatorLabel: "NPS stop",
   helpText: "Net Promoter Score survey at a mid-journey moment.",
-  storagePath: "sessionFlow.stops.nps",
+  storagePath: {
+    path: "sessionFlow.stops[]",
+    arrayKey: "id",
+    selectorValue: "nps",
+    writeMode: "merge",
+  },
   control: "stop",
   cascadeSources: [],
   composeImpact: {
@@ -1288,7 +1296,12 @@ const G6_POST_TEST_STOP: JourneySettingContract = {
   group: "G6",
   educatorLabel: "Post-test stop",
   helpText: "Final assessment before offboarding.",
-  storagePath: "sessionFlow.stops.postTest",
+  storagePath: {
+    path: "sessionFlow.stops[]",
+    arrayKey: "id",
+    selectorValue: "post-test",
+    writeMode: "merge",
+  },
   control: "stop",
   cascadeSources: [],
   composeImpact: {
@@ -1807,9 +1820,8 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G4_PROGRESS_SIGNAL_LOW_WATER,
   G4_PROGRESS_SIGNAL_HIGH_WATER,
   G4_INTERRUPT_SENSITIVITY,
-  // G5 (3)
+  // G5 (5)
   G5_MID_JOURNEY_STOP,
-  G5_MID_JOURNEY_STOP_TRIGGER,
   G5_NPS_ENABLED,
   G5_NPS_TRIGGER,
   G5_NPS_THRESHOLD,

--- a/apps/admin/tests/components/journey-controls/JourneyStop.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyStop.test.tsx
@@ -15,7 +15,12 @@ const contract: JourneySettingContract = {
   id: "preTestStop",
   group: "G2",
   educatorLabel: "Pre-test stop",
-  storagePath: "sessionFlow.stops.preTest",
+  storagePath: {
+    path: "sessionFlow.stops[]",
+    arrayKey: "id",
+    selectorValue: "pre-test",
+    writeMode: "merge",
+  },
   control: "stop",
   cascadeSources: [],
   composeImpact: {

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -95,7 +95,10 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(10);
     expect(JOURNEY_SETTINGS_BY_GROUP.G3.length).toBe(4);
     expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(27);
-    expect(JOURNEY_SETTINGS_BY_GROUP.G5.length).toBe(6);
+    // midJourneyStopTrigger removed in fix/journey-stops-structured-paths
+    // (storagePath was unrepresentable in the applier — trigger is now
+    // edited only via the midJourneyStop compound editor). G5 6 → 5.
+    expect(JOURNEY_SETTINGS_BY_GROUP.G5.length).toBe(5);
     expect(JOURNEY_SETTINGS_BY_GROUP.G6.length).toBe(10);
     // #1747 — Theme 7 talkTimeBudgets bumped G7 6 → 7; Lane 3 catch-up bumped further.
     expect(JOURNEY_SETTINGS_BY_GROUP.G7.length).toBe(14);
@@ -103,8 +106,9 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G8.length).toBe(7);
   });
 
-  it("(8) JOURNEY_SETTINGS.length === 85", () => {
-    expect(JOURNEY_SETTINGS.length).toBe(85);
+  it("(8) JOURNEY_SETTINGS.length === 84", () => {
+    // 85 → 84 after midJourneyStopTrigger removal (see G5 note above).
+    expect(JOURNEY_SETTINGS.length).toBe(84);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {

--- a/apps/admin/tests/lib/journey/registry-options-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-options-coverage.test.ts
@@ -154,11 +154,11 @@ const EXPECTED_OPTION_VALUES: Record<string, OptionPin> = {
   },
 
   // ── L_mid_journey ───────────────────────────────────────────────
-  midJourneyStopTrigger: {
-    values: ["mastery_threshold", "session_count"],
-    canonical:
-      "lib/types/json-fields.ts::JourneyStopTrigger discriminated union",
-  },
+  // midJourneyStopTrigger removed in fix/journey-stops-structured-paths —
+  // the contract was deleted because its storagePath
+  // (`sessionFlow.stops.midJourney.trigger`) was unrepresentable in the
+  // applier (nested write into an array element). The trigger picker now
+  // lives only inside the `midJourneyStop` compound editor.
   npsTrigger: {
     values: ["mastery", "session_count"],
     canonical: "lib/types/json-fields.ts::NpsConfig.trigger",

--- a/apps/admin/tests/lib/journey/save-roundtrip-smoke.test.ts
+++ b/apps/admin/tests/lib/journey/save-roundtrip-smoke.test.ts
@@ -93,12 +93,25 @@ function representativeValue(
       return { tierPresetId: "Generic" };
     case "voice-picker":
       return { voiceProvider: "vapi", voiceId: "test-voice" };
-    case "stop":
+    case "stop": {
+      // Structured stop contracts address an array element by
+      // `arrayKey: "id"` + a canonical `selectorValue` (`"pre-test"` /
+      // `"mid-test"` / `"post-test"` / `"nps"`). The applier injects the
+      // selector onto pushed elements, so the round-trip read-back will
+      // carry the id; mirror it in the written value so the comparison
+      // matches.
+      const struct = typeof c.storagePath === "object" ? c.storagePath : null;
+      const id =
+        struct?.arrayKey === "id" && struct.selectorValue
+          ? struct.selectorValue
+          : undefined;
       return {
+        ...(id ? { id } : {}),
         kind: "pre_test",
         enabled: true,
         trigger: { type: "first_session" },
       };
+    }
     case "min-target":
       return { min: 1, target: 2 };
     case "array-editor":


### PR DESCRIPTION
## Summary

The 4 stop contracts (`preTestStop`, `midJourneyStop`, `npsStop`, `postTestStop`) plus `midJourneyStopTrigger` sat at the wrong end of a 5-layer Lattice divergence:

| Layer | State |
|---|---|
| DB / `PlaybookConfig` | `sessionFlow.stops: JourneyStop[]` (array) |
| Type def | `stops?: JourneyStop[]` (array) ✅ |
| Readers (SessionFlowEditor / timeline-helpers / resolver / SessionFlowProgress) | `stops.filter` / `stops.find` — all array ops ✅ |
| **Contract storagePath** | `"sessionFlow.stops.preTest"` — dotted bare-string ❌ |
| **Applier on bare-string dotted** | walks dot path → writes `stops.preTest = {...}` as OBJECT key, not array element ❌ |

Net effect in production: educators toggling these Inspector controls silently wrote to a non-array shape (`stops.preTest = {...}`) that no reader recognised. The setting was live in the UI but disconnected from runtime behaviour.

## What this PR does

1. **4 stop contracts** → structured `StoragePath` form:

   ```ts
   storagePath: {
     path: "sessionFlow.stops[]",
     arrayKey: "id",
     selectorValue: "pre-test" | "mid-test" | "post-test" | "nps",
     writeMode: "merge",
   }
   ```

   Selector values match the canonical synthetic ids the resolver already mints (`lib/session-flow/resolver.ts:231,246,259` writes `id: "pre-test" | "post-test" | "nps"`) and the SessionFlowEditor's row-id taxonomy (`SessionFlowEditor.tsx:126-129`).

2. **`midJourneyStopTrigger` removed.** Its storagePath `sessionFlow.stops.midJourney.trigger` was a nested write into an array element — unrepresentable in the storage-path applier. The trigger picker is already part of the `midJourneyStop` compound editor; the sibling contract was redundant.

3. **Tests updated** — JourneyStop fixture, registry-completeness counts (G5 6→5, total 85→84), registry-options-coverage (drop midJourneyStopTrigger), save-roundtrip-smoke `representativeValue("stop")` (mint `id` matching selectorValue so the applier's selector-injection round-trips cleanly).

## Verified by

- `npx vitest run tests/lib/journey/ tests/components/journey-controls/JourneyStop.test.tsx tests/components/journey-tab/resolve-value-at-path.test.ts tests/api/courses/journey-setting-route.test.ts` — 87/87 pass (was 84/87: 3 round-trip failures on the old broken paths).
- `npx tsc --noEmit` — 57 errors (baseline, unchanged).
- Sibling-writer survey (per `.claude/rules/lattice-survey.md`):
  - DB column shape: `Playbook.config.sessionFlow.stops: JourneyStop[]` [verified].
  - Writers: `SessionFlowEditor` writes via row-id (`"pre-test"` etc.) canonical taxonomy; resolver synthesizes from legacy with the same ids; new Inspector path now writes through the same selector key. All writers produce array elements with matching id.
  - Readers: `timeline-helpers` / `SessionFlowProgress` / `SessionFlowEditor` / `journey-stop-runner` / `resolver` — all read by array operations, none by dotted key. No reader change needed [grep -rn 'sessionFlow.stops' apps/admin].
  - Convergence: all writers now produce array elements; all readers consume array elements. Lattice convergence achieved.
- Storage path applier tests (`tests/lib/journey/storage-path-applier.test.ts`) already pin the structured-form behaviour line 105-133 [verified].

## Production data note

Existing PROD data created via the OLD broken contracts would live at `config.sessionFlow.stops.preTest = {...}` (object key) — invisible to readers. The new contract path writes to the array, so old data is left in place but irrelevant. No backfill needed (the dotted keys were never read by anything). A cleanup script can sweep them later if cosmetic.

## Test plan

- [x] Round-trip smoke test green (the 3 previously failing stops now match)
- [x] Registry-completeness count assertions updated
- [x] JourneyStop component test still pins extras preservation
- [ ] Manual smoke on hf-dev: open course Journey tab → Inspector → toggle preTestStop → DB shows the toggle in `config.sessionFlow.stops[].id === "pre-test"` [pending `/vm-cp`]

🤖 Generated with [Claude Code](https://claude.com/claude-code)