### PR TITLE
feat(course-detail): P3c — wire Module Inspector mutator via existing /journey-setting route (#1850)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/journey-setting/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/journey-setting/route.ts
@@ -7,13 +7,24 @@
  * `docs/decisions/2026-06-15-journey-setting-contracts.md` Decision 5
  * + Tech Lead Q3.
  *
- * Body: `{ settingId: string, value: unknown }`.
+ * Body: `{ settingId: string, value: unknown, arraySelector?: string }`.
+ *
+ * `arraySelector` is the per-call selector VALUE used when the contract's
+ * `storagePath` declares `arrayKey` without a fixed `selectorValue` —
+ * the per-instance case (G8 module-scoped settings keyed on each
+ * AuthoredModule's `id`). The selector KEY stays defined in the
+ * contract (`arrayKey: "id"`); the caller supplies the runtime id.
+ * Fixed-selector contracts (e.g. JourneyStop `arrayKey: "kind"` +
+ * `selectorValue: "pre_test"`) ignore the body field and use the
+ * contract's `selectorValue`. P3c (#1850).
  *
  * Behaviour:
  *   1. Auth: `requireAuth("OPERATOR")`. Pipeline-service-token writes
  *      hit a stricter gate when `writeGate === "operator-only"`.
  *   2. Lookup contract in journey or voice registries.
  *   3. Resolve `storagePath` to a `PlaybookConfig` mutation point.
+ *      When the contract carries `arrayKey` with no fixed selectorValue,
+ *      thread the body's `arraySelector` through as the per-call value.
  *   4. Apply parent write + any `autoEnableLinks` matching `whenValue`
  *      in the SAME `updatePlaybookConfig` transformer (one transaction).
  *   5. Return updated effective value + autoEnableLinks fan-out summary.
@@ -51,6 +62,10 @@ import type { PlaybookConfig } from "@/lib/types/json-fields";
 const bodySchema = z.object({
   settingId: z.string().min(1),
   value: z.unknown(),
+  /** Per-call selector VALUE for contracts whose storagePath declares
+   *  `arrayKey` without a fixed `selectorValue` (G8 module-scoped
+   *  settings — the moduleId). Ignored by fixed-selector contracts. */
+  arraySelector: z.string().min(1).optional(),
 });
 
 interface PatchResponse {
@@ -100,7 +115,7 @@ export async function PATCH(
       { status: 400 },
     );
   }
-  const { settingId, value } = parsed.data;
+  const { settingId, value, arraySelector } = parsed.data;
 
   // Lookup contract
   const contract: JourneySettingContract | undefined =
@@ -131,7 +146,49 @@ export async function PATCH(
   }
 
   // Resolve storage root
-  const resolved = resolveStoragePath(contract.storagePath);
+  let resolved = resolveStoragePath(contract.storagePath);
+
+  // P3c (#1850): per-instance array selector. When the contract's
+  // storagePath declares `arrayKey` but no fixed `selectorValue` (e.g.
+  // G8 `config.modules[].settings.*` with `arrayKey: "id"`), the caller
+  // supplies the runtime selector via the body's `arraySelector` field.
+  // Fixed-selector contracts (storagePath carries `selectorValue`) ignore
+  // the body field — `resolved.arraySelector` is already non-null with
+  // the fixed value baked in.
+  if (
+    arraySelector !== undefined &&
+    typeof contract.storagePath !== "string" &&
+    contract.storagePath.arrayKey &&
+    contract.storagePath.selectorValue === undefined
+  ) {
+    resolved = {
+      ...resolved,
+      arraySelector: {
+        key: contract.storagePath.arrayKey,
+        value: arraySelector,
+      },
+    };
+  }
+
+  // Per-instance array contracts (G8) REQUIRE arraySelector — without
+  // it the write would target index 0 / push a new element, neither of
+  // which the caller intended. Reject explicitly so the surface tells
+  // the operator what's missing.
+  if (
+    typeof contract.storagePath !== "string" &&
+    contract.storagePath.arrayKey &&
+    contract.storagePath.selectorValue === undefined &&
+    resolved.arraySelector === null
+  ) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `Setting ${settingId} requires arraySelector in body (contract storagePath has arrayKey="${contract.storagePath.arrayKey}" with no fixed selectorValue).`,
+        code: "ARRAY_SELECTOR_REQUIRED",
+      },
+      { status: 400 },
+    );
+  }
 
   // Phase 3 (#1693): behaviorTargets is a separate model — the storage
   // path applier doesn't write to it. The existing FirstSessionSettings

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -8,10 +8,12 @@
  * picker; the Inspector hosts module-scoped settings.
  *
  * P3 wires the real per-module Inspector (`ModuleInspectorPanel`) and
