### PR TITLE
feat(voice): #1733 + #1744 — pinned cue-card writer + slot (Theme 3)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pinned-card/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pinned-card/route.ts
@@ -1,0 +1,66 @@
+/**
+ * @api GET /api/calls/:callId/pinned-card
+ * @visibility internal
+ * @scope calls:read
+ * @auth VIEWER (STUDENT scoped to own caller; OPERATOR+ unrestricted)
+ * @tags calls, voice, ielts
+ * @description #1744 (epic #1700 Theme 3) — read the persisted
+ * `Session.metadata.pinnedCard` so `<PinnedCardSlot>` can render the
+ * Part 2 / Part 3 / Mock cue card above SimChat. The write happens at
+ * session-start in `createSession` (#1733) under the same selection
+ * policy the prompt-side composer uses, so the UI card and the
+ * composed CUE CARD directive agree byte-for-byte.
+ *
+ * Returns `{ ok: true, card: null }` when:
+ *   - `HF_FLAG_IELTS_MODULE_SETTINGS` is off
+ *   - the call has no `sessionId` (legacy)
+ *   - the Session has no `metadata.pinnedCard` (no cueCardPool / non-IELTS)
+ *
+ * @response 200 { ok: true, card: PinnedCardContent | null }
+ * @response 403 { ok: false, error: "STUDENT cannot read a different caller" }
+ * @response 404 { ok: false, error: "Call not found" }
+ */
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  studentAllowedToReadCaller,
+  callerScopeMismatchResponse,
+} from "@/lib/learner-scope";
+import { isIeltsModuleSettingsEnabled } from "@/lib/journey/module-settings-flag";
+import type { PinnedCardContent, SessionMetadata } from "@/lib/types/json-fields";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ callId: string }> },
+) {
+  const auth = await requireAuth("VIEWER");
+  if (isAuthError(auth)) return auth.error;
+
+  const { callId } = await params;
+
+  const call = await prisma.call.findUnique({
+    where: { id: callId },
+    select: {
+      callerId: true,
+      session: { select: { metadata: true } },
+    },
+  });
+  if (!call) {
+    return NextResponse.json({ ok: false, error: "Call not found" }, { status: 404 });
+  }
+
+  if (!studentAllowedToReadCaller(auth.session, call.callerId ?? "")) {
+    return callerScopeMismatchResponse();
+  }
+
+  if (!isIeltsModuleSettingsEnabled()) {
+    return NextResponse.json({ ok: true, card: null });
+  }
+
+  const metadata = (call.session?.metadata ?? null) as SessionMetadata | null;
+  const card: PinnedCardContent | null = metadata?.pinnedCard ?? null;
+
+  return NextResponse.json({ ok: true, card });
+}

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1903,6 +1903,78 @@ html.light {
   transform: translateY(1px);
 }
 
