### PR TITLE
feat(course-detail): P4 — prune Journey LH to owned buckets (#1850)

### DIFF
--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 /**
- * CourseJourneyTab — Phase 4 of epic #1675, extended in Slice C (#1721).
+ * CourseJourneyTab — Phase 4 of epic #1675, extended in Slice C (#1721),
+ * pruned in P4 of epic #1850.
  *
  * The new first tab on the Course Design page. Tri-pane shape:
- *   - LH: 13 buckets grouped under G1..G7 visual section headers
+ *   - LH: 7 Journey-owned buckets (filtered against
+ *     `BUCKETS_BY_TAB.journey`) grouped under G1..G7 visual section
+ *     headers — G4 and G7 collapse to nothing because all their
+ *     buckets moved to Teaching / Scoring in P0
  *   - Canvas: existing `<PreviewLens>` mounted read-only inline + multi-
  *     pulse + pick-strip
  *   - RH: `<JourneyInspectorPanel>` stacks ALL settings in the selected
@@ -16,12 +20,11 @@
  * scrolling the LH.
  *
  * Phase P3b (#1850): when the click resolves to a bucket owned by a
- * different Course Detail tab (e.g. operator clicks the Intake bubble
- * while on the — hypothetical — Scoring journey), the Inspector renders
- * a `<CrossTabHintCard>` offering to jump there. Journey-tab buckets
- * span the chronological arc; today the in-scope path catches every
- * click, so the hint card is a defensive future-proofing for new
- * buckets that may live on other tabs.
+ * different Course Detail tab (e.g. operator clicks a Teaching-owned
+ * `priorCallFeedback` bubble while on Journey), the Inspector renders
+ * a `<CrossTabHintCard>` offering to jump there. With the P4 LH pruning,
+ * Teaching / Scoring / Voice buckets are no longer reachable via the LH
+ * — the hint card is the only on-tab affordance for those settings.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/apps/admin/components/journey-tab/JourneyLhMenu.tsx
+++ b/apps/admin/components/journey-tab/JourneyLhMenu.tsx
@@ -1,23 +1,29 @@
 "use client";
 
 /**
- * JourneyLhMenu — Phase 4 Slice C of epic #1675 (#1721).
+ * JourneyLhMenu — Phase 4 Slice C of epic #1675 (#1721); pruned in P4
+ * of epic #1850.
  *
- * Left-hand navigation for the Journey tab. Renders 13 educator-intent
- * BUCKETS grouped under the original G1..G7 visual section headers.
+ * Left-hand navigation for the Journey tab. Renders the educator-intent
+ * BUCKETS that the Journey tab OWNS — filtered against
+ * `BUCKETS_BY_TAB.journey` (7 buckets across G1..G3, G5, G6) — grouped
+ * under the original G1..G7 visual section headers.
  *
  * Pre-Slice-C, this menu was 45 individual setting rows (one click per
- * setting). Now: 13 buckets (one click → Inspector stacks all bucket
- * members). The IELTS pre-voice gap analysis (#1700) tells us this is
- * how power users actually think — by session moment, not by entity.
+ * setting). Slice C reshaped to 14 buckets. P4 (#1850) prunes the 7
+ * non-Journey buckets — Teaching (C/E/F/J), Scoring (I/K), Voice (N) —
+ * so the LH only shows what this tab edits. Out-of-tab clicks in the
+ * Preview lens still work via the parent's `CrossTabHintCard` path
+ * (#1893).
  *
  * Phase filter chips at the top narrow visibility by educator phase.
  * Clicking a bucket row selects it (mounts all bucket settings in the
  * Inspector via the parent's selection state).
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
+import { BUCKETS_BY_TAB } from "@/lib/journey/buckets-by-tab";
 import {
   JOURNEY_GROUPS,
   type JourneyGroup,
@@ -87,12 +93,21 @@ export function JourneyLhMenu({
 
   // Group buckets by their parentGroup so the visual section headers
   // (G1..G7) carry the chronology and the buckets are the leaves.
-  const bucketsByGroup = new Map<JourneyGroup, JourneyMenuBucket[]>();
-  for (const b of JOURNEY_MENU_ITEMS) {
-    const arr = bucketsByGroup.get(b.parentGroup) ?? [];
-    arr.push(b);
-    bucketsByGroup.set(b.parentGroup, arr);
-  }
+  // P4 (#1850): filter to BUCKETS_BY_TAB.journey first — Teaching /
+  // Scoring / Voice tabs own the rest. Groups with zero remaining
+  // buckets (G4 after the teaching split, G7 after the scoring split)
+  // collapse naturally — `buckets.length === 0` short-circuits below.
+  const bucketsByGroup = useMemo(() => {
+    const owned = new Set<JourneyMenuBucketId>(BUCKETS_BY_TAB.journey);
+    const byGroup = new Map<JourneyGroup, JourneyMenuBucket[]>();
+    for (const b of JOURNEY_MENU_ITEMS) {
+      if (!owned.has(b.id)) continue;
+      const arr = byGroup.get(b.parentGroup) ?? [];
+      arr.push(b);
+      byGroup.set(b.parentGroup, arr);
+    }
+    return byGroup;
+  }, []);
 
   return (
     <div className="hf-journey-lh" data-testid="hf-journey-lh-menu">

--- a/apps/admin/tests/components/cross-tab-hint/CourseJourneyTab-cross-tab.test.tsx
+++ b/apps/admin/tests/components/cross-tab-hint/CourseJourneyTab-cross-tab.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * CourseJourneyTab — Phase P4 (#1850) regression guard for P3b
+ * cross-tab Inspector hints.
+ *
+ * P4 prunes the Journey LH to the 7 Journey-owned buckets (Teaching /
+ * Scoring / Voice buckets are no longer reachable via LH). The cross-
+ * tab hint card is now the ONLY on-tab affordance for those settings.
+ * This test pins that:
+ *
+ *  1. Out-of-tab Preview click (e.g. `priorCallFeedback`, a Teaching-
+ *     owned section) → `<CrossTabHintCard>` mounts in the Inspector slot.
+ *  2. Clicking the hint card's primary button fires `onTabSwitch` with
+ *     the owning tab id + `{ selectedBucket }` payload.
+ *  3. In-tab Preview click (e.g. `intake`, A_intake) → Inspector opens
+ *     directly (regression guard for the in-tab path).
+ *
+ * Mirrors the structure of CourseTeachingTab-cross-tab.test.tsx +
+ * CourseScoringTab-cross-tab.test.tsx.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  within,
+  act,
+} from "@testing-library/react";
+
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+// PreviewLens mock — exposes the latest `onSelectSection` callback so
+// the test can dispatch section keys without rendering the real lens.
+const __testHooks: { lastOnSelect: ((s: string | null) => void) | null } = {
+  lastOnSelect: null,
+};
+vi.mock("@/app/x/courses/[courseId]/_components/PreviewLens", () => ({
+  PreviewLens: ({
+    onSelectSection,
+  }: {
+    onSelectSection?: (s: string | null) => void;
+  }) => {
+    __testHooks.lastOnSelect = onSelectSection ?? null;
+    return <div data-testid="hf-mock-preview-lens" />;
+  },
+}));
+
+import { CourseJourneyTab } from "@/components/journey-tab/CourseJourneyTab";
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({}),
+  } as Response),
+);
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(global.fetch).mockClear();
+  __testHooks.lastOnSelect = null;
+});
+
+describe("CourseJourneyTab — P4 cross-tab Inspector hint", () => {
+  it("renders <CrossTabHintCard> when a Preview click maps to a Teaching-tab bucket (priorCallFeedback → J_feedback)", () => {
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseJourneyTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    // priorCallFeedback locators map to J_feedback (Teaching tab) —
+    // see CourseTeachingTab-cross-tab.test.tsx for the inverse case.
+    expect(__testHooks.lastOnSelect).not.toBeNull();
+    act(() => __testHooks.lastOnSelect!("priorCallFeedback"));
+    const card = screen.getByTestId("hf-cross-tab-hint-card");
+    expect(card).toBeInTheDocument();
+    expect(
+      within(card).getByTestId("hf-cross-tab-hint-jump"),
+    ).toHaveTextContent(/Open in Teaching/);
+  });
+
+  it("clicking the jump button fires onTabSwitch with the owning tab + bucket", () => {
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseJourneyTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    act(() => __testHooks.lastOnSelect!("priorCallFeedback"));
+    fireEvent.click(screen.getByTestId("hf-cross-tab-hint-jump"));
+    expect(onTabSwitch).toHaveBeenCalledTimes(1);
+    expect(onTabSwitch).toHaveBeenCalledWith("teaching", {
+      selectedBucket: "J_feedback",
+    });
+  });
+
+  it("in-tab Preview click (intake → A_intake) does NOT show the cross-tab hint card", () => {
+    // intake lives on the Journey tab via A_intake — the in-tab path
+    // catches it before the cross-tab fork runs. Regression guard
+    // that the P4 prune didn't break the in-tab affordance.
+    //
+    // We assert the absence of the cross-tab card (the cross-tab fork
+    // never fired) rather than the presence of the A_intake Inspector
+    // — the latter depends on URL state propagation through
+    // `useJourneySelection` + `next/navigation`'s router, which would
+    // require a heavier router mock without adding signal here.
+    const onTabSwitch = vi.fn();
+    render(
+      <CourseJourneyTab
+        courseId="c1"
+        playbookConfig={{}}
+        onTabSwitch={onTabSwitch}
+      />,
+    );
+    act(() => __testHooks.lastOnSelect!("intake"));
+    expect(screen.queryByTestId("hf-cross-tab-hint-card")).toBeNull();
+    expect(onTabSwitch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
+++ b/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
@@ -2,11 +2,12 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 import { JourneyLhMenu } from "@/components/journey-tab/JourneyLhMenu";
+import { BUCKETS_BY_TAB } from "@/lib/journey/buckets-by-tab";
 
 afterEach(() => cleanup());
 
 describe("JourneyLhMenu — Slice C (#1721) bucket-grained menu", () => {
-  it("renders all 7 group headers in chronological order", () => {
+  it("renders only the group headers that own a Journey-tab bucket (P4 #1850 prune)", () => {
     render(
       <JourneyLhMenu
         selectedBucketId={null}
@@ -15,9 +16,14 @@ describe("JourneyLhMenu — Slice C (#1721) bucket-grained menu", () => {
         onFilterChange={vi.fn()}
       />,
     );
-    for (const g of ["G1", "G2", "G3", "G4", "G5", "G6", "G7"]) {
+    // The 7 Journey buckets distribute across G1, G2, G3, G5, G6 —
+    // G4 and G7 collapse after the P4 prune because all their
+    // buckets moved to Teaching / Scoring tabs.
+    for (const g of ["G1", "G2", "G3", "G5", "G6"]) {
       expect(screen.getByTestId(`hf-journey-group-${g}`)).toBeInTheDocument();
     }
+    expect(screen.queryByTestId("hf-journey-group-G4")).toBeNull();
+    expect(screen.queryByTestId("hf-journey-group-G7")).toBeNull();
   });
 
   it("phase filter chip narrows visible groups (e.g. 'End' shows only G6)", () => {
@@ -76,5 +82,88 @@ describe("JourneyLhMenu — Slice C (#1721) bucket-grained menu", () => {
     // capture, minus the dead intakeConsentFlow contract removed in followup).
     const row = screen.getByTestId("hf-journey-bucket-row-A_intake");
     expect(row.textContent).toMatch(/8/);
+  });
+});
+
+describe("JourneyLhMenu — P4 (#1850) LH pruning to Journey-owned buckets", () => {
+  it("renders exactly the 7 Journey-owned buckets from BUCKETS_BY_TAB.journey", () => {
+    render(
+      <JourneyLhMenu
+        selectedBucketId={null}
+        onSelectBucket={vi.fn()}
+        filter="All"
+        onFilterChange={vi.fn()}
+      />,
+    );
+    // Open every collapsed group so all rows are in the DOM —
+    // sessionStorage defaults to G1+G2 open only.
+    for (const g of ["G3", "G5", "G6"]) {
+      fireEvent.click(
+        screen.getByTestId(`hf-journey-group-${g}`).querySelector("button")!,
+      );
+    }
+    for (const id of BUCKETS_BY_TAB.journey) {
+      expect(
+        screen.getByTestId(`hf-journey-bucket-row-${id}`),
+      ).toBeInTheDocument();
+    }
+    expect(BUCKETS_BY_TAB.journey).toHaveLength(7);
+  });
+
+  it("does NOT render Teaching-owned buckets (C/E/F/J)", () => {
+    render(
+      <JourneyLhMenu
+        selectedBucketId={null}
+        onSelectBucket={vi.fn()}
+        filter="All"
+        onFilterChange={vi.fn()}
+      />,
+    );
+    // Teaching tab owns C_teaching_style, E_learner_visual,
+    // F_stall_recovery, J_feedback (parentGroup G4) — none should
+    // render in Journey LH after the P4 prune.
+    expect(
+      screen.queryByTestId("hf-journey-bucket-row-C_teaching_style"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("hf-journey-bucket-row-E_learner_visual"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("hf-journey-bucket-row-F_stall_recovery"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("hf-journey-bucket-row-J_feedback"),
+    ).toBeNull();
+  });
+
+  it("does NOT render Scoring-owned buckets (I/K)", () => {
+    render(
+      <JourneyLhMenu
+        selectedBucketId={null}
+        onSelectBucket={vi.fn()}
+        filter="All"
+        onFilterChange={vi.fn()}
+      />,
+    );
+    // Scoring tab owns I_scoring (G7) + K_between_calls (G7).
+    expect(
+      screen.queryByTestId("hf-journey-bucket-row-I_scoring"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("hf-journey-bucket-row-K_between_calls"),
+    ).toBeNull();
+  });
+
+  it("does NOT render the Voice-owned bucket (N_voice)", () => {
+    render(
+      <JourneyLhMenu
+        selectedBucketId={null}
+        onSelectBucket={vi.fn()}
+        filter="All"
+        onFilterChange={vi.fn()}
+      />,
+    );
+    // Voice tab owns N_voice (G4).
+    expect(screen.queryByTestId("hf-journey-bucket-row-N_voice")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase P4 of epic #1850 — prune the Journey tab's LH menu so it only renders the 7 buckets the Journey tab owns. Pre-P4 the LH iterated over all 14 `JOURNEY_MENU_ITEMS` regardless of `BUCKETS_BY_TAB.journey`, surfacing buckets that moved to Teaching / Scoring / Voice tabs in P0.

| | Before | After |
|---|---|---|
| Buckets in Journey LH | 14 | **7** |
| Group headers rendered | G1..G7 (all 7) | G1, G2, G3, G5, G6 (5) |
| Buckets that moved away | C / E / F / J (Teaching), I / K (Scoring), N (Voice) | hidden |

Groups G4 and G7 collapse naturally — every bucket they contained moved off the Journey tab — because the LH render loop short-circuits when `buckets.length === 0`. Same filter pattern used by `TeachingLhMenu` / `ScoringLhMenu`.

## Cross-tab hints (P3b) still work

Clicks on out-of-Journey-bucket PreviewLens bubbles continue to surface the `CrossTabHintCard` in the Inspector slot, with the "Open in Teaching / Scoring / Voice" jump button (#1893). New regression test pins this for Journey tab — clicking the `priorCallFeedback` section (8 of 8 locators map to `J_feedback` → Teaching) renders the hint card and fires `onTabSwitch("teaching", { selectedBucket: "J_feedback" })` on jump.

## Files changed

| File | Change |
|---|---|
| `apps/admin/components/journey-tab/JourneyLhMenu.tsx` | Filter `JOURNEY_MENU_ITEMS` against `BUCKETS_BY_TAB.journey` before grouping. Promote `bucketsByGroup` into a `useMemo`. Doc comment updated. |
| `apps/admin/components/journey-tab/CourseJourneyTab.tsx` | Doc comment refresh — 7 buckets now, G4/G7 collapse. |
| `apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx` | Update existing group-header test (G4/G7 no longer render). Add 4 new tests pinning the 7 Journey-owned buckets render + Teaching/Scoring/Voice buckets do NOT render. |
| `apps/admin/tests/components/cross-tab-hint/CourseJourneyTab-cross-tab.test.tsx` | New file — 3 tests pinning the P3b cross-tab hint path on Journey tab (Teaching click → hint card → jump fires `onTabSwitch`; in-tab click does NOT show the hint card). |

## Verified by

- `JourneyLhMenu.tsx:90-101` — new `useMemo` filters `JOURNEY_MENU_ITEMS` against `BUCKETS_BY_TAB.journey` before grouping into G1..G7 headers.
- `tests/components/journey-tab/JourneyLhMenu.test.tsx:8-86` — "renders only the group headers that own a Journey-tab bucket (P4 #1850 prune)" + "P4 (#1850) LH pruning to Journey-owned buckets" describe block (4 tests). All 9 vitests in this file PASS [verified].
- `tests/components/cross-tab-hint/CourseJourneyTab-cross-tab.test.tsx` — 3 vitests confirming P3b regression guard. All PASS [verified].
- `tests/lib/journey/buckets-by-tab.test.ts` — 5 vitests (exactly-one-tab membership invariant) still PASS unchanged [verified].
- Bucket count: `BUCKETS_BY_TAB.journey` length === 7 [verified at lib/journey/buckets-by-tab.ts:39-47].
- `priorCallFeedback` → `J_feedback` mapping: 8 of 8 setting contracts with a `previewLocators[].section === "priorCallFeedback"` have `menuGroupKey: "J_feedback"` [verified 2026-06-17 via parse of `lib/journey/setting-contracts.entries.ts`; `J_feedback` is in `BUCKETS_BY_TAB.teaching`].
- Test run: 25/25 PASS across `tests/components/journey-tab/JourneyLhMenu.test.tsx` + `tests/components/cross-tab-hint/*` + `tests/lib/journey/buckets-by-tab.test.ts` [verified].
- `npx tsc --noEmit`: 40 errors (baseline 41, -1 improvement — no new TS errors on touched files) [verified].
- `npm run ratchet:check`: lint_errors=0, lint_warnings=4511 (== baseline), tsc_errors=-1 under baseline [verified].
- KB regen: re-ran the 5 `npm run kb:*` scripts; `bash scripts/capture/check-kb-fresh.sh` returned green (only timestamp deltas, no content changes; reverted to avoid noise) [verified].

## Lattice survey

Touched surface: UI component (`JourneyLhMenu.tsx`) — no DB writes, no chain-stage boundary, no new contract, no AI path. Lattice survey not required per `.claude/rules/lattice-survey.md` "When this applies" criteria. The filter primitive (`BUCKETS_BY_TAB.journey`) is already pinned by `tests/lib/journey/buckets-by-tab.test.ts` (5 vitests for the exactly-one-tab invariant).

## Test plan

- [ ] Visual smoke on hf-dev: load `/x/courses/<id>?tab=journey`, confirm LH shows 7 buckets across 5 group headers (G1, G2, G3, G5, G6).
- [ ] Click PreviewLens bubble for a Teaching-owned section (e.g. recap prose), confirm the Inspector shows the cross-tab hint card with "Open in Teaching" jump.
- [ ] Cmd+K palette behavior preserved: palette is global per intent and selects any registered setting's owning bucket; out-of-tab selections render in the Inspector but the LH row stays absent (pre-existing behaviour from Slice C — `CourseJourneyTab.tsx:138-149` handlePaletteSelect unchanged in this PR) [verified].

Closes P4 of #1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)