### PR TITLE
feat(student): #1751 closeout — Mock Results post-call redirect + outbound nav

### DIFF
--- a/apps/admin/app/api/calls/[callId]/post-call-redirect/route.ts
+++ b/apps/admin/app/api/calls/[callId]/post-call-redirect/route.ts
@@ -1,0 +1,77 @@
+/**
+ * @api GET /api/calls/:callId/post-call-redirect
+ * @visibility public
+ * @scope calls:read
+ * @auth session (VIEWER+ — STUDENT scoped to own caller)
+ * @tags calls
+ * @description Resolves the URL a STUDENT learner should land on after
+ *   a call ends. Closes the Epic #1700 missing-surface gap on Theme
+ *   13a (Mock Results, #1751): pre-this-route Mock learners were
+ *   redirected to the generic `/x/student` home and never saw the
+ *   per-session Mock Results screen.
+ *
+ *   Returns `{ target: "/x/student/<playbookId>/results/<sessionId>" }`
+ *   for Mock-style calls (bound `CurriculumModule.coversModules.length > 0`
+ *   — the canonical multi-part Mock discriminator from #1702 / #1785).
+ *   Returns `{ target: "/x/student" }` otherwise.
+ *
+ *   STUDENT scope: enforced via `studentAllowedToReadCaller` against
+ *   the Call's `callerId` (mirrors the precedent at
+ *   `/api/calls/[callId]/route.ts`).
+ *
+ * @pathParam callId string - Call.id
+ * @response 200 { ok: true, target: string }
+ * @response 403 { ok: false, error: string }
+ * @response 404 { ok: false, error: string }
+ * @response 500 { ok: false, error: string }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
+
+const FALLBACK_TARGET = "/x/student";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ callId: string }> },
+): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth("VIEWER");
+    if (isAuthError(authResult)) return authResult.error;
+
+    const { callId } = await params;
+
+    const call = await prisma.call.findUnique({
+      where: { id: callId },
+      select: {
+        callerId: true,
+        playbookId: true,
+        sessionId: true,
+        curriculumModule: { select: { coversModules: true } },
+      },
+    });
+    if (!call) {
+      return NextResponse.json({ ok: false, error: "Call not found" }, { status: 404 });
+    }
+
+    if (!studentAllowedToReadCaller(authResult.session, call.callerId)) {
+      return callerScopeMismatchResponse();
+    }
+
+    const coversCount = call.curriculumModule?.coversModules?.length ?? 0;
+    const target =
+      call.playbookId && call.sessionId && coversCount > 0
+        ? `/x/student/${call.playbookId}/results/${call.sessionId}`
+        : FALLBACK_TARGET;
+
+    return NextResponse.json({ ok: true, target });
+  } catch (err) {
+    console.error("[/api/calls/[callId]/post-call-redirect] error", err);
+    return NextResponse.json(
+      { ok: false, error: "Failed to resolve post-call redirect" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -11,6 +11,33 @@ import { deriveParameterMap } from '@/lib/agent-tuner/derive';
 import type { AgentTunerPill } from '@/lib/agent-tuner/types';
 
 /**
+ * Epic #1700 missing-surface sweep — Mock learner post-call redirect.
+ *
+ * Resolves the target URL for a STUDENT learner returning from a call.
+ * For Mock-style calls (bound module declares `coversModules.length > 0`
+ * — the canonical "multi-part Mock" discriminator established in
+ * #1702/#1785), routes to the Mock Results screen at
+ * `/x/student/<playbookId>/results/<sessionId>`. Falls back to
+ * `/x/student` for anything else (regular tutor calls, errors, missing
+ * data).
+ *
+ * Network-best-effort: on any fetch or parse failure, return the
+ * fallback URL. Never throws.
+ */
+async function resolvePostCallRedirect(callId: string | undefined): Promise<string> {
+  const fallback = '/x/student';
+  if (!callId) return fallback;
+  try {
+    const res = await fetch(`/api/calls/${callId}/post-call-redirect`);
+    if (!res.ok) return fallback;
+    const body = (await res.json()) as { ok?: boolean; target?: string };
+    return body?.ok && typeof body.target === 'string' ? body.target : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
  * /x/sim/[callerId] — standalone simulator page (#1448).
  *
  * Page-level responsibilities:
@@ -158,8 +185,18 @@ export default function SimConversationPage() {
       onBack={isDesktop ? undefined : () => router.push('/x/sim')}
       onCallEnd={
         isStudent
-          ? () => {
-              setTimeout(() => router.push('/x/student'), 1500);
+          ? (info) => {
+              // Epic #1700 missing-surface sweep — Mock learners should
+              // land on the Mock Results screen (Theme 13a / #1751)
+              // instead of the generic /x/student home. Fetches the
+              // just-ended call's session + playbook + bound module
+              // mode/terminal flags and routes accordingly. Falls back
+              // to /x/student on any error or for non-Mock modules.
+              setTimeout(() => {
+                void resolvePostCallRedirect(info?.callId).then((target) => {
+                  router.push(target);
+                });
+              }, 1500);
             }
           : undefined
       }

--- a/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
@@ -22,6 +22,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
+import Link from "next/link";
 import { Loader2 } from "lucide-react";
 import type { ResultsPayload, ResultsResponse } from "@/app/api/student/[courseId]/results/[sessionId]/route";
 import "./results.css";
@@ -208,6 +209,27 @@ function ResultsView({ data }: { data: ResultsPayload }) {
           <div className="hf-results-table-empty">No scores recorded for this session.</div>
         )}
       </section>
+
+      {/* Outbound navigation — Results is a per-session band card; learner
+       *  still needs a path to their broader Progress dashboard and back
+       *  to module pick for another attempt. Added in the Epic #1700
+       *  missing-surface sweep — pre-fix learner was stranded here. */}
+      <nav className="hf-results-actions" aria-label="What's next">
+        <Link
+          className="hf-btn hf-btn-primary"
+          href={`/x/student/${data.courseId}/modules`}
+          data-testid="hf-results-pick-module"
+        >
+          Pick another module
+        </Link>
+        <Link
+          className="hf-btn hf-btn-secondary"
+          href="/x/student/progress"
+          data-testid="hf-results-view-progress"
+        >
+          View overall progress
+        </Link>
+      </nav>
     </>
   );
 }

--- a/apps/admin/app/x/student/[courseId]/results/[sessionId]/results.css
+++ b/apps/admin/app/x/student/[courseId]/results/[sessionId]/results.css
@@ -212,3 +212,12 @@
   font-size: 14px;
   text-align: center;
 }
+
+/* Outbound nav (Epic #1700 missing-surface sweep) */
+.hf-results-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}

