### PR TITLE
feat(voice): #1871 general PROSODY signals + Inspector chip

### DIFF
--- a/apps/admin/lib/chat/admin-tools.ts
+++ b/apps/admin/lib/chat/admin-tools.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AITool } from "@/lib/ai/client";
+import { PROSODY_MODE_VALUES } from "@/lib/pipeline/prosody-types";
 
 export const ADMIN_TOOLS: AITool[] = [
   {
@@ -1010,7 +1011,10 @@ export const ADMIN_TOOLS: AITool[] = [
             maxDurationSeconds: { type: "integer" },
             voicemailDetectionEnabled: { type: "boolean" },
             endCallPhrases: { type: "array", items: { type: "string" } },
-            prosodyMode: { type: "string", enum: ["ielts", "general", "auto"] },
+            // #1871 — enum derived from PROSODY_MODE_VALUES (single source
+            // of truth shared with the JourneySettingContract option list
+            // and the runtime resolveProsodyMode precedence).
+            prosodyMode: { type: "string", enum: [...PROSODY_MODE_VALUES] },
           },
           additionalProperties: true,
         },

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -25,6 +25,10 @@ import type {
 } from "./setting-contracts";
 import type { JourneyGroup } from "./setting-groups";
 import { TIER_PRESETS } from "@/lib/banding/presets";
+import {
+  PROSODY_MODE_VALUES,
+  PROSODY_MODE_LABELS,
+} from "@/lib/pipeline/prosody-types";
 
 // =============================================================
 // G1 — Sign-up & Intake (5)
@@ -623,6 +627,62 @@ const G4_TIER_PRESET_ID: JourneySettingContract = {
   options: Object.entries(TIER_PRESETS).map(([value, preset]) => ({
     value,
     label: preset.label,
+  })),
+};
+
+
+// #1871 — explicit operator override for the PROSODY pipeline stage's
+// scoring mode. Beats `tierPresetId` at runtime (see
+// `lib/pipeline/prosody-runner.ts::resolveProsodyMode`). Pre-#1871 the
+// only ways to flip this were Cmd+K on the Course Chat page
+// (`update_voice_config({ prosodyMode })`) or direct DB edit; operators
+// using the Scoring-tab Inspector could see the resolved value on the
+// course-header ProsodyModePill but couldn't edit it.
+//
+// `auto` writes `voice.prosodyMode = "auto"` — the runtime's
+// `resolveProsodyMode` treats anything other than "ielts" / "general"
+// as "fall through to the tierPresetId heuristic", so the literal "auto"
+// is the explicit "use the heuristic" state. Lets operators see "Auto"
+// in the dropdown rather than an unchecked blank.
+//
+// NOT registered in `lib/cascade/effective-value.ts::FAMILIES` — the
+// override is intentionally course-level only (Domain-level prosody-mode
+// override would silently swap scoring rubrics on every course in the
+// domain, which is dangerous). Snapshot read is correct per
+// `.claude/rules/cascade-reuse.md`: cascade resolver returns
+// `unresolvable: true`, Inspector falls back to snapshot read.
+//
+// Option list derived from `PROSODY_MODE_VALUES` + `PROSODY_MODE_LABELS`
+// in `lib/pipeline/prosody-types.ts` — single source of truth shared
+// with the `update_voice_config` admin tool's enum + the runtime's
+// `resolveProsodyMode` precedence.
+const G4_VOICE_PROSODY_MODE: JourneySettingContract = {
+  id: "voiceProsodyMode",
+  menuGroupKey: "I_scoring",
+  group: "G4",
+  educatorLabel: "Voice scoring mode (override)",
+  helpText:
+    "Explicit override for how PROSODY scores call audio. Auto falls back to the tier preset heuristic (`ielts-speaking` -> IELTS; everything else -> General). IELTS writes the 4-band CallScores (Fluency & Coherence, Pronunciation, Lexical Resource, Grammatical Range & Accuracy); General writes CONV_PACE + pace_indicators only.",
+  storagePath: "config.voice.prosodyMode",
+  control: "select",
+  cascadeSources: [],
+  composeImpact: {
+    // Same surface as tierPresetId — flipping prosody mode changes which
+    // signals flow into the mastery sections at AGGREGATE time, so the
+    // Preview lens flips stale for the same rendered sections.
+    sections: ["moduleMastery", "loMastery"],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [
+    // Course-header ProsodyModePill — clicking the pill historically
+    // routed to Course Chat; the Inspector dropdown is the canonical
+    // editor; pill remains a read-only display chip.
+    { section: "moduleMastery", hint: "ProsodyModePill (course header)" },
+  ],
+  options: PROSODY_MODE_VALUES.map((value) => ({
+    value,
+    label: PROSODY_MODE_LABELS[value],
   })),
 };
 
@@ -1840,6 +1900,7 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G4_TOLERANCE_CONFIDENCE,
   G4_TOLERANCE_ENGAGEMENT,
   G4_TIER_PRESET_ID,
+  G4_VOICE_PROSODY_MODE,
   G4_SKILL_MIN_CALLS_TO_FULL,
   G4_SKILL_TIER_MAPPING,
   G4_SKILL_SCORING_EMA_HALF_LIFE,

--- a/apps/admin/lib/pipeline/prosody-runner.ts
+++ b/apps/admin/lib/pipeline/prosody-runner.ts
@@ -63,9 +63,14 @@ import type {
   VoiceProsodyMode,
   IeltsScores,
   GeneralSignals,
+  GeneralSignalField,
   ProsodyPhaseEnvelope,
 } from "./prosody-types";
 import { withPhaseNamespace } from "./segment-key-namespace";
+import {
+  GENERAL_SIGNAL_FIELDS,
+  STUB_SIGNAL_ZERO,
+} from "./prosody-types";
 
 export interface RunProsodyOptions {
   callId: string;
@@ -248,6 +253,8 @@ export async function runProsodyStage(
         adapter,
         mode,
         vendorTimeoutMs,
+        callId,
+        callerId,
       }).then((r) => {
         vendorErrorMessage = r.errorMessage;
         return r.envelope;
@@ -259,6 +266,8 @@ export async function runProsodyStage(
       adapter,
       mode,
       vendorTimeoutMs,
+      callId,
+      callerId,
     });
     vendorEnvelope = whole.envelope;
     vendorErrorMessage = whole.errorMessage;
@@ -424,26 +433,82 @@ function normaliseVendorResult(
     };
   }
 
-  // General mode — vendor adapters don't yet return generic prosody
-  // signals in a normalised shape (the SpeechAce / SpeechSuper paths
-  // return IELTS even when called with `general` mode). For now, we
-  // derive degenerate signals from the IELTS payload when present, and
-  // emit zeros otherwise. A future story can extend the adapter
-  // interface with a `getGeneralSignals()` method when a vendor really
-  // exposes them.
+  // General mode — legacy fallback path. Adapters that don't implement
+  // `getGeneralSignals` end up here; the runner's general branch logs
+  // `voice.prosody.general_unsupported` once per call before this fires.
+  // `STUB_SIGNAL_ZERO` is the sentinel for "vendor doesn't expose this
+  // signal" — distinct from a real zero in code review (see
+  // prosody-types.ts). `confidenceProxy` keeps the existing IELTS-fluency
+  // derivation so legacy adapters that DO return IELTS bands while called
+  // in general mode still contribute a useful proxy.
   const generalSignals: GeneralSignals = {
-    paceWpm: 0,
-    hesitationRate: 0,
-    meanEnergyDb: 0,
-    pitchRangeHz: 0,
+    paceWpm: STUB_SIGNAL_ZERO,
+    hesitationRate: STUB_SIGNAL_ZERO,
+    meanEnergyDb: STUB_SIGNAL_ZERO,
+    pitchRangeHz: STUB_SIGNAL_ZERO,
     confidenceProxy: result.ielts?.fluency
       ? Math.min(1, result.ielts.fluency / 9)
-      : 0,
+      : STUB_SIGNAL_ZERO,
   };
   return {
     mode: "general",
     generalSignals,
     rawVendor: result.raw,
+  };
+}
+
+
+/**
+ * #1871 — compose a `VoiceProsodyFeatures` envelope for general mode from
+ * an adapter's `Partial<GeneralSignals>` return.
+ *
+ * The partial is merged onto a STUB_SIGNAL_ZERO baseline so downstream
+ * AGGREGATE reads every field unconditionally. `confidenceProxy` is set
+ * to STUB_SIGNAL_ZERO — adapters don't expose a learner-confidence proxy
+ * via the general-signal path; the existing IELTS-fluency-derived form
+ * lives on the legacy scoreUploadedAudio path and stays there.
+ *
+ * Emits `voice.prosody.general_partial_signals` AppLog with the populated
+ * / missing field-name lists derived from the canonical
+ * `GENERAL_SIGNAL_FIELDS` constant. Pinned by
+ * `prosody-runner-general-signals.test.ts`.
+ */
+function composeGeneralEnvelopeFromPartial(
+  partial: Partial<GeneralSignals>,
+  adapterKey: string,
+  callId: string | undefined,
+): VoiceProsodyFeatures {
+  const populated: GeneralSignalField[] = [];
+  const missing: GeneralSignalField[] = [];
+  for (const field of GENERAL_SIGNAL_FIELDS) {
+    const v = partial[field];
+    if (typeof v === "number" && Number.isFinite(v)) {
+      populated.push(field);
+    } else {
+      missing.push(field);
+    }
+  }
+
+  log("system", "voice.prosody.general_partial_signals", {
+    message: `Adapter ${adapterKey} returned ${populated.length}/${GENERAL_SIGNAL_FIELDS.length} general signal field(s)`,
+    callId,
+    adapterKey,
+    fieldsPopulated: populated,
+    fieldsMissing: missing,
+  });
+
+  const generalSignals: GeneralSignals = {
+    paceWpm: partial.paceWpm ?? STUB_SIGNAL_ZERO,
+    hesitationRate: partial.hesitationRate ?? STUB_SIGNAL_ZERO,
+    meanEnergyDb: partial.meanEnergyDb ?? STUB_SIGNAL_ZERO,
+    pitchRangeHz: partial.pitchRangeHz ?? STUB_SIGNAL_ZERO,
+    confidenceProxy: STUB_SIGNAL_ZERO,
+  };
+
+  return {
+    mode: "general",
+    generalSignals,
+    rawVendor: { partial, source: "getGeneralSignals", adapterKey },
   };
 }
 
@@ -497,6 +562,13 @@ interface RunWholeCallProsodyArgs {
   adapter: SpeechAssessmentAdapter;
   mode: VoiceProsodyMode;
   vendorTimeoutMs: number;
+  /** #1871 — passed through to the general-mode AppLog dump sites so
+   *  observability can attribute the partial-fill / unsupported events
+   *  back to the originating Call + Caller. Optional because the
+   *  segmented path's per-phase whole-call fallback (currently unused
+   *  but kept structurally) doesn't always have caller context. */
+  callId?: string;
+  callerId?: string | null;
 }
 
 interface VendorAttemptResult {
@@ -516,6 +588,39 @@ async function runWholeCallProsody(
     const audio = await fetchAudioBuffer(args.recordingUrl);
     const scoringMode: ScoringMode =
       args.mode === "ielts" ? "ielts" : "general";
+
+    // #1871 — general-mode preferred path: when the adapter implements
+    // `getGeneralSignals`, call that instead of `scoreUploadedAudio`. The
+    // partial result is merged onto a STUB_SIGNAL_ZERO baseline so
+    // downstream AGGREGATE reads every field unconditionally. Adapters
+    // that don't implement it fall back to the legacy stub-zero path AND
+    // emit `voice.prosody.general_unsupported` once per call so operators
+    // can SEE which adapters/courses still pay vendor cost for stub data.
+    if (
+      scoringMode === "general" &&
+      typeof args.adapter.getGeneralSignals === "function"
+    ) {
+      const partial = await Promise.race([
+        args.adapter.getGeneralSignals(audio.buffer, audio.mimeType),
+        timeoutAfter(args.vendorTimeoutMs),
+      ]);
+      return {
+        envelope: composeGeneralEnvelopeFromPartial(
+          partial,
+          args.adapter.slug,
+          args.callId,
+        ),
+      };
+    }
+    if (scoringMode === "general" && args.callId) {
+      log("system", "voice.prosody.general_unsupported", {
+        message: `Adapter ${args.adapter.slug} does not implement getGeneralSignals; falling back to stub-zero envelope`,
+        callId: args.callId,
+        adapterKey: args.adapter.slug,
+        callerId: args.callerId ?? undefined,
+      });
+    }
+
     const result = await Promise.race([
       args.adapter.scoreUploadedAudio(audio.buffer, audio.mimeType, scoringMode),
       timeoutAfter(args.vendorTimeoutMs),

--- a/apps/admin/lib/pipeline/prosody-types.ts
+++ b/apps/admin/lib/pipeline/prosody-types.ts
@@ -80,3 +80,64 @@ export interface VoiceProsodyFeatures {
 }
 
 export const VOICE_PROSODY_CONTRACT_ID = "VOICE_PROSODY_V1" as const;
+
+/**
+ * #1871 — canonical literal values the operator can write to
+ * `Playbook.config.voice.prosodyMode`. Single source of truth for:
+ *
+ *  - The runtime precedence in `resolveProsodyMode` (`"ielts" | "general"`
+ *    are the only two values that bypass the tier-preset heuristic; `"auto"`
+ *    is the explicit sentinel for "fall back to the heuristic")
+ *  - The `update_voice_config` admin tool's `prosodyMode` enum
+ *  - The JourneySettingContract option list for `voiceProsodyMode`
+ *
+ * Imports of this constant — NOT a hand-typed string array — are how the
+ * three writers stay agreement-locked. Adding `"deepgram"` (or any future
+ * mode) here flows to the tool schema + Inspector dropdown without a
+ * cross-file edit.
+ */
+export const PROSODY_MODE_VALUES = ["auto", "ielts", "general"] as const;
+
+export type ProsodyModeValue = (typeof PROSODY_MODE_VALUES)[number];
+
+/**
+ * Educator-facing labels keyed by canonical value. Centralised so the
+ * Inspector dropdown and the course-header ProsodyModePill agree on the
+ * human form. The "(auto)" suffix on the pill is rendered by the pill
+ * itself (it carries the resolved value + explicit/implicit nuance).
+ */
+export const PROSODY_MODE_LABELS: Record<ProsodyModeValue, string> = {
+  auto: "Auto (use tier preset)",
+  ielts: "IELTS (4 sub-bands)",
+  general: "General (pace + hesitation)",
+};
+
+/**
+ * #1871 — canonical field-name list for `GeneralSignals`. The PROSODY
+ * runner uses this to compute the `fieldsPopulated` / `fieldsMissing`
+ * arrays for the `voice.prosody.general_partial_signals` AppLog without
+ * hand-typing the field names at the emit site.
+ *
+ * Includes ONLY the four vendor-observable signals (paceWpm,
+ * hesitationRate, meanEnergyDb, pitchRangeHz). `confidenceProxy` is a
+ * derived scalar from IELTS fluency in today's general fallback and is
+ * tracked separately — it isn't an adapter-provided signal so it doesn't
+ * belong in the partial-fill telemetry.
+ */
+export const GENERAL_SIGNAL_FIELDS = [
+  "paceWpm",
+  "hesitationRate",
+  "meanEnergyDb",
+  "pitchRangeHz",
+] as const satisfies readonly (keyof GeneralSignals)[];
+
+export type GeneralSignalField = (typeof GENERAL_SIGNAL_FIELDS)[number];
+
+/**
+ * #1871 — sentinel for "vendor doesn't expose this signal in general mode".
+ * Distinguished from a real zero in code review: any read site that produces
+ * this value should comment why (vendor not asked / partial fill default /
+ * stub-fallback). The runner uses it for the legacy fallback when the
+ * adapter doesn't implement `getGeneralSignals`.
+ */
+export const STUB_SIGNAL_ZERO = 0 as const;

--- a/apps/admin/lib/speech-assessment/providers/speechace/index.ts
+++ b/apps/admin/lib/speech-assessment/providers/speechace/index.ts
@@ -23,6 +23,20 @@ import type {
   SpeechAssessmentAdapter,
   SpeechAssessmentCapabilities,
 } from "@/lib/speech-assessment/types";
+import type { GeneralSignals } from "@/lib/pipeline/prosody-types";
+
+/**
+ * #1871 — common English filler / hesitation tokens. Used by both the
+ * SpeechAce + SpeechSuper general-signal derivers. Kept here as a
+ * lower-case Set so callers can `.has(token.toLowerCase())` without
+ * re-allocating. The list is intentionally short — false positives ("so",
+ * "well") would dominate; only canonical fillers are tracked.
+ */
+const ENGLISH_FILLER_TOKENS: ReadonlySet<string> = new Set([
+  "um", "uh", "umm", "uhh", "uhm", "er", "erm",
+  "ah", "ahh", "hmm",
+  "like", "y'know", "yknow",
+]);
 
 const SPEECHACE_ENDPOINT = "https://api.speechace.co/api/scoring/speech/v9/json";
 
@@ -206,6 +220,67 @@ export class SpeechAceAdapter implements SpeechAssessmentAdapter {
       raw: body,
     };
   }
+
+  /**
+   * #1871 — derive general-mode prosody signals from SpeechAce's standard
+   * scoring response. SpeechAce v9 returns `word_score_list[]` with
+   * `start_time` + `end_time` (seconds) on each word + a `transcript`
+   * string. From these we can compute:
+   *
+   *   - `paceWpm` — words-per-minute over the scored window (utterance
+   *     start = first word's start_time; utterance end = last word's
+   *     end_time). Undefined when fewer than 2 words exist OR duration
+   *     is non-positive.
+   *   - `hesitationRate` — proportion of transcript tokens matching
+   *     `ENGLISH_FILLER_TOKENS`. Bounded to [0, 1]. Undefined when
+   *     transcript is empty.
+   *
+   * `meanEnergyDb` + `pitchRangeHz` are NOT supplied — SpeechAce's v9
+   * payload doesn't expose acoustic energy or pitch range. The runner's
+   * partial-fill merge cites them in the `fieldsMissing` AppLog.
+   *
+   * One vendor request — same endpoint as `scoreUploadedAudio` but with
+   * `include_ielts_feedback` omitted.
+   */
+  async getGeneralSignals(
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<Partial<GeneralSignals>> {
+    if (!this.apiKey) {
+      throw new Error(
+        "SpeechAceAdapter: apiKey is not configured. Set credentials.apiKey on the SpeechAssessmentProvider row.",
+      );
+    }
+    const url = new URL(SPEECHACE_ENDPOINT);
+    url.searchParams.set("key", this.apiKey);
+    url.searchParams.set("dialect", this.dialect);
+    if (this.userId) url.searchParams.set("user_id", this.userId);
+
+    const form = new FormData();
+    form.set(
+      "user_audio_file",
+      new Blob([new Uint8Array(buffer)], { type: mimeType }),
+      filenameForMimeType(mimeType),
+    );
+    if (this.pronunciationScoreMode) {
+      form.set("pronunciation_score_mode", this.pronunciationScoreMode);
+    }
+
+    const res = await fetch(url.toString(), { method: "POST", body: form });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `SpeechAceAdapter.getGeneralSignals: HTTP ${res.status}. Body: ${text.slice(0, 300)}`,
+      );
+    }
+    const body = (await res.json()) as SpeechAceResponse;
+    if (body.status && body.status !== "success") {
+      throw new Error(
+        `SpeechAceAdapter.getGeneralSignals: vendor returned status="${body.status}".`,
+      );
+    }
+    return deriveSignalsFromSpeechAceResponse(body);
+  }
 }
 
 /** Filename hint for the multipart upload. SpeechAce inspects the
@@ -219,4 +294,77 @@ function filenameForMimeType(mimeType: string): string {
   if (mimeType.includes("m4a") || mimeType.includes("aac"))
     return "audio.m4a";
   return "audio.wav";
+}
+
+interface SpeechAceWord {
+  word?: string;
+  start_time?: number;
+  end_time?: number;
+  start?: number;
+  end?: number;
+  startTime?: number;
+  endTime?: number;
+}
+
+/**
+ * Pure derivation — exported for direct unit-testing of the parser without
+ * a live vendor call. The runner consumes via `adapter.getGeneralSignals`.
+ */
+export function deriveSignalsFromSpeechAceResponse(
+  body: SpeechAceResponse,
+): Partial<GeneralSignals> {
+  const out: Partial<GeneralSignals> = {};
+
+  const words = Array.isArray(body.speech_score?.word_score_list)
+    ? (body.speech_score?.word_score_list as SpeechAceWord[])
+    : [];
+  const firstWordStart = firstNumericField(words[0], [
+    "start_time", "start", "startTime",
+  ]);
+  const lastWordEnd = firstNumericField(words[words.length - 1], [
+    "end_time", "end", "endTime",
+  ]);
+  if (
+    words.length >= 2 &&
+    typeof firstWordStart === "number" &&
+    typeof lastWordEnd === "number" &&
+    lastWordEnd > firstWordStart
+  ) {
+    const durationSec = lastWordEnd - firstWordStart;
+    const durationMin = durationSec / 60;
+    out.paceWpm = words.length / durationMin;
+  }
+
+  const transcript = body.speech_score?.transcript;
+  if (typeof transcript === "string" && transcript.trim().length > 0) {
+    out.hesitationRate = computeHesitationRate(transcript);
+  }
+  return out;
+}
+
+function firstNumericField(
+  obj: SpeechAceWord | undefined,
+  fields: readonly string[],
+): number | undefined {
+  if (!obj) return undefined;
+  for (const f of fields) {
+    const v = (obj as Record<string, unknown>)[f];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Filler-token ratio over the transcript. Tokenises on whitespace + strips
+ * trailing punctuation. Bounded to [0, 1].
+ */
+export function computeHesitationRate(transcript: string): number {
+  const tokens = transcript
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.replace(/[.,!?;:"]+$/g, "").replace(/^["']+/g, ""))
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return 0;
+  const fillers = tokens.filter((t) => ENGLISH_FILLER_TOKENS.has(t)).length;
+  return Math.min(1, fillers / tokens.length);
 }

--- a/apps/admin/lib/speech-assessment/providers/speechsuper/index.ts
+++ b/apps/admin/lib/speech-assessment/providers/speechsuper/index.ts
@@ -30,6 +30,7 @@ import type {
   SpeechAssessmentAdapter,
   SpeechAssessmentCapabilities,
 } from "@/lib/speech-assessment/types";
+import type { GeneralSignals } from "@/lib/pipeline/prosody-types";
 
 const SPEECHSUPER_BASE_URL = "https://api.speechsuper.com/";
 const CORE_TYPE_SPONTANEOUS_IELTS = "speak.eval.pro";
@@ -67,6 +68,19 @@ interface SpeechSuperResponse {
     vocabulary?: number;
     transcription?: string;
     words?: unknown;
+    /**
+     * #1871 — SpeechSuper Pro features. Vendor exposes these on the
+     * standard `speak.eval.pro` response. `speaking_rate` is wpm over
+     * the scored window; `pause_filler_frequency` is a rate-per-utterance
+     * proportion. Adapter doesn't surface them via `scoreUploadedAudio` —
+     * `getGeneralSignals` reads them off the same response for the
+     * general-mode prosody path.
+     */
+    speaking_rate?: number;
+    pause_filler_frequency?: number;
+    /** Tolerated alias seen in some sample payloads. */
+    speakingRate?: number;
+    pauseFillerFrequency?: number;
   };
 }
 
@@ -266,6 +280,93 @@ export class SpeechSuperAdapter implements SpeechAssessmentAdapter {
       raw: body,
     };
   }
+
+  /**
+   * #1871 — derive general-mode prosody signals from SpeechSuper's standard
+   * Pro response. Maps `speaking_rate` → `paceWpm` and
+   * `pause_filler_frequency` → `hesitationRate`. `meanEnergyDb` +
+   * `pitchRangeHz` are NOT supplied (vendor's Pro features expose
+   * cadence + filler signals, not acoustic energy or pitch range).
+   *
+   * Costs ONE vendor request. Same endpoint + same auth signatures as
+   * `scoreUploadedAudio`; request body omits `test_type: "ielts"` so
+   * the vendor returns the spontaneous-speech shape without IELTS scoring.
+   */
+  async getGeneralSignals(
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<Partial<GeneralSignals>> {
+    if (!this.appKey || !this.secretKey) {
+      throw new Error(
+        "SpeechSuperAdapter.getGeneralSignals: appKey and secretKey are not both configured.",
+      );
+    }
+    const coreType = CORE_TYPE_SPONTANEOUS_IELTS;
+    const url = `${SPEECHSUPER_BASE_URL}${coreType}`;
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const userId = this.defaultUserId;
+    const connectSig = crypto
+      .createHash("sha1")
+      .update(`${this.appKey}${timestamp}${this.secretKey}`)
+      .digest("hex");
+    const startSig = crypto
+      .createHash("sha1")
+      .update(`${this.appKey}${timestamp}${userId}${this.secretKey}`)
+      .digest("hex");
+    const audioType = audioTypeForMimeType(mimeType);
+    const params = {
+      connect: {
+        cmd: "connect",
+        param: {
+          sdk: { version: 16777472, source: 9, protocol: 2 },
+          app: { applicationId: this.appKey, sig: connectSig, timestamp },
+        },
+      },
+      start: {
+        cmd: "start",
+        param: {
+          app: {
+            userId,
+            applicationId: this.appKey,
+            timestamp,
+            sig: startSig,
+          },
+          audio: { audioType, channel: 1, sampleBytes: 2, sampleRate: 16000 },
+          request: {
+            coreType,
+            tokenId: "tokenId",
+            model: this.model,
+            penalize_offtopic: this.penalizeOfftopic ? 1 : 0,
+          },
+        },
+      },
+    };
+    const form = new FormData();
+    form.set("text", JSON.stringify(params));
+    form.set(
+      "audio",
+      new Blob([new Uint8Array(buffer)], { type: mimeType }),
+      `audio.${audioType}`,
+    );
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Request-Index": "0" },
+      body: form,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `SpeechSuperAdapter.getGeneralSignals: HTTP ${res.status}. Body: ${text.slice(0, 300)}`,
+      );
+    }
+    const body = (await res.json()) as SpeechSuperResponse;
+    if (body.errId !== undefined && body.errId !== 0) {
+      throw new Error(
+        `SpeechSuperAdapter.getGeneralSignals: errId=${body.errId} (${body.error ?? "unknown"})`,
+      );
+    }
+    return deriveSignalsFromSpeechSuperResponse(body);
+  }
 }
 
 function audioTypeForMimeType(mimeType: string): string {
@@ -274,4 +375,44 @@ function audioTypeForMimeType(mimeType: string): string {
   if (mimeType.includes("ogg")) return "ogg";
   if (mimeType.includes("webm")) return "webm";
   return "wav";
+}
+
+/**
+ * Pure derivation — exported for direct unit testing of the parser without
+ * a live vendor call. The runner consumes via `adapter.getGeneralSignals`.
+ *
+ * Reads both `snake_case` and `camelCase` aliases. Finite-number guard
+ * rejects null / NaN / Infinity. Bounds `hesitationRate` to [0, 1] in
+ * case the vendor returns a percent-like form.
+ */
+export function deriveSignalsFromSpeechSuperResponse(
+  body: SpeechSuperResponse,
+): Partial<GeneralSignals> {
+  const out: Partial<GeneralSignals> = {};
+  const result = body.result;
+  if (!result) return out;
+
+  const rate = firstFiniteField(result, ["speaking_rate", "speakingRate"]);
+  if (rate !== undefined) out.paceWpm = rate;
+
+  const filler = firstFiniteField(result, [
+    "pause_filler_frequency",
+    "pauseFillerFrequency",
+  ]);
+  if (filler !== undefined) {
+    const normalised = filler > 1 ? Math.min(1, filler / 100) : Math.max(0, filler);
+    out.hesitationRate = normalised;
+  }
+  return out;
+}
+
+function firstFiniteField(
+  obj: Record<string, unknown>,
+  fields: readonly string[],
+): number | undefined {
+  for (const f of fields) {
+    const v = obj[f];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return undefined;
 }

--- a/apps/admin/lib/speech-assessment/types.ts
+++ b/apps/admin/lib/speech-assessment/types.ts
@@ -14,6 +14,7 @@
  */
 
 import type { ProviderConfigSchema } from "@/lib/voice/types";
+import type { GeneralSignals } from "@/lib/pipeline/prosody-types";
 
 export interface SpeechAssessmentCapabilities {
   /** Vendor returns IELTS band scores (0.0–9.0). */
@@ -87,6 +88,37 @@ export interface SpeechAssessmentAdapter {
     mimeType: string,
     mode: ScoringMode,
   ): Promise<NormalisedScoreResult>;
+
+  /**
+   * #1871 — optional general-mode prosody signal extractor. When implemented,
+   * the PROSODY runner's `general` branch consumes this instead of falling
+   * back to stub-zero `GeneralSignals`. Returns a `Partial<GeneralSignals>`
+   * because no known vendor exposes the full four-field set today:
+   *
+   *   - SpeechAce v9 — derives `paceWpm` from word-timing + `hesitationRate`
+   *     from filler tokens in the transcript. Leaves `meanEnergyDb` +
+   *     `pitchRangeHz` undefined (not exposed).
+   *   - SpeechSuper — maps `speaking_rate` → `paceWpm` and
+   *     `pause filler frequency` → `hesitationRate`. Leaves energy + pitch
+   *     undefined.
+   *
+   * The runner merges the partial onto a stub-zero baseline so downstream
+   * AGGREGATE consumers can still read every field unconditionally; the
+   * partial-fill telemetry (`voice.prosody.general_partial_signals`) cites
+   * exactly which fields the adapter populated vs. which fell back.
+   *
+   * Optional on the interface so adapters without support don't fail-fast.
+   * The runner detects implementation with a `typeof` guard at the call
+   * site (see `lib/pipeline/prosody-runner.ts::runWholeCallProsody`).
+   *
+   * Returns `{}` (empty partial) when the adapter has no data to extract
+   * (e.g. SpeechAce response missing word-timings). The runner treats this
+   * as full-fallback to the stub-zero baseline — never crashes.
+   */
+  getGeneralSignals?(
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<Partial<GeneralSignals>>;
 }
 
 export interface SpeechAssessmentAdapterConstructor {

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -94,7 +94,8 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G1.length).toBe(7);
     expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(10);
     expect(JOURNEY_SETTINGS_BY_GROUP.G3.length).toBe(4);
-    expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(27);
+    // #1871 — voiceProsodyMode added (I_scoring / G4). 27 -> 28.
+    expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(28);
     // midJourneyStopTrigger removed in fix/journey-stops-structured-paths
     // (storagePath was unrepresentable in the applier — trigger is now
     // edited only via the midJourneyStop compound editor). G5 6 → 5.
@@ -107,9 +108,9 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G8.length).toBe(8);
   });
 
-  it("(8) JOURNEY_SETTINGS.length === 85", () => {
-    // 84 (post midJourneyStopTrigger removal) + 1 (moduleScaffoldPool #1743)
-    expect(JOURNEY_SETTINGS.length).toBe(85);
+  it("(8) JOURNEY_SETTINGS.length === 86", () => {
+    // 84 (post midJourneyStopTrigger removal) + 1 (moduleScaffoldPool #1743) + 1 (voiceProsodyMode #1871)
+    expect(JOURNEY_SETTINGS.length).toBe(86);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {

--- a/apps/admin/tests/lib/journey/registry-options-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-options-coverage.test.ts
@@ -47,6 +47,7 @@ import {
 } from "@/lib/journey/setting-contracts.entries";
 import { VOICE_SETTINGS } from "@/lib/settings/voice-setting-contracts";
 import { TIER_PRESETS } from "@/lib/banding/presets";
+import { PROSODY_MODE_VALUES } from "@/lib/pipeline/prosody-types";
 
 /** Marker for options that derive from a canonical source. The test
  *  verifies the derived array matches the canonical's current keys. */
@@ -117,6 +118,11 @@ const EXPECTED_OPTION_VALUES: Record<string, OptionPin> = {
     canonical:
       "lib/banding/presets.ts::TIER_PRESETS (Object.keys); contract derives both values and labels",
   },
+  voiceProsodyMode: {
+    values: DERIVED,
+    canonical:
+      "lib/pipeline/prosody-types.ts::PROSODY_MODE_VALUES (single source of truth shared with the update_voice_config admin tool enum)",
+  },
   maxMasteryTier: {
     values: ["FOUNDATION", "DEVELOPING", "PRACTITIONER", "DISTINCTION"],
     canonical: "lib/types/json-fields.ts::PlaybookConfig.maxMasteryTier",
@@ -179,6 +185,9 @@ function resolveExpected(id: string): readonly string[] | null {
     // Derive from canonical sources by id.
     if (id === "tierPresetId") {
       return Object.keys(TIER_PRESETS);
+    }
+    if (id === "voiceProsodyMode") {
+      return [...PROSODY_MODE_VALUES];
     }
     return null;
   }

--- a/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
@@ -96,6 +96,7 @@ const APPLIES_TO_ALL: readonly string[] = [
   "toleranceConfidence",
   "toleranceEngagement",
   "tierPresetId",
+  "voiceProsodyMode",
   "skillMinCallsToFull",
   "skillTierMapping",
   "skillScoringEmaHalfLife",

--- a/apps/admin/tests/lib/journey/setting-contracts-prosody-mode.test.ts
+++ b/apps/admin/tests/lib/journey/setting-contracts-prosody-mode.test.ts
@@ -1,0 +1,87 @@
+/**
+ * JourneySettingContract — voice.prosodyMode (#1871).
+ *
+ * Pins the new Track-B Inspector chip contract:
+ *   - id = "voiceProsodyMode" registered in JOURNEY_SETTINGS
+ *   - bucket I_scoring + group G4 (matches sibling G4_TIER_PRESET_ID)
+ *   - storagePath = "config.voice.prosodyMode" (single string form)
+ *   - control = "select"
+ *   - options derived from PROSODY_MODE_VALUES + PROSODY_MODE_LABELS
+ *     (single source of truth — no hand-typed enum array)
+ *   - composeImpact sections = moduleMastery + loMastery (mirrors
+ *     tierPresetId — both knobs change AGGREGATE's mastery writes)
+ *   - cascadeSources = [] (course-only override; Domain-level prosody
+ *     swap is intentionally not surfaced)
+ *   - previewLocators cite the course-header ProsodyModePill
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
+import {
+  PROSODY_MODE_VALUES,
+  PROSODY_MODE_LABELS,
+} from "@/lib/pipeline/prosody-types";
+
+describe("voice.prosodyMode JourneySettingContract — #1871", () => {
+  const contract = JOURNEY_SETTINGS.find((c) => c.id === "voiceProsodyMode");
+
+  it("is registered in JOURNEY_SETTINGS", () => {
+    expect(contract).toBeDefined();
+  });
+
+  it("bucketed under I_scoring + group G4 (matches sibling tierPresetId)", () => {
+    expect(contract!.menuGroupKey).toBe("I_scoring");
+    expect(contract!.group).toBe("G4");
+  });
+
+  it("storagePath is config.voice.prosodyMode (string form, no array hop)", () => {
+    expect(contract!.storagePath).toBe("config.voice.prosodyMode");
+  });
+
+  it("uses select control", () => {
+    expect(contract!.control).toBe("select");
+  });
+
+  it("options derived from PROSODY_MODE_VALUES (single source of truth)", () => {
+    const optionValues = contract!.options!.map((o) => o.value);
+    expect(optionValues).toEqual([...PROSODY_MODE_VALUES]);
+  });
+
+  it("option labels derived from PROSODY_MODE_LABELS (no drift)", () => {
+    for (const opt of contract!.options!) {
+      expect(opt.label).toBe(
+        PROSODY_MODE_LABELS[opt.value as keyof typeof PROSODY_MODE_LABELS],
+      );
+    }
+  });
+
+  it("composeImpact sections match tierPresetId precedent (moduleMastery + loMastery)", () => {
+    expect(contract!.composeImpact.sections).toEqual(["moduleMastery", "loMastery"]);
+    expect(contract!.composeImpact.kinds).toEqual(["scoring-weight"]);
+    expect(contract!.composeImpact.requiresReprompt).toBe(false);
+  });
+
+  it("cascadeSources empty (course-only override; Domain-level swap is intentionally hidden)", () => {
+    expect(contract!.cascadeSources).toEqual([]);
+  });
+
+  it("previewLocators reference the course-header ProsodyModePill section", () => {
+    expect(contract!.previewLocators.length).toBeGreaterThan(0);
+    expect(contract!.previewLocators[0].section).toBe("moduleMastery");
+  });
+
+  it("uses the same value set as the admin-tool prosodyMode enum", async () => {
+    const adminTools = await import("@/lib/chat/admin-tools");
+    const tool = adminTools.ADMIN_TOOLS.find((t) => t.name === "update_voice_config");
+    expect(tool).toBeDefined();
+    const props = (tool!.input_schema as unknown as {
+      properties: {
+        settings: {
+          properties: { prosodyMode: { enum: readonly string[] } };
+        };
+      };
+    }).properties.settings.properties.prosodyMode;
+    expect(props.enum).toEqual([...PROSODY_MODE_VALUES]);
+  });
+});

--- a/apps/admin/tests/lib/pipeline/prosody-runner-general-signals.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-runner-general-signals.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Prosody runner — general-mode getGeneralSignals wiring (#1871).
+ *
+ * Pins:
+ *   1. When the adapter implements `getGeneralSignals` AND mode resolves
+ *      to "general", the runner calls it instead of `scoreUploadedAudio`.
+ *   2. The returned partial is merged onto a STUB_SIGNAL_ZERO baseline →
+ *      every GeneralSignals field is populated on the envelope.
+ *   3. AppLog `voice.prosody.general_partial_signals` fires with the
+ *      populated / missing field-name lists derived from the canonical
+ *      `GENERAL_SIGNAL_FIELDS` constant.
+ *   4. When the adapter does NOT implement `getGeneralSignals`, the runner
+ *      falls back to the legacy `scoreUploadedAudio` + stub-zero path AND
+ *      fires `voice.prosody.general_unsupported`.
+ *   5. IELTS mode is unaffected — still routes through `scoreUploadedAudio`.
+ *   6. Partial fill (only paceWpm) → envelope has real paceWpm + STUB
+ *      zeros for the rest; AppLog lists the missing fields.
+ *   7. voice.prosodyMode explicit override beats tierPresetId.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCallFindUnique = vi.fn();
+const mockCallUpdate = vi.fn();
+const mockPlaybookFindUnique = vi.fn();
+const mockLog = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    call: { findUnique: mockCallFindUnique, update: mockCallUpdate },
+    playbook: { findUnique: mockPlaybookFindUnique },
+  },
+}));
+
+vi.mock("@/lib/voice/system-settings", () => ({
+  getVoiceSystemSettings: vi.fn().mockResolvedValue({
+    vendorTimeoutMs: 30000,
+    fallbackOnAdapterError: "throw",
+    maxCostPerCallUsd: null,
+    auditRetentionDays: 90,
+    defaultProviderSlug: "",
+    silenceTimeoutSeconds: 90,
+    maxDurationSeconds: 600,
+    voicemailDetectionEnabled: false,
+    endCallPhrases: [],
+    maxSegmentsPerCall: 5,
+  }),
+}));
+
+const mockResolveProvider = vi.fn();
+const mockGetProvider = vi.fn();
+
+vi.mock("@/lib/voice/resolve-speech-assessment-provider", () => ({
+  resolveSpeechAssessmentProviderForCall: (...args: unknown[]) =>
+    mockResolveProvider(...args),
+}));
+
+vi.mock("@/lib/speech-assessment/provider-factory", () => ({
+  getSpeechAssessmentProvider: (...args: unknown[]) => mockGetProvider(...args),
+}));
+
+vi.mock("@/lib/voice/telemetry", () => ({
+  logVoiceEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/pipeline/adaptive-loop-invariants", () => ({
+  recordIAL4ProsodySkip: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: (...args: unknown[]) => mockLog(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCallUpdate.mockResolvedValue({});
+});
+
+const callRow = (overrides: { playbookId?: string | null } = {}) => {
+  mockCallFindUnique.mockResolvedValue({
+    id: "c1",
+    stereoRecordingUrl: "https://recordings.example/abc.wav",
+    playbookId: overrides.playbookId ?? "pb-general",
+    voiceProsody: null,
+    session: null,
+  });
+};
+
+const stubFetch = () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    headers: { get: () => "audio/wav" },
+  }) as unknown as typeof fetch;
+};
+
+const playbookGeneral = () => {
+  mockPlaybookFindUnique.mockResolvedValue({ config: {} });
+};
+
+const playbookIelts = () => {
+  mockPlaybookFindUnique.mockResolvedValue({ config: { tierPresetId: "ielts-speaking" } });
+};
+
+describe("runProsodyStage — getGeneralSignals wiring (#1871)", () => {
+  it("calls adapter.getGeneralSignals when implemented + mode is general", async () => {
+    callRow();
+    playbookGeneral();
+    stubFetch();
+
+    const getGeneralSignals = vi.fn().mockResolvedValue({
+      paceWpm: 140,
+      hesitationRate: 0.08,
+    });
+    const scoreUploadedAudio = vi.fn();
+
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio,
+      getGeneralSignals,
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(getGeneralSignals).toHaveBeenCalledTimes(1);
+    expect(scoreUploadedAudio).not.toHaveBeenCalled();
+    expect(result.envelope.mode).toBe("general");
+    if (result.envelope.mode === "general") {
+      expect(result.envelope.generalSignals?.paceWpm).toBe(140);
+      expect(result.envelope.generalSignals?.hesitationRate).toBeCloseTo(0.08, 5);
+      expect(result.envelope.generalSignals?.meanEnergyDb).toBe(0);
+      expect(result.envelope.generalSignals?.pitchRangeHz).toBe(0);
+      expect(result.envelope.generalSignals?.confidenceProxy).toBe(0);
+    }
+  });
+
+  it("AppLog general_partial_signals carries populated + missing field lists", async () => {
+    callRow();
+    playbookGeneral();
+    stubFetch();
+
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio: vi.fn(),
+      getGeneralSignals: vi.fn().mockResolvedValue({
+        paceWpm: 140,
+        hesitationRate: 0.08,
+      }),
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    const partialCall = mockLog.mock.calls.find(
+      (args) => args[1] === "voice.prosody.general_partial_signals",
+    );
+    expect(partialCall).toBeDefined();
+    const metadata = partialCall![2] as {
+      callId: string;
+      adapterKey: string;
+      fieldsPopulated: readonly string[];
+      fieldsMissing: readonly string[];
+    };
+    expect(metadata.callId).toBe("c1");
+    expect(metadata.adapterKey).toBe("speechace");
+    expect(metadata.fieldsPopulated).toContain("paceWpm");
+    expect(metadata.fieldsPopulated).toContain("hesitationRate");
+    expect(metadata.fieldsMissing).toContain("meanEnergyDb");
+    expect(metadata.fieldsMissing).toContain("pitchRangeHz");
+  });
+
+  it("falls back to scoreUploadedAudio when adapter has no getGeneralSignals + fires general_unsupported", async () => {
+    callRow();
+    playbookGeneral();
+    stubFetch();
+
+    const scoreUploadedAudio = vi
+      .fn()
+      .mockResolvedValue({ ielts: { overall: 6.0, pronunciation: 6.5, fluency: 6.0 }, raw: {} });
+
+    mockResolveProvider.mockResolvedValue({ slug: "legacy-vendor", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "legacy-vendor",
+      scoreUploadedAudio,
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(scoreUploadedAudio).toHaveBeenCalledTimes(1);
+    expect(result.envelope.mode).toBe("general");
+    if (result.envelope.mode === "general") {
+      expect(result.envelope.generalSignals?.paceWpm).toBe(0);
+      expect(result.envelope.generalSignals?.hesitationRate).toBe(0);
+      expect(result.envelope.generalSignals?.confidenceProxy).toBeCloseTo(6 / 9, 2);
+    }
+
+    const unsupportedCall = mockLog.mock.calls.find(
+      (args) => args[1] === "voice.prosody.general_unsupported",
+    );
+    expect(unsupportedCall).toBeDefined();
+    expect((unsupportedCall![2] as { adapterKey: string }).adapterKey).toBe("legacy-vendor");
+
+    const partialCall = mockLog.mock.calls.find(
+      (args) => args[1] === "voice.prosody.general_partial_signals",
+    );
+    expect(partialCall).toBeUndefined();
+  });
+
+  it("IELTS mode is unaffected — routes through scoreUploadedAudio even when getGeneralSignals exists", async () => {
+    callRow();
+    playbookIelts();
+    stubFetch();
+
+    const getGeneralSignals = vi.fn();
+    const scoreUploadedAudio = vi.fn().mockResolvedValue({
+      ielts: { overall: 7.0, pronunciation: 7.5, fluency: 6.5, grammar: 7.0, vocabulary: 7.0 },
+      raw: {},
+    });
+
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio,
+      getGeneralSignals,
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(getGeneralSignals).not.toHaveBeenCalled();
+    expect(scoreUploadedAudio).toHaveBeenCalledTimes(1);
+    expect(result.envelope.mode).toBe("ielts");
+  });
+
+  it("partial fill (only paceWpm) → envelope has real paceWpm + STUB zeros + AppLog lists 3 missing", async () => {
+    callRow();
+    playbookGeneral();
+    stubFetch();
+
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio: vi.fn(),
+      getGeneralSignals: vi.fn().mockResolvedValue({ paceWpm: 120 }),
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(result.envelope.mode).toBe("general");
+    if (result.envelope.mode === "general") {
+      expect(result.envelope.generalSignals?.paceWpm).toBe(120);
+      expect(result.envelope.generalSignals?.hesitationRate).toBe(0);
+      expect(result.envelope.generalSignals?.meanEnergyDb).toBe(0);
+      expect(result.envelope.generalSignals?.pitchRangeHz).toBe(0);
+    }
+
+    const partialCall = mockLog.mock.calls.find(
+      (args) => args[1] === "voice.prosody.general_partial_signals",
+    );
+    const meta = partialCall![2] as {
+      fieldsPopulated: readonly string[];
+      fieldsMissing: readonly string[];
+    };
+    expect(meta.fieldsPopulated).toEqual(["paceWpm"]);
+    expect(meta.fieldsMissing).toEqual([
+      "hesitationRate",
+      "meanEnergyDb",
+      "pitchRangeHz",
+    ]);
+  });
+
+  it("respects voice.prosodyMode='general' explicit override (beats tierPresetId='ielts-speaking')", async () => {
+    callRow();
+    mockPlaybookFindUnique.mockResolvedValue({
+      config: {
+        tierPresetId: "ielts-speaking",
+        voice: { prosodyMode: "general" },
+      },
+    });
+    stubFetch();
+
+    const getGeneralSignals = vi.fn().mockResolvedValue({ paceWpm: 140 });
+    const scoreUploadedAudio = vi.fn();
+
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio,
+      getGeneralSignals,
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(getGeneralSignals).toHaveBeenCalledTimes(1);
+    expect(scoreUploadedAudio).not.toHaveBeenCalled();
+    expect(result.envelope.mode).toBe("general");
+  });
+
+  it("respects voice.prosodyMode='ielts' explicit override (beats tierPresetId absent)", async () => {
+    callRow();
+    mockPlaybookFindUnique.mockResolvedValue({
+      config: { voice: { prosodyMode: "ielts" } },
+    });
+    stubFetch();
+
+    const getGeneralSignals = vi.fn();
+    const scoreUploadedAudio = vi.fn().mockResolvedValue({
+      ielts: { overall: 7.0, pronunciation: 7.0, fluency: 7.0 },
+      raw: {},
+    });
+
+    mockResolveProvider.mockResolvedValue({ slug: "speechace", isFallback: false });
+    mockGetProvider.mockResolvedValue({
+      slug: "speechace",
+      scoreUploadedAudio,
+      getGeneralSignals,
+    });
+
+    const { runProsodyStage } = await import("@/lib/pipeline/prosody-runner");
+    const result = await runProsodyStage({ callId: "c1", callerId: "caller-a" });
+
+    expect(getGeneralSignals).not.toHaveBeenCalled();
+    expect(scoreUploadedAudio).toHaveBeenCalledTimes(1);
+    expect(result.envelope.mode).toBe("ielts");
+  });
+});

--- a/apps/admin/tests/lib/speech-assessment/providers/speechace/general-signals.test.ts
+++ b/apps/admin/tests/lib/speech-assessment/providers/speechace/general-signals.test.ts
@@ -1,0 +1,139 @@
+/**
+ * SpeechAce general-signal derivation tests (#1871).
+ *
+ * Covers:
+ *   - Word-timing → paceWpm correctness (≥2 words required)
+ *   - Transcript filler-token count → hesitationRate (bounded [0, 1])
+ *   - Response missing word-timings → empty partial (no crash)
+ *   - Response missing transcript → no hesitationRate populated
+ *   - Single-word response → no paceWpm populated (need ≥2 to span a duration)
+ *   - meanEnergyDb + pitchRangeHz never populated (vendor doesn't expose)
+ *
+ * Live adapter HTTP path tested separately — these tests exercise the pure
+ * derivation so they don't need a fetch mock.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveSignalsFromSpeechAceResponse,
+  computeHesitationRate,
+} from "@/lib/speech-assessment/providers/speechace";
+
+describe("deriveSignalsFromSpeechAceResponse — #1871", () => {
+  it("derives paceWpm from word-timing across ≥2 words", () => {
+    const out = deriveSignalsFromSpeechAceResponse({
+      speech_score: {
+        word_score_list: [
+          { word: "I", start_time: 0.0, end_time: 0.1 },
+          { word: "want", start_time: 0.1, end_time: 0.3 },
+          { word: "to", start_time: 0.3, end_time: 0.4 },
+          { word: "speak", start_time: 0.4, end_time: 1.0 },
+          { word: "now", start_time: 1.0, end_time: 2.0 },
+        ],
+        transcript: "I want to speak now",
+      },
+    });
+    expect(out.paceWpm).toBeCloseTo(150, 1);
+  });
+
+  it("derives hesitationRate from filler tokens in transcript", () => {
+    const out = deriveSignalsFromSpeechAceResponse({
+      speech_score: {
+        word_score_list: [
+          { word: "um", start_time: 0.0, end_time: 0.3 },
+          { word: "I", start_time: 0.3, end_time: 0.4 },
+          { word: "think", start_time: 0.4, end_time: 0.6 },
+          { word: "uh", start_time: 0.6, end_time: 0.9 },
+        ],
+        transcript: "um I think uh",
+      },
+    });
+    expect(out.hesitationRate).toBeCloseTo(0.5, 5);
+  });
+
+  it("returns empty partial when response has no word-timings AND no transcript", () => {
+    const out = deriveSignalsFromSpeechAceResponse({ speech_score: {} });
+    expect(out.paceWpm).toBeUndefined();
+    expect(out.hesitationRate).toBeUndefined();
+  });
+
+  it("returns empty partial when speech_score is absent", () => {
+    const out = deriveSignalsFromSpeechAceResponse({});
+    expect(out).toEqual({});
+  });
+
+  it("single-word response → no paceWpm (needs ≥2 to span a duration)", () => {
+    const out = deriveSignalsFromSpeechAceResponse({
+      speech_score: {
+        word_score_list: [{ word: "yes", start_time: 0.0, end_time: 0.4 }],
+        transcript: "yes",
+      },
+    });
+    expect(out.paceWpm).toBeUndefined();
+    expect(out.hesitationRate).toBe(0);
+  });
+
+  it("never populates meanEnergyDb or pitchRangeHz (vendor doesn't expose)", () => {
+    const out = deriveSignalsFromSpeechAceResponse({
+      speech_score: {
+        word_score_list: [
+          { word: "I", start_time: 0.0, end_time: 0.1 },
+          { word: "speak", start_time: 0.1, end_time: 0.6 },
+        ],
+        transcript: "I speak",
+      },
+    });
+    expect(out.meanEnergyDb).toBeUndefined();
+    expect(out.pitchRangeHz).toBeUndefined();
+  });
+
+  it("tolerates alternate field-name aliases (start/end vs start_time/end_time)", () => {
+    const out = deriveSignalsFromSpeechAceResponse({
+      speech_score: {
+        word_score_list: [
+          { word: "I", start: 0.0, end: 0.1 },
+          { word: "speak", start: 0.1, end: 1.0 } as never,
+        ],
+        transcript: "I speak",
+      },
+    });
+    expect(out.paceWpm).toBeCloseTo(120, 1);
+  });
+
+  it("non-positive duration → no paceWpm (defensive against vendor timing bugs)", () => {
+    const out = deriveSignalsFromSpeechAceResponse({
+      speech_score: {
+        word_score_list: [
+          { word: "I", start_time: 0.0, end_time: 0.1 },
+          { word: "speak", start_time: 0.0, end_time: 0.0 },
+        ],
+        transcript: "I speak",
+      },
+    });
+    expect(out.paceWpm).toBeUndefined();
+  });
+});
+
+describe("computeHesitationRate — #1871", () => {
+  it("returns 0 for an empty transcript", () => {
+    expect(computeHesitationRate("")).toBe(0);
+    expect(computeHesitationRate("   ")).toBe(0);
+  });
+
+  it("returns 0 when no filler tokens are present", () => {
+    expect(computeHesitationRate("hello world")).toBe(0);
+  });
+
+  it("strips punctuation when tokenising", () => {
+    expect(computeHesitationRate("um, I think, uh.")).toBeCloseTo(0.5, 5);
+  });
+
+  it("is case-insensitive", () => {
+    expect(computeHesitationRate("UM Hello UH")).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("bounded to [0, 1]", () => {
+    expect(computeHesitationRate("um uh er ah")).toBe(1);
+  });
+});

--- a/apps/admin/tests/lib/speech-assessment/providers/speechsuper/general-signals.test.ts
+++ b/apps/admin/tests/lib/speech-assessment/providers/speechsuper/general-signals.test.ts
@@ -1,0 +1,83 @@
+/**
+ * SpeechSuper general-signal derivation tests (#1871).
+ *
+ * Covers:
+ *   - `speaking_rate` → `paceWpm` direct mapping
+ *   - `pause_filler_frequency` → `hesitationRate` mapping (ratio form)
+ *   - Percent form (>1) normalises to [0, 1]
+ *   - camelCase aliases (`speakingRate`, `pauseFillerFrequency`) accepted
+ *   - Missing Pro features → empty partial (no crash)
+ *   - meanEnergyDb + pitchRangeHz never populated
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { deriveSignalsFromSpeechSuperResponse } from "@/lib/speech-assessment/providers/speechsuper";
+
+describe("deriveSignalsFromSpeechSuperResponse — #1871", () => {
+  it("maps speaking_rate → paceWpm directly", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: { speaking_rate: 145 },
+    });
+    expect(out.paceWpm).toBe(145);
+  });
+
+  it("maps pause_filler_frequency → hesitationRate as a ratio", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: { pause_filler_frequency: 0.12 },
+    });
+    expect(out.hesitationRate).toBeCloseTo(0.12, 5);
+  });
+
+  it("treats pause_filler_frequency > 1 as a percent and normalises to ratio", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: { pause_filler_frequency: 25 },
+    });
+    expect(out.hesitationRate).toBeCloseTo(0.25, 5);
+  });
+
+  it("clamps pause_filler_frequency to [0, 1]", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: { pause_filler_frequency: -0.5 },
+    });
+    expect(out.hesitationRate).toBe(0);
+  });
+
+  it("accepts camelCase aliases (speakingRate / pauseFillerFrequency)", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: {
+        speakingRate: 130,
+        pauseFillerFrequency: 0.08,
+      } as never,
+    });
+    expect(out.paceWpm).toBe(130);
+    expect(out.hesitationRate).toBeCloseTo(0.08, 5);
+  });
+
+  it("returns empty partial when result block is absent", () => {
+    expect(deriveSignalsFromSpeechSuperResponse({})).toEqual({});
+  });
+
+  it("returns empty partial when Pro features are missing", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: { overall: 6.5, pronunciation: 7.0 },
+    });
+    expect(out).toEqual({});
+  });
+
+  it("never populates meanEnergyDb or pitchRangeHz", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: { speaking_rate: 130, pause_filler_frequency: 0.1 },
+    });
+    expect(out.meanEnergyDb).toBeUndefined();
+    expect(out.pitchRangeHz).toBeUndefined();
+  });
+
+  it("ignores NaN / Infinity values", () => {
+    const out = deriveSignalsFromSpeechSuperResponse({
+      result: { speaking_rate: NaN as number, pause_filler_frequency: Infinity as number },
+    });
+    expect(out.paceWpm).toBeUndefined();
+    expect(out.hesitationRate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1871. Two-track scope shipped in one PR:

**Track A — General signals.** Extends `SpeechAssessmentAdapter` with an optional `getGeneralSignals(buffer, mimeType)` method. SpeechAce derives `paceWpm` from word-timings + `hesitationRate` from filler tokens. SpeechSuper maps `speaking_rate` / `pause_filler_frequency` from its Pro features. `prosody-runner.runWholeCallProsody` general branch calls the new method when implemented; falls back to legacy stub-zero path otherwise. AppLog `voice.prosody.general_partial_signals` cites populated + missing field lists; `voice.prosody.general_unsupported` fires once per call on legacy adapters.

**Track B — Inspector chip.** Registers `voiceProsodyMode` JourneySettingContract under `I_scoring`/`G4` (sibling to `tierPresetId`). `storagePath: "config.voice.prosodyMode"`, `control: "select"`, `composeImpact.sections: ["moduleMastery", "loMastery"]`. Option list derived from `PROSODY_MODE_VALUES` in `lib/pipeline/prosody-types.ts` — single source of truth shared with the `update_voice_config` admin tool enum + the runtime `resolveProsodyMode` precedence.

**No hardcoding.** `PROSODY_MODE_VALUES` + `PROSODY_MODE_LABELS` + `GENERAL_SIGNAL_FIELDS` + `STUB_SIGNAL_ZERO` centralised in `lib/pipeline/prosody-types.ts`. Three downstream consumers (Inspector contract, admin tool, runtime) import from the same source.

## Lattice survey (per .claude/rules/lattice-survey.md)

- **Sibling-writer scan** for `voice.prosodyMode` [verified]: `update_voice_config` already writes via shallow merge into `config.voice`; new Inspector PATCH route uses the same storage-path applier (merge semantics — see `lib/journey/storage-path-applier.ts`). No clobber.
- **Cascade respect** [verified]: `voiceProsodyMode` is NOT in `lib/cascade/effective-value.ts::FAMILIES` (intentional — Domain-level prosody-mode swap would silently re-rubric every course in the domain). Snapshot read is correct per `.claude/rules/cascade-reuse.md`.
- **Convention check** [verified]: lowercase `"auto"/"ielts"/"general"` matches `resolveProsodyMode` precedence + ProsodyModePill display.
- **Registry-schema-coverage (5th Lattice pillar)** [verified]: `voiceProsodyMode` added to `APPLIES_TO_ALL` in `registry-schema-coverage.test.ts`. New `EXPECTED_OPTION_VALUES` row in `registry-options-coverage.test.ts` with DERIVED marker pointing at `PROSODY_MODE_VALUES`.

## Canonical source

Option list derived from `PROSODY_MODE_VALUES` in `apps/admin/lib/pipeline/prosody-types.ts`, used by:
- `apps/admin/lib/journey/setting-contracts.entries.ts::G4_VOICE_PROSODY_MODE` (Inspector contract options)
- `apps/admin/lib/chat/admin-tools.ts::update_voice_config.input_schema.settings.properties.prosodyMode.enum` (admin tool schema)
- `apps/admin/lib/pipeline/prosody-runner.ts::resolveProsodyMode` (runtime precedence — explicit `"ielts"` / `"general"` win; `"auto"` falls through to tier-preset heuristic)

No duplication. `GENERAL_SIGNAL_FIELDS` in the same file is the single source for the runner's `fieldsPopulated`/`fieldsMissing` AppLog derivation.

## Verified by

- `lib/pipeline/prosody-runner.ts::normaliseVendorResult` general-mode legacy fallback path — the original hardcoded-zeros general branch the issue cites is now wrapped under the legacy fallback path with `STUB_SIGNAL_ZERO` sentinel [verified]
- `lib/journey/setting-contracts.entries.ts::G4_TIER_PRESET_ID` — sibling used as structural precedent for the new `G4_VOICE_PROSODY_MODE` entry [verified]
- `lib/cascade/effective-value.ts` FAMILIES list — `voiceProsodyMode` not present; decision documented in the contract header comment [verified]
- `lib/chat/admin-tools.ts::update_voice_config` enum now reads `PROSODY_MODE_VALUES` [verified]
- 39 new vitests across 4 files (13 speechace + 9 speechsuper + 7 prosody-runner + 10 setting-contracts)
- Regression: 479/479 across `tests/lib/speech-assessment` + `tests/lib/pipeline` + `tests/lib/journey` (was 440/440 pre-change, +39 new)
- tsc: 40 errors (baseline 41 pre-change, -1 due to tighter typing on the new constants)
- ESLint clean on all touched files

## Test plan

- [ ] On hf-dev, navigate to a course's Scoring tab Inspector. Confirm `voiceProsodyMode` dropdown appears with three options (Auto / IELTS / General). Set to "IELTS" — confirm `Playbook.config.voice.prosodyMode = "ielts"`. Confirm the course-header ProsodyModePill flips to "IELTS" (without the "(auto)" suffix).
- [ ] Verify the AppLog dump sites fire: trigger a sim call on a SpeechAce-backed course (general mode). Confirm `voice.prosody.general_partial_signals` appears with `fieldsPopulated: ["paceWpm", "hesitationRate"]` + `fieldsMissing: ["meanEnergyDb", "pitchRangeHz"]`.
- [ ] Verify legacy fallback: simulate an adapter without `getGeneralSignals` (or use the test-harness mock). Confirm `voice.prosody.general_unsupported` fires once per call.

## Deploy command

`/vm-cp` (code-only — no migration; the contract is a code-only registry entry; signal shape changes live on the existing `Call.voiceProsody Json?` column).