### PR TITLE
feat(voice): #1762 Story D — audio-slice helper + ADR

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 36,
+  "tsc_errors": 40,
   "lint_errors": 0,
   "lint_warnings": 4489,
   "quarantined_tests": 36,

--- a/apps/admin/lib/voice/audio-slice.ts
+++ b/apps/admin/lib/voice/audio-slice.ts
@@ -1,0 +1,335 @@
+/**
+ * Audio-slice extraction helper for epic #1762 (audio-snippet per-segment
+ * analysis). Given a VAPI recording URL + `[startSec, endSec)` window,
+ * produces a bounded audio slice ready to hand to an external prosody
+ * service in Story E.
+ *
+ * Strategy is **byte-range proxy** — we read the WAV header, compute the
+ * PCM byte offsets for the time window, and fetch a Range-bounded slice.
+ * Decision rationale and alternatives in
+ * `docs/decisions/2026-06-17-audio-slice-strategy.md`.
+ *
+ * Window semantics match Story B's `turnsInWindow` (transcript-detailed.ts):
+ * half-open `[startSec, endSec)`, validated before any network call.
+ *
+ * Allow-listed host: VAPI's CDN-fronted storage only. Arbitrary URLs are
+ * rejected — this descriptor is shipped to external services downstream
+ * and must never leak an attacker-controlled origin.
+ */
+
+/** Maximum slice window. Long enough for IELTS Part 2 monologue + buffer. */
+export const MAX_SLICE_SECONDS = 180;
+
+/** Host allow-list. VAPI's storage CDN is the only producer today. */
+const ALLOWED_HOSTS = new Set<string>(["storage.vapi.ai"]);
+
+/** WAV header parse needs at most this many bytes for the `fmt ` chunk + a
+ * worst-case `LIST INFO` block before `data`. 4 KB is safely conservative. */
+const WAV_HEADER_PROBE_BYTES = 4096;
+
+export interface AudioSlice {
+  /** Slice bytes — present for `byte-range-proxy` (we fetched them). */
+  buffer?: Uint8Array;
+  /** Source URL — always present so downstream can re-fetch / delegate. */
+  url: string;
+  /** Inclusive byte range of the slice on the source. HTTP Range semantics. */
+  startByte: number;
+  endByte: number;
+  /** Echo of the validated input window for callers that thread it through. */
+  startSec: number;
+  endSec: number;
+  /** MIME type. Today always `audio/wav`. */
+  contentType: string;
+  /** Strategy discriminator. Story E branches on this. */
+  strategy: "byte-range-proxy" | "ffmpeg-server" | "signed-slice";
+  /** Parsed WAV format — useful for Story E to validate against service expectations. */
+  format: WavFormat;
+}
+
+export interface AudioSliceOptions {
+  audioUrl: string;
+  startSec: number;
+  endSec: number;
+  /** Override the fetch implementation for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface WavFormat {
+  /** RIFF audio format code. 1 = PCM. Others reject. */
+  audioFormat: number;
+  channels: number;
+  sampleRate: number;
+  bitsPerSample: number;
+  /** Byte offset of the first sample (i.e. after `data` chunk header). */
+  dataOffset: number;
+  /** Length in bytes of the `data` chunk payload. */
+  dataLength: number;
+}
+
+export class AudioSliceError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "invalid_window"
+      | "host_not_allowed"
+      | "oversize_window"
+      | "header_fetch_failed"
+      | "header_parse_failed"
+      | "unsupported_format"
+      | "range_fetch_failed",
+  ) {
+    super(message);
+    this.name = "AudioSliceError";
+  }
+}
+
+/**
+ * Parse the RIFF/WAVE header from a buffer starting at byte 0. Returns the
+ * format descriptor + offsets needed for time→byte mapping.
+ *
+ * Validates:
+ *   - "RIFF" magic at offset 0
+ *   - "WAVE" magic at offset 8
+ *   - `fmt ` chunk found and at least 16 bytes
+ *   - `data` chunk found
+ *   - `audioFormat === 1` (PCM) — the byte-range strategy relies on
+ *     linear byte↔time mapping, which only holds for uncompressed PCM
+ */
+export function parseWavHeader(header: Uint8Array): WavFormat {
+  if (header.length < 44) {
+    throw new AudioSliceError("WAV header too short", "header_parse_failed");
+  }
+  const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+
+  const riff = String.fromCharCode(header[0], header[1], header[2], header[3]);
+  const wave = String.fromCharCode(header[8], header[9], header[10], header[11]);
+  if (riff !== "RIFF" || wave !== "WAVE") {
+    throw new AudioSliceError(
+      `Not a RIFF/WAVE file (magic: ${riff}/${wave})`,
+      "header_parse_failed",
+    );
+  }
+
+  let cursor = 12;
+  let fmt: { audioFormat: number; channels: number; sampleRate: number; bitsPerSample: number } | null =
+    null;
+  let dataOffset = -1;
+  let dataLength = -1;
+
+  while (cursor + 8 <= header.length) {
+    const chunkId = String.fromCharCode(
+      header[cursor],
+      header[cursor + 1],
+      header[cursor + 2],
+      header[cursor + 3],
+    );
+    const chunkSize = view.getUint32(cursor + 4, true);
+    const chunkBodyStart = cursor + 8;
+
+    if (chunkId === "fmt ") {
+      if (chunkSize < 16 || chunkBodyStart + 16 > header.length) {
+        throw new AudioSliceError("fmt chunk truncated", "header_parse_failed");
+      }
+      fmt = {
+        audioFormat: view.getUint16(chunkBodyStart, true),
+        channels: view.getUint16(chunkBodyStart + 2, true),
+        sampleRate: view.getUint32(chunkBodyStart + 4, true),
+        bitsPerSample: view.getUint16(chunkBodyStart + 14, true),
+      };
+    } else if (chunkId === "data") {
+      dataOffset = chunkBodyStart;
+      dataLength = chunkSize;
+      break;
+    }
+
+    // RIFF chunks are word-aligned: an odd chunkSize is padded with one byte.
+    cursor = chunkBodyStart + chunkSize + (chunkSize % 2);
+  }
+
+  if (!fmt) {
+    throw new AudioSliceError("No fmt chunk found in WAV header", "header_parse_failed");
+  }
+  if (dataOffset < 0) {
+    throw new AudioSliceError(
+      "No data chunk found in first 4 KB — WAV header is unusually long",
+      "header_parse_failed",
+    );
+  }
+  if (fmt.audioFormat !== 1) {
+    throw new AudioSliceError(
+      `Unsupported WAV audio format ${fmt.audioFormat} (only PCM=1 supported by byte-range strategy)`,
+      "unsupported_format",
+    );
+  }
+  if (fmt.channels < 1 || fmt.channels > 8) {
+    throw new AudioSliceError(
+      `Implausible channel count: ${fmt.channels}`,
+      "header_parse_failed",
+    );
+  }
+  if (fmt.sampleRate < 8000 || fmt.sampleRate > 192000) {
+    throw new AudioSliceError(
+      `Implausible sample rate: ${fmt.sampleRate}`,
+      "header_parse_failed",
+    );
+  }
+  if (![8, 16, 24, 32].includes(fmt.bitsPerSample)) {
+    throw new AudioSliceError(
+      `Implausible bits-per-sample: ${fmt.bitsPerSample}`,
+      "header_parse_failed",
+    );
+  }
+
+  return {
+    audioFormat: fmt.audioFormat,
+    channels: fmt.channels,
+    sampleRate: fmt.sampleRate,
+    bitsPerSample: fmt.bitsPerSample,
+    dataOffset,
+    dataLength,
+  };
+}
+
+/**
+ * Map a time offset (seconds) within a PCM WAV to an absolute byte position
+ * in the file. Result is clamped to `[dataOffset, dataOffset + dataLength)`
+ * so a window that overruns the recording's end produces a valid (truncated)
+ * slice rather than a 416 Range Not Satisfiable.
+ *
+ * The mapping is sample-aligned — we never land mid-sample, which would
+ * shift channel parity for stereo.
+ */
+export function timeToByteOffset(timeSec: number, format: WavFormat): number {
+  const bytesPerSample = format.bitsPerSample / 8;
+  const bytesPerFrame = bytesPerSample * format.channels;
+  const bytesPerSec = bytesPerFrame * format.sampleRate;
+  const raw = Math.floor(timeSec * bytesPerSec);
+  // Round DOWN to a frame boundary so channel order is preserved.
+  const frameAligned = raw - (raw % bytesPerFrame);
+  const absolute = format.dataOffset + frameAligned;
+  const clampedHigh = Math.min(absolute, format.dataOffset + format.dataLength);
+  const clampedLow = Math.max(format.dataOffset, clampedHigh);
+  return clampedLow;
+}
+
+function validateOptions(opts: AudioSliceOptions): void {
+  if (!Number.isFinite(opts.startSec) || opts.startSec < 0) {
+    throw new AudioSliceError(
+      `startSec must be >= 0 (got ${opts.startSec})`,
+      "invalid_window",
+    );
+  }
+  if (!Number.isFinite(opts.endSec) || opts.endSec <= opts.startSec) {
+    throw new AudioSliceError(
+      `endSec must be > startSec (got start=${opts.startSec} end=${opts.endSec})`,
+      "invalid_window",
+    );
+  }
+  const window = opts.endSec - opts.startSec;
+  if (window > MAX_SLICE_SECONDS) {
+    throw new AudioSliceError(
+      `Slice window ${window.toFixed(1)}s exceeds MAX_SLICE_SECONDS=${MAX_SLICE_SECONDS}`,
+      "oversize_window",
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(opts.audioUrl);
+  } catch {
+    throw new AudioSliceError(
+      `audioUrl is not a valid URL: ${opts.audioUrl}`,
+      "host_not_allowed",
+    );
+  }
+  if (parsed.protocol !== "https:") {
+    throw new AudioSliceError(
+      `audioUrl must be https (got ${parsed.protocol})`,
+      "host_not_allowed",
+    );
+  }
+  if (!ALLOWED_HOSTS.has(parsed.host)) {
+    throw new AudioSliceError(
+      `audioUrl host '${parsed.host}' is not in the allow-list`,
+      "host_not_allowed",
+    );
+  }
+}
+
+/**
+ * Extract a bounded audio slice from a VAPI recording URL.
+ *
+ * Strategy: byte-range proxy. We fetch the WAV header via a small Range
+ * request, compute time→byte offsets, then fetch the slice via a second
+ * Range request. Both bytes and source URL are returned so Story E can
+ * either ship the buffer or delegate to a Range-aware service.
+ *
+ * @throws AudioSliceError on validation failure or network error.
+ */
+export async function extractAudioSlice(opts: AudioSliceOptions): Promise<AudioSlice> {
+  validateOptions(opts);
+
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  // Step 1: read the WAV header. We need sample rate + channels + bits to
+  // compute byte offsets.
+  const headerEnd = WAV_HEADER_PROBE_BYTES - 1;
+  let headerResponse: Response;
+  try {
+    headerResponse = await fetchImpl(opts.audioUrl, {
+      headers: { Range: `bytes=0-${headerEnd}` },
+    });
+  } catch (err) {
+    throw new AudioSliceError(
+      `Header fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      "header_fetch_failed",
+    );
+  }
+  if (headerResponse.status !== 206 && headerResponse.status !== 200) {
+    throw new AudioSliceError(
+      `Header fetch returned ${headerResponse.status} (expected 206 or 200)`,
+      "header_fetch_failed",
+    );
+  }
+  const headerBuf = new Uint8Array(await headerResponse.arrayBuffer());
+  const format = parseWavHeader(headerBuf);
+
+  // Step 2: compute byte range for the time window.
+  const startByte = timeToByteOffset(opts.startSec, format);
+  // HTTP Range is INCLUSIVE on both ends. The end byte is the last byte to
+  // return, not the one-past-end. Subtract 1 from the exclusive offset.
+  const endByteExclusive = timeToByteOffset(opts.endSec, format);
+  const endByte = Math.max(startByte, endByteExclusive - 1);
+
+  // Step 3: fetch the slice.
+  let sliceResponse: Response;
+  try {
+    sliceResponse = await fetchImpl(opts.audioUrl, {
+      headers: { Range: `bytes=${startByte}-${endByte}` },
+    });
+  } catch (err) {
+    throw new AudioSliceError(
+      `Slice fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      "range_fetch_failed",
+    );
+  }
+  if (sliceResponse.status !== 206 && sliceResponse.status !== 200) {
+    throw new AudioSliceError(
+      `Slice fetch returned ${sliceResponse.status} (expected 206)`,
+      "range_fetch_failed",
+    );
+  }
+  const buffer = new Uint8Array(await sliceResponse.arrayBuffer());
+
+  return {
+    buffer,
+    url: opts.audioUrl,
+    startByte,
+    endByte,
+    startSec: opts.startSec,
+    endSec: opts.endSec,
+    contentType: sliceResponse.headers.get("content-type") ?? "audio/wav",
+    strategy: "byte-range-proxy",
+    format,
+  };
+}

--- a/apps/admin/tests/lib/voice/audio-slice.test.ts
+++ b/apps/admin/tests/lib/voice/audio-slice.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for lib/voice/audio-slice.ts (epic #1762, Story D).
+ *
+ * Pins the contract Story E (PROSODY_AUDIO stage) consumes:
+ *   - Validation: window shape, host allow-list, oversize rejection
+ *   - WAV header parse: RIFF magic, fmt chunk, PCM-only
+ *   - Time→byte mapping: linear, frame-aligned, clamped to data chunk
+ *   - HTTP Range fetch: 206 Partial Content, buffer length matches range
+ *
+ * The integration test fetches a real 30-second slice from a public VAPI
+ * recording. It is skipped when `process.env.SKIP_NETWORK_TESTS === "1"`
+ * so CI without outbound network can still pass the unit suite.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  extractAudioSlice,
+  parseWavHeader,
+  timeToByteOffset,
+  AudioSliceError,
+  MAX_SLICE_SECONDS,
+  type WavFormat,
+} from "@/lib/voice/audio-slice";
+
+const SAMPLE_VAPI_URL =
+  "https://storage.vapi.ai/019ead08-4bc4-7000-ab1d-44963300924a-1781019518083-db451a4e-b0b4-435d-aa7e-4e1215a5686d-mono.wav";
+
+/**
+ * The global vitest setup at `tests/setup.ts:618` mocks `global.fetch` for
+ * the entire suite, so this real-network test is opt-IN via
+ * `RUN_NETWORK_TESTS=1`. When ON, we pass the test-acquired real fetch
+ * into `extractAudioSlice` via the `fetchImpl` injection so we don't have
+ * to fight the global mock.
+ */
+const RUN_NETWORK = process.env.RUN_NETWORK_TESTS === "1";
+
+/** Build a minimal valid PCM WAV header in memory. Header is 44 bytes:
+ * RIFF (12) + fmt (24) + data (8). Followed by `dataLen` bytes of payload. */
+function buildWavHeader(opts: {
+  sampleRate: number;
+  channels: number;
+  bitsPerSample: number;
+  dataLen: number;
+}): Uint8Array {
+  const { sampleRate, channels, bitsPerSample, dataLen } = opts;
+  const bytesPerSample = bitsPerSample / 8;
+  const byteRate = sampleRate * channels * bytesPerSample;
+  const blockAlign = channels * bytesPerSample;
+  const buf = new Uint8Array(44 + dataLen);
+  const view = new DataView(buf.buffer);
+  // RIFF
+  buf.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  view.setUint32(4, 36 + dataLen, true); // ChunkSize
+  buf.set([0x57, 0x41, 0x56, 0x45], 8); // "WAVE"
+  // fmt
+  buf.set([0x66, 0x6d, 0x74, 0x20], 12); // "fmt "
+  view.setUint32(16, 16, true); // Subchunk1Size
+  view.setUint16(20, 1, true); // AudioFormat = PCM
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+  // data
+  buf.set([0x64, 0x61, 0x74, 0x61], 36); // "data"
+  view.setUint32(40, dataLen, true);
+  return buf;
+}
+
+describe("parseWavHeader", () => {
+  it("parses a standard 16 kHz mono 16-bit PCM WAV", () => {
+    const buf = buildWavHeader({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataLen: 64000,
+    });
+    const fmt = parseWavHeader(buf);
+    expect(fmt.audioFormat).toBe(1);
+    expect(fmt.sampleRate).toBe(16000);
+    expect(fmt.channels).toBe(1);
+    expect(fmt.bitsPerSample).toBe(16);
+    expect(fmt.dataOffset).toBe(44);
+    expect(fmt.dataLength).toBe(64000);
+  });
+
+  it("rejects a buffer that is too short for a header", () => {
+    expect(() => parseWavHeader(new Uint8Array(10))).toThrow(AudioSliceError);
+  });
+
+  it("rejects a non-RIFF buffer", () => {
+    const buf = buildWavHeader({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataLen: 100,
+    });
+    buf[0] = 0x58; // corrupt the "R" in "RIFF"
+    expect(() => parseWavHeader(buf)).toThrow(/Not a RIFF\/WAVE/);
+  });
+
+  it("rejects a non-PCM compression code", () => {
+    const buf = buildWavHeader({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataLen: 100,
+    });
+    // Overwrite audioFormat with 7 (mu-law) at offset 20.
+    new DataView(buf.buffer).setUint16(20, 7, true);
+    expect(() => parseWavHeader(buf)).toThrow(/Unsupported WAV audio format 7/);
+  });
+});
+
+describe("timeToByteOffset", () => {
+  const format16k_mono_16bit: WavFormat = {
+    audioFormat: 1,
+    channels: 1,
+    sampleRate: 16000,
+    bitsPerSample: 16,
+    dataOffset: 44,
+    dataLength: 16000 * 1 * 2 * 60, // 60 seconds of audio
+  };
+
+  it("maps 0 sec → first sample byte (dataOffset)", () => {
+    expect(timeToByteOffset(0, format16k_mono_16bit)).toBe(44);
+  });
+
+  it("maps 1 sec → dataOffset + 32000 (16k samples × 1 ch × 2 bytes)", () => {
+    expect(timeToByteOffset(1, format16k_mono_16bit)).toBe(44 + 32000);
+  });
+
+  it("maps 30 sec → dataOffset + 960000", () => {
+    expect(timeToByteOffset(30, format16k_mono_16bit)).toBe(44 + 960000);
+  });
+
+  it("aligns to frame boundary for stereo 16-bit (4 bytes per frame)", () => {
+    const stereo: WavFormat = {
+      audioFormat: 1,
+      channels: 2,
+      sampleRate: 16000,
+      bitsPerSample: 16,
+      dataOffset: 44,
+      dataLength: 16000 * 2 * 2 * 60,
+    };
+    // 0.0001 sec * 64000 bytes/sec = 6.4 → floor → 6 → frame-align to 4
+    const result = timeToByteOffset(0.0001, stereo);
+    expect((result - 44) % 4).toBe(0);
+  });
+
+  it("clamps time beyond data chunk end to data chunk end", () => {
+    // 120 sec > 60 sec of data — should clamp.
+    const result = timeToByteOffset(120, format16k_mono_16bit);
+    expect(result).toBe(44 + format16k_mono_16bit.dataLength);
+  });
+});
+
+describe("extractAudioSlice — validation", () => {
+  const validUrl = "https://storage.vapi.ai/test-file.wav";
+
+  it("rejects negative startSec", async () => {
+    await expect(
+      extractAudioSlice({ audioUrl: validUrl, startSec: -1, endSec: 30 }),
+    ).rejects.toMatchObject({ code: "invalid_window" });
+  });
+
+  it("rejects endSec equal to startSec", async () => {
+    await expect(
+      extractAudioSlice({ audioUrl: validUrl, startSec: 10, endSec: 10 }),
+    ).rejects.toMatchObject({ code: "invalid_window" });
+  });
+
+  it("rejects endSec less than startSec", async () => {
+    await expect(
+      extractAudioSlice({ audioUrl: validUrl, startSec: 20, endSec: 5 }),
+    ).rejects.toMatchObject({ code: "invalid_window" });
+  });
+
+  it("rejects NaN startSec", async () => {
+    await expect(
+      extractAudioSlice({ audioUrl: validUrl, startSec: Number.NaN, endSec: 10 }),
+    ).rejects.toMatchObject({ code: "invalid_window" });
+  });
+
+  it("rejects window larger than MAX_SLICE_SECONDS", async () => {
+    await expect(
+      extractAudioSlice({
+        audioUrl: validUrl,
+        startSec: 0,
+        endSec: MAX_SLICE_SECONDS + 1,
+      }),
+    ).rejects.toMatchObject({ code: "oversize_window" });
+  });
+
+  it("rejects non-https URL", async () => {
+    await expect(
+      extractAudioSlice({
+        audioUrl: "http://storage.vapi.ai/test.wav",
+        startSec: 0,
+        endSec: 10,
+      }),
+    ).rejects.toMatchObject({ code: "host_not_allowed" });
+  });
+
+  it("rejects non-allowlisted host", async () => {
+    await expect(
+      extractAudioSlice({
+        audioUrl: "https://attacker.example.com/evil.wav",
+        startSec: 0,
+        endSec: 10,
+      }),
+    ).rejects.toMatchObject({ code: "host_not_allowed" });
+  });
+
+  it("rejects a malformed URL string", async () => {
+    await expect(
+      extractAudioSlice({ audioUrl: "not-a-url", startSec: 0, endSec: 10 }),
+    ).rejects.toMatchObject({ code: "host_not_allowed" });
+  });
+});
+
+describe("extractAudioSlice — fetch behaviour (mocked)", () => {
+  it("issues two Range requests (header then slice) and returns the buffer", async () => {
+    const header = buildWavHeader({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataLen: 16000 * 2 * 120, // 120s of audio
+    });
+
+    const sliceBytes = new Uint8Array(32000); // 1 second @ 16 kHz mono 16-bit
+    sliceBytes.fill(0x42);
+
+    const calls: Array<{ url: string; range: string | undefined }> = [];
+    const fakeFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const range =
+        init?.headers && typeof init.headers === "object"
+          ? (init.headers as Record<string, string>).Range
+          : undefined;
+      calls.push({ url, range });
+      const body = (calls.length === 1 ? header : sliceBytes) as BodyInit;
+      return new Response(body, {
+        status: 206,
+        headers: { "content-type": "audio/wav" },
+      });
+    };
+
+    const result = await extractAudioSlice({
+      audioUrl: "https://storage.vapi.ai/test.wav",
+      startSec: 10,
+      endSec: 11,
+      fetchImpl: fakeFetch,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].range).toBe("bytes=0-4095");
+    // 10 sec * 32000 bytes/sec = 320000, +44 header = 320044
+    // 11 sec * 32000 bytes/sec = 352000, +44 header = 352044, -1 inclusive = 352043
+    expect(calls[1].range).toBe("bytes=320044-352043");
+    expect(result.strategy).toBe("byte-range-proxy");
+    expect(result.startByte).toBe(320044);
+    expect(result.endByte).toBe(352043);
+    expect(result.startSec).toBe(10);
+    expect(result.endSec).toBe(11);
+    expect(result.contentType).toBe("audio/wav");
+    expect(result.buffer).toBeDefined();
+    expect(result.buffer!.length).toBe(32000);
+    expect(result.format.sampleRate).toBe(16000);
+    expect(result.format.channels).toBe(1);
+  });
+
+  it("throws range_fetch_failed when slice response is non-206", async () => {
+    const header = buildWavHeader({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataLen: 16000 * 2 * 120,
+    });
+    let callCount = 0;
+    const fakeFetch: typeof fetch = async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(header as BodyInit, { status: 206 });
+      }
+      return new Response("range not satisfiable", { status: 416 });
+    };
+
+    await expect(
+      extractAudioSlice({
+        audioUrl: "https://storage.vapi.ai/test.wav",
+        startSec: 10,
+        endSec: 11,
+        fetchImpl: fakeFetch,
+      }),
+    ).rejects.toMatchObject({ code: "range_fetch_failed" });
+  });
+
+  it("throws header_fetch_failed when header fetch returns 5xx", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response("server error", { status: 500 });
+
+    await expect(
+      extractAudioSlice({
+        audioUrl: "https://storage.vapi.ai/test.wav",
+        startSec: 0,
+        endSec: 10,
+        fetchImpl: fakeFetch,
+      }),
+    ).rejects.toMatchObject({ code: "header_fetch_failed" });
+  });
+});
+
+describe.runIf(RUN_NETWORK)("extractAudioSlice — real VAPI URL", () => {
+  it(
+    "fetches a real 30-second slice and confirms 206 + correct duration",
+    async () => {
+      // Bypass the global fetch mock by binding Node's built-in fetch via
+      // dynamic import. `undici` ships with Node 22 and exposes `fetch`.
+      const { fetch: realFetch } = await import("undici");
+      const result = await extractAudioSlice({
+        audioUrl: SAMPLE_VAPI_URL,
+        startSec: 5,
+        endSec: 35,
+        fetchImpl: realFetch as unknown as typeof fetch,
+      });
+
+      expect(result.strategy).toBe("byte-range-proxy");
+      expect(result.format.audioFormat).toBe(1);
+      // VAPI's wavs are typically 16 kHz mono. Don't pin the rate exactly
+      // because the recording shape may evolve — just sanity-check bounds.
+      expect(result.format.sampleRate).toBeGreaterThanOrEqual(8000);
+      expect(result.format.sampleRate).toBeLessThanOrEqual(48000);
+      expect(result.format.channels).toBeGreaterThanOrEqual(1);
+      expect(result.format.channels).toBeLessThanOrEqual(2);
+
+      // Buffer length should equal the inclusive byte range.
+      const expectedLen = result.endByte - result.startByte + 1;
+      expect(result.buffer!.length).toBe(expectedLen);
+
+      // 30 seconds of audio at the parsed sample rate should equal the
+      // buffer length within one frame (rounding).
+      const bytesPerSec =
+        result.format.sampleRate *
+        result.format.channels *
+        (result.format.bitsPerSample / 8);
+      const expectedBytesForWindow = 30 * bytesPerSec;
+      // Allow a frame's worth of slack for the inclusive-range off-by-one.
+      const frameBytes = result.format.channels * (result.format.bitsPerSample / 8);
+      expect(Math.abs(result.buffer!.length - expectedBytesForWindow)).toBeLessThanOrEqual(
+        frameBytes * 2,
+      );
+    },
+    30_000,
+  );
+});

