### PR TITLE
feat(curriculum): #1746 Theme 5 revival — count-based module prereqs done properly

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 57,
+  "tsc_errors": 49,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx
@@ -35,6 +35,7 @@ import type {
   ModuleSource,
   ValidationWarning,
 } from "@/lib/types/json-fields";
+import { prerequisiteSlugs } from "@/lib/curriculum/check-module-unlock";
 import { ImportModulesDialog } from "./ImportModulesDialog";
 import { LearnerModulePicker } from "./LearnerModulePicker";
 import "./authored-modules-panel.css";
@@ -504,21 +505,25 @@ function ModuleDetail({
           <h4 className="authored-modules-detail__section-title">
             Prerequisites
           </h4>
-          {m.prerequisites.length === 0 ? (
-            <p className="hf-text-sm hf-text-muted">None — open from session 1.</p>
-          ) : (
-            <div className="authored-modules-detail__chips">
-              {m.prerequisites.map((id) => (
-                <span
-                  key={id}
-                  className="hf-badge hf-badge-sm hf-badge-muted"
-                  title="Advisory only — picker shows 'Recommended after' but does not gate"
-                >
-                  {id}
-                </span>
-              ))}
-            </div>
-          )}
+          {(() => {
+            const slugs = prerequisiteSlugs(m.prerequisites);
+            if (slugs.length === 0) {
+              return <p className="hf-text-sm hf-text-muted">None — open from session 1.</p>;
+            }
+            return (
+              <div className="authored-modules-detail__chips">
+                {slugs.map((id) => (
+                  <span
+                    key={id}
+                    className="hf-badge hf-badge-sm hf-badge-muted"
+                    title="Advisory only — picker shows 'Recommended after' but does not gate"
+                  >
+                    {id}
+                  </span>
+                ))}
+              </div>
+            );
+          })()}
         </section>
 
         {/* Content source */}

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -34,6 +34,7 @@ import {
   Lock,
 } from "lucide-react";
 import type { AuthoredModule } from "@/lib/types/json-fields";
+import { prerequisiteSlugs } from "@/lib/curriculum/check-module-unlock";
 import {
   PrereqsSoftWarningModal,
   type UnmetPrereq,
@@ -268,11 +269,9 @@ function computeUnmetPrereqs(
   candidate: AuthoredModule,
   modulesById: Map<string, AuthoredModule>,
 ): UnmetPrereq[] {
-  const prereqs = Array.isArray(candidate.prerequisites)
-    ? candidate.prerequisites
-    : [];
+  const slugs = prerequisiteSlugs(candidate.prerequisites);
   const unmet: UnmetPrereq[] = [];
-  for (const slug of prereqs) {
+  for (const slug of slugs) {
     const ref = modulesById.get(slug);
     if (!ref) continue; // stale slug — silently skip
     if (ref.progress?.status === "MASTERED") continue;
@@ -510,7 +509,9 @@ function RailLayout({
         const isInProgress = inProgress.has(m.id) && !isComplete;
         const isLocked = lockedModuleIds.has(m.id);
         const Tag = onSelect ? "button" : "div";
-        const prereqsUnmet = m.prerequisites.filter((p) => !completed.has(p));
+        const prereqsUnmet = prerequisiteSlugs(m.prerequisites).filter(
+          (slug) => !completed.has(slug),
+        );
         const advisoryHint =
           prereqsUnmet.length > 0
             ? `Recommended after ${prereqsUnmet.join(", ")}`

--- a/apps/admin/lib/curriculum/check-module-unlock.ts
+++ b/apps/admin/lib/curriculum/check-module-unlock.ts
@@ -1,0 +1,245 @@
+/**
+ * isModuleUnlocked — #1746 (epic #1700 Theme 5).
+ *
+ * Determines whether a learner can ENTER a module given the module's
+ * declared prerequisites and the learner's progress history.
+ *
+ * Two prerequisite shapes accepted (widened from `string[]` in #1746):
+ *
+ *   - **String** (legacy): bare slug. Treated as "needs ≥ 1 COMPLETED
+ *     attempt on the referenced sibling module".
+ *   - **`{moduleId, minCompletions}`**: count-based. Require ≥ N
+ *     COMPLETED attempts. e.g. IELTS Mock declares
+ *     `[{moduleId: "assessment", minCompletions: 1},
+ *       {moduleId: "part1", minCompletions: 2},
+ *       {moduleId: "part3", minCompletions: 2}]`.
+ *
+ * **Role bypass.** OPERATOR+ (level ≥ 3) ALWAYS reads back
+ * `{unlocked: true, reason: "role-bypass"}`. Testers must not be locked
+ * out of Mock when iterating on it; the gate is a STUDENT-only contract.
+ * Pinned by vitest.
+ *
+ * **Course-style gate.** Only structured courses honour the unlock
+ * gate. Continuous courses have no module-progress semantics; we
+ * default-allow (the caller decides what "allow" means without modules).
+ *
+ * Pure read — no writes. Returns `{unlocked, reason, missing?[]}` so
+ * the caller can render a "Complete X first" hint when blocked.
+ *
+ * @see docs/draft-issues/ielts-pre-voice-gap-analysis.md (Theme 5)
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+import { getCourseStyle } from "@/lib/pipeline/course-style";
+
+export type ModulePrerequisiteShape = string | { moduleId: string; minCompletions: number };
+
+/**
+ * Coerce a prerequisite entry to `{moduleId, minCompletions}`. Bare-string
+ * legacy entries become `{moduleId: <slug>, minCompletions: 1}`. Invalid
+ * entries (non-string, non-object, missing moduleId) are dropped.
+ *
+ * Exported so the 6 consumer sites can share one normalisation path
+ * instead of inlining `typeof p === "string" ? ... : ...` branches.
+ */
+export function normalisePrerequisite(
+  p: unknown,
+): { moduleId: string; minCompletions: number } | null {
+  if (typeof p === "string") {
+    return { moduleId: p, minCompletions: 1 };
+  }
+  if (typeof p === "object" && p !== null) {
+    const obj = p as { moduleId?: unknown; minCompletions?: unknown };
+    if (typeof obj.moduleId !== "string" || obj.moduleId.length === 0) {
+      return null;
+    }
+    const min =
+      typeof obj.minCompletions === "number" && obj.minCompletions > 0
+        ? obj.minCompletions
+        : 1;
+    return { moduleId: obj.moduleId, minCompletions: min };
+  }
+  return null;
+}
+
+/**
+ * Extract just the slug list from a mixed prerequisites array.
+ *
+ * For the read sites that don't care about `minCompletions` (UI chips,
+ * filter checks, advisory hints, the DB writer that targets the
+ * `String[]` Prisma column) — pass the prereqs array, get a `string[]`
+ * back.
+ *
+ * Invalid entries are dropped (defensive — the DB shape is permissive).
+ */
+export function prerequisiteSlugs(prereqs: unknown): string[] {
+  if (!Array.isArray(prereqs)) return [];
+  const out: string[] = [];
+  for (const p of prereqs) {
+    const n = normalisePrerequisite(p);
+    if (n) out.push(n.moduleId);
+  }
+  return out;
+}
+
+export interface UnlockCheckArgs {
+  callerId: string;
+  /** AuthoredModule whose unlock state we're checking. */
+  module: AuthoredModule;
+  /** Playbook config carrying the modules array + course style. */
+  playbookConfig: PlaybookConfig | null | undefined;
+  /** Caller's role for the role-bypass check. */
+  callerRole: string | null | undefined;
+}
+
+export interface UnlockCheckResult {
+  unlocked: boolean;
+  /**
+   * One of:
+   *   - `"role-bypass"` — OPERATOR+ always pass
+   *   - `"no-prerequisites"` — empty/missing prereq list
+   *   - `"continuous-course"` — non-structured course, gate doesn't apply
+   *   - `"all-prerequisites-met"` — every prereq satisfied
+   *   - `"prerequisites-unmet"` — at least one prereq below `minCompletions`
+   *   - `"module-id-unknown"` — module not in playbook (defensive)
+   */
+  reason: string;
+  /**
+   * For `prerequisites-unmet`: the list of unsatisfied prereqs +
+   * how many more completions each needs. UI surfaces this as
+   * "Complete X (1 more) and Y (2 more) first".
+   */
+  missing?: Array<{
+    moduleId: string;
+    moduleLabel: string | null;
+    required: number;
+    actual: number;
+  }>;
+}
+
+/** ROLE_LEVEL ordering — mirrors `lib/permissions.ts`. */
+const OPERATOR_BYPASS_ROLES = new Set([
+  "OPERATOR",
+  "EDUCATOR",
+  "ADMIN",
+  "SUPERADMIN",
+]);
+
+/** Minimal Prisma subset — keeps the test mock small. */
+type PrismaForUnlock = Pick<PrismaClient, "callerModuleProgress">;
+
+/**
+ * Returns whether this caller can ENTER the supplied module.
+ *
+ * `getCourseStyle` short-circuit:
+ *   - continuous courses: `{unlocked: true, reason: "continuous-course"}`
+ *   - structured: proceed with prereq evaluation
+ *
+ * Role bypass:
+ *   - OPERATOR+ → `{unlocked: true, reason: "role-bypass"}`
+ *   - STUDENT / VIEWER / TESTER / SUPER_TESTER / DEMO → gate enforced
+ */
+export async function isModuleUnlocked(
+  prisma: PrismaForUnlock,
+  args: UnlockCheckArgs,
+): Promise<UnlockCheckResult> {
+  // Role bypass — OPERATOR+ always pass. Testers iterating on Mock must
+  // not be locked out.
+  if (args.callerRole && OPERATOR_BYPASS_ROLES.has(args.callerRole)) {
+    return { unlocked: true, reason: "role-bypass" };
+  }
+
+  // Continuous-course short-circuit. Module-progress writes only make
+  // sense for structured courses (per #1252).
+  const courseStyle = getCourseStyle(args.playbookConfig);
+  if (courseStyle !== "structured") {
+    return { unlocked: true, reason: "continuous-course" };
+  }
+
+  const rawPrereqs = args.module.prerequisites as
+    | ModulePrerequisiteShape[]
+    | undefined;
+  if (!Array.isArray(rawPrereqs) || rawPrereqs.length === 0) {
+    return { unlocked: true, reason: "no-prerequisites" };
+  }
+
+  // Normalise both shapes to `{moduleId, minCompletions}`.
+  const normalised = rawPrereqs
+    .map(normalisePrerequisite)
+    .filter((p): p is { moduleId: string; minCompletions: number } => p !== null);
+
+  if (normalised.length === 0) {
+    return { unlocked: true, reason: "no-prerequisites" };
+  }
+
+  // Resolve prereq module ids → DB module ids. Authored module ids
+  // match `CurriculumModule.slug` by convention (see #407 slug-scope).
+  const authoredById = new Map<string, AuthoredModule>();
+  for (const m of args.playbookConfig?.modules ?? []) {
+    authoredById.set(m.id, m);
+  }
+  const slugsToCheck = normalised.map((p) => p.moduleId);
+
+  // Read the caller's progress on the prereq modules.
+  // #1252 — wrapped in a structured-only if-block (we already returned
+  // early on continuous). The find runs only inside the structured
+  // branch by control flow.
+  let progressRows: Array<{ moduleId: string; status: string; callCount: number; module: { slug: string | null } }> = [];
+  if (courseStyle === "structured") {
+    progressRows = await prisma.callerModuleProgress.findMany({
+      where: {
+        callerId: args.callerId,
+        module: { slug: { in: slugsToCheck } },
+      },
+      select: {
+        moduleId: true,
+        status: true,
+        callCount: true,
+        module: { select: { slug: true } },
+      },
+    });
+  }
+
+  // Map slug → completion count. A module counts toward its own
+  // requirement only when its progress reaches COMPLETED — `callCount`
+  // alone over-counts incomplete attempts.
+  const completionsBySlug = new Map<string, number>();
+  for (const row of progressRows) {
+    const slug = row.module.slug;
+    if (!slug) continue;
+    if (row.status === "COMPLETED") {
+      // `callCount` is the total touches; for COMPLETED rows we count
+      // it as ≥ the required minimum (the module reached COMPLETED at
+      // least once, plus any subsequent re-engagements). Conservative:
+      // use max(1, callCount) so a single-attempt COMPLETED satisfies
+      // `minCompletions: 1` even if callCount drifted.
+      completionsBySlug.set(slug, Math.max(1, row.callCount ?? 1));
+    }
+  }
+
+  const missing: NonNullable<UnlockCheckResult["missing"]> = [];
+  for (const req of normalised) {
+    const actual = completionsBySlug.get(req.moduleId) ?? 0;
+    if (actual < req.minCompletions) {
+      const authored = authoredById.get(req.moduleId);
+      missing.push({
+        moduleId: req.moduleId,
+        moduleLabel: authored?.label ?? null,
+        required: req.minCompletions,
+        actual,
+      });
+    }
+  }
+
+  if (missing.length > 0) {
+    return {
+      unlocked: false,
+      reason: "prerequisites-unmet",
+      missing,
+    };
+  }
+
+  return { unlocked: true, reason: "all-prerequisites-met" };
+}

--- a/apps/admin/lib/wizard/detect-authored-modules.ts
+++ b/apps/admin/lib/wizard/detect-authored-modules.ts
@@ -35,6 +35,7 @@ import type {
   ModuleDefaults,
   ValidationWarning,
 } from "@/lib/types/json-fields";
+import { prerequisiteSlugs } from "@/lib/curriculum/check-module-unlock";
 
 // ── Public types ──────────────────────────────────────────────────────
 
@@ -446,11 +447,11 @@ function validateCrossReferences(
 
   // Prerequisite references must point to existing modules
   for (const m of modules) {
-    for (const p of m.prerequisites) {
-      if (!ids.has(p)) {
+    for (const slug of prerequisiteSlugs(m.prerequisites)) {
+      if (!ids.has(slug)) {
         warnings.push({
           code: "MODULE_PREREQUISITE_UNKNOWN",
-          message: `Module "${m.id}" lists prerequisite "${p}" which is not a sibling module ID.`,
+          message: `Module "${m.id}" lists prerequisite "${slug}" which is not a sibling module ID.`,
           path: `modules.${m.id}.prerequisites`,
           severity: "error",
         });

--- a/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
+++ b/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
@@ -27,6 +27,7 @@
 
 import type { Prisma, PrismaClient } from "@prisma/client";
 import type { AuthoredModule } from "@/lib/types/json-fields";
+import { prerequisiteSlugs } from "@/lib/curriculum/check-module-unlock";
 import { detectMockShapeCovers } from "./detect-mock-shape-modules";
 import { assertValidLoRefBatch } from "@/lib/curriculum/validate-lo-refs";
 
@@ -127,6 +128,12 @@ export async function syncAuthoredModulesToCurriculum(
 
   for (const [idx, m] of modules.entries()) {
     const coversModules = coversBySlug.get(m.id) ?? [];
+    // `CurriculumModule.prerequisites` is `String[]` in the DB. The
+    // AuthoredModule type widens to allow `{moduleId, minCompletions}`
+    // (Theme 5). Serialise to slug list here — the count-based gate
+    // lives at read time in `lib/curriculum/check-module-unlock.ts`,
+    // which reads the richer shape directly from `Playbook.config.modules`.
+    const prereqSlugs = prerequisiteSlugs(m.prerequisites);
     const result = await tx.curriculumModule.upsert({
       where: {
         curriculumId_slug: { curriculumId, slug: m.id },
@@ -136,7 +143,7 @@ export async function syncAuthoredModulesToCurriculum(
         slug: m.id,
         title: m.label,
         sortOrder: m.position ?? idx,
-        prerequisites: m.prerequisites,
+        prerequisites: prereqSlugs,
         coversModules,
       },
       update: {
@@ -146,7 +153,7 @@ export async function syncAuthoredModulesToCurriculum(
         // shape today.
         title: m.label,
         sortOrder: m.position ?? idx,
-        prerequisites: m.prerequisites,
+        prerequisites: prereqSlugs,
         coversModules,
       },
       select: { id: true, createdAt: true, updatedAt: true },

--- a/apps/admin/tests/lib/curriculum/check-module-unlock.test.ts
+++ b/apps/admin/tests/lib/curriculum/check-module-unlock.test.ts
@@ -1,0 +1,323 @@
+/**
+ * #1746 (epic #1700 Theme 5) — isModuleUnlocked role-aware gate.
+ *
+ * Pins:
+ *   - OPERATOR+ always bypass
+ *   - STUDENT blocked when prereqs unmet
+ *   - String-form prereqs treated as minCompletions=1
+ *   - Object-form prereqs honour custom minCompletions (count-based)
+ *   - Continuous course → unlocked (gate doesn't apply)
+ *   - Empty prereqs → unlocked
+ *   - Missing prereqs surface in `missing[]` with module label
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  isModuleUnlocked,
+  normalisePrerequisite,
+  prerequisiteSlugs,
+} from "@/lib/curriculum/check-module-unlock";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeAuthored(
+  id: string,
+  prerequisites: AuthoredModule["prerequisites"] = [],
+): AuthoredModule {
+  return {
+    id,
+    label: id.charAt(0).toUpperCase() + id.slice(1),
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "10 min",
+    scoringFired: "All four",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: [],
+    prerequisites,
+  };
+}
+
+function makeConfig(modules: AuthoredModule[], structured = true): PlaybookConfig {
+  return {
+    modules,
+    ...(structured ? { lessonPlanMode: "structured" } : {}),
+  } as PlaybookConfig;
+}
+
+function makePrisma(
+  rows: Array<{ slug: string; status: string; callCount?: number }>,
+) {
+  return {
+    callerModuleProgress: {
+      findMany: vi.fn(async () =>
+        rows.map((r) => ({
+          moduleId: `mod-${r.slug}`,
+          status: r.status,
+          callCount: r.callCount ?? (r.status === "COMPLETED" ? 1 : 0),
+          module: { slug: r.slug },
+        })),
+      ),
+    },
+  };
+}
+
+describe("isModuleUnlocked", () => {
+  describe("role bypass", () => {
+    for (const role of ["OPERATOR", "EDUCATOR", "ADMIN", "SUPERADMIN"]) {
+      it(`${role} → unlocked + reason="role-bypass" regardless of prereqs`, async () => {
+        const mock = makePrisma([]);
+        const result = await isModuleUnlocked(mock as never, {
+          callerId: "caller-1",
+          module: makeAuthored("mock", [
+            { moduleId: "part1", minCompletions: 99 },
+          ]),
+          playbookConfig: makeConfig([
+            makeAuthored("mock"),
+            makeAuthored("part1"),
+          ]),
+          callerRole: role,
+        });
+        expect(result).toEqual({ unlocked: true, reason: "role-bypass" });
+        // Role bypass short-circuits before any DB call.
+        expect(mock.callerModuleProgress.findMany).not.toHaveBeenCalled();
+      });
+    }
+
+    for (const role of ["STUDENT", "VIEWER", "TESTER", "SUPER_TESTER", "DEMO", null, undefined]) {
+      it(`${role ?? "null"} → gate enforced (no bypass)`, async () => {
+        const mock = makePrisma([]);
+        const result = await isModuleUnlocked(mock as never, {
+          callerId: "caller-1",
+          module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 1 }]),
+          playbookConfig: makeConfig([
+            makeAuthored("mock"),
+            makeAuthored("part1"),
+          ]),
+          callerRole: role,
+        });
+        expect(result.unlocked).toBe(false);
+        expect(result.reason).toBe("prerequisites-unmet");
+      });
+    }
+  });
+
+  describe("continuous-course short-circuit", () => {
+    it("returns unlocked when course is not structured", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 99 }]),
+        playbookConfig: makeConfig([], false),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "continuous-course" });
+      expect(mock.callerModuleProgress.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("empty prereqs", () => {
+    it("returns unlocked when prerequisites array is empty", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("assessment", []),
+        playbookConfig: makeConfig([makeAuthored("assessment")]),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "no-prerequisites" });
+    });
+  });
+
+  describe("string-form prereqs (legacy shape)", () => {
+    it("STUDENT blocked when string prereq has no COMPLETED row", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("part2", ["part1"]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("part2", ["part1"]),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(false);
+      expect(result.missing).toHaveLength(1);
+      expect(result.missing![0].moduleId).toBe("part1");
+      expect(result.missing![0].required).toBe(1);
+      expect(result.missing![0].actual).toBe(0);
+    });
+
+    it("STUDENT unlocked when string prereq has 1 COMPLETED row", async () => {
+      const mock = makePrisma([{ slug: "part1", status: "COMPLETED" }]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("part2", ["part1"]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("part2", ["part1"]),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "all-prerequisites-met" });
+    });
+  });
+
+  describe("count-based prereqs (Mock pattern)", () => {
+    it("STUDENT blocked when actual < required", async () => {
+      // IELTS Mock: needs 2× Part 1 + 2× Part 3. Learner has only 1× P1.
+      const mock = makePrisma([
+        { slug: "part1", status: "COMPLETED", callCount: 1 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [
+          { moduleId: "part1", minCompletions: 2 },
+          { moduleId: "part3", minCompletions: 2 },
+        ]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("part3"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(false);
+      expect(result.missing).toHaveLength(2);
+      const p1 = result.missing!.find((m) => m.moduleId === "part1");
+      const p3 = result.missing!.find((m) => m.moduleId === "part3");
+      expect(p1!.actual).toBe(1);
+      expect(p1!.required).toBe(2);
+      expect(p3!.actual).toBe(0);
+      expect(p3!.required).toBe(2);
+    });
+
+    it("STUDENT unlocked when all count-based prereqs satisfied", async () => {
+      const mock = makePrisma([
+        { slug: "part1", status: "COMPLETED", callCount: 2 },
+        { slug: "part3", status: "COMPLETED", callCount: 2 },
+        { slug: "assessment", status: "COMPLETED", callCount: 1 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [
+          { moduleId: "assessment", minCompletions: 1 },
+          { moduleId: "part1", minCompletions: 2 },
+          { moduleId: "part3", minCompletions: 2 },
+        ]),
+        playbookConfig: makeConfig([
+          makeAuthored("assessment"),
+          makeAuthored("part1"),
+          makeAuthored("part3"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result).toEqual({ unlocked: true, reason: "all-prerequisites-met" });
+    });
+
+    it("IN_PROGRESS rows don't count toward minCompletions", async () => {
+      const mock = makePrisma([
+        { slug: "part1", status: "IN_PROGRESS", callCount: 5 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 1 }]),
+        playbookConfig: makeConfig([
+          makeAuthored("part1"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(false);
+      expect(result.missing![0].actual).toBe(0);
+    });
+  });
+
+  describe("mixed-shape prereqs (backwards compat)", () => {
+    it("accepts a mix of string + object forms in one array", async () => {
+      const mock = makePrisma([
+        { slug: "assessment", status: "COMPLETED" },
+        { slug: "part1", status: "COMPLETED", callCount: 2 },
+      ]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [
+          "assessment", // legacy string form, treated as minCompletions=1
+          { moduleId: "part1", minCompletions: 2 },
+        ]),
+        playbookConfig: makeConfig([
+          makeAuthored("assessment"),
+          makeAuthored("part1"),
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.unlocked).toBe(true);
+    });
+  });
+
+  describe("missing[] enrichment for UI", () => {
+    it("surfaces module label in missing[] when authored entry exists", async () => {
+      const mock = makePrisma([]);
+      const result = await isModuleUnlocked(mock as never, {
+        callerId: "caller-1",
+        module: makeAuthored("mock", [{ moduleId: "part1", minCompletions: 2 }]),
+        playbookConfig: makeConfig([
+          { ...makeAuthored("part1"), label: "Part 1: Familiar Topics" },
+          makeAuthored("mock"),
+        ]),
+        callerRole: "STUDENT",
+      });
+      expect(result.missing![0].moduleLabel).toBe("Part 1: Familiar Topics");
+    });
+  });
+
+  describe("normalisePrerequisite / prerequisiteSlugs helpers", () => {
+    it("normalises bare-string to {moduleId, minCompletions: 1}", () => {
+      expect(normalisePrerequisite("part1")).toEqual({
+        moduleId: "part1",
+        minCompletions: 1,
+      });
+    });
+
+    it("normalises object form, defaulting non-positive minCompletions to 1", () => {
+      expect(normalisePrerequisite({ moduleId: "p", minCompletions: 3 })).toEqual({
+        moduleId: "p",
+        minCompletions: 3,
+      });
+      expect(normalisePrerequisite({ moduleId: "p", minCompletions: 0 })).toEqual({
+        moduleId: "p",
+        minCompletions: 1,
+      });
+      expect(normalisePrerequisite({ moduleId: "p" })).toEqual({
+        moduleId: "p",
+        minCompletions: 1,
+      });
+    });
+
+    it("drops invalid entries (no moduleId / null / wrong type)", () => {
+      expect(normalisePrerequisite(null)).toBeNull();
+      expect(normalisePrerequisite(123)).toBeNull();
+      expect(normalisePrerequisite({})).toBeNull();
+      expect(normalisePrerequisite({ moduleId: "" })).toBeNull();
+    });
+
+    it("prerequisiteSlugs extracts just the moduleIds from a mixed array", () => {
+      expect(
+        prerequisiteSlugs([
+          "part1",
+          { moduleId: "part2", minCompletions: 2 },
+          { moduleId: "part3" },
+        ]),
+      ).toEqual(["part1", "part2", "part3"]);
+    });
+
+    it("prerequisiteSlugs returns [] for non-arrays / empty / all-invalid", () => {
+      expect(prerequisiteSlugs(null)).toEqual([]);
+      expect(prerequisiteSlugs(undefined)).toEqual([]);
+      expect(prerequisiteSlugs([])).toEqual([]);
+      expect(prerequisiteSlugs([null, 42, { foo: "bar" }])).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR #1786 widened `AuthoredModule.prerequisites` to `Array<string | {moduleId, minCompletions}>` and shipped the unlock-check gate `lib/curriculum/check-module-unlock.ts::isModuleUnlocked`. PR #1768 (Theme 10) then accidentally deleted the unlock gate and its tests, leaving the type widening behind with NO reader of the rich shape and 8 tsc errors across 6 sites that all assumed `string[]`.

This PR re-lands Theme 5 as a coherent pair (reader + widened type + helper + consumer wiring + DB writer serialization) — the right way to fix it once and for all.

## What ships

- **Restored** `lib/curriculum/check-module-unlock.ts` + its 20-test suite (from `fb07622d^`).
- **NEW** `normalisePrerequisite(p)` + `prerequisiteSlugs(prereqs)` exported helpers + 5 new vitests pinning them.
- **Updated 4 consumer sites** to use `prerequisiteSlugs()` instead of inline `typeof`-branches: `AuthoredModulesPanel`, `LearnerModulePicker` (×2), `detect-authored-modules`.
- **Updated 1 writer site** (`sync-authored-modules-to-curriculum`) to serialise through `prerequisiteSlugs()` before writing to the Prisma `String[]` column (the rich form lives only in `Playbook.config.modules[]`; the DB column is slug-only by design).

## Lattice convergence

| Layer | State after this PR |
|---|---|
| Type def | `Array<string \| {moduleId, minCompletions}>` (already widened on main) |
| Reader (unlock gate) | `isModuleUnlocked` consumes rich form via `normalisePrerequisite` |
| Reader (UI chips / advisory hints / wizard cross-ref) | Single canonical `prerequisiteSlugs()` helper |
| Writer (Prisma `String[]` column) | Serialises through `prerequisiteSlugs()` |
| DB | `CurriculumModule.prerequisites: String[]` — unchanged |

No two consumers re-implement the typeof-check. No writer can leak the object form into the DB column.

## Supersedes PR #1827

PR #1827 reverted the type widening to `string[]` as a quick fix for the same 8 tsc errors. This PR keeps the widening AND ships the machinery to support it. If both merge, the later one wins — this PR is preferred (preserves Theme 5 intent + the gate behaviour). No branch-dance: both PRs left open; user picks.

## Verified by

- `npx tsc --noEmit` — errors 57 → 49 (-8: AuthoredModulesPanel ×2, LearnerModulePicker ×3, detect-authored-modules ×1, sync-authored-modules-to-curriculum ×2) [verified]. Ratchet bumped accordingly.
- `npx vitest run tests/lib/curriculum/check-module-unlock.test.ts tests/lib/recommend-next-module.test.ts tests/lib/working-set-selector.test.ts tests/lib/module-flags-defaults.test.ts tests/lib/is-course-complete.test.ts tests/api/import-modules-prereqs.test.ts` — 86/86 pass (20 + 5 new helper + 12 + 25 + 12 + 12 + 5) [verified].
- Sibling-writer survey (per `.claude/rules/lattice-survey.md`):
  - DB column: `CurriculumModule.prerequisites: String[]` (slug-only) at `prisma/schema.prisma:2817` [verified].
  - Writers to the DB column: only `sync-authored-modules-to-curriculum.ts` — now serialises via `prerequisiteSlugs()`.
  - Writers to `Playbook.config.modules[].prerequisites` (rich form): wizard's `applyAuthoredModules` path — rich shape preserved through `Playbook.config` JSON column.
  - Readers of the rich form: only `isModuleUnlocked` (via `normalisePrerequisite`). All other sites use `prerequisiteSlugs()` — no silent downgrade.

## Test plan

- [x] tsc count drops by 8
- [x] 86/86 affected vitest banks pass (25 unlock-check incl. helpers + 61 sibling)
- [x] Helper API exported + tested
- [ ] Manual smoke on hf-dev: open Course Design → Authored Modules panel → an IELTS Mock module with `{moduleId: "part1", minCompletions: 2}` prereqs shows the right chips. STUDENT enrolment locked when prereqs unmet. OPERATOR bypasses [pending `/vm-cp` + seed fixture].

🤖 Generated with [Claude Code](https://claude.com/claude-code)