### PR TITLE
feat(sim): #1745 closeout — ExamModeShell sim-page mount

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/exam-mode-check/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/exam-mode-check/route.ts
@@ -1,0 +1,82 @@
+/**
+ * @api GET /api/callers/:callerId/exam-mode-check?moduleSlug=mock
+ * @visibility public
+ * @scope callers:read
+ * @auth session (VIEWER+ — STUDENT scoped to own caller)
+ * @tags callers, voice
+ * @description Returns whether the supplied module slug should mount the
+ *   IELTS Mock exam shell (Epic #1700 Theme 4 / #1745). Discriminator:
+ *   `CurriculumModule.coversModules.length > 0` — the canonical multi-part
+ *   Mock signal already established in #1702 / #1785 / #1840. The sim
+ *   surface uses this response to flip into the dark dual-waveform shell
+ *   for the Mock learner.
+ *
+ *   No moduleSlug → `{ examMode: false }`. Unknown module → same fallback.
+ *
+ * @pathParam callerId string - Caller.id
+ * @queryParam moduleSlug string - CurriculumModule.slug
+ * @response 200 { ok: true, examMode: boolean }
+ * @response 403 { ok: false, error: string }
+ * @response 500 { ok: false, error: string }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ callerId: string }> },
+): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth("VIEWER");
+    if (isAuthError(authResult)) return authResult.error;
+
+    const { callerId } = await params;
+    if (!studentAllowedToReadCaller(authResult.session, callerId)) {
+      return callerScopeMismatchResponse();
+    }
+
+    const moduleSlug = req.nextUrl.searchParams.get("moduleSlug");
+    if (!moduleSlug) {
+      return NextResponse.json({ ok: true, examMode: false });
+    }
+
+    // Resolve the caller's active enrollment → curriculum → module.
+    // Mirrors the same path the call-start pipeline takes (single
+    // CallerPlaybook with status ACTIVE; primary Curriculum link).
+    const enrollment = await prisma.callerPlaybook.findFirst({
+      where: { callerId, status: "ACTIVE" },
+      orderBy: { enrolledAt: "desc" },
+      select: {
+        playbook: {
+          select: {
+            playbookCurricula: {
+              where: { role: "primary" },
+              select: { curriculumId: true },
+            },
+          },
+        },
+      },
+    });
+    const curriculumId = enrollment?.playbook?.playbookCurricula[0]?.curriculumId;
+    if (!curriculumId) {
+      return NextResponse.json({ ok: true, examMode: false });
+    }
+
+    const targetModule = await prisma.curriculumModule.findFirst({
+      where: { curriculumId, slug: moduleSlug },
+      select: { coversModules: true },
+    });
+    const examMode = (targetModule?.coversModules?.length ?? 0) > 0;
+
+    return NextResponse.json({ ok: true, examMode });
+  } catch (err) {
+    console.error("[/api/callers/[callerId]/exam-mode-check] error", err);
+    return NextResponse.json(
+      { ok: false, error: "Failed to resolve exam mode" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -14,6 +14,7 @@ import { ContentPicker } from './ContentPicker';
 import { MediaLibraryPanel } from './MediaLibraryPanel';
 import { VoicePanel } from './VoicePanel';
 import { useVoiceMode } from './useVoiceMode';
+import { ExamModeShell } from './ExamModeShell';
 import { useProviderCall } from './useProviderCall';
 import { labelForEndSource } from '@/lib/voice/end-source';
 import { useOutboundDial } from './useOutboundDial';
@@ -256,6 +257,33 @@ export function SimChat({
     lastSpeechAt,
     pool: stallPool,
   });
+
+  // #1745 closeout (Epic #1700 missing-surface sweep) — Mock-style modules
+  // (CurriculumModule.coversModules.length > 0) mount the ExamModeShell
+  // overlay during an active call. Sibling fetch to module-stall-pool
+  // above; same lifecycle.
+  const [examMode, setExamMode] = useState(false);
+  useEffect(() => {
+    if (!requestedModuleId) {
+      setExamMode(false);
+      return;
+    }
+    const controller = new AbortController();
+    fetch(
+      `/api/callers/${encodeURIComponent(callerId)}/exam-mode-check?moduleSlug=${encodeURIComponent(requestedModuleId)}`,
+      { signal: controller.signal, credentials: 'same-origin' },
+    )
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body: { ok?: boolean; examMode?: boolean } | null) => {
+        if (!body?.ok) return;
+        setExamMode(Boolean(body.examMode));
+      })
+      .catch((err) => {
+        if ((err as Error)?.name === 'AbortError') return;
+        // Best-effort — fallback is examMode=false (no shell mounted).
+      });
+    return () => controller.abort();
+  }, [callerId, requestedModuleId]);
 
   // Voice mode — wired so transcribed speech sends as user message
   const voiceMode = useVoiceMode(useCallback((transcript: string) => {
@@ -1227,6 +1255,23 @@ export function SimChat({
     onNameChange?.(next);
   }, [callerId, onNameChange]);
 
+  // #1745 closeout — ExamModeShell overlay state. Renders only when the
+  // bound module is Mock-style (resolved server-side via
+  // /api/callers/[id]/exam-mode-check) AND the call is currently active.
+  const showExamShell = examMode && callPhase === 'active';
+  const examSpeakerRole: 'examiner' | 'learner' | 'idle' =
+    voiceMode.state === 'ai-speaking'
+      ? 'examiner'
+      : voiceMode.state === 'recording'
+      ? 'learner'
+      : 'idle';
+  // Examiner amplitude — Safari can't drive an AnalyserNode off a remote
+  // MediaStream reliably, so we use a binary proxy from `voiceMode.state`
+  // (the same signal the chat rail uses to flip its "AI speaking…" pill).
+  // Native AnalyserNode wiring via `useRemoteAudioLevel` is a follow-on
+  // once the TTS audio element is exposed by `useVoiceMode`.
+  const examExaminerLevel = voiceMode.state === 'ai-speaking' ? 0.6 : 0;
+
   const content = (
     <>
       {/* Header */}
