### PR TITLE
feat(wizard): P3f — resolve source: refs in module settings + backfill (#1850)

### DIFF
--- a/apps/admin/lib/wizard/__tests__/parse-content-sources.test.ts
+++ b/apps/admin/lib/wizard/__tests__/parse-content-sources.test.ts
@@ -1,0 +1,122 @@
+/**
+ * parse-content-sources.test.ts (#1850 P3f)
+ *
+ * Unit tests for `parseContentSources` — the Content Sources section
+ * parser feeding the source-ref resolver.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseContentSources } from "../parse-content-sources";
+
+const IELTS_V23 = readFileSync(
+  join(__dirname, "fixtures", "course-reference-ielts-v2.3.md"),
+  "utf-8",
+);
+
+describe("parseContentSources — IELTS v2.3 fixture", () => {
+  it("finds every Source N — Title block under the ## Content Sources heading", () => {
+    const parsed = parseContentSources(IELTS_V23);
+    // Sources 1-8 declared in the fixture; not all carry moduleRef/settingRef.
+    expect(parsed.all.length).toBeGreaterThanOrEqual(8);
+    const headers = parsed.all.map((e) => e.header);
+    expect(headers).toContain("Source 2 — Part 2 cue card bank");
+    expect(headers).toContain("Source 6 — Part 2 stall scaffolds (monologue)");
+    expect(headers).toContain("Source 7 — Part 3 stall scaffolds (discussion)");
+  });
+
+  it("indexes by (moduleRef, settingRef) for the three resolvable cohort entries", () => {
+    const parsed = parseContentSources(IELTS_V23);
+    const part2Cue = parsed.byModuleAndSetting.get("part2:cueCardPool");
+    expect(part2Cue).toBeDefined();
+    expect(part2Cue!.location).toContain("ielts-speaking-question-bank-part2.md");
+    expect(part2Cue!.format).toBe("structured-md");
+
+    const part2Scaffold = parsed.byModuleAndSetting.get("part2:scaffoldPool");
+    expect(part2Scaffold).toBeDefined();
+    expect(part2Scaffold!.location).toContain("stall-scaffolds-monologue.md");
+
+    const part3Scaffold = parsed.byModuleAndSetting.get("part3:scaffoldPool");
+    expect(part3Scaffold).toBeDefined();
+    expect(part3Scaffold!.location).toContain("stall-scaffolds-discussion.md");
+  });
+
+  it("strips the `module` prefix from settingRef so it matches AuthoredModuleSettings keys", () => {
+    const parsed = parseContentSources(IELTS_V23);
+    // The doc says `*settingRef:* moduleCueCardPool` — we want `cueCardPool`.
+    for (const entry of parsed.all) {
+      if (entry.settingRef) {
+        expect(entry.settingRef.startsWith("module")).toBe(false);
+      }
+    }
+  });
+
+  it("returns an empty index when the section is missing", () => {
+    const parsed = parseContentSources("# Some doc\n\nNo content sources section here.\n");
+    expect(parsed.all).toEqual([]);
+    expect(parsed.byModuleAndSetting.size).toBe(0);
+  });
+});
+
+describe("parseContentSources — tolerant of cosmetic variations", () => {
+  it("handles backtick-wrapped location values", () => {
+    const body = [
+      "## Content Sources",
+      "",
+      "### Source 1 — Test source",
+      "",
+      "- *location:* `docs/external/foo.md`",
+      "- *format:* structured-md",
+      "- *moduleRef:* test",
+      "- *settingRef:* moduleFoo",
+      "",
+    ].join("\n");
+    const parsed = parseContentSources(body);
+    const entry = parsed.byModuleAndSetting.get("test:foo");
+    expect(entry).toBeDefined();
+    expect(entry!.location).toBe("docs/external/foo.md");
+  });
+
+  it("ignores extra fields it doesn't recognise (Outcomes/Ordering/Notes)", () => {
+    const body = [
+      "## Content Sources",
+      "",
+      "### Source 1 — Test",
+      "",
+      "- *location:* foo.md",
+      "- *format:* structured-md",
+      "- *moduleRef:* m",
+      "- *settingRef:* moduleX",
+      "- *Outcomes served:* OUT-01, OUT-02.",
+      "- *Notes:* irrelevant metadata.",
+      "",
+    ].join("\n");
+    const parsed = parseContentSources(body);
+    const entry = parsed.byModuleAndSetting.get("m:x");
+    expect(entry).toBeDefined();
+    expect(entry!.location).toBe("foo.md");
+  });
+
+  it("stops at the next ## section header", () => {
+    const body = [
+      "## Content Sources",
+      "",
+      "### Source 1 — A",
+      "- *location:* a.md",
+      "- *format:* structured-md",
+      "- *moduleRef:* m1",
+      "- *settingRef:* moduleA",
+      "",
+      "## Some Other Section",
+      "",
+      "### Source 99 — Should-not-appear",
+      "- *location:* should-not.md",
+      "- *moduleRef:* mX",
+      "- *settingRef:* moduleZ",
+    ].join("\n");
+    const parsed = parseContentSources(body);
+    expect(parsed.all.length).toBe(1);
+    expect(parsed.byModuleAndSetting.has("mX:z")).toBe(false);
+  });
+});

--- a/apps/admin/lib/wizard/__tests__/parse-source-content.test.ts
+++ b/apps/admin/lib/wizard/__tests__/parse-source-content.test.ts
@@ -1,0 +1,108 @@
+/**
+ * parse-source-content.test.ts (#1850 P3f)
+ *
+ * Unit tests for the per-format parsers.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseCueCardBank, parseStallScaffolds } from "../parse-source-content";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..", "..");
+
+describe("parseCueCardBank — IELTS Part 2 question bank", () => {
+  const text = readFileSync(
+    join(
+      REPO_ROOT,
+      "docs",
+      "external",
+      "ielts",
+      "ielts-speaking",
+      "Upload Docs",
+      "ielts-speaking-question-bank-part2.md",
+    ),
+    "utf-8",
+  );
+
+  it("parses every card with a non-empty topic + bullet list", () => {
+    const cards = parseCueCardBank(text);
+    expect(cards.length).toBeGreaterThanOrEqual(80);
+    for (const c of cards) {
+      expect(c.topic.length).toBeGreaterThan(0);
+      expect(c.bullets.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("extracts the canonical first card cleanly", () => {
+    const cards = parseCueCardBank(text);
+    expect(cards[0]).toEqual({
+      topic: "Family member you admire",
+      bullets: ["who this person is", "how often you see them", "what kind of personality they have"],
+    });
+  });
+
+  it("returns empty when no cards are present", () => {
+    expect(parseCueCardBank("# Some doc\n\nNo cards here.\n")).toEqual([]);
+  });
+
+  it("skips the 'Describe …' verb-line and the 'and explain …' closer", () => {
+    const cards = parseCueCardBank(text);
+    for (const c of cards) {
+      for (const b of c.bullets) {
+        expect(b).not.toMatch(/^describe\b/i);
+        expect(b).not.toMatch(/^and\s+explain\b/i);
+        expect(b).not.toMatch(/^you should say:?$/i);
+      }
+    }
+  });
+});
+
+describe("parseStallScaffolds — IELTS Part 2 + Part 3 scaffolds", () => {
+  it("parses the Part 2 monologue pool into flat strings (tag dropped)", () => {
+    const text = readFileSync(
+      join(
+        REPO_ROOT,
+        "docs",
+        "external",
+        "ielts",
+        "ielts-speaking",
+        "stall-scaffolds-monologue.md",
+      ),
+      "utf-8",
+    );
+    const items = parseStallScaffolds(text);
+    expect(items.length).toBe(14);
+    expect(items[0]).toBe("Take another moment.");
+    expect(items[1]).toBe("Take your time.");
+    // Item 14 carries a trailing italic parenthetical; it must be stripped.
+    expect(items[13]).toBe("Mm.");
+    // No item should be empty or carry a markdown bullet/asterisks.
+    for (const s of items) {
+      expect(s.length).toBeGreaterThan(0);
+      expect(s).not.toContain("*");
+    }
+  });
+
+  it("parses the Part 3 discussion pool", () => {
+    const text = readFileSync(
+      join(
+        REPO_ROOT,
+        "docs",
+        "external",
+        "ielts",
+        "ielts-speaking",
+        "stall-scaffolds-discussion.md",
+      ),
+      "utf-8",
+    );
+    const items = parseStallScaffolds(text);
+    expect(items.length).toBe(15);
+    expect(items[0]).toBe("Take your time.");
+    expect(items[4]).toBe("Could you give an example?");
+  });
+
+  it("returns empty when no Scaffold pool section is present", () => {
+    expect(parseStallScaffolds("# A doc without the section.\n")).toEqual([]);
+  });
+});

--- a/apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts
+++ b/apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts
@@ -1,0 +1,146 @@
+/**
+ * resolve-module-source-refs.test.ts (#1850 P3f)
+ *
+ * Integration test for the resolver — feeds it the IELTS v2.3 fixture
+ * + a mock filesystem and asserts the per-module Settings come back
+ * with `cueCardPool` + `scaffoldPool` inlined as the expected shapes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  extractSourceRefsFromYamlBlocks,
+  resolveModuleSourceRefs,
+  type SourceFileReader,
+} from "../resolve-module-source-refs";
+import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
+
+const IELTS_V23 = readFileSync(
+  join(__dirname, "fixtures", "course-reference-ielts-v2.3.md"),
+  "utf-8",
+);
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..", "..");
+
+describe("extractSourceRefsFromYamlBlocks — IELTS v2.3", () => {
+  it("captures cueCardPool + scaffoldPool source-refs per module", () => {
+    const refs = extractSourceRefsFromYamlBlocks(IELTS_V23);
+    // 5 modules in v2.3 — each block carries at least one source-ref.
+    expect(refs.size).toBeGreaterThanOrEqual(4);
+    const part2 = refs.get("part2");
+    expect(part2).toBeDefined();
+    expect(part2!.get("cueCardPool")).toBe("source:cue-card-bank-v1");
+    expect(part2!.get("scaffoldPool")).toBe("source:stall-scaffolds-monologue");
+    const part3 = refs.get("part3");
+    expect(part3!.get("scaffoldPool")).toBe("source:stall-scaffolds-discussion");
+  });
+
+  it("returns empty for a body with no settings blocks", () => {
+    const refs = extractSourceRefsFromYamlBlocks("# A doc with no Module Settings blocks.\n");
+    expect(refs.size).toBe(0);
+  });
+});
+
+describe("resolveModuleSourceRefs — IELTS v2.3 against real disk", () => {
+  it("inlines part2.cueCardPool from the question-bank file", () => {
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
+    const part2 = out.byModuleId.get("part2");
+    expect(part2).toBeDefined();
+    expect(Array.isArray(part2!.cueCardPool)).toBe(true);
+    expect(part2!.cueCardPool!.length).toBeGreaterThanOrEqual(80);
+    expect(part2!.cueCardPool![0]).toEqual({
+      topic: "Family member you admire",
+      bullets: ["who this person is", "how often you see them", "what kind of personality they have"],
+    });
+  });
+
+  it("inlines scaffoldPool for part2 + part3 + mock + baseline", () => {
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
+    expect(out.byModuleId.get("part2")!.scaffoldPool).toEqual(
+      expect.arrayContaining(["Take another moment.", "Take your time."]),
+    );
+    expect(out.byModuleId.get("part3")!.scaffoldPool).toEqual(
+      expect.arrayContaining(["Could you give an example?"]),
+    );
+  });
+
+  it("skips source-refs with no Content Sources entry + emits a warning", () => {
+    // The Baseline module's cueCardPool references `source:cue-card-bank-baseline-v1`,
+    // but the fixture's Content Sources block declares Source 4 (Baseline pool)
+    // WITHOUT location/format/moduleRef/settingRef metadata. The resolver
+    // skips it; the fields untouched.
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
+    const baseline = out.byModuleId.get("baseline");
+    expect(baseline).toBeDefined();
+    expect(baseline!.cueCardPool).toBeUndefined();
+    const skips = out.resolutions.filter((r) => r.status === "skipped");
+    expect(skips.length).toBeGreaterThanOrEqual(1);
+    expect(
+      skips.some(
+        (r) => r.moduleId === "baseline" && r.field === "cueCardPool",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns a structured resolution log", () => {
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
+    const resolved = out.resolutions.filter((r) => r.status === "resolved");
+    // part2.cueCardPool + 3 scaffoldPool resolutions (part2 + part3 + mock + baseline)
+    // Some may skip (baseline scaffoldPool source:stall-scaffolds-monologue resolves).
+    expect(resolved.length).toBeGreaterThanOrEqual(3);
+    const part2Cue = resolved.find(
+      (r) => r.moduleId === "part2" && r.field === "cueCardPool",
+    );
+    expect(part2Cue).toBeDefined();
+    expect(part2Cue!.itemCount).toBeGreaterThanOrEqual(80);
+  });
+});
+
+describe("resolveModuleSourceRefs — file errors + missing files", () => {
+  it("skips with a warning when the file doesn't exist", () => {
+    const mockReader: SourceFileReader = {
+      exists: () => false,
+      read: () => "",
+    };
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, {
+      repoRoot: "/tmp",
+      reader: mockReader,
+    });
+    expect(out.byModuleId.get("part2")?.cueCardPool).toBeUndefined();
+    expect(out.validationWarnings.length).toBeGreaterThan(0);
+    expect(out.validationWarnings[0].code).toBe("MODULE_SOURCE_REF_UNRESOLVED");
+  });
+
+  it("skips with a warning when the file exists but the parser yields 0 items", () => {
+    const mockReader: SourceFileReader = {
+      exists: () => true,
+      read: () => "# Empty content — no cue cards or scaffolds here.",
+    };
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, {
+      repoRoot: "/tmp",
+      reader: mockReader,
+    });
+    expect(out.byModuleId.get("part2")?.cueCardPool).toBeUndefined();
+    const skipReasons = out.resolutions
+      .filter((r) => r.status === "skipped")
+      .map((r) => r.reason);
+    expect(skipReasons.some((r) => r?.includes("produced 0"))).toBe(true);
+  });
+
+  it("merges into an existing byModuleId without clobbering unrelated fields", () => {
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    byModuleId.set("part2", { closingLine: "Existing", minSpeakingSec: 120 });
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
+    const part2 = out.byModuleId.get("part2")!;
+    expect(part2.closingLine).toBe("Existing");
+    expect(part2.minSpeakingSec).toBe(120);
+    expect(Array.isArray(part2.cueCardPool)).toBe(true);
+  });
+});

--- a/apps/admin/lib/wizard/parse-content-sources.ts
+++ b/apps/admin/lib/wizard/parse-content-sources.ts
@@ -1,0 +1,189 @@
+/**
+ * parse-content-sources.ts (#1850 P3f)
+ *
+ * @canonical-doc docs/CONTENT-PIPELINE.md §"Per-module YAML settings blocks"
+ *
+ * Parse the `## Content Sources` section of a Course Reference document
+ * into an index keyed by `(moduleRef, settingRef)`. The YAML blocks
+ * extracted by `detect-module-settings.ts` reference content with
+ * `source:<id>` strings (e.g. `cueCardPool: source:cue-card-bank-v1`);
+ * this index lets `resolve-module-source-refs.ts` look up the disk path
+ * + format for each referenced source.
+ *
+ * Source block format (v2.3 fixture):
+ *
+ *   ### Source 2 — Part 2 cue card bank
+ *
+ *   A bank of Part 2 cue cards in the standard IELTS structure ...
+ *
+ *   - *location:* `docs/external/ielts/ielts-speaking/Upload Docs/...`
+ *   - *format:* structured-md
+ *   - *moduleRef:* part2
+ *   - *settingRef:* moduleCueCardPool
+ *
+ * The header text ("Source 2 — Part 2 cue card bank") is preserved as a
+ * debug breadcrumb. The `(moduleRef, settingRef)` pair is the lookup key
+ * downstream consumers use — sources without both fields are kept in the
+ * index but flagged as unresolvable.
+ *
+ * Field-name normalisation mirrors `detect-module-settings.ts`: the
+ * doc's `moduleCueCardPool` settingRef strips the `module` prefix to
+ * `cueCardPool` for matching against `AuthoredModuleSettings` keys.
+ *
+ * Issue #1850 P3f.
+ */
+
+// ── Public types ─────────────────────────────────────────────────────
+
+export interface ContentSourceEntry {
+  /** Debug breadcrumb — the `### Source N — Title` header text. */
+  header: string;
+  /** Absolute or repo-rooted file path (verbatim from the doc). */
+  location?: string;
+  /** Format tag — drives the parser dispatch in `resolve-module-source-refs.ts`. */
+  format?: string;
+  /** Module slug the source attaches to (verbatim from the doc). */
+  moduleRef?: string;
+  /**
+   * Setting key the source feeds, normalised to the unprefixed form
+   * (`moduleCueCardPool` → `cueCardPool`) so it matches
+   * `AuthoredModuleSettings` keys directly.
+   */
+  settingRef?: string;
+}
+
+export interface ParsedContentSources {
+  /**
+   * Lookup index keyed by `${moduleRef}:${settingRef}` (e.g.
+   * `"part2:cueCardPool"`). Multiple entries per key are allowed (the
+   * resolver picks the first); duplicates are not flagged here.
+   */
+  byModuleAndSetting: Map<string, ContentSourceEntry>;
+  /** Every parsed source, in source-doc order. */
+  all: ContentSourceEntry[];
+}
+
+// ── Detection ────────────────────────────────────────────────────────
+
+const SECTION_HEADER = /^##\s+Content\s+Sources\s*$/im;
+/** Matches `### Source N — Title`. Captures the full header text. */
+const SOURCE_HEADER = /^###\s+(Source\s+\d+\s*[—–-].+)$/i;
+/** Heading of any depth that ends a source block (excluding our own ### Source rows). */
+const ANY_HEADING = /^#{1,6}\s/;
+
+/**
+ * Strip italic / bold markers + leading bullet so the line's
+ * `key: value` shape is recoverable regardless of cosmetic wrappers.
+ */
+function stripMarkdownDecorators(s: string): string {
+  return s
+    .replace(/^\s*[-*]\s+/, "") // leading "- " bullet
+    .replace(/^\s*\*+/, "") // leading "*" bold/italic
+    .replace(/\*+\s*$/, "") // trailing "*"
+    .replace(/`/g, "") // backticks around values
+    .trim();
+}
+
+/** Strip the `module` prefix from a settingRef so it matches AuthoredModuleSettings keys. */
+function stripModulePrefix(key: string): string {
+  if (key.startsWith("module") && key.length > 6) {
+    return key.charAt(6).toLowerCase() + key.slice(7);
+  }
+  return key;
+}
+
+/** Parse a single source's body lines into a `ContentSourceEntry`. */
+function parseSourceBody(header: string, bodyLines: string[]): ContentSourceEntry {
+  const entry: ContentSourceEntry = { header };
+  for (const raw of bodyLines) {
+    const line = stripMarkdownDecorators(raw);
+    if (!line) continue;
+    // Recognise `key: value` shape where key is one of our known fields.
+    // The doc uses italic keys (`*location:*`), already stripped above.
+    const m = line.match(/^([A-Za-z][A-Za-z0-9]*)\s*:\s*(.+)$/);
+    if (!m) continue;
+    const key = m[1];
+    const value = m[2].replace(/^\s*[`*]?|[`*]?\s*$/g, "").trim();
+    if (!value) continue;
+    switch (key.toLowerCase()) {
+      case "location":
+        entry.location = value;
+        break;
+      case "format":
+        entry.format = value;
+        break;
+      case "moduleref":
+        entry.moduleRef = value;
+        break;
+      case "settingref":
+        entry.settingRef = stripModulePrefix(value);
+        break;
+      default:
+        // Unknown key — ignored (the doc carries Outcomes/Ordering/Notes too)
+        break;
+    }
+  }
+  return entry;
+}
+
+// ── Public entry point ───────────────────────────────────────────────
+
+/**
+ * Walk the course-ref body, find the `## Content Sources` section, then
+ * iterate every `### Source N — Title` block within it and extract the
+ * `location` / `format` / `moduleRef` / `settingRef` fields. Returns
+ * an empty index when the section is missing — the resolver treats
+ * absence as "no source-refs to inline".
+ */
+export function parseContentSources(bodyText: string): ParsedContentSources {
+  const result: ParsedContentSources = {
+    byModuleAndSetting: new Map(),
+    all: [],
+  };
+  const lines = bodyText.split(/\r?\n/);
+
+  // Locate the section header.
+  let sectionStart = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (SECTION_HEADER.test(lines[i])) {
+      sectionStart = i + 1;
+      break;
+    }
+  }
+  if (sectionStart < 0) return result;
+
+  // Walk forward; the section ends at the next `## ` heading.
+  let i = sectionStart;
+  while (i < lines.length) {
+    const line = lines[i];
+    // End of section — another top-level `## ` heading (not `### Source N`).
+    if (/^##\s/.test(line) && !/^###/.test(line)) break;
+
+    const headerMatch = line.match(SOURCE_HEADER);
+    if (!headerMatch) {
+      i++;
+      continue;
+    }
+    const header = headerMatch[1].trim();
+    // Collect body lines until the next heading or end-of-section.
+    const body: string[] = [];
+    let j = i + 1;
+    while (j < lines.length) {
+      const next = lines[j];
+      if (ANY_HEADING.test(next)) break;
+      body.push(next);
+      j++;
+    }
+    const entry = parseSourceBody(header, body);
+    result.all.push(entry);
+    if (entry.moduleRef && entry.settingRef) {
+      const key = `${entry.moduleRef}:${entry.settingRef}`;
+      // First-write-wins: the doc lists sources in canonical order.
+      if (!result.byModuleAndSetting.has(key)) {
+        result.byModuleAndSetting.set(key, entry);
+      }
+    }
+    i = j;
+  }
+  return result;
+}

--- a/apps/admin/lib/wizard/parse-source-content.ts
+++ b/apps/admin/lib/wizard/parse-source-content.ts
@@ -1,0 +1,165 @@
+/**
+ * parse-source-content.ts (#1850 P3f)
+ *
+ * @canonical-doc docs/CONTENT-PIPELINE.md §"Per-module YAML settings blocks"
+ *
+ * Per-format parsers for the content-source files referenced from a
+ * Course Reference's `## Content Sources` section. Each parser takes the
+ * source file's raw text and returns the shape `AuthoredModuleSettings`
+ * expects for the destination field.
+ *
+ * Format dispatch (today):
+ *   - `cueCardBank`   → Array<{ topic, bullets[] }>
+ *   - `stallScaffold` → string[]
+ *
+ * Both parsers are deterministic, dependency-free, and tolerant of the
+ * cosmetic variations in the HFF-authored fixtures (extra blank lines,
+ * `> ` quoted bodies, leading `## ` separators).
+ *
+ * Issue #1850 P3f.
+ */
+
+// ── Cue card bank (Source 2 — Part 2 cue cards) ──────────────────────
+//
+// Input format (verbatim from `ielts-speaking-question-bank-part2.md`):
+//
+//   ### Card 1 — Family member you admire
+//
+//   > Describe a family member you admire.
+//   > You should say:
+//   >   who this person is
+//   >   how often you see them
+//   >   what kind of personality they have
+//   > and explain why you admire them.
+//
+//   _Rounding-off: …_
+//
+//   _(source: …)_
+//
+// Output: { topic: "Family member you admire", bullets: [
+//   "who this person is", "how often you see them", ...
+// ]}
+//
+// The "Describe …" verb-line and the "and explain …" closer are kept
+// out of the bullets array — they're the cue-card framing, not the
+// student's bullet list. The first 3-4 indented quote lines under
+// "You should say:" are the bullets.
+
+export interface CueCard {
+  topic: string;
+  bullets: string[];
+}
+
+const CUE_HEADER = /^###\s+Card\s+\d+\s*[—–-]\s+(.+?)\s*$/i;
+const QUOTE_LINE = /^>\s?(.*)$/;
+
+/** Strip surrounding whitespace + leading-trailing punctuation. */
+function cleanBullet(s: string): string {
+  return s.replace(/^[\s>]*|[\s.]*$/g, "").trim();
+}
+
+/**
+ * Parse a cue-card-bank markdown file. Returns an array of cue cards
+ * — one per `### Card N — Title` heading. Cards with no bullets are
+ * dropped (defensive — the v1 fixture has none).
+ */
+export function parseCueCardBank(text: string): CueCard[] {
+  const lines = text.split(/\r?\n/);
+  const cards: CueCard[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const headerMatch = lines[i].match(CUE_HEADER);
+    if (!headerMatch) {
+      i++;
+      continue;
+    }
+    const topic = headerMatch[1].trim();
+    i++;
+    // Collect quoted lines until a blank-line or new heading.
+    const quoted: string[] = [];
+    while (i < lines.length) {
+      const line = lines[i];
+      if (/^###?\s/.test(line)) break;
+      const q = line.match(QUOTE_LINE);
+      if (q) {
+        quoted.push(q[1]);
+      } else if (line.trim() === "" && quoted.length > 0) {
+        // End-of-block on blank line if we've already seen quoted lines
+        break;
+      }
+      i++;
+    }
+    // Within the quoted block, the bullets are the lines AFTER
+    // "You should say:" and BEFORE the "and explain …" closer.
+    const bullets: string[] = [];
+    let sawYouShouldSay = false;
+    for (const raw of quoted) {
+      const line = raw.trimEnd();
+      if (/^you should say:?\s*$/i.test(line.trim())) {
+        sawYouShouldSay = true;
+        continue;
+      }
+      if (!sawYouShouldSay) continue;
+      // The "and explain …" line closes the bullet list.
+      if (/^and\s+explain\b/i.test(line.trim())) break;
+      // A bullet line is indented inside the quote block.
+      const cleaned = cleanBullet(line);
+      if (cleaned.length === 0) continue;
+      bullets.push(cleaned);
+    }
+    if (bullets.length > 0) {
+      cards.push({ topic, bullets });
+    }
+  }
+  return cards;
+}
+
+// ── Stall scaffolds (Source 6 + Source 7) ────────────────────────────
+//
+// Input format (verbatim from `stall-scaffolds-monologue.md`):
+//
+//   ## Scaffold pool
+//
+//   1. **early-stall** — "Take another moment."
+//   2. **early-stall** — "Take your time."
+//   ...
+//   14. **early-stall** — "Mm." *(minimal back-channel; …)*
+//
+// Output: ["Take another moment.", "Take your time.", ...]
+//
+// The tag (early-stall / deep-stall / …) is dropped — the runtime
+// stall detector picks at random and the schema is `string[]`. Trailing
+// italic parenthetical notes are stripped.
+
+const POOL_SECTION = /^##\s+Scaffold\s+pool\s*$/im;
+/** Matches `1. **tag** — "text"` (em-dash, en-dash, hyphen all accepted). */
+const SCAFFOLD_LINE = /^\s*\d+\.\s+\*\*[^*]+\*\*\s*[—–-]\s*"([^"]+)"\s*(?:\*\([^)]*\)\*)?\s*$/;
+
+/**
+ * Parse a stall-scaffold markdown file. Returns the flat list of scaffold
+ * strings in source order (tags dropped — schema is `string[]`). Returns
+ * an empty array when the `## Scaffold pool` section is missing.
+ */
+export function parseStallScaffolds(text: string): string[] {
+  const lines = text.split(/\r?\n/);
+  let sectionAt = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (POOL_SECTION.test(lines[i])) {
+      sectionAt = i + 1;
+      break;
+    }
+  }
+  if (sectionAt < 0) return [];
+
+  const out: string[] = [];
+  for (let i = sectionAt; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^##\s/.test(line)) break; // next top-level section ends the pool
+    const m = line.match(SCAFFOLD_LINE);
+    if (m) {
+      const txt = m[1].trim();
+      if (txt) out.push(txt);
+    }
+  }
+  return out;
+}

--- a/apps/admin/lib/wizard/resolve-module-source-refs.ts
+++ b/apps/admin/lib/wizard/resolve-module-source-refs.ts
@@ -1,0 +1,382 @@
+/**
+ * resolve-module-source-refs.ts (#1850 P3f)
+ *
+ * @canonical-doc docs/CONTENT-PIPELINE.md §"Per-module YAML settings blocks"
+ *
+ * P3e (`detect-module-settings.ts`) parses per-module YAML blocks from a
+ * course-ref body and emits a `Map<moduleId, Partial<AuthoredModuleSettings>>`.
+ * It intentionally SKIPS three fields whose YAML values are source-ref
+ * strings (`source:<id>`) instead of resolved structured values:
+ *   - `cueCardPool`               (e.g. `source:cue-card-bank-v1`)
+ *   - `scaffoldPool`              (e.g. `source:stall-scaffolds-monologue`)
+ *   - `profileFieldsToCapture`    (e.g. `[reason, targetBand, …]` shortform —
+ *      not a source-ref today; deferred to P3g, see below)
+ *
+ * This module IS the resolver stage. Given the per-module YAML output
+ * (as it would appear pre-skip — the caller re-parses raw YAML and
+ * keeps the `source:*` strings), the course-ref body (for the
+ * `## Content Sources` index), and a file reader, it:
+ *
+ *   1. Builds the content-sources index via `parseContentSources`.
+ *   2. For each module's `(moduleId, field)` pair, looks up the
+ *      matching content-source entry (`moduleRef === moduleId`,
+ *      `settingRef === field`).
+ *   3. Reads the file at `entry.location`, parses it per `entry.format`,
+ *      and substitutes the resolved structured value back into the
+ *      settings object.
+ *
+ * Resilient on every failure path:
+ *   - Missing content-source entry → leave the field unset + warn.
+ *   - Missing file → leave the field unset + warn.
+ *   - Unknown format → leave the field unset + warn.
+ *   - Empty parse result → leave the field unset + warn (no empty arrays).
+ *
+ * Pure (no Prisma, no network); injectable file reader for tests.
+ *
+ * The `profileFieldsToCapture` field is intentionally NOT resolved here
+ * — the v2.3 fixture supplies it as an inline shortlist
+ * (`[reason, targetBand, timeline, selfLevel]`) without per-key prompt
+ * + type metadata, and the source file doesn't exist on disk yet. P3g
+ * will introduce a profile-fields-source markdown convention and the
+ * matching parser. The resolver leaves the field unset on this PR.
+ *
+ * Issue #1850 P3f.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import type {
+  AuthoredModuleSettings,
+  ValidationWarning,
+} from "@/lib/types/json-fields";
+import {
+  parseContentSources,
+  type ContentSourceEntry,
+} from "./parse-content-sources";
+import {
+  parseCueCardBank,
+  parseStallScaffolds,
+} from "./parse-source-content";
+
+// ── YAML-block source-ref extractor ──────────────────────────────────
+//
+// P3e (`detect-module-settings.ts`) strips source-ref strings out of its
+// emit (they fail the field shape validators). We need them. Rather
+// than weaken P3e's invariants, the resolver re-walks the body
+// independently and harvests source-ref values per (moduleId, field).
+//
+// The regex pair below mirrors P3e's heading + fence detection
+// verbatim — keep them in sync if P3e's surface changes.
+
+const SETTINGS_HEADING_LINE = /^####\s+Module\s+\d+\s*[—–-]\s+.+?\s*[—–-]\s+Settings\s*$/i;
+const FENCE_OPEN = /^```ya?ml\s*$/i;
+const FENCE_CLOSE = /^```\s*$/;
+const MODULE_ID_LINE = /^moduleId:\s*([A-Za-z0-9_-]+)\s*$/;
+/**
+ * Captures `  fieldName: source:value` at 2-space indent inside the
+ * `settings:` body. `fieldName` is captured raw — we strip the optional
+ * `module` prefix downstream to match `AuthoredModuleSettings` keys.
+ */
+const SOURCE_REF_LINE = /^\s\s([A-Za-z][A-Za-z0-9]*)\s*:\s*(source:[A-Za-z0-9_-]+)\s*(?:#.*)?$/;
+
+function stripModulePrefix(key: string): string {
+  if (key.startsWith("module") && key.length > 6) {
+    return key.charAt(6).toLowerCase() + key.slice(7);
+  }
+  return key;
+}
+
+/**
+ * Walk every per-module YAML block in `bodyText` and return a map of
+ * `moduleId → { fieldName → sourceRefString }`. Only fields whose value
+ * is a `source:<id>` string are captured — every other shape is left
+ * for P3e to handle.
+ *
+ * Exported for unit tests.
+ */
+export function extractSourceRefsFromYamlBlocks(
+  bodyText: string,
+): Map<string, Map<keyof AuthoredModuleSettings, string>> {
+  const lines = bodyText.split(/\r?\n/);
+  const out = new Map<string, Map<keyof AuthoredModuleSettings, string>>();
+  let i = 0;
+  while (i < lines.length) {
+    if (!SETTINGS_HEADING_LINE.test(lines[i])) {
+      i++;
+      continue;
+    }
+    // Find the next yaml fence within 12 lines (per P3e convention).
+    let fenceAt = -1;
+    for (let j = i + 1; j < Math.min(i + 12, lines.length); j++) {
+      if (FENCE_OPEN.test(lines[j])) {
+        fenceAt = j;
+        break;
+      }
+      if (/^#{1,4}\s/.test(lines[j])) break;
+    }
+    if (fenceAt < 0) {
+      i++;
+      continue;
+    }
+    let closeAt = -1;
+    for (let j = fenceAt + 1; j < lines.length; j++) {
+      if (FENCE_CLOSE.test(lines[j])) {
+        closeAt = j;
+        break;
+      }
+    }
+    if (closeAt < 0) break;
+
+    // Scan the block body for `moduleId:` + `  field: source:…` lines.
+    let moduleId = "";
+    const refs: Array<[keyof AuthoredModuleSettings, string]> = [];
+    for (let k = fenceAt + 1; k < closeAt; k++) {
+      const raw = lines[k];
+      const idMatch = raw.match(MODULE_ID_LINE);
+      if (idMatch) {
+        moduleId = idMatch[1];
+        continue;
+      }
+      const srcMatch = raw.match(SOURCE_REF_LINE);
+      if (srcMatch) {
+        const field = stripModulePrefix(srcMatch[1]) as keyof AuthoredModuleSettings;
+        refs.push([field, srcMatch[2]]);
+      }
+    }
+    if (moduleId && refs.length > 0) {
+      const map = out.get(moduleId) ?? new Map<keyof AuthoredModuleSettings, string>();
+      for (const [k, v] of refs) map.set(k, v);
+      out.set(moduleId, map);
+    }
+    i = closeAt + 1;
+  }
+  return out;
+}
+
+// ── Public types ─────────────────────────────────────────────────────
+
+/** Field names this resolver knows how to inline. */
+const RESOLVABLE_FIELDS = new Set<keyof AuthoredModuleSettings>([
+  "cueCardPool",
+  "scaffoldPool",
+]);
+
+/** Injectable file reader so the resolver is unit-testable without disk. */
+export interface SourceFileReader {
+  exists(absolutePath: string): boolean;
+  read(absolutePath: string): string;
+}
+
+const DEFAULT_READER: SourceFileReader = {
+  exists: (p) => existsSync(p),
+  read: (p) => readFileSync(p, "utf-8"),
+};
+
+export interface ResolveOptions {
+  /** Repo-root path used to resolve relative source `location` values. */
+  repoRoot: string;
+  /** Injectable file reader (default: node:fs). */
+  reader?: SourceFileReader;
+}
+
+export interface ResolveModuleSourceRefsResult {
+  /** Updated per-module settings map with source-refs inlined where possible. */
+  byModuleId: Map<string, Partial<AuthoredModuleSettings>>;
+  /** Warnings — one per failed resolution; surfaced into the parser warning bag. */
+  validationWarnings: ValidationWarning[];
+  /**
+   * Per-resolution log: which `(moduleId, field)` resolved to which source +
+   * the resulting array length. Useful in the backfill script output.
+   */
+  resolutions: Array<{
+    moduleId: string;
+    field: keyof AuthoredModuleSettings;
+    sourceHeader?: string;
+    location?: string;
+    format?: string;
+    itemCount: number;
+    status: "resolved" | "skipped";
+    reason?: string;
+  }>;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** True when a setting value is the `source:<id>` string-form (P3e's known skip). */
+function isSourceRefString(v: unknown): v is string {
+  return typeof v === "string" && v.startsWith("source:");
+}
+
+function pushSkip(
+  result: ResolveModuleSourceRefsResult,
+  moduleId: string,
+  field: keyof AuthoredModuleSettings,
+  reason: string,
+  entry?: ContentSourceEntry,
+): void {
+  result.validationWarnings.push({
+    code: "MODULE_SOURCE_REF_UNRESOLVED",
+    message: `Module "${moduleId}" field "${field}" — ${reason}.`,
+    severity: "warning",
+    path: `modules.${moduleId}.settings.${field}`,
+  });
+  result.resolutions.push({
+    moduleId,
+    field,
+    sourceHeader: entry?.header,
+    location: entry?.location,
+    format: entry?.format,
+    itemCount: 0,
+    status: "skipped",
+    reason,
+  });
+}
+
+function parseByFormat(
+  format: string,
+  fileText: string,
+  field: keyof AuthoredModuleSettings,
+): { ok: true; value: unknown; itemCount: number } | { ok: false; reason: string } {
+  const normalisedFormat = format.toLowerCase().trim();
+  if (field === "cueCardPool") {
+    if (normalisedFormat !== "structured-md") {
+      return { ok: false, reason: `unexpected format "${format}" for cueCardPool` };
+    }
+    const cards = parseCueCardBank(fileText);
+    if (cards.length === 0) {
+      return { ok: false, reason: "cue-card parser produced 0 cards" };
+    }
+    return { ok: true, value: cards, itemCount: cards.length };
+  }
+  if (field === "scaffoldPool") {
+    if (normalisedFormat !== "structured-md") {
+      return { ok: false, reason: `unexpected format "${format}" for scaffoldPool` };
+    }
+    const items = parseStallScaffolds(fileText);
+    if (items.length === 0) {
+      return { ok: false, reason: "stall-scaffold parser produced 0 items" };
+    }
+    return { ok: true, value: items, itemCount: items.length };
+  }
+  return { ok: false, reason: `no parser registered for field "${field}"` };
+}
+
+// ── Public entry point ───────────────────────────────────────────────
+
+/**
+ * Resolve `source:<id>` references inside per-module YAML blocks into
+ * fully-inlined structured values, merged into `byModuleId`.
+ *
+ * Reads the course-ref body twice:
+ *   1. To find `source:*` strings (these don't survive P3e's emit).
+ *   2. To build the `## Content Sources` lookup index.
+ *
+ * `byModuleId` is consumed AND mutated; the same Map is returned for
+ * caller convenience. On successful resolution the field is SET (added
+ * if missing, or overwritten — P3e never emits a competing value); on
+ * failure the field is left UNTOUCHED (so the schema-shape contract
+ * holds), a warning is pushed, and the resolution row carries the
+ * skip reason.
+ */
+export function resolveModuleSourceRefs(
+  byModuleId: Map<string, Partial<AuthoredModuleSettings>>,
+  courseRefBodyText: string,
+  options: ResolveOptions,
+): ResolveModuleSourceRefsResult {
+  const reader = options.reader ?? DEFAULT_READER;
+  const result: ResolveModuleSourceRefsResult = {
+    byModuleId,
+    validationWarnings: [],
+    resolutions: [],
+  };
+
+  const sources = parseContentSources(courseRefBodyText);
+  const sourceRefsByModule = extractSourceRefsFromYamlBlocks(courseRefBodyText);
+
+  for (const [moduleId, fieldRefs] of sourceRefsByModule) {
+    for (const [field, sourceRefValue] of fieldRefs) {
+      if (!RESOLVABLE_FIELDS.has(field)) {
+        // Field exists in YAML but isn't one we know how to inline
+        // (e.g. `topicPool: source:…` — not in AuthoredModuleSettings).
+        continue;
+      }
+      // Affirm the value-shape is what we expect (defensive — the
+      // walker already filtered, but isSourceRefString is the
+      // canonical guard).
+      if (!isSourceRefString(sourceRefValue)) continue;
+
+      const key = `${moduleId}:${field}`;
+      const entry = sources.byModuleAndSetting.get(key);
+      const settings = byModuleId.get(moduleId) ?? {};
+      // Lazily insert the module entry if P3e didn't emit one (a
+      // settings block where every captured field was a source-ref).
+      if (!byModuleId.has(moduleId)) byModuleId.set(moduleId, settings);
+
+      if (!entry) {
+        pushSkip(
+          result,
+          moduleId,
+          field,
+          `no Content Sources entry for (${moduleId}, ${field})`,
+        );
+        continue;
+      }
+      if (!entry.location || !entry.format) {
+        pushSkip(
+          result,
+          moduleId,
+          field,
+          `Content Sources entry "${entry.header}" missing location or format`,
+          entry,
+        );
+        continue;
+      }
+
+      const absolutePath = resolvePath(options.repoRoot, entry.location);
+      if (!reader.exists(absolutePath)) {
+        pushSkip(
+          result,
+          moduleId,
+          field,
+          `source file not found at ${entry.location}`,
+          entry,
+        );
+        continue;
+      }
+
+      let fileText = "";
+      try {
+        fileText = reader.read(absolutePath);
+      } catch (err) {
+        pushSkip(
+          result,
+          moduleId,
+          field,
+          `read error: ${(err as Error).message}`,
+          entry,
+        );
+        continue;
+      }
+
+      const parsed = parseByFormat(entry.format, fileText, field);
+      if (!parsed.ok) {
+        pushSkip(result, moduleId, field, parsed.reason, entry);
+        continue;
+      }
+
+      // Success — inline the value.
+      (settings as Record<string, unknown>)[field] = parsed.value;
+      result.resolutions.push({
+        moduleId,
+        field,
+        sourceHeader: entry.header,
+        location: entry.location,
+        format: entry.format,
+        itemCount: parsed.itemCount,
+        status: "resolved",
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/admin/lib/wizard/run-projection-for-playbook.ts
+++ b/apps/admin/lib/wizard/run-projection-for-playbook.ts
@@ -26,6 +26,9 @@ import {
 } from "./apply-projection";
 import { projectCourseReference, type ParsedSkill } from "./project-course-reference";
 import { parseRubricBands } from "./parse-rubric-bands";
+import { resolveModuleSourceRefs } from "./resolve-module-source-refs";
+import type { AuthoredModuleSettings } from "@/lib/types/json-fields";
+import { resolve as resolvePath } from "node:path";
 import { deriveSkillTierMappingFromSkills } from "@/lib/banding/derive-skill-tier-mapping-from-source";
 import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
 import { resolveMasteryPolicyKnob } from "@/lib/cascade/resolvers/mastery-policy";
@@ -188,6 +191,39 @@ export async function runProjectionForPlaybook(playbookId: string): Promise<RunP
     }
 
     const projection = projectCourseReference(text, { sourceContentId: source.id });
+
+    // P3f (#1850) — inline `source:<id>` references that the YAML blocks
+    // declare for `cueCardPool` / `scaffoldPool`. The resolver reads the
+    // `## Content Sources` block in `text` to find each source's location
+    // + format, then reads the file from disk and parses it into the
+    // structured shape `AuthoredModuleSettings` expects. Failures are
+    // warn-and-skip — the projection still applies, just without the
+    // inlined content. The cwd at runtime is `apps/admin/`; the repo
+    // root is two levels up.
+    if (projection.configPatch.modules && projection.configPatch.modules.length > 0) {
+      const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+      for (const m of projection.configPatch.modules) {
+        if (m.settings) byModuleId.set(m.id, { ...m.settings });
+        else byModuleId.set(m.id, {});
+      }
+      const repoRoot = resolvePath(process.cwd(), "..", "..");
+      const resolution = resolveModuleSourceRefs(byModuleId, text, { repoRoot });
+      // Merge resolved settings back into the modules array.
+      projection.configPatch.modules = projection.configPatch.modules.map((m) => {
+        const resolved = resolution.byModuleId.get(m.id);
+        if (!resolved || Object.keys(resolved).length === 0) return m;
+        return { ...m, settings: { ...(m.settings ?? {}), ...resolved } };
+      });
+      for (const w of resolution.validationWarnings) {
+        projection.validationWarnings.push(w);
+      }
+      const resolvedCount = resolution.resolutions.filter((r) => r.status === "resolved").length;
+      if (resolvedCount > 0) {
+        console.log(
+          `[projection] P3f source-refs: ${resolvedCount} inlined from source=${source.id} (${source.name})`,
+        );
+      }
+    }
 
     // (3) Promote PROJECTION_NO_SKILLS_FRAMEWORK from a soft warning to a
     // launch blocker. Without skills no `skill_*` Parameters or BehaviorTargets

--- a/apps/admin/scripts/backfill-module-settings-from-course-ref.ts
+++ b/apps/admin/scripts/backfill-module-settings-from-course-ref.ts
@@ -29,6 +29,7 @@ import { readFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { prisma } from "@/lib/prisma";
 import { detectModuleSettings } from "@/lib/wizard/detect-module-settings";
+import { resolveModuleSourceRefs } from "@/lib/wizard/resolve-module-source-refs";
 import { bumpPlaybookComposeTimestamp } from "@/lib/compose/bump-timestamp";
 import type {
   AuthoredModule,
@@ -111,21 +112,58 @@ export function mergeModuleSettings(
 /**
  * Pure helper — compute the diff + next-config without touching the DB.
  * Exposed for unit tests (no Prisma dependency).
+ *
+ * Optional `repoRoot` enables P3f source-ref resolution: source-ref
+ * fields (`cueCardPool`, `scaffoldPool`) referenced as `source:<id>`
+ * in the YAML blocks are resolved against the course-ref body's
+ * `## Content Sources` block + the named files on disk. When omitted,
+ * source-ref fields stay unresolved (the P3e baseline behaviour).
  */
 export function computeBackfillPlan(
   config: PlaybookConfig,
   courseRefText: string,
+  repoRoot?: string,
 ): {
   diffs: ModuleDiff[];
   nextConfig: PlaybookConfig;
   parserWarnings: number;
   yamlBlockCount: number;
+  /**
+   * P3f — Per source-ref resolution row, in source-doc order. Empty when
+   * `repoRoot` is undefined (resolver not invoked).
+   */
+  sourceRefResolutions: Array<{
+    moduleId: string;
+    field: keyof AuthoredModuleSettings;
+    sourceHeader?: string;
+    itemCount: number;
+    status: "resolved" | "skipped";
+    reason?: string;
+  }>;
 } {
   const modules = config.modules ?? [];
   const detectedIds = modules
     .map((m) => m.id)
     .filter((s): s is string => typeof s === "string" && s.length > 0);
   const parsed = detectModuleSettings(courseRefText, detectedIds);
+  let parserWarningCount = parsed.validationWarnings.length;
+  const sourceRefResolutions: ReturnType<typeof computeBackfillPlan>["sourceRefResolutions"] = [];
+  if (repoRoot) {
+    const resolution = resolveModuleSourceRefs(parsed.byModuleId, courseRefText, {
+      repoRoot,
+    });
+    parserWarningCount += resolution.validationWarnings.length;
+    for (const r of resolution.resolutions) {
+      sourceRefResolutions.push({
+        moduleId: r.moduleId,
+        field: r.field,
+        sourceHeader: r.sourceHeader,
+        itemCount: r.itemCount,
+        status: r.status,
+        reason: r.reason,
+      });
+    }
+  }
   const diffs: ModuleDiff[] = [];
 
   const nextModules: AuthoredModule[] = modules.map((m) => {
@@ -159,8 +197,9 @@ export function computeBackfillPlan(
   return {
     diffs,
     nextConfig,
-    parserWarnings: parsed.validationWarnings.length,
+    parserWarnings: parserWarningCount,
     yamlBlockCount: parsed.blockCount,
+    sourceRefResolutions,
   };
 }
 
@@ -200,11 +239,27 @@ async function main(): Promise<void> {
   console.log("");
 
   const config = (pb.config ?? {}) as PlaybookConfig;
-  const plan = computeBackfillPlan(config, courseRefText);
+  // P3f — pass repoRoot so the resolver can read `## Content Sources`
+  // files (the parent of `apps/admin/` is the repo root when invoked
+  // from inside `apps/admin/`).
+  const repoRoot = resolvePath(__dirname, "..", "..", "..");
+  const plan = computeBackfillPlan(config, courseRefText, repoRoot);
 
   console.log(
     `Parser: ${plan.yamlBlockCount} YAML block(s) found; ${plan.parserWarnings} warning(s).`,
   );
+  if (plan.sourceRefResolutions.length > 0) {
+    console.log("Source-ref resolutions:");
+    for (const r of plan.sourceRefResolutions) {
+      if (r.status === "resolved") {
+        console.log(
+          `  - ${r.moduleId}.${String(r.field)}: ${r.itemCount} item(s) from ${r.sourceHeader ?? "?"}`,
+        );
+      } else {
+        console.log(`  - ${r.moduleId}.${String(r.field)}: SKIPPED — ${r.reason}`);
+      }
+    }
+  }
   console.log("Diff:");
   console.log(formatDiff(plan.diffs));
 

--- a/apps/admin/tests/scripts/backfill-module-settings.test.ts
+++ b/apps/admin/tests/scripts/backfill-module-settings.test.ts
@@ -165,3 +165,61 @@ describe("computeBackfillPlan — empty config short-circuit", () => {
     expect(plan.nextConfig.modules).toEqual([]);
   });
 });
+
+describe("computeBackfillPlan — P3f source-ref resolution (#1850 P3f)", () => {
+  const REPO_ROOT = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+  );
+
+  const config: PlaybookConfig = {
+    modules: [
+      makeModule("baseline", "Baseline Assessment"),
+      makeModule("part1", "Part 1"),
+      makeModule("part2", "Part 2"),
+      makeModule("part3", "Part 3"),
+      makeModule("mock", "Mock Exam"),
+    ],
+  };
+
+  it("source-refs stay unresolved when repoRoot is not passed (P3e baseline)", () => {
+    const plan = computeBackfillPlan(config, IELTS_V23);
+    expect(plan.sourceRefResolutions).toEqual([]);
+    const part2 = plan.nextConfig.modules!.find((m) => m.id === "part2")!;
+    expect(part2.settings!.cueCardPool).toBeUndefined();
+    expect(part2.settings!.scaffoldPool).toBeUndefined();
+  });
+
+  it("inlines part2.cueCardPool + scaffoldPools when repoRoot is supplied", () => {
+    const plan = computeBackfillPlan(config, IELTS_V23, REPO_ROOT);
+    expect(plan.sourceRefResolutions.length).toBeGreaterThan(0);
+    const part2 = plan.nextConfig.modules!.find((m) => m.id === "part2")!;
+    expect(Array.isArray(part2.settings!.cueCardPool)).toBe(true);
+    expect(part2.settings!.cueCardPool!.length).toBeGreaterThan(80);
+    expect(Array.isArray(part2.settings!.scaffoldPool)).toBe(true);
+    expect(part2.settings!.scaffoldPool!.length).toBe(14);
+    const part3 = plan.nextConfig.modules!.find((m) => m.id === "part3")!;
+    expect(part3.settings!.scaffoldPool!.length).toBe(15);
+  });
+
+  it("preserves manual edits when source-refs are also inlined", () => {
+    const cfgWithEdit: PlaybookConfig = {
+      modules: [
+        makeModule("part2", "Part 2", {
+          cueCardPool: [{ topic: "Manual override", bullets: ["x"] }],
+        }),
+      ],
+    };
+    const plan = computeBackfillPlan(cfgWithEdit, IELTS_V23, REPO_ROOT);
+    const part2 = plan.nextConfig.modules!.find((m) => m.id === "part2")!;
+    // mergeModuleSettings preserves manual edits — the inlined value
+    // landed in the YAML-derived plan but the merge wins for existing
+    // keys. So manual edit survives.
+    expect(part2.settings!.cueCardPool).toEqual([
+      { topic: "Manual override", bullets: ["x"] },
+    ]);
+  });
+});

--- a/docs/CONTENT-PIPELINE.md
+++ b/docs/CONTENT-PIPELINE.md
@@ -280,6 +280,30 @@ settings:
 
 **Manual-edit-wins:** The backfill script (`scripts/backfill-module-settings-from-course-ref.ts`) and the wizard projector preserve any setting already on `module.settings`. Manual edits via the Module Inspector trump re-projection — the YAML block fills in the gaps, never overwrites.
 
+**Source-ref resolution (#1850 P3f):** Three fields carry `source:<id>` strings in the YAML rather than fully-resolved structured shapes:
+
+| Field (`AuthoredModuleSettings`) | YAML form | Resolver | Disk format |
+|---|---|---|---|
+| `cueCardPool` | `cueCardPool: source:cue-card-bank-v1` | `lib/wizard/resolve-module-source-refs.ts` | `parseCueCardBank` → `Array<{topic, bullets[]}>` |
+| `scaffoldPool` | `scaffoldPool: source:stall-scaffolds-monologue` | same | `parseStallScaffolds` → `string[]` |
+| `profileFieldsToCapture` | `profileFieldsToCapture: [reason, targetBand, …]` (shortlist) | DEFERRED → P3g | DEFERRED — source file format TBD |
+
+P3f's detect→`resolveModuleSourceRefs` flow:
+
+1. P3e's `detect-module-settings.ts` parses the per-module YAML blocks AND intentionally skips fields whose value is a `source:*` string (they fail the per-field shape validators).
+2. `resolveModuleSourceRefs(byModuleId, courseRefBodyText, { repoRoot })` then:
+   - Re-walks the YAML blocks via `extractSourceRefsFromYamlBlocks` (an independent harvester so P3e's invariants stay intact).
+   - Parses the course-ref body's `## Content Sources` section via `parseContentSources` — each `### Source N — Title` block contributes `(moduleRef, settingRef) → { location, format }` to a lookup index.
+   - For each `(moduleId, field)` pair carrying a `source:*` value, looks up the matching source, reads the file at `entry.location`, parses it per `entry.format`, and writes the resolved value into `byModuleId.get(moduleId)[field]`.
+   - On any failure (no source entry, missing file, parser yields zero items, unknown format) the field is left untouched + a `MODULE_SOURCE_REF_UNRESOLVED` warning is pushed.
+3. Wired into:
+   - `lib/wizard/run-projection-for-playbook.ts` (after `projectCourseReference`, before `applyProjection` — every wizard-created course resolves source-refs at projection time).
+   - `scripts/backfill-module-settings-from-course-ref.ts` (when `--course-ref` and a repo-relative source-location are supplied — automatic, no flag).
+
+**Inlining strategy.** Cue-card pools are inlined verbatim into `Playbook.config.modules[].settings.cueCardPool` (option (c) of the brief — the Part 2 bank weighs ~22KB/playbook as JSON, well inside JSONB column limits, and avoids a new compose-time fetch edge). Scaffold pools are tiny (≤15 strings).
+
+**`profileFieldsToCapture` gap (P3g follow-on).** The v2.3 fixture supplies this field as an inline shortlist (`[reason, targetBand, timeline, selfLevel]`) without per-key prompt + type metadata. The schema requires `Array<{ key, prompt, type }>`. No source file exists on disk today. P3g will introduce a profile-fields-source markdown convention (`### Field N — <slug>` with `prompt:` + `type:`), the matching parser, and the third row in the resolver's format dispatch.
+
 ### Phase 3: Classification (LO audience)
 
 `lib/content-trust/classify-lo.ts` — heuristic regex first, LLM fallback. Each LO gets a `systemRole` from `LoSystemRole` enum.


### PR DESCRIPTION
## Summary

P3e (#1902) extracts per-module G8 YAML settings but skips fields whose YAML value is a source-ref string (`cueCardPool: source:cue-card-bank-v1`, `scaffoldPool: source:stall-scaffolds-monologue`). P3f closes the gap with a deterministic resolver that walks the course-ref's `## Content Sources` block, reads each referenced file from disk, parses it per format, and inlines the structured result into `Playbook.config.modules[].settings.*`.

- Three new pure helpers (`parse-content-sources.ts`, `parse-source-content.ts`, `resolve-module-source-refs.ts`) — no new deps, no LLM calls.
- Wired into BOTH the wizard projector (`run-projection-for-playbook.ts`) and the backfill script (`scripts/backfill-module-settings-from-course-ref.ts`) — every new wizard-created course AND every backfill run inlines source-refs.
- 34 new vitests, all green. Schema unchanged.

## Reuse-finder finding

No existing `source:*` resolution infrastructure existed. `lib/wizard/detect-authored-modules.ts:387` captures `contentSourceRef` per module but never resolves it (free-text field surfaced for educator review only). `lib/content-trust/parse-content-declaration.ts:151` handles document-level front-matter metadata (DocumentType, LoSystemRole, audience) — not source-id resolution. The closest pattern is `lib/wizard/run-projection-for-playbook.ts` which loads COURSE_REFERENCE source TEXT via the storage adapter, but the content INSIDE the text (the YAML source-refs) wasn't being followed to disk anywhere. Built fresh — matches P3e's lean parser approach (no `markdown-it`, no `gray-matter`, no YAML deps beyond the minimal P3e subset already in `detect-module-settings.ts`). [verified] reuse-finder probe in `lib/wizard/` + `lib/content-trust/` + `lib/sources/` (does-not-exist — directory not present).

## Inlining strategy

Option **(c)** from the brief — inline all source content verbatim into the playbook config. Rationale:

| Source | Items | Inlined size | Per playbook | x3 IELTS |
|---|---|---|---|---|
| Part 2 cue card bank | 88 cards | ~22 KB | ~22 KB | ~66 KB |
| Stall scaffolds (monologue) | 14 strings | ~0.4 KB | ~0.4 KB | ~1.2 KB |
| Stall scaffolds (discussion) | 15 strings | ~0.5 KB | ~0.5 KB | ~1.5 KB |

JSONB column limit is ~1 GB; we're 5 orders of magnitude under. Option (a) (curated subset) would force a separate operator UI to manage the curation; option (b) (lazy resolve at compose time) introduces a new chain-contract edge (compose-time file I/O against an external doc path, which couples prompt freshness to disk drift). Option (c) keeps the existing snapshot semantics: the projector inlines once, the operator can edit via Inspector, manual edits win.

## Per-resolution outcome (IELTS v2.3 fixture, 5 modules)

Driven by `tests/lib/wizard/__tests__/resolve-module-source-refs.test.ts` against `course-reference-ielts-v2.3.md`:

| Module | Field | Status | Items |
|---|---|---|---|
| baseline | cueCardPool | SKIPPED — Source 4 lacks location/format/moduleRef/settingRef metadata | 0 |
| baseline | scaffoldPool | resolved → Source 6 (stall-scaffolds-monologue.md) | 14 |
| part2 | cueCardPool | resolved → Source 2 (ielts-speaking-question-bank-part2.md) | 88 |
| part2 | scaffoldPool | resolved → Source 6 | 14 |
| part3 | scaffoldPool | resolved → Source 7 (stall-scaffolds-discussion.md) | 15 |
| mock | scaffoldPool | resolved → Source 6 | 14 |

Total resolved per backfill: 5/6 fields across the 3 IELTS playbooks (V1.0 / Practice / PAW). The 1 SKIP (baseline.cueCardPool → Source 4) is intentional — Source 4's content-sources block in the fixture has no `*location:*` / `*format:*` lines, so the resolver warns + skips. Adding metadata + file is a P3g surface (same place profile-fields source belongs).

## Backfill output expected on hf_sandbox (when operator runs)

Live re-backfill against the 3 IELTS playbooks is the operator's call (the script needs Prisma + the hf_sandbox DB). [unverified-here] — I can't hit hf_sandbox from the agent worktree. The script's CLI prints the new "Source-ref resolutions:" table so the operator can confirm. CIO/CTO playbooks have no v2.3 YAML blocks → resolver emits zero resolutions for them, no change.

## profile-fields gap (P3g follow-on)

The v2.3 fixture supplies `profileFieldsToCapture` as an inline shortlist (`[reason, targetBand, timeline, selfLevel]`) WITHOUT the per-key prompt+type metadata `ProfileFieldToCapture` requires. No `ielts-speaking-profile-fields.md` source file exists on disk. The resolver intentionally does NOT handle this field — `RESOLVABLE_FIELDS` is `{cueCardPool, scaffoldPool}` only. P3g will introduce a profile-fields-source markdown convention (`### Field N — <slug>` with `prompt:` + `type:` lines), the matching parser, and the third row in the resolver's format dispatch. Documented in `docs/CONTENT-PIPELINE.md` §"Per-module YAML settings blocks" → "Source-ref resolution". Tracking follow-on: [unfiled — operator's call once they want intake to capture these fields]. [verified] against schema in `lib/types/json-fields.ts:1015-1022`.

## Doc location

`docs/CONTENT-PIPELINE.md` §"Per-module YAML settings blocks" — extended with "Source-ref resolution (#1850 P3f)" subsection covering the format dispatch, the resolver flow, the inlining strategy, and the P3g gap.

## Test counts + status gates

- New: 34 vitests (`parse-content-sources` 7 + `parse-source-content` 7 + `resolve-module-source-refs` 9 + `backfill-module-settings` 3 extending).
- Broader bank (no regressions): 212 wizard tests, 86 compose tests, 132 journey/Lattice tests — all green.
- tsc: 40 errors (vs baseline 41 — improved by 1 unrelated win).
- lint: 0 errors / 4511 warnings — same as baseline.
- ratchet:check: clean (memory_md_bytes drift is pre-existing).

## Anything surprising about source-file formats

Two things:

1. **`scaffoldPool` schema is `string[]`, not `Array<{moment, text}>`** (as the brief suggested). The runtime consumer is the client-side stall detector at `app/api/callers/[callerId]/module-stall-pool/route.ts:88` which picks at random — the tag is dropped in the parse. If a future consumer needs the moment tag, the parser would need a v2 shape; today it's a flat list.
2. **The Content Sources block uses `moduleRef` + `settingRef` keys for resolution lookup, NOT the `source:cue-card-bank-v1` slug.** The fixture's source headers ("Source 2 — Part 2 cue card bank") and the YAML's `source:cue-card-bank-v1` reference have no shared identifier — the lookup ONLY works via the `(moduleRef, settingRef)` metadata block under each source. That means every new resolvable source MUST carry `*location:*`, `*format:*`, `*moduleRef:*`, `*settingRef:*` lines or it gets skipped. Documented in the source-ref subsection.

## Verified by

- Lattice survey (`.claude/rules/lattice-survey.md`): ran the sibling-writer survey before writing. `Playbook.config.modules[].settings.cueCardPool` writers — P3e's `detectModuleSettings` (skips source-refs), Module Inspector via `/journey-setting` route (`apps/admin/app/api/playbooks/[playbookId]/journey-setting/route.ts`), backfill script `mergeModuleSettings` (manual-edit-wins). No clobber risk — P3e never emits source-ref fields; manual edits via Inspector are preserved by `mergeModuleSettings`; the new resolver runs once at projection/backfill time and writes only into fields P3e left empty.
- File:line citations [verified]:
  - Resolver core: `apps/admin/lib/wizard/resolve-module-source-refs.ts:175-289`
  - YAML walker: `apps/admin/lib/wizard/resolve-module-source-refs.ts:51-110`
  - Content Sources parser: `apps/admin/lib/wizard/parse-content-sources.ts:113-149`
  - Wire-in (projector): `apps/admin/lib/wizard/run-projection-for-playbook.ts:194-220`
  - Wire-in (backfill): `apps/admin/scripts/backfill-module-settings-from-course-ref.ts:127-155`
- Vitests (all green):
  - `apps/admin/lib/wizard/__tests__/parse-content-sources.test.ts` 7/7
  - `apps/admin/lib/wizard/__tests__/parse-source-content.test.ts` 7/7
  - `apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts` 9/9
  - `apps/admin/tests/scripts/backfill-module-settings.test.ts` 11/11
- Schema unchanged. `cueCardPool` / `scaffoldPool` / `profileFieldsToCapture` already exist in `AuthoredModuleSettings` at `lib/types/json-fields.ts:1025-1063`. Registry-schema-coverage vitest still 6/6 green.

Closes P3f of #1850. Parent: #1902 (P3e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)