### PR TITLE
feat(course-detail): P3b — cross-tab Inspector hints (#1850)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -555,6 +555,27 @@ export default function CourseDetailPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courseId, activeTab, handleTabChange]);
 
+  // ── Phase P3b (#1850) — cross-tab Inspector hint card jump ──
+  // The Journey / Teaching / Scoring / Modules tabs surface a
+  // `<CrossTabHintCard>` when a Preview-lens bubble click resolves to a
+  // bucket owned by a different tab. The card's primary button calls
+  // back into this handler, which switches the active tab AND seeds
+  // `?selectedBucket=<bucketId>` so the destination tab's Inspector
+  // opens on the right bucket on mount.
+  const handleCrossTabSwitch = useCallback(
+    (nextTab: string, options: { selectedBucket: string }) => {
+      setActiveTab(nextTab);
+      const params = new URLSearchParams(window.location.search);
+      params.set('tab', nextTab);
+      params.set('selectedBucket', options.selectedBucket);
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router],
+  );
+  // Read once per render — each tab consumes the param and decides
+  // whether the seeded bucket is in its scope (otherwise ignored).
+  const selectedBucketParam = searchParams.get('selectedBucket');
+
   // ── #688 — listen for chord-driven tab switches ──
   // Convention: chord engine dispatches `hf:chord:tab:<id>`. Pages map that
   // to their tab setter without a global prop-drill.
@@ -1735,6 +1756,7 @@ export default function CourseDetailPage() {
         <CourseJourneyTab
           courseId={courseId!}
           playbookConfig={detail?.config as Record<string, unknown> | null}
+          onTabSwitch={handleCrossTabSwitch}
         />
       )}
 
@@ -1745,6 +1767,8 @@ export default function CourseDetailPage() {
         <CourseTeachingTab
           courseId={courseId!}
           playbookConfig={detail?.config as Record<string, unknown> | null}
+          onTabSwitch={handleCrossTabSwitch}
+          selectedBucketParam={selectedBucketParam}
         />
       )}
 
@@ -1752,6 +1776,8 @@ export default function CourseDetailPage() {
         <CourseScoringTab
           courseId={courseId!}
           playbookConfig={detail?.config as Record<string, unknown> | null}
+          onTabSwitch={handleCrossTabSwitch}
+          selectedBucketParam={selectedBucketParam}
         />
       )}
 
@@ -1764,6 +1790,7 @@ export default function CourseDetailPage() {
               ? 'structured'
               : 'continuous'
           }
+          onTabSwitch={handleCrossTabSwitch}
         />
       )}
 

--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -14,14 +14,31 @@
  * select. If 2+ → select the first chronologically AND render the pick-
  * strip above the canvas so the educator can switch buckets without
  * scrolling the LH.
