### PR TITLE
fix(journey): A_intake — silence cascade 400s + bind toggles to .enabled

### DIFF
--- a/apps/admin/lib/cascade/use-effective-value.ts
+++ b/apps/admin/lib/cascade/use-effective-value.ts
@@ -33,6 +33,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import type { Effective } from "./layer-types";
+import { isResolvableKnob } from "./effective-value";
 
 /** Mirror of the route's accepted scope ids. courseId is the operator-
  *  facing alias for playbookId. */
@@ -103,6 +104,23 @@ export function useEffectiveValue<T>(
       // assumes derivable state, but this is a true reset on a
       // transition signal (knobKey going null is a user action, not a
       // derivation).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setState({
+        envelope: null,
+        loading: false,
+        unresolvable: true,
+        error: null,
+      });
+      return;
+    }
+    // Pre-filter — when the knob has no registered cascade family, skip
+    // the fetch entirely. The route would 400 with "Unknown cascade knob
+    // key" and the hook would translate that to `unresolvable: true`; we
+    // short-circuit to the same terminal state without polluting the
+    // network tab + console. Mirrors the documented contract in
+    // `cascade-reuse.md` and matches the `isResolvableKnob` gate UI
+    // consumers use to decide whether to mount `<LayerBadge>`.
+    if (!isResolvableKnob(knobKey)) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setState({
         envelope: null,

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -57,7 +57,10 @@ const G1_INTAKE_KNOWLEDGE_CHECK: JourneySettingContract = {
   group: "G1",
   educatorLabel: "Knowledge check on sign-up",
   helpText: "Brief MCQ or Socratic probe in the sign-up form.",
-  storagePath: "sessionFlow.intake.knowledgeCheck",
+  // sessionFlow.intake.knowledgeCheck is `{enabled, deliveryMode?}`.
+  // Toggle binds to .enabled; sibling intakeKnowledgeCheckMode binds to
+  // .deliveryMode. The applier walks segments and preserves siblings.
+  storagePath: "sessionFlow.intake.knowledgeCheck.enabled",
   control: "toggle",
   cascadeSources: [],
   composeImpact: {
@@ -74,7 +77,7 @@ const G1_INTAKE_ABOUT_YOU: JourneySettingContract = {
   group: "G1",
   educatorLabel: '"About you" questions',
   helpText: 'Show the "About you" block in the sign-up form.',
-  storagePath: "sessionFlow.intake.aboutYou",
+  storagePath: "sessionFlow.intake.aboutYou.enabled",
   control: "toggle",
   cascadeSources: [],
   composeImpact: {
@@ -98,7 +101,7 @@ const G1_INTAKE_GOALS: JourneySettingContract = {
   educatorLabel: "Pre-call learner goals",
   helpText:
     "Show the learner-goals capture block in the sign-up form so learners declare what they want to work on before Call 1.",
-  storagePath: "sessionFlow.intake.goals",
+  storagePath: "sessionFlow.intake.goals.enabled",
   control: "toggle",
   cascadeSources: [],
   composeImpact: {
@@ -116,7 +119,7 @@ const G1_INTAKE_AI_INTRO_CALL: JourneySettingContract = {
   educatorLabel: "AI Intro Call after sign-up",
   helpText:
     "Optional 1–2 min AI call right after sign-up to confirm name + level + give the learner a low-stakes taste of the voice surface before Call 1.",
-  storagePath: "sessionFlow.intake.aiIntroCall",
+  storagePath: "sessionFlow.intake.aiIntroCall.enabled",
   control: "toggle",
   cascadeSources: [],
   composeImpact: {

--- a/apps/admin/tests/lib/cascade/use-effective-value.test.tsx
+++ b/apps/admin/tests/lib/cascade/use-effective-value.test.tsx
@@ -56,6 +56,20 @@ describe("useEffectiveValue — Slice C2 (#1737)", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  it("short-circuits with unresolvable=true for a knobKey with no registered family (no fetch)", () => {
+    // Pre-filter: when isResolvableKnob(knobKey) is false (course-only
+    // knob, no Domain/System ancestor), the hook does NOT fire the
+    // route — saves the 400 + console noise. Matches the documented
+    // contract in `.claude/rules/cascade-reuse.md`.
+    const { result } = renderHook(() =>
+      useEffectiveValue<unknown>("intakeKnowledgeCheck", { courseId: "c1" }),
+    );
+    expect(result.current.unresolvable).toBe(true);
+    expect(result.current.envelope).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("fetches the route and returns the envelope on success (skillTierMapping family)", async () => {
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary

Two coupled bugs in the A_intake Inspector pane, both spotted by the operator via screenshots + bug report at `/x/courses/<id>?j_bucket=A_intake`.

### Bug 1 — 8 × cascade-resolve 400s on bucket open

`useEffectiveValue` fired `/api/cascade/resolve` for every contract. The 8 intake knob keys have no registered cascade family (they're course-only, no Domain/System ancestor) so the route 400s with "Unknown cascade knob key" by design. The hook handles it correctly (`unresolvable: true`) but the 400 + console noise still hits the operator.

**Fix:** pre-filter on `isResolvableKnob(knobKey)` BEFORE fetching. Matches the documented `cascade-reuse.md` contract and mirrors the UI gate consumers already use for `<LayerBadge>`.

### Bug 2 — Toggle ON but JSON modal shows `enabled: false`

Reported by operator in screenshots. 4 intake toggle contracts had `storagePath` pointing at the sub-OBJECT (`sessionFlow.intake.knowledgeCheck` etc.) instead of its `.enabled` boolean field. `JourneyToggle` does `!!value` → any non-null object is truthy → toggle always rendered ON regardless of the stored shape. The "JSON" power-user modal read the same path and showed the raw object → divergence.

**Fix:** update 4 storagePaths to `.enabled`:

| Contract | Before | After |
|---|---|---|
| `intakeKnowledgeCheck` | `sessionFlow.intake.knowledgeCheck` | `sessionFlow.intake.knowledgeCheck.enabled` |
| `intakeAboutYou` | `sessionFlow.intake.aboutYou` | `sessionFlow.intake.aboutYou.enabled` |
| `intakeGoals` | `sessionFlow.intake.goals` | `sessionFlow.intake.goals.enabled` |
| `intakeAiIntroCall` | `sessionFlow.intake.aiIntroCall` | `sessionFlow.intake.aiIntroCall.enabled` |

The storage-path applier walks segments and preserves siblings (e.g. `deliveryMode`), so the toggle no longer clobbers structured siblings when written. The convention already exists — `intakeKnowledgeCheckMode` binds to `sessionFlow.intake.knowledgeCheck.deliveryMode`.

## Sibling-writer survey (per `.claude/rules/lattice-survey.md`)

- DB shape: `Playbook.config.sessionFlow.intake.<X>` is `{enabled: boolean, deliveryMode?: ...}` per `lib/types/json-fields.ts::IntakeConfig` [verified].
- Writers of `.enabled`:
  - `SessionFlowEditor` lines 328 / 345 / 362 / 375 / 844-850 already read + write `.enabled` directly [verified via grep].
  - This PR's new toggle paths also write `.enabled` — convergence with existing writer, no drift.
- Writers of `.deliveryMode`: the sibling `intakeKnowledgeCheckMode` select contract — already correctly pathed.
- Readers: `resolveSessionFlow()` returns a fully-resolved IntakeConfig; unchanged by this fix.
- Power-user "JSON" modal (`EditAsJsonButton`) now reads/writes the boolean directly — shows `true`/`false` instead of the full sub-object. Acceptable for an escape hatch.

## Verified by

- `npx vitest run tests/lib/journey/ tests/lib/cascade/` — 161/161 pass (pre-fix baseline) [verified].
- New vitest at `tests/lib/cascade/use-effective-value.test.tsx` pins the pre-filter: `useEffectiveValue("intakeKnowledgeCheck", …)` short-circuits to `unresolvable: true`, `global.fetch` NEVER called. 8/8 in that file [verified].
- `npx tsc --noEmit` — 41 errors (baseline, unchanged) [verified].
- `save-roundtrip-smoke.test.ts` — 4 toggles still round-trip cleanly through the storage-path applier to the new `.enabled` paths [verified].

## Test plan

- [x] Pre-filter test pins zero fetches on unresolvable knobs
- [x] Round-trip smoke test green on new paths
- [x] No new tsc errors
- [ ] Manual smoke on hf-dev: open `/x/courses/<id>?j_bucket=A_intake` in browser. Network tab should show ZERO `/api/cascade/resolve?knobKey=intake*` calls. Toggle "About you" OFF, verify JSON modal shows `false` (not the previous `{enabled: false}` object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)