### PR TITLE
chore(constants): TEACHING_CALLER_ROLES + DEFAULT_VOICE_PROVIDER_SLUG

### DIFF
--- a/apps/admin/app/api/cohorts/route.ts
+++ b/apps/admin/app/api/cohorts/route.ts
@@ -6,6 +6,7 @@ import {
   buildScopeFilter,
 } from "@/lib/access-control";
 import { parsePagination } from "@/lib/api-utils";
+import { isTeachingCallerRole } from "@/lib/caller-roles";
 
 /**
  * @api GET /api/cohorts
@@ -163,7 +164,7 @@ export async function POST(req: Request) {
         { status: 404 }
       );
     }
-    if (owner.role !== "TEACHER" && owner.role !== "TUTOR") {
+    if (!isTeachingCallerRole(owner.role)) {
       return NextResponse.json(
         { ok: false, error: "Owner must have TEACHER or TUTOR role" },
         { status: 400 }

--- a/apps/admin/app/api/courses/[courseId]/learners/ensure-cohort/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/learners/ensure-cohort/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { TEACHING_CALLER_ROLES } from "@/lib/caller-roles";
 
 /**
  * @api POST /api/courses/:courseId/learners/ensure-cohort
@@ -56,7 +57,7 @@ export async function POST(
     // 3. Find-or-create a teacher caller for the admin (required as cohort owner)
     const session = auth.session;
     let ownerCaller = await prisma.caller.findFirst({
-      where: { userId: session.user.id, domainId: playbook.domainId, role: { in: ["TEACHER", "TUTOR"] } },
+      where: { userId: session.user.id, domainId: playbook.domainId, role: { in: TEACHING_CALLER_ROLES } },
       select: { id: true },
     });
     if (!ownerCaller) {

--- a/apps/admin/app/api/domains/[domainId]/classroom/route.ts
+++ b/apps/admin/app/api/domains/[domainId]/classroom/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { randomUUID } from "crypto";
 import { assignPlaybookToCohort } from "@/lib/enrollment";
+import { TEACHING_CALLER_ROLES } from "@/lib/caller-roles";
 
 /**
  * @api POST /api/domains/:domainId/classroom
@@ -48,7 +49,7 @@ export async function POST(
       where: {
         userId: session.user.id,
         domainId,
-        role: { in: ["TEACHER", "TUTOR"] },
+        role: { in: TEACHING_CALLER_ROLES },
       },
       select: { id: true },
     });

--- a/apps/admin/lib/caller-roles.ts
+++ b/apps/admin/lib/caller-roles.ts
@@ -1,0 +1,35 @@
+/**
+ * CallerRole helpers — pinned subsets derived from the Prisma enum.
+ *
+ * `CallerRole` is the entity-side role on a `Caller` row (LEARNER /
+ * TEACHER / TUTOR / PARENT / MENTOR) — distinct from `UserRole`
+ * (SUPERADMIN / ADMIN / ... in `lib/roles.ts`) which gates session-level
+ * privileges.
+ *
+ * Use these subsets instead of hand-typed `["TEACHER", "TUTOR"]` literals
+ * in API routes and DB queries. Schema additions land in one place.
+ */
+
+import { CallerRole } from "@prisma/client";
+
+/**
+ * Caller roles that represent active *teaching* (curriculum-owning,
+ * cohort-supervising) responsibility. Used to find the teaching caller
+ * inside a domain or cohort.
+ *
+ *   TEACHER  — owns cohort groups, sees pupil dashboards
+ *   TUTOR    — 1-1 tutor, owns small groups or individual supervision
+ *
+ * Suitable for Prisma `where: { role: { in: TEACHING_CALLER_ROLES } }`.
+ */
+export const TEACHING_CALLER_ROLES: CallerRole[] = [
+  CallerRole.TEACHER,
+  CallerRole.TUTOR,
+];
+
+/** Predicate sibling of `TEACHING_CALLER_ROLES` for runtime equality checks. */
+export function isTeachingCallerRole(
+  role: CallerRole | string | null | undefined,
+): boolean {
+  return role === CallerRole.TEACHER || role === CallerRole.TUTOR;
+}

