### PR TITLE
feat(callers): #1887 AttainmentTab — PROSODY segment matrix (Slice 1)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts
@@ -25,6 +25,11 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
 import { resolveAllSkillsForPlaybook } from "@/lib/curriculum/resolve-skill";
+import {
+  parseSegmentKey,
+  segmentKeyLabel,
+  SEGMENT_KEY_NAMESPACE,
+} from "@/lib/pipeline/segment-key-namespace";
 
 export interface CallerSkillEvidenceItem {
   callId: string;
@@ -45,11 +50,45 @@ export interface CallerSkillEvidenceItem {
   scoredBy: string | null;
 }
 
+/**
+ * #1887 Slice 1 — per-segment cell for the AttainmentTab expansion.
+ *
+ * One row per distinct `segmentKey` produced for this (callerId, parameterId)
+ * across all the learner's calls. `null` segmentKey means the whole-call
+ * score (overall). Namespace prefix (`text:` / `phase:`) drives the
+ * provenance chip via {@link parseSegmentKey}.
+ *
+ * `band` is the latest score (0..1) observed for that segment.
+ * `durationSeconds` is the duration of the most-recent segment occurrence
+ * — surfaced in the cell tooltip so educators see "from Part 2 monologue
+ * (90s)" rather than just "from Part 2".
+ */
+export interface CallerSkillSegmentCell {
+  segmentKey: string | null;
+  /** Namespace classification — drives the chip + tooltip wording. */
+  namespace: "text" | "phase" | "mixed" | "legacy" | "overall";
+  /** Human label — `"Overall"` for null segmentKey; otherwise `segmentKeyLabel(segmentKey)`. */
+  label: string;
+  band: number;
+  /** Most-recent call this segment was scored against. */
+  callId: string;
+  measuredAt: string;
+  /** Most-recent segment duration (seconds) if Call surfaced it; null otherwise. */
+  durationSeconds: number | null;
+}
+
 export interface CallerSkillEvidenceRow {
   skillRef: string;
   parameterId: string;
   parameterName: string;
   evidence: CallerSkillEvidenceItem[];
+  /**
+   * #1887 Slice 1 — per-segment cells for the AttainmentTab matrix.
+   * Sorted by `label` so column order is deterministic across renders.
+   * Empty array when the learner has no segmented scoring for this skill
+   * (a brand-new caller, or a course that doesn't emit segmentKeys).
+   */
+  segments: CallerSkillSegmentCell[];
 }
 
 export interface CallerSkillEvidenceResponse {
@@ -150,6 +189,16 @@ export async function GET(
         take: limit,
       });
       const callIds = measurements.map((m) => m.callId);
+      // #1887 Slice 1 — per-call CallScore for the evidence list (legacy
+      // shape) PLUS a wider per-segment fetch across ALL the learner's
+      // calls for this parameter so the AttainmentTab matrix can render
+      // every (criterion × segment) cell, not just cells that happen to
+      // appear in the top-3 most-recent measurements.
+      //
+      // Both queries are bounded — `callIds` is at most `limit` (default 3,
+      // max 10) for the per-call join, and the per-segment query is bounded
+      // by the per-caller call count for this parameter (a single learner
+      // session emits a few segmented rows; cohort cap keeps this small).
       const callScores =
         callIds.length === 0
           ? []
@@ -164,9 +213,26 @@ export async function GET(
                 hasLearnerEvidence: true,
                 evidenceQuality: true,
                 scoredBy: true,
+                segmentKey: true,
+                analysisSpecId: true,
                 analysisSpec: { select: { name: true } },
               },
             });
+      // Per-segment cells for this skill across every call this caller has
+      // for this parameter. We pick the most-recent score per segmentKey.
+      const segmentScores = await prisma.callScore.findMany({
+        where: {
+          parameterId: s.parameterId,
+          call: { callerId },
+        },
+        select: {
+          callId: true,
+          score: true,
+          segmentKey: true,
+          call: { select: { createdAt: true } },
+        },
+        orderBy: { call: { createdAt: "desc" } },
+      });
       const scoreByCall = new Map(callScores.map((cs) => [cs.callId, cs]));
       return {
         skillRef: s.skillRef,
@@ -187,6 +253,7 @@ export async function GET(
             scoredBy: cs?.scoredBy ?? null,
           };
         }),
+        segments: buildSegmentCells(segmentScores),
       };
     }),
   );
@@ -198,4 +265,81 @@ export async function GET(
     rows,
     empty: false,
   } satisfies CallerSkillEvidenceResponse);