@@ -2150,10 +2195,30 @@ export function SimChat({
     </>
   );
 
+  // #1745 closeout — wrap the standalone surface in the ExamModeShell
+  // overlay when active on a Mock-style module. The shell is a
+  // position-fixed full-screen layer that visually replaces the chat UI
+  // beneath; the underlying SimChat keeps running so transcript +
+  // pipeline + voiceMode lifecycle continue uninterrupted. Embedded
+  // mode skips the shell — operator views need the chat feed.
+  const examShell = showExamShell && !isEmbedded ? (
+    <ExamModeShell
+      examinerLevel={examExaminerLevel}
+      learnerLevel={voiceMode.waveformLevel}
+      speakerRole={examSpeakerRole}
+      banner="Mock exam — speak naturally"
+    />
+  ) : null;
+
   if (isEmbedded) {
     return <div className="sim-embedded">{content}</div>;
   }
 
   // Standalone: rendered inside sim layout (which provides the container)
-  return content;
+  return (
+    <>
+      {content}
+      {examShell}
+    </>
+  );
 }

--- a/apps/admin/tests/api/callers/exam-mode-check/exam-mode-check.test.ts
+++ b/apps/admin/tests/api/callers/exam-mode-check/exam-mode-check.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for `GET /api/callers/[callerId]/exam-mode-check?moduleSlug=…`.
+ *
+ * Pinned acceptance:
+ *   1. STUDENT scope rejects foreign callerId (403)
+ *   2. No moduleSlug → `{ examMode: false }`
+ *   3. No active enrollment → `{ examMode: false }`
+ *   4. Module not found → `{ examMode: false }`
+ *   5. Module with empty coversModules → `{ examMode: false }`
+ *   6. Module with coversModules.length > 0 → `{ examMode: true }`
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockPrisma, mockStudentAllowed } = vi.hoisted(() => ({
+  mockPrisma: {
+    callerPlaybook: { findFirst: vi.fn() },
+    curriculumModule: { findFirst: vi.fn() },
+  },
+  mockStudentAllowed: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: mockStudentAllowed,
+  callerScopeMismatchResponse: () =>
+    new Response(JSON.stringify({ ok: false, error: "scope" }), { status: 403 }),
+}));
+
+const PARAMS = { params: Promise.resolve({ callerId: "caller-1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/callers/[callerId]/exam-mode-check/route");
+}
+
+function makeReq(slug?: string): NextRequest {
+  const url = slug
+    ? `http://x?moduleSlug=${encodeURIComponent(slug)}`
+    : "http://x";
+  return new NextRequest(url);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStudentAllowed.mockReturnValue(true);
+});
+
+describe("GET /api/callers/[callerId]/exam-mode-check", () => {
+  it("rejects STUDENT reading foreign caller (403)", async () => {
+    mockStudentAllowed.mockReturnValue(false);
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("mock"), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns examMode:false when moduleSlug is absent", async () => {
+    const route = await loadRoute();
+    const res = await route.GET(makeReq(), PARAMS);
+    const body = (await res.json()) as { examMode: boolean };
+    expect(body.examMode).toBe(false);
+    expect(mockPrisma.callerPlaybook.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns examMode:false when caller has no active enrollment", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("mock"), PARAMS);
+    const body = (await res.json()) as { examMode: boolean };
+    expect(body.examMode).toBe(false);
+  });
+
+  it("returns examMode:false when module not found in curriculum", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: { playbookCurricula: [{ curriculumId: "cur-1" }] },
+    });
+    mockPrisma.curriculumModule.findFirst.mockResolvedValue(null);
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("ghost"), PARAMS);
+    const body = (await res.json()) as { examMode: boolean };
+    expect(body.examMode).toBe(false);
+  });
+
+  it("returns examMode:false for module with empty coversModules", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: { playbookCurricula: [{ curriculumId: "cur-1" }] },
+    });
+    mockPrisma.curriculumModule.findFirst.mockResolvedValue({
+      coversModules: [],
+    });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("part1"), PARAMS);
+    const body = (await res.json()) as { examMode: boolean };
+    expect(body.examMode).toBe(false);
+  });
+
+  it("returns examMode:true for module with non-empty coversModules", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: { playbookCurricula: [{ curriculumId: "cur-1" }] },
+    });
+    mockPrisma.curriculumModule.findFirst.mockResolvedValue({
+      coversModules: ["part1", "part2", "part3"],
+    });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("mock"), PARAMS);
+    const body = (await res.json()) as { examMode: boolean };
+    expect(body.examMode).toBe(true);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -2782,6 +2782,33 @@ Update an enrollment status (pause, resume, complete, drop).
 
 ---
 
