### PR TITLE
chore(journey): registry↔consumer coverage test — 5th-Lattice-pillar member

### DIFF
--- a/.claude/rules/lattice-survey.md
+++ b/.claude/rules/lattice-survey.md
@@ -149,6 +149,20 @@ The 2026-06-16 #1701 G8 cohort intentionally landed as producer-only
 consumers are Phase 2 work (Themes 8, 10, plus the closing/orientation
 transform wires). Tracked at <follow-on issue TBD>.
 
+**Structural enforcement (2026-06-17):** this layer of the producer↔
+consumer pairing is now pinned by
+`tests/lib/journey/registry-consumer-coverage.test.ts`. Each
+`JOURNEY_SETTINGS` + `VOICE_SETTINGS` entry is classified
+`covered` / `family-shortcut` / `no-compose-impact` / `exempt` /
+`gap`. Exempt entries require a one-line reason; total exempt count
+is ratcheted — cannot grow without an explicit bump. See
+[`registry-consumer-coverage.md`](./registry-consumer-coverage.md)
+for the full rule. **15 entries on the exempt list at birth** —
+that's the pre-existing producer-only debt this rule freezes in
+place. The 2026-06-17 audit surfaced the drift after months of
+trust-based convention enforcement; any future entry must wire its
+consumer in the same PR or consciously join the exempt list.
+
 ## Producer ↔ consumer pairing — deeper layer: transform vs renderer
 
 Even when the registry → transform side of the pairing is solid, a

