### PR TITLE
feat(privacy): voice-call-recording disclosure at intake-v2 (S8a, #1918)

### DIFF
--- a/apps/admin/app/api/intake/bootstrap/route.ts
+++ b/apps/admin/app/api/intake/bootstrap/route.ts
@@ -51,6 +51,13 @@ const PROJECTION = "IntakeApplication" as ProjectionName;
 
 const ART13_REQUIREMENT_ID = "gdpr.art13.privacy-notice";
 const ART50_REQUIREMENT_ID = "eu-ai-act.art50.ai-interaction-disclosure";
+// #1918 (epic #1915 §6a I-PR2) — voice-recording consent. Delivered at
+// intake-v2 alongside the two existing regulatory notices so by the time
+// a learner reaches `createSession({kind: VOICE_CALL})` the ack already
+// exists in `tallyseal_disclosure`. Synthetic HF-internal requirement,
+// not a regulatory citation — copy describes recording + analysis +
+// erasure rights under our existing contract lawful basis.
+const VOICE_CALL_RECORDING_REQUIREMENT_ID = "voice-call-recording";
 
 export async function POST(req: NextRequest) {
   let body: z.infer<typeof BodySchema>;
@@ -78,7 +85,11 @@ export async function POST(req: NextRequest) {
   // copy's contentHash. The runtime safety belt in
   // disclosure-content.ts throws DraftCopyInProductionError if any
   // copy is status=DRAFT and NODE_ENV=production.
-  for (const requirementId of [ART13_REQUIREMENT_ID, ART50_REQUIREMENT_ID]) {
+  for (const requirementId of [
+    ART13_REQUIREMENT_ID,
+    ART50_REQUIREMENT_ID,
+    VOICE_CALL_RECORDING_REQUIREMENT_ID,
+  ]) {
     let copy;
     try {
       copy = await loadDisclosureCopy(requirementId);

--- a/apps/admin/lib/intake/copy/voice-call-recording.v0.1.0-rc.1.mdx
+++ b/apps/admin/lib/intake/copy/voice-call-recording.v0.1.0-rc.1.mdx
@@ -1,0 +1,20 @@
+---
+requirementId: voice-call-recording
+regulation: hf-internal
+article: "voice-consent"
+version: 0.1.0-rc.1
+status: RC
+effective: 2026-06-18
+controller: HumanFirst Foundation
+controllerContact: dpo@humanfirstfoundation.com
+locale: en
+targetWords: 60-100
+---
+
+# We record and analyse your voice calls
+
+When you speak with the AI tutor, your call audio and transcript are recorded so we can give you accurate feedback on what you said, score your progress against the course goals, and personalise your next session.
+
+A person from HumanFirst Foundation can review recordings and transcripts. We delete recordings after the retention period for your course.
+
+You can ask us to delete your call data at any time by contacting dpo@humanfirstfoundation.com.

--- a/apps/admin/lib/intake/copy/voice-call-recording.v0.1.0-rc.1.mdx
+++ b/apps/admin/lib/intake/copy/voice-call-recording.v0.1.0-rc.1.mdx
@@ -18,3 +18,4 @@ When you speak with the AI tutor, your call audio and transcript are recorded so
 A person from HumanFirst Foundation can review recordings and transcripts. We delete recordings after the retention period for your course.
 
 You can ask us to delete your call data at any time by contacting dpo@humanfirstfoundation.com.
+

--- a/apps/admin/tests/intake/disclosure-content.test.ts
+++ b/apps/admin/tests/intake/disclosure-content.test.ts
@@ -81,6 +81,24 @@ describe("DisclosureContentPort — production safety belt", () => {
     expect(entry.body).not.toMatch(/DO NOT SHIP/i);
   });
 
+  // #1918 (epic #1915 §6a I-PR2) — voice-call recording consent
+  // delivered at intake-v2 so the ack exists before `createSession`
+  // runs in the voice path.
+  it("loads the voice-call-recording consent", async () => {
+    const entry = await loadDisclosureCopy("voice-call-recording");
+    expect(entry.meta.requirementId).toBe("voice-call-recording");
+    expect(entry.meta.regulation).toBe("hf-internal");
+    expect(entry.meta.status).toBe("RC");
+    expect(entry.meta.controller).toBe("HumanFirst Foundation");
+    expect(entry.body).not.toMatch(/lorem ipsum/i);
+    expect(entry.body).not.toMatch(/DO NOT SHIP/i);
+    // Copy must mention recording + erasure right (informational
+    // pin — these are the two beats the I-PR2 contract is asserting
+    // about the learner's exposure).
+    expect(entry.body.toLowerCase()).toMatch(/record/);
+    expect(entry.body.toLowerCase()).toMatch(/delete/);
+  });
+
   // RC copy is delivered under every env value — the safety belt only
   // fires on status:DRAFT. After #1244 promoted the live files there
   // are no DRAFT files on disk to refuse; the mechanism itself remains


### PR DESCRIPTION
## Summary

Enforces CHAIN-CONTRACTS.md §6a I-PR2 (shipped in PR #1938). Delivers a third disclosure at intake-v2 — voice-call-recording consent — so by the time a learner reaches `createSession({kind: VOICE_CALL})` the ack already exists in `tallyseal_disclosure`.

- **New MDX copy:** `lib/intake/copy/voice-call-recording.v0.1.0-rc.1.mdx` (HF-internal requirementId — synthetic consent record covering recording, analysis, retention, erasure right; contract lawful basis)
- **Bootstrap extension:** delivery list goes from 2 disclosures (Art 13 + Art 50) to 3 (+ voice-call-recording)
- **Test:** `disclosure-content.test.ts` extended with a positive case pinning regulation = `hf-internal`, status = `RC`, recording + erasure copy beats

## Tech Lead reshape applied

- **Lazy gate at intake-v2, not blocking modal at call-start.** Default preset uses lazy delivery; HIPAA/COPPA preset-specific blocking is a separate story for when #1924/#1925 land.
- **Synthetic HF-internal requirement, not extending `@tallyseal/regulations`.** Per Tallyseal's reply to Ask #6, ConsentGranted/ConsentRevoked primitives exist for the explicit-consent variant; for now the DisclosureDelivered + DisclosureAcknowledged pair under contract lawful basis is sufficient.
- **Did NOT extend `deriveDisclosureId(intentId, requirementId)`** with a callerId variant. TL flagged that would break per-intent isolation. New requirement uses the existing intent-keyed derivation.

## Carve-out — legacy join flow

`/api/join/[token]` is NOT retroactively gated (no intake step on that path). Carve-out is declared as CHAIN-CONTRACTS.md §6a I-PR8 (shipped in PR #1938).

## Test plan

- [x] MDX frontmatter matches the existing Art 13 / Art 50 schema (loader requires `requirementId`, `regulation`, `article`, `version`, `status`, `effective`, `controller`, `controllerContact`, `locale`)
- [x] Bootstrap delivery list extended — for-loop iterates 3 IDs
- [x] `disclosure-content.test.ts` positive case added; pre-existing 2-disclosure cases untouched
- [x] Acknowledgement route untouched — handles arbitrary requirementIds via `deriveDisclosureId(intentId, requirementId)`
- [x] `audit-bundle.test.ts` composes its own session (independent of bootstrap loop) — won't break
- [x] `tests/fixtures/sprint-c-enrollment-bundle.audit.json` is a docs-only fixture with no test consumer (verified)
- [ ] CI green (tsc + lint + vitest)
- [ ] Verify on hf-dev: intake-v2 surfaces 3 banners; acknowledge each; check `tallyseal_disclosure` has 3 rows

## Verified by

- `grep -rn "ART13_REQUIREMENT|ART50_REQUIREMENT|art13|art50" apps/admin/{app,lib,tests}` → reviewed consumers; none break from a 3rd disclosure
- `grep -rn "sprint-c-enrollment-bundle" apps/admin/tests` → only the fixture's own README references it (no test consumer)
- MDX loader at `lib/intake/hf-adapter/disclosure-content.ts` inspected — all required frontmatter fields present in new copy
- `disclosure-content.test.ts` extended; the new case loads the new MDX through the canonical loader path

Closes #1918
Refs #1915 (epic), #1916 (S1 contracts → PR #1938), #1917 (S5a retention → PR #1939)
Pairs with: #1919 (ST Tallyseal tx), #1920 (S10 rules)

Deploy command: `/vm-cp`