### PR TITLE
chore(transforms): NEUTRAL_PARAMETER_TARGET — replace 8 bare 0.5 fallbacks

### DIFF
--- a/apps/admin/lib/measurement/neutral-target.ts
+++ b/apps/admin/lib/measurement/neutral-target.ts
@@ -1,0 +1,34 @@
+/**
+ * Neutral parameter target — the canonical midpoint on the 0..1 behavior axis.
+ *
+ * Every behavior parameter (BEH-WARMTH, BEH-RESPONSE-LEN, BEH-PAUSE-TOLERANCE,
+ * etc.) is scored on a 0..1 scale where 0.5 is "no override" — neither push
+ * toward the LOW pole nor the HIGH pole. When a transform reads `targetValue`
+ * and no measured value or configured default is available, it falls back to
+ * this midpoint.
+ *
+ * `NEUTRAL_TARGET_TOLERANCE` is the half-width used to treat a value as
+ * "effectively neutral" (e.g. identity-spec sliders skip rendering a
+ * `Department tone:` directive when the slider sits within ±0.05 of 0.5).
+ *
+ * **Why a const, not the literal:**
+ *  - 6 sites in `transforms/quickstart.ts` and 2 in `transforms/identity.ts`
+ *    used the bare literal `0.5`. If the neutral midpoint ever needs to
+ *    shift (or a per-param defaultTarget injection lands), the bare literals
+ *    are silent footguns.
+ *  - The `pipeline-and-prompt.md` rule treats hardcoded behavior values in
+ *    composition transforms as a contract-leak — they're tutor-behavior
+ *    knobs that must be sourced.
+ *
+ * **Per-parameter defaults:** when the calling site has access to the
+ * `Parameter` table row, prefer `parameter.defaultTarget` over this midpoint.
+ * This constant is the fallback when no parameter row is in scope.
+ */
+export const NEUTRAL_PARAMETER_TARGET = 0.5;
+
+/**
+ * Tolerance half-width around `NEUTRAL_PARAMETER_TARGET` for "effectively
+ * neutral" classification. `|value - 0.5| < 0.05` means the slider has not
+ * been moved meaningfully off the midpoint.
+ */
+export const NEUTRAL_TARGET_TOLERANCE = 0.05;

--- a/apps/admin/lib/prompt/composition/transforms/identity.ts
+++ b/apps/admin/lib/prompt/composition/transforms/identity.ts
@@ -8,6 +8,10 @@ import { config } from "@/lib/config";
 import { registerTransform } from "../TransformRegistry";
 import type { AssembledContext, PlaybookData, SystemSpecData, ResolvedSpecs, ResolvedSpec } from "../types";
 import type { SpecConfig } from "@/lib/types/json-fields";
