### PR TITLE
chore(voice): VoiceConfigSection inline-renders all 11 VOICE_SETTINGS

### DIFF
--- a/apps/admin/components/voice/VoiceConfigSection.tsx
+++ b/apps/admin/components/voice/VoiceConfigSection.tsx
@@ -70,6 +70,11 @@ const CROSS_CUTTING_LABELS: Record<string, { label: string; help: string; type: 
     help: "Hang up after this many seconds of silence. Lower = cheaper but harsher.",
     type: "number",
   },
+  silenceThreshold: {
+    label: "Silence re-prompt threshold (seconds)",
+    help: "Seconds of silence before the AI re-prompts (distinct from the hard hang-up timeout above).",
+    type: "number",
+  },
   maxDurationSeconds: {
     label: "Max call duration (seconds)",
     help: "Hard cap on call length. VAPI will end any call at this point.",
@@ -100,13 +105,76 @@ const CROSS_CUTTING_LABELS: Record<string, { label: string; help: string; type: 
     help: "Force this string into Call.voiceEndedReason. Debugging only.",
     type: "string",
   },
+  voiceSpeed: {
+    label: "Voice speed",
+    help: "Playback rate multiplier (1.0 default).",
+    type: "number",
+  },
+  voicePitch: {
+    label: "Voice pitch",
+    help: "Provider-supported pitch offset.",
+    type: "number",
+  },
+  interruptSensitivity: {
+    label: "Interrupt sensitivity",
+    help: "How readily the AI yields when the learner starts speaking.",
+    type: "number",
+  },
+  phoneNumber: {
+    label: "Outbound phone number",
+    help: "Caller-id phone number (E.164). Distinct from `phoneNumberId` below — this is the human-readable number string.",
+    type: "string",
+  },
+  vapiAssistantId: {
+    label: "VAPI assistant ID",
+    help: "Provider-specific assistant id (advanced).",
+    type: "string",
+  },
 };
 
