### PR TITLE
feat(privacy): Call.regulatoryExpiresAt stamp + retention purge (S5a, #1917)

### DIFF
--- a/apps/admin/app/api/admin/retention/cleanup/route.ts
+++ b/apps/admin/app/api/admin/retention/cleanup/route.ts
@@ -35,6 +35,7 @@ export async function POST() {
 
     let callersDeleted = 0;
     let auditLogsDeleted = 0;
+    let expiredCallsDeleted = 0;
 
     // --- Caller data cleanup ---
     if (callerRetentionDays > 0) {
@@ -76,6 +77,18 @@ export async function POST() {
       auditLogsDeleted = result.count;
     }
 
+    // --- Row-level Call expiry cleanup (#1917 / I-PR3) ---
+    // Distinct policy from caller-level cleanup above: this purges
+    // INDIVIDUAL Call rows whose `regulatoryExpiresAt` has elapsed,
+    // independent of caller activity. Stamped at create-time by
+    // `lib/privacy/stamp-regulatory-expiry.ts` (or NULL on legacy rows,
+    // which this query intentionally skips — legacy callers still flow
+    // through the caller-level cleanup above when they go dormant).
+    const expiredCalls = await prisma.call.deleteMany({
+      where: { regulatoryExpiresAt: { lte: new Date() } },
+    });
+    expiredCallsDeleted = expiredCalls.count;
+
     // Audit the cleanup itself
     auditLog({
       userId: authResult.session.user.id,
@@ -87,6 +100,7 @@ export async function POST() {
         auditRetentionDays,
         callersDeleted,
         auditLogsDeleted,
+        expiredCallsDeleted,
       },
     });
 
@@ -102,6 +116,11 @@ export async function POST() {
           enabled: auditRetentionDays > 0,
           retentionDays: auditRetentionDays,
           auditLogsDeleted,
+        },
+        regulatoryCallExpiry: {
+          // Always enabled — when nothing has a stamped expiry the query
+          // is a no-op (deletes 0 rows).
+          expiredCallsDeleted,
         },
       },
     });

--- a/apps/admin/app/api/voice/calls/outbound-dial/route.ts
+++ b/apps/admin/app/api/voice/calls/outbound-dial/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/voice/resolve-voice-provider";
 import { buildAssistantConfigForCaller } from "@/lib/voice/build-assistant-config";
 import { createSession } from "@/lib/voice/create-session";
+import { stampRegulatoryExpiry } from "@/lib/privacy/stamp-regulatory-expiry";
 import { recordCallFailure } from "@/lib/voice/record-call-failure";
 import { registerModuleScheduledCues } from "@/lib/voice/register-module-cues";
 import { startVoiceSpan, logVoiceEvent } from "@/lib/voice/telemetry";
@@ -211,6 +212,11 @@ export async function POST(request: Request) {
       source: providerSlug,
       voiceProvider: providerSlug,
     });
+    // #1917 §6a I-PR3 — stamp regulatory expiry from preset (when #1925
+    // wires the cascade) or `RETENTION_CALLER_DATA_DAYS` env fallback.
+    const regulatoryExpiresAt = stampRegulatoryExpiry({
+      presetRetentionDays: null,
+    });
     const placeholderCall = await prisma.call.create({
       data: {
         callerId: caller.id,
@@ -228,6 +234,7 @@ export async function POST(request: Request) {
         ...(sessionResult.usedPromptId
           ? { usedPromptId: sessionResult.usedPromptId }
           : {}),
+        ...(regulatoryExpiresAt ? { regulatoryExpiresAt } : {}),
       },
       select: { id: true },
     });

--- a/apps/admin/app/api/voice/calls/start/route.ts
+++ b/apps/admin/app/api/voice/calls/start/route.ts
@@ -13,6 +13,7 @@ import { startVoiceSpan } from "@/lib/voice/telemetry";
 import { buildAssistantConfigForCaller } from "@/lib/voice/build-assistant-config";
 import { createSession } from "@/lib/voice/create-session";
 import { voiceDiagDump } from "@/lib/voice/diag";
+import { stampRegulatoryExpiry } from "@/lib/privacy/stamp-regulatory-expiry";
 
 export const runtime = "nodejs";
 
@@ -184,6 +185,12 @@ export async function POST(request: Request) {
         ? { requestedModuleId: parsed.data.requestedModuleId }
         : {}),
     });
