### PR TITLE
feat(course-detail): P3 — wire Modules tab Inspector + dedicated route (#1850)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/modules/route.ts
@@ -1,0 +1,136 @@
+/**
+ * Course modules — Phase P3 of the Course Detail tab refactor (epic #1850).
+ *
+ * Returns the AuthoredModule[] (Playbook.config.modules) used by the
+ * Modules tab's LH picker AND the per-module Inspector. Distinct from
+ * the sibling `/api/courses/:courseId/sessions` route, which returns
+ * the CurriculumModule[] (the curriculum-side list) — Authored vs
+ * Curriculum is the canonical playbook-vs-curriculum split documented
+ * in `lib/types/json-fields.ts` (AuthoredModule JSDoc, line 846).
+ *
+ * AuthoredModule lives on `Playbook.config.modules`. The G8 module-
+ * scoped settings (`settings.questionTarget`, `settings.cueCardPool`,
+ * etc.) hang off each AuthoredModule, and the per-module Inspector
+ * (`ModuleInspectorPanel`) needs the full row — including the nested
+ * `settings` object — to render the right values.
+ *
+ * OPERATOR+ gate per `.claude/rules/api-conventions.md` — the response
+ * carries authoring-side metadata (`prerequisites`, `terminal`,
+ * `coversModules`) that isn't a learner read.
+ *
+ * @api OPERATOR
+ */
+
+import { NextResponse } from "next/server";
+
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+export const runtime = "nodejs";
+
+interface ModuleSummary {
+  id: string;
+  label: string;
+  /** Free-form catalogue duration, e.g. "20 min fixed", "Student-led". */
+  duration: string;
+  mode: AuthoredModule["mode"];
+  frequency: AuthoredModule["frequency"];
+  learnerSelectable: boolean;
+  sessionTerminal: boolean;
+  /** Position in a structured course's lesson plan (continuous → undefined). */
+  position?: number;
+  /** True when this module is the course-complete trigger
+   *  under `completionMode === "terminal-only"`. */
+  terminal?: boolean;
+  /** G8 module-scoped settings — verbatim sub-object. The Inspector
+   *  renders against this; storage path resolution is per-key under
+   *  `config.modules[].settings.<key>` with `arrayKey: "id"`. */
+  settings: NonNullable<AuthoredModule["settings"]> | Record<string, never>;
+}
+
+interface ModulesResponse {
+  ok: true;
+  modules: ModuleSummary[];
+}
+
+interface ModulesError {
+  ok: false;
+  error: string;
+}
+
+/**
+ * @api GET /api/courses/:courseId/modules
+ * @visibility internal
+ * @scope courses:read
+ * @auth session (OPERATOR+)
+ * @description Returns the AuthoredModule list from `Playbook.config.modules`.
+ *   Used by the Modules tab's LH picker + per-module Inspector. Distinct
+ *   from `/sessions` (which returns CurriculumModule + lesson plan).
+ * @response 200 { ok: true, modules: ModuleSummary[] }
+ * @response 403 { ok: false, error: "Unauthorized" }
+ * @response 404 { ok: false, error: "Course not found" }
+ * @response 500 { ok: false, error: string }
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse<ModulesResponse | ModulesError>> {
+  try {
+    const auth = await requireAuth("OPERATOR");
+    if (isAuthError(auth)) {
+      return auth.error as NextResponse<ModulesError>;
+    }
+
+    const { courseId } = await params;
+    if (!courseId) {
+      return NextResponse.json(
+        { ok: false, error: "courseId is required" },
+        { status: 400 },
+      );
+    }
+
+    const playbook = await prisma.playbook.findUnique({
+      where: { id: courseId },
+      select: { id: true, config: true },
+    });
+    if (!playbook) {
+      return NextResponse.json(
+        { ok: false, error: "Course not found" },
+        { status: 404 },
+      );
+    }
+
+    const config = (playbook.config ?? null) as PlaybookConfig | null;
+    const raw = config?.modules ?? [];
+
+    const modules: ModuleSummary[] = raw
+      .filter((m): m is AuthoredModule => Boolean(m) && typeof m === "object")
+      .map((m) => ({
+        id: m.id,
+        label: m.label,
+        duration: m.duration,
+        mode: m.mode,
+        frequency: m.frequency,
+        learnerSelectable: m.learnerSelectable,
+        sessionTerminal: m.sessionTerminal,
+        position: m.position,
+        terminal: m.terminal,
+        settings: (m.settings ?? {}) as ModuleSummary["settings"],
+      }))
+      .sort((a, b) => {
+        const ap = a.position ?? Number.MAX_SAFE_INTEGER;
+        const bp = b.position ?? Number.MAX_SAFE_INTEGER;
+        if (ap !== bp) return ap - bp;
+        return a.label.localeCompare(b.label);
+      });
+
+    return NextResponse.json({ ok: true, modules });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -1,23 +1,37 @@
 "use client";
 
 /**
- * CourseModulesTab — Track C P0 shell of the Journey-Design tab refactor.
+ * CourseModulesTab — Track C P3 of the Journey-Design tab refactor (epic #1850).
  *
  * Modules-tab does NOT use bucket-filtered nav like Teaching / Scoring /
  * Journey — its scope is per-AuthoredModule (G8). The LH is a module
- * picker; the Inspector eventually hosts module-scoped settings.
+ * picker; the Inspector hosts module-scoped settings.
+ *
+ * P3 wires the real per-module Inspector (`ModuleInspectorPanel`) and
+ * the dedicated `/api/courses/:courseId/modules` route. The Inspector
+ * is read-side only — saves surface a "module-mutator pending" notice;
+ * the writer follows in a separate PR (see TODO(module-mutator)
+ * comments in `ModuleInspectorPanel.tsx`).
  *
  * Continuous-course empty state: continuous courses have no authored
  * modules — they pull from a topic pool. We render an explanation
  * rather than an empty picker.
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
 
+import { ModuleInspectorPanel } from "./ModuleInspectorPanel";
 import { ModulesLhPicker } from "./ModulesLhPicker";
+
+interface ModuleRow {
+  id: string;
+  label: string;
+  settings?: Partial<AuthoredModuleSettings>;
+}
 
 interface CourseModulesTabProps {
   courseId: string;
@@ -31,6 +45,58 @@ export function CourseModulesTab({
   courseStyle,
 }: CourseModulesTabProps) {
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
+  const [modules, setModules] = useState<ModuleRow[]>([]);
+
+  // Mirror the LH picker fetch so the Inspector can read each module's
+  // `settings` sub-object without a second round-trip. The LH picker
+  // owns its own fetch (it renders without waiting on the parent), and
+  // this one feeds the Inspector — both target the same dedicated
+  // /modules route so the cache will collapse them.
+  useEffect(() => {
+    if (!courseId || courseStyle === "continuous") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset list on course/style change, matches sibling ModulesLhPicker pattern
+      setModules([]);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/modules`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data?.ok && Array.isArray(data.modules)) {
+          setModules(data.modules as ModuleRow[]);
+        } else {
+          setModules([]);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setModules([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId, courseStyle]);
+
+  const handleSaveAttempt = useCallback(
+    async (settingId: string, next: unknown) => {
+      // TODO(module-mutator): the existing journey-setting PATCH route's
+      // storage-path applier doesn't traverse mid-path arrays
+      // (`config.modules[].settings.*`). Until either (a) the applier
+      // is extended OR (b) a dedicated module-scope PATCH route lands,
+      // saves here surface a notice and do NOT persist. Tracked at the
+      // P3 follow-on (epic #1850).
+      if (typeof window !== "undefined") {
+        console.info(
+          `[modules-tab] save deferred — module-scope mutator pending`,
+          { settingId, next },
+        );
+        // Soft surfacing only; no toast library is wired in this tab.
+        // The banner inside ModuleInspectorPanel already tells the
+        // educator saves are deferred.
+      }
+    },
+    [],
+  );
 
   if (courseStyle === "continuous") {
     return (
@@ -49,6 +115,11 @@ export function CourseModulesTab({
     );
   }
 
+  const selectedModule =
+    selectedModuleId !== null
+      ? (modules.find((m) => m.id === selectedModuleId) ?? null)
+      : null;
+
   return (
     <DesignerShell
       nav={
@@ -58,20 +129,27 @@ export function CourseModulesTab({
           onSelect={setSelectedModuleId}
         />
       }
-      // TODO(preview-scope): extend PreviewLens to accept ?moduleId scope
-      // so the canvas can preview the module-scoped lesson when one is
-      // selected. For now we render the course-wide preview.
-      canvas={<PreviewLens courseId={courseId} suppressSidetray />}
+      canvas={
+        <>
+          {/* TODO(preview-scope): extend PreviewLens to accept ?moduleId
+              scope so the canvas previews the module-scoped lesson when
+              one is selected. P3 ships the course-wide preview only. */}
+          {selectedModuleId ? (
+            <div className="hf-banner hf-banner-info" role="status">
+              Showing course-wide preview. Module-scoped preview lands in
+              a follow-on.
+            </div>
+          ) : null}
+          <PreviewLens courseId={courseId} suppressSidetray />
+        </>
+      }
       inspector={
-        selectedModuleId ? (
-          // TODO(P1): replace placeholder with the per-module settings
-          // editor (G8 module-scoped knobs — cue cards, prep timers,
-          // completion gates).
-          <div className="hf-card hf-card-compact">
-            Module settings inspector — wires up post-P0. Selected module:{" "}
-            <code>{selectedModuleId}</code>.
-          </div>
-        ) : null
+        <ModuleInspectorPanel
+          selectedModuleId={selectedModuleId}
+          selectedModuleLabel={selectedModule?.label ?? null}
+          settings={selectedModule?.settings ?? null}
+          onSaveAttempt={handleSaveAttempt}
+        />
       }
     />
   );