+// FIELD_GROUPS decides which form field renders in which group. Keys are
+// the storagePath leaves used by the provider's `schemaFields` payload.
+// The set is the union of historical schema field names AND the
+// `VOICE_SETTINGS` registry storagePath leaves — keeping both surfaces
+// consistent. `phoneNumber` (E.164 string) and `phoneNumberId` (VAPI
+// object id) are intentionally distinct fields and both appear under
+// "Advanced".
 const FIELD_GROUPS: { title: string; keys: string[] }[] = [
   { title: "Behaviour", keys: ["autoPipeline", "endedReasonOverride"] },
-  { title: "Voice & transcription", keys: ["voiceId", "voiceProvider", "transcriber", "backgroundSound", "recordingEnabled"] },
-  { title: "Cost safety", keys: ["silenceTimeoutSeconds", "maxDurationSeconds", "voicemailDetectionEnabled", "endCallPhrases", "maxCostPerCallUsd"] },
-  { title: "Advanced", keys: ["pollIntervalMs", "publicKey", "phoneNumberId"] },
+  {
+    title: "Voice & transcription",
+    keys: [
+      "voiceId",
+      "voiceProvider",
+      "transcriber",
+      "backgroundSound",
+      "recordingEnabled",
+      "voiceSpeed",
+      "voicePitch",
+    ],
+  },
+  {
+    title: "Cost safety",
+    keys: [
+      "silenceTimeoutSeconds",
+      "silenceThreshold",
+      "maxDurationSeconds",
+      "voicemailDetectionEnabled",
+      "endCallPhrases",
+      "maxCostPerCallUsd",
+    ],
+  },
+  {
+    title: "Advanced",
+    keys: [
+      "pollIntervalMs",
+      "publicKey",
+      "phoneNumberId",
+      "phoneNumber",
+      "interruptSensitivity",
+      "vapiAssistantId",
+    ],
+  },
 ];
 
 export function sourceBadge(source: Source, scope: "course" | "domain") {

--- a/apps/admin/tests/lib/settings/voice-settings-render-coverage.test.ts
+++ b/apps/admin/tests/lib/settings/voice-settings-render-coverage.test.ts
@@ -60,48 +60,21 @@ const COMMAND_PALETTE_SRC: string = (() => {
 // Exempt list — VOICE_SETTINGS entries not yet rendered inline in
 // VoiceConfigSection. Each entry MUST cite the alternative surface
 // (currently: CommandPalette spread + Tuning tab auto-discovery).
+//
+// 2026-06-17: the exempt list went to ZERO after wiring all 11 entries
+// into FIELD_GROUPS (3 inline-by-id, 2 inline-by-storagePath-leaf, 6
+// added). The classifier now matches both registry `id` AND the leaf
+// of `storagePath` — `endCallAfterSilence` resolves through
+// `silenceTimeoutSeconds`, `maxCallDuration` through `maxDurationSeconds`.
 // ────────────────────────────────────────────────────────────
 
 interface ExemptEntry {
   reason: string;
 }
 
-const RENDER_EXEMPT: Record<string, ExemptEntry> = {
-  interruptSensitivity: {
-    reason:
-      "Reachable via CommandPalette spread (...VOICE_SETTINGS) + Tuning tab auto-discovery via prisma.parameter.findMany. VoiceConfigSection inline render is the follow-on.",
-  },
-  voiceSpeed: {
-    reason:
-      "Reachable via CommandPalette spread + Tuning tab. VoiceConfigSection inline render is the follow-on.",
-  },
-  voicePitch: {
-    reason:
-      "Reachable via CommandPalette spread + Tuning tab. VoiceConfigSection inline render is the follow-on.",
-  },
-  silenceThreshold: {
-    reason:
-      "Reachable via CommandPalette spread + Tuning tab. VoiceConfigSection covers `silenceTimeoutSeconds` (different field). Naming overlap — clarify in follow-on.",
-  },
-  endCallAfterSilence: {
-    reason:
-      "Reachable via CommandPalette spread + Tuning tab. VoiceConfigSection covers `silenceTimeoutSeconds` (different field) and `endCallPhrases`. Follow-on to unify.",
-  },
-  maxCallDuration: {
-    reason:
-      "Reachable via CommandPalette spread + Tuning tab. VoiceConfigSection covers `maxDurationSeconds` (different field name). Follow-on to unify naming.",
-  },
-  phoneNumber: {
-    reason:
-      "Reachable via CommandPalette spread + Tuning tab. VoiceConfigSection covers `phoneNumberId` (different field — ID vs human-readable). Follow-on.",
-  },
-  vapiAssistantId: {
-    reason:
-      "Reachable via CommandPalette spread + Tuning tab. Implementation-specific — may not need inline UI exposure.",
-  },
-};
+const RENDER_EXEMPT: Record<string, ExemptEntry> = {};
 
-const EXPECTED_EXEMPT_COUNT = 8;
+const EXPECTED_EXEMPT_COUNT = 0;
 
 // ────────────────────────────────────────────────────────────
 // Classification
@@ -115,13 +88,32 @@ interface SettingResult {
   reason?: string;
 }
 
+/**
+ * Return the trailing segment of a `storagePath` (after the last `.`),
+ * which is the literal key VoiceConfigSection's `FIELD_GROUPS` arrays
+ * use to dispatch fields. `playbook.voiceConfig.silenceTimeoutSeconds`
+ * → `silenceTimeoutSeconds`.
+ */
+function storagePathLeaf(storagePath: unknown): string | null {
+  if (typeof storagePath !== "string") return null;
+  const idx = storagePath.lastIndexOf(".");
+  return idx >= 0 ? storagePath.slice(idx + 1) : storagePath;
+}
+
 function classify(id: string): SettingResult {
   if (RENDER_EXEMPT[id]) {
     return { id, classification: "exempt", reason: RENDER_EXEMPT[id].reason };
   }
-  // Inline-rendered: appears as a quoted string in VoiceConfigSection's
-  // hardcoded keys array.
+  // Inline-rendered: the registry `id` OR the leaf of `storagePath`
+  // appears as a quoted string in VoiceConfigSection's `FIELD_GROUPS`
+  // arrays. Some registry ids (e.g. `endCallAfterSilence`) reach the
+  // editor under their storagePath leaf (`silenceTimeoutSeconds`).
   if (VOICE_CONFIG_SECTION_SRC.includes(`"${id}"`)) {
+    return { id, classification: "inline-rendered" };
+  }
+  const entry = VOICE_SETTINGS.find((s) => s.id === id);
+  const leaf = storagePathLeaf(entry?.storagePath);
+  if (leaf && leaf !== id && VOICE_CONFIG_SECTION_SRC.includes(`"${leaf}"`)) {
     return { id, classification: "inline-rendered" };
   }
   return { id, classification: "gap" };


### PR DESCRIPTION
## Summary

Outrageous-hardcoding sweep #6 — follow-on to #1879. The Coverage test in #1879 documented that 8 of 11 VOICE_SETTINGS entries were reachable only via Cmd+K (CommandPalette spread), not via the inline `VoiceConfigSection` editor. This PR closes the gap. Operator said "make some calls and leave it robust" — that's what landed.

Changes:
- Coverage classifier now matches both the registry `id` AND the leaf of `storagePath`. `endCallAfterSilence` resolves through `silenceTimeoutSeconds`, `maxCallDuration` through `maxDurationSeconds` (both already in FIELD_GROUPS).
- `FIELD_GROUPS` extended with 6 truly-missing entries:
  - **Voice & transcription**: `voiceSpeed`, `voicePitch`
  - **Cost safety**: `silenceThreshold`
  - **Advanced**: `interruptSensitivity`, `phoneNumber`, `vapiAssistantId`
- `CROSS_CUTTING_LABELS` gains the 6 corresponding label/help/type rows.
- `phoneNumber` (E.164 string) and `phoneNumberId` (VAPI object id) coexist under "Advanced" — comment documents they are distinct fields.
- `EXPECTED_EXEMPT_COUNT` drops 8 → 0; `RENDER_EXEMPT` is empty.

## Verified by

- `npx vitest run tests/lib/settings/voice-settings-render-coverage.test.ts` → 6/6 pass.
- `npx tsc --noEmit` → 36 errors (== current baseline).
- All 11 VOICE_SETTINGS entries classify as `inline-rendered` (3 by id, 2 by storagePath leaf, 6 newly added).

## Lattice survey

- Surface: VOICE_SETTINGS registry → VoiceConfigSection inline rendering.
- Sibling writers: zero. CommandPalette spread (audit ratchet from #1879) still works.
- Convergence: storagePath-leaf classifier closes the naming-mismatch class structurally; exempt-count ratchet at 0 catches any future regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)