### PR TITLE
chore(rbac): replace magic role arrays with ROLE_LEVEL primitives

### DIFF
--- a/apps/admin/app/api/dashboard/route.ts
+++ b/apps/admin/app/api/dashboard/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { isOperatorTrackAdmin } from "@/lib/roles";
 
 /**
  * @api GET /api/dashboard
@@ -21,7 +22,7 @@ export async function GET() {
 
     const role = session.user.role;
     const userId = session.user.id;
-    const isAdmin = ["SUPERADMIN", "ADMIN", "OPERATOR"].includes(role);
+    const isAdmin = isOperatorTrackAdmin(role);
     const isSuperAdmin = role === "SUPERADMIN";
     const isTester = ["TESTER", "VIEWER", "SUPER_TESTER"].includes(role);
     const isSuperTester = role === "SUPER_TESTER";

--- a/apps/admin/app/x/_dashboards/dashboard-config.ts
+++ b/apps/admin/app/x/_dashboards/dashboard-config.ts
@@ -307,9 +307,9 @@ export function getConfigForRole(role: string): DashboardRoleConfig {
   return DASHBOARD_CONFIGS[role] ?? DASHBOARD_CONFIGS.ADMIN;
 }
 
-/** Roles that are considered "admin-level" (OPERATOR+) */
-const ADMIN_ROLES = new Set(["SUPERADMIN", "ADMIN", "OPERATOR"]);
-
-export function isAdminRole(role: string): boolean {
-  return ADMIN_ROLES.has(role);
-}
+/**
+ * Roles that get the OPERATOR-track admin dashboard.
+ * Re-exported from `lib/roles.ts` — see `isOperatorTrackAdmin` for the
+ * documented EDUCATOR-exclusion rationale.
+ */
+export { isOperatorTrackAdmin as isAdminRole } from "@/lib/roles";

--- a/apps/admin/contexts/ViewModeContext.tsx
+++ b/apps/admin/contexts/ViewModeContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback } from "react";
 import { useSession } from "next-auth/react";
+import { isRoleAtOrAbove } from "@/lib/roles";
 
 export type ViewModePreference = "auto" | "simple" | "advanced";
 
@@ -15,9 +16,6 @@ const ViewModeContext = createContext<ViewModeContextValue | null>(null);
 
 const STORAGE_KEY = "hf.viewMode";
 
