### PR TITLE
feat(pipeline): #1823 canonical Session.metadata.overallBand write

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -29,6 +29,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { runAggregateSpecs } from "@/lib/pipeline/aggregate-runner";
 import { runProsodyStage } from "@/lib/pipeline/prosody-runner";
+import { writeOverallBandForCall } from "@/lib/pipeline/write-overall-band";
 import { applyProsodyContractToAggregate } from "@/lib/pipeline/prosody-consumer";
 import { aggregateCallerMemorySummary } from "@/lib/ops/memory-extract";
 import { runAdaptSpecs as runRuleBasedAdapt } from "@/lib/pipeline/adapt-runner";
@@ -1291,6 +1292,18 @@ async function runBatchedCallerAnalysis(
             userName,
           );
           scoresCreated += segmentScores;
+
+          // #1823 — canonical Session.metadata.overallBand write. Runs only
+          // when per-segment rows actually landed; the writer itself is
+          // idempotent and best-effort (non-throwing).
+          if (segmentScores > 0) {
+            await writeOverallBandForCall(
+              call.id,
+              (call as { sessionId?: string | null }).sessionId ?? null,
+              (call as { playbookId?: string | null }).playbookId ?? null,
+              log,
+            );
+          }
         } catch (err: any) {
           log.warn("Per-part MEASURE pass failed (non-blocking)", {
             error: err?.message ?? "unknown",

--- a/apps/admin/app/api/student/[courseId]/results/[sessionId]/route.ts
+++ b/apps/admin/app/api/student/[courseId]/results/[sessionId]/route.ts
@@ -35,6 +35,10 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
 import { scoreToTier, getSkillTierMapping } from "@/lib/goals/track-progress";
+import {
+  computeOverallBandFromScores,
+  roundHalfBand,
+} from "@/lib/pipeline/compute-overall-band";
 import type { SessionMetadata } from "@/lib/types/json-fields";
 
 export interface ResultsScore {
@@ -81,10 +85,6 @@ export interface ResultsPayload {
 export type ResultsResponse =
   | ResultsPayload
   | { ok: false; error: string };
-
-function roundHalfBand(value: number): number {
-  return Math.round(value * 2) / 2;
-}
 
 export async function GET(
   _req: NextRequest,
@@ -203,10 +203,15 @@ export async function GET(
 
     let overallBand: number | null = overallBandFromMeta;
     let overallBandSource: ResultsPayload["overallBandSource"] = overallBandFromMeta !== null ? "metadata" : null;
-    if (overallBand === null && aggregated.length > 0) {
-      const meanBand = aggregated.reduce((acc, c) => acc + c.band, 0) / aggregated.length;
-      overallBand = roundHalfBand(meanBand);
-      overallBandSource = "computed";
+    if (overallBand === null) {
+      // #1823 — fallback uses the same canonical helper the pipeline writer
+      // uses, so the on-the-fly value and the eventual metadata value cannot
+      // disagree on the same input.
+      overallBand = computeOverallBandFromScores(
+        scores.map((s) => ({ parameterId: s.parameterId, segmentKey: s.segmentKey, score: s.score })),
+        mapping,
+      );
+      if (overallBand !== null) overallBandSource = "computed";
     }
 
     // `processing` is true until the pipeline has both ended the Session AND

--- a/apps/admin/lib/pipeline/compute-overall-band.ts
+++ b/apps/admin/lib/pipeline/compute-overall-band.ts
@@ -1,0 +1,64 @@
+/**
+ * compute-overall-band.ts — canonical Mock overall band derivation.
+ *
+ * Single source of truth for the computation that produces
+ * `Session.metadata.overallBand`. Both the pipeline writer
+ * (`write-overall-band.ts`) and the Results-screen reader
+ * (`/api/student/[courseId]/results/[sessionId]/route.ts`) call this
+ * helper so the canonical metadata value and the on-the-fly fallback
+ * cannot disagree (Lattice — sibling-writer convergence on a derived
+ * value: same algorithm in both places). See #1823.
+ *
+ * Algorithm — mirrors the Theme 13a reader's mean-of-12 fallback:
+ *   1. Bucket non-null-segmentKey CallScore rows by `(parameterId, segmentKey)`.
+ *   2. Per bucket: mean of `score` values.
+ *   3. Convert each bucket mean to a band via `scoreToTier(mean, mapping)`.
+ *   4. Overall band = arithmetic mean of bucket bands, half-band rounded.
+ *
+ * Bucket selection — only rows with a non-null `segmentKey` contribute.
+ * Whole-call / bound-module rows (`segmentKey === null`) feed the
+ * existing weakSkill / diagnostic readers and are deliberately excluded
+ * from the Mock overall band (Theme 6 / #1702 boundary).
+ *
+ * Returns `null` when there are zero qualifying rows — caller decides
+ * whether to skip the write or write a sentinel.
+ */
+import { scoreToTier, type SkillTierMapping } from "@/lib/goals/track-progress";
+
+export interface OverallBandInputRow {
+  parameterId: string;
+  segmentKey: string | null;
+  score: number;
+}
+
+export function roundHalfBand(value: number): number {
+  return Math.round(value * 2) / 2;
+}
+
+export function computeOverallBandFromScores(
+  rows: ReadonlyArray<OverallBandInputRow>,
+  mapping: SkillTierMapping,
+): number | null {
+  const buckets = new Map<string, { sum: number; count: number }>();
+  for (const row of rows) {
+    if (row.segmentKey === null) continue;
+    const key = `${row.parameterId}::${row.segmentKey}`;
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.sum += row.score;
+      bucket.count += 1;
+    } else {
+      buckets.set(key, { sum: row.score, count: 1 });
+    }
+  }
+  if (buckets.size === 0) return null;
+
+  let bandSum = 0;
+  for (const b of buckets.values()) {
+    const mean = b.sum / b.count;
+    const { band } = scoreToTier(mean, mapping);
+    bandSum += band;
+  }
+  const meanBand = bandSum / buckets.size;
+  return roundHalfBand(meanBand);
+}

--- a/apps/admin/lib/pipeline/write-overall-band.ts
+++ b/apps/admin/lib/pipeline/write-overall-band.ts
@@ -1,0 +1,105 @@
+/**
+ * write-overall-band.ts — pipeline post-write helper that lands
+ * `Session.metadata.overallBand` after per-part scoring (#1823).
+ *
+ * Called once from the pipeline route after `runPerSegmentScoring`
+ * returns a non-zero row count. The write is best-effort:
+ *  - Loud-skip via AppLog when `Call.sessionId` is null (Slice-3 cutover
+ *    contract makes this case unreachable in steady state).
+ *  - Loud-skip when zero qualifying per-segment rows exist (segmenter
+ *    fallback already logged `prosody.segmentation.fallback`; no need
+ *    to double-log).
+ *  - JSON merge preserves any sibling keys (`pinnedCard`, `segmentLabels`,
+ *    `scoreDeltas`) already written by other producers.
+ *
+ * No throws — every failure path logs and returns, mirroring the
+ * per-segment scoring pass's `non-blocking` discipline.
+ */
+import { prisma } from "@/lib/prisma";
+import { log as appLog } from "@/lib/logger";
+import {
+  computeOverallBandFromScores,
+  type OverallBandInputRow,
+} from "@/lib/pipeline/compute-overall-band";
+import { getSkillTierMapping } from "@/lib/goals/track-progress";
+import type { SessionMetadata } from "@/lib/types/json-fields";
+
+export interface OverallBandWriteResult {
+  written: boolean;
+  band: number | null;
+  reason: "ok" | "no_session" | "no_segment_scores" | "db_error";
+}
+
+export async function writeOverallBandForCall(
+  callId: string,
+  sessionId: string | null,
+  playbookId: string | null,
+  log: { info: (msg: string, meta?: Record<string, unknown>) => void; warn: (msg: string, meta?: Record<string, unknown>) => void },
+): Promise<OverallBandWriteResult> {
+  if (!sessionId) {
+    appLog("system", "pipeline.overall_band.no_session", {
+      message: "Per-part scoring ran but Call.sessionId is null — overall band not written",
+      callId,
+    });
+    log.warn("Overall band: Call.sessionId is null — skipping", { callId });
+    return { written: false, band: null, reason: "no_session" };
+  }
+
+  try {
+    const [rows, mapping] = await Promise.all([
+      prisma.callScore.findMany({
+        where: { callId, segmentKey: { not: null } },
+        select: { parameterId: true, segmentKey: true, score: true },
+      }),
+      getSkillTierMapping(playbookId),
+    ]);
+
+    const inputRows: OverallBandInputRow[] = rows.map((r) => ({
+      parameterId: r.parameterId,
+      segmentKey: r.segmentKey,
+      score: r.score,
+    }));
+
+    const band = computeOverallBandFromScores(inputRows, mapping);
+    if (band === null) {
+      log.info("Overall band: no qualifying per-segment rows — skipping write", {
+        callId,
+        sessionId,
+        rowsRead: rows.length,
+      });
+      return { written: false, band: null, reason: "no_segment_scores" };
+    }
+
+    const session = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { metadata: true },
+    });
+    const currentMetadata = (session?.metadata ?? {}) as SessionMetadata;
+    const nextMetadata: SessionMetadata = { ...currentMetadata, overallBand: band };
+
+    await prisma.session.update({
+      where: { id: sessionId },
+      data: { metadata: nextMetadata as object },
+    });
+
+    appLog("system", "pipeline.overall_band.written", {
+      message: "Session.metadata.overallBand written from per-segment scores",
+      callId,
+      sessionId,
+      band,
+      bucketCount: new Set(inputRows.map((r) => `${r.parameterId}::${r.segmentKey}`)).size,
+    });
+    log.info("Overall band: written", { callId, sessionId, band });
+    return { written: true, band, reason: "ok" };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    appLog("system", "pipeline.overall_band.write_failed", {
+      message: "Overall band write failed",
+      callId,
+      sessionId,
+      error: msg,
+    });
+    log.warn("Overall band: write failed (non-blocking)", { callId, error: msg });
+    return { written: false, band: null, reason: "db_error" };
+  }
+}

--- a/apps/admin/tests/lib/pipeline/compute-overall-band.test.ts
+++ b/apps/admin/tests/lib/pipeline/compute-overall-band.test.ts
@@ -1,0 +1,104 @@
+/**
+ * compute-overall-band.test.ts — pins the canonical overall-band
+ * computation (#1823). The pipeline writer + Results-screen reader both
+ * call this helper; the round-trip pin guarantees they cannot diverge.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeOverallBandFromScores,
+  roundHalfBand,
+} from "@/lib/pipeline/compute-overall-band";
+import type { SkillTierMapping } from "@/lib/goals/track-progress";
+
+// Mirrors `scripts/migrate-ielts-playbook-mapping.ts::IELTS_MAPPING` —
+// the per-Playbook override the live IELTS Speaking Practice carries.
+const IELTS_MAPPING: SkillTierMapping = {
+  thresholds: {
+    approachingEmerging: 0.3,
+    emerging: 0.55,
+    developing: 0.7,
+    secure: 1.0,
+  },
+  tierBands: {
+    approachingEmerging: 3,
+    emerging: 4,
+    developing: 5.5,
+    secure: 7,
+  },
+};
+
+describe("roundHalfBand", () => {
+  it("rounds to nearest 0.5", () => {
+    expect(roundHalfBand(6.0)).toBe(6.0);
+    expect(roundHalfBand(6.24)).toBe(6.0);
+    expect(roundHalfBand(6.25)).toBe(6.5);
+    expect(roundHalfBand(6.74)).toBe(6.5);
+    expect(roundHalfBand(6.75)).toBe(7.0);
+  });
+});
+
+describe("computeOverallBandFromScores", () => {
+  it("returns null when no per-segment rows exist", () => {
+    expect(computeOverallBandFromScores([], IELTS_MAPPING)).toBeNull();
+  });
+
+  it("ignores rows with null segmentKey (whole-call / bound-module writes)", () => {
+    const rows = [
+      { parameterId: "p1", segmentKey: null, score: 0.9 },
+      { parameterId: "p2", segmentKey: null, score: 0.9 },
+    ];
+    expect(computeOverallBandFromScores(rows, IELTS_MAPPING)).toBeNull();
+  });
+
+  it("averages buckets across (parameterId, segmentKey) — IELTS 4-tier mapping", () => {
+    // IELTS mapping bands: <0.3 → 3, <0.55 → 4, <0.7 → 5.5, ≥0.7 → 7.
+    const rows = [
+      // Part 1 — scores 0.6/0.7/0.6/0.6 → bands 5.5/7/5.5/5.5
+      { parameterId: "fluency", segmentKey: "p1", score: 0.6 },
+      { parameterId: "lexical", segmentKey: "p1", score: 0.7 },
+      { parameterId: "grammar", segmentKey: "p1", score: 0.6 },
+      { parameterId: "pronunciation", segmentKey: "p1", score: 0.6 },
+      // Part 2 — 0.7/0.7/0.6/0.7 → 7/7/5.5/7
+      { parameterId: "fluency", segmentKey: "p2", score: 0.7 },
+      { parameterId: "lexical", segmentKey: "p2", score: 0.7 },
+      { parameterId: "grammar", segmentKey: "p2", score: 0.6 },
+      { parameterId: "pronunciation", segmentKey: "p2", score: 0.7 },
+      // Part 3 — 0.6/0.7/0.7/0.7 → 5.5/7/7/7
+      { parameterId: "fluency", segmentKey: "p3", score: 0.6 },
+      { parameterId: "lexical", segmentKey: "p3", score: 0.7 },
+      { parameterId: "grammar", segmentKey: "p3", score: 0.7 },
+      { parameterId: "pronunciation", segmentKey: "p3", score: 0.7 },
+    ];
+    // Sum of 12 bands = (5.5+7+5.5+5.5) + (7+7+5.5+7) + (5.5+7+7+7) = 23.5+26.5+26.5 = 76.5
+    // Mean = 76.5/12 = 6.375 → roundHalfBand → 6.5
+    expect(computeOverallBandFromScores(rows, IELTS_MAPPING)).toBe(6.5);
+  });
+
+  it("collapses duplicate (parameterId, segmentKey) entries via mean before banding", () => {
+    const rows = [
+      { parameterId: "fluency", segmentKey: "p1", score: 0.6 },
+      { parameterId: "fluency", segmentKey: "p1", score: 0.7 },
+    ];
+    // Mean of bucket = 0.65 → band 5.5 (developing, since 0.55 ≤ 0.65 < 0.7).
+    expect(computeOverallBandFromScores(rows, IELTS_MAPPING)).toBe(5.5);
+  });
+
+  it("rounds half-band up via the helper boundary (mean 0.25 → 0.5)", () => {
+    // Two buckets — bands 7 and 5.5 → mean 6.25 → roundHalfBand → 6.5.
+    const rows = [
+      { parameterId: "a", segmentKey: "p1", score: 0.8 },
+      { parameterId: "b", segmentKey: "p1", score: 0.6 },
+    ];
+    expect(computeOverallBandFromScores(rows, IELTS_MAPPING)).toBe(6.5);
+  });
+
+  it("returns whole-number band when all buckets land in the same tier", () => {
+    const rows = [
+      { parameterId: "a", segmentKey: "p1", score: 0.85 },
+      { parameterId: "b", segmentKey: "p1", score: 0.9 },
+      { parameterId: "c", segmentKey: "p2", score: 0.95 },
+    ];
+    // All ≥ 0.7 → all band 7 → mean 7 → 7.
+    expect(computeOverallBandFromScores(rows, IELTS_MAPPING)).toBe(7);
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -16326,8 +16326,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 539 |
-| Files with annotations | 525 |
+| Route files found | 541 |
+| Files with annotations | 527 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 


### PR DESCRIPTION
## Summary

Closes #1823. Single canonical writer for `Session.metadata.overallBand` after Mock per-part scoring lands. The Results-screen reader's fallback now calls the same pure helper as the writer, so the metadata value and the on-the-fly fallback cannot disagree on the same input.

## What

| Path | Change |
|---|---|
| `lib/pipeline/compute-overall-band.ts` (new) | Pure helper `computeOverallBandFromScores(rows, mapping)` + `roundHalfBand`. Buckets by `(parameterId, segmentKey)` (non-null `segmentKey` only), mean per bucket, `scoreToTier` → band, mean of bucket bands, half-band round. Returns `null` when zero qualifying rows. |
| `lib/pipeline/write-overall-band.ts` (new) | `writeOverallBandForCall(callId, sessionId, playbookId, log)`. Best-effort. Loud-skips via AppLog when `Call.sessionId` is null (`pipeline.overall_band.no_session`) or zero qualifying rows. Spread-merges into `Session.metadata` so sibling keys (`pinnedCard`, `segmentLabels`, `scoreDeltas`) are preserved. Never throws. |
| `app/api/calls/[callId]/pipeline/route.ts` | Calls `writeOverallBandForCall` after `runPerSegmentScoring` returns >0 segment rows. Wired inside the existing try-block — pre-existing non-blocking discipline applies. |
| `app/api/student/[courseId]/results/[sessionId]/route.ts` | Reader's fallback drops the inlined algorithm and calls the canonical helper. `roundHalfBand` re-imported from the helper. Behaviour unchanged for the same input. |
| `tests/lib/pipeline/compute-overall-band.test.ts` (new) | 7-case vitest pinning the helper (empty rows → null; null-segmentKey rows ignored; multi-bucket mean; duplicate-bucket collapse; half-band-up rounding; whole-band case). |

## Lattice survey [verified]

- **Surface:** `Session.metadata` write + per-segment `CallScore` read; pipeline EXTRACT/AGGREGATE boundary.
- **Sibling-writer drift:** other `Session.metadata` writers (pinned-card route, end-session per #1338) use the spread-merge pattern; mirrored here so sibling keys survive.
- **Default-deny gates:** N/A (no gating column).
- **Cascade respect:** `getSkillTierMapping` walks the canonical Playbook → contract → default cascade; we pass through.
- **Convention conflict:** half-band rounding extracted into shared helper — writer and reader cannot diverge on the same input.

## Verified by

- ✅ `tests/lib/pipeline/compute-overall-band.test.ts` 7/7 PASS.
- ✅ ESLint on changed files: 0 errors. `lib/pipeline/compute-overall-band.ts`, `lib/pipeline/write-overall-band.ts`, the new test, and the two route diffs all clean.
- ✅ tsc on changed files: 0 new errors. One pre-existing TS2322 at `pipeline/route.ts(1804,7)` confirmed identical to origin/main (`(1803,7)` pre-change — line shifted by the new import). Tracked under main-red baseline.
- ✅ Reader's fallback now byte-identical to writer's metadata path on the same `CallScore` input (single algorithm, single source of truth).
- ✅ Lattice survey citation in the body.

## Test plan

- [ ] `/vm-cp` — no migration.
- [ ] On hf-dev: trigger a Mock recompose (or wait for next Mock call), then `SELECT metadata FROM "Session" WHERE id = '<recent-mock-session-id>';` — expect `metadata.overallBand` to be a number ≥ 4 and ≤ 9.
- [ ] Confirm Results screen still renders an overall band when `metadata` carries the value (`overallBandSource: "metadata"`).