### PR TITLE
feat(fk): Query 11 — dangling AnalysisSpec.config.parameters[].id refs

### DIFF
--- a/apps/admin/scripts/check-fk-consistency.ts
+++ b/apps/admin/scripts/check-fk-consistency.ts
@@ -421,6 +421,70 @@ async function runChecks(): Promise<CheckResult[]> {
     })),
   });
 
+  // Query 11 — 2026-06-17 — soft-FK in AnalysisSpec.config.parameters[].id.
+  // `AnalysisSpec.config` is a JSON column holding `parameters: [{id, ...}]`
+  // where each `.id` is a string-form reference to `Parameter.parameterId`.
+  // There is no DB-level FK constraint (the value lives inside JSON), so a
+  // Parameter delete leaves dangling references. Consumers like
+  // `lib/goals/strategies/resolve-strategy.ts:76` do
+  // `.find((p) => p.id === "goal_progress_strategies")` and silently return
+  // DEFAULT_SPEC when the id is missing — no error, just a behaviour
+  // regression that's invisible until an educator notices targets aren't
+  // moving.
+  //
+  // This query unrolls the JSON array and joins against Parameter.parameterId
+  // to surface every dangling `(specSlug, configParameterId)` pair.
+  // Identified by the Lattice end-to-end audit (PR #1863). HIGH severity
+  // because the silent fallback class is hard to detect from telemetry —
+  // educators see "targets don't move" without a logged error.
+  type DanglingParamRow = {
+    spec_id: string;
+    spec_slug: string;
+    config_parameter_id: string;
+  };
+  let danglingParamRefs: DanglingParamRow[] = [];
+  try {
+    danglingParamRefs = await prisma.$queryRaw<DanglingParamRow[]>`
+      WITH spec_param_refs AS (
+        SELECT
+          s.id AS spec_id,
+          s.slug AS spec_slug,
+          jsonb_array_elements(s.config->'parameters')->>'id'
+            AS config_parameter_id
+        FROM "AnalysisSpec" s
+        WHERE jsonb_typeof(s.config->'parameters') = 'array'
+      )
+      SELECT spec_id, spec_slug, config_parameter_id
+      FROM spec_param_refs r
+      LEFT JOIN "Parameter" p ON p."parameterId" = r.config_parameter_id
+      WHERE r.config_parameter_id IS NOT NULL
+        AND p."parameterId" IS NULL
+      ORDER BY spec_slug, config_parameter_id;
+    `;
+  } catch (err) {
+    // JSON path query syntax differs across Postgres versions / SQLite
+    // dev DBs. Tolerate failure with a warn so unrelated CI doesn't
+    // block — the check is best-effort.
+    console.warn(
+      `[fk-check] AnalysisSpec.config parameter-ref scan errored: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  results.push({
+    name: "analysis-spec-config-dangling-parameter-ref",
+    description:
+      "AnalysisSpec.config.parameters[].id references a Parameter row that no longer exists. Soft-FK class — JSON column has no DB constraint. Consumers (e.g. lib/goals/strategies/resolve-strategy.ts) silently fall back to DEFAULT when the id is missing.",
+    rows: danglingParamRefs.map((r) => ({
+      id: `${r.spec_slug}/${r.config_parameter_id}`,
+      detail: {
+        specId: r.spec_id,
+        specSlug: r.spec_slug,
+        danglingParameterId: r.config_parameter_id,
+      },
+    })),
+  });
+
   return results;
 }
 

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -81,7 +81,7 @@ Three structural patterns, in order of preference:
 | Voice settings registry → Settings tab render | `lib/settings/voice-setting-contracts.ts::VOICE_SETTINGS` | `components/voice-section/VoiceSettings.tsx` | ❌ GAP | — | MED | No test pins render against registry. New voice setting could fail to mount. |
 | Parameter rows → AgentTuner UI | `prisma.parameter.findMany()` at `lib/agent-tuner/params.ts:37` | `components/sim/tuner/**/*.tsx` | ⚠️ PARTIAL | Runtime (auto-discover) | LOW | No test pins that all params render; runtime self-corrects on next page load. |
 | Parameter rows → JOURNEY_SETTINGS LH-menu exposure | `behavior-parameters.registry.json` | `JourneySettingContract` entries targeting `behaviorTargets[<paramId>]` | ❌ GAP | — | MED | New parameter doesn't auto-appear in Journey Inspector LH menu. Convention only. Per-param `JourneySettingContract` filing needed. |
-| Parameter rows → AnalysisSpec.measurements soft-FK | `behavior-parameters.registry.json::parameterId` | `AnalysisSpec.measurements[].parameterId` | ❌ GAP | — | HIGH | Soft-FK only — dangling ID causes silent measurement skip at read. Needs SQL check in `apps/admin/scripts/check-fk-consistency.ts`. |
+| Parameter rows → AnalysisSpec.config.parameters[].id soft-FK | `behavior-parameters.registry.json::parameterId` | `AnalysisSpec.config.parameters[].id` (JSON field — read at `lib/goals/strategies/resolve-strategy.ts:76`) | ✅ PROTECTED | `apps/admin/scripts/check-fk-consistency.ts` Query 11 (`analysis-spec-config-dangling-parameter-ref`, 2026-06-17) | — | SQL check via `jsonb_array_elements` + LEFT JOIN. Surfaces dangling `(specSlug, configParameterId)` pairs. Wrapped in try/catch so dev SQLite path tolerates JSON-syntax differences. |
 | Parameter rows → runtime consumer (compose/score/cascade) | `behavior-parameters.registry.json` | concat of `lib/prompt/composition/**` + `lib/pipeline/**` + `lib/cascade/resolvers/**` + others | ✅ PROTECTED | `tests/lib/measurement/parameter-coverage.test.ts` (#1856) | — | Exempt list (118 entries) with ratchet |
 
 ### Pipeline
@@ -201,7 +201,7 @@ Three structural patterns, in order of preference:
 
 | Gap | Severity | Effort | Ship plan |
 |---|---|---|---|
-| Parameter ↔ AnalysisSpec.measurements FK consistency | HIGH | 1–2 hr | SQL check in `apps/admin/scripts/check-fk-consistency.ts` |
+| ~~Parameter ↔ AnalysisSpec.measurements FK consistency~~ | ~~HIGH~~ | ~~1–2 hr~~ | **SHIPPED** as Query 11 in `apps/admin/scripts/check-fk-consistency.ts` (2026-06-17). The actual soft-FK was in `AnalysisSpec.config.parameters[].id` (JSON), not `measurements` — clarified during the fix. |
 | AnalysisSpec.outputType → stage dispatch enum guard | HIGH | 1–2 hr | TS const enum + ESLint rule + ratchet |
 | VAPI webhook subject whitelist | HIGH | 1 hr | Allowlist constant + handler guard + test |
 | Parameter ↔ JOURNEY_SETTINGS LH-menu exposure | MED | 2 hr | Coverage vitest in #1849 pattern |


### PR DESCRIPTION
## Summary

Closes the HIGH-severity gap from PR #1863 audit:

The original claim was "Parameter ↔ AnalysisSpec.measurements soft-FK" — wrong location. Live investigation showed:
- `AnalysisAction.parameterId` has a proper Prisma FK constraint (verified via `@relation` directive + migration files)
- The real soft-FK lives in `AnalysisSpec.config.parameters[].id` — a JSON column with no DB constraint
- Read at `lib/goals/strategies/resolve-strategy.ts:75-77` via string-form `.find((p) => p.id === ...)`
- If a Parameter is deleted, lookup returns undefined → DEFAULT_SPEC silently → educator-visible behaviour regression with no logged error

## What ships

1. `apps/admin/scripts/check-fk-consistency.ts::Query 11` (`analysis-spec-config-dangling-parameter-ref`) — SQL via `jsonb_array_elements` + LEFT JOIN
2. `docs/lattice-chains.md` — row updated ❌ GAP → ✅ PROTECTED with gate file path

## Lattice-compliant per the framework (#1864)

- ✅ Built structural gate (SQL check)
- ✅ Added inventory row pointing at the gate file
- ✅ Self-maintenance test 9/9 (file path appears in inventory automatically)
- N/A new rule file — FK check pattern is established

## Verified by

- `npx vitest run tests/lib/lattice-self-maintenance.test.ts` — 9/9 [verified]
- `npx tsc --noEmit | grep check-fk-consistency` — clean [verified]
- Reuse-finder discipline ran on adjacent surfaces — `BddAcceptanceCriteria`, `ParameterMapping`, `ParameterTag`, `CallScore`, `ParameterSetParameter` all have real Prisma FK constraints. Only the JSON soft-FK in `AnalysisSpec.config` was unguarded [verified via `grep "REFERENCES.*Parameter" prisma/migrations/`].

🤖 Generated with [Claude Code](https://claude.com/claude-code)