### PR TITLE
chore(api): tier-visibility coverage test — pin 5 confirmed leak routes

### DIFF
--- a/.claude/rules/tier-visibility-coverage.md
+++ b/.claude/rules/tier-visibility-coverage.md
@@ -1,0 +1,128 @@
+# Tier-visibility coverage (Lattice Coverage-pillar member)
+
+> Routes that mix operator-only fields with learner-safe fields AND admit
+> roles below OPERATOR MUST route their response through a
+> `redact<X>ForTier(raw, viewerTier)` projection per
+> [`response-redaction.md`](./response-redaction.md). This test pins the
+> known tier-sensitive routes in `TIER_SENSITIVE_ROUTES` and verifies
+> the redactor is wired.
+>
+> Sibling to [`registry-consumer-coverage.md`](./registry-consumer-coverage.md)
+> and [`route-auth-zod-coverage.md`](./route-auth-zod-coverage.md) — same
+> generic Coverage pattern, third surface.
+>
+> Catalogued in [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md)
+> as part of the Coverage pillar of HF Lattice.
+
+## Rule
+
+When you write or modify a route file under `apps/admin/app/api/`:
+
+1. Does the response mix operator-only fields (raw numeric scores,
+   confidence, free-text reasoning, evidence text, decay factors,
+   forward-planning) with learner-safe fields (status, category,
+   high-level labels)?
+2. Does the route admit roles below OPERATOR (e.g.
+   `requireAuth("VIEWER")`, `requireEntityAccess(..., "R")`)?
+
+If BOTH yes → add the route to `TIER_SENSITIVE_ROUTES` in
+`tests/api/tier-visibility-coverage.test.ts` AND wire a
+`redact<X>ForTier` (pattern: `lib/rbac/policies/adaptations.ts`).
+
+If you can't wire the redactor in the same PR (significant payload to
+audit), add to `TIER_VISIBILITY_EXEMPT` with a one-line reason
+describing what's deferred + bump `EXPECTED_EXEMPT_COUNT`.
+
+## Why this exists
+
+`response-redaction.md` ships the pattern (`visibilityTierForRole` +
+`redact<X>ForTier`) and the ESLint rule `hf-rbac/require-tiered-redactor`
+that enforces it once a route OPTS IN via the `@tieredVisibility` JSDoc
+tag.
+
+But the rule is opt-in by design. The 2026-06-17 audit found **1 of
+215 VIEWER-admitting routes** with the tag (0.5% adoption). **5
+confirmed active leak routes** in the callers namespace return
+operator-only fields to STUDENT readers:
+
+- `/callers/[id]/skills-evidence` — reasoning + analysisSpecName + evidenceQuality + scoredBy
+- `/callers/[id]/lo-mastery` — raw mastery (0-1) + tier + bandLabel
+- `/callers/[id]/uplift` — confidence + hasLearnerEvidence + reasoning
+- `/callers/[id]/memories` — confidence + evidence + decayFactor
+- `/callers/[id]/insights` — recommendation + reason
+
+This Coverage test makes the opt-in list itself structurally tracked.
+Once a route is named in `TIER_SENSITIVE_ROUTES`, the test enforces the
+redactor wiring. Authors can't quietly forget.
+
+## How matching works
+
+For each entry in `TIER_SENSITIVE_ROUTES`:
+
+1. Skip if file missing (stale entry — test fails on the stale check).
+2. If route is in `TIER_VISIBILITY_EXEMPT` → `exempt`.
+3. Else regex-check the source for:
+   - `visibilityTierForRole` (import + call)
+   - `redact<Anything>ForTier` (import + call)
+4. All four present → `compliant`. Otherwise → `gap` with `missing[]`
+   detail.
+
+## When NOT to apply
+
+- Routes that admit only OPERATOR+ — no tier confusion to redact.
+- Routes whose response is uniformly safe (status flags, slug IDs,
+  category labels) — nothing to redact.
+- Routes whose response is uniformly operator-only AND admitted only
+  to OPERATOR+ — no learner consumer.
+
+## When adding a new route
+
+Author checklist (same PR):
+
+1. Does the response carry per-field tier sensitivity? → continue.
+2. Does the route admit roles below OPERATOR? → continue.
+3. Add the route to `TIER_SENSITIVE_ROUTES`.
+4. Create `lib/rbac/policies/<resource>.ts::redact<Resource>ForTier`
+   (pure function — `(raw, tier) => Projected`).
+5. Add a test file at `tests/lib/rbac/policies/<resource>-redact.test.ts`
+   pinning the `redacted` shape's absence of every sensitive field.
+6. Wire into the route:
+   ```ts
+   import { visibilityTierForRole } from "@/lib/rbac/visibility";
+   import { redact<X>ForTier } from "@/lib/rbac/policies/<resource>";
+   ...
+   const viewerTier = visibilityTierForRole(auth.session.user.role);
+   const raw = await computeRaw(...);
+   return NextResponse.json(redact<X>ForTier(raw, viewerTier));
+   ```
+7. Add `@tieredVisibility` to the route's JSDoc header so the ESLint
+   rule `hf-rbac/require-tiered-redactor` enforces the imports
+   permanently.
+
+## Existing enforcement
+
+| Location | Mechanism | What it prevents |
+|---|---|---|
+| `tests/api/tier-visibility-coverage.test.ts` (born 2026-06-17, this PR) | 5 vitests: gap-check, ratchet, non-empty-reason, no-missing-files, no-contradiction | Tier-sensitive routes lacking redactors. Stale exempt entries. Routes silently wired without removing exempt. |
+| `eslint-rules/require-tiered-redactor.mjs` (Wave C5 of #1685) | Edit-time, error severity, opt-in via `@tieredVisibility` | Routes that opt in but forget imports / calls. |
+| `lib/rbac/policies/adaptations.ts` | Reference implementation | The canonical pattern: pure-function projection, discriminated union return, `viewerTier` field. |
+
+## Future hardening
+
+When all 5 exempt routes are wired, drop `EXPECTED_EXEMPT_COUNT` to 0.
+At that point the test enforces zero gaps — adding a new tier-sensitive
+route without the redactor fails CI immediately.
+
+Beyond that, consider an automated detector: routes that admit VIEWER
+AND return certain field shapes (e.g. confidence numeric, reasoning
+text, scoring metadata) get auto-suggested into `TIER_SENSITIVE_ROUTES`
+on PR review. But that's heuristic — keep the human-curated list as
+the source of truth for now.
+
+## Related
+
+- [`tests/api/tier-visibility-coverage.test.ts`](../../apps/admin/tests/api/tier-visibility-coverage.test.ts) — the test
+- [`.claude/rules/response-redaction.md`](./response-redaction.md) — the parent pattern
+- [`.claude/rules/registry-consumer-coverage.md`](./registry-consumer-coverage.md) — sibling Coverage-pillar test
+- [`.claude/rules/route-auth-zod-coverage.md`](./route-auth-zod-coverage.md) — sibling Coverage-pillar test for route auth/Zod
+- Memory: `feedback_lattice_5th_pillar_coverage.md`

--- a/apps/admin/tests/api/tier-visibility-coverage.test.ts
+++ b/apps/admin/tests/api/tier-visibility-coverage.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tier-visibility coverage — Lattice Coverage-pillar member (2026-06-17).
+ *
+ * **What this test pins:**
+ *  Routes that return per-caller payloads AND admit roles below
+ *  OPERATOR (e.g. `requireAuth("VIEWER")`, `requireEntityAccess(...)` at
+ *  R level) MUST route the response through a tier-aware redactor
+ *  (`redact<X>ForTier`) per `.claude/rules/response-redaction.md`.
+ *
+ *  The 2026-06-17 audit found 215 VIEWER-admitting routes and only 1
+ *  with the `@tieredVisibility` opt-in tag (0.5% adoption). 5 confirmed
+ *  active leak routes return operator-only fields (rationale text, raw
+ *  scores, confidence metadata) to STUDENT-tier readers.
+ *
+ *  This test names every KNOWN tier-sensitive route in
+ *  `TIER_SENSITIVE_ROUTES`. For each, verifies the file imports
+ *  `visibilityTierForRole` + a `redact<X>ForTier` AND invokes both.
+ *  Already-compliant routes pass; the 5 confirmed leaks are listed in
+ *  `TIER_VISIBILITY_EXEMPT` with reason "needs redactor (follow-on)".
+ *  Ratchet: exempt list cannot grow.
+ *
+ * **How matching works:**
+ *  For each route in `TIER_SENSITIVE_ROUTES`:
+ *    1. Skip if route file doesn't exist (stale list).
+ *    2. If route is in `TIER_VISIBILITY_EXEMPT` → `exempt`.
+ *    3. Else check: imports `visibilityTierForRole` AND imports
+ *       `redact<Anything>ForTier` AND both are invoked.
+ *    4. Both present → `compliant`. Otherwise → `gap`.
+ *
+ * **How to fix a failure:**
+ *  - "Tier-sensitive route lacks redactor": land a redactor at
+ *    `lib/rbac/policies/<resource>.ts` and wire it. Pattern is
+ *    `lib/rbac/policies/adaptations.ts::redactAdaptationsForTier`.
+ *  - "Stale exempt entry": redactor shipped; remove the exempt row.
+ *  - "Ratchet drifted up": you added a known leak without wiring it.
+ *    Wire the redactor or document the deferral in the exempt reason.
+ *
+ *  See `.claude/rules/tier-visibility-coverage.md`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const APP_API = resolve(__dirname, "..", "..", "app", "api");
+
+/**
+ * Routes whose payload mixes operator-only fields with learner-safe
+ * fields AND admit roles below OPERATOR. Maintained by humans —
+ * tier-sensitivity isn't reliably detectable from AST alone.
+ *
+ * Adding a route to this list is a conscious "this route needs a
+ * redactor" declaration. Once on the list, the test enforces the
+ * redactor is wired.
+ */
+const TIER_SENSITIVE_ROUTES: readonly string[] = [
+  // ── Already-compliant (the only opted-in route as of 2026-06-17) ──
+  "callers/[callerId]/adaptations/route.ts",
+
+  // ── 2026-06-17 audit — confirmed leaks (in exempt list below) ──
+  "callers/[callerId]/skills-evidence/route.ts",
+  "callers/[callerId]/lo-mastery/route.ts",
+  "callers/[callerId]/uplift/route.ts",
+  "callers/[callerId]/memories/route.ts",
+  "callers/[callerId]/insights/route.ts",
+];
+
+interface ExemptEntry {
+  reason: string;
+}
+
+/**
+ * Tier-sensitive routes that don't yet have a redactor. Each entry
+ * documents what's deferred. Ratchet drops as redactors ship.
+ */
+const TIER_VISIBILITY_EXEMPT: Record<string, ExemptEntry> = {
+  "callers/[callerId]/skills-evidence/route.ts": {
+    reason:
+      "Returns reasoning text + analysisSpecName + evidenceQuality + scoredBy. STUDENT-tier should see learner-evidence excerpts only. Needs redactSkillsEvidenceForTier.",
+  },
+  "callers/[callerId]/lo-mastery/route.ts": {
+    reason:
+      "Returns mastery (0-1 numeric) + tier + bandLabel. STUDENT-tier should see categorical status only (mastered / in_progress / not_started). Needs redactLoMasteryForTier.",
+  },
+  "callers/[callerId]/uplift/route.ts": {
+    reason:
+      "Returns callScores with confidence + hasLearnerEvidence + reasoning. STUDENT-tier should see engagement signals only. Needs redactUpliftForTier.",
+  },
+  "callers/[callerId]/memories/route.ts": {
+    reason:
+      "Returns confidence + evidence + decayFactor (operator-only adaptive signal). STUDENT-tier should see memory categories only. Needs redactMemoriesForTier.",
+  },
+  "callers/[callerId]/insights/route.ts": {
+    reason:
+      "Returns recommendation + reason (tutor's internal reasoning). STUDENT-tier should see high-level categories only. Needs redactInsightsForTier.",
+  },
+};
+
+const EXPECTED_EXEMPT_COUNT = 5;
+
+// ────────────────────────────────────────────────────────────
+// Detection
+// ────────────────────────────────────────────────────────────
+
+const VISIBILITY_IMPORT_RE = /visibilityTierForRole/;
+const REDACTOR_IMPORT_RE = /redact[A-Z][A-Za-z]*ForTier/;
+const VISIBILITY_CALL_RE = /visibilityTierForRole\(/;
+const REDACTOR_CALL_RE = /redact[A-Z][A-Za-z]*ForTier\(/;
+
+type Classification = "compliant" | "exempt" | "missing-file" | "gap";
+
+interface RouteResult {
+  route: string;
+  classification: Classification;
+  missing?: string[];
+  reason?: string;
+}
+
+function classifyRoute(route: string): RouteResult {
+  const full = join(APP_API, route);
+  try {
+    statSync(full);
+  } catch {
+    return { route, classification: "missing-file" };
+  }
+
+  if (TIER_VISIBILITY_EXEMPT[route]) {
+    return {
+      route,
+      classification: "exempt",
+      reason: TIER_VISIBILITY_EXEMPT[route].reason,
+    };
+  }
+
+  const src = readFileSync(full, "utf8");
+  const missing: string[] = [];
+  if (!VISIBILITY_IMPORT_RE.test(src)) missing.push("import visibilityTierForRole");
+  if (!REDACTOR_IMPORT_RE.test(src)) missing.push("import redact<X>ForTier");
+  if (!VISIBILITY_CALL_RE.test(src)) missing.push("call visibilityTierForRole(...)");
+  if (!REDACTOR_CALL_RE.test(src)) missing.push("call redact<X>ForTier(...)");
+
+  if (missing.length === 0) return { route, classification: "compliant" };
+  return { route, classification: "gap", missing };
+}
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe("Tier-visibility coverage (Lattice Coverage pillar)", () => {
+  const results = TIER_SENSITIVE_ROUTES.map(classifyRoute);
+
+  it("every tier-sensitive route either has the redactor wired or is exempt with reason", () => {
+    const gaps = results.filter((r) => r.classification === "gap");
+    expect(
+      gaps,
+      `Tier-sensitive routes that admit < OPERATOR but lack the redactor wiring:\n  ${gaps
+        .map((g) => `${g.route} — missing: ${g.missing?.join(", ")}`)
+        .join("\n  ")}\n\nFix: land redact<X>ForTier at lib/rbac/policies/<resource>.ts + wire it in the route, OR add to TIER_VISIBILITY_EXEMPT with a one-line reason describing what's deferred.`,
+    ).toEqual([]);
+  });
+
+  it("ratchet — exempt list pinned at EXPECTED_EXEMPT_COUNT", () => {
+    const exemptIds = Object.keys(TIER_VISIBILITY_EXEMPT);
+    expect(
+      exemptIds.length,
+      `Exempt-list size drifted from ${EXPECTED_EXEMPT_COUNT}. ` +
+        `If you wired a redactor + removed an entry, bump ` +
+        `EXPECTED_EXEMPT_COUNT down. If you added an entry, ` +
+        `pause: was that intentional? Wire the redactor first when ` +
+        `possible. Current entries: ${exemptIds.join(", ")}`,
+    ).toBe(EXPECTED_EXEMPT_COUNT);
+  });
+
+  it("every exempt entry has a non-empty reason (>20 chars)", () => {
+    for (const [route, entry] of Object.entries(TIER_VISIBILITY_EXEMPT)) {
+      expect(entry.reason.trim().length, `${route}: empty/short reason`).toBeGreaterThan(20);
+    }
+  });
+
+  it("no tier-sensitive route entry points at a non-existent file", () => {
+    const missing = results.filter((r) => r.classification === "missing-file");
+    expect(
+      missing.map((m) => m.route),
+      `TIER_SENSITIVE_ROUTES entry has no file on disk — route was renamed or removed; update the list.`,
+    ).toEqual([]);
+  });
+
+  it("no exempt entry is now compliant (would mean redactor shipped — remove the row)", () => {
+    const contradicted: string[] = [];
+    for (const route of Object.keys(TIER_VISIBILITY_EXEMPT)) {
+      const full = join(APP_API, route);
+      try {
+        const src = readFileSync(full, "utf8");
+        if (
+          VISIBILITY_IMPORT_RE.test(src) &&
+          REDACTOR_IMPORT_RE.test(src) &&
+          VISIBILITY_CALL_RE.test(src) &&
+          REDACTOR_CALL_RE.test(src)
+        ) {
+          contradicted.push(route);
+        }
+      } catch {
+        // missing-file caught by sibling test
+      }
+    }
+    expect(
+      contradicted,
+      `Exempt routes now compliant — remove from TIER_VISIBILITY_EXEMPT:\n  ${contradicted.join("\n  ")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Sibling to PR #1854 (route-auth-Zod coverage) — same generic Coverage pattern, third surface. The 2026-06-17 audit found 1 of 215 VIEWER-admitting routes opted into `@tieredVisibility` (0.5% adoption) and 5 confirmed-active leak routes returning operator-only fields to STUDENT-tier readers.

This test makes the opt-in list itself structurally tracked. Each tier-sensitive route is named in `TIER_SENSITIVE_ROUTES`; the test verifies the redactor is wired. The 5 leaks land in `TIER_VISIBILITY_EXEMPT` with "needs redactor (follow-on)" reasons + `EXPECTED_EXEMPT_COUNT = 5` ratchet. Each redactor that ships drops the count.

## The 5 confirmed leaks

| Route | Leaks |
|---|---|
| `/callers/[id]/skills-evidence` | `reasoning` + `analysisSpecName` + `evidenceQuality` + `scoredBy` |
| `/callers/[id]/lo-mastery` | raw `mastery` (0–1) + `tier` + `bandLabel` |
| `/callers/[id]/uplift` | `confidence` + `hasLearnerEvidence` + `reasoning` |
| `/callers/[id]/memories` | `confidence` + `evidence` + `decayFactor` |
| `/callers/[id]/insights` | `recommendation` + `reason` (tutor's internal reasoning) |

## The 5th vitest in the Coverage pillar

- `registry-schema-coverage.test.ts` (#1738) — schema → registry
- `registry-options-coverage.test.ts` (Lane 4) — registry → option literals
- `registry-consumer-coverage.test.ts` (#1849) — registry → transform reader
- `route-auth-zod-coverage.test.ts` (#1854) — route → auth + Zod
- **`tier-visibility-coverage.test.ts` (this PR)** — tier-sensitive route → redactor

Each: enumerate producers → classify (`compliant` / `exempt` / `gap`) → ratchet. Reusable framework future chains plug into.

## Verified by

- `npx vitest run tests/api/tier-visibility-coverage.test.ts` — 5/5 pass [verified].
- 5 leak routes inverse-probed: 0 redactor calls in each [verified].
- The 1 compliant route (`adaptations`) verified — both `visibilityTierForRole` and `redactAdaptationsForTier` imported + called [verified].

## What comes next

5 follow-up PRs, one per leak route. Each wires `redact<X>ForTier` at `lib/rbac/policies/<resource>.ts` (canonical pattern: `adaptations.ts`) + paired vitest. Each removes its entry from `TIER_VISIBILITY_EXEMPT` and drops `EXPECTED_EXEMPT_COUNT` by 1.

When the count reaches 0 the test enforces zero gaps — adding a new tier-sensitive route without the redactor fails CI immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)