### PR TITLE
feat(journey): P0 foundation — appliesTo + relevance-state primitives (#1850)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 41,
+  "tsc_errors": 36,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/components/journey-controls/RelevanceWrapper.tsx
+++ b/apps/admin/components/journey-controls/RelevanceWrapper.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * RelevanceWrapper — Phase 0 of the Journey-Design tab refactor.
+ *
+ * Wraps a journey-control field and renders the appropriate
+ * relevance-state overlay. Five mutually-exclusive states:
+ *
+ *   active       — nothing to indicate; children render bare
+ *   inherited    — value comes from a parent layer (Domain/System);
+ *                  child is wrapped in a LayerBadge chip
+ *   auto-derived — value is computed/coupled (e.g. cascade-derived
+ *                  banding); operator can decouple via `unlockAction`
+ *   gated-off    — a parent setting holds this control to its off-state;
+ *                  clicking the chip jumps to the parent
+ *   out-of-shape — the contract's `appliesTo` excludes the current
+ *                  course shape (e.g. module-scoped settings on a
+ *                  continuous course)
+ *
+ * Priority order (`computeRelevanceState` enforces):
+ *   out-of-shape > gated-off > auto-derived > inherited > active
+ *
+ * Sibling primitives: `<LayerBadge>` (cascade chip — used here for the
+ * inherited state to honour `.claude/rules/cascade-reuse.md`).
+ */
+
+import "./relevance-wrapper.css";
+
+import { Lock } from "lucide-react";
+
+export type RelevanceState =
+  | "active"
+  | "inherited"
+  | "auto-derived"
+  | "gated-off"
+  | "out-of-shape";
+
+export interface RelevanceWrapperProps {
+  /** Which relevance state the field is in. */
+  state: RelevanceState;
+  /** Human-readable rationale — surfaced in the chip on `auto-derived`
+   *  and `out-of-shape`. e.g. "Continuous courses don't use modules". */
+  reason?: string;
+  /** Contract id of the gating parent — used by `gated-off` to wire
+   *  the chip's click handler. */
+  parentSettingId?: string;
+  /** Educator-facing label of the gating parent (e.g. "NPS enabled"). */
+  parentSettingLabel?: string;
+  /** Layer of origin for `inherited` — e.g. "Domain" or "System". */
+  layerOrigin?: string;
+  /** Click handler for the `auto-derived` decouple action. */
+  unlockAction?: () => void;
+  /** Click handler for the `gated-off` chip. */
+  onJumpToParent?: (settingId: string) => void;
+  /** The wrapped control. */
+  children: React.ReactNode;
+}
+
+/**
+ * Render the appropriate overlay + child for the given relevance state.
+ *
+ * `active` short-circuits to a fragment — no wrapper at all. The other
+ * four states render an overlay container with a status chip and the
+ * (possibly visually-muted) children below.
+ */
+export function RelevanceWrapper({
+  state,
+  reason,
+  parentSettingId,
+  parentSettingLabel,
+  layerOrigin,
+  unlockAction,
+  onJumpToParent,
+  children,
+}: RelevanceWrapperProps): React.ReactElement {
+  if (state === "active") {
+    return <>{children}</>;
+  }
+
+  if (state === "inherited") {
+    // Cascade-aware inherited rendering. We don't have an Effective
+    // envelope here (this wrapper is shape-aware, not cascade-aware —
+    // cascade lives in LayerBadge). Render a minimal "inherited from X"
+    // chip so the operator sees provenance without a full cascade tray.
+    return (
+      <div
+        className="hf-relevance-wrap hf-relevance-wrap--inherited"
+        data-state="inherited"
+      >
+        <div className="hf-relevance-chip hf-relevance-chip--inherited">
+          <span aria-hidden="true" className="hf-relevance-chip-icon">↑</span>
+          <span className="hf-relevance-chip-text">
+            Inherited
+            {layerOrigin ? ` from ${layerOrigin}` : ""}
+          </span>
+        </div>
+        <div className="hf-relevance-children">{children}</div>
+      </div>
+    );
+  }
+
+  if (state === "auto-derived") {
+    return (
+      <div
+        className="hf-relevance-wrap hf-relevance-wrap--auto-derived"
+        data-state="auto-derived"
+      >
+        <div className="hf-relevance-chip hf-relevance-chip--auto-derived">
+          <Lock
+            size={12}
+            aria-hidden={true}
+            focusable="false"
+            className="hf-relevance-chip-icon"
+          />
+          <span className="hf-relevance-chip-text">
+            {reason ?? "Auto-derived"}
+          </span>
+          {unlockAction ? (
+            <button
+              type="button"
+              onClick={unlockAction}
+              className="hf-relevance-chip-action"
+              aria-label="Decouple this setting from its derived source"
+            >
+              Decouple
+            </button>
+          ) : null}
+        </div>
+        <div className="hf-relevance-children hf-relevance-children--muted">
+          {children}
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "gated-off") {
+    const chipText = parentSettingLabel
+      ? `Enable ${parentSettingLabel} first`
+      : "Disabled by parent setting";
+    const handleJump = () => {
+      if (parentSettingId && onJumpToParent) {
+        onJumpToParent(parentSettingId);
+      }
+    };
+    const clickable = Boolean(parentSettingId && onJumpToParent);
+    return (
+      <div
+        className="hf-relevance-wrap hf-relevance-wrap--gated-off"
+        data-state="gated-off"
+      >
+        {clickable ? (
+          <button
+            type="button"
+            onClick={handleJump}
+            className="hf-relevance-chip hf-relevance-chip--gated-off hf-relevance-chip-button"
+            aria-label={`Jump to parent setting: ${parentSettingLabel ?? parentSettingId}`}
+          >
+            <span aria-hidden="true" className="hf-relevance-chip-icon">⊘</span>
+            <span className="hf-relevance-chip-text">{chipText}</span>
+          </button>
+        ) : (
+          <div className="hf-relevance-chip hf-relevance-chip--gated-off">
+            <span aria-hidden="true" className="hf-relevance-chip-icon">⊘</span>
+            <span className="hf-relevance-chip-text">{chipText}</span>
+          </div>
+        )}
+        <div className="hf-relevance-children hf-relevance-children--muted">
+          {children}
+        </div>
+      </div>
+    );
+  }
+
+  // out-of-shape
+  return (
+    <div
+      className="hf-relevance-wrap hf-relevance-wrap--out-of-shape"
+      data-state="out-of-shape"
+    >
+      <div className="hf-relevance-chip hf-relevance-chip--out-of-shape">
+        <span aria-hidden="true" className="hf-relevance-chip-icon">∅</span>
+        <span className="hf-relevance-chip-text">
+          {reason ?? "Doesn't apply to this course shape"}
+        </span>
+      </div>
+      <div className="hf-relevance-children hf-relevance-children--muted">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/journey-controls/relevance-wrapper.css
+++ b/apps/admin/components/journey-controls/relevance-wrapper.css
@@ -1,0 +1,123 @@
+/**
+ * RelevanceWrapper styles — Phase 0 of the Journey-Design tab refactor.
+ *
+ * Tokens only. `color-mix()` for alpha. Co-located with the component.
+ *
+ * Visual hierarchy:
+ *   .hf-relevance-wrap        — outer container per non-`active` state
+ *   .hf-relevance-chip        — status chip rendered above the children
+ *   .hf-relevance-chip-icon   — small leading glyph
+ *   .hf-relevance-chip-text   — primary label
+ *   .hf-relevance-chip-action — optional CTA inside the chip (e.g. Decouple)
+ *   .hf-relevance-chip-button — when the chip is a click target
+ *   .hf-relevance-children    — slot holding the actual control
+ *
+ * State variants (data-state-driven where convenient) live on
+ * `.hf-relevance-chip--<state>` and `.hf-relevance-wrap--<state>`.
+ */
+
+.hf-relevance-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+  background: color-mix(in srgb, var(--surface-secondary) 30%, transparent);
+}
+
+.hf-relevance-wrap--inherited {
+  background: color-mix(in srgb, var(--surface-secondary) 20%, transparent);
+}
+
+.hf-relevance-wrap--auto-derived,
+.hf-relevance-wrap--gated-off,
+.hf-relevance-wrap--out-of-shape {
+  background: color-mix(in srgb, var(--surface-secondary) 60%, transparent);
+}
+
+.hf-relevance-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 1.4;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  width: max-content;
+  max-width: 100%;
+}
+
+.hf-relevance-chip-button {
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.hf-relevance-chip-button:hover {
+  background: color-mix(in srgb, var(--accent-primary) 8%, var(--surface-primary));
+  border-color: color-mix(in srgb, var(--accent-primary) 40%, var(--border-default));
+  color: var(--text-primary);
+}
+
+.hf-relevance-chip-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hf-relevance-chip-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hf-relevance-chip-action {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0 0 0 6px;
+  margin: 0;
+  font: inherit;
+  color: var(--accent-primary);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.hf-relevance-chip-action:hover {
+  color: color-mix(in srgb, var(--accent-primary) 80%, var(--text-primary));
+}
+
+.hf-relevance-chip--inherited {
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--accent-primary) 30%, var(--border-default));
+}
+
+.hf-relevance-chip--auto-derived {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--accent-primary) 5%, var(--surface-primary));
+  border-color: color-mix(in srgb, var(--accent-primary) 25%, var(--border-default));
+}
+
+.hf-relevance-chip--gated-off {
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 5%, var(--surface-primary));
+}
+
+.hf-relevance-chip--out-of-shape {
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--surface-secondary) 80%, var(--surface-primary));
+  font-style: italic;
+}
+
+.hf-relevance-children {
+  padding-top: 2px;
+}
+
+.hf-relevance-children--muted {
+  opacity: 0.55;
+  pointer-events: none;
+}

