### PR TITLE
feat(pipeline): #1872 segmentKey namespace (text:/phase: prefixes + ADR + backfill)

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -1797,14 +1797,20 @@ async function computeReward(
   let goalProgressScore: number | null = null;
   let overallScore = behaviorScore;
 
-  const assessmentGoals = await prisma.goal.findMany({
-    where: {
-      callerId: call.callerId,
-      isAssessmentTarget: true,
-      status: { in: ["ACTIVE", "PAUSED"] },
-    },
-    select: { id: true, progress: true, priority: true },
-  });
+  // call.callerId is typed `string | null` at this point but the function
+  // is guard-gated above on its presence — narrow here so the Prisma where
+  // clause type-checks. (Was a pre-existing tsc error before #1872; net-zero
+  // baseline keeps the macOS-local ratchet honest.)
+  const assessmentGoals = call.callerId
+    ? await prisma.goal.findMany({
+        where: {
+          callerId: call.callerId,
+          isAssessmentTarget: true,
+          status: { in: ["ACTIVE", "PAUSED"] },
+        },
+        select: { id: true, progress: true, priority: true },
+      })
+    : [];
 
   if (assessmentGoals.length > 0) {
     const totalWeight = assessmentGoals.reduce((sum, g) => sum + (g.priority || 5), 0);

--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -71,6 +71,7 @@ import { shouldRunCallerAnalysis } from "@/lib/pipeline/event-gate";
 import { getCourseStyle, type CourseStyle } from "@/lib/pipeline/course-style";
 import { getTranscriptLimit, getSystemSpecs, getSpecsByOutputType, getPlaybookSpecs, batchLoadParameters, resolveCallerTeachingProfile, filterByTeachingProfile } from "@/lib/pipeline/specs-loader";
 import { writeCallScore, MEASUREMENT_SENTINEL_SPEC_IDS } from "@/lib/measurement/write-call-score";
+import { withTextNamespace } from "@/lib/pipeline/segment-key-namespace";
 import { normalizeScoreAgentEvidence } from "@/lib/pipeline/normalize-score-agent-evidence";
 import { logStageWriteCounts } from "@/lib/pipeline/write-count-logger";
 import { updateTargets } from "@/lib/ops/update-targets";
@@ -785,7 +786,11 @@ async function runPerSegmentScoring(
           // score so the Results screen (Theme 13a) can render per-part
           // criterion bands. Bound-module/whole-call writes omit this →
           // `segmentKey = null`, zero regression on non-Mock paths.
-          segmentKey: segment.slug,
+          // #1872 — namespace prefix (`text:<slug>`) so this writer can't
+          // collide with the cue-scheduler's phase-keyed prosody writes.
+          // See `lib/pipeline/segment-key-namespace.ts` for the single
+          // source of truth.
+          segmentKey: withTextNamespace(segment.slug),
           score,
           confidence,
           reasoning,

--- a/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
+++ b/apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx
@@ -25,6 +25,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
 import type { ResultsPayload, ResultsResponse } from "@/app/api/student/[courseId]/results/[sessionId]/route";
+import { segmentKeyLabel } from "@/lib/pipeline/segment-key-namespace";
 import "./results.css";
 
 const POLL_INTERVAL_MS = 5_000;
@@ -185,7 +186,17 @@ function ResultsView({ data }: { data: ResultsPayload }) {
               <tr>
                 <th>Criterion</th>
                 {segmentKeys.map((seg) => (
-                  <th key={seg ?? "overall"}>{seg ?? "Overall"}</th>
+                  // #1872 — segmentKey carries a namespace prefix
+                  // ("text:partN" / "phase:pN") so the text-segmenter and
+                  // phase-boundary writers don't collide. The header strips
+                  // the prefix via `segmentKeyLabel`, which also humanises
+                  // the bare value ("part1" → "Part 1"; "p2_monologue" →
+                  // "Part 2 (monologue)"). Legacy un-backfilled rows fall
+                  // through to the raw value, so a missed migration row
+                  // doesn't blank the column.
+                  <th key={seg ?? "overall"}>
+                    {seg === null ? "Overall" : segmentKeyLabel(seg)}
+                  </th>
                 ))}
               </tr>
             </thead>

--- a/apps/admin/lib/pipeline/prosody-runner.ts
+++ b/apps/admin/lib/pipeline/prosody-runner.ts
@@ -65,6 +65,7 @@ import type {
   GeneralSignals,
   ProsodyPhaseEnvelope,
 } from "./prosody-types";
+import { withPhaseNamespace } from "./segment-key-namespace";
 
 export interface RunProsodyOptions {
   callId: string;
@@ -576,9 +577,10 @@ async function runSegmentedProsody(
     // #1872 — namespace prefix on segmentKey writes to avoid collision
     // with the text-side Theme 6 Mock segmenter ("part1" / "part2" /
     // "part3"). Operator-chosen phase names ("p1" / "p2_prep" / etc.)
-    // are wrapped here; the AGGREGATE consumer mirrors the prefix when
-    // writing CallScore rows.
-    const phaseKey = `phase:${boundary.phase}`;
+    // are wrapped here via the single-source-of-truth helper; the
+    // AGGREGATE consumer (`prosody-consumer.ts`) propagates the prefixed
+    // key when writing CallScore rows.
+    const phaseKey = withPhaseNamespace(boundary.phase);
 
     let phaseEnvelope: ProsodyPhaseEnvelope;
     try {

--- a/apps/admin/lib/pipeline/segment-key-namespace.ts
+++ b/apps/admin/lib/pipeline/segment-key-namespace.ts
@@ -1,0 +1,121 @@
+/**
+ * SegmentKey namespace prefixes — single source of truth (#1872).
+ *
+ * Two writers produce `CallScore.segmentKey` annotations after #1870 lands:
+ *
+ *   - Text-side Mock segmenter (#1702) — writes `segmentKey = "text:" + slug`
+ *     where slug is `"part1"` / `"part2"` / `"part3"` (Theme 6).
+ *     Producer: `app/api/calls/[callId]/pipeline/route.ts` (per-segment MEASURE loop).
+ *
+ *   - Phase-boundary scheduler-derived prosody (#1870) — writes
+ *     `segmentKey = "phase:" + phaseKey` where phaseKey is operator-chosen
+ *     (`"p1"` / `"p2_prep"` / `"p2_monologue"` / `"p3"` for IELTS, but
+ *     course-agnostic). Producer: `lib/pipeline/prosody-runner.ts`
+ *     (`runSegmentedProsody`); consumer that propagates the prefix:
+ *     `lib/pipeline/prosody-consumer.ts` (bySegment branch).
+ *
+ * The `(callId, parameterId, moduleId)` unique key on `CallScore` does NOT
+ * include `segmentKey` (Epic #1700 Decision 1 — `segmentKey` is annotation,
+ * not part of the unique key). Without prefixes the two writers can
+ * silently overwrite each other's rows on a single call where both ran.
+ *
+ * Decision (Option 2 — namespace prefix) recorded in
+ * [`docs/decisions/2026-06-17-segmentkey-namespace.md`](../../docs/decisions/2026-06-17-segmentkey-namespace.md).
+ * Issue: [#1872](https://github.com/WANDERCOLTD/HF/issues/1872).
+ *
+ * NO HARDCODING: every other call site that writes a prefixed segmentKey
+ * goes through `withTextNamespace(...)` / `withPhaseNamespace(...)`; every
+ * reader that wants the bare value goes through `parseSegmentKey(...)`.
+ * The string literals `"text:"` and `"phase:"` MUST appear exactly once —
+ * here.
+ */
+
+export const SEGMENT_KEY_NAMESPACE = {
+  TEXT: "text:",
+  PHASE: "phase:",
+} as const;
+
+export type SegmentKeyNamespace =
+  (typeof SEGMENT_KEY_NAMESPACE)[keyof typeof SEGMENT_KEY_NAMESPACE];
+
+/**
+ * Wrap a text-segmenter slug with the `text:` namespace prefix.
+ *
+ * Idempotent — re-wrapping an already-prefixed value returns the input
+ * unchanged. This keeps the backfill migration safe to re-run.
+ */
+export function withTextNamespace(slug: string): string {
+  if (slug.startsWith(SEGMENT_KEY_NAMESPACE.TEXT)) return slug;
+  return `${SEGMENT_KEY_NAMESPACE.TEXT}${slug}`;
+}
+
+/**
+ * Wrap a cue-scheduler phaseKey with the `phase:` namespace prefix.
+ *
+ * Idempotent — re-wrapping an already-prefixed value returns the input
+ * unchanged.
+ */
+export function withPhaseNamespace(phaseKey: string): string {
+  if (phaseKey.startsWith(SEGMENT_KEY_NAMESPACE.PHASE)) return phaseKey;
+  return `${SEGMENT_KEY_NAMESPACE.PHASE}${phaseKey}`;
+}
+
+/**
+ * Parse a `CallScore.segmentKey` value into its namespace + bare slug.
+ *
+ * Returns `{ namespace: "legacy", bare: key }` for any value that doesn't
+ * carry one of the canonical prefixes — necessary tolerance for rows
+ * written before the namespace landed (the hf-dev backfill migration
+ * re-keys them but other environments may have legacy data until
+ * deploy + backfill).
+ */
+export function parseSegmentKey(
+  key: string,
+): { namespace: SegmentKeyNamespace | "legacy"; bare: string } {
+  if (key.startsWith(SEGMENT_KEY_NAMESPACE.TEXT)) {
+    return {
+      namespace: SEGMENT_KEY_NAMESPACE.TEXT,
+      bare: key.slice(SEGMENT_KEY_NAMESPACE.TEXT.length),
+    };
+  }
+  if (key.startsWith(SEGMENT_KEY_NAMESPACE.PHASE)) {
+    return {
+      namespace: SEGMENT_KEY_NAMESPACE.PHASE,
+      bare: key.slice(SEGMENT_KEY_NAMESPACE.PHASE.length),
+    };
+  }
+  return { namespace: "legacy", bare: key };
+}
+
+/**
+ * Human-readable label for a parsed segmentKey. Course-agnostic — handles
+ * the IELTS Mock convention (`part1` → "Part 1"; `p2_monologue` →
+ * "Part 2 (monologue)") and falls through to the raw bare value for any
+ * unrecognised shape.
+ *
+ * Used by the Student Results UI to render column headers. Kept in the
+ * namespace module (rather than in JSX) so the IELTS-specific mappings
+ * are derived from a single canonical set rather than hardcoded inline.
+ */
+export function segmentKeyLabel(key: string): string {
+  const parsed = parseSegmentKey(key);
+  return labelForBareValue(parsed.bare);
+}
+
+function labelForBareValue(bare: string): string {
+  // IELTS text-segmenter convention: `part1` / `part2` / `part3`
+  const partMatch = /^part(\d+)$/i.exec(bare);
+  if (partMatch) return `Part ${partMatch[1]}`;
+
+  // IELTS phase-boundary convention: `p1` / `p2_prep` / `p2_monologue` / `p3`
+  const phaseMatch = /^p(\d+)(?:_(.+))?$/i.exec(bare);
+  if (phaseMatch) {
+    const partNum = phaseMatch[1];
+    const qualifier = phaseMatch[2];
+    if (qualifier) return `Part ${partNum} (${qualifier.replace(/_/g, " ")})`;
+    return `Part ${partNum}`;
+  }
+
+  // Fall-through — return the bare value (caller may further humanise).
+  return bare;
+}

--- a/apps/admin/prisma/migrations/20260617145200_1872_segmentkey_namespace_backfill/migration.sql
+++ b/apps/admin/prisma/migrations/20260617145200_1872_segmentkey_namespace_backfill/migration.sql
@@ -1,0 +1,56 @@
+-- #1872 — segmentKey namespace prefix backfill.
+--
+-- Two writers produce CallScore.segmentKey annotations after #1870 lands:
+--   * Text-side Mock segmenter (#1702)         → "text:" prefix
+--   * Phase-boundary prosody (#1870 / PR #1877) → "phase:" prefix
+--
+-- Bare slugs ("part1" / "part2" / "part3") existed in hf_sandbox from
+-- Theme 6 runs before the prefix landed. Re-key them to the "text:"
+-- namespace so the union-namespace reader (Student Results UI) can
+-- distinguish them from phase-keyed rows the prosody runner now writes
+-- with a "phase:" prefix.
+--
+-- The phase writer (`runSegmentedProsody`) has always emitted the
+-- prefixed form (`phase:p1`/`phase:p2_*`/`phase:p3`), so the phase side
+-- does not require a backfill. We still include a defensive UPDATE for
+-- the operator-chosen `p1` / `p2_prep` / `p2_monologue` / `p3` shapes in
+-- case any environment captured the bare form before #1877 shipped.
+--
+-- Idempotency:
+--   * The WHERE clause excludes rows that already start with `text:` or
+--     `phase:` — re-running this migration is a no-op once the rows are
+--     namespaced.
+--   * Match is exact on the bare slug set to avoid renaming arbitrary
+--     operator-chosen values (course-agnostic segment slugs may exist
+--     in non-IELTS courses that this migration must NOT touch).
+--
+-- Safety:
+--   * Production (sandbox / pilot / prod) does not yet carry bare-slug
+--     rows — the namespace is born of the same epic that introduces the
+--     phase writer. The UPDATEs are therefore safe no-ops on prod, but
+--     necessary on hf_sandbox where developer runs have populated the
+--     bare-slug shape.
+--
+-- Reverse (emergency rollback — do NOT auto-apply):
+--   UPDATE "CallScore" SET "segmentKey" = SUBSTRING("segmentKey" FROM 6)
+--     WHERE "segmentKey" LIKE 'text:%';
+--   UPDATE "CallScore" SET "segmentKey" = SUBSTRING("segmentKey" FROM 7)
+--     WHERE "segmentKey" LIKE 'phase:%';
+-- (collisions in the resulting space are the original #1872 bug; the
+-- forward migration is preferred.)
+
+-- Text-segmenter rows: bare "part1" / "part2" / "part3" → "text:part…".
+UPDATE "CallScore"
+SET "segmentKey" = 'text:' || "segmentKey"
+WHERE "segmentKey" IN ('part1', 'part2', 'part3')
+  AND "segmentKey" NOT LIKE 'text:%'
+  AND "segmentKey" NOT LIKE 'phase:%';
+
+-- Phase-boundary rows (defensive — runner has always prefixed, but a
+-- pre-#1877 manual write could have landed bare). IELTS Mock convention
+-- only; non-IELTS phase slugs are untouched.
+UPDATE "CallScore"
+SET "segmentKey" = 'phase:' || "segmentKey"
+WHERE "segmentKey" IN ('p1', 'p2_prep', 'p2_monologue', 'p3')
+  AND "segmentKey" NOT LIKE 'text:%'
+  AND "segmentKey" NOT LIKE 'phase:%';

--- a/apps/admin/tests/api/student/results/results-page.test.tsx
+++ b/apps/admin/tests/api/student/results/results-page.test.tsx
@@ -48,13 +48,18 @@ const READY_PAYLOAD = {
   startedAt: "2026-06-16T10:00:00Z",
   endedAt: "2026-06-16T10:14:00Z",
   status: "COMPLETED",
+  // #1872 — fixture uses namespace-prefixed segmentKey values (`text:partN`)
+  // matching what the text-segmenter now writes post-PR. The Results UI
+  // label-derives them to "Part 1" / "Part 2" / "Part 3" via
+  // `segmentKeyLabel(...)`. Legacy bare-slug rows (un-backfilled) still
+  // render correctly via the parser's fall-through.
   scores: [
-    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "part1", score: 0.7, tier: "Secure", band: 6, count: 1 },
-    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "part2", score: 0.7, tier: "Secure", band: 6, count: 1 },
-    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "part3", score: 0.7, tier: "Secure", band: 6, count: 1 },
-    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "part1", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
-    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "part2", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
-    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "part3", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
+    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "text:part1", score: 0.7, tier: "Secure", band: 6, count: 1 },
+    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "text:part2", score: 0.7, tier: "Secure", band: 6, count: 1 },
+    { parameterId: "fc", parameterName: "Fluency & Coherence", segmentKey: "text:part3", score: 0.7, tier: "Secure", band: 6, count: 1 },
+    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "text:part1", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
+    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "text:part2", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
+    { parameterId: "lr", parameterName: "Lexical Resource", segmentKey: "text:part3", score: 0.6, tier: "Developing", band: 5.5, count: 1 },
   ],
   overallBand: 6,
   overallBandSource: "computed",
@@ -98,10 +103,11 @@ describe("MockResultsPage", () => {
     expect(screen.getByText("Area to work on")).toBeInTheDocument();
     expect(screen.getAllByText("Fluency & Coherence").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lexical Resource").length).toBeGreaterThan(0);
-    // Per-criterion table headers
-    expect(screen.getByText("part1")).toBeInTheDocument();
-    expect(screen.getByText("part2")).toBeInTheDocument();
-    expect(screen.getByText("part3")).toBeInTheDocument();
+    // Per-criterion table headers — #1872: namespace prefix stripped,
+    // bare slug humanised via `segmentKeyLabel(...)`.
+    expect(screen.getByText("Part 1")).toBeInTheDocument();
+    expect(screen.getByText("Part 2")).toBeInTheDocument();
+    expect(screen.getByText("Part 3")).toBeInTheDocument();
   });
 
   it("shows error banner when the API returns ok=false", async () => {

--- a/apps/admin/tests/lib/pipeline/prosody-consumer-segmented.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-consumer-segmented.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { VoiceProsodyFeatures } from "@/lib/pipeline/prosody-types";
+import { withPhaseNamespace } from "@/lib/pipeline/segment-key-namespace";
 
 const { mockPrisma, mockWriteCallScore } = vi.hoisted(() => ({
   mockPrisma: {
@@ -101,14 +102,16 @@ describe("prosody-consumer — bySegment branch (#1870)", () => {
     const segmentKeys = mockWriteCallScore.mock.calls.map(
       (c) => (c[0] as { segmentKey?: string | null }).segmentKey,
     );
-    // 12 rows carry namespaced phase keys
-    expect(segmentKeys.filter((k) => k === "phase:p1").length).toBe(4);
-    expect(segmentKeys.filter((k) => k === "phase:p2_monologue").length).toBe(4);
-    expect(segmentKeys.filter((k) => k === "phase:p3").length).toBe(4);
+    // 12 rows carry namespaced phase keys — derived via the canonical
+    // helper, not hardcoded, so a future namespace change reaches both
+    // sides of the assertion atomically (#1872 NO HARDCODING contract).
+    expect(segmentKeys.filter((k) => k === withPhaseNamespace("p1")).length).toBe(4);
+    expect(segmentKeys.filter((k) => k === withPhaseNamespace("p2_monologue")).length).toBe(4);
+    expect(segmentKeys.filter((k) => k === withPhaseNamespace("p3")).length).toBe(4);
     // 4 aggregate rows carry segmentKey null
     expect(segmentKeys.filter((k) => k === null).length).toBe(4);
     // No bare phase names — these would collide with the text segmenter's
-    // "part1"/"part2"/"part3" namespace per #1872
+    // "part1"/"part2"/"part3" namespace per #1872.
     expect(segmentKeys.some((k) => k === "p1" || k === "p2_monologue" || k === "p3")).toBe(
       false,
     );
@@ -155,9 +158,9 @@ describe("prosody-consumer — bySegment branch (#1870)", () => {
     const segmentKeys = mockWriteCallScore.mock.calls.map(
       (c) => (c[0] as { segmentKey?: string | null }).segmentKey,
     );
-    expect(segmentKeys).toContain("phase:intro");
-    expect(segmentKeys).toContain("phase:main");
-    expect(segmentKeys).toContain("phase:wrap");
+    expect(segmentKeys).toContain(withPhaseNamespace("intro"));
+    expect(segmentKeys).toContain(withPhaseNamespace("main"));
+    expect(segmentKeys).toContain(withPhaseNamespace("wrap"));
   });
 
   it("per-phase 'unavailable' entries are skipped (no row written for that phase)", async () => {
@@ -206,7 +209,7 @@ describe("prosody-consumer — bySegment branch (#1870)", () => {
     const segmentKeys = mockWriteCallScore.mock.calls.map(
       (c) => (c[0] as { segmentKey?: string | null }).segmentKey,
     );
-    expect(segmentKeys.filter((k) => k === "phase:p2_monologue").length).toBe(0);
+    expect(segmentKeys.filter((k) => k === withPhaseNamespace("p2_monologue")).length).toBe(0);
   });
 
   it("no bySegment → existing whole-call behaviour unchanged (4 IELTS rows, no segmentKey)", async () => {

--- a/apps/admin/tests/lib/pipeline/prosody-runner-segmented.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-runner-segmented.test.ts
@@ -22,6 +22,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SessionMetadata } from "@/lib/types/json-fields";
+import { withPhaseNamespace } from "@/lib/pipeline/segment-key-namespace";
 
 // ── Mocks ─────────────────────────────────────────────────
 
@@ -235,10 +236,12 @@ describe("runProsodyStage — 3-phase IELTS Mock (#1870)", () => {
     expect(mockExtractAudioSlice).toHaveBeenCalledTimes(3);
     expect(result.envelope.mode).toBe("ielts");
     expect(result.envelope.bySegment).toBeDefined();
+    // #1872 — namespace prefix derived via the canonical helper (no
+    // hardcoded "phase:" strings in test assertions).
     expect(Object.keys(result.envelope.bySegment ?? {})).toEqual([
-      "phase:p1",
-      "phase:p2_monologue",
-      "phase:p3",
+      withPhaseNamespace("p1"),
+      withPhaseNamespace("p2_monologue"),
+      withPhaseNamespace("p3"),
     ]);
     // Top-level aggregate = mean(6, 7, 8) = 7
     if (result.envelope.mode === "ielts") {
@@ -247,9 +250,10 @@ describe("runProsodyStage — 3-phase IELTS Mock (#1870)", () => {
     }
     // Per-phase preserves the raw band
     const seg = result.envelope.bySegment ?? {};
-    expect(seg["phase:p1"]).toMatchObject({ mode: "ielts" });
-    if (seg["phase:p1"]?.mode === "ielts") {
-      expect(seg["phase:p1"].ieltsScores.overall).toBe(6);
+    expect(seg[withPhaseNamespace("p1")]).toMatchObject({ mode: "ielts" });
+    const phaseP1 = seg[withPhaseNamespace("p1")];
+    if (phaseP1?.mode === "ielts") {
+      expect(phaseP1.ieltsScores.overall).toBe(6);
     }
   });
 });
@@ -288,9 +292,9 @@ describe("runProsodyStage — partial-failure tolerance (#1870)", () => {
 
     expect(scorer).toHaveBeenCalledTimes(3);
     const seg = result.envelope.bySegment ?? {};
-    expect(seg["phase:p1"]?.mode).toBe("ielts");
-    expect(seg["phase:p2_monologue"]?.mode).toBe("unavailable");
-    expect(seg["phase:p3"]?.mode).toBe("ielts");
+    expect(seg[withPhaseNamespace("p1")]?.mode).toBe("ielts");
+    expect(seg[withPhaseNamespace("p2_monologue")]?.mode).toBe("unavailable");
+    expect(seg[withPhaseNamespace("p3")]?.mode).toBe("ielts");
     // Top-level aggregate uses 6 and 8 only → mean = 7
     if (result.envelope.mode === "ielts") {
       expect(result.envelope.ieltsScores?.overall).toBe(7);

--- a/apps/admin/tests/lib/pipeline/segment-key-namespace.test.ts
+++ b/apps/admin/tests/lib/pipeline/segment-key-namespace.test.ts
@@ -1,0 +1,170 @@
+/**
+ * #1872 — segmentKey namespace prefixes.
+ *
+ * Defends:
+ *   - Single source of truth — prefixes only ever produced by the helpers.
+ *   - Idempotency — re-wrapping is a no-op (the backfill migration relies
+ *     on this).
+ *   - Round-trip — `parseSegmentKey(withTextNamespace(x))` recovers x.
+ *   - Legacy tolerance — bare slugs returned with `namespace: "legacy"`
+ *     so un-backfilled rows don't crash the reader.
+ *   - Label derivation — IELTS Mock + cue-scheduler conventions
+ *     ("part1" → "Part 1"; "p2_monologue" → "Part 2 (monologue)").
+ *   - Grep ratchet — no bare `segmentKey: 'part1'` literals in pipeline
+ *     code outside the helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  SEGMENT_KEY_NAMESPACE,
+  parseSegmentKey,
+  segmentKeyLabel,
+  withPhaseNamespace,
+  withTextNamespace,
+} from "@/lib/pipeline/segment-key-namespace";
+
+describe("segment-key-namespace — constants", () => {
+  it("TEXT prefix is 'text:'", () => {
+    expect(SEGMENT_KEY_NAMESPACE.TEXT).toBe("text:");
+  });
+
+  it("PHASE prefix is 'phase:'", () => {
+    expect(SEGMENT_KEY_NAMESPACE.PHASE).toBe("phase:");
+  });
+});
+
+describe("segment-key-namespace — withTextNamespace", () => {
+  it("wraps a bare slug with the text: prefix", () => {
+    expect(withTextNamespace("part1")).toBe("text:part1");
+    expect(withTextNamespace("part2")).toBe("text:part2");
+    expect(withTextNamespace("part3")).toBe("text:part3");
+  });
+
+  it("is idempotent — re-wrapping returns the input unchanged", () => {
+    expect(withTextNamespace("text:part1")).toBe("text:part1");
+    expect(withTextNamespace(withTextNamespace("part1"))).toBe("text:part1");
+  });
+});
+
+describe("segment-key-namespace — withPhaseNamespace", () => {
+  it("wraps a bare phaseKey with the phase: prefix", () => {
+    expect(withPhaseNamespace("p1")).toBe("phase:p1");
+    expect(withPhaseNamespace("p2_monologue")).toBe("phase:p2_monologue");
+    expect(withPhaseNamespace("p2_prep")).toBe("phase:p2_prep");
+    expect(withPhaseNamespace("p3")).toBe("phase:p3");
+  });
+
+  it("is idempotent — re-wrapping returns the input unchanged", () => {
+    expect(withPhaseNamespace("phase:p2_monologue")).toBe("phase:p2_monologue");
+    expect(withPhaseNamespace(withPhaseNamespace("p1"))).toBe("phase:p1");
+  });
+});
+
+describe("segment-key-namespace — parseSegmentKey", () => {
+  it("recognises text:-prefixed values", () => {
+    expect(parseSegmentKey("text:part1")).toEqual({
+      namespace: "text:",
+      bare: "part1",
+    });
+    expect(parseSegmentKey("text:part3")).toEqual({
+      namespace: "text:",
+      bare: "part3",
+    });
+  });
+
+  it("recognises phase:-prefixed values", () => {
+    expect(parseSegmentKey("phase:p1")).toEqual({
+      namespace: "phase:",
+      bare: "p1",
+    });
+    expect(parseSegmentKey("phase:p2_monologue")).toEqual({
+      namespace: "phase:",
+      bare: "p2_monologue",
+    });
+  });
+
+  it("falls through to 'legacy' for un-backfilled bare values", () => {
+    expect(parseSegmentKey("part1")).toEqual({
+      namespace: "legacy",
+      bare: "part1",
+    });
+    expect(parseSegmentKey("p2_monologue")).toEqual({
+      namespace: "legacy",
+      bare: "p2_monologue",
+    });
+  });
+
+  it("round-trips through the wrap helpers", () => {
+    const textRound = parseSegmentKey(withTextNamespace("part2"));
+    expect(textRound).toEqual({ namespace: "text:", bare: "part2" });
+
+    const phaseRound = parseSegmentKey(withPhaseNamespace("p2_prep"));
+    expect(phaseRound).toEqual({ namespace: "phase:", bare: "p2_prep" });
+  });
+});
+
+describe("segment-key-namespace — segmentKeyLabel", () => {
+  it("renders Theme 6 text-segmenter values as 'Part N'", () => {
+    expect(segmentKeyLabel("text:part1")).toBe("Part 1");
+    expect(segmentKeyLabel("text:part2")).toBe("Part 2");
+    expect(segmentKeyLabel("text:part3")).toBe("Part 3");
+  });
+
+  it("renders cue-scheduler bare phase values as 'Part N'", () => {
+    expect(segmentKeyLabel("phase:p1")).toBe("Part 1");
+    expect(segmentKeyLabel("phase:p3")).toBe("Part 3");
+  });
+
+  it("renders qualifier-bearing phase values as 'Part N (qualifier)'", () => {
+    expect(segmentKeyLabel("phase:p2_prep")).toBe("Part 2 (prep)");
+    expect(segmentKeyLabel("phase:p2_monologue")).toBe("Part 2 (monologue)");
+  });
+
+  it("handles legacy bare values without a prefix", () => {
+    expect(segmentKeyLabel("part1")).toBe("Part 1");
+    expect(segmentKeyLabel("p2_monologue")).toBe("Part 2 (monologue)");
+  });
+
+  it("falls through to the raw bare value for unrecognised shapes", () => {
+    expect(segmentKeyLabel("text:custom_segment")).toBe("custom_segment");
+    expect(segmentKeyLabel("phase:opening")).toBe("opening");
+  });
+});
+
+describe("segment-key-namespace — no-bare-literals grep ratchet", () => {
+  it("only the namespace helper module hardcodes the 'text:'/'phase:' prefix or bare 'segmentKey: \"partN\"' / 'segmentKey: \"pN\"' shapes", () => {
+    const pipelineDir = join(__dirname, "..", "..", "..", "lib", "pipeline");
+    const offenders: string[] = [];
+
+    const stack = [pipelineDir];
+    while (stack.length > 0) {
+      const dir = stack.pop()!;
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const stat = statSync(full);
+        if (stat.isDirectory()) {
+          stack.push(full);
+          continue;
+        }
+        if (!entry.endsWith(".ts")) continue;
+        // The constants module is the single source of truth — it owns the
+        // literals. The runner emits `phase:${boundary.phase}` ONCE at the
+        // canonical write site (kept inline so a future refactor centralising
+        // this is the only change needed; documented in the file).
+        if (entry === "segment-key-namespace.ts") continue;
+
+        const source = readFileSync(full, "utf8");
+        // segmentKey assigned a bare slug literal (part1/p2_monologue/etc.)
+        const bareLiteralRe = /segmentKey\s*[:=]\s*['"](?:part\d+|p\d+(?:_[a-z]+)?)['"]/gi;
+        const matches = source.match(bareLiteralRe);
+        if (matches && matches.length > 0) {
+          offenders.push(`${full}: ${matches.join(", ")}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/docs/decisions/2026-06-17-segmentkey-namespace.md
+++ b/docs/decisions/2026-06-17-segmentkey-namespace.md
@@ -1,0 +1,144 @@
+# `CallScore.segmentKey` namespace prefix (`text:` / `phase:`)
+
+**Date:** 2026-06-17
+**Story:** [#1872](https://github.com/WANDERCOLTD/HF/issues/1872) (follow-on to [#1762](https://github.com/WANDERCOLTD/HF/issues/1762))
+**Related PR:** [#1877](https://github.com/WANDERCOLTD/HF/pull/1877) — phase-side writer landed with the `phase:` prefix as a string literal ahead of this ADR; this PR centralises the literal in a single source of truth.
+**Decision:** Option 2 — namespace prefix (`text:` for text-segmenter writes, `phase:` for cue-scheduler / phase-boundary writes).
+**Status:** Accepted
+
+## Context
+
+Two writers produce `CallScore.segmentKey` annotations after epic #1762
+lands:
+
+| Writer | Source | segmentKey values |
+|---|---|---|
+| Text-side Mock segmenter (#1702, shipped Theme 6) | `lib/curriculum/segment-mock-transcript.ts` (regex over transcript text) → consumed by per-segment MEASURE loop in `app/api/calls/[callId]/pipeline/route.ts` | `"part1"` / `"part2"` / `"part3"` |
+| Phase-boundary prosody (#1870 / PR #1877) | `lib/voice/cue-scheduler.ts` writes `Session.metadata.phaseBoundaries` from operator-chosen `phase` slugs; `lib/pipeline/prosody-runner.ts::runSegmentedProsody` reads them and emits per-phase CallScore rows | Operator-chosen: `"p1"` / `"p2_prep"` / `"p2_monologue"` / `"p3"` for IELTS Mock; course-agnostic in general |
+
+Both writers go through `writeCallScore(...)` with the same idempotency
+shape: `@@unique([callId, parameterId, moduleId])`. The unique key does
+**NOT** include `segmentKey` (Epic #1700 Decision 1 — annotation, not part
+of the unique key). On any call where both writers ran, the second writer
+**overwrote the first** for any `(callId, parameterId, moduleId)` it
+touched, with no visible error — silent data loss.
+
+Verified pre-fix at the time of #1872 filing:
+
+- `lib/curriculum/segment-mock-transcript.ts:37-48` — `TranscriptSegment.slug` is the raw `"part1"` / `"part2"` / `"part3"` (Theme 6).
+- `app/api/calls/[callId]/pipeline/route.ts:787-788` (pre-PR) — pipeline writer passed `segmentKey: segment.slug` (the raw slug).
+- `lib/voice/phase-boundaries.ts` (post-#1866) emits raw `phase` strings ("p1" / "p2_prep" / etc.).
+- `prisma/schema.prisma` — `@@unique([callId, parameterId, moduleId])` on `CallScore` does NOT include `segmentKey`.
+- `app/x/student/[courseId]/results/[sessionId]/page.tsx:131-133` (pre-PR) — Results UI read bare `segmentKey` values into column headers.
+
+## Options considered
+
+### Option 1 — Unify the namespace
+
+Pick one canonical set (`"part1"` / `"part2"` / `"part3"` since Theme 6
+already shipped). The cue-scheduler maps its phase names to the canonical
+form at write-time.
+
+| Pro | Con |
+|---|---|
+| One reader, one writer namespace | Loses Part 2's prep-vs-monologue split (`"p2_prep"` + `"p2_monologue"` collapse to `"part2"`). Operator-chosen granularity becomes silently coarser. |
+
+### Option 2 — Namespace prefix **(chosen)**
+
+Text segmenter writes `"text:" + slug`. Cue-scheduler writes
+`"phase:" + phaseKey`. Both prefixes live in
+[`lib/pipeline/segment-key-namespace.ts`](../../apps/admin/lib/pipeline/segment-key-namespace.ts);
+every other call site goes through `withTextNamespace(...)` /
+`withPhaseNamespace(...)` (writers) or `parseSegmentKey(...)` (readers).
+
+| Pro | Con |
+|---|---|
+| Lossless — Theme 6 keeps its three-part view; cue-scheduler keeps Part 2 fine-grain (`prep` / `monologue`) | Two namespaces in one UI surface; readers must handle both via `parseSegmentKey(...)` |
+| Self-documenting in the DB — `"text:part1"` vs `"phase:p1"` is unambiguous in any query result | One-time backfill needed on hf_sandbox (production environments are unaffected — the phase writer was born prefixed) |
+| Single source of truth for the prefix strings; future renames are a one-file change | |
+
+### Option 3 — Disjoint scoring contracts
+
+Text segmenter writes against `analysisSpecId: PROSODY` (existing);
+cue-scheduler writes against `analysisSpecId: PROSODY_PHASE` (new sentinel).
+Unique key includes `analysisSpecId`, so writes don't collide.
+
+| Pro | Con |
+|---|---|
+| Strongest isolation; readers explicitly opt in | Two sentinel specs to maintain (with parallel seed rows) |
+| | UI surfaces double their query shape (every Results-style consumer queries both spec ids) |
+| | Loses the unified "this is a prosody score" lineage in the audit trail |
+
+## Decision: Option 2 — namespace prefix
+
+The text-segmenter and cue-scheduler are not really the same kind of data
+— one is text-derived, the other recording-derived — but they share the
+same column for good reasons (idempotency model, EMA aggregation surface,
+Snapshot v3 lens path). A namespace prefix preserves that sharing while
+making the writer-origin explicit at every read.
+
+Lossless granularity (vs. Option 1) is the load-bearing tradeoff.
+Operators tuned `"p2_prep"` vs `"p2_monologue"` deliberately at the
+cue-scheduler level; collapsing them silently for Mock display would hide
+that intent. Option 1 also forces every future course author to think
+about whether their phase slugs collide with the canonical Mock slugs —
+that's an avoidable footgun.
+
+Self-documentation (vs. Option 3) is the second tradeoff. A DB query for
+"prosody scores for caller X" should not have to remember which of two
+sentinel spec ids each writer used. The prefix makes the origin visible
+at the row level without exploding the schema.
+
+## Implementation
+
+Constants live ONCE at
+[`apps/admin/lib/pipeline/segment-key-namespace.ts`](../../apps/admin/lib/pipeline/segment-key-namespace.ts).
+Helpers:
+
+- `withTextNamespace(slug)` — idempotent wrapper for text-segmenter writes.
+- `withPhaseNamespace(phaseKey)` — idempotent wrapper for cue-scheduler / prosody writes.
+- `parseSegmentKey(key)` — returns `{ namespace, bare }`; falls through to `{ namespace: "legacy", bare: key }` for un-backfilled rows.
+- `segmentKeyLabel(key)` — IELTS-aware human label ("text:part1" → "Part 1"; "phase:p2_monologue" → "Part 2 (monologue)"); course-agnostic fall-through.
+
+Writers updated to call the helpers:
+
+- `app/api/calls/[callId]/pipeline/route.ts` (text segmenter MEASURE loop).
+- `lib/pipeline/prosody-runner.ts::runSegmentedProsody` (phase-boundary path — PR #1877's literal `"phase:" + boundary.phase` refactored to `withPhaseNamespace(boundary.phase)`).
+
+Reader updated to render via the helpers:
+
+- `app/x/student/[courseId]/results/[sessionId]/page.tsx` — uses `segmentKeyLabel(...)` for column headers; legacy (un-backfilled) rows still render via the fall-through.
+
+## Backfill
+
+`apps/admin/prisma/migrations/20260617145200_1872_segmentkey_namespace_backfill/migration.sql`:
+
+```sql
+UPDATE "CallScore"
+SET "segmentKey" = 'text:' || "segmentKey"
+WHERE "segmentKey" IN ('part1', 'part2', 'part3')
+  AND "segmentKey" NOT LIKE 'text:%'
+  AND "segmentKey" NOT LIKE 'phase:%';
+
+UPDATE "CallScore"
+SET "segmentKey" = 'phase:' || "segmentKey"
+WHERE "segmentKey" IN ('p1', 'p2_prep', 'p2_monologue', 'p3')
+  AND "segmentKey" NOT LIKE 'text:%'
+  AND "segmentKey" NOT LIKE 'phase:%';
+```
+
+Idempotent — the `NOT LIKE 'text:%' AND NOT LIKE 'phase:%'` clauses ensure
+a second run changes zero rows. Narrowed by exact bare-slug list (not by
+`analysisSpecId`) because the text segmenter writes against `parentSpec`
+or the MOCK sentinel — there is no single spec id that scopes the
+collision-prone rows.
+
+## Guards against regression
+
+- `apps/admin/tests/lib/pipeline/segment-key-namespace.test.ts` — constants, idempotency, round-trip, label derivation, **grep-based ratchet** (scans `lib/pipeline/` for bare `segmentKey: "partN"` / `segmentKey: "pN_*"` literals outside the helpers and fails if any exist).
+- Existing prosody-consumer and prosody-runner segmented tests updated to derive expected strings from `withPhaseNamespace(...)` (not from string literals), so a future namespace change reaches both sides of the assertion atomically.
+
+## Deploy
+
+`/vm-cpp` — code + backfill migration. Cloud Run deploys carry the
+migration via the standard `hf-migrate-*` job.


### PR DESCRIPTION
## Summary

Closes #1872. Resolves the `CallScore.segmentKey` namespace collision between Theme 6's Mock text segmenter (`"part1"` / `"part2"` / `"part3"`) and the cue-scheduler phase-boundary writer (`"p1"` / `"p2_monologue"` etc.) per **Option 2 (namespace prefix)**.

- **Single source of truth** for the prefix strings — `apps/admin/lib/pipeline/segment-key-namespace.ts:34-35`. Every other call site goes through `withTextNamespace(...)` / `withPhaseNamespace(...)` (writers) or `parseSegmentKey(...)` / `segmentKeyLabel(...)` (readers). The literals `"text:"` and `"phase:"` appear exactly once in runtime code.
- Refactored writers, updated reader, idempotent backfill migration, ADR, vitests (incl. grep-based ratchet against future bare-slug literals).

ADR: [`docs/decisions/2026-06-17-segmentkey-namespace.md`](./docs/decisions/2026-06-17-segmentkey-namespace.md) — captures the three options considered and the lossless-granularity + self-documentation tradeoffs.

## File:line citations

| Surface | Path | Change |
|---|---|---|
| Constants source of truth | `apps/admin/lib/pipeline/segment-key-namespace.ts:34-35` | New file. `SEGMENT_KEY_NAMESPACE = { TEXT: "text:", PHASE: "phase:" }` — the only runtime occurrences of either literal in `lib/` + `app/`. |
| Text-segmenter writer refactor | `apps/admin/app/api/calls/[callId]/pipeline/route.ts:793` | `segmentKey: segment.slug` → `segmentKey: withTextNamespace(segment.slug)` |
| Phase-boundary writer refactor | `apps/admin/lib/pipeline/prosody-runner.ts:582` | `` const phaseKey = `phase:${boundary.phase}` `` → `const phaseKey = withPhaseNamespace(boundary.phase)` (refactor only — semantics unchanged from PR #1877) |
| Reader humanisation | `apps/admin/app/x/student/[courseId]/results/[sessionId]/page.tsx:194-196` | Column headers render `segmentKeyLabel(seg)` ("text:part1" → "Part 1"; "phase:p2_monologue" → "Part 2 (monologue)") |
| Backfill migration | `apps/admin/prisma/migrations/20260617145200_1872_segmentkey_namespace_backfill/migration.sql` | Idempotent SQL — 26 SQL lines + reverse-rollback documented in comment |

## Backfill SQL (idempotency clause)

```sql
UPDATE "CallScore"
SET "segmentKey" = 'text:' || "segmentKey"
WHERE "segmentKey" IN ('part1', 'part2', 'part3')
  AND "segmentKey" NOT LIKE 'text:%'
  AND "segmentKey" NOT LIKE 'phase:%';

UPDATE "CallScore"
SET "segmentKey" = 'phase:' || "segmentKey"
WHERE "segmentKey" IN ('p1', 'p2_prep', 'p2_monologue', 'p3')
  AND "segmentKey" NOT LIKE 'text:%'
  AND "segmentKey" NOT LIKE 'phase:%';
```

Idempotent via the `NOT LIKE` clauses — re-running changes zero rows. Narrowed by exact bare-slug list (not by `analysisSpecId`) because the text segmenter writes against `parentSpec` or the `MOCK` sentinel — there is no single spec id that scopes the collision-prone rows. Sanity-checked against migration directory format: timestamp prefix `20260617145200`, slug `1872_segmentkey_namespace_backfill`, `migration.sql` filename — matches `prisma/migrations/20260617120000_1870_max_segments_per_call/`.

## Lattice survey

- **Sibling-writer drift**: two writers (`pipeline/route.ts:783-800` for text; `prosody-runner.ts:582` + `prosody-consumer.ts:108-114` for phase) share `CallScore.segmentKey`. Unique key `@@unique([callId, parameterId, moduleId])` at `prisma/schema.prisma:5254` does NOT include `segmentKey` → without the prefix one writer silently overwrites the other. Convergence design: namespace-prefix wrapper helpers + grep-ratchet test.
- **Default-deny gates**: no ESLint rule against bare `segmentKey: "partN"` literals previously existed — this PR ships a grep-ratchet inside the new vitest (scans `lib/pipeline/`).
- **Cascade respect**: not cascadable (per-row annotation, not a knob).
- **Convention conflict**: `MASTERED` vs `COMPLETED`-class drift n/a here. The namespace itself is the new convention; the bare-slug shape is the legacy.
- **Producer ↔ consumer pairing**: producer (constants module) ships WITH the consumer in the same PR (grep ratchet test + updated prosody-consumer-segmented test + Student Results page reader). No producer-only lattice entry.

## Sibling-lane respect

Did NOT touch (`#1871`'s lane):
- `lib/pipeline/prosody-runner.ts::normaliseVendorResult` (line 398-449)
- `lib/speech-assessment/providers/`
- `lib/journey/setting-contracts.entries.ts`

The edit to `prosody-runner.ts` is at `runSegmentedProsody` (line 562+), a separate function.

## Test counts

| Bank | Result |
|---|---|
| New: `tests/lib/pipeline/segment-key-namespace.test.ts` | 16/16 green |
| Updated: `tests/lib/pipeline/prosody-consumer-segmented.test.ts` | 5/5 green |
| Updated: `tests/lib/pipeline/prosody-runner-segmented.test.ts` | 6/6 green |
| Updated: `tests/api/student/results/results-page.test.tsx` | 3/3 green (10/10 in the file) |
| Full pipeline bank | 343/343 green (29 files) |
| API calls + pipeline bank | 86/86 green (4 files) |

## Verified by

- tsc baseline: before commit 1 → 41 (parent `46f79f10`, macOS); after commit 1 → 41 (same — zero new errors, line shifted by 5 due to import + comment additions); after commit 2 (drive-by chore narrowing pre-existing `Goal.where.callerId` error to satisfy ratchet) → 40 (matches `.ratchet.json::tsc_errors`). Pre-push gate passes.
- Single-source-of-truth confirmed by `grep -rn '"text:"\|"phase:"' apps/admin/lib apps/admin/app` → 5 hits, all in `lib/pipeline/segment-key-namespace.ts` (4 comments + 2 runtime literals at lines 34-35).
- Sibling-writer survey: `lib/pipeline/route.ts:793` (text writer) + `lib/pipeline/prosody-runner.ts:582` (phase writer) + `lib/pipeline/prosody-consumer.ts:108-114` (consumer propagating phase prefix) all confirmed via grep + read.
- Backfill idempotency proven by inspection: re-running matches `WHERE … NOT LIKE 'text:%' AND NOT LIKE 'phase:%'` → zero rows updated on second pass.
- Grep ratchet pinned by vitest in `tests/lib/pipeline/segment-key-namespace.test.ts:135-167`: scans `lib/pipeline/` for bare `segmentKey: "partN"` / `"pN_*"` literals outside the helpers and fails if any exist. Currently 0 offenders [verified].

## Test plan

- [ ] `/vm-cpp` to apply the backfill migration on hf-dev.
- [ ] After `/vm-cpp`, run a Mock pipeline that exercises BOTH writers (text segmenter + segmented prosody) and confirm both writer's rows coexist with their prefixes intact on the `CallScore` table.
- [ ] Open `/x/student/<courseId>/results/<sessionId>` on a backfilled session; column headers should render "Part 1" / "Part 2" / "Part 3" (and any phase-prefixed cells should render their humanised form, e.g. "Part 2 (monologue)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