--- a/apps/admin/components/modules-tab/ModuleInspectorPanel.tsx
+++ b/apps/admin/components/modules-tab/ModuleInspectorPanel.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+/**
+ * ModuleInspectorPanel — Phase P3 of the Course Detail tab refactor (epic #1850).
+ *
+ * Per-module Inspector for the Modules tab. Mirrors `JourneyInspectorPanel`
+ * in shape (filter → stack → JourneyField primitives) but scopes by
+ * `selectedModuleId` instead of `selectedBucketId`. The G8 entries
+ * (`group === "G8"`, `scope === "module"`) live at
+ * `Playbook.config.modules[].settings.*` keyed by `arrayKey: "id"`,
+ * NOT on the top-level `Playbook.config` like other Journey settings.
+ *
+ * Read side (this PR): mounts JourneyField primitives against the
+ * selected module's `settings` object — the dedicated
+ * `/api/courses/:courseId/modules` route returns each module's full
+ * settings sub-tree.
+ *
+ * Write side (deferred → `TODO(module-mutator)`): the existing journey-
+ * setting PATCH route's storage-path applier
+ * (`lib/journey/storage-path-applier.ts::applyAtPath`) only handles
+ * arrays at the FINAL segment of the path (`sessionFlow.stops[]`). G8
+ * settings have a MID-path array (`config.modules[].settings.<key>`)
+ * which the applier doesn't traverse correctly today. Wiring a real
+ * mutator requires either (a) extending `applyAtPath` to walk mid-path
+ * arrays with `selectorValue`, or (b) a dedicated module-scope PATCH
+ * route. Both are out of scope for P3 — the read-side visibility win is
+ * shippable without it, so the stub mutator surfaces a toast and the
+ * follow-on lands the writer.
+ *
+ * Parallels the CourseTeachingTab → JourneyInspectorPanel relationship,
+ * but the per-module data model justifies a separate panel rather than
+ * extending JourneyInspectorPanel with a module-scope mode (the
+ * mutator-provider context writes to `Playbook.config.*`, not to
+ * `Playbook.config.modules[i].settings.*`).
+ */
+
+import { JourneyField } from "@/components/journey-controls";
+import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
+import type {
+  JourneySettingContract,
+  StoragePathStruct,
+} from "@/lib/journey/setting-contracts";
+import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
+
+interface ModuleInspectorPanelProps {
+  selectedModuleId: string | null;
+  /** The selected module's label — used in the panel header. */
+  selectedModuleLabel?: string | null;
+  /** The selected module's G8 settings sub-object (from
+   *  `/api/courses/:courseId/modules` → `modules[].settings`).
+   *  Undefined or empty → all fields render with default values. */
+  settings: Partial<AuthoredModuleSettings> | null;
+  /** Fired on a save attempt against a G8 field. P3 hooks this to a
+   *  stub that surfaces the "module-mutator pending" message; once
+   *  the writer lands, this becomes the real mutator. */
+  onSaveAttempt: (
+    settingId: string,
+    next: unknown,
+  ) => Promise<void> | void;
+}
+
+/** Pull the final segment from a G8 storagePath
+ *  (`config.modules[].settings.questionTarget` → `"questionTarget"`)
+ *  so the read can hit the right key in the module's settings sub-tree. */
+function lastSegmentOfStoragePath(contract: JourneySettingContract): string {
+  const sp = contract.storagePath;
+  const path = typeof sp === "string" ? sp : (sp as StoragePathStruct).path;
+  const segments = path.split(".").map((s) => s.replace(/\[\]$/, ""));
+  return segments[segments.length - 1] ?? "";
+}
+
+/** All G8 entries declared in the registry. Scope-guard avoids leaking
+ *  non-module Inspector rows in if the registry ever gains G8 entries
+ *  with a different scope. */
+const G8_SETTINGS: readonly JourneySettingContract[] = JOURNEY_SETTINGS.filter(
+  (c) => c.group === "G8" && c.scope === "module",
+);
+
+export function ModuleInspectorPanel({
+  selectedModuleId,
+  selectedModuleLabel,
+  settings,
+  onSaveAttempt,
+}: ModuleInspectorPanelProps) {
+  if (!selectedModuleId) {
+    return (
+      <div
+        className="hf-journey-inspector-empty"
+        data-testid="hf-module-inspector-empty"
+      >
+        Select a module from the left to edit its settings.
+      </div>
+    );
+  }
+
+  if (G8_SETTINGS.length === 0) {
+    return (
+      <div
+        className="hf-journey-inspector-empty"
+        data-testid="hf-module-inspector-no-settings"
+      >
+        No module-scoped settings registered yet.
+      </div>
+    );
+  }
+
+  const moduleSettings = (settings ?? {}) as Record<string, unknown>;
+
+  return (
+    <div
+      data-testid={`hf-module-inspector-${selectedModuleId}`}
+    >
+      <div className="hf-journey-bucket-header">
+        <h3 className="hf-section-title">
+          {selectedModuleLabel ?? selectedModuleId}
+        </h3>
+        <p className="hf-section-desc">
+          Module-scoped settings (G8). These keys live on this module
+          only — other modules in the same course read their own values.
+        </p>
+      </div>
+
+      <div className="hf-banner hf-banner-info" role="status">
+        Read-only preview. The module-scope writer ships in a follow-on
+        — saves here surface a notice instead of persisting.
+      </div>
+
+      <div className="hf-journey-inspector-stack">
+        {G8_SETTINGS.map((contract) => {
+          const key = lastSegmentOfStoragePath(contract);
+          const value = key ? moduleSettings[key] : undefined;
+          return (
+            <div
+              key={contract.id}
+              className="hf-journey-inspector-row"
+              data-testid={`hf-module-inspector-row-${contract.id}`}
+            >
+              <JourneyField
+                contract={contract}
+                value={value}
+                options={contract.options}
+                onSave={(next) =>
+                  Promise.resolve(onSaveAttempt(contract.id, next))
+                }
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/modules-tab/ModulesLhPicker.tsx
+++ b/apps/admin/components/modules-tab/ModulesLhPicker.tsx
@@ -3,26 +3,22 @@
 /**
  * ModulesLhPicker — LH module picker for the Modules tab.
  *
- * Fetches `/api/courses/[courseId]/sessions` for the modules array
- * (the sessions route already returns modules). When a dedicated
- * `/api/courses/[courseId]/modules` route lands, swap the fetch.
+ * Fetches the dedicated `/api/courses/[courseId]/modules` route
+ * (Phase P3 of epic #1850). Returns AuthoredModule[] from
+ * `Playbook.config.modules` — the playbook-side list — NOT the
+ * `/sessions` route's CurriculumModule[] (curriculum-side).
  *
  * Renders one row per AuthoredModule via `hf-list-row`. Click → setSelected.
- *
- * TODO(modules-route): replace the sessions piggyback with a dedicated
- * `/api/courses/[courseId]/modules` route when one exists. The sessions
- * route over-fetches (plan + studentProgress) for what's needed here.
  */
 
 import { useEffect, useState } from "react";
 
 interface ModuleSummary {
   id: string;
-  slug?: string;
-  title: string;
-  description?: string | null;
-  sortOrder?: number;
-  learningObjectiveCount?: number;
+  label: string;
+  mode?: string;
+  duration?: string;
+  position?: number;
 }
 
 interface ModulesLhPickerProps {
@@ -45,7 +41,7 @@ export function ModulesLhPicker({
     let cancelled = false;
     setLoading(true);
     setError(null);
-    fetch(`/api/courses/${courseId}/sessions`)
+    fetch(`/api/courses/${courseId}/modules`)
       .then((r) => r.json())
       .then((data) => {
         if (cancelled) return;
@@ -118,11 +114,9 @@ export function ModulesLhPicker({
             onClick={() => onSelect(m.id)}
             data-testid={`hf-modules-row-${m.id}`}
           >
-            <span className="hf-journey-bucket-label">{m.title}</span>
-            {typeof m.learningObjectiveCount === "number" ? (
-              <span className="hf-journey-bucket-count">
-                {m.learningObjectiveCount}
-              </span>
+            <span className="hf-journey-bucket-label">{m.label}</span>
+            {m.duration ? (
+              <span className="hf-journey-bucket-count">{m.duration}</span>
             ) : null}
           </button>
         ))}

--- a/apps/admin/tests/api/courses/modules-route.test.ts
+++ b/apps/admin/tests/api/courses/modules-route.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for `GET /api/courses/[courseId]/modules` — Phase P3 of epic #1850.
+ *
+ * Pins:
+ *   - OPERATOR+ admit gate (STUDENT rejected)
+ *   - 404 on missing course
+ *   - 400 on empty courseId
+ *   - Returns AuthoredModule[] from `Playbook.config.modules` (NOT the
+ *     CurriculumModule[] returned by the sibling `/sessions` route)
+ *   - Sort: by `position`, then label
+ *   - G8 `settings` sub-object preserved verbatim
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: (v: unknown) =>
+    typeof v === "object" && v !== null && "error" in v,
+}));
+
+const PARAMS = { params: Promise.resolve({ courseId: "course-1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/courses/[courseId]/modules/route");
+}
+
+describe("GET /api/courses/[courseId]/modules — P3 (#1850)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when requireAuth rejects (STUDENT below OPERATOR)", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      error: new Response("forbidden", { status: 403 }),
+    } as never);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when course is missing", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue(null);
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/Course not found/);
+  });
+
+  it("returns 400 when courseId is empty", async () => {
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), {
+      params: Promise.resolve({ courseId: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the AuthoredModule[] from Playbook.config.modules", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "course-1",
+      config: {
+        modules: [
+          {
+            id: "part2",
+            label: "Part 2 — Long Turn",
+            learnerSelectable: true,
+            mode: "examiner",
+            duration: "4 min fixed",
+            scoringFired: "All four",
+            voiceBandReadout: false,
+            sessionTerminal: false,
+            frequency: "repeatable",
+            outcomesPrimary: [],
+            prerequisites: [],
+            position: 2,
+            settings: {
+              questionTarget: { min: 1, target: 1 },
+              cueCardPool: [{ topic: "A book", bullets: ["author", "why"] }],
+            },
+          },
+          {
+            id: "part1",
+            label: "Part 1 — Interview",
+            learnerSelectable: true,
+            mode: "examiner",
+            duration: "4 min fixed",
+            scoringFired: "All four",
+            voiceBandReadout: false,
+            sessionTerminal: false,
+            frequency: "repeatable",
+            outcomesPrimary: [],
+            prerequisites: [],
+            position: 1,
+            settings: {
+              questionTarget: { min: 10, target: 13 },
+            },
+          },
+        ],
+      },
+    });
+
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.modules).toHaveLength(2);
+    // Sort by position (part1 → part2).
+    expect(body.modules[0].id).toBe("part1");
+    expect(body.modules[1].id).toBe("part2");
+    // G8 settings sub-object preserved verbatim.
+    expect(body.modules[0].settings).toEqual({
+      questionTarget: { min: 10, target: 13 },
+    });
+    expect(body.modules[1].settings).toEqual({
+      questionTarget: { min: 1, target: 1 },
+      cueCardPool: [{ topic: "A book", bullets: ["author", "why"] }],
+    });
+  });
+
+  it("returns empty modules array when Playbook.config.modules is missing", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "course-1",
+      config: {},
+    });
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, modules: [] });
+  });
+
+  it("substitutes empty {} for modules with no settings", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValue({
+      id: "course-1",
+      config: {
+        modules: [
+          {
+            id: "freeform",
+            label: "Freeform",
+            learnerSelectable: true,
+            mode: "tutor",
+            duration: "Student-led",
+            scoringFired: "All four",
+            voiceBandReadout: false,
+            sessionTerminal: false,
+            frequency: "once",
+            outcomesPrimary: [],
+            prerequisites: [],
+          },
+        ],
+      },
+    });
+    const { GET } = await loadRoute();
+    const res = await GET(new Request("http://x"), PARAMS);
+    const body = await res.json();
+    expect(body.modules[0].settings).toEqual({});
+  });
+});