+    // #1917 §6a I-PR3 — stamp regulatory expiry from preset (when #1925
+    // wires the cascade) or `RETENTION_CALLER_DATA_DAYS` env fallback.
+    // NULL when neither resolves; caller-level cleanup still applies.
+    const regulatoryExpiresAt = stampRegulatoryExpiry({
+      presetRetentionDays: null,
+    });
     const placeholderCall = await prisma.call.create({
       data: {
         callerId: caller.id,
@@ -201,6 +208,7 @@ export async function POST(request: Request) {
         ...(sessionResult.usedPromptId
           ? { usedPromptId: sessionResult.usedPromptId }
           : {}),
+        ...(regulatoryExpiresAt ? { regulatoryExpiresAt } : {}),
       },
       select: { id: true },
     });

--- a/apps/admin/lib/privacy/stamp-regulatory-expiry.ts
+++ b/apps/admin/lib/privacy/stamp-regulatory-expiry.ts
@@ -64,3 +64,5 @@ export function stampRegulatoryExpiry({
   const base = now ?? new Date();
   return new Date(base.getTime() + days * 86400000);
 }
+
+// #1917 — re-trigger CI 2026-06-18 (GH Actions stuck on this branch)

--- a/apps/admin/lib/privacy/stamp-regulatory-expiry.ts
+++ b/apps/admin/lib/privacy/stamp-regulatory-expiry.ts
@@ -1,0 +1,66 @@
+/**
+ * stamp-regulatory-expiry — derive `Call.regulatoryExpiresAt` at create-time.
+ *
+ * Closes the I-PR3 invariant from `docs/CHAIN-CONTRACTS.md §6a` (epic
+ * #1915 child #1917). Every code path that creates a `Call` row routes
+ * through here so the regulatory expiry is stamped at write-time, not
+ * computed later when the original preset is unknowable.
+ *
+ * Layered resolution (highest precedence first):
+ *
+ *   1. **Preset retention days** — when the per-Playbook `privacyPresetId`
+ *      cascade ships (#1925), `resolvePrivacyPreset(presetId)` returns
+ *      the preset's `retentionDays`. Not wired yet — call sites pass
+ *      `presetRetentionDays: null` until #1925.
+ *   2. **Env fallback** — `config.retention.callerDataDays` (env
+ *      `RETENTION_CALLER_DATA_DAYS`, default 0 = disabled). When `> 0`,
+ *      stamp `regulatoryExpiresAt = now + N days`.
+ *   3. **NULL** — when neither layer resolves, the column stays NULL.
+ *      Retention cleanup skips NULL rows; the legacy caller-level
+ *      cleanup keeps working for those callers.
+ *
+ * **Backfill discipline:** existing rows MUST stay NULL (see migration
+ * `20260618120000_1917_call_regulatory_expires_at/migration.sql` for the
+ * three reasons computed-date backfill is structurally wrong).
+ *
+ * @see docs/CHAIN-CONTRACTS.md §6a I-PR3
+ * @see #1917 (this enforcer) · #1915 (epic)
+ * @see lib/privacy/policy-presets.ts (#1924, deferred — presetRetentionDays plumbed there when it lands)
+ */
+
+import { config } from "@/lib/config";
+
+export interface StampRegulatoryExpiryArgs {
+  /**
+   * Preset-derived retention in days, when the cascade resolves a non-Basic
+   * preset. NULL during the pre-#1925 window or when the preset is "Basic".
+   * When NULL, the env fallback `RETENTION_CALLER_DATA_DAYS` takes over.
+   */
+  presetRetentionDays: number | null;
+  /** Override `now()` for tests. */
+  now?: Date;
+}
+
+/**
+ * Compute the regulatory expiry timestamp for a new `Call` row.
+ *
+ * Returns `null` when no retention policy resolves — caller spreads the
+ * field optionally (`...(expiry ? { regulatoryExpiresAt: expiry } : {})`)
+ * so the row write doesn't carry an explicit NULL when nothing was decided.
+ */
+export function stampRegulatoryExpiry({
+  presetRetentionDays,
+  now,
+}: StampRegulatoryExpiryArgs): Date | null {
+  const days =
+    presetRetentionDays !== null && presetRetentionDays > 0
+      ? presetRetentionDays
+      : config.retention.callerDataDays > 0
+        ? config.retention.callerDataDays
+        : null;
+
+  if (days === null) return null;
+
+  const base = now ?? new Date();
+  return new Date(base.getTime() + days * 86400000);
+}

--- a/apps/admin/lib/voice/route-handlers.ts
+++ b/apps/admin/lib/voice/route-handlers.ts
@@ -60,6 +60,7 @@ import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
 import { loadResolvedVoiceConfig } from "@/lib/voice/load-voice-config";
 import { isSessionModelV2Enabled } from "@/lib/voice/session-flag";
 import { createSession } from "@/lib/voice/create-session";
+import { stampRegulatoryExpiry } from "@/lib/privacy/stamp-regulatory-expiry";
 import { endSession } from "@/lib/voice/end-session";
 import { registerModuleScheduledCues } from "@/lib/voice/register-module-cues";
 import { broadcastToCall } from "@/lib/voice/sse-registry";
@@ -921,6 +922,14 @@ export async function persistEndOfCall(
     }
   }
 
+  // #1917 §6a I-PR3 — stamp regulatory expiry from preset (when #1925
+  // wires the cascade) or `RETENTION_CALLER_DATA_DAYS` env fallback.
+  // Inbound webhook fresh-arrival path: previously the call existed only
+  // as the end-of-call write, so the expiry stamp piggybacks on this
+  // create.
+  const regulatoryExpiresAt = stampRegulatoryExpiry({
+    presetRetentionDays: null,
+  });
   const newCall = await prisma.call.create({
     data: {
       externalId: externalCallId,
@@ -937,6 +946,7 @@ export async function persistEndOfCall(
       endSource: sourceTag === "fallback" ? "poll" : "webhook",
       ...(freshSessionId ? { sessionId: freshSessionId } : {}),
       ...(playbookId ? { playbookId } : {}),
+      ...(regulatoryExpiresAt ? { regulatoryExpiresAt } : {}),
       ...persistableCapture,
     },
   });

--- a/apps/admin/prisma/migrations/20260618120000_1917_call_regulatory_expires_at/migration.sql
+++ b/apps/admin/prisma/migrations/20260618120000_1917_call_regulatory_expires_at/migration.sql
@@ -1,0 +1,39 @@
+-- #1917 (epic #1915 §6a I-PR3) — regulatory expiry column on Call.
+--
+-- Adds Call.regulatoryExpiresAt as a NULLABLE timestamp. Future writes
+-- through `lib/privacy/stamp-regulatory-expiry.ts` populate it from the
+-- preset in effect (or `RETENTION_CALLER_DATA_DAYS` env fallback). The
+-- retention cleanup cron (`POST /api/admin/retention/cleanup`) extends
+-- its WHERE clause to delete rows where regulatoryExpiresAt <= NOW().
+--
+-- Backfill = NULL (intentional, per TL guidance):
+--   1. The preset-in-effect at original call-time is unknowable for
+--      historical rows. Computing `createdAt + RETENTION_CALLER_DATA_DAYS`
+--      picks the WRONG retention window for any caller enrolled before
+--      the env var was set or who was on a different preset cohort.
+--   2. If the preset later changes (e.g., domain switches to GDPR-EU
+--      from Basic), already-stamped retroactive dates create reconciliation
+--      drift — some rows expire under one policy, others under another.
+--   3. DSR-pending callers who requested deletion get their data
+--      EXTENDED by a retroactive stamp.
+--
+-- NULL is the safe identity element. The existing caller-level cleanup
+-- in `POST /api/admin/retention/cleanup` still applies to legacy rows
+-- (deletes the entire caller after activity goes dormant past the env
+-- threshold). Row-level expiry purge applies only to rows with a
+-- non-NULL `regulatoryExpiresAt`.
+--
+-- Naming discipline: column is `regulatoryExpiresAt`, NOT `retentionExpiry`
+-- or `expiresAt`. `CallerMemory.expiresAt` already exists for content
+-- decay ("traveling next week") — silent conflation is the failure mode
+-- this naming explicitly prevents (CHAIN-CONTRACTS.md §6a I-PR3).
+
+ALTER TABLE "Call"
+  ADD COLUMN "regulatoryExpiresAt" TIMESTAMP(3);
+
+-- Indexed for the retention-cleanup WHERE filter. Partial index
+-- (WHERE column IS NOT NULL) keeps the index small — NULL rows are
+-- the historical / unstamped majority during the rollout window.
+CREATE INDEX "Call_regulatoryExpiresAt_idx"
+  ON "Call" ("regulatoryExpiresAt")
+  WHERE "regulatoryExpiresAt" IS NOT NULL;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -1718,6 +1718,18 @@ model Call {
   transcript String
   createdAt  DateTime @default(now())
 
+  // #1917 (epic #1915 §6a I-PR3) — regulatory expiry stamped at
+  // create-time from the preset in effect (or `RETENTION_CALLER_DATA_DAYS`
+  // env fallback). NULL on existing rows (backfill=NULL by design — see
+  // `lib/privacy/stamp-regulatory-expiry.ts` JSDoc for the three reasons
+  // computed-date backfill is wrong). The retention cleanup cron deletes
+  // rows WHERE `regulatoryExpiresAt <= NOW()`.
+  //
+  // Naming discipline: NOT `expiresAt` — collides with
+  // `CallerMemory.expiresAt` (content decay) and would silently conflate
+  // two semantically different concepts.
+  regulatoryExpiresAt DateTime?
+
   // Caller tracking
   callerId String?
 

--- a/apps/admin/scripts/check-fk-consistency.ts
+++ b/apps/admin/scripts/check-fk-consistency.ts
@@ -485,6 +485,41 @@ async function runChecks(): Promise<CheckResult[]> {
     })),
   });
 
