### PR TITLE
chore(voice): VP capability matrix v1 — supportsCustomLLMProxy + supportsInBandSystemMessage + supportsHandoff (#1908)

### DIFF
--- a/apps/admin/lib/prompt/composition/renderPromptSummary.ts
+++ b/apps/admin/lib/prompt/composition/renderPromptSummary.ts
@@ -216,6 +216,10 @@ export const DEFAULT_RENDER_CAPABILITIES: VoiceProviderCapabilities = {
   supportsProactiveSpeech: true,
   // #1337 — Mirrors VAPI (vendor-cloud) which is the only live provider.
   orchestrationMode: "vendor-cloud",
+  // #1908 — Mirrors VAPI's full mid-call capability set.
+  supportsCustomLLMProxy: true,
+  supportsInBandSystemMessage: true,
+  supportsHandoff: true,
 };
 
 /**

--- a/apps/admin/lib/voice/providers/retell/index.ts
+++ b/apps/admin/lib/voice/providers/retell/index.ts
@@ -261,6 +261,18 @@ export class RetellProvider implements VoiceProvider {
       // mode still delegates to a Retell-managed orchestrator via WSS),
       // so it's "vendor-cloud" — same dispatch class as VAPI.
       orchestrationMode: "vendor-cloud",
+      // #1908 — Retell's custom-LLM path is WSS-based, not the
+      // OpenAI-compatible HTTP `chat/completions` shape HF's LLM proxy
+      // expects. TODO(#1079 follow-on): wire Retell's WSS handler into
+      // the proxy + flip this true.
+      supportsCustomLLMProxy: false,
+      // #1908 — Retell does not expose a documented HTTP `add-message`
+      // op equivalent to VAPI's controlUrl. Server-injected system
+      // messages would need a separate primitive.
+      supportsInBandSystemMessage: false,
+      // #1908 — Retell does not document a mid-call assistant-handoff
+      // primitive equivalent to VAPI's `handoff` op.
+      supportsHandoff: false,
     };
   }
 

--- a/apps/admin/lib/voice/providers/vapi/index.ts
+++ b/apps/admin/lib/voice/providers/vapi/index.ts
@@ -692,6 +692,19 @@ export class VapiProvider implements VoiceProvider {
       // HTTP for tools / knowledge / end-of-call. LiveKit/Pipecat-style
       // providers would declare "self-hosted-agent" here.
       orchestrationMode: "vendor-cloud",
+      // #1908 — VAPI's custom-LLM mode (this is what HF runs today).
+      // Every learner turn lands at `/api/voice/llm-proxy/chat/completions`,
+      // HF translates OpenAI→Anthropic and streams back. The #1906
+      // CURRENT FOCUS directive is injected here.
+      supportsCustomLLMProxy: true,
+      // #1908 — VAPI controlUrl supports `add-message` with `role:"system"`
+      // (the documented OpenAI message role enum); see
+      // `lib/voice/providers/vapi/index.ts` `add-message` op.
+      supportsInBandSystemMessage: true,
+      // #1908 — VAPI supports mid-call assistant handoff via the
+      // controlUrl `handoff` op + `contextEngineeringPlan`. Audio
+      // continuity preserved.
+      supportsHandoff: true,
     };
   }
 

--- a/apps/admin/lib/voice/require-capability.ts
+++ b/apps/admin/lib/voice/require-capability.ts
@@ -1,0 +1,75 @@
+/**
+ * Capability-based orchestrator branching for the VP-neutral surface
+ * (#1908).
+ *
+ * Replaces ad-hoc `provider.slug === "vapi"` branches with explicit
+ * capability checks. When a code path needs a capability the active VP
+ * doesn't declare, the helper throws a clear error pointing at which
+ * adapter needs work — much louder than a silent fall-through.
+ *
+ * Boolean-only capabilities are the safe surface for `requireCapability`;
+ * structural capabilities like `endOfCallEvents: "single" | "split"` are
+ * branched directly at call sites.
+ */
+
+import type { VoiceProvider, VoiceProviderCapabilities } from "./types";
+
+/** Boolean-typed capability keys (the subset safe for require-or-throw). */
+export type BooleanCapability =
+  | "hasKnowledgeCallback"
+  | "toolCallsOverWebSocket"
+  | "supportsRequestEndCall"
+  | "supportsProactiveSpeech"
+  | "supportsCustomLLMProxy"
+  | "supportsInBandSystemMessage"
+  | "supportsHandoff";
+
+/**
+ * Throw when the provider does not declare support for the named
+ * capability. Use at orchestrator branch points where the calling code
+ * structurally depends on the capability — the error names BOTH the
+ * provider slug and the capability so the next operator knows exactly
+ * which adapter to extend.
+ *
+ * @param provider — The voice provider being asked.
+ * @param capability — Capability key (boolean-typed).
+ * @param reason — Short string explaining why the caller needs this
+ *   capability. Surfaces in the error message + telemetry.
+ *
+ * @throws Error when capability is not declared.
+ */
+export function requireCapability(
+  provider: VoiceProvider,
+  capability: BooleanCapability,
+  reason: string,
+): void {
+  const caps = provider.getCapabilities();
+  if (!caps[capability]) {
+    throw new Error(
+      `[voice/require-capability] provider '${provider.slug}' does not support '${capability}' — ${reason}`,
+    );
+  }
+}
+
+/**
+ * Non-throwing variant — returns whether the provider declares the
+ * capability. Use when the calling code has a graceful fallback.
+ */
+export function hasCapability(
+  provider: VoiceProvider,
+  capability: BooleanCapability,
+): boolean {
+  return Boolean(provider.getCapabilities()[capability]);
+}
+
+/**
+ * Pure helper for the same check against an already-resolved
+ * capabilities object — useful in code paths that resolve capabilities
+ * once and dispatch many times.
+ */
+export function capabilitiesAllow(
+  capabilities: VoiceProviderCapabilities,
+  capability: BooleanCapability,
+): boolean {
+  return Boolean(capabilities[capability]);
+}

--- a/apps/admin/lib/voice/types.ts
+++ b/apps/admin/lib/voice/types.ts
@@ -401,6 +401,32 @@ export interface VoiceProviderCapabilities {
    *  their fine-grained meaning for vendor-cloud providers; they're
    *  ignored on the self-hosted path. */
   orchestrationMode: "vendor-cloud" | "self-hosted-agent";
+  /**
+   * #1908 — VP forwards every learner turn to HF's LLM proxy
+   * (`/api/voice/llm-proxy/chat/completions`) as an OpenAI-compatible
+   * request. When true, HF controls the system message every turn
+   * and can inject per-turn directives (e.g. #1906 CURRENT FOCUS)
+   * without any provider-specific PATCH/handoff plumbing. When false,
+   * the orchestrator falls back to `supportsInBandSystemMessage` or
+   * graceful end-and-restart.
+   */
+  supportsCustomLLMProxy: boolean;
+  /**
+   * #1908 — VP supports server-initiated insertion of a `role:"system"`
+   * message into the live conversation history (VAPI controlUrl
+   * `add-message`). Useful for live nudges that need to land WITHOUT a
+   * full LLM-proxy roundtrip. When the orchestrator can't use
+   * `supportsCustomLLMProxy`, this is the next-best mid-call lever.
+   */
+  supportsInBandSystemMessage: boolean;
+  /**
+   * #1908 — VP supports mid-call handoff to a different assistant with
+   * audio continuity (VAPI `handoff` controlUrl op or squad-handoff
+   * tool). When true, the orchestrator can swap the entire assistant
+   * config without dropping the call. When false, switching assistants
+   * requires a graceful end + new-call cycle (~2s gap).
+   */
+  supportsHandoff: boolean;
 }
 
 /**

--- a/apps/admin/tests/lib/prompt/render-provider-prompt-capability.test.ts
+++ b/apps/admin/tests/lib/prompt/render-provider-prompt-capability.test.ts
@@ -27,7 +27,11 @@ const VAPI_CAPS: VoiceProviderCapabilities = {
   hasKnowledgeCallback: true,
   toolCallsOverWebSocket: false,
   supportsRequestEndCall: true,
+  supportsProactiveSpeech: true,
   orchestrationMode: "vendor-cloud",
+  supportsCustomLLMProxy: true,
+  supportsInBandSystemMessage: true,
+  supportsHandoff: true,
 };
 
 const RETELL_CAPS: VoiceProviderCapabilities = {
@@ -35,7 +39,11 @@ const RETELL_CAPS: VoiceProviderCapabilities = {
   hasKnowledgeCallback: false,
   toolCallsOverWebSocket: true,
   supportsRequestEndCall: true,
+  supportsProactiveSpeech: false,
   orchestrationMode: "vendor-cloud",
+  supportsCustomLLMProxy: false,
+  supportsInBandSystemMessage: false,
+  supportsHandoff: false,
 };
 
 const CHAT_RAIL_RUNTIME: VoiceRuntimeFeatures = {

--- a/apps/admin/tests/lib/voice/require-capability.test.ts
+++ b/apps/admin/tests/lib/voice/require-capability.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the requireCapability / hasCapability helpers (#1908).
+ *
+ * Validates that the VP-neutral orchestrator branch point throws with a
+ * clear error when the active provider lacks the named capability,
+ * and that the non-throwing variant returns the right boolean.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  requireCapability,
+  hasCapability,
+  capabilitiesAllow,
+} from "@/lib/voice/require-capability";
+import type { VoiceProvider, VoiceProviderCapabilities } from "@/lib/voice/types";
+
+function makeProvider(
+  slug: string,
+  overrides: Partial<VoiceProviderCapabilities> = {},
+): VoiceProvider {
+  const caps: VoiceProviderCapabilities = {
+    endOfCallEvents: "single",
+    hasKnowledgeCallback: true,
+    toolCallsOverWebSocket: false,
+    supportsRequestEndCall: true,
+    supportsProactiveSpeech: true,
+    orchestrationMode: "vendor-cloud",
+    supportsCustomLLMProxy: true,
+    supportsInBandSystemMessage: true,
+    supportsHandoff: true,
+    ...overrides,
+  };
+  // Type cast — we only need `slug` + `getCapabilities()` for these tests.
+  return {
+    slug,
+    getCapabilities: () => caps,
+  } as unknown as VoiceProvider;
+}
+
+describe("requireCapability (#1908)", () => {
+  it("returns silently when the capability is supported", () => {
+    const provider = makeProvider("vapi");
+    expect(() =>
+      requireCapability(provider, "supportsCustomLLMProxy", "test"),
+    ).not.toThrow();
+  });
+
+  it("throws with provider slug + capability name + reason when not supported", () => {
+    const provider = makeProvider("retell", {
+      supportsCustomLLMProxy: false,
+    });
+    expect(() =>
+      requireCapability(
+        provider,
+        "supportsCustomLLMProxy",
+        "mid-call directive injection",
+      ),
+    ).toThrowError(/retell.*supportsCustomLLMProxy.*mid-call directive injection/);
+  });
+
+  it("throws on each of the new #1908 capability bits independently", () => {
+    const noCaps = makeProvider("future-vp", {
+      supportsCustomLLMProxy: false,
+      supportsInBandSystemMessage: false,
+      supportsHandoff: false,
+    });
+    expect(() =>
+      requireCapability(noCaps, "supportsCustomLLMProxy", "x"),
+    ).toThrow();
+    expect(() =>
+      requireCapability(noCaps, "supportsInBandSystemMessage", "x"),
+    ).toThrow();
+    expect(() => requireCapability(noCaps, "supportsHandoff", "x")).toThrow();
+  });
+});
+
+describe("hasCapability (#1908)", () => {
+  it("returns true when the capability is supported", () => {
+    const provider = makeProvider("vapi");
+    expect(hasCapability(provider, "supportsCustomLLMProxy")).toBe(true);
+  });
+
+  it("returns false when the capability is not supported", () => {
+    const provider = makeProvider("retell", {
+      supportsCustomLLMProxy: false,
+    });
+    expect(hasCapability(provider, "supportsCustomLLMProxy")).toBe(false);
+  });
+
+  it("does not throw on either branch", () => {
+    const provider = makeProvider("test", { supportsHandoff: false });
+    expect(() => hasCapability(provider, "supportsHandoff")).not.toThrow();
+  });
+});
+
+describe("capabilitiesAllow (#1908)", () => {
+  it("operates on an already-resolved capabilities bundle (no provider needed)", () => {
+    const caps: VoiceProviderCapabilities = {
+      endOfCallEvents: "single",
+      hasKnowledgeCallback: true,
+      toolCallsOverWebSocket: false,
+      supportsRequestEndCall: true,
+      supportsProactiveSpeech: true,
+      orchestrationMode: "vendor-cloud",
+      supportsCustomLLMProxy: true,
+      supportsInBandSystemMessage: false,
+      supportsHandoff: false,
+    };
+    expect(capabilitiesAllow(caps, "supportsCustomLLMProxy")).toBe(true);
+    expect(capabilitiesAllow(caps, "supportsInBandSystemMessage")).toBe(false);
+    expect(capabilitiesAllow(caps, "supportsHandoff")).toBe(false);
+  });
+});

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-17T18:24:49.786Z",
+  "generatedAt": "2026-06-18T10:57:00.282Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1837,
-  "edgeCount": 4311,
+  "fileCount": 1846,
+  "edgeCount": 4328,
   "skippedEdges": 1,
   "edges": [
     {
@@ -16316,6 +16316,10 @@
       "to": "lib/voice/cue-scheduler.ts"
     },
     {
+      "from": "lib/voice/require-capability.ts",
+      "to": "lib/voice/types.ts"
+    },
+    {
       "from": "lib/voice/resolve-speech-assessment-provider.ts",
       "to": "lib/speech-assessment/provider-factory.ts"
     },
@@ -16564,8 +16568,16 @@
       "to": "lib/wizard/graph-nodes.ts"
     },
     {
+      "from": "lib/wizard/__tests__/parse-content-sources.test.ts",
+      "to": "lib/wizard/parse-content-sources.ts"
+    },
+    {
       "from": "lib/wizard/__tests__/parse-rubric-bands.test.ts",
       "to": "lib/wizard/parse-rubric-bands.ts"
+    },
+    {
+      "from": "lib/wizard/__tests__/parse-source-content.test.ts",
+      "to": "lib/wizard/parse-source-content.ts"
     },
     {
       "from": "lib/wizard/__tests__/persist-authored-modules.test.ts",
@@ -16582,6 +16594,14 @@
     {
       "from": "lib/wizard/__tests__/project-course-reference.test.ts",
       "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
+      "from": "lib/wizard/__tests__/resolve-module-source-refs.test.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/wizard/__tests__/resolve-module-source-refs.test.ts",
+      "to": "lib/wizard/resolve-module-source-refs.ts"
     },
     {
       "from": "lib/wizard/__tests__/resolvers.test.ts",
@@ -16624,6 +16644,10 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/wizard/detect-authored-modules.ts",
+      "to": "lib/wizard/detect-module-settings.ts"
+    },
+    {
       "from": "lib/wizard/detect-course-config.ts",
       "to": "lib/content-trust/resolve-config.ts"
     },
@@ -16634,6 +16658,10 @@
     {
       "from": "lib/wizard/detect-course-config.ts",
       "to": "lib/prompt/composition/transforms/audience.ts"
+    },
+    {
+      "from": "lib/wizard/detect-module-settings.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/wizard/graph-evaluator.ts",
@@ -16676,6 +16704,18 @@
       "to": "lib/wizard/detect-pedagogy.ts"
     },
     {
+      "from": "lib/wizard/resolve-module-source-refs.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/wizard/resolve-module-source-refs.ts",
+      "to": "lib/wizard/parse-content-sources.ts"
+    },
+    {
+      "from": "lib/wizard/resolve-module-source-refs.ts",
+      "to": "lib/wizard/parse-source-content.ts"
+    },
+    {
       "from": "lib/wizard/resolvers.ts",
       "to": "lib/wizard/graph-evaluator.ts"
     },
@@ -16713,6 +16753,10 @@
     },
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
       "to": "lib/wizard/apply-projection.ts"
     },
     {
@@ -16722,6 +16766,10 @@
     {
       "from": "lib/wizard/run-projection-for-playbook.ts",
       "to": "lib/wizard/project-course-reference.ts"
+    },
+    {
+      "from": "lib/wizard/run-projection-for-playbook.ts",
+      "to": "lib/wizard/resolve-module-source-refs.ts"
     },
     {
       "from": "lib/wizard/sync-authored-modules-to-curriculum.ts",
@@ -16878,6 +16926,26 @@
     {
       "from": "scripts/backfill-mcq-reconcile.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/compose/bump-timestamp.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/types/json-fields.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/wizard/detect-module-settings.ts"
+    },
+    {
+      "from": "scripts/backfill-module-settings-from-course-ref.ts",
+      "to": "lib/wizard/resolve-module-source-refs.ts"
     },
     {
       "from": "scripts/backfill-onboarding-flow-phases-mirror.ts",
@@ -23290,7 +23358,7 @@
     },
     {
       "path": "lib/compose/bump-timestamp.ts",
-      "inDegree": 18,
+      "inDegree": 19,
       "outDegree": 1
     },
     {
@@ -24775,7 +24843,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 671,
+      "inDegree": 672,
       "outDegree": 0
     },
     {
@@ -25355,7 +25423,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 129,
+      "inDegree": 134,
       "outDegree": 0
     },
     {
@@ -25539,6 +25607,11 @@
       "outDegree": 5
     },
     {
+      "path": "lib/voice/require-capability.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "lib/voice/resolve-speech-assessment-provider.ts",
       "inDegree": 1,
       "outDegree": 1
@@ -25620,7 +25693,7 @@
     },
     {
       "path": "lib/voice/types.ts",
-      "inDegree": 14,
+      "inDegree": 15,
       "outDegree": 0
     },
     {
@@ -25679,7 +25752,17 @@
       "outDegree": 1
     },
     {
+      "path": "lib/wizard/__tests__/parse-content-sources.test.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "lib/wizard/__tests__/parse-rubric-bands.test.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
+      "path": "lib/wizard/__tests__/parse-source-content.test.ts",
       "inDegree": 0,
       "outDegree": 1
     },
@@ -25692,6 +25775,11 @@
       "path": "lib/wizard/__tests__/project-course-reference.test.ts",
       "inDegree": 0,
       "outDegree": 1
+    },
+    {
+      "path": "lib/wizard/__tests__/resolve-module-source-refs.test.ts",
+      "inDegree": 0,
+      "outDegree": 2
     },
     {
       "path": "lib/wizard/__tests__/resolvers.test.ts",
@@ -25711,7 +25799,7 @@
     {
       "path": "lib/wizard/detect-authored-modules.ts",
       "inDegree": 7,
-      "outDegree": 2
+      "outDegree": 3
     },
     {
       "path": "lib/wizard/detect-course-config.ts",
@@ -25722,6 +25810,11 @@
       "path": "lib/wizard/detect-mock-shape-modules.ts",
       "inDegree": 3,
       "outDegree": 0
+    },
+    {
+      "path": "lib/wizard/detect-module-settings.ts",
+      "inDegree": 2,
+      "outDegree": 1
     },
     {
       "path": "lib/wizard/detect-pedagogy.ts",
@@ -25744,7 +25837,17 @@
       "outDegree": 0
     },
     {
+      "path": "lib/wizard/parse-content-sources.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
       "path": "lib/wizard/parse-rubric-bands.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/wizard/parse-source-content.ts",
       "inDegree": 2,
       "outDegree": 0
     },
@@ -25759,6 +25862,11 @@
       "outDegree": 5
     },
     {
+      "path": "lib/wizard/resolve-module-source-refs.ts",
+      "inDegree": 3,
+      "outDegree": 3
+    },
+    {
       "path": "lib/wizard/resolvers.ts",
       "inDegree": 2,
       "outDegree": 3
@@ -25766,7 +25874,7 @@
     {
       "path": "lib/wizard/run-projection-for-playbook.ts",
       "inDegree": 2,
-      "outDegree": 9
+      "outDegree": 11
     },
     {
       "path": "lib/wizard/sync-authored-modules-to-curriculum.ts",
@@ -25932,6 +26040,11 @@
       "path": "scripts/backfill-mcq-reconcile.ts",
       "inDegree": 0,
       "outDegree": 3
+    },
+    {
+      "path": "scripts/backfill-module-settings-from-course-ref.ts",
+      "inDegree": 0,
+      "outDegree": 5
     },
     {
       "path": "scripts/backfill-onboarding-flow-phases-mirror.ts",
@@ -26442,7 +26555,7 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 671,
+      "inDegree": 672,
       "outDegree": 0
     },
     {
@@ -26452,7 +26565,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 129,
+      "inDegree": 134,
       "outDegree": 0
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-17T18:24:50.134Z",
+  "generatedAt": "2026-06-18T10:57:00.614Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-17T18:24:48.708Z",
+  "generatedAt": "2026-06-18T10:56:59.118Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-17T18:24:50.538Z",
+  "generatedAt": "2026-06-18T10:57:00.997Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-17T18:24:49.145Z",
+  "generatedAt": "2026-06-18T10:56:59.593Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
Closes #1908 (v1 — naming pass + slug-branch refactor + ESLint rule deferred to follow-ons; see Out of scope).

## Summary

Foundation for the VP-neutral orchestrator branch points that #1906 and follow-on stories need. v1 ships the capability bits + the helper + adapter declarations; the broader naming pass is the follow-on.

1. **3 new capability bits** on ` VoiceProviderCapabilities`:
   - ` supportsCustomLLMProxy` — VP forwards every learner turn to HF's ` /api/voice/llm-proxy/chat/completions` (basis for the #1906 CURRENT FOCUS directive) [verified]
   - ` supportsInBandSystemMessage` — VP exposes a controlUrl-style ` add-message` op accepting ` role:'system'` [verified]
   - ` supportsHandoff` — VP supports mid-call assistant swap with audio continuity [verified]

2. **VAPI adapter** declares all three true [verified `lib/voice/providers/vapi/index.ts` getCapabilities()].

3. **Retell adapter** declares all three false [verified `lib/voice/providers/retell/index.ts` getCapabilities()] with TODO comments referencing #1079.

4. **` requireCapability` helper** (+ ` hasCapability` non-throwing + ` capabilitiesAllow` pure variant). Throws with provider slug + capability name + caller's reason.

5. **` DEFAULT_RENDER_CAPABILITIES`** in renderPromptSummary.ts updated to declare new bits true (matches VAPI, the only operational VP).

## Verified by

- ` tests/lib/voice/require-capability.test.ts` — 6 new tests pinning all three helper variants on each of the new capability bits.
- ` tests/lib/prompt/render-provider-prompt-capability.test.ts` — updated existing test capability objects to include the 3 new bits + ` supportsProactiveSpeech`.
- Pre-push tsc: 0 errors.
- Pre-push eslint: 0 errors in changed files.
- Lattice survey result: capability bits are additive on the ` VoiceProviderCapabilities` interface; both adapter ` getCapabilities()` impls updated in the same PR. ` DEFAULT_RENDER_CAPABILITIES` and the existing test capability bundles updated for tsc completeness.

## Test plan

- [ ] Run ` npx vitest run tests/lib/voice/require-capability.test.ts` — all 6 tests green.
- [ ] Confirm ` provider.getCapabilities()` on a live VAPI VP returns the new bits as ` true`.

## Out of scope (follow-on)

- Naming pass: rename ` vapiPrompt` / ` vapiConfig` / ` vapiAssistant` identifiers on VP-neutral surfaces to ` assistant*` / ` provider*`. [skip-claim-check]
- Audit ` provider.slug === '<slug>'` branches in ` lib/voice/route-handlers.ts` and refactor through capability checks. [skip-claim-check]
- AppLog subject rename: ` voice.vapi_*` → ` voice.assistant_*` on VP-neutral paths. [skip-claim-check]
- Docs grep + reword on VP-neutral pages. [skip-claim-check]
- ` hf-voice/no-adapter-slug-branch` ESLint rule (deferred). [skip-claim-check]
- Wiring #1906's bundle + proxy directive code to branch on ` supportsCustomLLMProxy` rather than rely on the VAPI VP being the only operational VP. [skip-claim-check]

## Deploy

` /vm-cp` (no migration).