-/** Roles at level >= 3 default to advanced when preference is "auto" */
-const ADVANCED_ROLES = new Set(["SUPERADMIN", "ADMIN", "OPERATOR", "EDUCATOR"]);
-
 function getStoredPreference(): ViewModePreference {
   if (typeof window === "undefined") return "auto";
   const stored = localStorage.getItem(STORAGE_KEY);
@@ -30,8 +28,8 @@ function getStoredPreference(): ViewModePreference {
 function resolveAdvanced(preference: ViewModePreference, role: string | undefined): boolean {
   if (preference === "simple") return false;
   if (preference === "advanced") return true;
-  // "auto" — resolve from role
-  return ADVANCED_ROLES.has(role ?? "");
+  // "auto" — OPERATOR+ (level >= 3) defaults to advanced; EDUCATOR also qualifies
+  return isRoleAtOrAbove(role, "OPERATOR");
 }
 
 export function ViewModeProvider({ children }: { children: React.ReactNode }) {

--- a/apps/admin/lib/roles.ts
+++ b/apps/admin/lib/roles.ts
@@ -19,3 +19,56 @@ export const ROLE_LEVEL: Record<UserRole, number> = {
   DEMO: 0,
   VIEWER: 1, // @deprecated — alias for TESTER level
 };
+
+/**
+ * Runtime check: does the role have at-or-above the given minimum level?
+ *
+ * Use this instead of hand-rolling `["SUPERADMIN", "ADMIN", ...].includes(role)`.
+ * Adding a new role at the same level works automatically.
+ *
+ *   isRoleAtOrAbove("EDUCATOR", "OPERATOR") // true  (both level 3)
+ *   isRoleAtOrAbove("TESTER",   "OPERATOR") // false (level 1 vs 3)
+ */
+export function isRoleAtOrAbove(
+  role: UserRole | string | null | undefined,
+  minRole: UserRole,
+): boolean {
+  if (!role) return false;
+  const userLevel = ROLE_LEVEL[role as UserRole] ?? 0;
+  const minLevel = ROLE_LEVEL[minRole] ?? 0;
+  return userLevel >= minLevel;
+}
+
+/**
+ * "Operator-track admin" — SUPERADMIN, ADMIN, OPERATOR.
+ *
+ * NOTE: This deliberately excludes EDUCATOR even though EDUCATOR is at
+ * level 3 (same as OPERATOR per `ROLE_LEVEL`). EDUCATOR is a separate
+ * track with its own portal under `app/educator/` and does not see the
+ * OPERATOR-track dashboard. This is a track distinction, not a level one.
+ *
+ * For pure level checks that should include EDUCATOR, use
+ * `isRoleAtOrAbove(role, "OPERATOR")` instead.
+ */
+export function isOperatorTrackAdmin(
+  role: UserRole | string | null | undefined,
+): boolean {
+  return role === "SUPERADMIN" || role === "ADMIN" || role === "OPERATOR";
+}
+
+/**
+ * List the UserRole members at-or-above the given minimum level.
+ *
+ * Use this in Prisma `where: { role: { in: rolesAtOrAbove("OPERATOR") } }`
+ * — the result is suitable for any consumer that needs a literal enum-value
+ * array (Prisma queries cannot filter on a computed level).
+ *
+ *   rolesAtOrAbove("ADMIN")    // ["SUPERADMIN", "ADMIN"]
+ *   rolesAtOrAbove("OPERATOR") // ["SUPERADMIN", "ADMIN", "OPERATOR", "EDUCATOR"]
+ */
+export function rolesAtOrAbove(minRole: UserRole): UserRole[] {
+  const minLevel = ROLE_LEVEL[minRole] ?? 0;
+  return (Object.keys(ROLE_LEVEL) as UserRole[]).filter(
+    (r) => ROLE_LEVEL[r] >= minLevel && r !== "VIEWER", // exclude deprecated alias
+  );
+}

--- a/apps/admin/lib/system-ini.ts
+++ b/apps/admin/lib/system-ini.ts
@@ -7,6 +7,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { config } from "@/lib/config";
+import { rolesAtOrAbove } from "@/lib/roles";
 
 // ============================================================
 // Types
@@ -368,7 +369,7 @@ async function checkContracts(): Promise<IniCheck> {
 
 async function checkAdminUser(): Promise<IniCheck> {
   const adminCount = await prisma.user.count({
-    where: { role: { in: ["SUPERADMIN", "ADMIN"] } },
+    where: { role: { in: rolesAtOrAbove("ADMIN") } },
   });
 
   if (adminCount === 0) {

--- a/apps/admin/tests/lib/roles.test.ts
+++ b/apps/admin/tests/lib/roles.test.ts
@@ -1,0 +1,130 @@
+/**
+ * lib/roles — pin level math + adoption ratchet for the new helpers.
+ *
+ * **What this test pins:**
+ *  1. ROLE_LEVEL members + ordering (schema additions force a test
+ *     update — surprising drift becomes loud).
+ *  2. `isRoleAtOrAbove` answers correctly across the 9 roles.
+ *  3. `rolesAtOrAbove` excludes the deprecated VIEWER alias.
+ *  4. `isOperatorTrackAdmin` preserves the EDUCATOR exclusion that
+ *     distinguishes "OPERATOR-track admin dashboard" from a pure level
+ *     check.
+ *  5. **Ratchet:** no consumer under `apps/admin/{app,lib,contexts}`
+ *     reconstructs a role membership Set / array containing the
+ *     SUPERADMIN+ADMIN+OPERATOR triplet — those should use
+ *     `isOperatorTrackAdmin` from `@/lib/roles`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import {
+  ROLE_LEVEL,
+  isRoleAtOrAbove,
+  rolesAtOrAbove,
+  isOperatorTrackAdmin,
+} from "@/lib/roles";
+
+const REPO_ADMIN = resolve(__dirname, "..", "..");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (
+      (entry.endsWith(".ts") || entry.endsWith(".tsx")) &&
+      !entry.endsWith(".test.ts") &&
+      !entry.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("lib/roles — RBAC level math", () => {
+  it("ROLE_LEVEL has 9 known members with the documented hierarchy", () => {
+    expect(ROLE_LEVEL).toEqual({
+      SUPERADMIN: 5,
+      ADMIN: 4,
+      OPERATOR: 3,
+      EDUCATOR: 3,
+      SUPER_TESTER: 2,
+      TESTER: 1,
+      STUDENT: 1,
+      DEMO: 0,
+      VIEWER: 1,
+    });
+  });
+
+  it("isRoleAtOrAbove — OPERATOR threshold lets EDUCATOR through", () => {
+    expect(isRoleAtOrAbove("EDUCATOR", "OPERATOR")).toBe(true);
+    expect(isRoleAtOrAbove("OPERATOR", "OPERATOR")).toBe(true);
+    expect(isRoleAtOrAbove("ADMIN", "OPERATOR")).toBe(true);
+    expect(isRoleAtOrAbove("TESTER", "OPERATOR")).toBe(false);
+    expect(isRoleAtOrAbove("STUDENT", "OPERATOR")).toBe(false);
+    expect(isRoleAtOrAbove(undefined, "OPERATOR")).toBe(false);
+  });
+
+  it("rolesAtOrAbove excludes the deprecated VIEWER alias", () => {
+    expect(rolesAtOrAbove("ADMIN").sort()).toEqual(["ADMIN", "SUPERADMIN"]);
+    expect(rolesAtOrAbove("OPERATOR").sort()).toEqual([
+      "ADMIN",
+      "EDUCATOR",
+      "OPERATOR",
+      "SUPERADMIN",
+    ]);
+    expect(rolesAtOrAbove("TESTER")).not.toContain("VIEWER");
+  });
+
+  it("isOperatorTrackAdmin preserves the EDUCATOR-exclusion track distinction", () => {
+    expect(isOperatorTrackAdmin("SUPERADMIN")).toBe(true);
+    expect(isOperatorTrackAdmin("ADMIN")).toBe(true);
+    expect(isOperatorTrackAdmin("OPERATOR")).toBe(true);
+    // EDUCATOR is level 3 (same as OPERATOR) but excluded — separate portal.
+    expect(isOperatorTrackAdmin("EDUCATOR")).toBe(false);
+    expect(isOperatorTrackAdmin("TESTER")).toBe(false);
+    expect(isOperatorTrackAdmin(undefined)).toBe(false);
+  });
+
+  it("no consumer reconstructs the OPERATOR-track role triplet inline", () => {
+    // Looks for the specific 3-role inline set/array pattern. Subset arrays
+    // (e.g. testing matrices, role-iteration loops) are excluded.
+    const PATTERN =
+      /\[\s*"SUPERADMIN"\s*,\s*"ADMIN"\s*,\s*"OPERATOR"\s*\]|new Set\(\s*\[\s*"SUPERADMIN"\s*,\s*"ADMIN"\s*,\s*"OPERATOR"\s*\]\s*\)/;
+    const offenders: { file: string; line: number; text: string }[] = [];
+    const roots = ["app", "lib", "contexts"];
+    for (const root of roots) {
+      const rootDir = join(REPO_ADMIN, root);
+      try {
+        statSync(rootDir);
+      } catch {
+        continue;
+      }
+      for (const file of walk(rootDir)) {
+        const src = readFileSync(file, "utf8");
+        if (!PATTERN.test(src)) continue;
+        src.split("\n").forEach((line, idx) => {
+          if (PATTERN.test(line)) {
+            offenders.push({
+              file: file.replace(REPO_ADMIN + "/", ""),
+              line: idx + 1,
+              text: line.trim(),
+            });
+          }
+        });
+      }
+    }
+    expect(
+      offenders,
+      `OPERATOR-track triplet hardcoded — use \`isOperatorTrackAdmin\` from @/lib/roles:\n${offenders
+        .map((o) => `  ${o.file}:${o.line}  ${o.text}`)
+        .join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -107,6 +107,7 @@ Three structural patterns, in order of preference:
 | Transform behavior-target neutral fallback | `lib/measurement/neutral-target.ts::NEUTRAL_PARAMETER_TARGET` | composition transforms (`quickstart.ts`, `identity.ts`) | ✅ PROTECTED | `tests/lib/measurement/neutral-target.test.ts` (#1880) | — | Named const replaces bare `?? 0.5`; ratchet rejects new offenders in `lib/prompt/composition/transforms/`. |
 | `PlaybookCurriculumRole` enum adoption | `@prisma/client::PlaybookCurriculumRole` | 38 consumers under `apps/admin/{app,lib,scripts}` | ✅ PROTECTED | `tests/lib/playbook-curriculum-role-adoption.test.ts` | — | Ratchet rejects bare `role: "primary"` / `role: "linked"` literals across app, lib, scripts. |
 | `MemoryCategory` enum adoption | `@prisma/client::MemoryCategory` | `lib/chat/commands.ts` + `differentiation/route.ts` | ✅ PROTECTED | `tests/lib/memory-category-adoption.test.ts` | — | Ratchet rejects 6-permutation literal reconstructions. |
+| RBAC role-level adoption (no magic role arrays) | `lib/roles.ts` (`ROLE_LEVEL` + `isRoleAtOrAbove` + `rolesAtOrAbove` + `isOperatorTrackAdmin`) | 4 sites: `ViewModeContext`, `dashboard-config`, `dashboard/route`, `system-ini` | ✅ PROTECTED | `tests/lib/roles.test.ts` | — | Ratchet rejects new `["SUPERADMIN","ADMIN","OPERATOR"]` triplet literals in `app`/`lib`/`contexts`. EDUCATOR exclusion documented (track distinction, not level). |
 
 ### Cascade
 


### PR DESCRIPTION
## Summary

Outrageous-hardcoding sweep #4 — RBAC adoption. 4 sites hardcoded `["SUPERADMIN", "ADMIN", "OPERATOR"]`-style arrays duplicating the role hierarchy that `lib/roles.ts::ROLE_LEVEL` already canonicalises. Adding a new role at the right level silently misses every gate.

Changes:
- `lib/roles.ts` — 3 new primitives:
  - `isRoleAtOrAbove(role, minRole)` — boolean level check
  - `rolesAtOrAbove(minRole)` — `UserRole[]` suitable for Prisma `where.role.in`
  - `isOperatorTrackAdmin(role)` — named primitive for the EDUCATOR-excluding OPERATOR-track admin distinction
- `contexts/ViewModeContext.tsx` — `ADVANCED_ROLES` Set → `isRoleAtOrAbove(role, "OPERATOR")`
- `app/x/_dashboards/dashboard-config.ts` — inline `ADMIN_ROLES` Set → re-export `isOperatorTrackAdmin` as `isAdminRole` for backward compat
- `app/api/dashboard/route.ts` — `["SUPERADMIN","ADMIN","OPERATOR"].includes(role)` → `isOperatorTrackAdmin(role)`
- `lib/system-ini.ts` — Prisma `where: { role: { in: ["SUPERADMIN","ADMIN"] } }` → `rolesAtOrAbove("ADMIN")`

## Verified by

- `npx vitest run tests/lib/roles.test.ts` → 5/5 pass.
- `npx vitest run tests/lib/lattice-self-maintenance.test.ts` → 9/9 pass.
- `npx tsc --noEmit` → 36 errors (== current baseline).
- `grep -rn '"SUPERADMIN".*"ADMIN".*"OPERATOR"' apps/admin/{app,lib,contexts}` → 0 magic-triplet matches post-migration; only documented single-role equality checks remain.

## Lattice survey

- Surface: hand-typed role hierarchy literals vs canonical `ROLE_LEVEL`.
- Sibling writers: `lib/permissions.ts` already uses `ROLE_LEVEL` correctly; the 4 violating sites bypassed it.
- Convergence: RBAC primitives + ratchet vitest + inventory row.
- EDUCATOR exclusion: documented and named (track distinction). `isRoleAtOrAbove` covers pure level checks for callers that should include EDUCATOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)