### PR TITLE
feat(voice): #1870 segmented PROSODY — consume B/C/D

### DIFF
--- a/apps/admin/app/api/voice-system-settings/route.ts
+++ b/apps/admin/app/api/voice-system-settings/route.ts
@@ -39,6 +39,9 @@ const patchSchema = z
     maxDurationSeconds: z.number().int().min(30).max(7200).optional(),
     voicemailDetectionEnabled: z.boolean().optional(),
     endCallPhrases: z.array(z.string().min(1).max(80)).max(20).optional(),
+    // PROSODY knobs (#1119 + #1870)
+    vendorTimeoutMs: z.number().int().min(1000).max(120000).optional(),
+    maxSegmentsPerCall: z.number().int().min(1).max(20).optional(),
   })
   .strict();
 

--- a/apps/admin/lib/pipeline/prosody-consumer.ts
+++ b/apps/admin/lib/pipeline/prosody-consumer.ts
@@ -34,6 +34,7 @@ import {
 import type {
   GeneralSignals,
   IeltsScores,
+  ProsodyPhaseEnvelope,
   VoiceProsodyFeatures,
 } from "./prosody-types";
 
@@ -92,8 +93,43 @@ export async function applyProsodyContractToAggregate(
 
   const envelope = call.voiceProsody as unknown as VoiceProsodyFeatures;
 
-  if (envelope.mode === "unavailable") {
+  if (envelope.mode === "unavailable" && !envelope.bySegment) {
     return { applied: false, mode: "unavailable", scoresWritten: 0 };
+  }
+
+  // #1870 — segmented path. When `bySegment` is present, iterate it and
+  // write per-phase CallScore rows with namespace-prefixed segmentKey
+  // (`phase:<phaseKey>` per #1872 Option 2). The top-level mean
+  // aggregate is ALSO written so existing whole-call readers keep
+  // working — segmentKey null on the aggregate row to distinguish it
+  // from per-phase rows in the unique-key collision-free namespace.
+  if (envelope.bySegment) {
+    let written = 0;
+    for (const [phaseKey, phase] of Object.entries(envelope.bySegment)) {
+      written += await writePhaseEnvelope(
+        callId,
+        callerId,
+        phaseKey,
+        phase,
+      );
+    }
+    // Aggregate write — segmentKey null preserves the existing whole-call
+    // row shape that AGGREGATE EMA + Snapshot read. Skip when top-level
+    // is "unavailable" (every phase failed).
+    if (envelope.mode === "ielts" && envelope.ieltsScores) {
+      written += await writeIeltsCallScores(
+        callId,
+        callerId,
+        envelope.ieltsScores,
+      );
+    } else if (envelope.mode === "general" && envelope.generalSignals) {
+      written += await writeGeneralCallScores(
+        callId,
+        callerId,
+        envelope.generalSignals,
+      );
+    }
+    return { applied: true, mode: envelope.mode, scoresWritten: written };
   }
 
   if (envelope.mode === "ielts" && envelope.ieltsScores) {
@@ -117,10 +153,33 @@ export async function applyProsodyContractToAggregate(
   return { applied: false, mode: envelope.mode, scoresWritten: 0 };
 }
 
+/**
+ * Write per-phase CallScore rows for one phase's envelope. The
+ * `segmentKey` carries the namespace-prefixed phaseKey
+ * (`phase:<phaseKey>`) so the writes don't collide with the existing
+ * text segmenter's `"part1"` / `"part2"` / `"part3"` keys (#1872
+ * Option 2 namespace decision).
+ *
+ * "unavailable" phases are skipped silently — no row written.
+ */
+async function writePhaseEnvelope(
+  callId: string,
+  callerId: string | null,
+  phaseKey: string,
+  phase: ProsodyPhaseEnvelope,
+): Promise<number> {
+  if (phase.mode === "unavailable") return 0;
+  if (phase.mode === "ielts") {
+    return writeIeltsCallScores(callId, callerId, phase.ieltsScores, phaseKey);
+  }
+  return writeGeneralCallScores(callId, callerId, phase.generalSignals, phaseKey);
+}
+
 async function writeIeltsCallScores(
   callId: string,
   callerId: string | null,
   ielts: IeltsScores,
+  segmentKey?: string,
 ): Promise<number> {
   const rows: Array<{ parameterId: string; band: number }> = [
     { parameterId: IELTS_PARAM_IDS.fluencyCoherence, band: ielts.fluencyCoherence },
@@ -137,12 +196,16 @@ async function writeIeltsCallScores(
     // structurally spec-shaped (deterministic adapter output) but not
     // backed by an AnalysisSpec.promptTemplate row. The sentinel
     // surfaces "produced by PROSODY, not LLM" lineage honestly.
+    // #1870 — `segmentKey` carries the namespace-prefixed phaseKey
+    // (`phase:<name>`) for per-phase rows; undefined for the
+    // whole-call / aggregate row.
     await writeCallScore({
       callId,
       callerId,
       parameterId: row.parameterId,
       analysisSpecId: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
       moduleId: null,
+      segmentKey: segmentKey ?? null,
       score: normalisedScore,
       confidence: 0.9,
       evidence: [`prosody/ielts:band=${row.band.toFixed(1)}`],
@@ -158,6 +221,7 @@ async function writeGeneralCallScores(
   callId: string,
   callerId: string | null,
   signals: GeneralSignals,
+  segmentKey?: string,
 ): Promise<number> {
   // Map the two confirmed general-mode signals to BehaviorParameter-id'd
   // CallScore rows. Score normalised to 0–1:
@@ -193,12 +257,16 @@ async function writeGeneralCallScores(
   let written = 0;
   for (const w of writes) {
     // #1539 — same PROSODY sentinel for the general-mode writes.
+    // #1870 — `segmentKey` carries the namespace-prefixed phaseKey
+    // (`phase:<name>`) for per-phase rows; undefined for the
+    // whole-call / aggregate row.
     await writeCallScore({
       callId,
       callerId,
       parameterId: w.parameterId,
       analysisSpecId: MEASUREMENT_SENTINEL_SPEC_IDS.PROSODY,
       moduleId: null,
+      segmentKey: segmentKey ?? null,
       score: w.score,
       confidence: 0.7,
       evidence: [w.evidence],

--- a/apps/admin/lib/pipeline/prosody-runner.ts
+++ b/apps/admin/lib/pipeline/prosody-runner.ts
@@ -38,22 +38,32 @@
  */
 
 import { prisma } from "@/lib/prisma";
+import { log } from "@/lib/logger";
 import { logVoiceEvent } from "@/lib/voice/telemetry";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
 import { getSpeechAssessmentProvider } from "@/lib/speech-assessment/provider-factory";
 import { resolveSpeechAssessmentProviderForCall } from "@/lib/voice/resolve-speech-assessment-provider";
 import { recordIAL4ProsodySkip } from "@/lib/pipeline/adaptive-loop-invariants";
+import {
+  extractAudioSlice,
+  AudioSliceError,
+} from "@/lib/voice/audio-slice";
 import type {
   ScoringMode,
   NormalisedScoreResult,
   SpeechAssessmentAdapter,
 } from "@/lib/speech-assessment/types";
+import type {
+  PhaseBoundary,
+  SessionMetadata,
+} from "@/lib/types/json-fields";
 
 import type {
   VoiceProsodyFeatures,
   VoiceProsodyMode,
   IeltsScores,
   GeneralSignals,
+  ProsodyPhaseEnvelope,
 } from "./prosody-types";
 
 export interface RunProsodyOptions {
@@ -86,6 +96,10 @@ export async function runProsodyStage(
       stereoRecordingUrl: true,
       playbookId: true,
       voiceProsody: true,
+      // #1870 — read Session.metadata.phaseBoundaries via the 1:1
+      // Call.session relation (epic #1338). Null when no Session row is
+      // linked (legacy Calls during the Slice 0 transition window).
+      session: { select: { metadata: true } },
     },
   });
   if (!call) {
@@ -176,24 +190,77 @@ export async function runProsodyStage(
   let vendorEnvelope: VoiceProsodyFeatures;
   let vendorErrorMessage: string | undefined;
 
-  try {
-    const audio = await fetchAudioBuffer(call.stereoRecordingUrl);
-    const scoringMode: ScoringMode =
-      mode === "ielts" ? "ielts" : "general";
-    const result = await Promise.race([
-      adapter.scoreUploadedAudio(audio.buffer, audio.mimeType, scoringMode),
-      timeoutAfter(vendorTimeoutMs),
-    ]);
-    vendorEnvelope = normaliseVendorResult(result, mode);
-  } catch (err) {
-    const isTimeout =
-      err instanceof Error && err.message === "PROSODY_VENDOR_TIMEOUT";
-    vendorEnvelope = {
-      mode: "unavailable",
-      errorReason: isTimeout ? "vendor_timeout" : "vendor_error",
-      rawVendor: err instanceof Error ? { error: err.message } : { error: String(err) },
-    };
-    vendorErrorMessage = err instanceof Error ? err.message : String(err);
+  // 5a. Branch — segmented vs whole-call. Segmented requires:
+  //   - >= 2 phase boundaries (a single boundary degenerates to whole-call)
+  //   - boundaries.length <= maxSegmentsPerCall (cost cap, #1870 AC)
+  //   - audio-slice host allow-list (currently storage.vapi.ai only)
+  //   - Session relation populated (legacy Calls during #1338 Slice 0
+  //     window have no Session — degenerates to whole-call)
+  const boundaries = readPhaseBoundaries(call.session?.metadata);
+  const cap = settings.maxSegmentsPerCall;
+  const overCap = boundaries.length > cap;
+
+  if (overCap) {
+    log("system", "voice.prosody.segments_capped", {
+      level: "warn",
+      callId,
+      phaseCount: boundaries.length,
+      cap,
+    });
+  }
+
+  const wantSegmented = boundaries.length >= 2 && !overCap;
+
+  if (wantSegmented) {
+    // Probe the host once via the slice helper's validation pathway —
+    // a single failed call short-circuits the segmented branch and
+    // falls back to whole-call (rather than aborting). Use a zero-byte
+    // probe by passing fetchImpl that returns 416 immediately; cheaper
+    // to just try the first slice and catch host_not_allowed.
+    try {
+      const segmented = await runSegmentedProsody({
+        callId,
+        callerId,
+        recordingUrl: call.stereoRecordingUrl,
+        adapter,
+        mode,
+        vendorTimeoutMs,
+        boundaries,
+      });
+      vendorEnvelope = segmented.envelope;
+      vendorErrorMessage = segmented.errorMessage;
+    } catch (err) {
+      // Catastrophic failure (host_not_allowed on the very first phase
+      // — slice helper's URL validation rejected it). Fall back to
+      // whole-call so the call still gets a forensic envelope.
+      const reason =
+        err instanceof AudioSliceError && err.code === "host_not_allowed"
+          ? "segment_url_not_allowed"
+          : "segment_setup_failed";
+      log("system", `voice.prosody.${reason}`, {
+        level: "warn",
+        callId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      vendorEnvelope = await runWholeCallProsody({
+        recordingUrl: call.stereoRecordingUrl,
+        adapter,
+        mode,
+        vendorTimeoutMs,
+      }).then((r) => {
+        vendorErrorMessage = r.errorMessage;
+        return r.envelope;
+      });
+    }
+  } else {
+    const whole = await runWholeCallProsody({
+      recordingUrl: call.stereoRecordingUrl,
+      adapter,
+      mode,
+      vendorTimeoutMs,
+    });
+    vendorEnvelope = whole.envelope;
+    vendorErrorMessage = whole.errorMessage;
   }
 
   const durationMs = Date.now() - startMs;
@@ -389,4 +456,312 @@ async function persistProsody(
       voiceProsody: envelope as unknown as object,
     },
   });
+}
+
+/**
+ * Extract `phaseBoundaries` from `Session.metadata`. Defensive — accepts
+ * the raw JSON column shape (Prisma returns `JsonValue | null`). Returns
+ * an empty array when the metadata is missing, malformed, or empty so
+ * the caller can branch on `length`.
+ */
+function readPhaseBoundaries(metadata: unknown): PhaseBoundary[] {
+  if (!metadata || typeof metadata !== "object") return [];
+  const md = metadata as SessionMetadata;
+  const raw = md.phaseBoundaries;
+  if (!Array.isArray(raw)) return [];
+  // Filter shape-valid entries — defensive against a future writer
+  // shipping partial rows. A boundary with `endSec === startSec` is the
+  // OPEN-boundary convention (#1762 Story C) and is intentionally
+  // skipped here because we can't slice an empty window.
+  const out: PhaseBoundary[] = [];
+  for (const row of raw) {
+    if (
+      row &&
+      typeof row === "object" &&
+      typeof (row as PhaseBoundary).phase === "string" &&
+      typeof (row as PhaseBoundary).startSec === "number" &&
+      typeof (row as PhaseBoundary).endSec === "number" &&
+      Number.isFinite((row as PhaseBoundary).startSec) &&
+      Number.isFinite((row as PhaseBoundary).endSec) &&
+      (row as PhaseBoundary).endSec > (row as PhaseBoundary).startSec
+    ) {
+      out.push(row as PhaseBoundary);
+    }
+  }
+  return out;
+}
+
+interface RunWholeCallProsodyArgs {
+  recordingUrl: string;
+  adapter: SpeechAssessmentAdapter;
+  mode: VoiceProsodyMode;
+  vendorTimeoutMs: number;
+}
+
+interface VendorAttemptResult {
+  envelope: VoiceProsodyFeatures;
+  errorMessage?: string;
+}
+
+/**
+ * Whole-call vendor invocation — today's behaviour, factored out to a
+ * helper so the segmented branch can reuse the catch-and-encode pattern
+ * verbatim. Byte-identical to the pre-#1870 inline block.
+ */
+async function runWholeCallProsody(
+  args: RunWholeCallProsodyArgs,
+): Promise<VendorAttemptResult> {
+  try {
+    const audio = await fetchAudioBuffer(args.recordingUrl);
+    const scoringMode: ScoringMode =
+      args.mode === "ielts" ? "ielts" : "general";
+    const result = await Promise.race([
+      args.adapter.scoreUploadedAudio(audio.buffer, audio.mimeType, scoringMode),
+      timeoutAfter(args.vendorTimeoutMs),
+    ]);
+    return { envelope: normaliseVendorResult(result, args.mode) };
+  } catch (err) {
+    const isTimeout =
+      err instanceof Error && err.message === "PROSODY_VENDOR_TIMEOUT";
+    return {
+      envelope: {
+        mode: "unavailable",
+        errorReason: isTimeout ? "vendor_timeout" : "vendor_error",
+        rawVendor:
+          err instanceof Error ? { error: err.message } : { error: String(err) },
+      },
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+interface RunSegmentedProsodyArgs {
+  callId: string;
+  callerId: string | null;
+  recordingUrl: string;
+  adapter: SpeechAssessmentAdapter;
+  mode: VoiceProsodyMode;
+  vendorTimeoutMs: number;
+  boundaries: PhaseBoundary[];
+}
+
+/**
+ * Segmented vendor invocation — one adapter call per phase boundary.
+ *
+ * Idempotency note: the runner-level idempotency (Step 1, existing
+ * envelope short-circuit) covers the WHOLE call. Per-phase idempotency
+ * is a future hardening; for now a force-rerun goes phase-by-phase
+ * (re-billing every phase). This matches the AC: "cache key
+ * `(callId, phaseKey)` … full-call re-run still goes phase-by-phase".
+ *
+ * Per-phase failures are CONTAINED — one adapter exception writes a
+ * `{mode: "unavailable", errorReason}` slot for that phase but does NOT
+ * abort the sibling phases. The top-level aggregate uses only the
+ * successful phases.
+ */
+async function runSegmentedProsody(
+  args: RunSegmentedProsodyArgs,
+): Promise<VendorAttemptResult> {
+  log("system", "voice.prosody.segmented_start", {
+    level: "info",
+    callId: args.callId,
+    phaseCount: args.boundaries.length,
+  });
+
+  const bySegment: Record<string, ProsodyPhaseEnvelope> = {};
+  let lastErrorMessage: string | undefined;
+  let firstSetupError: unknown = null;
+
+  for (const boundary of args.boundaries) {
+    // #1872 — namespace prefix on segmentKey writes to avoid collision
+    // with the text-side Theme 6 Mock segmenter ("part1" / "part2" /
+    // "part3"). Operator-chosen phase names ("p1" / "p2_prep" / etc.)
+    // are wrapped here; the AGGREGATE consumer mirrors the prefix when
+    // writing CallScore rows.
+    const phaseKey = `phase:${boundary.phase}`;
+
+    let phaseEnvelope: ProsodyPhaseEnvelope;
+    try {
+      const slice = await extractAudioSlice({
+        audioUrl: args.recordingUrl,
+        startSec: boundary.startSec,
+        endSec: boundary.endSec,
+      });
+      const sliceBuffer = Buffer.from(slice.buffer ?? new Uint8Array(0));
+      const scoringMode: ScoringMode =
+        args.mode === "ielts" ? "ielts" : "general";
+      const result = await Promise.race([
+        args.adapter.scoreUploadedAudio(
+          sliceBuffer,
+          slice.contentType,
+          scoringMode,
+        ),
+        timeoutAfter(args.vendorTimeoutMs),
+      ]);
+      const whole = normaliseVendorResult(result, args.mode);
+      if (whole.mode === "ielts" && whole.ieltsScores) {
+        phaseEnvelope = { mode: "ielts", ieltsScores: whole.ieltsScores };
+      } else if (whole.mode === "general" && whole.generalSignals) {
+        phaseEnvelope = { mode: "general", generalSignals: whole.generalSignals };
+      } else {
+        phaseEnvelope = {
+          mode: "unavailable",
+          errorReason: whole.errorReason ?? "vendor_error",
+        };
+      }
+      log("system", "voice.prosody.segmented_phase_scored", {
+        level: "info",
+        callId: args.callId,
+        phaseKey,
+        criterionCount:
+          phaseEnvelope.mode === "ielts"
+            ? 4
+            : phaseEnvelope.mode === "general"
+            ? 2
+            : 0,
+      });
+    } catch (err) {
+      // AudioSliceError host_not_allowed on the FIRST phase indicates
+      // a configuration failure — propagate so the caller falls back
+      // to whole-call. Same for any setup-class error that hits all
+      // phases.
+      if (
+        Object.keys(bySegment).length === 0 &&
+        err instanceof AudioSliceError &&
+        err.code === "host_not_allowed"
+      ) {
+        firstSetupError = err;
+        break;
+      }
+      const isTimeout =
+        err instanceof Error && err.message === "PROSODY_VENDOR_TIMEOUT";
+      const errorReason = isTimeout ? "vendor_timeout" : "vendor_error";
+      phaseEnvelope = { mode: "unavailable", errorReason };
+      lastErrorMessage = err instanceof Error ? err.message : String(err);
+      log("system", "voice.prosody.segmented_phase_failed", {
+        level: "warn",
+        callId: args.callId,
+        phaseKey,
+        errorReason,
+        error: lastErrorMessage,
+      });
+    }
+    bySegment[phaseKey] = phaseEnvelope;
+  }
+
+  if (firstSetupError) {
+    throw firstSetupError;
+  }
+
+  // Aggregate top-level fields from the successful phases. Readers that
+  // only inspect top-level `ieltsScores` / `generalSignals` keep working
+  // — they see the MEAN across successful phases (AC: "top-level fields
+  // remain populated for backwards-compat").
+  const envelope = aggregateBySegment(bySegment, args.mode);
+  return { envelope, errorMessage: lastErrorMessage };
+}
+
+/**
+ * Aggregate per-phase envelopes into the top-level fields. Skips
+ * "unavailable" phases. Returns the parent envelope shape (top-level
+ * fields + `bySegment`).
+ *
+ * IELTS mode: MEAN per sub-band across successful IELTS phases.
+ * General mode: MEAN per field, skipping zeros (the existing vendor
+ *   stub returns 0 for all four signals until adapters expose general
+ *   prosody — comment lives at `prosody-runner.ts::normaliseVendorResult`
+ *   general branch). When every successful phase reports 0 for a
+ *   field, the field stays 0 — fine, matches the stub semantics.
+ */
+function aggregateBySegment(
+  bySegment: Record<string, ProsodyPhaseEnvelope>,
+  mode: VoiceProsodyMode,
+): VoiceProsodyFeatures {
+  const phases = Object.values(bySegment);
+  const successful = phases.filter(
+    (p): p is Exclude<ProsodyPhaseEnvelope, { mode: "unavailable" }> =>
+      p.mode !== "unavailable",
+  );
+
+  // Every phase failed → top-level "unavailable"; preserve bySegment
+  // for forensics.
+  if (successful.length === 0) {
+    return {
+      mode: "unavailable",
+      errorReason: "vendor_error",
+      bySegment,
+    };
+  }
+
+  if (mode === "ielts") {
+    const ieltsPhases = successful.filter(
+      (p): p is { mode: "ielts"; ieltsScores: IeltsScores } => p.mode === "ielts",
+    );
+    if (ieltsPhases.length === 0) {
+      return {
+        mode: "unavailable",
+        errorReason: "vendor_error",
+        bySegment,
+      };
+    }
+    const ieltsScores: IeltsScores = {
+      overall: mean(ieltsPhases.map((p) => p.ieltsScores.overall)),
+      pronunciation: mean(ieltsPhases.map((p) => p.ieltsScores.pronunciation)),
+      fluencyCoherence: mean(ieltsPhases.map((p) => p.ieltsScores.fluencyCoherence)),
+      lexicalResource: mean(ieltsPhases.map((p) => p.ieltsScores.lexicalResource)),
+      grammaticalRange: mean(ieltsPhases.map((p) => p.ieltsScores.grammaticalRange)),
+    };
+    return { mode: "ielts", ieltsScores, bySegment };
+  }
+
+  const generalPhases = successful.filter(
+    (p): p is { mode: "general"; generalSignals: GeneralSignals } =>
+      p.mode === "general",
+  );
+  if (generalPhases.length === 0) {
+    return {
+      mode: "unavailable",
+      errorReason: "vendor_error",
+      bySegment,
+    };
+  }
+  // Per-field stub-aware mean — skip 0 values (the existing vendor stub
+  // sentinel at `normaliseVendorResult` general branch). If every
+  // contributing phase is 0, the result stays 0; semantics match the
+  // whole-call stub.
+  const generalSignals: GeneralSignals = {
+    paceWpm: meanSkipZero(generalPhases.map((p) => p.generalSignals.paceWpm)),
+    hesitationRate: meanSkipZero(
+      generalPhases.map((p) => p.generalSignals.hesitationRate),
+    ),
+    meanEnergyDb: meanSkipZero(
+      generalPhases.map((p) => p.generalSignals.meanEnergyDb),
+    ),
+    pitchRangeHz: meanSkipZero(
+      generalPhases.map((p) => p.generalSignals.pitchRangeHz),
+    ),
+    confidenceProxy: mean(
+      generalPhases.map((p) => p.generalSignals.confidenceProxy),
+    ),
+  };
+  return { mode: "general", generalSignals, bySegment };
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  let sum = 0;
+  let count = 0;
+  for (const v of values) {
+    if (Number.isFinite(v)) {
+      sum += v;
+      count++;
+    }
+  }
+  return count === 0 ? 0 : sum / count;
+}
+
+function meanSkipZero(values: number[]): number {
+  const nonZero = values.filter((v) => Number.isFinite(v) && v !== 0);
+  if (nonZero.length === 0) return 0;
+  return nonZero.reduce((a, b) => a + b, 0) / nonZero.length;
 }

--- a/apps/admin/lib/pipeline/prosody-types.ts
+++ b/apps/admin/lib/pipeline/prosody-types.ts
@@ -46,6 +46,20 @@ export interface GeneralSignals {
   confidenceProxy: number;
 }
 
+/**
+ * Per-phase sub-envelope written when segmented scoring fires (#1870).
+ * Either an IELTS sub-band block, a generic signals block, or an
+ * "unavailable" marker for the phase the adapter failed on. Top-level
+ * `ieltsScores` / `generalSignals` on the parent envelope are the
+ * MEAN aggregate across the successful phases so existing readers
+ * (Snapshot v3, AGGREGATE consumer's whole-call branch, Adaptations
+ * tab) stay backwards-compat.
+ */
+export type ProsodyPhaseEnvelope =
+  | { mode: "ielts"; ieltsScores: IeltsScores }
+  | { mode: "general"; generalSignals: GeneralSignals }
+  | { mode: "unavailable"; errorReason: VoiceProsodyErrorReason };
+
 export interface VoiceProsodyFeatures {
   mode: VoiceProsodyMode;
   ieltsScores?: IeltsScores;
@@ -54,6 +68,15 @@ export interface VoiceProsodyFeatures {
   errorReason?: VoiceProsodyErrorReason;
   /** Verbatim vendor JSON, kept for forensics; never read in shared code. */
   rawVendor?: unknown;
+  /**
+   * #1870 — Per-phase score envelopes when the runner ran segmented
+   * scoring. Keys are the namespace-prefixed phaseKey (`phase:<name>`)
+   * — see [#1872](https://github.com/WANDERCOLTD/HF/issues/1872) for
+   * the namespace decision (Option 2 — namespace prefix). When
+   * absent, the envelope was produced by whole-call scoring (pre-#1870
+   * behaviour) and downstream readers see only the top-level fields.
+   */
+  bySegment?: Record<string, ProsodyPhaseEnvelope>;
 }
 
 export const VOICE_PROSODY_CONTRACT_ID = "VOICE_PROSODY_V1" as const;

--- a/apps/admin/lib/voice/system-settings.ts
+++ b/apps/admin/lib/voice/system-settings.ts
@@ -39,6 +39,12 @@ export interface VoiceSystemSettings {
    *  when calling SpeechAce / SpeechSuper. Default 30s leaves headroom
    *  inside Cloud Run's 60s request budget. */
   vendorTimeoutMs: number;
+  /** #1870 — Per-call cap on segmented PROSODY scoring. When a call has
+   *  more than this many `Session.metadata.phaseBoundaries[]`, the
+   *  runner falls back to whole-call scoring and logs
+   *  `voice.prosody.segments_capped`. Default 5 covers IELTS Mock's
+   *  4 phases plus headroom. */
+  maxSegmentsPerCall: number;
 }
 
 export const VOICE_SYSTEM_DEFAULTS: VoiceSystemSettings = {
@@ -57,6 +63,7 @@ export const VOICE_SYSTEM_DEFAULTS: VoiceSystemSettings = {
     "have a nice day",
   ],
   vendorTimeoutMs: 30000,
+  maxSegmentsPerCall: 5,
 };
 
 const SINGLETON_ID = "singleton";
@@ -83,6 +90,7 @@ function rowToSettings(
     voicemailDetectionEnabled: row.voicemailDetectionEnabled,
     endCallPhrases: row.endCallPhrases,
     vendorTimeoutMs: row.vendorTimeoutMs,
+    maxSegmentsPerCall: row.maxSegmentsPerCall,
   };
 }
 

--- a/apps/admin/prisma/migrations/20260617120000_1870_max_segments_per_call/migration.sql
+++ b/apps/admin/prisma/migrations/20260617120000_1870_max_segments_per_call/migration.sql
@@ -1,0 +1,15 @@
+-- #1870 — Per-call cap on segmented PROSODY scoring.
+--
+-- `VoiceSystemSettings.maxSegmentsPerCall` bounds the number of vendor
+-- invocations a single call's segmented PROSODY scoring may produce.
+-- When `Session.metadata.phaseBoundaries.length` exceeds this value,
+-- the runner falls back to whole-call scoring (one vendor invocation)
+-- and logs `voice.prosody.segments_capped`.
+--
+-- Default 5 covers IELTS Mock (Part 1 / Part 2 prep / Part 2 monologue
+-- / Part 3 = 4 phases) plus headroom. Additive + safe-default — no
+-- behaviour change for existing rows (the field reads as default until
+-- a phaseBoundaries population exists).
+
+ALTER TABLE "VoiceSystemSettings"
+  ADD COLUMN IF NOT EXISTS "maxSegmentsPerCall" INTEGER NOT NULL DEFAULT 5;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -5316,6 +5316,13 @@ model VoiceSystemSettings {
   // continues, AGGREGATE skips prosody-dependent writes for the call.
   vendorTimeoutMs Int @default(30000)
 
+  // #1870 — Per-call cap on segmented PROSODY scoring. When a call has
+  // more than this many `Session.metadata.phaseBoundaries[]` entries,
+  // the runner falls back to whole-call scoring (one vendor invocation)
+  // instead of N. Default 5 = IELTS Mock 4-phase budget + 1 headroom.
+  // On over-cap, emits AppLog `voice.prosody.segments_capped`.
+  maxSegmentsPerCall Int @default(5)
+
   updatedAt DateTime @updatedAt
   createdAt DateTime @default(now())
 }

--- a/apps/admin/tests/lib/pipeline/prosody-consumer-segmented.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-consumer-segmented.test.ts
@@ -1,0 +1,257 @@
+/**
+ * #1870 — Segmented PROSODY consumer.
+ *
+ * Defends:
+ *   - `bySegment` envelope with 3 phases → 3×4 IELTS CallScore rows
+ *     written with `segmentKey = "phase:<phaseKey>"` (per #1872 Option 2
+ *     namespace decision) + 4 aggregate rows with `segmentKey = null`
+ *   - Whole-call envelope (no bySegment) → existing behaviour unchanged
+ *     (4 IELTS rows, segmentKey null)
+ *   - Per-phase "unavailable" entries skipped silently — no row written
+ *
+ * Sibling: `prosody-consumer.test.ts` pins the parameter-routing
+ * contract for the whole-call branch. This file covers the new
+ * `bySegment` branch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { VoiceProsodyFeatures } from "@/lib/pipeline/prosody-types";
+
+const { mockPrisma, mockWriteCallScore } = vi.hoisted(() => ({
+  mockPrisma: {
+    call: { findUnique: vi.fn() },
+  },
+  mockWriteCallScore: vi.fn().mockResolvedValue({ id: "cs-1", created: true }),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+vi.mock("@/lib/measurement/write-call-score", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/measurement/write-call-score")
+  >("@/lib/measurement/write-call-score");
+  return {
+    ...actual,
+    writeCallScore: (...args: unknown[]) => mockWriteCallScore(...args),
+  };
+});
+
+describe("prosody-consumer — bySegment branch (#1870)", () => {
+  let applyProsodyContractToAggregate: typeof import("@/lib/pipeline/prosody-consumer").applyProsodyContractToAggregate;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mod = await import("@/lib/pipeline/prosody-consumer");
+    applyProsodyContractToAggregate = mod.applyProsodyContractToAggregate;
+  });
+
+  it("3-phase IELTS envelope writes 3×4 per-phase + 4 aggregate rows; all carry phase: prefix or null", async () => {
+    const envelope: VoiceProsodyFeatures = {
+      mode: "ielts",
+      ieltsScores: {
+        overall: 7,
+        pronunciation: 7,
+        fluencyCoherence: 7,
+        lexicalResource: 7,
+        grammaticalRange: 7,
+      },
+      bySegment: {
+        "phase:p1": {
+          mode: "ielts",
+          ieltsScores: {
+            overall: 6,
+            pronunciation: 6,
+            fluencyCoherence: 6,
+            lexicalResource: 6,
+            grammaticalRange: 6,
+          },
+        },
+        "phase:p2_monologue": {
+          mode: "ielts",
+          ieltsScores: {
+            overall: 7,
+            pronunciation: 7,
+            fluencyCoherence: 7,
+            lexicalResource: 7,
+            grammaticalRange: 7,
+          },
+        },
+        "phase:p3": {
+          mode: "ielts",
+          ieltsScores: {
+            overall: 8,
+            pronunciation: 8,
+            fluencyCoherence: 8,
+            lexicalResource: 8,
+            grammaticalRange: 8,
+          },
+        },
+      },
+    };
+    mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+    const result = await applyProsodyContractToAggregate("call-1", "caller-1");
+
+    // 3 phases × 4 criteria + 4 aggregate criteria = 16 writes
+    expect(result.applied).toBe(true);
+    expect(result.mode).toBe("ielts");
+    expect(result.scoresWritten).toBe(16);
+
+    const segmentKeys = mockWriteCallScore.mock.calls.map(
+      (c) => (c[0] as { segmentKey?: string | null }).segmentKey,
+    );
+    // 12 rows carry namespaced phase keys
+    expect(segmentKeys.filter((k) => k === "phase:p1").length).toBe(4);
+    expect(segmentKeys.filter((k) => k === "phase:p2_monologue").length).toBe(4);
+    expect(segmentKeys.filter((k) => k === "phase:p3").length).toBe(4);
+    // 4 aggregate rows carry segmentKey null
+    expect(segmentKeys.filter((k) => k === null).length).toBe(4);
+    // No bare phase names — these would collide with the text segmenter's
+    // "part1"/"part2"/"part3" namespace per #1872
+    expect(segmentKeys.some((k) => k === "p1" || k === "p2_monologue" || k === "p3")).toBe(
+      false,
+    );
+  });
+
+  it("3-phase general envelope writes 3×2 per-phase + 2 aggregate rows", async () => {
+    const phase = (paceWpm: number, hesitationRate: number) => ({
+      mode: "general" as const,
+      generalSignals: {
+        paceWpm,
+        hesitationRate,
+        meanEnergyDb: 0,
+        pitchRangeHz: 0,
+        confidenceProxy: 0.5,
+      },
+    });
+    const envelope: VoiceProsodyFeatures = {
+      mode: "general",
+      generalSignals: {
+        paceWpm: 130,
+        hesitationRate: 0.2,
+        meanEnergyDb: 0,
+        pitchRangeHz: 0,
+        confidenceProxy: 0.5,
+      },
+      bySegment: {
+        "phase:intro": phase(110, 0.3),
+        "phase:main": phase(130, 0.2),
+        "phase:wrap": phase(150, 0.1),
+      },
+    };
+    mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+    const result = await applyProsodyContractToAggregate("call-1", "caller-1");
+
+    // 3 phases × 2 signals + 2 aggregate signals = 8 writes
+    expect(result.scoresWritten).toBe(8);
+    const paramIds = mockWriteCallScore.mock.calls.map(
+      (c) => (c[0] as { parameterId: string }).parameterId,
+    );
+    expect(paramIds).toContain("prosody_pace_wpm");
+    expect(paramIds).toContain("prosody_hesitation_rate");
+    // Per-phase keys present
+    const segmentKeys = mockWriteCallScore.mock.calls.map(
+      (c) => (c[0] as { segmentKey?: string | null }).segmentKey,
+    );
+    expect(segmentKeys).toContain("phase:intro");
+    expect(segmentKeys).toContain("phase:main");
+    expect(segmentKeys).toContain("phase:wrap");
+  });
+
+  it("per-phase 'unavailable' entries are skipped (no row written for that phase)", async () => {
+    const envelope: VoiceProsodyFeatures = {
+      mode: "ielts",
+      ieltsScores: {
+        overall: 7,
+        pronunciation: 7,
+        fluencyCoherence: 7,
+        lexicalResource: 7,
+        grammaticalRange: 7,
+      },
+      bySegment: {
+        "phase:p1": {
+          mode: "ielts",
+          ieltsScores: {
+            overall: 6,
+            pronunciation: 6,
+            fluencyCoherence: 6,
+            lexicalResource: 6,
+            grammaticalRange: 6,
+          },
+        },
+        "phase:p2_monologue": {
+          mode: "unavailable",
+          errorReason: "vendor_error",
+        },
+        "phase:p3": {
+          mode: "ielts",
+          ieltsScores: {
+            overall: 8,
+            pronunciation: 8,
+            fluencyCoherence: 8,
+            lexicalResource: 8,
+            grammaticalRange: 8,
+          },
+        },
+      },
+    };
+    mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+    const result = await applyProsodyContractToAggregate("call-1", "caller-1");
+
+    // 2 ielts phases × 4 + 4 aggregate = 12
+    expect(result.scoresWritten).toBe(12);
+    const segmentKeys = mockWriteCallScore.mock.calls.map(
+      (c) => (c[0] as { segmentKey?: string | null }).segmentKey,
+    );
+    expect(segmentKeys.filter((k) => k === "phase:p2_monologue").length).toBe(0);
+  });
+
+  it("no bySegment → existing whole-call behaviour unchanged (4 IELTS rows, no segmentKey)", async () => {
+    const envelope: VoiceProsodyFeatures = {
+      mode: "ielts",
+      ieltsScores: {
+        overall: 7,
+        pronunciation: 7,
+        fluencyCoherence: 7,
+        lexicalResource: 7,
+        grammaticalRange: 7,
+      },
+    };
+    mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+    const result = await applyProsodyContractToAggregate("call-1", "caller-1");
+
+    expect(result.scoresWritten).toBe(4);
+    const segmentKeys = mockWriteCallScore.mock.calls.map(
+      (c) => (c[0] as { segmentKey?: string | null }).segmentKey,
+    );
+    // Whole-call rows MUST carry segmentKey null (pinned — adding a
+    // phase-prefix here would break backwards-compat with non-Mock
+    // readers).
+    expect(segmentKeys.every((k) => k === null)).toBe(true);
+  });
+
+  it("top-level 'unavailable' WITH bySegment populated still iterates per-phase writes", async () => {
+    // Every phase failed but bySegment captured the failures for forensics.
+    const envelope: VoiceProsodyFeatures = {
+      mode: "unavailable",
+      errorReason: "vendor_error",
+      bySegment: {
+        "phase:p1": { mode: "unavailable", errorReason: "vendor_error" },
+        "phase:p2": { mode: "unavailable", errorReason: "vendor_timeout" },
+      },
+    };
+    mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+    const result = await applyProsodyContractToAggregate("call-1", "caller-1");
+
+    // Both phases unavailable → no per-phase rows; no aggregate (top-level
+    // also unavailable). applied=true because the segmented branch was
+    // entered.
+    expect(result.scoresWritten).toBe(0);
+    expect(mockWriteCallScore).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/pipeline/prosody-runner-segmented.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-runner-segmented.test.ts
@@ -1,0 +1,390 @@
+/**
+ * #1870 — Segmented PROSODY runner (consume Stories B/C/D).
+ *
+ * Defends:
+ *   - No phaseBoundaries → byte-identical behaviour to whole-call path
+ *     (pre-#1870 baseline preserved)
+ *   - 1-phase boundary → segmented path NOT taken (needs >= 2)
+ *   - 3-phase IELTS Mock → 3 adapter invocations + per-phase envelopes +
+ *     top-level aggregate = MEAN of successful phases
+ *   - Adapter throws on phase 2 of 3 → phases 1 + 3 succeed, phase 2 has
+ *     mode:"unavailable", aggregate uses only successful phases
+ *   - boundaries.length > cap → AppLog + whole-call fallback (one
+ *     invocation, not N)
+ *   - 3-phase general mode → 3 invocations, top-level aggregate is
+ *     stub-aware mean across general signals
+ *
+ * Namespace: `segmentKey` writes use `phase:<phaseKey>` prefix per
+ * #1872 Option 2. This test pins the runner-side envelope shape; the
+ * consumer-side write is pinned in
+ * `prosody-consumer-segmented.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SessionMetadata } from "@/lib/types/json-fields";
+
+// ── Mocks ─────────────────────────────────────────────────
+
+const mockCallFindUnique = vi.fn();
+const mockCallUpdate = vi.fn();
+const mockPlaybookFindUnique = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    call: { findUnique: mockCallFindUnique, update: mockCallUpdate },
+    playbook: { findUnique: mockPlaybookFindUnique },
+  },
+}));
+
+const mockGetVoiceSystemSettings = vi.fn();
+vi.mock("@/lib/voice/system-settings", () => ({
+  getVoiceSystemSettings: () => mockGetVoiceSystemSettings(),
+}));
+
+const mockResolveProvider = vi.fn();
+const mockGetProvider = vi.fn();
+vi.mock("@/lib/voice/resolve-speech-assessment-provider", () => ({
+  resolveSpeechAssessmentProviderForCall: (...args: unknown[]) =>
+    mockResolveProvider(...args),
+}));
+vi.mock("@/lib/speech-assessment/provider-factory", () => ({
+  getSpeechAssessmentProvider: (...args: unknown[]) =>
+    mockGetProvider(...args),
+}));
+
+vi.mock("@/lib/voice/telemetry", () => ({
+  logVoiceEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/pipeline/adaptive-loop-invariants", () => ({
+  recordIAL4ProsodySkip: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: vi.fn(),
+}));
+
+// Mock audio-slice so we can stub the buffer return without doing HTTP.
+const mockExtractAudioSlice = vi.fn();
+vi.mock("@/lib/voice/audio-slice", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/voice/audio-slice")>(
+    "@/lib/voice/audio-slice",
+  );
+  return {
+    ...actual,
+    extractAudioSlice: (...args: unknown[]) => mockExtractAudioSlice(...args),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCallUpdate.mockResolvedValue({});
+  mockGetVoiceSystemSettings.mockResolvedValue({
+    vendorTimeoutMs: 30000,
+    fallbackOnAdapterError: "throw",
+    maxCostPerCallUsd: null,
+    auditRetentionDays: 90,
+    defaultProviderSlug: "",
+    silenceTimeoutSeconds: 30,
+    maxDurationSeconds: 600,
+    voicemailDetectionEnabled: false,
+    endCallPhrases: [],
+    maxSegmentsPerCall: 5,
+  });
+  // Default segmented branch — return a tiny buffer for each slice call.
+  mockExtractAudioSlice.mockImplementation(async () => ({
+    buffer: new Uint8Array(8),
+    url: "https://storage.vapi.ai/x.wav",
+    startByte: 0,
+    endByte: 7,
+    startSec: 0,
+    endSec: 10,
+    contentType: "audio/wav",
+    strategy: "byte-range-proxy" as const,
+    format: {
+      audioFormat: 1,
+      channels: 1,
+      sampleRate: 16000,
+      bitsPerSample: 16,
+      dataOffset: 44,
+      dataLength: 1000,
+    },
+  }));
+});
+
+interface CallRowOverrides {
+  stereoRecordingUrl?: string | null;
+  playbookId?: string | null;
+  voiceProsody?: unknown;
+  phaseBoundaries?: SessionMetadata["phaseBoundaries"];
+}
+
+const callRow = (overrides: CallRowOverrides) => {
+  const metadata: SessionMetadata = overrides.phaseBoundaries
+    ? { phaseBoundaries: overrides.phaseBoundaries }
+    : {};
+  mockCallFindUnique.mockResolvedValue({
+    id: "c1",
+    stereoRecordingUrl:
+      overrides.stereoRecordingUrl === undefined
+        ? "https://storage.vapi.ai/abc.wav"
+        : overrides.stereoRecordingUrl,
+    playbookId: overrides.playbookId ?? "pb-ielts-v1",
+    voiceProsody: overrides.voiceProsody ?? null,
+    session: overrides.phaseBoundaries
+      ? { metadata: metadata as unknown as object }
+      : { metadata: null },
+  });
+};
+
+const playbookTier = (tierPresetId: string | null) => {
+  mockPlaybookFindUnique.mockResolvedValue({
+    config: tierPresetId ? { tierPresetId } : {},
+  });
+};
+
+/**
+ * Adapter stub that returns per-invocation IELTS scores, allowing tests
+ * to assert N invocations + per-phase envelope shape.
+ */
+const ieltsAdapter = (perCallResults: number[]) => {
+  let i = 0;
+  const scoreUploadedAudio = vi.fn(async () => {
+    const overall = perCallResults[i++];
+    return {
+      ielts: {
+        overall,
+        pronunciation: overall,
+        fluency: overall,
+        vocabulary: overall,
+        grammar: overall,
+      },
+      raw: {},
+    };
+  });
+  mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+  mockGetProvider.mockResolvedValue({
+    slug: "speechace",
+    scoreUploadedAudio,
+  });
+  return scoreUploadedAudio;
+};
+
+const stubFetch = () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    headers: { get: () => "audio/wav" },
+  }) as unknown as typeof fetch;
+};
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("runProsodyStage — no phaseBoundaries → byte-identical whole-call (#1870)", () => {
+  it("calls vendor once and writes no bySegment when boundaries absent", async () => {
+    callRow({});
+    playbookTier("ielts-speaking");
+    stubFetch();
+    const scorer = ieltsAdapter([6.5]);
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+    expect(scorer).toHaveBeenCalledTimes(1);
+    expect(result.envelope.mode).toBe("ielts");
+    if (result.envelope.mode === "ielts") {
+      expect(result.envelope.ieltsScores?.overall).toBe(6.5);
+    }
+    expect(result.envelope.bySegment).toBeUndefined();
+    expect(mockExtractAudioSlice).not.toHaveBeenCalled();
+  });
+});
+
+describe("runProsodyStage — 1-phase boundary degenerates to whole-call (#1870)", () => {
+  it("single boundary is treated as whole-call (segmented requires >= 2)", async () => {
+    callRow({
+      phaseBoundaries: [{ phase: "p1", startSec: 0, endSec: 30 }],
+    });
+    playbookTier("ielts-speaking");
+    stubFetch();
+    const scorer = ieltsAdapter([7.0]);
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+    expect(scorer).toHaveBeenCalledTimes(1);
+    expect(result.envelope.bySegment).toBeUndefined();
+    expect(mockExtractAudioSlice).not.toHaveBeenCalled();
+  });
+});
+
+describe("runProsodyStage — 3-phase IELTS Mock (#1870)", () => {
+  it("invokes adapter 3 times, writes per-phase envelopes, aggregates by mean", async () => {
+    callRow({
+      phaseBoundaries: [
+        { phase: "p1", startSec: 0, endSec: 30 },
+        { phase: "p2_monologue", startSec: 30, endSec: 90 },
+        { phase: "p3", startSec: 90, endSec: 150 },
+      ],
+    });
+    playbookTier("ielts-speaking");
+    stubFetch();
+    const scorer = ieltsAdapter([6.0, 7.0, 8.0]);
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(scorer).toHaveBeenCalledTimes(3);
+    expect(mockExtractAudioSlice).toHaveBeenCalledTimes(3);
+    expect(result.envelope.mode).toBe("ielts");
+    expect(result.envelope.bySegment).toBeDefined();
+    expect(Object.keys(result.envelope.bySegment ?? {})).toEqual([
+      "phase:p1",
+      "phase:p2_monologue",
+      "phase:p3",
+    ]);
+    // Top-level aggregate = mean(6, 7, 8) = 7
+    if (result.envelope.mode === "ielts") {
+      expect(result.envelope.ieltsScores?.overall).toBe(7);
+      expect(result.envelope.ieltsScores?.pronunciation).toBe(7);
+    }
+    // Per-phase preserves the raw band
+    const seg = result.envelope.bySegment ?? {};
+    expect(seg["phase:p1"]).toMatchObject({ mode: "ielts" });
+    if (seg["phase:p1"]?.mode === "ielts") {
+      expect(seg["phase:p1"].ieltsScores.overall).toBe(6);
+    }
+  });
+});
+
+describe("runProsodyStage — partial-failure tolerance (#1870)", () => {
+  it("adapter throws on phase 2 of 3 → sibling phases continue, aggregate uses successes only", async () => {
+    callRow({
+      phaseBoundaries: [
+        { phase: "p1", startSec: 0, endSec: 30 },
+        { phase: "p2_monologue", startSec: 30, endSec: 90 },
+        { phase: "p3", startSec: 90, endSec: 150 },
+      ],
+    });
+    playbookTier("ielts-speaking");
+    stubFetch();
+    let i = 0;
+    const perCall: Array<() => Promise<unknown>> = [
+      async () => ({
+        ielts: { overall: 6, pronunciation: 6, fluency: 6, vocabulary: 6, grammar: 6 },
+        raw: {},
+      }),
+      async () => {
+        throw new Error("vendor 502");
+      },
+      async () => ({
+        ielts: { overall: 8, pronunciation: 8, fluency: 8, vocabulary: 8, grammar: 8 },
+        raw: {},
+      }),
+    ];
+    const scorer = vi.fn(async () => perCall[i++]());
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({ slug: "speechace", scoreUploadedAudio: scorer });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(scorer).toHaveBeenCalledTimes(3);
+    const seg = result.envelope.bySegment ?? {};
+    expect(seg["phase:p1"]?.mode).toBe("ielts");
+    expect(seg["phase:p2_monologue"]?.mode).toBe("unavailable");
+    expect(seg["phase:p3"]?.mode).toBe("ielts");
+    // Top-level aggregate uses 6 and 8 only → mean = 7
+    if (result.envelope.mode === "ielts") {
+      expect(result.envelope.ieltsScores?.overall).toBe(7);
+    }
+  });
+});
+
+describe("runProsodyStage — cost cap (#1870)", () => {
+  it("boundaries > cap → falls back to whole-call (1 invocation), AppLog emitted", async () => {
+    mockGetVoiceSystemSettings.mockResolvedValueOnce({
+      vendorTimeoutMs: 30000,
+      fallbackOnAdapterError: "throw",
+      maxCostPerCallUsd: null,
+      auditRetentionDays: 90,
+      defaultProviderSlug: "",
+      silenceTimeoutSeconds: 30,
+      maxDurationSeconds: 600,
+      voicemailDetectionEnabled: false,
+      endCallPhrases: [],
+      // tight cap to trigger the fallback
+      maxSegmentsPerCall: 2,
+    });
+    callRow({
+      phaseBoundaries: [
+        { phase: "p1", startSec: 0, endSec: 10 },
+        { phase: "p2_prep", startSec: 10, endSec: 20 },
+        { phase: "p2_monologue", startSec: 20, endSec: 80 },
+        { phase: "p3", startSec: 80, endSec: 140 },
+      ],
+    });
+    playbookTier("ielts-speaking");
+    stubFetch();
+    const scorer = ieltsAdapter([6.5]);
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(scorer).toHaveBeenCalledTimes(1);
+    expect(mockExtractAudioSlice).not.toHaveBeenCalled();
+    expect(result.envelope.bySegment).toBeUndefined();
+    // AppLog stub was called with the segments_capped subject — fetch the
+    // logged calls (we mocked the whole module).
+    const { log } = await import("@/lib/logger");
+    expect(log).toHaveBeenCalledWith(
+      "system",
+      "voice.prosody.segments_capped",
+      expect.objectContaining({ callId: "c1", phaseCount: 4, cap: 2 }),
+    );
+  });
+});
+
+describe("runProsodyStage — 3-phase general mode (#1870)", () => {
+  it("invokes adapter 3 times, aggregates general signals across phases", async () => {
+    callRow({
+      playbookId: "pb-general-v1",
+      phaseBoundaries: [
+        { phase: "intro", startSec: 0, endSec: 30 },
+        { phase: "main", startSec: 30, endSec: 90 },
+        { phase: "wrap", startSec: 90, endSec: 120 },
+      ],
+    });
+    // No tierPreset → general mode
+    playbookTier(null);
+    stubFetch();
+    // General mode derives confidenceProxy from fluency; rest are 0
+    // (stub sentinel). Successive ielts.fluency values produce
+    // different confidenceProxy values (mean across phases).
+    let i = 0;
+    const perCall = [4.5, 6.0, 7.5];
+    const scorer = vi.fn(async () => ({
+      ielts: { overall: 0, pronunciation: 0, fluency: perCall[i++] },
+      raw: {},
+    }));
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({ slug: "speechace", scoreUploadedAudio: scorer });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(scorer).toHaveBeenCalledTimes(3);
+    expect(result.envelope.mode).toBe("general");
+    expect(result.envelope.bySegment).toBeDefined();
+    if (result.envelope.mode === "general") {
+      // mean(min(1, 4.5/9), min(1, 6/9), min(1, 7.5/9))
+      //   = mean(0.5, 0.6667, 0.8333) ≈ 0.6667
+      expect(result.envelope.generalSignals?.confidenceProxy).toBeCloseTo(
+        (0.5 + 6 / 9 + 7.5 / 9) / 3,
+        4,
+      );
+      // paceWpm/hesitationRate/meanEnergyDb/pitchRangeHz are all 0 in the
+      // stub. meanSkipZero of [0, 0, 0] returns 0 — documented in
+      // aggregateBySegment's general branch.
+      expect(result.envelope.generalSignals?.paceWpm).toBe(0);
+      expect(result.envelope.generalSignals?.hesitationRate).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Wires `runProsodyStage` to consume per-phase primitives shipped by Stories B (#1862), C (#1866), D (#1865) — when `Session.metadata.phaseBoundaries[]` is populated, branches to segmented scoring (one vendor invocation per phase). Otherwise byte-identical to today's whole-call path.
- Per-phase envelopes land in a new optional `VoiceProsodyFeatures.bySegment` field. Top-level `ieltsScores` / `generalSignals` are the MEAN across successful phases so existing readers (Snapshot v3, AGGREGATE consumer's whole-call branch, Adaptations tab) keep working.
- AGGREGATE consumer iterates `bySegment` and writes per-phase `CallScore` rows via the existing `writeCallScore` chokepoint with `segmentKey = "phase:<phaseKey>"`. Per #1872 Option 2 namespace decision (issue still open at commit time) — the `phase:` prefix avoids collision with the Theme 6 text segmenter's `"part1"` / `"part2"` / `"part3"` keys.
- Cost cap: new `VoiceSystemSettings.maxSegmentsPerCall` (default 5 = IELTS Mock 4-phase + headroom). Over-cap calls log `voice.prosody.segments_capped` and fall back to whole-call **entirely** — not first-N phases — so cross-phase cohesion is preserved.
- Per-phase failures are CONTAINED: an adapter exception writes `{mode: "unavailable", errorReason}` for that phase and sibling phases continue. Top-level aggregate uses only successful phases.
- New AppLog subjects: `voice.prosody.segmented_start`, `voice.prosody.segmented_phase_scored`, `voice.prosody.segmented_phase_failed`, `voice.prosody.segments_capped`, `voice.prosody.segment_url_not_allowed`.

## Lattice survey

Sibling-writer scan on `CallScore.segmentKey` writes:

- Theme 6 text segmenter (#1702 → `pipeline/route.ts:787-788`) writes bare `"part1"` / `"part2"` / `"part3"`. Namespace collision closed via `"phase:"` prefix [verified at `prosody-consumer.ts:108` + `prosody-runner.ts` segmented branch].
- No ESLint rule scopes `prosody-consumer.ts` or `voiceProsody`; the existing `writeCallScore` chokepoint and the PROSODY sentinel `analysisSpecId` are reused — no new guard required.
- Cascade respect: `resolveProsodyMode(config)` reused verbatim from `prosody-runner.ts:288` [verified] — operator's explicit `voice.prosodyMode` wins over `tierPresetId` heuristic.
- Default-deny gate: no new gate required; runner reuses `recordIAL4ProsodySkip` for all skip paths.

`turnsInWindow` (Story B helper) intentionally NOT consumed by this PR — the runner hands the sliced audio buffer to the vendor adapter, which performs its own diarisation. A future "learner-only audio" optimisation could call `turnsInWindow` to drop tutor segments before slicing.

## Verified by

- **New tests:** `tests/lib/pipeline/prosody-runner-segmented.test.ts` — 6 tests covering no-boundaries byte-identical baseline, 1-phase degenerate, 3-phase IELTS Mock with 3 adapter invocations + per-phase envelopes + mean aggregate, partial-failure tolerance (phase 2 of 3 throws → sibling phases succeed), boundaries > cap → whole-call fallback + `segments_capped` AppLog, 3-phase general-mode aggregate.
- **New tests:** `tests/lib/pipeline/prosody-consumer-segmented.test.ts` — 5 tests: 3-phase IELTS bySegment → 12 namespaced + 4 aggregate rows; 3-phase general → 6 namespaced + 2 aggregate; per-phase unavailable entries skipped; no-bySegment branch behaviour unchanged (pin); top-level unavailable + bySegment yields zero rows.
- **Existing regression — zero failures:** 32/32 prosody tests in `prosody-{runner,consumer,runner-i-al4,mode-resolution}.test.ts` still green. 327/327 pipeline tests, 413/413 voice tests, 6/6 voice-system-settings tests all pass.
- `npx tsc --noEmit` clean on the 6 touched files (`prosody-runner.ts`, `prosody-consumer.ts`, `prosody-types.ts`, `system-settings.ts`, `voice-system-settings/route.ts`, two new test files). Pre-push tsc baseline 40 errors == baseline (no new errors introduced).
- `npx eslint` clean on touched files.
- Migration `20260617120000_1870_max_segments_per_call/migration.sql` adds the column additively (`INTEGER NOT NULL DEFAULT 5`) — no rewrites of existing rows.
- #1872 namespace decision: Option 2 (namespace prefix `"phase:"`) selected per the story instructions. Issue still open at commit time; the choice is documented inline in `prosody-types.ts::VoiceProsodyFeatures.bySegment` JSDoc and in the segmented-consumer test which pins both the presence of `phase:` keys AND the absence of bare phase names.

## Builds on

- PR #1862 (Story B — `deriveDetailedTranscriptFromVapi` + `turnsInWindow`)
- PR #1866 (Story C — `Session.metadata.phaseBoundaries[]` + cue-scheduler wiring)
- PR #1865 (Story D — `extractAudioSlice` byte-range proxy)
- PR #1872 (sibling namespace-decision story — namespace prefix Option 2 adopted here)

## Test plan

- [ ] CI green on this branch.
- [ ] After merge: `/vm-cpp` to apply migration `20260617120000_1870_max_segments_per_call` on `hf_sandbox`.
- [ ] Manual: on hf-dev, drive an IELTS Mock call through the cue-scheduler so `Session.metadata.phaseBoundaries[]` populates with 4 phases; trigger pipeline; verify `Call.voiceProsody.bySegment` has 4 envelopes and `CallScore` rows carry `segmentKey LIKE 'phase:%'` (4 criteria × 4 phases + 4 aggregate = 20 rows expected for IELTS mode).
- [ ] Manual: verify a non-Mock call (CIO/CTO) with no boundaries still produces byte-identical whole-call envelope (no `bySegment` field) — `Call.voiceProsody` shape matches pre-PR.

## Deploy command

`/vm-cpp` — needs migration for `VoiceSystemSettings.maxSegmentsPerCall`.

Closes #1870.