### PR TITLE
chore(prisma): PlaybookCurriculumRole enum adoption — replace 47 bare role literals

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/attainment/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/attainment/route.ts
@@ -46,6 +46,7 @@ import {
   type TalkTimeEvaluation,
 } from "@/lib/voice/talk-time-stats";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export interface AttainmentSkillBand {
   skillRef: string;
@@ -381,7 +382,7 @@ export async function GET(
             curriculum: {
               select: {
                 playbookLinks: {
-                  where: { playbookId, role: "primary" },
+                  where: { playbookId, role: PlaybookCurriculumRole.primary },
                   select: { playbookId: true },
                 },
               },

--- a/apps/admin/app/api/callers/[callerId]/exam-mode-check/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/exam-mode-check/route.ts
@@ -24,6 +24,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export async function GET(
   req: NextRequest,
@@ -53,7 +54,7 @@ export async function GET(
         playbook: {
           select: {
             playbookCurricula: {
-              where: { role: "primary" },
+              where: { role: PlaybookCurriculumRole.primary },
               select: { curriculumId: true },
             },
           },

--- a/apps/admin/app/api/callers/[callerId]/lo-mastery/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/lo-mastery/route.ts
@@ -43,6 +43,7 @@ import {
 import { isUseFreshMastery } from "@/lib/curriculum/playbook-mastery-config";
 import { getAllScratchMastery } from "@/lib/curriculum/scratch-mastery";
 import { getSkillTierMapping, scoreToTier } from "@/lib/goals/track-progress";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export type LoMasteryStatus =
   | "mastered"
@@ -133,7 +134,7 @@ export async function GET(
   // Resolve curriculumId via PlaybookCurriculum(primary) — canonical join
   // post-#1177. Mirrors `lib/curriculum/resolve-playbook-for-curriculum.ts`.
   const playbookCurriculum = await prisma.playbookCurriculum.findFirst({
-    where: { playbookId, role: "primary" },
+    where: { playbookId, role: PlaybookCurriculumRole.primary },
     select: { curriculumId: true },
   });
   if (!playbookCurriculum) {

--- a/apps/admin/app/api/callers/[callerId]/session-flow-progress/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/session-flow-progress/route.ts
@@ -31,6 +31,7 @@ import type {
   OnboardingFlowPhases,
   SessionFlowResolved,
 } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export interface CallerSessionFlowProgress {
   /** Course-level state */
@@ -89,7 +90,7 @@ export async function GET(
             // #1205 — canonical PlaybookCurriculum primary join (variant-aware).
             playbookCurricula: {
               where: {
-                role: "primary",
+                role: PlaybookCurriculumRole.primary,
                 curriculum: { deliveryConfig: { not: undefined } },
               },
               select: { curriculum: { select: { id: true, slug: true } } },

--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -78,6 +78,7 @@ import { updateTargets } from "@/lib/ops/update-targets";
 import { buildParameterSpecMap, type ParameterWithSpec } from "@/lib/measurement/parameter-spec-map";
 import { buildBatchedMeasurePrompt } from "@/lib/measurement/build-batched-measure-prompt";
 import type { SpecConfig } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 /**
  * Build a BATCHED prompt for all MEASURE + LEARN specs
@@ -139,7 +140,7 @@ async function loadCurrentModuleContext(
         config: true,
         // #1205 — canonical PlaybookCurriculum primary join (variant-aware).
         playbookCurricula: {
-          where: { role: "primary" },
+          where: { role: PlaybookCurriculumRole.primary },
           take: 1,
           select: { curriculum: { select: { slug: true } } },
         },
@@ -233,7 +234,7 @@ async function loadCurrentModuleContext(
         config: true,
         // #1205 — canonical PlaybookCurriculum primary join (variant-aware).
         playbookCurricula: {
-          where: { role: "primary" },
+          where: { role: PlaybookCurriculumRole.primary },
           take: 1,
           select: { curriculum: { select: { id: true, slug: true } } },
         },

--- a/apps/admin/app/api/courses/[courseId]/distribution-advisory/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/distribution-advisory/route.ts
@@ -4,6 +4,7 @@ import { requireAuth, isAuthError } from "@/lib/permissions";
 import { getLessonPlanModel } from "@/lib/lesson-plan/models";
 import { runAdvisoryChecks, type LessonSession } from "@/lib/content-trust/lesson-planner";
 import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 /**
  * @api GET /api/courses/:courseId/distribution-advisory
@@ -35,7 +36,7 @@ export async function GET(
         id: true,
         config: true,
         playbookCurricula: {
-          where: { role: "primary" },
+          where: { role: PlaybookCurriculumRole.primary },
           take: 1,
           select: { curriculum: { select: { id: true, deliveryConfig: true } } },
         },

--- a/apps/admin/app/api/courses/[courseId]/genome/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/genome/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { INSTRUCTION_CATEGORIES } from "@/lib/content-trust/resolve-config";
 import { getSourceIdsForPlaybook } from "@/lib/knowledge/domain-sources";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 type Params = { params: Promise<{ courseId: string }> };
 
@@ -110,7 +111,7 @@ export async function GET(
     // 2. Find curriculum — canonical PlaybookCurriculum primary join,
     // fallback to subject chain. #1177 Slice 6.
     let curriculum = await prisma.curriculum.findFirst({
-      where: { playbookLinks: { some: { playbookId: courseId, role: "primary" } } },
+      where: { playbookLinks: { some: { playbookId: courseId, role: PlaybookCurriculumRole.primary } } },
       orderBy: { updatedAt: "desc" },
       select: {
         id: true,

--- a/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/import-modules/route.ts
@@ -34,6 +34,7 @@ import { resolveCurriculumIdForPlaybook } from "@/lib/curriculum/resolve-module"
 import { recommendNextModule } from "@/lib/curriculum/recommend-next-module";
 import { readCourseFlags } from "@/lib/curriculum/course-completion";
 import { bumpPlaybookComposeTimestamp } from "@/lib/compose/bump-timestamp";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 // #495 Slice 4.2 — picker status badge. Per-module progress is returned to
 // the learner picker so each tile/rail card can render Mastered / In progress
@@ -258,7 +259,7 @@ export async function GET(
   if (allOutcomeRefs.length > 0) {
     // #1177 Slice 6 — canonical PlaybookCurriculum primary join (variant-aware).
     const curriculumRow = await prisma.curriculum.findFirst({
-      where: { playbookLinks: { some: { playbookId: courseId, role: "primary" } } },
+      where: { playbookLinks: { some: { playbookId: courseId, role: PlaybookCurriculumRole.primary } } },
       orderBy: { createdAt: "asc" },
       select: { id: true },
     });
@@ -446,7 +447,7 @@ async function loadProgressForCaller(
       callerId,
       module: {
         curriculum: {
-          playbookLinks: { some: { playbookId: courseId, role: "primary" } },
+          playbookLinks: { some: { playbookId: courseId, role: PlaybookCurriculumRole.primary } },
         },
       },
     },

--- a/apps/admin/app/api/courses/[courseId]/sessions/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/sessions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 type Params = { params: Promise<{ courseId: string }> };
 
@@ -40,7 +41,7 @@ export async function GET(
     // 2. Fetch curricula — canonical PlaybookCurriculum primary join,
     // fallback to subject chain. #1177 Slice 6.
     let curricula = await prisma.curriculum.findMany({
-      where: { playbookLinks: { some: { playbookId: courseId, role: "primary" } } },
+      where: { playbookLinks: { some: { playbookId: courseId, role: PlaybookCurriculumRole.primary } } },
       orderBy: { createdAt: "desc" },
       select: {
         id: true,

--- a/apps/admin/app/api/courses/[courseId]/test-learner/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/test-learner/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { createTestLearnerForPlaybook } from "@/lib/enrollment/create-test-learner";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 /**
  * @api POST /api/courses/:courseId/test-learner
@@ -50,7 +51,7 @@ export async function POST(
       isActive: true,
       curriculum: {
         OR: [
-          { playbookLinks: { some: { playbookId: courseId, role: "primary" } } },
+          { playbookLinks: { some: { playbookId: courseId, role: PlaybookCurriculumRole.primary } } },
           { subject: { playbooks: { some: { playbookId: courseId } } } },
         ],
       },

--- a/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/media-map/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/media-map/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 type Params = { params: Promise<{ curriculumId: string }> };
 
@@ -50,7 +51,7 @@ export async function GET(
         deliveryConfig: true,
         subjectId: true,
         playbookLinks: {
-          where: { role: "primary" },
+          where: { role: PlaybookCurriculumRole.primary },
           take: 1,
           select: { playbookId: true },
         },

--- a/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
+++ b/apps/admin/app/api/curricula/[curriculumId]/lesson-plan/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/ai/task-guidance";
 import { bumpPlaybookComposeTimestamp } from "@/lib/compose/bump-timestamp";
 import { resolvePlaybookIdForCurriculum } from "@/lib/curriculum/resolve-playbook-for-curriculum";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 type Params = { params: Promise<{ curriculumId: string }> };
 
@@ -291,7 +292,7 @@ async function runBackgroundLessonPlanGeneration(
         subjectId: true,
         deliveryConfig: true,
         playbookLinks: {
-          where: { role: "primary" },
+          where: { role: PlaybookCurriculumRole.primary },
           take: 1,
           select: { playbookId: true },
         },
@@ -697,7 +698,7 @@ export async function POST(
         deliveryConfig: true,
         subjectId: true,
         playbookLinks: {
-          where: { role: "primary" },
+          where: { role: PlaybookCurriculumRole.primary },
           take: 1,
           select: { playbookId: true },
         },

--- a/apps/admin/app/api/educator/classrooms/[id]/lesson-plan/route.ts
+++ b/apps/admin/app/api/educator/classrooms/[id]/lesson-plan/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 /**
  * @api GET /api/educator/classrooms/[id]/lesson-plan
@@ -44,7 +45,7 @@ export async function GET(
             id: true,
             name: true,
             playbookCurricula: {
-              where: { role: "primary" },
+              where: { role: PlaybookCurriculumRole.primary },
               take: 1,
               select: { curriculum: { select: { slug: true, deliveryConfig: true } } },
             },

--- a/apps/admin/app/api/student/assessment-questions/route.ts
+++ b/apps/admin/app/api/student/assessment-questions/route.ts
@@ -26,6 +26,7 @@ import { prisma } from "@/lib/prisma";
 import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
 import { buildPreTest, buildPreTestForPlaybook, buildPostTest, buildComprehensionPostTest } from "@/lib/assessment/pre-test-builder";
 import type { AuthoredModule } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 const VALID_TYPES = new Set(["pre_test", "post_test"]);
 
@@ -101,7 +102,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
           // #1205 — canonical PlaybookCurriculum primary join (variant-aware).
           playbookCurricula: {
             where: {
-              role: "primary",
+              role: PlaybookCurriculumRole.primary,
               curriculum: { deliveryConfig: { not: Prisma.JsonNull } },
             },
             select: { curriculum: { select: { id: true } } },

--- a/apps/admin/app/api/student/courses/[enrollmentId]/retake/route.ts
+++ b/apps/admin/app/api/student/courses/[enrollmentId]/retake/route.ts
@@ -19,6 +19,7 @@ import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access"
 import { autoComposeForCaller } from "@/lib/enrollment/auto-compose";
 // initializeLessonPlanSession removed — scheduler replaces session tracking
 import { SURVEY_SCOPES } from "@/lib/learner/survey-keys";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export async function POST(
   request: NextRequest,
@@ -50,7 +51,7 @@ export async function POST(
           // join row is the single source of truth for "this playbook's
           // curriculum body".
           playbookCurricula: {
-            where: { role: "primary" },
+            where: { role: PlaybookCurriculumRole.primary },
             take: 1,
             select: { curriculum: { select: { slug: true } } },
           },

--- a/apps/admin/app/api/student/journey-position/route.ts
+++ b/apps/admin/app/api/student/journey-position/route.ts
@@ -21,6 +21,7 @@ import { SURVEY_SCOPES } from "@/lib/learner/survey-keys";
 import { config } from "@/lib/config";
 import { resolveSessionFlow } from "@/lib/session-flow/resolver";
 import { evaluateStops, type JourneyStopState } from "@/lib/session-flow/journey-stop-runner";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 /**
  * Translate a fired JourneyStop into the legacy nextStop response shape.
@@ -72,7 +73,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
               // curriculum has none, this enrollment can't have a journey position.
               playbookCurricula: {
                 where: {
-                  role: "primary",
+                  role: PlaybookCurriculumRole.primary,
                   curriculum: { deliveryConfig: { not: Prisma.JsonNull } },
                 },
                 select: { curriculum: { select: { id: true, slug: true, deliveryConfig: true } } },

--- a/apps/admin/app/api/student/module-progress/route.ts
+++ b/apps/admin/app/api/student/module-progress/route.ts
@@ -27,6 +27,7 @@ import { NextRequest, NextResponse } from "next/server";
 import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireStudentOrAdmin, isStudentAuthError } from "@/lib/student-access";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = await requireStudentOrAdmin(request);
@@ -41,7 +42,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         callerId,
         module: {
           curriculum: {
-            playbookLinks: { some: { playbookId: courseId, role: "primary" } },
+            playbookLinks: { some: { playbookId: courseId, role: PlaybookCurriculumRole.primary } },
           },
         },
       }

--- a/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
+++ b/apps/admin/app/api/subjects/[subjectId]/curriculum/route.ts
@@ -19,6 +19,7 @@ import {
   findCurriculumByAnchor,
   QualificationAnchorAmbiguity,
 } from "@/lib/curriculum/find-sibling-curricula";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 type Params = { params: Promise<{ subjectId: string }> };
 
@@ -276,7 +277,7 @@ export async function POST(req: NextRequest, { params }: Params) {
                 create: {
                   playbookId: resolvedPlaybookId,
                   curriculumId: sibling.id,
-                  role: "linked",
+                  role: PlaybookCurriculumRole.linked,
                 },
                 update: {},
               });

--- a/apps/admin/lib/assessment/module-groups.ts
+++ b/apps/admin/lib/assessment/module-groups.ts
@@ -12,6 +12,7 @@
 
 import { prisma } from "@/lib/prisma";
 import type { AuthoredModule } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export interface ModuleGroup {
   /** AuthoredModule.id — e.g. "part1", "mock". */
@@ -47,7 +48,7 @@ export async function resolveModuleGroupsForSource(
           config: true,
           // #1205 — canonical PlaybookCurriculum primary join (variant-aware).
           playbookCurricula: {
-            where: { role: "primary" },
+            where: { role: PlaybookCurriculumRole.primary },
             select: { curriculum: { select: { id: true } } },
             take: 1,
           },

--- a/apps/admin/lib/assessment/pre-test-builder.ts
+++ b/apps/admin/lib/assessment/pre-test-builder.ts
@@ -13,6 +13,7 @@ import {
   shuffleOptions,
   relabelByPosition,
 } from "@/lib/assessment/shuffle-options";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -89,7 +90,7 @@ async function getSourceIdsForCurriculum(curriculumId: string): Promise<string[]
       primarySourceId: true,
       subjectId: true,
       playbookLinks: {
-        where: { role: "primary" },
+        where: { role: PlaybookCurriculumRole.primary },
         take: 1,
         select: { playbookId: true },
       },

--- a/apps/admin/lib/chat/admin-tool-handlers.ts
+++ b/apps/admin/lib/chat/admin-tool-handlers.ts
@@ -31,6 +31,7 @@ import { cascadeableKeys, LOCKED_KEYS, SECRET_KEYS } from "@/lib/voice/config";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
 import { getVoiceProvider } from "@/lib/voice/provider-factory";
 import { explainVoiceCascade } from "@/lib/cascade/voice-explain";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 const MAX_RESULT_LENGTH = 3000;
 
@@ -2322,7 +2323,7 @@ async function handleSwapPrimaryCurriculum(input: Record<string, any>) {
 
   // Demote any current primary (other than the target), then upsert target → primary.
   const previousPrimary = await prisma.playbookCurriculum.findFirst({
-    where: { playbookId, role: "primary" },
+    where: { playbookId, role: PlaybookCurriculumRole.primary },
     select: { curriculumId: true },
   });
 
@@ -2332,14 +2333,14 @@ async function handleSwapPrimaryCurriculum(input: Record<string, any>) {
         where: {
           playbookId_curriculumId: { playbookId, curriculumId: previousPrimary.curriculumId },
         },
-        data: { role: "linked" },
+        data: { role: PlaybookCurriculumRole.linked },
       });
     }
     // Upsert target → primary. If a 'linked' join row exists, promote it.
     await tx.playbookCurriculum.upsert({
       where: { playbookId_curriculumId: { playbookId, curriculumId } },
-      create: { playbookId, curriculumId, role: "primary" },
-      update: { role: "primary" },
+      create: { playbookId, curriculumId, role: PlaybookCurriculumRole.primary },
+      update: { role: PlaybookCurriculumRole.primary },
     });
   });
 
@@ -2397,7 +2398,7 @@ async function handleAttachLinkedCurriculum(input: Record<string, any>) {
   }
 
   await prisma.playbookCurriculum.create({
-    data: { playbookId, curriculumId, role: "linked" },
+    data: { playbookId, curriculumId, role: PlaybookCurriculumRole.linked },
   });
   await bumpPlaybookComposeTimestamp(playbookId);
 
@@ -2419,7 +2420,7 @@ async function handleAttachLinkedCurriculum(input: Record<string, any>) {
     ok: true,
     playbook_id: playbookId,
     curriculum_id: curriculumId,
-    role: "linked",
+    role: PlaybookCurriculumRole.linked,
     compose_inputs_bumped: true,
     message: `Attached "${curriculum.name}" as a linked variant on "${playbook.name}". ${TRAY_PROPOSED_SUFFIX}`,
     pendingChange,

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/mark_complete.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/mark_complete.ts
@@ -1,4 +1,5 @@
 import type { WizardToolExec } from "../_shared/types";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export async function execute(
   _input: Record<string, unknown>,
@@ -31,7 +32,7 @@ export async function execute(
       name: true,
       // #1205 — canonical PlaybookCurriculum primary join.
       playbookCurricula: {
-        where: { role: "primary" },
+        where: { role: PlaybookCurriculumRole.primary },
         take: 1,
         select: {
           curriculum: {

--- a/apps/admin/lib/curriculum/ensure-primary-playbook-link.ts
+++ b/apps/admin/lib/curriculum/ensure-primary-playbook-link.ts
@@ -1,4 +1,5 @@
 import type { Prisma, PrismaClient } from "@prisma/client";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 type TxOrClient =
   | PrismaClient
@@ -43,7 +44,7 @@ export async function ensurePrimaryPlaybookLink(
     create: {
       playbookId,
       curriculumId,
-      role: "primary",
+      role: PlaybookCurriculumRole.primary,
     },
     update: {},
   });

--- a/apps/admin/lib/curriculum/find-sibling-curricula.ts
+++ b/apps/admin/lib/curriculum/find-sibling-curricula.ts
@@ -4,7 +4,7 @@
  * When a create-course route declares qualification metadata (body + ref) that
  * derives to a non-null anchor, we look in the SAME DOMAIN for an existing
  * Curriculum carrying that anchor. If one exists, the new Playbook is linked
- * to it via PlaybookCurriculum(role: "linked") rather than minting a fresh
+ * to it via PlaybookCurriculum(role: PlaybookCurriculumRole.linked) rather than minting a fresh
  * Curriculum — that is the variant pattern from #1034 applied to ingest paths.
  *
  * Domain scope: a Curriculum's domain is reached via any of its linked
@@ -23,6 +23,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import type { Prisma } from "@prisma/client";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export class QualificationAnchorAmbiguity extends Error {
   public readonly anchor: string;

--- a/apps/admin/lib/domain/generate-content-spec.ts
+++ b/apps/admin/lib/domain/generate-content-spec.ts
@@ -13,6 +13,7 @@ import { db, type TxClient } from "@/lib/prisma";
 import { extractCurriculumFromAssertions, type CurriculumIntents } from "@/lib/content-trust/extract-curriculum";
 import { syncModulesToDB } from "@/lib/curriculum/sync-modules";
 import type { LegacyCurriculumModuleJSON } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 // ── Types ──────────────────────────────────────────────
 
@@ -264,7 +265,7 @@ export async function generateContentSpec(domainId: string, options?: GenerateCo
           ? {
               OR: [
                 { subjectId },
-                { playbookLinks: { some: { playbookId: options.playbookId, role: "primary" } } },
+                { playbookLinks: { some: { playbookId: options.playbookId, role: PlaybookCurriculumRole.primary } } },
               ],
             }
           : { subjectId },

--- a/apps/admin/lib/enrollment/instantiate-goals.ts
+++ b/apps/admin/lib/enrollment/instantiate-goals.ts
@@ -19,6 +19,7 @@
 import { prisma } from "@/lib/prisma";
 import { GOAL_TYPE_VALUES, type GoalTypeLiteral, type PlaybookConfig } from "@/lib/types/json-fields";
 import { loadGoalProgressSpec, resolveStrategyKey } from "@/lib/goals/strategies";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 const LEGACY_GOAL_TYPE_MAP: Record<string, GoalTypeLiteral> = {
   TOPIC_MASTERED: "LEARN",
@@ -72,7 +73,7 @@ async function deriveGoalsFromCurriculum(playbookId: string): Promise<GoalConfig
     where: {
       isActive: true,
       curriculum: {
-        playbookLinks: { some: { playbookId, role: "primary" } },
+        playbookLinks: { some: { playbookId, role: PlaybookCurriculumRole.primary } },
       },
     },
     select: { id: true, slug: true, title: true, description: true, sortOrder: true },

--- a/apps/admin/lib/enrollment/instantiate-module-progress.ts
+++ b/apps/admin/lib/enrollment/instantiate-module-progress.ts
@@ -40,6 +40,7 @@
 import { prisma } from "@/lib/prisma";
 import { getCourseStyle } from "@/lib/pipeline/course-style";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export interface InstantiateModuleProgressResult {
   created: number;
@@ -68,7 +69,7 @@ export async function instantiatePlaybookModuleProgress(
       id: true,
       config: true,
       playbookCurricula: {
-        where: { role: "primary" },
+        where: { role: PlaybookCurriculumRole.primary },
         select: { curriculumId: true },
         take: 1,
       },

--- a/apps/admin/lib/goals/track-progress.ts
+++ b/apps/admin/lib/goals/track-progress.ts
@@ -19,6 +19,7 @@ import {
   resolveStrategyKey,
 } from "./strategies";
 import type { StrategyKey } from "./strategies/types";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export interface GoalProgressUpdate {
   goalId: string;
@@ -326,7 +327,7 @@ async function resolveLearningObjective(
       where: {
         slug: moduleSlug,
         curriculum: {
-          playbookLinks: { some: { playbookId, role: "primary" } },
+          playbookLinks: { some: { playbookId, role: PlaybookCurriculumRole.primary } },
         },
       },
       select: {
@@ -360,7 +361,7 @@ async function resolveLearningObjective(
       ref,
       module: {
         curriculum: {
-          playbookLinks: { some: { playbookId, role: "primary" } },
+          playbookLinks: { some: { playbookId, role: PlaybookCurriculumRole.primary } },
         },
       },
     },

--- a/apps/admin/lib/playbooks/create-variant.ts
+++ b/apps/admin/lib/playbooks/create-variant.ts
@@ -40,6 +40,7 @@ import {
   deriveQualificationAnchor,
   isAnchorSafe,
 } from "@/lib/curriculum/qualification-anchor";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 export type VariantPreset = "revision" | "popquiz" | "exam";
 
@@ -192,7 +193,7 @@ export async function createPlaybookVariant(
           data: {
             playbookId: variant.id,
             curriculumId: sharedCurriculumId,
-            role: "linked",
+            role: PlaybookCurriculumRole.linked,
           },
         });
       }

--- a/apps/admin/lib/prompt/compose-content-section.ts
+++ b/apps/admin/lib/prompt/compose-content-section.ts
@@ -18,6 +18,7 @@ import { ContractRegistry } from "@/lib/contracts/registry";
 import { CURRICULUM_REQUIRED_FIELDS } from "@/lib/curriculum/constants";
 import { resolveMasteryThreshold } from "@/lib/tolerance/resolve-tolerance";
 import type { SpecConfig } from "@/lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 interface CurriculumMetadata {
   type: 'sequential' | 'branching' | 'open-ended';
@@ -137,7 +138,7 @@ export async function composeContentSection(
     const hasRealModules = await prisma.curriculumModule.count({
       where: {
         curriculum: {
-          playbookLinks: { some: { playbookId: playbook.id, role: "primary" } },
+          playbookLinks: { some: { playbookId: playbook.id, role: PlaybookCurriculumRole.primary } },
         },
       },
     });

--- a/apps/admin/lib/prompt/composition/SectionDataLoader.ts
+++ b/apps/admin/lib/prompt/composition/SectionDataLoader.ts
@@ -35,6 +35,7 @@ import type {
   CourseCompleteLoadedData,
   CurriculumAssertionData,
 } from "./types";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 /**
  * Loaded shape of the `curriculumAssertions` loader.
@@ -1542,7 +1543,7 @@ registerLoader("courseInstructions", async (_callerId, loaderConfig) => {
         module: {
           isActive: true,
           curriculum: {
-            playbookLinks: { some: { playbookId: scope.playbookId, role: "primary" } },
+            playbookLinks: { some: { playbookId: scope.playbookId, role: PlaybookCurriculumRole.primary } },
           },
         },
       },

--- a/apps/admin/lib/wizard/apply-projection.ts
+++ b/apps/admin/lib/wizard/apply-projection.ts
@@ -62,6 +62,7 @@ import type {
   ProjectedMeasureSpec,
   ProjectedParameter,
 } from "./project-course-reference";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 // ── Public types ────────────────────────────────────────────────────────────
 
@@ -263,7 +264,7 @@ async function ensureCurriculum(
   // #1081 Slice 2B.2 — anchor-aware sibling-link. Before minting a fresh
   // Curriculum, see if this Playbook's domain already hosts a Curriculum
   // teaching the same regulated qualification. If so, LINK the new Playbook
-  // via PlaybookCurriculum(role: "linked") and reuse the shared Curriculum.
+  // via PlaybookCurriculum(role: PlaybookCurriculumRole.linked) and reuse the shared Curriculum.
   // Mastery sharing flows naturally from the shared CurriculumModule UUIDs
   // (CC-E in docs/chain-contracts.md).
   //
@@ -325,7 +326,7 @@ async function ensureCurriculum(
           data: {
             playbookId,
             curriculumId: sibling.id,
-            role: "linked",
+            role: PlaybookCurriculumRole.linked,
           },
         });
         console.log(
@@ -366,7 +367,7 @@ async function ensureCurriculum(
     data: {
       playbookId,
       curriculumId: created.id,
-      role: "primary",
+      role: PlaybookCurriculumRole.primary,
     },
   });
   return { id: created.id, created: true };

--- a/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
+++ b/apps/admin/lib/wizard/sync-authored-modules-to-curriculum.ts
@@ -30,6 +30,7 @@ import type { AuthoredModule } from "@/lib/types/json-fields";
 import { prerequisiteSlugs } from "@/lib/curriculum/check-module-unlock";
 import { detectMockShapeCovers } from "./detect-mock-shape-modules";
 import { assertValidLoRefBatch } from "@/lib/curriculum/validate-lo-refs";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 // #317 — LO audience classification is NOT run from this helper because it
 // receives an open transaction (`tx`) and the classifier runs its own
@@ -101,7 +102,7 @@ export async function syncAuthoredModulesToCurriculum(
       data: {
         playbookId,
         curriculumId: created.id,
-        role: "primary",
+        role: PlaybookCurriculumRole.primary,
       },
     });
     curriculumId = created.id;

--- a/apps/admin/scripts/backfill-lesson-plan-mode.ts
+++ b/apps/admin/scripts/backfill-lesson-plan-mode.ts
@@ -33,6 +33,7 @@
 import { prisma } from "../lib/prisma";
 import { updatePlaybookConfig } from "../lib/playbook/update-playbook-config";
 import type { PlaybookConfig } from "../lib/types/json-fields";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 const APPLY = process.argv.includes("--apply");
 
@@ -53,7 +54,7 @@ async function main() {
       config: true,
       // #1177 — Curriculum is reached via PlaybookCurriculum (role:'primary').
       playbookCurricula: {
-        where: { role: "primary" },
+        where: { role: PlaybookCurriculumRole.primary },
         select: { curriculumId: true },
         take: 1,
       },

--- a/apps/admin/scripts/debug-session-tps.ts
+++ b/apps/admin/scripts/debug-session-tps.ts
@@ -3,6 +3,7 @@
  * Run: npx tsx scripts/debug-session-tps.ts
  */
 import { prisma } from "@/lib/prisma";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 async function main() {
   // Find the 11+ Comprehension course
@@ -18,7 +19,7 @@ async function main() {
 
   // #1177 Slice 6 — canonical PlaybookCurriculum primary join.
   const cur = await prisma.curriculum.findFirst({
-    where: { playbookLinks: { some: { playbookId: pb.id, role: "primary" } } },
+    where: { playbookLinks: { some: { playbookId: pb.id, role: PlaybookCurriculumRole.primary } } },
     select: { id: true, subjectId: true, deliveryConfig: true },
   });
   if (cur === null) {

--- a/apps/admin/scripts/proof-1252-mastery-loop.ts
+++ b/apps/admin/scripts/proof-1252-mastery-loop.ts
@@ -50,6 +50,7 @@ import { createTestLearnerForPlaybook } from "@/lib/enrollment/create-test-learn
 import { getCourseStyle } from "@/lib/pipeline/course-style";
 import { execSync } from "child_process";
 import fs from "fs";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 const DEFAULT_PLAYBOOK_ID = "5bbdbe7e-c32f-490e-8ff8-a938ddfc49a0"; // CIO/CTO Revision Aid
 
@@ -197,7 +198,7 @@ async function main() {
 
   const pb = await prisma.playbook.findUnique({
     where: { id: playbookId },
-    select: { name: true, config: true, status: true, playbookCurricula: { where: { role: "primary" }, select: { curriculumId: true }, take: 1 } },
+    select: { name: true, config: true, status: true, playbookCurricula: { where: { role: PlaybookCurriculumRole.primary }, select: { curriculumId: true }, take: 1 } },
   });
   if (!pb || pb.status !== "PUBLISHED") {
     console.error(`Playbook ${playbookId} not PUBLISHED — abort`);

--- a/apps/admin/scripts/snap-ielts-progress.ts
+++ b/apps/admin/scripts/snap-ielts-progress.ts
@@ -10,6 +10,7 @@
  */
 
 import { PrismaClient } from "@prisma/client";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 const CALEB_CALLER_ID = "17b1b0b7-4837-4ece-9ae5-f94a967e5ff9";
 const IELTS_PLAYBOOK_ID = "e460cd6f-0d0c-4948-9d8e-1ce696d4dfd3";
@@ -19,7 +20,7 @@ const p = new PrismaClient();
 async function main() {
   // #1177 Slice 6 — canonical PlaybookCurriculum primary join.
   const curric = await p.curriculum.findFirst({
-    where: { playbookLinks: { some: { playbookId: IELTS_PLAYBOOK_ID, role: "primary" } } },
+    where: { playbookLinks: { some: { playbookId: IELTS_PLAYBOOK_ID, role: PlaybookCurriculumRole.primary } } },
     select: { id: true },
   });
   const modules = curric

--- a/apps/admin/scripts/verify-409-resolution.ts
+++ b/apps/admin/scripts/verify-409-resolution.ts
@@ -12,6 +12,7 @@ import {
   resolveCurriculumIdForPlaybook,
   resolveModuleByLogicalId,
 } from "@/lib/curriculum/resolve-module";
+import { PlaybookCurriculumRole } from "@prisma/client";
 
 const CALLERS = [
   { id: "b9ad0217-9202-4f32-b358-6a79783170ef", name: "Opal Jensen" },
@@ -38,7 +39,7 @@ async function main() {
             curriculum: {
               select: {
                 playbookLinks: {
-                  where: { role: "primary" },
+                  where: { role: PlaybookCurriculumRole.primary },
                   take: 1,
                   select: { playbookId: true },
                 },

--- a/apps/admin/tests/lib/playbook-curriculum-role-adoption.test.ts
+++ b/apps/admin/tests/lib/playbook-curriculum-role-adoption.test.ts
@@ -1,0 +1,75 @@
+/**
+ * PlaybookCurriculumRole enum — adoption + drift ratchet.
+ *
+ * **What this test pins:**
+ *  1. The Prisma enum has exactly the 2 documented members
+ *     (`primary` / `linked`) — schema additions force a test update.
+ *  2. No code under `apps/admin/{app,lib,scripts}` falls back to the
+ *     bare string literal `role: "primary"` or `role: "linked"` for
+ *     `PlaybookCurriculum` writes/reads — every site MUST go through
+ *     `PlaybookCurriculumRole.<member>` from `@prisma/client`.
+ *
+ *  See `.claude/rules/ai-to-db-guard.md` — when a Prisma enum exists,
+ *  prefer the generated const value over a hand-typed literal. Bare
+ *  literals diverge on rename and produce no compile error.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { PlaybookCurriculumRole } from "@prisma/client";
+
+const REPO_ADMIN = resolve(__dirname, "..", "..");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("PlaybookCurriculumRole — enum adoption", () => {
+  it("Prisma enum has exactly 2 members", () => {
+    expect(Object.values(PlaybookCurriculumRole).sort()).toEqual([
+      "linked",
+      "primary",
+    ]);
+  });
+
+  it("no consumer uses bare `role: \"primary\"` or `role: \"linked\"` literal", () => {
+    const PATTERN = /role:\s*"(primary|linked)"/;
+    const offenders: { file: string; line: number; text: string }[] = [];
+    const roots = ["app", "lib", "scripts"];
+    for (const root of roots) {
+      const rootDir = join(REPO_ADMIN, root);
+      for (const file of walk(rootDir)) {
+        const src = readFileSync(file, "utf8");
+        if (!PATTERN.test(src)) continue;
+        src.split("\n").forEach((line, idx) => {
+          if (PATTERN.test(line)) {
+            offenders.push({
+              file: file.replace(REPO_ADMIN + "/", ""),
+              line: idx + 1,
+              text: line.trim(),
+            });
+          }
+        });
+      }
+    }
+    expect(
+      offenders,
+      `Bare \`role: "primary"\` / \`role: "linked"\` literal — replace with \`PlaybookCurriculumRole.<member>\` from @prisma/client:\n${offenders
+        .map((o) => `  ${o.file}:${o.line}  ${o.text}`)
+        .join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/admin/tests/setup.ts
+++ b/apps/admin/tests/setup.ts
@@ -358,6 +358,10 @@ vi.mock('@prisma/client', () => {
       RELATIONSHIP: 'RELATIONSHIP',
       CONTEXT: 'CONTEXT',
     },
+    PlaybookCurriculumRole: {
+      primary: 'primary',
+      linked: 'linked',
+    },
     MemorySource: {
       EXTRACTED: 'EXTRACTED',
       INFERRED: 'INFERRED',

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -105,6 +105,8 @@ Three structural patterns, in order of preference:
 | ComposeSectionKey → SECTION_OUTPUT_KEYS map | `COMPOSE_SECTION_KEYS` | `SECTION_OUTPUT_KEYS` | ✅ PROTECTED | Same `satisfies` + section-loaders test | — | Compile-time + test |
 | COMP-001 spec sections ↔ `getDefaultSections()` code | `docs-archive/bdd-specs/COMP-001-prompt-composition.spec.json` | `lib/compose/section.ts::getDefaultSections` | ⚠️ PARTIAL | `tests/lib/prompt/composition/seed-sync.test.ts` (existing) | MED | Test catches code-vs-spec divergence at fixture time; doesn't re-pin post-spec-JSON-update. |
 | Transform behavior-target neutral fallback | `lib/measurement/neutral-target.ts::NEUTRAL_PARAMETER_TARGET` | composition transforms (`quickstart.ts`, `identity.ts`) | ✅ PROTECTED | `tests/lib/measurement/neutral-target.test.ts` (#1880) | — | Named const replaces bare `?? 0.5`; ratchet rejects new offenders in `lib/prompt/composition/transforms/`. |
+| `PlaybookCurriculumRole` enum adoption | `@prisma/client::PlaybookCurriculumRole` | 38 consumers under `apps/admin/{app,lib,scripts}` | ✅ PROTECTED | `tests/lib/playbook-curriculum-role-adoption.test.ts` | — | Ratchet rejects bare `role: "primary"` / `role: "linked"` literals across app, lib, scripts. |
+| `MemoryCategory` enum adoption | `@prisma/client::MemoryCategory` | `lib/chat/commands.ts` + `differentiation/route.ts` | ✅ PROTECTED | `tests/lib/memory-category-adoption.test.ts` | — | Ratchet rejects 6-permutation literal reconstructions. |
 
 ### Cascade
 


### PR DESCRIPTION
## Summary

Outrageous-hardcoding sweep #3. 47 sites across 38 files duplicated the Prisma `PlaybookCurriculumRole` enum as bare string literals. The agent's audit claimed Prisma didn't export the enum — inverse-probe disproved that: it does export `{ primary: "primary", linked: "linked" }` as a runtime const, but zero call sites used it.

Changes:
- Replaced 47 bare literal sites in 38 files with `PlaybookCurriculumRole.<member>`.
- Added the import to each file (mix of new imports and additions to existing `@prisma/client` imports).
- Wired the enum into `tests/setup.ts` mock so vitest consumers can resolve it.
- New `tests/lib/playbook-curriculum-role-adoption.test.ts` — 2 vitests: pin the 2-member enum + ratchet rejecting bare `role: "primary"` / `role: "linked"` literals across `apps/admin/{app,lib,scripts}`.
- Added 2 lattice-chains.md rows (PlaybookCurriculumRole + the MemoryCategory follow-on from #1883).

## Verified by

- `npx vitest run tests/lib/playbook-curriculum-role-adoption.test.ts` → 2/2 pass.
- `npx vitest run tests/lib/curriculum` → 111/111 pass (no behavior change — Prisma type-checked the values match).
- `npx vitest run tests/lib/lattice-self-maintenance.test.ts` → 9/9 pass.
- `npx tsc --noEmit` → 36 errors (≤ baseline 41 in `.ratchet.json`, no new errors introduced by this PR).
- pre-push hook output: `[pre-push] tsc: 36 errors (== baseline 41). Push checks passed.`

## Lattice survey

- Surface: hand-typed enum literal arrays vs Prisma-generated value enum.
- Sibling writers: zero — the enum was unused in TypeScript despite `@prisma/client` exporting it.
- Convergence: enum-value adoption + ratchet vitest + inventory row + self-maintenance gate confirms inventory ↔ disk consistency.
- Risk: blast radius is 38 files but each replacement is type-checked by Prisma. tsc is the structural safety net; the ratchet vitest blocks future regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)