### PR TITLE
feat(course-detail): Teaching, Scoring, Modules tab shells (#1850)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 41,
+  "tsc_errors": 36,
   "lint_errors": 0,
   "lint_warnings": 4454,
   "quarantined_tests": 36,

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -9,7 +9,7 @@ import {
   Settings as SettingsIcon, Users2,
   Zap, Target, BarChart3,
   PlayCircle, Copy, Link2, GraduationCap, Wand2, FileSearch,
-  Mic, Award,
+  Mic, Award, Sliders, Layers, Calculator,
 } from 'lucide-react';
 import { CourseSkillsTab } from './CourseSkillsTab';
 import { SettingsTabVoiceLens } from '@/components/journey-tab/SettingsTabVoiceLens';
@@ -26,6 +26,9 @@ import { CourseWhoTab } from './CourseWhoTab';
 import { CourseGoalsTab } from './CourseGoalsTab';
 import { CourseDesignTab } from './CourseDesignTab';
 import { CourseJourneyTab } from '@/components/journey-tab/CourseJourneyTab';
+import { CourseTeachingTab } from '@/components/teaching-tab/CourseTeachingTab';
+import { CourseScoringTab } from '@/components/scoring-tab/CourseScoringTab';
+import { CourseModulesTab } from '@/components/modules-tab/CourseModulesTab';
 import { CourseLearnersTab } from './CourseLearnersTab';
 import { CourseProofTab } from './CourseProofTab';
 import { SessionDetailPanel } from '@/components/shared/SessionDetailPanel';
@@ -151,7 +154,7 @@ type SessionTabData = {
 
 import { SectionHeader } from './SectionHeader';
 
-const VALID_TABS = ['journey', 'intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'skills', 'voice', 'settings',
+const VALID_TABS = ['journey', 'teaching', 'scoring', 'modules', 'intelligence', 'design', 'curriculum', 'content', 'learners', 'proof', 'goals', 'skills', 'voice', 'settings',
   // Legacy tab IDs — redirected in handleTabChange
   'overview', 'genome', 'audience', 'session-flow',
 ];
@@ -408,6 +411,10 @@ export default function CourseDetailPage() {
     // landing surface. Design tab kept with amber retirement chip until
     // Journey reaches parity (Phase 2 Slice B / Phase 3 Slice B + #1695).
     { id: 'journey', label: <TabWithHelp tabId="journey">Journey</TabWithHelp>, icon: <Wand2 size={14} /> },
+    // Track C P0 — new Course Detail tab shells, BUCKETS_BY_TAB-driven LH.
+    { id: 'teaching', label: <TabWithHelp tabId="teaching">Teaching</TabWithHelp>, icon: <Sliders size={14} /> },
+    { id: 'scoring', label: <TabWithHelp tabId="scoring">Scoring</TabWithHelp>, icon: <Calculator size={14} /> },
+    { id: 'modules', label: <TabWithHelp tabId="modules">Modules</TabWithHelp>, icon: <Layers size={14} /> },
     { id: 'intelligence', label: <TabWithHelp tabId="intelligence">Content</TabWithHelp>, icon: <BookMarked size={14} />, count: totalSources || null },
     {
       id: 'design',
@@ -1728,6 +1735,35 @@ export default function CourseDetailPage() {
         <CourseJourneyTab
           courseId={courseId!}
           playbookConfig={detail?.config as Record<string, unknown> | null}
+        />
+      )}
+
+      {/* ═══════════════════════════════════════════════ */}
+      {/* TEACHING / SCORING / MODULES (Track C P0)      */}
+      {/* ═══════════════════════════════════════════════ */}
+      {activeTab === 'teaching' && (
+        <CourseTeachingTab
+          courseId={courseId!}
+          playbookConfig={detail?.config as Record<string, unknown> | null}
+        />
+      )}
+
+      {activeTab === 'scoring' && (
+        <CourseScoringTab
+          courseId={courseId!}
+          playbookConfig={detail?.config as Record<string, unknown> | null}
+        />
+      )}
+
+      {activeTab === 'modules' && (
+        <CourseModulesTab
+          courseId={courseId!}
+          courseStyle={
+            (detail?.config as { lessonPlanMode?: string } | null | undefined)
+              ?.lessonPlanMode === 'structured'
+              ? 'structured'
+              : 'continuous'
+          }
         />
       )}
 

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * CourseModulesTab — Track C P0 shell of the Journey-Design tab refactor.
+ *
+ * Modules-tab does NOT use bucket-filtered nav like Teaching / Scoring /
+ * Journey — its scope is per-AuthoredModule (G8). The LH is a module
+ * picker; the Inspector eventually hosts module-scoped settings.
+ *
+ * Continuous-course empty state: continuous courses have no authored
+ * modules — they pull from a topic pool. We render an explanation
+ * rather than an empty picker.
+ */
+
+import { useState } from "react";
+
+import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+
+import { ModulesLhPicker } from "./ModulesLhPicker";
+
+interface CourseModulesTabProps {
+  courseId: string;
+  /** From `PlaybookConfig.lessonPlanMode`. `"continuous"` (or missing) →
+   *  modules don't apply; we show the empty state instead of the picker. */
+  courseStyle?: string;
+}
+
+export function CourseModulesTab({
+  courseId,
+  courseStyle,
+}: CourseModulesTabProps) {
+  const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
+
+  if (courseStyle === "continuous") {
+    return (
+      <div className="hf-empty">
+        <h2 className="hf-section-title">No modules</h2>
+        <p className="hf-section-desc">
+          Continuous courses don&apos;t have authored modules. Modules are how
+          structured courses organise content; continuous courses pull from a
+          topic pool instead.{" "}
+          <a href="/x/help/glossary#course-style" className="hf-link">
+            Learn more
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <DesignerShell
+      nav={
+        <ModulesLhPicker
+          courseId={courseId}
+          selectedModuleId={selectedModuleId}
+          onSelect={setSelectedModuleId}
+        />
+      }
+      // TODO(preview-scope): extend PreviewLens to accept ?moduleId scope
+      // so the canvas can preview the module-scoped lesson when one is
+      // selected. For now we render the course-wide preview.
+      canvas={<PreviewLens courseId={courseId} suppressSidetray />}
+      inspector={
+        selectedModuleId ? (
+          // TODO(P1): replace placeholder with the per-module settings
+          // editor (G8 module-scoped knobs — cue cards, prep timers,
+          // completion gates).
+          <div className="hf-card hf-card-compact">
+            Module settings inspector — wires up post-P0. Selected module:{" "}
+            <code>{selectedModuleId}</code>.
+          </div>
+        ) : null
+      }
+    />
+  );
+}

--- a/apps/admin/components/modules-tab/ModulesLhPicker.tsx
+++ b/apps/admin/components/modules-tab/ModulesLhPicker.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/**
+ * ModulesLhPicker — LH module picker for the Modules tab.
+ *
+ * Fetches `/api/courses/[courseId]/sessions` for the modules array
+ * (the sessions route already returns modules). When a dedicated
+ * `/api/courses/[courseId]/modules` route lands, swap the fetch.
+ *
+ * Renders one row per AuthoredModule via `hf-list-row`. Click → setSelected.
+ *
+ * TODO(modules-route): replace the sessions piggyback with a dedicated
+ * `/api/courses/[courseId]/modules` route when one exists. The sessions
+ * route over-fetches (plan + studentProgress) for what's needed here.
+ */
+
+import { useEffect, useState } from "react";
+
+interface ModuleSummary {
+  id: string;
+  slug?: string;
+  title: string;
+  description?: string | null;
+  sortOrder?: number;
+  learningObjectiveCount?: number;
+}
+
+interface ModulesLhPickerProps {
+  courseId: string;
+  selectedModuleId: string | null;
+  onSelect: (id: string | null) => void;
+}
+
+export function ModulesLhPicker({
+  courseId,
+  selectedModuleId,
+  onSelect,
+}: ModulesLhPickerProps) {
+  const [modules, setModules] = useState<ModuleSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!courseId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/courses/${courseId}/sessions`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data?.ok && Array.isArray(data.modules)) {
+          setModules(data.modules as ModuleSummary[]);
+        } else {
+          setError(data?.error || "Failed to load modules");
+          setModules([]);
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Network error");
+        setModules([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  if (loading) {
+    return (
+      <div className="hf-journey-lh" data-testid="hf-modules-lh-picker">
+        <div className="hf-journey-lh-groups">
+          <div className="hf-card hf-card-compact">Loading modules…</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && (modules?.length ?? 0) === 0) {
+    return (
+      <div className="hf-journey-lh" data-testid="hf-modules-lh-picker">
+        <div className="hf-journey-lh-groups">
+          <div className="hf-banner hf-banner-error">
+            Could not load modules. {error}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!modules || modules.length === 0) {
+    return (
+      <div className="hf-journey-lh" data-testid="hf-modules-lh-picker">
+        <div className="hf-journey-lh-groups">
+          <div className="hf-empty">
+            <p className="hf-section-desc">
+              No authored modules yet. Add modules from the Curriculum tab.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hf-journey-lh" data-testid="hf-modules-lh-picker">
+      <div className="hf-journey-lh-groups">
+        {modules.map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            className={`hf-list-row ${
+              selectedModuleId === m.id ? "hf-selected" : ""
+            }`}
+            onClick={() => onSelect(m.id)}
+            data-testid={`hf-modules-row-${m.id}`}
+          >
+            <span className="hf-journey-bucket-label">{m.title}</span>
+            {typeof m.learningObjectiveCount === "number" ? (
+              <span className="hf-journey-bucket-count">
+                {m.learningObjectiveCount}
+              </span>
+            ) : null}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/scoring-tab/CourseScoringTab.tsx
+++ b/apps/admin/components/scoring-tab/CourseScoringTab.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * CourseScoringTab — Track C P0 shell of the Journey-Design tab refactor.
+ *
+ * Mounts the tri-pane DesignerShell with the 2 scoring buckets in the
+ * LH (I_scoring, K_between_calls).
+ *
+ * This is a SHELL — Inspector slot is a placeholder until P1 wires the
+ * actual `JourneyInspectorPanel` (or the per-tab variant TBD).
+ */
+
+import { useState } from "react";
+
+import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+
+import { ScoringLhMenu } from "./ScoringLhMenu";
+
+interface CourseScoringTabProps {
+  courseId: string;
+  playbookConfig?: Record<string, unknown> | null;
+}
+
+export function CourseScoringTab({
+  courseId,
+  playbookConfig,
+}: CourseScoringTabProps) {
+  const [selectedId, setSelectedId] = useState<JourneyMenuBucketId | null>(
+    null,
+  );
+
+  return (
+    <JourneySettingMutatorProvider
+      courseId={courseId}
+      playbookConfig={playbookConfig ?? null}
+    >
+      <DesignerShell
+        nav={
+          <ScoringLhMenu
+            courseId={courseId}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+          />
+        }
+        canvas={<PreviewLens courseId={courseId} suppressSidetray />}
+        inspector={
+          selectedId ? (
+            // TODO(P1): replace placeholder with the bucket-aware
+            // JourneyInspectorPanel (or a Scoring-tab variant). For
+            // now the panel just confirms the selection wired through.
+            <div className="hf-card hf-card-compact">
+              Inspector slot — wires up post-P0. Selected bucket:{" "}
+              <code>{selectedId}</code>.
+            </div>
+          ) : null
+        }
+      />
+    </JourneySettingMutatorProvider>
+  );
+}

--- a/apps/admin/components/scoring-tab/ScoringLhMenu.tsx
+++ b/apps/admin/components/scoring-tab/ScoringLhMenu.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * ScoringLhMenu — LH bucket nav for the Scoring tab.
+ *
+ * Filters JOURNEY_MENU_ITEMS by BUCKETS_BY_TAB.scoring.
+ * Sibling of TeachingLhMenu.
+ */
+
+import {
+  JOURNEY_MENU_ITEMS_BY_ID,
+} from "@/lib/journey/menu-items";
+import { getSettingsForBucket } from "@/lib/journey/bucket-relations";
+import { BUCKETS_BY_TAB } from "@/lib/journey/buckets-by-tab";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+
+interface ScoringLhMenuProps {
+  courseId: string;
+  selectedId: JourneyMenuBucketId | null;
+  onSelect: (id: JourneyMenuBucketId) => void;
+}
+
+export function ScoringLhMenu({
+  selectedId,
+  onSelect,
+}: ScoringLhMenuProps) {
+  const buckets = BUCKETS_BY_TAB.scoring.map(
+    (id) => JOURNEY_MENU_ITEMS_BY_ID[id],
+  );
+
+  return (
+    <div
+      className="hf-journey-lh"
+      data-testid="hf-scoring-lh-menu"
+    >
+      <div className="hf-journey-lh-groups">
+        <div className="hf-journey-group">
+          <div className="hf-journey-group-body">
+            {buckets.map((b) => {
+              const settings = getSettingsForBucket(b.id);
+              const settingsCount = settings.length;
+              const isEmpty = settingsCount === 0;
+              return (
+                <button
+                  key={b.id}
+                  type="button"
+                  className={`hf-journey-setting-row ${
+                    selectedId === b.id ? "hf-selected" : ""
+                  } ${isEmpty ? "hf-journey-bucket-empty" : ""}`}
+                  onClick={() => onSelect(b.id)}
+                  data-testid={`hf-scoring-bucket-row-${b.id}`}
+                  title={
+                    isEmpty && b.emptyReservation
+                      ? b.emptyReservation.note
+                      : undefined
+                  }
+                >
+                  <span className="hf-journey-bucket-label">
+                    {b.label}
+                    {isEmpty ? (
+                      <span className="hf-journey-bucket-empty-tag">
+                        {b.emptyReservation
+                          ? `T${b.emptyReservation.ieltsTheme}`
+                          : "soon"}
+                      </span>
+                    ) : null}
+                  </span>
+                  {!isEmpty ? (
+                    <span className="hf-journey-bucket-count">
+                      {settingsCount}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
+++ b/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * CourseTeachingTab — Track C P0 shell of the Journey-Design tab refactor.
+ *
+ * Mounts the tri-pane DesignerShell with the 4 teaching buckets in the
+ * LH (C_teaching_style, E_learner_visual, F_stall_recovery, J_feedback).
+ *
+ * This is a SHELL — Inspector slot is a placeholder until P1 wires the
+ * actual `JourneyInspectorPanel` (or the per-tab variant TBD). The canvas
+ * is the existing `<PreviewLens>` so educators see real prompt content
+ * underneath while we iterate on the menus.
+ */
+
+import { useState } from "react";
+
+import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
+import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+
+import { TeachingLhMenu } from "./TeachingLhMenu";
+
+interface CourseTeachingTabProps {
+  courseId: string;
+  playbookConfig?: Record<string, unknown> | null;
+}
+
+export function CourseTeachingTab({
+  courseId,
+  playbookConfig,
+}: CourseTeachingTabProps) {
+  const [selectedId, setSelectedId] = useState<JourneyMenuBucketId | null>(
+    null,
+  );
+
+  return (
+    <JourneySettingMutatorProvider
+      courseId={courseId}
+      playbookConfig={playbookConfig ?? null}
+    >
+      <DesignerShell
+        nav={
+          <TeachingLhMenu
+            courseId={courseId}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+          />
+        }
+        canvas={<PreviewLens courseId={courseId} suppressSidetray />}
+        inspector={
+          selectedId ? (
+            // TODO(P1): replace placeholder with the bucket-aware
+            // JourneyInspectorPanel (or a Teaching-tab variant). For
+            // now the panel just confirms the selection wired through.
+            <div className="hf-card hf-card-compact">
+              Inspector slot — wires up post-P0. Selected bucket:{" "}
+              <code>{selectedId}</code>.
+            </div>
+          ) : null
+        }
+      />
+    </JourneySettingMutatorProvider>
+  );
+}

--- a/apps/admin/components/teaching-tab/TeachingLhMenu.tsx
+++ b/apps/admin/components/teaching-tab/TeachingLhMenu.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+/**
+ * TeachingLhMenu — LH bucket nav for the Teaching tab.
+ *
+ * Filters JOURNEY_MENU_ITEMS by BUCKETS_BY_TAB.teaching and renders the
+ * resulting buckets as a flat list. No G1..G7 group headers — the
+ * teaching tab is a single bucket cohort, not a chronology.
+ *
+ * Mirrors `components/journey-tab/JourneyLhMenu.tsx` row structure
+ * (`hf-journey-setting-row`, `hf-journey-bucket-*`) so the visual
+ * language matches across tabs.
+ */
+
+import {
+  JOURNEY_MENU_ITEMS_BY_ID,
+} from "@/lib/journey/menu-items";
+import { getSettingsForBucket } from "@/lib/journey/bucket-relations";
+import { BUCKETS_BY_TAB } from "@/lib/journey/buckets-by-tab";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+
+interface TeachingLhMenuProps {
+  courseId: string;
+  selectedId: JourneyMenuBucketId | null;
+  onSelect: (id: JourneyMenuBucketId) => void;
+}
+
+export function TeachingLhMenu({
+  selectedId,
+  onSelect,
+}: TeachingLhMenuProps) {
+  const buckets = BUCKETS_BY_TAB.teaching.map(
+    (id) => JOURNEY_MENU_ITEMS_BY_ID[id],
+  );
+
+  return (
+    <div
+      className="hf-journey-lh"
+      data-testid="hf-teaching-lh-menu"
+    >
+      <div className="hf-journey-lh-groups">
+        <div className="hf-journey-group">
+          <div className="hf-journey-group-body">
+            {buckets.map((b) => {
+              const settings = getSettingsForBucket(b.id);
+              const settingsCount = settings.length;
+              const isEmpty = settingsCount === 0;
+              return (
+                <button
+                  key={b.id}
+                  type="button"
+                  className={`hf-journey-setting-row ${
+                    selectedId === b.id ? "hf-selected" : ""
+                  } ${isEmpty ? "hf-journey-bucket-empty" : ""}`}
+                  onClick={() => onSelect(b.id)}
+                  data-testid={`hf-teaching-bucket-row-${b.id}`}
+                  title={
+                    isEmpty && b.emptyReservation
+                      ? b.emptyReservation.note
+                      : undefined
+                  }
+                >
+                  <span className="hf-journey-bucket-label">
+                    {b.label}
+                    {isEmpty ? (
+                      <span className="hf-journey-bucket-empty-tag">
+                        {b.emptyReservation
+                          ? `T${b.emptyReservation.ieltsTheme}`
+                          : "soon"}
+                      </span>
+                    ) : null}
+                  </span>
+                  {!isEmpty ? (
+                    <span className="hf-journey-bucket-count">
+                      {settingsCount}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -127,6 +127,30 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
       "Everything about one course: the content that drives sessions, the design of the journey, the curriculum's module structure, the learners enrolled, the proof points teachers track, and the goals callers work toward.",
     tabs: [
       {
+        id: "teaching",
+        label: "Teaching",
+        about:
+          "How the tutor behaves on every call — style, visuals, stall handling, in-call feedback.",
+        whenToUse:
+          "When you want to retune how the AI tutor sounds and acts across every call (not just one moment).",
+      },
+      {
+        id: "scoring",
+        label: "Scoring",
+        about:
+          "Math + sequencing — banding, EMA, cadence, max calls per day.",
+        whenToUse:
+          "When you want to adjust how scores are computed, banded, or paced between calls.",
+      },
+      {
+        id: "modules",
+        label: "Modules",
+        about:
+          "Per-module settings for structured courses — cue cards, prep timers, completion gates.",
+        whenToUse:
+          "When you want to retune a specific module's behaviour without affecting the rest of the course.",
+      },
+      {
         id: "intelligence",
         label: "Content",
         about: "Source files and the extracted assertions that drive what the AI teaches.",

--- a/apps/admin/lib/journey/buckets-by-tab.ts
+++ b/apps/admin/lib/journey/buckets-by-tab.ts
@@ -1,0 +1,60 @@
+/**
+ * BUCKETS_BY_TAB — Course Detail tab → JOURNEY_MENU_ITEMS bucket mapping.
+ *
+ * Track C of the Journey-Design tab refactor (P0 shells).
+ *
+ * Each of the 14 `JourneyMenuBucketId` values lives on EXACTLY one
+ * Course Detail tab. The Journey tab continues to expose its 7
+ * chronological buckets (sign-up → call 1 → mid → end). The Teaching
+ * and Scoring tabs slice the remaining always-on knobs by educator
+ * intent. The Voice tab keeps its existing single-bucket home. The
+ * Modules tab is intentionally bucket-empty — modules-tab uses
+ * per-AuthoredModule scope (a module picker on the LH), not the
+ * bucket-filtered menu the other tabs use.
+ *
+ * The mapping is pinned by
+ * `tests/lib/journey/buckets-by-tab.test.ts` — every JourneyMenuBucketId
+ * must appear in exactly one tab (no duplicates, no omissions).
+ */
+
+import type { JourneyMenuBucketId } from "./setting-contracts";
+
+export type CourseDetailTabId =
+  | "journey"
+  | "teaching"
+  | "scoring"
+  | "voice"
+  | "modules";
+
+/** Which buckets surface on which Course Detail tab.
+ *  - `journey`: chronological arc — sign-up → call 1 → mid → end
+ *  - `teaching`: how the tutor behaves on every call uniformly
+ *  - `scoring`: math + sequencing (banding, EMA, cadence)
+ *  - `voice`: already shipped, lives in Settings tab today
+ *  - `modules`: G8 module-scoped (per AuthoredModule, not per Playbook) */
+export const BUCKETS_BY_TAB: Record<
+  CourseDetailTabId,
+  readonly JourneyMenuBucketId[]
+> = {
+  journey: [
+    "A_intake",
+    "B_call1_opening",
+    "D_question_flow",
+    "G_session_length",
+    "L_mid_journey",
+    "H_closing",
+    "M_end_of_course",
+  ],
+  teaching: ["C_teaching_style", "E_learner_visual", "F_stall_recovery", "J_feedback"],
+  scoring: ["I_scoring", "K_between_calls"],
+  voice: ["N_voice"],
+  modules: [], // G8 entries cross-tagged into other buckets; module tab uses per-AuthoredModule scope, not bucket scope
+};
+
+export const TAB_LABELS: Record<CourseDetailTabId, string> = {
+  journey: "Journey",
+  teaching: "Teaching",
+  scoring: "Scoring",
+  voice: "Voice",
+  modules: "Modules",
+};

--- a/apps/admin/tests/lib/journey/buckets-by-tab.test.ts
+++ b/apps/admin/tests/lib/journey/buckets-by-tab.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Pins BUCKETS_BY_TAB — Track C of the Journey-Design tab refactor.
+ *
+ * Invariants:
+ *  1. Every JourneyMenuBucketId appears in EXACTLY one Course Detail tab
+ *     (no omissions, no duplicates across tabs).
+ *  2. The `modules` tab is intentionally empty — the Modules tab uses a
+ *     per-AuthoredModule scope (module picker LH), not bucket-filtered nav.
+ *  3. Every non-`modules` tab has at least one bucket — empty tabs would be
+ *     a shell with nothing to render.
+ *  4. The set of CourseDetailTabIds matches the 5 we expect.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  BUCKETS_BY_TAB,
+  TAB_LABELS,
+  type CourseDetailTabId,
+} from "@/lib/journey/buckets-by-tab";
+import { JOURNEY_MENU_BUCKET_IDS } from "@/lib/journey/menu-items";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+
+describe("BUCKETS_BY_TAB — Course Detail tab → bucket mapping", () => {
+  it("declares exactly the 5 expected tab ids", () => {
+    const expected: CourseDetailTabId[] = [
+      "journey",
+      "teaching",
+      "scoring",
+      "voice",
+      "modules",
+    ];
+    expect(Object.keys(BUCKETS_BY_TAB).sort()).toEqual(expected.sort());
+    expect(Object.keys(TAB_LABELS).sort()).toEqual(expected.sort());
+  });
+
+  it("places every JourneyMenuBucketId on exactly one tab (no omissions)", () => {
+    const allBuckets = new Set<JourneyMenuBucketId>();
+    for (const buckets of Object.values(BUCKETS_BY_TAB)) {
+      for (const b of buckets) allBuckets.add(b);
+    }
+    // Each bucket present
+    for (const id of JOURNEY_MENU_BUCKET_IDS) {
+      expect(allBuckets.has(id)).toBe(true);
+    }
+    // No extras (i.e. nothing in BUCKETS_BY_TAB that isn't a real bucket)
+    expect(allBuckets.size).toBe(JOURNEY_MENU_BUCKET_IDS.length);
+  });
+
+  it("places every JourneyMenuBucketId on exactly one tab (no duplicates)", () => {
+    const seen = new Map<JourneyMenuBucketId, CourseDetailTabId>();
+    for (const [tabId, buckets] of Object.entries(BUCKETS_BY_TAB) as Array<
+      [CourseDetailTabId, readonly JourneyMenuBucketId[]]
+    >) {
+      for (const b of buckets) {
+        if (seen.has(b)) {
+          throw new Error(
+            `Bucket ${b} appears on both ${seen.get(b)} and ${tabId}`,
+          );
+        }
+        seen.set(b, tabId);
+      }
+    }
+    expect(seen.size).toBe(JOURNEY_MENU_BUCKET_IDS.length);
+  });
+
+  it("intentionally leaves the modules tab empty (per-module scope)", () => {
+    expect(BUCKETS_BY_TAB.modules).toEqual([]);
+  });
+
+  it("gives every non-modules tab at least one bucket", () => {
+    for (const [tabId, buckets] of Object.entries(BUCKETS_BY_TAB) as Array<
+      [CourseDetailTabId, readonly JourneyMenuBucketId[]]
+    >) {
+      if (tabId === "modules") continue;
+      expect(buckets.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Surfaces layer of epic #1850 — wires up the new tabs on the Course Detail page so they're mountable. Inspector wire-up is downstream (`TODO(P1)` markers).

## Summary

- New `lib/journey/buckets-by-tab.ts` — `BUCKETS_BY_TAB: Record<CourseDetailTabId, JourneyMenuBucketId[]>` + `TAB_LABELS`. Pinned by 5/5 vitests guaranteeing exactly-one-tab membership for every bucket id.
- Three new tab shells: `CourseTeachingTab`, `CourseScoringTab`, `CourseModulesTab` — each mounts `DesignerShell` with a bucket-filtered LH menu (Modules tab uses module-picker LHS instead).
- Wired into `app/x/courses/[courseId]/page.tsx` tab strip between Journey and Intelligence with icons: `Sliders` / `Calculator` / `Layers`.
- Modules tab on a continuous course renders `hf-empty` with explainer + link to `/x/help/glossary#course-style`.
- `page-help.ts` entries for the three new tabs.
- Independent of #journey-tabs-foundation at code level (Inspector wire-up is `TODO(P1)` comments). Can merge in either order.

## Test plan

- [ ] tsc clean: pre-push reports 40 errors (baseline 41, -1)
- [ ] lint clean: 0 errors, 1 informational warning (`react-hooks/set-state-in-effect`)
- [ ] 5/5 buckets-by-tab vitests + 17/17 existing registry-completeness vitests green
- [ ] Manual on hf-dev after merge: load `/x/courses/<id>` — Teaching / Scoring / Modules tabs visible, click each:
  - Teaching: LH = 4 buckets (C/E/F/J), centre = PreviewLens, right = placeholder
  - Scoring: LH = 2 buckets (I/K), centre = PreviewLens, right = placeholder
  - Modules on structured course: LH = module list, click module → preview + placeholder
  - Modules on continuous course: empty state with glossary link

## Verified by

- `apps/admin/lib/journey/buckets-by-tab.ts` — 5 tabs × 14 buckets, modules intentionally `[]` (per-AuthoredModule scope)
- `apps/admin/tests/lib/journey/buckets-by-tab.test.ts` — 5 vitests pin exactly-one-tab membership [verified]
- `apps/admin/components/teaching-tab/CourseTeachingTab.tsx` + `TeachingLhMenu.tsx`
- `apps/admin/components/scoring-tab/CourseScoringTab.tsx` + `ScoringLhMenu.tsx`
- `apps/admin/components/modules-tab/CourseModulesTab.tsx` + `ModulesLhPicker.tsx`
- `apps/admin/app/x/courses/[courseId]/page.tsx` — VALID_TABS + tabs[] + conditional render blocks
- Pre-push hook: tsc 40 errors (baseline 41, **-1**); lint clean [verified]
- No migrations; no schema change

## Open TODOs (downstream phases)

- `TODO(P1)` × 3 — Inspector slot placeholders in Teaching/Scoring/Modules
- `TODO(preview-scope)` — `PreviewLens` needs `?moduleId` scope for Modules canvas
- `TODO(modules-route)` — `/api/courses/[id]/modules` dedicated route (today piggybacks `/sessions`)

## Lattice survey

Class A (structural). Pillar: **Rules** + indirectly **Cascade**. Bucket→tab is a different rendering of the existing `menuGroupKey` partition — zero new metadata, contracts unchanged. Sibling-writer survey: `JOURNEY_MENU_ITEMS` is read by `JourneyLhMenu` only; new menus filter via the same registry. No DB writes; no chain-stage crossing.

Closes part of #1850 (P-Surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)