+/* #1744 — sticky pinned cue card above SimChat (Theme 3). Holds the
+   Part 2 monologue cue or Part 3 / Mock topic-focus banner so the
+   learner can refer back without scrolling. Sticky positioning keeps
+   it visible as the chat scrolls beneath. */
+.hf-pinned-card {
+  position: sticky;
+  top: 8px;
+  z-index: 10;
+  width: calc(100% - 16px);
+  max-width: 520px;
+  margin: 8px auto;
+  padding: 12px 36px 12px 14px;
+  border-radius: 12px;
+  background: var(--surface-secondary);
+  border: 1px solid color-mix(in srgb, var(--text-primary) 12%, transparent);
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.4;
+  box-shadow: 0 1px 3px color-mix(in srgb, #000 12%, transparent);
+}
+.hf-pinned-card-cue {
+  display: block;
+}
+.hf-pinned-card-focus {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.hf-pinned-card-topic {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.hf-pinned-card-focus .hf-pinned-card-topic {
+  margin-bottom: 0;
+}
+.hf-pinned-card-bullets {
+  list-style: disc;
+  margin: 0 0 0 18px;
+  padding: 0;
+}
+.hf-pinned-card-bullets li {
+  margin-bottom: 2px;
+}
+.hf-pinned-card-note {
+  margin-top: 8px;
+  font-style: italic;
+  color: var(--text-muted);
+}
+.hf-pinned-card-focus-area {
+  color: var(--text-muted);
+}
+.hf-pinned-card-dismiss {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  background: transparent;
+  border: 0;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+.hf-pinned-card-dismiss:hover,
+.hf-pinned-card-dismiss:focus-visible {
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+  color: var(--text-primary);
+  outline: none;
+}
+
 /* #1743 — stall-detector chip. Subtle fade-in cue above the chat surface
    when the learner has gone quiet during a monologue / discussion module.
    Voice never triggers from this; it is a visual nudge only. */

--- a/apps/admin/components/sim/PinnedCardSlot.tsx
+++ b/apps/admin/components/sim/PinnedCardSlot.tsx
@@ -1,0 +1,135 @@
+/**
+ * #1744 (epic #1700 Theme 3) — sticky pinned-card slot above SimChat.
+ *
+ * Renders the cue card (Part 2) or topic-focus banner (Part 3 / Mock
+ * sub-phases) the learner needs visible throughout prep + monologue +
+ * discussion. Source of truth is `Session.metadata.pinnedCard` written
+ * at session-start by `createSession` (#1733) under the same selection
+ * policy the prompt-side composer uses.
+ *
+ * Fetch: one-shot `GET /api/calls/[callId]/pinned-card` when the
+ * supplied `callId` becomes available (a sim `[Talk Here]` click). The
+ * card never changes mid-session — no SSE / polling.
+ *
+ * Render variants by `kind`:
+ *   - "cueCard":   topic + bullets + optional secondaryNote
+ *   - "topicFocus": topic + optional focusArea (single-line)
+ *
+ * Dismissibility: Esc key removes the card for the rest of the session
+ * (does not refetch on the next render). The learner can also call this
+ * a "soft" hide by clicking the ✕ button.
+ *
+ * Auto-clear: when `phaseEnded` flips true (callPhase === "ended" /
+ * "wrapping" at the consumer), the card stops rendering.
+ */
+
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import type { PinnedCardContent } from "@/lib/types/json-fields";
+
+interface PinnedCardSlotProps {
+  callId: string | null;
+  /** When true, the slot renders null regardless of fetched state. */
+  phaseEnded: boolean;
+}
+
+export function PinnedCardSlot({
+  callId,
+  phaseEnded,
+}: PinnedCardSlotProps): React.ReactElement | null {
+  const [card, setCard] = useState<PinnedCardContent | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  // Reset dismissal when callId changes — a new call earns a fresh card.
+  useEffect(() => {
+    setDismissed(false);
+    setCard(null);
+  }, [callId]);
+
+  useEffect(() => {
+    if (!callId) return;
+    const controller = new AbortController();
+    fetch(`/api/calls/${encodeURIComponent(callId)}/pinned-card`, {
+      signal: controller.signal,
+      credentials: "same-origin",
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body: { card?: PinnedCardContent | null } | null) => {
+        if (!body) return;
+        setCard(body.card ?? null);
+      })
+      .catch((err) => {
+        if ((err as Error)?.name === "AbortError") return;
+        // Best-effort — silent on failure (the slot simply renders null).
+      });
+    return () => controller.abort();
+  }, [callId]);
+
+  const handleDismiss = useCallback(() => setDismissed(true), []);
+
+  useEffect(() => {
+    if (!card || dismissed || phaseEnded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleDismiss();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [card, dismissed, phaseEnded, handleDismiss]);
+
+  if (!card || dismissed || phaseEnded) return null;
+
+  if (card.kind === "cueCard") {
+    return (
+      <div
+        className="hf-pinned-card hf-pinned-card-cue"
+        role="region"
+        aria-label="Pinned cue card"
+        data-testid="pinned-card-slot"
+      >
+        <button
+          type="button"
+          className="hf-pinned-card-dismiss"
+          aria-label="Dismiss pinned card"
+          onClick={handleDismiss}
+        >
+          ✕
+        </button>
+        <div className="hf-pinned-card-topic">{card.topic}</div>
+        {card.bullets && card.bullets.length > 0 ? (
+          <ul className="hf-pinned-card-bullets">
+            {card.bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        ) : null}
+        {card.secondaryNote ? (
+          <div className="hf-pinned-card-note">{card.secondaryNote}</div>
+        ) : null}
+      </div>
+    );
+  }
+
+  // kind === "topicFocus"
+  return (
+    <div
+      className="hf-pinned-card hf-pinned-card-focus"
+      role="region"
+      aria-label="Pinned topic focus"
+      data-testid="pinned-card-slot"
+    >
+      <button
+        type="button"
+        className="hf-pinned-card-dismiss"
+        aria-label="Dismiss pinned card"
+        onClick={handleDismiss}
+      >
+        ✕
+      </button>
+      <span className="hf-pinned-card-topic">{card.topic}</span>
+      {card.focusArea ? (
+        <span className="hf-pinned-card-focus-area"> — {card.focusArea}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -25,6 +25,7 @@ import { SimProgressPanel } from './SimProgressPanel';
 import { PostCallProgressCard } from './PostCallProgressCard';
 import { StallChip } from './StallChip';
 import { useStallDetector } from '@/hooks/use-stall-detector';
+import { PinnedCardSlot } from './PinnedCardSlot';
 import { QualificationSessionSummary } from './qualification/QualificationContextStrip';
 import { useStudentProgress } from '@/hooks/useStudentProgress';
 import { useJourneyPosition } from '@/hooks/useJourneyPosition';
@@ -1776,6 +1777,18 @@ export function SimChat({
             <span style={{ fontSize: 12, color: 'var(--status-success-text)' }}>View &rarr;</span>
           </div>
         )}
+
+        {/* #1744 — pinned cue card (Theme 3). Sticky-positioned card
+            above the chat surface that holds the Part 2 monologue cue
+            or Part 3 / Mock topic-focus banner. Read from the persisted
+            Session.metadata.pinnedCard written at session-start by
+            createSession (#1733) under the same selection policy the
+            prompt-side composer uses. Esc-dismissible; auto-clears on
+            session-complete. */}
+        <PinnedCardSlot
+          callId={callId}
+          phaseEnded={callPhase === 'ended' || callPhase === 'wrapping'}
+        />
 
         {/* #1241 Slice 5 — 30s silence watchdog banner. Surfaces when no
             transcript activity for >30s during a live call. Provides a

--- a/apps/admin/lib/voice/create-session.ts
+++ b/apps/admin/lib/voice/create-session.ts
@@ -40,6 +40,13 @@ import {
   deriveSkipStages,
   type SessionKindString,
 } from "@/lib/voice/session-rules";
+import { isIeltsModuleSettingsEnabled } from "@/lib/journey/module-settings-flag";
+import { selectPinnedCardForModule } from "@/lib/voice/select-pinned-card";
+import type {
+  PinnedCardContent,
+  PlaybookConfig,
+  SessionMetadata,
+} from "@/lib/types/json-fields";
 
 export type SessionKind = SessionKindString;
 
@@ -129,6 +136,19 @@ export async function createSession(
     }
   }
 
+  // (3b) #1733 / #1744 (epic #1700 Theme 3) — load the Playbook config
+  // so we can resolve the per-session pinned card pool. Side-effect-free
+  // read; safe outside the transaction. Skipped when the IELTS module
+  // settings flag is off (the same gate the prompt-side reader uses).
+  let pinnedCardConfig: PlaybookConfig | null = null;
+  if (isIeltsModuleSettingsEnabled() && playbookId && resolvedRequestedSlug) {
+    const playbook = await prisma.playbook.findUnique({
+      where: { id: playbookId },
+      select: { config: true },
+    });
+    pinnedCardConfig = (playbook?.config ?? null) as PlaybookConfig | null;
+  }
+
   // (4) usedPromptId — I-CT2 cascade. May be null on a brand-new caller.
   const promptResolution = await resolveUsedPromptId({ callerId: args.callerId });
 
@@ -203,6 +223,23 @@ export async function createSession(
       learnerFacingNumber = lf.nextSeq - 1;
     }
 
+    // #1733 / #1744 (epic #1700 Theme 3) — pin a cue card for THIS
+    // session. Same selection policy as `resolveModuleCueCard` in
+    // `transforms/instructions.ts` so the UI card and the prompt's
+    // CUE CARD directive agree byte-for-byte. Indexes on
+    // `learnerFacingNumber` when it exists (sim drops do not advance
+    // the count, so consecutive learner sessions rotate cards), falls
+    // back to `assignedSeq` otherwise.
+    let pinnedCard: PinnedCardContent | null = null;
+    if (pinnedCardConfig) {
+      pinnedCard = selectPinnedCardForModule({
+        config: pinnedCardConfig,
+        moduleSlug: resolvedRequestedSlug,
+        sequenceNumber: learnerFacingNumber ?? assignedSeq,
+      });
+    }
+    const metadata: SessionMetadata | null = pinnedCard ? { pinnedCard } : null;
+
     const session = await tx.session.create({
       data: {
         callerId: args.callerId,
@@ -225,6 +262,9 @@ export async function createSession(
           : {}),
         ...(promptResolution.usedPromptId
           ? { usedPromptId: promptResolution.usedPromptId }
+          : {}),
+        ...(metadata
+          ? { metadata: metadata as unknown as Prisma.InputJsonValue }
           : {}),
       },
       select: {

--- a/apps/admin/lib/voice/select-pinned-card.ts
+++ b/apps/admin/lib/voice/select-pinned-card.ts
@@ -1,0 +1,73 @@
+/**
+ * #1733 / #1744 (epic #1700 Theme 3) — pinned-card selector.
+ *
+ * Pure helper. Given a Playbook config, an authored-module slug, and the
+ * Session's `sequenceNumber` (the learner-facing count), return the
+ * `PinnedCardContent` that should be both:
+ *
+ *   - written into `Session.metadata.pinnedCard` at session-start so
+ *     `<PinnedCardSlot>` can render it above SimChat for THIS session
+ *   - matched, byte-for-byte, by `resolveModuleCueCard` inside
+ *     `transforms/instructions.ts` (#1733 prompt-side consumer) — same
+ *     selection policy (`(sequenceNumber - 1) % pool.length`) so the
+ *     UI card the learner sees agrees with the cue card the model was
+ *     prompted with.
+ *
+ * Selection policy is deliberately deterministic (modulo) rather than
+ * random so Preview-lens previews + actual call composition agree
+ * byte-for-byte (the contract `resolveModuleCueCard` already calls out).
+ *
+ * Returns `null` when:
+ *   - no `moduleSlug` (caller in no-module / continuous mode)
+ *   - no matching `AuthoredModule` in `config.modules`
+ *   - empty `cueCardPool`
+ *   - picked card is malformed (no topic, no valid bullets)
+ *
+ * Flag handling: pure helper — does NOT read the
+ * `HF_FLAG_IELTS_MODULE_SETTINGS` env var. Callers gate themselves so
+ * tests can exercise the selector independently.
+ */
+
+import type {
+  AuthoredModule,
+  PinnedCardContent,
+  PlaybookConfig,
+} from "@/lib/types/json-fields";
+
+export interface SelectPinnedCardArgs {
+  config: PlaybookConfig | null | undefined;
+  moduleSlug: string | null | undefined;
+  /** Session.sequenceNumber — 1-based learner-facing count. */
+  sequenceNumber: number;
+}
+
+export function selectPinnedCardForModule(
+  args: SelectPinnedCardArgs,
+): PinnedCardContent | null {
+  const { config, moduleSlug, sequenceNumber } = args;
+  if (!config || !moduleSlug) return null;
+
+  const modules: AuthoredModule[] = config.modules ?? [];
+  const matched = modules.find((m) => m.id === moduleSlug);
+  if (!matched) return null;
+
+  const pool = matched.settings?.cueCardPool;
+  if (!Array.isArray(pool) || pool.length === 0) return null;
+
+  const safeSeq = Number.isFinite(sequenceNumber) && sequenceNumber > 0 ? sequenceNumber : 1;
+  const index = (safeSeq - 1) % pool.length;
+  const picked = pool[index];
+  if (!picked || typeof picked.topic !== "string" || picked.topic.trim().length === 0) {
+    return null;
+  }
+  const bullets = Array.isArray(picked.bullets)
+    ? picked.bullets.filter((b) => typeof b === "string" && b.trim().length > 0)
+    : [];
+  if (bullets.length === 0) return null;
+
+  return {
+    kind: "cueCard",
+    topic: picked.topic,
+    bullets,
+  };
+}

--- a/apps/admin/tests/api/calls/pinned-card-route.test.ts
+++ b/apps/admin/tests/api/calls/pinned-card-route.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for `GET /api/calls/[callId]/pinned-card` (#1744 Theme 3).
+ *
+ * Pinned acceptance:
+ *   1. unknown callId → 404
+ *   2. flag-off → 200 { card: null } regardless of metadata content
+ *   3. flag-on + Session.metadata.pinnedCard present → returns the card
+ *   4. flag-on + no metadata → 200 { card: null }
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    call: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: () => true,
+  callerScopeMismatchResponse: () => new Response(null, { status: 403 }),
+}));
+
+import { GET } from "@/app/api/calls/[callId]/pinned-card/route";
+
+function req() {
+  return new Request("http://localhost/api/calls/call-1/pinned-card");
+}
+function params(callId: string) {
+  return { params: Promise.resolve({ callId }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+});
+
+describe("GET /api/calls/[callId]/pinned-card", () => {
+  it("(1) unknown callId → 404", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue(null);
+    const res = await GET(req(), params("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  it("(2) flag-off → 200 { card: null } even when metadata present", async () => {
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "c1",
+      session: {
+        metadata: { pinnedCard: { kind: "cueCard", topic: "T", bullets: ["b"] } },
+      },
+    });
+    const res = await GET(req(), params("call-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, card: null });
+  });
+
+  it("(3) flag-on + pinnedCard present → returns the card", async () => {
+    process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    const card = {
+      kind: "cueCard",
+      topic: "Describe a journey",
+      bullets: ["where", "when"],
+    };
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "c1",
+      session: { metadata: { pinnedCard: card } },
+    });
+    const res = await GET(req(), params("call-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, card });
+  });
+
+  it("(4) flag-on + no metadata → 200 { card: null }", async () => {
+    process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+    mockPrisma.call.findUnique.mockResolvedValue({
+      callerId: "c1",
+      session: { metadata: null },
+    });
+    const res = await GET(req(), params("call-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, card: null });
+  });
+});

--- a/apps/admin/tests/components/sim/PinnedCardSlot.test.tsx
+++ b/apps/admin/tests/components/sim/PinnedCardSlot.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * #1744 (epic #1700 Theme 3) — PinnedCardSlot render contract.
+ *
+ * Pinned acceptance:
+ *   1. cueCard variant renders topic + bullets + secondaryNote
+ *   2. topicFocus variant renders topic + focusArea on one line
+ *   3. phaseEnded=true → renders null even when a card is loaded
+ *   4. Esc dismisses; click ✕ also dismisses; remounting with new callId resets
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { PinnedCardSlot } from "@/components/sim/PinnedCardSlot";
+
+function mockFetch(body: unknown, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PinnedCardSlot", () => {
+  it("(1) renders cueCard variant — topic + bullets + secondaryNote", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: true,
+        card: {
+          kind: "cueCard",
+          topic: "Describe a book you enjoyed",
+          bullets: ["what kind", "what it was about", "why you enjoyed it"],
+          secondaryNote: "You have 1 minute to make notes.",
+        },
+      }),
+    );
+    render(<PinnedCardSlot callId="call-1" phaseEnded={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Describe a book you enjoyed")).toBeInTheDocument();
+    expect(screen.getByText("what kind")).toBeInTheDocument();
+    expect(screen.getByText("what it was about")).toBeInTheDocument();
+    expect(screen.getByText("why you enjoyed it")).toBeInTheDocument();
+    expect(screen.getByText("You have 1 minute to make notes.")).toBeInTheDocument();
+  });
+
+  it("(2) renders topicFocus variant — topic + focusArea inline", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: true,
+        card: {
+          kind: "topicFocus",
+          topic: "Education in your country",
+          focusArea: "giving reasons",
+        },
+      }),
+    );
+    render(<PinnedCardSlot callId="call-2" phaseEnded={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Education in your country")).toBeInTheDocument();
+    expect(screen.getByText("— giving reasons")).toBeInTheDocument();
+    // No bullets list in the focus variant.
+    expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  it("(3) phaseEnded=true renders null even when a card is loaded", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: true,
+        card: { kind: "cueCard", topic: "X", bullets: ["y"] },
+      }),
+    );
+    const { rerender } = render(
+      <PinnedCardSlot callId="call-3" phaseEnded={false} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+    rerender(<PinnedCardSlot callId="call-3" phaseEnded={true} />);
+    expect(screen.queryByTestId("pinned-card-slot")).toBeNull();
+  });
+
+  it("(4) Esc dismisses; ✕ dismisses; new callId resets dismissal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: true,
+        card: { kind: "cueCard", topic: "T", bullets: ["b"] },
+      }),
+    );
+    const { rerender } = render(
+      <PinnedCardSlot callId="call-4" phaseEnded={false} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("pinned-card-slot")).toBeNull();
+
+    // New callId resets dismissal — re-fetch should render again.
+    rerender(<PinnedCardSlot callId="call-5" phaseEnded={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+
+    // ✕ button also dismisses.
+    fireEvent.click(screen.getByLabelText("Dismiss pinned card"));
+    expect(screen.queryByTestId("pinned-card-slot")).toBeNull();
+  });
+});

--- a/apps/admin/tests/lib/voice/select-pinned-card.test.ts
+++ b/apps/admin/tests/lib/voice/select-pinned-card.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #1733 / #1744 (epic #1700 Theme 3) — selectPinnedCardForModule helper.
+ *
+ * Pinned acceptance:
+ *   1. null config → null
+ *   2. null moduleSlug → null
+ *   3. moduleSlug not in config.modules → null
+ *   4. module without cueCardPool → null
+ *   5. round-robin: sequenceNumber=1 → pool[0]; =2 → pool[1]; =3 → pool[0]
+ *   6. malformed pool entries (no topic / no bullets) skipped (returns null)
+ *   7. shape: returns {kind:"cueCard", topic, bullets} preserving bullets order
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { selectPinnedCardForModule } from "@/lib/voice/select-pinned-card";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+function withPool(pool: unknown): PlaybookConfig {
+  return {
+    modules: [
+      {
+        id: "part2",
+        settings: { cueCardPool: pool },
+      },
+    ],
+  } as unknown as PlaybookConfig;
+}
+
+describe("selectPinnedCardForModule", () => {
+  it("(1) null config → null", () => {
+    expect(
+      selectPinnedCardForModule({ config: null, moduleSlug: "part2", sequenceNumber: 1 }),
+    ).toBeNull();
+  });
+
+  it("(2) null moduleSlug → null", () => {
+    expect(
+      selectPinnedCardForModule({
+        config: withPool([{ topic: "x", bullets: ["a"] }]),
+        moduleSlug: null,
+        sequenceNumber: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it("(3) moduleSlug not in modules → null", () => {
+    expect(
+      selectPinnedCardForModule({
+        config: withPool([{ topic: "x", bullets: ["a"] }]),
+        moduleSlug: "part3",
+        sequenceNumber: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it("(4) module without cueCardPool → null", () => {
+    expect(
+      selectPinnedCardForModule({
+        config: { modules: [{ id: "part2", settings: {} }] } as unknown as PlaybookConfig,
+        moduleSlug: "part2",
+        sequenceNumber: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it("(5) round-robin over the pool", () => {
+    const pool = [
+      { topic: "Card A", bullets: ["a1", "a2"] },
+      { topic: "Card B", bullets: ["b1"] },
+    ];
+    const config = withPool(pool);
+    expect(
+      selectPinnedCardForModule({ config, moduleSlug: "part2", sequenceNumber: 1 }),
+    ).toEqual({ kind: "cueCard", topic: "Card A", bullets: ["a1", "a2"] });
+    expect(
+      selectPinnedCardForModule({ config, moduleSlug: "part2", sequenceNumber: 2 }),
+    ).toEqual({ kind: "cueCard", topic: "Card B", bullets: ["b1"] });
+    expect(
+      selectPinnedCardForModule({ config, moduleSlug: "part2", sequenceNumber: 3 }),
+    ).toEqual({ kind: "cueCard", topic: "Card A", bullets: ["a1", "a2"] });
+  });
+
+  it("(6) malformed picked entry → null", () => {
+    const cases: unknown[][] = [
+      [{ topic: "", bullets: ["x"] }],
+      [{ topic: "no-bullets" }],
+      [{ topic: "blank-bullets", bullets: ["", "  "] }],
+    ];
+    for (const pool of cases) {
+      expect(
+        selectPinnedCardForModule({
+          config: withPool(pool),
+          moduleSlug: "part2",
+          sequenceNumber: 1,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("(7) preserves bullets order; drops blanks", () => {
+    const config = withPool([
+      { topic: "Trip", bullets: ["where you went", "  ", "what you did", "who with"] },
+    ]);
+    const card = selectPinnedCardForModule({
+      config,
+      moduleSlug: "part2",
+      sequenceNumber: 1,
+    });
+    expect(card).toEqual({
+      kind: "cueCard",
+      topic: "Trip",
+      bullets: ["where you went", "what you did", "who with"],
+    });
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -3411,6 +3411,29 @@ Run a specific analysis op on a single call. Valid ops: measure, learn, measure-
 
 ---
 
+### `GET` /api/calls/:callId/pinned-card
+
+#1744 (epic #1700 Theme 3) — read the persisted
+
+**Auth**: VIEWER (STUDENT scoped to own caller; OPERATOR+ unrestricted) · **Scope**: `calls:read`
+
+**Response** `200`
+```json
+{ ok: true, card: PinnedCardContent | null }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: "STUDENT cannot read a different caller" }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Call not found" }
+```
+
+---
+
 ### `POST` /api/calls/:callId/pipeline
 
 SPEC-DRIVEN pipeline endpoint that runs analysis in configurable stages. Pipeline stages are loaded from the PIPELINE-001 spec (or GUARD-001 fallback), not hardcoded. Each stage has a name, order, outputTypes, and optional requiresMode. Default stages: EXTRACT (10), SCORE_AGENT (20), AGGREGATE (30), REWARD (40), ADAPT (50), SUPERVISE (60), COMPOSE (100, prompt mode only).
@@ -16244,8 +16267,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 538 |
-| Files with annotations | 524 |
+| Route files found | 539 |
+| Files with annotations | 525 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 


### PR DESCRIPTION
## Summary

- **#1733** — `createSession` writes `Session.metadata.pinnedCard` at session-start, picking from `Playbook.config.modules[].settings.cueCardPool` with the same `(seq-1) % pool.length` policy `resolveModuleCueCard` already uses. Prompt and UI now agree byte-for-byte on which card is in play.
- **#1744** — new `<PinnedCardSlot>` mounted above SimChat fetches the persisted card via a new `GET /api/calls/[id]/pinned-card` route and renders it sticky, Esc-dismissible.

Couples writer + reader because neither delivered learner-visible value alone. Closes **#1733** and **#1744**. Epic #1700 Theme 3.

## Verified by

- **Lattice survey** (sibling writers to `Session.metadata`, `cueCardPool` readers, convention shape):
  - No other writer touches `Session.metadata.pinnedCard` (confirmed via `qmd search pinnedCard` + grep over `lib/voice` + `lib/pipeline`).
  - Selection policy MATCHES `transforms/instructions.ts::resolveModuleCueCard` byte-for-byte — both index on `(callNumber - 1) % pool.length`. Writer uses Session's `learnerFacingNumber` (sim drops do not rotate the pool; consecutive learner sessions do).
  - Flag-gated by `HF_FLAG_IELTS_MODULE_SETTINGS` on both writer + reader (the same gate the rest of G8 honours).
  - Schema (`Session.metadata Json?` + `PinnedCardContent` interface) already shipped via #1714 — no migration needed.
- **Vitests** (15 new): `select-pinned-card.test.ts` (7) — null config / null slug / no module / no pool / round-robin / malformed entry / bullets-filter; `pinned-card-route.test.ts` (4) — 404 / flag-off masks payload / happy path / no metadata; `PinnedCardSlot.test.tsx` (4 RTL) — cueCard variant / topicFocus variant / phaseEnded clears / Esc + ✕ + callId-reset.
- **Regressions**: 216 sibling create-session + composition tests still green; pre-push lint clean.

## How the card is sourced (for review context)

`Playbook.config.modules[].settings.cueCardPool` is **operator-authored** — the IELTS Inspector G8 array editor for the module (e.g. `part2`). Pool shape: `Array<{ topic: string; bullets: string[] }>`. Nothing is fetched externally.

At session-start, `createSession`:
1. Reads `Playbook.config` (one indexed lookup, side-effect-free, outside the tx).
2. Inside the tx — after `learnerFacingNumber` is atomically assigned — picks `pool[(seq - 1) % pool.length]`.
3. Writes `{ kind: "cueCard", topic, bullets }` to `Session.metadata.pinnedCard` in the same row insert.

At runtime, `PinnedCardSlot` reads it via the GET route and renders sticky-positioned above the chat. The prompt-side `resolveModuleCueCard` independently computes the same pick → model and learner see the same card.

## Test plan (after `/vm-cp`)

- [ ] `HF_FLAG_IELTS_MODULE_SETTINGS=true` on the VM; restart `next dev`.
- [ ] On hf-dev, open Part 2 Inspector → G8 `Cue card pool` → paste an array of two `{topic, bullets}` entries → save.
- [ ] `/x/sim/<bertie>?requestedModuleId=part2` → [Talk Here].
- [ ] Pinned card appears above SimChat with the first card's topic + bullets.
- [ ] Press Esc → card dismisses for the rest of the session.
- [ ] End call → start a new session → card now shows the **second** entry (round-robin via `learnerFacingNumber`).
- [ ] DB check: `SELECT metadata->'pinnedCard' FROM "Session" WHERE "callerId" = '<bertie>' ORDER BY "sequenceNumber" DESC LIMIT 1;` — matches what the UI rendered.
- [ ] Flip the flag OFF, restart, start a new call → no pinned card; route returns `{card: null}`.

Deploy: `/vm-cp` (no Prisma migration — `Session.metadata` already exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)