+### `GET` /api/callers/:callerId/exam-mode-check?moduleSlug=mock
+
+Returns whether the supplied module slug should mount the
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | Caller.id |
+
+**Response** `200`
+```json
+{ ok: true, examMode: boolean }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `GET` /api/callers/:callerId/exam-readiness
 
 Compute exam readiness for a caller across all active curricula (or one specific)
@@ -16244,8 +16271,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 538 |
-| Files with annotations | 524 |
+| Route files found | 539 |
+| Files with annotations | 525 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -857,6 +857,33 @@ Enroll a caller in a playbook.
 
 ---
 
+### `GET` /api/v1/callers/:callerId/exam-mode-check?moduleSlug=mock
+
+Returns whether the supplied module slug should mount the
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | Caller.id |
+
+**Response** `200`
+```json
+{ ok: true, examMode: boolean }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: string }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `GET` /api/v1/callers/:callerId/exam-readiness
 
 Compute exam readiness for a caller across all active curricula (or one specific)


### PR DESCRIPTION
## Summary

Epic #1700 missing-surface sweep — surface 2 of 3.

#1745 shipped the `ExamModeShell` + `DualWaveform` + `useRemoteAudioLevel` + `shouldMountExamModeShell` discriminator BUT no call site. Mock learners never saw the dark dual-waveform UI — the shipped infrastructure was dormant. This wires it in.