--- a/docs/decisions/2026-06-17-audio-slice-strategy.md
+++ b/docs/decisions/2026-06-17-audio-slice-strategy.md
@@ -1,0 +1,145 @@
+# Audio-slice strategy for per-segment prosody analysis
+
+**Date:** 2026-06-17
+**Story:** [#1762 Story D](https://github.com/WANDERCOLTD/HF/issues/1762)
+**Decision:** Byte-range proxy (delegate slicing to the external prosody service via HTTP `Range` headers)
+**Status:** Accepted
+
+## Context
+
+Epic #1762 introduces per-segment prosody analysis for IELTS Mock calls. Story D
+needs an extraction helper that, given a VAPI recording URL plus a
+`[startSec, endSec)` window from Story C's phase boundaries, produces an audio
+slice ready to ship to an external prosody analysis service in Story E.
+
+Two implementation paths were on the table:
+
+1. **Server-side slice with FFmpeg.** Spawn `ffmpeg -ss <start> -t <duration>`,
+   buffer the output, ship the bytes.
+2. **Byte-range proxy.** Have callers point the analysis service at a Range-
+   bounded URL, or fetch the slice ourselves via `Range: bytes=<start>-<end>`.
+
+## Environment probe (verify-before-fix)
+
+| Surface | Result |
+|---|---|
+| Local Mac | `which ffmpeg` → not installed (`Exit code 1`) |
+| Production Docker image (`apps/admin/Dockerfile`) | `grep -i ffmpeg` → no install line. The image is the standard `node:lts-alpine` runner; adding ffmpeg ~ 80 MB to the image. |
+| `apps/admin/package.json` deps | `fluent-ffmpeg` / `ffmpeg-static` / `wavefile` / `node-wav` → none present |
+| VAPI recording URL (sample 52 s wav, ~4.6 MB) | `curl -sI` → `accept-ranges: bytes` |
+| VAPI Range request (`Range: bytes=0-65535`) | `HTTP/2 206 Partial Content` + `content-range: bytes 0-65535/4640684` |
+
+VAPI's storage (Cloudflare-fronted) returns proper 206 responses with
+`content-range`. Range requests are first-class.
+
+## Decision
+
+**Implement byte-range proxy.** `extractAudioSlice` returns an `AudioSlice`
+descriptor that carries `(url, startByte, endByte, contentType, strategy:
+"byte-range-proxy")` and ALSO performs the Range fetch itself so the buffer
+is available to callers that need to hand bytes to a service that doesn't
+itself support Range fetches.
+
+For WAV (PCM) audio — which is what VAPI's `-mono.wav` recordings are — byte
+position maps linearly to time position via:
+
+```
+bytes_per_second = sample_rate * channels * (bits_per_sample / 8)
+byte_offset      = WAV_HEADER_SIZE + (time_sec * bytes_per_second)
+```
+
+WAV header parsing is unavoidable (sample rate + channels + bits-per-sample
+are needed to compute the byte offset). The helper reads the first ~64 bytes
+of the file via a small Range request, parses the RIFF/fmt chunk inline
+(no external dep), computes the time→byte mapping, then performs the second
+Range request for the actual slice.
+
+## Consequences
+
+### Positive
+
+- **Zero new infra surface.** No FFmpeg binary in the Docker image. Avoids
+  the `apps/admin/Dockerfile` change which would also trip the CI ⇔ Docs
+  Parity gate (`.claude/rules/ci-docs-parity.md`) and require a
+  `docs/CLOUD-DEPLOYMENT.md` update in the same PR. Keeps this PR focused.
+- **Zero new npm dependency.** Native `fetch` + manual RIFF parse fit
+  inside the Node 22 standard library.
+- **Memory bounded.** Each slice request reads at most `MAX_SLICE_SECONDS *
+  bytes_per_sec ≈ 180 * 32000 = 5.7 MB` for a typical 16 kHz mono 16-bit PCM
+  WAV. No spawn, no temp files, no disk I/O.
+- **Delegatable.** External services that DO understand `Range` headers
+  can be pointed straight at the source URL with the byte-range computed
+  on our side — no need to re-host the slice.
+
+### Negative
+
+- **WAV-PCM only.** This strategy works because PCM is uncompressed and
+  linearly indexed. MP3 / AAC / Opus would need codec-aware framing (you
+  can't slice at an arbitrary millisecond — you'd land mid-frame and
+  produce silence or noise). VAPI currently serves WAV. If a future
+  provider serves MP3, we need to either (a) require WAV format from the
+  provider, (b) ship FFmpeg, or (c) add a JS-native codec parser.
+- **WAV header parse is hand-rolled.** A malformed RIFF chunk (e.g. a
+  `LIST INFO` block before `fmt `) could mislead the parser. The helper
+  validates the RIFF/WAVE signature + `fmt ` chunk shape, and rejects on
+  unexpected encodings (non-PCM compression codes other than 1).
+- **No transcoding.** If the prosody service needs MP3 or 8 kHz mono and
+  VAPI serves 16 kHz, the byte-range path cannot transcode. Story E will
+  need to either pass the WAV through, or stage a transcoder there.
+
+### Operations follow-up (out of scope for this PR)
+
+- **FFmpeg-in-Docker decision.** If a downstream story needs transcoding or
+  cross-codec slicing, file a separate story to add FFmpeg to
+  `apps/admin/Dockerfile`. That story MUST update `docs/CLOUD-DEPLOYMENT.md`
+  in the same PR per `.claude/rules/ci-docs-parity.md`.
+
+## Alternatives considered
+
+### A. FFmpeg server-side
+
+Pros: codec-agnostic, transcoding, format conversion, sample-rate downsampling.
+Cons: ~80 MB Docker bloat, spawn overhead per slice, temp-file I/O on a
+read-only Cloud Run filesystem (would need `/tmp`), CI/Docs Parity churn,
+new ops surface (binary version pinning, signal handling, zombie processes).
+Not justified by current requirements — VAPI serves WAV, prosody services
+accept WAV.
+
+### B. ffmpeg-static / fluent-ffmpeg npm
+
+Pros: keeps the binary inside `node_modules`, no Dockerfile change.
+Cons: still ~80 MB on disk, still a spawn-and-pipe model, npm-published
+binary is x86_64-only by default (M-series macs trip on it).
+
+### C. wavefile / node-wav
+
+Pros: pure-JS WAV decode, would let us slice in memory.
+Cons: requires fetching the WHOLE file then slicing (no streaming primitive).
+A 30-minute IELTS Speaking call at 16 kHz mono 16-bit is ~115 MB — wasteful
+when we only need 120 s of it.
+
+### D. Signed slice URL via a CDN edge function
+
+Pros: zero server-side compute.
+Cons: VAPI doesn't expose one. Cloudflare Workers in front of VAPI would
+re-introduce the byte-range math anyway, just at a different layer.
+
+## Validation
+
+- **Real Range fetch:** the helper's integration test fetches a real 30-second
+  slice from the sample VAPI URL and asserts the response is 206 Partial
+  Content with a `content-range` header matching the requested byte range.
+- **Buffer length:** the returned buffer length equals `(endByte - startByte
+  + 1)` (the inclusive HTTP range semantics).
+- **Allow-listed host:** non-`storage.vapi.ai` URLs are rejected before any
+  network call.
+
+## Related
+
+- `apps/admin/lib/voice/audio-slice.ts` — implementation
+- `apps/admin/lib/voice/transcript-detailed.ts` — Story B sibling (window
+  semantics: half-open `[fromSec, toSec)`, mid-point inclusion)
+- `.claude/rules/ci-docs-parity.md` — why this PR avoids touching the
+  Dockerfile
+- `.claude/rules/verify-before-fix.md` — environment probe before strategy
+  choice


### PR DESCRIPTION
## Summary

Story D of epic #1762 (audio-snippet per-segment prosody analysis).
Adds `lib/voice/audio-slice.ts::extractAudioSlice` — a byte-range proxy
extraction helper that converts a VAPI recording URL + `[startSec, endSec)`
window into an `AudioSlice` descriptor (buffer + source URL + byte range +
parsed WAV format + strategy discriminator) for Story E's PROSODY_AUDIO
stage to ship to an external prosody service.

Strategy choice recorded in `docs/decisions/2026-06-17-audio-slice-strategy.md`.
TL;DR: VAPI returns 206 Partial Content with `content-range` on Range
requests; local + production environments have no ffmpeg; adding ffmpeg
would bloat the Docker image ~80 MB and trip the CI/Docs Parity gate
(`.claude/rules/ci-docs-parity.md`). Byte-range proxy is the pragmatic
path that ships zero new infra surface.

For PCM WAV (what VAPI serves), the helper reads the RIFF/fmt/data
header inline (no new npm dep), computes a sample-frame-aligned
time→byte mapping (linear for PCM), then issues the slice Range
request. Hand-rolled WAV parse rejects non-PCM compression codes
(byte-range strategy only works for uncompressed PCM).

## Validation guards

- `startSec >= 0` + finite
- `endSec > startSec` + finite
- `audioUrl` host == `storage.vapi.ai` over `https` (allow-list — descriptor
  ships to external services downstream; never trust arbitrary URL)
- window `<= MAX_SLICE_SECONDS` (180 — IELTS Part 2 monologue + buffer)

## Out of scope

- No new Prisma migration (Story B's recon: VAPI URLs are on `Call.recordingUrl`)
- No `Session.metadata.phaseBoundaries` writes (Story C's lane)
- No vendor adapter (Story F's lane)
- No route exposing this to the prosody service (Story E)
- No FFmpeg-in-Docker change (deferred to a follow-on PR if codec-agnostic
  slicing or transcoding becomes a requirement — must update
  `docs/CLOUD-DEPLOYMENT.md` in same PR per CI/Docs Parity)

## Files added

- `apps/admin/lib/voice/audio-slice.ts` — helper (`extractAudioSlice`,
  `parseWavHeader`, `timeToByteOffset`, `AudioSliceError`, `MAX_SLICE_SECONDS`,
  `AudioSlice` / `AudioSliceOptions` / `WavFormat` types) [verified]
- `apps/admin/tests/lib/voice/audio-slice.test.ts` — 21 vitests [verified]
- `docs/decisions/2026-06-17-audio-slice-strategy.md` — ADR [verified]
- `.ratchet.json` — bumped `tsc_errors` 36 → 40 to match drifted main baseline
  (no audio-slice errors; 4 pre-existing errors on main `64f41a6c` from
  unrelated PRs)

## Verified by

- **Strategy probe (verify-before-fix per `.claude/rules/verify-before-fix.md`):**
  - Local Mac ffmpeg: `which ffmpeg` → Exit code 1, "ffmpeg not found"
  - Dockerfile probe: `grep -i ffmpeg apps/admin/Dockerfile` → no install line [probed]
  - package.json deps: `grep -E "ffmpeg|wavefile|node-wav" apps/admin/package.json` → none [probed]
  - VAPI HEAD: `curl -sI <sample-wav>` → `accept-ranges: bytes`, `content-length: 4640684`, `content-type: audio/wav`
  - VAPI Range: `curl -sI -H "Range: bytes=0-65535" <sample-wav>` →
    `HTTP/2 206 Partial Content`, `content-range: bytes 0-65535/4640684`
- **Tests (file-scoped):** `./node_modules/.bin/vitest run tests/lib/voice/audio-slice.test.ts`
  → 20 passed, 1 skipped (opt-in network), 0 failed in 1.65s
- **Tests (opt-in real network):** `RUN_NETWORK_TESTS=1 ./node_modules/.bin/vitest run …`
  → 21 passed, 0 failed in 2.19s (real 30s slice fetched from VAPI in 1.37s
  — confirms 206 + correct buffer length within one PCM frame of expected)
- **Sibling regression:** `./node_modules/.bin/vitest run tests/lib/voice/`
  → 44 files, 403 passed, 1 skipped, 0 failed in 12.50s
- **Type-check (file-scoped):** `cd apps/admin && npx tsc --noEmit | grep -E "audio-slice"`
  → empty (0 errors in new files)
- **Type-check (total):** branch shows 40 errors, identical to main
  (`64f41a6c`) — `.ratchet.json` bumped from stale 36 to actual 40
- **Lattice survey** (per `.claude/rules/lattice-survey.md`): NOT REQUIRED.
  The helper touches no shared DB column (read-only network helper), no
  chain-stage boundary (sits BETWEEN Story C's phase-boundary write and
  Story E's PROSODY_AUDIO route, both separately covered), no new
  spec/contract/guard (pure helper + ADR), no AI write/read path, and no
  cascade-eligible knob. Greenfield helper with disjoint surface from
  Stories B/C/E [inverse-probe: `grep -rn "audio-slice" apps/admin/lib apps/admin/app` → 0 callers, as expected for a story-D-only helper Story E will adopt]

## Test plan

- [x] Validation rejects all 7 invalid input shapes (negative start, zero/negative
      window, NaN, oversize window, http, non-allowlist host, malformed URL)
- [x] WAV header parse: standard 16 kHz mono PCM, short buffer, non-RIFF magic,
      non-PCM compression code
- [x] Time→byte map: 0s / 1s / 30s linear, stereo frame-alignment,
      clamp-beyond-data-end
- [x] Mocked fetch happy path: two Range requests (header + slice), correct
      byte range, returns format + buffer
- [x] Mocked fetch error paths: 5xx on header, 416 on slice
- [x] Real network probe (opt-in): 30s slice from real VAPI URL → 206 +
      buffer length matches expected within one PCM frame