+import {
+  NEUTRAL_PARAMETER_TARGET,
+  NEUTRAL_TARGET_TOLERANCE,
+} from "@/lib/measurement/neutral-target";
 
 /**
  * Resolve identity, content, and voice specs from stacked playbooks + system specs.
@@ -265,14 +269,19 @@ export function applyGroupToneOverride(
     };
 
     for (const [key, value] of Object.entries(sliders)) {
-      // Neutral (0.5) means no override — skip
-      if (typeof value !== "number" || Math.abs(value - 0.5) < 0.05) continue;
+      // Neutral midpoint means no override — skip
+      if (
+        typeof value !== "number" ||
+        Math.abs(value - NEUTRAL_PARAMETER_TARGET) < NEUTRAL_TARGET_TOLERANCE
+      ) {
+        continue;
+      }
 
       const labels = SLIDER_LABELS[key];
       if (!labels) continue;
 
       const [lowLabel, highLabel] = labels;
-      if (value < 0.5) {
+      if (value < NEUTRAL_PARAMETER_TARGET) {
         const intensity = value < 0.25 ? "strongly" : "somewhat";
         guidelines.push(`Department tone: Be ${intensity} ${lowLabel}.`);
       } else {

--- a/apps/admin/lib/prompt/composition/transforms/quickstart.ts
+++ b/apps/admin/lib/prompt/composition/transforms/quickstart.ts
@@ -11,6 +11,7 @@ import { classifyValue, getAttributeValue } from "../types";
 import type { SpecConfig, PlaybookConfig } from "@/lib/types/json-fields";
 import type { AssembledContext, CallerAttributeData } from "../types";
 import { PARAMS } from "@/lib/registry";
+import { NEUTRAL_PARAMETER_TARGET } from "@/lib/measurement/neutral-target";
 import { getAudienceOption } from "./audience";
 import { SURVEY_SCOPES, PRE_SURVEY_KEYS } from "@/lib/learner/survey-keys";
 import { config } from "@/lib/config";
@@ -476,9 +477,9 @@ registerTransform("computeQuickStart", (
       const warmth = mergedTargets.find((t: any) => t.parameterId === PARAMS.BEH_WARMTH);
       const questions = mergedTargets.find((t: any) => t.parameterId === PARAMS.BEH_QUESTION_RATE);
       const responseLength = mergedTargets.find((t: any) => t.parameterId === PARAMS.BEH_RESPONSE_LEN);
-      const warmthLevel = classifyValue(warmth?.targetValue ?? 0.5, thresholds) || "MODERATE";
-      const questionLevel = classifyValue(questions?.targetValue ?? 0.5, thresholds) || "MODERATE";
-      const responseLengthLevel = classifyValue(responseLength?.targetValue ?? 0.5, thresholds) || "MODERATE";
+      const warmthLevel = classifyValue(warmth?.targetValue ?? NEUTRAL_PARAMETER_TARGET, thresholds) || "MODERATE";
+      const questionLevel = classifyValue(questions?.targetValue ?? NEUTRAL_PARAMETER_TARGET, thresholds) || "MODERATE";
+      const responseLengthLevel = classifyValue(responseLength?.targetValue ?? NEUTRAL_PARAMETER_TARGET, thresholds) || "MODERATE";
       return `${warmthLevel} warmth, ${questionLevel} questions, ${responseLengthLevel} response length`;
     })(),
 
@@ -486,9 +487,9 @@ registerTransform("computeQuickStart", (
       const responseLength = mergedTargets.find((t: any) => t.parameterId === PARAMS.BEH_RESPONSE_LEN);
       const turnLength = mergedTargets.find((t: any) => t.parameterId === PARAMS.BEH_TURN_LENGTH);
       const pauseTolerance = mergedTargets.find((t: any) => t.parameterId === PARAMS.BEH_PAUSE_TOLERANCE);
-      const rl = classifyValue(responseLength?.targetValue ?? 0.5, thresholds);
-      const tl = classifyValue(turnLength?.targetValue ?? 0.5, thresholds);
-      const pt = classifyValue(pauseTolerance?.targetValue ?? 0.5, thresholds);
+      const rl = classifyValue(responseLength?.targetValue ?? NEUTRAL_PARAMETER_TARGET, thresholds);
+      const tl = classifyValue(turnLength?.targetValue ?? NEUTRAL_PARAMETER_TARGET, thresholds);
+      const pt = classifyValue(pauseTolerance?.targetValue ?? NEUTRAL_PARAMETER_TARGET, thresholds);
       return {
         sentences_per_turn: rl === "LOW" ? "1-2" : rl === "HIGH" ? "3-4" : "2-3",
         max_seconds: tl === "LOW" ? 10 : tl === "HIGH" ? 20 : 15,

--- a/apps/admin/tests/lib/measurement/neutral-target.test.ts
+++ b/apps/admin/tests/lib/measurement/neutral-target.test.ts
@@ -1,0 +1,81 @@
+/**
+ * NEUTRAL_PARAMETER_TARGET — pin the canonical midpoint + adoption.
+ *
+ * **What this test pins:**
+ *  1. The constant value (0.5) and tolerance (0.05) — surprising drift
+ *     would silently change tutor behavior across all consumers.
+ *  2. No transform under `lib/prompt/composition/transforms/` falls back
+ *     to a bare `?? 0.5` literal — every neutral-target fallback must use
+ *     the named constant. The ratchet catches new offenders before merge.
+ *
+ *  See `.claude/rules/pipeline-and-prompt.md` — composition transforms
+ *  must not hold raw behavior values; sourced or semantically-named only.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import {
+  NEUTRAL_PARAMETER_TARGET,
+  NEUTRAL_TARGET_TOLERANCE,
+} from "@/lib/measurement/neutral-target";
+
+const REPO_ADMIN = resolve(__dirname, "..", "..", "..");
+const TRANSFORMS_DIR = join(
+  REPO_ADMIN,
+  "lib",
+  "prompt",
+  "composition",
+  "transforms",
+);
+
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listTsFiles(full));
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("NEUTRAL_PARAMETER_TARGET — canonical midpoint", () => {
+  it("constant value is 0.5", () => {
+    expect(NEUTRAL_PARAMETER_TARGET).toBe(0.5);
+  });
+
+  it("tolerance is 0.05", () => {
+    expect(NEUTRAL_TARGET_TOLERANCE).toBe(0.05);
+  });
+
+  it("no transform falls back to a bare `?? 0.5` literal", () => {
+    const offenders: { file: string; line: number; text: string }[] = [];
+    for (const file of listTsFiles(TRANSFORMS_DIR)) {
+      const src = readFileSync(file, "utf8");
+      const lines = src.split("\n");
+      lines.forEach((line, idx) => {
+        // `?? 0.5` with a word-boundary trailing — matches `0.5,` `0.5)` `0.5;`
+        // but NOT `0.55`. Skips `NEUTRAL_PARAMETER_TARGET` itself.
+        if (/\?\?\s*0\.5(?![0-9])/.test(line)) {
+          offenders.push({
+            file: file.replace(REPO_ADMIN + "/", ""),
+            line: idx + 1,
+            text: line.trim(),
+          });
+        }
+      });
+    }
+    expect(
+      offenders,
+      `Bare \`?? 0.5\` fallback in composition transforms — replace with NEUTRAL_PARAMETER_TARGET from @/lib/measurement/neutral-target:\n${offenders
+        .map((o) => `  ${o.file}:${o.line}  ${o.text}`)
+        .join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -104,6 +104,7 @@ Three structural patterns, in order of preference:
 | ComposeSectionKey → staleness inputs map | `lib/compose/section.ts::COMPOSE_SECTION_KEYS` | `lib/compose/section-staleness.ts::PIPELINE_STATE_SECTION_LOADERS` | ✅ PROTECTED | TypeScript `satisfies const readonly ComposeSectionKey[]` + `tests/lib/compose/section-loaders.test.ts:23` | — | Compile-time exhaustiveness |
 | ComposeSectionKey → SECTION_OUTPUT_KEYS map | `COMPOSE_SECTION_KEYS` | `SECTION_OUTPUT_KEYS` | ✅ PROTECTED | Same `satisfies` + section-loaders test | — | Compile-time + test |
 | COMP-001 spec sections ↔ `getDefaultSections()` code | `docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json` | `lib/compose/section.ts::getDefaultSections` | ⚠️ PARTIAL | `tests/lib/prompt/composition/seed-sync.test.ts` (existing) | MED | Test catches code-vs-spec divergence at fixture time; doesn't re-pin post-spec-JSON-update. |
+| Transform behavior-target neutral fallback | `lib/measurement/neutral-target.ts::NEUTRAL_PARAMETER_TARGET` | composition transforms (`quickstart.ts`, `identity.ts`) | ✅ PROTECTED | `tests/lib/measurement/neutral-target.test.ts` (#1880) | — | Named const replaces bare `?? 0.5`; ratchet rejects new offenders in `lib/prompt/composition/transforms/`. |
 
 ### Cascade
 


### PR DESCRIPTION
## Summary

Outrageous-hardcoding sweep: 8 sites used the bare literal `?? 0.5` as the "neutral on 0..1 behavior axis" fallback — 6 in `transforms/quickstart.ts::voice_style`/`critical_voice`, 2 in `transforms/identity.ts` sliders. No named const, no JSDoc, no semantic anchor. `pipeline-and-prompt.md` treats hardcoded behavior values in composition transforms as a contract-leak class.

- New: `apps/admin/lib/measurement/neutral-target.ts` — exports `NEUTRAL_PARAMETER_TARGET = 0.5` + `NEUTRAL_TARGET_TOLERANCE = 0.05` with JSDoc explaining the 0..1 axis convention + when to prefer `Parameter.defaultTarget` over the midpoint.
- Refactored 6 fallbacks in `quickstart.ts` + 2 sites in `identity.ts`.
- New: `apps/admin/tests/lib/measurement/neutral-target.test.ts` (3 vitests: pin value, pin tolerance, ratchet `?? 0.5` in transforms/).
- Added `docs/lattice-chains.md` row under Compose.

## Verified by

- 3/3 new vitests pass: `npx vitest run tests/lib/measurement/neutral-target.test.ts`
- 210/210 composition tests pass: `npx vitest run tests/lib/prompt/composition/` — net-zero behavior change
- 9/9 self-maintenance gate passes: `npx vitest run tests/lib/lattice-self-maintenance.test.ts` — new file inventoried via lattice-chains row, no orphan claim.
- pre-push hook clean: tsc 41 == baseline, lint 0 errors.

## Lattice survey

- Surface: composition transforms' bare-literal neutral fallback for `targetValue`.
- Sibling writers: `identity.ts:268-269` also used `0.5` as the neutral midpoint with a `0.05` tolerance — confirms the value is a system-wide semantic constant, not a quickstart-local quirk.
- Convergence: single const file under `lib/measurement/`, exported semantically; ratchet vitest catches new bare-literal offenders in `lib/prompt/composition/transforms/`.
- Future improvement (documented in const header): when the calling site has a `Parameter` row in scope, prefer `parameter.defaultTarget` over the midpoint — turns a system-wide fallback into a per-parameter sourced default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)