--- a/apps/admin/lib/voice/default-provider.ts
+++ b/apps/admin/lib/voice/default-provider.ts
@@ -1,0 +1,20 @@
+/**
+ * DEFAULT_VOICE_PROVIDER_SLUG — canonical fallback when no provider
+ * is configured via `VoiceSystemSettings.defaultProviderSlug`.
+ *
+ * Several voice paths fall back to "vapi" when neither the per-call
+ * resolution nor the system-settings row supplies a slug. Centralising
+ * the literal makes the fallback explicit and lets a future operator
+ * change it in one place.
+ *
+ *  - `load-voice-config.ts:48` — picks an enabled provider when
+ *    `VoiceSystemSettings.defaultProviderSlug` is empty.
+ *  - `poll-stale-calls.ts::pollStaleCalls()` — defaults the slug arg
+ *    when the cron entry omits it.
+ *
+ * Provider-internal `slug` fields (e.g. `providers/vapi/index.ts:70`)
+ * are the provider's own identity and stay as literals — they're not
+ * "the default fallback," they're "the vapi provider's slug."
+ */
+
+export const DEFAULT_VOICE_PROVIDER_SLUG = "vapi";

--- a/apps/admin/lib/voice/load-voice-config.ts
+++ b/apps/admin/lib/voice/load-voice-config.ts
@@ -23,6 +23,7 @@ import { getVoiceCallSettings, type VoiceCallSettings } from "@/lib/system-setti
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
 import { getVoiceProvider } from "@/lib/voice/provider-factory";
 import { resolveVoiceConfig, type ResolvedVoiceConfig } from "@/lib/voice/config";
