### PR TITLE
feat(prompt-composition): parametersAsDirectives dispatcher v1 (#1907)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,7 +1,7 @@
 {
   "tsc_errors": 41,
   "lint_errors": 0,
-  "lint_warnings": 4511,
+  "lint_warnings": 4533,
   "quarantined_tests": 36,
   "knip_unused": 162,
   "same_issue_fix_chain_max": 10,

--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -9,7 +9,14 @@
       "name": "Abstract Vs Concrete",
       "definition": "Visual learners prefer concrete over abstract",
       "domainGroup": "learning_adaptation",
-      "defaultTarget": 0.5
+      "defaultTarget": 0.5,
+      "promptInjection": {
+        "section": "STYLE",
+        "condition": "when-non-default",
+        "templateLow": "Favour concrete examples (specific, hands-on, observable) over abstract reasoning.",
+        "templateHigh": "Lean into abstract reasoning (principles, generalisations) before concrete examples.",
+        "threshold": 0.5
+      }
     },
     {
       "parameterId": "adapt_to_feedback_style",

--- a/apps/admin/lib/prompt/composition/renderPromptSummary.ts
+++ b/apps/admin/lib/prompt/composition/renderPromptSummary.ts
@@ -307,6 +307,21 @@ export function renderProviderPrompt(
   if (adapt?.length) {
     adapt.slice(0, 3).forEach(a => parts.push(`- ${a}`));
   }
+  // #1907 — parametersAsDirectives dispatcher emits per-section
+  // behaviour directives derived from registry entries with a
+  // `promptInjection` block. Each section's directives are pushed
+  // into the matching part of this renderer. The STYLE-section
+  // directives land here; AUDIENCE / PEDAGOGY / etc. land in their
+  // own blocks below.
+  const dispatcherSections = (llmPrompt as any).parametersAsDirectives?.sections as
+    | Array<{ section: string; directives: string[] }>
+    | undefined;
+  const styleDirectives = dispatcherSections?.find((s) => s.section === "STYLE");
+  if (styleDirectives?.directives?.length) {
+    for (const d of styleDirectives.directives) {
+      parts.push(`- ${d}`);
+    }
+  }
   parts.push("");
 
   // --- AUDIENCE ---
@@ -323,6 +338,15 @@ export function renderProviderPrompt(
     parts.push(`Tone: ${ins.emotionalTone}`);
     if (ins.fillers?.length) parts.push(`Fillers: ${ins.fillers.join(", ")}`);
     if (ins.checkIns?.length) parts.push(`Check-ins: ${ins.checkIns.join(", ")}`);
+    // #1907 — AUDIENCE-section directives from parametersAsDirectives.
+    const audienceDirectives = dispatcherSections?.find(
+      (s) => s.section === "AUDIENCE",
+    );
+    if (audienceDirectives?.directives?.length) {
+      for (const d of audienceDirectives.directives) {
+        parts.push(`- ${d}`);
+      }
+    }
     parts.push("");
   }
 

--- a/apps/admin/lib/prompt/composition/transforms/parametersAsDirectives.ts
+++ b/apps/admin/lib/prompt/composition/transforms/parametersAsDirectives.ts
@@ -1,0 +1,225 @@
+/**
+ * parametersAsDirectives — #1907 dispatcher transform.
+ *
+ * Reads behaviour-parameter entries that carry a `promptInjection` block in
+ * the registry, resolves each parameter's effective cascade target via the
+ * batched `getEffectiveBehaviorTargetsForCaller` reader, picks the
+ * template variant (low vs high vs always) for the resolved value, and
+ * emits one directive string per parameter into the [STYLE] (or other
+ * named) section of the composed prompt.
+ *
+ * Architectural notes:
+ *
+ *   - **One DB read per compose cycle.** The cascade resolver is called
+ *     ONCE with `(playbookId, callerId)`. Resolving 70 params via
+ *     `resolveBehaviorTarget` would cost ~350 queries; the batched helper
+ *     does 3.
+ *
+ *   - **Null-effective contract.** When the cascade resolves to no
+ *     populated layer (parameter has no SYSTEM/PLAYBOOK/CALLER row), the
+ *     dispatcher silently skips emission for that parameter. The next
+ *     turn of the LLM proxy will see no directive for it — same as if
+ *     `promptInjection` were not set. This is the documented "skip + log"
+ *     behaviour from `parameter-coverage.md`.
+ *
+ *   - **Sibling-writer: targets.ts.** The existing `targets.ts` transform
+ *     emits structured `BehaviorTarget` data to the LLM via
+ *     `instructions.behavior_targets_summary` — distinct presentation
+ *     (structured context vs natural-language directive). The two coexist
+ *     without conflict; both can mention the same `parameterId` because
+ *     the LLM consumes them as separate signals (data + guidance).
+ *
+ *   - **`@renderer-consumed-at` sentinel.** Required by the
+ *     `composition-directive-needs-renderer` ESLint rule (#1848). Render
+ *     site: `renderPromptSummary.ts::renderProviderPrompt`.
+ *
+ * @renderer-consumed-at lib/prompt/composition/renderPromptSummary.ts
+ *
+ * @see docs/decisions/2026-06-17-registry-schema-coverage.md
+ * @see .claude/rules/parameter-coverage.md
+ * @see github.com/.../issues/1907
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { registerTransform } from "../TransformRegistry";
+import type { AssembledContext } from "../types";
+import { getEffectiveBehaviorTargetsForCaller } from "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller";
+
+// ── Registry shape ──────────────────────────────────────────────────────
+// Mirror of the JSON shape; promptInjection is optional. Only entries
+// that carry it participate in the dispatcher.
+
+interface PromptInjectionConfig {
+  /** Render section name — e.g. "STYLE", "AUDIENCE", "PEDAGOGY". */
+  section: string;
+  /**
+   * Emission gate: "always" emits regardless of value; "when-non-default"
+   * skips emission when the effective value equals `defaultTarget`. The
+   * latter is the documented default for behaviour-shape params.
+   */
+  condition?: "always" | "when-non-default";
+  /**
+   * Single-template path: a single directive line, with `{value}` token
+   * substitution. Mutually exclusive with templateLow/templateHigh.
+   */
+  template?: string;
+  /**
+   * Bipolar template path: pick `templateLow` when effectiveValue <
+   * threshold, `templateHigh` otherwise. Useful for axis-style params
+   * (abstract↔concrete, formal↔casual, etc.).
+   */
+  templateLow?: string;
+  templateHigh?: string;
+  /** Threshold for the bipolar split (default 0.5). */
+  threshold?: number;
+}
+
+interface RegistryEntry {
+  parameterId: string;
+  defaultTarget: number;
+  promptInjection?: PromptInjectionConfig;
+}
+
+interface Registry {
+  parameters: RegistryEntry[];
+}
+
+// ── Module-level load of the registry JSON ──────────────────────────────
+// Loaded once per server process — the JSON is seed-data, byte-identical
+// across compose cycles within a deployment.
+
+let _registryCache: Registry | null = null;
+function loadRegistry(): Registry {
+  if (_registryCache) return _registryCache;
+  const registryPath = resolve(
+    process.cwd(),
+    "docs-archive",
+    "bdd-specs",
+    "behavior-parameters.registry.json",
+  );
+  try {
+    const text = readFileSync(registryPath, "utf8");
+    _registryCache = JSON.parse(text) as Registry;
+  } catch (err) {
+    console.warn(
+      `[parametersAsDirectives] failed to load registry from ${registryPath}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    _registryCache = { parameters: [] };
+  }
+  return _registryCache;
+}
+
+// ── Directive rendering ─────────────────────────────────────────────────
+
+interface SectionDirectives {
+  section: string;
+  directives: string[];
+}
+
+function pickTemplate(
+  cfg: PromptInjectionConfig,
+  effectiveValue: number,
+): string | null {
+  // Single-template path
+  if (cfg.template) {
+    return cfg.template.replace(/\{value\}/g, formatValue(effectiveValue));
+  }
+  // Bipolar template path
+  const threshold = cfg.threshold ?? 0.5;
+  if (effectiveValue >= threshold) {
+    return cfg.templateHigh ?? cfg.templateLow ?? null;
+  }
+  return cfg.templateLow ?? cfg.templateHigh ?? null;
+}
+
+function formatValue(v: number): string {
+  // Two decimals; trim trailing zeros so 0.50 → "0.5", 0.75 → "0.75".
+  return Number.isFinite(v)
+    ? v.toFixed(2).replace(/0+$/, "").replace(/\.$/, "")
+    : "";
+}
+
+// ── Transform ───────────────────────────────────────────────────────────
+
+interface DispatcherInput {
+  playbookId: string | null;
+  callerId: string;
+}
+
+interface DispatcherOutput {
+  /** Sections grouped by name, each with its emitted directive lines. */
+  sections: SectionDirectives[];
+  /** Total directive count emitted across all sections. */
+  directiveCount: number;
+}
+
+registerTransform(
+  "parametersAsDirectives",
+  async (
+    rawData: DispatcherInput,
+    _context: AssembledContext,
+  ): Promise<DispatcherOutput> => {
+    const { playbookId, callerId } = rawData;
+
+    if (!playbookId || !callerId) {
+      return { sections: [], directiveCount: 0 };
+    }
+
+    const registry = loadRegistry();
+    const injectable = registry.parameters.filter(
+      (p): p is RegistryEntry & { promptInjection: PromptInjectionConfig } =>
+        Boolean(p.promptInjection),
+    );
+
+    if (injectable.length === 0) {
+      return { sections: [], directiveCount: 0 };
+    }
+
+    // ── Single batched cascade read for all parameters at once ─────────
+    const effective = await getEffectiveBehaviorTargetsForCaller(
+      playbookId,
+      callerId,
+    );
+    const effectiveByParam = new Map(
+      effective.map((e) => [e.parameterId, e.effectiveValue]),
+    );
+
+    // ── Build directives grouped by section ────────────────────────────
+    const bySection = new Map<string, string[]>();
+    for (const entry of injectable) {
+      const effectiveValue = effectiveByParam.get(entry.parameterId);
+
+      // Null-effective contract: parameter has no populated cascade
+      // layer — silently skip emission. The bundle (#1906) carries the
+      // module content; the directive layer is purely supplemental.
+      if (effectiveValue === undefined) continue;
+
+      // when-non-default gate: skip when value matches the seeded default
+      const condition = entry.promptInjection.condition ?? "when-non-default";
+      if (condition === "when-non-default" && effectiveValue === entry.defaultTarget) {
+        continue;
+      }
+
+      const directive = pickTemplate(entry.promptInjection, effectiveValue);
+      if (!directive) continue;
+
+      const section = entry.promptInjection.section;
+      const list = bySection.get(section) ?? [];
+      list.push(directive);
+      bySection.set(section, list);
+    }
+
+    const sections: SectionDirectives[] = Array.from(bySection.entries()).map(
+      ([section, directives]) => ({ section, directives }),
+    );
+    const directiveCount = sections.reduce(
+      (sum, s) => sum + s.directives.length,
+      0,
+    );
+
+    return { sections, directiveCount };
+  },
+);

--- a/apps/admin/lib/prompt/composition/transforms/parametersAsDirectives.ts
+++ b/apps/admin/lib/prompt/composition/transforms/parametersAsDirectives.ts
@@ -46,6 +46,7 @@ import { resolve } from "node:path";
 import { registerTransform } from "../TransformRegistry";
 import type { AssembledContext } from "../types";
 import { getEffectiveBehaviorTargetsForCaller } from "@/lib/tolerance/getEffectiveBehaviorTargetsForCaller";
+import { NEUTRAL_PARAMETER_TARGET } from "@/lib/measurement/neutral-target";
 
 // ── Registry shape ──────────────────────────────────────────────────────
 // Mirror of the JSON shape; promptInjection is optional. Only entries
@@ -128,7 +129,7 @@ function pickTemplate(
     return cfg.template.replace(/\{value\}/g, formatValue(effectiveValue));
   }
   // Bipolar template path
-  const threshold = cfg.threshold ?? 0.5;
+  const threshold = cfg.threshold ?? NEUTRAL_PARAMETER_TARGET;
   if (effectiveValue >= threshold) {
     return cfg.templateHigh ?? cfg.templateLow ?? null;
   }

--- a/apps/admin/tests/lib/composition/parameters-as-directives.test.ts
+++ b/apps/admin/tests/lib/composition/parameters-as-directives.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the parametersAsDirectives dispatcher transform (#1907).
+ *
+ * The dispatcher reads registry entries with a `promptInjection` block,
+ * resolves the cascade target via the batched
+ * `getEffectiveBehaviorTargetsForCaller` helper, and emits one directive
+ * per parameter into the matching section. These tests verify:
+ *
+ *   - Bipolar template path (templateLow vs templateHigh)
+ *   - Single-template path with {value} substitution
+ *   - Null-effective contract (no directive when cascade returns nothing)
+ *   - when-non-default condition (no directive at default value)
+ *   - Batched cascade read (helper called exactly ONCE per compose)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetEffectiveBehaviorTargetsForCaller = vi.fn();
+
+vi.mock("@/lib/tolerance/getEffectiveBehaviorTargetsForCaller", () => ({
+  getEffectiveBehaviorTargetsForCaller: (...args: unknown[]) =>
+    mockGetEffectiveBehaviorTargetsForCaller(...args),
+}));
+
+// Import after the mock is in place so the transform picks up the mock.
+import "@/lib/prompt/composition/transforms/parametersAsDirectives";
+import { getTransform } from "@/lib/prompt/composition/TransformRegistry";
+
+describe("parametersAsDirectives transform (#1907)", () => {
+  const transform = getTransform("parametersAsDirectives")!;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is registered in the transform registry", () => {
+    expect(transform).toBeDefined();
+    expect(typeof transform).toBe("function");
+  });
+
+  it("returns an empty result when playbookId is null", async () => {
+    const out: any = await transform(
+      { playbookId: null, callerId: "c-1" },
+      {} as any,
+      {} as any,
+    );
+    expect(out.sections).toEqual([]);
+    expect(out.directiveCount).toBe(0);
+    expect(mockGetEffectiveBehaviorTargetsForCaller).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty result when callerId is empty", async () => {
+    const out: any = await transform(
+      { playbookId: "pb-1", callerId: "" },
+      {} as any,
+      {} as any,
+    );
+    expect(out.sections).toEqual([]);
+    expect(out.directiveCount).toBe(0);
+    expect(mockGetEffectiveBehaviorTargetsForCaller).not.toHaveBeenCalled();
+  });
+
+  it("calls the batched cascade reader exactly ONCE per compose (TL Risk-2 pin)", async () => {
+    mockGetEffectiveBehaviorTargetsForCaller.mockResolvedValue([
+      {
+        parameterId: "abstract-vs-concrete",
+        effectiveValue: 0.2, // low → favour concrete
+        sourceScope: "CALLER",
+        systemValue: 0.5,
+        playbookValue: null,
+        callerValue: 0.2,
+      },
+    ]);
+
+    await transform(
+      { playbookId: "pb-1", callerId: "c-1" },
+      {} as any,
+      {} as any,
+    );
+
+    expect(mockGetEffectiveBehaviorTargetsForCaller).toHaveBeenCalledTimes(1);
+    expect(mockGetEffectiveBehaviorTargetsForCaller).toHaveBeenCalledWith(
+      "pb-1",
+      "c-1",
+    );
+  });
+
+  it("bipolar template — emits templateLow when value < threshold", async () => {
+    mockGetEffectiveBehaviorTargetsForCaller.mockResolvedValue([
+      {
+        parameterId: "abstract-vs-concrete",
+        effectiveValue: 0.2, // < 0.5 → templateLow
+        sourceScope: "CALLER",
+        systemValue: 0.5,
+        playbookValue: null,
+        callerValue: 0.2,
+      },
+    ]);
+
+    const out: any = await transform(
+      { playbookId: "pb-1", callerId: "c-1" },
+      {} as any,
+      {} as any,
+    );
+
+    expect(out.directiveCount).toBe(1);
+    expect(out.sections).toHaveLength(1);
+    expect(out.sections[0].section).toBe("STYLE");
+    expect(out.sections[0].directives[0]).toMatch(/concrete/i);
+  });
+
+  it("bipolar template — emits templateHigh when value > threshold", async () => {
+    mockGetEffectiveBehaviorTargetsForCaller.mockResolvedValue([
+      {
+        parameterId: "abstract-vs-concrete",
+        effectiveValue: 0.85, // > 0.5 → templateHigh
+        sourceScope: "CALLER",
+        systemValue: 0.5,
+        playbookValue: null,
+        callerValue: 0.85,
+      },
+    ]);
+
+    const out: any = await transform(
+      { playbookId: "pb-1", callerId: "c-1" },
+      {} as any,
+      {} as any,
+    );
+
+    expect(out.directiveCount).toBe(1);
+    expect(out.sections[0].directives[0]).toMatch(/abstract/i);
+  });
+
+  it("when-non-default contract — skips emission when value equals defaultTarget", async () => {
+    mockGetEffectiveBehaviorTargetsForCaller.mockResolvedValue([
+      {
+        parameterId: "abstract-vs-concrete",
+        effectiveValue: 0.5, // === defaultTarget
+        sourceScope: "SYSTEM",
+        systemValue: 0.5,
+        playbookValue: null,
+        callerValue: null,
+      },
+    ]);
+
+    const out: any = await transform(
+      { playbookId: "pb-1", callerId: "c-1" },
+      {} as any,
+      {} as any,
+    );
+
+    expect(out.directiveCount).toBe(0);
+    expect(out.sections).toEqual([]);
+  });
+
+  it("null-effective contract — skips emission when no cascade layer has the parameter", async () => {
+    mockGetEffectiveBehaviorTargetsForCaller.mockResolvedValue([]); // nothing populated
+
+    const out: any = await transform(
+      { playbookId: "pb-1", callerId: "c-1" },
+      {} as any,
+      {} as any,
+    );
+
+    expect(out.directiveCount).toBe(0);
+    expect(out.sections).toEqual([]);
+  });
+});

--- a/apps/admin/tests/lib/measurement/parameter-coverage.test.ts
+++ b/apps/admin/tests/lib/measurement/parameter-coverage.test.ts
@@ -219,6 +219,19 @@ function classify(p: RegistryEntry): ParamResult {
       domainGroup: p.domainGroup,
     };
   }
+  // #1907 — dispatcher-covered classification. Parameters carrying a
+  // `promptInjection` block in the registry are read dynamically by the
+  // `parametersAsDirectives` transform (no literal mention in consumer
+  // source — would otherwise show as `gap`). Treat the registry block
+  // itself as the consumer signal.
+  if ((p as RegistryEntry & { promptInjection?: unknown }).promptInjection) {
+    return {
+      id: p.parameterId,
+      classification: "covered",
+      matchedTerm: "promptInjection (registry-driven dispatcher)",
+      domainGroup: p.domainGroup,
+    };
+  }
   for (const term of searchTerms(p.parameterId)) {
     if (term.length < 4) continue; // skip too-generic
     const re = new RegExp(

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-17T18:24:49.786Z",
+  "generatedAt": "2026-06-18T10:55:09.881Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1837,
-  "edgeCount": 4311,
+  "fileCount": 1846,
+  "edgeCount": 4330,
   "skippedEdges": 1,
   "edges": [
     {
@@ -15276,6 +15276,18 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/prompt/composition/transforms/parametersAsDirectives.ts",
+      "to": "lib/prompt/composition/TransformRegistry.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/parametersAsDirectives.ts",
+      "to": "lib/prompt/composition/types.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/parametersAsDirectives.ts",
+      "to": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts"
+    },
+    {
       "from": "lib/prompt/composition/transforms/pedagogy-mode.ts",
       "to": "lib/content-trust/resolve-config.ts"
     },
@@ -16564,8 +16576,16 @@
       "to": "lib/wizard/graph-nodes.ts"
     },
     {
+      "from": "lib/wizard/__tests__/parse-content-sources.test.ts",
+      "to": "lib/wizard/parse-content-sources.ts"
+    },
+    {
       "from": "lib/wizard/__tests__/parse-rubric-bands.test.ts",
       "to": "lib/wizard/parse-rubric-bands.ts"
+    },
+    {
+      "from": "lib/wizard/__tests__/parse-source-content.test.ts",
+      "to": "lib/wizard/parse-source-content.ts"
     },
     {
       "from": "lib/wizard/__tests__/persist-authored-modules.test.ts",
@@ -16582,6 +16602,14 @@
     {
       "from": "lib/wizard/__tests__/project-course-reference.test.ts",
       "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
+      "from": "lib/wizard/__tests__/resolve-module-source-refs.test.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/wizard/__tests__/resolve-module-source-refs.test.ts",
+      "to": "lib/wizard/resolve-module-source-refs.ts"
     },
     {
       "from": "lib/wizard/__tests__/resolvers.test.ts",
@@ -16624,6 +16652,10 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/wizard/detect-authored-modules.ts",
+      "to": "lib/wizard/detect-module-settings.ts"
+    },
+    {
       "from": "lib/wizard/detect-course-config.ts",
       "to": "lib/content-trust/resolve-config.ts"
     },
@@ -16634,6 +16666,10 @@
     {
       "from": "lib/wizard/detect-course-config.ts",
       "to": "lib/prompt/composition/transforms/audience.ts"
+    },
+    {
+      "from": "lib/wizard/detect-module-settings.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/wizard/graph-evaluator.ts",
@@ -16676,6 +16712,18 @@
       "to": "lib/wizard/detect-pedagogy.ts"
     },
     {
+      "from": "lib/wizard/resolve-module-source-refs.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/wizard/resolve-module-source-refs.ts",
+      "to": "lib/wizard/parse-content-sources.ts"
+    },
+    {
+      "from": "lib/wizard/resolve-module-source-refs.ts",
+      "to": "lib/wizard/parse-source-content.ts"
+    },
+    {
       "from": "lib/wizard/resolvers.ts",
       "to": "lib/wizard/graph-evaluator.ts"
     },
@@ -16713,6 +16761,10 @@
     },
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
       "to": "lib/wizard/apply-projection.ts"
     },
     {
@@ -16722,6 +16774,10 @@
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
       "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/wizard/resolve-module-source-refs.ts"
     },
     {
       "from": "lib/wizard/sync-authored-modules-to-curriculum.ts",
@@ -16878,6 +16934,26 @@
     {
       "from": "scripts/backfill-mcq-reconcile.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/compose/bump-timestamp.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/wizard/detect-module-settings.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/wizard/resolve-module-source-refs.ts"
     },
     {
       "from": "scripts/backfill-onboarding-flow-phases-mirror.ts",
@@ -23290,7 +23366,7 @@
     },
     {
       "path": "lib/compose/bump-timestamp.ts",
-      "inDegree": 18,
+      "inDegree": 19,
       "outDegree": 1
     },
     {
@@ -24775,7 +24851,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 671,
+      "inDegree": 672,
       "outDegree": 0
     },
     {
@@ -24805,7 +24881,7 @@
     },
     {
       "path": "lib/prompt/composition/TransformRegistry.ts",
-      "inDegree": 32,
+      "inDegree": 33,
       "outDegree": 1
     },
     {
@@ -24974,6 +25050,11 @@
       "outDegree": 5
     },
     {
+      "path": "lib/prompt/composition/transforms/parametersAsDirectives.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
       "path": "lib/prompt/composition/transforms/pedagogy-mode.ts",
       "inDegree": 1,
       "outDegree": 4
@@ -25060,7 +25141,7 @@
     },
     {
       "path": "lib/prompt/composition/types.ts",
-      "inDegree": 43,
+      "inDegree": 44,
       "outDegree": 1
     },
     {
@@ -25325,7 +25406,7 @@
     },
     {
       "path": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts",
-      "inDegree": 3,
+      "inDegree": 4,
       "outDegree": 2
     },
     {
@@ -25355,7 +25436,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 129,
+      "inDegree": 134,
       "outDegree": 0
     },
     {
@@ -25679,7 +25760,17 @@
       "outDegree": 1
     },
     {
+      "path": "lib/wizard/__tests__/parse-content-sources.test.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "lib/wizard/__tests__/parse-rubric-bands.test.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/wizard/__tests__/parse-source-content.test.ts",
       "inDegree": 0,
       "outDegree": 1
     },
@@ -25692,6 +25783,11 @@
       "path": "lib/wizard/__tests__/project-course-reference.test.ts",
       "inDegree": 0,
       "outDegree": 1
+    },
+    {
+      "path": "lib/wizard/__tests__/resolve-module-source-refs.test.ts",
+      "inDegree": 0,
+      "outDegree": 2
     },
     {
       "path": "lib/wizard/__tests__/resolvers.test.ts",
@@ -25711,7 +25807,7 @@
     {
       "path": "lib/wizard/detect-authored-modules.ts",
       "inDegree": 7,
-      "outDegree": 2
+      "outDegree": 3
     },
     {
       "path": "lib/wizard/detect-course-config.ts",
@@ -25722,6 +25818,11 @@
       "path": "lib/wizard/detect-mock-shape-modules.ts",
       "inDegree": 3,
       "outDegree": 0
+    },
+    {
+      "path": "lib/wizard/detect-module-settings.ts",
+      "inDegree": 2,
+      "outDegree": 1
     },
     {
       "path": "lib/wizard/detect-pedagogy.ts",
@@ -25744,7 +25845,17 @@
       "outDegree": 0
     },
     {
+      "path": "lib/wizard/parse-content-sources.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
       "path": "lib/wizard/parse-rubric-bands.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/wizard/parse-source-content.ts",
       "inDegree": 2,
       "outDegree": 0
     },
@@ -25759,6 +25870,11 @@
       "outDegree": 5
     },
     {
+      "path": "lib/wizard/resolve-module-source-refs.ts",
+      "inDegree": 3,
+      "outDegree": 3
+    },
+    {
       "path": "lib/wizard/resolvers.ts",
       "inDegree": 2,
       "outDegree": 3
@@ -25766,7 +25882,7 @@
     {
       "path": "lib/wizard/run-projection-for-playbook.ts",
       "inDegree": 2,
-      "outDegree": 9
+      "outDegree": 11
     },
     {
       "path": "lib/wizard/sync-authored-modules-to-curriculum.ts",
@@ -25932,6 +26048,11 @@
       "path": "scripts/backfill-mcq-reconcile.ts",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "scripts/backfill-module-settings-from-course-ref.ts",
+      "inDegree": 0,
+      "outDegree": 5
     },
     {
       "path": "scripts/backfill-onboarding-flow-phases-mirror.ts",
@@ -26442,7 +26563,7 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 671,
+      "inDegree": 672,
       "outDegree": 0
     },
     {
@@ -26452,7 +26573,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 129,
+      "inDegree": 134,
       "outDegree": 0
     },
     {
@@ -26487,7 +26608,7 @@
     },
     {
       "path": "lib/prompt/composition/types.ts",
-      "inDegree": 43,
+      "inDegree": 44,
       "outDegree": 1
     },
     {
@@ -26512,7 +26633,7 @@
     },
     {
       "path": "lib/prompt/composition/TransformRegistry.ts",
-      "inDegree": 32,
+      "inDegree": 33,
       "outDegree": 1
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-17T18:24:50.134Z",
+  "generatedAt": "2026-06-18T10:55:10.221Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-17T18:24:48.708Z",
+  "generatedAt": "2026-06-18T10:55:08.543Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-17T18:24:50.538Z",
+  "generatedAt": "2026-06-18T10:55:10.605Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-17T18:24:49.145Z",
+  "generatedAt": "2026-06-18T10:55:09.070Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
Closes #1907 (v1 — populating the other ~70 behaviour params + COMP-001 seed sync + ESLint manifest enforcement deferred to follow-ons; see Out of scope).

## Summary

Foundation for retiring the 117 producer-only behaviour parameters (~76% of the 154-param registry) via a registry-driven dispatcher that emits natural-language directives into the composed prompt. v1 ships the architecture + 1 populated parameter as proof-of-concept; mass-populating the remaining behaviour-directive entries is the follow-on.

1. **Registry schema extension** — entries gain an optional ` promptInjection: { section, condition, template | templateLow/High, threshold }` block. Backward-compatible.

2. **` transforms/parametersAsDirectives.ts`** — reads the registry JSON, calls ` getEffectiveBehaviorTargetsForCaller` ONCE per compose (the batched 3-query helper at ` lib/tolerance/`, NOT the naive per-param resolver which would cost 350 queries — TL Risk-2 pinned in vitest), filters by ` condition: when-non-default`, picks the template variant, emits per-section directives.

3. **Renderer wire-up** in ` renderPromptSummary.ts` — reads ` llmPrompt.parametersAsDirectives?.sections` and pushes per-section directives into the matching block ([STYLE], [AUDIENCE]). Carries the ` @renderer-consumed-at` sentinel for ` composition-directive-needs-renderer` ESLint rule (#1848).

4. **Coverage classifier extension** — ` parameter-coverage.test.ts` now recognises ` promptInjection`-tagged entries as ` covered` (the dispatcher reads them dynamically — no literal mention in consumer source). Without this the ratchet would not improve when params are populated.

5. **Example parameter populated**: ` abstract-vs-concrete` (learning_adaptation). Bipolar-template path — value <0.5 emits "Favour concrete examples…"; >=0.5 emits "Lean into abstract reasoning…". At value==defaultTarget, when-non-default gate skips emission.

## Verified by

- ` tests/lib/composition/parameters-as-directives.test.ts` — 7 new tests pinning: registry registration, batched-cascade-once-per-compose (TL Risk-2), bipolar templateLow/templateHigh, when-non-default gate, null-effective contract, empty-input short-circuit.
- ` tests/lib/measurement/parameter-coverage.test.ts` — classifier extension; ` abstract-vs-concrete` flips from ` gap` to ` covered`, ratchet gap-count drops by 1.
- Pre-push tsc: 0 errors.
- Pre-push eslint: 0 errors in changed files (` composition-directive-needs-renderer` rule passes via ` @renderer-consumed-at` sentinel).
- Lattice survey result: sibling-writer with ` targets.ts` does not double-up — ` targets.ts` emits structured ` BehaviorTarget` data via ` instructions.behavior_targets_summary`; dispatcher emits natural-language directives via ` parametersAsDirectives.sections`. Distinct LLM consumption surfaces; both can reference the same ` parameterId` without conflict.

## Test plan

- [ ] On hf-dev VM: set ` abstract-vs-concrete` BehaviorTarget for a test caller to 0.2 → next call's composed prompt contains "Favour concrete examples…" line in [STYLE]. Reset to 0.5 (default) → line gone.
- [ ] Run ` npx vitest run tests/lib/measurement/parameter-coverage.test.ts` — gap count drops by 1, ratchet still satisfied.
- [ ] Run ` npx vitest run tests/lib/composition/parameters-as-directives.test.ts` — all 7 tests green.

## Out of scope (follow-on)

- Populating the remaining ~70 behaviour-directive parameters in the registry JSON.
- Spec-config wiring of the dispatcher into a section-loader (today the transform is registered but no ` section-loaders.ts` entry wires its output onto ` llmPrompt.parametersAsDirectives`).
- ESLint manifest-file enforcement for N-to-1 dispatcher pairing (` @renderer-consumed-at` sentinel is sufficient for v1).
- ` COMP-001-prompt-composition` seed-sync update.
- Inspector cascade chips on dispatcher-sourced directives.

## Deploy

` /vm-cp` (no migration; seed JSON change picks up on next ` db:seed`).