### PR TITLE
docs(ielts): multi-route Sources 9-13 to all module contexts (#1850)

### DIFF
--- a/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
+++ b/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
@@ -1128,6 +1128,51 @@ The authoritative public-version IELTS Speaking band descriptors for the four sc
 - *usage:* Skills Framework tier-mapping derivation at projection time.  
 - *Notes:* Public Version only. The Examiner Version (licensed to certified examiners) is NOT to be reproduced. A handful of Pron half-band descriptors are marked `[verify against IELTS.org publication before wizard run]` in the source file — the projector should surface those as warnings, not silently ship.  
   
+### Source 9 — Mock Exam cue card bank (reuses Source 2 content)  
+  
+The Mock Exam's Part 2 phase reuses the same 88 cue cards as Part 2 practice; mock-specific scenarios are deferred to a future source-authoring pass. The runtime guard `selectPinnedCardForModule` would otherwise return null on the Mock Part 2 phase, leaving the tutor with no cue card to pin.  
+  
+- *location:* `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part2.md`  
+- *format:* structured-md  
+- *moduleRef:* mock  
+- *settingRef:* moduleCueCardPool  
+  
+### Source 10 — Baseline cue card bank (reuses Source 2 content)  
+  
+The Baseline Assessment's Part 2 phase reuses the same cue card bank as Part 2 practice; baseline-specific topics are deferred. Closes the same `selectPinnedCardForModule` null-return gap as Source 9, on the Baseline path.  
+  
+- *location:* `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part2.md`  
+- *format:* structured-md  
+- *moduleRef:* baseline  
+- *settingRef:* moduleCueCardPool  
+  
+### Source 11 — Baseline stall scaffolds (reuses Source 6 content)  
+  
+The Baseline Assessment uses the same monologue stall scaffolds as Part 2 — examiner-mode silence rules apply throughout the Baseline Part 2 long-turn.  
+  
+- *location:* `docs/external/ielts/ielts-speaking/stall-scaffolds-monologue.md`  
+- *format:* structured-md  
+- *moduleRef:* baseline  
+- *settingRef:* moduleScaffoldPool  
+  
+### Source 12 — Mock Exam stall scaffolds (reuses Source 6 content)  
+  
+The Mock Exam uses the same monologue stall scaffolds as Part 2 — examiner-mode silence rules apply throughout the Mock Part 2 long-turn.  
+  
+- *location:* `docs/external/ielts/ielts-speaking/stall-scaffolds-monologue.md`  
+- *format:* structured-md  
+- *moduleRef:* mock  
+- *settingRef:* moduleScaffoldPool  
+  
+### Source 13 — Part 1 stall scaffolds (reuses Source 7 content)  
+  
+Part 1 short Q&A reuses the discussion stall scaffolds — single-question stalls with the same reframe-not-resolve shape as Part 3, scaled to Part 1's shorter turns.  
+  
+- *location:* `docs/external/ielts/ielts-speaking/stall-scaffolds-discussion.md`  
+- *format:* structured-md  
+- *moduleRef:* part1  
+- *settingRef:* moduleScaffoldPool  
+  
 ### Content preferences  
   
 - The tutor does not use the same Part 1 topic two drills in a row.  

--- a/apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts
+++ b/apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts
@@ -67,32 +67,50 @@ describe("resolveModuleSourceRefs — IELTS v2.3 against real disk", () => {
     );
   });
 