--- a/apps/admin/lib/journey/compute-relevance-state.ts
+++ b/apps/admin/lib/journey/compute-relevance-state.ts
@@ -1,0 +1,225 @@
+/**
+ * computeRelevanceState — Phase 0 of the Journey-Design tab refactor.
+ *
+ * Reads the contract + the current course-shape + cascade envelope
+ * + PlaybookConfig and returns the relevance state the Inspector
+ * should render the control in.
+ *
+ * Priority (highest first — `out-of-shape` shadows every other state):
+ *
+ *   1. out-of-shape   The contract's `appliesTo` excludes the
+ *                     current course shape.
+ *   2. gated-off      A parent setting holds this control to its
+ *                     off-equivalent state (via explicit `gatedBy` or
+ *                     a peer's noop `autoEnableLinks`).
+ *   3. auto-derived   A peer's `autoEnableLinks` is currently FORCING
+ *                     this control's value (parent value matches
+ *                     `whenValue`, `decoupleAllowed` is true, and the
+ *                     enforce value is not a noop — i.e. it's an
+ *                     actual coupling, not a gate).
+ *   4. inherited      The cascade envelope's effective value comes
+ *                     from a layer other than the course (Domain or
+ *                     System).
+ *   5. active         Default — the control is editable here.
+ *
+ * Sibling to `<RelevanceWrapper>` (the render-side consumer of this
+ * helper's output).
+ */
+
+import type { PlaybookConfig } from "../types/json-fields";
+import { isGatedBy } from "./is-gated-by";
+import type {
+  CourseShape,
+  JourneySettingContract,
+} from "./setting-contracts";
+
+export type RelevanceState =
+  | "active"
+  | "inherited"
+  | "auto-derived"
+  | "gated-off"
+  | "out-of-shape";
+
+/** Layer of the effective value — a thin mirror of the cascade
+ *  `Layer` union for the inputs to this helper, kept independent so
+ *  this lib doesn't import from `lib/cascade/` (cascade depends on
+ *  setting contracts indirectly, not the other way around). */
+export type EffectiveLayer = "system" | "domain" | "course" | "caller";
+
+export interface ComputeRelevanceStateArgs {
+  setting: JourneySettingContract;
+  playbookConfig: PlaybookConfig;
+  courseShape: CourseShape;
+  /** The cascade-resolved effective value envelope. When the setting
+   *  has no registered cascade family, callers should pass
+   *  `{ layer: "course", value: <local-snapshot> }` so the helper's
+   *  "inherited" branch never fires. */
+  effectiveValue: { layer: EffectiveLayer; value: unknown };
+  /** The full registry of contracts. Used by `isGatedBy` to resolve
+   *  parent ids to labels + paths, and for auto-derive detection. */
+  registry: readonly JourneySettingContract[];
+}
+
+export interface ComputeRelevanceStateResult {
+  state: RelevanceState;
+  /** Free-text rationale to surface in the overlay chip. */
+  reason?: string;
+  /** Gating / auto-derive parent id (when applicable). */
+  parentId?: string;
+  /** Educator-facing label of the parent (when applicable). */
+  parentLabel?: string;
+  /** Layer name for inherited state (e.g. "Domain"). */
+  layerOrigin?: string;
+}
+
+/**
+ * Resolve the relevance state in priority order. Stops at the first
+ * match — never returns multiple states.
+ */
+export function computeRelevanceState(
+  args: ComputeRelevanceStateArgs,
+): ComputeRelevanceStateResult {
+  const { setting, playbookConfig, courseShape, effectiveValue, registry } =
+    args;
+
+  // 1) out-of-shape — highest priority. When the contract declares
+  // `appliesTo` and the current course shape isn't in the array, the
+  // setting is irrelevant for this course. Educator should never edit
+  // it (and downstream readers will ignore it).
+  if (setting.appliesTo && !setting.appliesTo.includes(courseShape)) {
+    return {
+      state: "out-of-shape",
+      reason: outOfShapeReason(setting.appliesTo, courseShape),
+    };
+  }
+
+  // 2) gated-off — parent setting holds this control to its
+  // off-equivalent state.
+  const gate = isGatedBy(setting, playbookConfig, registry);
+  if (gate) {
+    return {
+      state: "gated-off",
+      parentId: gate.parentId,
+      parentLabel: gate.parentLabel,
+    };
+  }
+
+  // 3) auto-derived — a peer's autoEnableLink is currently FORCING
+  // this control's value with a non-noop enforce. Operator may decouple
+  // if the link declares `decoupleAllowed`.
+  const autoLink = findActiveAutoEnable(setting, playbookConfig, registry);
+  if (autoLink) {
+    return {
+      state: "auto-derived",
+      reason: autoLink.reason,
+      parentId: autoLink.parentId,
+      parentLabel: autoLink.parentLabel,
+    };
+  }
+
+  // 4) inherited — the cascade envelope's effective value resolves
+  // from a layer other than the course.
+  if (
+    effectiveValue.layer === "domain" ||
+    effectiveValue.layer === "system" ||
+    effectiveValue.layer === "caller"
+  ) {
+    return {
+      state: "inherited",
+      layerOrigin: layerLabel(effectiveValue.layer),
+    };
+  }
+
+  // 5) active — editable here.
+  return { state: "active" };
+}
+
+function outOfShapeReason(
+  appliesTo: readonly CourseShape[],
+  current: CourseShape,
+): string {
+  // Friendly explanations per current shape. The educator clicked
+  // into a control on a course shape that doesn't honour it.
+  if (current === "continuous") {
+    return "Continuous courses don't use modules";
+  }
+  if (current === "exam" && !appliesTo.includes("exam")) {
+    return "Exam courses use a different setting for this";
+  }
+  if (current === "structured" && !appliesTo.includes("structured")) {
+    return "Structured courses use a different setting for this";
+  }
+  const allowed = appliesTo.join(", ");
+  return `Only applies to ${allowed} courses`;
+}
+
+function layerLabel(layer: EffectiveLayer): string {
+  switch (layer) {
+    case "system":
+      return "System";
+    case "domain":
+      return "Domain";
+    case "course":
+      return "Course";
+    case "caller":
+      return "Caller";
+  }
+}
+
+interface ActiveAutoEnable {
+  parentId: string;
+  parentLabel: string;
+  reason: string;
+}
+
+function findActiveAutoEnable(
+  setting: JourneySettingContract,
+  playbookConfig: PlaybookConfig,
+  registry: readonly JourneySettingContract[],
+): ActiveAutoEnable | null {
+  for (const peer of registry) {
+    if (peer.id === setting.id) continue;
+    if (!peer.autoEnableLinks) continue;
+    for (const link of peer.autoEnableLinks) {
+      if (link.targetId !== setting.id) continue;
+      // Noop enforce values are handled by `isGatedBy` (gated-off
+      // state). Auto-derive is the inverse: a real value forcing the
+      // child to a non-default state.
+      if (isNoopEnforce(link.enforce)) continue;
+      const peerPath =
+        typeof peer.storagePath === "string"
+          ? peer.storagePath
+          : peer.storagePath.path;
+      const peerValue = readByDotPath(playbookConfig, peerPath);
+      if (peerValue === link.whenValue) {
+        return {
+          parentId: peer.id,
+          parentLabel: peer.educatorLabel,
+          reason: link.reason,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function isNoopEnforce(enforce: unknown): boolean {
+  return (
+    enforce === false ||
+    enforce === "" ||
+    enforce === 0 ||
+    enforce === null
+  );
+}
+
+function readByDotPath(config: PlaybookConfig, path: string): unknown {
+  const trimmed = path.startsWith("config.") ? path.slice(7) : path;
+  const parts = trimmed.split(".");
+  let cur: unknown = config;
+  for (const part of parts) {
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur;
+}

--- a/apps/admin/lib/journey/is-gated-by.ts
+++ b/apps/admin/lib/journey/is-gated-by.ts
@@ -1,0 +1,129 @@
+/**
+ * isGatedBy — Phase 0 of the Journey-Design tab refactor.
+ *
+ * Returns the parent setting id (+ educator label) that gates this
+ * setting to "off", or null if not gated.
+ *
+ * Two sources of gating, checked in priority order:
+ *   1. Explicit `setting.gatedBy = { parentId, inactiveValues }` —
+ *      the canonical form for cases where the gating relationship is
+ *      a UX concept rather than a server-side coupling.
+ *   2. Derived from sibling-writer `autoEnableLinks` — when ANOTHER
+ *      contract in the registry has an autoEnableLink that forces
+ *      THIS setting to its "off" value (e.g. `enforce: false` for a
+ *      toggle, `enforce: ""` for a text field) when the parent has a
+ *      specific value, we treat that as a gate.
+ *
+ * Returns `null` when neither source applies.
+ *
+ * Sibling to `.claude/rules/cascade-reuse.md` — both are read-side
+ * disciplines for the Journey Inspector. Cascade-reuse handles layer
+ * provenance; this handles parent-relevance gating.
+ */
+
+import type { PlaybookConfig } from "../types/json-fields";
+import type { JourneySettingContract } from "./setting-contracts";
+
+/** Helper return shape. `parentId` is the contract id; `parentLabel`
+ *  is the educator-facing label of the parent (for chip text). */
+export interface GatedByResult {
+  parentId: string;
+  parentLabel: string;
+}
+
+/**
+ * Resolve `playbookConfig.<storagePath>` for the simple bare-string
+ * path case used by gating-parent settings (all current gating parents
+ * are top-level config booleans / strings, not array-addressed).
+ *
+ * Returns `undefined` if the path doesn't resolve. Structured
+ * StoragePath (`{path, arrayKey, selectorValue}`) is NOT supported here
+ * — gating parents in scope today are bare-string paths.
+ */
+function readByDotPath(config: PlaybookConfig, path: string): unknown {
+  // Strip a leading "config." prefix when present — registry entries
+  // use both `config.foo` (Playbook envelope) and `foo` (bare).
+  const trimmed = path.startsWith("config.") ? path.slice(7) : path;
+  const parts = trimmed.split(".");
+  let cur: unknown = config;
+  for (const part of parts) {
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur;
+}
+
+/**
+ * Returns the parent setting that holds `setting` in its inactive
+ * state, or `null` when not gated.
+ *
+ * @param setting     The contract whose gating we're checking.
+ * @param playbookConfig The PlaybookConfig snapshot to read parent
+ *                    values from.
+ * @param registry    The full registry of contracts (used to resolve
+ *                    parent ids → labels + storage paths). Pass the
+ *                    union of `JOURNEY_SETTINGS` + `VOICE_SETTINGS`
+ *                    when in doubt — the function only follows ids it
+ *                    actually finds.
+ */
+export function isGatedBy(
+  setting: JourneySettingContract,
+  playbookConfig: PlaybookConfig,
+  registry: readonly JourneySettingContract[],
+): GatedByResult | null {
+  // 1) Explicit `gatedBy` declaration — preferred.
+  if (setting.gatedBy) {
+    const parent = registry.find((c) => c.id === setting.gatedBy!.parentId);
+    if (!parent) return null;
+    const parentPath =
+      typeof parent.storagePath === "string"
+        ? parent.storagePath
+        : parent.storagePath.path;
+    const parentValue = readByDotPath(playbookConfig, parentPath);
+    const isInactive = setting.gatedBy.inactiveValues.some(
+      (v) => v === parentValue,
+    );
+    return isInactive
+      ? { parentId: parent.id, parentLabel: parent.educatorLabel }
+      : null;
+  }
+
+  // 2) Derive from sibling `autoEnableLinks` — when a peer in the
+  // registry has an autoEnableLink that targets `setting.id` and
+  // forces it into a "noop" / "off" value, we treat the peer as a
+  // gating parent.
+  //
+  // Noop shapes we recognise:
+  //   - `enforce === false` (toggles)
+  //   - `enforce === ""` (text/select cleared)
+  //   - `enforce === 0` (numeric zeroed)
+  //   - `enforce === null` (any "cleared" sentinel)
+  for (const peer of registry) {
+    if (peer.id === setting.id) continue;
+    if (!peer.autoEnableLinks) continue;
+    for (const link of peer.autoEnableLinks) {
+      if (link.targetId !== setting.id) continue;
+      if (!isNoopEnforce(link.enforce)) continue;
+      const peerPath =
+        typeof peer.storagePath === "string"
+          ? peer.storagePath
+          : peer.storagePath.path;
+      const peerValue = readByDotPath(playbookConfig, peerPath);
+      if (peerValue === link.whenValue) {
+        return { parentId: peer.id, parentLabel: peer.educatorLabel };
+      }
+    }
+  }
+
+  return null;
+}
+
+function isNoopEnforce(enforce: unknown): boolean {
+  return (
+    enforce === false ||
+    enforce === "" ||
+    enforce === 0 ||
+    enforce === null
+  );
+}

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -446,6 +446,7 @@ const G3_MODULE_SEQUENCE_POLICY: JourneySettingContract = {
     { value: "interleaved", label: "Interleaved review" },
     { value: "learner_led", label: "Learner picks next" },
   ],
+  appliesTo: ["structured"],
 };
 
 const G3_FIRST_CALL_CURRICULUM_FOCUS: JourneySettingContract = {
@@ -1422,6 +1423,7 @@ const G7_FIRST_CALL_MODULE_VISIBILITY: JourneySettingContract = {
     { value: "hide_until_call_2", label: "Hide until Call 2" },
     { value: "hide_until_learner_picks", label: "Hide until learner picks" },
   ],
+  appliesTo: ["structured"],
 };
 
 const G7_COMPLETION_MODE: JourneySettingContract = {
@@ -1463,6 +1465,7 @@ const G7_STRICT_PREREQUISITES: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "modulesGate" }],
+  appliesTo: ["structured"],
 };
 
 const G7_LO_MASTERY_THRESHOLD: JourneySettingContract = {
@@ -1633,6 +1636,7 @@ const G8_MODULE_QUESTION_TARGET: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "instructions", hint: "question count directive" }],
+  appliesTo: ["structured", "exam"],
 };
 
 const G8_MODULE_MIN_SPEAKING_SEC: JourneySettingContract = {
@@ -1654,6 +1658,7 @@ const G8_MODULE_MIN_SPEAKING_SEC: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [],
+  appliesTo: ["structured", "exam"],
 };
 
 const G8_MODULE_CUE_CARD_POOL: JourneySettingContract = {
@@ -1675,6 +1680,7 @@ const G8_MODULE_CUE_CARD_POOL: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "instructions", hint: "cue card content" }],
+  appliesTo: ["exam"],
 };
 
 const G8_MODULE_CLOSING_LINE: JourneySettingContract = {
@@ -1696,6 +1702,7 @@ const G8_MODULE_CLOSING_LINE: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "offboarding", hint: "closing line" }],
+  appliesTo: ["structured", "exam"],
 };
 
 const G8_MODULE_FIRST_TIME_ORIENTATION_LINE: JourneySettingContract = {
@@ -1717,6 +1724,7 @@ const G8_MODULE_FIRST_TIME_ORIENTATION_LINE: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "onboarding", hint: "orientation line" }],
+  appliesTo: ["exam"],
 };
 
 const G8_MODULE_SCHEDULED_CUES: JourneySettingContract = {
@@ -1738,6 +1746,7 @@ const G8_MODULE_SCHEDULED_CUES: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [],
+  appliesTo: ["exam"],
 };
 
 // #1743 (epic #1700 Theme 2b — Theme 1 extension) — module-scoped pool
