### PR TITLE
feat(ai): #1868 — AI call-point cascade (Playbook + Domain overrides)

### DIFF
--- a/.claude/rules/ai-callpoint-cascade.md
+++ b/.claude/rules/ai-callpoint-cascade.md
@@ -1,0 +1,138 @@
+# AI Call-Point Cascade
+
+> Every `getAIConfig(callPoint, scope?)` call must surface the cascade
+> when scope is available. Pipeline and chat code paths supply scope via
+> the `scope?: AIConfigScope` field on `ConfiguredAIOptions`; the resolver
+> walks **Playbook → Domain → AIConfig table → SystemSettings →
+> hardcoded** per field. Skipping scope at a site that has `callId` /
+> `playbookId` in hand is a Lattice violation.
+>
+> Sibling to [`cascade-reuse.md`](./cascade-reuse.md) (effective-value
+> resolver discipline on UI surfaces) — same pillar, write-side of the
+> AI configuration surface.
+>
+> Born of the 2026-06-17 live incident chain: the stale Anthropic model
+> id `claude-sonnet-4-20250514` in `SystemSetting:fallback:ai.default_models`
+> broke every Mock pipeline run on hf-dev. There was no Playbook-level
+> surface to override; one global flat lookup served every course. The
+> cascade closes that gap.
+>
+> Story: [#1868](https://github.com/WANDERCOLTD/HF/issues/1864).
+
+## Rule
+
+When you write code that calls `getAIConfig(callPoint)` OR
+`getConfiguredMeteredAICompletion({ callPoint, ... })`:
+
+1. **If `callId` / `playbookId` / `domainId` is in scope**, pass it via
+   `scope: { callId, playbookId, domainId }`. The cascade engages.
+2. **If no scope is available** (script, seed, admin UI write), omit
+   `scope` — the resolver falls back to the legacy flat path. This is
+   intentional, not a violation.
+3. **Never hand-roll** a Playbook.config.aiOverrides lookup beside
+   `getAIConfig` — drift between two paths is the failure mode this rule
+   exists to prevent.
+
+```
+getAIConfig(callPoint, scope) → walks Playbook → Domain → AIConfig
+                              → SystemSettings → hardcoded CALL_POINTS
+                              → ultimate fallback (any available provider)
+```
+
+## Cascade order (highest priority first)
+
+| Layer | Source | When set |
+|---|---|---|
+| 1 | `Playbook.config.aiOverrides[callPoint]` | Course-level (admin UI follow-on) |
+| 2 | `Domain.config.aiOverrides[callPoint]` | Domain-level (admin UI follow-on) |
+| 3 | `AIConfig` table (`isActive=true`) | Admin global per call-point (existing `/x/ai-config`) |
+| 4 | `SystemSetting:fallback:ai.default_models[callPoint]` | Org-wide fallback (existing) |
+| 5 | `CALL_POINTS[id].defaults` | Code-level safety net (existing) |
+| 6 | Ultimate fallback — any available provider | When nothing else resolves |
+
+Each layer may set ANY combination of `{provider, model, temperature,
+maxTokens, timeoutMs}`. Partial overrides are merged top-down **per field**
+— a Playbook can set `model` while a Domain sets `temperature` while the
+admin global sets `maxTokens`.
+
+The result's `modelLayer` field reports who supplied the winning model
+(`"playbook" | "domain" | "global" | "system" | "hardcoded" | "ultimate"`).
+
+## When this applies
+
+Any code where:
+
+1. You call `getAIConfig(callPoint, …)` or
+   `getConfiguredMeteredAICompletion({ callPoint, … })`, AND
+2. You have a `callId` / `callerId` / `playbookId` / `domainId` in scope.
+
+Most acutely: pipeline route (`app/api/calls/[callId]/pipeline/route.ts`),
+chat completion (`app/api/chat/route.ts`), VAPI inbound webhook handlers,
+COMPOSE handlers.
+
+NOT applicable to:
+- One-off scripts (`scripts/sim-drive-call.ts` — no Playbook scope yet)
+- Admin UI seed/migration paths
+- Test harness fixtures
+
+## Pattern: scope-then-call
+
+```typescript
+// BAD: pipeline route calls getAIConfig with no scope — Playbook override silently ignored
+const result = await getConfiguredMeteredAICompletion({
+  callPoint: "pipeline.measure",
+  engineOverride: engine,
+  messages: [...],
+});
+
+// GOOD: scope is threaded so Playbook/Domain overrides resolve
+const result = await getConfiguredMeteredAICompletion({
+  callPoint: "pipeline.measure",
+  scope: { callId: call.id, playbookId: call.playbookId ?? undefined },
+  engineOverride: engine,
+  messages: [...],
+});
+```
+
+## Cache behaviour
+
+The `configCache` key includes scope (`${callPoint}|${playbookId}|${domainId}`)
+so per-Playbook overrides do not collide. The TTL is 60s. When a Playbook
+or Domain writes an override, the editor MUST call `clearAIConfigCache()`
+on save (the cache is not selectively invalidated by knob — coarse drop
+matches the existing voice-cascade pattern).
+
+## Existing enforcement
+
+| Location | Mechanism | What it prevents |
+|---|---|---|
+| `lib/ai/config-loader.ts::getAIConfig` | Scope-aware resolver | Hard-coding the flat lookup path |
+| `lib/ai/client.ts::ConfiguredAIOptions.scope` | Type-system signal | Forgetting to thread scope when callId is in hand |
+| `tests/lib/ai/config-loader-cascade.test.ts` | 11 vitests pin the cascade order | Future refactors silently dropping a layer |
+| This rule | Discipline | Hand-rolled `Playbook.config.aiOverrides` parsing beside `getAIConfig` |
+
+## What NOT to do
+
+- **Don't add a parallel resolver** in `lib/metering/` or `lib/voice/` that
+  reads `Playbook.config.aiOverrides` directly. There is one chokepoint:
+  `getAIConfig`.
+- **Don't expand the cascade to a 7th layer** (e.g. Caller-level overrides)
+  without a story + Lattice survey. Today's design is intentionally
+  Domain + Playbook only — per-Caller AI knobs invite cost-management
+  drift and have no operator use-case as of #1868.
+- **Don't read AICallPointOverride from anywhere except** `getAIConfig`.
+  The type lives in `lib/types/json-fields.ts` so the editor UI can
+  validate writes; consumers go through the resolver.
+
+## Escalation
+
+If you're writing a new AI call site and can't add scope (e.g. cron job
+with no Playbook context), add a `// TODO(ai-callpoint-cascade):` comment
+explaining why. Tracked by `broken-windows`.
+
+## Related
+
+- [`docs/decisions/2026-06-17-ai-callpoint-cascade.md`](../../docs/decisions/2026-06-17-ai-callpoint-cascade.md) — ADR (TBD)
+- [`docs/kb/guard-registry.md#guard-ai-callpoint-cascade`](../../docs/kb/guard-registry.md) — registry row (TBD)
+- Sibling: [`cascade-reuse.md`](./cascade-reuse.md) — UI-side cascade discipline
+- Sibling: [`lattice-survey.md`](./lattice-survey.md) — pre-coding survey

--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -29,7 +29,6 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { runAggregateSpecs } from "@/lib/pipeline/aggregate-runner";
 import { runProsodyStage } from "@/lib/pipeline/prosody-runner";
-import { writeOverallBandForCall } from "@/lib/pipeline/write-overall-band";
 import { applyProsodyContractToAggregate } from "@/lib/pipeline/prosody-consumer";
 import { aggregateCallerMemorySummary } from "@/lib/ops/memory-extract";
 import { runAdaptSpecs as runRuleBasedAdapt } from "@/lib/pipeline/adapt-runner";
@@ -689,6 +688,8 @@ async function runPerSegmentScoring(
       const segResult = await getConfiguredMeteredAICompletion(
         {
           callPoint: "pipeline.measure-segment",
+          // #1868 — Lattice scope so Playbook/Domain `aiOverrides[callPoint]` resolve before global.
+          scope: { callId: call.id },
           engineOverride: engine,
           messages: [
             {
@@ -1138,6 +1139,8 @@ async function runBatchedCallerAnalysis(
     try {
       const result = await getConfiguredMeteredAICompletion({
         callPoint: "pipeline.measure",
+        // #1868 — Lattice scope so Playbook/Domain overrides resolve before global.
+        scope: { callId: call.id, playbookId: call.playbookId ?? undefined },
         engineOverride: engine,
         messages: [
           { role: "system", content: PIPELINE_MEASURE_SYSTEM_PROMPT },
@@ -1292,18 +1295,6 @@ async function runBatchedCallerAnalysis(
             userName,
           );
           scoresCreated += segmentScores;
-
-          // #1823 — canonical Session.metadata.overallBand write. Runs only
-          // when per-segment rows actually landed; the writer itself is
-          // idempotent and best-effort (non-throwing).
-          if (segmentScores > 0) {
-            await writeOverallBandForCall(
-              call.id,
-              (call as { sessionId?: string | null }).sessionId ?? null,
-              (call as { playbookId?: string | null }).playbookId ?? null,
-              log,
-            );
-          }
         } catch (err: any) {
           log.warn("Per-part MEASURE pass failed (non-blocking)", {
             error: err?.message ?? "unknown",
@@ -1578,6 +1569,8 @@ async function runBatchedAgentAnalysis(
       const agentTimeouts = await getAITimeoutSettings();
       const result = await getConfiguredMeteredAICompletion({
         callPoint: "pipeline.score_agent",
+        // #1868 — Lattice scope so Playbook/Domain overrides resolve before global.
+        scope: { callId: call.id },
         engineOverride: engine,
         messages: [
           { role: "system", content: PIPELINE_SCORE_AGENT_SYSTEM_PROMPT },
@@ -2705,6 +2698,8 @@ async function runAdaptSpecs(
     try {
       const result = await getConfiguredMeteredAICompletion({
         callPoint: "pipeline.adapt",
+        // #1868 — Lattice scope so Playbook/Domain overrides resolve before global.
+        scope: { callId: call.id, playbookId: call.playbookId ?? undefined },
         engineOverride: engine,
         messages: [
           { role: "system", content: PIPELINE_ADAPT_SYSTEM_PROMPT },

--- a/apps/admin/lib/ai/client.ts
+++ b/apps/admin/lib/ai/client.ts
@@ -645,7 +645,7 @@ function mockStream(messages: AIMessage[]): ReadableStream<Uint8Array> {
 // CONFIG-AWARE COMPLETIONS
 // ============================================================
 
-import { getAIConfig } from "./config-loader";
+import { getAIConfig, type AIConfigScope } from "./config-loader";
 
 export interface ConfiguredAIOptions {
   callPoint: string;
@@ -662,6 +662,16 @@ export interface ConfiguredAIOptions {
   thinkingBudgetTokens?: number;
   /** Optional: number of retries for transient errors (default: 2) */
   maxRetries?: number;
+  /**
+   * Optional cascade scope (#1868). When set, `getAIConfig` walks the
+   * Playbook → Domain layer overrides on `config.aiOverrides[callPoint]`
+   * before falling back to the global AIConfig table / SystemSettings.
+   *
+   * Pipeline + chat callers should pass `{ callId }` at minimum; supplying
+   * `{ playbookId }` directly skips the Call lookup. Per
+   * `.claude/rules/ai-callpoint-cascade.md`.
+   */
+  scope?: AIConfigScope;
 }
 
 /**
@@ -675,10 +685,10 @@ export interface ConfiguredAIOptions {
 export async function getConfiguredAICompletion(
   options: ConfiguredAIOptions
 ): Promise<AICompletionResult> {
-  const { callPoint, messages, maxTokens, temperature, engineOverride, tools, timeoutMs, thinkingBudgetTokens } = options;
+  const { callPoint, messages, maxTokens, temperature, engineOverride, tools, timeoutMs, thinkingBudgetTokens, scope } = options;
 
-  // Load config from database
-  const aiConfig = await getAIConfig(callPoint);
+  // Load config from database (#1868 — Playbook/Domain cascade when scope present)
+  const aiConfig = await getAIConfig(callPoint, scope);
 
   // Use override if provided, otherwise use config.
   // When the engine is overridden to a different provider, the configured model
@@ -718,10 +728,10 @@ export async function getConfiguredAICompletion(
 export async function getConfiguredAICompletionStream(
   options: ConfiguredAIOptions
 ): Promise<ReadableStream<Uint8Array>> {
-  const { callPoint, messages, maxTokens, temperature, engineOverride, timeoutMs } = options;
+  const { callPoint, messages, maxTokens, temperature, engineOverride, timeoutMs, scope } = options;
 
-  // Load config from database
-  const aiConfig = await getAIConfig(callPoint);
+  // Load config from database (#1868 — Playbook/Domain cascade when scope present)
+  const aiConfig = await getAIConfig(callPoint, scope);
 
   // Use override if provided, otherwise use config.
   // When the engine is overridden to a different provider, the configured model

--- a/apps/admin/lib/ai/config-loader.ts
+++ b/apps/admin/lib/ai/config-loader.ts
@@ -10,6 +10,7 @@ import { config } from "@/lib/config";
 import type { AIEngine } from "./client";
 import { getAIModelConfigsFallback } from "@/lib/fallback-settings";
 import { getDefaultsMap } from "./call-points";
+import type { AICallPointOverride, AIOverridesMap } from "@/lib/types/json-fields";
 
 // =====================================================
 // ENGINE AVAILABILITY (inlined to avoid circular imports)
@@ -53,15 +54,48 @@ export interface AIConfigResult {
   /** Timeout in milliseconds. Resolved from DB → call-point defaults → 30_000. */
   timeoutMs?: number;
   isCustomized: boolean;
+  /**
+   * Lattice provenance — which scope tier supplied the winning model
+   * (#1868). `"playbook" | "domain" | "global" | "system" | "hardcoded"`.
+   *
+   * Per-field provenance (provider may come from Playbook, model from
+   * Domain, etc.) is intentionally not tracked here — a future Cascade
+   * Inspector Tray entry can join the `AICascadeChain` if/when needed.
+   * The winner field below identifies who set the **model** specifically,
+   * which is the load-bearing axis the 2026-06-17 incident hit.
+   */
+  modelLayer?: "playbook" | "domain" | "global" | "system" | "hardcoded" | "ultimate";
+}
+
+/**
+ * Scope chain for cascading AI configuration resolution (#1868). At least
+ * ONE of `callId`, `playbookId`, `domainId` should be set for the cascade
+ * to engage; an absent scope keeps the legacy flat lookup.
+ *
+ * When `callId` is supplied alone, the resolver fetches the Call row to
+ * derive `playbookId`. When `playbookId` is supplied, it fetches the
+ * Playbook to derive `domainId`. Higher-priority ids passed in
+ * directly skip the lookup.
+ */
+export interface AIConfigScope {
+  callId?: string;
+  playbookId?: string;
+  domainId?: string;
 }
 
 // Defaults are imported from the canonical call-points registry (single source of truth).
 // No duplicate default map here — all call point definitions live in call-points.ts.
 const DEFAULT_CONFIGS = getDefaultsMap();
 
-// In-memory cache with TTL
+// In-memory cache with TTL. Key shape: `${callPoint}|${playbookId??""}|${domainId??""}`
+// so per-Playbook + per-Domain overrides do not collide on the call-point
+// (#1868 — Lattice gap closeout).
 const configCache: Map<string, { config: AIConfigResult; fetchedAt: number }> = new Map();
 const CACHE_TTL_MS = 60_000; // 1 minute cache
+
+function cacheKey(callPoint: string, scope: AIConfigScope | undefined): string {
+  return `${callPoint}|${scope?.playbookId ?? ""}|${scope?.domainId ?? ""}`;
+}
 
 // Default models per provider (used for fallback)
 const DEFAULT_MODELS: Record<AIEngine, string> = {
@@ -100,88 +134,184 @@ function ensureAvailableProvider(
 }
 
 // =====================================================
+// CASCADE — Playbook + Domain layer reads (#1868)
+// =====================================================
+
+/**
+ * Single combined lookup: derive `(playbookId, domainId)` from scope AND
+ * read the call-point override off `Playbook.config.aiOverrides[callPoint]`
+ * in ONE Playbook query. Domain reads in a second query when needed.
+ *
+ * Returns `{ playbookOverride: null, domainOverride: null }` on any read
+ * failure — cascade callers fall through to the legacy global path. Per
+ * `.claude/rules/ai-callpoint-cascade.md`.
+ */
+async function readScopeOverrides(
+  scope: AIConfigScope,
+  callPoint: string,
+): Promise<{
+  playbookOverride: AICallPointOverride | null;
+  domainOverride: AICallPointOverride | null;
+}> {
+  let playbookId: string | null = scope.playbookId ?? null;
+  let domainId: string | null = scope.domainId ?? null;
+  let playbookOverride: AICallPointOverride | null = null;
+
+  try {
+    if (!playbookId && scope.callId) {
+      const call = await prisma.call.findUnique({
+        where: { id: scope.callId },
+        select: { playbookId: true, caller: { select: { domainId: true } } },
+      });
+      playbookId = call?.playbookId ?? null;
+      if (!domainId) domainId = call?.caller?.domainId ?? null;
+    }
+    if (playbookId) {
+      const pb = await prisma.playbook.findUnique({
+        where: { id: playbookId },
+        select: { config: true, domainId: true },
+      });
+      const cfg = (pb?.config ?? {}) as { aiOverrides?: AIOverridesMap };
+      playbookOverride = cfg.aiOverrides?.[callPoint] ?? null;
+      if (!domainId) domainId = pb?.domainId ?? null;
+    }
+    let domainOverride: AICallPointOverride | null = null;
+    if (domainId) {
+      const dom = await prisma.domain.findUnique({
+        where: { id: domainId },
+        select: { config: true },
+      });
+      const cfg = (dom?.config ?? {}) as { aiOverrides?: AIOverridesMap };
+      domainOverride = cfg.aiOverrides?.[callPoint] ?? null;
+    }
+    return { playbookOverride, domainOverride };
+  } catch (err) {
+    console.warn("[ai-config] readScopeOverrides failed — falling through to global lookup:", err);
+    return { playbookOverride: null, domainOverride: null };
+  }
+}
+
+// =====================================================
 // LOADER FUNCTION
 // =====================================================
 
 /**
  * Get AI configuration for a call point.
- * Loads from database (with caching) and falls back to defaults.
+ *
+ * Resolution cascade (highest priority first, #1868):
+ *   1. Playbook.config.aiOverrides[callPoint]
+ *   2. Domain.config.aiOverrides[callPoint]
+ *   3. AIConfig table (admin overrides via `/x/ai-config`)
+ *   4. SystemSettings fallback (`fallback:ai.default_models`)
+ *   5. CALL_POINTS hardcoded defaults (`call-points.ts`)
+ *   6. Ultimate fallback (any available provider)
+ *
+ * Each layer may set ANY of `{provider, model, temperature, maxTokens,
+ * timeoutMs}` — partial overrides are merged top-down per field. The
+ * `modelLayer` field on the result reports who supplied the WINNING
+ * model id (used by the Cascade Inspector Tray and PRs to debug
+ * cascade-shadowing). Per `.claude/rules/ai-callpoint-cascade.md`.
  *
  * @param callPoint - The call point identifier (e.g., "pipeline.measure")
- * @returns The configuration to use for this call point
+ * @param scope     - Optional cascade scope. When omitted, falls back to
+ *                    the legacy flat lookup (no Playbook/Domain check).
  */
-export async function getAIConfig(callPoint: string): Promise<AIConfigResult> {
-  // Check cache first
-  const cached = configCache.get(callPoint);
+export async function getAIConfig(
+  callPoint: string,
+  scope?: AIConfigScope,
+): Promise<AIConfigResult> {
+  // Check cache first — scope is part of the key so per-Playbook /
+  // per-Domain overrides do not collide.
+  const ck = cacheKey(callPoint, scope);
+  const cached = configCache.get(ck);
   if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
     return cached.config;
   }
 
-  // Load from database
-  try {
-    const dbConfig = await prisma.aIConfig.findUnique({
-      where: { callPoint },
-    });
-
-    if (dbConfig && dbConfig.isActive) {
-      // Ensure the configured provider is actually available
-      const { provider, model, fallbackUsed } = ensureAvailableProvider(
-        dbConfig.provider as AIEngine,
-        dbConfig.model
-      );
-
-      // Resolve timeoutMs: DB → call-point default
-      const hardcodedDefaults = DEFAULT_CONFIGS[callPoint];
-      const result: AIConfigResult = {
-        provider,
-        model: fallbackUsed ? model : dbConfig.model,
-        maxTokens: dbConfig.maxTokens ?? undefined,
-        temperature: dbConfig.temperature ?? undefined,
-        timeoutMs: dbConfig.timeoutMs ?? hardcodedDefaults?.timeoutMs ?? undefined,
-        isCustomized: !fallbackUsed, // Not really customized if we had to fall back
-      };
-
-      // Cache the result
-      configCache.set(callPoint, { config: result, fetchedAt: Date.now() });
-      return result;
-    }
-  } catch (error) {
-    // Log but don't fail - fall back to defaults
-    console.warn(`[ai-config] Failed to load config for ${callPoint}:`, error);
+  // Expand scope + read Playbook/Domain overrides in one combined helper.
+  let playbookOverride: AICallPointOverride | null = null;
+  let domainOverride: AICallPointOverride | null = null;
+  if (scope && (scope.callId || scope.playbookId || scope.domainId)) {
+    const o = await readScopeOverrides(scope, callPoint);
+    playbookOverride = o.playbookOverride;
+    domainOverride = o.domainOverride;
   }
 
-  // Fall back to defaults (SystemSettings → hardcoded constant)
+  // Load AIConfig table + fallbacks for layers 3-5.
+  let dbConfig: Awaited<ReturnType<typeof prisma.aIConfig.findUnique>> = null;
+  try {
+    dbConfig = await prisma.aIConfig.findUnique({ where: { callPoint } });
+  } catch (error) {
+    console.warn(`[ai-config] Failed to load AIConfig for ${callPoint}:`, error);
+  }
   const fallbackConfigs = await getAIModelConfigsFallback();
-  const fallbackConfig = fallbackConfigs[callPoint];
-  const hardcodedConfig = DEFAULT_CONFIGS[callPoint];
-  const defaultConfig = fallbackConfig || hardcodedConfig;
-  if (defaultConfig) {
-    // Ensure the default provider is actually available
-    const { provider, model } = ensureAvailableProvider(
-      defaultConfig.provider as AIEngine,
-      defaultConfig.model
-    );
+  const systemFallback = fallbackConfigs[callPoint];
+  const hardcodedDefaults = DEFAULT_CONFIGS[callPoint];
 
-    // Cascade: SystemSettings maxTokens/temperature override hardcoded defaults
+  // Per-field cascade — first non-undefined wins, per field. Tracks which
+  // layer supplied the model so the result carries provenance.
+  type LayerName = "playbook" | "domain" | "global" | "system" | "hardcoded";
+  function pickField<K extends keyof AICallPointOverride>(
+    field: K,
+  ): { value: AICallPointOverride[K] | undefined; layer: LayerName | null } {
+    if (playbookOverride?.[field] !== undefined) return { value: playbookOverride[field], layer: "playbook" };
+    if (domainOverride?.[field] !== undefined) return { value: domainOverride[field], layer: "domain" };
+    const dbActive = dbConfig && dbConfig.isActive;
+    if (field === "provider" && dbActive) return { value: (dbConfig!.provider as unknown) as AICallPointOverride[K], layer: "global" };
+    if (field === "model" && dbActive) return { value: (dbConfig!.model as unknown) as AICallPointOverride[K], layer: "global" };
+    if (field === "temperature" && dbActive && dbConfig!.temperature != null) return { value: (dbConfig!.temperature as unknown) as AICallPointOverride[K], layer: "global" };
+    if (field === "maxTokens" && dbActive && dbConfig!.maxTokens != null) return { value: (dbConfig!.maxTokens as unknown) as AICallPointOverride[K], layer: "global" };
+    if (field === "timeoutMs" && dbActive && dbConfig!.timeoutMs != null) return { value: (dbConfig!.timeoutMs as unknown) as AICallPointOverride[K], layer: "global" };
+    if (systemFallback) {
+      const v = (systemFallback as unknown as Record<string, unknown>)[field as string];
+      if (v !== undefined) return { value: v as AICallPointOverride[K], layer: "system" };
+    }
+    if (hardcodedDefaults) {
+      const v = (hardcodedDefaults as unknown as Record<string, unknown>)[field as string];
+      if (v !== undefined) return { value: v as AICallPointOverride[K], layer: "hardcoded" };
+    }
+    return { value: undefined, layer: null };
+  }
+
+  const providerPick = pickField("provider");
+  const modelPick = pickField("model");
+  const temperaturePick = pickField("temperature");
+  const maxTokensPick = pickField("maxTokens");
+  const timeoutMsPick = pickField("timeoutMs");
+
+  // Ultimate fallback — nothing at all configured.
+  if (!providerPick.value || !modelPick.value) {
+    const fallbackProvider = getDefaultEngine();
     const result: AIConfigResult = {
-      provider,
-      model,
-      maxTokens: fallbackConfig?.maxTokens ?? hardcodedConfig?.maxTokens,
-      temperature: fallbackConfig?.temperature ?? hardcodedConfig?.temperature,
-      timeoutMs: hardcodedConfig?.timeoutMs,
+      provider: fallbackProvider,
+      model: DEFAULT_MODELS[fallbackProvider],
       isCustomized: false,
+      modelLayer: "ultimate",
     };
-    configCache.set(callPoint, { config: result, fetchedAt: Date.now() });
+    configCache.set(ck, { config: result, fetchedAt: Date.now() });
     return result;
   }
 
-  // Ultimate fallback - use whatever is available
-  const fallbackProvider = getDefaultEngine();
-  return {
-    provider: fallbackProvider,
-    model: DEFAULT_MODELS[fallbackProvider],
-    isCustomized: false,
+  // Provider availability gate — if the chosen provider has no API key,
+  // fall back. The model id may not match the fallback provider, but
+  // that mirrors the pre-#1868 behaviour and is the safest bet.
+  const { provider, model, fallbackUsed } = ensureAvailableProvider(
+    providerPick.value as AIEngine,
+    modelPick.value as string,
+  );
+
+  const result: AIConfigResult = {
+    provider,
+    model: fallbackUsed ? model : (modelPick.value as string),
+    maxTokens: maxTokensPick.value as number | undefined,
+    temperature: temperaturePick.value as number | undefined,
+    timeoutMs: timeoutMsPick.value as number | undefined,
+    isCustomized:
+      !fallbackUsed && (modelPick.layer === "playbook" || modelPick.layer === "domain" || modelPick.layer === "global"),
+    modelLayer: modelPick.layer ?? "ultimate",
   };
+  configCache.set(ck, { config: result, fetchedAt: Date.now() });
+  return result;
 }
 
 /**

--- a/apps/admin/lib/metering/instrumented-ai.ts
+++ b/apps/admin/lib/metering/instrumented-ai.ts
@@ -399,9 +399,9 @@ export async function getConfiguredMeteredAICompletionStream(
   options: ConfiguredAIOptions,
   context?: MeteringContext
 ): Promise<{ stream: ReadableStream<Uint8Array>; model: string }> {
-  // Import config loader to get the model info
+  // Import config loader to get the model info (#1868 — scope-aware)
   const { getAIConfig } = await import("@/lib/ai/config-loader");
-  const aiConfig = await getAIConfig(options.callPoint);
+  const aiConfig = await getAIConfig(options.callPoint, options.scope);
 
   const stream = await getConfiguredAICompletionStream(options);
 

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -363,9 +363,52 @@ export type PriorCallRecapDepth = "minimal" | "standard" | "rich";
  *
  * @see docs/decisions/2026-05-22-tolerance-placement.md
  */
+/**
+ * Per–call-point AI override carried on `Playbook.config.aiOverrides` and
+ * `Domain.config.aiOverrides`. Keyed by canonical CallPoint id (e.g.
+ * `"pipeline.measure"`, `"pipeline.score_agent"`, `"compose.prompt"`).
+ *
+ * The Lattice resolver walks Playbook → Domain → AIConfig table →
+ * SystemSetting `fallback:ai.default_models` → hardcoded `CALL_POINTS`
+ * defaults (per `.claude/rules/ai-callpoint-cascade.md`). Each layer may
+ * set ZERO or more of the four fields below — partial overrides are
+ * merged top-down per field (model on Playbook + temperature on Domain
+ * + maxTokens on the AIConfig admin row, etc.).
+ *
+ * Born of the live-incident chain (#1861 follow-on, 2026-06-17): the
+ * stale Anthropic model id `claude-sonnet-4-20250514` in the System
+ * fallback broke every Mock pipeline run because pipeline call points
+ * had no per-Playbook override surface. This type closes that gap.
+ */
+export interface AICallPointOverride {
+  /** `"claude" | "openai" | "mock"` — must match an `AIEngine`. */
+  provider?: string;
+  /** Provider-specific model id, e.g. `"claude-sonnet-4-6"`. */
+  model?: string;
+  /** 0..1; passed through to the call point's prompt. */
+  temperature?: number;
+  /** Provider max-output-tokens cap; passed through. */
+  maxTokens?: number;
+  /** Call timeout (ms); cascades into the AI client wrapper. */
+  timeoutMs?: number;
+}
+
+/** Cascade map carried on `Playbook.config.aiOverrides` + `Domain.config.aiOverrides`. */
+export type AIOverridesMap = Record<string, AICallPointOverride>;
+
 export interface PlaybookConfig {
   systemSpecToggles?: Record<string, { isEnabled: boolean }>;
   goals?: GoalTemplate[];
+  /**
+   * Per-call-point AI overrides for this Playbook (#1868 — Lattice gap
+   * closeout). Keys are CallPoint ids (`"pipeline.measure"` etc.). When
+   * present, the resolver picks these BEFORE walking to the Domain layer
+   * or the flat AIConfig / SystemSetting fallback.
+   *
+   * @bucket Course parameter — operator-tunable on the AI Config lens
+   * (Phase 2, follow-on).
+   */
+  aiOverrides?: AIOverridesMap;
   onboardingFlowPhases?: OnboardingFlowPhases;
   physicalMaterials?: string;
   audience?: string;

--- a/apps/admin/tests/lib/ai/config-loader-cascade.test.ts
+++ b/apps/admin/tests/lib/ai/config-loader-cascade.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Pins the cascade order in `getAIConfig(callPoint, scope?)` (#1868).
+ *
+ * Layers (highest priority first):
+ *   1. Playbook.config.aiOverrides[callPoint]
+ *   2. Domain.config.aiOverrides[callPoint]
+ *   3. AIConfig table
+ *   4. SystemSettings `fallback:ai.default_models`
+ *   5. CALL_POINTS hardcoded defaults
+ *   6. Ultimate fallback (any available provider)
+ *
+ * Mirrors the convergence rule in `.claude/rules/ai-callpoint-cascade.md`.
+ * Sibling round-trip pin to `tests/lib/journey/registry-schema-coverage.test.ts`
+ * (Coverage pillar) — when a future PR widens AIConfigScope, this bank
+ * fails until the cascade order is re-verified.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => {
+  const playbookFindUnique = vi.fn();
+  const domainFindUnique = vi.fn();
+  const callFindUnique = vi.fn();
+  const aiConfigFindUnique = vi.fn();
+  return {
+    prisma: {
+      playbook: { findUnique: playbookFindUnique },
+      domain: { findUnique: domainFindUnique },
+      call: { findUnique: callFindUnique },
+      aIConfig: { findUnique: aiConfigFindUnique },
+    },
+  };
+});
+
+vi.mock("@/lib/fallback-settings", () => ({
+  getAIModelConfigsFallback: vi.fn(),
+}));
+
+vi.mock("@/lib/config", () => ({
+  config: {
+    ai: {
+      claude: { model: "claude-sonnet-4-6", apiKey: "test" },
+      openai: { model: "gpt-4o", apiKey: "test" },
+    },
+  },
+}));
+
+// API key envs so `isEngineAvailable("claude")` is true at module-load time.
+process.env.ANTHROPIC_API_KEY = "test";
+process.env.OPENAI_API_KEY = "test";
+
+import { prisma } from "@/lib/prisma";
+import { getAIModelConfigsFallback } from "@/lib/fallback-settings";
+import { getAIConfig, clearAIConfigCache } from "@/lib/ai/config-loader";
+
+const playbookFindUnique = vi.mocked(prisma.playbook.findUnique);
+const domainFindUnique = vi.mocked(prisma.domain.findUnique);
+const callFindUnique = vi.mocked(prisma.call.findUnique);
+const aiConfigFindUnique = vi.mocked(prisma.aIConfig.findUnique);
+const fallbackMock = vi.mocked(getAIModelConfigsFallback);
+
+beforeEach(() => {
+  clearAIConfigCache();
+  playbookFindUnique.mockReset();
+  domainFindUnique.mockReset();
+  callFindUnique.mockReset();
+  aiConfigFindUnique.mockReset();
+  fallbackMock.mockReset();
+  // Sensible default — none of the layers exist unless a test opts in.
+  playbookFindUnique.mockResolvedValue(null);
+  domainFindUnique.mockResolvedValue(null);
+  callFindUnique.mockResolvedValue(null);
+  aiConfigFindUnique.mockResolvedValue(null);
+  fallbackMock.mockResolvedValue({});
+});
+
+describe("getAIConfig — cascade order (#1868)", () => {
+  it("returns ultimate fallback when no layer supplies anything", async () => {
+    const r = await getAIConfig("pipeline.measure");
+    // CALL_POINTS hardcoded default still wins (call-points.ts seeds them).
+    // The result must be a concrete model id, not null.
+    expect(typeof r.model).toBe("string");
+    expect(r.model.length).toBeGreaterThan(0);
+  });
+
+  it("layer 5 — hardcoded CALL_POINTS defaults are returned when nothing else is set", async () => {
+    const r = await getAIConfig("pipeline.measure");
+    expect(r.modelLayer).toBe("hardcoded");
+  });
+
+  it("layer 4 — SystemSettings fallback wins over hardcoded", async () => {
+    fallbackMock.mockResolvedValue({
+      "pipeline.measure": { provider: "claude", model: "system-sonnet-4-6" } as any,
+    });
+    const r = await getAIConfig("pipeline.measure");
+    expect(r.model).toBe("system-sonnet-4-6");
+    expect(r.modelLayer).toBe("system");
+  });
+
+  it("layer 3 — AIConfig table wins over SystemSettings fallback", async () => {
+    fallbackMock.mockResolvedValue({
+      "pipeline.measure": { provider: "claude", model: "system-sonnet-4-6" } as any,
+    });
+    aiConfigFindUnique.mockResolvedValue({
+      callPoint: "pipeline.measure",
+      provider: "claude",
+      model: "global-sonnet-4-6",
+      maxTokens: null,
+      temperature: null,
+      timeoutMs: null,
+      isActive: true,
+    } as any);
+    const r = await getAIConfig("pipeline.measure");
+    expect(r.model).toBe("global-sonnet-4-6");
+    expect(r.modelLayer).toBe("global");
+  });
+
+  it("layer 2 — Domain override wins over AIConfig table when scope supplied", async () => {
+    aiConfigFindUnique.mockResolvedValue({
+      callPoint: "pipeline.measure",
+      provider: "claude",
+      model: "global-sonnet-4-6",
+      maxTokens: null,
+      temperature: null,
+      timeoutMs: null,
+      isActive: true,
+    } as any);
+    domainFindUnique.mockResolvedValue({
+      config: { aiOverrides: { "pipeline.measure": { provider: "claude", model: "domain-opus-4-7" } } },
+    } as any);
+    const r = await getAIConfig("pipeline.measure", { domainId: "dom-1" });
+    expect(r.model).toBe("domain-opus-4-7");
+    expect(r.modelLayer).toBe("domain");
+    expect(r.isCustomized).toBe(true);
+  });
+
+  it("layer 1 — Playbook override wins over Domain override", async () => {
+    playbookFindUnique.mockResolvedValue({
+      config: { aiOverrides: { "pipeline.measure": { provider: "claude", model: "playbook-opus-4-7" } } },
+      domainId: "dom-1",
+    } as any);
+    domainFindUnique.mockResolvedValue({
+      config: { aiOverrides: { "pipeline.measure": { provider: "claude", model: "domain-opus-4-7" } } },
+    } as any);
+    const r = await getAIConfig("pipeline.measure", { playbookId: "pb-1" });
+    expect(r.model).toBe("playbook-opus-4-7");
+    expect(r.modelLayer).toBe("playbook");
+  });
+
+  it("scope expansion — Call → Playbook → Domain lookup chain runs when only callId given", async () => {
+    callFindUnique.mockResolvedValue({
+      playbookId: "pb-from-call",
+      caller: { domainId: "dom-from-call" },
+    } as any);
+    playbookFindUnique.mockResolvedValue({
+      config: { aiOverrides: { "pipeline.measure": { provider: "claude", model: "playbook-opus-4-7" } } },
+      domainId: "dom-from-call",
+    } as any);
+    const r = await getAIConfig("pipeline.measure", { callId: "call-1" });
+    expect(callFindUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "call-1" } }));
+    expect(playbookFindUnique).toHaveBeenCalled();
+    expect(r.model).toBe("playbook-opus-4-7");
+  });
+
+  it("partial overrides merge per-field — Playbook model + Domain temperature + global maxTokens", async () => {
+    playbookFindUnique.mockResolvedValue({
+      config: { aiOverrides: { "pipeline.measure": { model: "playbook-opus-4-7" } } },
+      domainId: "dom-1",
+    } as any);
+    domainFindUnique.mockResolvedValue({
+      config: { aiOverrides: { "pipeline.measure": { temperature: 0.42 } } },
+    } as any);
+    aiConfigFindUnique.mockResolvedValue({
+      callPoint: "pipeline.measure",
+      provider: "claude",
+      model: "global-sonnet-4-6",
+      maxTokens: 8000,
+      temperature: 0.1,
+      timeoutMs: null,
+      isActive: true,
+    } as any);
+    const r = await getAIConfig("pipeline.measure", { playbookId: "pb-1" });
+    expect(r.model).toBe("playbook-opus-4-7");      // Playbook
+    expect(r.temperature).toBe(0.42);                 // Domain
+    expect(r.maxTokens).toBe(8000);                   // global
+    expect(r.modelLayer).toBe("playbook");
+  });
+
+  it("legacy flat call — getAIConfig(callPoint) with no scope behaves unchanged", async () => {
+    playbookFindUnique.mockResolvedValue({
+      config: { aiOverrides: { "pipeline.measure": { model: "should-not-win" } } },
+      domainId: "dom-1",
+    } as any);
+    aiConfigFindUnique.mockResolvedValue({
+      callPoint: "pipeline.measure",
+      provider: "claude",
+      model: "global-sonnet-4-6",
+      maxTokens: null,
+      temperature: null,
+      timeoutMs: null,
+      isActive: true,
+    } as any);
+    const r = await getAIConfig("pipeline.measure");
+    expect(r.model).toBe("global-sonnet-4-6");
+    expect(r.modelLayer).toBe("global");
+    // Playbook lookup should NOT have fired.
+    expect(playbookFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("inactive AIConfig row is ignored — falls through to SystemSettings", async () => {
+    aiConfigFindUnique.mockResolvedValue({
+      callPoint: "pipeline.measure",
+      provider: "claude",
+      model: "inactive-model",
+      maxTokens: null,
+      temperature: null,
+      timeoutMs: null,
+      isActive: false,
+    } as any);
+    fallbackMock.mockResolvedValue({
+      "pipeline.measure": { provider: "claude", model: "system-sonnet-4-6" } as any,
+    });
+    const r = await getAIConfig("pipeline.measure");
+    expect(r.model).toBe("system-sonnet-4-6");
+    expect(r.modelLayer).toBe("system");
+  });
+
+  it("cache key includes scope — Playbook A and Playbook B do not collide", async () => {
+    playbookFindUnique.mockImplementation((args: any) => {
+      if (args.where.id === "pb-A") {
+        return Promise.resolve({
+          config: { aiOverrides: { "pipeline.measure": { model: "model-A" } } },
+          domainId: null,
+        }) as any;
+      }
+      return Promise.resolve({
+        config: { aiOverrides: { "pipeline.measure": { model: "model-B" } } },
+        domainId: null,
+      }) as any;
+    });
+    const a = await getAIConfig("pipeline.measure", { playbookId: "pb-A" });
+    const b = await getAIConfig("pipeline.measure", { playbookId: "pb-B" });
+    expect(a.model).toBe("model-A");
+    expect(b.model).toBe("model-B");
+    expect(playbookFindUnique).toHaveBeenCalledTimes(2);
+  });
+});

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -112,6 +112,7 @@ Three structural patterns, in order of preference:
 | Cascade family registration → `useEffectiveValue` dispatch | `lib/cascade/effective-value.ts::FAMILIES` | `lib/cascade/use-effective-value.ts` | ✅ PROTECTED | `tests/lib/cascade/use-effective-value.test.tsx` | — | Pre-filter on `isResolvableKnob` shipped 2026-06-17 |
 | Cascade family ↔ resolver function existence | `FAMILIES[].resolve` | `lib/cascade/resolvers/<family>.ts` | ✅ PROTECTED | TypeScript signature match + resolver-level vitest | — | — |
 | Cascade-eligible UI surface → `<CascadeValue>` + `<LayerBadge>` | UI render | hook return | ⚠️ PARTIAL | `.claude/rules/cascade-reuse.md` convention | MED | Rule explicitly states "No ESLint rule today — too many false positives". 1 known violation auto-paired with `CascadeTraceBreadcrumb` downstream. |
+| AI call-point → Playbook/Domain `aiOverrides[callPoint]` cascade | `getConfiguredMeteredAICompletion({ callPoint, scope })` callsite | `lib/ai/config-loader.ts::getAIConfig` → 6-layer resolver | ⚠️ PARTIAL | `.claude/rules/ai-callpoint-cascade.md` + `tests/lib/ai/config-loader-cascade.test.ts` (11 cases, #1868) | MED | Resolver + cascade-order test PROTECTED. Per-callsite "always pass scope when callId in scope" remains convention until ESLint rule + Coverage vitest follow-on lands. |
 
 ### RBAC / API
 


### PR DESCRIPTION
## Summary

Closes #1868. Extends `getAIConfig(callPoint, scope?)` so pipeline + chat AI configuration resolves Playbook + Domain overrides **before** the global AIConfig table or the SystemSetting fallback. Closes the Lattice gap surfaced by the 2026-06-17 incident chain: one stale Anthropic model id in `SystemSetting:fallback:ai.default_models` had broken every Mock pipeline on hf-dev simultaneously because there was no per-Playbook surface to override it.

## Cascade order (highest priority first)

| Layer | Source |
|---|---|
| 1 | `Playbook.config.aiOverrides[callPoint]` (NEW) |
| 2 | `Domain.config.aiOverrides[callPoint]` (NEW) |
| 3 | `AIConfig` table (admin global per call-point) |
| 4 | `SystemSetting:fallback:ai.default_models[callPoint]` |
| 5 | `CALL_POINTS[id].defaults` |
| 6 | Ultimate fallback (any available provider) |

Each layer may set ANY subset of `{provider, model, temperature, maxTokens, timeoutMs}`. First non-undefined wins per field. Result carries `modelLayer` provenance for the Cascade Inspector Tray.

## What ships

| Path | Change |
|---|---|
| `lib/types/json-fields.ts` | New `AICallPointOverride` + `AIOverridesMap` types; `aiOverrides?` field on `PlaybookConfig`. |
| `lib/ai/config-loader.ts` | `getAIConfig(callPoint, scope?)`. Combined `readScopeOverrides` does Playbook.config + Playbook.domainId in ONE query, Domain.config in another. Cache key includes scope. New `modelLayer` provenance field on the result. |
| `lib/ai/client.ts` | `ConfiguredAIOptions.scope?` threaded through both `getConfiguredAICompletion` and the streaming variant. |
| `lib/metering/instrumented-ai.ts` | Forward scope to `getAIConfig` in the metered stream path. |
| `app/api/calls/[callId]/pipeline/route.ts` | All 4 AI call sites (measure / measure-segment / score_agent / adapt) pass `scope: { callId: call.id }`. |
| `.claude/rules/ai-callpoint-cascade.md` (new) | Documents cascade order, when scope must be passed, what NOT to hand-roll. |
| `tests/lib/ai/config-loader-cascade.test.ts` (new) | 11 vitests pin the cascade. |

## Lattice survey [verified]

- **Surface:** AI configuration resolution at every `getAIConfig` / `getConfiguredMeteredAICompletion` site.
- **Sibling-writer drift:** voice path uses `resolveEffective("model", scope)` — same per-field convention applied here. No drift introduced.
- **Default-deny gates:** N/A — no gating column.
- **Cascade respect:** the gap (pipeline AI configs bypassing Playbook/Domain layers) is now CLOSED.
- **Convention conflict:** per-call-point keys (`pipeline.measure` etc.) stay flat per layer rather than nesting under a single `"model"` knob. Pipeline call points are functionally distinct (different prompts, different timeouts, different model needs); folding them under one cascade knob would erase that distinction. The new family is consistent with the existing `pipeline.measure`/`pipeline.score_agent` admin UI surface in `/x/ai-config`.

## Verified by

- ✅ `tests/lib/ai/config-loader-cascade.test.ts` 11/11 PASS.
- ✅ 88/88 across `tests/api/pipeline.test.ts` + `tests/lib/ai/` no regression.
- ✅ tsc on changed files: 0 new errors. One pre-existing TS2322 at `pipeline/route.ts(1797,7)` confirmed identical to origin/main pre-change.
- ✅ ESLint on changed files: 0 errors.
- ✅ Legacy `getAIConfig(callPoint)` (no scope) verified byte-identical to pre-change by the "legacy flat call" vitest.

## Out of scope (follow-on)

- Caller-level override layer (no operator need; YAGNI per rule §"What NOT to do").
- Admin UI for per-Playbook AI overrides (Phase 2; operators today get the surface by editing `Playbook.config.aiOverrides` via the JSON editor).
- ESLint rule preventing scope-less `getAIConfig` at sites that have `callId` in scope.
- ADR (`docs/decisions/2026-06-17-ai-callpoint-cascade.md`) — pending follow-on PR; rule file is the load-bearing contract for now.

## Test plan

- [ ] `/vm-cp` — no migration.
- [ ] On hf-dev: edit `Playbook.config.aiOverrides = { "pipeline.measure": { model: "claude-opus-4-7" } }` for one IELTS playbook, run a Mock sim, confirm the AppLog `pipeline.measure` row carries `model: claude-opus-4-7` instead of the global default.