--- a/apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx
+++ b/apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
+
+// jsdom doesn't ship matchMedia; DesignerShell uses it for the narrow-
+// viewport drawer behaviour. Stub once for the file (mirrors
+// `tests/components/designer-shell.test.tsx`).
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+import { CourseModulesTab } from "@/components/modules-tab/CourseModulesTab";
+
+// Mock PreviewLens — it pulls in fetch + composition pipeline state that
+// the tab-level mount test doesn't need to exercise (the journey-tab
+// sibling tests follow the same shape: test the Inspector wiring, not
+// the canvas).
+vi.mock("@/app/x/courses/[courseId]/_components/PreviewLens", () => ({
+  PreviewLens: () => <div data-testid="hf-mock-preview-lens" />,
+}));
+
+const moduleFixtures = [
+  {
+    id: "part1",
+    label: "Part 1 — Interview",
+    duration: "4 min fixed",
+    mode: "examiner",
+    frequency: "repeatable",
+    learnerSelectable: true,
+    sessionTerminal: false,
+    position: 1,
+    settings: {
+      questionTarget: { min: 10, target: 13 },
+    },
+  },
+  {
+    id: "part2",
+    label: "Part 2 — Long Turn",
+    duration: "4 min fixed",
+    mode: "examiner",
+    frequency: "repeatable",
+    learnerSelectable: true,
+    sessionTerminal: false,
+    position: 2,
+    settings: {
+      questionTarget: { min: 1, target: 1 },
+      cueCardPool: [{ topic: "A book", bullets: ["author", "why"] }],
+    },
+  },
+];
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => {
+    return new Response(
+      JSON.stringify({ ok: true, modules: moduleFixtures }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CourseModulesTab — P3 (#1850) Inspector wiring", () => {
+  it("renders the continuous-course empty state when courseStyle='continuous'", () => {
+    render(<CourseModulesTab courseId="c1" courseStyle="continuous" />);
+    expect(screen.getByText(/No modules/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Continuous courses don't have authored modules/i),
+    ).toBeInTheDocument();
+    // LH picker must NOT mount on continuous courses.
+    expect(screen.queryByTestId("hf-modules-lh-picker")).toBeNull();
+  });
+
+  it("mounts the empty-state Inspector when no module is selected", async () => {
+    render(<CourseModulesTab courseId="c1" courseStyle="structured" />);
+    // ModuleInspectorPanel renders this testid when selectedModuleId is null.
+    expect(
+      screen.getByTestId("hf-module-inspector-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("lists modules from the dedicated /api/courses/<id>/modules route", async () => {
+    render(<CourseModulesTab courseId="c1" courseStyle="structured" />);
+    // ModulesLhPicker fires the fetch on mount; rows appear once it resolves.
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-modules-row-part1")).toBeInTheDocument();
+      expect(screen.getByTestId("hf-modules-row-part2")).toBeInTheDocument();
+    });
+    // Fetch hit the dedicated route, NOT the legacy /sessions one.
+    const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls;
+    const urls = calls.map((args) => String(args[0]));
+    expect(urls.some((u) => u.includes("/api/courses/c1/modules"))).toBe(true);
+    expect(urls.every((u) => !u.includes("/api/courses/c1/sessions"))).toBe(
+      true,
+    );
+  });
+
+  it("clicking a module mounts the per-module Inspector with G8 rows", async () => {
+    render(<CourseModulesTab courseId="c1" courseStyle="structured" />);
+    const row = await waitFor(() =>
+      screen.getByTestId("hf-modules-row-part1"),
+    );
+    fireEvent.click(row);
+    // The inspector container appears, keyed on the selected module id.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-module-inspector-part1"),
+      ).toBeInTheDocument();
+    });
+    // At least one G8 row renders (the module-scoped settings).
+    expect(
+      screen.getByTestId("hf-module-inspector-row-moduleQuestionTarget"),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the read-only banner when a module is selected", async () => {
+    render(<CourseModulesTab courseId="c1" courseStyle="structured" />);
+    const row = await waitFor(() =>
+      screen.getByTestId("hf-modules-row-part1"),
+    );
+    fireEvent.click(row);
+    await waitFor(() =>
+      screen.getByTestId("hf-module-inspector-part1"),
+    );
+    // Inspector banner + canvas banner both surface that saves + preview
+    // are deferred to follow-on PRs.
+    expect(
+      screen.getByText(/Read-only preview/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Showing course-wide preview/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx
+++ b/apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { ModuleInspectorPanel } from "@/components/modules-tab/ModuleInspectorPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ModuleInspectorPanel — P3 (#1850)", () => {
+  it("renders the empty-state when selectedModuleId is null", () => {
+    render(
+      <ModuleInspectorPanel
+        selectedModuleId={null}
+        selectedModuleLabel={null}
+        settings={null}
+        onSaveAttempt={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId("hf-module-inspector-empty"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Select a module from the left/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders G8 rows when a module is selected", () => {
+    render(
+      <ModuleInspectorPanel
+        selectedModuleId="part1"
+        selectedModuleLabel="Part 1 — Interview"
+        settings={{ questionTarget: { min: 10, target: 13 } }}
+        onSaveAttempt={vi.fn()}
+      />,
+    );
+    // Container keyed on the selected module id.
+    expect(
+      screen.getByTestId("hf-module-inspector-part1"),
+    ).toBeInTheDocument();
+    // Module label surfaces as the header.
+    expect(
+      screen.getByText("Part 1 — Interview"),
+    ).toBeInTheDocument();
+    // At least one G8 field renders (moduleQuestionTarget is the first
+    // G8 entry; assert it by testid so we don't depend on the field's
+    // visual label string).
+    expect(
+      screen.getByTestId("hf-module-inspector-row-moduleQuestionTarget"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the deferred-writer banner so saves do not look silent", () => {
+    render(
+      <ModuleInspectorPanel
+        selectedModuleId="part1"
+        selectedModuleLabel="Part 1"
+        settings={null}
+        onSaveAttempt={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/Read-only preview/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/module-scope writer ships in a follow-on/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -10054,6 +10054,34 @@ Returns the most recent COURSE_REFERENCE markdown document
 
 ---
 
+### `GET` /api/courses/:courseId/modules
+
+Returns the AuthoredModule list from `Playbook.config.modules`.
+
+**Auth**: session (OPERATOR+) · **Scope**: `courses:read`
+
+**Response** `200`
+```json
+{ ok: true, modules: ModuleSummary[] }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: "Unauthorized" }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+**Response** `500`
+```json
+{ ok: false, error: string }
+```
+
+---
+
 ### `POST` /api/courses/:courseId/recompose-section
 
 Recompose one section across every active enrolled caller's
@@ -16326,8 +16354,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 541 |
-| Files with annotations | 527 |
+| Route files found | 542 |
+| Files with annotations | 528 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 


### PR DESCRIPTION
## Summary

Phase P3 of epic #1850 — wires the Modules tab Inspector + ships a dedicated `/api/courses/[courseId]/modules` route. Distinct from P1/P2: the Modules tab is **per-module** (selected entity is `selectedModuleId`), not per-bucket.

**Design call: Option B (new `ModuleInspectorPanel`)**. Rationale — the existing journey-setting PATCH route's storage-path applier (`lib/journey/storage-path-applier.ts::applyAtPath`) treats `arrayKey` as applying to the FINAL segment of the path (e.g. `sessionFlow.stops[]`). G8 module-scoped settings live at `config.modules[].settings.<key>` — a MID-path array. Extending `JourneyInspectorPanel` would force its mutator-provider (which writes to top-level `Playbook.config`) to grow a module-scope branch, AND would still need a new applier branch before any write could land cleanly. Cleaner to ship a separate panel that reads from each module's `settings` sub-tree (exposed verbatim by the new `/modules` route).

### What ships

- **`GET /api/courses/:courseId/modules`** — OPERATOR+ gate, returns `AuthoredModule[]` from `Playbook.config.modules`. Includes each module's full `settings` sub-object for the Inspector. Sort: by `position`, then label.
- **`ModulesLhPicker`** swaps off the `/sessions` piggyback onto the dedicated route. `TODO(modules-route)` removed.
- **`ModuleInspectorPanel`** (new file, Option B) — filters `JOURNEY_SETTINGS` by `group === "G8" && scope === "module"`, renders 8 G8 entries against the selected module's `settings` sub-object via existing `JourneyField` primitives.
- **`CourseModulesTab`** mounts the real Inspector + adds a course-wide-preview banner above the canvas when a module is selected.

### What's explicitly deferred

- **`TODO(module-mutator)`** — read-side only this PR. Saves surface a banner inside `ModuleInspectorPanel` (\"Read-only preview. The module-scope writer ships in a follow-on…\") and a `console.info` breadcrumb. The writer needs either (a) extending `applyAtPath` to traverse mid-path arrays with `arrayKey + selectorValue`, or (b) a dedicated module-scope PATCH route. Visible at [`apps/admin/components/modules-tab/CourseModulesTab.tsx:81-101`](https://github.com/WANDERCOLTD/HF/blob/feat/journey-tabs-p3-modules-inspector/apps/admin/components/modules-tab/CourseModulesTab.tsx#L81-L101) and [`apps/admin/components/modules-tab/ModuleInspectorPanel.tsx:21-31`](https://github.com/WANDERCOLTD/HF/blob/feat/journey-tabs-p3-modules-inspector/apps/admin/components/modules-tab/ModuleInspectorPanel.tsx#L21-L31).
- **`TODO(preview-scope)`** — PreviewLens module-scope NOT built. Canvas shows the course-wide preview; a banner above tells the operator. Marker at [`apps/admin/components/modules-tab/CourseModulesTab.tsx:131-133`](https://github.com/WANDERCOLTD/HF/blob/feat/journey-tabs-p3-modules-inspector/apps/admin/components/modules-tab/CourseModulesTab.tsx#L131-L133).

## Test plan

- [x] `npx vitest run tests/components/modules-tab tests/api/courses/modules-route tests/lib/journey/buckets-by-tab` — 19/19 green.
- [x] Sibling coverage tests still green: `tests/lib/journey/*` (15 files, 106 tests) including `registry-completeness`, `registry-consumer-coverage`, `registry-schema-coverage`, `storage-path-applier`, `buckets-by-tab` + `tests/api/route-auth-zod-coverage`.
- [x] tsc clean — baseline held at 40.
- [x] lint zero errors on touched files (pre-push gate passes).
- [x] ratchet check — lint warnings net zero against working main.
- [ ] Manual on hf-dev — `/x/courses/<id>?tab=modules` against an IELTS-shaped course: confirm LH lists Part 1 / Part 2 / Part 3 from `Playbook.config.modules`, click Part 2 → Inspector shows 8 G8 rows including `moduleCueCardPool` populated from the module's settings.

## Verified by

- Route shape pinned by [`apps/admin/tests/api/courses/modules-route.test.ts`](apps/admin/tests/api/courses/modules-route.test.ts) — 6 tests: 403 on STUDENT, 404 on missing course, 400 on empty courseId, sort by position, G8 settings preserved verbatim, empty fallback.
- Tab wiring pinned by [`apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx`](apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx) — 5 tests: continuous empty-state, Inspector empty state, dedicated route called (sessions NOT called), module click mounts Inspector, banners surface.
- Panel pinned by [`apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx`](apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx) — 3 tests: empty state, G8 row renders, deferred-writer banner.
- Mid-path array gap evidenced by [`apps/admin/lib/journey/storage-path-applier.ts:148-178`](apps/admin/lib/journey/storage-path-applier.ts#L148-L178) — `arraySelector` branch fires on `arr[finalKey]` after walking `segments[0..n-2]`. For path `config.modules[].settings.questionTarget` with `arrayKey: "id"`, the walker would step into `config.modules.settings` and try `arr["questionTarget"]` — wrong shape for the on-disk `modules[i].settings.questionTarget`. This makes a Real mutator unsafe without applier work; documented in the Inspector header.

## Lattice survey

Surfaces touched:
- READ from `Playbook.config.modules` (no DB write). Sibling readers: `lib/curriculum/check-module-unlock.ts`, `lib/runtime/auto-include-stops.ts`, the picker route `lib/curriculum/import-modules`. No sibling-writer drift — read-only.
- No chain-stage boundary, no new guard/contract, no AI write/read path, no cascade-eligible knob mutation.
- Registry coverage: G8 entries already classified as `family-shortcut (module)` via `registry-consumer-coverage.test.ts` because `scope === "module"`. Adding the read-side Inspector doesn't change classification.
- Tier-visibility: route gated at OPERATOR — admit gate is NOT below OPERATOR, so the response-redaction tier rule does not apply.

Reference: epic #1850.