### PR TITLE
feat(callers): #1703 closeout — incomplete-attempts chip on AttainmentTab

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/attainment/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/attainment/route.ts
@@ -110,6 +110,14 @@ export interface AttainmentModuleProgress {
   mastery: number;
   status: string;
   attemptsCount: number;
+  /**
+   * #1703 Theme 9 — count of incomplete attempts on this module. Incremented
+   * by `markModuleIncomplete()` when a Session ends below the module's
+   * `minSpeakingSec` threshold OR with outcome GHOST/FAILED. Surfaced in
+   * the AttainmentTab ModulesSection as a chip when > 0 — Epic #1700
+   * missing-surface sweep (surface 3 of 3).
+   */
+  incompleteAttempts: number;
   /** True when the caller is on a `useFreshMastery: true` playbook —
    *  per-LO mastery for THIS playbook lives on `Call.scratchMastery`
    *  per-call, NOT this `mastery` field. Drives the UI's per-section
@@ -394,6 +402,7 @@ export async function GET(
         mastery: m.mastery,
         status: m.status,
         attemptsCount: m.callCount ?? 0,
+        incompleteAttempts: m.incompleteAttempts ?? 0,
         freshMasteryActive: useFreshMastery,
       }));
   }

--- a/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
@@ -62,6 +62,13 @@ interface ModuleProgress {
   mastery: number;
   status: string;
   attemptsCount: number;
+  /**
+   * #1703 Theme 9 — count of incomplete attempts on this module
+   * (incremented when Session ends below `minSpeakingSec` OR with
+   * GHOST/FAILED outcome). Surfaced as a chip in ModulesSection when > 0
+   * per Epic #1700 missing-surface sweep (surface 3 of 3).
+   */
+  incompleteAttempts: number;
   freshMasteryActive: boolean;
 }
 