- * the dedicated `/api/courses/:courseId/modules` route. The Inspector
- * is read-side only — saves surface a "module-mutator pending" notice;
- * the writer follows in a separate PR (see TODO(module-mutator)
- * comments in `ModuleInspectorPanel.tsx`).
+ * the dedicated `/api/courses/:courseId/modules` route. P3c (#1850)
+ * lit up the write side — the Inspector PATCHes through the shared
+ * `/api/courses/:courseId/journey-setting` route with `arraySelector:
+ * selectedModuleId` so the storage-path applier resolves the right
+ * `config.modules[]` element. Saves refresh the local module list so
+ * the Inspector reflects persisted state on subsequent renders.
  *
  * Continuous-course empty state: continuous courses have no authored
  * modules — they pull from a topic pool. We render an explanation
@@ -51,7 +53,9 @@ export function CourseModulesTab({
   // `settings` sub-object without a second round-trip. The LH picker
   // owns its own fetch (it renders without waiting on the parent), and
   // this one feeds the Inspector — both target the same dedicated
-  // /modules route so the cache will collapse them.
+  // /modules route so the cache will collapse them. `reloadKey` bumps
+  // after each save so the Inspector reflects persisted state.
+  const [reloadKey, setReloadKey] = useState(0);
   useEffect(() => {
     if (!courseId || courseStyle === "continuous") {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset list on course/style change, matches sibling ModulesLhPicker pattern
@@ -75,28 +79,11 @@ export function CourseModulesTab({
     return () => {
       cancelled = true;
     };
-  }, [courseId, courseStyle]);
+  }, [courseId, courseStyle, reloadKey]);
 
-  const handleSaveAttempt = useCallback(
-    async (settingId: string, next: unknown) => {
-      // TODO(module-mutator): the existing journey-setting PATCH route's
-      // storage-path applier doesn't traverse mid-path arrays
-      // (`config.modules[].settings.*`). Until either (a) the applier
-      // is extended OR (b) a dedicated module-scope PATCH route lands,
-      // saves here surface a notice and do NOT persist. Tracked at the
-      // P3 follow-on (epic #1850).
-      if (typeof window !== "undefined") {
-        console.info(
-          `[modules-tab] save deferred — module-scope mutator pending`,
-          { settingId, next },
-        );
-        // Soft surfacing only; no toast library is wired in this tab.
-        // The banner inside ModuleInspectorPanel already tells the
-        // educator saves are deferred.
-      }
-    },
-    [],
-  );
+  const handleSaved = useCallback(() => {
+    setReloadKey((k) => k + 1);
+  }, []);
 
   if (courseStyle === "continuous") {
     return (
@@ -145,10 +132,11 @@ export function CourseModulesTab({
       }
       inspector={
         <ModuleInspectorPanel
+          courseId={courseId}
           selectedModuleId={selectedModuleId}
           selectedModuleLabel={selectedModule?.label ?? null}
           settings={selectedModule?.settings ?? null}
-          onSaveAttempt={handleSaveAttempt}
+          onSaved={handleSaved}
         />
       }
     />

--- a/apps/admin/components/modules-tab/ModuleInspectorPanel.tsx
+++ b/apps/admin/components/modules-tab/ModuleInspectorPanel.tsx
@@ -10,22 +10,18 @@
  * `Playbook.config.modules[].settings.*` keyed by `arrayKey: "id"`,
  * NOT on the top-level `Playbook.config` like other Journey settings.
  *
- * Read side (this PR): mounts JourneyField primitives against the
- * selected module's `settings` object — the dedicated
- * `/api/courses/:courseId/modules` route returns each module's full
- * settings sub-tree.
+ * Read side: mounts JourneyField primitives against the selected
+ * module's `settings` object — the dedicated `/api/courses/:courseId/modules`
+ * route returns each module's full settings sub-tree.
  *
- * Write side (deferred → `TODO(module-mutator)`): the existing journey-
- * setting PATCH route's storage-path applier
- * (`lib/journey/storage-path-applier.ts::applyAtPath`) only handles
- * arrays at the FINAL segment of the path (`sessionFlow.stops[]`). G8
- * settings have a MID-path array (`config.modules[].settings.<key>`)
- * which the applier doesn't traverse correctly today. Wiring a real
- * mutator requires either (a) extending `applyAtPath` to walk mid-path
- * arrays with `selectorValue`, or (b) a dedicated module-scope PATCH
- * route. Both are out of scope for P3 — the read-side visibility win is
- * shippable without it, so the stub mutator surfaces a toast and the
- * follow-on lands the writer.
+ * Write side (P3c, #1850): saves go through the existing
+ * `/api/courses/:courseId/journey-setting` PATCH route. P3c extended
+ * the route's body to accept an `arraySelector` field — the selector
+ * VALUE for contracts whose storagePath has `arrayKey` without a fixed
+ * `selectorValue` — and extended `lib/journey/storage-path-applier.ts`
+ * to walk mid-path arrays (`config.modules[].settings.<key>`). The
+ * Inspector threads `selectedModuleId` through as `arraySelector` so
+ * the route resolves the right `modules[]` element.
  *
  * Parallels the CourseTeachingTab → JourneyInspectorPanel relationship,
  * but the per-module data model justifies a separate panel rather than
@@ -33,6 +29,8 @@
  * mutator-provider context writes to `Playbook.config.*`, not to
  * `Playbook.config.modules[i].settings.*`).
  */
+
+import { useCallback } from "react";
 
 import { JourneyField } from "@/components/journey-controls";
 import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
@@ -43,6 +41,8 @@ import type {
 import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
 
 interface ModuleInspectorPanelProps {
+  /** Course id — passed to the PATCH route URL. */
+  courseId: string;
   selectedModuleId: string | null;
   /** The selected module's label — used in the panel header. */
   selectedModuleLabel?: string | null;
@@ -50,13 +50,10 @@ interface ModuleInspectorPanelProps {
    *  `/api/courses/:courseId/modules` → `modules[].settings`).
    *  Undefined or empty → all fields render with default values. */
   settings: Partial<AuthoredModuleSettings> | null;
-  /** Fired on a save attempt against a G8 field. P3 hooks this to a
-   *  stub that surfaces the "module-mutator pending" message; once
-   *  the writer lands, this becomes the real mutator. */
-  onSaveAttempt: (
-    settingId: string,
-    next: unknown,
-  ) => Promise<void> | void;
+  /** Optional hook fired after every successful save. Parent uses it
+   *  to refetch the module list so the Inspector reflects persisted
+   *  state on subsequent renders. */
+  onSaved?: () => void;
 }
 
 /** Pull the final segment from a G8 storagePath
@@ -77,11 +74,55 @@ const G8_SETTINGS: readonly JourneySettingContract[] = JOURNEY_SETTINGS.filter(
 );
 
 export function ModuleInspectorPanel({
+  courseId,
   selectedModuleId,
   selectedModuleLabel,
   settings,
-  onSaveAttempt,
+  onSaved,
 }: ModuleInspectorPanelProps) {
+  // Module-scope mutator — P3c (#1850). Threads `selectedModuleId`
+  // through as the per-call `arraySelector` so the existing
+  // `/journey-setting` PATCH route resolves the right
+  // `config.modules[]` element. Inline rather than via
+  // `useJourneySettingMutator` because that hook's body shape is
+  // `{ settingId, value }` only — G8 needs the extra `arraySelector`
+  // field, and threading it through the shared hook would change the
+  // surface for every Journey/Teaching/Scoring caller.
+  const handleSave = useCallback(
+    async (settingId: string, value: unknown) => {
+      if (!courseId) {
+        throw new Error("ModuleInspectorPanel: courseId is required");
+      }
+      if (!selectedModuleId) {
+        throw new Error("ModuleInspectorPanel: selectedModuleId is required");
+      }
+      const res = await fetch(
+        `/api/courses/${courseId}/journey-setting`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            settingId,
+            value,
+            arraySelector: selectedModuleId,
+          }),
+        },
+      );
+      if (!res.ok) {
+        type ErrBody = { ok?: boolean; error?: string; code?: string };
+        let body: ErrBody | null = null;
+        try {
+          body = (await res.json()) as ErrBody;
+        } catch {
+          body = null;
+        }
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      onSaved?.();
+    },
+    [courseId, selectedModuleId, onSaved],
+  );
+
   if (!selectedModuleId) {
     return (
       <div
@@ -120,11 +161,6 @@ export function ModuleInspectorPanel({
         </p>
       </div>
 
-      <div className="hf-banner hf-banner-info" role="status">
-        Read-only preview. The module-scope writer ships in a follow-on
-        — saves here surface a notice instead of persisting.
-      </div>
-
       <div className="hf-journey-inspector-stack">
         {G8_SETTINGS.map((contract) => {
           const key = lastSegmentOfStoragePath(contract);
@@ -139,9 +175,7 @@ export function ModuleInspectorPanel({
                 contract={contract}
                 value={value}
                 options={contract.options}
-                onSave={(next) =>
-                  Promise.resolve(onSaveAttempt(contract.id, next))
-                }
+                onSave={(next) => handleSave(contract.id, next)}
               />
             </div>
           );

--- a/apps/admin/lib/journey/storage-path-applier.ts
+++ b/apps/admin/lib/journey/storage-path-applier.ts
@@ -20,6 +20,16 @@
  * The structured form (`StoragePathStruct` with `arrayKey + selectorValue`)
  * is handled only when the path is rooted inside `playbookConfig`.
  *
+ * Array traversal modes (both supported):
+ *  - **Final-segment array** (legacy): the `[]` marker is the LAST
+ *    segment, e.g. `sessionFlow.stops[]`. The whole array element is
+ *    replaced / merged.
+ *  - **Mid-path array** (P3c #1850): `[]` sits in the middle, e.g.
+ *    `config.modules[].settings.questionTarget`. The applier walks to
+ *    the array, finds / creates the element matching `arraySelector`,
+ *    then dives into the trailing segments to write a specific key
+ *    inside the matched element. Used for G8 module-scoped settings.
+ *
  * The applier is pure — call it from inside `updatePlaybookConfig`'s
  * transformer.
  */
@@ -45,6 +55,13 @@ export interface ResolvedPath {
   segments: readonly string[];
   /** When structured: the array-item selector (kind/id) and value. */
   arraySelector: { key: string; value: string } | null;
+  /** Index into `segments` of the array marker `[]`, when present. Used
+   *  by `applyAtPath` to distinguish a final-segment array
+   *  (e.g. `sessionFlow.stops[]`) from a mid-path array
+   *  (e.g. `config.modules[].settings.questionTarget`). Defaults to the
+   *  final-segment behaviour when omitted. P3c (#1850) wired the
+   *  mid-path traversal for G8 module-scoped writes. */
+  arraySegmentIndex: number | null;
   /** Write mode — "merge" shallow-merges into the parent, "replace" overwrites. */
   writeMode: "merge" | "replace";
 }
@@ -57,56 +74,54 @@ export function resolveStoragePath(storage: StoragePath): ResolvedPath {
   const writeMode: "merge" | "replace" =
     isStruct(storage) && storage.writeMode === "merge" ? "merge" : "replace";
 
-  // Detect root and strip the placeholder `[]` if present.
-  if (path.startsWith("config.")) {
+  // Detect root, then capture the array-marker index BEFORE stripping
+  // brackets so `applyAtPath` can tell mid-path arrays from
+  // final-segment arrays.
+  function buildAfter(rootStripped: string, root: StorageRoot): ResolvedPath {
+    const rawParts = rootStripped.split(".");
+    let arraySegmentIndex: number | null = null;
+    for (let i = 0; i < rawParts.length; i++) {
+      if (rawParts[i].endsWith("[]")) {
+        arraySegmentIndex = i;
+        break;
+      }
+    }
     return {
-      root: "config",
-      segments: stripBrackets(path.slice("config.".length).split(".")),
+      root,
+      segments: stripBrackets(rawParts),
       arraySelector,
+      arraySegmentIndex,
       writeMode,
     };
+  }
+
+  if (path.startsWith("config.")) {
+    return buildAfter(path.slice("config.".length), "config");
   }
   if (path.startsWith("sessionFlow.")) {
-    return {
-      root: "sessionFlow",
-      segments: stripBrackets(path.slice("sessionFlow.".length).split(".")),
-      arraySelector,
-      writeMode,
-    };
+    return buildAfter(path.slice("sessionFlow.".length), "sessionFlow");
   }
   if (path.startsWith("tolerances.")) {
-    return {
-      root: "tolerances",
-      segments: stripBrackets(path.slice("tolerances.".length).split(".")),
-      arraySelector,
-      writeMode,
-    };
+    return buildAfter(path.slice("tolerances.".length), "tolerances");
   }
   if (path.startsWith("playbook.voiceConfig.")) {
-    return {
-      root: "playbook.voiceConfig",
-      segments: stripBrackets(path.slice("playbook.voiceConfig.".length).split(".")),
-      arraySelector,
-      writeMode,
-    };
+    return buildAfter(path.slice("playbook.voiceConfig.".length), "playbook.voiceConfig");
   }
   if (path.startsWith("domain.")) {
-    return {
-      root: "domain",
-      segments: stripBrackets(path.slice("domain.".length).split(".")),
-      arraySelector,
-      writeMode,
-    };
+    return buildAfter(path.slice("domain.".length), "domain");
   }
   if (path.startsWith("behaviorTargets")) {
+    // behaviorTargets keeps the legacy split-on-dot behaviour; the array
+    // marker sits inside the bracket-segment itself, not as a trailing `[]`.
     return {
       root: "behaviorTargets",
       segments: stripBrackets(path.split(".")),
       arraySelector,
+      arraySegmentIndex: null,
       writeMode,
     };
   }
-  return { root: "unknown", segments: [], arraySelector, writeMode };
+  return { root: "unknown", segments: [], arraySelector, arraySegmentIndex: null, writeMode };
 }
 
 /** Apply a value at the resolved path inside a PlaybookConfig clone. */
@@ -138,6 +153,68 @@ export function applyAtPath(
       // Caller handles these — leave the config untouched. The PATCH
       // route returns 501 / 400 for these cases.
       return config;
+  }
+
+  // Mid-path array (P3c, #1850): `config.modules[].settings.<key>` where
+  // `modules` is the array and `settings.<key>` lives WITHIN each
+  // matched element. Walk up to the array segment, locate / create the
+  // matching element, then dive into its trailing segments. The
+  // final-segment array branch below handles the legacy
+  // `sessionFlow.stops[]` case (array IS the final segment).
+  const lastIdx = resolved.segments.length - 1;
+  if (
+    resolved.arraySelector &&
+    resolved.arraySegmentIndex !== null &&
+    resolved.arraySegmentIndex < lastIdx
+  ) {
+    // Walk segments up to (but not including) the array segment as objects.
+    for (let i = 0; i < resolved.arraySegmentIndex; i++) {
+      parent = ensureObject(parent, resolved.segments[i]);
+    }
+    // The array segment itself.
+    const arrayKey = resolved.segments[resolved.arraySegmentIndex];
+    const arr = ensureArray(parent, arrayKey);
+    let idx = arr.findIndex(
+      (it) =>
+        typeof it === "object" &&
+        it !== null &&
+        (it as Record<string, unknown>)[resolved.arraySelector!.key] ===
+          resolved.arraySelector!.value,
+    );
+    if (idx === -1) {
+      // Element doesn't yet exist → seed it with the selector key.
+      arr.push({
+        [resolved.arraySelector.key]: resolved.arraySelector.value,
+      });
+      idx = arr.length - 1;
+    }
+    let element = arr[idx] as Record<string, unknown>;
+    if (typeof element !== "object" || element === null) {
+      element = { [resolved.arraySelector.key]: resolved.arraySelector.value };
+      arr[idx] = element;
+    }
+    // Walk the trailing segments WITHIN the matched element.
+    let cursor: Record<string, unknown> = element;
+    for (let i = resolved.arraySegmentIndex + 1; i < lastIdx; i++) {
+      cursor = ensureObject(cursor, resolved.segments[i]);
+    }
+    const finalKey = resolved.segments[lastIdx];
+    if (!finalKey) return config;
+    if (
+      resolved.writeMode === "merge" &&
+      typeof value === "object" &&
+      value !== null &&
+      typeof cursor[finalKey] === "object" &&
+      cursor[finalKey] !== null
+    ) {
+      cursor[finalKey] = {
+        ...(cursor[finalKey] as Record<string, unknown>),
+        ...(value as Record<string, unknown>),
+      };
+    } else {
+      cursor[finalKey] = value;
+    }
+    return config;
   }
 
   // Walk segments creating intermediate objects.

--- a/apps/admin/tests/api/courses/journey-setting-route.test.ts
+++ b/apps/admin/tests/api/courses/journey-setting-route.test.ts
@@ -166,4 +166,91 @@ describe("PATCH /api/courses/[courseId]/journey-setting — Phase 2 #1687", () =
     expect(body.compoundOwnedSave).toBe(true);
     expect(body.bumpedSections).toEqual([]);
   });
+
+  // ===========================================================
+  // P3c (#1850) — module-scope writes (G8) via arraySelector
+  // ===========================================================
+
+  it("P3c: G8 module-scoped write succeeds when arraySelector supplied", async () => {
+    const updaters: Array<(c: Record<string, unknown>) => Record<string, unknown>> = [];
+    const ucMod = await import("@/lib/playbook/update-playbook-config");
+    vi.mocked(ucMod.updatePlaybookConfig).mockImplementationOnce(
+      async (_playbookId: string, transform: (c: Record<string, unknown>) => Record<string, unknown>) => {
+        updaters.push(transform);
+        const initial: Record<string, unknown> = {
+          modules: [
+            { id: "part1", settings: { questionTarget: { min: 8, target: 10 } } },
+            { id: "part2", settings: {} },
+          ],
+        };
+        transform(initial);
+        return {
+          playbook: { config: initial } as unknown as Awaited<ReturnType<typeof ucMod.updatePlaybookConfig>>["playbook"],
+          composeAffectingChanged: true,
+          timestampBumped: true,
+          fanoutScope: "none",
+        };
+      },
+    );
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({
+        settingId: "moduleQuestionTarget",
+        value: { min: 12, target: 15 },
+        arraySelector: "part1",
+      }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.effectiveValue).toEqual({ min: 12, target: 15 });
+    // The transformer captured the write — re-running it on a fresh
+    // config proves the path resolved correctly onto part1, not part2,
+    // not the root.
+    const fresh: Record<string, unknown> = {
+      modules: [
+        { id: "part1", settings: { questionTarget: { min: 8, target: 10 } } },
+        { id: "part2", settings: {} },
+      ],
+    };
+    updaters[0](fresh);
+    const mods = fresh.modules as Array<{ id: string; settings: Record<string, unknown> }>;
+    expect(mods[0].id).toBe("part1");
+    expect(mods[0].settings.questionTarget).toEqual({ min: 12, target: 15 });
+    // part2 untouched
+    expect(mods[1].settings).toEqual({});
+  });
+
+  it("P3c: G8 write 400s when arraySelector missing (per-instance contract)", async () => {
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({
+        settingId: "moduleQuestionTarget",
+        value: { min: 12, target: 15 },
+      }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("ARRAY_SELECTOR_REQUIRED");
+  });
+
+  it("P3c: arraySelector on a non-array contract is ignored (backwards-compat)", async () => {
+    // welcomeMessage is a string-path contract — supplying arraySelector
+    // must not break the legacy path.
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({
+        settingId: "welcomeMessage",
+        value: "hello",
+        arraySelector: "ignored-id",
+      }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.effectiveValue).toBe("hello");
+  });
 });

--- a/apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx
+++ b/apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx
@@ -135,7 +135,7 @@ describe("CourseModulesTab — P3 (#1850) Inspector wiring", () => {
     ).toBeInTheDocument();
   });
 
-  it("surfaces the read-only banner when a module is selected", async () => {
+  it("surfaces the course-wide-preview banner only — P3c (#1850) removed the Inspector read-only banner", async () => {
     render(<CourseModulesTab courseId="c1" courseStyle="structured" />);
     const row = await waitFor(() =>
       screen.getByTestId("hf-modules-row-part1"),
@@ -144,13 +144,18 @@ describe("CourseModulesTab — P3 (#1850) Inspector wiring", () => {
     await waitFor(() =>
       screen.getByTestId("hf-module-inspector-part1"),
     );
-    // Inspector banner + canvas banner both surface that saves + preview
-    // are deferred to follow-on PRs.
-    expect(
-      screen.getByText(/Read-only preview/i),
-    ).toBeInTheDocument();
+    // The canvas-side "Showing course-wide preview" banner persists
+    // until the preview-scope follow-on lands.
     expect(
       screen.getByText(/Showing course-wide preview/i),
     ).toBeInTheDocument();
+    // The Inspector-side "Read-only preview" banner is GONE — the
+    // mutator is wired in P3c.
+    expect(
+      screen.queryByText(/Read-only preview/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/module-scope writer ships in a follow-on/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx
+++ b/apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 
 import { ModuleInspectorPanel } from "@/components/modules-tab/ModuleInspectorPanel";
 
@@ -11,10 +11,10 @@ describe("ModuleInspectorPanel — P3 (#1850)", () => {
   it("renders the empty-state when selectedModuleId is null", () => {
     render(
       <ModuleInspectorPanel
+        courseId="course-1"
         selectedModuleId={null}
         selectedModuleLabel={null}
         settings={null}
-        onSaveAttempt={vi.fn()}
       />,
     );
     expect(
@@ -28,10 +28,10 @@ describe("ModuleInspectorPanel — P3 (#1850)", () => {
   it("renders G8 rows when a module is selected", () => {
     render(
       <ModuleInspectorPanel
+        courseId="course-1"
         selectedModuleId="part1"
         selectedModuleLabel="Part 1 — Interview"
         settings={{ questionTarget: { min: 10, target: 13 } }}
-        onSaveAttempt={vi.fn()}
       />,
     );
     // Container keyed on the selected module id.
@@ -50,20 +50,131 @@ describe("ModuleInspectorPanel — P3 (#1850)", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the deferred-writer banner so saves do not look silent", () => {
+  it("does NOT render the deferred-writer banner — P3c (#1850) wired the writer", () => {
     render(
       <ModuleInspectorPanel
+        courseId="course-1"
         selectedModuleId="part1"
         selectedModuleLabel="Part 1"
         settings={null}
-        onSaveAttempt={vi.fn()}
       />,
     );
     expect(
-      screen.getByText(/Read-only preview/i),
-    ).toBeInTheDocument();
+      screen.queryByText(/Read-only preview/i),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/module-scope writer ships in a follow-on/i),
-    ).toBeInTheDocument();
+      screen.queryByText(/module-scope writer ships in a follow-on/i),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("ModuleInspectorPanel — P3c mutator wiring (#1850)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          effectiveValue: "x",
+          autoEnabled: [],
+          bumpedSections: ["instructions"],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("PATCHes /journey-setting with {settingId, value, arraySelector: moduleId} on save", async () => {
+    const onSaved = vi.fn();
+    render(
+      <ModuleInspectorPanel
+        courseId="course-1"
+        selectedModuleId="part1"
+        selectedModuleLabel="Part 1"
+        settings={{ closingLine: "Goodbye!" }}
+        onSaved={onSaved}
+      />,
+    );
+
+    // The closingLine G8 field is a text control; type into it then blur
+    // (JourneyField wires onSave on commit-style events depending on
+    // control). Easier path: fire a change + blur on a text input the
+    // row renders.
+    const row = screen.getByTestId(
+      "hf-module-inspector-row-moduleClosingLine",
+    );
+    const inputs = row.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>(
+      "input, textarea",
+    );
+    expect(inputs.length).toBeGreaterThan(0);
+    const field = inputs[0];
+    fireEvent.change(field, { target: { value: "See you next time" } });
+    fireEvent.blur(field);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/courses/course-1/journey-setting");
+    expect((init as RequestInit).method).toBe("PATCH");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.settingId).toBe("moduleClosingLine");
+    expect(body.arraySelector).toBe("part1");
+    expect(body.value).toBe("See you next time");
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalled();
+    });
+  });
+
+  it("does NOT call onSaved when the PATCH fails (failed save surfaces via JourneyField commit hook)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ ok: false, error: "boom", code: "X" }),
+        { status: 500, headers: { "content-type": "application/json" } },
+      ),
+    );
+    // The mutator throws on non-2xx; JourneyField re-raises into its
+    // commit hook (consumed by the wrapping editor as a toast trigger).
+    // For unit-test purposes the relevant invariant is: `onSaved` must
+    // NOT fire. We register a no-op unhandled-rejection listener so the
+    // rejection doesn't pollute the test runner's failure surface.
+    const swallow = () => undefined;
+    process.on("unhandledRejection", swallow);
+    try {
+      const onSaved = vi.fn();
+      render(
+        <ModuleInspectorPanel
+          courseId="course-1"
+          selectedModuleId="part1"
+          selectedModuleLabel="Part 1"
+          settings={{ closingLine: "Goodbye!" }}
+          onSaved={onSaved}
+        />,
+      );
+      const row = screen.getByTestId(
+        "hf-module-inspector-row-moduleClosingLine",
+      );
+      const field = row.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+        "input, textarea",
+      );
+      expect(field).not.toBeNull();
+      fireEvent.change(field!, { target: { value: "x" } });
+      fireEvent.blur(field!);
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+      // Give the microtask queue a tick so the rejected promise settles
+      // BEFORE we assert + clean up the listener.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(onSaved).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", swallow);
+    }
   });
 });

--- a/apps/admin/tests/lib/journey/storage-path-applier.test.ts
+++ b/apps/admin/tests/lib/journey/storage-path-applier.test.ts
@@ -133,3 +133,92 @@ describe("applyAtPath", () => {
     expect(stops[0].trigger).toEqual({ type: "first" });
   });
 });
+
+describe("applyAtPath — mid-path arrays (P3c #1850)", () => {
+  it("writes into the matching array element for config.modules[].settings.<key>", () => {
+    const config: PlaybookConfig = {
+      modules: [
+        { id: "part1", settings: { questionTarget: { min: 8, target: 10 } } },
+        { id: "part2", settings: {} },
+      ],
+    } as unknown as PlaybookConfig;
+    const resolved = {
+      ...resolveStoragePath({
+        path: "config.modules[].settings.questionTarget",
+        arrayKey: "id",
+      }),
+      arraySelector: { key: "id", value: "part1" },
+    };
+    applyAtPath(config, resolved, { min: 12, target: 15 });
+    const mods = (config as unknown as { modules: Array<Record<string, unknown>> }).modules;
+    expect(mods).toHaveLength(2);
+    expect(mods[0].id).toBe("part1");
+    expect((mods[0].settings as Record<string, unknown>).questionTarget).toEqual({
+      min: 12,
+      target: 15,
+    });
+    expect(mods[1].settings).toEqual({});
+  });
+
+  it("creates the matching array element when not yet present", () => {
+    const config: PlaybookConfig = {} as PlaybookConfig;
+    const resolved = {
+      ...resolveStoragePath({
+        path: "config.modules[].settings.closingLine",
+        arrayKey: "id",
+      }),
+      arraySelector: { key: "id", value: "part2" },
+    };
+    applyAtPath(config, resolved, "See you next time!");
+    const mods = (config as unknown as { modules: Array<Record<string, unknown>> }).modules;
+    expect(mods).toHaveLength(1);
+    expect(mods[0].id).toBe("part2");
+    expect((mods[0].settings as Record<string, unknown>).closingLine).toBe(
+      "See you next time!",
+    );
+  });
+
+  it("creates intermediate `settings` sub-object when missing", () => {
+    const config: PlaybookConfig = {
+      modules: [{ id: "part1" }],
+    } as unknown as PlaybookConfig;
+    const resolved = {
+      ...resolveStoragePath({
+        path: "config.modules[].settings.minSpeakingSec",
+        arrayKey: "id",
+      }),
+      arraySelector: { key: "id", value: "part1" },
+    };
+    applyAtPath(config, resolved, 120);
+    const mods = (config as unknown as { modules: Array<Record<string, unknown>> }).modules;
+    expect((mods[0].settings as Record<string, unknown>).minSpeakingSec).toBe(120);
+  });
+
+  it("resolveStoragePath captures arraySegmentIndex for mid-path arrays", () => {
+    const r = resolveStoragePath({
+      path: "config.modules[].settings.questionTarget",
+      arrayKey: "id",
+    });
+    // segments: ["modules", "settings", "questionTarget"] — the [] is on modules
+    expect(r.segments).toEqual(["modules", "settings", "questionTarget"]);
+    expect(r.arraySegmentIndex).toBe(0);
+  });
+
+  it("resolveStoragePath: arraySegmentIndex is null for non-array paths", () => {
+    const r = resolveStoragePath("config.firstCallMode");
+    expect(r.arraySegmentIndex).toBeNull();
+  });
+
+  it("resolveStoragePath: arraySegmentIndex points at the final segment for sessionFlow.stops[]", () => {
+    const r = resolveStoragePath({
+      path: "sessionFlow.stops[]",
+      arrayKey: "kind",
+      selectorValue: "pre_test",
+    });
+    // segments: ["stops"] — the [] is on the final segment, so the
+    // applier's legacy final-segment array branch handles it (mid-path
+    // branch only fires when arraySegmentIndex < lastIdx).
+    expect(r.arraySegmentIndex).toBe(0);
+    expect(r.segments).toEqual(["stops"]);
+  });
+});


### PR DESCRIPTION
## Summary

P3c of epic #1850 — wire the existing journey-setting mutator into the Module Inspector. Closes the `TODO(module-mutator)` from P3 (PR #1880).

**Reuse-finder finding from the brief overturned the P3 agent's premise that `applyAtPath` doesn't support mid-path arrays.** Reading the code carefully:

- The **route** already handled `applyAtPath` for all roots — but its body schema was `{settingId, value}` with no per-call `arraySelector`, so G8 contracts (whose `storagePath.arrayKey === "id"` is per-instance) had no way to thread `moduleId` through.
- **`applyAtPath` itself** only walked final-segment arrays (`sessionFlow.stops[]`). G8 entries have a mid-path array (`config.modules[].settings.<key>`). The brief's "applier supports mid-path arrays via `arraySelector`" claim is from lines 152-177 — but those handle FINAL-segment arrays only. Verified live by re-reading the function: segments after stripBrackets become `["modules", "settings", "questionTarget"]`, and `arr = ensureArray(parent, "questionTarget")` would treat `questionTarget` as the array — wrong.

So the structural answer is the SAME — extend existing infra rather than building parallel — but BOTH the route body AND the applier needed a small extension. No new route. No new hook. No new mutator file.

## What changed

| File | LOC | Change |
|---|---|---|
| `lib/journey/storage-path-applier.ts` | +95/-19 | `ResolvedPath` gains `arraySegmentIndex`; `applyAtPath` adds mid-path-array branch (walk to array → find/create element → dive into trailing segments). Final-segment branch unchanged. |
| `app/api/courses/[courseId]/journey-setting/route.ts` | +56/-5 | Zod body schema gains optional `arraySelector: string`. When contract's storagePath has `arrayKey` without fixed `selectorValue`, body value becomes the per-call selector value. 400 `ARRAY_SELECTOR_REQUIRED` when missing. Backwards-compatible for fixed-selector + non-array contracts. |
| `components/modules-tab/ModuleInspectorPanel.tsx` | +66/-30 | Inline `handleSave` PATCHes the route with `arraySelector: selectedModuleId`. Drops the "Read-only preview" banner. `onSaved` callback for parent refetch. |
| `components/modules-tab/CourseModulesTab.tsx` | +14/-28 | Removes stub mutator + TODO marker; threads `courseId` + `onSaved` (reload-key bump). |

Total non-test code: **+231/-82 lines** across 4 files. Tests: **+323 lines** (10 new tests across 4 files pinning the new behaviour + protecting the existing).

### Why an inline mutator, not the shared `useJourneySettingMutator` hook

The shared hook's body shape is `{settingId, value}` for every Journey/Teaching/Scoring caller. Threading `arraySelector` through the shared hook would either (a) add a 3rd argument that 99% of callers ignore, or (b) break the hook's call signature. The Module Inspector is the only per-instance-array consumer; inlining the mutator (~30 LOC) is cleaner than rippling a parameter to 11+ renderer consumers. If a second per-instance surface arrives later, the right call is to bump the shared hook then.

### Route was extended, not unchanged

The brief asked "is the route extended or unchanged?" — **extended, one optional body field** (`arraySelector?: string`). Backwards-compatible: existing Journey/Teaching/Scoring callers omit it and the route behaves identically. Pinned by the "arraySelector on a non-array contract is ignored" test.

## Verified by

- `tests/lib/journey/storage-path-applier.test.ts` — 21 tests (5 new) including:
  - `applyAtPath — mid-path arrays (P3c #1850) → writes into the matching array element for config.modules[].settings.<key>`
  - `applyAtPath — mid-path arrays → creates the matching array element when not yet present`
  - `applyAtPath — mid-path arrays → creates intermediate settings sub-object when missing`
  - `resolveStoragePath captures arraySegmentIndex for mid-path arrays`
  - `arraySegmentIndex points at the final segment for sessionFlow.stops[]` (legacy regression guard)
- `tests/api/courses/journey-setting-route.test.ts` — 13 tests (3 new) including:
  - `P3c: G8 module-scoped write succeeds when arraySelector supplied` — re-runs captured transformer on fresh state, proves part1.settings.questionTarget got the update and part2 untouched
  - `P3c: G8 write 400s when arraySelector missing (per-instance contract)` — code `ARRAY_SELECTOR_REQUIRED`
  - `P3c: arraySelector on a non-array contract is ignored (backwards-compat)`
- `tests/components/modules-tab/ModuleInspectorPanel.test.tsx` — 5 tests (2 new):
  - `PATCHes /journey-setting with {settingId, value, arraySelector: moduleId} on save` — pins URL, method, body shape
  - `does NOT render the deferred-writer banner — P3c (#1850) wired the writer`
- `tests/components/modules-tab/CourseModulesTab.test.tsx` — last test updated to assert banner-gone.
- `npx tsc --noEmit` on `apps/admin/` clean on all 8 touched files; total error count drops 41→40 (-1 under baseline).
- `npx eslint <8 touched files>` clean — zero errors on touched surface.
- All 44 tests across `tests/components/modules-tab/`, `tests/api/courses/journey-setting-route.test.ts`, `tests/lib/journey/storage-path-applier.test.ts` pass.
- Wider sweep: 276/276 tests pass across `tests/lib/journey/`, `tests/components/journey-tab/`, `tests/components/journey-controls/`, `tests/components/modules-tab/`, `tests/api/courses/` — no regressions in sibling Journey/Teaching/Scoring surfaces.
- **Lattice survey**: writes go through the existing chokepoint (`updatePlaybookConfig` → `applyAtPath`). No sibling-writer drift (one chokepoint). Default-deny respected — G8 `appliesTo: ["structured","exam"]`; continuous courses guard via empty state in `CourseModulesTab.tsx:101`. Cascade: G8 has empty `cascadeSources` — no provenance to lose. No convention conflict.

## Test plan

- [x] Unit tests green (44/44 on direct surface, 276/276 on wider Journey sweep)
- [x] tsc clean on touched files; total drops 1
- [x] Lint clean on touched files
- [x] Banner removed from Inspector
- [x] `TODO(module-mutator)` removed from both files
- [ ] Manual verification on hf-dev: edit G8 field in Modules Inspector → reload → value persists. Pending operator load — `/vm-cp`.

Refs #1850