+import { DEFAULT_VOICE_PROVIDER_SLUG } from "@/lib/voice/default-provider";
 
 interface LoadArgs {
   callerId?: string | null;
@@ -45,7 +46,7 @@ export async function loadResolvedVoiceConfig(args: LoadArgs): Promise<ResolvedV
   // `VoiceSystemSettings.defaultProviderSlug` is blank but a VAPI row
   // exists. Pick a real voice provider: explicit setting → vapi default.
   const explicit = sys.defaultProviderSlug?.trim();
-  const enabledSlug = explicit && explicit.length > 0 ? explicit : "vapi";
+  const enabledSlug = explicit && explicit.length > 0 ? explicit : DEFAULT_VOICE_PROVIDER_SLUG;
 
   const [vpRow, adapter, domainConfig, courseConfig] = await Promise.all([
     prisma.voiceProvider.findUnique({

--- a/apps/admin/lib/voice/poll-stale-calls.ts
+++ b/apps/admin/lib/voice/poll-stale-calls.ts
@@ -46,6 +46,7 @@ import { prisma } from "@/lib/prisma";
 import { persistEndOfCall } from "@/lib/voice/route-handlers";
 import { getVoiceProvider } from "@/lib/voice/provider-factory";
 import { logVoiceEvent } from "@/lib/voice/telemetry";
+import { DEFAULT_VOICE_PROVIDER_SLUG } from "@/lib/voice/default-provider";
 
 export interface PollBatchResult {
   /** Total stale rows considered for polling this cycle. */
@@ -109,7 +110,7 @@ export async function pollStaleVoiceCalls(
   options: PollOptions = {},
 ): Promise<PollBatchResult> {
   const startMs = Date.now();
-  const slug = options.slug ?? "vapi";
+  const slug = options.slug ?? DEFAULT_VOICE_PROVIDER_SLUG;
   const staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
   const batchLimit = options.batchLimit ?? DEFAULT_BATCH_LIMIT;
   const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;

--- a/apps/admin/tests/lib/teaching-caller-roles.test.ts
+++ b/apps/admin/tests/lib/teaching-caller-roles.test.ts
@@ -1,0 +1,95 @@
+/**
+ * TEACHING_CALLER_ROLES + isTeachingCallerRole — pin + adoption ratchet.
+ *
+ * **What this test pins:**
+ *  1. The const matches CallerRole.TEACHER + CallerRole.TUTOR exactly.
+ *  2. The predicate returns true only for those two members.
+ *  3. **Ratchet:** no consumer under `apps/admin/{app,lib}` falls back
+ *     to a bare `["TEACHER", "TUTOR"]` array or hand-rolled
+ *     `role === "TEACHER" || role === "TUTOR"` chain.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { CallerRole } from "@prisma/client";
+
+import {
+  TEACHING_CALLER_ROLES,
+  isTeachingCallerRole,
+} from "@/lib/caller-roles";
+
+const REPO_ADMIN = resolve(__dirname, "..", "..");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (
+      (entry.endsWith(".ts") || entry.endsWith(".tsx")) &&
+      !entry.endsWith(".test.ts") &&
+      !entry.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("TEACHING_CALLER_ROLES — Prisma-enum subset", () => {
+  it("contains exactly TEACHER and TUTOR", () => {
+    expect([...TEACHING_CALLER_ROLES].sort()).toEqual(
+      [CallerRole.TEACHER, CallerRole.TUTOR].sort(),
+    );
+  });
+
+  it("isTeachingCallerRole matches TEACHER/TUTOR only", () => {
+    expect(isTeachingCallerRole(CallerRole.TEACHER)).toBe(true);
+    expect(isTeachingCallerRole(CallerRole.TUTOR)).toBe(true);
+    expect(isTeachingCallerRole(CallerRole.LEARNER)).toBe(false);
+    expect(isTeachingCallerRole(CallerRole.PARENT)).toBe(false);
+    expect(isTeachingCallerRole(CallerRole.MENTOR)).toBe(false);
+    expect(isTeachingCallerRole(undefined)).toBe(false);
+  });
+
+  it("no consumer hand-rolls the TEACHER/TUTOR subset", () => {
+    const PATTERNS = [
+      /\[\s*"TEACHER"\s*,\s*"TUTOR"\s*\]/,
+      /"TEACHER"\s*\|\|\s*role\s*===\s*"TUTOR"|"TUTOR"\s*\|\|\s*role\s*===\s*"TEACHER"/,
+      /role\s*!==\s*"TEACHER"\s*&&\s*role\s*!==\s*"TUTOR"/,
+    ];
+    const offenders: { file: string; line: number; text: string }[] = [];
+    const roots = ["app", "lib"];
+    // The source file documents the pattern it forbids — exclude it.
+    const EXCLUDE = new Set(["lib/caller-roles.ts"]);
+    for (const root of roots) {
+      const rootDir = join(REPO_ADMIN, root);
+      for (const file of walk(rootDir)) {
+        const rel = file.replace(REPO_ADMIN + "/", "");
+        if (EXCLUDE.has(rel)) continue;
+        const src = readFileSync(file, "utf8");
+        if (!PATTERNS.some((p) => p.test(src))) continue;
+        src.split("\n").forEach((line, idx) => {
+          if (PATTERNS.some((p) => p.test(line))) {
+            offenders.push({
+              file: rel,
+              line: idx + 1,
+              text: line.trim(),
+            });
+          }
+        });
+      }
+    }
+    expect(
+      offenders,
+      `TEACHING_CALLER_ROLES inlined — use TEACHING_CALLER_ROLES / isTeachingCallerRole from @/lib/caller-roles:\n${offenders
+        .map((o) => `  ${o.file}:${o.line}  ${o.text}`)
+        .join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/admin/tests/lib/voice/default-provider.test.ts
+++ b/apps/admin/tests/lib/voice/default-provider.test.ts
@@ -1,0 +1,70 @@
+/**
+ * DEFAULT_VOICE_PROVIDER_SLUG — pin + adoption ratchet.
+ *
+ * Pin: value is "vapi" (an operator-visible change to flip this would be
+ * a deployment-affecting decision; the test catches accidental drift).
+ *
+ * Ratchet: no consumer under `apps/admin/lib/voice/` falls back to a
+ * bare `?? "vapi"` outside the provider's own identity file. Provider-
+ * internal `slug = "vapi"` is excluded — that's the provider's own
+ * name, not "the default fallback."
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { DEFAULT_VOICE_PROVIDER_SLUG } from "@/lib/voice/default-provider";
+
+const REPO_ADMIN = resolve(__dirname, "..", "..", "..");
+const VOICE_DIR = join(REPO_ADMIN, "lib", "voice");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Provider-internal identity files where `slug = "vapi"` is the provider's own name. */
+const PROVIDER_IDENTITY_FILES = [
+  "lib/voice/providers/vapi/index.ts",
+  "lib/voice/llm-proxy/run-vapi-chat-completion.ts",
+  "lib/voice/default-provider.ts",
+];
+
+describe("DEFAULT_VOICE_PROVIDER_SLUG", () => {
+  it('exports "vapi"', () => {
+    expect(DEFAULT_VOICE_PROVIDER_SLUG).toBe("vapi");
+  });
+
+  it('no fallback `?? "vapi"` under lib/voice/ outside provider identity files', () => {
+    const PATTERN = /\?\?\s*"vapi"/;
+    const offenders: { file: string; line: number; text: string }[] = [];
+    for (const file of walk(VOICE_DIR)) {
+      const rel = file.replace(REPO_ADMIN + "/", "");
+      if (PROVIDER_IDENTITY_FILES.includes(rel)) continue;
+      const src = readFileSync(file, "utf8");
+      if (!PATTERN.test(src)) continue;
+      src.split("\n").forEach((line, idx) => {
+        if (PATTERN.test(line)) {
+          offenders.push({ file: rel, line: idx + 1, text: line.trim() });
+        }
+      });
+    }
+    expect(
+      offenders,
+      `Bare \`?? "vapi"\` fallback — use DEFAULT_VOICE_PROVIDER_SLUG from @/lib/voice/default-provider:\n${offenders
+        .map((o) => `  ${o.file}:${o.line}  ${o.text}`)
+        .join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -108,6 +108,8 @@ Three structural patterns, in order of preference:
 | `PlaybookCurriculumRole` enum adoption | `@prisma/client::PlaybookCurriculumRole` | 38 consumers under `apps/admin/{app,lib,scripts}` | ✅ PROTECTED | `tests/lib/playbook-curriculum-role-adoption.test.ts` | — | Ratchet rejects bare `role: "primary"` / `role: "linked"` literals across app, lib, scripts. |
 | `MemoryCategory` enum adoption | `@prisma/client::MemoryCategory` | `lib/chat/commands.ts` + `differentiation/route.ts` | ✅ PROTECTED | `tests/lib/memory-category-adoption.test.ts` | — | Ratchet rejects 6-permutation literal reconstructions. |
 | RBAC role-level adoption (no magic role arrays) | `lib/roles.ts` (`ROLE_LEVEL` + `isRoleAtOrAbove` + `rolesAtOrAbove` + `isOperatorTrackAdmin`) | 4 sites: `ViewModeContext`, `dashboard-config`, `dashboard/route`, `system-ini` | ✅ PROTECTED | `tests/lib/roles.test.ts` | — | Ratchet rejects new `["SUPERADMIN","ADMIN","OPERATOR"]` triplet literals in `app`/`lib`/`contexts`. EDUCATOR exclusion documented (track distinction, not level). |
+| `TEACHING_CALLER_ROLES` (CallerRole subset) | `lib/caller-roles.ts` (`TEACHING_CALLER_ROLES` + `isTeachingCallerRole`) | 3 routes: `classroom`, `cohorts`, `ensure-cohort` | ✅ PROTECTED | `tests/lib/teaching-caller-roles.test.ts` | — | Ratchet rejects bare `["TEACHER","TUTOR"]` literals and `role === "TEACHER" \|\| role === "TUTOR"` chains. |
+| `DEFAULT_VOICE_PROVIDER_SLUG` | `lib/voice/default-provider.ts` | `load-voice-config.ts:48` + `poll-stale-calls.ts:112` | ✅ PROTECTED | `tests/lib/voice/default-provider.test.ts` | — | Ratchet rejects `?? "vapi"` fallbacks under `lib/voice/` outside the provider's own identity files. |
 
 ### Cascade
 


### PR DESCRIPTION
## Summary

Outrageous-hardcoding sweep #5 — two small const adoptions bundled.

**C: TEACHING_CALLER_ROLES (3 sites)**
- New `lib/caller-roles.ts` — exports `TEACHING_CALLER_ROLES: CallerRole[]` + `isTeachingCallerRole(role)`.
- `app/api/domains/[domainId]/classroom/route.ts:51` — `["TEACHER","TUTOR"]` → const.
- `app/api/courses/[courseId]/learners/ensure-cohort/route.ts:59` — same.
- `app/api/cohorts/route.ts:166` — chain of `!==` comparisons → `!isTeachingCallerRole(...)`.

**F: DEFAULT_VOICE_PROVIDER_SLUG (2 sites)**
- New `lib/voice/default-provider.ts` — exports `DEFAULT_VOICE_PROVIDER_SLUG = "vapi"` with docstring distinguishing "default fallback" from provider-internal identity.
- `lib/voice/load-voice-config.ts:48` — `? explicit : "vapi"` → const.
- `lib/voice/poll-stale-calls.ts:112` — `slug ?? "vapi"` → const.
- Provider-internal `slug = "vapi"` literals (e.g. `providers/vapi/index.ts:70`) are excluded — that's the provider's name, not the fallback.

## Verified by

- `npx vitest run tests/lib/teaching-caller-roles.test.ts tests/lib/voice/default-provider.test.ts` → 5/5 pass.
- `npx vitest run tests/lib/lattice-self-maintenance.test.ts` → 9/9 pass (both new files inventoried via lattice-chains rows).
- `npx tsc --noEmit` → 36 errors (== current baseline).
- Ratchet vitests: TEACHING_CALLER_ROLES test catches future `["TEACHER","TUTOR"]` literals + `role === "TEACHER" || role === "TUTOR"` chains; default-provider test catches future `?? "vapi"` fallbacks under `lib/voice/` outside provider identity files.

## Lattice survey

- Two distinct surfaces, both with the same shape: hand-typed literal duplicating a canonical concept.
- Sibling writers: zero for both.
- Convergence: 2 named primitives + 2 ratchet vitests + 2 inventory rows.
- Provider identity exclusion is explicit + tested (test's `PROVIDER_IDENTITY_FILES` list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)