@@ -710,6 +717,15 @@ function ModulesSection({
                     ? ` · ${m.attemptsCount} attempt(s)`
                     : ""}
                 </span>
+                {m.incompleteAttempts > 0 ? (
+                  <span
+                    className="hf-attainment-module-incomplete-chip"
+                    title="Sessions that ended below the module's minSpeakingSec threshold or with GHOST / FAILED outcome (#1703 Theme 9)"
+                    data-testid={`hf-attainment-module-incomplete-${m.moduleSlug}`}
+                  >
+                    {m.incompleteAttempts} incomplete
+                  </span>
+                ) : null}
               </button>
               {expanded ? (
                 <div

--- a/apps/admin/components/callers/caller-detail/attainment-tab.css
+++ b/apps/admin/components/callers/caller-detail/attainment-tab.css
@@ -607,3 +607,19 @@
 .hf-attainment-talktime-chip strong {
   font-weight: 600;
 }
+
+/* #1703 Theme 9 — incomplete-attempts chip on each module row.
+ * Epic #1700 missing-surface sweep — surface 3 of 3. */
+.hf-attainment-module-incomplete-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  margin-left: 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--status-warning-text, #c97a00) 14%, transparent);
+  color: var(--status-warning-text, #c97a00);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}

--- a/apps/admin/tests/api/callers/attainment-route.test.ts
+++ b/apps/admin/tests/api/callers/attainment-route.test.ts
@@ -244,3 +244,74 @@ describe("GET /api/callers/[callerId]/attainment — goal trail (SP4-D)", () => 
     expect(t.firstNoticedAt).toBe("2026-06-05T10:00:00Z");
   });
 });
+
+// ── #1703 Theme 9 — incomplete-attempts surface ────────────────────────────
+// Epic #1700 missing-surface sweep (surface 3 of 3).
+
+describe("GET /api/callers/[callerId]/attainment — incompleteAttempts on modules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns incompleteAttempts on each ModuleProgress row for structured courses", async () => {
+    const { getCourseStyle } = await import("@/lib/pipeline/course-style");
+    (getCourseStyle as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      "structured",
+    );
+    happy();
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      {
+        moduleId: "m-part1",
+        callCount: 4,
+        incompleteAttempts: 2,
+        mastery: 0.65,
+        status: "IN_PROGRESS",
+        module: {
+          id: "m-part1",
+          slug: "part1",
+          title: "Part 1",
+          curriculum: {
+            playbookLinks: [{ playbookId: "pb1" }],
+          },
+        },
+      },
+    ]);
+    mockPrisma.goal.findMany.mockResolvedValue([]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.modules).toHaveLength(1);
+    expect(body.modules[0].incompleteAttempts).toBe(2);
+    expect(body.modules[0].attemptsCount).toBe(4);
+  });
+
+  it("defaults incompleteAttempts to 0 when column null (older rows)", async () => {
+    const { getCourseStyle } = await import("@/lib/pipeline/course-style");
+    (getCourseStyle as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      "structured",
+    );
+    happy();
+    mockPrisma.callerModuleProgress.findMany.mockResolvedValue([
+      {
+        moduleId: "m-part1",
+        callCount: 1,
+        incompleteAttempts: null,
+        mastery: 0.1,
+        status: "IN_PROGRESS",
+        module: {
+          id: "m-part1",
+          slug: "part1",
+          title: "Part 1",
+          curriculum: {
+            playbookLinks: [{ playbookId: "pb1" }],
+          },
+        },
+      },
+    ]);
+    mockPrisma.goal.findMany.mockResolvedValue([]);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.modules[0].incompleteAttempts).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Epic #1700 missing-surface sweep — surface 3 of 3.

#1703 Theme 9 shipped the `CallerModuleProgress.incompleteAttempts` column + `markModuleIncomplete()` chokepoint + ESLint guard — BUT no UI ever surfaced the counter. Operators couldn't tell who was bouncing off a module; the data was invisible.

## What ships

- `GET /api/callers/[callerId]/attainment` — `AttainmentModuleProgress` shape widened with `incompleteAttempts: number`. The route already fetches `CallerModuleProgress`; the value reads off the row (defaults to 0 when the legacy column is null).
- `components/callers/caller-detail/AttainmentTab.tsx`:
  - `ModuleProgress` interface widened with the same field.
  - When `incompleteAttempts > 0`, renders an amber chip next to the existing `pct%·status·N attempt(s)` meta line: `"N incomplete"` with a tooltip explaining the semantics.
- `attainment-tab.css` — new `.hf-attainment-module-incomplete-chip` class. Uses `color-mix()` for the warm-amber background (no hex opacity per design system), matches surrounding `hf-attainment-module-meta` typography.

## Lattice survey [verified]

- **Surface:** read-side only — no DB writes; the route reads an existing column that ESLint guard `hf-curriculum/no-bare-module-progress-update` already protects on the write side.
- **Sibling-writer drift:** NIL — chip is pure render. [verified — `grep -rn 'incompleteAttempts' app/api/callers/[callerId]/attainment/route.ts` shows only the new read].
- **Default-deny gates:** chip only renders when `> 0`, so zero-state UI is unchanged. Null column → 0 (no UI delta) [verified — vitest pin].
- **Cascade respect:** N/A — per-module DB column.
- **Convention conflict:** NIL — chip placement matches the existing `attemptsCount` rendering pattern; `color-mix()` matches the design system rule at `.claude/rules/ui-design-system.md`.

## Verified by

- ✅ vitest `tests/api/callers/attainment-route.test.ts` 8/8 (6 existing + 2 new pinning incompleteAttempts surfaces + 0-default for null columns). [verified — `npx vitest run tests/api/callers/attainment-route.test.ts` exits 0].
- ✅ tsc on changed files: 0 errors. [verified — `npx tsc --noEmit | grep -E 'attainment'` returns no rows].
- ✅ pre-push: lint 0 errors in changed files. [verified at log above].
- ✅ Lattice survey result inline above.

## Test plan

- [ ] `/vm-cp` — no migration (column from #1714 migration B).
- [ ] On hf-dev: open `/x/callers/<id>?tab=attainment` for a caller who has bounced off a module (e.g. ended early on Part 2 multiple times). Expect the amber `"N incomplete"` chip beside the module row's meta line, with the tooltip on hover. Modules at 0 → no chip rendered.

Closes the missing-surface gap on #1703 Theme 9.
