### PR TITLE
test(banding): behavioural unit tests for uncovered pure functions

### DIFF
--- a/apps/admin/tests/lib/banding/derive-skill-tier-mapping-from-source.test.ts
+++ b/apps/admin/tests/lib/banding/derive-skill-tier-mapping-from-source.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for `lib/banding/derive-skill-tier-mapping-from-source.ts` (#1630) —
+ * the pure function that lifts a per-skill `tierScheme` signal up to the
+ * course-level `skillTierMapping` shape.
+ *
+ * Pins the decision contract set by TL review:
+ *
+ *   - `cto` scheme → 5-level mapping with Foundation/Practitioner/Distinction
+ *     labels + `derivedFromScheme: "cto"`.
+ *   - `cefr` scheme → the CEFR preset's mapping + labels, so BandingPicker's
+ *     `detectPresetId()` auto-detects it.
+ *   - `three` (the default scheme) and unrecognised schemes → null (IELTS
+ *     default still serves; operator decides).
+ *   - **Q2 advisory-null on disagreement**: a course mixing two schemes
+ *     produces no derivation (the union has >1 scheme).
+ *   - Empty input → null.
+ */
+
+import { describe, it, expect } from "vitest";
+import { deriveSkillTierMappingFromSkills } from "@/lib/banding/derive-skill-tier-mapping-from-source";
+import { TIER_PRESETS } from "@/lib/banding/presets";
+import type { ParsedSkill } from "@/lib/wizard/project-course-reference";
+
+/** Minimal ParsedSkill with only the field the deriver reads (`tierScheme`). */
+function skill(tierScheme: string[]): ParsedSkill {
+  return {
+    ref: `SKILL-${tierScheme.join("-")}`,
+    name: "test skill",
+    tiers: {},
+    tierScheme,
+  };
+}
+
+const CTO = ["foundation", "developing", "practitioner", "distinction"];
+const CEFR = ["a1", "a2", "b1", "b2", "c1", "c2"];
+const THREE = ["emerging", "developing", "secure"];
+
+describe("deriveSkillTierMappingFromSkills — recognised schemes", () => {
+  it("derives the CTO mapping with native labels", () => {
+    const result = deriveSkillTierMappingFromSkills([skill(CTO)]);
+    expect(result).not.toBeNull();
+    expect(result!.derivedFromScheme).toBe("cto");
+    expect(result!.tierLabels.approachingEmerging).toBe("Foundation");
+    expect(result!.tierLabels.secure).toBe("Distinction");
+    expect(result!.mapping).toBe(TIER_PRESETS["5-level"].mapping);
+  });
+
+  it("derives the CEFR mapping from the CEFR preset", () => {
+    const result = deriveSkillTierMappingFromSkills([skill(CEFR)]);
+    expect(result).not.toBeNull();
+    expect(result!.derivedFromScheme).toBe("cefr");
+    expect(result!.mapping).toBe(TIER_PRESETS.cefr.mapping);
+    expect(result!.tierLabels).toEqual(TIER_PRESETS.cefr.tierLabels);
+  });
+
+  it("derives from a unanimous multi-skill course", () => {
+    const result = deriveSkillTierMappingFromSkills([skill(CTO), skill(CTO), skill(CTO)]);
+    expect(result?.derivedFromScheme).toBe("cto");
+  });
+});
+
+describe("deriveSkillTierMappingFromSkills — null cases", () => {
+  it("returns null for the default 3-tier scheme", () => {
+    expect(deriveSkillTierMappingFromSkills([skill(THREE)])).toBeNull();
+  });
+
+  it("returns null for an unrecognised scheme", () => {
+    expect(deriveSkillTierMappingFromSkills([skill(["low", "mid", "high"])])).toBeNull();
+  });
+
+  it("returns null (advisory) when skills disagree on scheme — Q2", () => {
+    expect(deriveSkillTierMappingFromSkills([skill(CTO), skill(CEFR)])).toBeNull();
+  });
+
+  it("returns null when one skill is unrecognised even if others agree", () => {
+    expect(deriveSkillTierMappingFromSkills([skill(CTO), skill(["x", "y"])])).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(deriveSkillTierMappingFromSkills([])).toBeNull();
+  });
+
+  it("does not match a scheme when tier order differs", () => {
+    const reordered = ["distinction", "practitioner", "developing", "foundation"];
+    expect(deriveSkillTierMappingFromSkills([skill(reordered)])).toBeNull();
+  });
+});

--- a/apps/admin/tests/lib/banding/glossary.test.ts
+++ b/apps/admin/tests/lib/banding/glossary.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for `lib/banding/glossary.ts` — the acronym lookup behind
+ * `components/shared/Acronym.tsx`.
+ *
+ * Pins the two non-obvious behaviours of `lookupAcronym`:
+ *
+ *   1. Literal keys resolve directly (IELTS criteria, banding tiers).
+ *   2. The `OUT-NN` / `SKILL-NN` ref shapes are resolved by REGEX, not by
+ *      literal key — `OUT-01` must map onto the shared `OUT-NN` definition,
+ *      case-insensitively, while a bare unknown key returns undefined.
+ *
+ * The regex branch is the load-bearing bit: a consumer passing a concrete
+ * ref ("SKILL-03") must get the family tooltip, not a miss.
+ */
+
+import { describe, it, expect } from "vitest";
+import { lookupAcronym, ACRONYM_GLOSSARY } from "@/lib/banding/glossary";
+
+describe("lookupAcronym — literal keys", () => {
+  it("resolves IELTS Speaking criteria short-codes", () => {
+    expect(lookupAcronym("FC")?.full).toBe("Fluency & Coherence");
+    expect(lookupAcronym("LR")?.full).toBe("Lexical Resource");
+    expect(lookupAcronym("GRA")?.full).toBe("Grammatical Range & Accuracy");
+    expect(lookupAcronym("P")?.full).toBe("Pronunciation");
+  });
+
+  it("resolves banding tier names", () => {
+    expect(lookupAcronym("Emerging")).toBeDefined();
+    expect(lookupAcronym("Secure")?.full).toBe("Secure tier");
+  });
+});
+
+describe("lookupAcronym — ref-shape regex branch", () => {
+  it("maps a concrete OUT-NN ref onto the shared definition", () => {
+    const concrete = lookupAcronym("OUT-01");
+    expect(concrete).toBeDefined();
+    expect(concrete).toBe(ACRONYM_GLOSSARY["OUT-NN"]);
+  });
+
+  it("maps a concrete SKILL-NN ref onto the shared definition", () => {
+    const concrete = lookupAcronym("SKILL-03");
+    expect(concrete).toBe(ACRONYM_GLOSSARY["SKILL-NN"]);
+  });
+
+  it("matches the ref shape case-insensitively", () => {
+    expect(lookupAcronym("out-7")).toBe(ACRONYM_GLOSSARY["OUT-NN"]);
+    expect(lookupAcronym("skill-12")).toBe(ACRONYM_GLOSSARY["SKILL-NN"]);
+  });
+
+  it("does not match a ref shape with no numeric suffix", () => {
+    expect(lookupAcronym("OUT-")).toBeUndefined();
+    expect(lookupAcronym("SKILL")).toBeUndefined();
+  });
+});
+
+describe("lookupAcronym — misses", () => {
+  it("returns undefined for an unknown key", () => {
+    expect(lookupAcronym("ZZZ")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty key without throwing", () => {
+    expect(lookupAcronym("")).toBeUndefined();
+  });
+});

--- a/apps/admin/tests/lib/banding/presets.test.ts
+++ b/apps/admin/tests/lib/banding/presets.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for `lib/banding/presets.ts` — the per-playbook tier-mapping presets
+ * consumed by `BandingPicker.tsx` and `scoreToTier()`.
+ *
+ * Structural coverage (registry-options-coverage) already pins that every
+ * preset's `value` is a member of the canonical set. These tests pin the
+ * BEHAVIOURAL invariants the structural gate can't see:
+ *
+ *   1. `getPreset()` resolution semantics — known id, unknown id, nullish
+ *      all funnel to a defined preset (Generic 4-tier is the documented
+ *      default, #1657).
+ *   2. Every preset exposes the four fixed threshold slots `scoreToTier`
+ *      indexes by, in strictly ascending order with `secure === 1.0`.
+ *   3. Framework presets (IELTS / CEFR / 5-level) carry native `tierLabels`
+ *      so a CEFR course renders "B1" not "Developing"; the neutral presets
+ *      (generic / source-derived / custom) intentionally do not.
+ */
+
+import { describe, it, expect } from "vitest";
+import { TIER_PRESETS, getPreset, type TierPresetId } from "@/lib/banding/presets";
+
+const SLOTS = ["approachingEmerging", "emerging", "developing", "secure"] as const;
+
+describe("getPreset", () => {
+  it("resolves a known preset id to its own entry", () => {
+    expect(getPreset("ielts-speaking").id).toBe("ielts-speaking");
+    expect(getPreset("cefr").id).toBe("cefr");
+  });
+
+  it("falls back to Generic 4-tier for an unknown id", () => {
+    expect(getPreset("not-a-real-preset").id).toBe("generic");
+  });
+
+  it("falls back to Generic 4-tier for nullish input", () => {
+    expect(getPreset(undefined).id).toBe("generic");
+    expect(getPreset(null).id).toBe("generic");
+    expect(getPreset("").id).toBe("generic");
+  });
+
+  it("never returns undefined for any input", () => {
+    for (const id of [undefined, null, "", "garbage", "generic", "cefr"]) {
+      expect(getPreset(id as TierPresetId)).toBeDefined();
+    }
+  });
+});
+
+describe("TIER_PRESETS threshold invariants", () => {
+  const ids = Object.keys(TIER_PRESETS) as TierPresetId[];
+
+  it.each(ids)("%s exposes all four fixed threshold + band slots", (id) => {
+    const { thresholds, tierBands } = TIER_PRESETS[id].mapping;
+    for (const slot of SLOTS) {
+      expect(thresholds[slot]).toBeTypeOf("number");
+      expect(tierBands?.[slot]).toBeTypeOf("number");
+    }
+  });
+
+  it.each(ids)("%s has strictly ascending thresholds topping out at 1.0", (id) => {
+    const t = TIER_PRESETS[id].mapping.thresholds;
+    expect(t.approachingEmerging).toBeLessThan(t.emerging);
+    expect(t.emerging).toBeLessThan(t.developing);
+    expect(t.developing).toBeLessThan(t.secure);
+    expect(t.secure).toBe(1.0);
+  });
+
+  it("each preset's id matches its map key (no copy-paste drift)", () => {
+    for (const id of ids) {
+      expect(TIER_PRESETS[id].id).toBe(id);
+    }
+  });
+});
+
+describe("TIER_PRESETS tierLabels", () => {
+  it("framework presets carry native tier labels", () => {
+    expect(TIER_PRESETS["ielts-speaking"].tierLabels?.secure).toBe("Band 7");
+    expect(TIER_PRESETS.cefr.tierLabels?.emerging).toBe("B1");
+    expect(TIER_PRESETS["5-level"].tierLabels?.approachingEmerging).toBe("Novice");
+  });
+
+  it("neutral presets intentionally omit tierLabels (fall back to default names)", () => {
+    expect(TIER_PRESETS.generic.tierLabels).toBeUndefined();
+    expect(TIER_PRESETS["source-derived"].tierLabels).toBeUndefined();
+    expect(TIER_PRESETS.custom.tierLabels).toBeUndefined();
+  });
+
+  it("when present, tierLabels cover all four slots", () => {
+    for (const id of Object.keys(TIER_PRESETS) as TierPresetId[]) {
+      const labels = TIER_PRESETS[id].tierLabels;
+      if (!labels) continue;
+      for (const slot of SLOTS) {
+        expect(labels[slot]).toBeTruthy();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds behavioural unit tests for the genuinely-uncovered pure functions in `apps/admin/lib/banding/`. The Lattice Coverage-pillar tests enforce that consumers **exist** (structural); these pin that the functions are **correct** (behavioural) — orthogonal to the structural pillars.

- **`presets.ts`** — `getPreset()` resolution (known / unknown / nullish all funnel to the Generic 4-tier default, #1657), threshold-slot invariants (strictly ascending, `secure === 1.0`), tierLabels presence on framework presets vs absence on neutral presets.
- **`glossary.ts`** — `lookupAcronym()` literal-key resolution plus the `OUT-NN` / `SKILL-NN` regex branch (case-insensitive; rejects suffix-less keys).
- **`derive-skill-tier-mapping-from-source.ts`** — the #1630 decision contract: `cto` / `cefr` derivation, Q2 advisory-null on scheme disagreement, null for the 3-tier default and unrecognised/reordered schemes.

## Why

A sweep of the vitest suite vs the Lattice confirmed **zero redundancy to remove** — every Coverage-pillar test (`route-auth-zod`, `parameter`, `registry-consumer`, `registry-schema`, `tier-visibility`, `coverage-producer-consumer`, `lattice-self-maintenance`) enforces a property no ESLint rule can replicate. The only worthwhile *add* was behavioural coverage of these 2–3 uncovered pure functions.

## Verified by

- `node_modules/.bin/vitest run tests/lib/banding` → **37 new tests pass**.
- `tests/lib/lattice-self-maintenance.test.ts` → still green; plain unit tests don't count as orphan coverage-pillar tests, so no ratchet drift.
- `tsc --noEmit` → no errors in the new files.

Ready for `/vm-cp` (tests only — no schema, no runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ccM7xsnooH4RGFPfzyPfX

---
_Generated by [Claude Code](https://claude.ai/code/session_017ccM7xsnooH4RGFPfzyPfX)_