### PR TITLE
feat(voice): exhaustive Session.kind → skipStages mapping + Coverage pin

### DIFF
--- a/apps/admin/lib/voice/session-rules.ts
+++ b/apps/admin/lib/voice/session-rules.ts
@@ -150,15 +150,48 @@ export function statusFromOutcome(outcome: SessionOutcomeString): SessionStatusS
  *
  * Returns a sorted, de-duplicated string[].
  */
+/**
+ * Derive which pipeline stages should be skipped for a given Session.kind
+ * + outcome combo.
+ *
+ * Uses `switch + never` exhaustiveness on `kind` so a new SessionKind
+ * cannot be added without a deliberate decision here. Pinned by
+ * `tests/lib/voice/session-kind-exhaustiveness.test.ts` — that test also
+ * surfaces drift if the kind→stages mapping silently changes.
+ *
+ * Stage-skip semantics by kind (no outcome override):
+ *   - ENROLLMENT / ASSESSMENT: intake / probe — no audio to score,
+ *     transcript is structured intake form. Skip EXTRACT / SCORE_AGENT
+ *     / PROSODY; pipeline still runs ADAPT / SUPERVISE / COMPOSE.
+ *   - VOICE_CALL / SIM_CALL / TEXT_CHAT: full pipeline at kind level.
+ *     (TEXT_CHAT has no audio — PROSODY would no-op on empty audio path,
+ *     but the pipeline runner handles that itself; we don't pre-skip.)
+ *
+ * Outcome overrides (always applied on top of kind-level skips):
+ *   - FAILED / GHOST: scoring on an empty / failed transcript is
+ *     misleading. Skip EXTRACT / SCORE_AGENT / PROSODY / REWARD.
+ */
 export function deriveSkipStages(args: {
   kind: SessionKindString;
   outcome?: SessionOutcomeString;
 }): string[] {
   const skip = new Set<string>();
-  if (args.kind === "ENROLLMENT" || args.kind === "ASSESSMENT") {
-    skip.add("EXTRACT");
-    skip.add("SCORE_AGENT");
-    skip.add("PROSODY");
+  switch (args.kind) {
+    case "ENROLLMENT":
+    case "ASSESSMENT":
+      skip.add("EXTRACT");
+      skip.add("SCORE_AGENT");
+      skip.add("PROSODY");
+      break;
+    case "VOICE_CALL":
+    case "SIM_CALL":
+    case "TEXT_CHAT":
+      // Full pipeline at kind level. Outcome-level skip below may still apply.
+      break;
+    default: {
+      const exhaustive: never = args.kind;
+      return exhaustive;
+    }
   }
   if (args.outcome === "FAILED" || args.outcome === "GHOST") {
     skip.add("EXTRACT");

--- a/apps/admin/tests/lib/voice/session-kind-exhaustiveness.test.ts
+++ b/apps/admin/tests/lib/voice/session-kind-exhaustiveness.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Session.kind exhaustiveness — Lattice Coverage-pillar member (2026-06-17).
+ *
+ * **What this test pins:**
+ *  Every member of `SessionKindString` (= the Prisma `SessionKind` enum)
+ *  has an explicit decision in `deriveSkipStages` AND
+ *  `initialCounterFlags` AT `lib/voice/session-rules.ts`. Both helpers
+ *  use `switch + never` exhaustiveness, so a new SessionKind cannot
+ *  silently default to "no skips" — TS fails at edit time. This test
+ *  is the behavioural pin paired with that compile-time gate.
+ *
+ *  Pre-fix: `deriveSkipStages` used `if (kind === "ENROLLMENT" ||
+ *  kind === "ASSESSMENT")` — any other kind silently produced zero
+ *  skips at kind level. Adding a new SessionKind to the Prisma enum
+ *  would silently default to "full pipeline" with no compile-time
+ *  signal.
+ *
+ *  See `.claude/rules/session-kind-exhaustiveness.md` for the durable
+ *  rule.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  deriveSkipStages,
+  initialCounterFlags,
+  type SessionKindString,
+} from "@/lib/voice/session-rules";
+
+/**
+ * Canonical enumeration of every SessionKind. If the Prisma enum
+ * grows, add the new member here AND update deriveSkipStages /
+ * initialCounterFlags. The compile-time `never` check forces the
+ * latter; this list forces the former.
+ */
+const ALL_KINDS: readonly SessionKindString[] = [
+  "ENROLLMENT",
+  "ASSESSMENT",
+  "VOICE_CALL",
+  "SIM_CALL",
+  "TEXT_CHAT",
+] as const;
+
+/**
+ * Pinned kind→skipStages mapping. Update deliberately if rules change.
+ * Stage skips at the OUTCOME level (FAILED / GHOST) are tested
+ * separately at the bottom — these are the kind-level base values.
+ */
+const EXPECTED_KIND_LEVEL_SKIPS: Record<SessionKindString, readonly string[]> = {
+  ENROLLMENT: ["EXTRACT", "PROSODY", "SCORE_AGENT"],
+  ASSESSMENT: ["EXTRACT", "PROSODY", "SCORE_AGENT"],
+  VOICE_CALL: [],
+  SIM_CALL: [],
+  TEXT_CHAT: [],
+};
+
+describe("Session.kind exhaustiveness (Lattice Coverage pillar)", () => {
+  it("covers every SessionKindString member without sentinel gap", () => {
+    // If a new kind is added to the union but missing from ALL_KINDS,
+    // TypeScript flags the readonly tuple shape; this assertion is the
+    // runtime backstop.
+    expect(ALL_KINDS).toHaveLength(5);
+    const set = new Set(ALL_KINDS);
+    expect(set.size).toBe(ALL_KINDS.length);
+  });
+
+  it("deriveSkipStages returns the pinned mapping for every kind", () => {
+    for (const kind of ALL_KINDS) {
+      const result = deriveSkipStages({ kind });
+      expect(
+        result,
+        `deriveSkipStages drift for kind=${kind}`,
+      ).toEqual(EXPECTED_KIND_LEVEL_SKIPS[kind]);
+    }
+  });
+
+  it("initialCounterFlags returns valid flags for every kind (no exhaustive throw)", () => {
+    for (const kind of ALL_KINDS) {
+      const flags = initialCounterFlags(kind);
+      expect(
+        typeof flags.countsTowardLearnerNumber,
+        `initialCounterFlags missing countsTowardLearnerNumber for kind=${kind}`,
+      ).toBe("boolean");
+      expect(
+        typeof flags.countsTowardPipelineNumber,
+        `initialCounterFlags missing countsTowardPipelineNumber for kind=${kind}`,
+      ).toBe("boolean");
+    }
+  });
+
+  it("outcome=FAILED / GHOST adds the pinned set of additional skips (overrides VOICE_CALL/SIM_CALL/TEXT_CHAT base)", () => {
+    const expectedFailedExtras = ["EXTRACT", "PROSODY", "REWARD", "SCORE_AGENT"];
+    for (const kind of ALL_KINDS) {
+      for (const outcome of ["FAILED", "GHOST"] as const) {
+        const result = deriveSkipStages({ kind, outcome });
+        // The override union always contains the 4 stages.
+        for (const stage of expectedFailedExtras) {
+          expect(
+            result,
+            `Expected ${kind}/${outcome} to skip ${stage}`,
+          ).toContain(stage);
+        }
+      }
+    }
+  });
+
+  it("outcome=COMPLETED leaves only the kind-level skips (no extras)", () => {
+    for (const kind of ALL_KINDS) {
+      const result = deriveSkipStages({ kind, outcome: "COMPLETED" });
+      expect(
+        result,
+        `COMPLETED outcome shouldn't add stages beyond the kind base for ${kind}`,
+      ).toEqual(EXPECTED_KIND_LEVEL_SKIPS[kind]);
+    }
+  });
+});

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -133,7 +133,7 @@ Three structural patterns, in order of preference:
 | Stall detector event → server persistence | `hooks/use-stall-detector.ts` | (no server-side persistence today) | ❌ GAP | — | MED | Client-only. Needed before `BEH-STALL-RECOVERY-MS` can ship (epic #1860) |
 | `Session.voiceConfigSnapshot` → reproducibility consumer | `lib/voice/create-session.ts` snapshot at session-start | (forensics + reproducibility — no automated consumer) | ⚠️ PARTIAL | Schema field + create-session test pins write | LOW | Snapshot stored; no test that it enables replay |
 | `Session.sequenceNumber` → call ordering | atomic upsert at `CallerSequenceCounter` | pipeline + reads | ✅ PROTECTED | `ai-to-db-guard.md` (createSession atomic increment) + `apps/admin/tests/lib/voice/create-session.test.ts` | — | Postgres row-level lock serialises concurrent webhooks |
-| Session.kind → `skipStages` pipeline gate | `lib/voice/create-session.ts` | `lib/pipeline/run-spec-driven.ts` | ⚠️ PARTIAL | Runtime + `tests/lib/voice/create-session.test.ts` | MED | Mapping logic tested at write but no coverage test that all 5 kinds map correctly |
+| Session.kind → `skipStages` pipeline gate | `lib/voice/session-rules.ts::deriveSkipStages` (switch + never exhaustiveness) | `lib/pipeline/run-spec-driven.ts` | ✅ PROTECTED | `apps/admin/tests/lib/voice/session-kind-exhaustiveness.test.ts` (5 vitests: kind enumeration + per-kind skip pin + outcome override pin + initialCounterFlags exhaustiveness pin) + TS `never` compile-time check | — | 2026-06-17: refactored `deriveSkipStages` from `if (kind === ... \|\| kind === ...)` to `switch + never`. Behaviour-preserving (TEXT_CHAT/VOICE_CALL/SIM_CALL still no kind-level skips). Test pins the kind→skip-list mapping byte-identical with the original behaviour. |
 
 ### Schema / migration
 
@@ -207,7 +207,7 @@ Three structural patterns, in order of preference:
 | Parameter ↔ JOURNEY_SETTINGS LH-menu exposure | MED | 2 hr | Coverage vitest in #1849 pattern |
 | VOICE_SETTINGS ↔ Settings tab render coverage | MED | 1 hr | Coverage vitest |
 | Migration ↔ seed compatibility | MED | 2 hr | CI step running seed after each migration |
-| Session.kind ↔ skipStages mapping | MED | 1 hr | Exhaustiveness test |
+| ~~Session.kind ↔ skipStages mapping~~ | ~~MED~~ | ~~1 hr~~ | **SHIPPED** 2026-06-17 — `switch + never` refactor in `lib/voice/session-rules.ts::deriveSkipStages` + 5 pinning vitests in `tests/lib/voice/session-kind-exhaustiveness.test.ts`. |
 | Stall detector → server persistence | MED | (epic) | Tracked in #1860 epic Phase 3 |
 | `composeImpact.kinds` consumer | LOW | (decide) | Either build the UI or drop the field |
 


### PR DESCRIPTION
## Summary

Closes the MED gap from #1863 audit (`Session.kind ↔ skipStages mapping`). `deriveSkipStages` was non-exhaustive `if (kind === "ENROLLMENT" || kind === "ASSESSMENT")` — adding a new `SessionKind` to the Prisma enum would silently default to "full pipeline at kind level". Sibling `initialCounterFlags(kind)` already uses `switch + never` — this PR matches it.

> **Note**: branch name says `parameter-inspector-exposure` but pivoted mid-flight after Lattice survey showed AgentTuner already auto-discovers all Parameters (no per-parameter Journey LH-menu gap). Branch kept; actual scope is Session.kind exhaustiveness.

## What ships

1. `lib/voice/session-rules.ts::deriveSkipStages` — refactored to `switch(kind)` + `default { exhaustive: never }` catch
2. `tests/lib/voice/session-kind-exhaustiveness.test.ts` — 5 vitests pinning kind→skip-list × outcome behaviour
3. `docs/lattice-chains.md` — row ⚠️ PARTIAL → ✅ PROTECTED with gate path; to-do entry struck through

## Behaviour preservation

| Kind | Pre-fix | Post-fix | Change |
|---|---|---|---|
| ENROLLMENT | EXTRACT/SCORE_AGENT/PROSODY | EXTRACT/SCORE_AGENT/PROSODY | — |
| ASSESSMENT | EXTRACT/SCORE_AGENT/PROSODY | EXTRACT/SCORE_AGENT/PROSODY | — |
| VOICE_CALL | (none) | (none) | — |
| SIM_CALL | (none) | (none) | — |
| TEXT_CHAT | (none) | (none) | — |

Outcome-level overrides (FAILED/GHOST → +EXTRACT/SCORE_AGENT/PROSODY/REWARD) unchanged.

## Lattice-compliant per the framework (#1864)

- ✅ Structural gate: TS `never` exhaustiveness + 5 pinning vitests
- ✅ Inventory row updated with gate path
- ✅ Self-maintenance test 9/9 [verified]
- ✅ Lattice survey before writing — confirmed sibling helper `initialCounterFlags` already uses this pattern; followed established convention
- ✅ Behaviour-preserving — sibling `create-session.test.ts` (13 tests) still green [verified]

## Verified by

- `npx vitest run tests/lib/voice/session-kind-exhaustiveness.test.ts tests/lib/voice/create-session.test.ts tests/lib/lattice-self-maintenance.test.ts` — 27/27 pass [verified]
- `EXPECTED_KIND_LEVEL_SKIPS` matches pre-fix output for all 5 kinds × 4 outcomes [verified by test execution]

🤖 Generated with [Claude Code](https://claude.com/claude-code)