### PR TITLE
feat(course-detail): P1 — wire Inspector into Teaching tab (#1850)

### DIFF
--- a/apps/admin/components/scoring-tab/CourseScoringTab.tsx
+++ b/apps/admin/components/scoring-tab/CourseScoringTab.tsx
@@ -1,18 +1,23 @@
 "use client";
 
 /**
- * CourseScoringTab — Track C P0 shell of the Journey-Design tab refactor.
+ * CourseScoringTab — Track C P1 of the Journey-Design tab refactor (epic #1850).
  *
  * Mounts the tri-pane DesignerShell with the 2 scoring buckets in the
  * LH (I_scoring, K_between_calls).
  *
- * This is a SHELL — Inspector slot is a placeholder until P1 wires the
- * actual `JourneyInspectorPanel` (or the per-tab variant TBD).
+ * P1 (this PR): the Inspector slot mounts the real `JourneyInspectorPanel`
+ * — same component the Journey + Teaching tabs use. The ScoringLhMenu
+ * already filters by `BUCKETS_BY_TAB.scoring`, so the educator can only
+ * navigate to buckets intended for this tab; the Inspector then renders
+ * the bucket's settings via `getSettingsForBucket(bucketId)`. Mirror of
+ * `CourseTeachingTab.tsx`.
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspectorPanel";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
@@ -21,7 +26,7 @@ import { ScoringLhMenu } from "./ScoringLhMenu";
 
 interface CourseScoringTabProps {
   courseId: string;
-  playbookConfig?: Record<string, unknown> | null;
+  playbookConfig: Record<string, unknown> | null;
 }
 
 export function CourseScoringTab({
@@ -31,11 +36,36 @@ export function CourseScoringTab({
   const [selectedId, setSelectedId] = useState<JourneyMenuBucketId | null>(
     null,
   );
+  // Tab-local override of the parent's playbookConfig — mirrors the
+  // Journey + Teaching tabs' stale-read cure. Refetched after each save
+  // via the provider's `onCompoundSaved` callback.
+  const [localConfig, setLocalConfig] = useState<
+    Record<string, unknown> | null
+  >(playbookConfig);
+  useEffect(() => {
+    setLocalConfig(playbookConfig);
+  }, [playbookConfig]);
+  const refetchPlaybookConfig = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/playbooks/${courseId}`);
+      if (!res.ok) return;
+      const body = (await res.json()) as {
+        ok?: boolean;
+        playbook?: { config?: Record<string, unknown> | null };
+      };
+      if (body.ok && body.playbook) {
+        setLocalConfig(body.playbook.config ?? null);
+      }
+    } catch {
+      // Best-effort — see CourseTeachingTab.tsx for the rationale.
+    }
+  }, [courseId]);
 
   return (
     <JourneySettingMutatorProvider
       courseId={courseId}
-      playbookConfig={playbookConfig ?? null}
+      playbookConfig={localConfig}
+      onCompoundSaved={refetchPlaybookConfig}
     >
       <DesignerShell
         nav={
@@ -46,17 +76,7 @@ export function CourseScoringTab({
           />
         }
         canvas={<PreviewLens courseId={courseId} suppressSidetray />}
-        inspector={
-          selectedId ? (
-            // TODO(P1): replace placeholder with the bucket-aware
-            // JourneyInspectorPanel (or a Scoring-tab variant). For
-            // now the panel just confirms the selection wired through.
-            <div className="hf-card hf-card-compact">
-              Inspector slot — wires up post-P0. Selected bucket:{" "}
-              <code>{selectedId}</code>.
-            </div>
-          ) : null
-        }
+        inspector={<JourneyInspectorPanel selectedBucketId={selectedId} />}
       />
     </JourneySettingMutatorProvider>
   );

--- a/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
+++ b/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
@@ -1,20 +1,31 @@
 "use client";
 
 /**
- * CourseTeachingTab — Track C P0 shell of the Journey-Design tab refactor.
+ * CourseTeachingTab — Track C P1 of the Journey-Design tab refactor (epic #1850).
  *
  * Mounts the tri-pane DesignerShell with the 4 teaching buckets in the
  * LH (C_teaching_style, E_learner_visual, F_stall_recovery, J_feedback).
  *
- * This is a SHELL — Inspector slot is a placeholder until P1 wires the
- * actual `JourneyInspectorPanel` (or the per-tab variant TBD). The canvas
- * is the existing `<PreviewLens>` so educators see real prompt content
- * underneath while we iterate on the menus.
+ * P1 (this PR): the Inspector slot mounts the real `JourneyInspectorPanel`
+ * — the same component the Journey tab uses (see
+ * `components/journey-tab/CourseJourneyTab.tsx`). The Inspector reads its
+ * stack of settings via `getSettingsForBucket(bucketId)`, which is
+ * bucket-scoped — clicking a Teaching bucket only ever exposes settings
+ * in that bucket. The TeachingLhMenu already filters by
+ * `BUCKETS_BY_TAB.teaching`, so the educator can only navigate to buckets
+ * intended for this tab. No per-tab Inspector variant needed.
+ *
+ * Like the Journey tab, the tab seeds a local copy of `playbookConfig` so
+ * the Inspector + EditAsJsonButton read freshly-saved state without
+ * waiting on a parent route change. After a save, the provider's
+ * `onCompoundSaved` callback refetches `/api/playbooks/<id>` and replaces
+ * the local snapshot.
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspectorPanel";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
@@ -23,7 +34,7 @@ import { TeachingLhMenu } from "./TeachingLhMenu";
 
 interface CourseTeachingTabProps {
   courseId: string;
-  playbookConfig?: Record<string, unknown> | null;
+  playbookConfig: Record<string, unknown> | null;
 }
 
 export function CourseTeachingTab({
@@ -33,11 +44,39 @@ export function CourseTeachingTab({
   const [selectedId, setSelectedId] = useState<JourneyMenuBucketId | null>(
     null,
   );
+  // Tab-local override of the parent's playbookConfig — mirrors the
+  // Journey tab's stale-read cure (CourseJourneyTab.tsx). Seeded from
+  // the prop on mount/prop-change; replaced after each save via the
+  // provider's `onCompoundSaved` callback below.
+  const [localConfig, setLocalConfig] = useState<
+    Record<string, unknown> | null
+  >(playbookConfig);
+  useEffect(() => {
+    setLocalConfig(playbookConfig);
+  }, [playbookConfig]);
+  const refetchPlaybookConfig = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/playbooks/${courseId}`);
+      if (!res.ok) return;
+      const body = (await res.json()) as {
+        ok?: boolean;
+        playbook?: { config?: Record<string, unknown> | null };
+      };
+      if (body.ok && body.playbook) {
+        setLocalConfig(body.playbook.config ?? null);
+      }
+    } catch {
+      // Best-effort — the parent will pick up the new value on next
+      // route change. Don't surface the network error; the save itself
+      // already succeeded.
+    }
+  }, [courseId]);
 
   return (
     <JourneySettingMutatorProvider
       courseId={courseId}
-      playbookConfig={playbookConfig ?? null}
+      playbookConfig={localConfig}
+      onCompoundSaved={refetchPlaybookConfig}
     >
       <DesignerShell
         nav={
@@ -48,17 +87,7 @@ export function CourseTeachingTab({
           />
         }
         canvas={<PreviewLens courseId={courseId} suppressSidetray />}
-        inspector={
-          selectedId ? (
-            // TODO(P1): replace placeholder with the bucket-aware
-            // JourneyInspectorPanel (or a Teaching-tab variant). For
-            // now the panel just confirms the selection wired through.
-            <div className="hf-card hf-card-compact">
-              Inspector slot — wires up post-P0. Selected bucket:{" "}
-              <code>{selectedId}</code>.
-            </div>
-          ) : null
-        }
+        inspector={<JourneyInspectorPanel selectedBucketId={selectedId} />}
       />
     </JourneySettingMutatorProvider>
   );

--- a/apps/admin/tests/components/scoring-tab/CourseScoringTab.test.tsx
+++ b/apps/admin/tests/components/scoring-tab/CourseScoringTab.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  within,
+} from "@testing-library/react";
+
+// jsdom doesn't ship matchMedia; DesignerShell uses it for the narrow-
+// viewport drawer behaviour. Stub once for the file.
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+import { CourseScoringTab } from "@/components/scoring-tab/CourseScoringTab";
+
+vi.mock("@/app/x/courses/[courseId]/_components/PreviewLens", () => ({
+  PreviewLens: () => <div data-testid="hf-mock-preview-lens" />,
+}));
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({}),
+  } as Response),
+);
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockClear();
+});
+
+describe("CourseScoringTab — P1 (#1850) Inspector wiring", () => {
+  it("mounts the empty-state Inspector when no bucket is selected", () => {
+    render(<CourseScoringTab courseId="c1" playbookConfig={{}} />);
+    expect(
+      screen.getByTestId("hf-journey-inspector-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders only Scoring-tab buckets in the LH menu", () => {
+    render(<CourseScoringTab courseId="c1" playbookConfig={{}} />);
+    // BUCKETS_BY_TAB.scoring = [I_scoring, K_between_calls].
+    expect(
+      screen.getByTestId("hf-scoring-bucket-row-I_scoring"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-scoring-bucket-row-K_between_calls"),
+    ).toBeInTheDocument();
+    // Teaching + Journey buckets do not leak in.
+    expect(
+      screen.queryByTestId("hf-scoring-bucket-row-C_teaching_style"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("hf-scoring-bucket-row-A_intake"),
+    ).toBeNull();
+  });
+
+  it("clicking a Scoring bucket mounts the real Inspector with that bucket's stack", () => {
+    render(<CourseScoringTab courseId="c1" playbookConfig={{}} />);
+    fireEvent.click(
+      screen.getByTestId("hf-scoring-bucket-row-I_scoring"),
+    );
+    const inspectorRoot = screen.getByTestId(
+      "hf-journey-inspector-bucket-I_scoring",
+    );
+    expect(inspectorRoot).toBeInTheDocument();
+    // Header copy from JOURNEY_MENU_ITEMS_BY_ID for I_scoring, scoped
+    // to the Inspector container (LH menu uses the same label).
+    expect(
+      within(inspectorRoot).getByText(/How learners are scored/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the old P0 placeholder text once wired", () => {
+    render(<CourseScoringTab courseId="c1" playbookConfig={{}} />);
+    fireEvent.click(
+      screen.getByTestId("hf-scoring-bucket-row-I_scoring"),
+    );
+    expect(
+      screen.queryByText(/Inspector slot — wires up post-P0/),
+    ).toBeNull();
+  });
+});

--- a/apps/admin/tests/components/teaching-tab/CourseTeachingTab.test.tsx
+++ b/apps/admin/tests/components/teaching-tab/CourseTeachingTab.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  within,
+} from "@testing-library/react";
+
+// jsdom doesn't ship matchMedia; DesignerShell uses it for the narrow-
+// viewport drawer behaviour. Stub once for the file (mirrors
+// `tests/components/designer-shell.test.tsx`).
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+import { CourseTeachingTab } from "@/components/teaching-tab/CourseTeachingTab";
+
+// Mock PreviewLens — it pulls in fetch + composition pipeline state that
+// the tab-level mount test doesn't need to exercise (the journey-tab
+// sibling tests follow the same shape: test the Inspector wiring, not
+// the canvas).
+vi.mock("@/app/x/courses/[courseId]/_components/PreviewLens", () => ({
+  PreviewLens: () => <div data-testid="hf-mock-preview-lens" />,
+}));
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({}),
+  } as Response),
+);
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockClear();
+});
+
+describe("CourseTeachingTab — P1 (#1850) Inspector wiring", () => {
+  it("mounts the empty-state Inspector when no bucket is selected", () => {
+    render(<CourseTeachingTab courseId="c1" playbookConfig={{}} />);
+    // JourneyInspectorPanel renders this testid when selectedBucketId is null.
+    expect(
+      screen.getByTestId("hf-journey-inspector-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders only Teaching-tab buckets in the LH menu", () => {
+    render(<CourseTeachingTab courseId="c1" playbookConfig={{}} />);
+    // BUCKETS_BY_TAB.teaching = [C_teaching_style, E_learner_visual,
+    // F_stall_recovery, J_feedback]. All 4 rows present.
+    expect(
+      screen.getByTestId("hf-teaching-bucket-row-C_teaching_style"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-teaching-bucket-row-E_learner_visual"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-teaching-bucket-row-F_stall_recovery"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-teaching-bucket-row-J_feedback"),
+    ).toBeInTheDocument();
+    // Journey-tab buckets (A_intake, B_call1_opening etc.) must NOT
+    // leak into the teaching LH.
+    expect(
+      screen.queryByTestId("hf-teaching-bucket-row-A_intake"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("hf-teaching-bucket-row-B_call1_opening"),
+    ).toBeNull();
+  });
+
+  it("clicking a Teaching bucket mounts the real Inspector with that bucket's stack", () => {
+    render(<CourseTeachingTab courseId="c1" playbookConfig={{}} />);
+    fireEvent.click(
+      screen.getByTestId("hf-teaching-bucket-row-C_teaching_style"),
+    );
+    // JourneyInspectorPanel mounts the bucket container — proves we're
+    // running the real component (not the prior <div>Inspector slot…</div>
+    // P0 placeholder, which carried no such testid).
+    const inspectorRoot = screen.getByTestId(
+      "hf-journey-inspector-bucket-C_teaching_style",
+    );
+    expect(inspectorRoot).toBeInTheDocument();
+    // And the header copy from JOURNEY_MENU_ITEMS_BY_ID, scoped to the
+    // Inspector container (the LH menu uses the same label string).
+    expect(
+      within(inspectorRoot).getByText(/How the tutor teaches every call/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the old P0 placeholder text once wired", () => {
+    render(<CourseTeachingTab courseId="c1" playbookConfig={{}} />);
+    fireEvent.click(
+      screen.getByTestId("hf-teaching-bucket-row-F_stall_recovery"),
+    );
+    // The P0 placeholder said "Inspector slot — wires up post-P0"; we
+    // remove that path entirely in P1. The empty-reservation bucket
+    // header (still rendered by the panel for empty IELTS-deferred
+    // buckets) is the expected content.
+    expect(
+      screen.queryByText(/Inspector slot — wires up post-P0/),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

P1 of epic #1850 — replace the P0 placeholder Inspector stub in the new Teaching and Scoring tabs with the real `JourneyInspectorPanel`.

- **Teaching tab** (`apps/admin/components/teaching-tab/CourseTeachingTab.tsx`): swap the `<div>Inspector slot — wires up post-P0</div>` placeholder for `<JourneyInspectorPanel selectedBucketId={selectedId} />`. Add local-snapshot pattern (`localConfig` + `refetchPlaybookConfig` via `onCompoundSaved`) so post-save reads see fresh state — mirrors `components/journey-tab/CourseJourneyTab.tsx:55-78,143-146`.
- **Scoring tab** (`apps/admin/components/scoring-tab/CourseScoringTab.tsx`): identical port. No new design decisions — the bucket-aware Inspector + the LH menu's `BUCKETS_BY_TAB` filter together give Teaching/Scoring tabs Inspector content scoped to their tab without any per-tab variant or filter prop. The Inspector's existing `getSettingsForBucket(bucketId)` body already only stacks settings registered to the clicked bucket.
- Tightened prop type from optional `playbookConfig?:` to required `playbookConfig:` (the `app/x/courses/[courseId]/page.tsx:1746,1753` caller already passes the wider type — see `Record<string, unknown> | null`). This satisfies the `react-hooks/set-state-in-effect` lint rule, which the optional form tripped.

## Test plan

- [x] `npx vitest run tests/components/teaching-tab tests/components/scoring-tab tests/lib/journey/buckets-by-tab` — 13 new tests, all green
- [x] `npx vitest run tests/components/journey-tab tests/components/designer-shell.test.tsx tests/lib/journey` — 165/165 sibling tests still green
- [x] `npx tsc --noEmit` — 40 errors (matches baseline; none in touched files)
- [x] `npm run lint` — 0 errors / 0 new warnings on touched files
- [x] `npm run ratchet:check` — `tsc_errors == baseline`, `lint_errors == baseline`, `quarantined_tests == baseline`. (`lint_warnings: 4490 (+1)` and `memory_md_bytes` drift are pre-existing on `origin/main`, not introduced by this PR — confirmed by re-running ratchet after `git stash -u`.)
- [ ] Manual on hf-dev: open `/x/courses/<id>?tab=teaching` → click each of the 4 teaching buckets → confirm Inspector renders the stack (or empty-reservation copy for IELTS-deferred buckets `E_learner_visual` / `F_stall_recovery`). Same on `?tab=scoring` with the 2 scoring buckets.

## Verified by

- Reference impl: `apps/admin/components/journey-tab/CourseJourneyTab.tsx:179` mounts `<JourneyInspectorPanel selectedBucketId={selection.bucketId} />`; this PR ports the same call shape to `apps/admin/components/teaching-tab/CourseTeachingTab.tsx:85` and `apps/admin/components/scoring-tab/CourseScoringTab.tsx:79`.
- Inspector body: `apps/admin/components/journey-tab/JourneyInspectorPanel.tsx:97` calls `getSettingsForBucket(selectedBucketId)` [verified] — naturally tab-filtered because `apps/admin/components/teaching-tab/TeachingLhMenu.tsx:32` and `apps/admin/components/scoring-tab/ScoringLhMenu.tsx:27` walk `BUCKETS_BY_TAB.teaching` / `.scoring` respectively (`apps/admin/lib/journey/buckets-by-tab.ts:48-49` [verified]). No per-tab Inspector variant required — confirmed by reading the Inspector's filter logic end-to-end.
- Lattice survey: this change is presentational glue (component mount swap). Touches no shared DB column, no chain-stage boundary, no new guard/contract, no AI write/read path. Survey not triggered (see `.claude/rules/lattice-survey.md` "When this applies" criteria).
- Cascade-reuse: not triggered. The Inspector already routes cascade-eligible knobs through `CascadeTraceBreadcrumb` → `useEffectiveValue` (see `apps/admin/components/journey-tab/JourneyInspectorPanel.tsx:56` → `apps/admin/components/journey-tab/CascadeTraceBreadcrumb.tsx`). This PR adds no new cascade reads.
- Registry coverage: this PR adds zero `JourneySettingContract` entries — registry/coverage tests unaffected (re-confirmed by `tests/lib/journey/registry-schema-coverage.test.ts` green in the sibling run).
- Vitests pinning the swap: `tests/components/teaching-tab/CourseTeachingTab.test.tsx` 4 tests (empty-state, LH filter, real-Inspector-on-click via `hf-journey-inspector-bucket-<id>` testid, P0-placeholder-text-gone) + `tests/components/scoring-tab/CourseScoringTab.test.tsx` 4 tests (mirror).

## Notes

- Modules tab (`CourseModulesTab.tsx`) intentionally NOT touched — it uses a different shape (module-picker LHS, module-scoped Inspector). That's P3 work.
- Scoring tab port was mechanical (literal copy with `BUCKETS_BY_TAB.scoring` already wired in the existing `ScoringLhMenu.tsx`) — shipped in this PR.

Epic: #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)
