### PR TITLE
fix(journey): JSON-modal stale read + Esc-to-close + warn-if-unsaved

### DIFF
--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -47,6 +47,35 @@ export function CourseJourneyTab({
   const [pickStripSection, setPickStripSection] = useState<ComposeSectionKey | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLElement>(null);
+  // Tab-local override of the parent's playbookConfig. Seeded from the
+  // prop on mount/prop-change; replaced after each save via the
+  // `onCompoundSaved` callback below. This is the cure for the
+  // stale-read class — without it, the Inspector + "Edit as JSON"
+  // modal kept reading from the parent's `detail.config` snapshot
+  // that page.tsx only refetched on route change.
+  const [localConfig, setLocalConfig] = useState<
+    Record<string, unknown> | null
+  >(playbookConfig);
+  useEffect(() => {
+    setLocalConfig(playbookConfig);
+  }, [playbookConfig]);
+  const refetchPlaybookConfig = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/playbooks/${courseId}`);
+      if (!res.ok) return;
+      const body = (await res.json()) as {
+        ok?: boolean;
+        playbook?: { config?: Record<string, unknown> | null };
+      };
+      if (body.ok && body.playbook) {
+        setLocalConfig(body.playbook.config ?? null);
+      }
+    } catch {
+      // Refetch is best-effort — the parent will still pick up the new
+      // value on the next route change. Don't surface the network error
+      // here; the save itself already succeeded.
+    }
+  }, [courseId]);
 
   // Slice C — multi-pulse over all bucket sections.
   useBubblePulse(canvasRef, selection.bucketId);
@@ -112,7 +141,8 @@ export function CourseJourneyTab({
   return (
     <JourneySettingMutatorProvider
       courseId={courseId}
-      playbookConfig={playbookConfig}
+      playbookConfig={localConfig}
+      onCompoundSaved={refetchPlaybookConfig}
     >
       <div
         ref={rootRef}

--- a/apps/admin/components/settings/JsonEditorModal.tsx
+++ b/apps/admin/components/settings/JsonEditorModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { X, Save } from "lucide-react";
 
 interface JsonEditorModalProps {
@@ -24,6 +24,45 @@ export function JsonEditorModal({
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
 
+  // Re-sync the textarea to the latest `initialText` whenever the modal
+  // is opened OR the parent's snapshot changes while open. Without this
+  // the modal would hold its first-mount text even after the parent
+  // refetched a fresh playbookConfig — produces the stale-read fingerprint
+  // the operator reported on 2026-06-17 (toggle ON in UI, modal still
+  // showed `false` until a hard page refresh).
+  useEffect(() => {
+    if (!isOpen) return;
+    setText(initialText);
+    setError("");
+  }, [isOpen, initialText]);
+
+  const isDirty = text !== initialText;
+
+  const requestClose = useCallback(() => {
+    if (saving) return;
+    if (isDirty) {
+      const ok = window.confirm(
+        "Discard unsaved changes to this setting? Click Cancel to keep editing.",
+      );
+      if (!ok) return;
+    }
+    onClose();
+  }, [isDirty, onClose, saving]);
+
+  // Esc closes the modal (with warn-if-unsaved). Capture-phase listener
+  // so we win over nested editors that also bind Escape.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        requestClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [isOpen, requestClose]);
+
   if (!isOpen) return null;
 
   return (
@@ -37,7 +76,8 @@ export function JsonEditorModal({
         justifyContent: "center",
         zIndex: 1000,
       }}
-      onClick={onClose}
+      onClick={requestClose}
+      data-testid="hf-json-editor-modal-backdrop"
     >
       <div
         onClick={(e) => e.stopPropagation()}
@@ -52,13 +92,16 @@ export function JsonEditorModal({
           display: "flex",
           flexDirection: "column",
         }}
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
       >
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
           <h3 style={{ fontSize: 16, fontWeight: 600, color: "var(--text-primary)", margin: 0 }}>
             {label}
           </h3>
           <button
-            onClick={onClose}
+            onClick={requestClose}
             style={{
               background: "none",
               border: "none",
@@ -66,6 +109,9 @@ export function JsonEditorModal({
               cursor: "pointer",
               padding: 4,
             }}
+            aria-label="Close (Esc)"
+            title="Close (Esc)"
+            data-testid="hf-json-editor-modal-close"
           >
             <X size={20} />
           </button>
@@ -73,6 +119,11 @@ export function JsonEditorModal({
 
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginBottom: 8, fontFamily: "monospace" }}>
           {settingKey}
+          {isDirty && (
+            <span style={{ marginLeft: 8, color: "var(--accent-primary)" }}>
+              • Unsaved
+            </span>
+          )}
         </div>
 
         <textarea
@@ -96,6 +147,7 @@ export function JsonEditorModal({
             lineHeight: 1.5,
             resize: "vertical",
           }}
+          data-testid="hf-json-editor-modal-textarea"
         />
 
         {error && (
@@ -106,7 +158,7 @@ export function JsonEditorModal({
 
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
           <button
-            onClick={onClose}
+            onClick={requestClose}
             style={{
               padding: "8px 16px",
               borderRadius: 8,
@@ -151,6 +203,7 @@ export function JsonEditorModal({
               alignItems: "center",
               gap: 6,
             }}
+            data-testid="hf-json-editor-modal-save"
           >
             <Save size={14} />
             {saving ? "Saving..." : "Save"}

--- a/apps/admin/components/shared/preview-renderers/_journey-setting-context.tsx
+++ b/apps/admin/components/shared/preview-renderers/_journey-setting-context.tsx
@@ -20,7 +20,7 @@
  * Underscore-prefix = renderer-internal; not in the public barrel.
  */
 
-import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
 
 import { useJourneySettingMutator } from "./_useJourneySettingMutator";
 
@@ -69,15 +69,30 @@ export function JourneySettingMutatorProvider({
   children,
 }: JourneySettingMutatorProviderProps) {
   const mutator = useJourneySettingMutator(courseId);
+  // Wrap the raw mutator so the parent's refetch callback also fires
+  // after a successful PATCH route save (toggle / select / number /
+  // text / etc.). Without this, only compound editors (Banding,
+  // Targets, Stops) — which call `onCompoundSaved` directly from their
+  // own save loops — triggered a refetch; the simple primitives left
+  // the snapshot stale, producing the toggle-vs-JSON-modal divergence
+  // operators reported (toggle ON in UI, JSON modal showed stale
+  // `false`). See journey-r2 follow-on session 2026-06-17.
+  const wrappedSaveSetting = useCallback(
+    async (settingId: string, nextValue: unknown) => {
+      await mutator(settingId, nextValue);
+      onCompoundSaved?.();
+    },
+    [mutator, onCompoundSaved],
+  );
   const value = useMemo<JourneySettingContextValue>(
     () => ({
       courseId,
-      saveSetting: mutator,
+      saveSetting: wrappedSaveSetting,
       readonly: readonly || courseId === null,
       playbookConfig,
       onCompoundSaved,
     }),
-    [courseId, mutator, readonly, playbookConfig, onCompoundSaved],
+    [courseId, wrappedSaveSetting, readonly, playbookConfig, onCompoundSaved],
   );
   return (
     <JourneySettingContext.Provider value={value}>

--- a/apps/admin/tests/components/settings/JsonEditorModal.test.tsx
+++ b/apps/admin/tests/components/settings/JsonEditorModal.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * JsonEditorModal — UX hardening (2026-06-17 session).
+ *
+ * Pins three behaviours added in fix/json-modal-stale-read-and-esc:
+ *
+ *   1. **Esc closes** — keyboard convenience the operator asked for.
+ *   2. **Warn-if-unsaved** — Esc/X/backdrop while the textarea diverges
+ *      from `initialText` triggers a `window.confirm`. Cancel = stay.
+ *   3. **Stale-read re-sync** — when the modal is open and `initialText`
+ *      prop changes (parent refetch landed a fresh value), the textarea
+ *      contents follow. Without this the operator had to hard-refresh
+ *      the page to see the new value after a toggle.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+import { JsonEditorModal } from "@/components/settings/JsonEditorModal";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("JsonEditorModal", () => {
+  it("Esc closes when clean (no confirm dialog)", () => {
+    const onClose = vi.fn();
+    render(
+      <JsonEditorModal
+        isOpen
+        onClose={onClose}
+        label="About you"
+        settingKey="intakeAboutYou"
+        initialText="false"
+        onSave={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Esc prompts for confirmation when dirty; Cancel keeps the modal open", () => {
+    const onClose = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(
+      <JsonEditorModal
+        isOpen
+        onClose={onClose}
+        label="About you"
+        settingKey="intakeAboutYou"
+        initialText="false"
+        onSave={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("hf-json-editor-modal-textarea"), {
+      target: { value: "true" },
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("Esc closes when dirty if the operator confirms discard", () => {
+    const onClose = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(
+      <JsonEditorModal
+        isOpen
+        onClose={onClose}
+        label="About you"
+        settingKey="intakeAboutYou"
+        initialText="false"
+        onSave={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("hf-json-editor-modal-textarea"), {
+      target: { value: "true" },
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-syncs textarea when initialText changes while open (stale-read fix)", () => {
+    const { rerender } = render(
+      <JsonEditorModal
+        isOpen
+        onClose={vi.fn()}
+        label="About you"
+        settingKey="intakeAboutYou"
+        initialText="false"
+        onSave={vi.fn()}
+      />,
+    );
+    const textarea = screen.getByTestId(
+      "hf-json-editor-modal-textarea",
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe("false");
+
+    // Parent refetched a fresh value while the modal was open — modal
+    // must adopt the new value, not hold the original mount-time one.
+    rerender(
+      <JsonEditorModal
+        isOpen
+        onClose={vi.fn()}
+        label="About you"
+        settingKey="intakeAboutYou"
+        initialText="true"
+        onSave={vi.fn()}
+      />,
+    );
+    expect(textarea.value).toBe("true");
+  });
+
+  it("does not fire onClose on first mount (avoids confirm-on-open)", () => {
+    const onClose = vi.fn();
+    render(
+      <JsonEditorModal
+        isOpen
+        onClose={onClose}
+        label="About you"
+        settingKey="intakeAboutYou"
+        initialText="false"
+        onSave={vi.fn()}
+      />,
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows an `Unsaved` chip when the textarea differs from initialText", () => {
+    render(
+      <JsonEditorModal
+        isOpen
+        onClose={vi.fn()}
+        label="About you"
+        settingKey="intakeAboutYou"
+        initialText="false"
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/Unsaved/i)).toBeNull();
+    fireEvent.change(screen.getByTestId("hf-json-editor-modal-textarea"), {
+      target: { value: "true" },
+    });
+    expect(screen.getByText(/Unsaved/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Operator-reported follow-on to #1842 (A_intake toggle/JSON sync). After toggling "About you" ON, the JSON modal still showed `false` until a hard page refresh. Same operator also asked: *"all modals to have Esc to exit (warn if save needed)"*.

This PR closes both with one cohesive change.

## Bug A — Stale read after save

`JourneySettingMutatorProvider`'s `saveSetting` mutator hit the PATCH route then returned. The `onCompoundSaved` callback existed but only fired for compound editors (Banding / Targets / Stops) — the simple primitive path (toggle / select / number / text) didn't trigger any refetch. Parent `playbookConfig` snapshot stayed stale until route change.

**Fix in 2 layers:**

1. **Mutator** wraps `saveSetting` so `onCompoundSaved?.()` ALSO fires after a successful PATCH save — symmetric with the compound editors that already used it.
2. **CourseJourneyTab** owns a local `playbookConfig` state seeded from the prop; refetches `/api/playbooks/<courseId>` on every `onCompoundSaved` tick. No `page.tsx` change needed — the Journey tab takes ownership while it's mounted.

After this, the JSON modal mounted next to a toggle reads the FRESH post-save value with no manual refresh.

## Bug B — Esc + warn-if-unsaved

`JsonEditorModal` only closed via mouse-click on Cancel/X/backdrop, and discarded silently regardless of dirty state.

- **Esc closes** (capture-phase listener so nested editors that also bind Escape don't steal the event)
- **Warn-if-unsaved** — Esc/X/backdrop all route through `requestClose` which checks `text !== initialText` and triggers `window.confirm` before discarding. Cancel in the confirm = stay editing.
- **"• Unsaved" chip** next to `settingKey` so the operator sees dirty state without guessing.
- **Re-sync textarea** on `initialText` prop change — fixes the inverse stale-read where parent refetches WHILE the modal is open.

## Sibling-writer survey (per `.claude/rules/lattice-survey.md`)

- `JsonEditorModal` is shared by `EditAsJsonButton` (Journey tab) and `SettingsEditAsJson` (Settings tab). One Esc handler covers both [verified by `grep -rn JsonEditorModal`].
- `JourneySettingMutatorProvider` is mounted at 6 sites. The new `onCompoundSaved`-fires-on-PATCH behaviour is opt-in via passing the callback — sites that don't pass one are unaffected.

## Verified by

- `npx vitest run tests/components/settings/JsonEditorModal.test.tsx` — 6/6 pass (Esc-when-clean, Esc-when-dirty-confirms-discard, Esc-when-dirty-cancel-keeps-open, re-sync-on-prop-change, no-onClose-on-first-mount, Unsaved-chip-toggles) [verified].
- `npx vitest run tests/lib/journey/ tests/lib/cascade/` — 168/168 pass (no regression) [verified].
- `npx tsc --noEmit` — 41 errors (baseline, unchanged) [verified].

## Test plan

- [x] Modal UX unit tests
- [x] Journey + cascade regression banks
- [ ] Manual smoke on hf-dev: open A_intake → toggle "About you" OFF → click JSON → see `false`. Close, toggle ON, click JSON immediately → should see `true` WITHOUT refresh. Esc the modal — closes. Type something in the textarea, hit Esc — should prompt "Discard?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)