@@ -1764,6 +1773,7 @@ const G8_MODULE_SCAFFOLD_POOL: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [],
+  appliesTo: ["structured", "exam"],
 };
 
 // #1704 Theme 10 — generic profile capture. EXTRACT walks this list and
@@ -1790,6 +1800,7 @@ const G8_MODULE_PROFILE_FIELDS_TO_CAPTURE: JourneySettingContract = {
     requiresReprompt: false,
   },
   previewLocators: [{ section: "instructions", hint: "profile capture prompts" }],
+  appliesTo: ["structured", "exam"],
 };
 
 // =============================================================

--- a/apps/admin/lib/journey/setting-contracts.ts
+++ b/apps/admin/lib/journey/setting-contracts.ts
@@ -47,6 +47,28 @@ import type { JourneyGroup } from "./setting-groups";
 type SettingsGroupKey = "S1_voice" | "S2_integration" | "S3_demo" | "S4_access";
 
 // =============================================================
+// CourseShape — the shape envelope a setting applies to
+// =============================================================
+
+/** The course shapes a setting can be tagged against. Distinct from the
+ *  runtime `CourseStyle` (`lib/pipeline/course-style.ts`) which only
+ *  resolves `"structured" | "continuous"` from `PlaybookConfig.lessonPlanMode`.
+ *
+ *  `appliesTo` is the *editor-facing* envelope: it tells the Inspector
+ *  whether to render a setting at all for a given course. The runtime
+ *  course-style resolver is unchanged — exam courses still resolve to
+ *  their pipeline-relevant shape via the existing helper. This field is
+ *  about UX visibility, not runtime behaviour.
+ *
+ *  Continuous courses don't have AuthoredModules; module-scoped and
+ *  module-sequence settings declare `["structured"]` so the editor hides
+ *  them when an operator opens a continuous course. IELTS-specific
+ *  settings (cue cards, scheduled cues, first-time orientation) declare
+ *  `["exam"]` only.
+ */
+export type CourseShape = "structured" | "continuous" | "exam";
+
+// =============================================================
 // StoragePath — where a setting binds in the DB
 // =============================================================
 
