### PR TITLE
feat(wizard): parser allows Source Na sub-numbering (#1850)

### DIFF
--- a/apps/admin/lib/wizard/__tests__/parse-content-sources.test.ts
+++ b/apps/admin/lib/wizard/__tests__/parse-content-sources.test.ts
@@ -98,6 +98,88 @@ describe("parseContentSources — tolerant of cosmetic variations", () => {
     expect(entry!.location).toBe("foo.md");
   });
 
+  it("parses `Source 2a` sub-numbering with a single lowercase suffix", () => {
+    const body = [
+      "## Content Sources",
+      "",
+      "### Source 2a — Part 2 cue card bank (Mock)",
+      "",
+      "- *location:* `docs/external/cue-cards-mock.md`",
+      "- *format:* structured-md",
+      "- *moduleRef:* part2Mock",
+      "- *settingRef:* moduleCueCardPool",
+      "",
+      "### Source 2b — Part 2 cue card bank (Baseline)",
+      "",
+      "- *location:* `docs/external/cue-cards-baseline.md`",
+      "- *format:* structured-md",
+      "- *moduleRef:* part2Baseline",
+      "- *settingRef:* moduleCueCardPool",
+      "",
+    ].join("\n");
+    const parsed = parseContentSources(body);
+    expect(parsed.all.length).toBe(2);
+    expect(parsed.all.map((e) => e.header)).toEqual([
+      "Source 2a — Part 2 cue card bank (Mock)",
+      "Source 2b — Part 2 cue card bank (Baseline)",
+    ]);
+    const mock = parsed.byModuleAndSetting.get("part2Mock:cueCardPool");
+    expect(mock?.location).toBe("docs/external/cue-cards-mock.md");
+    const baseline = parsed.byModuleAndSetting.get("part2Baseline:cueCardPool");
+    expect(baseline?.location).toBe("docs/external/cue-cards-baseline.md");
+  });
+
+  it("parses two-digit + suffix headers (`Source 10b`)", () => {
+    const body = [
+      "## Content Sources",
+      "",
+      "### Source 10b — Some pool",
+      "",
+      "- *location:* `docs/external/pool-10b.md`",
+      "- *format:* structured-md",
+      "- *moduleRef:* part3",
+      "- *settingRef:* moduleScaffoldPool",
+      "",
+    ].join("\n");
+    const parsed = parseContentSources(body);
+    expect(parsed.all.length).toBe(1);
+    expect(parsed.all[0].header).toBe("Source 10b — Some pool");
+    const entry = parsed.byModuleAndSetting.get("part3:scaffoldPool");
+    expect(entry?.location).toBe("docs/external/pool-10b.md");
+  });
+
+  it("rejects multi-letter suffixes (`Source 99x` parses; `Source 99xy` does NOT)", () => {
+    // Single letter is allowed; the regex uses `[a-z]?` (zero or one).
+    const single = parseContentSources(
+      [
+        "## Content Sources",
+        "",
+        "### Source 99x — Single letter ok",
+        "- *location:* ok.md",
+        "- *format:* structured-md",
+        "- *moduleRef:* m",
+        "- *settingRef:* moduleX",
+        "",
+      ].join("\n"),
+    );
+    expect(single.all.length).toBe(1);
+    expect(single.all[0].header).toBe("Source 99x — Single letter ok");
+
+    // Multi-letter suffix should NOT match — header parser silently skips it.
+    const multi = parseContentSources(
+      [
+        "## Content Sources",
+        "",
+        "### Source 99xy — Multi letter rejected",
+        "- *location:* skip.md",
+        "- *moduleRef:* m",
+        "- *settingRef:* moduleX",
+        "",
+      ].join("\n"),
+    );
+    expect(multi.all.length).toBe(0);
+  });
+
   it("stops at the next ## section header", () => {
     const body = [
       "## Content Sources",

--- a/apps/admin/lib/wizard/parse-content-sources.ts
+++ b/apps/admin/lib/wizard/parse-content-sources.ts
@@ -13,6 +13,8 @@
  * Source block format (v2.3 fixture):
  *
  *   ### Source 2 — Part 2 cue card bank
+ *   ### Source 2a — Part 2 cue card bank (Mock)
+ *   ### Source 2b — Part 2 cue card bank (Baseline)
  *
  *   A bank of Part 2 cue cards in the standard IELTS structure ...
  *
@@ -66,8 +68,15 @@ export interface ParsedContentSources {
 // ── Detection ────────────────────────────────────────────────────────
 
 const SECTION_HEADER = /^##\s+Content\s+Sources\s*$/im;
-/** Matches `### Source N — Title`. Captures the full header text. */
-const SOURCE_HEADER = /^###\s+(Source\s+\d+\s*[—–-].+)$/i;
+/**
+ * Matches `### Source N — Title` or `### Source Na — Title`. Captures the
+ * full header text. The optional single lowercase letter suffix (e.g. `2a`,
+ * `6b`, `7c`) lets a parent source split into related sub-sources that route
+ * to different consumers — for example `Source 2a` (Mock cue card bank) and
+ * `Source 2b` (Baseline cue card bank). Sibling numbering preserves the
+ * semantic relationship that flat renumbering (Source 9 / 10 / 11) loses.
+ */
+const SOURCE_HEADER = /^###\s+(Source\s+\d+[a-z]?\s*[—–-].+)$/i;
 /** Heading of any depth that ends a source block (excluding our own ### Source rows). */
 const ANY_HEADING = /^#{1,6}\s/;
 


### PR DESCRIPTION
## Summary

Pure parser extension on `apps/admin/lib/wizard/parse-content-sources.ts`. The `SOURCE_HEADER` regex matched `### Source N — Title` with `\d+` only; this PR allows an optional single lowercase letter suffix (`\d+[a-z]?`) so blocks like `### Source 2a — Part 2 cue card bank (Mock)` and `### Source 2b — Part 2 cue card bank (Baseline)` parse correctly.

### Why

PR #1913 wanted to multi-route Source 2 to Mock + Baseline via `Source 2a` / `Source 2b` blocks. The parser silently skipped them (regex didn't match), so the agent renumbered to flat `Source 9 / 10 / 11 / 12 / 13`. Flat works but loses the parent-with-variants semantic relationship.

### Regex change

```diff
-const SOURCE_HEADER = /^###\s+(Source\s+\d+\s*[—–-].+)$/i;
+const SOURCE_HEADER = /^###\s+(Source\s+\d+[a-z]?\s*[—–-].+)$/i;
```

Single letter `[a-z]?` only — `Source 99x` parses, `Source 99xy` does not.

### Scope

- Pure parser change. No new infrastructure. No backfill changes.
- `ContentSourceEntry.header` already captures the full header text including any suffix — downstream consumers (`resolve-module-source-refs.ts`) index by `(moduleRef, settingRef)`, so suffix has zero effect on resolution semantics.
- Existing Source 1-99 numbering (including the flat Sources 9-13 from #1913) parses byte-identically — the suffix is optional.

## Tests

3 new vitests in `apps/admin/lib/wizard/__tests__/parse-content-sources.test.ts`:

- `Source 2a` / `Source 2b` sub-numbering parses with valid annotations [verified at lib/wizard/__tests__/parse-content-sources.test.ts:122]
- Two-digit + suffix (`Source 10b`) parses [verified at lib/wizard/__tests__/parse-content-sources.test.ts:153]
- Multi-letter rejected (`Source 99x` passes, `Source 99xy` does not) [verified at lib/wizard/__tests__/parse-content-sources.test.ts:171]

All 7 pre-existing tests still pass. 10/10 in `parse-content-sources.test.ts`, 10/10 in `resolve-module-source-refs.test.ts` (no regression).

## Verified by

- \`npx vitest run lib/wizard/__tests__/parse-content-sources.test.ts\` → 10/10 passed (7 original + 3 new)
- \`npx vitest run lib/wizard/__tests__/resolve-module-source-refs.test.ts\` → 10/10 passed
- \`npx tsc --noEmit\` → 40 pre-existing errors, zero in changed files (pre-push hook confirms -1 vs baseline 41)
- \`npx eslint lib/wizard/parse-content-sources.ts lib/wizard/__tests__/parse-content-sources.test.ts\` → clean
- Lattice survey: parser is pure-function over text input; no shared DB column, no chain-stage boundary, no cascade family, no new guard. Survey not required per \`.claude/rules/lattice-survey.md\` "When NOT to apply" section.

## Test plan

- [x] New + existing vitests green
- [x] tsc clean for changed files
- [x] eslint clean
- [ ] Verified manually on hf-dev after \`/vm-cp\` by adding a `Source 2a` block to a course-ref doc and confirming `parseContentSources` indexes it