--- a/.claude/rules/registry-consumer-coverage.md
+++ b/.claude/rules/registry-consumer-coverage.md
@@ -1,0 +1,137 @@
+# Registry ↔ Consumer Coverage (Lattice 5th-pillar member)
+
+> A `JourneySettingContract` (or `VoiceSettingsContract`) with non-empty
+> `composeImpact.sections[]` MUST have a transform / resolver / loader that
+> actually reads its `storagePath`. The setting is producer-only otherwise
+> — the educator edits it, the Inspector shows "✓ Saved", but the composed
+> prompt is byte-identical before and after.
+>
+> Sibling to [`ai-to-db-guard.md`](./ai-to-db-guard.md) (WRITE-side
+> validate-before-execute), [`ai-read-grounding.md`](./ai-read-grounding.md)
+> (CHAT-side verify-before-claim), [`verify-before-fix.md`](./verify-before-fix.md)
+> (DEVELOPER-side symptom-then-cite), [`cascade-reuse.md`](./cascade-reuse.md)
+> (READ-side cascade discipline), [`response-redaction.md`](./response-redaction.md)
+> (READ-side role-tier discipline), and the new
+> [`lattice-survey.md`](./lattice-survey.md) "Producer ↔ consumer pairing"
+> section. This rule structurally enforces the upper-layer pairing the
+> survey rule documented — registry storagePath ↔ transform reader.
+>
+> Catalogued in [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md)
+> as part of the Coverage pillar of HF Lattice.
+
+## Rule: every registry entry with compose impact has a consumer
+
+When a setting lands in `JOURNEY_SETTINGS` or `VOICE_SETTINGS` with a
+non-empty `composeImpact.sections[]`, the SAME PR MUST land a
+transform / resolver / loader that READS the setting's `storagePath`
+— OR add the contract id to
+`tests/lib/journey/registry-consumer-coverage.test.ts::REGISTRY_CONSUMER_EXEMPT_PATHS`
+with a one-line reason AND bump `EXPECTED_EXEMPT_COUNT`.
+
+```
+Author adds registry entry → vitest checks transform reads it →
+  if yes, ship
+  if no, exempt-with-reason + ratchet bump (forces a conscious choice)
+```
+
+## Why this exists
+
+The producer-only failure mode lived as DOCUMENTED CONVENTION in
+[`lattice-survey.md`](./lattice-survey.md) for the entire 2026
+journey-tab build-out:
+
+> A setting that has a registry entry but no consuming transform is a
+> producer-only Lattice entry.
+
+The convention was trust-based — no structural gate enforced it. Lane 3
+catch-up PRs (#1780-series) prioritised closing Inspector visibility
+gaps; the corresponding transform reads were deferred or forgotten on a
+case-by-case basis. By 2026-06-17 there were **15 producer-only settings
+in the registry** — operators editing them, "✓ Saved" appearing, prompt
+unchanged.
+
+The 2026-06-17 audit surfaced the drift. This rule + its paired vitest
+make the producer↔consumer pairing structurally enforceable for the
+first time at this layer.
+
+## When this applies
+
+Any PR that touches:
+
+- `apps/admin/lib/journey/setting-contracts.entries.ts` (adds / changes
+  / removes a `JourneySettingContract` entry)
+- `apps/admin/lib/settings/voice-setting-contracts.ts` (same for
+  `VoiceSettingsContract`)
+- A transform that previously read a setting AND the read is being
+  removed (the exempt list contradiction-check fires)
+
+## The check
+
+The vitest classifies each `JOURNEY_SETTINGS` + `VOICE_SETTINGS` entry:
+
+| Classification | Meaning |
+|---|---|
+| `no-compose-impact` | `composeImpact.sections.length === 0` — operator-only, no consumer needed |
+| `family-shortcut` | `storagePath` under `sessionFlow.*` / `playbook.voiceConfig.*` / `behaviorTargets*` / `domain.*` — covered by canonical resolver (which IS in `CONSUMER_DIRS`) |
+| `family-shortcut` (module) | `scope === "module"` — the G8 IELTS cohort intentionally landed producer-only per epic #1700 decision 5; `HF_FLAG_IELTS_MODULE_SETTINGS` tracks the operator surface |
+| `covered` | Substring of the distinctive path segment found at word-boundary in concat'd consumer source |
+| `exempt` | In `REGISTRY_CONSUMER_EXEMPT_PATHS` with a documented one-line reason |
+| `gap` | None of the above — fails the test |
+
+## Required actions when this test fails
+
+| Failure shape | Fix |
+|---|---|
+| "Producer-only settings (no transform / resolver / loader reads their storagePath)" | Best: land the transform read in the same PR. Acceptable: add to `REGISTRY_CONSUMER_EXEMPT_PATHS` with a one-line reason, bump `EXPECTED_EXEMPT_COUNT`. |
+| "Exempt-list size drifted" | Either you wired a consumer + need to REMOVE an exempt entry (drop `EXPECTED_EXEMPT_COUNT`) OR you added an entry without bumping (force a conscious decision). |
+| "Exempt entries with no matching registry contract" | A setting was deleted; remove the stale exempt entry. |
+| "Exempt entries that now have consumer reads" | The wiring shipped; remove from the exempt list. |
+| "empty reason" | Each exempt entry needs a >10-char justification. Write one. |
+
+Never: lower the bar by widening `CONSUMER_DIRS` to cover an unrelated
+file. That defeats the audit.
+
+## When adding a new JourneySettingContract / VoiceSettingsContract
+
+Author checklist — satisfied in the same PR:
+
+1. Is `composeImpact.sections.length > 0`?
+   - **No** → operator-only. Test classifies as `no-compose-impact`, no action.
+   - **Yes** → continue.
+2. Is the `storagePath` root one of the cascade families
+   (`sessionFlow.*`, `playbook.voiceConfig.*`, `behaviorTargets*`,
+   `domain.*`)?
+   - **Yes** → test classifies as `family-shortcut`. No action.
+   - **No** (root is `config.*` or `tolerances.*`) → continue.
+3. Will the matching transform / resolver / loader be in the same PR?
+   - **Yes** → land both; test classifies as `covered`. Done.
+   - **No, deferred** → add to `REGISTRY_CONSUMER_EXEMPT_PATHS` with a
+     reason describing what's deferred + bump `EXPECTED_EXEMPT_COUNT`.
+
+## Existing enforcement
+
+| Location | Mechanism | What it prevents |
+|---|---|---|
+| `tests/lib/journey/registry-consumer-coverage.test.ts` (born 2026-06-17, this PR) | 6 vitests: gap-check, ratchet, non-empty-reason, non-stale-exempt, no-contradiction, distribution-sanity | The Lane 3 catch-up regression class — registry entry without consumer (the 2026-06-17 fingerprint: 15 producer-only settings). |
+| `tests/lib/prompt/composition/coverage-producer-consumer.test.ts` (#1848) | Static manifest + sweep at the transform↔renderer layer | The #1768 regression class — transform output lacks a renderer push (the 2026-06-17 IELTS Mock fingerprint). |
+| `eslint-rules/composition-directive-needs-renderer.mjs` (#1848) | Edit-time, error severity | Adding a `directive:` field to a transform without registering it in `coverage-producer-consumer.test.ts`. |
+| `.claude/rules/lattice-survey.md` "Producer ↔ consumer pairing" + "deeper layer" | Author discipline | Catches what slips past (1) + (2). |
+| `tests/lib/journey/registry-completeness.test.ts` | Existing shape checks | Adjacent shape problems (invalid section keys, kind mismatches) — independent of consumer pairing. |
+
+## When NOT to apply
+
+This rule applies to any setting with `composeImpact.sections.length > 0`.
+It does NOT apply to:
+
+- Settings whose effect is enforced outside compose (e.g. RBAC writeGates,
+  audit-only metadata) — those naturally have `composeImpact.sections: []`.
+- Module-scoped settings (`scope === "module"`) — the G8 IELTS cohort
+  intentionally landed producer-only. The `family-shortcut` classification
+  in the test covers this without needing exemption entries per setting.
+
+## Related
+
+- [`tests/lib/journey/registry-consumer-coverage.test.ts`](../../apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts) — the test
+- [`.claude/rules/lattice-survey.md`](./lattice-survey.md) — the convention this rule structurally enforces
+- [`docs/decisions/2026-06-16-registry-schema-coverage.md`](../../docs/decisions/2026-06-16-registry-schema-coverage.md) — sibling pattern (Lane 1)
+- Memory: feedback_lattice_guard_umbrella.md — the 4-pillar Lattice this rule extends to 5

--- a/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Registry ↔ consumer coverage — 5th-Lattice-pillar Coverage test.
+ *
+ * **What this test pins:**
+ *  Every `JourneySettingContract` (and `VOICE_SETTINGS`) entry with a
+ *  non-empty `composeImpact.sections[]` MUST have a consumer that
+ *  reads its `storagePath`. A setting that lands in the registry
+ *  without a reader is a "producer-only" Lattice violation — the
+ *  educator sees the control in the Inspector and edits it, but the
+ *  composed prompt is identical before and after the change because
+ *  no transform reads the value.
+ *
+ *  Catches the gap class surfaced by the 2026-06-17 audit (7 of 53
+ *  educator-facing settings were producer-only — Lane 3 catch-up
+ *  PRs #1780-series added the registry entries but the consumer
+ *  reads were deferred or forgotten).
+ *
+ * **How matching works:**
+ *  Settings whose `storagePath.root` is a known cascade family
+ *  (`sessionFlow.*`, `playbook.voiceConfig.*`, `behaviorTargets*`,
+ *  `domain.*`) shortcut to COVERED — their reads go through the
+ *  canonical resolver, which IS the consumer.
+ *
+ *  For `config.*` and `tolerances.*` paths the test concatenates
+ *  source from the consumer surfaces (transforms / compose / cascade
+ *  resolvers / pipeline schedulers) and checks that the most
+ *  distinctive segment of the path appears as a substring. Generic
+ *  trailing segments (`enabled`, `value`, `type`, `mode`) are
+ *  stripped — the next-up segment is searched instead.
+ *
+ *  Exemptions live in `REGISTRY_CONSUMER_EXEMPT_PATHS` with required
+ *  one-line reason. The ratchet pins the current exempt count: it
+ *  cannot grow without an explicit bump (force the author to
+ *  acknowledge they're adding to the gap pile).
+ *
+ * **How to fix a failure:**
+ *  - "Setting X has no consumer": the author shipped a registry
+ *    entry without a reading transform/resolver. Either land the
+ *    consumer in the same PR OR add to `REGISTRY_CONSUMER_EXEMPT_PATHS`
+ *    with a reason.
+ *  - "Stale exempt entry": the setting got wired up; remove from the
+ *    exempt list.
+ *  - "Ratchet drifted up": you added an exempt entry without bumping
+ *    `EXPECTED_EXEMPT_COUNT`. Decide consciously: did you mean to
+ *    grow the gap? If yes, bump. If no, wire the consumer.
+ *
+ *  See `.claude/rules/registry-consumer-coverage.md` for the durable
+ *  rule + `lattice-survey.md` "Producer ↔ consumer pairing" section.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
+import { VOICE_SETTINGS } from "@/lib/settings/voice-setting-contracts";
+import type {
+  JourneySettingContract,
+  StoragePath,
+} from "@/lib/journey/setting-contracts";
+
+// ────────────────────────────────────────────────────────────
+// Exempt list — settings whose reader is genuinely missing OR
+// landed as producer-only by explicit design decision.
+// Required: one-line reason. Periodic audit removes stale entries.
+// ────────────────────────────────────────────────────────────
+
+interface ExemptEntry {
+  /** One-line justification. Required. */
+  reason: string;
+}
+
+const REGISTRY_CONSUMER_EXEMPT_PATHS: Record<string, ExemptEntry> = {
+  // 2026-06-17 audit gaps — registry entries shipped without consumers
+  // during Lane 3 catch-up (#1780-series). Lane B follow-on issue tracks
+  // the wiring work; each transform read needs per-setting design
+  // (e.g., baselineAssessmentDepth needs "light/standard/deep" prompt
+  // synthesis, not just a substring read).
+  intakeSkipIfReturning: {
+    reason:
+      "Producer-only since 2026-06-17 audit. Intake-gate skip-for-returning-learner logic deferred to follow-on (intake transform needs the read).",
+  },
+  baselineAssessmentDepth: {
+    reason:
+      "Producer-only since 2026-06-17 audit. firstCallMode / instructions transforms don't synthesise light/standard/deep directives yet.",
+  },
+  firstCallCurriculumFocus: {
+    reason:
+      "Producer-only since 2026-06-17 audit. modulesGate transform doesn't filter Call 1 module set by focus tag yet.",
+  },
+  moduleSequencePolicy: {
+    reason:
+      "Producer-only since 2026-06-17 audit. modulesGate transform doesn't apply strict/interleaved/learner-led ordering yet.",
+  },
+  loMasteryThreshold: {
+    reason:
+      "Producer-only since 2026-06-17 audit. loMastery transform uses tierPresetId, not per-course override.",
+  },
+  assessmentReadinessThreshold: {
+    reason:
+      "Producer-only since 2026-06-17 audit. modulesGate / instructions transforms don't gate stop-fire on readiness yet.",
+  },
+  progressSignalLowWater: {
+    reason:
+      "Producer-only since 2026-06-17 audit. instructions / moduleMastery transforms don't surface low-water progress signals.",
+  },
+  progressSignalHighWater: {
+    reason:
+      "Producer-only since 2026-06-17 audit. instructions / moduleMastery transforms don't surface high-water progress signals.",
+  },
+  // 2026-06-17 follow-on — surfaced by the structural test itself
+  // (settings the agent's manual audit missed). All confirmed
+  // producer-only via wide `grep -rln <id> lib/` returning 0 hits
+  // outside `setting-contracts.entries.ts`.
+  interruptSensitivity: {
+    reason:
+      "Producer-only since 2026-06-17 audit. Voice-stack consumer pending — interrupt sensitivity should gate the VAPI assistant's `voicemailDetectionEnabled` + barge-in threshold but no transform reads it today.",
+  },
+  offboardingBannerMessage: {
+    reason:
+      "Producer-only since 2026-06-17 audit. offboarding transform doesn't render the operator's banner copy yet.",
+  },
+  offboardingCertificate: {
+    reason:
+      "Producer-only since 2026-06-17 audit. offboarding transform doesn't include certificate-mention directive yet.",
+  },
+  offboardingTriggerAfterCalls: {
+    reason:
+      "Producer-only since 2026-06-17 audit. Stop-trigger evaluator doesn't gate on this counter (offboarding fires on course-complete only).",
+  },
+  openingRecapEnabled: {
+    reason:
+      "Producer-only since 2026-06-17 audit. Opening-recap is a SECOND recap variant (Call 1 framing) distinct from priorCallFeedback (Call 2+ history). No transform consults the flag.",
+  },
+  recapSynthesisEnabled: {
+    reason:
+      "Producer-only since 2026-06-17 audit. `recapSynthesisCache` is the OUTPUT column read by transforms; the gating flag `recapSynthesisEnabled` is never checked — synthesis runs unconditionally when there's prior-call context.",
+  },
+  rewardStrategy: {
+    reason:
+      "Producer-only since 2026-06-17 audit. REWARD pipeline stage uses a hardcoded strategy; the operator-set override is not consulted yet (writeGate is operator-only with reprompt — landing was deferred per epic #779 Felt Progress S1).",
+  },
+};
+
+/** Ratchet — the exempt count is allowed to GO DOWN (wire a consumer,
+ *  remove the entry), never UP without a bump here. The test fails on
+ *  drift in either direction so a careless add gets caught at PR time. */
+const EXPECTED_EXEMPT_COUNT = 15;
+
+// ────────────────────────────────────────────────────────────
+// Consumer-surface concatenation
+// ────────────────────────────────────────────────────────────
+
+const REPO_ADMIN = resolve(__dirname, "..", "..", "..");
+
+/** Directories whose source files are the canonical "consumers". A
+ *  setting's storagePath substring appearing in ANY of these counts
+ *  as covered. */
+const CONSUMER_DIRS = [
+  "lib/prompt/composition/transforms",
+  "lib/prompt/composition/loaders",
+  "lib/prompt/composition",
+  "lib/compose",
+  "lib/session-flow",
+  "lib/cascade/resolvers",
+  "lib/pipeline",
+  "lib/contracts",
+  // Settings whose effect is enforced outside compose itself still
+  // count — the educator's edit changes runtime behaviour either via
+  // prompt content (above) OR via runtime gates (below).
+  "lib/channels",
+  "lib/curriculum",
+  "lib/voice",
+  "lib/goals",
+  "lib/tolerance",
+  "lib/intake",
+  "lib/banding",
+];
+
+function walkTs(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      out.push(...walkTs(full));
+    } else if (e.endsWith(".ts") || e.endsWith(".tsx")) {
+      // Skip test files — they don't count as consumers.
+      if (full.includes("/__tests__/") || full.endsWith(".test.ts") || full.endsWith(".test.tsx")) {
+        continue;
+      }
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const CONSUMER_SOURCE: string = (() => {
+  const files: string[] = [];
+  for (const dir of CONSUMER_DIRS) {
+    files.push(...walkTs(join(REPO_ADMIN, dir)));
+  }
+  return files
+    .map((f) => {
+      try {
+        return readFileSync(f, "utf8");
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+})();
+
+// ────────────────────────────────────────────────────────────
+// Path → search-term extraction
+// ────────────────────────────────────────────────────────────
+
+/** Generic field names that don't uniquely identify a setting — skip
+ *  these when picking the search term and use the next-up segment. */
+const GENERIC_SEGMENTS = new Set([
+  "enabled",
+  "value",
+  "values",
+  "type",
+  "id",
+  "ids",
+  "kind",
+  "mode",
+  "count",
+  "threshold",
+  "min",
+  "max",
+  "default",
+]);
+
+function getPathString(sp: StoragePath): string {
+  return typeof sp === "string" ? sp : sp.path;
+}
+
+function getStorageRoot(path: string): string {
+  if (path.startsWith("config.")) return "config";
+  if (path.startsWith("sessionFlow.")) return "sessionFlow";
+  if (path.startsWith("tolerances.")) return "tolerances";
+  if (path.startsWith("playbook.voiceConfig.")) return "playbook.voiceConfig";
+  if (path.startsWith("domain.")) return "domain";
+  if (path.startsWith("behaviorTargets")) return "behaviorTargets";
+  return "unknown";
+}
+
+/** Pick search terms to try. Strips `[]` placeholders + generic
+ *  trailing names + handles `*Enabled` camelCase boolean suffixes by
+ *  also trying the bare concept (`recapSynthesisEnabled` → also try
+ *  `recapSynthesis`). Returns the ordered candidate set — the test
+ *  treats any match as covered. */
+function pickSearchTerms(path: string): string[] {
+  const segments = path
+    .split(".")
+    .map((s) => s.replace(/\[\]$/, "").replace(/\[.*\]$/, ""))
+    .filter((s) => s.length > 0);
+  const out: string[] = [];
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const seg = segments[i];
+    if (GENERIC_SEGMENTS.has(seg)) continue;
+    out.push(seg);
+    // `*Enabled` boolean-flag suffix: also try the bare concept.
+    const m = seg.match(/^(.+)Enabled$/);
+    if (m && m[1].length > 0) out.push(m[1]);
+    // First non-generic segment is distinctive enough — don't keep
+    // walking up to broader parents (would produce false positives
+    // on common parent names like `config`).
+    break;
+  }
+  if (out.length === 0 && segments.length > 0) {
+    out.push(segments[segments.length - 1]);
+  }
+  return out;
+}
+
+// ────────────────────────────────────────────────────────────
+// Classification
+// ────────────────────────────────────────────────────────────
+
+type Classification =
+  | "covered"
+  | "family-shortcut"
+  | "no-compose-impact"
+  | "exempt"
+  | "gap";
+
+interface ClassResult {
+  id: string;
+  classification: Classification;
+  searchTerm?: string;
+  reason?: string;
+}
+
+function classify(c: JourneySettingContract): ClassResult {
+  // Operator-only settings with no compose impact: no consumer needed.
+  if (c.composeImpact.sections.length === 0) {
+    return { id: c.id, classification: "no-compose-impact" };
+  }
+
+  // Module-scoped (G8 IELTS cohort + future per-module settings): the
+  // existing `lattice-survey.md` rule intentionally permits producer-
+  // only here while Phase 2 wiring lands. Marked family-shortcut so
+  // they don't pollute the gap list; the operator-level tracking is
+  // the `HF_FLAG_IELTS_MODULE_SETTINGS` flag.
+  if (c.scope === "module") {
+    return { id: c.id, classification: "family-shortcut" };
+  }
+
+  const path = getPathString(c.storagePath);
+  const root = getStorageRoot(path);
+
+  // Family shortcut — paths under a known cascade family are read
+  // through their canonical resolver (which IS in CONSUMER_DIRS).
+  if (
+    root === "sessionFlow" ||
+    root === "playbook.voiceConfig" ||
+    root === "behaviorTargets" ||
+    root === "domain"
+  ) {
+    return { id: c.id, classification: "family-shortcut" };
+  }
+
+  // Exempt — known producer-only with documented reason.
+  if (REGISTRY_CONSUMER_EXEMPT_PATHS[c.id]) {
+    return {
+      id: c.id,
+      classification: "exempt",
+      reason: REGISTRY_CONSUMER_EXEMPT_PATHS[c.id].reason,
+    };
+  }
+
+  // Substring search for `config.*` and `tolerances.*` paths. Try each
+  // candidate term; any match counts.
+  const terms = pickSearchTerms(path);
+  for (const term of terms) {
+    if (term.length === 0) continue;
+    const re = new RegExp(`\\b${term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`);
+    if (re.test(CONSUMER_SOURCE)) {
+      return { id: c.id, classification: "covered", searchTerm: term };
+    }
+  }
+  return { id: c.id, classification: "gap", searchTerm: terms.join(" / ") };
+}
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe("Registry consumer coverage (Lattice 5th-pillar)", () => {
+  const all = [...JOURNEY_SETTINGS, ...VOICE_SETTINGS];
+  const results = all.map(classify);
+
+  it("no producer-only setting has slipped past the exempt list", () => {
+    const gaps = results.filter((r) => r.classification === "gap");
+    expect(
+      gaps,
+      `Producer-only settings (no transform / resolver / loader reads their storagePath):\n  ${gaps
+        .map((g) => `${g.id} (term: ${g.searchTerm})`)
+        .join("\n  ")}\n\nFix: either land the consumer in the same PR, OR add to REGISTRY_CONSUMER_EXEMPT_PATHS with a one-line reason.`,
+    ).toEqual([]);
+  });
+
+  it("exempt list ratchet — count matches EXPECTED_EXEMPT_COUNT", () => {
+    const exemptIds = Object.keys(REGISTRY_CONSUMER_EXEMPT_PATHS);
+    expect(
+      exemptIds.length,
+      `Exempt-list size drifted from ${EXPECTED_EXEMPT_COUNT}. ` +
+        `If you wired a consumer + removed an entry, bump ` +
+        `EXPECTED_EXEMPT_COUNT down. If you added an entry, ` +
+        `pause: was that intentional? Wire the consumer first. ` +
+        `Current entries: ${exemptIds.join(", ")}`,
+    ).toBe(EXPECTED_EXEMPT_COUNT);
+  });
+
+  it("every exempt entry has a non-empty reason", () => {
+    for (const [id, entry] of Object.entries(REGISTRY_CONSUMER_EXEMPT_PATHS)) {
+      expect(entry.reason.trim().length, `${id}: empty reason`).toBeGreaterThan(
+        10,
+      );
+    }
+  });
+
+  it("no exempt entry is stale (each id still appears in JOURNEY_SETTINGS / VOICE_SETTINGS)", () => {
+    const knownIds = new Set(all.map((c) => c.id));
+    const stale = Object.keys(REGISTRY_CONSUMER_EXEMPT_PATHS).filter(
+      (id) => !knownIds.has(id),
+    );
+    expect(
+      stale,
+      `Exempt entries with no matching registry contract — registry deleted the setting; remove the exempt row: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("no exempt entry is contradicted by an actual consumer read", () => {
+    // If a setting is in the exempt list but its searchTerm IS present
+    // in consumer source, the exempt entry is stale — the wiring shipped
+    // and the entry should be removed.
+    const contradicted: string[] = [];
+    for (const id of Object.keys(REGISTRY_CONSUMER_EXEMPT_PATHS)) {
+      const c = all.find((x) => x.id === id);
+      if (!c) continue;
+      const path = getPathString(c.storagePath);
+      const terms = pickSearchTerms(path);
+      for (const term of terms) {
+        if (term.length === 0) continue;
+        const re = new RegExp(
+          `\\b${term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+        );
+        if (re.test(CONSUMER_SOURCE)) {
+          contradicted.push(
+            `${id} (term '${term}' now found in consumer source)`,
+          );
+          break;
+        }
+      }
+    }
+    expect(
+      contradicted,
+      `Exempt entries that now have consumer reads — remove from REGISTRY_CONSUMER_EXEMPT_PATHS:\n  ${contradicted.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("classification distribution sanity check (operator-facing log)", () => {
+    const counts: Record<Classification, number> = {
+      covered: 0,
+      "family-shortcut": 0,
+      "no-compose-impact": 0,
+      exempt: 0,
+      gap: 0,
+    };
+    for (const r of results) counts[r.classification]++;
+    // The sum must equal the input size — sanity for the classifier.
+    const sum = Object.values(counts).reduce((s, n) => s + n, 0);
+    expect(sum).toBe(all.length);
+  });
+});


### PR DESCRIPTION
## Summary

Structural fix for the producer-only failure mode at the **registry storagePath → transform reader** layer. Complements PR #1848 which closed the layer below (transform → renderer).

`.claude/rules/lattice-survey.md` "Producer ↔ consumer pairing" has documented this rule since the journey-tab build-out. Without a structural gate, 15 producer-only settings drifted in over months via Lane 3 catch-up PRs (#1780-series) — operators editing them, "✓ Saved" appearing, prompt unchanged.

This PR makes the rule structurally enforceable.

## What ships

1. **`tests/lib/journey/registry-consumer-coverage.test.ts`** — 6 vitests classify each `JOURNEY_SETTINGS` + `VOICE_SETTINGS` entry as: `no-compose-impact` / `family-shortcut` / `covered` / `exempt` / `gap`.
2. **15 exempt entries at birth** — pre-existing producer-only debt frozen in place with documented reasons + `EXPECTED_EXEMPT_COUNT = 15` ratchet.
3. **`.claude/rules/registry-consumer-coverage.md`** — durable rule + author checklist.
4. **`.claude/rules/lattice-survey.md`** — references the new structural test + birth-state debt.

## Why this happened

The Lattice had this surface covered by **convention** (`lattice-survey.md` rule file) but not by **structure** (no vitest, no ESLint). Authors were trusted; nothing fired when they slipped. The other Coverage pillar tests check the registry is well-formed (valid keys, kinds, sections, option literals) but none reach into transforms to verify any actually read a `storagePath`.

After this PR + #1848, the producer↔consumer chain has structural gates at **both** layers (registry→transform AND transform→renderer).

## The 15 exempt entries

intakeSkipIfReturning · baselineAssessmentDepth · firstCallCurriculumFocus · moduleSequencePolicy · loMasteryThreshold · assessmentReadinessThreshold · progressSignalLowWater · progressSignalHighWater · interruptSensitivity · offboardingBannerMessage · offboardingCertificate · offboardingTriggerAfterCalls · openingRecapEnabled · recapSynthesisEnabled · rewardStrategy.

Each has a one-line reason explaining what's deferred. Wiring any of them — in a follow-up PR — removes the exempt entry + drops the ratchet by 1.

## Verified by

- `npx vitest run tests/lib/journey/registry-consumer-coverage.test.ts` — 6/6 pass [verified].
- `npx vitest run tests/lib/journey/` — 68/68 pass (no regression) [verified].
- Sibling-writer survey: each of the 15 exempt entries inverse-probed via `grep -rln <id> lib/ --include="*.ts"` returning 0 hits outside `setting-contracts.entries.ts` itself [verified for all 15].

## Heuristic notes

- Substring search uses word-boundary regex against the last distinctive path segment.
- `*Enabled` boolean-flag suffix is stripped (`config.recapSynthesisEnabled` also tries `recapSynthesis`) for the gate-flag-on-named-feature case.
- Generic trailing segments (`enabled`, `value`, `type`, `mode`, `count`, `threshold`, `min`, `max`, `default`) skipped in favour of next-up segment.
- Test files excluded from consumer source (`*.test.ts`, `__tests__/`).
- Family shortcut for cascade-resolved paths + `scope: "module"` (G8 cohort) preserves existing intentional-gap conventions.

## Test plan

- [x] No producer-only setting slips past the exempt list
- [x] Ratchet pins count at 15
- [x] Every exempt entry has a non-empty (>10-char) reason
- [x] No exempt entry is stale (id still exists in registry)
- [x] No exempt entry is contradicted (a consumer now reads its term)
- [x] Distribution sanity (sum of classifications == input length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)