@@ -292,6 +314,21 @@ export interface JourneySettingContract {
    *  contract id resolves through `skillScoringEmaHalfLifeDays` knob).
    *  `isResolvableKnob(cascadeKnobKey)` is the runtime gate. */
   cascadeKnobKey?: string;
+
+  /** Phase 0 of Journey-Design tab refactor — course shapes this setting
+   *  affects. Omit (undefined) → applies to all shapes (default).
+   *
+   *  Continuous courses don't have AuthoredModules; module-scoped +
+   *  module-sequence settings declare `["structured"]`. IELTS-specific
+   *  settings (cue-card pool, scheduled cues, first-time orientation
+   *  line) declare `["exam"]` only.
+   *
+   *  The `RelevanceWrapper` reads this field to render the
+   *  `"out-of-shape"` overlay when the course's resolved shape is not
+   *  in the array. The `registry-schema-coverage` vitest pins coverage —
+   *  every entry must either declare `appliesTo` or be on the
+   *  `APPLIES_TO_ALL` allow-list. */
+  appliesTo?: readonly CourseShape[];
 }
 
 // Re-export for sibling registries (Settings tab Voice subset).

--- a/apps/admin/lib/journey/setting-contracts.ts
+++ b/apps/admin/lib/journey/setting-contracts.ts
@@ -329,6 +329,33 @@ export interface JourneySettingContract {
    *  every entry must either declare `appliesTo` or be on the
    *  `APPLIES_TO_ALL` allow-list. */
   appliesTo?: readonly CourseShape[];
+
+  /** Phase 0 of Journey-Design tab refactor — explicit parent-setting
+   *  gates. When the parent is in the listed `inactiveValues`, this
+   *  control is structurally rendered as `gated-off` in the Inspector.
+   *
+   *  Distinct from `autoEnableLinks`:
+   *  - `autoEnableLinks` is the WRITE-side discipline (server forces a
+   *    child value when a parent has a specific value).
+   *  - `gatedBy` is the READ-side discipline (Inspector grays out the
+   *    child control entirely when the parent says "off-equivalent").
+   *
+   *  Most gating relationships are derivable from `autoEnableLinks` but
+   *  some (e.g. progressNarrativeCadence depending on
+   *  progressNarrativeEnabled) don't model as auto-enables and benefit
+   *  from explicit declaration here.
+   *
+   *  `isGatedBy()` in `lib/journey/is-gated-by.ts` reads this field
+   *  (and falls back to autoEnableLinks-derivation) to decide whether
+   *  to wrap the control in a `<RelevanceWrapper state="gated-off">`. */
+  gatedBy?: {
+    /** Contract id of the parent that gates this one. */
+    parentId: string;
+    /** Parent values that make this control irrelevant. The Inspector
+     *  renders the child as `gated-off` when the parent's effective
+     *  value is in this set. */
+    inactiveValues: readonly unknown[];
+  };
 }
 
 // Re-export for sibling registries (Settings tab Voice subset).