+  // Query 12 — #1917 (epic #1915 §6a I-PR3) — Calls without
+  // `regulatoryExpiresAt` stamped, older than the configured grace
+  // window. WARN-only — pre-#1917 rows are EXPECTED to be NULL
+  // (intentional NULL backfill, see migration body). After #1917 ships
+  // and an env preset becomes active, new rows should ALL be stamped;
+  // surfacing the count keeps the rollout state observable.
+  //
+  // Grace window: 7 days. Adjust upward if a wider rollout window is
+  // declared by the operator (set via env or admin UI when #1928
+  // ships).
+  const REGULATORY_EXPIRY_GRACE_DAYS = 7;
+  const callsWithoutRegulatoryExpiry = await prisma.$queryRaw<
+    Array<{ id: string; callerId: string | null; createdAt: Date }>
+  >`
+    SELECT "id", "callerId", "createdAt"
+    FROM "Call"
+    WHERE "regulatoryExpiresAt" IS NULL
+      AND "createdAt" < NOW() - (${REGULATORY_EXPIRY_GRACE_DAYS} || ' days')::interval
+    ORDER BY "createdAt" DESC
+    LIMIT 200
+  `;
+  results.push({
+    name: "call-without-regulatory-expiry",
+    description:
+      "#1917 (#1915 I-PR3) — Call rows older than the grace window with NULL regulatoryExpiresAt. Pre-migration rows are EXPECTED NULL (intentional NULL backfill). New rows after #1917 ships should be stamped unless `RETENTION_CALLER_DATA_DAYS` is 0 AND no preset is wired (#1925, pending). WARN-only: count plateauing post-rollout = healthy; growing = enforcer regression.",
+    rows: callsWithoutRegulatoryExpiry.map((r) => ({
+      id: r.id,
+      detail: {
+        callerId: r.callerId,
+        createdAt: r.createdAt.toISOString(),
+      },
+    })),
+    warnOnly: true,
+  });
+
   return results;
 }
 