## What ships

- New route `GET /api/callers/[callerId]/exam-mode-check?moduleSlug=…`. Server-side decision: returns `{examMode: true}` when the supplied module slug on the caller's active enrollment has `CurriculumModule.coversModules.length > 0` (canonical multi-part Mock discriminator). Returns `{examMode: false}` for missing slug, no enrollment, module not found, empty coversModules. STUDENT scope via `studentAllowedToReadCaller` (mirrors the precedent from #1840).
- `components/sim/SimChat.tsx`:
  - New `examMode` state, hydrated via a fetch to the new route that fires on `requestedModuleId` change. Sibling pattern to the existing `module-stall-pool` fetch right above it.
  - When `examMode && callPhase === 'active'` AND the surface is standalone (embedded admin views skip — they need the chat feed), renders `<ExamModeShell>` as the final element. Shell is `position: fixed; inset: 0; z-index: 50` from #1816 so it overlays the chat surface beneath while SimChat's lifecycle keeps running (transcript, pipeline, voiceMode).
  - Amplitudes: `learnerLevel = voiceMode.waveformLevel` (already AnalyserNode-driven via useVoiceMode). `examinerLevel` uses a Safari-safe binary proxy from `voiceMode.state` (`0.6 when ai-speaking, 0 otherwise`) — same signal the chat rail uses for the "AI speaking…" pill. Native AnalyserNode wiring via `useRemoteAudioLevel` is the obvious follow-on once useVoiceMode exposes its TTS audio element.
  - `speakerRole` derives from voiceMode.state with the same matrix.

## Lattice survey [verified]

- **Surface:** new read-only route + minor render branch inside SimChat. No DB writes.
- **Sibling-writer drift:** NIL — pure read; chokepoint scope helper matches the established `studentAllowedToReadCaller` pattern. [verified — `grep -rn 'prisma' app/api/callers/[callerId]/exam-mode-check/route.ts` shows only one findFirst per query].
- **Default-deny gates:** fallback `examMode = false` covers every failure mode (no slug, no enrollment, no module, fetch error). [verified — 6-case vitest].
- **Cascade respect:** N/A.
- **Convention conflict:** NIL — fetch sibling pattern matches `module-stall-pool` at `SimChat.tsx:237-251`; `position: fixed` overlay matches the shell's own CSS contract at `components/sim/exam-mode-shell.css` [verified].

## Verified by

- ✅ vitest `tests/api/callers/exam-mode-check/exam-mode-check.test.ts` 6/6 (STUDENT 403 · no slug · no enrollment · module not found · empty coversModules · non-empty coversModules). [verified — `npx vitest run tests/api/callers/exam-mode-check/` exits 0].
- ✅ tsc on changed files: 0 errors. [verified — `npx tsc --noEmit | grep -E 'exam-mode-check|SimChat'` returns no rows].
- ✅ pre-push: lint 0 errors in changed files. [verified at log above].
- ✅ Lattice survey result inline above.

## Test plan

- [ ] `/vm-cp` — no migration.
- [ ] On hf-dev: sign in as STUDENT. Pick a non-Mock module (e.g. Part 1) → start call → shell does NOT appear. End call. Pick the Mock module → start call → after `callPhase === 'active'`, dark dual-waveform overlay appears with banner "Mock exam — speak naturally". Learner bar tracks mic level, examiner bar lights up when TTS is speaking. End call → overlay clears.

Follow-on (not in this PR): expose `useVoiceMode().ttsAudioRef` so the examiner side can use the real `useRemoteAudioLevel` AnalyserNode wiring instead of the binary proxy.

Closes the missing-mount gap on #1745.