--- a/apps/admin/lib/settings/voice-setting-contracts.ts
+++ b/apps/admin/lib/settings/voice-setting-contracts.ts
@@ -29,6 +29,7 @@ export type {
   ComposeImpact,
   ComposeImpactKind,
   ControlType,
+  CourseShape,
   JourneySettingContract,
   PreviewLocator,
   StoragePath,

--- a/apps/admin/tests/components/journey-controls/relevance-wrapper.test.tsx
+++ b/apps/admin/tests/components/journey-controls/relevance-wrapper.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * RelevanceWrapper — Phase 0 of the Journey-Design tab refactor.
+ *
+ * Pins all 5 mutually-exclusive relevance states with a representative
+ * fixture each. Failures here surface as overlay-rendering regressions
+ * in the Journey-Design Inspector.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RelevanceWrapper } from "@/components/journey-controls/RelevanceWrapper";
+
+describe("RelevanceWrapper", () => {
+  it("active state renders children bare (no wrapper, no chip)", () => {
+    const { container } = render(
+      <RelevanceWrapper state="active">
+        <input data-testid="inner" placeholder="active-control" />
+      </RelevanceWrapper>,
+    );
+    // No outer hf-relevance-wrap class.
+    expect(container.querySelector(".hf-relevance-wrap")).toBeNull();
+    // Children remain intact.
+    expect(screen.getByTestId("inner")).toBeTruthy();
+    // No chip rendered.
+    expect(container.querySelector(".hf-relevance-chip")).toBeNull();
+  });
+
+  it("inherited state renders a layer-origin chip + children", () => {
+    const { container } = render(
+      <RelevanceWrapper state="inherited" layerOrigin="Domain">
+        <input data-testid="inner" />
+      </RelevanceWrapper>,
+    );
+    const wrap = container.querySelector(".hf-relevance-wrap--inherited");
+    expect(wrap).toBeTruthy();
+    expect(wrap?.getAttribute("data-state")).toBe("inherited");
+    expect(screen.getByText(/Inherited from Domain/)).toBeTruthy();
+    expect(screen.getByTestId("inner")).toBeTruthy();
+  });
+
+  it("auto-derived state shows reason + Decouple button that calls unlockAction", () => {
+    const unlock = vi.fn();
+    const { container } = render(
+      <RelevanceWrapper
+        state="auto-derived"
+        reason="Derived from skillTierMapping cascade"
+        unlockAction={unlock}
+      >
+        <input data-testid="inner" />
+      </RelevanceWrapper>,
+    );
+    expect(container.querySelector(".hf-relevance-wrap--auto-derived")).toBeTruthy();
+    expect(screen.getByText(/Derived from skillTierMapping cascade/)).toBeTruthy();
+    const decouple = screen.getByRole("button", { name: /Decouple/ });
+    fireEvent.click(decouple);
+    expect(unlock).toHaveBeenCalledTimes(1);
+    // Children rendered but muted.
+    expect(screen.getByTestId("inner")).toBeTruthy();
+    expect(container.querySelector(".hf-relevance-children--muted")).toBeTruthy();
+  });
+
+  it("gated-off state shows parent label + chip click calls onJumpToParent", () => {
+    const jump = vi.fn();
+    const { container } = render(
+      <RelevanceWrapper
+        state="gated-off"
+        parentSettingId="npsEnabled"
+        parentSettingLabel="NPS enabled"
+        onJumpToParent={jump}
+      >
+        <input data-testid="inner" />
+      </RelevanceWrapper>,
+    );
+    expect(container.querySelector(".hf-relevance-wrap--gated-off")).toBeTruthy();
+    const chip = screen.getByRole("button", { name: /NPS enabled/ });
+    expect(chip.textContent).toMatch(/Enable NPS enabled first/);
+    fireEvent.click(chip);
+    expect(jump).toHaveBeenCalledWith("npsEnabled");
+    expect(container.querySelector(".hf-relevance-children--muted")).toBeTruthy();
+  });
+
+  it("out-of-shape state shows reason chip + muted children", () => {
+    const { container } = render(
+      <RelevanceWrapper
+        state="out-of-shape"
+        reason="Continuous courses don't use modules"
+      >
+        <input data-testid="inner" />
+      </RelevanceWrapper>,
+    );
+    expect(container.querySelector(".hf-relevance-wrap--out-of-shape")).toBeTruthy();
+    expect(screen.getByText(/Continuous courses don't use modules/)).toBeTruthy();
+    expect(container.querySelector(".hf-relevance-children--muted")).toBeTruthy();
+    expect(screen.getByTestId("inner")).toBeTruthy();
+  });
+
+  it("gated-off without jump handler renders the chip as static (no button role)", () => {
+    const { container, queryByRole } = render(
+      <RelevanceWrapper state="gated-off" parentSettingLabel="Some parent">
+        <input />
+      </RelevanceWrapper>,
+    );
+    expect(container.querySelector(".hf-relevance-wrap--gated-off")).toBeTruthy();
+    expect(queryByRole("button")).toBeNull();
+  });
+});

--- a/apps/admin/tests/lib/journey/compute-relevance-state.test.ts
+++ b/apps/admin/tests/lib/journey/compute-relevance-state.test.ts
@@ -1,0 +1,278 @@
+/**
+ * computeRelevanceState — Phase 0 of the Journey-Design tab refactor.
+ *
+ * Pins the priority order:
+ *   out-of-shape > gated-off > auto-derived > inherited > active
+ *
+ * Fixtures cover each state plus priority interactions (out-of-shape
+ * shadowing gated-off, gated-off shadowing inherited, etc.).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type {
+  JourneySettingContract,
+  StoragePath,
+} from "@/lib/journey/setting-contracts";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+import {
+  computeRelevanceState,
+  type ComputeRelevanceStateArgs,
+} from "@/lib/journey/compute-relevance-state";
+
+function makeContract(overrides: Partial<JourneySettingContract> & {
+  id: string;
+  educatorLabel: string;
+  storagePath: StoragePath;
+}): JourneySettingContract {
+  return {
+    group: "G4",
+    control: "toggle",
+    cascadeSources: [],
+    composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+    previewLocators: [],
+    ...overrides,
+  };
+}
+
+const baseConfig = {} as PlaybookConfig;
+
+describe("computeRelevanceState", () => {
+  it("returns 'active' for a vanilla course-layer setting with no gates", () => {
+    const setting = makeContract({
+      id: "noGates",
+      educatorLabel: "Vanilla",
+      storagePath: "config.noGates",
+    });
+    const args: ComputeRelevanceStateArgs = {
+      setting,
+      playbookConfig: baseConfig,
+      courseShape: "structured",
+      effectiveValue: { layer: "course", value: true },
+      registry: [setting],
+    };
+    expect(computeRelevanceState(args)).toEqual({ state: "active" });
+  });
+
+  it("returns 'inherited' when effective value comes from Domain", () => {
+    const setting = makeContract({
+      id: "domainInherited",
+      educatorLabel: "Domain-inherited",
+      storagePath: "config.domainInherited",
+    });
+    const args: ComputeRelevanceStateArgs = {
+      setting,
+      playbookConfig: baseConfig,
+      courseShape: "structured",
+      effectiveValue: { layer: "domain", value: true },
+      registry: [setting],
+    };
+    expect(computeRelevanceState(args)).toEqual({
+      state: "inherited",
+      layerOrigin: "Domain",
+    });
+  });
+
+  it("returns 'inherited' from System default with the System label", () => {
+    const setting = makeContract({
+      id: "sys",
+      educatorLabel: "System",
+      storagePath: "config.sys",
+    });
+    const args: ComputeRelevanceStateArgs = {
+      setting,
+      playbookConfig: baseConfig,
+      courseShape: "structured",
+      effectiveValue: { layer: "system", value: true },
+      registry: [setting],
+    };
+    expect(computeRelevanceState(args)).toEqual({
+      state: "inherited",
+      layerOrigin: "System",
+    });
+  });
+
+  it("returns 'gated-off' when an explicit gatedBy parent is in inactiveValues", () => {
+    const parent = makeContract({
+      id: "parentToggle",
+      educatorLabel: "Parent",
+      storagePath: "config.parentToggle",
+    });
+    const child = makeContract({
+      id: "child",
+      educatorLabel: "Child",
+      storagePath: "config.child",
+      gatedBy: { parentId: "parentToggle", inactiveValues: [false] },
+    });
+    const config = { parentToggle: false } as unknown as PlaybookConfig;
+    const args: ComputeRelevanceStateArgs = {
+      setting: child,
+      playbookConfig: config,
+      courseShape: "structured",
+      effectiveValue: { layer: "course", value: true },
+      registry: [parent, child],
+    };
+    expect(computeRelevanceState(args)).toEqual({
+      state: "gated-off",
+      parentId: "parentToggle",
+      parentLabel: "Parent",
+    });
+  });
+
+  it("returns 'auto-derived' when a peer's autoEnableLink actively forces this setting", () => {
+    const parent = makeContract({
+      id: "parent",
+      educatorLabel: "Parent (Baseline)",
+      storagePath: "config.parent",
+      autoEnableLinks: [
+        {
+          targetId: "child",
+          whenValue: "baseline_assessment",
+          enforce: true,
+          decoupleAllowed: true,
+          reason: "Baseline mode auto-enables the pre-test stop.",
+        },
+      ],
+    });
+    const child = makeContract({
+      id: "child",
+      educatorLabel: "Pre-test stop",
+      storagePath: "config.child",
+    });
+    const config = {
+      parent: "baseline_assessment",
+      child: true,
+    } as unknown as PlaybookConfig;
+    const args: ComputeRelevanceStateArgs = {
+      setting: child,
+      playbookConfig: config,
+      courseShape: "structured",
+      effectiveValue: { layer: "course", value: true },
+      registry: [parent, child],
+    };
+    expect(computeRelevanceState(args)).toEqual({
+      state: "auto-derived",
+      parentId: "parent",
+      parentLabel: "Parent (Baseline)",
+      reason: "Baseline mode auto-enables the pre-test stop.",
+    });
+  });
+
+  it("returns 'out-of-shape' when current shape isn't in appliesTo (priority over gated-off)", () => {
+    const parent = makeContract({
+      id: "parent",
+      educatorLabel: "Parent",
+      storagePath: "config.parent",
+    });
+    const child = makeContract({
+      id: "child",
+      educatorLabel: "Module thing",
+      storagePath: "config.child",
+      appliesTo: ["structured"],
+      gatedBy: { parentId: "parent", inactiveValues: [false] },
+    });
+    // Even though the parent toggle IS off (would otherwise be
+    // gated-off), the course is continuous → out-of-shape wins.
+    const config = { parent: false } as unknown as PlaybookConfig;
+    const args: ComputeRelevanceStateArgs = {
+      setting: child,
+      playbookConfig: config,
+      courseShape: "continuous",
+      effectiveValue: { layer: "course", value: true },
+      registry: [parent, child],
+    };
+    const result = computeRelevanceState(args);
+    expect(result.state).toBe("out-of-shape");
+    expect(result.reason).toMatch(/Continuous courses don't use modules/);
+  });
+
+  it("out-of-shape returns a friendly reason for exam vs structured mismatch", () => {
+    const setting = makeContract({
+      id: "examOnly",
+      educatorLabel: "Exam-only setting",
+      storagePath: "config.examOnly",
+      appliesTo: ["exam"],
+    });
+    const args: ComputeRelevanceStateArgs = {
+      setting,
+      playbookConfig: baseConfig,
+      courseShape: "structured",
+      effectiveValue: { layer: "course", value: true },
+      registry: [setting],
+    };
+    const result = computeRelevanceState(args);
+    expect(result.state).toBe("out-of-shape");
+    expect(result.reason).toMatch(/Structured courses use a different setting/);
+  });
+
+  it("gated-off shadows inherited (Domain default doesn't matter when parent gates)", () => {
+    const parent = makeContract({
+      id: "parent",
+      educatorLabel: "Parent toggle",
+      storagePath: "config.parent",
+    });
+    const child = makeContract({
+      id: "child",
+      educatorLabel: "Child",
+      storagePath: "config.child",
+      gatedBy: { parentId: "parent", inactiveValues: [false] },
+    });
+    const config = { parent: false } as unknown as PlaybookConfig;
+    const args: ComputeRelevanceStateArgs = {
+      setting: child,
+      playbookConfig: config,
+      courseShape: "structured",
+      effectiveValue: { layer: "domain", value: true },
+      registry: [parent, child],
+    };
+    expect(computeRelevanceState(args).state).toBe("gated-off");
+  });
+
+  it("auto-derived shadows inherited (a Domain default doesn't matter when actively forced)", () => {
+    const parent = makeContract({
+      id: "parent",
+      educatorLabel: "Parent",
+      storagePath: "config.parent",
+      autoEnableLinks: [
+        {
+          targetId: "child",
+          whenValue: "force",
+          enforce: "forced-value",
+          decoupleAllowed: true,
+          reason: "Coupled.",
+        },
+      ],
+    });
+    const child = makeContract({
+      id: "child",
+      educatorLabel: "Child",
+      storagePath: "config.child",
+    });
+    const config = { parent: "force" } as unknown as PlaybookConfig;
+    const args: ComputeRelevanceStateArgs = {
+      setting: child,
+      playbookConfig: config,
+      courseShape: "structured",
+      effectiveValue: { layer: "domain", value: "irrelevant" },
+      registry: [parent, child],
+    };
+    expect(computeRelevanceState(args).state).toBe("auto-derived");
+  });
+
+  it("active for course-shape exam course with appliesTo including exam", () => {
+    const setting = makeContract({
+      id: "examOk",
+      educatorLabel: "Exam OK",
+      storagePath: "config.examOk",
+      appliesTo: ["exam", "structured"],
+    });
+    const args: ComputeRelevanceStateArgs = {
+      setting,
+      playbookConfig: baseConfig,
+      courseShape: "exam",
+      effectiveValue: { layer: "course", value: 1 },
+      registry: [setting],
+    };
+    expect(computeRelevanceState(args).state).toBe("active");
+  });
+});

--- a/apps/admin/tests/lib/journey/is-gated-by.test.ts
+++ b/apps/admin/tests/lib/journey/is-gated-by.test.ts
@@ -1,0 +1,215 @@
+/**
+ * isGatedBy — Phase 0 of the Journey-Design tab refactor.
+ *
+ * Pins the gating-resolution discipline with fixtures for each case
+ * the helper must handle:
+ *
+ *   - Explicit `gatedBy` declared, parent value is in inactiveValues → gated
+ *   - Explicit `gatedBy` declared, parent value NOT in inactiveValues → not gated
+ *   - Derived from autoEnableLinks (peer enforces noop on this setting)
+ *   - Setting with no gatedBy + no peer autoEnableLinks → null
+ *   - Setting with gatedBy pointing at a non-existent parent id → null
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type {
+  JourneySettingContract,
+  StoragePath,
+} from "@/lib/journey/setting-contracts";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { isGatedBy } from "@/lib/journey/is-gated-by";
+
+/** Minimal test-contract factory. Most JourneySettingContract fields
+ *  are irrelevant to this helper; we fill in just enough to satisfy
+ *  the type. */
+function makeContract(overrides: {
+  id: string;
+  educatorLabel: string;
+  storagePath: StoragePath;
+  autoEnableLinks?: JourneySettingContract["autoEnableLinks"];
+  gatedBy?: JourneySettingContract["gatedBy"];
+}): JourneySettingContract {
+  return {
+    id: overrides.id,
+    group: "G4",
+    educatorLabel: overrides.educatorLabel,
+    storagePath: overrides.storagePath,
+    control: "toggle",
+    cascadeSources: [],
+    composeImpact: { sections: [], kinds: [], requiresReprompt: false },
+    previewLocators: [],
+    autoEnableLinks: overrides.autoEnableLinks,
+    gatedBy: overrides.gatedBy,
+  };
+}
+
+describe("isGatedBy", () => {
+  it("progressNarrativeCadence is gated when progressNarrativeEnabled = false", () => {
+    const enabled = makeContract({
+      id: "progressNarrativeEnabled",
+      educatorLabel: "Mid-call mastery acknowledgement",
+      storagePath: "config.progressNarrative.enabled",
+    });
+    const cadence = makeContract({
+      id: "progressNarrativeCadence",
+      educatorLabel: "Mid-call cadence",
+      storagePath: "config.progressNarrative.cadence",
+      gatedBy: { parentId: "progressNarrativeEnabled", inactiveValues: [false] },
+    });
+    const config: PlaybookConfig = {
+      progressNarrative: { enabled: false, cadence: "every_call" },
+    } as unknown as PlaybookConfig;
+
+    const result = isGatedBy(cadence, config, [enabled, cadence]);
+    expect(result).toEqual({
+      parentId: "progressNarrativeEnabled",
+      parentLabel: "Mid-call mastery acknowledgement",
+    });
+  });
+
+  it("progressNarrativeCadence is NOT gated when progressNarrativeEnabled = true", () => {
+    const enabled = makeContract({
+      id: "progressNarrativeEnabled",
+      educatorLabel: "Mid-call mastery acknowledgement",
+      storagePath: "config.progressNarrative.enabled",
+    });
+    const cadence = makeContract({
+      id: "progressNarrativeCadence",
+      educatorLabel: "Mid-call cadence",
+      storagePath: "config.progressNarrative.cadence",
+      gatedBy: { parentId: "progressNarrativeEnabled", inactiveValues: [false] },
+    });
+    const config: PlaybookConfig = {
+      progressNarrative: { enabled: true, cadence: "every_call" },
+    } as unknown as PlaybookConfig;
+
+    expect(isGatedBy(cadence, config, [enabled, cadence])).toBeNull();
+  });
+
+  it("npsThreshold is NOT gated when npsTrigger = 'score_drop'", () => {
+    const trigger = makeContract({
+      id: "npsTrigger",
+      educatorLabel: "NPS trigger",
+      storagePath: "config.nps.trigger",
+    });
+    const threshold = makeContract({
+      id: "npsThreshold",
+      educatorLabel: "NPS threshold",
+      storagePath: "config.nps.threshold",
+      gatedBy: { parentId: "npsTrigger", inactiveValues: ["always"] },
+    });
+    const config: PlaybookConfig = {
+      nps: { trigger: "score_drop", threshold: 4 },
+    } as unknown as PlaybookConfig;
+
+    expect(isGatedBy(threshold, config, [trigger, threshold])).toBeNull();
+  });
+
+  it("npsThreshold IS gated when npsTrigger = 'always' (threshold has no meaning)", () => {
+    const trigger = makeContract({
+      id: "npsTrigger",
+      educatorLabel: "NPS trigger",
+      storagePath: "config.nps.trigger",
+    });
+    const threshold = makeContract({
+      id: "npsThreshold",
+      educatorLabel: "NPS threshold",
+      storagePath: "config.nps.threshold",
+      gatedBy: { parentId: "npsTrigger", inactiveValues: ["always"] },
+    });
+    const config: PlaybookConfig = {
+      nps: { trigger: "always", threshold: 4 },
+    } as unknown as PlaybookConfig;
+
+    expect(isGatedBy(threshold, config, [trigger, threshold])).toEqual({
+      parentId: "npsTrigger",
+      parentLabel: "NPS trigger",
+    });
+  });
+
+  it("a setting with no gatedBy AND no peer autoEnableLinks returns null", () => {
+    const standalone = makeContract({
+      id: "standaloneToggle",
+      educatorLabel: "Standalone toggle",
+      storagePath: "config.standaloneToggle",
+    });
+    const config: PlaybookConfig = {} as PlaybookConfig;
+
+    expect(isGatedBy(standalone, config, [standalone])).toBeNull();
+  });
+
+  it("gatedBy pointing at a non-existent parent id returns null", () => {
+    const orphan = makeContract({
+      id: "orphan",
+      educatorLabel: "Orphan",
+      storagePath: "config.orphan",
+      gatedBy: { parentId: "nonExistentParent", inactiveValues: [false] },
+    });
+    const config: PlaybookConfig = {} as PlaybookConfig;
+
+    expect(isGatedBy(orphan, config, [orphan])).toBeNull();
+  });
+
+  it("derives gating from a peer's autoEnableLinks when enforce is a noop value (false)", () => {
+    // Parent has an autoEnableLink that forces target to `false` (the
+    // toggle's off state) when parent value === "off-equivalent".
+    const parent = makeContract({
+      id: "parent",
+      educatorLabel: "Parent toggle",
+      storagePath: "config.parent",
+      autoEnableLinks: [
+        {
+          targetId: "child",
+          whenValue: false,
+          enforce: false,
+          decoupleAllowed: false,
+          reason: "When parent is off, child has no meaning.",
+        },
+      ],
+    });
+    const child = makeContract({
+      id: "child",
+      educatorLabel: "Child toggle",
+      storagePath: "config.child",
+    });
+    const config: PlaybookConfig = {
+      parent: false,
+      child: true,
+    } as unknown as PlaybookConfig;
+
+    expect(isGatedBy(child, config, [parent, child])).toEqual({
+      parentId: "parent",
+      parentLabel: "Parent toggle",
+    });
+  });
+
+  it("does NOT derive gating from autoEnableLinks when enforce is a non-noop value (true)", () => {
+    // Parent forces child to TRUE — that's auto-enable, not gating.
+    const parent = makeContract({
+      id: "parent",
+      educatorLabel: "Parent",
+      storagePath: "config.parent",
+      autoEnableLinks: [
+        {
+          targetId: "child",
+          whenValue: "enabling",
+          enforce: true,
+          decoupleAllowed: true,
+          reason: "Parent enables child when in 'enabling' mode.",
+        },
+      ],
+    });
+    const child = makeContract({
+      id: "child",
+      educatorLabel: "Child",
+      storagePath: "config.child",
+    });
+    const config: PlaybookConfig = {
+      parent: "enabling",
+      child: true,
+    } as unknown as PlaybookConfig;
+
+    expect(isGatedBy(child, config, [parent, child])).toBeNull();
+  });
+});

--- a/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Registry ↔ schema appliesTo coverage — Phase 0 of the Journey-Design
+ * tab refactor.
+ *
+ * **What this test pins:**
+ *  Every entry in `JOURNEY_SETTINGS` either:
+ *    (a) declares `appliesTo: readonly CourseShape[]` — meaning it has
+ *        been deliberately scoped to a subset of course shapes
+ *        (e.g. module-scoped settings → `["structured", "exam"]`,
+ *        IELTS-specific settings → `["exam"]`), OR
+ *    (b) is listed in `APPLIES_TO_ALL` — meaning the author has
+ *        confirmed the setting applies to every course shape
+ *        (structured + continuous + exam) by default.
+ *
+ *  Coverage is exhaustive. A new entry that doesn't appear in either
+ *  bucket fails CI immediately — author MUST think about its shape
+ *  envelope before merge.
+ *
+ * **Why this exists:**
+ *  Phase 0 of the Journey-Design tab refactor adds the
+ *  `appliesTo?: readonly CourseShape[]` field. Default-undefined means
+ *  "applies to all shapes" — useful, but silent. Without this test,
+ *  adding a new module-scoped setting and forgetting to tag it would
+ *  silently render the control on continuous courses (where there
+ *  are no AuthoredModules) and silently hide it from exam courses.
+ *
+ *  Same shape as `tests/lib/journey/registry-schema-coverage.test.ts`
+ *  (the referenced 5th-pillar test) applied to the new `appliesTo`
+ *  field rather than `storagePath` ↔ `PlaybookConfig` field coverage.
+ *
+ * **How to fix a failure:**
+ *  - "Entry has no appliesTo and is not in APPLIES_TO_ALL":
+ *    Either tag the entry with `appliesTo: [...]` in
+ *    `setting-contracts.entries.ts`, or add its id to `APPLIES_TO_ALL`
+ *    below with a comment indicating you reviewed the shape envelope.
+ *    When in doubt, prefer `APPLIES_TO_ALL` (default = all shapes).
+ *  - "Entry appears in APPLIES_TO_ALL AND declares appliesTo":
+ *    Drift — pick one. Tagging is more expressive; the allow-list is
+ *    the explicit-default path.
+ *  - "APPLIES_TO_ALL entry no longer exists in JOURNEY_SETTINGS":
+ *    A contract was removed. Delete the id from APPLIES_TO_ALL.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
+import { VOICE_SETTINGS } from "@/lib/settings/voice-setting-contracts";
+
+/** Allow-list of journey + voice contract ids that apply to every
+ *  course shape (structured + continuous + exam) by default. Adding
+ *  an id here is a deliberate "yes, this affects every course shape"
+ *  declaration — equivalent to omitting `appliesTo` but tracked here
+ *  for discoverability.
+ *
+ *  Authoring discipline: when adding a new contract, default to this
+ *  allow-list unless you have a concrete reason to scope it. Tagging
+ *  incorrectly is worse than not tagging — an over-tagged entry
+ *  silently disappears from courses it should affect.
+ *
+ *  Maintenance: when a contract is removed from
+ *  `JOURNEY_SETTINGS` / `VOICE_SETTINGS`, delete the id here too.
+ *  The "stale allow-list" assertion below catches drift. */
+const APPLIES_TO_ALL: readonly string[] = [
+  // ── A_intake (5 of 7 — intakeKnowledgeCheck variants apply to every shape)
+  "intakeSpecId",
+  "intakeKnowledgeCheck",
+  "intakeAboutYou",
+  "intakeGoals",
+  "intakeAiIntroCall",
+  "intakeKnowledgeCheckMode",
+  "intakeSkipIfReturning",
+
+  // ── B_call1_opening (9 of 10 — firstCallModuleVisibility is structured-only)
+  "firstCallMode",
+  "welcomeMessage",
+  "firstCallCourseIntro",
+  "firstCallWaitForAck",
+  "firstCallDurationOverride",
+  "firstCallIntroducePedagogy",
+  "onboardingFlowPhases",
+  "firstCallTargets",
+  "preTestStop",
+  "baselineAssessmentDepth",
+
+  // ── C_teaching_style + module-sequence siblings
+  "teachingStyle",
+  // moduleSequencePolicy is structured-only — NOT in this list.
+  "firstCallCurriculumFocus",
+  "openingRecapEnabled",
+
+  // ── D_question_flow + tolerance + skills (G4 — applies broadly)
+  "modePolicy",
+  "shareMaterials",
+  "toleranceAccuracy",
+  "toleranceFluency",
+  "toleranceConfidence",
+  "toleranceEngagement",
+  "tierPresetId",
+  "skillMinCallsToFull",
+  "skillTierMapping",
+  "skillScoringEmaHalfLife",
+  "maxMasteryTier",
+  "useFreshMastery",
+  "scoringMode",
+  "progressNarrativeEnabled",
+  "progressNarrativeCadence",
+  "progressNarrativeThreshold",
+  "progressNarrativeSkipFirstCall",
+  "priorCallRecapEnabled",
+  "priorCallRecapDepth",
+  "priorCallRecapDailyCap",
+  "recapEnabled",
+  "recapSynthesisEnabled",
+  "priorCallFeedbackEnabled",
+  "agentTunerNlpEnabled",
+  "progressSignalLowWater",
+  "progressSignalHighWater",
+  "interruptSensitivity",
+
+  // ── G5 — mid-journey + NPS (applies to every shape)
+  "midJourneyStop",
+  "npsEnabled",
+  "npsTrigger",
+  "npsThreshold",
+  "npsStop",
+
+  // ── G6 — offboarding
+  "offboardingFlowPhases",
+  "offboardingSummaryEnabled",
+  "offboardingSummaryCadence",
+  "offboardingSummaryIncludeModuleMastery",
+  "offboardingSummaryIncludeGoalProgress",
+  "offboardingSummaryIncludeSkillScore",
+  "offboardingTriggerAfterCalls",
+  "offboardingBannerMessage",
+  "offboardingCertificate",
+  "postTestStop",
+
+  // ── G7 — tolerance + completion + sequencing
+  "tolMasteryThreshold",
+  "tolRetrievalCadence",
+  "tolMemoryDecay",
+  "tolCarryForwardBoost",
+  // firstCallModuleVisibility is structured-only — NOT in this list.
+  "completionMode",
+  // strictPrerequisites is structured-only — NOT in this list.
+  "loMasteryThreshold",
+  "interleaveReviewMinDays",
+  "callCountPolicy",
+  "maxCallsPerDay",
+  "assessmentReadinessThreshold",
+  "rewardStrategy",
+  "talkTimeBudgets",
+
+  // ── G8 — module-scoped IELTS settings are ALL deliberately tagged
+  //   (`appliesTo: ["structured", "exam"]` or `["exam"]`) so none of
+  //   them belong on this allow-list. Their absence is intentional.
+
+  // ── N_voice (Settings tab voice subset — 11 entries; all global)
+  "voiceProvider",
+  "voiceId",
+  "backgroundSound",
+  // interruptSensitivity duplicates the journey entry above — same id
+  // is intentional (cross-registry mirror). The completeness vitest
+  // pins this. Listing once is sufficient.
+  "voiceSpeed",
+  "voicePitch",
+  "silenceThreshold",
+  "endCallAfterSilence",
+  "maxCallDuration",
+  "phoneNumber",
+  "vapiAssistantId",
+];
+
+const APPLIES_TO_ALL_SET = new Set(APPLIES_TO_ALL);
+
+/** All contracts spanning both registries. The journey registry holds
+ *  85 entries; the voice registry holds 11 entries; they share
+ *  `interruptSensitivity` by id so the unified set is smaller than
+ *  the raw sum. */
+const ALL_CONTRACTS = [...JOURNEY_SETTINGS, ...VOICE_SETTINGS];
+
+describe("registry ↔ schema appliesTo coverage", () => {
+  it("every contract either declares appliesTo OR is in APPLIES_TO_ALL", () => {
+    const missing: string[] = [];
+    for (const contract of ALL_CONTRACTS) {
+      const hasTag = contract.appliesTo !== undefined;
+      const inAllowlist = APPLIES_TO_ALL_SET.has(contract.id);
+      if (!hasTag && !inAllowlist) {
+        missing.push(contract.id);
+      }
+    }
+    if (missing.length > 0) {
+      // De-duplicate (cross-registry mirrors like interruptSensitivity).
+      const deduped = Array.from(new Set(missing));
+      throw new Error(
+        `${deduped.length} contract(s) lack appliesTo AND are not in APPLIES_TO_ALL.\n` +
+          `Add to APPLIES_TO_ALL (preferred default) or tag with appliesTo:\n` +
+          deduped.map((id) => `  - ${id}`).join("\n"),
+      );
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("no contract is in APPLIES_TO_ALL AND declares appliesTo", () => {
+    const drift: string[] = [];
+    for (const contract of ALL_CONTRACTS) {
+      if (
+        contract.appliesTo !== undefined &&
+        APPLIES_TO_ALL_SET.has(contract.id)
+      ) {
+        drift.push(contract.id);
+      }
+    }
+    if (drift.length > 0) {
+      const deduped = Array.from(new Set(drift));
+      throw new Error(
+        `${deduped.length} contract(s) are both tagged AND in APPLIES_TO_ALL — pick one:\n` +
+          deduped.map((id) => `  - ${id}`).join("\n"),
+      );
+    }
+    expect(drift).toEqual([]);
+  });
+
+  it("APPLIES_TO_ALL entries all exist in the registries (no stale ids)", () => {
+    const knownIds = new Set(ALL_CONTRACTS.map((c) => c.id));
+    const stale = APPLIES_TO_ALL.filter((id) => !knownIds.has(id));
+    if (stale.length > 0) {
+      throw new Error(
+        `${stale.length} APPLIES_TO_ALL id(s) no longer exist in JOURNEY_SETTINGS / VOICE_SETTINGS:\n` +
+          stale.map((id) => `  - ${id}`).join("\n") +
+          `\nRemove from APPLIES_TO_ALL.`,
+      );
+    }
+    expect(stale).toEqual([]);
+  });
+
+  it("APPLIES_TO_ALL entries have no duplicates", () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const id of APPLIES_TO_ALL) {
+      if (seen.has(id)) dupes.push(id);
+      seen.add(id);
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it("every `appliesTo` value uses only valid CourseShape literals", () => {
+    const validShapes = new Set(["structured", "continuous", "exam"]);
+    const invalid: { id: string; bad: string[] }[] = [];
+    for (const contract of ALL_CONTRACTS) {
+      if (contract.appliesTo === undefined) continue;
+      const bad = contract.appliesTo.filter((s) => !validShapes.has(s));
+      if (bad.length > 0) invalid.push({ id: contract.id, bad });
+    }
+    if (invalid.length > 0) {
+      throw new Error(
+        `${invalid.length} contract(s) declare invalid CourseShape values:\n` +
+          invalid
+            .map((e) => `  - ${e.id}: [${e.bad.join(", ")}]`)
+            .join("\n"),
+      );
+    }
+    expect(invalid).toEqual([]);
+  });
+
+  it("every `appliesTo` array is non-empty (avoids the never-renders trap)", () => {
+    const empty: string[] = [];
+    for (const contract of ALL_CONTRACTS) {
+      if (contract.appliesTo !== undefined && contract.appliesTo.length === 0) {
+        empty.push(contract.id);
+      }
+    }
+    if (empty.length > 0) {
+      throw new Error(
+        `${empty.length} contract(s) have an EMPTY appliesTo (means "renders for no shape" — almost certainly a bug):\n` +
+          empty.map((id) => `  - ${id}`).join("\n") +
+          `\nOmit the field for "all shapes", or list the shape(s) it applies to.`,
+      );
+    }
+    expect(empty).toEqual([]);
+  });
+});


### PR DESCRIPTION
Phase 0 of epic #1850 — the structural foundation for the bucket→tab split. Adds the contract field, helpers, and rendering primitive that every downstream phase depends on.

## Summary

- New `CourseShape = "structured" | "continuous" | "exam"` + optional `appliesTo` field on `JourneySettingContract`. Distinct from runtime `CourseStyle` (`lib/pipeline/course-style.ts`) which stays narrower.
- 11 entries tagged: 3 structured-only, 3 IELTS exam-only, 5 structured+exam. Remaining 85 in `APPLIES_TO_ALL` allow-list.
- New `tests/lib/journey/registry-schema-coverage.test.ts` — the file the 5th-pillar rule referenced but didn't exist. 6 vitests pin coverage exhaustively.
- `<RelevanceWrapper>` primitive at `components/journey-controls/RelevanceWrapper.tsx` with all 5 states (`active` / `inherited` / `auto-derived` / `gated-off` / `out-of-shape`).
- `isGatedBy` + `computeRelevanceState` helpers; strict priority `out-of-shape > gated-off > auto-derived > inherited > active`.
- 30 new vitests, all green. Foundation only — no tab additions; that's the sibling PR.

## Test plan

- [ ] tsc clean: pre-push reports 40 errors (baseline 41, -1)
- [ ] lint clean: no errors in changed files
- [ ] 30 new vitests + full 134/134 journey + journey-controls suite green
- [ ] Manual: load Course Detail page on hf-dev after merge — Journey tab unchanged (no UI surface in this PR)

## Verified by

- `apps/admin/lib/journey/setting-contracts.ts:48` — `CourseShape` type added
- `apps/admin/lib/journey/setting-contracts.ts` — `appliesTo` field on `JourneySettingContract`
- `apps/admin/tests/lib/journey/registry-schema-coverage.test.ts` — 6 vitests, run: `npx vitest run tests/lib/journey/registry-schema-coverage` [verified]
- `apps/admin/components/journey-controls/RelevanceWrapper.tsx` — 5 states; pinned at `tests/components/journey-controls/relevance-wrapper.test.tsx` (6 vitests) [verified]
- `apps/admin/lib/journey/is-gated-by.ts` + `tests/lib/journey/is-gated-by.test.ts` (8 vitests) [verified]
- `apps/admin/lib/journey/compute-relevance-state.ts` + test (10 vitests) [verified]
- Pre-push hook: tsc 40 errors (baseline 41, **-1**); lint clean [verified]
- No migrations; no schema change; no public-API removal

## Lattice survey

Class A (structural). Pillar: **Coverage (5th)**. The new `registry-schema-coverage.test.ts` extends the Lattice coverage pillar to the `appliesTo` axis. No cross-stage boundary crossing; no AI write/read path; no shared-column mutation. Sibling-writer survey: zero existing readers of `JourneySettingContract.appliesTo` (field is new). Sibling-writer of the registry itself: only `voice-setting-contracts.ts` (covered by the coverage test).

Closes part of #1850 (P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)