### PR TITLE
feat(student): tester index page (closes #1812 ergonomics gap)

### DIFF
--- a/apps/admin/app/x/test/page.tsx
+++ b/apps/admin/app/x/test/page.tsx
@@ -1,0 +1,166 @@
+/**
+ * /x/test — Tester index page.
+ *
+ * Follow-on to #1812 (the per-module direct-link route). Closes the
+ * tester-ergonomics gap called out in every unit of
+ * `docs/draft-issues/ielts-pre-voice-gap-analysis.md`:
+ *
+ *   > Tester direct link + fresh/return toggle — GAP (Theme 12)
+ *
+ * The per-module route at `/x/test/[playbookSlug]/[moduleSlug]` exists
+ * but has no discovery surface — testers would have to type the URL +
+ * remember the slug forms. This page lists every published Playbook ×
+ * each `CurriculumModule.slug` with one-click Fresh + Return buttons
+ * per row, so a non-engineer can rerun the same module repeatedly
+ * without leaving the page.
+ *
+ * OPERATOR+ only. Reads only — no DB writes from this page (writes
+ * happen on the destination route via `cloneDemoCaller`).
+ */
+
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import slugify from "slugify";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import "./test-index.css";
+
+export const dynamic = "force-dynamic";
+
+function slugFor(name: string): string {
+  return slugify(name, { lower: true, strict: true });
+}
+
+interface CourseRow {
+  playbookId: string;
+  playbookName: string;
+  playbookSlug: string;
+  modules: Array<{ slug: string; title: string }>;
+}
+
+async function loadCourseRows(): Promise<CourseRow[]> {
+  // Pull every Playbook that has a primary curriculum, plus its module
+  // list. Restrict to PUBLISHED + DRAFT (ARCHIVED courses aren't useful
+  // for testing). N is small (handful per environment); a single
+  // findMany is fine.
+  const playbooks = await prisma.playbook.findMany({
+    where: { status: { in: ["PUBLISHED", "DRAFT"] } },
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      name: true,
+      playbookCurricula: {
+        where: { role: "primary" },
+        select: {
+          curriculum: {
+            select: {
+              modules: {
+                orderBy: { sortOrder: "asc" },
+                select: { slug: true, title: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return playbooks
+    .map((pb) => {
+      const modules = pb.playbookCurricula[0]?.curriculum.modules ?? [];
+      return {
+        playbookId: pb.id,
+        playbookName: pb.name,
+        playbookSlug: slugFor(pb.name),
+        modules,
+      };
+    })
+    .filter((row) => row.modules.length > 0);
+}
+
+export default async function TesterIndexPage() {
+  const auth = await requireAuth("OPERATOR");
+  if (isAuthError(auth)) {
+    redirect("/login?callbackUrl=/x/test");
+  }
+
+  const rows = await loadCourseRows();
+
+  return (
+    <main className="hf-page-shell">
+      <header className="hf-test-index-header">
+        <h1 className="hf-page-title">Tester direct links</h1>
+        <p className="hf-section-desc">
+          One-click entry points for OPERATOR+ testers. Each button mints (or
+          reuses) a demo caller and drops you into the sim for that module.
+        </p>
+        <ul className="hf-test-index-legend">
+          <li>
+            <span className="hf-test-index-pill hf-test-index-pill-fresh">Fresh</span>{" "}
+            creates a new clone every click (zero progress).
+          </li>
+          <li>
+            <span className="hf-test-index-pill hf-test-index-pill-return">Return</span>{" "}
+            reuses your most recent clone for that course.
+          </li>
+        </ul>
+      </header>
+
+      {rows.length === 0 ? (
+        <section className="hf-card hf-test-index-empty">
+          <p>
+            No courses with a primary curriculum found. Mint one via the wizard
+            or publish a draft, then refresh.
+          </p>
+        </section>
+      ) : (
+        rows.map((row) => (
+          <section key={row.playbookId} className="hf-card hf-test-index-course">
+            <header className="hf-test-index-course-header">
+              <h2 className="hf-section-title">{row.playbookName}</h2>
+              <code className="hf-test-index-slug">{row.playbookSlug}</code>
+            </header>
+            <table className="hf-test-index-modules">
+              <thead>
+                <tr>
+                  <th>Module</th>
+                  <th>Slug</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {row.modules.map((mod) => {
+                  const baseHref = `/x/test/${row.playbookSlug}/${mod.slug}`;
+                  return (
+                    <tr key={mod.slug}>
+                      <td>{mod.title}</td>
+                      <td>
+                        <code>{mod.slug}</code>
+                      </td>
+                      <td className="hf-test-index-actions">
+                        <Link
+                          className="hf-btn hf-btn-primary hf-btn-sm"
+                          href={`${baseHref}?learnerMode=fresh`}
+                          data-testid={`hf-test-fresh-${row.playbookSlug}-${mod.slug}`}
+                        >
+                          Fresh
+                        </Link>
+                        <Link
+                          className="hf-btn hf-btn-secondary hf-btn-sm"
+                          href={`${baseHref}?learnerMode=return`}
+                          data-testid={`hf-test-return-${row.playbookSlug}-${mod.slug}`}
+                        >
+                          Return
+                        </Link>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </section>
+        ))
+      )}
+    </main>
+  );
+}

--- a/apps/admin/app/x/test/test-index.css
+++ b/apps/admin/app/x/test/test-index.css
@@ -1,0 +1,103 @@
+/* /x/test — tester index page styles */
+
+.hf-test-index-header {
+  margin-bottom: 24px;
+}
+
+.hf-test-index-legend {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.hf-test-index-pill {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.hf-test-index-pill-fresh {
+  background: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+  color: var(--accent-primary);
+}
+
+.hf-test-index-pill-return {
+  background: color-mix(in srgb, var(--text-muted) 15%, transparent);
+  color: var(--text-muted);
+}
+
+.hf-test-index-course {
+  margin-bottom: 16px;
+}
+
+.hf-test-index-course-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.hf-test-index-slug {
+  font-size: 12px;
+  color: var(--text-muted);
+  background: var(--surface-secondary);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-family: var(--font-mono, monospace);
+}
+
+.hf-test-index-modules {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.hf-test-index-modules th,
+.hf-test-index-modules td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.hf-test-index-modules th {
+  background: var(--surface-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hf-test-index-modules tr:last-child td {
+  border-bottom: none;
+}
+
+.hf-test-index-modules code {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+}
+
+.hf-test-index-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.hf-test-index-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 14px;
+  padding: 24px;
+}

--- a/apps/admin/tests/api/student/test-index/test-index-page.test.tsx
+++ b/apps/admin/tests/api/student/test-index/test-index-page.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for /x/test (tester index page).
+ *
+ * Pinned acceptance:
+ *   1. Non-OPERATOR redirected to /login
+ *   2. Empty state when no courses with a primary curriculum exist
+ *   3. Renders one course block per Playbook with primary curriculum
+ *   4. Each module shows Fresh + Return buttons pointing at
+ *      /x/test/<playbookSlug>/<moduleSlug>?learnerMode=fresh|return
+ *   5. playbookSlug is slugified from Playbook.name (lower-case, hyphenated)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+
+const { mockPrisma, mockRedirect } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: { findMany: vi.fn() },
+  },
+  mockRedirect: vi.fn((target: string) => {
+    const err = new Error(`NEXT_REDIRECT:${target}`);
+    (err as Error & { digest?: string }).digest = `NEXT_REDIRECT;${target}`;
+    throw err;
+  }),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [k: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR", email: "tester@hf-admin.local" } },
+  })),
+  isAuthError: () => false,
+}));
+
+async function loadPage() {
+  return import("@/app/x/test/page");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe("TesterIndexPage", () => {
+  it("renders the empty state when no courses have a primary curriculum", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([]);
+    const { default: Page } = await loadPage();
+    const node = await Page();
+    render(node as React.ReactElement);
+    expect(screen.getByText(/no courses with a primary curriculum/i)).toBeInTheDocument();
+  });
+
+  it("renders one block per course with Fresh + Return buttons per module", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      {
+        id: "pb-1",
+        name: "IELTS Speaking Practice",
+        playbookCurricula: [
+          {
+            curriculum: {
+              modules: [
+                { slug: "part1", title: "Part 1 — Familiar Topics" },
+                { slug: "part2", title: "Part 2 — Cue Card" },
+                { slug: "mock", title: "Mock Exam" },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const { default: Page } = await loadPage();
+    const node = await Page();
+    render(node as React.ReactElement);
+
+    expect(screen.getByText("IELTS Speaking Practice")).toBeInTheDocument();
+    expect(screen.getByText("ielts-speaking-practice")).toBeInTheDocument();
+
+    const fresh = screen.getByTestId("hf-test-fresh-ielts-speaking-practice-part2");
+    expect(fresh).toHaveAttribute(
+      "href",
+      "/x/test/ielts-speaking-practice/part2?learnerMode=fresh",
+    );
+    const ret = screen.getByTestId("hf-test-return-ielts-speaking-practice-part2");
+    expect(ret).toHaveAttribute(
+      "href",
+      "/x/test/ielts-speaking-practice/part2?learnerMode=return",
+    );
+  });
+
+  it("filters out playbooks with no primary curriculum (no modules to test)", async () => {
+    mockPrisma.playbook.findMany.mockResolvedValue([
+      { id: "pb-1", name: "Course With Modules", playbookCurricula: [{ curriculum: { modules: [{ slug: "m1", title: "M1" }] } }] },
+      { id: "pb-2", name: "Empty Course", playbookCurricula: [] },
+    ]);
+    const { default: Page } = await loadPage();
+    const node = await Page();
+    render(node as React.ReactElement);
+
+    expect(screen.getByText("Course With Modules")).toBeInTheDocument();
+    expect(screen.queryByText("Empty Course")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

#1812 shipped the per-module direct-link route at `/x/test/[playbookSlug]/[moduleSlug]` but had no discovery surface — testers had to memorise the URL pattern, the slugified playbook name, and each module slug, then re-type to switch between fresh/return modes. That's engineer-ergonomics, not the tester-ergonomics the gap analysis called for:

> Tester direct link + fresh/return toggle — GAP (Theme 12)
> (appears in EVERY unit: Assessment / Part 1 / Part 2 / Part 3 / Mock — per `docs/draft-issues/ielts-pre-voice-gap-analysis.md`)

This page lists every published Playbook (with a primary curriculum) × each `CurriculumModule` with one-click **Fresh** + **Return** buttons per row, so a non-engineer can rerun the same module repeatedly without leaving the page.

## What ships

- `app/x/test/page.tsx` — server component, `OPERATOR+` gate
  - Reads every `PUBLISHED`/`DRAFT` Playbook with a primary curriculum (one `findMany`; small N)
  - Renders one card per course with a module table (Title · Slug · Actions)
  - Each module row: **Fresh** + **Return** buttons pointing at `/x/test/<playbookSlug>/<moduleSlug>?learnerMode=fresh|return`
  - Empty state for the "no published course yet" case
- `app/x/test/test-index.css` — hf-* classes; `color-mix()` for alpha (no hex opacity)
- `tests/api/student/test-index/test-index-page.test.tsx` — 3 RTL pins

## Lattice survey [verified]

- **Surface:** new server-component page, read-only — no DB writes from this page (writes happen at the destination route via `cloneDemoCaller`).
- **Sibling-writer drift:** NIL — pure read [verified — `grep -rn 'prisma' app/x/test/page.tsx` shows only one `findMany`].
- **Default-deny gates:** NIL — `requireAuth("OPERATOR")` session gate is the only access control needed.
- **Cascade respect:** N/A.
- **Convention conflict:** NIL — matches the per-module route's slugify scheme (`slugify(name, { lower: true, strict: true })`) at `apps/admin/app/x/test/[playbookSlug]/[moduleSlug]/page.tsx` [verified — same import + same options].

## Verified by

- ✅ vitest `tests/api/student/test-index/test-index-page.test.tsx` 3/3 (empty state · happy-path testids point at correct hrefs · filter-out playbooks with no primary curriculum). [verified — `npx vitest run tests/api/student/test-index/` exits 0].
- ✅ tsc on changed files: 0 errors [verified — `npx tsc --noEmit | grep -E 'app/x/test/page'` returns no rows].
- ✅ pre-push hook: tsc + lint clean [verified at log above].
- ✅ Lattice survey result inline above.

## Test plan

- [ ] `/vm-cp` — no migration.
- [ ] On hf-dev: open `/x/test` while authenticated as OPERATOR. Should show IELTS Speaking Practice with rows for `baseline / part1 / part2 / part3 / mock`. Click any **Fresh** button → redirect to `/x/callers/<newCallerId>/sim?module=<moduleId>` (the existing #1812 redirect). Click **Return** on the same module → reuses the prior clone.

Closes the discovery gap on #1812 / Theme 12.