--- a/apps/admin/tests/api/retention-cleanup.test.ts
+++ b/apps/admin/tests/api/retention-cleanup.test.ts
@@ -38,6 +38,9 @@ const mockPrisma = prisma as any;
 // Add missing mock methods
 mockPrisma.caller.findMany = vi.fn().mockResolvedValue([]);
 mockPrisma.auditLog = { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) };
+// #1917 — row-level Call expiry purge added to the cleanup route
+mockPrisma.call = mockPrisma.call ?? {};
+mockPrisma.call.deleteMany = vi.fn().mockResolvedValue({ count: 0 });
 
 import { POST } from "@/app/api/admin/retention/cleanup/route";
 
@@ -48,6 +51,7 @@ describe("POST /api/admin/retention/cleanup", () => {
     mockConfig.retention.auditLogDays = 365;
     mockPrisma.caller.findMany.mockResolvedValue([]);
     mockPrisma.auditLog.deleteMany.mockResolvedValue({ count: 0 });
+    mockPrisma.call.deleteMany.mockResolvedValue({ count: 0 });
   });
 
   it("returns skipped when both retention periods are 0", async () => {

--- a/apps/admin/tests/lib/privacy/stamp-regulatory-expiry.test.ts
+++ b/apps/admin/tests/lib/privacy/stamp-regulatory-expiry.test.ts
@@ -1,0 +1,115 @@
+/**
+ * #1917 (epic #1915 §6a I-PR3) — unit tests for the stamp helper.
+ *
+ * Pins the layered resolution: preset > env > NULL.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock `@/lib/config` so we can drive `config.retention.callerDataDays`
+// per test without depending on the actual env. Mock factory runs at
+// import time so it must be hoisted above the SUT import.
+vi.mock("@/lib/config", () => ({
+  config: {
+    retention: {
+      get callerDataDays() {
+        return mockCallerDataDays;
+      },
+    },
+  },
+}));
+
+let mockCallerDataDays = 0;
+
+import { stampRegulatoryExpiry } from "@/lib/privacy/stamp-regulatory-expiry";
+
+describe("stampRegulatoryExpiry", () => {
+  const FIXED_NOW = new Date("2026-06-18T12:00:00.000Z");
+
+  beforeEach(() => {
+    mockCallerDataDays = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns NULL when both preset and env are absent", () => {
+    mockCallerDataDays = 0;
+    const result = stampRegulatoryExpiry({
+      presetRetentionDays: null,
+      now: FIXED_NOW,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns NULL when preset is 0 and env is 0", () => {
+    mockCallerDataDays = 0;
+    const result = stampRegulatoryExpiry({
+      presetRetentionDays: 0,
+      now: FIXED_NOW,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("uses env fallback when preset is NULL and env > 0", () => {
+    mockCallerDataDays = 30;
+    const result = stampRegulatoryExpiry({
+      presetRetentionDays: null,
+      now: FIXED_NOW,
+    });
+    expect(result).toEqual(new Date("2026-07-18T12:00:00.000Z"));
+  });
+
+  it("preset wins over env when both are set and non-zero", () => {
+    mockCallerDataDays = 30;
+    const result = stampRegulatoryExpiry({
+      presetRetentionDays: 90,
+      now: FIXED_NOW,
+    });
+    expect(result).toEqual(new Date("2026-09-16T12:00:00.000Z"));
+  });
+
+  it("preset wins over env when preset = 1 and env = 365", () => {
+    mockCallerDataDays = 365;
+    const result = stampRegulatoryExpiry({
+      presetRetentionDays: 1,
+      now: FIXED_NOW,
+    });
+    expect(result).toEqual(new Date("2026-06-19T12:00:00.000Z"));
+  });
+
+  it("preset = 0 falls through to env (treated as 'no preset opinion')", () => {
+    // Per helper contract: presetRetentionDays === 0 is treated the same
+    // as null — "preset has no opinion, use env fallback". This avoids
+    // an accidental "preset says delete immediately" interpretation.
+    mockCallerDataDays = 14;
+    const result = stampRegulatoryExpiry({
+      presetRetentionDays: 0,
+      now: FIXED_NOW,
+    });
+    expect(result).toEqual(new Date("2026-07-02T12:00:00.000Z"));
+  });
+
+  it("uses real Date.now() when `now` arg omitted", () => {
+    mockCallerDataDays = 7;
+    const before = Date.now();
+    const result = stampRegulatoryExpiry({ presetRetentionDays: null });
+    const after = Date.now();
+    expect(result).not.toBeNull();
+    const expiry = result!.getTime();
+    expect(expiry).toBeGreaterThanOrEqual(before + 7 * 86400000);
+    expect(expiry).toBeLessThanOrEqual(after + 7 * 86400000);
+  });
+
+  it("365-day preset produces a future date within 366 days", () => {
+    mockCallerDataDays = 0;
+    const result = stampRegulatoryExpiry({
+      presetRetentionDays: 365,
+      now: FIXED_NOW,
+    });
+    expect(result).not.toBeNull();
+    const diffDays = (result!.getTime() - FIXED_NOW.getTime()) / 86400000;
+    expect(diffDays).toBe(365);
+  });
+});

--- a/apps/admin/tests/lib/voice/route-handlers-1345.test.ts
+++ b/apps/admin/tests/lib/voice/route-handlers-1345.test.ts
@@ -42,6 +42,9 @@ interface MockCallRow {
   createdAt: Date;
   playbookId: string | null;
   usedPromptId: string | null;
+  // #1917 — regulatory expiry column; nullable, populated by
+  // stampRegulatoryExpiry() at create-time via the fresh-arrival path.
+  regulatoryExpiresAt: Date | null;
 }
 
 const stores = vi.hoisted(() => ({
@@ -127,6 +130,10 @@ vi.mock("@/lib/prisma", () => ({
           createdAt: data.createdAt ?? new Date(),
           playbookId: data.playbookId ?? null,
           usedPromptId: data.usedPromptId ?? null,
+          // #1917 — regulatory expiry; spread conditionally by the
+          // route, so the field may be absent from `data` when the
+          // env retention is disabled.
+          regulatoryExpiresAt: data.regulatoryExpiresAt ?? null,
         };
         stores.callStore.set(id, row);
         return row;
@@ -234,6 +241,12 @@ vi.mock("@/lib/config", () => ({
       claude: { model: "claude-3-5-sonnet", maxTokens: 4096, temperature: 0.7 },
       openai: { model: "gpt-4o-mini", maxTokens: 4096, temperature: 0.7 },
     },
+    // #1917 — stampRegulatoryExpiry reads this at create-time. Zero
+    // means "no env-driven retention" so the column stays NULL in
+    // the mock store — matches the existing post-fix-create assertions
+    // (the field is added to MockCallRow but defaults to null when
+    // env retention is disabled, which preserves the pre-#1917 shape).
+    retention: { callerDataDays: 0, auditLogDays: 365 },
   },
 }));
 

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-18T13:16:27.376Z",
+  "generatedAt": "2026-06-18T13:20:59.597Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1842,
-  "edgeCount": 4332,
+  "fileCount": 1843,
+  "edgeCount": 4336,
   "skippedEdges": 1,
   "edges": [
     {
@@ -7217,6 +7217,10 @@
     },
     {
       "from": "app/api/voice/calls/outbound-dial/route.ts",
+      "to": "lib/privacy/stamp-regulatory-expiry.ts"
+    },
+    {
+      "from": "app/api/voice/calls/outbound-dial/route.ts",
       "to": "lib/voice/build-assistant-config.ts"
     },
     {
@@ -7254,6 +7258,10 @@
     {
       "from": "app/api/voice/calls/start/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/voice/calls/start/route.ts",
+      "to": "lib/privacy/stamp-regulatory-expiry.ts"
     },
     {
       "from": "app/api/voice/calls/start/route.ts",
@@ -14684,6 +14692,10 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/privacy/stamp-regulatory-expiry.ts",
+      "to": "lib/config.ts"
+    },
+    {
       "from": "lib/prompt/compose-content-section.ts",
       "to": "lib/contracts/registry.ts"
     },
@@ -16382,6 +16394,10 @@
     {
       "from": "lib/voice/route-handlers.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "lib/voice/route-handlers.ts",
+      "to": "lib/privacy/stamp-regulatory-expiry.ts"
     },
     {
       "from": "lib/voice/route-handlers.ts",
@@ -19970,12 +19986,12 @@
     {
       "path": "app/api/voice/calls/outbound-dial/route.ts",
       "inDegree": 0,
-      "outDegree": 11
+      "outDegree": 12
     },
     {
       "path": "app/api/voice/calls/start/route.ts",
       "inDegree": 0,
-      "outDegree": 8
+      "outDegree": 9
     },
     {
       "path": "app/api/voice/costs/route.ts",
@@ -23364,7 +23380,7 @@
     },
     {
       "path": "lib/config.ts",
-      "inDegree": 93,
+      "inDegree": 94,
       "outDegree": 0
     },
     {
@@ -24813,6 +24829,11 @@
       "outDegree": 0
     },
     {
+      "path": "lib/privacy/stamp-regulatory-expiry.ts",
+      "inDegree": 3,
+      "outDegree": 1
+    },
+    {
       "path": "lib/prompt-analyzer/section-map.ts",
       "inDegree": 2,
       "outDegree": 0
@@ -25625,7 +25646,7 @@
     {
       "path": "lib/voice/route-handlers.ts",
       "inDegree": 5,
-      "outDegree": 28
+      "outDegree": 29
     },
     {
       "path": "lib/voice/runtime-features.ts",
@@ -26566,7 +26587,7 @@
     },
     {
       "path": "lib/config.ts",
-      "inDegree": 93,
+      "inDegree": 94,
       "outDegree": 0
     },
     {
@@ -26627,7 +26648,7 @@
     {
       "path": "lib/voice/route-handlers.ts",
       "inDegree": 5,
-      "outDegree": 28
+      "outDegree": 29
     },
     {
       "path": "lib/playbook/update-playbook-config.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-18T13:16:27.804Z",
+  "generatedAt": "2026-06-18T13:21:00.016Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-18T13:16:25.559Z",
+  "generatedAt": "2026-06-18T13:20:58.048Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",
@@ -736,15 +736,16 @@
     },
     {
       "name": "Call",
-      "fieldCount": 45,
+      "fieldCount": 46,
       "relationCount": 19,
-      "meaningfulScalarCount": 16,
+      "meaningfulScalarCount": 17,
       "scalarFields": [
         "id",
         "source",
         "externalId",
         "transcript",
         "createdAt",
+        "regulatoryExpiresAt",
         "callerId",
         "sessionId",
         "playbookId",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-18T13:16:28.368Z",
+  "generatedAt": "2026-06-18T13:21:00.514Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-18T13:16:26.203Z",
+  "generatedAt": "2026-06-18T13:20:58.714Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Enforces CHAIN-CONTRACTS.md §6a I-PR3 (shipped in PR #1938). Every `Call` row stamps a `regulatoryExpiresAt` at create-time so the retention cleanup cron can purge by column rather than full-table scan.

- **Schema:** `Call.regulatoryExpiresAt DateTime?` (nullable) + partial index on non-NULL slice
- **Helper:** `lib/privacy/stamp-regulatory-expiry.ts` with layered preset > env > NULL resolution
- **Adopt:** 3 canonical voice `Call.create` sites (start / outbound-dial / inbound-webhook fresh-arrival)
- **Cron:** retention cleanup extended with row-level expiry purge branch
- **Detector:** `check-fk-consistency.ts` Query 12 (WARN-only) — NULL-expiry rows older than 7-day grace
- **Tests:** 8 vitests pinning helper layered resolution + edge cases

## Tech Lead reshape applied

- **Column name `regulatoryExpiresAt`** NOT `retentionExpiry` / `expiresAt`. `CallerMemory.expiresAt` already exists for content decay — silent conflation is the failure mode this naming explicitly prevents.
- **Backfill = NULL.** Computed dates pick the wrong preset for historical rows, create drift on later preset changes, and extend DSR-pending callers. Migration body documents all three reasons.
- **Partial index** on `WHERE regulatoryExpiresAt IS NOT NULL` keeps the index small while the NULL-heavy rollout window is in effect.

## Lattice sibling-writer survey

Per `.claude/rules/lattice-survey.md` MANDATORY discipline:

11 total `prisma.call.create` sites in the codebase. This PR adopts at the 3 canonical voice paths only:

- `lib/voice/route-handlers.ts:924` (inbound webhook fresh-arrival)
- `app/api/voice/calls/start/route.ts:187` (WebRTC + JS SDK start)
- `app/api/voice/calls/outbound-dial/route.ts:214` (PSTN outbound)

Deferred to follow-on PRs (lower-priority writers — adopt the helper as touched):
- `lib/ops/transcripts-process.ts` batch import
- `app/api/transcripts/import/route.ts` CSV import
- `lib/test-harness/sim-runner.ts` sim
- `app/api/test-harness/onboarding-call/route.ts`
- `app/api/callers/[callerId]/calls/route.ts` sim-callers
- `lib/chat/admin-tool-handlers.ts` admin debug
- 2 one-off scripts (proof + sim-drive)

No race for the new column: partial-update writers (`prosody-runner`, `compose-next-prompt`) only write specified fields, so they don't touch `regulatoryExpiresAt`.

## Test plan

- [x] Schema diff inspected — additive nullable column, partial index
- [x] Migration SQL inspected — idempotent ADD COLUMN + partial CREATE INDEX
- [x] 8 helper unit tests authored covering: NULL-NULL → NULL · preset > env · env fallback · preset = 0 falls through to env · tied days · 365d boundary · real Date.now() path
- [x] pre-push ESLint passes
- [ ] CI green (tsc + lint + vitest + check-fk-consistency)
- [ ] Migration applied on hf-dev via `/vm-cpp`
- [ ] Verify on hf-dev: new Call row from a sim call has `regulatoryExpiresAt` stamped when `RETENTION_CALLER_DATA_DAYS` is non-zero; stays NULL when it is 0

## Verified by

- `grep -rn "prisma.call.create" apps/admin/{app,lib,scripts}` → 11 sites enumerated; survey reflected in commit body
- `grep -n "expiresAt" apps/admin/prisma/schema.prisma` → 5 hits, none on `Call` model pre-edit (confirms greenfield naming)
- `find apps/admin/lib/privacy/ -type f` pre-edit → empty (confirms new directory greenfield for #1924 future siblings)
- Sibling rule citations (`response-redaction.md`, `lattice-survey.md`) verified on disk via `tests/lib/lattice-self-maintenance.test.ts` regex
- CHAIN-CONTRACTS.md §6a I-PR3 (PR #1938) cited as the contract this PR enforces

Closes #1917
Refs #1915 (epic), #1916 (S1 contracts → PR #1938)
Pairs with: #1918 (S8a voice-consent), #1919 (ST Tallyseal tx), #1920 (S10 rules)

Deploy command: `/vm-cpp` (migration)