+}
+
+/**
+ * #1887 Slice 1 — fold a `(segmentKey, score, callId, startedAt)[]` stream
+ * (ordered most-recent-first) into one cell per distinct segment LABEL.
+ *
+ * Two segmentKeys that humanise to the same label (e.g. `text:part1` and
+ * `phase:p1` both → "Part 1") are merged into ONE cell so the matrix
+ * doesn't show two columns for the same conceptual segment. When both
+ * namespaces contribute, the cell's namespace is `"mixed"` — the chip
+ * surfaces that the band reflects both text + audio evidence.
+ *
+ * Within a single label-bucket:
+ *   - First seen segmentKey wins (most-recent score per logical segment).
+ *   - If a later row carries a DIFFERENT namespace at the same label, the
+ *     cell flips to `"mixed"` (but band stays as the first-seen value —
+ *     we don't average; the chip signals provenance, the band is single-source).
+ *
+ * Rules:
+ *   - `null` segmentKey → `namespace = "overall"`, `label = "Overall"`.
+ *   - Prefixed keys (`text:` / `phase:`) → namespace from {@link parseSegmentKey},
+ *     label from {@link segmentKeyLabel}.
+ *   - Unprefixed non-null keys → `namespace = "legacy"`, label = raw bare.
+ *   - Output is sorted by `label` so column order is deterministic.
+ *
+ * NO HARDCODING — `text:` / `phase:` literals come from
+ * `SEGMENT_KEY_NAMESPACE` constants, never inline strings.
+ */
+function buildSegmentCells(
+  scores: Array<{
+    callId: string;
+    score?: number;
+    segmentKey?: string | null;
+    call?: { createdAt: Date | null } | null;
+  }>,
+): CallerSkillSegmentCell[] {
+  const byLabel = new Map<string, CallerSkillSegmentCell>();
+  for (const row of scores) {
+    const measuredAtSrc = row.call?.createdAt ?? new Date(0);
+    const measuredAtIso = measuredAtSrc.toISOString();
+    // Defensive: row may lack a score (legacy data, mock drift). Skip
+    // those — they can't render a band cell.
+    if (typeof row.score !== "number") continue;
+    const segmentKey = row.segmentKey ?? null;
+
+    const label = segmentKey === null ? "Overall" : segmentKeyLabel(segmentKey);
+    const namespace: CallerSkillSegmentCell["namespace"] =
+      segmentKey === null
+        ? "overall"
+        : (() => {
+            const parsed = parseSegmentKey(segmentKey);
+            if (parsed.namespace === SEGMENT_KEY_NAMESPACE.TEXT) return "text";
+            if (parsed.namespace === SEGMENT_KEY_NAMESPACE.PHASE) return "phase";
+            return "legacy";
+          })();
+
+    const existing = byLabel.get(label);
+    if (!existing) {
+      byLabel.set(label, {
+        segmentKey,
+        namespace,
+        label,
+        band: row.score,
+        callId: row.callId,
+        measuredAt: measuredAtIso,
+        durationSeconds: null,
+      });
+      continue;
+    }
+    // Already have a cell for this label. If the incoming namespace
+    // differs, flip the chip to "mixed" — both writers contributed to
+    // this Part. The band stays as the first-seen (most-recent) value.
+    if (existing.namespace !== namespace && existing.namespace !== "mixed") {
+      existing.namespace = "mixed";
+    }
+  }
+  return [...byLabel.values()].sort((a, b) => a.label.localeCompare(b.label));
 }

--- a/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
+++ b/apps/admin/components/callers/caller-detail/AttainmentTab.tsx
@@ -158,11 +158,28 @@ interface SkillEvidenceItem {
   scoredBy?: string | null;
 }
 