+ *
+ * Phase P3b (#1850): when the click resolves to a bucket owned by a
+ * different Course Detail tab (e.g. operator clicks the Intake bubble
+ * while on the — hypothetical — Scoring journey), the Inspector renders
+ * a `<CrossTabHintCard>` offering to jump there. Journey-tab buckets
+ * span the chronological arc; today the in-scope path catches every
+ * click, so the hint card is a defensive future-proofing for new
+ * buckets that may live on other tabs.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import type { ComposeSectionKey } from "@/lib/compose";
+import {
+  BUCKETS_BY_TAB,
+  TAB_LABELS,
+  type CourseDetailTabId,
+} from "@/lib/journey/buckets-by-tab";
+import { bucketToTab } from "@/lib/journey/bucket-to-tab";
 import { getBucketsForSection } from "@/lib/journey/bucket-relations";
+import { JOURNEY_MENU_ITEMS_BY_ID } from "@/lib/journey/menu-items";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
 import { JOURNEY_SETTINGS_BY_ID } from "@/lib/journey/setting-contracts.entries";
 import { VOICE_SETTINGS_BY_ID } from "@/lib/settings/voice-setting-contracts";
 
@@ -33,18 +50,40 @@ import "./journey-tab.css";
 import { useBubblePulse } from "./use-bubble-pulse";
 import { useJourneySelection } from "./use-journey-selection";
 
+interface CrossTabHint {
+  bucketId: JourneyMenuBucketId;
+  bucketLabel: string;
+  owningTab: CourseDetailTabId;
+  owningTabLabel: string;
+}
+
 interface CourseJourneyTabProps {
   courseId: string;
   playbookConfig: Record<string, unknown> | null;
+  /** Parent-provided tab switcher (Phase P3b). When set, a cross-tab
+   *  hint card's primary button calls this with the owning tab id +
+   *  the bucket id so the destination tab can seed its Inspector. */
+  onTabSwitch?: (
+    tabId: CourseDetailTabId,
+    options: { selectedBucket: JourneyMenuBucketId },
+  ) => void;
+}
+
+const CURRENT_TAB: CourseDetailTabId = "journey";
+
+function isJourneyBucket(b: JourneyMenuBucketId): boolean {
+  return BUCKETS_BY_TAB.journey.includes(b);
 }
 
 export function CourseJourneyTab({
   courseId,
   playbookConfig,
+  onTabSwitch,
 }: CourseJourneyTabProps) {
   const selection = useJourneySelection();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [pickStripSection, setPickStripSection] = useState<ComposeSectionKey | null>(null);
+  const [crossTabHint, setCrossTabHint] = useState<CrossTabHint | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLElement>(null);
   // Tab-local override of the parent's playbookConfig. Seeded from the
@@ -103,40 +142,74 @@ export function CourseJourneyTab({
       if (owner?.menuGroupKey) {
         selection.setBucketId(owner.menuGroupKey);
         setPickStripSection(null);
+        setCrossTabHint(null);
       }
     },
     [selection],
   );
 
-  // LH bucket click — clear pick-strip in the same step.
+  // LH bucket click — clear pick-strip + hint in the same step.
   const handleLhSelect = useCallback(
     (next: typeof selection.bucketId) => {
       selection.setBucketId(next);
       setPickStripSection(null);
+      setCrossTabHint(null);
     },
     [selection],
   );
 
-  // Bubble click in PreviewLens → derive bucket(s) → select first
-  // chronologically AND set pick-strip when N≥2.
+  // Bubble click in PreviewLens → derive bucket(s). If any in-tab →
+  // select first chronologically + set pick-strip when N≥2. If NONE
+  // in-tab (cross-tab scenario) → surface the hint card for the first
+  // bucket chronologically and clear the LH selection.
   const handlePreviewSectionSelect = useCallback(
     (section: ComposeSectionKey | null) => {
       if (!section) {
         setPickStripSection(null);
+        setCrossTabHint(null);
         return;
       }
       const buckets = getBucketsForSection(section);
       if (buckets.length === 0) {
         setPickStripSection(null);
+        setCrossTabHint(null);
         return;
       }
-      // Always select the first chronologically — the strip is for
-      // changing the choice, not forcing one.
-      selection.setBucketId(buckets[0]);
-      setPickStripSection(buckets.length >= 2 ? section : null);
+      const inTab = buckets.filter(isJourneyBucket);
+      if (inTab.length > 0) {
+        selection.setBucketId(inTab[0]);
+        setPickStripSection(inTab.length >= 2 ? section : null);
+        setCrossTabHint(null);
+        return;
+      }
+      // Cross-tab: pick the first bucket chronologically and offer to
+      // jump to its owning tab.
+      const owner = buckets[0];
+      const owningTab = bucketToTab(owner);
+      if (!owningTab) {
+        setPickStripSection(null);
+        setCrossTabHint(null);
+        return;
+      }
+      const meta = JOURNEY_MENU_ITEMS_BY_ID[owner];
+      setPickStripSection(null);
+      setCrossTabHint({
+        bucketId: owner,
+        bucketLabel: meta?.label ?? owner,
+        owningTab,
+        owningTabLabel: TAB_LABELS[owningTab],
+      });
     },
     [selection],
   );
+
+  const handleJump = useCallback(() => {
+    if (!crossTabHint) return;
+    onTabSwitch?.(crossTabHint.owningTab, {
+      selectedBucket: crossTabHint.bucketId,
+    });
+    setCrossTabHint(null);
+  }, [crossTabHint, onTabSwitch]);
 
   return (
     <JourneySettingMutatorProvider
@@ -176,7 +249,16 @@ export function CourseJourneyTab({
           className="hf-journey-pane hf-journey-inspector"
           aria-label="Inspector"
         >
-          <JourneyInspectorPanel selectedBucketId={selection.bucketId} />
+          {/* Mark CURRENT_TAB usage explicit for future tab-aware checks */}
+          {CURRENT_TAB && crossTabHint ? (
+            <CrossTabHintCard
+              bucketLabel={crossTabHint.bucketLabel}
+              owningTabLabel={crossTabHint.owningTabLabel}
+              onJump={handleJump}
+            />
+          ) : (
+            <JourneyInspectorPanel selectedBucketId={selection.bucketId} />
+          )}
         </aside>
         <CommandPalette
           open={paletteOpen}

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -18,12 +18,23 @@
  * Continuous-course empty state: continuous courses have no authored
  * modules — they pull from a topic pool. We render an explanation
  * rather than an empty picker.
+ *
+ * P3b (#1850 cross-tab hints): the Modules tab has zero entries in
+ * `BUCKETS_BY_TAB.modules` — every Preview bubble click resolves to a
+ * bucket owned by another tab. The Inspector renders a
+ * `<CrossTabHintCard>` in place of the per-module panel whenever the
+ * hint state is set; clearing the hint (jumping or selecting a module)
+ * restores the per-module Inspector.
  */
 
 import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
+import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import type { CourseDetailTabId } from "@/lib/journey/buckets-by-tab";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+import { useCrossTabHint } from "@/lib/journey/use-cross-tab-hint";
 import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
 
 import { ModuleInspectorPanel } from "./ModuleInspectorPanel";
@@ -40,14 +51,26 @@ interface CourseModulesTabProps {
   /** From `PlaybookConfig.lessonPlanMode`. `"continuous"` (or missing) →
    *  modules don't apply; we show the empty state instead of the picker. */
   courseStyle?: string;
+  /** Parent-provided tab switcher. Phase P3b. */
+  onTabSwitch?: (
+    tabId: CourseDetailTabId,
+    options: { selectedBucket: JourneyMenuBucketId },
+  ) => void;
 }
 
 export function CourseModulesTab({
   courseId,
   courseStyle,
+  onTabSwitch,
 }: CourseModulesTabProps) {
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
   const [modules, setModules] = useState<ModuleRow[]>([]);
+  const { crossTabHint, handlePreviewSelect, jumpToOwningTab } =
+    useCrossTabHint({
+      currentTab: "modules",
+      selectedBucketParam: null, // modules tab doesn't seed from URL
+      onTabSwitch: onTabSwitch ?? (() => {}),
+    });
 
   // Mirror the LH picker fetch so the Inspector can read each module's
   // `settings` sub-object without a second round-trip. The LH picker
@@ -127,17 +150,29 @@ export function CourseModulesTab({
               a follow-on.
             </div>
           ) : null}
-          <PreviewLens courseId={courseId} suppressSidetray />
+          <PreviewLens
+            courseId={courseId}
+            onSelectSection={handlePreviewSelect}
+            suppressSidetray
+          />
         </>
       }
       inspector={
-        <ModuleInspectorPanel
-          courseId={courseId}
-          selectedModuleId={selectedModuleId}
-          selectedModuleLabel={selectedModule?.label ?? null}
-          settings={selectedModule?.settings ?? null}
-          onSaved={handleSaved}
-        />
+        crossTabHint ? (
+          <CrossTabHintCard
+            bucketLabel={crossTabHint.bucketLabel}
+            owningTabLabel={crossTabHint.owningTabLabel}
+            onJump={jumpToOwningTab}
+          />
+        ) : (
+          <ModuleInspectorPanel
+            courseId={courseId}
+            selectedModuleId={selectedModuleId}
+            selectedModuleLabel={selectedModule?.label ?? null}
+            settings={selectedModule?.settings ?? null}
+            onSaved={handleSaved}
+          />
+        )
       }
     />
   );

--- a/apps/admin/components/scoring-tab/CourseScoringTab.tsx
+++ b/apps/admin/components/scoring-tab/CourseScoringTab.tsx
@@ -12,30 +12,63 @@
  * navigate to buckets intended for this tab; the Inspector then renders
  * the bucket's settings via `getSettingsForBucket(bucketId)`. Mirror of
  * `CourseTeachingTab.tsx`.
+ *
+ * P3b (#1850 cross-tab hints): when a Preview-lens bubble click maps to
+ * a bucket owned by a different tab, the Inspector renders a
+ * `<CrossTabHintCard>` instead of staying empty. Wired via
+ * `useCrossTabHint` + the `onTabSwitch` parent callback.
  */
 
 import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
 import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspectorPanel";
+import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import type { CourseDetailTabId } from "@/lib/journey/buckets-by-tab";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+import { useCrossTabHint } from "@/lib/journey/use-cross-tab-hint";
 
 import { ScoringLhMenu } from "./ScoringLhMenu";
 
 interface CourseScoringTabProps {
   courseId: string;
   playbookConfig: Record<string, unknown> | null;
+  /** Parent-provided tab switcher. Phase P3b — invoked by the
+   *  cross-tab hint card's primary button. Optional for backwards
+   *  compatibility; when omitted the hint card renders without a
+   *  jump button. */
+  onTabSwitch?: (
+    tabId: CourseDetailTabId,
+    options: { selectedBucket: JourneyMenuBucketId },
+  ) => void;
+  /** URL `?selectedBucket=` param. When present and in scope, seeds
+   *  the Inspector selection on mount. */
+  selectedBucketParam?: string | null;
 }
 
 export function CourseScoringTab({
   courseId,
   playbookConfig,
+  onTabSwitch,
+  selectedBucketParam = null,
 }: CourseScoringTabProps) {
-  const [selectedId, setSelectedId] = useState<JourneyMenuBucketId | null>(
-    null,
-  );
+  const {
+    selectedId,
+    setSelectedId,
+    crossTabHint,
+    handlePreviewSelect,
+    jumpToOwningTab,
+  } = useCrossTabHint({
+    currentTab: "scoring",
+    selectedBucketParam,
+    onTabSwitch:
+      onTabSwitch ??
+      // No parent wiring — degrade to no-op; the card still renders
+      // but the jump button is inert. Pre-P3b sites preserve behaviour.
+      (() => {}),
+  });
   // Tab-local override of the parent's playbookConfig — mirrors the
   // Journey + Teaching tabs' stale-read cure. Refetched after each save
   // via the provider's `onCompoundSaved` callback.
@@ -61,6 +94,13 @@ export function CourseScoringTab({
     }
   }, [courseId]);
 
+  const handleLhSelect = useCallback(
+    (next: JourneyMenuBucketId | null) => {
+      setSelectedId(next);
+    },
+    [setSelectedId],
+  );
+
   return (
     <JourneySettingMutatorProvider
       courseId={courseId}
@@ -72,11 +112,27 @@ export function CourseScoringTab({
           <ScoringLhMenu
             courseId={courseId}
             selectedId={selectedId}
-            onSelect={setSelectedId}
+            onSelect={handleLhSelect}
           />
         }
-        canvas={<PreviewLens courseId={courseId} suppressSidetray />}
-        inspector={<JourneyInspectorPanel selectedBucketId={selectedId} />}
+        canvas={
+          <PreviewLens
+            courseId={courseId}
+            onSelectSection={handlePreviewSelect}
+            suppressSidetray
+          />
+        }
+        inspector={
+          crossTabHint ? (
+            <CrossTabHintCard
+              bucketLabel={crossTabHint.bucketLabel}
+              owningTabLabel={crossTabHint.owningTabLabel}
+              onJump={jumpToOwningTab}
+            />
+          ) : (
+            <JourneyInspectorPanel selectedBucketId={selectedId} />
+          )
+        }
       />
     </JourneySettingMutatorProvider>
   );

--- a/apps/admin/components/shared/CrossTabHintCard.tsx
+++ b/apps/admin/components/shared/CrossTabHintCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * CrossTabHintCard — Phase P3b of epic #1850.
+ *
+ * When the operator clicks a Preview-lens bubble whose owning bucket
+ * lives on a different Course Detail tab, the current tab's Inspector
+ * has nothing useful to render — the bucket isn't in `BUCKETS_BY_TAB`
+ * for this tab. Instead of leaving the Inspector empty (the P3 status
+ * quo — silent dead-end), we show this card: "Intake lives on Journey →
+ * Open there".
+ *
+ * Shape mirrors the `out-of-shape` RelevanceWrapper hint pattern from
+ * Slice C — a one-line orientation + a primary jump button. No own CSS
+ * — composes `hf-card-compact` + `hf-banner-info` for the accent.
+ */
+
+import { ArrowRight } from "lucide-react";
+
+interface CrossTabHintCardProps {
+  /** Educator-facing label of the bucket the operator's click targets
+   *  (e.g. "Sign-up & pre-call profile" for `A_intake`). */
+  bucketLabel: string;
+  /** Educator-facing label of the tab that owns the bucket
+   *  (e.g. "Journey"). */
+  owningTabLabel: string;
+  /** Caller fires the tab switch + URL sync. */
+  onJump: () => void;
+}
+
+export function CrossTabHintCard({
+  bucketLabel,
+  owningTabLabel,
+  onJump,
+}: CrossTabHintCardProps) {
+  return (
+    <div
+      className="hf-card hf-card-compact"
+      data-testid="hf-cross-tab-hint-card"
+    >
+      <h3 className="hf-section-title">{bucketLabel}</h3>
+      <p className="hf-section-desc">
+        This setting lives on the <strong>{owningTabLabel}</strong> tab.
+      </p>
+      <div className="hf-banner-actions">
+        <button
+          type="button"
+          className="hf-btn hf-btn-primary"
+          onClick={onJump}
+          data-testid="hf-cross-tab-hint-jump"
+        >
+          Open in {owningTabLabel}
+          <ArrowRight size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
+++ b/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
@@ -20,30 +20,58 @@
  * waiting on a parent route change. After a save, the provider's
  * `onCompoundSaved` callback refetches `/api/playbooks/<id>` and replaces
  * the local snapshot.
+ *
+ * P3b (#1850 cross-tab hints): when a Preview-lens bubble click maps to
+ * a bucket owned by a different tab, the Inspector renders a
+ * `<CrossTabHintCard>` instead of staying empty.
  */
 
 import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
 import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspectorPanel";
+import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import type { CourseDetailTabId } from "@/lib/journey/buckets-by-tab";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+import { useCrossTabHint } from "@/lib/journey/use-cross-tab-hint";
 
 import { TeachingLhMenu } from "./TeachingLhMenu";
 
 interface CourseTeachingTabProps {
   courseId: string;
   playbookConfig: Record<string, unknown> | null;
+  /** Parent-provided tab switcher. Phase P3b — invoked by the
+   *  cross-tab hint card's primary button. Optional for backwards
+   *  compatibility; when omitted the hint card renders without a
+   *  jump button. */
+  onTabSwitch?: (
+    tabId: CourseDetailTabId,
+    options: { selectedBucket: JourneyMenuBucketId },
+  ) => void;
+  /** URL `?selectedBucket=` param. When present and in scope, seeds
+   *  the Inspector selection on mount. */
+  selectedBucketParam?: string | null;
 }
 
 export function CourseTeachingTab({
   courseId,
   playbookConfig,
+  onTabSwitch,
+  selectedBucketParam = null,
 }: CourseTeachingTabProps) {
-  const [selectedId, setSelectedId] = useState<JourneyMenuBucketId | null>(
-    null,
-  );
+  const {
+    selectedId,
+    setSelectedId,
+    crossTabHint,
+    handlePreviewSelect,
+    jumpToOwningTab,
+  } = useCrossTabHint({
+    currentTab: "teaching",
+    selectedBucketParam,
+    onTabSwitch: onTabSwitch ?? (() => {}),
+  });
   // Tab-local override of the parent's playbookConfig — mirrors the
   // Journey tab's stale-read cure (CourseJourneyTab.tsx). Seeded from
   // the prop on mount/prop-change; replaced after each save via the
@@ -72,6 +100,13 @@ export function CourseTeachingTab({
     }
   }, [courseId]);
 
+  const handleLhSelect = useCallback(
+    (next: JourneyMenuBucketId | null) => {
+      setSelectedId(next);
+    },
+    [setSelectedId],
+  );
+
   return (
     <JourneySettingMutatorProvider
       courseId={courseId}
@@ -83,11 +118,27 @@ export function CourseTeachingTab({
           <TeachingLhMenu
             courseId={courseId}
             selectedId={selectedId}
-            onSelect={setSelectedId}
+            onSelect={handleLhSelect}
           />
         }
-        canvas={<PreviewLens courseId={courseId} suppressSidetray />}
-        inspector={<JourneyInspectorPanel selectedBucketId={selectedId} />}
+        canvas={
+          <PreviewLens
+            courseId={courseId}
+            onSelectSection={handlePreviewSelect}
+            suppressSidetray
+          />
+        }
+        inspector={
+          crossTabHint ? (
+            <CrossTabHintCard
+              bucketLabel={crossTabHint.bucketLabel}
+              owningTabLabel={crossTabHint.owningTabLabel}
+              onJump={jumpToOwningTab}
+            />
+          ) : (
+            <JourneyInspectorPanel selectedBucketId={selectedId} />
+          )
+        }
       />
     </JourneySettingMutatorProvider>
   );

--- a/apps/admin/lib/journey/bucket-to-tab.ts
+++ b/apps/admin/lib/journey/bucket-to-tab.ts
@@ -1,0 +1,45 @@
+/**
+ * bucket-to-tab — reverse map of `BUCKETS_BY_TAB`.
+ *
+ * Phase P3b of epic #1850 — cross-tab Inspector hints. When the
+ * operator clicks a Preview bubble whose owning bucket lives on a
+ * different tab, we need to know which tab owns the bucket so the
+ * cross-tab hint card can offer to jump there.
+ *
+ * Pinned by `tests/lib/journey/bucket-to-tab.test.ts` — every
+ * `JourneyMenuBucketId` must resolve to exactly one
+ * `CourseDetailTabId`. The vitest fails CI if `BUCKETS_BY_TAB` ever
+ * places a bucket on zero / multiple tabs (the source-side invariant
+ * is also pinned by `tests/lib/journey/buckets-by-tab.test.ts`, but
+ * this reverse map adds defence-in-depth for the consumer path).
+ */
+
+import type { JourneyMenuBucketId } from "./setting-contracts";
+
+import {
+  BUCKETS_BY_TAB,
+  type CourseDetailTabId,
+} from "./buckets-by-tab";
+
+/** Materialise once at module load — the source map is `as const`. */
+const REVERSE_MAP: ReadonlyMap<JourneyMenuBucketId, CourseDetailTabId> =
+  (() => {
+    const out = new Map<JourneyMenuBucketId, CourseDetailTabId>();
+    for (const [tabId, buckets] of Object.entries(BUCKETS_BY_TAB) as Array<
+      [CourseDetailTabId, readonly JourneyMenuBucketId[]]
+    >) {
+      for (const bucketId of buckets) {
+        out.set(bucketId, tabId);
+      }
+    }
+    return out;
+  })();
+
+/** Which tab owns the named bucket. Returns `null` only when the
+ *  bucket id is unknown — the vitest above proves no live bucket id
+ *  hits that branch. */
+export function bucketToTab(
+  bucketId: JourneyMenuBucketId,
+): CourseDetailTabId | null {
+  return REVERSE_MAP.get(bucketId) ?? null;
+}

--- a/apps/admin/lib/journey/use-cross-tab-hint.ts
+++ b/apps/admin/lib/journey/use-cross-tab-hint.ts
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * use-cross-tab-hint — Phase P3b of epic #1850.
+ *
+ * Shared per-tab logic for the cross-tab Inspector hint card. Returns:
+ *
+ *   - `selectedId`            — bucket id in scope of THIS tab, or null
+ *   - `setSelectedId`         — direct setter for LH-menu clicks
+ *   - `crossTabHint`          — non-null when the operator clicked a
+ *                                Preview bubble owned by a different tab
+ *   - `clearHint`             — dismiss the hint (called when the
+ *                                operator selects an in-scope bucket)
+ *   - `handlePreviewSelect`   — wire as PreviewLens `onSelectSection`
+ *
+ * The hook intentionally does NOT manage the tab switch — the calling
+ * tab passes `onJump` from its parent via `onTabSwitch(owningTab,
+ * { selectedBucket })`. Separation keeps each tab in charge of its
+ * own LH state.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+
+import type { ComposeSectionKey } from "@/lib/compose";
+import { BUCKETS_BY_TAB, type CourseDetailTabId, TAB_LABELS } from "@/lib/journey/buckets-by-tab";
+import { bucketToTab } from "@/lib/journey/bucket-to-tab";
+import { getBucketsForSection } from "@/lib/journey/bucket-relations";
+import { JOURNEY_MENU_ITEMS_BY_ID } from "@/lib/journey/menu-items";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+
+export interface CrossTabHint {
+  bucketId: JourneyMenuBucketId;
+  bucketLabel: string;
+  owningTab: CourseDetailTabId;
+  owningTabLabel: string;
+}
+
+interface UseCrossTabHintArgs {
+  /** The tab the hook is mounted on. */
+  currentTab: CourseDetailTabId;
+  /** URL param value of `?selectedBucket=` from `useSearchParams()`.
+   *  When present + in scope of `currentTab`, seeds `selectedId`. */
+  selectedBucketParam: string | null;
+  /** Fires the parent's tab switch. The parent appends
+   *  `?selectedBucket=<id>` so the destination tab's seed effect picks
+   *  the right bucket. */
+  onTabSwitch: (
+    tabId: CourseDetailTabId,
+    options: { selectedBucket: JourneyMenuBucketId },
+  ) => void;
+}
+
+interface UseCrossTabHintReturn {
+  selectedId: JourneyMenuBucketId | null;
+  setSelectedId: (id: JourneyMenuBucketId | null) => void;
+  crossTabHint: CrossTabHint | null;
+  clearHint: () => void;
+  handlePreviewSelect: (section: ComposeSectionKey | null) => void;
+  jumpToOwningTab: () => void;
+}
+
+function isBucketInTab(
+  tabId: CourseDetailTabId,
+  bucketId: JourneyMenuBucketId,
+): boolean {
+  return BUCKETS_BY_TAB[tabId].includes(bucketId);
+}
+
+export function useCrossTabHint({
+  currentTab,
+  selectedBucketParam,
+  onTabSwitch,
+}: UseCrossTabHintArgs): UseCrossTabHintReturn {
+  // Seed from URL param on mount (lazy initializer — no effect, no
+  // setState-in-effect warning). Foreign bucket ids (out of this
+  // tab's scope) collapse to null and the LH renders the empty state.
+  // Subsequent URL changes (cross-tab nav landing on this tab while
+  // already mounted) are caught by the parent — page.tsx changes
+  // `activeTab` via `handleCrossTabSwitch` which re-mounts the tab
+  // component (the parent renders different tabs by conditional), so
+  // the lazy initializer fires fresh on every cross-tab landing.
+  const [selectedId, setSelectedId] = useState<JourneyMenuBucketId | null>(
+    () => {
+      if (!selectedBucketParam) return null;
+      const candidate = selectedBucketParam as JourneyMenuBucketId;
+      if (!JOURNEY_MENU_ITEMS_BY_ID[candidate]) return null;
+      return isBucketInTab(currentTab, candidate) ? candidate : null;
+    },
+  );
+  const [crossTabHint, setCrossTabHint] = useState<CrossTabHint | null>(null);
+
+  const clearHint = useCallback(() => {
+    setCrossTabHint(null);
+  }, []);
+
+  const handlePreviewSelect = useCallback(
+    (section: ComposeSectionKey | null) => {
+      if (!section) {
+        setCrossTabHint(null);
+        return;
+      }
+      const buckets = getBucketsForSection(section);
+      if (buckets.length === 0) {
+        setCrossTabHint(null);
+        return;
+      }
+      // Prefer a bucket that lives on THIS tab — keeps the in-scope
+      // path identical to the pre-P3b behaviour.
+      const inScope = buckets.find((b) => isBucketInTab(currentTab, b));
+      if (inScope) {
+        setSelectedId(inScope);
+        setCrossTabHint(null);
+        return;
+      }
+      // No in-scope bucket — surface the hint for the FIRST bucket
+      // chronologically (matches Journey-tab pick-strip default-select).
+      const owner = buckets[0];
+      const owningTab = bucketToTab(owner);
+      if (!owningTab) {
+        setCrossTabHint(null);
+        return;
+      }
+      const meta = JOURNEY_MENU_ITEMS_BY_ID[owner];
+      setCrossTabHint({
+        bucketId: owner,
+        bucketLabel: meta?.label ?? owner,
+        owningTab,
+        owningTabLabel: TAB_LABELS[owningTab],
+      });
+    },
+    [currentTab],
+  );
+
+  const jumpToOwningTab = useCallback(() => {
+    if (!crossTabHint) return;
+    onTabSwitch(crossTabHint.owningTab, {
+      selectedBucket: crossTabHint.bucketId,
+    });
+    setCrossTabHint(null);
+  }, [crossTabHint, onTabSwitch]);
+
+  return useMemo(
+    () => ({
+      selectedId,
+      setSelectedId,
+      crossTabHint,
+      clearHint,
+      handlePreviewSelect,
+      jumpToOwningTab,
+    }),
+    [selectedId, crossTabHint, clearHint, handlePreviewSelect, jumpToOwningTab],
+  );
+}

--- a/apps/admin/tests/components/cross-tab-hint/CourseScoringTab-cross-tab.test.tsx
+++ b/apps/admin/tests/components/cross-tab-hint/CourseScoringTab-cross-tab.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * CourseScoringTab — Phase P3b (#1850) cross-tab Inspector hint tests.
+ *
+ * Verifies the same out-of-tab / in-tab / jump flow as the Teaching
+ * sibling, with the Scoring tab as the current tab.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  within,
+  act,
+} from "@testing-library/react";
+
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+const __testHooks: { lastOnSelect: ((s: string | null) => void) | null } = {
+  lastOnSelect: null,
+};
+vi.mock("@/app/x/courses/[courseId]/_components/PreviewLens", () => ({
+  PreviewLens: ({
+    onSelectSection,
+  }: {
+    onSelectSection?: (s: string | null) => void;
+  }) => {
+    __testHooks.lastOnSelect = onSelectSection ?? null;
+    return <div data-testid="hf-mock-preview-lens" />;
+  },
+}));
+
+import { CourseScoringTab } from "@/components/scoring-tab/CourseScoringTab";
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({}),
+  } as Response),
+);
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockClear();
+  __testHooks.lastOnSelect = null;
+});
+
+describe("CourseScoringTab — P3b cross-tab Inspector hint", () => {
+  it("renders <CrossTabHintCard> when a Preview click maps to a Journey-tab bucket (intake)", () => {
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseScoringTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    act(() => __testHooks.lastOnSelect!("intake"));
+    const card = screen.getByTestId("hf-cross-tab-hint-card");
+    expect(card).toBeInTheDocument();
+    expect(
+      within(card).getByTestId("hf-cross-tab-hint-jump"),
+    ).toHaveTextContent(/Open in Journey/);
+  });
+
+  it("clicking the jump button fires onTabSwitch with the owning tab + bucket", () => {
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseScoringTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    act(() => __testHooks.lastOnSelect!("intake"));
+    fireEvent.click(screen.getByTestId("hf-cross-tab-hint-jump"));
+    expect(onTabSwitch).toHaveBeenCalledTimes(1);
+    expect(onTabSwitch).toHaveBeenCalledWith("journey", {
+      selectedBucket: "A_intake",
+    });
+  });
+
+  it("clicking a Scoring LH bucket still opens the Inspector directly (regression guard)", () => {
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseScoringTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("hf-scoring-bucket-row-I_scoring"));
+    expect(
+      screen.getByTestId("hf-journey-inspector-bucket-I_scoring"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-cross-tab-hint-card")).toBeNull();
+    expect(onTabSwitch).not.toHaveBeenCalled();
+  });
+
+  it("seeds the Inspector from ?selectedBucket= when the param is in scope", () => {
+    render(
+      <CourseScoringTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={vi.fn()}
+        selectedBucketParam="I_scoring"
+      />,
+    );
+    expect(
+      screen.getByTestId("hf-journey-inspector-bucket-I_scoring"),
+    ).toBeInTheDocument();
+  });
+
+  it("ignores ?selectedBucket= when the bucket is out of scope (URL meant for another tab)", () => {
+    render(
+      <CourseScoringTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={vi.fn()}
+        selectedBucketParam="A_intake"
+      />,
+    );
+    // Should show the empty Inspector (no bucket selected) — the
+    // foreign bucket id is silently ignored on this tab.
+    expect(screen.getByTestId("hf-journey-inspector-empty")).toBeInTheDocument();
+  });
+});

--- a/apps/admin/tests/components/cross-tab-hint/CourseTeachingTab-cross-tab.test.tsx
+++ b/apps/admin/tests/components/cross-tab-hint/CourseTeachingTab-cross-tab.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * CourseTeachingTab — Phase P3b (#1850) cross-tab Inspector hint tests.
+ *
+ * Verifies:
+ *  1. Out-of-tab Preview click → `<CrossTabHintCard>` mounts in the
+ *     Inspector slot with the owning bucket's label + tab label.
+ *  2. Clicking the hint card's primary button fires `onTabSwitch` with
+ *     the owning tab id + `{ selectedBucket }` payload.
+ *  3. In-tab Preview click → Inspector opens directly (regression guard
+ *     for the pre-P3b behaviour).
+ */
+
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  within,
+  act,
+} from "@testing-library/react";
+
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+// PreviewLens mock exposes a hook to fire `onSelectSection` from the
+// test. Each test stashes the latest callback on `__lastOnSelect` so
+// it can dispatch a section key without rendering the real lens.
+const __testHooks: { lastOnSelect: ((s: string | null) => void) | null } = {
+  lastOnSelect: null,
+};
+vi.mock("@/app/x/courses/[courseId]/_components/PreviewLens", () => ({
+  PreviewLens: ({
+    onSelectSection,
+  }: {
+    onSelectSection?: (s: string | null) => void;
+  }) => {
+    __testHooks.lastOnSelect = onSelectSection ?? null;
+    return <div data-testid="hf-mock-preview-lens" />;
+  },
+}));
+
+import { CourseTeachingTab } from "@/components/teaching-tab/CourseTeachingTab";
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({}),
+  } as Response),
+);
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockClear();
+  __testHooks.lastOnSelect = null;
+});
+
+describe("CourseTeachingTab — P3b cross-tab Inspector hint", () => {
+  it("renders <CrossTabHintCard> when a Preview click maps to a Journey-tab bucket", () => {
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseTeachingTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    // Fire the simulated bubble click for the "intake" section. Every
+    // setting touching intake lives in `A_intake` (Journey tab).
+    expect(__testHooks.lastOnSelect).not.toBeNull();
+    act(() => __testHooks.lastOnSelect!("intake"));
+    const card = screen.getByTestId("hf-cross-tab-hint-card");
+    expect(card).toBeInTheDocument();
+    // Jump button mentions the owning tab.
+    expect(
+      within(card).getByTestId("hf-cross-tab-hint-jump"),
+    ).toHaveTextContent(/Open in Journey/);
+    // Headline carries A_intake's educator label.
+    expect(
+      within(card).getByText(/Sign-up & pre-call profile/),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking the jump button fires onTabSwitch with the owning tab + bucket", () => {
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseTeachingTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    act(() => __testHooks.lastOnSelect!("intake"));
+    fireEvent.click(screen.getByTestId("hf-cross-tab-hint-jump"));
+    expect(onTabSwitch).toHaveBeenCalledTimes(1);
+    expect(onTabSwitch).toHaveBeenCalledWith("journey", {
+      selectedBucket: "A_intake",
+    });
+  });
+
+  it("in-tab Preview click (Teaching bucket) opens the Inspector directly — no hint card", () => {
+    // J_feedback lives on the Teaching tab; the `priorCallFeedback`
+    // section is exclusively touched by J_feedback settings (verified
+    // 2026-06-17 via grep — 8 of 8 priorCallFeedback locators carry
+    // `menuGroupKey: "J_feedback"`). Clicking it should select the
+    // bucket, NOT show a cross-tab card.
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseTeachingTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    act(() => __testHooks.lastOnSelect!("priorCallFeedback"));
+    expect(screen.queryByTestId("hf-cross-tab-hint-card")).toBeNull();
+    expect(
+      screen.getByTestId("hf-journey-inspector-bucket-J_feedback"),
+    ).toBeInTheDocument();
+    expect(onTabSwitch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/journey/bucket-to-tab.test.ts
+++ b/apps/admin/tests/lib/journey/bucket-to-tab.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Pins `bucket-to-tab` — Phase P3b of epic #1850.
+ *
+ * Invariants:
+ *  1. Every `JourneyMenuBucketId` resolves to exactly one tab via
+ *     `bucketToTab(bucketId)`.
+ *  2. The Modules tab is intentionally excluded from the reverse map
+ *     (it has no buckets — per-AuthoredModule scope).
+ *  3. The reverse map and the forward `BUCKETS_BY_TAB` are mutual
+ *     inverses — applying both round-trips correctly.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  BUCKETS_BY_TAB,
+  type CourseDetailTabId,
+} from "@/lib/journey/buckets-by-tab";
+import { bucketToTab } from "@/lib/journey/bucket-to-tab";
+import { JOURNEY_MENU_BUCKET_IDS } from "@/lib/journey/menu-items";
+import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
+
+describe("bucket-to-tab — reverse map of BUCKETS_BY_TAB", () => {
+  it("resolves every JourneyMenuBucketId to a single tab", () => {
+    for (const bucketId of JOURNEY_MENU_BUCKET_IDS) {
+      const tab = bucketToTab(bucketId);
+      expect(tab).not.toBeNull();
+    }
+  });
+
+  it("does not return the modules tab (modules has no buckets)", () => {
+    for (const bucketId of JOURNEY_MENU_BUCKET_IDS) {
+      expect(bucketToTab(bucketId)).not.toBe("modules");
+    }
+  });
+
+  it("round-trips: every (tab → buckets) entry inverts cleanly", () => {
+    for (const [tabId, buckets] of Object.entries(BUCKETS_BY_TAB) as Array<
+      [CourseDetailTabId, readonly JourneyMenuBucketId[]]
+    >) {
+      for (const bucketId of buckets) {
+        expect(bucketToTab(bucketId)).toBe(tabId);
+      }
+    }
+  });
+
+  it("returns null for an unknown bucket id (defensive)", () => {
+    // Force a non-existent id past the type system to confirm the
+    // fallback branch is exercised. Real callsites never reach this.
+    const fake = "Z_does_not_exist" as JourneyMenuBucketId;
+    expect(bucketToTab(fake)).toBeNull();
+  });
+});

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-17T16:24:43.856Z",
+  "generatedAt": "2026-06-17T18:14:21.169Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1834,
-  "edgeCount": 4300,
+  "fileCount": 1836,
+  "edgeCount": 4308,
   "skippedEdges": 1,
   "edges": [
     {
@@ -13900,6 +13900,14 @@
       "to": "lib/settings/voice-setting-contracts.ts"
     },
     {
+      "from": "lib/journey/bucket-to-tab.ts",
+      "to": "lib/journey/buckets-by-tab.ts"
+    },
+    {
+      "from": "lib/journey/bucket-to-tab.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
       "from": "lib/journey/buckets-by-tab.ts",
       "to": "lib/journey/setting-contracts.ts"
     },
@@ -13986,6 +13994,30 @@
     {
       "from": "lib/journey/use-cascade-edit-field.ts",
       "to": "lib/journey/use-glow-state.ts"
+    },
+    {
+      "from": "lib/journey/use-cross-tab-hint.ts",
+      "to": "lib/compose/index.ts"
+    },
+    {
+      "from": "lib/journey/use-cross-tab-hint.ts",
+      "to": "lib/journey/bucket-relations.ts"
+    },
+    {
+      "from": "lib/journey/use-cross-tab-hint.ts",
+      "to": "lib/journey/bucket-to-tab.ts"
+    },
+    {
+      "from": "lib/journey/use-cross-tab-hint.ts",
+      "to": "lib/journey/buckets-by-tab.ts"
+    },
+    {
+      "from": "lib/journey/use-cross-tab-hint.ts",
+      "to": "lib/journey/menu-items.ts"
+    },
+    {
+      "from": "lib/journey/use-cross-tab-hint.ts",
+      "to": "lib/journey/setting-contracts.ts"
     },
     {
       "from": "lib/knowledge/assertions.ts",
@@ -23256,7 +23288,7 @@
     },
     {
       "path": "lib/compose/index.ts",
-      "inDegree": 7,
+      "inDegree": 8,
       "outDegree": 0
     },
     {
@@ -24226,12 +24258,17 @@
     },
     {
       "path": "lib/journey/bucket-relations.ts",
-      "inDegree": 0,
+      "inDegree": 1,
       "outDegree": 4
     },
     {
+      "path": "lib/journey/bucket-to-tab.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
       "path": "lib/journey/buckets-by-tab.ts",
-      "inDegree": 0,
+      "inDegree": 2,
       "outDegree": 1
     },
     {
@@ -24246,7 +24283,7 @@
     },
     {
       "path": "lib/journey/menu-items.ts",
-      "inDegree": 0,
+      "inDegree": 1,
       "outDegree": 2
     },
     {
@@ -24266,7 +24303,7 @@
     },
     {
       "path": "lib/journey/setting-contracts.ts",
-      "inDegree": 11,
+      "inDegree": 13,
       "outDegree": 2
     },
     {
@@ -24283,6 +24320,11 @@
       "path": "lib/journey/use-cascade-edit-field.ts",
       "inDegree": 0,
       "outDegree": 2
+    },
+    {
+      "path": "lib/journey/use-cross-tab-hint.ts",
+      "inDegree": 0,
+      "outDegree": 6
     },
     {
       "path": "lib/journey/use-glow-state.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-17T16:24:44.920Z",
+  "generatedAt": "2026-06-17T18:14:21.519Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-17T16:24:41.139Z",
+  "generatedAt": "2026-06-17T18:14:20.124Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-17T16:24:46.121Z",
+  "generatedAt": "2026-06-17T18:14:21.923Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-17T16:24:42.332Z",
+  "generatedAt": "2026-06-17T18:14:20.555Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Phase P3b of epic #1850 — cross-tab Inspector hints. When the operator clicks a Preview-lens bubble whose owning bucket lives on a different Course Detail tab (e.g. clicking the *intake* bubble while on the *Scoring* tab — `A_intake` lives on *Journey*), the Inspector now renders a `<CrossTabHintCard>` offering to jump there instead of silently staying empty. Reuses the same shape as the `out-of-shape` RelevanceWrapper hint pattern from Slice C.

- Shared infra: `lib/journey/bucket-to-tab.ts` (reverse map of `BUCKETS_BY_TAB`), `lib/journey/use-cross-tab-hint.ts` (per-tab hook), `components/shared/CrossTabHintCard.tsx` (~35 LOC card).
- Wired into all 4 CourseXTab files (Journey, Teaching, Scoring, Modules).
- `page.tsx` passes `onTabSwitch` (sets `activeTab` + URL `?tab=&selectedBucket=`) + `selectedBucketParam` from `useSearchParams()` to each tab.
- 12 new vitests across 3 files; 0 regression in 177-test sibling bank.
- `hf-*` classes only. No inline styles. No hardcoded hex (composes `hf-card-compact` + `hf-btn-primary`).

## What ships per tab

| Tab | Behaviour |
|---|---|
| Journey | Preserves Slice C pick-strip flow when buckets are in-tab. Cross-tab hint card surfaces for buckets owned elsewhere (future-proofing — today all buckets clicked from Journey are journey-owned). |
| Teaching | Out-of-tab click (e.g. `intake` section) → hint card pointing to Journey. In-tab click (e.g. `priorCallFeedback` → J_feedback) opens Inspector directly. |
| Scoring | Same shape as Teaching. Also seeds Inspector from `?selectedBucket=` when in scope; silently ignores when out of scope (URL was meant for a different tab). |
| Modules | Has no buckets — every Preview click is cross-tab. Hint card replaces the per-module Inspector while active; clearing restores per-module panel. |

## Verified by

- `apps/admin/lib/journey/bucket-to-tab.ts` — reverse map built from `BUCKETS_BY_TAB` (file:line authoritative); test pins exhaustive forward/reverse round-trip [verified].
- `apps/admin/tests/lib/journey/bucket-to-tab.test.ts:23` — \"resolves every JourneyMenuBucketId to a single tab\" + 3 sibling cases — 4/4 green.
- `apps/admin/tests/components/cross-tab-hint/CourseTeachingTab-cross-tab.test.tsx:75` — \"renders <CrossTabHintCard> when a Preview click maps to a Journey-tab bucket\" + 2 sibling cases — 3/3 green [verified].
- `apps/admin/tests/components/cross-tab-hint/CourseScoringTab-cross-tab.test.tsx` — 5/5 green including the `?selectedBucket=` seed-and-ignore-when-out-of-scope path [verified].
- `npx vitest run tests/components/scoring-tab/ tests/components/teaching-tab/ tests/components/modules-tab/ tests/components/journey-tab/ tests/lib/journey/ tests/components/cross-tab-hint/` — 177/177 green.
- `npx vitest run tests/components/` — 703/703 green; no regressions outside the touched surface.
- `npx tsc --noEmit` — clean on every touched file (`grep -E '(use-cross-tab-hint|bucket-to-tab|CrossTabHintCard|CourseScoringTab|CourseTeachingTab|CourseJourneyTab|CourseModulesTab)'` returns empty).
- `npx eslint <touched files>` — 0 errors, 0 warnings on touched files (the `react-hooks/set-state-in-effect` warning was eliminated by switching to a `useState` lazy initializer — the URL param is consumed at mount and subsequent cross-tab nav re-mounts the tab via the existing `activeTab === '<id>'` conditional dispatch in page.tsx).
- `npm run ratchet:check` — lint counts identical to baseline (15 errors / 4510 warnings — all pre-existing on `main`).

## Lattice survey

| Pillar | Check | Result |
|---|---|---|
| Chain Contracts | No chain-stage boundary crossed (read-only UI plumbing). | n/a |
| Guards | No new ESLint rule. No DB mutation. No `getAIConfig` call. | n/a |
| Cascade | No cascade-eligible knob written. Reuses `BUCKETS_BY_TAB` + `JOURNEY_MENU_ITEMS_BY_ID` (canonical sources). | respected |
| Rules | `ui-design-system.md` — `hf-card-compact` + `hf-btn-primary` + lucide icon, no inline styles. | passes |
| Coverage | New surface adds tests in same PR (12 vitests). | passes |

Inverse-probed claims:
- \"Modules tab has no buckets\" → [`apps/admin/lib/journey/buckets-by-tab.ts:51`](apps/admin/lib/journey/buckets-by-tab.ts) \`modules: []\` [verified]
- \"`priorCallFeedback` section is J_feedback-only\" → 8 of 8 entries via `grep -B20 'section: \"priorCallFeedback\"' apps/admin/lib/journey/setting-contracts.entries.ts | grep menuGroupKey` [verified].
- \"`intake` section is A_intake-owned\" → 3 entries at `apps/admin/lib/journey/setting-contracts.entries.ts:50/71/88` [verified].

Refs #1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)