### PR TITLE
feat(modules): P3d — appliesTo filter on Module Inspector (#1850)

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -1791,6 +1791,7 @@ export default function CourseDetailPage() {
               : 'continuous'
           }
           onTabSwitch={handleCrossTabSwitch}
+          playbookConfig={detail?.config as Record<string, unknown> | null | undefined}
         />
       )}
 

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -27,7 +27,7 @@
  * restores the per-module Inspector.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
 import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
@@ -35,7 +35,10 @@ import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell"
 import type { CourseDetailTabId } from "@/lib/journey/buckets-by-tab";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
 import { useCrossTabHint } from "@/lib/journey/use-cross-tab-hint";
-import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
+import type {
+  AuthoredModuleSettings,
+  PlaybookConfig,
+} from "@/lib/types/json-fields";
 
 import { ModuleInspectorPanel } from "./ModuleInspectorPanel";
 import { ModulesLhPicker } from "./ModulesLhPicker";
@@ -56,12 +59,18 @@ interface CourseModulesTabProps {
     tabId: CourseDetailTabId,
     options: { selectedBucket: JourneyMenuBucketId },
   ) => void;
+  /** Full PlaybookConfig — threaded through to ModuleInspectorPanel so
+   *  it can derive the editor-facing CourseShape (P3d, #1850). Optional;
+   *  legacy callers without it fall back to the binary courseStyle and
+   *  exam-only G8 entries render as `out-of-shape`. */
+  playbookConfig?: Record<string, unknown> | null;
 }
 
 export function CourseModulesTab({
   courseId,
   courseStyle,
   onTabSwitch,
+  playbookConfig,
 }: CourseModulesTabProps) {
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
   const [modules, setModules] = useState<ModuleRow[]>([]);
@@ -107,6 +116,18 @@ export function CourseModulesTab({
   const handleSaved = useCallback(() => {
     setReloadKey((k) => k + 1);
   }, []);
+
+  // P3d (#1850) — cast once at the boundary; ModuleInspectorPanel
+  // consumes the typed shape and falls back to "continuous" when null.
+  // Hoisted above the continuous-course early return to keep hook order
+  // stable across renders (react-hooks/rules-of-hooks).
+  const typedPlaybookConfig = useMemo<PlaybookConfig | null>(
+    () =>
+      playbookConfig === null || playbookConfig === undefined
+        ? null
+        : (playbookConfig as unknown as PlaybookConfig),
+    [playbookConfig],
+  );
 
   if (courseStyle === "continuous") {
     return (
@@ -170,6 +191,7 @@ export function CourseModulesTab({
             selectedModuleId={selectedModuleId}
             selectedModuleLabel={selectedModule?.label ?? null}
             settings={selectedModule?.settings ?? null}
+            playbookConfig={typedPlaybookConfig}
             onSaved={handleSaved}
           />
         )

--- a/apps/admin/components/modules-tab/ModuleInspectorPanel.tsx
+++ b/apps/admin/components/modules-tab/ModuleInspectorPanel.tsx
@@ -30,15 +30,21 @@
  * `Playbook.config.modules[i].settings.*`).
  */
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { JourneyField } from "@/components/journey-controls";
+import { RelevanceWrapper } from "@/components/journey-controls/RelevanceWrapper";
+import { getCourseShape } from "@/lib/journey/course-shape";
 import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
 import type {
+  CourseShape,
   JourneySettingContract,
   StoragePathStruct,
 } from "@/lib/journey/setting-contracts";
-import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
+import type {
+  AuthoredModuleSettings,
+  PlaybookConfig,
+} from "@/lib/types/json-fields";
 
 interface ModuleInspectorPanelProps {
   /** Course id — passed to the PATCH route URL. */
@@ -50,6 +56,12 @@ interface ModuleInspectorPanelProps {
    *  `/api/courses/:courseId/modules` → `modules[].settings`).
    *  Undefined or empty → all fields render with default values. */
   settings: Partial<AuthoredModuleSettings> | null;
+  /** The course's full PlaybookConfig — used by `getCourseShape` to
+   *  decide which G8 entries apply to this course shape. Optional so
+   *  consumers that haven't threaded it through (yet) keep working;
+   *  when omitted the helper short-circuits to "continuous" and the
+   *  exam-only entries render as `out-of-shape`. P3d (#1850). */
+  playbookConfig?: PlaybookConfig | null;
   /** Optional hook fired after every successful save. Parent uses it
    *  to refetch the module list so the Inspector reflects persisted
    *  state on subsequent renders. */
@@ -73,13 +85,62 @@ const G8_SETTINGS: readonly JourneySettingContract[] = JOURNEY_SETTINGS.filter(
   (c) => c.group === "G8" && c.scope === "module",
 );
 
+/** P3d (#1850) — true when the contract declares an `appliesTo` set
+ *  that excludes the current `courseShape`. Show-don't-hide: the row
+ *  remains in the DOM but is wrapped in `RelevanceWrapper state="out-of-shape"`.
+ *  Contracts that don't declare `appliesTo` apply to all shapes. */
+function isOutOfShape(
+  contract: JourneySettingContract,
+  courseShape: CourseShape,
+): boolean {
+  if (!contract.appliesTo || contract.appliesTo.length === 0) return false;
+  return !contract.appliesTo.includes(courseShape);
+}
+
+/** Educator-facing explainer chip text for the `out-of-shape` overlay.
+ *  Reads the contract's allowed shapes to render "Exam courses use … —
+ *  this is a Structured course" rather than a generic "doesn't apply". */
+function outOfShapeReason(
+  contract: JourneySettingContract,
+  courseShape: CourseShape,
+): string {
+  const allowed = (contract.appliesTo ?? []) as readonly CourseShape[];
+  const allowedLabel = allowed.map(shapeLabel).join(" or ");
+  const currentLabel = shapeLabel(courseShape);
+  return `${allowedLabel} courses use ${contract.educatorLabel.toLowerCase()} — this is a ${currentLabel} course`;
+}
+
+/** Short title-cased label for the chip — keeps the message educator-friendly. */
+function shapeLabel(shape: CourseShape): string {
+  switch (shape) {
+    case "structured":
+      return "Structured";
+    case "continuous":
+      return "Continuous";
+    case "exam":
+      return "Exam";
+    default:
+      return shape;
+  }
+}
+
 export function ModuleInspectorPanel({
   courseId,
   selectedModuleId,
   selectedModuleLabel,
   settings,
+  playbookConfig,
   onSaved,
 }: ModuleInspectorPanelProps) {
+  // P3d (#1850) — derive the editor-facing course shape so we can
+  // dim G8 entries whose `appliesTo` excludes this course's shape
+  // (e.g. IELTS cue-card pool on a non-exam structured course).
+  // Memoised because PlaybookConfig is a large object that's stable
+  // between renders within a tab session.
+  const courseShape: CourseShape = useMemo(
+    () => getCourseShape(playbookConfig ?? null),
+    [playbookConfig],
+  );
   // Module-scope mutator — P3c (#1850). Threads `selectedModuleId`
   // through as the per-call `arraySelector` so the existing
   // `/journey-setting` PATCH route resolves the right
@@ -165,18 +226,32 @@ export function ModuleInspectorPanel({
         {G8_SETTINGS.map((contract) => {
           const key = lastSegmentOfStoragePath(contract);
           const value = key ? moduleSettings[key] : undefined;
+          const outOfShape = isOutOfShape(contract, courseShape);
+          const field = (
+            <JourneyField
+              contract={contract}
+              value={value}
+              options={contract.options}
+              onSave={(next) => handleSave(contract.id, next)}
+            />
+          );
           return (
             <div
               key={contract.id}
               className="hf-journey-inspector-row"
               data-testid={`hf-module-inspector-row-${contract.id}`}
+              data-relevance-state={outOfShape ? "out-of-shape" : "active"}
             >
-              <JourneyField
-                contract={contract}
-                value={value}
-                options={contract.options}
-                onSave={(next) => handleSave(contract.id, next)}
-              />
+              {outOfShape ? (
+                <RelevanceWrapper
+                  state="out-of-shape"
+                  reason={outOfShapeReason(contract, courseShape)}
+                >
+                  {field}
+                </RelevanceWrapper>
+              ) : (
+                field
+              )}
             </div>
           );
         })}

--- a/apps/admin/lib/journey/course-shape.ts
+++ b/apps/admin/lib/journey/course-shape.ts
@@ -1,0 +1,59 @@
+/**
+ * course-shape.ts — Phase P3d of the Course Detail tab refactor (epic #1850).
+ *
+ * Adapter from the binary runtime `CourseStyle`
+ * (`structured | continuous` from `lib/pipeline/course-style.ts`) to the
+ * ternary editor-facing `CourseShape` (`structured | continuous | exam`
+ * from `lib/journey/setting-contracts.ts`).
+ *
+ * The `JourneySettingContract.appliesTo` field is keyed by `CourseShape`
+ * so the Inspector can render an `out-of-shape` overlay for settings the
+ * current course doesn't use (e.g. IELTS cue-card pool on a non-exam
+ * structured course). The runtime pipeline only cares about the binary
+ * style; this adapter is purely the EDITOR side per the
+ * `setting-contracts.ts` `CourseShape` JSDoc:
+ *
+ *   > `appliesTo` is the *editor-facing* envelope: it tells the Inspector
+ *   > whether to render a setting at all for a given course. The runtime
+ *   > course-style resolver is unchanged.
+ *
+ * Detection heuristic (short-term):
+ *   - `lessonPlanMode !== "structured"` → `"continuous"`
+ *   - any module carries non-empty `settings.cueCardPool` → `"exam"`
+ *   - otherwise → `"structured"`
+ *
+ * The cue-card-pool heuristic is a stop-gap: long-term the wizard
+ * projection should set an explicit `Playbook.config.examShape` (or
+ * widen `lessonPlanMode` to a ternary value) so this helper doesn't
+ * have to read into `modules[].settings`. Tracked separately — for
+ * now the heuristic matches the way IELTS courses are authored
+ * (the cue-card pool is the most discriminating module setting).
+ */
+
+import { getCourseStyle } from "../pipeline/course-style";
+import type { PlaybookConfig } from "../types/json-fields";
+import type { CourseShape } from "./setting-contracts";
+
+/**
+ * Derive the editor-facing `CourseShape` from a Playbook config.
+ *
+ * Returns `"continuous"` when the runtime style resolver says so, the
+ * Inspector hides modules entirely on this branch.
+ *
+ * For structured courses, looks for an exam-like signal — any
+ * AuthoredModule whose `settings.cueCardPool` is a non-empty array.
+ * That marks the course as an exam (the IELTS Mock pattern). All other
+ * structured courses resolve to `"structured"`.
+ */
+export function getCourseShape(
+  config: PlaybookConfig | null | undefined,
+): CourseShape {
+  const style = getCourseStyle(config);
+  if (style === "continuous") return "continuous";
+  const modules = config?.modules ?? [];
+  const hasCueCardPool = modules.some((m) => {
+    const pool = m?.settings?.cueCardPool;
+    return Array.isArray(pool) && pool.length > 0;
+  });
+  return hasCueCardPool ? "exam" : "structured";
+}

--- a/apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx
+++ b/apps/admin/tests/components/modules-tab/ModuleInspectorPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 
 import { ModuleInspectorPanel } from "@/components/modules-tab/ModuleInspectorPanel";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
 
 afterEach(() => {
   cleanup();
@@ -175,6 +176,151 @@ describe("ModuleInspectorPanel — P3c mutator wiring (#1850)", () => {
       expect(onSaved).not.toHaveBeenCalled();
     } finally {
       process.off("unhandledRejection", swallow);
+    }
+  });
+});
+
+describe("ModuleInspectorPanel — P3d appliesTo filter (#1850)", () => {
+  /** A structured (non-exam) course config — no module cue-card pools. */
+  const STRUCTURED_NON_EXAM: PlaybookConfig = {
+    lessonPlanMode: "structured",
+    modules: [
+      {
+        id: "m1",
+        label: "Module 1",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "20 min",
+        scoringFired: "All four",
+        voiceBandReadout: false,
+        sessionTerminal: false,
+        frequency: "always_available",
+        outcomesPrimary: [],
+        settings: {},
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any,
+  } as PlaybookConfig;
+
+  /** An exam course config — at least one module carries a cue-card pool. */
+  const EXAM: PlaybookConfig = {
+    lessonPlanMode: "structured",
+    modules: [
+      {
+        id: "p1",
+        label: "Part 1",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "20 min",
+        scoringFired: "All four",
+        voiceBandReadout: false,
+        sessionTerminal: false,
+        frequency: "always_available",
+        outcomesPrimary: [],
+        settings: {},
+      },
+      {
+        id: "p2",
+        label: "Part 2",
+        learnerSelectable: true,
+        mode: "tutor",
+        duration: "2 min monologue",
+        scoringFired: "All four",
+        voiceBandReadout: true,
+        sessionTerminal: false,
+        frequency: "always_available",
+        outcomesPrimary: [],
+        settings: {
+          cueCardPool: [
+            { topic: "Describe a hobby", bullets: ["What it is"] },
+          ],
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any,
+  } as PlaybookConfig;
+
+  /** The 3 exam-only G8 entries the brief calls out. */
+  const EXAM_ONLY_IDS = [
+    "moduleCueCardPool",
+    "moduleScheduledCues",
+    "moduleFirstTimeOrientationLine",
+  ] as const;
+
+  /** All 8 G8 entries — used to assert show-don't-hide. */
+  const ALL_G8_IDS = [
+    "moduleQuestionTarget",
+    "moduleMinSpeakingSec",
+    "moduleCueCardPool",
+    "moduleClosingLine",
+    "moduleFirstTimeOrientationLine",
+    "moduleScheduledCues",
+    "moduleScaffoldPool",
+    "moduleProfileFieldsToCapture",
+  ] as const;
+
+  it("on a non-exam structured course, the 3 exam-only G8 entries render as out-of-shape", () => {
+    render(
+      <ModuleInspectorPanel
+        courseId="course-1"
+        selectedModuleId="m1"
+        selectedModuleLabel="Module 1"
+        settings={null}
+        playbookConfig={STRUCTURED_NON_EXAM}
+      />,
+    );
+
+    for (const id of EXAM_ONLY_IDS) {
+      const row = screen.getByTestId(`hf-module-inspector-row-${id}`);
+      expect(row.getAttribute("data-relevance-state")).toBe("out-of-shape");
+      // RelevanceWrapper emits a wrapper with data-state="out-of-shape"
+      expect(row.querySelector('[data-state="out-of-shape"]')).toBeTruthy();
+    }
+
+    // The other 5 entries render active (no overlay)
+    const activeIds = ALL_G8_IDS.filter(
+      (id) => !EXAM_ONLY_IDS.includes(id as (typeof EXAM_ONLY_IDS)[number]),
+    );
+    for (const id of activeIds) {
+      const row = screen.getByTestId(`hf-module-inspector-row-${id}`);
+      expect(row.getAttribute("data-relevance-state")).toBe("active");
+    }
+  });
+
+  it("on an exam course, all 8 G8 entries render as editable (active)", () => {
+    render(
+      <ModuleInspectorPanel
+        courseId="course-1"
+        selectedModuleId="p1"
+        selectedModuleLabel="Part 1"
+        settings={null}
+        playbookConfig={EXAM}
+      />,
+    );
+
+    for (const id of ALL_G8_IDS) {
+      const row = screen.getByTestId(`hf-module-inspector-row-${id}`);
+      expect(row.getAttribute("data-relevance-state")).toBe("active");
+      expect(row.querySelector('[data-state="out-of-shape"]')).toBeNull();
+    }
+  });
+
+  it("show-don't-hide: every G8 entry is in the DOM regardless of course shape", () => {
+    // Render on a non-exam course where 3 are out-of-shape.
+    render(
+      <ModuleInspectorPanel
+        courseId="course-1"
+        selectedModuleId="m1"
+        selectedModuleLabel="Module 1"
+        settings={null}
+        playbookConfig={STRUCTURED_NON_EXAM}
+      />,
+    );
+    // All 8 rows are present — the out-of-shape ones are wrapped, not hidden.
+    for (const id of ALL_G8_IDS) {
+      expect(
+        screen.getByTestId(`hf-module-inspector-row-${id}`),
+      ).toBeInTheDocument();
     }
   });
 });

--- a/apps/admin/tests/lib/journey/course-shape.test.ts
+++ b/apps/admin/tests/lib/journey/course-shape.test.ts
@@ -1,0 +1,152 @@
+/**
+ * course-shape — Phase P3d of the Course Detail tab refactor (epic #1850).
+ *
+ * Pins the binary-CourseStyle → ternary-CourseShape adapter:
+ *   - continuous course → "continuous"
+ *   - structured with NO module cue cards → "structured"
+ *   - structured WITH a non-empty module cue-card pool → "exam"
+ *   - empty / null config → defaults to "structured" via getCourseStyle
+ *     short-circuit ("continuous"), so empty → "continuous"
+ *
+ * The empty-config case warrants a note: `getCourseStyle` default-denies
+ * to `"continuous"` unless `lessonPlanMode === "structured"`. This is
+ * intentional — see `course-style.ts` header. The brief asks for
+ * `empty config → "structured" (default)` but the project-wide invariant
+ * is the opposite. We pin the actual behaviour rather than diverge.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { getCourseShape } from "@/lib/journey/course-shape";
+import type { PlaybookConfig } from "@/lib/types/json-fields";
+
+function makeConfig(overrides: Partial<PlaybookConfig> = {}): PlaybookConfig {
+  return {
+    lessonPlanMode: "continuous",
+    ...overrides,
+  } as PlaybookConfig;
+}
+
+describe("getCourseShape", () => {
+  it("returns 'continuous' for a continuous course", () => {
+    const config = makeConfig({ lessonPlanMode: "continuous" });
+    expect(getCourseShape(config)).toBe("continuous");
+  });
+
+  it("returns 'structured' for a structured course with no module cue cards", () => {
+    const config = makeConfig({
+      lessonPlanMode: "structured",
+      modules: [
+        {
+          id: "m1",
+          label: "Module 1",
+          learnerSelectable: true,
+          mode: "tutor",
+          duration: "20 min",
+          scoringFired: "All four",
+          voiceBandReadout: false,
+          sessionTerminal: false,
+          frequency: "always_available",
+          outcomesPrimary: [],
+          settings: {
+            questionTarget: { min: 10, target: 13 },
+          },
+        },
+        {
+          id: "m2",
+          label: "Module 2",
+          learnerSelectable: true,
+          mode: "tutor",
+          duration: "20 min",
+          scoringFired: "All four",
+          voiceBandReadout: false,
+          sessionTerminal: false,
+          frequency: "always_available",
+          outcomesPrimary: [],
+          // No settings at all
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    });
+    expect(getCourseShape(config)).toBe("structured");
+  });
+
+  it("returns 'exam' for a structured course with a non-empty module cue-card pool", () => {
+    const config = makeConfig({
+      lessonPlanMode: "structured",
+      modules: [
+        {
+          id: "p1",
+          label: "Part 1",
+          learnerSelectable: true,
+          mode: "tutor",
+          duration: "20 min",
+          scoringFired: "All four",
+          voiceBandReadout: false,
+          sessionTerminal: false,
+          frequency: "always_available",
+          outcomesPrimary: [],
+          settings: {},
+        },
+        {
+          id: "p2",
+          label: "Part 2",
+          learnerSelectable: true,
+          mode: "tutor",
+          duration: "2 min monologue",
+          scoringFired: "All four",
+          voiceBandReadout: true,
+          sessionTerminal: false,
+          frequency: "always_available",
+          outcomesPrimary: [],
+          settings: {
+            cueCardPool: [
+              { topic: "Describe a hobby", bullets: ["What it is", "Why you like it"] },
+            ],
+          },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    });
+    expect(getCourseShape(config)).toBe("exam");
+  });
+
+  it("returns 'continuous' for an empty config (default-deny by getCourseStyle)", () => {
+    // getCourseStyle default-denies to "continuous" unless
+    // `lessonPlanMode === "structured"`. See `course-style.ts` header.
+    expect(getCourseShape({} as PlaybookConfig)).toBe("continuous");
+    expect(getCourseShape(null)).toBe("continuous");
+    expect(getCourseShape(undefined)).toBe("continuous");
+  });
+
+  it("returns 'structured' when modules array is empty on a structured course", () => {
+    const config = makeConfig({
+      lessonPlanMode: "structured",
+      modules: [],
+    });
+    expect(getCourseShape(config)).toBe("structured");
+  });
+
+  it("returns 'structured' when modules carry empty cueCardPool arrays", () => {
+    const config = makeConfig({
+      lessonPlanMode: "structured",
+      modules: [
+        {
+          id: "m1",
+          label: "M1",
+          learnerSelectable: true,
+          mode: "tutor",
+          duration: "20 min",
+          scoringFired: "All four",
+          voiceBandReadout: false,
+          sessionTerminal: false,
+          frequency: "always_available",
+          outcomesPrimary: [],
+          settings: { cueCardPool: [] },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    });
+    expect(getCourseShape(config)).toBe("structured");
+  });
+});

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-17T18:14:21.169Z",
+  "generatedAt": "2026-06-17T18:24:49.786Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1836,
-  "edgeCount": 4308,
+  "fileCount": 1837,
+  "edgeCount": 4311,
   "skippedEdges": 1,
   "edges": [
     {
@@ -13924,6 +13924,18 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/journey/course-shape.ts",
+      "to": "lib/journey/setting-contracts.ts"
+    },
+    {
+      "from": "lib/journey/course-shape.ts",
+      "to": "lib/pipeline/course-style.ts"
+    },
+    {
+      "from": "lib/journey/course-shape.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
       "from": "lib/journey/is-gated-by.ts",
       "to": "lib/journey/setting-contracts.ts"
     },
@@ -24277,6 +24289,11 @@
       "outDegree": 3
     },
     {
+      "path": "lib/journey/course-shape.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "lib/journey/is-gated-by.ts",
       "inDegree": 1,
       "outDegree": 2
@@ -24303,7 +24320,7 @@
     },
     {
       "path": "lib/journey/setting-contracts.ts",
-      "inDegree": 13,
+      "inDegree": 14,
       "outDegree": 2
     },
     {
@@ -24618,7 +24635,7 @@
     },
     {
       "path": "lib/pipeline/course-style.ts",
-      "inDegree": 9,
+      "inDegree": 10,
       "outDegree": 1
     },
     {
@@ -25338,7 +25355,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 128,
+      "inDegree": 129,
       "outDegree": 0
     },
     {
@@ -26435,7 +26452,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 128,
+      "inDegree": 129,
       "outDegree": 0
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-17T18:14:21.519Z",
+  "generatedAt": "2026-06-17T18:24:50.134Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-17T18:14:20.124Z",
+  "generatedAt": "2026-06-17T18:24:48.708Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-17T18:14:21.923Z",
+  "generatedAt": "2026-06-17T18:24:50.538Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-17T18:14:20.555Z",
+  "generatedAt": "2026-06-17T18:24:49.145Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

- Phase **P3d** of the Course Detail tab refactor (epic #1850). Module Inspector now honours each G8 contract's `appliesTo` envelope so exam-only fields render with the existing \`RelevanceWrapper state=\"out-of-shape\"\` chip on non-exam courses instead of appearing freely editable.
- **Show-don't-hide:** every G8 entry stays in the DOM regardless of shape. The 3 exam-only entries (\`moduleCueCardPool\`, \`moduleScheduledCues\`, \`moduleFirstTimeOrientationLine\`) dim with an explainer chip on non-exam structured courses; on exam courses all 8 G8 entries render active.
- New adapter \`lib/journey/course-shape.ts::getCourseShape\` lifts the binary runtime \`CourseStyle\` (\"structured | continuous\") to the ternary editor-facing \`CourseShape\` (\"structured | continuous | exam\" — already declared in \`setting-contracts.ts\`).

## Reuse-finder findings

Per \`.claude/rules/agent-report-verification.md\`:

| Existing piece | Location | Reused? |
|---|---|---|
| Binary \`CourseStyle\` + \`getCourseStyle\` | \`lib/pipeline/course-style.ts:26,39\` [verified] | yes — composed into the adapter |
| Ternary \`CourseShape\` type | \`lib/journey/setting-contracts.ts:69\` [verified] | yes — adapter's return type |
| \`RelevanceWrapper\` (out-of-shape state) | \`components/journey-controls/RelevanceWrapper.tsx\` [verified] | yes — wraps the JourneyField when out-of-shape |
| 3 exam-only G8 entries vs 5 broader ones | \`setting-contracts.entries.ts\` lines 1680-1865 [verified] | confirmed scope — only the 3 expected entries are exam-only |

What's new (justified):
- \`lib/journey/course-shape.ts\` — ~30-line adapter with exam-detection heuristic. No existing helper combined the runtime \`CourseStyle\` with the editor's \`appliesTo\` envelope.

## Exam-detection heuristic — short-term

Any \`AuthoredModule\` whose \`settings.cueCardPool\` is a non-empty array flags the course as \`\"exam\"\`. Reasoning: the IELTS Mock pattern uses a Part-2 cue-card pool, and that's the most discriminating module setting today; the wizard currently doesn't write any other exam-shape sentinel.

**Long-term path:** the wizard projection should set an explicit \`Playbook.config.examShape\` field (or widen \`lessonPlanMode\` to a ternary value), so this helper doesn't have to peek into \`modules[].settings\`. That's a separate epic — out of scope for P3d.

## Lattice survey

Read-side UI only:

- No DB column writes.
- No chain-stage boundaries crossed.
- No new guards / contracts / ESLint rules.
- No \`@ai-call\` annotations or AI write/read paths.
- No new cascade-eligible knobs (\`appliesTo\` was already in the registry; only the consumer is new).

Reuses existing \`appliesTo\` registry field + existing \`RelevanceWrapper\` machinery. No survey gap.

## Verified by

- \`npx vitest run tests/lib/journey/course-shape tests/components/modules-tab\` → **19/19 green** (6 helper + 5 CourseModulesTab + 8 ModuleInspectorPanel including 3 new P3d tests)
  - \`tests/lib/journey/course-shape.test.ts\` — \"returns 'continuous' for a continuous course\", \"returns 'structured' for a structured course with no module cue cards\", \"returns 'exam' for a structured course with a non-empty module cue-card pool\", \"returns 'continuous' for an empty config (default-deny by getCourseStyle)\", \"returns 'structured' when modules array is empty on a structured course\", \"returns 'structured' when modules carry empty cueCardPool arrays\"
  - \`tests/components/modules-tab/ModuleInspectorPanel.test.tsx\` (P3d block) — \"on a non-exam structured course, the 3 exam-only G8 entries render as out-of-shape\", \"on an exam course, all 8 G8 entries render as editable (active)\", \"show-don't-hide: every G8 entry is in the DOM regardless of course shape\"
- \`npx tsc --noEmit\` — touched files clean; 40 pre-existing errors unchanged from baseline 41 (one improvement is on a separate file, not ours)
- \`npm run lint\` — **touched files clean**; 15 pre-existing errors all in unrelated \`lib/ai/\` / \`lib/pipeline/\` / \`app/x/ai-errors\` paths, baseline-matched
- \`npm run ratchet:check\` — baseline-matched (verified lint_errors = 15 with and without our changes via \`git stash\` comparison)
- Inverse probe (per agent-report-verification): grepped all \`appliesTo\` declarations in \`setting-contracts.entries.ts\` → confirmed only 3 of 8 G8 entries are exam-only (the documented ones); no other G8 entries flag as \`[\"exam\"]\` [verified]

## Test plan

- [ ] Open \`/x/courses/<exam-course-id>?tab=modules\` — select any module, all 8 G8 fields editable, no out-of-shape chips
- [ ] Open \`/x/courses/<non-exam-structured-course-id>?tab=modules\` — select any module, the 3 exam-only fields show \"Exam courses use cue card pool — this is a Structured course\" (or similar) chips and are visually muted; the other 5 G8 fields editable
- [ ] Open a continuous course — no module picker (existing empty state); not affected by P3d

Refs: #1850 (epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)