-  it("skips source-refs with no Content Sources entry + emits a warning", () => {
-    // The Baseline module's cueCardPool references `source:cue-card-bank-baseline-v1`,
-    // but the fixture's Content Sources block declares Source 4 (Baseline pool)
-    // WITHOUT location/format/moduleRef/settingRef metadata. The resolver
-    // skips it; the fields untouched.
+  it("inlines baseline.cueCardPool + mock.cueCardPool via Source 2a/2b multi-route entries", () => {
+    // Source 2a (moduleRef: mock) and Source 2b (moduleRef: baseline) point the
+    // same Part 2 question-bank file at the Mock and Baseline contexts. Both
+    // resolve against the multi-route Content Sources entries; the legacy
+    // `source:mock-exam-scenario-pool-v1` / `source:cue-card-bank-baseline-v1`
+    // sentinels in the YAML are sentinels-only (the resolver matches by
+    // `(moduleRef, settingRef)`, not by the source id string).
     const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
     const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
     const baseline = out.byModuleId.get("baseline");
+    const mock = out.byModuleId.get("mock");
     expect(baseline).toBeDefined();
-    expect(baseline!.cueCardPool).toBeUndefined();
-    const skips = out.resolutions.filter((r) => r.status === "skipped");
-    expect(skips.length).toBeGreaterThanOrEqual(1);
-    expect(
-      skips.some(
-        (r) => r.moduleId === "baseline" && r.field === "cueCardPool",
-      ),
-    ).toBe(true);
+    expect(mock).toBeDefined();
+    expect(Array.isArray(baseline!.cueCardPool)).toBe(true);
+    expect(baseline!.cueCardPool!.length).toBeGreaterThanOrEqual(80);
+    expect(Array.isArray(mock!.cueCardPool)).toBe(true);
+    expect(mock!.cueCardPool!.length).toBeGreaterThanOrEqual(80);
+  });
+
+  it("inlines baseline.scaffoldPool + mock.scaffoldPool + part1.scaffoldPool via Source 6a/6b/7a", () => {
+    // Source 6a (moduleRef: baseline), 6b (moduleRef: mock) route the
+    // monologue stall scaffolds to Baseline + Mock Part 2 long-turn. Source
+    // 7a (moduleRef: part1) routes the discussion scaffolds to Part 1 short
+    // Q&A. All resolve against the multi-route Content Sources entries.
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
+    expect(out.byModuleId.get("baseline")!.scaffoldPool).toEqual(
+      expect.arrayContaining(["Take another moment.", "Take your time."]),
+    );
+    expect(out.byModuleId.get("mock")!.scaffoldPool).toEqual(
+      expect.arrayContaining(["Take another moment.", "Take your time."]),
+    );
+    expect(out.byModuleId.get("part1")!.scaffoldPool).toEqual(
+      expect.arrayContaining(["Could you give an example?"]),
+    );
   });
 
   it("returns a structured resolution log", () => {
     const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
     const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
     const resolved = out.resolutions.filter((r) => r.status === "resolved");
-    // part2.cueCardPool + 3 scaffoldPool resolutions (part2 + part3 + mock + baseline)
-    // Some may skip (baseline scaffoldPool source:stall-scaffolds-monologue resolves).
-    expect(resolved.length).toBeGreaterThanOrEqual(3);
+    // post-multi-route: 3 cueCardPool resolutions (part2 + mock + baseline)
+    // + 5 scaffoldPool resolutions (part2 + part3 + mock + baseline + part1) = 8
+    expect(resolved.length).toBeGreaterThanOrEqual(8);
     const part2Cue = resolved.find(
       (r) => r.moduleId === "part2" && r.field === "cueCardPool",
     );


### PR DESCRIPTION
## Summary

Path A from epic #1850 follow-on. Closes the 5 documented gaps from P3f's backfill by re-routing 3 existing source files at additional `moduleRef` slots. No new content authored.

| Gap closed | Severity | New Source |
|---|---|---|
| Mock cueCardPool | HIGH (`selectPinnedCardForModule` was returning null) | Source 9 |
| Baseline cueCardPool | MEDIUM | Source 10 |
| Baseline scaffoldPool | low | Source 11 |
| Mock scaffoldPool | low | Source 12 |
| Part 1 scaffoldPool | low | Source 13 |

All 5 entries point at existing files:
- Sources 9 + 10 → `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part2.md` (same as Source 2)
- Sources 11 + 12 → `docs/external/ielts/ielts-speaking/stall-scaffolds-monologue.md` (same as Source 6)
- Source 13 → `docs/external/ielts/ielts-speaking/stall-scaffolds-discussion.md` (same as Source 7)

## Parser constraint discovered

The brief proposed sub-source naming (`Source 2a`, `Source 6b`). The Content Sources parser regex `^###\s+(Source\s+\d+\s*[—–-].+)$` requires a numeric N — `2a` silently bypasses parsing. Per the task brief constraint (no parser changes), used plain `Source 9 — 13`. The resolver matches by `(moduleRef, settingRef)`, not by the source-N number, so the choice is purely cosmetic.

## Per-playbook backfill output (hf-sandbox)

```
== Playbook: IELTS Speaking Practice V1.0 (eb6bc79e-3168-49e5-90a0-d732a37fe294)
  WROTE: 3 setting(s) — part1.scaffoldPool, mock.cueCardPool, mock.scaffoldPool
  (no baseline module in this playbook's config)

== Playbook: IELTS Speaking PAW (41d4dcfa-1908-4095-8980-51c3502c1345)
  WROTE: 3 setting(s) — part1.scaffoldPool, mock.cueCardPool, mock.scaffoldPool
  (no baseline module in this playbook's config)

== Playbook: IELTS Speaking Practice (20b21160-0516-49c9-a8da-105772f41e64)
  WROTE: 5 setting(s) — baseline.cueCardPool, baseline.scaffoldPool,
                         part1.scaffoldPool, mock.cueCardPool, mock.scaffoldPool
```

Total: 11 settings written across 3 playbooks. `composeInputsUpdatedAt` bumped on each.

## Verified by

**Test bank (file: line):** `apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts:80` (cueCardPool multi-route inline) + `:91` (scaffoldPool multi-route inline) + `:111` (resolution log >=8 resolved) — 66/66 vitests pass across the 5 fixture-consuming suites (parse-content-sources, detect-module-settings, detect-authored-modules, resolve-module-source-refs, backfill-module-settings) [verified].

**Resolver dry-run log:** 8 resolved / 0 skipped (vs 3 resolved / 5 skipped pre-change):
- baseline.cueCardPool: 88 cards from Source 10
- baseline.scaffoldPool: 14 items from Source 11
- part1.scaffoldPool: 15 items from Source 13
- mock.cueCardPool: 88 cards from Source 9
- mock.scaffoldPool: 14 items from Source 12
- (part2.cueCardPool: 88 / part2.scaffoldPool: 14 / part3.scaffoldPool: 15 unchanged)

**hf-sandbox post-state SQL audit (live, run via gcloud compute ssh):**

Across 3 IELTS playbooks × 5 modules = 15 module slots. Post-state:
- `cueCardPool` populated on 7 module-slots (was 3)
- `scaffoldPool` populated on 9 module-slots (was 3)

The remaining unpopulated slots are *by design*: `part1.cueCardPool` + `part3.cueCardPool` are `null` in the YAML blocks (Part 1 uses topic sets, not cue cards; Part 3 uses thematic question banks). And the V1.0 + PAW playbooks lack a `baseline` module entirely in their `config.modules[]` — a deeper config gap orthogonal to this PR.

## Test plan

- [x] vitest run resolve-module-source-refs.test.ts → 10/10 pass
- [x] vitest run parse-content-sources.test.ts → 7/7 pass
- [x] vitest run detect-module-settings.test.ts → 14/14 pass
- [x] vitest run detect-authored-modules.test.ts → 24/24 pass
- [x] vitest run backfill-module-settings.test.ts → 11/11 pass
- [x] hf-sandbox dry-run on IELTS Speaking Practice → shows 5 settings would land
- [x] hf-sandbox write on all 3 IELTS playbooks → 11 settings landed cleanly
- [x] hf-sandbox post-state audit → all 5 documented gaps closed where module exists

## Anything surprising

Parser constraint on `Source N` naming forced renumber from sub-source (`2a / 6b`) to flat (`9-13`). Resolver matches on `(moduleRef, settingRef)` regardless of N — net-zero functional effect, choice was purely cosmetic.

Two of three IELTS playbooks (V1.0 + PAW) have no `baseline` module in their `config.modules[]` at all — pre-existing config drift unrelated to this PR; the backfill correctly skips with "no YAML block for this module id" diff lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)