### PR TITLE
feat(voice): #1762 Story C — phase boundary persistence

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 36,
+  "tsc_errors": 40,
   "lint_errors": 0,
   "lint_warnings": 4489,
   "quarantined_tests": 36,

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -995,8 +995,15 @@ export interface AuthoredModuleSettings {
   closingLine?: string;
   /** One-shot per-module orientation, gated by `orientationShown` on `CallerModuleProgress`. */
   firstTimeOrientationLine?: string;
-  /** Time-keyed tutor/examiner cues, consumed at runtime by the Theme 2 cue scheduler. */
-  scheduledCues?: Array<{ at: number; text: string }>;
+  /**
+   * Time-keyed tutor/examiner cues, consumed at runtime by the Theme 2
+   * cue scheduler. Optional `phase` tag (#1762 Story C) marks the cue
+   * as a phase transition — when the cue fires, the dispatcher writes
+   * a phase boundary into `Session.metadata.phaseBoundaries`. Phase
+   * naming is course-agnostic (IELTS Mock: `"p1"`, `"p2_prep"`,
+   * `"p2_monologue"`, `"p3"`).
+   */
+  scheduledCues?: Array<{ at: number; text: string; phase?: string }>;
   /**
    * #1743 (epic #1700 Theme 2b — Theme 1 extension) — pool of subtle
    * scaffold strings the client-side stall detector picks from when the
@@ -1081,10 +1088,34 @@ export interface SessionScoreDeltas {
   focusDelta?: { parameterSlug: string; delta: number };
 }
 
+/**
+ * Phase boundary captured at runtime by the cue-scheduler when a
+ * phase-tagged cue fires (#1762 Story C). Closed-form boundary —
+ * `endSec` is filled when the NEXT phase transition arrives; while a
+ * phase is still in flight `endSec === startSec` (open boundary).
+ * Reader: `lib/voice/audio-slice.ts` (Story D) uses these to pick
+ * start/end timestamps for an audio slice.
+ *
+ * Phase name convention is course-agnostic — IELTS Mock uses
+ * `"p1" / "p2_prep" / "p2_monologue" / "p3"`; other courses define
+ * their own.
+ */
+export interface PhaseBoundary {
+  phase: string;
+  startSec: number;
+  endSec: number;
+}
+
 export interface SessionMetadata {
   pinnedCard?: PinnedCardContent;
   segmentLabels?: SegmentLabel[];
   scoreDeltas?: SessionScoreDeltas;
   /** Overall band estimate for Mock sessions — mean-of-12, half-band rounded (Theme 6). */
   overallBand?: number;
+  /**
+   * Phase transitions captured at runtime by the cue-scheduler
+   * (#1762 Story C). Append-only; readers depend on monotonic
+   * `startSec` ordering.
+   */
+  phaseBoundaries?: PhaseBoundary[];
 }

--- a/apps/admin/lib/voice/cue-scheduler.ts
+++ b/apps/admin/lib/voice/cue-scheduler.ts
@@ -36,6 +36,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { log } from "@/lib/logger";
 import { getVoiceProvider } from "./provider-factory";
+import { appendPhaseTransition } from "./phase-boundaries";
 import type { SayMessageOptions } from "./types";
 
 const CUE_STATUS = {
@@ -56,6 +57,13 @@ export interface ScheduleCueArgs {
   noInterruption?: boolean;
   queueOnly?: boolean;
   traceId?: string;
+  /**
+   * #1762 Story C — when set, dispatching this cue records a phase
+   * transition in `Session.metadata.phaseBoundaries` via
+   * `appendPhaseTransition`. Non-empty string is treated as the phase
+   * name; falsy / missing means "no phase boundary side-effect".
+   */
+  phase?: string;
 }
 
 export interface ScheduledCue {
@@ -222,6 +230,20 @@ export async function drainDueCues(
         outcome: result.status,
       });
       await markCueTerminal(row.id, CUE_STATUS.fired, result.status);
+      // #1762 Story C — phase-boundary side-effect. Only fires for
+      // cues that carry a `phase` tag; speech-only cues stay zero-cost.
+      // Helper catches its own errors + logs; we await it so the loop
+      // is deterministic for tests, but we NEVER throw out of this
+      // block on persistence failure (the helper returns false, we
+      // continue the drain).
+      const phase = extractPhase(row.options);
+      if (phase && row.callId) {
+        await tryPersistPhaseBoundary({
+          callId: row.callId,
+          phase,
+          scheduledFor: row.scheduledFor,
+        });
+      }
       fired += 1;
     } else if (result.status === "skipped") {
       await markCueTerminal(row.id, CUE_STATUS.skipped, "provider_skipped");
@@ -279,7 +301,72 @@ function serialiseOptions(args: ScheduleCueArgs): Record<string, unknown> {
   if (args.noInterruption !== undefined) out.noInterruption = args.noInterruption;
   if (args.queueOnly !== undefined) out.queueOnly = args.queueOnly;
   if (args.traceId !== undefined) out.traceId = args.traceId;
+  if (typeof args.phase === "string" && args.phase.trim().length > 0) {
+    out.phase = args.phase;
+  }
   return out;
+}
+
+/**
+ * Extract the optional phase tag from a persisted cue's options blob.
+ * Returns null when the row carries no phase (the normal speech-only
+ * case).
+ */
+function extractPhase(options: unknown): string | null {
+  if (!options || typeof options !== "object") return null;
+  const phase = (options as Record<string, unknown>).phase;
+  if (typeof phase !== "string" || phase.trim().length === 0) return null;
+  return phase;
+}
+
+/**
+ * #1762 Story C — best-effort phase-boundary persistence. Looks up
+ * the Session attached to the Call (Call.sessionId, from epic #1338
+ * Session model), computes `startSec` from
+ * `(scheduledFor - Session.startedAt) / 1000`, and appends. Failures
+ * are caught + logged inside `appendPhaseTransition`; this wrapper
+ * adds a second guard to swallow lookup errors (e.g. Call row gone)
+ * so the cue-scheduler drain loop is never derailed.
+ */
+async function tryPersistPhaseBoundary(args: {
+  callId: string;
+  phase: string;
+  scheduledFor: Date;
+}): Promise<void> {
+  try {
+    const call = await prisma.call.findUnique({
+      where: { id: args.callId },
+      select: {
+        sessionId: true,
+        session: { select: { startedAt: true } },
+      },
+    });
+    if (!call?.sessionId || !call.session) {
+      log("system", "voice.cue.phase_boundary_persist_failed", {
+        level: "warn",
+        callId: args.callId,
+        phase: args.phase,
+        reason: "no_session_for_call",
+      });
+      return;
+    }
+    const startedAtMs = call.session.startedAt.getTime();
+    const scheduledMs = args.scheduledFor.getTime();
+    const startSec = Math.max(0, (scheduledMs - startedAtMs) / 1000);
+    await appendPhaseTransition(call.sessionId, {
+      phase: args.phase,
+      startSec,
+      // Open boundary — the NEXT phase-tagged cue closes it.
+      endSec: startSec,
+    });
+  } catch (err) {
+    log("system", "voice.cue.phase_boundary_persist_failed", {
+      level: "warn",
+      callId: args.callId,
+      phase: args.phase,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 function deserialiseOptions(

--- a/apps/admin/lib/voice/phase-boundaries.ts
+++ b/apps/admin/lib/voice/phase-boundaries.ts
@@ -1,0 +1,157 @@
+/**
+ * Phase-boundary persistence helper (#1762 Story C).
+ *
+ * Persists phase transitions into `Session.metadata.phaseBoundaries` as
+ * an append-only list of `{phase, startSec, endSec}` rows. Reader:
+ * `lib/voice/audio-slice.ts` (Story D) uses the boundaries to pick
+ * start/end timestamps for an audio slice.
+ *
+ * Boundary semantics:
+ *   - First call writes `[{phase: P1, startSec: T1, endSec: T1}]` —
+ *     `endSec === startSec` signals an **open** boundary (phase still
+ *     in flight).
+ *   - Second call (different phase) closes the previous boundary by
+ *     setting its `endSec` to the new `startSec`, then appends the new
+ *     open boundary.
+ *   - A second call with the SAME phase name as the last open boundary
+ *     is a no-op (idempotent — duplicate webhook delivery / re-fired
+ *     cue won't double-close or duplicate the row).
+ *
+ * Lattice survey notes — `Session.metadata` siblings:
+ *   - `pinnedCard` (Theme 3 / `create-session.ts:241`) — written ONCE at
+ *     session-start; not racing with us.
+ *   - `segmentLabels` (Theme 6) — written by compose/section-loaders.
+ *   - `scoreDeltas`, `overallBand` (Theme 11) — written by pipeline
+ *     post-write.
+ *   None overlap with our `phaseBoundaries` key. We always merge into
+ *   the existing object — never replace.
+ *
+ * Concurrency: the helper is best-effort. Two concurrent cue-fires
+ * could observe the same `metadata` snapshot and race; the second
+ * write wins and may drop one boundary. This is acceptable for Story
+ * C — audio slicing is forensic, not runtime-critical. A future hard
+ * variant would use a `WHERE jsonb @> '{boundariesVersion: N}'`
+ * row-lock; out of scope today.
+ *
+ * Error handling: prisma failures are caught + logged via AppLog
+ * subject `voice.cue.phase_boundary_persist_failed`. Caller (the
+ * cue-scheduler drain loop) keeps running.
+ *
+ * See `docs/decisions/2026-06-16-voice-say-message-primitive.md` for
+ * the parent ADR and `lib/voice/transcript-detailed.ts` for the Story
+ * B sibling `{startSec, endSec}` shape.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { log } from "@/lib/logger";
+import type { PhaseBoundary, SessionMetadata } from "@/lib/types/json-fields";
+
+export interface AppendPhaseTransitionArgs {
+  /** Required — non-empty phase name (e.g. `"p1"`, `"p2_prep"`). */
+  phase: string;
+  /** Seconds from session start. Non-negative finite number. */
+  startSec: number;
+  /**
+   * Seconds from session start for the END of the new phase. When
+   * unknown at append time, callers pass the same value as `startSec`
+   * (open boundary — to be closed by the next transition).
+   */
+  endSec: number;
+}
+
+/**
+ * Append a phase transition to `Session.metadata.phaseBoundaries`.
+ *
+ * Returns `true` when the metadata was written (or the call was a
+ * no-op same-phase idempotence absorption — both signal "we handled
+ * it without error"). Returns `false` when validation or persistence
+ * failed; the cue-scheduler MUST NOT throw on a false return.
+ */
+export async function appendPhaseTransition(
+  sessionId: string,
+  args: AppendPhaseTransitionArgs,
+): Promise<boolean> {
+  // Conservative input validation. The cue-scheduler calls us with
+  // values it stitched from JSON columns + wall-clock arithmetic —
+  // garbage in must not corrupt the metadata bag.
+  if (!sessionId || typeof sessionId !== "string") return false;
+  if (!args.phase || typeof args.phase !== "string" || args.phase.trim().length === 0) {
+    return false;
+  }
+  if (typeof args.startSec !== "number" || !Number.isFinite(args.startSec) || args.startSec < 0) {
+    return false;
+  }
+  if (typeof args.endSec !== "number" || !Number.isFinite(args.endSec) || args.endSec < args.startSec) {
+    return false;
+  }
+
+  try {
+    const row = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { metadata: true },
+    });
+    if (!row) {
+      log("system", "voice.cue.phase_boundary_persist_failed", {
+        level: "warn",
+        sessionId,
+        reason: "session_not_found",
+      });
+      return false;
+    }
+
+    const existing = (row.metadata ?? {}) as SessionMetadata;
+    const boundaries: PhaseBoundary[] = Array.isArray(existing.phaseBoundaries)
+      ? [...existing.phaseBoundaries]
+      : [];
+    const last = boundaries.length > 0 ? boundaries[boundaries.length - 1] : null;
+
+    // Idempotence: re-firing the same phase doesn't double-append.
+    // The cue-scheduler's at-least-once dispatch (combined with the
+    // cue-scheduler-runner overlap guard) can re-enter this helper
+    // for the same logical transition.
+    if (last && last.phase === args.phase) {
+      return true;
+    }
+
+    // Close the previous open boundary by stamping its endSec at the
+    // new boundary's startSec. The previous row's startSec is
+    // preserved.
+    if (last) {
+      boundaries[boundaries.length - 1] = {
+        ...last,
+        endSec: args.startSec,
+      };
+    }
+
+    boundaries.push({
+      phase: args.phase,
+      startSec: args.startSec,
+      endSec: args.endSec,
+    });
+
+    const nextMetadata: SessionMetadata = {
+      ...existing,
+      phaseBoundaries: boundaries,
+    };
+
+    await prisma.session.update({
+      where: { id: sessionId },
+      // Cast: the SessionMetadata interface is structural; Prisma's
+      // generated Json type accepts plain objects but TS doesn't
+      // recognise our SessionMetadata as a structural subtype until
+      // the generated client is regenerated. Same pattern as
+      // create-session.ts:241.
+      data: { metadata: nextMetadata as unknown as object },
+    });
+
+    return true;
+  } catch (err) {
+    log("system", "voice.cue.phase_boundary_persist_failed", {
+      level: "warn",
+      sessionId,
+      phase: args.phase,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/apps/admin/lib/voice/register-module-cues.ts
+++ b/apps/admin/lib/voice/register-module-cues.ts
@@ -116,6 +116,12 @@ export async function registerModuleScheduledCues(
       callId: args.callId,
       scheduledFor: new Date(baseMs + cue.at * 1000),
       content: cue.text,
+      // #1762 Story C — phase tag (optional) flows through to the
+      // CueScheduleEntry row; the dispatcher writes a Session.metadata
+      // boundary when the cue fires.
+      ...(typeof cue.phase === "string" && cue.phase.trim().length > 0
+        ? { phase: cue.phase }
+        : {}),
     });
     registered += 1;
   }

--- a/apps/admin/tests/lib/voice/phase-boundaries.test.ts
+++ b/apps/admin/tests/lib/voice/phase-boundaries.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for lib/voice/phase-boundaries.ts (#1762 Story C).
+ *
+ * Pinned acceptance:
+ *   1. Empty metadata + first append → one open boundary {phase, startSec, endSec=startSec}
+ *   2. Second append (different phase) → previous closed (endSec = new startSec) + new appended
+ *   3. Sibling keys (e.g. pinnedCard) on existing metadata are preserved
+ *   4. Same-phase re-append is a no-op (idempotence)
+ *   5. Invalid inputs (empty sessionId / phase / negative startSec / endSec < startSec) return false
+ *   6. Session not found returns false + logs
+ *   7. prisma.session.update throws → helper catches, logs, returns false
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, mockLog } = vi.hoisted(() => ({
+  mockPrisma: {
+    session: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+  mockLog: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/logger", () => ({ log: mockLog }));
+
+import { appendPhaseTransition } from "@/lib/voice/phase-boundaries";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.session.findUnique.mockReset();
+  mockPrisma.session.update.mockReset();
+  mockLog.mockReset();
+});
+
+describe("appendPhaseTransition", () => {
+  it("writes the first boundary as an open boundary on empty metadata", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue({ metadata: null });
+    mockPrisma.session.update.mockResolvedValue({});
+
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "p1",
+      startSec: 0,
+      endSec: 0,
+    });
+
+    expect(ok).toBe(true);
+    expect(mockPrisma.session.update).toHaveBeenCalledTimes(1);
+    const callArgs = mockPrisma.session.update.mock.calls[0][0];
+    expect(callArgs.where).toEqual({ id: "sess-1" });
+    expect(callArgs.data.metadata.phaseBoundaries).toEqual([
+      { phase: "p1", startSec: 0, endSec: 0 },
+    ]);
+  });
+
+  it("closes the previous boundary and appends the new one", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue({
+      metadata: {
+        phaseBoundaries: [{ phase: "p1", startSec: 0, endSec: 0 }],
+      },
+    });
+    mockPrisma.session.update.mockResolvedValue({});
+
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "p2_prep",
+      startSec: 240,
+      endSec: 240,
+    });
+
+    expect(ok).toBe(true);
+    const written = mockPrisma.session.update.mock.calls[0][0].data.metadata.phaseBoundaries;
+    expect(written).toEqual([
+      { phase: "p1", startSec: 0, endSec: 240 },
+      { phase: "p2_prep", startSec: 240, endSec: 240 },
+    ]);
+  });
+
+  it("preserves sibling metadata keys through the round-trip", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue({
+      metadata: {
+        pinnedCard: { kind: "cueCard", topic: "your hometown", bullets: ["a", "b"] },
+        overallBand: 6.5,
+        phaseBoundaries: [{ phase: "p1", startSec: 0, endSec: 0 }],
+      },
+    });
+    mockPrisma.session.update.mockResolvedValue({});
+
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "p2_prep",
+      startSec: 240,
+      endSec: 240,
+    });
+
+    expect(ok).toBe(true);
+    const written = mockPrisma.session.update.mock.calls[0][0].data.metadata;
+    expect(written.pinnedCard).toEqual({
+      kind: "cueCard",
+      topic: "your hometown",
+      bullets: ["a", "b"],
+    });
+    expect(written.overallBand).toBe(6.5);
+    expect(written.phaseBoundaries).toHaveLength(2);
+  });
+
+  it("is idempotent — same phase re-append does not double-close or duplicate", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue({
+      metadata: {
+        phaseBoundaries: [
+          { phase: "p1", startSec: 0, endSec: 240 },
+          { phase: "p2_prep", startSec: 240, endSec: 240 },
+        ],
+      },
+    });
+
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "p2_prep",
+      startSec: 245,
+      endSec: 245,
+    });
+
+    expect(ok).toBe(true);
+    // Idempotence: no update should be issued — the metadata is
+    // unchanged because the last boundary is already the same phase.
+    expect(mockPrisma.session.update).not.toHaveBeenCalled();
+  });
+
+  it("returns false on invalid sessionId", async () => {
+    const ok = await appendPhaseTransition("", { phase: "p1", startSec: 0, endSec: 0 });
+    expect(ok).toBe(false);
+    expect(mockPrisma.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns false on empty phase name", async () => {
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "   ",
+      startSec: 0,
+      endSec: 0,
+    });
+    expect(ok).toBe(false);
+    expect(mockPrisma.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns false on negative startSec", async () => {
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "p1",
+      startSec: -5,
+      endSec: 0,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("returns false when endSec < startSec", async () => {
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "p1",
+      startSec: 100,
+      endSec: 50,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("returns false + logs when session row is missing", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(null);
+
+    const ok = await appendPhaseTransition("sess-missing", {
+      phase: "p1",
+      startSec: 0,
+      endSec: 0,
+    });
+
+    expect(ok).toBe(false);
+    expect(mockPrisma.session.update).not.toHaveBeenCalled();
+    expect(mockLog).toHaveBeenCalledWith(
+      "system",
+      "voice.cue.phase_boundary_persist_failed",
+      expect.objectContaining({ sessionId: "sess-missing", reason: "session_not_found" }),
+    );
+  });
+
+  it("catches prisma.session.update errors, logs, and returns false", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue({ metadata: null });
+    mockPrisma.session.update.mockRejectedValue(new Error("db down"));
+
+    const ok = await appendPhaseTransition("sess-1", {
+      phase: "p1",
+      startSec: 0,
+      endSec: 0,
+    });
+
+    expect(ok).toBe(false);
+    expect(mockLog).toHaveBeenCalledWith(
+      "system",
+      "voice.cue.phase_boundary_persist_failed",
+      expect.objectContaining({
+        sessionId: "sess-1",
+        phase: "p1",
+        error: "db down",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `lib/voice/phase-boundaries.ts::appendPhaseTransition(sessionId, {phase, startSec, endSec})` — a chokepoint that writes per-session phase boundaries into `Session.metadata.phaseBoundaries: Array<{phase, startSec, endSec}>`. Reader: `lib/voice/audio-slice.ts` (Story D, sibling worktree) uses these to pick start/end timestamps for an audio slice.
- Extends `SessionMetadata` (`lib/types/json-fields.ts:1084-1118`) with the new optional `phaseBoundaries` key and `PhaseBoundary` interface. No schema migration — `Session.metadata Json?` column landed in epic #1700 Migration A.
- Wires the helper into the cue-scheduler advance path: optional `phase?: string` on `AuthoredModuleSettings.scheduledCues[]` flows through `scheduleCue` → `CueScheduleEntry.options.phase` → the `fired` branch of `drainDueCues` (`lib/voice/cue-scheduler.ts:222-241`). When a phase-tagged cue fires, the dispatcher looks up `Call.sessionId` + `Session.startedAt`, computes `startSec = (scheduledFor - startedAt) / 1000`, and calls `appendPhaseTransition`. Speech-only cues stay zero-cost.

## Boundary semantics

- First call → one open boundary (`endSec === startSec`).
- Second call (different phase) → previous boundary closed at the new `startSec`; new open boundary appended.
- Same-phase re-append → no-op (idempotent — the cue scheduler is at-least-once + has an overlap-tick guard, so a phase-tagged cue can re-enter the dispatcher for the same logical transition).

## Error handling

- Helper catches its own prisma errors + invalid inputs and returns `false`. The cue-scheduler drain loop is NEVER derailed by a metadata write — failures emit AppLog subject `voice.cue.phase_boundary_persist_failed` and the next cue continues.

## Lattice survey — `Session.metadata` sibling-writer scan

Per `.claude/rules/lattice-survey.md` requirement before mutating a shared Json column [verified]:

| Sibling key | Writer | Timing | Race risk |
|---|---|---|---|
| `pinnedCard` (Theme 3) | `lib/voice/create-session.ts:241` | Once at session-start, inside session.create | None — write happens before any cue can fire |
| `segmentLabels` (Theme 6) | section-loaders | Compose path | Different lifecycle stage; distinct key |
| `scoreDeltas` / `overallBand` (Theme 11) | pipeline post-write | After endSession | Different lifecycle; distinct keys |
| `phaseBoundaries` (this PR) | cue-scheduler `fired` branch | Mid-session, runtime | Self-only — helper always merges via `{ ...existing, phaseBoundaries: ... }` so sibling keys are preserved (pinned by vitest case 3) |

No sibling-writer convergence design needed — the helper is the only writer of `phaseBoundaries` and never touches other keys.

## Verified by

- 10/10 new vitests green: `apps/admin/tests/lib/voice/phase-boundaries.test.ts` covers empty / second-append / sibling preservation / idempotence / 4 invalid-input shapes / missing-session / prisma-throw [file:line]
- Full voice bank: 393/393 across 44 files (`tests/lib/voice/`) — zero regressions. Includes existing `cue-scheduler.test.ts` (11/11) + `register-module-cues.test.ts` (8/8) which exercise the modified files [verified]
- `npx tsc --noEmit` clean on every touched file (`phase-boundaries.ts`, `cue-scheduler.ts`, `register-module-cues.ts`, `json-fields.ts`) — pre-existing tsc baseline of 40 untouched [verified]
- Schema-coverage test (`tests/lib/journey/registry-schema-coverage`) 6/6 green — `phaseBoundaries` lives on `SessionMetadata` not `PlaybookConfig`, so no `EXPECTED_SCHEMA_PATHS` entry required [verified]
- Cue-scheduler dispatch shape probed at `apps/admin/lib/voice/cue-scheduler.ts:179-241` — the `fired` branch is the natural hook (after provider returns `spoken`/`queued`; before status mark). Confirmed `row.scheduledFor` + `row.callId` available at that point [file:line]
- Story B sibling shape at `apps/admin/lib/voice/transcript-detailed.ts:19-24` (`DetailedTurn`) — same `{startSec: number, endSec: number}` numeric convention reused for `PhaseBoundary` so Story D's audio-slicer can window across both [file:line]
- Ratchet bump (`chore(ratchet): align worktree tsc baseline...`) confirmed against `origin/main:.ratchet.json` which already shipped at 40 post-#1862 [verified]

## Test plan

- [x] Unit tests for `appendPhaseTransition` (10 cases)
- [x] Full voice-bank regression (393/393)
- [x] Type-check clean on touched files
- [ ] Live verification on hf-dev deferred to Story D's integration — boundaries are forensic, not runtime-critical; no learner-visible behaviour today

Closes part of #1762 (Story C). Story D's `audio-slice.ts` (sibling worktree) consumes `Session.metadata.phaseBoundaries` via the `{startSec, endSec}` half-open windowing pattern already established by `turnsInWindow` in Story B's `transcript-detailed.ts`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>