--- a/apps/admin/components/callers/CallerVoiceSurface.tsx
+++ b/apps/admin/components/callers/CallerVoiceSurface.tsx
@@ -69,11 +69,13 @@ export interface CallerVoiceSurfaceProps {
   /** STANDALONE-only — passed through to SimChat. Routes back to /x/sim on mobile. */
   onBack?: () => void;
   /**
-   * STANDALONE-only — STUDENT-session post-call redirect. Sim page passes
-   * a 1.5s `router.push('/x/student')` for learners. Embedded callers
-   * (admin) leave this undefined.
+   * STANDALONE-only — STUDENT-session post-call redirect. Sim page reads
+   * the just-ended `callId` (when present) and routes to the Mock
+   * Results screen (Epic #1700 Theme 13a) for Mock-style modules; falls
+   * back to `/x/student` otherwise. Embedded callers (admin) leave this
+   * undefined.
    */
-  onCallEnd?: () => void;
+  onCallEnd?: (info?: { callId: string }) => void;
   /**
    * EMBEDDED — parent's hook to refetch its own caller data + prompts
    * after the call ends, so the broader caller-detail view stays in sync.
@@ -324,10 +326,13 @@ export function CallerVoiceSurface({
     setCallSession((prev) => prev + 1);
   }, []);
 
-  const handleCallEnd = useCallback(() => {
-    onCallEnd?.();
-    onPostCallRefresh?.();
-  }, [onCallEnd, onPostCallRefresh]);
+  const handleCallEnd = useCallback(
+    (info?: { callId: string }) => {
+      onCallEnd?.(info);
+      onPostCallRefresh?.();
+    },
+    [onCallEnd, onPostCallRefresh],
+  );
 
   if (error) {
     return (

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -53,7 +53,18 @@ export interface SimChatProps {
   sessionGoal?: string;
   targetOverrides?: Record<string, number>;
   forceFirstCall?: boolean;
-  onCallEnd?: () => void;
+  /**
+   * Fires once the call has fully wrapped (Call row written, transcript
+   * persisted, end-of-call telemetry flushed).
+   *
+   * Argument shape was widened in the Epic #1700 missing-surface sweep
+   * so the standalone sim page can route Mock learners to the Results
+   * screen instead of the generic /x/student home. Callers that don't
+   * care about the just-ended call id continue to work — the arg is
+   * optional and most existing call sites pass a `() =>` shape that
+   * structurally satisfies the wider signature.
+   */
+  onCallEnd?: (info?: { callId: string }) => void;
   onNewCall?: () => void;
   onBack?: () => void;
   /**
@@ -1124,7 +1135,7 @@ export function SimChat({
       // phase transition — so the breadcrumb stays "Active" through any
       // post-call UI settle and only flips back once the call is fully
       // wrapped. Sync the ref so the watcher effect won't re-fire.
-      onCallEnd?.();
+      onCallEnd?.(callId ? { callId } : undefined);
       lastCallActiveFiredRef.current = false;
       onCallStateChange?.(false);
       journey?.onCallEnd();

--- a/apps/admin/tests/api/calls/post-call-redirect/post-call-redirect.test.ts
+++ b/apps/admin/tests/api/calls/post-call-redirect/post-call-redirect.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
 
 const { mockPrisma, mockStudentAllowed } = vi.hoisted(() => ({
   mockPrisma: {
@@ -55,14 +56,14 @@ describe("GET /api/calls/[callId]/post-call-redirect", () => {
       curriculumModule: { coversModules: ["part1", "part2", "part3"] },
     });
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x"), PARAMS);
     expect(res.status).toBe(403);
   });
 
   it("returns 404 when call not found", async () => {
     mockPrisma.call.findUnique.mockResolvedValue(null);
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x"), PARAMS);
     expect(res.status).toBe(404);
   });
 
@@ -74,7 +75,7 @@ describe("GET /api/calls/[callId]/post-call-redirect", () => {
       curriculumModule: { coversModules: ["part1", "part2", "part3"] },
     });
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x"), PARAMS);
     const body = (await res.json()) as { ok: true; target: string };
     expect(res.status).toBe(200);
     expect(body.target).toBe("/x/student/pb-1/results/sess-1");
@@ -88,7 +89,7 @@ describe("GET /api/calls/[callId]/post-call-redirect", () => {
       curriculumModule: { coversModules: [] },
     });
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x"), PARAMS);
     const body = (await res.json()) as { ok: true; target: string };
     expect(body.target).toBe("/x/student");
   });
@@ -101,7 +102,7 @@ describe("GET /api/calls/[callId]/post-call-redirect", () => {
       curriculumModule: null,
     });
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x"), PARAMS);
     const body = (await res.json()) as { ok: true; target: string };
     expect(body.target).toBe("/x/student");
   });
@@ -114,7 +115,7 @@ describe("GET /api/calls/[callId]/post-call-redirect", () => {
       curriculumModule: { coversModules: ["part1"] },
     });
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x"), PARAMS);
     const body = (await res.json()) as { ok: true; target: string };
     expect(body.target).toBe("/x/student");
   });
@@ -127,7 +128,7 @@ describe("GET /api/calls/[callId]/post-call-redirect", () => {
       curriculumModule: { coversModules: ["part1"] },
     });
     const route = await loadRoute();
-    const res = await route.GET(new Request("http://x"), PARAMS);
+    const res = await route.GET(new NextRequest("http://x"), PARAMS);
     const body = (await res.json()) as { ok: true; target: string };
     expect(body.target).toBe("/x/student");
   });

--- a/apps/admin/tests/api/calls/post-call-redirect/post-call-redirect.test.ts
+++ b/apps/admin/tests/api/calls/post-call-redirect/post-call-redirect.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for `GET /api/calls/[callId]/post-call-redirect`.
+ *
+ * Pinned acceptance:
+ *   1. STUDENT scope rejects foreign callerId (403)
+ *   2. 404 when call not found
+ *   3. Mock-style call (coversModules.length > 0) returns
+ *      `/x/student/<playbookId>/results/<sessionId>`
+ *   4. Non-Mock call (coversModules empty / module absent) returns
+ *      `/x/student` fallback
+ *   5. Missing playbookId or sessionId returns `/x/student` fallback
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, mockStudentAllowed } = vi.hoisted(() => ({
+  mockPrisma: {
+    call: { findUnique: vi.fn() },
+  },
+  mockStudentAllowed: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: mockStudentAllowed,
+  callerScopeMismatchResponse: () =>
+    new Response(JSON.stringify({ ok: false, error: "scope" }), { status: 403 }),
+}));
+
+const PARAMS = { params: Promise.resolve({ callId: "call-1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/calls/[callId]/post-call-redirect/route");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStudentAllowed.mockReturnValue(true);
+});
+
+describe("GET /api/calls/[callId]/post-call-redirect", () => {
+  it("rejects STUDENT reading foreign call (403)", async () => {
+    mockStudentAllowed.mockReturnValue(false);
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "caller-1",
+      playbookId: "pb-1",
+      sessionId: "sess-1",
+      curriculumModule: { coversModules: ["part1", "part2", "part3"] },
+    });
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when call not found", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue(null);
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns Mock Results URL when coversModules.length > 0", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "caller-1",
+      playbookId: "pb-1",
+      sessionId: "sess-1",
+      curriculumModule: { coversModules: ["part1", "part2", "part3"] },
+    });
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x"), PARAMS);
+    const body = (await res.json()) as { ok: true; target: string };
+    expect(res.status).toBe(200);
+    expect(body.target).toBe("/x/student/pb-1/results/sess-1");
+  });
+
+  it("returns /x/student fallback for non-Mock call (coversModules empty)", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "caller-1",
+      playbookId: "pb-1",
+      sessionId: "sess-1",
+      curriculumModule: { coversModules: [] },
+    });
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x"), PARAMS);
+    const body = (await res.json()) as { ok: true; target: string };
+    expect(body.target).toBe("/x/student");
+  });
+
+  it("returns /x/student fallback when curriculumModule is null (regular tutor call)", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "caller-1",
+      playbookId: "pb-1",
+      sessionId: "sess-1",
+      curriculumModule: null,
+    });
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x"), PARAMS);
+    const body = (await res.json()) as { ok: true; target: string };
+    expect(body.target).toBe("/x/student");
+  });
+
+  it("returns /x/student fallback when sessionId is missing (orphan Call)", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "caller-1",
+      playbookId: "pb-1",
+      sessionId: null,
+      curriculumModule: { coversModules: ["part1"] },
+    });
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x"), PARAMS);
+    const body = (await res.json()) as { ok: true; target: string };
+    expect(body.target).toBe("/x/student");
+  });
+
+  it("returns /x/student fallback when playbookId is missing", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "caller-1",
+      playbookId: null,
+      sessionId: "sess-1",
+      curriculumModule: { coversModules: ["part1"] },
+    });
+    const route = await loadRoute();
+    const res = await route.GET(new Request("http://x"), PARAMS);
+    const body = (await res.json()) as { ok: true; target: string };
+    expect(body.target).toBe("/x/student");
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -3447,6 +3447,38 @@ SPEC-DRIVEN pipeline endpoint that runs analysis in configurable stages. Pipelin
 
 ---
 
+### `GET` /api/calls/:callId/post-call-redirect
+
+Resolves the URL a STUDENT learner should land on after
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `calls:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callId | path | string | Yes | Call.id |
+
+**Response** `200`
+```json
+{ ok: true, target: string }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `GET` /api/calls/[callId]/messages
 
 Fetch messages for a call, optionally filtered by timestamp and role. Includes call ended status for observation polling.
@@ -16244,8 +16276,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 538 |
-| Files with annotations | 524 |
+| Route files found | 539 |
+| Files with annotations | 525 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -1291,6 +1291,38 @@ SPEC-DRIVEN pipeline endpoint that runs analysis in configurable stages. Pipelin
 
 ---
 
+### `GET` /api/v1/calls/:callId/post-call-redirect
+
+Resolves the URL a STUDENT learner should land on after
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `calls:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callId | path | string | Yes | Call.id |
+
+**Response** `200`
+```json
+{ ok: true, target: string }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `GET` /api/v1/calls/rewards
 
 List reward scores across all calls, ordered by most recent. Includes associated call source and transcript.


### PR DESCRIPTION
## Summary

Epic #1700 missing-surface sweep — surface 1 of 3.

### The gap

#1751 shipped the Mock Results page at `/x/student/<courseId>/results/<sessionId>` but:
1. Nothing redirected learners there after their Mock call ended — `app/x/sim/[callerId]/page.tsx:162` hardcoded `setTimeout(() => router.push('/x/student'), 1500)` so Mock learners landed on the generic student home, never saw their bands.
2. The Results page had ZERO outbound links — once they got there (via direct URL or the new redirect), no way to navigate to broader Progress or back to module pick.

Both fixed here.

### How Results relates to Progress (per discussion)

| Page | Audience moment | What it shows |
|---|---|---|
| `/x/student/progress` (existing) | Cumulative dashboard | total calls · personality · goals · top topics · surveys · uplift · qualification · classroom · journey |
| `/x/student/<courseId>/results/<sessionId>` (new in #1751) | Per-session band card after a Mock | Overall band · Strength · Area · 4×3 per-criterion-per-part table |

Complementary, not duplicative. Mock learners go to Results FIRST (the band number is what they care about right after the exam), then navigate to Progress from the new "View overall progress" button.

## What ships

- New route `GET /api/calls/[callId]/post-call-redirect` — server-side decision. Returns `{target: "/x/student/<playbookId>/results/<sessionId>"}` for Mock-style calls (bound `CurriculumModule.coversModules.length > 0` — canonical multi-part Mock discriminator from #1702/#1785), otherwise `{target: "/x/student"}`. STUDENT scope via `studentAllowedToReadCaller`.
- `components/sim/SimChat.tsx` — `onCallEnd` widened from `() => void` to `(info?: { callId: string }) => void`. Forwards the just-ended `callId` so the parent can make a routing decision. Backwards-compatible (existing `() =>` call sites still satisfy the wider signature structurally).
- `components/callers/CallerVoiceSurface.tsx` — propagates the same signature; `handleCallEnd` forwards the `info` arg.
- `app/x/sim/[callerId]/page.tsx` — adds `resolvePostCallRedirect(callId)` helper that calls the new route. STUDENT redirect branches on the response. Network-failure best-effort: any fetch/parse error → `/x/student` fallback.
- `app/x/student/[courseId]/results/[sessionId]/page.tsx` — adds two-button outbound nav: "Pick another module" → `/x/student/<courseId>/modules`, "View overall progress" → `/x/student/progress`. CSS class `hf-results-actions` appended to results.css.

## Lattice survey [verified]

- **Surface:** new read-only route + interface widening in the sim flow. No DB writes.
- **Sibling-writer drift:** NIL — pure read. [verified — `grep -rn 'prisma' app/api/calls/[callId]/post-call-redirect/route.ts` shows only one `findUnique`].
- **Default-deny gates:** fallback `/x/student` covers every failure mode (no call · no session · no playbook · no module · error). [verified — 7-case vitest].
- **Cascade respect:** N/A.
- **Convention conflict:** NIL — STUDENT-scope helper `studentAllowedToReadCaller` matches `app/api/calls/[callId]/route.ts:182` precedent [verified].

## Verified by

- ✅ vitest `tests/api/calls/post-call-redirect/post-call-redirect.test.ts` 7/7 (STUDENT 403 · 404 missing call · Mock URL · empty coversModules · null module · null sessionId · null playbookId). [verified — `npx vitest run tests/api/calls/post-call-redirect/` exits 0].
- ✅ tsc on changed files: 0 errors. [verified — `npx tsc --noEmit | grep -E 'post-call-redirect|sim/\[callerId\]/page|SimChat|CallerVoiceSurface'` returns no rows].
- ✅ pre-push: tsc + lint clean on changed files. [verified at log above].
- ✅ Lattice survey result inline above.

## Test plan

- [ ] `/vm-cp` — no migration.
- [ ] On hf-dev: sign in as STUDENT. Run a regular tutor call → ends → land on `/x/student` (unchanged). Run a Mock call → ends → land on `/x/student/<playbookId>/results/<sessionId>` with the band card. Click "View overall progress" → land on `/x/student/progress`. Click "Pick another module" → land on the module picker.

Closes the discovery gap on #1751.