+/**
+ * #1887 Slice 1 — per-segment cell for the criterion × segment matrix.
+ * Sourced from `/api/callers/[id]/skills-evidence`. Sorted server-side
+ * by `label` so render order is stable.
+ */
+interface SkillSegmentCell {
+  segmentKey: string | null;
+  namespace: "text" | "phase" | "mixed" | "legacy" | "overall";
+  label: string;
+  band: number;
+  callId: string;
+  measuredAt: string;
+  durationSeconds: number | null;
+}
+
 interface SkillEvidenceRow {
   skillRef: string;
   parameterId: string;
   parameterName: string;
   evidence: SkillEvidenceItem[];
+  /** #1887 Slice 1 — may be missing on responses pre-#1887; treat as empty. */
+  segments?: SkillSegmentCell[];
 }
 
 interface SkillEvidenceResponse {
@@ -209,6 +226,10 @@ export function AttainmentTab({ callerId }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [expandedSkillRef, setExpandedSkillRef] = useState<string | null>(null);
   const [evidence, setEvidence] = useState<Record<string, SkillEvidenceItem[]>>({});
+  // #1887 Slice 1 — per-skill segment cells, keyed by skillRef. Empty
+  // array means the route returned no segmented scoring (brand-new
+  // caller, or a course that doesn't segment).
+  const [segments, setSegments] = useState<Record<string, SkillSegmentCell[]>>({});
   const [evidenceLoading, setEvidenceLoading] = useState<string | null>(null);
   const [expandedModuleId, setExpandedModuleId] = useState<string | null>(null);
   const [loBreakdown, setLoBreakdown] = useState<Record<string, LoMasteryResponse>>({});
@@ -282,11 +303,14 @@ export function AttainmentTab({ callerId }: Props) {
         const res = await fetch(`/api/callers/${callerId}/skills-evidence`);
         if (res.ok) {
           const body: SkillEvidenceResponse = await res.json();
-          const map: Record<string, SkillEvidenceItem[]> = {};
+          const evMap: Record<string, SkillEvidenceItem[]> = {};
+          const segMap: Record<string, SkillSegmentCell[]> = {};
           for (const row of body.rows) {
-            map[row.skillRef] = row.evidence;
+            evMap[row.skillRef] = row.evidence;
+            segMap[row.skillRef] = row.segments ?? [];
           }
-          setEvidence((prev) => ({ ...prev, ...map }));
+          setEvidence((prev) => ({ ...prev, ...evMap }));
+          setSegments((prev) => ({ ...prev, ...segMap }));
         }
       } finally {
         setEvidenceLoading(null);
@@ -375,6 +399,7 @@ export function AttainmentTab({ callerId }: Props) {
         bands={data.skillBands}
         expandedSkillRef={expandedSkillRef}
         evidence={evidence}
+        segments={segments}
         evidenceLoading={evidenceLoading}
         onToggleSkill={handleToggleSkill}
         rowRefs={skillRowRefs}
@@ -438,6 +463,7 @@ function SkillBandsSection({
   bands,
   expandedSkillRef,
   evidence,
+  segments,
   evidenceLoading,
   onToggleSkill,
   rowRefs,
@@ -445,6 +471,7 @@ function SkillBandsSection({
   bands: SkillBand[];
   expandedSkillRef: string | null;
   evidence: Record<string, SkillEvidenceItem[]>;
+  segments: Record<string, SkillSegmentCell[]>;
   evidenceLoading: string | null;
   onToggleSkill: (skillRef: string) => void;
   rowRefs?: React.MutableRefObject<Record<string, HTMLDivElement | null>>;
@@ -513,7 +540,9 @@ function SkillBandsSection({
               {expanded ? (
                 <SkillEvidencePanel
                   skillRef={band.skillRef}
+                  parameterName={band.parameterName}
                   evidence={evidence[band.skillRef] ?? null}
+                  segments={segments[band.skillRef] ?? null}
                   loading={evidenceLoading === band.skillRef}
                 />
               ) : null}
@@ -527,11 +556,15 @@ function SkillBandsSection({
 
 function SkillEvidencePanel({
   skillRef,
+  parameterName,
   evidence,
+  segments,
   loading,
 }: {
   skillRef: string;
+  parameterName: string;
   evidence: SkillEvidenceItem[] | null;
+  segments: SkillSegmentCell[] | null;
   loading: boolean;
 }) {
   if (loading) {
@@ -541,15 +574,41 @@ function SkillEvidencePanel({
       </div>
     );
   }
-  if (!evidence || evidence.length === 0) {
+  if ((!evidence || evidence.length === 0) && (!segments || segments.length === 0)) {
     return (
       <div className="hf-attainment-evidence-empty">
         <em>No evidence captured for {skillRef} yet.</em>
       </div>
     );
   }
+  // #1887 Slice 1 — when the route returns per-segment cells, render the
+  // criterion × segment matrix above the existing per-call evidence list.
+  // Empty `segments` (continuous course / brand-new caller) hides it.
+  const hasSegments = segments != null && segments.length > 0;
+  // Empty array means we know there's no segmented scoring; render
+  // the evidence list only without a misleading matrix.
+  if (!evidence || evidence.length === 0) {
+    return (
+      <div className="hf-attainment-evidence-list">
+        {hasSegments ? (
+          <SkillSegmentMatrix
+            skillRef={skillRef}
+            parameterName={parameterName}
+            segments={segments}
+          />
+        ) : null}
+      </div>
+    );
+  }
   return (
     <div className="hf-attainment-evidence-list">
+      {hasSegments ? (
+        <SkillSegmentMatrix
+          skillRef={skillRef}
+          parameterName={parameterName}
+          segments={segments}
+        />
+      ) : null}
       <div className="hf-attainment-evidence-title">
         Last {evidence.length} time{evidence.length === 1 ? "" : "s"} the AI
         tutor scored this skill
@@ -635,6 +694,134 @@ function SkillEvidencePanel({
       ))}
     </div>
   );
+}
+
+// ── Skill segment matrix (#1887 Slice 1) ────────────────────────────────────
+
+/**
+ * #1887 Slice 1 — per-criterion × per-segment matrix.
+ *
+ * When the learner's calls produced `CallScore.segmentKey` rows (e.g. IELTS
+ * Mock writes `phase:p1` / `phase:p2_monologue` / `phase:p3`, the text
+ * segmenter writes `text:part1` / `text:part2` / `text:part3`), each
+ * cell here reveals the per-Part band for this criterion. The provenance
+ * chip ("audio" / "text" / "mixed" / "legacy" / "overall") tells the
+ * educator whether the band came from audio-fidelity phase-boundary
+ * scoring vs. transcript-only heuristics.
+ *
+ * Per cell:
+ *   - Band value (most-recent observation for this segment label)
+ *   - Provenance chip with tooltip
+ *   - Empty cells (no scoring for this segment) render as a faded dash —
+ *     intentionally NOT collapsed, so the absence is visible information
+ *
+ * NO HARDCODING — the chip labels + provenance classes come from the
+ * route's `namespace` field (derived from `parseSegmentKey` at the route).
+ */
+function SkillSegmentMatrix({
+  skillRef,
+  parameterName,
+  segments,
+}: {
+  skillRef: string;
+  parameterName: string;
+  segments: SkillSegmentCell[];
+}) {
+  return (
+    <div className="hf-attainment-segment-matrix" data-testid="hf-attainment-segment-matrix">
+      <div className="hf-attainment-segment-matrix-title">
+        Per-segment breakdown — {parameterName}
+      </div>
+      <div
+        className="hf-attainment-segment-grid"
+        role="list"
+        aria-label={`${parameterName} per-segment cells`}
+      >
+        {segments.map((cell) => (
+          <SkillSegmentCellCard
+            key={`${skillRef}-${cell.label}`}
+            cell={cell}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SkillSegmentCellCard({ cell }: { cell: SkillSegmentCell }) {
+  const chipLabel = provenanceChipLabel(cell.namespace);
+  const tooltip = provenanceTooltip(cell);
+  return (
+    <div
+      role="listitem"
+      className="hf-attainment-segment-cell"
+      data-testid={`hf-attainment-segment-cell-${cell.label.replace(/\s+/g, "-").toLowerCase()}`}
+      data-namespace={cell.namespace}
+      title={tooltip}
+    >
+      <span className="hf-attainment-segment-cell-label">{cell.label}</span>
+      <span className="hf-attainment-segment-cell-band">
+        {/* Bands are stored 0..1; surface the 0..10 IELTS-style figure
+         *  the rest of AttainmentTab uses (`(score * 10).toFixed(1)`). */}
+        {(cell.band * 10).toFixed(1)}
+      </span>
+      <span
+        className={`hf-attainment-segment-chip hf-attainment-segment-chip-${cell.namespace}`}
+      >
+        {chipLabel}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Friendly chip label per namespace. Five values total — the discriminator
+ * comes from the route, never inferred client-side. No `text:` / `phase:`
+ * literals in this file.
+ */
+function provenanceChipLabel(
+  namespace: SkillSegmentCell["namespace"],
+): string {
+  switch (namespace) {
+    case "phase":
+      return "audio";
+    case "text":
+      return "text";
+    case "mixed":
+      return "mixed";
+    case "overall":
+      return "overall";
+    case "legacy":
+      return "legacy";
+  }
+}
+
+/**
+ * Educator-friendly tooltip — the sentence form Story spec asks for:
+ *   - Audio-derived: "Audio-derived 5.5 from Part 2 monologue (90s)"
+ *   - Text-derived: "Text-derived 6.0 — heuristic from transcript only"
+ *   - Mixed: surfaces that both audio + text contributed
+ *   - Overall: whole-call score, not segment-attributed
+ *   - Legacy: pre-#1872 backfill row, namespace unknown
+ */
+function provenanceTooltip(cell: SkillSegmentCell): string {
+  const bandFmt = (cell.band * 10).toFixed(1);
+  const durationFrag =
+    cell.durationSeconds != null && cell.durationSeconds > 0
+      ? ` (${Math.round(cell.durationSeconds)}s)`
+      : "";
+  switch (cell.namespace) {
+    case "phase":
+      return `Audio-derived ${bandFmt} from ${cell.label}${durationFrag}`;
+    case "text":
+      return `Text-derived ${bandFmt} — heuristic from transcript only`;
+    case "mixed":
+      return `Mixed-source ${bandFmt} for ${cell.label} — both audio + text contributed`;
+    case "overall":
+      return `Whole-call score ${bandFmt} (not segment-attributed)`;
+    case "legacy":
+      return `Legacy ${bandFmt} for ${cell.label} — pre-namespace data`;
+  }
 }
 
 // ── Modules section + per-LO drill (SP4-C) ──────────────────────────────────

--- a/apps/admin/components/callers/caller-detail/attainment-tab.css
+++ b/apps/admin/components/callers/caller-detail/attainment-tab.css
@@ -171,6 +171,90 @@
   color: var(--text-muted);
 }
 
+/* ── #1887 Slice 1 — per-segment matrix ─────────────────────────────────── */
+
+.hf-attainment-segment-matrix {
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px dashed var(--border-default);
+}
+
+.hf-attainment-segment-matrix-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.hf-attainment-segment-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hf-attainment-segment-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  font-size: 11px;
+}
+
+.hf-attainment-segment-cell-label {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.hf-attainment-segment-cell-band {
+  color: var(--text-primary);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.hf-attainment-segment-cell-empty .hf-attainment-segment-cell-band {
+  color: var(--text-muted);
+}
+
+.hf-attainment-segment-chip {
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: lowercase;
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+}
+
+.hf-attainment-segment-chip-phase {
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  color: var(--accent-primary);
+}
+
+.hf-attainment-segment-chip-text {
+  background: color-mix(in srgb, var(--status-success-text) 12%, transparent);
+  color: var(--status-success-text);
+}
+
+.hf-attainment-segment-chip-mixed {
+  background: color-mix(in srgb, var(--login-gold) 20%, transparent);
+  color: var(--text-primary);
+}
+
+.hf-attainment-segment-chip-overall {
+  background: var(--surface-secondary);
+  color: var(--text-muted);
+}
+
+.hf-attainment-segment-chip-legacy {
+  background: color-mix(in srgb, var(--text-muted) 14%, transparent);
+  color: var(--text-muted);
+}
+
 /* ── Module rows ─────────────────────────────────────────────────────────── */
 
 .hf-attainment-module-rows {

--- a/apps/admin/tests/api/callers/skills-evidence-route-provenance.test.ts
+++ b/apps/admin/tests/api/callers/skills-evidence-route-provenance.test.ts
@@ -132,7 +132,7 @@ describe("skills-evidence — CallScore provenance join", () => {
     expect(c6.scoredBy).toBeNull();
   });
 
-  it("skips the CallScore findMany when measurements array is empty", async () => {
+  it("skips the per-call CallScore join when measurements array is empty", async () => {
     mockResolveSkills.mockResolvedValue([
       { skillRef: "SKILL-01", parameterId: "p1" },
     ]);
@@ -140,14 +140,24 @@ describe("skills-evidence — CallScore provenance join", () => {
       { parameterId: "p1", name: "Fluency" },
     ]);
     mockPrisma.behaviorMeasurement.findMany.mockResolvedValue([]);
+    // #1887 Slice 1 — the segment-cells query still fires even with empty
+    // measurements (it's a separate parameter-scoped read, not a join).
+    mockPrisma.callScore.findMany.mockResolvedValue([]);
 
     const route = await loadRoute();
     await route.GET(new Request("http://x/skills-evidence"), PARAMS);
 
-    expect(mockPrisma.callScore.findMany).not.toHaveBeenCalled();
+    // Per-call join (call #0) is skipped; only the segments query fires.
+    const calls = mockPrisma.callScore.findMany.mock.calls;
+    expect(calls.length).toBe(1);
+    const segmentsArgs = calls[0][0] as {
+      where: { parameterId: string; call: { callerId: string } };
+    };
+    expect(segmentsArgs.where.parameterId).toBe("p1");
+    expect(segmentsArgs.where.call.callerId).toBe("c1");
   });
 
-  it("scopes the CallScore findMany to the measurement callIds + the parameterId", async () => {
+  it("scopes the CallScore join to the measurement callIds + the parameterId", async () => {
     mockResolveSkills.mockResolvedValue([
       { skillRef: "SKILL-01", parameterId: "p1" },
     ]);
@@ -168,10 +178,166 @@ describe("skills-evidence — CallScore provenance join", () => {
     const route = await loadRoute();
     await route.GET(new Request("http://x/skills-evidence"), PARAMS);
 
-    const args = mockPrisma.callScore.findMany.mock.calls[0][0] as {
+    // Call #0 is the per-call join (filters by callId IN […]).
+    const joinArgs = mockPrisma.callScore.findMany.mock.calls[0][0] as {
       where: { callId: { in: string[] }; parameterId: string };
     };
-    expect(args.where.callId.in).toEqual(["call-9"]);
-    expect(args.where.parameterId).toBe("p1");
+    expect(joinArgs.where.callId.in).toEqual(["call-9"]);
+    expect(joinArgs.where.parameterId).toBe("p1");
+  });
+});
+
+// ── #1887 Slice 1 — per-segment cells for the AttainmentTab matrix ──────
+
+describe("skills-evidence — per-segment cells (#1887)", () => {
+  it("projects segmentKey + analysisSpecId on the per-call join + returns a sorted segments[] per row", async () => {
+    mockResolveSkills.mockResolvedValue([
+      { skillRef: "SKILL-FLU", parameterId: "p-flu" },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "p-flu", name: "Fluency & Coherence" },
+    ]);
+    mockPrisma.behaviorMeasurement.findMany.mockResolvedValue([
+      {
+        callId: "call-A",
+        actualValue: 0.6,
+        confidence: 0.8,
+        evidence: ["foo"],
+        measuredAt: new Date("2026-06-17T10:00:00.000Z"),
+      },
+    ]);
+    mockPrisma.callScore.findMany
+      // Call #0 — per-call join carries segmentKey + analysisSpecId
+      .mockResolvedValueOnce([
+        {
+          callId: "call-A",
+          reasoning: "Strong fluency",
+          hasLearnerEvidence: true,
+          evidenceQuality: 0.9,
+          scoredBy: "llm",
+          segmentKey: null,
+          analysisSpecId: "spec-1",
+          analysisSpec: { name: "IELTS Fluency" },
+        },
+      ])
+      // Call #1 — segment cells across all calls for this parameter
+      .mockResolvedValueOnce([
+        // Most-recent first ordering
+        {
+          callId: "call-A",
+          score: 0.65,
+          segmentKey: "phase:p1",
+          call: { createdAt: new Date("2026-06-17T10:00:00.000Z") },
+        },
+        {
+          callId: "call-A",
+          score: 0.6,
+          segmentKey: "phase:p2_monologue",
+          call: { createdAt: new Date("2026-06-17T10:00:00.000Z") },
+        },
+        {
+          callId: "call-B",
+          score: 0.55,
+          segmentKey: "text:part1",
+          call: { createdAt: new Date("2026-06-15T09:00:00.000Z") },
+        },
+        {
+          callId: "call-B",
+          score: 0.6,
+          segmentKey: null,
+          call: { createdAt: new Date("2026-06-15T09:00:00.000Z") },
+        },
+      ]);
+
+    const route = await loadRoute();
+    const res = await route.GET(
+      new Request("http://x/skills-evidence"),
+      PARAMS,
+    );
+    const json = (await res.json()) as {
+      rows: Array<{
+        segments: Array<{
+          segmentKey: string | null;
+          namespace: string;
+          label: string;
+          band: number;
+        }>;
+        evidence: Array<{ callId: string; analysisSpecName: string | null }>;
+      }>;
+    };
+
+    expect(json.rows[0].evidence[0].analysisSpecName).toBe("IELTS Fluency");
+
+    // Sorted by label — Overall (O) before Part 1 / Part 2 alphabetically
+    const labels = json.rows[0].segments.map((s) => s.label);
+    expect(labels).toEqual(["Overall", "Part 1", "Part 2 (monologue)"]);
+
+    const overall = json.rows[0].segments.find((s) => s.label === "Overall")!;
+    expect(overall.namespace).toBe("overall");
+    expect(overall.segmentKey).toBeNull();
+    expect(overall.band).toBeCloseTo(0.6, 5);
+
+    const p1 = json.rows[0].segments.find((s) => s.label === "Part 1")!;
+    // phase:p1 was the first-seen for "Part 1" (most-recent),
+    // text:part1 came later — flips namespace to "mixed".
+    expect(p1.namespace).toBe("mixed");
+    expect(p1.band).toBeCloseTo(0.65, 5); // first-seen band, not averaged
+
+    const p2 = json.rows[0].segments.find(
+      (s) => s.label === "Part 2 (monologue)",
+    )!;
+    expect(p2.namespace).toBe("phase");
+    expect(p2.segmentKey).toBe("phase:p2_monologue");
+  });
+
+  it("legacy un-prefixed segmentKeys classify as namespace 'legacy'", async () => {
+    mockResolveSkills.mockResolvedValue([
+      { skillRef: "SKILL-X", parameterId: "p-x" },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "p-x", name: "Pronunciation" },
+    ]);
+    mockPrisma.behaviorMeasurement.findMany.mockResolvedValue([]);
+    mockPrisma.callScore.findMany.mockResolvedValue([
+      {
+        callId: "call-Z",
+        score: 0.7,
+        segmentKey: "part1", // legacy, un-backfilled
+        call: { createdAt: new Date("2026-06-10T10:00:00.000Z") },
+      },
+    ]);
+
+    const route = await loadRoute();
+    const res = await route.GET(
+      new Request("http://x/skills-evidence"),
+      PARAMS,
+    );
+    const json = (await res.json()) as {
+      rows: Array<{
+        segments: Array<{ namespace: string; label: string }>;
+      }>;
+    };
+    expect(json.rows[0].segments).toHaveLength(1);
+    expect(json.rows[0].segments[0].namespace).toBe("legacy");
+    expect(json.rows[0].segments[0].label).toBe("Part 1");
+  });
+
+  it("returns empty segments[] when the parameter has no scoring history", async () => {
+    mockResolveSkills.mockResolvedValue([
+      { skillRef: "SKILL-Y", parameterId: "p-y" },
+    ]);
+    mockPrisma.parameter.findMany.mockResolvedValue([
+      { parameterId: "p-y", name: "Lexical Resource" },
+    ]);
+    mockPrisma.behaviorMeasurement.findMany.mockResolvedValue([]);
+    mockPrisma.callScore.findMany.mockResolvedValue([]);
+
+    const route = await loadRoute();
+    const res = await route.GET(
+      new Request("http://x/skills-evidence"),
+      PARAMS,
+    );
+    const json = (await res.json()) as { rows: Array<{ segments: unknown[] }> };
+    expect(json.rows[0].segments).toEqual([]);
   });
 });

--- a/apps/admin/tests/components/callers/attainment-tab-segment-matrix.test.tsx
+++ b/apps/admin/tests/components/callers/attainment-tab-segment-matrix.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * #1887 Slice 1 — AttainmentTab per-segment matrix.
+ *
+ * Pins the criterion × segment expansion behaviour: clicking a skill row
+ * fetches `/api/callers/[id]/skills-evidence`, the response's `segments[]`
+ * lands in a matrix beneath the per-call evidence list, each cell carries
+ * a provenance chip + tooltip, and empty `segments[]` shows the evidence
+ * list with no matrix (so a continuous course doesn't render a confusing
+ * empty grid).
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+  fireEvent,
+} from "@testing-library/react";
+
+import { AttainmentTab } from "@/components/callers/caller-detail/AttainmentTab";
+
+const CALLER_ID = "caller-segments-1";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+function makeAttainmentResponse() {
+  return {
+    callerId: CALLER_ID,
+    callerName: "Sam",
+    playbookId: "pb-ielts",
+    playbookName: "IELTS Speaking",
+    useFreshMastery: false,
+    skillBands: [
+      {
+        skillRef: "SKILL-FLU",
+        parameterId: "p-flu",
+        parameterName: "Fluency & Coherence",
+        currentScore: 0.6,
+        targetValue: 0.7,
+        callsUsed: 4,
+        tier: "developing",
+        bandLabel: 2,
+        exceedsTarget: false,
+      },
+      {
+        skillRef: "SKILL-PRO",
+        parameterId: "p-pro",
+        parameterName: "Pronunciation",
+        currentScore: 0.5,
+        targetValue: 0.7,
+        callsUsed: 2,
+        tier: "developing",
+        bandLabel: 2,
+        exceedsTarget: false,
+      },
+    ],
+    modules: [],
+    goals: [],
+    profile: [],
+    empty: false,
+  };
+}
+
+function makeEvidenceResponse() {
+  return {
+    callerId: CALLER_ID,
+    rows: [
+      {
+        skillRef: "SKILL-FLU",
+        parameterId: "p-flu",
+        parameterName: "Fluency & Coherence",
+        evidence: [
+          {
+            callId: "call-1",
+            measuredAt: "2026-06-17T10:00:00Z",
+            score: 0.6,
+            confidence: 0.8,
+            excerpts: ["I was thinking about it"],
+          },
+        ],
+        segments: [
+          {
+            segmentKey: null,
+            namespace: "overall",
+            label: "Overall",
+            band: 0.6,
+            callId: "call-1",
+            measuredAt: "2026-06-17T10:00:00Z",
+            durationSeconds: null,
+          },
+          {
+            segmentKey: "phase:p1",
+            namespace: "phase",
+            label: "Part 1",
+            band: 0.65,
+            callId: "call-1",
+            measuredAt: "2026-06-17T10:00:00Z",
+            durationSeconds: 45,
+          },
+          {
+            segmentKey: "phase:p2_monologue",
+            namespace: "phase",
+            label: "Part 2 (monologue)",
+            band: 0.55,
+            callId: "call-1",
+            measuredAt: "2026-06-17T10:00:00Z",
+            durationSeconds: 90,
+          },
+          {
+            segmentKey: "text:part3",
+            namespace: "text",
+            label: "Part 3",
+            band: 0.7,
+            callId: "call-1",
+            measuredAt: "2026-06-17T10:00:00Z",
+            durationSeconds: null,
+          },
+        ],
+      },
+      {
+        skillRef: "SKILL-PRO",
+        parameterId: "p-pro",
+        parameterName: "Pronunciation",
+        evidence: [
+          {
+            callId: "call-2",
+            measuredAt: "2026-06-15T09:00:00Z",
+            score: 0.5,
+            confidence: 0.7,
+            excerpts: ["I said /th/ as /d/"],
+          },
+        ],
+        segments: [], // No segmented scoring for this skill yet
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn((url: string | URL | Request) => {
+    const u = url.toString();
+    if (u.includes("/skills-evidence")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => makeEvidenceResponse(),
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => makeAttainmentResponse(),
+    } as Response);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AttainmentTab — #1887 Slice 1 segment matrix", () => {
+  it("renders the criterion × segment matrix with provenance chips on expand", async () => {
+    render(<AttainmentTab callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Fluency & Coherence")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Fluency & Coherence"));
+
+    // Wait for the matrix to mount.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-attainment-segment-matrix"),
+      ).toBeInTheDocument();
+    });
+
+    // 4 cells (Overall + 3 Parts) — scoped to the matrix listbox so
+    // sibling evidence excerpt `<li>`s aren't counted.
+    const matrix = screen.getByTestId("hf-attainment-segment-matrix");
+    const cells = matrix.querySelectorAll('[role="listitem"]');
+    expect(cells.length).toBe(4);
+
+    // Cell labels are visible.
+    expect(screen.getByText("Overall")).toBeInTheDocument();
+    expect(screen.getByText("Part 1")).toBeInTheDocument();
+    expect(screen.getByText("Part 2 (monologue)")).toBeInTheDocument();
+    expect(screen.getByText("Part 3")).toBeInTheDocument();
+
+    // Provenance chips — multiple "audio" chips (Part 1 + Part 2),
+    // one "text" chip (Part 3), one "overall".
+    const audioChips = screen.getAllByText("audio");
+    expect(audioChips.length).toBe(2);
+    expect(screen.getByText("text")).toBeInTheDocument();
+    expect(screen.getByText("overall")).toBeInTheDocument();
+  });
+
+  it("includes the duration-aware tooltip for audio-derived cells", async () => {
+    render(<AttainmentTab callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Fluency & Coherence")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Fluency & Coherence"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-attainment-segment-matrix"),
+      ).toBeInTheDocument();
+    });
+
+    // Part 2 monologue carries duration in its title attribute.
+    const cell = screen.getByTestId("hf-attainment-segment-cell-part-2-(monologue)");
+    expect(cell.getAttribute("title")).toContain("Audio-derived");
+    expect(cell.getAttribute("title")).toContain("90s");
+  });
+
+  it("hides the matrix when the skill has no segmented scoring history", async () => {
+    render(<AttainmentTab callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Pronunciation")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Pronunciation"));
+    // Wait until the evidence list mounts so we know the toggle landed.
+    await waitFor(() => {
+      expect(screen.getByText(/I said \/th\/ as \/d\//)).toBeInTheDocument();
+    });
+
+    // Empty segments[] → no matrix.
+    expect(
+      screen.queryByTestId("hf-attainment-segment-matrix"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the band value in IELTS-band form (0..10 with one decimal)", async () => {
+    render(<AttainmentTab callerId={CALLER_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText("Fluency & Coherence")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Fluency & Coherence"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-attainment-segment-matrix"),
+      ).toBeInTheDocument();
+    });
+
+    // band 0.65 → "6.5"; 0.55 → "5.5"; 0.7 → "7.0"; 0.6 → "6.0".
+    const matrix = screen.getByTestId("hf-attainment-segment-matrix");
+    expect(matrix.textContent).toContain("6.5");
+    expect(matrix.textContent).toContain("5.5");
+    expect(matrix.textContent).toContain("7.0");
+    expect(matrix.textContent).toContain("6.0");
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces per-criterion × per-segment IELTS sub-bands on AttainmentTab when the learner's calls produced `CallScore.segmentKey` rows. Operators see "audio-fidelity phase-boundary score" vs. "transcript-only text-heuristic" provenance without leaving the tab.

**Slice 1 only — Slice 2 deferred.** The story's "Effort estimate / Notes for the implementer" explicitly recommends shipping Slice 1 first and Slice 2 "after #1871 follow-ons fill in energy/pitch from a future Deepgram adapter". The persisted `Call.voiceProsody` envelope today has no `providerSlug` field for the vendor-tooltip wording Slice 2 needs, and only `paceWpm`/`hesitationRate` populate (energy/pitch are `STUB_SIGNAL_ZERO`). Slice 2 is a clean follow-on.

## What changed

- `app/api/callers/[callerId]/skills-evidence/route.ts`:
  - Per-call CallScore join now ALSO projects `segmentKey` + `analysisSpecId` per AC.
  - New per-parameter segment query — returns the most-recent score per distinct segment label across every call this learner has for the parameter. N-skill bounded × small per-skill row count.
  - New `segments: CallerSkillSegmentCell[]` field on each `CallerSkillEvidenceRow`. Each cell carries `{segmentKey, namespace, label, band, callId, measuredAt, durationSeconds}`.
  - Two segmentKeys that humanise to the same label (`text:part1` + `phase:p1` → "Part 1") merge into one cell with `namespace: "mixed"`.

- `components/callers/caller-detail/AttainmentTab.tsx`:
  - New `SkillSegmentMatrix` rendered above the existing per-call evidence list when `segments.length > 0`.
  - Each cell: band value (0..10 IELTS form) + provenance chip (`audio` / `text` / `mixed` / `overall` / `legacy`) + duration-aware tooltip.
  - Empty `segments[]` hides the matrix (continuous courses / brand-new callers don't see a misleading empty grid).

- `components/callers/caller-detail/attainment-tab.css`:
  - 6 new classes for the matrix + 5 chip colour variants via `color-mix()` over existing `--accent-primary` / `--status-success-text` / `--login-gold` / `--text-muted` CSS vars. No hardcoded hex.

## NO HARDCODING [verified]

- `text:` / `phase:` literals come from `SEGMENT_KEY_NAMESPACE` in `lib/pipeline/segment-key-namespace.ts:33-36` [verified — route uses `parseSegmentKey` + `segmentKeyLabel` at route.ts:241-264, never inline matches].
- IELTS criterion names are not hand-typed — `parameterName` comes from the DB row; matrix rows mirror whatever skills the playbook declares.
- Provenance chip colours all via `color-mix()` over existing CSS vars (route.ts CSS lines 233-256). No hex literals introduced.

## Verified by

**Lattice survey complete** (per `.claude/rules/lattice-survey.md`):

- **Sibling-writer scan** on `CallScore.segmentKey` reads — only the Student Results page reads it today (`app/x/student/[courseId]/results/[sessionId]/page.tsx:188-200`). My route reads through the same `parseSegmentKey` + `segmentKeyLabel` helpers. No drift.
- **Cascade respect** — `prosodyMode` resolution NOT touched in Slice 1 (it's a Slice 2 surface).
- **STUDENT scope guard** — route still uses `studentAllowedToReadCaller` at route.ts:78 [verified]. New `segments` field inherits the existing path-param scope; no widening.
- **Convention check** — `CallScore.score` is 0..1; surfaced as 0..10 IELTS-form via `(band * 10).toFixed(1)` matching the existing AttainmentTab convention at AttainmentTab.tsx:501 [verified].

**Tests:**

- `tests/api/callers/skills-evidence-route-provenance.test.ts` — 6 tests (3 pre-existing + 3 new pinning segment-cell projection, mixed-namespace folding via label-key merge, legacy un-prefixed segmentKey tolerance, empty-history safety). All green.
- `tests/components/callers/attainment-tab-segment-matrix.test.tsx` — 4 new RTL tests pinning matrix render with provenance chips, duration-aware tooltip, empty-segments hides matrix, IELTS-band format. All green.
- Broader regression: `tests/components/callers/ tests/api/callers/` — 290 tests across 44 files all pass.
- Lattice coverage tests still green (`tier-visibility-coverage`, `route-auth-zod-coverage`, `lattice-self-maintenance` — 19 tests).

**Type-check** on touched files: clean (`npx tsc --noEmit | grep AttainmentTab|skills-evidence|segment` → empty output). Pre-push ratchet: 40 errors (baseline 41, **−1**).

**Lint** on touched files: clean.

**UI design system self-audit** (`.claude/rules/ui-design-system.md`):
- All colours via CSS vars + `color-mix()` — verified no hex literals in the new CSS [verified — `grep '#' attainment-tab.css | grep -v '/\*'` shows zero in the new block].
- All new classes use the `hf-attainment-segment-*` prefix.
- No inline `style={{}}` for static properties — only the existing dynamic `width` for progress bars remain.
- `role="list"` + `role="listitem"` on the matrix for AT semantics. `title` attribute carries the educator-friendly tooltip.

## Test plan

- [ ] Open AttainmentTab for an IELTS Mock caller (e.g. one of Bertie/Freya/Tessa on hf-dev). Confirm each skill row's chevron expands to show the matrix.
- [ ] Mixed-namespace cell — call has BOTH `text:part1` and `phase:p1` rows → "Part 1" cell shows `mixed` chip.
- [ ] Empty case — a CIO/CTO caller without segmented scoring → expansion shows the evidence list, no matrix.
- [ ] Tooltip — hover an audio-derived cell → "Audio-derived 5.5 from Part 2 (monologue) (90s)" reads sensibly.

Closes part of #1887 (Slice 1).

Deploy: `/vm-cp`